### PR TITLE
Replace amber colors with blue-gray in ToolCallApproval (#156)

### DIFF
--- a/client/src/components/chat/ToolCallApproval.tsx
+++ b/client/src/components/chat/ToolCallApproval.tsx
@@ -21,13 +21,13 @@ export const ToolCallApproval: React.FC<ToolCallApprovalProps> = ({
   onReject,
 }) => {
   return (
-    <div className="flex gap-4 p-4 border border-amber-200 dark:border-amber-800 rounded-xl bg-amber-50 dark:bg-amber-900/30 mb-2">
-      <div className="flex-1">
-        <div className="text-sm font-medium text-amber-800 dark:text-amber-200 mb-1">
-          Approve tool call: {toolCall.name}
-        </div>
-        <div className="text-xs text-amber-700 dark:text-amber-300 bg-amber-100 dark:bg-amber-900/50 p-2 rounded font-mono overflow-auto max-h-28">
-          {JSON.stringify(toolCall.input, null, 2)}
+      <div className="flex gap-4 p-4 border border-slate-200 dark:border-slate-700 rounded-xl bg-slate-50 dark:bg-slate-800 mb-2">
+        <div className="flex-1">
+          <div className="text-sm font-medium text-slate-800 dark:text-slate-200 mb-1">
+            Approve tool call: {toolCall.name}
+          </div>
+          <div className="text-xs text-slate-700 dark:text-slate-300 bg-slate-100 dark:bg-slate-700 p-2 rounded font-mono overflow-auto max-h-28">
+            {JSON.stringify(toolCall.input, null, 2)}
         </div>
       </div>
       <div className="flex flex-col justify-center gap-2">


### PR DESCRIPTION
## What does this PR do?

This PR updates the color scheme of the Tool Call Approval component (ToolCallApproval.tsx) by replacing the amber/orange colors with a more neutral blue-gray (slate) palette using TailwindCSS.
