### PR TITLE
Quick OAuth conformance CLI improves

### DIFF
--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -78,6 +78,8 @@ export interface OAuthCommandOptions {
   header?: string[];
   verifyTools?: boolean;
   verifyCallTool?: string;
+  conformanceChecks?: boolean;
+  printUrl?: boolean;
 }
 
 interface OAuthProxyCommandOptions {
@@ -233,7 +235,7 @@ export function registerOAuthCommands(program: Command): void {
     .option(
       "--auth-mode <mode>",
       "Authorization mode: headless, interactive, or client_credentials",
-      "headless",
+      "interactive",
     )
     .option(
       "--header <header>",
@@ -262,6 +264,14 @@ export function registerOAuthCommands(program: Command): void {
     .option(
       "--verify-call-tool <name>",
       "After listing tools, also call the named tool",
+    )
+    .option(
+      "--conformance-checks",
+      "Run additional OAuth negative checks (invalid client, invalid redirect, token format) after the main flow",
+    )
+    .option(
+      "--print-url",
+      "In interactive mode, print the consent URL to stderr instead of launching a browser",
     )
     .action(async (options, command) => {
       const format = getOAuthFormat(command);
@@ -376,8 +386,14 @@ export function buildOAuthConformanceConfig(
   const protocolVersion = parseProtocolVersion(options.protocolVersion);
   const registrationStrategy = parseRegistrationStrategy(options.registration);
   const authMode = parseAuthMode(
-    options.authMode ?? defaults?.defaultAuthMode ?? "headless",
+    options.authMode ?? defaults?.defaultAuthMode ?? "interactive",
   );
+
+  if (options.printUrl && authMode !== "interactive") {
+    throw usageError(
+      "--print-url only applies to --auth-mode interactive. Headless and client_credentials modes do not open a browser.",
+    );
+  }
 
   if (
     protocolVersion !== "2025-11-25" &&
@@ -447,17 +463,27 @@ export function buildOAuthConformanceConfig(
         }
       : undefined;
 
+  const auth = buildAuthConfig(authMode, registrationStrategy, clientId, clientSecret);
+
+  if (options.printUrl && auth.mode === "interactive") {
+    (auth as { openUrl?: (url: string) => Promise<void> }).openUrl =
+      async (url: string) => {
+        process.stderr.write(`OAUTH_CONSENT_URL: ${url}\n`);
+      };
+  }
+
   return {
     serverUrl,
     protocolVersion,
     registrationStrategy,
-    auth: buildAuthConfig(authMode, registrationStrategy, clientId, clientSecret),
+    auth,
     client,
     scopes: options.scopes?.trim() || undefined,
     customHeaders,
     redirectUrl,
     stepTimeout: options.stepTimeout ?? 30_000,
     verification,
+    oauthConformanceChecks: options.conformanceChecks ?? false,
   };
 }
 

--- a/cli/tests/oauth.test.ts
+++ b/cli/tests/oauth.test.ts
@@ -7,14 +7,14 @@ import {
 } from "../src/commands/oauth";
 import { CliError } from "../src/lib/output";
 
-test("buildOAuthConformanceConfig defaults to headless auth", () => {
+test("buildOAuthConformanceConfig defaults to interactive auth", () => {
   const config = buildOAuthConformanceConfig({
     url: "https://example.com/mcp",
     protocolVersion: "2025-11-25",
     registration: "cimd",
   });
 
-  assert.equal(config.auth?.mode, "headless");
+  assert.equal(config.auth?.mode, "interactive");
   assert.equal(config.registrationStrategy, "cimd");
 });
 
@@ -113,6 +113,74 @@ test("buildOAuthConformanceConfig omits verification when flags not set", () => 
   });
 
   assert.equal(config.verification, undefined);
+});
+
+test("buildOAuthConformanceConfig enables conformance checks when flag is set", () => {
+  const config = buildOAuthConformanceConfig({
+    url: "https://example.com/mcp",
+    protocolVersion: "2025-11-25",
+    registration: "dcr",
+    conformanceChecks: true,
+  });
+
+  assert.equal(config.oauthConformanceChecks, true);
+});
+
+test("buildOAuthConformanceConfig defaults conformance checks to false", () => {
+  const config = buildOAuthConformanceConfig({
+    url: "https://example.com/mcp",
+    protocolVersion: "2025-11-25",
+    registration: "dcr",
+  });
+
+  assert.equal(config.oauthConformanceChecks, false);
+});
+
+test("buildOAuthConformanceConfig sets openUrl for print-url in interactive mode", () => {
+  const config = buildOAuthConformanceConfig({
+    url: "https://example.com/mcp",
+    protocolVersion: "2025-11-25",
+    registration: "dcr",
+    authMode: "interactive",
+    printUrl: true,
+  });
+
+  assert.equal(config.auth?.mode, "interactive");
+  assert.equal(typeof (config.auth as any).openUrl, "function");
+});
+
+test("buildOAuthConformanceConfig rejects print-url with headless mode", () => {
+  assert.throws(
+    () =>
+      buildOAuthConformanceConfig({
+        url: "https://example.com/mcp",
+        protocolVersion: "2025-11-25",
+        registration: "dcr",
+        authMode: "headless",
+        printUrl: true,
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("--print-url only applies to --auth-mode interactive"),
+  );
+});
+
+test("buildOAuthConformanceConfig rejects print-url with client_credentials mode", () => {
+  assert.throws(
+    () =>
+      buildOAuthConformanceConfig({
+        url: "https://example.com/mcp",
+        protocolVersion: "2025-11-25",
+        registration: "preregistered",
+        authMode: "client_credentials",
+        clientId: "id",
+        clientSecret: "secret",
+        printUrl: true,
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("--print-url only applies to --auth-mode interactive"),
+  );
 });
 
 test("buildOAuthConformanceConfig rejects unsupported combinations", () => {


### PR DESCRIPTION
## Changes

**Default** **`--auth-mode`** **changed from** **`headless`** **to** **`interactive`**

Aligns with `oauth login` behavior. Most MCP server developers first run conformance locally during development — `interactive` works out of the box, `headless` only works against auto-consenting auth servers. CI pipelines should now pass `--auth-mode headless` or `--auth-mode client_credentials` explicitly.

**New flag:** **`--conformance-checks`**

Exposes the SDK's `oauthConformanceChecks` option. When set, runs 3 additional negative checks after a successful OAuth flow:

- Invalid client ID rejection
- Mismatched redirect URI rejection
- Token response format validation

Previously SDK-only — the CLI was strictly weaker.

**New flag:** **`--print-url`**

In interactive mode, prints the consent URL to stderr (`OAUTH_CONSENT_URL: <url>`) instead of launching a browser. The local callback listener still runs. Enables Playwright-driven and scripted consent automation. Rejects with a clear error when combined with `headless` or `client_credentials`.

## Test plan

- [x] Existing 57 tests pass (default-mode assertion updated)
- [x] 5 new tests: conformance-checks on/off, print-url wiring, print-url rejection for headless and client_credentials
- [x] `npm run typecheck` clean
- [x] `mcpjam oauth conformance --help` shows new flags and updated default
- [x] `--print-url --auth-mode headless` exits 2 with clear error
- [x] Run `mpcjam` `oauth conformance --url https://mcp.linear.app/mcp --protocol-version 2025-11-25 --registration dcr --verify-tools` end-to-end with interactive consent