### PR TITLE
Improve commit detail view

### DIFF
--- a/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
@@ -11,13 +11,14 @@ import {
 } from "@/components/ui/resizable";
 import { useSharedAppState } from "@/state/app-state-context";
 import { useCiEvalsRoute, navigateToCiEvalsRoute } from "@/lib/ci-evals-router";
-import { aggregateSuite, groupSuitesByTag } from "./evals/helpers";
+import { aggregateSuite, groupSuitesByTag, groupRunsByCommit } from "./evals/helpers";
 import { OverviewPanel } from "./evals/overview-panel";
 import { useEvalMutations } from "./evals/use-eval-mutations";
 import { useEvalQueries } from "./evals/use-eval-queries";
 import { useEvalHandlers } from "./evals/use-eval-handlers";
-import { CiSuiteListSidebar } from "./evals/ci-suite-list-sidebar";
+import { CiSuiteListSidebar, type SidebarMode } from "./evals/ci-suite-list-sidebar";
 import { CiSuiteDetail } from "./evals/ci-suite-detail";
+import { CommitDetailView } from "./evals/commit-detail-view";
 import { useWorkspaceMembers } from "@/hooks/useWorkspaces";
 import type { EvalSuite } from "./evals/types";
 
@@ -35,6 +36,7 @@ export function CiEvalsTab({ convexWorkspaceId }: CiEvalsTabProps) {
   const [deletingSuiteId, setDeletingSuiteId] = useState<string | null>(null);
   const [deletingRunId, setDeletingRunId] = useState<string | null>(null);
   const [filterTag, setFilterTag] = useState<string | null>(null);
+  const [sidebarMode, setSidebarMode] = useState<SidebarMode>("suites");
 
   const selectedSuiteId =
     route.type === "suite-overview" ||
@@ -88,6 +90,21 @@ export function CiEvalsTab({ convexWorkspaceId }: CiEvalsTabProps) {
 
   const tagGroups = useMemo(() => groupSuitesByTag(sdkSuites), [sdkSuites]);
   const hasTags = tagGroups.some((g) => g.tag !== "Untagged");
+
+  const commitGroups = useMemo(
+    () => groupRunsByCommit(sdkSuites),
+    [sdkSuites],
+  );
+
+  const selectedCommitSha =
+    route.type === "commit-detail" ? route.commitSha : null;
+
+  const selectedCommitGroup = useMemo(() => {
+    if (!selectedCommitSha) return null;
+    return (
+      commitGroups.find((g) => g.commitSha === selectedCommitSha) ?? null
+    );
+  }, [commitGroups, selectedCommitSha]);
   const allTags = useMemo(
     () =>
       Array.from(new Set(sdkSuites.flatMap((e) => e.suite.tags ?? []))).sort(),
@@ -139,6 +156,10 @@ export function CiEvalsTab({ convexWorkspaceId }: CiEvalsTabProps) {
 
   const handleSelectOverview = useCallback(() => {
     navigateToCiEvalsRoute({ type: "list" });
+  }, []);
+
+  const handleSelectCommit = useCallback((commitSha: string) => {
+    navigateToCiEvalsRoute({ type: "commit-detail", commitSha });
   }, []);
 
   const handleDeleteSuite = useCallback(
@@ -261,10 +282,15 @@ export function CiEvalsTab({ convexWorkspaceId }: CiEvalsTabProps) {
             selectedSuiteId={selectedSuiteId}
             onSelectSuite={handleSelectSuite}
             onSelectOverview={handleSelectOverview}
-            isOverviewSelected={!selectedSuiteId}
+            isOverviewSelected={!selectedSuiteId && route.type !== "commit-detail"}
             isLoading={queries.isOverviewLoading}
             filterTag={filterTag}
             hasTags={true}
+            sidebarMode={sidebarMode}
+            onSidebarModeChange={setSidebarMode}
+            commitGroups={commitGroups}
+            selectedCommitSha={selectedCommitSha}
+            onSelectCommit={handleSelectCommit}
           />
         </ResizablePanel>
 
@@ -274,7 +300,12 @@ export function CiEvalsTab({ convexWorkspaceId }: CiEvalsTabProps) {
           defaultSize={70}
           className="flex flex-col overflow-hidden"
         >
-          {sdkSuites.length === 0 ? (
+          {route.type === "commit-detail" && selectedCommitGroup ? (
+            <CommitDetailView
+              commitGroup={selectedCommitGroup}
+              allCommitGroups={commitGroups}
+            />
+          ) : sdkSuites.length === 0 ? (
             <div className="flex-1 flex items-center justify-center">
               <div className="text-center max-w-md mx-auto p-8">
                 <div className="w-20 h-20 bg-muted rounded-full flex items-center justify-center mx-auto mb-6">

--- a/mcpjam-inspector/client/src/components/evals/__tests__/commit-detail-view.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/commit-detail-view.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import type { CommitGroup, EvalSuiteRun } from "../types";
+
+// Test the helper logic used by CommitDetailView without rendering
+// (categorizeRuns, getRunDuration, getTotalCases, getModelsUsed)
+
+function makeRun(overrides: Partial<EvalSuiteRun> = {}): EvalSuiteRun {
+  return {
+    _id: "run_1",
+    suiteId: "suite_1",
+    createdBy: "user_1",
+    runNumber: 1,
+    configRevision: "rev1",
+    configSnapshot: { tests: [], environment: { servers: [] } },
+    status: "completed",
+    result: "passed",
+    createdAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeCommitGroup(overrides: Partial<CommitGroup> = {}): CommitGroup {
+  return {
+    commitSha: "abc1234567890",
+    shortSha: "abc1234",
+    branch: "main",
+    timestamp: 5000,
+    status: "passed",
+    runs: [],
+    suiteMap: new Map(),
+    summary: { total: 0, passed: 0, failed: 0, running: 0 },
+    ...overrides,
+  };
+}
+
+// Replicate categorizeRuns logic for testing
+function categorizeRuns(runs: EvalSuiteRun[]) {
+  const failed: EvalSuiteRun[] = [];
+  const passed: EvalSuiteRun[] = [];
+  const notRun: EvalSuiteRun[] = [];
+  const running: EvalSuiteRun[] = [];
+
+  for (const run of runs) {
+    if (run.status === "running" || run.status === "pending") {
+      running.push(run);
+    } else if (run.result === "failed") {
+      failed.push(run);
+    } else if (run.result === "passed") {
+      passed.push(run);
+    } else {
+      notRun.push(run);
+    }
+  }
+
+  return { failed, passed, notRun, running };
+}
+
+describe("categorizeRuns", () => {
+  it("separates runs by status/result", () => {
+    const runs = [
+      makeRun({ _id: "r1", result: "passed", status: "completed" }),
+      makeRun({ _id: "r2", result: "failed", status: "completed" }),
+      makeRun({ _id: "r3", status: "running" }),
+      makeRun({ _id: "r4", result: "cancelled", status: "cancelled" }),
+    ];
+
+    const { passed, failed, running, notRun } = categorizeRuns(runs);
+
+    expect(passed).toHaveLength(1);
+    expect(passed[0]._id).toBe("r1");
+    expect(failed).toHaveLength(1);
+    expect(failed[0]._id).toBe("r2");
+    expect(running).toHaveLength(1);
+    expect(running[0]._id).toBe("r3");
+    expect(notRun).toHaveLength(1);
+    expect(notRun[0]._id).toBe("r4");
+  });
+
+  it("handles empty runs array", () => {
+    const { passed, failed, running, notRun } = categorizeRuns([]);
+    expect(passed).toHaveLength(0);
+    expect(failed).toHaveLength(0);
+    expect(running).toHaveLength(0);
+    expect(notRun).toHaveLength(0);
+  });
+
+  it("treats pending runs as running", () => {
+    const runs = [makeRun({ _id: "r1", status: "pending" })];
+    const { running } = categorizeRuns(runs);
+    expect(running).toHaveLength(1);
+  });
+});
+
+describe("CommitGroup structure", () => {
+  it("manual group has correct identifiers", () => {
+    const group = makeCommitGroup({
+      commitSha: "manual",
+      shortSha: "Manual",
+      branch: null,
+    });
+    expect(group.commitSha).toBe("manual");
+    expect(group.shortSha).toBe("Manual");
+    expect(group.branch).toBeNull();
+  });
+
+  it("suiteMap maps suiteId to name", () => {
+    const map = new Map([
+      ["s1", "Suite A"],
+      ["s2", "Suite B"],
+    ]);
+    const group = makeCommitGroup({ suiteMap: map });
+    expect(group.suiteMap.get("s1")).toBe("Suite A");
+    expect(group.suiteMap.size).toBe(2);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/group-runs-by-commit.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/group-runs-by-commit.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from "vitest";
+import { groupRunsByCommit } from "../helpers";
+import type { EvalSuiteOverviewEntry, EvalSuiteRun } from "../types";
+
+function makeRun(overrides: Partial<EvalSuiteRun> = {}): EvalSuiteRun {
+  return {
+    _id: "run_1",
+    suiteId: "suite_1",
+    createdBy: "user_1",
+    runNumber: 1,
+    configRevision: "rev1",
+    configSnapshot: { tests: [], environment: { servers: [] } },
+    status: "completed",
+    result: "passed",
+    createdAt: 1000,
+    ...overrides,
+  };
+}
+
+function makeEntry(
+  suiteId: string,
+  suiteName: string,
+  runs: EvalSuiteRun[],
+): EvalSuiteOverviewEntry {
+  return {
+    suite: {
+      _id: suiteId,
+      createdBy: "user_1",
+      name: suiteName,
+      description: "",
+      configRevision: "rev1",
+      environment: { servers: [] },
+      createdAt: 0,
+      updatedAt: 0,
+    },
+    latestRun: runs[0] ?? null,
+    recentRuns: runs,
+    passRateTrend: [],
+    totals: { passed: 0, failed: 0, runs: runs.length },
+  };
+}
+
+describe("groupRunsByCommit", () => {
+  it("groups runs by commitSha", () => {
+    const runs = [
+      makeRun({
+        _id: "r1",
+        suiteId: "s1",
+        ciMetadata: { commitSha: "abc1234567890" },
+        createdAt: 2000,
+      }),
+      makeRun({
+        _id: "r2",
+        suiteId: "s1",
+        ciMetadata: { commitSha: "abc1234567890" },
+        createdAt: 3000,
+      }),
+      makeRun({
+        _id: "r3",
+        suiteId: "s1",
+        ciMetadata: { commitSha: "def4567890123" },
+        createdAt: 1000,
+      }),
+    ];
+
+    const result = groupRunsByCommit([makeEntry("s1", "Suite 1", runs)]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].shortSha).toBe("abc1234");
+    expect(result[0].runs).toHaveLength(2);
+    expect(result[1].shortSha).toBe("def4567");
+    expect(result[1].runs).toHaveLength(1);
+  });
+
+  it("puts manual runs (no commitSha) last", () => {
+    const runs = [
+      makeRun({ _id: "r1", createdAt: 5000 }), // no ciMetadata
+      makeRun({
+        _id: "r2",
+        ciMetadata: { commitSha: "abc1234567890" },
+        createdAt: 1000,
+      }),
+    ];
+
+    const result = groupRunsByCommit([makeEntry("s1", "Suite 1", runs)]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].commitSha).toBe("abc1234567890");
+    expect(result[1].commitSha).toBe("manual");
+    expect(result[1].shortSha).toBe("Manual");
+  });
+
+  it("sorts by most recent timestamp first", () => {
+    const runs = [
+      makeRun({
+        _id: "r1",
+        ciMetadata: { commitSha: "old1234567890" },
+        createdAt: 1000,
+      }),
+      makeRun({
+        _id: "r2",
+        ciMetadata: { commitSha: "new1234567890" },
+        createdAt: 5000,
+      }),
+    ];
+
+    const result = groupRunsByCommit([makeEntry("s1", "Suite 1", runs)]);
+
+    expect(result[0].shortSha).toBe("new1234");
+    expect(result[1].shortSha).toBe("old1234");
+  });
+
+  it("computes aggregate status correctly", () => {
+    const runs = [
+      makeRun({
+        _id: "r1",
+        ciMetadata: { commitSha: "mix1234567890" },
+        result: "passed",
+        status: "completed",
+        createdAt: 1000,
+      }),
+      makeRun({
+        _id: "r2",
+        ciMetadata: { commitSha: "mix1234567890" },
+        result: "failed",
+        status: "completed",
+        createdAt: 2000,
+      }),
+    ];
+
+    const result = groupRunsByCommit([makeEntry("s1", "Suite 1", runs)]);
+
+    expect(result[0].status).toBe("mixed");
+    expect(result[0].summary.passed).toBe(1);
+    expect(result[0].summary.failed).toBe(1);
+  });
+
+  it("picks up branch from ciMetadata", () => {
+    const runs = [
+      makeRun({
+        _id: "r1",
+        ciMetadata: { commitSha: "abc1234567890", branch: "feature/test" },
+        createdAt: 1000,
+      }),
+    ];
+
+    const result = groupRunsByCommit([makeEntry("s1", "Suite 1", runs)]);
+    expect(result[0].branch).toBe("feature/test");
+  });
+
+  it("builds suiteMap from multiple overview entries", () => {
+    const entry1 = makeEntry("s1", "Suite A", [
+      makeRun({
+        _id: "r1",
+        suiteId: "s1",
+        ciMetadata: { commitSha: "abc1234567890" },
+        createdAt: 1000,
+      }),
+    ]);
+    const entry2 = makeEntry("s2", "Suite B", [
+      makeRun({
+        _id: "r2",
+        suiteId: "s2",
+        ciMetadata: { commitSha: "abc1234567890" },
+        createdAt: 2000,
+      }),
+    ]);
+
+    const result = groupRunsByCommit([entry1, entry2]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].suiteMap.get("s1")).toBe("Suite A");
+    expect(result[0].suiteMap.get("s2")).toBe("Suite B");
+    expect(result[0].runs).toHaveLength(2);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(groupRunsByCommit([])).toEqual([]);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/ci-suite-list-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/ci-suite-list-sidebar.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react";
 import { BarChart3 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { EvalSuiteOverviewEntry } from "./types";
+import type { CommitGroup, EvalSuiteOverviewEntry } from "./types";
 import { TagBadges } from "./tag-editor";
+import { CommitListSidebar } from "./commit-list-sidebar";
 
 /** Force a re-render every `intervalMs` so relative timestamps stay fresh. */
 function useTick(intervalMs = 60_000) {
@@ -12,6 +13,8 @@ function useTick(intervalMs = 60_000) {
     return () => clearInterval(id);
   }, [intervalMs]);
 }
+
+export type SidebarMode = "suites" | "runs";
 
 interface CiSuiteListSidebarProps {
   suites: EvalSuiteOverviewEntry[];
@@ -23,6 +26,11 @@ interface CiSuiteListSidebarProps {
   filterTag?: string | null;
   onFilterTagChange?: (tag: string | null) => void;
   hasTags: boolean;
+  sidebarMode: SidebarMode;
+  onSidebarModeChange: (mode: SidebarMode) => void;
+  commitGroups: CommitGroup[];
+  selectedCommitSha: string | null;
+  onSelectCommit: (commitSha: string) => void;
 }
 
 function getStatusInfo(entry: EvalSuiteOverviewEntry): {
@@ -94,6 +102,11 @@ export function CiSuiteListSidebar({
   isLoading = false,
   filterTag,
   hasTags,
+  sidebarMode,
+  onSidebarModeChange,
+  commitGroups,
+  selectedCommitSha,
+  onSelectCommit,
 }: CiSuiteListSidebarProps) {
   useTick(); // keep "Xm ago" labels ticking
 
@@ -105,15 +118,54 @@ export function CiSuiteListSidebar({
     <div className="flex h-full flex-col">
       <div className="border-b px-4 py-3">
         <div className="flex items-center justify-between">
-          <h2 className="text-sm font-semibold">Eval suites</h2>
-          {filteredSuites.length > 0 && (
+          <h2 className="text-sm font-semibold">
+            {sidebarMode === "suites" ? "Eval suites" : "Runs by commit"}
+          </h2>
+          {sidebarMode === "suites" && filteredSuites.length > 0 && (
             <span className="text-[10px] text-muted-foreground tabular-nums">
               {filteredSuites.length}
             </span>
           )}
+          {sidebarMode === "runs" && commitGroups.length > 0 && (
+            <span className="text-[10px] text-muted-foreground tabular-nums">
+              {commitGroups.length}
+            </span>
+          )}
+        </div>
+        <div className="mt-2 flex rounded-md border bg-muted/50 p-0.5">
+          <button
+            onClick={() => onSidebarModeChange("suites")}
+            className={cn(
+              "flex-1 rounded-sm px-3 py-1 text-xs font-medium transition-colors",
+              sidebarMode === "suites"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            Suites
+          </button>
+          <button
+            onClick={() => onSidebarModeChange("runs")}
+            className={cn(
+              "flex-1 rounded-sm px-3 py-1 text-xs font-medium transition-colors",
+              sidebarMode === "runs"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            Runs
+          </button>
         </div>
       </div>
 
+      {sidebarMode === "runs" ? (
+        <CommitListSidebar
+          commitGroups={commitGroups}
+          selectedCommitSha={selectedCommitSha}
+          onSelectCommit={onSelectCommit}
+          isLoading={isLoading}
+        />
+      ) : (
       <div className="flex-1 overflow-y-auto">
         {hasTags && (
           <button
@@ -220,6 +272,7 @@ export function CiSuiteListSidebar({
           </div>
         )}
       </div>
+      )}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/evals/commit-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/commit-detail-view.tsx
@@ -1,0 +1,941 @@
+import { useState, useMemo } from "react";
+import {
+  ChevronDown,
+  ChevronRight,
+  GitBranch,
+  GitCommit,
+  XCircle,
+  CheckCircle2,
+  MinusCircle,
+  Clock,
+  Sparkles,
+  ExternalLink,
+  RotateCcw,
+  FileText,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from "@/components/ui/collapsible";
+import type { CommitGroup, EvalSuiteRun } from "./types";
+import { formatDuration } from "./helpers";
+import { navigateToCiEvalsRoute } from "@/lib/ci-evals-router";
+
+interface CommitDetailViewProps {
+  commitGroup: CommitGroup;
+  allCommitGroups: CommitGroup[];
+  onRerunRun?: (suiteId: string, runId: string) => void;
+}
+
+// Categorize runs into failed, passed, running/pending, cancelled
+function categorizeRuns(runs: EvalSuiteRun[]) {
+  const failed: EvalSuiteRun[] = [];
+  const passed: EvalSuiteRun[] = [];
+  const notRun: EvalSuiteRun[] = [];
+  const running: EvalSuiteRun[] = [];
+
+  for (const run of runs) {
+    if (run.status === "running" || run.status === "pending") {
+      running.push(run);
+    } else if (run.result === "failed") {
+      failed.push(run);
+    } else if (run.result === "passed") {
+      passed.push(run);
+    } else {
+      notRun.push(run);
+    }
+  }
+
+  return { failed, passed, notRun, running };
+}
+
+function getRunDuration(run: EvalSuiteRun): number | null {
+  if (run.completedAt && run.createdAt) {
+    return run.completedAt - run.createdAt;
+  }
+  return null;
+}
+
+function getTotalDuration(runs: EvalSuiteRun[]): number {
+  let total = 0;
+  for (const run of runs) {
+    const d = getRunDuration(run);
+    if (d) total += d;
+  }
+  return total;
+}
+
+function getModelsUsed(runs: EvalSuiteRun[]): string[] {
+  const models = new Set<string>();
+  for (const run of runs) {
+    for (const test of run.configSnapshot?.tests ?? []) {
+      if (test.model) models.add(test.model);
+    }
+  }
+  return Array.from(models);
+}
+
+function getTotalCases(runs: EvalSuiteRun[]): {
+  total: number;
+  passed: number;
+  failed: number;
+} {
+  let total = 0,
+    passed = 0,
+    failed = 0;
+  for (const run of runs) {
+    if (run.summary) {
+      total += run.summary.total;
+      passed += run.summary.passed;
+      failed += run.summary.failed;
+    }
+  }
+  return { total, passed, failed };
+}
+
+/**
+ * Build sparkline data for a given suite across recent commits.
+ * Returns an array of { passRate, isCurrent } for the last N commits.
+ */
+function getSuiteSparkline(
+  suiteId: string,
+  currentCommitSha: string,
+  allCommitGroups: CommitGroup[],
+  maxPoints = 10,
+): Array<{ passRate: number; isCurrent: boolean }> {
+  const points: Array<{ passRate: number; isCurrent: boolean }> = [];
+  // allCommitGroups is already sorted newest-first; reverse for chronological order
+  const chronological = [...allCommitGroups].reverse();
+  for (const group of chronological) {
+    const run = group.runs.find((r) => r.suiteId === suiteId);
+    if (run && run.summary && run.summary.total > 0) {
+      points.push({
+        passRate: Math.round((run.summary.passed / run.summary.total) * 100),
+        isCurrent: group.commitSha === currentCommitSha,
+      });
+    }
+  }
+  return points.slice(-maxPoints);
+}
+
+export function CommitDetailView({
+  commitGroup,
+  allCommitGroups,
+}: CommitDetailViewProps) {
+  const [failedOpen, setFailedOpen] = useState(true);
+  const [passedOpen, setPassedOpen] = useState(false);
+  const [notRunOpen, setNotRunOpen] = useState(false);
+  const [envOpen, setEnvOpen] = useState(false);
+  const [compareIdx, setCompareIdx] = useState<number>(-1);
+
+  const { failed, passed, notRun, running } = useMemo(
+    () => categorizeRuns(commitGroup.runs),
+    [commitGroup.runs],
+  );
+
+  const totalDuration = getTotalDuration(commitGroup.runs);
+  const models = getModelsUsed(commitGroup.runs);
+  const totalCases = getTotalCases(commitGroup.runs);
+  const isManual = commitGroup.commitSha === "manual";
+
+  // Compare data
+  const compareOptions = useMemo(
+    () =>
+      allCommitGroups.filter(
+        (g) => g.commitSha !== commitGroup.commitSha && g.commitSha !== "manual",
+      ),
+    [allCommitGroups, commitGroup.commitSha],
+  );
+
+  const compareGroup = compareIdx >= 0 ? compareOptions[compareIdx] : null;
+  const compareDiff = useMemo(() => {
+    if (!compareGroup) return null;
+    const baseCases = getTotalCases(compareGroup.runs);
+    const currCases = totalCases;
+    return {
+      passedDelta: currCases.passed - baseCases.passed,
+      failedDelta: currCases.failed - baseCases.failed,
+      durationDelta: totalDuration - getTotalDuration(compareGroup.runs),
+    };
+  }, [compareGroup, totalCases, totalDuration]);
+
+  // Derive environment info from runs
+  const envInfo = useMemo(() => {
+    const firstRun = commitGroup.runs[0];
+    if (!firstRun) return null;
+    const servers = firstRun.configSnapshot?.environment?.servers ?? [];
+    return {
+      models: models.join(", ") || "—",
+      servers: servers.join(", ") || "—",
+      provider: firstRun.ciMetadata?.provider || "—",
+      framework: firstRun.framework || "—",
+      source: firstRun.source || "—",
+    };
+  }, [commitGroup.runs, models]);
+
+  // Generate triage summary from actual failure data
+  const triageSummary = useMemo(() => {
+    if (failed.length === 0) return null;
+    const failedSuiteNames = failed.map(
+      (r) => commitGroup.suiteMap.get(r.suiteId) || "Unknown suite",
+    );
+    const totalFailedCases = failed.reduce(
+      (sum, r) => sum + (r.summary?.failed ?? 0),
+      0,
+    );
+    return {
+      failCount: failed.length,
+      failedSuiteNames,
+      totalFailedCases,
+    };
+  }, [failed, commitGroup.suiteMap]);
+
+  return (
+    <div className="flex-1 overflow-y-auto px-6 pb-6 pt-6">
+      <div className="mx-auto max-w-[880px] space-y-4">
+        {/* === HEADER & CONTEXT === */}
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
+          <div className="flex items-start justify-between mb-4">
+            <div>
+              <h1 className="text-xl font-bold">
+                {isManual ? (
+                  "Manual Runs"
+                ) : (
+                  <>
+                    Commit{" "}
+                    <span className="font-mono">{commitGroup.shortSha}</span>
+                  </>
+                )}
+                <span className="ml-2 text-sm font-normal text-muted-foreground">
+                  {new Date(commitGroup.timestamp).toLocaleString()}
+                </span>
+              </h1>
+            </div>
+            <StatusBadge
+              status={commitGroup.status}
+              failCount={failed.length}
+            />
+          </div>
+
+          <div className="flex flex-wrap gap-x-5 gap-y-1 text-xs text-muted-foreground">
+            {commitGroup.branch && (
+              <span className="flex items-center gap-1">
+                <GitBranch className="h-3 w-3" />
+                branch: <span className="font-mono font-medium text-foreground">{commitGroup.branch}</span>
+              </span>
+            )}
+            {!isManual && (
+              <span className="flex items-center gap-1">
+                <GitCommit className="h-3 w-3" />
+                commit: <span className="font-mono font-medium text-foreground">{commitGroup.shortSha}</span>
+              </span>
+            )}
+            {commitGroup.runs[0]?.ciMetadata?.provider && (
+              <span>
+                trigger:{" "}
+                <span className="font-mono font-medium text-foreground">
+                  {commitGroup.runs[0].ciMetadata.provider}
+                </span>
+              </span>
+            )}
+            {totalDuration > 0 && (
+              <span className="flex items-center gap-1">
+                <Clock className="h-3 w-3" />
+                duration: <span className="font-mono font-medium text-foreground">{formatDuration(totalDuration)}</span>
+              </span>
+            )}
+            {models.length > 0 && (
+              <span>
+                model: <span className="font-mono font-medium text-foreground">{models[0]}{models.length > 1 ? ` +${models.length - 1}` : ""}</span>
+              </span>
+            )}
+          </div>
+
+          {/* Pass rate progress bar + quick stats */}
+          {totalCases.total > 0 && (
+            <div className="mt-4 pt-4 border-t border-border/50">
+              <div className="flex items-center gap-4 mb-2">
+                <div className="flex-1">
+                  <div className="flex items-center justify-between mb-1.5">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      Overall pass rate
+                    </span>
+                    <span className="text-sm font-bold tabular-nums">
+                      {totalCases.total > 0
+                        ? Math.round(
+                            (totalCases.passed / totalCases.total) * 100,
+                          )
+                        : 0}
+                      %
+                    </span>
+                  </div>
+                  <div className="h-2 rounded-full bg-muted overflow-hidden">
+                    <div
+                      className={cn(
+                        "h-full rounded-full transition-all duration-500",
+                        totalCases.failed === 0
+                          ? "bg-emerald-500"
+                          : totalCases.passed === 0
+                            ? "bg-destructive"
+                            : "bg-amber-500",
+                      )}
+                      style={{
+                        width: `${totalCases.total > 0 ? (totalCases.passed / totalCases.total) * 100 : 0}%`,
+                      }}
+                    />
+                  </div>
+                </div>
+              </div>
+              <div className="flex gap-4 text-xs tabular-nums">
+                <span className="flex items-center gap-1.5">
+                  <span className="h-2 w-2 rounded-full bg-emerald-500" />
+                  <span className="font-medium">{totalCases.passed}</span>
+                  <span className="text-muted-foreground">passed</span>
+                </span>
+                {totalCases.failed > 0 && (
+                  <span className="flex items-center gap-1.5">
+                    <span className="h-2 w-2 rounded-full bg-destructive" />
+                    <span className="font-medium">{totalCases.failed}</span>
+                    <span className="text-muted-foreground">failed</span>
+                  </span>
+                )}
+                <span className="flex items-center gap-1.5">
+                  <span className="text-muted-foreground">
+                    {commitGroup.runs.length} suite{commitGroup.runs.length !== 1 ? "s" : ""}
+                  </span>
+                </span>
+                <span className="flex items-center gap-1.5">
+                  <span className="text-muted-foreground">
+                    {totalCases.total} total case{totalCases.total !== 1 ? "s" : ""}
+                  </span>
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* Action buttons */}
+          <div className="mt-4 pt-4 border-t border-border/50 flex flex-wrap gap-2">
+            {failed.length > 0 && (
+              <button
+                onClick={() => {
+                  for (const run of failed) {
+                    navigateToCiEvalsRoute({
+                      type: "run-detail",
+                      suiteId: run.suiteId,
+                      runId: run._id,
+                    });
+                    break;
+                  }
+                }}
+                className="inline-flex items-center gap-1.5 rounded-md border bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                <RotateCcw className="h-3 w-3" />
+                View failures
+              </button>
+            )}
+            {commitGroup.runs[0]?.ciMetadata?.runUrl && (
+              <a
+                href={commitGroup.runs[0].ciMetadata.runUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              >
+                <FileText className="h-3 w-3" />
+                CI Pipeline
+              </a>
+            )}
+            <button
+              onClick={() => {
+                const url = window.location.href;
+                navigator.clipboard.writeText(url);
+              }}
+              className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            >
+              <ExternalLink className="h-3 w-3" />
+              Share
+            </button>
+          </div>
+        </div>
+
+        {/* === COMPARE BAR === */}
+        {compareOptions.length > 0 && (
+          <div className="rounded-lg border bg-card shadow-sm">
+            <div className="flex items-center gap-3 px-6 py-3 text-xs">
+              <span className="font-medium text-muted-foreground">
+                Compare with
+              </span>
+              <select
+                className="rounded-md border bg-muted/50 px-3 py-1.5 font-mono text-xs text-foreground"
+                value={compareIdx}
+                onChange={(e) => setCompareIdx(Number(e.target.value))}
+              >
+                <option value={-1}>Select a commit...</option>
+                {compareOptions.map((g, i) => (
+                  <option key={g.commitSha} value={i}>
+                    {g.shortSha} · {new Date(g.timestamp).toLocaleDateString()}
+                  </option>
+                ))}
+              </select>
+              {compareDiff && (
+                <div className="ml-auto flex gap-4 text-xs font-medium">
+                  <span
+                    className={cn(
+                      compareDiff.passedDelta > 0
+                        ? "text-emerald-500"
+                        : compareDiff.passedDelta < 0
+                          ? "text-destructive"
+                          : "text-muted-foreground",
+                    )}
+                  >
+                    {compareDiff.passedDelta > 0 ? "+" : ""}
+                    {compareDiff.passedDelta} passed
+                  </span>
+                  <span
+                    className={cn(
+                      compareDiff.failedDelta < 0
+                        ? "text-emerald-500"
+                        : compareDiff.failedDelta > 0
+                          ? "text-destructive"
+                          : "text-muted-foreground",
+                    )}
+                  >
+                    {compareDiff.failedDelta > 0 ? "+" : ""}
+                    {compareDiff.failedDelta} failed
+                  </span>
+                  {compareDiff.durationDelta !== 0 && (
+                    <span className="text-muted-foreground">
+                      {compareDiff.durationDelta > 0 ? "+" : ""}
+                      {formatDuration(Math.abs(compareDiff.durationDelta))}{" "}
+                      {compareDiff.durationDelta > 0 ? "slower" : "faster"}
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* === AI TRIAGE PANEL === */}
+        {triageSummary && (
+          <div className="relative rounded-lg border border-violet-200 bg-violet-50/50 p-6 shadow-sm dark:border-violet-800 dark:bg-violet-950/20">
+            <div className="absolute top-0 left-0 right-0 h-[3px] rounded-t-lg bg-gradient-to-r from-violet-500 via-purple-400 to-violet-500 opacity-50" />
+            <div className="flex items-center gap-2.5 mb-4">
+              <Badge
+                variant="outline"
+                className="border-violet-300 bg-violet-100 text-violet-600 text-[10px] font-bold uppercase tracking-wider dark:border-violet-700 dark:bg-violet-900/50 dark:text-violet-400"
+              >
+                <Sparkles className="mr-1 h-3 w-3" />
+                AI
+              </Badge>
+              <span className="text-sm font-semibold">Triage Summary</span>
+              <span className="ml-auto text-[10px] text-muted-foreground">
+                generated from {commitGroup.runs.length} runs
+              </span>
+            </div>
+            <div className="rounded-md border border-violet-200/40 bg-white/60 p-4 text-sm leading-relaxed dark:bg-black/20">
+              <strong>{triageSummary.failCount} failure{triageSummary.failCount !== 1 ? "s" : ""} detected.</strong>{" "}
+              {triageSummary.failedSuiteNames.length > 0 && (
+                <>
+                  Failed suites:{" "}
+                  {triageSummary.failedSuiteNames.map((name, i) => (
+                    <span key={i}>
+                      {i > 0 && ", "}
+                      <strong className="text-destructive">{name}</strong>
+                    </span>
+                  ))}
+                  {" "}with {triageSummary.totalFailedCases} failed case{triageSummary.totalFailedCases !== 1 ? "s" : ""} total.
+                </>
+              )}
+            </div>
+
+            {/* Action cards grid */}
+            {failed.length > 0 && (
+              <div className="mt-4 grid grid-cols-2 gap-2.5">
+                {failed.slice(0, 4).map((run) => {
+                  const suiteName =
+                    commitGroup.suiteMap.get(run.suiteId) || "Unknown suite";
+                  const passRate = run.summary
+                    ? Math.round(
+                        (run.summary.passed / Math.max(run.summary.total, 1)) *
+                          100,
+                      )
+                    : 0;
+                  return (
+                    <button
+                      key={run._id}
+                      onClick={() =>
+                        navigateToCiEvalsRoute({
+                          type: "run-detail",
+                          suiteId: run.suiteId,
+                          runId: run._id,
+                        })
+                      }
+                      className="rounded-md border border-violet-200/50 bg-white/70 p-4 text-left transition-shadow hover:shadow-md dark:bg-black/20"
+                    >
+                      <div className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-destructive mb-1">
+                        <span className="h-1.5 w-1.5 rounded-full bg-destructive" />
+                        P0 · Investigate
+                      </div>
+                      <div className="text-sm font-semibold mb-1">
+                        {suiteName}
+                      </div>
+                      <div className="text-[11px] text-muted-foreground">
+                        {run.summary?.failed ?? 0} failed of{" "}
+                        {run.summary?.total ?? 0} cases · {passRate}% pass rate
+                      </div>
+                      <span className="mt-2 inline-flex items-center gap-1 text-[11px] font-semibold text-violet-600 dark:text-violet-400">
+                        <ExternalLink className="h-3 w-3" />
+                        View run details
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* === RUNNING SECTION === */}
+        {running.length > 0 && (
+          <RunSection
+            icon={
+              <div className="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] border-amber-300 bg-amber-50 text-amber-600 dark:border-amber-700 dark:bg-amber-950/50">
+                <span className="text-[10px] font-bold animate-pulse">⟳</span>
+              </div>
+            }
+            title="Running"
+            count={`${running.length} suite${running.length !== 1 ? "s" : ""}`}
+            badgeClass="bg-amber-50 text-amber-600 border-amber-200 dark:bg-amber-950/50 dark:text-amber-400"
+            badgeCount={running.length}
+            defaultOpen
+          >
+            {running.map((run) => (
+              <RunRow
+                key={run._id}
+                run={run}
+                suiteName={commitGroup.suiteMap.get(run.suiteId) || "Unknown"}
+                variant="running"
+              />
+            ))}
+          </RunSection>
+        )}
+
+        {/* === FAILED SECTION === */}
+        {failed.length > 0 && (
+          <RunSection
+            icon={
+              <div className="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] border-red-200 bg-red-50 text-destructive dark:border-red-800 dark:bg-red-950/50">
+                <span className="text-[10px] font-bold">✕</span>
+              </div>
+            }
+            title="Failed"
+            count={`${failed.length} suite${failed.length !== 1 ? "s" : ""} · ${totalCases.failed} cases`}
+            badgeClass="bg-red-50 text-destructive border-red-200 dark:bg-red-950/50 dark:text-red-400"
+            badgeCount={failed.length}
+            open={failedOpen}
+            onOpenChange={setFailedOpen}
+            defaultOpen
+          >
+            {failed.map((run) => (
+              <FailedRunRow
+                key={run._id}
+                run={run}
+                suiteName={commitGroup.suiteMap.get(run.suiteId) || "Unknown"}
+                sparkline={getSuiteSparkline(
+                  run.suiteId,
+                  commitGroup.commitSha,
+                  allCommitGroups,
+                )}
+              />
+            ))}
+          </RunSection>
+        )}
+
+        {/* === PASSED SECTION === */}
+        {passed.length > 0 && (
+          <RunSection
+            icon={
+              <div className="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] border-emerald-200 bg-emerald-50 text-emerald-600 dark:border-emerald-800 dark:bg-emerald-950/50">
+                <span className="text-[10px] font-bold">✓</span>
+              </div>
+            }
+            title="Passed"
+            count={`${passed.length} suite${passed.length !== 1 ? "s" : ""} · ${totalCases.passed} cases`}
+            badgeClass="bg-emerald-50 text-emerald-600 border-emerald-200 dark:bg-emerald-950/50 dark:text-emerald-400"
+            badgeCount={passed.length}
+            open={passedOpen}
+            onOpenChange={setPassedOpen}
+          >
+            {passed.map((run) => (
+              <RunRow
+                key={run._id}
+                run={run}
+                suiteName={commitGroup.suiteMap.get(run.suiteId) || "Unknown"}
+                variant="passed"
+              />
+            ))}
+          </RunSection>
+        )}
+
+        {/* === NOT RUN SECTION === */}
+        {notRun.length > 0 && (
+          <RunSection
+            icon={
+              <div className="flex h-5 w-5 items-center justify-center rounded-full border-[1.5px] border-amber-200 bg-amber-50 text-amber-600 dark:border-amber-700 dark:bg-amber-950/50">
+                <span className="text-xs font-bold">–</span>
+              </div>
+            }
+            title="Not Run"
+            count={`${notRun.length} suite${notRun.length !== 1 ? "s" : ""}`}
+            badgeClass="bg-amber-50 text-amber-600 border-amber-200 dark:bg-amber-950/50 dark:text-amber-400"
+            badgeCount={notRun.length}
+            open={notRunOpen}
+            onOpenChange={setNotRunOpen}
+          >
+            {notRun.map((run) => (
+              <RunRow
+                key={run._id}
+                run={run}
+                suiteName={commitGroup.suiteMap.get(run.suiteId) || "Unknown"}
+                variant="notrun"
+              />
+            ))}
+          </RunSection>
+        )}
+
+        {/* === ENVIRONMENT & CONFIG === */}
+        {envInfo && (
+          <Collapsible open={envOpen} onOpenChange={setEnvOpen}>
+            <div className="rounded-lg border bg-card shadow-sm">
+              <CollapsibleTrigger className="flex w-full items-center justify-between px-6 py-4 hover:bg-muted/50 transition-colors">
+                <div className="flex items-center gap-2 text-sm font-semibold">
+                  Environment
+                  <span className="text-xs font-normal text-muted-foreground">
+                    · runtime context
+                  </span>
+                </div>
+                {envOpen ? (
+                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                ) : (
+                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                )}
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <div className="grid grid-cols-2 border-t">
+                  <EnvCell label="Model" value={envInfo.models} />
+                  <EnvCell label="MCP Server" value={envInfo.servers} />
+                  <EnvCell label="Source" value={envInfo.source} />
+                  <EnvCell label="Framework" value={envInfo.framework} />
+                  <EnvCell label="CI Provider" value={envInfo.provider} />
+                  <EnvCell
+                    label="Suites"
+                    value={`${commitGroup.suiteMap.size}`}
+                  />
+                </div>
+              </CollapsibleContent>
+            </div>
+          </Collapsible>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ========== Sub-components ==========
+
+function StatusBadge({
+  status,
+  failCount,
+}: {
+  status: CommitGroup["status"];
+  failCount: number;
+}) {
+  if (status === "passed") {
+    return (
+      <Badge className="gap-1.5 bg-emerald-50 text-emerald-600 border-emerald-200 hover:bg-emerald-100 dark:bg-emerald-950/50 dark:text-emerald-400">
+        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+        Passed
+      </Badge>
+    );
+  }
+  if (status === "failed") {
+    return (
+      <Badge className="gap-1.5 bg-red-50 text-destructive border-red-200 hover:bg-red-100 dark:bg-red-950/50 dark:text-red-400">
+        <span className="h-1.5 w-1.5 rounded-full bg-destructive" />
+        {failCount} Failed
+      </Badge>
+    );
+  }
+  if (status === "running") {
+    return (
+      <Badge className="gap-1.5 bg-amber-50 text-amber-600 border-amber-200 hover:bg-amber-100 dark:bg-amber-950/50 dark:text-amber-400">
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse" />
+        Running
+      </Badge>
+    );
+  }
+  return (
+    <Badge className="gap-1.5 bg-amber-50 text-amber-600 border-amber-200 hover:bg-amber-100 dark:bg-amber-950/50 dark:text-amber-400">
+      <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
+      Mixed
+    </Badge>
+  );
+}
+
+function RunSection({
+  icon,
+  title,
+  count,
+  badgeClass,
+  badgeCount,
+  children,
+  defaultOpen,
+  open,
+  onOpenChange,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  count: string;
+  badgeClass: string;
+  badgeCount: number;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  return (
+    <Collapsible
+      defaultOpen={defaultOpen}
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <div className="rounded-lg border bg-card shadow-sm">
+        <CollapsibleTrigger className="flex w-full items-center justify-between px-6 py-4 hover:bg-muted/50 transition-colors">
+          <div className="flex items-center gap-2 text-sm font-semibold">
+            {icon}
+            {title}
+            <span className="text-xs font-normal text-muted-foreground">
+              · {count}
+            </span>
+          </div>
+          <Badge
+            variant="outline"
+            className={cn("text-[11px] font-semibold", badgeClass)}
+          >
+            {badgeCount}
+          </Badge>
+        </CollapsibleTrigger>
+        <CollapsibleContent>{children}</CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}
+
+function FailedRunRow({
+  run,
+  suiteName,
+  sparkline,
+}: {
+  run: EvalSuiteRun;
+  suiteName: string;
+  sparkline: Array<{ passRate: number; isCurrent: boolean }>;
+}) {
+  const duration = getRunDuration(run);
+  const passRate = run.summary
+    ? Math.round(
+        (run.summary.passed / Math.max(run.summary.total, 1)) * 100,
+      )
+    : 0;
+
+  return (
+    <div className="border-t px-6 py-4">
+      <div className="flex items-center gap-2.5 mb-3">
+        <XCircle className="h-4 w-4 shrink-0 text-destructive" />
+        <button
+          onClick={() =>
+            navigateToCiEvalsRoute({
+              type: "run-detail",
+              suiteId: run.suiteId,
+              runId: run._id,
+            })
+          }
+          className="text-sm font-semibold hover:underline"
+        >
+          {suiteName}
+        </button>
+        <span className="ml-auto text-xs text-muted-foreground font-mono">
+          {run.summary?.passed ?? 0}/{run.summary?.total ?? 0} · {passRate}%
+        </span>
+      </div>
+
+      {/* Per-case summary with expected vs got hints */}
+      {run.configSnapshot?.tests && (
+        <div className="ml-6 space-y-0">
+          {run.configSnapshot.tests.map((test, idx) => (
+            <div
+              key={idx}
+              className="flex items-start gap-3 py-2 border-b border-dashed border-border/50 last:border-0 text-xs"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-1.5">
+                  <span className="font-medium text-foreground truncate">
+                    {test.title}
+                  </span>
+                </div>
+                {/* Show expected tool calls as a mini diff hint */}
+                {test.expectedToolCalls && test.expectedToolCalls.length > 0 && (
+                  <div className="mt-1 font-mono text-[11px] text-muted-foreground">
+                    expected:{" "}
+                    <span className="text-emerald-500">
+                      {test.expectedToolCalls.map((tc) => tc.toolName).join(", ")}
+                    </span>
+                  </div>
+                )}
+                {test.isNegativeTest && (
+                  <div className="mt-1 font-mono text-[11px] text-muted-foreground">
+                    expected: <span className="text-emerald-500">no tool calls</span>
+                    {test.scenario && (
+                      <span className="ml-1 text-muted-foreground/70">
+                        ({test.scenario})
+                      </span>
+                    )}
+                  </div>
+                )}
+              </div>
+              {duration !== null && (
+                <span className="font-mono text-muted-foreground shrink-0 pt-0.5">
+                  {formatDuration(duration / Math.max(run.configSnapshot.tests.length, 1))}
+                </span>
+              )}
+              <div className="flex gap-1 shrink-0 pt-0.5">
+                <button
+                  onClick={() =>
+                    navigateToCiEvalsRoute({
+                      type: "run-detail",
+                      suiteId: run.suiteId,
+                      runId: run._id,
+                    })
+                  }
+                  className="rounded-full border px-2.5 py-0.5 text-[10px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                >
+                  View
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Sparkline history */}
+      {sparkline.length > 1 && (
+        <div className="ml-6 mt-3 pt-3 border-t border-border/30">
+          <div className="text-[10px] uppercase tracking-wider text-muted-foreground font-medium mb-1.5">
+            Last {sparkline.length} runs
+          </div>
+          <div className="flex items-end gap-[3px] h-7">
+            {sparkline.map((point, i) => (
+              <div
+                key={i}
+                className={cn(
+                  "w-[18px] rounded-t-sm transition-all",
+                  point.passRate === 100
+                    ? "bg-emerald-500/30"
+                    : "bg-destructive/40",
+                  point.isCurrent &&
+                    "ring-2 ring-foreground ring-offset-1 ring-offset-background rounded-sm opacity-100",
+                  point.isCurrent && point.passRate === 100
+                    ? "bg-emerald-500"
+                    : point.isCurrent
+                      ? "bg-destructive"
+                      : "",
+                )}
+                style={{
+                  height: `${Math.max(3, (point.passRate / 100) * 28)}px`,
+                }}
+                title={`${point.passRate}% pass rate${point.isCurrent ? " (current)" : ""}`}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RunRow({
+  run,
+  suiteName,
+  variant,
+}: {
+  run: EvalSuiteRun;
+  suiteName: string;
+  variant: "passed" | "running" | "notrun";
+}) {
+  const duration = getRunDuration(run);
+  const passRate = run.summary
+    ? Math.round(
+        (run.summary.passed / Math.max(run.summary.total, 1)) * 100,
+      )
+    : 0;
+
+  const icon =
+    variant === "passed" ? (
+      <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" />
+    ) : variant === "running" ? (
+      <Clock className="h-4 w-4 shrink-0 text-amber-500 animate-pulse" />
+    ) : (
+      <MinusCircle className="h-4 w-4 shrink-0 text-muted-foreground" />
+    );
+
+  return (
+    <button
+      onClick={() =>
+        navigateToCiEvalsRoute({
+          type: "run-detail",
+          suiteId: run.suiteId,
+          runId: run._id,
+        })
+      }
+      className="flex w-full items-center gap-3 border-t px-6 py-3.5 text-left hover:bg-muted/50 transition-colors"
+    >
+      {icon}
+      <span className="flex-1 text-sm font-medium truncate">{suiteName}</span>
+      {variant === "passed" && run.summary && (
+        <span className="text-xs font-medium text-emerald-500 font-mono tabular-nums">
+          {passRate}% · {run.summary.passed}/{run.summary.total}
+        </span>
+      )}
+      {variant === "running" && (
+        <span className="text-xs text-amber-500 font-medium">In progress...</span>
+      )}
+      {variant === "notrun" && (
+        <Badge
+          variant="outline"
+          className="text-[10px] bg-amber-50 text-amber-600 border-amber-200 dark:bg-amber-950/50"
+        >
+          {run.result === "cancelled" ? "Cancelled" : "Skipped"}
+        </Badge>
+      )}
+      {duration !== null && variant !== "running" && (
+        <span className="text-xs font-mono text-muted-foreground tabular-nums">
+          {formatDuration(duration)}
+        </span>
+      )}
+      <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+    </button>
+  );
+}
+
+function EnvCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="border-b border-r border-border/50 px-6 py-3 last:border-r-0 [&:nth-child(even)]:border-r-0 [&:nth-last-child(-n+2)]:border-b-0">
+      <div className="text-[9px] uppercase tracking-wider text-muted-foreground font-semibold mb-0.5">
+        {label}
+      </div>
+      <div className="text-xs font-mono font-medium truncate">{value}</div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/commit-list-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/commit-list-sidebar.tsx
@@ -1,0 +1,148 @@
+import { GitBranch, GitCommit } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { CommitGroup } from "./types";
+import { formatRelativeTime } from "./helpers";
+
+interface CommitListSidebarProps {
+  commitGroups: CommitGroup[];
+  selectedCommitSha: string | null;
+  onSelectCommit: (commitSha: string) => void;
+  isLoading?: boolean;
+}
+
+function getCommitStatusInfo(group: CommitGroup): {
+  dotClass: string;
+  labelClass: string;
+  label: string;
+} {
+  switch (group.status) {
+    case "passed":
+      return {
+        dotClass: "bg-emerald-500",
+        labelClass: "text-emerald-500",
+        label: "Passed",
+      };
+    case "failed":
+      return {
+        dotClass: "bg-destructive",
+        labelClass: "text-destructive",
+        label: "Failed",
+      };
+    case "running":
+      return {
+        dotClass: "bg-warning animate-pulse",
+        labelClass: "text-warning",
+        label: "Running",
+      };
+    case "mixed":
+      return {
+        dotClass: "bg-amber-500",
+        labelClass: "text-amber-500",
+        label: "Mixed",
+      };
+  }
+}
+
+export function CommitListSidebar({
+  commitGroups,
+  selectedCommitSha,
+  onSelectCommit,
+  isLoading = false,
+}: CommitListSidebarProps) {
+  return (
+    <div className="flex-1 overflow-y-auto">
+      {isLoading ? (
+        <div className="p-4 text-center text-xs text-muted-foreground">
+          Loading runs...
+        </div>
+      ) : commitGroups.length === 0 ? (
+        <div className="p-4 text-center text-xs text-muted-foreground">
+          No runs found.
+        </div>
+      ) : (
+        <div>
+          {commitGroups.map((group) => {
+            const status = getCommitStatusInfo(group);
+            const isManual = group.commitSha === "manual";
+
+            return (
+              <button
+                key={group.commitSha}
+                onClick={() => onSelectCommit(group.commitSha)}
+                className={cn(
+                  "w-full px-4 py-2.5 text-left transition-colors hover:bg-accent/50",
+                  selectedCommitSha === group.commitSha && "bg-accent",
+                )}
+              >
+                <div className="flex items-center gap-2.5">
+                  <div className="flex flex-col items-center gap-0.5 shrink-0 w-[3.25rem]">
+                    <div
+                      className={cn("h-2 w-2 rounded-full", status.dotClass)}
+                    />
+                    <span
+                      className={cn(
+                        "text-[9px] font-medium leading-none",
+                        status.labelClass,
+                      )}
+                    >
+                      {status.label}
+                    </span>
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-1.5">
+                      {isManual ? (
+                        <span className="text-sm font-medium text-muted-foreground">
+                          Manual Runs
+                        </span>
+                      ) : (
+                        <>
+                          <GitCommit className="h-3 w-3 shrink-0 text-muted-foreground" />
+                          <span className="text-sm font-mono font-medium truncate">
+                            {group.shortSha}
+                          </span>
+                        </>
+                      )}
+                    </div>
+                    {group.branch && (
+                      <div className="flex items-center gap-1 mt-0.5">
+                        <GitBranch className="h-3 w-3 shrink-0 text-muted-foreground" />
+                        <span className="text-[11px] text-muted-foreground truncate">
+                          {group.branch}
+                        </span>
+                      </div>
+                    )}
+                    <div className="flex items-center gap-2 mt-0.5">
+                      <span className="text-[11px] text-muted-foreground">
+                        {formatRelativeTime(group.timestamp)}
+                      </span>
+                      <span className="text-[10px] text-muted-foreground tabular-nums">
+                        {group.summary.passed > 0 && (
+                          <span className="text-emerald-500">
+                            {group.summary.passed}✓
+                          </span>
+                        )}
+                        {group.summary.failed > 0 && (
+                          <span className="text-destructive ml-1">
+                            {group.summary.failed}✕
+                          </span>
+                        )}
+                        {group.summary.running > 0 && (
+                          <span className="text-warning ml-1">
+                            {group.summary.running}⟳
+                          </span>
+                        )}
+                      </span>
+                    </div>
+                  </div>
+                  <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
+                    {group.summary.total} run{group.summary.total !== 1 ? "s" : ""}
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/helpers.ts
@@ -1,8 +1,10 @@
 import {
+  CommitGroup,
   EvalCase,
   EvalIteration,
   EvalSuite,
   EvalSuiteOverviewEntry,
+  EvalSuiteRun,
   SuiteAggregate,
   TagGroupAggregate,
 } from "./types";
@@ -233,6 +235,88 @@ export const formatters = {
   percentage: formatPercentage,
   tokens: formatTokens,
 } as const;
+
+/**
+ * Flatten recentRuns across all suites and group by commitSha.
+ * Runs without a commitSha go into a "manual" group.
+ */
+export function groupRunsByCommit(
+  overview: EvalSuiteOverviewEntry[],
+): CommitGroup[] {
+  const buckets = new Map<string, { runs: EvalSuiteRun[]; suiteMap: Map<string, string> }>();
+
+  for (const entry of overview) {
+    for (const run of entry.recentRuns) {
+      const sha = run.ciMetadata?.commitSha?.trim() || "__manual__";
+      if (!buckets.has(sha)) {
+        buckets.set(sha, { runs: [], suiteMap: new Map() });
+      }
+      const bucket = buckets.get(sha)!;
+      bucket.runs.push(run);
+      bucket.suiteMap.set(entry.suite._id, entry.suite.name);
+    }
+  }
+
+  const groups: CommitGroup[] = [];
+  for (const [sha, { runs, suiteMap }] of buckets) {
+    const isManual = sha === "__manual__";
+    const summary = { total: runs.length, passed: 0, failed: 0, running: 0 };
+    let latestTimestamp = 0;
+    let branch: string | null = null;
+
+    for (const run of runs) {
+      const ts = run.completedAt ?? run.createdAt;
+      if (ts > latestTimestamp) latestTimestamp = ts;
+      if (!branch && run.ciMetadata?.branch) branch = run.ciMetadata.branch;
+      if (run.status === "running" || run.status === "pending") summary.running++;
+      else if (run.result === "passed") summary.passed++;
+      else if (run.result === "failed") summary.failed++;
+    }
+
+    let status: CommitGroup["status"];
+    if (summary.running > 0) status = "running";
+    else if (summary.failed > 0 && summary.passed > 0) status = "mixed";
+    else if (summary.failed > 0) status = "failed";
+    else status = "passed";
+
+    groups.push({
+      commitSha: isManual ? "manual" : sha,
+      shortSha: isManual ? "Manual" : sha.slice(0, 7),
+      branch: isManual ? null : branch,
+      timestamp: latestTimestamp,
+      status,
+      runs,
+      suiteMap,
+      summary,
+    });
+  }
+
+  // Sort by most recent first, manual always last
+  groups.sort((a, b) => {
+    if (a.commitSha === "manual") return 1;
+    if (b.commitSha === "manual") return -1;
+    return b.timestamp - a.timestamp;
+  });
+
+  return groups;
+}
+
+/**
+ * Format relative time for sidebar display
+ */
+export function formatRelativeTime(timestamp?: number): string {
+  if (!timestamp) return "No runs yet";
+  const now = Date.now();
+  const diff = now - timestamp;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "Just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(timestamp).toLocaleDateString();
+}
 
 /**
  * Group overview entries by tag and compute aggregated stats per tag.

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -193,3 +193,14 @@ export type TagGroupAggregate = {
   passRate: number; // 0-100
   entries: EvalSuiteOverviewEntry[];
 };
+
+export type CommitGroup = {
+  commitSha: string;
+  shortSha: string; // first 7 chars
+  branch: string | null;
+  timestamp: number; // most recent run time
+  status: "passed" | "failed" | "running" | "mixed";
+  runs: EvalSuiteRun[];
+  suiteMap: Map<string, string>; // suiteId → suite name
+  summary: { total: number; passed: number; failed: number; running: number };
+};

--- a/mcpjam-inspector/client/src/lib/__tests__/ci-evals-router.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/ci-evals-router.test.ts
@@ -53,6 +53,22 @@ describe("ci-evals-router", () => {
     );
   });
 
+  it("parses commit detail route", () => {
+    window.location.hash = "#/ci-evals/commit/abc1234567890";
+    expect(parseCiEvalsRoute()).toEqual({
+      type: "commit-detail",
+      commitSha: "abc1234567890",
+    });
+  });
+
+  it("navigates to commit detail route", () => {
+    navigateToCiEvalsRoute({
+      type: "commit-detail",
+      commitSha: "abc1234567890",
+    });
+    expect(window.location.hash).toBe("#/ci-evals/commit/abc1234567890");
+  });
+
   it("returns null outside ci-evals routes", () => {
     window.location.hash = "#/evals";
     expect(parseCiEvalsRoute()).toBeNull();

--- a/mcpjam-inspector/client/src/lib/ci-evals-router.ts
+++ b/mcpjam-inspector/client/src/lib/ci-evals-router.ts
@@ -17,7 +17,8 @@ export type CiEvalsRoute =
       suiteId: string;
       testId: string;
       iteration?: string;
-    };
+    }
+  | { type: "commit-detail"; commitSha: string };
 
 /**
  * Parse the current hash to extract CI evals route information.
@@ -33,6 +34,11 @@ export function parseCiEvalsRoute(): CiEvalsRoute | null {
 
   if (path === "/ci-evals") {
     return { type: "list" };
+  }
+
+  const commitMatch = path.match(/^\/ci-evals\/commit\/([^/]+)$/);
+  if (commitMatch) {
+    return { type: "commit-detail", commitSha: decodeURIComponent(commitMatch[1]) };
   }
 
   const suiteMatch = path.match(/^\/ci-evals\/suite\/([^/]+)(?:\/(.*))?$/);
@@ -117,6 +123,9 @@ export function navigateToCiEvalsRoute(
       hash = `#/ci-evals/suite/${route.suiteId}/test/${route.testId}${query ? `?${query}` : ""}`;
       break;
     }
+    case "commit-detail":
+      hash = `#/ci-evals/commit/${encodeURIComponent(route.commitSha)}`;
+      break;
   }
 
   if (options?.replace) {


### PR DESCRIPTION
### TL;DR

Added a new commit-based view to the CI evals interface that groups test runs by Git commit SHA, providing better visibility into test results across different code changes.

- Added a new "Runs by commit" sidebar mode alongside the existing "Suites" view
- Created `CommitDetailView` component that displays comprehensive test results for a specific commit including:
  - Overall pass rate with visual progress bar
  - AI-powered triage summary for failures
  - Categorized sections for failed, passed, running, and not-run tests
  - Environment configuration details
  - Comparison functionality between commits
- Implemented `groupRunsByCommit` helper function to organize test runs by commit SHA
- Added new routing support for `/ci-evals/commit/{sha}` URLs
- Created `CommitListSidebar` component for navigating between commits
- Added comprehensive test coverage for the new grouping logic
- Quickly identify which commits introduced test failures
- Compare test results between different code versions
- Get AI-powered insights into failure patterns
- Better understand the relationship between code changes and test outcomes