### PR TITLE
fix: Preserve input value when switching connection types in server modals

### DIFF
--- a/client/src/components/connection/AddServerModal.tsx
+++ b/client/src/components/connection/AddServerModal.tsx
@@ -176,12 +176,22 @@ export function AddServerModal({
               <div className="flex">
                 <Select
                   value={formState.serverFormData.type}
-                  onValueChange={(value: "stdio" | "http") =>
+                  onValueChange={(value: "stdio" | "http") => {
+                    // Preserve the current input value before switching
+                    const currentValue = formState.commandInput;
                     formState.setServerFormData((prev) => ({
                       ...prev,
                       type: value,
-                    }))
-                  }
+                    }));
+
+                    // Apply the preserved value to the appropriate field after switching
+                    if (value === "http" && currentValue) {
+                      formState.setServerFormData((prev) => ({
+                        ...prev,
+                        url: currentValue,
+                      }));
+                    }
+                  }}
                 >
                   <SelectTrigger className="w-22 rounded-r-none border-r-0 text-xs border-border">
                     <SelectValue />
@@ -203,12 +213,19 @@ export function AddServerModal({
               <div className="flex">
                 <Select
                   value={formState.serverFormData.type}
-                  onValueChange={(value: "stdio" | "http") =>
+                  onValueChange={(value: "stdio" | "http") => {
+                    // Preserve the current input value before switching
+                    const currentValue = formState.serverFormData.url;
                     formState.setServerFormData((prev) => ({
                       ...prev,
                       type: value,
-                    }))
-                  }
+                    }));
+
+                    // Apply the preserved value to the appropriate field after switching
+                    if (value === "stdio" && currentValue) {
+                      formState.setCommandInput(currentValue);
+                    }
+                  }}
                 >
                   <SelectTrigger className="w-22 rounded-r-none border-r-0 text-xs border-border">
                     <SelectValue />

--- a/client/src/components/connection/EditServerModal.tsx
+++ b/client/src/components/connection/EditServerModal.tsx
@@ -166,12 +166,22 @@ export function EditServerModal({
               <div className="flex">
                 <Select
                   value={serverFormData.type}
-                  onValueChange={(value: "stdio" | "http") =>
+                  onValueChange={(value: "stdio" | "http") => {
+                    // Preserve the current input value before switching
+                    const currentValue = commandInput;
                     setServerFormData((prev) => ({
                       ...prev,
                       type: value,
-                    }))
-                  }
+                    }));
+
+                    // Apply the preserved value to the appropriate field after switching
+                    if (value === "http" && currentValue) {
+                      setServerFormData((prev) => ({
+                        ...prev,
+                        url: currentValue,
+                      }));
+                    }
+                  }}
                 >
                   <SelectTrigger className="w-22 rounded-r-none border-r-0 text-xs border-border">
                     <SelectValue />
@@ -193,12 +203,19 @@ export function EditServerModal({
               <div className="flex">
                 <Select
                   value={serverFormData.type}
-                  onValueChange={(value: "stdio" | "http") =>
+                  onValueChange={(value: "stdio" | "http") => {
+                    // Preserve the current input value before switching
+                    const currentValue = serverFormData.url;
                     setServerFormData((prev) => ({
                       ...prev,
                       type: value,
-                    }))
-                  }
+                    }));
+
+                    // Apply the preserved value to the appropriate field after switching
+                    if (value === "stdio" && currentValue) {
+                      setCommandInput(currentValue);
+                    }
+                  }}
                 >
                   <SelectTrigger className="w-22 rounded-r-none border-r-0 text-xs border-border">
                     <SelectValue />


### PR DESCRIPTION

## Purely a UX improvement

### Problem
When switching between STDIO and HTTP connection types, the input field value was cleared, forcing users to re-paste their connection string.

### Solution
Modified the connection type dropdown handlers in `AddServerModal` and `EditServerModal` to preserve and transfer the input value when switching between connection types.

https://github.com/user-attachments/assets/12727340-d33b-486a-baf1-7fe63b2a36b5

