### PR TITLE
Fixed#150

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -553,7 +553,10 @@ const App = () => {
           {/* Horizontal Tabs */}
           <Tabs
             currentPage={currentPage}
-            onPageChange={setCurrentPage}
+            onPageChange={(page) => {
+              setCurrentPage(page);
+              serverState.handleCancelClientForm(); 
+            }}
             serverCapabilities={serverCapabilities}
             pendingSampleRequests={mcpOperations.pendingSampleRequests}
             shouldDisableAll={!connectionState.mcpAgent}


### PR DESCRIPTION
Fixes #150 
---

## 🛠️ Fix: Close Edit Connection Panel on Tab Change

### Summary

This PR improves the user experience by ensuring that the edit connection panel (used for editing server configurations) is automatically closed whenever a main navigation tab (e.g., Tools, Chat, Ping, etc.) is selected.

### Details

- Updated the `onPageChange` handler in `App.tsx` to call `handleCancelClientForm()` in addition to changing the current page.
- This ensures that if the edit connection panel is open, it will be closed when the user navigates to a different main tab.
- Prevents the edit panel from obscuring the content of the newly selected tab.

### Before

- The edit connection panel remained open even after clicking a different main tab, causing confusion and blocking access to tab content.

### After

- The edit connection panel is closed as soon as a new main tab is selected, and the correct tab content is displayed.

### Testing

- Open the edit connection panel.
- Click any main tab (Tools, Chat, etc.).
- Confirm that the edit panel closes and the selected tab’s content is visible.

---