### PR TITLE
Add the ability to edit server configs 

### DIFF
--- a/claude-code-prompts/edit_server_modal_07_29.md
+++ b/claude-code-prompts/edit_server_modal_07_29.md
@@ -1,0 +1,17 @@
+# Objective
+
+Create the ability to edit a server config. Editing a server config will open the edit server modal. The edit server modal will have all the fields of the server its editing already filled out. Allow the user to edit and save the new configuration.
+
+## Create the EditServerModal component
+
+Create a component `EditServerModal` in `src/components/connection/EditServerModal.tsx`. This modal should have the same structure as `AddServerModal`, but it should be able to take in a server config and pre-fill the form. Allow the user to edit the form in the modal.
+
+On submit, delete the original server and connect to an MCP with the new config.
+
+## Create edit server entry point
+
+Create a button right below the "Reconnect" option in the component `ServerConnectionCard.tsx` called "edit". Clicking on the button will open up the `EditServerModal`.
+
+# Additional instructions
+
+Propose how to do this before implementing for approval

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,6 +41,7 @@ export default function Home() {
     handleConnect,
     handleDisconnect,
     handleReconnect,
+    handleUpdate,
     setSelectedServer,
     toggleServerSelection,
     selectedMCPConfigsMap,
@@ -105,6 +106,7 @@ export default function Home() {
               onConnect={handleConnect}
               onDisconnect={handleDisconnect}
               onReconnect={handleReconnect}
+              onUpdate={handleUpdate}
             />
           )}
 

--- a/src/components/ServersTab.tsx
+++ b/src/components/ServersTab.tsx
@@ -7,6 +7,7 @@ import { Plus, Database } from "lucide-react";
 import { ServerWithName } from "@/hooks/use-app-state";
 import { ServerConnectionCard } from "./connection/ServerConnectionCard";
 import { AddServerModal } from "./connection/AddServerModal";
+import { EditServerModal } from "./connection/EditServerModal";
 import { ServerFormData } from "@/lib/types";
 import { MCPIcon } from "./ui/mcp-icon";
 
