### PR TITLE
Fix prompt rows to use a user icon in the trace timeline

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
@@ -204,6 +204,41 @@ describe("TraceTimeline detail pane", () => {
     expect(stepRow).toBeUndefined();
   });
 
+  it("uses a user icon for prompt rows", () => {
+    const spans = [
+      {
+        id: "p0-step0",
+        name: "Step 1",
+        category: "step" as const,
+        startMs: 0,
+        endMs: 120,
+        promptIndex: 0,
+        stepIndex: 0,
+        messageStartIndex: 0,
+        messageEndIndex: 1,
+      },
+    ];
+    const transcriptMessages = [
+      { role: "user", content: "Need docs" },
+      { role: "assistant", content: "Sure" },
+    ];
+
+    render(
+      <TraceTimeline
+        recordedSpans={spans}
+        transcriptMessages={transcriptMessages}
+      />,
+    );
+
+    const promptRow = screen
+      .getAllByTestId("trace-row")
+      .find((el) => el.textContent?.includes('User: "Need docs"'));
+
+    expect(promptRow).toBeTruthy();
+    expect(promptRow?.querySelector("svg.lucide-user")).toBeTruthy();
+    expect(promptRow?.querySelector("svg.lucide-layers")).toBeNull();
+  });
+
   it("marks tool spans as failed from transcript when persisted status is ok", async () => {
     const user = userEvent.setup();
     const spans: EvalTraceSpan[] = [

--- a/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
@@ -19,6 +19,7 @@ import {
   MessageSquareQuote,
   Minus,
   Plus,
+  User,
   Wrench,
 } from "lucide-react";
 import type { EvalTraceSpan, EvalTraceSpanCategory } from "@/shared/eval-trace";
@@ -1026,7 +1027,7 @@ function CategoryGlyph({
   );
   switch (category) {
     case "prompt":
-      return <Layers className={iconClass} aria-hidden />;
+      return <User className={iconClass} aria-hidden />;
     case "llm":
       return <Bot className={iconClass} aria-hidden />;
     case "tool":


### PR DESCRIPTION
## Summary
- replace the prompt-row glyph in the eval trace timeline from `Layers` to `User`
- add a regression test to verify prompt rows render the user icon and no longer render the layers icon

## Testing
- Not run (not requested)