### PR TITLE
Add workspace Slack integration settings UI

### DIFF
--- a/mcpjam-inspector/client/src/components/WorkspaceSettingsTab.tsx
+++ b/mcpjam-inspector/client/src/components/WorkspaceSettingsTab.tsx
@@ -2,6 +2,7 @@ import { useConvexAuth } from "convex/react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { EditableText } from "./ui/editable-text";
 import { AccountApiKeySection } from "./setting/AccountApiKeySection";
+import { WorkspaceSlackIntegrationSection } from "./setting/WorkspaceSlackIntegrationSection";
 import { WorkspaceMembersFacepile } from "./workspace/WorkspaceMembersFacepile";
 import { WorkspaceShareButton } from "./workspace/WorkspaceShareButton";
 import { WorkspaceIconPicker } from "./workspace/WorkspaceEmojiPicker";
@@ -147,6 +148,19 @@ export function WorkspaceSettingsTab({
           <AccountApiKeySection
             workspaceId={convexWorkspaceId}
             workspaceName={workspaceName || null}
+          />
+        </div>
+
+        {/* Integrations */}
+        <div className="space-y-2">
+          <h2 className="text-sm font-medium text-muted-foreground">
+            Integrations
+          </h2>
+          <WorkspaceSlackIntegrationSection
+            workspaceId={convexWorkspaceId}
+            workspaceName={workspaceName || null}
+            organizationId={workspace?.organizationId}
+            canManageIntegration={canManageMembers}
           />
         </div>
 

--- a/mcpjam-inspector/client/src/components/setting/WorkspaceSlackIntegrationSection.tsx
+++ b/mcpjam-inspector/client/src/components/setting/WorkspaceSlackIntegrationSection.tsx
@@ -1,0 +1,352 @@
+import { useState } from "react";
+import { useAuth } from "@workos-inc/authkit-react";
+import { useConvexAuth } from "convex/react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { useWorkspaceSlackIntegration } from "@/hooks/useWorkspaceSlackIntegration";
+
+interface WorkspaceSlackIntegrationSectionProps {
+  workspaceId: string | null;
+  workspaceName: string | null;
+  organizationId?: string;
+  canManageIntegration: boolean;
+}
+
+function formatTimestamp(timestamp: number | null): string | null {
+  if (!timestamp) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(timestamp);
+}
+
+export function WorkspaceSlackIntegrationSection({
+  workspaceId,
+  workspaceName,
+  organizationId,
+  canManageIntegration,
+}: WorkspaceSlackIntegrationSectionProps) {
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const { signIn } = useAuth();
+  const [webhookInput, setWebhookInput] = useState("");
+  const [isReplaceMode, setIsReplaceMode] = useState(false);
+  const [disconnectConfirmOpen, setDisconnectConfirmOpen] = useState(false);
+
+  const isSyncedWorkspace = Boolean(workspaceId && organizationId);
+  const {
+    status,
+    error,
+    isLoadingStatus,
+    isConnecting,
+    isSendingTest,
+    isDisconnecting,
+    connectWebhook,
+    sendTestMessage,
+    disconnect,
+  } = useWorkspaceSlackIntegration({
+    isAuthenticated,
+    workspaceId: isSyncedWorkspace ? workspaceId : null,
+    canManageIntegration: isSyncedWorkspace && canManageIntegration,
+  });
+
+  const isBusy = isConnecting || isSendingTest || isDisconnecting;
+  const lastTestedLabel = formatTimestamp(status?.lastTestedAt ?? null);
+  const lastUpdatedLabel = formatTimestamp(status?.updatedAt ?? null);
+
+  const handleSaveWebhook = async () => {
+    const trimmedWebhook = webhookInput.trim();
+    if (!trimmedWebhook) {
+      toast.error("Slack webhook URL is required");
+      return;
+    }
+
+    try {
+      await connectWebhook(trimmedWebhook);
+      setWebhookInput("");
+      setIsReplaceMode(false);
+      toast.success(
+        status?.connected ? "Slack webhook updated" : "Slack connected",
+      );
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to connect Slack",
+      );
+    }
+  };
+
+  const handleSendTestMessage = async () => {
+    try {
+      await sendTestMessage();
+      toast.success("Slack test message sent");
+    } catch (err) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : "Failed to send Slack test message",
+      );
+    }
+  };
+
+  const handleDisconnect = async () => {
+    try {
+      await disconnect();
+      setDisconnectConfirmOpen(false);
+      setWebhookInput("");
+      setIsReplaceMode(false);
+      toast.success("Slack disconnected");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to disconnect Slack",
+      );
+    }
+  };
+
+  if (isAuthLoading) {
+    return (
+      <div className="rounded-md border border-border/40 px-4 py-3">
+        <p className="text-sm text-muted-foreground">
+          Checking Slack integration access…
+        </p>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="flex items-center justify-between gap-4 rounded-md border border-border/40 px-4 py-3">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium">Slack</span>
+            <Badge variant="outline">Sign in required</Badge>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Sign in to connect this workspace to a Slack incoming webhook.
+          </p>
+        </div>
+        <Button type="button" size="sm" onClick={() => signIn()}>
+          Sign in
+        </Button>
+      </div>
+    );
+  }
+
+  if (!isSyncedWorkspace) {
+    return (
+      <div className="rounded-md border border-border/40 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">Slack</span>
+          <Badge variant="outline">Synced workspaces only</Badge>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Slack integrations are available after this workspace is synced to
+          MCPJam.
+        </p>
+      </div>
+    );
+  }
+
+  if (!canManageIntegration) {
+    return (
+      <div className="rounded-md border border-border/40 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">Slack</span>
+          <Badge variant="outline">Read only</Badge>
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Only workspace admins can manage Slack integrations.
+        </p>
+      </div>
+    );
+  }
+
+  const isConnected = status?.connected ?? false;
+
+  return (
+    <>
+      <div className="rounded-md border border-border/40 px-4 py-4 space-y-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium">Slack</span>
+              <Badge variant={isConnected ? "secondary" : "outline"}>
+                {isConnected ? "Connected" : "Not connected"}
+              </Badge>
+              {status?.lastTestStatus ? (
+                <Badge
+                  variant={
+                    status.lastTestStatus === "success"
+                      ? "secondary"
+                      : "destructive"
+                  }
+                >
+                  {status.lastTestStatus === "success"
+                    ? "Last test passed"
+                    : "Last test failed"}
+                </Badge>
+              ) : null}
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Send workspace notifications to a Slack channel with an incoming
+              webhook.
+            </p>
+          </div>
+          {lastUpdatedLabel ? (
+            <span className="text-xs text-muted-foreground">
+              Updated {lastUpdatedLabel}
+            </span>
+          ) : null}
+        </div>
+
+        {isLoadingStatus ? (
+          <p className="text-sm text-muted-foreground">
+            Loading Slack integration…
+          </p>
+        ) : null}
+
+        {!isLoadingStatus && isConnected ? (
+          <div className="rounded-md border border-border/40 bg-muted/20 px-3 py-3 space-y-1">
+            <p className="text-sm font-medium">
+              {workspaceName || "This workspace"} is connected to Slack.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {lastTestedLabel
+                ? `Last tested ${lastTestedLabel}.`
+                : "No test message has been sent yet."}
+            </p>
+            {status?.lastTestError ? (
+              <p className="text-xs text-destructive">{status.lastTestError}</p>
+            ) : null}
+            {error ? <p className="text-xs text-destructive">{error}</p> : null}
+          </div>
+        ) : null}
+
+        {!isLoadingStatus && (!isConnected || isReplaceMode) ? (
+          <div className="space-y-2">
+            <Input
+              type="url"
+              value={webhookInput}
+              onChange={(event) => setWebhookInput(event.target.value)}
+              placeholder="https://hooks.slack.com/services/..."
+              disabled={isBusy}
+            />
+            <p className="text-xs text-muted-foreground">
+              Saved webhook URLs are never shown again after they are stored.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => {
+                  void handleSaveWebhook();
+                }}
+                disabled={isBusy || webhookInput.trim().length === 0}
+              >
+                {isConnecting
+                  ? isConnected
+                    ? "Saving…"
+                    : "Connecting…"
+                  : isConnected
+                    ? "Save webhook"
+                    : "Connect Slack"}
+              </Button>
+              {isConnected ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={isBusy}
+                  onClick={() => {
+                    setIsReplaceMode(false);
+                    setWebhookInput("");
+                  }}
+                >
+                  Cancel
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+
+        {!isLoadingStatus && isConnected && !isReplaceMode ? (
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                void handleSendTestMessage();
+              }}
+              disabled={isBusy}
+            >
+              {isSendingTest ? "Sending…" : "Send test message"}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => setIsReplaceMode(true)}
+              disabled={isBusy}
+            >
+              Replace webhook
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="destructive"
+              onClick={() => setDisconnectConfirmOpen(true)}
+              disabled={isBusy}
+            >
+              Disconnect
+            </Button>
+          </div>
+        ) : null}
+      </div>
+
+      <AlertDialog
+        open={disconnectConfirmOpen}
+        onOpenChange={setDisconnectConfirmOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Disconnect Slack?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove the stored Slack webhook for{" "}
+              {workspaceName || "this workspace"}. You can reconnect it at any
+              time with a new webhook URL.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDisconnecting}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                void handleDisconnect();
+              }}
+              disabled={isDisconnecting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isDisconnecting ? "Disconnecting…" : "Disconnect"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/mcpjam-inspector/client/src/components/setting/__tests__/WorkspaceSlackIntegrationSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/setting/__tests__/WorkspaceSlackIntegrationSection.test.tsx
@@ -1,0 +1,221 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WorkspaceSlackIntegrationSection } from "../WorkspaceSlackIntegrationSection";
+
+const mockSignIn = vi.fn();
+const mockConnectWebhook = vi.fn();
+const mockSendTestMessage = vi.fn();
+const mockDisconnect = vi.fn();
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+const mockUseConvexAuth = vi.fn();
+const mockUseWorkspaceSlackIntegration = vi.fn();
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => mockUseConvexAuth(),
+}));
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({
+    signIn: mockSignIn,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+vi.mock("@/hooks/useWorkspaceSlackIntegration", () => ({
+  useWorkspaceSlackIntegration: (...args: unknown[]) =>
+    mockUseWorkspaceSlackIntegration(...args),
+}));
+
+function renderSection(
+  overrides: Partial<
+    ComponentProps<typeof WorkspaceSlackIntegrationSection>
+  > = {},
+) {
+  render(
+    <WorkspaceSlackIntegrationSection
+      workspaceId="ws-1"
+      workspaceName="Acme"
+      organizationId="org-1"
+      canManageIntegration
+      {...overrides}
+    />,
+  );
+}
+
+describe("WorkspaceSlackIntegrationSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseConvexAuth.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    mockConnectWebhook.mockResolvedValue({
+      workspaceId: "ws-1",
+      connected: true,
+    });
+    mockSendTestMessage.mockResolvedValue({
+      workspaceId: "ws-1",
+      connected: true,
+    });
+    mockDisconnect.mockResolvedValue({
+      workspaceId: "ws-1",
+      connected: false,
+      lastTestedAt: null,
+      lastTestStatus: null,
+      lastTestError: null,
+      updatedAt: null,
+    });
+
+    mockUseWorkspaceSlackIntegration.mockReturnValue({
+      status: {
+        workspaceId: "ws-1",
+        connected: false,
+        lastTestedAt: null,
+        lastTestStatus: null,
+        lastTestError: null,
+        updatedAt: null,
+      },
+      error: null,
+      isLoadingStatus: false,
+      isConnecting: false,
+      isSendingTest: false,
+      isDisconnecting: false,
+      connectWebhook: mockConnectWebhook,
+      sendTestMessage: mockSendTestMessage,
+      disconnect: mockDisconnect,
+    });
+  });
+
+  it("shows a sign-in state for unauthenticated users", async () => {
+    const user = userEvent.setup();
+    mockUseConvexAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+
+    renderSection();
+
+    expect(
+      screen.getByText(/Sign in to connect this workspace/i),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+    expect(mockSignIn).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a synced-workspace note when the workspace is not shared in MCPJam", () => {
+    renderSection({
+      workspaceId: null,
+      organizationId: undefined,
+    });
+
+    expect(
+      screen.getByText(
+        /Slack integrations are available after this workspace is synced/i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Connect Slack" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a read-only note for non-admin members", () => {
+    renderSection({
+      canManageIntegration: false,
+    });
+
+    expect(
+      screen.getByText(/Only workspace admins can manage Slack integrations/i),
+    ).toBeInTheDocument();
+  });
+
+  it("connects Slack from the disconnected state", async () => {
+    const user = userEvent.setup();
+    renderSection();
+
+    const input = screen.getByPlaceholderText(
+      "https://hooks.slack.com/services/...",
+    );
+    await user.type(input, "https://hooks.slack.com/services/T/B/C");
+    await user.click(screen.getByRole("button", { name: "Connect Slack" }));
+
+    await waitFor(() => {
+      expect(mockConnectWebhook).toHaveBeenCalledWith(
+        "https://hooks.slack.com/services/T/B/C",
+      );
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith("Slack connected");
+  });
+
+  it("renders connected actions and supports replace, test, and disconnect flows", async () => {
+    const user = userEvent.setup();
+    mockUseWorkspaceSlackIntegration.mockReturnValue({
+      status: {
+        workspaceId: "ws-1",
+        connected: true,
+        lastTestedAt: 1_764_000_000_000,
+        lastTestStatus: "failure",
+        lastTestError: "Slack rejected the webhook request",
+        updatedAt: 1_764_000_000_000,
+      },
+      error: null,
+      isLoadingStatus: false,
+      isConnecting: false,
+      isSendingTest: false,
+      isDisconnecting: false,
+      connectWebhook: mockConnectWebhook,
+      sendTestMessage: mockSendTestMessage,
+      disconnect: mockDisconnect,
+    });
+
+    renderSection();
+
+    expect(
+      screen.queryByPlaceholderText("https://hooks.slack.com/services/..."),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Slack rejected the webhook request"),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Send test message" }));
+    await waitFor(() => {
+      expect(mockSendTestMessage).toHaveBeenCalledTimes(1);
+    });
+
+    await user.click(screen.getByRole("button", { name: "Replace webhook" }));
+    const input = screen.getByPlaceholderText(
+      "https://hooks.slack.com/services/...",
+    );
+    await user.type(input, "https://hooks.slack.com/services/T/B/NEW");
+    await user.click(screen.getByRole("button", { name: "Save webhook" }));
+
+    await waitFor(() => {
+      expect(mockConnectWebhook).toHaveBeenCalledWith(
+        "https://hooks.slack.com/services/T/B/NEW",
+      );
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith("Slack webhook updated");
+
+    await user.click(screen.getByRole("button", { name: "Disconnect" }));
+    const confirmDialog = screen.getByRole("alertdialog");
+    await user.click(
+      within(confirmDialog).getByRole("button", { name: "Disconnect" }),
+    );
+
+    await waitFor(() => {
+      expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    });
+    expect(mockToastSuccess).toHaveBeenCalledWith("Slack disconnected");
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useWorkspaceSlackIntegration.ts
+++ b/mcpjam-inspector/client/src/hooks/useWorkspaceSlackIntegration.ts
@@ -1,0 +1,124 @@
+import { useAction, useQuery } from "convex/react";
+import { useCallback, useState } from "react";
+
+export type WorkspaceSlackTestStatus = "success" | "failure";
+
+export interface WorkspaceSlackIntegrationStatus {
+  workspaceId: string;
+  connected: boolean;
+  lastTestedAt: number | null;
+  lastTestStatus: WorkspaceSlackTestStatus | null;
+  lastTestError: string | null;
+  updatedAt: number | null;
+}
+
+export function useWorkspaceSlackIntegration({
+  isAuthenticated,
+  workspaceId,
+  canManageIntegration,
+}: {
+  isAuthenticated: boolean;
+  workspaceId: string | null;
+  canManageIntegration: boolean;
+}) {
+  const shouldQuery = isAuthenticated && !!workspaceId && canManageIntegration;
+
+  const status = useQuery(
+    "workspaceSlackIntegrations:getStatus" as any,
+    shouldQuery ? ({ workspaceId } as any) : "skip",
+  ) as WorkspaceSlackIntegrationStatus | undefined;
+
+  const connectAction = useAction(
+    "workspaceSlackIntegrations:connectIncomingWebhook" as any,
+  );
+  const sendTestAction = useAction(
+    "workspaceSlackIntegrations:sendTestMessage" as any,
+  );
+  const disconnectAction = useAction(
+    "workspaceSlackIntegrations:disconnect" as any,
+  );
+
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [isSendingTest, setIsSendingTest] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const connectWebhook = useCallback(
+    async (webhookUrl: string) => {
+      if (!workspaceId) {
+        throw new Error("Workspace is required");
+      }
+
+      setIsConnecting(true);
+      setError(null);
+      try {
+        return (await connectAction({
+          workspaceId,
+          webhookUrl,
+        })) as WorkspaceSlackIntegrationStatus;
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to connect Slack";
+        setError(message);
+        throw err;
+      } finally {
+        setIsConnecting(false);
+      }
+    },
+    [connectAction, workspaceId],
+  );
+
+  const sendTestMessage = useCallback(async () => {
+    if (!workspaceId) {
+      throw new Error("Workspace is required");
+    }
+
+    setIsSendingTest(true);
+    setError(null);
+    try {
+      return (await sendTestAction({
+        workspaceId,
+      })) as WorkspaceSlackIntegrationStatus;
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to send Slack test";
+      setError(message);
+      throw err;
+    } finally {
+      setIsSendingTest(false);
+    }
+  }, [sendTestAction, workspaceId]);
+
+  const disconnect = useCallback(async () => {
+    if (!workspaceId) {
+      throw new Error("Workspace is required");
+    }
+
+    setIsDisconnecting(true);
+    setError(null);
+    try {
+      return (await disconnectAction({
+        workspaceId,
+      })) as WorkspaceSlackIntegrationStatus;
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to disconnect Slack";
+      setError(message);
+      throw err;
+    } finally {
+      setIsDisconnecting(false);
+    }
+  }, [disconnectAction, workspaceId]);
+
+  return {
+    status,
+    error,
+    isLoadingStatus: shouldQuery && status === undefined,
+    isConnecting,
+    isSendingTest,
+    isDisconnecting,
+    connectWebhook,
+    sendTestMessage,
+    disconnect,
+  };
+}


### PR DESCRIPTION
## Summary
- add a Slack integration section to Workspace Settings
- add a small hook for Slack integration status and actions
- cover connected, disconnected, replace, manual test, disconnect, sign-in, unsynced workspace, and non-admin states
- add targeted frontend tests for the new settings UI

## Testing
- npm test -- client/src/components/setting/__tests__/WorkspaceSlackIntegrationSection.test.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new settings UI that stores/updates Slack incoming webhook URLs and triggers backend actions (connect/test/disconnect), which could impact notification delivery if misused or buggy; changes are isolated to the client with test coverage.
> 
> **Overview**
> Adds an **Integrations** section to `WorkspaceSettingsTab` that lets admins manage a workspace’s Slack incoming webhook.
> 
> Introduces `WorkspaceSlackIntegrationSection` with gated states (auth required, synced-workspace only, admin-only) and flows to connect/replace a webhook, send a test message, and disconnect with confirmation; wires these to new `useWorkspaceSlackIntegration` hook that queries status and calls Convex actions.
> 
> Adds targeted component tests covering unauthenticated, unsynced, read-only, connect, replace, test-send, and disconnect behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df4a0eeb73b74a4e859a0f29567e4a73d84530f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->