### PR TITLE
make steps clickable

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
@@ -1,9 +1,15 @@
 import type { ReactNode } from "react";
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { render, screen, fireEvent, within } from "@testing-library/react";
 import type { EvalTraceSpan } from "@/shared/eval-trace";
 import { selectAxisTickPercents, TraceTimeline } from "../trace-timeline";
+
+const mockCapture = vi.fn();
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: mockCapture }),
+}));
 
 vi.mock("@/components/ui/resizable", () => ({
   ResizablePanelGroup: ({ children }: { children: ReactNode }) => (
@@ -40,6 +46,10 @@ vi.mock("@/components/ui/json-editor", () => ({
     <div data-testid="json-editor">{JSON.stringify(value)}</div>
   ),
 }));
+
+beforeEach(() => {
+  mockCapture.mockClear();
+});
 
 describe("selectAxisTickPercents", () => {
   it("uses only endpoints when unmeasured, zero, or very narrow", () => {
@@ -171,6 +181,7 @@ describe("TraceTimeline detail pane", () => {
         startMs: 0,
         endMs: 120,
         toolName: "read_me",
+        toolCallId: "tc-100",
       },
     ];
     const transcriptMessages = [
@@ -391,6 +402,7 @@ describe("TraceTimeline detail pane", () => {
         startMs: 0,
         endMs: 20,
         toolName: "read_me",
+        toolCallId: "tc-101",
       },
     ];
     render(
@@ -402,6 +414,7 @@ describe("TraceTimeline detail pane", () => {
             content: [
               {
                 type: "tool-call",
+                toolCallId: "tc-101",
                 toolName: "read_me",
                 input: { x: 1 },
               },
@@ -428,6 +441,7 @@ describe("TraceTimeline detail pane", () => {
         startMs: 0,
         endMs: 20,
         toolName: "read_me",
+        toolCallId: "tc-102",
       },
     ];
     render(
@@ -439,6 +453,7 @@ describe("TraceTimeline detail pane", () => {
             content: [
               {
                 type: "tool-call",
+                toolCallId: "tc-102",
                 toolName: "read_me",
                 input: { x: 1 },
               },
@@ -467,6 +482,7 @@ describe("TraceTimeline detail pane", () => {
         startMs: 0,
         endMs: 20,
         toolName: "read_me",
+        toolCallId: "tc-103",
       },
     ];
     render(
@@ -478,6 +494,7 @@ describe("TraceTimeline detail pane", () => {
             content: [
               {
                 type: "tool-call",
+                toolCallId: "tc-103",
                 toolName: "read_me",
                 input: { x: 1 },
               },
@@ -496,6 +513,54 @@ describe("TraceTimeline detail pane", () => {
 
     const pane = screen.getByTestId("trace-detail-pane");
     expect(within(pane).getByText("Tool · read_me")).toBeInTheDocument();
+  });
+
+  it("captures row selection only once when clicking the label button", async () => {
+    const user = userEvent.setup();
+    const spans: EvalTraceSpan[] = [
+      {
+        id: "tool-a",
+        name: "read_me",
+        category: "tool",
+        startMs: 0,
+        endMs: 20,
+        toolName: "read_me",
+        toolCallId: "tc-104",
+      },
+    ];
+    render(
+      <TraceTimeline
+        recordedSpans={spans}
+        transcriptMessages={[
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolCallId: "tc-104",
+                toolName: "read_me",
+                input: { x: 1 },
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const toolRow = screen
+      .getAllByTestId("trace-row")
+      .find((el) => el.textContent?.includes("read_me"));
+    expect(toolRow).toBeTruthy();
+
+    await user.click(within(toolRow!).getByTestId("trace-row-label-button"));
+
+    expect(mockCapture).toHaveBeenCalledTimes(1);
+    expect(mockCapture).toHaveBeenCalledWith(
+      "trace_span_clicked",
+      expect.objectContaining({
+        span_kind: "span",
+      }),
+    );
   });
 
   it("labels generic LLM spans as Agent and keeps tokens out of the inline row text", () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
@@ -162,6 +162,52 @@ describe("TraceTimeline detail pane", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("selects a row from the outer row container", () => {
+    const spans: EvalTraceSpan[] = [
+      {
+        id: "tool-a",
+        name: "read_me",
+        category: "tool",
+        startMs: 0,
+        endMs: 120,
+        toolName: "read_me",
+      },
+    ];
+    const transcriptMessages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "tc-100",
+            toolName: "read_me",
+            input: { path: "README.md" },
+          },
+        ],
+      },
+    ];
+
+    render(
+      <TraceTimeline
+        recordedSpans={spans}
+        transcriptMessages={transcriptMessages}
+      />,
+    );
+
+    const toolRow = screen
+      .getAllByTestId("trace-row")
+      .find((el) => el.textContent?.includes("read_me"));
+    expect(toolRow).toBeTruthy();
+
+    fireEvent.click(toolRow!);
+
+    const pane = screen.getByTestId("trace-detail-pane");
+    expect(within(pane).getByText("Tool · read_me")).toBeInTheDocument();
+    expect(within(pane).getByTestId("json-editor").textContent).toContain(
+      "README.md",
+    );
+  });
+
   it("hides step rows from the waterfall (only LLM/tool/error spans are shown)", () => {
     const spans = [
       {
@@ -407,6 +453,47 @@ describe("TraceTimeline detail pane", () => {
       .find((el) => el.textContent?.includes("read_me"));
     expect(toolRow).toBeTruthy();
     await user.click(within(toolRow!).getByTestId("trace-row-duration-hit"));
+    const pane = screen.getByTestId("trace-detail-pane");
+    expect(within(pane).getByText("Tool · read_me")).toBeInTheDocument();
+  });
+
+  it("selects a row from the timeline bar hit area", async () => {
+    const user = userEvent.setup();
+    const spans: EvalTraceSpan[] = [
+      {
+        id: "tool-a",
+        name: "read_me",
+        category: "tool",
+        startMs: 0,
+        endMs: 20,
+        toolName: "read_me",
+      },
+    ];
+    render(
+      <TraceTimeline
+        recordedSpans={spans}
+        transcriptMessages={[
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool-call",
+                toolName: "read_me",
+                input: { x: 1 },
+              },
+            ],
+          },
+        ]}
+      />,
+    );
+
+    const toolRow = screen
+      .getAllByTestId("trace-row")
+      .find((el) => el.textContent?.includes("read_me"));
+    expect(toolRow).toBeTruthy();
+
+    await user.click(within(toolRow!).getByTestId("trace-row-bar-hit"));
+
     const pane = screen.getByTestId("trace-detail-pane");
     expect(within(pane).getByText("Tool · read_me")).toBeInTheDocument();
   });
@@ -785,6 +872,84 @@ describe("TraceTimeline detail pane", () => {
     expect(
       within(hoverCard).getByTestId("trace-row-hover-total-tokens"),
     ).toHaveTextContent("—");
+  });
+
+  it("toggles a prompt chevron without changing another selected row", async () => {
+    const user = userEvent.setup();
+    const spans: EvalTraceSpan[] = [
+      {
+        id: "llm-1",
+        name: "Model response",
+        category: "llm",
+        startMs: 0,
+        endMs: 100,
+        promptIndex: 0,
+      },
+      {
+        id: "llm-2",
+        name: "Model response",
+        category: "llm",
+        startMs: 100,
+        endMs: 200,
+        promptIndex: 1,
+      },
+    ];
+    const transcriptMessages = [
+      { role: "user" as const, content: "first turn" },
+      { role: "assistant" as const, content: "first answer" },
+      { role: "user" as const, content: "second turn" },
+      { role: "assistant" as const, content: "second answer" },
+    ];
+
+    render(
+      <TraceTimeline
+        recordedSpans={spans}
+        transcriptMessages={transcriptMessages}
+      />,
+    );
+
+    expect(screen.getAllByTestId("trace-row")).toHaveLength(4);
+
+    const secondPrompt = screen.getAllByTestId("trace-row").find((el) =>
+      within(el).queryByRole("button", { name: "Collapse Prompt 2" }),
+    );
+    expect(secondPrompt).toBeTruthy();
+
+    await user.click(within(secondPrompt!).getByTestId("trace-row-label-button"));
+
+    const secondPromptSelected = screen.getAllByTestId("trace-row").find((el) =>
+      within(el).queryByRole("button", { name: "Collapse Prompt 2" }),
+    );
+    expect(secondPromptSelected).toBeTruthy();
+    expect(secondPromptSelected!).toHaveClass("trace-waterfall-row-selected");
+
+    const firstPrompt = screen.getAllByTestId("trace-row").find((el) =>
+      within(el).queryByRole("button", { name: "Collapse Prompt 1" }),
+    );
+    expect(firstPrompt).toBeTruthy();
+
+    await user.click(
+      within(firstPrompt!).getByRole("button", { name: "Collapse Prompt 1" }),
+    );
+
+    expect(screen.getAllByTestId("trace-row")).toHaveLength(3);
+
+    const firstPromptAfter = screen.getAllByTestId("trace-row").find((el) =>
+      within(el).queryByRole("button", { name: "Expand Prompt 1" }),
+    );
+    const secondPromptAfter = screen.getAllByTestId("trace-row").find((el) =>
+      within(el).queryByRole("button", { name: "Collapse Prompt 2" }),
+    );
+
+    expect(firstPromptAfter).toBeTruthy();
+    expect(secondPromptAfter).toBeTruthy();
+    expect(firstPromptAfter!).not.toHaveClass("trace-waterfall-row-selected");
+    expect(secondPromptAfter!).toHaveClass("trace-waterfall-row-selected");
+    expect(
+      within(firstPromptAfter!).getByRole("button", {
+        name: "Expand Prompt 1",
+      }),
+    ).toBeInTheDocument();
   });
 
   it("does NOT inherit LLM token counts onto tool row hover card", async () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-timeline.test.tsx
@@ -910,22 +910,30 @@ describe("TraceTimeline detail pane", () => {
 
     expect(screen.getAllByTestId("trace-row")).toHaveLength(4);
 
-    const secondPrompt = screen.getAllByTestId("trace-row").find((el) =>
-      within(el).queryByRole("button", { name: "Collapse Prompt 2" }),
-    );
+    const secondPrompt = screen
+      .getAllByTestId("trace-row")
+      .find((el) =>
+        within(el).queryByRole("button", { name: "Collapse Prompt 2" }),
+      );
     expect(secondPrompt).toBeTruthy();
 
-    await user.click(within(secondPrompt!).getByTestId("trace-row-label-button"));
-
-    const secondPromptSelected = screen.getAllByTestId("trace-row").find((el) =>
-      within(el).queryByRole("button", { name: "Collapse Prompt 2" }),
+    await user.click(
+      within(secondPrompt!).getByTestId("trace-row-label-button"),
     );
+
+    const secondPromptSelected = screen
+      .getAllByTestId("trace-row")
+      .find((el) =>
+        within(el).queryByRole("button", { name: "Collapse Prompt 2" }),
+      );
     expect(secondPromptSelected).toBeTruthy();
     expect(secondPromptSelected!).toHaveClass("trace-waterfall-row-selected");
 
-    const firstPrompt = screen.getAllByTestId("trace-row").find((el) =>
-      within(el).queryByRole("button", { name: "Collapse Prompt 1" }),
-    );
+    const firstPrompt = screen
+      .getAllByTestId("trace-row")
+      .find((el) =>
+        within(el).queryByRole("button", { name: "Collapse Prompt 1" }),
+      );
     expect(firstPrompt).toBeTruthy();
 
     await user.click(
@@ -934,12 +942,16 @@ describe("TraceTimeline detail pane", () => {
 
     expect(screen.getAllByTestId("trace-row")).toHaveLength(3);
 
-    const firstPromptAfter = screen.getAllByTestId("trace-row").find((el) =>
-      within(el).queryByRole("button", { name: "Expand Prompt 1" }),
-    );
-    const secondPromptAfter = screen.getAllByTestId("trace-row").find((el) =>
-      within(el).queryByRole("button", { name: "Collapse Prompt 2" }),
-    );
+    const firstPromptAfter = screen
+      .getAllByTestId("trace-row")
+      .find((el) =>
+        within(el).queryByRole("button", { name: "Expand Prompt 1" }),
+      );
+    const secondPromptAfter = screen
+      .getAllByTestId("trace-row")
+      .find((el) =>
+        within(el).queryByRole("button", { name: "Collapse Prompt 2" }),
+      );
 
     expect(firstPromptAfter).toBeTruthy();
     expect(secondPromptAfter).toBeTruthy();

--- a/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
   type KeyboardEvent,
+  type MouseEvent,
 } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { usePostHog } from "posthog-js/react";
@@ -2271,6 +2272,12 @@ export function TraceTimeline({
                       });
                       setSelectedRowKey(row.key);
                     };
+                    const selectRowFromChild = (
+                      event: MouseEvent<HTMLButtonElement>,
+                    ) => {
+                      event.stopPropagation();
+                      selectRow();
+                    };
                     const leftCellClass = isSelected
                       ? cn("bg-transparent", borderAccent)
                       : "border-l-transparent bg-background group-hover:bg-muted/20 hover:bg-muted/20";
@@ -2365,6 +2372,7 @@ export function TraceTimeline({
                                 type="button"
                                 data-testid="trace-row-label-button"
                                 className="min-w-0 flex-1 text-left"
+                                onClick={selectRowFromChild}
                               >
                                 <div className="flex min-w-0 items-center gap-2">
                                   {row.kind === "prompt" ? (
@@ -2404,6 +2412,7 @@ export function TraceTimeline({
                                 sharedCellClass,
                               )}
                               aria-label={`Select on timeline (${formatDuration(durationMs)})`}
+                              onClick={selectRowFromChild}
                             >
                               <div
                                 data-testid={
@@ -2430,6 +2439,7 @@ export function TraceTimeline({
                                 sharedCellClass,
                               )}
                               aria-label={`Select row duration (${durationLabel})`}
+                              onClick={selectRowFromChild}
                             >
                               <Clock
                                 className="size-3 shrink-0 opacity-80"

--- a/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-timeline.tsx
@@ -2284,6 +2284,7 @@ export function TraceTimeline({
                           <motion.div
                             data-testid="trace-row"
                             data-state={isSelected ? "selected" : undefined}
+                            onClick={selectRow}
                             initial={
                               shouldReduceMotion || rowIndex >= 20
                                 ? false
@@ -2306,7 +2307,7 @@ export function TraceTimeline({
                               gridTemplateColumns: "subgrid",
                             }}
                             className={cn(
-                              "group min-h-0 min-w-0 items-stretch",
+                              "group min-h-0 min-w-0 cursor-pointer items-stretch",
                               isSelected &&
                                 "trace-waterfall-row-selected ring-1 ring-inset ring-ring/40",
                             )}
@@ -2364,7 +2365,6 @@ export function TraceTimeline({
                                 type="button"
                                 data-testid="trace-row-label-button"
                                 className="min-w-0 flex-1 text-left"
-                                onClick={selectRow}
                               >
                                 <div className="flex min-w-0 items-center gap-2">
                                   {row.kind === "prompt" ? (
@@ -2404,7 +2404,6 @@ export function TraceTimeline({
                                 sharedCellClass,
                               )}
                               aria-label={`Select on timeline (${formatDuration(durationMs)})`}
-                              onClick={selectRow}
                             >
                               <div
                                 data-testid={
@@ -2431,7 +2430,6 @@ export function TraceTimeline({
                                 sharedCellClass,
                               )}
                               aria-label={`Select row duration (${durationLabel})`}
-                              onClick={selectRow}
                             >
                               <Clock
                                 className="size-3 shrink-0 opacity-80"


### PR DESCRIPTION
Makes trace timeline rows fully clickable, so you can open a step by clicking anywhere on the row instead of needing to hit just the icon, label, or bar. It also cleans up the row-button click handling and adds tests to prevent duplicate selection events.


https://github.com/user-attachments/assets/dded78a3-0537-42e6-8b6e-b632830fddef

