### PR TITLE
Fix hosted web OAuth redirect URI

### DIFF
--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/constants.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/constants.test.ts
@@ -11,6 +11,12 @@ describe("resolveBrowserOAuthRedirectOrigin", () => {
     ).toBe("http://localhost:5173");
   });
 
+  it("keeps 127.0.0.1 origins for local development", () => {
+    expect(
+      resolveBrowserOAuthRedirectOrigin(new URL("http://127.0.0.1:5173/#test")),
+    ).toBe("http://127.0.0.1:5173");
+  });
+
   it("keeps the current origin on the hosted app domain", () => {
     expect(
       resolveBrowserOAuthRedirectOrigin(

--- a/mcpjam-inspector/client/src/lib/oauth/constants.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/constants.ts
@@ -20,6 +20,7 @@ export function resolveBrowserOAuthRedirectOrigin(
   locationLike: Pick<Location, "protocol" | "origin" | "hostname">,
 ): string {
   if (locationLike.protocol !== "http:" && locationLike.protocol !== "https:") {
+    // Defensive fallback for non-browser-like locations. Electron exits earlier.
     return MCPJAM_HOSTED_APP_ORIGIN;
   }
 


### PR DESCRIPTION
## Summary
- fix the hosted web OAuth redirect helper to use the app origin instead of the marketing site
- preserve localhost and hosted subdomain behavior while keeping Electron on the custom protocol callback
- add a regression test covering localhost, app.mcpjam.com, staging.app.mcpjam.com, and www.mcpjam.com fallback behavior

## Root cause
The browser OAuth helper was generating `https://www.mcpjam.com/oauth/callback` in production. Hosted web OAuth runs on `app.mcpjam.com`, so fresh DCR registrations and authorize requests could send users to the wrong host and fail with redirect URI mismatch / 404 errors.

## Testing
- `npm exec -- vitest run client/src/lib/oauth/__tests__/constants.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated change to OAuth redirect URL construction plus targeted tests; main risk is misclassification of origins causing redirect mismatches in edge environments.
> 
> **Overview**
> Fixes browser `getRedirectUri()` to build `/oauth/callback` off a new `resolveBrowserOAuthRedirectOrigin()` helper that preserves `localhost`/`127.0.0.1` and `*.app.mcpjam.com` origins, but otherwise **falls back to** the hosted app origin `https://app.mcpjam.com` (instead of the marketing site).
> 
> Adds `vitest` coverage for localhost, hosted app, hosted subdomain (staging), and `www.mcpjam.com` fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa6ab55efca458bcbd44a7cb58b2c7f40b7a015d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->