### PR TITLE
Add GPT OSS

### DIFF
--- a/client/src/components/ChatTab.tsx
+++ b/client/src/components/ChatTab.tsx
@@ -68,7 +68,7 @@ export function ChatTab({
     },
   });
   const isUsingMcpjamProvidedModel = model
-    ? isMCPJamProvidedModel(model.provider)
+    ? isMCPJamProvidedModel(model.id)
     : false;
   const showSignInPrompt = isUsingMcpjamProvidedModel && !isAuthenticated;
   const signInPromptMessage = "Sign in to use MCPJam provided models";

--- a/client/src/components/chat/model-selector.tsx
+++ b/client/src/components/chat/model-selector.tsx
@@ -80,10 +80,16 @@ export function ModelSelector({
   const sortedProviders = Array.from(groupedModels.keys()).sort();
   const mcpjamProviders = hideProvidedModels
     ? []
-    : sortedProviders.filter((p) => isMCPJamProvidedModel(p));
-  const otherProviders = sortedProviders.filter(
-    (p) => !isMCPJamProvidedModel(p),
-  );
+    : sortedProviders.filter((p) => {
+        // Check if this provider has any MCPJam-provided models
+        const models = groupedModels.get(p) || [];
+        return models.some((m) => isMCPJamProvidedModel(m.id));
+      });
+  const otherProviders = sortedProviders.filter((p) => {
+    // Check if this provider has any non-MCPJam models
+    const models = groupedModels.get(p) || [];
+    return models.some((m) => !isMCPJamProvidedModel(m.id));
+  });
 
   return (
     <DropdownMenu
@@ -135,18 +141,18 @@ export function ModelSelector({
                 avoidCollisions={true}
                 collisionPadding={8}
               >
-                {models.map((model) => {
-                  const isMCPJamProvided = isMCPJamProvidedModel(
-                    model.provider,
-                  );
-                  const isDisabled =
-                    !!model.disabled || (isMCPJamProvided && !isAuthenticated);
-                  const computedReason =
-                    isMCPJamProvided && !isAuthenticated
-                      ? "Sign in to use MCPJam provided models"
-                      : model.disabledReason;
+                {models
+                  .filter((model) => isMCPJamProvidedModel(model.id))
+                  .map((model) => {
+                    const isMCPJamProvided = isMCPJamProvidedModel(model.id);
+                    const isDisabled =
+                      !!model.disabled || (isMCPJamProvided && !isAuthenticated);
+                    const computedReason =
+                      isMCPJamProvided && !isAuthenticated
+                        ? "Sign in to use MCPJam provided models"
+                        : model.disabledReason;
 
-                  const item = (
+                    const item = (
                     <DropdownMenuItem
                       key={model.id}
                       onSelect={() => {
@@ -214,10 +220,12 @@ export function ModelSelector({
                 avoidCollisions={true}
                 collisionPadding={8}
               >
-                {models.map((model) => {
-                  const isDisabled = !!model.disabled;
+                {models
+                  .filter((model) => !isMCPJamProvidedModel(model.id))
+                  .map((model) => {
+                    const isDisabled = !!model.disabled;
 
-                  const item = (
+                    const item = (
                     <DropdownMenuItem
                       key={model.id}
                       onSelect={() => {

--- a/client/src/components/chat/model-selector.tsx
+++ b/client/src/components/chat/model-selector.tsx
@@ -140,44 +140,45 @@ export function ModelSelector({
                   .map((model) => {
                     const isMCPJamProvided = isMCPJamProvidedModel(model.id);
                     const isDisabled =
-                      !!model.disabled || (isMCPJamProvided && !isAuthenticated);
+                      !!model.disabled ||
+                      (isMCPJamProvided && !isAuthenticated);
                     const computedReason =
                       isMCPJamProvided && !isAuthenticated
                         ? "Sign in to use MCPJam provided models"
                         : model.disabledReason;
 
                     const item = (
-                    <DropdownMenuItem
-                      key={model.id}
-                      onSelect={() => {
-                        onModelChange(model);
-                        setIsModelSelectorOpen(false);
-                      }}
-                      className="flex items-center gap-3 text-sm cursor-pointer"
-                      disabled={isDisabled}
-                    >
-                      <div className="flex flex-col flex-1">
-                        <span className="font-medium">{model.name}</span>
-                      </div>
-                      {model.id === currentModel.id && (
-                        <div className="ml-auto w-2 h-2 bg-primary rounded-full" />
-                      )}
-                    </DropdownMenuItem>
-                  );
+                      <DropdownMenuItem
+                        key={model.id}
+                        onSelect={() => {
+                          onModelChange(model);
+                          setIsModelSelectorOpen(false);
+                        }}
+                        className="flex items-center gap-3 text-sm cursor-pointer"
+                        disabled={isDisabled}
+                      >
+                        <div className="flex flex-col flex-1">
+                          <span className="font-medium">{model.name}</span>
+                        </div>
+                        {model.id === currentModel.id && (
+                          <div className="ml-auto w-2 h-2 bg-primary rounded-full" />
+                        )}
+                      </DropdownMenuItem>
+                    );
 
-                  return isDisabled ? (
-                    <Tooltip key={model.id}>
-                      <TooltipTrigger asChild>
-                        <div className="pointer-events-auto">{item}</div>
-                      </TooltipTrigger>
-                      <TooltipContent side="right">
-                        {computedReason}
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : (
-                    item
-                  );
-                })}
+                    return isDisabled ? (
+                      <Tooltip key={model.id}>
+                        <TooltipTrigger asChild>
+                          <div className="pointer-events-auto">{item}</div>
+                        </TooltipTrigger>
+                        <TooltipContent side="right">
+                          {computedReason}
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      item
+                    );
+                  })}
               </DropdownMenuSubContent>
             </DropdownMenuSub>
           );
@@ -219,37 +220,37 @@ export function ModelSelector({
                     const isDisabled = !!model.disabled;
 
                     const item = (
-                    <DropdownMenuItem
-                      key={model.id}
-                      onSelect={() => {
-                        onModelChange(model);
-                        setIsModelSelectorOpen(false);
-                      }}
-                      className="flex items-center gap-3 text-sm cursor-pointer"
-                      disabled={isDisabled}
-                    >
-                      <div className="flex flex-col flex-1">
-                        <span className="font-medium">{model.name}</span>
-                      </div>
-                      {model.id === currentModel.id && (
-                        <div className="ml-auto w-2 h-2 bg-primary rounded-full" />
-                      )}
-                    </DropdownMenuItem>
-                  );
+                      <DropdownMenuItem
+                        key={model.id}
+                        onSelect={() => {
+                          onModelChange(model);
+                          setIsModelSelectorOpen(false);
+                        }}
+                        className="flex items-center gap-3 text-sm cursor-pointer"
+                        disabled={isDisabled}
+                      >
+                        <div className="flex flex-col flex-1">
+                          <span className="font-medium">{model.name}</span>
+                        </div>
+                        {model.id === currentModel.id && (
+                          <div className="ml-auto w-2 h-2 bg-primary rounded-full" />
+                        )}
+                      </DropdownMenuItem>
+                    );
 
-                  return isDisabled ? (
-                    <Tooltip key={model.id}>
-                      <TooltipTrigger asChild>
-                        <div className="pointer-events-auto">{item}</div>
-                      </TooltipTrigger>
-                      <TooltipContent side="right">
-                        {model.disabledReason}
-                      </TooltipContent>
-                    </Tooltip>
-                  ) : (
-                    item
-                  );
-                })}
+                    return isDisabled ? (
+                      <Tooltip key={model.id}>
+                        <TooltipTrigger asChild>
+                          <div className="pointer-events-auto">{item}</div>
+                        </TooltipTrigger>
+                        <TooltipContent side="right">
+                          {model.disabledReason}
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      item
+                    );
+                  })}
               </DropdownMenuSubContent>
             </DropdownMenuSub>
           );

--- a/client/src/components/chat/model-selector.tsx
+++ b/client/src/components/chat/model-selector.tsx
@@ -73,20 +73,15 @@ export function ModelSelector({
   const currentModelData = currentModel;
   const { isAuthenticated } = useConvexAuth();
 
-  // Group models by provider
   const groupedModels = groupModelsByProvider(availableModels);
-
-  // Get sorted provider keys for consistent ordering
   const sortedProviders = Array.from(groupedModels.keys()).sort();
   const mcpjamProviders = hideProvidedModels
     ? []
     : sortedProviders.filter((p) => {
-        // Check if this provider has any MCPJam-provided models
         const models = groupedModels.get(p) || [];
         return models.some((m) => isMCPJamProvidedModel(m.id));
       });
   const otherProviders = sortedProviders.filter((p) => {
-    // Check if this provider has any non-MCPJam models
     const models = groupedModels.get(p) || [];
     return models.some((m) => !isMCPJamProvidedModel(m.id));
   });
@@ -112,7 +107,6 @@ export function ModelSelector({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="min-w-[200px]">
-        {/* MCPJam-provided models */}
         {mcpjamProviders.length > 0 && (
           <div className="px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
             MCPJam Provided Models
@@ -191,7 +185,6 @@ export function ModelSelector({
         {mcpjamProviders.length > 0 && otherProviders.length > 0 && (
           <div className="my-1 h-px bg-muted/50" />
         )}
-        {/* User-configured providers */}
         {otherProviders.length > 0 && (
           <div className="px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
             Your providers

--- a/client/src/components/evals/eval-runner.tsx
+++ b/client/src/components/evals/eval-runner.tsx
@@ -18,7 +18,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { useAppState } from "@/hooks/use-app-state";
 import { useAiProviderKeys } from "@/hooks/use-ai-provider-keys";
 import { ModelSelector } from "@/components/chat/model-selector";
-import { ModelDefinition } from "@/shared/types";
+import { ModelDefinition, isMCPJamProvidedModel } from "@/shared/types";
 
 interface TestCase {
   title: string;
@@ -172,11 +172,11 @@ export function EvalRunner({
       return;
     }
 
-    const apiKey =
-      selectedModel.provider !== "meta"
-        ? getToken(selectedModel.provider as keyof typeof tokens)
-        : "";
-    if (!apiKey && selectedModel.provider !== "meta") {
+    const isMCPJamModel = isMCPJamProvidedModel(selectedModel.id);
+    const apiKey = !isMCPJamModel
+      ? getToken(selectedModel.provider as keyof typeof tokens)
+      : "";
+    if (!apiKey && !isMCPJamModel) {
       toast.error(
         `Please configure your ${selectedModel.provider} API key in Settings`,
       );

--- a/client/src/hooks/use-chat.ts
+++ b/client/src/hooks/use-chat.ts
@@ -331,8 +331,7 @@ export function useChat(options: UseChatOptions = {}) {
   const sendChatRequest = useCallback(
     async (userMessage: ChatMessage) => {
       const routeThroughBackend =
-        sendMessagesToBackend ||
-        (model && isMCPJamProvidedModel(model.id));
+        sendMessagesToBackend || (model && isMCPJamProvidedModel(model.id));
 
       if (!routeThroughBackend && (!model || !currentApiKey)) {
         throw new Error(

--- a/client/src/hooks/use-chat.ts
+++ b/client/src/hooks/use-chat.ts
@@ -125,9 +125,8 @@ export function useChat(options: UseChatOptions = {}) {
   const getApiKeyForModel = useCallback(
     (m: ModelDefinition | null) => {
       if (!m) return "";
-      // Router-backed model requires no user token; backend provides it
       if (isMCPJamProvidedModel(m.id)) {
-        return "router"; // sentinel token to pass client validation
+        return "router";
       }
       if (m.provider === "ollama") {
         const available =
@@ -137,7 +136,6 @@ export function useChat(options: UseChatOptions = {}) {
           );
         return available ? "local" : "";
       }
-      // Meta provider models should be MCPJam-provided (caught above)
       if (m.provider === "meta") {
         return "";
       }
@@ -161,7 +159,6 @@ export function useChat(options: UseChatOptions = {}) {
     [onModelChange],
   );
 
-  // Available models with API keys or local Ollama models
   const availableModels = useMemo(() => {
     const providerHasKey: Record<string, boolean> = {
       anthropic: hasToken("anthropic"),
@@ -169,15 +166,13 @@ export function useChat(options: UseChatOptions = {}) {
       deepseek: hasToken("deepseek"),
       google: hasToken("google"),
       ollama: isOllamaRunning,
-      meta: false, // Meta models are MCPJam-provided, checked separately below
+      meta: false,
     } as const;
 
     const cloud = SUPPORTED_MODELS.filter((m) => {
-      // MCPJam-provided models are always available (backend has the key)
       if (isMCPJamProvidedModel(m.id)) {
         return true;
       }
-      // Otherwise check if user has API key for the provider
       return providerHasKey[m.provider];
     });
     return isOllamaRunning && ollamaModels.length > 0

--- a/evals-cli/src/evals/runner.ts
+++ b/evals-cli/src/evals/runner.ts
@@ -153,6 +153,7 @@ const runIterationViaBackend = async ({
     await runBackendConversation({
       maxSteps: MAX_STEPS,
       messageHistory,
+      modelId: test.model, // Pass the model ID from the test
       toolDefinitions: toolDefs,
       fetchBackend: async (payload) => {
         try {
@@ -470,7 +471,7 @@ const runTestCase = async ({
 
   for (let runIndex = 0; runIndex < runs; runIndex++) {
     // Branch based on whether this is an MCPJam-provided model
-    const usesBackend = isMCPJamProvidedModel(provider as any);
+    const usesBackend = isMCPJamProvidedModel(model);
 
     const evaluation =
       usesBackend && convexUrl && authToken

--- a/evals-cli/src/evals/runner.ts
+++ b/evals-cli/src/evals/runner.ts
@@ -153,7 +153,7 @@ const runIterationViaBackend = async ({
     await runBackendConversation({
       maxSteps: MAX_STEPS,
       messageHistory,
-      modelId: test.model, // Pass the model ID from the test
+      modelId: test.model,
       toolDefinitions: toolDefs,
       fetchBackend: async (payload) => {
         try {

--- a/server/routes/mcp/chat.ts
+++ b/server/routes/mcp/chat.ts
@@ -559,7 +559,8 @@ chat.post("/", async (c) => {
       );
     }
     const sendToBackend =
-      model?.id && isMCPJamProvidedModel(model.id) &&
+      model?.id &&
+      isMCPJamProvidedModel(model.id) &&
       Boolean(requestData.sendMessagesToBackend);
 
     if (!sendToBackend && (!model?.id || !apiKey)) {

--- a/server/routes/mcp/chat.ts
+++ b/server/routes/mcp/chat.ts
@@ -375,6 +375,7 @@ const sendMessagesToBackend = async (
   streamingContext: StreamingContext,
   mcpClientManager: any,
   baseUrl: string,
+  modelId: string,
   authHeader?: string,
   selectedServers?: string[],
 ): Promise<void> => {
@@ -442,6 +443,7 @@ const sendMessagesToBackend = async (
   await runBackendConversation({
     maxSteps: MAX_AGENT_STEPS,
     messageHistory,
+    modelId,
     toolDefinitions: toolDefs,
     fetchBackend: async (payload) => {
       const data = await sendBackendRequest(
@@ -557,7 +559,7 @@ chat.post("/", async (c) => {
       );
     }
     const sendToBackend =
-      isMCPJamProvidedModel(provider) &&
+      model?.id && isMCPJamProvidedModel(model.id) &&
       Boolean(requestData.sendMessagesToBackend);
 
     if (!sendToBackend && (!model?.id || !apiKey)) {
@@ -644,6 +646,7 @@ chat.post("/", async (c) => {
               streamingContext,
               mcpClientManager,
               process.env.CONVEX_HTTP_URL!,
+              model!.id,
               authHeader,
               requestData.selectedServers,
             );

--- a/server/routes/mcp/evals.ts
+++ b/server/routes/mcp/evals.ts
@@ -65,7 +65,9 @@ evals.post("/run", async (c) => {
       serverIds,
       clientManager,
     );
-    const llms = transformLLMConfigToLlmsConfig(llmConfig);
+    // Use the model ID from the first test to determine if MCPJam-provided
+    const modelId = tests.length > 0 ? tests[0].model : undefined;
+    const llms = transformLLMConfigToLlmsConfig(llmConfig, modelId);
 
     const convexUrl = process.env.CONVEX_URL;
     if (!convexUrl) {

--- a/server/routes/mcp/evals.ts
+++ b/server/routes/mcp/evals.ts
@@ -65,7 +65,6 @@ evals.post("/run", async (c) => {
       serverIds,
       clientManager,
     );
-    // Use the model ID from the first test to determine if MCPJam-provided
     const modelId = tests.length > 0 ? tests[0].model : undefined;
     const llms = transformLLMConfigToLlmsConfig(llmConfig, modelId);
 

--- a/server/services/eval-agent.ts
+++ b/server/services/eval-agent.ts
@@ -134,6 +134,7 @@ ${toolsContext}
       Authorization: `Bearer ${convexAuthToken}`,
     },
     body: JSON.stringify({
+      model: "meta-llama/llama-3.3-70b-instruct", // Default MCPJam-provided model for test generation
       tools: [], // No tools needed for generation
       messages: JSON.stringify(messageHistory),
     }),

--- a/server/services/eval-agent.ts
+++ b/server/services/eval-agent.ts
@@ -134,8 +134,8 @@ ${toolsContext}
       Authorization: `Bearer ${convexAuthToken}`,
     },
     body: JSON.stringify({
-      model: "meta-llama/llama-3.3-70b-instruct", // Default MCPJam-provided model for test generation
-      tools: [], // No tools needed for generation
+      model: "meta-llama/llama-3.3-70b-instruct",
+      tools: [],
       messages: JSON.stringify(messageHistory),
     }),
   });

--- a/server/utils/eval-transformer.ts
+++ b/server/utils/eval-transformer.ts
@@ -55,7 +55,7 @@ export function transformLLMConfigToLlmsConfig(
 ): LlmsConfig {
   const llms: Record<string, string> = {};
   const isMCPJamModel = modelId && isMCPJamProvidedModel(modelId);
-  
+
   if (isMCPJamModel) {
     llms.openrouter = "BACKEND_EXECUTION";
   } else {

--- a/server/utils/eval-transformer.ts
+++ b/server/utils/eval-transformer.ts
@@ -49,15 +49,20 @@ export function transformServerConfigsToEnvironment(
 /**
  * Transforms LLM configuration from UI format to LlmsConfig format
  */
-export function transformLLMConfigToLlmsConfig(llmConfig: {
-  provider: string;
-  apiKey: string;
-}): LlmsConfig {
+export function transformLLMConfigToLlmsConfig(
+  llmConfig: {
+    provider: string;
+    apiKey: string;
+  },
+  modelId?: string,
+): LlmsConfig {
   const llms: Record<string, string> = {};
 
   // MCPJam-provided models use backend execution, so we use a special marker
   // that will pass validation but won't be used (backend has the actual key)
-  if (isMCPJamProvidedModel(llmConfig.provider as any)) {
+  const isMCPJamModel = modelId && isMCPJamProvidedModel(modelId);
+  
+  if (isMCPJamModel) {
     llms.openrouter = "BACKEND_EXECUTION";
   } else {
     // Map provider names to expected format

--- a/server/utils/eval-transformer.ts
+++ b/server/utils/eval-transformer.ts
@@ -46,9 +46,6 @@ export function transformServerConfigsToEnvironment(
   };
 }
 
-/**
- * Transforms LLM configuration from UI format to LlmsConfig format
- */
 export function transformLLMConfigToLlmsConfig(
   llmConfig: {
     provider: string;
@@ -57,20 +54,15 @@ export function transformLLMConfigToLlmsConfig(
   modelId?: string,
 ): LlmsConfig {
   const llms: Record<string, string> = {};
-
-  // MCPJam-provided models use backend execution, so we use a special marker
-  // that will pass validation but won't be used (backend has the actual key)
   const isMCPJamModel = modelId && isMCPJamProvidedModel(modelId);
   
   if (isMCPJamModel) {
     llms.openrouter = "BACKEND_EXECUTION";
   } else {
-    // Map provider names to expected format
     const providerKey = llmConfig.provider.toLowerCase();
     llms[providerKey] = llmConfig.apiKey;
   }
 
-  // Validate the result
   const validated = LlmsConfigSchema.safeParse(llms);
   if (!validated.success) {
     throw new Error(`Invalid LLM configuration: ${validated.error.message}`);

--- a/shared/backend-conversation.ts
+++ b/shared/backend-conversation.ts
@@ -4,7 +4,7 @@ import { hasUnresolvedToolCalls } from "./http-tool-calls";
 export type BackendFetchPayload = {
   tools: Tool[];
   messages: string;
-  model?: string; // Model ID for MCPJam-provided models
+  model?: string;
 };
 
 export type BackendFetchResponse = {

--- a/shared/backend-conversation.ts
+++ b/shared/backend-conversation.ts
@@ -4,6 +4,7 @@ import { hasUnresolvedToolCalls } from "./http-tool-calls";
 export type BackendFetchPayload = {
   tools: Tool[];
   messages: string;
+  model?: string; // Model ID for MCPJam-provided models
 };
 
 export type BackendFetchResponse = {
@@ -39,6 +40,7 @@ export type BackendConversationOptions = {
   maxSteps: number;
   messageHistory: ModelMessage[];
   toolDefinitions: Tool[];
+  modelId?: string;
   executeToolCalls: (messages: ModelMessage[]) => Promise<void>;
   fetchBackend: (
     payload: BackendFetchPayload,
@@ -73,6 +75,7 @@ export const runBackendConversation = async (
     const payload: BackendFetchPayload = {
       tools: options.toolDefinitions,
       messages: JSON.stringify(options.messageHistory),
+      model: options.modelId,
     };
     const data = await options.fetchBackend(payload);
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -105,10 +105,15 @@ export type ModelProvider =
   | "google"
   | "meta";
 
-// Helper to check if a provider is MCPJam-provided (requires backend execution)
-export const isMCPJamProvidedModel = (provider: ModelProvider): boolean => {
-  const MCPJAM_PROVIDERS: ModelProvider[] = ["meta"];
-  return MCPJAM_PROVIDERS.includes(provider);
+// List of specific model IDs that are MCPJam-provided (requires backend execution)
+const MCPJAM_PROVIDED_MODEL_IDS: string[] = [
+  "meta-llama/llama-3.3-70b-instruct",
+  "openai/gpt-oss-120b",
+];
+
+// Helper to check if a model is MCPJam-provided (requires backend execution)
+export const isMCPJamProvidedModel = (modelId: string): boolean => {
+  return MCPJAM_PROVIDED_MODEL_IDS.includes(modelId);
 };
 
 export interface ModelDefinition {
@@ -235,6 +240,11 @@ export const SUPPORTED_MODELS: ModelDefinition[] = [
     id: "meta-llama/llama-3.3-70b-instruct",
     name: "Llama 3.3 70B (Free)",
     provider: "meta",
+  },
+  {
+    id: "openai/gpt-oss-120b",
+    name: "GPT-OSS 120B (Free)",
+    provider: "openai",
   },
 ];
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -105,13 +105,11 @@ export type ModelProvider =
   | "google"
   | "meta";
 
-// List of specific model IDs that are MCPJam-provided (requires backend execution)
 const MCPJAM_PROVIDED_MODEL_IDS: string[] = [
   "meta-llama/llama-3.3-70b-instruct",
   "openai/gpt-oss-120b",
 ];
 
-// Helper to check if a model is MCPJam-provided (requires backend execution)
 export const isMCPJamProvidedModel = (modelId: string): boolean => {
   return MCPJAM_PROVIDED_MODEL_IDS.includes(modelId);
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds GPT-OSS 120B (free) and refactors MCPJam-provided model handling to be based on explicit model IDs, wiring modelId through chat/evals backends and UI filtering/auth.
> 
> - **Models**
>   - Add `openai/gpt-oss-120b` (GPT-OSS 120B) to `SUPPORTED_MODELS` and mark as MCPJam-provided.
>   - Change `isMCPJamProvidedModel` to accept `modelId` and use an explicit allowlist of MCPJam-provided IDs.
> - **Chat/UI**
>   - Use `model.id` (not provider) to detect MCPJam-provided models in `ChatTab`, model selector, and routing decisions.
>   - Model selector groups/providers now filter by MCPJam-provided status per-model; disables items and sign-in prompts accordingly.
>   - Availability logic: include MCPJam-provided models regardless of user API keys; adjust meta handling.
> - **Backend & Evals**
>   - Plumb `modelId` through backend conversation (`BackendFetchPayload`, `runBackendConversation`) and server routes (`/mcp/chat`, backend streaming helpers).
>   - Evals: determine backend usage via `isMCPJamProvidedModel(test.model)`; send `modelId` to backend; transform LLM config based on `modelId`.
>   - Eval test generation sets the backend model explicitly (`meta-llama/llama-3.3-70b-instruct`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 438d0dadc11feafc31d64dc01e681395facdcaa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->