### PR TITLE
Fix promise bug

### DIFF
--- a/mcpjam-inspector/sdk/src/mcp-client-manager/index.ts
+++ b/mcpjam-inspector/sdk/src/mcp-client-manager/index.ts
@@ -423,6 +423,9 @@ export class MCPClientManager {
     const client = this.getClientById(serverId);
     try {
       await client.close();
+    } catch {
+      // Ignore errors from close() - the SDK may throw McpError when closing
+      // connections that have pending requests. This is expected behavior.
     } finally {
       if (client.transport) {
         await this.safeCloseTransport(client.transport);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves robustness around MCP disconnects to avoid process crashes and noisy errors.
> 
> - **SDK (`mcp-client-manager`)**: `disconnectServer` now ignores expected errors from `client.close()` (e.g., pending requests), still closes transport via `safeCloseTransport` and resets state.
> - **Server**: Adds a global `unhandledRejection` handler that logs expected MCP connection-close rejections at debug level and warns on unexpected ones, preventing Node v24+ from terminating the process.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08b7f74db085eb9429d0f048a453cd85d777620b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->