### PR TITLE
feat(client): enable copy of tool results

### DIFF
--- a/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
@@ -96,6 +96,8 @@ export function ResultsPanel({
               value={rawResult}
               readOnly
               showToolbar={false}
+              className="break-normal"
+              collapsible={true}
               height="100%"
             />
           </div>

--- a/mcpjam-inspector/client/src/components/ui/json-editor/json-editor-view.tsx
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/json-editor-view.tsx
@@ -45,6 +45,8 @@ export function JsonEditorView({
       <JsonTreeView
         value={value}
         className={className}
+        height={height ?? "100%"}
+        maxHeight={maxHeight}
         defaultExpandDepth={defaultExpandDepth}
         collapsedPaths={collapsedPaths}
         onCollapseChange={onCollapseChange}

--- a/mcpjam-inspector/client/src/components/ui/json-editor/json-tree-view.tsx
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/json-tree-view.tsx
@@ -6,6 +6,8 @@ import { JsonTreeNode } from "./json-tree-node";
 interface JsonTreeViewProps {
   value: unknown;
   className?: string;
+  height?: string | number;
+  maxHeight?: string | number;
   defaultExpandDepth?: number;
   collapsedPaths?: Set<string>;
   onCollapseChange?: (paths: Set<string>) => void;
@@ -16,6 +18,8 @@ interface JsonTreeViewProps {
 export function JsonTreeView({
   value,
   className,
+  height,
+  maxHeight,
   defaultExpandDepth,
   collapsedPaths: controlledCollapsedPaths,
   onCollapseChange,
@@ -38,12 +42,16 @@ export function JsonTreeView({
   return (
     <div
       className={cn(
-        "p-3 text-xs overflow-auto select-text cursor-text",
+        "p-3 text-xs overflow-auto select-text cursor-text min-h-0",
         className,
         // pl-7 must come after className to ensure space for collapse toggles
         "pl-7",
       )}
-      style={{ fontFamily: "var(--font-code)" }}
+      style={{
+        fontFamily: "var(--font-code)",
+        height,
+        maxHeight,
+      }}
     >
       <JsonTreeNode
         value={value}


### PR DESCRIPTION
## Summary
This PR improves the Tool Results experience by making results easier to copy and easier to read for large payloads.

## What Changed
- Added copy-friendly result rendering in the Tool Results panel.
- Enabled collapsible JSON tree view for large/nested tool outputs.
- Improved layout/readability for long result content.


Before Changes:
<img width="1510" height="773" alt="tools-before" src="https://github.com/user-attachments/assets/07d78e79-9dca-4a25-9ecd-ad46050c0f90" />

After Changes:
<img width="1511" height="771" alt="tools-after" src="https://github.com/user-attachments/assets/b0aef921-4df6-4dda-84b9-8582b604e98f" />
