### PR TITLE
Update Convex sandbox URLs for local dev

### DIFF
--- a/mcpjam-inspector/.env.local
+++ b/mcpjam-inspector/.env.local
@@ -1,7 +1,7 @@
-VITE_CONVEX_URL=https://exuberant-albatross-496.convex.cloud
-CONVEX_URL=https://exuberant-albatross-496.convex.cloud
+VITE_CONVEX_URL=https://proper-clownfish-150.convex.cloud
+CONVEX_URL=https://proper-clownfish-150.convex.cloud
 VITE_WORKOS_CLIENT_ID=client_01K4C1TVA6CMQ3G32F1P301A9G
 VITE_WORKOS_REDIRECT_URI=mcpjam://oauth/callback
-CONVEX_HTTP_URL=https://exuberant-albatross-496.convex.site
+CONVEX_HTTP_URL=https://proper-clownfish-150.convex.site
 ENVIRONMENT=local
 VITE_DISABLE_POSTHOG_LOCAL=true


### PR DESCRIPTION
## Summary
- Switch `.env.local` Convex URLs from `exuberant-albatross-496` to `proper-clownfish-150`
- Provides devs with an updated shared sandbox environment for local testing

## Test plan
- [ ] Verify local dev connects to the new Convex sandbox successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes local `.env.local` endpoints; no production code or logic changes, with the main risk being local dev connectivity if the new sandbox is misconfigured.
> 
> **Overview**
> Updates local development configuration to point Convex (`VITE_CONVEX_URL`, `CONVEX_URL`, `CONVEX_HTTP_URL`) from `exuberant-albatross-496` to the new shared sandbox `proper-clownfish-150`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8aae7424c3c3948289dac3d4f254bb12c88c21c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->