### PR TITLE
Fix formatting checks on pull requests

### DIFF
--- a/.github/workflows/prettier-fix.yml
+++ b/.github/workflows/prettier-fix.yml
@@ -1,4 +1,4 @@
-name: Auto Prettier Fix
+name: Formatting
 
 on:
   push:
@@ -7,13 +7,37 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
+  prettier-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    name: Check Code Formatting
+    defaults:
+      run:
+        working-directory: mcpjam-inspector
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npx prettier --check .
+
   prettier-fix:
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     name: Auto-fix Formatting
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: mcpjam-inspector


### PR DESCRIPTION
## Summary
- add a pull-request formatting job named `Check Code Formatting` so it matches the required branch-protection context
- limit auto-formatting commits to direct pushes on `main` so PR workflows stop pushing a new head SHA that never gets follow-on checks
- keep the existing auto-fix behavior for `main` while making PR formatting purely a check

## Testing
- ruby -e "require 'yaml'; data = YAML.load_file('/Users/marcelojimenezrocabado/mcpjam-inspector/.github/workflows/prettier-fix.yml'); puts data['name']; puts data['jobs'].values.map { |job| job['name'] }.join("\\n")"