### PR TITLE
fix(mcp-apps): fix display mode height handling

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -73,6 +73,7 @@ const SIGNATURE_MAX_ARRAY_ITEMS = 24;
 const SIGNATURE_MAX_OBJECT_KEYS = 32;
 const SIGNATURE_STRING_EDGE_LENGTH = 24;
 const SUPPRESSED_UI_LOG_METHODS = new Set(["ui/notifications/size-changed"]);
+const PIP_MAX_HEIGHT = "min(40vh, 600px)";
 
 type DisplayMode = "inline" | "pip" | "fullscreen";
 type ToolState =
@@ -1392,13 +1393,16 @@ export function MCPAppsRenderer({
   const showWidget = isReady && canRenderStreamingInput;
 
   const iframeStyle: CSSProperties = {
-    height: isFullscreen ? "100%" : lastInlineHeightRef.current,
+    height: isFullscreen
+      ? "100%"
+      : isPip
+        ? PIP_MAX_HEIGHT
+        : lastInlineHeightRef.current,
     width: "100%",
     maxWidth: "100%",
     // Width transition was previously included here ("width 300ms ease-out").
     transition:
-      isFullscreen ||
-      effectiveDisplayModeRef.current !== effectiveDisplayMode
+      isFullscreen || effectiveDisplayModeRef.current !== effectiveDisplayMode
         ? undefined
         : "height 300ms ease-out",
     // Hide iframe visually while not ready to display


### PR DESCRIPTION
## Summary
- Preserve iframe height across display mode transitions (inline → PIP → fullscreen) by storing the last inline height in a ref
- Clamp PIP mode height to `min(40vh, 600px)` so tall apps don't overflow the viewport in the floating overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)