### PR TITLE
fix: standardize tool icons to match tab design pattern

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -17,6 +17,7 @@ import {
   Star,
   Edit2,
   CopyPlus,
+  Hammer,
 } from "lucide-react";
 import { RequestStorage } from "@/lib/utils/request/requestStorage";
 import {
@@ -317,7 +318,9 @@ const ToolsTab = ({
                 {/* Tool name with emoji and styling */}
                 <div className="flex items-center justify-between">
                   <div className="flex items-center space-x-2">
-                    <span className="text-lg">🛠️</span>
+                    <span className="text-lg">
+                      <Hammer className="w-5 h-5 text-muted-foreground" />
+                    </span>
                     <span className="font-mono text-xs bg-gradient-to-r from-slate-100 to-gray-100 dark:from-slate-800 dark:to-gray-800 px-2.5 py-1 rounded-md border border-slate-300 dark:border-slate-600 text-slate-800 dark:text-slate-200 font-medium shadow-sm">
                       {tool.name}
                     </span>


### PR DESCRIPTION
- Replace wrench emoji with Hammer icon from lucide-react in tooltab.tsx
- Ensure consistent icon usage between tool displays and navigation tabs

Fixes #171

## What does this PR do?

This PR standardizes the icon usage across the MCPJam Inspector UI by replacing the wrench emoji with a proper Hammer icon from lucide-react in the Tools tab. This ensures visual consistency between the navigation tabs and tool displays, following the established design pattern used throughout the application.

## How to test

1. Navigate to the Tools tab
2. Verify that the tab icon now shows a Hammer icon (from lucide-react) instead of the wrench emoji
3. Compare the Tools tab icon with other tab icons to ensure consistent styling and sizing
4. Check that tool displays throughout the app use matching iconography