### PR TITLE
client: keep Playground input fixed

### DIFF
--- a/client/src/components/ChatTab.tsx
+++ b/client/src/components/ChatTab.tsx
@@ -36,7 +36,6 @@ export function ChatTab({
 }: ChatTabProps) {
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const [isAtBottom, setIsAtBottom] = useState(true);
-  const chatPanelRef = useRef<HTMLDivElement>(null);
   const { isAuthenticated } = useConvexAuth();
   const { signUp } = useAuth();
   const posthog = usePostHog();
@@ -90,7 +89,6 @@ export function ChatTab({
     }
   }, [showSignInPrompt, setInput]);
 
-  // CSS-only layout; no JS sizing for the footer
 
   // Restore model from localStorage on mount
   useEffect(() => {
@@ -157,8 +155,7 @@ export function ChatTab({
       icon: Sparkles,
     },
   ];
-  // Keep bottom padding minimal when thread is short; add space when long/streaming
-  const bottomPaddingClass = (messages.length > 2 || isLoading) ? "pb-16" : "pb-2";
+  // No JS needed; layout keeps input pinned
   // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
     if (isAtBottom && messagesContainerRef.current) {
@@ -388,15 +385,14 @@ export function ChatTab({
       >
         {/* Main Chat Panel */}
         <ResizablePanel defaultSize={70} minSize={40}>
-          <div ref={chatPanelRef} className="grid bg-background h-full min-h-0 overflow-hidden grid-rows-[1fr_auto]">
-            {/* Messages Area - only scrollable region */
-            }
+          <div className="relative h-full bg-background overflow-hidden">
+            {/* Messages Area - scrollable with bottom padding for input */}
             <div
               ref={messagesContainerRef}
               onScroll={handleScroll}
-              className="min-h-0 overflow-y-auto"
+              className="absolute inset-0 overflow-y-auto pb-32"
             >
-              <div className={`max-w-4xl mx-auto px-4 pt-8 pb-4`}>
+              <div className="max-w-4xl mx-auto px-4 pt-8 pb-8">
                 <AnimatePresence mode="popLayout">
                   {messages.map((message, index) => (
                     <motion.div
@@ -469,47 +465,46 @@ export function ChatTab({
                   </motion.div>
                 )}
               </AnimatePresence>
-
             </div>
 
-            {/* Bottom input row (pinned by grid, full panel width) */}
-            <div className="border-t border-border/50 bg-background/90 backdrop-blur-sm">
-              <div className="w-full px-4 py-4">
+            {/* Input footer - absolutely positioned at bottom */}
+            <div className="absolute bottom-0 left-0 right-0 border-t border-border/50 bg-background">
+              <div className="max-w-4xl mx-auto px-4 py-4">
                 <ChatInput
-                  value={input}
-                  onChange={setInput}
-                  onSubmit={(message, attachments) => {
-                    posthog.capture("send_message", {
-                      location: "chat_tab",
-                      platform: detectPlatform(),
-                      environment: detectEnvironment(),
-                      model_id: model?.id ?? null,
-                      model_name: model?.name ?? null,
-                      model_provider: model?.provider ?? null,
-                    });
-                    sendMessage(message, attachments);
-                  }}
-                  onStop={stopGeneration}
-                  disabled={
-                    availableModels.length === 0 ||
-                    noServersConnected ||
-                    showSignInPrompt
-                  }
-                  isLoading={isLoading}
-                  placeholder={
-                    showSignInPrompt ? signInPromptMessage : "Send a message..."
-                  }
-                  className="border-2 shadow-sm"
-                  currentModel={model}
-                  availableModels={availableModels}
-                  onModelChange={setModel}
-                  onClearChat={clearChat}
-                  hasMessages={hasMessages}
-                  systemPrompt={systemPromptState}
-                  onSystemPromptChange={setSystemPromptState}
-                  temperature={temperatureState}
-                  onTemperatureChange={setTemperatureState}
-                  isSendBlocked={showSignInPrompt}
+                value={input}
+                onChange={setInput}
+                onSubmit={(message, attachments) => {
+                  posthog.capture("send_message", {
+                    location: "chat_tab",
+                    platform: detectPlatform(),
+                    environment: detectEnvironment(),
+                    model_id: model?.id ?? null,
+                    model_name: model?.name ?? null,
+                    model_provider: model?.provider ?? null,
+                  });
+                  sendMessage(message, attachments);
+                }}
+                onStop={stopGeneration}
+                disabled={
+                  availableModels.length === 0 ||
+                  noServersConnected ||
+                  showSignInPrompt
+                }
+                isLoading={isLoading}
+                placeholder={
+                  showSignInPrompt ? signInPromptMessage : "Send a message..."
+                }
+                className="border-2 shadow-sm w-full"
+                currentModel={model}
+                availableModels={availableModels}
+                onModelChange={setModel}
+                onClearChat={clearChat}
+                hasMessages={hasMessages}
+                systemPrompt={systemPromptState}
+                onSystemPromptChange={setSystemPromptState}
+                temperature={temperatureState}
+                onTemperatureChange={setTemperatureState}
+                isSendBlocked={showSignInPrompt}
                 />
               </div>
             </div>


### PR DESCRIPTION
_Note:My earlier “input fixed” comment was from unpushed local changes. I’ve now pushed the actual fix on a clean branch (commit 31fad3a6) and re‑verified; videos match this PR._
**_Refs #672_**


**Verification (local)**
Environment: macOS (darwin 22.5.0), client localhost:3000, API localhost:3001, one AI provider key set.
Repro: Open Playground with server-everything (STDIO), send many messages to create a long thread, observe chat behavior during/after streaming.

**Before:**
[x] Open the playground with a connected MCP server — Loaded Playground; server-everything connected.
[x] Send multiple messages to create a long conversation — Long thread created via repeated text sends.
[x] Verify the messages area scrolls properly without breaking the UI — Older messages scroll off the top; messages column gets its own vertical scrollbar; page does not grow.
[ ] Verify the input stays fixed at the bottom — Input bar doesn’t stay pinned; during long threads/streaming it scrolls off‑screen.
[x] Verify error messages display correctly — Error bubbles render inline with consistent spacing; no overlap with input; they scroll with the thread.

https://github.com/user-attachments/assets/59c5f847-5bc6-4a9c-aba8-20de4acc9068



**After**
[x] Open the playground with a connected MCP server — Loaded Playground; server-everything connected.
[x] Send multiple messages to create a long conversation — Long thread created via repeated text sends.
[x] Verify the messages area scrolls properly without breaking the UI — Older messages scroll off the top; messages column gets its own vertical scrollbar; page does not grow.
[x] Verify the input stays fixed at the bottom — Input bar now fixed to bottom; thread scrolls behind it.
[x] Verify error messages display correctly — Error bubbles render inline with consistent spacing; no overlap with input; they scroll with the thread.

https://github.com/user-attachments/assets/e9a44656-77ac-45f9-9120-4088de1d9e3c