### PR TITLE
Use zod v3 everywhere but ollama

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,10 +29,8 @@ jobs:
           rm -rf client/package-lock.json client/node_modules
           rm -rf server/package-lock.json server/node_modules
 
-          # Install dependencies
-          npm install
-          cd client && npm install
-          cd ../server && npm install
+          # Install dependencies from root (this applies overrides to all packages)
+          npm install --legacy-peer-deps
 
       - name: Check Prettier formatting
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,13 +24,15 @@ jobs:
           # Clean npm cache
           npm cache clean --force
 
-          # Remove lock files and node_modules to fix rollup binary issues
+          # Remove lock files and node_modules to ensure fresh install
           rm -rf package-lock.json node_modules
           rm -rf client/package-lock.json client/node_modules
           rm -rf server/package-lock.json server/node_modules
 
-          # Install dependencies from root (this applies overrides to all packages)
+          # Install all dependencies (root + client + server)
           npm install --legacy-peer-deps
+          cd client && npm install --legacy-peer-deps
+          cd ../server && npm install --legacy-peer-deps
 
       - name: Check Prettier formatting
         run: |
@@ -49,5 +51,9 @@ jobs:
       - name: Build project
         run: |
           echo "🏗️ Building project..."
-          npm run build
+          # Clean build (uses npm ci for production-like fresh install)
+          npm run build:clean
+          # Now build client and server
+          npm run build:client
+          npm run build:server
           echo "✅ Build completed successfully!"

--- a/package-lock.json
+++ b/package-lock.json
@@ -419,36 +419,6 @@
         "@types/json-schema": "^7.0.15"
       }
     },
