### PR TITLE
Fix mac dmg cicd

### DIFF
--- a/.github/workflows/mac-release.yml
+++ b/.github/workflows/mac-release.yml
@@ -74,7 +74,16 @@ jobs:
       - name: Build and sign application
         run: |
           npm run build
+
+          # Clean up any mounted volumes before making
+          sudo diskutil unmountDisk force /Volumes/"MCPJam Inspector" 2>/dev/null || true
+          hdiutil detach /Volumes/"MCPJam Inspector" -force 2>/dev/null || true
+
           npm run electron:make
+
+          # Clean up any mounted volumes after making
+          sudo diskutil unmountDisk force /Volumes/"MCPJam Inspector" 2>/dev/null || true
+          hdiutil detach /Volumes/"MCPJam Inspector" -force 2>/dev/null || true
         env:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -85,6 +85,17 @@ const config: ForgeConfig = {
     new MakerDMG({
       format: "ULFO",
       name: "MCPJam Inspector",
+      overwrite: true,
+      additionalDMGOptions: {
+        window: {
+          size: {
+            width: 540,
+            height: 380,
+          },
+        },
+        background: undefined,
+        icon: undefined,
+      },
     }),
     new MakerDeb({
       options: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add DMG volume cleanup to macOS release workflow and tweak Electron Forge DMG maker (overwrite + window sizing).
> 
> - **CI/GitHub Actions** (`.github/workflows/mac-release.yml`):
>   - Unmount/detach any mounted `"MCPJam Inspector"` volumes before and after `npm run electron:make` to avoid DMG mount conflicts.
> - **Build Config** (`forge.config.ts`):
>   - Update `MakerDMG`:
>     - `overwrite: true`.
>     - `additionalDMGOptions.window.size` set to `540x380`.
>     - Explicitly unset `background` and `icon`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4979f37848b5428c1b73f34eb875fc65e18c1f5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->