### PR TITLE
Fix tunneling by unprotecting HTTP adapter endpoints

### DIFF
--- a/mcpjam-inspector/server/middleware/session-auth.ts
+++ b/mcpjam-inspector/server/middleware/session-auth.ts
@@ -42,6 +42,8 @@ const UNPROTECTED_PREFIXES = [
   "/api/mcp/apps/", // MCP Apps widgets - loaded in sandboxed iframes, can't send headers
   "/api/apps/chatgpt/", // ChatGPT widgets - loaded in sandboxed iframes, can't send headers
   "/api/mcp/sandbox-proxy", // Sandbox proxy - loaded in iframe, serves isolated content
+  "/api/mcp/adapter-http/", // HTTP adapter for tunneled MCP clients - auth via URL secrecy
+  "/api/mcp/manager-http/", // HTTP manager for tunneled MCP clients - auth via URL secrecy
 ];
 
 /**


### PR DESCRIPTION
## Summary

- Fixes tunneling feature broken by PR #1222's session token authentication
- Adds `/api/mcp/adapter-http/` and `/api/mcp/manager-http/` to unprotected prefixes
- Updates tests to reflect intentional design decision

## Problem

PR #1222 added session token authentication that protected all API endpoints. External MCP clients (like Claude Desktop) connecting via ngrok tunnels couldn't authenticate because they have no way to obtain a session token - it's only injected into the Inspector HTML page.

## Solution

Add the HTTP adapter endpoints to `UNPROTECTED_PREFIXES` since they are designed to be accessed by external MCP clients through the tunnel.

## Security Model (unchanged)

The existing security model for tunneling remains intact:
1. **URL secrecy** - Tunnel URLs are randomly generated ngrok subdomains, rotated when closed
2. **Cross-origin protection** - Browser-based CSRF attacks still blocked by origin validation middleware
3. **User awareness** - Warning modal shown when creating tunnels: *"Anyone with the tunnel URL can access your MCP servers"*

## Test plan

- [x] All 644 tests pass
- [x] Cross-origin protection tests still pass (browser-based attacks blocked)
- [x] HTTP adapter endpoints now accept requests without session tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores tunneling support by allowing external MCP clients to reach HTTP bridge endpoints without session tokens.
> 
> - Adds `/api/mcp/adapter-http/` and `/api/mcp/manager-http/` to `UNPROTECTED_PREFIXES` in `session-auth.ts`
> - Includes these paths in `SSE_ROUTES` for clearer token hinting on SSE endpoints
> - Updates `http-adapters.test.ts` to expect unauthenticated POST/GET access for these routes and verifies CORS/origin protections and JSON-RPC behavior
> - Keeps cross-origin validation blocking malicious origins (403) and ensures no wildcard `Access-Control-Allow-Origin` headers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8ac072da247a1fd09cfb9e5ef193eb660f81d35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->