### PR TITLE
width flash gptapps

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-app-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-app-renderer.tsx
@@ -936,13 +936,13 @@ export function ChatGPTAppRenderer({
     }
   }, [widgetUrl, maxHeight]);
 
-  // When returning to inline, ask the widget to re-measure so backend-driven
-  // resize logic publishes the fresh height.
+  // When returning to inline or when the device type changes, ask the widget
+  // to re-measure so backend-driven resize logic publishes fresh dimensions.
   useEffect(() => {
     if (!widgetUrl || effectiveDisplayMode !== "inline" || !isReady) return;
     setContentWidth(undefined);
     sandboxRef.current?.postMessage({ type: "openai:requestResize" });
-  }, [widgetUrl, effectiveDisplayMode, isReady]);
+  }, [widgetUrl, effectiveDisplayMode, isReady, deviceType]);
 
   // When returning from pip/fullscreen to inline, push the latest measured
   // height back into the iframe so it reflects current content.


### PR DESCRIPTION
chatgpt container was shrinking but iframe wasn't on display mode changes
Before:
<img width="724" height="781" alt="Screenshot 2026-02-20 at 11 27 06 PM" src="https://github.com/user-attachments/assets/73298797-e1ab-43b4-aaa1-15a263a861cf" />
After:
<img width="433" height="833" alt="Screenshot 2026-02-20 at 11 28 29 PM" src="https://github.com/user-attachments/assets/ca18841d-c4cd-4bee-8cef-dad348edbddf" />
