### PR TITLE
Clean up sidebar and other top improves

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/ci-suite-list-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/ci-suite-list-sidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { BarChart3 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { CommitGroup, EvalSuiteOverviewEntry } from "./types";
@@ -114,25 +114,37 @@ export function CiSuiteListSidebar({
     ? suites.filter((e) => e.suite.tags?.includes(filterTag))
     : suites;
 
+  // Group suites by name, keeping the most recent one as the "primary" entry
+  const groupedSuites = useMemo(() => {
+    const groups = new Map<string, EvalSuiteOverviewEntry[]>();
+    for (const entry of filteredSuites) {
+      const name = entry.suite.name || "Untitled suite";
+      if (!groups.has(name)) {
+        groups.set(name, []);
+      }
+      groups.get(name)!.push(entry);
+    }
+    // Sort each group by latest run time (most recent first)
+    for (const entries of groups.values()) {
+      entries.sort((a, b) => {
+        const aTime = a.latestRun?.completedAt ?? a.latestRun?.createdAt ?? a.suite.updatedAt ?? 0;
+        const bTime = b.latestRun?.completedAt ?? b.latestRun?.createdAt ?? b.suite.updatedAt ?? 0;
+        return bTime - aTime;
+      });
+    }
+    return groups;
+  }, [filteredSuites]);
+
+  const uniqueSuiteCount = groupedSuites.size;
+
+  const failCount = suites.filter(
+    (e) => e.latestRun?.result === "failed",
+  ).length;
+
   return (
     <div className="flex h-full flex-col">
-      <div className="border-b px-4 py-3">
-        <div className="flex items-center justify-between">
-          <h2 className="text-sm font-semibold">
-            {sidebarMode === "suites" ? "Eval suites" : "Runs by commit"}
-          </h2>
-          {sidebarMode === "suites" && filteredSuites.length > 0 && (
-            <span className="text-[10px] text-muted-foreground tabular-nums">
-              {filteredSuites.length}
-            </span>
-          )}
-          {sidebarMode === "runs" && commitGroups.length > 0 && (
-            <span className="text-[10px] text-muted-foreground tabular-nums">
-              {commitGroups.length}
-            </span>
-          )}
-        </div>
-        <div className="mt-2 flex rounded-md border bg-muted/50 p-0.5">
+      <div className="border-b px-4 py-3 space-y-2">
+        <div className="flex rounded-md border bg-muted/50 p-0.5">
           <button
             onClick={() => onSidebarModeChange("runs")}
             className={cn(
@@ -142,7 +154,7 @@ export function CiSuiteListSidebar({
                 : "text-muted-foreground hover:text-foreground",
             )}
           >
-            Runs
+            By Commit
           </button>
           <button
             onClick={() => onSidebarModeChange("suites")}
@@ -153,39 +165,31 @@ export function CiSuiteListSidebar({
                 : "text-muted-foreground hover:text-foreground",
             )}
           >
-            Suites
+            By Suite
           </button>
         </div>
       </div>
 
-      {/* Overview button — always visible regardless of sidebar mode */}
-      <button
-        onClick={onSelectOverview}
-        className={cn(
-          "w-full px-4 py-2.5 text-left transition-colors hover:bg-accent/50 border-b",
-          isOverviewSelected && "bg-accent",
-        )}
-      >
-        <div className="flex items-center gap-2.5">
-          <BarChart3 className="h-4 w-4 shrink-0 text-muted-foreground" />
-          <div className="min-w-0 flex-1">
-            <div className="text-sm font-medium">Overview</div>
-            <div className="text-[11px] text-muted-foreground">
-              Suite health & status
-            </div>
-          </div>
-          {(() => {
-            const failCount = suites.filter(
-              (e) => e.latestRun?.result === "failed",
-            ).length;
-            return failCount > 0 ? (
-              <span className="shrink-0 flex h-5 min-w-[20px] items-center justify-center rounded-full bg-destructive px-1.5 text-[10px] font-bold text-destructive-foreground">
-                {failCount}
-              </span>
-            ) : null;
-          })()}
-        </div>
-      </button>
+      {/* Dashboard button — always visible regardless of sidebar mode */}
+      <div className="px-3 py-2 border-b">
+        <button
+          onClick={onSelectOverview}
+          className={cn(
+            "w-full flex items-center gap-2 rounded-md px-2.5 py-1.5 text-left text-xs font-medium transition-colors cursor-pointer border border-transparent",
+            isOverviewSelected
+              ? "bg-primary/15 text-primary border-primary/30"
+              : "text-muted-foreground hover:bg-accent hover:text-foreground hover:border-border",
+          )}
+        >
+          <BarChart3 className="h-3.5 w-3.5 shrink-0" />
+          <span className="flex-1">Dashboard</span>
+          {failCount > 0 && (
+            <span className="shrink-0 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-destructive px-1 text-[9px] font-bold text-destructive-foreground">
+              {failCount}
+            </span>
+          )}
+        </button>
+      </div>
 
       {sidebarMode === "runs" ? (
         <CommitListSidebar
@@ -206,73 +210,196 @@ export function CiSuiteListSidebar({
           </div>
         ) : (
           <div>
-            {filteredSuites.map((entry) => {
-              const latestRun = entry.latestRun;
-              const status = getStatusInfo(entry);
-              const trend = entry.passRateTrend
-                .slice(-12)
-                .map((value) => toPercent(value));
-              const timestamp = formatRelativeTime(
-                latestRun?.completedAt ??
-                  latestRun?.createdAt ??
-                  entry.suite.updatedAt,
-              );
-
-              return (
-                <button
-                  key={entry.suite._id}
-                  onClick={() => onSelectSuite(entry.suite._id)}
-                  className={cn(
-                    "w-full px-4 py-2.5 text-left transition-colors hover:bg-accent/50",
-                    selectedSuiteId === entry.suite._id && "bg-accent",
-                  )}
-                >
-                  <div className="flex items-center gap-2.5">
-                    <div className="flex flex-col items-center gap-0.5 shrink-0 w-[3.25rem]">
-                      <div
-                        className={cn("h-2 w-2 rounded-full", status.dotClass)}
-                      />
-                      <span
-                        className={cn(
-                          "text-[9px] font-medium leading-none",
-                          status.labelClass,
-                        )}
-                      >
-                        {status.label}
-                      </span>
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="truncate text-sm font-medium">
-                        {entry.suite.name || "Untitled suite"}
-                      </div>
-                      {entry.suite.tags && entry.suite.tags.length > 0 && (
-                        <TagBadges tags={entry.suite.tags} className="mt-0.5" />
-                      )}
-                      <div className="text-[11px] text-muted-foreground">
-                        {timestamp}
-                      </div>
-                    </div>
-                    {trend.length > 0 && (
-                      <div className="flex h-5 shrink-0 items-end gap-px">
-                        {trend.map((value, idx) => (
-                          <div
-                            key={`${entry.suite._id}-t-${idx}`}
-                            className="w-1 rounded-sm bg-primary/70"
-                            style={{
-                              height: `${Math.max(3, (value / 100) * 20)}px`,
-                            }}
-                          />
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </button>
-              );
-            })}
+            {Array.from(groupedSuites.entries()).map(([suiteName, entries]) => (
+              <SuiteGroupItem
+                key={suiteName}
+                suiteName={suiteName}
+                entries={entries}
+                selectedSuiteId={selectedSuiteId}
+                onSelectSuite={onSelectSuite}
+              />
+            ))}
           </div>
         )}
       </div>
       )}
     </div>
+  );
+}
+
+function SuiteGroupItem({
+  suiteName,
+  entries,
+  selectedSuiteId,
+  onSelectSuite,
+}: {
+  suiteName: string;
+  entries: EvalSuiteOverviewEntry[];
+  selectedSuiteId: string | null;
+  onSelectSuite: (suiteId: string) => void;
+}) {
+  const primary = entries[0]; // most recent
+  const hasMultiple = entries.length > 1;
+  const isAnySelected = entries.some((e) => e.suite._id === selectedSuiteId);
+  const [expanded, setExpanded] = useState(false);
+
+  const latestRun = primary.latestRun;
+  const status = getStatusInfo(primary);
+  const trend = primary.passRateTrend.slice(-12).map((value) => toPercent(value));
+  const timestamp = formatRelativeTime(
+    latestRun?.completedAt ?? latestRun?.createdAt ?? primary.suite.updatedAt,
+  );
+
+  // For single-entry groups, render directly
+  if (!hasMultiple) {
+    return (
+      <SuiteEntryButton
+        entry={primary}
+        isSelected={selectedSuiteId === primary.suite._id}
+        onSelect={() => onSelectSuite(primary.suite._id)}
+        status={status}
+        trend={trend}
+        timestamp={timestamp}
+      />
+    );
+  }
+
+  // For multi-entry groups, render as expandable group
+  return (
+    <div>
+      <button
+        onClick={() => {
+          if (!isAnySelected) {
+            // Click selects the most recent entry
+            onSelectSuite(primary.suite._id);
+          } else {
+            setExpanded(!expanded);
+          }
+        }}
+        className={cn(
+          "w-full px-4 py-2.5 text-left transition-colors hover:bg-accent/50",
+          isAnySelected && "bg-accent shadow-sm",
+        )}
+      >
+        <div className="flex items-center gap-2.5">
+          <div className="flex flex-col items-center gap-0.5 shrink-0 w-[3.25rem]">
+            <div className={cn("h-2 w-2 rounded-full", status.dotClass)} />
+            <span className={cn("text-[9px] font-medium leading-none", status.labelClass)}>
+              {status.label}
+            </span>
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1.5">
+              <span className={cn("truncate text-sm font-medium", isAnySelected && "font-semibold")}>
+                {suiteName}
+              </span>
+              <span className="shrink-0 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-muted px-1 text-[9px] font-medium text-muted-foreground">
+                {entries.length}
+              </span>
+            </div>
+            {primary.suite.tags && primary.suite.tags.length > 0 && (
+              <TagBadges tags={primary.suite.tags} className="mt-0.5" />
+            )}
+            <div className="text-[11px] text-muted-foreground">{timestamp}</div>
+          </div>
+          {trend.length >= 3 && (
+            <div className="flex h-5 shrink-0 items-end gap-px">
+              {trend.map((value, idx) => (
+                <div
+                  key={`${primary.suite._id}-t-${idx}`}
+                  className={cn("w-1 rounded-sm", value >= 80 ? "bg-emerald-500/70" : value >= 50 ? "bg-amber-500/70" : "bg-destructive/70")}
+                  style={{ height: `${Math.max(3, (value / 100) * 20)}px` }}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </button>
+      {(expanded || isAnySelected) && entries.length > 1 && (
+        <div className="border-l-2 border-muted ml-6">
+          {entries.map((entry) => {
+            const entryStatus = getStatusInfo(entry);
+            const entryTimestamp = formatRelativeTime(
+              entry.latestRun?.completedAt ?? entry.latestRun?.createdAt ?? entry.suite.updatedAt,
+            );
+            return (
+              <button
+                key={entry.suite._id}
+                onClick={() => onSelectSuite(entry.suite._id)}
+                className={cn(
+                  "w-full px-3 py-1.5 text-left transition-colors hover:bg-accent/50",
+                  selectedSuiteId === entry.suite._id && "bg-primary/10 border-r-2 border-r-primary",
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  <div className={cn("h-1.5 w-1.5 rounded-full shrink-0", entryStatus.dotClass)} />
+                  <span className="text-[11px] text-muted-foreground truncate flex-1">
+                    {entryTimestamp}
+                  </span>
+                  <span className={cn("text-[10px] font-medium", entryStatus.labelClass)}>
+                    {entryStatus.label}
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SuiteEntryButton({
+  entry,
+  isSelected,
+  onSelect,
+  status,
+  trend,
+  timestamp,
+}: {
+  entry: EvalSuiteOverviewEntry;
+  isSelected: boolean;
+  onSelect: () => void;
+  status: { label: string; dotClass: string; labelClass: string };
+  trend: number[];
+  timestamp: string;
+}) {
+  return (
+    <button
+      onClick={onSelect}
+      className={cn(
+        "w-full px-4 py-2.5 text-left transition-colors hover:bg-accent/50",
+        isSelected && "bg-accent shadow-sm",
+      )}
+    >
+      <div className="flex items-center gap-2.5">
+        <div className="flex flex-col items-center gap-0.5 shrink-0 w-[3.25rem]">
+          <div className={cn("h-2 w-2 rounded-full", status.dotClass)} />
+          <span className={cn("text-[9px] font-medium leading-none", status.labelClass)}>
+            {status.label}
+          </span>
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className={cn("truncate text-sm font-medium", isSelected && "font-semibold")}>
+            {entry.suite.name || "Untitled suite"}
+          </div>
+          {entry.suite.tags && entry.suite.tags.length > 0 && (
+            <TagBadges tags={entry.suite.tags} className="mt-0.5" />
+          )}
+          <div className="text-[11px] text-muted-foreground">{timestamp}</div>
+        </div>
+        {trend.length >= 3 && (
+          <div className="flex h-5 shrink-0 items-end gap-px">
+            {trend.map((value, idx) => (
+              <div
+                key={`${entry.suite._id}-t-${idx}`}
+                className="w-1 rounded-sm bg-primary/70"
+                style={{ height: `${Math.max(3, (value / 100) * 20)}px` }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </button>
   );
 }

--- a/mcpjam-inspector/client/src/components/evals/commit-list-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/commit-list-sidebar.tsx
@@ -71,72 +71,65 @@ export function CommitListSidebar({
                 onClick={() => onSelectCommit(group.commitSha)}
                 className={cn(
                   "w-full px-4 py-2.5 text-left transition-colors hover:bg-accent/50",
-                  selectedCommitSha === group.commitSha && "bg-accent",
+                  selectedCommitSha === group.commitSha && "bg-accent shadow-sm",
                 )}
               >
-                <div className="flex items-center gap-2.5">
-                  <div className="flex flex-col items-center gap-0.5 shrink-0 w-[3.25rem]">
-                    <div
-                      className={cn("h-2 w-2 rounded-full", status.dotClass)}
-                    />
-                    <span
-                      className={cn(
-                        "text-[9px] font-medium leading-none",
-                        status.labelClass,
-                      )}
-                    >
-                      {status.label}
-                    </span>
-                  </div>
+                <div className="flex items-start gap-2.5">
+                  {/* Status dot */}
+                  <div className={cn("h-2 w-2 rounded-full mt-1.5 shrink-0", status.dotClass)} />
+
+                  {/* Content */}
                   <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-1.5">
+                    {/* Row 1: SHA + timestamp */}
+                    <div className="flex items-center justify-between gap-2">
                       {isManual ? (
                         <span className="text-sm font-medium text-muted-foreground">
-                          Manual Runs
+                          Manual
                         </span>
                       ) : (
-                        <>
+                        <div className="flex items-center gap-1">
                           <GitCommit className="h-3 w-3 shrink-0 text-muted-foreground" />
                           <span className="text-sm font-mono font-medium truncate">
                             {group.shortSha}
                           </span>
-                        </>
+                        </div>
                       )}
-                    </div>
-                    {group.branch && (
-                      <div className="flex items-center gap-1 mt-0.5">
-                        <GitBranch className="h-3 w-3 shrink-0 text-muted-foreground" />
-                        <span className="text-[11px] text-muted-foreground truncate">
-                          {group.branch}
-                        </span>
-                      </div>
-                    )}
-                    <div className="flex items-center gap-2 mt-0.5">
-                      <span className="text-[11px] text-muted-foreground">
+                      <span className="text-[10px] text-muted-foreground shrink-0 tabular-nums">
                         {formatRelativeTime(group.timestamp)}
                       </span>
-                      <span className="text-[10px] text-muted-foreground tabular-nums">
+                    </div>
+
+                    {/* Row 2: branch + pass/fail summary */}
+                    <div className="flex items-center justify-between gap-2 mt-0.5">
+                      {group.branch ? (
+                        <div className="flex items-center gap-1 min-w-0">
+                          <GitBranch className="h-3 w-3 shrink-0 text-muted-foreground" />
+                          <span className="text-[11px] text-muted-foreground truncate">
+                            {group.branch}
+                          </span>
+                        </div>
+                      ) : (
+                        <div />
+                      )}
+                      <div className="flex items-center gap-1.5 shrink-0 text-[10px] tabular-nums">
                         {group.summary.passed > 0 && (
-                          <span className="text-emerald-500">
-                            {group.summary.passed}✓
+                          <span className="text-emerald-500 font-medium">
+                            {group.summary.passed} passed
                           </span>
                         )}
                         {group.summary.failed > 0 && (
-                          <span className="text-destructive ml-1">
-                            {group.summary.failed}✕
+                          <span className="text-destructive font-medium">
+                            {group.summary.failed} failed
                           </span>
                         )}
                         {group.summary.running > 0 && (
-                          <span className="text-warning ml-1">
-                            {group.summary.running}⟳
+                          <span className="text-warning font-medium">
+                            {group.summary.running} running
                           </span>
                         )}
-                      </span>
+                      </div>
                     </div>
                   </div>
-                  <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
-                    {group.summary.total} run{group.summary.total !== 1 ? "s" : ""}
-                  </span>
                 </div>
               </button>
             );

--- a/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
+++ b/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
@@ -2,7 +2,7 @@ import { useAction } from "convex/react";
 import { useEffect, useMemo, useState } from "react";
 import { EvalIteration, EvalCase } from "./types";
 import { TraceViewer } from "./trace-viewer";
-import { MessageSquare, Code2, ChevronDown, ChevronRight } from "lucide-react";
+import { MessageSquare, Code2, ChevronDown, ChevronRight, ShieldCheck, ShieldX } from "lucide-react";
 import { ToolServerMap, listTools } from "@/lib/apis/mcp-tools-api";
 import { JsonEditor } from "@/components/ui/json-editor";
 import {
@@ -408,8 +408,41 @@ export function IterationDetails({
   const errorDetailsJson = parseErrorDetails(iteration.errorDetails);
   const [isErrorDetailsOpen, setIsErrorDetailsOpen] = useState(false);
 
+  const isNegativeTest = iteration.testCaseSnapshot?.isNegativeTest || testCase?.isNegativeTest;
+  const negativeTestScenario = iteration.testCaseSnapshot?.scenario || testCase?.scenario;
+
   return (
     <div className="space-y-4 py-2">
+      {/* Negative Test Summary */}
+      {isNegativeTest && (
+        <div className={`rounded-md border p-3 space-y-1 ${
+          iteration.result === "passed"
+            ? "border-emerald-500/30 bg-emerald-500/10"
+            : "border-destructive/30 bg-destructive/10"
+        }`}>
+          <div className="flex items-center gap-2">
+            {iteration.result === "passed" ? (
+              <ShieldCheck className="h-4 w-4 text-emerald-500 shrink-0" />
+            ) : (
+              <ShieldX className="h-4 w-4 text-destructive shrink-0" />
+            )}
+            <span className="text-xs font-semibold">
+              Negative Test {iteration.result === "passed" ? "Passed" : "Failed"}
+            </span>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {iteration.result === "passed"
+              ? "No tools were called, which is the expected behavior for this test."
+              : "Tools were unexpectedly called during this negative test."}
+          </p>
+          {negativeTestScenario && (
+            <p className="text-xs text-muted-foreground/80 italic mt-1">
+              Scenario: {negativeTestScenario}
+            </p>
+          )}
+        </div>
+      )}
+
       {/* Error Display */}
       {iteration.error && (
         <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 space-y-2">

--- a/mcpjam-inspector/client/src/components/evals/pass-criteria-badge.tsx
+++ b/mcpjam-inspector/client/src/components/evals/pass-criteria-badge.tsx
@@ -4,7 +4,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { CheckCircle2, XCircle } from "lucide-react";
+import { CheckCircle2, XCircle, AlertTriangle } from "lucide-react";
 import { EvalSuiteRun } from "./types";
 
 interface PassCriteriaBadgeProps {
@@ -22,12 +22,14 @@ export function PassCriteriaBadge({
   const minimumPassRate = run.passCriteria?.minimumPassRate ?? 100;
   const result = run.result ?? "pending";
   const status = run.status ?? "pending";
-  // passRate is stored as decimal (0-1), convert to percentage (0-100)
-  const passRateDecimal = run.summary?.passRate ?? 0;
-  const passRate = passRateDecimal * 100;
+  // passRate may be stored as decimal (0-1) or percentage (0-100); normalize to 0-100
+  const rawPassRate = run.summary?.passRate ?? 0;
+  const passRate = rawPassRate <= 1 && rawPassRate > 0 ? rawPassRate * 100 : rawPassRate;
 
   const passed = result === "passed";
   const isRunning = status === "running" || status === "pending";
+  const failedCount = run.summary?.failed ?? 0;
+  const passedWithFailures = passed && failedCount > 0;
 
   // Don't show pass/fail badge while run is in progress
   if (isRunning) {
@@ -41,26 +43,32 @@ export function PassCriteriaBadge({
           <Badge
             variant="outline"
             className={
-              passed
-                ? "gap-1 bg-success/50 text-success-foreground border-success/50 hover:bg-success/70"
-                : "gap-1 bg-destructive/50 text-destructive-foreground border-destructive/50 hover:bg-destructive/70"
+              passedWithFailures
+                ? "gap-1 bg-amber-500/20 text-amber-600 border-amber-500/40 hover:bg-amber-500/30 dark:text-amber-400"
+                : passed
+                  ? "gap-1 bg-success/50 text-success-foreground border-success/50 hover:bg-success/70"
+                  : "gap-1 bg-destructive/50 text-destructive-foreground border-destructive/50 hover:bg-destructive/70"
             }
           >
-            {passed ? (
+            {passedWithFailures ? (
+              <AlertTriangle className="h-3 w-3" />
+            ) : passed ? (
               <CheckCircle2 className="h-3 w-3" />
             ) : (
               <XCircle className="h-3 w-3" />
             )}
-            {passed ? "Passed" : "Failed"}
+            {passedWithFailures ? `Passed (${failedCount} failed)` : passed ? "Passed" : "Failed"}
           </Badge>
         </TooltipTrigger>
         <TooltipContent className="max-w-xs">
           <div className="space-y-1 text-xs">
             <div className="font-medium text-white">
-              {passed ? "✓ Suite Passed" : "✗ Suite Failed"}
+              {passedWithFailures
+                ? `⚠ Suite Passed with ${failedCount} failure${failedCount !== 1 ? "s" : ""}`
+                : passed ? "✓ Suite Passed" : "✗ Suite Failed"}
             </div>
             <div className="text-white">
-              Required: {minimumPassRate}% {metricLabel}
+              Required: {minimumPassRate}% {metricLabel} · Actual: {passRate.toFixed(0)}%
             </div>
           </div>
         </TooltipContent>

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { X, Loader2 } from "lucide-react";
+import { X, Loader2, CheckCircle2, XCircle, AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   ChartContainer,
@@ -316,10 +316,11 @@ export function RunDetailView({
                   No iterations found.
                 </div>
               ) : (
-                caseGroupsForSelectedRun.map((iteration) => (
+                caseGroupsForSelectedRun.map((iteration, idx) => (
                   <IterationListItem
                     key={iteration._id}
                     iteration={iteration}
+                    index={idx + 1}
                     isSelected={selectedIterationId === iteration._id}
                     onSelect={() => onSelectIteration(iteration._id)}
                   />
@@ -649,10 +650,12 @@ export function RunDetailView({
 // Compact iteration list item for the left pane
 function IterationListItem({
   iteration,
+  index,
   isSelected,
   onSelect,
 }: {
   iteration: EvalIteration;
+  index: number;
   isSelected: boolean;
   onSelect: () => void;
 }) {
@@ -667,6 +670,23 @@ function IterationListItem({
   const modelName = testInfo?.model || "—";
 
   const computedResult = computeIterationResult(iteration);
+  const passed = computeIterationPassed(iteration);
+
+  // Extract a distinguishing detail from the query or expected tool call args
+  const distinguisher = useMemo(() => {
+    if (!testInfo) return null;
+    // Try to get key params from expected tool calls
+    const expectedArgs = testInfo.expectedToolCalls?.[0]?.arguments;
+    if (expectedArgs && Object.keys(expectedArgs).length > 0) {
+      const entries = Object.entries(expectedArgs).slice(0, 2);
+      return entries.map(([k, v]) => `${k}: ${typeof v === 'object' ? JSON.stringify(v) : v}`).join(', ');
+    }
+    // Fall back to first ~60 chars of query if different from title
+    if (testInfo.query && testInfo.query !== testInfo.title) {
+      return testInfo.query.length > 60 ? testInfo.query.slice(0, 57) + '...' : testInfo.query;
+    }
+    return null;
+  }, [testInfo]);
 
   return (
     <div className={`relative ${isPending ? "opacity-60" : ""}`}>
@@ -683,23 +703,38 @@ function IterationListItem({
             : "hover:bg-muted/50"
         }`}
       >
-        <div className="flex items-center gap-2 min-w-0">
+        <div className="flex items-center gap-1.5 min-w-0">
+          {/* Sequence number */}
+          <span className="text-[10px] text-muted-foreground font-mono shrink-0 w-4 text-right">
+            {index}
+          </span>
+          {/* Pass/fail icon */}
+          {isPending ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-warning shrink-0" />
+          ) : passed ? (
+            <CheckCircle2 className="h-3.5 w-3.5 text-emerald-500 shrink-0" />
+          ) : (
+            <XCircle className="h-3.5 w-3.5 text-destructive shrink-0" />
+          )}
           <span className="text-xs font-medium truncate flex-1">
             {testInfo?.title || "Iteration"}
           </span>
-          {isPending && (
-            <Loader2 className="h-3 w-3 animate-spin text-warning shrink-0" />
-          )}
           {testInfo?.isNegativeTest && (
             <span
-              className="text-[10px] text-orange-500 shrink-0"
-              title="Negative test"
+              className="text-[9px] font-medium px-1 py-0.5 rounded bg-orange-500/15 text-orange-500 shrink-0"
+              title="Negative test — expects the tool NOT to be called"
             >
-              NEG
+              Negative
             </span>
           )}
         </div>
-        <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+        {/* Distinguishing detail */}
+        {distinguisher && (
+          <div className="ml-[calc(1rem+0.375rem+0.875rem)] text-[10px] text-muted-foreground/70 truncate italic">
+            {distinguisher}
+          </div>
+        )}
+        <div className="ml-[calc(1rem+0.375rem+0.875rem)] flex items-center gap-2 text-[10px] text-muted-foreground">
           <span className="font-mono truncate">{modelName}</span>
           <span className="shrink-0">
             {isPending


### PR DESCRIPTION
### TL;DR

Redesigned the evaluation suite sidebar to group suites by name and improved the visual layout with better status indicators and expandable groups.

### What changed?

- **Suite Grouping**: Suites with the same name are now grouped together, with the most recent run shown as the primary entry and a count badge indicating multiple versions
- **Expandable Groups**: Multi-version suite groups can be expanded to show individual entries with timestamps and status indicators
- **Visual Improvements**: 
  - Renamed "Overview" to "Dashboard" with updated styling
  - Changed sidebar mode labels from "Runs"/"Suites" to "By Commit"/"By Suite"
  - Improved commit list layout with better spacing and status positioning
  - Added color-coded trend charts (green/amber/red based on pass rates)
- **Enhanced Test Case Display**:
  - Added negative test indicators with shield icons and explanatory text
  - Improved iteration list with sequence numbers and distinguishing details
  - Updated pass criteria badges to show "Passed (X failed)" for suites that pass overall but have individual failures
- **Better Status Indicators**: More prominent visual cues for pass/fail states with appropriate icons and colors
