### PR TITLE
Add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 .mcpjam/skills/
 **/.mcpjam/skills/
+.claude/


### PR DESCRIPTION
## Summary
- Add `.claude/` directory to `.gitignore` to prevent local Claude Code working files (worktrees, settings) from being tracked in version control.

## Test plan
- [x] Verify `.claude/` no longer appears as untracked in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line `.gitignore` change with no runtime impact; only affects what files Git will track.
> 
> **Overview**
> Updates `.gitignore` to ignore the `.claude/` directory so local Claude tooling/workspace files aren’t accidentally committed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f24216e127b743b3dc33fb5def863874263f2a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->