### PR TITLE
fix: temporarily disable interceptor feature

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,7 +8,7 @@ import { EvalsResultsTab } from "./components/EvalsResultsTab";
 import { EvalsRunTab } from "./components/EvalsRunTab";
 import { SettingsTab } from "./components/SettingsTab";
 import { TracingTab } from "./components/TracingTab";
-import { InterceptorTab } from "./components/InterceptorTab";
+// import { InterceptorTab } from "./components/InterceptorTab"; // Temporarily disabled
 import { AuthTab } from "./components/AuthTab";
 import OAuthDebugCallback from "./components/OAuthDebugCallback";
 import { MCPSidebar } from "./components/mcp-sidebar";
@@ -155,13 +155,12 @@ export default function App() {
           </header>
 
           <div className="flex-1">
-            {/* Active Server Selector - Only show on Tools, Resources, Prompts, Auth, and Interceptor pages */}
+            {/* Active Server Selector - Only show on Tools, Resources, Prompts, Auth, and Chat pages */}
             {(activeTab === "tools" ||
               activeTab === "resources" ||
               activeTab === "prompts" ||
               activeTab === "auth" ||
-              activeTab === "chat" ||
-              activeTab === "interceptor") && (
+              activeTab === "chat") && (
               <ActiveServerSelector
                 connectedServerConfigs={connectedServerConfigs}
                 selectedServer={appState.selectedServer}
@@ -222,12 +221,13 @@ export default function App() {
               />
             )}
 
-            {activeTab === "interceptor" && (
+            {/* Temporarily disabled interceptor feature */}
+            {/* {activeTab === "interceptor" && (
               <InterceptorTab
                 connectedServerConfigs={connectedServerConfigs}
                 selectedServer={appState.selectedServer}
               />
-            )}
+            )} */}
 
             {activeTab === "tracing" && <TracingTab />}
 


### PR DESCRIPTION
## Summary
- Temporarily disables the interceptor tab as requested in issue #673
- The Run evals and Eval results tabs remain in their own evals section in the sidebar
- All interceptor-related code is commented out for easy re-enabling in the future

## Changes Made
- Commented out `InterceptorTab` import in `client/src/App.tsx`
- Removed `interceptor` from the ActiveServerSelector condition
- Commented out interceptor tab rendering logic

## Test plan
- [x] Build completes successfully
- [x] No TypeScript errors
- [ ] Verify interceptor tab is no longer accessible
- [ ] Verify Run evals and Eval results tabs still work correctly
- [ ] Verify other tabs (Tools, Resources, Prompts, Auth, Chat) still function properly

Fixes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables the `InterceptorTab` by commenting out its import and rendering, and removes `interceptor` from the `ActiveServerSelector` condition while keeping `chat` enabled.
> 
> - **App UI (`client/src/App.tsx`)**:
>   - Comment out `InterceptorTab` import and its render block.
>   - Remove `interceptor` from `ActiveServerSelector` visibility condition; keep `chat` in condition.
>   - Update inline comments to note the interceptor feature is temporarily disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0de1379ce34863cbe5c7108b3d39bd9be1645219. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->