### PR TITLE
chore: add contentfulStatusCode type

### DIFF
--- a/server/routes/mcp/chat.ts
+++ b/server/routes/mcp/chat.ts
@@ -9,6 +9,7 @@ import { createOpenAI } from '@ai-sdk/openai'
 import { createOllama } from 'ollama-ai-provider'
 import { ChatMessage, ModelDefinition } from '../../../shared/types'
 import { MCPClient } from '@mastra/mcp'
+import { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const chat = new Hono()
 
@@ -85,7 +86,7 @@ chat.post('/', async (c) => {
           success: false, 
           error: validation.error!.message,
           details: validation.errors 
-        }, validation.error!.status)
+        }, validation.error!.status as ContentfulStatusCode)
       }
 
       client = createMCPClientWithMultipleConnections(validation.validConfigs!)

--- a/server/routes/mcp/connect.ts
+++ b/server/routes/mcp/connect.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { validateServerConfig, createMCPClient } from '../../utils/mcp-utils'
+import { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const connect = new Hono()
 
@@ -15,7 +16,7 @@ connect.post('/', async (c) => {
           success: false,
           error: error.message,
         },
-        error.status,
+        error.status as ContentfulStatusCode,
       )
     }
 

--- a/server/routes/mcp/prompts.ts
+++ b/server/routes/mcp/prompts.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { validateServerConfig, createMCPClient } from '../../utils/mcp-utils'
+import { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const prompts = new Hono()
 
@@ -10,7 +11,7 @@ prompts.post('/list', async (c) => {
 
     const validation = validateServerConfig(serverConfig)
     if (!validation.success) {
-      return c.json({ success: false, error: validation.error!.message }, validation.error!.status)
+      return c.json({ success: false, error: validation.error!.message }, validation.error!.status as ContentfulStatusCode)
     }
 
     const client = createMCPClient(
@@ -45,7 +46,7 @@ prompts.post('/get', async (c) => {
 
     const validation = validateServerConfig(serverConfig)
     if (!validation.success) {
-      return c.json({ success: false, error: validation.error!.message }, validation.error!.status)
+      return c.json({ success: false, error: validation.error!.message }, validation.error!.status as ContentfulStatusCode)
     }
 
     if (!name) {

--- a/server/routes/mcp/resources.ts
+++ b/server/routes/mcp/resources.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { validateServerConfig, createMCPClient } from '../../utils/mcp-utils'
+import { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const resources = new Hono()
 
@@ -10,7 +11,7 @@ resources.post('/list', async (c) => {
 
     const validation = validateServerConfig(serverConfig)
     if (!validation.success) {
-      return c.json({ success: false, error: validation.error!.message }, validation.error!.status)
+      return c.json({ success: false, error: validation.error!.message }, validation.error!.status as ContentfulStatusCode)
     }
 
     const client = createMCPClient(
@@ -45,7 +46,7 @@ resources.post('/read', async (c) => {
 
     const validation = validateServerConfig(serverConfig)
     if (!validation.success) {
-      return c.json({ success: false, error: validation.error!.message }, validation.error!.status)
+      return c.json({ success: false, error: validation.error!.message }, validation.error!.status as ContentfulStatusCode)
     }
 
     if (!uri) {

--- a/server/routes/mcp/tools.ts
+++ b/server/routes/mcp/tools.ts
@@ -3,6 +3,7 @@ import { validateServerConfig, createMCPClient } from '../../utils/mcp-utils'
 import type { Tool } from '@mastra/core/tools'
 import { z } from 'zod'
 import { zodToJsonSchema } from 'zod-to-json-schema'
+import { ContentfulStatusCode } from 'hono/utils/http-status'
 
 const tools = new Hono()
 
@@ -61,7 +62,7 @@ tools.post('/', async (c) => {
 
     const validation = validateServerConfig(serverConfig)
     if (!validation.success) {
-      return c.json({ success: false, error: validation.error!.message }, validation.error!.status)
+      return c.json({ success: false, error: validation.error!.message }, validation.error!.status as ContentfulStatusCode)
     }
 
     encoder = new TextEncoder()


### PR DESCRIPTION

## Description
PR resolves https://github.com/MCPJam/inspector/issues/329 by adding missing error code type for `Hono Backend`

## Changes made:
Give `error.status` type `ContentfulStatusCode` 