### PR TITLE
Remove App Builder promotion banner

### DIFF
--- a/mcpjam-inspector/client/src/components/ipc/ipc-registry.tsx
+++ b/mcpjam-inspector/client/src/components/ipc/ipc-registry.tsx
@@ -1,6 +1,4 @@
 import type { ReactNode } from "react";
-import { Button } from "../ui/button";
-import { X } from "lucide-react";
 
 export type HeaderIpc = {
   id: string;
@@ -9,34 +7,4 @@ export type HeaderIpc = {
 
 // Append new IPC entries here. Use a new unique `id` so previously dismissed
 // banners will not automatically reappear.
-export const headerIpcs: HeaderIpc[] = [
-  {
-    id: "ipc-2025-app-builder-1-1-1",
-    render: ({ dismiss }) => (
-      <div className="no-drag bg-orange-200 px-4 py-2 text-gray-900 lg:px-6">
-        <div className="flex items-center justify-between gap-4">
-          <div className="flex items-center gap-4 flex-1">
-            <p className="text-sm font-normal leading-snug">
-              Try the new App Builder for ChatGPT Apps and MCP Apps
-            </p>
-            <a
-              href="#app-builder"
-              onClick={dismiss}
-              className="text-sm font-normal text-orange-700 hover:text-orange-800 underline underline-offset-2"
-            >
-              Try it now
-            </a>
-          </div>
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={dismiss}
-            className="hover:bg-orange-200 p-1 h-8 w-8"
-          >
-            <X className="h-5 w-5" />
-          </Button>
-        </div>
-      </div>
-    ),
-  },
-];
+export const headerIpcs: HeaderIpc[] = [];


### PR DESCRIPTION
## Summary
- Removes the "Try the new App Builder for ChatGPT Apps and MCP Apps" promotional banner from the header
- Clears the `headerIpcs` array and removes unused imports (`Button`, `X`)

## Test plan
- [ ] Verify the banner no longer appears in the header
- [ ] Verify no build errors from the removed imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change that removes a banner; no changes to data handling, auth, or core application logic.
> 
> **Overview**
> Removes the App Builder promotional header banner by deleting its `HeaderIpc` entry and exporting an empty `headerIpcs` array in `ipc-registry.tsx`.
> 
> Cleans up the related unused imports (`Button`, `X`) now that no header IPC is rendered.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4609db3f79a1c8f322fcf46e9eab2f6433bb4d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->