### PR TITLE
Fix destructive styling on chat stop button

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
@@ -232,6 +232,7 @@ describe("ChatInput", () => {
         (btn) => btn.querySelector("svg.lucide-square") !== null,
       );
       expect(stopButton).toBeDefined();
+      expect(stopButton?.className).not.toContain("bg-destructive");
     });
 
     it("calls stop when stop button clicked", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -571,8 +571,8 @@ export function ChatInput({
                   <Button
                     type="button"
                     size="icon"
-                    variant="destructive"
-                    className="size-[34px] rounded-full transition-colors bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    variant="secondary"
+                    className="size-[34px] rounded-full transition-colors"
                     onClick={() => stop()}
                   >
                     <Square size={16} />


### PR DESCRIPTION
### Motivation
- The loading-state "Stop generating" button was styled as a destructive action which could mislead users, so it should use a neutral appearance.

### Description
- Changed the stop button in `ChatInput` from `variant="destructive"` with `bg-destructive text-destructive-foreground` to `variant="secondary"` and removed the explicit destructive color classes, and added a test assertion in `client/src/components/chat-v2/__tests__/ChatInput.test.tsx` to ensure the stop button does not contain `bg-destructive`.

### Testing
- Ran `npm run test -- client/src/components/chat-v2/__tests__/ChatInput.test.tsx` with Vitest and the test file passed (24 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b06a1544d0832cbdf48f9c228f82ce)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI styling change to the loading-state stop button plus a small test assertion; no logic, data, or security paths are affected.
> 
> **Overview**
> Updates the loading-state "Stop generating" button in `ChatInput` to use a neutral `secondary` button variant and removes explicit destructive color classes so it no longer appears as a destructive action.
> 
> Adds a unit test assertion in `ChatInput.test.tsx` to ensure the stop button does not include `bg-destructive` styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e46d5c353e2ff8cd1fe5c44a5e314f7f865f7087. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->