### PR TITLE
Add device globals

### DIFF
--- a/client/src/components/chat-v2/chatgpt-app-renderer.tsx
+++ b/client/src/components/chat-v2/chatgpt-app-renderer.tsx
@@ -476,10 +476,14 @@ export function ChatGPTAppRenderer({
   const playgroundCspMode = useUIPlaygroundStore((s) => s.cspMode);
   const playgroundDeviceType = useUIPlaygroundStore((s) => s.deviceType);
   const playgroundCapabilities = useUIPlaygroundStore((s) => s.capabilities);
-  const playgroundSafeAreaInsets = useUIPlaygroundStore((s) => s.safeAreaInsets);
+  const playgroundSafeAreaInsets = useUIPlaygroundStore(
+    (s) => s.safeAreaInsets,
+  );
   const cspMode = isPlaygroundActive ? playgroundCspMode : "permissive";
   // Use playground settings when active, otherwise compute from window
-  const deviceType = isPlaygroundActive ? playgroundDeviceType : getDeviceType();
+  const deviceType = isPlaygroundActive
+    ? playgroundDeviceType
+    : getDeviceType();
   const capabilities = isPlaygroundActive
     ? playgroundCapabilities
     : { hover: true, touch: false }; // Default for non-playground contexts
@@ -919,7 +923,15 @@ export function ChatGPTAppRenderer({
         },
       },
     });
