### PR TITLE
Add request timeout configuration to ServerModal and related types

### DIFF
--- a/client/src/state/server-helpers.ts
+++ b/client/src/state/server-helpers.ts
@@ -6,14 +6,20 @@ import {
 } from "@/shared/types.js";
 
 export function toMCPConfig(formData: ServerFormData): MCPServerConfig {
+  const baseConfig = {
+    timeout: formData.requestTimeout,
+  };
+
   if (formData.type === "stdio") {
     return {
+      ...baseConfig,
       command: formData.command!,
       args: formData.args,
       env: formData.env,
     } as StdioServerDefinition;
   }
   return {
+    ...baseConfig,
     url: new URL(formData.url!),
     requestInit: { headers: formData.headers || {} },
   } as HttpServerDefinition;

--- a/evals-cli/package-lock.json
+++ b/evals-cli/package-lock.json
@@ -6240,6 +6240,13 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/p-map": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
@@ -6757,6 +6764,16 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -414,6 +414,7 @@ export interface ServerFormData {
   oauthScopes?: string[];
   clientId?: string;
   clientSecret?: string;
+  requestTimeout?: number;
 }
 
 export interface OauthTokens {


### PR DESCRIPTION
Adds a user-configurable request timeout setting for MCP server connections, allowing users to customize timeout values based on their specific use cases and server response times.
### New Features
- ✅ Added **Request Timeout** configuration field in server modal
- ✅ Collapsible **Configuration** section with Settings icon for better UX
- ✅ Input validation with min (1s) and max (10min) constraints
- ✅ Default timeout of 10 seconds (10000ms)
- ✅ Timeout configuration persists across sessions
- ✅ Works for both STDIO and HTTP/SSE server types

Fix: #736 

Demo:

https://github.com/user-attachments/assets/9ccc7e9d-a148-4072-8424-571cc5ddfc71

