### PR TITLE
views encourager banner was below widget

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
@@ -368,8 +368,8 @@ export function ToolPart({
         !isSaving &&
         !hasUsedSaveViewButton &&
         displayMode !== "fullscreen" && (
-          <span className="absolute right-0 top-full z-50 mt-2 whitespace-nowrap rounded-xl border border-primary/70 bg-primary px-2.5 py-1 text-[10px] font-semibold normal-case text-primary-foreground shadow-md shadow-primary/30 ring-1 ring-primary/40">
-            <span className="absolute -top-1 right-2 z-50 h-2.5 w-2.5 rotate-45 border-l border-t border-primary/70 bg-primary" />
+          <span className="absolute right-0 bottom-full z-50 mb-2 whitespace-nowrap rounded-xl border border-primary/70 bg-primary px-2.5 py-1 text-[10px] font-semibold normal-case text-primary-foreground shadow-md shadow-primary/30 ring-1 ring-primary/40">
+            <span className="absolute -bottom-1 right-2 z-50 h-2.5 w-2.5 rotate-45 border-b border-r border-primary/70 bg-primary" />
             <span className="relative z-10">Like how it looks? Save it.</span>
           </span>
         )}


### PR DESCRIPTION
before:
<img width="820" height="144" alt="Screenshot 2026-02-22 at 5 07 40 PM" src="https://github.com/user-attachments/assets/b8f5a110-6697-48e4-8984-e9a56f478cdd" />
after:
<img width="801" height="142" alt="Screenshot 2026-02-22 at 5 07 48 PM" src="https://github.com/user-attachments/assets/21325875-2d9c-4883-8e8b-27842ca42387" />
