### PR TITLE
cors 2

### DIFF
--- a/server/routes/mcp/index.ts
+++ b/server/routes/mcp/index.ts
@@ -4,6 +4,7 @@ import tools from './tools'
 import resources from './resources'
 import prompts from './prompts'
 import chat from './chat'
+import oauth from './oauth'
 
 const mcp = new Hono()
 
@@ -30,5 +31,8 @@ mcp.route('/resources', resources)
 
 // Prompts endpoints - REAL IMPLEMENTATION
 mcp.route('/prompts', prompts)
+
+// OAuth proxy endpoints
+mcp.route('/oauth', oauth)
 
 export default mcp

--- a/server/routes/mcp/oauth.ts
+++ b/server/routes/mcp/oauth.ts
@@ -1,0 +1,56 @@
+import { Hono } from 'hono'
+
+const oauth = new Hono()
+
+/**
+ * Proxy OAuth metadata requests to bypass CORS restrictions
+ * GET /api/mcp/oauth/metadata?url=https://mcp.asana.com/.well-known/oauth-authorization-server/sse
+ */
+oauth.get('/metadata', async (c) => {
+  try {
+    const url = c.req.query('url')
+    
+    if (!url) {
+      return c.json({ error: 'Missing url parameter' }, 400)
+    }
+
+    // Validate URL format and ensure it's HTTPS
+    let metadataUrl: URL
+    try {
+      metadataUrl = new URL(url)
+      if (metadataUrl.protocol !== 'https:') {
+        return c.json({ error: 'Only HTTPS URLs are allowed' }, 400)
+      }
+    } catch (error) {
+      return c.json({ error: 'Invalid URL format' }, 400)
+    }
+
+    // Fetch OAuth metadata from the server
+    const response = await fetch(metadataUrl.toString(), {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+        'User-Agent': 'MCP-Inspector/1.0'
+      }
+    })
+
+    if (!response.ok) {
+      return c.json({ 
+        error: `Failed to fetch OAuth metadata: ${response.status} ${response.statusText}` 
+      }, response.status)
+    }
+
+    const metadata = await response.json()
+    
+    // Return the metadata with proper CORS headers
+    return c.json(metadata)
+    
+  } catch (error) {
+    console.error('OAuth metadata proxy error:', error)
+    return c.json({ 
+      error: error instanceof Error ? error.message : 'Unknown error occurred' 
+    }, 500)
+  }
+})
+
+export default oauth


### PR DESCRIPTION
Root Cause Analysis

  The CORS error occurs because the MCP SDK's auth() function in
  /client/src/lib/mcp-oauth.ts:130-133 attempts to fetch OAuth metadata
  directly from
  https://mcp.asana.com/.well-known/oauth-authorization-server/sse from the
   browser.

  Problem: Browser security policies prevent direct cross-origin requests
  to external OAuth metadata endpoints without proper CORS headers. The
  Asana MCP server doesn't include CORS headers allowing requests from your
   localhost origins.

  Current server CORS config (/server/index.ts:14-17):
  app.use('*', cors({
    origin: ['http://localhost:8080', 'http://localhost:3000'],
    credentials: true,
  }))

  This only configures CORS for your own server, not for proxying external
  requests.

  Proposed Fix

  Add a server-side proxy endpoint to handle OAuth metadata discovery,
  bypassing browser CORS restrictions:

  1. Add OAuth proxy route in /server/routes/mcp/index.ts
  2. Create OAuth metadata proxy handler that fetches from external servers
   server-side
  3. Update client OAuth code to use the proxy endpoint instead of direct
  requests

  This approach:
  - ✅ Bypasses browser CORS restrictions (server-to-server requests don't
  have CORS)
  - ✅ Maintains security (your server validates and forwards requests)
  - ✅ Works with existing OAuth flow
  - ✅ Minimal changes to existing code