### PR TITLE
fix: Auto select port when port 3000 (default) is not available 

### DIFF
--- a/bin/start.js
+++ b/bin/start.js
@@ -15,7 +15,7 @@ const MCP_BANNER = `
 ██╔████╔██║██║     ██████╔╝    ██║███████║██╔████╔██║
 ██║╚██╔╝██║██║     ██╔═══╝██   ██║██╔══██║██║╚██╔╝██║
 ██║ ╚═╝ ██║╚██████╗██║    ╚█████╔╝██║  ██║██║ ╚═╝ ██║
-╚═╝     ╚═╝ ╚═════╝╚═╝     ╚════╝ ╚═╝  ╚═╝╚═╝     ╚═╝                                                    
+╚═╝     ╚═╝ ╚═════╝╚═╝     ╚════╝ ╚═╝  ╚═╝╚═╝     ╚═╝
 `;
 
 // ANSI color codes
@@ -527,16 +527,17 @@ async function main() {
         throw new Error(`Port ${requestedPort} is already in use`);
       }
     } else {
-      // Fixed port policy: use default port 3000 and fail fast if unavailable
-      logInfo("No specific port requested, using fixed default port 3000");
+      // Auto port selection: try default port 3000, then find next available port
+      logInfo("No specific port requested, trying default port 3000");
       if (await isPortAvailable(requestedPort)) {
         PORT = requestedPort.toString();
         logSuccess(`Default port ${requestedPort} is available`);
       } else {
-        logError(
-          `Default port ${requestedPort} is already in use. Please free the port`,
-        );
-        throw new Error(`Port ${requestedPort} is already in use`);
+        logWarning(`Default port ${requestedPort} is already in use`);
+        logInfo("Searching for next available port...");
+        const availablePort = await findAvailablePort(requestedPort);
+        PORT = availablePort.toString();
+        logSuccess(`Found available port: ${availablePort}`);
       }
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -61,7 +61,7 @@ async function findAvailablePort(startPort = 3000): Promise<number> {
 
 async function startHonoServer(): Promise<number> {
   try {
-    const port = app.isPackaged ? 3000 : await findAvailablePort(3000);
+    const port = await findAvailablePort(3000);
 
     // Set environment variables to tell the server it's running in Electron
     process.env.ELECTRON_APP = "true";


### PR DESCRIPTION
* I was running something on port 3000 and opened inspector (packaged electron app) and it crashed
* This PR attempts to fix the issue