-    "node_modules/@auth/core": {
-      "version": "0.37.4",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.37.4.tgz",
-      "integrity": "sha512-HOXJwXWXQRhbBDHlMU0K/6FT1v+wjtzdKhsNg0ZN7/gne6XPsIrjZ4daMcFnbq0Z/vsAbYBinQhhua0d77v7qw==",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "@panva/hkdf": "^1.2.1",
-        "jose": "^5.9.6",
-        "oauth4webapi": "^3.1.1",
-        "preact": "10.24.3",
-        "preact-render-to-string": "6.5.11"
-      },
-      "peerDependencies": {
-        "@simplewebauthn/browser": "^9.0.1",
-        "@simplewebauthn/server": "^9.0.2",
-        "nodemailer": "^6.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@simplewebauthn/browser": {
-          "optional": true
-        },
-        "@simplewebauthn/server": {
-          "optional": true
-        },
-        "nodemailer": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
@@ -1330,39 +1300,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/@electron/fuses": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
-      "integrity": "sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "chalk": "^4.1.1",
-        "fs-extra": "^9.0.1",
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "electron-fuses": "dist/bin.js"
-      }
-    },
-    "node_modules/@electron/fuses/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@electron/get": {
@@ -2913,9 +2850,9 @@
       }
     },
     "node_modules/@inquirer/core/node_modules/@types/node": {
-      "version": "22.18.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.6.tgz",
-      "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
+      "version": "22.18.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.7.tgz",
+      "integrity": "sha512-3E97nlWEVp2V6J7aMkR8eOnw/w0pArPwf/5/W0865f+xzBoGL/ZuHkTAKAGN7cOWNwd+sG+hZOqj+fjzeHS75g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6191,16 +6128,6 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
-    "node_modules/@panva/hkdf": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
-      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -9140,9 +9067,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
-      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
+      "version": "20.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.18.tgz",
+      "integrity": "sha512-KeYVbfnbsBCyKG8e3gmUqAfyZNcoj/qpEbHRkQkfZdKOBrU7QQ+BsTdfqLSWX9/m1ytYreMhpKvp+EZi3UFYAg==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -9193,6 +9120,7 @@
       "version": "19.1.15",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.15.tgz",
       "integrity": "sha512-+kLxJpaJzXybyDyFXYADyP1cznTO8HSuBpenGlnKOAkH4hyNINiywvXS/tGJhsrGGP/gM185RA3xpjY0Yg4erA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -9202,7 +9130,7 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -10834,6 +10762,7 @@
       "version": "1.27.3",
       "resolved": "https://registry.npmjs.org/convex/-/convex-1.27.3.tgz",
       "integrity": "sha512-Ebr9lPgXkL7JO5IFr3bG+gYvHskyJjc96Fx0BBNkJUDXrR/bd9/uI4q8QszbglK75XfDu068vR0d/HK2T7tB9Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.25.4",
@@ -11327,7 +11256,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.1.tgz",
       "integrity": "sha512-ecqj/sy1jcK1uWrwpR67UhYrIFQ+5WlGxth34WquCbamhFA6hkkwiu37o6J5xCHdo1oixJRfVRw+ywV+Hq/0Aw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -12004,9 +11933,9 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "22.18.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.6.tgz",
-      "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
+      "version": "22.18.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.7.tgz",
+      "integrity": "sha512-3E97nlWEVp2V6J7aMkR8eOnw/w0pArPwf/5/W0865f+xzBoGL/ZuHkTAKAGN7cOWNwd+sG+hZOqj+fjzeHS75g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12123,6 +12052,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13019,6 +12949,23 @@
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/fflate": {
@@ -14769,7 +14716,7 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
       "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -14801,6 +14748,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14821,6 +14769,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14841,6 +14790,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14861,6 +14811,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14881,6 +14832,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14901,6 +14853,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14921,6 +14874,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14941,6 +14895,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14961,6 +14916,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -14981,6 +14937,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16991,13 +16948,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/openapi-types": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
-      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -17806,23 +17756,13 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.24.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
-      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "version": "10.27.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
+      "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
-      }
-    },
-    "node_modules/preact-render-to-string": {
-      "version": "6.5.11",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
-      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
-      "license": "MIT",
-      "peer": true,
-      "peerDependencies": {
-        "preact": ">=10"
       }
     },
     "node_modules/prelude-ls": {
@@ -17839,6 +17779,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -20407,23 +20348,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
@@ -20777,7 +20701,7 @@
       "version": "4.20.6",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.25.0",
@@ -20797,6 +20721,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -20882,7 +20807,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -21392,23 +21317,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vite/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
       }
     },
     "node_modules/vite/node_modules/fsevents": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@ai-sdk/google": "^2.0.11",
         "@ai-sdk/openai": "^2.0.32",
         "@ai-sdk/provider": "^2.0.0",
-        "@alcyone-labs/zod-to-json-schema": "^4.0.10",
         "@convex-dev/auth": "^0.0.88",
         "@convex-dev/workos": "^0.0.1",
         "@dnd-kit/core": "^6.3.1",
@@ -65,7 +64,8 @@
         "tailwind-merge": "^3.3.1",
         "update-electron-app": "^3.1.1",
         "vaul": "^1.1.2",
-        "zod": "^4.0.16",
+        "zod": "^3.25.76",
+        "zod-to-json-schema": "^3.24.6",
         "zustand": "^5.0.6"
       },
       "bin": {
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.20.tgz",
-      "integrity": "sha512-5uNRnagf1mFx/hTPjLxNoR4yahnyTYkHXX/IpfL3qdtdUrQMrEwkwVgNssh1pfgEkIOs51sG/6j+ptQ8SE2Gvg==",
+      "version": "2.0.22",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-2.0.22.tgz",
+      "integrity": "sha512-Lbg3Q9ZnzKVjPNjRAbdA7luGoCBp4e85EPlqSU0ePXqV2OrTnHVZgdhOKQuVelUCuptCcoMHjvzxvuKb9GOk6Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
@@ -186,9 +186,9 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "2.0.39",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.39.tgz",
-      "integrity": "sha512-137yPzoP58kAouF3ss/9EkTBs9iZrNCZ2IPZdSMAf0h/r5nk8dSqpAjmK7iBlZAmSmRWnc20QfSdZ/TaE4hpCw==",
+      "version": "2.0.40",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.40.tgz",
+      "integrity": "sha512-VFPS6zuDkMTXuZCR7QvYdcrilk1xTa+vfQedK2IBOLDU52GgdC7ywPqR5NScb7vHuxCwm/CKfk6X4WZ08kCr9Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
@@ -277,14 +277,116 @@
         "node": ">=18"
       }
     },
