### PR TITLE
Fix :Replaced tool icon with Hammer from lucide-react

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -73,6 +73,6 @@
     "ts-jest": "^29.2.6",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.7.0",
-    "vite": "^6.3.0"
+    "vite": "^6.3.5"
   }
 }

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -17,6 +17,7 @@ import {
   Star,
   Edit2,
   CopyPlus,
+  Hammer,
 } from "lucide-react";
 import { RequestStorage } from "@/lib/utils/request/requestStorage";
 import {
@@ -317,7 +318,7 @@ const ToolsTab = ({
                 {/* Tool name with emoji and styling */}
                 <div className="flex items-center justify-between">
                   <div className="flex items-center space-x-2">
-                    <span className="text-lg">🛠️</span>
+                  <Hammer className="w-4 h-4 text-slate-700 dark:text-slate-300" />
                     <span className="font-mono text-xs bg-gradient-to-r from-slate-100 to-gray-100 dark:from-slate-800 dark:to-gray-800 px-2.5 py-1 rounded-md border border-slate-300 dark:border-slate-600 text-slate-800 dark:text-slate-200 font-medium shadow-sm">
                       {tool.name}
                     </span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcpjam/inspector",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcpjam/inspector",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "workspaces": [
         "client",
@@ -45,7 +45,7 @@
     },
     "cli": {
       "name": "@mcpjam/inspector-cli",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.0",
@@ -66,7 +66,7 @@
     },
     "client": {
       "name": "@mcpjam/inspector-client",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.0",
@@ -122,7 +122,7 @@
         "ts-jest": "^29.2.6",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.7.0",
-        "vite": "^6.3.0"
+        "vite": "^6.3.5"
       }
     },
     "client/node_modules/lucide-react": {
@@ -10793,7 +10793,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -11283,7 +11282,7 @@
     },
     "server": {
       "name": "@mcpjam/inspector-server",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.0",


### PR DESCRIPTION
This PR replaces the hardcoded 🛠 emoji used in the tool list with a `Hammer` icon from `lucide-react` to match the visual style of the tab bar.

Fixes #171

✔️ Uses consistent size and color  
✔️ Supports dark and light mode  
✔️ Improves UI consistency

Let me know if you'd like me to apply different icons for other tools too!