### PR TITLE
feat(server): added app identification header openrouter

### DIFF
--- a/mcpjam-inspector/server/utils/chat-helpers.ts
+++ b/mcpjam-inspector/server/utils/chat-helpers.ts
@@ -72,7 +72,13 @@ export const createLlmModel = (
       return openai.chat(modelDefinition.id);
     }
     case "openrouter":
-      return createOpenRouter({ apiKey })(modelDefinition.id);
+      return createOpenRouter({
+        apiKey,
+        headers: {
+          "HTTP-Referer": "https://www.mcpjam.com/",
+          "X-Title": "MCPJam",
+        },
+      })(modelDefinition.id);
     case "xai":
       return createXai({ apiKey })(modelDefinition.id);
     case "azure":


### PR DESCRIPTION
Allows MCPJam to be discoverable on openrouter requests

https://openrouter.ai/docs/app-attribution

<img width="1488" height="353" alt="image" src="https://github.com/user-attachments/assets/fe22e1fe-8495-436a-8945-fdb6d9cd91b2" />
