### PR TITLE
Bugfix - Send State when Adding Oauth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ sdk/dist/
 sdk/node_modules/
 sdk/mcp-client-manager/node_modules/
 sdk/mcp-client-manager/dist/
+.idea/

--- a/client/src/lib/mcp-oauth.ts
+++ b/client/src/lib/mcp-oauth.ts
@@ -120,6 +120,10 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     this.customClientSecret = customClientSecret;
   }
 
+  state(): string {
+    return `mcp-state-${this.serverName}`
+  }
+
   get redirectUrl(): string {
     return this.redirectUri;
   }
@@ -593,6 +597,7 @@ export function clearOAuthData(serverName: string): void {
   localStorage.removeItem(`mcp-verifier-${serverName}`);
   localStorage.removeItem(`mcp-serverUrl-${serverName}`);
   localStorage.removeItem(`mcp-oauth-config-${serverName}`);
+  localStorage.removeItem(`mcp-state-${serverName}`);
 }
 
 /**


### PR DESCRIPTION
State should be sent with the request -- it's correctly sent in the debugger view but wasn't sent in the add server page.  This adds a placeholder state value.