### PR TITLE
Handle stale org-scoped workspace queries

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/useWorkspaces.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useWorkspaces.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterWorkspacesForOrganization,
+  type RemoteWorkspace,
+} from "../useWorkspaces";
+
+function createWorkspace(
+  id: string,
+  overrides: Partial<RemoteWorkspace> = {},
+): RemoteWorkspace {
+  return {
+    _id: id,
+    name: `Workspace ${id}`,
+    servers: {},
+    ownerId: "user-1",
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+describe("filterWorkspacesForOrganization", () => {
+  it("returns all workspaces when no organization filter is set", () => {
+    const workspaces = [
+      createWorkspace("ws-1", { organizationId: "org-1" }),
+      createWorkspace("ws-2", { organizationId: "org-2" }),
+    ];
+
+    expect(filterWorkspacesForOrganization(workspaces)).toEqual(workspaces);
+  });
+
+  it("keeps legacy unscoped results while any workspace is missing organizationId", () => {
+    const workspaces = [
+      createWorkspace("ws-1", { organizationId: "org-1" }),
+      createWorkspace("ws-2"),
+    ];
+
+    expect(filterWorkspacesForOrganization(workspaces, "org-1")).toEqual(
+      workspaces,
+    );
+  });
+
+  it("filters by organization once all workspaces are org-scoped", () => {
+    const workspaces = [
+      createWorkspace("ws-1", { organizationId: "org-1" }),
+      createWorkspace("ws-2", { organizationId: "org-2" }),
+      createWorkspace("ws-3", { organizationId: "org-1" }),
+    ];
+
+    expect(filterWorkspacesForOrganization(workspaces, "org-1")).toEqual([
+      workspaces[0],
+      workspaces[2],
+    ]);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useWorkspaces.ts
+++ b/mcpjam-inspector/client/src/hooks/useWorkspaces.ts
@@ -66,6 +66,26 @@ export interface WorkspaceMember {
   } | null;
 }
 
+export function filterWorkspacesForOrganization(
+  workspaces: RemoteWorkspace[] | undefined,
+  organizationId?: string,
+) {
+  if (!workspaces || !organizationId) return workspaces;
+
+  // Keep the legacy unscoped behavior until every returned workspace has been
+  // backfilled with an organizationId.
+  const allWorkspacesAreScoped = workspaces.every(
+    (workspace) => workspace.organizationId !== undefined,
+  );
+  if (!allWorkspacesAreScoped) {
+    return workspaces;
+  }
+
+  return workspaces.filter(
+    (workspace) => workspace.organizationId === organizationId,
+  );
+}
+
 export function useWorkspaceQueries({
   isAuthenticated,
   organizationId,
@@ -73,14 +93,18 @@ export function useWorkspaceQueries({
   isAuthenticated: boolean;
   organizationId?: string;
 }) {
-  const workspaces = useQuery(
+  const queriedWorkspaces = useQuery(
     "workspaces:getMyWorkspaces" as any,
-    isAuthenticated
-      ? ((organizationId ? { organizationId } : {}) as any)
-      : "skip",
+    isAuthenticated ? ({} as any) : "skip",
   ) as RemoteWorkspace[] | undefined;
 
-  const isLoading = isAuthenticated && workspaces === undefined;
+  const isLoading = isAuthenticated && queriedWorkspaces === undefined;
+
+  const workspaces = useMemo(
+    () =>
+      filterWorkspacesForOrganization(queriedWorkspaces, organizationId) ?? [],
+    [queriedWorkspaces, organizationId],
+  );
 
   const sortedWorkspaces = useMemo(() => {
     if (!workspaces) return [];


### PR DESCRIPTION
### Summary

Bugfix: implemented client-side workspace filtering by organization with backward compatibility for legacy workspaces.

### What changed?

Added a `filterWorkspacesForOrganization` function that filters workspaces by organization ID while maintaining legacy behavior when some workspaces lack organization scoping. The function returns all workspaces if any workspace is missing an `organizationId`, ensuring backward compatibility during the migration period. Updated `useWorkspaceQueries` to fetch all workspaces and apply organization filtering client-side instead of server-side.

![Screenshot 2026-03-20 at 9.33.49 PM.png](https://app.graphite.com/user-attachments/assets/a1e33990-b779-4748-aece-35f15b46d0c0.png)

