### PR TITLE
feat: Add Enter key shortcut to execute tools, resources, and prompts

### DIFF
--- a/client/src/components/PromptsTab.tsx
+++ b/client/src/components/PromptsTab.tsx
@@ -175,6 +175,36 @@ export function PromptsTab({ serverConfig, serverName }: PromptsTabProps) {
 
   const promptNames = prompts.map((prompt) => prompt.name);
 
+  // Handle Enter key in input fields
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && !loading) {
+      e.preventDefault();
+      getPrompt();
+    }
+  };
+
+  // Handle Enter key to get prompt globally
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Enter" && !e.shiftKey && selectedPrompt && !loading) {
+        // Don't trigger if user is typing in an input, textarea, or contenteditable
+        const target = e.target as HTMLElement;
+        const tagName = target.tagName;
+        const isEditable = target.isContentEditable;
+
+        if (tagName === "INPUT" || tagName === "TEXTAREA" || isEditable) {
+          return;
+        }
+
+        e.preventDefault();
+        getPrompt();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selectedPrompt, loading]);
+
   if (!serverConfig || !serverName) {
     return (
       <EmptyState
@@ -462,6 +492,7 @@ export function PromptsTab({ serverConfig, serverName }: PromptsTabProps) {
                                             e.target.value,
                                           )
                                         }
+                                        onKeyDown={handleInputKeyDown}
                                         placeholder={`Enter ${field.name}`}
                                         className="bg-background border-border hover:border-border/80 focus:border-ring focus:ring-0 font-medium text-xs"
                                       />

--- a/client/src/components/ResourcesTab.tsx
+++ b/client/src/components/ResourcesTab.tsx
@@ -115,6 +115,28 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
     }
   };
 
+  // Handle Enter key to read resource globally
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Enter" && !e.shiftKey && selectedResource && !loading) {
+        // Don't trigger if user is typing in an input, textarea, or contenteditable
+        const target = e.target as HTMLElement;
+        const tagName = target.tagName;
+        const isEditable = target.isContentEditable;
+
+        if (tagName === "INPUT" || tagName === "TEXTAREA" || isEditable) {
+          return;
+        }
+
+        e.preventDefault();
+        readResource(selectedResource);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selectedResource, loading]);
+
   if (!serverConfig || !serverName) {
     return (
       <EmptyState

--- a/client/src/components/ToolsTab.tsx
+++ b/client/src/components/ToolsTab.tsx
@@ -329,6 +329,29 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
     }
   };
 
+  // Handle Enter key to execute tool globally
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Check if Enter is pressed (not Shift+Enter)
+      if (e.key === "Enter" && !e.shiftKey && selectedTool && !loading) {
+        // Don't trigger if user is typing in an input, textarea, or contenteditable
+        const target = e.target as HTMLElement;
+        const tagName = target.tagName;
+        const isEditable = target.isContentEditable;
+
+        if (tagName === "INPUT" || tagName === "TEXTAREA" || isEditable) {
+          return;
+        }
+
+        e.preventDefault();
+        executeTool();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [selectedTool, loading]);
+
   const handleElicitationResponse = async (
     action: "accept" | "decline" | "cancel",
     parameters?: Record<string, unknown>,

--- a/client/src/components/tools/ParametersPanel.tsx
+++ b/client/src/components/tools/ParametersPanel.tsx
@@ -31,6 +31,23 @@ export function ParametersPanel({
   onFieldChange,
 }: ParametersPanelProps) {
   const posthog = usePostHog();
+
+  // Handle Enter key in input fields
+  const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && !loading) {
+      e.preventDefault();
+      onExecute();
+    }
+  };
+
+  // Handle Enter key in select fields
+  const handleSelectKeyDown = (e: React.KeyboardEvent<HTMLSelectElement>) => {
+    if (e.key === "Enter" && !loading) {
+      e.preventDefault();
+      onExecute();
+    }
+  };
+
   return (
     <ResizablePanel defaultSize={70} minSize={50}>
       <div className="h-full flex flex-col bg-background">
@@ -149,6 +166,7 @@ export function ParametersPanel({
                             onChange={(e) =>
                               onFieldChange(field.name, e.target.value)
                             }
+                            onKeyDown={handleSelectKeyDown}
                             className="w-full h-9 bg-background border border-border rounded px-2 text-xs"
                           >
                             {field.enum?.map((v) => (
@@ -197,6 +215,7 @@ export function ParametersPanel({
                             onChange={(e) =>
                               onFieldChange(field.name, e.target.value)
                             }
+                            onKeyDown={handleInputKeyDown}
                             placeholder={`Enter ${field.name}`}
                             className="bg-background border-border hover:border-border/80 focus:border-ring focus:ring-0 font-medium text-xs"
                           />


### PR DESCRIPTION
Added keyboard shortcut support to execute tools, read resources, and get prompts by pressing **Enter**, improving workflow efficiency and enabling keyboard-first navigation.


Fix: #885 