### PR TITLE
CLI improvements pt1

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -23,6 +23,9 @@ mcpjam server doctor --url https://your-server.com/mcp
 # OAuth login
 mcpjam oauth login --url https://your-server.com/mcp
 
+# MCP Apps conformance
+mcpjam apps conformance --url https://your-server.com/mcp
+
 # Exercise tools
 mcpjam tools list --url https://your-server.com/mcp
 ```

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcpjam/cli",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcpjam/cli",
-      "version": "2.0.0",
+      "version": "2.0.2",
       "dependencies": {
         "@mcpjam/sdk": "^0.9.2",
         "commander": "^12.1.0"

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpjam/cli",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "CLI for MCPJam SDK inspection commands and OAuth conformance",
   "main": "dist/index.js",
   "files": [

--- a/cli/src/commands/apps.ts
+++ b/cli/src/commands/apps.ts
@@ -35,6 +35,7 @@ const APPS_CHECK_IDS_BY_CATEGORY: Record<
   tools: [
     "ui-tools-present",
     "ui-tool-metadata-valid",
+    "ui-tool-input-schema-valid",
   ],
   resources: [
     "ui-listed-resources-valid",

--- a/cli/src/commands/apps.ts
+++ b/cli/src/commands/apps.ts
@@ -1,5 +1,13 @@
 import { Command } from "commander";
 import {
+  MCP_APPS_CHECK_CATEGORIES,
+  MCP_APPS_CHECK_IDS,
+  MCPAppsConformanceTest,
+  type MCPAppsCheckCategory,
+  type MCPAppsCheckId,
+  type MCPAppsConformanceConfig,
+} from "@mcpjam/sdk";
+import {
   buildChatGptWidgetContent,
   buildMcpWidgetContent,
 } from "../lib/apps";
@@ -12,13 +20,79 @@ import {
   getGlobalOptions,
   parseJsonRecord,
   parseServerConfig,
+  type SharedServerTargetOptions,
 } from "../lib/server-config";
-import { usageError, writeResult } from "../lib/output";
+import {
+  setProcessExitCode,
+  usageError,
+  writeResult,
+} from "../lib/output";
+
+const APPS_CHECK_IDS_BY_CATEGORY: Record<
+  MCPAppsCheckCategory,
+  readonly MCPAppsCheckId[]
+> = {
+  tools: [
+    "ui-tools-present",
+    "ui-tool-metadata-valid",
+  ],
+  resources: [
+    "ui-listed-resources-valid",
+    "ui-resources-readable",
+    "ui-resource-contents-valid",
+    "ui-resource-meta-valid",
+  ],
+};
+
+export interface AppsConformanceOptions extends SharedServerTargetOptions {
+  category?: string[];
+  checkId?: string[];
+}
 
 export function registerAppsCommands(program: Command): void {
   const apps = program
     .command("apps")
-    .description("Fetch MCP App and ChatGPT App widget content");
+    .description("MCP Apps utilities, widget extraction, and conformance checks");
+
+  addSharedServerOptions(
+    apps
+      .command("conformance")
+      .description("Run MCP Apps server conformance checks")
+      .option(
+        "--category <category>",
+        "Check category to run. Repeat for multiple. Default: all.",
+        (value: string, previous: string[] = []) => [...previous, value],
+        [],
+      )
+      .option(
+        "--check-id <id>",
+        "Specific check ID to run. Repeat for multiple. Default: all.",
+        (value: string, previous: string[] = []) => [...previous, value],
+        [],
+      ),
+  ).action(async (options, command) => {
+    const globalOptions = getGlobalOptions(command);
+    const target = describeTarget(options);
+    const collector = globalOptions.rpc
+      ? createCliRpcLogCollector({ __cli__: target })
+      : undefined;
+    const config: MCPAppsConformanceConfig = {
+      ...buildAppsConformanceConfig({
+        ...(options as AppsConformanceOptions),
+        timeout: globalOptions.timeout,
+      }),
+      ...(collector ? { rpcLogger: collector.rpcLogger } : {}),
+    };
+    const result = await new MCPAppsConformanceTest(config).run();
+
+    writeResult(
+      withRpcLogsIfRequested(result, collector, globalOptions),
+      globalOptions.format,
+    );
+    if (!result.passed) {
+      setProcessExitCode(1);
+    }
+  });
 
   addSharedServerOptions(
     apps
@@ -182,4 +256,58 @@ function parseDeviceType(
   throw usageError(
     `Invalid device type "${value}". Use "mobile", "tablet", or "desktop".`,
   );
+}
+
+function collectInvalidEntries(
+  values: string[] | undefined,
+  allowedValues: readonly string[],
+): string[] {
+  return (values ?? []).filter((value) => !allowedValues.includes(value));
+}
+
+export function buildAppsConformanceConfig(
+  options: AppsConformanceOptions,
+): MCPAppsConformanceConfig {
+  const serverConfig = parseServerConfig(options);
+  const categories = options.category?.filter(Boolean);
+  const invalidCategories = collectInvalidEntries(
+    categories,
+    MCP_APPS_CHECK_CATEGORIES,
+  );
+  if (invalidCategories.length > 0) {
+    throw usageError(
+      invalidCategories.length === 1
+        ? `Unknown category: ${invalidCategories[0]}`
+        : `Unknown categories: ${invalidCategories.join(", ")}`,
+    );
+  }
+
+  const checkIds = options.checkId?.filter(Boolean);
+  const invalidCheckIds = collectInvalidEntries(checkIds, MCP_APPS_CHECK_IDS);
+  if (invalidCheckIds.length > 0) {
+    throw usageError(
+      `Unknown check id${invalidCheckIds.length === 1 ? "" : "s"}: ${invalidCheckIds.join(", ")}`,
+    );
+  }
+
+  const resolvedCheckIds =
+    checkIds && checkIds.length > 0
+      ? checkIds
+      : categories && categories.length > 0
+        ? Array.from(
+            new Set(
+              categories.flatMap(
+                (category) =>
+                  APPS_CHECK_IDS_BY_CATEGORY[category as MCPAppsCheckCategory],
+              ),
+            ),
+          )
+        : undefined;
+
+  return {
+    ...serverConfig,
+    ...(resolvedCheckIds && resolvedCheckIds.length > 0
+      ? { checkIds: resolvedCheckIds as MCPAppsConformanceConfig["checkIds"] }
+      : {}),
+  };
 }

--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -154,6 +154,13 @@ export function registerOAuthCommands(program: Command): void {
       const snapshotCollector = options.debugOut
         ? createCliRpcLogCollector({ __cli__: config.serverUrl })
         : undefined;
+      const isTTY = process.stderr.isTTY;
+      if (isTTY) {
+        config.onProgress = (message: string) => {
+          process.stderr.write(`\r\x1b[K${message}`);
+        };
+      }
+
       let result: OAuthLoginResult | undefined;
       let commandError: unknown;
 
@@ -161,6 +168,10 @@ export function registerOAuthCommands(program: Command): void {
         result = await runOAuthLogin(config);
       } catch (error) {
         commandError = error;
+      } finally {
+        if (isTTY) {
+          process.stderr.write("\r\x1b[K");
+        }
       }
 
       const snapshotConfig = buildOAuthLoginSnapshotConfig(config, result);

--- a/cli/tests/apps-conformance.test.ts
+++ b/cli/tests/apps-conformance.test.ts
@@ -36,6 +36,7 @@ test("buildAppsConformanceConfig expands categories into check ids", () => {
   assert.deepEqual(config.checkIds, [
     "ui-tools-present",
     "ui-tool-metadata-valid",
+    "ui-tool-input-schema-valid",
   ]);
 });
 

--- a/cli/tests/apps-conformance.test.ts
+++ b/cli/tests/apps-conformance.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildAppsConformanceConfig } from "../src/commands/apps";
+import { CliError } from "../src/lib/output";
+
+test("buildAppsConformanceConfig rejects unknown categories and check ids", () => {
+  assert.throws(
+    () =>
+      buildAppsConformanceConfig({
+        url: "https://example.com/mcp",
+        category: ["tools", "bogus"],
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("Unknown category"),
+  );
+
+  assert.throws(
+    () =>
+      buildAppsConformanceConfig({
+        url: "https://example.com/mcp",
+        checkId: ["ui-tools-present", "bogus"],
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("Unknown check id"),
+  );
+});
+
+test("buildAppsConformanceConfig expands categories into check ids", () => {
+  const config = buildAppsConformanceConfig({
+    url: "https://example.com/mcp",
+    category: ["tools"],
+  });
+
+  assert.deepEqual(config.checkIds, [
+    "ui-tools-present",
+    "ui-tool-metadata-valid",
+  ]);
+});
+
+test("buildAppsConformanceConfig lets explicit check ids override categories", () => {
+  const config = buildAppsConformanceConfig({
+    url: "https://example.com/mcp",
+    category: ["resources"],
+    checkId: ["ui-tools-present"],
+  });
+
+  assert.deepEqual(config.checkIds, ["ui-tools-present"]);
+});

--- a/docs/cli/apps-conformance.mdx
+++ b/docs/cli/apps-conformance.mdx
@@ -1,0 +1,129 @@
+---
+title: "MCP Apps Conformance"
+description: "Validate MCP Apps tool metadata and ui:// resources from the CLI"
+icon: "app-window"
+---
+
+The `apps conformance` command validates the server-side MCP Apps surface your server exposes through tools and `ui://` resources.
+
+It is designed for MCP Apps triage, CI checks, and fast regression detection when you change `_meta.ui.resourceUri`, `resources/list`, or `resources/read`.
+
+<Note>
+  This is currently **server-side** MCP Apps conformance only. A passing run does
+  **not** prove full SEP-1865 host behavior such as `ui/initialize`,
+  `ui/notifications/tool-input` ordering, sandbox proxy behavior, or host
+  display-mode handling.
+</Note>
+
+## Quick start
+
+```bash
+mcpjam apps conformance --url https://your-server.com/mcp
+```
+
+For a local stdio server:
+
+```bash
+mcpjam apps conformance --command node --command-args server.js
+```
+
+## What it checks
+
+The current runner validates:
+
+1. MCP Apps tools are present.
+2. Tool metadata uses valid `_meta.ui.resourceUri` and `visibility` values.
+3. Listed UI resources use `ui://` URIs and `text/html;profile=mcp-app`.
+4. Referenced UI resources can be fetched with `resources/read`.
+5. Resource contents provide exactly one HTML payload via `text` or `blob`.
+6. `_meta.ui.csp`, `permissions`, `domain`, and `prefersBorder` use valid shapes.
+
+## Example output
+
+```bash
+mcpjam apps conformance \
+  --url https://your-server.com/mcp \
+  --format json
+```
+
+Typical success summary:
+
+```json
+{
+  "passed": true,
+  "summary": "6/6 checks passed, 0 failed, 0 skipped",
+  "discovery": {
+    "toolCount": 3,
+    "uiToolCount": 1,
+    "listedResourceCount": 1,
+    "listedUiResourceCount": 1,
+    "checkedUiResourceCount": 1
+  }
+}
+```
+
+## Categories and check ids
+
+Two categories are available:
+
+- `tools`
+- `resources`
+
+Specific check ids:
+
+- `ui-tools-present`
+- `ui-tool-metadata-valid`
+- `ui-listed-resources-valid`
+- `ui-resources-readable`
+- `ui-resource-contents-valid`
+- `ui-resource-meta-valid`
+
+Use `--category` to run a subset by category, or `--check-id` to run specific checks.
+
+```bash
+# Tool-only checks
+mcpjam apps conformance \
+  --url https://your-server.com/mcp \
+  --category tools
+
+# Specific checks
+mcpjam apps conformance \
+  --url https://your-server.com/mcp \
+  --check-id ui-resources-readable \
+  --check-id ui-resource-contents-valid
+```
+
+<Note>
+  If you pass both `--category` and `--check-id`, the explicit `--check-id`
+  selection wins.
+</Note>
+
+## Shared connection flags
+
+`apps conformance` uses the same shared target flags as the rest of the CLI:
+
+| Flag | Description |
+|------|-------------|
+| `--url <url>` | HTTP MCP server URL |
+| `--access-token <token>` | Bearer access token |
+| `--oauth-access-token <token>` | OAuth bearer access token |
+| `--refresh-token <token>` | OAuth refresh token |
+| `--client-id <id>` | OAuth client ID (with `--refresh-token`) |
+| `--client-secret <secret>` | OAuth client secret (with `--refresh-token`) |
+| `--header <header>` | HTTP header in `Key: Value` format (repeatable) |
+| `--client-capabilities <json>` | Client capabilities JSON object |
+| `--command <command>` | Command for a stdio server |
+| `--command-args <arg>` | Stdio command argument (repeatable) |
+| `--env <env>` | Stdio environment `KEY=VALUE` (repeatable) |
+
+## Notes
+
+- The runner always advertises the MCP Apps UI extension capability so servers do not hide their MCP Apps surface when custom client capabilities are provided.
+- Deprecated `_meta["ui/resourceUri"]` is accepted but reported as a warning.
+- `permissions` are validated against the SEP-1865 object shape, for example `geolocation: {}` instead of booleans.
+
+## Related commands
+
+- [Server inspection](/cli/server-inspection) for breadth-first connectivity and capability triage
+- [Tools, resources & prompts](/cli/tools-resources-prompts) for direct connected checks
+- [Command reference](/cli/reference) for the full flag list

--- a/docs/cli/apps-conformance.mdx
+++ b/docs/cli/apps-conformance.mdx
@@ -33,10 +33,11 @@ The current runner validates:
 
 1. MCP Apps tools are present.
 2. Tool metadata uses valid `_meta.ui.resourceUri` and `visibility` values.
-3. Listed UI resources use `ui://` URIs and `text/html;profile=mcp-app`.
-4. Referenced UI resources can be fetched with `resources/read`.
-5. Resource contents provide exactly one HTML payload via `text` or `blob`.
-6. `_meta.ui.csp`, `permissions`, `domain`, and `prefersBorder` use valid shapes.
+3. Tool `inputSchema` is a non-null JSON Schema object.
+4. Listed UI resources use `ui://` URIs and `text/html;profile=mcp-app`.
+5. Referenced UI resources can be fetched with `resources/read`.
+6. Resource contents provide exactly one HTML payload via `text` or `blob`.
+7. `_meta.ui.csp`, `permissions`, `domain`, and `prefersBorder` use valid shapes.
 
 ## Example output
 
@@ -51,7 +52,7 @@ Typical success summary:
 ```json
 {
   "passed": true,
-  "summary": "6/6 checks passed, 0 failed, 0 skipped",
+  "summary": "7/7 checks passed, 0 failed, 0 skipped",
   "discovery": {
     "toolCount": 3,
     "uiToolCount": 1,
@@ -73,6 +74,7 @@ Specific check ids:
 
 - `ui-tools-present`
 - `ui-tool-metadata-valid`
+- `ui-tool-input-schema-valid`
 - `ui-listed-resources-valid`
 - `ui-resources-readable`
 - `ui-resource-contents-valid`
@@ -120,6 +122,7 @@ mcpjam apps conformance \
 
 - The runner always advertises the MCP Apps UI extension capability so servers do not hide their MCP Apps surface when custom client capabilities are provided.
 - Deprecated `_meta["ui/resourceUri"]` is accepted but reported as a warning.
+- Tool name SHOULD validations (length, character set, uniqueness) surface as warnings, not failures.
 - `permissions` are validated against the SEP-1865 object shape, for example `geolocation: {}` instead of booleans.
 
 ## Related commands

--- a/docs/cli/oauth-conformance.mdx
+++ b/docs/cli/oauth-conformance.mdx
@@ -51,9 +51,10 @@ Each conformance run walks through:
 6. **Authenticated request** — retries the MCP request with the token
 7. **Post-auth verification** (optional) — connects via MCP and lists tools / calls a tool
 
-When `--conformance-checks` is enabled, three additional negative checks run after the flow:
+When `--conformance-checks` is enabled, four additional negative checks run after the flow:
+- **DCR redirect URI policy** — attempts dynamic client registration with a non-loopback `http://` redirect URI and expects rejection under the MCP authorization profile
 - **Invalid client** — confirms the auth server rejects an unknown client ID
-- **Invalid redirect** — confirms the auth server rejects a mismatched redirect URI
+- **Invalid redirect** — attempts a token request with a mismatched redirect URI to look for exact-match enforcement; this check may be skipped if the request is rejected for a different reason first
 - **Token format** — validates the token response has the expected fields
 
 ## Scenarios
@@ -174,7 +175,7 @@ mcpjam oauth conformance \
   --verify-tools
 ```
 
-This adds 3 checks after the main flow: invalid client rejection, invalid redirect rejection, and token format validation.
+This adds 4 checks after the main flow: DCR redirect URI policy, invalid client rejection, invalid redirect enforcement, and token format validation.
 
 ## Registration strategies
 

--- a/docs/cli/oauth-conformance.mdx
+++ b/docs/cli/oauth-conformance.mdx
@@ -51,9 +51,11 @@ Each conformance run walks through:
 6. **Authenticated request** — retries the MCP request with the token
 7. **Post-auth verification** (optional) — connects via MCP and lists tools / calls a tool
 
-When `--conformance-checks` is enabled, four additional negative checks run after the flow:
+When `--conformance-checks` is enabled, six additional negative checks run after the flow:
 - **DCR redirect URI policy** — attempts dynamic client registration with a non-loopback `http://` redirect URI and expects rejection under the MCP authorization profile
 - **Invalid client** — confirms the auth server rejects an unknown client ID
+- **Invalid redirect at the authorization endpoint** — sends an authorization request with a mismatched `redirect_uri` and looks for rejection before the server redirects back to it
+- **Invalid token** — confirms the MCP server rejects an obviously invalid bearer token with HTTP 401
 - **Invalid redirect** — attempts a token request with a mismatched redirect URI to look for exact-match enforcement; this check may be skipped if the request is rejected for a different reason first
 - **Token format** — validates the token response has the expected fields
 
@@ -148,7 +150,9 @@ mcpjam oauth conformance \
 
 <Note>
   `--scopes` sets what you **request** from the auth server. The runner does
-  not currently verify that granted scopes match requested scopes.
+  not currently verify that granted scopes match requested scopes. When
+  `--scopes` is omitted, the runner prefers the `scope=` value from the initial
+  `WWW-Authenticate` challenge and falls back to `scopes_supported`.
 </Note>
 
 ### Drive consent via Playwright or automation
@@ -175,7 +179,7 @@ mcpjam oauth conformance \
   --verify-tools
 ```
 
-This adds 4 checks after the main flow: DCR redirect URI policy, invalid client rejection, invalid redirect enforcement, and token format validation.
+This adds 6 checks after the main flow: DCR redirect URI policy, invalid client rejection, invalid redirect enforcement at the authorization endpoint, invalid bearer token rejection at the MCP server, invalid redirect enforcement at the token endpoint, and token format validation.
 
 ## Registration strategies
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -4,7 +4,7 @@ description: "Stateless MCP server probing, debugging, OAuth, and conformance fr
 icon: "terminal"
 ---
 
-The `mcpjam` CLI is a stateless tool for inspecting, debugging, and testing MCP servers from the command line or CI. It covers the full lifecycle: connectivity checks, OAuth login, tool/resource/prompt exploration, and protocol conformance.
+The `mcpjam` CLI is a stateless tool for inspecting, debugging, and testing MCP servers from the command line or CI. It covers the full lifecycle: connectivity checks, OAuth login, MCP Apps validation, tool/resource/prompt exploration, and protocol conformance.
 
 ## Recommended: Use with Agent Skills
 
@@ -37,6 +37,7 @@ npx -y @mcpjam/cli@latest --help
 |-------|---------|-------------|
 | [`server`](/cli/server-inspection) | Triage connectivity and capabilities | `probe`, `doctor`, `info`, `validate`, `ping`, `capabilities`, `export` |
 | [`oauth`](/cli/oauth-conformance) | Test OAuth flows and conformance | `conformance`, `conformance-suite`, `login`, `metadata`, `proxy` |
+| [`apps`](/cli/apps-conformance) | Validate MCP Apps tool metadata and `ui://` resources | `conformance`, `mcp-widget`, `chatgpt-widget` |
 | [`tools`](/cli/tools-resources-prompts) | Exercise the tool surface | `list`, `call` |
 | [`resources`](/cli/tools-resources-prompts) | Read resources and templates | `list`, `read`, `templates` |
 | [`prompts`](/cli/tools-resources-prompts) | Fetch prompts | `list`, `get` |
@@ -119,6 +120,9 @@ mcpjam server doctor --url https://your-server.com/mcp --oauth-access-token $TOK
 mcpjam tools list --url https://your-server.com/mcp --access-token $TOKEN
 mcpjam tools call --url https://your-server.com/mcp --access-token $TOKEN \
   --tool-name my_tool --tool-args '{"key": "value"}'
+
+# 5. If the server exposes MCP Apps, validate the ui:// surface
+mcpjam apps conformance --url https://your-server.com/mcp --access-token $TOKEN
 ```
 
 ## What's next
@@ -126,5 +130,6 @@ mcpjam tools call --url https://your-server.com/mcp --access-token $TOKEN \
 - [Server inspection](/cli/server-inspection) — probe, doctor, and diagnostics
 - [OAuth conformance](/cli/oauth-conformance) — test your OAuth implementation
 - [OAuth login](/cli/oauth-login) — authenticate and debug OAuth flows
+- [MCP Apps conformance](/cli/apps-conformance) — validate `_meta.ui.resourceUri` and `ui://` resources
 - [Tools, resources & prompts](/cli/tools-resources-prompts) — exercise the connected surface
 - [Full command reference](/cli/reference) — every flag for every command

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -162,7 +162,7 @@ Plus shared connection flags.
 | `--step-timeout <ms>` | No | `30000` | Per-step timeout |
 | `--verify-tools` | No | | After OAuth, list tools |
 | `--verify-call-tool <name>` | No | | Also call the named tool |
-| `--conformance-checks` | No | | Run additional negative OAuth checks |
+| `--conformance-checks` | No | | Run additional negative OAuth checks, including DCR redirect URI policy and redirect-mismatch probes |
 | `--print-url` | No | | Print consent URL to stderr (interactive only) |
 
 ### `oauth conformance-suite`

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -200,13 +200,64 @@ MCP protocol conformance checks against an HTTP server. Uses shared connection f
 
 ## `apps` commands
 
+### Shared connection flags
+
+| Flag | Description |
+|------|-------------|
+| `--url <url>` | HTTP MCP server URL |
+| `--access-token <token>` | Bearer access token |
+| `--oauth-access-token <token>` | OAuth bearer access token |
+| `--refresh-token <token>` | OAuth refresh token |
+| `--client-id <id>` | OAuth client ID (with `--refresh-token`) |
+| `--client-secret <secret>` | OAuth client secret (with `--refresh-token`) |
+| `--header <header>` | HTTP header `Key: Value` (repeatable) |
+| `--client-capabilities <json>` | Client capabilities JSON object |
+| `--command <command>` | Stdio server command |
+| `--command-args <arg>` | Stdio command argument (repeatable) |
+| `--env <env>` | Stdio environment `KEY=VALUE` (repeatable) |
+
+### `apps conformance`
+
+MCP Apps server-side conformance checks. Uses shared connection flags plus:
+
+| Flag | Description |
+|------|-------------|
+| `--category <category>` | Check category to run (`tools`, `resources`). Repeatable |
+| `--check-id <id>` | Specific check id to run. Repeatable |
+
 ### `apps mcp-widget`
 
 Fetch hosted-style MCP App widget content.
 
+| Flag | Description |
+|------|-------------|
+| `--resource-uri <uri>` | Widget resource URI |
+| `--tool-id <id>` | Tool call id used for runtime injection |
+| `--tool-name <name>` | Tool name used for runtime injection |
+| `--tool-input <json>` | Tool input payload as JSON |
+| `--tool-output <json>` | Tool output payload as JSON |
+| `--theme <theme>` | Widget theme: `light` or `dark` |
+| `--csp-mode <mode>` | CSP mode: `permissive` or `widget-declared` |
+| `--template <uri>` | Optional `ui://` template override |
+| `--view-mode <mode>` | Widget view mode |
+| `--view-params <json>` | Widget view params as JSON |
+
 ### `apps chatgpt-widget`
 
 Fetch hosted-style ChatGPT App widget content.
+
+| Flag | Description |
+|------|-------------|
+| `--uri <uri>` | Widget resource URI |
+| `--tool-id <id>` | Tool call id used for runtime injection |
+| `--tool-name <name>` | Tool name used for runtime injection |
+| `--tool-input <json>` | Tool input payload as JSON |
+| `--tool-output <json>` | Tool output payload as JSON |
+| `--tool-response-metadata <json>` | Tool response metadata as a JSON object |
+| `--theme <theme>` | Widget theme: `light` or `dark` |
+| `--csp-mode <mode>` | CSP mode: `permissive` or `widget-declared` |
+| `--locale <locale>` | Locale override |
+| `--device-type <type>` | Device type: `mobile`, `tablet`, or `desktop` |
 
 ---
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -46,6 +46,7 @@
           "cli/server-inspection",
           "cli/oauth-conformance",
           "cli/oauth-login",
+          "cli/apps-conformance",
           "cli/tools-resources-prompts",
           "cli/reference"
         ]
@@ -79,7 +80,8 @@
               "sdk/reference/eval-reporting",
               "sdk/reference/validators",
               "sdk/reference/llm-providers",
-              "sdk/reference/oauth-conformance"
+              "sdk/reference/oauth-conformance",
+              "sdk/reference/apps-conformance"
             ]
           }
         ]

--- a/docs/sdk/reference/apps-conformance.mdx
+++ b/docs/sdk/reference/apps-conformance.mdx
@@ -1,0 +1,127 @@
+---
+title: "MCP Apps Conformance SDK"
+description: "Programmatic MCP Apps surface validation with MCPAppsConformanceTest"
+icon: "app-window"
+---
+
+The MCP Apps Conformance SDK lets you validate the server-side MCP Apps surface your server exposes through tools and `ui://` resources.
+
+Use it when you want the same checks as the CLI's [`apps conformance`](/cli/apps-conformance) command, but inside your own test runner or CI pipeline.
+
+<Note>
+  This currently validates the **server-side** MCP Apps surface only. It does
+  not prove full host-side SEP-1865 behavior such as `ui/initialize`,
+  sandbox-proxy forwarding, or host notification ordering.
+</Note>
+
+## Import
+
+```typescript
+import { MCPAppsConformanceTest } from "@mcpjam/sdk";
+```
+
+## Basic usage
+
+```typescript
+const test = new MCPAppsConformanceTest({
+  url: "https://your-server.com/mcp",
+  timeout: 30_000,
+});
+
+const result = await test.run();
+
+console.log(result.passed);   // true
+console.log(result.summary);  // "6/6 checks passed, 0 failed, 0 skipped"
+console.log(result.discovery.uiToolCount);
+```
+
+For a stdio server:
+
+```typescript
+const test = new MCPAppsConformanceTest({
+  command: "node",
+  args: ["server.js"],
+  timeout: 30_000,
+});
+```
+
+## MCPAppsConformanceConfig
+
+`MCPAppsConformanceConfig` extends the standard `MCPServerConfig`, so it accepts the same HTTP and stdio connection settings as `MCPClientManager`.
+
+Additional property:
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `checkIds` | `MCPAppsCheckId[]` | No | all checks | Run only the selected MCP Apps checks |
+
+Example with custom headers and a focused check set:
+
+```typescript
+const test = new MCPAppsConformanceTest({
+  url: "https://your-server.com/mcp",
+  requestInit: {
+    headers: {
+      Authorization: `Bearer ${process.env.TOKEN}`,
+    },
+  },
+  checkIds: [
+    "ui-resources-readable",
+    "ui-resource-contents-valid",
+  ],
+});
+```
+
+## Check ids
+
+Available checks:
+
+- `ui-tools-present`
+- `ui-tool-metadata-valid`
+- `ui-listed-resources-valid`
+- `ui-resources-readable`
+- `ui-resource-contents-valid`
+- `ui-resource-meta-valid`
+
+## Result shape
+
+`run()` returns an `MCPAppsConformanceResult`.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `passed` | `boolean` | Whether any selected check failed |
+| `target` | `string` | URL or stdio command under test |
+| `checks` | `MCPAppsCheckResult[]` | Individual check results |
+| `summary` | `string` | Human-readable summary |
+| `durationMs` | `number` | Total duration |
+| `categorySummary` | `Record<"tools" \| "resources", ...>` | Pass/fail counts by category |
+| `discovery` | object | Counts for tools and UI resources discovered during the run |
+
+Each `MCPAppsCheckResult` includes:
+
+- `id`
+- `category`
+- `title`
+- `description`
+- `status`
+- `durationMs`
+- optional `details`
+- optional `warnings`
+- optional `error`
+
+## What the runner validates
+
+The current runner checks:
+
+1. At least one tool advertises MCP Apps UI metadata.
+2. Tool metadata uses a valid `ui://` resource URI and valid `visibility` values.
+3. Listed UI resources use `ui://` and `text/html;profile=mcp-app`.
+4. Referenced UI resources are readable via `resources/read`.
+5. Resource payloads provide exactly one HTML document through `text` or `blob`.
+6. `_meta.ui.csp`, `permissions`, `domain`, and `prefersBorder` use valid shapes.
+
+## Notes
+
+- The runner always advertises the MCP Apps UI extension capability so servers do not hide their MCP Apps surface when custom `clientCapabilities` are supplied.
+- Deprecated `_meta["ui/resourceUri"]` is accepted but surfaced as a warning.
+- HTML validation is intentionally lightweight. It verifies the expected MIME type and document-style HTML payload, not the full browser lifecycle.