-  }, [currentWidgetState, resolvedToolCallId, themeMode, locale, deviceType, capabilities, safeAreaInsets]);
+  }, [
+    currentWidgetState,
+    resolvedToolCallId,
+    themeMode,
+    locale,
+    deviceType,
+    capabilities,
+    safeAreaInsets,
+  ]);
 
   // Reset modal sandbox state when modal closes
   useEffect(() => {

--- a/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -573,7 +573,9 @@ export function PlaygroundMain({
                 <Button
                   variant={capabilities.hover ? "secondary" : "ghost"}
                   size="icon"
-                  onClick={() => setCapabilities({ hover: !capabilities.hover })}
+                  onClick={() =>
+                    setCapabilities({ hover: !capabilities.hover })
+                  }
                   className="h-7 w-7"
                 >
                   <MousePointer2 className="h-3.5 w-3.5" />
@@ -591,7 +593,9 @@ export function PlaygroundMain({
                 <Button
                   variant={capabilities.touch ? "secondary" : "ghost"}
                   size="icon"
-                  onClick={() => setCapabilities({ touch: !capabilities.touch })}
+                  onClick={() =>
+                    setCapabilities({ touch: !capabilities.touch })
+                  }
                   className="h-7 w-7"
                 >
                   <Hand className="h-3.5 w-3.5" />

--- a/client/src/components/ui-playground/SafeAreaEditor.tsx
+++ b/client/src/components/ui-playground/SafeAreaEditor.tsx
@@ -22,13 +22,18 @@ const PRESET_OPTIONS: {
 }[] = [
   { preset: "none", label: "None", shortLabel: "None" },
   { preset: "iphone-notch", label: "iPhone Notch", shortLabel: "Notch" },
-  { preset: "iphone-dynamic-island", label: "Dynamic Island", shortLabel: "Island" },
+  {
+    preset: "iphone-dynamic-island",
+    label: "Dynamic Island",
+    shortLabel: "Island",
+  },
   { preset: "android-gesture", label: "Android", shortLabel: "Android" },
 ];
 
 /** Safe Area Visualization - shows the insets visually */
 function SafeAreaVisualization({ insets }: { insets: SafeAreaInsets }) {
-  const hasAnyInset = insets.top > 0 || insets.bottom > 0 || insets.left > 0 || insets.right > 0;
+  const hasAnyInset =
+    insets.top > 0 || insets.bottom > 0 || insets.left > 0 || insets.right > 0;
 
   return (
     <div className="relative w-full h-[140px] rounded-lg border-2 border-dashed border-border overflow-hidden bg-muted/30">
@@ -187,12 +192,14 @@ export function SafeAreaEditor() {
             {PRESET_OPTIONS.map((option) => (
               <Button
                 key={option.preset}
-                variant={safeAreaPreset === option.preset ? "secondary" : "ghost"}
+                variant={
+                  safeAreaPreset === option.preset ? "secondary" : "ghost"
+                }
                 size="sm"
                 onClick={() => setSafeAreaPreset(option.preset)}
                 className={cn(
                   "flex-1 h-6 text-[10px] px-1",
-                  safeAreaPreset === option.preset && "ring-1 ring-ring"
+                  safeAreaPreset === option.preset && "ring-1 ring-ring",
                 )}
               >
                 {option.shortLabel}

--- a/client/src/stores/ui-playground-store.ts
+++ b/client/src/stores/ui-playground-store.ts
@@ -26,11 +26,19 @@ export interface SafeAreaInsets {
   right: number;
 }
 
-export type SafeAreaPreset = "none" | "iphone-notch" | "iphone-dynamic-island" | "android-gesture" | "custom";
+export type SafeAreaPreset =
+  | "none"
+  | "iphone-notch"
+  | "iphone-dynamic-island"
+  | "android-gesture"
+  | "custom";
 
 /** Preset safe area configurations for common devices */
-export const SAFE_AREA_PRESETS: Record<Exclude<SafeAreaPreset, "custom">, SafeAreaInsets> = {
-  "none": { top: 0, bottom: 0, left: 0, right: 0 },
+export const SAFE_AREA_PRESETS: Record<
+  Exclude<SafeAreaPreset, "custom">,
+  SafeAreaInsets
+> = {
+  none: { top: 0, bottom: 0, left: 0, right: 0 },
   "iphone-notch": { top: 44, bottom: 34, left: 0, right: 0 },
   "iphone-dynamic-island": { top: 59, bottom: 34, left: 0, right: 0 },
   "android-gesture": { top: 24, bottom: 16, left: 0, right: 0 },

--- a/server/routes/mcp/chatgpt.ts
+++ b/server/routes/mcp/chatgpt.ts
@@ -243,7 +243,12 @@ function generateApiScript(opts: ApiScriptOptions): string {
 
   // Host-controlled capabilities (with fallback to widget detection if not provided)
   const hostCapabilities = capabilities ?? null;
-  const hostSafeAreaInsets = safeAreaInsets ?? { top: 0, bottom: 0, left: 0, right: 0 };
+  const hostSafeAreaInsets = safeAreaInsets ?? {
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+  };
 
   return `<script>
 (function() {
@@ -768,7 +773,12 @@ chatgpt.post("/widget/store", async (c) => {
       maxHeight: maxHeight ?? null, // Host-controlled max height constraint
       cspMode: cspMode ?? "permissive", // CSP enforcement mode
       capabilities: capabilities ?? { hover: true, touch: false }, // Device capabilities
-      safeAreaInsets: safeAreaInsets ?? { top: 0, bottom: 0, left: 0, right: 0 }, // Safe area insets
+      safeAreaInsets: safeAreaInsets ?? {
+        top: 0,
+        bottom: 0,
+        left: 0,
+        right: 0,
+      }, // Safe area insets
       timestamp: Date.now(),
     });
     return c.json({ success: true });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Plumbs `deviceType`, `capabilities` (hover/touch), and `safeAreaInsets` from the UI Playground through the renderer to the server and into the widget API/globals, adding playground controls and presets.
> 
> - **Frontend**
>   - **ChatGPT App Renderer (`client/src/components/chat-v2/chatgpt-app-renderer.tsx`)**:
>     - Accepts and forwards `deviceType`, `capabilities`, and `safeAreaInsets` to widget storage and globals (`openai:set_globals`), including modal.
>     - Reads these from UI Playground when active; defaults applied otherwise.
>   - **UI Playground (`client/src/components/ui-playground`)**:
>     - Adds capability toggles (hover/touch) and a `SafeAreaEditor` popover with presets and per-edge inputs.
>     - Extends store (`ui-playground-store.ts`) with `capabilities`, `safeAreaPreset`, `safeAreaInsets`, presets, setters, and auto-capability updates on `deviceType` change.
> - **Backend**
>   - **Server routes (`server/routes/mcp/chatgpt.ts`)**:
>     - Extends `WidgetData`, request payloads, and route handling to persist and pass `capabilities` and `safeAreaInsets`.
>     - Updates `generateApiScript` to include `safeArea.insets` and `userAgent.capabilities` (with host-provided or detected fallbacks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3c1383c3a1881b9f5df82ba9ce3b8f8d268d2e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->