-    "node_modules/@alcyone-labs/zod-to-json-schema": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@alcyone-labs/zod-to-json-schema/-/zod-to-json-schema-4.0.10.tgz",
-      "integrity": "sha512-TFsSpAPToqmqmT85SGHXuxoCwEeK9zUDvn512O9aBVvWRhSuy+VvAXZkifzsdllD3ncF0ZjUrf4MpBwIEixdWQ==",
-      "license": "ISC",
+    "node_modules/@ai-sdk/react": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
+      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
       "peerDependencies": {
-        "zod": "^4.0.5"
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/@ai-sdk/react/node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/react/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/react/node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@ai-sdk/ui-utils": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
+      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils/node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils/node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -1333,7 +1435,7 @@
     "node_modules/@electron/node-gyp": {
       "version": "10.2.0-electron.1",
       "resolved": "git+ssh://git@github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
-      "integrity": "sha512-CrYo6TntjpoMO1SHjl5Pa/JoUsECNqNdB7Kx49WLQpWzPw53eEITJ2Hs9fh/ryUYDn4pxZz11StaBYBrLFJdqg==",
+      "integrity": "sha512-lBSgDMQqt7QWMuIjS8zNAq5FI5o5RVBAcJUGWGI6GgoQITJt3msAkUrHp8YHj3RTVE+h70ndqMGqURjp3IfRyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3291,39 +3393,6 @@
         "zod": "^3.23.8"
       }
     },
-    "node_modules/@mastra/core/node_modules/@ai-sdk/ui-utils": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
-      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "1.1.3",
-        "@ai-sdk/provider-utils": "2.2.8",
-        "zod-to-json-schema": "^3.24.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.23.8"
-      }
-    },
-    "node_modules/@mastra/core/node_modules/@mastra/schema-compat": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/@mastra/schema-compat/-/schema-compat-0.11.4.tgz",
-      "integrity": "sha512-oh3+enP3oYftZlmJAKQQj5VXR86KgTMwfMnwALZyLk04dPSWfVD2wGytoDg5Qbi3rX9qHj6g0rMNa0CUjR6aTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0",
-        "zod-from-json-schema": "^0.5.0",
-        "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5",
-        "zod-to-json-schema": "^3.24.6"
-      },
-      "peerDependencies": {
-        "ai": "^4.0.0 || ^5.0.0",
-        "zod": "^3.25.0 || ^4.0.0"
-      }
-    },
     "node_modules/@mastra/core/node_modules/ai": {
       "version": "4.3.19",
       "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
@@ -3350,110 +3419,11 @@
         }
       }
     },
