### PR TITLE
feat(registry): add Registry tab with server-side OAuth credential protection

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -19,6 +19,7 @@ import { AppBuilderTab } from "./components/ui-playground/AppBuilderTab";
 import { ProfileTab } from "./components/ProfileTab";
 import { OrganizationsTab } from "./components/OrganizationsTab";
 import { SupportTab } from "./components/SupportTab";
+import { RegistryTab } from "./components/RegistryTab";
 import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
 import { MCPSidebar } from "./components/mcp-sidebar";
 import { SidebarInset, SidebarProvider } from "./components/ui/sidebar";
@@ -498,6 +499,13 @@ export default function App() {
               isLoadingWorkspaces={isLoadingRemoteWorkspaces}
               onWorkspaceShared={handleWorkspaceShared}
               onLeaveWorkspace={() => handleLeaveWorkspace(activeWorkspaceId)}
+            />
+          )}
+          {activeTab === "registry" && (
+            <RegistryTab
+              onConnect={handleConnect}
+              onDisconnect={handleDisconnect}
+              servers={appState.servers}
             />
           )}
           {activeTab === "tools" && (

--- a/mcpjam-inspector/client/src/components/RegistryTab.tsx
+++ b/mcpjam-inspector/client/src/components/RegistryTab.tsx
@@ -1,0 +1,204 @@
+import { useQuery } from "convex/react";
+import { Package, Loader2, CheckCircle2, Unplug } from "lucide-react";
+import { Card } from "./ui/card";
+import { Skeleton } from "./ui/skeleton";
+import { EmptyState } from "./ui/empty-state";
+import type { ServerFormData } from "@/shared/types";
+import type { ServerWithName } from "@/state/app-types";
+import { useState } from "react";
+
+interface RegistryServer {
+  _id: string;
+  slug: string;
+  name: string;
+  description: string;
+  iconUrl: string;
+  url: string;
+  useOAuth: boolean;
+  oauthScopes?: string[];
+  clientId?: string;
+  sortOrder: number;
+}
+
+interface RegistryTabProps {
+  onConnect: (formData: ServerFormData) => void;
+  onDisconnect?: (serverName: string) => void;
+  servers?: Record<string, ServerWithName>;
+}
+
+function RegistryServerCard({
+  server,
+  onConnect,
+  onDisconnect,
+  connectionStatus,
+}: {
+  server: RegistryServer;
+  onConnect: (formData: ServerFormData) => void;
+  onDisconnect?: (serverName: string) => void;
+  connectionStatus?: string;
+}) {
+  const [isConnecting, setIsConnecting] = useState(false);
+  const isConnected = connectionStatus === "connected";
+  const isInProgress =
+    connectionStatus === "connecting" || connectionStatus === "oauth-flow";
+
+  const handleConnect = () => {
+    setIsConnecting(true);
+    const formData: ServerFormData = {
+      name: server.name,
+      type: "http",
+      url: server.url,
+      useOAuth: server.useOAuth,
+      oauthScopes: server.oauthScopes,
+      clientId: server.clientId,
+      registryManaged: true,
+      registrySlug: server.slug,
+    };
+    onConnect(formData);
+    setTimeout(() => setIsConnecting(false), 2000);
+  };
+
+  const handleDisconnect = () => {
+    onDisconnect?.(server.name);
+  };
+
+  return (
+    <Card className="group h-full rounded-xl border border-border/50 bg-card/60 p-0 shadow-sm transition-all duration-200 hover:border-border hover:shadow-md">
+      <div className="p-4">
+        <div className="flex items-start gap-3">
+          <div className="flex-shrink-0">
+            <img
+              src={server.iconUrl}
+              alt={`${server.name} icon`}
+              className="h-8 w-8 rounded"
+              onError={(e) => {
+                e.currentTarget.style.display = "none";
+              }}
+            />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <h3 className="truncate text-sm font-semibold text-foreground">
+                {server.name}
+              </h3>
+              {isConnected && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+                  <CheckCircle2 className="h-3 w-3" />
+                  Connected
+                </span>
+              )}
+            </div>
+            <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2">
+              {server.description}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-3 rounded-md border border-border/50 bg-muted/30 p-2 font-mono text-xs text-muted-foreground">
+          <div className="truncate">{server.url}</div>
+        </div>
+
+        <div className="mt-3 flex items-center justify-end gap-2">
+          {isConnected ? (
+            <button
+              onClick={handleDisconnect}
+              className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-muted/30 px-3 py-1 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10 cursor-pointer"
+            >
+              <Unplug className="h-3 w-3" />
+              <span>Disconnect</span>
+            </button>
+          ) : (
+            <button
+              onClick={handleConnect}
+              disabled={isConnecting || isInProgress}
+              className="inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-muted/30 px-3 py-1 text-xs font-medium text-foreground transition-colors hover:bg-accent/60 disabled:cursor-not-allowed disabled:opacity-60 cursor-pointer"
+            >
+              {isConnecting || isInProgress ? (
+                <>
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  <span>Connecting...</span>
+                </>
+              ) : (
+                <span>Connect</span>
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="h-full w-full overflow-auto">
+      <div className="space-y-6 p-8">
+        <div>
+          <Skeleton className="h-6 w-40 mb-2" />
+          <Skeleton className="h-4 w-72" />
+        </div>
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-36 rounded-xl" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function RegistryTab({
+  onConnect,
+  onDisconnect,
+  servers,
+}: RegistryTabProps) {
+  const registryServers = useQuery(
+    "registryServers:listEnabled" as any,
+    {} as any,
+  ) as RegistryServer[] | undefined;
+
+  const isLoading = registryServers === undefined;
+
+  if (isLoading) {
+    return <LoadingSkeleton />;
+  }
+
+  if (!registryServers || registryServers.length === 0) {
+    return (
+      <EmptyState
+        icon={Package}
+        title="No Registry Servers"
+        description="No servers are available in the registry at this time."
+      />
+    );
+  }
+
+  return (
+    <div className="h-full w-full overflow-auto">
+      <div className="space-y-6 p-8">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground">
+            Server Registry
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Connect to popular MCP servers with one click.
+          </p>
+        </div>
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+          {registryServers.map((server) => {
+            const serverState = servers?.[server.name];
+            return (
+              <RegistryServerCard
+                key={server._id}
+                server={server}
+                onConnect={onConnect}
+                onDisconnect={onDisconnect}
+                connectionStatus={serverState?.connectionStatus}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   ListTodo,
   SquareSlash,
   MessageCircleQuestionIcon,
+  Package,
 } from "lucide-react";
 import { usePostHog } from "posthog-js/react";
 
@@ -53,6 +54,11 @@ const navigationSections = [
         title: "Servers",
         url: "#servers",
         icon: MCPIcon,
+      },
+      {
+        title: "Registry",
+        url: "#registry",
+        icon: Package,
       },
       {
         title: "Chat",

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -25,6 +25,7 @@ import {
   getStoredTokens,
   clearOAuthData,
   initiateOAuth,
+  type MCPOAuthOptions,
 } from "@/lib/oauth/mcp-oauth";
 import { HOSTED_MODE } from "@/lib/config";
 import { injectHostedServerMapping } from "@/lib/apis/web/context";
@@ -552,43 +553,49 @@ export function useServerState({
         retryCount: 0,
         enabled: true,
         useOAuth: formData.useOAuth ?? false,
+        registryManaged: formData.registryManaged,
+        registrySlug: formData.registrySlug,
       };
-      if (HOSTED_MODE) {
-        try {
-          const serverId = await syncServerToConvex(
-            formData.name,
-            serverEntryForSave,
-          );
-          if (serverId) {
-            injectHostedServerMapping(formData.name, serverId);
+
+      // Skip Convex workspace sync and workspace state for registry-managed servers
+      if (!formData.registryManaged) {
+        if (HOSTED_MODE) {
+          try {
+            const serverId = await syncServerToConvex(
+              formData.name,
+              serverEntryForSave,
+            );
+            if (serverId) {
+              injectHostedServerMapping(formData.name, serverId);
+            }
+          } catch (err) {
+            logger.warn("Sync to Convex failed (pre-connection)", {
+              serverName: formData.name,
+              err,
+            });
           }
-        } catch (err) {
-          logger.warn("Sync to Convex failed (pre-connection)", {
-            serverName: formData.name,
-            err,
-          });
+        } else {
+          syncServerToConvex(formData.name, serverEntryForSave).catch((err) =>
+            logger.warn("Background sync to Convex failed (pre-connection)", {
+              serverName: formData.name,
+              err,
+            }),
+          );
         }
-      } else {
-        syncServerToConvex(formData.name, serverEntryForSave).catch((err) =>
-          logger.warn("Background sync to Convex failed (pre-connection)", {
-            serverName: formData.name,
-            err,
-          }),
-        );
-      }
-      if (!isAuthenticated) {
-        const workspace = appState.workspaces[appState.activeWorkspaceId];
-        if (workspace) {
-          dispatch({
-            type: "UPDATE_WORKSPACE",
-            workspaceId: appState.activeWorkspaceId,
-            updates: {
-              servers: {
-                ...workspace.servers,
-                [formData.name]: serverEntryForSave,
+        if (!isAuthenticated) {
+          const workspace = appState.workspaces[appState.activeWorkspaceId];
+          if (workspace) {
+            dispatch({
+              type: "UPDATE_WORKSPACE",
+              workspaceId: appState.activeWorkspaceId,
+              updates: {
+                servers: {
+                  ...workspace.servers,
+                  [formData.name]: serverEntryForSave,
+                },
               },
-            },
-          });
+            });
+          }
         }
       }
 
@@ -654,15 +661,17 @@ export function useServerState({
             } as ServerWithName,
           });
 
-          const oauthOptions: any = {
+          const oauthOptions: MCPOAuthOptions = {
             serverName: formData.name,
             serverUrl: formData.url,
             clientId: formData.clientId,
-            clientSecret: formData.clientSecret,
+            // For registry servers, clientSecret is injected server-side
+            clientSecret: formData.registryManaged
+              ? undefined
+              : formData.clientSecret,
+            registrySlug: formData.registrySlug,
+            scopes: formData.oauthScopes,
           };
-          if (formData.oauthScopes && formData.oauthScopes.length > 0) {
-            oauthOptions.scopes = formData.oauthScopes;
-          }
           const oauthResult = await initiateOAuth(oauthOptions);
           if (oauthResult.success) {
             if (oauthResult.serverConfig) {

--- a/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
@@ -1,10 +1,10 @@
 const HASH_TAB_ALIASES = {
-  registry: "servers",
   chat: "chat-v2",
 } as const;
 
 export const HOSTED_SIDEBAR_ALLOWED_TABS = [
   "servers",
+  "registry",
   "chat-v2",
   "app-builder",
   "views",

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -17,7 +17,7 @@ const originalFetch = window.fetch;
 /**
  * Custom fetch interceptor that proxies OAuth requests through our server to avoid CORS
  */
-function createOAuthFetchInterceptor(): typeof fetch {
+function createOAuthFetchInterceptor(registrySlug?: string): typeof fetch {
   return async function interceptedFetch(
     input: RequestInfo | URL,
     init?: RequestInit,
@@ -32,7 +32,7 @@ function createOAuthFetchInterceptor(): typeof fetch {
     // Check if this is an OAuth-related request that needs CORS bypass
     const isOAuthRequest =
       url.includes("/.well-known/") ||
-      url.match(/\/(register|token|authorize)$/);
+      url.match(/\/(register|access_token|token|authorize)(?:[?#]|$)/);
 
     if (!isOAuthRequest) {
       return await originalFetch(input, init);
@@ -62,6 +62,7 @@ function createOAuthFetchInterceptor(): typeof fetch {
             ? Object.fromEntries(new Headers(init.headers as HeadersInit))
             : {},
           body,
+          ...(registrySlug && { registrySlug }),
         }),
       });
 
@@ -101,6 +102,7 @@ export interface MCPOAuthOptions {
   scopes?: string[];
   clientId?: string;
   clientSecret?: string;
+  registrySlug?: string;
 }
 
 export interface OAuthResult {
@@ -247,14 +249,15 @@ export async function initiateOAuth(
   options: MCPOAuthOptions,
 ): Promise<OAuthResult> {
   // Install fetch interceptor for OAuth metadata requests
-  const interceptedFetch = createOAuthFetchInterceptor();
+  const interceptedFetch = createOAuthFetchInterceptor(options.registrySlug);
   window.fetch = interceptedFetch;
 
   try {
     const provider = new MCPOAuthProvider(
       options.serverName,
       options.clientId,
-      options.clientSecret,
+      // For registry servers, the Hono server injects clientSecret during token exchange
+      options.registrySlug ? undefined : options.clientSecret,
     );
 
     // Store server URL for callback recovery
@@ -263,6 +266,14 @@ export async function initiateOAuth(
       options.serverUrl,
     );
     localStorage.setItem("mcp-oauth-pending", options.serverName);
+
+    // Store registrySlug for callback recovery (survives full-page redirect)
+    if (options.registrySlug) {
+      localStorage.setItem(
+        `mcp-registry-slug-${options.serverName}`,
+        options.registrySlug,
+      );
+    }
 
     // Store OAuth configuration (scopes) for recovery if connection fails
     const oauthConfig: any = {};
@@ -362,17 +373,21 @@ export async function initiateOAuth(
 export async function handleOAuthCallback(
   authorizationCode: string,
 ): Promise<OAuthResult & { serverName?: string }> {
+  // Get pending server name from localStorage (needed before interceptor setup)
+  const serverName = localStorage.getItem("mcp-oauth-pending");
+  if (!serverName) {
+    throw new Error("No pending OAuth flow found");
+  }
+
+  // Retrieve registrySlug stored before the redirect
+  const registrySlug =
+    localStorage.getItem(`mcp-registry-slug-${serverName}`) || undefined;
+
   // Install fetch interceptor for OAuth metadata requests
-  const interceptedFetch = createOAuthFetchInterceptor();
+  const interceptedFetch = createOAuthFetchInterceptor(registrySlug);
   window.fetch = interceptedFetch;
 
   try {
-    // Get pending server name from localStorage
-    const serverName = localStorage.getItem("mcp-oauth-pending");
-    if (!serverName) {
-      throw new Error("No pending OAuth flow found");
-    }
-
     // Get server URL
     const serverUrl = localStorage.getItem(`mcp-serverUrl-${serverName}`);
     if (!serverUrl) {
@@ -384,9 +399,12 @@ export async function handleOAuthCallback(
     const customClientId = storedClientInfo
       ? JSON.parse(storedClientInfo).client_id
       : undefined;
-    const customClientSecret = storedClientInfo
-      ? JSON.parse(storedClientInfo).client_secret
-      : undefined;
+    // For registry servers, don't use client_secret — Hono injects it server-side
+    const customClientSecret = registrySlug
+      ? undefined
+      : storedClientInfo
+        ? JSON.parse(storedClientInfo).client_secret
+        : undefined;
 
     const provider = new MCPOAuthProvider(
       serverName,
@@ -404,6 +422,7 @@ export async function handleOAuthCallback(
       if (tokens) {
         // Clean up pending state
         localStorage.removeItem("mcp-oauth-pending");
+        localStorage.removeItem(`mcp-registry-slug-${serverName}`);
 
         const serverConfig = createServerConfig(serverUrl, tokens);
         return {
@@ -514,8 +533,12 @@ export async function waitForTokens(
 export async function refreshOAuthTokens(
   serverName: string,
 ): Promise<OAuthResult> {
+  // Retrieve registrySlug if this is a registry-managed server
+  const registrySlug =
+    localStorage.getItem(`mcp-registry-slug-${serverName}`) || undefined;
+
   // Install fetch interceptor for OAuth metadata requests
-  const interceptedFetch = createOAuthFetchInterceptor();
+  const interceptedFetch = createOAuthFetchInterceptor(registrySlug);
   window.fetch = interceptedFetch;
 
   try {
@@ -524,9 +547,12 @@ export async function refreshOAuthTokens(
     const customClientId = storedClientInfo
       ? JSON.parse(storedClientInfo).client_id
       : undefined;
-    const customClientSecret = storedClientInfo
-      ? JSON.parse(storedClientInfo).client_secret
-      : undefined;
+    // For registry servers, don't use client_secret — Hono injects it server-side
+    const customClientSecret = registrySlug
+      ? undefined
+      : storedClientInfo
+        ? JSON.parse(storedClientInfo).client_secret
+        : undefined;
 
     const provider = new MCPOAuthProvider(
       serverName,
@@ -609,6 +635,7 @@ export function clearOAuthData(serverName: string): void {
   localStorage.removeItem(`mcp-verifier-${serverName}`);
   localStorage.removeItem(`mcp-serverUrl-${serverName}`);
   localStorage.removeItem(`mcp-oauth-config-${serverName}`);
+  localStorage.removeItem(`mcp-registry-slug-${serverName}`);
 }
 
 /**

--- a/mcpjam-inspector/client/src/state/app-types.ts
+++ b/mcpjam-inspector/client/src/state/app-types.ts
@@ -41,6 +41,10 @@ export interface ServerWithName {
   enabled?: boolean;
   /** Whether OAuth is explicitly enabled for this server. When false, reconnect skips OAuth flow. */
   useOAuth?: boolean;
+  /** Whether this server is managed by the Registry tab (not shown in Servers tab). */
+  registryManaged?: boolean;
+  /** Registry slug for credential injection during OAuth. */
+  registrySlug?: string;
 }
 
 export interface Workspace {

--- a/mcpjam-inspector/server/routes/mcp/oauth.ts
+++ b/mcpjam-inspector/server/routes/mcp/oauth.ts
@@ -6,6 +6,8 @@ import {
   executeDebugOAuthProxy,
   fetchOAuthMetadata,
   OAuthProxyError,
+  isTokenExchangeUrl,
+  fetchRegistryCredentials,
 } from "../../utils/oauth-proxy.js";
 
 const oauth = new Hono();
@@ -51,8 +53,23 @@ oauth.post("/debug/proxy", async (c) => {
  */
 oauth.post("/proxy", async (c) => {
   try {
-    const { url, method, body, headers } = await c.req.json();
-    const result = await executeOAuthProxy({ url, method, body, headers });
+    const { url, method, body, headers, registrySlug } = await c.req.json();
+
+    // For registry servers, inject clientSecret server-side during token exchange
+    let enrichedBody = body;
+    if (registrySlug && isTokenExchangeUrl(url)) {
+      const creds = await fetchRegistryCredentials(registrySlug);
+      if (creds?.clientSecret) {
+        enrichedBody = { ...body, client_secret: creds.clientSecret };
+      }
+    }
+
+    const result = await executeOAuthProxy({
+      url,
+      method,
+      body: enrichedBody,
+      headers,
+    });
     return c.json(result);
   } catch (error) {
     if (error instanceof OAuthProxyError) {

--- a/mcpjam-inspector/server/utils/oauth-proxy.ts
+++ b/mcpjam-inspector/server/utils/oauth-proxy.ts
@@ -1,4 +1,5 @@
 import type { ContentfulStatusCode } from "hono/utils/http-status";
+import { logger } from "./logger";
 
 export class OAuthProxyError extends Error {
   status: number;
@@ -300,4 +301,48 @@ export async function fetchOAuthMetadata(
 
   const metadata = (await response.json()) as Record<string, unknown>;
   return { metadata };
+}
+
+/**
+ * Check if a URL is a token exchange endpoint (where client_secret needs injection).
+ */
+export function isTokenExchangeUrl(url: string): boolean {
+  return /\/(token|access_token)(?:[?#]|$)/.test(url);
+}
+
+/**
+ * Fetch OAuth credentials for a registry server from Convex.
+ * Server-to-server call protected by a shared secret.
+ */
+export async function fetchRegistryCredentials(
+  slug: string,
+): Promise<{ clientId: string; clientSecret: string } | null> {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  const secret = process.env.REGISTRY_SECRET;
+  if (!convexUrl || !secret) {
+    logger.warn(
+      "[Registry] Missing CONVEX_HTTP_URL or REGISTRY_SECRET for credential fetch",
+    );
+    return null;
+  }
+
+  try {
+    const res = await fetch(
+      `${convexUrl}/registry/credentials?slug=${encodeURIComponent(slug)}`,
+      {
+        headers: { "x-registry-secret": secret },
+      },
+    );
+    if (!res.ok) {
+      logger.warn("[Registry] Credential fetch failed", {
+        slug,
+        status: res.status,
+      });
+      return null;
+    }
+    return (await res.json()) as { clientId: string; clientSecret: string };
+  } catch (err) {
+    logger.error("[Registry] Credential fetch error", { slug, err });
+    return null;
+  }
 }

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -585,6 +585,8 @@ export interface ServerFormData {
   clientId?: string;
   clientSecret?: string;
   requestTimeout?: number;
+  registryManaged?: boolean;
+  registrySlug?: string;
 }
 
 export interface OauthTokens {


### PR DESCRIPTION

<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/8d1d5ef9-9690-4b89-8c6b-8e776c3899fa" />


## Summary
- Adds a curated **Registry tab** in the sidebar for one-click connection to first-party MCP servers (Asana, GitHub, Notion, Linear, Jira)
- Server-side credential injection: OAuth `client_secret` is fetched from Convex and injected during token exchange in the Hono proxy — secrets never reach the browser
- `registryManaged` flag keeps registry servers out of the Servers tab and skips workspace sync
- `registrySlug` is threaded through the OAuth flow (stored in localStorage to survive full-page redirects)

## Changes
### Client
- **RegistryTab.tsx** — New component showing server cards with connect/disconnect, connection status badges
- **mcp-sidebar.tsx** — Added "Registry" entry to sidebar navigation
- **App.tsx** — Wired RegistryTab with `onConnect`, `onDisconnect`, and `servers` props
- **hosted-tab-policy.ts** — Added `registry` to allowed hosted tabs
- **mcp-oauth.ts** — Threaded `registrySlug` through `initiateOAuth`, `handleOAuthCallback`, `refreshOAuthTokens`, and `clearOAuthData`; parameterized fetch interceptor to include slug in proxy requests
- **app-types.ts** — Added `registryManaged` and `registrySlug` to `ServerWithName`
- **types.ts** — Added `registryManaged` and `registrySlug` to `ServerFormData`

### Server
- **oauth.ts** — Proxy route accepts `registrySlug`, injects `client_secret` for registry servers during token exchange
- **oauth-proxy.ts** — Added `isTokenExchangeUrl()` and `fetchRegistryCredentials()` helpers

### Hooks
- **use-server-state.ts** — Skips Convex workspace sync and `UPDATE_WORKSPACE` dispatch for registry-managed servers; typed `oauthOptions` as `MCPOAuthOptions`

## Companion PR
Backend changes (schema, seed, credentials endpoint, icon storage) in `mcpjam-backend` repo.

## Test plan
- [ ] Registry tab loads with 5 server cards (Asana, GitHub, Notion, Linear, Jira)
- [ ] SVG icons render from Convex storage
- [ ] Clicking "Connect" on a registry server initiates OAuth flow
- [ ] Token exchange succeeds (Hono injects `client_secret` server-side)
- [ ] Connected servers show "Connected" badge + "Disconnect" button
- [ ] Registry servers do NOT appear in the Servers tab
- [ ] Disconnecting a registry server returns card to "Connect" state
- [ ] No secrets visible in browser DevTools network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)