### PR TITLE
 Consolidate server and client ports to 6274 and 5173

### DIFF
--- a/bin/start.js
+++ b/bin/start.js
@@ -124,7 +124,7 @@ function isPortAvailable(port) {
   });
 }
 
-async function findAvailablePort(startPort = 3000, maxPort = 65535) {
+async function findAvailablePort(startPort = 6274, maxPort = 65535) {
   logProgress(`Scanning for available ports starting from ${startPort}...`);
 
   for (let port = startPort; port <= maxPort; port++) {

--- a/client/package.json
+++ b/client/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "vite --port 3000",
-    "dev:clean": "rm -rf node_modules/.vite && FORCE_OPTIMIZE=true vite --port 3000",
+    "dev": "vite",
+    "dev:clean": "rm -rf node_modules/.vite && FORCE_OPTIMIZE=true vite",
     "build": "vite build --outDir ../dist/client",
     "build:clean": "rm -rf node_modules/.vite && FORCE_OPTIMIZE=true vite build --outDir ../dist/client",
     "preview": "vite preview"

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "http://localhost:3001",
+        target: "http://localhost:6274",
         changeOrigin: true,
         secure: false,
         ws: true,

--- a/server/app.ts
+++ b/server/app.ts
@@ -91,11 +91,10 @@ export function createHonoApp() {
     "*",
     cors({
       origin: [
-        "http://localhost:8080",
-        "http://localhost:3000",
-        "http://127.0.0.1:3000",
         "http://localhost:5173",
-        "http://localhost:3000",
+        "http://localhost:6274",
+        "http://127.0.0.1:5173",
+        "http://127.0.0.1:6274",
       ],
       credentials: true,
     }),
@@ -124,7 +123,7 @@ export function createHonoApp() {
     app.get("/*", serveStatic({ path: `${root}/index.html` }));
   } else if (isElectron && !isPackaged) {
     // Electron development: redirect any front-end route to the renderer dev server
-    const rendererDevUrl = "http://localhost:8080";
+    const rendererDevUrl = "http://localhost:5173";
     app.get("/*", (c) => {
       const target = new URL(c.req.path, rendererDevUrl).toString();
       return c.redirect(target, 307);
@@ -135,7 +134,7 @@ export function createHonoApp() {
       return c.json({
         message: "MCPJam API Server",
         environment: "development",
-        frontend: "http://localhost:8080",
+        frontend: "http://localhost:5173", // Vite dev server
       });
     });
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -185,10 +185,10 @@ app.use("*", async (c, next) => {
 // Middleware
 app.use("*", logger());
 // Dynamic CORS origin based on PORT environment variable
-const serverPort = process.env.PORT || "3001";
+const serverPort = process.env.PORT || "6274";
 const corsOrigins = [
   `http://localhost:${serverPort}`,
-  "http://localhost:3000", // Keep for frontend development
+  "http://localhost:5173", // Vite dev server (both npm and Electron)
 ];
 
 app.use(
@@ -358,7 +358,7 @@ if (process.env.NODE_ENV === "production") {
   });
 }
 
-const port = parseInt(process.env.PORT || "3001");
+const port = parseInt(process.env.PORT || "6274");
 
 // Default to localhost unless explicitly running in production
 const hostname = process.env.ENVIRONMENT === "dev" ? "localhost" : "127.0.0.1";

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,7 +38,7 @@ let serverPort: number = 0;
 
 const isDev = process.env.NODE_ENV === "development";
 
-async function findAvailablePort(startPort = 3000): Promise<number> {
+async function findAvailablePort(startPort = 6274): Promise<number> {
   return new Promise((resolve, reject) => {
     const net = require("net");
     const server = net.createServer();
@@ -61,7 +61,7 @@ async function findAvailablePort(startPort = 3000): Promise<number> {
 
 async function startHonoServer(): Promise<number> {
   try {
-    const port = app.isPackaged ? 3000 : await findAvailablePort(3000);
+    const port = app.isPackaged ? 6274 : await findAvailablePort(6274);
 
     // Set environment variables to tell the server it's running in Electron
     process.env.ELECTRON_APP = "true";

--- a/vite.renderer.config.mts
+++ b/vite.renderer.config.mts
@@ -24,13 +24,13 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
-      port: 8080,
+      port: 5173,
       hmr: {
-        port: 8081,
+        port: 5174,
       },
       proxy: {
         "/api": {
-          target: "http://localhost:3000", // the port need to be the same as the server port
+          target: "http://localhost:6274", // the port need to be the same as the server port
           changeOrigin: true,
         },
       },


### PR DESCRIPTION
Consolidated scattered port configurations across the application to simplify development and deployment. This PR reduces port complexity from 4+ ports to just 2 standard ports across all runtime modes (NPM dev, NPM prod, Electron dev, Electron packaged).
<img width="604" height="198" alt="Screenshot 2025-11-02 at 11 19 31 AM" src="https://github.com/user-attachments/assets/437fc93c-72a2-4a40-a4c8-3c4b8a404f74" />
