### PR TITLE
Oauth proxy requires bearer token, guest session cont.

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/guest-session.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/guest-session.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Guest Session Endpoint Tests
+ *
+ * Tests for POST /api/web/guest-session.
+ * Covers token issuance, response format, and IP-based rate limiting.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { Hono } from "hono";
+import guestSession from "../guest-session.js";
+import { initGuestTokenSecret } from "../../../services/guest-token.js";
+
+function createTestApp(): Hono {
+  const app = new Hono();
+  app.route("/guest-session", guestSession);
+  return app;
+}
+
+describe("POST /guest-session", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    initGuestTokenSecret();
+    app = createTestApp();
+  });
+
+  describe("token issuance", () => {
+    it("returns 200 with guestId, token, and expiresAt", async () => {
+      const res = await app.request("/guest-session", { method: "POST" });
+
+      expect(res.status).toBe(200);
+
+      const data = await res.json();
+      expect(data.guestId).toBeDefined();
+      expect(typeof data.guestId).toBe("string");
+      expect(data.token).toBeDefined();
+      expect(typeof data.token).toBe("string");
+      expect(data.expiresAt).toBeDefined();
+      expect(typeof data.expiresAt).toBe("number");
+    });
+
+    it("returns a UUID guestId", async () => {
+      const res = await app.request("/guest-session", { method: "POST" });
+      const data = await res.json();
+
+      expect(data.guestId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+    });
+
+    it("returns a two-part token (payload.signature)", async () => {
+      const res = await app.request("/guest-session", { method: "POST" });
+      const data = await res.json();
+
+      const parts = data.token.split(".");
+      expect(parts.length).toBe(2);
+    });
+
+    it("returns expiresAt in the future", async () => {
+      const before = Date.now();
+      const res = await app.request("/guest-session", { method: "POST" });
+      const data = await res.json();
+
+      expect(data.expiresAt).toBeGreaterThan(before);
+    });
+
+    it("returns different tokens on successive requests", async () => {
+      const res1 = await app.request("/guest-session", { method: "POST" });
+      const res2 = await app.request("/guest-session", { method: "POST" });
+
+      const data1 = await res1.json();
+      const data2 = await res2.json();
+
+      expect(data1.guestId).not.toBe(data2.guestId);
+      expect(data1.token).not.toBe(data2.token);
+    });
+  });
+
+  describe("HTTP method handling", () => {
+    it("returns 404 for GET requests", async () => {
+      const res = await app.request("/guest-session");
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 404 for PUT requests", async () => {
+      const res = await app.request("/guest-session", { method: "PUT" });
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 404 for DELETE requests", async () => {
+      const res = await app.request("/guest-session", { method: "DELETE" });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("IP-based rate limiting", () => {
+    it("allows up to 10 requests per IP", async () => {
+      for (let i = 0; i < 10; i++) {
+        const res = await app.request("/guest-session", {
+          method: "POST",
+          headers: { "x-forwarded-for": "10.0.0.1" },
+        });
+        expect(res.status).toBe(200);
+      }
+    });
+
+    it("returns 429 after 10 requests from the same IP", async () => {
+      // Exhaust the rate limit
+      for (let i = 0; i < 10; i++) {
+        await app.request("/guest-session", {
+          method: "POST",
+          headers: { "x-forwarded-for": "10.0.0.2" },
+        });
+      }
+
+      // 11th request should be rate-limited
+      const res = await app.request("/guest-session", {
+        method: "POST",
+        headers: { "x-forwarded-for": "10.0.0.2" },
+      });
+
+      expect(res.status).toBe(429);
+      const data = await res.json();
+      expect(data.code).toBe("RATE_LIMITED");
+      expect(data.message).toBeDefined();
+    });
+
+    it("rate limits are per-IP", async () => {
+      // Exhaust limit for IP1
+      for (let i = 0; i < 10; i++) {
+        await app.request("/guest-session", {
+          method: "POST",
+          headers: { "x-forwarded-for": "10.0.0.3" },
+        });
+      }
+
+      // IP2 should still be allowed
+      const res = await app.request("/guest-session", {
+        method: "POST",
+        headers: { "x-forwarded-for": "10.0.0.4" },
+      });
+      expect(res.status).toBe(200);
+    });
+
+    it("uses first IP from x-forwarded-for when multiple present", async () => {
+      // Exhaust limit for the first IP in the chain
+      for (let i = 0; i < 10; i++) {
+        await app.request("/guest-session", {
+          method: "POST",
+          headers: { "x-forwarded-for": "10.0.0.5, 10.0.0.6, 10.0.0.7" },
+        });
+      }
+
+      // Same first IP should be rate-limited
+      const res = await app.request("/guest-session", {
+        method: "POST",
+        headers: { "x-forwarded-for": "10.0.0.5" },
+      });
+      expect(res.status).toBe(429);
+
+      // Different first IP should be allowed
+      const res2 = await app.request("/guest-session", {
+        method: "POST",
+        headers: { "x-forwarded-for": "10.0.0.6" },
+      });
+      expect(res2.status).toBe(200);
+    });
+
+    it("falls back to x-real-ip when x-forwarded-for is absent", async () => {
+      // Exhaust limit using x-real-ip
+      for (let i = 0; i < 10; i++) {
+        await app.request("/guest-session", {
+          method: "POST",
+          headers: { "x-real-ip": "10.0.0.8" },
+        });
+      }
+
+      const res = await app.request("/guest-session", {
+        method: "POST",
+        headers: { "x-real-ip": "10.0.0.8" },
+      });
+      expect(res.status).toBe(429);
+    });
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/oauth-auth.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/oauth-auth.test.ts
@@ -1,0 +1,220 @@
+/**
+ * OAuth Proxy Token Requirement Tests
+ *
+ * Tests for the bearer token requirement middleware added to OAuth web routes.
+ * Validates that guest tokens, WorkOS tokens, and missing tokens are handled correctly.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { Hono } from "hono";
+import {
+  initGuestTokenSecret,
+  issueGuestToken,
+  validateGuestToken,
+} from "../../../services/guest-token.js";
+import { guestRateLimitMiddleware } from "../../../middleware/guest-rate-limit.js";
+
+/**
+ * Creates a test app that replicates the middleware from oauth.ts
+ * with simple test handlers (avoids importing real oauth-proxy utils).
+ */
+function createTestOAuthApp(): Hono {
+  const app = new Hono();
+
+  // Replicate the token requirement middleware from oauth.ts
+  app.use("*", async (c, next) => {
+    const authHeader = c.req.header("authorization");
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return c.json(
+        { code: "UNAUTHORIZED", message: "Bearer token required" },
+        401,
+      );
+    }
+
+    const token = authHeader.slice("Bearer ".length);
+
+    const result = validateGuestToken(token);
+    if (result.valid && result.guestId) {
+      c.set("guestId", result.guestId);
+      return next();
+    }
+
+    // Not a guest token — assume WorkOS, allow through
+    return next();
+  });
+
+  app.use("*", guestRateLimitMiddleware);
+
+  // Test routes simulating OAuth proxy endpoints
+  app.post("/proxy", (c) =>
+    c.json({ proxied: true, guestId: c.get("guestId") ?? null }),
+  );
+  app.get("/metadata", (c) =>
+    c.json({ metadata: true, guestId: c.get("guestId") ?? null }),
+  );
+
+  return app;
+}
+
+describe("OAuth proxy token middleware", () => {
+  let app: Hono;
+
+  beforeEach(() => {
+    initGuestTokenSecret();
+    app = createTestOAuthApp();
+  });
+
+  describe("no token", () => {
+    it("returns 401 for request without Authorization header", async () => {
+      const res = await app.request("/proxy", { method: "POST" });
+
+      expect(res.status).toBe(401);
+      const data = await res.json();
+      expect(data.code).toBe("UNAUTHORIZED");
+      expect(data.message).toBe("Bearer token required");
+    });
+
+    it("returns 401 for GET request without Authorization header", async () => {
+      const res = await app.request("/metadata");
+
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 401 for non-Bearer auth scheme", async () => {
+      const res = await app.request("/proxy", {
+        method: "POST",
+        headers: { Authorization: "Basic dXNlcjpwYXNz" },
+      });
+
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 401 for Bearer with empty token value", async () => {
+      const res = await app.request("/proxy", {
+        method: "POST",
+        headers: { Authorization: "Bearer " },
+      });
+
+      // Hono trims header value, so "Bearer " becomes "Bearer" which
+      // doesn't start with "Bearer " (note trailing space), returning 401
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("guest token", () => {
+    it("allows request with valid guest token", async () => {
+      const { token } = issueGuestToken();
+
+      const res = await app.request("/proxy", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.proxied).toBe(true);
+    });
+
+    it("sets guestId in context for valid guest token", async () => {
+      const { token, guestId } = issueGuestToken();
+
+      const res = await app.request("/proxy", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.guestId).toBe(guestId);
+    });
+
+    it("rejects expired guest token but allows through as WorkOS", async () => {
+      // Issue token in the past
+      const realDateNow = Date.now;
+      vi.spyOn(Date, "now").mockReturnValue(
+        realDateNow() - 25 * 60 * 60 * 1000,
+      );
+      const { token } = issueGuestToken();
+      vi.spyOn(Date, "now").mockImplementation(realDateNow);
+
+      const res = await app.request("/proxy", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.guestId).toBeNull();
+    });
+
+    it("rejects tampered guest token but allows through as WorkOS", async () => {
+      const { token } = issueGuestToken();
+      const tamperedToken = token + "tampered";
+
+      const res = await app.request("/proxy", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${tamperedToken}` },
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.guestId).toBeNull();
+    });
+  });
+
+  describe("WorkOS token (non-guest)", () => {
+    it("allows request with a non-guest bearer token", async () => {
+      const res = await app.request("/proxy", {
+        method: "POST",
+        headers: { Authorization: "Bearer some-workos-jwt-token" },
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.guestId).toBeNull();
+    });
+
+    it("allows request with JWT-like bearer token", async () => {
+      const fakeJwt =
+        "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.fakesig";
+
+      const res = await app.request("/metadata", {
+        headers: { Authorization: `Bearer ${fakeJwt}` },
+      });
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.guestId).toBeNull();
+    });
+  });
+
+  describe("rate limiting integration", () => {
+    it("rate limits guest users after 60 requests", async () => {
+      const { token } = issueGuestToken();
+
+      for (let i = 0; i < 60; i++) {
+        const res = await app.request("/proxy", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        expect(res.status).toBe(200);
+      }
+
+      const res = await app.request("/proxy", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      expect(res.status).toBe(429);
+    });
+
+    it("does not rate limit WorkOS tokens (no guestId set)", async () => {
+      for (let i = 0; i < 100; i++) {
+        const res = await app.request("/proxy", {
+          method: "POST",
+          headers: { Authorization: "Bearer workos-token" },
+        });
+        expect(res.status).toBe(200);
+      }
+    });
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
@@ -25,6 +25,10 @@ vi.mock("../../../utils/oauth-proxy.js", () => ({
 }));
 
 import { OAuthProxyError } from "../../../utils/oauth-proxy.js";
+import { initGuestTokenSecret } from "../../../services/guest-token.js";
+
+// Guest token secret must be initialized before oauth routes validate tokens
+initGuestTokenSecret();
 
 interface OAuthErrorResponse {
   code: string;
@@ -32,15 +36,42 @@ interface OAuthErrorResponse {
   error: string;
 }
 
-describe("web routes — oauth no-auth required", () => {
-  const { app } = createWebTestApp();
+describe("web routes — oauth requires bearer token", () => {
+  const { app, token } = createWebTestApp();
 
   beforeEach(() => {
     executeOAuthProxyMock.mockReset();
     fetchOAuthMetadataMock.mockReset();
   });
 
-  it("POST /proxy succeeds without bearer token", async () => {
+  it("POST /proxy returns 401 without bearer token", async () => {
+    const response = await postJson(app, "/api/web/oauth/proxy", {
+      url: "https://example.com/token",
+    });
+    const { status, data } = await expectJson(response);
+
+    expect(status).toBe(401);
+    expect(data).toEqual({
+      code: "UNAUTHORIZED",
+      message: "Bearer token required",
+    });
+  });
+
+  it("GET /metadata returns 401 without bearer token", async () => {
+    const response = await getJson(
+      app,
+      "/api/web/oauth/metadata?url=https://example.com/.well-known/oauth",
+    );
+    const { status, data } = await expectJson(response);
+
+    expect(status).toBe(401);
+    expect(data).toEqual({
+      code: "UNAUTHORIZED",
+      message: "Bearer token required",
+    });
+  });
+
+  it("POST /proxy succeeds with bearer token", async () => {
     executeOAuthProxyMock.mockResolvedValueOnce({
       status: 200,
       statusText: "OK",
@@ -48,9 +79,12 @@ describe("web routes — oauth no-auth required", () => {
       body: { ok: true },
     });
 
-    const response = await postJson(app, "/api/web/oauth/proxy", {
-      url: "https://example.com/token",
-    });
+    const response = await postJson(
+      app,
+      "/api/web/oauth/proxy",
+      { url: "https://example.com/token" },
+      token,
+    );
     const { status, data } = await expectJson(response);
 
     expect(status).toBe(200);
@@ -62,7 +96,7 @@ describe("web routes — oauth no-auth required", () => {
     });
   });
 
-  it("GET /metadata succeeds without bearer token", async () => {
+  it("GET /metadata succeeds with bearer token", async () => {
     fetchOAuthMetadataMock.mockResolvedValueOnce({
       metadata: { issuer: "https://example.com" },
     });
@@ -70,6 +104,7 @@ describe("web routes — oauth no-auth required", () => {
     const response = await getJson(
       app,
       "/api/web/oauth/metadata?url=https://example.com/.well-known/oauth",
+      token,
     );
     const { status, data } = await expectJson(response);
 

--- a/mcpjam-inspector/server/routes/web/guest-session.ts
+++ b/mcpjam-inspector/server/routes/web/guest-session.ts
@@ -1,0 +1,67 @@
+import { Hono } from "hono";
+import { issueGuestToken } from "../../services/guest-token.js";
+import { ErrorCode } from "./errors.js";
+
+const guestSession = new Hono();
+
+// IP-based rate limiting: 10 req/min per IP (sliding window)
+const ipWindows = new Map<string, { count: number; windowStart: number }>();
+const IP_RATE_LIMIT = 10;
+const IP_WINDOW_MS = 60_000;
+
+// Cleanup stale entries every 5 minutes
+setInterval(() => {
+  const now = Date.now();
+  for (const [ip, entry] of ipWindows) {
+    if (now - entry.windowStart > IP_WINDOW_MS * 2) {
+      ipWindows.delete(ip);
+    }
+  }
+}, 5 * 60_000).unref();
+
+function getClientIp(c: any): string {
+  return (
+    c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ||
+    c.req.header("x-real-ip") ||
+    "unknown"
+  );
+}
+
+/**
+ * POST /api/web/guest-session
+ *
+ * Issues a new guest bearer token for unauthenticated visitors.
+ * Rate limited to 10 requests per minute per IP.
+ */
+guestSession.post("/", async (c) => {
+  const ip = getClientIp(c);
+  const now = Date.now();
+
+  // Check rate limit
+  const entry = ipWindows.get(ip);
+  if (entry) {
+    if (now - entry.windowStart < IP_WINDOW_MS) {
+      if (entry.count >= IP_RATE_LIMIT) {
+        return c.json(
+          {
+            code: ErrorCode.RATE_LIMITED,
+            message: "Too many guest session requests. Try again later.",
+          },
+          429,
+        );
+      }
+      entry.count++;
+    } else {
+      // Reset window
+      entry.count = 1;
+      entry.windowStart = now;
+    }
+  } else {
+    ipWindows.set(ip, { count: 1, windowStart: now });
+  }
+
+  const { guestId, token, expiresAt } = issueGuestToken();
+  return c.json({ guestId, token, expiresAt });
+});
+
+export default guestSession;

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -9,6 +9,7 @@ import apps from "./apps.js";
 import oauthWeb from "./oauth.js";
 import xrayPayload from "./xray-payload.js";
 import exporter from "./export.js";
+import guestSession from "./guest-session.js";
 
 const web = new Hono();
 
@@ -21,6 +22,7 @@ web.route("/chat-v2", chatV2);
 web.route("/apps", apps);
 web.route("/oauth", oauthWeb);
 web.route("/xray-payload", xrayPayload);
+web.route("/guest-session", guestSession);
 
 web.onError((error, c) => {
   const routeError = mapRuntimeError(error);

--- a/mcpjam-inspector/server/routes/web/oauth.ts
+++ b/mcpjam-inspector/server/routes/web/oauth.ts
@@ -8,8 +8,37 @@ import {
   OAuthProxyError,
 } from "../../utils/oauth-proxy.js";
 import { ErrorCode, WebRouteError, mapRuntimeError } from "./errors.js";
+import { validateGuestToken } from "../../services/guest-token.js";
+import { guestRateLimitMiddleware } from "../../middleware/guest-rate-limit.js";
 
 const oauthWeb = new Hono();
+
+// Require some form of bearer token (guest or WorkOS) on all OAuth proxy routes
+oauthWeb.use("*", async (c, next) => {
+  const authHeader = c.req.header("authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return c.json(
+      { code: ErrorCode.UNAUTHORIZED, message: "Bearer token required" },
+      401,
+    );
+  }
+
+  const token = authHeader.slice("Bearer ".length);
+
+  // Try validating as a guest token
+  const result = validateGuestToken(token);
+  if (result.valid && result.guestId) {
+    c.set("guestId", result.guestId);
+    return next();
+  }
+
+  // Not a guest token — assume WorkOS token, allow through
+  // (matches current no-validation behavior for authenticated users)
+  return next();
+});
+
+// Rate limit guest users on OAuth proxy routes
+oauthWeb.use("*", guestRateLimitMiddleware);
 
 function statusToErrorCode(status: number): ErrorCode {
   if (status === 400) return ErrorCode.VALIDATION_ERROR;


### PR DESCRIPTION
### TL;DR

Added guest session authentication system with bearer token requirement for OAuth proxy routes and comprehensive rate limiting.

### What changed?

- Created new `/api/web/guest-session` endpoint that issues temporary bearer tokens for unauthenticated users
- Added bearer token requirement middleware to all OAuth proxy routes (`/api/web/oauth/*`)
- Implemented IP-based rate limiting (10 requests/minute) for guest session creation
- Added guest user rate limiting (60 requests/minute) for OAuth proxy usage
- Guest tokens are validated first, with fallback to WorkOS tokens for authenticated users
- Added comprehensive test coverage for guest session issuance, token validation, and rate limiting behavior

### How to test?

1. Test guest session creation: `POST /api/web/guest-session` (no auth required)
2. Verify OAuth routes now require bearer tokens: `POST /api/web/oauth/proxy` and `GET /api/web/oauth/metadata`
3. Test rate limiting by making multiple requests from the same IP to guest session endpoint
4. Verify guest tokens work with OAuth proxy routes and are subject to rate limiting
5. Confirm WorkOS tokens still work with OAuth proxy routes without rate limiting
