### PR TITLE
Electron full screen mode fix

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,6 @@ function createMainWindow(serverUrl: string): BrowserWindow {
       // Vite plugin outputs main.js and preload.js into the same directory (.vite/build)
       preload: path.join(__dirname, "preload.js"),
     },
-    titleBarStyle: process.platform === "darwin" ? "hiddenInset" : "default",
     show: false, // Don't show until ready
   });
 


### PR DESCRIPTION
<img width="1512" height="1012" alt="image" src="https://github.com/user-attachments/assets/b06e9849-50f9-41cc-add9-dfa1ac712dbb" />


* Adds default MacOS title bar back to avoid UX issues
* Closes #961 