-    "node_modules/@mastra/core/node_modules/ai/node_modules/@ai-sdk/react": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
-      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider-utils": "2.2.8",
-        "@ai-sdk/ui-utils": "1.2.11",
-        "swr": "^2.2.5",
-        "throttleit": "2.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mastra/core/node_modules/hono-openapi": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/hono-openapi/-/hono-openapi-0.4.8.tgz",
-      "integrity": "sha512-LYr5xdtD49M7hEAduV1PftOMzuT8ZNvkyWfh1DThkLsIr4RkvDb12UxgIiFbwrJB6FLtFXLoOZL9x4IeDk2+VA==",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-walker": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@hono/arktype-validator": "^2.0.0",
-        "@hono/effect-validator": "^1.2.0",
-        "@hono/typebox-validator": "^0.2.0 || ^0.3.0",
-        "@hono/valibot-validator": "^0.5.1",
-        "@hono/zod-validator": "^0.4.1",
-        "@sinclair/typebox": "^0.34.9",
-        "@valibot/to-json-schema": "^1.0.0-beta.3",
-        "arktype": "^2.0.0",
-        "effect": "^3.11.3",
-        "hono": "^4.6.13",
-        "openapi-types": "^12.1.3",
-        "valibot": "^1.0.0-beta.9",
-        "zod": "^3.23.8",
-        "zod-openapi": "^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@hono/arktype-validator": {
-          "optional": true
-        },
-        "@hono/effect-validator": {
-          "optional": true
-        },
-        "@hono/typebox-validator": {
-          "optional": true
-        },
-        "@hono/valibot-validator": {
-          "optional": true
-        },
-        "@hono/zod-validator": {
-          "optional": true
-        },
-        "@sinclair/typebox": {
-          "optional": true
-        },
-        "@valibot/to-json-schema": {
-          "optional": true
-        },
-        "arktype": {
-          "optional": true
-        },
-        "effect": {
-          "optional": true
-        },
-        "hono": {
-          "optional": true
-        },
-        "valibot": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        },
-        "zod-openapi": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@mastra/core/node_modules/secure-json-parse": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/@mastra/core/node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.24.1"
-      }
     },
     "node_modules/@mastra/mcp": {
       "version": "0.13.1",
@@ -3483,6 +3453,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/@mastra/schema-compat": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@mastra/schema-compat/-/schema-compat-0.11.4.tgz",
+      "integrity": "sha512-oh3+enP3oYftZlmJAKQQj5VXR86KgTMwfMnwALZyLk04dPSWfVD2wGytoDg5Qbi3rX9qHj6g0rMNa0CUjR6aTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0",
+        "zod-from-json-schema": "^0.5.0",
+        "zod-from-json-schema-v3": "npm:zod-from-json-schema@^0.0.5",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "peerDependencies": {
+        "ai": "^4.0.0 || ^5.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -3718,24 +3704,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.24.1"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -5824,23 +5792,22 @@
       }
     },
     "node_modules/@opentelemetry/redis-common": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.0.tgz",
-      "integrity": "sha512-4Wc0AWURII2cfXVVoZ6vDqK+s5n4K5IssdrlVrvGsx6OEOKdghKtJZqXAHWFiZv4nTDLH2/2fldjIHY8clMOjQ==",
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.1.tgz",
+      "integrity": "sha512-qBiEvH7UUZmHFlhEgv5dVKy6wYpjvnplfD+HkQbQXGnBdQj1f+qdKkBZUEbIy4Q1iDN6ii3sm4RiyHjyXc4sww==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       }
     },
     "node_modules/@opentelemetry/resource-detector-alibaba-cloud": {
-      "version": "0.31.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.31.5.tgz",
-      "integrity": "sha512-SVweVr/WWWQZVuBII7WlqIW2exT5bYZdLwuGEh3EAi5Y5mulY4KUzvW8Rx+NoFWd8wgEscCltxuztFhhnlQDWQ==",
+      "version": "0.31.7",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-alibaba-cloud/-/resource-detector-alibaba-cloud-0.31.7.tgz",
+      "integrity": "sha512-y1k+A2TijUogPrlaiQ0gmMDfEXGOOb7TUBAh0xP06/vyKEDuIq5UIhN8CfawKJlXLeijtjxJdqSOYCBbX7L4+A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/resources": "^2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/resources": "^2.0.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -5850,9 +5817,9 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-2.5.0.tgz",
-      "integrity": "sha512-NI7by8oi4G03yQA/igYZLZhbKkEy9tn/9JOQsHCPaRTDjzW+VHNcP5BLJH0FEM0NJZm7Ue/59J1a1aTSNJSDuA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-2.5.2.tgz",
+      "integrity": "sha512-IoxR3saObqGxontUJ2z5wqDvm9r9NrLn5U/mcZ66IuRi8GSa2gKDHkePA+3FyLDEfOoDk03dajsMOCdv1S1paw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
@@ -5884,14 +5851,13 @@
       }
     },
     "node_modules/@opentelemetry/resource-detector-container": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.7.5.tgz",
