### PR TITLE
fix: Add validation feedback for test suite name in evals

### DIFF
--- a/client/src/components/evals/eval-runner.tsx
+++ b/client/src/components/evals/eval-runner.tsx
@@ -110,8 +110,7 @@ export function EvalRunner({
   const [modelTab, setModelTab] = useState<"mcpjam" | "yours">("mcpjam");
   const [suiteName, setSuiteName] = useState("");
   const [suiteDescription, setSuiteDescription] = useState("");
-  const [isEditingSuiteName, setIsEditingSuiteName] = useState(false);
-  const [editedSuiteName, setEditedSuiteName] = useState("");
+  const [showNameError, setShowNameError] = useState(false);
   const [hasRestoredPreferences, setHasRestoredPreferences] = useState(false);
   const [availableTools, setAvailableTools] = useState<AvailableTool[]>([]);
 
@@ -407,37 +406,12 @@ export function EvalRunner({
   const handleNext = () => {
     if (currentStep >= WIZARD_STEPS.length - 1) return;
     if (!canAdvance) return;
-    setIsEditingSuiteName(false);
     setCurrentStep((prev) => Math.min(prev + 1, WIZARD_STEPS.length - 1));
   };
 
   const handleBack = () => {
     if (currentStep === 0) return;
-    setIsEditingSuiteName(false);
     setCurrentStep((prev) => Math.max(prev - 1, 0));
-  };
-
-  const handleSuiteNameClick = () => {
-    setIsEditingSuiteName(true);
-    setEditedSuiteName(suiteName);
-  };
-
-  const handleSuiteNameBlur = () => {
-    setIsEditingSuiteName(false);
-    if (editedSuiteName.trim() && editedSuiteName !== suiteName) {
-      setSuiteName(editedSuiteName.trim());
-    } else {
-      setEditedSuiteName(suiteName);
-    }
-  };
-
-  const handleSuiteNameKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      handleSuiteNameBlur();
-    } else if (e.key === "Escape") {
-      setIsEditingSuiteName(false);
-      setEditedSuiteName(suiteName);
-    }
   };
 
   const handleSubmit = async () => {
@@ -481,10 +455,13 @@ export function EvalRunner({
     }
 
     if (!suiteName.trim()) {
-      toast.error("Please provide a name for this test suite");
-      setCurrentStep(3);
+      setShowNameError(true);
+      // Stay on current step (step 3 - review)
       return;
     }
+
+    // Clear error state if we got this far
+    setShowNameError(false);
 
     // Switch view immediately before starting the API call
     if (!inline) {
@@ -564,8 +541,7 @@ export function EvalRunner({
       setTestTemplates([buildBlankTestTemplate()]);
       setSuiteName("");
       setSuiteDescription("");
-      setIsEditingSuiteName(false);
-      setEditedSuiteName("");
+      setShowNameError(false);
       setCurrentStep(3);
     } catch (error) {
       toast.error(
@@ -620,19 +596,15 @@ export function EvalRunner({
           <ReviewStep
             suiteName={suiteName}
             suiteDescription={suiteDescription}
-            isEditingSuiteName={isEditingSuiteName}
-            editedSuiteName={editedSuiteName}
             minimumPassRate={minimumPassRate}
             selectedServers={selectedServers}
             selectedModels={selectedModels}
             validTestTemplates={validTestTemplates}
-            onSuiteNameClick={handleSuiteNameClick}
-            onSuiteNameBlur={handleSuiteNameBlur}
-            onSuiteNameKeyDown={handleSuiteNameKeyDown}
-            onEditedSuiteNameChange={setEditedSuiteName}
+            onSuiteNameChange={setSuiteName}
             onSuiteDescriptionChange={setSuiteDescription}
             onMinimumPassRateChange={setMinimumPassRate}
             onEditStep={setCurrentStep}
+            showNameError={showNameError}
           />
         );
       default:

--- a/client/src/components/evals/eval-runner/ReviewStep.tsx
+++ b/client/src/components/evals/eval-runner/ReviewStep.tsx
@@ -1,79 +1,81 @@
-import type { KeyboardEvent } from "react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { PassCriteriaSelector } from "../pass-criteria-selector";
+import { cn } from "@/lib/utils";
 import type { ModelDefinition } from "@/shared/types";
 import type { TestTemplate } from "@/components/evals/eval-runner/types";
 
 interface ReviewStepProps {
   suiteName: string;
   suiteDescription: string;
-  isEditingSuiteName: boolean;
-  editedSuiteName: string;
   minimumPassRate: number;
   selectedServers: string[];
   selectedModels: ModelDefinition[];
   validTestTemplates: TestTemplate[];
-  onSuiteNameClick: () => void;
-  onSuiteNameBlur: () => void;
-  onSuiteNameKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
-  onEditedSuiteNameChange: (value: string) => void;
+  onSuiteNameChange: (value: string) => void;
   onSuiteDescriptionChange: (value: string) => void;
   onMinimumPassRateChange: (value: number) => void;
   onEditStep: (stepIndex: number) => void;
+  showNameError?: boolean;
 }
 
 export function ReviewStep({
   suiteName,
   suiteDescription,
-  isEditingSuiteName,
-  editedSuiteName,
   minimumPassRate,
   selectedServers,
   selectedModels,
   validTestTemplates,
-  onSuiteNameClick,
-  onSuiteNameBlur,
-  onSuiteNameKeyDown,
-  onEditedSuiteNameChange,
+  onSuiteNameChange,
   onSuiteDescriptionChange,
   onMinimumPassRateChange,
   onEditStep,
+  showNameError = false,
 }: ReviewStepProps) {
   return (
     <div className="space-y-6">
       <div className="space-y-4">
-        {isEditingSuiteName ? (
-          <input
+        <div className="space-y-2">
+          <Label htmlFor="suite-name" className="text-sm font-medium">
+            Test Suite Name <span className="text-destructive">*</span>
+          </Label>
+          <Input
+            id="suite-name"
             type="text"
-            value={editedSuiteName}
-            onChange={(event) => onEditedSuiteNameChange(event.target.value)}
-            onBlur={onSuiteNameBlur}
-            onKeyDown={onSuiteNameKeyDown}
-            autoFocus
-            className="w-full px-3 py-2 text-lg font-semibold border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-ring bg-background"
-            placeholder="New Test Suite"
-          />
-        ) : (
-          <Button
-            variant="ghost"
-            onClick={onSuiteNameClick}
-            className="w-full justify-start px-3 py-2 h-auto text-lg font-semibold hover:bg-accent border border-transparent hover:border-input rounded-md"
-          >
-            {suiteName || (
-              <span className="text-muted-foreground">New Test Suite</span>
+            value={suiteName}
+            onChange={(event) => onSuiteNameChange(event.target.value)}
+            placeholder="e.g., Weather API Integration Tests"
+            className={cn(
+              "text-lg font-semibold",
+              showNameError &&
+                !suiteName.trim() &&
+                "border-destructive focus-visible:ring-destructive",
             )}
-          </Button>
-        )}
-        <Textarea
-          value={suiteDescription}
-          onChange={(event) => onSuiteDescriptionChange(event.target.value)}
-          rows={3}
-          placeholder="What does this suite cover?"
-          className="resize-none"
-        />
+            autoFocus
+          />
+          {showNameError && !suiteName.trim() && (
+            <p className="text-sm text-red-600 font-medium">
+              Please provide a name for this test suite
+            </p>
+          )}
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="suite-description" className="text-sm font-medium">
+            Description (optional)
+          </Label>
+          <Textarea
+            id="suite-description"
+            value={suiteDescription}
+            onChange={(event) => onSuiteDescriptionChange(event.target.value)}
+            rows={3}
+            placeholder="What does this suite cover?"
+            className="resize-none"
+          />
+        </div>
       </div>
 
       <PassCriteriaSelector


### PR DESCRIPTION
**Changes:**
- Replace button toggle with always-visible input field
- Add red border validation when name is missing
- Show inline error message: "Please provide a name for this test suite"
- Add required field indicator (*)
- Auto-focus name input on step 4

Fix: #941 

Demo:

https://github.com/user-attachments/assets/e8ba8cb4-ac98-4385-8fb2-81c401a5a213

