### PR TITLE
split format and build into two jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,8 +53,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --legacy-peer-deps
-          cd sdk && npm ci --legacy-peer-deps && cd ..
+          npm ci
 
       - name: Build project
         run: |


### PR DESCRIPTION
* If formatting it fails, it shouldn't cause the build job to just not run
* Makes both jobs run in parallel