### PR TITLE
Fix App Builder tool metadata issue

### DIFF
--- a/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -69,6 +69,7 @@ import { usePostHog } from "posthog-js/react";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { useTrafficLogStore } from "@/stores/traffic-log-store";
 import { MCPJamFreeModelsPrompt } from "@/components/chat-v2/mcpjam-free-models-prompt";
+import { useSharedAppState } from "@/state/app-state-context";
 
 /** Device frame configurations - extends shared viewport config with UI properties */
 const PRESET_DEVICE_CONFIGS: Record<
@@ -285,10 +286,13 @@ export function PlaygroundMain({
     setThemeMode(newTheme);
   }, [themeMode, setThemeMode]);
 
-  // Single server for playground
+  const { servers } = useSharedAppState();
   const selectedServers = useMemo(
-    () => (serverName ? [serverName] : []),
-    [serverName],
+    () =>
+      serverName && servers[serverName]?.connectionStatus === "connected"
+        ? [serverName]
+        : [],
+    [serverName, servers],
   );
 
   // Use shared chat session hook


### PR DESCRIPTION
## Issue
When you run the MCPJam command with the `--tab` and `--oauth` tags 
```
npx @mcpjam/inspector@latest --url https://chatagotchi-9f494189.alpic.live/ --oauth --tab app-builder
```
it would take the user to the app-builder tab with a pre-connection. This command connects to the server too. However, this command did not refresh the tools metadata, hence why the widgets were not loading. 

## Fix 
The issue was that when the app builder is initially loaded, the server isn't connected yet, and the tools metadata is empty. Once the server is connected, we _didn't_ refresh the tools metadata. 