### PR TITLE
fix: prevent crash when deselecting tool in App Builder

### DIFF
--- a/mcpjam-inspector/client/src/components/tools/ToolsSidebar.tsx
+++ b/mcpjam-inspector/client/src/components/tools/ToolsSidebar.tsx
@@ -264,14 +264,16 @@ export function ToolsSidebar({
                     </AccordionContent>
                   </AccordionItem>
                 )}
-                <AccordionItem value="input-schema">
-                  <AccordionTrigger className="text-xs">
-                    Input Schema
-                  </AccordionTrigger>
-                  <AccordionContent>
-                    <SchemaViewer schema={selectedTool.inputSchema} />
-                  </AccordionContent>
-                </AccordionItem>
+                {selectedTool?.inputSchema && (
+                  <AccordionItem value="input-schema">
+                    <AccordionTrigger className="text-xs">
+                      Input Schema
+                    </AccordionTrigger>
+                    <AccordionContent>
+                      <SchemaViewer schema={selectedTool.inputSchema} />
+                    </AccordionContent>
+                  </AccordionItem>
+                )}
                 {selectedTool?.outputSchema && (
                   <AccordionItem value="output-schema">
                     <AccordionTrigger className="text-xs">

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundLeft.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundLeft.tsx
@@ -158,7 +158,7 @@ export function PlaygroundLeft({
           onDuplicateRequest={onDuplicateRequest}
           onDeleteRequest={onDeleteRequest}
         />
-      ) : isListExpanded ? (
+      ) : isListExpanded || !selectedToolName ? (
         <ToolList
           tools={tools}
           toolNames={toolNames}
@@ -347,14 +347,16 @@ function ToolParametersView({
               </AccordionContent>
             </AccordionItem>
           )}
-          <AccordionItem value="input-schema">
-            <AccordionTrigger className="text-xs">
-              Input Schema
-            </AccordionTrigger>
-            <AccordionContent>
-              <SchemaViewer schema={selectedTool.inputSchema} />
-            </AccordionContent>
-          </AccordionItem>
+          {selectedTool?.inputSchema && (
+            <AccordionItem value="input-schema">
+              <AccordionTrigger className="text-xs">
+                Input Schema
+              </AccordionTrigger>
+              <AccordionContent>
+                <SchemaViewer schema={selectedTool.inputSchema} />
+              </AccordionContent>
+            </AccordionItem>
+          )}
           {selectedTool?.outputSchema && (
             <AccordionItem value="output-schema">
               <AccordionTrigger className="text-xs">

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundLeft.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundLeft.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { PlaygroundLeft } from "../PlaygroundLeft";
+
+vi.mock("../TabHeader", () => ({
+  TabHeader: () => <div data-testid="tab-header" />,
+}));
+
+vi.mock("../ToolList", () => ({
+  ToolList: () => <div data-testid="tool-list" />,
+}));
+
+vi.mock("../SelectedToolHeader", () => ({
+  SelectedToolHeader: () => <div data-testid="selected-tool-header" />,
+}));
+
+vi.mock("../ParametersForm", () => ({
+  ParametersForm: () => <div data-testid="parameters-form" />,
+}));
+
+vi.mock("../../ui/schema-viewer", () => ({
+  SchemaViewer: () => <div data-testid="schema-viewer" />,
+}));
+
+vi.mock("../../logger-view", () => ({
+  LoggerView: () => <div data-testid="logger-view" />,
+}));
+
+vi.mock("../../ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: () => <div />,
+}));
+
+vi.mock("@/lib/mcp-ui/mcp-apps-utils", () => ({
+  detectUiTypeFromTool: vi.fn().mockReturnValue(null),
+  UIType: { OPENAI_SDK_AND_MCP_APPS: "both" },
+}));
+
+const defaultProps = {
+  tools: {} as Record<string, Tool>,
+  selectedToolName: null as string | null,
+  fetchingTools: false,
+  onRefresh: vi.fn(),
+  onSelectTool: vi.fn(),
+  formFields: [],
+  onFieldChange: vi.fn(),
+  onToggleField: vi.fn(),
+  isExecuting: false,
+  onExecute: vi.fn(),
+  onSave: vi.fn(),
+  savedRequests: [],
+  highlightedRequestId: null,
+  onLoadRequest: vi.fn(),
+  onRenameRequest: vi.fn(),
+  onDuplicateRequest: vi.fn(),
+  onDeleteRequest: vi.fn(),
+};
+
+describe("PlaygroundLeft", () => {
+  it("shows tool list when no tool is selected", () => {
+    render(<PlaygroundLeft {...defaultProps} selectedToolName={null} />);
+    expect(screen.getByTestId("tool-list")).toBeInTheDocument();
+  });
+
+  it("does not crash when selected tool is missing from tools map", () => {
+    expect(() =>
+      render(
+        <PlaygroundLeft
+          {...defaultProps}
+          tools={{}}
+          selectedToolName="deleted-tool"
+        />,
+      ),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
The tool details panel briefly renders before the app knows no tool is selected, causing a crash. Added a guard to always show the tool list when no tool is selected.