### PR TITLE
CLI docs

### DIFF
--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -1,0 +1,120 @@
+---
+title: "CLI Overview"
+description: "Stateless MCP server probing, debugging, OAuth, and conformance from your terminal"
+icon: "terminal"
+---
+
+The `mcpjam` CLI is a stateless tool for inspecting, debugging, and testing MCP servers from the command line or CI. It covers the full lifecycle: connectivity checks, OAuth login, tool/resource/prompt exploration, and protocol conformance.
+
+## Install
+
+```bash
+# Global (gives you the mcpjam command)
+npm i -g @mcpjam/cli-preview
+
+# Or run without installing
+npx -y @mcpjam/cli-preview@latest --help
+```
+
+<Note>
+  All examples in these docs use `mcpjam` directly. If you installed via `npx`,
+  replace `mcpjam` with `npx -y @mcpjam/cli-preview@latest`.
+</Note>
+
+## Command groups
+
+| Group | Purpose | Key commands |
+|-------|---------|-------------|
+| [`server`](/cli/server-inspection) | Triage connectivity and capabilities | `probe`, `doctor`, `info`, `validate`, `ping`, `capabilities`, `export` |
+| [`oauth`](/cli/oauth-conformance) | Test OAuth flows and conformance | `conformance`, `conformance-suite`, `login`, `metadata`, `proxy` |
+| [`tools`](/cli/tools-resources-prompts) | Exercise the tool surface | `list`, `call` |
+| [`resources`](/cli/tools-resources-prompts) | Read resources and templates | `list`, `read`, `templates` |
+| [`prompts`](/cli/tools-resources-prompts) | Fetch prompts | `list`, `get` |
+| [`protocol`](/cli/reference) | MCP protocol conformance checks | `conformance` |
+
+## Global flags
+
+These flags apply to every command.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--timeout <ms>` | `30000` | Request timeout in milliseconds |
+| `--rpc` | off | Include raw JSON-RPC request/response logs in output |
+| `--format <format>` | `human` on TTY, `json` when piped | Output format (`json`, `human`, or `junit-xml` for conformance commands) |
+| `-v, --version` | | Print the CLI version |
+
+## Output formats
+
+The CLI auto-detects whether stdout is a terminal:
+
+- **Interactive terminal** — defaults to `--format human`, a compact readable summary.
+- **Piped or redirected** (CI, `| jq`, agent invocation) — defaults to `--format json`, the full structured result.
+- **Explicit `--format`** always wins over the auto-detected default.
+
+**For agents**: raw JSON is the source of truth. Human format is a lossy presentation layer. If you're parsing output programmatically, always pass `--format json`.
+
+## Connecting to servers
+
+The CLI supports two transport modes, selected by which flags you pass:
+
+### HTTP (Streamable HTTP / SSE)
+
+```bash
+mcpjam server doctor --url https://your-server.com/mcp
+```
+
+Add auth when needed:
+
+```bash
+# Static bearer token
+mcpjam server doctor --url https://your-server.com/mcp --access-token $TOKEN
+
+# OAuth tokens from a prior login
+mcpjam server doctor --url https://your-server.com/mcp --oauth-access-token $TOKEN
+
+# Custom headers
+mcpjam server doctor --url https://your-server.com/mcp --header "X-API-Key: $KEY"
+```
+
+### Stdio (local subprocess)
+
+```bash
+mcpjam server doctor --command node --command-args server.js --env API_KEY=$KEY
+```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success / all checks passed |
+| `1` | Command ran but reported a failure (e.g., server unhealthy, conformance failed) |
+| `2` | Invalid arguments or configuration |
+
+## Quick triage workflow
+
+The fastest path from "I have a server URL" to "I know what's wrong":
+
+```bash
+# 1. One-shot health check (probe + connect + sweep)
+mcpjam server doctor --url https://your-server.com/mcp
+
+# 2. If oauth_required: get a token
+mcpjam oauth login --url https://your-server.com/mcp \
+  --protocol-version 2025-11-25 --registration dcr
+
+# 3. Re-run doctor with the token
+mcpjam server doctor --url https://your-server.com/mcp --oauth-access-token $TOKEN
+
+# 4. Exercise tools directly
+mcpjam tools list --url https://your-server.com/mcp --access-token $TOKEN
+mcpjam tools call --url https://your-server.com/mcp --access-token $TOKEN \
+  --tool-name my_tool --tool-args '{"key": "value"}'
+```
+
+## What's next
+
+- [Server inspection](/cli/server-inspection) — probe, doctor, and diagnostics
+- [OAuth conformance](/cli/oauth-conformance) — test your OAuth implementation
+- [OAuth login](/cli/oauth-login) — authenticate and debug OAuth flows
+- [Tools, resources & prompts](/cli/tools-resources-prompts) — exercise the connected surface
+- [Full command reference](/cli/reference) — every flag for every command

--- a/docs/cli/oauth-conformance.mdx
+++ b/docs/cli/oauth-conformance.mdx
@@ -1,0 +1,314 @@
+---
+title: "OAuth Conformance"
+description: "Test your MCP server's OAuth implementation across all registration methods and protocol versions"
+icon: "shield-check"
+---
+
+The OAuth conformance module runs real OAuth handshakes against your MCP server — the same flows Claude Desktop, ChatGPT, and Claude Code perform — and tells you exactly where they break.
+
+## Why you need this
+
+- **Each MCP client exercises OAuth slightly differently.** Passing conformance means your server works for all of them.
+- **OAuth bugs are silent.** A valid-looking token can be rejected by MCP authentication downstream. Users see "failed to connect" with no context. `--verify-tools` catches this.
+- **3 registration strategies x 3 protocol versions x 3 auth modes** = 27 possible flow combinations. The suite runner covers the matrix in one invocation.
+- **CI-ready output.** `--format junit-xml` for dashboards. Exit 0/1/2 for scripts.
+
+## Quick start
+
+```bash
+mcpjam oauth conformance \
+  --url https://your-server.com/mcp \
+  --protocol-version 2025-11-25 \
+  --registration dcr \
+  --verify-tools
+```
+
+The default `--auth-mode` is `interactive` — a browser opens for consent. Pass `--auth-mode headless` for CI against auto-consenting auth servers, or `--auth-mode client_credentials` for M2M.
+
+**What success looks like:**
+
+```text
+OAuth conformance: PASSED
+Server: https://your-server.com/mcp
+Flow: 2025-11-25 / dcr
+Summary: OAuth conformance passed for https://your-server.com/mcp (2025-11-25, dcr)
+Duration: 4312ms
+Steps: 12 passed steps, 0 failed steps, 0 skipped steps
+
+Verification
+listTools: PASS (8 tools)
+```
+
+## What it tests
+
+Each conformance run walks through:
+
+1. **Initial request** — sends an unauthenticated request to trigger a 401
+2. **Discovery** — fetches resource metadata and authorization server metadata
+3. **Registration** — registers the client via CIMD, DCR, or pre-registered credentials
+4. **Authorization** — obtains an authorization code (interactive, headless, or client_credentials)
+5. **Token exchange** — exchanges the code for access/refresh tokens
+6. **Authenticated request** — retries the MCP request with the token
+7. **Post-auth verification** (optional) — connects via MCP and lists tools / calls a tool
+
+When `--conformance-checks` is enabled, three additional negative checks run after the flow:
+- **Invalid client** — confirms the auth server rejects an unknown client ID
+- **Invalid redirect** — confirms the auth server rejects a mismatched redirect URI
+- **Token format** — validates the token response has the expected fields
+
+## Scenarios
+
+### I just added OAuth to my MCP server
+
+```bash
+mcpjam oauth conformance \
+  --url http://localhost:8080/mcp \
+  --protocol-version 2025-11-25 \
+  --registration dcr \
+  --verify-tools
+```
+
+### CI conformance testing without a browser
+
+```bash
+# Option A: headless (requires auto-consenting auth server)
+mcpjam oauth conformance \
+  --url $MCP_SERVER_URL \
+  --protocol-version 2025-11-25 \
+  --registration dcr \
+  --auth-mode headless \
+  --verify-tools
+
+# Option B: client_credentials (M2M, no browser)
+mcpjam oauth conformance \
+  --url $MCP_SERVER_URL \
+  --protocol-version 2025-11-25 \
+  --registration preregistered \
+  --auth-mode client_credentials \
+  --client-id "$M2M_CLIENT_ID" \
+  --client-secret "$M2M_CLIENT_SECRET" \
+  --verify-tools
+```
+
+<Note>
+  Always pass `--auth-mode` explicitly in CI. The default is `interactive`
+  and will attempt to open a browser.
+</Note>
+
+### Test multiple protocol versions at once
+
+Create a config file:
+
+```json
+{
+  "name": "Full Protocol Matrix",
+  "serverUrl": "https://your-server.com/mcp",
+  "defaults": {
+    "auth": { "mode": "headless" },
+    "verification": { "listTools": true }
+  },
+  "flows": [
+    { "label": "2025-03-26 / dcr", "protocolVersion": "2025-03-26", "registrationStrategy": "dcr" },
+    { "label": "2025-06-18 / dcr", "protocolVersion": "2025-06-18", "registrationStrategy": "dcr" },
+    { "label": "2025-11-25 / dcr", "protocolVersion": "2025-11-25", "registrationStrategy": "dcr" },
+    { "label": "2025-11-25 / cimd", "protocolVersion": "2025-11-25", "registrationStrategy": "cimd" }
+  ]
+}
+```
+
+```bash
+mcpjam oauth conformance-suite --config ./oauth-tests.json
+```
+
+### Users report tokens work but tool calls fail
+
+This is exactly what `--verify-call-tool` catches. OAuth can succeed (valid token issued) while the MCP layer rejects it (wrong audience, missing scope, session binding).
+
+```bash
+mcpjam oauth conformance \
+  --url https://your-server.com/mcp \
+  --protocol-version 2025-11-25 \
+  --registration dcr \
+  --verify-call-tool your_tool_name
+```
+
+`--verify-call-tool` implies `--verify-tools`.
+
+### Test specific scopes
+
+```bash
+mcpjam oauth conformance \
+  --url https://your-server.com/mcp \
+  --protocol-version 2025-11-25 \
+  --registration dcr \
+  --scopes "read:tools write:tools" \
+  --verify-tools
+```
+
+<Note>
+  `--scopes` sets what you **request** from the auth server. The runner does
+  not currently verify that granted scopes match requested scopes.
+</Note>
+
+### Drive consent via Playwright or automation
+
+```bash
+mcpjam oauth conformance \
+  --url https://your-server.com/mcp \
+  --protocol-version 2025-11-25 \
+  --registration dcr \
+  --print-url \
+  --verify-tools
+```
+
+`--print-url` writes the consent URL to stderr (`OAUTH_CONSENT_URL: https://...`) instead of launching a browser. The local callback listener still runs — your Playwright script opens the URL, drives consent, and the CLI catches the redirect.
+
+### Run the OAuth negative checks
+
+```bash
+mcpjam oauth conformance \
+  --url https://your-server.com/mcp \
+  --protocol-version 2025-11-25 \
+  --registration dcr \
+  --conformance-checks \
+  --verify-tools
+```
+
+This adds 3 checks after the main flow: invalid client rejection, invalid redirect rejection, and token format validation.
+
+## Registration strategies
+
+| Strategy | Description | Protocol versions |
+|----------|-------------|-------------------|
+| `cimd` | Client ID Metadata Document — the client publishes its identity at a URL | 2025-11-25 only |
+| `dcr` | Dynamic Client Registration — the client registers itself at runtime | All |
+| `preregistered` | Pre-registered client ID and optional secret | All |
+
+**When to choose what:**
+- **CIMD** (2025-11-25): preferred for production when the auth server supports it — avoids mutable DCR state.
+- **DCR**: the default for quick testing — works everywhere, no pre-configuration needed.
+- **Preregistered**: use when the auth server doesn't support DCR, or for `client_credentials` M2M flows.
+
+When `cimd` is used without `--client-metadata-url`, the runner falls back to mcpjam's public metadata document at `https://www.mcpjam.com/.well-known/oauth/client-metadata.json`.
+
+## Auth modes
+
+| Mode | Use case | User interaction |
+|------|----------|-----------------|
+| `interactive` (default) | Local dev — opens browser for consent | Browser popup |
+| `headless` | CI with auto-consenting auth servers | None |
+| `client_credentials` | Machine-to-machine service accounts | None |
+
+### Compatibility
+
+| Registration | `headless` | `interactive` | `client_credentials` |
+|--------------|:----------:|:-------------:|:--------------------:|
+| `cimd` (2025-11-25 only) | yes | yes | no |
+| `dcr` | yes | yes | yes (secret from DCR) |
+| `preregistered` | yes | yes | yes (requires `--client-secret`) |
+
+`cimd` + `client_credentials` is rejected with a clear error: *"CIMD is a browser-based registration flow and only works with --auth-mode headless or --auth-mode interactive."*
+
+## Post-auth verification
+
+OAuth conformance proves a token was issued. Verification proves the token is actually **usable for MCP operations**.
+
+Three silent-failure modes this catches:
+
+1. **Token audience mismatch** — OAuth flow succeeds but `tools/list` returns 401 because `aud` doesn't match the MCP resource URL.
+2. **Scope mismatch** — token issued but the MCP tool handler requires different scopes.
+3. **Session binding** — some servers require a separate session init after auth.
+
+| Flag | What it does |
+|------|-------------|
+| `--verify-tools` | After OAuth, connect to the MCP server and call `tools/list` |
+| `--verify-call-tool <name>` | Also call the named tool (implies `--verify-tools`) |
+
+## Troubleshooting
+
+| Step that failed | Likely cause | Fix |
+|-----------------|-------------|-----|
+| `request_without_token` returned 200 | Server allows anonymous access or missing `WWW-Authenticate` | Return 401 with `WWW-Authenticate: Bearer resource_metadata="..."` |
+| `request_resource_metadata` 404 | `/.well-known/oauth-protected-resource` missing or wrong Content-Type | Ensure the endpoint exists and returns `application/json` |
+| `received_resource_metadata` — AS URL mismatch | `authorization_servers` points to a URL without AS metadata | Verify the AS URL has `/.well-known/oauth-authorization-server` |
+| `request_client_registration` 400 | DCR endpoint rejected the registration metadata | Check required fields; use SDK `dynamicRegistration` overrides for custom metadata |
+| `received_authorization_code` — HTML login page | Auth server requires interactive login but you used `--auth-mode headless` | Switch to `--auth-mode interactive` |
+| `received_authorization_code` — state mismatch | Stale popup or concurrent authorization flows | Close other browser tabs and retry |
+| `token_request` 401 `invalid_client` | Wrong `token_endpoint_auth_method` or client_id mismatch | Check DCR response for `token_endpoint_auth_method`; CIMD uses `none` |
+| `authenticated_mcp_request` 401 | Token `aud` doesn't match MCP resource URL | Ensure your auth server sets `aud` correctly |
+| `verify_list_tools` auth error | Token works for OAuth but MCP layer rejects it — scope issue | Check that the token's scope matches what tool handlers require |
+| DCR + `client_credentials`: "Dynamic registration produced a public client" | DCR returned `token_endpoint_auth_method: "none"` | Use `--registration preregistered` with explicit credentials instead |
+
+## CI/CD integration
+
+### GitHub Actions
+
+```yaml
+- name: OAuth Conformance
+  run: |
+    npx -y @mcpjam/cli-preview@latest oauth conformance \
+      --url ${{ secrets.MCP_SERVER_URL }} \
+      --protocol-version 2025-11-25 \
+      --registration preregistered \
+      --auth-mode client_credentials \
+      --client-id ${{ secrets.M2M_CLIENT_ID }} \
+      --client-secret ${{ secrets.M2M_CLIENT_SECRET }} \
+      --verify-tools
+```
+
+### GitLab CI (JUnit output)
+
+```yaml
+oauth-conformance:
+  stage: test
+  script:
+    - npx -y @mcpjam/cli-preview@latest oauth conformance-suite
+        --config ./oauth-tests.json
+        --format junit-xml > report.xml
+  artifacts:
+    reports:
+      junit: report.xml
+```
+
+## All flags
+
+### `oauth conformance`
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--url <url>` | Yes | | MCP server URL |
+| `--protocol-version <v>` | Yes | | `2025-03-26`, `2025-06-18`, or `2025-11-25` |
+| `--registration <s>` | Yes | | `cimd`, `dcr`, or `preregistered` |
+| `--auth-mode <m>` | No | `interactive` | `headless`, `interactive`, or `client_credentials` |
+| `--client-id <id>` | No | | OAuth client ID (required for `preregistered`) |
+| `--client-secret <s>` | No | | OAuth client secret |
+| `--client-metadata-url <url>` | No | | CIMD metadata document URL |
+| `--redirect-url <url>` | No | Auto-generated | OAuth redirect URL |
+| `--scopes <scopes>` | No | | Space-separated scope string |
+| `--header <header>` | No | | HTTP header `Key: Value` (repeatable) |
+| `--step-timeout <ms>` | No | `30000` | Per-step timeout |
+| `--verify-tools` | No | | After OAuth, connect and list tools |
+| `--verify-call-tool <name>` | No | | Also call the named tool (implies `--verify-tools`) |
+| `--conformance-checks` | No | | Run additional negative OAuth checks after the main flow |
+| `--print-url` | No | | Print consent URL to stderr instead of launching a browser |
+
+### `oauth conformance-suite`
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--config <path>` | Yes | | Path to JSON config file |
+| `--verify-tools` | No | | Enable tool listing on all flows |
+| `--verify-call-tool <name>` | No | | Call the named tool after listing |
+| `--format <fmt>` | No | Auto-detected | `json`, `human`, or `junit-xml` |
+
+<Note>
+  `--verify-tools` and `--verify-call-tool` on the suite command are forced
+  onto **every** flow. Per-flow `verification` entries in the config file
+  cannot disable them once the CLI flag is set.
+</Note>
+
+## Related
+
+- [OAuth Login & Debugging](/cli/oauth-login) — get tokens and debug OAuth flows
+- [Server Inspection](/cli/server-inspection) — probe and diagnose before testing conformance
+- [OAuth Conformance SDK Reference](/sdk/reference/oauth-conformance) — programmatic usage with `OAuthConformanceTest`

