### PR TITLE
fix(client): move read resource button

### DIFF
--- a/mcpjam-inspector/client/src/components/ResourcesTab.tsx
+++ b/mcpjam-inspector/client/src/components/ResourcesTab.tsx
@@ -369,7 +369,7 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
           </div>
 
           {/* Action buttons */}
-          <div className="flex items-center gap-0.5 text-muted-foreground/80">
+          <div className="ml-auto flex items-center gap-0.5 text-muted-foreground/80">
             <Button
               onClick={() => {
                 if (activeTab === "resources") {
@@ -408,7 +408,7 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
               onClick={readTemplateResource}
               disabled={templateLoading || !selectedTemplate}
               size="sm"
-              className="h-8 px-3 text-xs ml-auto"
+              className="h-8 px-3 text-xs"
             >
               {templateLoading ? (
                 <RefreshCw className="h-3 w-3 animate-spin" />


### PR DESCRIPTION
This PR addresses the placement of the Read Resource button brought up in #1415 by moving it to the same location as the Run Button in tools.

<img width="1509" height="776" alt="Screenshot 2026-02-24 at 12 51 08 PM" src="https://github.com/user-attachments/assets/051f2796-0980-4dd2-b415-45468bc0df16" />
