### PR TITLE
renamed getServerConfig to getServerConfigs

### DIFF
--- a/docs/contributing/mcp-client-manager.mdx
+++ b/docs/contributing/mcp-client-manager.mdx
@@ -355,7 +355,7 @@ await mcpClientManager.disconnectAllServers();
 </ResponseField>
 
 <ResponseField
-  name="getServerConfig"
+  name="getServerConfigs"
   type="(serverId: string) => MCPServerConfig | undefined"
 >
   Get configuration for a server.

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -196,7 +196,7 @@ export class MCPClientManager {
   /**
    * Gets the configuration for a server.
    */
-  getServerConfig(serverId: string): MCPServerConfig | undefined {
+  getServerConfigs(serverId: string): MCPServerConfig | undefined {
     return this.clientStates.get(serverId)?.config;
   }
 

--- a/sdk/tests/MCPClientManager.test.ts
+++ b/sdk/tests/MCPClientManager.test.ts
@@ -248,7 +248,7 @@ describe("MCPClientManager", () => {
         timeout: 5000,
       });
 
-      const config = manager.getServerConfig("configured");
+      const config = manager.getServerConfigs("configured");
       expect(config).toBeDefined();
       expect((config as any).command).toBe("npx");
       expect((config as any).timeout).toBe(5000);
@@ -313,7 +313,7 @@ describe("MCPClientManager", () => {
     });
 
     it("should return undefined for unknown server config", () => {
-      expect(manager.getServerConfig("unknown")).toBeUndefined();
+      expect(manager.getServerConfigs("unknown")).toBeUndefined();
     });
 
     it("should throw when connecting to already connected server", async () => {


### PR DESCRIPTION
i believe that getServerConfig might confuse the user, specially if there are lots of configs