### PR TITLE
docs: fix MCPJam inspector usage

### DIFF
--- a/docs/guides/first-mcp-app.mdx
+++ b/docs/guides/first-mcp-app.mdx
@@ -477,17 +477,13 @@ Your server is now running and communicating via STDIO. It's ready to be connect
 
 ### Testing with MCPJam Inspector
 
-The easiest way to test your app is using MCPJam Inspector with the built-in `node` command:
+The easiest way to test your app is using MCPJam Inspector:
 
 ```bash
-npx @mcpjam/inspector node server.ts
+npx @mcpjam/inspector
 ```
 
-This will:
-1. Start MCPJam Inspector
-2. Automatically connect to your server via STDIO
-3. Show all available tools including `get-reservation` and `get-menu`
-4. Let you test the full interactive flow
+You can then add your server and use our App Builder or our LLM Playground to test your app!
 
 ### What's next?
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates documentation in `docs/guides/first-mcp-app.mdx` to reflect current MCPJam Inspector workflow.
> 
> - Replaces `npx @mcpjam/inspector node server.ts` with `npx @mcpjam/inspector`
> - Removes auto-connection/auto-tool listing steps; instructs users to add their server and use App Builder or LLM Playground for testing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 829211e426aee2dee39aa8c31706d06f3592dede. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->