### PR TITLE
prompts doesn't bug when server doesn't support prompts anymore

### DIFF
--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -634,6 +634,12 @@ export class MCPClientManager {
     await this.ensureConnected(serverId);
     const client = this.getClientOrThrow(serverId);
 
+    // Skip if server doesn't advertise prompts capability
+    const capabilities = client.getServerCapabilities();
+    if (capabilities && !capabilities.prompts) {
+      return { prompts: [] } as Awaited<ReturnType<Client["listPrompts"]>>;
+    }
+
     try {
       return await client.listPrompts(
         params,

--- a/sdk/src/mcp-client-manager/error-utils.ts
+++ b/sdk/src/mcp-client-manager/error-utils.ts
@@ -36,6 +36,8 @@ export function isMethodUnavailableError(
     "unsupported",
     "does not support",
     "unimplemented",
+    "unknown method",
+    "unknown mcp method",
   ];
 
   const indicatorMatch = indicators.some((indicator) =>


### PR DESCRIPTION
Before
<img width="2320" height="514" alt="image" src="https://github.com/user-attachments/assets/d431b367-82d0-4256-a125-0d71047263f4" />
After:
<img width="1750" height="460" alt="Screenshot 2026-02-13 at 4 33 36 PM" src="https://github.com/user-attachments/assets/b5c298c6-ee1c-486b-bf57-b382be1e055d" />
