### PR TITLE
refactor(client, sdk): deprecate hasOwnProperty

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/expected-tools-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/expected-tools-editor.tsx
@@ -227,7 +227,7 @@ export function ExpectedToolsEditor({
                 const argSchema = getArgumentSchema(toolIndex, key);
                 const availableArgs = getAvailableArguments(toolIndex).filter(
                   (arg) =>
-                    !toolCall.arguments.hasOwnProperty(arg.key) ||
+                    !Object.hasOwn(toolCall.arguments, arg.key) ||
                     arg.key === key,
                 );
 

--- a/mcpjam-inspector/client/src/lib/tool-form.ts
+++ b/mcpjam-inspector/client/src/lib/tool-form.ts
@@ -238,7 +238,7 @@ export function applyParametersToFields(
   params: Record<string, any>,
 ): FormField[] {
   return fields.map((field) => {
-    if (Object.prototype.hasOwnProperty.call(params, field.name)) {
+    if (Object.hasOwn(params, field.name)) {
       const raw = params[field.name];
       if (field.type === "array" || field.type === "object") {
         return {

--- a/mcpjam-inspector/client/tsconfig.json
+++ b/mcpjam-inspector/client/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",

--- a/sdk/src/validators.ts
+++ b/sdk/src/validators.ts
@@ -176,7 +176,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
 
     for (const key of aKeys) {
       if (
-        !Object.prototype.hasOwnProperty.call(b, key) ||
+        !Object.hasOwn(b, key) ||
         !deepEqual(
           (a as Record<string, unknown>)[key],
           (b as Record<string, unknown>)[key]


### PR DESCRIPTION
**PROBLEM:**

`hasOwnProperty` is deprecated for `hasOwn` because of issues existing with `hasOwnProperty`: [Problematic Cases For Hasownproperty](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn#problematic_cases_for_hasownproperty)

**SOLUTION:** 

update tsconfig to support types for `hasOwn` and update `hasOwnProperty` calls to `hasOwn`

**Testing:**

I ran the unit tests and checked the UI app, but would be nice for others who know what the key flows are to ensure nothing is broken. 