--- a/docs/cli/oauth-login.mdx
+++ b/docs/cli/oauth-login.mdx
@@ -1,0 +1,121 @@
+---
+title: "OAuth Login & Debugging"
+description: "Authenticate with MCP servers and debug OAuth flows"
+icon: "key"
+---
+
+The `oauth` command group handles authentication against MCP servers that require OAuth. Use `oauth login` to obtain tokens interactively, and the proxy/metadata commands to debug discovery and endpoint behavior.
+
+## Quick start
+
+```bash
+# Interactive login — opens a browser for consent
+mcpjam oauth login --url https://your-server.com/mcp \
+  --protocol-version 2025-11-25 \
+  --registration dcr
+```
+
+On success, the command prints credentials (access token, refresh token, client ID) that you can pass to other commands via `--oauth-access-token` or `--access-token`.
+
+## Commands
+
+### `oauth login`
+
+Runs a full OAuth flow: discovery, registration, authorization, token exchange. Supports all three registration strategies and auth modes.
+
+```bash
+# DCR + interactive (most common for local dev)
+mcpjam oauth login --url https://your-server.com/mcp \
+  --protocol-version 2025-11-25 \
+  --registration dcr
+
+# CIMD + interactive (2025-11-25 only)
+mcpjam oauth login --url https://your-server.com/mcp \
+  --protocol-version 2025-11-25 \
+  --registration cimd
+
+# Preregistered + client_credentials (M2M, no browser)
+mcpjam oauth login --url https://your-server.com/mcp \
+  --protocol-version 2025-11-25 \
+  --registration preregistered \
+  --auth-mode client_credentials \
+  --client-id "$CLIENT_ID" \
+  --client-secret "$CLIENT_SECRET"
+```
+
+<Warning>
+  Prefer environment variables for `--client-secret`. Passing it inline leaks
+  to shell history and process listings.
+</Warning>
+
+The `--debug-out <path>` flag captures a structured debug artifact with full HTTP traces — useful for filing bug reports or handing off to another engineer.
+
+```bash
+mcpjam oauth login --url https://your-server.com/mcp \
+  --protocol-version 2025-11-25 \
+  --registration dcr \
+  --debug-out oauth-debug.json
+```
+
+### `oauth metadata`
+
+Fetch and display OAuth metadata from a URL. Useful for verifying your server's discovery endpoints are correct.
+
+```bash
+mcpjam oauth metadata --url https://your-server.com/.well-known/oauth-protected-resource
+mcpjam oauth metadata --url https://auth.example.com/.well-known/oauth-authorization-server
+```
+
+### `oauth proxy`
+
+Send an arbitrary HTTP request through the OAuth proxy with hosted-mode safety checks. Useful for testing individual OAuth endpoints (registration, token, etc.) without building raw HTTP requests.
+
+```bash
+# Test a DCR registration
+mcpjam oauth proxy \
+  --url https://auth.example.com/register \
+  --method POST \
+  --header "Content-Type: application/json" \
+  --body '{"redirect_uris":["http://localhost:8080/callback"],"client_name":"test"}'
+
+# Fetch an endpoint
+mcpjam oauth proxy --url https://auth.example.com/v1/oauth2/token --method GET
+```
+
+### `oauth debug-proxy`
+
+Same as `oauth proxy` but routes through the debug proxy path. Use when testing endpoints that behave differently for debug vs. production requests.
+
+## Login flags
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--url <url>` | Yes | | MCP server URL |
+| `--protocol-version <v>` | Yes | | `2025-03-26`, `2025-06-18`, or `2025-11-25` |
+| `--registration <s>` | Yes | | `cimd`, `dcr`, or `preregistered` |
+| `--auth-mode <m>` | No | `interactive` | `headless`, `interactive`, or `client_credentials` |
+| `--client-id <id>` | No | | OAuth client ID (required for `preregistered`) |
+| `--client-secret <s>` | No | | OAuth client secret |
+| `--client-metadata-url <url>` | No | | CIMD metadata document URL |
+| `--redirect-url <url>` | No | Auto-generated | OAuth redirect URL |
+| `--scopes <scopes>` | No | | Space-separated scope string |
+| `--header <header>` | No | | HTTP header `Key: Value` (repeatable) |
+| `--step-timeout <ms>` | No | `30000` | Per-step timeout |
+| `--verify-tools` | No | | After login, connect and list tools |
+| `--verify-call-tool <name>` | No | | After listing, also call a named tool |
+| `--debug-out <path>` | No | | Write debug artifact to file |
+
+## Using tokens from login
+
+After a successful `oauth login`, use the printed access token with other commands:
+
+```bash
+# Capture the token
+TOKEN=$(mcpjam oauth login --url https://your-server.com/mcp \
+  --protocol-version 2025-11-25 --registration dcr \
+  --format json | jq -r '.credentials.accessToken')
+
+# Use it
+mcpjam server doctor --url https://your-server.com/mcp --oauth-access-token "$TOKEN"
+mcpjam tools list --url https://your-server.com/mcp --access-token "$TOKEN"
+```

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -1,0 +1,219 @@
+---
+title: "Command Reference"
+description: "Complete flag reference for every mcpjam CLI command"
+icon: "book"
+---
+
+Complete flag tables for every `mcpjam` command. For guides and recipes, see the individual command pages.
+
+## Global flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--timeout <ms>` | `30000` | Request timeout in milliseconds |
+| `--rpc` | off | Include raw JSON-RPC logs in output |
+| `--format <format>` | `human` on TTY, `json` when piped | Output format |
+| `-v, --version` | | Print the CLI version |
+
+---
+
+## `server` commands
+
+All server commands accept the shared connection flags below, plus command-specific options.
+
+### Shared connection flags
+
+| Flag | Description |
+|------|-------------|
+| `--url <url>` | HTTP MCP server URL |
+| `--access-token <token>` | Bearer access token |
+| `--oauth-access-token <token>` | OAuth bearer access token |
+| `--refresh-token <token>` | OAuth refresh token |
+| `--client-id <id>` | OAuth client ID (with `--refresh-token`) |
+| `--client-secret <secret>` | OAuth client secret (with `--refresh-token`) |
+| `--header <header>` | HTTP header `Key: Value` (repeatable) |
+| `--client-capabilities <json>` | Client capabilities JSON object |
+| `--command <command>` | Stdio server command |
+| `--command-args <arg>` | Stdio command argument (repeatable) |
+| `--env <env>` | Stdio environment `KEY=VALUE` (repeatable) |
+
+### `server probe`
+
+No additional flags beyond shared connection flags.
+
+### `server doctor`
+
+| Flag | Description |
+|------|-------------|
+| `--out <path>` | Write the doctor JSON artifact to a file |
+
+### `server info`
+
+No additional flags.
+
+### `server validate`
+
+No additional flags.
+
+### `server ping`
+
+No additional flags.
+
+### `server capabilities`
+
+No additional flags.
+
+### `server export`
+
+No additional flags.
+
+---
+
+## `tools` commands
+
+### `tools list`
+
+Uses shared connection flags.
+
+### `tools call`
+
+| Flag | Description |
+|------|-------------|
+| `--tool-name <name>` | Name of the tool to call |
+| `--tool-args <json>` | Tool arguments as a JSON string |
+| `--debug-out <path>` | Write debug artifact to file |
+
+Plus shared connection flags.
+
+---
+
+## `resources` commands
+
+### `resources list`
+
+Uses shared connection flags.
+
+### `resources read`
+
+| Flag | Description |
+|------|-------------|
+| `--resource-uri <uri>` | URI of the resource to read |
+
+Plus shared connection flags.
+
+### `resources templates`
+
+Uses shared connection flags.
+
+---
+
+## `prompts` commands
+
+### `prompts list`
+
+Uses shared connection flags.
+
+### `prompts get`
+
+| Flag | Description |
+|------|-------------|
+| `--prompt-name <name>` | Name of the prompt |
+| `--prompt-args <json>` | Prompt arguments as a JSON string |
+
+Plus shared connection flags.
+
+---
+
+## `oauth` commands
+
+### `oauth login`
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--url <url>` | Yes | | MCP server URL |
+| `--protocol-version <v>` | Yes | | `2025-03-26`, `2025-06-18`, or `2025-11-25` |
+| `--registration <s>` | Yes | | `cimd`, `dcr`, or `preregistered` |
+| `--auth-mode <m>` | No | `interactive` | `headless`, `interactive`, or `client_credentials` |
+| `--client-id <id>` | No | | OAuth client ID |
+| `--client-secret <s>` | No | | OAuth client secret |
+| `--client-metadata-url <url>` | No | | CIMD metadata document URL |
+| `--redirect-url <url>` | No | Auto-generated | OAuth redirect URL |
+| `--scopes <scopes>` | No | | Space-separated scope string |
+| `--header <header>` | No | | HTTP header `Key: Value` (repeatable) |
+| `--step-timeout <ms>` | No | `30000` | Per-step timeout |
+| `--verify-tools` | No | | After login, list tools |
+| `--verify-call-tool <name>` | No | | Also call the named tool |
+| `--debug-out <path>` | No | | Write debug artifact to file |
+
+### `oauth conformance`
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--url <url>` | Yes | | MCP server URL |
+| `--protocol-version <v>` | Yes | | `2025-03-26`, `2025-06-18`, or `2025-11-25` |
+| `--registration <s>` | Yes | | `cimd`, `dcr`, or `preregistered` |
+| `--auth-mode <m>` | No | `interactive` | `headless`, `interactive`, or `client_credentials` |
+| `--client-id <id>` | No | | OAuth client ID |
+| `--client-secret <s>` | No | | OAuth client secret |
+| `--client-metadata-url <url>` | No | | CIMD metadata document URL |
+| `--redirect-url <url>` | No | Auto-generated | OAuth redirect URL |
+| `--scopes <scopes>` | No | | Space-separated scope string |
+| `--header <header>` | No | | HTTP header `Key: Value` (repeatable) |
+| `--step-timeout <ms>` | No | `30000` | Per-step timeout |
+| `--verify-tools` | No | | After OAuth, list tools |
+| `--verify-call-tool <name>` | No | | Also call the named tool |
+| `--conformance-checks` | No | | Run additional negative OAuth checks |
+| `--print-url` | No | | Print consent URL to stderr (interactive only) |
+
+### `oauth conformance-suite`
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--config <path>` | Yes | | Path to JSON config file |
+| `--verify-tools` | No | | Enable tool listing on all flows |
+| `--verify-call-tool <name>` | No | | Call the named tool after listing |
+
+### `oauth metadata`
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--url <url>` | Yes | OAuth metadata URL to fetch |
+
+### `oauth proxy` / `oauth debug-proxy`
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--url <url>` | Yes | | OAuth request URL |
+| `--method <method>` | No | `GET` | HTTP method |
+| `--header <header>` | No | | HTTP header `Key: Value` (repeatable) |
+| `--body <value>` | No | | Request body (JSON or raw string) |
+
+---
+
+## `protocol` commands
+
+### `protocol conformance`
+
+MCP protocol conformance checks against an HTTP server. Uses shared connection flags.
+
+---
+
+## `apps` commands
+
+### `apps mcp-widget`
+
+Fetch hosted-style MCP App widget content.
+
+### `apps chatgpt-widget`
+
+Fetch hosted-style ChatGPT App widget content.
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | Success / all checks passed |
+| `1` | Command ran but reported a failure |
+| `2` | Invalid arguments or configuration |

--- a/docs/cli/server-inspection.mdx
+++ b/docs/cli/server-inspection.mdx
@@ -1,0 +1,154 @@
+---
+title: "Server Inspection"
+description: "Probe, diagnose, and export MCP server connectivity and capabilities"
+icon: "stethoscope"
+---
+
+The `server` command group gives you a breadth-first view of any MCP server — connectivity, OAuth discovery, capabilities, tools, resources, and prompts — without writing code.
+
+## Quick start
+
+```bash
+# One command does everything: probe, connect, sweep tools/resources/prompts
+mcpjam server doctor --url https://your-server.com/mcp
+```
+
+If the server requires OAuth, doctor reports `oauth_required` with the discovery metadata. See [OAuth login](/cli/oauth-login) to obtain a token, then re-run with `--oauth-access-token`.
+
+## Commands
+
+### `server probe`
+
+Stateless HTTP probe — no full client connection. Tests transport selection, OAuth discovery, and `WWW-Authenticate` parsing.
+
+```bash
+mcpjam server probe --url https://your-server.com/mcp
+```
+
+Use this when you want to check reachability and OAuth metadata without triggering a full MCP initialize handshake. The probe sends an unauthenticated `initialize` request and inspects the response.
+
+**What it returns:**
+- Transport type (streamable-http, SSE, or failed)
+- OAuth metadata (resource metadata URL, authorization server metadata, registration strategies, scopes)
+- `WWW-Authenticate` header parsing
+
+### `server doctor`
+
+Combined triage — runs probe, then attempts a full client connection, then sweeps tools, resources, resource templates, and prompts. Returns a single JSON artifact.
+
+```bash
+# Human-readable summary
+mcpjam server doctor --url https://your-server.com/mcp
+
+# Full JSON artifact with RPC logs
+mcpjam server doctor --url https://your-server.com/mcp --rpc --out doctor.json
+
+# Stdio server
+mcpjam server doctor --command node --command-args server.js
+```
+
+**What it returns:**
+- `status`: `ready`, `oauth_required`, or `error`
+- Probe results (transport, OAuth discovery)
+- Initialization info and negotiated capabilities
+- Counts: tools, resources, resource templates, prompts
+
+The `--out <path>` flag writes the full JSON artifact to a file — useful for handoff to another engineer or agent.
+
+### `server info`
+
+Get initialization info for a connected server.
+
+```bash
+mcpjam server info --url https://your-server.com/mcp --access-token $TOKEN
+```
+
+Returns the server's `serverInfo` (name, version) and `capabilities` from the MCP initialize response.
+
+### `server capabilities`
+
+Get resolved server capabilities.
+
+```bash
+mcpjam server capabilities --url https://your-server.com/mcp --access-token $TOKEN
+```
+
+### `server validate`
+
+Connect to a server and verify the debugger surface works.
+
+```bash
+mcpjam server validate --url https://your-server.com/mcp --access-token $TOKEN
+```
+
+### `server ping`
+
+Simple connectivity check.
+
+```bash
+mcpjam server ping --url https://your-server.com/mcp
+```
+
+### `server export`
+
+Export a full snapshot of the server's tools, resources, prompts, and capabilities as JSON.
+
+```bash
+mcpjam server export --url https://your-server.com/mcp --access-token $TOKEN > snapshot.json
+```
+
+## Shared server flags
+
+Every `server` subcommand accepts these flags for specifying how to connect:
+
+| Flag | Description |
+|------|-------------|
+| `--url <url>` | HTTP MCP server URL |
+| `--access-token <token>` | Bearer access token |
+| `--oauth-access-token <token>` | OAuth bearer access token |
+| `--refresh-token <token>` | OAuth refresh token |
+| `--client-id <id>` | OAuth client ID (used with `--refresh-token`) |
+| `--client-secret <secret>` | OAuth client secret (used with `--refresh-token`) |
+| `--header <header>` | HTTP header in `Key: Value` format (repeatable) |
+| `--client-capabilities <json>` | Client capabilities as a JSON object |
+| `--command <command>` | Command for a stdio server |
+| `--command-args <arg>` | Stdio command argument (repeatable) |
+| `--env <env>` | Stdio environment `KEY=VALUE` (repeatable) |
+
+## Common patterns
+
+### Triage an unknown server
+
+```bash
+# Start with doctor
+mcpjam server doctor --url https://unknown-server.com/mcp
+
+# If it returns oauth_required, login first
+mcpjam oauth login --url https://unknown-server.com/mcp \
+  --protocol-version 2025-11-25 --registration dcr
+
+# Then re-run with the token
+mcpjam server doctor --url https://unknown-server.com/mcp --oauth-access-token $TOKEN
+```
+
+### Compare before/after a deploy
+
+```bash
+# Capture a snapshot before
+mcpjam server export --url https://your-server.com/mcp --access-token $TOKEN > before.json
+
+# Deploy...
+
+# Capture after
+mcpjam server export --url https://your-server.com/mcp --access-token $TOKEN > after.json
+
+# Diff
+diff <(jq -S . before.json) <(jq -S . after.json)
+```
+
+### CI health check
+
+```bash
+mcpjam server doctor --url $MCP_SERVER_URL --access-token $TOKEN --format json | jq '.status'
+# exits 0 if ready, 1 if not
+```

--- a/docs/cli/tools-resources-prompts.mdx
+++ b/docs/cli/tools-resources-prompts.mdx
@@ -1,0 +1,107 @@
+---
+title: "Tools, Resources & Prompts"
+description: "List, read, and call MCP server tools, resources, and prompts"
+icon: "wrench"
+---
+
+Once connected (with or without auth), the `tools`, `resources`, and `prompts` command groups let you explore and exercise what the server exposes.
+
+## Tools
+
+### List tools
+
+```bash
+mcpjam tools list --url https://your-server.com/mcp --access-token $TOKEN
+```
+
+Returns every tool the server exposes, including names, descriptions, and input schemas.
+
+### Call a tool
+
+```bash
+mcpjam tools call --url https://your-server.com/mcp --access-token $TOKEN \
+  --tool-name search_docs \
+  --tool-args '{"query": "authentication"}'
+```
+
+Tool arguments are passed as a JSON string. The result includes the tool's response content.
+
+<Note>
+  `tools call` supports `--debug-out <path>` to capture the full request/response
+  trace for debugging.
+</Note>
+
+## Resources
+
+### List resources
+
+```bash
+mcpjam resources list --url https://your-server.com/mcp --access-token $TOKEN
+```
+
+### Read a resource
+
+```bash
+mcpjam resources read --url https://your-server.com/mcp --access-token $TOKEN \
+  --resource-uri "file:///docs/readme.md"
+```
+
+### List resource templates
+
+```bash
+mcpjam resources templates --url https://your-server.com/mcp --access-token $TOKEN
+```
+
+## Prompts
+
+### List prompts
+
+```bash
+mcpjam prompts list --url https://your-server.com/mcp --access-token $TOKEN
+```
+
+### Get a prompt
+
+```bash
+mcpjam prompts get --url https://your-server.com/mcp --access-token $TOKEN \
+  --prompt-name summarize \
+  --prompt-args '{"text": "Hello world"}'
+```
+
+## Common patterns
+
+### Enumerate the full server surface
+
+```bash
+# One-shot: doctor already sweeps everything
+mcpjam server doctor --url https://your-server.com/mcp --access-token $TOKEN
+
+# Or individually for focused output
+mcpjam tools list --url $URL --access-token $TOKEN --format json | jq '.tools[].name'
+mcpjam resources list --url $URL --access-token $TOKEN --format json | jq '.resources[].uri'
+mcpjam prompts list --url $URL --access-token $TOKEN --format json | jq '.prompts[].name'
+```
+
+### Test a specific tool end-to-end
+
+```bash
+# List to find the tool
+mcpjam tools list --url $URL --access-token $TOKEN --format json \
+  | jq '.tools[] | select(.name == "search_docs")'
+
+# Call it
+mcpjam tools call --url $URL --access-token $TOKEN \
+  --tool-name search_docs \
+  --tool-args '{"query": "setup guide"}' \
+  --format json
+```
+
+### No-auth servers
+
+For servers that don't require authentication (like `mcp.excalidraw.com/mcp`), simply omit the auth flags:
+
+```bash
+mcpjam tools list --url https://mcp.excalidraw.com/mcp
+mcpjam tools call --url https://mcp.excalidraw.com/mcp \
+  --tool-name read_me
+```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -39,6 +39,18 @@
         ]
       },
       {
+        "group": "CLI",
+        "icon": "terminal",
+        "pages": [
+          "cli/index",
+          "cli/server-inspection",
+          "cli/oauth-conformance",
+          "cli/oauth-login",
+          "cli/tools-resources-prompts",
+          "cli/reference"
+        ]
+      },
+      {
         "group": "SDK",
         "icon": "code",
         "pages": [

--- a/docs/sdk/reference/oauth-conformance.mdx
+++ b/docs/sdk/reference/oauth-conformance.mdx
@@ -1,328 +1,27 @@
 ---
-title: "OAuth Conformance"
-description: "Test your MCP server's OAuth implementation across all registration methods and protocol versions"
+title: "OAuth Conformance SDK"
+description: "Programmatic OAuth conformance testing with OAuthConformanceTest and OAuthConformanceSuite"
 icon: "shield-check"
 ---
 
-The OAuth Conformance module tests that your MCP server correctly implements the [MCP OAuth specification](https://modelcontextprotocol.io/specification/draft/basic/authorization). It walks through the full OAuth handshake — discovery, registration, authorization, token exchange — and optionally verifies the token works by connecting to the server and listing tools.
-
-Use it to validate that real MCP clients (Claude Desktop, ChatGPT, Claude Code, etc.) will be able to authenticate with your server.
-
-## What it tests
-
-Each conformance run walks through:
-
-1. **Initial request** — Sends an unauthenticated request to trigger a 401
-2. **Discovery** — Fetches resource metadata and authorization server metadata
-3. **Registration** — Registers the client via CIMD, DCR, or pre-registered credentials
-4. **Authorization** — Obtains an authorization code (interactive, headless, or client_credentials)
-5. **Token exchange** — Exchanges the code for access/refresh tokens
-6. **Authenticated request** — Retries the MCP request with the token
-7. **Post-auth verification** (optional) — Connects via MCP and lists tools / calls a tool
-
-## Registration strategies
-
-| Strategy | Description | Protocol versions |
-|----------|-------------|-------------------|
-| `cimd` | Client ID Metadata Document — the client publishes its identity at a URL | 2025-11-25 only |
-| `dcr` | Dynamic Client Registration — the client registers itself at runtime | All |
-| `preregistered` | Pre-registered client ID and optional secret | All |
-
-## Auth modes
-
-| Mode | Use case | User interaction |
-|------|----------|-----------------|
-| `headless` | CI/CD with auto-consenting auth servers | None |
-| `interactive` | Local dev — opens browser for consent | Browser popup |
-| `client_credentials` | Machine-to-machine (M2M) service accounts | None |
-
-### Compatibility
-
-Not every combination is valid. The runner rejects unsupported pairs before making any HTTP requests.
-
-| Registration | `headless` | `interactive` | `client_credentials` |
-|--------------|:----------:|:-------------:|:--------------------:|
-| `cimd` (2025-11-25 only) | ✅ | ✅ | ❌ |
-| `dcr` | ✅ | ✅ | ✅ (secret returned by DCR) |
-| `preregistered` | ✅ | ✅ | ✅ (requires `--client-secret`) |
-
-`cimd` + `client_credentials` is explicitly rejected: CIMD identifies a public client by a metadata URL and has no client secret to authenticate an M2M token request.
-
----
-
-## CLI Usage
+The OAuth Conformance SDK classes let you run the same flows the [CLI `oauth conformance`](/cli/oauth-conformance) command runs, but programmatically — for custom reporters, test frameworks, recording/replay via custom `fetchFn`, or Playwright-driven consent via `openUrl`.
 
 <Note>
-  All examples use `npx -y @mcpjam/cli-preview@latest` so each run picks up the
-  newest preview build and `-y` auto-accepts the install prompt in non-interactive
-  shells (CI, scripted agents). Drop `@latest` if you want npx's cached copy.
+  For CLI usage (one-liners, CI recipes, troubleshooting), see [CLI: OAuth Conformance](/cli/oauth-conformance).
+  This page covers the TypeScript SDK only.
 </Note>
 
-### Quick start — interactive DCR (local dev)
-
-The simplest one-liner. Opens a browser for consent, registers a fresh client via DCR, then verifies the token by listing tools.
-
-```bash
-npx -y @mcpjam/cli-preview@latest oauth conformance \
-  --url https://your-server.com/mcp \
-  --protocol-version 2025-11-25 \
-  --registration dcr \
-  --auth-mode interactive \
-  --verify-tools
-```
-
-### Headless DCR (CI against an auto-consenting auth server)
-
-```bash
-npx -y @mcpjam/cli-preview@latest oauth conformance \
-  --url https://your-server.com/mcp \
-  --protocol-version 2025-11-25 \
-  --registration dcr \
-  --auth-mode headless \
-  --verify-tools
-```
-
-### Preregistered + interactive
-
-Use this when the auth server doesn't support DCR and you've already registered a client out-of-band. Pass the exact `--redirect-url` that's allow-listed on the client record.
-
-```bash
-npx -y @mcpjam/cli-preview@latest oauth conformance \
-  --url https://your-server.com/mcp \
-  --protocol-version 2025-11-25 \
-  --registration preregistered \
-  --auth-mode interactive \
-  --client-id "$OAUTH_CLIENT_ID" \
-  --client-secret "$OAUTH_CLIENT_SECRET" \
-  --redirect-url http://localhost:6274/oauth/callback \
-  --verify-tools
-```
-
-<Warning>
-  Prefer environment variables for `--client-secret`. Passing it inline leaks it
-  to shell history and process listings.
-</Warning>
-
-### CIMD (2025-11-25)
-
-Client ID Metadata Document registration — the server fetches your client's identity from `--client-metadata-url`. If omitted, the runner falls back to mcpjam's public metadata document, so you can try a CIMD flow with zero CIMD config:
-
-```bash
-npx -y @mcpjam/cli-preview@latest oauth conformance \
-  --url https://your-server.com/mcp \
-  --protocol-version 2025-11-25 \
-  --registration cimd \
-  --auth-mode interactive \
-  --verify-tools
-```
-
-To publish and test your own metadata document:
-
-```bash
-npx -y @mcpjam/cli-preview@latest oauth conformance \
-  --url https://your-server.com/mcp \
-  --protocol-version 2025-11-25 \
-  --registration cimd \
-  --auth-mode interactive \
-  --client-metadata-url https://your-app.com/.well-known/oauth-client \
-  --verify-tools
-```
-
-### All options
-
-| Flag | Required | Default | Description |
-|------|----------|---------|-------------|
-| `--url <url>` | Yes | — | MCP server URL |
-| `--protocol-version <v>` | Yes | — | `2025-03-26`, `2025-06-18`, or `2025-11-25` |
-| `--registration <s>` | Yes | — | `cimd`, `dcr`, or `preregistered` |
-| `--auth-mode <m>` | No | `headless` | `headless`, `interactive`, or `client_credentials` |
-| `--client-id <id>` | No | — | OAuth client ID (required for `preregistered`) |
-| `--client-secret <s>` | No | — | OAuth client secret |
-| `--client-metadata-url <url>` | No | — | Client metadata URL for CIMD |
-| `--redirect-url <url>` | No | Auto-generated | OAuth redirect URL to use for the run |
-| `--scopes <scopes>` | No | — | Space-separated scope string |
-| `--header <header>` | No | — | Custom HTTP header (`Key: Value`). Repeatable. |
-| `--step-timeout <ms>` | No | `30000` | Per-step timeout in milliseconds |
-| `--verify-tools` | No | — | After OAuth, connect and list tools |
-| `--verify-call-tool <name>` | No | — | Also call the named tool after listing |
-| `--format <fmt>` | No | `human` on TTY, `json` otherwise | `json`, `human`, or `junit-xml` |
-
-### Human vs JSON output
-
-- Interactive terminal runs default to `--format human`, which prints a compact OAuth-specific report.
-- Piped or redirected runs default to `--format json`, so CI, `jq`, and agent workflows still receive the full raw result unchanged.
-- `--format json`, `--format human`, and `--format junit-xml` always override the default.
-
-### Redirect URL behavior
-
-- `--redirect-url` is passed directly to `OAuthConformanceConfig.redirectUrl`.
-- For `interactive` auth mode, the SDK still enforces loopback redirects only: `http://localhost/.../callback` or `http://127.0.0.1/.../callback`.
-- For `headless` and `client_credentials`, the CLI only validates that the value is a syntactically valid URL.
-
-### Example human-readable failure output
-
-```text
-OAuth conformance: FAILED
-Server: https://mcp.asana.com/v2/mcp
-Flow: 2025-06-18 / dcr
-Summary: OAuth conformance failed at received_authorization_code: Headless authorization requires auto-consent. The authorization endpoint returned a 200 response instead of redirecting back with a code.
-
-Failure
-Step: received_authorization_code
-HTTP: 200 OK
-URL: https://app.asana.com/-/oauth_authorize?...
-Content-Type: text/html; charset=utf-8
-Page title: Log in - Asana
-Snippet: Welcome to Asana To get started, please sign in ...
-Hint: Authorization endpoint returned an HTML login page instead of redirecting back to the callback URL.
-```
-
-### Client credentials (M2M)
-
-For CI pipelines where no browser is available and your auth server supports `client_credentials`:
-
-```bash
-npx -y @mcpjam/cli-preview@latest oauth conformance \
-  --url https://your-server.com/mcp \
-  --protocol-version 2025-11-25 \
-  --registration preregistered \
-  --auth-mode client_credentials \
-  --client-id "$M2M_CLIENT_ID" \
-  --client-secret "$M2M_CLIENT_SECRET" \
-  --verify-tools
-```
-
----
-
-## Suite runner
-
-Test multiple OAuth flows in one invocation using a JSON config file.
-
-### Config file format
-
-```json
-{
-  "name": "My Server OAuth Conformance",
-  "serverUrl": "https://your-server.com/mcp",
-  "defaults": {
-    "stepTimeout": 15000,
-    "verification": { "listTools": true }
-  },
-  "flows": [
-    {
-      "label": "CIMD (2025-11-25)",
-      "protocolVersion": "2025-11-25",
-      "registrationStrategy": "cimd",
-      "auth": { "mode": "interactive" }
-    },
-    {
-      "label": "DCR (2025-11-25)",
-      "protocolVersion": "2025-11-25",
-      "registrationStrategy": "dcr",
-      "auth": { "mode": "interactive" }
-    },
-    {
-      "label": "M2M client_credentials",
-      "protocolVersion": "2025-11-25",
-      "registrationStrategy": "preregistered",
-      "client": {
-        "preregistered": {
-          "clientId": "my-m2m-client-id",
-          "clientSecret": "my-m2m-client-secret"
-        }
-      },
-      "auth": {
-        "mode": "client_credentials",
-        "clientId": "my-m2m-client-id",
-        "clientSecret": "my-m2m-client-secret"
-      }
-    }
-  ]
-}
-```
-
-Each flow inherits from `defaults` and can override any field. The `serverUrl` is shared across all flows.
-
-### Running the suite
-
-```bash
-# JSON output (for agents)
-npx -y @mcpjam/cli-preview@latest oauth conformance-suite --config ./oauth-tests.json --format json
-
-# Human-readable (default on a TTY)
-npx -y @mcpjam/cli-preview@latest oauth conformance-suite --config ./oauth-tests.json --format human
-
-# JUnit XML (for CI)
-npx -y @mcpjam/cli-preview@latest oauth conformance-suite --config ./oauth-tests.json --format junit-xml > report.xml
-```
-
-<Note>
-  `--verify-tools` and `--verify-call-tool` on the suite command are forced onto
-  **every** flow (and the suite defaults). Per-flow `verification` entries in
-  the config file cannot disable them once the CLI flag is set.
-</Note>
-
-### Suite options
-
-| Flag | Required | Default | Description |
-|------|----------|---------|-------------|
-| `--config <path>` | Yes | — | Path to JSON config file |
-| `--verify-tools` | No | — | Enable tool listing on all flows |
-| `--verify-call-tool <name>` | No | — | Call the named tool after listing |
-| `--format <fmt>` | No | `human` on TTY, `json` otherwise | `json`, `human`, or `junit-xml` |
-
----
-
-## CI/CD Integration
-
-### GitLab CI
-
-```yaml
-oauth-conformance:
-  stage: test
-  script:
-    - npx -y @mcpjam/cli-preview@latest oauth conformance-suite
-        --config ./oauth-tests.json
-        --format junit-xml > report.xml
-  artifacts:
-    reports:
-      junit: report.xml
-```
-
-### GitHub Actions
-
-```yaml
-- name: OAuth Conformance
-  run: |
-    npx -y @mcpjam/cli-preview@latest oauth conformance \
-      --url ${{ secrets.MCP_SERVER_URL }} \
-      --protocol-version 2025-11-25 \
-      --registration preregistered \
-      --auth-mode client_credentials \
-      --client-id ${{ secrets.M2M_CLIENT_ID }} \
-      --client-secret ${{ secrets.M2M_CLIENT_SECRET }} \
-      --verify-tools
-```
-
-### Exit codes
-
-| Code | Meaning |
-|------|---------|
-| `0` | All flows passed |
-| `1` | One or more flows failed |
-| `2` | Invalid arguments or config |
-
----
-
-## SDK Usage
-
-Use the SDK directly for programmatic testing, custom reporters, or integration into your own test framework.
-
-### Single flow
+## Import
 
 ```typescript
-import { OAuthConformanceTest } from "@mcpjam/sdk";
+import { OAuthConformanceTest, OAuthConformanceSuite } from "@mcpjam/sdk";
+```
 
