### PR TITLE
Chevron doesnt expand

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
@@ -412,7 +412,15 @@ export function ToolPart({
       <button
         type="button"
         className="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-wide text-muted-foreground cursor-pointer overflow-hidden"
-        onClick={() => setUserExpanded((prev) => !prev)}
+        onClick={() => {
+          setUserExpanded((prev) => {
+            const willExpand = !prev;
+            if (willExpand && activeDebugTab === null) {
+              setActiveDebugTab("data");
+            }
+            return willExpand;
+          });
+        }}
         aria-expanded={isExpanded}
       >
         <span className="inline-flex items-center gap-2 font-medium normal-case text-foreground min-w-0">


### PR DESCRIPTION
Chevron bugged out when dealing with tool header buttons. now it goes back to expanding last viewed tool header button (data button as fallback)

Before:
https://github.com/user-attachments/assets/373b8b3d-54ad-4db6-aa8d-822712676099

After:
https://github.com/user-attachments/assets/db03ef3c-975a-4f01-85eb-c88ad32695ff

