### PR TITLE
Expand chat limits

### DIFF
--- a/client/src/components/ChatTab.tsx
+++ b/client/src/components/ChatTab.tsx
@@ -5,7 +5,7 @@ import {
   Tool as MessageTool,
 } from "@anthropic-ai/sdk/resources/messages/messages.mjs";
 import { Anthropic } from "@anthropic-ai/sdk";
-import { Send, User, Loader2, Key, ChevronDown } from "lucide-react";
+import { Send, User, Key, ChevronDown, Square } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CLAUDE_MODELS } from "@/lib/constants";
 import { ToolCallMessage } from "./ToolCallMessage";
@@ -296,6 +296,7 @@ const ChatTab: React.FC = () => {
     "claude-3-5-sonnet-latest",
   );
   const [showModelSelector, setShowModelSelector] = useState(false);
+  const [abortController, setAbortController] = useState<AbortController | null>(null);
 
   const chatEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -326,7 +327,7 @@ const ChatTab: React.FC = () => {
     setChat((prev) => [...prev, message]);
   };
 
-  const processUserQuery = async (userMessage: string) => {
+  const processUserQuery = async (userMessage: string, signal?: AbortSignal) => {
     if (
       !mcpClient || !(mcpClient instanceof MCPJamClient)
     ) {
@@ -343,6 +344,7 @@ const ChatTab: React.FC = () => {
         addMessageToChat(assistantMessage);
       },
       selectedModel,
+      signal,
     );
   };
 
@@ -359,13 +361,29 @@ const ChatTab: React.FC = () => {
     setInput("");
     setLoading(true);
 
+    // Create new AbortController for this request
+    const controller = new AbortController();
+    setAbortController(controller);
+
     try {
-      await processUserQuery(userMessage);
+      await processUserQuery(userMessage, controller.signal);
     } catch (e: unknown) {
       const errorMessage =
         e instanceof Error ? e.message : "Error sending message";
-      setError(errorMessage);
+      // Don't show error message if the request was cancelled
+      if (errorMessage !== "Chat was cancelled") {
+        setError(errorMessage);
+      }
     } finally {
+      setLoading(false);
+      setAbortController(null);
+    }
+  };
+
+  const handleStop = () => {
+    if (abortController) {
+      abortController.abort();
+      setAbortController(null);
       setLoading(false);
     }
   };
@@ -436,6 +454,15 @@ const ChatTab: React.FC = () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
   }, [showModelSelector]);
+
+  // Cleanup effect to abort any ongoing requests when component unmounts
+  useEffect(() => {
+    return () => {
+      if (abortController) {
+        abortController.abort();
+      }
+    };
+  }, [abortController]);
 
   return (
     <div className="flex flex-col h-full bg-white dark:bg-slate-950">
@@ -545,22 +572,31 @@ const ChatTab: React.FC = () => {
                   maxHeight: "128px",
                 }}
               />
-              <button
-                type="submit"
-                disabled={isSendDisabled}
-                className={cn(
-                  "flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center transition-colors",
-                  isSendDisabled
-                    ? "bg-slate-100 dark:bg-slate-800 text-slate-400 cursor-not-allowed"
-                    : "bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-slate-200",
-                )}
-              >
-                {loading ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                ) : (
+              {loading ? (
+                <button
+                  type="button"
+                  onClick={handleStop}
+                  className={cn(
+                    "flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center transition-colors",
+                    "bg-red-600 hover:bg-red-700 text-white",
+                  )}
+                >
+                  <Square className="w-4 h-4" />
+                </button>
+              ) : (
+                <button
+                  type="submit"
+                  disabled={isSendDisabled}
+                  className={cn(
+                    "flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center transition-colors",
+                    isSendDisabled
+                      ? "bg-slate-100 dark:bg-slate-800 text-slate-400 cursor-not-allowed"
+                      : "bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 hover:bg-slate-800 dark:hover:bg-slate-200",
+                  )}
+                >
                   <Send className="w-4 h-4" />
-                )}
-              </button>
+                </button>
+              )}
             </div>
 
             {/* Tips */}

--- a/client/src/components/ChatTab.tsx
+++ b/client/src/components/ChatTab.tsx
@@ -328,7 +328,7 @@ const ChatTab: React.FC = () => {
 
   const processUserQuery = async (userMessage: string) => {
     if (
-      !mcpClient || mcpClient instanceof MCPJamClient
+      !mcpClient || !(mcpClient instanceof MCPJamClient)
     ) {
       throw new Error(
         "Chat functionality is not available. Please ensure you have a valid API key and the server is connected.",

--- a/client/src/mcpjamClient.ts
+++ b/client/src/mcpjamClient.ts
@@ -769,7 +769,7 @@ export class MCPJamClient extends Client<Request, Notification, Result> {
       finalText: [] as string[],
       sanitizedTools: mappedTools(tools),
       model,
-      MAX_ITERATIONS: 5,
+      MAX_ITERATIONS: 50,
     };
   }
 


### PR DESCRIPTION
In this PR, we expand chat limits beyond 5 messages. We had originally set a MAX_ITERATIONS to 5 to prevent excessive usage of tokens. 

With this change, we set a hard limit to `50`, but provide the user with the option to kill a looping chat. 
