### PR TITLE
logging improvements, and catching server errors(stderr output)

### DIFF
--- a/server/logs/mcp-server--modelcontextprotocol-server-filesystem.log
+++ b/server/logs/mcp-server--modelcontextprotocol-server-filesystem.log
@@ -1,0 +1,26 @@
+2025-06-23T05:12:35.913Z [test] [info] Direct endpoint logger test { metadata: undefined }
+2025-06-23T05:12:39.509Z [stdio-stderr] [error] Error accessing directory E:/: [Error: ENOENT: no such file or directory, stat 'E:\'] {
+  errno: -4058,
+  code: 'ENOENT',
+  syscall: 'stat',
+  path: 'E:\\'
+}
+ { metadata: {} }
+2025-06-23T05:12:43.419Z [test] [info] Direct endpoint logger test { metadata: undefined }
+2025-06-23T05:12:46.649Z [stdio-stderr] [error] Error accessing directory E:/: [Error: ENOENT: no such file or directory, stat 'E:\'] {
+  errno: -4058,
+  code: 'ENOENT',
+  syscall: 'stat',
+  path: 'E:\\'
+}
+ { metadata: {} }
+2025-06-23T05:12:50.426Z [test] [info] Direct endpoint logger test { metadata: undefined }
+2025-06-23T05:12:53.333Z [stdio-stderr] [error] Error accessing directory E:/: [Error: ENOENT: no such file or directory, stat 'E:\'] {
+  errno: -4058,
+  code: 'ENOENT',
+  syscall: 'stat',
+  path: 'E:\\'
+}
+ { metadata: {} }
+2025-06-23T05:12:56.426Z [test] [info] Direct endpoint logger test { metadata: undefined }
+2025-06-23T05:12:57.041Z [stdio-stderr] [error] ^C { metadata: {} }

--- a/server/src/logger.ts
+++ b/server/src/logger.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+
+export function logToFile(
+  level: string,
+  subsystem: string,
+  message: string,
+  metadata?: any,
+  logFileName?: string
+) {
+  const timestamp = new Date().toISOString();
+  const entry = `${timestamp} [${subsystem}] [${level}] ${message} { metadata: ${JSON.stringify(metadata)} }\n`;
+  const logsDir = path.join(process.cwd(), 'logs');
+  if (!fs.existsSync(logsDir)) {
+    fs.mkdirSync(logsDir);
+  }
+  const logFile = path.join(logsDir, logFileName || 'inspector.log');
+  console.log('[LOGGER] Writing to:', logFile);
+  fs.appendFileSync(logFile, entry);
+} 


### PR DESCRIPTION
---

# 📝 MCPJam Inspector: Per-Server Error Logging Implementation

## Overview

We enhanced the backend of MCPJam Inspector to provide robust, per-server error logging, similar to the experience in Claude Desktop. Now, every MCP server you attempt to connect to gets its own log file in a dedicated `logs/` directory, making debugging and support much easier.

---

## Key Steps & Features

### 1. Logger Utility

- Created a `logToFile` utility in `server/src/logger.ts` that:
  - Writes log entries to files in a `logs/` directory.
  - Automatically creates the `logs/` directory if it doesn’t exist.
  - Accepts a log file name so each MCP server can have its own log file.

### 2. Log File Naming

- Improved the log file naming logic to:
  - Use the actual MCP server name (e.g., `@modelcontextprotocol/server-filesystem`) instead of just the command (`npx`).
  - Skip flags (like `-y`) and use the first non-flag argument as the server name.
  - For HTTP/SSE transports, use the host as the log file name.
  - Result: Log files like `logs/mcp-server-modelcontextprotocol-server-filesystem.log`.

### 3. Error Handling

- **Synchronous errors** (e.g., connection setup failures) are caught in try/catch blocks and logged to the correct per-server log file.
- **Asynchronous errors** (e.g., process or stream errors) are caught by attaching error listeners to the transport objects:
  - `StdioClientTransport.stderr.on('data', ...)` logs all stderr output from the MCP server process.
  - `transport.on('error', ...)` logs transport-level errors.
- **Global errors** (uncaught exceptions, unhandled rejections) are logged to the most recently used per-server log file, tracked by a global variable.

### 4. Debugging and Verification

- Added `[LOGGER]` debug prints to confirm when and where logs are written.
- Added direct logger tests and endpoint tests to verify log file creation and naming.
- Iteratively refined the logic based on real-world test results and your feedback.

---

## Result

- Whenever you attempt to connect to an MCP server (even with errors or missing arguments), a log file is created in `logs/` with a descriptive name for that server.
- All errors (sync and async) related to that server are captured in its log file.
- The logging system is robust, extensible, and matches the developer experience of Claude Desktop.

---

## Example Log File Names

- `logs/mcp-server-modelcontextprotocol-server-filesystem.log`

---