### PR TITLE
Revert removal of structural output switch for tools

### DIFF
--- a/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
@@ -1,9 +1,32 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { useMemo, useState } from "react";
 import { CheckCircle, Info, ExternalLink, Clock3 } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
 import { detectUIType, UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import { JsonEditor } from "@/components/ui/json-editor";
+
+const OUTPUT_MODE_STORAGE_KEY = "mcpjam.tools.results.outputMode";
+
+function getStoredOutputMode(): "structured" | "raw" | null {
+  try {
+    const stored = sessionStorage.getItem(OUTPUT_MODE_STORAGE_KEY);
+    if (stored === "structured" || stored === "raw") {
+      return stored;
+    }
+  } catch {
+    // Ignore storage access failures (private mode, security settings)
+  }
+  return null;
+}
+
+function setStoredOutputMode(mode: "structured" | "raw") {
+  try {
+    sessionStorage.setItem(OUTPUT_MODE_STORAGE_KEY, mode);
+  } catch {
+    // Ignore storage access failures
+  }
+}
 
 interface ResultsPanelProps {
   error: string;
@@ -21,6 +44,26 @@ export function ResultsPanel({
   responseDurationMs,
 }: ResultsPanelProps) {
   const rawResult = result as unknown as Record<string, unknown> | null;
+  const hasStructuredContent =
+    !!rawResult &&
+    typeof rawResult === "object" &&
+    rawResult !== null &&
+    "structuredContent" in rawResult;
+  const [preferredOutputMode, setPreferredOutputMode] = useState<
+    "structured" | "raw"
+  >(getStoredOutputMode() ?? "structured");
+  const outputMode: "structured" | "raw" = hasStructuredContent
+    ? preferredOutputMode
+    : "raw";
+
+  const displayedResult = useMemo(() => {
+    if (!rawResult) return null;
+    if (outputMode === "structured" && hasStructuredContent) {
+      return (rawResult as Record<string, unknown>).structuredContent;
+    }
+    return rawResult;
+  }, [rawResult, outputMode, hasStructuredContent]);
+
   const uiType = detectUIType(toolMeta, rawResult);
   const hasOpenAIComponent = uiType === UIType.OPENAI_SDK;
   const hasMCPAppsComponent = uiType === UIType.MCP_APPS;
@@ -38,6 +81,42 @@ export function ResultsPanel({
       <div className="flex-shrink-0 flex items-center justify-between p-4 border-b border-border">
         <div className="flex items-center gap-4">
           <h2 className="text-xs font-semibold text-foreground">Response</h2>
+          {hasStructuredContent && (
+            <div
+              className="inline-flex items-center rounded-md border border-border bg-muted/50 p-0.5"
+              role="group"
+              aria-label="Output mode"
+            >
+              <button
+                type="button"
+                className={`px-2 py-1 text-[11px] font-medium rounded-sm transition-colors cursor-pointer ${
+                  outputMode === "structured"
+                    ? "bg-background text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+                onClick={() => {
+                  setPreferredOutputMode("structured");
+                  setStoredOutputMode("structured");
+                }}
+              >
+                Structured
+              </button>
+              <button
+                type="button"
+                className={`px-2 py-1 text-[11px] font-medium rounded-sm transition-colors cursor-pointer ${
+                  outputMode === "raw"
+                    ? "bg-background text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+                onClick={() => {
+                  setPreferredOutputMode("raw");
+                  setStoredOutputMode("raw");
+                }}
+              >
+                Raw
+              </button>
+            </div>
+          )}
           {structuredContentValid && (
             <Badge
               variant="default"
@@ -63,7 +142,7 @@ export function ResultsPanel({
             {error}
           </div>
         </div>
-      ) : rawResult ? (
+      ) : displayedResult !== null ? (
         <div className="flex-1 min-h-0 p-4 flex flex-col gap-4">
           {hasUIComponent && (
             <div className="flex-shrink-0 p-2 bg-muted/50 border border-border rounded flex items-center justify-between gap-2">
@@ -93,7 +172,7 @@ export function ResultsPanel({
           {/* JSON Editor - fills ALL remaining space */}
           <div className="flex-1 min-h-0 overflow-hidden">
             <JsonEditor
-              value={rawResult}
+              value={displayedResult}
               readOnly
               showToolbar={false}
               height="100%"

--- a/mcpjam-inspector/client/src/components/tools/__tests__/ResultsPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/tools/__tests__/ResultsPanel.test.tsx
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ResultsPanel } from "../ResultsPanel";
+
+vi.mock("@/components/ui/json-editor", () => ({
+  JsonEditor: ({ value }: { value: unknown }) => (
+    <pre data-testid="json-editor">{JSON.stringify(value)}</pre>
+  ),
+}));
+
+const withStructured = {
+  content: [{ type: "text", text: "raw text" }],
+  structuredContent: { greeting: "hello" },
+} as any;
+
+const withStructured2 = {
+  content: [{ type: "text", text: "raw text 2" }],
+  structuredContent: { greeting: "hello-2" },
+} as any;
+
+const rawOnly = { content: [{ type: "text", text: "only raw" }] } as any;
+
+describe("ResultsPanel", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("defaults to structured output when structuredContent exists", () => {
+    render(
+      <ResultsPanel
+        error=""
+        result={withStructured}
+        structuredContentValid={undefined}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Structured" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Raw" })).toBeInTheDocument();
+    expect(screen.getByTestId("json-editor")).toHaveTextContent(
+      JSON.stringify({ greeting: "hello" }),
+    );
+  });
+
+  it("switches to raw output when raw mode is selected", () => {
+    render(
+      <ResultsPanel
+        error=""
+        result={withStructured}
+        structuredContentValid={undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw" }));
+
+    expect(screen.getByTestId("json-editor")).toHaveTextContent(
+      JSON.stringify(withStructured),
+    );
+  });
+
+  it("keeps raw mode selected across result updates when structuredContent exists", () => {
+    const { rerender } = render(
+      <ResultsPanel
+        error=""
+        result={withStructured}
+        structuredContentValid={undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw" }));
+
+    rerender(
+      <ResultsPanel
+        error=""
+        result={withStructured2}
+        structuredContentValid={undefined}
+      />,
+    );
+
+    expect(screen.getByTestId("json-editor")).toHaveTextContent(
+      JSON.stringify(withStructured2),
+    );
+  });
+
+  it("falls back to raw mode if structuredContent becomes unavailable", () => {
+    const { rerender } = render(
+      <ResultsPanel
+        error=""
+        result={withStructured}
+        structuredContentValid={undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Structured" }));
+
+    rerender(
+      <ResultsPanel
+        error=""
+        result={rawOnly}
+        structuredContentValid={undefined}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Structured" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("json-editor")).toHaveTextContent(
+      JSON.stringify(rawOnly),
+    );
+  });
+
+  it("restores structured output when structuredContent returns after a raw-only result", () => {
+    const { rerender } = render(
+      <ResultsPanel
+        error=""
+        result={withStructured}
+        structuredContentValid={undefined}
+      />,
+    );
+
+    rerender(
+      <ResultsPanel
+        error=""
+        result={rawOnly}
+        structuredContentValid={undefined}
+      />,
+    );
+
+    rerender(
+      <ResultsPanel
+        error=""
+        result={withStructured2}
+        structuredContentValid={undefined}
+      />,
+    );
+
+    expect(screen.getByTestId("json-editor")).toHaveTextContent(
+      JSON.stringify({ greeting: "hello-2" }),
+    );
+  });
+
+  it("restores raw output when structuredContent returns if user previously selected raw", () => {
+    const { rerender } = render(
+      <ResultsPanel
+        error=""
+        result={withStructured}
+        structuredContentValid={undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw" }));
+
+    rerender(
+      <ResultsPanel
+        error=""
+        result={rawOnly}
+        structuredContentValid={undefined}
+      />,
+    );
+
+    rerender(
+      <ResultsPanel
+        error=""
+        result={withStructured2}
+        structuredContentValid={undefined}
+      />,
+    );
+
+    expect(screen.getByTestId("json-editor")).toHaveTextContent(
+      JSON.stringify(withStructured2),
+    );
+  });
+
+  it("keeps user-selected mode after unmount/remount (close and reopen tool)", () => {
+    const { unmount } = render(
+      <ResultsPanel
+        error=""
+        result={withStructured}
+        structuredContentValid={undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw" }));
+    expect(screen.getByTestId("json-editor")).toHaveTextContent(
+      JSON.stringify(withStructured),
+    );
+
+    unmount();
+
+    render(
+      <ResultsPanel
+        error=""
+        result={withStructured2}
+        structuredContentValid={undefined}
+      />,
+    );
+
+    expect(screen.getByTestId("json-editor")).toHaveTextContent(
+      JSON.stringify(withStructured2),
+    );
+  });
+
+  it("does not render output mode toggle when structuredContent is absent", () => {
+    render(
+      <ResultsPanel
+        error=""
+        result={rawOnly}
+        structuredContentValid={undefined}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Structured" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("json-editor")).toHaveTextContent(
+      JSON.stringify(rawOnly),
+    );
+  });
+});


### PR DESCRIPTION
Preserves preference between requests

This partially re-adds the structured output removed from #1344 

The idea of the removal was hey just use app builder instead, but its not really the same (at least for my use cases).

App builder can show structured output but it shows it in a compact form without syntax highlighting, you can expand each call to see it but that gets repetitive.  There isn't a whole lot of code here to add it back in.

It also persists output mode for the user (so structured/vs not) 