### PR TITLE
Free evals

### DIFF
--- a/client/src/components/ChatTab.tsx
+++ b/client/src/components/ChatTab.tsx
@@ -67,7 +67,9 @@ export function ChatTab({
       toast.error(error);
     },
   });
-  const isUsingMcpjamProvidedModel = model ? isMCPJamProvidedModel(model.provider) : false;
+  const isUsingMcpjamProvidedModel = model
+    ? isMCPJamProvidedModel(model.provider)
+    : false;
   const showSignInPrompt = isUsingMcpjamProvidedModel && !isAuthenticated;
   const signInPromptMessage = "Sign in to use MCPJam provided models";
 

--- a/client/src/components/ChatTab.tsx
+++ b/client/src/components/ChatTab.tsx
@@ -15,6 +15,7 @@ import type { ServerWithName } from "@/hooks/use-app-state";
 import { Button } from "@/components/ui/button";
 import { usePostHog } from "posthog-js/react";
 import { detectEnvironment, detectPlatform } from "@/logs/PosthogUtils";
+import { isMCPJamProvidedModel } from "@/shared/types";
 interface ChatTabProps {
   serverConfigs?: Record<string, MastraMCPServerDefinition>;
   connectedServerConfigs?: Record<string, ServerWithName>;
@@ -66,7 +67,7 @@ export function ChatTab({
       toast.error(error);
     },
   });
-  const isUsingMcpjamProvidedModel = model?.provider === "meta";
+  const isUsingMcpjamProvidedModel = model ? isMCPJamProvidedModel(model.provider) : false;
   const showSignInPrompt = isUsingMcpjamProvidedModel && !isAuthenticated;
   const signInPromptMessage = "Sign in to use MCPJam provided models";
 