+---
+
+## Single flow
+
+```typescript
 const test = new OAuthConformanceTest({
   serverUrl: "https://your-server.com/mcp",
   protocolVersion: "2025-11-25",
@@ -342,21 +41,20 @@ console.log(result.steps);    // Step-by-step results with HTTP traces
 
 | Property | Type | Required | Default | Description |
 |----------|------|----------|---------|-------------|
-| `serverUrl` | `string` | Yes | — | MCP server URL |
-| `protocolVersion` | `string` | Yes | — | `2025-03-26`, `2025-06-18`, or `2025-11-25` |
-| `registrationStrategy` | `string` | Yes | — | `cimd`, `dcr`, or `preregistered` |
+| `serverUrl` | `string` | Yes | | MCP server URL |
+| `protocolVersion` | `string` | Yes | | `2025-03-26`, `2025-06-18`, or `2025-11-25` |
+| `registrationStrategy` | `string` | Yes | | `cimd`, `dcr`, or `preregistered` |
 | `auth` | `OAuthConformanceAuthConfig` | No | `{ mode: "interactive" }` | Auth mode config |
 | `client` | `OAuthConformanceClientConfig` | No | `{}` | Client credentials config |
 | `verification` | `OAuthVerificationConfig` | No | `{}` | Post-auth verification config |
-| `scopes` | `string` | No | — | Space-separated scope string (e.g. `"read:tools write:tools"`) |
-| `customHeaders` | `Record<string, string>` | No | — | Extra HTTP headers |
+| `scopes` | `string` | No | | Space-separated scope string |
+| `customHeaders` | `Record<string, string>` | No | | Extra HTTP headers |
 | `redirectUrl` | `string` | No | Auto-generated | OAuth redirect URL |
-| `fetchFn` | `typeof fetch` | No | `fetch` | Custom fetch (useful for testing) |
+| `fetchFn` | `typeof fetch` | No | `fetch` | Custom fetch for recording/replay |
 | `stepTimeout` | `number` | No | `30000` | Per-step timeout in ms |
+| `oauthConformanceChecks` | `boolean` | No | `false` | Run 3 additional negative checks post-flow |
 
 ### OAuthConformanceAuthConfig
-
-A discriminated union on `mode`:
 
 ```typescript
 type OAuthConformanceAuthConfig =
