### PR TITLE
CLI README and docs updates for v2.0.2

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,6 @@
 # @mcpjam/cli
 
-Test, debug, and validate MCP servers — health checks, OAuth conformance, tool-surface diffing, and structured triage from the terminal or CI.
+Test, debug, and validate MCP servers. Health checks, OAuth conformance, tool-surface diffing, and structured triage from the terminal or CI.
 
 ## Install
 
@@ -21,8 +21,7 @@ $ mcpjam --help
 
 Usage: mcpjam [options] [command]
 
-Test, debug, and validate MCP servers — health checks, OAuth conformance,
-tool-surface diffing, and structured triage from the terminal or CI
+Test, debug, and validate MCP servers. Health checks, OAuth conformance, tool-surface diffing, and structured triage from the terminal or CI.
 
 Options:
   -v, --version      output the CLI version
@@ -59,7 +58,7 @@ mcpjam tools list --url https://your-server.com/mcp --access-token $TOKEN --form
 
 ## Why
 
-MCP servers ship without the testing infrastructure REST APIs take for granted. No health checks, no OAuth conformance tests, no deploy-time regression detection. `mcpjam` fills that gap.
+MCP servers don't have built-in health checks, OAuth conformance tests, or deploy-time regression detection. `mcpjam` adds those.
 
 ## What it does
 
@@ -73,7 +72,7 @@ mcpjam server doctor --url $MCP_SERVER_URL --access-token $TOKEN --format json
 
 ### Catch breaking changes before they ship
 
-`server export` snapshots your entire tool surface — names, schemas, descriptions, capabilities — as diffable JSON. A renamed parameter or changed description shows up in the diff.
+`server export` snapshots your entire tool surface as diffable JSON. A renamed parameter or changed description shows up in the diff.
 
 ```bash
 mcpjam server export --url $URL --access-token $TOKEN > before.json
@@ -92,7 +91,7 @@ mcpjam oauth conformance-suite --config ./oauth-matrix.json --format junit-xml >
 
 ### Verify tokens work end-to-end
 
-OAuth can succeed while `tools/list` returns 401 because the audience, scope, or session init is wrong. `--verify-call-tool` completes the full chain — OAuth, MCP connect, tool call — and reports which step fails.
+OAuth can succeed while `tools/list` returns 401 because the audience, scope, or session init is wrong. `--verify-call-tool` completes the full chain (OAuth, MCP connect, tool call) and reports which step fails.
 
 ```bash
 mcpjam oauth conformance --url $URL --protocol-version 2025-11-25 \
@@ -115,7 +114,7 @@ MCP has shipped three protocol versions (2025-03-26, 2025-06-18, 2025-11-25). Cl
 
 ### Structured debug artifacts
 
-`--debug-out` captures a JSON artifact with every request and response in the OAuth and MCP flow. Attach it to a ticket — no reproduction steps required.
+`--debug-out` captures a JSON artifact with every request and response in the OAuth and MCP flow. Attach it to a ticket instead of writing reproduction steps.
 
 ```bash
 mcpjam oauth login --url $URL --protocol-version 2025-11-25 \
@@ -124,7 +123,7 @@ mcpjam oauth login --url $URL --protocol-version 2025-11-25 \
 
 ### Incident triage
 
-Separate your failures from host-side failures. `--rpc` records what your server returned — transport type, status codes, raw JSON-RPC pairs — as a structured artifact for postmortems.
+Separate your failures from host-side failures. `--rpc` records what your server returned (transport type, status codes, raw JSON-RPC pairs) as a structured artifact for postmortems.
 
 ```bash
 mcpjam server doctor --url $URL --access-token $TOKEN --rpc --out incident-triage.json
