### PR TITLE
CLI devex improves, based on LLM findings

### DIFF
--- a/cli/src/commands/apps.ts
+++ b/cli/src/commands/apps.ts
@@ -12,6 +12,7 @@ import {
   getGlobalOptions,
   parseJsonRecord,
   parseServerConfig,
+  resolveAliasedStringOption,
 } from "../lib/server-config";
 import { usageError, writeResult } from "../lib/output";
 
@@ -24,7 +25,8 @@ export function registerAppsCommands(program: Command): void {
     apps
       .command("mcp-widget")
       .description("Fetch hosted-style MCP App widget content")
-      .requiredOption("--resource-uri <uri>", "Widget resource URI")
+      .option("--resource-uri <uri>", "Widget resource URI")
+      .option("--uri <uri>", "Alias for --resource-uri")
       .requiredOption("--tool-id <id>", "Tool call id used for runtime injection")
       .requiredOption("--tool-name <name>", "Tool name used for runtime injection")
       .option("--tool-input <json>", "Tool input payload as JSON")
@@ -43,6 +45,15 @@ export function registerAppsCommands(program: Command): void {
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
       : undefined;
+    const resourceUri = resolveAliasedStringOption(
+      options as Record<string, unknown>,
+      [
+        { key: "resourceUri", flag: "--resource-uri" },
+        { key: "uri", flag: "--uri" },
+      ],
+      "Widget resource URI",
+      { required: true },
+    ) as string;
     const config = parseServerConfig({
       ...options,
       timeout: globalOptions.timeout,
@@ -52,7 +63,7 @@ export function registerAppsCommands(program: Command): void {
       config,
       (manager, serverId) =>
         buildMcpWidgetContent(manager, serverId, {
-          resourceUri: options.resourceUri as string,
+          resourceUri,
           toolId: options.toolId as string,
           toolName: options.toolName as string,
           toolInput: parseJsonRecord(options.toolInput, "Tool input") ?? {},
@@ -76,7 +87,8 @@ export function registerAppsCommands(program: Command): void {
     apps
       .command("chatgpt-widget")
       .description("Fetch hosted-style ChatGPT App widget content")
-      .requiredOption("--uri <uri>", "Widget resource URI")
+      .option("--resource-uri <uri>", "Widget resource URI")
+      .option("--uri <uri>", "Alias for --resource-uri")
       .requiredOption("--tool-id <id>", "Tool call id used for runtime injection")
       .requiredOption("--tool-name <name>", "Tool name used for runtime injection")
       .option("--tool-input <json>", "Tool input payload as JSON")
@@ -98,6 +110,15 @@ export function registerAppsCommands(program: Command): void {
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
       : undefined;
+    const resourceUri = resolveAliasedStringOption(
+      options as Record<string, unknown>,
+      [
+        { key: "resourceUri", flag: "--resource-uri" },
+        { key: "uri", flag: "--uri" },
+      ],
+      "Widget resource URI",
+      { required: true },
+    ) as string;
     const config = parseServerConfig({
       ...options,
       timeout: globalOptions.timeout,
@@ -107,7 +128,7 @@ export function registerAppsCommands(program: Command): void {
       config,
       (manager, serverId) =>
         buildChatGptWidgetContent(manager, serverId, {
-          uri: options.uri as string,
+          uri: resourceUri,
           toolId: options.toolId as string,
           toolName: options.toolName as string,
           toolInput: parseJsonRecord(options.toolInput, "Tool input") ?? {},

--- a/cli/src/commands/conformance.ts
+++ b/cli/src/commands/conformance.ts
@@ -10,6 +10,7 @@ import {
   parsePositiveInteger,
 } from "../lib/server-config";
 import {
+  resolveOutputFormat,
   setProcessExitCode,
   usageError,
   writeResult,
@@ -73,11 +74,7 @@ export function registerProtocolCommands(program: Command): void {
 
 function getFormat(command: Command): OutputFormat {
   const opts = command.optsWithGlobals() as { format?: string };
-  const value = opts.format ?? "json";
-  if (value === "json" || value === "human") {
-    return value;
-  }
-  throw usageError(`Invalid output format "${value}". Use "json" or "human".`);
+  return resolveOutputFormat(opts.format, process.stdout.isTTY);
 }
 
 function collectInvalidEntries(

--- a/cli/src/commands/prompts.ts
+++ b/cli/src/commands/prompts.ts
@@ -9,6 +9,7 @@ import {
   getGlobalOptions,
   parsePromptArguments,
   parseServerConfig,
+  resolveAliasedStringOption,
 } from "../lib/server-config";
 import { writeResult } from "../lib/output";
 
@@ -50,7 +51,8 @@ export function registerPromptCommands(program: Command): void {
     prompts
       .command("get")
       .description("Get a named prompt from an MCP server")
-      .requiredOption("--name <prompt>", "Prompt name")
+      .option("--prompt-name <prompt>", "Prompt name")
+      .option("--name <prompt>", "Alias for --prompt-name")
       .option("--prompt-args <json>", "Prompt arguments as a JSON object"),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
@@ -58,6 +60,15 @@ export function registerPromptCommands(program: Command): void {
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
       : undefined;
+    const promptName = resolveAliasedStringOption(
+      options as Record<string, unknown>,
+      [
+        { key: "promptName", flag: "--prompt-name" },
+        { key: "name", flag: "--name" },
+      ],
+      "Prompt name",
+      { required: true },
+    ) as string;
     const config = parseServerConfig({
       ...options,
       timeout: globalOptions.timeout,
@@ -69,7 +80,7 @@ export function registerPromptCommands(program: Command): void {
       (manager, serverId) =>
         getPrompt(manager, {
           serverId,
-          name: options.name as string,
+          name: promptName,
           arguments: promptArguments,
         }),
       {

--- a/cli/src/commands/resources.ts
+++ b/cli/src/commands/resources.ts
@@ -8,6 +8,7 @@ import {
   describeTarget,
   getGlobalOptions,
   parseServerConfig,
+  resolveAliasedStringOption,
 } from "../lib/server-config";
 import { writeResult } from "../lib/output";
 
@@ -49,13 +50,23 @@ export function registerResourcesCommands(program: Command): void {
     resources
       .command("read")
       .description("Read a resource from an MCP server")
-      .requiredOption("--uri <uri>", "Resource URI"),
+      .option("--resource-uri <uri>", "Resource URI")
+      .option("--uri <uri>", "Alias for --resource-uri"),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
       : undefined;
+    const resourceUri = resolveAliasedStringOption(
+      options as Record<string, unknown>,
+      [
+        { key: "resourceUri", flag: "--resource-uri" },
+        { key: "uri", flag: "--uri" },
+      ],
+      "Resource URI",
+      { required: true },
+    ) as string;
     const config = parseServerConfig({
       ...options,
       timeout: globalOptions.timeout,
@@ -63,8 +74,7 @@ export function registerResourcesCommands(program: Command): void {
 
     const result = await withEphemeralManager(
       config,
-      (manager, serverId) =>
-        readResource(manager, { serverId, uri: options.uri as string }),
+      (manager, serverId) => readResource(manager, { serverId, uri: resourceUri }),
       {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,

--- a/cli/src/commands/tools.ts
+++ b/cli/src/commands/tools.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { isCallToolResultError } from "@mcpjam/sdk";
 import { writeCommandDebugArtifact } from "../lib/debug-artifact";
 import { withEphemeralManager } from "../lib/ephemeral";
 import { createCliRpcLogCollector } from "../lib/rpc-logs";
@@ -11,8 +12,9 @@ import {
   getGlobalOptions,
   parseJsonRecord,
   parseServerConfig,
+  resolveAliasedStringOption,
 } from "../lib/server-config";
-import { writeResult } from "../lib/output";
+import { setProcessExitCode, writeResult } from "../lib/output";
 
 export function registerToolsCommands(program: Command): void {
   const tools = program
@@ -57,8 +59,10 @@ export function registerToolsCommands(program: Command): void {
     tools
       .command("call")
       .description("Call an MCP tool")
-      .requiredOption("--name <tool>", "Tool name")
-      .option("--params <json>", "Tool parameter object as JSON")
+      .option("--tool-name <tool>", "Tool name")
+      .option("--name <tool>", "Alias for --tool-name")
+      .option("--tool-args <json>", "Tool parameter object as JSON")
+      .option("--params <json>", "Alias for --tool-args")
       .option(
         "--debug-out <path>",
         "Write a structured debug artifact to a file",
@@ -76,7 +80,24 @@ export function registerToolsCommands(program: Command): void {
       ...options,
       timeout: globalOptions.timeout,
     });
-    const params = parseJsonRecord(options.params, "Tool parameters") ?? {};
+    const toolName = resolveAliasedStringOption(
+      options as Record<string, unknown>,
+      [
+        { key: "toolName", flag: "--tool-name" },
+        { key: "name", flag: "--name" },
+      ],
+      "Tool name",
+      { required: true },
+    ) as string;
+    const paramsInput = resolveAliasedStringOption(
+      options as Record<string, unknown>,
+      [
+        { key: "toolArgs", flag: "--tool-args" },
+        { key: "params", flag: "--params" },
+      ],
+      "Tool parameters",
+    );
+    const params = parseJsonRecord(paramsInput, "Tool parameters") ?? {};
     const targetSummary = summarizeServerDoctorTarget(target, config);
 
     let result: unknown;
@@ -85,8 +106,7 @@ export function registerToolsCommands(program: Command): void {
     try {
       result = await withEphemeralManager(
         config,
-        (manager, serverId) =>
-          manager.executeTool(serverId, options.name as string, params),
+        (manager, serverId) => manager.executeTool(serverId, toolName, params),
         {
           timeout: globalOptions.timeout,
           rpcLogger: primaryCollector?.rpcLogger,
@@ -101,7 +121,7 @@ export function registerToolsCommands(program: Command): void {
       format: globalOptions.format,
       commandName: "tools call",
       commandInput: {
-        toolName: options.name as string,
+        toolName,
         params,
       },
       target: targetSummary,
@@ -135,5 +155,8 @@ export function registerToolsCommands(program: Command): void {
       withRpcLogsIfRequested(result, primaryCollector, globalOptions),
       globalOptions.format,
     );
+    if (isCallToolResultError(result)) {
+      setProcessExitCode(1);
+    }
   });
 }

--- a/cli/src/lib/output.ts
+++ b/cli/src/lib/output.ts
@@ -130,8 +130,16 @@ export function parseOutputFormat(value: string): OutputFormat {
   throw usageError(`Invalid output format "${value}". Use "json" or "human".`);
 }
 
+export function resolveOutputFormat(
+  value: string | undefined,
+  isTTY: boolean,
+): OutputFormat {
+  return parseOutputFormat(value ?? (isTTY ? "human" : "json"));
+}
+
 export function detectOutputFormatFromArgv(
   argv: readonly string[],
+  isTTY = process.stdout.isTTY,
 ): OutputFormat {
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
@@ -145,7 +153,7 @@ export function detectOutputFormatFromArgv(
     }
   }
 
-  return DEFAULT_OUTPUT_FORMAT;
+  return isTTY ? "human" : DEFAULT_OUTPUT_FORMAT;
 }
 
 function parseLooseOutputFormat(value: string | undefined): OutputFormat {

--- a/cli/src/lib/server-config.ts
+++ b/cli/src/lib/server-config.ts
@@ -1,7 +1,7 @@
 import type { MCPServerConfig } from "@mcpjam/sdk";
 import { Command } from "commander";
 import {
-  parseOutputFormat,
+  resolveOutputFormat,
   type OutputFormat,
   usageError,
 } from "./output";
@@ -77,7 +77,7 @@ export function addSharedServerOptions(command: Command): Command {
 export function getGlobalOptions(command: Command): GlobalOptions {
   const options = command.optsWithGlobals() as Partial<GlobalOptions>;
   return {
-    format: parseOutputFormat(options.format as string ?? "json"),
+    format: resolveOutputFormat(options.format as string | undefined, process.stdout.isTTY),
     timeout: options.timeout ?? 30_000,
     rpc: options.rpc ?? false,
   };
@@ -152,6 +152,49 @@ export function parsePromptArguments(
   return Object.fromEntries(
     Object.entries(raw).map(([key, entryValue]) => [key, String(entryValue)]),
   );
+}
+
+export function resolveAliasedStringOption(
+  options: Record<string, unknown>,
+  aliases: ReadonlyArray<{ key: string; flag: string }>,
+  label: string,
+  config?: { required?: boolean },
+): string | undefined {
+  const provided = aliases
+    .map((alias) => {
+      const value = options[alias.key];
+      if (typeof value !== "string") {
+        return undefined;
+      }
+
+      const normalized = value.trim();
+      if (!normalized) {
+        return undefined;
+      }
+
+      return {
+        flag: alias.flag,
+        value: normalized,
+      };
+    })
+    .filter((entry): entry is { flag: string; value: string } => entry !== undefined);
+
+  const flagsText = aliases.map((alias) => alias.flag).join(" or ");
+
+  if (provided.length === 0) {
+    if (config?.required) {
+      throw usageError(`${label} is required. Use ${flagsText}.`);
+    }
+
+    return undefined;
+  }
+
+  const values = new Set(provided.map((entry) => entry.value));
+  if (values.size > 1) {
+    throw usageError(`Specify only one of ${flagsText}.`);
+  }
+
+  return provided[0]?.value;
 }
 
 export function parseServerConfig(

--- a/cli/tests/output.test.ts
+++ b/cli/tests/output.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  detectOutputFormatFromArgv,
+  resolveOutputFormat,
+} from "../src/lib/output";
+
+test("resolveOutputFormat defaults to human on TTY and json otherwise", () => {
+  assert.equal(resolveOutputFormat(undefined, true), "human");
+  assert.equal(resolveOutputFormat(undefined, false), "json");
+  assert.equal(resolveOutputFormat("json", true), "json");
+  assert.equal(resolveOutputFormat("human", false), "human");
+});
+
+test("detectOutputFormatFromArgv respects explicit flags and TTY defaults", () => {
+  assert.equal(
+    detectOutputFormatFromArgv(["node", "cli"], true),
+    "human",
+  );
+  assert.equal(
+    detectOutputFormatFromArgv(["node", "cli"], false),
+    "json",
+  );
+  assert.equal(
+    detectOutputFormatFromArgv(["node", "cli", "--format", "human"], false),
+    "human",
+  );
+  assert.equal(
+    detectOutputFormatFromArgv(["node", "cli", "--format=json"], true),
+    "json",
+  );
+});

--- a/cli/tests/server-config.test.ts
+++ b/cli/tests/server-config.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   parseJsonRecord,
   parseServerConfig,
+  resolveAliasedStringOption,
 } from "../src/lib/server-config";
 import { CliError } from "../src/lib/output";
 
@@ -162,3 +163,77 @@ test("parseJsonRecord rejects non-object JSON", () => {
   );
 });
 
+test("resolveAliasedStringOption accepts either alias and preserves matching values", () => {
+  assert.equal(
+    resolveAliasedStringOption(
+      { toolName: "search_docs" },
+      [
+        { key: "toolName", flag: "--tool-name" },
+        { key: "name", flag: "--name" },
+      ],
+      "Tool name",
+      { required: true },
+    ),
+    "search_docs",
+  );
+
+  assert.equal(
+    resolveAliasedStringOption(
+      { name: "search_docs" },
+      [
+        { key: "toolName", flag: "--tool-name" },
+        { key: "name", flag: "--name" },
+      ],
+      "Tool name",
+      { required: true },
+    ),
+    "search_docs",
+  );
+
+  assert.equal(
+    resolveAliasedStringOption(
+      { toolName: "search_docs", name: "search_docs" },
+      [
+        { key: "toolName", flag: "--tool-name" },
+        { key: "name", flag: "--name" },
+      ],
+      "Tool name",
+      { required: true },
+    ),
+    "search_docs",
+  );
+});
+
+test("resolveAliasedStringOption rejects missing and conflicting aliases", () => {
+  assert.throws(
+    () =>
+      resolveAliasedStringOption(
+        {},
+        [
+          { key: "toolName", flag: "--tool-name" },
+          { key: "name", flag: "--name" },
+        ],
+        "Tool name",
+        { required: true },
+      ),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("Tool name is required"),
+  );
+
+  assert.throws(
+    () =>
+      resolveAliasedStringOption(
+        { toolName: "search_docs", name: "read_me" },
+        [
+          { key: "toolName", flag: "--tool-name" },
+          { key: "name", flag: "--name" },
+        ],
+        "Tool name",
+        { required: true },
+      ),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("Specify only one of --tool-name or --name"),
+  );
+});

--- a/docs/cli/oauth-conformance.mdx
+++ b/docs/cli/oauth-conformance.mdx
@@ -292,6 +292,12 @@ oauth-conformance:
 | `--conformance-checks` | No | | Run additional negative OAuth checks after the main flow |
 | `--print-url` | No | | Print consent URL to stderr instead of launching a browser |
 
+<Note>
+  For interactive conformance runs, a custom `--redirect-url` must still be an
+  `http://localhost` or `http://127.0.0.1` loopback URL. Custom callback paths
+  are supported.
+</Note>
+
 ### `oauth conformance-suite`
 
 | Flag | Required | Default | Description |

--- a/docs/cli/oauth-login.mdx
+++ b/docs/cli/oauth-login.mdx
@@ -105,6 +105,12 @@ Same as `oauth proxy` but routes through the debug proxy path. Use when testing 
 | `--verify-call-tool <name>` | No | | After listing, also call a named tool |
 | `--debug-out <path>` | No | | Write debug artifact to file |
 
+<Note>
+  For interactive login, a custom `--redirect-url` must still be an
+  `http://localhost` or `http://127.0.0.1` loopback URL. Custom callback paths
+  are supported.
+</Note>
+
 ## Using tokens from login
 
 After a successful `oauth login`, use the printed access token with other commands:

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -40,6 +40,7 @@ npx -y @mcpjam/cli@latest --help
 | [`tools`](/cli/tools-resources-prompts) | Exercise the tool surface | `list`, `call` |
 | [`resources`](/cli/tools-resources-prompts) | Read resources and templates | `list`, `read`, `templates` |
 | [`prompts`](/cli/tools-resources-prompts) | Fetch prompts | `list`, `get` |
+| [`apps`](/cli/reference) | Render hosted-style widget HTML for MCP and ChatGPT apps | `mcp-widget`, `chatgpt-widget` |
 | [`protocol`](/cli/reference) | MCP protocol conformance checks | `conformance` |
 
 ## Global flags
@@ -49,15 +50,15 @@ These flags apply to every command.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--timeout <ms>` | `30000` | Request timeout in milliseconds |
-| `--rpc` | off | Include raw JSON-RPC request/response logs in output |
-| `--format <format>` | `human` on TTY, `json` when piped | Output format (`json`, `human`, or `junit-xml` for conformance commands) |
+| `--rpc` | off | Include raw JSON-RPC request/response logs in JSON output under `_rpcLogs` |
+| `--format <format>` | `human` on TTY, `json` when piped | Output format (`json` or `human`; `junit-xml` is available on OAuth conformance commands only) |
 | `-v, --version` | | Print the CLI version |
 
 ## Output formats
 
 The CLI auto-detects whether stdout is a terminal:
 
-- **Interactive terminal** — defaults to `--format human`, a compact readable summary.
+- **Interactive terminal** — defaults to `--format human`. For most commands this is pretty-printed JSON; `server doctor` and the OAuth conformance commands provide dedicated human-readable summaries.
 - **Piped or redirected** (CI, `| jq`, agent invocation) — defaults to `--format json`, the full structured result.
 - **Explicit `--format`** always wins over the auto-detected default.
 

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -11,8 +11,8 @@ Complete flag tables for every `mcpjam` command. For guides and recipes, see the
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--timeout <ms>` | `30000` | Request timeout in milliseconds |
-| `--rpc` | off | Include raw JSON-RPC logs in output |
-| `--format <format>` | `human` on TTY, `json` when piped | Output format |
+| `--rpc` | off | Include raw JSON-RPC logs in JSON output under `_rpcLogs` |
+| `--format <format>` | `human` on TTY, `json` when piped | Output format (`json` or `human`; `junit-xml` is available on OAuth conformance commands only) |
 | `-v, --version` | | Print the CLI version |
 
 ---
@@ -80,7 +80,9 @@ Uses shared connection flags.
 | Flag | Description |
 |------|-------------|
 | `--tool-name <name>` | Name of the tool to call |
+| `--name <name>` | Legacy alias for `--tool-name` |
 | `--tool-args <json>` | Tool arguments as a JSON string |
+| `--params <json>` | Legacy alias for `--tool-args` |
 | `--debug-out <path>` | Write debug artifact to file |
 
 Plus shared connection flags.
@@ -98,6 +100,7 @@ Uses shared connection flags.
 | Flag | Description |
 |------|-------------|
 | `--resource-uri <uri>` | URI of the resource to read |
+| `--uri <uri>` | Legacy alias for `--resource-uri` |
 
 Plus shared connection flags.
 
@@ -118,6 +121,7 @@ Uses shared connection flags.
 | Flag | Description |
 |------|-------------|
 | `--prompt-name <name>` | Name of the prompt |
+| `--name <name>` | Legacy alias for `--prompt-name` |
 | `--prompt-args <json>` | Prompt arguments as a JSON string |
 
 Plus shared connection flags.
@@ -194,7 +198,16 @@ Plus shared connection flags.
 
 ### `protocol conformance`
 
-MCP protocol conformance checks against an HTTP server. Uses shared connection flags.
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--url <url>` | Yes | | MCP server URL |
+| `--access-token <token>` | No | | Bearer access token |
+| `--header <header>` | No | | HTTP header `Key: Value` (repeatable) |
+| `--check-timeout <ms>` | No | `15000` | Per-check timeout in milliseconds |
+| `--category <category>` | No | all | Restrict checks to one or more categories |
+| `--check-id <id>` | No | all | Restrict checks to one or more check IDs |
+
+Supports `--format json` and `--format human`. `junit-xml` is not supported on protocol conformance.
 
 ---
 
@@ -204,9 +217,41 @@ MCP protocol conformance checks against an HTTP server. Uses shared connection f
 
 Fetch hosted-style MCP App widget content.
 
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--resource-uri <uri>` | Yes | Widget resource URI |
+| `--uri <uri>` | No | Legacy alias for `--resource-uri` |
+| `--tool-id <id>` | Yes | Tool call ID used for runtime injection |
+| `--tool-name <name>` | Yes | Tool name used for runtime injection |
+| `--tool-input <json>` | No | Tool input payload as JSON |
+| `--tool-output <json>` | No | Tool output payload as JSON |
+| `--theme <theme>` | No | Widget theme: `light` or `dark` |
+| `--csp-mode <mode>` | No | CSP mode: `permissive` or `widget-declared` |
+| `--template <uri>` | No | Optional `ui://` template override |
+| `--view-mode <mode>` | No | Widget view mode |
+| `--view-params <json>` | No | Widget view params as JSON |
+
+Plus shared connection flags.
+
 ### `apps chatgpt-widget`
 
 Fetch hosted-style ChatGPT App widget content.
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--resource-uri <uri>` | Yes | Widget resource URI |
+| `--uri <uri>` | No | Legacy alias for `--resource-uri` |
+| `--tool-id <id>` | Yes | Tool call ID used for runtime injection |
+| `--tool-name <name>` | Yes | Tool name used for runtime injection |
+| `--tool-input <json>` | No | Tool input payload as JSON |
+| `--tool-output <json>` | No | Tool output payload as JSON |
+| `--tool-response-metadata <json>` | No | Tool response metadata as a JSON object |
+| `--theme <theme>` | No | Widget theme: `light` or `dark` |
+| `--csp-mode <mode>` | No | CSP mode: `permissive` or `widget-declared` |
+| `--locale <locale>` | No | Locale override |
+| `--device-type <type>` | No | Device type: `mobile`, `tablet`, or `desktop` |
+
+Plus shared connection flags.
 
 ---
 

--- a/mcpjam-inspector/server/utils/chat-helpers.ts
+++ b/mcpjam-inspector/server/utils/chat-helpers.ts
@@ -82,9 +82,7 @@ export const createLlmModel = (
       const resourceName = azureResourceMatch?.[1];
       return createAzure({
         apiKey,
-        ...(resourceName
-          ? { resourceName }
-          : { baseURL: azureBaseUrl }),
+        ...(resourceName ? { resourceName } : { baseURL: azureBaseUrl }),
       })(modelDefinition.id);
     }
     case "custom": {

--- a/sdk/src/oauth-conformance/auth-strategies/interactive.ts
+++ b/sdk/src/oauth-conformance/auth-strategies/interactive.ts
@@ -100,11 +100,6 @@ export async function createInteractiveAuthorizationSession(options?: {
         "Interactive OAuth conformance runs require a localhost or 127.0.0.1 redirect URL",
       );
     }
-    if (parsed.pathname !== "/callback") {
-      throw new Error(
-        "Interactive OAuth conformance runs require the callback path to be /callback",
-      );
-    }
 
     hostname = parsed.hostname;
     port = parsed.port ? Number(parsed.port) : 0;

--- a/sdk/tests/oauth-conformance/interactive.test.ts
+++ b/sdk/tests/oauth-conformance/interactive.test.ts
@@ -36,6 +36,31 @@ describe("interactive authorization session", () => {
     }
   });
 
+  it("accepts custom loopback callback paths", async () => {
+    const session = await createInteractiveAuthorizationSession({
+      redirectUrl: "http://127.0.0.1:0/oauth/custom-callback",
+    });
+
+    try {
+      expect(session.redirectUrl).toMatch(/\/oauth\/custom-callback$/);
+
+      const resultPromise = session.authorize({
+        authorizationUrl: "https://auth.example.com/authorize",
+        expectedState: "expected-state",
+        timeoutMs: 2_000,
+        openUrl: async () => {
+          await fetch(
+            `${session.redirectUrl}?code=test-code&state=expected-state`,
+          );
+        },
+      });
+
+      await expect(resultPromise).resolves.toEqual({ code: "test-code" });
+    } finally {
+      await session.stop().catch(() => undefined);
+    }
+  });
+
   it("surfaces OAuth error responses from the callback without waiting for timeout", async () => {
     const session = await createInteractiveAuthorizationSession();
 


### PR DESCRIPTION
- Added backward-compatible CLI flag aliases:
    - tools call: --tool-name / --tool-args now work, with legacy --name / --params still accepted
    - resources read: --resource-uri and --uri both work
    - prompts get: --prompt-name and --name both work
    - apps mcp-widget / apps chatgpt-widget: --resource-uri and --uri both work
- Fixed CLI behavior:
    - tools call now exits with code 1 when the tool result returns isError: true
    - Interactive OAuth now allows custom loopback callback paths instead of requiring /callback
    - Non-OAuth commands now default to human output on TTY and json when piped, matching docs
- Updated docs:
    - Clarified that --rpc adds _rpcLogs to JSON output
    - Documented protocol conformance flags: --category, --check-id, --check-timeout
    - Clarified that junit-xml is only supported on OAuth conformance commands
    - Added proper docs for the apps command group
    - Explained that most --format human output is pretty-printed JSON, with dedicated human formatters only for server doctor and OAuth conformance