### PR TITLE
Add `prefersBorder` in MCP apps

### DIFF
--- a/client/src/components/chat-v2/thread/mcp-apps-renderer.tsx
+++ b/client/src/components/chat-v2/thread/mcp-apps-renderer.tsx
@@ -230,6 +230,7 @@ export function MCPAppsRenderer({
     undefined,
   );
   const [widgetPermissive, setWidgetPermissive] = useState<boolean>(false);
+  const [prefersBorder, setPrefersBorder] = useState<boolean>(true);
   const [loadedCspMode, setLoadedCspMode] = useState<CspMode | null>(null);
   // SEP-1865 mimetype validation
   const [mimeTypeWarning, setMimeTypeWarning] = useState<string | null>(null);
@@ -286,16 +287,17 @@ export function MCPAppsRenderer({
               `Failed to fetch widget: ${contentResponse.statusText}`,
           );
         }
-
         const {
           html,
           csp,
           permissive,
           mimeTypeWarning: warning,
+          prefersBorder,
         } = await contentResponse.json();
         setWidgetHtml(html);
         setWidgetCsp(csp);
         setWidgetPermissive(permissive ?? false);
+        setPrefersBorder(prefersBorder ?? true);
         setLoadedCspMode(cspMode);
         setMimeTypeWarning(warning ?? null);
       } catch (err) {
@@ -980,7 +982,7 @@ export function MCPAppsRenderer({
         className={`w-full bg-background overflow-hidden ${
           isFullscreen
             ? "flex-1 border-0 rounded-none"
-            : "border border-border/40 rounded-md"
+            : `rounded-md ${prefersBorder ? "border border-border/40" : ""}`
         }`}
         style={{
           height: isFullscreen ? "100%" : "400px",

--- a/server/routes/mcp/apps.ts
+++ b/server/routes/mcp/apps.ts
@@ -88,7 +88,7 @@ apps.post("/widget/store", async (c) => {
 
     return c.json({ success: true });
   } catch (error) {
-    logger.error("[MCP Apps] Error storing widget data", error, { toolId });
+    logger.error("[MCP Apps] Error storing widget data", error);
     return c.json(
       {
         success: false,
@@ -202,7 +202,7 @@ apps.get("/widget-content/:toolId", async (c) => {
       mimeTypeWarning,
     });
   } catch (error) {
-    logger.error("[MCP Apps] Error fetching resource", error, { resourceUri });
+    logger.error("[MCP Apps] Error fetching resource", error);
     return c.json(
       { error: error instanceof Error ? error.message : "Unknown error" },
       500,


### PR DESCRIPTION
In this PR, we add support for `prefersBorder`. See the [official MCP apps](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/draft/apps.mdx) doc for what prefersBorder does. 

