### PR TITLE
Add ChatGPT Apps Modal Support

### DIFF
--- a/server/routes/mcp/openai.ts
+++ b/server/routes/mcp/openai.ts
@@ -407,6 +407,27 @@ openai.get("/widget-content/:toolId", async (c) => {
                 }
               }
             }
+
+            if (event.data.type === 'openai:pushWidgetState' && event.data.toolId === ${JSON.stringify(toolId)}) {
+              try {
+                const nextState = event.data.state ?? null;
+                window.openai.widgetState = nextState;
+                try {
+                  localStorage.setItem(${JSON.stringify(widgetStateKey)}, JSON.stringify(nextState));
+                } catch (err) {
+                }
+                try {
+                  const stateEvent = new CustomEvent('openai:widget_state', {
+                    detail: { state: nextState }
+                  });
+                  window.dispatchEvent(stateEvent);
+                } catch (err) {
+                  console.error('[OpenAI Widget] Failed to dispatch widget state event:', err);
+                }
+              } catch (err) {
+                console.error('[OpenAI Widget] Failed to apply pushed widget state:', err);
+              }
+            }
           });
         })();
       </script>


### PR DESCRIPTION
* Adds Modal support for ChatGPT Apps SDK
* Adds new OpenAI bridge `window.openai.requestModal`
* Seems like ChatGPT behavior mounts the iframe with a new OpenAI global called "view" which can be "modal" or "inline" then its up to the developer to set up the logic for that
* Still a little slow

https://github.com/user-attachments/assets/151096e8-ac59-4e30-9693-5536f5ae6dd0

