### PR TITLE
Add Docker support for simple deployment

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -50,7 +50,7 @@ if (process.env.NODE_ENV === 'production') {
   })
 }
 
-const port = parseInt(process.env.PORT || '8001')
+const port = parseInt(process.env.PORT || '3001')
 
 console.log(`🚀 MCP Inspector Server starting on port ${port}`)
 console.log(`📡 API available at: http://localhost:${port}/api`)
@@ -62,7 +62,7 @@ if (process.env.NODE_ENV !== 'production') {
 const server = serve({
   fetch: app.fetch,
   port,
-  hostname: '127.0.0.1'  // Fix: explicitly bind to localhost
+  hostname: '0.0.0.0'  // Bind to all interfaces for Docker
 })
 
 // Handle graceful shutdown


### PR DESCRIPTION
- Add Docker section to README with simple run commands
- Update GitHub workflow for manual Docker Hub deployment
- Use DOCKERHUB_USERNAME secret name in workflow
- Remove complex docker-compose and dev Dockerfile for simplicity