### PR TITLE
Add button to collapse/expand server tools

### DIFF
--- a/client/src/components/chat/ToolSelector.tsx
+++ b/client/src/components/chat/ToolSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { ChevronDown, Wrench, Check } from "lucide-react";
+import { ChevronDown, ChevronRight, Wrench, Check } from "lucide-react";
 import { cn } from "@/lib/utils/request/utils";
 
 export interface ToolSelection {
@@ -30,6 +30,9 @@ export const ToolSelector: React.FC<ToolSelectorProps> = ({
   loading = false,
 }) => {
   const [showSelector, setShowSelector] = useState(false);
+  const [expandedServers, setExpandedServers] = useState<Set<string>>(
+    new Set(),
+  );
   const selectorRef = useRef<HTMLDivElement>(null);
 
   const availableTools = serverInfo
@@ -80,6 +83,20 @@ export const ToolSelector: React.FC<ToolSelectorProps> = ({
     onSelectionChange({
       enabledTools: newEnabledTools,
       enabledServers: toolSelection.enabledServers,
+    });
+  };
+
+  const toggleExpandedServer = (serverName: string) => {
+    setExpandedServers((prev) => {
+      const newSet = new Set(prev);
+
+      if (newSet.has(serverName)) {
+        newSet.delete(serverName);
+      } else {
+        newSet.add(serverName);
+      }
+
+      return newSet;
     });
   };
 
@@ -161,6 +178,7 @@ export const ToolSelector: React.FC<ToolSelectorProps> = ({
               const serverEnabled = toolSelection.enabledServers.has(
                 server.name,
               );
+              const serverExpanded = expandedServers.has(server.name);
               const serverTools = server.tools;
               const enabledServerToolCount = serverTools.filter((tool) =>
                 toolSelection.enabledTools.has(tool.name),
@@ -171,8 +189,8 @@ export const ToolSelector: React.FC<ToolSelectorProps> = ({
               return (
                 <div key={server.name} className="mb-2">
                   {/* Server Toggle */}
-                  <div className="px-4 py-2 hover:bg-slate-50 dark:hover:bg-slate-800/50">
-                    <label className="flex items-center gap-3 cursor-pointer">
+                  <div className="relative">
+                    <label className="flex items-center gap-3 pl-4 pr-12 py-2 min-w-0 cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-800/50">
                       <div className="relative">
                         <input
                           type="checkbox"
@@ -186,8 +204,8 @@ export const ToolSelector: React.FC<ToolSelectorProps> = ({
                           <Check className="w-3 h-3 text-blue-600 absolute top-0.5 left-0.5 pointer-events-none" />
                         )}
                       </div>
-                      <div className="flex-1">
-                        <div className="text-sm font-medium text-slate-900 dark:text-slate-100">
+                      <div className="min-w-0">
+                        <div className="text-sm font-medium break-words text-slate-900 dark:text-slate-100">
                           {server.name}
                         </div>
                         <div className="text-xs text-slate-500 dark:text-slate-400">
@@ -195,11 +213,22 @@ export const ToolSelector: React.FC<ToolSelectorProps> = ({
                         </div>
                       </div>
                     </label>
+
+                    <button
+                      onClick={() => toggleExpandedServer(server.name)}
+                      className="absolute top-1/2 right-3 -translate-y-1/2 text-xs p-2 hover:bg-slate-100 dark:hover:bg-slate-800 rounded text-slate-600 dark:text-slate-300"
+                    >
+                      {serverExpanded ? (
+                        <ChevronDown className="w-3 h-3 text-slate-400" />
+                      ) : (
+                        <ChevronRight className="w-3 h-3 text-slate-400" />
+                      )}
+                    </button>
                   </div>
 
                   {/* Server Tools */}
-                  {serverEnabled && (
-                    <div className="ml-8 space-y-1">
+                  {serverExpanded && (
+                    <div className="space-y-1">
                       {serverTools.map((tool) => {
                         const toolEnabled = toolSelection.enabledTools.has(
                           tool.name,
@@ -208,9 +237,9 @@ export const ToolSelector: React.FC<ToolSelectorProps> = ({
                         return (
                           <div
                             key={tool.name}
-                            className="px-4 py-1.5 hover:bg-slate-50 dark:hover:bg-slate-800/50"
+                            className="hover:bg-slate-50 dark:hover:bg-slate-800/50"
                           >
-                            <label className="flex items-center gap-3 cursor-pointer">
+                            <label className="pl-12 pr-4 py-1.5 flex items-center gap-3 cursor-pointer">
                               <input
                                 type="checkbox"
                                 checked={toolEnabled}


### PR DESCRIPTION
## What does this PR do?

This pull request adds the ability to collapse and expand the list of tools for each server, making it easier for users to navigate.

<img width="280" alt="Screenshot 2025-07-09 at 6 35 17 p m" src="https://github.com/user-attachments/assets/3a297be7-aa41-4c17-91bb-2bf5e042050e" />

Closes #151 

## How to test

Navigate to the `Chat` tab and click the `Tools` button. A chevron icon should appear next to each server, allowing you to toggle the visibility of its tools.
