### PR TITLE
feat(client): add copy logs functionality to TabbedHistoryPanel

### DIFF
--- a/client/src/components/TabbedHistoryPanel.tsx
+++ b/client/src/components/TabbedHistoryPanel.tsx
@@ -1,6 +1,13 @@
 import { CompatibilityCallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { useEffect, useState } from "react";
-import { Activity, ScrollText, ChevronDown, Bug, Trash2, Copy } from "lucide-react";
+import {
+  Activity,
+  ScrollText,
+  ChevronDown,
+  Bug,
+  Trash2,
+  Copy,
+} from "lucide-react";
 import ActivityTab from "./ActivityTab";
 import ResultsTab from "./ResultsTab";
 import ClientLogsTab from "./ClientLogsTab";
@@ -47,16 +54,16 @@ const TabbedHistoryPanel = ({
           const timestamp = new Date(log.timestamp).toISOString();
           return `[${timestamp}] ${log.level.toUpperCase()}: ${log.message}`;
         })
-        .join('\n');
+        .join("\n");
 
       await navigator.clipboard.writeText(logsText);
-      
+
       toast({
         title: "Logs copied to clipboard",
         description: `Successfully copied ${clientLogs.length} log entries to clipboard`,
       });
     } catch (err) {
-      console.error('Failed to copy logs to clipboard:', err);
+      console.error("Failed to copy logs to clipboard:", err);
       toast({
         title: "Failed to copy logs",
         description: "Could not copy logs to clipboard. Please try again.",


### PR DESCRIPTION
Resolves: https://github.com/MCPJam/inspector/issues/187

## What does this PR do?

- Introduced a button to copy client logs to the clipboard.
- Implemented toast notifications for successful and failed copy actions.
- Updated the UI to include the new CopyLogsButton component in the logs tab.

## How to test

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/c6c14bee-178d-42ab-ac85-318009e3792e" />

Copied content: 
```
[2025-07-07T04:16:19.835Z] DEBUG: Checking MCP proxy server health
[2025-07-07T04:16:19.854Z] DEBUG: MCP proxy server health check passed
[2025-07-07T04:16:19.855Z] INFO: Attempting to connect to MCP server (attempt 1/2)
[2025-07-07T04:16:19.855Z] INFO: Connecting to MCP server via stdio: npx
[2025-07-07T04:16:21.711Z] INFO: Successfully connected to MCP server via stdio
[2025-07-07T04:16:21.712Z] DEBUG: Server capabilities retrieved: {"resources":{},"tools":{"listChanged":true}}
[2025-07-07T04:16:21.712Z] INFO: MCP client initialization completed
...


```
