### PR TITLE
Bundle all dependencies

### DIFF
--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -18,18 +18,9 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
-        // Core Electron & Node modules
+        // Core Electron & Node modules only
         "electron",
-        // External runtime dependencies (must be in package.json dependencies)
-        "@hono/node-server",
-        "hono",
-        "@modelcontextprotocol/sdk",
-        "fix-path",
-        "dotenv",
-        "electron-log",
-        "update-electron-app",
-        "@sentry/electron",
-        // @/sdk and @/shared will be bundled (not marked as external)
+        // Bundle everything else including electron-log, update-electron-app, etc.
       ],
     },
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update Vite main config to only mark `electron` as external, bundling all other dependencies.
> 
> - **Build**:
>   - **Vite main config (`vite.main.config.ts`)**:
>     - Restricts `rollupOptions.external` to only `electron` (Core Electron & Node modules only).
>     - Bundles all other runtime dependencies (e.g., `electron-log`, `update-electron-app`, etc.).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ec59b532dd3bfe886a2ee22577b8ec5f046fb0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->