### PR TITLE
Fix Dockerfile: add missing bundle steps before build:server

### DIFF
--- a/mcpjam-inspector/Dockerfile
+++ b/mcpjam-inspector/Dockerfile
@@ -58,6 +58,8 @@ RUN npm run build:lib
 
 # Layer 6: Build server (changes moderately, depends on SDK)
 COPY mcpjam-inspector/server ./server
+COPY mcpjam-inspector/scripts ./scripts
+RUN npm run bundle:chatgpt && npm run bundle:mcp-apps && npm run bundle:sandbox-proxies
 RUN npm run build:server
 
 # Layer 7: Build client (changes most frequently, depends on SDK and shared)


### PR DESCRIPTION
## Summary
- Adds the three missing bundle steps (`bundle:chatgpt`, `bundle:mcp-apps`, `bundle:sandbox-proxies`) to the Dockerfile before `build:server`
- These steps generate `.bundled.ts` files (`OpenAIRuntime.bundled`, `McpAppsOpenAICompatibleRuntime.bundled`, `SandboxProxyHtml.bundled`) that the server build depends on
- Without these, `build:server` fails with esbuild "Could not resolve" errors

## Test plan
- [x] Verified Docker build succeeds locally with `docker build`
- [ ] Railway deployment should now pass the `build:server` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build pipeline-only change that adjusts Docker layering and adds required bundling commands; low risk aside from potential build time/caching impact.
> 
> **Overview**
> Fixes the Docker image build by adding the missing pre-build bundling step for the server.
> 
> The `Dockerfile` now copies `mcpjam-inspector/scripts` and runs `bundle:chatgpt`, `bundle:mcp-apps`, and `bundle:sandbox-proxies` before `build:server`, ensuring required bundled artifacts exist during the server compile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c22c81735129aef93b7450c609b729f328ec328. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->