### PR TITLE
fix(v1.0.0): display manual Bearer tokens in server connection cards

### DIFF
--- a/v1-0-0/src/components/connection/ServerConnectionCard.tsx
+++ b/v1-0-0/src/components/connection/ServerConnectionCard.tsx
@@ -46,6 +46,14 @@ export function ServerConnectionCard({
 
   const isHttpServer = server.config.url !== undefined;
   const hasOAuth = server.oauthState || server.oauthFlow;
+  
+  // Extract manual Bearer token from headers
+  const manualBearerToken = server.config.requestInit?.headers?.Authorization?.startsWith('Bearer ') 
+    ? server.config.requestInit.headers.Authorization.slice(7) // Remove 'Bearer ' prefix
+    : null;
+  
+  // Show expandable section if there's OAuth data, manual Bearer token, or STDIO server
+  const hasExpandableContent = hasOAuth || manualBearerToken || !isHttpServer;
 
   // Update current time every second for live countdown
   useEffect(() => {
@@ -248,7 +256,7 @@ export function ServerConnectionCard({
               )}
             </div>
           )}
-          {(hasOAuth || !isHttpServer) && (
+          {hasExpandableContent && (
             <div className="flex justify-end">
               <Button
                 variant="ghost"
@@ -265,8 +273,38 @@ export function ServerConnectionCard({
             </div>
           )}
           {/* Expandable Details */}
-          {isExpanded && (hasOAuth || !isHttpServer) && (
+          {isExpanded && hasExpandableContent && (
             <div className="space-y-3 pt-2">
+              {/* Manual Bearer Token Information - only show if no OAuth */}
+              {manualBearerToken && !server.oauthState && (
+                <div className="space-y-2">
+                  <div className="space-y-3 text-xs">
+                    <div>
+                      <span className="text-muted-foreground font-medium">
+                        Bearer Access Token (Manual):
+                      </span>
+                      <div className="font-mono text-foreground break-all bg-muted/30 p-2 rounded mt-1 relative group">
+                        <div className="pr-8">
+                          {manualBearerToken}
+                        </div>
+                        <button
+                          onClick={() =>
+                            copyToClipboard(manualBearerToken, "manualBearerToken")
+                          }
+                          className="absolute top-1 right-1 p-1 text-muted-foreground/50 hover:text-foreground transition-colors cursor-pointer"
+                        >
+                          {copiedField === "manualBearerToken" ? (
+                            <Check className="h-3 w-3 text-green-500" />
+                          ) : (
+                            <Copy className="h-3 w-3" />
+                          )}
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
               {/* OAuth Information */}
               {server.oauthState && (
                 <div className="space-y-2">


### PR DESCRIPTION
## Changes
  - Added logic to extract and display manual Bearer tokens from Authorization headers
  - Implemented prioritization: OAuth tokens take precedence when both auth methods exist
  - Added "(Manual)" label to distinguish manual tokens from OAuth tokens
  - Included copy functionality for manual Bearer tokens
  - Updated expandable content conditions to show manual tokens when no OAuth is present
  
  
<img width="438" height="327" alt="Screenshot 2025-07-24 at 12 07 11 PM" src="https://github.com/user-attachments/assets/99ec59b9-1591-47f1-a589-1e82e1bab4b1" />