### PR TITLE
point .env.local at prod Convex deployment instead of dev

### DIFF
--- a/mcpjam-inspector/.env.local
+++ b/mcpjam-inspector/.env.local
@@ -1,7 +1,7 @@
-VITE_CONVEX_URL=https://exuberant-albatross-496.convex.cloud
-CONVEX_URL=https://exuberant-albatross-496.convex.cloud
+VITE_CONVEX_URL=https://outstanding-fennec-304.convex.cloud
+CONVEX_URL=https://outstanding-fennec-304.convex.cloud
 VITE_WORKOS_CLIENT_ID=client_01K4C1TVA6CMQ3G32F1P301A9G
 VITE_WORKOS_REDIRECT_URI=mcpjam://oauth/callback
-CONVEX_HTTP_URL=https://exuberant-albatross-496.convex.site
+CONVEX_HTTP_URL=https://outstanding-fennec-304.convex.site
 ENVIRONMENT=local
 VITE_DISABLE_POSTHOG_LOCAL=true


### PR DESCRIPTION
this is so local inspector users aren't affected by backend dev changes.