### PR TITLE
chore: migrate tools tab OpenAI App renderer to V2

### DIFF
--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -103,8 +103,6 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
     string,
     unknown
   > | null>(null);
-  const [lastToolCallTimestamp, setLastToolCallTimestamp] =
-    useState<Date | null>(null);
   const [savedRequests, setSavedRequests] = useState<SavedRequest[]>([]);
   const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
   const [editingRequestId, setEditingRequestId] = useState<string | null>(null);
@@ -309,14 +307,12 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
 
     const executionStartTime = Date.now();
     const toolCallId = `tool-${executionStartTime}`;
-    const toolCallTimestamp = new Date();
 
     try {
       const params = buildParameters();
       setLastToolCallId(toolCallId);
       setLastToolName(selectedTool);
       setLastToolParameters(params);
-      setLastToolCallTimestamp(toolCallTimestamp);
 
       const response = await executeToolApi(serverName, selectedTool, params);
       handleExecutionResponse(response, selectedTool, executionStartTime);
@@ -515,7 +511,6 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
                 toolCallId={lastToolCallId ?? undefined}
                 toolName={lastToolName ?? undefined}
                 toolParameters={lastToolParameters ?? undefined}
-                toolCallTimestamp={lastToolCallTimestamp ?? undefined}
                 toolMeta={getToolMeta(lastToolName)}
                 onExecuteFromUI={async (name, params) => {
                   if (!serverName) return { error: "No server selected" };

--- a/client/src/components/tools/ResultsPanel.tsx
+++ b/client/src/components/tools/ResultsPanel.tsx
@@ -2,7 +2,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { ToolExecutionResponse } from "@/lib/mcp-tools-api";
 import { UIResourceRenderer } from "@mcp-ui/client";
 import { CheckCircle, XCircle } from "lucide-react";
-import { OpenAIComponentRenderer } from "../chat/openai-component-renderer";
+import { OpenAIAppRenderer } from "../chat-v2/openai-app-renderer";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
@@ -74,7 +74,6 @@ interface ResultsPanelProps {
   toolCallId?: string;
   toolName?: string;
   toolParameters?: Record<string, unknown>;
-  toolCallTimestamp?: Date;
   toolMeta?: Record<string, any>; // Tool metadata from definition (_meta field)
 }
 
@@ -93,7 +92,6 @@ export function ResultsPanel({
   toolCallId,
   toolName,
   toolParameters,
-  toolCallTimestamp,
   toolMeta,
 }: ResultsPanelProps) {
   const rawResult = result as unknown as Record<string, unknown> | null;
@@ -231,21 +229,15 @@ export function ResultsPanel({
           (() => {
             if (!showStructured && hasOpenAIComponent && openaiOutputTemplate) {
               return (
-                <OpenAIComponentRenderer
-                  componentUrl={openaiOutputTemplate}
-                  toolCall={{
-                    id: toolCallId || "tool-result",
-                    name: toolName || "tool",
-                    parameters: toolParameters || {},
-                    timestamp: toolCallTimestamp || new Date(),
-                    status: "completed",
-                  }}
-                  toolResult={{
-                    id: `${toolCallId || "tool-result"}-result`,
-                    toolCallId: toolCallId || "tool-result",
-                    result: rawResult,
-                    timestamp: new Date(),
-                  }}
+                <OpenAIAppRenderer
+                  serverId={serverId || "unknown-server"}
+                  toolCallId={toolCallId}
+                  toolName={toolName}
+                  toolState="output-available"
+                  toolInput={toolParameters || null}
+                  toolOutput={rawResult}
+                  toolMetadata={toolMeta}
+                  onSendFollowUp={onSendFollowup}
                   onCallTool={async (invocationToolName, params) => {
                     const toolResponse = await onExecuteFromUI(
                       invocationToolName,
@@ -281,8 +273,6 @@ export function ResultsPanel({
                       error: "Elicitation not supported in this context",
                     };
                   }}
-                  onSendFollowup={onSendFollowup}
-                  serverId={serverId}
                 />
               );
             }


### PR DESCRIPTION
* Migrated OpenAI App renderer from V1 to V2 in the Results panel

<img width="1335" height="985" alt="image" src="https://github.com/user-attachments/assets/c542a6d3-d097-4b14-a49b-4899e967dbd4" />
