### PR TITLE
Fix ngrok for desktop

### DIFF
--- a/client/src/components/ServersTab.tsx
+++ b/client/src/components/ServersTab.tsx
@@ -40,7 +40,14 @@ import {
   cleanupOrphanedTunnels,
 } from "@/lib/mcp-tunnels-api";
 import { useAuth } from "@workos-inc/authkit-react";
+import { useConvexAuth } from "convex/react";
 import { toast } from "sonner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
 
 interface ServersTabProps {
   connectedServerConfigs: Record<string, ServerWithName>;
@@ -65,6 +72,7 @@ export function ServersTab({
 }: ServersTabProps) {
   const posthog = usePostHog();
   const { getAccessToken } = useAuth();
+  const { isAuthenticated } = useConvexAuth();
   const [isAddingServer, setIsAddingServer] = useState(false);
   const [isImportingJson, setIsImportingJson] = useState(false);
   const [isEditingServer, setIsEditingServer] = useState(false);
@@ -255,12 +263,12 @@ export function ServersTab({
       );
     }
 
-    return (
+    const button = (
       <Button
         variant="outline"
         size="sm"
         onClick={handleCreateTunnel}
-        disabled={isCreatingTunnel}
+        disabled={isCreatingTunnel || !isAuthenticated}
         className="cursor-pointer"
       >
         {isCreatingTunnel ? (
@@ -271,6 +279,23 @@ export function ServersTab({
         Create ngrok tunnel
       </Button>
     );
+
+    if (!isAuthenticated) {
+      return (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span tabIndex={0}>{button}</span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>Sign in to create tunnels</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      );
+    }
+
+    return button;
   };
 
   const renderServerActionsMenu = () => (

--- a/vite.main.config.ts
+++ b/vite.main.config.ts
@@ -20,6 +20,8 @@ export default defineConfig({
       external: [
         // Core Electron & Node modules only
         "electron",
+        // Native modules that can't be bundled
+        "@ngrok/ngrok",
         // Bundle everything else including electron-log, update-electron-app, etc.
       ],
       output: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Packages ngrok’s native module correctly for Electron and gates the “Create ngrok tunnel” UI behind authentication with a tooltip prompt when signed out.
> 
> - **Build/Packaging**:
>   - Add `postPackage` hook in `forge.config.ts` to copy `@ngrok` into `Resources/node_modules` for packaged apps.
>   - Treat `@ngrok/ngrok` as external in `vite.main.config.ts` to avoid bundling.
> - **UI/Auth** (`client/src/components/ServersTab.tsx`):
>   - Disable "Create ngrok tunnel" when `!isAuthenticated` (uses `useConvexAuth`).
>   - Show tooltip prompting sign-in when button is disabled.
>   - Keep existing tunnel create/close logic unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit adc73588f33dd1c2961d700482296bf01c1dbc2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->