### PR TITLE
Fix tunnel issue with servers that have a space in the name

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/tunnels.ts
+++ b/mcpjam-inspector/server/routes/mcp/tunnels.ts
@@ -238,8 +238,13 @@ tunnels.post("/create/:serverId", async (c) => {
       authHeader,
     );
 
+    const serverTunnelUrl = tunnelManager.getServerTunnelUrl(serverId);
+    if (!serverTunnelUrl) {
+      throw new Error("Failed to build server tunnel URL");
+    }
+
     return c.json({
-      url: `${baseUrl}/api/mcp/adapter-http/${serverId}`,
+      url: serverTunnelUrl,
       serverId,
       existed: false,
     });

--- a/mcpjam-inspector/server/services/tunnel-manager.ts
+++ b/mcpjam-inspector/server/services/tunnel-manager.ts
@@ -110,8 +110,9 @@ class TunnelManager {
 
   getServerTunnelUrl(serverId: string): string | null {
     const perServerTunnelUrl = this.getTunnelUrl(serverId);
+    const encodedServerId = encodeURIComponent(serverId);
     return perServerTunnelUrl
-      ? `${perServerTunnelUrl}/api/mcp/adapter-http/${serverId}`
+      ? `${perServerTunnelUrl}/api/mcp/adapter-http/${encodedServerId}`
       : null;
   }
 


### PR DESCRIPTION
# Issue

When I have a MCP Server with a name like "brave search http" and I hit the Create ngrok tunnel button it will create an URL like

https://ozsmcix15hde.ngrok.app/api/mcp/adapter-http/brave search http

# Fix 
This PR uses the encoded URL instead, effectively removing spaces in the URL. 