### PR TITLE
feat(cli): add clickable console URLs

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -123,9 +123,10 @@ async function runWebClient(args: Args): Promise<void> {
   if (serverOk) {
     try {
       console.log("\x1b[32m%s\x1b[0m", "✅ Server initialized successfully"); // Green color
+      const url = `http://127.0.0.1:${CLIENT_PORT}`;
       console.log(
         "\x1b[36m%s\x1b[0m",
-        `🌐 Opening browser at http://127.0.0.1:${CLIENT_PORT}`,
+        `🌐 Opening browser at \u001B]8;;${url}\u0007${url}\u001B]8;;\u0007`,
       );
 
       if (process.env.MCP_AUTO_OPEN_ENABLED !== "false") {

--- a/client/bin/client.js
+++ b/client/bin/client.js
@@ -40,15 +40,16 @@ const server = http.createServer((request, response) => {
 });
 
 const port = process.env.PORT || 6274;
+const url = `http://127.0.0.1:${port}`;
 server.on("listening", () => {
   console.log(
-    `🔍 MCPJam Inspector is up and running at http://127.0.0.1:${port} 🚀`,
+    `🔍 MCPJam Inspector is up and running at \u001B]8;;${url}\u0007${url}\u001B]8;;\u0007 🚀`,
   );
 });
 server.on("error", (err) => {
   if (err.message.includes(`EADDRINUSE`)) {
     console.error(
-      `❌  MCPJam Inspector PORT IS IN USE at http://127.0.0.1:${port} ❌ `,
+      `❌  MCPJam Inspector PORT IS IN USE at \u001B]8;;${url}\u0007${url}\u001B]8;;\u0007 ❌ `,
     );
   } else {
     throw err;

--- a/client/bin/start.js
+++ b/client/bin/start.js
@@ -116,9 +116,10 @@ async function main() {
   if (serverOk) {
     try {
       console.log("\x1b[32m%s\x1b[0m", "✅ Server initialized successfully"); // Green color
+      const url = `http://127.0.0.1:${CLIENT_PORT}`;
       console.log(
         "\x1b[36m%s\x1b[0m",
-        `🌐 Opening browser at http://127.0.0.1:${CLIENT_PORT}`,
+        `🌐 Opening browser at \u001B]8;;${url}\u0007${url}\u001B]8;;\u0007`,
       );
 
       if (process.env.MCP_AUTO_OPEN_ENABLED !== "false") {


### PR DESCRIPTION
## What does this PR do?

Resolves #144 

- Add clickable URLs in cli.ts console output using ANSI escape sequences
- Add clickable URLs in client.js server status messages
- Add clickable URLs in start.js console output
- Improve user experience by making localhost URLs interactive in terminal

This change makes it easier for users to open the inspector interface by clicking the URLs directly in their terminal instead of copying and pasting.