### PR TITLE
fix(electron): externalize Node built-ins and fix sandbox proxy paths

### DIFF
--- a/mcpjam-inspector/vite.main.config.ts
+++ b/mcpjam-inspector/vite.main.config.ts
@@ -1,16 +1,17 @@
 import { defineConfig, Plugin } from "vite";
 import { resolve } from "path";
 import { copyFileSync, mkdirSync } from "fs";
+import { builtinModules } from "module";
 
 // Plugin to copy sandbox proxy HTML files to the Electron main build output
 function copySandboxProxy(): Plugin {
   const filesToCopy = [
     {
-      src: "server/routes/mcp/sandbox-proxy.html",
+      src: "server/routes/apps/mcp-apps/sandbox-proxy.html",
       dest: "sandbox-proxy.html",
     },
     {
-      src: "server/routes/apps/chatgpt-sandbox-proxy.html",
+      src: "server/routes/apps/chatgpt-apps/sandbox-proxy.html",
       dest: "chatgpt-sandbox-proxy.html",
     },
   ];
@@ -44,11 +45,10 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
-        // Core Electron & Node modules only
         "electron",
-        // Native modules that can't be bundled
         "@ngrok/ngrok",
-        // Bundle everything else including electron-log, update-electron-app, etc.
+        ...builtinModules,
+        ...builtinModules.map((m) => `node:${m}`),
       ],
       output: {
         inlineDynamicImports: true,


### PR DESCRIPTION
Stuck here

<img width="519" height="257" alt="Screenshot 2026-03-06 at 10 27 58 PM" src="https://github.com/user-attachments/assets/c8023e14-1161-493a-9daa-f2dc19047588" />

Vite was trying to bundle Node.js built-ins (perf_hooks, fs, path, etc.)
into the Electron main process output, treating them as regular npm packages.
This fails because Vite uses a browser-like bundling context and doesn't know
how to handle them. 

Fix: add all Node built-ins to the bundler's external list so they're left alone.
Electron already has Node available at runtime.

The copySandboxProxy plugin was also copying HTML files from paths that no
longer exist. The files were moved during a refactor but the config was not
updated:

  server/routes/mcp/sandbox-proxy.html          → server/routes/apps/mcp-apps/sandbox-proxy.html
  server/routes/apps/chatgpt-sandbox-proxy.html → server/routes/apps/chatgpt-apps/sandbox-proxy.html

This caused electron-forge to silently hang on the main process build step.