### PR TITLE
[SDK] Add EvalSuite class

### DIFF
--- a/sdk/src/EvalsSuite.ts
+++ b/sdk/src/EvalsSuite.ts
@@ -1,21 +1,226 @@
+import type { TestAgent } from "./TestAgent.js";
+import type { QueryResult } from "./QueryResult.js";
+import type { LatencyBreakdown } from "./types.js";
+import { calculateLatencyStats, type LatencyStats } from "./percentiles.js";
+import {
+  matchToolCalls,
+  matchToolCallsSubset,
+  matchAnyToolCall,
+  matchNoToolCalls,
+} from "./validators.js";
+
 export interface EvalsSuiteConfig {
   name?: string;
 }
 
+/**
+ * Result of a multi-turn conversation evaluation
+ */
+export interface ConversationResult {
+  pass: boolean;
+  results: QueryResult[];
+}
+
+/**
+ * A single test case for multi-case batch testing
+ */
+export interface TestCase {
+  name?: string;
+  query: string;
+  expectTools?: string[];
+  expectExactTools?: string[];
+  expectAnyTool?: string[];
+  expectNoTools?: boolean;
+  validator?: (result: QueryResult) => boolean | Promise<boolean>;
+}
+
+/**
+ * Result details for a single iteration
+ */
+export interface IterationResult {
+  passed: boolean;
+  latencies: LatencyBreakdown[];
+  tokens: number;
+  error?: string;
+  retryCount?: number;
+}
+
+/**
+ * Result details for a single test case
+ */
+export interface CaseResult {
+  name?: string;
+  query: string;
+  iterations: IterationResult[];
+  successes: number;
+  failures: number;
+  accuracy: number;
+}
+
+/**
+ * Configuration for running an eval suite
+ */
+export interface RunConfig {
+  agent: TestAgent;
+  iterations: number;
+
+  // === Single-turn ===
+  query?: string;
+  expectTools?: string[];
+  expectExactTools?: string[];
+  expectAnyTool?: string[];
+  expectNoTools?: boolean;
+  validator?: (result: QueryResult) => boolean | Promise<boolean>;
+
+  // === Multi-turn ===
+  conversation?: (agent: TestAgent) => Promise<ConversationResult>;
+
+  // === Multi-case ===
+  cases?: TestCase[];
+
+  // === DX options ===
+  concurrency?: number;
+  retries?: number;
+  timeoutMs?: number;
+  onProgress?: (completed: number, total: number) => void;
+}
+
+/**
+ * Result of an eval run
+ */
 export interface EvalRunResult {
   iterations: number;
   successes: number;
   failures: number;
   results: boolean[];
+  iterationDetails: IterationResult[];
+  caseResults?: CaseResult[];
   tokenUsage: {
     total: number;
     perIteration: number[];
   };
+  latency: {
+    e2e: LatencyStats;
+    llm: LatencyStats;
+    mcp: LatencyStats;
+    perIteration: LatencyBreakdown[];
+  };
 }
 
