### PR TITLE
Remove What's Next sub-section from workspaces docs

### DIFF
--- a/docs/inspector/workspaces.mdx
+++ b/docs/inspector/workspaces.mdx
@@ -63,9 +63,3 @@ Once they sign in with that email address, the shared workspace will appear in t
 If you created the workspace, you can remove any member by clicking the X next to their name.
 
 If you're not the creator, you can leave the workspace at any time. The creator can also remove you from the workspace.
-
-## What's Next
-
-- **[Servers](/inspector/connecting-servers)** - Configure MCP servers to add to your workspaces
-- **[MCP Evals](/evals/overview)** - Test your server configurations
-- **[LLM Playground](/inspector/llm-playground)** - Chat with your servers


### PR DESCRIPTION
Remove What's Next sub-section from workspaces docs, it didn't make sense