### PR TITLE
fix(docker): resolve build errors and improve cross-platform compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ COPY vite.preload.config.ts ./
 COPY .env.production ./
 # Set environment variable for Docker platform detection
 ENV VITE_DOCKER=true
+# Increase Node.js memory limit for the build process
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN npm run build:client
 
 # Stage 3: Build SDK (required by server)
@@ -85,16 +87,16 @@ RUN groupadd --gid 1001 nodejs && \
 RUN chown -R mcpjam:nodejs /app
 USER mcpjam
 
-# Expose port
-EXPOSE 3001
+# Expose port (matching .env.production)
+EXPOSE 6274
 
 # Set environment variables
-ENV PORT=3001
+ENV PORT=6274
 ENV NODE_ENV=production
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD node -e "require('http').request('http://localhost:3001/health', (res) => process.exit(res.statusCode === 200 ? 0 : 1)).end()"
+    CMD node -e "require('http').request('http://localhost:6274/health', (res) => process.exit(res.statusCode === 200 ? 0 : 1)).end()"
 
 # Use dumb-init to handle signals properly
 ENTRYPOINT ["dumb-init", "--"]

--- a/README.md
+++ b/README.md
@@ -66,14 +66,33 @@ We also have a Mac and Windows desktop app:
 Run MCPJam Inspector using Docker:
 
 ```bash
-# Run the latest version from Docker Hub
-docker run -p 3001:3001 mcpjam/mcp-inspector:latest
+# Using Docker Compose (recommended)
+docker-compose up -d
 
-# Or run in the background
-docker run -d -p 3001:3001 --name mcp-inspector mcpjam/mcp-inspector:latest
+# Or using Docker run
+docker run -d \
+  -p 6274:6274 \
+  --env-file .env.production \
+  -e NODE_ENV=production \
+  --add-host host.docker.internal:host-gateway \
+  --name mcp-inspector \
+  --restart unless-stopped \
+  mcpjam/mcp-inspector:latest
 ```
 
-The application will be available at `http://localhost:3001`.
+The application will be available at `http://127.0.0.1:6274`.
+
+**Important for macOS/Windows users:**
+
+- Access the app via `http://127.0.0.1:6274` (not `localhost`)
+- When connecting to MCP servers on your host machine, use `http://host.docker.internal:PORT` instead of `http://127.0.0.1:PORT`
+
+Example:
+
+```bash
+# Your MCP server runs on host at: http://127.0.0.1:8080/mcp
+# In Docker, configure it as: http://host.docker.internal:8080/mcp
+```
 
 # Key Features
 

--- a/client/src/lib/chat-utils.ts
+++ b/client/src/lib/chat-utils.ts
@@ -2,6 +2,7 @@ import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { ChatMessage } from "./chat-types";
 import { ModelDefinition } from "@/shared/types.js";
+import { getDefaultTemperatureByProvider } from "@/shared/chat-utils.js";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -186,21 +187,6 @@ export function debounce<T extends (...args: any[]) => any>(
     clearTimeout(timeout);
     timeout = setTimeout(() => func(...args), wait);
   };
-}
-
-export function getDefaultTemperatureByProvider(provider: string): number {
-  switch (provider) {
-    case "openai":
-      return 1.0;
-    case "anthropic":
-      return 0;
-    case "google":
-      return 0.9; // Google's recommended default
-    case "mistral":
-      return 0.7; // Mistral's recommended default
-    default:
-      return 0;
-  }
 }
 
 export function getDefaultTemperatureForModel(model: ModelDefinition): number {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3.9"
+services:
+  inspector:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: mcpjam/mcp-inspector:latest
+    ports:
+      - "6274:6274"
+    # Injects env vars to process.env (server requires CONVEX_HTTP_URL, etc.)
+    env_file:
+      - .env.production
+    # Also mount the file so dotenv can find it on disk at /app/.env.production
+    volumes:
+      - ./.env.production:/app/.env.production:ro
+    environment:
+      - NODE_ENV=production
+    # Add extra host mapping for macOS Docker to access host machine services
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "require('http').request('http://localhost:6274/health', (res) => process.exit(res.statusCode === 200 ? 0 : 1)).end()",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped

--- a/server/routes/mcp/chat.ts
+++ b/server/routes/mcp/chat.ts
@@ -7,7 +7,7 @@ import {
   isMCPJamProvidedModel,
 } from "../../../shared/types";
 import { TextEncoder } from "util";
-import { getDefaultTemperatureByProvider } from "../../../client/src/lib/chat-utils";
+import { getDefaultTemperatureByProvider } from "../../../shared/chat-utils";
 import { createLlmModel } from "../../utils/chat-helpers";
 import { SSEvent } from "../../../shared/sse";
 import type { ModelMessage, ToolSet } from "ai";

--- a/shared/chat-utils.ts
+++ b/shared/chat-utils.ts
@@ -1,0 +1,17 @@
+/**
+ * Get default temperature value based on the model provider
+ */
+export function getDefaultTemperatureByProvider(provider: string): number {
+  switch (provider) {
+    case "openai":
+      return 1.0;
+    case "anthropic":
+      return 0;
+    case "google":
+      return 0.9; // Google's recommended default
+    case "mistral":
+      return 0.7; // Mistral's recommended default
+    default:
+      return 0;
+  }
+}


### PR DESCRIPTION
Issues Fixed
Build failure: Server couldn't resolve imports from client directory
Out of memory: Client build crashed during Vite compilation
Port mismatch: Dockerfile used port 3001 instead of 6274
Network isolation: Couldn't connect to MCP servers on host machine from Docker (macOS)

Fix: #845 