### PR TITLE
Remove incorrect docs from contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,12 +55,6 @@ This runs:
 - **Client**: Vite dev server on `:3000`
 - **Server**: Hono dev server on `:3001`
 
-For Windows users, there's a specific script:
-
-```bash
-npm run dev:windows
-```
-
 ### Electron Development
 
 To run the Electron app in development mode:


### PR DESCRIPTION
Removed Windows-specific script instructions from the contributing guide.

I looked at the history for `package.json` and this command was removed in commit 9c983ccd6bb0711983ee1dadad83e9fb1c95677c a few months ago.