### PR TITLE
Fix types for elicitation 

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import {
   PromptReference,
   CreateMessageRequest,
   CreateMessageResult,
+  ElicitRequest,
 } from "@modelcontextprotocol/sdk/types.js";
 import React, {
   Suspense,
@@ -51,7 +52,9 @@ import { loadOAuthTokens, handleOAuthDebugConnect } from "./services/oauth";
 import { getMCPProxyAddressAsync } from "./utils/configUtils";
 import { handleRootsChange, MCPHelperDependencies } from "./utils/mcpHelpers";
 
-import ElicitationModal from "./components/ElicitationModal";
+import ElicitationModal, {
+  ElicitationResponse,
+} from "./components/ElicitationModal";
 
 // Types
 import {
@@ -139,7 +142,10 @@ const App = () => {
   );
 
   const onElicitationRequest = useCallback(
-    (request: any, resolve: (result: any) => void) => {
+    (
+      request: ElicitRequest,
+      resolve: (result: ElicitationResponse) => void,
+    ) => {
       mcpOperations.setPendingElicitationRequest({
         id: nextRequestId.current++,
         message: request.params.message,

--- a/client/src/components/ElicitationModal.tsx
+++ b/client/src/components/ElicitationModal.tsx
@@ -13,6 +13,7 @@ import { JsonSchemaType, JsonValue } from "@/utils/jsonUtils";
 import { generateDefaultValue } from "@/utils/schemaUtils";
 import Ajv from "ajv";
 
+// TODO: This is a temporary type for the elicitation request. Move this elsewhere.
 export interface ElicitationRequest {
   id: number;
   message: string;
@@ -20,6 +21,7 @@ export interface ElicitationRequest {
   resolve: (response: ElicitationResponse) => void;
 }
 
+// TODO: This is a temporary type for the elicitation request. Move this elsewhere.
 export interface ElicitationResponse {
   action: "accept" | "reject" | "cancel";
   content?: Record<string, unknown>;

--- a/client/src/hooks/useConnectionState.ts
+++ b/client/src/hooks/useConnectionState.ts
@@ -5,11 +5,13 @@ import { InspectorConfig } from "@/lib/configurationTypes";
 import {
   CreateMessageRequest,
   CreateMessageResult,
+  ElicitRequest,
   Root,
 } from "@modelcontextprotocol/sdk/types.js";
 import { StdErrNotification } from "@/lib/notificationTypes";
 import { ConnectionStatus } from "@/lib/constants";
 import { ClientLogLevels } from "@/hooks/helpers/types";
+import { ElicitationResponse } from "@/components/ElicitationModal";
 
 export const useConnectionState = (
   addRequestHistory: (request: object, response?: object) => void,
@@ -35,7 +37,10 @@ export const useConnectionState = (
         reject: (error: Error) => void,
       ) => void,
       getRoots: () => Root[],
-      onElicitationRequest?: (request: any, resolve: any) => void,
+      onElicitationRequest?: (
+        request: ElicitRequest,
+        resolve: (result: ElicitationResponse) => void,
+      ) => void,
     ) => {
       if (Object.keys(serverConfigs).length === 0) {
         console.log("No servers configured, skipping connection");
@@ -85,7 +90,10 @@ export const useConnectionState = (
         reject: (error: Error) => void,
       ) => void,
       getRoots: () => Root[],
-      onElicitationRequest?: (request: any, resolve: any) => void,
+      onElicitationRequest?: (
+        request: ElicitRequest,
+        resolve: (result: ElicitationResponse) => void,
+      ) => void,
     ) => {
       const options: MCPClientOptions = {
         servers: serverConfigs,
@@ -123,7 +131,10 @@ export const useConnectionState = (
         reject: (error: Error) => void,
       ) => void,
       getRoots: () => Root[],
-      onElicitationRequest?: (request: any, resolve: any) => void,
+      onElicitationRequest?: (
+        request: ElicitRequest,
+        resolve: (result: ElicitationResponse) => void,
+      ) => void,
     ) => {
       console.log("🔧 addServer called with:", { name, serverConfig });
 

--- a/client/src/mcpjamAgent.ts
+++ b/client/src/mcpjamAgent.ts
@@ -5,6 +5,7 @@ import {
   Resource,
   Prompt,
   ServerCapabilities,
+  ElicitRequest,
 } from "@modelcontextprotocol/sdk/types.js";
 import { MCPJamServerConfig } from "./lib/serverTypes";
 import { createDefaultConfig } from "./utils/configUtils";
@@ -15,6 +16,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { ConnectionStatus } from "./lib/constants";
 import { ClientLogLevels } from "./hooks/helpers/types";
+import { ElicitationResponse } from "./components/ElicitationModal";
 
 export interface MCPClientOptions {
   id?: string;
@@ -30,7 +32,10 @@ export interface MCPClientOptions {
     resolve: (result: CreateMessageResult) => void,
     reject: (error: Error) => void,
   ) => void;
-  onElicitationRequest?: (request: any, resolve: any) => void;
+  onElicitationRequest?: (
+    request: ElicitRequest,
+    resolve: (result: ElicitationResponse) => void,
+  ) => void;
   getRoots?: () => unknown[];
   addRequestHistory: (request: object, response?: object) => void;
   addClientLog: (message: string, level: ClientLogLevels) => void;
@@ -57,7 +62,10 @@ export class MCPJamAgent {
     resolve: (result: CreateMessageResult) => void,
     reject: (error: Error) => void,
   ) => void;
-  private onElicitationRequest?: (request: any, resolve: any) => void;
+  private onElicitationRequest?: (
+    request: ElicitRequest,
+    resolve: (result: ElicitationResponse) => void,
+  ) => void;
   private getRoots?: () => unknown[];
   private addRequestHistory: (request: object, response?: object) => void;
   private addClientLog: (message: string, level: ClientLogLevels) => void;


### PR DESCRIPTION
Fix types for elicitation: 
Before: Use of `any` type everywhere 
After: Enforce types