### PR TITLE
Send token counts for free chat

### DIFF
--- a/client/src/components/ChatTabV2.tsx
+++ b/client/src/components/ChatTabV2.tsx
@@ -218,6 +218,7 @@ export function ChatTabV2({
       ? undefined
       : lastAssistantMessageIsCompleteWithToolCalls,
   });
+  console.log('messages', messages);
   const resetChat = useCallback(() => {
     setChatSessionId(generateId());
     setMessages([]);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the free-chat backend to relay Convex SSE stream events to the client and adds a client-side messages debug log.
> 
> - **Server (`server/routes/mcp/chat-v2.ts`)**:
>   - Replace JSON response handling with SSE stream parsing from `POST /stream`.
>     - Forward `text-*`, `tool-call*`, `start*`, `finish*` events to client; capture `finish` metadata.
>     - Accumulate `text-delta` into `currentText` and append an assistant message to `messageHistory`.
>     - Stop loop when finished or when no tool calls are present; remove `mode: "step"`.
>   - Include auth header passthrough; add debug log for response.
> - **Client (`client/src/components/ChatTabV2.tsx`)**:
>   - Add debug `console.log` for `messages`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f10c653874e0d94f59f6b0973017687c7c37bbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->