### PR TITLE
Create the ability to set log levels

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,6 +23,7 @@ import { useElectronOAuth } from "./hooks/useElectronOAuth";
 import { useEnsureDbUser } from "./hooks/useEnsureDbUser";
 import { usePostHog } from "posthog-js/react";
 import { usePostHogIdentify } from "./hooks/usePostHogIdentify";
+import { AppStateProvider } from "./state/app-state-context";
 
 // Import global styles
 import "./index.css";
@@ -98,11 +99,9 @@ export default function App() {
     handleRemoveServer,
     setSelectedServer,
     toggleServerSelection,
-    selectedMCPConfigsMap,
     setSelectedMultipleServersToAllServers,
     workspaces,
     activeWorkspaceId,
-    activeWorkspace,
     handleSwitchWorkspace,
     handleCreateWorkspace,
     handleUpdateWorkspace,
@@ -290,12 +289,14 @@ export default function App() {
       themePreset={initialThemePreset}
     >
       <RegistryStoreProvider>
-        <Toaster />
-        {shouldShowLoginPage && !isOAuthCallbackComplete ? (
-          <LoginPage />
-        ) : (
-          appContent
-        )}
+        <AppStateProvider appState={appState}>
+          <Toaster />
+          {shouldShowLoginPage && !isOAuthCallbackComplete ? (
+            <LoginPage />
+          ) : (
+            appContent
+          )}
+        </AppStateProvider>
       </RegistryStoreProvider>
     </PreferencesStoreProvider>
   );

--- a/client/src/components/EvalsTab.tsx
+++ b/client/src/components/EvalsTab.tsx
@@ -13,7 +13,6 @@ import {
 import { detectEnvironment, detectPlatform } from "@/logs/PosthogUtils";
 import { useEvalsRoute, navigateToEvalsRoute } from "@/lib/evals-router";
 import { useChat } from "@/hooks/use-chat";
-import { useAppState } from "@/hooks/use-app-state";
 import { aggregateSuite } from "./evals/helpers";
 import { SuiteIterationsView } from "./evals/suite-iterations-view";
 import { EvalRunner } from "./evals/eval-runner";
@@ -22,6 +21,7 @@ import { ConfirmationDialogs } from "./evals/ConfirmationDialogs";
 import { useEvalQueries } from "./evals/use-eval-queries";
 import { useEvalMutations } from "./evals/use-eval-mutations";
 import { useEvalHandlers } from "./evals/use-eval-handlers";
+import { useSharedAppState } from "@/state/app-state-context";
 
 export function EvalsTab() {
   const { isAuthenticated, isLoading } = useConvexAuth();
@@ -86,7 +86,7 @@ export function EvalsTab() {
   });
 
   // Get app state for server connections
-  const { appState } = useAppState();
+  const appState = useSharedAppState();
 
   // Get connected server names
   const connectedServerNames = useMemo(

--- a/client/src/components/evals/eval-runner.tsx
+++ b/client/src/components/evals/eval-runner.tsx
@@ -41,6 +41,7 @@ import type {
   TestTemplate,
   ExpectedToolCall,
 } from "./eval-runner/types";
+import { useSharedAppState } from "@/state/app-state-context";
 
 interface EvalRunnerProps {
   availableModels: ModelDefinition[];
@@ -99,7 +100,7 @@ export function EvalRunner({
   } | null>(null);
   const { isAuthenticated } = useConvexAuth();
   const { getAccessToken } = useAuth();
-  const { appState } = useAppState();
+  const appState = useSharedAppState();
   const { getToken, hasToken } = useAiProviderKeys();
 
   const [selectedServers, setSelectedServers] = useState<string[]>([]);

--- a/client/src/state/app-state-context.tsx
+++ b/client/src/state/app-state-context.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext } from "react";
+import type { AppState } from "./app-types";
+
+const AppStateContext = createContext<AppState | null>(null);
+
+export function AppStateProvider({
+  appState,
+  children,
+}: {
+  appState: AppState;
+  children: React.ReactNode;
+}) {
+  return (
+    <AppStateContext.Provider value={appState}>
+      {children}
+    </AppStateContext.Provider>
+  );
+}
+
+export function useSharedAppState(): AppState {
+  const ctx = useContext(AppStateContext);
+  if (!ctx) {
+    throw new Error("useSharedAppState must be used within AppStateProvider");
+  }
+  return ctx;
+}

--- a/client/src/state/mcp-api.ts
+++ b/client/src/state/mcp-api.ts
@@ -1,4 +1,5 @@
 import { MCPServerConfig } from "@/sdk";
+import type { LoggingLevel } from "@modelcontextprotocol/sdk/types.js";
 
 // Helper to add timeout to fetch requests
 async function fetchWithTimeout(
@@ -75,5 +76,17 @@ export async function getInitializationInfo(serverId: string) {
   const res = await fetch(
     `/api/mcp/servers/init-info/${encodeURIComponent(serverId)}`,
   );
+  return res.json();
+}
+
+export async function setServerLoggingLevel(
+  serverId: string,
+  level: LoggingLevel,
+) {
+  const res = await fetch("/api/mcp/log-level", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ serverId, level }),
+  });
   return res.json();
 }

--- a/server/routes/mcp/index.ts
+++ b/server/routes/mcp/index.ts
@@ -21,6 +21,7 @@ import models from "./models";
 import listTools from "./list-tools";
 import tokenizer from "./tokenizer";
 import tunnelsRoute from "./tunnels";
+import logLevel from "./log-level";
 
 // ES module equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -106,5 +107,8 @@ mcp.route("/tokenizer", tokenizer);
 
 // Tunnel management endpoints - create ngrok tunnels for servers
 mcp.route("/tunnels", tunnelsRoute);
+
+// Logging level endpoint - configure per-server logging verbosity
+mcp.route("/log-level", logLevel);
 
 export default mcp;

--- a/server/routes/mcp/log-level.ts
+++ b/server/routes/mcp/log-level.ts
@@ -1,0 +1,75 @@
+import { Hono } from "hono";
+import type { LoggingLevel } from "@modelcontextprotocol/sdk/types.js";
+import "../../types/hono"; // Extend Hono context
+
+type SetLogLevelRequest = {
+  serverId?: string;
+  level?: LoggingLevel;
+};
+
+const VALID_LEVELS: LoggingLevel[] = [
+  "debug",
+  "info",
+  "notice",
+  "warning",
+  "error",
+  "critical",
+  "alert",
+  "emergency",
+];
+
+const logLevel = new Hono();
+
+logLevel.post("/", async (c) => {
+  try {
+    const { serverId, level } = (await c.req.json()) as SetLogLevelRequest;
+
+    if (!serverId || !level) {
+      return c.json(
+        { success: false, error: "serverId and level are required" },
+        400,
+      );
+    }
+
+    if (!VALID_LEVELS.includes(level)) {
+      return c.json(
+        {
+          success: false,
+          error: `Invalid logging level "${level}". Expected one of: ${VALID_LEVELS.join(", ")}`,
+        },
+        400,
+      );
+    }
+
+    const mcpClientManager = c.mcpClientManager;
+    if (!mcpClientManager.hasServer(serverId)) {
+      return c.json(
+        {
+          success: false,
+          error: `Server "${serverId}" is not registered`,
+        },
+        404,
+      );
+    }
+
+    await mcpClientManager.setLoggingLevel(serverId, level);
+
+    return c.json({
+      success: true,
+      serverId,
+      level,
+      message: `Logging level set to "${level}" for server "${serverId}"`,
+    });
+  } catch (error) {
+    console.error("Error setting MCP server logging level:", error);
+    return c.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      500,
+    );
+  }
+});
+
+export default logLevel;


### PR DESCRIPTION
We want to be able to set log levels for various MCP servers. Look at the [official documentation](https://modelcontextprotocol.info/specification/draft/server/utilities/logging/) for how to configure log levels. 

Fixes https://github.com/MCPJam/inspector/issues/989

https://github.com/user-attachments/assets/bcff0992-0482-49e5-9137-d6b151695080

