### PR TITLE
Fix race condition in MCP Apps renderer during streaming

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps-renderer.tsx
@@ -344,6 +344,16 @@ export function MCPAppsRenderer({
     onAppSupportedDisplayModesChange,
   );
 
+  // Refs for values consumed inside the async fetchWidgetHtml function.
+  // These change reference on every streaming chunk (AI SDK recreates part objects),
+  // but we don't want to re-trigger the fetch effect for reference-only changes.
+  const toolInputRef = useRef(toolInput);
+  toolInputRef.current = toolInput;
+  const toolOutputRef = useRef(toolOutput);
+  toolOutputRef.current = toolOutput;
+  const themeModeRef = useRef(themeMode);
+  themeModeRef.current = themeMode;
+
   // Fetch widget HTML when tool output is available or CSP mode changes
   useEffect(() => {
     if (toolState !== "output-available") return;
@@ -359,11 +369,11 @@ export function MCPAppsRenderer({
           body: JSON.stringify({
             serverId,
             resourceUri,
-            toolInput,
-            toolOutput,
+            toolInput: toolInputRef.current,
+            toolOutput: toolOutputRef.current,
             toolId: toolCallId,
             toolName,
-            theme: themeMode,
+            theme: themeModeRef.current,
             protocol: "mcp-apps",
             cspMode, // Pass CSP mode preference
           }),
@@ -445,10 +455,7 @@ export function MCPAppsRenderer({
     loadedCspMode,
     serverId,
     resourceUri,
-    toolInput,
-    toolOutput,
     toolName,
-    themeMode,
     cspMode,
   ]);
 


### PR DESCRIPTION
## Summary
- Fix `ui/initialize` being called twice when the LLM makes a second tool call after an MCP App widget has already loaded
- The `fetchWidgetHtml` effect had `toolInput`, `toolOutput`, and `themeMode` in its dependency array, causing concurrent fetches during streaming when the AI SDK recreates part objects with new references
- Uses refs for the volatile values (same pattern as the ChatGPT app renderer fix in #1348)

## Test plan
- [ ] Connect an MCP Apps server, use free chat, trigger a tool call, verify widget loads correctly
- [ ] Trigger a second tool call after the first widget loads — verify the first widget does NOT re-initialize
- [ ] Verify `ui/initialize` is only sent once per widget (check traffic logs)
- [ ] Verify BYOK path still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)