### PR TITLE
Prevent 0.0.0.0 day RCE vulnerability

### DIFF
--- a/server/routes/mcp/elicitation.ts
+++ b/server/routes/mcp/elicitation.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { ElicitResult } from "@modelcontextprotocol/sdk/types.js";
+import { buildCorsHeaders } from "../../utils/cors";
 
 const elicitation = new Hono();
 
@@ -49,6 +50,10 @@ elicitation.use("*", async (c, next) => {
 
 // SSE stream for elicitation events
 elicitation.get("/stream", async (c) => {
+  const originHeader = c.req.header("origin");
+  const { headers: corsHeaders } = buildCorsHeaders(originHeader, {
+    allowCredentials: true,
+  });
   const encoder = new TextEncoder();
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
@@ -85,11 +90,11 @@ elicitation.get("/stream", async (c) => {
   return new Response(stream as any, {
     status: 200,
     headers: {
+      ...corsHeaders,
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache, no-transform",
       Connection: "keep-alive",
       "X-Accel-Buffering": "no",
-      "Access-Control-Allow-Origin": "*",
     },
   });
 });

--- a/server/utils/cors.ts
+++ b/server/utils/cors.ts
@@ -1,0 +1,84 @@
+import { CORS_ORIGINS, SERVER_HOSTNAME } from "../config";
+
+type CorsOptions = {
+  allowCredentials?: boolean;
+  allowHeaders?: string;
+  allowMethods?: string;
+  exposeHeaders?: string;
+  maxAge?: string;
+  requestPrivateNetwork?: boolean;
+  allowPrivateNetwork?: boolean;
+};
+
+const normalizedAllowedOrigins = new Set(
+  CORS_ORIGINS.map((origin) => normalizeOrigin(origin)),
+);
+
+const allowedHostnames = new Set(
+  [SERVER_HOSTNAME, "localhost", "127.0.0.1", "::1"].map((host) =>
+    host.toLowerCase(),
+  ),
+);
+
+function normalizeOrigin(origin: string) {
+  return origin.trim().replace(/\/$/, "").toLowerCase();
+}
+
+function extractHostname(hostHeader: string | null | undefined) {
+  if (!hostHeader) return null;
+  const trimmed = hostHeader.trim();
+  if (trimmed.startsWith("[")) {
+    const closing = trimmed.indexOf("]");
+    if (closing !== -1) return trimmed.slice(1, closing).toLowerCase();
+  }
+  return trimmed.split(":")[0]?.toLowerCase() ?? null;
+}
+
+export function getAllowedOrigin(originHeader: string | null | undefined) {
+  if (!originHeader) return null;
+  const normalized = normalizeOrigin(originHeader);
+  return normalizedAllowedOrigins.has(normalized) ? normalized : null;
+}
+
+export function isAllowedHost(hostHeader: string | null | undefined) {
+  const hostname = extractHostname(hostHeader);
+  if (!hostname) return true;
+  return allowedHostnames.has(hostname);
+}
+
+export function buildCorsHeaders(
+  originHeader: string | null | undefined,
+  options: CorsOptions = {},
+) {
+  const allowedOrigin = getAllowedOrigin(originHeader);
+  const headers: Record<string, string> = { Vary: "Origin" };
+
+  if (allowedOrigin) {
+    headers["Access-Control-Allow-Origin"] = allowedOrigin;
+    if (options.allowCredentials) {
+      headers["Access-Control-Allow-Credentials"] = "true";
+    }
+    if (
+      options.allowPrivateNetwork &&
+      options.requestPrivateNetwork &&
+      originHeader
+    ) {
+      headers["Access-Control-Allow-Private-Network"] = "true";
+    }
+  }
+
+  if (options.allowMethods) {
+    headers["Access-Control-Allow-Methods"] = options.allowMethods;
+  }
+  if (options.allowHeaders) {
+    headers["Access-Control-Allow-Headers"] = options.allowHeaders;
+  }
+  if (options.exposeHeaders) {
+    headers["Access-Control-Expose-Headers"] = options.exposeHeaders;
+  }
+  if (options.maxAge) {
+    headers["Access-Control-Max-Age"] = options.maxAge;
+  }
+
+  return { headers, allowedOrigin };
+}


### PR DESCRIPTION
This PR proposes a fix to the 0.0.0.0 day vulnerability where localhost applications are vulnerable to remote code execution. We add a PNA pre-flight with verification to reject requests from unverified origins. 

https://github.com/MCPJam/inspector/issues/1095

- Add centralized CORS/host utility that enforces the localhost allowlist and builds consistent headers (including PNA
  support).
- Reject requests with disallowed Host/Origin early and answer preflights only for trusted origins.
- Replace wildcard CORS on MCP HTTP/SSE/elicitation endpoints with allowlisted, credentials-aware responses.