--- a/docs/sdk/reference/apps-conformance.mdx
+++ b/docs/sdk/reference/apps-conformance.mdx
@@ -90,7 +90,7 @@ Available checks:
 
 | Property | Type | Description |
 |----------|------|-------------|
-| `passed` | `boolean` | Whether any selected check failed |
+| `passed` | `boolean` | Whether all selected checks passed (no failures) |
 | `target` | `string` | URL or stdio command under test |
 | `checks` | `MCPAppsCheckResult[]` | Individual check results |
 | `summary` | `string` | Human-readable summary |

--- a/docs/sdk/reference/apps-conformance.mdx
+++ b/docs/sdk/reference/apps-conformance.mdx
@@ -31,7 +31,7 @@ const test = new MCPAppsConformanceTest({
 const result = await test.run();
 
 console.log(result.passed);   // true
-console.log(result.summary);  // "6/6 checks passed, 0 failed, 0 skipped"
+console.log(result.summary);  // "7/7 checks passed, 0 failed, 0 skipped"
 console.log(result.discovery.uiToolCount);
 ```
 
@@ -78,6 +78,7 @@ Available checks:
 
 - `ui-tools-present`
 - `ui-tool-metadata-valid`
+- `ui-tool-input-schema-valid`
 - `ui-listed-resources-valid`
 - `ui-resources-readable`
 - `ui-resource-contents-valid`
@@ -115,13 +116,15 @@ The current runner checks:
 
 1. At least one tool advertises MCP Apps UI metadata.
 2. Tool metadata uses a valid `ui://` resource URI and valid `visibility` values.
-3. Listed UI resources use `ui://` and `text/html;profile=mcp-app`.
-4. Referenced UI resources are readable via `resources/read`.
-5. Resource payloads provide exactly one HTML document through `text` or `blob`.
-6. `_meta.ui.csp`, `permissions`, `domain`, and `prefersBorder` use valid shapes.
+3. Tool `inputSchema` is a non-null JSON Schema object.
+4. Listed UI resources use `ui://` and `text/html;profile=mcp-app`.
+5. Referenced UI resources are readable via `resources/read`.
+6. Resource payloads provide exactly one HTML document through `text` or `blob`.
+7. `_meta.ui.csp`, `permissions`, `domain`, and `prefersBorder` use valid shapes.
 
 ## Notes
 
 - The runner always advertises the MCP Apps UI extension capability so servers do not hide their MCP Apps surface when custom `clientCapabilities` are supplied.
 - Deprecated `_meta["ui/resourceUri"]` is accepted but surfaced as a warning.
+- Tool name SHOULD validations (length, character set, uniqueness) surface as warnings, not failures.
 - HTML validation is intentionally lightweight. It verifies the expected MIME type and document-style HTML payload, not the full browser lifecycle.

--- a/docs/sdk/reference/oauth-conformance.mdx
+++ b/docs/sdk/reference/oauth-conformance.mdx
@@ -52,7 +52,7 @@ console.log(result.steps);    // Step-by-step results with HTTP traces
 | `redirectUrl` | `string` | No | Auto-generated | OAuth redirect URL |
 | `fetchFn` | `typeof fetch` | No | `fetch` | Custom fetch for recording/replay |
 | `stepTimeout` | `number` | No | `30000` | Per-step timeout in ms |
-| `oauthConformanceChecks` | `boolean` | No | `false` | Run 4 additional negative checks post-flow |
+| `oauthConformanceChecks` | `boolean` | No | `false` | Run 6 additional negative checks post-flow |
 
 ### OAuthConformanceAuthConfig
 
@@ -136,12 +136,14 @@ const test = new OAuthConformanceTest({
 
 ### Negative conformance checks (`oauthConformanceChecks`)
 
-When enabled, four extra checks run after a successful flow:
+When enabled, six extra checks run after a successful flow:
 
 1. **DCR redirect URI policy** — attempts dynamic client registration with a non-loopback `http://` redirect URI; expects rejection under the MCP authorization profile.
 2. **Invalid client** — sends a token request with an unknown `client_id`; expects rejection.
-3. **Invalid redirect** — sends a token request with a mismatched `redirect_uri` to look for redirect exact-match enforcement. This step may be `skipped` if the request is rejected for another reason before redirect validation is demonstrated.
-4. **Token format** — validates the token response includes `access_token`, `token_type`, and expiration metadata.
+3. **Invalid redirect at the authorization endpoint** — sends an authorization request with a mismatched `redirect_uri` and looks for rejection before the server redirects back to it. This step may be `skipped` if the server defers validation behind user interaction.
+4. **Invalid token** — sends an authenticated MCP initialize request with an obviously invalid bearer token; expects HTTP 401 from the MCP server.
+5. **Invalid redirect at the token endpoint** — sends a token request with a mismatched `redirect_uri` to look for redirect exact-match enforcement. This step may be `skipped` if the request is rejected for another reason before redirect validation is demonstrated.
+6. **Token format** — validates the token response includes `access_token`, `token_type`, and expiration metadata.
 
 ```typescript
 const test = new OAuthConformanceTest({
@@ -152,7 +154,9 @@ const test = new OAuthConformanceTest({
 });
 
 const result = await test.run();
-// result.steps will include oauth_dcr_http_redirect_uri, oauth_invalid_client, oauth_invalid_redirect, oauth_token_format
+// result.steps will include oauth_dcr_http_redirect_uri, oauth_invalid_client,
+// oauth_invalid_authorize_redirect, oauth_invalid_token,
+// oauth_invalid_redirect, and oauth_token_format
 ```
 
 <Note>

--- a/docs/sdk/reference/oauth-conformance.mdx
+++ b/docs/sdk/reference/oauth-conformance.mdx
@@ -52,7 +52,7 @@ console.log(result.steps);    // Step-by-step results with HTTP traces
 | `redirectUrl` | `string` | No | Auto-generated | OAuth redirect URL |
 | `fetchFn` | `typeof fetch` | No | `fetch` | Custom fetch for recording/replay |
 | `stepTimeout` | `number` | No | `30000` | Per-step timeout in ms |
-| `oauthConformanceChecks` | `boolean` | No | `false` | Run 3 additional negative checks post-flow |
+| `oauthConformanceChecks` | `boolean` | No | `false` | Run 4 additional negative checks post-flow |
 
 ### OAuthConformanceAuthConfig
 
@@ -136,11 +136,12 @@ const test = new OAuthConformanceTest({
 
 ### Negative conformance checks (`oauthConformanceChecks`)
 
-When enabled, three extra checks run after a successful flow:
+When enabled, four extra checks run after a successful flow:
 
-1. **Invalid client** — sends a token request with an unknown `client_id`; expects rejection.
-2. **Invalid redirect** — sends a token request with a mismatched `redirect_uri`; expects rejection.
-3. **Token format** — validates the token response includes `access_token`, `token_type`, and expiration metadata.
+1. **DCR redirect URI policy** — attempts dynamic client registration with a non-loopback `http://` redirect URI; expects rejection under the MCP authorization profile.
+2. **Invalid client** — sends a token request with an unknown `client_id`; expects rejection.
+3. **Invalid redirect** — sends a token request with a mismatched `redirect_uri` to look for redirect exact-match enforcement. This step may be `skipped` if the request is rejected for another reason before redirect validation is demonstrated.
+4. **Token format** — validates the token response includes `access_token`, `token_type`, and expiration metadata.
 
 ```typescript
 const test = new OAuthConformanceTest({
@@ -151,7 +152,7 @@ const test = new OAuthConformanceTest({
 });
 
 const result = await test.run();
-// result.steps will include oauth_invalid_client, oauth_invalid_redirect, oauth_token_format
+// result.steps will include oauth_dcr_http_redirect_uri, oauth_invalid_client, oauth_invalid_redirect, oauth_token_format
 ```
 
 <Note>

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -210,6 +210,41 @@ npx @mcpjam/cli oauth conformance --url https://your-server.com/mcp --protocol-v
 npx @mcpjam/cli oauth conformance-suite --config ./oauth-tests.json --format junit-xml > report.xml
 ```
 
+### MCP Apps Conformance
+
+Validate the server-side MCP Apps surface your server exposes through tools and `ui://` resources.
+
+```ts
+import { MCPAppsConformanceTest } from "@mcpjam/sdk";
+
+const test = new MCPAppsConformanceTest({
+  url: "https://your-server.com/mcp",
+  timeout: 30_000,
+});
+
+const result = await test.run();
+console.log(result.passed);
+console.log(result.summary);
+```
+
+Or use the CLI:
+
+```bash
+# Full MCP Apps surface check
+npx @mcpjam/cli apps conformance \
+  --url https://your-server.com/mcp \
+  --format human
+
+# Focus on resource checks only
+npx @mcpjam/cli apps conformance \
+  --url https://your-server.com/mcp \
+  --category resources
+```
+
+The current runner validates tool metadata, `ui://` resource discovery, `resources/read`, HTML payload shape, and `_meta.ui` metadata such as `csp`, `permissions`, `domain`, and `prefersBorder`.
+
+It does **not** yet validate full host-side SEP-1865 behavior such as `ui/initialize`, sandbox proxy behavior, or host notification ordering.
+
 ---
 
 ## API Reference

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mcpjam/sdk",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mcpjam/sdk",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.17",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mcpjam/sdk",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "MCP server unit testing, end to end (e2e) testing, and server evals",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/sdk/src/apps-conformance/index.ts
+++ b/sdk/src/apps-conformance/index.ts
@@ -1,0 +1,16 @@
+export { MCPAppsConformanceTest } from "./runner.js";
+
+export type {
+  MCPAppsCheckCategory,
+  MCPAppsCheckId,
+  MCPAppsCheckResult,
+  MCPAppsCheckStatus,
+  MCPAppsConformanceConfig,
+  MCPAppsConformanceResult,
+  MCPAppsResourceReadOutcome,
+} from "./types.js";
+
+export {
+  MCP_APPS_CHECK_CATEGORIES,
+  MCP_APPS_CHECK_IDS,
+} from "./types.js";

--- a/sdk/src/apps-conformance/runner.ts
+++ b/sdk/src/apps-conformance/runner.ts
@@ -386,10 +386,13 @@ function buildConnectionFailureResult(
   startedAt: number,
 ): MCPAppsConformanceResult {
   const selectedCheckIds = buildCheckSelection(config);
+  const failureCheckId = selectedCheckIds.has("ui-tools-present")
+    ? "ui-tools-present"
+    : selectedCheckIds.values().next().value;
   const checks: MCPAppsCheckResult[] = [];
 
   for (const checkId of selectedCheckIds) {
-    if (checkId === "ui-tools-present") {
+    if (checkId === failureCheckId) {
       checks.push(
         failedResult(
           checkId,
@@ -847,9 +850,9 @@ export class MCPAppsConformanceTest {
                   ? outcome.result.contents
                   : [];
 
-                if (contents.length === 0) {
+                if (contents.length !== 1) {
                   violations.push(
-                    `${outcome.uri} returned no contents from resources/read`,
+                    `${outcome.uri} must return exactly one content entry from resources/read (got ${contents.length})`,
                   );
                   continue;
                 }

--- a/sdk/src/apps-conformance/runner.ts
+++ b/sdk/src/apps-conformance/runner.ts
@@ -37,6 +37,13 @@ const APPS_CHECK_METADATA: Record<
     description:
       "Tools with UI metadata use a ui:// resource URI and valid visibility values.",
   },
+  "ui-tool-input-schema-valid": {
+    id: "ui-tool-input-schema-valid",
+    category: "tools",
+    title: "UI Tool Input Schema Valid",
+    description:
+      "UI tools provide a non-null JSON Schema object as their inputSchema.",
+  },
   "ui-listed-resources-valid": {
     id: "ui-listed-resources-valid",
     category: "resources",
@@ -599,6 +606,27 @@ export class MCPAppsConformanceTest {
                     `Tool ${tool.name} uses deprecated _meta["ui/resourceUri"]; prefer _meta.ui.resourceUri`,
                   );
                 }
+
+                if (tool.name.length < 1 || tool.name.length > 128) {
+                  warnings.push(
+                    `Tool ${tool.name} name SHOULD be between 1 and 128 characters (has ${tool.name.length})`,
+                  );
+                }
+                if (!/^[A-Za-z0-9_\-.]+$/.test(tool.name)) {
+                  warnings.push(
+                    `Tool ${tool.name} name SHOULD only contain A-Z, a-z, 0-9, underscore, hyphen, or dot`,
+                  );
+                }
+              }
+
+              const seenNames = new Set<string>();
+              for (const tool of uiTools) {
+                if (seenNames.has(tool.name)) {
+                  warnings.push(
+                    `Tool name "${tool.name}" appears more than once; names SHOULD be unique within a server`,
+                  );
+                }
+                seenNames.add(tool.name);
               }
 
               if (violations.length > 0) {
@@ -625,6 +653,67 @@ export class MCPAppsConformanceTest {
                       uiToolNames: uiTools.map((tool) => tool.name),
                     },
                     warnings,
+                  ),
+                );
+              }
+            }
+          }
+
+          if (selectedCheckIds.has("ui-tool-input-schema-valid")) {
+            const stepStartedAt = Date.now();
+            if (toolsError) {
+              checks.push(
+                skippedResult(
+                  "ui-tool-input-schema-valid",
+                  "Skipping check because tools/list did not complete",
+                ),
+              );
+            } else if (uiTools.length === 0) {
+              checks.push(
+                skippedResult(
+                  "ui-tool-input-schema-valid",
+                  "Skipping check because no MCP Apps tools were discovered",
+                ),
+              );
+            } else {
+              const violations: string[] = [];
+
+              for (const tool of uiTools) {
+                const sourceTool = tools.find((entry) => entry.name === tool.name);
+                const schema = sourceTool?.inputSchema;
+
+                if (schema === undefined || schema === null) {
+                  violations.push(
+                    `Tool ${tool.name} is missing inputSchema (MUST be a JSON Schema object)`,
+                  );
+                } else if (!isPlainObject(schema)) {
+                  violations.push(
+                    `Tool ${tool.name} inputSchema MUST be a JSON Schema object, got ${Array.isArray(schema) ? "array" : typeof schema}`,
+                  );
+                }
+              }
+
+              if (violations.length > 0) {
+                checks.push(
+                  failedResult(
+                    "ui-tool-input-schema-valid",
+                    Date.now() - stepStartedAt,
+                    `${violations.length} inputSchema violation(s) found`,
+                    {
+                      violations,
+                      uiToolNames: uiTools.map((tool) => tool.name),
+                    },
+                  ),
+                );
+              } else {
+                checks.push(
+                  passedResult(
+                    "ui-tool-input-schema-valid",
+                    Date.now() - stepStartedAt,
+                    {
+                      uiToolCount: uiTools.length,
+                      uiToolNames: uiTools.map((tool) => tool.name),
+                    },
                   ),
                 );
               }

--- a/sdk/src/apps-conformance/runner.ts
+++ b/sdk/src/apps-conformance/runner.ts
@@ -1,0 +1,921 @@
+import { Buffer } from "node:buffer";
+import {
+  MCP_UI_RESOURCE_MIME_TYPE,
+  type ListToolsResult,
+  type MCPReadResourceResult,
+  type MCPResource,
+  type MCPServerConfig,
+} from "../mcp-client-manager/index.js";
+import { withEphemeralClient } from "../operations.js";
+import {
+  MCP_APPS_CHECK_IDS,
+  MCP_APPS_CHECK_CATEGORIES,
+  type MCPAppsCheckId,
+  type MCPAppsCheckResult,
+  type MCPAppsConformanceConfig,
+  type MCPAppsConformanceResult,
+  type MCPAppsResourceReadOutcome,
+  type NormalizedMCPAppsConformanceConfig,
+} from "./types.js";
+import { normalizeMCPAppsConformanceConfig } from "./validation.js";
+
+const APPS_CHECK_METADATA: Record<
+  MCPAppsCheckId,
+  Pick<MCPAppsCheckResult, "id" | "category" | "title" | "description">
+> = {
+  "ui-tools-present": {
+    id: "ui-tools-present",
+    category: "tools",
+    title: "UI Tools Present",
+    description:
+      "At least one tool advertises MCP Apps UI metadata through _meta.ui.resourceUri or the deprecated ui/resourceUri field.",
+  },
+  "ui-tool-metadata-valid": {
+    id: "ui-tool-metadata-valid",
+    category: "tools",
+    title: "UI Tool Metadata Valid",
+    description:
+      "Tools with UI metadata use a ui:// resource URI and valid visibility values.",
+  },
+  "ui-listed-resources-valid": {
+    id: "ui-listed-resources-valid",
+    category: "resources",
+    title: "Listed UI Resources Valid",
+    description:
+      "UI resources returned by resources/list use ui:// URIs and the MCP Apps HTML MIME type.",
+  },
+  "ui-resources-readable": {
+    id: "ui-resources-readable",
+    category: "resources",
+    title: "UI Resources Readable",
+    description:
+      "Every UI resource referenced by a tool or listed by the server can be fetched with resources/read.",
+  },
+  "ui-resource-contents-valid": {
+    id: "ui-resource-contents-valid",
+    category: "resources",
+    title: "UI Resource Contents Valid",
+    description:
+      "UI resource contents use the MCP Apps HTML MIME type and provide exactly one HTML payload via text or blob.",
+  },
+  "ui-resource-meta-valid": {
+    id: "ui-resource-meta-valid",
+    category: "resources",
+    title: "UI Resource Metadata Valid",
+    description:
+      "UI resource metadata uses valid csp, permissions, domain, and prefersBorder shapes.",
+  },
+};
+
+type UIToolReference = {
+  name: string;
+  resourceUri: string;
+  visibility?: unknown;
+  usesLegacyField: boolean;
+  hasNestedField: boolean;
+  hasLegacyField: boolean;
+};
+
+type MCPListedTool = NonNullable<ListToolsResult["tools"]>[number];
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function passedResult(
+  id: MCPAppsCheckId,
+  durationMs: number,
+  details?: Record<string, unknown>,
+  warnings?: string[],
+): MCPAppsCheckResult {
+  return {
+    ...APPS_CHECK_METADATA[id],
+    status: "passed",
+    durationMs,
+    ...(details ? { details } : {}),
+    ...(warnings && warnings.length > 0 ? { warnings } : {}),
+  };
+}
+
+function failedResult(
+  id: MCPAppsCheckId,
+  durationMs: number,
+  message: string,
+  details?: Record<string, unknown>,
+  rawError?: unknown,
+  warnings?: string[],
+): MCPAppsCheckResult {
+  return {
+    ...APPS_CHECK_METADATA[id],
+    status: "failed",
+    durationMs,
+    error: {
+      message,
+      ...(rawError === undefined ? {} : { details: rawError }),
+    },
+    ...(details ? { details } : {}),
+    ...(warnings && warnings.length > 0 ? { warnings } : {}),
+  };
+}
+
+function skippedResult(
+  id: MCPAppsCheckId,
+  message: string,
+  details?: Record<string, unknown>,
+): MCPAppsCheckResult {
+  return {
+    ...APPS_CHECK_METADATA[id],
+    status: "skipped",
+    durationMs: 0,
+    error: { message },
+    ...(details ? { details } : {}),
+  };
+}
+
+function buildCheckSelection(
+  config: NormalizedMCPAppsConformanceConfig,
+): Set<MCPAppsCheckId> {
+  return new Set(config.checkIds ?? MCP_APPS_CHECK_IDS);
+}
+
+function summarizeChecks(checks: MCPAppsCheckResult[]) {
+  return Object.fromEntries(
+    MCP_APPS_CHECK_CATEGORIES.map((category) => {
+      const categoryChecks = checks.filter((check) => check.category === category);
+      return [
+        category,
+        {
+          total: categoryChecks.length,
+          passed: categoryChecks.filter((check) => check.status === "passed").length,
+          failed: categoryChecks.filter((check) => check.status === "failed").length,
+          skipped: categoryChecks.filter((check) => check.status === "skipped").length,
+        },
+      ];
+    }),
+  ) as MCPAppsConformanceResult["categorySummary"];
+}
+
+function buildSummary(checks: MCPAppsCheckResult[]): string {
+  const passed = checks.filter((check) => check.status === "passed").length;
+  const failed = checks.filter((check) => check.status === "failed").length;
+  const skipped = checks.filter((check) => check.status === "skipped").length;
+  return `${passed}/${checks.length} checks passed, ${failed} failed, ${skipped} skipped`;
+}
+
+function extractUiToolReference(tool: MCPListedTool): UIToolReference | undefined {
+  const toolMeta = isPlainObject(tool._meta) ? tool._meta : undefined;
+  const nested = isPlainObject(toolMeta?.ui) ? toolMeta.ui : undefined;
+  const nestedResourceUri =
+    typeof nested?.resourceUri === "string" ? nested.resourceUri : undefined;
+  const legacyResourceUri =
+    typeof toolMeta?.["ui/resourceUri"] === "string"
+      ? (toolMeta["ui/resourceUri"] as string)
+      : undefined;
+
+  if (!nestedResourceUri && !legacyResourceUri) {
+    return undefined;
+  }
+
+  return {
+    name: tool.name,
+    resourceUri: nestedResourceUri ?? legacyResourceUri!,
+    visibility: nested?.visibility,
+    usesLegacyField: !nestedResourceUri && !!legacyResourceUri,
+    hasNestedField: !!nestedResourceUri,
+    hasLegacyField: !!legacyResourceUri,
+  };
+}
+
+function getListedUiResources(resources: MCPResource[]): MCPResource[] {
+  return resources.filter((resource) => {
+    const uri = typeof resource.uri === "string" ? resource.uri : "";
+    return (
+      uri.startsWith("ui://") || resource.mimeType === MCP_UI_RESOURCE_MIME_TYPE
+    );
+  });
+}
+
+function decodeHtmlPayload(content: Record<string, unknown>): {
+  hasText: boolean;
+  hasBlob: boolean;
+  html: string;
+} {
+  const text = typeof content.text === "string" ? content.text : undefined;
+  const blob = typeof content.blob === "string" ? content.blob : undefined;
+
+  if (text !== undefined) {
+    return {
+      hasText: true,
+      hasBlob: false,
+      html: text,
+    };
+  }
+
+  if (blob !== undefined) {
+    return {
+      hasText: false,
+      hasBlob: true,
+      html: Buffer.from(blob, "base64").toString("utf8"),
+    };
+  }
+
+  return {
+    hasText: false,
+    hasBlob: false,
+    html: "",
+  };
+}
+
+function looksLikeHtmlDocument(html: string): boolean {
+  const normalized = html.trim().toLowerCase();
+  return (
+    normalized.startsWith("<!doctype html") ||
+    normalized.includes("<html")
+  );
+}
+
+function validateUiMeta(
+  meta: unknown,
+  uri: string,
+  contentIndex: number,
+): string[] {
+  if (meta === undefined) {
+    return [];
+  }
+
+  if (!isPlainObject(meta)) {
+    return [`${uri} contents[${contentIndex}] _meta must be an object`];
+  }
+
+  const ui = meta.ui;
+  if (ui === undefined) {
+    return [];
+  }
+
+  if (!isPlainObject(ui)) {
+    return [`${uri} contents[${contentIndex}] _meta.ui must be an object`];
+  }
+
+  const violations: string[] = [];
+  const csp = ui.csp;
+  if (csp !== undefined) {
+    if (!isPlainObject(csp)) {
+      violations.push(`${uri} contents[${contentIndex}] _meta.ui.csp must be an object`);
+    } else {
+      for (const key of [
+        "connectDomains",
+        "resourceDomains",
+        "frameDomains",
+        "baseUriDomains",
+      ] as const) {
+        const value = csp[key];
+        if (
+          value !== undefined &&
+          (!Array.isArray(value) ||
+            value.some((entry) => typeof entry !== "string" || entry.trim().length === 0))
+        ) {
+          violations.push(
+            `${uri} contents[${contentIndex}] _meta.ui.csp.${key} must be an array of non-empty strings`,
+          );
+        }
+      }
+    }
+  }
+
+  const permissions = ui.permissions;
+  if (permissions !== undefined) {
+    if (!isPlainObject(permissions)) {
+      violations.push(
+        `${uri} contents[${contentIndex}] _meta.ui.permissions must be an object`,
+      );
+    } else {
+      const allowedPermissions = new Set([
+        "camera",
+        "microphone",
+        "geolocation",
+        "clipboardWrite",
+      ]);
+      for (const [key, value] of Object.entries(permissions)) {
+        if (!allowedPermissions.has(key)) {
+          violations.push(
+            `${uri} contents[${contentIndex}] _meta.ui.permissions.${key} is not a recognized permission`,
+          );
+          continue;
+        }
+        if (!isPlainObject(value)) {
+          violations.push(
+            `${uri} contents[${contentIndex}] _meta.ui.permissions.${key} must be an object`,
+          );
+        }
+      }
+    }
+  }
+
+  if (ui.domain !== undefined) {
+    if (typeof ui.domain !== "string" || ui.domain.trim().length === 0) {
+      violations.push(
+        `${uri} contents[${contentIndex}] _meta.ui.domain must be a non-empty string`,
+      );
+    }
+  }
+
+  if (
+    ui.prefersBorder !== undefined &&
+    typeof ui.prefersBorder !== "boolean"
+  ) {
+    violations.push(
+      `${uri} contents[${contentIndex}] _meta.ui.prefersBorder must be a boolean`,
+    );
+  }
+
+  return violations;
+}
+
+async function readUiResources(
+  manager: {
+    readResource: (
+      serverId: string,
+      params: { uri: string },
+    ) => Promise<MCPReadResourceResult>;
+  },
+  serverId: string,
+  resourceUris: string[],
+  uiTools: UIToolReference[],
+  listedUiResourceUris: Set<string>,
+): Promise<MCPAppsResourceReadOutcome[]> {
+  return Promise.all(
+    resourceUris.map(async (uri) => {
+      try {
+        const result = await manager.readResource(serverId, { uri });
+        return {
+          uri,
+          referencedByTools: uiTools
+            .filter((tool) => tool.resourceUri === uri)
+            .map((tool) => tool.name),
+          listed: listedUiResourceUris.has(uri),
+          result,
+        };
+      } catch (error) {
+        return {
+          uri,
+          referencedByTools: uiTools
+            .filter((tool) => tool.resourceUri === uri)
+            .map((tool) => tool.name),
+          listed: listedUiResourceUris.has(uri),
+          error,
+        };
+      }
+    }),
+  );
+}
+
+function buildConnectionFailureResult(
+  config: NormalizedMCPAppsConformanceConfig,
+  error: unknown,
+  startedAt: number,
+): MCPAppsConformanceResult {
+  const selectedCheckIds = buildCheckSelection(config);
+  const checks: MCPAppsCheckResult[] = [];
+
+  for (const checkId of selectedCheckIds) {
+    if (checkId === "ui-tools-present") {
+      checks.push(
+        failedResult(
+          checkId,
+          Date.now() - startedAt,
+          errorMessage(error),
+          undefined,
+          error,
+        ),
+      );
+    } else {
+      checks.push(
+        skippedResult(
+          checkId,
+          "Skipping check because the MCP server could not be connected",
+        ),
+      );
+    }
+  }
+
+  return {
+    passed: false,
+    target: config.target,
+    checks,
+    summary: buildSummary(checks),
+    durationMs: Date.now() - startedAt,
+    categorySummary: summarizeChecks(checks),
+    discovery: {
+      toolCount: 0,
+      uiToolCount: 0,
+      listedResourceCount: 0,
+      listedUiResourceCount: 0,
+      checkedUiResourceCount: 0,
+    },
+  };
+}
+
+export class MCPAppsConformanceTest {
+  private readonly config: NormalizedMCPAppsConformanceConfig;
+
+  constructor(config: MCPAppsConformanceConfig) {
+    this.config = normalizeMCPAppsConformanceConfig(config);
+  }
+
+  async run(): Promise<MCPAppsConformanceResult> {
+    const startedAt = Date.now();
+    const selectedCheckIds = buildCheckSelection(this.config);
+
+    try {
+      return await withEphemeralClient(
+        this.config.serverConfig as MCPServerConfig,
+        async (manager, serverId) => {
+          const checks: MCPAppsCheckResult[] = [];
+          let tools: MCPListedTool[] = [];
+          let resources: MCPResource[] = [];
+          let toolsError: unknown;
+          let resourcesError: unknown;
+
+          try {
+            const result = await manager.listTools(serverId);
+            tools = result.tools ?? [];
+          } catch (error) {
+            toolsError = error;
+          }
+
+          try {
+            const result = await manager.listResources(serverId);
+            resources = result.resources ?? [];
+          } catch (error) {
+            resourcesError = error;
+          }
+
+          const uiTools = tools
+            .map((tool) => extractUiToolReference(tool))
+            .filter((tool): tool is UIToolReference => tool !== undefined);
+          const listedUiResources = getListedUiResources(resources);
+          const listedUiResourceUris = new Set(
+            listedUiResources
+              .map((resource) => resource.uri)
+              .filter((uri): uri is string => typeof uri === "string"),
+          );
+          const resourceUrisToRead = Array.from(
+            new Set([
+              ...uiTools.map((tool) => tool.resourceUri),
+              ...listedUiResourceUris,
+            ]),
+          );
+
+          let readOutcomes: MCPAppsResourceReadOutcome[] = [];
+          if (
+            (selectedCheckIds.has("ui-resources-readable") ||
+              selectedCheckIds.has("ui-resource-contents-valid") ||
+              selectedCheckIds.has("ui-resource-meta-valid")) &&
+            resourceUrisToRead.length > 0
+          ) {
+            readOutcomes = await readUiResources(
+              manager,
+              serverId,
+              resourceUrisToRead,
+              uiTools,
+              listedUiResourceUris,
+            );
+          }
+
+          if (selectedCheckIds.has("ui-tools-present")) {
+            const stepStartedAt = Date.now();
+            if (toolsError) {
+              checks.push(
+                failedResult(
+                  "ui-tools-present",
+                  Date.now() - stepStartedAt,
+                  `tools/list failed: ${errorMessage(toolsError)}`,
+                  undefined,
+                  toolsError,
+                ),
+              );
+            } else if (uiTools.length === 0) {
+              checks.push(
+                failedResult(
+                  "ui-tools-present",
+                  Date.now() - stepStartedAt,
+                  "No tools advertise MCP Apps UI resources",
+                  {
+                    toolCount: tools.length,
+                    listedUiResourceCount: listedUiResources.length,
+                  },
+                ),
+              );
+            } else {
+              checks.push(
+                passedResult("ui-tools-present", Date.now() - stepStartedAt, {
+                  toolCount: tools.length,
+                  uiToolCount: uiTools.length,
+                  uiToolNames: uiTools.map((tool) => tool.name),
+                  resourceUris: uiTools.map((tool) => tool.resourceUri),
+                }),
+              );
+            }
+          }
+
+          if (selectedCheckIds.has("ui-tool-metadata-valid")) {
+            const stepStartedAt = Date.now();
+            if (toolsError) {
+              checks.push(
+                skippedResult(
+                  "ui-tool-metadata-valid",
+                  "Skipping check because tools/list did not complete",
+                ),
+              );
+            } else if (uiTools.length === 0) {
+              checks.push(
+                skippedResult(
+                  "ui-tool-metadata-valid",
+                  "Skipping check because no MCP Apps tools were discovered",
+                ),
+              );
+            } else {
+              const violations: string[] = [];
+              const warnings: string[] = [];
+
+              for (const tool of uiTools) {
+                const sourceTool = tools.find((entry) => entry.name === tool.name);
+                const toolMeta = isPlainObject(sourceTool?._meta)
+                  ? sourceTool._meta
+                  : undefined;
+                const nested = isPlainObject(toolMeta?.ui) ? toolMeta.ui : undefined;
+                const nestedResourceUri =
+                  typeof nested?.resourceUri === "string"
+                    ? nested.resourceUri
+                    : undefined;
+                const legacyResourceUri =
+                  typeof toolMeta?.["ui/resourceUri"] === "string"
+                    ? (toolMeta["ui/resourceUri"] as string)
+                    : undefined;
+
+                if (
+                  nestedResourceUri &&
+                  legacyResourceUri &&
+                  nestedResourceUri !== legacyResourceUri
+                ) {
+                  violations.push(
+                    `Tool ${tool.name} defines conflicting ui.resourceUri and ui/resourceUri values`,
+                  );
+                }
+
+                if (!tool.resourceUri.startsWith("ui://")) {
+                  violations.push(
+                    `Tool ${tool.name} references "${tool.resourceUri}", which must use the ui:// scheme`,
+                  );
+                }
+
+                if (nested?.visibility !== undefined) {
+                  if (!Array.isArray(nested.visibility)) {
+                    violations.push(
+                      `Tool ${tool.name} _meta.ui.visibility must be an array`,
+                    );
+                  } else if (nested.visibility.length === 0) {
+                    violations.push(
+                      `Tool ${tool.name} _meta.ui.visibility must not be empty`,
+                    );
+                  } else {
+                    const invalidValues = nested.visibility.filter(
+                      (value) => value !== "model" && value !== "app",
+                    );
+                    if (invalidValues.length > 0) {
+                      violations.push(
+                        `Tool ${tool.name} uses unsupported visibility values: ${invalidValues.join(", ")}`,
+                      );
+                    }
+                  }
+                }
+
+                if (tool.usesLegacyField) {
+                  warnings.push(
+                    `Tool ${tool.name} uses deprecated _meta["ui/resourceUri"]; prefer _meta.ui.resourceUri`,
+                  );
+                }
+              }
+
+              if (violations.length > 0) {
+                checks.push(
+                  failedResult(
+                    "ui-tool-metadata-valid",
+                    Date.now() - stepStartedAt,
+                    `${violations.length} tool metadata violation(s) found`,
+                    {
+                      violations,
+                      uiToolNames: uiTools.map((tool) => tool.name),
+                    },
+                    undefined,
+                    warnings,
+                  ),
+                );
+              } else {
+                checks.push(
+                  passedResult(
+                    "ui-tool-metadata-valid",
+                    Date.now() - stepStartedAt,
+                    {
+                      uiToolCount: uiTools.length,
+                      uiToolNames: uiTools.map((tool) => tool.name),
+                    },
+                    warnings,
+                  ),
+                );
+              }
+            }
+          }
+
+          if (selectedCheckIds.has("ui-listed-resources-valid")) {
+            const stepStartedAt = Date.now();
+            if (resourcesError) {
+              checks.push(
+                failedResult(
+                  "ui-listed-resources-valid",
+                  Date.now() - stepStartedAt,
+                  `resources/list failed: ${errorMessage(resourcesError)}`,
+                  undefined,
+                  resourcesError,
+                ),
+              );
+            } else if (listedUiResources.length === 0) {
+              checks.push(
+                skippedResult(
+                  "ui-listed-resources-valid",
+                  "Skipping check because resources/list did not expose any UI resources",
+                ),
+              );
+            } else {
+              const violations: string[] = [];
+
+              for (const resource of listedUiResources) {
+                if (!resource.uri.startsWith("ui://")) {
+                  violations.push(
+                    `Listed resource ${resource.name} uses "${resource.uri}" but UI resources must use the ui:// scheme`,
+                  );
+                }
+                if (resource.mimeType !== MCP_UI_RESOURCE_MIME_TYPE) {
+                  violations.push(
+                    `Listed UI resource ${resource.uri} uses mimeType "${resource.mimeType ?? "<missing>"}" instead of "${MCP_UI_RESOURCE_MIME_TYPE}"`,
+                  );
+                }
+              }
+
+              if (violations.length > 0) {
+                checks.push(
+                  failedResult(
+                    "ui-listed-resources-valid",
+                    Date.now() - stepStartedAt,
+                    `${violations.length} listed UI resource violation(s) found`,
+                    {
+                      violations,
+                      listedUiResourceUris: listedUiResources.map(
+                        (resource) => resource.uri,
+                      ),
+                    },
+                  ),
+                );
+              } else {
+                checks.push(
+                  passedResult(
+                    "ui-listed-resources-valid",
+                    Date.now() - stepStartedAt,
+                    {
+                      listedUiResourceCount: listedUiResources.length,
+                      listedUiResourceUris: listedUiResources.map(
+                        (resource) => resource.uri,
+                      ),
+                    },
+                  ),
+                );
+              }
+            }
+          }
+
+          if (selectedCheckIds.has("ui-resources-readable")) {
+            const stepStartedAt = Date.now();
+            if (resourceUrisToRead.length === 0) {
+              checks.push(
+                skippedResult(
+                  "ui-resources-readable",
+                  "Skipping check because no UI resources were discovered",
+                ),
+              );
+            } else {
+              const failures = readOutcomes.filter((outcome) => outcome.error);
+              if (failures.length > 0) {
+                checks.push(
+                  failedResult(
+                    "ui-resources-readable",
+                    Date.now() - stepStartedAt,
+                    `${failures.length} UI resource read(s) failed`,
+                    {
+                      failures: failures.map((outcome) => ({
+                        uri: outcome.uri,
+                        referencedByTools: outcome.referencedByTools,
+                        listed: outcome.listed,
+                        error: errorMessage(outcome.error),
+                      })),
+                    },
+                  ),
+                );
+              } else {
+                checks.push(
+                  passedResult("ui-resources-readable", Date.now() - stepStartedAt, {
+                    checkedUiResourceCount: readOutcomes.length,
+                    resourceUris: readOutcomes.map((outcome) => outcome.uri),
+                  }),
+                );
+              }
+            }
+          }
+
+          if (selectedCheckIds.has("ui-resource-contents-valid")) {
+            const stepStartedAt = Date.now();
+            const successfulReads = readOutcomes.filter(
+              (outcome): outcome is MCPAppsResourceReadOutcome & {
+                result: MCPReadResourceResult;
+              } => outcome.result !== undefined,
+            );
+
+            if (successfulReads.length === 0) {
+              checks.push(
+                skippedResult(
+                  "ui-resource-contents-valid",
+                  "Skipping check because no UI resources were read successfully",
+                ),
+              );
+            } else {
+              const violations: string[] = [];
+
+              for (const outcome of successfulReads) {
+                const contents = Array.isArray(outcome.result.contents)
+                  ? outcome.result.contents
+                  : [];
+
+                if (contents.length === 0) {
+                  violations.push(
+                    `${outcome.uri} returned no contents from resources/read`,
+                  );
+                  continue;
+                }
+
+                contents.forEach((content, index) => {
+                  if (!isPlainObject(content)) {
+                    violations.push(
+                      `${outcome.uri} contents[${index}] must be an object`,
+                    );
+                    return;
+                  }
+
+                  if (content.uri !== outcome.uri) {
+                    violations.push(
+                      `${outcome.uri} contents[${index}] returned uri "${String(content.uri)}" instead of "${outcome.uri}"`,
+                    );
+                  }
+
+                  if (content.mimeType !== MCP_UI_RESOURCE_MIME_TYPE) {
+                    violations.push(
+                      `${outcome.uri} contents[${index}] returned mimeType "${String(content.mimeType ?? "<missing>")}" instead of "${MCP_UI_RESOURCE_MIME_TYPE}"`,
+                    );
+                  }
+
+                  const hasText =
+                    "text" in content && typeof content.text === "string";
+                  const hasBlob =
+                    "blob" in content && typeof content.blob === "string";
+                  if (hasText === hasBlob) {
+                    violations.push(
+                      `${outcome.uri} contents[${index}] must provide exactly one of text or blob`,
+                    );
+                    return;
+                  }
+
+                  try {
+                    const payload = decodeHtmlPayload(content);
+                    if (payload.html.trim().length === 0) {
+                      violations.push(
+                        `${outcome.uri} contents[${index}] HTML payload must not be empty`,
+                      );
+                    } else if (!looksLikeHtmlDocument(payload.html)) {
+                      violations.push(
+                        `${outcome.uri} contents[${index}] must contain an HTML document`,
+                      );
+                    }
+                  } catch (error) {
+                    violations.push(
+                      `${outcome.uri} contents[${index}] blob could not be decoded as UTF-8 HTML: ${errorMessage(error)}`,
+                    );
+                  }
+                });
+              }
+
+              if (violations.length > 0) {
+                checks.push(
+                  failedResult(
+                    "ui-resource-contents-valid",
+                    Date.now() - stepStartedAt,
+                    `${violations.length} UI resource content violation(s) found`,
+                    { violations },
+                  ),
+                );
+              } else {
+                checks.push(
+                  passedResult(
+                    "ui-resource-contents-valid",
+                    Date.now() - stepStartedAt,
+                    {
+                      checkedUiResourceCount: successfulReads.length,
+                      resourceUris: successfulReads.map((outcome) => outcome.uri),
+                    },
+                  ),
+                );
+              }
+            }
+          }
+
+          if (selectedCheckIds.has("ui-resource-meta-valid")) {
+            const stepStartedAt = Date.now();
+            const successfulReads = readOutcomes.filter(
+              (outcome): outcome is MCPAppsResourceReadOutcome & {
+                result: MCPReadResourceResult;
+              } => outcome.result !== undefined,
+            );
+
+            if (successfulReads.length === 0) {
+              checks.push(
+                skippedResult(
+                  "ui-resource-meta-valid",
+                  "Skipping check because no UI resources were read successfully",
+                ),
+              );
+            } else {
+              const violations: string[] = [];
+
+              for (const outcome of successfulReads) {
+                const contents = Array.isArray(outcome.result.contents)
+                  ? outcome.result.contents
+                  : [];
+                contents.forEach((content, index) => {
+                  if (!isPlainObject(content)) {
+                    return;
+                  }
+                  violations.push(
+                    ...validateUiMeta(content._meta, outcome.uri, index),
+                  );
+                });
+              }
+
+              if (violations.length > 0) {
+                checks.push(
+                  failedResult(
+                    "ui-resource-meta-valid",
+                    Date.now() - stepStartedAt,
+                    `${violations.length} UI resource metadata violation(s) found`,
+                    { violations },
+                  ),
+                );
+              } else {
+                checks.push(
+                  passedResult("ui-resource-meta-valid", Date.now() - stepStartedAt, {
+                    checkedUiResourceCount: successfulReads.length,
+                    resourceUris: successfulReads.map((outcome) => outcome.uri),
+                  }),
+                );
+              }
+            }
+          }
+
+          return {
+            passed: checks.every((check) => check.status !== "failed"),
+            target: this.config.target,
+            checks,
+            summary: buildSummary(checks),
+            durationMs: Date.now() - startedAt,
+            categorySummary: summarizeChecks(checks),
+            discovery: {
+              toolCount: tools.length,
+              uiToolCount: uiTools.length,
+              listedResourceCount: resources.length,
+              listedUiResourceCount: listedUiResources.length,
+              checkedUiResourceCount: resourceUrisToRead.length,
+            },
+          };
+        },
+        {
+          serverId: "__apps_conformance__",
+          clientName: "mcpjam-sdk-apps-conformance",
+          timeout: this.config.timeout,
+          rpcLogger: this.config.serverConfig.rpcLogger,
+        },
+      );
+    } catch (error) {
+      return buildConnectionFailureResult(this.config, error, startedAt);
+    }
+  }
+}

--- a/sdk/src/apps-conformance/types.ts
+++ b/sdk/src/apps-conformance/types.ts
@@ -1,0 +1,79 @@
+import type {
+  MCPReadResourceResult,
+  MCPServerConfig,
+} from "../mcp-client-manager/index.js";
+
+export const MCP_APPS_CHECK_CATEGORIES = ["tools", "resources"] as const;
+
+export type MCPAppsCheckCategory = (typeof MCP_APPS_CHECK_CATEGORIES)[number];
+
+export const MCP_APPS_CHECK_IDS = [
+  "ui-tools-present",
+  "ui-tool-metadata-valid",
+  "ui-listed-resources-valid",
+  "ui-resources-readable",
+  "ui-resource-contents-valid",
+  "ui-resource-meta-valid",
+] as const;
+
+export type MCPAppsCheckId = (typeof MCP_APPS_CHECK_IDS)[number];
+
+export type MCPAppsCheckStatus = "passed" | "failed" | "skipped";
+
+export interface MCPAppsCheckResult {
+  id: MCPAppsCheckId;
+  category: MCPAppsCheckCategory;
+  title: string;
+  description: string;
+  status: MCPAppsCheckStatus;
+  durationMs: number;
+  error?: {
+    message: string;
+    details?: unknown;
+  };
+  details?: Record<string, unknown>;
+  warnings?: string[];
+}
+
+export type MCPAppsConformanceConfig = MCPServerConfig & {
+  checkIds?: MCPAppsCheckId[];
+};
+
+export interface NormalizedMCPAppsConformanceConfig {
+  serverConfig: MCPServerConfig;
+  target: string;
+  timeout: number;
+  checkIds?: MCPAppsCheckId[];
+}
+
+export interface MCPAppsResourceReadOutcome {
+  uri: string;
+  referencedByTools: string[];
+  listed: boolean;
+  result?: MCPReadResourceResult;
+  error?: unknown;
+}
+
+export interface MCPAppsConformanceResult {
+  passed: boolean;
+  target: string;
+  checks: MCPAppsCheckResult[];
+  summary: string;
+  durationMs: number;
+  categorySummary: Record<
+    MCPAppsCheckCategory,
+    {
+      total: number;
+      passed: number;
+      failed: number;
+      skipped: number;
+    }
+  >;
+  discovery: {
+    toolCount: number;
+    uiToolCount: number;
+    listedResourceCount: number;
+    listedUiResourceCount: number;
+    checkedUiResourceCount: number;
+  };
+}

--- a/sdk/src/apps-conformance/types.ts
+++ b/sdk/src/apps-conformance/types.ts
@@ -10,6 +10,7 @@ export type MCPAppsCheckCategory = (typeof MCP_APPS_CHECK_CATEGORIES)[number];
 export const MCP_APPS_CHECK_IDS = [
   "ui-tools-present",
   "ui-tool-metadata-valid",
+  "ui-tool-input-schema-valid",
   "ui-listed-resources-valid",
   "ui-resources-readable",
   "ui-resource-contents-valid",

--- a/sdk/src/apps-conformance/validation.ts
+++ b/sdk/src/apps-conformance/validation.ts
@@ -1,0 +1,99 @@
+import {
+  getDefaultClientCapabilities,
+  mergeClientCapabilities,
+  MCP_UI_EXTENSION_ID,
+  MCP_UI_RESOURCE_MIME_TYPE,
+  type MCPServerConfig,
+} from "../mcp-client-manager/index.js";
+import {
+  MCP_APPS_CHECK_IDS,
+  type MCPAppsCheckId,
+  type MCPAppsConformanceConfig,
+  type NormalizedMCPAppsConformanceConfig,
+} from "./types.js";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeCheckIds(
+  checkIds: MCPAppsConformanceConfig["checkIds"],
+): MCPAppsCheckId[] | undefined {
+  if (!checkIds || checkIds.length === 0) {
+    return undefined;
+  }
+
+  const normalized = Array.from(new Set(checkIds));
+  for (const checkId of normalized) {
+    if (!MCP_APPS_CHECK_IDS.includes(checkId)) {
+      throw new Error(`Unknown MCP Apps conformance check id: ${checkId}`);
+    }
+  }
+
+  return normalized;
+}
+
+function deriveTarget(config: MCPServerConfig): string {
+  return ("url" in config ? config.url : config.command) ?? "";
+}
+
+function ensureUiCapability(config: MCPServerConfig): MCPServerConfig {
+  if (!("clientCapabilities" in config) || !config.clientCapabilities) {
+    return config;
+  }
+
+  const mergedCapabilities = mergeClientCapabilities(
+    getDefaultClientCapabilities(),
+    config.clientCapabilities,
+  );
+
+  const capabilityRecord = mergedCapabilities as Record<string, unknown>;
+  const extensions = isPlainObject(capabilityRecord.extensions)
+    ? { ...capabilityRecord.extensions }
+    : {};
+  const uiExtension = isPlainObject(extensions[MCP_UI_EXTENSION_ID])
+    ? { ...(extensions[MCP_UI_EXTENSION_ID] as Record<string, unknown>) }
+    : {};
+  const existingMimeTypes = Array.isArray(uiExtension.mimeTypes)
+    ? uiExtension.mimeTypes.filter(
+        (value): value is string => typeof value === "string" && value.trim().length > 0,
+      )
+    : [];
+
+  extensions[MCP_UI_EXTENSION_ID] = {
+    ...uiExtension,
+    mimeTypes: [
+      MCP_UI_RESOURCE_MIME_TYPE,
+      ...existingMimeTypes.filter(
+        (value) => value !== MCP_UI_RESOURCE_MIME_TYPE,
+      ),
+    ],
+  };
+
+  return {
+    ...config,
+    clientCapabilities: {
+      ...(mergedCapabilities as Record<string, unknown>),
+      extensions,
+    } as MCPServerConfig["clientCapabilities"],
+  };
+}
+
+export function normalizeMCPAppsConformanceConfig(
+  config: MCPAppsConformanceConfig,
+): NormalizedMCPAppsConformanceConfig {
+  const { checkIds, ...serverConfig } = config;
+  const normalizedServerConfig = ensureUiCapability(serverConfig as MCPServerConfig);
+  const target = deriveTarget(normalizedServerConfig).trim();
+
+  if (!target) {
+    throw new Error("MCP Apps conformance config requires a target");
+  }
+
+  return {
+    serverConfig: normalizedServerConfig,
+    target,
+    timeout: normalizedServerConfig.timeout ?? 30_000,
+    checkIds: normalizeCheckIds(checkIds),
+  };
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -306,6 +306,23 @@ export {
   MCP_CHECK_CATEGORIES,
   MCP_CHECK_IDS,
 } from "./mcp-conformance/index.js";
+
+// MCP Apps conformance
+export { MCPAppsConformanceTest } from "./apps-conformance/index.js";
+export type {
+  MCPAppsCheckCategory,
+  MCPAppsCheckId,
+  MCPAppsCheckResult,
+  MCPAppsCheckStatus,
+  MCPAppsConformanceConfig,
+  MCPAppsConformanceResult,
+  MCPAppsResourceReadOutcome,
+} from "./apps-conformance/index.js";
+export {
+  MCP_APPS_CHECK_CATEGORIES,
+  MCP_APPS_CHECK_IDS,
+} from "./apps-conformance/index.js";
+
 export type {
   ConformanceResult,
   ConformanceStepId,

--- a/sdk/src/oauth-conformance/auth-strategies/interactive.ts
+++ b/sdk/src/oauth-conformance/auth-strategies/interactive.ts
@@ -305,6 +305,13 @@ export async function createInteractiveAuthorizationSession(options?: {
     | undefined;
   let pendingReject: ((error: Error) => void) | undefined;
   let timeoutHandle: NodeJS.Timeout | undefined;
+  let activeExpectedState: string | undefined;
+
+  const clearPending = (): void => {
+    pendingResolve = undefined;
+    pendingReject = undefined;
+    activeExpectedState = undefined;
+  };
 
   const failPending = (error: Error): void => {
     if (timeoutHandle) {
@@ -312,8 +319,7 @@ export async function createInteractiveAuthorizationSession(options?: {
       timeoutHandle = undefined;
     }
     pendingReject?.(error);
-    pendingResolve = undefined;
-    pendingReject = undefined;
+    clearPending();
   };
 
   const server = createServer((req, res) => {
@@ -372,6 +378,23 @@ export async function createInteractiveAuthorizationSession(options?: {
     }
 
     const state = requestUrl.searchParams.get("state") ?? undefined;
+    if (activeExpectedState !== undefined && state !== activeExpectedState) {
+      const message = `Authorization state mismatch. Expected ${activeExpectedState}, received ${state ?? "missing"}`;
+      res.statusCode = 400;
+      res.setHeader("Content-Type", "text/html; charset=utf-8");
+      res.end(
+        renderCallbackPage({
+          tone: "error",
+          title: "Authorization failed",
+          message: "Return to the terminal for details.",
+          detail: message,
+          caption: "You can close this window.",
+        })
+      );
+      failPending(new Error(message));
+      return;
+    }
+
     res.statusCode = 200;
     res.setHeader("Content-Type", "text/html; charset=utf-8");
     res.end(
@@ -389,8 +412,7 @@ export async function createInteractiveAuthorizationSession(options?: {
     }
 
     pendingResolve?.({ code, state });
-    pendingResolve = undefined;
-    pendingReject = undefined;
+    clearPending();
   });
 
   await new Promise<void>((resolve, reject) => {
@@ -420,25 +442,16 @@ export async function createInteractiveAuthorizationSession(options?: {
       if (pendingResolve || pendingReject) {
         throw new Error("Interactive authorization is already in progress");
       }
+      activeExpectedState = expectedState;
 
       const codePromise = new Promise<AuthorizationCodeResult>(
         (resolve, reject) => {
-          pendingResolve = ({ code, state }) => {
-            if (expectedState && state !== expectedState) {
-              reject(
-                new Error(
-                  `Authorization state mismatch. Expected ${expectedState}, received ${state ?? "missing"}`
-                )
-              );
-              return;
-            }
-
+          pendingResolve = ({ code }) => {
             resolve({ code });
           };
           pendingReject = reject;
           timeoutHandle = setTimeout(() => {
-            pendingResolve = undefined;
-            pendingReject = undefined;
+            clearPending();
             reject(
               new Error(
                 `Interactive authorization timed out after ${timeoutMs}ms`
@@ -459,8 +472,7 @@ export async function createInteractiveAuthorizationSession(options?: {
           clearTimeout(timeoutHandle);
           timeoutHandle = undefined;
         }
-        pendingResolve = undefined;
-        pendingReject = undefined;
+        clearPending();
         throw error;
       }
 
@@ -471,8 +483,7 @@ export async function createInteractiveAuthorizationSession(options?: {
         clearTimeout(timeoutHandle);
       }
       pendingReject?.(new Error("Interactive authorization session closed"));
-      pendingResolve = undefined;
-      pendingReject = undefined;
+      clearPending();
       await closeServer(server);
     },
   };

--- a/sdk/src/oauth-conformance/auth-strategies/interactive.ts
+++ b/sdk/src/oauth-conformance/auth-strategies/interactive.ts
@@ -26,9 +26,7 @@ function escapeHtml(value: string): string {
     .replace(/'/g, "&#39;");
 }
 
-function getBrowserOpenCommand(
-  url: string,
-): {
+function getBrowserOpenCommand(url: string): {
   command: string;
   args: string[];
 } {
@@ -81,6 +79,202 @@ function closeServer(server: Server): Promise<void> {
   });
 }
 
+const MCPJAM_CALLBACK_LOGO = `<svg width="1080" height="1080" viewBox="0 0 1080 1080" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><g clip-path="url(#clip0_1_2)"><rect width="1080" height="1080" rx="241" ry="241" fill="#2D2D2D"/><path d="M196.547 508V298H245.447L332.447 440.8H306.647L391.247 298H440.147L440.747 508H386.147L385.547 381.1H394.847L331.547 487.3H305.147L240.047 381.1H251.447V508H196.547ZM587.477 512.2C570.877 512.2 555.477 509.6 541.277 504.4C527.277 499 515.077 491.4 504.677 481.6C494.477 471.8 486.477 460.3 480.677 447.1C474.877 433.7 471.977 419 471.977 403C471.977 387 474.877 372.4 480.677 359.2C486.477 345.8 494.477 334.2 504.677 324.4C515.077 314.6 527.277 307.1 541.277 301.9C555.477 296.5 570.877 293.8 587.477 293.8C606.877 293.8 624.177 297.2 639.377 304C654.777 310.8 667.577 320.6 677.777 333.4L639.977 367.6C633.177 359.6 625.677 353.5 617.477 349.3C609.477 345.1 600.477 343 590.477 343C581.877 343 573.977 344.4 566.777 347.2C559.577 350 553.377 354.1 548.177 359.5C543.177 364.7 539.177 371 536.177 378.4C533.377 385.8 531.977 394 531.977 403C531.977 412 533.377 420.2 536.177 427.6C539.177 435 543.177 441.4 548.177 446.8C553.377 452 559.577 456 566.777 458.8C573.977 461.6 581.877 463 590.477 463C600.477 463 609.477 460.9 617.477 456.7C625.677 452.5 633.177 446.4 639.977 438.4L677.777 472.6C667.577 485.2 654.777 495 639.377 502C624.177 508.8 606.877 512.2 587.477 512.2ZM704.262 508V298H800.262C819.462 298 835.962 301.1 849.762 307.3C863.762 313.5 874.562 322.5 882.162 334.3C889.762 345.9 893.562 359.7 893.562 375.7C893.562 391.5 889.762 405.2 882.162 416.8C874.562 428.4 863.762 437.4 849.762 443.8C835.962 450 819.462 453.1 800.262 453.1H737.262L763.662 427.3V508H704.262ZM763.662 433.6L737.262 406.3H796.662C809.062 406.3 818.262 403.6 824.262 398.2C830.462 392.8 833.562 385.3 833.562 375.7C833.562 365.9 830.462 358.3 824.262 352.9C818.262 347.5 809.062 344.8 796.662 344.8H737.262L763.662 317.5V433.6Z" fill="#FBFBFB"/><path d="M264.566 792.2C249.166 792.2 235.166 789.6 222.566 784.4C210.166 779 199.866 771.3 191.666 761.3L224.066 722.9C229.666 730.1 235.466 735.6 241.466 739.4C247.466 743 253.766 744.8 260.366 744.8C277.966 744.8 286.766 734.6 286.766 714.2V623.9H214.166V578H345.566V710.6C345.566 738 338.666 758.5 324.866 772.1C311.066 785.5 290.966 792.2 264.566 792.2ZM356.064 788L448.764 578H507.264L600.264 788H538.464L465.864 607.1H489.264L416.664 788H356.064ZM406.764 747.2L422.064 703.4H524.664L539.964 747.2H406.764ZM617.104 788V578H666.004L753.004 720.8H727.204L811.804 578H860.704L861.304 788H806.704L806.104 661.1H815.404L752.104 767.3H725.704L660.604 661.1H672.004V788H617.104Z" fill="#F2735B"/></g><defs><clipPath id="clip0_1_2"><rect width="1080" height="1080" rx="241" ry="241" fill="white"/></clipPath></defs></svg>`;
+
+function renderCallbackPage(input: {
+  tone: "success" | "error";
+  title: string;
+  message: string;
+  detail?: string;
+  caption: string;
+}): string {
+  const surface =
+    input.tone === "success"
+      ? "rgba(242, 115, 91, 0.08)"
+      : "rgba(209, 78, 97, 0.08)";
+  const border =
+    input.tone === "success"
+      ? "rgba(242, 115, 91, 0.18)"
+      : "rgba(209, 78, 97, 0.18)";
+  const detailHtml = input.detail
+    ? `<p class="detail">${escapeHtml(input.detail)}</p>`
+    : "";
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MCPJam | ${escapeHtml(input.title)}</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --page-bg: #f6f3ef;
+        --card-bg: rgba(255, 255, 255, 0.94);
+        --card-border: rgba(34, 28, 30, 0.08);
+        --card-shadow: 0 18px 42px rgba(26, 20, 22, 0.08);
+        --text: #231c1f;
+        --muted: #6f6568;
+        --detail-bg: ${surface};
+        --detail-border: ${border};
+      }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --page-bg: #111013;
+          --card-bg: rgba(26, 24, 27, 0.96);
+          --card-border: rgba(255, 255, 255, 0.08);
+          --card-shadow: 0 24px 56px rgba(0, 0, 0, 0.32);
+          --text: #f5f2ef;
+          --muted: #b0a6aa;
+          --detail-bg: rgba(255, 255, 255, 0.04);
+          --detail-border: rgba(255, 255, 255, 0.1);
+        }
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        min-height: 100%;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100dvh;
+        display: grid;
+        place-items: center;
+        padding: 32px 20px;
+        background: var(--page-bg);
+        color: var(--text);
+        font-family: "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif;
+      }
+
+      .shell {
+        width: min(100%, 396px);
+      }
+
+      .card {
+        border-radius: 24px;
+        border: 1px solid var(--card-border);
+        padding: 34px 24px 26px;
+        background: var(--card-bg);
+        box-shadow: var(--card-shadow);
+        text-align: center;
+      }
+
+      .brand {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin-bottom: 18px;
+      }
+
+      .logo {
+        flex: none;
+        width: 44px;
+        height: 44px;
+        overflow: hidden;
+        border-radius: 14px;
+        background: #2D2D2D;
+      }
+
+      .logo svg {
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
+
+      h1 {
+        margin: 0;
+        color: var(--text);
+        font-size: clamp(1.45rem, 4.5vw, 1.95rem);
+        font-weight: 600;
+        line-height: 1.12;
+        letter-spacing: -0.025em;
+        text-wrap: balance;
+      }
+
+      .message,
+      .detail,
+      .caption {
+        margin-left: auto;
+        margin-right: auto;
+      }
+
+      .message {
+        max-width: 100%;
+        margin-top: 14px;
+        margin-bottom: 0;
+        color: var(--text);
+        font-size: 14px;
+        line-height: 1.6;
+        text-wrap: pretty;
+      }
+
+      .detail {
+        max-width: 100%;
+        margin-top: 16px;
+        padding: 12px 14px;
+        border: 1px solid var(--detail-border);
+        border-radius: 12px;
+        background: var(--detail-bg);
+        color: var(--text);
+        font-family: "SFMono-Regular", "SF Mono", "Menlo", "Consolas", "Liberation Mono", monospace;
+        font-size: 13px;
+        line-height: 1.5;
+        white-space: pre-wrap;
+        word-break: break-word;
+        text-align: left;
+      }
+
+      .caption {
+        margin-top: 16px;
+        color: var(--muted);
+        font-size: 12px;
+        line-height: 1.6;
+      }
+
+      @media (max-width: 640px) {
+        body {
+          padding: 20px 16px;
+        }
+
+        .card {
+          border-radius: 22px;
+          padding: 30px 20px 24px;
+        }
+
+        .logo {
+          width: 42px;
+          height: 42px;
+          border-radius: 13px;
+        }
+
+        .message {
+          font-size: 14px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <section class="card" role="status" aria-live="polite">
+        <div class="brand">
+          <div class="logo">${MCPJAM_CALLBACK_LOGO}</div>
+        </div>
+        <h1>${escapeHtml(input.title)}</h1>
+        <p class="message">${escapeHtml(input.message)}</p>
+        ${detailHtml}
+        <p class="caption">${escapeHtml(input.caption)}</p>
+      </section>
+    </main>
+  </body>
+</html>`;
+}
+
 export async function createInteractiveAuthorizationSession(options?: {
   redirectUrl?: string;
 }): Promise<InteractiveAuthorizationSession> {
@@ -92,17 +286,17 @@ export async function createInteractiveAuthorizationSession(options?: {
     const parsed = new URL(options.redirectUrl);
     if (parsed.protocol !== "http:") {
       throw new Error(
-        "Interactive OAuth conformance runs require an http:// loopback redirect URL",
+        "Interactive OAuth conformance runs require an http:// loopback redirect URL"
       );
     }
     if (!isLoopbackHostname(parsed.hostname)) {
       throw new Error(
-        "Interactive OAuth conformance runs require a localhost or 127.0.0.1 redirect URL",
+        "Interactive OAuth conformance runs require a localhost or 127.0.0.1 redirect URL"
       );
     }
     if (parsed.pathname !== "/callback") {
       throw new Error(
-        "Interactive OAuth conformance runs require the callback path to be /callback",
+        "Interactive OAuth conformance runs require the callback path to be /callback"
       );
     }
 
@@ -130,7 +324,7 @@ export async function createInteractiveAuthorizationSession(options?: {
   const server = createServer((req, res) => {
     const requestUrl = new URL(
       req.url || callbackPath,
-      `http://${hostname}:${resolvedPort}`,
+      `http://${hostname}:${resolvedPort}`
     );
 
     if (requestUrl.pathname !== callbackPath) {
@@ -148,7 +342,13 @@ export async function createInteractiveAuthorizationSession(options?: {
       res.statusCode = 400;
       res.setHeader("Content-Type", "text/html; charset=utf-8");
       res.end(
-        `<html><body><p>Authorization failed: ${escapeHtml(message)}. You can close this window.</p></body></html>`,
+        renderCallbackPage({
+          tone: "error",
+          title: "Authorization failed",
+          message: "Return to the terminal for details.",
+          detail: message,
+          caption: "You can close this window.",
+        })
       );
       failPending(new Error(`Authorization server returned error: ${message}`));
       return;
@@ -157,11 +357,21 @@ export async function createInteractiveAuthorizationSession(options?: {
     const code = requestUrl.searchParams.get("code");
     if (!code) {
       res.statusCode = 400;
-      res.end("Missing authorization code");
+      res.setHeader("Content-Type", "text/html; charset=utf-8");
+      res.end(
+        renderCallbackPage({
+          tone: "error",
+          title: "Authorization incomplete",
+          message: "No authorization code was included in the callback.",
+          detail:
+            "Try the login flow again. If this keeps happening, inspect the provider's redirect URI configuration.",
+          caption: "You can close this window.",
+        })
+      );
       failPending(
         new Error(
-          "Authorization callback was invoked without a code or error parameter",
-        ),
+          "Authorization callback was invoked without a code or error parameter"
+        )
       );
       return;
     }
@@ -170,7 +380,12 @@ export async function createInteractiveAuthorizationSession(options?: {
     res.statusCode = 200;
     res.setHeader("Content-Type", "text/html; charset=utf-8");
     res.end(
-      "<html><body><p>Authorization received. You can close this window.</p></body></html>",
+      renderCallbackPage({
+        tone: "success",
+        title: "Authorization complete",
+        message: "Return to the terminal to continue.",
+        caption: "You can close this window.",
+      })
     );
 
     if (timeoutHandle) {
@@ -217,8 +432,8 @@ export async function createInteractiveAuthorizationSession(options?: {
             if (expectedState && state !== expectedState) {
               reject(
                 new Error(
-                  `Authorization state mismatch. Expected ${expectedState}, received ${state ?? "missing"}`,
-                ),
+                  `Authorization state mismatch. Expected ${expectedState}, received ${state ?? "missing"}`
+                )
               );
               return;
             }
@@ -231,11 +446,11 @@ export async function createInteractiveAuthorizationSession(options?: {
             pendingReject = undefined;
             reject(
               new Error(
-                `Interactive authorization timed out after ${timeoutMs}ms`,
-              ),
+                `Interactive authorization timed out after ${timeoutMs}ms`
+              )
             );
           }, timeoutMs);
-        },
+        }
       );
       // Attach a no-op handler to suppress "unhandled rejection" warnings when
       // the callback server rejects before the caller awaits codePromise. The

--- a/sdk/src/oauth-conformance/checks/oauth-negative.ts
+++ b/sdk/src/oauth-conformance/checks/oauth-negative.ts
@@ -1,4 +1,5 @@
 import { canonicalizeResourceUrl } from "../../oauth/state-machines/shared/urls.js";
+import { getConformanceAuthCodeDynamicRegistrationMetadata } from "../../oauth/client-identity.js";
 import type { OAuthFlowState } from "../../oauth/state-machines/types.js";
 import type {
   NormalizedOAuthConformanceConfig,
@@ -9,7 +10,9 @@ import type {
 
 type OAuthNegativeCheckStep = Extract<
   OAuthConformanceCheckId,
-  "oauth_invalid_client" | "oauth_invalid_redirect"
+  | "oauth_dcr_http_redirect_uri"
+  | "oauth_invalid_client"
+  | "oauth_invalid_redirect"
 >;
 
 export interface OAuthNegativeCheckOutcome {
@@ -45,16 +48,17 @@ function buildTransportFailure(
     method: string;
     url: string;
     headers: Record<string, string>;
-    body: Record<string, string>;
+    body: Record<string, unknown>;
   },
   error: unknown,
+  messagePrefix = "Token endpoint request failed",
 ): OAuthNegativeCheckOutcome {
   return {
     step,
     status: "failed",
     durationMs: Date.now() - startedAt,
     error: {
-      message: `Token endpoint request failed: ${error instanceof Error ? error.message : String(error)}`,
+      message: `${messagePrefix}: ${error instanceof Error ? error.message : String(error)}`,
       details: {
         request,
         error: errorDetails(error),
@@ -68,6 +72,15 @@ function buildTokenRequestHeaders(
 ): Record<string, string> {
   return {
     "Content-Type": "application/x-www-form-urlencoded",
+    ...(config.customHeaders ?? {}),
+  };
+}
+
+function buildJsonRequestHeaders(
+  config: NormalizedOAuthConformanceConfig,
+): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
     ...(config.customHeaders ?? {}),
   };
 }
@@ -125,6 +138,131 @@ function responseLooksRejected(response: {
     typeof response.body === "object" &&
     "error" in response.body
   );
+}
+
+function summarizeResponseBody(body: unknown): string | undefined {
+  if (!body) {
+    return undefined;
+  }
+
+  if (typeof body === "string") {
+    return body;
+  }
+
+  if (typeof body !== "object") {
+    return String(body);
+  }
+
+  const record = body as Record<string, unknown>;
+  const prioritizedKeys = [
+    "error_description",
+    "error",
+    "message",
+    "title",
+    "detail",
+    "description",
+  ];
+
+  for (const key of prioritizedKeys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function rejectionLooksRedirectSpecific(response: {
+  body: unknown;
+}): boolean {
+  const summary = summarizeResponseBody(response.body)?.toLowerCase();
+  if (!summary) {
+    return false;
+  }
+
+  return (
+    summary.includes("redirect_uri") ||
+    summary.includes("redirect uri") ||
+    summary.includes("redirect")
+  );
+}
+
+export async function runDcrHttpRedirectUriCheck(
+  input: OAuthNegativeCheckInput,
+): Promise<OAuthNegativeCheckOutcome> {
+  const registrationEndpoint =
+    input.state.authorizationServerMetadata?.registration_endpoint;
+  const startedAt = Date.now();
+
+  if (!registrationEndpoint) {
+    return {
+      step: "oauth_dcr_http_redirect_uri",
+      status: "skipped",
+      durationMs: 0,
+      error: {
+        message:
+          "Registration endpoint is unavailable for redirect URI policy testing",
+      },
+    };
+  }
+
+  const redirectUri = "http://evil.example/callback";
+  const request = {
+    method: "POST",
+    url: registrationEndpoint,
+    headers: buildJsonRequestHeaders(input.config),
+    body: {
+      ...getConformanceAuthCodeDynamicRegistrationMetadata(),
+      redirect_uris: [redirectUri],
+    },
+  };
+  let response: Awaited<ReturnType<TrackedRequestFn>>;
+
+  try {
+    response = await input.trackedRequest(request);
+  } catch (error) {
+    return buildTransportFailure(
+      "oauth_dcr_http_redirect_uri",
+      startedAt,
+      request,
+      error,
+      "Dynamic client registration request failed",
+    );
+  }
+
+  if (responseLooksRejected(response)) {
+    return {
+      step: "oauth_dcr_http_redirect_uri",
+      status: "passed",
+      durationMs: Date.now() - startedAt,
+    };
+  }
+
+  const clientId =
+    response.body &&
+    typeof response.body === "object" &&
+    typeof (response.body as Record<string, unknown>).client_id === "string"
+      ? ((response.body as Record<string, unknown>).client_id as string)
+      : undefined;
+
+  return {
+    step: "oauth_dcr_http_redirect_uri",
+    status: "failed",
+    durationMs: Date.now() - startedAt,
+    error: {
+      message:
+        "Authorization server accepted a non-loopback http redirect_uri during dynamic client registration",
+      details: {
+        redirectUri,
+        clientId,
+        response: response.body,
+        evidence: clientId
+          ? `Registered redirect_uri ${redirectUri} was accepted and returned client_id ${clientId}.`
+          : `Registered redirect_uri ${redirectUri} was accepted.`,
+      },
+    },
+  };
 }
 
 export async function runInvalidClientCheck(
@@ -242,6 +380,26 @@ export async function runInvalidRedirectCheck(
         message:
           "Authorization server accepted a token request with a mismatched redirect_uri",
         details: response.body,
+      },
+    };
+  }
+
+  const rejectionSummary = summarizeResponseBody(response.body);
+  if (!rejectionLooksRedirectSpecific(response)) {
+    return {
+      step: "oauth_invalid_redirect",
+      status: "skipped",
+      durationMs: Date.now() - startedAt,
+      error: {
+        message: rejectionSummary
+          ? `Token request was rejected for a non-redirect reason: ${rejectionSummary}`
+          : "Token request was rejected, but redirect_uri validation was not isolated.",
+        details: {
+          response: response.body,
+          evidence: rejectionSummary
+            ? `Received ${response.status} ${response.statusText} with ${rejectionSummary}.`
+            : `Received ${response.status} ${response.statusText} without a redirect-specific error.`,
+        },
       },
     };
   }

--- a/sdk/src/oauth-conformance/checks/oauth-negative.ts
+++ b/sdk/src/oauth-conformance/checks/oauth-negative.ts
@@ -1,6 +1,11 @@
 import { canonicalizeResourceUrl } from "../../oauth/state-machines/shared/urls.js";
 import { getConformanceAuthCodeDynamicRegistrationMetadata } from "../../oauth/client-identity.js";
 import type { OAuthFlowState } from "../../oauth/state-machines/types.js";
+import {
+  buildInitializeRequestBody,
+  resolveInitializeProtocolVersion,
+} from "../../oauth/state-machines/shared/initialize.js";
+import { resolveRequestedScopeValue } from "../../oauth/state-machines/shared/challenges.js";
 import type {
   NormalizedOAuthConformanceConfig,
   OAuthConformanceCheckId,
@@ -12,6 +17,8 @@ type OAuthNegativeCheckStep = Extract<
   OAuthConformanceCheckId,
   | "oauth_dcr_http_redirect_uri"
   | "oauth_invalid_client"
+  | "oauth_invalid_authorize_redirect"
+  | "oauth_invalid_token"
   | "oauth_invalid_redirect"
 >;
 
@@ -48,7 +55,7 @@ function buildTransportFailure(
     method: string;
     url: string;
     headers: Record<string, string>;
-    body: Record<string, unknown>;
+    body?: Record<string, unknown>;
   },
   error: unknown,
   messagePrefix = "Token endpoint request failed",
@@ -76,6 +83,41 @@ function buildTokenRequestHeaders(
   };
 }
 
+function buildInvalidTokenMcpRequest(
+  input: OAuthNegativeCheckInput,
+): {
+  method: string;
+  url: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+} {
+  const headers: Record<string, string> = {
+    ...(input.config.customHeaders ?? {}),
+    Authorization: "Bearer invalid-access-token",
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+
+  if (input.config.protocolVersion !== "2025-03-26") {
+    headers["MCP-Protocol-Version"] = input.config.protocolVersion;
+  }
+
+  return {
+    method: "POST",
+    url: input.config.serverUrl,
+    headers,
+    body: buildInitializeRequestBody({
+      protocolVersion: resolveInitializeProtocolVersion(
+        input.config.protocolVersion,
+      ),
+      authMode: input.config.auth.mode,
+      clientName: "MCPJam SDK OAuth Conformance",
+      clientVersion: "1.0.0",
+      id: 999,
+    }),
+  };
+}
+
 function buildJsonRequestHeaders(
   config: NormalizedOAuthConformanceConfig,
 ): Record<string, string> {
@@ -85,11 +127,21 @@ function buildJsonRequestHeaders(
   };
 }
 
+function buildAuthorizeRequestHeaders(
+  config: NormalizedOAuthConformanceConfig,
+): Record<string, string> {
+  return {
+    Accept: "text/html, application/json",
+    ...(config.customHeaders ?? {}),
+  };
+}
+
 function buildTokenRequestBody(
   input: OAuthNegativeCheckInput,
   overrides: Record<string, string | undefined>,
 ): Record<string, string> {
   const body: Record<string, string> = {};
+  const resource = canonicalizeResourceUrl(input.config.serverUrl);
   const state = input.state;
 
   if (input.config.auth.mode === "client_credentials") {
@@ -99,7 +151,7 @@ function buildTokenRequestBody(
     if (input.config.scopes) {
       body.scope = input.config.scopes;
     }
-    body.resource = canonicalizeResourceUrl(input.config.serverUrl);
+    body.resource = resource;
   } else {
     body.grant_type = "authorization_code";
     body.client_id = state.clientId ?? "unknown-client";
@@ -111,6 +163,7 @@ function buildTokenRequestBody(
     if (state.codeVerifier) {
       body.code_verifier = state.codeVerifier;
     }
+    body.resource = resource;
   }
 
   for (const [key, value] of Object.entries(overrides)) {
@@ -186,6 +239,38 @@ function rejectionLooksRedirectSpecific(response: {
     summary.includes("redirect uri") ||
     summary.includes("redirect")
   );
+}
+
+function redirectLocationTargetsUri(
+  location: string,
+  redirectUri: string,
+): boolean {
+  try {
+    const normalizedLocation = new URL(location);
+    const normalizedRedirect = new URL(redirectUri);
+
+    if (
+      normalizedLocation.origin !== normalizedRedirect.origin ||
+      normalizedLocation.pathname !== normalizedRedirect.pathname
+    ) {
+      return false;
+    }
+
+    for (const [key, value] of normalizedRedirect.searchParams.entries()) {
+      if (normalizedLocation.searchParams.get(key) !== value) {
+        return false;
+      }
+    }
+
+    return true;
+  } catch {
+    return (
+      location === redirectUri ||
+      location.startsWith(`${redirectUri}?`) ||
+      location.startsWith(`${redirectUri}&`) ||
+      location.startsWith(`${redirectUri}#`)
+    );
+  }
 }
 
 export async function runDcrHttpRedirectUriCheck(
@@ -319,6 +404,221 @@ export async function runInvalidClientCheck(
     step: "oauth_invalid_client",
     status: "passed",
     durationMs: Date.now() - startedAt,
+  };
+}
+
+export async function runInvalidAuthorizeRedirectCheck(
+  input: OAuthNegativeCheckInput,
+): Promise<OAuthNegativeCheckOutcome> {
+  const authorizationEndpoint =
+    input.state.authorizationServerMetadata?.authorization_endpoint;
+  const startedAt = Date.now();
+
+  if (!authorizationEndpoint) {
+    return {
+      step: "oauth_invalid_authorize_redirect",
+      status: "skipped",
+      durationMs: 0,
+      error: {
+        message:
+          "Authorization endpoint is unavailable for invalid redirect_uri testing",
+      },
+    };
+  }
+
+  if (input.config.auth.mode === "client_credentials") {
+    return {
+      step: "oauth_invalid_authorize_redirect",
+      status: "skipped",
+      durationMs: 0,
+      error: {
+        message:
+          "redirect_uri validation at the authorization endpoint does not apply to client_credentials flows",
+      },
+    };
+  }
+
+  const clientId = input.state.clientId;
+  if (!clientId) {
+    return {
+      step: "oauth_invalid_authorize_redirect",
+      status: "skipped",
+      durationMs: 0,
+      error: {
+        message:
+          "Client identifier is unavailable for invalid redirect_uri authorization testing",
+      },
+    };
+  }
+
+  const invalidRedirectUri = `${input.redirectUrl}?invalid=1`;
+  const authorizeUrl = new URL(authorizationEndpoint);
+  authorizeUrl.searchParams.set("response_type", "code");
+  authorizeUrl.searchParams.set("client_id", clientId);
+  authorizeUrl.searchParams.set("redirect_uri", invalidRedirectUri);
+  authorizeUrl.searchParams.set(
+    "code_challenge",
+    input.state.codeChallenge ?? "invalid-redirect-check-challenge",
+  );
+  authorizeUrl.searchParams.set("code_challenge_method", "S256");
+  authorizeUrl.searchParams.set(
+    "state",
+    input.state.state ?? "invalid-redirect-check-state",
+  );
+  authorizeUrl.searchParams.set(
+    "resource",
+    canonicalizeResourceUrl(input.config.serverUrl),
+  );
+
+  const requestedScopeValue = resolveRequestedScopeValue({
+    customScopes: input.config.scopes,
+    challengedScopes: input.state.challengedScopes,
+    supportedScopes:
+      input.state.resourceMetadata?.scopes_supported ??
+      input.state.authorizationServerMetadata?.scopes_supported,
+  });
+  if (requestedScopeValue) {
+    authorizeUrl.searchParams.set("scope", requestedScopeValue);
+  }
+
+  const request = {
+    method: "GET",
+    url: authorizeUrl.toString(),
+    headers: buildAuthorizeRequestHeaders(input.config),
+  };
+  let response: Awaited<ReturnType<TrackedRequestFn>>;
+
+  try {
+    response = await input.trackedRequest(request, { redirect: "manual" });
+  } catch (error) {
+    return buildTransportFailure(
+      "oauth_invalid_authorize_redirect",
+      startedAt,
+      request,
+      error,
+      "Authorization request failed",
+    );
+  }
+
+  const location = response.headers.location;
+  if (typeof location === "string") {
+    if (redirectLocationTargetsUri(location, invalidRedirectUri)) {
+      return {
+        step: "oauth_invalid_authorize_redirect",
+        status: "failed",
+        durationMs: Date.now() - startedAt,
+        error: {
+          message:
+            "Authorization server redirected the user agent to an invalid redirect_uri",
+          details: {
+            redirectUri: invalidRedirectUri,
+            location,
+            evidence: `Authorization endpoint responded with Location: ${location}.`,
+          },
+        },
+      };
+    }
+
+    return {
+      step: "oauth_invalid_authorize_redirect",
+      status: "skipped",
+      durationMs: Date.now() - startedAt,
+      error: {
+        message:
+          "Authorization request redirected elsewhere before redirect_uri validation was isolated",
+        details: {
+          redirectUri: invalidRedirectUri,
+          location,
+        },
+      },
+    };
+  }
+
+  const rejectionSummary = summarizeResponseBody(response.body);
+  if (responseLooksRejected(response)) {
+    if (!rejectionLooksRedirectSpecific(response)) {
+      return {
+        step: "oauth_invalid_authorize_redirect",
+        status: "skipped",
+        durationMs: Date.now() - startedAt,
+        error: {
+          message: rejectionSummary
+            ? `Authorization request was rejected for a non-redirect reason: ${rejectionSummary}`
+            : "Authorization request was rejected, but redirect_uri validation was not isolated.",
+          details: {
+            redirectUri: invalidRedirectUri,
+            response: response.body,
+            evidence: rejectionSummary
+              ? `Received ${response.status} ${response.statusText} with ${rejectionSummary}.`
+              : `Received ${response.status} ${response.statusText} without a redirect-specific error.`,
+          },
+        },
+      };
+    }
+
+    return {
+      step: "oauth_invalid_authorize_redirect",
+      status: "passed",
+      durationMs: Date.now() - startedAt,
+    };
+  }
+
+  return {
+    step: "oauth_invalid_authorize_redirect",
+    status: "skipped",
+    durationMs: Date.now() - startedAt,
+    error: {
+      message:
+        "Authorization request did not produce an explicit redirect_uri validation error",
+      details: {
+        redirectUri: invalidRedirectUri,
+        status: response.status,
+        statusText: response.statusText,
+        response: response.body,
+      },
+    },
+  };
+}
+
+export async function runInvalidTokenCheck(
+  input: OAuthNegativeCheckInput,
+): Promise<OAuthNegativeCheckOutcome> {
+  const startedAt = Date.now();
+  const request = buildInvalidTokenMcpRequest(input);
+  let response: Awaited<ReturnType<TrackedRequestFn>>;
+
+  try {
+    response = await input.trackedRequest(request);
+  } catch (error) {
+    return buildTransportFailure(
+      "oauth_invalid_token",
+      startedAt,
+      request,
+      error,
+      "Authenticated MCP request failed",
+    );
+  }
+
+  if (response.status === 401) {
+    return {
+      step: "oauth_invalid_token",
+      status: "passed",
+      durationMs: Date.now() - startedAt,
+    };
+  }
+
+  return {
+    step: "oauth_invalid_token",
+    status: "failed",
+    durationMs: Date.now() - startedAt,
+    error: {
+      message: `MCP server accepted or mishandled an invalid bearer token (expected HTTP 401, received ${response.status})`,
+      details: {
+        response: response.body,
+        status: response.status,
+        statusText: response.statusText,
+      },
+    },
   };
 }
 

--- a/sdk/src/oauth-conformance/checks/oauth-negative.ts
+++ b/sdk/src/oauth-conformance/checks/oauth-negative.ts
@@ -317,6 +317,27 @@ export async function runDcrHttpRedirectUriCheck(
   }
 
   if (responseLooksRejected(response)) {
+    const rejectionSummary = summarizeResponseBody(response.body);
+    if (!rejectionLooksRedirectSpecific(response)) {
+      return {
+        step: "oauth_dcr_http_redirect_uri",
+        status: "skipped",
+        durationMs: Date.now() - startedAt,
+        error: {
+          message: rejectionSummary
+            ? `Dynamic client registration was rejected for a non-redirect reason: ${rejectionSummary}`
+            : "Dynamic client registration was rejected, but redirect_uri validation was not isolated.",
+          details: {
+            redirectUri,
+            response: response.body,
+            evidence: rejectionSummary
+              ? `Received ${response.status} ${response.statusText} with ${rejectionSummary}.`
+              : `Received ${response.status} ${response.statusText} without a redirect-specific error.`,
+          },
+        },
+      };
+    }
+
     return {
       step: "oauth_dcr_http_redirect_uri",
       status: "passed",

--- a/sdk/src/oauth-conformance/formatter.ts
+++ b/sdk/src/oauth-conformance/formatter.ts
@@ -153,6 +153,19 @@ function deriveHint(
   return undefined;
 }
 
+function extractEvidence(details: unknown): string | undefined {
+  if (!details || typeof details !== "object") {
+    return undefined;
+  }
+
+  const evidence = (details as { evidence?: unknown }).evidence;
+  if (typeof evidence !== "string" || !evidence.trim()) {
+    return undefined;
+  }
+
+  return truncate(evidence);
+}
+
 function countStatuses(result: ConformanceResult): string {
   const passed = result.steps.filter((step) => step.status === "passed").length;
   const failed = result.steps.filter((step) => step.status === "failed").length;
@@ -176,6 +189,7 @@ function formatFailureLines(result: ConformanceResult): string[] {
   const contentType = response?.headers?.["content-type"];
   const bodySummary = summarizeBody(response?.body, contentType);
   const hint = deriveHint(failure, contentType, bodySummary);
+  const evidence = extractEvidence(failure.error?.details);
 
   const lines = [
     `Step: ${failure.step}`,
@@ -194,6 +208,10 @@ function formatFailureLines(result: ConformanceResult): string[] {
 
   if (bodySummary?.snippet) {
     lines.push(`Snippet: ${bodySummary.snippet}`);
+  }
+
+  if (evidence) {
+    lines.push(`Evidence: ${evidence}`);
   }
 
   if (hint) {

--- a/sdk/src/oauth-conformance/formatter.ts
+++ b/sdk/src/oauth-conformance/formatter.ts
@@ -34,6 +34,26 @@ function truncate(value: string, maxLength = BODY_SNIPPET_LIMIT): string {
   return `${normalized.slice(0, maxLength - 1).trimEnd()}...`;
 }
 
+function redactSensitiveStrings(value: string): string {
+  return value
+    .replace(
+      /(authorization\s*:\s*bearer\s+)([^\s,;]+)/gi,
+      "$1[REDACTED]",
+    )
+    .replace(
+      /([?&](?:access_token|refresh_token|client_secret|code)=)([^&#\s]+)/gi,
+      "$1[REDACTED]",
+    )
+    .replace(
+      /("(?:access_token|refresh_token|client_secret|code)"\s*:\s*")([^"]*)(")/gi,
+      '$1[REDACTED]$3',
+    )
+    .replace(
+      /('(?:access_token|refresh_token|client_secret|code)'\s*:\s*')([^']*)(')/gi,
+      "$1[REDACTED]$3",
+    );
+}
+
 function decodeHtmlEntities(value: string): string {
   return value
     .replace(/&quot;/g, '"')
@@ -163,7 +183,7 @@ function extractEvidence(details: unknown): string | undefined {
     return undefined;
   }
 
-  return truncate(evidence);
+  return truncate(redactSensitiveStrings(evidence));
 }
 
 function countStatuses(result: ConformanceResult): string {

--- a/sdk/src/oauth-conformance/runner.ts
+++ b/sdk/src/oauth-conformance/runner.ts
@@ -24,7 +24,9 @@ import {
 } from "./auth-strategies/interactive.js";
 import {
   runDcrHttpRedirectUriCheck,
+  runInvalidAuthorizeRedirectCheck,
   runInvalidClientCheck,
+  runInvalidTokenCheck,
   runInvalidRedirectCheck,
 } from "./checks/oauth-negative.js";
 import { runTokenFormatCheck } from "./checks/oauth-token-format.js";
@@ -408,6 +410,8 @@ export class OAuthConformanceTest {
           DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
         customScopes: this.config.scopes,
         customHeaders: this.config.customHeaders,
+        authMode: this.config.auth.mode,
+        strictConformance: true,
       });
 
       let guard = 0;
@@ -643,6 +647,22 @@ export class OAuthConformanceTest {
         );
         await recordOAuthCheck("oauth_invalid_client", () =>
           runInvalidClientCheck({
+            config: this.config,
+            state,
+            trackedRequest,
+            redirectUrl: oauthCheckRedirectUrl,
+          }),
+        );
+        await recordOAuthCheck("oauth_invalid_authorize_redirect", () =>
+          runInvalidAuthorizeRedirectCheck({
+            config: this.config,
+            state,
+            trackedRequest,
+            redirectUrl: oauthCheckRedirectUrl,
+          }),
+        );
+        await recordOAuthCheck("oauth_invalid_token", () =>
+          runInvalidTokenCheck({
             config: this.config,
             state,
             trackedRequest,

--- a/sdk/src/oauth-conformance/runner.ts
+++ b/sdk/src/oauth-conformance/runner.ts
@@ -23,6 +23,7 @@ import {
   type InteractiveAuthorizationSession,
 } from "./auth-strategies/interactive.js";
 import {
+  runDcrHttpRedirectUriCheck,
   runInvalidClientCheck,
   runInvalidRedirectCheck,
 } from "./checks/oauth-negative.js";
@@ -629,10 +630,17 @@ export class OAuthConformanceTest {
       if (
         state.currentStep === "complete" &&
         steps.every((step) => step.status !== "failed") &&
-        this.config.oauthConformanceChecks &&
-        redirectUrl
+        this.config.oauthConformanceChecks
       ) {
         const oauthCheckRedirectUrl = redirectUrl;
+        await recordOAuthCheck("oauth_dcr_http_redirect_uri", () =>
+          runDcrHttpRedirectUriCheck({
+            config: this.config,
+            state,
+            trackedRequest,
+            redirectUrl: oauthCheckRedirectUrl,
+          }),
+        );
         await recordOAuthCheck("oauth_invalid_client", () =>
           runInvalidClientCheck({
             config: this.config,
@@ -641,14 +649,18 @@ export class OAuthConformanceTest {
             redirectUrl: oauthCheckRedirectUrl,
           }),
         );
-        await recordOAuthCheck("oauth_invalid_redirect", () =>
-          runInvalidRedirectCheck({
-            config: this.config,
-            state,
-            trackedRequest,
-            redirectUrl: oauthCheckRedirectUrl,
-          }),
-        );
+        if (oauthCheckRedirectUrl) {
+          await recordOAuthCheck("oauth_invalid_redirect", () =>
+            runInvalidRedirectCheck({
+              config: this.config,
+              state,
+              trackedRequest,
+              redirectUrl: oauthCheckRedirectUrl,
+            }),
+          );
+        } else {
+          steps.push(buildSkippedStepResult("oauth_invalid_redirect"));
+        }
 
         const tokenRequestStep = [...steps]
           .reverse()

--- a/sdk/src/oauth-conformance/types.ts
+++ b/sdk/src/oauth-conformance/types.ts
@@ -19,6 +19,8 @@ import type { OAuthStepInfo } from "../oauth/state-machines/shared/step-metadata
 export type OAuthConformanceCheckId =
   | "oauth_dcr_http_redirect_uri"
   | "oauth_invalid_client"
+  | "oauth_invalid_authorize_redirect"
+  | "oauth_invalid_token"
   | "oauth_invalid_redirect"
   | "oauth_token_format";
 
@@ -43,6 +45,22 @@ export const CONFORMANCE_CHECK_METADATA: Record<
       "Send a token request with an invalid client identifier and confirm the authorization server rejects it.",
     teachableMoments: [
       "Authorization servers should reject malformed or unknown clients instead of issuing tokens.",
+    ],
+  },
+  oauth_invalid_authorize_redirect: {
+    title: "OAuth Check: Invalid Redirect URI at Authorization Endpoint",
+    summary:
+      "Send an authorization request with a mismatched redirect URI and confirm the authorization server refuses to redirect back to it.",
+    teachableMoments: [
+      "Authorization servers should validate redirect_uri before redirecting user agents to untrusted callback URLs.",
+    ],
+  },
+  oauth_invalid_token: {
+    title: "OAuth Check: Invalid Access Token",
+    summary:
+      "Send an authenticated MCP initialize request with an obviously invalid bearer token and confirm the MCP server returns HTTP 401.",
+    teachableMoments: [
+      "Resource servers must reject invalid bearer tokens with HTTP 401 instead of treating them as authenticated.",
     ],
   },
   oauth_invalid_redirect: {

--- a/sdk/src/oauth-conformance/types.ts
+++ b/sdk/src/oauth-conformance/types.ts
@@ -124,6 +124,8 @@ export interface OAuthConformanceConfig {
   stepTimeout?: number;
   verification?: OAuthVerificationConfig;
   oauthConformanceChecks?: boolean;
+  /** Optional callback for progress messages during the OAuth flow. */
+  onProgress?: (message: string) => void;
 }
 
 export interface StepResult {
@@ -167,6 +169,7 @@ export interface NormalizedOAuthConformanceConfig {
   stepTimeout: number;
   verification: OAuthVerificationConfig;
   oauthConformanceChecks: boolean;
+  onProgress: (message: string) => void;
 }
 
 export interface TrackedRequestOptions {

--- a/sdk/src/oauth-conformance/types.ts
+++ b/sdk/src/oauth-conformance/types.ts
@@ -17,6 +17,7 @@ import type { OAuthStepInfo } from "../oauth/state-machines/shared/step-metadata
 // (the interactive debugger state machine never enters these states).
 
 export type OAuthConformanceCheckId =
+  | "oauth_dcr_http_redirect_uri"
   | "oauth_invalid_client"
   | "oauth_invalid_redirect"
   | "oauth_token_format";
@@ -28,6 +29,14 @@ export const CONFORMANCE_CHECK_METADATA: Record<
   OAuthConformanceCheckId,
   OAuthStepInfo
 > = {
+  oauth_dcr_http_redirect_uri: {
+    title: "OAuth Check: DCR Redirect URI Policy",
+    summary:
+      "Attempt dynamic client registration with a non-loopback http redirect URI and confirm the authorization server rejects it.",
+    teachableMoments: [
+      "MCP authorization requires redirect URIs to use localhost or HTTPS.",
+    ],
+  },
   oauth_invalid_client: {
     title: "OAuth Check: Invalid Client",
     summary:
@@ -39,9 +48,9 @@ export const CONFORMANCE_CHECK_METADATA: Record<
   oauth_invalid_redirect: {
     title: "OAuth Check: Invalid Redirect URI",
     summary:
-      "Send a token request with a mismatched redirect URI and confirm the authorization server rejects it.",
+      "Send a token request with a mismatched redirect URI and look for a redirect-specific rejection from the token endpoint.",
     teachableMoments: [
-      "Redirect URI validation prevents authorization code injection and token leakage.",
+      "A generic invalid_grant rejection does not prove redirect URI exact-match validation.",
     ],
   },
   oauth_token_format: {

--- a/sdk/src/oauth-conformance/validation.ts
+++ b/sdk/src/oauth-conformance/validation.ts
@@ -122,5 +122,6 @@ export function normalizeOAuthConformanceConfig(
       timeout: config.verification?.timeout ?? 30_000,
     },
     oauthConformanceChecks: config.oauthConformanceChecks ?? false,
+    onProgress: config.onProgress ?? (() => {}),
   };
 }

--- a/sdk/src/oauth-login.ts
+++ b/sdk/src/oauth-login.ts
@@ -368,6 +368,7 @@ export async function runOAuthLogin(
         DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
       customScopes: config.scopes,
       customHeaders: config.customHeaders,
+      authMode: config.auth.mode,
     });
 
     let guard = 0;

--- a/sdk/src/oauth-login.ts
+++ b/sdk/src/oauth-login.ts
@@ -454,6 +454,7 @@ export async function runOAuthLogin(
         }
 
         try {
+          config.onProgress("Opening browser for authorization...");
           const authorizationResult =
             config.auth.mode === "interactive"
               ? await interactiveSession!.authorize({
@@ -472,6 +473,7 @@ export async function runOAuthLogin(
                   request: trackedRequest,
                 });
 
+          config.onProgress("Authorization received, exchanging token...");
           updateState({
             currentStep: "received_authorization_code",
             authorizationCode: authorizationResult.code,
@@ -527,6 +529,9 @@ export async function runOAuthLogin(
       );
     }
 
+    if (config.verification.listTools) {
+      config.onProgress("Verifying token with server...");
+    }
     const verification = await runVerification(
       config,
       state,

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
@@ -34,6 +34,11 @@ import {
   generateRandomString,
   generateCodeChallenge,
 } from "./shared/pkce.js";
+import {
+  buildInitializeRequestBody,
+  resolveInitializeProtocolVersion,
+} from "./shared/initialize.js";
+import { resolveRequestedScopeValue } from "./shared/challenges.js";
 
 // Re-export types for backward compatibility
 export type { OAuthFlowStep, OAuthFlowState };
@@ -351,10 +356,13 @@ export const createDebugOAuthStateMachine = (
     dynamicRegistration,
     customScopes,
     customHeaders,
+    authMode,
+    strictConformance = false,
     registrationStrategy = "dcr", // Default to DCR for 2025-03-26
   } = config;
 
   const redirectUri = redirectUrl;
+  const initializeProtocolVersion = resolveInitializeProtocolVersion("2025-03-26");
   const dynamicRegistrationDefaults = dynamicRegistration ?? {};
 
   if (
@@ -424,19 +432,15 @@ export const createDebugOAuthStateMachine = (
                   "Content-Type": "application/json",
                   Accept: "application/json, text/event-stream",
                 }),
-                body: JSON.stringify({
-                  jsonrpc: "2.0",
-                  method: "initialize",
-                  params: {
-                    protocolVersion: "2024-11-05",
-                    capabilities: {},
-                    clientInfo: {
-                      name: "MCP Inspector",
-                      version: "1.0.0",
-                    },
-                  },
-                  id: 1,
-                }),
+                body: JSON.stringify(
+                  buildInitializeRequestBody({
+                    protocolVersion: initializeProtocolVersion,
+                    authMode,
+                    clientName: "MCP Inspector",
+                    clientVersion: "1.0.0",
+                    id: 1,
+                  }),
+                ),
               });
 
               const responseData = {
@@ -776,6 +780,10 @@ export const createDebugOAuthStateMachine = (
             ) {
               const scopesSupported =
                 state.authorizationServerMetadata.scopes_supported;
+              const requestedScopeValue = resolveRequestedScopeValue({
+                customScopes,
+                supportedScopes: scopesSupported,
+              });
 
               const clientMetadata: Record<string, any> = {
                 ...dynamicRegistrationDefaults,
@@ -792,8 +800,8 @@ export const createDebugOAuthStateMachine = (
                   "none",
               };
 
-              if (scopesSupported && scopesSupported.length > 0) {
-                clientMetadata.scope = scopesSupported.join(" ");
+              if (requestedScopeValue) {
+                clientMetadata.scope = requestedScopeValue;
               }
 
               const registrationRequest = {
@@ -823,6 +831,15 @@ export const createDebugOAuthStateMachine = (
               autoAdvance(50);
               return;
             } else {
+              if (strictConformance) {
+                updateState({
+                  error:
+                    "Authorization server metadata does not include a registration_endpoint required for DCR conformance.",
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
+
               // No registration endpoint - use mock client ID
               updateState({
                 currentStep: "generate_pkce_parameters",
@@ -872,11 +889,19 @@ export const createDebugOAuthStateMachine = (
               }
 
               if (!response.ok) {
+                const registrationError = strictConformance
+                  ? `Dynamic Client Registration failed (${response.status}).`
+                  : `Dynamic Client Registration failed (${response.status}). Using fallback client ID.`;
+
                 updateState({
                   lastResponse: registrationResponseData,
                   httpHistory: updatedHistoryReg,
-                  error: `Dynamic Client Registration failed (${response.status}). Using fallback client ID.`,
+                  error: registrationError,
                 });
+
+                if (strictConformance) {
+                  return;
+                }
 
                 const fallbackClientId = "preregistered-client-id";
 
@@ -889,6 +914,19 @@ export const createDebugOAuthStateMachine = (
                 });
               } else {
                 const clientInfo = response.body;
+                if (
+                  strictConformance &&
+                  typeof clientInfo?.client_id !== "string"
+                ) {
+                  updateState({
+                    lastResponse: registrationResponseData,
+                    httpHistory: updatedHistoryReg,
+                    error:
+                      "Dynamic Client Registration response is missing a client_id.",
+                    isInitiatingAuth: false,
+                  });
+                  return;
+                }
 
                 const dcrInfo: Record<string, any> = {
                   "Client ID": clientInfo.client_id,
@@ -950,8 +988,14 @@ export const createDebugOAuthStateMachine = (
               updateState({
                 lastResponse: errorResponse,
                 httpHistory: updatedHistoryError,
-                error: `Client registration failed: ${error instanceof Error ? error.message : String(error)}. Using fallback.`,
+                error: strictConformance
+                  ? `Client registration failed: ${error instanceof Error ? error.message : String(error)}`
+                  : `Client registration failed: ${error instanceof Error ? error.message : String(error)}. Using fallback.`,
               });
+
+              if (strictConformance) {
+                return;
+              }
 
               const fallbackClientId = "preregistered-client-id";
 
@@ -1019,26 +1063,13 @@ export const createDebugOAuthStateMachine = (
               authUrl.searchParams.set("resource", state.serverUrl);
             }
 
-            // Add scopes
-            if (customScopes) {
-              authUrl.searchParams.set("scope", customScopes);
-            } else {
-              const scopesSupported =
-                state.authorizationServerMetadata.scopes_supported;
-
-              const scopes = new Set<string>();
-
-              if (scopesSupported && scopesSupported.length > 0) {
-                scopesSupported.forEach((scope) => scopes.add(scope));
-              }
-
-              if (scopesSupported?.includes("offline_access")) {
-                scopes.add("offline_access");
-              }
-
-              if (scopes.size > 0) {
-                authUrl.searchParams.set("scope", Array.from(scopes).join(" "));
-              }
+            const requestedScopeValue = resolveRequestedScopeValue({
+              customScopes,
+              supportedScopes:
+                state.authorizationServerMetadata.scopes_supported,
+            });
+            if (requestedScopeValue) {
+              authUrl.searchParams.set("scope", requestedScopeValue);
             }
 
             const authUrlInfoLogs = addInfoLog(
@@ -1404,19 +1435,13 @@ export const createDebugOAuthStateMachine = (
                 "Content-Type": "application/json",
                 Accept: "application/json, text/event-stream",
               },
-              body: {
-                jsonrpc: "2.0",
-                method: "initialize",
-                params: {
-                  protocolVersion: "2024-11-05",
-                  capabilities: {},
-                  clientInfo: {
-                    name: "MCP Inspector",
-                    version: "1.0.0",
-                  },
-                },
+              body: buildInitializeRequestBody({
+                protocolVersion: initializeProtocolVersion,
+                authMode,
+                clientName: "MCP Inspector",
+                clientVersion: "1.0.0",
                 id: 2,
-              },
+              }),
             };
 
             const authenticatedRequestInfoLogs = addInfoLog(
@@ -1465,19 +1490,15 @@ export const createDebugOAuthStateMachine = (
                   "Content-Type": "application/json",
                   Accept: "application/json, text/event-stream",
                 }),
-                body: JSON.stringify({
-                  jsonrpc: "2.0",
-                  method: "initialize",
-                  params: {
-                    protocolVersion: "2024-11-05",
-                    capabilities: {},
-                    clientInfo: {
-                      name: "MCP Inspector",
-                      version: "1.0.0",
-                    },
-                  },
-                  id: 2,
-                }),
+                body: JSON.stringify(
+                  buildInitializeRequestBody({
+                    protocolVersion: initializeProtocolVersion,
+                    authMode,
+                    clientName: "MCP Inspector",
+                    clientVersion: "1.0.0",
+                    id: 2,
+                  }),
+                ),
               });
 
               const mcpResponseData = {

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -35,6 +35,15 @@ import {
   generateCodeChallenge,
 } from "./shared/pkce.js";
 import { buildResourceMetadataUrl } from "./shared/urls.js";
+import {
+  buildInitializeRequestBody,
+  resolveInitializeProtocolVersion,
+} from "./shared/initialize.js";
+import {
+  parseBearerAuthenticateParameters,
+  parseScopeString,
+  resolveRequestedScopeValue,
+} from "./shared/challenges.js";
 import { discoverOAuthProtectedResourceMetadata } from "@modelcontextprotocol/sdk/client/auth.js";
 
 // Re-export types for backward compatibility
@@ -397,10 +406,13 @@ export const createDebugOAuthStateMachine = (
     dynamicRegistration,
     customScopes,
     customHeaders,
+    authMode,
+    strictConformance = false,
     registrationStrategy = "dcr", // Default to DCR for 2025-06-18
   } = config;
 
   const redirectUri = redirectUrl;
+  const initializeProtocolVersion = resolveInitializeProtocolVersion("2025-06-18");
   const dynamicRegistrationDefaults = dynamicRegistration ?? {};
 
   if (
@@ -448,24 +460,19 @@ export const createDebugOAuthStateMachine = (
               "Content-Type": "application/json",
               Accept: "application/json, text/event-stream",
             });
+            const initializeRequestBody = buildInitializeRequestBody({
+              protocolVersion: initializeProtocolVersion,
+              authMode,
+              clientName: "MCPJam Inspector",
+              clientVersion: "1.0.0",
+              id: 1,
+            });
 
             const initialRequest = {
               method: "POST",
               url: serverUrl,
               headers: initialRequestHeaders,
-              body: {
-                jsonrpc: "2.0",
-                method: "initialize",
-                params: {
-                  protocolVersion: "2024-11-05",
-                  capabilities: {},
-                  clientInfo: {
-                    name: "MCPJam Inspector",
-                    version: "1.0.0",
-                  },
-                },
-                id: 1,
-              },
+              body: initializeRequestBody,
             };
 
             // Update state with the request
@@ -504,19 +511,15 @@ export const createDebugOAuthStateMachine = (
                   "Content-Type": "application/json",
                   Accept: "application/json, text/event-stream",
                 }),
-                body: JSON.stringify({
-                  jsonrpc: "2.0",
-                  method: "initialize",
-                  params: {
-                    protocolVersion: "2024-11-05",
-                    capabilities: {},
-                    clientInfo: {
-                      name: "MCPJam Inspector",
-                      version: "1.0.0",
-                    },
-                  },
-                  id: 1,
-                }),
+                body: JSON.stringify(
+                  buildInitializeRequestBody({
+                    protocolVersion: initializeProtocolVersion,
+                    authMode,
+                    clientName: "MCPJam Inspector",
+                    clientVersion: "1.0.0",
+                    id: 1,
+                  }),
+                ),
               });
 
               // Capture response data for all status codes
@@ -540,6 +543,12 @@ export const createDebugOAuthStateMachine = (
                 // Expected 401 response with WWW-Authenticate header
                 const wwwAuthenticateHeader =
                   response.headers["www-authenticate"];
+                const challengeParams = parseBearerAuthenticateParameters(
+                  wwwAuthenticateHeader,
+                );
+                const challengedScopes = parseScopeString(
+                  challengeParams.scope,
+                );
 
                 // Add info log for WWW-Authenticate header
                 const infoLogs = wwwAuthenticateHeader
@@ -550,6 +559,9 @@ export const createDebugOAuthStateMachine = (
                       "WWW-Authenticate Header",
                       {
                         header: wwwAuthenticateHeader,
+                        ...(challengedScopes && challengedScopes.length > 0
+                          ? { scope: challengedScopes.join(" ") }
+                          : {}),
                         "Received from": state.serverUrl || "Unknown",
                       },
                     )
@@ -558,6 +570,7 @@ export const createDebugOAuthStateMachine = (
                 updateState({
                   currentStep: "received_401_unauthorized",
                   wwwAuthenticateHeader: wwwAuthenticateHeader || undefined,
+                  challengedScopes,
                   lastResponse: responseData,
                   httpHistory: updatedHistory,
                   infoLogs,
@@ -604,18 +617,11 @@ export const createDebugOAuthStateMachine = (
 
           case "received_401_unauthorized":
             // Step 3: Extract resource metadata URL and prepare request
-            let extractedResourceMetadataUrl: string | undefined;
-
-            if (state.wwwAuthenticateHeader) {
-              // Parse WWW-Authenticate header to extract resource_metadata URL
-              // Format: Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"
-              const resourceMetadataMatch = state.wwwAuthenticateHeader.match(
-                /resource_metadata="([^"]+)"/,
-              );
-              if (resourceMetadataMatch) {
-                extractedResourceMetadataUrl = resourceMetadataMatch[1];
-              }
-            }
+            const challengeParams = parseBearerAuthenticateParameters(
+              state.wwwAuthenticateHeader,
+            );
+            let extractedResourceMetadataUrl =
+              challengeParams.resource_metadata;
 
             // Fallback to building the URL if not found in header
             if (!extractedResourceMetadataUrl && state.serverUrl) {
@@ -1104,6 +1110,11 @@ export const createDebugOAuthStateMachine = (
               const scopesSupported =
                 state.resourceMetadata?.scopes_supported ||
                 state.authorizationServerMetadata.scopes_supported;
+              const requestedScopeValue = resolveRequestedScopeValue({
+                customScopes,
+                challengedScopes: state.challengedScopes,
+                supportedScopes: scopesSupported,
+              });
 
               const clientMetadata: Record<string, any> = {
                 ...dynamicRegistrationDefaults,
@@ -1120,9 +1131,8 @@ export const createDebugOAuthStateMachine = (
                   "none",
               };
 
-              // Include scopes if supported by the server
-              if (scopesSupported && scopesSupported.length > 0) {
-                clientMetadata.scope = scopesSupported.join(" ");
+              if (requestedScopeValue) {
+                clientMetadata.scope = requestedScopeValue;
               }
 
               const registrationRequest = {
@@ -1154,6 +1164,15 @@ export const createDebugOAuthStateMachine = (
               autoAdvance(50);
               return;
             } else {
+              if (strictConformance) {
+                updateState({
+                  error:
+                    "Authorization server metadata does not include a registration_endpoint required for DCR conformance.",
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
+
               // No registration endpoint and DCR strategy - skip to PKCE generation with a mock client ID
               updateState({
                 currentStep: "generate_pkce_parameters",
@@ -1206,13 +1225,20 @@ export const createDebugOAuthStateMachine = (
 
               if (!response.ok) {
                 // Registration failed - could be server doesn't support DCR or request was invalid
+                const registrationError = strictConformance
+                  ? `Dynamic Client Registration failed (${response.status}).`
+                  : `Dynamic Client Registration failed (${response.status}). Using fallback client ID.`;
 
                 // Update state with error but continue with fallback
                 updateState({
                   lastResponse: registrationResponseData,
                   httpHistory: updatedHistoryReg,
-                  error: `Dynamic Client Registration failed (${response.status}). Using fallback client ID.`,
+                  error: registrationError,
                 });
+
+                if (strictConformance) {
+                  return;
+                }
 
                 // Fall back to mock client ID (simulating preregistered client)
                 const fallbackClientId = "preregistered-client-id";
@@ -1227,6 +1253,19 @@ export const createDebugOAuthStateMachine = (
               } else {
                 // Registration successful
                 const clientInfo = response.body;
+                if (
+                  strictConformance &&
+                  typeof clientInfo?.client_id !== "string"
+                ) {
+                  updateState({
+                    lastResponse: registrationResponseData,
+                    httpHistory: updatedHistoryReg,
+                    error:
+                      "Dynamic Client Registration response is missing a client_id.",
+                    isInitiatingAuth: false,
+                  });
+                  return;
+                }
 
                 // Add info log for DCR
                 const dcrInfo: Record<string, any> = {
@@ -1290,8 +1329,14 @@ export const createDebugOAuthStateMachine = (
               updateState({
                 lastResponse: errorResponse,
                 httpHistory: updatedHistoryError,
-                error: `Client registration failed: ${error instanceof Error ? error.message : String(error)}. Using fallback.`,
+                error: strictConformance
+                  ? `Client registration failed: ${error instanceof Error ? error.message : String(error)}`
+                  : `Client registration failed: ${error instanceof Error ? error.message : String(error)}. Using fallback.`,
               });
+
+              if (strictConformance) {
+                return;
+              }
 
               // Fall back to mock client ID
               const fallbackClientId = "preregistered-client-id";
@@ -1362,34 +1407,15 @@ export const createDebugOAuthStateMachine = (
               authUrl.searchParams.set("resource", state.serverUrl);
             }
 
-            // Add scopes to request refresh tokens and other capabilities
-            // If custom scopes are provided, use them exclusively
-            if (customScopes) {
-              authUrl.searchParams.set("scope", customScopes);
-            } else {
-              // Otherwise, use automatic scope discovery
-              const scopesSupported =
+            const requestedScopeValue = resolveRequestedScopeValue({
+              customScopes,
+              challengedScopes: state.challengedScopes,
+              supportedScopes:
                 state.resourceMetadata?.scopes_supported ||
-                state.authorizationServerMetadata.scopes_supported;
-
-              // Build scope string following OAuth 2.1 best practices
-              const scopes = new Set<string>();
-
-              // 1. Add server-advertised scopes first (MCP-specific like tasks.read, read-mcp, etc.)
-              if (scopesSupported && scopesSupported.length > 0) {
-                scopesSupported.forEach((scope) => scopes.add(scope));
-              }
-
-              // 2. Request offline_access for refresh tokens ONLY if server supports it
-              // Per OAuth 2.1, this is required to get refresh tokens
-              if (scopesSupported?.includes("offline_access")) {
-                scopes.add("offline_access");
-              }
-
-              // Set scope parameter - use only scopes the server actually supports
-              if (scopes.size > 0) {
-                authUrl.searchParams.set("scope", Array.from(scopes).join(" "));
-              }
+                state.authorizationServerMetadata.scopes_supported,
+            });
+            if (requestedScopeValue) {
+              authUrl.searchParams.set("scope", requestedScopeValue);
             }
 
             // Add info log for Authorization URL
@@ -1782,19 +1808,13 @@ export const createDebugOAuthStateMachine = (
                 Accept: "application/json, text/event-stream",
                 "MCP-Protocol-Version": "2025-06-18",
               },
-              body: {
-                jsonrpc: "2.0",
-                method: "initialize",
-                params: {
-                  protocolVersion: "2025-06-18",
-                  capabilities: {},
-                  clientInfo: {
-                    name: "MCPJam Inspector",
-                    version: "1.0.0",
-                  },
-                },
+              body: buildInitializeRequestBody({
+                protocolVersion: initializeProtocolVersion,
+                authMode,
+                clientName: "MCPJam Inspector",
+                clientVersion: "1.0.0",
                 id: 2,
-              },
+              }),
             };
 
             // Add info log for authenticated initialize request
@@ -1846,19 +1866,15 @@ export const createDebugOAuthStateMachine = (
                   "Content-Type": "application/json",
                   Accept: "application/json, text/event-stream",
                 }),
-                body: JSON.stringify({
-                  jsonrpc: "2.0",
-                  method: "initialize",
-                  params: {
-                    protocolVersion: "2024-11-05",
-                    capabilities: {},
-                    clientInfo: {
-                      name: "MCPJam Inspector",
-                      version: "1.0.0",
-                    },
-                  },
-                  id: 2,
-                }),
+                body: JSON.stringify(
+                  buildInitializeRequestBody({
+                    protocolVersion: initializeProtocolVersion,
+                    authMode,
+                    clientName: "MCPJam Inspector",
+                    clientVersion: "1.0.0",
+                    id: 2,
+                  }),
+                ),
               });
 
               const mcpResponseData = {

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -593,6 +593,7 @@ export const createDebugOAuthStateMachine = (
                 updateState({
                   currentStep: "received_401_unauthorized", // Reuse the same flow
                   wwwAuthenticateHeader: undefined, // No WWW-Authenticate header
+                  challengedScopes: undefined,
                   lastResponse: responseData,
                   httpHistory: updatedHistory,
                   infoLogs,

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -1390,6 +1390,7 @@ export const createDebugOAuthStateMachine = (
                   lastResponse: registrationResponseData,
                   httpHistory: updatedHistoryReg,
                   error: registrationError,
+                  isInitiatingAuth: false,
                 });
 
                 if (strictConformance) {
@@ -1490,6 +1491,7 @@ export const createDebugOAuthStateMachine = (
                 lastResponse: errorResponse,
                 httpHistory: updatedHistoryError,
                 error: registrationError,
+                isInitiatingAuth: false,
               });
 
               if (strictConformance) {

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -38,6 +38,15 @@ import {
   buildResourceMetadataUrl,
   canonicalizeResourceUrl,
 } from "./shared/urls.js";
+import {
+  buildInitializeRequestBody,
+  resolveInitializeProtocolVersion,
+} from "./shared/initialize.js";
+import {
+  parseBearerAuthenticateParameters,
+  parseScopeString,
+  resolveRequestedScopeValue,
+} from "./shared/challenges.js";
 import { discoverOAuthProtectedResourceMetadata } from "@modelcontextprotocol/sdk/client/auth.js";
 
 export type { OAuthFlowStep, OAuthFlowState };
@@ -528,12 +537,15 @@ export const createDebugOAuthStateMachine = (
     clientIdMetadataUrl,
     customScopes,
     customHeaders,
+    authMode,
+    strictConformance = false,
     registrationStrategy = "cimd", // Default to CIMD for 2025-11-25
   } = config;
 
   // Canonicalize the server URL once at initialization (per RFC 8707)
   const canonicalServerUrl = canonicalizeResourceUrl(serverUrl);
   const redirectUri = redirectUrl;
+  const initializeProtocolVersion = resolveInitializeProtocolVersion("2025-11-25");
   const dynamicRegistrationDefaults = dynamicRegistration ?? {};
   let cimdClientId = clientIdMetadataUrl ?? "";
 
@@ -590,24 +602,19 @@ export const createDebugOAuthStateMachine = (
               "Content-Type": "application/json",
               Accept: "application/json, text/event-stream",
             });
+            const initializeRequestBody = buildInitializeRequestBody({
+              protocolVersion: initializeProtocolVersion,
+              authMode,
+              clientName: "MCPJam Inspector",
+              clientVersion: "1.0.0",
+              id: 1,
+            });
 
             const initialRequest = {
               method: "POST",
               url: serverUrl,
               headers: initialRequestHeaders,
-              body: {
-                jsonrpc: "2.0",
-                method: "initialize",
-                params: {
-                  protocolVersion: "2025-11-25",
-                  capabilities: {},
-                  clientInfo: {
-                    name: "MCPJam Inspector",
-                    version: "1.0.0",
-                  },
-                },
-                id: 1,
-              },
+              body: initializeRequestBody,
             };
 
             // Update state with the request
@@ -646,19 +653,15 @@ export const createDebugOAuthStateMachine = (
                   "Content-Type": "application/json",
                   Accept: "application/json, text/event-stream",
                 }),
-                body: JSON.stringify({
-                  jsonrpc: "2.0",
-                  method: "initialize",
-                  params: {
-                    protocolVersion: "2025-11-25",
-                    capabilities: {},
-                    clientInfo: {
-                      name: "MCPJam Inspector",
-                      version: "1.0.0",
-                    },
-                  },
-                  id: 1,
-                }),
+                body: JSON.stringify(
+                  buildInitializeRequestBody({
+                    protocolVersion: initializeProtocolVersion,
+                    authMode,
+                    clientName: "MCPJam Inspector",
+                    clientVersion: "1.0.0",
+                    id: 1,
+                  }),
+                ),
               });
 
               // Capture response data for all status codes
@@ -682,6 +685,12 @@ export const createDebugOAuthStateMachine = (
                 // Expected 401 response with WWW-Authenticate header
                 const wwwAuthenticateHeader =
                   response.headers["www-authenticate"];
+                const challengeParams = parseBearerAuthenticateParameters(
+                  wwwAuthenticateHeader,
+                );
+                const challengedScopes = parseScopeString(
+                  challengeParams.scope,
+                );
 
                 // Add info log for WWW-Authenticate header
                 const infoLogs = wwwAuthenticateHeader
@@ -692,6 +701,9 @@ export const createDebugOAuthStateMachine = (
                       "WWW-Authenticate Header",
                       {
                         header: wwwAuthenticateHeader,
+                        ...(challengedScopes && challengedScopes.length > 0
+                          ? { scope: challengedScopes.join(" ") }
+                          : {}),
                         "Received from": state.serverUrl || "Unknown",
                       }
                     )
@@ -700,6 +712,7 @@ export const createDebugOAuthStateMachine = (
                 updateState({
                   currentStep: "received_401_unauthorized",
                   wwwAuthenticateHeader: wwwAuthenticateHeader || undefined,
+                  challengedScopes,
                   lastResponse: responseData,
                   httpHistory: updatedHistory,
                   infoLogs,
@@ -746,18 +759,11 @@ export const createDebugOAuthStateMachine = (
 
           case "received_401_unauthorized":
             // Step 3: Extract resource metadata URL and prepare request
-            let extractedResourceMetadataUrl: string | undefined;
-
-            if (state.wwwAuthenticateHeader) {
-              // Parse WWW-Authenticate header to extract resource_metadata URL
-              // Format: Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"
-              const resourceMetadataMatch = state.wwwAuthenticateHeader.match(
-                /resource_metadata="([^"]+)"/
-              );
-              if (resourceMetadataMatch) {
-                extractedResourceMetadataUrl = resourceMetadataMatch[1];
-              }
-            }
+            const challengeParams = parseBearerAuthenticateParameters(
+              state.wwwAuthenticateHeader,
+            );
+            let extractedResourceMetadataUrl =
+              challengeParams.resource_metadata;
 
             // Fallback to building the URL if not found in header
             if (!extractedResourceMetadataUrl && state.serverUrl) {
@@ -1145,6 +1151,20 @@ export const createDebugOAuthStateMachine = (
             );
 
             if (!supportedMethods.includes("S256")) {
+              const s256Error =
+                "Authorization server metadata must advertise S256 in code_challenge_methods_supported for 2025-11-25 conformance.";
+
+              if (strictConformance) {
+                updateState({
+                  lastResponse: authServerResponseData,
+                  httpHistory: updatedHistoryFinal,
+                  infoLogs,
+                  error: s256Error,
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
+
               console.warn(
                 "Authorization server may not support S256 PKCE method. Supported methods:",
                 supportedMethods
@@ -1245,6 +1265,11 @@ export const createDebugOAuthStateMachine = (
               const scopesSupported =
                 state.resourceMetadata?.scopes_supported ||
                 state.authorizationServerMetadata.scopes_supported;
+              const requestedScopeValue = resolveRequestedScopeValue({
+                customScopes,
+                challengedScopes: state.challengedScopes,
+                supportedScopes: scopesSupported,
+              });
 
               const clientMetadata: Record<string, any> = {
                 ...dynamicRegistrationDefaults,
@@ -1262,8 +1287,8 @@ export const createDebugOAuthStateMachine = (
               };
 
               // Include scopes if supported by the server
-              if (scopesSupported && scopesSupported.length > 0) {
-                clientMetadata.scope = scopesSupported.join(" ");
+              if (requestedScopeValue) {
+                clientMetadata.scope = requestedScopeValue;
               }
 
               const registrationRequest = {
@@ -1295,6 +1320,15 @@ export const createDebugOAuthStateMachine = (
               autoAdvance(50);
               return;
             } else {
+              if (strictConformance) {
+                updateState({
+                  error:
+                    "Authorization server metadata does not include a registration_endpoint required for DCR conformance.",
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
+
               // No registration endpoint and DCR strategy - skip to PKCE generation with a mock client ID
               updateState({
                 currentStep: "generate_pkce_parameters",
@@ -1347,13 +1381,20 @@ export const createDebugOAuthStateMachine = (
 
               if (!response.ok) {
                 // Registration failed - could be server doesn't support DCR or request was invalid
+                const registrationError = strictConformance
+                  ? `Dynamic Client Registration failed (${response.status}).`
+                  : `Dynamic Client Registration failed (${response.status}). Using fallback client ID.`;
 
                 // Update state with error but continue with fallback
                 updateState({
                   lastResponse: registrationResponseData,
                   httpHistory: updatedHistoryReg,
-                  error: `Dynamic Client Registration failed (${response.status}). Using fallback client ID.`,
+                  error: registrationError,
                 });
+
+                if (strictConformance) {
+                  return;
+                }
 
                 // Fall back to mock client ID (simulating preregistered client)
                 const fallbackClientId = "preregistered-client-id";
@@ -1368,6 +1409,19 @@ export const createDebugOAuthStateMachine = (
               } else {
                 // Registration successful
                 const clientInfo = response.body;
+                if (
+                  strictConformance &&
+                  typeof clientInfo?.client_id !== "string"
+                ) {
+                  updateState({
+                    lastResponse: registrationResponseData,
+                    httpHistory: updatedHistoryReg,
+                    error:
+                      "Dynamic Client Registration response is missing a client_id.",
+                    isInitiatingAuth: false,
+                  });
+                  return;
+                }
 
                 // Add info log for DCR
                 const dcrInfo: Record<string, any> = {
@@ -1428,11 +1482,19 @@ export const createDebugOAuthStateMachine = (
                   Date.now() - (lastEntry.timestamp || Date.now());
               }
 
+              const registrationError = strictConformance
+                ? `Client registration failed: ${error instanceof Error ? error.message : String(error)}`
+                : `Client registration failed: ${error instanceof Error ? error.message : String(error)}. Using fallback.`;
+
               updateState({
                 lastResponse: errorResponse,
                 httpHistory: updatedHistoryError,
-                error: `Client registration failed: ${error instanceof Error ? error.message : String(error)}. Using fallback.`,
+                error: registrationError,
               });
+
+              if (strictConformance) {
+                return;
+              }
 
               // Fall back to mock client ID
               const fallbackClientId = "preregistered-client-id";
@@ -1616,29 +1678,15 @@ export const createDebugOAuthStateMachine = (
             authUrl.searchParams.set("state", state.state || "");
             authUrl.searchParams.set("resource", canonicalServerUrl);
 
-            // Add scopes to request refresh tokens and other capabilities
-            // If custom scopes are provided, use them exclusively
-            if (customScopes) {
-              authUrl.searchParams.set("scope", customScopes);
-            } else {
-              // Otherwise, use automatic scope discovery
-              const scopesSupported =
+            const requestedScopeValue = resolveRequestedScopeValue({
+              customScopes,
+              challengedScopes: state.challengedScopes,
+              supportedScopes:
                 state.resourceMetadata?.scopes_supported ||
-                state.authorizationServerMetadata.scopes_supported;
-
-              // Build scope string using only server-advertised scopes
-              const scopes = new Set<string>();
-
-              // Add all server-advertised scopes (MCP-specific, OIDC, or other)
-              // This ensures we only request scopes the server explicitly supports
-              if (scopesSupported && scopesSupported.length > 0) {
-                scopesSupported.forEach((scope) => scopes.add(scope));
-              }
-
-              // Set scope parameter - use only scopes the server actually supports
-              if (scopes.size > 0) {
-                authUrl.searchParams.set("scope", Array.from(scopes).join(" "));
-              }
+                state.authorizationServerMetadata.scopes_supported,
+            });
+            if (requestedScopeValue) {
+              authUrl.searchParams.set("scope", requestedScopeValue);
             }
 
             // Add info log for Authorization URL
@@ -2027,19 +2075,13 @@ export const createDebugOAuthStateMachine = (
                 Accept: "application/json, text/event-stream",
                 "MCP-Protocol-Version": "2025-11-25",
               },
-              body: {
-                jsonrpc: "2.0",
-                method: "initialize",
-                params: {
-                  protocolVersion: "2025-11-25",
-                  capabilities: {},
-                  clientInfo: {
-                    name: "MCPJam Inspector",
-                    version: "1.0.0",
-                  },
-                },
+              body: buildInitializeRequestBody({
+                protocolVersion: initializeProtocolVersion,
+                authMode,
+                clientName: "MCPJam Inspector",
+                clientVersion: "1.0.0",
                 id: 2,
-              },
+              }),
             };
 
             // Add info log for authenticated initialize request
@@ -2091,19 +2133,15 @@ export const createDebugOAuthStateMachine = (
                   "Content-Type": "application/json",
                   Accept: "application/json, text/event-stream",
                 }),
-                body: JSON.stringify({
-                  jsonrpc: "2.0",
-                  method: "initialize",
-                  params: {
-                    protocolVersion: "2025-11-25",
-                    capabilities: {},
-                    clientInfo: {
-                      name: "MCPJam Inspector",
-                      version: "1.0.0",
-                    },
-                  },
-                  id: 2,
-                }),
+                body: JSON.stringify(
+                  buildInitializeRequestBody({
+                    protocolVersion: initializeProtocolVersion,
+                    authMode,
+                    clientName: "MCPJam Inspector",
+                    clientVersion: "1.0.0",
+                    id: 2,
+                  }),
+                ),
               });
 
               const mcpResponseData = {

--- a/sdk/src/oauth/state-machines/shared/challenges.ts
+++ b/sdk/src/oauth/state-machines/shared/challenges.ts
@@ -1,0 +1,57 @@
+export function parseBearerAuthenticateParameters(
+  header?: string,
+): Record<string, string> {
+  if (!header) {
+    return {};
+  }
+
+  const match = header.trim().match(/^Bearer\s+(.+)$/i);
+  if (!match) {
+    return {};
+  }
+
+  const params: Record<string, string> = {};
+  const pattern = /([a-zA-Z_][a-zA-Z0-9_-]*)=(?:"([^"]*)"|([^,\s]+))/g;
+
+  for (let next = pattern.exec(match[1]); next; next = pattern.exec(match[1])) {
+    params[next[1].toLowerCase()] = next[2] ?? next[3] ?? "";
+  }
+
+  return params;
+}
+
+export function parseScopeString(scopeValue?: string): string[] | undefined {
+  if (!scopeValue) {
+    return undefined;
+  }
+
+  const scopes = scopeValue
+    .split(/\s+/)
+    .map((scope) => scope.trim())
+    .filter(Boolean);
+
+  return scopes.length > 0 ? Array.from(new Set(scopes)) : undefined;
+}
+
+export function resolveRequestedScopeValue(input: {
+  customScopes?: string;
+  challengedScopes?: string[];
+  supportedScopes?: string[];
+}): string | undefined {
+  const customScopes = input.customScopes?.trim();
+  if (customScopes) {
+    return customScopes;
+  }
+
+  const challengedScopes = input.challengedScopes?.filter(Boolean) ?? [];
+  if (challengedScopes.length > 0) {
+    return Array.from(new Set(challengedScopes)).join(" ");
+  }
+
+  const supportedScopes = input.supportedScopes?.filter(Boolean) ?? [];
+  if (supportedScopes.length === 0) {
+    return undefined;
+  }
+
+  return Array.from(new Set(supportedScopes)).join(" ");
+}

--- a/sdk/src/oauth/state-machines/shared/initialize.ts
+++ b/sdk/src/oauth/state-machines/shared/initialize.ts
@@ -1,0 +1,54 @@
+import type { OAuthAuthMode, OAuthProtocolVersion } from "../types.js";
+
+export const MCP_OAUTH_CLIENT_CREDENTIALS_EXTENSION =
+  "io.modelcontextprotocol/oauth-client-credentials";
+
+export function resolveInitializeProtocolVersion(
+  protocolVersion: OAuthProtocolVersion,
+): string {
+  switch (protocolVersion) {
+    case "2025-11-25":
+      return "2025-11-25";
+    case "2025-06-18":
+    case "2025-03-26":
+      return "2024-11-05";
+    default:
+      return protocolVersion;
+  }
+}
+
+export function buildInitializeCapabilities(
+  authMode?: OAuthAuthMode,
+): Record<string, unknown> {
+  if (authMode !== "client_credentials") {
+    return {};
+  }
+
+  return {
+    extensions: {
+      [MCP_OAUTH_CLIENT_CREDENTIALS_EXTENSION]: {},
+    },
+  };
+}
+
+export function buildInitializeRequestBody(input: {
+  protocolVersion: string;
+  authMode?: OAuthAuthMode;
+  clientName: string;
+  clientVersion: string;
+  id: number;
+}): Record<string, unknown> {
+  return {
+    jsonrpc: "2.0",
+    method: "initialize",
+    params: {
+      protocolVersion: input.protocolVersion,
+      capabilities: buildInitializeCapabilities(input.authMode),
+      clientInfo: {
+        name: input.clientName,
+        version: input.clientVersion,
+      },
+    },
+    id: input.id,
+  };
+}

--- a/sdk/src/oauth/state-machines/types.ts
+++ b/sdk/src/oauth/state-machines/types.ts
@@ -4,6 +4,11 @@
 
 export type MaybePromise<T> = T | Promise<T>;
 
+export type OAuthAuthMode =
+  | "interactive"
+  | "headless"
+  | "client_credentials";
+
 // OAuth flow steps based on MCP specification
 export type OAuthFlowStep =
   | "idle"
@@ -39,6 +44,7 @@ export interface OAuthFlowState {
   // Data collected during the flow
   serverUrl?: string;
   wwwAuthenticateHeader?: string;
+  challengedScopes?: string[];
   resourceMetadataUrl?: string;
   resourceMetadata?: {
     resource: string;
@@ -212,6 +218,8 @@ export interface BaseOAuthStateMachineConfig {
   clientIdMetadataUrl?: string;
   customScopes?: string;
   customHeaders?: Record<string, string>;
+  authMode?: OAuthAuthMode;
+  strictConformance?: boolean;
 }
 
 // Registration strategies

--- a/sdk/tests/apps-conformance/runner.test.ts
+++ b/sdk/tests/apps-conformance/runner.test.ts
@@ -2,6 +2,7 @@ import {
   MCP_APPS_CHECK_IDS,
   MCPAppsConformanceTest,
 } from "../../src/apps-conformance/index.js";
+import * as operations from "../../src/operations.js";
 import {
   CONFORMANCE_UI_RESOURCE_URI,
   startConformanceMockServer,
@@ -60,6 +61,112 @@ describe("MCPAppsConformanceTest", () => {
       });
     } finally {
       await mockServer.stop();
+    }
+  });
+
+  it("surfaces one failed check when the MCP server connection cannot be established", async () => {
+    const withEphemeralClientSpy = jest
+      .spyOn(operations, "withEphemeralClient")
+      .mockRejectedValue(new Error("connection refused"));
+
+    try {
+      const test = new MCPAppsConformanceTest({
+        url: "https://example.com/mcp",
+        timeout: 10_000,
+        checkIds: ["ui-resources-readable", "ui-resource-meta-valid"],
+      });
+
+      const result = await test.run();
+
+      expect(result.passed).toBe(false);
+      expect(result.checks).toEqual([
+        expect.objectContaining({
+          id: "ui-resources-readable",
+          status: "failed",
+          error: expect.objectContaining({
+            message: "connection refused",
+          }),
+        }),
+        expect.objectContaining({
+          id: "ui-resource-meta-valid",
+          status: "skipped",
+        }),
+      ]);
+    } finally {
+      withEphemeralClientSpy.mockRestore();
+    }
+  });
+
+  it("fails when resources/read returns more than one HTML payload for a UI resource", async () => {
+    const withEphemeralClientSpy = jest
+      .spyOn(operations, "withEphemeralClient")
+      .mockImplementation(async (_config, fn) => {
+        const mockManager = {
+          listTools: jest.fn().mockResolvedValue({
+            tools: [
+              {
+                name: "ui_tool",
+                inputSchema: { type: "object" },
+                _meta: {
+                  ui: {
+                    resourceUri: CONFORMANCE_UI_RESOURCE_URI,
+                  },
+                },
+              },
+            ],
+          }),
+          listResources: jest.fn().mockResolvedValue({
+            resources: [
+              {
+                name: "UI Dashboard",
+                uri: CONFORMANCE_UI_RESOURCE_URI,
+                mimeType: "text/html;profile=mcp-app",
+              },
+            ],
+          }),
+          readResource: jest.fn().mockResolvedValue({
+            contents: [
+              {
+                uri: CONFORMANCE_UI_RESOURCE_URI,
+                mimeType: "text/html;profile=mcp-app",
+                text: "<!DOCTYPE html><html><body>First</body></html>",
+              },
+              {
+                uri: CONFORMANCE_UI_RESOURCE_URI,
+                mimeType: "text/html;profile=mcp-app",
+                text: "<!DOCTYPE html><html><body>Second</body></html>",
+              },
+            ],
+          }),
+        } as any;
+
+        return fn(mockManager, "__apps_conformance__");
+      });
+
+    try {
+      const test = new MCPAppsConformanceTest({
+        url: "https://example.com/mcp",
+        timeout: 10_000,
+        checkIds: ["ui-resource-contents-valid"],
+      });
+
+      const result = await test.run();
+
+      expect(result.passed).toBe(false);
+      expect(result.checks).toHaveLength(1);
+      expect(result.checks[0]).toEqual(
+        expect.objectContaining({
+          id: "ui-resource-contents-valid",
+          status: "failed",
+          details: expect.objectContaining({
+            violations: [
+              `${CONFORMANCE_UI_RESOURCE_URI} must return exactly one content entry from resources/read (got 2)`,
+            ],
+          }),
+        }),
+      );
+    } finally {
+      withEphemeralClientSpy.mockRestore();
     }
   });
 });

--- a/sdk/tests/apps-conformance/runner.test.ts
+++ b/sdk/tests/apps-conformance/runner.test.ts
@@ -22,7 +22,7 @@ describe("MCPAppsConformanceTest", () => {
       expect(result.passed).toBe(true);
       expect(result.checks).toHaveLength(MCP_APPS_CHECK_IDS.length);
       expect(result.checks.every((check) => check.status === "passed")).toBe(true);
-      expect(result.categorySummary.tools.passed).toBe(2);
+      expect(result.categorySummary.tools.passed).toBe(3);
       expect(result.categorySummary.resources.passed).toBe(4);
       expect(result.discovery.uiToolCount).toBe(1);
       expect(result.discovery.listedUiResourceCount).toBe(1);
@@ -52,6 +52,7 @@ describe("MCPAppsConformanceTest", () => {
       expect(statuses).toEqual({
         "ui-tools-present": "passed",
         "ui-tool-metadata-valid": "passed",
+        "ui-tool-input-schema-valid": "passed",
         "ui-listed-resources-valid": "skipped",
         "ui-resources-readable": "failed",
         "ui-resource-contents-valid": "skipped",

--- a/sdk/tests/apps-conformance/runner.test.ts
+++ b/sdk/tests/apps-conformance/runner.test.ts
@@ -1,0 +1,64 @@
+import {
+  MCP_APPS_CHECK_IDS,
+  MCPAppsConformanceTest,
+} from "../../src/apps-conformance/index.js";
+import {
+  CONFORMANCE_UI_RESOURCE_URI,
+  startConformanceMockServer,
+} from "../mock-servers/conformance-mcp-server.js";
+
+describe("MCPAppsConformanceTest", () => {
+  it("passes the full apps conformance suite against the dedicated mock server", async () => {
+    const mockServer = await startConformanceMockServer();
+
+    try {
+      const test = new MCPAppsConformanceTest({
+        url: mockServer.url,
+        timeout: 10_000,
+      });
+
+      const result = await test.run();
+
+      expect(result.passed).toBe(true);
+      expect(result.checks).toHaveLength(MCP_APPS_CHECK_IDS.length);
+      expect(result.checks.every((check) => check.status === "passed")).toBe(true);
+      expect(result.categorySummary.tools.passed).toBe(2);
+      expect(result.categorySummary.resources.passed).toBe(4);
+      expect(result.discovery.uiToolCount).toBe(1);
+      expect(result.discovery.listedUiResourceCount).toBe(1);
+      expect(result.discovery.checkedUiResourceCount).toBe(1);
+    } finally {
+      await mockServer.stop();
+    }
+  });
+
+  it("fails when a UI tool references a resource that cannot be read", async () => {
+    const mockServer = await startConformanceMockServer({
+      omitResources: [CONFORMANCE_UI_RESOURCE_URI],
+    });
+
+    try {
+      const test = new MCPAppsConformanceTest({
+        url: mockServer.url,
+        timeout: 10_000,
+      });
+
+      const result = await test.run();
+      const statuses = Object.fromEntries(
+        result.checks.map((check) => [check.id, check.status]),
+      );
+
+      expect(result.passed).toBe(false);
+      expect(statuses).toEqual({
+        "ui-tools-present": "passed",
+        "ui-tool-metadata-valid": "passed",
+        "ui-listed-resources-valid": "skipped",
+        "ui-resources-readable": "failed",
+        "ui-resource-contents-valid": "skipped",
+        "ui-resource-meta-valid": "skipped",
+      });
+    } finally {
+      await mockServer.stop();
+    }
+  });
+});

--- a/sdk/tests/apps-conformance/validation.test.ts
+++ b/sdk/tests/apps-conformance/validation.test.ts
@@ -1,0 +1,35 @@
+import {
+  MCP_UI_EXTENSION_ID,
+  MCP_UI_RESOURCE_MIME_TYPE,
+} from "../../src/mcp-client-manager/index.js";
+import { normalizeMCPAppsConformanceConfig } from "../../src/apps-conformance/validation.js";
+
+describe("normalizeMCPAppsConformanceConfig", () => {
+  it("forces the MCP Apps UI capability even when clientCapabilities clears extensions", () => {
+    const normalized = normalizeMCPAppsConformanceConfig({
+      command: "echo",
+      clientCapabilities: {
+        extensions: {},
+        experimental: {
+          customClient: {},
+        },
+      } as any,
+    });
+
+    expect(normalized.serverConfig.clientCapabilities).toMatchObject({
+      experimental: {
+        customClient: {},
+      },
+      elicitation: {},
+    });
+    expect(
+      (
+        normalized.serverConfig.clientCapabilities as Record<string, unknown>
+      ).extensions,
+    ).toEqual({
+      [MCP_UI_EXTENSION_ID]: {
+        mimeTypes: [MCP_UI_RESOURCE_MIME_TYPE],
+      },
+    });
+  });
+});

--- a/sdk/tests/mock-servers/conformance-mcp-server.ts
+++ b/sdk/tests/mock-servers/conformance-mcp-server.ts
@@ -15,6 +15,9 @@ import { z } from "zod";
 
 const TEST_IMAGE_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==";
+export const CONFORMANCE_UI_TOOL_NAME = "test_ui_dashboard";
+export const CONFORMANCE_UI_RESOURCE_URI = "ui://test/dashboard";
+const CONFORMANCE_UI_RESOURCE_MIME_TYPE = "text/html;profile=mcp-app";
 
 type ConformanceServerOptions = {
   omitTools?: string[];
@@ -442,6 +445,41 @@ function createMcpServer(
     );
   }
 
+  if (!omittedTools.has(CONFORMANCE_UI_TOOL_NAME)) {
+    server.registerTool(
+      CONFORMANCE_UI_TOOL_NAME,
+      {
+        description: shouldOmitDescription(
+          options.omitToolDescriptions,
+          CONFORMANCE_UI_TOOL_NAME,
+        )
+          ? undefined
+          : "Returns dashboard data and advertises an MCP Apps HTML resource.",
+        inputSchema: {},
+        _meta: {
+          ui: {
+            resourceUri: CONFORMANCE_UI_RESOURCE_URI,
+            visibility: ["model", "app"],
+          },
+        },
+      },
+      async () => ({
+        content: [
+          {
+            type: "text",
+            text: "Dashboard ready.",
+          },
+        ],
+        structuredContent: {
+          status: "ready",
+          cards: [
+            { id: "summary", label: "Summary", value: 42 },
+          ],
+        },
+      }),
+    );
+  }
+
   if (!omittedResources.has("test://static-binary")) {
     server.registerResource(
       "static-binary",
@@ -505,6 +543,54 @@ function createMcpServer(
             uri: "test://watched-resource",
             mimeType: "text/plain",
             text: watchedResourceContent,
+          },
+        ],
+      }),
+    );
+  }
+
+  if (!omittedResources.has(CONFORMANCE_UI_RESOURCE_URI)) {
+    server.registerResource(
+      "ui-dashboard",
+      CONFORMANCE_UI_RESOURCE_URI,
+      {
+        title: "UI Dashboard",
+        description: "An MCP Apps HTML resource for conformance testing.",
+        mimeType: CONFORMANCE_UI_RESOURCE_MIME_TYPE,
+      },
+      async () => ({
+        contents: [
+          {
+            uri: CONFORMANCE_UI_RESOURCE_URI,
+            mimeType: CONFORMANCE_UI_RESOURCE_MIME_TYPE,
+            text: [
+              "<!DOCTYPE html>",
+              '<html lang="en">',
+              "<head>",
+              '  <meta charset="utf-8" />',
+              "  <title>Conformance Dashboard</title>",
+              "</head>",
+              "<body>",
+              '  <main id="app">MCP Apps conformance dashboard</main>',
+              "</body>",
+              "</html>",
+            ].join("\n"),
+            _meta: {
+              ui: {
+                csp: {
+                  connectDomains: ["https://api.example.com"],
+                  resourceDomains: ["https://cdn.example.com"],
+                  frameDomains: ["https://frames.example.com"],
+                  baseUriDomains: ["https://assets.example.com"],
+                },
+                permissions: {
+                  geolocation: {},
+                  clipboardWrite: {},
+                },
+                domain: "conformance-dashboard.oaiusercontent.test",
+                prefersBorder: true,
+              },
+            },
           },
         ],
       }),

--- a/sdk/tests/oauth-conformance/checks.test.ts
+++ b/sdk/tests/oauth-conformance/checks.test.ts
@@ -1,6 +1,8 @@
 import {
   runDcrHttpRedirectUriCheck,
+  runInvalidAuthorizeRedirectCheck,
   runInvalidClientCheck,
+  runInvalidTokenCheck,
   runInvalidRedirectCheck,
 } from "../../src/oauth-conformance/checks/oauth-negative.js";
 import { runTokenFormatCheck } from "../../src/oauth-conformance/checks/oauth-token-format.js";
@@ -8,6 +10,7 @@ import { runTokenFormatCheck } from "../../src/oauth-conformance/checks/oauth-to
 const baseNegativeInput = {
   config: {
     serverUrl: "https://mcp.example.com",
+    protocolVersion: "2025-11-25",
     auth: { mode: "headless" },
   },
   state: {
@@ -58,6 +61,200 @@ describe("oauth conformance unit checks", () => {
             url: "https://auth.example.com/token",
           }),
         }),
+      },
+    });
+  });
+
+  it("includes resource in authorization_code invalid-client checks", async () => {
+    const trackedRequest = jest.fn().mockImplementation(async (request) => {
+      expect(request.body).toMatchObject({
+        grant_type: "authorization_code",
+        client_id: "invalid-client-id",
+        code: "auth-code",
+        redirect_uri: "http://127.0.0.1:3333/callback",
+        resource: "https://mcp.example.com/",
+      });
+
+      return {
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        body: {
+          error: "invalid_client",
+        },
+      };
+    });
+
+    const result = await runInvalidClientCheck({
+      ...(baseNegativeInput as any),
+      trackedRequest,
+    });
+
+    expect(result).toMatchObject({
+      step: "oauth_invalid_client",
+      status: "passed",
+    });
+  });
+
+  it("includes resource in authorization_code invalid-redirect checks", async () => {
+    const trackedRequest = jest.fn().mockImplementation(async (request) => {
+      expect(request.body).toMatchObject({
+        grant_type: "authorization_code",
+        code: "auth-code",
+        redirect_uri: "http://127.0.0.1:3333/callback?invalid=1",
+        resource: "https://mcp.example.com/",
+      });
+
+      return {
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        body: {
+          error: "invalid_request",
+          error_description: "redirect_uri mismatch",
+        },
+      };
+    });
+
+    const result = await runInvalidRedirectCheck({
+      ...(baseNegativeInput as any),
+      trackedRequest,
+    });
+
+    expect(result).toMatchObject({
+      step: "oauth_invalid_redirect",
+      status: "passed",
+    });
+  });
+
+  it("passes when the MCP server rejects an invalid bearer token with HTTP 401", async () => {
+    const result = await runInvalidTokenCheck({
+      ...(baseNegativeInput as any),
+      trackedRequest: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: "Unauthorized",
+        body: {
+          error: "invalid_token",
+        },
+      }),
+    });
+
+    expect(result).toMatchObject({
+      step: "oauth_invalid_token",
+      status: "passed",
+    });
+  });
+
+  it("passes when the authorization endpoint rejects a mismatched redirect_uri", async () => {
+    const result = await runInvalidAuthorizeRedirectCheck({
+      ...(baseNegativeInput as any),
+      state: {
+        clientId: "registered-client",
+        codeChallenge: "test-code-challenge",
+        authorizationServerMetadata: {
+          authorization_endpoint: "https://auth.example.com/authorize",
+        },
+      },
+      trackedRequest: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        body: {
+          error: "invalid_request",
+          error_description: "redirect_uri mismatch",
+        },
+      }),
+    });
+
+    expect(result).toMatchObject({
+      step: "oauth_invalid_authorize_redirect",
+      status: "passed",
+    });
+  });
+
+  it("skips authorization-endpoint redirect validation when the rejection is unrelated", async () => {
+    const result = await runInvalidAuthorizeRedirectCheck({
+      ...(baseNegativeInput as any),
+      state: {
+        clientId: "registered-client",
+        codeChallenge: "test-code-challenge",
+        authorizationServerMetadata: {
+          authorization_endpoint: "https://auth.example.com/authorize",
+        },
+      },
+      trackedRequest: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        body: {
+          error: "invalid_scope",
+          error_description: "Client is not allowed to request this scope",
+        },
+      }),
+    });
+
+    expect(result).toMatchObject({
+      step: "oauth_invalid_authorize_redirect",
+      status: "skipped",
+      error: {
+        message:
+          "Authorization request was rejected for a non-redirect reason: Client is not allowed to request this scope",
+      },
+    });
+  });
+
+  it("fails when the authorization endpoint redirects to an invalid redirect_uri", async () => {
+    const result = await runInvalidAuthorizeRedirectCheck({
+      ...(baseNegativeInput as any),
+      state: {
+        clientId: "registered-client",
+        codeChallenge: "test-code-challenge",
+        authorizationServerMetadata: {
+          authorization_endpoint: "https://auth.example.com/authorize",
+        },
+      },
+      trackedRequest: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 302,
+        statusText: "Found",
+        headers: {
+          location: "http://127.0.0.1:3333/callback?invalid=1&error=invalid_request",
+        },
+        body: undefined,
+      }),
+    });
+
+    expect(result).toMatchObject({
+      step: "oauth_invalid_authorize_redirect",
+      status: "failed",
+      error: {
+        message: expect.stringContaining("redirected the user agent"),
+      },
+    });
+  });
+
+  it("fails when the MCP server accepts an invalid bearer token", async () => {
+    const result = await runInvalidTokenCheck({
+      ...(baseNegativeInput as any),
+      trackedRequest: jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        body: {
+          jsonrpc: "2.0",
+          result: {},
+        },
+      }),
+    });
+
+    expect(result).toMatchObject({
+      step: "oauth_invalid_token",
+      status: "failed",
+      error: {
+        message: expect.stringContaining("expected HTTP 401"),
       },
     });
   });

--- a/sdk/tests/oauth-conformance/checks.test.ts
+++ b/sdk/tests/oauth-conformance/checks.test.ts
@@ -1,4 +1,5 @@
 import {
+  runDcrHttpRedirectUriCheck,
   runInvalidClientCheck,
   runInvalidRedirectCheck,
 } from "../../src/oauth-conformance/checks/oauth-negative.js";
@@ -56,6 +57,67 @@ describe("oauth conformance unit checks", () => {
             method: "POST",
             url: "https://auth.example.com/token",
           }),
+        }),
+      },
+    });
+  });
+
+  it("fails when dynamic client registration accepts a non-loopback http redirect URI", async () => {
+    const result = await runDcrHttpRedirectUriCheck({
+      ...(baseNegativeInput as any),
+      state: {
+        authorizationServerMetadata: {
+          registration_endpoint: "https://auth.example.com/register",
+        },
+      },
+      trackedRequest: jest.fn().mockResolvedValue({
+        ok: true,
+        status: 201,
+        statusText: "Created",
+        body: {
+          client_id: "evil-client",
+          redirect_uris: ["http://evil.example/callback"],
+        },
+      }),
+    });
+
+    expect(result).toMatchObject({
+      step: "oauth_dcr_http_redirect_uri",
+      status: "failed",
+      error: {
+        message:
+          "Authorization server accepted a non-loopback http redirect_uri during dynamic client registration",
+        details: expect.objectContaining({
+          redirectUri: "http://evil.example/callback",
+          clientId: "evil-client",
+        }),
+      },
+    });
+  });
+
+  it("skips redirect validation when the token rejection is not redirect-specific", async () => {
+    const result = await runInvalidRedirectCheck({
+      ...(baseNegativeInput as any),
+      trackedRequest: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        body: {
+          error: "invalid_grant",
+          error_description: "Authorization code already used",
+        },
+      }),
+    });
+
+    expect(result).toMatchObject({
+      step: "oauth_invalid_redirect",
+      status: "skipped",
+      error: {
+        message:
+          "Token request was rejected for a non-redirect reason: Authorization code already used",
+        details: expect.objectContaining({
+          evidence:
+            "Received 400 Bad Request with Authorization code already used.",
         }),
       },
     });

--- a/sdk/tests/oauth-conformance/checks.test.ts
+++ b/sdk/tests/oauth-conformance/checks.test.ts
@@ -292,6 +292,40 @@ describe("oauth conformance unit checks", () => {
     });
   });
 
+  it("skips DCR redirect validation when the rejection is not redirect-specific", async () => {
+    const result = await runDcrHttpRedirectUriCheck({
+      ...(baseNegativeInput as any),
+      state: {
+        authorizationServerMetadata: {
+          registration_endpoint: "https://auth.example.com/register",
+        },
+      },
+      trackedRequest: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        body: {
+          error: "invalid_scope",
+          error_description: "Client is not allowed to request this scope",
+        },
+      }),
+    });
+
+    expect(result).toMatchObject({
+      step: "oauth_dcr_http_redirect_uri",
+      status: "skipped",
+      error: {
+        message:
+          "Dynamic client registration was rejected for a non-redirect reason: Client is not allowed to request this scope",
+        details: expect.objectContaining({
+          redirectUri: "http://evil.example/callback",
+          evidence:
+            "Received 400 Bad Request with Client is not allowed to request this scope.",
+        }),
+      },
+    });
+  });
+
   it("skips redirect validation when the token rejection is not redirect-specific", async () => {
     const result = await runInvalidRedirectCheck({
       ...(baseNegativeInput as any),

--- a/sdk/tests/oauth-conformance/formatter.test.ts
+++ b/sdk/tests/oauth-conformance/formatter.test.ts
@@ -243,6 +243,44 @@ describe("OAuth conformance human formatter", () => {
       "Evidence: Registered redirect_uri http://evil.example/callback was accepted and returned client_id evil-client.",
     );
   });
+
+  it("redacts sensitive values before printing evidence", () => {
+    const result = createPassingResult({
+      passed: false,
+      steps: [
+        {
+          step: "oauth_invalid_redirect",
+          title: "OAuth Check: Invalid Redirect",
+          summary: "Verify redirect URI validation.",
+          status: "failed",
+          durationMs: 12,
+          logs: [],
+          httpAttempts: [],
+          error: {
+            message: "Invalid redirect was accepted",
+            details: {
+              evidence:
+                'Authorization: Bearer tok /?code=abc&access_token=xyz {"client_secret":"shh","refresh_token":"ref"}',
+            },
+          },
+        },
+      ],
+      summary: "OAuth conformance failed at oauth_invalid_redirect",
+    });
+
+    const output = formatOAuthConformanceHuman(result);
+
+    expect(output).toContain("Authorization: Bearer [REDACTED]");
+    expect(output).toContain("code=[REDACTED]");
+    expect(output).toContain("access_token=[REDACTED]");
+    expect(output).toContain('"client_secret":"[REDACTED]"');
+    expect(output).toContain('"refresh_token":"[REDACTED]"');
+    expect(output).not.toContain("Bearer tok");
+    expect(output).not.toContain("code=abc");
+    expect(output).not.toContain("access_token=xyz");
+    expect(output).not.toContain('"client_secret":"shh"');
+    expect(output).not.toContain('"refresh_token":"ref"');
+  });
 });
 
 describe("OAuth conformance suite human formatter", () => {

--- a/sdk/tests/oauth-conformance/formatter.test.ts
+++ b/sdk/tests/oauth-conformance/formatter.test.ts
@@ -208,6 +208,41 @@ describe("OAuth conformance human formatter", () => {
     expect(output).toContain("listTools: PASS (7 tools)");
     expect(output).not.toContain("—");
   });
+
+  it("prints a compact evidence line for failed OAuth checks", () => {
+    const result = createPassingResult({
+      passed: false,
+      steps: [
+        {
+          step: "oauth_dcr_http_redirect_uri",
+          title: "OAuth Check: DCR Redirect URI Policy",
+          summary:
+            "Attempt dynamic client registration with a non-loopback http redirect URI and confirm the authorization server rejects it.",
+          status: "failed",
+          durationMs: 18,
+          logs: [],
+          httpAttempts: [],
+          error: {
+            message:
+              "Authorization server accepted a non-loopback http redirect_uri during dynamic client registration",
+            details: {
+              evidence:
+                "Registered redirect_uri http://evil.example/callback was accepted and returned client_id evil-client.",
+            },
+          },
+        },
+      ],
+      summary:
+        "OAuth conformance failed at oauth_dcr_http_redirect_uri: Authorization server accepted a non-loopback http redirect_uri during dynamic client registration",
+    });
+
+    const output = formatOAuthConformanceHuman(result);
+
+    expect(output).toContain("Step: oauth_dcr_http_redirect_uri");
+    expect(output).toContain(
+      "Evidence: Registered redirect_uri http://evil.example/callback was accepted and returned client_id evil-client.",
+    );
+  });
 });
 
 describe("OAuth conformance suite human formatter", () => {

--- a/sdk/tests/oauth-conformance/interactive.test.ts
+++ b/sdk/tests/oauth-conformance/interactive.test.ts
@@ -24,9 +24,15 @@ describe("interactive authorization session", () => {
         expectedState: "expected-state",
         timeoutMs: 2_000,
         openUrl: async () => {
-          await fetch(
-            `${session.redirectUrl}?code=test-code&state=expected-state`,
+          const response = await fetch(
+            `${session.redirectUrl}?code=test-code&state=expected-state`
           );
+          expect(response.status).toBe(200);
+          expect(response.headers.get("content-type")).toContain("text/html");
+
+          const html = await response.text();
+          expect(html).toContain("Authorization complete");
+          expect(html).toContain("Return to the terminal to continue.");
         },
       });
 
@@ -44,14 +50,21 @@ describe("interactive authorization session", () => {
         authorizationUrl: "https://auth.example.com/authorize",
         timeoutMs: 10_000,
         openUrl: async () => {
-          await fetch(
-            `${session.redirectUrl}?error=access_denied&error_description=User+rejected+access`,
+          const response = await fetch(
+            `${session.redirectUrl}?error=access_denied&error_description=User+rejected+%3Caccess%3E`
           );
+          expect(response.status).toBe(400);
+          expect(response.headers.get("content-type")).toContain("text/html");
+
+          const html = await response.text();
+          expect(html).toContain("Authorization failed");
+          expect(html).toContain("Return to the terminal for details.");
+          expect(html).toContain("access_denied: User rejected &lt;access&gt;");
         },
       });
 
       await expect(resultPromise).rejects.toThrow(
-        /access_denied: User rejected access/,
+        /access_denied: User rejected <access>/
       );
     } finally {
       await session.stop().catch(() => undefined);
@@ -66,12 +79,20 @@ describe("interactive authorization session", () => {
         authorizationUrl: "https://auth.example.com/authorize",
         timeoutMs: 10_000,
         openUrl: async () => {
-          await fetch(`${session.redirectUrl}?state=no-code`);
+          const response = await fetch(`${session.redirectUrl}?state=no-code`);
+          expect(response.status).toBe(400);
+          expect(response.headers.get("content-type")).toContain("text/html");
+
+          const html = await response.text();
+          expect(html).toContain("Authorization incomplete");
+          expect(html).toContain(
+            "No authorization code was included in the callback."
+          );
         },
       });
 
       await expect(resultPromise).rejects.toThrow(
-        /without a code or error parameter/,
+        /without a code or error parameter/
       );
     } finally {
       await session.stop().catch(() => undefined);

--- a/sdk/tests/oauth-conformance/interactive.test.ts
+++ b/sdk/tests/oauth-conformance/interactive.test.ts
@@ -124,6 +124,36 @@ describe("interactive authorization session", () => {
     }
   });
 
+  it("returns an error page when the callback state does not match", async () => {
+    const session = await createInteractiveAuthorizationSession();
+
+    try {
+      const resultPromise = session.authorize({
+        authorizationUrl: "https://auth.example.com/authorize",
+        expectedState: "expected-state",
+        timeoutMs: 10_000,
+        openUrl: async () => {
+          const response = await fetch(
+            `${session.redirectUrl}?code=test-code&state=wrong-state`
+          );
+          expect(response.status).toBe(400);
+          expect(response.headers.get("content-type")).toContain("text/html");
+
+          const html = await response.text();
+          expect(html).toContain("Authorization failed");
+          expect(html).toContain("Authorization state mismatch.");
+          expect(html).not.toContain("Authorization complete");
+        },
+      });
+
+      await expect(resultPromise).rejects.toThrow(
+        /Authorization state mismatch/
+      );
+    } finally {
+      await session.stop().catch(() => undefined);
+    }
+  });
+
   it("opens the browser with a node-native system command", async () => {
     const child = new EventEmitter() as EventEmitter & {
       unref: jest.Mock;

--- a/sdk/tests/oauth-conformance/runner.test.ts
+++ b/sdk/tests/oauth-conformance/runner.test.ts
@@ -1,5 +1,6 @@
 import { OAuthConformanceTest } from "../../src/oauth-conformance/index.js";
 import { DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL } from "../../src/oauth/client-identity.js";
+import { MCP_OAUTH_CLIENT_CREDENTIALS_EXTENSION } from "../../src/oauth/state-machines/shared/initialize.js";
 import * as operations from "../../src/operations.js";
 
 function jsonResponse(
@@ -219,10 +220,15 @@ describe("OAuthConformanceTest", () => {
     const resourceMetadataUrl =
       "https://mcp.example.com/.well-known/oauth-protected-resource/mcp";
     const authServerUrl = "https://auth.example.com";
+    const initializeRequests: Array<Record<string, any>> = [];
 
     const fetchFn: typeof fetch = jest.fn(async (input, init) => {
       const url = String(input);
       const headers = new Headers(init?.headers);
+
+      if (url === serverUrl && init?.body) {
+        initializeRequests.push(JSON.parse(String(init.body)) as Record<string, any>);
+      }
 
       if (url === serverUrl && !headers.get("Authorization")) {
         return new Response(null, {
@@ -310,6 +316,20 @@ describe("OAuthConformanceTest", () => {
     expect(
       result.steps.find((step) => step.step === "token_request")?.httpAttempts,
     ).toHaveLength(1);
+    expect(initializeRequests).toHaveLength(2);
+    for (const requestBody of initializeRequests) {
+      expect(requestBody).toMatchObject({
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {
+            extensions: {
+              [MCP_OAUTH_CLIENT_CREDENTIALS_EXTENSION]: {},
+            },
+          },
+        },
+      });
+    }
   });
 
   it("fails client_credentials runs when DCR returns a public client", async () => {
@@ -576,6 +596,19 @@ describe("OAuthConformanceTest", () => {
         return jsonResponse({ error: "invalid_redirect_uri" }, 400);
       }
 
+      if (url.startsWith(`${authServerUrl}/authorize?`)) {
+        const redirectUri = new URL(url).searchParams.get("redirect_uri");
+        if (redirectUri?.includes("invalid=1")) {
+          return jsonResponse(
+            {
+              error: "invalid_request",
+              error_description: "redirect_uri mismatch",
+            },
+            400,
+          );
+        }
+      }
+
       if (url === DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL) {
         return jsonResponse({
           client_id: DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
@@ -606,6 +639,13 @@ describe("OAuthConformanceTest", () => {
           token_type: "Bearer",
           expires_in: 3600,
         });
+      }
+
+      if (
+        url === serverUrl &&
+        headers.get("Authorization") === "Bearer invalid-access-token"
+      ) {
+        return jsonResponse({ error: "invalid_token" }, 401);
       }
 
       if (url === serverUrl && headers.get("Authorization") === "Bearer access-token") {
@@ -641,8 +681,226 @@ describe("OAuthConformanceTest", () => {
     expect(tokenBodies).toHaveLength(3);
     expect(statuses.oauth_dcr_http_redirect_uri).toBe("passed");
     expect(statuses.oauth_invalid_client).toBe("passed");
+    expect(statuses.oauth_invalid_authorize_redirect).toBe("passed");
+    expect(statuses.oauth_invalid_token).toBe("passed");
     expect(statuses.oauth_invalid_redirect).toBe("skipped");
     expect(statuses.oauth_token_format).toBe("passed");
+  });
+
+  it("prefers the challenged scope from WWW-Authenticate over scopes_supported", async () => {
+    const serverUrl = "https://mcp.example.com/mcp";
+    const resourceMetadataUrl =
+      "https://mcp.example.com/.well-known/oauth-protected-resource/mcp";
+    const authServerUrl = "https://auth.example.com";
+    const completeHeadlessAuthorization = jest.fn(
+      async ({ authorizationUrl }: { authorizationUrl: string }) => {
+        const url = new URL(authorizationUrl);
+        expect(url.searchParams.get("scope")).toBe("files:read files:write");
+        return { code: "auth-code" };
+      },
+    );
+
+    const fetchFn: typeof fetch = jest.fn(async (input, init) => {
+      const url = String(input);
+      const headers = new Headers(init?.headers);
+
+      if (url === serverUrl && !headers.get("Authorization")) {
+        return new Response(null, {
+          status: 401,
+          headers: {
+            "WWW-Authenticate": `Bearer resource_metadata="${resourceMetadataUrl}", scope="files:read files:write"`,
+          },
+        });
+      }
+
+      if (url === resourceMetadataUrl) {
+        return jsonResponse({
+          resource: serverUrl,
+          authorization_servers: [authServerUrl],
+          scopes_supported: ["openid", "profile", "mcp"],
+        });
+      }
+
+      if (url === `${authServerUrl}/.well-known/oauth-authorization-server`) {
+        return jsonResponse({
+          issuer: authServerUrl,
+          authorization_endpoint: `${authServerUrl}/authorize`,
+          token_endpoint: `${authServerUrl}/token`,
+          registration_endpoint: `${authServerUrl}/register`,
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          code_challenge_methods_supported: ["S256"],
+          client_id_metadata_document_supported: true,
+          scopes_supported: ["openid", "profile", "mcp"],
+        });
+      }
+
+      if (url === DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL) {
+        return jsonResponse({
+          client_id: DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
+          client_name: "MCPJam SDK OAuth Conformance",
+          redirect_uris: ["http://127.0.0.1:3333/callback"],
+        });
+      }
+
+      if (url === `${authServerUrl}/token`) {
+        return jsonResponse({
+          access_token: "scoped-access-token",
+          refresh_token: "refresh-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      }
+
+      if (
+        url === serverUrl &&
+        headers.get("Authorization") === "Bearer scoped-access-token"
+      ) {
+        return createMcpInitializeResponse("2025-11-25");
+      }
+
+      return jsonResponse({ error: "not found" }, 404);
+    }) as typeof fetch;
+
+    const test = new OAuthConformanceTest(
+      {
+        serverUrl,
+        protocolVersion: "2025-11-25",
+        registrationStrategy: "cimd",
+        auth: { mode: "headless" },
+        fetchFn,
+      },
+      {
+        completeHeadlessAuthorization,
+      },
+    );
+
+    const result = await test.run();
+
+    expect(result.passed).toBe(true);
+    expect(completeHeadlessAuthorization).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails strict conformance when DCR metadata omits registration_endpoint", async () => {
+    const serverUrl = "https://mcp.example.com/mcp";
+    const resourceMetadataUrl =
+      "https://mcp.example.com/.well-known/oauth-protected-resource/mcp";
+    const authServerUrl = "https://auth.example.com";
+
+    const fetchFn: typeof fetch = jest.fn(async (input, init) => {
+      const url = String(input);
+      const headers = new Headers(init?.headers);
+
+      if (url === serverUrl && !headers.get("Authorization")) {
+        return new Response(null, {
+          status: 401,
+          headers: {
+            "WWW-Authenticate": `Bearer resource_metadata="${resourceMetadataUrl}"`,
+          },
+        });
+      }
+
+      if (url === resourceMetadataUrl) {
+        return jsonResponse({
+          resource: serverUrl,
+          authorization_servers: [authServerUrl],
+        });
+      }
+
+      if (url === `${authServerUrl}/.well-known/oauth-authorization-server`) {
+        return jsonResponse({
+          issuer: authServerUrl,
+          authorization_endpoint: `${authServerUrl}/authorize`,
+          token_endpoint: `${authServerUrl}/token`,
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          code_challenge_methods_supported: ["S256"],
+        });
+      }
+
+      return jsonResponse({ error: "not found" }, 404);
+    }) as typeof fetch;
+
+    const test = new OAuthConformanceTest({
+      serverUrl,
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "dcr",
+      auth: { mode: "headless" },
+      fetchFn,
+    });
+
+    const result = await test.run();
+    const failedStep = result.steps.find((step) => step.status === "failed");
+
+    expect(result.passed).toBe(false);
+    expect(failedStep).toMatchObject({
+      status: "failed",
+      error: {
+        message: expect.stringContaining("registration_endpoint"),
+      },
+    });
+  });
+
+  it("fails 2025-11-25 conformance when S256 is not advertised", async () => {
+    const serverUrl = "https://mcp.example.com/mcp";
+    const resourceMetadataUrl =
+      "https://mcp.example.com/.well-known/oauth-protected-resource/mcp";
+    const authServerUrl = "https://auth.example.com";
+
+    const fetchFn: typeof fetch = jest.fn(async (input, init) => {
+      const url = String(input);
+      const headers = new Headers(init?.headers);
+
+      if (url === serverUrl && !headers.get("Authorization")) {
+        return new Response(null, {
+          status: 401,
+          headers: {
+            "WWW-Authenticate": `Bearer resource_metadata="${resourceMetadataUrl}"`,
+          },
+        });
+      }
+
+      if (url === resourceMetadataUrl) {
+        return jsonResponse({
+          resource: serverUrl,
+          authorization_servers: [authServerUrl],
+        });
+      }
+
+      if (url === `${authServerUrl}/.well-known/oauth-authorization-server`) {
+        return jsonResponse({
+          issuer: authServerUrl,
+          authorization_endpoint: `${authServerUrl}/authorize`,
+          token_endpoint: `${authServerUrl}/token`,
+          registration_endpoint: `${authServerUrl}/register`,
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          code_challenge_methods_supported: ["plain"],
+          client_id_metadata_document_supported: true,
+        });
+      }
+
+      return jsonResponse({ error: "not found" }, 404);
+    }) as typeof fetch;
+
+    const test = new OAuthConformanceTest({
+      serverUrl,
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "cimd",
+      auth: { mode: "headless" },
+      fetchFn,
+    });
+
+    const result = await test.run();
+    const failedStep = result.steps.find((step) => step.status === "failed");
+
+    expect(result.passed).toBe(false);
+    expect(failedStep).toMatchObject({
+      status: "failed",
+      error: {
+        message: expect.stringContaining("advertise S256"),
+      },
+    });
   });
 
   it("fails conformance when DCR accepts a non-loopback http redirect URI", async () => {

--- a/sdk/tests/oauth-conformance/runner.test.ts
+++ b/sdk/tests/oauth-conformance/runner.test.ts
@@ -572,6 +572,10 @@ describe("OAuthConformanceTest", () => {
         });
       }
 
+      if (url === `${authServerUrl}/register`) {
+        return jsonResponse({ error: "invalid_redirect_uri" }, 400);
+      }
+
       if (url === DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL) {
         return jsonResponse({
           client_id: DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
@@ -635,8 +639,145 @@ describe("OAuthConformanceTest", () => {
 
     expect(result.passed).toBe(true);
     expect(tokenBodies).toHaveLength(3);
+    expect(statuses.oauth_dcr_http_redirect_uri).toBe("passed");
     expect(statuses.oauth_invalid_client).toBe("passed");
-    expect(statuses.oauth_invalid_redirect).toBe("passed");
+    expect(statuses.oauth_invalid_redirect).toBe("skipped");
     expect(statuses.oauth_token_format).toBe("passed");
+  });
+
+  it("fails conformance when DCR accepts a non-loopback http redirect URI", async () => {
+    const serverUrl = "https://mcp.example.com/mcp";
+    const redirectUrl = "http://127.0.0.1:3333/callback";
+    const resourceMetadataUrl =
+      "https://mcp.example.com/.well-known/oauth-protected-resource/mcp";
+    const authServerUrl = "https://auth.example.com";
+
+    const fetchFn: typeof fetch = jest.fn(async (input, init) => {
+      const url = String(input);
+      const headers = new Headers(init?.headers);
+
+      if (url === serverUrl && !headers.get("Authorization")) {
+        return new Response(null, {
+          status: 401,
+          headers: {
+            "WWW-Authenticate": `Bearer resource_metadata="${resourceMetadataUrl}"`,
+          },
+        });
+      }
+
+      if (url === resourceMetadataUrl) {
+        return jsonResponse({
+          resource: serverUrl,
+          authorization_servers: [authServerUrl],
+        });
+      }
+
+      if (url === `${authServerUrl}/.well-known/oauth-authorization-server`) {
+        return jsonResponse({
+          issuer: authServerUrl,
+          authorization_endpoint: `${authServerUrl}/authorize`,
+          token_endpoint: `${authServerUrl}/token`,
+          registration_endpoint: `${authServerUrl}/register`,
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          code_challenge_methods_supported: ["S256"],
+        });
+      }
+
+      if (url === `${authServerUrl}/register`) {
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          redirect_uris?: string[];
+        };
+
+        if (body.redirect_uris?.[0] === "http://evil.example/callback") {
+          return jsonResponse(
+            {
+              client_id: "evil-client",
+              redirect_uris: body.redirect_uris,
+            },
+            201,
+          );
+        }
+
+        return jsonResponse(
+          {
+            client_id: "legit-client",
+            redirect_uris: body.redirect_uris,
+          },
+          201,
+        );
+      }
+
+      if (url === `${authServerUrl}/token`) {
+        const body = String(init?.body ?? "");
+
+        if (body.includes("client_id=invalid-client-id")) {
+          return jsonResponse({ error: "invalid_client" }, 401);
+        }
+
+        if (
+          body.includes(
+            "redirect_uri=http%3A%2F%2F127.0.0.1%3A3333%2Fcallback%3Finvalid%3D1",
+          )
+        ) {
+          return jsonResponse(
+            {
+              error: "invalid_request",
+              error_description: "redirect_uri mismatch",
+            },
+            400,
+          );
+        }
+
+        return jsonResponse({
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      }
+
+      if (url === serverUrl && headers.get("Authorization") === "Bearer access-token") {
+        return createMcpInitializeResponse("2025-11-25");
+      }
+
+      return jsonResponse({ error: "not found" }, 404);
+    }) as typeof fetch;
+
+    const test = new OAuthConformanceTest(
+      {
+        serverUrl,
+        protocolVersion: "2025-11-25",
+        registrationStrategy: "dcr",
+        auth: { mode: "headless" },
+        fetchFn,
+        redirectUrl,
+        oauthConformanceChecks: true,
+        verification: { listTools: true },
+      },
+      {
+        completeHeadlessAuthorization: jest.fn(async () => ({
+          code: "auth-code",
+        })),
+      },
+    );
+
+    const result = await test.run();
+    const dcrCheck = result.steps.find(
+      (step) => step.step === "oauth_dcr_http_redirect_uri",
+    );
+
+    expect(result.passed).toBe(false);
+    expect(dcrCheck).toMatchObject({
+      status: "failed",
+      error: {
+        details: expect.objectContaining({
+          redirectUri: "http://evil.example/callback",
+          clientId: "evil-client",
+        }),
+      },
+    });
+    expect(result.verification).toBeUndefined();
+    expect(result.steps.map((step) => step.step)).not.toContain("verify_list_tools");
   });
 });

--- a/sdk/tests/oauth/state-machine-regressions.test.ts
+++ b/sdk/tests/oauth/state-machine-regressions.test.ts
@@ -1,0 +1,176 @@
+import { createOAuthStateMachine } from "../../src/oauth/state-machines/factory.js";
+import { EMPTY_OAUTH_FLOW_STATE } from "../../src/oauth/state-machines/types.js";
+
+const REDIRECT_URI = "http://127.0.0.1:3333/callback";
+const SERVER_URL = "https://mcp.example.com/mcp";
+const REGISTRATION_ENDPOINT = "https://auth.example.com/register";
+
+describe("OAuth state machine regressions", () => {
+  it("clears stale challengedScopes when optional auth is detected in 2025-06-18", async () => {
+    let state = {
+      ...EMPTY_OAUTH_FLOW_STATE,
+      currentStep: "request_without_token" as const,
+      serverUrl: SERVER_URL,
+      challengedScopes: ["stale-scope"],
+      httpHistory: [
+        {
+          step: "request_without_token" as const,
+          timestamp: Date.now(),
+          request: {
+            method: "POST",
+            url: SERVER_URL,
+            headers: {},
+            body: { method: "initialize" },
+          },
+        },
+      ],
+      infoLogs: [],
+    };
+
+    const machine = createOAuthStateMachine({
+      protocolVersion: "2025-06-18",
+      registrationStrategy: "dcr",
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_URL,
+      serverName: "Test Server",
+      redirectUrl: REDIRECT_URI,
+      requestExecutor: jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: {
+          jsonrpc: "2.0",
+          result: {},
+        },
+      }),
+      dynamicRegistration: {
+        client_name: "Test Client",
+      },
+    });
+
+    await machine.proceedToNextStep();
+
+    expect(state.currentStep).toBe("received_401_unauthorized");
+    expect(state.challengedScopes).toBeUndefined();
+    expect(state.isInitiatingAuth).toBe(false);
+  });
+
+  it("clears isInitiatingAuth when strict DCR fails with an HTTP error in 2025-11-25", async () => {
+    let state = {
+      ...EMPTY_OAUTH_FLOW_STATE,
+      currentStep: "request_client_registration" as const,
+      authorizationServerMetadata: {
+        registration_endpoint: REGISTRATION_ENDPOINT,
+      },
+      lastRequest: {
+        method: "POST",
+        url: REGISTRATION_ENDPOINT,
+        headers: {},
+        body: { client_name: "Test Client" },
+      },
+      httpHistory: [
+        {
+          step: "request_client_registration" as const,
+          timestamp: Date.now(),
+          request: {
+            method: "POST",
+            url: REGISTRATION_ENDPOINT,
+            headers: {},
+            body: { client_name: "Test Client" },
+          },
+        },
+      ],
+      infoLogs: [],
+      isInitiatingAuth: true,
+    };
+
+    const machine = createOAuthStateMachine({
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "dcr",
+      strictConformance: true,
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_URL,
+      serverName: "Test Server",
+      redirectUrl: REDIRECT_URI,
+      requestExecutor: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        body: {
+          error: "invalid_client_metadata",
+        },
+      }),
+      dynamicRegistration: {
+        client_name: "Test Client",
+      },
+    });
+
+    await machine.proceedToNextStep();
+
+    expect(state.error).toBe("Dynamic Client Registration failed (400).");
+    expect(state.isInitiatingAuth).toBe(false);
+  });
+
+  it("clears isInitiatingAuth when strict DCR fails with a transport error in 2025-11-25", async () => {
+    let state = {
+      ...EMPTY_OAUTH_FLOW_STATE,
+      currentStep: "request_client_registration" as const,
+      authorizationServerMetadata: {
+        registration_endpoint: REGISTRATION_ENDPOINT,
+      },
+      lastRequest: {
+        method: "POST",
+        url: REGISTRATION_ENDPOINT,
+        headers: {},
+        body: { client_name: "Test Client" },
+      },
+      httpHistory: [
+        {
+          step: "request_client_registration" as const,
+          timestamp: Date.now(),
+          request: {
+            method: "POST",
+            url: REGISTRATION_ENDPOINT,
+            headers: {},
+            body: { client_name: "Test Client" },
+          },
+        },
+      ],
+      infoLogs: [],
+      isInitiatingAuth: true,
+    };
+
+    const machine = createOAuthStateMachine({
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "dcr",
+      strictConformance: true,
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_URL,
+      serverName: "Test Server",
+      redirectUrl: REDIRECT_URI,
+      requestExecutor: jest.fn().mockRejectedValue(new Error("boom")),
+      dynamicRegistration: {
+        client_name: "Test Client",
+      },
+    });
+
+    await machine.proceedToNextStep();
+
+    expect(state.error).toBe("Client registration failed: boom");
+    expect(state.isInitiatingAuth).toBe(false);
+  });
+});

--- a/skills/mcp-inspector/SKILL.md
+++ b/skills/mcp-inspector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mcp-inspector
-description: Interpret `mcpjam-cli` probe, doctor, OAuth, tools, resources, and prompts output conservatively against MCP 2025-11-25. Use when triaging MCP server findings, performing security reviews, deciding whether a CLI finding is real or overstated, or turning inspection output into an engineer-facing report with severity and confidence.
+description: Interpret `mcpjam-cli` probe, doctor, OAuth, apps conformance, tools, resources, and prompts output conservatively against MCP 2025-11-25. Use when triaging MCP server findings, performing security reviews, deciding whether a CLI finding is real or overstated, or turning inspection output into an engineer-facing report with severity and confidence.
 ---
 
 # MCPJam CLI Investigation
@@ -28,10 +28,11 @@ Use this skill when analyzing MCP server behavior from `mcpjam-cli` output. The 
 4. After successful auth, inspect the connected surface with direct commands such as `server info`, `server capabilities`, `tools list`, `resources list/read/templates`, and `prompts list/get`.
 5. Use `server doctor --out <path>` when you need one breadth-first snapshot instead of several single-purpose command outputs.
 6. If the output came from `server doctor` or a `--debug-out` artifact, split it into primary command evidence, probe evidence, and connected-sweep evidence.
-7. If a field may be CLI-added or SDK-normalized, read `references/cli-surface-notes.md` before concluding anything.
-8. If the claim depends on MCP semantics, read `references/mcp-2025-11-25-interpretation.md`.
-9. If the task involves security review, read `references/security-best-practices.md` for the full checklist and follow the security review workflow below.
-10. Write the result using the output contract below.
+7. If the claim is specifically about MCP Apps tool metadata or `ui://` resources, start with `apps conformance --format json` before dropping to `tools list` or `resources read`.
+8. If a field may be CLI-added or SDK-normalized, read `references/cli-surface-notes.md` before concluding anything.
+9. If the claim depends on MCP semantics, read `references/mcp-2025-11-25-interpretation.md`.
+10. If the task involves security review, read `references/security-best-practices.md` for the full checklist and follow the security review workflow below.
+11. Write the result using the output contract below.
 
 ## Security review workflow
 
@@ -103,6 +104,7 @@ Use `pending` instead of manufacturing a `medium` or `high` security severity fr
 - `oauth metadata`, `oauth proxy`, `oauth debug-proxy`: exact endpoint and metadata inspection when conformance output looks surprising.
 - `oauth login`: obtain reusable credentials and verify the authenticated MCP path. Use this when the goal is to inspect a server that requires OAuth, then follow it with connected commands rather than stopping at the login result.
 - `oauth conformance`, `oauth conformance-suite`: flow-level auth checks. Treat these as targeted probes, not a complete security review.
+- `apps conformance`: server-side MCP Apps checks for `_meta.ui.resourceUri`, `ui://` resources, `resources/read`, HTML MIME and payload shape, and `_meta.ui` metadata. Use this for MCP Apps surface triage.
 - `server info`, `server capabilities`, `server validate`, `server ping`, `server export`: connected behavior after initialization and auth.
 - `tools list` and `tools call`, `resources list/read/templates`, `prompts list/get/list-multi`: direct post-connect capability checks.
 - Prefer `--format json`. Add `--rpc` when available if you need request and response evidence rather than a summary. Add `--debug-out` when you need a failure-safe artifact, not as a replacement for raw evidence.
@@ -138,6 +140,7 @@ For each claimed security-review finding, return:
 - Never call `toolsMetadata` an MCP server field.
 - Never infer prompt support from an empty prompts list unless you have raw RPC evidence that `prompts/list` was actually sent and answered by the server.
 - Never stop at `oauth_required` when the user asked to inspect the authenticated server surface and the CLI can complete login. Authenticate and continue with post-login commands when feasible.
+- Never treat a passing `apps conformance` result as full SEP-1865 conformance. The current command is server-side only and does not prove host lifecycle, sandbox proxy, or postMessage bridge behavior.
 - Never treat missing optional metadata such as `outputSchema`, content annotations, `scopes_supported`, or `scope` hints as a hard failure without a `MUST`.
 - Separate OAuth RFC violations from MCP profile preferences.
 - Distinguish "the server correctly rejected a bad request" from "the overall design is secure."

--- a/skills/mcp-inspector/SKILL.md
+++ b/skills/mcp-inspector/SKILL.md
@@ -103,7 +103,7 @@ Use `pending` instead of manufacturing a `medium` or `high` security severity fr
 - `server doctor`: combined triage artifact for probe plus connected behavior. Good for breadth, not always sufficient to prove wire-level behavior by itself.
 - `oauth metadata`, `oauth proxy`, `oauth debug-proxy`: exact endpoint and metadata inspection when conformance output looks surprising.
 - `oauth login`: obtain reusable credentials and verify the authenticated MCP path. Use this when the goal is to inspect a server that requires OAuth, then follow it with connected commands rather than stopping at the login result.
-- `oauth conformance`, `oauth conformance-suite`: flow-level auth checks. Treat these as targeted probes, not a complete security review.
+- `oauth conformance`, `oauth conformance-suite`: flow-level auth checks. Treat these as targeted probes, not a complete security review. When `--conformance-checks` is enabled, the command can directly probe DCR non-loopback `http://` redirects, invalid client rejection, authorization-endpoint redirect mismatch handling, invalid bearer-token rejection at the MCP server, and token-endpoint redirect mismatch handling.
 - `apps conformance`: server-side MCP Apps checks for `_meta.ui.resourceUri`, `ui://` resources, `resources/read`, HTML MIME and payload shape, and `_meta.ui` metadata. Use this for MCP Apps surface triage.
 - `server info`, `server capabilities`, `server validate`, `server ping`, `server export`: connected behavior after initialization and auth.
 - `tools list` and `tools call`, `resources list/read/templates`, `prompts list/get/list-multi`: direct post-connect capability checks.
@@ -147,6 +147,7 @@ For each claimed security-review finding, return:
 - Treat `--debug-out` artifacts as aggregated evidence envelopes, not pure wire captures.
 - Never flag missing `scopes_supported` or missing `scope` in `WWW-Authenticate` as a security issue. Both are optional.
 - Never claim a server is "secure" based solely on it rejecting one specific bad input. A single negative test does not prove broader security posture.
+- Never treat a passing `oauth_invalid_token` or redirect-mismatch probe as proof that the whole authorization design is secure. Those checks only prove the exact case that was sent.
 - Never let a checklist hit assign `high` security severity by itself.
 - JWT `aud` mismatch is not token passthrough proof unless you show the server accepts a token issued for a different audience or resource, or otherwise misbinds the token.
 - Supporting `plain` PKCE is usually hardening only. It cannot compound with attacker-owned-client DCR flows where the attacker chose the verifier.

--- a/skills/mcp-inspector/references/cli-surface-notes.md
+++ b/skills/mcp-inspector/references/cli-surface-notes.md
@@ -63,6 +63,21 @@ If a higher-priority surface contradicts a lower-priority summary, trust the hig
 - A passing negative test only proves the specific negative case that was sent.
 - A failing headless flow may reflect login UX or consent requirements, not a spec violation.
 
+### `apps conformance`
+
+- This is a connected, server-side MCP Apps check.
+- It validates:
+  - tools advertising `_meta.ui.resourceUri` or deprecated `_meta["ui/resourceUri"]`
+  - `ui://` resource discovery and `resources/read`
+  - `text/html;profile=mcp-app` payload shape
+  - `_meta.ui.csp`, `permissions`, `domain`, and `prefersBorder`
+- It does not currently validate:
+  - `ui/initialize` and `ui/notifications/initialized`
+  - `ui/notifications/tool-input` or `ui/notifications/tool-result` ordering
+  - sandbox proxy behavior
+  - host display modes, host context changes, or postMessage bridge behavior
+- Treat a pass as evidence that the server advertises an MCP Apps surface with plausible resource wiring. Do not describe it as full SEP-1865 conformance.
+
 ### `tools list`
 
 - The command returns:

--- a/skills/mcp-inspector/references/cli-surface-notes.md
+++ b/skills/mcp-inspector/references/cli-surface-notes.md
@@ -60,7 +60,15 @@ If a higher-priority surface contradicts a lower-priority summary, trust the hig
 ### `oauth login`, `oauth conformance`, `oauth conformance-suite`
 
 - These are targeted flow tests, not a full security audit.
+- `oauth conformance --conformance-checks` adds targeted negative probes for:
+  - DCR acceptance of non-loopback `http://` redirect URIs
+  - invalid client rejection at the token endpoint
+  - authorization-endpoint handling of mismatched `redirect_uri`
+  - invalid bearer-token rejection by the MCP server
+  - token-endpoint handling of mismatched `redirect_uri`
 - A passing negative test only proves the specific negative case that was sent.
+- Current auth-code negative checks include the OAuth `resource` parameter, so failures are less likely to be caused by obviously malformed token requests.
+- A redirect-mismatch check marked `skipped` often means the request was rejected for some other reason before redirect validation was isolated. Do not overread that as a pass.
 - A failing headless flow may reflect login UX or consent requirements, not a spec violation.
 
 ### `apps conformance`

--- a/skills/mcp-inspector/references/cli-surface-notes.md
+++ b/skills/mcp-inspector/references/cli-surface-notes.md
@@ -76,6 +76,8 @@ If a higher-priority surface contradicts a lower-priority summary, trust the hig
 - This is a connected, server-side MCP Apps check.
 - It validates:
   - tools advertising `_meta.ui.resourceUri` or deprecated `_meta["ui/resourceUri"]`
+  - tool `inputSchema` is a non-null JSON Schema object (MUST)
+  - tool name length, character set, and uniqueness (SHOULD — warnings only)
   - `ui://` resource discovery and `resources/read`
   - `text/html;profile=mcp-app` payload shape
   - `_meta.ui.csp`, `permissions`, `domain`, and `prefersBorder`

--- a/skills/mcp-inspector/references/mcp-2025-11-25-interpretation.md
+++ b/skills/mcp-inspector/references/mcp-2025-11-25-interpretation.md
@@ -45,6 +45,8 @@ Primary MCP references:
 - Missing `resource_metadata` in `WWW-Authenticate` is not automatically a hard failure if the well-known metadata path works.
 - `scope` in the `WWW-Authenticate` challenge is guidance and is only a `SHOULD`.
 - `scopes_supported` is useful for clients, but absence is not automatically a protocol failure.
+- The OAuth `resource` parameter is a `MUST` in both authorization and token requests. If a client-side negative check omits `resource`, a rejection may be caused by a malformed request rather than the behavior under test.
+- When both are present, clients should prefer the `scope` value challenged in `WWW-Authenticate` over `scopes_supported` for the current request.
 - Redirect URI findings need calibration:
   - accepting non-localhost `http://` redirect URIs is a real problem under the MCP profile
   - accepting arbitrary `https://` redirect URIs is not automatically a vulnerability; open registration and trust-policy details matter

--- a/skills/mcp-inspector/references/security-best-practices.md
+++ b/skills/mcp-inspector/references/security-best-practices.md
@@ -61,11 +61,12 @@ Use this file when performing a security-focused review of an MCP server. Each c
 
 - **Command**: `oauth proxy --url <registration_endpoint> --method POST --header "Content-Type: application/json" --body '{"redirect_uris":["http://evil.example/callback"],"client_name":"security-test","token_endpoint_auth_method":"none","grant_types":["authorization_code"],"response_types":["code"]}'`
 - **Where to look**: Response status and body. A `2xx` with a `client_id` means the registration succeeded.
-- **Checklist hit**: Server accepted a non-loopback `http://` redirect URI
+- **Checklist hit**: Server accepted a non-loopback `http://` redirect URI. Under the MCP authorization spec, this is a direct profile violation because redirect URIs must be either `localhost` or `https`.
 - **Default compliance impact**: `medium`
 - **Default security impact**: `pending`
+- **Interpretation**: Treat this as a real conformance failure even when attacker benefit is not yet proved.
 - **Escalates when**: Phase 3 proves code or token capture, consent skip, a misleading consent flow, redirect exact-match bypass, or another end-to-end attacker benefit
-- **Do not escalate when**: Registration succeeds but the authorization and token path is not proved
+- **Do not escalate when**: Registration succeeds but the authorization and token path is not proved. Lack of exploit proof lowers the security severity, not the compliance finding.
 - **Best proving command**: Phase 2 `oauth proxy` registration, then Phase 3 `oauth login` plus an authorization URL opened in the same browser session
 - **Phase**: 2 then 3
 
@@ -88,8 +89,9 @@ Use this file when performing a security-focused review of an MCP server. Each c
 - **Checklist hit**: Server accepts a redirect URI that does not exactly match the registered one
 - **Default compliance impact**: `medium`
 - **Default security impact**: `pending`
+- **Interpretation**: Keep this separate from the non-loopback `http://` redirect check. A server can enforce exact matching and still violate the MCP redirect URI policy, or vice versa.
 - **Escalates when**: The modified URI actually receives an auth code, token, or other meaningful authorization result
-- **Do not escalate when**: You only suspect loose matching from registration behavior or summaries
+- **Do not escalate when**: You only suspect loose matching from registration behavior, a token-endpoint rejection reason, or summaries. Use a live authorization request to prove the mismatch was accepted.
 - **Best proving command**: DCR registration plus a live authorization request using the modified URI
 - **Phase**: 3
 

--- a/skills/mcp-inspector/references/security-best-practices.md
+++ b/skills/mcp-inspector/references/security-best-practices.md
@@ -95,6 +95,19 @@ Use this file when performing a security-focused review of an MCP server. Each c
 - **Best proving command**: DCR registration plus a live authorization request using the modified URI
 - **Phase**: 3
 
+### Invalid bearer token rejection
+
+- **Command**: `oauth conformance --conformance-checks` or a direct authenticated MCP request with an obviously invalid bearer token
+- **Where to look**: MCP server response status and body
+- **Checklist hit**: The MCP server responds with anything other than `401` to an obviously invalid bearer token
+- **Default compliance impact**: `medium`
+- **Default security impact**: `pending`
+- **Interpretation**: This is a targeted token-validation probe, not proof of token passthrough by itself. It is strongest when the request reaches the real MCP endpoint rather than only an OAuth metadata path.
+- **Escalates when**: You can show the server accepts foreign, expired, or otherwise invalid tokens for real MCP operations
+- **Do not escalate when**: The server cleanly rejects the token with `401`, or when a proxy layer rejects the request before the MCP server is meaningfully exercised
+- **Best proving command**: `oauth conformance --conformance-checks`, then a narrower follow-up request if the result is surprising
+- **Phase**: 2, with any abuse proof in 3
+
 ## PKCE Weakness
 
 ### Authorization server supports plain PKCE


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new conformance runner (CLI + SDK) and materially expands OAuth conformance/interactive login behavior, touching authentication flows and request construction. Risk is moderate due to new validation logic and additional negative checks that could change test outcomes and surface new failures in CI.
> 
> **Overview**
> Adds **MCP Apps conformance** to both the CLI (`mcpjam apps conformance`) and SDK via `MCPAppsConformanceTest`, including category/check-id selection and validation of `_meta.ui.resourceUri`, `ui://` resource listing/reading, HTML payload shape, and `_meta.ui` metadata.
> 
> Expands **OAuth conformance** from 3 to 6 post-flow negative checks (including DCR http redirect URI policy, redirect mismatch at the authorization endpoint, and invalid bearer token handling), adds TTY progress reporting via a new `onProgress` callback, improves interactive callback handling/UX (HTML page + stricter state mismatch), and redacts sensitive token-like strings when surfacing evidence.
> 
> Updates docs/README/reference and bumps versions (`@mcpjam/cli` to `2.0.2`, `@mcpjam/sdk` to `0.9.3`), with new tests and mock server coverage for apps conformance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5262dcbd1053d485ea448261f469caface2b87c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->