### PR TITLE
Fix XSS vulnerability in ServerInfoModal websiteUrl href

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/ServerInfoModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerInfoModal.tsx
@@ -340,7 +340,7 @@ export function ServerInfoModal({
                 </div>
               )}
 
-              {websiteUrl && (
+              {websiteUrl && websiteUrl.startsWith("https://") && (
                 <div>
                   <a
                     href={websiteUrl}
@@ -546,7 +546,7 @@ export function ServerInfoModal({
               </div>
             )}
 
-            {websiteUrl && (
+            {websiteUrl && websiteUrl.startsWith("https://") && (
               <div>
                 <a
                   href={websiteUrl}


### PR DESCRIPTION
A malicious shared server could set websiteUrl to a javascript: URI, causing code execution when a user clicks "Visit documentation" or "Website URL". Only render the link when the URL starts with https://.