### PR TITLE
Delayed client name validation

### DIFF
--- a/client/src/components/ClientFormSection.tsx
+++ b/client/src/components/ClientFormSection.tsx
@@ -95,6 +95,7 @@ const ClientFormSection: React.FC<ClientFormSectionProps> = ({
   const { toast } = useToast();
   const [showImportDialog, setShowImportDialog] = useState(false);
   const [nameError, setNameError] = useState<string>("");
+  const [isNameTouched, setIsNameTouched] = useState(false);
 
   // Initialize argsString when clientFormConfig changes
   useEffect(() => {
@@ -114,12 +115,14 @@ const ClientFormSection: React.FC<ClientFormSectionProps> = ({
   }, [clientFormConfig]);
 
   useEffect(() => {
+    if (!isNameTouched) return;
+    
     if (clientFormName.trim()) {
       setNameError("");
     } else {
       setNameError("Client name is required");
     }
-  }, [clientFormName]);
+  }, [clientFormName, isNameTouched]);
 
   // Handler for args changes that preserves input while typing
   const handleArgsChange = (newArgsString: string) => {
@@ -664,6 +667,7 @@ const ClientFormSection: React.FC<ClientFormSectionProps> = ({
                   id="client-name"
                   value={clientFormName}
                   onChange={(e) => setClientFormName(e.target.value)}
+                  onBlur={() => setIsNameTouched(true)}
                   placeholder="Enter client name"
                   className={`max-w-md ${nameError ? "border-red-500 focus:border-red-500 focus:ring-red-500" : ""}`}
                 />

--- a/client/src/components/ClientFormSection.tsx
+++ b/client/src/components/ClientFormSection.tsx
@@ -116,7 +116,7 @@ const ClientFormSection: React.FC<ClientFormSectionProps> = ({
 
   useEffect(() => {
     if (!isNameTouched) return;
-    
+
     if (clientFormName.trim()) {
       setNameError("");
     } else {
@@ -661,7 +661,7 @@ const ClientFormSection: React.FC<ClientFormSectionProps> = ({
               {/* Client Name */}
               <div className="space-y-2">
                 <Label htmlFor="client-name" className="text-sm font-medium">
-                  Name
+                  Name*
                 </Label>
                 <Input
                   id="client-name"


### PR DESCRIPTION
## What does this PR do?
Improves the client name validation UX by only showing validation errors after user interaction with the field. This builds on PR #160 by addressing the initial error state that could confuse users.

Changes made:
- Added `isNameTouched `state to track field interaction
- Modified validation logic to only show errors after field interaction
- Added `onBlur` handler to detect when user leaves the name input field
- Maintains required field validation while providing better user feedback timing
- Marks client name field as required with * in ClientFormSection

## How to test
Open the client creation form
1. Verify the name field starts with no error state
2. Click into the name field and then click away (blur) - should show error
3. Type a name and verify error disappears
4. Delete the name and click away - should show error again
5. Verify the form still requires a name to be submitted