### PR TITLE
fix(ui): Improve playground empty state and fix auth flash

### DIFF
--- a/client/src/components/ChatTabV2.tsx
+++ b/client/src/components/ChatTabV2.tsx
@@ -86,7 +86,7 @@ export function ChatTabV2({
   selectedServerNames,
 }: ChatTabProps) {
   const { getAccessToken, signUp } = useAuth();
-  const { isAuthenticated } = useConvexAuth();
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
   const posthog = usePostHog();
   const {
     hasToken,
@@ -352,8 +352,10 @@ export function ChatTabV2({
     placeholder = "Sign in to use free chat";
   }
 
-  const shouldShowUpsell = disableForAuthentication;
-  const shouldShowConnectCallout = disableForServers && !shouldShowUpsell;
+  // Show loading state while auth is initializing
+  const shouldShowUpsell = disableForAuthentication && !isAuthLoading;
+  const shouldShowConnectCallout =
+    disableForServers && !shouldShowUpsell && !isAuthLoading;
   const showDisabledCallout =
     messages.length === 0 && (shouldShowUpsell || shouldShowConnectCallout);
 
@@ -428,7 +430,8 @@ export function ChatTabV2({
     submitDisabled: submitBlocked,
   };
 
-  const showStarterPrompts = !showDisabledCallout && messages.length === 0;
+  const showStarterPrompts =
+    !showDisabledCallout && messages.length === 0 && !isAuthLoading;
 
   return (
     <div className="flex flex-1 h-full min-h-0 flex-col overflow-hidden">
@@ -441,7 +444,14 @@ export function ChatTabV2({
             {messages.length === 0 ? (
               <div className="flex-1 flex items-center justify-center overflow-y-auto px-4">
                 <div className="w-full max-w-3xl space-y-6 py-8">
-                  {showDisabledCallout && (
+                  {isAuthLoading ? (
+                    <div className="text-center space-y-4">
+                      <div className="mx-auto h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-primary" />
+                      <p className="text-sm text-muted-foreground">
+                        Loading...
+                      </p>
+                    </div>
+                  ) : showDisabledCallout ? (
                     <div className="space-y-4">
                       {shouldShowUpsell ? (
                         <MCPJamFreeModelsPrompt onSignUp={handleSignUp} />
@@ -449,7 +459,7 @@ export function ChatTabV2({
                         <ConnectMcpServerCallout />
                       )}
                     </div>
-                  )}
+                  ) : null}
 
                   <div className="space-y-4">
                     {showStarterPrompts && (
@@ -472,13 +482,18 @@ export function ChatTabV2({
                       </div>
                     )}
 
-                    <ChatInput {...sharedChatInputProps} hasMessages={false} />
+                    {!isAuthLoading && (
+                      <ChatInput
+                        {...sharedChatInputProps}
+                        hasMessages={false}
+                      />
+                    )}
                   </div>
                 </div>
               </div>
             ) : (
               <>
-                <div className="flex flex-1 flex-col min-h-0">
+                <div className="flex flex-1 flex-col min-h-0 animate-in fade-in duration-300">
                   <div className="flex-1 overflow-y-auto">
                     <Thread
                       messages={messages}
@@ -501,7 +516,7 @@ export function ChatTabV2({
                   )}
                 </div>
 
-                <div className="bg-background/80 backdrop-blur-sm border-t border-border flex-shrink-0">
+                <div className="bg-background/80 backdrop-blur-sm border-t border-border flex-shrink-0 animate-in slide-in-from-bottom duration-500">
                   <div className="max-w-4xl mx-auto p-4">
                     <ChatInput {...sharedChatInputProps} hasMessages />
                   </div>


### PR DESCRIPTION
## Changes

- **Enhanced empty state UI** - Added gradient icon, better typography, and improved action cards with hover effects
- **Fixed auth flash** - Added `isAuthLoading` check to prevent upsell message flashing on page refresh
- **Consistent input positioning** - Chat input now stays at bottom in both empty and message states

## Screenshots Before
<img width="1499" height="817" alt="Screenshot 2025-11-04 at 1 49 58 PM" src="https://github.com/user-attachments/assets/531e4d01-aa51-4d92-81e3-2f9691289a5a" />
<img width="1512" height="819" alt="Screenshot 2025-11-04 at 1 48 32 PM" src="https://github.com/user-attachments/assets/46645bfe-03c3-41dd-a5ae-526a61a7c03d" />
<img width="1506" height="813" alt="Screenshot 2025-11-04 at 1 48 26 PM" src="https://github.com/user-attachments/assets/598c21d5-1901-460e-b8ea-6f06701ef9a6" />

## Screenshots After
<img width="1501" height="818" alt="Screenshot 2025-11-04 at 1 54 00 PM" src="https://github.com/user-attachments/assets/77633fbf-761f-4d3a-b836-fedcc6f166a9" />
<img width="1501" height="820" alt="Screenshot 2025-11-04 at 1 53 48 PM" src="https://github.com/user-attachments/assets/20a7f607-20e1-45db-891d-0498caef2d22" />
<img width="1490" height="812" alt="Screenshot 2025-11-04 at 1 53 22 PM" src="https://github.com/user-attachments/assets/a2d760b9-5b62-4c3a-927e-8d76ad9af107" />