@@ -15,6 +16,7 @@ interface ServersTabProps {
   onConnect: (formData: ServerFormData) => void;
   onDisconnect: (serverName: string) => void;
   onReconnect: (serverName: string) => void;
+  onUpdate: (originalServerName: string, formData: ServerFormData) => void;
 }
 
 export function ServersTab({
@@ -22,8 +24,11 @@ export function ServersTab({
   onConnect,
   onDisconnect,
   onReconnect,
+  onUpdate,
 }: ServersTabProps) {
   const [isAddingServer, setIsAddingServer] = useState(false);
+  const [isEditingServer, setIsEditingServer] = useState(false);
+  const [serverToEdit, setServerToEdit] = useState<ServerWithName | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [filterType, setFilterType] = useState<"all" | "stdio" | "http">("all");
 
@@ -50,6 +55,16 @@ export function ServersTab({
 
   const connectedCount = Object.keys(connectedServerConfigs).length;
 
+  const handleEditServer = (server: ServerWithName) => {
+    setServerToEdit(server);
+    setIsEditingServer(true);
+  };
+
+  const handleCloseEditModal = () => {
+    setIsEditingServer(false);
+    setServerToEdit(null);
+  };
+
   return (
     <div className="space-y-6 p-8">
       {/* Header Section */}
@@ -74,6 +89,7 @@ export function ServersTab({
               server={server}
               onDisconnect={onDisconnect}
               onReconnect={onReconnect}
+              onEdit={handleEditServer}
             />
           ))}
         </div>
@@ -114,6 +130,16 @@ export function ServersTab({
         onClose={() => setIsAddingServer(false)}
         onConnect={onConnect}
       />
+
+      {/* Edit Server Modal */}
+      {serverToEdit && (
+        <EditServerModal
+          isOpen={isEditingServer}
+          onClose={handleCloseEditModal}
+          onUpdate={onUpdate}
+          server={serverToEdit}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/connection/AddServerModal.tsx
+++ b/src/components/connection/AddServerModal.tsx
@@ -40,7 +40,7 @@ export function AddServerModal({
   const [bearerToken, setBearerToken] = useState("");
   const [authType, setAuthType] = useState<"oauth" | "bearer" | "none">("none");
   const [envVars, setEnvVars] = useState<Array<{ key: string; value: string }>>(
-    [],
+    []
   );
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -60,7 +60,7 @@ export function AddServerModal({
             if (key && value) acc[key] = value;
             return acc;
           },
-          {} as Record<string, string>,
+          {} as Record<string, string>
         );
         finalFormData = { ...finalFormData, env: envObj };
       }
@@ -94,22 +94,12 @@ export function AddServerModal({
 
       onConnect(finalFormData);
       resetForm();
-      setCommandInput("");
-      setOauthScopesInput("");
-      setBearerToken("");
-      setAuthType("none");
-      setEnvVars([]);
       onClose();
     }
   };
 
   const handleClose = () => {
     resetForm();
-    setCommandInput("");
-    setOauthScopesInput("");
-    setBearerToken("");
-    setAuthType("oauth");
-    setEnvVars([]);
     onClose();
   };
 
@@ -125,6 +115,11 @@ export function AddServerModal({
       useOAuth: true,
       oauthScopes: ["mcp:*"],
     });
+    setCommandInput("");
+    setOauthScopesInput("");
+    setBearerToken("");
+    setAuthType("none");
+    setEnvVars([]);
   };
 
   const addEnvVar = () => {
@@ -138,7 +133,7 @@ export function AddServerModal({
   const updateEnvVar = (
     index: number,
     field: "key" | "value",
-    value: string,
+    value: string
   ) => {
     const updated = [...envVars];
     updated[index][field] = value;

--- a/src/components/connection/ServerConnectionCard.tsx
+++ b/src/components/connection/ServerConnectionCard.tsx
@@ -23,6 +23,7 @@ import {
   Check,
   X,
   Wifi,
+  Edit,
 } from "lucide-react";
 import { ServerWithName } from "@/hooks/use-app-state";
 import { formatTimeRemaining, getTimeBreakdown } from "@/lib/utils";
@@ -31,12 +32,14 @@ interface ServerConnectionCardProps {
   server: ServerWithName;
   onDisconnect: (serverName: string) => void;
   onReconnect: (serverName: string) => void;
+  onEdit: (server: ServerWithName) => void;
 }
 
 export function ServerConnectionCard({
   server,
   onDisconnect,
   onReconnect,
+  onEdit,
 }: ServerConnectionCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isReconnecting, setIsReconnecting] = useState(false);
@@ -199,6 +202,13 @@ export function ServerConnectionCard({
                     )}
                     {isReconnecting ? "Reconnecting..." : "Reconnect"}
                   </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => onEdit(server)}
+                    className="text-xs cursor-pointer"
+                  >
+                    <Edit className="h-3 w-3 mr-2" />
+                    Edit
+                  </DropdownMenuItem>
                   <Separator />
                   <DropdownMenuItem
                     className="text-destructive text-xs cursor-pointer"
@@ -286,7 +296,7 @@ export function ServerConnectionCard({
                           onClick={() =>
                             copyToClipboard(
                               manualBearerToken,
-                              "manualBearerToken"
+                              "manualBearerToken",
                             )
                           }
                           className="absolute top-1 right-1 p-1 text-muted-foreground/50 hover:text-foreground transition-colors cursor-pointer"
@@ -319,7 +329,7 @@ export function ServerConnectionCard({
                           onClick={() =>
                             copyToClipboard(
                               server.oauthTokens?.access_token || "",
-                              "accessToken"
+                              "accessToken",
                             )
                           }
                           className="absolute top-1 right-1 p-1 text-muted-foreground/50 hover:text-foreground transition-colors cursor-pointer"
@@ -402,7 +412,7 @@ export function ServerConnectionCard({
                                 <span className="text-blue-600">{key}</span>=
                                 <span className="text-green-600">{value}</span>
                               </div>
-                            )
+                            ),
                           )}
                         </div>
                       </div>

--- a/src/lib/mcp-oauth.ts
+++ b/src/lib/mcp-oauth.ts
@@ -56,7 +56,7 @@ class MCPOAuthProvider implements OAuthClientProvider {
   async saveClientInformation(clientInformation: any) {
     localStorage.setItem(
       `mcp-client-${this.serverName}`,
-      JSON.stringify(clientInformation)
+      JSON.stringify(clientInformation),
     );
   }
 
@@ -68,7 +68,7 @@ class MCPOAuthProvider implements OAuthClientProvider {
   async saveTokens(tokens: any) {
     localStorage.setItem(
       `mcp-tokens-${this.serverName}`,
-      JSON.stringify(tokens)
+      JSON.stringify(tokens),
     );
   }
 
@@ -115,7 +115,7 @@ class MCPOAuthProvider implements OAuthClientProvider {
  * Initiates OAuth flow for an MCP server
  */
 export async function initiateOAuth(
-  options: MCPOAuthOptions
+  options: MCPOAuthOptions,
 ): Promise<OAuthResult> {
   try {
     const provider = new MCPOAuthProvider(options.serverName);
@@ -123,7 +123,7 @@ export async function initiateOAuth(
     // Store server URL for callback recovery
     localStorage.setItem(
       `mcp-serverUrl-${options.serverName}`,
-      options.serverUrl
+      options.serverUrl,
     );
     localStorage.setItem("mcp-oauth-pending", options.serverName);
 
@@ -165,7 +165,7 @@ export async function initiateOAuth(
  * Handles OAuth callback and completes the flow
  */
 export async function handleOAuthCallback(
-  authorizationCode: string
+  authorizationCode: string,
 ): Promise<OAuthResult & { serverName?: string }> {
   try {
     // Get pending server name from localStorage
@@ -228,7 +228,7 @@ export function getStoredTokens(serverName: string): any {
  */
 export async function waitForTokens(
   serverName: string,
-  timeoutMs: number = 5000
+  timeoutMs: number = 5000,
 ): Promise<any> {
   const startTime = Date.now();
 
@@ -247,7 +247,7 @@ export async function waitForTokens(
  * Refreshes OAuth tokens for a server using the refresh token
  */
 export async function refreshOAuthTokens(
-  serverName: string
+  serverName: string,
 ): Promise<OAuthResult> {
   try {
     const provider = new MCPOAuthProvider(serverName);
@@ -312,7 +312,7 @@ export function clearOAuthData(serverName: string): void {
  */
 function createServerConfig(
   serverUrl: string,
-  tokens: any
+  tokens: any,
 ): HttpServerDefinition {
   return {
     url: new URL(serverUrl),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -131,10 +131,10 @@ export type MastraMCPServerDefinition =
   | HttpServerDefinition;
 
 export interface OauthTokens {
-    client_id: string;
-    client_secret: string;
-    access_token: string;
-    refresh_token: string;
-    expires_in: number;
-    scope: string;
-  }
+  client_id: string;
+  client_secret: string;
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  scope: string;
+}


### PR DESCRIPTION
# Objective

Create the ability to edit a server config. Editing a server config will open the edit server modal. The edit server modal will have all the fields of the server its editing already filled out. Allow the user to edit and save the new configuration.

## Create the EditServerModal component

Create a component `EditServerModal` in `src/components/connection/EditServerModal.tsx`. This modal should have the same structure as `AddServerModal`, but it should be able to take in a server config and pre-fill the form. Allow the user to edit the form in the modal.

On submit, delete the original server and connect to an MCP with the new config.

## Create edit server entry point

Create a button right below the "Reconnect" option in the component `ServerConnectionCard.tsx` called "edit". Clicking on the button will open up the `EditServerModal`.

# Additional instructions

Propose how to do this before implementing for approval