### PR TITLE
Simplify origin code

### DIFF
--- a/mcpjam-inspector/client/src/components/auth/auth-upper-area.tsx
+++ b/mcpjam-inspector/client/src/components/auth/auth-upper-area.tsx
@@ -69,14 +69,10 @@ export function AuthUpperArea({
 
   const handleSignOut = () => {
     const isElectron = (window as any).isElectron;
-    const origin = window.location.origin;
-    const normalizedOrigin = origin.includes("://localhost")
-      ? origin.replace("://localhost", "://127.0.0.1")
-      : origin;
     const returnTo =
       isElectron && import.meta.env.DEV
         ? "http://localhost:8080/callback"
-        : normalizedOrigin;
+        : window.location.origin;
     signOut({ returnTo });
   };
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Simplify sign-out redirect logic**
> 
> - Streamlines `handleSignOut` in `auth-upper-area.tsx` by removing localhost→127.0.0.1 normalization and defaulting non-Electron return URL to `window.location.origin` (Electron DEV still uses `http://localhost:8080/callback`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bab12772392ad935d5a7188199267b2239c7b38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->