### PR TITLE
rename chat to LLM playground

### DIFF
--- a/client/src/components/Tabs.tsx
+++ b/client/src/components/Tabs.tsx
@@ -41,7 +41,7 @@ const Tabs = ({
     },
     {
       id: "chat",
-      label: "Chat",
+      label: "Playground",
       icon: Bot,
       disabled: shouldDisableAll,
     },

--- a/client/src/components/chat/ChatTab.tsx
+++ b/client/src/components/chat/ChatTab.tsx
@@ -10,7 +10,7 @@ interface ChatTabProps {
 
 const ChatTab: React.FC<ChatTabProps> = ({ mcpAgent, updateTrigger }) => {
   const config = createChatConfig({
-    subtitle: "Chat with access to tools from all connected servers",
+    subtitle: "LLM Playground with access to tools from all connected servers",
     additionalSuggestions: ["What tools do you have access to?"],
   });
 

--- a/client/src/lib/utils/request/utils.ts
+++ b/client/src/lib/utils/request/utils.ts
@@ -38,7 +38,7 @@ export function createChatConfig(
   ];
 
   const config: ChatConfig = {
-    title: `Chat`,
+    title: "LLM Playground",
     suggestions: [...baseSuggestions, ...(options.additionalSuggestions || [])],
   };
 


### PR DESCRIPTION
### 🔧 Changes Made
This PR updates terminology in the UI and configuration to replace "Chat" with "LLM Playground" for better clarity and alignment with current project direction.

Specifically:

- Renamed tab label from "Chat" → "Playground" in Tabs.tsx

- Updated subtitle in ChatTab.tsx to reflect the LLM Playground purpose

- Changed title in createChatConfig from 'Chat' → 'LLM Playground'