### PR TITLE
Hosted mode server connection race conditions

### DIFF
--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -806,7 +806,10 @@ export function useServerState({
 
       if (isAuthenticated && effectiveActiveWorkspaceId) {
         try {
-          await syncServerToConvex(serverName, serverEntry);
+          const serverId = await syncServerToConvex(serverName, serverEntry);
+          if (HOSTED_MODE && serverId) {
+            injectHostedServerMapping(serverName, serverId);
+          }
         } catch (error) {
           logger.error("Failed to sync server to Convex", {
             error: error instanceof Error ? error.message : "Unknown error",

--- a/mcpjam-inspector/client/src/lib/apis/web/__tests__/context.hosted.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/__tests__/context.hosted.test.ts
@@ -130,4 +130,21 @@ describe("injectHostedServerMapping", () => {
     // Pending injection still survives.
     expect(resolveHostedServerId("new-server")).toBe("id-new");
   });
+
+  it("multiple rapid injections all survive stale subscription data", () => {
+    injectHostedServerMapping("server-a", "id-a");
+    injectHostedServerMapping("server-b", "id-b");
+
+    // Stale subscription fires without either new server.
+    setHostedApiContext({
+      workspaceId: "workspace-1",
+      serverIdsByName: {
+        "existing-server": "id-existing",
+      },
+    });
+
+    expect(resolveHostedServerId("server-a")).toBe("id-a");
+    expect(resolveHostedServerId("server-b")).toBe("id-b");
+    expect(resolveHostedServerId("existing-server")).toBe("id-existing");
+  });
 });

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -45,6 +45,7 @@ export function setHostedApiContext(next: HostedApiContext | null): void {
   const base = next ?? EMPTY_CONTEXT;
 
   // Self-clean: remove pending injections that the subscription now confirms.
+  // Safe: Map spec allows delete of the current entry during for..of iteration.
   for (const [name, id] of pendingInjections) {
     if (base.serverIdsByName[name] === id) {
       pendingInjections.delete(name);


### PR DESCRIPTION
- Fix race condition between Convex subscription and mutation between user pressing connect server and the server actually connecting
- Fix race condition in OAuth flow by adding missing server ID to hosted context before connecting to a server, mirroring handleConnect
