### PR TITLE
Move the resources result to the results panel

### DIFF
--- a/client/src/components/ResourcesTab.tsx
+++ b/client/src/components/ResourcesTab.tsx
@@ -74,8 +74,6 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
         } else if (
           !serverResources.some((resource) => resource.uri === selectedResource)
         ) {
-          // TODO: Revisit NOT setting a default resource on load
-          // setSelectedResource(serverResources[0].uri);
           setResourceContent(null);
         }
       } else {


### PR DESCRIPTION
### Summary
The result of reading an MCP resource now displays in the results panel located in the bottom right, aligning with the behavior of other tabs. This change enhances the user experience by providing a consistent location for results across the application.

Fixes #729

### Screenshot
![image](https://github.com/user-attachments/assets/bc6425b1-6501-4622-b39c-d595e90b4062)
