### PR TITLE
Set logging level to debug by default

### DIFF
--- a/client/src/components/connection/ServerConnectionCard.tsx
+++ b/client/src/components/connection/ServerConnectionCard.tsx
@@ -292,8 +292,11 @@ export function ServerConnectionCard({
                         environment: detectEnvironment(),
                       });
                       // Only force OAuth flow for servers that actually use OAuth
-                      const shouldForceOAuth = server.useOAuth === true || server.oauthTokens != null;
-                      handleReconnect(shouldForceOAuth ? { forceOAuthFlow: true } : undefined);
+                      const shouldForceOAuth =
+                        server.useOAuth === true || server.oauthTokens != null;
+                      handleReconnect(
+                        shouldForceOAuth ? { forceOAuthFlow: true } : undefined,
+                      );
                     }}
                     disabled={
                       isReconnecting ||

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -23,6 +23,7 @@ import type {
   ElicitRequest,
   ElicitResult,
   JSONRPCMessage,
+  LoggingLevel,
   MessageExtraInfo,
 } from "@modelcontextprotocol/sdk/types.js";
 import {
@@ -321,7 +322,7 @@ export class MCPClientManager {
       // clear pending
       state.promise = undefined;
       this.clientStates.set(serverId, state);
-
+      this.setLoggingLevel(serverId, "debug"); // TODO: Allow the user to configure the debugging level to debug.
       return client;
     })().catch((error) => {
       this.resetState(serverId);
@@ -528,6 +529,18 @@ export class MCPClientManager {
       CallToolResultSchema,
       mergedOptions,
     );
+  }
+
+  async setLoggingLevel(serverId: string, level: LoggingLevel = "debug") {
+    await this.ensureConnected(serverId);
+    const client = this.getClientById(serverId);
+    try {
+      await client.setLoggingLevel(level);
+    } catch (error) {
+      throw new Error(
+        `Failed to set logging level for MCP server "${serverId}": ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
+    }
   }
 
   async listResources(


### PR DESCRIPTION
In this PR, we set the logging level to `debug` by default. In the next PR, we allow the user to configure the logging level at the connection step. 

In the official inspector, the current default log level is `debug`
