### PR TITLE
chore: fix playground input width

### DIFF
--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -657,10 +657,10 @@ export function PlaygroundMain({
       {!isWidgetFullTakeover && !showFullscreenChatOverlay && (
         <div
           className={cn(
-            "flex-shrink-0",
+            "flex-shrink-0 max-w-xl mx-auto w-full",
             isThreadEmpty
-              ? "px-4 pb-4 max-w-xl mx-auto w-full"
-              : "bg-background/80 backdrop-blur-sm border-t border-border p-3",
+              ? "px-4 pb-4"
+              : "bg-background/80 backdrop-blur-sm p-3",
           )}
         >
           <ChatInput {...sharedChatInputProps} hasMessages={!isThreadEmpty} />


### PR DESCRIPTION
Before:
<img width="861" height="766" alt="image" src="https://github.com/user-attachments/assets/c1aca3f5-1417-49a0-a997-4b09c09160f2" />


After:
<img width="866" height="760" alt="image" src="https://github.com/user-attachments/assets/ad9a64ed-3707-4e7e-920a-3afda191545d" />

* Makes the app builder input width fixed instead of growing after a message is sent