### PR TITLE
Pass env variables to server correctly

### DIFF
--- a/server/utils/load-env.ts
+++ b/server/utils/load-env.ts
@@ -1,0 +1,87 @@
+import dotenv from "dotenv";
+import { existsSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+function dedupe(values: (string | null | undefined)[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    if (!value) continue;
+    if (seen.has(value)) continue;
+    seen.add(value);
+    result.push(value);
+  }
+  return result;
+}
+
+function collectFilenameVariants(mode: string | undefined): string[] {
+  const normalizedMode = mode && mode.trim().length > 0 ? mode.trim() : undefined;
+  const modeSpecific = normalizedMode
+    ? [`.env.${normalizedMode}.local`, `.env.${normalizedMode}`]
+    : [];
+
+  const defaults = [
+    ".env.production.local",
+    ".env.production",
+    ".env.development.local",
+    ".env.development",
+  ];
+
+  const shared = [".env.local", ".env"];
+
+  return dedupe([...modeSpecific, ...defaults, ...shared]);
+}
+
+export function loadEnvFromKnownLocations(importMetaUrl: string): string[] {
+  const filenames = collectFilenameVariants(process.env.NODE_ENV);
+
+  const moduleDir = dirname(fileURLToPath(importMetaUrl));
+  const projectRoot = resolve(moduleDir, "..");
+  const packageRoot = resolve(projectRoot, "..");
+  const electronResources = process.env.ELECTRON_RESOURCES_PATH;
+
+  const explicitEnvFile = process.env.MCP_ENV_FILE
+    ? resolve(process.cwd(), process.env.MCP_ENV_FILE)
+    : null;
+  const explicitEnvDir = process.env.MCP_ENV_DIR
+    ? resolve(process.env.MCP_ENV_DIR)
+    : null;
+
+  const baseDirectories = dedupe([
+    explicitEnvDir,
+    process.cwd(),
+    moduleDir,
+    projectRoot,
+    packageRoot,
+    electronResources || null,
+  ]);
+
+  const explicitFiles = dedupe([
+    explicitEnvFile,
+    ...(explicitEnvFile ? filenames.map((name) => resolve(dirname(explicitEnvFile), name)) : []),
+  ]);
+
+  const resolvedCandidates = dedupe([
+    ...explicitFiles,
+    ...baseDirectories.flatMap((dir) => filenames.map((name) => resolve(dir, name))),
+  ]);
+
+  const loaded: string[] = [];
+  for (const candidate of resolvedCandidates) {
+    try {
+      if (!existsSync(candidate)) continue;
+      const result = dotenv.config({
+        path: candidate,
+        override: true,
+      });
+      if (!result.error) {
+        loaded.push(candidate);
+      }
+    } catch (error) {
+      // Ignore filesystem errors and continue searching other locations.
+    }
+  }
+
+  return loaded;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Load env vars from multiple known locations with detailed startup logs, and add chat endpoint diagnostics while enforcing CONVEX_HTTP_URL for backend sends.
> 
> - **Server startup/env**:
>   - Replace direct `dotenv.config` usage with `loadEnvFromKnownLocations(import.meta.url)` in `server/app.ts` and `server/index.ts`.
>   - Add startup logs for loaded env files and `CONVEX_HTTP_URL` presence/value; fallback to `dotenv.config()` if still missing.
> - **Chat API diagnostics** (`server/routes/mcp/chat.ts`):
>   - Log incoming and parsed request metadata (provider, backend flag, selected env keys) and `CONVEX_HTTP_URL` state/value when sending to backend.
>   - Emit explicit error log and 500 when backend send requested but `CONVEX_HTTP_URL` is undefined.
> - **Utilities**:
>   - Add `server/utils/load-env.ts` to search and load `.env*` files across multiple directories (supports `NODE_ENV`, `MCP_ENV_FILE`, `MCP_ENV_DIR`, Electron resources) with override behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3eb308c70b83e4d4ab7405f9d80e6aefda985d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->