### PR TITLE
fix(v1.0.0): temporarily remove profile icon in header

### DIFF
--- a/v1-0-0/src/app/page.tsx
+++ b/v1-0-0/src/app/page.tsx
@@ -16,18 +16,18 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { ThemeSwitcher } from "@/components/sidebar/theme-switcher";
-import { AccountSwitcher } from "@/components/sidebar/account-switcher";
+// import { AccountSwitcher } from "@/components/sidebar/account-switcher";
 import { useAppState } from "@/hooks/useAppState";
 
-const users = [
-  {
-    id: "1",
-    name: "MCP Inspector",
-    email: "inspector@example.com",
-    avatar: "/avatars/shadcn.jpg",
-    role: "Inspector",
-  },
-] as const;
+// const users = [
+//   {
+//     id: "1",
+//     name: "MCP Inspector",
+//     email: "inspector@example.com",
+//     avatar: "/avatars/shadcn.jpg",
+//     role: "Inspector",
+//   },
+// ] as const;
 
 export default function Home() {
   const [activeTab, setActiveTab] = useState("servers");
@@ -69,7 +69,7 @@ export default function Home() {
             </div>
             <div className="flex items-center gap-2">
               <ThemeSwitcher />
-              <AccountSwitcher users={users} />
+              {/* <AccountSwitcher users={users} /> */}
             </div>
           </div>
         </header>


### PR DESCRIPTION
## What does this PR do?

  Temporarily removes the profile icon (AccountSwitcher) from the upper right corner of the header
  as requested in issue #264.

  ## How to test

  1. Run the v1.0.0 application (`cd v1-0-0 && npm run dev`)
  2. Navigate to any page
  3. Verify the profile icon is no longer visible in the upper right corner
  4. Only the theme switcher should remain in the header
  
<img width="1553" height="882" alt="Screenshot 2025-07-22 at 12 23 35 PM" src="https://github.com/user-attachments/assets/f88ed75c-f3de-4a4b-a4ba-02a810ab8774" />
  
