### PR TITLE
feat: Add xAI provider support

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,6 +13,7 @@
         "@ai-sdk/google": "^2.0.11",
         "@ai-sdk/mistral": "^2.0.19",
         "@ai-sdk/openai": "^2.0.32",
+        "@ai-sdk/xai": "^1.0.7",
         "@hono/node-server": "^1.13.7",
         "@mastra/core": "0.18.0",
         "@mastra/mcp": "0.13.1",
@@ -237,6 +238,74 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@ai-sdk/xai": {
+      "version": "1.2.18",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/xai/-/xai-1.2.18.tgz",
+      "integrity": "sha512-T70WEu+UKXD/Fdj9ck+ujIqUp5ru06mJ/7usePXeXL5EeTi8KXevXF9AMIDdhyD5MZPT2jI8t19lEr8Bhuh/Bg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/openai-compatible": "0.2.16",
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/xai/node_modules/@ai-sdk/openai-compatible": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-0.2.16.tgz",
+      "integrity": "sha512-LkvfcM8slJedRyJa/MiMiaOzcMjV1zNDwzTHEGz7aAsgsQV0maLfmJRi/nuSwf5jmp0EouC+JXXDUj2l94HgQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/xai/node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/xai/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/xai/node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
       "version": "14.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
     "@ai-sdk/google": "^2.0.11",
     "@ai-sdk/mistral": "^2.0.19",
     "@ai-sdk/openai": "^2.0.32",
+    "@ai-sdk/xai": "^1.0.7",
     "@hono/node-server": "^1.13.7",
     "@mastra/core": "0.18.0",
     "@mastra/mcp": "0.13.1",

--- a/server/utils/chat-helpers.ts
+++ b/server/utils/chat-helpers.ts
@@ -4,6 +4,7 @@ import { createDeepSeek } from "@ai-sdk/deepseek";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createMistral } from "@ai-sdk/mistral";
 import { createOpenAI } from "@ai-sdk/openai";
