### PR TITLE
fix: resize loops for MCP Apps

### DIFF
--- a/client/src/components/ui/sandboxed-iframe.tsx
+++ b/client/src/components/ui/sandboxed-iframe.tsx
@@ -25,6 +25,7 @@ import {
 
 export interface SandboxedIframeHandle {
   postMessage: (data: unknown) => void;
+  getIframeElement: () => HTMLIFrameElement | null;
 }
 
 /** CSP metadata per SEP-1865 */
@@ -118,6 +119,7 @@ export const SandboxedIframe = forwardRef<
       postMessage: (data: unknown) => {
         outerRef.current?.contentWindow?.postMessage(data, sandboxProxyOrigin);
       },
+      getIframeElement: () => outerRef.current,
     }),
     [sandboxProxyOrigin],
   );


### PR DESCRIPTION
* This PR should finally fix most issues with resizing widgets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle widget resize by directly sizing/animating the iframe (with border-box compensation) in inline mode, remove state-based height clamping, and expose `getIframeElement` from `SandboxedIframe`.
> 
> - **MCP Apps Renderer (`client/src/components/chat-v2/thread/mcp-apps-renderer.tsx`)**:
>   - Replace state-driven height (`contentHeight`/`appliedHeight`) with direct iframe resizing on `ui/notifications/size-changed`.
>     - Ignore resize in non-inline modes; compute height with border-box compensation; animate via Web Animations API.
>   - Stop clamping height to `maxHeight`; keep `maxHeight` only in viewport info.
>   - Default inline height set to `400px`; fullscreen uses `100%`.
>   - Remove transition class-based height handling.
> - **Sandboxed Iframe (`client/src/components/ui/sandboxed-iframe.tsx`)**:
>   - Add `getIframeElement()` to ref handle for direct iframe access from host.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb6dd349343a3835d0e6a00ce234dc1e7cefa280. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->