### PR TITLE
Update mcpjam.js to also support paths on windows

### DIFF
--- a/evals-cli/bin/mcpjam.js
+++ b/evals-cli/bin/mcpjam.js
@@ -1,12 +1,16 @@
 #!/usr/bin/env node
 
-import { fileURLToPath } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import { dirname, resolve } from "path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const cliPath = resolve(__dirname, "../dist/index.js");
 
-import(cliPath).catch((err) => {
+const fixedCliPath = process.platform === "win32"
+  ? pathToFileURL(cliPath).href
+  : cliPath;
+
+import(fixedCliPath).catch((err) => {
   console.error("Failed to start MCPJam CLI:", err.message);
   process.exit(1);
 });


### PR DESCRIPTION
On Windows using the cli mode
```powershell
mcpjam evals run --tests mcp-tests.json --environment mcp-environment.json --llms mcp-llms.json
```
this throws Error:
Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'