### PR TITLE
add widgetPrefersBorder for OpenAI Apps

### DIFF
--- a/client/src/components/chat-v2/chatgpt-app-renderer.tsx
+++ b/client/src/components/chat-v2/chatgpt-app-renderer.tsx
@@ -373,7 +373,7 @@ function useWidgetFetch(
             return;
           }
 
-            setPrefersBorder(data.prefersBorder);
+          setPrefersBorder(data.prefersBorder ?? true);
         }
 
         // Set the widget URL with CSP mode query param


### PR DESCRIPTION
* Exposes `widgetPrefersBorder` to the client and uses conditionally rendering to render a widget.