### PR TITLE
Simplify evals dash cont.

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/ci-suite-detail.tsx
+++ b/mcpjam-inspector/client/src/components/evals/ci-suite-detail.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import { SuiteHeader } from "./suite-header";
-import { RunOverview } from "./run-overview";
+import { SuiteHeroStats } from "./suite-hero-stats";
+import { RunAccordionView } from "./run-accordion-view";
 import { RunDetailView } from "./run-detail-view";
-import { TestCasesOverview } from "./test-cases-overview";
 import { TestCaseDetailView } from "./test-case-detail-view";
 import { useSuiteData, useRunDetailData } from "./use-suite-data";
 import type {
@@ -66,15 +66,10 @@ export function CiSuiteDetail({
       : route.type === "test-detail"
         ? "test-detail"
         : "overview";
-  const runsViewMode =
-    route.type === "suite-overview" && route.view === "test-cases"
-      ? "test-cases"
-      : "runs";
-
   const [showRunSummarySidebar, setShowRunSummarySidebar] = useState(false);
   const [runDetailSortBy, setRunDetailSortBy] = useState<
     "model" | "test" | "result"
-  >("test");
+  >("result");
 
   const { runTrendData, modelStats } = useSuiteData(
     suite,
@@ -158,7 +153,7 @@ export function CiSuiteDetail({
     navigateToCiEvalsRoute({
       type: "suite-overview",
       suiteId: suite._id,
-      view: runsViewMode,
+      view: "test-cases",
     });
   };
 
@@ -186,7 +181,7 @@ export function CiSuiteDetail({
           deletingRunId={deletingRunId}
           showRunSummarySidebar={showRunSummarySidebar}
           setShowRunSummarySidebar={setShowRunSummarySidebar}
-          runsViewMode={runsViewMode}
+          runsViewMode={"test-cases"}
           runs={runs}
           allIterations={allIterations}
           aggregate={aggregate}
@@ -214,6 +209,13 @@ export function CiSuiteDetail({
                 iterations={caseIterations}
                 runs={runs}
                 serverNames={connectedSuiteServers}
+                suiteName={suite.name}
+                onNavigateToSuite={() => {
+                  navigateToCiEvalsRoute({
+                    type: "suite-overview",
+                    suiteId: suite._id,
+                  });
+                }}
                 onBack={() => {
                   navigateToCiEvalsRoute({
                     type: "suite-overview",
@@ -232,54 +234,30 @@ export function CiSuiteDetail({
             );
           })()
         ) : viewMode === "overview" ? (
-          <div key={runsViewMode} className="space-y-4">
-            {runsViewMode === "runs" ? (
-              <RunOverview
-                suite={suite}
-                runs={runs}
-                runsLoading={runsLoading}
-                allIterations={allIterations}
-                runTrendData={runTrendData}
-                modelStats={modelStats}
-                onRunClick={handleRunClick}
-                onDirectDeleteRun={onDirectDeleteRun}
-                runsViewMode={runsViewMode}
-                onViewModeChange={(value) => {
-                  navigateToCiEvalsRoute({
-                    type: "suite-overview",
-                    suiteId: suite._id,
-                    view: value,
-                  });
-                }}
-                userMap={userMap}
-              />
-            ) : (
-              <TestCasesOverview
-                suite={suite}
-                cases={cases}
-                allIterations={allIterations}
-                runs={runs}
-                runsViewMode={runsViewMode}
-                onViewModeChange={(value) => {
-                  navigateToCiEvalsRoute({
-                    type: "suite-overview",
-                    suiteId: suite._id,
-                    view: value,
-                  });
-                }}
-                onTestCaseClick={(testCaseId) => {
-                  navigateToCiEvalsRoute({
-                    type: "test-detail",
-                    suiteId: suite._id,
-                    testId: testCaseId,
-                  });
-                }}
-                runTrendData={runTrendData}
-                modelStats={modelStats}
-                runsLoading={runsLoading}
-                onRunClick={handleRunClick}
-              />
-            )}
+          <div className="space-y-4 overflow-y-auto h-full p-0.5">
+            <SuiteHeroStats
+              runs={runs}
+              allIterations={allIterations}
+              runTrendData={runTrendData}
+              modelStats={modelStats}
+              testCaseCount={cases.length}
+              isSDK={suite.source === "sdk"}
+              onRunClick={handleRunClick}
+            />
+            <RunAccordionView
+              suite={suite}
+              runs={runs}
+              allIterations={allIterations}
+              onRunClick={handleRunClick}
+              onTestCaseClick={(testCaseId) => {
+                navigateToCiEvalsRoute({
+                  type: "test-detail",
+                  suiteId: suite._id,
+                  testId: testCaseId,
+                });
+              }}
+              userMap={userMap}
+            />
           </div>
         ) : viewMode === "run-detail" && selectedRunDetails ? (
           <RunDetailView

--- a/mcpjam-inspector/client/src/components/evals/run-accordion-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-accordion-view.tsx
@@ -1,0 +1,381 @@
+import { useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { getInitials } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { formatRunId, getIterationBorderColor } from "./helpers";
+import { computeIterationResult } from "./pass-criteria";
+import { CiMetadataDisplay } from "./ci-metadata-display";
+import type { EvalIteration, EvalSuiteRun } from "./types";
+
+interface RunAccordionViewProps {
+  suite: { _id: string; name: string; source?: "ui" | "sdk" };
+  runs: EvalSuiteRun[];
+  allIterations: EvalIteration[];
+  onRunClick: (runId: string) => void;
+  onTestCaseClick?: (testCaseId: string) => void;
+  userMap?: Map<string, { name: string; imageUrl?: string }>;
+}
+
+interface RunTestCase {
+  testCaseId: string;
+  title: string;
+  result: "passed" | "failed" | "pending" | "cancelled";
+  duration: number;
+  model?: string;
+}
+
+export function RunAccordionView({
+  suite,
+  runs,
+  allIterations,
+  onRunClick,
+  onTestCaseClick,
+  userMap,
+}: RunAccordionViewProps) {
+  // Sort runs by time (latest first)
+  const sortedRuns = useMemo(
+    () =>
+      [...runs]
+        .filter((r) => r.isActive !== false)
+        .sort((a, b) => {
+          const aTime = a.completedAt ?? a.createdAt ?? 0;
+          const bTime = b.completedAt ?? b.createdAt ?? 0;
+          return bTime - aTime;
+        }),
+    [runs],
+  );
+
+  // Start with only the latest run expanded
+  const [expandedRunIds, setExpandedRunIds] = useState<Set<string>>(() => {
+    if (sortedRuns.length > 0) {
+      return new Set([sortedRuns[0]._id]);
+    }
+    return new Set();
+  });
+
+  const toggleRun = (runId: string) => {
+    setExpandedRunIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(runId)) {
+        next.delete(runId);
+      } else {
+        next.add(runId);
+      }
+      return next;
+    });
+  };
+
+  // Pre-compute test cases for each run
+  const runTestCases = useMemo(() => {
+    const map = new Map<string, RunTestCase[]>();
+    for (const run of sortedRuns) {
+      const runIterations = allIterations.filter(
+        (iter) => iter.suiteRunId === run._id,
+      );
+      const testCases: RunTestCase[] = runIterations.map((iter) => ({
+        testCaseId: iter.testCaseId ?? "",
+        title:
+          iter.testCaseSnapshot?.title || "Untitled test",
+        result: computeIterationResult(iter),
+        duration:
+          iter.startedAt && iter.updatedAt
+            ? iter.updatedAt - iter.startedAt
+            : 0,
+        model: iter.testCaseSnapshot?.model,
+      }));
+      // Sort: failed first, then passed, then pending
+      testCases.sort((a, b) => {
+        const order = { failed: 0, pending: 1, cancelled: 2, passed: 3 };
+        return (order[a.result] ?? 4) - (order[b.result] ?? 4);
+      });
+      map.set(run._id, testCases);
+    }
+    return map;
+  }, [sortedRuns, allIterations]);
+
+  if (sortedRuns.length === 0) {
+    return (
+      <div className="rounded-xl border bg-card p-8 text-center text-sm text-muted-foreground">
+        No runs yet. Run your suite to see results here.
+      </div>
+    );
+  }
+
+  const metricLabel = suite.source === "sdk" ? "Pass Rate" : "Accuracy";
+
+  return (
+    <div className="rounded-xl border bg-card text-card-foreground divide-y">
+      {sortedRuns.map((run, index) => {
+        const isExpanded = expandedRunIds.has(run._id);
+        const testCases = runTestCases.get(run._id) ?? [];
+        const passed = testCases.filter((t) => t.result === "passed").length;
+        const failed = testCases.filter((t) => t.result === "failed").length;
+        const total = passed + failed;
+        const passRate = total > 0 ? Math.round((passed / total) * 100) : null;
+
+        const runResult =
+          run.result ||
+          (run.status === "completed" && passRate !== null
+            ? passRate >= (run.passCriteria?.minimumPassRate ?? 100)
+              ? "passed"
+              : "failed"
+            : run.status === "cancelled"
+              ? "cancelled"
+              : "pending");
+        const borderColor = getIterationBorderColor(runResult);
+
+        const duration =
+          run.completedAt && run.createdAt
+            ? formatDuration(run.completedAt - run.createdAt)
+            : run.createdAt && run.status === "running"
+              ? formatDuration(Date.now() - run.createdAt)
+              : null;
+
+        const timestamp = run.completedAt ?? run.createdAt;
+        const timeAgo = timestamp ? formatTimeAgo(timestamp) : null;
+
+        const creator = run.createdBy && userMap?.get(run.createdBy);
+
+        const showCiMetadata =
+          !!run.ciMetadata?.branch ||
+          !!run.ciMetadata?.commitSha ||
+          !!run.ciMetadata?.runUrl;
+
+        return (
+          <div key={run._id} className="relative">
+            {/* Colored left border */}
+            <div
+              className={`absolute left-0 top-0 h-full w-1 ${borderColor} ${index === 0 ? "rounded-tl-xl" : ""} ${index === sortedRuns.length - 1 && !isExpanded ? "rounded-bl-xl" : ""}`}
+            />
+
+            {/* Run header — clickable to expand/collapse */}
+            <button
+              onClick={() => toggleRun(run._id)}
+              className="flex w-full items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/50"
+            >
+              {/* Expand/collapse chevron */}
+              <span className="shrink-0 text-muted-foreground">
+                {isExpanded ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
+                  <ChevronRight className="h-4 w-4" />
+                )}
+              </span>
+
+              {/* Run info */}
+              <div className="flex flex-1 items-center gap-3 min-w-0">
+                <span className="text-xs font-medium shrink-0">
+                  Run {formatRunId(run._id)}
+                </span>
+
+                {timeAgo && (
+                  <span className="text-xs text-muted-foreground shrink-0">
+                    {timeAgo}
+                  </span>
+                )}
+
+                {duration && (
+                  <span className="text-xs font-mono text-muted-foreground shrink-0">
+                    {duration}
+                  </span>
+                )}
+
+                {showCiMetadata && (
+                  <span className="shrink-0">
+                    <CiMetadataDisplay
+                      ciMetadata={run.ciMetadata}
+                      compact={true}
+                      compactMode="chip"
+                      interactive={false}
+                    />
+                  </span>
+                )}
+
+                {/* Spacer */}
+                <span className="flex-1" />
+
+                {/* Pass/fail summary */}
+                {total > 0 && (
+                  <span className="flex items-center gap-2 shrink-0">
+                    <span className="text-xs font-mono">
+                      <span className="text-green-500">{passed}</span>
+                      {failed > 0 && (
+                        <>
+                          <span className="text-muted-foreground"> / </span>
+                          <span className="text-red-500">{failed}</span>
+                        </>
+                      )}
+                    </span>
+                    {passRate !== null && (
+                      <span
+                        className={cn(
+                          "text-xs font-medium px-1.5 py-0.5 rounded",
+                          passRate === 100
+                            ? "bg-green-500/15 text-green-500"
+                            : passRate >= 80
+                              ? "bg-yellow-500/15 text-yellow-500"
+                              : "bg-red-500/15 text-red-500",
+                        )}
+                      >
+                        {passRate}%
+                      </span>
+                    )}
+                  </span>
+                )}
+
+                {run.status === "running" && (
+                  <span className="text-xs text-yellow-500 font-medium shrink-0">
+                    Running...
+                  </span>
+                )}
+
+                {/* Avatar */}
+                {creator && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Avatar className="size-5 shrink-0">
+                        <AvatarImage
+                          src={creator.imageUrl}
+                          alt={creator.name}
+                        />
+                        <AvatarFallback className="text-[9px]">
+                          {getInitials(creator.name)}
+                        </AvatarFallback>
+                      </Avatar>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p className="text-xs">{creator.name}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                )}
+              </div>
+            </button>
+
+            {/* Expanded test cases */}
+            {isExpanded && (
+              <div className="border-t bg-muted/20">
+                {testCases.length === 0 ? (
+                  <div className="px-10 py-4 text-xs text-muted-foreground">
+                    {run.status === "running" || run.status === "pending"
+                      ? "Tests are still running..."
+                      : "No test results."}
+                  </div>
+                ) : (
+                  <div className="divide-y divide-border/50">
+                    {testCases.map((tc, tcIndex) => {
+                      const resultIcon =
+                        tc.result === "passed"
+                          ? "text-green-500"
+                          : tc.result === "failed"
+                            ? "text-red-500"
+                            : "text-muted-foreground";
+
+                      return (
+                        <button
+                          key={`${tc.testCaseId}-${tcIndex}`}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (tc.testCaseId && onTestCaseClick) {
+                              onTestCaseClick(tc.testCaseId);
+                            } else {
+                              onRunClick(run._id);
+                            }
+                          }}
+                          className="flex w-full items-center gap-3 px-4 pl-11 py-2 text-left transition-colors hover:bg-muted/50"
+                        >
+                          {/* Status dot */}
+                          <span
+                            className={cn(
+                              "h-2 w-2 rounded-full shrink-0",
+                              tc.result === "passed"
+                                ? "bg-green-500"
+                                : tc.result === "failed"
+                                  ? "bg-red-500"
+                                  : "bg-muted-foreground",
+                            )}
+                          />
+
+                          {/* Test name */}
+                          <span className="text-xs flex-1 min-w-0 truncate">
+                            {tc.title}
+                          </span>
+
+                          {/* Model (if shown) */}
+                          {tc.model && (
+                            <span className="text-[10px] text-muted-foreground shrink-0">
+                              {tc.model}
+                            </span>
+                          )}
+
+                          {/* Duration */}
+                          {tc.duration > 0 && (
+                            <span className="text-xs font-mono text-muted-foreground shrink-0">
+                              {formatDuration(tc.duration)}
+                            </span>
+                          )}
+
+                          {/* Result label */}
+                          <span
+                            className={cn(
+                              "text-xs font-medium shrink-0",
+                              resultIcon,
+                            )}
+                          >
+                            {tc.result === "passed"
+                              ? "Passed"
+                              : tc.result === "failed"
+                                ? "Failed"
+                                : tc.result === "cancelled"
+                                  ? "Cancelled"
+                                  : "Pending"}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+
+                {/* "View full run details" link */}
+                <button
+                  onClick={() => onRunClick(run._id)}
+                  className="w-full px-4 pl-11 py-2 text-left text-xs text-primary hover:underline border-t border-border/50"
+                >
+                  View full run details
+                </button>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function formatTimeAgo(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatDuration(durationMs: number): string {
+  if (durationMs < 1000) return `${Math.round(durationMs)}ms`;
+  const totalSeconds = Math.round(durationMs / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+}

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -1,21 +1,11 @@
 import { useMemo } from "react";
-import { X, Loader2, CheckCircle2, XCircle, AlertTriangle } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Loader2, CheckCircle2, XCircle } from "lucide-react";
 import {
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
-import {
-  BarChart,
-  Bar,
-  CartesianGrid,
-  PieChart,
-  Pie,
-  XAxis,
-  YAxis,
-  Label,
-} from "recharts";
+import { PieChart, Pie, Label } from "recharts";
 import { PassCriteriaBadge } from "./pass-criteria-badge";
 import { IterationDetails } from "./iteration-details";
 import { getIterationBorderColor } from "./helpers";
@@ -288,6 +278,40 @@ export function RunDetailView({
               metricLabel={metricLabel}
             />
           </div>
+
+          {/* Inline model performance (only when ≥2 models) */}
+          {selectedRunChartData.modelData.length >= 2 && (
+            <div className="flex items-center gap-4 mt-2 pt-2 border-t border-border/50">
+              <span className="text-[10px] text-muted-foreground">
+                By Model:
+              </span>
+              {selectedRunChartData.modelData.map((model) => (
+                <div
+                  key={model.model}
+                  className="flex items-center gap-1.5"
+                >
+                  <div
+                    className="h-1.5 w-1.5 rounded-full"
+                    style={{
+                      backgroundColor:
+                        model.passRate >= 80
+                          ? "hsl(142.1 76.2% 36.3%)"
+                          : model.passRate >= 50
+                            ? "hsl(45.4 93.4% 47.5%)"
+                            : "hsl(0 84.2% 60.2%)",
+                    }}
+                  />
+                  <span className="text-[11px]">{model.model}</span>
+                  <span className="text-[11px] font-mono font-medium">
+                    {model.passRate}%
+                  </span>
+                  <span className="text-[10px] text-muted-foreground">
+                    ({model.passed}/{model.total})
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </div>
 
@@ -316,15 +340,12 @@ export function RunDetailView({
                   No iterations found.
                 </div>
               ) : (
-                caseGroupsForSelectedRun.map((iteration, idx) => (
-                  <IterationListItem
-                    key={iteration._id}
-                    iteration={iteration}
-                    index={idx + 1}
-                    isSelected={selectedIterationId === iteration._id}
-                    onSelect={() => onSelectIteration(iteration._id)}
-                  />
-                ))
+                <IterationListWithSections
+                  iterations={caseGroupsForSelectedRun}
+                  sortBy={runDetailSortBy}
+                  selectedIterationId={selectedIterationId}
+                  onSelectIteration={onSelectIteration}
+                />
               )}
             </div>
           </div>
@@ -356,294 +377,113 @@ export function RunDetailView({
         </div>
       </div>
 
-      {/* Run Summary Sidebar */}
-      {showRunSummarySidebar && (
-        <>
-          <div
-            className="fixed inset-0 bg-black/50 z-40 animate-in fade-in duration-200"
-            onClick={() => setShowRunSummarySidebar(false)}
+    </div>
+  );
+}
+
+// Iteration list with section headers when sorted by result
+function IterationListWithSections({
+  iterations,
+  sortBy,
+  selectedIterationId,
+  onSelectIteration,
+}: {
+  iterations: EvalIteration[];
+  sortBy: "model" | "test" | "result";
+  selectedIterationId: string | null;
+  onSelectIteration: (id: string) => void;
+}) {
+  if (sortBy !== "result") {
+    // No sections — just render flat list
+    return (
+      <>
+        {iterations.map((iteration, idx) => (
+          <IterationListItem
+            key={iteration._id}
+            iteration={iteration}
+            index={idx + 1}
+            isSelected={selectedIterationId === iteration._id}
+            onSelect={() => onSelectIteration(iteration._id)}
           />
+        ))}
+      </>
+    );
+  }
 
-          <div className="fixed right-0 top-0 bottom-0 w-[500px] bg-background border-l z-50 overflow-y-auto animate-in slide-in-from-right duration-300">
-            <div className="sticky top-0 bg-background border-b px-4 py-3 flex items-center justify-between z-10">
-              <div className="text-sm font-semibold">Run Summary</div>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => setShowRunSummarySidebar(false)}
-              >
-                <X className="h-4 w-4" />
-              </Button>
-            </div>
+  // Group by result: failing first, then passing, then pending/cancelled
+  const failing = iterations.filter(
+    (i) => computeIterationResult(i) === "failed",
+  );
+  const passing = iterations.filter(
+    (i) => computeIterationResult(i) === "passed",
+  );
+  const other = iterations.filter((i) => {
+    const r = computeIterationResult(i);
+    return r !== "failed" && r !== "passed";
+  });
 
-            <div className="p-4 space-y-4">
-              {/* Charts */}
-              {(selectedRunChartData.durationData.length > 0 ||
-                selectedRunChartData.tokensData.length > 0 ||
-                selectedRunChartData.modelData.length > 0) && (
-                <div className="space-y-4">
-                  {/* Duration per Test Bar Chart */}
-                  {selectedRunChartData.durationData.length > 0 && (
-                    <div className="rounded-lg border bg-background/50 p-4">
-                      <div className="text-xs font-medium text-muted-foreground mb-3">
-                        Duration per Test
-                      </div>
-                      <ChartContainer
-                        config={{
-                          duration: {
-                            label: "Duration",
-                            color: "var(--chart-1)",
-                          },
-                        }}
-                        className="aspect-auto h-64 w-full"
-                      >
-                        <BarChart
-                          data={selectedRunChartData.durationData}
-                          width={undefined}
-                          height={undefined}
-                        >
-                          <CartesianGrid
-                            strokeDasharray="3 3"
-                            vertical={false}
-                            stroke="hsl(var(--muted-foreground) / 0.2)"
-                          />
-                          <XAxis
-                            dataKey="name"
-                            tickLine={false}
-                            axisLine={false}
-                            tickMargin={8}
-                            tick={{
-                              fontSize: 10,
-                              angle: -45,
-                              textAnchor: "end",
-                            }}
-                            interval={0}
-                            height={80}
-                            tickFormatter={(value) => {
-                              if (value.length > 20) {
-                                return value.substring(0, 17) + "...";
-                              }
-                              return value;
-                            }}
-                          />
-                          <YAxis
-                            tickLine={false}
-                            axisLine={false}
-                            tickMargin={8}
-                            tick={{ fontSize: 12 }}
-                            tickFormatter={(value) => `${value.toFixed(1)}s`}
-                          />
-                          <ChartTooltip
-                            cursor={false}
-                            content={({ active, payload }) => {
-                              if (!active || !payload || payload.length === 0)
-                                return null;
-                              const data = payload[0].payload;
-                              return (
-                                <div className="rounded-lg border bg-background p-2 shadow-sm">
-                                  <div className="text-xs font-semibold">
-                                    {data.name}
-                                  </div>
-                                  <div className="text-sm font-medium mt-1">
-                                    {data.durationSeconds.toFixed(2)}s
-                                  </div>
-                                </div>
-                              );
-                            }}
-                          />
-                          <Bar
-                            dataKey="durationSeconds"
-                            fill="var(--color-duration)"
-                            radius={[4, 4, 0, 0]}
-                            isAnimationActive={false}
-                          />
-                        </BarChart>
-                      </ChartContainer>
-                    </div>
-                  )}
+  let globalIdx = 0;
 
-                  {/* Tokens per Test Bar Chart */}
-                  {selectedRunChartData.tokensData.length > 0 && (
-                    <div className="rounded-lg border bg-background/50 p-4">
-                      <div className="text-xs font-medium text-muted-foreground mb-3">
-                        Tokens per Test
-                      </div>
-                      <ChartContainer
-                        config={{
-                          tokens: {
-                            label: "Tokens",
-                            color: "var(--chart-2)",
-                          },
-                        }}
-                        className="aspect-auto h-64 w-full"
-                      >
-                        <BarChart
-                          data={selectedRunChartData.tokensData}
-                          width={undefined}
-                          height={undefined}
-                        >
-                          <CartesianGrid
-                            strokeDasharray="3 3"
-                            vertical={false}
-                            stroke="hsl(var(--muted-foreground) / 0.2)"
-                          />
-                          <XAxis
-                            dataKey="name"
-                            tickLine={false}
-                            axisLine={false}
-                            tickMargin={8}
-                            tick={{
-                              fontSize: 10,
-                              angle: -45,
-                              textAnchor: "end",
-                            }}
-                            interval={0}
-                            height={80}
-                            tickFormatter={(value) => {
-                              if (value.length > 20) {
-                                return value.substring(0, 17) + "...";
-                              }
-                              return value;
-                            }}
-                          />
-                          <YAxis
-                            tickLine={false}
-                            axisLine={false}
-                            tickMargin={8}
-                            tick={{ fontSize: 12 }}
-                            tickFormatter={(value) => value.toLocaleString()}
-                          />
-                          <ChartTooltip
-                            cursor={false}
-                            content={({ active, payload }) => {
-                              if (!active || !payload || payload.length === 0)
-                                return null;
-                              const data = payload[0].payload;
-                              return (
-                                <div className="rounded-lg border bg-background p-2 shadow-sm">
-                                  <div className="text-xs font-semibold">
-                                    {data.name}
-                                  </div>
-                                  <div className="text-sm font-medium mt-1">
-                                    {Math.round(data.tokens).toLocaleString()}{" "}
-                                    tokens
-                                  </div>
-                                </div>
-                              );
-                            }}
-                          />
-                          <Bar
-                            dataKey="tokens"
-                            fill="var(--color-tokens)"
-                            radius={[4, 4, 0, 0]}
-                            isAnimationActive={false}
-                          />
-                        </BarChart>
-                      </ChartContainer>
-                    </div>
-                  )}
-
-                  {/* Per-Model Performance for this run */}
-                  {selectedRunChartData.modelData.length > 1 && (
-                    <div className="rounded-lg border bg-background/50 p-4">
-                      <div className="text-xs font-medium text-muted-foreground mb-3">
-                        Performance by model
-                      </div>
-                      <ChartContainer
-                        config={{
-                          passRate: {
-                            label: metricLabel,
-                            color: "var(--chart-1)",
-                          },
-                        }}
-                        className="aspect-auto h-48 w-full"
-                      >
-                        <BarChart
-                          data={selectedRunChartData.modelData}
-                          width={undefined}
-                          height={undefined}
-                        >
-                          <CartesianGrid
-                            strokeDasharray="3 3"
-                            vertical={false}
-                            stroke="hsl(var(--muted-foreground) / 0.2)"
-                          />
-                          <XAxis
-                            dataKey="model"
-                            tickLine={false}
-                            axisLine={false}
-                            tickMargin={8}
-                            tick={{ fontSize: 11 }}
-                            interval={0}
-                            height={40}
-                            tickFormatter={(value) => {
-                              if (value.length > 15) {
-                                return value.substring(0, 12) + "...";
-                              }
-                              return value;
-                            }}
-                          />
-                          <YAxis
-                            domain={[0, 100]}
-                            tickLine={false}
-                            axisLine={false}
-                            tickMargin={8}
-                            tick={{ fontSize: 12 }}
-                            tickFormatter={(value) => `${value}%`}
-                          />
-                          <ChartTooltip
-                            cursor={false}
-                            content={({ active, payload }) => {
-                              if (!active || !payload || payload.length === 0)
-                                return null;
-                              const data = payload[0].payload;
-                              return (
-                                <div className="rounded-lg border bg-background p-2 shadow-sm">
-                                  <div className="grid gap-2">
-                                    <div className="flex flex-col">
-                                      <span className="text-xs font-semibold">
-                                        {data.model}
-                                      </span>
-                                      <span className="text-xs text-muted-foreground mt-0.5">
-                                        {data.passed} passed · {data.failed}{" "}
-                                        failed
-                                      </span>
-                                    </div>
-                                    <div className="flex items-center gap-2">
-                                      <div
-                                        className="h-2 w-2 rounded-full"
-                                        style={{
-                                          backgroundColor:
-                                            "var(--color-passRate)",
-                                        }}
-                                      />
-                                      <span className="text-sm font-semibold">
-                                        {data.passRate}%
-                                      </span>
-                                    </div>
-                                  </div>
-                                </div>
-                              );
-                            }}
-                          />
-                          <Bar
-                            dataKey="passRate"
-                            fill="var(--color-passRate)"
-                            radius={[4, 4, 0, 0]}
-                            isAnimationActive={false}
-                            minPointSize={8}
-                          />
-                        </BarChart>
-                      </ChartContainer>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
+  return (
+    <>
+      {failing.length > 0 && (
+        <>
+          <div className="px-3 py-1.5 bg-red-500/10 text-[10px] font-semibold text-red-500 uppercase tracking-wide sticky top-0 z-[1]">
+            Failing ({failing.length})
           </div>
+          {failing.map((iteration) => {
+            globalIdx++;
+            return (
+              <IterationListItem
+                key={iteration._id}
+                iteration={iteration}
+                index={globalIdx}
+                isSelected={selectedIterationId === iteration._id}
+                onSelect={() => onSelectIteration(iteration._id)}
+              />
+            );
+          })}
         </>
       )}
-    </div>
+      {passing.length > 0 && (
+        <>
+          <div className="px-3 py-1.5 bg-green-500/10 text-[10px] font-semibold text-green-500 uppercase tracking-wide sticky top-0 z-[1]">
+            Passing ({passing.length})
+          </div>
+          {passing.map((iteration) => {
+            globalIdx++;
+            return (
+              <IterationListItem
+                key={iteration._id}
+                iteration={iteration}
+                index={globalIdx}
+                isSelected={selectedIterationId === iteration._id}
+                onSelect={() => onSelectIteration(iteration._id)}
+              />
+            );
+          })}
+        </>
+      )}
+      {other.length > 0 && (
+        <>
+          <div className="px-3 py-1.5 bg-muted/50 text-[10px] font-semibold text-muted-foreground uppercase tracking-wide sticky top-0 z-[1]">
+            Pending / Cancelled ({other.length})
+          </div>
+          {other.map((iteration) => {
+            globalIdx++;
+            return (
+              <IterationListItem
+                key={iteration._id}
+                iteration={iteration}
+                index={globalIdx}
+                isSelected={selectedIterationId === iteration._id}
+                onSelect={() => onSelectIteration(iteration._id)}
+              />
+            );
+          })}
+        </>
+      )}
+    </>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/evals/run-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-overview.tsx
@@ -17,13 +17,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
-import { AccuracyChart } from "./accuracy-chart";
 import { formatRunId, getIterationBorderColor } from "./helpers";
 import { computeIterationResult } from "./pass-criteria";
 import { EvalIteration, EvalSuiteRun } from "./types";
@@ -326,132 +319,8 @@ export function RunOverview({
       });
   }, [selectedRunIds, onDirectDeleteRun]);
 
-  const modelChartConfig = {
-    passRate: {
-      label: "Pass Rate",
-      color: "var(--chart-1)",
-    },
-  };
-
   return (
     <>
-      {/* Charts Side by Side */}
-      <div className="grid gap-4 lg:grid-cols-2">
-        {/* Accuracy */}
-        <div className="rounded-xl border bg-card text-card-foreground">
-          <div className="px-4 pt-3 pb-2">
-            <div className="text-xs font-medium text-muted-foreground">
-              {suite.source === "sdk" ? "Pass Rate Trend" : "Accuracy Trend"}
-            </div>
-          </div>
-          <div className="px-4 pb-4">
-            <AccuracyChart
-              data={runTrendData}
-              isLoading={runsLoading}
-              height="h-32"
-              onClick={onRunClick}
-              metricLabel={suite.source === "sdk" ? "Pass Rate" : "Accuracy"}
-            />
-          </div>
-        </div>
-
-        {/* Per-Model Performance */}
-        <div className="rounded-xl border bg-card text-card-foreground">
-          <div className="px-4 pt-3 pb-2">
-            <div className="text-xs font-medium text-muted-foreground">
-              Performance by model
-            </div>
-          </div>
-          <div className="px-4 pb-4">
-            {modelStats.length > 1 ? (
-              <ChartContainer
-                config={modelChartConfig}
-                className="aspect-auto h-32 w-full"
-              >
-                <BarChart
-                  data={modelStats}
-                  width={undefined}
-                  height={undefined}
-                >
-                  <CartesianGrid
-                    strokeDasharray="3 3"
-                    vertical={false}
-                    stroke="hsl(var(--muted-foreground) / 0.2)"
-                  />
-                  <XAxis
-                    dataKey="model"
-                    tickLine={false}
-                    axisLine={false}
-                    tickMargin={8}
-                    tick={{ fontSize: 11 }}
-                    interval={0}
-                    height={40}
-                    tickFormatter={(value) => {
-                      if (value.length > 15) {
-                        return value.substring(0, 12) + "...";
-                      }
-                      return value;
-                    }}
-                  />
-                  <YAxis
-                    domain={[0, 100]}
-                    tickLine={false}
-                    axisLine={false}
-                    tickMargin={8}
-                    tick={{ fontSize: 12 }}
-                    tickFormatter={(value) => `${value}%`}
-                  />
-                  <ChartTooltip
-                    cursor={false}
-                    content={({ active, payload }) => {
-                      if (!active || !payload || payload.length === 0)
-                        return null;
-                      const data = payload[0].payload;
-                      return (
-                        <div className="rounded-lg border bg-background p-2 shadow-sm">
-                          <div className="grid gap-2">
-                            <div className="flex flex-col">
-                              <span className="text-xs font-semibold">
-                                {data.model}
-                              </span>
-                              <span className="text-xs text-muted-foreground mt-0.5">
-                                {data.passed} passed · {data.failed} failed
-                              </span>
-                            </div>
-                            <div className="flex items-center gap-2">
-                              <div
-                                className="h-2 w-2 rounded-full"
-                                style={{
-                                  backgroundColor: "var(--color-passRate)",
-                                }}
-                              />
-                              <span className="text-sm font-semibold">
-                                {data.passRate}%
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      );
-                    }}
-                  />
-                  <Bar
-                    dataKey="passRate"
-                    fill="var(--color-passRate)"
-                    radius={[4, 4, 0, 0]}
-                    isAnimationActive={false}
-                    minPointSize={8}
-                  />
-                </BarChart>
-              </ChartContainer>
-            ) : (
-              <p className="text-xs text-muted-foreground">
-                No model data available.
-              </p>
-            )}
-          </div>
-        </div>
-      </div>
-
       {/* Runs List */}
       <div className="rounded-xl border bg-card text-card-foreground flex flex-col max-h-[600px]">
         {selectedRunIds.size > 0 ? (

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -15,12 +15,6 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
-import { PieChart, Pie, Label } from "recharts";
 import { BarChart3, Loader2, Plus, RotateCw, Trash2, X } from "lucide-react";
 import { formatRunId } from "./helpers";
 import {
@@ -32,7 +26,7 @@ import {
 } from "./types";
 import { useMutation } from "convex/react";
 import { toast } from "sonner";
-import { computeIterationResult } from "./pass-criteria";
+
 import type { ModelDefinition } from "@/shared/types";
 import { isMCPJamProvidedModel } from "@/shared/types";
 import { ProviderLogo } from "@/components/chat-v2/chat-input/model/provider-logo";
@@ -189,65 +183,6 @@ export function SuiteHeader({
     [suiteModels, onUpdateModels],
   );
 
-  // Calculate accuracy chart data from active runs
-  const accuracyChartData = useMemo(() => {
-    if (!runs || !allIterations || runs.length === 0) {
-      return null;
-    }
-
-    // Filter to active runs only
-    const activeRuns = runs.filter((run) => run.isActive !== false);
-    if (activeRuns.length === 0) {
-      return null;
-    }
-
-    // Get all iterations from active runs
-    const activeRunIds = new Set(activeRuns.map((run) => run._id));
-    const activeIterations = allIterations.filter(
-      (iter) => iter.suiteRunId && activeRunIds.has(iter.suiteRunId),
-    );
-
-    if (activeIterations.length === 0) {
-      return null;
-    }
-
-    // Calculate passed/failed counts using consistent computation
-    // Only count completed iterations - exclude pending/cancelled
-    const iterationResults = activeIterations.map((iter) =>
-      computeIterationResult(iter),
-    );
-    const passed = iterationResults.filter((r) => r === "passed").length;
-    const failed = iterationResults.filter((r) => r === "failed").length;
-    const total = passed + failed; // Only count completed iterations for accuracy
-
-    if (total === 0) {
-      return null;
-    }
-
-    // Build donut chart data
-    const donutData = [];
-    if (passed > 0) {
-      donutData.push({
-        name: "passed",
-        value: passed,
-        fill: "hsl(142.1 76.2% 36.3%)",
-      });
-    }
-    if (failed > 0) {
-      donutData.push({
-        name: "failed",
-        value: failed,
-        fill: "hsl(0 84.2% 60.2%)",
-      });
-    }
-
-    return {
-      donutData,
-      total,
-      accuracy: Math.round((passed / total) * 100),
-    };
-  }, [runs, allIterations]);
-
   const latestRunForMetadata = useMemo(() => {
     if (!runs || runs.length === 0) return null;
     return [...runs].sort((a, b) => {
@@ -342,19 +277,22 @@ export function SuiteHeader({
 
     return (
       <div className="flex items-center justify-between gap-4 mb-4">
-        <h2 className="text-lg font-semibold">
-          Run {formatRunId(selectedRunDetails._id)}
-        </h2>
+        <div>
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+            <button
+              onClick={() => onViewModeChange("overview")}
+              className="hover:text-foreground hover:underline transition-colors cursor-pointer"
+            >
+              {suite.name}
+            </button>
+            <span className="text-muted-foreground/50">/</span>
+            <span className="text-primary font-medium">Run</span>
+          </div>
+          <h2 className="text-lg font-semibold">
+            Run {formatRunId(selectedRunDetails._id)}
+          </h2>
+        </div>
         <div className="flex items-center gap-2 shrink-0">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setShowRunSummarySidebar(!showRunSummarySidebar)}
-            className="gap-2"
-          >
-            <BarChart3 className="h-4 w-4" />
-            View run summary
-          </Button>
           {!readOnlyConfig &&
             (isRunInProgress ? (
               <Tooltip>
@@ -412,18 +350,6 @@ export function SuiteHeader({
             ))}
           <Button
             variant="outline"
-            size="sm"
-            onClick={() => onDeleteRun(selectedRunDetails._id)}
-            disabled={deletingRunId === selectedRunDetails._id}
-            className="gap-2"
-          >
-            <Trash2 className="h-4 w-4" />
-            {deletingRunId === selectedRunDetails._id
-              ? "Deleting..."
-              : "Delete"}
-          </Button>
-          <Button
-            variant="outline"
             size="icon"
             onClick={() => onViewModeChange("overview")}
           >
@@ -468,68 +394,6 @@ export function SuiteHeader({
             ciMetadata={latestRunForMetadata.ciMetadata}
             compact={true}
           />
-        )}
-        {/* Accuracy Chart */}
-        {accuracyChartData && accuracyChartData.donutData.length > 0 && (
-          <div className="flex items-center gap-2">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="text-sm font-medium text-foreground">
-                  Suite Accuracy:
-                </span>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p className="text-xs">Calculated across all active runs.</p>
-              </TooltipContent>
-            </Tooltip>
-            <ChartContainer
-              config={{
-                passed: { label: "Passed", color: "hsl(142.1 76.2% 36.3%)" },
-                failed: { label: "Failed", color: "hsl(0 84.2% 60.2%)" },
-                pending: { label: "Pending", color: "hsl(45.4 93.4% 47.5%)" },
-                cancelled: {
-                  label: "Cancelled",
-                  color: "hsl(240 3.7% 15.9%)",
-                },
-              }}
-              className="h-12 w-12"
-            >
-              <PieChart>
-                <ChartTooltip content={<ChartTooltipContent hideLabel />} />
-                <Pie
-                  data={accuracyChartData.donutData}
-                  dataKey="value"
-                  nameKey="name"
-                  innerRadius={15}
-                  outerRadius={22}
-                  strokeWidth={1}
-                >
-                  <Label
-                    content={({ viewBox }) => {
-                      if (viewBox && "cx" in viewBox && "cy" in viewBox) {
-                        return (
-                          <text
-                            x={viewBox.cx}
-                            y={viewBox.cy}
-                            textAnchor="middle"
-                            dominantBaseline="middle"
-                          >
-                            <tspan
-                              x={viewBox.cx}
-                              y={viewBox.cy}
-                              className="fill-foreground text-[10px] font-bold"
-                            >
-                              {accuracyChartData.accuracy}%
-                            </tspan>
-                          </text>
-                        );
-                      }
-                    }}
-                  />
-                </Pie>
-              </PieChart>
-            </ChartContainer>
-          </div>
         )}
         {!readOnlyConfig && (
           <TagEditor
@@ -750,21 +614,6 @@ export function SuiteHeader({
             </TooltipContent>
           </Tooltip>
         )}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onDelete(suite)}
-              disabled={isDeleting}
-              className="gap-2"
-            >
-              <Trash2 className="h-4 w-4" />
-              {isDeleting ? "Deleting..." : "Delete"}
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>Delete this test suite</TooltipContent>
-        </Tooltip>
       </div>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/evals/suite-hero-stats.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-hero-stats.tsx
@@ -1,0 +1,342 @@
+import { useMemo } from "react";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { PieChart, Pie, Label } from "recharts";
+import { Area, AreaChart } from "recharts";
+import { computeIterationResult } from "./pass-criteria";
+import type { EvalIteration, EvalSuiteRun } from "./types";
+
+interface SuiteHeroStatsProps {
+  runs: EvalSuiteRun[];
+  allIterations: EvalIteration[];
+  runTrendData: Array<{
+    runId: string;
+    runIdDisplay: string;
+    passRate: number;
+    label: string;
+  }>;
+  modelStats: Array<{
+    model: string;
+    passRate: number;
+    passed: number;
+    failed: number;
+    total: number;
+  }>;
+  testCaseCount: number;
+  isSDK: boolean;
+  onRunClick?: (runId: string) => void;
+}
+
+export function SuiteHeroStats({
+  runs,
+  allIterations,
+  runTrendData,
+  modelStats,
+  testCaseCount,
+  isSDK,
+  onRunClick,
+}: SuiteHeroStatsProps) {
+  const stats = useMemo(() => {
+    const activeRuns = runs.filter((run) => run.isActive !== false);
+    if (activeRuns.length === 0) return null;
+
+    const activeRunIds = new Set(activeRuns.map((r) => r._id));
+    const activeIterations = allIterations.filter(
+      (iter) => iter.suiteRunId && activeRunIds.has(iter.suiteRunId),
+    );
+
+    const results = activeIterations.map((iter) => computeIterationResult(iter));
+    const passed = results.filter((r) => r === "passed").length;
+    const failed = results.filter((r) => r === "failed").length;
+    const total = passed + failed;
+
+    if (total === 0) return null;
+
+    const accuracy = Math.round((passed / total) * 100);
+
+    // Latest run info
+    const latestRun = [...activeRuns].sort((a, b) => {
+      const aTime = a.completedAt ?? a.createdAt ?? 0;
+      const bTime = b.completedAt ?? b.createdAt ?? 0;
+      return bTime - aTime;
+    })[0];
+
+    const latestRunTime = latestRun?.completedAt ?? latestRun?.createdAt;
+    const latestRunAgo = latestRunTime ? formatTimeAgo(latestRunTime) : null;
+
+    // Latest run pass/fail
+    const latestRunIterations = allIterations.filter(
+      (iter) => iter.suiteRunId === latestRun?._id,
+    );
+    const latestResults = latestRunIterations.map((iter) =>
+      computeIterationResult(iter),
+    );
+    const latestPassed = latestResults.filter((r) => r === "passed").length;
+    const latestTotal = latestResults.filter(
+      (r) => r === "passed" || r === "failed",
+    ).length;
+
+    // Avg duration across runs
+    const completedRuns = activeRuns.filter(
+      (r) => r.completedAt && r.createdAt,
+    );
+    const avgDuration =
+      completedRuns.length > 0
+        ? completedRuns.reduce(
+            (sum, r) => sum + ((r.completedAt ?? 0) - (r.createdAt ?? 0)),
+            0,
+          ) / completedRuns.length
+        : 0;
+
+    return {
+      accuracy,
+      passed,
+      failed,
+      total,
+      runCount: activeRuns.length,
+      latestRunAgo,
+      latestPassed,
+      latestTotal,
+      avgDuration,
+      donutData: [
+        ...(passed > 0
+          ? [
+              {
+                name: "passed",
+                value: passed,
+                fill: "hsl(142.1 76.2% 36.3%)",
+              },
+            ]
+          : []),
+        ...(failed > 0
+          ? [
+              {
+                name: "failed",
+                value: failed,
+                fill: "hsl(0 84.2% 60.2%)",
+              },
+            ]
+          : []),
+      ],
+    };
+  }, [runs, allIterations]);
+
+  if (!stats) {
+    return (
+      <div className="rounded-xl border bg-card p-6 text-center text-sm text-muted-foreground">
+        No completed runs yet. Run your suite to see results.
+      </div>
+    );
+  }
+
+  const metricLabel = isSDK ? "Pass Rate" : "Accuracy";
+  const showTrend = runTrendData.length >= 3;
+  const showModelComparison = modelStats.length >= 2;
+
+  return (
+    <div className="rounded-xl border bg-card text-card-foreground">
+      <div className="flex items-center gap-6 p-5">
+        {/* Big accuracy ring */}
+        <div className="shrink-0">
+          <ChartContainer
+            config={{
+              passed: {
+                label: "Passed",
+                color: "hsl(142.1 76.2% 36.3%)",
+              },
+              failed: {
+                label: "Failed",
+                color: "hsl(0 84.2% 60.2%)",
+              },
+            }}
+            className="h-[88px] w-[88px]"
+          >
+            <PieChart>
+              <ChartTooltip content={<ChartTooltipContent hideLabel />} />
+              <Pie
+                data={stats.donutData}
+                dataKey="value"
+                nameKey="name"
+                innerRadius={28}
+                outerRadius={40}
+                strokeWidth={2}
+              >
+                <Label
+                  content={({ viewBox }) => {
+                    if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                      return (
+                        <text
+                          x={viewBox.cx}
+                          y={viewBox.cy}
+                          textAnchor="middle"
+                          dominantBaseline="middle"
+                        >
+                          <tspan
+                            x={viewBox.cx}
+                            y={viewBox.cy}
+                            className="fill-foreground text-lg font-bold"
+                          >
+                            {stats.accuracy}%
+                          </tspan>
+                        </text>
+                      );
+                    }
+                  }}
+                />
+              </Pie>
+            </PieChart>
+          </ChartContainer>
+        </div>
+
+        {/* Stats */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-2 mb-1">
+            <span className="text-2xl font-bold">{stats.accuracy}%</span>
+            <span className="text-sm text-muted-foreground">{metricLabel}</span>
+          </div>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            <span>{testCaseCount} tests</span>
+            <span className="text-muted-foreground/40">|</span>
+            <span>{stats.runCount} runs</span>
+            <span className="text-muted-foreground/40">|</span>
+            <span>Avg {formatDuration(stats.avgDuration)}</span>
+            {stats.latestRunAgo && (
+              <>
+                <span className="text-muted-foreground/40">|</span>
+                <span>
+                  Latest: {stats.latestRunAgo} — {stats.latestPassed}/
+                  {stats.latestTotal} passed
+                </span>
+              </>
+            )}
+          </div>
+          {/* Pass/fail progress bar */}
+          <div className="mt-3 flex items-center gap-3">
+            <div className="flex-1 h-2 rounded-full bg-muted overflow-hidden flex">
+              <div
+                className="h-full rounded-l-full transition-all"
+                style={{
+                  width: `${(stats.passed / stats.total) * 100}%`,
+                  backgroundColor: "hsl(142.1 76.2% 36.3%)",
+                }}
+              />
+              <div
+                className="h-full rounded-r-full transition-all"
+                style={{
+                  width: `${(stats.failed / stats.total) * 100}%`,
+                  backgroundColor: "hsl(0 84.2% 60.2%)",
+                }}
+              />
+            </div>
+            <span className="text-xs text-muted-foreground shrink-0">
+              {stats.passed} passed · {stats.failed} failed
+            </span>
+          </div>
+        </div>
+
+        {/* Sparkline trend (only if ≥3 runs) */}
+        {showTrend && (
+          <div className="shrink-0 w-[160px]">
+            <div className="text-[10px] text-muted-foreground mb-1">Trend</div>
+            <ChartContainer
+              config={{
+                passRate: { label: metricLabel, color: "var(--chart-1)" },
+              }}
+              className="h-[52px] w-full"
+            >
+              <AreaChart
+                data={runTrendData}
+                onClick={
+                  onRunClick
+                    ? (chartData: any) => {
+                        if (chartData?.activePayload?.[0]?.payload?.runId) {
+                          onRunClick(
+                            chartData.activePayload[0].payload.runId,
+                          );
+                        }
+                      }
+                    : undefined
+                }
+              >
+                <Area
+                  type="monotone"
+                  dataKey="passRate"
+                  stroke="var(--color-passRate)"
+                  fill="var(--color-passRate)"
+                  fillOpacity={0.1}
+                  strokeWidth={1.5}
+                  isAnimationActive={false}
+                  dot={false}
+                  activeDot={
+                    onRunClick ? { cursor: "pointer", r: 4 } : undefined
+                  }
+                />
+              </AreaChart>
+            </ChartContainer>
+          </div>
+        )}
+      </div>
+
+      {/* Model comparison row (only if ≥2 models) */}
+      {showModelComparison && (
+        <div className="border-t px-5 py-3">
+          <div className="text-[10px] text-muted-foreground mb-2">
+            Performance by Model
+          </div>
+          <div className="flex flex-wrap items-center gap-4">
+            {modelStats.map((model) => (
+              <div key={model.model} className="flex items-center gap-2">
+                <div
+                  className="h-2 w-2 rounded-full"
+                  style={{
+                    backgroundColor:
+                      model.passRate >= 80
+                        ? "hsl(142.1 76.2% 36.3%)"
+                        : model.passRate >= 50
+                          ? "hsl(45.4 93.4% 47.5%)"
+                          : "hsl(0 84.2% 60.2%)",
+                  }}
+                />
+                <span className="text-xs">
+                  {model.model}
+                </span>
+                <span className="text-xs font-mono font-medium">
+                  {model.passRate}%
+                </span>
+                <span className="text-[10px] text-muted-foreground">
+                  ({model.passed}/{model.total})
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatTimeAgo(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatDuration(durationMs: number): string {
+  if (durationMs < 1000) return `${Math.round(durationMs)}ms`;
+  const totalSeconds = Math.round(durationMs / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes < 60) return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return remainingMinutes ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
+}

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -311,6 +311,13 @@ export function SuiteIterationsView({
                   serverNames={(suite.environment?.servers || []).filter(
                     (name) => connectedServerNames.has(name),
                   )}
+                  suiteName={suite.name}
+                  onNavigateToSuite={() => {
+                    navigateToEvalsRoute({
+                      type: "suite-overview",
+                      suiteId: suite._id,
+                    });
+                  }}
                   onBack={() => {
                     navigateToEvalsRoute({
                       type: "suite-overview",

--- a/mcpjam-inspector/client/src/components/evals/test-case-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-case-detail-view.tsx
@@ -2,13 +2,6 @@ import { useMemo, useState } from "react";
 import { X, ChevronDown, ChevronRight, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { AccuracyChart } from "./accuracy-chart";
-import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
 import { computeIterationResult } from "./pass-criteria";
 import { getIterationBorderColor, formatRunId } from "./helpers";
 import { IterationDetails } from "./iteration-details";
@@ -21,6 +14,8 @@ interface TestCaseDetailViewProps {
   onBack: () => void;
   onViewRun?: (runId: string) => void;
   serverNames?: string[];
+  suiteName?: string;
+  onNavigateToSuite?: () => void;
 }
 
 export function TestCaseDetailView({
@@ -30,6 +25,8 @@ export function TestCaseDetailView({
   onBack,
   onViewRun,
   serverNames = [],
+  suiteName,
+  onNavigateToSuite,
 }: TestCaseDetailViewProps) {
   const [openIterationId, setOpenIterationId] = useState<string | null>(null);
 
@@ -42,59 +39,6 @@ export function TestCaseDetailView({
       (iter) => !iter.suiteRunId || !inactiveRunIds.has(iter.suiteRunId),
     );
   }, [iterations, runs]);
-
-  // Performance trend data
-  const trendData = useMemo(() => {
-    const iterationsByRun = new Map<string, EvalIteration[]>();
-    activeIterations.forEach((iteration) => {
-      if (iteration.suiteRunId) {
-        if (!iterationsByRun.has(iteration.suiteRunId)) {
-          iterationsByRun.set(iteration.suiteRunId, []);
-        }
-        iterationsByRun.get(iteration.suiteRunId)!.push(iteration);
-      }
-    });
-
-    const data: Array<{
-      runId: string;
-      runIdDisplay: string;
-      passRate: number;
-      label: string;
-    }> = [];
-
-    runs.forEach((run) => {
-      // Skip inactive runs
-      if (run.isActive === false) return;
-
-      const runIters = iterationsByRun.get(run._id);
-      if (runIters && runIters.length > 0) {
-        // Only count completed iterations - exclude pending/cancelled
-        const iterationResults = runIters.map((iter) =>
-          computeIterationResult(iter),
-        );
-        const passed = iterationResults.filter((r) => r === "passed").length;
-        const total = iterationResults.filter(
-          (r) => r === "passed" || r === "failed",
-        ).length;
-        const passRate = total > 0 ? Math.round((passed / total) * 100) : 0;
-
-        data.push({
-          runId: run._id,
-          runIdDisplay: run._id.slice(-6),
-          passRate,
-          label: new Date(run.completedAt ?? run.createdAt).toLocaleString(),
-        });
-      }
-    });
-
-    return data.sort((a, b) => {
-      const runA = runs.find((r) => r._id === a.runId);
-      const runB = runs.find((r) => r._id === b.runId);
-      const timeA = runA?.createdAt ?? 0;
-      const timeB = runB?.createdAt ?? 0;
-      return timeA - timeB;
-    });
-  }, [activeIterations, runs]);
 
   // Model breakdown
   const modelBreakdown = useMemo(() => {
@@ -152,18 +96,57 @@ export function TestCaseDetailView({
       .sort((a, b) => b.passRate - a.passRate);
   }, [activeIterations]);
 
-  const modelChartConfig = {
-    passRate: {
-      label: "Pass Rate",
-      color: "var(--chart-1)",
-    },
+  // Compute overall stats
+  const overallStats = useMemo(() => {
+    const results = activeIterations.map((i) => computeIterationResult(i));
+    const passed = results.filter((r) => r === "passed").length;
+    const failed = results.filter((r) => r === "failed").length;
+    const total = passed + failed;
+    const passRate = total > 0 ? Math.round((passed / total) * 100) : 0;
+
+    // Avg duration
+    const completed = activeIterations.filter(
+      (i) => i.startedAt && i.updatedAt && i.result !== "pending",
+    );
+    const avgDuration =
+      completed.length > 0
+        ? completed.reduce(
+            (sum, i) => sum + ((i.updatedAt ?? 0) - (i.startedAt ?? 0)),
+            0,
+          ) / completed.length
+        : 0;
+
+    return { passed, failed, total, passRate, avgDuration };
+  }, [activeIterations]);
+
+  const formatDurationHelper = (ms: number) => {
+    if (ms < 1000) return `${Math.round(ms)}ms`;
+    const s = Math.round(ms / 1000);
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    const sec = s % 60;
+    return sec ? `${m}m ${sec}s` : `${m}m`;
   };
 
   return (
-    <div className="space-y-4">
-      {/* Header */}
+    <div className="space-y-4 overflow-y-auto h-full p-0.5">
+      {/* Breadcrumb + Header */}
       <div className="flex items-center justify-between">
         <div>
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+            {suiteName && onNavigateToSuite && (
+              <>
+                <button
+                  onClick={onNavigateToSuite}
+                  className="hover:text-foreground hover:underline transition-colors cursor-pointer"
+                >
+                  {suiteName}
+                </button>
+                <span className="text-muted-foreground/50">/</span>
+              </>
+            )}
+            <span className="text-primary font-medium">Test Case</span>
+          </div>
           <h2 className="text-lg font-semibold">
             {testCase.title || "Untitled test case"}
           </h2>
@@ -178,120 +161,75 @@ export function TestCaseDetailView({
         </Button>
       </div>
 
-      {/* Charts Side by Side */}
-      <div className="grid gap-4 lg:grid-cols-2">
-        {/* Performance Chart */}
-        {trendData.length > 0 && (
-          <div className="rounded-xl border bg-card text-card-foreground">
-            <div className="px-4 pt-3 pb-2">
-              <div className="text-xs font-medium text-muted-foreground">
-                Performance across runs
-              </div>
-            </div>
-            <div className="px-4 pb-4">
-              <AccuracyChart
-                data={trendData}
-                height="h-32"
-                showLabel={true}
-                onClick={onViewRun}
+      {/* Hero Stats */}
+      {overallStats.total > 0 && (
+        <div className="rounded-xl border bg-card text-card-foreground p-4">
+          <div className="flex items-center gap-4">
+            <span className="text-2xl font-bold">{overallStats.passRate}%</span>
+            <span className="text-sm text-muted-foreground">Pass Rate</span>
+            <span className="text-muted-foreground/40">|</span>
+            <span className="text-xs text-muted-foreground">
+              {overallStats.total} iterations
+            </span>
+            <span className="text-muted-foreground/40">|</span>
+            <span className="text-xs text-muted-foreground">
+              Avg {formatDurationHelper(overallStats.avgDuration)}
+            </span>
+          </div>
+          {/* Progress bar */}
+          <div className="mt-2 flex items-center gap-3">
+            <div className="flex-1 h-2 rounded-full bg-muted overflow-hidden flex">
+              <div
+                className="h-full rounded-l-full transition-all"
+                style={{
+                  width: `${(overallStats.passed / overallStats.total) * 100}%`,
+                  backgroundColor: "hsl(142.1 76.2% 36.3%)",
+                }}
+              />
+              <div
+                className="h-full rounded-r-full transition-all"
+                style={{
+                  width: `${(overallStats.failed / overallStats.total) * 100}%`,
+                  backgroundColor: "hsl(0 84.2% 60.2%)",
+                }}
               />
             </div>
+            <span className="text-xs text-muted-foreground shrink-0">
+              {overallStats.passed} passed · {overallStats.failed} failed
+            </span>
           </div>
-        )}
-
-        {/* Model Breakdown */}
-        {modelBreakdown.length > 0 && (
-          <div className="rounded-xl border bg-card text-card-foreground">
-            <div className="px-4 pt-3 pb-2">
-              <div className="text-xs font-medium text-muted-foreground">
-                Performance by model
-              </div>
-            </div>
-            <div className="px-4 pb-4">
-              <ChartContainer
-                config={modelChartConfig}
-                className="aspect-auto h-32 w-full"
-              >
-                <BarChart
-                  data={modelBreakdown}
-                  width={undefined}
-                  height={undefined}
-                >
-                  <CartesianGrid
-                    strokeDasharray="3 3"
-                    vertical={false}
-                    stroke="hsl(var(--muted-foreground) / 0.2)"
-                  />
-                  <XAxis
-                    dataKey="model"
-                    tickLine={false}
-                    axisLine={false}
-                    tickMargin={8}
-                    tick={{ fontSize: 11 }}
-                    interval={0}
-                    height={40}
-                    tickFormatter={(value) => {
-                      const parts = value.split("/");
-                      if (parts.length === 2 && parts[1].length > 15) {
-                        return `${parts[0]}/${parts[1].substring(0, 12)}...`;
-                      }
-                      return value;
+          {/* Inline model breakdown */}
+          {modelBreakdown.length >= 1 && (
+            <div className="flex flex-wrap items-center gap-4 mt-2 pt-2 border-t border-border/50">
+              <span className="text-[10px] text-muted-foreground">
+                By Model:
+              </span>
+              {modelBreakdown.map((model) => (
+                <div key={model.model} className="flex items-center gap-1.5">
+                  <div
+                    className="h-1.5 w-1.5 rounded-full"
+                    style={{
+                      backgroundColor:
+                        model.passRate >= 80
+                          ? "hsl(142.1 76.2% 36.3%)"
+                          : model.passRate >= 50
+                            ? "hsl(45.4 93.4% 47.5%)"
+                            : "hsl(0 84.2% 60.2%)",
                     }}
                   />
-                  <YAxis
-                    domain={[0, 100]}
-                    tickLine={false}
-                    axisLine={false}
-                    tickMargin={8}
-                    tick={{ fontSize: 12 }}
-                    tickFormatter={(value) => `${value}%`}
-                  />
-                  <ChartTooltip
-                    cursor={false}
-                    content={({ active, payload }) => {
-                      if (!active || !payload || payload.length === 0)
-                        return null;
-                      const data = payload[0].payload;
-                      return (
-                        <div className="rounded-lg border bg-background p-2 shadow-sm">
-                          <div className="grid gap-2">
-                            <div className="flex flex-col">
-                              <span className="text-xs font-semibold">
-                                {data.model}
-                              </span>
-                              <span className="text-xs text-muted-foreground mt-0.5">
-                                {data.passed} passed · {data.failed} failed
-                              </span>
-                            </div>
-                            <div className="flex items-center gap-2">
-                              <div
-                                className="h-2 w-2 rounded-full"
-                                style={{
-                                  backgroundColor: "var(--color-passRate)",
-                                }}
-                              />
-                              <span className="text-sm font-semibold">
-                                {data.passRate}%
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      );
-                    }}
-                  />
-                  <Bar
-                    dataKey="passRate"
-                    fill="var(--color-passRate)"
-                    radius={[4, 4, 0, 0]}
-                    isAnimationActive={false}
-                    minPointSize={8}
-                  />
-                </BarChart>
-              </ChartContainer>
+                  <span className="text-[11px]">{model.model}</span>
+                  <span className="text-[11px] font-mono font-medium">
+                    {model.passRate}%
+                  </span>
+                  <span className="text-[10px] text-muted-foreground">
+                    ({model.passed}/{model.passed + model.failed})
+                  </span>
+                </div>
+              ))}
             </div>
-          </div>
-        )}
-      </div>
+          )}
+        </div>
+      )}
 
       {/* Iterations List */}
       <div className="space-y-2">
@@ -304,7 +242,34 @@ export function TestCaseDetailView({
           </div>
         ) : (
           <div className="rounded-md border bg-card text-card-foreground divide-y overflow-hidden">
-            {activeIterations.map((iteration) => {
+            {/* Column headers */}
+            <div className="flex items-center justify-between gap-3 px-3 py-1.5 bg-muted/30 text-[10px] font-medium text-muted-foreground uppercase tracking-wide">
+              <div className="flex min-w-0 flex-1 items-center gap-3 pl-2">
+                <div className="w-3.5" />
+                <span>Result</span>
+              </div>
+              <div className="flex items-center gap-4 shrink-0">
+                <div className="min-w-[120px] text-left">Model</div>
+                <div className="min-w-[50px] text-center">Calls</div>
+                <div className="min-w-[60px] text-center">Tokens</div>
+                <div className="min-w-[40px] text-right">Time</div>
+                {onViewRun && <div className="min-w-[100px]">Run</div>}
+              </div>
+            </div>
+            {/* Failing iterations first */}
+            {(() => {
+              const failing = activeIterations.filter(
+                (i) => computeIterationResult(i) === "failed",
+              );
+              const passing = activeIterations.filter(
+                (i) => computeIterationResult(i) === "passed",
+              );
+              const other = activeIterations.filter((i) => {
+                const r = computeIterationResult(i);
+                return r !== "failed" && r !== "passed";
+              });
+              return [...failing, ...passing, ...other];
+            })().map((iteration) => {
               const snapshot = iteration.testCaseSnapshot;
               const startedAt = iteration.startedAt ?? iteration.createdAt;
               const completedAt = iteration.updatedAt ?? iteration.createdAt;
@@ -393,7 +358,7 @@ export function TestCaseDetailView({
                               onViewRun(iteration.suiteRunId!);
                             }}
                           >
-                            Run {formatRunId(iteration.suiteRunId)}
+                            {formatTimeAgo(iteration.createdAt)}
                           </Button>
                         </div>
                       )}
@@ -421,4 +386,15 @@ export function TestCaseDetailView({
       </div>
     </div>
   );
+}
+
+function formatTimeAgo(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
 }

--- a/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
@@ -1,13 +1,6 @@
 import { useMemo } from "react";
 import { computeIterationResult } from "./pass-criteria";
 import type { EvalCase, EvalIteration, EvalSuiteRun } from "./types";
-import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
-import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts";
-import { AccuracyChart } from "./accuracy-chart";
 
 interface TestCasesOverviewProps {
   suite: { _id: string; name: string; source?: "ui" | "sdk" };
@@ -109,132 +102,8 @@ export function TestCasesOverview({
     return seconds ? `${minutes}m ${seconds}s` : `${minutes}m`;
   };
 
-  const modelChartConfig = {
-    passRate: {
-      label: "Pass Rate",
-      color: "var(--chart-1)",
-    },
-  };
-
   return (
     <>
-      {/* Charts Side by Side */}
-      <div className="grid gap-4 lg:grid-cols-2">
-        {/* Accuracy */}
-        <div className="rounded-xl border bg-card text-card-foreground">
-          <div className="px-4 pt-3 pb-2">
-            <div className="text-xs font-medium text-muted-foreground">
-              {suite.source === "sdk" ? "Pass Rate" : "Accuracy"}
-            </div>
-          </div>
-          <div className="px-4 pb-4">
-            <AccuracyChart
-              data={runTrendData}
-              isLoading={runsLoading}
-              height="h-32"
-              onClick={onRunClick}
-              metricLabel={suite.source === "sdk" ? "Pass Rate" : "Accuracy"}
-            />
-          </div>
-        </div>
-
-        {/* Per-Model Performance */}
-        <div className="rounded-xl border bg-card text-card-foreground">
-          <div className="px-4 pt-3 pb-2">
-            <div className="text-xs font-medium text-muted-foreground">
-              Performance by model
-            </div>
-          </div>
-          <div className="px-4 pb-4">
-            {modelStats.length > 1 ? (
-              <ChartContainer
-                config={modelChartConfig}
-                className="aspect-auto h-32 w-full"
-              >
-                <BarChart
-                  data={modelStats}
-                  width={undefined}
-                  height={undefined}
-                >
-                  <CartesianGrid
-                    strokeDasharray="3 3"
-                    vertical={false}
-                    stroke="hsl(var(--muted-foreground) / 0.2)"
-                  />
-                  <XAxis
-                    dataKey="model"
-                    tickLine={false}
-                    axisLine={false}
-                    tickMargin={8}
-                    tick={{ fontSize: 11 }}
-                    interval={0}
-                    height={40}
-                    tickFormatter={(value) => {
-                      if (value.length > 15) {
-                        return value.substring(0, 12) + "...";
-                      }
-                      return value;
-                    }}
-                  />
-                  <YAxis
-                    domain={[0, 100]}
-                    tickLine={false}
-                    axisLine={false}
-                    tickMargin={8}
-                    tick={{ fontSize: 12 }}
-                    tickFormatter={(value) => `${value}%`}
-                  />
-                  <ChartTooltip
-                    cursor={false}
-                    content={({ active, payload }) => {
-                      if (!active || !payload || payload.length === 0)
-                        return null;
-                      const data = payload[0].payload;
-                      return (
-                        <div className="rounded-lg border bg-background p-2 shadow-sm">
-                          <div className="grid gap-2">
-                            <div className="flex flex-col">
-                              <span className="text-xs font-semibold">
-                                {data.model}
-                              </span>
-                              <span className="text-xs text-muted-foreground mt-0.5">
-                                {data.passed} passed · {data.failed} failed
-                              </span>
-                            </div>
-                            <div className="flex items-center gap-2">
-                              <div
-                                className="h-2 w-2 rounded-full"
-                                style={{
-                                  backgroundColor: "var(--color-passRate)",
-                                }}
-                              />
-                              <span className="text-sm font-semibold">
-                                {data.passRate}%
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                      );
-                    }}
-                  />
-                  <Bar
-                    dataKey="passRate"
-                    fill="var(--color-passRate)"
-                    radius={[4, 4, 0, 0]}
-                    isAnimationActive={false}
-                    minPointSize={8}
-                  />
-                </BarChart>
-              </ChartContainer>
-            ) : (
-              <p className="text-xs text-muted-foreground">
-                No model data available.
-              </p>
-            )}
-          </div>
-        </div>
-      </div>
-
       {/* Test Cases List */}
       <div className="rounded-xl border bg-card text-card-foreground flex flex-col max-h-[600px]">
         <div className="border-b px-4 py-2 shrink-0 flex items-center justify-between">

--- a/mcpjam-inspector/client/src/lib/ci-evals-router.ts
+++ b/mcpjam-inspector/client/src/lib/ci-evals-router.ts
@@ -75,7 +75,7 @@ export function parseCiEvalsRoute(): CiEvalsRoute | null {
       return {
         type: "suite-overview",
         suiteId,
-        view: view === "test-cases" ? "test-cases" : "runs",
+        view: view === "runs" ? "runs" : "test-cases",
       };
     }
   }
@@ -98,7 +98,7 @@ export function navigateToCiEvalsRoute(
       break;
     case "suite-overview": {
       const params = new URLSearchParams();
-      if (route.view && route.view !== "runs") {
+      if (route.view && route.view !== "test-cases") {
         params.set("view", route.view);
       }
       const query = params.toString();


### PR DESCRIPTION
### TL;DR

Redesigned the CI suite overview page with a new accordion-style run view and consolidated hero stats section.

### What changed?

- Replaced the dual-view runs/test-cases toggle with a single accordion-style interface that shows runs with expandable test case details
- Added a new `SuiteHeroStats` component that displays overall suite metrics, trends, and model performance in a compact card
- Created `RunAccordionView` component that lists runs chronologically with collapsible test case results
- Removed separate chart sections and consolidated them into the hero stats
- Updated the run detail view to show model performance inline and group iterations by result status (failing/passing/pending)
- Added breadcrumb navigation to test case detail view
- Changed default sort order in run details from "test" to "result"
- Simplified suite header by removing accuracy donut chart and delete buttons

### How to test?

1. Navigate to any CI suite overview page
2. Verify the new hero stats card shows suite-level metrics with trend sparkline and model comparison
3. Test expanding/collapsing runs in the accordion view
4. Click on individual test cases within expanded runs to navigate to test detail
5. Check that run detail view groups iterations by result status
6. Verify breadcrumb navigation works in test case detail view

### Why make this change?

This redesign provides a more streamlined and information-dense interface that reduces visual clutter while making it easier to quickly scan run results and drill down into specific failures. The accordion format allows users to see both high-level run status and detailed test results in a single view without switching between tabs.