@@ -138,6 +137,54 @@ Pipe the full schema inventory into your own linter, review it in a PR, or check
 mcpjam tools list --url $URL --access-token $TOKEN --format json \
   | jq '.tools[] | {name, description, inputSchema}'
 ```
+
+## GitHub Actions
+
+```yaml
+name: MCP Health Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  mcp-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: OAuth login (headless)
+        run: |
+          set -euo pipefail
+          npx -y @mcpjam/cli@latest oauth login \
+            --url ${{ secrets.MCP_SERVER_URL }} \
+            --protocol-version 2025-11-25 \
+            --registration dcr \
+            --auth-mode headless \
+            --format json > /tmp/oauth-result.json
+          TOKEN=$(jq -r '.credentials.accessToken // empty' /tmp/oauth-result.json)
+          rm -f /tmp/oauth-result.json
+          if [ -z "$TOKEN" ]; then
+            echo "::error::OAuth login did not return an access token"
+            exit 1
+          fi
+          echo "::add-mask::$TOKEN"
+          echo "MCP_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+
+      - name: Run doctor
+        run: npx -y @mcpjam/cli@latest server doctor --url ${{ secrets.MCP_SERVER_URL }} --access-token $MCP_TOKEN --format json
+```
+
+If you already have a refresh token, you can skip the login step and pass it directly:
+
+```bash
+mcpjam server doctor --url $URL --refresh-token $REFRESH_TOKEN --client-id $CLIENT_ID --client-secret $CLIENT_SECRET --format json
+```
+
+See the full [CI documentation](https://docs.mcpjam.com/cli/ci-github-actions) for all authentication options.
 
 ## Documentation
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mcpjam/cli",
   "version": "2.0.1",
-  "description": "Test, debug, and validate MCP servers — health checks, OAuth conformance, tool-surface diffing, and structured triage from the terminal or CI",
+  "description": "Test, debug, and validate MCP servers. Health checks, OAuth conformance, tool-surface diffing, and structured triage from the terminal or CI.",
   "main": "dist/index.js",
   "files": [
     "dist"

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -21,7 +21,7 @@ async function main(argv: readonly string[] = process.argv): Promise<number> {
       .name("mcpjam")
       .version(pkgVersion, "-v, --version", "output the CLI version")
       .description(
-        "Test, debug, and validate MCP servers — health checks, OAuth conformance, tool-surface diffing, and structured triage from the terminal or CI",
+        "Test, debug, and validate MCP servers. Health checks, OAuth conformance, tool-surface diffing, and structured triage from the terminal or CI.",
       )
       .allowExcessArguments(false)
       .exitOverride()

--- a/docs/cli/ci-github-actions.mdx
+++ b/docs/cli/ci-github-actions.mdx
@@ -1,0 +1,201 @@
+---
+title: "CI / GitHub Actions"
+description: "Run MCP health checks and OAuth conformance in GitHub Actions"
+icon: "github"
+---
+
+Run `mcpjam` in CI to catch MCP server regressions on every push. The examples below use GitHub Actions, but the same commands work in any CI environment.
+
+## Authentication
+
+There are three ways to authenticate in CI, depending on your server setup.
+
+### Option 1: Headless OAuth login
+
+Best when your server supports OAuth with auto-consent (no interactive login page). The workflow obtains a fresh access token on every run.
+
+**Secrets needed:**
+
+| Secret | Description |
+|---|---|
+| `MCP_SERVER_URL` | Your MCP server URL |
+
+```yaml
+name: MCP Health Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  mcp-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: OAuth login (headless)
+        run: |
+          set -euo pipefail
+          npx -y @mcpjam/cli@latest oauth login \
+            --url ${{ secrets.MCP_SERVER_URL }} \
+            --protocol-version 2025-11-25 \
+            --registration dcr \
+            --auth-mode headless \
+            --format json > /tmp/oauth-result.json
+          TOKEN=$(jq -r '.credentials.accessToken // empty' /tmp/oauth-result.json)
+          rm -f /tmp/oauth-result.json
+          if [ -z "$TOKEN" ]; then
+            echo "::error::OAuth login did not return an access token"
+            exit 1
+          fi
+          echo "::add-mask::$TOKEN"
+          echo "MCP_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+
+      - name: Run doctor
+        run: npx -y @mcpjam/cli@latest server doctor --url ${{ secrets.MCP_SERVER_URL }} --access-token $MCP_TOKEN --format json
+```
+
+### Option 2: Refresh token
+
+Best when you already have a refresh token from a previous `oauth login`. Refresh tokens are long-lived and safe to store as secrets. The CLI handles the token exchange automatically.
+
+**Secrets needed:**
+
+| Secret | Description |
+|---|---|
+| `MCP_SERVER_URL` | Your MCP server URL |
+| `MCP_REFRESH_TOKEN` | OAuth refresh token from a previous login |
+| `MCP_CLIENT_ID` | OAuth client ID (required with refresh tokens) |
+| `MCP_CLIENT_SECRET` | OAuth client secret (if the client is confidential) |
+
+```yaml
+name: MCP Health Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  mcp-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run doctor
+        run: |
+          npx -y @mcpjam/cli@latest server doctor \
+            --url ${{ secrets.MCP_SERVER_URL }} \
+            --refresh-token ${{ secrets.MCP_REFRESH_TOKEN }} \
+            --client-id ${{ secrets.MCP_CLIENT_ID }} \
+            --client-secret ${{ secrets.MCP_CLIENT_SECRET }} \
+            --format json
+```
+
+<Tip>
+To get a refresh token, run `mcpjam oauth login` locally with `--format json` and grab `.credentials.refreshToken` from the output.
+</Tip>
+
+### Option 3: Static API key
+
+Best when your server uses a non-expiring API key instead of OAuth.
+
+**Secrets needed:**
+
+| Secret | Description |
+|---|---|
+| `MCP_SERVER_URL` | Your MCP server URL |
+| `MCP_API_KEY` | Static API key |
+
+```yaml
+name: MCP Health Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  mcp-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run doctor
+        run: npx -y @mcpjam/cli@latest server doctor --url ${{ secrets.MCP_SERVER_URL }} --access-token ${{ secrets.MCP_API_KEY }} --format json
+```
+
+### Option 4: No auth
+
+Some servers don't require authentication at all.
+
+**Secrets needed:**
+
+| Secret | Description |
+|---|---|
+| `MCP_SERVER_URL` | Your MCP server URL |
+
+```yaml
+name: MCP Health Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  mcp-doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run doctor
+        run: npx -y @mcpjam/cli@latest server doctor --url ${{ secrets.MCP_SERVER_URL }} --format json
+```
+
+## Tool surface diffing
+
+Snapshot your tool surface before and after a deploy to catch breaking changes (renamed parameters, changed descriptions, removed tools).
+
+```yaml
+      - name: Snapshot before
+        run: npx -y @mcpjam/cli@latest server export --url ${{ secrets.MCP_SERVER_URL }} --access-token $MCP_TOKEN --format json > before.json
+
+      # your deploy step here
+
+      - name: Snapshot after
+        run: npx -y @mcpjam/cli@latest server export --url ${{ secrets.MCP_SERVER_URL }} --access-token $MCP_TOKEN --format json > after.json
+
+      - name: Diff
+        run: diff <(jq -S . before.json) <(jq -S . after.json)
+```
+
+## OAuth conformance suite
+
+Run the full registration x protocol version x auth mode matrix from a config file and output JUnit XML for test reporters.
+
+```yaml
+      - name: OAuth conformance
+        run: |
+          npx -y @mcpjam/cli@latest oauth conformance-suite \
+            --config ./oauth-matrix.json \
+            --format junit-xml > report.xml
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: oauth-conformance
+          path: report.xml
+```
+
+See [OAuth Conformance](/cli/oauth-conformance) for details on the config file format.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -47,6 +47,7 @@
           "cli/oauth-conformance",
           "cli/oauth-login",
           "cli/tools-resources-prompts",
+          "cli/ci-github-actions",
           "cli/reference"
         ]
       },


### PR DESCRIPTION
### TL;DR

Improved CLI description consistency and added comprehensive GitHub Actions documentation for CI integration.

### What changed?

- Simplified several description sentences to be more concise and direct
- Added new GitHub Actions documentation page (`ci-github-actions.mdx`) with four authentication methods: headless OAuth, refresh tokens, static API keys, and no auth
- Included examples for tool surface diffing and OAuth conformance testing in CI
- Added the new CI documentation to the docs navigation structure