### PR TITLE
fix: remove duplicate close button in MCP server detail modal

### DIFF
--- a/client/src/components/connection/ServerDetailModal.tsx
+++ b/client/src/components/connection/ServerDetailModal.tsx
@@ -57,7 +57,10 @@ export function ServerDetailModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
+      <DialogContent
+        className="max-w-3xl max-h-[80vh] overflow-y-auto"
+        showCloseButton={false}
+      >
         <DialogHeader>
           <div className="flex items-center justify-between">
             <DialogTitle className="text-xl font-semibold flex items-center gap-3">


### PR DESCRIPTION
The DialogContent component was rendering a default close button
in addition to the custom close button in the modal header.
Resolved by setting showCloseButton={false} on DialogContent.

Fix: #772 


Screenshot:
<img width="835" height="459" alt="Screenshot 2025-11-02 at 10 55 56 PM" src="https://github.com/user-attachments/assets/f80b74b9-3687-420e-94d6-fd2f085f69ac" />
