### PR TITLE
client: update URL handling in createServerConfig

### DIFF
--- a/client/src/lib/mcp-oauth.ts
+++ b/client/src/lib/mcp-oauth.ts
@@ -538,13 +538,11 @@ function createServerConfig(
   serverUrl: string,
   tokens: any,
 ): HttpServerDefinition {
-  // Normalize the URL to avoid leaking query/hash (e.g., ?login) into MCP base URL
-  const normalizedUrl = new URL(serverUrl);
-  normalizedUrl.search = "";
-  normalizedUrl.hash = "";
+  // Preserve full URL including query and hash to support servers configured with query params
+  const fullUrl = new URL(serverUrl);
 
   return {
-    url: normalizedUrl,
+    url: fullUrl,
     requestInit: {
       headers: tokens.access_token
         ? {


### PR DESCRIPTION
closes #473 

This pull request updates the logic for constructing the server URL in the `createServerConfig` function. Instead of stripping query parameters and hash fragments, the full URL—including any query and hash—is now preserved. This change allows support for servers that require configuration via query parameters.

- Server URL handling:
  * [`client/src/lib/mcp-oauth.ts`](diffhunk://#diff-21751ff7ecd473557f57b8b07921c8708f65cee0c4563cba44f2d3f8d8046f98L541-R545): Modified `createServerConfig` to preserve the full URL (including query and hash) instead of normalizing it and removing these components. This enables support for servers configured with query parameters.