### PR TITLE
Send CSS variables via hostContext.styles.variables

### DIFF
--- a/client/src/components/chat-v2/thread/mcp-apps-renderer.tsx
+++ b/client/src/components/chat-v2/thread/mcp-apps-renderer.tsx
@@ -513,6 +513,26 @@ export function MCPAppsRenderer({
     setWidgetGlobals,
   ]);
 
+  // CSS Variables for theming (SEP-1865 styles.variables)
+  // These are sent via hostContext.styles.variables - the SDK should pass them through
+  const styleVariables = useMemo(() => {
+    const isDark = themeMode === "dark";
+    return {
+      "--color-background-primary": isDark ? "#171717" : "#ffffff",
+      "--color-background-secondary": isDark ? "#262626" : "#f5f5f5",
+      "--color-text-primary": isDark ? "#fafafa" : "#171717",
+      "--color-text-secondary": isDark ? "#a3a3a3" : "#737373",
+      "--color-border-primary": isDark ? "#404040" : "#e5e5e5",
+      "--font-sans":
+        "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+      "--font-mono":
+        "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace",
+      "--border-radius-sm": "4px",
+      "--border-radius-md": "8px",
+      "--border-radius-lg": "12px",
+    } as Record<string, string>;
+  }, [themeMode]);
+
   const hostContext = useMemo<McpUiHostContext>(
     () => ({
       theme: themeMode,
@@ -530,6 +550,9 @@ export function MCPAppsRenderer({
       userAgent: navigator.userAgent,
       deviceCapabilities,
       safeAreaInsets,
+      styles: {
+        variables: styleVariables,
+      },
       toolInfo: {
         id: toolCallId,
         tool: {
@@ -556,6 +579,7 @@ export function MCPAppsRenderer({
       platform,
       deviceCapabilities,
       safeAreaInsets,
+      styleVariables,
       toolCallId,
       toolName,
       toolMetadata,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enables MCP Apps theming by providing host-defined CSS variables.
> 
> - Adds `styleVariables` (light/dark colors, fonts, border radii) computed from `themeMode`
> - Injects variables into `hostContext.styles.variables` so the SDK can pass them to widgets
> - Updates memo deps to include `styleVariables`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c317167122b0f515bdb5b39d06460461955ddc64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->