-interface RunConfig {
-  func: () => boolean | Promise<boolean>;
-  iterations: number;
+/**
+ * Semaphore for controlling concurrency
+ */
+class Semaphore {
+  private permits: number;
+  private waiting: (() => void)[] = [];
+
+  constructor(permits: number) {
+    this.permits = permits;
+  }
+
+  async acquire(): Promise<void> {
+    if (this.permits > 0) {
+      this.permits--;
+      return;
+    }
+    await new Promise<void>((resolve) => this.waiting.push(resolve));
+  }
+
+  release(): void {
+    const next = this.waiting.shift();
+    if (next) {
+      next();
+    } else {
+      this.permits++;
+    }
+  }
+}
+
+/**
+ * Create a validator function from config expectations
+ */
+function createValidator(
+  config: Pick<
+    RunConfig | TestCase,
+    | "expectTools"
+    | "expectExactTools"
+    | "expectAnyTool"
+    | "expectNoTools"
+    | "validator"
+  >
+): (result: QueryResult) => boolean | Promise<boolean> {
+  if (config.validator) {
+    return config.validator;
+  }
+
+  return (result: QueryResult) => {
+    const toolsCalled = result.toolsCalled();
+
+    if (config.expectTools) {
+      return matchToolCallsSubset(config.expectTools, toolsCalled);
+    }
+    if (config.expectExactTools) {
+      return matchToolCalls(config.expectExactTools, toolsCalled);
+    }
+    if (config.expectAnyTool) {
+      return matchAnyToolCall(config.expectAnyTool, toolsCalled);
+    }
+    if (config.expectNoTools) {
+      return matchNoToolCalls(toolsCalled);
+    }
+
+    // Default: pass if no error
+    return !result.hasError();
+  };
+}
+
+/**
+ * Check if config is for conversation mode
+ */
+function isConversationConfig(config: RunConfig): boolean {
+  return "conversation" in config && typeof config.conversation === "function";
+}
+
+/**
+ * Check if config is for multi-case mode
+ */
+function isMultiCaseConfig(config: RunConfig): boolean {
+  return "cases" in config && Array.isArray(config.cases);
+}
+
+/**
+ * Check if config is for single-turn mode
+ */
+function isSingleTurnConfig(config: RunConfig): boolean {
+  return "query" in config && typeof config.query === "string";
+}
+
+/**
+ * Timeout wrapper for promises
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Operation timed out after ${ms}ms`));
+    }, ms);
+
+    promise
+      .then((value) => {
+        clearTimeout(timer);
+        resolve(value);
+      })
+      .catch((error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+  });
+}
+
+/**
+ * Sleep for a given number of milliseconds
+ */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export class EvalsSuite {
@@ -27,37 +232,328 @@ export class EvalsSuite {
   }
 
   async run(config: RunConfig): Promise<EvalRunResult> {
-    const results: boolean[] = [];
-    const tokenUsagePerIteration: number[] = [];
-    let successes = 0;
-    let failures = 0;
+    const concurrency = config.concurrency ?? 5;
+    const retries = config.retries ?? 0;
+    const timeoutMs = config.timeoutMs ?? 30000;
+    const onProgress = config.onProgress;
 
-    for (let i = 0; i < config.iterations; i++) {
+    const semaphore = new Semaphore(concurrency);
+    let completedCount = 0;
+
+    if (isMultiCaseConfig(config)) {
+      return this.runMultiCase(
+        config,
+        semaphore,
+        retries,
+        timeoutMs,
+        onProgress,
+        () => ++completedCount
+      );
+    } else if (isConversationConfig(config)) {
+      return this.runConversation(
+        config,
+        semaphore,
+        retries,
+        timeoutMs,
+        onProgress,
+        () => ++completedCount
+      );
+    } else if (isSingleTurnConfig(config)) {
+      return this.runSingleTurn(
+        config,
+        semaphore,
+        retries,
+        timeoutMs,
+        onProgress,
+        () => ++completedCount
+      );
+    } else {
+      throw new Error(
+        "Invalid config: must provide 'query', 'conversation', or 'cases'"
+      );
+    }
+  }
+
+  private async runSingleTurn(
+    config: RunConfig,
+    semaphore: Semaphore,
+    retries: number,
+    timeoutMs: number,
+    onProgress: ((completed: number, total: number) => void) | undefined,
+    incrementCompleted: () => number
+  ): Promise<EvalRunResult> {
+    const query = config.query!;
+    const validator = createValidator(config);
+    const iterations: IterationResult[] = [];
+    const total = config.iterations;
+
+    const runSingleIteration = async (): Promise<IterationResult> => {
+      await semaphore.acquire();
       try {
-        const result = await config.func();
-        results.push(result);
-        if (result) {
-          successes++;
-        } else {
-          failures++;
+        let lastError: string | undefined;
+
+        for (let attempt = 0; attempt <= retries; attempt++) {
+          try {
+            const result = await withTimeout(
+              config.agent.query(query),
+              timeoutMs
+            );
+
+            const passed = await validator(result);
+            const latency = result.getLatency();
+            const tokens = result.totalTokens();
+
+            return {
+              passed,
+              latencies: [latency],
+              tokens,
+              error: result.hasError() ? result.getError() : undefined,
+              retryCount: attempt,
+            };
+          } catch (error) {
+            lastError = error instanceof Error ? error.message : String(error);
+
+            if (attempt < retries) {
+              // Exponential backoff: 100ms, 200ms, 400ms, ...
+              await sleep(100 * Math.pow(2, attempt));
+            }
+          }
         }
-        // TODO: Track actual token usage from TestAgent
-        tokenUsagePerIteration.push(0);
-      } catch {
-        results.push(false);
-        failures++;
-        tokenUsagePerIteration.push(0);
+
+        // All retries exhausted
+        return {
+          passed: false,
+          latencies: [{ e2eMs: 0, llmMs: 0, mcpMs: 0 }],
+          tokens: 0,
+          error: lastError,
+          retryCount: retries,
+        };
+      } finally {
+        semaphore.release();
+        const completed = incrementCompleted();
+        if (onProgress) {
+          onProgress(completed, total);
+        }
       }
+    };
+
+    // Run iterations in parallel (limited by semaphore)
+    const promises = Array.from({ length: config.iterations }, () =>
+      runSingleIteration()
+    );
+    const results = await Promise.all(promises);
+    iterations.push(...results);
+
+    return this.aggregateResults(iterations);
+  }
+
+  private async runConversation(
+    config: RunConfig,
+    semaphore: Semaphore,
+    retries: number,
+    timeoutMs: number,
+    onProgress: ((completed: number, total: number) => void) | undefined,
+    incrementCompleted: () => number
+  ): Promise<EvalRunResult> {
+    const conversation = config.conversation!;
+    const iterations: IterationResult[] = [];
+    const total = config.iterations;
+
+    const runSingleIteration = async (): Promise<IterationResult> => {
+      await semaphore.acquire();
+      try {
+        let lastError: string | undefined;
+
+        for (let attempt = 0; attempt <= retries; attempt++) {
+          try {
+            const convResult = await withTimeout(
+              conversation(config.agent),
+              timeoutMs
+            );
+
+            const latencies = convResult.results.map((r) => r.getLatency());
+            const tokens = convResult.results.reduce(
+              (sum, r) => sum + r.totalTokens(),
+              0
+            );
+
+            return {
+              passed: convResult.pass,
+              latencies,
+              tokens,
+              retryCount: attempt,
+            };
+          } catch (error) {
+            lastError = error instanceof Error ? error.message : String(error);
+
+            if (attempt < retries) {
+              await sleep(100 * Math.pow(2, attempt));
+            }
+          }
+        }
+
+        return {
+          passed: false,
+          latencies: [{ e2eMs: 0, llmMs: 0, mcpMs: 0 }],
+          tokens: 0,
+          error: lastError,
+          retryCount: retries,
+        };
+      } finally {
+        semaphore.release();
+        const completed = incrementCompleted();
+        if (onProgress) {
+          onProgress(completed, total);
+        }
+      }
+    };
+
+    const promises = Array.from({ length: config.iterations }, () =>
+      runSingleIteration()
+    );
+    const results = await Promise.all(promises);
+    iterations.push(...results);
+
+    return this.aggregateResults(iterations);
+  }
+
+  private async runMultiCase(
+    config: RunConfig,
+    semaphore: Semaphore,
+    retries: number,
+    timeoutMs: number,
+    onProgress: ((completed: number, total: number) => void) | undefined,
+    incrementCompleted: () => number
+  ): Promise<EvalRunResult> {
+    const cases = config.cases!;
+    const caseResults: CaseResult[] = [];
+    const allIterations: IterationResult[] = [];
+    const total = cases.length * config.iterations;
+
+    for (const testCase of cases) {
+      const validator = createValidator(testCase);
+      const caseIterations: IterationResult[] = [];
+
+      const runSingleIteration = async (): Promise<IterationResult> => {
+        await semaphore.acquire();
+        try {
+          let lastError: string | undefined;
+
+          for (let attempt = 0; attempt <= retries; attempt++) {
+            try {
+              const result = await withTimeout(
+                config.agent.query(testCase.query),
+                timeoutMs
+              );
+
+              const passed = await validator(result);
+              const latency = result.getLatency();
+              const tokens = result.totalTokens();
+
+              return {
+                passed,
+                latencies: [latency],
+                tokens,
+                error: result.hasError() ? result.getError() : undefined,
+                retryCount: attempt,
+              };
+            } catch (error) {
+              lastError =
+                error instanceof Error ? error.message : String(error);
+
+              if (attempt < retries) {
+                await sleep(100 * Math.pow(2, attempt));
+              }
+            }
+          }
+
+          return {
+            passed: false,
+            latencies: [{ e2eMs: 0, llmMs: 0, mcpMs: 0 }],
+            tokens: 0,
+            error: lastError,
+            retryCount: retries,
+          };
+        } finally {
+          semaphore.release();
+          const completed = incrementCompleted();
+          if (onProgress) {
+            onProgress(completed, total);
+          }
+        }
+      };
+
+      const promises = Array.from({ length: config.iterations }, () =>
+        runSingleIteration()
+      );
+      const results = await Promise.all(promises);
+      caseIterations.push(...results);
+      allIterations.push(...results);
+
+      const successes = caseIterations.filter((r) => r.passed).length;
+      const failures = caseIterations.filter((r) => !r.passed).length;
+
+      caseResults.push({
+        name: testCase.name,
+        query: testCase.query,
+        iterations: caseIterations,
+        successes,
+        failures,
+        accuracy: successes / config.iterations,
+      });
     }
 
+    return this.aggregateResults(allIterations, caseResults);
+  }
+
+  private aggregateResults(
+    iterations: IterationResult[],
+    caseResults?: CaseResult[]
+  ): EvalRunResult {
+    const allLatencies = iterations.flatMap((r) => r.latencies);
+
+    // Handle empty latencies array
+    const defaultStats: LatencyStats = {
+      min: 0,
+      max: 0,
+      mean: 0,
+      p50: 0,
+      p95: 0,
+      count: 0,
+    };
+
+    const e2eValues = allLatencies.map((l) => l.e2eMs);
+    const llmValues = allLatencies.map((l) => l.llmMs);
+    const mcpValues = allLatencies.map((l) => l.mcpMs);
+
+    const successes = iterations.filter((r) => r.passed).length;
+    const failures = iterations.filter((r) => !r.passed).length;
+
     this.lastRunResult = {
-      iterations: config.iterations,
+      iterations: iterations.length,
       successes,
       failures,
-      results,
+      results: iterations.map((r) => r.passed),
+      iterationDetails: iterations,
+      caseResults,
       tokenUsage: {
-        total: tokenUsagePerIteration.reduce((a, b) => a + b, 0),
-        perIteration: tokenUsagePerIteration,
+        total: iterations.reduce((sum, r) => sum + r.tokens, 0),
+        perIteration: iterations.map((r) => r.tokens),
+      },
+      latency: {
+        e2e:
+          e2eValues.length > 0
+            ? calculateLatencyStats(e2eValues)
+            : defaultStats,
+        llm:
+          llmValues.length > 0
+            ? calculateLatencyStats(llmValues)
+            : defaultStats,
+        mcp:
+          mcpValues.length > 0
+            ? calculateLatencyStats(mcpValues)
+            : defaultStats,
+        perIteration: allLatencies,
       },
     };
 

--- a/sdk/src/TestAgent.ts
+++ b/sdk/src/TestAgent.ts
@@ -3,7 +3,7 @@
  */
 
 import { generateText, stepCountIs } from "ai";
-import type { LanguageModelUsage, ToolSet } from "ai";
+import type { ToolSet } from "ai";
 import { createModelFromString } from "./model-factory.js";
 import type { CreateModelOptions } from "./model-factory.js";
 import { extractToolCalls } from "./tool-extraction.js";

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -119,7 +119,15 @@ export {
 
 // EvalsSuite
 export { EvalsSuite } from "./EvalsSuite.js";
-export type { EvalsSuiteConfig, EvalRunResult } from "./EvalsSuite.js";
+export type {
+  EvalsSuiteConfig,
+  EvalRunResult,
+  ConversationResult,
+  TestCase,
+  IterationResult,
+  CaseResult,
+  RunConfig,
+} from "./EvalsSuite.js";
 
 // Core SDK types
 export type {

--- a/sdk/tests/EvalsSuite.test.ts
+++ b/sdk/tests/EvalsSuite.test.ts
@@ -1,4 +1,39 @@
 import { EvalsSuite } from "../src/EvalsSuite";
+import { QueryResult } from "../src/QueryResult";
+import type { TestAgent } from "../src/TestAgent";
+
+// Mock QueryResult factory
+function createMockQueryResult(options: {
+  text?: string;
+  toolsCalled?: string[];
+  tokens?: number;
+  latency?: { e2eMs: number; llmMs: number; mcpMs: number };
+  error?: string;
+}): QueryResult {
+  return QueryResult.from({
+    text: options.text ?? "Test response",
+    toolCalls: (options.toolsCalled ?? []).map((name) => ({
+      toolName: name,
+      arguments: {},
+    })),
+    usage: {
+      inputTokens: Math.floor((options.tokens ?? 100) / 2),
+      outputTokens: Math.floor((options.tokens ?? 100) / 2),
+      totalTokens: options.tokens ?? 100,
+    },
+    latency: options.latency ?? { e2eMs: 100, llmMs: 80, mcpMs: 20 },
+    error: options.error,
+  });
+}
+
+// Create a mock TestAgent
+function createMockAgent(
+  queryFn: (prompt: string) => Promise<QueryResult>
+): TestAgent {
+  return {
+    query: queryFn,
+  } as TestAgent;
+}
 
 describe("EvalsSuite", () => {
   describe("constructor", () => {
@@ -13,69 +48,631 @@ describe("EvalsSuite", () => {
     });
   });
 
-  describe("run", () => {
-    it("should run iterations and track results", async () => {
+  describe("single-turn mode", () => {
+    it("should run iterations with query and track results", async () => {
       const suite = new EvalsSuite();
-      let counter = 0;
+      let callCount = 0;
 
-      const result = await suite.run({
-        func: () => {
-          counter++;
-          return true;
-        },
-        iterations: 5,
+      const agent = createMockAgent(async () => {
+        callCount++;
+        return createMockQueryResult({ toolsCalled: ["add"] });
       });
 
-      expect(counter).toBe(5);
+      const result = await suite.run({
+        agent,
+        query: "Add 2 and 3",
+        iterations: 5,
+        expectTools: ["add"],
+      });
+
+      expect(callCount).toBe(5);
       expect(result.iterations).toBe(5);
       expect(result.successes).toBe(5);
       expect(result.failures).toBe(0);
       expect(result.results).toEqual([true, true, true, true, true]);
     });
 
-    it("should handle mixed results", async () => {
+    it("should use expectTools with matchToolCallsSubset", async () => {
       const suite = new EvalsSuite();
-      let counter = 0;
 
-      const result = await suite.run({
-        func: () => {
-          counter++;
-          return counter % 2 === 0; // true on even iterations
-        },
-        iterations: 4,
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({ toolsCalled: ["add", "multiply"] });
       });
 
-      expect(result.successes).toBe(2);
-      expect(result.failures).toBe(2);
-      expect(result.results).toEqual([false, true, false, true]);
-    });
-
-    it("should handle async functions", async () => {
-      const suite = new EvalsSuite();
-
       const result = await suite.run({
-        func: async () => {
-          await new Promise((resolve) => setTimeout(resolve, 1));
-          return true;
-        },
+        agent,
+        query: "Add and multiply",
         iterations: 3,
+        expectTools: ["add"], // Should pass even with extra tools
       });
 
       expect(result.successes).toBe(3);
     });
 
-    it("should treat thrown errors as failures", async () => {
+    it("should use expectExactTools with matchToolCalls", async () => {
       const suite = new EvalsSuite();
 
-      const result = await suite.run({
-        func: () => {
-          throw new Error("Test error");
-        },
-        iterations: 3,
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({ toolsCalled: ["add", "multiply"] });
       });
 
-      expect(result.failures).toBe(3);
-      expect(result.results).toEqual([false, false, false]);
+      // Exact match - wrong order
+      const result1 = await suite.run({
+        agent,
+        query: "Test",
+        iterations: 2,
+        expectExactTools: ["multiply", "add"],
+      });
+      expect(result1.failures).toBe(2);
+
+      // Exact match - correct order
+      const result2 = await suite.run({
+        agent,
+        query: "Test",
+        iterations: 2,
+        expectExactTools: ["add", "multiply"],
+      });
+      expect(result2.successes).toBe(2);
+    });
+
+    it("should use expectAnyTool with matchAnyToolCall", async () => {
+      const suite = new EvalsSuite();
+
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({ toolsCalled: ["add"] });
+      });
+
+      const result = await suite.run({
+        agent,
+        query: "Test",
+        iterations: 2,
+        expectAnyTool: ["subtract", "add", "multiply"],
+      });
+
+      expect(result.successes).toBe(2);
+    });
+
+    it("should use expectNoTools with matchNoToolCalls", async () => {
+      const suite = new EvalsSuite();
+
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({ toolsCalled: [] });
+      });
+
+      const result = await suite.run({
+        agent,
+        query: "Just respond",
+        iterations: 2,
+        expectNoTools: true,
+      });
+
+      expect(result.successes).toBe(2);
+    });
+
+    it("should use custom validator when provided", async () => {
+      const suite = new EvalsSuite();
+
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({
+          text: "The answer is 42",
+          toolsCalled: ["add"],
+        });
+      });
+
+      const result = await suite.run({
+        agent,
+        query: "Test",
+        iterations: 3,
+        validator: (result) => result.text.includes("42"),
+      });
+
+      expect(result.successes).toBe(3);
+    });
+
+    it("should support async validators", async () => {
+      const suite = new EvalsSuite();
+
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({ text: "response" });
+      });
+
+      const result = await suite.run({
+        agent,
+        query: "Test",
+        iterations: 2,
+        validator: async (result) => {
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          return result.text.length > 0;
+        },
+      });
+
+      expect(result.successes).toBe(2);
+    });
+
+    it("should default to pass if no error when no expectations set", async () => {
+      const suite = new EvalsSuite();
+
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({});
+      });
+
+      const result = await suite.run({
+        agent,
+        query: "Test",
+        iterations: 2,
+      });
+
+      expect(result.successes).toBe(2);
+    });
+
+    it("should fail when there is an error and no expectations", async () => {
+      const suite = new EvalsSuite();
+
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({ error: "Something went wrong" });
+      });
+
+      const result = await suite.run({
+        agent,
+        query: "Test",
+        iterations: 2,
+      });
+
+      expect(result.failures).toBe(2);
+    });
+  });
+
+  describe("multi-turn conversation mode", () => {
+    it("should run conversation function and aggregate results", async () => {
+      const suite = new EvalsSuite();
+
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({ toolsCalled: ["search"] });
+      });
+
+      const result = await suite.run({
+        agent,
+        iterations: 3,
+        conversation: async (agent) => {
+          const r1 = await agent.query("Search for X");
+          const r2 = await agent.query("Summarize results");
+          return {
+            pass: r1.toolsCalled().includes("search"),
+            results: [r1, r2],
+          };
+        },
+      });
+
+      expect(result.successes).toBe(3);
+      // Should have 2 latencies per iteration (2 queries in conversation)
+      expect(result.latency.perIteration.length).toBe(6);
+    });
+
+    it("should handle conversation failures", async () => {
+      const suite = new EvalsSuite();
+
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({ toolsCalled: [] });
+      });
+
+      const result = await suite.run({
+        agent,
+        iterations: 2,
+        conversation: async (agent) => {
+          const r1 = await agent.query("Search");
+          return {
+            pass: r1.toolsCalled().includes("search"), // Will fail
+            results: [r1],
+          };
+        },
+      });
+
+      expect(result.failures).toBe(2);
+    });
+  });
+
+  describe("multi-case mode", () => {
+    it("should run all test cases with iterations", async () => {
+      const suite = new EvalsSuite();
+      const queries: string[] = [];
+
+      const agent = createMockAgent(async (prompt) => {
+        queries.push(prompt);
+        if (prompt.includes("Add")) {
+          return createMockQueryResult({ toolsCalled: ["add"] });
+        } else {
+          return createMockQueryResult({ toolsCalled: ["multiply"] });
+        }
+      });
+
+      const result = await suite.run({
+        agent,
+        iterations: 2,
+        cases: [
+          { name: "addition", query: "Add 2+3", expectTools: ["add"] },
+          {
+            name: "multiply",
+            query: "Multiply 4*5",
+            expectTools: ["multiply"],
+          },
+        ],
+      });
+
+      expect(queries).toHaveLength(4); // 2 cases * 2 iterations
+      expect(result.iterations).toBe(4);
+      expect(result.successes).toBe(4);
+      expect(result.caseResults).toHaveLength(2);
+      expect(result.caseResults![0].name).toBe("addition");
+      expect(result.caseResults![0].accuracy).toBe(1);
+      expect(result.caseResults![1].name).toBe("multiply");
+      expect(result.caseResults![1].accuracy).toBe(1);
+    });
+
+    it("should track per-case statistics", async () => {
+      const suite = new EvalsSuite();
+      let addCount = 0;
+
+      const agent = createMockAgent(async (prompt) => {
+        if (prompt.includes("Add")) {
+          addCount++;
+          // Fail every other add
+          if (addCount % 2 === 0) {
+            return createMockQueryResult({ toolsCalled: [] });
+          }
+          return createMockQueryResult({ toolsCalled: ["add"] });
+        }
+        return createMockQueryResult({ toolsCalled: ["multiply"] });
+      });
+
+      const result = await suite.run({
+        agent,
+        iterations: 4,
+        cases: [
+          { name: "addition", query: "Add 2+3", expectTools: ["add"] },
+          { name: "multiply", query: "Multiply", expectTools: ["multiply"] },
+        ],
+      });
+
+      const addCase = result.caseResults!.find((c) => c.name === "addition");
+      expect(addCase!.successes).toBe(2);
+      expect(addCase!.failures).toBe(2);
+      expect(addCase!.accuracy).toBe(0.5);
+
+      const multiplyCase = result.caseResults!.find(
+        (c) => c.name === "multiply"
+      );
+      expect(multiplyCase!.accuracy).toBe(1);
+    });
+  });
+
+  describe("concurrency control", () => {
+    it("should limit parallel executions to concurrency value", async () => {
+      const suite = new EvalsSuite();
+      let concurrent = 0;
+      let maxConcurrent = 0;
+
+      const agent = createMockAgent(async () => {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        concurrent--;
+        return createMockQueryResult({});
+      });
+
+      await suite.run({
+        agent,
+        query: "Test",
+        iterations: 10,
+        concurrency: 3,
+      });
+
+      expect(maxConcurrent).toBeLessThanOrEqual(3);
+    });
+
+    it("should default to concurrency of 5", async () => {
+      const suite = new EvalsSuite();
+      let maxConcurrent = 0;
+      let concurrent = 0;
+
+      const agent = createMockAgent(async () => {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        concurrent--;
+        return createMockQueryResult({});
+      });
+
+      await suite.run({
+        agent,
+        query: "Test",
+        iterations: 15,
+      });
+
+      expect(maxConcurrent).toBeLessThanOrEqual(5);
+    });
+  });
+
+  describe("retry behavior", () => {
+    it("should retry on failure up to retries count", async () => {
+      const suite = new EvalsSuite();
+      let attempts = 0;
+
+      const agent = createMockAgent(async () => {
+        attempts++;
+        if (attempts < 3) {
+          throw new Error("Temporary failure");
+        }
+        return createMockQueryResult({});
+      });
+
+      const result = await suite.run({
+        agent,
+        query: "Test",
+        iterations: 1,
+        retries: 3,
+        concurrency: 1,
+      });
+
+      expect(attempts).toBe(3);
+      expect(result.successes).toBe(1);
+    });
+
+    it("should fail after exhausting retries", async () => {
+      const suite = new EvalsSuite();
+      let attempts = 0;
+
+      const agent = createMockAgent(async () => {
+        attempts++;
+        throw new Error("Persistent failure");
+      });
+
+      const result = await suite.run({
+        agent,
+        query: "Test",
+        iterations: 1,
+        retries: 2,
+        concurrency: 1,
+      });
+
+      expect(attempts).toBe(3); // 1 initial + 2 retries
+      expect(result.failures).toBe(1);
+      expect(result.iterationDetails[0].error).toBe("Persistent failure");
+    });
+
+    it("should track retry count in iteration details", async () => {
+      const suite = new EvalsSuite();
+      let attemptCount = 0;
+
+      const agent = createMockAgent(async () => {
+        attemptCount++;
+        if (attemptCount === 2) {
+          return createMockQueryResult({});
+        }
+        throw new Error("Fail first time");
+      });
+
+      const result = await suite.run({
+        agent,
+        query: "Test",
+        iterations: 1,
+        retries: 2,
+        concurrency: 1,
+      });
+
+      expect(result.iterationDetails[0].retryCount).toBe(1);
+    });
+  });
+
+  describe("timeout handling", () => {
+    it("should timeout after timeoutMs", async () => {
+      const suite = new EvalsSuite();
+
+      const agent = createMockAgent(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        return createMockQueryResult({});
+      });
+
+      const result = await suite.run({
+        agent,
+        query: "Test",
+        iterations: 1,
+        timeoutMs: 50,
+        concurrency: 1,
+      });
+
+      expect(result.failures).toBe(1);
+      expect(result.iterationDetails[0].error).toContain("timed out");
+    });
+
+    it("should use default timeout of 30000ms", async () => {
+      const suite = new EvalsSuite();
+
+      const agent = createMockAgent(async () => {
+        // This should complete before 30s timeout
+        return createMockQueryResult({});
+      });
+
+      const result = await suite.run({
+        agent,
+        query: "Test",
+        iterations: 1,
+      });
+
+      expect(result.successes).toBe(1);
+    });
+  });
+
+  describe("progress callback", () => {
+    it("should call onProgress after each iteration", async () => {
+      const suite = new EvalsSuite();
+      const progressCalls: [number, number][] = [];
+
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({});
+      });
+
+      await suite.run({
+        agent,
+        query: "Test",
+        iterations: 3,
+        concurrency: 1,
+        onProgress: (completed, total) => {
+          progressCalls.push([completed, total]);
+        },
+      });
+
+      expect(progressCalls).toContainEqual([1, 3]);
+      expect(progressCalls).toContainEqual([2, 3]);
+      expect(progressCalls).toContainEqual([3, 3]);
+    });
+
+    it("should report correct total for multi-case", async () => {
+      const suite = new EvalsSuite();
+      const progressCalls: [number, number][] = [];
+
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({});
+      });
+
+      await suite.run({
+        agent,
+        iterations: 2,
+        cases: [{ query: "A" }, { query: "B" }],
+        concurrency: 1,
+        onProgress: (completed, total) => {
+          progressCalls.push([completed, total]);
+        },
+      });
+
+      // 2 cases * 2 iterations = 4 total
+      expect(progressCalls[progressCalls.length - 1]).toEqual([4, 4]);
+    });
+  });
+
+  describe("latency statistics", () => {
+    it("should calculate latency stats correctly", async () => {
+      const suite = new EvalsSuite();
+      let callCount = 0;
+
+      const agent = createMockAgent(async () => {
+        callCount++;
+        return createMockQueryResult({
+          latency: {
+            e2eMs: callCount * 100,
+            llmMs: callCount * 80,
+            mcpMs: callCount * 20,
+          },
+        });
+      });
+
+      const result = await suite.run({
+        agent,
+        query: "Test",
+        iterations: 5,
+        concurrency: 1,
+      });
+
+      expect(result.latency.e2e.min).toBe(100);
+      expect(result.latency.e2e.max).toBe(500);
+      expect(result.latency.e2e.mean).toBe(300);
+      expect(result.latency.e2e.count).toBe(5);
+    });
+
+    it("should flatten multi-turn latencies for stats", async () => {
+      const suite = new EvalsSuite();
+
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({
+          latency: { e2eMs: 100, llmMs: 80, mcpMs: 20 },
+        });
+      });
+
+      const result = await suite.run({
+        agent,
+        iterations: 2,
+        conversation: async (agent) => {
+          const r1 = await agent.query("First");
+          const r2 = await agent.query("Second");
+          return { pass: true, results: [r1, r2] };
+        },
+        concurrency: 1,
+      });
+
+      // 2 iterations * 2 queries = 4 latency entries
+      expect(result.latency.perIteration).toHaveLength(4);
+      expect(result.latency.e2e.count).toBe(4);
+    });
+  });
+
+  describe("token usage", () => {
+    it("should aggregate token usage across iterations", async () => {
+      const suite = new EvalsSuite();
+
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({ tokens: 100 });
+      });
+
+      const result = await suite.run({
+        agent,
+        query: "Test",
+        iterations: 5,
+      });
+
+      expect(result.tokenUsage.total).toBe(500);
+      expect(result.tokenUsage.perIteration).toEqual([100, 100, 100, 100, 100]);
+    });
+
+    it("should aggregate tokens from multi-turn conversations", async () => {
+      const suite = new EvalsSuite();
+
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({ tokens: 50 });
+      });
+
+      const result = await suite.run({
+        agent,
+        iterations: 2,
+        conversation: async (agent) => {
+          const r1 = await agent.query("First");
+          const r2 = await agent.query("Second");
+          return { pass: true, results: [r1, r2] };
+        },
+      });
+
+      // Each iteration has 2 queries of 50 tokens = 100 per iteration
+      expect(result.tokenUsage.perIteration).toEqual([100, 100]);
+      expect(result.tokenUsage.total).toBe(200);
+    });
+  });
+
+  describe("error handling", () => {
+    it("should preserve error messages in iteration details", async () => {
+      const suite = new EvalsSuite();
+
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({ error: "Tool execution failed" });
+      });
+
+      const result = await suite.run({
+        agent,
+        query: "Test",
+        iterations: 1,
+      });
+
+      expect(result.iterationDetails[0].error).toBe("Tool execution failed");
+    });
+
+    it("should throw if invalid config provided", async () => {
+      const suite = new EvalsSuite();
+      const agent = createMockAgent(async () => createMockQueryResult({}));
+
+      await expect(
+        suite.run({
+          agent,
+          iterations: 1,
+          // No query, conversation, or cases
+        })
+      ).rejects.toThrow("Invalid config");
     });
   });
 
