### PR TITLE
Add Gemini 3 Pro Preview Model

### DIFF
--- a/shared/types.ts
+++ b/shared/types.ts
@@ -182,6 +182,7 @@ export enum Model {
   DEEPSEEK_CHAT = "deepseek-chat",
   DEEPSEEK_REASONER = "deepseek-reasoner",
   // Google Gemini models
+  GEMINI_3_PRO = "gemini-3-pro-preview",
   GEMINI_2_5_PRO = "gemini-2.5-pro",
   GEMINI_2_5_FLASH = "gemini-2.5-flash",
   GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite",
@@ -356,6 +357,12 @@ export const SUPPORTED_MODELS: ModelDefinition[] = [
     contextLength: 128000,
   },
   // Google Gemini models (latest first)
+  {
+    id: Model.GEMINI_3_PRO,
+    name: "Gemini 3 Pro (Preview)",
+    provider: "google",
+    contextLength: 1000000,
+  },
   {
     id: Model.GEMINI_2_5_PRO,
     name: "Gemini 2.5 Pro",


### PR DESCRIPTION
* Adds Gemini 3 Pro Preview as a supported model

<img width="1271" height="1127" alt="image" src="https://github.com/user-attachments/assets/e542f181-e78c-4f85-924f-c4f13d531c9c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Google Gemini 3 Pro (Preview) model and registers it in supported models.
> 
> - **Models**:
>   - Add `Model.GEMINI_3_PRO = "gemini-3-pro-preview"` to enum.
>   - Register in `SUPPORTED_MODELS` with name "Gemini 3 Pro (Preview)", provider `google`, contextLength `1000000`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ec60ab8bd644d6c8a8236d679bc678552e450c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->