### PR TITLE
Shorten string

### DIFF
--- a/client/src/components/Sidebar/ConnectionItem.tsx
+++ b/client/src/components/Sidebar/ConnectionItem.tsx
@@ -118,7 +118,7 @@ const ConnectionItem: React.FC<ConnectionItemProps> = ({
             {getConnectionStatusIcon(connection.connectionStatus)}
             <div>
               <div className="font-medium text-sm">{connection.name}</div>
-              <div className="text-xs text-muted-foreground">
+              <div className={`text-xs text-muted-foreground break-all`}>
                 {getConnectionDisplayText(connection)}
               </div>
             </div>

--- a/client/src/components/Sidebar/connectionHelpers.tsx
+++ b/client/src/components/Sidebar/connectionHelpers.tsx
@@ -1,5 +1,6 @@
 import { Wifi, WifiOff, AlertCircle } from "lucide-react";
 import { ServerConnectionInfo } from "@/lib/utils/mcp/mcpjamAgent";
+import StringUtil from "@/utils/stringUtil";
 
 export const getConnectionStatusIcon = (status: string) => {
   switch (status) {
@@ -37,7 +38,7 @@ export const getConnectionDisplayText = (connection: ServerConnectionInfo) => {
     return `${connection.config.command} ${connection.config.args?.join(" ") || ""}`;
   }
   if ("url" in connection.config && connection.config.url) {
-    return connection.config.url.toString();
+    return StringUtil.shorten(connection.config.url.toString());
   }
   return "Unknown configuration";
 };

--- a/client/src/utils/stringUtil.ts
+++ b/client/src/utils/stringUtil.ts
@@ -1,0 +1,13 @@
+/**
+ * Shortens a string to a maximum length, adding "..." if it exceeds the length.
+ *
+ * @param str - The string to shorten.
+ * @param maxLength - The maximum length of the string. Defaults to 40.
+ * @returns The shortened string.
+ */
+
+export default class StringUtil {
+  static shorten(str: string, maxLength: number = 30): string {
+    return str.length > maxLength ? str.substring(0, maxLength - 3) + "..." : str;
+  }
+}


### PR DESCRIPTION
Resolve: https://github.com/MCPJam/inspector/issues/212

## What does this PR do?

* Provide 2 solutions to handle the issue:
  * Add a `StringUtil` and a shorten string function to allow the truncation of URL
  * But the truncation is still not a good idea when any of `connection.config.args` is too long -> allowing them to wrap to the next line using the CSS `break-all` class (I know it's a bit hard to understand, I can explain more if needed)

## How to test

1. Create a connection with a long command and multiple arguments
2. Verify the command text wraps to the next line in the sidebar
3. Check that URLs are still shortened appropriately
4. Test at different sidebar widths to ensure proper wrapping
