### PR TITLE
JRPC in Hosted 

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/logger-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/logger-view.test.tsx
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/state/app-state-context", () => ({
+  useSharedAppState: () => ({
+    servers: {
+      "srv-1": { connectionStatus: "connected", name: "Notion" },
+      "srv-2": { connectionStatus: "connected", name: "GitHub" },
+    },
+  }),
+}));
+
+vi.mock("@/stores/traffic-log-store", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/stores/traffic-log-store")
+  >("@/stores/traffic-log-store");
+  return {
+    ...actual,
+    subscribeToRpcStream: vi.fn(() => () => {}),
+  };
+});
+
+import { LoggerView } from "../logger-view";
+import { useTrafficLogStore } from "@/stores/traffic-log-store";
+
+describe("LoggerView hosted rpc logs", () => {
+  beforeEach(() => {
+    useTrafficLogStore.getState().clear();
+  });
+
+  it("renders hosted server names and filters by server name prop", () => {
+    useTrafficLogStore.getState().addMcpServerLog({
+      serverId: "srv-1",
+      serverName: "Notion",
+      direction: "SEND",
+      method: "tools/list",
+      timestamp: "2026-04-10T12:00:00.000Z",
+      payload: { ok: true },
+    });
+    useTrafficLogStore.getState().addMcpServerLog({
+      serverId: "srv-2",
+      serverName: "GitHub",
+      direction: "SEND",
+      method: "tools/list",
+      timestamp: "2026-04-10T12:00:01.000Z",
+      payload: { ok: true },
+    });
+
+    render(<LoggerView serverIds={["Notion"]} />);
+
+    expect(screen.getByText("Notion")).toBeInTheDocument();
+    expect(screen.queryByText("GitHub")).not.toBeInTheDocument();
+  });
+
+  it("searches by hosted server name and copies both server name and id", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText,
+      },
+    });
+
+    useTrafficLogStore.getState().addMcpServerLog({
+      serverId: "srv-1",
+      serverName: "Notion",
+      direction: "SEND",
+      method: "tools/list",
+      timestamp: "2026-04-10T12:00:00.000Z",
+      payload: { ok: true },
+    });
+    useTrafficLogStore.getState().addMcpServerLog({
+      serverId: "srv-2",
+      serverName: "GitHub",
+      direction: "RECEIVE",
+      method: "result",
+      timestamp: "2026-04-10T12:00:01.000Z",
+      payload: { ok: false },
+    });
+
+    render(<LoggerView />);
+
+    await user.type(screen.getByPlaceholderText("Search logs"), "git");
+
+    expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(screen.queryByText("Notion")).not.toBeInTheDocument();
+
+    await user.click(screen.getByTitle("Copy logs to clipboard"));
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(writeText.mock.calls[0][0])).toEqual([
+      expect.objectContaining({
+        serverId: "srv-2",
+        serverName: "GitHub",
+      }),
+    ]);
+  });
+});

