### PR TITLE
Allow structured content to be null, if none is returned

### DIFF
--- a/client/src/components/chat/openai-component-renderer.tsx
+++ b/client/src/components/chat/openai-component-renderer.tsx
@@ -65,11 +65,6 @@ export function OpenAIComponentRenderer({
           }
         }
 
-        // Fallback to entire result if nothing else found
-        if (!structuredContent) {
-          structuredContent = result;
-        }
-
         // Extract _meta field (toolResponseMetadata)
         // _meta is delivered only to the component (hidden from model)
         toolResponseMetadata = result._meta ?? null;


### PR DESCRIPTION
Fixes #731

This pull request makes a small change to the `OpenAIComponentRenderer` function, removing the fallback logic that would use the entire result as structured content if no other content was found. This streamlines how structured content is determined from the result.