### PR TITLE
fix: add back client logic for handling mcp.json

### DIFF
--- a/client/src/hooks/use-app-state.ts
+++ b/client/src/hooks/use-app-state.ts
@@ -314,26 +314,99 @@ export function useAppState() {
     [appState.servers, logger],
   );
 
-  // Auto-connect to CLI-provided MCP server on mount
+  // CLI config processing guard
+  const cliConfigProcessedRef = useRef<boolean>(false);
+
+  // Auto-connect to CLI-provided MCP server(s) on mount
   useEffect(() => {
-    if (!isLoading) {
-      const windowCliConfig = (window as any).MCP_CLI_CONFIG;
-      if (windowCliConfig && windowCliConfig.command) {
-        logger.info(
-          "Auto-connecting to CLI-provided MCP server (from window)",
-          { cliConfig: windowCliConfig },
-        );
-        const formData: ServerFormData = {
-          name: windowCliConfig.name || "CLI Server",
-          type: "stdio" as const,
-          command: windowCliConfig.command,
-          args: windowCliConfig.args || [],
-        };
-        handleConnect(formData);
-        return;
-      }
+    if (!isLoading && !cliConfigProcessedRef.current) {
+      cliConfigProcessedRef.current = true;
+      // Fetch CLI config from API (both dev and production)
+      fetch("/api/mcp-cli-config")
+        .then((response) => response.json())
+        .then((data) => {
+          const cliConfig = data.config;
+          if (cliConfig) {
+            // Handle multiple servers from config file
+            if (cliConfig.servers && Array.isArray(cliConfig.servers)) {
+              const autoConnectServer = cliConfig.autoConnectServer;
+
+              logger.info(
+                "Processing CLI-provided MCP servers (from config file)",
+                {
+                  serverCount: cliConfig.servers.length,
+                  autoConnectServer: autoConnectServer || "all",
+                  cliConfig: cliConfig,
+                },
+              );
+
+              // Add all servers to the UI, but only auto-connect to filtered ones
+              cliConfig.servers.forEach((server: any) => {
+                const formData: ServerFormData = {
+                  name: server.name || "CLI Server",
+                  type: "stdio" as const,
+                  command: server.command,
+                  args: server.args || [],
+                  env: server.env || {},
+                };
+
+                // Only add server if it doesn't already exist (CLI config as convenience pre-loader)
+                const mcpConfig = toMCPConfig(formData);
+                dispatch({
+                  type: "UPSERT_SERVER",
+                  name: formData.name,
+                  server: {
+                    name: formData.name,
+                    config: mcpConfig,
+                    lastConnectionTime: new Date(),
+                    connectionStatus: "disconnected" as const,
+                    retryCount: 0,
+                    enabled: false, // Start disabled, will enable on successful connection
+                  },
+                });
+
+                // Only auto-connect if server was newly added and matches filter
+                if (!autoConnectServer || server.name === autoConnectServer) {
+                  logger.info("Auto-connecting to server", {
+                    serverName: server.name,
+                  });
+                  handleConnect(formData);
+                } else if (appState.servers[formData.name]) {
+                  logger.info("Skipping auto-connect for server", {
+                    serverName: server.name,
+                    reason: "server already exists",
+                  });
+                } else {
+                  logger.info("Skipping auto-connect for server", {
+                    serverName: server.name,
+                    reason: "filtered out",
+                  });
+                }
+              });
+              return;
+            }
+            // Handle legacy single server mode
+            if (cliConfig.command) {
+              logger.info(
+                "Auto-connecting to CLI-provided MCP server (from config file)",
+                { cliConfig },
+              );
+              const formData: ServerFormData = {
+                name: cliConfig.name || "CLI Server",
+                type: "stdio" as const,
+                command: cliConfig.command,
+                args: cliConfig.args || [],
+                env: cliConfig.env || {},
+              };
+              handleConnect(formData);
+            }
+          }
+        })
+        .catch((error) => {
+          logger.debug("Could not fetch CLI config from API", { error });
+        });
     }
-  }, [isLoading, handleConnect, logger]);
+  }, [isLoading, handleConnect, logger, appState.servers]);
 
   const getValidAccessToken = useCallback(
     async (serverName: string): Promise<string | null> => {

--- a/client/src/hooks/use-app-state.ts
+++ b/client/src/hooks/use-app-state.ts
@@ -350,7 +350,7 @@ export function useAppState() {
                   env: server.env || {},
                 };
 
-                // Only add server if it doesn't already exist (CLI config as convenience pre-loader)
+                // Always add/update server from CLI config
                 const mcpConfig = toMCPConfig(formData);
                 dispatch({
                   type: "UPSERT_SERVER",
@@ -365,17 +365,12 @@ export function useAppState() {
                   },
                 });
 
-                // Only auto-connect if server was newly added and matches filter
+                // Only auto-connect if matches filter (or no filter)
                 if (!autoConnectServer || server.name === autoConnectServer) {
                   logger.info("Auto-connecting to server", {
                     serverName: server.name,
                   });
                   handleConnect(formData);
-                } else if (appState.servers[formData.name]) {
-                  logger.info("Skipping auto-connect for server", {
-                    serverName: server.name,
-                    reason: "server already exists",
-                  });
                 } else {
                   logger.info("Skipping auto-connect for server", {
                     serverName: server.name,


### PR DESCRIPTION
Looks like #499 reverted some logic in `useAppState` hook in `use-app-state.ts` for handling `mcp.json` cli connection logic from #490.

This pull request updates the logic for auto-connecting to mcp.json  provided MCP servers in the `useAppState` hook. Added code back that fetches the mcp configuration from an API endpoint instead of relying on a global window variable, supports multiple servers, and improves handling for auto-connect scenarios. The main changes are grouped below:

**MCP Configuration Loading and Processing:**

* Replaces the use of the global `window.MCP_CLI_CONFIG` with a fetch call to `/api/mcp-cli-config` to retrieve the mcp configuration, making it compatible with both development and production environments.
* Adds support for processing multiple servers from the mcp config, including logic to add each server to the UI and selectively auto-connect based on a filter (`autoConnectServer`).
* Improves handling for legacy single-server CLI config mode, maintaining backward compatibility.

**Robustness and Logging Enhancements:**

* Introduces a guard (`cliConfigProcessedRef`) to ensure the mcp config is processed only once per mount, preventing duplicate connections.
* Expands logging to provide more detailed information about server processing, connection attempts, and error handling during config fetch.