--- a/mcpjam-inspector/client/src/components/logger-view.tsx
+++ b/mcpjam-inspector/client/src/components/logger-view.tsx
@@ -56,6 +56,7 @@ interface RpcEventMessage {
 interface RenderableRpcItem {
   id: string;
   serverId: string;
+  serverName?: string;
   direction: string;
   method: string;
   timestamp: string;
@@ -90,6 +91,23 @@ function normalizePayload(
   if (payload !== null && typeof payload === "object")
     return payload as Record<string, unknown>;
   return { value: payload } as Record<string, unknown>;
+}
+
+function getDisplayServerLabel(item: {
+  serverId: string;
+  serverName?: string;
+}): string {
+  return item.serverName ?? item.serverId;
+}
+
+function getDisplayServerTitle(item: {
+  serverId: string;
+  serverName?: string;
+}): string {
+  if (item.serverName && item.serverName !== item.serverId) {
+    return `${item.serverName} (${item.serverId})`;
+  }
+  return getDisplayServerLabel(item);
 }
 
 function DirectionLabel({
@@ -151,6 +169,7 @@ export function LoggerView({
     return uiLogItems.map((item: UiLogEvent) => ({
       id: item.id,
       serverId: item.serverId,
+      serverName: undefined,
       direction: item.direction === "ui-to-host" ? "UI→HOST" : "HOST→UI",
       method: item.method,
       timestamp: item.timestamp,
@@ -166,6 +185,7 @@ export function LoggerView({
     return mcpServerRpcItems.map((item) => ({
       id: item.id,
       serverId: item.serverId,
+      serverName: item.serverName,
       direction: item.direction,
       method: item.method,
       timestamp: item.timestamp,
@@ -211,6 +231,7 @@ export function LoggerView({
       timestamp: item.timestamp,
       source: item.source,
       serverId: item.serverId,
+      ...(item.serverName ? { serverName: item.serverName } : {}),
       direction: item.direction,
       method: item.method,
       payload: item.payload,
@@ -249,7 +270,11 @@ export function LoggerView({
     // Filter by serverIds if provided
     if (serverIds && serverIds.length > 0) {
       const serverIdSet = new Set(serverIds);
-      result = result.filter((item) => serverIdSet.has(item.serverId));
+      result = result.filter(
+        (item) =>
+          serverIdSet.has(item.serverId) ||
+          (!!item.serverName && serverIdSet.has(item.serverName)),
+      );
     }
 
     // Filter by search query
@@ -258,6 +283,7 @@ export function LoggerView({
       result = result.filter((item) => {
         return (
           item.serverId.toLowerCase().includes(queryLower) ||
+          getDisplayServerLabel(item).toLowerCase().includes(queryLower) ||
           item.method.toLowerCase().includes(queryLower) ||
           item.direction.toLowerCase().includes(queryLower) ||
           JSON.stringify(item.payload).toLowerCase().includes(queryLower)
@@ -517,9 +543,9 @@ export function LoggerView({
                     </span>
                     <span
                       className="hidden sm:inline text-muted-foreground truncate max-w-[120px] text-[11px]"
-                      title={it.serverId}
+                      title={getDisplayServerTitle(it)}
                     >
-                      {it.serverId}
+                      {getDisplayServerLabel(it)}
                     </span>
                     <span className="text-muted-foreground font-mono text-[11px] whitespace-nowrap tabular-nums">
                       {new Date(it.timestamp).toLocaleTimeString()}

--- a/mcpjam-inspector/client/src/components/logger-view.tsx
+++ b/mcpjam-inspector/client/src/components/logger-view.tsx
@@ -169,7 +169,7 @@ export function LoggerView({
     return uiLogItems.map((item: UiLogEvent) => ({
       id: item.id,
       serverId: item.serverId,
-      serverName: undefined,
+      serverName: item.serverName,
       direction: item.direction === "ui-to-host" ? "UI→HOST" : "HOST→UI",
       method: item.method,
       timestamp: item.timestamp,
@@ -231,7 +231,7 @@ export function LoggerView({
       timestamp: item.timestamp,
       source: item.source,
       serverId: item.serverId,
-      ...(item.serverName ? { serverName: item.serverName } : {}),
+      serverName: item.serverName,
       direction: item.direction,
       method: item.method,
       payload: item.payload,
@@ -282,7 +282,6 @@ export function LoggerView({
       const queryLower = searchQuery.toLowerCase();
       result = result.filter((item) => {
         return (
-          item.serverId.toLowerCase().includes(queryLower) ||
           getDisplayServerLabel(item).toLowerCase().includes(queryLower) ||
           item.method.toLowerCase().includes(queryLower) ||
           item.direction.toLowerCase().includes(queryLower) ||

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatSession } from "../use-chat-session";
+import { useTrafficLogStore } from "@/stores/traffic-log-store";
 
 const mockState = vi.hoisted(() => ({
   sendMessage: vi.fn(),
@@ -19,6 +20,7 @@ const mockState = vi.hoisted(() => ({
   getCustomProviderByName: vi.fn(),
   setSelectedModelId: vi.fn(),
   useSharedChatWidgetCapture: vi.fn(),
+  latestOnData: undefined as ((part: unknown) => void) | undefined,
   convexAuth: {
     isAuthenticated: true,
     isLoading: false,
@@ -139,6 +141,7 @@ vi.mock("@/lib/apis/mcp-tokenizer-api", () => ({
 vi.mock("@/lib/session-token", () => ({
   authFetch: (...args: unknown[]) => mockState.authFetch(...args),
   getAuthHeaders: vi.fn(() => ({})),
+  addTokenToUrl: vi.fn((url: string) => url),
 }));
 
 vi.mock("@/lib/guest-session", () => ({
@@ -167,14 +170,17 @@ vi.mock("@ai-sdk/react", async () => {
       ({
         id,
         transport,
+        onData,
       }: {
         id: string;
         transport: {
           sendMessages: (options: any) => Promise<unknown>;
         };
+        onData?: (part: unknown) => void;
       }) => {
         const latchedIdRef = React.useRef(id);
         const latchedTransportRef = React.useRef(transport);
+        mockState.latestOnData = onData;
 
         if (latchedIdRef.current !== id) {
           latchedIdRef.current = id;
@@ -258,6 +264,8 @@ describe("useChatSession hosted mode", () => {
     mockState.getGuestBearerToken.mockReset();
     mockState.getGuestBearerToken.mockResolvedValue("guest-token");
     mockState.selectedModelId = "anthropic/claude-haiku-4.5";
+    mockState.latestOnData = undefined;
+    useTrafficLogStore.getState().clear();
   });
 
   it("includes chatSessionId in the hosted transport body", async () => {
@@ -276,6 +284,7 @@ describe("useChatSession hosted mode", () => {
       workspaceId: "workspace-1",
       chatSessionId: "chat-session-id",
       selectedServerIds: ["server-id-1"],
+      selectedServerNames: ["server-1"],
       shareToken: "share-token",
       accessScope: "chat_v2",
     });
@@ -298,6 +307,7 @@ describe("useChatSession hosted mode", () => {
       workspaceId: "workspace-1",
       chatSessionId: "chat-session-id",
       selectedServerIds: ["server-id-1"],
+      selectedServerNames: ["server-1"],
       sandboxToken: "sandbox-token",
       accessScope: "chat_v2",
     });
@@ -352,6 +362,7 @@ describe("useChatSession hosted mode", () => {
   it("includes the selected direct-guest server in hosted chat bodies", async () => {
     mockState.convexAuth.isAuthenticated = false;
     mockState.buildHostedServerRequest.mockReturnValue({
+      serverName: "Excalidraw (App)",
       serverUrl: "https://mcp.excalidraw.com/mcp",
       serverHeaders: { "X-Api-Key": "guest-key" },
       oauthAccessToken: "guest-oauth-token",
@@ -372,6 +383,7 @@ describe("useChatSession hosted mode", () => {
     );
     expect(body).toMatchObject({
       chatSessionId: "chat-session-id",
+      serverName: "Excalidraw (App)",
       serverUrl: "https://mcp.excalidraw.com/mcp",
       serverHeaders: { "X-Api-Key": "guest-key" },
       oauthAccessToken: "guest-oauth-token",
@@ -469,11 +481,13 @@ describe("useChatSession hosted mode", () => {
       (serverName: string) =>
         serverName === "Excalidraw (App)"
           ? {
+              serverName: "Excalidraw (App)",
               serverUrl: "https://mcp.excalidraw.com/mcp",
               serverHeaders: { "X-Api-Key": "guest-key-1" },
               oauthAccessToken: "guest-oauth-token-1",
             }
           : {
+              serverName: "Learn (App)",
               serverUrl: "https://mcp.learn.com/mcp",
               serverHeaders: { "X-Api-Key": "guest-key-2" },
               oauthAccessToken: "guest-oauth-token-2",
@@ -519,6 +533,7 @@ describe("useChatSession hosted mode", () => {
       ),
     ).toMatchObject({
       chatSessionId: initialChatSessionId,
+      serverName: "Excalidraw (App)",
       serverUrl: "https://mcp.excalidraw.com/mcp",
       serverHeaders: { "X-Api-Key": "guest-key-1" },
       oauthAccessToken: "guest-oauth-token-1",
@@ -550,6 +565,7 @@ describe("useChatSession hosted mode", () => {
       ),
     ).toMatchObject({
       chatSessionId: initialChatSessionId,
+      serverName: "Learn (App)",
       serverUrl: "https://mcp.learn.com/mcp",
       serverHeaders: { "X-Api-Key": "guest-key-2" },
       oauthAccessToken: "guest-oauth-token-2",
@@ -574,6 +590,100 @@ describe("useChatSession hosted mode", () => {
     });
     expect(body.serverUrl).toBeUndefined();
     unmount();
+  });
+
+  it("ingests hosted rpc logs from chat error responses", async () => {
+    mockState.authFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          code: "INTERNAL_ERROR",
+          message: "chat failed",
+          _rpcLogs: [
+            {
+              serverId: "server-id-1",
+              serverName: "server-1",
+              direction: "send",
+              timestamp: "2026-04-10T12:00:00.000Z",
+              message: {
+                jsonrpc: "2.0",
+                id: 1,
+                method: "tools/list",
+              },
+            },
+          ],
+        }),
+        {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const { result } = renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1"],
+        hostedWorkspaceId: "workspace-1",
+        hostedSelectedServerIds: ["server-id-1"],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSessionBootstrapComplete).toBe(true);
+    });
+
+    act(() => {
+      result.current.sendMessage({ text: "hello" });
+    });
+
+    await waitFor(() => {
+      expect(useTrafficLogStore.getState().mcpServerItems).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            serverId: "server-id-1",
+            serverName: "server-1",
+            method: "tools/list",
+          }),
+        ]),
+      );
+    });
+  });
+
+  it("ingests hosted rpc log data parts from the chat stream", async () => {
+    renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1"],
+        hostedWorkspaceId: "workspace-1",
+        hostedSelectedServerIds: ["server-id-1"],
+      }),
+    );
+
+    act(() => {
+      mockState.latestOnData?.({
+        type: "data-rpc-log",
+        data: {
+          serverId: "server-id-1",
+          serverName: "server-1",
+          direction: "receive",
+          timestamp: "2026-04-10T12:00:00.000Z",
+          message: {
+            jsonrpc: "2.0",
+            id: 1,
+            result: { tools: [] },
+          },
+        },
+      });
+    });
+
+    expect(useTrafficLogStore.getState().mcpServerItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          serverId: "server-id-1",
+          serverName: "server-1",
+          direction: "RECEIVE",
+          method: "result",
+        }),
+      ]),
+    );
   });
 
   it("keeps only the three premium hosted models disabled for anonymous hosted viewers", async () => {

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -71,6 +71,7 @@ import {
 } from "@/components/evals/trace-viewer-adapter";
 import { useSharedChatWidgetCapture } from "@/hooks/useSharedChatWidgetCapture";
 import { buildHostedServerRequest } from "@/lib/apis/web/context";
+import { ingestHostedRpcLogs } from "@/stores/traffic-log-store";
 import type { EvalTraceSpan } from "@/shared/eval-trace";
 import {
   getTraceSpansDurationMs,
@@ -87,6 +88,8 @@ import {
   buildLiveChatPreviewSpans,
   pickTranscriptForLiveTracePreview,
 } from "@/shared/live-chat-trace-preview";
+import { isHostedRpcLogDataPart } from "@/shared/hosted-rpc-log";
+import { ingestHostedRpcLogsFromResponse } from "@/lib/apis/web/rpc-logs";
 
 export interface UseChatSessionOptions {
   /** Server names to connect to */
@@ -820,8 +823,11 @@ export function useChatSession({
     liveTraceState.activeTurnHasSnapshot,
     liveTraceState.events,
   ]);
-  const handleTraceDataPart = useCallback((part: unknown) => {
+  const handleStreamDataPart = useCallback((part: unknown) => {
     if (!isTraceEventDataPart(part)) {
+      if (isHostedRpcLogDataPart(part)) {
+        ingestHostedRpcLogs([part.data]);
+      }
       return;
     }
 
@@ -957,6 +963,17 @@ export function useChatSession({
   }, [selectedModel]);
   const traceViewsSupported = HOSTED_MODE ? isMcpJamModel : true;
 
+  const hostedChatFetch = useCallback(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const response = await authFetch(input, init);
+      if (!response.ok) {
+        await ingestHostedRpcLogsFromResponse(response);
+      }
+      return response;
+    },
+    [],
+  );
+
   // Create transport
   const transport = useMemo(() => {
     let apiKey: string;
@@ -1009,6 +1026,7 @@ export function useChatSession({
         workspaceId: hostedWorkspaceId,
         chatSessionId,
         selectedServerIds: hostedSelectedServerIds,
+        selectedServerNames: selectedServers,
         accessScope: "chat_v2" as const,
         ...(isHostedDirectChat ? { directVisibility } : {}),
         ...(hostedShareToken ? { shareToken: hostedShareToken } : {}),
@@ -1024,7 +1042,7 @@ export function useChatSession({
 
     return new DefaultChatTransport({
       api: chatApi,
-      fetch: HOSTED_MODE ? authFetch : undefined,
+      fetch: HOSTED_MODE ? hostedChatFetch : undefined,
       body: () => ({
         model: selectedModel,
         ...(HOSTED_MODE ? {} : { apiKey }),
@@ -1067,6 +1085,7 @@ export function useChatSession({
     hostedShareToken,
     hostedSandboxToken,
     hostedSandboxSurface,
+    hostedChatFetch,
     // requireToolApproval read from ref at request time
   ]);
   // `@ai-sdk/react` only recreates its internal Chat when the chat id changes.
@@ -1096,7 +1115,7 @@ export function useChatSession({
   } = useChat({
     id: chatSessionId,
     transport: proxyTransport,
-    onData: handleTraceDataPart,
+    onData: handleStreamDataPart,
     sendAutomaticallyWhen: requireToolApproval
       ? lastAssistantMessageIsCompleteWithApprovalResponses
       : undefined,

--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-web-context.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-web-context.test.ts
@@ -35,6 +35,7 @@ describe("hosted web context", () => {
     expect(buildHostedServerRequest("bench")).toEqual({
       workspaceId: "ws_shared",
       serverId: "srv_bench",
+      serverName: "bench",
       clientCapabilities: defaultClientCapabilities,
       accessScope: "chat_v2",
       shareToken: "share_tok_123",
@@ -43,6 +44,7 @@ describe("hosted web context", () => {
     expect(buildHostedServerBatchRequest(["bench"])).toEqual({
       workspaceId: "ws_shared",
       serverIds: ["srv_bench"],
+      serverNames: ["bench"],
       clientCapabilities: defaultClientCapabilities,
       accessScope: "chat_v2",
       shareToken: "share_tok_123",
@@ -68,6 +70,7 @@ describe("hosted web context", () => {
     expect(buildHostedServerRequest("bench")).toEqual({
       workspaceId: "ws_regular",
       serverId: "srv_bench",
+      serverName: "bench",
       clientCapabilities: defaultClientCapabilities,
     });
   });
@@ -87,6 +90,7 @@ describe("hosted web context", () => {
 
     expect(buildHostedServerRequest("myServer")).toEqual({
       serverUrl: "https://example.com/mcp",
+      serverName: "myServer",
       serverHeaders: { "X-Api-Key": "key123" },
       clientCapabilities: defaultClientCapabilities,
     });
@@ -108,6 +112,7 @@ describe("hosted web context", () => {
 
     expect(buildHostedServerRequest("myServer")).toEqual({
       serverUrl: "https://example.com/mcp",
+      serverName: "myServer",
       serverHeaders: { "X-Api-Key": "key123" },
       clientCapabilities: defaultClientCapabilities,
     });
@@ -136,6 +141,7 @@ describe("hosted web context", () => {
 
     expect(buildHostedServerRequest("myServer")).toEqual({
       serverUrl: "https://example.com/mcp",
+      serverName: "myServer",
       serverHeaders: {
         Authorization: "Bearer stale-access-token",
         "X-Api-Key": "key123",
@@ -174,6 +180,7 @@ describe("hosted web context", () => {
 
     expect(buildHostedServerRequest("myServer")).toEqual({
       serverUrl: "https://example.com/mcp",
+      serverName: "myServer",
       serverHeaders: {
         "X-Api-Key": "key123",
       },
@@ -197,6 +204,7 @@ describe("hosted web context", () => {
 
     expect(buildHostedServerRequest("myServer")).toEqual({
       serverUrl: "https://example.com/mcp",
+      serverName: "myServer",
       clientCapabilities: defaultClientCapabilities,
     });
   });
@@ -217,6 +225,7 @@ describe("hosted web context", () => {
     expect(buildHostedServerRequest("bench")).toEqual({
       workspaceId: "ws_override",
       serverId: "srv_bench",
+      serverName: "bench",
       clientCapabilities,
     });
   });
@@ -255,6 +264,7 @@ describe("hosted web context", () => {
 
     expect(buildHostedServerRequest("myServer")).toEqual({
       serverUrl: "https://example.com/mcp",
+      serverName: "myServer",
       clientCapabilities: defaultClientCapabilities,
     });
   });

--- a/mcpjam-inspector/client/src/lib/apis/web/__tests__/base.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/__tests__/base.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authFetchMock = vi.fn();
+
+vi.mock("@/lib/config", () => ({
+  HOSTED_MODE: true,
+}));
+
+vi.mock("@/lib/session-token", () => ({
+  authFetch: (...args: unknown[]) => authFetchMock(...args),
+  addTokenToUrl: vi.fn((url: string) => url),
+}));
+
+import { webPost, WebApiError } from "../base";
+import { useTrafficLogStore } from "@/stores/traffic-log-store";
+
+describe("web/base hosted rpc logs", () => {
+  beforeEach(() => {
+    authFetchMock.mockReset();
+    useTrafficLogStore.getState().clear();
+  });
+
+  it("strips hosted rpc logs from successful JSON responses and ingests them", async () => {
+    authFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          ok: true,
+          value: 123,
+          _rpcLogs: [
+            {
+              serverId: "srv-1",
+              serverName: "Notion",
+              direction: "send",
+              timestamp: "2026-04-10T12:00:00.000Z",
+              message: {
+                jsonrpc: "2.0",
+                id: 1,
+                method: "tools/list",
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    const result = await webPost<
+      { request: boolean },
+      { ok: boolean; value: number }
+    >("/api/web/tools/list", { request: true });
+
+    expect(result).toEqual({ ok: true, value: 123 });
+    expect(useTrafficLogStore.getState().mcpServerItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          serverId: "srv-1",
+          serverName: "Notion",
+          direction: "SEND",
+          method: "tools/list",
+        }),
+      ]),
+    );
+  });
+
+  it("strips hosted rpc logs from error JSON responses before throwing", async () => {
+    authFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          code: "INTERNAL_ERROR",
+          message: "boom",
+          _rpcLogs: [
+            {
+              serverId: "srv-2",
+              serverName: "GitHub",
+              direction: "receive",
+              timestamp: "2026-04-10T12:00:00.000Z",
+              message: {
+                jsonrpc: "2.0",
+                id: 1,
+                result: { ok: false },
+              },
+            },
+          ],
+        }),
+        {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await expect(
+      webPost<{ request: boolean }, { ok: boolean }>("/api/web/tools/list", {
+        request: true,
+      }),
+    ).rejects.toEqual(
+      expect.objectContaining<WebApiError>({
+        status: 500,
+        code: "INTERNAL_ERROR",
+        message: "boom",
+      }),
+    );
+
+    expect(useTrafficLogStore.getState().mcpServerItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          serverId: "srv-2",
+          serverName: "GitHub",
+          direction: "RECEIVE",
+          method: "result",
+        }),
+      ]),
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/lib/apis/web/__tests__/context.guest-fallback.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/__tests__/context.guest-fallback.test.ts
@@ -235,6 +235,7 @@ describe("isGuestMode and buildHostedServerRequest consistency", () => {
 
     expect(result).toMatchObject({
       serverUrl: "https://my-mcp.example.com/sse",
+      serverName: "my-server",
     });
     // Should NOT have workspaceId — this is a guest request
     expect(result).not.toHaveProperty("workspaceId");
@@ -253,6 +254,7 @@ describe("isGuestMode and buildHostedServerRequest consistency", () => {
     expect(result).toMatchObject({
       workspaceId: "ws-shared",
       serverId: "srv-1",
+      serverName: "my-server",
       shareToken: "share_tok_123",
     });
   });
@@ -270,6 +272,7 @@ describe("isGuestMode and buildHostedServerRequest consistency", () => {
     expect(result).toMatchObject({
       workspaceId: "ws-sandbox",
       serverId: "srv-1",
+      serverName: "my-server",
       sandboxToken: "sandbox_tok_123",
     });
   });
@@ -298,9 +301,11 @@ describe("isGuestMode and buildHostedServerRequest consistency", () => {
           elicitation: {},
           experimental: { inspectorProfile: true },
         },
+        "example-server",
       ),
     ).toEqual({
       serverUrl: "https://example.com/mcp",
+      serverName: "example-server",
       clientCapabilities: {
         elicitation: {},
         experimental: { inspectorProfile: true },

--- a/mcpjam-inspector/client/src/lib/apis/web/base.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/base.ts
@@ -1,4 +1,5 @@
 import { authFetch } from "@/lib/session-token";
+import { ingestHostedRpcLogsFromPayload, stripHostedRpcLogs } from "./rpc-logs";
 
 export class WebApiError extends Error {
   code: string | null;
@@ -14,12 +15,12 @@ export class WebApiError extends Error {
 
 export async function webPost<TRequest, TResponse>(
   path: string,
-  payload: TRequest,
+  requestBody: TRequest,
 ): Promise<TResponse> {
   const response = await authFetch(path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
+    body: JSON.stringify(requestBody),
   });
 
   let body: any = null;
@@ -29,21 +30,24 @@ export async function webPost<TRequest, TResponse>(
     // ignored
   }
 
+  const { payload: sanitizedPayload } = stripHostedRpcLogs(body);
+  ingestHostedRpcLogsFromPayload(body);
+
   if (!response.ok) {
     const code =
-      typeof body?.code === "string"
-        ? body.code
-        : typeof body?.error === "string"
-          ? body.error
+      typeof (sanitizedPayload as any)?.code === "string"
+        ? (sanitizedPayload as any).code
+        : typeof (sanitizedPayload as any)?.error === "string"
+          ? (sanitizedPayload as any).error
           : null;
     const message =
-      typeof body?.message === "string"
-        ? body.message
-        : typeof body?.error === "string"
-          ? body.error
+      typeof (sanitizedPayload as any)?.message === "string"
+        ? (sanitizedPayload as any).message
+        : typeof (sanitizedPayload as any)?.error === "string"
+          ? (sanitizedPayload as any).error
           : `Request failed (${response.status})`;
     throw new WebApiError(response.status, code, message);
   }
 
-  return body as TResponse;
+  return sanitizedPayload as TResponse;
 }

--- a/mcpjam-inspector/client/src/lib/apis/web/base.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/base.ts
@@ -15,12 +15,12 @@ export class WebApiError extends Error {
 
 export async function webPost<TRequest, TResponse>(
   path: string,
-  requestBody: TRequest,
+  payload: TRequest,
 ): Promise<TResponse> {
   const response = await authFetch(path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(requestBody),
+    body: JSON.stringify(payload),
   });
 
   let body: any = null;
@@ -34,17 +34,18 @@ export async function webPost<TRequest, TResponse>(
   ingestHostedRpcLogsFromPayload(body);
 
   if (!response.ok) {
+    const errBody = sanitizedPayload as Record<string, unknown> | null;
     const code =
-      typeof (sanitizedPayload as any)?.code === "string"
-        ? (sanitizedPayload as any).code
-        : typeof (sanitizedPayload as any)?.error === "string"
-          ? (sanitizedPayload as any).error
+      typeof errBody?.code === "string"
+        ? errBody.code
+        : typeof errBody?.error === "string"
+          ? errBody.error
           : null;
     const message =
-      typeof (sanitizedPayload as any)?.message === "string"
-        ? (sanitizedPayload as any).message
-        : typeof (sanitizedPayload as any)?.error === "string"
-          ? (sanitizedPayload as any).error
+      typeof errBody?.message === "string"
+        ? errBody.message
+        : typeof errBody?.error === "string"
+          ? errBody.error
           : `Request failed (${response.status})`;
     throw new WebApiError(response.status, code, message);
   }

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -119,6 +119,7 @@ export function buildGuestServerRequest(
   config: unknown,
   oauthAccessToken?: string,
   clientCapabilities?: Record<string, unknown>,
+  serverName?: string,
 ): Record<string, unknown> {
   const httpConfig = config as {
     url?: string | URL;
@@ -134,6 +135,7 @@ export function buildGuestServerRequest(
   const headers = httpConfig.requestInit?.headers;
   return {
     serverUrl: urlStr,
+    ...(serverName ? { serverName } : {}),
     ...(headers && Object.keys(headers).length > 0
       ? { serverHeaders: headers }
       : {}),
@@ -286,6 +288,7 @@ export function buildHostedServerRequest(
       config,
       oauthToken,
       hostedApiContext.clientCapabilities,
+      serverNameOrId,
     );
   }
 
@@ -299,6 +302,10 @@ export function buildHostedServerRequest(
   return {
     workspaceId: getHostedWorkspaceId(),
     serverId,
+    serverName:
+      hostedApiContext.serverIdsByName[serverNameOrId] !== undefined
+        ? serverNameOrId
+        : (findHostedServerName(serverId) ?? serverNameOrId),
     ...(oauthToken ? { oauthAccessToken: oauthToken } : {}),
     ...(hostedApiContext.clientCapabilities
       ? { clientCapabilities: hostedApiContext.clientCapabilities }
@@ -312,6 +319,7 @@ export function buildHostedServerRequest(
 export function buildHostedServerBatchRequest(serverNamesOrIds: string[]): {
   workspaceId: string;
   serverIds: string[];
+  serverNames: string[];
   clientCapabilities?: Record<string, unknown>;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
@@ -319,9 +327,9 @@ export function buildHostedServerBatchRequest(serverNamesOrIds: string[]): {
   sandboxToken?: string;
 } {
   assertHostedClientConfigSynced();
-  const serverIds = resolveHostedServerEntries(serverNamesOrIds).map(
-    (entry) => entry.serverId,
-  );
+  const serverEntries = resolveHostedServerEntries(serverNamesOrIds);
+  const serverIds = serverEntries.map((entry) => entry.serverId);
+  const serverNames = serverEntries.map((entry) => entry.serverName);
   const oauthTokens = buildHostedOAuthTokensMap(serverIds);
   const shareToken = getHostedShareToken();
   const sandboxToken = getHostedSandboxToken();
@@ -329,6 +337,7 @@ export function buildHostedServerBatchRequest(serverNamesOrIds: string[]): {
   return {
     workspaceId: getHostedWorkspaceId(),
     serverIds,
+    serverNames,
     ...(hostedApiContext.clientCapabilities
       ? { clientCapabilities: hostedApiContext.clientCapabilities }
       : {}),

--- a/mcpjam-inspector/client/src/lib/apis/web/rpc-logs.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/rpc-logs.ts
@@ -1,0 +1,55 @@
+import {
+  isHostedRpcLogEvent,
+  type HostedRpcLogEvent,
+} from "@/shared/hosted-rpc-log";
+import { ingestHostedRpcLogs } from "@/stores/traffic-log-store";
+
+function extractEnvelopeLogs(value: unknown): HostedRpcLogEvent[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+
+  const candidate = value as Record<string, unknown>;
+  if (!Array.isArray(candidate._rpcLogs)) {
+    return [];
+  }
+
+  return candidate._rpcLogs.filter(isHostedRpcLogEvent);
+}
+
+export function stripHostedRpcLogs<T>(payload: T): {
+  payload: T;
+  rpcLogs: HostedRpcLogEvent[];
+} {
+  const rpcLogs = extractEnvelopeLogs(payload);
+
+  if (
+    rpcLogs.length === 0 ||
+    !payload ||
+    typeof payload !== "object" ||
+    Array.isArray(payload)
+  ) {
+    return { payload, rpcLogs };
+  }
+
+  const { _rpcLogs: _discarded, ...rest } = payload as Record<string, unknown>;
+  return {
+    payload: rest as T,
+    rpcLogs,
+  };
+}
+
+export function ingestHostedRpcLogsFromPayload(payload: unknown): void {
+  ingestHostedRpcLogs(extractEnvelopeLogs(payload));
+}
+
+export async function ingestHostedRpcLogsFromResponse(
+  response: Response,
+): Promise<void> {
+  try {
+    const body = await response.clone().json();
+    ingestHostedRpcLogsFromPayload(body);
+  } catch {
+    // Ignore non-JSON responses and malformed payloads.
+  }
+}

--- a/mcpjam-inspector/client/src/state/__tests__/mcp-api.hosted.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/mcp-api.hosted.test.ts
@@ -122,6 +122,7 @@ describe("mcp-api hosted-mode reconnect hardening", () => {
       config,
       undefined,
       { roots: { listChanged: true } },
+      "Excalidraw (App)",
     );
     expect(webPostMock).toHaveBeenCalledWith("/api/web/servers/validate", {
       serverUrl: "https://mcp.excalidraw.com/mcp",

--- a/mcpjam-inspector/client/src/state/mcp-api.ts
+++ b/mcpjam-inspector/client/src/state/mcp-api.ts
@@ -56,6 +56,7 @@ async function safeValidateHostedServer(
         serverConfig,
         extractOAuthToken(serverConfig),
         serverConfig.capabilities as Record<string, unknown> | undefined,
+        serverId,
       );
 
       return await webPost<typeof request, HostedServerValidateResponse>(

--- a/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.hosted.test.ts
+++ b/mcpjam-inspector/client/src/stores/__tests__/traffic-log-store.hosted.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/config", () => ({
+  HOSTED_MODE: true,
+}));
+
+vi.mock("@/lib/session-token", () => ({
+  addTokenToUrl: vi.fn((url: string) => url),
+}));
+
+import { subscribeToRpcStream, useTrafficLogStore } from "../traffic-log-store";
+
+describe("traffic-log-store hosted mode", () => {
+  beforeEach(() => {
+    useTrafficLogStore.getState().clear();
+  });
+
+  it("does not create the local rpc EventSource subscription in hosted mode", () => {
+    const eventSourceSpy = vi.fn();
+    Object.assign(globalThis, { EventSource: eventSourceSpy });
+
+    const unsubscribe = subscribeToRpcStream();
+
+    expect(eventSourceSpy).not.toHaveBeenCalled();
+    expect(typeof unsubscribe).toBe("function");
+  });
+});

--- a/mcpjam-inspector/client/src/stores/traffic-log-store.ts
+++ b/mcpjam-inspector/client/src/stores/traffic-log-store.ts
@@ -141,7 +141,6 @@ export function subscribeToRpcStream(): () => void {
         const { serverId, direction, message, timestamp } = data;
         useTrafficLogStore.getState().addMcpServerLog({
           serverId: typeof serverId === "string" ? serverId : "unknown",
-          serverName: undefined,
           direction:
             typeof direction === "string" ? direction.toUpperCase() : "",
           method: extractRpcMethod(message),

--- a/mcpjam-inspector/client/src/stores/traffic-log-store.ts
+++ b/mcpjam-inspector/client/src/stores/traffic-log-store.ts
@@ -11,6 +11,8 @@
 
 import { create } from "zustand";
 import { addTokenToUrl } from "@/lib/session-token";
+import { HOSTED_MODE } from "@/lib/config";
+import type { HostedRpcLogEvent } from "@/shared/hosted-rpc-log";
 
 export type UiProtocol = "mcp-apps" | "openai-apps";
 
@@ -28,6 +30,7 @@ export interface UiLogEvent {
 export interface McpServerRpcItem {
   id: string;
   serverId: string;
+  serverName?: string;
   direction: string;
   method: string;
   timestamp: string;
@@ -69,6 +72,37 @@ export const useTrafficLogStore = create<TrafficLogState>((set) => ({
   clear: () => set({ items: [], mcpServerItems: [] }),
 }));
 
+function extractRpcMethod(message: unknown): string {
+  const msg = message as {
+    method?: string;
+    result?: unknown;
+    error?: unknown;
+  };
+
+  if (typeof msg?.method === "string") return msg.method;
+  if (msg?.result !== undefined) return "result";
+  if (msg?.error !== undefined) return "error";
+  return "unknown";
+}
+
+export function ingestHostedRpcLogs(logs: HostedRpcLogEvent[]): void {
+  if (!Array.isArray(logs) || logs.length === 0) {
+    return;
+  }
+
+  const store = useTrafficLogStore.getState();
+  logs.forEach((log) => {
+    store.addMcpServerLog({
+      serverId: log.serverId,
+      serverName: log.serverName,
+      direction: log.direction.toUpperCase(),
+      method: extractRpcMethod(log.message),
+      timestamp: log.timestamp,
+      payload: log.message,
+    });
+  });
+}
+
 /**
  * Singleton SSE subscription for MCP server RPC traffic.
  * This ensures only one EventSource connection exists regardless of
@@ -78,6 +112,10 @@ let sseConnection: EventSource | null = null;
 let sseSubscriberCount = 0;
 
 export function subscribeToRpcStream(): () => void {
+  if (HOSTED_MODE) {
+    return () => {};
+  }
+
   sseSubscriberCount++;
 
   if (!sseConnection) {
@@ -101,25 +139,12 @@ export function subscribeToRpcStream(): () => void {
         if (!data || data.type !== "rpc") return;
 
         const { serverId, direction, message, timestamp } = data;
-        const msg = message as {
-          method?: string;
-          result?: unknown;
-          error?: unknown;
-        };
-        const method: string =
-          typeof msg?.method === "string"
-            ? msg.method
-            : msg?.result !== undefined
-              ? "result"
-              : msg?.error !== undefined
-                ? "error"
-                : "unknown";
-
         useTrafficLogStore.getState().addMcpServerLog({
           serverId: typeof serverId === "string" ? serverId : "unknown",
+          serverName: undefined,
           direction:
             typeof direction === "string" ? direction.toUpperCase() : "",
-          method,
+          method: extractRpcMethod(message),
           timestamp: timestamp ?? new Date().toISOString(),
           payload: message,
         });

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -6,11 +6,13 @@ const {
   handleMCPJamFreeChatModelMock,
   persistChatSessionToConvexMock,
   disconnectAllServersMock,
+  emitConstructorRpcLogMock,
 } = vi.hoisted(() => ({
   prepareChatV2Mock: vi.fn(),
   handleMCPJamFreeChatModelMock: vi.fn(),
   persistChatSessionToConvexMock: vi.fn(),
   disconnectAllServersMock: vi.fn(),
+  emitConstructorRpcLogMock: vi.fn(),
 }));
 
 vi.mock("ai", async () => {
@@ -23,9 +25,12 @@ vi.mock("ai", async () => {
 
 vi.mock("@mcpjam/sdk", () => ({
   isMCPAuthError: vi.fn().mockReturnValue(false),
-  MCPClientManager: vi.fn().mockImplementation(() => ({
-    disconnectAllServers: disconnectAllServersMock,
-  })),
+  MCPClientManager: vi.fn().mockImplementation((_servers, options) => {
+    emitConstructorRpcLogMock(options?.rpcLogger);
+    return {
+      disconnectAllServers: disconnectAllServersMock,
+    };
+  }),
 }));
 
 vi.mock("../../../utils/chat-v2-orchestration.js", () => ({
@@ -68,6 +73,7 @@ describe("web routes — chat-v2 hosted mode", () => {
       enhancedSystemPrompt: "system",
       resolvedTemperature: 0.7,
     });
+    emitConstructorRpcLogMock.mockReset();
 
     handleMCPJamFreeChatModelMock.mockImplementation(async (options: any) => {
       await options.onConversationComplete?.([
@@ -183,6 +189,55 @@ describe("web routes — chat-v2 hosted mode", () => {
         workspaceId: "workspace-1",
         sourceType: "direct",
         directVisibility: "workspace",
+      }),
+    );
+  });
+
+  it("includes pre-stream rpc logs in hosted chat JSON errors", async () => {
+    const { app, token } = createWebTestApp();
+
+    emitConstructorRpcLogMock.mockImplementation((rpcLogger) => {
+      rpcLogger?.({
+        direction: "send",
+        serverId: "server-1",
+        message: {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/list",
+        },
+      });
+    });
+    prepareChatV2Mock.mockRejectedValueOnce(new Error("chat setup failed"));
+
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        workspaceId: "workspace-1",
+        selectedServerIds: ["server-1"],
+        selectedServerNames: ["Notion"],
+        messages: [{ role: "user", content: "hello" }],
+        model: {
+          id: "openai/gpt-5-mini",
+          provider: "openai",
+          name: "GPT-5 Mini",
+        },
+      },
+      token,
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual(
+      expect.objectContaining({
+        code: "INTERNAL_ERROR",
+        message: "chat setup failed",
+        _rpcLogs: [
+          expect.objectContaining({
+            serverId: "server-1",
+            serverName: "Notion",
+            direction: "send",
+          }),
+        ],
       }),
     );
   });

--- a/mcpjam-inspector/server/routes/web/__tests__/rpc-logs.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/rpc-logs.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+vi.mock("@mcpjam/sdk", () => {
+  class MockMCPClientManager {
+    private readonly rpcLogger?: (event: {
+      direction: "send" | "receive";
+      message: unknown;
+      serverId: string;
+    }) => void;
+
+    constructor(
+      _servers: Record<string, unknown>,
+      options?: {
+        rpcLogger?: (event: {
+          direction: "send" | "receive";
+          message: unknown;
+          serverId: string;
+        }) => void;
+      },
+    ) {
+      this.rpcLogger = options?.rpcLogger;
+    }
+
+    async listTools(serverId: string) {
+      this.rpcLogger?.({
+        direction: "send",
+        serverId,
+        message: { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      });
+      this.rpcLogger?.({
+        direction: "receive",
+        serverId,
+        message: {
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            tools: [{ name: `tool-${serverId}` }],
+          },
+        },
+      });
+      return { tools: [{ name: `tool-${serverId}` }] };
+    }
+
+    getAllToolsMetadata() {
+      return {};
+    }
+
+    async listPrompts(serverId: string) {
+      this.rpcLogger?.({
+        direction: "send",
+        serverId,
+        message: { jsonrpc: "2.0", id: 1, method: "prompts/list" },
+      });
+      this.rpcLogger?.({
+        direction: "receive",
+        serverId,
+        message: {
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            prompts: [{ name: `prompt-${serverId}` }],
+          },
+        },
+      });
+      return { prompts: [{ name: `prompt-${serverId}` }] };
+    }
+
+    async disconnectAllServers() {
+      return undefined;
+    }
+  }
+
+  return {
+    MCPClientManager: MockMCPClientManager,
+    isMCPAuthError: vi.fn().mockReturnValue(false),
+  };
+});
+
+import toolsRoutes from "../tools.js";
+import promptsRoutes from "../prompts.js";
+import { toolsListSchema, withEphemeralConnection } from "../auth.js";
+import { listTools } from "../../../utils/route-handlers.js";
+import { expectJson, postJson } from "./helpers/test-app.js";
+
+function createRpcLogsTestApp(): Hono {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("guestId", "guest-1");
+    await next();
+  });
+  app.route("/api/web/tools", toolsRoutes);
+  app.route("/api/web/prompts", promptsRoutes);
+  app.post("/api/web/testing/tools/list-no-rpc-logs", async (c) =>
+    withEphemeralConnection(
+      c,
+      toolsListSchema,
+      (manager, body) => listTools(manager, body),
+      { rpcLogs: false },
+    ),
+  );
+  return app;
+}
+
+describe("web hosted rpc logs", () => {
+  const originalFetch = global.fetch;
+  const originalConvexHttpUrl = process.env.CONVEX_HTTP_URL;
+
+  beforeEach(() => {
+    process.env.CONVEX_HTTP_URL = "https://convex.example.com";
+    global.fetch = vi.fn(async (input) => {
+      if (String(input).endsWith("/web/authorize")) {
+        return new Response(
+          JSON.stringify({
+            authorized: true,
+            role: "member",
+            accessLevel: "workspace_member",
+            permissions: { chatOnly: false },
+            serverConfig: {
+              transportType: "http",
+              url: "https://server.example.com/mcp",
+              headers: {},
+              useOAuth: false,
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      throw new Error(`Unexpected fetch: ${String(input)}`);
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalConvexHttpUrl) {
+      process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
+    } else {
+      delete process.env.CONVEX_HTTP_URL;
+    }
+  });
+
+  it("attaches rpc logs with server names to single-server hosted responses", async () => {
+    const app = createRpcLogsTestApp();
+
+    const response = await postJson(
+      app,
+      "/api/web/tools/list",
+      {
+        workspaceId: "workspace-1",
+        serverId: "srv-1",
+        serverName: "Notion",
+      },
+      "test-token",
+    );
+
+    const { status, data } = await expectJson<{
+      tools: Array<{ name: string }>;
+      _rpcLogs: Array<{
+        serverId: string;
+        serverName: string;
+        direction: string;
+      }>;
+    }>(response);
+
+    expect(status).toBe(200);
+    expect(data.tools).toEqual([{ name: "tool-srv-1" }]);
+    expect(data._rpcLogs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          serverId: "srv-1",
+          serverName: "Notion",
+          direction: "send",
+        }),
+        expect.objectContaining({
+          serverId: "srv-1",
+          serverName: "Notion",
+          direction: "receive",
+        }),
+      ]),
+    );
+  });
+
+  it("attaches rpc logs with aligned server names to batch hosted responses", async () => {
+    const app = createRpcLogsTestApp();
+
+    const response = await postJson(
+      app,
+      "/api/web/prompts/list-multi",
+      {
+        workspaceId: "workspace-1",
+        serverIds: ["srv-1", "srv-2"],
+        serverNames: ["Notion", "GitHub"],
+      },
+      "test-token",
+    );
+
+    const { status, data } = await expectJson<{
+      prompts: Record<string, Array<{ name: string }>>;
+      _rpcLogs: Array<{ serverId: string; serverName: string }>;
+    }>(response);
+
+    expect(status).toBe(200);
+    expect(data.prompts).toEqual({
+      "srv-1": [{ name: "prompt-srv-1" }],
+      "srv-2": [{ name: "prompt-srv-2" }],
+    });
+    expect(data._rpcLogs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          serverId: "srv-1",
+          serverName: "Notion",
+        }),
+        expect.objectContaining({
+          serverId: "srv-2",
+          serverName: "GitHub",
+        }),
+      ]),
+    );
+  });
+
+  it("uses the provided guest server name instead of __guest__ in rpc logs", async () => {
+    const app = createRpcLogsTestApp();
+
+    const response = await postJson(app, "/api/web/tools/list", {
+      serverUrl: "https://guest.example.com/mcp",
+      serverName: "Excalidraw (App)",
+    });
+
+    const { status, data } = await expectJson<{
+      _rpcLogs: Array<{ serverId: string; serverName: string }>;
+    }>(response);
+
+    expect(status).toBe(200);
+    expect(data._rpcLogs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          serverId: "__guest__",
+          serverName: "Excalidraw (App)",
+        }),
+      ]),
+    );
+  });
+
+  it("keeps hosted rpc logs request-scoped with no cross-request carryover", async () => {
+    const app = createRpcLogsTestApp();
+
+    const first = await expectJson<{
+      _rpcLogs: Array<{ serverName: string }>;
+    }>(
+      await postJson(
+        app,
+        "/api/web/tools/list",
+        {
+          workspaceId: "workspace-1",
+          serverId: "srv-1",
+          serverName: "Notion",
+        },
+        "test-token",
+      ),
+    );
+    const second = await expectJson<{
+      _rpcLogs: Array<{ serverName: string }>;
+    }>(
+      await postJson(
+        app,
+        "/api/web/tools/list",
+        {
+          workspaceId: "workspace-1",
+          serverId: "srv-2",
+          serverName: "GitHub",
+        },
+        "test-token",
+      ),
+    );
+
+    expect(first.data._rpcLogs).toHaveLength(2);
+    expect(second.data._rpcLogs).toHaveLength(2);
+    expect(
+      first.data._rpcLogs.every((log) => log.serverName === "Notion"),
+    ).toBe(true);
+    expect(
+      second.data._rpcLogs.every((log) => log.serverName === "GitHub"),
+    ).toBe(true);
+  });
+
+  it("allows hosted routes to opt out of rpc log envelopes", async () => {
+    const app = createRpcLogsTestApp();
+
+    const response = await postJson(
+      app,
+      "/api/web/testing/tools/list-no-rpc-logs",
+      {
+        workspaceId: "workspace-1",
+        serverId: "srv-1",
+        serverName: "Notion",
+      },
+      "test-token",
+    );
+
+    const { status, data } = await expectJson<{
+      tools: Array<{ name: string }>;
+      _rpcLogs?: unknown;
+    }>(response);
+
+    expect(status).toBe(200);
+    expect(data.tools).toEqual([{ name: "tool-srv-1" }]);
+    expect(data._rpcLogs).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -1,8 +1,12 @@
 import { z } from "zod";
 import { MCPClientManager } from "@mcpjam/sdk";
-import type { HttpServerConfig } from "@mcpjam/sdk";
+import type { HttpServerConfig, RpcLogger } from "@mcpjam/sdk";
 import { WEB_CALL_TIMEOUT_MS } from "../../config.js";
 import { validateUrl, OAuthProxyError } from "../../utils/oauth-proxy.js";
+import {
+  attachHostedRpcLogs,
+  createHostedRpcLogCollector,
+} from "./hosted-rpc-logs.js";
 import {
   ErrorCode,
   WebRouteError,
@@ -39,6 +43,7 @@ export const workspaceServerSchema = refineHostedTokens(
   z.object({
     workspaceId: z.string().min(1),
     serverId: z.string().min(1),
+    serverName: z.string().min(1).optional(),
     clientCapabilities: clientCapabilitiesSchema.optional(),
     oauthAccessToken: z.string().optional(),
     accessScope: z.enum(["workspace_member", "chat_v2"]).optional(),
@@ -74,6 +79,7 @@ export const promptsListMultiSchema = refineHostedTokens(
   z.object({
     workspaceId: z.string().min(1),
     serverIds: z.array(z.string().min(1)).min(1),
+    serverNames: z.array(z.string().min(1)).optional(),
     clientCapabilities: clientCapabilitiesSchema.optional(),
     oauthTokens: z.record(z.string(), z.string()).optional(),
     accessScope: z.enum(["workspace_member", "chat_v2"]).optional(),
@@ -94,6 +100,7 @@ export const hostedChatSchema = refineHostedTokens(
     .object({
       workspaceId: z.string().min(1),
       selectedServerIds: z.array(z.string().min(1)),
+      selectedServerNames: z.array(z.string().min(1)).optional(),
       clientCapabilities: clientCapabilitiesSchema.optional(),
       chatSessionId: z.string().min(1).optional(),
       surface: z.enum(["preview", "share_link"]).optional(),
@@ -109,6 +116,7 @@ export const hostedChatSchema = refineHostedTokens(
 
 export const guestServerInputSchema = z.object({
   serverUrl: z.string().min(1),
+  serverName: z.string().min(1).optional(),
   serverHeaders: z.record(z.string(), z.string()).optional(),
   clientCapabilities: clientCapabilitiesSchema.optional(),
 });
@@ -274,6 +282,7 @@ export async function createAuthorizedManager(
     accessScope?: "workspace_member" | "chat_v2";
     shareToken?: string;
     sandboxToken?: string;
+    rpcLogger?: RpcLogger;
   },
 ): Promise<AuthorizedManagerResult> {
   const uniqueServerIds = Array.from(new Set(serverIds));
@@ -314,6 +323,7 @@ export async function createAuthorizedManager(
 
   const manager = new MCPClientManager(Object.fromEntries(configEntries), {
     defaultTimeout: timeoutMs,
+    rpcLogger: options?.rpcLogger,
   });
   return { manager, oauthServerUrls };
 }
@@ -412,11 +422,16 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
     manager: InstanceType<typeof MCPClientManager>,
     body: z.infer<S>,
   ) => Promise<T>,
-  options?: { timeoutMs?: number },
+  options?: { timeoutMs?: number; rpcLogs?: boolean },
 ) {
-  return handleRoute(c, async () => {
+  let rpcCollector: ReturnType<typeof createHostedRpcLogCollector> | undefined;
+
+  try {
     // Read body once — Hono streams can only be consumed once
     const rawBody = await readJsonBody<Record<string, unknown>>(c);
+    if (options?.rpcLogs !== false) {
+      rpcCollector = createHostedRpcLogCollector(rawBody);
+    }
 
     // Detect guest requests by body shape: presence of serverUrl without workspaceId.
     // This is more robust than relying solely on guestId from middleware, which
@@ -424,6 +439,8 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
     // sends a guest-shaped body.
     const isGuestRequest =
       typeof rawBody.serverUrl === "string" && !rawBody.workspaceId;
+
+    let result: T;
 
     if (isGuestRequest) {
       // ── Guest path: direct connection, no Convex ────────────────
@@ -491,55 +508,71 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
 
       const manager = new MCPClientManager(
         { __guest__: httpConfig },
-        { defaultTimeout: timeoutMs },
+        {
+          defaultTimeout: timeoutMs,
+          rpcLogger: rpcCollector?.rpcLogger,
+        },
       );
 
       try {
-        return await fn(manager, body as z.infer<S>);
+        result = await fn(manager, body as z.infer<S>);
       } finally {
         await manager.disconnectAllServers();
       }
+    } else {
+      // ── Authenticated path: Convex authorization ──────────────────
+      const bearerToken = assertBearerToken(c);
+      const body = parseWithSchema(schema, rawBody);
+      // Cast for internal plumbing — all web schemas include workspaceId + serverId(s).
+      // The strongly-typed `body` is passed through to `fn` unchanged.
+      const raw = body as Record<string, unknown>;
+      const { serverIds, oauthTokens } = resolveConnectionParams(raw);
+      const timeoutMs = options?.timeoutMs ?? WEB_CALL_TIMEOUT_MS;
+      const accessScope =
+        raw.accessScope === "workspace_member" || raw.accessScope === "chat_v2"
+          ? raw.accessScope
+          : undefined;
+      const shareToken =
+        typeof raw.shareToken === "string" && raw.shareToken.trim()
+          ? raw.shareToken
+          : undefined;
+      const sandboxToken =
+        typeof raw.sandboxToken === "string" && raw.sandboxToken.trim()
+          ? raw.sandboxToken
+          : undefined;
+
+      result = await withManager(
+        createAuthorizedManager(
+          bearerToken,
+          raw.workspaceId as string,
+          serverIds,
+          timeoutMs,
+          oauthTokens,
+          (raw.clientCapabilities as Record<string, unknown> | undefined) ??
+            undefined,
+          {
+            accessScope,
+            shareToken,
+            sandboxToken,
+            rpcLogger: rpcCollector?.rpcLogger,
+          },
+        ),
+        (manager) => fn(manager, body as z.infer<S>),
+      );
     }
 
-    // ── Authenticated path: Convex authorization ──────────────────
-    const bearerToken = assertBearerToken(c);
-    const body = parseWithSchema(schema, rawBody);
-    // Cast for internal plumbing — all web schemas include workspaceId + serverId(s).
-    // The strongly-typed `body` is passed through to `fn` unchanged.
-    const raw = body as Record<string, unknown>;
-    const { serverIds, oauthTokens } = resolveConnectionParams(raw);
-    const timeoutMs = options?.timeoutMs ?? WEB_CALL_TIMEOUT_MS;
-    const accessScope =
-      raw.accessScope === "workspace_member" || raw.accessScope === "chat_v2"
-        ? raw.accessScope
-        : undefined;
-    const shareToken =
-      typeof raw.shareToken === "string" && raw.shareToken.trim()
-        ? raw.shareToken
-        : undefined;
-    const sandboxToken =
-      typeof raw.sandboxToken === "string" && raw.sandboxToken.trim()
-        ? raw.sandboxToken
-        : undefined;
-
-    return withManager(
-      createAuthorizedManager(
-        bearerToken,
-        raw.workspaceId as string,
-        serverIds,
-        timeoutMs,
-        oauthTokens,
-        (raw.clientCapabilities as Record<string, unknown> | undefined) ??
-          undefined,
-        {
-          accessScope,
-          shareToken,
-          sandboxToken,
-        },
-      ),
-      (manager) => fn(manager, body as z.infer<S>),
+    return c.json(attachHostedRpcLogs(result, rpcCollector), 200);
+  } catch (error) {
+    const routeError = mapRuntimeError(error);
+    return webError(
+      c,
+      routeError.status,
+      routeError.code,
+      routeError.message,
+      routeError.details,
+      rpcCollector?.buildEnvelope(),
     );
-  });
+  }
 }
 
 // Re-export commonly used error utilities for convenience

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -25,6 +25,10 @@ import {
   webError,
   mapRuntimeError,
 } from "./auth.js";
+import {
+  attachHostedRpcLogs,
+  createHostedRpcLogCollector,
+} from "./hosted-rpc-logs.js";
 
 const chatV2 = new Hono();
 
@@ -34,9 +38,11 @@ chatV2.post("/", async (c) => {
   // serialize the Response object as '{}' instead of forwarding the stream.
   // Track OAuth server URLs so we can enrich auth errors with redirect info
   let oauthServerUrls: Record<string, string> = {};
+  let rpcCollector: ReturnType<typeof createHostedRpcLogCollector> | undefined;
   try {
     const bearerToken = assertBearerToken(c);
     const rawBody = await readJsonBody<Record<string, unknown>>(c);
+    rpcCollector = createHostedRpcLogCollector(rawBody);
 
     // Detect guest request by body shape: no workspaceId means guest-direct
     // (matching the pattern from withEphemeralConnection in auth.ts)
@@ -54,6 +60,7 @@ chatV2.post("/", async (c) => {
       }
 
       const body = rawBody as unknown as ChatV2Request & {
+        serverName?: string;
         serverUrl?: string;
         serverHeaders?: Record<string, string>;
         oauthAccessToken?: string;
@@ -144,13 +151,19 @@ chatV2.post("/", async (c) => {
 
         manager = new MCPClientManager(
           { __guest__: httpConfig },
-          { defaultTimeout: WEB_STREAM_TIMEOUT_MS },
+          {
+            defaultTimeout: WEB_STREAM_TIMEOUT_MS,
+            rpcLogger: rpcCollector.rpcLogger,
+          },
         );
       } else {
         // Guest without servers — empty manager for plain LLM chat
         manager = new MCPClientManager(
           {},
-          { defaultTimeout: WEB_STREAM_TIMEOUT_MS },
+          {
+            defaultTimeout: WEB_STREAM_TIMEOUT_MS,
+            rpcLogger: rpcCollector.rpcLogger,
+          },
         );
       }
 
@@ -217,6 +230,8 @@ chatV2.post("/", async (c) => {
               }
             : undefined,
           onStreamComplete: () => manager.disconnectAllServers(),
+          onStreamWriterReady: (writer) =>
+            rpcCollector?.attachStreamWriter(writer),
         });
       } catch (error) {
         await manager.disconnectAllServers();
@@ -275,6 +290,7 @@ chatV2.post("/", async (c) => {
         accessScope: "chat_v2",
         shareToken,
         sandboxToken,
+        rpcLogger: rpcCollector.rpcLogger,
       },
     );
     oauthServerUrls = urls;
@@ -368,6 +384,8 @@ chatV2.post("/", async (c) => {
             }
           : undefined,
         onStreamComplete: () => manager.disconnectAllServers(),
+        onStreamWriterReady: (writer) =>
+          rpcCollector?.attachStreamWriter(writer),
       });
     } catch (error) {
       await manager.disconnectAllServers();
@@ -378,10 +396,17 @@ chatV2.post("/", async (c) => {
     if (isMCPAuthError(error) && Object.keys(oauthServerUrls).length > 0) {
       const firstUrl = Object.values(oauthServerUrls)[0];
       const msg = error instanceof Error ? error.message : String(error);
-      return webError(c, 401, ErrorCode.UNAUTHORIZED, msg, {
-        oauthRequired: true,
-        serverUrl: firstUrl,
-      });
+      return webError(
+        c,
+        401,
+        ErrorCode.UNAUTHORIZED,
+        msg,
+        {
+          oauthRequired: true,
+          serverUrl: firstUrl,
+        },
+        rpcCollector?.buildEnvelope(),
+      );
     }
     const routeError = mapRuntimeError(error);
     return webError(
@@ -390,6 +415,7 @@ chatV2.post("/", async (c) => {
       routeError.code,
       routeError.message,
       routeError.details,
+      rpcCollector?.buildEnvelope(),
     );
   }
 });

--- a/mcpjam-inspector/server/routes/web/errors.ts
+++ b/mcpjam-inspector/server/routes/web/errors.ts
@@ -38,8 +38,17 @@ export function webError(
   code: ErrorCode,
   message: string,
   details?: Record<string, unknown>,
+  extras?: object,
 ) {
-  return c.json({ code, message, ...(details ? { details } : {}) }, status);
+  return c.json(
+    {
+      code,
+      message,
+      ...(details ? { details } : {}),
+      ...(extras ?? {}),
+    },
+    status,
+  );
 }
 
 export function parseErrorMessage(error: unknown): string {

--- a/mcpjam-inspector/server/routes/web/evals.ts
+++ b/mcpjam-inspector/server/routes/web/evals.ts
@@ -91,20 +91,28 @@ const hostedTraceRepairStopSchema = z.object({
 });
 
 evals.post("/run", async (c) =>
-  withEphemeralConnection(c, hostedRunEvalsSchema, (manager, body) =>
-    runEvalsWithManager(manager, {
-      ...body,
-      convexAuthToken: assertBearerToken(c),
-    }),
+  withEphemeralConnection(
+    c,
+    hostedRunEvalsSchema,
+    (manager, body) =>
+      runEvalsWithManager(manager, {
+        ...body,
+        convexAuthToken: assertBearerToken(c),
+      }),
+    { rpcLogs: false },
   ),
 );
 
 evals.post("/run-test-case", async (c) =>
-  withEphemeralConnection(c, hostedRunTestCaseSchema, (manager, body) =>
-    runEvalTestCaseWithManager(manager, {
-      ...body,
-      convexAuthToken: assertBearerToken(c),
-    }),
+  withEphemeralConnection(
+    c,
+    hostedRunTestCaseSchema,
+    (manager, body) =>
+      runEvalTestCaseWithManager(manager, {
+        ...body,
+        convexAuthToken: assertBearerToken(c),
+      }),
+    { rpcLogs: false },
   ),
 );
 
@@ -164,11 +172,15 @@ evals.post("/stream-test-case", async (c) => {
 });
 
 evals.post("/generate-tests", async (c) =>
-  withEphemeralConnection(c, hostedGenerateTestsSchema, (manager, body) =>
-    generateEvalTestsWithManager(manager, {
-      ...body,
-      convexAuthToken: assertBearerToken(c),
-    }),
+  withEphemeralConnection(
+    c,
+    hostedGenerateTestsSchema,
+    (manager, body) =>
+      generateEvalTestsWithManager(manager, {
+        ...body,
+        convexAuthToken: assertBearerToken(c),
+      }),
+    { rpcLogs: false },
   ),
 );
 
@@ -181,6 +193,7 @@ evals.post("/generate-negative-tests", async (c) =>
         ...body,
         convexAuthToken: assertBearerToken(c),
       }),
+    { rpcLogs: false },
   ),
 );
 

--- a/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
+++ b/mcpjam-inspector/server/routes/web/hosted-rpc-logs.ts
@@ -1,0 +1,167 @@
+import type { UIMessageChunk } from "ai";
+import type { RpcLogger } from "@mcpjam/sdk";
+import type {
+  HostedRpcLogEvent,
+  HostedRpcLogsEnvelope,
+} from "@/shared/hosted-rpc-log";
+
+type HostedRpcChunkWriter = {
+  write: (chunk: UIMessageChunk) => void;
+};
+
+function normalizeServerName(
+  serverId: string,
+  serverNamesById: Record<string, string>,
+): string {
+  const resolved = serverNamesById[serverId];
+  return typeof resolved === "string" && resolved.trim().length > 0
+    ? resolved
+    : serverId;
+}
+
+function writeHostedRpcLogDataPart(
+  writer: HostedRpcChunkWriter,
+  event: HostedRpcLogEvent,
+): void {
+  writer.write({
+    type: "data-rpc-log",
+    data: event,
+    transient: true,
+  } as unknown as UIMessageChunk);
+}
+
+function readOptionalString(
+  value: unknown,
+  fallback?: string,
+): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value
+    : fallback;
+}
+
+function mapAlignedServerNames(
+  serverIds: unknown,
+  serverNames: unknown,
+): Record<string, string> {
+  if (!Array.isArray(serverIds) || serverIds.length === 0) {
+    return {};
+  }
+
+  const names = Array.isArray(serverNames) ? serverNames : [];
+  const resolved: Record<string, string> = {};
+
+  serverIds.forEach((serverId, index) => {
+    if (typeof serverId !== "string" || serverId.trim().length === 0) {
+      return;
+    }
+
+    resolved[serverId] = readOptionalString(names[index], serverId) ?? serverId;
+  });
+
+  return resolved;
+}
+
+function extractServerNamesById(
+  body: Record<string, unknown> | null | undefined,
+): Record<string, string> {
+  if (!body) {
+    return {};
+  }
+
+  const resolved: Record<string, string> = {};
+
+  if (typeof body.serverId === "string") {
+    resolved[body.serverId] =
+      readOptionalString(body.serverName, body.serverId) ?? body.serverId;
+  }
+
+  Object.assign(
+    resolved,
+    mapAlignedServerNames(body.serverIds, body.serverNames),
+  );
+  Object.assign(
+    resolved,
+    mapAlignedServerNames(body.selectedServerIds, body.selectedServerNames),
+  );
+
+  if (typeof body.serverUrl === "string") {
+    resolved.__guest__ =
+      readOptionalString(body.serverName, "__guest__") ?? "__guest__";
+  }
+
+  return resolved;
+}
+
+export class HostedRpcLogCollector {
+  private readonly logs: HostedRpcLogEvent[] = [];
+  private streamedCount = 0;
+  private writer: HostedRpcChunkWriter | null = null;
+
+  constructor(private readonly serverNamesById: Record<string, string>) {}
+
+  readonly rpcLogger: RpcLogger = ({ direction, message, serverId }) => {
+    const event: HostedRpcLogEvent = {
+      serverId,
+      serverName: normalizeServerName(serverId, this.serverNamesById),
+      direction,
+      timestamp: new Date().toISOString(),
+      message,
+    };
+
+    this.logs.push(event);
+    this.flushBufferedLogs();
+  };
+
+  hasLogs(): boolean {
+    return this.logs.length > 0;
+  }
+
+  getLogs(): HostedRpcLogEvent[] {
+    return this.logs.map((event) => ({ ...event }));
+  }
+
+  attachStreamWriter(writer: HostedRpcChunkWriter): void {
+    this.writer = writer;
+    this.flushBufferedLogs();
+  }
+
+  buildEnvelope(): HostedRpcLogsEnvelope {
+    return this.hasLogs() ? { _rpcLogs: this.getLogs() } : {};
+  }
+
+  private flushBufferedLogs(): void {
+    if (!this.writer) {
+      return;
+    }
+
+    while (this.streamedCount < this.logs.length) {
+      writeHostedRpcLogDataPart(this.writer, this.logs[this.streamedCount]);
+      this.streamedCount += 1;
+    }
+  }
+}
+
+export function createHostedRpcLogCollector(
+  body: Record<string, unknown> | null | undefined,
+): HostedRpcLogCollector {
+  return new HostedRpcLogCollector(extractServerNamesById(body));
+}
+
+export function attachHostedRpcLogs<T>(
+  payload: T,
+  collector?: HostedRpcLogCollector,
+): T | (T & HostedRpcLogsEnvelope) {
+  if (
+    !collector?.hasLogs() ||
+    !payload ||
+    typeof payload !== "object" ||
+    Array.isArray(payload)
+  ) {
+    return payload;
+  }
+
+  return {
+    ...(payload as Record<string, unknown>),
+    ...collector.buildEnvelope(),
+  } as T & HostedRpcLogsEnvelope;
+}

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -4,6 +4,7 @@ import {
   hasUnresolvedToolCalls,
 } from "@/shared/http-tool-calls";
 import { handleMCPJamFreeChatModel } from "../mcpjam-stream-handler";
+import { createHostedRpcLogCollector } from "../../routes/web/hosted-rpc-logs.js";
 
 let lastExecution: Promise<void> | null = null;
 let writtenChunks: any[] = [];
@@ -631,6 +632,93 @@ describe("mcpjam-stream-handler", () => {
       outputTokens: 5,
       totalTokens: 15,
     });
+  });
+
+  it("flushes buffered hosted rpc logs first and streams live hosted rpc logs as data parts", async () => {
+    let resolveFetch: ((response: Response) => void) | undefined;
+    global.fetch = vi.fn().mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    const collector = createHostedRpcLogCollector({
+      selectedServerIds: ["srv-notion"],
+      selectedServerNames: ["Notion"],
+    });
+
+    collector.rpcLogger({
+      direction: "send",
+      serverId: "srv-notion",
+      message: {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+      },
+    });
+
+    await handleMCPJamFreeChatModel({
+      messages: [{ role: "user", content: "Say hello" }] as any,
+      modelId: "openai/gpt-5-mini",
+      systemPrompt: "You are helpful",
+      tools: {},
+      mcpClientManager: {
+        getAllToolsMetadata: vi.fn().mockReturnValue({}),
+      } as any,
+      onStreamWriterReady: (writer) => collector.attachStreamWriter(writer),
+    });
+
+    expect(writtenChunks[0]).toMatchObject({
+      type: "data-rpc-log",
+      data: expect.objectContaining({
+        serverId: "srv-notion",
+        serverName: "Notion",
+        direction: "send",
+      }),
+    });
+
+    collector.rpcLogger({
+      direction: "receive",
+      serverId: "srv-notion",
+      message: {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { tools: [] },
+      },
+    });
+
+    resolveFetch?.(
+      createSseResponse([
+        {
+          type: "finish",
+          finishReason: "stop",
+          totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ]),
+    );
+
+    await lastExecution;
+
+    const rpcChunks = writtenChunks.filter(
+      (chunk) => chunk?.type === "data-rpc-log",
+    );
+    expect(rpcChunks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({
+            serverName: "Notion",
+            direction: "send",
+          }),
+        }),
+        expect.objectContaining({
+          data: expect.objectContaining({
+            serverName: "Notion",
+            direction: "receive",
+          }),
+        }),
+      ]),
+    );
   });
 
   it("emits tool trace events when local tool execution runs after a streamed call", async () => {

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -83,6 +83,9 @@ export interface MCPJamHandlerOptions {
     fullHistory: ModelMessage[],
   ) => Promise<void> | void;
   onStreamComplete?: () => Promise<void> | void;
+  onStreamWriterReady?: (writer: {
+    write: (chunk: UIMessageChunk) => void;
+  }) => void;
 }
 
 interface StepContext {
@@ -1237,6 +1240,7 @@ export async function handleMCPJamFreeChatModel(
     requireToolApproval,
     onConversationComplete,
     onStreamComplete,
+    onStreamWriterReady,
   } = options;
 
   const toolDefs = serializeToolsForConvex(tools);
@@ -1261,6 +1265,8 @@ export async function handleMCPJamFreeChatModel(
       let finishEmitted = false;
 
       try {
+        onStreamWriterReady?.(writer);
+
         writeTraceEvent(writer, {
           type: "turn_start",
           turnId: traceTurn.turnId,

--- a/mcpjam-inspector/shared/chat-v2.ts
+++ b/mcpjam-inspector/shared/chat-v2.ts
@@ -6,6 +6,7 @@ export interface ChatV2Request {
   chatSessionId?: string;
   directVisibility?: "private" | "workspace";
   surface?: "preview" | "share_link";
+  serverName?: string;
   serverUrl?: string;
   serverHeaders?: Record<string, string>;
   oauthAccessToken?: string;
@@ -25,6 +26,7 @@ export interface ChatV2Request {
     apiKey?: string;
   }>;
   selectedServers?: string[];
+  selectedServerNames?: string[];
   requireToolApproval?: boolean;
   /** Workspace ID for direct-chat history persistence */
   workspaceId?: string;

--- a/mcpjam-inspector/shared/hosted-rpc-log.ts
+++ b/mcpjam-inspector/shared/hosted-rpc-log.ts
@@ -1,0 +1,46 @@
+export interface HostedRpcLogEvent {
+  serverId: string;
+  serverName: string;
+  direction: "send" | "receive";
+  timestamp: string;
+  message: unknown;
+}
+
+export interface HostedRpcLogsEnvelope {
+  _rpcLogs?: HostedRpcLogEvent[];
+}
+
+export interface HostedRpcLogDataPart {
+  type: "data-rpc-log";
+  data: HostedRpcLogEvent;
+}
+
+export function isHostedRpcLogEvent(
+  value: unknown,
+): value is HostedRpcLogEvent {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.serverId === "string" &&
+    typeof candidate.serverName === "string" &&
+    (candidate.direction === "send" || candidate.direction === "receive") &&
+    typeof candidate.timestamp === "string" &&
+    "message" in candidate
+  );
+}
+
+export function isHostedRpcLogDataPart(
+  value: unknown,
+): value is HostedRpcLogDataPart {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return (
+    candidate.type === "data-rpc-log" && isHostedRpcLogEvent(candidate.data)
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new hosted RPC-log envelope/streaming data-part path and threads server names through multiple client/server APIs, which could affect hosted request/response shapes and streaming behavior if integrations aren’t updated consistently.
> 
> **Overview**
> Adds **hosted JSON-RPC log propagation** from server to client: server routes now collect MCP RPC events via an `rpcLogger`, attach them to JSON responses/errors as `_rpcLogs`, and (for chat streaming) emit them as `data-rpc-log` stream parts.
> 
> On the client, hosted RPC logs are **ingested into `traffic-log-store`** (including stripping `_rpcLogs` from `webPost` responses) and the logger UI now **displays/searches/filters by `serverName`** (with copy-to-clipboard including both `serverId` and `serverName`).
> 
> Updates hosted request payloads to include server-name context (`serverName`, `serverNames`, `selectedServerNames`) and disables the local SSE RPC stream subscription in hosted mode; adds targeted tests covering these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bf917a19a8762d85d3515a4af2f78e6a11ff2fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->