### PR TITLE
Add star history section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,3 +229,13 @@ This project is licensed under the **Apache License 2.0** - see the [LICENSE](LI
 [🌐 Website](https://mcpjam.com) • [📖 Docs](https://modelcontextprotocol.io/) • [🐛 Issues](https://github.com/MCPJam/inspector/issues)
 
 </div>
+
+
+# ⭐ Star History
+<a href="https://star-history.com/#MCPJam/inspector&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=MCPJam/inspector&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=MCPJam/inspector&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=MCPJam/inspector&type=Date" />
+ </picture>
+</a>


### PR DESCRIPTION
Updates the Star History chart in the README to display the repository stats

fix #573


## Screenshots
<img width="1061" height="712" alt="Screenshot 2025-09-27 at 11 42 55 PM" src="https://github.com/user-attachments/assets/4aa6c04f-a4a2-4388-9ce1-dd773e728429" />
