### PR TITLE
permisive was falsely showing csp errors

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-app-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-app-renderer.tsx
@@ -707,6 +707,16 @@ export function ChatGPTAppRenderer({
     : DEFAULT_SAFE_AREA_INSETS;
   const setWidgetCsp = useWidgetDebugStore((s) => s.setWidgetCsp);
   const setWidgetHtml = useWidgetDebugStore((s) => s.setWidgetHtml);
+  const clearCspViolations = useWidgetDebugStore((s) => s.clearCspViolations);
+
+  // Clear CSP violations when CSP mode changes (stale data from previous mode)
+  const prevCspModeRef = useRef(cspMode);
+  useEffect(() => {
+    if (prevCspModeRef.current !== cspMode) {
+      clearCspViolations(resolvedToolCallId);
+      prevCspModeRef.current = cspMode;
+    }
+  }, [cspMode, resolvedToolCallId, clearCspViolations]);
 
   // Mobile playground mode detection
   const isMobilePlaygroundMode = isPlaygroundActive && deviceType === "mobile";


### PR DESCRIPTION
When a ChatGPT app has CSP violations in Strict mode and the user switches to Permissive, the red badge with the violation count persists on the per-widget CSP button. This is because chatgpt-app-renderer.tsx never calls clearCspViolations on mode change. 
Before:
<img width="324" height="148" alt="Screenshot 2026-02-17 at 11 36 18 PM" src="https://github.com/user-attachments/assets/da962aab-eea7-4b16-9909-767e7f97e5a9" />
After:
<img width="375" height="91" alt="Screenshot 2026-02-17 at 11 34 39 PM" src="https://github.com/user-attachments/assets/d507ebb7-9461-4df0-8d5e-eff11b466e07" />
