### PR TITLE
Frontend AI triage insights

### DIFF
--- a/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
@@ -36,7 +36,7 @@ export function CiEvalsTab({ convexWorkspaceId }: CiEvalsTabProps) {
   const [deletingSuiteId, setDeletingSuiteId] = useState<string | null>(null);
   const [deletingRunId, setDeletingRunId] = useState<string | null>(null);
   const [filterTag, setFilterTag] = useState<string | null>(null);
-  const [sidebarMode, setSidebarMode] = useState<SidebarMode>("suites");
+  const [sidebarMode, setSidebarMode] = useState<SidebarMode>("runs");
 
   const selectedSuiteId =
     route.type === "suite-overview" ||
@@ -331,6 +331,7 @@ export function CiEvalsTab({ convexWorkspaceId }: CiEvalsTabProps) {
                 const entry = sdkSuites.find((e) => e.suite._id === suiteId);
                 if (entry) handlers.handleRerun(entry.suite);
               }}
+              allCommitGroups={commitGroups}
             />
           ) : queries.isSuiteDetailsLoading ? (
             <div className="flex h-full items-center justify-center">

--- a/mcpjam-inspector/client/src/components/evals/__tests__/ai-insights.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/ai-insights.test.ts
@@ -1,0 +1,442 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyFailure,
+  getSuiteHistory,
+  isFlaky,
+  classifyAllFailures,
+  buildTriageContext,
+  buildOverviewTriageContext,
+} from "../ai-insights";
+import type { EvalSuiteRun, CommitGroup } from "../types";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeRun(
+  overrides: Partial<EvalSuiteRun> & { suiteId: string },
+): EvalSuiteRun {
+  return {
+    _id: `run-${Math.random().toString(36).slice(2, 8)}`,
+    createdBy: "user",
+    runNumber: 1,
+    configRevision: "rev1",
+    configSnapshot: { tests: [], environment: { servers: [] } },
+    status: "completed",
+    result: "failed",
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeCommitGroup(
+  overrides: Partial<CommitGroup> & { runs: EvalSuiteRun[] },
+): CommitGroup {
+  return {
+    commitSha: `sha-${Math.random().toString(36).slice(2, 8)}`,
+    shortSha: "abc1234",
+    branch: "main",
+    timestamp: Date.now(),
+    status: "failed",
+    suiteMap: new Map(),
+    summary: { total: 0, passed: 0, failed: 0, running: 0 },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// getSuiteHistory
+// ---------------------------------------------------------------------------
+
+describe("getSuiteHistory", () => {
+  it("returns results for a suite across commit groups (newest first)", () => {
+    const suiteId = "suite-1";
+    const groups: CommitGroup[] = [
+      makeCommitGroup({
+        runs: [makeRun({ suiteId, result: "failed" })],
+      }),
+      makeCommitGroup({
+        runs: [makeRun({ suiteId, result: "passed" })],
+      }),
+      makeCommitGroup({
+        runs: [makeRun({ suiteId, result: "passed" })],
+      }),
+    ];
+
+    const history = getSuiteHistory(suiteId, groups);
+    expect(history).toEqual(["failed", "passed", "passed"]);
+  });
+
+  it("returns empty array when suite has no runs in any group", () => {
+    const groups: CommitGroup[] = [
+      makeCommitGroup({
+        runs: [makeRun({ suiteId: "other-suite", result: "passed" })],
+      }),
+    ];
+
+    expect(getSuiteHistory("nonexistent", groups)).toEqual([]);
+  });
+
+  it("maps non-pass/fail results to 'other'", () => {
+    const suiteId = "suite-1";
+    const groups: CommitGroup[] = [
+      makeCommitGroup({
+        runs: [makeRun({ suiteId, result: "cancelled" })],
+      }),
+      makeCommitGroup({
+        runs: [makeRun({ suiteId, result: "pending" })],
+      }),
+    ];
+
+    const history = getSuiteHistory(suiteId, groups);
+    expect(history).toEqual(["other", "other"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isFlaky
+// ---------------------------------------------------------------------------
+
+describe("isFlaky", () => {
+  it("returns false for fewer than 3 definitive results", () => {
+    expect(isFlaky(["passed", "failed"])).toBe(false);
+    expect(isFlaky(["passed"])).toBe(false);
+    expect(isFlaky([])).toBe(false);
+  });
+
+  it("returns false for consistent pass history", () => {
+    expect(isFlaky(["passed", "passed", "passed", "passed"])).toBe(false);
+  });
+
+  it("returns false for consistent fail history", () => {
+    expect(isFlaky(["failed", "failed", "failed", "failed"])).toBe(false);
+  });
+
+  it("returns false for single switch (not enough flakiness)", () => {
+    // One switch: passed → failed
+    expect(isFlaky(["failed", "failed", "passed", "passed"])).toBe(false);
+  });
+
+  it("returns true for alternating pass/fail (2+ switches)", () => {
+    // failed→passed→failed = 2 switches
+    expect(isFlaky(["failed", "passed", "failed", "passed"])).toBe(true);
+  });
+
+  it("returns true for frequent alternation", () => {
+    expect(
+      isFlaky(["passed", "failed", "passed", "failed", "passed"]),
+    ).toBe(true);
+  });
+
+  it("ignores 'other' results when counting switches", () => {
+    // After filtering: passed, failed, passed = 2 switches
+    expect(
+      isFlaky(["passed", "other", "failed", "other", "passed"]),
+    ).toBe(true);
+  });
+
+  it("only looks at first 10 entries", () => {
+    // 12 entries, but only first 10 are considered
+    const history: Array<"passed" | "failed" | "other"> = [
+      "passed",
+      "passed",
+      "passed",
+      "passed",
+      "passed",
+      "passed",
+      "passed",
+      "passed",
+      "passed",
+      "passed",
+      "failed",
+      "passed", // these are beyond the 10-entry window
+    ];
+    expect(isFlaky(history)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyFailure
+// ---------------------------------------------------------------------------
+
+describe("classifyFailure", () => {
+  it("tags as 'new' when there is no prior history", () => {
+    const suiteId = "suite-new";
+    const run = makeRun({ suiteId, result: "failed" });
+    const groups: CommitGroup[] = [
+      makeCommitGroup({ runs: [run] }),
+    ];
+
+    const result = classifyFailure(run, "New Suite", groups);
+    expect(result.tags).toContain("new");
+    expect(result.suiteName).toBe("New Suite");
+  });
+
+  it("tags as 'regression' when previous run was passing", () => {
+    const suiteId = "suite-reg";
+    const failedRun = makeRun({ suiteId, result: "failed" });
+    const groups: CommitGroup[] = [
+      makeCommitGroup({ runs: [failedRun] }), // current (newest)
+      makeCommitGroup({
+        runs: [makeRun({ suiteId, result: "passed" })],
+      }), // previous
+    ];
+
+    const result = classifyFailure(failedRun, "Regression Suite", groups);
+    expect(result.tags).toContain("regression");
+    expect(result.tags).not.toContain("new");
+  });
+
+  it("does NOT tag as regression when previous run was also failing", () => {
+    const suiteId = "suite-still-fail";
+    const failedRun = makeRun({ suiteId, result: "failed" });
+    const groups: CommitGroup[] = [
+      makeCommitGroup({ runs: [failedRun] }),
+      makeCommitGroup({
+        runs: [makeRun({ suiteId, result: "failed" })],
+      }),
+    ];
+
+    const result = classifyFailure(failedRun, "Still Failing", groups);
+    expect(result.tags).not.toContain("regression");
+    expect(result.tags).not.toContain("new");
+  });
+
+  it("tags as both 'regression' and 'flaky' when history shows alternation", () => {
+    const suiteId = "suite-flaky-reg";
+    const failedRun = makeRun({ suiteId, result: "failed" });
+    const groups: CommitGroup[] = [
+      makeCommitGroup({ runs: [failedRun] }), // failed (current)
+      makeCommitGroup({
+        runs: [makeRun({ suiteId, result: "passed" })],
+      }),
+      makeCommitGroup({
+        runs: [makeRun({ suiteId, result: "failed" })],
+      }),
+      makeCommitGroup({
+        runs: [makeRun({ suiteId, result: "passed" })],
+      }),
+    ];
+
+    const result = classifyFailure(
+      failedRun,
+      "Flaky Regression",
+      groups,
+    );
+    expect(result.tags).toContain("regression");
+    expect(result.tags).toContain("flaky");
+  });
+
+  it("tags as 'flaky' without 'regression' when previous was also failing but history alternates", () => {
+    const suiteId = "suite-flaky-nreg";
+    const failedRun = makeRun({ suiteId, result: "failed" });
+    const groups: CommitGroup[] = [
+      makeCommitGroup({ runs: [failedRun] }), // failed (current)
+      makeCommitGroup({
+        runs: [makeRun({ suiteId, result: "failed" })],
+      }),
+      makeCommitGroup({
+        runs: [makeRun({ suiteId, result: "passed" })],
+      }),
+      makeCommitGroup({
+        runs: [makeRun({ suiteId, result: "failed" })],
+      }),
+      makeCommitGroup({
+        runs: [makeRun({ suiteId, result: "passed" })],
+      }),
+    ];
+
+    const result = classifyFailure(failedRun, "Flaky Only", groups);
+    expect(result.tags).not.toContain("regression");
+    expect(result.tags).toContain("flaky");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyAllFailures
+// ---------------------------------------------------------------------------
+
+describe("classifyAllFailures", () => {
+  it("classifies multiple failures with correct suite names", () => {
+    const run1 = makeRun({ suiteId: "s1", result: "failed" });
+    const run2 = makeRun({ suiteId: "s2", result: "failed" });
+
+    const suiteMap = new Map([
+      ["s1", "Suite A"],
+      ["s2", "Suite B"],
+    ]);
+
+    const groups: CommitGroup[] = [
+      makeCommitGroup({ runs: [run1, run2], suiteMap }),
+    ];
+
+    const results = classifyAllFailures([run1, run2], suiteMap, groups);
+    expect(results).toHaveLength(2);
+    expect(results[0].suiteName).toBe("Suite A");
+    expect(results[1].suiteName).toBe("Suite B");
+    // Both are new (only one commit group)
+    expect(results[0].tags).toContain("new");
+    expect(results[1].tags).toContain("new");
+  });
+
+  it("uses 'Unknown suite' for unmapped suite IDs", () => {
+    const run = makeRun({ suiteId: "unknown-id", result: "failed" });
+    const groups: CommitGroup[] = [makeCommitGroup({ runs: [run] })];
+
+    const results = classifyAllFailures([run], new Map(), groups);
+    expect(results[0].suiteName).toBe("Unknown suite");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTriageContext
+// ---------------------------------------------------------------------------
+
+describe("buildTriageContext", () => {
+  it("builds context with correct aggregated data", () => {
+    const failedRun = makeRun({
+      suiteId: "s1",
+      result: "failed",
+      summary: { total: 10, passed: 7, failed: 3, passRate: 70 },
+      configSnapshot: {
+        tests: [
+          {
+            title: "test-a",
+            query: "q",
+            provider: "p",
+            model: "m",
+            runs: 1,
+            expectedToolCalls: [],
+          },
+          {
+            title: "test-b",
+            query: "q",
+            provider: "p",
+            model: "m",
+            runs: 1,
+            expectedToolCalls: [],
+          },
+        ],
+        environment: { servers: [] },
+      },
+    });
+    const passedRun = makeRun({
+      suiteId: "s2",
+      result: "passed",
+      summary: { total: 5, passed: 5, failed: 0, passRate: 100 },
+    });
+    const notRunRun = makeRun({
+      suiteId: "s3",
+      result: "cancelled",
+    });
+
+    const suiteMap = new Map([
+      ["s1", "Failed Suite"],
+      ["s2", "Passed Suite"],
+      ["s3", "Not Run Suite"],
+    ]);
+
+    const commitGroup = makeCommitGroup({
+      commitSha: "abc123",
+      shortSha: "abc1234",
+      branch: "main",
+      runs: [failedRun, passedRun, notRunRun],
+      suiteMap,
+    });
+
+    const classified = [
+      {
+        run: failedRun,
+        suiteName: "Failed Suite",
+        tags: ["regression" as const],
+      },
+    ];
+
+    const ctx = buildTriageContext(
+      commitGroup,
+      classified,
+      [passedRun],
+      [notRunRun],
+    );
+
+    expect(ctx.commitSha).toBe("abc1234");
+    expect(ctx.branch).toBe("main");
+    expect(ctx.totalSuites).toBe(3);
+    expect(ctx.totalCases.total).toBe(15);
+    expect(ctx.totalCases.passed).toBe(12);
+    expect(ctx.totalCases.failed).toBe(3);
+    expect(ctx.failures).toHaveLength(1);
+    expect(ctx.failures[0].suiteName).toBe("Failed Suite");
+    expect(ctx.failures[0].tags).toEqual(["regression"]);
+    expect(ctx.failures[0].testNames).toEqual(["test-a", "test-b"]);
+    expect(ctx.passedSuites).toEqual(["Passed Suite"]);
+    expect(ctx.notRunSuites).toEqual(["Not Run Suite"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildOverviewTriageContext
+// ---------------------------------------------------------------------------
+
+describe("buildOverviewTriageContext", () => {
+  it("categorizes suites correctly", () => {
+    const suites = [
+      {
+        suite: { _id: "s1", name: "Failing Suite" } as any,
+        latestRun: makeRun({ suiteId: "s1", result: "failed" }),
+        recentRuns: [],
+        passRateTrend: [],
+        totals: { passed: 3, failed: 2, runs: 5 },
+      },
+      {
+        suite: { _id: "s2", name: "Passing Suite" } as any,
+        latestRun: makeRun({ suiteId: "s2", result: "passed" }),
+        recentRuns: [],
+        passRateTrend: [],
+        totals: { passed: 10, failed: 0, runs: 10 },
+      },
+      {
+        suite: { _id: "s3", name: "New Suite" } as any,
+        latestRun: null,
+        recentRuns: [],
+        passRateTrend: [],
+        totals: { passed: 0, failed: 0, runs: 0 },
+      },
+    ];
+
+    const ctx = buildOverviewTriageContext(suites, []);
+    expect(ctx.totalSuites).toBe(3);
+    expect(ctx.passingSuites).toBe(1);
+    expect(ctx.neverRunSuites).toBe(1);
+    expect(ctx.failingSuites).toHaveLength(1);
+    expect(ctx.failingSuites[0].name).toBe("Failing Suite");
+    expect(ctx.failingSuites[0].passRate).toBe("60%");
+  });
+
+  it("includes suites that passed overall but have failed cases", () => {
+    const suites = [
+      {
+        suite: { _id: "s1", name: "Mostly Passing Suite" } as any,
+        latestRun: makeRun({ suiteId: "s1", result: "passed" }),
+        recentRuns: [],
+        passRateTrend: [],
+        totals: { passed: 14, failed: 2, runs: 16 },
+      },
+      {
+        suite: { _id: "s2", name: "Fully Passing Suite" } as any,
+        latestRun: makeRun({ suiteId: "s2", result: "passed" }),
+        recentRuns: [],
+        passRateTrend: [],
+        totals: { passed: 10, failed: 0, runs: 10 },
+      },
+    ];
+
+    const ctx = buildOverviewTriageContext(suites, []);
+    expect(ctx.totalSuites).toBe(2);
+    expect(ctx.passingSuites).toBe(1);
+    expect(ctx.failingSuites).toHaveLength(1);
+    expect(ctx.failingSuites[0].name).toBe("Mostly Passing Suite");
+    expect(ctx.failingSuites[0].passRate).toBe("88%");
+    expect(ctx.failingSuites[0].failedCases).toBe(2);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/ai-insights.ts
+++ b/mcpjam-inspector/client/src/components/evals/ai-insights.ts
@@ -1,0 +1,241 @@
+import type { EvalSuiteOverviewEntry, EvalSuiteRun, CommitGroup } from "./types";
+
+// ---------------------------------------------------------------------------
+// Failure Classification
+// ---------------------------------------------------------------------------
+
+export type FailureTag = "regression" | "flaky" | "new";
+
+export interface ClassifiedFailure {
+  run: EvalSuiteRun;
+  suiteName: string;
+  tags: FailureTag[];
+}
+
+/**
+ * Classify a failed run by examining its history across recent commits.
+ *
+ * - "regression": suite was passing in a previous commit and is now failing
+ * - "flaky": suite has alternated between pass/fail in recent history
+ * - "new": this is the first time this suite has been run (no prior history)
+ */
+export function classifyFailure(
+  run: EvalSuiteRun,
+  suiteName: string,
+  allCommitGroups: CommitGroup[],
+): ClassifiedFailure {
+  const tags: FailureTag[] = [];
+
+  // Collect history for this suite across commit groups (newest-first order)
+  const history = getSuiteHistory(run.suiteId, allCommitGroups);
+
+  if (history.length <= 1) {
+    // No prior runs — this is a new suite
+    tags.push("new");
+  } else {
+    // history[0] is the current run's commit group (newest)
+    // Check if the immediately previous run was passing
+    const previousResult = history[1];
+    if (previousResult === "passed") {
+      tags.push("regression");
+    }
+
+    // Check for flakiness: alternating pass/fail in recent history
+    if (isFlaky(history)) {
+      tags.push("flaky");
+    }
+  }
+
+  return { run, suiteName, tags };
+}
+
+/**
+ * Get the result history of a suite across commit groups.
+ * Returns an array of results from newest to oldest.
+ */
+export function getSuiteHistory(
+  suiteId: string,
+  allCommitGroups: CommitGroup[],
+): Array<"passed" | "failed" | "other"> {
+  const results: Array<"passed" | "failed" | "other"> = [];
+
+  for (const group of allCommitGroups) {
+    const run = group.runs.find((r) => r.suiteId === suiteId);
+    if (run) {
+      if (run.result === "passed") results.push("passed");
+      else if (run.result === "failed") results.push("failed");
+      else results.push("other");
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Determine if a suite is flaky based on its result history.
+ * A suite is flaky if it has switched between pass and fail
+ * at least 2 times in the recent history (up to last 10 runs).
+ */
+export function isFlaky(
+  history: Array<"passed" | "failed" | "other">,
+): boolean {
+  // Filter to only definitive results
+  const definitive = history
+    .slice(0, 10)
+    .filter((r) => r === "passed" || r === "failed");
+
+  if (definitive.length < 3) return false;
+
+  let switches = 0;
+  for (let i = 1; i < definitive.length; i++) {
+    if (definitive[i] !== definitive[i - 1]) {
+      switches++;
+    }
+  }
+
+  return switches >= 2;
+}
+
+/**
+ * Classify all failed runs in a commit group.
+ */
+export function classifyAllFailures(
+  failedRuns: EvalSuiteRun[],
+  suiteMap: Map<string, string>,
+  allCommitGroups: CommitGroup[],
+): ClassifiedFailure[] {
+  return failedRuns.map((run) => {
+    const suiteName = suiteMap.get(run.suiteId) || "Unknown suite";
+    return classifyFailure(run, suiteName, allCommitGroups);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// AI Triage Data Preparation
+// ---------------------------------------------------------------------------
+
+export interface TriageContext {
+  commitSha: string;
+  branch: string | null;
+  totalSuites: number;
+  totalCases: { total: number; passed: number; failed: number };
+  failures: Array<{
+    suiteName: string;
+    tags: FailureTag[];
+    failedCases: number;
+    totalCases: number;
+    passRate: number;
+    testNames: string[];
+  }>;
+  passedSuites: string[];
+  notRunSuites: string[];
+}
+
+/**
+ * Build context object for the LLM triage prompt.
+ */
+export function buildTriageContext(
+  commitGroup: CommitGroup,
+  classifiedFailures: ClassifiedFailure[],
+  passedRuns: EvalSuiteRun[],
+  notRunRuns: EvalSuiteRun[],
+): TriageContext {
+  const totalCases = { total: 0, passed: 0, failed: 0 };
+  for (const run of commitGroup.runs) {
+    if (run.summary) {
+      totalCases.total += run.summary.total;
+      totalCases.passed += run.summary.passed;
+      totalCases.failed += run.summary.failed;
+    }
+  }
+
+  return {
+    commitSha: commitGroup.shortSha,
+    branch: commitGroup.branch,
+    totalSuites: commitGroup.runs.length,
+    totalCases,
+    failures: classifiedFailures.map((cf) => ({
+      suiteName: cf.suiteName,
+      tags: cf.tags,
+      failedCases: cf.run.summary?.failed ?? 0,
+      totalCases: cf.run.summary?.total ?? 0,
+      passRate: cf.run.summary
+        ? Math.round(
+            (cf.run.summary.passed / Math.max(cf.run.summary.total, 1)) * 100,
+          )
+        : 0,
+      testNames:
+        cf.run.configSnapshot?.tests?.map((t) => t.title).filter(Boolean) ?? [],
+    })),
+    passedSuites: passedRuns.map(
+      (r) => commitGroup.suiteMap.get(r.suiteId) || "Unknown",
+    ),
+    notRunSuites: notRunRuns.map(
+      (r) => commitGroup.suiteMap.get(r.suiteId) || "Unknown",
+    ),
+  };
+}
+
+/**
+ * Build context for overview-level AI insights from all suites.
+ */
+export interface OverviewTriageContext {
+  totalSuites: number;
+  failingSuites: Array<{
+    name: string;
+    tags: FailureTag[];
+    passRate: string;
+    failedCases: number;
+    totalCases: number;
+  }>;
+  passingSuites: number;
+  neverRunSuites: number;
+}
+
+export function buildOverviewTriageContext(
+  suites: EvalSuiteOverviewEntry[],
+  allCommitGroups: CommitGroup[],
+): OverviewTriageContext {
+  const failingSuites: OverviewTriageContext["failingSuites"] = [];
+  let passingSuites = 0;
+  let neverRunSuites = 0;
+
+  for (const entry of suites) {
+    if (!entry.latestRun) {
+      neverRunSuites++;
+      continue;
+    }
+    // Include suites that have any failed cases — even if the suite-level
+    // result is "passed" due to pass rate thresholds being met
+    const hasFailedCases = entry.totals.failed > 0;
+    const suiteResultFailed = entry.latestRun.result === "failed";
+
+    if (hasFailedCases || suiteResultFailed) {
+      const classified = classifyFailure(
+        entry.latestRun,
+        entry.suite.name,
+        allCommitGroups,
+      );
+      const total = entry.totals.passed + entry.totals.failed;
+      failingSuites.push({
+        name: entry.suite.name,
+        tags: classified.tags,
+        passRate:
+          total > 0
+            ? `${Math.round((entry.totals.passed / total) * 100)}%`
+            : "--",
+        failedCases: entry.totals.failed,
+        totalCases: total,
+      });
+    } else {
+      passingSuites++;
+    }
+  }
+
+  return {
+    totalSuites: suites.length,
+    failingSuites,
+    passingSuites,
+    neverRunSuites,
+  };
+}

--- a/mcpjam-inspector/client/src/components/evals/ci-suite-list-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/ci-suite-list-sidebar.tsx
@@ -134,17 +134,6 @@ export function CiSuiteListSidebar({
         </div>
         <div className="mt-2 flex rounded-md border bg-muted/50 p-0.5">
           <button
-            onClick={() => onSidebarModeChange("suites")}
-            className={cn(
-              "flex-1 rounded-sm px-3 py-1 text-xs font-medium transition-colors",
-              sidebarMode === "suites"
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-          >
-            Suites
-          </button>
-          <button
             onClick={() => onSidebarModeChange("runs")}
             className={cn(
               "flex-1 rounded-sm px-3 py-1 text-xs font-medium transition-colors",
@@ -155,8 +144,48 @@ export function CiSuiteListSidebar({
           >
             Runs
           </button>
+          <button
+            onClick={() => onSidebarModeChange("suites")}
+            className={cn(
+              "flex-1 rounded-sm px-3 py-1 text-xs font-medium transition-colors",
+              sidebarMode === "suites"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            Suites
+          </button>
         </div>
       </div>
+
+      {/* Overview button — always visible regardless of sidebar mode */}
+      <button
+        onClick={onSelectOverview}
+        className={cn(
+          "w-full px-4 py-2.5 text-left transition-colors hover:bg-accent/50 border-b",
+          isOverviewSelected && "bg-accent",
+        )}
+      >
+        <div className="flex items-center gap-2.5">
+          <BarChart3 className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-medium">Overview</div>
+            <div className="text-[11px] text-muted-foreground">
+              Suite health & status
+            </div>
+          </div>
+          {(() => {
+            const failCount = suites.filter(
+              (e) => e.latestRun?.result === "failed",
+            ).length;
+            return failCount > 0 ? (
+              <span className="shrink-0 flex h-5 min-w-[20px] items-center justify-center rounded-full bg-destructive px-1.5 text-[10px] font-bold text-destructive-foreground">
+                {failCount}
+              </span>
+            ) : null;
+          })()}
+        </div>
+      </button>
 
       {sidebarMode === "runs" ? (
         <CommitListSidebar
@@ -167,35 +196,6 @@ export function CiSuiteListSidebar({
         />
       ) : (
       <div className="flex-1 overflow-y-auto">
-        {hasTags && (
-          <button
-            onClick={onSelectOverview}
-            className={cn(
-              "w-full px-4 py-2.5 text-left transition-colors hover:bg-accent/50 border-b",
-              isOverviewSelected && "bg-accent",
-            )}
-          >
-            <div className="flex items-center gap-2.5">
-              <BarChart3 className="h-4 w-4 shrink-0 text-muted-foreground" />
-              <div className="min-w-0 flex-1">
-                <div className="text-sm font-medium">Overview</div>
-                <div className="text-[11px] text-muted-foreground">
-                  Suite health & status
-                </div>
-              </div>
-              {(() => {
-                const failCount = suites.filter(
-                  (e) => e.latestRun?.result === "failed",
-                ).length;
-                return failCount > 0 ? (
-                  <span className="shrink-0 flex h-5 min-w-[20px] items-center justify-center rounded-full bg-destructive px-1.5 text-[10px] font-bold text-destructive-foreground">
-                    {failCount}
-                  </span>
-                ) : null;
-              })()}
-            </div>
-          </button>
-        )}
         {isLoading ? (
           <div className="p-4 text-center text-xs text-muted-foreground">
             Loading suites...

--- a/mcpjam-inspector/client/src/components/evals/commit-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/commit-detail-view.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import {
   ChevronDown,
   ChevronRight,
@@ -12,6 +12,9 @@ import {
   ExternalLink,
   RotateCcw,
   FileText,
+  Loader2,
+  AlertTriangle,
+  RefreshCw,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
@@ -23,6 +26,12 @@ import {
 import type { CommitGroup, EvalSuiteRun } from "./types";
 import { formatDuration } from "./helpers";
 import { navigateToCiEvalsRoute } from "@/lib/ci-evals-router";
+import {
+  classifyAllFailures,
+  buildTriageContext,
+  type FailureTag,
+} from "./ai-insights";
+import { useCommitAiTriage } from "./use-ai-triage";
 
 interface CommitDetailViewProps {
   commitGroup: CommitGroup;
@@ -176,22 +185,48 @@ export function CommitDetailView({
     };
   }, [commitGroup.runs, models]);
 
-  // Generate triage summary from actual failure data
+  // Runs that have any failed cases — includes suites that "passed" overall
+  // (due to pass rate thresholds) but still have individual case failures
+  const runsWithFailedCases = useMemo(
+    () => commitGroup.runs.filter((r) => (r.summary?.failed ?? 0) > 0),
+    [commitGroup.runs],
+  );
+
+  // Classify failures with regression/flaky/new tags
+  const classifiedFailures = useMemo(
+    () =>
+      classifyAllFailures(runsWithFailedCases, commitGroup.suiteMap, allCommitGroups),
+    [runsWithFailedCases, commitGroup.suiteMap, allCommitGroups],
+  );
+
+  // Build triage context for LLM
+  const triageCtx = useMemo(() => {
+    if (totalCases.failed === 0) return null;
+    return buildTriageContext(commitGroup, classifiedFailures, passed, notRun);
+  }, [commitGroup, classifiedFailures, passed, notRun, totalCases.failed]);
+
+  // AI triage hook
+  const aiTriage = useCommitAiTriage(triageCtx);
+
+  // Auto-generate triage when any failed cases exist
+  useEffect(() => {
+    if (triageCtx && !aiTriage.result && !aiTriage.loading) {
+      aiTriage.generate();
+    }
+  }, [triageCtx, aiTriage.result, aiTriage.loading, aiTriage.generate]);
+
+  // Triage summary — shows when any cases failed
   const triageSummary = useMemo(() => {
-    if (failed.length === 0) return null;
-    const failedSuiteNames = failed.map(
+    if (totalCases.failed === 0) return null;
+    const suiteNames = runsWithFailedCases.map(
       (r) => commitGroup.suiteMap.get(r.suiteId) || "Unknown suite",
     );
-    const totalFailedCases = failed.reduce(
-      (sum, r) => sum + (r.summary?.failed ?? 0),
-      0,
-    );
     return {
-      failCount: failed.length,
-      failedSuiteNames,
-      totalFailedCases,
+      failCount: runsWithFailedCases.length,
+      failedSuiteNames: suiteNames,
+      totalFailedCases: totalCases.failed,
     };
-  }, [failed, commitGroup.suiteMap]);
+  }, [runsWithFailedCases, commitGroup.suiteMap, totalCases.failed]);
 
   return (
     <div className="flex-1 overflow-y-auto px-6 pb-6 pt-6">
@@ -431,60 +466,97 @@ export function CommitDetailView({
                 AI
               </Badge>
               <span className="text-sm font-semibold">Triage Summary</span>
-              <span className="ml-auto text-[10px] text-muted-foreground">
-                generated from {commitGroup.runs.length} runs
+              <span className="ml-auto text-[10px] text-muted-foreground flex items-center gap-2">
+                {aiTriage.result && (
+                  <span>
+                    generated{" "}
+                    {Math.round(
+                      (Date.now() - aiTriage.result.generatedAt) / 1000,
+                    )}
+                    s ago
+                  </span>
+                )}
+                {aiTriage.loading && (
+                  <span className="flex items-center gap-1">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    analyzing...
+                  </span>
+                )}
+                {!aiTriage.loading && (
+                  <button
+                    onClick={() => aiTriage.generate()}
+                    className="p-0.5 rounded hover:bg-violet-200/50 transition-colors"
+                    title="Regenerate AI triage"
+                  >
+                    <RefreshCw className="h-3 w-3" />
+                  </button>
+                )}
               </span>
             </div>
+
+            {/* AI-generated summary */}
             <div className="rounded-md border border-violet-200/40 bg-white/60 p-4 text-sm leading-relaxed dark:bg-black/20">
-              <strong>{triageSummary.failCount} failure{triageSummary.failCount !== 1 ? "s" : ""} detected.</strong>{" "}
-              {triageSummary.failedSuiteNames.length > 0 && (
-                <>
-                  Failed suites:{" "}
-                  {triageSummary.failedSuiteNames.map((name, i) => (
-                    <span key={i}>
-                      {i > 0 && ", "}
-                      <strong className="text-destructive">{name}</strong>
-                    </span>
-                  ))}
-                  {" "}with {triageSummary.totalFailedCases} failed case{triageSummary.totalFailedCases !== 1 ? "s" : ""} total.
-                </>
+              {aiTriage.result ? (
+                <p>{aiTriage.result.summary}</p>
+              ) : aiTriage.error ? (
+                <div className="flex items-start gap-2 text-amber-600 dark:text-amber-400">
+                  <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+                  <div>
+                    <p className="font-medium text-xs">AI triage unavailable</p>
+                    <p className="text-[11px] text-muted-foreground mt-0.5">{aiTriage.error}</p>
+                    <p className="text-xs mt-2">
+                      <strong>{triageSummary.failCount} failure{triageSummary.failCount !== 1 ? "s" : ""} detected</strong>{" "}
+                      across {triageSummary.failedSuiteNames.join(", ")} with{" "}
+                      {triageSummary.totalFailedCases} failed case{triageSummary.totalFailedCases !== 1 ? "s" : ""}.
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <span>Analyzing {triageSummary.failCount} failure{triageSummary.failCount !== 1 ? "s" : ""}...</span>
+                </div>
               )}
             </div>
 
-            {/* Action cards grid */}
-            {failed.length > 0 && (
+            {/* Action cards grid with classification tags */}
+            {classifiedFailures.length > 0 && (
               <div className="mt-4 grid grid-cols-2 gap-2.5">
-                {failed.slice(0, 4).map((run) => {
-                  const suiteName =
-                    commitGroup.suiteMap.get(run.suiteId) || "Unknown suite";
-                  const passRate = run.summary
+                {classifiedFailures.slice(0, 4).map((cf) => {
+                  const passRate = cf.run.summary
                     ? Math.round(
-                        (run.summary.passed / Math.max(run.summary.total, 1)) *
+                        (cf.run.summary.passed / Math.max(cf.run.summary.total, 1)) *
                           100,
                       )
                     : 0;
                   return (
                     <button
-                      key={run._id}
+                      key={cf.run._id}
                       onClick={() =>
                         navigateToCiEvalsRoute({
                           type: "run-detail",
-                          suiteId: run.suiteId,
-                          runId: run._id,
+                          suiteId: cf.run.suiteId,
+                          runId: cf.run._id,
                         })
                       }
                       className="rounded-md border border-violet-200/50 bg-white/70 p-4 text-left transition-shadow hover:shadow-md dark:bg-black/20"
                     >
-                      <div className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-destructive mb-1">
-                        <span className="h-1.5 w-1.5 rounded-full bg-destructive" />
-                        P0 · Investigate
+                      <div className="flex items-center gap-1.5 mb-1.5 flex-wrap">
+                        {cf.tags.map((tag) => (
+                          <FailureTagBadge key={tag} tag={tag} />
+                        ))}
+                        {cf.tags.length === 0 && (
+                          <span className="text-[10px] font-bold uppercase tracking-wider text-destructive">
+                            Investigate
+                          </span>
+                        )}
                       </div>
                       <div className="text-sm font-semibold mb-1">
-                        {suiteName}
+                        {cf.suiteName}
                       </div>
                       <div className="text-[11px] text-muted-foreground">
-                        {run.summary?.failed ?? 0} failed of{" "}
-                        {run.summary?.total ?? 0} cases · {passRate}% pass rate
+                        {cf.run.summary?.failed ?? 0} failed of{" "}
+                        {cf.run.summary?.total ?? 0} cases · {passRate}% pass rate
                       </div>
                       <span className="mt-2 inline-flex items-center gap-1 text-[11px] font-semibold text-violet-600 dark:text-violet-400">
                         <ExternalLink className="h-3 w-3" />
@@ -493,6 +565,18 @@ export function CommitDetailView({
                     </button>
                   );
                 })}
+              </div>
+            )}
+
+            {/* Placeholder action links */}
+            {classifiedFailures.length > 0 && (
+              <div className="mt-3 flex gap-3">
+                <button className="text-[11px] font-medium text-violet-600 hover:text-violet-800 dark:text-violet-400 dark:hover:text-violet-300 transition-colors">
+                  → Create issue with context
+                </button>
+                <button className="text-[11px] font-medium text-violet-600 hover:text-violet-800 dark:text-violet-400 dark:hover:text-violet-300 transition-colors">
+                  → View config requirements
+                </button>
               </div>
             )}
           </div>
@@ -539,18 +623,26 @@ export function CommitDetailView({
             onOpenChange={setFailedOpen}
             defaultOpen
           >
-            {failed.map((run) => (
-              <FailedRunRow
-                key={run._id}
-                run={run}
-                suiteName={commitGroup.suiteMap.get(run.suiteId) || "Unknown"}
-                sparkline={getSuiteSparkline(
-                  run.suiteId,
-                  commitGroup.commitSha,
-                  allCommitGroups,
-                )}
-              />
-            ))}
+            {failed.map((run) => {
+              const cf = classifiedFailures.find(
+                (c) => c.run._id === run._id,
+              );
+              return (
+                <FailedRunRow
+                  key={run._id}
+                  run={run}
+                  suiteName={
+                    commitGroup.suiteMap.get(run.suiteId) || "Unknown"
+                  }
+                  sparkline={getSuiteSparkline(
+                    run.suiteId,
+                    commitGroup.commitSha,
+                    allCommitGroups,
+                  )}
+                  tags={cf?.tags ?? []}
+                />
+              );
+            })}
           </RunSection>
         )}
 
@@ -738,10 +830,12 @@ function FailedRunRow({
   run,
   suiteName,
   sparkline,
+  tags = [],
 }: {
   run: EvalSuiteRun;
   suiteName: string;
   sparkline: Array<{ passRate: number; isCurrent: boolean }>;
+  tags?: FailureTag[];
 }) {
   const duration = getRunDuration(run);
   const passRate = run.summary
@@ -766,6 +860,13 @@ function FailedRunRow({
         >
           {suiteName}
         </button>
+        {tags.length > 0 && (
+          <div className="flex gap-1">
+            {tags.map((tag) => (
+              <FailureTagBadge key={tag} tag={tag} />
+            ))}
+          </div>
+        )}
         <span className="ml-auto text-xs text-muted-foreground font-mono">
           {run.summary?.passed ?? 0}/{run.summary?.total ?? 0} · {passRate}%
         </span>
@@ -937,5 +1038,36 @@ function EnvCell({ label, value }: { label: string; value: string }) {
       </div>
       <div className="text-xs font-mono font-medium truncate">{value}</div>
     </div>
+  );
+}
+
+function FailureTagBadge({ tag }: { tag: FailureTag }) {
+  const config = {
+    regression: {
+      label: "regression",
+      className:
+        "bg-red-50 text-destructive border-red-200 dark:bg-red-950/50 dark:text-red-400 dark:border-red-800",
+    },
+    flaky: {
+      label: "flaky",
+      className:
+        "bg-amber-50 text-amber-600 border-amber-200 dark:bg-amber-950/50 dark:text-amber-400 dark:border-amber-800",
+    },
+    new: {
+      label: "new",
+      className:
+        "bg-violet-50 text-violet-600 border-violet-200 dark:bg-violet-950/50 dark:text-violet-400 dark:border-violet-800",
+    },
+  }[tag];
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold",
+        config.className,
+      )}
+    >
+      {config.label}
+    </span>
   );
 }

--- a/mcpjam-inspector/client/src/components/evals/overview-panel.tsx
+++ b/mcpjam-inspector/client/src/components/evals/overview-panel.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -12,6 +12,8 @@ import {
   ArrowRight,
   TrendingUp,
   TrendingDown,
+  Sparkles,
+  RefreshCw,
 } from "lucide-react";
 import {
   Collapsible,
@@ -19,8 +21,15 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
 import { TagBadges } from "./tag-editor";
-import type { EvalSuiteOverviewEntry, EvalSuiteRun } from "./types";
+import type { EvalSuiteOverviewEntry, EvalSuiteRun, CommitGroup } from "./types";
+import {
+  buildOverviewTriageContext,
+  classifyFailure,
+  type FailureTag,
+} from "./ai-insights";
+import { useOverviewAiTriage } from "./use-ai-triage";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -159,6 +168,7 @@ interface OverviewPanelProps {
   onFilterTagChange: (tag: string | null) => void;
   onSelectSuite?: (suiteId: string) => void;
   onRerunSuite?: (suiteId: string) => void;
+  allCommitGroups?: CommitGroup[];
 }
 
 export function OverviewPanel({
@@ -168,6 +178,7 @@ export function OverviewPanel({
   onFilterTagChange,
   onSelectSuite,
   onRerunSuite,
+  allCommitGroups = [],
 }: OverviewPanelProps) {
   const [failureFeedOpen, setFailureFeedOpen] = useState(true);
   const [selectedBucketId, setSelectedBucketId] = useState<string | null>(null);
@@ -199,10 +210,18 @@ export function OverviewPanel({
     );
     const neverRun = filteredSuites.filter((e) => !e.latestRun);
 
-    const lastRunTime = filteredSuites.reduce((max, e) => {
+    let lastRunTime = 0;
+    let latestCommitSha: string | null = null;
+    let latestBranch: string | null = null;
+
+    for (const e of filteredSuites) {
       const t = e.latestRun?.completedAt ?? e.latestRun?.createdAt ?? 0;
-      return t > max ? t : max;
-    }, 0);
+      if (t > lastRunTime) {
+        lastRunTime = t;
+        latestCommitSha = e.latestRun?.ciMetadata?.commitSha ?? null;
+        latestBranch = e.latestRun?.ciMetadata?.branch ?? null;
+      }
+    }
 
     return {
       failed,
@@ -215,8 +234,57 @@ export function OverviewPanel({
       runningCount: running.length,
       neverRunCount: neverRun.length,
       lastRunTime: lastRunTime || undefined,
+      latestCommitSha,
+      latestBranch,
     };
   }, [filteredSuites]);
+
+  // ---------------------------------------------------------------------------
+  // AI Overview Triage
+  // ---------------------------------------------------------------------------
+  const overviewTriageCtx = useMemo(
+    () => buildOverviewTriageContext(filteredSuites, allCommitGroups),
+    [filteredSuites, allCommitGroups],
+  );
+
+  const aiOverviewTriage = useOverviewAiTriage(
+    overviewTriageCtx.failingSuites.length > 0 ? overviewTriageCtx : null,
+  );
+
+  // Auto-generate on first load when there are suites with failed cases
+  useEffect(() => {
+    if (
+      overviewTriageCtx.failingSuites.length > 0 &&
+      !aiOverviewTriage.result &&
+      !aiOverviewTriage.loading
+    ) {
+      aiOverviewTriage.generate();
+    }
+  }, [
+    overviewTriageCtx.failingSuites.length,
+    aiOverviewTriage.result,
+    aiOverviewTriage.loading,
+    aiOverviewTriage.generate,
+  ]);
+
+  // Pre-compute inline failure tags for the failure feed
+  // Tags suites with failed cases OR failed result
+  const failureTagMap = useMemo(() => {
+    const map = new Map<string, FailureTag[]>();
+    for (const entry of filteredSuites) {
+      const hasFailedCases = entry.totals.failed > 0;
+      const suiteResultFailed = entry.latestRun?.result === "failed";
+      if ((hasFailedCases || suiteResultFailed) && entry.latestRun) {
+        const classified = classifyFailure(
+          entry.latestRun,
+          entry.suite.name,
+          allCommitGroups,
+        );
+        map.set(entry.suite._id, classified.tags);
+      }
+    }
+    return map;
+  }, [filteredSuites, allCommitGroups]);
 
   // ---------------------------------------------------------------------------
   // Section B: Run Timeline
@@ -382,6 +450,12 @@ export function OverviewPanel({
               {stats.neverRunCount > 0 && (
                 <> &middot; {stats.neverRunCount} never run</>
               )}
+              {stats.latestBranch && (
+                <> &middot; {stats.latestBranch}</>
+              )}
+              {stats.latestCommitSha && (
+                <> @ <span className="font-mono">{stats.latestCommitSha.slice(0, 7)}</span></>
+              )}
             </span>
           </div>
         </div>
@@ -391,6 +465,72 @@ export function OverviewPanel({
           </span>
         )}
       </div>
+
+      {/* AI Overview Summary — only when failures exist */}
+      {overviewTriageCtx.failingSuites.length > 0 && (
+        <div className="relative rounded-lg border border-violet-200 bg-violet-50/50 shadow-sm dark:border-violet-800 dark:bg-violet-950/20">
+          <div className="absolute top-0 left-0 right-0 h-[3px] rounded-t-lg bg-gradient-to-r from-violet-500 via-purple-400 to-violet-500 opacity-50" />
+          <div className="px-4 py-3">
+            <div className="flex items-center gap-2 mb-2">
+              <Badge
+                variant="outline"
+                className="border-violet-300 bg-violet-100 text-violet-600 text-[10px] font-bold uppercase tracking-wider dark:border-violet-700 dark:bg-violet-900/50 dark:text-violet-400"
+              >
+                <Sparkles className="mr-1 h-3 w-3" />
+                AI
+              </Badge>
+              <span className="text-xs font-semibold">Overview Insights</span>
+              {stats.latestCommitSha && (
+                <span className="text-[10px] text-muted-foreground font-mono">
+                  {stats.latestBranch && <>{stats.latestBranch} @ </>}
+                  {stats.latestCommitSha.slice(0, 7)}
+                  {" · "}
+                  {stats.totalSuites} suite{stats.totalSuites !== 1 ? "s" : ""}
+                </span>
+              )}
+              <span className="ml-auto flex items-center gap-2 text-[10px] text-muted-foreground">
+                {aiOverviewTriage.loading && (
+                  <span className="flex items-center gap-1">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    analyzing...
+                  </span>
+                )}
+                {!aiOverviewTriage.loading && (
+                  <button
+                    onClick={() => aiOverviewTriage.generate()}
+                    className="p-0.5 rounded hover:bg-violet-200/50 transition-colors"
+                    title="Regenerate AI insights"
+                  >
+                    <RefreshCw className="h-3 w-3" />
+                  </button>
+                )}
+              </span>
+            </div>
+            <div className="text-xs leading-relaxed">
+              {aiOverviewTriage.result ? (
+                <p>{aiOverviewTriage.result.summary}</p>
+              ) : aiOverviewTriage.error ? (
+                <div className="flex items-start gap-2 text-amber-600 dark:text-amber-400">
+                  <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                  <div>
+                    <p className="font-medium">AI insights unavailable</p>
+                    <p className="text-[11px] text-muted-foreground mt-0.5">
+                      {aiOverviewTriage.error}
+                    </p>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  <span>
+                    Analyzing {overviewTriageCtx.failingSuites.length} suite{overviewTriageCtx.failingSuites.length !== 1 ? "s" : ""} with failures...
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Section B: Run Timeline Chips */}
       {timeline.length > 0 && (
@@ -481,8 +621,14 @@ export function OverviewPanel({
                         <MinusCircle className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
                       )}
                       <div className="min-w-0 flex-1">
-                        <div className="text-sm font-medium truncate">
-                          {entry.suite.name}
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-sm font-medium truncate">
+                            {entry.suite.name}
+                          </span>
+                          {isFailed &&
+                            failureTagMap.get(entry.suite._id)?.map((tag) => (
+                              <InlineFailureTag key={tag} tag={tag} />
+                            ))}
                         </div>
                         {isFailed && entry.latestRun?.summary && (
                           <div className="text-xs text-muted-foreground mt-0.5">
@@ -696,7 +842,16 @@ export function OverviewPanel({
                         : undefined
                     }
                   >
-                    {lastRunTs ? formatRelativeTime(lastRunTs) : "—"}
+                    {entry.latestRun?.ciMetadata?.commitSha ? (
+                      <div>
+                        <span className="font-mono">{entry.latestRun.ciMetadata.commitSha.slice(0, 7)}</span>
+                        {lastRunTs && (
+                          <div className="text-[10px]">{formatRelativeTime(lastRunTs)}</div>
+                        )}
+                      </div>
+                    ) : (
+                      lastRunTs ? formatRelativeTime(lastRunTs) : "—"
+                    )}
                   </div>
 
                   {/* Trend sparkline */}
@@ -740,5 +895,37 @@ export function OverviewPanel({
         </div>
       </div>
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline failure tag for the failure feed
+// ---------------------------------------------------------------------------
+
+function InlineFailureTag({ tag }: { tag: FailureTag }) {
+  const config = {
+    regression: {
+      label: "regression",
+      className: "text-destructive bg-red-50 border-red-200 dark:bg-red-950/50 dark:border-red-800",
+    },
+    flaky: {
+      label: "flaky",
+      className: "text-amber-600 bg-amber-50 border-amber-200 dark:bg-amber-950/50 dark:border-amber-800",
+    },
+    new: {
+      label: "new",
+      className: "text-violet-600 bg-violet-50 border-violet-200 dark:bg-violet-950/50 dark:border-violet-800",
+    },
+  }[tag];
+
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center rounded-full border px-1.5 py-0 text-[9px] font-semibold leading-4",
+        config.className,
+      )}
+    >
+      {config.label}
+    </span>
   );
 }

--- a/mcpjam-inspector/client/src/components/evals/use-ai-triage.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-ai-triage.ts
@@ -1,0 +1,272 @@
+import { useState, useCallback, useRef } from "react";
+import type { TriageContext, OverviewTriageContext } from "./ai-insights";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AiTriageResult {
+  summary: string;
+  generatedAt: number;
+}
+
+export interface UseAiTriageReturn {
+  result: AiTriageResult | null;
+  loading: boolean;
+  error: string | null;
+  generate: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = "mcp-inspector-provider-tokens";
+
+function getOpenRouterApiKey(): string | null {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return null;
+    const tokens = JSON.parse(stored);
+    return tokens.openrouter?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function getOpenRouterModel(): string {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return "anthropic/claude-sonnet-4";
+    const tokens = JSON.parse(stored);
+    const models = tokens.openRouterSelectedModels;
+    if (Array.isArray(models) && models.length > 0) {
+      return models[0];
+    }
+  } catch {
+    // fall through
+  }
+  return "anthropic/claude-sonnet-4";
+}
+
+async function callOpenRouter(
+  prompt: string,
+  systemPrompt: string,
+  signal?: AbortSignal,
+): Promise<string> {
+  const apiKey = getOpenRouterApiKey();
+  if (!apiKey) {
+    throw new Error(
+      "OpenRouter API key not configured. Add your key in Settings → LLM Providers.",
+    );
+  }
+
+  const model = getOpenRouterModel();
+
+  const response = await fetch(
+    "https://openrouter.ai/api/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        "HTTP-Referer": "https://www.mcpjam.com/",
+        "X-Title": "MCPJam Inspector",
+      },
+      body: JSON.stringify({
+        model,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: prompt },
+        ],
+        temperature: 0.3,
+        max_tokens: 1024,
+      }),
+      signal,
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    if (response.status === 401) {
+      throw new Error(
+        "Invalid OpenRouter API key. Check your key in Settings → LLM Providers.",
+      );
+    }
+    throw new Error(`OpenRouter request failed (${response.status}): ${body}`);
+  }
+
+  const data = await response.json();
+  const content = data?.choices?.[0]?.message?.content;
+  if (!content) {
+    throw new Error("Empty response from OpenRouter");
+  }
+  return content;
+}
+
+// ---------------------------------------------------------------------------
+// Prompts
+// ---------------------------------------------------------------------------
+
+const SYSTEM_PROMPT = `You are an expert MCP server evaluation analyst. You analyze eval/test run results and provide concise, actionable triage summaries for engineering teams.
+
+Your summaries should:
+- Lead with the most important finding
+- Identify regression patterns (was passing, now failing)
+- Flag flaky tests (intermittent pass/fail)
+- Note coverage gaps (suites not running)
+- Be concise — 2-4 sentences max
+- Use technical language appropriate for engineers
+- Focus on what to fix and why, not just what failed`;
+
+function buildCommitTriagePrompt(ctx: TriageContext): string {
+  const failureDetails = ctx.failures
+    .map((f) => {
+      const tagStr = f.tags.length > 0 ? ` [${f.tags.join(", ")}]` : "";
+      const testList =
+        f.testNames.length > 0
+          ? `\n    Tests: ${f.testNames.join(", ")}`
+          : "";
+      return `  - ${f.suiteName}${tagStr}: ${f.failedCases}/${f.totalCases} failed (${f.passRate}% pass rate)${testList}`;
+    })
+    .join("\n");
+
+  const passedStr =
+    ctx.passedSuites.length > 0
+      ? `\nPassed suites (${ctx.passedSuites.length}): ${ctx.passedSuites.join(", ")}`
+      : "";
+
+  const notRunStr =
+    ctx.notRunSuites.length > 0
+      ? `\nNot run (${ctx.notRunSuites.length}): ${ctx.notRunSuites.join(", ")}`
+      : "";
+
+  return `Analyze this eval run and provide a triage summary:
+
+Commit: ${ctx.commitSha}${ctx.branch ? ` (branch: ${ctx.branch})` : ""}
+Total: ${ctx.totalSuites} suites, ${ctx.totalCases.total} cases (${ctx.totalCases.passed} passed, ${ctx.totalCases.failed} failed)
+
+Failures (${ctx.failures.length}):
+${failureDetails}
+${passedStr}${notRunStr}
+
+Provide a concise triage summary (2-4 sentences). Highlight regressions and flaky patterns. Suggest what to investigate first.`;
+}
+
+function buildOverviewTriagePrompt(ctx: OverviewTriageContext): string {
+  const failureDetails = ctx.failingSuites
+    .map((f) => {
+      const tagStr = f.tags.length > 0 ? ` [${f.tags.join(", ")}]` : "";
+      return `  - ${f.name}${tagStr}: ${f.failedCases} failures, ${f.passRate} pass rate`;
+    })
+    .join("\n");
+
+  return `Analyze the current state of all eval suites and provide a brief summary:
+
+Total suites: ${ctx.totalSuites}
+Fully passing: ${ctx.passingSuites}
+Suites with failed cases: ${ctx.failingSuites.length}
+Never run: ${ctx.neverRunSuites}
+
+Suites with failures:
+${failureDetails}
+
+Provide a concise overview summary (2-3 sentences). Focus on the most critical issues and patterns across all suites. Note that some suites may have an overall "passed" status due to pass rate thresholds while still having individual case failures.`;
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+/**
+ * Hook for generating AI triage for a commit detail view.
+ * Caches results by commit SHA to avoid redundant calls.
+ */
+export function useCommitAiTriage(ctx: TriageContext | null): UseAiTriageReturn {
+  const [result, setResult] = useState<AiTriageResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const lastCtxRef = useRef<string | null>(null);
+
+  const generate = useCallback(() => {
+    if (!ctx) return;
+
+    // Avoid re-generating for the same context
+    const ctxKey = `${ctx.commitSha}-${ctx.failures.length}`;
+    if (lastCtxRef.current === ctxKey && result) return;
+
+    // Cancel any in-flight request
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+    setError(null);
+    lastCtxRef.current = ctxKey;
+
+    const prompt = buildCommitTriagePrompt(ctx);
+
+    callOpenRouter(prompt, SYSTEM_PROMPT, controller.signal)
+      .then((summary) => {
+        if (!controller.signal.aborted) {
+          setResult({ summary, generatedAt: Date.now() });
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!controller.signal.aborted) {
+          setError(err instanceof Error ? err.message : String(err));
+          setLoading(false);
+        }
+      });
+  }, [ctx, result]);
+
+  return { result, loading, error, generate };
+}
+
+/**
+ * Hook for generating AI triage for the overview panel.
+ */
+export function useOverviewAiTriage(
+  ctx: OverviewTriageContext | null,
+): UseAiTriageReturn {
+  const [result, setResult] = useState<AiTriageResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  const lastCtxRef = useRef<string | null>(null);
+
+  const generate = useCallback(() => {
+    if (!ctx) return;
+
+    const ctxKey = `overview-${ctx.failingSuites.length}-${ctx.totalSuites}`;
+    if (lastCtxRef.current === ctxKey && result) return;
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+    setError(null);
+    lastCtxRef.current = ctxKey;
+
+    const prompt = buildOverviewTriagePrompt(ctx);
+
+    callOpenRouter(prompt, SYSTEM_PROMPT, controller.signal)
+      .then((summary) => {
+        if (!controller.signal.aborted) {
+          setResult({ summary, generatedAt: Date.now() });
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!controller.signal.aborted) {
+          setError(err instanceof Error ? err.message : String(err));
+          setLoading(false);
+        }
+      });
+  }, [ctx, result]);
+
+  return { result, loading, error, generate };
+}


### PR DESCRIPTION
### TL;DR

Added AI-powered failure analysis to CI evaluation runs with automatic classification of failures as regressions, flaky tests, or new failures, plus intelligent triage summaries.

### What changed?

- **AI Triage System**: New `ai-insights.ts` module that classifies test failures by analyzing historical run data across commits to identify regressions (previously passing, now failing), flaky tests (alternating pass/fail patterns), and new failures
- **Commit Detail View Enhancements**: Added AI-generated triage summaries that automatically analyze failures when any test cases fail, with visual failure classification tags and regeneration controls
- **Overview Panel Intelligence**: Integrated AI insights at the suite overview level to provide high-level analysis of all failing suites with their failure patterns
- **Failure Classification Tags**: Visual badges showing "regression", "flaky", or "new" status for failed test runs based on historical analysis
- **Auto-generation**: AI triage automatically triggers when failures are detected, with manual refresh capabilities
- **Comprehensive Test Coverage**: Added 442 lines of tests covering failure classification logic, history analysis, and context building functions
- **UI Improvements**: Changed default sidebar mode to "runs" and moved overview button to always be visible regardless of sidebar mode
