### PR TITLE
feat(ui): add explanatory tooltip for client name validation error. R…

### DIFF
--- a/client/src/components/ClientFormSection.tsx
+++ b/client/src/components/ClientFormSection.tsx
@@ -34,6 +34,12 @@ import {
   ChevronDown,
   ChevronRight,
 } from "lucide-react";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "@/components/ui/tooltip";
 import ConfigImportDialog from "./ConfigImportDialog";
 
 interface ClientConfig {
@@ -673,7 +679,23 @@ const ClientFormSection: React.FC<ClientFormSectionProps> = ({
                 />
                 {nameError && (
                   <p className="text-sm text-red-500 flex items-center gap-1">
-                    <AlertCircle className="h-3 w-3" />
+                    <TooltipProvider>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <AlertCircle className="h-4 w-4 cursor-help" />
+                        </TooltipTrigger>
+                        <TooltipContent
+                          side="top"
+                          className="max-w-sm p-2 text-xs leading-relaxed">
+                          A client name is required to help you identify and
+                          manage your MCP connections.
+                          <br/>
+                          It ensures clarity when debugging or switching between
+                          multiple clients. Leaving it blank makes the
+                          connection untraceable within the tool.
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
                     {nameError}
                   </p>
                 )}


### PR DESCRIPTION
resolves #198

## What does this PR do?

Adds a tooltip to the AlertCircle icon shown during client name validation
errors. The tooltip explains why a name is required when creating a client
connection, improving UX for new users.

## How to test

changes are in client\src\components\ClientFormSection.tsx