-      "integrity": "sha512-oa2+suq7q2epLC1R+pp3rmel7sS6kc4lPe67lxNNVSJ2Bw23ZJatCeG4Fjb2enueDE70VhqPpslVef5hnw1mBA==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-container/-/resource-detector-container-0.7.7.tgz",
+      "integrity": "sha512-A/zv2TN5MbsVIZQVGnZE1iqVwF1PadqrN3qZsG+YAaxVBvr+antvQDJM8k/FFuYuHLq/YiSuXv/MBKKoVrw95w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/resources": "^2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
+        "@opentelemetry/resources": "^2.0.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -6171,9 +6137,9 @@
       }
     },
     "node_modules/@opentelemetry/sql-common": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.0.tgz",
-      "integrity": "sha512-pmzXctVbEERbqSfiAgdes9Y63xjoOyXcD7B6IXBkVb+vbM7M9U98mn33nGXxPf4dfYR0M+vhcKRZmbSJ7HfqFA==",
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.1.tgz",
+      "integrity": "sha512-dpEVRCemNOb7Q9NYpTdQrfZWZ0S1Qv+J7sqdXwho4tzsrwaensXAHOLukMdX8JDUb7pihlIbwItMKoghSwdmUA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0"
@@ -10646,10 +10612,9 @@
       }
     },
     "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true,
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -11248,6 +11213,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults/node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/defer-to-connect": {
@@ -13901,6 +13876,72 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/hono-openapi": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/hono-openapi/-/hono-openapi-0.4.8.tgz",
+      "integrity": "sha512-LYr5xdtD49M7hEAduV1PftOMzuT8ZNvkyWfh1DThkLsIr4RkvDb12UxgIiFbwrJB6FLtFXLoOZL9x4IeDk2+VA==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-walker": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@hono/arktype-validator": "^2.0.0",
+        "@hono/effect-validator": "^1.2.0",
+        "@hono/typebox-validator": "^0.2.0 || ^0.3.0",
+        "@hono/valibot-validator": "^0.5.1",
+        "@hono/zod-validator": "^0.4.1",
+        "@sinclair/typebox": "^0.34.9",
+        "@valibot/to-json-schema": "^1.0.0-beta.3",
+        "arktype": "^2.0.0",
+        "effect": "^3.11.3",
+        "hono": "^4.6.13",
+        "openapi-types": "^12.1.3",
+        "valibot": "^1.0.0-beta.9",
+        "zod": "^3.23.8",
+        "zod-openapi": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@hono/arktype-validator": {
+          "optional": true
+        },
+        "@hono/effect-validator": {
+          "optional": true
+        },
+        "@hono/typebox-validator": {
+          "optional": true
+        },
+        "@hono/valibot-validator": {
+          "optional": true
+        },
+        "@hono/zod-validator": {
+          "optional": true
+        },
+        "@sinclair/typebox": {
+          "optional": true
+        },
+        "@valibot/to-json-schema": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        },
+        "valibot": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        },
+        "zod-openapi": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -14612,15 +14653,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/philsturgeon"
-      }
-    },
-    "node_modules/json-schema-walker/node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -16899,9 +16931,9 @@
       }
     },
     "node_modules/ollama-ai-provider-v2": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ollama-ai-provider-v2/-/ollama-ai-provider-v2-1.3.1.tgz",
