### PR TITLE
Consolidate chat options into + button, consolidate servers tabs into + popover

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1308,10 +1308,8 @@ export default function App() {
     activeTab === "tasks" ||
     activeTab === "oauth-flow" ||
     activeTab === "chat" ||
-    activeTab === "chat-v2" ||
     activeTab === "evals" ||
-    activeTab === "views" ||
-    activeTab === "app-builder";
+    activeTab === "views";
 
   const activeServerSelectorProps: ActiveServerSelectorProps | undefined =
     shouldShowActiveServerSelector
@@ -1322,13 +1320,13 @@ export default function App() {
           onServerChange: setSelectedServer,
           onConnect: handleConnect,
           onReconnect: handleReconnect,
-          isMultiSelectEnabled: activeTab === "chat" || activeTab === "chat-v2",
+          isMultiSelectEnabled: activeTab === "chat",
           onMultiServerToggle: toggleServerSelection,
           selectedMultipleServers: appState.selectedMultipleServers,
           showOnlyOAuthServers: false,
           showOnlyServersWithViews: activeTab === "views",
           serversWithViews: serversWithViews,
-          hasMessages: activeTab === "chat-v2" ? chatHasMessages : false,
+          hasMessages: false,
         }
       : undefined;
 

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1578,7 +1578,9 @@ export default function App() {
                 connectedOrConnectingServerConfigs
               }
               selectedServerNames={appState.selectedMultipleServers}
-              onSelectedServerNamesChange={setSelectedMCPConfigs}
+              allServerConfigs={workspaceServers}
+              onServerToggle={toggleServerSelection}
+              onReconnectServer={handleReconnect}
               onHasMessagesChange={setChatHasMessages}
               enableMultiModelChat
               evalChatHandoff={evalChatHandoff}

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1581,6 +1581,7 @@ export default function App() {
               allServerConfigs={workspaceServers}
               onServerToggle={toggleServerSelection}
               onReconnectServer={handleReconnect}
+              onSelectedServerNamesChange={setSelectedMCPConfigs}
               onHasMessagesChange={setChatHasMessages}
               enableMultiModelChat
               evalChatHandoff={evalChatHandoff}

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1579,6 +1579,7 @@ export default function App() {
               allServerConfigs={workspaceServers}
               onServerToggle={toggleServerSelection}
               onReconnectServer={handleReconnect}
+              onAddServer={handleConnect}
               onSelectedServerNamesChange={setSelectedMCPConfigs}
               onHasMessagesChange={setChatHasMessages}
               enableMultiModelChat

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -106,6 +106,8 @@ interface ChatTabProps {
   onServerToggle?: (serverName: string) => void;
   /** Reconnect a disconnected server. */
   onReconnectServer?: (serverName: string) => Promise<void>;
+  /** Add a new server (opens add-server modal). */
+  onAddServer?: (formData: import("@/shared/types").ServerFormData) => void;
   onSelectedServerNamesChange?: (names: string[]) => void;
   onHasMessagesChange?: (hasMessages: boolean) => void;
   enableMultiModelChat?: boolean;
@@ -146,6 +148,7 @@ export function ChatTabV2({
   allServerConfigs,
   onServerToggle,
   onReconnectServer,
+  onAddServer,
   onSelectedServerNamesChange,
   onHasMessagesChange,
   enableMultiModelChat = false,
@@ -1846,6 +1849,7 @@ export function ChatTabV2({
     allServerConfigs,
     onServerToggle,
     onReconnectServer,
+    onAddServer,
     sandboxAttachableServers:
       sandboxOptionalInventory && sandboxOptionalInventory.length > 0
         ? sandboxOptionalInventory

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -106,6 +106,7 @@ interface ChatTabProps {
   onServerToggle?: (serverName: string) => void;
   /** Reconnect a disconnected server. */
   onReconnectServer?: (serverName: string) => Promise<void>;
+  onSelectedServerNamesChange?: (names: string[]) => void;
   onHasMessagesChange?: (hasMessages: boolean) => void;
   enableMultiModelChat?: boolean;
   minimalMode?: boolean;
@@ -145,6 +146,7 @@ export function ChatTabV2({
   allServerConfigs,
   onServerToggle,
   onReconnectServer,
+  onSelectedServerNamesChange,
   onHasMessagesChange,
   enableMultiModelChat = false,
   minimalMode = false,

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -100,7 +100,12 @@ import {
 interface ChatTabProps {
   connectedOrConnectingServerConfigs: Record<string, ServerWithName>;
   selectedServerNames: string[];
-  onSelectedServerNamesChange?: (names: string[]) => void;
+  /** All workspace servers (for the "+" dropdown server toggles). */
+  allServerConfigs?: Record<string, ServerWithName>;
+  /** Toggle a server on/off for multi-select. */
+  onServerToggle?: (serverName: string) => void;
+  /** Reconnect a disconnected server. */
+  onReconnectServer?: (serverName: string) => Promise<void>;
   onHasMessagesChange?: (hasMessages: boolean) => void;
   enableMultiModelChat?: boolean;
   minimalMode?: boolean;
@@ -137,7 +142,9 @@ const RESUMED_THREAD_REFRESH_RETRIES = 2;
 export function ChatTabV2({
   connectedOrConnectingServerConfigs,
   selectedServerNames,
-  onSelectedServerNamesChange,
+  allServerConfigs,
+  onServerToggle,
+  onReconnectServer,
   onHasMessagesChange,
   enableMultiModelChat = false,
   minimalMode = false,
@@ -1834,6 +1841,9 @@ export function ChatTabV2({
     requireToolApproval,
     onRequireToolApprovalChange: handleRequireToolApprovalChange,
     minimalMode,
+    allServerConfigs,
+    onServerToggle,
+    onReconnectServer,
     sandboxAttachableServers:
       sandboxOptionalInventory && sandboxOptionalInventory.length > 0
         ? sandboxOptionalInventory

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
@@ -143,11 +143,8 @@ describe("ChatInput", () => {
       expect(screen.getByTestId("model-selector")).toHaveTextContent("GPT-4");
     });
 
-    it("renders system prompt selector inside plus dropdown", async () => {
+    it("renders system prompt selector", async () => {
       render(<ChatInput {...defaultProps} />);
-
-      const plusButton = screen.getByRole("button", { name: "Options" });
-      fireEvent.click(plusButton);
 
       expect(screen.getByTestId("system-prompt-selector")).toBeInTheDocument();
     });

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
@@ -143,8 +143,11 @@ describe("ChatInput", () => {
       expect(screen.getByTestId("model-selector")).toHaveTextContent("GPT-4");
     });
 
-    it("renders system prompt selector", () => {
+    it("renders system prompt selector inside plus dropdown", async () => {
       render(<ChatInput {...defaultProps} />);
+
+      const plusButton = screen.getByRole("button", { name: "Options" });
+      fireEvent.click(plusButton);
 
       expect(screen.getByTestId("system-prompt-selector")).toBeInTheDocument();
     });
@@ -522,14 +525,17 @@ describe("ChatInput", () => {
   });
 
   describe("minimal mode", () => {
-    it("hides file attachments, system prompt, model selector, and tool approval in minimal mode", () => {
+    it("hides plus dropdown, model selector, and context in minimal mode", () => {
       render(<ChatInput {...defaultProps} minimalMode={true} />);
 
       expect(screen.getByTestId("prompts-popover")).toBeInTheDocument();
       expect(
+        screen.queryByRole("button", { name: "Options" }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByTestId("model-selector")).not.toBeInTheDocument();
+      expect(
         screen.queryByTestId("system-prompt-selector"),
       ).not.toBeInTheDocument();
-      expect(screen.queryByText("Tool Approval")).not.toBeInTheDocument();
     });
 
     it("hides context usage UI in minimal mode", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -445,152 +445,159 @@ export function ChatInput({
 
   return (
     <>
-    <form ref={formRef} className={cn("w-full", className)} onSubmit={onSubmit}>
-      <div
-        ref={containerRef}
-        className={cn(
-          "relative flex w-full flex-col px-2 pt-2 pb-2",
-          composerClasses,
-        )}
+      <form
+        ref={formRef}
+        className={cn("w-full", className)}
+        onSubmit={onSubmit}
       >
-        <PromptsPopover
-          anchor={caret}
-          selectedServers={selectedServers}
-          onPromptSelected={onMCPPromptSelected}
-          onSkillSelected={onSkillSelected}
-          actionTrigger={mcpPromptPopoverKeyTrigger}
-          setActionTrigger={setMcpPromptPopoverKeyTrigger}
-          value={value}
-          caretIndex={caretIndex}
-          minimalMode={minimalMode}
-        />
-
-        {minimalMode &&
-        sandboxAttachableServers &&
-        sandboxAttachableServers.length > 0 &&
-        onAttachSandboxServer ? (
-          <div className="flex flex-wrap items-center gap-2 px-4 pb-1 pt-0.5">
-            <Popover>
-              <PopoverTrigger asChild>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-8 gap-1 rounded-full border-dashed px-3 text-xs"
-                  disabled={disabled}
-                  aria-label="Add optional server"
-                >
-                  <Plus className="h-3.5 w-3.5" />
-                  Add server
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className="w-72 p-1" align="start">
-                <p className="px-2 py-1.5 text-xs text-muted-foreground">
-                  Connect an optional server. You may be asked to authorize.
-                </p>
-                <div className="max-h-48 overflow-y-auto">
-                  {sandboxAttachableServers.map((s) => (
-                    <button
-                      key={s.serverId}
-                      type="button"
-                      className="flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm hover:bg-muted/80"
-                      onClick={() => onAttachSandboxServer(s.serverId)}
-                    >
-                      <span className="truncate font-medium">
-                        {s.serverName}
-                      </span>
-                      {s.useOAuth ? (
-                        <span className="shrink-0 text-[10px] text-muted-foreground">
-                          OAuth
-                        </span>
-                      ) : null}
-                    </button>
-                  ))}
-                </div>
-              </PopoverContent>
-            </Popover>
-          </div>
-        ) : null}
-
-        {/* Hidden file input */}
-        <input
-          ref={fileInputRef}
-          type="file"
-          multiple
-          accept={getFileInputAccept()}
-          onChange={handleFileInputChange}
-          className="hidden"
-          aria-hidden="true"
-        />
-
-        {/* File Attachment Cards */}
-        {renderFileAttachmentCards()}
-
-        {/* MCP Prompts and Skills Cards */}
-        {renderResultCards()}
-
-        {/* File validation error */}
-        {fileError && (
-          <div className="px-4 py-1">
-            <p className="text-xs text-destructive whitespace-pre-line">
-              {fileError}
-            </p>
-          </div>
-        )}
-
-        <TextareaAutosize
-          ref={textareaRef}
-          value={value}
-          onChange={(e) => {
-            onChange(e.target.value);
-            setCaretIndex(e.target.selectionStart);
-          }}
-          onKeyDown={handleKeyDown}
-          onKeyUp={(e) => setCaretIndex(e.currentTarget.selectionStart)}
-          placeholder={placeholder}
-          disabled={disabled}
-          readOnly={disabled}
-          minRows={2}
+        <div
+          ref={containerRef}
           className={cn(
-            "max-h-32 min-h-[64px] w-full resize-none border-none bg-transparent dark:bg-transparent px-4",
-            "pt-2 pb-3 text-base text-foreground placeholder:text-muted-foreground/70",
-            "outline-none focus-visible:outline-none focus-visible:ring-0 shadow-none focus-visible:shadow-none",
-            disabled ? "cursor-not-allowed text-muted-foreground" : "",
+            "relative flex w-full flex-col px-2 pt-2 pb-2",
+            composerClasses,
           )}
-          autoFocus={!disabled}
-        />
+        >
+          <PromptsPopover
+            anchor={caret}
+            selectedServers={selectedServers}
+            onPromptSelected={onMCPPromptSelected}
+            onSkillSelected={onSkillSelected}
+            actionTrigger={mcpPromptPopoverKeyTrigger}
+            setActionTrigger={setMcpPromptPopoverKeyTrigger}
+            value={value}
+            caretIndex={caretIndex}
+            minimalMode={minimalMode}
+          />
 
-        <div className="@container/toolbar flex items-center justify-between gap-2 px-2 min-w-0">
-          <div className="flex items-center gap-1 min-w-0 flex-shrink overflow-hidden">
-            {!minimalMode && (
-              <Popover open={plusPopoverOpen} onOpenChange={setPlusPopoverOpen}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <PopoverTrigger asChild>
-                      <Button
+          {minimalMode &&
+          sandboxAttachableServers &&
+          sandboxAttachableServers.length > 0 &&
+          onAttachSandboxServer ? (
+            <div className="flex flex-wrap items-center gap-2 px-4 pb-1 pt-0.5">
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-8 gap-1 rounded-full border-dashed px-3 text-xs"
+                    disabled={disabled}
+                    aria-label="Add optional server"
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                    Add server
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-72 p-1" align="start">
+                  <p className="px-2 py-1.5 text-xs text-muted-foreground">
+                    Connect an optional server. You may be asked to authorize.
+                  </p>
+                  <div className="max-h-48 overflow-y-auto">
+                    {sandboxAttachableServers.map((s) => (
+                      <button
+                        key={s.serverId}
                         type="button"
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8 rounded-full"
-                        disabled={disabled}
-                        aria-label="Options"
+                        className="flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-sm hover:bg-muted/80"
+                        onClick={() => onAttachSandboxServer(s.serverId)}
                       >
-                        <Plus className="h-4 w-4" />
-                      </Button>
-                    </PopoverTrigger>
-                  </TooltipTrigger>
-                  <TooltipContent>Options</TooltipContent>
-                </Tooltip>
-                <PopoverContent
-                  className="w-72 p-0"
-                  align="start"
-                  side="top"
-                  sideOffset={8}
+                        <span className="truncate font-medium">
+                          {s.serverName}
+                        </span>
+                        {s.useOAuth ? (
+                          <span className="shrink-0 text-[10px] text-muted-foreground">
+                            OAuth
+                          </span>
+                        ) : null}
+                      </button>
+                    ))}
+                  </div>
+                </PopoverContent>
+              </Popover>
+            </div>
+          ) : null}
+
+          {/* Hidden file input */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept={getFileInputAccept()}
+            onChange={handleFileInputChange}
+            className="hidden"
+            aria-hidden="true"
+          />
+
+          {/* File Attachment Cards */}
+          {renderFileAttachmentCards()}
+
+          {/* MCP Prompts and Skills Cards */}
+          {renderResultCards()}
+
+          {/* File validation error */}
+          {fileError && (
+            <div className="px-4 py-1">
+              <p className="text-xs text-destructive whitespace-pre-line">
+                {fileError}
+              </p>
+            </div>
+          )}
+
+          <TextareaAutosize
+            ref={textareaRef}
+            value={value}
+            onChange={(e) => {
+              onChange(e.target.value);
+              setCaretIndex(e.target.selectionStart);
+            }}
+            onKeyDown={handleKeyDown}
+            onKeyUp={(e) => setCaretIndex(e.currentTarget.selectionStart)}
+            placeholder={placeholder}
+            disabled={disabled}
+            readOnly={disabled}
+            minRows={2}
+            className={cn(
+              "max-h-32 min-h-[64px] w-full resize-none border-none bg-transparent dark:bg-transparent px-4",
+              "pt-2 pb-3 text-base text-foreground placeholder:text-muted-foreground/70",
+              "outline-none focus-visible:outline-none focus-visible:ring-0 shadow-none focus-visible:shadow-none",
+              disabled ? "cursor-not-allowed text-muted-foreground" : "",
+            )}
+            autoFocus={!disabled}
+          />
+
+          <div className="@container/toolbar flex items-center justify-between gap-2 px-2 min-w-0">
+            <div className="flex items-center gap-1 min-w-0 flex-shrink overflow-hidden">
+              {!minimalMode && (
+                <Popover
+                  open={plusPopoverOpen}
+                  onOpenChange={setPlusPopoverOpen}
                 >
-                  {(onAddServer ||
-                    (allServerConfigs &&
-                      onServerToggle &&
-                      Object.keys(allServerConfigs).length > 0)) && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <PopoverTrigger asChild>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8 rounded-full"
+                          disabled={disabled}
+                          aria-label="Options"
+                        >
+                          <Plus className="h-4 w-4" />
+                        </Button>
+                      </PopoverTrigger>
+                    </TooltipTrigger>
+                    <TooltipContent>Options</TooltipContent>
+                  </Tooltip>
+                  <PopoverContent
+                    className="w-72 p-0"
+                    align="start"
+                    side="top"
+                    sideOffset={8}
+                  >
+                    {(onAddServer ||
+                      (allServerConfigs &&
+                        onServerToggle &&
+                        Object.keys(allServerConfigs).length > 0)) && (
                       <div className="px-1 pt-1 pb-0">
                         <p className="px-2 py-1.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
                           Servers
@@ -598,95 +605,98 @@ export function ChatInput({
                         {allServerConfigs &&
                           onServerToggle &&
                           Object.keys(allServerConfigs).length > 0 && (
-                        <div className="max-h-48 overflow-y-auto">
-                          {Object.entries(allServerConfigs)
-                            .sort(([aName, a], [bName, b]) => {
-                              const statusOrder: Record<string, number> = {
-                                connected: 0,
-                                connecting: 1,
-                                failed: 2,
-                              };
-                              const aOrder = statusOrder[a.connectionStatus] ?? 3;
-                              const bOrder = statusOrder[b.connectionStatus] ?? 3;
-                              if (aOrder !== bOrder) return aOrder - bOrder;
-                              return aName.localeCompare(bName);
-                            })
-                            .map(([name, server]) => {
-                              const isSelected =
-                                selectedServers?.includes(name) ?? false;
-                              const isConnected =
-                                server.connectionStatus === "connected";
-                              const isConnecting =
-                                server.connectionStatus === "connecting";
-                              const isFailed =
-                                server.connectionStatus === "failed";
-                              const statusColor = isConnected
-                                ? "bg-green-500 dark:bg-green-400"
-                                : isConnecting
-                                  ? "bg-yellow-500 dark:bg-yellow-400 animate-pulse"
-                                  : isFailed
-                                    ? "bg-red-500 dark:bg-red-400"
-                                    : "bg-muted-foreground";
+                            <div className="max-h-48 overflow-y-auto">
+                              {Object.entries(allServerConfigs)
+                                .sort(([aName, a], [bName, b]) => {
+                                  const statusOrder: Record<string, number> = {
+                                    connected: 0,
+                                    connecting: 1,
+                                    failed: 2,
+                                  };
+                                  const aOrder =
+                                    statusOrder[a.connectionStatus] ?? 3;
+                                  const bOrder =
+                                    statusOrder[b.connectionStatus] ?? 3;
+                                  if (aOrder !== bOrder) return aOrder - bOrder;
+                                  return aName.localeCompare(bName);
+                                })
+                                .map(([name, server]) => {
+                                  const isSelected =
+                                    selectedServers?.includes(name) ?? false;
+                                  const isConnected =
+                                    server.connectionStatus === "connected";
+                                  const isConnecting =
+                                    server.connectionStatus === "connecting";
+                                  const isFailed =
+                                    server.connectionStatus === "failed";
+                                  const statusColor = isConnected
+                                    ? "bg-green-500 dark:bg-green-400"
+                                    : isConnecting
+                                      ? "bg-yellow-500 dark:bg-yellow-400 animate-pulse"
+                                      : isFailed
+                                        ? "bg-red-500 dark:bg-red-400"
+                                        : "bg-muted-foreground";
 
-                              return (
-                                <div
-                                  key={name}
-                                  className="flex items-center justify-between gap-2 rounded-md px-2 py-2 hover:bg-muted/60"
-                                >
-                                  <div className="flex items-center gap-2 min-w-0">
+                                  return (
                                     <div
-                                      className={cn(
-                                        "w-2 h-2 rounded-full shrink-0",
-                                        statusColor,
-                                      )}
-                                    />
-                                    <span
-                                      className={cn(
-                                        "text-sm font-medium truncate",
-                                        !isConnected &&
-                                          !isConnecting &&
-                                          "text-muted-foreground",
-                                      )}
+                                      key={name}
+                                      className="flex items-center justify-between gap-2 rounded-md px-2 py-2 hover:bg-muted/60"
                                     >
-                                      {name}
-                                    </span>
-                                    <span className="text-[10px] text-muted-foreground shrink-0">
-                                      {server.config.command ? "STDIO" : "HTTP"}
-                                    </span>
-                                  </div>
-                                  <div className="flex items-center shrink-0">
-                                    {isConnecting ? (
-                                      <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
-                                    ) : isConnected ? (
-                                      <Switch
-                                        checked={isSelected}
-                                        onCheckedChange={() =>
-                                          onServerToggle(name)
-                                        }
-                                      />
-                                    ) : (
-                                      <button
-                                        type="button"
-                                        className="text-xs font-medium text-primary hover:text-primary/80 transition-colors cursor-pointer px-1.5 py-0.5 rounded hover:bg-primary/5"
-                                        onClick={() => {
-                                          if (!isSelected) {
-                                            onServerToggle(name);
-                                          }
-                                          onReconnectServer?.(name).catch(
-                                            () => {},
-                                          );
-                                        }}
-                                      >
-                                        {isFailed ? "Retry" : "Connect"}
-                                      </button>
-                                    )}
-                                  </div>
-                                </div>
-                              );
-                            },
+                                      <div className="flex items-center gap-2 min-w-0">
+                                        <div
+                                          className={cn(
+                                            "w-2 h-2 rounded-full shrink-0",
+                                            statusColor,
+                                          )}
+                                        />
+                                        <span
+                                          className={cn(
+                                            "text-sm font-medium truncate",
+                                            !isConnected &&
+                                              !isConnecting &&
+                                              "text-muted-foreground",
+                                          )}
+                                        >
+                                          {name}
+                                        </span>
+                                        <span className="text-[10px] text-muted-foreground shrink-0">
+                                          {server.config.command
+                                            ? "STDIO"
+                                            : "HTTP"}
+                                        </span>
+                                      </div>
+                                      <div className="flex items-center shrink-0">
+                                        {isConnecting ? (
+                                          <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                                        ) : isConnected ? (
+                                          <Switch
+                                            checked={isSelected}
+                                            onCheckedChange={() =>
+                                              onServerToggle(name)
+                                            }
+                                          />
+                                        ) : (
+                                          <button
+                                            type="button"
+                                            className="text-xs font-medium text-primary hover:text-primary/80 transition-colors cursor-pointer px-1.5 py-0.5 rounded hover:bg-primary/5"
+                                            onClick={() => {
+                                              if (!isSelected) {
+                                                onServerToggle(name);
+                                              }
+                                              onReconnectServer?.(name).catch(
+                                                () => {},
+                                              );
+                                            }}
+                                          >
+                                            {isFailed ? "Retry" : "Connect"}
+                                          </button>
+                                        )}
+                                      </div>
+                                    </div>
+                                  );
+                                })}
+                            </div>
                           )}
-                        </div>
-                        )}
                         {onAddServer && (
                           <button
                             type="button"
@@ -703,183 +713,183 @@ export function ChatInput({
                       </div>
                     )}
 
-                  <div
-                    className={cn(
-                      "px-1 pb-1",
-                      allServerConfigs &&
-                        Object.keys(allServerConfigs).length > 0 &&
-                        "border-t border-border mt-1 pt-1",
-                    )}
-                  >
-                    {onChangeFileAttachments && (
+                    <div
+                      className={cn(
+                        "px-1 pb-1",
+                        allServerConfigs &&
+                          Object.keys(allServerConfigs).length > 0 &&
+                          "border-t border-border mt-1 pt-1",
+                      )}
+                    >
+                      {onChangeFileAttachments && (
+                        <button
+                          type="button"
+                          className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-muted/60 cursor-pointer"
+                          onClick={() => {
+                            setPlusPopoverOpen(false);
+                            openFilePicker();
+                          }}
+                        >
+                          <Paperclip className="h-4 w-4 text-muted-foreground" />
+                          Attach files
+                        </button>
+                      )}
+
                       <button
                         type="button"
                         className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-muted/60 cursor-pointer"
                         onClick={() => {
                           setPlusPopoverOpen(false);
-                          openFilePicker();
+                          setSystemPromptOpen(true);
                         }}
                       >
-                        <Paperclip className="h-4 w-4 text-muted-foreground" />
-                        Attach files
+                        <Settings2 className="h-4 w-4 text-muted-foreground" />
+                        System Prompt & Temperature
                       </button>
-                    )}
 
-                    <button
-                      type="button"
-                      className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-muted/60 cursor-pointer"
-                      onClick={() => {
-                        setPlusPopoverOpen(false);
-                        setSystemPromptOpen(true);
-                      }}
-                    >
-                      <Settings2 className="h-4 w-4 text-muted-foreground" />
-                      System Prompt & Temperature
-                    </button>
-
-                    {onRequireToolApprovalChange && (
-                      <div className="flex items-center justify-between gap-2 rounded-md px-2 py-2 hover:bg-muted/60">
-                        <div className="flex items-center gap-2 text-sm">
-                          <ShieldCheck className="h-4 w-4 text-muted-foreground" />
-                          Tool Approval
+                      {onRequireToolApprovalChange && (
+                        <div className="flex items-center justify-between gap-2 rounded-md px-2 py-2 hover:bg-muted/60">
+                          <div className="flex items-center gap-2 text-sm">
+                            <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+                            Tool Approval
+                          </div>
+                          <Switch
+                            checked={requireToolApproval}
+                            onCheckedChange={(checked) =>
+                              onRequireToolApprovalChange(checked)
+                            }
+                          />
                         </div>
-                        <Switch
-                          checked={requireToolApproval}
-                          onCheckedChange={(checked) =>
-                            onRequireToolApprovalChange(checked)
-                          }
-                        />
-                      </div>
-                    )}
-                  </div>
-                </PopoverContent>
-              </Popover>
-            )}
-            {!minimalMode && (
-              <ModelSelector
-                currentModel={currentModel}
-                availableModels={availableModels}
-                onModelChange={onModelChange}
-                isLoading={isLoading}
-                hasMessages={hasMessages}
-                enableMultiModel={enableMultiModel}
-                multiModelEnabled={multiModelEnabled}
-                selectedModels={effectiveSelectedModels}
-                onSelectedModelsChange={onSelectedModelsChange}
-                onMultiModelEnabledChange={onMultiModelEnabledChange}
-              />
-            )}
-          </div>
+                      )}
+                    </div>
+                  </PopoverContent>
+                </Popover>
+              )}
+              {!minimalMode && (
+                <ModelSelector
+                  currentModel={currentModel}
+                  availableModels={availableModels}
+                  onModelChange={onModelChange}
+                  isLoading={isLoading}
+                  hasMessages={hasMessages}
+                  enableMultiModel={enableMultiModel}
+                  multiModelEnabled={multiModelEnabled}
+                  selectedModels={effectiveSelectedModels}
+                  onSelectedModelsChange={onSelectedModelsChange}
+                  onMultiModelEnabledChange={onMultiModelEnabledChange}
+                />
+              )}
+            </div>
 
-          <div className="flex items-center gap-2 flex-shrink-0">
-            {!minimalMode && !hideContextPopover && (
-              <Context
-                usedTokens={tokenUsage?.totalTokens ?? 0}
-                usage={
-                  tokenUsage && tokenUsage.totalTokens > 0
-                    ? {
-                        inputTokens: tokenUsage.inputTokens,
-                        outputTokens: tokenUsage.outputTokens,
-                        totalTokens: tokenUsage.totalTokens,
-                        inputTokenDetails: {
-                          noCacheTokens: undefined,
-                          cacheReadTokens: undefined,
-                          cacheWriteTokens: undefined,
-                        },
-                        outputTokenDetails: {
-                          textTokens: undefined,
-                          reasoningTokens: undefined,
-                        },
-                      }
-                    : undefined
-                }
-                modelId={`${currentModel.id}`}
-                selectedServers={selectedServers}
-                mcpToolsTokenCount={mcpToolsTokenCount}
-                mcpToolsTokenCountLoading={mcpToolsTokenCountLoading}
-                connectedOrConnectingServerConfigs={
-                  connectedOrConnectingServerConfigs
-                }
-                systemPromptTokenCount={systemPromptTokenCount}
-                systemPromptTokenCountLoading={systemPromptTokenCountLoading}
-                hasMessages={hasMessages}
-              >
-                <ContextTrigger />
-                {/* Only render popover content when there's something to show */}
-                {(hasMessages && tokenUsage && tokenUsage.totalTokens > 0) ||
-                (systemPromptTokenCount && systemPromptTokenCount > 0) ||
-                systemPromptTokenCountLoading ||
-                (mcpToolsTokenCount &&
-                  Object.keys(mcpToolsTokenCount).length > 0) ||
-                mcpToolsTokenCountLoading ? (
-                  <ContextContent>
-                    {hasMessages &&
-                      tokenUsage &&
-                      tokenUsage.totalTokens > 0 && <ContextContentHeader />}
-                    <ContextContentBody>
+            <div className="flex items-center gap-2 flex-shrink-0">
+              {!minimalMode && !hideContextPopover && (
+                <Context
+                  usedTokens={tokenUsage?.totalTokens ?? 0}
+                  usage={
+                    tokenUsage && tokenUsage.totalTokens > 0
+                      ? {
+                          inputTokens: tokenUsage.inputTokens,
+                          outputTokens: tokenUsage.outputTokens,
+                          totalTokens: tokenUsage.totalTokens,
+                          inputTokenDetails: {
+                            noCacheTokens: undefined,
+                            cacheReadTokens: undefined,
+                            cacheWriteTokens: undefined,
+                          },
+                          outputTokenDetails: {
+                            textTokens: undefined,
+                            reasoningTokens: undefined,
+                          },
+                        }
+                      : undefined
+                  }
+                  modelId={`${currentModel.id}`}
+                  selectedServers={selectedServers}
+                  mcpToolsTokenCount={mcpToolsTokenCount}
+                  mcpToolsTokenCountLoading={mcpToolsTokenCountLoading}
+                  connectedOrConnectingServerConfigs={
+                    connectedOrConnectingServerConfigs
+                  }
+                  systemPromptTokenCount={systemPromptTokenCount}
+                  systemPromptTokenCountLoading={systemPromptTokenCountLoading}
+                  hasMessages={hasMessages}
+                >
+                  <ContextTrigger />
+                  {/* Only render popover content when there's something to show */}
+                  {(hasMessages && tokenUsage && tokenUsage.totalTokens > 0) ||
+                  (systemPromptTokenCount && systemPromptTokenCount > 0) ||
+                  systemPromptTokenCountLoading ||
+                  (mcpToolsTokenCount &&
+                    Object.keys(mcpToolsTokenCount).length > 0) ||
+                  mcpToolsTokenCountLoading ? (
+                    <ContextContent>
                       {hasMessages &&
                         tokenUsage &&
-                        tokenUsage.totalTokens > 0 && (
-                          <>
-                            <ContextInputUsage />
-                            <ContextOutputUsage />
-                          </>
-                        )}
-                      <ContextSystemPromptUsage />
-                      <ContextMCPServerUsage />
-                    </ContextContentBody>
-                  </ContextContent>
-                ) : null}
-              </Context>
-            )}
-            {isLoading ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="secondary"
-                    className="size-[34px] rounded-full transition-colors"
-                    aria-label="Stop generating"
-                    onClick={() => stop()}
-                  >
-                    <Square size={16} />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Stop generating</TooltipContent>
-              </Tooltip>
-            ) : (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="submit"
-                    size="icon"
-                    aria-label="Send message"
-                    className={cn(
-                      "size-[34px] rounded-full transition-colors shadow-none",
-                      (value.trim() || hasResults) &&
-                        !disabled &&
-                        !submitDisabled
-                        ? activeSubmitButtonClasses
-                        : inactiveSubmitButtonClasses,
-                      pulseSubmit && "animate-onboarding-pulse",
-                    )}
-                    disabled={
-                      (!value.trim() && !hasResults) ||
-                      disabled ||
-                      submitDisabled
-                    }
-                  >
-                    <ArrowUp size={16} />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Send message</TooltipContent>
-              </Tooltip>
-            )}
+                        tokenUsage.totalTokens > 0 && <ContextContentHeader />}
+                      <ContextContentBody>
+                        {hasMessages &&
+                          tokenUsage &&
+                          tokenUsage.totalTokens > 0 && (
+                            <>
+                              <ContextInputUsage />
+                              <ContextOutputUsage />
+                            </>
+                          )}
+                        <ContextSystemPromptUsage />
+                        <ContextMCPServerUsage />
+                      </ContextContentBody>
+                    </ContextContent>
+                  ) : null}
+                </Context>
+              )}
+              {isLoading ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="secondary"
+                      className="size-[34px] rounded-full transition-colors"
+                      aria-label="Stop generating"
+                      onClick={() => stop()}
+                    >
+                      <Square size={16} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Stop generating</TooltipContent>
+                </Tooltip>
+              ) : (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="submit"
+                      size="icon"
+                      aria-label="Send message"
+                      className={cn(
+                        "size-[34px] rounded-full transition-colors shadow-none",
+                        (value.trim() || hasResults) &&
+                          !disabled &&
+                          !submitDisabled
+                          ? activeSubmitButtonClasses
+                          : inactiveSubmitButtonClasses,
+                        pulseSubmit && "animate-onboarding-pulse",
+                      )}
+                      disabled={
+                        (!value.trim() && !hasResults) ||
+                        disabled ||
+                        submitDisabled
+                      }
+                    >
+                      <ArrowUp size={16} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Send message</TooltipContent>
+                </Tooltip>
+              )}
+            </div>
           </div>
         </div>
-      </div>
-    </form>
+      </form>
 
       {onAddServer && (
         <AddServerModal

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -34,7 +34,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { ModelSelector } from "@/components/chat-v2/chat-input/model-selector";
-import { ModelDefinition } from "@/shared/types";
+import { ModelDefinition, ServerFormData } from "@/shared/types";
+import { AddServerModal } from "@/components/connection/AddServerModal";
 import type { ServerWithName } from "@/hooks/use-app-state";
 import { SystemPromptSelector } from "@/components/chat-v2/chat-input/system-prompt-selector";
 import { useTextareaCaretPosition } from "@/hooks/use-textarea-caret-position";
@@ -128,6 +129,8 @@ interface ChatInputProps {
   onServerToggle?: (serverName: string) => void;
   /** Reconnect a disconnected server. */
   onReconnectServer?: (serverName: string) => Promise<void>;
+  /** Add a new server (opens the add-server modal). */
+  onAddServer?: (formData: ServerFormData) => void;
   /** Hosted sandbox: optional servers not yet connected (Add server popover). */
   sandboxAttachableServers?: Array<{
     serverId: string;
@@ -182,6 +185,7 @@ export function ChatInput({
   allServerConfigs,
   onServerToggle,
   onReconnectServer,
+  onAddServer,
   sandboxAttachableServers,
   onAttachSandboxServer,
 }: ChatInputProps) {
@@ -200,6 +204,8 @@ export function ChatInput({
   >(null);
   const [fileError, setFileError] = useState<string | null>(null);
   const [plusPopoverOpen, setPlusPopoverOpen] = useState(false);
+  const [addServerModalOpen, setAddServerModalOpen] = useState(false);
+  const [systemPromptOpen, setSystemPromptOpen] = useState(false);
 
   const caret = useTextareaCaretPosition(
     textareaRef,
@@ -438,6 +444,7 @@ export function ChatInput({
         : "bg-muted text-muted-foreground cursor-not-allowed";
 
   return (
+    <>
     <form ref={formRef} className={cn("w-full", className)} onSubmit={onSubmit}>
       <div
         ref={containerRef}
@@ -580,16 +587,31 @@ export function ChatInput({
                   side="top"
                   sideOffset={8}
                 >
-                  {allServerConfigs &&
-                    onServerToggle &&
-                    Object.keys(allServerConfigs).length > 0 && (
+                  {(onAddServer ||
+                    (allServerConfigs &&
+                      onServerToggle &&
+                      Object.keys(allServerConfigs).length > 0)) && (
                       <div className="px-1 pt-1 pb-0">
                         <p className="px-2 py-1.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
                           Servers
                         </p>
+                        {allServerConfigs &&
+                          onServerToggle &&
+                          Object.keys(allServerConfigs).length > 0 && (
                         <div className="max-h-48 overflow-y-auto">
-                          {Object.entries(allServerConfigs).map(
-                            ([name, server]) => {
+                          {Object.entries(allServerConfigs)
+                            .sort(([aName, a], [bName, b]) => {
+                              const statusOrder: Record<string, number> = {
+                                connected: 0,
+                                connecting: 1,
+                                failed: 2,
+                              };
+                              const aOrder = statusOrder[a.connectionStatus] ?? 3;
+                              const bOrder = statusOrder[b.connectionStatus] ?? 3;
+                              if (aOrder !== bOrder) return aOrder - bOrder;
+                              return aName.localeCompare(bName);
+                            })
+                            .map(([name, server]) => {
                               const isSelected =
                                 selectedServers?.includes(name) ?? false;
                               const isConnected =
@@ -664,6 +686,20 @@ export function ChatInput({
                             },
                           )}
                         </div>
+                        )}
+                        {onAddServer && (
+                          <button
+                            type="button"
+                            className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm text-muted-foreground hover:text-foreground hover:bg-muted/60 cursor-pointer"
+                            onClick={() => {
+                              setPlusPopoverOpen(false);
+                              setAddServerModalOpen(true);
+                            }}
+                          >
+                            <Plus className="h-3.5 w-3.5" />
+                            Add server
+                          </button>
+                        )}
                       </div>
                     )}
 
@@ -689,31 +725,17 @@ export function ChatInput({
                       </button>
                     )}
 
-                    <SystemPromptSelector
-                      systemPrompt={
-                        systemPrompt ||
-                        "You are a helpful assistant with access to MCP tools."
-                      }
-                      onSystemPromptChange={onSystemPromptChange}
-                      temperature={temperature}
-                      onTemperatureChange={onTemperatureChange}
-                      isLoading={isLoading}
-                      hasMessages={hasMessages}
-                      onResetChat={onResetChat}
-                      currentModel={currentModel}
-                      multiModelEnabled={multiModelEnabled}
-                      selectedModels={effectiveSelectedModels}
-                      renderTrigger={
-                        <button
-                          type="button"
-                          className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-muted/60 cursor-pointer"
-                          onClick={() => setPlusPopoverOpen(false)}
-                        >
-                          <Settings2 className="h-4 w-4 text-muted-foreground" />
-                          System Prompt & Temperature
-                        </button>
-                      }
-                    />
+                    <button
+                      type="button"
+                      className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-muted/60 cursor-pointer"
+                      onClick={() => {
+                        setPlusPopoverOpen(false);
+                        setSystemPromptOpen(true);
+                      }}
+                    >
+                      <Settings2 className="h-4 w-4 text-muted-foreground" />
+                      System Prompt & Temperature
+                    </button>
 
                     {onRequireToolApprovalChange && (
                       <div className="flex items-center justify-between gap-2 rounded-md px-2 py-2 hover:bg-muted/60">
@@ -858,5 +880,37 @@ export function ChatInput({
         </div>
       </div>
     </form>
+
+      {onAddServer && (
+        <AddServerModal
+          isOpen={addServerModalOpen}
+          onClose={() => setAddServerModalOpen(false)}
+          onSubmit={(formData) => {
+            onAddServer(formData);
+            setAddServerModalOpen(false);
+          }}
+        />
+      )}
+
+      {!minimalMode && (
+        <SystemPromptSelector
+          systemPrompt={
+            systemPrompt ||
+            "You are a helpful assistant with access to MCP tools."
+          }
+          onSystemPromptChange={onSystemPromptChange}
+          temperature={temperature}
+          onTemperatureChange={onTemperatureChange}
+          isLoading={isLoading}
+          hasMessages={hasMessages}
+          onResetChat={onResetChat}
+          currentModel={currentModel}
+          multiModelEnabled={multiModelEnabled}
+          selectedModels={effectiveSelectedModels}
+          open={systemPromptOpen}
+          onOpenChange={setSystemPromptOpen}
+        />
+      )}
+    </>
   );
 }

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -17,7 +17,7 @@ import {
   ShieldCheck,
   Plus,
   Settings2,
-  RefreshCw,
+  Loader2,
 } from "lucide-react";
 import { Switch } from "@/components/ui/switch";
 import { FileAttachmentCard } from "@/components/chat-v2/chat-input/attachments/file-attachment-card";
@@ -598,8 +598,6 @@ export function ChatInput({
                                 server.connectionStatus === "connecting";
                               const isFailed =
                                 server.connectionStatus === "failed";
-                              const isDisconnected =
-                                !isConnected && !isConnecting;
                               const statusColor = isConnected
                                 ? "bg-green-500 dark:bg-green-400"
                                 : isConnecting
@@ -607,18 +605,6 @@ export function ChatInput({
                                   : isFailed
                                     ? "bg-red-500 dark:bg-red-400"
                                     : "bg-muted-foreground";
-
-                              const handleToggle = () => {
-                                const turningOn = !isSelected;
-                                onServerToggle(name);
-                                if (
-                                  turningOn &&
-                                  isDisconnected &&
-                                  onReconnectServer
-                                ) {
-                                  onReconnectServer(name).catch(() => {});
-                                }
-                              };
 
                               return (
                                 <div
@@ -635,8 +621,8 @@ export function ChatInput({
                                     <span
                                       className={cn(
                                         "text-sm font-medium truncate",
-                                        isDisconnected &&
-                                          !isSelected &&
+                                        !isConnected &&
+                                          !isConnecting &&
                                           "text-muted-foreground",
                                       )}
                                     >
@@ -646,34 +632,32 @@ export function ChatInput({
                                       {server.config.command ? "STDIO" : "HTTP"}
                                     </span>
                                   </div>
-                                  <div className="flex items-center gap-1.5 shrink-0">
-                                    {isSelected &&
-                                      isFailed &&
-                                      onReconnectServer && (
-                                        <Tooltip>
-                                          <TooltipTrigger asChild>
-                                            <button
-                                              type="button"
-                                              className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/80 transition-colors"
-                                              onClick={(e) => {
-                                                e.stopPropagation();
-                                                onReconnectServer(
-                                                  name,
-                                                ).catch(() => {});
-                                              }}
-                                            >
-                                              <RefreshCw className="w-3 h-3" />
-                                            </button>
-                                          </TooltipTrigger>
-                                          <TooltipContent side="left">
-                                            Reconnect
-                                          </TooltipContent>
-                                        </Tooltip>
-                                      )}
-                                    <Switch
-                                      checked={isSelected}
-                                      onCheckedChange={handleToggle}
-                                    />
+                                  <div className="flex items-center shrink-0">
+                                    {isConnecting ? (
+                                      <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+                                    ) : isConnected ? (
+                                      <Switch
+                                        checked={isSelected}
+                                        onCheckedChange={() =>
+                                          onServerToggle(name)
+                                        }
+                                      />
+                                    ) : (
+                                      <button
+                                        type="button"
+                                        className="text-xs font-medium text-primary hover:text-primary/80 transition-colors cursor-pointer px-1.5 py-0.5 rounded hover:bg-primary/5"
+                                        onClick={() => {
+                                          if (!isSelected) {
+                                            onServerToggle(name);
+                                          }
+                                          onReconnectServer?.(name).catch(
+                                            () => {},
+                                          );
+                                        }}
+                                      >
+                                        {isFailed ? "Retry" : "Connect"}
+                                      </button>
+                                    )}
                                   </div>
                                 </div>
                               );

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -10,7 +10,16 @@ import { cn } from "@/lib/chat-utils";
 import { Button } from "@/components/ui/button";
 import { TextareaAutosize } from "@/components/ui/textarea-autosize";
 import { PromptsPopover } from "@/components/chat-v2/chat-input/prompts/mcp-prompts-popover";
-import { ArrowUp, Square, Paperclip, ShieldCheck, Plus } from "lucide-react";
+import {
+  ArrowUp,
+  Square,
+  Paperclip,
+  ShieldCheck,
+  Plus,
+  Settings2,
+  RefreshCw,
+} from "lucide-react";
+import { Switch } from "@/components/ui/switch";
 import { FileAttachmentCard } from "@/components/chat-v2/chat-input/attachments/file-attachment-card";
 import {
   type FileAttachment,
@@ -26,6 +35,7 @@ import {
 } from "@/components/ui/tooltip";
 import { ModelSelector } from "@/components/chat-v2/chat-input/model-selector";
 import { ModelDefinition } from "@/shared/types";
+import type { ServerWithName } from "@/hooks/use-app-state";
 import { SystemPromptSelector } from "@/components/chat-v2/chat-input/system-prompt-selector";
 import { useTextareaCaretPosition } from "@/hooks/use-textarea-caret-position";
 import {
@@ -112,6 +122,12 @@ interface ChatInputProps {
   pulseSubmit?: boolean;
   /** Move the textarea caret to the end when this trigger changes */
   moveCaretToEndTrigger?: number;
+  /** All workspace servers for the "+" dropdown server toggles. */
+  allServerConfigs?: Record<string, ServerWithName>;
+  /** Toggle a server on/off for the current chat session. */
+  onServerToggle?: (serverName: string) => void;
+  /** Reconnect a disconnected server. */
+  onReconnectServer?: (serverName: string) => Promise<void>;
   /** Hosted sandbox: optional servers not yet connected (Add server popover). */
   sandboxAttachableServers?: Array<{
     serverId: string;
@@ -163,6 +179,9 @@ export function ChatInput({
   minimalMode = false,
   pulseSubmit = false,
   moveCaretToEndTrigger,
+  allServerConfigs,
+  onServerToggle,
+  onReconnectServer,
   sandboxAttachableServers,
   onAttachSandboxServer,
 }: ChatInputProps) {
@@ -180,6 +199,7 @@ export function ChatInput({
     string | null
   >(null);
   const [fileError, setFileError] = useState<string | null>(null);
+  const [plusPopoverOpen, setPlusPopoverOpen] = useState(false);
 
   const caret = useTextareaCaretPosition(
     textareaRef,
@@ -535,88 +555,213 @@ export function ChatInput({
 
         <div className="@container/toolbar flex items-center justify-between gap-2 px-2 min-w-0">
           <div className="flex items-center gap-1 min-w-0 flex-shrink overflow-hidden">
-            {!minimalMode && onChangeFileAttachments && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 rounded-full"
-                    onClick={openFilePicker}
-                    disabled={disabled}
-                  >
-                    <Paperclip className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Attach files</TooltipContent>
-              </Tooltip>
-            )}
             {!minimalMode && (
-              <>
-                <ModelSelector
-                  currentModel={currentModel}
-                  availableModels={availableModels}
-                  onModelChange={onModelChange}
-                  isLoading={isLoading}
-                  hasMessages={hasMessages}
-                  enableMultiModel={enableMultiModel}
-                  multiModelEnabled={multiModelEnabled}
-                  selectedModels={effectiveSelectedModels}
-                  onSelectedModelsChange={onSelectedModelsChange}
-                  onMultiModelEnabledChange={onMultiModelEnabledChange}
-                />
-                <SystemPromptSelector
-                  systemPrompt={
-                    systemPrompt ||
-                    "You are a helpful assistant with access to MCP tools."
-                  }
-                  onSystemPromptChange={onSystemPromptChange}
-                  temperature={temperature}
-                  onTemperatureChange={onTemperatureChange}
-                  isLoading={isLoading}
-                  hasMessages={hasMessages}
-                  onResetChat={onResetChat}
-                  currentModel={currentModel}
-                  multiModelEnabled={multiModelEnabled}
-                  selectedModels={effectiveSelectedModels}
-                />
-              </>
-            )}
-            {!minimalMode && onRequireToolApprovalChange && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant={requireToolApproval ? "secondary" : "ghost"}
-                    size="sm"
-                    onClick={() =>
-                      onRequireToolApprovalChange(!requireToolApproval)
-                    }
+              <Popover open={plusPopoverOpen} onOpenChange={setPlusPopoverOpen}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <PopoverTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8 rounded-full"
+                        disabled={disabled}
+                        aria-label="Options"
+                      >
+                        <Plus className="h-4 w-4" />
+                      </Button>
+                    </PopoverTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>Options</TooltipContent>
+                </Tooltip>
+                <PopoverContent
+                  className="w-72 p-0"
+                  align="start"
+                  side="top"
+                  sideOffset={8}
+                >
+                  {allServerConfigs &&
+                    onServerToggle &&
+                    Object.keys(allServerConfigs).length > 0 && (
+                      <div className="px-1 pt-1 pb-0">
+                        <p className="px-2 py-1.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+                          Servers
+                        </p>
+                        <div className="max-h-48 overflow-y-auto">
+                          {Object.entries(allServerConfigs).map(
+                            ([name, server]) => {
+                              const isSelected =
+                                selectedServers?.includes(name) ?? false;
+                              const isConnected =
+                                server.connectionStatus === "connected";
+                              const isConnecting =
+                                server.connectionStatus === "connecting";
+                              const isFailed =
+                                server.connectionStatus === "failed";
+                              const isDisconnected =
+                                !isConnected && !isConnecting;
+                              const statusColor = isConnected
+                                ? "bg-green-500 dark:bg-green-400"
+                                : isConnecting
+                                  ? "bg-yellow-500 dark:bg-yellow-400 animate-pulse"
+                                  : isFailed
+                                    ? "bg-red-500 dark:bg-red-400"
+                                    : "bg-muted-foreground";
+
+                              const handleToggle = () => {
+                                const turningOn = !isSelected;
+                                onServerToggle(name);
+                                if (
+                                  turningOn &&
+                                  isDisconnected &&
+                                  onReconnectServer
+                                ) {
+                                  onReconnectServer(name).catch(() => {});
+                                }
+                              };
+
+                              return (
+                                <div
+                                  key={name}
+                                  className="flex items-center justify-between gap-2 rounded-md px-2 py-2 hover:bg-muted/60"
+                                >
+                                  <div className="flex items-center gap-2 min-w-0">
+                                    <div
+                                      className={cn(
+                                        "w-2 h-2 rounded-full shrink-0",
+                                        statusColor,
+                                      )}
+                                    />
+                                    <span
+                                      className={cn(
+                                        "text-sm font-medium truncate",
+                                        isDisconnected &&
+                                          !isSelected &&
+                                          "text-muted-foreground",
+                                      )}
+                                    >
+                                      {name}
+                                    </span>
+                                    <span className="text-[10px] text-muted-foreground shrink-0">
+                                      {server.config.command ? "STDIO" : "HTTP"}
+                                    </span>
+                                  </div>
+                                  <div className="flex items-center gap-1.5 shrink-0">
+                                    {isSelected &&
+                                      isFailed &&
+                                      onReconnectServer && (
+                                        <Tooltip>
+                                          <TooltipTrigger asChild>
+                                            <button
+                                              type="button"
+                                              className="p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/80 transition-colors"
+                                              onClick={(e) => {
+                                                e.stopPropagation();
+                                                onReconnectServer(
+                                                  name,
+                                                ).catch(() => {});
+                                              }}
+                                            >
+                                              <RefreshCw className="w-3 h-3" />
+                                            </button>
+                                          </TooltipTrigger>
+                                          <TooltipContent side="left">
+                                            Reconnect
+                                          </TooltipContent>
+                                        </Tooltip>
+                                      )}
+                                    <Switch
+                                      checked={isSelected}
+                                      onCheckedChange={handleToggle}
+                                    />
+                                  </div>
+                                </div>
+                              );
+                            },
+                          )}
+                        </div>
+                      </div>
+                    )}
+
+                  <div
                     className={cn(
-                      "h-8 px-2 rounded-full hover:bg-muted/80 transition-colors text-xs cursor-pointer",
-                      "@max-2xl/toolbar:w-8 @max-2xl/toolbar:px-0",
-                      requireToolApproval &&
-                        "bg-success/10 hover:bg-success/15",
+                      "px-1 pb-1",
+                      allServerConfigs &&
+                        Object.keys(allServerConfigs).length > 0 &&
+                        "border-t border-border mt-1 pt-1",
                     )}
                   >
-                    <ShieldCheck
-                      className={cn(
-                        "h-2 w-2 mr-1 flex-shrink-0 @max-2xl/toolbar:h-4 @max-2xl/toolbar:w-4 @max-2xl/toolbar:mr-0",
-                        requireToolApproval && "text-success",
-                      )}
+                    {onChangeFileAttachments && (
+                      <button
+                        type="button"
+                        className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-muted/60 cursor-pointer"
+                        onClick={() => {
+                          setPlusPopoverOpen(false);
+                          openFilePicker();
+                        }}
+                      >
+                        <Paperclip className="h-4 w-4 text-muted-foreground" />
+                        Attach files
+                      </button>
+                    )}
+
+                    <SystemPromptSelector
+                      systemPrompt={
+                        systemPrompt ||
+                        "You are a helpful assistant with access to MCP tools."
+                      }
+                      onSystemPromptChange={onSystemPromptChange}
+                      temperature={temperature}
+                      onTemperatureChange={onTemperatureChange}
+                      isLoading={isLoading}
+                      hasMessages={hasMessages}
+                      onResetChat={onResetChat}
+                      currentModel={currentModel}
+                      multiModelEnabled={multiModelEnabled}
+                      selectedModels={effectiveSelectedModels}
+                      renderTrigger={
+                        <button
+                          type="button"
+                          className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-muted/60 cursor-pointer"
+                          onClick={() => setPlusPopoverOpen(false)}
+                        >
+                          <Settings2 className="h-4 w-4 text-muted-foreground" />
+                          System Prompt & Temperature
+                        </button>
+                      }
                     />
-                    <span className="text-[10px] font-medium @max-2xl/toolbar:hidden">
-                      Tool Approval
-                    </span>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {requireToolApproval
-                    ? "Turn off tool approval"
-                    : "Require approval before tools run"}
-                </TooltipContent>
-              </Tooltip>
+
+                    {onRequireToolApprovalChange && (
+                      <div className="flex items-center justify-between gap-2 rounded-md px-2 py-2 hover:bg-muted/60">
+                        <div className="flex items-center gap-2 text-sm">
+                          <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+                          Tool Approval
+                        </div>
+                        <Switch
+                          checked={requireToolApproval}
+                          onCheckedChange={(checked) =>
+                            onRequireToolApprovalChange(checked)
+                          }
+                        />
+                      </div>
+                    )}
+                  </div>
+                </PopoverContent>
+              </Popover>
+            )}
+            {!minimalMode && (
+              <ModelSelector
+                currentModel={currentModel}
+                availableModels={availableModels}
+                onModelChange={onModelChange}
+                isLoading={isLoading}
+                hasMessages={hasMessages}
+                enableMultiModel={enableMultiModel}
+                multiModelEnabled={multiModelEnabled}
+                selectedModels={effectiveSelectedModels}
+                onSelectedModelsChange={onSelectedModelsChange}
+                onMultiModelEnabledChange={onMultiModelEnabledChange}
+              />
             )}
           </div>
 

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/system-prompt-selector.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/system-prompt-selector.tsx
@@ -31,6 +31,8 @@ interface SystemPromptSelectorProps {
   currentModel: ModelDefinition;
   multiModelEnabled?: boolean;
   selectedModels?: ModelDefinition[];
+  /** Custom trigger element to replace the default toolbar button. */
+  renderTrigger?: React.ReactNode;
 }
 
 export function SystemPromptSelector({
@@ -45,6 +47,7 @@ export function SystemPromptSelector({
   currentModel,
   multiModelEnabled = false,
   selectedModels,
+  renderTrigger,
 }: SystemPromptSelectorProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [draftPrompt, setDraftPrompt] = useState(systemPrompt);
@@ -98,24 +101,30 @@ export function SystemPromptSelector({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <DialogTrigger asChild>
-            <Button
-              variant="ghost"
-              size="sm"
-              disabled={disabled || isLoading}
-              className="h-8 px-2 rounded-full hover:bg-muted/80 transition-colors text-xs cursor-pointer max-w-[180px] @max-2xl/toolbar:w-8 @max-2xl/toolbar:px-0 @max-2xl/toolbar:max-w-none"
-            >
-              <Settings2 className="h-2 w-2 mr-1 flex-shrink-0 @max-2xl/toolbar:h-4 @max-2xl/toolbar:w-4 @max-2xl/toolbar:mr-0" />
-              <span className="text-[10px] font-medium truncate @max-2xl/toolbar:hidden">
-                System Prompt & Temperature
-              </span>
-            </Button>
-          </DialogTrigger>
-        </TooltipTrigger>
-        <TooltipContent side="top">System Prompt & Temperature</TooltipContent>
-      </Tooltip>
+      {renderTrigger ? (
+        <DialogTrigger asChild>{renderTrigger}</DialogTrigger>
+      ) : (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DialogTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={disabled || isLoading}
+                className="h-8 px-2 rounded-full hover:bg-muted/80 transition-colors text-xs cursor-pointer max-w-[180px] @max-2xl/toolbar:w-8 @max-2xl/toolbar:px-0 @max-2xl/toolbar:max-w-none"
+              >
+                <Settings2 className="h-2 w-2 mr-1 flex-shrink-0 @max-2xl/toolbar:h-4 @max-2xl/toolbar:w-4 @max-2xl/toolbar:mr-0" />
+                <span className="text-[10px] font-medium truncate @max-2xl/toolbar:hidden">
+                  System Prompt & Temperature
+                </span>
+              </Button>
+            </DialogTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="top">
+            System Prompt & Temperature
+          </TooltipContent>
+        </Tooltip>
+      )}
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>System Prompt & Temperature</DialogTitle>

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/system-prompt-selector.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/system-prompt-selector.tsx
@@ -33,6 +33,10 @@ interface SystemPromptSelectorProps {
   selectedModels?: ModelDefinition[];
   /** Custom trigger element to replace the default toolbar button. */
   renderTrigger?: React.ReactNode;
+  /** Controlled open state (overrides internal state when provided). */
+  open?: boolean;
+  /** Callback when controlled open state changes. */
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function SystemPromptSelector({
@@ -48,8 +52,12 @@ export function SystemPromptSelector({
   multiModelEnabled = false,
   selectedModels,
   renderTrigger,
+  open: controlledOpen,
+  onOpenChange: controlledOnOpenChange,
 }: SystemPromptSelectorProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isOpen = controlledOpen ?? internalOpen;
+  const setIsOpen = controlledOnOpenChange ?? setInternalOpen;
   const [draftPrompt, setDraftPrompt] = useState(systemPrompt);
   const [draftTemperature, setDraftTemperature] = useState(temperature);
   const [confirmReset, setConfirmReset] = useState(false);

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/system-prompt-selector.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/system-prompt-selector.tsx
@@ -109,7 +109,7 @@ export function SystemPromptSelector({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      {renderTrigger ? (
+      {controlledOpen !== undefined ? null : renderTrigger ? (
         <DialogTrigger asChild>{renderTrigger}</DialogTrigger>
       ) : (
         <Tooltip>

--- a/mcpjam-inspector/client/src/components/ui-playground/AppBuilderTab.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/AppBuilderTab.tsx
@@ -214,13 +214,18 @@ export function AppBuilderTab({
     }
   }, [serverName, reset, setTools, setExecutionError]);
 
+  const serverConnectionStatus = serverName
+    ? servers[serverName]?.connectionStatus
+    : undefined;
+
   useEffect(() => {
-    if (serverConfig && serverName) {
+    if (serverConfig && serverName && serverConnectionStatus === "connected") {
       fetchTools();
     } else {
       reset();
+      setToolsMetadata({});
     }
-  }, [serverConfig, serverName, fetchTools, reset]);
+  }, [serverConfig, serverName, serverConnectionStatus, fetchTools, reset]);
 
   // Update form fields when tool is selected
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -312,6 +312,17 @@ export function PlaygroundMain({
     serverName && servers[serverName]?.connectionStatus === "connected",
   );
 
+  const handlePlaygroundServerToggle = useCallback(
+    (name: string) => {
+      if (name === serverName) {
+        playgroundServerSelectorProps?.onServerChange("none");
+      } else {
+        playgroundServerSelectorProps?.onServerChange(name);
+      }
+    },
+    [serverName, playgroundServerSelectorProps],
+  );
+
   // Hosted mode context (workspaceId, serverIds, OAuth tokens)
   const activeWorkspace = appState.workspaces[appState.activeWorkspaceId];
   const convexWorkspaceId = activeWorkspace?.sharedWorkspaceId ?? null;
@@ -1119,6 +1130,9 @@ export function PlaygroundMain({
     pulseSubmit: composer.sendButtonOnboardingPulse,
     minimalMode: showPostConnectGuide,
     moveCaretToEndTrigger: composer.moveCaretToEndTrigger,
+    allServerConfigs: playgroundServerSelectorProps?.serverConfigs,
+    onServerToggle: handlePlaygroundServerToggle,
+    onReconnectServer: playgroundServerSelectorProps?.onReconnect,
   };
 
   // Check if widget should take over the full container

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -1133,6 +1133,7 @@ export function PlaygroundMain({
     allServerConfigs: playgroundServerSelectorProps?.serverConfigs,
     onServerToggle: handlePlaygroundServerToggle,
     onReconnectServer: playgroundServerSelectorProps?.onReconnect,
+    onAddServer: playgroundServerSelectorProps?.onConnect,
   };
 
   // Check if widget should take over the full container

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/AppBuilderTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/AppBuilderTab.test.tsx
@@ -351,7 +351,11 @@ describe("AppBuilderTab", () => {
       });
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -363,7 +367,11 @@ describe("AppBuilderTab", () => {
       const serverConfig = createServerConfig();
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -383,7 +391,11 @@ describe("AppBuilderTab", () => {
       });
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -397,7 +409,11 @@ describe("AppBuilderTab", () => {
       mockListTools.mockRejectedValue(new Error("Network error"));
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -414,7 +430,11 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.isSidebarVisible = true;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -427,7 +447,11 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.isSidebarVisible = false;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -439,7 +463,11 @@ describe("AppBuilderTab", () => {
       const serverConfig = createServerConfig();
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -451,7 +479,11 @@ describe("AppBuilderTab", () => {
       const serverConfig = createServerConfig();
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="my-server" servers={connectedServer("my-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="my-server"
+          servers={connectedServer("my-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -466,7 +498,11 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.hostStyle = "claude";
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="my-server" servers={connectedServer("my-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="my-server"
+          servers={connectedServer("my-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -481,7 +517,11 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.hostStyle = "chatgpt";
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="my-server" servers={connectedServer("my-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="my-server"
+          servers={connectedServer("my-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -500,7 +540,11 @@ describe("AppBuilderTab", () => {
       };
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -521,7 +565,11 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.isSidebarVisible = true;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -538,7 +586,11 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.isSidebarVisible = false;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -555,7 +607,11 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.isSidebarVisible = true;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -578,7 +634,11 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.isExecuting = true;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -592,7 +652,11 @@ describe("AppBuilderTab", () => {
       const serverConfig = createServerConfig();
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -643,7 +707,11 @@ describe("AppBuilderTab", () => {
       mockOnboarding.isBootstrappingFirstRunConnection = false;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       expect(screen.getByTestId("playground-main")).toBeInTheDocument();
@@ -658,7 +726,11 @@ describe("AppBuilderTab", () => {
       mockOnboarding.isGuidedPostConnect = true;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -674,7 +746,11 @@ describe("AppBuilderTab", () => {
       mockOnboarding.isGuidedPostConnect = true;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -695,7 +771,11 @@ describe("AppBuilderTab", () => {
       mockOnboarding.isBootstrappingFirstRunConnection = false;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -718,7 +798,11 @@ describe("AppBuilderTab", () => {
       mockOnboarding.isGuidedPostConnect = false;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -736,7 +820,11 @@ describe("AppBuilderTab", () => {
       mockOnboarding.isGuidedPostConnect = true;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          servers={connectedServer("test-server")}
+        />,
       );
 
       await waitFor(() => {
@@ -786,7 +874,11 @@ describe("AppBuilderTab", () => {
       const serverConfig = createServerConfig();
 
       const { rerender } = render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="server-1" servers={connectedServer("server-1")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="server-1"
+          servers={connectedServer("server-1")}
+        />,
       );
 
       await waitFor(() => {
@@ -796,7 +888,11 @@ describe("AppBuilderTab", () => {
       });
 
       rerender(
-        <AppBuilderTab serverConfig={serverConfig} serverName="server-2" servers={connectedServer("server-2")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="server-2"
+          servers={connectedServer("server-2")}
+        />,
       );
 
       await waitFor(() => {
@@ -810,7 +906,11 @@ describe("AppBuilderTab", () => {
       const serverConfig = createServerConfig();
 
       const { rerender } = render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="server-1" servers={connectedServer("server-1")} />,
+        <AppBuilderTab
+          serverConfig={serverConfig}
+          serverName="server-1"
+          servers={connectedServer("server-1")}
+        />,
       );
 
       await waitFor(() => {

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/AppBuilderTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/AppBuilderTab.test.tsx
@@ -288,6 +288,16 @@ describe("AppBuilderTab", () => {
       args: ["server.js"],
     }) as MCPServerConfig;
 
+  const connectedServer = (name: string) => ({
+    [name]: {
+      name,
+      config: createServerConfig(),
+      connectionStatus: "connected" as const,
+      lastConnectionTime: new Date(),
+      retryCount: 0,
+    },
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockListTools.mockResolvedValue({ tools: [], toolsMetadata: {} });
@@ -341,7 +351,7 @@ describe("AppBuilderTab", () => {
       });
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -353,7 +363,7 @@ describe("AppBuilderTab", () => {
       const serverConfig = createServerConfig();
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -373,7 +383,7 @@ describe("AppBuilderTab", () => {
       });
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -387,7 +397,7 @@ describe("AppBuilderTab", () => {
       mockListTools.mockRejectedValue(new Error("Network error"));
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -404,7 +414,7 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.isSidebarVisible = true;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -417,7 +427,7 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.isSidebarVisible = false;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -429,7 +439,7 @@ describe("AppBuilderTab", () => {
       const serverConfig = createServerConfig();
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -441,7 +451,7 @@ describe("AppBuilderTab", () => {
       const serverConfig = createServerConfig();
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="my-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="my-server" servers={connectedServer("my-server")} />,
       );
 
       await waitFor(() => {
@@ -456,7 +466,7 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.hostStyle = "claude";
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="my-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="my-server" servers={connectedServer("my-server")} />,
       );
 
       await waitFor(() => {
@@ -471,7 +481,7 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.hostStyle = "chatgpt";
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="my-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="my-server" servers={connectedServer("my-server")} />,
       );
 
       await waitFor(() => {
@@ -490,7 +500,7 @@ describe("AppBuilderTab", () => {
       };
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -511,7 +521,7 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.isSidebarVisible = true;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -528,7 +538,7 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.isSidebarVisible = false;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -545,7 +555,7 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.isSidebarVisible = true;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -568,7 +578,7 @@ describe("AppBuilderTab", () => {
       mockUIPlaygroundStore.isExecuting = true;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -582,7 +592,7 @@ describe("AppBuilderTab", () => {
       const serverConfig = createServerConfig();
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -633,7 +643,7 @@ describe("AppBuilderTab", () => {
       mockOnboarding.isBootstrappingFirstRunConnection = false;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       expect(screen.getByTestId("playground-main")).toBeInTheDocument();
@@ -648,7 +658,7 @@ describe("AppBuilderTab", () => {
       mockOnboarding.isGuidedPostConnect = true;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -664,7 +674,7 @@ describe("AppBuilderTab", () => {
       mockOnboarding.isGuidedPostConnect = true;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -685,7 +695,7 @@ describe("AppBuilderTab", () => {
       mockOnboarding.isBootstrappingFirstRunConnection = false;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -708,7 +718,7 @@ describe("AppBuilderTab", () => {
       mockOnboarding.isGuidedPostConnect = false;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -726,7 +736,7 @@ describe("AppBuilderTab", () => {
       mockOnboarding.isGuidedPostConnect = true;
 
       render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="test-server" servers={connectedServer("test-server")} />,
       );
 
       await waitFor(() => {
@@ -776,7 +786,7 @@ describe("AppBuilderTab", () => {
       const serverConfig = createServerConfig();
 
       const { rerender } = render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="server-1" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="server-1" servers={connectedServer("server-1")} />,
       );
 
       await waitFor(() => {
@@ -786,7 +796,7 @@ describe("AppBuilderTab", () => {
       });
 
       rerender(
-        <AppBuilderTab serverConfig={serverConfig} serverName="server-2" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="server-2" servers={connectedServer("server-2")} />,
       );
 
       await waitFor(() => {
@@ -800,7 +810,7 @@ describe("AppBuilderTab", () => {
       const serverConfig = createServerConfig();
 
       const { rerender } = render(
-        <AppBuilderTab serverConfig={serverConfig} serverName="server-1" />,
+        <AppBuilderTab serverConfig={serverConfig} serverName="server-1" servers={connectedServer("server-1")} />,
       );
 
       await waitFor(() => {


### PR DESCRIPTION
## Consolidate chat interface by removing chat-v2 tab and enhancing plus dropdown

Removed the separate "chat-v2" and "app-builder" tabs from the active tab conditions and consolidated functionality into the main chat interface.

### Key Changes

- **Removed chat-v2 tab references** from App.tsx tab conditions and server selector logic
- **Enhanced plus dropdown in chat input** with comprehensive server management:
  - Added server list with connection status indicators (connected/connecting/failed)
  - Integrated server toggle switches for multi-select functionality  
  - Added connect/retry buttons for disconnected servers
  - Moved system prompt selector and tool approval settings into dropdown
  - Moved file attachment option into dropdown
- **Updated SystemPromptSelector** to support custom trigger rendering for dropdown integration
- **Fixed AppBuilderTab** to only fetch tools when server is actually connected, not just configured
- **Added new props** to ChatTabV2 and ChatInput for server management:
  - `allServerConfigs` for workspace servers
  - `onServerToggle` for multi-select functionality
  - `onReconnectServer` for reconnection handling

The chat interface now provides a unified experience with all server management, settings, and options accessible through the streamlined plus dropdown menu.

<img width="1098" height="927" alt="Screenshot 2026-04-09 at 4 50 05 PM" src="https://github.com/user-attachments/assets/9ca9406b-210e-4411-aec8-cad4ee8f1b3b" />
