### PR TITLE
Handle theme updates from inspector into the iframe for MCP apps

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -437,7 +437,7 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
   }
 
   return (
-    <div className="h-[calc(100vh-120px)] flex flex-col">
+    <div className="h-full flex flex-col">
       <ResizablePanelGroup direction="vertical" className="flex-1">
         <ResizablePanel defaultSize={70} minSize={30}>
           <ResizablePanelGroup direction="horizontal" className="h-full">

--- a/client/src/components/chat/openai-component-renderer.tsx
+++ b/client/src/components/chat/openai-component-renderer.tsx
@@ -39,6 +39,16 @@ export function OpenAIComponentRenderer({
   // Storage key for widget state
   const widgetStateKey = `openai-widget-state:${toolCall.name}:${toolCall.id}`;
 
+  const setIframeDocumentTheme = (iframe) => {
+    try {
+      iframe.document.documentElement.classList.toggle("dark", themeMode === "dark");
+    } catch (err) {
+      console.debug("Unable to access iframe document (likely cross-origin):", err);
+    }
+  }
+
+  setIframeDocumentTheme(iframeRef.current?.contentWindow);
+
   // Store widget data server-side
   useEffect(() => {
     if (componentUrl.startsWith("ui://") && serverId) {
@@ -226,11 +236,7 @@ export function OpenAIComponentRenderer({
     );
 
     // Handle sending theme updates to the iframe document
-    try {
-      iframeWindow.document.documentElement.classList.toggle("dark", themeMode === "dark");
-    } catch (err) {
-      console.debug("Unable to access iframe document (likely cross-origin):", err);
-    }
+    setIframeDocumentTheme(iframeWindow);
   }, [themeMode, isReady]);
 
   return (


### PR DESCRIPTION
Fixes #742
This pull request updates the way theme changes are communicated and applied to the iframe in the `OpenAIComponentRenderer` component. In addition to posting a message to the iframe window, it now directly toggles the `dark` class on the iframe's root HTML element to ensure the theme is correctly reflected.

Improvements to theme synchronization:

* [`client/src/components/chat/openai-component-renderer.tsx`](diffhunk://#diff-97ea85b10b1f10188c0ebd68b6d0945c09f926468ced48c334620973a166eb73R215-R218): Refactored iframe window access for clarity and maintainability, and added logic to toggle the `dark` class on the iframe's HTML element based on the current theme mode. This ensures the iframe's appearance matches the selected theme. [[1]](diffhunk://#diff-97ea85b10b1f10188c0ebd68b6d0945c09f926468ced48c334620973a166eb73R215-R218) [[2]](diffhunk://#diff-97ea85b10b1f10188c0ebd68b6d0945c09f926468ced48c334620973a166eb73R227-R236)