### PR TITLE
Clean up use of global variables in Hono

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -76,7 +76,7 @@ const mcpJamClientManager = new MCPJamClientManager();
 
 // Middleware to inject client manager into context
 app.use("*", async (c, next) => {
-  c.set("mcpJamClientManager", mcpJamClientManager);
+  c.mcpJamClientManager = mcpJamClientManager;
   await next();
 });
 

--- a/server/routes/mcp/connect.ts
+++ b/server/routes/mcp/connect.ts
@@ -1,6 +1,5 @@
 import { Hono } from "hono";
 import "../../types/hono"; // Type extensions
-import MCPJamClientManager from "../../services/mcpjam-client-manager";
 
 const connect = new Hono();
 
@@ -28,9 +27,7 @@ connect.post("/", async (c) => {
       );
     }
 
-    const mcpClientManager = c.get(
-      "mcpJamClientManager",
-    ) as MCPJamClientManager;
+    const mcpClientManager = c.mcpJamClientManager;
 
     try {
       await mcpClientManager.connectToServer(serverId, serverConfig);

--- a/server/routes/mcp/prompts.ts
+++ b/server/routes/mcp/prompts.ts
@@ -1,6 +1,5 @@
 import { Hono } from "hono";
 import "../../types/hono"; // Type extensions
-import MCPJamClientManager from "../../services/mcpjam-client-manager";
 
 const prompts = new Hono();
 
@@ -13,9 +12,7 @@ prompts.post("/list", async (c) => {
       return c.json({ success: false, error: "serverId is required" }, 400);
     }
 
-    const mcpJamClientManager = c.get(
-      "mcpJamClientManager",
-    ) as MCPJamClientManager;
+    const mcpJamClientManager = c.mcpJamClientManager;
 
     // Get prompts for specific server
     const serverPrompts = mcpJamClientManager.getPromptsForServer(serverId);
@@ -52,9 +49,7 @@ prompts.post("/get", async (c) => {
       );
     }
 
-    const mcpJamClientManager = c.get(
-      "mcpJamClientManager",
-    ) as MCPJamClientManager;
+    const mcpJamClientManager = c.mcpJamClientManager;
 
     // Get prompt content directly - servers are already connected
     const content = await mcpJamClientManager.getPrompt(

--- a/server/routes/mcp/resources.ts
+++ b/server/routes/mcp/resources.ts
@@ -1,6 +1,5 @@
 import { Hono } from "hono";
 import "../../types/hono"; // Type extensions
-import MCPJamClientManager from "../../services/mcpjam-client-manager";
 
 const resources = new Hono();
 
@@ -12,9 +11,7 @@ resources.post("/list", async (c) => {
     if (!serverId) {
       return c.json({ success: false, error: "serverId is required" }, 400);
     }
-    const mcpClientManager = c.get(
-      "mcpJamClientManager",
-    ) as MCPJamClientManager;
+    const mcpClientManager = c.mcpJamClientManager;
     const serverResources = mcpClientManager.getResourcesForServer(serverId);
     return c.json({ resources: { [serverId]: serverResources } });
   } catch (error) {
@@ -48,9 +45,7 @@ resources.post("/read", async (c) => {
       );
     }
 
-    const mcpClientManager = c.get(
-      "mcpJamClientManager",
-    ) as MCPJamClientManager;
+    const mcpClientManager = c.mcpJamClientManager;
 
     const content = await mcpClientManager.getResource(uri, serverId);
 

--- a/server/routes/mcp/servers.ts
+++ b/server/routes/mcp/servers.ts
@@ -1,15 +1,12 @@
 import { Hono } from "hono";
 import "../../types/hono"; // Type extensions
-import MCPJamClientManager from "../../services/mcpjam-client-manager";
 
 const servers = new Hono();
 
 // List all connected servers with their status
 servers.get("/", async (c) => {
   try {
-    const mcpJamClientManager = c.get(
-      "mcpJamClientManager",
-    ) as MCPJamClientManager;
+    const mcpJamClientManager = c.mcpJamClientManager;
 
     // Get all server configurations and statuses
     const connectedServers = mcpJamClientManager.getConnectedServers();
@@ -43,9 +40,7 @@ servers.get("/", async (c) => {
 servers.get("/status/:serverId", async (c) => {
   try {
     const serverId = c.req.param("serverId");
-    const mcpJamClientManager = c.get(
-      "mcpJamClientManager",
-    ) as MCPJamClientManager;
+    const mcpJamClientManager = c.mcpJamClientManager;
 
     const status = mcpJamClientManager.getConnectionStatus(serverId);
 
@@ -70,9 +65,7 @@ servers.get("/status/:serverId", async (c) => {
 servers.delete("/:serverId", async (c) => {
   try {
     const serverId = c.req.param("serverId");
-    const mcpJamClientManager = c.get(
-      "mcpJamClientManager",
-    ) as MCPJamClientManager;
+    const mcpJamClientManager = c.mcpJamClientManager;
 
     await mcpJamClientManager.disconnectFromServer(serverId);
 
@@ -107,9 +100,7 @@ servers.post("/reconnect", async (c) => {
       );
     }
 
-    const mcpJamClientManager = c.get(
-      "mcpJamClientManager",
-    ) as MCPJamClientManager;
+    const mcpJamClientManager = c.mcpJamClientManager;
 
     // Disconnect first, then reconnect
     await mcpJamClientManager.disconnectFromServer(serverId);

--- a/server/routes/mcp/tools.ts
+++ b/server/routes/mcp/tools.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import { TextEncoder } from "util";
 import "../../types/hono"; // Type extensions
-import MCPJamClientManager from "../../services/mcpjam-client-manager";
 
 const tools = new Hono();
 
@@ -48,9 +47,7 @@ tools.post("/", async (c) => {
         );
       }
 
-      const mcpJamClientManager = c.get(
-        "mcpJamClientManager",
-      ) as MCPJamClientManager;
+      const mcpJamClientManager = c.mcpJamClientManager;
       const success = mcpJamClientManager.respondToElicitation(
         requestId,
         response,
@@ -93,9 +90,7 @@ tools.post("/", async (c) => {
             return;
           }
 
-          const mcpJamClientManager = c.get(
-            "mcpJamClientManager",
-          ) as MCPJamClientManager;
+          const mcpJamClientManager = c.mcpJamClientManager;
           // Use server name from config or default key
           const serverId =
             (serverConfig as any).name || (serverConfig as any).id || "server";
@@ -233,9 +228,7 @@ tools.post("/", async (c) => {
           controller.close();
         } finally {
           // Clear the elicitation callback
-          const mcpJamClientManager = c.get(
-            "mcpJamClientManager",
-          ) as MCPJamClientManager;
+          const mcpJamClientManager = c.mcpJamClientManager;
           if (mcpJamClientManager) {
             mcpJamClientManager.clearElicitationCallback();
           }

--- a/server/types/hono.ts
+++ b/server/types/hono.ts
@@ -3,12 +3,6 @@ import { MCPJamClientManager } from "../services/mcpjam-client-manager";
 // Extend Hono's context with our custom variables
 declare module "hono" {
   interface Context {
-    get<K extends "mcpJamClientManager">(
-      key: K,
-    ): K extends "mcpJamClientManager" ? MCPJamClientManager : never;
-    set<K extends "mcpJamClientManager">(
-      key: K,
-      value: K extends "mcpJamClientManager" ? MCPJamClientManager : never,
-    ): void;
+    mcpJamClientManager: MCPJamClientManager;
   }
 }


### PR DESCRIPTION
We want to use `c.mcpClientManager`