### PR TITLE
Fix auth on streamable HTTP

### DIFF
--- a/client/src/components/OAuthCallback.tsx
+++ b/client/src/components/OAuthCallback.tsx
@@ -71,6 +71,8 @@ const OAuthCallback = ({ onConnect }: OAuthCallbackProps) => {
     };
 
     handleCallback().finally(() => {
+      // Clean up session storage
+      sessionStorage.removeItem(SESSION_KEYS.TRANSPORT_TYPE);
       window.history.replaceState({}, document.title, "/");
     });
   }, [toast, onConnect]);

--- a/client/src/hooks/app/useOAuthHandlers.ts
+++ b/client/src/hooks/app/useOAuthHandlers.ts
@@ -6,6 +6,7 @@ import {
 import { handleOAuthDebugConnect } from "../../services/oauth";
 import { useServerState } from "../useServerState";
 import { useConfigState } from "../useConfigState";
+import { SESSION_KEYS, getServerSpecificKey } from "../../lib/types/constants";
 
 // OAuth Handlers Hook
 export const useOAuthHandlers = (
@@ -44,8 +45,19 @@ export const useOAuthHandlers = (
       }
 
       const finalServerName = existingServerName || serverName;
+
+      // Get transport type from session storage or default to "sse"
+      const transportKey = getServerSpecificKey(
+        SESSION_KEYS.TRANSPORT_TYPE,
+        serverUrl,
+      );
+      const storedTransportType = sessionStorage.getItem(transportKey) as
+        | "sse"
+        | "streamable-http"
+        | null;
+      const transportType = storedTransportType || "sse";
       const serverConfig: HttpServerDefinition = {
-        transportType: "sse", // TODO: Make this dynamic
+        transportType,
         url: new URL(serverUrl),
       };
 

--- a/client/src/lib/types/constants.ts
+++ b/client/src/lib/types/constants.ts
@@ -4,6 +4,7 @@ import { InspectorConfig } from "./configurationTypes";
 export const SESSION_KEYS = {
   CODE_VERIFIER: "mcp_code_verifier",
   SERVER_URL: "mcp_server_url",
+  TRANSPORT_TYPE: "mcp_transport_type",
   TOKENS: "mcp_tokens",
   CLIENT_INFORMATION: "mcp_client_information",
   SERVER_METADATA: "mcp_server_metadata",

--- a/client/src/lib/utils/auth/auth.ts
+++ b/client/src/lib/utils/auth/auth.ts
@@ -10,9 +10,21 @@ import {
 import { SESSION_KEYS, getServerSpecificKey } from "../../types/constants";
 
 export class InspectorOAuthClientProvider implements OAuthClientProvider {
-  constructor(public serverUrl: string) {
+  constructor(
+    public serverUrl: string,
+    public transportType?: "sse" | "streamable-http",
+  ) {
     // Save the server URL to session storage
     sessionStorage.setItem(SESSION_KEYS.SERVER_URL, serverUrl);
+
+    // Save the transport type to session storage if provided
+    if (transportType) {
+      const transportKey = getServerSpecificKey(
+        SESSION_KEYS.TRANSPORT_TYPE,
+        serverUrl,
+      );
+      sessionStorage.setItem(transportKey, transportType);
+    }
   }
 
   get redirectUrl() {
@@ -100,6 +112,10 @@ export class InspectorOAuthClientProvider implements OAuthClientProvider {
     );
     sessionStorage.removeItem(
       getServerSpecificKey(SESSION_KEYS.CODE_VERIFIER, this.serverUrl),
+    );
+    // Clean up transport type when clearing OAuth data
+    sessionStorage.removeItem(
+      getServerSpecificKey(SESSION_KEYS.TRANSPORT_TYPE, this.serverUrl),
     );
   }
 }

--- a/client/src/lib/utils/mcp/mcpjamClient.ts
+++ b/client/src/lib/utils/mcp/mcpjamClient.ts
@@ -388,7 +388,10 @@ export class MCPJamClient extends Client<Request, Notification, Result> {
       "url" in this.serverConfig &&
       this.serverConfig.url
     ) {
-      return new InspectorOAuthClientProvider(this.serverConfig.url.toString());
+      return new InspectorOAuthClientProvider(
+        this.serverConfig.url.toString(),
+        this.serverConfig.transportType,
+      );
     }
     return null;
   }
@@ -509,6 +512,7 @@ export class MCPJamClient extends Client<Request, Notification, Result> {
       // Create an auth provider with the current server URL
       const serverAuthProvider = new InspectorOAuthClientProvider(
         this.serverConfig.url.toString(),
+        this.serverConfig.transportType,
       );
 
       // Use manually provided bearer token if available, otherwise use OAuth tokens
@@ -881,6 +885,7 @@ export class MCPJamClient extends Client<Request, Notification, Result> {
     if (this.serverConfig.transportType !== "stdio") {
       const authProvider = new InspectorOAuthClientProvider(
         (this.serverConfig as HttpServerDefinition).url.toString(),
+        this.serverConfig.transportType,
       );
       authProvider.clear();
       this.addClientLog("OAuth tokens cleared", "debug");


### PR DESCRIPTION
## What does this PR do?

Before, auth with streamable http was broken. This was because we hard coded the OAuth flow to return a hard coded "sse" route, when it should be `streamable-http`. We are able to persist the connection type via browser storage. 

## How to test

Test that https://huggingface.co/mcp?login now works
