### PR TITLE
fix: convert playground chat to flex layout to constrain height

### DIFF
--- a/client/src/components/ChatTab.tsx
+++ b/client/src/components/ChatTab.tsx
@@ -380,12 +380,12 @@ export function ChatTab({
       <ResizablePanelGroup direction="horizontal" className="h-screen">
         {/* Main Chat Panel */}
         <ResizablePanel defaultSize={70} minSize={40}>
-          <div className="relative bg-background h-full overflow-hidden">
+          <div className="flex flex-col bg-background h-full overflow-hidden">
             {/* Messages Area - Scrollable with bottom padding for input */}
             <div
               ref={messagesContainerRef}
               onScroll={handleScroll}
-              className="h-full overflow-y-auto pb-40"
+              className="flex-1 overflow-y-auto pb-4"
             >
               <div className="max-w-4xl mx-auto px-4 pt-8 pb-8">
                 <AnimatePresence mode="popLayout">
@@ -447,14 +447,14 @@ export function ChatTab({
               </div>
             </div>
 
-            {/* Error Display - Absolute positioned above input */}
+            {/* Error Display */}
             <AnimatePresence>
               {error && (
                 <motion.div
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: 20 }}
-                  className="absolute bottom-40 left-0 right-0 px-4 py-3 bg-destructive/5 border-t border-destructive/10 z-10"
+                  className="px-4 py-3 bg-destructive/5 border-t border-destructive/10"
                 >
                   <div className="max-w-4xl mx-auto">
                     <p className="text-sm text-destructive">{error}</p>
@@ -463,8 +463,8 @@ export function ChatTab({
               )}
             </AnimatePresence>
 
-            {/* Fixed Bottom Input - Absolute positioned */}
-            <div className="absolute bottom-0 left-0 right-0 border-t border-border/50 bg-background/80 backdrop-blur-sm">
+            {/* Fixed Bottom Input */}
+            <div className="border-t border-border/50 bg-background/80 backdrop-blur-sm flex-shrink-0">
               <div className="max-w-4xl mx-auto p-4">
                 <div>
                   <ChatInput


### PR DESCRIPTION
## Summary
- Fixed the playground component height issue where long conversations would extend the UI indefinitely
- Changed from absolute positioning to flexbox layout for proper height constraints
- Messages area now properly scrolls within available space while keeping input fixed at bottom

## Changes Made
1. **Parent container**: Changed from `relative` to `flex flex-col` to establish flexbox context
2. **Messages area**: Changed from `h-full` to `flex-1` so it takes available space and scrolls properly
3. **Input area**: Added `flex-shrink-0` to keep it fixed at the bottom without growing
4. **Error display**: Removed absolute positioning, now part of flex flow

## Technical Details
The previous implementation used:
- Absolute positioning for both error display and input
- `h-full` on messages container causing unlimited height growth
- Large padding (`pb-40`) to account for fixed input

New implementation uses:
- Flexbox with `flex-col` on parent
- `flex-1` on messages for flexible scrolling area
- `flex-shrink-0` on input to maintain fixed height
- Natural flow for error messages

## Test Plan
- [ ] Open the playground with a connected MCP server
- [ ] Send multiple messages to create a long conversation
- [ ] Verify the messages area scrolls properly without breaking the UI
- [ ] Verify the input stays fixed at the bottom
- [ ] Verify error messages display correctly

Fixes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces absolute-positioned chat layout with flexbox so messages scroll within `flex-1` and input/error sit correctly at the bottom.
> 
> - **Frontend – Chat layout (`client/src/components/ChatTab.tsx`)**:
>   - **Container**: `relative` -> `flex flex-col` for flex context.
>   - **Messages area**: `h-full pb-40` -> `flex-1 pb-4` for proper scrolling.
>   - **Error display**: removed absolute positioning; now in normal flow.
>   - **Input bar**: removed absolute positioning; added `flex-shrink-0` to keep fixed at bottom; retains border/backdrop styles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d4108df1b7cc41001c77ff7e35114d99ed17802. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

📎 **Task**: https://www.terragonlabs.com/task/efef5487-4db0-4aea-ade8-0681394f2949