### PR TITLE
fix(electron): set the renderer vite hmr server proxy the hono

### DIFF
--- a/vite.renderer.config.mts
+++ b/vite.renderer.config.mts
@@ -14,6 +14,9 @@ export default defineConfig({
   },
   server: {
     port: 8080,
+    hmr: {
+      port: 8081,
+    },
     proxy: {
       "/api": {
         target: "http://localhost:3001", // the port need to be the same as the server port

--- a/vite.renderer.config.mts
+++ b/vite.renderer.config.mts
@@ -14,5 +14,11 @@ export default defineConfig({
   },
   server: {
     port: 8080,
+    proxy: {
+      "/api": {
+        target: "http://localhost:3001", // the port need to be the same as the server port
+        changeOrigin: true,
+      },
+    },
   },
 });


### PR DESCRIPTION
1. fix the electron api 404 error
2. but `/api/mcp-cli-config` still 404, because it's not defined in `createHonoApp` (which used in electron main)