### PR TITLE
fix: support multiple servers from config file without --server flag

### DIFF
--- a/client/src/hooks/app/useAppEffects.ts
+++ b/client/src/hooks/app/useAppEffects.ts
@@ -115,23 +115,75 @@ export const useAppEffects = (
     configState.updateAuthState,
   ]);
 
-  // Fetch default environment
+  // Fetch default environment and handle CLI server configs
   useEffect(() => {
     const fetchConfig = async () => {
       try {
         const proxyAddress = await getMCPProxyAddressAsync(configState.config);
         const response = await fetch(`${proxyAddress}/config`);
         const data = await response.json();
-        const currentConfig =
-          serverState.serverConfigs[serverState.selectedServerName];
-        if (currentConfig?.transportType === "stdio") {
-          serverState.setServerConfigs((prev) => ({
-            ...prev,
-            [serverState.selectedServerName]: {
-              ...prev[serverState.selectedServerName],
-              env: data.defaultEnvironment || {},
-            } as StdioServerDefinition,
-          }));
+        
+        // Handle CLI-provided server configurations
+        if (data.serverConfigs && Object.keys(data.serverConfigs).length > 0) {
+          console.log("📡 Found CLI server configurations, loading...");
+          
+          // Convert CLI config format to internal format
+          const convertedConfigs: Record<string, any> = {};
+          
+          for (const [serverName, cliConfig] of Object.entries(data.serverConfigs)) {
+            const config = cliConfig as any;
+            
+            // Convert different transport types
+            if (config.type === "sse" && config.url) {
+              // SSE configuration
+              convertedConfigs[serverName] = {
+                transportType: "sse",
+                url: new URL(config.url),
+                name: serverName,
+              };
+            } else if (config.command) {
+              // STDIO configuration
+              convertedConfigs[serverName] = {
+                transportType: "stdio",
+                command: config.command,
+                args: config.args || [],
+                env: { ...(data.defaultEnvironment || {}), ...(config.env || {}) },
+                name: serverName,
+              };
+            } else if (config.url) {
+              // Default to SSE for URL-based configs
+              convertedConfigs[serverName] = {
+                transportType: "sse", 
+                url: new URL(config.url),
+                name: serverName,
+              };
+            }
+          }
+          
+          // Only update if we have valid configurations and no existing ones
+          if (Object.keys(convertedConfigs).length > 0 && Object.keys(serverState.serverConfigs).length === 0) {
+            console.log(`✅ Loading ${Object.keys(convertedConfigs).length} servers from CLI config`);
+            serverState.setServerConfigs(convertedConfigs);
+            
+            // Set the first server as selected
+            const firstServerName = Object.keys(convertedConfigs)[0];
+            serverState.setSelectedServerName(firstServerName);
+            
+            addClientLog(`Loaded ${Object.keys(convertedConfigs).length} servers from CLI configuration`, "info");
+          }
+        } else {
+          // Handle single server environment update (existing behavior)
+          const currentConfig =
+            serverState.serverConfigs[serverState.selectedServerName];
+          if (currentConfig?.transportType === "stdio") {
+            serverState.setServerConfigs((prev) => ({
+              ...prev,
+              [serverState.selectedServerName]: {
+                ...prev[serverState.selectedServerName],
+                env: data.defaultEnvironment || {},
+              } as StdioServerDefinition,
+            }));
+          }
         }
       } catch (error) {
         console.error("Error fetching default environment:", error);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -34,6 +34,10 @@ const defaultEnvironment = {
   ...(process.env.MCP_ENV_VARS ? JSON.parse(process.env.MCP_ENV_VARS) : {}),
 };
 
+const serverConfigs = process.env.MCP_SERVER_CONFIGS 
+  ? JSON.parse(process.env.MCP_SERVER_CONFIGS) 
+  : null;
+
 const { values } = parseArgs({
   args: process.argv.slice(2),
   options: {
@@ -362,6 +366,7 @@ app.get("/config", (req, res) => {
       defaultEnvironment,
       defaultCommand: values.env,
       defaultArgs: values.args,
+      serverConfigs,
     });
   } catch (error) {
     console.error("❌ Error in /config route:", error);

--- a/test-config.json
+++ b/test-config.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "everything": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-everything"],
+      "env": {
+        "hello": "Hello MCP!"
+      }
+    },
+    "currency": {
+      "type": "sse",
+      "url": "https://currency-mcp.wesbos.com/sse",
+      "note": "For SSE connections, add this URL directly in Client"
+    },
+    "sentry": {
+      "command": "npx",
+      "args": ["mcp-remote@latest", "https://mcp.sentry.dev/sse"]
+    }
+  }
+}


### PR DESCRIPTION
Fixes #118 by enabling CLI to load all servers from config file when only --config is provided.

Changes:
- CLI: Allow --config without --server, load all servers when no --server specified
- Server: Pass multiple server configurations via MCP_SERVER_CONFIGS env var
- Client: Auto-create and connect to servers from CLI config on startup
- Support both stdio and SSE transport types from config file

Usage:
- Multiple servers: `npx @mcpjam/inspector --config ./mcp.json`
- Single server: `npx @mcpjam/inspector --config ./mcp.json --server everything`
