### PR TITLE
Add server inspection diff engine and change detection UI

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -54,6 +54,8 @@ import {
   DialogTitle,
 } from "./components/ui/dialog";
 import { useAppState } from "./hooks/use-app-state";
+import { useInspectionCoordinator } from "./hooks/use-inspection-coordinator";
+import { writeInspectionDetailRequest } from "./lib/inspection-detail-request";
 import { PreferencesStoreProvider } from "./stores/preferences/preferences-provider";
 import { Toaster } from "./components/ui/sonner";
 import { useElectronOAuth } from "./hooks/useElectronOAuth";
@@ -246,6 +248,21 @@ function AppChromeHeader({ hidden, ...props }: AppChromeHeaderProps) {
   }
 
   return <Header {...props} />;
+}
+
+/**
+ * Zero-UI bridge component rendered inside AppStateProvider so the
+ * inspection coordinator hook has access to useSharedAppState().
+ */
+function InspectionCoordinatorBridge({
+  workspaceServers,
+  onViewChanges,
+}: {
+  workspaceServers: Record<string, import("./state/app-types").ServerWithName>;
+  onViewChanges: (serverName: string) => void;
+}) {
+  useInspectionCoordinator(workspaceServers, onViewChanges);
+  return null;
 }
 
 export default function App() {
@@ -892,6 +909,15 @@ export default function App() {
       isSharedChatRoute,
       setSelectedMultipleServersToAllServers,
     ],
+  );
+
+  // Callback for inspection toast "View changes" action
+  const handleInspectionViewChanges = useCallback(
+    (serverName: string) => {
+      writeInspectionDetailRequest(serverName);
+      applyNavigation("servers", { updateHash: true });
+    },
+    [applyNavigation],
   );
 
   // Sync tab with hash on mount and when hash changes
