### PR TITLE
Errors when exiting full screen on chatgpt apps

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-app-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-app-renderer.tsx
@@ -696,6 +696,11 @@ export function ChatGPTAppRenderer({
   const previousWidgetStateRef = useRef<string | null>(null);
   const [modalSandboxReady, setModalSandboxReady] = useState(false);
   const lastAppliedHeightRef = useRef<number>(0);
+  const effectiveDisplayModeRef = useRef(effectiveDisplayMode);
+
+  useEffect(() => {
+    effectiveDisplayModeRef.current = effectiveDisplayMode;
+  }, [effectiveDisplayMode]);
 
   // Host-backed navigation state for fullscreen header buttons
   const [canGoBack, setCanGoBack] = useState(false);
@@ -923,6 +928,7 @@ export function ChatGPTAppRenderer({
   // resize logic publishes the fresh height.
   useEffect(() => {
     if (!widgetUrl || effectiveDisplayMode !== "inline" || !isReady) return;
+    setContentWidth(undefined);
     sandboxRef.current?.postMessage({ type: "openai:requestResize" });
   }, [widgetUrl, effectiveDisplayMode, isReady]);
 
@@ -1003,7 +1009,11 @@ export function ChatGPTAppRenderer({
         case "openai:resize": {
           applyMeasuredHeight(event.data.height);
           const w = Number(event.data.width);
-          if (Number.isFinite(w) && w > 0) {
+          if (
+            Number.isFinite(w) &&
+            w > 0 &&
+            effectiveDisplayModeRef.current === "inline"
+          ) {
             setContentWidth(Math.ceil(w));
           }
           break;


### PR DESCRIPTION
Fullscreen widths for ChatGPT apps would persist when exited. Now reset width to default when transitioning back to inline mode.
Before:

https://github.com/user-attachments/assets/fce2706a-bd5d-4561-bfde-8896217e64ca



After:

https://github.com/user-attachments/assets/cf5ae6c9-f4e3-4700-bc84-b3a06593b919


