### PR TITLE
Prepare OAuth debugger foundations for future learning lessons

### DIFF
--- a/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
@@ -1,73 +1,18 @@
-import { useState, useCallback, useEffect, useMemo, useRef } from "react";
-import { EMPTY_OAUTH_FLOW_STATE_V2 } from "@/lib/oauth/state-machines/debug-oauth-2025-06-18";
-import {
-  OAuthFlowState,
-  type OAuthFlowStep,
-} from "@/lib/oauth/state-machines/types";
-import { createOAuthStateMachine } from "@/lib/oauth/state-machines/factory";
-import { DebugMCPOAuthClientProvider } from "@/lib/oauth/debug-oauth-provider";
-import { OAuthSequenceDiagram } from "@/components/oauth/OAuthSequenceDiagram";
-import { OAuthAuthorizationModal } from "@/components/oauth/OAuthAuthorizationModal";
-import {
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from "./ui/resizable";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import posthog from "posthog-js";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
-import { OAuthProfileModal } from "./oauth/OAuthProfileModal";
-import { type OAuthTestProfile } from "@/lib/oauth/profile";
-import { OAuthFlowLogger } from "./oauth/OAuthFlowLogger";
+import { OAuthFlowExperience } from "@/components/oauth/OAuthFlowExperience";
+import { OAuthProfileModal } from "@/components/oauth/OAuthProfileModal";
+import { useOAuthFlowController } from "@/components/oauth/useOAuthFlowController";
+import {
+  deriveServerIdentifier,
+  describeRegistrationStrategy,
+  type OAuthTokensFromFlow,
+} from "@/components/oauth/oauthFlowShared";
+import type { OAuthTestProfile } from "@/lib/oauth/profile";
 import type { ServerFormData } from "@/shared/types.js";
 import type { ServerWithName } from "@/hooks/use-app-state";
-import { deriveOAuthProfileFromServer } from "./oauth/utils";
-import { RefreshTokensConfirmModal } from "./oauth/RefreshTokensConfirmModal";
-
-export interface OAuthTokensFromFlow {
-  accessToken: string;
-  refreshToken?: string;
-  tokenType?: string;
-  expiresIn?: number;
-  clientId?: string;
-  clientSecret?: string;
-}
-
-const deriveServerIdentifier = (profile: OAuthTestProfile): string => {
-  const trimmedUrl = profile.serverUrl.trim();
-  if (!trimmedUrl) {
-    return "oauth-flow-target";
-  }
-
-  try {
-    const url = new URL(trimmedUrl);
-    return url.host;
-  } catch {
-    return trimmedUrl;
-  }
-};
-
-const buildHeaderMap = (
-  headers: Array<{ key: string; value: string }>,
-): Record<string, string> | undefined => {
-  const entries = headers
-    .map((header) => ({
-      key: header.key.trim(),
-      value: header.value.trim(),
-    }))
-    .filter((header) => header.key.length > 0);
-
-  if (!entries.length) {
-    return undefined;
-  }
-
-  return Object.fromEntries(entries.map(({ key, value }) => [key, value]));
-};
-
-const describeRegistrationStrategy = (strategy: string): string => {
-  if (strategy === "cimd") return "CIMD (URL-based)";
-  if (strategy === "dcr") return "Dynamic (DCR)";
-  return "Pre-registered";
-};
+import { deriveOAuthProfileFromServer } from "@/components/oauth/utils";
 
 const isHttpServer = (server?: ServerWithName) =>
   Boolean(server && "url" in server.config);
@@ -104,13 +49,6 @@ export const OAuthFlowTab = ({
   const [pendingServerSelection, setPendingServerSelection] = useState<
     string | null
   >(null);
-  const [oauthFlowState, setOAuthFlowState] = useState<OAuthFlowState>(
-    EMPTY_OAUTH_FLOW_STATE_V2,
-  );
-  const [focusedStep, setFocusedStep] = useState<OAuthFlowStep | null>(null);
-  const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
-  const [isRefreshTokensModalOpen, setIsRefreshTokensModalOpen] =
-    useState(false);
   const [isApplyingTokens, setIsApplyingTokens] = useState(false);
 
   const httpServers = useMemo(
@@ -154,113 +92,37 @@ export const OAuthFlowTab = ({
     [activeServer],
   );
 
-  const hasProfile = Boolean(activeServer && profile.serverUrl.trim());
   const serverIdentifier = useMemo(
     () => (activeServer ? activeServer.name : deriveServerIdentifier(profile)),
-    [activeServer, profile.serverUrl],
+    [activeServer, profile],
   );
 
-  const protocolVersion = profile.protocolVersion;
-  const registrationStrategy = profile.registrationStrategy;
-
-  const oauthFlowStateRef = useRef(oauthFlowState);
-  useEffect(() => {
-    oauthFlowStateRef.current = oauthFlowState;
-  }, [oauthFlowState]);
-
-  useEffect(() => {
-    setFocusedStep(null);
-  }, [oauthFlowState.currentStep]);
-
-  const updateOAuthFlowState = useCallback(
-    (updates: Partial<OAuthFlowState>) => {
-      setOAuthFlowState((prev) => ({ ...prev, ...updates }));
-    },
-    [],
-  );
-
-  const processedCodeRef = useRef<string | null>(null);
-  const exchangeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-
-  // Reset OAuth flow state when switching servers
-  const prevServerNameRef = useRef(selectedServerName);
-  useEffect(() => {
-    if (prevServerNameRef.current !== selectedServerName) {
-      prevServerNameRef.current = selectedServerName;
-      setOAuthFlowState({
-        ...EMPTY_OAUTH_FLOW_STATE_V2,
-        serverUrl: profile.serverUrl || undefined,
-      });
-      processedCodeRef.current = null;
-      if (exchangeTimeoutRef.current) {
-        clearTimeout(exchangeTimeoutRef.current);
-        exchangeTimeoutRef.current = null;
-      }
-    }
-  }, [selectedServerName, profile.serverUrl]);
-
-  const resetOAuthFlow = useCallback(
-    (serverUrlOverride?: string) => {
-      const nextServerUrl = serverUrlOverride ?? profile.serverUrl;
-      setOAuthFlowState({
-        ...EMPTY_OAUTH_FLOW_STATE_V2,
-        serverUrl: nextServerUrl || undefined,
-      });
-      processedCodeRef.current = null;
-      if (exchangeTimeoutRef.current) {
-        clearTimeout(exchangeTimeoutRef.current);
-        exchangeTimeoutRef.current = null;
-      }
-    },
-    [profile.serverUrl],
-  );
-
-  const clearInfoLogs = () => {
-    updateOAuthFlowState({ infoLogs: [] });
-  };
-
-  const clearHttpHistory = () => {
-    updateOAuthFlowState({ httpHistory: [] });
-  };
-
-  const customHeaders = useMemo(
-    () => buildHeaderMap(profile.customHeaders),
-    [profile.customHeaders],
-  );
-
-  const oauthStateMachine = useMemo(() => {
-    if (!hasProfile) return null;
-
-    const provider = new DebugMCPOAuthClientProvider(profile.serverUrl);
-
-    return createOAuthStateMachine({
-      protocolVersion,
-      state: oauthFlowStateRef.current,
-      getState: () => oauthFlowStateRef.current,
-      updateState: updateOAuthFlowState,
-      serverUrl: profile.serverUrl,
-      serverName: serverIdentifier,
-      redirectUrl: provider.redirectUrl,
-      customScopes: profile.scopes.trim() || undefined,
-      customHeaders,
-      registrationStrategy,
-    });
-  }, [
+  const {
+    oauthFlowState,
+    focusedStep,
+    setFocusedStep,
+    isAuthModalOpen,
+    setIsAuthModalOpen,
+    isRefreshTokensModalOpen,
+    setIsRefreshTokensModalOpen,
     hasProfile,
     protocolVersion,
-    profile.serverUrl,
-    profile.scopes,
-    serverIdentifier,
-    customHeaders,
     registrationStrategy,
-    updateOAuthFlowState,
-  ]);
-
-  const proceedToNextStep = useCallback(async () => {
-    if (oauthStateMachine) {
-      await oauthStateMachine.proceedToNextStep();
-    }
-  }, [oauthStateMachine]);
+    continueLabel,
+    continueDisabled,
+    clearInfoLogs,
+    clearHttpHistory,
+    handleAdvance: advanceOAuthFlow,
+    resetOAuthFlow,
+    extractTokensFromFlowState,
+  } = useOAuthFlowController({
+    profile,
+    serverIdentifier,
+    resetKey: selectedServerName,
+    experienceConfig: {
+      targetMode: "server-backed",
+    },
+  });
 
   const handleAdvance = useCallback(async () => {
     posthog.capture("oauth_flow_tab_next_step_button_clicked", {
@@ -274,70 +136,22 @@ export const OAuthFlowTab = ({
       targetUrlConfigured: Boolean(profile.serverUrl),
     });
 
-    if (
-      oauthFlowState.currentStep === "authorization_request" ||
-      oauthFlowState.currentStep === "generate_pkce_parameters"
-    ) {
-      if (oauthFlowState.currentStep === "generate_pkce_parameters") {
-        await proceedToNextStep();
-      }
-      setIsAuthModalOpen(true);
-    } else {
-      await proceedToNextStep();
-    }
+    await advanceOAuthFlow();
   }, [
+    advanceOAuthFlow,
     hasProfile,
     oauthFlowState.currentStep,
-    proceedToNextStep,
     profile.serverUrl,
     protocolVersion,
     registrationStrategy,
   ]);
 
-  const continueLabel = !hasProfile
-    ? "Configure Target"
-    : oauthFlowState.currentStep === "complete"
-      ? "Flow Complete"
-      : oauthFlowState.isInitiatingAuth
-        ? "Continue"
-        : oauthFlowState.currentStep === "authorization_request" ||
-            oauthFlowState.currentStep === "generate_pkce_parameters"
-          ? "Authorize"
-          : "Continue";
-  const continueDisabled =
-    !hasProfile ||
-    !oauthStateMachine ||
-    oauthFlowState.isInitiatingAuth ||
-    oauthFlowState.currentStep === "complete";
-
-  // Determine if we can apply tokens (flow complete with access token)
   const isServerConnected = activeServer?.connectionStatus === "connected";
   const canApplyTokens =
     oauthFlowState.currentStep === "complete" &&
     oauthFlowState.accessToken &&
     activeServer;
 
-  // Extract tokens from flow state
-  const extractTokensFromFlowState = useCallback(
-    (): OAuthTokensFromFlow => ({
-      accessToken: oauthFlowState.accessToken!,
-      refreshToken: oauthFlowState.refreshToken,
-      tokenType: oauthFlowState.tokenType,
-      expiresIn: oauthFlowState.expiresIn,
-      clientId: oauthFlowState.clientId,
-      clientSecret: oauthFlowState.clientSecret,
-    }),
-    [
-      oauthFlowState.accessToken,
-      oauthFlowState.refreshToken,
-      oauthFlowState.tokenType,
-      oauthFlowState.expiresIn,
-      oauthFlowState.clientId,
-      oauthFlowState.clientSecret,
-    ],
-  );
-
-  // Handler for connecting server with new tokens
   const handleConnectServer = useCallback(async () => {
     if (!activeServer || !onConnectWithTokens) return;
     setIsApplyingTokens(true);
@@ -352,12 +166,11 @@ export const OAuthFlowTab = ({
     }
   }, [
     activeServer,
-    onConnectWithTokens,
     extractTokensFromFlowState,
+    onConnectWithTokens,
     profile.serverUrl,
   ]);
 
-  // Handler for refreshing tokens (called after modal confirmation)
   const handleRefreshTokensConfirm = useCallback(async () => {
     if (!activeServer || !onRefreshTokens) return;
     setIsApplyingTokens(true);
@@ -373,88 +186,11 @@ export const OAuthFlowTab = ({
     }
   }, [
     activeServer,
-    onRefreshTokens,
     extractTokensFromFlowState,
+    onRefreshTokens,
     profile.serverUrl,
+    setIsRefreshTokensModalOpen,
   ]);
-
-  useEffect(() => {
-    const processOAuthCallback = (code: string, state: string | undefined) => {
-      if (processedCodeRef.current === code) {
-        return;
-      }
-
-      const expectedState = oauthFlowStateRef.current.state;
-      const currentStep = oauthFlowStateRef.current.currentStep;
-      const isWaitingForCode =
-        currentStep === "received_authorization_code" ||
-        currentStep === "authorization_request";
-
-      if (!isWaitingForCode) {
-        return;
-      }
-
-      if (!expectedState) {
-        updateOAuthFlowState({
-          error:
-            "Flow was reset. Please start a new authorization by clicking 'Next Step'.",
-        });
-        return;
-      }
-
-      if (state !== expectedState) {
-        updateOAuthFlowState({
-          error:
-            "Invalid state parameter - this authorization code is from a previous flow. Please try again.",
-        });
-        return;
-      }
-
-      processedCodeRef.current = code;
-
-      if (exchangeTimeoutRef.current) {
-        clearTimeout(exchangeTimeoutRef.current);
-      }
-
-      updateOAuthFlowState({
-        authorizationCode: code,
-        error: undefined,
-      });
-
-      exchangeTimeoutRef.current = setTimeout(() => {
-        oauthStateMachine?.proceedToNextStep();
-        exchangeTimeoutRef.current = null;
-      }, 500);
-    };
-
-    const handleMessage = (event: MessageEvent) => {
-      if (event.origin !== window.location.origin) {
-        return;
-      }
-
-      if (event.data?.type === "OAUTH_CALLBACK" && event.data?.code) {
-        processOAuthCallback(event.data.code, event.data.state);
-      }
-    };
-
-    let channel: BroadcastChannel | null = null;
-    try {
-      channel = new BroadcastChannel("oauth_callback_channel");
-      channel.onmessage = (event) => {
-        if (event.data?.type === "OAUTH_CALLBACK" && event.data?.code) {
-          processOAuthCallback(event.data.code, event.data.state);
-        }
-      };
-    } catch (error) {
-      // BroadcastChannel not supported; fallback to window message only
-    }
-
-    window.addEventListener("message", handleMessage);
-    return () => {
-      window.removeEventListener("message", handleMessage);
-      channel?.close();
-    };
-  }, [oauthStateMachine, updateOAuthFlowState]);
 
   useEffect(() => {
     posthog.capture("oauth_flow_tab_viewed", {
@@ -469,84 +205,71 @@ export const OAuthFlowTab = ({
     : "Paste an MCP base URL to start debugging the OAuth flow.";
 
   return (
-    <div className="h-full flex flex-col bg-background">
-      <div className="flex-1 overflow-hidden">
-        <ResizablePanelGroup direction="horizontal" className="h-full">
-          <ResizablePanel defaultSize={50} minSize={30}>
-            <OAuthSequenceDiagram
-              flowState={oauthFlowState}
-              registrationStrategy={registrationStrategy}
-              protocolVersion={protocolVersion}
-              focusedStep={focusedStep}
-              hasProfile={hasProfile}
-              onConfigure={() => setIsProfileModalOpen(true)}
-            />
-          </ResizablePanel>
-
-          <ResizableHandle withHandle />
-
-          <ResizablePanel defaultSize={50} minSize={20} maxSize={50}>
-            <OAuthFlowLogger
-              oauthFlowState={oauthFlowState}
-              onClearLogs={clearInfoLogs}
-              onClearHttpHistory={clearHttpHistory}
-              activeStep={focusedStep ?? oauthFlowState.currentStep}
-              onFocusStep={setFocusedStep}
-              hasProfile={hasProfile}
-              summary={{
-                label: hasProfile ? serverIdentifier : "No target configured",
-                description: headerDescription,
-                protocol: hasProfile ? protocolVersion : undefined,
-                registration: hasProfile
-                  ? describeRegistrationStrategy(registrationStrategy)
-                  : undefined,
-                step: oauthFlowState.currentStep,
-                serverUrl: hasProfile ? profile.serverUrl : undefined,
-                scopes:
-                  hasProfile && profile.scopes.trim()
-                    ? profile.scopes.trim()
-                    : undefined,
-                clientId:
-                  hasProfile && profile.clientId.trim()
-                    ? profile.clientId.trim()
-                    : undefined,
-                customHeadersCount: hasProfile
-                  ? profile.customHeaders.filter((h) => h.key.trim()).length
-                  : undefined,
-              }}
-              actions={{
-                onConfigure: () => setIsProfileModalOpen(true),
-                onReset: hasProfile ? () => resetOAuthFlow() : undefined,
-                // Hide Continue button when showing Connect/Refresh buttons
-                onContinue:
-                  canApplyTokens || continueDisabled
-                    ? undefined
-                    : handleAdvance,
-                continueLabel,
-                continueDisabled: Boolean(canApplyTokens || continueDisabled),
-                resetDisabled: !hasProfile || oauthFlowState.isInitiatingAuth,
-                onConnectServer:
-                  canApplyTokens && !isServerConnected
-                    ? handleConnectServer
-                    : undefined,
-                onRefreshTokens:
-                  canApplyTokens && isServerConnected
-                    ? () => setIsRefreshTokensModalOpen(true)
-                    : undefined,
-                isApplyingTokens,
-              }}
-            />
-          </ResizablePanel>
-        </ResizablePanelGroup>
-      </div>
-
-      {oauthFlowState.authorizationUrl && (
-        <OAuthAuthorizationModal
-          open={isAuthModalOpen}
-          onOpenChange={setIsAuthModalOpen}
-          authorizationUrl={oauthFlowState.authorizationUrl}
-        />
-      )}
+    <>
+      <OAuthFlowExperience
+        flowState={oauthFlowState}
+        focusedStep={focusedStep}
+        onFocusStep={setFocusedStep}
+        hasProfile={hasProfile}
+        protocolVersion={protocolVersion}
+        registrationStrategy={registrationStrategy}
+        summary={{
+          label: hasProfile ? serverIdentifier : "No target configured",
+          description: headerDescription,
+          protocol: hasProfile ? protocolVersion : undefined,
+          registration: hasProfile
+            ? describeRegistrationStrategy(registrationStrategy)
+            : undefined,
+          step: oauthFlowState.currentStep,
+          serverUrl: hasProfile ? profile.serverUrl : undefined,
+          scopes: hasProfile && profile.scopes.trim()
+            ? profile.scopes.trim()
+            : undefined,
+          clientId: hasProfile && profile.clientId.trim()
+            ? profile.clientId.trim()
+            : undefined,
+          customHeadersCount: hasProfile
+            ? profile.customHeaders.filter((header) => header.key.trim()).length
+            : undefined,
+        }}
+        config={{
+          targetMode: "server-backed",
+        }}
+        onClearLogs={clearInfoLogs}
+        onClearHttpHistory={clearHttpHistory}
+        onConfigureTarget={() => setIsProfileModalOpen(true)}
+        onReset={hasProfile ? () => resetOAuthFlow() : undefined}
+        onContinue={
+          canApplyTokens || continueDisabled ? undefined : handleAdvance
+        }
+        continueLabel={continueLabel}
+        continueDisabled={Boolean(canApplyTokens || continueDisabled)}
+        onApplyTokens={
+          canApplyTokens && !isServerConnected ? handleConnectServer : undefined
+        }
+        onRefreshTokens={
+          canApplyTokens && isServerConnected
+            ? () => setIsRefreshTokensModalOpen(true)
+            : undefined
+        }
+        isApplyingTokens={isApplyingTokens}
+        authModal={{
+          open: isAuthModalOpen,
+          onOpenChange: setIsAuthModalOpen,
+          authorizationUrl: oauthFlowState.authorizationUrl,
+        }}
+        refreshModal={
+          activeServer
+            ? {
+                open: isRefreshTokensModalOpen,
+                onOpenChange: setIsRefreshTokensModalOpen,
+                serverName: activeServer.name,
+                onConfirm: handleRefreshTokensConfirm,
+                isLoading: isApplyingTokens,
+              }
+            : undefined
+        }
+      />
 
       <OAuthProfileModal
         open={isProfileModalOpen}
@@ -559,16 +282,6 @@ export const OAuthFlowTab = ({
           resetOAuthFlow(formData.url);
         }}
       />
-
-      {activeServer && (
-        <RefreshTokensConfirmModal
-          open={isRefreshTokensModalOpen}
-          onOpenChange={setIsRefreshTokensModalOpen}
-          serverName={activeServer.name}
-          onConfirm={handleRefreshTokensConfirm}
-          isLoading={isApplyingTokens}
-        />
-      )}
-    </div>
+    </>
   );
 };

--- a/mcpjam-inspector/client/src/components/__tests__/OAuthFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OAuthFlowTab.test.tsx
@@ -1,0 +1,467 @@
+import type { ReactNode } from "react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OAuthStateMachineFactoryConfig } from "@/lib/oauth/state-machines/factory";
+import { OAuthFlowTab } from "../OAuthFlowTab";
+import type { ServerWithName } from "@/hooks/use-app-state";
+
+const {
+  mockCreateOAuthStateMachine,
+  mockProceedToNextStep,
+  mockPosthogCapture,
+  savedProfilePayload,
+} = vi.hoisted(() => ({
+  mockCreateOAuthStateMachine: vi.fn(),
+  mockProceedToNextStep: vi.fn(),
+  mockPosthogCapture: vi.fn(),
+  savedProfilePayload: {
+    formData: {
+      name: "saved-target",
+      type: "http",
+      url: "https://saved.example.com/mcp",
+      useOAuth: true,
+    },
+    profile: {
+      serverUrl: "https://saved.example.com/mcp",
+      clientId: "",
+      clientSecret: "",
+      scopes: "openid profile",
+      customHeaders: [],
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "cimd",
+    },
+  },
+}));
+
+class MockBroadcastChannel {
+  public onmessage:
+    | ((event: { data: unknown }) => void)
+    | null = null;
+
+  constructor(_name: string) {}
+
+  close = vi.fn();
+}
+
+vi.mock("posthog-js", () => ({
+  default: {
+    capture: mockPosthogCapture,
+  },
+}));
+
+vi.mock("@/lib/PosthogUtils", () => ({
+  detectEnvironment: () => "test",
+  detectPlatform: () => "web",
+}));
+
+vi.mock("@/lib/oauth/state-machines/factory", () => ({
+  createOAuthStateMachine: mockCreateOAuthStateMachine,
+}));
+
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({
+    children,
+  }: {
+    children?: ReactNode;
+  }) => <div>{children}</div>,
+  ResizablePanel: ({
+    children,
+  }: {
+    children?: ReactNode;
+  }) => <div>{children}</div>,
+  ResizableHandle: () => <div data-testid="resizable-handle" />,
+}));
+
+vi.mock("@/components/oauth/OAuthSequenceDiagram", () => ({
+  OAuthSequenceDiagram: () => <div data-testid="oauth-sequence-diagram" />,
+}));
+
+vi.mock("@/components/oauth/OAuthFlowLogger", () => ({
+  OAuthFlowLogger: ({
+    oauthFlowState,
+    summary,
+    actions,
+  }: {
+    oauthFlowState: { currentStep: string };
+    summary?: { serverUrl?: string; description: string };
+    actions?: {
+      onConfigure?: () => void | Promise<void>;
+      showConfigureTarget?: boolean;
+      showEditTarget?: boolean;
+      onContinue?: () => void | Promise<void>;
+      continueLabel?: string;
+      onConnectServer?: () => void | Promise<void>;
+      onRefreshTokens?: () => void | Promise<void>;
+      onReset?: () => void | Promise<void>;
+    };
+  }) => {
+    const hasProfile = Boolean(summary?.serverUrl);
+    return (
+      <div>
+        <div data-testid="current-step">{oauthFlowState.currentStep}</div>
+        <div data-testid="summary-text">
+          {summary?.serverUrl || summary?.description}
+        </div>
+        {hasProfile && actions?.showEditTarget !== false && actions?.onConfigure && (
+          <button type="button" onClick={() => actions.onConfigure?.()}>
+            Edit
+          </button>
+        )}
+        {!hasProfile &&
+          actions?.showConfigureTarget !== false &&
+          actions?.onConfigure && (
+            <button type="button" onClick={() => actions.onConfigure?.()}>
+              Configure Target
+            </button>
+          )}
+        {actions?.onContinue && (
+          <button type="button" onClick={() => actions.onContinue?.()}>
+            {actions.continueLabel || "Continue"}
+          </button>
+        )}
+        {actions?.onConnectServer && (
+          <button type="button" onClick={() => actions.onConnectServer?.()}>
+            Connect Server
+          </button>
+        )}
+        {actions?.onRefreshTokens && (
+          <button type="button" onClick={() => actions.onRefreshTokens?.()}>
+            Refresh Tokens
+          </button>
+        )}
+        {actions?.onReset && (
+          <button type="button" onClick={() => actions.onReset?.()}>
+            Reset
+          </button>
+        )}
+      </div>
+    );
+  },
+}));
+
+vi.mock("@/components/oauth/OAuthAuthorizationModal", () => ({
+  OAuthAuthorizationModal: ({
+    open,
+    authorizationUrl,
+  }: {
+    open: boolean;
+    authorizationUrl: string;
+  }) =>
+    open ? <div data-testid="auth-modal">{authorizationUrl}</div> : null,
+}));
+
+vi.mock("@/components/oauth/OAuthProfileModal", () => ({
+  OAuthProfileModal: ({
+    open,
+    onSave,
+  }: {
+    open: boolean;
+    onSave: (payload: typeof savedProfilePayload) => void;
+  }) =>
+    open ? (
+      <div data-testid="profile-modal">
+        <button type="button" onClick={() => onSave(savedProfilePayload)}>
+          Save Target
+        </button>
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/components/oauth/RefreshTokensConfirmModal", () => ({
+  RefreshTokensConfirmModal: ({
+    open,
+    onConfirm,
+  }: {
+    open: boolean;
+    onConfirm: () => void | Promise<void>;
+  }) =>
+    open ? (
+      <div data-testid="refresh-modal">
+        <button type="button" onClick={() => onConfirm()}>
+          Confirm Refresh
+        </button>
+      </div>
+    ) : null,
+}));
+
+const createHttpServer = (
+  name: string,
+  {
+    status = "disconnected",
+    url = `https://${name}.example.com/mcp`,
+  }: {
+    status?: ServerWithName["connectionStatus"];
+    url?: string;
+  } = {},
+): ServerWithName =>
+  ({
+    name,
+    config: {
+      type: "http",
+      url,
+      headers: {},
+    },
+    oauthFlowProfile: {
+      serverUrl: url,
+      clientId: "",
+      clientSecret: "",
+      scopes: "openid profile",
+      customHeaders: [],
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "cimd",
+    },
+    lastConnectionTime: new Date("2026-01-01T00:00:00Z"),
+    connectionStatus: status,
+    retryCount: 0,
+  }) as ServerWithName;
+
+const setupStateMachineMock = () => {
+  mockCreateOAuthStateMachine.mockImplementation(
+    (config: OAuthStateMachineFactoryConfig) => ({
+      state: config.state,
+      updateState: config.updateState,
+      proceedToNextStep: mockProceedToNextStep.mockImplementation(async () => {
+        const state = config.getState?.() ?? config.state;
+
+        switch (state.currentStep) {
+          case "idle":
+            config.updateState({ currentStep: "generate_pkce_parameters" });
+            break;
+          case "generate_pkce_parameters":
+            config.updateState({
+              currentStep: "authorization_request",
+              authorizationUrl: "https://auth.example.com/authorize",
+              state: "expected-state",
+            });
+            break;
+          case "authorization_request":
+            config.updateState({
+              currentStep: "complete",
+              accessToken: "access-token",
+              refreshToken: "refresh-token",
+              tokenType: "Bearer",
+              expiresIn: 3600,
+            });
+            break;
+          default:
+            break;
+        }
+      }),
+      startGuidedFlow: vi.fn(),
+      resetFlow: vi.fn(),
+    }),
+  );
+};
+
+async function advanceToAuthorization() {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+  });
+  expect(screen.getByTestId("current-step")).toHaveTextContent(
+    "generate_pkce_parameters",
+  );
+
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Authorize" }));
+  });
+  expect(screen.getByTestId("current-step")).toHaveTextContent(
+    "authorization_request",
+  );
+}
+
+async function completeOAuthCallback() {
+  await act(async () => {
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        origin: window.location.origin,
+        data: {
+          type: "OAUTH_CALLBACK",
+          code: "oauth-code",
+          state: "expected-state",
+        },
+      }),
+    );
+  });
+
+  await act(async () => {
+    vi.advanceTimersByTime(500);
+  });
+}
+
+describe("OAuthFlowTab", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockCreateOAuthStateMachine.mockReset();
+    mockProceedToNextStep.mockReset();
+    mockPosthogCapture.mockReset();
+    setupStateMachineMock();
+    vi.stubGlobal("BroadcastChannel", MockBroadcastChannel);
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("opens target configuration and saves a new OAuth debugger target", () => {
+    const onSelectServer = vi.fn();
+    const onSaveServerConfig = vi.fn();
+
+    const { rerender } = render(
+      <OAuthFlowTab
+        serverConfigs={{}}
+        selectedServerName="none"
+        onSelectServer={onSelectServer}
+        onSaveServerConfig={onSaveServerConfig}
+      />,
+    );
+
+    expect(screen.getByTestId("profile-modal")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Save Target" }));
+
+    expect(onSaveServerConfig).toHaveBeenCalledWith(
+      savedProfilePayload.formData,
+      { oauthProfile: savedProfilePayload.profile },
+    );
+
+    rerender(
+      <OAuthFlowTab
+        serverConfigs={{
+          "saved-target": createHttpServer("saved-target", {
+            url: savedProfilePayload.formData.url,
+          }),
+        }}
+        selectedServerName="none"
+        onSelectServer={onSelectServer}
+        onSaveServerConfig={onSaveServerConfig}
+      />,
+    );
+
+    expect(onSelectServer).toHaveBeenCalledWith("saved-target");
+  });
+
+  it("advances the debugger flow, opens auth, and applies tokens to a disconnected server", async () => {
+    const onConnectWithTokens = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <OAuthFlowTab
+        serverConfigs={{
+          "server-one": createHttpServer("server-one"),
+        }}
+        selectedServerName="server-one"
+        onSelectServer={vi.fn()}
+        onConnectWithTokens={onConnectWithTokens}
+      />,
+    );
+
+    await advanceToAuthorization();
+
+    expect(screen.getByTestId("auth-modal")).toHaveTextContent(
+      "https://auth.example.com/authorize",
+    );
+
+    await completeOAuthCallback();
+
+    expect(screen.queryByTestId("auth-modal")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Connect Server" }),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Connect Server" }));
+    });
+
+    expect(onConnectWithTokens).toHaveBeenCalledWith(
+      "server-one",
+      expect.objectContaining({
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        tokenType: "Bearer",
+        expiresIn: 3600,
+      }),
+      "https://server-one.example.com/mcp",
+    );
+  });
+
+  it("handles refresh-token application for connected servers", async () => {
+    const onRefreshTokens = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <OAuthFlowTab
+        serverConfigs={{
+          "server-one": createHttpServer("server-one", {
+            status: "connected",
+          }),
+        }}
+        selectedServerName="server-one"
+        onSelectServer={vi.fn()}
+        onRefreshTokens={onRefreshTokens}
+      />,
+    );
+
+    await advanceToAuthorization();
+    await completeOAuthCallback();
+
+    expect(
+      screen.getByRole("button", { name: "Refresh Tokens" }),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Refresh Tokens" }));
+    });
+    expect(screen.getByTestId("refresh-modal")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Confirm Refresh" }));
+    });
+
+    expect(onRefreshTokens).toHaveBeenCalledWith(
+      "server-one",
+      expect.objectContaining({
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        tokenType: "Bearer",
+        expiresIn: 3600,
+      }),
+      "https://server-one.example.com/mcp",
+    );
+  });
+
+  it("resets the flow when the selected server changes", async () => {
+    const serverOne = createHttpServer("server-one");
+    const serverTwo = createHttpServer("server-two");
+
+    const { rerender } = render(
+      <OAuthFlowTab
+        serverConfigs={{
+          "server-one": serverOne,
+          "server-two": serverTwo,
+        }}
+        selectedServerName="server-one"
+        onSelectServer={vi.fn()}
+      />,
+    );
+
+    await advanceToAuthorization();
+    expect(screen.getByTestId("auth-modal")).toBeInTheDocument();
+
+    rerender(
+      <OAuthFlowTab
+        serverConfigs={{
+          "server-one": serverOne,
+          "server-two": serverTwo,
+        }}
+        selectedServerName="server-two"
+        onSelectServer={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("current-step")).toHaveTextContent("idle");
+    expect(screen.queryByTestId("auth-modal")).not.toBeInTheDocument();
+    expect(screen.getByTestId("summary-text")).toHaveTextContent(
+      "https://server-two.example.com/mcp",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/oauth/OAuthAuthorizationModal.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthAuthorizationModal.tsx
@@ -4,60 +4,15 @@ interface OAuthAuthorizationModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   authorizationUrl: string;
-  onAuthorizationComplete?: () => void;
 }
 
 export const OAuthAuthorizationModal = ({
   open,
   onOpenChange,
   authorizationUrl,
-  onAuthorizationComplete,
 }: OAuthAuthorizationModalProps) => {
   const popupRef = useRef<Window | null>(null);
   const hasOpenedRef = useRef(false);
-
-  // Listen for OAuth callback messages from popup
-  useEffect(() => {
-    // Method 1: Listen via window.postMessage (standard approach)
-    const handleMessage = (event: MessageEvent) => {
-      // Verify origin matches our app
-      if (event.origin !== window.location.origin) {
-        return;
-      }
-
-      // Check if this is an OAuth callback message
-      if (event.data?.type === "OAUTH_CALLBACK" && event.data?.code) {
-        // Notify parent component
-        onAuthorizationComplete?.();
-        // Close our "modal" state
-        onOpenChange(false);
-        hasOpenedRef.current = false;
-      }
-    };
-
-    // Method 2: Listen via BroadcastChannel (fallback for COOP-protected OAuth servers)
-    let channel: BroadcastChannel | null = null;
-    try {
-      channel = new BroadcastChannel("oauth_callback_channel");
-      channel.onmessage = (event) => {
-        if (event.data?.type === "OAUTH_CALLBACK" && event.data?.code) {
-          // Notify parent component
-          onAuthorizationComplete?.();
-          // Close our "modal" state
-          onOpenChange(false);
-          hasOpenedRef.current = false;
-        }
-      };
-    } catch (error) {
-      console.warn("[OAuth Popup] BroadcastChannel not supported:", error);
-    }
-
-    window.addEventListener("message", handleMessage);
-    return () => {
-      window.removeEventListener("message", handleMessage);
-      channel?.close();
-    };
-  }, [onOpenChange, onAuthorizationComplete]);
 
   // Open popup when modal opens
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/oauth/OAuthFlowExperience.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthFlowExperience.tsx
@@ -1,0 +1,152 @@
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import { OAuthSequenceDiagram } from "@/components/oauth/OAuthSequenceDiagram";
+import { OAuthAuthorizationModal } from "@/components/oauth/OAuthAuthorizationModal";
+import { OAuthFlowLogger } from "@/components/oauth/OAuthFlowLogger";
+import { RefreshTokensConfirmModal } from "@/components/oauth/RefreshTokensConfirmModal";
+import type {
+  OAuthFlowState,
+  OAuthFlowStep,
+  OAuthProtocolVersion,
+} from "@/lib/oauth/state-machines/types";
+import type { OAuthRegistrationStrategy } from "@/lib/oauth/profile";
+import {
+  resolveOAuthFlowExperienceCapabilities,
+  type OAuthFlowExperienceConfig,
+  type OAuthFlowExperienceSummary,
+} from "./oauthFlowShared";
+
+interface OAuthFlowExperienceProps {
+  flowState: OAuthFlowState;
+  focusedStep: OAuthFlowStep | null;
+  onFocusStep: (step: OAuthFlowStep | null) => void;
+  hasProfile: boolean;
+  protocolVersion: OAuthProtocolVersion;
+  registrationStrategy: OAuthRegistrationStrategy;
+  summary: OAuthFlowExperienceSummary;
+  config?: OAuthFlowExperienceConfig;
+  onClearLogs: () => void;
+  onClearHttpHistory: () => void;
+  onConfigureTarget?: () => void | Promise<void>;
+  onReset?: () => void | Promise<void>;
+  onContinue?: () => void | Promise<void>;
+  continueLabel: string;
+  continueDisabled: boolean;
+  onApplyTokens?: () => void | Promise<void>;
+  onRefreshTokens?: () => void | Promise<void>;
+  isApplyingTokens?: boolean;
+  authModal: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    authorizationUrl?: string;
+  };
+  refreshModal?: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    serverName: string;
+    onConfirm: () => void | Promise<void>;
+    isLoading?: boolean;
+  };
+}
+
+export function OAuthFlowExperience({
+  flowState,
+  focusedStep,
+  onFocusStep,
+  hasProfile,
+  protocolVersion,
+  registrationStrategy,
+  summary,
+  config,
+  onClearLogs,
+  onClearHttpHistory,
+  onConfigureTarget,
+  onReset,
+  onContinue,
+  continueLabel,
+  continueDisabled,
+  onApplyTokens,
+  onRefreshTokens,
+  isApplyingTokens,
+  authModal,
+  refreshModal,
+}: OAuthFlowExperienceProps) {
+  const capabilities = resolveOAuthFlowExperienceCapabilities(config);
+  const canConfigureTarget =
+    capabilities.canConfigureTarget && Boolean(onConfigureTarget);
+  const canEditTarget =
+    capabilities.canEditTarget &&
+    capabilities.canConfigureTarget &&
+    Boolean(onConfigureTarget);
+
+  return (
+    <div className="h-full flex flex-col bg-background">
+      <div className="flex-1 overflow-hidden">
+        <ResizablePanelGroup direction="horizontal" className="h-full">
+          <ResizablePanel defaultSize={50} minSize={30}>
+            <OAuthSequenceDiagram
+              flowState={flowState}
+              registrationStrategy={registrationStrategy}
+              protocolVersion={protocolVersion}
+              focusedStep={focusedStep}
+              hasProfile={hasProfile}
+              onConfigure={canConfigureTarget ? onConfigureTarget : undefined}
+            />
+          </ResizablePanel>
+
+          <ResizableHandle withHandle />
+
+          <ResizablePanel defaultSize={50} minSize={20} maxSize={50}>
+            <OAuthFlowLogger
+              oauthFlowState={flowState}
+              onClearLogs={onClearLogs}
+              onClearHttpHistory={onClearHttpHistory}
+              activeStep={focusedStep ?? flowState.currentStep}
+              onFocusStep={(step) => onFocusStep(step)}
+              hasProfile={hasProfile}
+              summary={summary}
+              actions={{
+                onConfigure: onConfigureTarget,
+                showConfigureTarget: canConfigureTarget,
+                showEditTarget: canEditTarget,
+                onReset,
+                onContinue,
+                continueLabel,
+                continueDisabled,
+                resetDisabled: !hasProfile || flowState.isInitiatingAuth,
+                onConnectServer: capabilities.canApplyTokens
+                  ? onApplyTokens
+                  : undefined,
+                onRefreshTokens: capabilities.canRefreshTokens
+                  ? onRefreshTokens
+                  : undefined,
+                isApplyingTokens,
+              }}
+            />
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
+
+      {authModal.authorizationUrl && (
+        <OAuthAuthorizationModal
+          open={authModal.open}
+          onOpenChange={authModal.onOpenChange}
+          authorizationUrl={authModal.authorizationUrl}
+        />
+      )}
+
+      {capabilities.canRefreshTokens && refreshModal && (
+        <RefreshTokensConfirmModal
+          open={refreshModal.open}
+          onOpenChange={refreshModal.onOpenChange}
+          serverName={refreshModal.serverName}
+          onConfirm={refreshModal.onConfirm}
+          isLoading={refreshModal.isLoading}
+        />
+      )}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/oauth/OAuthFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthFlowLogger.tsx
@@ -46,14 +46,16 @@ interface OAuthFlowLoggerProps {
     customHeadersCount?: number;
   };
   actions?: {
-    onConfigure?: () => void;
-    onReset?: () => void;
-    onContinue?: () => void;
+    onConfigure?: () => void | Promise<void>;
+    showConfigureTarget?: boolean;
+    showEditTarget?: boolean;
+    onReset?: () => void | Promise<void>;
+    onContinue?: () => void | Promise<void>;
     continueLabel?: string;
     continueDisabled?: boolean;
     resetDisabled?: boolean;
-    onConnectServer?: () => void;
-    onRefreshTokens?: () => void;
+    onConnectServer?: () => void | Promise<void>;
+    onRefreshTokens?: () => void | Promise<void>;
     isApplyingTokens?: boolean;
   };
 }
@@ -273,6 +275,11 @@ export function OAuthFlowLogger({
     }
   };
 
+  const showConfigureTarget =
+    actions?.showConfigureTarget !== false && Boolean(actions?.onConfigure);
+  const showEditTarget =
+    actions?.showEditTarget !== false && Boolean(actions?.onConfigure);
+
   return (
     <div className="h-full border-l border-border flex flex-col">
       <div className="bg-muted/30 border-b border-border px-4 py-3 space-y-3">
@@ -280,19 +287,26 @@ export function OAuthFlowLogger({
           <>
             {/* Top row: Server URL with Edit, and Reset/Continue on right */}
             <div className="flex items-center gap-2">
-              <button
-                onClick={actions?.onConfigure}
-                disabled={!actions?.onConfigure}
-                className="min-w-0 flex-1 flex items-center gap-2 text-left border border-border hover:border-foreground/30 bg-background rounded-md px-3 py-2 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed group"
-              >
-                <p className="text-sm font-medium text-foreground break-all flex-1">
-                  {summary.serverUrl || summary.description}
-                </p>
-                <span className="flex items-center gap-1 text-xs text-muted-foreground group-hover:text-foreground shrink-0">
-                  <Pencil className="h-3 w-3" />
-                  Edit
-                </span>
-              </button>
+              {showEditTarget ? (
+                <button
+                  onClick={actions?.onConfigure}
+                  className="min-w-0 flex-1 flex items-center gap-2 text-left border border-border hover:border-foreground/30 bg-background rounded-md px-3 py-2 transition-colors cursor-pointer group"
+                >
+                  <p className="text-sm font-medium text-foreground break-all flex-1">
+                    {summary.serverUrl || summary.description}
+                  </p>
+                  <span className="flex items-center gap-1 text-xs text-muted-foreground group-hover:text-foreground shrink-0">
+                    <Pencil className="h-3 w-3" />
+                    Edit
+                  </span>
+                </button>
+              ) : (
+                <div className="min-w-0 flex-1 border border-border bg-background rounded-md px-3 py-2">
+                  <p className="text-sm font-medium text-foreground break-all">
+                    {summary.serverUrl || summary.description}
+                  </p>
+                </div>
+              )}
               <div className="flex items-center gap-1 shrink-0">
                 <Button
                   variant="ghost"
@@ -378,13 +392,11 @@ export function OAuthFlowLogger({
             <p className="text-sm text-muted-foreground">
               {summary.description}
             </p>
-            <Button
-              size="sm"
-              onClick={actions?.onConfigure}
-              disabled={!actions?.onConfigure}
-            >
-              Configure Target
-            </Button>
+            {showConfigureTarget && (
+              <Button size="sm" onClick={actions?.onConfigure}>
+                Configure Target
+              </Button>
+            )}
           </div>
         )}
       </div>
@@ -449,8 +461,8 @@ export function OAuthFlowLogger({
                         </li>
                       </ol>
                     </div>
-                    {actions?.onConfigure && (
-                      <Button onClick={actions.onConfigure}>
+                    {showConfigureTarget && (
+                      <Button onClick={() => actions?.onConfigure?.()}>
                         Configure Target
                       </Button>
                     )}

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthFlowExperience.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthFlowExperience.test.tsx
@@ -1,0 +1,260 @@
+import type { ReactNode } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { OAuthFlowExperience } from "../OAuthFlowExperience";
+import type { OAuthFlowState } from "@/lib/oauth/state-machines/types";
+
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({
+    children,
+  }: {
+    children?: ReactNode;
+  }) => <div data-testid="resizable-group">{children}</div>,
+  ResizablePanel: ({
+    children,
+  }: {
+    children?: ReactNode;
+  }) => <div>{children}</div>,
+  ResizableHandle: () => <div data-testid="resizable-handle" />,
+}));
+
+vi.mock("@/components/oauth/OAuthSequenceDiagram", () => ({
+  OAuthSequenceDiagram: ({
+    hasProfile,
+  }: {
+    hasProfile: boolean;
+  }) => (
+    <div data-testid="oauth-sequence-diagram">
+      diagram-{hasProfile ? "configured" : "unconfigured"}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/oauth/OAuthAuthorizationModal", () => ({
+  OAuthAuthorizationModal: ({
+    open,
+    authorizationUrl,
+  }: {
+    open: boolean;
+    authorizationUrl: string;
+  }) =>
+    open ? (
+      <div data-testid="oauth-authorization-modal">{authorizationUrl}</div>
+    ) : null,
+}));
+
+vi.mock("@/components/oauth/RefreshTokensConfirmModal", () => ({
+  RefreshTokensConfirmModal: ({
+    open,
+    serverName,
+  }: {
+    open: boolean;
+    serverName: string;
+  }) =>
+    open ? (
+      <div data-testid="refresh-tokens-modal">{serverName}</div>
+    ) : null,
+}));
+
+const baseFlowState: OAuthFlowState = {
+  isInitiatingAuth: false,
+  currentStep: "idle",
+  httpHistory: [],
+  infoLogs: [],
+  tokenEndpointAuthMethod: undefined,
+};
+
+describe("OAuthFlowExperience", () => {
+  it("renders the shared layout, summary, and server-backed actions", () => {
+    const onConfigureTarget = vi.fn();
+    const onContinue = vi.fn();
+    const onApplyTokens = vi.fn();
+    const onRefreshTokens = vi.fn();
+
+    render(
+      <OAuthFlowExperience
+        flowState={baseFlowState}
+        focusedStep={null}
+        onFocusStep={vi.fn()}
+        hasProfile={true}
+        protocolVersion="2025-11-25"
+        registrationStrategy="cimd"
+        summary={{
+          label: "Example Server",
+          description: "Example OAuth target",
+          protocol: "2025-11-25",
+          registration: "CIMD (URL-based)",
+          serverUrl: "https://example.com/mcp",
+          scopes: "openid profile",
+          clientId: "client-id",
+        }}
+        config={{
+          targetMode: "server-backed",
+        }}
+        onClearLogs={vi.fn()}
+        onClearHttpHistory={vi.fn()}
+        onConfigureTarget={onConfigureTarget}
+        onReset={vi.fn()}
+        onContinue={onContinue}
+        continueLabel="Continue"
+        continueDisabled={false}
+        onApplyTokens={onApplyTokens}
+        onRefreshTokens={onRefreshTokens}
+        isApplyingTokens={false}
+        authModal={{
+          open: true,
+          onOpenChange: vi.fn(),
+          authorizationUrl: "https://auth.example.com/authorize",
+        }}
+        refreshModal={{
+          open: true,
+          onOpenChange: vi.fn(),
+          serverName: "Example Server",
+          onConfirm: vi.fn(),
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("oauth-sequence-diagram")).toBeInTheDocument();
+    expect(screen.getByTestId("resizable-group")).toBeInTheDocument();
+    expect(screen.getByText("https://example.com/mcp")).toBeInTheDocument();
+    expect(screen.getByText("2025-11-25")).toBeInTheDocument();
+    expect(screen.getByText("CIMD (URL-based)")).toBeInTheDocument();
+    expect(screen.getByText("openid profile")).toBeInTheDocument();
+    expect(screen.getByText("Client ID set")).toBeInTheDocument();
+    expect(screen.getByTestId("oauth-authorization-modal")).toHaveTextContent(
+      "https://auth.example.com/authorize",
+    );
+    expect(screen.getByTestId("refresh-tokens-modal")).toHaveTextContent(
+      "Example Server",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /edit/i }));
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    fireEvent.click(screen.getByRole("button", { name: "Connect Server" }));
+    fireEvent.click(screen.getByRole("button", { name: "Refresh Tokens" }));
+
+    expect(onConfigureTarget).toHaveBeenCalledTimes(1);
+    expect(onContinue).toHaveBeenCalledTimes(1);
+    expect(onApplyTokens).toHaveBeenCalledTimes(1);
+    expect(onRefreshTokens).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides fixed-profile editing and token actions without forking the layout", () => {
+    render(
+      <OAuthFlowExperience
+        flowState={baseFlowState}
+        focusedStep={null}
+        onFocusStep={vi.fn()}
+        hasProfile={true}
+        protocolVersion="2025-11-25"
+        registrationStrategy="cimd"
+        summary={{
+          label: "Lesson Target",
+          description: "Curated OAuth target",
+          serverUrl: "https://lesson.example.com/mcp",
+        }}
+        config={{
+          targetMode: "fixed-profile",
+        }}
+        onClearLogs={vi.fn()}
+        onClearHttpHistory={vi.fn()}
+        onConfigureTarget={vi.fn()}
+        onReset={vi.fn()}
+        onContinue={vi.fn()}
+        continueLabel="Continue"
+        continueDisabled={false}
+        onApplyTokens={vi.fn()}
+        onRefreshTokens={vi.fn()}
+        authModal={{
+          open: false,
+          onOpenChange: vi.fn(),
+          authorizationUrl: "https://auth.example.com/authorize",
+        }}
+        refreshModal={{
+          open: true,
+          onOpenChange: vi.fn(),
+          serverName: "Lesson Target",
+          onConfirm: vi.fn(),
+        }}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /edit/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Connect Server" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Refresh Tokens" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("refresh-tokens-modal"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Continue" })).toBeInTheDocument();
+  });
+
+  it("shows or hides configure-target UI based on the experience mode", () => {
+    const { rerender } = render(
+      <OAuthFlowExperience
+        flowState={baseFlowState}
+        focusedStep={null}
+        onFocusStep={vi.fn()}
+        hasProfile={false}
+        protocolVersion="2025-11-25"
+        registrationStrategy="cimd"
+        summary={{
+          label: "No target",
+          description: "Add an MCP base URL to begin.",
+        }}
+        config={{
+          targetMode: "server-backed",
+        }}
+        onClearLogs={vi.fn()}
+        onClearHttpHistory={vi.fn()}
+        onConfigureTarget={vi.fn()}
+        continueLabel="Configure Target"
+        continueDisabled={true}
+        authModal={{
+          open: false,
+          onOpenChange: vi.fn(),
+        }}
+      />,
+    );
+
+    expect(screen.getAllByRole("button", { name: "Configure Target" })).not.toHaveLength(0);
+
+    rerender(
+      <OAuthFlowExperience
+        flowState={baseFlowState}
+        focusedStep={null}
+        onFocusStep={vi.fn()}
+        hasProfile={false}
+        protocolVersion="2025-11-25"
+        registrationStrategy="cimd"
+        summary={{
+          label: "Lesson Target",
+          description: "Curated lesson target",
+        }}
+        config={{
+          targetMode: "fixed-profile",
+        }}
+        onClearLogs={vi.fn()}
+        onClearHttpHistory={vi.fn()}
+        onConfigureTarget={vi.fn()}
+        continueLabel="Continue"
+        continueDisabled={true}
+        authModal={{
+          open: false,
+          onOpenChange: vi.fn(),
+        }}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Configure Target" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Curated lesson target")).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/useOAuthFlowController.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/useOAuthFlowController.test.tsx
@@ -1,0 +1,304 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OAuthStateMachineFactoryConfig } from "@/lib/oauth/state-machines/factory";
+import { useOAuthFlowController } from "../useOAuthFlowController";
+import type { OAuthTestProfile } from "@/lib/oauth/profile";
+
+const {
+  mockCreateOAuthStateMachine,
+  mockProceedToNextStep,
+  mockBroadcastChannels,
+} = vi.hoisted(() => ({
+  mockCreateOAuthStateMachine: vi.fn(),
+  mockProceedToNextStep: vi.fn(),
+  mockBroadcastChannels: [] as any[],
+}));
+
+class MockBroadcastChannel {
+  public onmessage:
+    | ((event: { data: unknown }) => void)
+    | null = null;
+
+  constructor(public readonly name: string) {
+    mockBroadcastChannels.push(this);
+  }
+
+  close = vi.fn();
+
+  emit(data: unknown) {
+    this.onmessage?.({ data });
+  }
+}
+
+vi.mock("@/lib/oauth/state-machines/factory", () => ({
+  createOAuthStateMachine: mockCreateOAuthStateMachine,
+}));
+
+const baseProfile: OAuthTestProfile = {
+  serverUrl: "https://example.com/mcp",
+  clientId: "client-id",
+  clientSecret: "",
+  scopes: "openid profile",
+  customHeaders: [{ key: "x-test-header", value: "debug" }],
+  protocolVersion: "2025-11-25",
+  registrationStrategy: "cimd",
+};
+
+const setupStateMachineMock = () => {
+  mockCreateOAuthStateMachine.mockImplementation(
+    (config: OAuthStateMachineFactoryConfig) => ({
+      state: config.state,
+      updateState: config.updateState,
+      proceedToNextStep: mockProceedToNextStep.mockImplementation(async () => {
+        const state = config.getState?.() ?? config.state;
+
+        switch (state.currentStep) {
+          case "idle":
+            config.updateState({ currentStep: "generate_pkce_parameters" });
+            break;
+          case "generate_pkce_parameters":
+            config.updateState({
+              currentStep: "authorization_request",
+              authorizationUrl: "https://auth.example.com/authorize",
+              state: "expected-state",
+            });
+            break;
+          case "authorization_request":
+            config.updateState({
+              currentStep: "complete",
+              accessToken: "access-token",
+              refreshToken: "refresh-token",
+              tokenType: "Bearer",
+              expiresIn: 3600,
+            });
+            break;
+          default:
+            break;
+        }
+      }),
+      startGuidedFlow: vi.fn(),
+      resetFlow: vi.fn(),
+    }),
+  );
+};
+
+describe("useOAuthFlowController", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockCreateOAuthStateMachine.mockReset();
+    mockProceedToNextStep.mockReset();
+    mockBroadcastChannels.length = 0;
+    setupStateMachineMock();
+    vi.stubGlobal("BroadcastChannel", MockBroadcastChannel);
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("initializes the state machine from the provided profile", () => {
+    const { result } = renderHook(() =>
+      useOAuthFlowController({
+        profile: baseProfile,
+        serverIdentifier: "Example Server",
+        resetKey: "server-one",
+        experienceConfig: {
+          initialFocusedStep: "authorization_request",
+        },
+      }),
+    );
+
+    expect(result.current.oauthFlowState.serverUrl).toBe(baseProfile.serverUrl);
+    expect(result.current.focusedStep).toBe("authorization_request");
+    expect(mockCreateOAuthStateMachine).toHaveBeenCalledWith(
+      expect.objectContaining({
+        protocolVersion: "2025-11-25",
+        registrationStrategy: "cimd",
+        serverName: "Example Server",
+        serverUrl: "https://example.com/mcp",
+        customScopes: "openid profile",
+        customHeaders: { "x-test-header": "debug" },
+      }),
+    );
+  });
+
+  it("advances through setup and opens the auth modal when authorization is reached", async () => {
+    const { result } = renderHook(() =>
+      useOAuthFlowController({
+        profile: baseProfile,
+        serverIdentifier: "Example Server",
+        resetKey: "server-one",
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleAdvance();
+    });
+
+    expect(result.current.oauthFlowState.currentStep).toBe(
+      "generate_pkce_parameters",
+    );
+    expect(result.current.isAuthModalOpen).toBe(false);
+
+    await act(async () => {
+      await result.current.handleAdvance();
+    });
+
+    expect(result.current.oauthFlowState.currentStep).toBe(
+      "authorization_request",
+    );
+    expect(result.current.oauthFlowState.authorizationUrl).toBe(
+      "https://auth.example.com/authorize",
+    );
+    expect(result.current.isAuthModalOpen).toBe(true);
+  });
+
+  it("processes a window message callback and auto-advances the flow", async () => {
+    const { result } = renderHook(() =>
+      useOAuthFlowController({
+        profile: baseProfile,
+        serverIdentifier: "Example Server",
+        resetKey: "server-one",
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleAdvance();
+    });
+
+    await act(async () => {
+      await result.current.handleAdvance();
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: window.location.origin,
+          data: {
+            type: "OAUTH_CALLBACK",
+            code: "oauth-code",
+            state: "expected-state",
+          },
+        }),
+      );
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current.isAuthModalOpen).toBe(false);
+    expect(result.current.oauthFlowState.authorizationCode).toBe("oauth-code");
+    expect(result.current.oauthFlowState.currentStep).toBe("complete");
+    expect(result.current.extractTokensFromFlowState()).toEqual({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+      expiresIn: 3600,
+      clientId: undefined,
+      clientSecret: undefined,
+    });
+  });
+
+  it("processes a BroadcastChannel callback and rejects stale state mismatches", async () => {
+    const { result } = renderHook(() =>
+      useOAuthFlowController({
+        profile: baseProfile,
+        serverIdentifier: "Example Server",
+        resetKey: "server-one",
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleAdvance();
+    });
+
+    await act(async () => {
+      await result.current.handleAdvance();
+    });
+
+    act(() => {
+      mockBroadcastChannels[0]?.emit({
+        type: "OAUTH_CALLBACK",
+        code: "stale-code",
+        state: "wrong-state",
+      });
+    });
+
+    expect(result.current.oauthFlowState.currentStep).toBe(
+      "authorization_request",
+    );
+    expect(result.current.oauthFlowState.error).toContain(
+      "Invalid state parameter",
+    );
+
+    act(() => {
+      mockBroadcastChannels[0]?.emit({
+        type: "OAUTH_CALLBACK",
+        code: "fresh-code",
+        state: "expected-state",
+      });
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current.oauthFlowState.authorizationCode).toBe("fresh-code");
+    expect(result.current.oauthFlowState.currentStep).toBe("complete");
+  });
+
+  it("resets flow state when requested directly or when the target key changes", async () => {
+    const { result, rerender } = renderHook(
+      ({
+        profile,
+        resetKey,
+      }: {
+        profile: OAuthTestProfile;
+        resetKey: string;
+      }) =>
+        useOAuthFlowController({
+          profile,
+          serverIdentifier: "Example Server",
+          resetKey,
+          experienceConfig: {
+            initialFocusedStep: "authorization_request",
+          },
+        }),
+      {
+        initialProps: {
+          profile: baseProfile,
+          resetKey: "server-one",
+        },
+      },
+    );
+
+    await act(async () => {
+      await result.current.handleAdvance();
+      await result.current.handleAdvance();
+    });
+
+    act(() => {
+      result.current.resetOAuthFlow("https://override.example.com/mcp");
+    });
+
+    expect(result.current.oauthFlowState.currentStep).toBe("idle");
+    expect(result.current.oauthFlowState.serverUrl).toBe(
+      "https://override.example.com/mcp",
+    );
+    expect(result.current.oauthFlowState.accessToken).toBeUndefined();
+    expect(result.current.oauthFlowState.authorizationCode).toBeUndefined();
+    expect(result.current.focusedStep).toBe("authorization_request");
+    expect(result.current.isAuthModalOpen).toBe(false);
+
+    rerender({
+      profile: {
+        ...baseProfile,
+        serverUrl: "https://second.example.com/mcp",
+      },
+      resetKey: "server-two",
+    });
+
+    expect(result.current.oauthFlowState.currentStep).toBe("idle");
+    expect(result.current.oauthFlowState.serverUrl).toBe(
+      "https://second.example.com/mcp",
+    );
+    expect(result.current.focusedStep).toBe("authorization_request");
+  });
+});

--- a/mcpjam-inspector/client/src/components/oauth/oauthFlowShared.ts
+++ b/mcpjam-inspector/client/src/components/oauth/oauthFlowShared.ts
@@ -1,0 +1,112 @@
+import type {
+  OAuthRegistrationStrategy,
+  OAuthTestProfile,
+} from "@/lib/oauth/profile";
+import type { OAuthFlowStep } from "@/lib/oauth/state-machines/types";
+
+export interface OAuthTokensFromFlow {
+  accessToken: string;
+  refreshToken?: string;
+  tokenType?: string;
+  expiresIn?: number;
+  clientId?: string;
+  clientSecret?: string;
+}
+
+export type OAuthFlowExperienceTargetMode =
+  | "server-backed"
+  | "fixed-profile";
+
+export interface OAuthFlowExperienceCapabilities {
+  canConfigureTarget?: boolean;
+  canEditTarget?: boolean;
+  canApplyTokens?: boolean;
+  canRefreshTokens?: boolean;
+}
+
+export interface OAuthFlowExperienceConfig {
+  targetMode?: OAuthFlowExperienceTargetMode;
+  capabilities?: OAuthFlowExperienceCapabilities;
+  initialFocusedStep?: OAuthFlowStep | null;
+  visibleStepRange?: {
+    start?: OAuthFlowStep;
+    end?: OAuthFlowStep;
+  };
+}
+
+export interface OAuthFlowExperienceSummary {
+  label: string;
+  description: string;
+  protocol?: string;
+  registration?: string;
+  step?: OAuthFlowStep;
+  serverUrl?: string;
+  scopes?: string;
+  clientId?: string;
+  customHeadersCount?: number;
+}
+
+export const deriveServerIdentifier = (profile: OAuthTestProfile): string => {
+  const trimmedUrl = profile.serverUrl.trim();
+  if (!trimmedUrl) {
+    return "oauth-flow-target";
+  }
+
+  try {
+    const url = new URL(trimmedUrl);
+    return url.host;
+  } catch {
+    return trimmedUrl;
+  }
+};
+
+export const buildHeaderMap = (
+  headers: Array<{ key: string; value: string }>,
+): Record<string, string> | undefined => {
+  const entries = headers
+    .map((header) => ({
+      key: header.key.trim(),
+      value: header.value.trim(),
+    }))
+    .filter((header) => header.key.length > 0);
+
+  if (!entries.length) {
+    return undefined;
+  }
+
+  return Object.fromEntries(entries.map(({ key, value }) => [key, value]));
+};
+
+export const describeRegistrationStrategy = (
+  strategy: OAuthRegistrationStrategy | string,
+): string => {
+  if (strategy === "cimd") return "CIMD (URL-based)";
+  if (strategy === "dcr") return "Dynamic (DCR)";
+  return "Pre-registered";
+};
+
+export const resolveOAuthFlowExperienceCapabilities = (
+  config?: OAuthFlowExperienceConfig,
+): Required<OAuthFlowExperienceCapabilities> => {
+  const targetMode = config?.targetMode ?? "server-backed";
+
+  const defaults: Required<OAuthFlowExperienceCapabilities> =
+    targetMode === "fixed-profile"
+      ? {
+          canConfigureTarget: false,
+          canEditTarget: false,
+          canApplyTokens: false,
+          canRefreshTokens: false,
+        }
+      : {
+          canConfigureTarget: true,
+          canEditTarget: true,
+          canApplyTokens: true,
+          canRefreshTokens: true,
+        };
+
+  return {
+    ...defaults,
+    ...config?.capabilities,
+  };
+};

--- a/mcpjam-inspector/client/src/components/oauth/useOAuthFlowController.ts
+++ b/mcpjam-inspector/client/src/components/oauth/useOAuthFlowController.ts
@@ -1,0 +1,323 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { EMPTY_OAUTH_FLOW_STATE_V2 } from "@/lib/oauth/state-machines/debug-oauth-2025-06-18";
+import { createOAuthStateMachine } from "@/lib/oauth/state-machines/factory";
+import { DebugMCPOAuthClientProvider } from "@/lib/oauth/debug-oauth-provider";
+import type { OAuthTestProfile } from "@/lib/oauth/profile";
+import type {
+  OAuthFlowState,
+  OAuthFlowStep,
+} from "@/lib/oauth/state-machines/types";
+import {
+  buildHeaderMap,
+  type OAuthFlowExperienceConfig,
+  type OAuthTokensFromFlow,
+} from "./oauthFlowShared";
+
+interface UseOAuthFlowControllerOptions {
+  profile: OAuthTestProfile;
+  serverIdentifier: string;
+  resetKey: string;
+  experienceConfig?: OAuthFlowExperienceConfig;
+}
+
+export interface OAuthFlowControllerResult {
+  oauthFlowState: OAuthFlowState;
+  focusedStep: OAuthFlowStep | null;
+  setFocusedStep: (step: OAuthFlowStep | null) => void;
+  isAuthModalOpen: boolean;
+  setIsAuthModalOpen: (open: boolean) => void;
+  isRefreshTokensModalOpen: boolean;
+  setIsRefreshTokensModalOpen: (open: boolean) => void;
+  hasProfile: boolean;
+  protocolVersion: OAuthTestProfile["protocolVersion"];
+  registrationStrategy: OAuthTestProfile["registrationStrategy"];
+  continueLabel: string;
+  continueDisabled: boolean;
+  clearInfoLogs: () => void;
+  clearHttpHistory: () => void;
+  handleAdvance: () => Promise<void>;
+  resetOAuthFlow: (serverUrlOverride?: string) => void;
+  extractTokensFromFlowState: () => OAuthTokensFromFlow;
+}
+
+const CALLBACK_CHANNEL_NAME = "oauth_callback_channel";
+const EXCHANGE_DELAY_MS = 500;
+
+const buildInitialFlowState = (serverUrl?: string): OAuthFlowState => ({
+  ...EMPTY_OAUTH_FLOW_STATE_V2,
+  serverUrl: serverUrl || undefined,
+});
+
+export function useOAuthFlowController({
+  profile,
+  serverIdentifier,
+  resetKey,
+  experienceConfig,
+}: UseOAuthFlowControllerOptions): OAuthFlowControllerResult {
+  const initialFocusedStep = experienceConfig?.initialFocusedStep ?? null;
+  const [oauthFlowState, setOAuthFlowState] = useState<OAuthFlowState>(() =>
+    buildInitialFlowState(profile.serverUrl),
+  );
+  const [focusedStep, setFocusedStep] =
+    useState<OAuthFlowStep | null>(initialFocusedStep);
+  const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
+  const [isRefreshTokensModalOpen, setIsRefreshTokensModalOpen] =
+    useState(false);
+
+  const hasProfile = Boolean(profile.serverUrl.trim());
+  const protocolVersion = profile.protocolVersion;
+  const registrationStrategy = profile.registrationStrategy;
+
+  const oauthFlowStateRef = useRef(oauthFlowState);
+  const skipNextFocusResetRef = useRef(initialFocusedStep !== null);
+  useEffect(() => {
+    oauthFlowStateRef.current = oauthFlowState;
+  }, [oauthFlowState]);
+
+  useEffect(() => {
+    if (skipNextFocusResetRef.current) {
+      skipNextFocusResetRef.current = false;
+      return;
+    }
+    setFocusedStep(null);
+  }, [oauthFlowState.currentStep]);
+
+  const updateOAuthFlowState = useCallback(
+    (updates: Partial<OAuthFlowState>) => {
+      setOAuthFlowState((prev) => ({ ...prev, ...updates }));
+    },
+    [],
+  );
+
+  const processedCodeRef = useRef<string | null>(null);
+  const exchangeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearPendingExchange = useCallback(() => {
+    if (exchangeTimeoutRef.current) {
+      clearTimeout(exchangeTimeoutRef.current);
+      exchangeTimeoutRef.current = null;
+    }
+  }, []);
+
+  const resetOAuthFlow = useCallback(
+    (serverUrlOverride?: string) => {
+      const nextServerUrl = serverUrlOverride ?? profile.serverUrl;
+      setOAuthFlowState(buildInitialFlowState(nextServerUrl));
+      setFocusedStep(initialFocusedStep);
+      skipNextFocusResetRef.current = initialFocusedStep !== null;
+      setIsAuthModalOpen(false);
+      setIsRefreshTokensModalOpen(false);
+      processedCodeRef.current = null;
+      clearPendingExchange();
+    },
+    [clearPendingExchange, initialFocusedStep, profile.serverUrl],
+  );
+
+  useEffect(() => {
+    return () => {
+      clearPendingExchange();
+    };
+  }, [clearPendingExchange]);
+
+  const previousResetKeyRef = useRef(resetKey);
+  useEffect(() => {
+    if (previousResetKeyRef.current !== resetKey) {
+      previousResetKeyRef.current = resetKey;
+      resetOAuthFlow(profile.serverUrl);
+    }
+  }, [profile.serverUrl, resetKey, resetOAuthFlow]);
+
+  const clearInfoLogs = useCallback(() => {
+    updateOAuthFlowState({ infoLogs: [] });
+  }, [updateOAuthFlowState]);
+
+  const clearHttpHistory = useCallback(() => {
+    updateOAuthFlowState({ httpHistory: [] });
+  }, [updateOAuthFlowState]);
+
+  const customHeaders = useMemo(
+    () => buildHeaderMap(profile.customHeaders),
+    [profile.customHeaders],
+  );
+
+  const oauthStateMachine = useMemo(() => {
+    if (!hasProfile) return null;
+
+    const provider = new DebugMCPOAuthClientProvider(profile.serverUrl);
+
+    return createOAuthStateMachine({
+      protocolVersion,
+      state: oauthFlowStateRef.current,
+      getState: () => oauthFlowStateRef.current,
+      updateState: updateOAuthFlowState,
+      serverUrl: profile.serverUrl,
+      serverName: serverIdentifier,
+      redirectUrl: provider.redirectUrl,
+      customScopes: profile.scopes.trim() || undefined,
+      customHeaders,
+      registrationStrategy,
+    });
+  }, [
+    customHeaders,
+    hasProfile,
+    profile.scopes,
+    profile.serverUrl,
+    protocolVersion,
+    registrationStrategy,
+    serverIdentifier,
+    updateOAuthFlowState,
+  ]);
+
+  const proceedToNextStep = useCallback(async () => {
+    if (oauthStateMachine) {
+      await oauthStateMachine.proceedToNextStep();
+    }
+  }, [oauthStateMachine]);
+
+  const handleAdvance = useCallback(async () => {
+    if (
+      oauthFlowState.currentStep === "authorization_request" ||
+      oauthFlowState.currentStep === "generate_pkce_parameters"
+    ) {
+      if (oauthFlowState.currentStep === "generate_pkce_parameters") {
+        await proceedToNextStep();
+      }
+      setIsAuthModalOpen(true);
+      return;
+    }
+
+    await proceedToNextStep();
+  }, [oauthFlowState.currentStep, proceedToNextStep]);
+
+  const continueLabel = !hasProfile
+    ? "Configure Target"
+    : oauthFlowState.currentStep === "complete"
+      ? "Flow Complete"
+      : oauthFlowState.isInitiatingAuth
+        ? "Continue"
+        : oauthFlowState.currentStep === "authorization_request" ||
+            oauthFlowState.currentStep === "generate_pkce_parameters"
+          ? "Authorize"
+          : "Continue";
+
+  const continueDisabled =
+    !hasProfile ||
+    !oauthStateMachine ||
+    oauthFlowState.isInitiatingAuth ||
+    oauthFlowState.currentStep === "complete";
+
+  const extractTokensFromFlowState = useCallback(
+    (): OAuthTokensFromFlow => ({
+      accessToken: oauthFlowState.accessToken!,
+      refreshToken: oauthFlowState.refreshToken,
+      tokenType: oauthFlowState.tokenType,
+      expiresIn: oauthFlowState.expiresIn,
+      clientId: oauthFlowState.clientId,
+      clientSecret: oauthFlowState.clientSecret,
+    }),
+    [
+      oauthFlowState.accessToken,
+      oauthFlowState.clientId,
+      oauthFlowState.clientSecret,
+      oauthFlowState.expiresIn,
+      oauthFlowState.refreshToken,
+      oauthFlowState.tokenType,
+    ],
+  );
+
+  useEffect(() => {
+    const processOAuthCallback = (code: string, state: string | undefined) => {
+      if (processedCodeRef.current === code) {
+        return;
+      }
+
+      const expectedState = oauthFlowStateRef.current.state;
+      const currentStep = oauthFlowStateRef.current.currentStep;
+      const isWaitingForCode =
+        currentStep === "received_authorization_code" ||
+        currentStep === "authorization_request";
+
+      if (!isWaitingForCode) {
+        return;
+      }
+
+      if (!expectedState) {
+        updateOAuthFlowState({
+          error:
+            "Flow was reset. Please start a new authorization by clicking 'Next Step'.",
+        });
+        return;
+      }
+
+      if (state !== expectedState) {
+        updateOAuthFlowState({
+          error:
+            "Invalid state parameter - this authorization code is from a previous flow. Please try again.",
+        });
+        return;
+      }
+
+      processedCodeRef.current = code;
+      clearPendingExchange();
+      setIsAuthModalOpen(false);
+
+      updateOAuthFlowState({
+        authorizationCode: code,
+        error: undefined,
+      });
+
+      exchangeTimeoutRef.current = setTimeout(() => {
+        oauthStateMachine?.proceedToNextStep();
+        exchangeTimeoutRef.current = null;
+      }, EXCHANGE_DELAY_MS);
+    };
+
+    const handleMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) {
+        return;
+      }
+
+      if (event.data?.type === "OAUTH_CALLBACK" && event.data?.code) {
+        processOAuthCallback(event.data.code, event.data.state);
+      }
+    };
+
+    let channel: BroadcastChannel | null = null;
+    try {
+      channel = new BroadcastChannel(CALLBACK_CHANNEL_NAME);
+      channel.onmessage = (event) => {
+        if (event.data?.type === "OAUTH_CALLBACK" && event.data?.code) {
+          processOAuthCallback(event.data.code, event.data.state);
+        }
+      };
+    } catch {
+      // BroadcastChannel is optional; window messages remain the fallback.
+    }
+
+    window.addEventListener("message", handleMessage);
+    return () => {
+      window.removeEventListener("message", handleMessage);
+      channel?.close();
+    };
+  }, [clearPendingExchange, oauthStateMachine, updateOAuthFlowState]);
+
+  return {
+    oauthFlowState,
+    focusedStep,
+    setFocusedStep,
+    isAuthModalOpen,
+    setIsAuthModalOpen,
+    isRefreshTokensModalOpen,
+    setIsRefreshTokensModalOpen,
+    hasProfile,
+    protocolVersion,
+    registrationStrategy,
+    continueLabel,
+    continueDisabled,
+    clearInfoLogs,
+    clearHttpHistory,
+    handleAdvance,
+    resetOAuthFlow,
+    extractTokensFromFlowState,
+  };
+}

--- a/mcpjam-inspector/client/src/test/setup.ts
+++ b/mcpjam-inspector/client/src/test/setup.ts
@@ -44,6 +44,9 @@ global.IntersectionObserver = vi.fn().mockImplementation(() => ({
   thresholds: [],
 }));
 
+// Mock scrollTo for components that auto-scroll log panes.
+HTMLElement.prototype.scrollTo = vi.fn();
+
 // Mock localStorage
 const localStorageMock = (() => {
   let store: Record<string, string> = {};


### PR DESCRIPTION
## Summary
- extract a reusable `useOAuthFlowController` hook from `OAuthFlowTab` and move flow orchestration, callback handling, modal timing, reset behavior, and token extraction into it
- add a shared `OAuthFlowExperience` shell plus a small capability/config layer so server-backed debugger flows and future fixed-profile learning flows can reuse the same UI without route wiring yet
- keep the existing debugger behavior intact, preserve shared OAuth step metadata as the canonical source, and keep the profile modal as the thin app-specific adapter surface
- add regression, controller, and presentation coverage for the debugger tab, the new controller, and capability-gated experience rendering

## Testing
- `npx vitest run client/src/components/oauth/__tests__/useOAuthFlowController.test.tsx client/src/components/oauth/__tests__/OAuthFlowExperience.test.tsx client/src/components/__tests__/OAuthFlowTab.test.tsx`

## Notes
- foundation-only change; no new Learning tab routes, lessons, or sidebar items are included here

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because OAuth flow orchestration and callback handling were refactored into a new hook and the debugger UI was re-composed, which could subtly affect auth modal timing, reset behavior, or token application despite aiming to preserve behavior.
> 
> **Overview**
> Refactors the OAuth debugger tab to use a new `useOAuthFlowController` hook for state-machine orchestration, OAuth callback processing (window message/BroadcastChannel), reset behavior, and token extraction, reducing `OAuthFlowTab` to app wiring + PostHog events.
> 
> Introduces a reusable `OAuthFlowExperience` layout with capability-gated actions via `oauthFlowShared` (e.g., supporting future *fixed-profile* lesson flows without editing/apply/refresh controls), and updates `OAuthFlowLogger` to respect these capability flags.
> 
> Simplifies `OAuthAuthorizationModal` to only manage the popup lifecycle (callback listening moved to the controller), adds comprehensive unit tests for the tab/controller/experience, and updates test setup to mock `HTMLElement.scrollTo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 101a66d4c86d0f6458291c9c9d1daf1b70a3f8d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->