### PR TITLE
keep widgets routing inside iframe

### DIFF
--- a/client/src/components/chat-v2/openai-app-renderer.tsx
+++ b/client/src/components/chat-v2/openai-app-renderer.tsx
@@ -411,7 +411,6 @@ export function OpenAIAppRenderer({
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <base href="/" />
   </head>
   <body>
     ${htmlContent}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes base href from the iframe HTML template so widget routing stays inside the iframe.
> 
> - **Renderer**:
>   - In `client/src/components/chat-v2/openai-app-renderer.tsx`, remove `base href="/"` from the generated iframe HTML template to keep routing scoped within the iframe.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94dfa5d24c8a01e5270213e96d1782faf7916f6d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->