### PR TITLE
Convert to url objects

### DIFF
--- a/client/src/hooks/use-app-state.ts
+++ b/client/src/hooks/use-app-state.ts
@@ -79,18 +79,34 @@ export function useAppState() {
         // Ensure all loaded servers have the new fields with defaults
         const updatedServers = Object.fromEntries(
           Object.entries(parsed.servers || {}).map(
-            ([name, server]: [string, any]) => [
-              name,
-              {
-                ...server,
-                connectionStatus: server.connectionStatus || "disconnected",
-                retryCount: server.retryCount || 0,
-                lastConnectionTime: server.lastConnectionTime
-                  ? new Date(server.lastConnectionTime)
-                  : new Date(),
-                enabled: server.enabled !== false,
-              },
-            ],
+            ([name, server]: [string, any]) => {
+              // Fix URL serialization issue: convert string URLs back to URL objects
+              let config = server.config;
+              if (config && typeof config.url === 'string') {
+                try {
+                  config = {
+                    ...config,
+                    url: new URL(config.url),
+                  };
+                } catch (error) {
+                  logger.error(`Failed to parse URL for server ${name}:`, error);
+                }
+              }
+              
+              return [
+                name,
+                {
+                  ...server,
+                  config,
+                  connectionStatus: server.connectionStatus || "disconnected",
+                  retryCount: server.retryCount || 0,
+                  lastConnectionTime: server.lastConnectionTime
+                    ? new Date(server.lastConnectionTime)
+                    : new Date(),
+                  enabled: server.enabled !== false,
+                },
+              ];
+            },
           ),
         );
         setAppState({

--- a/client/src/hooks/use-app-state.ts
+++ b/client/src/hooks/use-app-state.ts
@@ -82,17 +82,20 @@ export function useAppState() {
             ([name, server]: [string, any]) => {
               // Fix URL serialization issue: convert string URLs back to URL objects
               let config = server.config;
-              if (config && typeof config.url === 'string') {
+              if (config && typeof config.url === "string") {
                 try {
                   config = {
                     ...config,
                     url: new URL(config.url),
                   };
                 } catch (error) {
-                  logger.error(`Failed to parse URL for server ${name}:`, error);
+                  logger.error(
+                    `Failed to parse URL for server ${name}:`,
+                    error,
+                  );
                 }
               }
-              
+
               return [
                 name,
                 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpjam/inspector",
-  "version": "0.9.6",
+  "version": "0.9.9",
   "type": "module",
   "description": "MCPJam Inspector",
   "license": "Apache-2.0",
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/mcpjam/inspector/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MCPJam/inspector.git"
+    "url": "git+https://github.com/MCPJam/inspector.git"
   },
   "main": ".vite/build/main.cjs",
   "bin": {
@@ -31,7 +31,6 @@
     "build:client": "cd client && npm run build",
     "build:server": "cd server && npm run build",
     "start": "NODE_ENV=production node bin/start.js",
-    "publish": "node -e \"console.error('Use npm publish directly.'); process.exit(1)\"",
     "prettier-fix": "prettier --write .",
     "install:deps": "cd server && npm install && cd ../client && npm install",
     "docker:build": "docker build -t mcpjam/mcp-inspector:latest .",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpjam/inspector",
-  "version": "0.9.12",
+  "version": "0.9.6",
   "type": "module",
   "description": "MCPJam Inspector",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpjam/inspector",
-  "version": "0.9.9",
+  "version": "0.9.12",
   "type": "module",
   "description": "MCPJam Inspector",
   "license": "Apache-2.0",
@@ -9,7 +9,7 @@
   "bugs": "https://github.com/mcpjam/inspector/issues",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/MCPJam/inspector.git"
+    "url": "https://github.com/MCPJam/inspector.git"
   },
   "main": ".vite/build/main.cjs",
   "bin": {
@@ -17,8 +17,7 @@
   },
   "files": [
     "bin",
-    "dist/client",
-    "dist/server",
+    "dist",
     "package.json",
     "README.md",
     "LICENSE"
@@ -31,6 +30,7 @@
     "build:client": "cd client && npm run build",
     "build:server": "cd server && npm run build",
     "start": "NODE_ENV=production node bin/start.js",
+    "publish": "node -e \"console.error('Use npm publish directly.'); process.exit(1)\"",
     "prettier-fix": "prettier --write .",
     "install:deps": "cd server && npm install && cd ../client && npm install",
     "docker:build": "docker build -t mcpjam/mcp-inspector:latest .",
@@ -53,6 +53,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.12",
     "@ai-sdk/deepseek": "^1.0.5",
+    "@ai-sdk/google": "^1.2.22",
     "@ai-sdk/openai": "^1.3.23",
     "@ai-sdk/provider": "^2.0.0",
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
The fix ensures that loaded configs have their string URLs converted back to URL objects before being used