### PR TITLE
fix(client): infinite scroll for tools reset

### DIFF
--- a/mcpjam-inspector/client/src/components/ToolsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ToolsTab.tsx
@@ -294,7 +294,7 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
     });
   }, []);
 
-  const fetchTools = async () => {
+  const fetchTools = async (reset = false) => {
     if (!serverName) {
       logger.warn("Cannot fetch tools: no serverId available");
       return;
@@ -302,13 +302,15 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
 
     setFetchingTools(true);
     setError("");
-    setSelectedTool("");
-    setFormFields([]);
-    setResult(null);
-    setStructuredResult(null);
-    setShowStructured(false);
-    setValidationErrors(undefined);
-    setUnstructuredValidationResult("not_applicable");
+    if (reset) {
+      setSelectedTool("");
+      setFormFields([]);
+      setResult(null);
+      setStructuredResult(null);
+      setShowStructured(false);
+      setValidationErrors(undefined);
+      setUnstructuredValidationResult("not_applicable");
+    }
 
     try {
       // Call to get all of the tools for server
@@ -608,6 +610,10 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
     setIsSaveDialogOpen(true);
   };
 
+  const handleToolRefresh = () => {
+    void fetchTools(true);
+  };
+
   const filteredSavedRequests = searchQuery.trim()
     ? savedRequests.filter((tool) => {
         const haystack =
@@ -652,7 +658,7 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
               fetchingTools={fetchingTools}
               searchQuery={searchQuery}
               onSearchQueryChange={setSearchQuery}
-              onRefresh={fetchTools}
+              onRefresh={handleToolRefresh}
               onSelectTool={setSelectedTool}
               savedRequests={filteredSavedRequests}
               highlightedRequestId={highlightedRequestId}


### PR DESCRIPTION
**PROBLEM:** `fetchTools` was clearing UI state (selected tool, form fields, results) on every call, including during pagination, causing users to lose context when loading more tools. 


**SOLUTION:** Added a `reset` parameter to `fetchTools` that only clears UI state when true (refresh button), preserving state during pagination (reset = false).

**Note:** Infinite scroll for tools implementation: https://github.com/MCPJam/inspector/pull/1159