-      "integrity": "sha512-UfDX40h2uz/mHjvjFapQIrPzb7h+QQuq0j8OxYLWXMz6Z5CCydmI5l4oLQtZm/lZijisF3zaG1EkIPNzOVDMcw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/ollama-ai-provider-v2/-/ollama-ai-provider-v2-1.4.1.tgz",
+      "integrity": "sha512-coo3+IvnL6O4Ku0TekUiQCEYYvLRbfLfPBcx0e30fxrfKTArEff0oinTKGZ0RRGFxvqd0LgFa6f3kxppA71f3A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "^2.0.0",
@@ -21811,9 +21843,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
-      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -21838,13 +21870,13 @@
         "zod": "^3.24.2"
       }
     },
-    "node_modules/zod-from-json-schema-v3/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "dev:convex": "convex dev",
     "dev:server": "cd server && npm run dev",
     "dev:client": "cd client && npm run dev",
-    "build": "rm -rf dist node_modules/.vite && npm ci && npm run build:client && npm run build:server",
+    "build": "npm run build:clean && npm run build:client && npm run build:server",
+    "build:clean": "rm -rf dist && npm ci",
     "build:client": "cd client && npm run build",
     "build:server": "cd server && npm run build",
     "start": "NODE_ENV=production node bin/start.js",
@@ -113,7 +114,7 @@
     "update-electron-app": "^3.1.1",
     "vaul": "^1.1.2",
     "zod": "^3.25.76",
-    "zod-to-json-schema": "^3.23.3",
+    "zod-to-json-schema": "^3.24.6",
     "zustand": "^5.0.6"
   },
   "devDependencies": {
@@ -151,7 +152,6 @@
   "overrides": {
     "tmp": "0.2.5",
     "jsondiffpatch": "0.7.2",
-    "zod": "^3.25.76",
-    "ollama-ai-provider-v2>zod": "^4.0.16"
+    "zod": "^3.25.76"
   }
 }

--- a/package.json
+++ b/package.json
@@ -112,8 +112,8 @@
     "tailwind-merge": "^3.3.1",
     "update-electron-app": "^3.1.1",
     "vaul": "^1.1.2",
