### PR TITLE
claude's pulse got regressed

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/LoadingIndicatorContent.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/LoadingIndicatorContent.test.tsx
@@ -35,6 +35,21 @@ describe("LoadingIndicatorContent", () => {
     ).toHaveAttribute("hidden");
   });
 
+  it("renders animated Claude strips with explicit aspect ratios", () => {
+    render(<ClaudeLoadingIndicator />);
+
+    const strip900 = screen.getByTestId("loading-indicator-claude-strip-900");
+    const strip800 = screen.getByTestId("loading-indicator-claude-strip-800");
+
+    expect(strip900).not.toHaveAttribute("hidden");
+    expect(strip900).toHaveAttribute("preserveAspectRatio", "xMidYMin meet");
+    expect(strip900.getAttribute("style")).toContain("aspect-ratio: 1 / 9;");
+
+    expect(strip800).not.toHaveAttribute("hidden");
+    expect(strip800).toHaveAttribute("preserveAspectRatio", "xMidYMin meet");
+    expect(strip800.getAttribute("style")).toContain("aspect-ratio: 1 / 8;");
+  });
+
   it("renders the direct static Claude mode without animated strips", () => {
     render(<ClaudeLoadingIndicator mode="static" />);
 

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/claude-loading-indicator.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/claude-loading-indicator.tsx
@@ -1,4 +1,5 @@
 import { useReducedMotion } from "framer-motion";
+import type { CSSProperties } from "react";
 import { cn } from "@/lib/utils";
 
 const CLAUDE_STATIC_PATH =
@@ -21,6 +22,8 @@ interface ClaudeSvgProps {
   viewBox: string;
   pathData: string;
   className?: string;
+  preserveAspectRatio?: string;
+  style?: CSSProperties;
   testId: string;
   hidden?: boolean;
 }
@@ -29,6 +32,8 @@ function ClaudeSvg({
   viewBox,
   pathData,
   className,
+  preserveAspectRatio,
+  style,
   testId,
   hidden = false,
 }: ClaudeSvgProps) {
@@ -37,6 +42,8 @@ function ClaudeSvg({
       xmlns="http://www.w3.org/2000/svg"
       viewBox={viewBox}
       className={className}
+      preserveAspectRatio={preserveAspectRatio}
+      style={style}
       data-testid={testId}
       hidden={hidden}
     >
@@ -84,7 +91,7 @@ export function ClaudeLoadingIndicator({
             >
               <span
                 data-testid="loading-indicator-claude-stage"
-                className="claude-loading-indicator__stage relative block h-full w-full [&>svg]:block [&>svg]:w-full [&>svg]:fill-current"
+                className="claude-loading-indicator__stage relative block h-full w-full [&>svg]:block [&>svg]:w-full"
               >
                 <ClaudeSvg
                   viewBox="0 0 100 100"
@@ -97,6 +104,8 @@ export function ClaudeLoadingIndicator({
                   viewBox="0 0 100 900"
                   pathData={CLAUDE_STRIP_900_PATH}
                   className="claude-loading-indicator__strip claude-loading-indicator__strip--900"
+                  preserveAspectRatio="xMidYMin meet"
+                  style={{ aspectRatio: "1 / 9" }}
                   testId="loading-indicator-claude-strip-900"
                   hidden={!showAnimatedStrips}
                 />
@@ -104,6 +113,8 @@ export function ClaudeLoadingIndicator({
                   viewBox="0 0 100 800"
                   pathData={CLAUDE_STRIP_800_PATH}
                   className="claude-loading-indicator__strip claude-loading-indicator__strip--800"
+                  preserveAspectRatio="xMidYMin meet"
+                  style={{ aspectRatio: "1 / 8" }}
                   testId="loading-indicator-claude-strip-800"
                   hidden={!showAnimatedStrips}
                 />

--- a/mcpjam-inspector/client/src/components/hosted/SandboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/SandboxChatPage.tsx
@@ -681,6 +681,9 @@ export function SandboxChatPage({
           )}
           minimalMode
           reasoningDisplayMode="hidden"
+          loadingIndicatorVariant={
+            hostStyle === "chatgpt" ? "chatgpt-dot" : "claude-mark"
+          }
           hostedWorkspaceIdOverride={session.payload.workspaceId}
           hostedSelectedServerIdsOverride={sessionServersActive.map(
             (server) => server.serverId,

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/SandboxChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/SandboxChatPage.test.tsx
@@ -66,6 +66,7 @@ vi.mock("@/components/ChatTabV2", () => ({
       serverName?: string | null;
     }) => void;
     reasoningDisplayMode?: string;
+    loadingIndicatorVariant?: string;
   }) => {
     mockChatTabV2(props);
     const { onOAuthRequired } = props;
@@ -190,6 +191,37 @@ describe("SandboxChatPage", () => {
     expect(mockChatTabV2).toHaveBeenCalledWith(
       expect.objectContaining({
         reasoningDisplayMode: "hidden",
+        loadingIndicatorVariant: "chatgpt-dot",
+      }),
+    );
+  });
+
+  it("uses the Claude loading indicator variant for Claude-style hosted sandboxes", async () => {
+    writeSandboxSession({
+      token: "sandbox-token",
+      payload: {
+        workspaceId: "ws_1",
+        sandboxId: "sbx_1",
+        name: "Claude Sandbox",
+        description: "Hosted sandbox",
+        hostStyle: "claude",
+        mode: "invited_only",
+        allowGuestAccess: false,
+        viewerIsWorkspaceMember: true,
+        systemPrompt: "You are helpful.",
+        modelId: "anthropic/claude-sonnet-4-5",
+        temperature: 0.4,
+        requireToolApproval: true,
+        servers: [],
+      },
+    });
+
+    render(<SandboxChatPage />);
+
+    expect(await screen.findByTestId("sandbox-chat-tab")).toBeInTheDocument();
+    expect(mockChatTabV2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        loadingIndicatorVariant: "claude-mark",
       }),
     );
   });

--- a/mcpjam-inspector/client/src/index.css
+++ b/mcpjam-inspector/client/src/index.css
@@ -624,11 +624,18 @@
 
 .claude-loading-indicator__strip,
 .claude-loading-indicator__static {
-  inset: 0;
   position: absolute;
+  fill: #d97757;
+}
+
+.claude-loading-indicator__static {
+  inset: 0;
 }
 
 .claude-loading-indicator__strip {
+  left: 0;
+  top: 0;
+  width: 100%;
   height: auto;
   transform: translateY(0);
   transform-origin: top center;
@@ -638,60 +645,35 @@
 .claude-loading-indicator__strip--900 {
   animation:
     claude-strip-900-position 1.7s linear infinite,
-    claude-strip-900-visibility 1.7s linear infinite;
+    claude-strip-900-visibility 1.7s step-end infinite;
 }
 
 .claude-loading-indicator__strip--800 {
   animation:
     claude-strip-800-position 1.7s linear infinite,
-    claude-strip-800-visibility 1.7s linear infinite;
+    claude-strip-800-visibility 1.7s step-end infinite;
 }
 
+/* Use step timing within wide keyframe ranges so production minification cannot
+   collapse adjacent boundaries, while keeping the original faster frame cadence. */
 @keyframes claude-strip-900-position {
-  0%,
-  5.882353% {
+  0% {
     transform: translateY(0%);
+    animation-timing-function: steps(8, end);
   }
-  5.882354%,
-  11.764706% {
-    transform: translateY(-11.1111%);
-  }
-  11.764707%,
-  17.647059% {
-    transform: translateY(-22.2222%);
-  }
-  17.64706%,
-  23.529412% {
-    transform: translateY(-33.3333%);
-  }
-  23.529413%,
-  29.411765% {
-    transform: translateY(-44.4444%);
-  }
-  29.411766%,
-  35.294118% {
-    transform: translateY(-55.5556%);
-  }
-  35.294119%,
-  41.176471% {
-    transform: translateY(-66.6667%);
-  }
-  41.176472%,
-  47.058824% {
-    transform: translateY(-77.7778%);
-  }
-  47.058825%,
+  47.058824%,
   100% {
     transform: translateY(-88.8889%);
   }
 }
 
+/* Keep these thresholds separated enough to survive CSS minification. */
 @keyframes claude-strip-900-visibility {
   0%,
-  52.941176% {
+  52.9% {
     opacity: 1;
   }
-  52.941177%,
+  53%,
   100% {
     opacity: 0;
   }
@@ -701,32 +683,8 @@
   0%,
   58.823529% {
     transform: translateY(0%);
+    animation-timing-function: steps(7, end);
   }
-  58.82353%,
-  64.705882% {
-    transform: translateY(-12.5%);
-  }
-  64.705883%,
-  70.588235% {
-    transform: translateY(-25%);
-  }
-  70.588236%,
-  76.470588% {
-    transform: translateY(-37.5%);
-  }
-  76.470589%,
-  82.352941% {
-    transform: translateY(-50%);
-  }
-  82.352942%,
-  88.235294% {
-    transform: translateY(-62.5%);
-  }
-  88.235295%,
-  94.117647% {
-    transform: translateY(-75%);
-  }
-  94.117648%,
   100% {
     transform: translateY(-87.5%);
   }
@@ -734,10 +692,10 @@
 
 @keyframes claude-strip-800-visibility {
   0%,
-  52.941176% {
+  52.9% {
     opacity: 0;
   }
-  52.941177%,
+  53%,
   100% {
     opacity: 1;
   }


### PR DESCRIPTION
This restores the hosted Claude thinking pulse that was accidentally regressed after #1727. The diff is intentionally small: it only rewires hosted chat to use claude-mark again, restores the hardened Claude animation/CSS, and adds narrow regression tests so it does not get dropped again.


