### PR TITLE
feat(vite-plugin): add cspMode option for App Builder sandbox

### DIFF
--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -31,6 +31,7 @@ import { injectHostedServerMapping } from "@/lib/apis/web/context";
 import type { OAuthTestProfile } from "@/lib/oauth/profile";
 import { SHARED_OAUTH_PENDING_KEY } from "@/lib/shared-server-session";
 import { authFetch } from "@/lib/session-token";
+import { useUIPlaygroundStore } from "@/stores/ui-playground-store";
 import { useServerMutations, type RemoteServer } from "./useWorkspaces";
 
 /**
@@ -1000,6 +1001,15 @@ export function useServerState({
           if (cliConfig) {
             if (cliConfig.initialTab && !window.location.hash) {
               window.location.hash = cliConfig.initialTab;
+            }
+
+            if (
+              cliConfig.cspMode === "permissive" ||
+              cliConfig.cspMode === "widget-declared"
+            ) {
+              const store = useUIPlaygroundStore.getState();
+              store.setCspMode(cliConfig.cspMode);
+              store.setMcpAppsCspMode(cliConfig.cspMode);
             }
 
             if (cliConfig.servers && Array.isArray(cliConfig.servers)) {

--- a/mcpjam-inspector/client/src/stores/ui-playground-store.ts
+++ b/mcpjam-inspector/client/src/stores/ui-playground-store.ts
@@ -449,6 +449,9 @@ export const useUIPlaygroundStore = create<UIPlaygroundState>((set) => ({
         selectedProtocol: getStoredSelectedProtocol(),
         // Preserve host style from localStorage
         hostStyle: getStoredHostStyle(),
+        // Preserve CSP modes (may be set via CLI config before reset fires)
+        cspMode: state.cspMode,
+        mcpAppsCspMode: state.mcpAppsCspMode,
       };
     }),
 }));

--- a/mcpjam-inspector/lib/launcher/index.ts
+++ b/mcpjam-inspector/lib/launcher/index.ts
@@ -42,6 +42,13 @@ export interface LaunchOptions {
    * When false (default), the inspector runs silently.
    */
   verbose?: boolean;
+
+  /**
+   * Content Security Policy mode for the App Builder sandbox.
+   * - "widget-declared": enforces CSP directives declared by the widget (default)
+   * - "permissive": disables CSP enforcement for easier development
+   */
+  cspMode?: "permissive" | "widget-declared";
 }
 
 /**
@@ -141,6 +148,10 @@ export async function launchInspector(
 
   if (options.verbose) {
     env.VERBOSE_LOGS = "true";
+  }
+
+  if (options.cspMode) {
+    env.MCP_CSP_MODE = options.cspMode;
   }
 
   // Spawn the process

--- a/mcpjam-inspector/lib/vite/index.ts
+++ b/mcpjam-inspector/lib/vite/index.ts
@@ -47,6 +47,13 @@ export interface MCPInspectorPluginOptions {
    * When false (default), the inspector runs silently.
    */
   verbose?: boolean;
+
+  /**
+   * Content Security Policy mode for the App Builder sandbox.
+   * - "widget-declared": enforces CSP directives declared by the widget (default)
+   * - "permissive": disables CSP enforcement for easier development
+   */
+  cspMode?: "permissive" | "widget-declared";
 }
 
 /**
@@ -88,6 +95,7 @@ export function mcpInspector(options: MCPInspectorPluginOptions = {}): Plugin {
             server: options.server,
             defaultTab: options.defaultTab ?? "app-builder",
             verbose: options.verbose,
+            cspMode: options.cspMode,
           });
           console.log(`\n  MCP Inspector running at ${inspector.url}\n`);
         } catch (error) {

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -100,6 +100,7 @@ import "./types/hono"; // Type extensions
 function getMCPConfigFromEnv() {
   // Global options that apply to all modes
   const initialTab = process.env.MCP_INITIAL_TAB || null;
+  const cspMode = process.env.MCP_CSP_MODE || null;
 
   // First check if we have a full config file
   const configData = process.env.MCP_CONFIG_DATA;
@@ -134,6 +135,7 @@ function getMCPConfigFromEnv() {
           servers,
           autoConnectServer: autoConnectServer || null,
           initialTab,
+          cspMode,
         };
       }
     } catch (error) {
@@ -145,10 +147,11 @@ function getMCPConfigFromEnv() {
   const command = process.env.MCP_SERVER_COMMAND;
   if (!command) {
     // No server config, but still return global options if set
-    if (initialTab) {
+    if (initialTab || cspMode) {
       return {
         servers: [],
         initialTab,
+        cspMode,
       };
     }
     return null;
@@ -167,6 +170,7 @@ function getMCPConfigFromEnv() {
       },
     ],
     initialTab,
+    cspMode,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add `cspMode` option (`"permissive" | "widget-declared"`) to the Vite plugin and launcher APIs
- Flow the option through the existing CLI config pipeline: env var `MCP_CSP_MODE` → server `getMCPConfigFromEnv()` → `/api/mcp-cli-config` → client Zustand store
- Set both `cspMode` (ChatGPT Apps) and `mcpAppsCspMode` (MCP Apps) in the UI playground store
- Preserve CSP mode values through store `reset()` calls so they survive server reconnections

## Usage
```typescript
// vite.config.ts
mcpInspector({
  server: { name: 'My Server', url: 'http://localhost:3000/mcp' },
  cspMode: 'permissive',
})
```

Or via env var:
```bash
MCP_CSP_MODE=permissive npm run dev
```

## Test plan
- [ ] Run `MCP_CSP_MODE=permissive npm run dev`, connect to an MCP server, execute a tool with UI — sandbox should run without CSP enforcement
- [ ] Run without the env var — default `widget-declared` CSP should still apply
- [ ] Verify CSP mode persists after reconnecting to a server (store reset)
- [ ] Verify the DisplayContextHeader CSP toggle reflects the correct initial mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)