### PR TITLE
Remove visibility badges from workspace selector

### DIFF
--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-workspace-selector.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-workspace-selector.tsx
@@ -15,7 +15,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import type { Workspace } from "@/state/app-types";
-import { WorkspaceVisibilityBadge } from "@/components/workspace/WorkspaceVisibilityBadge";
+
 
 interface SidebarWorkspaceSelectorProps {
   activeWorkspaceId: string;
@@ -52,10 +52,6 @@ export function SidebarWorkspaceSelector({
   const activeWorkspace = workspaces[activeWorkspaceId];
   const workspaceName = activeWorkspace?.name || "No Workspace";
   const initial = workspaceName.charAt(0).toUpperCase();
-  const showActiveVisibility =
-    Boolean(activeWorkspace?.sharedWorkspaceId) ||
-    Boolean(activeWorkspace?.visibility);
-
   const workspaceList = Object.values(workspaces).sort((a, b) => {
     if (a.isDefault) return -1;
     if (b.isDefault) return 1;
@@ -90,13 +86,6 @@ export function SidebarWorkspaceSelector({
               </div>
               <div className="grid flex-1 text-left text-sm leading-tight group-data-[collapsible=icon]:hidden">
                 <span className="truncate font-semibold">{workspaceName}</span>
-                {showActiveVisibility ? (
-                  <WorkspaceVisibilityBadge
-                    visibility={activeWorkspace?.visibility}
-                    compact
-                    className="mt-1"
-                  />
-                ) : null}
               </div>
               <ChevronsUpDown className="ml-auto size-4 group-data-[collapsible=icon]:hidden" />
             </SidebarMenuButton>
@@ -122,13 +111,6 @@ export function SidebarWorkspaceSelector({
                   </div>
                   <div className="min-w-0 flex-1">
                     <span className="truncate block">{workspace.name}</span>
-                    {workspace.sharedWorkspaceId || workspace.visibility ? (
-                      <WorkspaceVisibilityBadge
-                        visibility={workspace.visibility}
-                        compact
-                        className="mt-1"
-                      />
-                    ) : null}
                   </div>
                 </div>
                 <button


### PR DESCRIPTION
## Summary
- Removed the Public/Private visibility badge from the workspace selector dropdown and the active workspace display in the sidebar
- The labels were too visually prominent and cluttered the workspace switcher UI

## Test plan
- [ ] Open the workspace selector dropdown and verify no Public/Private badges appear
- [ ] Verify the active workspace in the sidebar no longer shows a visibility badge
- [ ] Confirm workspace switching still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that removes visibility indicators from the workspace switcher; no data or permission logic is modified.
> 
> **Overview**
> Removes `WorkspaceVisibilityBadge` rendering from the sidebar workspace selector, both for the active workspace display and each workspace entry in the dropdown.
> 
> Cleans up now-unused visibility-related conditional logic in `sidebar-workspace-selector.tsx`, leaving workspace switching/creation/deletion behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ec62155ea02bfb40a3465a3ed5f064e91b4e558. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->