### PR TITLE
Changed Dropdown from HTTP to HTTP/SSE

### DIFF
--- a/client/src/components/connection/AddServerModal.tsx
+++ b/client/src/components/connection/AddServerModal.tsx
@@ -243,7 +243,7 @@ export function AddServerModal({
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="stdio">STDIO</SelectItem>
-                    <SelectItem value="http">HTTP</SelectItem>
+                    <SelectItem value="http">HTTP/SSE</SelectItem>
                   </SelectContent>
                 </Select>
                 <Input

--- a/client/src/components/connection/EditServerModal.tsx
+++ b/client/src/components/connection/EditServerModal.tsx
@@ -247,7 +247,7 @@ export function EditServerModal({
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="stdio">STDIO</SelectItem>
-                    <SelectItem value="http">HTTP</SelectItem>
+                    <SelectItem value="http">HTTP/SSE</SelectItem>
                   </SelectContent>
                 </Select>
                 <Input


### PR DESCRIPTION
**Description**

This pull request solves issue #359 

**Change Logs** 

This PR updates the text of the Connection Type dropdown from "HTTP" to "HTTP/SSE" in both the Add and Edit MCP Server modals. 