### PR TITLE
Expose widget state to the model

### DIFF
--- a/client/src/components/ChatTabV2.tsx
+++ b/client/src/components/ChatTabV2.tsx
@@ -278,6 +278,54 @@ export function ChatTabV2({
     setInput("");
   }, [setMessages]);
 
+  const handleWidgetStateChange = useCallback(
+    (toolCallId: string, state: any) => {
+      setMessages((prevMessages) => {
+        const messageId = `widget-state-${toolCallId}`;
+
+        // If state is null, remove the widget state message
+        if (state === null) {
+          return prevMessages.filter((msg) => msg.id !== messageId);
+        }
+
+        const stateText = `The state of widget ${toolCallId} is: ${JSON.stringify(state)}`;
+
+        const existingIndex = prevMessages.findIndex(
+          (msg) => msg.id === messageId,
+        );
+
+        if (existingIndex !== -1) {
+          const existingMessage = prevMessages[existingIndex];
+          const existingText =
+            existingMessage.parts?.[0]?.type === "text"
+              ? (existingMessage.parts[0] as any).text
+              : null;
+          if (existingText === stateText) {
+            return prevMessages;
+          }
+
+          const newMessages = [...prevMessages];
+          newMessages[existingIndex] = {
+            id: messageId,
+            role: "assistant",
+            parts: [{ type: "text", text: stateText }],
+          };
+          return newMessages;
+        }
+
+        return [
+          ...prevMessages,
+          {
+            id: messageId,
+            role: "assistant",
+            parts: [{ type: "text", text: stateText }],
+          },
+        ];
+      });
+    },
+    [setMessages],
+  );
+
   useEffect(() => {
     resetChat();
   }, [resetChat]);
@@ -627,6 +675,7 @@ export function ChatTabV2({
                       isLoading={status === "submitted"}
                       toolsMetadata={toolsMetadata}
                       toolServerMap={toolServerMap}
+                      onWidgetStateChange={handleWidgetStateChange}
                     />
                   </div>
                   {errorMessage && (

--- a/client/src/components/chat-v2/thread.tsx
+++ b/client/src/components/chat-v2/thread.tsx
@@ -47,6 +47,7 @@ interface ThreadProps {
   isLoading: boolean;
   toolsMetadata: Record<string, Record<string, any>>;
   toolServerMap: ToolServerMap;
+  onWidgetStateChange?: (toolCallId: string, state: any) => void;
 }
 
 export function Thread({
@@ -56,6 +57,7 @@ export function Thread({
   isLoading,
   toolsMetadata,
   toolServerMap,
+  onWidgetStateChange,
 }: ThreadProps) {
   return (
     <div className="flex-1 overflow-y-auto pb-4">
@@ -68,6 +70,7 @@ export function Thread({
             onSendFollowUp={sendFollowUpMessage}
             toolsMetadata={toolsMetadata}
             toolServerMap={toolServerMap}
+            onWidgetStateChange={onWidgetStateChange}
           />
         ))}
         {isLoading && <ThinkingIndicator model={model} />}
@@ -82,15 +85,19 @@ function MessageView({
   onSendFollowUp,
   toolsMetadata,
   toolServerMap,
+  onWidgetStateChange,
 }: {
   message: UIMessage;
   model: ModelDefinition;
   onSendFollowUp: (text: string) => void;
   toolsMetadata: Record<string, Record<string, any>>;
   toolServerMap: ToolServerMap;
+  onWidgetStateChange?: (toolCallId: string, state: any) => void;
 }) {
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const logoSrc = getProviderLogoFromModel(model, themeMode);
+  // Hide widget-state messages from UI (they're sent to model but not displayed)
+  if (message.id?.startsWith("widget-state-")) return null;
   const role = message.role;
   if (role !== "user" && role !== "assistant") return null;
 
@@ -106,6 +113,7 @@ function MessageView({
               onSendFollowUp={onSendFollowUp}
               toolsMetadata={toolsMetadata}
               toolServerMap={toolServerMap}
+              onWidgetStateChange={onWidgetStateChange}
             />
           ))}
         </div>
@@ -139,6 +147,7 @@ function MessageView({
                 onSendFollowUp={onSendFollowUp}
                 toolsMetadata={toolsMetadata}
                 toolServerMap={toolServerMap}
+                onWidgetStateChange={onWidgetStateChange}
               />
             ))}
           </div>
@@ -171,12 +180,14 @@ function PartSwitch({
   onSendFollowUp,
   toolsMetadata,
   toolServerMap,
+  onWidgetStateChange,
 }: {
   part: AnyPart;
   role: UIMessage["role"];
   onSendFollowUp: (text: string) => void;
   toolsMetadata: Record<string, Record<string, any>>;
   toolServerMap: ToolServerMap;
+  onWidgetStateChange?: (toolCallId: string, state: any) => void;
 }) {
   if (isToolPart(part) || isDynamicTool(part)) {
     let maybeUiResource: any;
@@ -259,6 +270,7 @@ function PartSwitch({
             onCallTool={(toolName, params) =>
               callTool(serverId, toolName, params)
             }
+            onWidgetStateChange={onWidgetStateChange}
           />
         </>
       );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Propagates OpenAI App widget state changes from iframe to the model by capturing events, deduping, and storing them as hidden assistant messages, wired through Thread to Chat.
> 
> - **Chat/Thread plumbing**:
>   - Add `handleWidgetStateChange` in `client/src/components/ChatTabV2.tsx` to add/update/remove hidden assistant messages (`id` prefixed with `widget-state-`) reflecting widget state.
>   - Hide these `widget-state-*` messages from the UI in `thread.tsx`.
>   - Thread pipeline updated to pass `onWidgetStateChange` through `Thread` → `MessageView` → `PartSwitch` into `OpenAIAppRenderer`.
> - **OpenAI App Renderer** (`client/src/components/chat-v2/openai-app-renderer.tsx`):
>   - New `onWidgetStateChange` prop; track last state via `previousWidgetStateRef`.
>   - Listen for `openai:setWidgetState` postMessage; dedupe by `toolId`/state and invoke callback when changed.
>   - Update `handleMessage` dependencies to include widget-state handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f8ee3b888b51f3de8c94cfa7820da6ad31b51f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

* Example:
<img width="1292" height="1210" alt="image" src="https://github.com/user-attachments/assets/2f583eb2-3948-419a-8d2b-da949b6af52d" />