### PR TITLE
Fix guest __guest__ serverId leaking to Convex snapshot mutation

### DIFF
--- a/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
@@ -269,8 +269,10 @@ export function useSharedChatWidgetCapture({
     if (persistedSnapshotToolCallIdsRef.current.has(toolCallId)) {
       return;
     }
-    // serverId is required by the snapshot schema for all modes
-    if (!toolSource.serverId) {
+    // serverId is required by the snapshot schema for all modes.
+    // "__guest__" is a synthetic sentinel used for direct-guest connections
+    // and is not a valid Convex document ID.
+    if (!toolSource.serverId || toolSource.serverId === "__guest__") {
       return;
     }
 


### PR DESCRIPTION
## Summary
- Fixes [CONVEX-23](https://mcpjam-gh.sentry.io/issues/CONVEX-23) — 1722 occurrences, 18 users impacted
- The synthetic `"__guest__"` sentinel used for direct-guest connections was passing through to `directChatHistory:createDirectWidgetSnapshot`, which expects a valid `v.id("servers")`
- Adds a guard in `useSharedChatWidgetCapture` to reject `"__guest__"` alongside falsy serverIds

## Test plan
- [x] Existing `useSharedChatWidgetCapture` tests pass (6/6)
- [ ] Manually verify in hosted guest mode: connect to a server, trigger a widget, confirm no new Sentry errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)