### PR TITLE
Hosted: App builder was showing stale servers (not connected servers)

### DIFF
--- a/mcpjam-inspector/client/src/components/ActiveServerSelector.tsx
+++ b/mcpjam-inspector/client/src/components/ActiveServerSelector.tsx
@@ -133,6 +133,9 @@ export function ActiveServerSelector({
           new Date(a.lastConnectionTime).getTime(),
       );
       onServerChange(sorted[0][0]);
+    } else if (!isCurrentSelectionValid && selectedServer !== "none") {
+      // No available servers and selection is stale — clear it
+      onServerChange("none");
     }
   }, [servers.length, selectedServer, isMultiSelectEnabled, onServerChange]);
 


### PR DESCRIPTION
in hosted mode, selectedServer was persisting in localStorage through app loads. this introduced a bug where selectedServer was being opened in app builder.
Fix:
check selectedServer against real servers connected (isCurrentSelectionValid)

Before:

https://github.com/user-attachments/assets/ece9f8a9-b078-4b3d-84d2-59b9d8cd96c8

After:


https://github.com/user-attachments/assets/559b3604-3b4d-4d9e-b081-56fb73cae6ba