@@ -369,31 +67,102 @@ type OAuthConformanceAuthConfig =
     };
 ```
 
-- `interactive.openUrl` — override how the consent URL is opened. Default is to launch the system browser. Useful for custom launchers or pointing an automated browser (Playwright, etc.) at the URL.
-- `client_credentials` requires both `clientId` and `clientSecret` on the auth object itself, even when `registrationStrategy` is `dcr` (in which case the values are replaced at runtime by the DCR response).
+- `interactive.openUrl` — override how the consent URL is opened. Default launches the system browser. Use for Playwright, custom launchers, or logging the URL.
 
 ### OAuthConformanceClientConfig
 
 | Property | Type | Description |
 |----------|------|-------------|
 | `preregistered.clientId` | `string` | Required when `registrationStrategy === "preregistered"` |
-| `preregistered.clientSecret` | `string` | Required for `preregistered` + `client_credentials`; optional otherwise |
-| `dynamicRegistration` | `Partial<OAuthDynamicRegistrationMetadata>` | Overrides sent during DCR (e.g. `client_name`, `logo_uri`, `scope`). SDK-only — not exposed via CLI |
-| `clientIdMetadataUrl` | `string` | CIMD metadata document URL. If omitted for `cimd` runs, the runner falls back to a default mcpjam-hosted metadata document |
+| `preregistered.clientSecret` | `string` | Required for `preregistered` + `client_credentials` |
+| `dynamicRegistration` | `Partial<OAuthDynamicRegistrationMetadata>` | Override the default DCR body (e.g. `client_name`, `logo_uri`, `scope`) |
+| `clientIdMetadataUrl` | `string` | CIMD metadata URL. Defaults to `https://www.mcpjam.com/.well-known/oauth/client-metadata.json` |
 
 ### OAuthVerificationConfig
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `listTools` | `boolean` | `false` (or `true` if `callTool` is set) | Connect to the MCP server and list tools after auth |
-| `callTool` | `{ name, params? }` | — | Also call the named tool. Implicitly enables `listTools`. |
+| `listTools` | `boolean` | `false` | Connect and call `tools/list` after auth |
+| `callTool` | `{ name, params? }` | | Also call the named tool (enables `listTools`) |
 | `timeout` | `number` | `30000` | Verification timeout in ms |
 
