### PR TITLE
Ingest Axiom infra logs 

### DIFF
--- a/mcpjam-inspector/package-lock.json
+++ b/mcpjam-inspector/package-lock.json
@@ -17,6 +17,7 @@
         "@ai-sdk/openai": "^3.0.25",
         "@ai-sdk/react": "^3.0.71",
         "@ai-sdk/xai": "^3.0.46",
+        "@axiomhq/js": "^1.4.0",
         "@convex-dev/auth": "^0.0.88",
         "@convex-dev/workos": "^0.0.1",
         "@dnd-kit/core": "^6.3.1",
@@ -135,7 +136,7 @@
     },
     "../sdk": {
       "name": "@mcpjam/sdk",
-      "version": "0.8.7",
+      "version": "0.8.8",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.17",
@@ -154,6 +155,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
+        "@sentry/cli": "^2.58.4",
+        "@sentry/node": "^8.55.0",
         "@types/jest": "^29.5.12",
         "@types/json-schema": "^7.0.15",
         "@types/node": "^20.11.0",
@@ -171,6 +174,14 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@sentry/node": "^8.55.0"
+      },
+      "peerDependenciesMeta": {
+        "@sentry/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@acemir/cssom": {
@@ -752,6 +763,18 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axiomhq/js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@axiomhq/js/-/js-1.4.0.tgz",
+      "integrity": "sha512-wC5x1ud/QJMstrjpicATkyY8+ZVWEl4WlXMtA5EZf7hkj0+b191yv4yynLxLEfr/MveXora9m6CWdJq4DsbcAg==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-retry": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.28.6",
@@ -14423,6 +14446,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fetch-retry": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/fetch-retry/-/fetch-retry-6.0.0.tgz",
+      "integrity": "sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==",
+      "license": "MIT"
     },
     "node_modules/fflate": {
       "version": "0.4.8",

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -94,6 +94,7 @@
     "@ai-sdk/openai": "^3.0.25",
     "@ai-sdk/react": "^3.0.71",
     "@ai-sdk/xai": "^3.0.46",
+    "@axiomhq/js": "^1.4.0",
     "@convex-dev/auth": "^0.0.88",
     "@convex-dev/workos": "^0.0.1",
     "@dnd-kit/core": "^6.3.1",

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -436,18 +436,15 @@ const server = serve({
 });
 
 // Handle graceful shutdown
-process.on("SIGINT", async () => {
+async function shutdown() {
   console.log("\n🛑 Shutting down gracefully...");
   await tunnelManager.closeAll();
   server.close();
+  await appLogger.flush();
   process.exit(0);
-});
+}
 
-process.on("SIGTERM", async () => {
-  console.log("\n🛑 Shutting down gracefully...");
-  await tunnelManager.closeAll();
-  server.close();
-  process.exit(0);
-});
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
 
 export default app;

--- a/mcpjam-inspector/server/utils/__tests__/logger.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/logger.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock Sentry before importing logger
+vi.mock("@sentry/node", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+// Mock Axiom
+const mockIngest = vi.fn();
+const mockFlush = vi.fn().mockResolvedValue(undefined);
+vi.mock("@axiomhq/js", () => ({
+  Axiom: vi.fn().mockImplementation(() => ({
+    ingest: mockIngest,
+    flush: mockFlush,
+  })),
+}));
+
+describe("logger", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockIngest.mockClear();
+    mockFlush.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("axiom ingestion", () => {
+    it("initializes Axiom client when AXIOM_TOKEN and AXIOM_DATASET are set", async () => {
+      vi.stubEnv("AXIOM_TOKEN", "test-token");
+      vi.stubEnv("AXIOM_DATASET", "test-dataset");
+      vi.stubEnv("NODE_ENV", "production");
+
+      const { Axiom } = await import("@axiomhq/js");
+      await import("../logger.js");
+
+      expect(Axiom).toHaveBeenCalledWith({ token: "test-token" });
+    });
+
+    it("does not initialize Axiom client when AXIOM_TOKEN is missing", async () => {
+      vi.stubEnv("AXIOM_TOKEN", "");
+      vi.stubEnv("AXIOM_DATASET", "test-dataset");
+
+      const { Axiom } = await import("@axiomhq/js");
+      (Axiom as ReturnType<typeof vi.fn>).mockClear();
+
+      await import("../logger.js");
+
+      expect(Axiom).not.toHaveBeenCalled();
+    });
+
+    it("does not initialize Axiom client when AXIOM_DATASET is missing", async () => {
+      vi.stubEnv("AXIOM_TOKEN", "test-token");
+      delete process.env.AXIOM_DATASET;
+
+      const { Axiom } = await import("@axiomhq/js");
+      (Axiom as ReturnType<typeof vi.fn>).mockClear();
+
+      await import("../logger.js");
+
+      expect(Axiom).not.toHaveBeenCalled();
+    });
+
+    describe("when Axiom is configured", () => {
+      let logger: (typeof import("../logger.js"))["logger"];
+
+      beforeEach(async () => {
+        vi.stubEnv("AXIOM_TOKEN", "test-token");
+        vi.stubEnv("AXIOM_DATASET", "test-dataset");
+        vi.stubEnv("NODE_ENV", "production");
+
+        const mod = await import("../logger.js");
+        logger = mod.logger;
+      });
+
+      it("ingests error logs to Axiom with error details", () => {
+        const error = new Error("something broke");
+        logger.error("fail", error, { requestId: "abc" });
+
+        expect(mockIngest).toHaveBeenCalledWith("test-dataset", [
+          {
+            level: "error",
+            message: "fail",
+            environment: "unknown",
+            requestId: "abc",
+            error: "something broke",
+          },
+        ]);
+      });
+
+      it("ingests error logs with stringified non-Error objects", () => {
+        logger.error("fail", "string-error");
+
+        expect(mockIngest).toHaveBeenCalledWith("test-dataset", [
+          expect.objectContaining({
+            level: "error",
+            message: "fail",
+            error: "string-error",
+          }),
+        ]);
+      });
+
+      it("ingests warn logs to Axiom", () => {
+        logger.warn("watch out", { userId: "123" });
+
+        expect(mockIngest).toHaveBeenCalledWith("test-dataset", [
+          {
+            level: "warn",
+            message: "watch out",
+            environment: "unknown",
+            userId: "123",
+          },
+        ]);
+      });
+
+      it("ingests info logs to Axiom", () => {
+        logger.info("started", { port: 3000 });
+
+        expect(mockIngest).toHaveBeenCalledWith("test-dataset", [
+          {
+            level: "info",
+            message: "started",
+            environment: "unknown",
+            port: 3000,
+          },
+        ]);
+      });
+
+      it("ingests debug logs to Axiom", () => {
+        logger.debug("trace", "arg1", "arg2");
+
+        expect(mockIngest).toHaveBeenCalledWith("test-dataset", [
+          {
+            level: "debug",
+            message: "trace",
+            environment: "unknown",
+            args: ["arg1", "arg2"],
+          },
+        ]);
+      });
+
+      it("flushes Axiom on logger.flush()", async () => {
+        await logger.flush();
+        expect(mockFlush).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/mcpjam-inspector/server/utils/logger.ts
+++ b/mcpjam-inspector/server/utils/logger.ts
@@ -1,30 +1,59 @@
 import * as Sentry from "@sentry/node";
+import { Axiom } from "@axiomhq/js";
 
 const isVerbose = () => process.env.VERBOSE_LOGS === "true";
 const isDev = () => process.env.NODE_ENV !== "production";
 const shouldLog = () => isVerbose() || isDev();
 
+const axiom =
+  process.env.AXIOM_TOKEN && process.env.AXIOM_DATASET
+    ? new Axiom({ token: process.env.AXIOM_TOKEN })
+    : null;
+
+const dataset = process.env.AXIOM_DATASET ?? "";
+
+const environment = process.env.ENVIRONMENT ?? "unknown";
+
+function ingestToAxiom(
+  level: "info" | "warn" | "error" | "debug",
+  message: string,
+  context?: Record<string, unknown>,
+) {
+  if (!axiom) return;
+  axiom.ingest(dataset, [{ ...context, level, message, environment }]);
+}
+
 /**
  * Centralized logger that sends errors to Sentry and only logs to console
  * in dev mode or when verbose mode is enabled (--verbose flag or VERBOSE_LOGS=true).
+ * Sends info/warn/error logs to Axiom when AXIOM_TOKEN and AXIOM_DATASET are set.
  */
 export const logger = {
   /**
-   * Log an error. Always sends to Sentry, only prints to console in dev/verbose mode.
+   * Log an error. Always sends to Sentry and Axiom, only prints to console in dev/verbose mode.
    */
   error(message: string, error?: unknown, context?: Record<string, unknown>) {
     Sentry.captureException(error ?? new Error(message), {
       extra: { message, ...context },
     });
 
-    console.error(message, error);
+    ingestToAxiom("error", message, {
+      ...context,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    if (shouldLog()) {
+      console.error(message, error);
+    }
   },
 
   /**
-   * Log a warning. Always sends to Sentry, only prints to console in dev/verbose mode.
+   * Log a warning. Always sends to Sentry and Axiom, only prints to console in dev/verbose mode.
    */
   warn(message: string, context?: Record<string, unknown>) {
     Sentry.captureMessage(message, { level: "warning", extra: context });
+
+    ingestToAxiom("warn", message, context);
 
     if (shouldLog()) {
       console.warn(message);
@@ -32,20 +61,32 @@ export const logger = {
   },
 
   /**
-   * Log info. Only prints to console in dev/verbose mode. Does not send to Sentry.
+   * Log info. Always sends to Axiom. Only prints to console in dev/verbose mode.
    */
-  info(message: string) {
+  info(message: string, context?: Record<string, unknown>) {
+    ingestToAxiom("info", message, context);
+
     if (shouldLog()) {
       console.log(message);
     }
   },
 
   /**
-   * Log debug info. Only prints to console in dev/verbose mode. Does not send to Sentry.
+   * Log debug info. Always sends to Axiom. Only prints to console in dev/verbose mode. Does not send to Sentry.
    */
   debug(message: string, ...args: unknown[]) {
+    ingestToAxiom("debug", message, args.length ? { args } : undefined);
     if (shouldLog()) {
       console.log(message, ...args);
     }
   },
+
+  /**
+   * Flush pending Axiom events. Call before process exit.
+   */
+  async flush() {
+    await axiom?.flush();
+  },
 };
+
+process.on("beforeExit", () => logger.flush());


### PR DESCRIPTION
### TL;DR

Added Axiom logging integration to centralize application logs alongside existing Sentry error reporting.

### What changed?

- Added `@axiomhq/js` dependency for Axiom logging service integration
- Enhanced the logger utility to send all log levels (info, warn, error, debug) to Axiom when `AXIOM_TOKEN` and `AXIOM_DATASET` environment variables are configured
- Added automatic log flushing on process exit events (`beforeExit`, `SIGTERM`)
- Included environment context in all Axiom log entries
- Added comprehensive test coverage for the new Axiom logging functionality
- Bumped SDK version from 0.8.7 to 0.8.8

### Test plan
1. Set `AXIOM_TOKEN` and `AXIOM_DATASET` environment variables in railway
2. Used logger methods (`logger.info()`, `logger.warn()`, `logger.error()`, `logger.debug()`)
3. Verify logs appear in your configured Axiom dataset
4. Run the new test suite: `npm test server/utils/__tests__/logger.test.ts`


staging logs, TBD improves -> basic for now
![Screenshot 2026-03-12 at 6.51.09 PM.png](https://app.graphite.com/user-attachments/assets/935140ed-e833-4729-860e-b226815ae947.png)

