### PR TITLE
Fix ghost request

### DIFF
--- a/client/src/components/ToolRunCard.tsx
+++ b/client/src/components/ToolRunCard.tsx
@@ -417,10 +417,14 @@ const ToolRunCard = ({
       setParams(loadedRequest.parameters);
       setParamsInitialized(true);
       setCurrentRequestId(loadedRequest.id);
-    } else if (selectedTool && !paramsInitialized) {
-      setParams(initializeParams(selectedTool));
-      setParamsInitialized(true);
-      setCurrentRequestId(null);
+    } else if (selectedTool) {
+      if (!paramsInitialized) {
+        setParams(initializeParams(selectedTool));
+        setParamsInitialized(true);
+        setCurrentRequestId(null);
+      } else if (!loadedRequest) {
+        setCurrentRequestId(null);
+      }
     }
   }, [selectedTool, loadedRequest, paramsInitialized]);
 


### PR DESCRIPTION
This PR resolves a UI bug in the ToolRunCard component where the "Save Request" button would incorrectly display "Update Request" after the loaded request was deleted.
The issue stemmed from the component's internal state not being properly reset. When a loadedRequest was removed, the currentRequestId state persisted, causing the UI to believe it was still in "update" mode.
Changes:
The useEffect hook in ToolRunCard.tsx has been updated to correctly handle changes to the loadedRequest prop.
It now includes logic to reset currentRequestId to null when loadedRequest is no longer available, ensuring the component's state accurately reflects that a new request can be saved.
This change guarantees that after deleting a request, the button text correctly reverts from "Update Request" to "Save Request."