@@ -84,12 +681,19 @@ describe("EvalsSuite", () => {
       const suite = new EvalsSuite();
       let counter = 0;
 
+      const agent = createMockAgent(async () => {
+        counter++;
+        return createMockQueryResult({
+          toolsCalled: counter <= 8 ? ["add"] : [],
+        });
+      });
+
       await suite.run({
-        func: () => {
-          counter++;
-          return counter <= 8; // 8 successes, 2 failures
-        },
+        agent,
+        query: "Test",
         iterations: 10,
+        expectTools: ["add"],
+        concurrency: 1,
       });
 
       expect(suite.accuracy()).toBe(0.8);
@@ -118,12 +722,34 @@ describe("EvalsSuite", () => {
     it("should calculate falsePositiveRate correctly", async () => {
       const suite = new EvalsSuite();
 
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({ toolsCalled: [] });
+      });
+
       await suite.run({
-        func: () => false,
+        agent,
+        query: "Test",
         iterations: 10,
+        expectTools: ["add"], // Will all fail
       });
 
       expect(suite.falsePositiveRate()).toBe(1.0);
+    });
+
+    it("should calculate averageTokenUse correctly", async () => {
+      const suite = new EvalsSuite();
+
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({ tokens: 150 });
+      });
+
+      await suite.run({
+        agent,
+        query: "Test",
+        iterations: 4,
+      });
+
+      expect(suite.averageTokenUse()).toBe(150);
     });
   });
 