-    "zod": "^4.0.16",
-    "@alcyone-labs/zod-to-json-schema": "^4.0.10",
+    "zod": "^3.25.76",
+    "zod-to-json-schema": "^3.23.3",
     "zustand": "^5.0.6"
   },
   "devDependencies": {
@@ -150,6 +150,8 @@
   },
   "overrides": {
     "tmp": "0.2.5",
-    "jsondiffpatch": "0.7.2"
+    "jsondiffpatch": "0.7.2",
+    "zod": "^3.25.76",
+    "ollama-ai-provider-v2>zod": "^4.0.16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dev:convex": "convex dev",
     "dev:server": "cd server && npm run dev",
     "dev:client": "cd client && npm run dev",
-    "build": "npm run build:client && npm run build:server",
+    "build": "rm -rf dist node_modules/.vite && npm ci && npm run build:client && npm run build:server",
     "build:client": "cd client && npm run build",
     "build:server": "cd server && npm run build",
     "start": "NODE_ENV=production node bin/start.js",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dev:server": "cd server && npm run dev",
     "dev:client": "cd client && npm run dev",
     "build": "npm run build:clean && npm run build:client && npm run build:server",
-    "build:clean": "rm -rf dist && npm ci",
+    "build:clean": "rm -rf dist && npm ci --legacy-peer-deps",
     "build:client": "cd client && npm run build",
     "build:server": "cd server && npm run build",
     "start": "NODE_ENV=production node bin/start.js",

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
     "@ai-sdk/deepseek": "^1.0.5",
     "@ai-sdk/google": "^2.0.11",
     "@ai-sdk/openai": "^2.0.32",
-    "@alcyone-labs/zod-to-json-schema": "^4.0.10",
+    "zod-to-json-schema": "^3.23.3",
     "@hono/node-server": "^1.13.7",
     "@mastra/core": "0.18.0",
     "@mastra/mcp": "0.13.1",
@@ -22,7 +22,7 @@
     "dotenv": "^16.4.5",
     "hono": "^4.6.11",
     "ollama-ai-provider-v2": "^1.3.1",
-    "zod": "^4.0.16"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/server/routes/mcp/chat.ts
+++ b/server/routes/mcp/chat.ts
@@ -14,7 +14,7 @@ import {
   hasUnresolvedToolCalls,
   executeToolCallsFromMessages,
 } from "../../../shared/http-tool-calls";
-import { zodToJsonSchema } from "@alcyone-labs/zod-to-json-schema";
+import { zodToJsonSchema } from "zod-to-json-schema";
 import type { ModelMessage, Tool } from "ai";
 
 // Types

--- a/server/routes/mcp/export.ts
+++ b/server/routes/mcp/export.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { zodToJsonSchema } from "@alcyone-labs/zod-to-json-schema";
+import { zodToJsonSchema } from "zod-to-json-schema";
 import "../../types/hono"; // Type extensions
 
 const exporter = new Hono();

--- a/server/routes/mcp/tools.ts
+++ b/server/routes/mcp/tools.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { z } from "zod";
-import { zodToJsonSchema } from "@alcyone-labs/zod-to-json-schema";
+import { zodToJsonSchema } from "zod-to-json-schema";
 import "../../types/hono"; // Type extensions
 
 const tools = new Hono();

--- a/server/services/mcp-http-bridge.ts
+++ b/server/services/mcp-http-bridge.ts
@@ -1,6 +1,6 @@
 import { MCPJamClientManager } from "./mcpjam-client-manager";
 import { z } from "zod";
-import { zodToJsonSchema } from "@alcyone-labs/zod-to-json-schema";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 // Unify JSON-RPC handling used by adapter-http and manager-http routes
 // while preserving their minor response-shape differences.

--- a/server/tsup.config.ts
+++ b/server/tsup.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     "@ai-sdk/deepseek",
     "ollama-ai-provider",
     "zod",
-    "@alcyone-labs/zod-to-json-schema",
+    "zod-to-json-schema",
     "clsx",
     "tailwind-merge",
     // Keep environment PATH fixers external (these may use CJS internals and dynamic requires)

--- a/shared/tools.ts
+++ b/shared/tools.ts
@@ -1,5 +1,5 @@
 import { z, ZodTypeAny } from "zod";
-import { zodToJsonSchema } from "@alcyone-labs/zod-to-json-schema";
+import { zodToJsonSchema } from "zod-to-json-schema";
 import { tool, type Tool as VercelTool, type ToolCallOptions } from "ai";
 
 type MastraToolExecuteArgs = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Migrates to zod v3 and replaces @alcyone-labs/zod-to-json-schema with zod-to-json-schema, updating imports, build scripts, and CI install/build steps.
> 
> - **Dependencies**:
>   - Standardize on `zod@^3.25.76` and add `zod-to-json-schema@^3.24.6`; remove `@alcyone-labs/zod-to-json-schema`.
>   - Add `overrides` for `zod`; adjust lockfile accordingly.
> - **Code Updates**:
>   - Replace imports of `@alcyone-labs/zod-to-json-schema` with `zod-to-json-schema` in `server/routes/mcp/chat.ts`, `server/routes/mcp/export.ts`, `server/routes/mcp/tools.ts`, `server/services/mcp-http-bridge.ts`, and `shared/tools.ts`.
>   - Update `server/tsup.config.ts` externals to `zod-to-json-schema`.
> - **Build/CI**:
>   - `package.json` scripts: add `build:clean` and update `build` to run clean + client/server builds.
>   - CI (`.github/workflows/lint.yml`): use fresh installs with `--legacy-peer-deps`; split build into clean/client/server steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d019efb69302bfcb9168dd9906ac46f583c4ec9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->