### PR TITLE
fix(docker): copy sdk/skills into build stage for SKILL.md import

### DIFF
--- a/mcpjam-inspector/Dockerfile
+++ b/mcpjam-inspector/Dockerfile
@@ -49,6 +49,7 @@ COPY mcpjam-inspector/shared ./shared
 
 # Layer 4: Build SDK first (changes infrequently, required by server and client)
 COPY sdk/src ../sdk/src
+COPY sdk/skills ../sdk/skills
 RUN npm run build:sdk
 
 # Layer 5: Build lib (changes infrequently)


### PR DESCRIPTION
The SDK build fails because sdk/src/skill-reference.ts imports ../skills/create-mcp-eval/SKILL.md, but only sdk/src was copied into the Docker build context.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Dockerfile change that only affects build-time inputs/caching and should not alter runtime behavior beyond unblocking the SDK build.
> 
> **Overview**
> Fixes Docker image builds by copying `sdk/skills` into the build stage so the SDK’s `skill-reference.ts` markdown import (e.g., `../skills/.../SKILL.md`) is available during `npm run build:sdk`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9725f3c38b06ead17130d5fdc2d3f67dda13339. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->