@@ -136,14 +762,20 @@ describe("EvalsSuite", () => {
     it("should return results after run", async () => {
       const suite = new EvalsSuite();
 
+      const agent = createMockAgent(async () => {
+        return createMockQueryResult({});
+      });
+
       await suite.run({
-        func: () => true,
+        agent,
+        query: "Test",
         iterations: 3,
       });
 
       const results = suite.getResults();
       expect(results).not.toBeNull();
       expect(results?.iterations).toBe(3);
+      expect(results?.iterationDetails).toHaveLength(3);
     });
   });
 });

--- a/sdk/tests/validators.test.ts
+++ b/sdk/tests/validators.test.ts
@@ -239,7 +239,9 @@ describe("validators", () => {
 
     it("should match objects regardless of key order", () => {
       // LLMs often return JSON with keys in arbitrary order
-      const calls: ToolCall[] = [{ toolName: "add", arguments: { b: 3, a: 2 } }];
+      const calls: ToolCall[] = [
+        { toolName: "add", arguments: { b: 3, a: 2 } },
+      ];
       expect(matchToolCallWithArgs("add", { a: 2, b: 3 }, calls)).toBe(true);
       expect(matchToolCallWithArgs("add", { b: 3, a: 2 }, calls)).toBe(true);
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a comprehensive evaluation suite for LLM + tool-calling workflows with flexible modes and robust runtime controls.
> 
> - **New `EvalsSuite`**: Supports `query` (single-turn), `conversation` (multi-turn), and `cases` (multi-case) modes; integrates validators (`expectTools`, `expectExactTools`, `expectAnyTool`, `expectNoTools`) or custom validators
> - **Runtime controls**: Bounded concurrency via a semaphore, configurable retries with exponential backoff, per-iteration timeouts, and `onProgress` callback
> - **Metrics & outputs**: Records per-iteration pass/fail, errors, retry counts; aggregates tokens and latency (`e2e`, `llm`, `mcp`) with percentile stats; exposes `iterationDetails`, per-case results, and summary accuracy helpers
> - **Exports**: Re-exports `EvalsSuite` and related types (`RunConfig`, `EvalRunResult`, `ConversationResult`, `TestCase`, `IterationResult`, `CaseResult`) from `index.ts`
> - **Tests**: Extensive coverage for modes, validators, concurrency, retries, timeouts, progress, latency stats, token aggregation, and metrics; minor type cleanup in `TestAgent`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a32d51aa929d349b4bcd28b43a83cd3e91eac075. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->