### PR TITLE
Accept other mcpconfig types

### DIFF
--- a/evals-cli/src/evals/index.ts
+++ b/evals-cli/src/evals/index.ts
@@ -6,6 +6,10 @@ import { Logger } from "../utils/logger.js";
 import { runEvals } from "./runner.js";
 import { hogClient } from "../utils/hog.js";
 import { getUserId } from "../utils/user-id.js";
+import {
+  parseAndTransformConfig,
+  detectConfigFormat,
+} from "../utils/config-transformer.js";
 
 // node dist/index.js evals run -t examples/test-servers.json -e examples/mcp-environment.json
 
@@ -123,7 +127,8 @@ evalsCommand
 
       // Read and parse environment file with env var substitution
       const envContent = await readFile(resolve(options.environment), "utf8");
-      const envData = substituteEnvVarsInObject(JSON.parse(envContent));
+      const transformedConfig = parseAndTransformConfig(envContent);
+      const envData = substituteEnvVarsInObject(transformedConfig);
 
       // Read and parse LLMs file OR auto-detect from environment
       let llmsData: Record<string, string>;

--- a/evals-cli/src/utils/config-transformer.ts
+++ b/evals-cli/src/utils/config-transformer.ts
@@ -1,0 +1,120 @@
+interface MCPServerConfig {
+  type?: "http" | "sse" | "stdio";
+  url?: string;
+  headers?: Record<string, string>;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+interface MCPServersConfig {
+  mcpServers: Record<string, MCPServerConfig>;
+}
+
+interface EvalsServerConfig {
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  requestInit?: {
+    headers?: Record<string, string>;
+  };
+}
+
+interface EvalsEnvironmentConfig {
+  servers: Record<string, EvalsServerConfig>;
+}
+
+export function transformMCPServersConfig(
+  config: MCPServersConfig,
+): EvalsEnvironmentConfig {
+  const evalsServers: Record<string, EvalsServerConfig> = {};
+
+  for (const [serverName, serverConfig] of Object.entries(config.mcpServers)) {
+    if (!serverConfig || typeof serverConfig !== "object") {
+      console.warn(`Skipping invalid server config for "${serverName}"`);
+      continue;
+    }
+
+    const evalsConfig: EvalsServerConfig = {};
+
+    // Handle HTTP/SSE servers
+    if (serverConfig.url) {
+      evalsConfig.url = serverConfig.url;
+
+      // Transform headers
+      if (
+        serverConfig.headers &&
+        Object.keys(serverConfig.headers).length > 0
+      ) {
+        evalsConfig.requestInit = {
+          headers: serverConfig.headers,
+        };
+      }
+    }
+    // Handle STDIO servers
+    else if (serverConfig.command) {
+      evalsConfig.command = serverConfig.command;
+
+      if (serverConfig.args && serverConfig.args.length > 0) {
+        evalsConfig.args = serverConfig.args;
+      }
+
+      if (serverConfig.env && Object.keys(serverConfig.env).length > 0) {
+        evalsConfig.env = serverConfig.env;
+      }
+    } else {
+      console.warn(
+        `Skipping server "${serverName}": missing both url and command`,
+      );
+      continue;
+    }
+
+    evalsServers[serverName] = evalsConfig;
+  }
+
+  return { servers: evalsServers };
+}
+
+/**
+ * Detects if a config is in Claude/Cursor format vs evals format
+ */
+export function detectConfigFormat(
+  config: unknown,
+): "claude-cursor" | "evals" | "unknown" {
+  if (!config || typeof config !== "object") {
+    return "unknown";
+  }
+
+  const obj = config as Record<string, unknown>;
+
+  // Evals format has "servers" key
+  if (obj.servers && typeof obj.servers === "object") {
+    return "evals";
+  }
+
+  // Claude/Cursor format has "mcpServers" key
+  if (obj.mcpServers && typeof obj.mcpServers === "object") {
+    return "claude-cursor";
+  }
+
+  return "unknown";
+}
+
+export function parseAndTransformConfig(
+  jsonContent: string,
+): EvalsEnvironmentConfig {
+  const parsed = JSON.parse(jsonContent);
+  const format = detectConfigFormat(parsed);
+
+  switch (format) {
+    case "evals":
+      return parsed as EvalsEnvironmentConfig;
+    case "claude-cursor":
+      return transformMCPServersConfig(parsed as MCPServersConfig);
+    case "unknown":
+      throw new Error(
+        'Invalid config format. Expected either { "servers": {...} } or { "mcpServers": {...} }',
+      );
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds automatic detection and transformation of environment configs from `mcpServers` to `servers`, enabling multiple MCP config formats with env var substitution.
> 
> - **CLI (evals)**:
>   - Parse environment config via `parseAndTransformConfig` to accept both `{"servers":...}` and `{"mcpServers":...}` formats in `evals-cli/src/evals/index.ts`.
>   - Maintain env var substitution after transformation.
> - **Utils**:
>   - Add `evals-cli/src/utils/config-transformer.ts` with:
>     - `detectConfigFormat` to distinguish formats.
>     - `transformMCPServersConfig` to map `mcpServers` to evals `servers` (including `url`, `command`, `args`, `env`, and headers into `requestInit.headers`).
>     - `parseAndTransformConfig` to parse JSON and return an evals-compatible config.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 260ae10ecd8aecd058870f65cfdd2b290bb102da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->