### PR TITLE
Save array requests

### DIFF
--- a/client/src/components/DynamicJsonForm.tsx
+++ b/client/src/components/DynamicJsonForm.tsx
@@ -65,12 +65,10 @@ const DynamicJsonForm = ({
 
   // Update rawJsonValue when value prop changes
   useEffect(() => {
-    if (!isJsonMode) {
-      setRawJsonValue(
-        JSON.stringify(value ?? generateDefaultValue(schema), null, 2),
-      );
-    }
-  }, [value, schema, isJsonMode]);
+    setRawJsonValue(
+      JSON.stringify(value ?? generateDefaultValue(schema), null, 2),
+    );
+  }, [value, schema]);
 
   const handleSwitchToFormMode = () => {
     if (isJsonMode) {


### PR DESCRIPTION
Modify the useEffect to ensure it updates the component's state with the loaded request's data, even in JSON mode. This might cause the cursor to jump during manual JSON editing, but it will fix the critical bug of not loading and saving array parameters correctly.

Closes #83 