### PR TITLE
Update CLI to SDK 0.9.2 and add version flag

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@mcpjam/cli-preview",
       "version": "0.0.4",
       "dependencies": {
-        "@mcpjam/sdk": "^0.9.1",
+        "@mcpjam/sdk": "^0.9.2",
         "commander": "^12.1.0"
       },
       "bin": {
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/@mcpjam/sdk": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@mcpjam/sdk/-/sdk-0.9.1.tgz",
-      "integrity": "sha512-7cy516ZB+lZI1lc0uR19w455dHBPlUIErVKMN25HuZlD5z9nm69/ajz/SROkoVGFUkk4OPEYM9XxxXrLSL4rSQ==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@mcpjam/sdk/-/sdk-0.9.2.tgz",
+      "integrity": "sha512-mDJHyF2E56+H9EBZbK4AZwnkQkhOGCeYsLpWM+4VUY0Kv9/6H7+gpc/e2m00g6CLNle8NpwU0iW87V7Q+JndSg==",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.17",
@@ -739,7 +739,6 @@
         "@openrouter/ai-sdk-provider": "^2.2.0",
         "ai": "^6.0.141",
         "ollama-ai-provider-v2": "^1.5.2",
-        "open": "^10.2.0",
         "posthog-node": "^5.24.10",
         "zod": "^4.1.12"
       },
