### PR TITLE
Debug hugging face oauth connection failure

### DIFF
--- a/client/src/lib/mcp-oauth.ts
+++ b/client/src/lib/mcp-oauth.ts
@@ -88,7 +88,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       redirect_uris: [this.redirectUri],
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
-      token_endpoint_auth_method: "client_secret_post",
+      token_endpoint_auth_method: "none",
     };
   }
 


### PR DESCRIPTION
Change OAuth `token_endpoint_auth_method` to "none" to support public client PKCE flow for browser-based applications.

Hugging Face's authorization server expects a PKCE public client (no client secret) from browser apps. Using `client_secret_post` from the browser can trigger `invalid_request` errors. This change aligns the client's OAuth flow with the debug provider, which already uses `"none"` and works correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-4dbdf396-cd5c-4d47-97d3-62fd617e02f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4dbdf396-cd5c-4d47-97d3-62fd617e02f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