+import { createXai } from "@ai-sdk/xai";
 import { createOllama } from "ollama-ai-provider-v2";
 
 export const createLlmModel = (
@@ -36,6 +37,8 @@ export const createLlmModel = (
     }
     case "mistral":
       return createMistral({ apiKey })(modelDefinition.id);
+    case "xai":
+      return createXai({ apiKey })(modelDefinition.id);
     case "litellm": {
       // LiteLLM uses OpenAI-compatible endpoints (standard chat completions API)
       const baseURL = litellmBaseUrl || "http://localhost:4000";

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -105,6 +105,7 @@ export type ModelProvider =
   | "google"
   | "meta"
   | "x-ai"
+  | "xai"
   | "litellm"
   | "mistral";
 
@@ -170,6 +171,23 @@ export enum Model {
   CODESTRAL_LATEST = "codestral-latest",
   MINISTRAL_8B_LATEST = "ministral-8b-latest",
   MINISTRAL_3B_LATEST = "ministral-3b-latest",
+  // xAI models
+  GROK_4_FAST_NON_REASONING = "grok-4-fast-non-reasoning",
+  GROK_4_FAST_REASONING = "grok-4-fast-reasoning",
+  GROK_CODE_FAST_1 = "grok-code-fast-1",
+  GROK_4 = "grok-4",
+  GROK_3 = "grok-3",
+  GROK_3_LATEST = "grok-3-latest",
+  GROK_3_FAST = "grok-3-fast",
+  GROK_3_FAST_LATEST = "grok-3-fast-latest",
+  GROK_3_MINI = "grok-3-mini",
+  GROK_3_MINI_LATEST = "grok-3-mini-latest",
+  GROK_3_MINI_FAST = "grok-3-mini-fast",
+  GROK_3_MINI_FAST_LATEST = "grok-3-mini-fast-latest",
+  GROK_2 = "grok-2",
+  GROK_2_LATEST = "grok-2-latest",
+  GROK_2_VISION = "grok-2-vision",
+  GROK_2_VISION_LATEST = "grok-2-vision-latest",
 }
 
 export const SUPPORTED_MODELS: ModelDefinition[] = [
@@ -290,6 +308,87 @@ export const SUPPORTED_MODELS: ModelDefinition[] = [
     id: Model.MINISTRAL_3B_LATEST,
     name: "Ministral 3B",
     provider: "mistral",
+  },
+  // xAI models
+  {
+    id: Model.GROK_4_FAST_NON_REASONING,
+    name: "Grok 4 Fast (Non-Reasoning)",
+    provider: "xai",
+  },
+  {
+    id: Model.GROK_4_FAST_REASONING,
+    name: "Grok 4 Fast (Reasoning)",
+    provider: "xai",
+  },
+  {
+    id: Model.GROK_CODE_FAST_1,
+    name: "Grok Code Fast 1",
+    provider: "xai",
+  },
+  {
+    id: Model.GROK_4,
+    name: "Grok 4",
+    provider: "xai",
+  },
+  {
+    id: Model.GROK_3,
+    name: "Grok 3",
+    provider: "xai",
+  },
+  {
+    id: Model.GROK_3_LATEST,
+    name: "Grok 3 (Latest)",
+    provider: "xai",
+  },
+  {
+    id: Model.GROK_3_FAST,
+    name: "Grok 3 Fast",
+    provider: "xai",
+  },
+  {
+    id: Model.GROK_3_FAST_LATEST,
+    name: "Grok 3 Fast (Latest)",
+    provider: "xai",
+  },
+  {
+    id: Model.GROK_3_MINI,
+    name: "Grok 3 Mini",
+    provider: "xai",
+  },
+  {
+    id: Model.GROK_3_MINI_LATEST,
+    name: "Grok 3 Mini (Latest)",
+    provider: "xai",
+  },
+  {
+    id: Model.GROK_3_MINI_FAST,
+    name: "Grok 3 Mini Fast",
+    provider: "xai",
+  },
+  {
+    id: Model.GROK_3_MINI_FAST_LATEST,
+    name: "Grok 3 Mini Fast (Latest)",
+    provider: "xai",
+  },
+  {
+    id: Model.GROK_2,
+    name: "Grok 2",
+    provider: "xai",
+  },
+  {
+    id: Model.GROK_2_LATEST,
+    name: "Grok 2 (Latest)",
+    provider: "xai",
+  },
+  {
+    id: Model.GROK_2_VISION,
+    name: "Grok 2 Vision",
+    provider: "xai",
+  },
+  {
+    id: Model.GROK_2_VISION_LATEST,
+    name: "Grok 2 Vision (Latest)",
+    provider: "xai",
   },
 ];
 


### PR DESCRIPTION
## Summary

Adds xAI (Grok) models support to MCPJam Inspector, resolving issue #702.

This PR implements xAI provider integration following the same pattern as Mistral and other providers, making all Grok models available in the playground.

## Changes Made

### 1. Package Dependency
- ✅ Added `@ai-sdk/xai` version 1.0.7 to `server/package.json`
- ✅ Ran `npm install --legacy-peer-deps` successfully

### 2. Provider Integration
- ✅ Imported `createXai` from `@ai-sdk/xai` in `server/utils/chat-helpers.ts`
- ✅ Added xAI case to the `createLlmModel` function switch statement

### 3. Type Definitions
- ✅ Added `"xai"` to the `ModelProvider` type in `shared/types.ts`
- ✅ Added 16 Grok model enum values to the `Model` enum

### 4. Model Definitions
Added the following xAI models to `SUPPORTED_MODELS` array:

**Grok 4 Models:**
- Grok 4 Fast (Non-Reasoning) - `grok-4-fast-non-reasoning`
- Grok 4 Fast (Reasoning) - `grok-4-fast-reasoning`
- Grok Code Fast 1 - `grok-code-fast-1`
- Grok 4 - `grok-4`

**Grok 3 Models:**
- Grok 3 - `grok-3`
- Grok 3 (Latest) - `grok-3-latest`
- Grok 3 Fast - `grok-3-fast`
- Grok 3 Fast (Latest) - `grok-3-fast-latest`
- Grok 3 Mini - `grok-3-mini`
- Grok 3 Mini (Latest) - `grok-3-mini-latest`
- Grok 3 Mini Fast - `grok-3-mini-fast`
- Grok 3 Mini Fast (Latest) - `grok-3-mini-fast-latest`

**Grok 2 Models:**
- Grok 2 - `grok-2`
- Grok 2 (Latest) - `grok-2-latest`
- Grok 2 Vision - `grok-2-vision`
- Grok 2 Vision (Latest) - `grok-2-vision-latest`

## Testing

- ✅ TypeScript compilation verified - no errors in modified files
- ✅ Dependencies installed successfully
- ✅ Follows the established pattern from Mistral PR #701

## Files Changed

- `server/package.json` - Added dependency
- `server/package-lock.json` - Lockfile updated
- `server/utils/chat-helpers.ts` - Added provider integration
- `shared/types.ts` - Added type definitions and models

## Reference

- Issue: Closes #702
- Reference Implementation: #701 (Mistral provider)
- AI SDK Documentation: https://ai-sdk.dev/providers/ai-sdk-providers/xai

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds xAI provider integration and registers Grok models, enabling xAI-backed chat models.
> 
> - **Backend**
>   - **Provider integration**: Import `createXai` and add `"xai"` case in `server/utils/chat-helpers.ts` to create models via `@ai-sdk/xai`.
> - **Types/Models**
>   - Extend `ModelProvider` with `"xai"` in `shared/types.ts`.
>   - Add Grok model enums (Grok 4/3/2 variants, including vision) and register them in `SUPPORTED_MODELS`.
> - **Dependencies**
>   - Add `@ai-sdk/xai` to `server/package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb8a434f33877612fe1e33db981ad10ea4a7d584. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->