@@ -1695,6 +1721,10 @@ export default function App() {
         savedClientConfig={activeWorkspace?.clientConfig}
       />
       <AppStateProvider appState={effectiveAppState}>
+        <InspectionCoordinatorBridge
+          workspaceServers={workspaceServers}
+          onViewChanges={handleInspectionViewChanges}
+        />
         <Toaster />
         <div
           aria-hidden={shouldShowBillingHandoffOverlay || undefined}

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -661,8 +661,7 @@ export default function App() {
     if (!needsServer || selectedMCPConfig) return;
 
     const firstConnected = Object.entries(workspaceServers).find(
-      ([, server]) =>
-        (server as any).connectionStatus === "connected",
+      ([, server]) => (server as any).connectionStatus === "connected",
     );
     if (firstConnected) {
       setSelectedServer(firstConnected[0]);

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -87,6 +87,10 @@ import {
   readServerDetailModalOAuthResume,
   writeOpenServerDetailModalState,
 } from "@/lib/server-detail-modal-resume";
+import {
+  readInspectionDetailRequest,
+  clearInspectionDetailRequest,
+} from "@/lib/inspection-detail-request";
 import { cn } from "@/lib/utils";
 import { compareQuickConnectCatalogCards } from "@/lib/quick-connect-catalog-sort";
 import { toast } from "sonner";
@@ -562,6 +566,27 @@ export function ServersTab({
       serverSnapshot: resumeServer,
     }));
     clearServerDetailModalOAuthResume();
+  }, [detailModalState.isOpen, workspaceServers]);
+
+  // Consume inspection detail request (from toast "View changes" CTA)
+  useEffect(() => {
+    if (detailModalState.isOpen) return;
+
+    const request = readInspectionDetailRequest();
+    if (!request) return;
+
+    clearInspectionDetailRequest();
+
+    const server = workspaceServers[request.serverName];
+    if (!server) return;
+
+    setDetailModalState((prev) => ({
+      isOpen: true,
+      serverName: server.name,
+      defaultTab: "overview",
+      sessionKey: prev.sessionKey + 1,
+      serverSnapshot: server,
+    }));
   }, [detailModalState.isOpen, workspaceServers]);
 
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/connection/ServerChangesPanel.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerChangesPanel.tsx
@@ -1,0 +1,323 @@
+/**
+ * "Changes since last successful connect" panel rendered at the top
+ * of the server detail modal Overview tab.
+ */
+
+import { useState } from "react";
+import { ChevronDown, ChevronRight, Plus, Minus, RefreshCw } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { ScrollableJsonView } from "@/components/ui/json-editor";
+import type {
+  ServerInspectionDiff,
+  ToolChange,
+  InitChange,
+} from "@/lib/inspection/types";
+
+interface ServerChangesPanelProps {
+  diff: ServerInspectionDiff | null | undefined;
+}
+
+export function ServerChangesPanel({ diff }: ServerChangesPanelProps) {
+  if (!diff) return null;
+
+  const hasInitChanges = diff.initChanges.length > 0;
+  const added = diff.toolChanges.filter((c) => c.type === "added");
+  const removed = diff.toolChanges.filter((c) => c.type === "removed");
+  const changed = diff.toolChanges.filter((c) => c.type === "changed");
+  const hasToolChanges = added.length + removed.length + changed.length > 0;
+
+  if (!hasInitChanges && !hasToolChanges) return null;
+
+  return (
+    <div
+      data-testid="server-changes-panel"
+      className="rounded-md border border-border/50 bg-muted/20 p-3 space-y-3 mb-4"
+    >
+      <div className="text-sm font-medium text-muted-foreground">
+        Changes since last connect
+      </div>
+
+      {/* Summary badges */}
+      <div className="flex flex-wrap gap-1.5">
+        {added.length > 0 && (
+          <Badge
+            data-testid="badge-added"
+            className="bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 border-emerald-500/30"
+          >
+            <Plus className="h-3 w-3" />
+            {added.length} added
+          </Badge>
+        )}
+        {removed.length > 0 && (
+          <Badge
+            data-testid="badge-removed"
+            className="bg-red-500/15 text-red-600 dark:text-red-400 border-red-500/30"
+          >
+            <Minus className="h-3 w-3" />
+            {removed.length} removed
+          </Badge>
+        )}
+        {changed.length > 0 && (
+          <Badge
+            data-testid="badge-changed"
+            className="bg-amber-500/15 text-amber-600 dark:text-amber-400 border-amber-500/30"
+          >
+            <RefreshCw className="h-3 w-3" />
+            {changed.length} changed
+          </Badge>
+        )}
+        {hasInitChanges && (
+          <Badge
+            data-testid="badge-init"
+            className="bg-blue-500/15 text-blue-600 dark:text-blue-400 border-blue-500/30"
+          >
+            Init changed
+          </Badge>
+        )}
+      </div>
+
+      {/* Init changes section */}
+      {hasInitChanges && (
+        <CollapsibleSection title="Initialization Changes" defaultOpen>
+          <div className="space-y-2">
+            {diff.initChanges.map((change) => (
+              <InitChangeRow key={change.field} change={change} />
+            ))}
+          </div>
+        </CollapsibleSection>
+      )}
+
+      {/* Tool changes section */}
+      {hasToolChanges && (
+        <CollapsibleSection title="Tool Changes" defaultOpen>
+          <div className="space-y-3">
+            {added.length > 0 && (
+              <ToolChangeGroup label="Added" changes={added} />
+            )}
+            {removed.length > 0 && (
+              <ToolChangeGroup label="Removed" changes={removed} />
+            )}
+            {changed.length > 0 && (
+              <ToolChangeGroup label="Changed" changes={changed} />
+            )}
+          </div>
+        </CollapsibleSection>
+      )}
+    </div>
+  );
+}
+
+// ── Sub-components ───────────────────────────────────────────────────
+
+function CollapsibleSection({
+  title,
+  defaultOpen = false,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground cursor-pointer w-full">
+        {open ? (
+          <ChevronDown className="h-3 w-3" />
+        ) : (
+          <ChevronRight className="h-3 w-3" />
+        )}
+        {title}
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2">{children}</CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function InitChangeRow({ change }: { change: InitChange }) {
+  const isObject =
+    typeof change.before === "object" ||
+    typeof change.after === "object";
+
+  return (
+    <div
+      data-testid={`init-change-${change.field}`}
+      className="text-xs space-y-1"
+    >
+      <div className="font-medium text-muted-foreground capitalize">
+        {formatFieldLabel(change.field)}
+      </div>
+      {isObject ? (
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <div className="text-[10px] text-muted-foreground/70 mb-0.5">
+              Before
+            </div>
+            <ScrollableJsonView
+              value={change.before ?? null}
+              showLineNumbers={false}
+              containerClassName="max-h-48 rounded"
+            />
+          </div>
+          <div>
+            <div className="text-[10px] text-muted-foreground/70 mb-0.5">
+              After
+            </div>
+            <ScrollableJsonView
+              value={change.after ?? null}
+              showLineNumbers={false}
+              containerClassName="max-h-48 rounded"
+            />
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 font-mono">
+          <span className="text-red-500/80 line-through">
+            {String(change.before ?? "(none)")}
+          </span>
+          <span className="text-muted-foreground">→</span>
+          <span className="text-emerald-500">
+            {String(change.after ?? "(none)")}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ToolChangeGroup({
+  label,
+  changes,
+}: {
+  label: string;
+  changes: ToolChange[];
+}) {
+  return (
+    <div data-testid={`tool-group-${label.toLowerCase()}`}>
+      <div className="text-[10px] font-medium text-muted-foreground/70 uppercase tracking-wider mb-1">
+        {label}
+      </div>
+      <div className="space-y-1.5">
+        {changes.map((change) => (
+          <ToolChangeCard key={change.name} change={change} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ToolChangeCard({ change }: { change: ToolChange }) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (change.type === "added") {
+    return (
+      <div className="rounded bg-emerald-500/5 border border-emerald-500/20 px-2.5 py-1.5 text-xs">
+        <span className="font-mono font-medium">{change.name}</span>
+        {change.after?.description && (
+          <span className="text-muted-foreground ml-2">
+            — {change.after.description}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  if (change.type === "removed") {
+    return (
+      <div className="rounded bg-red-500/5 border border-red-500/20 px-2.5 py-1.5 text-xs">
+        <span className="font-mono font-medium line-through text-muted-foreground">
+          {change.name}
+        </span>
+      </div>
+    );
+  }
+
+  // Changed
+  return (
+    <Collapsible open={expanded} onOpenChange={setExpanded}>
+      <div className="rounded bg-amber-500/5 border border-amber-500/20 px-2.5 py-1.5 text-xs">
+        <CollapsibleTrigger className="flex items-center gap-1.5 w-full cursor-pointer">
+          {expanded ? (
+            <ChevronDown className="h-3 w-3 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-3 w-3 text-muted-foreground" />
+          )}
+          <span className="font-mono font-medium">{change.name}</span>
+          <div className="flex gap-1 ml-auto">
+            {change.changedFields?.map((field) => (
+              <Badge
+                key={field}
+                variant="outline"
+                className="text-[10px] px-1.5 py-0"
+              >
+                {field}
+              </Badge>
+            ))}
+          </div>
+        </CollapsibleTrigger>
+        <CollapsibleContent className="mt-2 space-y-2">
+          {change.changedFields?.map((field) => (
+            <div key={field} className="space-y-1">
+              <div className="text-[10px] font-medium text-muted-foreground/70">
+                {field}
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <div>
+                  <div className="text-[10px] text-muted-foreground/70 mb-0.5">
+                    Before
+                  </div>
+                  <ScrollableJsonView
+                    value={
+                      change.before?.[
+                        field as keyof typeof change.before
+                      ] ?? null
+                    }
+                    showLineNumbers={false}
+                    containerClassName="max-h-32 rounded"
+                  />
+                </div>
+                <div>
+                  <div className="text-[10px] text-muted-foreground/70 mb-0.5">
+                    After
+                  </div>
+                  <ScrollableJsonView
+                    value={
+                      change.after?.[
+                        field as keyof typeof change.after
+                      ] ?? null
+                    }
+                    showLineNumbers={false}
+                    containerClassName="max-h-32 rounded"
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}
+
+function formatFieldLabel(field: string): string {
+  switch (field) {
+    case "protocolVersion":
+      return "Protocol Version";
+    case "transport":
+      return "Transport";
+    case "serverVersion":
+      return "Server Version";
+    case "instructions":
+      return "Instructions";
+    case "serverCapabilities":
+      return "Server Capabilities";
+    default:
+      return field;
+  }
+}

--- a/mcpjam-inspector/client/src/components/connection/ServerChangesPanel.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerChangesPanel.tsx
@@ -4,7 +4,13 @@
  */
 
 import { useState } from "react";
-import { ChevronDown, ChevronRight, Plus, Minus, RefreshCw } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronRight,
+  Plus,
+  Minus,
+  RefreshCw,
+} from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
   Collapsible,
@@ -142,8 +148,7 @@ function CollapsibleSection({
 
 function InitChangeRow({ change }: { change: InitChange }) {
   const isObject =
-    typeof change.before === "object" ||
-    typeof change.after === "object";
+    typeof change.before === "object" || typeof change.after === "object";
 
   return (
     <div
@@ -274,9 +279,8 @@ function ToolChangeCard({ change }: { change: ToolChange }) {
                   </div>
                   <ScrollableJsonView
                     value={
-                      change.before?.[
-                        field as keyof typeof change.before
-                      ] ?? null
+                      change.before?.[field as keyof typeof change.before] ??
+                      null
                     }
                     showLineNumbers={false}
                     containerClassName="max-h-32 rounded"
@@ -288,9 +292,7 @@ function ToolChangeCard({ change }: { change: ToolChange }) {
                   </div>
                   <ScrollableJsonView
                     value={
-                      change.after?.[
-                        field as keyof typeof change.after
-                      ] ?? null
+                      change.after?.[field as keyof typeof change.after] ?? null
                     }
                     showLineNumbers={false}
                     containerClassName="max-h-32 rounded"

--- a/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
@@ -11,7 +11,10 @@ import { getStoredTokensState } from "@/lib/oauth/mcp-oauth";
 import { decodeJWT } from "@/lib/oauth/jwt-decoder";
 import { ScrollableJsonView } from "@/components/ui/json-editor";
 import { useSharedAppState } from "@/state/app-state-context";
-import { useInspectionStore, inspectionStoreKey } from "@/stores/inspection-store";
+import {
+  useInspectionStore,
+  inspectionStoreKey,
+} from "@/stores/inspection-store";
 import { ServerChangesPanel } from "./ServerChangesPanel";
 
 interface ServerInfoContentProps {

--- a/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
@@ -10,6 +10,9 @@ import { ServerWithName } from "@/hooks/use-app-state";
 import { getStoredTokensState } from "@/lib/oauth/mcp-oauth";
 import { decodeJWT } from "@/lib/oauth/jwt-decoder";
 import { ScrollableJsonView } from "@/components/ui/json-editor";
+import { useSharedAppState } from "@/state/app-state-context";
+import { useInspectionStore, inspectionStoreKey } from "@/stores/inspection-store";
+import { ServerChangesPanel } from "./ServerChangesPanel";
 
 interface ServerInfoContentProps {
   server: ServerWithName;
@@ -20,6 +23,10 @@ export function ServerInfoContent({
   server,
   needsReconnect = false,
 }: ServerInfoContentProps) {
+  const { activeWorkspaceId } = useSharedAppState();
+  const storeKey = inspectionStoreKey(activeWorkspaceId, server.name);
+  const inspectionRecord = useInspectionStore((s) => s.records[storeKey]);
+
   const [copiedField, setCopiedField] = useState<string | null>(null);
   const [expandedTokens, setExpandedTokens] = useState<Set<string>>(new Set());
 
@@ -203,6 +210,9 @@ export function ServerInfoContent({
           payload. Reconnect the server to apply the workspace client profile.
         </div>
       ) : null}
+
+      <ServerChangesPanel diff={inspectionRecord?.latestDiff} />
+
       {serverName && (
         <div>
           <div className="text-sm font-medium text-muted-foreground mb-1">

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerChangesPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerChangesPanel.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ServerChangesPanel } from "../ServerChangesPanel";
+import type { ServerInspectionDiff } from "@/lib/inspection/types";
+
+// Mock ScrollableJsonView to avoid json-editor complexity in tests
+vi.mock("@/components/ui/json-editor", () => ({
+  ScrollableJsonView: ({ value }: { value: unknown }) => (
+    <pre data-testid="json-view">{JSON.stringify(value)}</pre>
+  ),
+}));
+
+function makeDiff(
+  overrides: Partial<ServerInspectionDiff> = {},
+): ServerInspectionDiff {
+  return {
+    initChanges: [],
+    toolChanges: [],
+    computedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("ServerChangesPanel", () => {
+  it("renders nothing when diff is null", () => {
+    const { container } = render(<ServerChangesPanel diff={null} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when diff is undefined", () => {
+    const { container } = render(<ServerChangesPanel diff={undefined} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when diff has no changes", () => {
+    const { container } = render(<ServerChangesPanel diff={makeDiff()} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders summary badges for added tools", () => {
+    render(
+      <ServerChangesPanel
+        diff={makeDiff({
+          toolChanges: [
+            { type: "added", name: "tool_a" },
+            { type: "added", name: "tool_b" },
+          ],
+        })}
+      />,
+    );
+    const badge = screen.getByTestId("badge-added");
+    expect(badge).toBeInTheDocument();
+    expect(badge.textContent).toContain("2 added");
+  });
+
+  it("renders summary badges for removed tools", () => {
+    render(
+      <ServerChangesPanel
+        diff={makeDiff({
+          toolChanges: [{ type: "removed", name: "old_tool" }],
+        })}
+      />,
+    );
+    const badge = screen.getByTestId("badge-removed");
+    expect(badge.textContent).toContain("1 removed");
+  });
+
+  it("renders summary badges for changed tools", () => {
+    render(
+      <ServerChangesPanel
+        diff={makeDiff({
+          toolChanges: [
+            {
+              type: "changed",
+              name: "t",
+              changedFields: ["description"],
+            },
+          ],
+        })}
+      />,
+    );
+    const badge = screen.getByTestId("badge-changed");
+    expect(badge.textContent).toContain("1 changed");
+  });
+
+  it("renders init changed badge", () => {
+    render(
+      <ServerChangesPanel
+        diff={makeDiff({
+          initChanges: [
+            { field: "protocolVersion", before: "1", after: "2" },
+          ],
+        })}
+      />,
+    );
+    const badge = screen.getByTestId("badge-init");
+    expect(badge.textContent).toContain("Init changed");
+  });
+
+  it("renders added tool group", () => {
+    render(
+      <ServerChangesPanel
+        diff={makeDiff({
+          toolChanges: [
+            {
+              type: "added",
+              name: "new_tool",
+              after: { name: "new_tool", description: "Does stuff" },
+            },
+          ],
+        })}
+      />,
+    );
+    const group = screen.getByTestId("tool-group-added");
+    expect(group).toBeInTheDocument();
+    expect(screen.getByText("new_tool")).toBeInTheDocument();
+  });
+
+  it("renders removed tool group with strikethrough", () => {
+    render(
+      <ServerChangesPanel
+        diff={makeDiff({
+          toolChanges: [{ type: "removed", name: "old_tool" }],
+        })}
+      />,
+    );
+    const group = screen.getByTestId("tool-group-removed");
+    expect(group).toBeInTheDocument();
+    const toolName = screen.getByText("old_tool");
+    expect(toolName.className).toContain("line-through");
+  });
+
+  it("renders changed tool group with field badges", () => {
+    render(
+      <ServerChangesPanel
+        diff={makeDiff({
+          toolChanges: [
+            {
+              type: "changed",
+              name: "my_tool",
+              changedFields: ["description", "inputSchema"],
+              before: { name: "my_tool", description: "old" },
+              after: { name: "my_tool", description: "new" },
+            },
+          ],
+        })}
+      />,
+    );
+    const group = screen.getByTestId("tool-group-changed");
+    expect(group).toBeInTheDocument();
+    expect(screen.getByText("description")).toBeInTheDocument();
+    expect(screen.getByText("inputSchema")).toBeInTheDocument();
+  });
+
+  it("renders init change for string fields with before/after", () => {
+    render(
+      <ServerChangesPanel
+        diff={makeDiff({
+          initChanges: [
+            {
+              field: "protocolVersion",
+              before: "2024-11-05",
+              after: "2025-03-26",
+            },
+          ],
+        })}
+      />,
+    );
+    const changeEl = screen.getByTestId("init-change-protocolVersion");
+    expect(changeEl).toBeInTheDocument();
+    expect(screen.getByText("2024-11-05")).toBeInTheDocument();
+    expect(screen.getByText("2025-03-26")).toBeInTheDocument();
+  });
+
+  it("renders init change for object fields with JSON views", () => {
+    render(
+      <ServerChangesPanel
+        diff={makeDiff({
+          initChanges: [
+            {
+              field: "serverCapabilities",
+              before: { tools: {} },
+              after: { tools: {}, prompts: {} },
+            },
+          ],
+        })}
+      />,
+    );
+    const jsonViews = screen.getAllByTestId("json-view");
+    expect(jsonViews.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerChangesPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerChangesPanel.test.tsx
@@ -87,9 +87,7 @@ describe("ServerChangesPanel", () => {
     render(
       <ServerChangesPanel
         diff={makeDiff({
-          initChanges: [
-            { field: "protocolVersion", before: "1", after: "2" },
-          ],
+          initChanges: [{ field: "protocolVersion", before: "1", after: "2" }],
         })}
       />,
     );

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-inspection-coordinator.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-inspection-coordinator.test.ts
@@ -69,7 +69,9 @@ describe("useInspectionCoordinator", () => {
     vi.clearAllMocks();
     mockActiveWorkspaceId.current = "ws-default";
     useInspectionStore.setState({ records: {} });
-    vi.mocked(listTools).mockResolvedValue(makeToolsResult([{ name: "tool1" }]));
+    vi.mocked(listTools).mockResolvedValue(
+      makeToolsResult([{ name: "tool1" }]),
+    );
   });
 
   it("runs inspection on connect transition with initInfo", async () => {
@@ -96,7 +98,10 @@ describe("useInspectionCoordinator", () => {
 
     // Wait for async inspection to complete
     await vi.waitFor(() => {
-      expect(listTools).toHaveBeenCalledWith({ serverId: "s1", cursor: undefined });
+      expect(listTools).toHaveBeenCalledWith({
+        serverId: "s1",
+        cursor: undefined,
+      });
     });
 
     // Should have saved a record

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-inspection-coordinator.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-inspection-coordinator.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { ServerWithName } from "@/state/app-types";
+import type { ListToolsResultWithMetadata } from "@/lib/apis/mcp-tools-api";
+
+// ── Mocks ────────────────────────────────────────────────────────────
+
+const mockActiveWorkspaceId = { current: "ws-default" };
+
+vi.mock("@/state/app-state-context", () => ({
+  useSharedAppState: () => ({
+    activeWorkspaceId: mockActiveWorkspaceId.current,
+  }),
+}));
+
+vi.mock("@/lib/apis/mcp-tools-api", () => ({
+  listTools: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: vi.fn(),
+}));
+
+// Import after mocks
+import { useInspectionCoordinator } from "../use-inspection-coordinator";
+import { useInspectionStore } from "@/stores/inspection-store";
+import { listTools } from "@/lib/apis/mcp-tools-api";
+import { toast } from "sonner";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function createServer(overrides: Partial<ServerWithName> = {}): ServerWithName {
+  return {
+    name: overrides.name ?? "test-server",
+    config: { url: new URL("http://localhost:3000") } as any,
+    connectionStatus: "disconnected",
+    retryCount: 0,
+    lastConnectionTime: new Date(),
+    ...overrides,
+  } as ServerWithName;
+}
+
+function makeToolsResult(
+  tools: Array<{ name: string; description?: string }> = [],
+): ListToolsResultWithMetadata {
+  return {
+    tools: tools.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: { type: "object" as const },
+    })),
+  };
+}
+
+const defaultInitInfo = {
+  protocolVersion: "2025-03-26",
+  transport: "streamable-http",
+  serverVersion: { name: "test-server", version: "1.0.0" },
+  instructions: "Be helpful.",
+  serverCapabilities: { tools: {} },
+};
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("useInspectionCoordinator", () => {
+  const onViewChanges = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockActiveWorkspaceId.current = "ws-default";
+    useInspectionStore.setState({ records: {} });
+    vi.mocked(listTools).mockResolvedValue(makeToolsResult([{ name: "tool1" }]));
+  });
+
+  it("runs inspection on connect transition with initInfo", async () => {
+    const { rerender } = renderHook(
+      ({ servers }: { servers: Record<string, ServerWithName> }) =>
+        useInspectionCoordinator(servers, onViewChanges),
+      {
+        initialProps: {
+          servers: { s1: createServer({ name: "s1" }) },
+        },
+      },
+    );
+
+    // Transition to connected with initInfo
+    rerender({
+      servers: {
+        s1: createServer({
+          name: "s1",
+          connectionStatus: "connected",
+          initializationInfo: defaultInitInfo,
+        }),
+      },
+    });
+
+    // Wait for async inspection to complete
+    await vi.waitFor(() => {
+      expect(listTools).toHaveBeenCalledWith({ serverId: "s1", cursor: undefined });
+    });
+
+    // Should have saved a record
+    await vi.waitFor(() => {
+      const record = useInspectionStore.getState().getRecord("ws-default::s1");
+      expect(record).toBeDefined();
+      expect(record!.latestDiff).toBeNull(); // first connect
+    });
+  });
+
+  it("does NOT run when already connected (rerender)", async () => {
+    const connectedServer = createServer({
+      name: "s1",
+      connectionStatus: "connected",
+      initializationInfo: defaultInitInfo,
+    });
+
+    const { rerender } = renderHook(
+      ({ servers }: { servers: Record<string, ServerWithName> }) =>
+        useInspectionCoordinator(servers, onViewChanges),
+      {
+        initialProps: { servers: { s1: connectedServer } },
+      },
+    );
+
+    // Rerender with same connected status
+    rerender({ servers: { s1: connectedServer } });
+    rerender({ servers: { s1: connectedServer } });
+
+    // listTools should NOT be called (no transition occurred)
+    expect(listTools).not.toHaveBeenCalled();
+  });
+
+  it("shows toast only when diff has meaningful changes", async () => {
+    // Seed a baseline
+    useInspectionStore.getState().saveInspection(
+      "ws-default::s1",
+      {
+        init: { protocolVersion: "2025-03-26" },
+        tools: [],
+        capturedAt: 1000,
+      },
+      null,
+    );
+
+    // Return different tools on reconnect
+    vi.mocked(listTools).mockResolvedValue(
+      makeToolsResult([{ name: "new_tool", description: "New!" }]),
+    );
+
+    const { rerender } = renderHook(
+      ({ servers }: { servers: Record<string, ServerWithName> }) =>
+        useInspectionCoordinator(servers, onViewChanges),
+      {
+        initialProps: {
+          servers: { s1: createServer({ name: "s1" }) },
+        },
+      },
+    );
+
+    rerender({
+      servers: {
+        s1: createServer({
+          name: "s1",
+          connectionStatus: "connected",
+          initializationInfo: defaultInitInfo,
+        }),
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        "Server changes detected",
+        expect.objectContaining({
+          description: expect.stringContaining("s1"),
+        }),
+      );
+    });
+  });
+
+  it("no toast on first connect (no baseline)", async () => {
+    const { rerender } = renderHook(
+      ({ servers }: { servers: Record<string, ServerWithName> }) =>
+        useInspectionCoordinator(servers, onViewChanges),
+      {
+        initialProps: {
+          servers: { s1: createServer({ name: "s1" }) },
+        },
+      },
+    );
+
+    rerender({
+      servers: {
+        s1: createServer({
+          name: "s1",
+          connectionStatus: "connected",
+          initializationInfo: defaultInitInfo,
+        }),
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        useInspectionStore.getState().getRecord("ws-default::s1"),
+      ).toBeDefined();
+    });
+
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  it("inspection failure does not overwrite previous record", async () => {
+    const existingSnapshot = {
+      init: { protocolVersion: "old" },
+      tools: [],
+      capturedAt: 1000,
+    };
+    useInspectionStore
+      .getState()
+      .saveInspection("ws-default::s1", existingSnapshot, null);
+
+    // Make listTools throw
+    vi.mocked(listTools).mockRejectedValue(new Error("network error"));
+
+    const { rerender } = renderHook(
+      ({ servers }: { servers: Record<string, ServerWithName> }) =>
+        useInspectionCoordinator(servers, onViewChanges),
+      {
+        initialProps: {
+          servers: { s1: createServer({ name: "s1" }) },
+        },
+      },
+    );
+
+    rerender({
+      servers: {
+        s1: createServer({
+          name: "s1",
+          connectionStatus: "connected",
+          initializationInfo: defaultInitInfo,
+        }),
+      },
+    });
+
+    // Wait a tick for async to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Previous record should be untouched
+    const record = useInspectionStore.getState().getRecord("ws-default::s1");
+    expect(record!.latestSnapshot.capturedAt).toBe(1000);
+  });
+
+  it("incomplete pagination skips diff and preserves previous baseline", async () => {
+    const existingSnapshot = {
+      init: { protocolVersion: "old" },
+      tools: [],
+      capturedAt: 1000,
+    };
+    useInspectionStore
+      .getState()
+      .saveInspection("ws-default::s1", existingSnapshot, null);
+
+    // Return page with nextCursor, then fail on second page
+    vi.mocked(listTools)
+      .mockResolvedValueOnce({
+        tools: [{ name: "t1", inputSchema: { type: "object" } }],
+        nextCursor: "page2",
+      } as any)
+      .mockRejectedValueOnce(new Error("pagination failed"));
+
+    const { rerender } = renderHook(
+      ({ servers }: { servers: Record<string, ServerWithName> }) =>
+        useInspectionCoordinator(servers, onViewChanges),
+      {
+        initialProps: {
+          servers: { s1: createServer({ name: "s1" }) },
+        },
+      },
+    );
+
+    rerender({
+      servers: {
+        s1: createServer({
+          name: "s1",
+          connectionStatus: "connected",
+          initializationInfo: defaultInitInfo,
+        }),
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Previous record should be untouched
+    const record = useInspectionStore.getState().getRecord("ws-default::s1");
+    expect(record!.latestSnapshot.capturedAt).toBe(1000);
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  it("discards result if workspace changes before async inspection completes", async () => {
+    let resolveTools: (value: any) => void;
+    vi.mocked(listTools).mockReturnValue(
+      new Promise((resolve) => {
+        resolveTools = resolve;
+      }),
+    );
+
+    const { rerender } = renderHook(
+      ({ servers }: { servers: Record<string, ServerWithName> }) =>
+        useInspectionCoordinator(servers, onViewChanges),
+      {
+        initialProps: {
+          servers: { s1: createServer({ name: "s1" }) },
+        },
+      },
+    );
+
+    // Trigger inspection
+    rerender({
+      servers: {
+        s1: createServer({
+          name: "s1",
+          connectionStatus: "connected",
+          initializationInfo: defaultInitInfo,
+        }),
+      },
+    });
+
+    // Switch workspace while inspection is in-flight
+    mockActiveWorkspaceId.current = "ws-other";
+    rerender({
+      servers: {
+        s1: createServer({
+          name: "s1",
+          connectionStatus: "connected",
+          initializationInfo: defaultInitInfo,
+        }),
+      },
+    });
+
+    // Now resolve the tools fetch
+    resolveTools!(makeToolsResult([{ name: "tool1" }]));
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Result should have been discarded (generation mismatch)
+    // The old workspace key should not have a record
+    expect(
+      useInspectionStore.getState().getRecord("ws-default::s1"),
+    ).toBeUndefined();
+  });
+
+  it("waits for initInfo before running inspection", async () => {
+    const { rerender } = renderHook(
+      ({ servers }: { servers: Record<string, ServerWithName> }) =>
+        useInspectionCoordinator(servers, onViewChanges),
+      {
+        initialProps: {
+          servers: { s1: createServer({ name: "s1" }) },
+        },
+      },
+    );
+
+    // Connected but no initInfo yet
+    rerender({
+      servers: {
+        s1: createServer({
+          name: "s1",
+          connectionStatus: "connected",
+          // no initializationInfo
+        }),
+      },
+    });
+
+    // Should not fetch tools yet
+    expect(listTools).not.toHaveBeenCalled();
+
+    // Now initInfo arrives
+    rerender({
+      servers: {
+        s1: createServer({
+          name: "s1",
+          connectionStatus: "connected",
+          initializationInfo: defaultInitInfo,
+        }),
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(listTools).toHaveBeenCalled();
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/use-inspection-coordinator.ts
+++ b/mcpjam-inspector/client/src/hooks/use-inspection-coordinator.ts
@@ -18,10 +18,20 @@ import { useEffect, useRef } from "react";
 import { toast } from "sonner";
 import type { ServerWithName, ConnectionStatus } from "@/state/app-types";
 import { useSharedAppState } from "@/state/app-state-context";
-import { listTools, type ListToolsResultWithMetadata } from "@/lib/apis/mcp-tools-api";
-import { buildSnapshot, computeInspectionDiff, hasMeaningfulChanges } from "@/lib/inspection/diff-engine";
+import {
+  listTools,
+  type ListToolsResultWithMetadata,
+} from "@/lib/apis/mcp-tools-api";
+import {
+  buildSnapshot,
+  computeInspectionDiff,
+  hasMeaningfulChanges,
+} from "@/lib/inspection/diff-engine";
 import { formatDiffSummary } from "@/lib/inspection/diff-summary";
-import { useInspectionStore, inspectionStoreKey } from "@/stores/inspection-store";
+import {
+  useInspectionStore,
+  inspectionStoreKey,
+} from "@/stores/inspection-store";
 
 interface ServerTrack {
   status: ConnectionStatus;
@@ -64,7 +74,8 @@ async function fetchAllTools(
 
   return {
     tools: allTools,
-    toolsMetadata: Object.keys(allMetadata).length > 0 ? allMetadata : undefined,
+    toolsMetadata:
+      Object.keys(allMetadata).length > 0 ? allMetadata : undefined,
   };
 }
 
@@ -104,7 +115,11 @@ export function useInspectionCoordinator(
 
       // Detect transition to connected (only if we have a previous state —
       // first render just records the baseline, doesn't trigger inspection)
-      if (status === "connected" && prev != null && prev.status !== "connected") {
+      if (
+        status === "connected" &&
+        prev != null &&
+        prev.status !== "connected"
+      ) {
         pendingRef.current.add(name);
       }
 
@@ -149,8 +164,7 @@ export function useInspectionCoordinator(
             capturedServerName,
           );
 
-          const prevRecord =
-            useInspectionStore.getState().getRecord(storeKey);
+          const prevRecord = useInspectionStore.getState().getRecord(storeKey);
 
           if (!prevRecord) {
             // First connect — seed baseline, no diff

--- a/mcpjam-inspector/client/src/hooks/use-inspection-coordinator.ts
+++ b/mcpjam-inspector/client/src/hooks/use-inspection-coordinator.ts
@@ -1,0 +1,204 @@
+/**
+ * App-level coordinator that watches all workspace servers for connection
+ * transitions and runs the inspection pipeline (snapshot + diff) after
+ * each successful connect.
+ *
+ * Mounted via a zero-UI bridge component inside AppStateProvider so it
+ * has access to useSharedAppState().
+ *
+ * Key design decisions:
+ *  - Captures workspaceId + serverName before async work
+ *  - Verifies they still match after async work completes
+ *  - Incomplete pagination = skip diff, keep previous baseline
+ *  - Never overwrites previous record on error
+ *  - Shows rich toast with "View changes" CTA only when diff has changes
+ */
+
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import type { ServerWithName, ConnectionStatus } from "@/state/app-types";
+import { useSharedAppState } from "@/state/app-state-context";
+import { listTools, type ListToolsResultWithMetadata } from "@/lib/apis/mcp-tools-api";
+import { buildSnapshot, computeInspectionDiff, hasMeaningfulChanges } from "@/lib/inspection/diff-engine";
+import { formatDiffSummary } from "@/lib/inspection/diff-summary";
+import { useInspectionStore, inspectionStoreKey } from "@/stores/inspection-store";
+
+interface ServerTrack {
+  status: ConnectionStatus;
+  hasInitInfo: boolean;
+}
+
+/**
+ * Fetch the complete tool catalog, following all pagination cursors.
+ * Returns null if pagination is incomplete (e.g. mid-pagination error).
+ */
+async function fetchAllTools(
+  serverId: string,
+): Promise<ListToolsResultWithMetadata | null> {
+  let allTools: ListToolsResultWithMetadata["tools"] = [];
+  let allMetadata: Record<string, Record<string, any>> = {};
+  let cursor: string | undefined;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    let page: ListToolsResultWithMetadata;
+    try {
+      page = await listTools({ serverId, cursor });
+    } catch (error) {
+      // Mid-pagination failure — return null to signal incomplete
+      console.warn(
+        `[inspection] Failed to fetch tools page for ${serverId}:`,
+        error,
+      );
+      return null;
+    }
+
+    allTools = allTools.concat(page.tools ?? []);
+    if (page.toolsMetadata) {
+      allMetadata = { ...allMetadata, ...page.toolsMetadata };
+    }
+
+    if (!page.nextCursor) break;
+    cursor = page.nextCursor;
+  }
+
+  return {
+    tools: allTools,
+    toolsMetadata: Object.keys(allMetadata).length > 0 ? allMetadata : undefined,
+  };
+}
+
+export function useInspectionCoordinator(
+  workspaceServers: Record<string, ServerWithName>,
+  onViewChanges: (serverName: string) => void,
+): void {
+  const { activeWorkspaceId } = useSharedAppState();
+
+  // Track previous state per server to detect transitions
+  const prevTrackRef = useRef<Record<string, ServerTrack>>({});
+  // Pending inspection flags — set when connected but awaiting initInfo
+  const pendingRef = useRef<Set<string>>(new Set());
+  // In-flight set to prevent concurrent inspections for the same server
+  const inFlightRef = useRef<Set<string>>(new Set());
+  // Cancellation: increment to invalidate all in-flight work
+  const generationRef = useRef(0);
+
+  // Reset pending/in-flight when workspace changes
+  const prevWorkspaceRef = useRef(activeWorkspaceId);
+  if (prevWorkspaceRef.current !== activeWorkspaceId) {
+    prevWorkspaceRef.current = activeWorkspaceId;
+    pendingRef.current.clear();
+    generationRef.current++;
+  }
+
+  useEffect(() => {
+    const prevTrack = prevTrackRef.current;
+    const nextTrack: Record<string, ServerTrack> = {};
+
+    for (const [name, server] of Object.entries(workspaceServers)) {
+      const prev = prevTrack[name];
+      const status = server.connectionStatus;
+      const hasInitInfo = server.initializationInfo != null;
+
+      nextTrack[name] = { status, hasInitInfo };
+
+      // Detect transition to connected (only if we have a previous state —
+      // first render just records the baseline, doesn't trigger inspection)
+      if (status === "connected" && prev != null && prev.status !== "connected") {
+        pendingRef.current.add(name);
+      }
+
+      // If disconnected/failed, clear pending
+      if (status !== "connected") {
+        pendingRef.current.delete(name);
+        continue;
+      }
+
+      // Run inspection when pending AND initInfo is populated
+      if (!pendingRef.current.has(name) || !hasInitInfo) continue;
+      if (inFlightRef.current.has(name)) continue;
+
+      pendingRef.current.delete(name);
+      inFlightRef.current.add(name);
+
+      // Capture at scheduling time
+      const capturedWorkspaceId = activeWorkspaceId;
+      const capturedServerName = name;
+      const capturedGeneration = generationRef.current;
+      const initInfo = server.initializationInfo!;
+
+      void (async () => {
+        try {
+          // Fetch complete tool catalog
+          const toolsResult = await fetchAllTools(capturedServerName);
+
+          // Incomplete pagination — skip diff
+          if (!toolsResult) {
+            console.warn(
+              `[inspection] Incomplete tool catalog for ${capturedServerName}, skipping diff`,
+            );
+            return;
+          }
+
+          // Verify workspace hasn't changed (generation check covers workspace switches)
+          if (capturedGeneration !== generationRef.current) return;
+
+          const snapshot = buildSnapshot(initInfo, toolsResult);
+          const storeKey = inspectionStoreKey(
+            capturedWorkspaceId,
+            capturedServerName,
+          );
+
+          const prevRecord =
+            useInspectionStore.getState().getRecord(storeKey);
+
+          if (!prevRecord) {
+            // First connect — seed baseline, no diff
+            useInspectionStore
+              .getState()
+              .saveInspection(storeKey, snapshot, null);
+            return;
+          }
+
+          // Compute diff
+          const diff = computeInspectionDiff(
+            prevRecord.latestSnapshot,
+            snapshot,
+          );
+          useInspectionStore
+            .getState()
+            .saveInspection(storeKey, snapshot, diff);
+
+          if (hasMeaningfulChanges(diff)) {
+            const summary = formatDiffSummary(diff);
+            toast("Server changes detected", {
+              description: `${capturedServerName}: ${summary}`,
+              duration: 8000,
+              action: {
+                label: "View changes",
+                onClick: () => onViewChanges(capturedServerName),
+              },
+            });
+          }
+        } catch (error) {
+          // Never overwrite previous record on error
+          console.error(
+            `[inspection] Inspection failed for ${capturedServerName}:`,
+            error,
+          );
+        } finally {
+          inFlightRef.current.delete(capturedServerName);
+        }
+      })();
+    }
+
+    // Clean up servers that disappeared from workspaceServers
+    for (const name of Object.keys(prevTrack)) {
+      if (!(name in workspaceServers)) {
+        pendingRef.current.delete(name);
+      }
+    }
+
+    prevTrackRef.current = nextTrack;
+  }, [workspaceServers, activeWorkspaceId, onViewChanges]);
+}

--- a/mcpjam-inspector/client/src/lib/inspection-detail-request.ts
+++ b/mcpjam-inspector/client/src/lib/inspection-detail-request.ts
@@ -1,0 +1,71 @@
+/**
+ * Global detail-open request helper for the inspection toast CTA.
+ *
+ * Extends the existing server-detail-modal-resume.ts localStorage pattern.
+ * The toast writes a request, App navigates to ServersTab, and ServersTab
+ * consumes the request to open the detail modal on the Overview tab.
+ *
+ * Includes a 5-minute TTL to prevent stale requests from reopening the
+ * wrong modal after reload or navigation.
+ */
+
+const INSPECTION_DETAIL_REQUEST_KEY = "mcp-inspection-detail-request";
+const INSPECTION_DETAIL_REQUEST_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export interface InspectionDetailRequest {
+  serverName: string;
+  createdAt: number;
+}
+
+function isValidRequest(
+  value: unknown,
+): value is InspectionDetailRequest {
+  return (
+    value != null &&
+    typeof value === "object" &&
+    typeof (value as InspectionDetailRequest).serverName === "string" &&
+    typeof (value as InspectionDetailRequest).createdAt === "number"
+  );
+}
+
+export function writeInspectionDetailRequest(serverName: string): void {
+  localStorage.setItem(
+    INSPECTION_DETAIL_REQUEST_KEY,
+    JSON.stringify({
+      serverName,
+      createdAt: Date.now(),
+    } satisfies InspectionDetailRequest),
+  );
+}
+
+/**
+ * Read and return a pending detail request.
+ * Returns null if missing, invalid, or stale (> 5 min TTL).
+ * Stale entries are auto-cleared.
+ */
+export function readInspectionDetailRequest(): InspectionDetailRequest | null {
+  try {
+    const raw = localStorage.getItem(INSPECTION_DETAIL_REQUEST_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw);
+    if (!isValidRequest(parsed)) {
+      localStorage.removeItem(INSPECTION_DETAIL_REQUEST_KEY);
+      return null;
+    }
+
+    if (Date.now() - parsed.createdAt > INSPECTION_DETAIL_REQUEST_TTL_MS) {
+      localStorage.removeItem(INSPECTION_DETAIL_REQUEST_KEY);
+      return null;
+    }
+
+    return parsed;
+  } catch {
+    localStorage.removeItem(INSPECTION_DETAIL_REQUEST_KEY);
+    return null;
+  }
+}
+
+export function clearInspectionDetailRequest(): void {
+  localStorage.removeItem(INSPECTION_DETAIL_REQUEST_KEY);
+}

--- a/mcpjam-inspector/client/src/lib/inspection-detail-request.ts
+++ b/mcpjam-inspector/client/src/lib/inspection-detail-request.ts
@@ -17,9 +17,7 @@ export interface InspectionDetailRequest {
   createdAt: number;
 }
 
-function isValidRequest(
-  value: unknown,
-): value is InspectionDetailRequest {
+function isValidRequest(value: unknown): value is InspectionDetailRequest {
   return (
     value != null &&
     typeof value === "object" &&

--- a/mcpjam-inspector/client/src/lib/inspection/__tests__/diff-engine.test.ts
+++ b/mcpjam-inspector/client/src/lib/inspection/__tests__/diff-engine.test.ts
@@ -24,7 +24,9 @@ function makeTool(overrides: Partial<Tool> & { name: string }): Tool {
   } as Tool;
 }
 
-function makeInit(overrides: Partial<InitializationInfo> = {}): InitializationInfo {
+function makeInit(
+  overrides: Partial<InitializationInfo> = {},
+): InitializationInfo {
   return {
     protocolVersion: "2025-03-26",
     transport: "streamable-http",
@@ -128,7 +130,10 @@ describe("normalizeToolSnapshot", () => {
   it("stabilizes key order in nested objects", () => {
     const tool = makeTool({
       name: "t",
-      inputSchema: { type: "object", properties: { z: { type: "string" }, a: { type: "number" } } },
+      inputSchema: {
+        type: "object",
+        properties: { z: { type: "string" }, a: { type: "number" } },
+      },
     });
     const json = JSON.stringify(normalizeToolSnapshot(tool));
     // "a" should come before "z" in the stabilized output
@@ -187,14 +192,20 @@ describe("buildSnapshot", () => {
   it("merges toolsMetadata into tool snapshots", () => {
     const tool = makeTool({ name: "my_tool" });
     const metadata = { my_tool: { uiHint: "panel" } };
-    const snapshot = buildSnapshot(makeInit(), makeToolsResult([tool], metadata));
+    const snapshot = buildSnapshot(
+      makeInit(),
+      makeToolsResult([tool], metadata),
+    );
     expect(snapshot.tools[0].metadata).toEqual({ uiHint: "panel" });
   });
 
   it("prefers tool._meta over toolsMetadata", () => {
     const tool = makeTool({ name: "my_tool", _meta: { uiHint: "button" } });
     const metadata = { my_tool: { uiHint: "panel" } };
-    const snapshot = buildSnapshot(makeInit(), makeToolsResult([tool], metadata));
+    const snapshot = buildSnapshot(
+      makeInit(),
+      makeToolsResult([tool], metadata),
+    );
     expect(snapshot.tools[0].metadata).toEqual({ uiHint: "button" });
   });
 
@@ -209,7 +220,10 @@ describe("buildSnapshot", () => {
 
 describe("computeInspectionDiff", () => {
   it("produces empty diff for identical snapshots", () => {
-    const s = makeSnapshot(makeInit(), makeToolsResult([makeTool({ name: "t" })]));
+    const s = makeSnapshot(
+      makeInit(),
+      makeToolsResult([makeTool({ name: "t" })]),
+    );
     const diff = computeInspectionDiff(s, s);
     expect(diff.initChanges).toHaveLength(0);
     expect(diff.toolChanges).toHaveLength(0);
@@ -261,13 +275,25 @@ describe("computeInspectionDiff", () => {
     const prev = makeSnapshot(
       makeInit(),
       makeToolsResult([
-        makeTool({ name: "t", inputSchema: { type: "object", properties: { a: { type: "string" } } } }),
+        makeTool({
+          name: "t",
+          inputSchema: {
+            type: "object",
+            properties: { a: { type: "string" } },
+          },
+        }),
       ]),
     );
     const current = makeSnapshot(
       makeInit(),
       makeToolsResult([
-        makeTool({ name: "t", inputSchema: { type: "object", properties: { b: { type: "number" } } } }),
+        makeTool({
+          name: "t",
+          inputSchema: {
+            type: "object",
+            properties: { b: { type: "number" } },
+          },
+        }),
       ]),
     );
     const diff = computeInspectionDiff(prev, current);
@@ -276,8 +302,14 @@ describe("computeInspectionDiff", () => {
   });
 
   it("detects changed outputSchema", () => {
-    const toolA = { ...makeTool({ name: "t" }), outputSchema: { type: "string" } } as unknown as Tool;
-    const toolB = { ...makeTool({ name: "t" }), outputSchema: { type: "number" } } as unknown as Tool;
+    const toolA = {
+      ...makeTool({ name: "t" }),
+      outputSchema: { type: "string" },
+    } as unknown as Tool;
+    const toolB = {
+      ...makeTool({ name: "t" }),
+      outputSchema: { type: "number" },
+    } as unknown as Tool;
     const prev = makeSnapshot(makeInit(), makeToolsResult([toolA]));
     const current = makeSnapshot(makeInit(), makeToolsResult([toolB]));
     const diff = computeInspectionDiff(prev, current);
@@ -332,8 +364,14 @@ describe("computeInspectionDiff", () => {
   // ── Init diffs ───────────────────────────────────────────────────
 
   it("detects changed protocolVersion", () => {
-    const prev = makeSnapshot(makeInit({ protocolVersion: "2024-11-05" }), makeToolsResult([]));
-    const current = makeSnapshot(makeInit({ protocolVersion: "2025-03-26" }), makeToolsResult([]));
+    const prev = makeSnapshot(
+      makeInit({ protocolVersion: "2024-11-05" }),
+      makeToolsResult([]),
+    );
+    const current = makeSnapshot(
+      makeInit({ protocolVersion: "2025-03-26" }),
+      makeToolsResult([]),
+    );
     const diff = computeInspectionDiff(prev, current);
     expect(diff.initChanges).toContainEqual({
       field: "protocolVersion",
@@ -343,8 +381,14 @@ describe("computeInspectionDiff", () => {
   });
 
   it("detects changed transport", () => {
-    const prev = makeSnapshot(makeInit({ transport: "stdio" }), makeToolsResult([]));
-    const current = makeSnapshot(makeInit({ transport: "streamable-http" }), makeToolsResult([]));
+    const prev = makeSnapshot(
+      makeInit({ transport: "stdio" }),
+      makeToolsResult([]),
+    );
+    const current = makeSnapshot(
+      makeInit({ transport: "streamable-http" }),
+      makeToolsResult([]),
+    );
     const diff = computeInspectionDiff(prev, current);
     expect(diff.initChanges).toContainEqual({
       field: "transport",
@@ -380,7 +424,9 @@ describe("computeInspectionDiff", () => {
       makeToolsResult([]),
     );
     const diff = computeInspectionDiff(prev, current);
-    expect(diff.initChanges.find((c) => c.field === "serverVersion")).toBeTruthy();
+    expect(
+      diff.initChanges.find((c) => c.field === "serverVersion"),
+    ).toBeTruthy();
   });
 
   it("detects changed serverCapabilities", () => {
@@ -454,8 +500,12 @@ describe("computeInspectionDiff", () => {
     const diff = computeInspectionDiff(prev, current);
     expect(diff.initChanges).toHaveLength(2);
     expect(diff.toolChanges.filter((c) => c.type === "added")).toHaveLength(1);
-    expect(diff.toolChanges.filter((c) => c.type === "removed")).toHaveLength(1);
-    expect(diff.toolChanges.filter((c) => c.type === "changed")).toHaveLength(1);
+    expect(diff.toolChanges.filter((c) => c.type === "removed")).toHaveLength(
+      1,
+    );
+    expect(diff.toolChanges.filter((c) => c.type === "changed")).toHaveLength(
+      1,
+    );
   });
 
   // ── Sort order ───────────────────────────────────────────────────

--- a/mcpjam-inspector/client/src/lib/inspection/__tests__/diff-engine.test.ts
+++ b/mcpjam-inspector/client/src/lib/inspection/__tests__/diff-engine.test.ts
@@ -1,0 +1,527 @@
+import { describe, it, expect } from "vitest";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { InitializationInfo } from "@/state/app-types";
+import type { ListToolsResultWithMetadata } from "@/lib/apis/mcp-tools-api";
+import type { ServerInspectionSnapshot } from "../types";
+import {
+  stableStringify,
+  normalizeToolSnapshot,
+  normalizeInitSnapshot,
+  buildSnapshot,
+  computeInspectionDiff,
+  hasMeaningfulChanges,
+} from "../diff-engine";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function makeTool(overrides: Partial<Tool> & { name: string }): Tool {
+  return {
+    name: overrides.name,
+    description: overrides.description,
+    inputSchema: overrides.inputSchema ?? { type: "object" as const },
+    ...(overrides.annotations ? { annotations: overrides.annotations } : {}),
+    ...(overrides._meta ? { _meta: overrides._meta } : {}),
+  } as Tool;
+}
+
+function makeInit(overrides: Partial<InitializationInfo> = {}): InitializationInfo {
+  return {
+    protocolVersion: "2025-03-26",
+    transport: "streamable-http",
+    serverVersion: { name: "test-server", version: "1.0.0" },
+    instructions: "You are a helpful assistant.",
+    serverCapabilities: { tools: {} },
+    ...overrides,
+  };
+}
+
+function makeToolsResult(
+  tools: Tool[],
+  toolsMetadata?: Record<string, Record<string, any>>,
+): ListToolsResultWithMetadata {
+  return { tools, toolsMetadata };
+}
+
+function makeSnapshot(
+  init: InitializationInfo,
+  toolsResult: ListToolsResultWithMetadata,
+): ServerInspectionSnapshot {
+  return buildSnapshot(init, toolsResult);
+}
+
+// ── stableStringify ──────────────────────────────────────────────────
+
+describe("stableStringify", () => {
+  it("produces identical output regardless of key order", () => {
+    const a = { z: 1, a: 2, m: 3 };
+    const b = { a: 2, m: 3, z: 1 };
+    expect(stableStringify(a)).toBe(stableStringify(b));
+  });
+
+  it("handles nested objects", () => {
+    const a = { outer: { z: 1, a: 2 } };
+    const b = { outer: { a: 2, z: 1 } };
+    expect(stableStringify(a)).toBe(stableStringify(b));
+  });
+
+  it("preserves array order", () => {
+    const a = [3, 1, 2];
+    const b = [1, 2, 3];
+    expect(stableStringify(a)).not.toBe(stableStringify(b));
+  });
+
+  it("handles null and undefined", () => {
+    expect(stableStringify(null)).toBe("null");
+    expect(stableStringify(undefined)).toBe(undefined);
+  });
+});
+
+// ── normalizeToolSnapshot ────────────────────────────────────────────
+
+describe("normalizeToolSnapshot", () => {
+  it("extracts relevant fields from a tool", () => {
+    const tool = makeTool({
+      name: "get_weather",
+      description: "Get weather data",
+      inputSchema: { type: "object", properties: { city: { type: "string" } } },
+    });
+
+    const result = normalizeToolSnapshot(tool);
+    expect(result.name).toBe("get_weather");
+    expect(result.description).toBe("Get weather data");
+    expect(result.inputSchema).toEqual({
+      type: "object",
+      properties: { city: { type: "string" } },
+    });
+  });
+
+  it("merges tool._meta when present", () => {
+    const tool = makeTool({
+      name: "t",
+      _meta: { uiHint: "button" },
+    });
+
+    const result = normalizeToolSnapshot(tool);
+    expect(result.metadata).toEqual({ uiHint: "button" });
+  });
+
+  it("uses externalMetadata when tool._meta is absent", () => {
+    const tool = makeTool({ name: "t" });
+    const result = normalizeToolSnapshot(tool, { uiHint: "panel" });
+    expect(result.metadata).toEqual({ uiHint: "panel" });
+  });
+
+  it("prefers tool._meta over externalMetadata", () => {
+    const tool = makeTool({ name: "t", _meta: { uiHint: "button" } });
+    const result = normalizeToolSnapshot(tool, { uiHint: "panel" });
+    expect(result.metadata).toEqual({ uiHint: "button" });
+  });
+
+  it("omits undefined optional fields", () => {
+    const tool = makeTool({ name: "bare" });
+    const result = normalizeToolSnapshot(tool);
+    expect(result).toEqual({ name: "bare", inputSchema: { type: "object" } });
+    expect("metadata" in result).toBe(false);
+    expect("annotations" in result).toBe(false);
+  });
+
+  it("stabilizes key order in nested objects", () => {
+    const tool = makeTool({
+      name: "t",
+      inputSchema: { type: "object", properties: { z: { type: "string" }, a: { type: "number" } } },
+    });
+    const json = JSON.stringify(normalizeToolSnapshot(tool));
+    // "a" should come before "z" in the stabilized output
+    expect(json.indexOf('"a"')).toBeLessThan(json.indexOf('"z"'));
+  });
+});
+
+// ── normalizeInitSnapshot ────────────────────────────────────────────
+
+describe("normalizeInitSnapshot", () => {
+  it("extracts server-facing fields", () => {
+    const init = makeInit();
+    const result = normalizeInitSnapshot(init);
+    expect(result.protocolVersion).toBe("2025-03-26");
+    expect(result.transport).toBe("streamable-http");
+    expect(result.serverVersion).toEqual({
+      name: "test-server",
+      version: "1.0.0",
+    });
+    expect(result.instructions).toBe("You are a helpful assistant.");
+    expect(result.serverCapabilities).toEqual({ tools: {} });
+  });
+
+  it("excludes clientCapabilities", () => {
+    const init = makeInit({
+      clientCapabilities: { sampling: {} },
+    });
+    const result = normalizeInitSnapshot(init);
+    expect("clientCapabilities" in result).toBe(false);
+  });
+
+  it("omits undefined fields", () => {
+    const result = normalizeInitSnapshot({});
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+});
+
+// ── buildSnapshot ────────────────────────────────────────────────────
+
+describe("buildSnapshot", () => {
+  it("builds a snapshot with sorted tools", () => {
+    const init = makeInit();
+    const tools = [
+      makeTool({ name: "z_tool" }),
+      makeTool({ name: "a_tool" }),
+      makeTool({ name: "m_tool" }),
+    ];
+    const snapshot = buildSnapshot(init, makeToolsResult(tools));
+    expect(snapshot.tools.map((t) => t.name)).toEqual([
+      "a_tool",
+      "m_tool",
+      "z_tool",
+    ]);
+  });
+
+  it("merges toolsMetadata into tool snapshots", () => {
+    const tool = makeTool({ name: "my_tool" });
+    const metadata = { my_tool: { uiHint: "panel" } };
+    const snapshot = buildSnapshot(makeInit(), makeToolsResult([tool], metadata));
+    expect(snapshot.tools[0].metadata).toEqual({ uiHint: "panel" });
+  });
+
+  it("prefers tool._meta over toolsMetadata", () => {
+    const tool = makeTool({ name: "my_tool", _meta: { uiHint: "button" } });
+    const metadata = { my_tool: { uiHint: "panel" } };
+    const snapshot = buildSnapshot(makeInit(), makeToolsResult([tool], metadata));
+    expect(snapshot.tools[0].metadata).toEqual({ uiHint: "button" });
+  });
+
+  it("sets capturedAt to a timestamp", () => {
+    const snapshot = buildSnapshot(makeInit(), makeToolsResult([]));
+    expect(typeof snapshot.capturedAt).toBe("number");
+    expect(snapshot.capturedAt).toBeGreaterThan(0);
+  });
+});
+
+// ── computeInspectionDiff ────────────────────────────────────────────
+
+describe("computeInspectionDiff", () => {
+  it("produces empty diff for identical snapshots", () => {
+    const s = makeSnapshot(makeInit(), makeToolsResult([makeTool({ name: "t" })]));
+    const diff = computeInspectionDiff(s, s);
+    expect(diff.initChanges).toHaveLength(0);
+    expect(diff.toolChanges).toHaveLength(0);
+  });
+
+  // ── Tool diffs ───────────────────────────────────────────────────
+
+  it("detects added tool", () => {
+    const prev = makeSnapshot(makeInit(), makeToolsResult([]));
+    const current = makeSnapshot(
+      makeInit(),
+      makeToolsResult([makeTool({ name: "new_tool", description: "New!" })]),
+    );
+    const diff = computeInspectionDiff(prev, current);
+    expect(diff.toolChanges).toHaveLength(1);
+    expect(diff.toolChanges[0].type).toBe("added");
+    expect(diff.toolChanges[0].name).toBe("new_tool");
+    expect(diff.toolChanges[0].after?.description).toBe("New!");
+  });
+
+  it("detects removed tool", () => {
+    const prev = makeSnapshot(
+      makeInit(),
+      makeToolsResult([makeTool({ name: "old_tool" })]),
+    );
+    const current = makeSnapshot(makeInit(), makeToolsResult([]));
+    const diff = computeInspectionDiff(prev, current);
+    expect(diff.toolChanges).toHaveLength(1);
+    expect(diff.toolChanges[0].type).toBe("removed");
+    expect(diff.toolChanges[0].name).toBe("old_tool");
+  });
+
+  it("detects changed tool description", () => {
+    const prev = makeSnapshot(
+      makeInit(),
+      makeToolsResult([makeTool({ name: "t", description: "old" })]),
+    );
+    const current = makeSnapshot(
+      makeInit(),
+      makeToolsResult([makeTool({ name: "t", description: "new" })]),
+    );
+    const diff = computeInspectionDiff(prev, current);
+    expect(diff.toolChanges).toHaveLength(1);
+    expect(diff.toolChanges[0].type).toBe("changed");
+    expect(diff.toolChanges[0].changedFields).toEqual(["description"]);
+  });
+
+  it("detects changed inputSchema", () => {
+    const prev = makeSnapshot(
+      makeInit(),
+      makeToolsResult([
+        makeTool({ name: "t", inputSchema: { type: "object", properties: { a: { type: "string" } } } }),
+      ]),
+    );
+    const current = makeSnapshot(
+      makeInit(),
+      makeToolsResult([
+        makeTool({ name: "t", inputSchema: { type: "object", properties: { b: { type: "number" } } } }),
+      ]),
+    );
+    const diff = computeInspectionDiff(prev, current);
+    expect(diff.toolChanges).toHaveLength(1);
+    expect(diff.toolChanges[0].changedFields).toContain("inputSchema");
+  });
+
+  it("detects changed outputSchema", () => {
+    const toolA = { ...makeTool({ name: "t" }), outputSchema: { type: "string" } } as unknown as Tool;
+    const toolB = { ...makeTool({ name: "t" }), outputSchema: { type: "number" } } as unknown as Tool;
+    const prev = makeSnapshot(makeInit(), makeToolsResult([toolA]));
+    const current = makeSnapshot(makeInit(), makeToolsResult([toolB]));
+    const diff = computeInspectionDiff(prev, current);
+    expect(diff.toolChanges[0].changedFields).toContain("outputSchema");
+  });
+
+  it("detects changed metadata", () => {
+    const prev = makeSnapshot(
+      makeInit(),
+      makeToolsResult([makeTool({ name: "t", _meta: { v: 1 } })]),
+    );
+    const current = makeSnapshot(
+      makeInit(),
+      makeToolsResult([makeTool({ name: "t", _meta: { v: 2 } })]),
+    );
+    const diff = computeInspectionDiff(prev, current);
+    expect(diff.toolChanges[0].changedFields).toContain("metadata");
+  });
+
+  it("detects changed annotations", () => {
+    const prev = makeSnapshot(
+      makeInit(),
+      makeToolsResult([
+        makeTool({ name: "t", annotations: { readOnlyHint: true } as any }),
+      ]),
+    );
+    const current = makeSnapshot(
+      makeInit(),
+      makeToolsResult([
+        makeTool({ name: "t", annotations: { readOnlyHint: false } as any }),
+      ]),
+    );
+    const diff = computeInspectionDiff(prev, current);
+    expect(diff.toolChanges[0].changedFields).toContain("annotations");
+  });
+
+  it("detects merged metadata change from toolsMetadata", () => {
+    const tool = makeTool({ name: "t" });
+    const prev = makeSnapshot(
+      makeInit(),
+      makeToolsResult([tool], { t: { panel: "old" } }),
+    );
+    const current = makeSnapshot(
+      makeInit(),
+      makeToolsResult([tool], { t: { panel: "new" } }),
+    );
+    const diff = computeInspectionDiff(prev, current);
+    expect(diff.toolChanges).toHaveLength(1);
+    expect(diff.toolChanges[0].changedFields).toContain("metadata");
+  });
+
+  // ── Init diffs ───────────────────────────────────────────────────
+
+  it("detects changed protocolVersion", () => {
+    const prev = makeSnapshot(makeInit({ protocolVersion: "2024-11-05" }), makeToolsResult([]));
+    const current = makeSnapshot(makeInit({ protocolVersion: "2025-03-26" }), makeToolsResult([]));
+    const diff = computeInspectionDiff(prev, current);
+    expect(diff.initChanges).toContainEqual({
+      field: "protocolVersion",
+      before: "2024-11-05",
+      after: "2025-03-26",
+    });
+  });
+
+  it("detects changed transport", () => {
+    const prev = makeSnapshot(makeInit({ transport: "stdio" }), makeToolsResult([]));
+    const current = makeSnapshot(makeInit({ transport: "streamable-http" }), makeToolsResult([]));
+    const diff = computeInspectionDiff(prev, current);
+    expect(diff.initChanges).toContainEqual({
+      field: "transport",
+      before: "stdio",
+      after: "streamable-http",
+    });
+  });
+
+  it("detects changed instructions", () => {
+    const prev = makeSnapshot(
+      makeInit({ instructions: "Be helpful." }),
+      makeToolsResult([]),
+    );
+    const current = makeSnapshot(
+      makeInit({ instructions: "Be concise." }),
+      makeToolsResult([]),
+    );
+    const diff = computeInspectionDiff(prev, current);
+    expect(diff.initChanges).toContainEqual({
+      field: "instructions",
+      before: "Be helpful.",
+      after: "Be concise.",
+    });
+  });
+
+  it("detects changed serverVersion", () => {
+    const prev = makeSnapshot(
+      makeInit({ serverVersion: { name: "s", version: "1.0.0" } }),
+      makeToolsResult([]),
+    );
+    const current = makeSnapshot(
+      makeInit({ serverVersion: { name: "s", version: "2.0.0" } }),
+      makeToolsResult([]),
+    );
+    const diff = computeInspectionDiff(prev, current);
+    expect(diff.initChanges.find((c) => c.field === "serverVersion")).toBeTruthy();
+  });
+
+  it("detects changed serverCapabilities", () => {
+    const prev = makeSnapshot(
+      makeInit({ serverCapabilities: { tools: {} } }),
+      makeToolsResult([]),
+    );
+    const current = makeSnapshot(
+      makeInit({ serverCapabilities: { tools: {}, prompts: {} } }),
+      makeToolsResult([]),
+    );
+    const diff = computeInspectionDiff(prev, current);
+    expect(
+      diff.initChanges.find((c) => c.field === "serverCapabilities"),
+    ).toBeTruthy();
+  });
+
+  // ── Normalization ────────────────────────────────────────────────
+
+  it("ignores key-ordering-only changes", () => {
+    const init1 = makeInit({ serverCapabilities: { tools: {}, prompts: {} } });
+    const init2 = makeInit({ serverCapabilities: { prompts: {}, tools: {} } });
+    const prev = makeSnapshot(init1, makeToolsResult([]));
+    const current = makeSnapshot(init2, makeToolsResult([]));
+    const diff = computeInspectionDiff(prev, current);
+    expect(diff.initChanges).toHaveLength(0);
+  });
+
+  it("ignores tool ordering differences", () => {
+    const tools1 = [makeTool({ name: "b" }), makeTool({ name: "a" })];
+    const tools2 = [makeTool({ name: "a" }), makeTool({ name: "b" })];
+    const prev = makeSnapshot(makeInit(), makeToolsResult(tools1));
+    const current = makeSnapshot(makeInit(), makeToolsResult(tools2));
+    const diff = computeInspectionDiff(prev, current);
+    expect(diff.toolChanges).toHaveLength(0);
+  });
+
+  // ── clientCapabilities exclusion ─────────────────────────────────
+
+  it("does not report clientCapabilities changes", () => {
+    const init1 = makeInit({ clientCapabilities: { sampling: {} } });
+    const init2 = makeInit({ clientCapabilities: { sampling: {}, roots: {} } });
+    const prev = makeSnapshot(init1, makeToolsResult([]));
+    const current = makeSnapshot(init2, makeToolsResult([]));
+    const diff = computeInspectionDiff(prev, current);
+    expect(
+      diff.initChanges.find((c) => c.field === "clientCapabilities"),
+    ).toBeUndefined();
+    expect(diff.initChanges).toHaveLength(0);
+  });
+
+  // ── Aggregate changes ────────────────────────────────────────────
+
+  it("handles multiple simultaneous changes", () => {
+    const prev = makeSnapshot(
+      makeInit({ protocolVersion: "1.0", instructions: "old" }),
+      makeToolsResult([
+        makeTool({ name: "keep", description: "same" }),
+        makeTool({ name: "remove_me" }),
+        makeTool({ name: "change_me", description: "old" }),
+      ]),
+    );
+    const current = makeSnapshot(
+      makeInit({ protocolVersion: "2.0", instructions: "new" }),
+      makeToolsResult([
+        makeTool({ name: "keep", description: "same" }),
+        makeTool({ name: "add_me", description: "new tool" }),
+        makeTool({ name: "change_me", description: "new" }),
+      ]),
+    );
+    const diff = computeInspectionDiff(prev, current);
+    expect(diff.initChanges).toHaveLength(2);
+    expect(diff.toolChanges.filter((c) => c.type === "added")).toHaveLength(1);
+    expect(diff.toolChanges.filter((c) => c.type === "removed")).toHaveLength(1);
+    expect(diff.toolChanges.filter((c) => c.type === "changed")).toHaveLength(1);
+  });
+
+  // ── Sort order ───────────────────────────────────────────────────
+
+  it("sorts tool changes: added, changed, removed, alpha within groups", () => {
+    const prev = makeSnapshot(
+      makeInit(),
+      makeToolsResult([
+        makeTool({ name: "remove_b" }),
+        makeTool({ name: "remove_a" }),
+        makeTool({ name: "change_b", description: "old" }),
+        makeTool({ name: "change_a", description: "old" }),
+      ]),
+    );
+    const current = makeSnapshot(
+      makeInit(),
+      makeToolsResult([
+        makeTool({ name: "add_b" }),
+        makeTool({ name: "add_a" }),
+        makeTool({ name: "change_b", description: "new" }),
+        makeTool({ name: "change_a", description: "new" }),
+      ]),
+    );
+    const diff = computeInspectionDiff(prev, current);
+    const names = diff.toolChanges.map((c) => `${c.type}:${c.name}`);
+    expect(names).toEqual([
+      "added:add_a",
+      "added:add_b",
+      "changed:change_a",
+      "changed:change_b",
+      "removed:remove_a",
+      "removed:remove_b",
+    ]);
+  });
+});
+
+// ── hasMeaningfulChanges ─────────────────────────────────────────────
+
+describe("hasMeaningfulChanges", () => {
+  it("returns false for empty diff", () => {
+    expect(
+      hasMeaningfulChanges({
+        initChanges: [],
+        toolChanges: [],
+        computedAt: Date.now(),
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when init changes exist", () => {
+    expect(
+      hasMeaningfulChanges({
+        initChanges: [{ field: "protocolVersion", before: "1", after: "2" }],
+        toolChanges: [],
+        computedAt: Date.now(),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when tool changes exist", () => {
+    expect(
+      hasMeaningfulChanges({
+        initChanges: [],
+        toolChanges: [{ type: "added", name: "t" }],
+        computedAt: Date.now(),
+      }),
+    ).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/inspection/__tests__/diff-summary.test.ts
+++ b/mcpjam-inspector/client/src/lib/inspection/__tests__/diff-summary.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import type { ServerInspectionDiff } from "../types";
+import { formatDiffSummary } from "../diff-summary";
+
+function makeDiff(
+  overrides: Partial<ServerInspectionDiff> = {},
+): ServerInspectionDiff {
+  return {
+    initChanges: [],
+    toolChanges: [],
+    computedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("formatDiffSummary", () => {
+  it("returns empty string for empty diff", () => {
+    expect(formatDiffSummary(makeDiff())).toBe("");
+  });
+
+  it("formats singular tool added", () => {
+    expect(
+      formatDiffSummary(
+        makeDiff({ toolChanges: [{ type: "added", name: "t" }] }),
+      ),
+    ).toBe("1 tool added");
+  });
+
+  it("formats plural tools added", () => {
+    expect(
+      formatDiffSummary(
+        makeDiff({
+          toolChanges: [
+            { type: "added", name: "a" },
+            { type: "added", name: "b" },
+          ],
+        }),
+      ),
+    ).toBe("2 tools added");
+  });
+
+  it("formats removed tools", () => {
+    expect(
+      formatDiffSummary(
+        makeDiff({ toolChanges: [{ type: "removed", name: "t" }] }),
+      ),
+    ).toBe("1 tool removed");
+  });
+
+  it("formats changed tools", () => {
+    expect(
+      formatDiffSummary(
+        makeDiff({
+          toolChanges: [
+            { type: "changed", name: "a", changedFields: ["description"] },
+            { type: "changed", name: "b", changedFields: ["inputSchema"] },
+          ],
+        }),
+      ),
+    ).toBe("2 tools changed");
+  });
+
+  it("formats init changes with field names", () => {
+    expect(
+      formatDiffSummary(
+        makeDiff({
+          initChanges: [
+            { field: "instructions", before: "a", after: "b" },
+          ],
+        }),
+      ),
+    ).toBe("instructions updated");
+  });
+
+  it("formats multiple init changes", () => {
+    expect(
+      formatDiffSummary(
+        makeDiff({
+          initChanges: [
+            { field: "protocolVersion", before: "1", after: "2" },
+            { field: "serverCapabilities", before: {}, after: { tools: {} } },
+          ],
+        }),
+      ),
+    ).toBe("protocol version, capabilities updated");
+  });
+
+  it("combines tool and init changes", () => {
+    const result = formatDiffSummary(
+      makeDiff({
+        toolChanges: [
+          { type: "added", name: "a" },
+          { type: "added", name: "b" },
+          { type: "removed", name: "c" },
+          { type: "changed", name: "d", changedFields: ["description"] },
+        ],
+        initChanges: [
+          { field: "instructions", before: "old", after: "new" },
+        ],
+      }),
+    );
+    expect(result).toBe(
+      "2 tools added, 1 tool removed, 1 tool changed, instructions updated",
+    );
+  });
+
+  it("formats only init changes", () => {
+    expect(
+      formatDiffSummary(
+        makeDiff({
+          initChanges: [
+            { field: "transport", before: "stdio", after: "http" },
+          ],
+        }),
+      ),
+    ).toBe("transport updated");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/inspection/__tests__/diff-summary.test.ts
+++ b/mcpjam-inspector/client/src/lib/inspection/__tests__/diff-summary.test.ts
@@ -64,9 +64,7 @@ describe("formatDiffSummary", () => {
     expect(
       formatDiffSummary(
         makeDiff({
-          initChanges: [
-            { field: "instructions", before: "a", after: "b" },
-          ],
+          initChanges: [{ field: "instructions", before: "a", after: "b" }],
         }),
       ),
     ).toBe("instructions updated");
@@ -94,9 +92,7 @@ describe("formatDiffSummary", () => {
           { type: "removed", name: "c" },
           { type: "changed", name: "d", changedFields: ["description"] },
         ],
-        initChanges: [
-          { field: "instructions", before: "old", after: "new" },
-        ],
+        initChanges: [{ field: "instructions", before: "old", after: "new" }],
       }),
     );
     expect(result).toBe(
@@ -108,9 +104,7 @@ describe("formatDiffSummary", () => {
     expect(
       formatDiffSummary(
         makeDiff({
-          initChanges: [
-            { field: "transport", before: "stdio", after: "http" },
-          ],
+          initChanges: [{ field: "transport", before: "stdio", after: "http" }],
         }),
       ),
     ).toBe("transport updated");

--- a/mcpjam-inspector/client/src/lib/inspection/__tests__/inspection-detail-request.test.ts
+++ b/mcpjam-inspector/client/src/lib/inspection/__tests__/inspection-detail-request.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  writeInspectionDetailRequest,
+  readInspectionDetailRequest,
+  clearInspectionDetailRequest,
+} from "@/lib/inspection-detail-request";
+
+describe("inspection-detail-request", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("write/read lifecycle works", () => {
+    writeInspectionDetailRequest("my-server");
+    const request = readInspectionDetailRequest();
+    expect(request).not.toBeNull();
+    expect(request!.serverName).toBe("my-server");
+    expect(typeof request!.createdAt).toBe("number");
+  });
+
+  it("read returns null when nothing written", () => {
+    expect(readInspectionDetailRequest()).toBeNull();
+  });
+
+  it("clear removes the request", () => {
+    writeInspectionDetailRequest("my-server");
+    clearInspectionDetailRequest();
+    expect(readInspectionDetailRequest()).toBeNull();
+  });
+
+  it("returns null for stale requests (> 5 min TTL)", () => {
+    writeInspectionDetailRequest("my-server");
+    // Manually set createdAt to 6 minutes ago
+    const raw = localStorage.getItem("mcp-inspection-detail-request");
+    const parsed = JSON.parse(raw!);
+    parsed.createdAt = Date.now() - 6 * 60 * 1000;
+    localStorage.setItem(
+      "mcp-inspection-detail-request",
+      JSON.stringify(parsed),
+    );
+
+    expect(readInspectionDetailRequest()).toBeNull();
+    // Stale entry should be auto-cleared
+    expect(localStorage.getItem("mcp-inspection-detail-request")).toBeNull();
+  });
+
+  it("returns null and clears invalid JSON", () => {
+    localStorage.setItem("mcp-inspection-detail-request", "not-json");
+    expect(readInspectionDetailRequest()).toBeNull();
+    expect(localStorage.getItem("mcp-inspection-detail-request")).toBeNull();
+  });
+
+  it("returns null and clears malformed data", () => {
+    localStorage.setItem(
+      "mcp-inspection-detail-request",
+      JSON.stringify({ wrong: "shape" }),
+    );
+    expect(readInspectionDetailRequest()).toBeNull();
+    expect(localStorage.getItem("mcp-inspection-detail-request")).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/inspection/diff-engine.ts
+++ b/mcpjam-inspector/client/src/lib/inspection/diff-engine.ts
@@ -64,8 +64,8 @@ export function normalizeToolSnapshot(
   tool: Tool,
   externalMetadata?: Record<string, unknown>,
 ): NormalizedToolSnapshot {
-  const merged = (tool._meta as Record<string, unknown> | undefined) ??
-    externalMetadata;
+  const merged =
+    (tool._meta as Record<string, unknown> | undefined) ?? externalMetadata;
   const snapshot: NormalizedToolSnapshot = { name: tool.name };
 
   if (tool.description !== undefined) snapshot.description = tool.description;
@@ -102,7 +102,8 @@ export function normalizeInitSnapshot(
         : {}),
     };
   }
-  if (info.instructions !== undefined) snapshot.instructions = info.instructions;
+  if (info.instructions !== undefined)
+    snapshot.instructions = info.instructions;
   if (info.serverCapabilities !== undefined)
     snapshot.serverCapabilities = info.serverCapabilities;
 
@@ -123,7 +124,10 @@ export function buildSnapshot(
 ): ServerInspectionSnapshot {
   const toolsMetadata = toolsResult.toolsMetadata ?? {};
   const tools = (toolsResult.tools ?? []).map((tool: Tool) =>
-    normalizeToolSnapshot(tool, toolsMetadata[tool.name] as Record<string, unknown> | undefined),
+    normalizeToolSnapshot(
+      tool,
+      toolsMetadata[tool.name] as Record<string, unknown> | undefined,
+    ),
   );
 
   // Sort tools by name for deterministic ordering

--- a/mcpjam-inspector/client/src/lib/inspection/diff-engine.ts
+++ b/mcpjam-inspector/client/src/lib/inspection/diff-engine.ts
@@ -1,0 +1,237 @@
+/**
+ * Pure, side-effect-free diff engine for MCP server inspection snapshots.
+ *
+ * All functions are deterministic — same inputs always produce same outputs.
+ * Object key ordering is normalized via stableStringify to avoid false diffs.
+ */
+
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { InitializationInfo } from "@/state/app-types";
+import type { ListToolsResultWithMetadata } from "@/lib/apis/mcp-tools-api";
+import type {
+  NormalizedToolSnapshot,
+  NormalizedInitSnapshot,
+  ServerInspectionSnapshot,
+  ServerInspectionDiff,
+  InitChange,
+  ToolChange,
+} from "./types";
+
+// ── Stable Serialization ─────────────────────────────────────────────
+
+/**
+ * Deterministic JSON.stringify with recursively sorted keys.
+ * Produces identical output regardless of object key insertion order.
+ */
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (val !== null && typeof val === "object" && !Array.isArray(val)) {
+      return Object.keys(val)
+        .sort()
+        .reduce<Record<string, unknown>>((sorted, k) => {
+          sorted[k] = (val as Record<string, unknown>)[k];
+          return sorted;
+        }, {});
+    }
+    return val;
+  });
+}
+
+/**
+ * Deep-equal comparison using stable serialization.
+ */
+function deepEqual(a: unknown, b: unknown): boolean {
+  return stableStringify(a) === stableStringify(b);
+}
+
+/**
+ * Stable-sort the keys of an object recursively so stored snapshots
+ * are deterministic.
+ */
+function stabilize<T>(value: T): T {
+  return JSON.parse(stableStringify(value)) as T;
+}
+
+// ── Normalization ────────────────────────────────────────────────────
+
+/**
+ * Normalize a raw MCP Tool into a snapshot-safe shape.
+ *
+ * Merges metadata via `tool._meta ?? externalMetadata` to match the
+ * existing UI behavior in ServerInfoToolsMetadataContent.
+ */
+export function normalizeToolSnapshot(
+  tool: Tool,
+  externalMetadata?: Record<string, unknown>,
+): NormalizedToolSnapshot {
+  const merged = (tool._meta as Record<string, unknown> | undefined) ??
+    externalMetadata;
+  const snapshot: NormalizedToolSnapshot = { name: tool.name };
+
+  if (tool.description !== undefined) snapshot.description = tool.description;
+  if (tool.inputSchema !== undefined)
+    snapshot.inputSchema = tool.inputSchema as object;
+  if ((tool as any).outputSchema !== undefined)
+    snapshot.outputSchema = (tool as any).outputSchema as object;
+  if (tool.annotations !== undefined)
+    snapshot.annotations = tool.annotations as object;
+  if (merged !== undefined) snapshot.metadata = merged;
+
+  return stabilize(snapshot);
+}
+
+/**
+ * Normalize server-facing initialization info.
+ * Explicitly excludes `clientCapabilities` — that reflects the client
+ * profile, not server behavior.
+ */
+export function normalizeInitSnapshot(
+  info: InitializationInfo,
+): NormalizedInitSnapshot {
+  const snapshot: NormalizedInitSnapshot = {};
+
+  if (info.protocolVersion !== undefined)
+    snapshot.protocolVersion = info.protocolVersion;
+  if (info.transport !== undefined) snapshot.transport = info.transport;
+  if (info.serverVersion !== undefined) {
+    snapshot.serverVersion = {
+      name: info.serverVersion.name,
+      version: info.serverVersion.version,
+      ...(info.serverVersion.title !== undefined
+        ? { title: info.serverVersion.title }
+        : {}),
+    };
+  }
+  if (info.instructions !== undefined) snapshot.instructions = info.instructions;
+  if (info.serverCapabilities !== undefined)
+    snapshot.serverCapabilities = info.serverCapabilities;
+
+  // clientCapabilities is intentionally excluded
+
+  return stabilize(snapshot);
+}
+
+/**
+ * Build a full inspection snapshot from init info and the tools/list result.
+ *
+ * Accepts `ListToolsResultWithMetadata` so it can merge the separate
+ * `toolsMetadata` record into each tool's normalized snapshot.
+ */
+export function buildSnapshot(
+  init: InitializationInfo,
+  toolsResult: ListToolsResultWithMetadata,
+): ServerInspectionSnapshot {
+  const toolsMetadata = toolsResult.toolsMetadata ?? {};
+  const tools = (toolsResult.tools ?? []).map((tool: Tool) =>
+    normalizeToolSnapshot(tool, toolsMetadata[tool.name] as Record<string, unknown> | undefined),
+  );
+
+  // Sort tools by name for deterministic ordering
+  tools.sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    init: normalizeInitSnapshot(init),
+    tools,
+    capturedAt: Date.now(),
+  };
+}
+
+// ── Diff Computation ─────────────────────────────────────────────────
+
+/** Fields compared on each NormalizedToolSnapshot. */
+const TOOL_DIFF_FIELDS: (keyof NormalizedToolSnapshot)[] = [
+  "description",
+  "inputSchema",
+  "outputSchema",
+  "annotations",
+  "metadata",
+];
+
+/** Fields compared on NormalizedInitSnapshot. */
+const INIT_DIFF_FIELDS: (keyof NormalizedInitSnapshot)[] = [
+  "protocolVersion",
+  "transport",
+  "serverVersion",
+  "instructions",
+  "serverCapabilities",
+];
+
+/**
+ * Compute a semantic diff between two inspection snapshots.
+ *
+ * For tools: detects added, removed, and changed tools, listing which
+ * fields changed for each modified tool.
+ *
+ * For init: detects field-level changes for all server-facing fields.
+ */
+export function computeInspectionDiff(
+  prev: ServerInspectionSnapshot,
+  current: ServerInspectionSnapshot,
+): ServerInspectionDiff {
+  // ── Init changes ─────────────────────────────────────────────────
+  const initChanges: InitChange[] = [];
+  for (const field of INIT_DIFF_FIELDS) {
+    const before = prev.init[field];
+    const after = current.init[field];
+    if (!deepEqual(before, after)) {
+      initChanges.push({ field, before, after });
+    }
+  }
+
+  // ── Tool changes ─────────────────────────────────────────────────
+  const prevByName = new Map(prev.tools.map((t) => [t.name, t]));
+  const currentByName = new Map(current.tools.map((t) => [t.name, t]));
+  const toolChanges: ToolChange[] = [];
+
+  // Added tools (in current but not in prev)
+  for (const [name, after] of currentByName) {
+    if (!prevByName.has(name)) {
+      toolChanges.push({ type: "added", name, after });
+    }
+  }
+
+  // Removed tools (in prev but not in current)
+  for (const [name, before] of prevByName) {
+    if (!currentByName.has(name)) {
+      toolChanges.push({ type: "removed", name, before });
+    }
+  }
+
+  // Changed tools (in both, but with field differences)
+  for (const [name, after] of currentByName) {
+    const before = prevByName.get(name);
+    if (!before) continue;
+
+    const changedFields: string[] = [];
+    for (const field of TOOL_DIFF_FIELDS) {
+      if (!deepEqual(before[field], after[field])) {
+        changedFields.push(field);
+      }
+    }
+
+    if (changedFields.length > 0) {
+      toolChanges.push({ type: "changed", name, before, after, changedFields });
+    }
+  }
+
+  // Sort tool changes: added first, then changed, then removed, alpha within each
+  toolChanges.sort((a, b) => {
+    const order = { added: 0, changed: 1, removed: 2 };
+    const typeCompare = order[a.type] - order[b.type];
+    if (typeCompare !== 0) return typeCompare;
+    return a.name.localeCompare(b.name);
+  });
+
+  return {
+    initChanges,
+    toolChanges,
+    computedAt: Date.now(),
+  };
+}
+
+/**
+ * Returns true if the diff contains at least one meaningful change.
+ */
+export function hasMeaningfulChanges(diff: ServerInspectionDiff): boolean {
+  return diff.initChanges.length > 0 || diff.toolChanges.length > 0;
+}

--- a/mcpjam-inspector/client/src/lib/inspection/diff-summary.ts
+++ b/mcpjam-inspector/client/src/lib/inspection/diff-summary.ts
@@ -1,0 +1,49 @@
+/**
+ * Human-readable summary text for an inspection diff.
+ */
+
+import type { ServerInspectionDiff } from "./types";
+
+/**
+ * Format a diff into a scannable one-line summary like:
+ * "2 tools added, 1 tool changed, instructions updated"
+ */
+export function formatDiffSummary(diff: ServerInspectionDiff): string {
+  const parts: string[] = [];
+
+  // Tool change counts
+  const added = diff.toolChanges.filter((c) => c.type === "added").length;
+  const removed = diff.toolChanges.filter((c) => c.type === "removed").length;
+  const changed = diff.toolChanges.filter((c) => c.type === "changed").length;
+
+  if (added > 0) parts.push(`${added} tool${added === 1 ? "" : "s"} added`);
+  if (removed > 0)
+    parts.push(`${removed} tool${removed === 1 ? "" : "s"} removed`);
+  if (changed > 0)
+    parts.push(`${changed} tool${changed === 1 ? "" : "s"} changed`);
+
+  // Init changes — list the specific fields
+  if (diff.initChanges.length > 0) {
+    const fields = diff.initChanges.map((c) => formatInitFieldName(c.field));
+    parts.push(fields.join(", ") + " updated");
+  }
+
+  return parts.join(", ");
+}
+
+function formatInitFieldName(field: string): string {
+  switch (field) {
+    case "protocolVersion":
+      return "protocol version";
+    case "transport":
+      return "transport";
+    case "serverVersion":
+      return "server version";
+    case "instructions":
+      return "instructions";
+    case "serverCapabilities":
+      return "capabilities";
+    default:
+      return field;
+  }
+}

--- a/mcpjam-inspector/client/src/lib/inspection/types.ts
+++ b/mcpjam-inspector/client/src/lib/inspection/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Types for MCP server inspection snapshots and diffs.
+ *
+ * These types are used entirely within the inspector client — no backend
+ * schema or Convex types are involved.
+ */
+
+// ── Normalized Snapshots ─────────────────────────────────────────────
+
+export interface NormalizedToolSnapshot {
+  name: string;
+  description?: string;
+  inputSchema?: object;
+  outputSchema?: object;
+  annotations?: object;
+  /** Merged metadata: tool._meta ?? toolsMetadata[tool.name] */
+  metadata?: Record<string, unknown>;
+}
+
+export interface NormalizedInitSnapshot {
+  protocolVersion?: string;
+  transport?: string;
+  serverVersion?: { name: string; version: string; title?: string };
+  instructions?: string;
+  serverCapabilities?: Record<string, unknown>;
+}
+
+export interface ServerInspectionSnapshot {
+  init: NormalizedInitSnapshot;
+  tools: NormalizedToolSnapshot[];
+  capturedAt: number;
+}
+
+// ── Diff Results ─────────────────────────────────────────────────────
+
+export interface InitChange {
+  field: string;
+  before: unknown;
+  after: unknown;
+}
+
+export interface ToolChange {
+  type: "added" | "removed" | "changed";
+  name: string;
+  before?: NormalizedToolSnapshot;
+  after?: NormalizedToolSnapshot;
+  changedFields?: string[];
+}
+
+export interface ServerInspectionDiff {
+  initChanges: InitChange[];
+  toolChanges: ToolChange[];
+  computedAt: number;
+}
+
+// ── Storage Record ───────────────────────────────────────────────────
+
+export interface ServerInspectionRecord {
+  latestSnapshot: ServerInspectionSnapshot;
+  latestDiff: ServerInspectionDiff | null;
+}

--- a/mcpjam-inspector/client/src/stores/__tests__/inspection-store.test.ts
+++ b/mcpjam-inspector/client/src/stores/__tests__/inspection-store.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useInspectionStore, inspectionStoreKey } from "../inspection-store";
+import type {
+  ServerInspectionSnapshot,
+  ServerInspectionDiff,
+} from "@/lib/inspection/types";
+
+function makeSnapshot(
+  overrides: Partial<ServerInspectionSnapshot> = {},
+): ServerInspectionSnapshot {
+  return {
+    init: { protocolVersion: "2025-03-26" },
+    tools: [],
+    capturedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function makeDiff(
+  overrides: Partial<ServerInspectionDiff> = {},
+): ServerInspectionDiff {
+  return {
+    initChanges: [],
+    toolChanges: [{ type: "added", name: "new_tool" }],
+    computedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("inspection-store", () => {
+  beforeEach(() => {
+    // Reset the store to clean state
+    useInspectionStore.setState({ records: {} });
+  });
+
+  describe("inspectionStoreKey", () => {
+    it("formats workspace::server key", () => {
+      expect(inspectionStoreKey("ws1", "my-server")).toBe("ws1::my-server");
+    });
+  });
+
+  describe("saveInspection + getRecord", () => {
+    it("saves and retrieves a record", () => {
+      const key = "ws::server1";
+      const snapshot = makeSnapshot();
+      const diff = makeDiff();
+
+      useInspectionStore.getState().saveInspection(key, snapshot, diff);
+      const record = useInspectionStore.getState().getRecord(key);
+
+      expect(record).toBeDefined();
+      expect(record!.latestSnapshot).toEqual(snapshot);
+      expect(record!.latestDiff).toEqual(diff);
+    });
+
+    it("saves record with null diff (first connect)", () => {
+      const key = "ws::server1";
+      const snapshot = makeSnapshot();
+
+      useInspectionStore.getState().saveInspection(key, snapshot, null);
+      const record = useInspectionStore.getState().getRecord(key);
+
+      expect(record!.latestDiff).toBeNull();
+    });
+
+    it("overwrites previous record for same key", () => {
+      const key = "ws::server1";
+      const snap1 = makeSnapshot({ capturedAt: 1000 });
+      const snap2 = makeSnapshot({ capturedAt: 2000 });
+
+      useInspectionStore.getState().saveInspection(key, snap1, null);
+      useInspectionStore.getState().saveInspection(key, snap2, makeDiff());
+
+      const record = useInspectionStore.getState().getRecord(key);
+      expect(record!.latestSnapshot.capturedAt).toBe(2000);
+      expect(record!.latestDiff).not.toBeNull();
+    });
+
+    it("returns undefined for unknown key", () => {
+      expect(useInspectionStore.getState().getRecord("nope")).toBeUndefined();
+    });
+  });
+
+  describe("clearForServer", () => {
+    it("removes the record for a specific key", () => {
+      const key = "ws::server1";
+      useInspectionStore.getState().saveInspection(key, makeSnapshot(), null);
+      expect(useInspectionStore.getState().getRecord(key)).toBeDefined();
+
+      useInspectionStore.getState().clearForServer(key);
+      expect(useInspectionStore.getState().getRecord(key)).toBeUndefined();
+    });
+
+    it("does not affect other keys", () => {
+      const key1 = "ws::s1";
+      const key2 = "ws::s2";
+      useInspectionStore.getState().saveInspection(key1, makeSnapshot(), null);
+      useInspectionStore.getState().saveInspection(key2, makeSnapshot(), null);
+
+      useInspectionStore.getState().clearForServer(key1);
+      expect(useInspectionStore.getState().getRecord(key1)).toBeUndefined();
+      expect(useInspectionStore.getState().getRecord(key2)).toBeDefined();
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/stores/inspection-store.ts
+++ b/mcpjam-inspector/client/src/stores/inspection-store.ts
@@ -1,0 +1,65 @@
+/**
+ * Zustand store for MCP server inspection snapshots and diffs.
+ *
+ * Persisted to localStorage under "mcp-inspector-inspections".
+ * Completely separate from AppState / app-reducer — no Convex interaction.
+ *
+ * Keys are "{workspaceId}::{serverName}".
+ * Each key maps to one atomic record containing both the latest snapshot
+ * and the latest diff (or null if this is the first connect).
+ */
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type {
+  ServerInspectionRecord,
+  ServerInspectionSnapshot,
+  ServerInspectionDiff,
+} from "@/lib/inspection/types";
+
+export interface InspectionStoreState {
+  records: Record<string, ServerInspectionRecord>;
+
+  saveInspection: (
+    key: string,
+    snapshot: ServerInspectionSnapshot,
+    diff: ServerInspectionDiff | null,
+  ) => void;
+  getRecord: (key: string) => ServerInspectionRecord | undefined;
+  clearForServer: (key: string) => void;
+}
+
+export function inspectionStoreKey(
+  workspaceId: string,
+  serverName: string,
+): string {
+  return `${workspaceId}::${serverName}`;
+}
+
+export const useInspectionStore = create<InspectionStoreState>()(
+  persist(
+    (set, get) => ({
+      records: {},
+
+      saveInspection: (key, snapshot, diff) =>
+        set((state) => ({
+          records: {
+            ...state.records,
+            [key]: { latestSnapshot: snapshot, latestDiff: diff },
+          },
+        })),
+
+      getRecord: (key) => get().records[key],
+
+      clearForServer: (key) =>
+        set((state) => {
+          const { [key]: _, ...rest } = state.records;
+          return { records: rest };
+        }),
+    }),
+    {
+      name: "mcp-inspector-inspections",
+      version: 1,
+    },
+  ),
+);


### PR DESCRIPTION
## Summary

Implements a complete server inspection system that captures MCP server snapshots on connection and detects meaningful changes between connections. Includes a diff engine, state management, coordinator hook, and UI panel to display changes to users.

## Key Changes

- **Diff Engine** (`diff-engine.ts`): Pure, deterministic functions for normalizing server snapshots, computing diffs, and detecting meaningful changes. Uses stable JSON serialization to handle object key ordering consistently.

- **Inspection Store** (`inspection-store.ts`): Zustand store persisted to localStorage that maintains inspection records keyed by `{workspaceId}::{serverName}`, storing both the latest snapshot and diff.

- **Inspection Coordinator Hook** (`use-inspection-coordinator.ts`): App-level effect hook that monitors all workspace servers for connection transitions, automatically runs the inspection pipeline (snapshot + diff) after successful connects, and shows toast notifications with "View changes" CTA when meaningful changes are detected.

- **Server Changes Panel** (`ServerChangesPanel.tsx`): New UI component that displays a summary of changes since last connect, with collapsible sections for initialization changes and tool changes (added/removed/changed), including side-by-side JSON diffs for complex fields.

- **Supporting Utilities**:
  - `diff-summary.ts`: Formats diffs into human-readable one-line summaries
  - `inspection-detail-request.ts`: localStorage-based request pattern for opening the detail modal from toast CTAs with 5-minute TTL
  - `types.ts`: TypeScript definitions for snapshots, diffs, and related structures

- **Comprehensive Test Coverage**: Added 1000+ lines of tests covering the diff engine, coordinator hook, UI component, store, and utilities with realistic scenarios (pagination, errors, stale requests, etc.)

- **Integration Points**:
  - `App.tsx`: Mounted `useInspectionCoordinator` hook via zero-UI bridge component
  - `ServersTab.tsx`: Consumes inspection detail requests to open detail modal on Overview tab
  - `ServerInfoContent.tsx`: Integrated `ServerChangesPanel` into the Overview tab

## Implementation Details

- **Deterministic Snapshots**: All snapshots are normalized and stabilized with sorted keys to ensure identical diffs regardless of object construction order
- **Safe Async Handling**: Captures workspaceId and serverName before async work, verifies they still match after completion to handle rapid workspace/server changes
- **Incomplete Pagination**: If tool list pagination fails mid-stream, the inspection is skipped and the previous baseline is preserved (no partial diffs)
- **Error Resilience**: Failed inspections never overwrite previous records; only successful complete inspections update state
- **Metadata Merging**: Tool metadata is merged from both `tool._meta` (preferred) and external `toolsMetadata` record, matching existing UI behavior
- **Client-Only**: Entirely client-side inspection system with no backend/Convex involvement; uses localStorage for persistence

https://claude.ai/code/session_01KBjUEbjapGUfujDhE4gYqA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new persisted client-side state plus async inspection/diffing on server connect events; mistakes could lead to noisy toasts, stale localStorage, or incorrect server modal navigation, but it does not touch auth/payment/back-end data paths.
> 
> **Overview**
> Adds a full client-side inspection system that **snapshots MCP server initialization info + tool catalogs on successful connect**, computes deterministic diffs on subsequent connects, and persists the latest snapshot/diff per `{workspaceId}::{serverName}` in a new Zustand `inspection-store` (localStorage-backed).
> 
> When meaningful changes are detected, the app now shows a toast with a **“View changes” CTA**; clicking it writes a short-lived `inspection-detail-request` (TTL) and navigates to `ServersTab`, which consumes the request to open the server detail modal on the Overview tab. The Overview UI is extended with a new `ServerChangesPanel` that summarizes added/removed/changed tools and init-field changes with expandable JSON before/after views, plus extensive new unit tests covering diffing, summary formatting, coordinator behavior, and request/store lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dbfa85e017053e049fcad6ad84a2b045f4fb19a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->