### PR TITLE
csp-violations now has a red color in logs that matches csp color in thread

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
@@ -344,7 +344,7 @@ export function ToolPart({
                         {badge !== undefined && badge > 0 && (
                           <Badge
                             variant="destructive"
-                            className="absolute -top-1.5 -right-1.5 h-3.5 min-w-[14px] px-1 text-[8px] leading-none"
+                            className="absolute -top-1.5 -right-1.5 h-3.5 min-w-[14px] px-1 text-[8px] leading-none text-white"
                           >
                             {badge}
                           </Badge>

--- a/mcpjam-inspector/client/src/components/logger-view.tsx
+++ b/mcpjam-inspector/client/src/components/logger-view.tsx
@@ -440,10 +440,14 @@ export function LoggerView({
               const isIncoming =
                 it.direction === "RECEIVE" || it.direction === "UI→HOST";
 
-              // Border color: purple for Apps traffic, none for MCP Server
-              const borderClass = isAppsTraffic
-                ? "border-l-4 border-l-purple-500/50"
-                : "";
+              const isCspViolation = it.method === "csp-violation";
+
+              // Border color: red for CSP violations, purple for Apps traffic, none for MCP Server
+              const borderClass = isCspViolation
+                ? "border-l-4 border-l-destructive"
+                : isAppsTraffic
+                  ? "border-l-4 border-l-purple-500/50"
+                  : "";
 
               return (
                 <div
@@ -481,7 +485,10 @@ export function LoggerView({
                         )}
                       </span>
                       <span
-                        className="text-xs font-mono text-foreground truncate"
+                        className={cn(
+                          "text-xs font-mono truncate",
+                          "text-foreground",
+                        )}
                         title={it.method}
                       >
                         {it.method}


### PR DESCRIPTION
also, changed csp icon in the thread to have white letters instead

<img width="2484" height="1342" alt="image" src="https://github.com/user-attachments/assets/75b9ec29-004e-4433-a861-19cc6fbc0083" />
