### PR TITLE
Fix race condition between app and browser on npm command

### DIFF
--- a/mcpjam-inspector/bin/start.js
+++ b/mcpjam-inspector/bin/start.js
@@ -787,11 +787,7 @@ async function main() {
       let url = process.env.BASE_URL || `http://${host}:${PORT}`;
 
       // Wait until the server is actually accepting connections
-      const ready = await waitForServerReady(
-        parseInt(PORT, 10),
-        host,
-        30000,
-      );
+      const ready = await waitForServerReady(parseInt(PORT, 10), host, 30000);
 
       if (!ready) {
         logWarning(

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
@@ -309,7 +309,9 @@ describe("useChatSession minimal mode parity", () => {
     const latestTransport = mockTransportInstances.at(-1)!;
     expect(latestTransport.options.api).toBe("/api/mcp/chat-v2");
     expect(latestTransport.options.fetch).toBeUndefined();
-    expect(await resolveConfig(latestTransport.options.headers)).toBeUndefined();
+    expect(
+      await resolveConfig(latestTransport.options.headers),
+    ).toBeUndefined();
 
     act(() => {
       result.current.sendMessage({ text: "hello" });
@@ -353,9 +355,9 @@ describe("useChatSession minimal mode parity", () => {
     expect(await resolveConfig(latestTransport.options.headers)).toEqual({
       Authorization: "Bearer convex-token",
     });
-    expect(await resolveConfig(latestTransport.options.headers)).not.toHaveProperty(
-      "X-MCP-Session-Auth",
-    );
+    expect(
+      await resolveConfig(latestTransport.options.headers),
+    ).not.toHaveProperty("X-MCP-Session-Auth");
     expect(mockAuthFetch).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.guest.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.guest.test.ts
@@ -105,7 +105,9 @@ describe("web routes — chat-v2 guest mode", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    testGuestKeyDir = mkdtempSync(path.join(os.tmpdir(), "chat-v2-guest-test-"));
+    testGuestKeyDir = mkdtempSync(
+      path.join(os.tmpdir(), "chat-v2-guest-test-"),
+    );
     process.env.GUEST_JWT_KEY_DIR = testGuestKeyDir;
     initGuestTokenSecret();
     process.env.CONVEX_HTTP_URL = "https://example.convex.site";


### PR DESCRIPTION
## Summary

Replaced the 2-second delay with a proper connection check that waits for the server to actually accept connections before attempting to open the browser. Added `waitForServerReady()` function that polls the server port with exponential backoff and a 30-second timeout to ensure the application is fully ready before launching the browser

On `npx @mcpjam/inspector@latest`:
![Screenshot 2026-03-14 at 4.24.40 PM.png](https://app.graphite.com/user-attachments/assets/9ee137b1-6361-4e23-882c-f67d7a951a96.png)

