### PR TITLE
Align Playground and Evals loading states

### DIFF
--- a/client/src/components/ChatTabV2.tsx
+++ b/client/src/components/ChatTabV2.tsx
@@ -709,7 +709,7 @@ export function ChatTabV2({
                 <div className="w-full max-w-3xl space-y-6 py-8">
                   {isAuthLoading ? (
                     <div className="text-center space-y-4">
-                      <div className="mx-auto h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-primary" />
+                      <div className="mx-auto h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
                       <p className="text-sm text-muted-foreground">
                         Loading...
                       </p>

--- a/client/src/components/EvalsTab.tsx
+++ b/client/src/components/EvalsTab.tsx
@@ -180,7 +180,7 @@ export function EvalsTab() {
   if (isLoading) {
     return (
       <div className="p-6">
-        <div className="flex h-64 items-center justify-center">
+        <div className="flex min-h-[calc(100vh-200px)] items-center justify-center">
           <div className="text-center">
             <div className="mx-auto h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
             <p className="mt-4 text-muted-foreground">Loading...</p>
@@ -208,7 +208,7 @@ export function EvalsTab() {
   if (isOverviewLoading && enableOverviewQuery && route.type !== "create") {
     return (
       <div className="p-6">
-        <div className="flex h-64 items-center justify-center">
+        <div className="flex min-h-[calc(100vh-200px)] items-center justify-center">
           <div className="text-center">
             <div className="mx-auto h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
             <p className="mt-4 text-muted-foreground">


### PR DESCRIPTION
1.Update Playground loading spinner to use the modern eval-style indicator for a consistent look across tabs.


2.Adjust EvalsTab loading wrappers to center the indicator vertically by using viewport-based height.

https://github.com/user-attachments/assets/b71b06c1-8f62-4a89-9393-cdc6f635cd17

