### PR TITLE
Fix vite config

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,9 @@
   "private": true,
   "scripts": {
     "dev": "vite --port 3000",
+    "dev:clean": "rm -rf node_modules/.vite && FORCE_OPTIMIZE=true vite --port 3000",
     "build": "vite build --outDir ../dist/client",
+    "build:clean": "rm -rf node_modules/.vite && FORCE_OPTIMIZE=true vite build --outDir ../dist/client",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -9,10 +9,17 @@ export default defineConfig({
     alias: {
       "@/shared": path.resolve(__dirname, "../shared"),
       "@": path.resolve(__dirname, "./src"),
+      // Force React resolution to prevent conflicts with @mcp-ui/client
       react: path.resolve(__dirname, "node_modules/react"),
       "react-dom": path.resolve(__dirname, "node_modules/react-dom"),
     },
     dedupe: ["react", "react-dom"],
+  },
+  optimizeDeps: {
+    // Explicitly include React runtimes to ensure proper resolution
+    include: ["react", "react-dom", "react/jsx-runtime", "react/jsx-dev-runtime"],
+    // Force re-optimization to clear any cached conflicts
+    force: process.env.FORCE_OPTIMIZE === "true",
   },
   server: {
     proxy: {


### PR DESCRIPTION
` @mcp-ui/client` package includes React 18.3.1 while the main project uses React 19.1.0, causing import resolution conflicts. Please use `npm run dev:clean ` to clear vite cache