### PR TITLE
Fix tri tab colors

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -1930,6 +1930,7 @@ export function ChatTabV2({
                 {showTopTraceViewTabs ? (
                   <ChatTraceViewModeHeaderBar
                     mode={activeTraceViewMode}
+                    activeVariant="sidebar"
                     onModeChange={(mode) => {
                       if (mode === "tools") {
                         return;
@@ -2143,6 +2144,7 @@ export function ChatTabV2({
                 {showTopTraceViewTabs ? (
                   <ChatTraceViewModeHeaderBar
                     mode={activeTraceViewMode}
+                    activeVariant="sidebar"
                     onModeChange={(mode) => {
                       if (mode === "tools") {
                         return;

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-compare-card-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-compare-card-header.test.tsx
@@ -91,6 +91,25 @@ describe("ModelCompareCardHeader", () => {
     expect(screen.getByText("Latency")).toBeInTheDocument();
   });
 
+  it("uses the sidebar-selected styling for active trace tabs", () => {
+    render(
+      <ModelCompareCardHeader
+        model={model}
+        summary={idleSummary}
+        allSummaries={[]}
+        mode="chat"
+        onModeChange={vi.fn()}
+        showTraceTabs={true}
+        showComparisonChrome={false}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Chat" })).toHaveClass(
+      "bg-sidebar-accent",
+      "text-sidebar-accent-foreground",
+    );
+  });
+
   it("hides status dot and Tools row in compact mode (default)", () => {
     const withTools: MultiModelCardSummary = {
       ...idleSummary,

--- a/mcpjam-inspector/client/src/components/chat-v2/model-compare-card-header.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/model-compare-card-header.tsx
@@ -267,6 +267,7 @@ export function ModelCompareCardHeader({
       {showTraceTabs ? (
         <ChatTraceViewModeHeaderBar
           mode={mode as TraceViewMode}
+          activeVariant="sidebar"
           onModeChange={(nextMode) => {
             if (nextMode === "tools") {
               return;

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-view-mode-tabs.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-view-mode-tabs.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TraceViewModeTabs } from "../trace-view-mode-tabs";
+
+describe("TraceViewModeTabs", () => {
+  it("keeps the default active styling when no variant is requested", () => {
+    render(
+      <TraceViewModeTabs
+        mode="chat"
+        onModeChange={vi.fn()}
+        showToolsTab={false}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Chat" })).toHaveClass(
+      "bg-primary/10",
+      "text-foreground",
+    );
+  });
+
+  it("can opt into the sidebar active styling when explicitly requested", () => {
+    render(
+      <TraceViewModeTabs
+        mode="chat"
+        onModeChange={vi.fn()}
+        showToolsTab={false}
+        activeVariant="sidebar"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Chat" })).toHaveClass(
+      "bg-sidebar-accent",
+      "text-sidebar-accent-foreground",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
@@ -12,6 +12,7 @@ export function TraceViewModeTabs({
   onModeChange,
   showToolsTab,
   layout = "default",
+  activeVariant = "default",
   className,
 }: {
   mode: TraceViewMode;
@@ -19,6 +20,7 @@ export function TraceViewModeTabs({
   showToolsTab: boolean;
   /** `fullWidth`: equal-width segments across the container (e.g. chat trace header). */
   layout?: "default" | "fullWidth";
+  activeVariant?: "default" | "sidebar";
   className?: string;
 }) {
   const fullWidth = layout === "fullWidth";
@@ -28,7 +30,9 @@ export function TraceViewModeTabs({
       "inline-flex min-w-0 items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors",
       fullWidth && "min-h-8 flex-1 basis-0 justify-center",
       active
-        ? "bg-primary/10 font-medium text-foreground"
+        ? activeVariant === "sidebar"
+          ? "bg-sidebar-accent font-medium text-sidebar-accent-foreground"
+          : "bg-primary/10 font-medium text-foreground"
         : "text-muted-foreground hover:text-foreground",
     );
 
@@ -90,10 +94,12 @@ export function TraceViewModeTabs({
 export function ChatTraceViewModeHeaderBar({
   mode,
   onModeChange,
+  activeVariant = "default",
   className,
 }: {
   mode: TraceViewMode;
   onModeChange: (mode: TraceViewMode) => void;
+  activeVariant?: "default" | "sidebar";
   className?: string;
 }) {
   return (
@@ -109,6 +115,7 @@ export function ChatTraceViewModeHeaderBar({
           mode={mode}
           onModeChange={onModeChange}
           showToolsTab={false}
+          activeVariant={activeVariant}
         />
       </div>
     </div>

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -1422,6 +1422,7 @@ export function PlaygroundMain({
           {showTraceViewTabs ? (
             <ChatTraceViewModeHeaderBar
               mode={activeTraceViewMode}
+              activeVariant="sidebar"
               onModeChange={(mode) => {
                 if (mode === "tools") {
                   return;

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -320,11 +320,17 @@ vi.mock("@/components/evals/trace-view-mode-tabs", () => {
   const tabs = ({
     mode,
     onModeChange,
+    activeVariant,
   }: {
     mode: "chat" | "timeline" | "raw";
     onModeChange: (mode: "chat" | "timeline" | "raw" | "tools") => void;
+    activeVariant?: "default" | "sidebar";
   }) => (
-    <div data-testid="trace-view-tabs" data-mode={mode}>
+    <div
+      data-testid="trace-view-tabs"
+      data-mode={mode}
+      data-active-variant={activeVariant ?? "default"}
+    >
       <button onClick={() => onModeChange("chat")}>Chat</button>
       <button onClick={() => onModeChange("timeline")}>Trace</button>
       <button onClick={() => onModeChange("raw")}>Raw</button>
@@ -336,12 +342,17 @@ vi.mock("@/components/evals/trace-view-mode-tabs", () => {
     ChatTraceViewModeHeaderBar: ({
       mode,
       onModeChange,
+      activeVariant,
     }: {
       mode: "chat" | "timeline" | "raw";
       onModeChange: (mode: "chat" | "timeline" | "raw" | "tools") => void;
+      activeVariant?: "default" | "sidebar";
     }) => (
-      <div data-testid="chat-trace-view-mode-header-bar">
-        {tabs({ mode, onModeChange })}
+      <div
+        data-testid="chat-trace-view-mode-header-bar"
+        data-active-variant={activeVariant ?? "default"}
+      >
+        {tabs({ mode, onModeChange, activeVariant })}
       </div>
     ),
   };
@@ -784,6 +795,21 @@ describe("PlaygroundMain", () => {
       render(<PlaygroundMain {...defaultProps} enableTraceViews={true} />);
 
       expect(screen.getByTestId("trace-view-tabs")).toBeInTheDocument();
+    });
+
+    it("uses the sidebar active variant for the trace header tabs", () => {
+      mockUseChatSession.messages = [];
+      mockUseChatSession.traceViewsSupported = true;
+
+      render(<PlaygroundMain {...defaultProps} enableTraceViews={true} />);
+
+      expect(
+        screen.getByTestId("chat-trace-view-mode-header-bar"),
+      ).toHaveAttribute("data-active-variant", "sidebar");
+      expect(screen.getByTestId("trace-view-tabs")).toHaveAttribute(
+        "data-active-variant",
+        "sidebar",
+      );
     });
 
     it("shows the sample raw JSON empty state on an empty thread when Raw is selected", () => {


### PR DESCRIPTION
Restore the `Trace / Chat / Raw` active-tab colors on the current hosted surfaces.

The original color change from `#1738` looked correct locally, but it did not stick on the latest hosted code path. This PR reapplies that styling on top of current `main` by restoring the shared active variant and wiring it into the places that render the tri-tab header.