@@ -1342,21 +1341,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/bundle-name": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "run-applescript": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/bundle-require": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
@@ -1549,46 +1533,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/default-browser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
-      "license": "MIT",
-      "dependencies": {
-        "bundle-name": "^4.1.0",
-        "default-browser-id": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/default-browser-id": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/depd": {
@@ -2068,59 +2012,11 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-inside-container": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-docker": "^3.0.0"
-      },
-      "bin": {
-        "is-inside-container": "cli.js"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
-    },
-    "node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2356,24 +2252,6 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/open": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.2.1",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parseurl": {
@@ -2679,18 +2557,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/run-applescript": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/safer-buffer": {
@@ -3121,21 +2987,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/cli/package.json
+++ b/cli/package.json
@@ -15,7 +15,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@mcpjam/sdk": "^0.9.1",
+    "@mcpjam/sdk": "^0.9.2",
     "commander": "^12.1.0"
   },
   "devDependencies": {

--- a/cli/skills/mcpjam-cli-investigation/SKILL.md
+++ b/cli/skills/mcpjam-cli-investigation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcpjam-cli-investigation
-description: Interpret `mcpjam-cli` probe, doctor, OAuth, tools, resources, and prompts output conservatively against MCP 2025-11-25. Use when triaging MCP server findings, deciding whether a CLI finding is real or overstated, or turning inspection output into an engineer-facing report with severity and confidence.
+description: Interpret `mcpjam-cli` probe, doctor, OAuth, tools, resources, and prompts output conservatively against MCP 2025-11-25. Use when triaging MCP server findings, performing security reviews, deciding whether a CLI finding is real or overstated, or turning inspection output into an engineer-facing report with severity and confidence.
 ---
 
 # MCPJam CLI Investigation
@@ -15,9 +15,10 @@ Use this skill when analyzing MCP server behavior from `mcpjam-cli` output. The 
 ## Default stance
 
 - Treat raw request/response evidence as higher trust than normalized CLI convenience output.
+- Separate observations, compliance issues, and security findings. They are related, but not interchangeable.
 - Map claims to spec strength: `MUST` and `MUST NOT` are strong conformance signals; `SHOULD` and `RECOMMENDED` are softer guidance; `MAY` and optional fields are usually informational.
-- Do not label a finding `high` severity unless the spec clearly forbids the behavior or you can describe a concrete exploit or breakage path.
-- When evidence is ambiguous, lower confidence before overstating the conclusion.
+- Do not label a security finding `high` unless you can support a concrete attacker benefit or clear breakage path.
+- When evidence is ambiguous, lower confidence or use `pending` before overstating the conclusion.
 
 ## Quick workflow
 
@@ -34,41 +35,66 @@ Use this skill when analyzing MCP server behavior from `mcpjam-cli` output. The 
 
 ## Security review workflow
 
-Use this when the task is to assess an MCP server's security posture. All checks use existing CLI commands — no special security tooling is needed.
+Use this when the task is to assess an MCP server's security posture. All checks use existing CLI commands — no special security tooling is needed. Do not assume every server should require auth.
 
-### Phase 1: Passive discovery (no auth required)
+### Phase 1: Observe (read-only)
 
-Run `server probe --url <target> --format json` and inspect the output:
+Run `server probe --url <target> --format json` first. Add `oauth metadata` or `server doctor --out <path>` only when they clarify the picture.
 
-1. **SSRF via OAuth discovery**: Check all URLs in `oauth.authorizationServerMetadata` and `oauth.resourceMetadata` for non-HTTPS, private IPs, and cloud metadata targets (169.254.169.254). See `references/security-best-practices.md` for the full IP range list.
-2. **Scope design**: Check `scopes_supported` for wildcards (`*`, `all`, `full-access`, `:*`). Compare `WWW-Authenticate` scope against the full catalog.
-3. **PKCE strength**: Check `code_challenge_methods_supported` for `plain` support.
-4. **Registration strategies**: Note which are available (`dcr`, `cimd`, `preregistered`) — DCR servers need the redirect URI checks in phase 2.
+- Record an initial auth signal:
+  - `full-auth candidate`: probe `status` is `oauth_required`
+  - `public-or-mixed candidate`: probe `status` is `ready`
+  - `unknown`: probe is only `reachable`, `error`, or otherwise ambiguous
+- Capture discovery facts:
+  - OAuth metadata URLs and whether they point to public, private, or suspicious targets
+  - `scopes_supported`, `WWW-Authenticate`, and PKCE methods
+  - registration strategies such as `dcr`, `cimd`, and `preregistered`
+- Record the evidence surface you are trusting. Raw probe/RPC evidence beats doctor summaries or convenience fields.
+- Phase 1 can produce observations and compliance notes. By itself it should not produce a `high` security severity.
 
-### Phase 2: DCR abuse testing (if DCR is supported)
+### Phase 2: Provoke (behavior, still mostly unauth)
 
-Use `oauth proxy` to test the registration endpoint directly:
+Treat the Phase 1 auth signal as provisional until behavior confirms it.
 
-1. **HTTP redirect URI acceptance**: POST a registration with `"redirect_uris":["http://evil.example/callback"]`. A `2xx` with a `client_id` is a HIGH finding.
-2. **Redirect URI validation**: Register normally, then attempt authorization with a modified redirect URI.
-3. **Registration response quality**: Check for relative `registration_client_uri` (RFC 7592 violation).
+- For a `full-auth candidate`:
+  - run DCR shape probes if DCR is supported
+  - spot-check representative unauth `tools list` or `tools call` behavior when feasible
+  - check malformed, expired, or obviously wrong-audience token handling without overstating what a rejection proves
+- For a `public-or-mixed candidate`:
+  - run unauth `tools list`
+  - classify exposed tools as read-only, write, or side-effect
+  - call representative public tools unauth
+  - check whether gated tools fail with a clean auth challenge instead of silent empty data or partial data
+- Anonymous tiers, rate limits, or degraded public access are posture notes, not a separate posture class.
+- Reclassify to one of `no-auth`, `full-auth`, `mixed-auth`, or `unknown` once Phase 2 behavior is clear. If Phase 2 contradicts Phase 1, update the posture and rerun the relevant checks instead of forcing the old classification.
+- Input-validation hits from Phase 2 cap at `medium` security severity until Phase 3 proves attacker benefit.
+- Design or posture findings can be real security findings in Phase 2, but do not auto-promote them. Document the unsafe behavior, abuse path, and any owner-intent uncertainty before calling them `medium` or `high`.
 
-### Phase 3: Authenticated review (requires successful auth)
+### Phase 3: Exploit or confirm attacker benefit
 
-Run `oauth login` to obtain credentials, then:
+Use `oauth login` and the same browser session when the proof depends on consent or cookies.
 
-1. **Token audience binding**: Decode the JWT access token (base64url-decode the second `.`-delimited segment). Check `aud` against the MCP server resource URL.
-2. **Session ID quality**: Run `server info` multiple times with `--rpc` and inspect `Mcp-Session-Id` headers for predictability.
-3. **Connected surface**: Use `tools list`, `resources list`, `prompts list` to understand the blast radius of a compromised token.
+- Use Phase 3 to turn a plausible concern into a real end-to-end security finding:
+  - DCR plus authorization flow proof
+  - redirect URI exact-match bypass proof
+  - foreign-token acceptance or token passthrough proof
+  - code, token, or cross-tenant data capture
+- Consent skip is one route to `high`, not the only route. Any demonstrated chain that shows concrete attacker gain can justify `high`.
 
-### Severity calibration for security findings
+### Phase 4: Inventory blast radius
 
-- **HIGH**: Clear spec violation with a concrete exploit path (e.g., HTTP redirect URI + working authorization flow = auth code interception)
-- **MEDIUM**: Real standards issue with security implications but no demonstrated end-to-end exploit (e.g., relative registration_client_uri, wildcard scopes)
-- **LOW**: Hardening opportunity or defense-in-depth gap (e.g., `plain` PKCE support alongside `S256`, full-catalog scope challenges)
-- **INFO**: Observations that are true but not actionable (e.g., opaque tokens without `aud`, missing optional scope metadata)
+- After auth succeeds, decode JWT claims, inspect `Mcp-Session-Id` with raw logs, and enumerate tools, resources, prompts, scopes, and tenant context.
+- Phase 4 is mainly blast-radius calibration. Treat it as context unless you also prove abuse.
 
-Always note compounding factors — a LOW finding can become MEDIUM when combined with another finding (e.g., `plain` PKCE + HTTP redirect URIs).
+### Security severity calibration
+
+- `high`: demonstrated attacker benefit or conforming-client breakage with direct evidence
+- `medium`: credible security issue with a concrete attack scenario, but end-to-end proof is still partial
+- `low`: hardening gap or limited-impact security concern
+- `pending`: plausible security concern with a specific missing proof step that could materially raise or lower severity
+- `info`: true observation with no credible attacker benefit yet
+
+Use `pending` instead of manufacturing a `medium` or `high` security severity from a checklist hit.
 
 ## Command choice
 
@@ -83,12 +109,27 @@ Always note compounding factors — a LOW finding can become MEDIUM when combine
 
 ## Output contract
 
-For each claimed finding, return:
+### General triage output
+
+For non-security tasks, return:
 
 - `Verdict`: `real issue`, `interop warning`, `implementation polish`, or `scanner/client artifact`
 - `Severity`: `high`, `medium`, `low`, or `info`
 - `Confidence`: `high`, `medium`, or `low`
 - `Why it matters`: one short paragraph tied to interoperability, security, or user impact
+- `Evidence`: the exact CLI behavior that supports the claim
+- `Missing evidence`: what would need to be confirmed before raising severity or confidence
+
+### Security review output
+
+For each claimed security-review finding, return:
+
+- `Verdict`: `real issue`, `interop warning`, `implementation polish`, or `scanner/client artifact`
+- `Compliance severity`: `high`, `medium`, `low`, or `info`
+- `Security severity`: `high`, `medium`, `low`, `info`, or `pending`
+- `Confidence`: `high`, `medium`, or `low`
+- `Attack scenario or pending rationale`: if `Security severity` is `medium` or `high`, open with 2-3 sentences answering who the attacker is, what they need, and what they gain; if it is `pending`, say exactly what proof is missing
+- `Verified via`: the phase plus exact command or result that supports the claim
 - `Evidence`: the exact CLI behavior that supports the claim
 - `Missing evidence`: what would need to be confirmed before raising severity or confidence
 
@@ -103,6 +144,12 @@ For each claimed finding, return:
 - Treat `--debug-out` artifacts as aggregated evidence envelopes, not pure wire captures.
 - Never flag missing `scopes_supported` or missing `scope` in `WWW-Authenticate` as a security issue — both are optional.
 - Never claim a server is "secure" based solely on it rejecting one specific bad input. A single negative test does not prove broader security posture.
+- Never let a checklist hit assign `high` security severity by itself.
+- JWT `aud` mismatch is not token passthrough proof unless you show the server accepts a token issued for a different audience or resource, or otherwise misbinds the token.
+- Supporting `plain` PKCE is usually hardening only. It cannot compound with attacker-owned-client DCR flows where the attacker chose the verifier.
+- Hostile `redirect_uri` values are not SSRF unless you show the server fetches them.
+- Public unauthenticated access is not itself a finding. Check whether behavior matches advertised posture and whether exposed surfaces are safe by design.
+- Anonymous trial or rate-limited access is a posture note, not a separate severity finding.
 - When compounding findings, explain the compound attack path. Do not just list unrelated findings and call the combination worse.
 
 ## Reference map
@@ -112,4 +159,4 @@ For each claimed finding, return:
 - `references/mcp-2025-11-25-interpretation.md`
   Use for capability, lifecycle, transport, authorization, tools, resources, and prompts interpretation against the latest MCP spec.
 - `references/security-best-practices.md`
-  Use for security review checks mapped to CLI commands. Covers SSRF, confused deputy, PKCE, token passthrough, scope minimization, and session security. Source: https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices
+  Use for security review checks mapped to CLI commands. Covers SSRF, confused deputy, PKCE, token passthrough, scope minimization, auth-posture checks, and session security. Source: https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices

--- a/cli/skills/mcpjam-cli-investigation/references/security-best-practices.md
+++ b/cli/skills/mcpjam-cli-investigation/references/security-best-practices.md
@@ -17,7 +17,7 @@ Use this file when performing a security-focused review of an MCP server. Each c
 
 **Attack**: A malicious MCP server populates OAuth metadata URLs (`resource_metadata`, `authorization_servers`, `token_endpoint`, `authorization_endpoint`) with internal targets. The client follows them, leaking internal network data or cloud credentials.
 
-#### Non-HTTPS OAuth URLs in production
+### Non-HTTPS OAuth URLs in production
 
 - **Command**: `server probe --url <target>`
 - **Where to look**: `oauth.authorizationServerMetadata` — inspect `token_endpoint`, `authorization_endpoint`, `registration_endpoint`, `jwks_uri`, `userinfo_endpoint`; also `oauth.resourceMetadataUrl` and `oauth.authorizationServerMetadataUrl`
@@ -29,26 +29,26 @@ Use this file when performing a security-focused review of an MCP server. Each c
 - **Best proving command**: `server probe`; use `oauth debug-proxy` or raw fetch evidence if metadata path handling is ambiguous
 - **Phase**: 1
 
-#### Private/internal IPs in discovered OAuth URLs
+### Private/internal IPs in discovered OAuth URLs
 
 - **Command**: `server probe --url <target>`
 - **Where to look**: All URLs in `oauth.authorizationServerMetadata` and `oauth.resourceMetadata.authorization_servers`
 - **Checklist hit**: URL hostname resolves to or is a private range: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `127.0.0.0/8`, `::1`, `fc00::/7`, `fe80::/10`
 - **Default compliance impact**: `medium`
-- **Default security impact**: `high` when a public target advertises a private or internal discovery URL; `info` when the target itself is private or loopback
-- **Escalates when**: The path reaches cloud metadata or another sensitive internal service
+- **Default security impact**: `medium` when a public target advertises a private or internal discovery URL; `info` when the target itself is private or loopback
+- **Escalates when**: `server probe` or stronger raw evidence shows the public-facing target leading to cloud metadata or another sensitive internal service, or the internal hop produces a meaningful response
 - **Do not escalate when**: The entire review target is already private and the URL does not cross a trust boundary
 - **Best proving command**: `server probe` with raw discovery evidence
 - **Phase**: 1
 
-#### Cloud metadata endpoint targeting
+### Cloud metadata endpoint targeting
 
 - **Command**: `server probe --url <target>`
 - **Where to look**: All discovered URLs
 - **Checklist hit**: Any URL targeting `169.254.169.254`, `metadata.google.internal`, or `169.254.170.2`
 - **Default compliance impact**: `medium`
-- **Default security impact**: `high`
-- **Escalates when**: The metadata path is actually followed from a public target or produces sensitive responses
+- **Default security impact**: `medium`
+- **Escalates when**: `server probe` or stronger raw evidence shows a public-facing target leading to a live cloud metadata path, or the metadata request succeeds or returns sensitive responses
 - **Do not escalate when**: The hostname match is false-positive or synthetic and the server never presents it as a fetch target
 - **Best proving command**: `server probe` plus raw response capture if needed
 - **Phase**: 1
@@ -57,7 +57,7 @@ Use this file when performing a security-focused review of an MCP server. Each c
 
 **Attack**: An attacker dynamically registers a malicious client with an HTTP redirect URI, then tricks a user into authorizing through the MCP proxy. The consent cookie from a prior legitimate flow causes the authorization server to skip consent, and the auth code goes to the attacker.
 
-#### DCR accepts non-loopback HTTP redirect URIs
+### DCR accepts non-loopback HTTP redirect URIs
 
 - **Command**: `oauth proxy --url <registration_endpoint> --method POST --header "Content-Type: application/json" --body '{"redirect_uris":["http://evil.example/callback"],"client_name":"security-test","token_endpoint_auth_method":"none","grant_types":["authorization_code"],"response_types":["code"]}'`
 - **Where to look**: Response status and body. A `2xx` with a `client_id` means the registration succeeded.
@@ -69,7 +69,7 @@ Use this file when performing a security-focused review of an MCP server. Each c
 - **Best proving command**: Phase 2 `oauth proxy` registration, then Phase 3 `oauth login` plus an authorization URL opened in the same browser session
 - **Phase**: 2 then 3
 
-#### DCR returns relative registration_client_uri
+### DCR returns relative registration_client_uri
 
 - **Command**: Same DCR registration as above
 - **Where to look**: `registration_client_uri` in the response body
@@ -81,7 +81,7 @@ Use this file when performing a security-focused review of an MCP server. Each c
 - **Best proving command**: The DCR registration response itself
 - **Phase**: 2
 
-#### Redirect URI exact-match validation
+### Redirect URI exact-match validation
 
 - **Command**: Register via DCR, then attempt authorization with a modified redirect URI
 - **Where to look**: Authorization endpoint response
@@ -95,7 +95,7 @@ Use this file when performing a security-focused review of an MCP server. Each c
 
 ## PKCE Weakness
 
-#### Authorization server supports plain PKCE
+### Authorization server supports plain PKCE
 
 - **Command**: `server probe --url <target>`
 - **Where to look**: `oauth.authorizationServerMetadata.code_challenge_methods_supported`
@@ -111,7 +111,7 @@ Use this file when performing a security-focused review of an MCP server. Each c
 
 **Attack**: MCP server accepts tokens not issued for it, enabling security control circumvention, accountability gaps, and trust boundary issues.
 
-#### Token audience mismatch (JWT)
+### Token audience mismatch (JWT)
 
 - **Command**: `oauth login --url <target> --protocol-version 2025-11-25 --registration <strategy> --auth-mode interactive` then decode the JWT from `credentials.accessToken`
 - **Where to look**: The `aud` claim in the decoded JWT
@@ -127,7 +127,7 @@ Use this file when performing a security-focused review of an MCP server. Each c
 
 **Attack**: Broad tokens (`files:*`, `db:*`, `admin:*`) expand the blast radius of compromise.
 
-#### Wildcard or omnibus scopes in scopes_supported
+### Wildcard or omnibus scopes in scopes_supported
 
 - **Command**: `server probe --url <target>`
 - **Where to look**: `oauth.resourceMetadata.scopes_supported` and `oauth.authorizationServerMetadata.scopes_supported`
@@ -139,7 +139,7 @@ Use this file when performing a security-focused review of an MCP server. Each c
 - **Best proving command**: `server probe` first, then inspect the token or granted surface after `oauth login`
 - **Phase**: 1 then 4
 
-#### WWW-Authenticate challenges the full scope catalog
+### WWW-Authenticate challenges the full scope catalog
 
 - **Command**: `server probe --url <target>`
 - **Where to look**: Compare `oauth.wwwAuthenticate` scope parameter against `oauth.resourceMetadata.scopes_supported` or `oauth.authorizationServerMetadata.scopes_supported`
@@ -153,7 +153,7 @@ Use this file when performing a security-focused review of an MCP server. Each c
 
 ## Posture and Exposed Tool Surface
 
-#### Public side-effect tools
+### Public side-effect tools
 
 - **Command**: `tools list` without auth, then representative `tools call`
 - **Where to look**: Tool names, descriptions, annotations, and observed call behavior
@@ -165,7 +165,7 @@ Use this file when performing a security-focused review of an MCP server. Each c
 - **Best proving command**: `tools list` plus a narrow `tools call`
 - **Phase**: 2
 
-#### Gated tools return partial or misleading success without auth
+### Gated tools return partial or misleading success without auth
 
 - **Command**: `tools list` plus representative unauth `tools call`
 - **Where to look**: Tool results and auth errors
@@ -179,7 +179,7 @@ Use this file when performing a security-focused review of an MCP server. Each c
 
 ## Session Security
 
-#### Session ID predictability
+### Session ID predictability
 
 - **Command**: `server info --url <target> --access-token <token>` (multiple times) or inspect `Mcp-Session-Id` headers in `--rpc` output
 - **Where to look**: `Mcp-Session-Id` response header across multiple connections

--- a/cli/skills/mcpjam-cli-investigation/references/security-best-practices.md
+++ b/cli/skills/mcpjam-cli-investigation/references/security-best-practices.md
@@ -2,133 +2,194 @@
 
 Source: https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices
 
-Use this file when performing a security-focused review of an MCP server. Each check maps to an existing CLI command and describes what to look for, what severity to assign, and what the spec actually requires.
+Use this file when performing a security-focused review of an MCP server. Each check maps to an existing CLI command and gives conservative default impacts plus explicit escalation rules.
+
+## How to use this file
+
+- `Checklist hit` means the observed condition is true.
+- `Default compliance impact` is the standalone standards or profile impact.
+- `Default security impact` is the conservative baseline before exploit confirmation.
+- `pending` means a real security concern may exist, but a named follow-up test still decides whether it stays low or escalates.
+- Prefer the narrowest proving command. If a stronger evidence surface contradicts a summary, trust the stronger surface.
+- Do not let any single checklist hit assign `high` security severity by itself unless the attack path is already demonstrated by the observed behavior.
 
 ## SSRF via OAuth Discovery
 
 **Attack**: A malicious MCP server populates OAuth metadata URLs (`resource_metadata`, `authorization_servers`, `token_endpoint`, `authorization_endpoint`) with internal targets. The client follows them, leaking internal network data or cloud credentials.
 
-### Checks
-
 #### Non-HTTPS OAuth URLs in production
 
 - **Command**: `server probe --url <target>`
 - **Where to look**: `oauth.authorizationServerMetadata` — inspect `token_endpoint`, `authorization_endpoint`, `registration_endpoint`, `jwks_uri`, `userinfo_endpoint`; also `oauth.resourceMetadataUrl` and `oauth.authorizationServerMetadataUrl`
-- **Finding**: Any `http://` URL that is not loopback (`localhost`, `127.0.0.1`, `::1`)
-- **Severity**: `medium` — violates OAuth 2.1 Section 1.5 HTTPS requirement; `high` if the URL points to a private IP or cloud metadata
-- **Spec strength**: SHOULD (MCP security best practices); MUST in OAuth 2.1
+- **Checklist hit**: Any `http://` URL that is not loopback (`localhost`, `127.0.0.1`, `::1`)
+- **Default compliance impact**: `medium`
+- **Default security impact**: `low` for public internet targets, `info` for clearly local or dev-only setups
+- **Escalates when**: The discovered URL creates a public-to-private hop or points at cloud metadata
+- **Do not escalate when**: The URL is loopback or the environment is private by design and no trust-boundary hop exists
+- **Best proving command**: `server probe`; use `oauth debug-proxy` or raw fetch evidence if metadata path handling is ambiguous
+- **Phase**: 1
 
 #### Private/internal IPs in discovered OAuth URLs
 
 - **Command**: `server probe --url <target>`
 - **Where to look**: All URLs in `oauth.authorizationServerMetadata` and `oauth.resourceMetadata.authorization_servers`
-- **Finding**: URL hostname resolves to or is a private range: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16` (link-local/cloud metadata), `127.0.0.0/8`, `::1`, `fc00::/7`, `fe80::/10`
-- **Severity**: `high` when the initial server URL is public but a discovered OAuth URL is private (public-to-private hop); `info` when the server itself is private/loopback
-- **Spec strength**: SHOULD (MCP best practices, RFC 9728 Section 7.7)
+- **Checklist hit**: URL hostname resolves to or is a private range: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `169.254.0.0/16`, `127.0.0.0/8`, `::1`, `fc00::/7`, `fe80::/10`
+- **Default compliance impact**: `medium`
+- **Default security impact**: `high` when a public target advertises a private or internal discovery URL; `info` when the target itself is private or loopback
+- **Escalates when**: The path reaches cloud metadata or another sensitive internal service
+- **Do not escalate when**: The entire review target is already private and the URL does not cross a trust boundary
+- **Best proving command**: `server probe` with raw discovery evidence
+- **Phase**: 1
 
 #### Cloud metadata endpoint targeting
 
 - **Command**: `server probe --url <target>`
 - **Where to look**: All discovered URLs
-- **Finding**: Any URL targeting `169.254.169.254`, `metadata.google.internal`, or `169.254.170.2` (ECS)
-- **Severity**: `high` — direct cloud credential exfiltration risk
-- **Spec strength**: SHOULD block (MCP best practices)
+- **Checklist hit**: Any URL targeting `169.254.169.254`, `metadata.google.internal`, or `169.254.170.2`
+- **Default compliance impact**: `medium`
+- **Default security impact**: `high`
+- **Escalates when**: The metadata path is actually followed from a public target or produces sensitive responses
+- **Do not escalate when**: The hostname match is false-positive or synthetic and the server never presents it as a fetch target
+- **Best proving command**: `server probe` plus raw response capture if needed
+- **Phase**: 1
 
 ## Confused Deputy / DCR Abuse
 
 **Attack**: An attacker dynamically registers a malicious client with an HTTP redirect URI, then tricks a user into authorizing through the MCP proxy. The consent cookie from a prior legitimate flow causes the authorization server to skip consent, and the auth code goes to the attacker.
 
-### Checks
-
 #### DCR accepts non-loopback HTTP redirect URIs
 
 - **Command**: `oauth proxy --url <registration_endpoint> --method POST --header "Content-Type: application/json" --body '{"redirect_uris":["http://evil.example/callback"],"client_name":"security-test","token_endpoint_auth_method":"none","grant_types":["authorization_code"],"response_types":["code"]}'`
 - **Where to look**: Response status and body. A `2xx` with a `client_id` means the registration succeeded.
-- **Finding**: Server accepted a non-loopback `http://` redirect URI
-- **Severity**: `high` — enables authorization code interception via DNS spoofing, MITM, or open WiFi. Well-understood attack path under MCP OAuth profile (building on OAuth 2.1)
-- **Spec strength**: MCP authorization spec requires HTTPS for non-loopback redirect URIs
-- **Follow-up**: Verify the authorization endpoint also accepts the registered client by checking `oauth proxy --url <authorization_endpoint>?client_id=<returned_id>&redirect_uri=http://evil.example/callback&response_type=code --method GET`
+- **Checklist hit**: Server accepted a non-loopback `http://` redirect URI
+- **Default compliance impact**: `medium`
+- **Default security impact**: `pending`
+- **Escalates when**: Phase 3 proves code or token capture, consent skip, a misleading consent flow, redirect exact-match bypass, or another end-to-end attacker benefit
+- **Do not escalate when**: Registration succeeds but the authorization and token path is not proved
+- **Best proving command**: Phase 2 `oauth proxy` registration, then Phase 3 `oauth login` plus an authorization URL opened in the same browser session
+- **Phase**: 2 then 3
 
 #### DCR returns relative registration_client_uri
 
 - **Command**: Same DCR registration as above
 - **Where to look**: `registration_client_uri` in the response body
-- **Finding**: Value is a relative path instead of an absolute URL
-- **Severity**: `medium` — RFC 7592 Section 3 defines this as a URL (absolute). Breaks conforming clients doing client configuration management.
-- **Spec strength**: MUST (RFC 7592)
+- **Checklist hit**: Value is a relative path instead of an absolute URL
+- **Default compliance impact**: `medium`
+- **Default security impact**: `info`
+- **Escalates when**: You can show real client-management breakage or a downstream trust problem, not just RFC drift
+- **Do not escalate when**: The issue is only that the response is non-conformant
+- **Best proving command**: The DCR registration response itself
+- **Phase**: 2
 
 #### Redirect URI exact-match validation
 
 - **Command**: Register via DCR, then attempt authorization with a modified redirect URI
 - **Where to look**: Authorization endpoint response
-- **Finding**: Server accepts a redirect URI that does not exactly match the registered one (e.g., added path segments, different query params)
-- **Severity**: `high` if the server redirects with an auth code to the modified URI; `medium` if it just doesn't reject the request
-- **Spec strength**: MUST use exact string matching (MCP best practices)
+- **Checklist hit**: Server accepts a redirect URI that does not exactly match the registered one
+- **Default compliance impact**: `medium`
+- **Default security impact**: `pending`
+- **Escalates when**: The modified URI actually receives an auth code, token, or other meaningful authorization result
+- **Do not escalate when**: You only suspect loose matching from registration behavior or summaries
+- **Best proving command**: DCR registration plus a live authorization request using the modified URI
+- **Phase**: 3
 
 ## PKCE Weakness
-
-### Checks
 
 #### Authorization server supports plain PKCE
 
 - **Command**: `server probe --url <target>`
 - **Where to look**: `oauth.authorizationServerMetadata.code_challenge_methods_supported`
-- **Finding**: Array includes `"plain"`
-- **Severity**: `low` as standalone (hardening note, not a spec violation); `medium` when combined with other findings like HTTP redirect URIs (compounds interception risk since the code_verifier equals the challenge)
-- **Spec strength**: MCP clients MUST verify PKCE support; `S256` is essential for MCP compatibility. Supporting `plain` is not prohibited but weakens the PKCE guarantee.
+- **Checklist hit**: Array includes `"plain"`
+- **Default compliance impact**: `info`
+- **Default security impact**: `low`
+- **Escalates when**: It compounds with code interception in a legitimate-client flow
+- **Do not escalate when**: The attacker owns the DCR client or otherwise chose the PKCE verifier
+- **Best proving command**: `server probe`
+- **Phase**: 1, with any compounding proof in 3
 
 ## Token Passthrough
 
 **Attack**: MCP server accepts tokens not issued for it, enabling security control circumvention, accountability gaps, and trust boundary issues.
 
-### Checks
-
 #### Token audience mismatch (JWT)
 
 - **Command**: `oauth login --url <target> --protocol-version 2025-11-25 --registration <strategy> --auth-mode interactive` then decode the JWT from `credentials.accessToken`
 - **Where to look**: The `aud` claim in the decoded JWT
-- **Finding**:
-  - `aud` matches the MCP server resource URL → `ok`
-  - `aud` is present but does not match → `high` severity, token may not be scoped to this server
-  - token is opaque or has no `aud` → `info`, advisory only
-- **Severity**: varies as described above
-- **Spec strength**: MUST NOT accept tokens not issued for the MCP server (MCP authorization spec)
-- **Note**: JWT decoding is base64 — no library needed. Split on `.`, base64url-decode the second segment.
+- **Checklist hit**: The token is a JWT and the decoded `aud` does not clearly match the MCP server resource URL
+- **Default compliance impact**: `low`, or `medium` if the mismatch is clear and no resource aliasing explanation exists
+- **Default security impact**: `pending`
+- **Escalates when**: You show the server accepts a foreign token, cross-resource token, or otherwise misbinds the token in practice
+- **Do not escalate when**: The token is opaque, `aud` is absent, or resource aliasing and canonicalization could explain the value
+- **Best proving command**: `oauth login` for the issued token, then a separate proof that a foreign token is accepted if you want a real passthrough finding
+- **Phase**: 4 for observation, 3 for abuse proof
 
 ## Scope Minimization
 
 **Attack**: Broad tokens (`files:*`, `db:*`, `admin:*`) expand the blast radius of compromise.
 
-### Checks
-
 #### Wildcard or omnibus scopes in scopes_supported
 
 - **Command**: `server probe --url <target>`
 - **Where to look**: `oauth.resourceMetadata.scopes_supported` and `oauth.authorizationServerMetadata.scopes_supported`
-- **Finding**: Any of `*`, `all`, `full-access`, or patterns ending in `:*`
-- **Severity**: `medium` — poor scope design increases token compromise impact
-- **Spec strength**: SHOULD implement progressive, least-privilege scope model (MCP best practices)
+- **Checklist hit**: Any of `*`, `all`, `full-access`, or patterns ending in `:*`
+- **Default compliance impact**: `low`
+- **Default security impact**: `info`
+- **Escalates when**: Phase 4 shows issued tokens really receive broad scopes that map to sensitive actions
+- **Do not escalate when**: You only know the advertised scope names, not the scopes actually granted or enforced
+- **Best proving command**: `server probe` first, then inspect the token or granted surface after `oauth login`
+- **Phase**: 1 then 4
 
 #### WWW-Authenticate challenges the full scope catalog
 
 - **Command**: `server probe --url <target>`
 - **Where to look**: Compare `oauth.wwwAuthenticate` scope parameter against `oauth.resourceMetadata.scopes_supported` or `oauth.authorizationServerMetadata.scopes_supported`
-- **Finding**: The challenge scope lists the entire `scopes_supported` set
-- **Severity**: `low` — the server should emit precise scope challenges rather than returning the full catalog
-- **Spec strength**: SHOULD (MCP best practices guidance)
-- **Note**: Missing `scope` in the challenge or missing `scopes_supported` is NOT a finding. Do not penalize absence.
+- **Checklist hit**: The challenge scope lists the entire `scopes_supported` set
+- **Default compliance impact**: `low`
+- **Default security impact**: `info`
+- **Escalates when**: You can show concrete client confusion, overscoped consent behavior, or a user-impacting auth mistake
+- **Do not escalate when**: The server simply provides a broad hint, or `scope` or `scopes_supported` is absent
+- **Best proving command**: `server probe`
+- **Phase**: 1
+
+## Posture and Exposed Tool Surface
+
+#### Public side-effect tools
+
+- **Command**: `tools list` without auth, then representative `tools call`
+- **Where to look**: Tool names, descriptions, annotations, and observed call behavior
+- **Checklist hit**: An unauthenticated tool can send network requests, mutate shared state, send messages, run code, or trigger other side effects
+- **Default compliance impact**: `info`
+- **Default security impact**: `low`
+- **Escalates when**: The tool can be abused as a spam relay, SSRF proxy, free-compute surface, or write primitive and the exposure is not clearly intentional and safeguarded
+- **Do not escalate when**: The server is explicitly designed as a public automation surface and the tool has clear limits or accountability
+- **Best proving command**: `tools list` plus a narrow `tools call`
+- **Phase**: 2
+
+#### Gated tools return partial or misleading success without auth
+
+- **Command**: `tools list` plus representative unauth `tools call`
+- **Where to look**: Tool results and auth errors
+- **Checklist hit**: A gated tool returns `200`, empty data, or partial data instead of a clear auth challenge
+- **Default compliance impact**: `low`
+- **Default security impact**: `pending`
+- **Escalates when**: The unauth path leaks existence, tenant info, or real data, or causes a concrete client-side auth confusion issue
+- **Do not escalate when**: The response is a clean `401` or `403` with machine-readable auth guidance
+- **Best proving command**: Raw `tools call` evidence
+- **Phase**: 2
 
 ## Session Security
-
-### Checks
 
 #### Session ID predictability
 
 - **Command**: `server info --url <target> --access-token <token>` (multiple times) or inspect `Mcp-Session-Id` headers in `--rpc` output
 - **Where to look**: `Mcp-Session-Id` response header across multiple connections
-- **Finding**: Sequential, short, or low-entropy session IDs
-- **Severity**: `medium` — enables session hijacking and event injection
-- **Spec strength**: MUST use secure, non-deterministic session IDs (MCP best practices)
+- **Checklist hit**: Session IDs appear sequential, short, or otherwise low-entropy across multiple connections
+- **Default compliance impact**: `medium`
+- **Default security impact**: `pending`
+- **Escalates when**: You can show session hijack, event injection, or cross-connection confusion
+- **Do not escalate when**: You only saw one or two IDs or the entropy evidence is weak
+- **Best proving command**: repeated connected commands with `--rpc`
+- **Phase**: 4, with any abuse proof in 3
 
 ## What NOT to flag
 
@@ -136,5 +197,8 @@ Use this file when performing a security-focused review of an MCP server. Each c
 - Missing `scope` in `WWW-Authenticate` — this is a SHOULD, not MUST
 - Custom URI schemes in redirect URIs — may be allowed by generic OAuth even if MCP profile is stricter
 - `https://` redirect URIs with open registration — not automatically a vulnerability without more context
+- `plain` PKCE support by itself as a medium or high finding
+- JWT `aud` mismatch by itself as token passthrough proof
+- A no-auth server exposing read-only public tools by design
 - Missing optional metadata like `outputSchema` — not a security issue
 - A server correctly rejecting a bad request — that is the desired behavior, not a finding

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,4 +1,5 @@
 import { Command, CommanderError } from "commander";
+import { version as pkgVersion } from "../package.json";
 import { registerAppsCommands } from "./commands/apps";
 import { registerProtocolCommands } from "./commands/conformance";
 import { registerOAuthCommands } from "./commands/oauth";
@@ -18,6 +19,7 @@ async function main(argv: readonly string[] = process.argv): Promise<number> {
   const program = addGlobalOptions(
     new Command()
       .name("mcpjam")
+      .version(pkgVersion, "-v, --version", "output the CLI version")
       .description(
         "Stateless MCP server probing, debugging, OAuth login, and conformance commands backed by @mcpjam/sdk",
       )


### PR DESCRIPTION
### TL;DR

Updated @mcpjam/sdk dependency from 0.9.1 to 0.9.2, enhanced security review guidance in CLI investigation skill, and added version flag to CLI.

### What changed?

- Bumped @mcpjam/sdk from version 0.9.1 to 0.9.2, which removed the `open` package dependency and its related browser utilities
- Enhanced the mcpjam-cli-investigation skill with more detailed security review workflows, including 4-phase security assessment (Observe, Provoke, Exploit, Inventory) and refined severity calibration guidelines
- Updated security best practices reference with more conservative default impacts and explicit escalation rules for security findings
- Added version flag (`-v, --version`) to the CLI command interface

### How to test?

- Run `mcpjam --version` to verify the version flag works correctly
- Test existing CLI commands to ensure the SDK update doesn't break functionality
- Use the updated security review workflow on MCP servers to validate the enhanced investigation guidance

### Why make this change?

The SDK update removes unnecessary browser-opening dependencies, making the CLI more lightweight. The enhanced security review guidance provides more structured and conservative approaches to security assessments, reducing false positives and improving the quality of security findings. The version flag improves CLI usability by allowing users to check their installed version.