### PR TITLE
Grouped all the models together by their providers

### DIFF
--- a/client/src/components/chat/message.tsx
+++ b/client/src/components/chat/message.tsx
@@ -196,7 +196,7 @@ const PureMessage = ({
                 <div className="space-y-2">
                   {message.toolCalls.map((toolCall) => {
                     const toolResult = message.toolResults?.find(
-                      (tr) => tr.toolCallId === toolCall.id
+                      (tr) => tr.toolCallId === toolCall.id,
                     );
                     return (
                       <ToolCallDisplay

--- a/client/src/components/chat/model-selector.tsx
+++ b/client/src/components/chat/model-selector.tsx
@@ -21,14 +21,16 @@ interface ModelSelectorProps {
 }
 
 // Helper function to group models by provider
-const groupModelsByProvider = (models: ModelDefinition[]): Map<ModelProvider, ModelDefinition[]> => {
+const groupModelsByProvider = (
+  models: ModelDefinition[],
+): Map<ModelProvider, ModelDefinition[]> => {
   const groupedModels = new Map<ModelProvider, ModelDefinition[]>();
-  
-  models.forEach(model => {
+
+  models.forEach((model) => {
     const existing = groupedModels.get(model.provider) || [];
     groupedModels.set(model.provider, [...existing, model]);
   });
-  
+
   return groupedModels;
 };
 
@@ -57,10 +59,10 @@ export function ModelSelector({
 }: ModelSelectorProps) {
   const [isModelSelectorOpen, setIsModelSelectorOpen] = useState(false);
   const currentModelData = currentModel;
-  
+
   // Group models by provider
   const groupedModels = groupModelsByProvider(availableModels);
-  
+
   // Get sorted provider keys for consistent ordering
   const sortedProviders = Array.from(groupedModels.keys()).sort();
 
@@ -88,20 +90,22 @@ export function ModelSelector({
         {sortedProviders.map((provider) => {
           const models = groupedModels.get(provider) || [];
           const modelCount = models.length;
-          
+
           return (
             <DropdownMenuSub key={provider}>
               <DropdownMenuSubTrigger className="flex items-center gap-3 text-sm cursor-pointer">
                 <ProviderLogo provider={provider} />
                 <div className="flex flex-col flex-1">
-                  <span className="font-medium">{getProviderDisplayName(provider)}</span>
+                  <span className="font-medium">
+                    {getProviderDisplayName(provider)}
+                  </span>
                   <span className="text-xs text-muted-foreground">
-                    {modelCount} model{modelCount !== 1 ? 's' : ''}
+                    {modelCount} model{modelCount !== 1 ? "s" : ""}
                   </span>
                 </div>
               </DropdownMenuSubTrigger>
-              
-              <DropdownMenuSubContent 
+
+              <DropdownMenuSubContent
                 className="min-w-[200px] max-h-[180px] overflow-y-auto"
                 avoidCollisions={true}
                 collisionPadding={8}

--- a/client/src/components/chat/model-selector.tsx
+++ b/client/src/components/chat/model-selector.tsx
@@ -4,9 +4,12 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
-import { Model, ModelDefinition } from "@/shared/types.js";
+import { ModelDefinition, ModelProvider } from "@/shared/types.js";
 import { ProviderLogo } from "./provider-logo";
 
 interface ModelSelectorProps {
@@ -17,6 +20,34 @@ interface ModelSelectorProps {
   isLoading?: boolean;
 }
 
+// Helper function to group models by provider
+const groupModelsByProvider = (models: ModelDefinition[]): Map<ModelProvider, ModelDefinition[]> => {
+  const groupedModels = new Map<ModelProvider, ModelDefinition[]>();
+  
+  models.forEach(model => {
+    const existing = groupedModels.get(model.provider) || [];
+    groupedModels.set(model.provider, [...existing, model]);
+  });
+  
+  return groupedModels;
+};
+
+// Provider display names
+const getProviderDisplayName = (provider: ModelProvider): string => {
+  switch (provider) {
+    case "anthropic":
+      return "Anthropic";
+    case "openai":
+      return "OpenAI";
+    case "deepseek":
+      return "DeepSeek";
+    case "ollama":
+      return "Ollama";
+    default:
+      return provider;
+  }
+};
+
 export function ModelSelector({
   currentModel,
   availableModels,
@@ -26,6 +57,12 @@ export function ModelSelector({
 }: ModelSelectorProps) {
   const [isModelSelectorOpen, setIsModelSelectorOpen] = useState(false);
   const currentModelData = currentModel;
+  
+  // Group models by provider
+  const groupedModels = groupModelsByProvider(availableModels);
+  
+  // Get sorted provider keys for consistent ordering
+  const sortedProviders = Array.from(groupedModels.keys()).sort();
 
   return (
     <DropdownMenu
@@ -48,24 +85,48 @@ export function ModelSelector({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-[200px]">
-        {availableModels.map((model) => (
-          <DropdownMenuItem
-            key={model.id}
-            onClick={() => {
-              onModelChange(model);
-              setIsModelSelectorOpen(false);
-            }}
-            className="flex items-center gap-3 text-sm cursor-pointer"
-          >
-            <ProviderLogo provider={model.provider} />
-            <div className="flex flex-col">
-              <span className="font-medium">{model.name}</span>
-            </div>
-            {model.id === currentModel.id && (
-              <div className="ml-auto w-2 h-2 bg-primary rounded-full" />
-            )}
-          </DropdownMenuItem>
-        ))}
+        {sortedProviders.map((provider) => {
+          const models = groupedModels.get(provider) || [];
+          const modelCount = models.length;
+          
+          return (
+            <DropdownMenuSub key={provider}>
+              <DropdownMenuSubTrigger className="flex items-center gap-3 text-sm cursor-pointer">
+                <ProviderLogo provider={provider} />
+                <div className="flex flex-col flex-1">
+                  <span className="font-medium">{getProviderDisplayName(provider)}</span>
+                  <span className="text-xs text-muted-foreground">
+                    {modelCount} model{modelCount !== 1 ? 's' : ''}
+                  </span>
+                </div>
+              </DropdownMenuSubTrigger>
+              
+              <DropdownMenuSubContent 
+                className="min-w-[200px] max-h-[180px] overflow-y-auto"
+                avoidCollisions={true}
+                collisionPadding={8}
+              >
+                {models.map((model) => (
+                  <DropdownMenuItem
+                    key={model.id}
+                    onClick={() => {
+                      onModelChange(model);
+                      setIsModelSelectorOpen(false);
+                    }}
+                    className="flex items-center gap-3 text-sm cursor-pointer"
+                  >
+                    <div className="flex flex-col flex-1">
+                      <span className="font-medium">{model.name}</span>
+                    </div>
+                    {model.id === currentModel.id && (
+                      <div className="ml-auto w-2 h-2 bg-primary rounded-full" />
+                    )}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuSubContent>
+            </DropdownMenuSub>
+          );
+        })}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/client/src/lib/chat-utils.ts
+++ b/client/src/lib/chat-utils.ts
@@ -46,7 +46,7 @@ export function formatMessageDate(date: Date): string {
 export function createMessage(
   role: "user" | "assistant",
   content: string,
-  attachments?: any[]
+  attachments?: any[],
 ): ChatMessage {
   return {
     id: generateId(),
@@ -93,7 +93,7 @@ export function isImageUrl(url: string): boolean {
 }
 
 export function getImageDimensions(
-  url: string
+  url: string,
 ): Promise<{ width: number; height: number }> {
   return new Promise((resolve, reject) => {
     const img = new Image();
@@ -130,7 +130,7 @@ export function scrollToBottom(element?: Element | null) {
 
 export function debounce<T extends (...args: any[]) => any>(
   func: T,
-  wait: number
+  wait: number,
 ): (...args: Parameters<T>) => void {
   let timeout: NodeJS.Timeout;
   return (...args: Parameters<T>) => {


### PR DESCRIPTION
 Implement nested submenu pattern for model selection with provider grouping

  - Replace flat model list with provider-based navigation
  - Add DropdownMenuSub components for right-side submenu display
  - Group models by provider (Anthropic, OpenAI, DeepSeek, Ollama)
  - Implement hover/click triggers to open provider submenus
  - Add collision detection to prevent submenus from going off-screen
  - Display model counts for each provider in main menu
  - Maintain current model selection indicator across submenus
  
  Previous View : 
  
<img width="1557" height="820" alt="Screenshot 2025-08-21 at 10 17 56 PM" src="https://github.com/user-attachments/assets/bdbdb281-4eb7-4887-a896-f3e3344c6de3" />

Updated View : 

<img width="1702" height="943" alt="Screenshot 2025-08-21 at 10 13 08 PM" src="https://github.com/user-attachments/assets/5d29f726-a2a6-4156-ac6c-c648329de08a" />
