### PR TITLE
Use refresh token to get new auth token 

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,2 +1,3 @@
 # Security Policy
+
 Thank you for helping us keep the MCPJam secure. Please notify us via email (mcpjams@gmail.com) or discord as soon as possible for us to put a fix. Thank you!


### PR DESCRIPTION
## Issue
The refresh tokens are never used to get new access tokens. In this PR we make that happen. Users can get a new access token if they hit refresh. 