-### Suite
+---
+
+## SDK-only features
+
+These are available in the SDK but not exposed as CLI flags.
+
+### Custom fetch (`fetchFn`)
+
+Swap in a recording, mocking, or proxying fetch implementation:
 
 ```typescript
-import { OAuthConformanceSuite } from "@mcpjam/sdk";
+import { OAuthConformanceTest } from "@mcpjam/sdk";
 
+const requests: Request[] = [];
+
+const test = new OAuthConformanceTest({
+  serverUrl: "https://your-server.com/mcp",
+  protocolVersion: "2025-11-25",
+  registrationStrategy: "dcr",
+  fetchFn: async (url, init) => {
+    requests.push(new Request(url, init));
+    return fetch(url, init);
+  },
+});
+
+const result = await test.run();
+console.log(`Captured ${requests.length} HTTP requests`);
+```
+
+### DCR metadata overrides (`dynamicRegistration`)
+
+Customize the client metadata sent during Dynamic Client Registration:
+
+```typescript
+const test = new OAuthConformanceTest({
+  serverUrl: "https://your-server.com/mcp",
+  protocolVersion: "2025-11-25",
+  registrationStrategy: "dcr",
+  client: {
+    dynamicRegistration: {
+      client_name: "My Custom Test Client",
+      logo_uri: "https://example.com/logo.png",
+      scope: "read:tools write:tools",
+    },
+  },
+});
+```
+
+### Negative conformance checks (`oauthConformanceChecks`)
+
+When enabled, three extra checks run after a successful flow:
+
+1. **Invalid client** — sends a token request with an unknown `client_id`; expects rejection.
+2. **Invalid redirect** — sends a token request with a mismatched `redirect_uri`; expects rejection.
+3. **Token format** — validates the token response includes `access_token`, `token_type`, and expiration metadata.
+
+```typescript
+const test = new OAuthConformanceTest({
+  serverUrl: "https://your-server.com/mcp",
+  protocolVersion: "2025-11-25",
+  registrationStrategy: "dcr",
+  oauthConformanceChecks: true,
+});
+
+const result = await test.run();
+// result.steps will include oauth_invalid_client, oauth_invalid_redirect, oauth_token_format
+```
+
+<Note>
+  `oauthConformanceChecks` is also available via the CLI's `--conformance-checks` flag.
+</Note>
+
+---
+
+## Suite
+
+```typescript
 const suite = new OAuthConformanceSuite({
   name: "My Server",
   serverUrl: "https://your-server.com/mcp",
@@ -412,9 +181,13 @@ const result = await suite.run();
 console.log(result.passed);   // true
 console.log(result.summary);  // "All 2 flows passed for ..."
 for (const flow of result.results) {
-  console.log(`${flow.label}: ${flow.passed ? "PASS" : "FAIL"}`);
+  console.log(`${flow.passed ? "PASS" : "FAIL"} ${flow.label}`);
 }
 ```
