### PR TITLE
Telemetry for skills

### DIFF
--- a/mcpjam-inspector/client/src/components/SkillsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SkillsTab.tsx
@@ -17,6 +17,7 @@ import {
   Code,
   Eye,
 } from "lucide-react";
+import posthog from "posthog-js";
 import { EmptyState } from "./ui/empty-state";
 import {
   listSkills,
@@ -186,6 +187,7 @@ export function SkillsTab() {
     setIsDeleting(true);
     try {
       await deleteSkill(skillToDelete);
+      posthog.capture("skill_deleted", { skill_name: skillToDelete });
       // Refresh skills list
       await fetchSkills();
       // Clear selection if deleted skill was selected
@@ -220,6 +222,7 @@ export function SkillsTab() {
     setFileContent(null);
     setRawMode(false);
     setDescriptionExpanded(false);
+    posthog.capture("skill_viewed", { skill_name: name });
   };
 
   const handleSelectFile = (skillName: string, filePath: string) => {

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skill-upload-dialog.tsx
@@ -11,6 +11,7 @@ import {
 import { uploadSkillFolder } from "@/lib/apis/mcp-skills-api";
 import type { SkillResult } from "./skill-types";
 import { isValidSkillName } from "../../../../../../shared/skill-types";
+import posthog from "posthog-js";
 
 interface SkillUploadDialogProps {
   open: boolean;
@@ -199,6 +200,10 @@ export function SkillUploadDialog({
 
     try {
       const skill = await uploadSkillFolder(files, skillInfo.name);
+      posthog.capture("skill_uploaded", {
+        skill_name: skillInfo.name,
+        file_count: files.length,
+      });
       onSkillCreated?.(skill);
       handleOpenChange(false);
     } catch (err) {

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skills-popover-section.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/skills/skills-popover-section.tsx
@@ -8,6 +8,7 @@ import { SquareSlash, Loader2 } from "lucide-react";
 import { useEffect, useState, useCallback } from "react";
 import { listSkills, getSkill } from "@/lib/apis/mcp-skills-api";
 import type { SkillListItem, SkillResult } from "./skill-types";
+import posthog from "posthog-js";
 
 interface SkillsPopoverSectionProps {
   onSkillSelected: (skillResult: SkillResult) => void;
@@ -60,6 +61,7 @@ export function SkillsPopoverSection({
       try {
         setLoadingSkillName(skill.name);
         const fullSkill = await getSkill(skill.name);
+        posthog.capture("skill_injected", { skill_name: skill.name });
         onSkillSelected(fullSkill);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   SquareSlash,
   MessageCircleQuestionIcon,
 } from "lucide-react";
+import posthog from "posthog-js";
 
 import { NavMain } from "@/components/sidebar/nav-main";
 import {
@@ -209,6 +210,10 @@ export function MCPSidebar({
       if (section === "app-builder" && showAppBuilderBubble) {
         localStorage.setItem(APP_BUILDER_VISITED_KEY, "true");
         setHasVisitedAppBuilder(true);
+      }
+      // Track skills tab opened
+      if (section === "skills") {
+        posthog.capture("skills_tab_opened");
       }
       onNavigate(section);
     } else {


### PR DESCRIPTION
skills_tab_opened             User clicks Skills button in sidebar
skill_viewed                       User selects a skill in Skills tab
skill_injected                     User injects skill into chat via / popover
skill_uploaded                   User creates a new skill
skill_deleted                      User deletes a skill

<img width="571" height="463" alt="Screenshot 2026-02-03 at 10 48 29 PM" src="https://github.com/user-attachments/assets/e61f4656-eabb-478c-b810-4c105262c7a9" />
