### PR TITLE
fix: switch PostHog person_profiles to always to deduplicate anonymous visitors

### DIFF
--- a/mcpjam-inspector/client/src/lib/PosthogUtils.ts
+++ b/mcpjam-inspector/client/src/lib/PosthogUtils.ts
@@ -5,7 +5,7 @@ export const VITE_PUBLIC_POSTHOG_HOST = "https://us.i.posthog.com";
 export const options = {
   api_host: VITE_PUBLIC_POSTHOG_HOST,
   capture_pageview: false,
-  person_profiles: "identified_only", // Only create profiles for identified users
+  person_profiles: "always",
 
   // Optional: Set static super properties that never change
   loaded: (posthog: any) => {


### PR DESCRIPTION
## Summary
- Switches PostHog `person_profiles` from `"identified_only"` to `"always"` so anonymous visitors on sandbox/shared public links get a persistent `distinct_id` via cookies/localStorage
- Fixes inflated DAU counts caused by the same browser getting a new unique ID on every visit

## Test plan
- [ ] After deploying, revisit a sandbox link in the same browser multiple times without logging in — PostHog should show 1 unique user, not N
- [ ] Monitor DAU in PostHog over the following days to confirm inflated counts normalize

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line client analytics configuration change that may alter PostHog user/profile creation behavior but does not affect app logic or data flows beyond telemetry.
> 
> **Overview**
> Updates the PostHog client config in `PosthogUtils.ts` to set `person_profiles` from `"identified_only"` to `"always"`, ensuring anonymous visitors also get persistent profiles/IDs (helping deduplicate repeat visits and reduce inflated unique-user counts).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edfe3a081d2eaa3fd52ddb22a22ecb49b4188967. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->