### PR TITLE
fix: add empty `onprogress` to receive eventual progress notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcpjam/inspector",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcpjam/inspector",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.17",

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -509,13 +509,24 @@ export class MCPClientManager {
   ) {
     await this.ensureConnected(serverId);
     const client = this.getClientById(serverId);
+
+    // Merge global progress handler with any provided options
+    const mergedOptions = this.withTimeout(serverId, options);
+    if (!mergedOptions.onprogress) {
+      mergedOptions.onprogress = () => {
+		// register an empty on progress so that the client will send
+		// progress notifications...the notifications will be sent through the
+		// rpc logger
+	  };
+    }
+
     return client.callTool(
       {
         name: toolName,
         arguments: args,
       },
       CallToolResultSchema,
-      this.withTimeout(serverId, options),
+      mergedOptions,
     );
   }
 
@@ -548,7 +559,16 @@ export class MCPClientManager {
   ) {
     await this.ensureConnected(serverId);
     const client = this.getClientById(serverId);
-    return client.readResource(params, this.withTimeout(serverId, options));
+	 // Merge global progress handler with any provided options
+    const mergedOptions = this.withTimeout(serverId, options);
+    if (!mergedOptions.onprogress) {
+      mergedOptions.onprogress = () => {
+		// register an empty on progress so that the client will send
+		// progress notifications...the notifications will be sent through the
+		// rpc logger
+	  };
+    }
+    return client.readResource(params, mergedOptions);
   }
 
   async subscribeResource(
@@ -619,7 +639,16 @@ export class MCPClientManager {
   ) {
     await this.ensureConnected(serverId);
     const client = this.getClientById(serverId);
-    return client.getPrompt(params, this.withTimeout(serverId, options));
+	 // Merge global progress handler with any provided options
+    const mergedOptions = this.withTimeout(serverId, options);
+    if (!mergedOptions.onprogress) {
+      mergedOptions.onprogress = () => {
+		// register an empty on progress so that the client will send
+		// progress notifications...the notifications will be sent through the
+		// rpc logger
+	  };
+    }
+    return client.getPrompt(params, mergedOptions);
   }
 
   getSessionIdByServer(serverId: string): string | undefined {


### PR DESCRIPTION
Closes #834 

I think the problem was that if there's no `onprogress` at the invocation step the progress token is not included (and the server will not send notifications for it).

By adding an empty `onprogress` those notifications are sent, captured by the logger and sent back to the client.