### PR TITLE
Migrate eval agents from /streaming to /stream endpoint

### DIFF
--- a/mcpjam-inspector/server/services/eval-agent.ts
+++ b/mcpjam-inspector/server/services/eval-agent.ts
@@ -196,13 +196,14 @@ ${toolsContext}
   ];
 
   // Call the backend LLM API
-  const response = await fetch(`${convexHttpUrl}/streaming`, {
+  const response = await fetch(`${convexHttpUrl}/stream`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${convexAuthToken}`,
     },
     body: JSON.stringify({
+      mode: "step",
       model: "anthropic/claude-haiku-4.5",
       tools: [],
       messages: JSON.stringify(messageHistory),

--- a/mcpjam-inspector/server/services/negative-test-agent.ts
+++ b/mcpjam-inspector/server/services/negative-test-agent.ts
@@ -144,13 +144,14 @@ ${toolsContext}
   ];
 
   // Call the backend LLM API
-  const response = await fetch(`${convexHttpUrl}/streaming`, {
+  const response = await fetch(`${convexHttpUrl}/stream`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${convexAuthToken}`,
     },
     body: JSON.stringify({
+      mode: "step",
       model: "anthropic/claude-haiku-4.5",
       tools: [],
       messages: JSON.stringify(messageHistory),


### PR DESCRIPTION
## Summary
- Migrate `eval-agent.ts` and `negative-test-agent.ts` from the legacy `/streaming` endpoint to the newer `/stream` endpoint with `mode: "step"`
- The `/stream` endpoint returns a compatible superset response (`{ ok, messages }` plus optional `finishReason` and `usage`), so no response handling changes are needed
- After this change, zero callsites reference `/streaming`, clearing the path for its deprecation in the Convex backend

## Test plan
- [ ] Run eval agent flow and verify test case generation works correctly
- [ ] Run negative test agent flow and verify negative test generation works correctly
- [ ] Confirm `grep -r "/streaming" server/` returns no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)