### PR TITLE
feat: add same allow permission in the mcp apps iframe than in chatgpt app

### DIFF
--- a/client/src/components/ui/sandboxed-iframe.tsx
+++ b/client/src/components/ui/sandboxed-iframe.tsx
@@ -196,6 +196,7 @@ export const SandboxedIframe = forwardRef<
       ref={outerRef}
       src={sandboxProxyUrl}
       sandbox="allow-scripts allow-same-origin"
+      allow="local-network-access *; microphone *; midi *"
       title={title}
       className={className}
       style={style}

--- a/server/routes/mcp/sandbox-proxy.html
+++ b/server/routes/mcp/sandbox-proxy.html
@@ -191,6 +191,11 @@ document.addEventListener('securitypolicyviolation', function(e) {
         "sandbox",
         "allow-scripts allow-same-origin allow-forms",
       );
+      // Permissions Policy matching ChatGPT's actual implementation
+      inner.setAttribute(
+        "allow",
+        "local-network-access *; microphone *; midi *",
+      );
       document.body.appendChild(inner);
 
       // Handle messages from parent (host) and inner (guest UI)


### PR DESCRIPTION
At Skybridge, we are adding a small middleware to check if the current host has the local-network-access permission enabled. 

The reason behind that is for people testing developing an app on ChatGPT and who have might (by mistake) disable localhost calls.

This is being done by using the request :

`const status = await navigator.permissions.query({ name: "local-network-access" });`

This value returns "denied" if it's being used in an iframe that does not have the local-network-access allow attribute.

So I'm proposing to mimic the current behavior on the ChatGPT iframes.