--- a/client/src/components/chat/model-selector.tsx
+++ b/client/src/components/chat/model-selector.tsx
@@ -9,7 +9,11 @@ import {
   DropdownMenuSubTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
-import { ModelDefinition, ModelProvider, isMCPJamProvidedModel } from "@/shared/types.js";
+import {
+  ModelDefinition,
+  ModelProvider,
+  isMCPJamProvidedModel,
+} from "@/shared/types.js";
 import { ProviderLogo } from "./provider-logo";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { useConvexAuth } from "convex/react";
@@ -132,7 +136,9 @@ export function ModelSelector({
                 collisionPadding={8}
               >
                 {models.map((model) => {
-                  const isMCPJamProvided = isMCPJamProvidedModel(model.provider);
+                  const isMCPJamProvided = isMCPJamProvidedModel(
+                    model.provider,
+                  );
                   const isDisabled =
                     !!model.disabled || (isMCPJamProvided && !isAuthenticated);
                   const computedReason =

--- a/client/src/components/chat/model-selector.tsx
+++ b/client/src/components/chat/model-selector.tsx
@@ -37,6 +37,12 @@ const groupModelsByProvider = (
   return groupedModels;
 };
 
+// Helper to check if a provider is MCPJam-provided
+export const isMCPJamProvidedModel = (provider: ModelProvider): boolean => {
+  const MCPJAM_PROVIDERS: ModelProvider[] = ["meta"];
+  return MCPJAM_PROVIDERS.includes(provider);
+};
+
 // Provider display names
 const getProviderDisplayName = (provider: ModelProvider): string => {
   switch (provider) {
@@ -74,12 +80,11 @@ export function ModelSelector({
 
   // Get sorted provider keys for consistent ordering
   const sortedProviders = Array.from(groupedModels.keys()).sort();
-  const MCPJAM_PROVIDERS: ModelProvider[] = ["meta"];
   const mcpjamProviders = hideProvidedModels
     ? []
-    : sortedProviders.filter((p) => MCPJAM_PROVIDERS.includes(p));
+    : sortedProviders.filter((p) => isMCPJamProvidedModel(p));
   const otherProviders = sortedProviders.filter(
-    (p) => !MCPJAM_PROVIDERS.includes(p),
+    (p) => !isMCPJamProvidedModel(p),
   );
 
   return (
@@ -133,11 +138,11 @@ export function ModelSelector({
                 collisionPadding={8}
               >
                 {models.map((model) => {
-                  const isMeta = model.provider === "meta";
+                  const isMCPJamProvided = isMCPJamProvidedModel(model.provider);
                   const isDisabled =
-                    !!model.disabled || (isMeta && !isAuthenticated);
+                    !!model.disabled || (isMCPJamProvided && !isAuthenticated);
                   const computedReason =
-                    isMeta && !isAuthenticated
+                    isMCPJamProvided && !isAuthenticated
                       ? "Sign in to use MCPJam provided models"
                       : model.disabledReason;
 

--- a/client/src/components/chat/model-selector.tsx
+++ b/client/src/components/chat/model-selector.tsx
@@ -9,7 +9,7 @@ import {
   DropdownMenuSubTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
-import { ModelDefinition, ModelProvider } from "@/shared/types.js";
+import { ModelDefinition, ModelProvider, isMCPJamProvidedModel } from "@/shared/types.js";
 import { ProviderLogo } from "./provider-logo";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../ui/tooltip";
 import { useConvexAuth } from "convex/react";
@@ -35,12 +35,6 @@ const groupModelsByProvider = (
   });
 
   return groupedModels;
-};
-
-// Helper to check if a provider is MCPJam-provided
-export const isMCPJamProvidedModel = (provider: ModelProvider): boolean => {
-  const MCPJAM_PROVIDERS: ModelProvider[] = ["meta"];
-  return MCPJAM_PROVIDERS.includes(provider);
 };
 
 // Provider display names

--- a/client/src/components/evals/eval-runner.tsx
+++ b/client/src/components/evals/eval-runner.tsx
@@ -226,7 +226,7 @@ export function EvalRunner({
             currentModel={selectedModel}
             availableModels={availableModels}
             onModelChange={setSelectedModel}
-            hideProvidedModels={true}
+            hideProvidedModels={false}
           />
         )}
       </div>

--- a/client/src/hooks/use-chat.ts
+++ b/client/src/hooks/use-chat.ts
@@ -3,7 +3,12 @@ import { useAuth } from "@workos-inc/authkit-react";
 import { usePostHog } from "posthog-js/react";
 import { ChatMessage, ChatState, Attachment } from "@/lib/chat-types";
 import { createMessage } from "@/lib/chat-utils";
-import { Model, ModelDefinition, SUPPORTED_MODELS, isMCPJamProvidedModel } from "@/shared/types.js";
+import {
+  Model,
+  ModelDefinition,
+  SUPPORTED_MODELS,
+  isMCPJamProvidedModel,
+} from "@/shared/types.js";
 import { useAiProviderKeys } from "@/hooks/use-ai-provider-keys";
 import {
   detectOllamaModels,
@@ -320,7 +325,8 @@ export function useChat(options: UseChatOptions = {}) {
   const sendChatRequest = useCallback(
     async (userMessage: ChatMessage) => {
       const routeThroughBackend =
-        sendMessagesToBackend || (model && isMCPJamProvidedModel(model.provider));
+        sendMessagesToBackend ||
+        (model && isMCPJamProvidedModel(model.provider));
 
       if (!routeThroughBackend && (!model || !currentApiKey)) {
         throw new Error(

--- a/client/src/hooks/use-chat.ts
+++ b/client/src/hooks/use-chat.ts
@@ -3,7 +3,7 @@ import { useAuth } from "@workos-inc/authkit-react";
 import { usePostHog } from "posthog-js/react";
 import { ChatMessage, ChatState, Attachment } from "@/lib/chat-types";
 import { createMessage } from "@/lib/chat-utils";
-import { Model, ModelDefinition, SUPPORTED_MODELS } from "@/shared/types.js";
+import { Model, ModelDefinition, SUPPORTED_MODELS, isMCPJamProvidedModel } from "@/shared/types.js";
 import { useAiProviderKeys } from "@/hooks/use-ai-provider-keys";
 import {
   detectOllamaModels,
@@ -121,7 +121,7 @@ export function useChat(options: UseChatOptions = {}) {
     (m: ModelDefinition | null) => {
       if (!m) return "";
       // Router-backed model requires no user token; backend provides it
-      if (m.provider === "meta") {
+      if (isMCPJamProvidedModel(m.provider)) {
         return "router"; // sentinel token to pass client validation
       }
       if (m.provider === "ollama") {
@@ -320,7 +320,7 @@ export function useChat(options: UseChatOptions = {}) {
   const sendChatRequest = useCallback(
     async (userMessage: ChatMessage) => {
       const routeThroughBackend =
-        sendMessagesToBackend || model?.provider === "meta";
+        sendMessagesToBackend || (model && isMCPJamProvidedModel(model.provider));
 
       if (!routeThroughBackend && (!model || !currentApiKey)) {
         throw new Error(

--- a/evals-cli/.env.local
+++ b/evals-cli/.env.local
@@ -1,0 +1,2 @@
+CONVEX_URL=https://exuberant-albatross-496.convex.cloud
+CONVEX_HTTP_URL=https://exuberant-albatross-496.convex.site

--- a/evals-cli/.env.production
+++ b/evals-cli/.env.production
@@ -1,2 +1,3 @@
 CONVEX_URL=https://outstanding-fennec-304.convex.cloud
+CONVEX_HTTP_URL=https://outstanding-fennec-304.convex.site
 ENVIRONMENT=prod

--- a/evals-cli/src/evals/runner.ts
+++ b/evals-cli/src/evals/runner.ts
@@ -22,6 +22,7 @@ import { Logger } from "../utils/logger";
 import { evaluateResults } from "./evaluator";
 import { getUserId } from "../utils/user-id";
 import { hogClient } from "../utils/hog";
+import { isMCPJamProvidedModel } from "../../../shared/types";
 
 const MAX_STEPS = 20;
 
@@ -82,6 +83,155 @@ type RunIterationParams = {
   tools: ToolMap;
   recorder: RunRecorder;
   testCaseId?: string;
+};
+
+type RunIterationViaBackendParams = RunIterationParams & {
+  convexUrl: string;
+  authToken: string;
+};
+
+const runIterationViaBackend = async ({
+  test,
+  runIndex,
+  totalRuns,
+  tools,
+  recorder,
+  testCaseId,
+  convexUrl,
+  authToken,
+}: RunIterationViaBackendParams): Promise<EvaluationResult> => {
+  const { advancedConfig, query } = test;
+  const { system } = advancedConfig ?? {};
+
+  Logger.testRunStart({
+    runNumber: runIndex + 1,
+    totalRuns,
+    provider: test.provider,
+    model: test.model,
+    temperature: advancedConfig?.temperature,
+  });
+
+  if (system) {
+    Logger.conversation({ messages: [{ role: "system", content: system }] });
+  }
+
+  const userMessage: ModelMessage = {
+    role: "user",
+    content: query,
+  };
+
+  Logger.conversation({ messages: [userMessage] });
+
+  const messageHistory: ModelMessage[] = [userMessage];
+  const toolsCalled: string[] = [];
+  let stepCount = 0;
+
+  const runStartedAt = Date.now();
+  const iterationId = await recorder.startIteration({
+    testCaseId,
+    iterationNumber: runIndex + 1,
+    startedAt: runStartedAt,
+  });
+
+  // Convert tools to serializable format for backend
+  const toolDefs = Object.entries(tools).map(([name, tool]) => ({
+    name,
+    description: tool?.description,
+    inputSchema: tool?.inputSchema,
+  }));
+
+  while (stepCount < MAX_STEPS) {
+    try {
+      const res = await fetch(`${convexUrl}/streaming`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+        },
+        body: JSON.stringify({
+          tools: toolDefs,
+          messages: JSON.stringify(messageHistory),
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error(`Backend request failed: ${res.statusText}`);
+      }
+
+      const data = await res.json();
+
+      if (!data?.ok || !Array.isArray(data.messages)) {
+        throw new Error("Invalid response from backend");
+      }
+
+      // Process response messages
+      for (const msg of data.messages as ModelMessage[]) {
+        messageHistory.push(msg);
+
+        if ((msg as any).role === "assistant" && Array.isArray((msg as any).content)) {
+          for (const c of (msg as any).content) {
+            if (c?.type === "text" && typeof c.text === "string") {
+              Logger.conversation({ messages: [{ role: "assistant", content: c.text }] });
+            } else if (c?.type === "tool-call") {
+              const toolName = c.toolName || c.name;
+              toolsCalled.push(toolName);
+              Logger.streamToolCall(toolName, c.input || c.parameters || c.args || {});
+            }
+          }
+        }
+      }
+
+      // Check if we need to continue (more tool calls to execute)
+      const hasUnresolvedTools = messageHistory.some(
+        (m: any) =>
+          m.role === "assistant" &&
+          Array.isArray(m.content) &&
+          m.content.some((c: any) => c.type === "tool-call")
+      );
+
+      stepCount++;
+
+      if (!hasUnresolvedTools) {
+        break;
+      }
+    } catch (error) {
+      Logger.errorWithExit(
+        `Backend execution error: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  const evaluation = evaluateResults(test.expectedToolCalls, toolsCalled);
+
+  const usage: UsageTotals = {
+    inputTokens: undefined,
+    outputTokens: undefined,
+    totalTokens: undefined,
+  };
+
+  await recorder.finishIteration({
+    iterationId,
+    passed: evaluation.passed,
+    toolsCalled,
+    usage,
+    messages: messageHistory,
+  });
+
+  Logger.toolSummary({
+    expected: evaluation.expectedToolCalls,
+    actual: evaluation.toolsCalled,
+    missing: evaluation.missing,
+    unexpected: evaluation.unexpected,
+    passed: evaluation.passed,
+  });
+
+  Logger.testRunResult({
+    passed: evaluation.passed,
+    durationMs: Date.now() - runStartedAt,
+    usage: undefined,
+  });
+
+  return evaluation;
 };
 
 const runIteration = async ({
@@ -257,6 +407,8 @@ type RunTestCaseParams = {
   llms: LlmsConfig;
   tools: ToolMap;
   recorder: RunRecorder;
+  convexUrl?: string;
+  authToken?: string;
 };
 
 const runTestCase = async ({
@@ -265,6 +417,8 @@ const runTestCase = async ({
   llms,
   tools,
   recorder,
+  convexUrl,
+  authToken,
 }: RunTestCaseParams) => {
   const { runs, model, provider } = test;
 
@@ -276,15 +430,30 @@ const runTestCase = async ({
   const testCaseId = await recorder.recordTestCase(test, testIndex);
 
   for (let runIndex = 0; runIndex < runs; runIndex++) {
-    const evaluation = await runIteration({
-      test,
-      runIndex,
-      totalRuns: runs,
-      llms,
-      tools,
-      recorder,
-      testCaseId,
-    });
+    // Branch based on whether this is an MCPJam-provided model
+    const usesBackend = isMCPJamProvidedModel(provider as any);
+
+    const evaluation = usesBackend && convexUrl && authToken
+      ? await runIterationViaBackend({
+          test,
+          runIndex,
+          totalRuns: runs,
+          llms,
+          tools,
+          recorder,
+          testCaseId,
+          convexUrl,
+          authToken,
+        })
+      : await runIteration({
+          test,
+          runIndex,
+          totalRuns: runs,
+          llms,
+          tools,
+          recorder,
+          testCaseId,
+        });
 
     if (evaluation.passed) {
       passedRuns++;
@@ -302,6 +471,8 @@ async function runEvalSuiteCore(
   validatedLlms: LlmsConfig,
   recorder: RunRecorder,
   suiteStartedAt: number,
+  convexUrl?: string,
+  authToken?: string,
 ) {
   const { vercelTools, serverNames, mcpClient } = await prepareSuite(
     validatedTests,
@@ -334,6 +505,8 @@ async function runEvalSuiteCore(
           llms: validatedLlms,
           tools: vercelTools,
           recorder,
+          convexUrl,
+          authToken,
         });
       passedRuns += casePassed;
       failedRuns += caseFailed;
@@ -397,6 +570,8 @@ export const runEvalsWithAuth = async (
   environment: unknown,
   llms: unknown,
   convexClient: ConvexHttpClient,
+  convexUrl?: string,
+  authToken?: string,
 ) => {
   const suiteStartedAt = Date.now();
   Logger.info("Starting eval suite with session authentication");
@@ -423,5 +598,7 @@ export const runEvalsWithAuth = async (
     validatedLlms,
     recorder,
     suiteStartedAt,
+    convexUrl,
+    authToken,
   );
 };

--- a/evals-cli/src/evals/runner.ts
+++ b/evals-cli/src/evals/runner.ts
@@ -175,7 +175,9 @@ const runIterationViaBackend = async ({
 
           return data;
         } catch (error) {
-          console.error(`Backend fetch error: ${error instanceof Error ? error.message : String(error)}`);
+          console.error(
+            `Backend fetch error: ${error instanceof Error ? error.message : String(error)}`,
+          );
           return null;
         }
       },
@@ -186,7 +188,9 @@ const runIterationViaBackend = async ({
       },
       handlers: {
         onAssistantText: (text) => {
-          Logger.conversation({ messages: [{ role: "assistant", content: text }] });
+          Logger.conversation({
+            messages: [{ role: "assistant", content: text }],
+          });
         },
         onToolCall: (call: BackendToolCallEvent) => {
           toolsCalled.push(call.name);
@@ -441,27 +445,28 @@ const runTestCase = async ({
     // Branch based on whether this is an MCPJam-provided model
     const usesBackend = isMCPJamProvidedModel(provider as any);
 
-    const evaluation = usesBackend && convexUrl && authToken
-      ? await runIterationViaBackend({
-          test,
-          runIndex,
-          totalRuns: runs,
-          llms,
-          tools,
-          recorder,
-          testCaseId,
-          convexUrl,
-          authToken,
-        })
-      : await runIteration({
-          test,
-          runIndex,
-          totalRuns: runs,
-          llms,
-          tools,
-          recorder,
-          testCaseId,
-        });
+    const evaluation =
+      usesBackend && convexUrl && authToken
+        ? await runIterationViaBackend({
+            test,
+            runIndex,
+            totalRuns: runs,
+            llms,
+            tools,
+            recorder,
+            testCaseId,
+            convexUrl,
+            authToken,
+          })
+        : await runIteration({
+            test,
+            runIndex,
+            totalRuns: runs,
+            llms,
+            tools,
+            recorder,
+            testCaseId,
+          });
 
     if (evaluation.passed) {
       passedRuns++;

--- a/evals-cli/src/utils/validators.ts
+++ b/evals-cli/src/utils/validators.ts
@@ -174,6 +174,10 @@ export function validateLlms(value: unknown): LlmsConfig | undefined {
 }
 
 const isValidLlmApiKey = (key: string | undefined) => {
+  // Accept backend execution marker for MCPJam-provided models
+  if (key === "BACKEND_EXECUTION") {
+    return true;
+  }
   if (key && key.startsWith("sk-")) {
     return true;
   }

--- a/server/routes/mcp/chat.ts
+++ b/server/routes/mcp/chat.ts
@@ -4,6 +4,7 @@ import {
   ChatMessage,
   ModelDefinition,
   ModelProvider,
+  isMCPJamProvidedModel,
 } from "../../../shared/types";
 import { TextEncoder } from "util";
 import { getDefaultTemperatureByProvider } from "../../../client/src/lib/chat-utils";
@@ -571,7 +572,7 @@ chat.post("/", async (c) => {
       );
     }
     const sendToBackend =
-      provider === "meta" && Boolean(requestData.sendMessagesToBackend);
+      isMCPJamProvidedModel(provider) && Boolean(requestData.sendMessagesToBackend);
 
     if (!sendToBackend && (!model?.id || !apiKey)) {
       return c.json(

--- a/server/routes/mcp/chat.ts
+++ b/server/routes/mcp/chat.ts
@@ -11,10 +11,12 @@ import { getDefaultTemperatureByProvider } from "../../../client/src/lib/chat-ut
 import { createLlmModel } from "../../utils/chat-helpers";
 import { SSEvent } from "../../../shared/sse";
 import { convertMastraToolsToVercelTools } from "../../../shared/tools";
+import { executeToolCallsFromMessages } from "../../../shared/http-tool-calls";
 import {
-  hasUnresolvedToolCalls,
-  executeToolCallsFromMessages,
-} from "../../../shared/http-tool-calls";
+  runBackendConversation,
+  type BackendToolCallEvent,
+  type BackendToolResultEvent,
+} from "../../../shared/backend-conversation";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import type { ModelMessage, Tool } from "ai";
 
@@ -404,105 +406,88 @@ const sendMessagesToBackend = async (
   if (!baseUrl) {
     throw new Error("CONVEX_HTTP_URL is not set");
   }
-  let steps = 0;
-  while (steps < MAX_AGENT_STEPS) {
-    const data = await sendBackendRequest(
-      baseUrl,
-      authHeader,
-      {
-        tools: toolDefs,
-        messages: JSON.stringify(messageHistory),
-      },
-      streamingContext,
-    );
-    if (!data) break;
-    if (data?.ok && Array.isArray(data.messages)) {
-      // Append assistant messages and emit their text/tool_call events
-      for (const msg of data.messages as ModelMessage[]) {
-        messageHistory.push(msg);
-        if (
-          (msg as any).role === "assistant" &&
-          Array.isArray((msg as any).content)
-        ) {
-          for (const c of (msg as any).content) {
-            if (c?.type === "text" && typeof c.text === "string") {
-              sendSseEvent(
-                streamingContext.controller,
-                streamingContext.encoder!,
-                {
-                  type: "text",
-                  content: c.text,
-                },
-              );
-            } else if (c?.type === "tool-call") {
-              const currentToolCallId = ++streamingContext.toolCallId;
-              streamingContext.lastEmittedToolCallId = currentToolCallId;
-              sendSseEvent(
-                streamingContext.controller,
-                streamingContext.encoder!,
-                {
-                  type: "tool_call",
-                  toolCall: {
-                    id: currentToolCallId,
-                    name: c.toolName || c.name,
-                    parameters: c.input || c.parameters || c.args || {},
-                    timestamp: new Date().toISOString(),
-                    status: "executing",
-                  },
-                },
-              );
-            }
-          }
-        }
-      }
-    } else {
-      sendBackendErrorText(streamingContext);
-      break;
-    }
 
-    // Execute unresolved tool calls locally and emit tool_result events
-    const beforeLen = messageHistory.length;
-    if (hasUnresolvedToolCalls(messageHistory as any)) {
-      await executeToolCallsFromMessages(messageHistory as ModelMessage[], {
+  const emitToolCall = (call: BackendToolCallEvent) => {
+    const currentToolCallId = ++streamingContext.toolCallId;
+    streamingContext.lastEmittedToolCallId = currentToolCallId;
+    sendSseEvent(streamingContext.controller, streamingContext.encoder!, {
+      type: "tool_call",
+      toolCall: {
+        id: currentToolCallId,
+        name: call.name,
+        parameters: call.params || {},
+        timestamp: new Date().toISOString(),
+        status: "executing",
+      },
+    });
+  };
+
+  const emitToolResult = (result: BackendToolResultEvent) => {
+    const currentToolCallId =
+      streamingContext.lastEmittedToolCallId != null
+        ? streamingContext.lastEmittedToolCallId
+        : ++streamingContext.toolCallId;
+    sendSseEvent(streamingContext.controller, streamingContext.encoder!, {
+      type: "tool_result",
+      toolResult: {
+        id: currentToolCallId,
+        toolCallId: currentToolCallId,
+        result: result.result,
+        error: result.error,
+        timestamp: new Date().toISOString(),
+      },
+    });
+  };
+
+  await runBackendConversation({
+    maxSteps: MAX_AGENT_STEPS,
+    messageHistory,
+    toolDefinitions: toolDefs,
+    fetchBackend: async (payload) => {
+      const data = await sendBackendRequest(
+        baseUrl,
+        authHeader,
+        payload,
+        streamingContext,
+      );
+      if (data && (!data.ok || !Array.isArray(data.messages))) {
+        sendBackendErrorText(streamingContext);
+        return null;
+      }
+      return data;
+    },
+    executeToolCalls: async (messages) => {
+      await executeToolCallsFromMessages(messages, {
         tools: flatTools as any,
       });
-      const newMsgs = messageHistory.slice(beforeLen);
-      for (const m of newMsgs) {
-        if ((m as any).role === "tool" && Array.isArray((m as any).content)) {
-          for (const tc of (m as any).content) {
-            if (tc.type === "tool-result") {
-              const currentToolCallId =
-                streamingContext.lastEmittedToolCallId != null
-                  ? streamingContext.lastEmittedToolCallId
-                  : ++streamingContext.toolCallId;
-              const out = tc.output;
-              const value =
-                out && typeof out === "object" && "value" in out
-                  ? out.value
-                  : out;
-              sendSseEvent(
-                streamingContext.controller,
-                streamingContext.encoder!,
-                {
-                  type: "tool_result",
-                  toolResult: {
-                    id: currentToolCallId,
-                    toolCallId: currentToolCallId,
-                    result: value,
-                    timestamp: new Date().toISOString(),
-                  },
-                },
-              );
-            }
-          }
-        }
-      }
-    } else {
-      break;
-    }
-
-    steps++;
-  }
+    },
+    handlers: {
+      onAssistantText: (text) => {
+        sendSseEvent(streamingContext.controller, streamingContext.encoder!, {
+          type: "text",
+          content: text,
+        });
+      },
+      onToolCall: (call) => {
+        emitToolCall(call);
+      },
+      onToolResult: (result) => {
+        emitToolResult(result);
+      },
+      onStepComplete: ({ text, toolCalls, toolResults }) => {
+        handleAgentStepFinish(
+          streamingContext,
+          text,
+          toolCalls,
+          toolResults.map((result) => ({
+            result: result.result,
+            error: result.error,
+          })),
+          false,
+        );
+      },
+    },
+  });
 
   sendSseEvent(streamingContext.controller, streamingContext.encoder!, {
     type: "elicitation_complete",

--- a/server/routes/mcp/chat.ts
+++ b/server/routes/mcp/chat.ts
@@ -557,7 +557,8 @@ chat.post("/", async (c) => {
       );
     }
     const sendToBackend =
-      isMCPJamProvidedModel(provider) && Boolean(requestData.sendMessagesToBackend);
+      isMCPJamProvidedModel(provider) &&
+      Boolean(requestData.sendMessagesToBackend);
 
     if (!sendToBackend && (!model?.id || !apiKey)) {
       return c.json(

--- a/server/routes/mcp/evals.ts
+++ b/server/routes/mcp/evals.ts
@@ -71,10 +71,22 @@ evals.post("/run", async (c) => {
       throw new Error("CONVEX_URL is not set");
     }
 
+    const convexHttpUrl = process.env.CONVEX_HTTP_URL;
+    if (!convexHttpUrl) {
+      throw new Error("CONVEX_HTTP_URL is not set");
+    }
+
     const convexClient = new ConvexHttpClient(convexUrl);
     convexClient.setAuth(convexAuthToken);
 
-    runEvalsWithAuth(tests, environment, llms, convexClient).catch((error) => {
+    runEvalsWithAuth(
+      tests,
+      environment,
+      llms,
+      convexClient,
+      convexHttpUrl,
+      convexAuthToken,
+    ).catch((error) => {
       console.error("[Hono:Evals] Error running evals:", error);
     });
 

--- a/server/routes/mcp/index.ts
+++ b/server/routes/mcp/index.ts
@@ -5,7 +5,6 @@ import tools from "./tools";
 import resources from "./resources";
 import prompts from "./prompts";
 import chat from "./chat";
-import tests from "./tests.ts";
 import oauth from "./oauth";
 import exporter from "./export";
 import interceptor from "./interceptor";
@@ -34,9 +33,6 @@ mcp.route("/servers", servers);
 
 // Tools endpoint - REAL IMPLEMENTATION
 mcp.route("/tools", tools);
-
-// Tests endpoint - generate per-test agents
-mcp.route("/tests", tests);
 
 // Evals endpoint - run evaluations
 mcp.route("/evals", evals);

--- a/server/tsup.config.ts
+++ b/server/tsup.config.ts
@@ -31,6 +31,9 @@ export default defineConfig({
     "execa",
     // Sentry packages with native modules must remain external
     "@sentry/node",
+    // evals-cli dependencies
+    "posthog-node",
+    "@openrouter/ai-sdk-provider",
   ],
   noExternal: [
     // Force bundling of problematic packages

--- a/server/utils/eval-transformer.ts
+++ b/server/utils/eval-transformer.ts
@@ -4,6 +4,7 @@ import {
   LlmsConfig,
   LlmsConfigSchema,
 } from "../../evals-cli/src/utils/validators";
+import { isMCPJamProvidedModel } from "../../shared/types";
 
 /**
  * Transforms server IDs from MCPJamClientManager to MCPClientOptions format
@@ -54,9 +55,15 @@ export function transformLLMConfigToLlmsConfig(llmConfig: {
 }): LlmsConfig {
   const llms: Record<string, string> = {};
 
-  // Map provider names to expected format
-  const providerKey = llmConfig.provider.toLowerCase();
-  llms[providerKey] = llmConfig.apiKey;
+  // MCPJam-provided models use backend execution, so we use a special marker
+  // that will pass validation but won't be used (backend has the actual key)
+  if (isMCPJamProvidedModel(llmConfig.provider as any)) {
+    llms.openrouter = "BACKEND_EXECUTION";
+  } else {
+    // Map provider names to expected format
+    const providerKey = llmConfig.provider.toLowerCase();
+    llms[providerKey] = llmConfig.apiKey;
+  }
 
   // Validate the result
   const validated = LlmsConfigSchema.safeParse(llms);

--- a/shared/backend-conversation.ts
+++ b/shared/backend-conversation.ts
@@ -52,7 +52,11 @@ export type BackendConversationResult = {
 };
 
 const extractToolResultValue = (raw: unknown) => {
-  if (raw && typeof raw === "object" && "value" in (raw as Record<string, unknown>)) {
+  if (
+    raw &&
+    typeof raw === "object" &&
+    "value" in (raw as Record<string, unknown>)
+  ) {
     return (raw as Record<string, unknown>).value;
   }
 
@@ -116,7 +120,11 @@ export const runBackendConversation = async (
           for (const item of content) {
             if (item?.type === "tool-result") {
               const rawOutput =
-                item.output ?? item.result ?? item.value ?? item.data ?? item.content;
+                item.output ??
+                item.result ??
+                item.value ??
+                item.data ??
+                item.content;
               const resultEvent: BackendToolResultEvent = {
                 toolName: item.toolName ?? item.name,
                 result: extractToolResultValue(rawOutput),

--- a/shared/backend-conversation.ts
+++ b/shared/backend-conversation.ts
@@ -1,0 +1,157 @@
+import type { ModelMessage } from "ai";
+import { hasUnresolvedToolCalls } from "./http-tool-calls";
+
+export type BackendToolDefinition = {
+  name: string;
+  description?: string;
+  inputSchema?: unknown;
+};
+
+export type BackendFetchPayload = {
+  tools: BackendToolDefinition[];
+  messages: string;
+};
+
+export type BackendFetchResponse = {
+  ok?: boolean;
+  messages?: ModelMessage[];
+  [key: string]: unknown;
+};
+
+export type BackendToolCallEvent = {
+  name: string;
+  params: unknown;
+};
+
+export type BackendToolResultEvent = {
+  toolName?: string;
+  result: unknown;
+  error?: unknown;
+};
+
+export type BackendConversationHandlers = {
+  onAssistantText?: (text: string) => void;
+  onToolCall?: (call: BackendToolCallEvent) => void;
+  onToolResult?: (result: BackendToolResultEvent) => void;
+  onStepComplete?: (payload: {
+    step: number;
+    text: string;
+    toolCalls: BackendToolCallEvent[];
+    toolResults: BackendToolResultEvent[];
+  }) => void;
+};
+
+export type BackendConversationOptions = {
+  maxSteps: number;
+  messageHistory: ModelMessage[];
+  toolDefinitions: BackendToolDefinition[];
+  executeToolCalls: (messages: ModelMessage[]) => Promise<void>;
+  fetchBackend: (
+    payload: BackendFetchPayload,
+  ) => Promise<BackendFetchResponse | null>;
+  handlers?: BackendConversationHandlers;
+};
+
+export type BackendConversationResult = {
+  steps: number;
+  messageHistory: ModelMessage[];
+};
+
+const extractToolResultValue = (raw: unknown) => {
+  if (raw && typeof raw === "object" && "value" in (raw as Record<string, unknown>)) {
+    return (raw as Record<string, unknown>).value;
+  }
+
+  return raw;
+};
+
+export const runBackendConversation = async (
+  options: BackendConversationOptions,
+): Promise<BackendConversationResult> => {
+  const { handlers } = options;
+  let step = 0;
+
+  while (step < options.maxSteps) {
+    const payload: BackendFetchPayload = {
+      tools: options.toolDefinitions,
+      messages: JSON.stringify(options.messageHistory),
+    };
+    const data = await options.fetchBackend(payload);
+
+    if (!data || !data.ok || !Array.isArray(data.messages)) {
+      break;
+    }
+
+    const iterationToolCalls: BackendToolCallEvent[] = [];
+    const iterationToolResults: BackendToolResultEvent[] = [];
+    let iterationText = "";
+
+    for (const msg of data.messages) {
+      options.messageHistory.push(msg);
+
+      const content = (msg as any).content;
+      if ((msg as any).role === "assistant" && Array.isArray(content)) {
+        for (const item of content) {
+          if (item?.type === "text" && typeof item.text === "string") {
+            iterationText += item.text;
+            handlers?.onAssistantText?.(item.text);
+          } else if (item?.type === "tool-call") {
+            const name = item.toolName ?? item.name;
+            if (!name) {
+              continue;
+            }
+            const params = item.input ?? item.parameters ?? item.args ?? {};
+            const callEvent: BackendToolCallEvent = { name, params };
+            iterationToolCalls.push(callEvent);
+            handlers?.onToolCall?.(callEvent);
+          }
+        }
+      }
+    }
+
+    const unresolved = hasUnresolvedToolCalls(options.messageHistory as any);
+
+    if (unresolved) {
+      const beforeLen = options.messageHistory.length;
+      await options.executeToolCalls(options.messageHistory);
+      const newMessages = options.messageHistory.slice(beforeLen);
+
+      for (const msg of newMessages) {
+        const content = (msg as any).content;
+        if ((msg as any).role === "tool" && Array.isArray(content)) {
+          for (const item of content) {
+            if (item?.type === "tool-result") {
+              const rawOutput =
+                item.output ?? item.result ?? item.value ?? item.data ?? item.content;
+              const resultEvent: BackendToolResultEvent = {
+                toolName: item.toolName ?? item.name,
+                result: extractToolResultValue(rawOutput),
+                error: item.error,
+              };
+              iterationToolResults.push(resultEvent);
+              handlers?.onToolResult?.(resultEvent);
+            }
+          }
+        }
+      }
+    }
+
+    step += 1;
+
+    handlers?.onStepComplete?.({
+      step,
+      text: iterationText,
+      toolCalls: iterationToolCalls,
+      toolResults: iterationToolResults,
+    });
+
+    if (!unresolved) {
+      break;
+    }
+  }
+
+  return {
+    steps: step,
+    messageHistory: options.messageHistory,
+  };
+};

--- a/shared/backend-conversation.ts
+++ b/shared/backend-conversation.ts
@@ -1,14 +1,8 @@
-import type { ModelMessage } from "ai";
+import type { ModelMessage, Tool } from "ai";
 import { hasUnresolvedToolCalls } from "./http-tool-calls";
 
-export type BackendToolDefinition = {
-  name: string;
-  description?: string;
-  inputSchema?: unknown;
-};
-
 export type BackendFetchPayload = {
-  tools: BackendToolDefinition[];
+  tools: Tool[];
   messages: string;
 };
 
@@ -44,7 +38,7 @@ export type BackendConversationHandlers = {
 export type BackendConversationOptions = {
   maxSteps: number;
   messageHistory: ModelMessage[];
-  toolDefinitions: BackendToolDefinition[];
+  toolDefinitions: Tool[];
   executeToolCalls: (messages: ModelMessage[]) => Promise<void>;
   fetchBackend: (
     payload: BackendFetchPayload,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -105,6 +105,12 @@ export type ModelProvider =
   | "google"
   | "meta";
 
+// Helper to check if a provider is MCPJam-provided (requires backend execution)
+export const isMCPJamProvidedModel = (provider: ModelProvider): boolean => {
+  const MCPJAM_PROVIDERS: ModelProvider[] = ["meta"];
+  return MCPJAM_PROVIDERS.includes(provider);
+};
+
 export interface ModelDefinition {
   id: Model | string;
   name: string;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds backend execution path for MCPJam-provided models across chat and evals, using a shared conversation runner and a provider helper to gate auth/UX.
> 
> - **Shared**:
>   - Add `isMCPJamProvidedModel` in `shared/types` and use it across client/server.
>   - Introduce `shared/backend-conversation.ts` to standardize backend conversation loop, tool-call/result handling, and SSE emissions.
> - **Client**:
>   - Chat flow (`use-chat`, `ChatTab`) routes meta/MCPJam models through backend and updates auth gating with `isMCPJamProvidedModel`.
>   - Model selector groups/disables MCPJam models via `isMCPJamProvidedModel`.
>   - Evals UI shows MCPJam-provided models (`hideProvidedModels=false`).
> - **Server**:
>   - Chat route refactored to use `runBackendConversation`; backend-sent tool/text events and tool execution streamlined.
>   - Evals route passes `CONVEX_HTTP_URL` and auth token into eval runs; removes `tests` route from router.
>   - Eval transformer maps MCPJam providers to `openrouter: BACKEND_EXECUTION` for validation.
> - **Evals CLI**:
>   - Runner can execute via backend for MCPJam models (fetches Convex, executes local tools, logs); validators accept `BACKEND_EXECUTION` API key.
> - **Config/Build**:
>   - Add `CONVEX_HTTP_URL` to `.env` files; update server bundling externals for evals deps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9393076c0678fe945180ba8ae21652ca1bf92018. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->