### PR TITLE
view server info was not clickable and allowed dragging servers in the background

### DIFF
--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -72,14 +72,17 @@ function saveServerOrder(workspaceId: string, orderedNames: string[]): void {
 
 function SortableServerCard({
   id,
+  dndDisabled,
   server,
   onDisconnect,
   onReconnect,
   onEdit,
   onRemove,
+  onServerInfoModalOpenChange,
   hostedServerId,
 }: {
   id: string;
+  dndDisabled: boolean;
   server: ServerWithName;
   onDisconnect: (name: string) => void;
   onReconnect: (
@@ -88,6 +91,7 @@ function SortableServerCard({
   ) => Promise<void>;
   onEdit: (server: ServerWithName) => void;
   onRemove: (name: string) => void;
+  onServerInfoModalOpenChange: (isOpen: boolean) => void;
   hostedServerId?: string;
 }) {
   const {
@@ -97,7 +101,7 @@ function SortableServerCard({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id });
+  } = useSortable({ id, disabled: dndDisabled });
 
   const style = {
     transform: CSS.Translate.toString(transform),
@@ -113,6 +117,7 @@ function SortableServerCard({
         onReconnect={onReconnect}
         onEdit={onEdit}
         onRemove={onRemove}
+        onServerInfoModalOpenChange={onServerInfoModalOpenChange}
         hostedServerId={hostedServerId}
       />
     </div>
@@ -172,6 +177,7 @@ export function ServersTab({
   const [serverToEdit, setServerToEdit] = useState<ServerWithName | null>(null);
   const [isActionMenuOpen, setIsActionMenuOpen] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [isServerInfoModalOpen, setIsServerInfoModalOpen] = useState(false);
 
   // --- Self-contained local ordering (localStorage only, never synced to Convex) ---
   const allNames = useMemo(
@@ -394,11 +400,13 @@ export function ServersTab({
                     <SortableServerCard
                       key={name}
                       id={name}
+                      dndDisabled={isServerInfoModalOpen}
                       server={server}
                       onDisconnect={onDisconnect}
                       onReconnect={onReconnect}
                       onEdit={handleEditServer}
                       onRemove={onRemove}
+                      onServerInfoModalOpenChange={setIsServerInfoModalOpen}
                       hostedServerId={sharedWorkspaceServersRecord[name]?._id}
                     />
                   );

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -76,6 +76,7 @@ interface ServerConnectionCardProps {
   ) => Promise<void>;
   onEdit: (server: ServerWithName) => void;
   onRemove?: (serverName: string) => void;
+  onServerInfoModalOpenChange?: (isOpen: boolean) => void;
   serverTunnelUrl?: string | null;
   hostedServerId?: string;
 }
@@ -86,6 +87,7 @@ export function ServerConnectionCard({
   onReconnect,
   onEdit,
   onRemove,
+  onServerInfoModalOpenChange,
   serverTunnelUrl,
   hostedServerId,
 }: ServerConnectionCardProps) {
@@ -543,6 +545,7 @@ export function ServerConnectionCard({
                       server_id: server.name,
                     });
                     setIsInfoModalOpen(true);
+                    onServerInfoModalOpenChange?.(true);
                   }}
                   className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-muted/30 px-2 py-0.5 text-[11px] text-foreground transition-colors hover:bg-accent/60 cursor-pointer"
                 >
@@ -668,7 +671,10 @@ export function ServerConnectionCard({
       </Card>
       <ServerInfoModal
         isOpen={isInfoModalOpen}
-        onClose={() => setIsInfoModalOpen(false)}
+        onClose={() => {
+          setIsInfoModalOpen(false);
+          onServerInfoModalOpenChange?.(false);
+        }}
         server={server}
         toolsData={toolsData}
       />

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -330,6 +330,30 @@ describe("ServerConnectionCard", () => {
 
       expect(screen.getByText("View server info")).toBeInTheDocument();
     });
+
+    it("notifies parent when server info modal opens and closes", () => {
+      const onServerInfoModalOpenChange = vi.fn();
+      const server = createServer({
+        initializationInfo: {
+          serverCapabilities: { tools: {} },
+          protocolVersion: "2024-11-05",
+        },
+      });
+
+      render(
+        <ServerConnectionCard
+          server={server}
+          {...defaultProps}
+          onServerInfoModalOpenChange={onServerInfoModalOpenChange}
+        />,
+      );
+
+      fireEvent.click(screen.getByText("View server info"));
+      expect(onServerInfoModalOpenChange).toHaveBeenCalledWith(true);
+
+      fireEvent.click(screen.getByRole("button", { name: "Close" }));
+      expect(onServerInfoModalOpenChange).toHaveBeenCalledWith(false);
+    });
   });
 
   describe("tunnel URL", () => {


### PR DESCRIPTION
changes ServerConnectionCard.tsx to notify ServersTab.tsx when view server info modal is up so ServersTab.tsx disables drag (this also allows server connection card to be clickable and selectable). Added a test for the notification callback in ServerConnectionCard.

https://github.com/user-attachments/assets/1a4e5511-0c28-4836-b437-6c8c8b348022

