### PR TITLE
Fix hosted callback 500 from missing join import

### DIFF
--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -8,7 +8,7 @@ import { logger } from "hono/logger";
 import { logger as appLogger } from "./utils/logger";
 import { serveStatic } from "@hono/node-server/serve-static";
 import { readFileSync } from "fs";
-import { dirname } from "path";
+import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { MCPClientManager } from "@mcpjam/sdk";
 import { loadInspectorEnv, warnOnConvexDevMisconfiguration } from "./env";


### PR DESCRIPTION
## Summary
- import `join` from `path` in `mcpjam-inspector/server/index.ts`
- fix hosted SPA fallback for deep links like `/callback`

## Root cause
Production sign-in on `app.mcpjam.com` redirects to `/callback`, which goes through the SPA fallback in `server/index.ts`. That code calls `join(...)` to load `dist/client/index.html`, but `join` was never imported, so the fallback throws at runtime.

Railway logs for the production service show:
`Error serving index.html: ReferenceError: join is not defined`

## Repro
- `https://app.mcpjam.com/` returns 200
- `https://app.mcpjam.com/callback?code=test` returns 500 before this fix
- arbitrary deep links like `/foo` also return 500 for the same reason

## Testing
- verified the production error via Railway logs
- verified the code path uses `join(...)` without importing it before this change
- did not run a full local build/test pass in this worktree because dependencies are not bootstrapped cleanly here

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a missing `join` import to fix a runtime `ReferenceError` in the production SPA fallback path with no behavior changes beyond preventing 500s on deep links.
> 
> **Overview**
> Fixes hosted production deep links (e.g. `/callback`) returning 500 by importing `join` from `path` in `mcpjam-inspector/server/index.ts`, preventing the SPA fallback `index.html` loader from throwing `ReferenceError: join is not defined`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b311afaa35998f1f6a4491a880c394ce1024bacb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->