### PR TITLE
improved hover secondary color

### DIFF
--- a/mcpjam-inspector/client/src/components/shared/DisplayContextHeader.tsx
+++ b/mcpjam-inspector/client/src/components/shared/DisplayContextHeader.tsx
@@ -460,7 +460,7 @@ export function DisplayContextHeader({
                 </TooltipTrigger>
                 <TooltipContent>
                   <p className="font-medium">Hover</p>
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-xs font-light text-primary-foreground/90">
                     {capabilities.hover ? "Enabled" : "Disabled"}
                   </p>
                 </TooltipContent>
@@ -480,7 +480,7 @@ export function DisplayContextHeader({
                 </TooltipTrigger>
                 <TooltipContent>
                   <p className="font-medium">Touch</p>
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-xs font-light text-primary-foreground/90">
                     {capabilities.touch ? "Enabled" : "Disabled"}
                   </p>
                 </TooltipContent>
@@ -798,7 +798,7 @@ export function DisplayContextHeader({
                 </TooltipTrigger>
                 <TooltipContent>
                   <p className="font-medium">Hover</p>
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-xs font-light text-primary-foreground/90">
                     {capabilities.hover ? "Enabled" : "Disabled"}
                   </p>
                 </TooltipContent>
@@ -818,7 +818,7 @@ export function DisplayContextHeader({
                 </TooltipTrigger>
                 <TooltipContent>
                   <p className="font-medium">Touch</p>
-                  <p className="text-xs text-muted-foreground">
+                  <p className="text-xs font-light text-primary-foreground/90">
                     {capabilities.touch ? "Enabled" : "Disabled"}
                   </p>
                 </TooltipContent>


### PR DESCRIPTION
Before:
<img width="106" height="66" alt="Screenshot 2026-02-16 at 10 29 59 PM" src="https://github.com/user-attachments/assets/26f42441-d955-44e1-aa3e-523b158cc5b3" />

After:
<img width="119" height="99" alt="Screenshot 2026-02-16 at 9 36 03 PM" src="https://github.com/user-attachments/assets/34ce93b1-fb6f-4bb3-a9e5-00ddd82f36e1" />
