### PR TITLE
Change dark mode bg to match app bg

### DIFF
--- a/client/src/components/chat/openai-component-renderer.tsx
+++ b/client/src/components/chat/openai-component-renderer.tsx
@@ -224,7 +224,7 @@ export function OpenAIComponentRenderer({
         <iframe
           ref={iframeRef}
           src={widgetUrl}
-          className="w-full border rounded-md bg-white dark:bg-gray-900"
+          className="w-full border rounded-md bg-background"
           style={{
             minHeight: "400px",
             height: "600px",


### PR DESCRIPTION
This pull request makes a minor update to the styling of the OpenAI component renderer. The background color class for the embedded iframe has been changed to use the theme variable, improving consistency.

* Updated the `className` for the iframe in `openai-component-renderer.tsx` to use `bg-background` instead of hardcoded `bg-white dark:bg-gray-900`, ensuring better alignment with global theme variables. Fixes #732