+
+---
+
+## Result types
 
 ### ConformanceResult
 
@@ -433,25 +206,38 @@ for (const flow of result.results) {
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `step` | `OAuthFlowStep` | Step identifier (e.g. `"discovery"`, `"received_authorization_code"`) |
+| `step` | `string` | Step identifier (e.g. `"discovery"`, `"token_request"`, `"verify_list_tools"`) |
 | `title` | `string` | Human-readable step name |
-| `summary` | `string` | Short result summary for this step |
+| `summary` | `string` | Short result summary |
 | `status` | `"passed" \| "failed" \| "skipped"` | Step outcome |
 | `durationMs` | `number` | Step duration |
-| `logs` | `InfoLogEntry[]` | Structured log entries emitted during the step |
-| `http` | `HttpHistoryEntry` | The primary HTTP exchange for the step (if any) |
-| `httpAttempts` | `HttpHistoryEntry[]` | All HTTP request/response traces, including retries |
+| `logs` | `InfoLogEntry[]` | Structured log entries |
+| `http` | `HttpHistoryEntry` | Primary HTTP exchange (if any) |
+| `httpAttempts` | `HttpHistoryEntry[]` | All HTTP traces including retries |
 | `error` | `{ message, details? }` | Error info (if failed) |
-| `teachableMoments` | `string[]` | Educational notes for this step |
+| `teachableMoments` | `string[]` | Educational hints for this step |
+
+### VerificationResult
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `listTools.passed` | `boolean` | Whether `tools/list` succeeded |
+| `listTools.toolCount` | `number` | Number of tools returned |
+| `listTools.durationMs` | `number` | Duration |
+| `listTools.error` | `string` | Error message if failed |
+| `callTool.passed` | `boolean` | Whether the tool call succeeded |
+| `callTool.toolName` | `string` | Name of the tool called |
+| `callTool.durationMs` | `number` | Duration |
+| `callTool.error` | `string` | Error message if failed |
 
 ### OAuthConformanceSuiteResult
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `name` | `string` | Suite name from config |
+| `name` | `string` | Suite name |
 | `serverUrl` | `string` | Shared server URL |
 | `passed` | `boolean` | `true` iff every flow passed |
-| `results` | `Array<ConformanceResult & { label: string }>` | Per-flow results |
+| `results` | `Array<ConformanceResult & { label }>` | Per-flow results |
 | `summary` | `string` | Human-readable suite summary |
 | `durationMs` | `number` | Total suite duration |
 
@@ -459,5 +245,6 @@ for (const flow of result.results) {
 
 ## Related
 
-- [OAuth Debugger](/inspector/guided-oauth) — Visual OAuth debugging in the Inspector UI
-- [MCPClientManager](/sdk/reference/mcp-client-manager) — Connecting to MCP servers programmatically
+- [CLI: OAuth Conformance](/cli/oauth-conformance) — recipes, troubleshooting, CI integration
+- [CLI: OAuth Login](/cli/oauth-login) — interactive authentication and debugging
+- [MCPClientManager](/sdk/reference/mcp-client-manager) — connecting to MCP servers programmatically


### PR DESCRIPTION
# CLI docs

This pull request adds comprehensive CLI documentation for the `mcpjam` command-line tool, covering server inspection, OAuth conformance testing, authentication, and MCP resource exploration.

## New CLI documentation

- **CLI Overview** (`cli/index.mdx`) - Installation, command groups, global flags, connection methods, and quick triage workflow
- **Server Inspection** (`cli/server-inspection.mdx`) - Commands for probing, diagnosing, and exporting MCP server connectivity and capabilities (`probe`, `doctor`, `info`, `validate`, `ping`, `capabilities`, `export`)
- **OAuth Conformance** (`cli/oauth-conformance.mdx`) - Testing OAuth implementations across registration methods and protocol versions with conformance checks and suite runner
- **OAuth Login & Debugging** (`cli/oauth-login.mdx`) - Interactive authentication flows and OAuth endpoint debugging (`login`, `metadata`, `proxy`)
- **Tools, Resources & Prompts** (`cli/tools-resources-prompts.mdx`) - Commands for listing and exercising MCP server capabilities (`tools list/call`, `resources list/read/templates`, `prompts list/get`)
- **Command Reference** (`cli/reference.mdx`) - Complete flag reference for all CLI commands with exit codes

## SDK documentation updates

- **OAuth Conformance SDK** (`sdk/reference/oauth-conformance.mdx`) - Refactored to focus on programmatic usage with `OAuthConformanceTest` and `OAuthConformanceSuite` classes, removing CLI usage details now covered in dedicated CLI docs

The CLI documentation includes practical examples, troubleshooting guides, CI/CD integration patterns, and comprehensive flag references for all commands.