### PR TITLE
Add organization-level model provider configuration

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1594,7 +1594,12 @@ export default function App() {
               onNavigateAway={() => handleNavigate("servers")}
             />
           )}
-          {activeTab === "settings" && <SettingsTab />}
+          {activeTab === "settings" && (
+              <SettingsTab
+                activeOrganizationId={activeOrganizationId}
+                onNavigate={handleNavigate}
+              />
+            )}
           {activeTab === "support" && <SupportTab />}
           {activeTab === "profile" && <ProfileTab />}
           {activeTab === "organizations" && (

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1595,11 +1595,11 @@ export default function App() {
             />
           )}
           {activeTab === "settings" && (
-              <SettingsTab
-                activeOrganizationId={activeOrganizationId}
-                onNavigate={handleNavigate}
-              />
-            )}
+            <SettingsTab
+              activeOrganizationId={activeOrganizationId}
+              onNavigate={handleNavigate}
+            />
+          )}
           {activeTab === "support" && <SupportTab />}
           {activeTab === "profile" && <ProfileTab />}
           {activeTab === "organizations" && (

--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -64,6 +64,7 @@ import { OrganizationAuditLog } from "./organization/OrganizationAuditLog";
 import { OrganizationBillingSection } from "./organization/OrganizationBillingSection";
 import { OrganizationCurrentPlanPanel } from "./organization/OrganizationCurrentPlanPanel";
 import { OrganizationMemberRow } from "./organization/OrganizationMemberRow";
+import { OrganizationModelsSection } from "./organization/OrganizationModelsSection";
 
 interface OrganizationsTabProps {
   organizationId?: string;
@@ -78,9 +79,9 @@ function getOrganizationRouteHash(
   organizationId: string,
   section: OrganizationRouteSection,
 ): string {
-  return section === "billing"
-    ? `organizations/${organizationId}/billing`
-    : `organizations/${organizationId}`;
+  if (section === "billing") return `organizations/${organizationId}/billing`;
+  if (section === "models") return `organizations/${organizationId}/models`;
+  return `organizations/${organizationId}`;
 }
 
 interface PendingPaidUpgradeConfirmation {
@@ -423,8 +424,12 @@ function OrganizationPage({
     "billing-entitlements-ui",
   );
   const billingUiEnabled = billingEntitlementsUiEnabled === true;
-  const activeSection =
-    billingUiEnabled && section === "billing" ? "billing" : "overview";
+  const activeSection: OrganizationRouteSection =
+    section === "models"
+      ? "models"
+      : billingUiEnabled && section === "billing"
+        ? "billing"
+        : "overview";
   const memberInviteGate = resolveBillingGateState({
     billingUiEnabled,
     organizationId: organization._id,
@@ -1079,24 +1084,37 @@ function OrganizationPage({
               </div>
             </div>
           </CardContent>
-          {billingUiEnabled ? (
-            <nav
-              className="flex items-end gap-1 border-t border-border/60 bg-muted/20 px-2 sm:px-5"
-              aria-label="Organization settings sections"
+          <nav
+            className="flex items-end gap-1 border-t border-border/60 bg-muted/20 px-2 sm:px-5"
+            aria-label="Organization settings sections"
+          >
+            <button
+              type="button"
+              onClick={() => navigateToSection("overview")}
+              aria-current={activeSection === "overview" ? "page" : undefined}
+              className={cn(
+                "-mb-px shrink-0 border-b-2 px-3 py-3.5 text-sm font-medium transition-colors sm:px-4",
+                activeSection === "overview"
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground",
+              )}
             >
-              <button
-                type="button"
-                onClick={() => navigateToSection("overview")}
-                aria-current={activeSection === "overview" ? "page" : undefined}
-                className={cn(
-                  "-mb-px shrink-0 border-b-2 px-3 py-3.5 text-sm font-medium transition-colors sm:px-4",
-                  activeSection === "overview"
-                    ? "border-primary text-foreground"
-                    : "border-transparent text-muted-foreground hover:text-foreground",
-                )}
-              >
-                General
-              </button>
+              General
+            </button>
+            <button
+              type="button"
+              onClick={() => navigateToSection("models")}
+              aria-current={activeSection === "models" ? "page" : undefined}
+              className={cn(
+                "-mb-px shrink-0 border-b-2 px-3 py-3.5 text-sm font-medium transition-colors sm:px-4",
+                activeSection === "models"
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground",
+              )}
+            >
+              Models
+            </button>
+            {billingUiEnabled ? (
               <button
                 type="button"
                 onClick={() => navigateToSection("billing")}
@@ -1110,11 +1128,16 @@ function OrganizationPage({
               >
                 Billing
               </button>
-            </nav>
-          ) : null}
+            ) : null}
+          </nav>
         </Card>
 
-        {activeSection === "billing" ? (
+        {activeSection === "models" ? (
+          <OrganizationModelsSection
+            organizationId={organization._id}
+            isAdmin={canEdit}
+          />
+        ) : activeSection === "billing" ? (
           <>
             <OrganizationBillingSection
               billingStatus={billingStatus}

--- a/mcpjam-inspector/client/src/components/SettingsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SettingsTab.tsx
@@ -13,7 +13,7 @@ import { Switch } from "./ui/switch";
 import { Button } from "./ui/button";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { updateThemeMode } from "@/lib/theme-utils";
-import { Plus, Pencil, Trash2 } from "lucide-react";
+import { Plus, Pencil, Trash2, Info } from "lucide-react";
 import { HOSTED_MODE } from "@/lib/config";
 
 import type { CustomProvider } from "@mcpjam/sdk/browser";
@@ -28,7 +28,15 @@ interface ProviderConfig {
   getApiKeyUrl: string;
 }
 
-export function SettingsTab() {
+interface SettingsTabProps {
+  activeOrganizationId?: string;
+  onNavigate?: (section: string) => void;
+}
+
+export function SettingsTab({
+  activeOrganizationId,
+  onNavigate,
+}: SettingsTabProps = {}) {
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const setThemeMode = usePreferencesStore((s) => s.setThemeMode);
   const {
@@ -49,6 +57,10 @@ export function SettingsTab() {
     updateCustomProvider,
     removeCustomProvider,
   } = useCustomProviders();
+
+  // When the user is in an org-backed context, LLM provider configuration is
+  // managed at the organization level, not per-user in local storage.
+  const isOrgBacked = !!activeOrganizationId;
 
   const [editingValue, setEditingValue] = useState("");
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -286,7 +298,31 @@ export function SettingsTab() {
           />
         </SettingsSection>
 
-        {!HOSTED_MODE && (
+        {!HOSTED_MODE && isOrgBacked && (
+          <SettingsSection title="LLM Providers">
+            <div className="flex items-start gap-3 px-4 py-3 rounded-md border border-border/40 bg-muted/30">
+              <Info className="size-4 mt-0.5 shrink-0 text-muted-foreground" />
+              <div className="flex flex-col gap-1">
+                <span className="text-sm text-muted-foreground">
+                  Model providers are managed in your organization settings.
+                </span>
+                <Button
+                  variant="link"
+                  className="h-auto p-0 text-sm justify-start"
+                  onClick={() =>
+                    onNavigate?.(
+                      `organizations/${activeOrganizationId}/models`,
+                    )
+                  }
+                >
+                  Go to Organization Models
+                </Button>
+              </div>
+            </div>
+          </SettingsSection>
+        )}
+
+        {!HOSTED_MODE && !isOrgBacked && (
           <>
             {/* LLM Providers */}
             <SettingsSection title="LLM Providers">

--- a/mcpjam-inspector/client/src/components/SettingsTab.tsx
+++ b/mcpjam-inspector/client/src/components/SettingsTab.tsx
@@ -310,9 +310,7 @@ export function SettingsTab({
                   variant="link"
                   className="h-auto p-0 text-sm justify-start"
                   onClick={() =>
-                    onNavigate?.(
-                      `organizations/${activeOrganizationId}/models`,
-                    )
+                    onNavigate?.(`organizations/${activeOrganizationId}/models`)
                   }
                 >
                   Go to Organization Models

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/model-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/model-helpers.ts
@@ -140,14 +140,16 @@ export function buildAvailableModelsFromOrgConfig(
   const openRouterConfig = orgConfig.providers.find(
     (p) => p.providerKey === "openrouter" && p.enabled && p.hasSecret,
   );
-  if (openRouterConfig?.selectedModels && openRouterConfig.selectedModels.length > 0) {
-    const openRouterModels: ModelDefinition[] = openRouterConfig.selectedModels.map(
-      (id) => ({
+  if (
+    openRouterConfig?.selectedModels &&
+    openRouterConfig.selectedModels.length > 0
+  ) {
+    const openRouterModels: ModelDefinition[] =
+      openRouterConfig.selectedModels.map((id) => ({
         id,
         name: id,
         provider: "openrouter" as const,
-      }),
-    );
+      }));
     models.push(...openRouterModels);
   }
 

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/model-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/model-helpers.ts
@@ -7,6 +7,7 @@ import {
   Model,
 } from "@/shared/types";
 import type { CustomProvider } from "@mcpjam/sdk/browser";
+import type { OrgModelProvider } from "@/hooks/use-org-model-config";
 
 export function parseModelAliases(
   aliasString: string,
@@ -78,6 +79,93 @@ export function buildAvailableModels(params: {
     models = models.concat(ollamaModels);
   if (openRouterModels.length > 0) models = models.concat(openRouterModels);
   if (customModels.length > 0) models = models.concat(customModels);
+  return models;
+}
+
+/**
+ * OrgVisibleConfig shape as returned by the org model config query.
+ */
+export type OrgVisibleConfig = {
+  providers: OrgModelProvider[];
+};
+
+/**
+ * Check whether a given provider key is present and available in the org config.
+ */
+export function isOrgProviderAvailable(
+  orgConfig: OrgVisibleConfig | undefined,
+  providerKey: string,
+): boolean {
+  if (!orgConfig?.providers) return false;
+  return orgConfig.providers.some((p) => {
+    if (p.providerKey !== providerKey) return false;
+    if (!p.enabled) return false;
+    // Ollama only needs baseUrl, not a secret
+    if (p.providerKey === "ollama") return Boolean(p.baseUrl);
+    return p.hasSecret;
+  });
+}
+
+/**
+ * Build the list of available models from an organization's provider config.
+ * Used in org-backed workspaces where the server resolves API keys.
+ */
+export function buildAvailableModelsFromOrgConfig(
+  orgConfig: OrgVisibleConfig | undefined,
+): ModelDefinition[] {
+  if (!orgConfig?.providers) {
+    // No org config loaded yet — return only MCPJam-provided models
+    return SUPPORTED_MODELS.filter((m) => isMCPJamProvidedModel(String(m.id)));
+  }
+
+  // Determine which provider keys are available
+  const availableProviderKeys = new Set<string>();
+  for (const p of orgConfig.providers) {
+    if (!p.enabled) continue;
+    // Ollama only needs baseUrl; all others need hasSecret
+    if (p.providerKey === "ollama") {
+      if (p.baseUrl) availableProviderKeys.add(p.providerKey);
+    } else {
+      if (p.hasSecret) availableProviderKeys.add(p.providerKey);
+    }
+  }
+
+  // Always include MCPJam-provided models
+  const models: ModelDefinition[] = SUPPORTED_MODELS.filter((m) => {
+    if (isMCPJamProvidedModel(String(m.id))) return true;
+    return availableProviderKeys.has(m.provider);
+  });
+
+  // OpenRouter: include selectedModels from org config
+  const openRouterConfig = orgConfig.providers.find(
+    (p) => p.providerKey === "openrouter" && p.enabled && p.hasSecret,
+  );
+  if (openRouterConfig?.selectedModels && openRouterConfig.selectedModels.length > 0) {
+    const openRouterModels: ModelDefinition[] = openRouterConfig.selectedModels.map(
+      (id) => ({
+        id,
+        name: id,
+        provider: "openrouter" as const,
+      }),
+    );
+    models.push(...openRouterModels);
+  }
+
+  // Custom providers (providerKey starts with "custom:")
+  for (const p of orgConfig.providers) {
+    if (!p.providerKey.startsWith("custom:")) continue;
+    if (!p.enabled || !p.hasSecret) continue;
+    const customName = p.displayName || p.providerKey.replace(/^custom:/, "");
+    for (const modelId of p.modelIds ?? []) {
+      models.push({
+        id: `custom:${customName}:${modelId}`,
+        name: modelId,
+        provider: "custom" as const,
+        customProviderName: customName,
+      });
+    }
+  }
+
   return models;
 }
 

--- a/mcpjam-inspector/client/src/components/evals/single-test-case-runner.ts
+++ b/mcpjam-inspector/client/src/components/evals/single-test-case-runner.ts
@@ -165,9 +165,11 @@ export async function prepareSingleTestCaseRun({
     throw new Error("Invalid model selection");
   }
 
+  // When running in an org-backed workspace the server resolves API keys
+  // from the org config, so we skip populating modelApiKeys.
   const modelApiKeys: Record<string, string> = {};
 
-  if (!isMCPJamProvidedModel(model)) {
+  if (!workspaceId && !isMCPJamProvidedModel(model)) {
     const tokenKey = provider.toLowerCase() as keyof ProviderTokens;
     if (!hasToken(tokenKey)) {
       throw new Error(

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -192,18 +192,22 @@ export function useEvalHandlers({
         return null;
       }
 
+      // When running in an org-backed workspace the server resolves API keys
+      // from the org config, so we skip populating modelApiKeys.
       const modelApiKeys: Record<string, string> = {};
-      for (const provider of providersNeeded) {
-        const tokenKey = provider.toLowerCase() as keyof ProviderTokens;
-        if (!hasToken(tokenKey)) {
-          toast.error(
-            `Please add your ${provider} API key in Settings before running evals`,
-          );
-          return null;
-        }
-        const key = getToken(tokenKey);
-        if (key) {
-          modelApiKeys[provider] = key;
+      if (!workspaceId) {
+        for (const provider of providersNeeded) {
+          const tokenKey = provider.toLowerCase() as keyof ProviderTokens;
+          if (!hasToken(tokenKey)) {
+            toast.error(
+              `Please add your ${provider} API key in Settings before running evals`,
+            );
+            return null;
+          }
+          const key = getToken(tokenKey);
+          if (key) {
+            modelApiKeys[provider] = key;
+          }
         }
       }
 
@@ -215,7 +219,7 @@ export function useEvalHandlers({
         providersNeeded,
       };
     },
-    [getTestCasesForRerun, getToken, hasToken],
+    [getTestCasesForRerun, getToken, hasToken, workspaceId],
   );
 
   const handleReplayRun = useCallback(

--- a/mcpjam-inspector/client/src/components/organization/OrganizationModelsSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationModelsSection.tsx
@@ -62,15 +62,50 @@ interface ProviderCatalogEntry {
 }
 
 const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
-  { key: "openai", name: "OpenAI", kind: "api-key-only", logo: "/openai_logo.svg" },
-  { key: "anthropic", name: "Anthropic", kind: "api-key-only", logo: "/anthropic_logo.svg" },
-  { key: "google", name: "Google", kind: "api-key-only", logo: "/google_logo.svg" },
-  { key: "deepseek", name: "DeepSeek", kind: "api-key-only", logo: "/deepseek_logo.svg" },
-  { key: "mistral", name: "Mistral", kind: "api-key-only", logo: "/mistral_logo.svg" },
+  {
+    key: "openai",
+    name: "OpenAI",
+    kind: "api-key-only",
+    logo: "/openai_logo.svg",
+  },
+  {
+    key: "anthropic",
+    name: "Anthropic",
+    kind: "api-key-only",
+    logo: "/anthropic_logo.svg",
+  },
+  {
+    key: "google",
+    name: "Google",
+    kind: "api-key-only",
+    logo: "/google_logo.svg",
+  },
+  {
+    key: "deepseek",
+    name: "DeepSeek",
+    kind: "api-key-only",
+    logo: "/deepseek_logo.svg",
+  },
+  {
+    key: "mistral",
+    name: "Mistral",
+    kind: "api-key-only",
+    logo: "/mistral_logo.svg",
+  },
   { key: "xai", name: "xAI", kind: "api-key-only", logo: "/xai_logo.svg" },
-  { key: "azure", name: "Azure OpenAI", kind: "azure", logo: "/azure_logo.png" },
+  {
+    key: "azure",
+    name: "Azure OpenAI",
+    kind: "azure",
+    logo: "/azure_logo.png",
+  },
   { key: "ollama", name: "Ollama", kind: "ollama", logo: "/ollama_logo.svg" },
-  { key: "openrouter", name: "OpenRouter", kind: "openrouter", logo: "/openrouter_logo.png" },
+  {
+    key: "openrouter",
+    name: "OpenRouter",
+    kind: "openrouter",
+    logo: "/openrouter_logo.png",
+  },
 ];
 
 function findCatalogEntry(key: string): ProviderCatalogEntry | undefined {
@@ -237,11 +272,7 @@ export function OrganizationModelsSection({
 
               {isAdmin ? (
                 <div className="pt-3">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={openAddCustom}
-                  >
+                  <Button variant="outline" size="sm" onClick={openAddCustom}>
                     <Plus className="mr-2 size-4" />
                     Add Custom Provider
                   </Button>
@@ -270,9 +301,7 @@ export function OrganizationModelsSection({
               setConfigTarget(null);
             } catch (err) {
               toast.error(
-                err instanceof Error
-                  ? err.message
-                  : "Failed to save provider",
+                err instanceof Error ? err.message : "Failed to save provider",
               );
             }
           }}
@@ -408,7 +437,10 @@ function ProviderRow({
             Configured
           </Badge>
         ) : (
-          <Badge variant="outline" className="gap-1 text-xs text-muted-foreground">
+          <Badge
+            variant="outline"
+            className="gap-1 text-xs text-muted-foreground"
+          >
             <Circle className="size-3" />
             Not configured
           </Badge>
@@ -511,7 +543,9 @@ function KnownProviderConfigDialog({
       case "ollama":
         return !!baseUrl.trim();
       case "openrouter":
-        return (!!secret.trim() || existing?.hasSecret) && !!selectedModels.trim();
+        return (
+          (!!secret.trim() || existing?.hasSecret) && !!selectedModels.trim()
+        );
       default:
         return false;
     }
@@ -546,7 +580,10 @@ function KnownProviderConfigDialog({
           {/* API key field -- all except ollama */}
           {kind !== "ollama" ? (
             <div>
-              <label htmlFor="org-provider-secret" className="text-sm font-medium">
+              <label
+                htmlFor="org-provider-secret"
+                className="text-sm font-medium"
+              >
                 API Key
                 {existing?.hasSecret ? (
                   <span className="text-muted-foreground font-normal ml-1">
@@ -566,7 +603,7 @@ function KnownProviderConfigDialog({
           ) : null}
 
           {/* Base URL field -- azure, ollama */}
-          {(kind === "azure" || kind === "ollama") ? (
+          {kind === "azure" || kind === "ollama" ? (
             <div>
               <label htmlFor="org-provider-url" className="text-sm font-medium">
                 Base URL
@@ -795,7 +832,9 @@ function OrgCustomProviderDialog({
             <label htmlFor="org-cp-secret" className="text-sm font-medium">
               API Key{" "}
               <span className="text-muted-foreground font-normal">
-                (optional{editProvider?.hasSecret ? ", leave blank to keep current" : ""})
+                (optional
+                {editProvider?.hasSecret ? ", leave blank to keep current" : ""}
+                )
               </span>
             </label>
             <Input

--- a/mcpjam-inspector/client/src/components/organization/OrganizationModelsSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationModelsSection.tsx
@@ -1,0 +1,848 @@
+import { useEffect, useState } from "react";
+import {
+  CheckCircle2,
+  Circle,
+  Loader2,
+  Pencil,
+  Plus,
+  Settings2,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  useOrgModelConfig,
+  type OrgModelProvider,
+} from "@/hooks/use-org-model-config";
+
+// ---------------------------------------------------------------------------
+// Provider catalog -- defines known providers and their configuration fields
+// ---------------------------------------------------------------------------
+
+type ProviderKind =
+  | "api-key-only"
+  | "azure"
+  | "ollama"
+  | "openrouter"
+  | "custom";
+
+interface ProviderCatalogEntry {
+  key: string;
+  name: string;
+  kind: ProviderKind;
+  logo?: string;
+}
+
+const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
+  { key: "openai", name: "OpenAI", kind: "api-key-only", logo: "/openai_logo.svg" },
+  { key: "anthropic", name: "Anthropic", kind: "api-key-only", logo: "/anthropic_logo.svg" },
+  { key: "google", name: "Google", kind: "api-key-only", logo: "/google_logo.svg" },
+  { key: "deepseek", name: "DeepSeek", kind: "api-key-only", logo: "/deepseek_logo.svg" },
+  { key: "mistral", name: "Mistral", kind: "api-key-only", logo: "/mistral_logo.svg" },
+  { key: "xai", name: "xAI", kind: "api-key-only", logo: "/xai_logo.svg" },
+  { key: "azure", name: "Azure OpenAI", kind: "azure", logo: "/azure_logo.png" },
+  { key: "ollama", name: "Ollama", kind: "ollama", logo: "/ollama_logo.svg" },
+  { key: "openrouter", name: "OpenRouter", kind: "openrouter", logo: "/openrouter_logo.png" },
+];
+
+function findCatalogEntry(key: string): ProviderCatalogEntry | undefined {
+  return PROVIDER_CATALOG.find((p) => p.key === key);
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface OrganizationModelsSectionProps {
+  organizationId: string;
+  isAdmin: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function OrganizationModelsSection({
+  organizationId,
+  isAdmin,
+}: OrganizationModelsSectionProps) {
+  const { providers, isLoading, upsertProvider, deleteProvider, isSaving } =
+    useOrgModelConfig(organizationId);
+
+  // Dialog state
+  const [configDialogOpen, setConfigDialogOpen] = useState(false);
+  const [configTarget, setConfigTarget] = useState<{
+    providerKey: string;
+    kind: ProviderKind;
+    name: string;
+    existing?: OrgModelProvider;
+  } | null>(null);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<{
+    providerKey: string;
+    name: string;
+  } | null>(null);
+  const [customDialogOpen, setCustomDialogOpen] = useState(false);
+  const [editingCustom, setEditingCustom] = useState<OrgModelProvider | null>(
+    null,
+  );
+
+  // -----------------------------------------------------------------------
+  // Handlers
+  // -----------------------------------------------------------------------
+
+  const openConfigDialog = (
+    entry: ProviderCatalogEntry,
+    existing?: OrgModelProvider,
+  ) => {
+    setConfigTarget({
+      providerKey: entry.key,
+      kind: entry.kind,
+      name: entry.name,
+      existing,
+    });
+    setConfigDialogOpen(true);
+  };
+
+  const openDeleteConfirm = (providerKey: string, name: string) => {
+    setDeleteTarget({ providerKey, name });
+    setDeleteConfirmOpen(true);
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    try {
+      await deleteProvider(deleteTarget.providerKey);
+      toast.success(`${deleteTarget.name} removed`);
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to remove provider",
+      );
+    } finally {
+      setDeleteConfirmOpen(false);
+      setDeleteTarget(null);
+    }
+  };
+
+  const openAddCustom = () => {
+    setEditingCustom(null);
+    setCustomDialogOpen(true);
+  };
+
+  const openEditCustom = (provider: OrgModelProvider) => {
+    setEditingCustom(provider);
+    setCustomDialogOpen(true);
+  };
+
+  // -----------------------------------------------------------------------
+  // Derived data
+  // -----------------------------------------------------------------------
+
+  // Merge catalog with actual server data so we always show all known
+  // providers and any extra custom providers returned from the server.
+  const providerMap = new Map<string, OrgModelProvider>();
+  providers?.forEach((p) => providerMap.set(p.providerKey, p));
+
+  const knownProviderKeys = new Set(PROVIDER_CATALOG.map((c) => c.key));
+  const customProviders =
+    providers?.filter((p) => !knownProviderKeys.has(p.providerKey)) ?? [];
+
+  // -----------------------------------------------------------------------
+  // Render
+  // -----------------------------------------------------------------------
+
+  return (
+    <>
+      <Card className="border-border/60">
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-xl">
+            <Settings2 className="size-4 text-muted-foreground" />
+            Model Providers
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            {isAdmin
+              ? "Configure AI model providers for your organization. API keys are stored securely and shared with all members."
+              : "View which AI model providers are configured for your organization."}
+          </p>
+        </CardHeader>
+
+        <CardContent className="space-y-1 pt-0">
+          {isLoading ? (
+            <div className="flex items-center gap-2 py-4 text-muted-foreground">
+              <Loader2 className="size-4 animate-spin" />
+              Loading providers...
+            </div>
+          ) : (
+            <>
+              {PROVIDER_CATALOG.map((entry) => {
+                const provider = providerMap.get(entry.key);
+                const configured = !!provider?.hasSecret || !!provider?.baseUrl;
+                return (
+                  <ProviderRow
+                    key={entry.key}
+                    name={entry.name}
+                    logo={entry.logo}
+                    configured={configured}
+                    isAdmin={isAdmin}
+                    onConfigure={() => openConfigDialog(entry, provider)}
+                    onRemove={() => openDeleteConfirm(entry.key, entry.name)}
+                  />
+                );
+              })}
+
+              {customProviders.map((cp) => (
+                <ProviderRow
+                  key={cp.providerKey}
+                  name={cp.displayName || cp.providerKey}
+                  configured={!!cp.hasSecret || !!cp.baseUrl}
+                  isAdmin={isAdmin}
+                  isCustom
+                  onConfigure={() => openEditCustom(cp)}
+                  onRemove={() =>
+                    openDeleteConfirm(
+                      cp.providerKey,
+                      cp.displayName || cp.providerKey,
+                    )
+                  }
+                />
+              ))}
+
+              {isAdmin ? (
+                <div className="pt-3">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={openAddCustom}
+                  >
+                    <Plus className="mr-2 size-4" />
+                    Add Custom Provider
+                  </Button>
+                </div>
+              ) : null}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Config dialog for known providers */}
+      {configTarget ? (
+        <KnownProviderConfigDialog
+          open={configDialogOpen}
+          onOpenChange={setConfigDialogOpen}
+          providerKey={configTarget.providerKey}
+          kind={configTarget.kind}
+          name={configTarget.name}
+          existing={configTarget.existing}
+          isSaving={isSaving}
+          onSave={async (args) => {
+            try {
+              await upsertProvider(args);
+              toast.success(`${configTarget.name} configured`);
+              setConfigDialogOpen(false);
+              setConfigTarget(null);
+            } catch (err) {
+              toast.error(
+                err instanceof Error
+                  ? err.message
+                  : "Failed to save provider",
+              );
+            }
+          }}
+          onCancel={() => {
+            setConfigDialogOpen(false);
+            setConfigTarget(null);
+          }}
+        />
+      ) : null}
+
+      {/* Custom provider dialog */}
+      <OrgCustomProviderDialog
+        open={customDialogOpen}
+        onOpenChange={setCustomDialogOpen}
+        editProvider={editingCustom}
+        isSaving={isSaving}
+        onSave={async (args) => {
+          try {
+            await upsertProvider(args);
+            toast.success(
+              editingCustom
+                ? "Custom provider updated"
+                : "Custom provider added",
+            );
+            setCustomDialogOpen(false);
+            setEditingCustom(null);
+          } catch (err) {
+            toast.error(
+              err instanceof Error
+                ? err.message
+                : "Failed to save custom provider",
+            );
+          }
+        }}
+        onCancel={() => {
+          setCustomDialogOpen(false);
+          setEditingCustom(null);
+        }}
+      />
+
+      {/* Delete confirmation */}
+      <AlertDialog
+        open={deleteConfirmOpen}
+        onOpenChange={(open) => {
+          if (!open && !isSaving) {
+            setDeleteConfirmOpen(false);
+            setDeleteTarget(null);
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove {deleteTarget?.name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove the provider configuration including any stored
+              API keys. Organization members will no longer be able to use
+              models from this provider.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isSaving}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                void handleDelete();
+              }}
+              disabled={isSaving}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isSaving ? "Removing..." : "Remove"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ProviderRow
+// ---------------------------------------------------------------------------
+
+function ProviderRow({
+  name,
+  logo,
+  configured,
+  isAdmin,
+  isCustom,
+  onConfigure,
+  onRemove,
+}: {
+  name: string;
+  logo?: string;
+  configured: boolean;
+  isAdmin: boolean;
+  isCustom?: boolean;
+  onConfigure: () => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between rounded-md border border-border/40 px-3 py-2.5">
+      <div className="flex items-center gap-3">
+        {logo ? (
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border bg-card p-1">
+            <img
+              src={logo}
+              alt={name}
+              className="h-full w-full object-contain"
+            />
+          </div>
+        ) : (
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border bg-muted text-xs font-semibold text-muted-foreground">
+            {name.charAt(0).toUpperCase()}
+          </div>
+        )}
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">{name}</span>
+          {isCustom ? (
+            <Badge variant="outline" className="text-[10px]">
+              Custom
+            </Badge>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        {configured ? (
+          <Badge
+            variant="secondary"
+            className="gap-1 text-xs text-emerald-600 dark:text-emerald-400"
+          >
+            <CheckCircle2 className="size-3" />
+            Configured
+          </Badge>
+        ) : (
+          <Badge variant="outline" className="gap-1 text-xs text-muted-foreground">
+            <Circle className="size-3" />
+            Not configured
+          </Badge>
+        )}
+
+        {isAdmin ? (
+          <>
+            <Button variant="ghost" size="sm" onClick={onConfigure}>
+              {configured ? (
+                <Pencil className="size-3.5" />
+              ) : (
+                <>
+                  <Settings2 className="mr-1.5 size-3.5" />
+                  Configure
+                </>
+              )}
+            </Button>
+            {configured ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onRemove}
+                className="text-destructive hover:text-destructive hover:bg-destructive/10"
+              >
+                <Trash2 className="size-3.5" />
+              </Button>
+            ) : null}
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// KnownProviderConfigDialog
+// ---------------------------------------------------------------------------
+
+function KnownProviderConfigDialog({
+  open,
+  onOpenChange,
+  providerKey,
+  kind,
+  name,
+  existing,
+  isSaving,
+  onSave,
+  onCancel,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  providerKey: string;
+  kind: ProviderKind;
+  name: string;
+  existing?: OrgModelProvider;
+  isSaving: boolean;
+  onSave: (args: {
+    providerKey: string;
+    secret?: string;
+    baseUrl?: string;
+    selectedModels?: string[];
+  }) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [secret, setSecret] = useState("");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [selectedModels, setSelectedModels] = useState("");
+
+  // Reset fields when dialog opens
+  useEffect(() => {
+    if (open) {
+      setSecret("");
+      setBaseUrl(existing?.baseUrl ?? "");
+      setSelectedModels(existing?.selectedModels?.join(", ") ?? "");
+    }
+  }, [open, existing]);
+
+  const catalogEntry = findCatalogEntry(providerKey);
+  const logo = catalogEntry?.logo;
+
+  const handleSave = () => {
+    const args: Parameters<typeof onSave>[0] = { providerKey };
+    if (secret.trim()) args.secret = secret.trim();
+    if (baseUrl.trim()) args.baseUrl = baseUrl.trim();
+    if (kind === "openrouter" && selectedModels.trim()) {
+      args.selectedModels = selectedModels
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }
+    void onSave(args);
+  };
+
+  const canSave = (() => {
+    switch (kind) {
+      case "api-key-only":
+        return !!secret.trim() || existing?.hasSecret;
+      case "azure":
+        return !!baseUrl.trim();
+      case "ollama":
+        return !!baseUrl.trim();
+      case "openrouter":
+        return (!!secret.trim() || existing?.hasSecret) && !!selectedModels.trim();
+      default:
+        return false;
+    }
+  })();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <div className="flex items-center gap-3 mb-4">
+            {logo ? (
+              <div className="w-12 h-12 rounded-lg bg-card p-2 border">
+                <img
+                  src={logo}
+                  alt={name}
+                  className="w-full h-full object-contain"
+                />
+              </div>
+            ) : null}
+            <div>
+              <DialogTitle className="text-left">Configure {name}</DialogTitle>
+              <DialogDescription className="text-left">
+                {existing?.hasSecret
+                  ? "Update the configuration. Leave API key blank to keep the existing key."
+                  : `Set up ${name} for your organization.`}
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* API key field -- all except ollama */}
+          {kind !== "ollama" ? (
+            <div>
+              <label htmlFor="org-provider-secret" className="text-sm font-medium">
+                API Key
+                {existing?.hasSecret ? (
+                  <span className="text-muted-foreground font-normal ml-1">
+                    (leave blank to keep current)
+                  </span>
+                ) : null}
+              </label>
+              <Input
+                id="org-provider-secret"
+                type="password"
+                value={secret}
+                onChange={(e) => setSecret(e.target.value)}
+                placeholder={existing?.hasSecret ? "********" : "sk-..."}
+                className="mt-1"
+              />
+            </div>
+          ) : null}
+
+          {/* Base URL field -- azure, ollama */}
+          {(kind === "azure" || kind === "ollama") ? (
+            <div>
+              <label htmlFor="org-provider-url" className="text-sm font-medium">
+                Base URL
+              </label>
+              <Input
+                id="org-provider-url"
+                type="url"
+                value={baseUrl}
+                onChange={(e) => setBaseUrl(e.target.value)}
+                placeholder={
+                  kind === "azure"
+                    ? "https://RESOURCE_NAME.openai.azure.com/openai"
+                    : "http://127.0.0.1:11434/api"
+                }
+                className="mt-1"
+              />
+            </div>
+          ) : null}
+
+          {/* Selected models -- openrouter */}
+          {kind === "openrouter" ? (
+            <div>
+              <label
+                htmlFor="org-provider-models"
+                className="text-sm font-medium"
+              >
+                Selected Models{" "}
+                <span className="text-muted-foreground font-normal">
+                  (comma-separated model IDs)
+                </span>
+              </label>
+              <Input
+                id="org-provider-models"
+                type="text"
+                value={selectedModels}
+                onChange={(e) => setSelectedModels(e.target.value)}
+                placeholder="openai/gpt-4o, anthropic/claude-3.5-sonnet"
+                className="mt-1"
+              />
+            </div>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!canSave || isSaving}>
+            {isSaving ? "Saving..." : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// OrgCustomProviderDialog
+// ---------------------------------------------------------------------------
+
+function OrgCustomProviderDialog({
+  open,
+  onOpenChange,
+  editProvider,
+  isSaving,
+  onSave,
+  onCancel,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  editProvider: OrgModelProvider | null;
+  isSaving: boolean;
+  onSave: (args: {
+    providerKey: string;
+    secret?: string;
+    baseUrl?: string;
+    protocol?: string;
+    modelIds?: string[];
+    displayName?: string;
+  }) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [displayName, setDisplayName] = useState("");
+  const [protocol, setProtocol] = useState("openai-compatible");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [secret, setSecret] = useState("");
+  const [modelIds, setModelIds] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      if (editProvider) {
+        setDisplayName(editProvider.displayName || editProvider.providerKey);
+        setProtocol(editProvider.protocol || "openai-compatible");
+        setBaseUrl(editProvider.baseUrl || "");
+        setSecret("");
+        setModelIds(editProvider.modelIds?.join(", ") ?? "");
+      } else {
+        setDisplayName("");
+        setProtocol("openai-compatible");
+        setBaseUrl("");
+        setSecret("");
+        setModelIds("");
+      }
+      setValidationError(null);
+    }
+  }, [open, editProvider]);
+
+  const handleSave = () => {
+    setValidationError(null);
+
+    const trimmedName = displayName.trim();
+    if (!trimmedName) {
+      setValidationError("Provider name is required");
+      return;
+    }
+    if (trimmedName.includes("/") || trimmedName.includes(":")) {
+      setValidationError("Provider name cannot contain '/' or ':'");
+      return;
+    }
+
+    const trimmedBaseUrl = baseUrl.trim();
+    if (!trimmedBaseUrl) {
+      setValidationError("Base URL is required");
+      return;
+    }
+
+    const parsedModelIds = modelIds
+      .split(",")
+      .map((id) => id.trim())
+      .filter(Boolean);
+    if (parsedModelIds.length === 0) {
+      setValidationError("At least one model name is required");
+      return;
+    }
+
+    // Use lowercase name as providerKey for new providers, keep existing key for edits
+    const providerKey = editProvider
+      ? editProvider.providerKey
+      : `custom-${trimmedName.toLowerCase().replace(/\s+/g, "-")}`;
+
+    const args: Parameters<typeof onSave>[0] = {
+      providerKey,
+      displayName: trimmedName,
+      protocol,
+      baseUrl: trimmedBaseUrl,
+      modelIds: parsedModelIds,
+    };
+    if (secret.trim()) args.secret = secret.trim();
+
+    void onSave(args);
+  };
+
+  const isValid =
+    displayName.trim() &&
+    !displayName.includes("/") &&
+    !displayName.includes(":") &&
+    baseUrl.trim() &&
+    modelIds.split(",").some((id) => id.trim());
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-left">
+            {editProvider ? "Edit Custom Provider" : "Add Custom Provider"}
+          </DialogTitle>
+          <DialogDescription className="text-left">
+            Connect to any OpenAI-compatible or Anthropic-compatible API
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="org-cp-name" className="text-sm font-medium">
+              Provider Name
+            </label>
+            <Input
+              id="org-cp-name"
+              type="text"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder="e.g. groq, together, vllm"
+              className="mt-1"
+              disabled={!!editProvider}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Used to identify this provider. No slashes or colons.
+            </p>
+          </div>
+
+          <div>
+            <label htmlFor="org-cp-protocol" className="text-sm font-medium">
+              Protocol
+            </label>
+            <Select value={protocol} onValueChange={setProtocol}>
+              <SelectTrigger className="mt-1">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="openai-compatible">
+                  OpenAI Compatible
+                </SelectItem>
+                <SelectItem value="anthropic-compatible">
+                  Anthropic Compatible
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div>
+            <label htmlFor="org-cp-url" className="text-sm font-medium">
+              Base URL
+            </label>
+            <Input
+              id="org-cp-url"
+              type="url"
+              value={baseUrl}
+              onChange={(e) => setBaseUrl(e.target.value)}
+              placeholder="https://api.groq.com/openai/v1"
+              className="mt-1"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="org-cp-secret" className="text-sm font-medium">
+              API Key{" "}
+              <span className="text-muted-foreground font-normal">
+                (optional{editProvider?.hasSecret ? ", leave blank to keep current" : ""})
+              </span>
+            </label>
+            <Input
+              id="org-cp-secret"
+              type="password"
+              value={secret}
+              onChange={(e) => setSecret(e.target.value)}
+              placeholder={editProvider?.hasSecret ? "********" : "sk-..."}
+              className="mt-1"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="org-cp-models" className="text-sm font-medium">
+              Model Names{" "}
+              <span className="text-muted-foreground font-normal">
+                (comma-separated)
+              </span>
+            </label>
+            <Input
+              id="org-cp-models"
+              type="text"
+              value={modelIds}
+              onChange={(e) => setModelIds(e.target.value)}
+              placeholder="llama-3.3-70b-versatile, mixtral-8x7b"
+              className="mt-1"
+            />
+          </div>
+
+          {validationError ? (
+            <p className="text-sm text-destructive">{validationError}</p>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={!isValid || isSaving}>
+            {isSaving
+              ? "Saving..."
+              : editProvider
+                ? "Save Changes"
+                : "Add Provider"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -420,19 +420,25 @@ export function useChatSession({
       };
     };
 
+    // In org-backed workspaces the server resolves credentials from the org
+    // config, so we send workspaceId instead of apiKey / customProviders.
+    const hasOrgWorkspace = !HOSTED_MODE && !!hostedWorkspaceId;
+
     return new DefaultChatTransport({
       api: chatApi,
       fetch: HOSTED_MODE ? authFetch : undefined,
       body: () => ({
         model: selectedModel,
-        ...(HOSTED_MODE ? {} : { apiKey }),
+        ...(HOSTED_MODE || hasOrgWorkspace ? {} : { apiKey }),
         ...(isGpt5 ? {} : { temperature }),
         systemPrompt,
         ...(HOSTED_MODE
           ? buildHostedBody()
-          : { selectedServers, chatSessionId }),
+          : hasOrgWorkspace
+            ? { workspaceId: hostedWorkspaceId, selectedServers, chatSessionId }
+            : { selectedServers, chatSessionId }),
         requireToolApproval: requireToolApprovalRef.current,
-        ...(!HOSTED_MODE && customProviders.length > 0
+        ...(!HOSTED_MODE && !hasOrgWorkspace && customProviders.length > 0
           ? { customProviders }
           : {}),
       }),

--- a/mcpjam-inspector/client/src/hooks/use-org-model-config.ts
+++ b/mcpjam-inspector/client/src/hooks/use-org-model-config.ts
@@ -1,0 +1,114 @@
+import { useCallback, useState } from "react";
+import { useQuery, useAction } from "convex/react";
+
+export interface OrgModelProvider {
+  providerKey: string;
+  enabled: boolean;
+  baseUrl?: string;
+  protocol?: string;
+  modelIds?: string[];
+  displayName?: string;
+  selectedModels?: string[];
+  hasSecret: boolean;
+}
+
+export interface OrgModelConfigResult {
+  providers: OrgModelProvider[] | undefined;
+  isLoading: boolean;
+  upsertProvider: (args: {
+    providerKey: string;
+    secret?: string;
+    baseUrl?: string;
+    protocol?: string;
+    modelIds?: string[];
+    displayName?: string;
+    selectedModels?: string[];
+  }) => Promise<{ success: true }>;
+  deleteProvider: (providerKey: string) => Promise<{ success: true }>;
+  isSaving: boolean;
+  error: string | null;
+}
+
+export function useOrgModelConfig(
+  organizationId: string | null,
+): OrgModelConfigResult {
+  const shouldQuery = !!organizationId;
+
+  const config = useQuery(
+    "organizationModelProviders:getVisibleConfig" as any,
+    shouldQuery ? ({ organizationId } as any) : "skip",
+  ) as { providers: OrgModelProvider[] } | undefined;
+
+  const upsertProviderAction = useAction(
+    "organizationModelProviders:upsertProvider" as any,
+  );
+  const deleteProviderAction = useAction(
+    "organizationModelProviders:deleteProvider" as any,
+  );
+
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const upsertProvider = useCallback(
+    async (args: {
+      providerKey: string;
+      secret?: string;
+      baseUrl?: string;
+      protocol?: string;
+      modelIds?: string[];
+      displayName?: string;
+      selectedModels?: string[];
+    }): Promise<{ success: true }> => {
+      if (!organizationId) throw new Error("Organization is required");
+      setIsSaving(true);
+      setError(null);
+      try {
+        const result = await upsertProviderAction({
+          organizationId,
+          ...args,
+        });
+        return result as { success: true };
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to save provider";
+        setError(message);
+        throw err;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [organizationId, upsertProviderAction],
+  );
+
+  const deleteProvider = useCallback(
+    async (providerKey: string): Promise<{ success: true }> => {
+      if (!organizationId) throw new Error("Organization is required");
+      setIsSaving(true);
+      setError(null);
+      try {
+        const result = await deleteProviderAction({
+          organizationId,
+          providerKey,
+        });
+        return result as { success: true };
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to delete provider";
+        setError(message);
+        throw err;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [organizationId, deleteProviderAction],
+  );
+
+  return {
+    providers: config?.providers,
+    isLoading: shouldQuery && config === undefined,
+    upsertProvider,
+    deleteProvider,
+    isSaving,
+    error,
+  };
+}

--- a/mcpjam-inspector/client/src/lib/hosted-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-navigation.ts
@@ -3,7 +3,7 @@ import {
   normalizeHostedHashTab,
 } from "./hosted-tab-policy";
 
-export type OrganizationRouteSection = "overview" | "billing";
+export type OrganizationRouteSection = "overview" | "billing" | "models";
 
 export interface HostedNavigationResolution {
   normalizedParts: string[];
@@ -66,7 +66,9 @@ export function getInvalidOrganizationRouteNavigationTarget({
 function normalizeOrganizationSection(
   section: string | undefined,
 ): OrganizationRouteSection {
-  return section === "billing" ? "billing" : "overview";
+  if (section === "billing") return "billing";
+  if (section === "models") return "models";
+  return "overview";
 }
 
 export function getNormalizedHashParts(hashValue: string): string[] {
@@ -78,9 +80,10 @@ export function getNormalizedHashParts(hashValue: string): string[] {
 
   if (hashParts[0] === "organizations" && hashParts[1]) {
     const section = normalizeOrganizationSection(hashParts[2]);
-    return section === "billing"
-      ? ["organizations", hashParts[1], "billing"]
-      : ["organizations", hashParts[1]];
+    if (section === "billing" || section === "models") {
+      return ["organizations", hashParts[1], section];
+    }
+    return ["organizations", hashParts[1]];
   }
 
   return hashParts;

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -8,6 +8,10 @@ import {
 import type { ChatV2Request } from "@/shared/chat-v2";
 import { createLlmModel } from "../../utils/chat-helpers";
 import { isMCPJamProvidedModel, isGuestAllowedModel } from "@/shared/types";
+import {
+  resolveOrgModelConfig,
+  resolveProviderForModel,
+} from "../../utils/org-model-config";
 import type { ModelProvider } from "@/shared/types";
 import { getProductionGuestAuthHeader } from "../../utils/guest-auth.js";
 import { logger } from "../../utils/logger";
@@ -188,14 +192,32 @@ chatV2.post("/", async (c) => {
     }
 
     // User-provided models: direct streamText
-    const llmModel = createLlmModel(
-      modelDefinition,
-      apiKey ?? "",
-      {
+    // If workspaceId is present, resolve provider config from org; otherwise use client-sent keys.
+    let resolvedApiKey: string;
+    let resolvedBaseUrls: { ollama?: string; azure?: string };
+    let resolvedCustomProviders = body.customProviders;
+
+    if (body.workspaceId) {
+      const orgConfig = await resolveOrgModelConfig({
+        workspaceId: body.workspaceId,
+      });
+      const resolved = resolveProviderForModel(orgConfig, modelDefinition);
+      resolvedApiKey = resolved.apiKey;
+      resolvedBaseUrls = resolved.baseUrls;
+      resolvedCustomProviders = resolved.customProviders;
+    } else {
+      resolvedApiKey = apiKey ?? "";
+      resolvedBaseUrls = {
         ollama: body.ollamaBaseUrl,
         azure: body.azureBaseUrl,
-      },
-      body.customProviders,
+      };
+    }
+
+    const llmModel = createLlmModel(
+      modelDefinition,
+      resolvedApiKey,
+      resolvedBaseUrls,
+      resolvedCustomProviders,
     );
 
     const modelMessages = await convertToModelMessages(messages);

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -18,6 +18,10 @@ import {
 import type { EvalStreamEvent } from "@/shared/eval-stream-events";
 import { logger } from "../../utils/logger";
 import { ErrorCode, WebRouteError } from "../web/errors.js";
+import {
+  resolveOrgModelConfig,
+  buildModelApiKeysFromOrgConfig,
+} from "../../utils/org-model-config";
 import { flattenServerToolSnapshotTools } from "../../utils/export-helpers.js";
 import { sanitizeForConvexTransport } from "../../services/evals/convex-sanitize.js";
 import { type PromptTurn } from "@/shared/prompt-turns";
@@ -496,11 +500,25 @@ export async function runEvalsWithManager(
     }
   }
 
+  // Resolve model API keys: prefer client-sent keys, fall back to org config
+  let resolvedModelApiKeys = modelApiKeys;
+  if (!resolvedModelApiKeys && workspaceId) {
+    try {
+      const orgConfig = await resolveOrgModelConfig({ workspaceId });
+      resolvedModelApiKeys = buildModelApiKeysFromOrgConfig(orgConfig);
+    } catch (error) {
+      logger.warn("[evals] Failed to resolve org model config", {
+        workspaceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   await runEvalSuiteWithAiSdk({
     suiteId: resolvedSuiteId,
     runId,
     config,
-    modelApiKeys: modelApiKeys ?? undefined,
+    modelApiKeys: resolvedModelApiKeys ?? undefined,
     convexClient,
     convexHttpUrl,
     convexAuthToken,
@@ -569,6 +587,22 @@ export async function runEvalTestCaseWithManager(
     testCaseId: testCase._id,
   };
 
+  // Resolve model API keys: prefer client-sent keys, fall back to org config
+  let resolvedModelApiKeys = modelApiKeys;
+  if (!resolvedModelApiKeys && testCase.workspaceId) {
+    try {
+      const orgConfig = await resolveOrgModelConfig({
+        workspaceId: testCase.workspaceId,
+      });
+      resolvedModelApiKeys = buildModelApiKeysFromOrgConfig(orgConfig);
+    } catch (error) {
+      logger.warn("[evals] Failed to resolve org model config for test case", {
+        testCaseId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   const quickResult = await runEvalSuiteWithAiSdk({
     suiteId: testCase.evalTestSuiteId,
     runId: null,
@@ -576,7 +610,7 @@ export async function runEvalTestCaseWithManager(
       tests: [test],
       environment: { servers: resolvedServerIds },
     },
-    modelApiKeys: modelApiKeys ?? undefined,
+    modelApiKeys: resolvedModelApiKeys ?? undefined,
     convexClient,
     convexHttpUrl,
     convexAuthToken,
@@ -758,6 +792,25 @@ export async function streamEvalTestCaseWithManager(
     testCaseId: testCase._id,
   };
 
+  // Resolve model API keys: prefer client-sent keys, fall back to org config
+  let resolvedStreamModelApiKeys = modelApiKeys;
+  if (!resolvedStreamModelApiKeys && testCase.workspaceId) {
+    try {
+      const orgConfig = await resolveOrgModelConfig({
+        workspaceId: testCase.workspaceId,
+      });
+      resolvedStreamModelApiKeys = buildModelApiKeysFromOrgConfig(orgConfig);
+    } catch (error) {
+      logger.warn(
+        "[evals] Failed to resolve org model config for stream test case",
+        {
+          testCaseId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+  }
+
   const tools = (await clientManager.getToolsForAiSdk(
     resolvedServerIds,
   )) as Record<string, any>;
@@ -773,7 +826,7 @@ export async function streamEvalTestCaseWithManager(
           test,
           tools,
           recorder: null,
-          modelApiKeys: modelApiKeys ?? undefined,
+          modelApiKeys: resolvedStreamModelApiKeys ?? undefined,
           convexHttpUrl,
           convexAuthToken,
           convexClient,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -6,6 +6,13 @@ import { isMCPAuthError, MCPClientManager } from "@mcpjam/sdk";
 import type { HttpServerConfig } from "@mcpjam/sdk";
 import { handleMCPJamFreeChatModel } from "../../utils/mcpjam-stream-handler.js";
 import { isMCPJamProvidedModel, isGuestAllowedModel } from "@/shared/types";
+import type { ModelProvider } from "@/shared/types";
+import {
+  resolveOrgModelConfig,
+  resolveProviderForModel,
+} from "../../utils/org-model-config";
+import { createLlmModel } from "../../utils/chat-helpers";
+import { streamText, stepCountIs, type ToolSet as StreamToolSet } from "ai";
 import { WEB_STREAM_TIMEOUT_MS } from "../../config.js";
 import { prepareChatV2 } from "../../utils/chat-v2-orchestration.js";
 import { validateUrl, OAuthProxyError } from "../../utils/oauth-proxy.js";
@@ -293,7 +300,12 @@ chatV2.post("/", async (c) => {
       const { allTools, enhancedSystemPrompt, resolvedTemperature } = prepared;
       const hostedChatSessionId = body.chatSessionId;
 
-      if (modelDefinition.id && isMCPJamProvidedModel(modelDefinition.id)) {
+      const modelMessages = await convertToModelMessages(messages);
+      const isMcpjamModel =
+        modelDefinition.id && isMCPJamProvidedModel(modelDefinition.id);
+
+      if (isMcpjamModel) {
+        // MCPJam-provided model — delegate to the hosted stream handler
         if (!process.env.CONVEX_HTTP_URL) {
           throw new WebRouteError(
             500,
@@ -301,31 +313,75 @@ chatV2.post("/", async (c) => {
             "Server missing CONVEX_HTTP_URL configuration",
           );
         }
-      } else {
-        throw new WebRouteError(
-          400,
-          ErrorCode.FEATURE_NOT_SUPPORTED,
-          "Only MCPJam hosted models are supported in hosted mode",
-        );
+
+        return handleMCPJamFreeChatModel({
+          messages: modelMessages as ModelMessage[],
+          modelId: String(modelDefinition.id),
+          systemPrompt: enhancedSystemPrompt,
+          temperature: resolvedTemperature,
+          tools: allTools as ToolSet,
+          authHeader: c.req.header("authorization"),
+          mcpClientManager: manager,
+          selectedServers: selectedServerIds,
+          requireToolApproval,
+          onConversationComplete: hostedChatSessionId
+            ? async (fullHistory) => {
+                await persistChatSessionToConvex({
+                  chatSessionId: hostedChatSessionId,
+                  modelId: String(modelDefinition.id),
+                  modelSource: "mcpjam",
+                  workspaceId: hostedBody.workspaceId,
+                  sourceType: shareToken
+                    ? "serverShare"
+                    : sandboxToken
+                      ? "sandbox"
+                      : "direct",
+                  ...(sandboxToken && surface ? { surface } : {}),
+                  shareToken,
+                  sandboxToken,
+                  ...(shareToken && selectedServerIds[0]
+                    ? { serverId: selectedServerIds[0] }
+                    : {}),
+                  authHeader: c.req.header("authorization"),
+                  sessionMessages: fullHistory,
+                  startedAt: sessionStartedAt,
+                  lastActivityAt: Date.now(),
+                });
+              }
+            : undefined,
+          onStreamComplete: () => manager.disconnectAllServers(),
+        });
       }
 
-      const modelMessages = await convertToModelMessages(messages);
-      return handleMCPJamFreeChatModel({
+      // BYOK model — resolve provider config from org
+      const orgConfig = await resolveOrgModelConfig({
+        workspaceId: hostedBody.workspaceId,
+      });
+      const { apiKey: resolvedKey, baseUrls, customProviders: resolvedCustomProviders } =
+        resolveProviderForModel(orgConfig, modelDefinition);
+      const llmModel = createLlmModel(
+        modelDefinition,
+        resolvedKey,
+        baseUrls,
+        resolvedCustomProviders,
+      );
+
+      const result = streamText({
+        model: llmModel,
         messages: modelMessages as ModelMessage[],
-        modelId: String(modelDefinition.id),
-        systemPrompt: enhancedSystemPrompt,
-        temperature: resolvedTemperature,
-        tools: allTools as ToolSet,
-        authHeader: c.req.header("authorization"),
-        mcpClientManager: manager,
-        selectedServers: selectedServerIds,
-        requireToolApproval,
-        onConversationComplete: hostedChatSessionId
-          ? async (fullHistory) => {
+        ...(resolvedTemperature !== undefined
+          ? { temperature: resolvedTemperature }
+          : {}),
+        system: enhancedSystemPrompt,
+        tools: allTools as StreamToolSet,
+        stopWhen: stepCountIs(20),
+        onFinish: async () => {
+          if (hostedChatSessionId) {
+            try {
               await persistChatSessionToConvex({
                 chatSessionId: hostedChatSessionId,
                 modelId: String(modelDefinition.id),
-                modelSource: "mcpjam",
+                modelSource: "byok",
                 workspaceId: hostedBody.workspaceId,
                 sourceType: shareToken
                   ? "serverShare"
@@ -339,14 +395,20 @@ chatV2.post("/", async (c) => {
                   ? { serverId: selectedServerIds[0] }
                   : {}),
                 authHeader: c.req.header("authorization"),
-                sessionMessages: fullHistory,
+                sessionMessages: [],
                 startedAt: sessionStartedAt,
                 lastActivityAt: Date.now(),
               });
+            } catch (e) {
+              // Non-fatal — log but don't break the stream
+              console.error("Failed to persist BYOK chat session", e);
             }
-          : undefined,
-        onStreamComplete: () => manager.disconnectAllServers(),
+          }
+          await manager.disconnectAllServers();
+        },
       });
+
+      return result.toDataStreamResponse();
     } catch (error) {
       await manager.disconnectAllServers();
       throw error;

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -357,8 +357,11 @@ chatV2.post("/", async (c) => {
       const orgConfig = await resolveOrgModelConfig({
         workspaceId: hostedBody.workspaceId,
       });
-      const { apiKey: resolvedKey, baseUrls, customProviders: resolvedCustomProviders } =
-        resolveProviderForModel(orgConfig, modelDefinition);
+      const {
+        apiKey: resolvedKey,
+        baseUrls,
+        customProviders: resolvedCustomProviders,
+      } = resolveProviderForModel(orgConfig, modelDefinition);
       const llmModel = createLlmModel(
         modelDefinition,
         resolvedKey,

--- a/mcpjam-inspector/server/services/evals/replay-suite-run.ts
+++ b/mcpjam-inspector/server/services/evals/replay-suite-run.ts
@@ -10,6 +10,10 @@ import {
   storeReplayConfig,
 } from "./route-helpers.js";
 import { logger } from "../../utils/logger.js";
+import {
+  resolveOrgModelConfig,
+  buildModelApiKeysFromOrgConfig,
+} from "../../utils/org-model-config.js";
 
 export type ExecuteSuiteReplayFromRunParams = {
   convexClient: ConvexHttpClient;
@@ -97,11 +101,27 @@ export async function executeSuiteReplayFromRun(
       }
     }
 
+    // Resolve model API keys: prefer client-sent keys, fall back to org config
+    let resolvedModelApiKeys = modelApiKeys;
+    if (!resolvedModelApiKeys && replayMetadata.workspaceId) {
+      try {
+        const orgConfig = await resolveOrgModelConfig({
+          workspaceId: replayMetadata.workspaceId,
+        });
+        resolvedModelApiKeys = buildModelApiKeysFromOrgConfig(orgConfig);
+      } catch (error) {
+        logger.warn("[evals] Failed to resolve org model config for replay", {
+          sourceRunId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
     await runEvalSuiteWithAiSdk({
       suiteId: replayMetadata.suiteId,
       runId,
       config,
-      modelApiKeys: modelApiKeys ?? undefined,
+      modelApiKeys: resolvedModelApiKeys ?? undefined,
       convexClient,
       convexHttpUrl,
       convexAuthToken,

--- a/mcpjam-inspector/server/services/evals/trace-repair-runner.ts
+++ b/mcpjam-inspector/server/services/evals/trace-repair-runner.ts
@@ -14,6 +14,10 @@ import {
 } from "./route-helpers.js";
 import { executeSuiteReplayFromRun } from "./replay-suite-run.js";
 import { sanitizeForConvexTransport } from "./convex-sanitize.js";
+import {
+  resolveOrgModelConfig,
+  buildModelApiKeysFromOrgConfig,
+} from "../../utils/org-model-config.js";
 
 const LEASE_MS = 30_000;
 const HEARTBEAT_MS = 10_000;
@@ -301,7 +305,29 @@ export async function runTraceRepairJob(
   params: TraceRepairRunnerParams,
 ): Promise<void> {
   const { convexClient, convexAuthToken, jobId } = params;
-  const modelApiKeys = params.modelApiKeys;
+  let modelApiKeys = params.modelApiKeys;
+
+  // Resolve model API keys from org config if not provided
+  if (!modelApiKeys) {
+    try {
+      const job = await convexClient.query(
+        "traceRepair:getTraceRepairJob" as any,
+        { jobId },
+      );
+      if (job?.workspaceId) {
+        const orgConfig = await resolveOrgModelConfig({
+          workspaceId: job.workspaceId,
+        });
+        modelApiKeys = buildModelApiKeysFromOrgConfig(orgConfig);
+      }
+    } catch (error) {
+      logger.warn("[trace-repair] Failed to resolve org model config", {
+        jobId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   const leaseOwner = crypto.randomUUID();
 
   await convexClient.mutation("traceRepair:claimTraceRepairJobLease" as any, {

--- a/mcpjam-inspector/server/utils/org-model-config.ts
+++ b/mcpjam-inspector/server/utils/org-model-config.ts
@@ -1,0 +1,152 @@
+import type { ModelDefinition } from "@/shared/types";
+import type { BaseUrls, CustomProviderConfig } from "./chat-helpers";
+import { logger } from "./logger";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ResolvedProviderConfig = {
+  providerKey: string;
+  apiKey?: string;
+  baseUrl?: string;
+  protocol?: string;
+  modelIds?: string[];
+  displayName?: string;
+  selectedModels?: string[];
+};
+
+export type ResolvedOrgModelConfig = {
+  providers: ResolvedProviderConfig[];
+};
+
+// ---------------------------------------------------------------------------
+// Resolution — call the Convex HTTP endpoint
+// ---------------------------------------------------------------------------
+
+const INSPECTOR_SERVICE_TOKEN_HEADER = "X-Inspector-Service-Token";
+const RESOLVE_TIMEOUT_MS = 15_000;
+
+export async function resolveOrgModelConfig(
+  params: { workspaceId: string } | { organizationId: string },
+): Promise<ResolvedOrgModelConfig> {
+  const convexHttpUrl = process.env.CONVEX_HTTP_URL;
+  if (!convexHttpUrl) {
+    throw new Error("CONVEX_HTTP_URL is not set");
+  }
+
+  const inspectorServiceToken = process.env.INSPECTOR_SERVICE_TOKEN;
+  if (!inspectorServiceToken) {
+    throw new Error("INSPECTOR_SERVICE_TOKEN is not set");
+  }
+
+  const url = `${convexHttpUrl.replace(/\/$/, "")}/internal/v1/org-model-config/resolve`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), RESOLVE_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [INSPECTOR_SERVICE_TOKEN_HEADER]: inspectorServiceToken,
+      },
+      body: JSON.stringify(params),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      let message = `Org model config resolution failed (${response.status})`;
+      try {
+        const parsed = JSON.parse(body);
+        if (parsed?.error) message = parsed.error;
+      } catch {
+        // ignore parse failure
+      }
+      throw new Error(message);
+    }
+
+    const data = await response.json();
+    if (!data?.ok) {
+      throw new Error(data?.error ?? "Failed to resolve org model config");
+    }
+
+    return { providers: data.providers ?? [] };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Convert resolved config to what createLlmModel() expects
+// ---------------------------------------------------------------------------
+
+export function resolveProviderForModel(
+  config: ResolvedOrgModelConfig,
+  modelDefinition: ModelDefinition,
+): { apiKey: string; baseUrls: BaseUrls; customProviders: CustomProviderConfig[] } {
+  const { provider, customProviderName } = modelDefinition;
+
+  // Build custom providers list from org config
+  const customProviders: CustomProviderConfig[] = config.providers
+    .filter((p) => p.providerKey.startsWith("custom:"))
+    .map((p) => ({
+      name: p.displayName ?? p.providerKey.replace(/^custom:/, ""),
+      protocol: p.protocol ?? "openai-compatible",
+      baseUrl: p.baseUrl ?? "",
+      modelIds: p.modelIds ?? [],
+      apiKey: p.apiKey,
+    }));
+
+  // For custom providers, the apiKey comes from the custom provider config itself
+  if (provider === "custom" && customProviderName) {
+    const cp = customProviders.find((p) => p.name === customProviderName);
+    return {
+      apiKey: cp?.apiKey ?? "",
+      baseUrls: buildBaseUrls(config),
+      customProviders,
+    };
+  }
+
+  // For built-in providers, find the matching provider config
+  const providerConfig = config.providers.find(
+    (p) => p.providerKey === provider,
+  );
+
+  return {
+    apiKey: providerConfig?.apiKey ?? "",
+    baseUrls: buildBaseUrls(config),
+    customProviders,
+  };
+}
+
+function buildBaseUrls(config: ResolvedOrgModelConfig): BaseUrls {
+  const ollama = config.providers.find((p) => p.providerKey === "ollama");
+  const azure = config.providers.find((p) => p.providerKey === "azure");
+  return {
+    ollama: ollama?.baseUrl,
+    azure: azure?.baseUrl,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Build modelApiKeys map (for eval routes)
+// ---------------------------------------------------------------------------
+
+export function buildModelApiKeysFromOrgConfig(
+  config: ResolvedOrgModelConfig,
+): Record<string, string> {
+  const keys: Record<string, string> = {};
+  for (const p of config.providers) {
+    if (p.apiKey) {
+      // Strip "custom:" prefix for custom providers — the eval runner
+      // looks up by provider name (e.g. "anthropic", "openai")
+      const key = p.providerKey.startsWith("custom:")
+        ? p.providerKey
+        : p.providerKey;
+      keys[key] = p.apiKey;
+    }
+  }
+  return keys;
+}

--- a/mcpjam-inspector/server/utils/org-model-config.ts
+++ b/mcpjam-inspector/server/utils/org-model-config.ts
@@ -85,7 +85,11 @@ export async function resolveOrgModelConfig(
 export function resolveProviderForModel(
   config: ResolvedOrgModelConfig,
   modelDefinition: ModelDefinition,
-): { apiKey: string; baseUrls: BaseUrls; customProviders: CustomProviderConfig[] } {
+): {
+  apiKey: string;
+  baseUrls: BaseUrls;
+  customProviders: CustomProviderConfig[];
+} {
   const { provider, customProviderName } = modelDefinition;
 
   // Build custom providers list from org config

--- a/mcpjam-inspector/shared/chat-v2.ts
+++ b/mcpjam-inspector/shared/chat-v2.ts
@@ -25,4 +25,6 @@ export interface ChatV2Request {
   }>;
   selectedServers?: string[];
   requireToolApproval?: boolean;
+  /** When present, the server resolves model provider config from the org backing this workspace. */
+  workspaceId?: string;
 }


### PR DESCRIPTION
## Summary
This PR adds organization-level configuration for AI model providers, allowing admins to manage API keys and provider settings centrally that are shared across all organization members. This enables org-backed workspaces to resolve model credentials from the organization config instead of requiring individual user setup.

## Key Changes

### Client-Side Components
- **OrganizationModelsSection**: New component for managing provider configurations with support for:
  - Known providers (OpenAI, Anthropic, Google, Azure, Ollama, OpenRouter, etc.)
  - Custom provider creation with OpenAI/Anthropic-compatible protocols
  - Provider enable/disable, edit, and delete operations
  - Admin-only configuration UI with role-based visibility

- **Model selection helpers**: Added `buildAvailableModelsFromOrgConfig()` and `isOrgProviderAvailable()` to determine available models based on org provider configuration

- **Navigation**: Extended organization routes to include `/models` section alongside existing overview and billing sections

- **Settings integration**: Updated SettingsTab to accept organization context and conditionally hide local provider configuration when in org-backed mode

### Server-Side Utilities
- **org-model-config.ts**: New utility module providing:
  - `resolveOrgModelConfig()`: Fetches org provider configuration from Convex via HTTP endpoint
  - `resolveProviderForModel()`: Maps model definitions to resolved provider credentials
  - `buildModelApiKeysFromOrgConfig()`: Extracts API keys for eval/test case execution
  - Support for both workspace and organization ID resolution

### Integration Points
- **Chat routes** (web and MCP): Updated to resolve provider config from org when `workspaceId` is present, falling back to client-sent credentials
- **Eval execution**: Modified to use org-resolved API keys when available, with fallback to client-provided keys
- **Trace repair and replay**: Updated to resolve credentials from org config for background job execution

### Type Updates
- Extended `ChatV2Request` to include optional `workspaceId` parameter
- Added `OrgModelProvider` interface for provider configuration state
- Added `OrganizationRouteSection` type to support "models" route

## Implementation Details
- Provider configuration uses a catalog-based approach with known providers and custom provider support
- API keys are stored securely server-side and never exposed to the client
- Org config resolution includes timeout protection (15s) and proper error handling
- Custom providers support both OpenAI-compatible and Anthropic-compatible protocols
- OpenRouter supports per-organization model selection via `selectedModels` field
- Graceful degradation: if org config resolution fails, evals/chat fall back to client-provided credentials

https://claude.ai/code/session_013YhDfdj193M62kR2oAhHD2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches credential resolution for chat and eval execution by introducing org-backed provider config lookup (via service token/Convex HTTP), which is security- and reliability-sensitive and could break BYOK model access if misconfigured.
> 
> **Overview**
> Adds an **organization-level “Models” settings area** where admins can configure shared model providers (including OpenRouter selections and custom providers) and routes it under `organizations/:id/models`.
> 
> Updates the client to treat org-backed contexts differently: `SettingsTab` hides per-user/local provider keys and links to org models, model availability can be derived from org provider config, and chat/evals requests can omit client API keys.
> 
> Updates server chat (`mcp` + `web`) and eval/repair/replay flows to accept `workspaceId` in `ChatV2Request` and, when present, **resolve provider API keys/base URLs from org config** (via new `utils/org-model-config.ts`) with fallback to client-sent credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7691b093531f160e6a8d319b91aa9d786e5c150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->