### PR TITLE
fullscreen-disables-views-encourager

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
@@ -331,12 +331,15 @@ export function ToolPart({
 
   const renderSaveViewButton = () => (
     <span className="relative inline-flex items-center">
-      {canSaveView && !isSaving && !hasUsedSaveViewButton && displayMode !== "fullscreen" && (
-        <span className="absolute right-0 top-full z-50 mt-2 whitespace-nowrap rounded-xl border border-primary/70 bg-primary px-2.5 py-1 text-[10px] font-semibold normal-case text-primary-foreground shadow-md shadow-primary/30 ring-1 ring-primary/40">
-          <span className="absolute -top-1 right-2 z-50 h-2.5 w-2.5 rotate-45 border-l border-t border-primary/70 bg-primary" />
-          <span className="relative z-10">Like how it looks? Save it.</span>
-        </span>
-      )}
+      {canSaveView &&
+        !isSaving &&
+        !hasUsedSaveViewButton &&
+        displayMode !== "fullscreen" && (
+          <span className="absolute right-0 top-full z-50 mt-2 whitespace-nowrap rounded-xl border border-primary/70 bg-primary px-2.5 py-1 text-[10px] font-semibold normal-case text-primary-foreground shadow-md shadow-primary/30 ring-1 ring-primary/40">
+            <span className="absolute -top-1 right-2 z-50 h-2.5 w-2.5 rotate-45 border-l border-t border-primary/70 bg-primary" />
+            <span className="relative z-10">Like how it looks? Save it.</span>
+          </span>
+        )}
       <button
         type="button"
         aria-label={saveViewAriaLabel}


### PR DESCRIPTION
Banner's still there when exiting fullscreen.

Before:
<img width="2880" height="1510" alt="image" src="https://github.com/user-attachments/assets/d14fab7f-ca16-4b0f-9885-6ed0e853f97b" />

After:


https://github.com/user-attachments/assets/fa9db2b3-c2ad-4bc6-b205-17f2b9fa0e6f



