### PR TITLE
Add loading states for tools tab and app builder tab

### DIFF
--- a/mcpjam-inspector/client/src/components/ToolsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ToolsTab.tsx
@@ -280,6 +280,7 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
     }
 
     setError("");
+    setFetchingTools(true);
     if (reset) {
       setSelectedTool("");
       setFormFields([]);
@@ -288,8 +289,6 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
       setResponseDurationMs(null);
       setTools({});
       setCursor(undefined);
-    } else {
-      setFetchingTools(true);
     }
 
     try {

--- a/mcpjam-inspector/client/src/components/ui-playground/AppBuilderTab.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/AppBuilderTab.tsx
@@ -107,6 +107,9 @@ export function AppBuilderTab({
     });
   }, []);
 
+  // Loading state for tool fetching
+  const [fetchingTools, setFetchingTools] = useState(false);
+
   // Tools metadata used for deterministic injection and invocation messaging
   const [toolsMetadata, setToolsMetadata] = useState<
     Record<string, Record<string, unknown>>
@@ -141,6 +144,7 @@ export function AppBuilderTab({
 
     reset();
     setToolsMetadata({});
+    setFetchingTools(true);
     try {
       const data = await listTools({ serverId: serverName });
       const toolArray = data.tools ?? [];
@@ -154,6 +158,8 @@ export function AppBuilderTab({
       setExecutionError(
         err instanceof Error ? err.message : "Failed to fetch tools",
       );
+    } finally {
+      setFetchingTools(false);
     }
   }, [serverName, reset, setTools, setExecutionError]);
 
@@ -237,7 +243,7 @@ export function AppBuilderTab({
               <PlaygroundLeft
                 tools={tools}
                 selectedToolName={selectedTool}
-                fetchingTools={false}
+                fetchingTools={fetchingTools}
                 onRefresh={fetchTools}
                 onSelectTool={setSelectedTool}
                 formFields={formFields}


### PR DESCRIPTION
Tools tab: fetchTools has two modes — initial load and loading more
tools as you scroll. The loading spinner was only shown when loading
more tools, not on the initial load. Moved the spinner trigger so it
fires in both cases.

App Builder tab: the loading state was hardcoded to never show. Added
actual state tracking so the spinner appears while tools are being
fetched, matching the pattern used by Resources and Prompts tabs.

Closes #1534
Before:

https://github.com/user-attachments/assets/e3b7e04b-fd71-492d-a64a-8d261c4fb5a3

After:

https://github.com/user-attachments/assets/b8b5f9b8-81c7-4729-8b51-8ed3c1420b7c

