### PR TITLE
Fix App Builder to open the last connected server instead of the first one

### DIFF
--- a/mcpjam-inspector/client/src/components/ActiveServerSelector.tsx
+++ b/mcpjam-inspector/client/src/components/ActiveServerSelector.tsx
@@ -125,8 +125,14 @@ export function ActiveServerSelector({
     const serverNames = servers.map(([name]) => name);
     const isCurrentSelectionValid = serverNames.includes(selectedServer);
 
-    if (!isCurrentSelectionValid && serverNames.length > 0) {
-      onServerChange(serverNames[0]);
+    if (!isCurrentSelectionValid && servers.length > 0) {
+      // Pick the most recently connected server instead of the first by insertion order
+      const sorted = [...servers].sort(
+        ([, a], [, b]) =>
+          new Date(b.lastConnectionTime).getTime() -
+          new Date(a.lastConnectionTime).getTime(),
+      );
+      onServerChange(sorted[0][0]);
     }
   }, [servers.length, selectedServer, isMultiSelectEnabled, onServerChange]);
 

--- a/mcpjam-inspector/client/src/components/__tests__/ActiveServerSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ActiveServerSelector.test.tsx
@@ -82,6 +82,7 @@ describe("ActiveServerSelector", () => {
       enabled: true,
       retryCount: 0,
       useOAuth: false,
+      lastConnectionTime: new Date("2024-01-01"),
       config: {
         transportType: "stdio",
         command: "node",
@@ -476,11 +477,21 @@ describe("ActiveServerSelector", () => {
   });
 
   describe("auto-selection", () => {
-    it("auto-selects first server when current selection is invalid", async () => {
+    it("auto-selects most recently connected server when current selection is invalid", async () => {
       const onServerChange = vi.fn();
       const serverConfigs = {
-        "server-1": createServer({ name: "server-1" }),
-        "server-2": createServer({ name: "server-2" }),
+        "server-1": createServer({
+          name: "server-1",
+          lastConnectionTime: new Date("2024-01-01"),
+        }),
+        "server-2": createServer({
+          name: "server-2",
+          lastConnectionTime: new Date("2024-01-03"),
+        }),
+        "server-3": createServer({
+          name: "server-3",
+          lastConnectionTime: new Date("2024-01-02"),
+        }),
       };
 
       render(
@@ -493,7 +504,7 @@ describe("ActiveServerSelector", () => {
       );
 
       await waitFor(() => {
-        expect(onServerChange).toHaveBeenCalledWith("server-1");
+        expect(onServerChange).toHaveBeenCalledWith("server-2");
       });
     });
 


### PR DESCRIPTION
When connecting multiple servers from the Servers tab, the App Builder (and other tabs) would always default to the first server added, not the last one connected.

This happened because connecting from the Servers tab uses handleReconnect, which never updates selectedServer (it stays at "none"). When navigating to App Builder, the auto-select fallback just picked the first server by insertion order.

Now the fallback sorts by lastConnectionTime and picks the most recently connected server instead.

