### PR TITLE
fix: OpenRouter isConfigured icon is inconsistent

### DIFF
--- a/client/src/components/setting/OpenRouterTableRow.tsx
+++ b/client/src/components/setting/OpenRouterTableRow.tsx
@@ -43,7 +43,7 @@ export function OpenRouterTableRow({
           </div>
           <div>
             <h3 className="text-md font-semibold text-foreground pb-1">
-              OpenRouter {isConfigured && <span className="text-md">√</span>}
+              OpenRouter {isConfigured && <span className="text-md">✔️</span>}
             </h3>
             <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground">
               {isConfigured


### PR DESCRIPTION
**Description:** The icon to indicate `OpenRouter` API key is configured is different from the other providers. This PR makes the icon consistent for all providers. 

**Before:**
<img width="1428" height="780" alt="Screenshot 2025-12-08 at 4 45 37 PM" src="https://github.com/user-attachments/assets/70fff106-d103-4e9e-81c0-d8cdadb005e8" />

**After:**
<img width="1428" height="780" alt="Screenshot 2025-12-08 at 4 45 00 PM" src="https://github.com/user-attachments/assets/fab62d13-78af-49f2-87e9-9fe9e13089e5" />