### PR TITLE
stripped extension from json ajv

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/schema-utils.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/schema-utils.test.ts
@@ -166,6 +166,55 @@ describe("validateToolOutput", () => {
     });
   });
 
+  describe("x- extension key stripping", () => {
+    const fastmcpSchema = {
+      type: "object",
+      properties: {
+        result: { type: "number" },
+      },
+      required: ["result"],
+      "x-fastmcp-wrap-result": true,
+    };
+
+    it("validates structured content with x- keys in schema", () => {
+      const result = {
+        content: [{ type: "text", text: '{"result": 6}' }],
+        structuredContent: { result: 6 },
+      };
+
+      const report = validateToolOutput(result, fastmcpSchema);
+      expect(report.structuredErrors).toBeNull();
+    });
+
+    it("validates unstructured content with x- keys in schema", () => {
+      const result = {
+        content: [{ type: "text", text: '{"result": 6}' }],
+      };
+
+      const report = validateToolOutput(result, fastmcpSchema);
+      expect(report.unstructuredStatus).toBe("valid");
+    });
+
+    it("handles nested x- keys in properties", () => {
+      const schema = {
+        type: "object",
+        properties: {
+          data: { type: "string", "x-custom-annotation": "hello" },
+        },
+        "x-vendor-info": { version: 2 },
+      };
+
+      const result = {
+        content: [{ type: "text", text: '{"data": "test"}' }],
+        structuredContent: { data: "test" },
+      };
+
+      const report = validateToolOutput(result, schema);
+      expect(report.structuredErrors).toBeNull();
+      expect(report.unstructuredStatus).toBe("valid");
+    });
+  });
+
   describe("edge cases", () => {
     it("throws when content array is empty (accessing undefined index)", () => {
       const result = { content: [] };

--- a/mcpjam-inspector/client/src/lib/schema-utils.ts
+++ b/mcpjam-inspector/client/src/lib/schema-utils.ts
@@ -3,6 +3,22 @@ import type { ErrorObject } from "ajv";
 
 const ajv = new Ajv();
 
+/**
+ * Recursively strips vendor extension keys (prefixed with "x-") from a JSON Schema.
+ * These are custom annotations (e.g. "x-fastmcp-wrap-result") that are valid in JSON Schema
+ * but cause AJV strict mode to reject the schema as unrecognized keywords.
+ */
+function stripExtensionKeys(schema: any): any {
+  if (typeof schema !== "object" || schema === null) return schema;
+  if (Array.isArray(schema)) return schema.map(stripExtensionKeys);
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema)) {
+    if (key.startsWith("x-")) continue;
+    cleaned[key] = stripExtensionKeys(value);
+  }
+  return cleaned;
+}
+
 export type UnstructuredValidationStatus =
   | "not_applicable"
   | "valid"
@@ -29,7 +45,7 @@ export function validateToolOutput(
 
   if (result.structuredContent) {
     try {
-      const validate = ajv.compile(outputSchema);
+      const validate = ajv.compile(stripExtensionKeys(outputSchema));
       const isValid = validate(result.structuredContent);
       report.structuredErrors = isValid ? null : validate.errors || []; // null means valid
     } catch (e) {
@@ -51,7 +67,7 @@ export function validateToolOutput(
   if (typeof result.content[0].text === "string") {
     try {
       const parsedContent = JSON.parse(result.content[0].text);
-      const validate = ajv.compile(outputSchema);
+      const validate = ajv.compile(stripExtensionKeys(outputSchema));
       const isValid = validate(parsedContent);
       report.unstructuredStatus = isValid ? "valid" : "schema_mismatch";
     } catch (e) {


### PR DESCRIPTION
AJV strict mode throws when it encounters unrecognized keywords. Many MCP server frameworks (e.g. FastMCP) add vendor extensions like "x-fastmcp-wrap-result" to their output schemas, following the x- convention. Rather than disabling strict mode entirely, we strip x- prefixed keys before compilation so extensions are tolerated but typos in real schema keywords are still caught.

Before
<img width="452" height="266" alt="Screenshot 2026-02-10 at 11 18 20 PM" src="https://github.com/user-attachments/assets/779e7f66-0a75-46ae-a3c7-390eb77c6363" />
After:
<img width="356" height="292" alt="Screenshot 2026-02-10 at 11 17 39 PM" src="https://github.com/user-attachments/assets/e8942399-aba7-4a99-a1df-ce8afbef74fa" />