### PR TITLE
Remove CI evals overview panel and tag filtering

### DIFF
--- a/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
@@ -15,7 +15,10 @@ import { aggregateSuite, groupRunsByCommit } from "./evals/helpers";
 import { useEvalMutations } from "./evals/use-eval-mutations";
 import { useEvalQueries } from "./evals/use-eval-queries";
 import { useEvalHandlers } from "./evals/use-eval-handlers";
-import { CiSuiteListSidebar, type SidebarMode } from "./evals/ci-suite-list-sidebar";
+import {
+  CiSuiteListSidebar,
+  type SidebarMode,
+} from "./evals/ci-suite-list-sidebar";
 import { CiSuiteDetail } from "./evals/ci-suite-detail";
 import { CommitDetailView } from "./evals/commit-detail-view";
 import { useWorkspaceMembers } from "@/hooks/useWorkspaces";
@@ -87,10 +90,7 @@ export function CiEvalsTab({ convexWorkspaceId }: CiEvalsTabProps) {
     [queries.sortedSuites],
   );
 
-  const commitGroups = useMemo(
-    () => groupRunsByCommit(sdkSuites),
-    [sdkSuites],
-  );
+  const commitGroups = useMemo(() => groupRunsByCommit(sdkSuites), [sdkSuites]);
 
   // Auto-switch to "By Suite" when all runs are manual (no commit SHAs)
   useEffect(() => {
@@ -108,9 +108,7 @@ export function CiEvalsTab({ convexWorkspaceId }: CiEvalsTabProps) {
 
   const selectedCommitGroup = useMemo(() => {
     if (!selectedCommitSha) return null;
-    return (
-      commitGroups.find((g) => g.commitSha === selectedCommitSha) ?? null
-    );
+    return commitGroups.find((g) => g.commitSha === selectedCommitSha) ?? null;
   }, [commitGroups, selectedCommitSha]);
   const selectedSuiteEntry = useMemo(() => {
     if (!selectedSuiteId) return null;
@@ -323,7 +321,8 @@ export function CiEvalsTab({ convexWorkspaceId }: CiEvalsTabProps) {
                   Select a suite
                 </h2>
                 <p className="text-sm text-muted-foreground">
-                  Choose a CI suite or commit from the sidebar to inspect runs and test iterations.
+                  Choose a CI suite or commit from the sidebar to inspect runs
+                  and test iterations.
                 </p>
               </div>
             </div>

--- a/mcpjam-inspector/client/src/components/evals/__tests__/ai-insights.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/ai-insights.test.ts
@@ -123,16 +123,16 @@ describe("isFlaky", () => {
   });
 
   it("returns true for frequent alternation", () => {
-    expect(
-      isFlaky(["passed", "failed", "passed", "failed", "passed"]),
-    ).toBe(true);
+    expect(isFlaky(["passed", "failed", "passed", "failed", "passed"])).toBe(
+      true,
+    );
   });
 
   it("ignores 'other' results when counting switches", () => {
     // After filtering: passed, failed, passed = 2 switches
-    expect(
-      isFlaky(["passed", "other", "failed", "other", "passed"]),
-    ).toBe(true);
+    expect(isFlaky(["passed", "other", "failed", "other", "passed"])).toBe(
+      true,
+    );
   });
 
   it("only looks at first 10 entries", () => {
@@ -163,9 +163,7 @@ describe("classifyFailure", () => {
   it("tags as 'new' when there is no prior history", () => {
     const suiteId = "suite-new";
     const run = makeRun({ suiteId, result: "failed" });
-    const groups: CommitGroup[] = [
-      makeCommitGroup({ runs: [run] }),
-    ];
+    const groups: CommitGroup[] = [makeCommitGroup({ runs: [run] })];
 
     const result = classifyFailure(run, "New Suite", groups);
     expect(result.tags).toContain("new");
@@ -218,11 +216,7 @@ describe("classifyFailure", () => {
       }),
     ];
 
-    const result = classifyFailure(
-      failedRun,
-      "Flaky Regression",
-      groups,
-    );
+    const result = classifyFailure(failedRun, "Flaky Regression", groups);
     expect(result.tags).toContain("regression");
     expect(result.tags).toContain("flaky");
   });
@@ -285,158 +279,5 @@ describe("classifyAllFailures", () => {
 
     const results = classifyAllFailures([run], new Map(), groups);
     expect(results[0].suiteName).toBe("Unknown suite");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// buildTriageContext
-// ---------------------------------------------------------------------------
-
-describe("buildTriageContext", () => {
-  it("builds context with correct aggregated data", () => {
-    const failedRun = makeRun({
-      suiteId: "s1",
-      result: "failed",
-      summary: { total: 10, passed: 7, failed: 3, passRate: 70 },
-      configSnapshot: {
-        tests: [
-          {
-            title: "test-a",
-            query: "q",
-            provider: "p",
-            model: "m",
-            runs: 1,
-            expectedToolCalls: [],
-          },
-          {
-            title: "test-b",
-            query: "q",
-            provider: "p",
-            model: "m",
-            runs: 1,
-            expectedToolCalls: [],
-          },
-        ],
-        environment: { servers: [] },
-      },
-    });
-    const passedRun = makeRun({
-      suiteId: "s2",
-      result: "passed",
-      summary: { total: 5, passed: 5, failed: 0, passRate: 100 },
-    });
-    const notRunRun = makeRun({
-      suiteId: "s3",
-      result: "cancelled",
-    });
-
-    const suiteMap = new Map([
-      ["s1", "Failed Suite"],
-      ["s2", "Passed Suite"],
-      ["s3", "Not Run Suite"],
-    ]);
-
-    const commitGroup = makeCommitGroup({
-      commitSha: "abc123",
-      shortSha: "abc1234",
-      branch: "main",
-      runs: [failedRun, passedRun, notRunRun],
-      suiteMap,
-    });
-
-    const classified = [
-      {
-        run: failedRun,
-        suiteName: "Failed Suite",
-        tags: ["regression" as const],
-      },
-    ];
-
-    const ctx = buildTriageContext(
-      commitGroup,
-      classified,
-      [passedRun],
-      [notRunRun],
-    );
-
-    expect(ctx.commitSha).toBe("abc1234");
-    expect(ctx.branch).toBe("main");
-    expect(ctx.totalSuites).toBe(3);
-    expect(ctx.totalCases.total).toBe(15);
-    expect(ctx.totalCases.passed).toBe(12);
-    expect(ctx.totalCases.failed).toBe(3);
-    expect(ctx.failures).toHaveLength(1);
-    expect(ctx.failures[0].suiteName).toBe("Failed Suite");
-    expect(ctx.failures[0].tags).toEqual(["regression"]);
-    expect(ctx.failures[0].testNames).toEqual(["test-a", "test-b"]);
-    expect(ctx.passedSuites).toEqual(["Passed Suite"]);
-    expect(ctx.notRunSuites).toEqual(["Not Run Suite"]);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// buildOverviewTriageContext
-// ---------------------------------------------------------------------------
-
-describe("buildOverviewTriageContext", () => {
-  it("categorizes suites correctly", () => {
-    const suites = [
-      {
-        suite: { _id: "s1", name: "Failing Suite" } as any,
-        latestRun: makeRun({ suiteId: "s1", result: "failed" }),
-        recentRuns: [],
-        passRateTrend: [],
-        totals: { passed: 3, failed: 2, runs: 5 },
-      },
-      {
-        suite: { _id: "s2", name: "Passing Suite" } as any,
-        latestRun: makeRun({ suiteId: "s2", result: "passed" }),
-        recentRuns: [],
-        passRateTrend: [],
-        totals: { passed: 10, failed: 0, runs: 10 },
-      },
-      {
-        suite: { _id: "s3", name: "New Suite" } as any,
-        latestRun: null,
-        recentRuns: [],
-        passRateTrend: [],
-        totals: { passed: 0, failed: 0, runs: 0 },
-      },
-    ];
-
-    const ctx = buildOverviewTriageContext(suites, []);
-    expect(ctx.totalSuites).toBe(3);
-    expect(ctx.passingSuites).toBe(1);
-    expect(ctx.neverRunSuites).toBe(1);
-    expect(ctx.failingSuites).toHaveLength(1);
-    expect(ctx.failingSuites[0].name).toBe("Failing Suite");
-    expect(ctx.failingSuites[0].passRate).toBe("60%");
-  });
-
-  it("includes suites that passed overall but have failed cases", () => {
-    const suites = [
-      {
-        suite: { _id: "s1", name: "Mostly Passing Suite" } as any,
-        latestRun: makeRun({ suiteId: "s1", result: "passed" }),
-        recentRuns: [],
-        passRateTrend: [],
-        totals: { passed: 14, failed: 2, runs: 16 },
-      },
-      {
-        suite: { _id: "s2", name: "Fully Passing Suite" } as any,
-        latestRun: makeRun({ suiteId: "s2", result: "passed" }),
-        recentRuns: [],
-        passRateTrend: [],
-        totals: { passed: 10, failed: 0, runs: 10 },
-      },
-    ];
-
-    const ctx = buildOverviewTriageContext(suites, []);
-    expect(ctx.totalSuites).toBe(2);
-    expect(ctx.passingSuites).toBe(1);
-    expect(ctx.failingSuites).toHaveLength(1);
-    expect(ctx.failingSuites[0].name).toBe("Mostly Passing Suite");
-    expect(ctx.failingSuites[0].passRate).toBe("88%");
-    expect(ctx.failingSuites[0].failedCases).toBe(2);
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/ai-insights.ts
+++ b/mcpjam-inspector/client/src/components/evals/ai-insights.ts
@@ -109,4 +109,3 @@ export function classifyAllFailures(
     return classifyFailure(run, suiteName, allCommitGroups);
   });
 }
-

--- a/mcpjam-inspector/client/src/components/evals/ci-suite-list-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/ci-suite-list-sidebar.tsx
@@ -107,7 +107,9 @@ export function CiSuiteListSidebar({
     for (const entry of suites) {
       const rawName = entry.suite.name || "Untitled suite";
       // Strip trailing " (YYYY-MM-DD ...)" or " (timestamp)" patterns
-      const baseName = rawName.replace(/\s*\(\d{4}-\d{2}-\d{2}[^)]*\)\s*$/, "").trim() || rawName;
+      const baseName =
+        rawName.replace(/\s*\(\d{4}-\d{2}-\d{2}[^)]*\)\s*$/, "").trim() ||
+        rawName;
       if (!groups.has(baseName)) {
         groups.set(baseName, []);
       }
@@ -116,8 +118,16 @@ export function CiSuiteListSidebar({
     // Sort each group by latest run time (most recent first)
     for (const entries of groups.values()) {
       entries.sort((a, b) => {
-        const aTime = a.latestRun?.completedAt ?? a.latestRun?.createdAt ?? a.suite.updatedAt ?? 0;
-        const bTime = b.latestRun?.completedAt ?? b.latestRun?.createdAt ?? b.suite.updatedAt ?? 0;
+        const aTime =
+          a.latestRun?.completedAt ??
+          a.latestRun?.createdAt ??
+          a.suite.updatedAt ??
+          0;
+        const bTime =
+          b.latestRun?.completedAt ??
+          b.latestRun?.createdAt ??
+          b.suite.updatedAt ??
+          0;
         return bTime - aTime;
       });
     }
@@ -161,29 +171,31 @@ export function CiSuiteListSidebar({
           isLoading={isLoading}
         />
       ) : (
-      <div className="flex-1 overflow-y-auto">
-        {isLoading ? (
-          <div className="p-4 text-center text-xs text-muted-foreground">
-            Loading suites...
-          </div>
-        ) : suites.length === 0 ? (
-          <div className="p-4 text-center text-xs text-muted-foreground">
-            No SDK suites found.
-          </div>
-        ) : (
-          <div>
-            {Array.from(groupedSuites.entries()).map(([suiteName, entries]) => (
-              <SuiteGroupItem
-                key={suiteName}
-                suiteName={suiteName}
-                entries={entries}
-                selectedSuiteId={selectedSuiteId}
-                onSelectSuite={onSelectSuite}
-              />
-            ))}
-          </div>
-        )}
-      </div>
+        <div className="flex-1 overflow-y-auto">
+          {isLoading ? (
+            <div className="p-4 text-center text-xs text-muted-foreground">
+              Loading suites...
+            </div>
+          ) : suites.length === 0 ? (
+            <div className="p-4 text-center text-xs text-muted-foreground">
+              No SDK suites found.
+            </div>
+          ) : (
+            <div>
+              {Array.from(groupedSuites.entries()).map(
+                ([suiteName, entries]) => (
+                  <SuiteGroupItem
+                    key={suiteName}
+                    suiteName={suiteName}
+                    entries={entries}
+                    selectedSuiteId={selectedSuiteId}
+                    onSelectSuite={onSelectSuite}
+                  />
+                ),
+              )}
+            </div>
+          )}
+        </div>
       )}
     </div>
   );
@@ -207,7 +219,9 @@ function SuiteGroupItem({
 
   const latestRun = primary.latestRun;
   const status = getStatusInfo(primary);
-  const trend = primary.passRateTrend.slice(-12).map((value) => toPercent(value));
+  const trend = primary.passRateTrend
+    .slice(-12)
+    .map((value) => toPercent(value));
   const timestamp = formatRelativeTime(
     latestRun?.completedAt ?? latestRun?.createdAt ?? primary.suite.updatedAt,
   );
@@ -246,13 +260,23 @@ function SuiteGroupItem({
         <div className="flex items-center gap-2.5">
           <div className="flex flex-col items-center gap-0.5 shrink-0 w-[3.25rem]">
             <div className={cn("h-2 w-2 rounded-full", status.dotClass)} />
-            <span className={cn("text-[9px] font-medium leading-none", status.labelClass)}>
+            <span
+              className={cn(
+                "text-[9px] font-medium leading-none",
+                status.labelClass,
+              )}
+            >
               {status.label}
             </span>
           </div>
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-1.5">
-              <span className={cn("truncate text-sm font-medium", isAnySelected && "font-semibold")}>
+              <span
+                className={cn(
+                  "truncate text-sm font-medium",
+                  isAnySelected && "font-semibold",
+                )}
+              >
                 {suiteName}
               </span>
               <span className="shrink-0 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-muted px-1 text-[9px] font-medium text-muted-foreground">
@@ -269,7 +293,14 @@ function SuiteGroupItem({
               {trend.map((value, idx) => (
                 <div
                   key={`${primary.suite._id}-t-${idx}`}
-                  className={cn("w-1 rounded-sm", value >= 80 ? "bg-emerald-500/70" : value >= 50 ? "bg-amber-500/70" : "bg-destructive/70")}
+                  className={cn(
+                    "w-1 rounded-sm",
+                    value >= 80
+                      ? "bg-emerald-500/70"
+                      : value >= 50
+                        ? "bg-amber-500/70"
+                        : "bg-destructive/70",
+                  )}
                   style={{ height: `${Math.max(3, (value / 100) * 20)}px` }}
                 />
               ))}
@@ -282,7 +313,9 @@ function SuiteGroupItem({
           {entries.map((entry) => {
             const entryStatus = getStatusInfo(entry);
             const entryTimestamp = formatRelativeTime(
-              entry.latestRun?.completedAt ?? entry.latestRun?.createdAt ?? entry.suite.updatedAt,
+              entry.latestRun?.completedAt ??
+                entry.latestRun?.createdAt ??
+                entry.suite.updatedAt,
             );
             return (
               <button
@@ -290,15 +323,26 @@ function SuiteGroupItem({
                 onClick={() => onSelectSuite(entry.suite._id)}
                 className={cn(
                   "w-full px-3 py-1.5 text-left transition-colors hover:bg-accent/50",
-                  selectedSuiteId === entry.suite._id && "bg-primary/10 border-r-2 border-r-primary",
+                  selectedSuiteId === entry.suite._id &&
+                    "bg-primary/10 border-r-2 border-r-primary",
                 )}
               >
                 <div className="flex items-center gap-2">
-                  <div className={cn("h-1.5 w-1.5 rounded-full shrink-0", entryStatus.dotClass)} />
+                  <div
+                    className={cn(
+                      "h-1.5 w-1.5 rounded-full shrink-0",
+                      entryStatus.dotClass,
+                    )}
+                  />
                   <span className="text-[11px] text-muted-foreground truncate flex-1">
                     {entryTimestamp}
                   </span>
-                  <span className={cn("text-[10px] font-medium", entryStatus.labelClass)}>
+                  <span
+                    className={cn(
+                      "text-[10px] font-medium",
+                      entryStatus.labelClass,
+                    )}
+                  >
                     {entryStatus.label}
                   </span>
                 </div>
@@ -337,12 +381,22 @@ function SuiteEntryButton({
       <div className="flex items-center gap-2.5">
         <div className="flex flex-col items-center gap-0.5 shrink-0 w-[3.25rem]">
           <div className={cn("h-2 w-2 rounded-full", status.dotClass)} />
-          <span className={cn("text-[9px] font-medium leading-none", status.labelClass)}>
+          <span
+            className={cn(
+              "text-[9px] font-medium leading-none",
+              status.labelClass,
+            )}
+          >
             {status.label}
           </span>
         </div>
         <div className="min-w-0 flex-1">
-          <div className={cn("truncate text-sm font-medium", isSelected && "font-semibold")}>
+          <div
+            className={cn(
+              "truncate text-sm font-medium",
+              isSelected && "font-semibold",
+            )}
+          >
             {entry.suite.name || "Untitled suite"}
           </div>
           {entry.suite.tags && entry.suite.tags.length > 0 && (

--- a/mcpjam-inspector/client/src/components/evals/commit-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/commit-detail-view.tsx
@@ -24,10 +24,7 @@ import {
 import type { CommitGroup, EvalSuiteRun } from "./types";
 import { formatDuration } from "./helpers";
 import { navigateToCiEvalsRoute } from "@/lib/ci-evals-router";
-import {
-  classifyAllFailures,
-  type FailureTag,
-} from "./ai-insights";
+import { classifyAllFailures, type FailureTag } from "./ai-insights";
 import { useCommitTriage } from "./use-ai-triage";
 
 interface CommitDetailViewProps {
@@ -151,7 +148,8 @@ export function CommitDetailView({
   const compareOptions = useMemo(
     () =>
       allCommitGroups.filter(
-        (g) => g.commitSha !== commitGroup.commitSha && g.commitSha !== "manual",
+        (g) =>
+          g.commitSha !== commitGroup.commitSha && g.commitSha !== "manual",
       ),
     [allCommitGroups, commitGroup.commitSha],
   );
@@ -192,7 +190,11 @@ export function CommitDetailView({
   // Classify failures with regression/flaky/new tags
   const classifiedFailures = useMemo(
     () =>
-      classifyAllFailures(runsWithFailedCases, commitGroup.suiteMap, allCommitGroups),
+      classifyAllFailures(
+        runsWithFailedCases,
+        commitGroup.suiteMap,
+        allCommitGroups,
+      ),
     [runsWithFailedCases, commitGroup.suiteMap, allCommitGroups],
   );
 
@@ -207,10 +209,21 @@ export function CommitDetailView({
 
   // Auto-request triage when failures exist and no result yet
   useEffect(() => {
-    if (failedRunIds.length > 0 && !aiTriage.summary && !aiTriage.loading && !aiTriage.unavailable) {
+    if (
+      failedRunIds.length > 0 &&
+      !aiTriage.summary &&
+      !aiTriage.loading &&
+      !aiTriage.unavailable
+    ) {
       aiTriage.requestTriage();
     }
-  }, [failedRunIds.length, aiTriage.summary, aiTriage.loading, aiTriage.unavailable, aiTriage.requestTriage]);
+  }, [
+    failedRunIds.length,
+    aiTriage.summary,
+    aiTriage.loading,
+    aiTriage.unavailable,
+    aiTriage.requestTriage,
+  ]);
 
   // Triage summary — shows when any cases failed
   const triageSummary = useMemo(() => {
@@ -256,13 +269,19 @@ export function CommitDetailView({
             {commitGroup.branch && (
               <span className="flex items-center gap-1">
                 <GitBranch className="h-3 w-3" />
-                branch: <span className="font-mono font-medium text-foreground">{commitGroup.branch}</span>
+                branch:{" "}
+                <span className="font-mono font-medium text-foreground">
+                  {commitGroup.branch}
+                </span>
               </span>
             )}
             {!isManual && (
               <span className="flex items-center gap-1">
                 <GitCommit className="h-3 w-3" />
-                commit: <span className="font-mono font-medium text-foreground">{commitGroup.shortSha}</span>
+                commit:{" "}
+                <span className="font-mono font-medium text-foreground">
+                  {commitGroup.shortSha}
+                </span>
               </span>
             )}
             {commitGroup.runs[0]?.ciMetadata?.provider && (
@@ -276,12 +295,19 @@ export function CommitDetailView({
             {totalDuration > 0 && (
               <span className="flex items-center gap-1">
                 <Clock className="h-3 w-3" />
-                duration: <span className="font-mono font-medium text-foreground">{formatDuration(totalDuration)}</span>
+                duration:{" "}
+                <span className="font-mono font-medium text-foreground">
+                  {formatDuration(totalDuration)}
+                </span>
               </span>
             )}
             {models.length > 0 && (
               <span>
-                model: <span className="font-mono font-medium text-foreground">{models[0]}{models.length > 1 ? ` +${models.length - 1}` : ""}</span>
+                model:{" "}
+                <span className="font-mono font-medium text-foreground">
+                  {models[0]}
+                  {models.length > 1 ? ` +${models.length - 1}` : ""}
+                </span>
               </span>
             )}
           </div>
@@ -336,12 +362,14 @@ export function CommitDetailView({
                 )}
                 <span className="flex items-center gap-1.5">
                   <span className="text-muted-foreground">
-                    {commitGroup.runs.length} suite{commitGroup.runs.length !== 1 ? "s" : ""}
+                    {commitGroup.runs.length} suite
+                    {commitGroup.runs.length !== 1 ? "s" : ""}
                   </span>
                 </span>
                 <span className="flex items-center gap-1.5">
                   <span className="text-muted-foreground">
-                    {totalCases.total} total case{totalCases.total !== 1 ? "s" : ""}
+                    {totalCases.total} total case
+                    {totalCases.total !== 1 ? "s" : ""}
                   </span>
                 </span>
               </div>
@@ -372,53 +400,65 @@ export function CommitDetailView({
         </div>
 
         {/* === AI TRIAGE PANEL === */}
-        {triageSummary && !aiTriage.unavailable && (aiTriage.summary || aiTriage.loading || aiTriage.error) && (
-          <div className="relative rounded-lg border border-orange-200/60 bg-orange-50/30 p-6 shadow-sm dark:border-orange-900/40 dark:bg-orange-950/10">
-            <div className="absolute top-0 left-0 right-0 h-[3px] rounded-t-lg ai-shimmer-bar" />
-            <div className="flex items-center gap-2.5 mb-4">
-              <Badge
-                variant="outline"
-                className="border-orange-300/70 bg-orange-100/60 text-orange-700 text-[10px] font-bold uppercase tracking-wider dark:border-orange-800/50 dark:bg-orange-900/30 dark:text-orange-400"
-              >
-                <Sparkles className="mr-1 h-3 w-3" />
-                AI
-              </Badge>
-              <span className="text-sm font-semibold">Triage Summary</span>
-              {aiTriage.loading && (
-                <span className="ml-auto text-[10px] text-muted-foreground flex items-center gap-1">
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                  analyzing...
-                </span>
-              )}
-            </div>
+        {triageSummary &&
+          !aiTriage.unavailable &&
+          (aiTriage.summary || aiTriage.loading || aiTriage.error) && (
+            <div className="relative rounded-lg border border-orange-200/60 bg-orange-50/30 p-6 shadow-sm dark:border-orange-900/40 dark:bg-orange-950/10">
+              <div className="absolute top-0 left-0 right-0 h-[3px] rounded-t-lg ai-shimmer-bar" />
+              <div className="flex items-center gap-2.5 mb-4">
+                <Badge
+                  variant="outline"
+                  className="border-orange-300/70 bg-orange-100/60 text-orange-700 text-[10px] font-bold uppercase tracking-wider dark:border-orange-800/50 dark:bg-orange-900/30 dark:text-orange-400"
+                >
+                  <Sparkles className="mr-1 h-3 w-3" />
+                  AI
+                </Badge>
+                <span className="text-sm font-semibold">Triage Summary</span>
+                {aiTriage.loading && (
+                  <span className="ml-auto text-[10px] text-muted-foreground flex items-center gap-1">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    analyzing...
+                  </span>
+                )}
+              </div>
 
-            {/* AI-generated summary */}
-            <div className="rounded-md border border-border/40 bg-white/60 p-4 text-[13px] leading-relaxed dark:bg-black/20">
-              {aiTriage.summary ? (
-                <p>{aiTriage.summary}</p>
-              ) : aiTriage.error ? (
-                <div className="flex items-start gap-2 text-amber-600 dark:text-amber-400">
-                  <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
-                  <div>
-                    <p className="font-medium text-xs">AI triage unavailable</p>
-                    <p className="text-[11px] text-muted-foreground mt-0.5">{aiTriage.error}</p>
-                    <p className="text-xs mt-2">
-                      <strong>{triageSummary.failCount} failure{triageSummary.failCount !== 1 ? "s" : ""} detected</strong>{" "}
-                      across {triageSummary.failedSuiteNames.join(", ")} with{" "}
-                      {triageSummary.totalFailedCases} failed case{triageSummary.totalFailedCases !== 1 ? "s" : ""}.
-                    </p>
+              {/* AI-generated summary */}
+              <div className="rounded-md border border-border/40 bg-white/60 p-4 text-[13px] leading-relaxed dark:bg-black/20">
+                {aiTriage.summary ? (
+                  <p>{aiTriage.summary}</p>
+                ) : aiTriage.error ? (
+                  <div className="flex items-start gap-2 text-amber-600 dark:text-amber-400">
+                    <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+                    <div>
+                      <p className="font-medium text-xs">
+                        AI triage unavailable
+                      </p>
+                      <p className="text-[11px] text-muted-foreground mt-0.5">
+                        {aiTriage.error}
+                      </p>
+                      <p className="text-xs mt-2">
+                        <strong>
+                          {triageSummary.failCount} failure
+                          {triageSummary.failCount !== 1 ? "s" : ""} detected
+                        </strong>{" "}
+                        across {triageSummary.failedSuiteNames.join(", ")} with{" "}
+                        {triageSummary.totalFailedCases} failed case
+                        {triageSummary.totalFailedCases !== 1 ? "s" : ""}.
+                      </p>
+                    </div>
                   </div>
-                </div>
-              ) : (
-                <div className="flex items-center gap-2 text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  <span>Analyzing {triageSummary.failCount} failure{triageSummary.failCount !== 1 ? "s" : ""}...</span>
-                </div>
-              )}
+                ) : (
+                  <div className="flex items-center gap-2 text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <span>
+                      Analyzing {triageSummary.failCount} failure
+                      {triageSummary.failCount !== 1 ? "s" : ""}...
+                    </span>
+                  </div>
+                )}
+              </div>
             </div>
-
-          </div>
-        )}
+          )}
 
         {/* === COMPARE BAR === */}
         {compareOptions.length > 0 && (
@@ -486,7 +526,8 @@ export function CommitDetailView({
                 <XCircle className="h-4 w-4 text-destructive" />
                 <span className="text-sm font-semibold">Failure Details</span>
                 <span className="text-xs text-muted-foreground">
-                  · {classifiedFailures.length} suite{classifiedFailures.length !== 1 ? "s" : ""} with failures
+                  · {classifiedFailures.length} suite
+                  {classifiedFailures.length !== 1 ? "s" : ""} with failures
                 </span>
               </div>
             </div>
@@ -494,7 +535,8 @@ export function CommitDetailView({
               {classifiedFailures.slice(0, 4).map((cf) => {
                 const passRate = cf.run.summary
                   ? Math.round(
-                      (cf.run.summary.passed / Math.max(cf.run.summary.total, 1)) *
+                      (cf.run.summary.passed /
+                        Math.max(cf.run.summary.total, 1)) *
                         100,
                     )
                   : 0;
@@ -524,8 +566,11 @@ export function CommitDetailView({
                       {cf.suiteName}
                     </div>
                     <div className="text-[11px] text-muted-foreground">
-                      <span className="text-destructive font-medium">{cf.run.summary?.failed ?? 0} failed</span> of{" "}
-                      {cf.run.summary?.total ?? 0} cases · {passRate}% pass rate
+                      <span className="text-destructive font-medium">
+                        {cf.run.summary?.failed ?? 0} failed
+                      </span>{" "}
+                      of {cf.run.summary?.total ?? 0} cases · {passRate}% pass
+                      rate
                     </div>
                     <span className="mt-2 inline-flex items-center gap-1 text-[12px] font-semibold text-orange-600 dark:text-orange-400">
                       <ExternalLink className="h-3 w-3" />
@@ -580,16 +625,12 @@ export function CommitDetailView({
             defaultOpen
           >
             {failed.map((run) => {
-              const cf = classifiedFailures.find(
-                (c) => c.run._id === run._id,
-              );
+              const cf = classifiedFailures.find((c) => c.run._id === run._id);
               return (
                 <FailedRunRow
                   key={run._id}
                   run={run}
-                  suiteName={
-                    commitGroup.suiteMap.get(run.suiteId) || "Unknown"
-                  }
+                  suiteName={commitGroup.suiteMap.get(run.suiteId) || "Unknown"}
                   sparkline={getSuiteSparkline(
                     run.suiteId,
                     commitGroup.commitSha,
@@ -795,9 +836,7 @@ function FailedRunRow({
 }) {
   const duration = getRunDuration(run);
   const passRate = run.summary
-    ? Math.round(
-        (run.summary.passed / Math.max(run.summary.total, 1)) * 100,
-      )
+    ? Math.round((run.summary.passed / Math.max(run.summary.total, 1)) * 100)
     : 0;
 
   return (
@@ -843,17 +882,21 @@ function FailedRunRow({
                   </span>
                 </div>
                 {/* Show expected tool calls as a mini diff hint */}
-                {test.expectedToolCalls && test.expectedToolCalls.length > 0 && (
-                  <div className="mt-1 font-mono text-[11px] text-muted-foreground">
-                    expected:{" "}
-                    <span className="text-emerald-500">
-                      {test.expectedToolCalls.map((tc) => tc.toolName).join(", ")}
-                    </span>
-                  </div>
-                )}
+                {test.expectedToolCalls &&
+                  test.expectedToolCalls.length > 0 && (
+                    <div className="mt-1 font-mono text-[11px] text-muted-foreground">
+                      expected:{" "}
+                      <span className="text-emerald-500">
+                        {test.expectedToolCalls
+                          .map((tc) => tc.toolName)
+                          .join(", ")}
+                      </span>
+                    </div>
+                  )}
                 {test.isNegativeTest && (
                   <div className="mt-1 font-mono text-[11px] text-muted-foreground">
-                    expected: <span className="text-emerald-500">no tool calls</span>
+                    expected:{" "}
+                    <span className="text-emerald-500">no tool calls</span>
                     {test.scenario && (
                       <span className="ml-1 text-muted-foreground/70">
                         ({test.scenario})
@@ -864,7 +907,9 @@ function FailedRunRow({
               </div>
               {duration !== null && (
                 <span className="font-mono text-muted-foreground shrink-0 pt-0.5">
-                  {formatDuration(duration / Math.max(run.configSnapshot.tests.length, 1))}
+                  {formatDuration(
+                    duration / Math.max(run.configSnapshot.tests.length, 1),
+                  )}
                 </span>
               )}
               <div className="flex gap-1 shrink-0 pt-0.5">
@@ -933,9 +978,7 @@ function RunRow({
 }) {
   const duration = getRunDuration(run);
   const passRate = run.summary
-    ? Math.round(
-        (run.summary.passed / Math.max(run.summary.total, 1)) * 100,
-      )
+    ? Math.round((run.summary.passed / Math.max(run.summary.total, 1)) * 100)
     : 0;
 
   const icon =
@@ -966,7 +1009,9 @@ function RunRow({
         </span>
       )}
       {variant === "running" && (
-        <span className="text-xs text-amber-500 font-medium">In progress...</span>
+        <span className="text-xs text-amber-500 font-medium">
+          In progress...
+        </span>
       )}
       {variant === "notrun" && (
         <Badge

--- a/mcpjam-inspector/client/src/components/evals/commit-list-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/evals/commit-list-sidebar.tsx
@@ -71,12 +71,18 @@ export function CommitListSidebar({
                 onClick={() => onSelectCommit(group.commitSha)}
                 className={cn(
                   "w-full px-4 py-2.5 text-left transition-colors hover:bg-accent/50",
-                  selectedCommitSha === group.commitSha && "bg-accent shadow-sm",
+                  selectedCommitSha === group.commitSha &&
+                    "bg-accent shadow-sm",
                 )}
               >
                 <div className="flex items-start gap-2.5">
                   {/* Status dot */}
-                  <div className={cn("h-2 w-2 rounded-full mt-1.5 shrink-0", status.dotClass)} />
+                  <div
+                    className={cn(
+                      "h-2 w-2 rounded-full mt-1.5 shrink-0",
+                      status.dotClass,
+                    )}
+                  />
 
                   {/* Content */}
                   <div className="min-w-0 flex-1">

--- a/mcpjam-inspector/client/src/components/evals/helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/helpers.ts
@@ -243,7 +243,10 @@ export const formatters = {
 export function groupRunsByCommit(
   overview: EvalSuiteOverviewEntry[],
 ): CommitGroup[] {
-  const buckets = new Map<string, { runs: EvalSuiteRun[]; suiteMap: Map<string, string> }>();
+  const buckets = new Map<
+    string,
+    { runs: EvalSuiteRun[]; suiteMap: Map<string, string> }
+  >();
 
   for (const entry of overview) {
     for (const run of entry.recentRuns) {
@@ -268,7 +271,8 @@ export function groupRunsByCommit(
       const ts = run.completedAt ?? run.createdAt;
       if (ts > latestTimestamp) latestTimestamp = ts;
       if (!branch && run.ciMetadata?.branch) branch = run.ciMetadata.branch;
-      if (run.status === "running" || run.status === "pending") summary.running++;
+      if (run.status === "running" || run.status === "pending")
+        summary.running++;
       else if (run.result === "passed") summary.passed++;
       else if (run.result === "failed") summary.failed++;
     }

--- a/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
+++ b/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
@@ -2,7 +2,14 @@ import { useAction } from "convex/react";
 import { useEffect, useMemo, useState } from "react";
 import { EvalIteration, EvalCase } from "./types";
 import { TraceViewer } from "./trace-viewer";
-import { MessageSquare, Code2, ChevronDown, ChevronRight, ShieldCheck, ShieldX } from "lucide-react";
+import {
+  MessageSquare,
+  Code2,
+  ChevronDown,
+  ChevronRight,
+  ShieldCheck,
+  ShieldX,
+} from "lucide-react";
 import { ToolServerMap, listTools } from "@/lib/apis/mcp-tools-api";
 import { JsonEditor } from "@/components/ui/json-editor";
 import {
@@ -408,18 +415,22 @@ export function IterationDetails({
   const errorDetailsJson = parseErrorDetails(iteration.errorDetails);
   const [isErrorDetailsOpen, setIsErrorDetailsOpen] = useState(false);
 
-  const isNegativeTest = iteration.testCaseSnapshot?.isNegativeTest || testCase?.isNegativeTest;
-  const negativeTestScenario = iteration.testCaseSnapshot?.scenario || testCase?.scenario;
+  const isNegativeTest =
+    iteration.testCaseSnapshot?.isNegativeTest || testCase?.isNegativeTest;
+  const negativeTestScenario =
+    iteration.testCaseSnapshot?.scenario || testCase?.scenario;
 
   return (
     <div className="space-y-4 py-2">
       {/* Negative Test Summary */}
       {isNegativeTest && (
-        <div className={`rounded-md border p-3 space-y-1 ${
-          iteration.result === "passed"
-            ? "border-emerald-500/30 bg-emerald-500/10"
-            : "border-destructive/30 bg-destructive/10"
-        }`}>
+        <div
+          className={`rounded-md border p-3 space-y-1 ${
+            iteration.result === "passed"
+              ? "border-emerald-500/30 bg-emerald-500/10"
+              : "border-destructive/30 bg-destructive/10"
+          }`}
+        >
           <div className="flex items-center gap-2">
             {iteration.result === "passed" ? (
               <ShieldCheck className="h-4 w-4 text-emerald-500 shrink-0" />
@@ -427,7 +438,8 @@ export function IterationDetails({
               <ShieldX className="h-4 w-4 text-destructive shrink-0" />
             )}
             <span className="text-xs font-semibold">
-              Negative Test {iteration.result === "passed" ? "Passed" : "Failed"}
+              Negative Test{" "}
+              {iteration.result === "passed" ? "Passed" : "Failed"}
             </span>
           </div>
           <p className="text-xs text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/evals/overview-panel.tsx
+++ b/mcpjam-inspector/client/src/components/evals/overview-panel.tsx
@@ -22,11 +22,12 @@ import {
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { TagBadges } from "./tag-editor";
-import type { EvalSuiteOverviewEntry, EvalSuiteRun, CommitGroup } from "./types";
-import {
-  classifyFailure,
-  type FailureTag,
-} from "./ai-insights";
+import type {
+  EvalSuiteOverviewEntry,
+  EvalSuiteRun,
+  CommitGroup,
+} from "./types";
+import { classifyFailure, type FailureTag } from "./ai-insights";
 import { useCommitTriage } from "./use-ai-triage";
 
 // ---------------------------------------------------------------------------
@@ -276,7 +277,11 @@ export function OverviewPanel({
   // Collect run IDs from suites with failures for backend triage
   const failedOverviewRunIds = useMemo(() => {
     return filteredSuites
-      .filter((e) => (e.totals.failed > 0 || e.latestRun?.result === "failed") && e.latestRun)
+      .filter(
+        (e) =>
+          (e.totals.failed > 0 || e.latestRun?.result === "failed") &&
+          e.latestRun,
+      )
       .map((e) => e.latestRun!._id);
   }, [filteredSuites]);
 
@@ -293,7 +298,14 @@ export function OverviewPanel({
     ) {
       aiOverviewTriage.requestTriage();
     }
-  }, [failedOverviewRunIds.length, aiOverviewTriage.summary, aiOverviewTriage.loading, aiOverviewTriage.unavailable, aiOverviewTriage.error, aiOverviewTriage.requestTriage]);
+  }, [
+    failedOverviewRunIds.length,
+    aiOverviewTriage.summary,
+    aiOverviewTriage.loading,
+    aiOverviewTriage.unavailable,
+    aiOverviewTriage.error,
+    aiOverviewTriage.requestTriage,
+  ]);
 
   // Pre-compute inline failure tags for the failure feed
   // Tags suites with failed cases OR failed result
@@ -374,9 +386,7 @@ export function OverviewPanel({
     if (activeBucket) {
       list = list.filter((e) => activeBucket.suiteIds.has(e.suite._id));
     }
-    return list.filter(
-      (e) => e.latestRun?.result === "failed" || !e.latestRun,
-    );
+    return list.filter((e) => e.latestRun?.result === "failed" || !e.latestRun);
   }, [filteredSuites, activeBucket]);
 
   // Auto-collapse failure feed when no failures
@@ -486,11 +496,15 @@ export function OverviewPanel({
               {stats.neverRunCount > 0 && (
                 <> &middot; {stats.neverRunCount} never run</>
               )}
-              {stats.latestBranch && (
-                <> &middot; {stats.latestBranch}</>
-              )}
+              {stats.latestBranch && <> &middot; {stats.latestBranch}</>}
               {stats.latestCommitSha && (
-                <> @ <span className="font-mono">{stats.latestCommitSha.slice(0, 7)}</span></>
+                <>
+                  {" "}
+                  @{" "}
+                  <span className="font-mono">
+                    {stats.latestCommitSha.slice(0, 7)}
+                  </span>
+                </>
               )}
             </span>
           </div>
@@ -503,59 +517,66 @@ export function OverviewPanel({
       </div>
 
       {/* AI Overview Summary — only when failures exist and triage is active */}
-      {failedOverviewRunIds.length > 0 && !aiOverviewTriage.unavailable && (aiOverviewTriage.summary || aiOverviewTriage.loading || aiOverviewTriage.error) && (
-        <div className="relative rounded-lg border border-orange-200/60 bg-orange-50/30 shadow-sm dark:border-orange-900/40 dark:bg-orange-950/10">
-          <div className="absolute top-0 left-0 right-0 h-[3px] rounded-t-lg ai-shimmer-bar" />
-          <div className="px-4 py-3">
-            <div className="flex items-center gap-2 mb-2">
-              <Badge
-                variant="outline"
-                className="border-orange-300/70 bg-orange-100/60 text-orange-700 text-[10px] font-bold uppercase tracking-wider dark:border-orange-800/50 dark:bg-orange-900/30 dark:text-orange-400"
-              >
-                <Sparkles className="mr-1 h-3 w-3" />
-                AI
-              </Badge>
-              <span className="text-xs font-semibold">Overview Insights</span>
-              {stats.latestCommitSha && (
-                <span className="text-[10px] text-muted-foreground font-mono">
-                  {stats.latestBranch && <>{stats.latestBranch} @ </>}
-                  {stats.latestCommitSha.slice(0, 7)}
-                  {" · "}
-                  {stats.totalSuites} suite{stats.totalSuites !== 1 ? "s" : ""}
-                </span>
-              )}
-              {aiOverviewTriage.loading && (
-                <span className="ml-auto text-[10px] text-muted-foreground flex items-center gap-1">
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                  analyzing...
-                </span>
-              )}
-            </div>
-            <div className="text-[13px] leading-relaxed">
-              {aiOverviewTriage.summary ? (
-                <p>{aiOverviewTriage.summary}</p>
-              ) : aiOverviewTriage.error ? (
-                <div className="flex items-start gap-2 text-amber-600 dark:text-amber-400">
-                  <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
-                  <div>
-                    <p className="font-medium">AI insights unavailable</p>
-                    <p className="text-[11px] text-muted-foreground mt-0.5">
-                      {aiOverviewTriage.error}
-                    </p>
-                  </div>
-                </div>
-              ) : (
-                <div className="flex items-center gap-2 text-muted-foreground">
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  <span>
-                    Analyzing {failedOverviewRunIds.length} suite{failedOverviewRunIds.length !== 1 ? "s" : ""} with failures...
+      {failedOverviewRunIds.length > 0 &&
+        !aiOverviewTriage.unavailable &&
+        (aiOverviewTriage.summary ||
+          aiOverviewTriage.loading ||
+          aiOverviewTriage.error) && (
+          <div className="relative rounded-lg border border-orange-200/60 bg-orange-50/30 shadow-sm dark:border-orange-900/40 dark:bg-orange-950/10">
+            <div className="absolute top-0 left-0 right-0 h-[3px] rounded-t-lg ai-shimmer-bar" />
+            <div className="px-4 py-3">
+              <div className="flex items-center gap-2 mb-2">
+                <Badge
+                  variant="outline"
+                  className="border-orange-300/70 bg-orange-100/60 text-orange-700 text-[10px] font-bold uppercase tracking-wider dark:border-orange-800/50 dark:bg-orange-900/30 dark:text-orange-400"
+                >
+                  <Sparkles className="mr-1 h-3 w-3" />
+                  AI
+                </Badge>
+                <span className="text-xs font-semibold">Overview Insights</span>
+                {stats.latestCommitSha && (
+                  <span className="text-[10px] text-muted-foreground font-mono">
+                    {stats.latestBranch && <>{stats.latestBranch} @ </>}
+                    {stats.latestCommitSha.slice(0, 7)}
+                    {" · "}
+                    {stats.totalSuites} suite
+                    {stats.totalSuites !== 1 ? "s" : ""}
                   </span>
-                </div>
-              )}
+                )}
+                {aiOverviewTriage.loading && (
+                  <span className="ml-auto text-[10px] text-muted-foreground flex items-center gap-1">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    analyzing...
+                  </span>
+                )}
+              </div>
+              <div className="text-[13px] leading-relaxed">
+                {aiOverviewTriage.summary ? (
+                  <p>{aiOverviewTriage.summary}</p>
+                ) : aiOverviewTriage.error ? (
+                  <div className="flex items-start gap-2 text-amber-600 dark:text-amber-400">
+                    <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                    <div>
+                      <p className="font-medium">AI insights unavailable</p>
+                      <p className="text-[11px] text-muted-foreground mt-0.5">
+                        {aiOverviewTriage.error}
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2 text-muted-foreground">
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    <span>
+                      Analyzing {failedOverviewRunIds.length} suite
+                      {failedOverviewRunIds.length !== 1 ? "s" : ""} with
+                      failures...
+                    </span>
+                  </div>
+                )}
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
 
       {/* Section B: Run Timeline Chips */}
       {timeline.length > 0 && (
@@ -596,11 +617,14 @@ export function OverviewPanel({
 
               const totalRuns = bucket.runs.length;
               const summaryParts: string[] = [];
-              if (bucket.passedCount > 0) summaryParts.push(`${bucket.passedCount}✓`);
-              if (bucket.failedCount > 0) summaryParts.push(`${bucket.failedCount}✗`);
-              const summaryText = summaryParts.length > 0
-                ? summaryParts.join(" ")
-                : `${totalRuns} run${totalRuns !== 1 ? "s" : ""}`;
+              if (bucket.passedCount > 0)
+                summaryParts.push(`${bucket.passedCount}✓`);
+              if (bucket.failedCount > 0)
+                summaryParts.push(`${bucket.failedCount}✗`);
+              const summaryText =
+                summaryParts.length > 0
+                  ? summaryParts.join(" ")
+                  : `${totalRuns} run${totalRuns !== 1 ? "s" : ""}`;
 
               const tooltipParts = [
                 bucket.branch ? `${bucket.branch} @ ${chipLabel}` : chipLabel,
@@ -611,7 +635,11 @@ export function OverviewPanel({
               return (
                 <button
                   key={bucket.id}
-                  onClick={() => setSelectedBucketId(bucket.id === activeBucketId ? null : bucket.id)}
+                  onClick={() =>
+                    setSelectedBucketId(
+                      bucket.id === activeBucketId ? null : bucket.id,
+                    )
+                  }
                   title={tooltipParts.join("\n")}
                   className={cn(
                     "flex flex-col items-center gap-1 px-3 py-2 rounded-lg transition-all shrink-0 min-w-[68px]",
@@ -624,7 +652,9 @@ export function OverviewPanel({
                     <div
                       className={cn("h-2.5 w-2.5 rounded-full", chipColor)}
                     />
-                    <span className="text-xs font-mono font-medium">{chipLabel}</span>
+                    <span className="text-xs font-mono font-medium">
+                      {chipLabel}
+                    </span>
                   </div>
                   <span className="text-[10px] text-muted-foreground">
                     {formatRelativeTime(bucket.timestamp)}
@@ -662,9 +692,10 @@ export function OverviewPanel({
                 {failureEntries.slice(0, failurePageSize).map((entry) => {
                   const isFailed = entry.latestRun?.result === "failed";
                   const isNeverRun = !entry.latestRun;
-                  const passRate = isFailed && entry.latestRun?.summary
-                    ? toPercent(entry.latestRun.summary.passRate ?? 0)
-                    : null;
+                  const passRate =
+                    isFailed && entry.latestRun?.summary
+                      ? toPercent(entry.latestRun.summary.passRate ?? 0)
+                      : null;
 
                   return (
                     <button
@@ -684,9 +715,11 @@ export function OverviewPanel({
                               {stripTimestampSuffix(entry.suite.name)}
                             </span>
                             {isFailed &&
-                              failureTagMap.get(entry.suite._id)?.map((tag) => (
-                                <InlineFailureTag key={tag} tag={tag} />
-                              ))}
+                              failureTagMap
+                                .get(entry.suite._id)
+                                ?.map((tag) => (
+                                  <InlineFailureTag key={tag} tag={tag} />
+                                ))}
                           </div>
                           {isFailed && entry.latestRun?.summary && (
                             <div className="flex items-center gap-2 mt-1">
@@ -694,7 +727,9 @@ export function OverviewPanel({
                                 <div
                                   className={cn(
                                     "h-full rounded-full transition-all",
-                                    passRate! >= 75 ? "bg-amber-500" : "bg-destructive",
+                                    passRate! >= 75
+                                      ? "bg-amber-500"
+                                      : "bg-destructive",
                                   )}
                                   style={{ width: `${passRate}%` }}
                                 />
@@ -713,7 +748,11 @@ export function OverviewPanel({
                               {entry.latestRun.ciMetadata.commitSha && (
                                 <span>
                                   {" "}
-                                  @ {entry.latestRun.ciMetadata.commitSha.slice(0, 7)}
+                                  @{" "}
+                                  {entry.latestRun.ciMetadata.commitSha.slice(
+                                    0,
+                                    7,
+                                  )}
                                 </span>
                               )}
                               {" · "}
@@ -748,7 +787,8 @@ export function OverviewPanel({
                   onClick={() => setFailurePageSize((s) => s + 20)}
                   className="w-full py-2 text-xs text-primary hover:bg-muted/50 transition-colors border-t font-medium"
                 >
-                  Show more ({failureEntries.length - failurePageSize} remaining)
+                  Show more ({failureEntries.length - failurePageSize}{" "}
+                  remaining)
                 </button>
               )}
             </CollapsibleContent>
@@ -766,7 +806,9 @@ export function OverviewPanel({
               className="text-xs px-2.5 py-1 rounded-full border bg-primary/10 text-primary border-primary/30 hover:bg-primary/20 transition-colors flex items-center gap-1"
             >
               <span className="font-mono">
-                {activeBucket.commitSha ? activeBucket.commitSha.slice(0, 7) : "manual"}
+                {activeBucket.commitSha
+                  ? activeBucket.commitSha.slice(0, 7)
+                  : "manual"}
               </span>
               <span>&times;</span>
             </button>
@@ -872,7 +914,8 @@ export function OverviewPanel({
                   {/* Suite name */}
                   <div className="min-w-0">
                     <div className="text-sm font-medium truncate">
-                      {stripTimestampSuffix(entry.suite.name) || "Untitled suite"}
+                      {stripTimestampSuffix(entry.suite.name) ||
+                        "Untitled suite"}
                     </div>
                   </div>
 
@@ -927,13 +970,19 @@ export function OverviewPanel({
                   >
                     {entry.latestRun?.ciMetadata?.commitSha ? (
                       <div>
-                        <span className="font-mono">{entry.latestRun.ciMetadata.commitSha.slice(0, 7)}</span>
+                        <span className="font-mono">
+                          {entry.latestRun.ciMetadata.commitSha.slice(0, 7)}
+                        </span>
                         {lastRunTs && (
-                          <div className="text-[10px]">{formatRelativeTime(lastRunTs)}</div>
+                          <div className="text-[10px]">
+                            {formatRelativeTime(lastRunTs)}
+                          </div>
                         )}
                       </div>
+                    ) : lastRunTs ? (
+                      formatRelativeTime(lastRunTs)
                     ) : (
-                      lastRunTs ? formatRelativeTime(lastRunTs) : "—"
+                      "—"
                     )}
                   </div>
 
@@ -989,15 +1038,18 @@ function InlineFailureTag({ tag }: { tag: FailureTag }) {
   const config = {
     regression: {
       label: "regression",
-      className: "text-destructive bg-red-50 border-red-200 dark:bg-red-950/50 dark:border-red-800",
+      className:
+        "text-destructive bg-red-50 border-red-200 dark:bg-red-950/50 dark:border-red-800",
     },
     flaky: {
       label: "flaky",
-      className: "text-amber-600 bg-amber-50 border-amber-200 dark:bg-amber-950/50 dark:border-amber-800",
+      className:
+        "text-amber-600 bg-amber-50 border-amber-200 dark:bg-amber-950/50 dark:border-amber-800",
     },
     new: {
       label: "new",
-      className: "text-blue-600 bg-blue-50 border-blue-200 dark:bg-blue-950/50 dark:border-blue-800",
+      className:
+        "text-blue-600 bg-blue-50 border-blue-200 dark:bg-blue-950/50 dark:border-blue-800",
     },
   }[tag];
 

--- a/mcpjam-inspector/client/src/components/evals/pass-criteria-badge.tsx
+++ b/mcpjam-inspector/client/src/components/evals/pass-criteria-badge.tsx
@@ -24,7 +24,8 @@ export function PassCriteriaBadge({
   const status = run.status ?? "pending";
   // passRate may be stored as decimal (0-1) or percentage (0-100); normalize to 0-100
   const rawPassRate = run.summary?.passRate ?? 0;
-  const passRate = rawPassRate <= 1 && rawPassRate > 0 ? rawPassRate * 100 : rawPassRate;
+  const passRate =
+    rawPassRate <= 1 && rawPassRate > 0 ? rawPassRate * 100 : rawPassRate;
 
   const passed = result === "passed";
   const isRunning = status === "running" || status === "pending";
@@ -57,7 +58,11 @@ export function PassCriteriaBadge({
             ) : (
               <XCircle className="h-3 w-3" />
             )}
-            {passedWithFailures ? `Passed (${failedCount} failed)` : passed ? "Passed" : "Failed"}
+            {passedWithFailures
+              ? `Passed (${failedCount} failed)`
+              : passed
+                ? "Passed"
+                : "Failed"}
           </Badge>
         </TooltipTrigger>
         <TooltipContent className="max-w-xs">
@@ -65,10 +70,13 @@ export function PassCriteriaBadge({
             <div className="font-medium text-white">
               {passedWithFailures
                 ? `⚠ Suite Passed with ${failedCount} failure${failedCount !== 1 ? "s" : ""}`
-                : passed ? "✓ Suite Passed" : "✗ Suite Failed"}
+                : passed
+                  ? "✓ Suite Passed"
+                  : "✗ Suite Failed"}
             </div>
             <div className="text-white">
-              Required: {minimumPassRate}% {metricLabel} · Actual: {passRate.toFixed(0)}%
+              Required: {minimumPassRate}% {metricLabel} · Actual:{" "}
+              {passRate.toFixed(0)}%
             </div>
           </div>
         </TooltipContent>

--- a/mcpjam-inspector/client/src/components/evals/run-accordion-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-accordion-view.tsx
@@ -80,8 +80,7 @@ export function RunAccordionView({
       );
       const testCases: RunTestCase[] = runIterations.map((iter) => ({
         testCaseId: iter.testCaseId ?? "",
-        title:
-          iter.testCaseSnapshot?.title || "Untitled test",
+        title: iter.testCaseSnapshot?.title || "Untitled test",
         result: computeIterationResult(iter),
         duration:
           iter.startedAt && iter.updatedAt

--- a/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-detail-view.tsx
@@ -286,10 +286,7 @@ export function RunDetailView({
                 By Model:
               </span>
               {selectedRunChartData.modelData.map((model) => (
-                <div
-                  key={model.model}
-                  className="flex items-center gap-1.5"
-                >
+                <div key={model.model} className="flex items-center gap-1.5">
                   <div
                     className="h-1.5 w-1.5 rounded-full"
                     style={{
@@ -376,7 +373,6 @@ export function RunDetailView({
           )}
         </div>
       </div>
-
     </div>
   );
 }
@@ -519,11 +515,17 @@ function IterationListItem({
     const expectedArgs = testInfo.expectedToolCalls?.[0]?.arguments;
     if (expectedArgs && Object.keys(expectedArgs).length > 0) {
       const entries = Object.entries(expectedArgs).slice(0, 2);
-      return entries.map(([k, v]) => `${k}: ${typeof v === 'object' ? JSON.stringify(v) : v}`).join(', ');
+      return entries
+        .map(
+          ([k, v]) => `${k}: ${typeof v === "object" ? JSON.stringify(v) : v}`,
+        )
+        .join(", ");
     }
     // Fall back to first ~60 chars of query if different from title
     if (testInfo.query && testInfo.query !== testInfo.title) {
-      return testInfo.query.length > 60 ? testInfo.query.slice(0, 57) + '...' : testInfo.query;
+      return testInfo.query.length > 60
+        ? testInfo.query.slice(0, 57) + "..."
+        : testInfo.query;
     }
     return null;
   }, [testInfo]);

--- a/mcpjam-inspector/client/src/components/evals/suite-hero-stats.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-hero-stats.tsx
@@ -48,7 +48,9 @@ export function SuiteHeroStats({
       (iter) => iter.suiteRunId && activeRunIds.has(iter.suiteRunId),
     );
 
-    const results = activeIterations.map((iter) => computeIterationResult(iter));
+    const results = activeIterations.map((iter) =>
+      computeIterationResult(iter),
+    );
     const passed = results.filter((r) => r === "passed").length;
     const failed = results.filter((r) => r === "failed").length;
     const total = passed + failed;
@@ -253,9 +255,7 @@ export function SuiteHeroStats({
                   onRunClick
                     ? (chartData: any) => {
                         if (chartData?.activePayload?.[0]?.payload?.runId) {
-                          onRunClick(
-                            chartData.activePayload[0].payload.runId,
-                          );
+                          onRunClick(chartData.activePayload[0].payload.runId);
                         }
                       }
                     : undefined
@@ -300,9 +300,7 @@ export function SuiteHeroStats({
                           : "hsl(0 84.2% 60.2%)",
                   }}
                 />
-                <span className="text-xs">
-                  {model.model}
-                </span>
+                <span className="text-xs">{model.model}</span>
                 <span className="text-xs font-mono font-medium">
                   {model.passRate}%
                 </span>

--- a/mcpjam-inspector/client/src/components/evals/use-ai-triage.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-ai-triage.ts
@@ -27,9 +27,7 @@ export interface TriageResult {
  * Until the backend mutation is deployed, requests fail gracefully and the
  * panel stays hidden instead of flashing briefly.
  */
-export function useCommitTriage(
-  failedRunIds: string[],
-): {
+export function useCommitTriage(failedRunIds: string[]): {
   summary: string | null;
   loading: boolean;
   error: string | null;
@@ -62,7 +60,8 @@ export function useCommitTriage(
   }, [runKey]);
 
   const requestTriage = useCallback(() => {
-    if (failedRunIds.length === 0 || unavailable || hasAttemptedRef.current) return;
+    if (failedRunIds.length === 0 || unavailable || hasAttemptedRef.current)
+      return;
 
     hasAttemptedRef.current = true;
     setLoading(true);
@@ -79,7 +78,9 @@ export function useCommitTriage(
         } else {
           // Backend will generate async — for now show as pending
           setLoading(false);
-          setSummary("Triage requested — results will appear when backend processing completes.");
+          setSummary(
+            "Triage requested — results will appear when backend processing completes.",
+          );
         }
       })
       .catch((err: unknown) => {

--- a/mcpjam-inspector/client/src/lib/ci-evals-router.ts
+++ b/mcpjam-inspector/client/src/lib/ci-evals-router.ts
@@ -38,7 +38,10 @@ export function parseCiEvalsRoute(): CiEvalsRoute | null {
 
   const commitMatch = path.match(/^\/ci-evals\/commit\/([^/]+)$/);
   if (commitMatch) {
-    return { type: "commit-detail", commitSha: decodeURIComponent(commitMatch[1]) };
+    return {
+      type: "commit-detail",
+      commitSha: decodeURIComponent(commitMatch[1]),
+    };
   }
 
   const suiteMatch = path.match(/^\/ci-evals\/suite\/([^/]+)(?:\/(.*))?$/);


### PR DESCRIPTION
### TL;DR

Removed the dashboard overview panel and simplified the CI evals interface to show a "Select a suite" placeholder when no suite is selected.

### What changed?

- Removed the `OverviewPanel` component and its associated imports
- Eliminated dashboard-related state variables (`filterTag`, tag filtering logic)
- Removed the dashboard button from the sidebar that showed suite overview statistics
- Replaced the overview panel with a simple placeholder message encouraging users to select a suite or commit
- Cleaned up unused props and handlers related to overview functionality

### How to test?

1. Navigate to the CI Evals tab
2. Verify that no dashboard button appears in the sidebar
3. Confirm that when no suite is selected, a "Select a suite" message with instructions is displayed
4. Test that selecting suites and commits from the sidebar still works correctly
5. Ensure the suite details view loads properly when a suite is selected

### Why make this change?

This simplifies the user interface by removing the dashboard overview functionality, likely because it was underutilized or the team decided to focus users directly on individual suite inspection rather than aggregate views.