### PR TITLE
Auto connect on create

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -321,7 +321,7 @@ const App = () => {
         try {
           console.log(`🔧 Creating client: "${client.name}"`);
           await handleAddServer(client.name, client.config, {
-            autoConnect: true,
+            autoConnect: false,
           });
           results.success.push(client.name);
           console.log(`✅ Successfully created client: "${client.name}"`);


### PR DESCRIPTION
This pull request introduces an auto-connect feature upon client creation and refines the connection logic for various client management scenarios.
Key Changes:
Auto-Connect on Client Creation: When a user creates a single new client, the application now automatically establishes a connection to that client, streamlining the user workflow.
Selective Auto-Connection for Multi-Client Import: The auto-connect feature is disabled by default when importing multiple clients at once. This prevents a flurry of connection attempts and allows the user to manually connect to the desired client.
Refactored Connection Logic:
The handleAddServer function was updated to include an autoConnect option, centralizing the connection logic.
The onOAuthConnect callback was simplified to leverage the new autoConnect flag, removing redundant code.
The client creation and editing flows were updated to use the new connection option appropriately.

closes #64 