### PR TITLE
Views are not seen in mobile

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
@@ -29,6 +29,11 @@ import {
 } from "../thread-helpers";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { CspDebugPanel } from "../csp-debug-panel";
 import { JsonEditor } from "@/components/ui/json-editor";
 import { cn } from "@/lib/chat-utils";
@@ -257,27 +262,35 @@ export function ToolPart({
       const buttonLabel =
         mode === "inline" ? "Inline" : mode === "pip" ? "PiP" : "Fullscreen";
       return (
-        <button
-          key={mode}
-          type="button"
-          aria-label={buttonLabel}
-          disabled={isDisabled}
-          onClick={(e) => {
-            e.stopPropagation();
-            if (isDisabled) return;
-            handleDisplayModeChange(mode);
-          }}
-          className={`inline-flex items-center gap-1 px-1.5 py-1 rounded transition-colors ${
-            isDisabled
-              ? "text-muted-foreground/30 cursor-not-allowed"
-              : isActive
-                ? "bg-background text-foreground shadow-sm cursor-pointer"
-                : "text-muted-foreground/60 hover:text-muted-foreground hover:bg-background/50 cursor-pointer"
-          }`}
-        >
-          <Icon className="h-3.5 w-3.5" />
-          <span className="text-[9px] leading-none hidden @[32rem]:inline">{buttonLabel}</span>
-        </button>
+        <Tooltip key={mode}>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={buttonLabel}
+              disabled={isDisabled}
+              onClick={(e) => {
+                e.stopPropagation();
+                if (isDisabled) return;
+                handleDisplayModeChange(mode);
+              }}
+              className={`inline-flex items-center gap-1 px-1.5 py-1 rounded transition-colors ${
+                isDisabled
+                  ? "text-muted-foreground/30 cursor-not-allowed"
+                  : isActive
+                    ? "bg-background text-foreground shadow-sm cursor-pointer"
+                    : "text-muted-foreground/60 hover:text-muted-foreground hover:bg-background/50 cursor-pointer"
+              }`}
+            >
+              <Icon className="h-3.5 w-3.5" />
+              <span className="text-[9px] leading-none hidden @[33rem]:inline">
+                {buttonLabel}
+              </span>
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p className="font-medium">{buttonLabel}</p>
+          </TooltipContent>
+        </Tooltip>
       );
     });
 
@@ -291,35 +304,51 @@ export function ToolPart({
             : tab === "csp"
               ? "CSP"
               : "Context";
+      const tooltipLabel =
+        tab === "data"
+          ? "Data"
+          : tab === "state"
+            ? "Widget State"
+            : tab === "csp"
+              ? "CSP"
+              : "Model Context";
 
       return (
-        <button
-          key={tab}
-          type="button"
-          aria-label={buttonLabel}
-          onClick={(e) => {
-            e.stopPropagation();
-            handleDebugClick(tab);
-          }}
-          className={`inline-flex items-center gap-1 px-1.5 py-1 rounded transition-colors cursor-pointer relative ${
-            activeDebugTab === tab
-              ? "bg-background text-foreground shadow-sm"
-              : badge && badge > 0
-                ? "text-destructive hover:text-destructive hover:bg-destructive/10"
-                : "text-muted-foreground/60 hover:text-muted-foreground hover:bg-background/50"
-          }`}
-        >
-          <Icon className="h-3.5 w-3.5" />
-          <span className="text-[9px] leading-none hidden @[32rem]:inline">{buttonLabel}</span>
-          {badge !== undefined && badge > 0 && (
-            <Badge
-              variant="destructive"
-              className="absolute -top-1.5 -right-1.5 h-3.5 min-w-[14px] px-1 text-[8px] leading-none text-white"
+        <Tooltip key={tab}>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={tooltipLabel}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleDebugClick(tab);
+              }}
+              className={`inline-flex items-center gap-1 px-1.5 py-1 rounded transition-colors cursor-pointer relative ${
+                activeDebugTab === tab
+                  ? "bg-background text-foreground shadow-sm"
+                  : badge && badge > 0
+                    ? "text-destructive hover:text-destructive hover:bg-destructive/10"
+                    : "text-muted-foreground/60 hover:text-muted-foreground hover:bg-background/50"
+              }`}
             >
-              {badge}
-            </Badge>
-          )}
-        </button>
+              <Icon className="h-3.5 w-3.5" />
+              <span className="text-[9px] leading-none hidden @[33rem]:inline">
+                {buttonLabel}
+              </span>
+              {badge !== undefined && badge > 0 && (
+                <Badge
+                  variant="destructive"
+                  className="absolute -top-1.5 -right-1.5 h-3.5 min-w-[14px] px-1 text-[8px] leading-none text-white"
+                >
+                  {badge}
+                </Badge>
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p className="font-medium">{tooltipLabel}</p>
+          </TooltipContent>
+        </Tooltip>
       );
     });
 
@@ -337,24 +366,33 @@ export function ToolPart({
           <span className="relative z-10">Like how it looks? Save it.</span>
         </span>
       )}
-      <button
-        type="button"
-        aria-label={saveViewAriaLabel}
-        disabled={!canSaveView || isSaving}
-        onClick={handleSaveViewClick}
-        className={`inline-flex items-center gap-1 px-1.5 py-1 rounded transition-colors ${
-          canSaveView && !isSaving
-            ? "border border-border/50 bg-background text-foreground shadow-sm hover:bg-background/80 cursor-pointer"
-            : "border border-border/30 text-muted-foreground/30 cursor-not-allowed"
-        }`}
-      >
-        {isSaving ? (
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-        ) : (
-          <Layers className="h-3.5 w-3.5" />
-        )}
-        <span className="text-[9px] leading-none hidden @[32rem]:inline">Save View</span>
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-label={saveViewAriaLabel}
+            disabled={!canSaveView || isSaving}
+            onClick={handleSaveViewClick}
+            className={`inline-flex items-center gap-1 px-1.5 py-1 rounded transition-colors ${
+              canSaveView && !isSaving
+                ? "border border-border/50 bg-background text-foreground shadow-sm hover:bg-background/80 cursor-pointer"
+                : "border border-border/30 text-muted-foreground/30 cursor-not-allowed"
+            }`}
+          >
+            {isSaving ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Layers className="h-3.5 w-3.5" />
+            )}
+            <span className="text-[9px] leading-none hidden @[33rem]:inline">
+              Save View
+            </span>
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p className="font-medium">Save View</p>
+        </TooltipContent>
+      </Tooltip>
     </span>
   );
 


### PR DESCRIPTION
- display modes of all sizes won't cut down width of tool header. we go from icons -> titles at 626+ of our custom device dimenstions. 
- highlighted all buttons from tool header since we're gonna show icons when device is narrow

NOTE: everything is so compacted that we might want to do a hover for tool name
<img width="565" height="247" alt="Screenshot 2026-02-12 at 10 09 13 PM" src="https://github.com/user-attachments/assets/5b8e429a-2ddb-4b29-b7c4-891bf8941b2a" />
<img width="331" height="47" alt="Screenshot 2026-02-12 at 10 09 38 PM" src="https://github.com/user-attachments/assets/de8d4914-a9be-4b99-82e8-b9c1e453b63e" />
<img width="542" height="164" alt="Screenshot 2026-02-12 at 10 10 37 PM" src="https://github.com/user-attachments/assets/7764bf76-cd12-46bb-ab1d-fc0847a948fe" />
<img width="306" height="54" alt="Screenshot 2026-02-12 at 10 11 40 PM" src="https://github.com/user-attachments/assets/9526509a-cbce-470d-b17b-fafba5338b53" />

