### PR TITLE
Add support for private registries

### DIFF
--- a/client/src/components/registry/AddRegistryDialog.tsx
+++ b/client/src/components/registry/AddRegistryDialog.tsx
@@ -1,0 +1,179 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { useRegistrySourcesStore } from "@/stores/registry/registry-sources-store";
+import { listRegistryServers, isAuthRequired } from "@/lib/registry-api";
+import { Loader2, AlertCircle } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { toast } from "sonner";
+
+interface AddRegistryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRegistryAdded?: (registryUrl: string) => void;
+}
+
+export function AddRegistryDialog({
+  open,
+  onOpenChange,
+  onRegistryAdded,
+}: AddRegistryDialogProps) {
+  const [name, setName] = useState("");
+  const [url, setUrl] = useState("");
+  const [isChecking, setIsChecking] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { addSource, setActiveSource, sources } = useRegistrySourcesStore();
+
+  const resetForm = () => {
+    setName("");
+    setUrl("");
+    setError(null);
+    setIsChecking(false);
+  };
+
+  const handleClose = () => {
+    resetForm();
+    onOpenChange(false);
+  };
+
+  const handleAdd = async () => {
+    setIsChecking(true);
+    setError(null);
+
+    try {
+      // Validate URL format
+      let registryUrl: URL;
+      try {
+        registryUrl = new URL(url);
+      } catch {
+        throw new Error("Invalid URL format");
+      }
+
+      // Check if registry already exists
+      const existingSource = sources.find((s) => s.url === registryUrl.toString());
+      if (existingSource) {
+        throw new Error("This registry is already added");
+      }
+
+      // Try to fetch from the registry (will tell us if auth is needed)
+      const result = await listRegistryServers({
+        registryUrl: registryUrl.toString(),
+        limit: 1,
+      });
+
+      const requiresAuth = isAuthRequired(result);
+
+      // Add the new source
+      const sourceId = addSource({
+        name: name.trim() || registryUrl.hostname,
+        url: registryUrl.toString(),
+        isOfficial: false,
+        requiresAuth,
+      });
+
+      // Set as active source
+      setActiveSource(sourceId);
+
+      // Notify parent
+      if (onRegistryAdded) {
+        onRegistryAdded(registryUrl.toString());
+      }
+
+      if (requiresAuth) {
+        toast.info("Registry added", {
+          description:
+            "This registry requires authentication. OAuth support coming soon!",
+        });
+      } else {
+        toast.success("Registry added", {
+          description: `Successfully connected to ${name || registryUrl.hostname}`,
+        });
+      }
+
+      handleClose();
+    } catch (e) {
+      const message =
+        e instanceof Error ? e.message : "Failed to connect to registry";
+      setError(message);
+    } finally {
+      setIsChecking(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && url && !isChecking) {
+      handleAdd();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Add Registry</DialogTitle>
+          <DialogDescription>
+            Connect to a custom MCP server registry. Enter the base URL of the
+            registry API.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="registry-name">Name (optional)</Label>
+            <Input
+              id="registry-name"
+              placeholder="My Company Registry"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+            <p className="text-xs text-muted-foreground">
+              A friendly name to identify this registry
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="registry-url">Registry URL</Label>
+            <Input
+              id="registry-url"
+              placeholder="https://registry.example.com/v0.1"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              onKeyDown={handleKeyDown}
+            />
+            <p className="text-xs text-muted-foreground">
+              The base URL of the registry API (e.g.,
+              https://registry.example.com/v0.1)
+            </p>
+          </div>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button onClick={handleAdd} disabled={!url.trim() || isChecking}>
+            {isChecking && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            {isChecking ? "Checking..." : "Add Registry"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/registry/RegistrySelector.tsx
+++ b/client/src/components/registry/RegistrySelector.tsx
@@ -1,0 +1,116 @@
+import { useState } from "react";
+import { useRegistrySourcesStore } from "@/stores/registry/registry-sources-store";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Lock, Plus, Trash2 } from "lucide-react";
+import { AddRegistryDialog } from "./AddRegistryDialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface RegistrySelectorProps {
+  onRegistryChange?: (registryUrl: string) => void;
+}
+
+export function RegistrySelector({ onRegistryChange }: RegistrySelectorProps) {
+  const { sources, activeSourceId, setActiveSource, removeSource } =
+    useRegistrySourcesStore();
+  const [showAddDialog, setShowAddDialog] = useState(false);
+
+  const handleValueChange = (value: string) => {
+    if (value === "__add__") {
+      setShowAddDialog(true);
+      return;
+    }
+    setActiveSource(value);
+    const source = sources.find((s) => s.id === value);
+    if (source && onRegistryChange) {
+      onRegistryChange(source.url);
+    }
+  };
+
+  const handleRemoveSource = (
+    e: React.MouseEvent,
+    sourceId: string,
+  ) => {
+    e.preventDefault();
+    e.stopPropagation();
+    removeSource(sourceId);
+  };
+
+  const activeSource = sources.find((s) => s.id === activeSourceId);
+
+  return (
+    <>
+      <Select value={activeSourceId} onValueChange={handleValueChange}>
+        <SelectTrigger className="w-[200px]">
+          <SelectValue placeholder="Select registry">
+            {activeSource && (
+              <span className="flex items-center gap-2">
+                {activeSource.name}
+                {activeSource.requiresAuth && (
+                  <Lock className="h-3 w-3 text-muted-foreground" />
+                )}
+              </span>
+            )}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {sources.map((source) => (
+            <SelectItem key={source.id} value={source.id}>
+              <div className="flex items-center justify-between w-full gap-2">
+                <span className="flex items-center gap-2">
+                  {source.name}
+                  {source.requiresAuth && (
+                    <Lock className="h-3 w-3 text-muted-foreground" />
+                  )}
+                </span>
+                {!source.isOfficial && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-5 w-5 p-0 hover:bg-destructive/10"
+                        onClick={(e) => handleRemoveSource(e, source.id)}
+                      >
+                        <Trash2 className="h-3 w-3 text-muted-foreground hover:text-destructive" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Remove registry</TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
+            </SelectItem>
+          ))}
+          <SelectSeparator />
+          <SelectItem value="__add__">
+            <span className="flex items-center gap-2 text-muted-foreground">
+              <Plus className="h-4 w-4" />
+              Add Registry
+            </span>
+          </SelectItem>
+        </SelectContent>
+      </Select>
+
+      <AddRegistryDialog
+        open={showAddDialog}
+        onOpenChange={setShowAddDialog}
+        onRegistryAdded={(registryUrl) => {
+          if (onRegistryChange) {
+            onRegistryChange(registryUrl);
+          }
+        }}
+      />
+    </>
+  );
+}

--- a/client/src/lib/registry-api.ts
+++ b/client/src/lib/registry-api.ts
@@ -2,23 +2,42 @@ import type {
   RegistryServerListResponse,
   RegistryVersionListResponse,
   RegistryServerVersion,
+  RegistryAuthRequiredResponse,
 } from "@/shared/types";
 
 const API_BASE = "/api/mcp/registry";
 
+export interface RegistryRequestOptions {
+  registryUrl?: string;
+  accessToken?: string;
+}
+
 /**
  * List servers from the MCP registry
  */
-export async function listRegistryServers(options?: {
-  limit?: number;
-  cursor?: string;
-}): Promise<RegistryServerListResponse> {
+export async function listRegistryServers(
+  options?: RegistryRequestOptions & {
+    limit?: number;
+    cursor?: string;
+  },
+): Promise<RegistryServerListResponse | RegistryAuthRequiredResponse> {
   const params = new URLSearchParams();
   if (options?.limit) params.append("limit", options.limit.toString());
   if (options?.cursor) params.append("cursor", options.cursor);
+  if (options?.registryUrl) params.append("registryUrl", options.registryUrl);
+
+  const headers: HeadersInit = {};
+  if (options?.accessToken) {
+    headers["Authorization"] = `Bearer ${options.accessToken}`;
+  }
 
   const url = `${API_BASE}/servers${params.toString() ? `?${params.toString()}` : ""}`;
-  const response = await fetch(url);
+  const response = await fetch(url, { headers });
+
+  // Return auth required response for 401
+  if (response.status === 401) {
+    return response.json() as Promise<RegistryAuthRequiredResponse>;
+  }
 
   if (!response.ok) {
     throw new Error(`Failed to fetch registry servers: ${response.statusText}`);
@@ -28,14 +47,36 @@ export async function listRegistryServers(options?: {
 }
 
 /**
+ * Check if a response indicates auth is required
+ */
+export function isAuthRequired(
+  response: RegistryServerListResponse | RegistryAuthRequiredResponse,
+): response is RegistryAuthRequiredResponse {
+  return "requiresAuth" in response && response.requiresAuth === true;
+}
+
+/**
  * Get all versions for a specific server
  */
 export async function listServerVersions(
   serverName: string,
-): Promise<RegistryVersionListResponse> {
+  options?: RegistryRequestOptions,
+): Promise<RegistryVersionListResponse | RegistryAuthRequiredResponse> {
   const encodedName = encodeURIComponent(serverName);
-  const url = `${API_BASE}/servers/${encodedName}/versions`;
-  const response = await fetch(url);
+  const params = new URLSearchParams();
+  if (options?.registryUrl) params.append("registryUrl", options.registryUrl);
+
+  const headers: HeadersInit = {};
+  if (options?.accessToken) {
+    headers["Authorization"] = `Bearer ${options.accessToken}`;
+  }
+
+  const url = `${API_BASE}/servers/${encodedName}/versions${params.toString() ? `?${params.toString()}` : ""}`;
+  const response = await fetch(url, { headers });
+
+  if (response.status === 401) {
+    return response.json() as Promise<RegistryAuthRequiredResponse>;
+  }
 
   if (!response.ok) {
     throw new Error(`Failed to fetch server versions: ${response.statusText}`);
@@ -50,11 +91,24 @@ export async function listServerVersions(
 export async function getServerVersion(
   serverName: string,
   version: string = "latest",
-): Promise<RegistryServerVersion> {
+  options?: RegistryRequestOptions,
+): Promise<RegistryServerVersion | RegistryAuthRequiredResponse> {
   const encodedName = encodeURIComponent(serverName);
   const encodedVersion = encodeURIComponent(version);
-  const url = `${API_BASE}/servers/${encodedName}/versions/${encodedVersion}`;
-  const response = await fetch(url);
+  const params = new URLSearchParams();
+  if (options?.registryUrl) params.append("registryUrl", options.registryUrl);
+
+  const headers: HeadersInit = {};
+  if (options?.accessToken) {
+    headers["Authorization"] = `Bearer ${options.accessToken}`;
+  }
+
+  const url = `${API_BASE}/servers/${encodedName}/versions/${encodedVersion}${params.toString() ? `?${params.toString()}` : ""}`;
+  const response = await fetch(url, { headers });
+
+  if (response.status === 401) {
+    return response.json() as Promise<RegistryAuthRequiredResponse>;
+  }
 
   if (!response.ok) {
     throw new Error(`Failed to fetch server version: ${response.statusText}`);

--- a/client/src/stores/registry/registry-sources-store.ts
+++ b/client/src/stores/registry/registry-sources-store.ts
@@ -1,0 +1,77 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { RegistrySource } from "@/shared/types";
+
+const OFFICIAL_REGISTRY: RegistrySource = {
+  id: "official",
+  name: "Official",
+  url: "https://registry.modelcontextprotocol.io/v0.1",
+  isOfficial: true,
+  requiresAuth: false,
+};
+
+interface RegistrySourcesState {
+  sources: RegistrySource[];
+  activeSourceId: string;
+
+  // Actions
+  addSource: (source: Omit<RegistrySource, "id">) => string;
+  updateSource: (id: string, updates: Partial<Omit<RegistrySource, "id">>) => void;
+  removeSource: (id: string) => void;
+  setActiveSource: (id: string) => void;
+  getActiveSource: () => RegistrySource;
+}
+
+export const useRegistrySourcesStore = create<RegistrySourcesState>()(
+  persist(
+    (set, get) => ({
+      sources: [OFFICIAL_REGISTRY],
+      activeSourceId: "official",
+
+      addSource: (source) => {
+        const id = crypto.randomUUID();
+        set((state) => ({
+          sources: [...state.sources, { ...source, id }],
+        }));
+        return id;
+      },
+
+      updateSource: (id, updates) => {
+        if (id === "official") return; // Can't modify official
+        set((state) => ({
+          sources: state.sources.map((s) =>
+            s.id === id ? { ...s, ...updates } : s
+          ),
+        }));
+      },
+
+      removeSource: (id) => {
+        if (id === "official") return; // Can't remove official
+        set((state) => ({
+          sources: state.sources.filter((s) => s.id !== id),
+          // Reset to official if removing active source
+          activeSourceId:
+            state.activeSourceId === id ? "official" : state.activeSourceId,
+        }));
+      },
+
+      setActiveSource: (id) => {
+        const { sources } = get();
+        // Only set if source exists
+        if (sources.some((s) => s.id === id)) {
+          set({ activeSourceId: id });
+        }
+      },
+
+      getActiveSource: () => {
+        const { sources, activeSourceId } = get();
+        return (
+          sources.find((s) => s.id === activeSourceId) || OFFICIAL_REGISTRY
+        );
+      },
+    }),
+    {
+      name: "mcp-registry-sources",
+    }
+  )
+);

--- a/server/routes/mcp/registry.ts
+++ b/server/routes/mcp/registry.ts
@@ -2,20 +2,50 @@ import { Hono } from "hono";
 
 const registry = new Hono();
 
-const REGISTRY_BASE_URL = "https://registry.modelcontextprotocol.io/v0.1";
+const DEFAULT_REGISTRY_URL = "https://registry.modelcontextprotocol.io/v0.1";
+
+// Helper to get registry headers with optional auth forwarding
+function getRegistryHeaders(authHeader?: string): HeadersInit {
+  const headers: HeadersInit = {
+    Accept: "application/json",
+  };
+  if (authHeader) {
+    headers["Authorization"] = authHeader;
+  }
+  return headers;
+}
 
 // List all servers with pagination
 registry.get("/servers", async (c) => {
   try {
     const limit = c.req.query("limit") || "50";
     const cursor = c.req.query("cursor");
+    const registryUrl = c.req.query("registryUrl") || DEFAULT_REGISTRY_URL;
 
-    let url = `${REGISTRY_BASE_URL}/servers?limit=${limit}`;
+    let url = `${registryUrl}/servers?limit=${limit}`;
     if (cursor) {
       url += `&cursor=${encodeURIComponent(cursor)}`;
     }
 
-    const response = await fetch(url);
+    // Forward auth header if present
+    const authHeader = c.req.header("Authorization");
+    const response = await fetch(url, {
+      headers: getRegistryHeaders(authHeader),
+    });
+
+    // Handle 401 - return auth challenge info for OAuth flow
+    if (response.status === 401) {
+      const wwwAuthenticate = response.headers.get("WWW-Authenticate");
+      return c.json(
+        {
+          requiresAuth: true,
+          wwwAuthenticate,
+          registryUrl,
+        },
+        401,
+      );
+    }
+
     if (!response.ok) {
       throw new Error(`Registry API returned ${response.status}`);
     }
@@ -38,10 +68,26 @@ registry.get("/servers", async (c) => {
 registry.get("/servers/:serverName/versions", async (c) => {
   try {
     const serverName = c.req.param("serverName");
+    const registryUrl = c.req.query("registryUrl") || DEFAULT_REGISTRY_URL;
     const encodedName = encodeURIComponent(serverName);
 
-    const url = `${REGISTRY_BASE_URL}/servers/${encodedName}/versions`;
-    const response = await fetch(url);
+    const url = `${registryUrl}/servers/${encodedName}/versions`;
+    const authHeader = c.req.header("Authorization");
+    const response = await fetch(url, {
+      headers: getRegistryHeaders(authHeader),
+    });
+
+    if (response.status === 401) {
+      const wwwAuthenticate = response.headers.get("WWW-Authenticate");
+      return c.json(
+        {
+          requiresAuth: true,
+          wwwAuthenticate,
+          registryUrl,
+        },
+        401,
+      );
+    }
 
     if (!response.ok) {
       throw new Error(`Registry API returned ${response.status}`);
@@ -66,11 +112,27 @@ registry.get("/servers/:serverName/versions/:version", async (c) => {
   try {
     const serverName = c.req.param("serverName");
     const version = c.req.param("version");
+    const registryUrl = c.req.query("registryUrl") || DEFAULT_REGISTRY_URL;
     const encodedName = encodeURIComponent(serverName);
     const encodedVersion = encodeURIComponent(version);
 
-    const url = `${REGISTRY_BASE_URL}/servers/${encodedName}/versions/${encodedVersion}`;
-    const response = await fetch(url);
+    const url = `${registryUrl}/servers/${encodedName}/versions/${encodedVersion}`;
+    const authHeader = c.req.header("Authorization");
+    const response = await fetch(url, {
+      headers: getRegistryHeaders(authHeader),
+    });
+
+    if (response.status === 401) {
+      const wwwAuthenticate = response.headers.get("WWW-Authenticate");
+      return c.json(
+        {
+          requiresAuth: true,
+          wwwAuthenticate,
+          registryUrl,
+        },
+        401,
+      );
+    }
 
     if (!response.ok) {
       throw new Error(`Registry API returned ${response.status}`);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -810,3 +810,18 @@ export interface RegistryVersionListResponse {
     count: number;
   };
 }
+
+// Multi-registry support
+export interface RegistrySource {
+  id: string;
+  name: string;
+  url: string;
+  isOfficial: boolean;
+  requiresAuth: boolean;
+}
+
+export interface RegistryAuthRequiredResponse {
+  requiresAuth: true;
+  wwwAuthenticate?: string;
+  registryUrl: string;
+}


### PR DESCRIPTION
Based on https://github.com/modelcontextprotocol/registry/pull/756
<img width="1911" height="958" alt="image" src="https://github.com/user-attachments/assets/90fe2908-5a05-4062-a90a-a4288d19a4c2" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds multi-registry support with a selector and add dialog, per-registry caching, and auth-required handling across client and server.
> 
> - **UI/UX (client)**
>   - `RegistryTab`: integrates `RegistrySelector`, per-registry refresh, and an auth-required empty state; updates header/status UI.
>   - New `registry/RegistrySelector` with add/remove sources and auth indicator; opens `AddRegistryDialog`.
>   - New `registry/AddRegistryDialog` to add custom registries (validates URL, checks connectivity/auth, updates store).
> - **State Management**
>   - New `stores/registry/registry-sources-store`: persistable list of `RegistrySource`s with active source management.
>   - `stores/registry/registry-store`: per-registry cache keys, `currentRegistryUrl`, `authRequired`; fetch methods accept `registryUrl`, handle 401 auth responses, and cache per registry.
> - **Client API**
>   - `lib/registry-api`: requests accept `registryUrl`/`accessToken`; `isAuthRequired` helper; all endpoints return typed auth-required responses on 401.
> - **Server API**
>   - `server/routes/mcp/registry`: accept `registryUrl` param, forward `Authorization`, and return `{ requiresAuth, wwwAuthenticate, registryUrl }` on 401 for servers, versions, and specific version endpoints.
> - **Types**
>   - `shared/types`: add `RegistrySource` and `RegistryAuthRequiredResponse` types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01d6e36f99c8ad481f1438f0165af3d3041f108b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->