### PR TITLE
rewire mascots to be more reusable and less regresssable

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -18,7 +18,7 @@ import { PromptsTab } from "./components/PromptsTab";
 import { SkillsTab } from "./components/SkillsTab";
 import { LearningTab } from "./components/LearningTab";
 import { TasksTab } from "./components/TasksTab";
-import { ChatTabV2 } from "./components/ChatTabV2";
+import { HostStyledChatTabV2 } from "./components/HostStyledChatTabV2";
 import type { EvalChatHandoff } from "./lib/eval-chat-handoff";
 import { EvalsTab } from "./components/EvalsTab";
 import { CiEvalsTab } from "./components/CiEvalsTab";
@@ -1571,7 +1571,7 @@ export default function App() {
             </ErrorBoundary>
           )}
           {activeTab === "chat-v2" && (
-            <ChatTabV2
+            <HostStyledChatTabV2
               connectedOrConnectingServerConfigs={
                 connectedOrConnectingServerConfigs
               }
@@ -1583,6 +1583,7 @@ export default function App() {
               onSelectedServerNamesChange={setSelectedMCPConfigs}
               onHasMessagesChange={setChatHasMessages}
               enableMultiModelChat
+              showHostStyleSelector
               evalChatHandoff={evalChatHandoff}
               onEvalChatHandoffConsumed={(id) =>
                 setEvalChatHandoff((current) =>

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -104,6 +104,7 @@ import {
   getChatComposerInteractivity,
   useChatStopControls,
 } from "@/hooks/use-chat-stop-controls";
+import type { SandboxHostStyle } from "@/lib/sandbox-host-style";
 
 interface ChatTabProps {
   connectedOrConnectingServerConfigs: Record<string, ServerWithName>;
@@ -132,6 +133,9 @@ interface ChatTabProps {
   initialRequireToolApproval?: boolean;
   reasoningDisplayMode?: ReasoningDisplayMode;
   loadingIndicatorVariant?: LoadingIndicatorVariant;
+  showHostStyleSelector?: boolean;
+  hostStyle?: SandboxHostStyle;
+  onHostStyleChange?: (hostStyle: SandboxHostStyle) => void;
   onOAuthRequired?: (details?: HostedOAuthRequiredDetails) => void;
   /** When true, blocks sending until sandbox onboarding/OAuth completes. */
   sandboxComposerBlocked?: boolean;
@@ -172,7 +176,10 @@ export function ChatTabV2({
   initialTemperature,
   initialRequireToolApproval,
   reasoningDisplayMode = "inline",
-  loadingIndicatorVariant = "default",
+  loadingIndicatorVariant,
+  showHostStyleSelector = false,
+  hostStyle,
+  onHostStyleChange,
   onOAuthRequired,
   sandboxComposerBlocked = false,
   sandboxComposerBlockedReason,
@@ -1858,6 +1865,9 @@ export function ChatTabV2({
     requireToolApproval,
     onRequireToolApprovalChange: handleRequireToolApprovalChange,
     minimalMode,
+    showHostStyleSelector,
+    hostStyle,
+    onHostStyleChange,
     allServerConfigs,
     onServerToggle,
     onReconnectServer,

--- a/mcpjam-inspector/client/src/components/HostStyledChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/HostStyledChatTabV2.tsx
@@ -1,0 +1,43 @@
+import type { ComponentProps } from "react";
+import { ChatTabV2 } from "./ChatTabV2";
+import {
+  SandboxHostStyleProvider,
+  SandboxHostThemeProvider,
+} from "@/contexts/sandbox-host-style-context";
+import { getSandboxShellStyle } from "@/lib/sandbox-host-style";
+import { cn } from "@/lib/utils";
+import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
+
+type HostStyledChatTabV2Props = ComponentProps<typeof ChatTabV2>;
+
+export function HostStyledChatTabV2({
+  showHostStyleSelector = false,
+  ...props
+}: HostStyledChatTabV2Props) {
+  const themeMode = usePreferencesStore((state) => state.themeMode);
+  const hostStyle = usePreferencesStore((state) => state.hostStyle);
+  const setHostStyle = usePreferencesStore((state) => state.setHostStyle);
+  const shellStyle = getSandboxShellStyle(hostStyle, themeMode);
+
+  return (
+    <SandboxHostStyleProvider value={hostStyle}>
+      <SandboxHostThemeProvider value={themeMode}>
+        <div
+          className={cn(
+            "sandbox-host-shell app-theme-scope flex h-full min-h-0 flex-1 flex-col overflow-hidden",
+            themeMode === "dark" && "dark",
+          )}
+          data-host-style={hostStyle}
+          style={shellStyle}
+        >
+          <ChatTabV2
+            {...props}
+            showHostStyleSelector={showHostStyleSelector}
+            hostStyle={hostStyle}
+            onHostStyleChange={setHostStyle}
+          />
+        </div>
+      </SandboxHostThemeProvider>
+    </SandboxHostStyleProvider>
+  );
+}

--- a/mcpjam-inspector/client/src/components/HostStyledChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/HostStyledChatTabV2.tsx
@@ -8,7 +8,10 @@ import { getSandboxShellStyle } from "@/lib/sandbox-host-style";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 
-type HostStyledChatTabV2Props = ComponentProps<typeof ChatTabV2>;
+type HostStyledChatTabV2Props = Omit<
+  ComponentProps<typeof ChatTabV2>,
+  "hostStyle" | "onHostStyleChange"
+>;
 
 export function HostStyledChatTabV2({
   showHostStyleSelector = false,

--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.trace-views.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.trace-views.test.tsx
@@ -586,6 +586,26 @@ describe("ChatTabV2 trace views", () => {
     });
   });
 
+  it("passes the host style selector props through to ChatInput when enabled", () => {
+    const onHostStyleChange = vi.fn();
+
+    render(
+      <ChatTabV2
+        {...defaultProps}
+        showHostStyleSelector={true}
+        hostStyle="chatgpt"
+        onHostStyleChange={onHostStyleChange}
+      />,
+    );
+
+    const chatInputProps = mockChatInput.mock.calls.at(-1)?.[0];
+    expect(chatInputProps).toMatchObject({
+      showHostStyleSelector: true,
+      hostStyle: "chatgpt",
+      onHostStyleChange,
+    });
+  });
+
   it("renders compare cards when multi-model chat is enabled on the main chat surface", () => {
     mockUseChatSession.availableModels = [
       {

--- a/mcpjam-inspector/client/src/components/__tests__/HostStyledChatTabV2.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/HostStyledChatTabV2.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HostStyledChatTabV2 } from "../HostStyledChatTabV2";
+import { PreferencesStoreProvider } from "@/stores/preferences/preferences-provider";
+import { HOST_STYLE_KEY } from "@/stores/preferences/preferences-store";
+
+const mockChatTabV2 = vi.hoisted(() => vi.fn());
+
+vi.mock("../ChatTabV2", async () => {
+  const {
+    useSandboxHostStyle,
+    useSandboxHostTheme,
+  } = await import("@/contexts/sandbox-host-style-context");
+
+  return {
+    ChatTabV2: (props: {
+      hostStyle?: string;
+      showHostStyleSelector?: boolean;
+      onHostStyleChange?: (hostStyle: "claude" | "chatgpt") => void;
+    }) => {
+      mockChatTabV2(props);
+      const hostStyle = useSandboxHostStyle();
+      const hostTheme = useSandboxHostTheme();
+
+      return (
+        <div
+          data-testid="wrapped-chat-tab"
+          data-context-host-style={hostStyle ?? ""}
+          data-context-host-theme={hostTheme ?? ""}
+        >
+          <span data-testid="wrapped-chat-prop-host-style">
+            {props.hostStyle ?? ""}
+          </span>
+          <span data-testid="wrapped-chat-prop-selector">
+            {props.showHostStyleSelector ? "true" : "false"}
+          </span>
+          <button
+            type="button"
+            onClick={() => props.onHostStyleChange?.("chatgpt")}
+          >
+            Switch host style
+          </button>
+        </div>
+      );
+    },
+  };
+});
+
+function renderWithPreferences(hostStyle?: "claude" | "chatgpt") {
+  if (hostStyle) {
+    localStorage.setItem(HOST_STYLE_KEY, hostStyle);
+  }
+
+  return render(
+    <PreferencesStoreProvider themeMode="dark" themePreset="default">
+      <HostStyledChatTabV2
+        connectedOrConnectingServerConfigs={{} as any}
+        selectedServerNames={[]}
+        showHostStyleSelector={true}
+      />
+    </PreferencesStoreProvider>,
+  );
+}
+
+describe("HostStyledChatTabV2", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("wraps ChatTabV2 with the shared host-style shell and selector props", () => {
+    renderWithPreferences("claude");
+
+    expect(screen.getByTestId("wrapped-chat-tab")).toHaveAttribute(
+      "data-context-host-style",
+      "claude",
+    );
+    expect(screen.getByTestId("wrapped-chat-tab")).toHaveAttribute(
+      "data-context-host-theme",
+      "dark",
+    );
+    expect(screen.getByTestId("wrapped-chat-prop-host-style")).toHaveTextContent(
+      "claude",
+    );
+    expect(screen.getByTestId("wrapped-chat-prop-selector")).toHaveTextContent(
+      "true",
+    );
+
+    const shell = screen.getByTestId("wrapped-chat-tab").parentElement;
+    expect(shell).toHaveAttribute("data-host-style", "claude");
+    expect(shell?.className).toContain("sandbox-host-shell");
+    expect(shell?.className).toContain("dark");
+    expect(shell?.getAttribute("style")).toContain("--background");
+  });
+
+  it("updates and persists the shared host style when ChatTabV2 changes it", () => {
+    const firstRender = renderWithPreferences("claude");
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch host style" }));
+
+    expect(screen.getByTestId("wrapped-chat-tab")).toHaveAttribute(
+      "data-context-host-style",
+      "chatgpt",
+    );
+    expect(screen.getByTestId("wrapped-chat-prop-host-style")).toHaveTextContent(
+      "chatgpt",
+    );
+    expect(localStorage.getItem(HOST_STYLE_KEY)).toBe("chatgpt");
+
+    firstRender.unmount();
+
+    renderWithPreferences();
+
+    expect(screen.getByTestId("wrapped-chat-tab")).toHaveAttribute(
+      "data-context-host-style",
+      "chatgpt",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/ChatInput.test.tsx
@@ -419,6 +419,79 @@ describe("ChatInput", () => {
     });
   });
 
+  describe("host style selector", () => {
+    it("shows the Claude/ChatGPT pill selector in the options menu when enabled", () => {
+      render(
+        <ChatInput
+          {...defaultProps}
+          showHostStyleSelector={true}
+          hostStyle="claude"
+          onHostStyleChange={vi.fn()}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Options" }));
+
+      expect(screen.getByText("Host Style")).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "ChatGPT" })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "Claude" })).toBeInTheDocument();
+    });
+
+    it("calls onHostStyleChange when the host style pill is changed", () => {
+      const onHostStyleChange = vi.fn();
+
+      render(
+        <ChatInput
+          {...defaultProps}
+          showHostStyleSelector={true}
+          hostStyle="claude"
+          onHostStyleChange={onHostStyleChange}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Options" }));
+      fireEvent.click(screen.getByRole("radio", { name: "ChatGPT" }));
+
+      expect(onHostStyleChange).toHaveBeenCalledWith("chatgpt");
+    });
+
+    it("renders the host style section after tool approval at the bottom of the menu", () => {
+      render(
+        <ChatInput
+          {...defaultProps}
+          showHostStyleSelector={true}
+          hostStyle="claude"
+          onHostStyleChange={vi.fn()}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Options" }));
+
+      const toolApproval = screen.getByText("Tool Approval");
+      const hostStyle = screen.getByText("Host Style");
+
+      expect(
+        toolApproval.compareDocumentPosition(hostStyle) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).not.toBe(0);
+    });
+
+    it("keeps the host style selector out of the options menu by default", () => {
+      render(
+        <ChatInput
+          {...defaultProps}
+          hostStyle="claude"
+          onHostStyleChange={vi.fn()}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Options" }));
+
+      expect(screen.queryByText("Host Style")).not.toBeInTheDocument();
+      expect(screen.queryByRole("radio", { name: "ChatGPT" })).not.toBeInTheDocument();
+    });
+  });
+
   describe("MCP prompt results", () => {
     it("renders MCP prompt cards when results exist", () => {
       const mcpPromptResults = [

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/FullscreenChatOverlay.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/FullscreenChatOverlay.test.tsx
@@ -12,14 +12,10 @@ import { FullscreenChatOverlay } from "../fullscreen-chat-overlay";
 vi.mock("../shared/loading-indicator-content", () => ({
   LoadingIndicatorContent: ({
     variant,
-    resolvedVariant,
   }: {
     variant?: string;
-    resolvedVariant?: string;
   }) => (
-    <div
-      data-testid={`loading-indicator-${resolvedVariant ?? variant ?? "default"}`}
-    />
+    <div data-testid={`loading-indicator-${variant ?? "default"}`} />
   ),
   useResolvedLoadingIndicatorVariant: (variant?: string) => variant ?? "default",
 }));

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/FullscreenChatOverlay.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/FullscreenChatOverlay.test.tsx
@@ -10,8 +10,16 @@ import {
 import { FullscreenChatOverlay } from "../fullscreen-chat-overlay";
 
 vi.mock("../shared/loading-indicator-content", () => ({
-  LoadingIndicatorContent: ({ variant }: { variant?: string }) => (
-    <div data-testid={`loading-indicator-${variant ?? "default"}`} />
+  LoadingIndicatorContent: ({
+    variant,
+    resolvedVariant,
+  }: {
+    variant?: string;
+    resolvedVariant?: string;
+  }) => (
+    <div
+      data-testid={`loading-indicator-${resolvedVariant ?? variant ?? "default"}`}
+    />
   ),
   useResolvedLoadingIndicatorVariant: (variant?: string) => variant ?? "default",
 }));

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/FullscreenChatOverlay.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/FullscreenChatOverlay.test.tsx
@@ -13,6 +13,7 @@ vi.mock("../shared/loading-indicator-content", () => ({
   LoadingIndicatorContent: ({ variant }: { variant?: string }) => (
     <div data-testid={`loading-indicator-${variant ?? "default"}`} />
   ),
+  useResolvedLoadingIndicatorVariant: (variant?: string) => variant ?? "default",
 }));
 
 vi.mock("../shared/claude-loading-indicator", () => ({

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/LoadingIndicatorContent.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/LoadingIndicatorContent.test.tsx
@@ -93,6 +93,19 @@ describe("LoadingIndicatorContent", () => {
     expect(screen.getByTestId("loading-indicator-dot")).toBeInTheDocument();
   });
 
+  it("renders an explicit resolvedVariant directly without host-style fallback", () => {
+    render(
+      <SandboxHostStyleProvider value="claude">
+        <LoadingIndicatorContent resolvedVariant="chatgpt-dot" />
+      </SandboxHostStyleProvider>,
+    );
+
+    expect(screen.getByTestId("loading-indicator-dot")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("loading-indicator-claude"),
+    ).not.toBeInTheDocument();
+  });
+
   it('treats variant="default" as fallback so host-style mascots still render', () => {
     render(
       <SandboxHostStyleProvider value="claude">

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/LoadingIndicatorContent.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/LoadingIndicatorContent.test.tsx
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { LoadingIndicatorContent } from "../shared/loading-indicator-content";
+import {
+  LoadingIndicatorContent,
+  resolveLoadingIndicatorVariant,
+} from "../shared/loading-indicator-content";
 import { ClaudeLoadingIndicator } from "../shared/claude-loading-indicator";
+import { SandboxHostStyleProvider } from "@/contexts/sandbox-host-style-context";
 
 const mockUseReducedMotion = vi.hoisted(() => vi.fn(() => false));
 
@@ -67,5 +71,85 @@ describe("LoadingIndicatorContent", () => {
     expect(
       screen.getByTestId("loading-indicator-claude-strip-800"),
     ).toHaveAttribute("hidden");
+  });
+
+  it("defaults to the Claude mascot for Claude-style sandbox hosts", () => {
+    render(
+      <SandboxHostStyleProvider value="claude">
+        <LoadingIndicatorContent />
+      </SandboxHostStyleProvider>,
+    );
+
+    expect(screen.getByTestId("loading-indicator-claude")).toBeInTheDocument();
+  });
+
+  it("defaults to the GPT pulse for ChatGPT-style sandbox hosts", () => {
+    render(
+      <SandboxHostStyleProvider value="chatgpt">
+        <LoadingIndicatorContent />
+      </SandboxHostStyleProvider>,
+    );
+
+    expect(screen.getByTestId("loading-indicator-dot")).toBeInTheDocument();
+  });
+
+  it('treats variant="default" as fallback so host-style mascots still render', () => {
+    render(
+      <SandboxHostStyleProvider value="claude">
+        <LoadingIndicatorContent variant="default" />
+      </SandboxHostStyleProvider>,
+    );
+
+    expect(screen.getByTestId("loading-indicator-claude")).toBeInTheDocument();
+  });
+
+  it("treats undefined variant as fallback to host style", () => {
+    expect(
+      resolveLoadingIndicatorVariant({
+        variant: undefined,
+        hostStyle: "chatgpt",
+      }),
+    ).toBe("chatgpt-dot");
+  });
+
+  it('treats variant="default" as fallback to host style', () => {
+    expect(
+      resolveLoadingIndicatorVariant({
+        variant: "default",
+        hostStyle: "claude",
+      }),
+    ).toBe("claude-mark");
+  });
+
+  it("preserves explicit loading-indicator overrides", () => {
+    expect(
+      resolveLoadingIndicatorVariant({
+        variant: "chatgpt-dot",
+        hostStyle: "claude",
+        modelProvider: "anthropic",
+      }),
+    ).toBe("chatgpt-dot");
+    expect(
+      resolveLoadingIndicatorVariant({
+        variant: "claude-mark",
+        hostStyle: "chatgpt",
+        modelProvider: "openai",
+      }),
+    ).toBe("claude-mark");
+  });
+
+  it("falls back to the model provider when no explicit or host style override exists", () => {
+    expect(
+      resolveLoadingIndicatorVariant({
+        variant: undefined,
+        modelProvider: "openai",
+      }),
+    ).toBe("chatgpt-dot");
+    expect(
+      resolveLoadingIndicatorVariant({
+        variant: "default",
+        modelProvider: "anthropic",
+      }),
+    ).toBe("claude-mark");
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/LoadingIndicatorContent.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/LoadingIndicatorContent.test.tsx
@@ -93,19 +93,6 @@ describe("LoadingIndicatorContent", () => {
     expect(screen.getByTestId("loading-indicator-dot")).toBeInTheDocument();
   });
 
-  it("renders an explicit resolvedVariant directly without host-style fallback", () => {
-    render(
-      <SandboxHostStyleProvider value="claude">
-        <LoadingIndicatorContent resolvedVariant="chatgpt-dot" />
-      </SandboxHostStyleProvider>,
-    );
-
-    expect(screen.getByTestId("loading-indicator-dot")).toBeInTheDocument();
-    expect(
-      screen.queryByTestId("loading-indicator-claude"),
-    ).not.toBeInTheDocument();
-  });
-
   it('treats variant="default" as fallback so host-style mascots still render', () => {
     render(
       <SandboxHostStyleProvider value="claude">

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/ThinkingIndicator.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/ThinkingIndicator.test.tsx
@@ -68,7 +68,7 @@ describe("ThinkingIndicator", () => {
 
   it("renders the pulsing dot variant with hidden accessible text", () => {
     renderThinkingIndicator(
-      <ThinkingIndicator model={defaultModel} variant="chatgpt-dot" />,
+      <ThinkingIndicator model={defaultModel} resolvedVariant="chatgpt-dot" />,
     );
 
     expect(screen.getByTestId("loading-indicator-dot")).toBeInTheDocument();
@@ -79,7 +79,7 @@ describe("ThinkingIndicator", () => {
 
   it("renders the animated Claude mark variant with hidden accessible text", () => {
     renderThinkingIndicator(
-      <ThinkingIndicator model={defaultModel} variant="claude-mark" />,
+      <ThinkingIndicator model={defaultModel} resolvedVariant="claude-mark" />,
     );
 
     expect(screen.getByTestId("loading-indicator-claude")).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/ThinkingIndicator.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/ThinkingIndicator.test.tsx
@@ -40,7 +40,9 @@ describe("ThinkingIndicator", () => {
     );
 
   it("renders a leading assistant avatar outside host-style contexts", () => {
-    renderThinkingIndicator(<ThinkingIndicator model={defaultModel} />);
+    renderThinkingIndicator(
+      <ThinkingIndicator model={defaultModel} resolvedVariant="default" />,
+    );
 
     expect(screen.getByRole("img")).toBeInTheDocument();
     expect(screen.getByLabelText("GPT-4 assistant")).toBeInTheDocument();
@@ -49,7 +51,7 @@ describe("ThinkingIndicator", () => {
   it("hides the leading assistant avatar in sandbox host-style contexts", () => {
     renderThinkingIndicator(
       <SandboxHostStyleProvider value="claude">
-        <ThinkingIndicator model={defaultModel} />
+        <ThinkingIndicator model={defaultModel} resolvedVariant="default" />
       </SandboxHostStyleProvider>,
     );
 
@@ -58,7 +60,9 @@ describe("ThinkingIndicator", () => {
   });
 
   it("keeps the default visible thinking label", () => {
-    renderThinkingIndicator(<ThinkingIndicator model={defaultModel} />);
+    renderThinkingIndicator(
+      <ThinkingIndicator model={defaultModel} resolvedVariant="default" />,
+    );
 
     expect(screen.getByText(/Thinking/)).toBeInTheDocument();
     expect(

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/Thread.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/Thread.test.tsx
@@ -255,6 +255,43 @@ describe("Thread", () => {
       );
     });
 
+    it("defaults to the GPT pulse for OpenAI models when no explicit variant is provided", () => {
+      const messages = [createMessage({ id: "msg-1", role: "user" })];
+
+      render(<Thread {...defaultProps} messages={messages} isLoading={true} />);
+
+      expect(mockThinkingIndicator).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "chatgpt-dot",
+        }),
+      );
+    });
+
+    it("defaults to the Claude mascot for Anthropic models when no explicit variant is provided", () => {
+      const messages = [createMessage({ id: "msg-1", role: "user" })];
+      const claudeModel: ModelDefinition = {
+        ...defaultModel,
+        id: "anthropic/claude-sonnet-4.5",
+        name: "Claude Sonnet 4.5",
+        provider: "anthropic",
+      };
+
+      render(
+        <Thread
+          {...defaultProps}
+          model={claudeModel}
+          messages={messages}
+          isLoading={true}
+        />,
+      );
+
+      expect(mockThinkingIndicator).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "claude-mark",
+        }),
+      );
+    });
+
     it("passes the selected loading indicator variant to the inline indicator", () => {
       render(
         <Thread

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/Thread.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/Thread.test.tsx
@@ -29,12 +29,12 @@ vi.mock("../thread/message-view", () => ({
 vi.mock("../shared/thinking-indicator", () => ({
   ThinkingIndicator: ({
     model,
-    variant,
+    resolvedVariant,
   }: {
     model: ModelDefinition;
-    variant?: string;
+    resolvedVariant?: string;
   }) => {
-    mockThinkingIndicator({ model, variant });
+    mockThinkingIndicator({ model, resolvedVariant });
     return (
       <div data-testid="thinking-indicator">Thinking... ({model.name})</div>
     );
@@ -262,7 +262,7 @@ describe("Thread", () => {
 
       expect(mockThinkingIndicator).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: "chatgpt-dot",
+          resolvedVariant: "chatgpt-dot",
         }),
       );
     });
@@ -287,7 +287,7 @@ describe("Thread", () => {
 
       expect(mockThinkingIndicator).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: "claude-mark",
+          resolvedVariant: "claude-mark",
         }),
       );
     });
@@ -303,7 +303,7 @@ describe("Thread", () => {
 
       expect(mockThinkingIndicator).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: "claude-mark",
+          resolvedVariant: "claude-mark",
         }),
       );
     });
@@ -323,7 +323,7 @@ describe("Thread", () => {
       expect(screen.getByTestId("thinking-indicator")).toBeInTheDocument();
       expect(mockThinkingIndicator).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: "chatgpt-dot",
+          resolvedVariant: "chatgpt-dot",
         }),
       );
     });
@@ -368,7 +368,7 @@ describe("Thread", () => {
       expect(screen.getByTestId("thinking-indicator")).toBeInTheDocument();
       expect(mockThinkingIndicator).toHaveBeenCalledWith(
         expect.objectContaining({
-          variant: "claude-mark",
+          resolvedVariant: "claude-mark",
         }),
       );
       expect(mockMessageView).toHaveBeenCalledWith(
@@ -544,7 +544,7 @@ describe("Thread", () => {
       expect(screen.getByTestId("fullscreen-chat-overlay")).toBeInTheDocument();
       expect(mockFullscreenChatOverlay).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          loadingIndicatorVariant: "claude-mark",
+          resolvedLoadingIndicatorVariant: "claude-mark",
         }),
       );
     });

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/Thread.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/Thread.test.tsx
@@ -32,7 +32,7 @@ vi.mock("../shared/thinking-indicator", () => ({
     resolvedVariant,
   }: {
     model: ModelDefinition;
-    resolvedVariant?: string;
+    resolvedVariant: string;
   }) => {
     mockThinkingIndicator({ model, resolvedVariant });
     return (
@@ -544,7 +544,7 @@ describe("Thread", () => {
       expect(screen.getByTestId("fullscreen-chat-overlay")).toBeInTheDocument();
       expect(mockFullscreenChatOverlay).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          resolvedLoadingIndicatorVariant: "claude-mark",
+          loadingIndicatorVariant: "claude-mark",
         }),
       );
     });

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/TranscriptThread.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/TranscriptThread.test.tsx
@@ -9,7 +9,11 @@ import { TranscriptThread } from "../thread/transcript-thread";
 const mockMessageView = vi.fn();
 
 vi.mock("../thread/message-view", () => ({
-  MessageView: (props: { message: UIMessage; model: ModelDefinition }) => {
+  MessageView: (props: {
+    message: UIMessage;
+    model: ModelDefinition;
+    claudeFooterMode?: "none" | "animated" | "static";
+  }) => {
     mockMessageView(props);
     const { message, model } = props;
     return (
@@ -257,6 +261,48 @@ describe("TranscriptThread", () => {
     expect(wrapper?.className).toContain("bg-primary/5");
     expect(screen.getByTestId("transcript-focus-guide")).toBeInTheDocument();
     expect(screen.getByTestId("message-assistant-1")).toBeInTheDocument();
+  });
+
+  it("uses the resolved Claude variant to attach an animated footer to the latest assistant message", () => {
+    render(
+      <TranscriptThread
+        {...defaultProps}
+        isLoading={true}
+        resolvedLoadingIndicatorVariant="claude-mark"
+        lastRenderableMessageId="assistant-1"
+      />,
+    );
+
+    expect(mockMessageView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({ id: "assistant-1" }),
+        claudeFooterMode: "animated",
+      }),
+    );
+    expect(mockMessageView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({ id: "user-1" }),
+        claudeFooterMode: "none",
+      }),
+    );
+  });
+
+  it("uses the resolved Claude variant to keep the latest assistant footer static after loading", () => {
+    render(
+      <TranscriptThread
+        {...defaultProps}
+        isLoading={false}
+        resolvedLoadingIndicatorVariant="claude-mark"
+        lastRenderableMessageId="assistant-1"
+      />,
+    );
+
+    expect(mockMessageView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({ id: "assistant-1" }),
+        claudeFooterMode: "static",
+      }),
+    );
   });
 
   it("scrolls the focused message using the nearest scrollable ancestor", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -69,6 +69,8 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { HostStylePillSelector } from "@/components/shared/HostStylePillSelector";
+import type { SandboxHostStyle } from "@/lib/sandbox-host-style";
 
 interface ChatInputProps {
   value: string;
@@ -121,6 +123,12 @@ interface ChatInputProps {
   onRequireToolApprovalChange?: (enabled: boolean) => void;
   /** Shared chat-only mode */
   minimalMode?: boolean;
+  /** Main chat: show the Claude/ChatGPT host-style selector in the "+" menu. */
+  showHostStyleSelector?: boolean;
+  /** Current host style for the selector UI. */
+  hostStyle?: SandboxHostStyle;
+  /** Shared host-style setter. */
+  onHostStyleChange?: (hostStyle: SandboxHostStyle) => void;
   /** Onboarding: pulse the send button with glow animation */
   pulseSubmit?: boolean;
   /** Move the textarea caret to the end when this trigger changes */
@@ -182,6 +190,9 @@ export function ChatInput({
   requireToolApproval = false,
   onRequireToolApprovalChange,
   minimalMode = false,
+  showHostStyleSelector = false,
+  hostStyle,
+  onHostStyleChange,
   pulseSubmit = false,
   moveCaretToEndTrigger,
   allServerConfigs,
@@ -218,6 +229,15 @@ export function ChatInput({
   };
   const [addServerModalOpen, setAddServerModalOpen] = useState(false);
   const [systemPromptOpen, setSystemPromptOpen] = useState(false);
+  const selectorHostStyle = hostStyle ?? sandboxHostStyle;
+  const hasServerOptions = Boolean(
+    onAddServer ||
+      (allServerConfigs && Object.keys(allServerConfigs).length > 0),
+  );
+  const showHostStyleSelectorControl =
+    showHostStyleSelector &&
+    Boolean(selectorHostStyle) &&
+    Boolean(onHostStyleChange);
 
   const caret = useTextareaCaretPosition(
     textareaRef,
@@ -606,10 +626,7 @@ export function ChatInput({
                     side="top"
                     sideOffset={8}
                   >
-                    {(onAddServer ||
-                      (allServerConfigs &&
-                        onServerToggle &&
-                        Object.keys(allServerConfigs).length > 0)) && (
+                    {hasServerOptions && (
                       <div className="px-1 pt-1 pb-0">
                         <p className="px-2 py-1.5 text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
                           Servers
@@ -728,9 +745,7 @@ export function ChatInput({
                     <div
                       className={cn(
                         "px-1 pb-1",
-                        allServerConfigs &&
-                          Object.keys(allServerConfigs).length > 0 &&
-                          "border-t border-border mt-1 pt-1",
+                        hasServerOptions && "border-t border-border mt-1 pt-1",
                       )}
                     >
                       {onChangeFileAttachments && (
@@ -775,6 +790,23 @@ export function ChatInput({
                               onRequireToolApprovalChange(checked)
                             }
                           />
+                        </div>
+                      )}
+
+                      {showHostStyleSelectorControl && selectorHostStyle && (
+                        <div className="mt-1 border-t border-border/70 px-2 py-[5px]">
+                          <div className="flex items-center justify-between gap-2">
+                            <p className="shrink-0 text-[9px] font-medium text-muted-foreground uppercase tracking-[0.18em]">
+                              Host Style
+                            </p>
+                            <HostStylePillSelector
+                              className="w-[164px] shrink-0"
+                              value={selectorHostStyle}
+                              onValueChange={(nextStyle) =>
+                                onHostStyleChange?.(nextStyle)
+                              }
+                            />
+                          </div>
                         </div>
                       )}
                     </div>

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input.tsx
@@ -230,9 +230,13 @@ export function ChatInput({
   const [addServerModalOpen, setAddServerModalOpen] = useState(false);
   const [systemPromptOpen, setSystemPromptOpen] = useState(false);
   const selectorHostStyle = hostStyle ?? sandboxHostStyle;
+  const hasServerRows = Boolean(
+    allServerConfigs &&
+      onServerToggle &&
+      Object.keys(allServerConfigs).length > 0,
+  );
   const hasServerOptions = Boolean(
-    onAddServer ||
-      (allServerConfigs && Object.keys(allServerConfigs).length > 0),
+    onAddServer || hasServerRows,
   );
   const showHostStyleSelectorControl =
     showHostStyleSelector &&
@@ -745,7 +749,9 @@ export function ChatInput({
                     <div
                       className={cn(
                         "px-1 pb-1",
-                        hasServerOptions && "border-t border-border mt-1 pt-1",
+                        allServerConfigs &&
+                          Object.keys(allServerConfigs).length > 0 &&
+                          "border-t border-border mt-1 pt-1",
                       )}
                     >
                       {onChangeFileAttachments && (

--- a/mcpjam-inspector/client/src/components/chat-v2/fullscreen-chat-overlay.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/fullscreen-chat-overlay.tsx
@@ -16,6 +16,7 @@ import { TextareaAutosize } from "@/components/ui/textarea-autosize";
 import {
   LoadingIndicatorContent,
   type LoadingIndicatorVariant,
+  useResolvedLoadingIndicatorVariant,
 } from "@/components/chat-v2/shared/loading-indicator-content";
 import { ClaudeLoadingIndicator } from "@/components/chat-v2/shared/claude-loading-indicator";
 import { getRenderableConversationMessages } from "@/components/chat-v2/thread/thread-helpers";
@@ -139,16 +140,19 @@ function MessageBubble({
 }
 
 function ThinkingRow({
-  variant = "default",
+  variant,
 }: {
   variant?: LoadingIndicatorVariant;
 }) {
+  const shouldRenderDefaultBubble =
+    variant !== "claude-mark" && variant !== "chatgpt-dot";
+
   return (
     <div
       data-testid="fullscreen-thinking-row"
       className="flex w-full justify-start"
     >
-      {variant === "default" ? (
+      {shouldRenderDefaultBubble ? (
         <div className="inline-flex items-center gap-2 rounded-2xl bg-muted px-3 py-2 text-sm text-muted-foreground/80">
           <LoadingIndicatorContent variant={variant} />
         </div>
@@ -192,7 +196,7 @@ function MessageList({
   messages,
   isThinking,
   open,
-  loadingIndicatorVariant = "default",
+  loadingIndicatorVariant,
 }: {
   messages: UIMessage[];
   isThinking: boolean;
@@ -373,7 +377,7 @@ export function FullscreenChatOverlay({
   disabled,
   canSend,
   isThinking,
-  loadingIndicatorVariant = "default",
+  loadingIndicatorVariant,
   onStop,
   onSend,
 }: {
@@ -392,6 +396,8 @@ export function FullscreenChatOverlay({
 }) {
   const sandboxHostStyle = useSandboxHostStyle();
   const sandboxHostTheme = useSandboxHostTheme();
+  const resolvedLoadingIndicatorVariant =
+    useResolvedLoadingIndicatorVariant(loadingIndicatorVariant);
   const resolvedThemeMode = sandboxHostTheme ?? "light";
   const isDarkSandboxTheme = resolvedThemeMode === "dark";
   const appearance = useMemo(
@@ -415,7 +421,7 @@ export function FullscreenChatOverlay({
             messages={messages}
             isThinking={isThinking}
             open={open}
-            loadingIndicatorVariant={loadingIndicatorVariant}
+            loadingIndicatorVariant={resolvedLoadingIndicatorVariant}
           />
           <Composer
             value={input}

--- a/mcpjam-inspector/client/src/components/chat-v2/fullscreen-chat-overlay.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/fullscreen-chat-overlay.tsx
@@ -154,16 +154,10 @@ function ThinkingRow({
     >
       {shouldRenderDefaultBubble ? (
         <div className="inline-flex items-center gap-2 rounded-2xl bg-muted px-3 py-2 text-sm text-muted-foreground/80">
-          {resolvedVariant !== undefined ? (
-            <LoadingIndicatorContent resolvedVariant={resolvedVariant} />
-          ) : (
-            <LoadingIndicatorContent />
-          )}
+          <LoadingIndicatorContent variant={resolvedVariant} />
         </div>
       ) : (
-        <LoadingIndicatorContent
-          resolvedVariant={resolvedVariant ?? "default"}
-        />
+        <LoadingIndicatorContent variant={resolvedVariant} />
       )}
     </div>
   );
@@ -373,7 +367,7 @@ function Composer({
   );
 }
 
-type FullscreenChatOverlayBaseProps = {
+type FullscreenChatOverlayProps = {
   messages: UIMessage[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -383,21 +377,11 @@ type FullscreenChatOverlayBaseProps = {
   disabled: boolean;
   canSend: boolean;
   isThinking: boolean;
+  loadingIndicatorVariant?: LoadingIndicatorVariant;
   onStop?: () => void;
   onSend: () => void;
 };
-
-type FullscreenChatOverlayProps =
-  | (FullscreenChatOverlayBaseProps & {
-      loadingIndicatorVariant?: LoadingIndicatorVariant;
-      resolvedLoadingIndicatorVariant?: undefined;
-    })
-  | (FullscreenChatOverlayBaseProps & {
-      loadingIndicatorVariant?: never;
-      resolvedLoadingIndicatorVariant: LoadingIndicatorVariant;
-    });
-
-function ResolvedFullscreenChatOverlay({
+export function FullscreenChatOverlay({
   messages,
   open,
   onOpenChange,
@@ -407,14 +391,14 @@ function ResolvedFullscreenChatOverlay({
   disabled,
   canSend,
   isThinking,
-  resolvedLoadingIndicatorVariant,
+  loadingIndicatorVariant,
   onStop,
   onSend,
-}: FullscreenChatOverlayBaseProps & {
-  resolvedLoadingIndicatorVariant: LoadingIndicatorVariant;
-}) {
+}: FullscreenChatOverlayProps) {
   const sandboxHostStyle = useSandboxHostStyle();
   const sandboxHostTheme = useSandboxHostTheme();
+  const resolvedLoadingIndicatorVariant =
+    useResolvedLoadingIndicatorVariant(loadingIndicatorVariant);
   const resolvedThemeMode = sandboxHostTheme ?? "light";
   const isDarkSandboxTheme = resolvedThemeMode === "dark";
   const appearance = useMemo(
@@ -463,36 +447,4 @@ function ResolvedFullscreenChatOverlay({
       </div>
     </div>
   );
-}
-
-function SelfResolvingFullscreenChatOverlay({
-  loadingIndicatorVariant,
-  ...props
-}: FullscreenChatOverlayBaseProps & {
-  loadingIndicatorVariant?: LoadingIndicatorVariant;
-}) {
-  const resolvedLoadingIndicatorVariant =
-    useResolvedLoadingIndicatorVariant(loadingIndicatorVariant);
-
-  return (
-    <ResolvedFullscreenChatOverlay
-      {...props}
-      resolvedLoadingIndicatorVariant={resolvedLoadingIndicatorVariant}
-    />
-  );
-}
-
-export function FullscreenChatOverlay(props: FullscreenChatOverlayProps) {
-  if (props.resolvedLoadingIndicatorVariant !== undefined) {
-    const { resolvedLoadingIndicatorVariant, ...rest } = props;
-
-    return (
-      <ResolvedFullscreenChatOverlay
-        {...rest}
-        resolvedLoadingIndicatorVariant={resolvedLoadingIndicatorVariant}
-      />
-    );
-  }
-
-  return <SelfResolvingFullscreenChatOverlay {...props} />;
 }

--- a/mcpjam-inspector/client/src/components/chat-v2/fullscreen-chat-overlay.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/fullscreen-chat-overlay.tsx
@@ -140,12 +140,12 @@ function MessageBubble({
 }
 
 function ThinkingRow({
-  variant,
+  resolvedVariant,
 }: {
-  variant?: LoadingIndicatorVariant;
+  resolvedVariant?: LoadingIndicatorVariant;
 }) {
   const shouldRenderDefaultBubble =
-    variant !== "claude-mark" && variant !== "chatgpt-dot";
+    resolvedVariant !== "claude-mark" && resolvedVariant !== "chatgpt-dot";
 
   return (
     <div
@@ -154,10 +154,16 @@ function ThinkingRow({
     >
       {shouldRenderDefaultBubble ? (
         <div className="inline-flex items-center gap-2 rounded-2xl bg-muted px-3 py-2 text-sm text-muted-foreground/80">
-          <LoadingIndicatorContent variant={variant} />
+          {resolvedVariant !== undefined ? (
+            <LoadingIndicatorContent resolvedVariant={resolvedVariant} />
+          ) : (
+            <LoadingIndicatorContent />
+          )}
         </div>
       ) : (
-        <LoadingIndicatorContent variant={variant} />
+        <LoadingIndicatorContent
+          resolvedVariant={resolvedVariant ?? "default"}
+        />
       )}
     </div>
   );
@@ -196,12 +202,12 @@ function MessageList({
   messages,
   isThinking,
   open,
-  loadingIndicatorVariant,
+  resolvedLoadingIndicatorVariant,
 }: {
   messages: UIMessage[];
   isThinking: boolean;
   open: boolean;
-  loadingIndicatorVariant?: LoadingIndicatorVariant;
+  resolvedLoadingIndicatorVariant?: LoadingIndicatorVariant;
 }) {
   const bottomRef = useRef<HTMLDivElement>(null);
 
@@ -218,8 +224,8 @@ function MessageList({
   const lastVisibleMessage = visibleMessages.at(-1)?.message ?? null;
   const hasVisibleAssistantResponse = lastVisibleMessage?.role === "assistant";
   const shouldShowStandaloneThinkingRow =
-    loadingIndicatorVariant === "claude-mark" ||
-    loadingIndicatorVariant === "chatgpt-dot"
+    resolvedLoadingIndicatorVariant === "claude-mark" ||
+    resolvedLoadingIndicatorVariant === "chatgpt-dot"
       ? isThinking && !hasVisibleAssistantResponse
       : isThinking;
 
@@ -235,7 +241,7 @@ function MessageList({
       <div className="max-h-[45vh] overflow-y-auto px-4 py-3 space-y-3">
         {visibleMessages.map(({ message, text }, idx) => {
           const claudeFooterMode =
-            loadingIndicatorVariant === "claude-mark" &&
+            resolvedLoadingIndicatorVariant === "claude-mark" &&
             message.role === "assistant" &&
             message.id === lastVisibleMessage?.id
               ? isThinking
@@ -252,7 +258,7 @@ function MessageList({
           );
         })}
         {shouldShowStandaloneThinkingRow ? (
-          <ThinkingRow variant={loadingIndicatorVariant} />
+          <ThinkingRow resolvedVariant={resolvedLoadingIndicatorVariant} />
         ) : null}
         <div ref={bottomRef} />
       </div>
@@ -367,20 +373,7 @@ function Composer({
   );
 }
 
-export function FullscreenChatOverlay({
-  messages,
-  open,
-  onOpenChange,
-  input,
-  onInputChange,
-  placeholder,
-  disabled,
-  canSend,
-  isThinking,
-  loadingIndicatorVariant,
-  onStop,
-  onSend,
-}: {
+type FullscreenChatOverlayBaseProps = {
   messages: UIMessage[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -390,14 +383,38 @@ export function FullscreenChatOverlay({
   disabled: boolean;
   canSend: boolean;
   isThinking: boolean;
-  loadingIndicatorVariant?: LoadingIndicatorVariant;
   onStop?: () => void;
   onSend: () => void;
+};
+
+type FullscreenChatOverlayProps =
+  | (FullscreenChatOverlayBaseProps & {
+      loadingIndicatorVariant?: LoadingIndicatorVariant;
+      resolvedLoadingIndicatorVariant?: undefined;
+    })
+  | (FullscreenChatOverlayBaseProps & {
+      loadingIndicatorVariant?: never;
+      resolvedLoadingIndicatorVariant: LoadingIndicatorVariant;
+    });
+
+function ResolvedFullscreenChatOverlay({
+  messages,
+  open,
+  onOpenChange,
+  input,
+  onInputChange,
+  placeholder,
+  disabled,
+  canSend,
+  isThinking,
+  resolvedLoadingIndicatorVariant,
+  onStop,
+  onSend,
+}: FullscreenChatOverlayBaseProps & {
+  resolvedLoadingIndicatorVariant: LoadingIndicatorVariant;
 }) {
   const sandboxHostStyle = useSandboxHostStyle();
   const sandboxHostTheme = useSandboxHostTheme();
-  const resolvedLoadingIndicatorVariant =
-    useResolvedLoadingIndicatorVariant(loadingIndicatorVariant);
   const resolvedThemeMode = sandboxHostTheme ?? "light";
   const isDarkSandboxTheme = resolvedThemeMode === "dark";
   const appearance = useMemo(
@@ -421,7 +438,7 @@ export function FullscreenChatOverlay({
             messages={messages}
             isThinking={isThinking}
             open={open}
-            loadingIndicatorVariant={resolvedLoadingIndicatorVariant}
+            resolvedLoadingIndicatorVariant={resolvedLoadingIndicatorVariant}
           />
           <Composer
             value={input}
@@ -446,4 +463,36 @@ export function FullscreenChatOverlay({
       </div>
     </div>
   );
+}
+
+function SelfResolvingFullscreenChatOverlay({
+  loadingIndicatorVariant,
+  ...props
+}: FullscreenChatOverlayBaseProps & {
+  loadingIndicatorVariant?: LoadingIndicatorVariant;
+}) {
+  const resolvedLoadingIndicatorVariant =
+    useResolvedLoadingIndicatorVariant(loadingIndicatorVariant);
+
+  return (
+    <ResolvedFullscreenChatOverlay
+      {...props}
+      resolvedLoadingIndicatorVariant={resolvedLoadingIndicatorVariant}
+    />
+  );
+}
+
+export function FullscreenChatOverlay(props: FullscreenChatOverlayProps) {
+  if (props.resolvedLoadingIndicatorVariant !== undefined) {
+    const { resolvedLoadingIndicatorVariant, ...rest } = props;
+
+    return (
+      <ResolvedFullscreenChatOverlay
+        {...rest}
+        resolvedLoadingIndicatorVariant={resolvedLoadingIndicatorVariant}
+      />
+    );
+  }
+
+  return <SelfResolvingFullscreenChatOverlay {...props} />;
 }

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/loading-indicator-content.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/loading-indicator-content.tsx
@@ -1,3 +1,5 @@
+import { useSandboxHostStyle } from "@/contexts/sandbox-host-style-context";
+import type { SandboxHostStyle } from "@/lib/sandbox-host-style";
 import { cn } from "@/lib/utils";
 import { ClaudeLoadingIndicator } from "./claude-loading-indicator";
 
@@ -8,15 +10,74 @@ interface LoadingIndicatorContentProps {
   className?: string;
 }
 
+export function getLoadingIndicatorVariantForHostStyle(
+  hostStyle: SandboxHostStyle | null | undefined,
+): LoadingIndicatorVariant {
+  if (hostStyle === "chatgpt") {
+    return "chatgpt-dot";
+  }
+
+  if (hostStyle === "claude") {
+    return "claude-mark";
+  }
+
+  return "default";
+}
+
+export function resolveLoadingIndicatorVariant({
+  variant,
+  hostStyle,
+  modelProvider,
+}: {
+  variant?: LoadingIndicatorVariant;
+  hostStyle?: SandboxHostStyle | null;
+  modelProvider?: string | null;
+}): LoadingIndicatorVariant {
+  if (variant !== undefined && variant !== "default") {
+    return variant;
+  }
+
+  const hostVariant = getLoadingIndicatorVariantForHostStyle(hostStyle);
+  if (hostVariant !== "default") {
+    return hostVariant;
+  }
+
+  const normalizedProvider = modelProvider?.toLowerCase();
+  if (normalizedProvider === "openai") {
+    return "chatgpt-dot";
+  }
+
+  if (normalizedProvider === "anthropic") {
+    return "claude-mark";
+  }
+
+  return "default";
+}
+
+export function useResolvedLoadingIndicatorVariant(
+  variant?: LoadingIndicatorVariant,
+  options?: { modelProvider?: string | null },
+): LoadingIndicatorVariant {
+  const sandboxHostStyle = useSandboxHostStyle();
+
+  return resolveLoadingIndicatorVariant({
+    variant,
+    hostStyle: sandboxHostStyle,
+    modelProvider: options?.modelProvider,
+  });
+}
+
 export function LoadingIndicatorContent({
-  variant = "default",
+  variant,
   className,
 }: LoadingIndicatorContentProps) {
-  if (variant === "claude-mark") {
+  const resolvedVariant = useResolvedLoadingIndicatorVariant(variant);
+
+  if (resolvedVariant === "claude-mark") {
     return <ClaudeLoadingIndicator className={className} />;
   }
 
-  if (variant === "chatgpt-dot") {
+  if (resolvedVariant === "chatgpt-dot") {
     return (
       <span className={cn("inline-flex min-h-6 items-center", className)}>
         <span className="sr-only">Thinking</span>

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/loading-indicator-content.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/loading-indicator-content.tsx
@@ -5,18 +5,6 @@ import { ClaudeLoadingIndicator } from "./claude-loading-indicator";
 
 export type LoadingIndicatorVariant = "default" | "chatgpt-dot" | "claude-mark";
 
-type LoadingIndicatorContentProps =
-  | {
-      resolvedVariant: LoadingIndicatorVariant;
-      variant?: never;
-      className?: string;
-    }
-  | {
-      resolvedVariant?: undefined;
-      variant?: LoadingIndicatorVariant;
-      className?: string;
-    };
-
 export function getLoadingIndicatorVariantForHostStyle(
   hostStyle: SandboxHostStyle | null | undefined,
 ): LoadingIndicatorVariant {
@@ -74,13 +62,15 @@ export function useResolvedLoadingIndicatorVariant(
   });
 }
 
-function ResolvedLoadingIndicatorContent({
-  resolvedVariant,
+export function LoadingIndicatorContent({
+  variant,
   className,
 }: {
-  resolvedVariant: LoadingIndicatorVariant;
+  variant?: LoadingIndicatorVariant;
   className?: string;
 }) {
+  const resolvedVariant = useResolvedLoadingIndicatorVariant(variant);
+
   if (resolvedVariant === "claude-mark") {
     return <ClaudeLoadingIndicator className={className} />;
   }
@@ -111,40 +101,5 @@ function ResolvedLoadingIndicatorContent({
         </span>
       </span>
     </span>
-  );
-}
-
-function SelfResolvingLoadingIndicatorContent({
-  variant,
-  className,
-}: {
-  variant?: LoadingIndicatorVariant;
-  className?: string;
-}) {
-  const resolvedVariant = useResolvedLoadingIndicatorVariant(variant);
-
-  return (
-    <ResolvedLoadingIndicatorContent
-      resolvedVariant={resolvedVariant}
-      className={className}
-    />
-  );
-}
-
-export function LoadingIndicatorContent(props: LoadingIndicatorContentProps) {
-  if (props.resolvedVariant !== undefined) {
-    return (
-      <ResolvedLoadingIndicatorContent
-        resolvedVariant={props.resolvedVariant}
-        className={props.className}
-      />
-    );
-  }
-
-  return (
-    <SelfResolvingLoadingIndicatorContent
-      variant={props.variant}
-      className={props.className}
-    />
   );
 }

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/loading-indicator-content.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/loading-indicator-content.tsx
@@ -5,10 +5,17 @@ import { ClaudeLoadingIndicator } from "./claude-loading-indicator";
 
 export type LoadingIndicatorVariant = "default" | "chatgpt-dot" | "claude-mark";
 
-interface LoadingIndicatorContentProps {
-  variant?: LoadingIndicatorVariant;
-  className?: string;
-}
+type LoadingIndicatorContentProps =
+  | {
+      resolvedVariant: LoadingIndicatorVariant;
+      variant?: never;
+      className?: string;
+    }
+  | {
+      resolvedVariant?: undefined;
+      variant?: LoadingIndicatorVariant;
+      className?: string;
+    };
 
 export function getLoadingIndicatorVariantForHostStyle(
   hostStyle: SandboxHostStyle | null | undefined,
@@ -67,12 +74,13 @@ export function useResolvedLoadingIndicatorVariant(
   });
 }
 
-export function LoadingIndicatorContent({
-  variant,
+function ResolvedLoadingIndicatorContent({
+  resolvedVariant,
   className,
-}: LoadingIndicatorContentProps) {
-  const resolvedVariant = useResolvedLoadingIndicatorVariant(variant);
-
+}: {
+  resolvedVariant: LoadingIndicatorVariant;
+  className?: string;
+}) {
   if (resolvedVariant === "claude-mark") {
     return <ClaudeLoadingIndicator className={className} />;
   }
@@ -103,5 +111,40 @@ export function LoadingIndicatorContent({
         </span>
       </span>
     </span>
+  );
+}
+
+function SelfResolvingLoadingIndicatorContent({
+  variant,
+  className,
+}: {
+  variant?: LoadingIndicatorVariant;
+  className?: string;
+}) {
+  const resolvedVariant = useResolvedLoadingIndicatorVariant(variant);
+
+  return (
+    <ResolvedLoadingIndicatorContent
+      resolvedVariant={resolvedVariant}
+      className={className}
+    />
+  );
+}
+
+export function LoadingIndicatorContent(props: LoadingIndicatorContentProps) {
+  if (props.resolvedVariant !== undefined) {
+    return (
+      <ResolvedLoadingIndicatorContent
+        resolvedVariant={props.resolvedVariant}
+        className={props.className}
+      />
+    );
+  }
+
+  return (
+    <SelfResolvingLoadingIndicatorContent
+      variant={props.variant}
+      className={props.className}
+    />
   );
 }

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/thinking-indicator.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/thinking-indicator.tsx
@@ -17,7 +17,7 @@ export function ThinkingIndicator({
   resolvedVariant,
 }: {
   model: ModelDefinition;
-  resolvedVariant?: LoadingIndicatorVariant;
+  resolvedVariant: LoadingIndicatorVariant;
 }) {
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const sandboxHostStyle = useSandboxHostStyle();
@@ -58,11 +58,7 @@ export function ThinkingIndicator({
       ) : null}
 
       <div className="inline-flex items-center gap-2 text-muted-foreground/80">
-        {resolvedVariant !== undefined ? (
-          <LoadingIndicatorContent resolvedVariant={resolvedVariant} />
-        ) : (
-          <LoadingIndicatorContent />
-        )}
+        <LoadingIndicatorContent variant={resolvedVariant} />
       </div>
     </article>
   );

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/thinking-indicator.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/thinking-indicator.tsx
@@ -9,12 +9,13 @@ import {
 import {
   LoadingIndicatorContent,
   type LoadingIndicatorVariant,
+  useResolvedLoadingIndicatorVariant,
 } from "./loading-indicator-content";
 import { getAssistantAvatarDescriptor } from "./assistant-avatar";
 
 export function ThinkingIndicator({
   model,
-  variant = "default",
+  variant,
 }: {
   model: ModelDefinition;
   variant?: LoadingIndicatorVariant;
@@ -22,6 +23,9 @@ export function ThinkingIndicator({
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const sandboxHostStyle = useSandboxHostStyle();
   const sandboxHostTheme = useSandboxHostTheme();
+  const resolvedVariant = useResolvedLoadingIndicatorVariant(variant, {
+    modelProvider: model.provider,
+  });
   const assistantAvatar = getAssistantAvatarDescriptor({
     model,
     themeMode: sandboxHostTheme ?? themeMode,
@@ -58,7 +62,7 @@ export function ThinkingIndicator({
       ) : null}
 
       <div className="inline-flex items-center gap-2 text-muted-foreground/80">
-        <LoadingIndicatorContent variant={variant} />
+        <LoadingIndicatorContent variant={resolvedVariant} />
       </div>
     </article>
   );

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/thinking-indicator.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/thinking-indicator.tsx
@@ -9,23 +9,19 @@ import {
 import {
   LoadingIndicatorContent,
   type LoadingIndicatorVariant,
-  useResolvedLoadingIndicatorVariant,
 } from "./loading-indicator-content";
 import { getAssistantAvatarDescriptor } from "./assistant-avatar";
 
 export function ThinkingIndicator({
   model,
-  variant,
+  resolvedVariant,
 }: {
   model: ModelDefinition;
-  variant?: LoadingIndicatorVariant;
+  resolvedVariant?: LoadingIndicatorVariant;
 }) {
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const sandboxHostStyle = useSandboxHostStyle();
   const sandboxHostTheme = useSandboxHostTheme();
-  const resolvedVariant = useResolvedLoadingIndicatorVariant(variant, {
-    modelProvider: model.provider,
-  });
   const assistantAvatar = getAssistantAvatarDescriptor({
     model,
     themeMode: sandboxHostTheme ?? themeMode,
@@ -62,7 +58,11 @@ export function ThinkingIndicator({
       ) : null}
 
       <div className="inline-flex items-center gap-2 text-muted-foreground/80">
-        <LoadingIndicatorContent variant={resolvedVariant} />
+        {resolvedVariant !== undefined ? (
+          <LoadingIndicatorContent resolvedVariant={resolvedVariant} />
+        ) : (
+          <LoadingIndicatorContent />
+        )}
       </div>
     </article>
   );

--- a/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
@@ -15,7 +15,10 @@ import { ThinkingIndicator } from "@/components/chat-v2/shared/thinking-indicato
 import { FullscreenChatOverlay } from "@/components/chat-v2/fullscreen-chat-overlay";
 import { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import { ToolRenderOverride } from "@/components/chat-v2/thread/tool-render-overrides";
-import type { LoadingIndicatorVariant } from "@/components/chat-v2/shared/loading-indicator-content";
+import {
+  type LoadingIndicatorVariant,
+  useResolvedLoadingIndicatorVariant,
+} from "@/components/chat-v2/shared/loading-indicator-content";
 import { type ReasoningDisplayMode } from "./thread/parts/reasoning-part";
 import { TranscriptThread } from "./thread/transcript-thread";
 import {
@@ -85,7 +88,7 @@ export function Thread({
   showSaveViewButton = true,
   minimalMode = false,
   interactive = true,
-  loadingIndicatorVariant = "default",
+  loadingIndicatorVariant,
   reasoningDisplayMode = "inline",
   focusMessageId = null,
   highlightedMessageIds = [],
@@ -140,6 +143,12 @@ export function Thread({
 
   const sandboxHostStyle = useSandboxHostStyle();
   const sandboxHostTheme = useSandboxHostTheme();
+  const resolvedLoadingIndicatorVariant = useResolvedLoadingIndicatorVariant(
+    loadingIndicatorVariant,
+    {
+      modelProvider: model.provider,
+    },
+  );
   const isChatgptDark =
     sandboxHostStyle === "chatgpt" && sandboxHostTheme === "dark";
   const lastRenderableMessage = useMemo(
@@ -153,8 +162,8 @@ export function Thread({
     ? lastRenderableMessage.id
     : null;
   const shouldShowStandaloneThinkingIndicator =
-    loadingIndicatorVariant === "claude-mark" ||
-    loadingIndicatorVariant === "chatgpt-dot"
+    resolvedLoadingIndicatorVariant === "claude-mark" ||
+    resolvedLoadingIndicatorVariant === "chatgpt-dot"
       ? isLoading && !hasVisibleAssistantResponse
       : isLoading;
 
@@ -199,7 +208,7 @@ export function Thread({
         navigationKey={navigationKey}
         viewportRef={viewportRef}
         isLoading={isLoading}
-        loadingIndicatorVariant={loadingIndicatorVariant}
+        loadingIndicatorVariant={resolvedLoadingIndicatorVariant}
         lastRenderableMessageId={lastRenderableMessageId}
         contentClassName={
           contentClassName ??
@@ -209,7 +218,10 @@ export function Thread({
       />
       {shouldShowStandaloneThinkingIndicator && (
         <div className="min-w-0 w-full max-w-4xl mx-auto px-4">
-          <ThinkingIndicator model={model} variant={loadingIndicatorVariant} />
+          <ThinkingIndicator
+            model={model}
+            variant={resolvedLoadingIndicatorVariant}
+          />
         </div>
       )}
 
@@ -224,7 +236,7 @@ export function Thread({
           disabled={fullscreenChatDisabled}
           canSend={canSendFullscreenChat}
           isThinking={isLoading}
-          loadingIndicatorVariant={loadingIndicatorVariant}
+          loadingIndicatorVariant={resolvedLoadingIndicatorVariant}
           onStop={onFullscreenChatStop}
           onSend={() => {
             if (!canSendFullscreenChat) return;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
@@ -208,7 +208,7 @@ export function Thread({
         navigationKey={navigationKey}
         viewportRef={viewportRef}
         isLoading={isLoading}
-        loadingIndicatorVariant={resolvedLoadingIndicatorVariant}
+        resolvedLoadingIndicatorVariant={resolvedLoadingIndicatorVariant}
         lastRenderableMessageId={lastRenderableMessageId}
         contentClassName={
           contentClassName ??
@@ -220,7 +220,7 @@ export function Thread({
         <div className="min-w-0 w-full max-w-4xl mx-auto px-4">
           <ThinkingIndicator
             model={model}
-            variant={resolvedLoadingIndicatorVariant}
+            resolvedVariant={resolvedLoadingIndicatorVariant}
           />
         </div>
       )}
@@ -236,7 +236,7 @@ export function Thread({
           disabled={fullscreenChatDisabled}
           canSend={canSendFullscreenChat}
           isThinking={isLoading}
-          loadingIndicatorVariant={resolvedLoadingIndicatorVariant}
+          resolvedLoadingIndicatorVariant={resolvedLoadingIndicatorVariant}
           onStop={onFullscreenChatStop}
           onSend={() => {
             if (!canSendFullscreenChat) return;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
@@ -236,7 +236,7 @@ export function Thread({
           disabled={fullscreenChatDisabled}
           canSend={canSendFullscreenChat}
           isThinking={isLoading}
-          resolvedLoadingIndicatorVariant={resolvedLoadingIndicatorVariant}
+          loadingIndicatorVariant={resolvedLoadingIndicatorVariant}
           onStop={onFullscreenChatStop}
           onSend={() => {
             if (!canSendFullscreenChat) return;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -78,6 +78,11 @@ const mockClientConfigStoreState = {
     | undefined,
 };
 
+const mockPreferencesState = {
+  themeMode: "light" as const,
+  hostStyle: "claude" as const,
+};
+
 // ── Module mocks ───────────────────────────────────────────────────────────
 vi.mock("@modelcontextprotocol/ext-apps/app-bridge", () => ({
   AppBridge: vi.fn().mockImplementation(() => mockBridge),
@@ -119,7 +124,8 @@ vi.mock("@/components/ui/sandboxed-iframe", () => ({
 }));
 
 vi.mock("@/stores/preferences/preferences-provider", () => ({
-  usePreferencesStore: () => "light",
+  usePreferencesStore: (selector: any) =>
+    selector ? selector(mockPreferencesState) : mockPreferencesState,
 }));
 
 vi.mock("@/stores/ui-playground-store", () => ({

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -178,6 +178,7 @@ export function MCPAppsRenderer({
 }: MCPAppsRendererProps) {
   const sandboxRef = useRef<SandboxedIframeHandle>(null);
   const themeMode = usePreferencesStore((s) => s.themeMode);
+  const sharedHostStyle = usePreferencesStore((s) => s.hostStyle);
   const sandboxHostStyle = useSandboxHostStyle();
   const draftHostContext = useClientConfigStore(
     (s) => s.draftConfig?.hostContext,
@@ -195,7 +196,6 @@ export function MCPAppsRenderer({
 
   // Get CSP mode and host style from playground store when in playground
   const isPlaygroundActive = useUIPlaygroundStore((s) => s.isPlaygroundActive);
-  const playgroundHostStyle = useUIPlaygroundStore((s) => s.hostStyle);
   const playgroundCspMode = useUIPlaygroundStore((s) => s.mcpAppsCspMode);
   const cspMode: CspMode = isPlaygroundActive
     ? playgroundCspMode
@@ -684,7 +684,7 @@ export function MCPAppsRenderer({
   // CSS Variables for theming (SEP-1865 styles.variables)
   // These are sent via hostContext.styles.variables - the SDK should pass them through
   const effectiveHostStyle = isPlaygroundActive
-    ? playgroundHostStyle
+    ? sharedHostStyle
     : (sandboxHostStyle ?? "claude");
   const useChatGPTStyle = effectiveHostStyle === "chatgpt";
   themeModeRef.current = resolvedTheme;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/transcript-thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/transcript-thread.tsx
@@ -17,7 +17,10 @@ import type { DisplayMode } from "@/stores/ui-playground-store";
 import type { ToolServerMap } from "@/lib/apis/mcp-tools-api";
 import type { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import { cn } from "@/lib/utils";
-import type { LoadingIndicatorVariant } from "@/components/chat-v2/shared/loading-indicator-content";
+import {
+  type LoadingIndicatorVariant,
+  useResolvedLoadingIndicatorVariant,
+} from "@/components/chat-v2/shared/loading-indicator-content";
 
 const NOOP = (..._args: unknown[]) => {};
 const TRANSCRIPT_SCROLL_SETTLE_MS = 120;
@@ -197,13 +200,19 @@ export function TranscriptThread({
   transcriptRef,
   contentClassName,
   isLoading = false,
-  loadingIndicatorVariant = "default",
+  loadingIndicatorVariant,
   lastRenderableMessageId = null,
   getMessageWrapperProps,
 }: TranscriptThreadProps) {
   const contentRef = useRef<HTMLDivElement | null>(null);
   const messageRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const shouldReduceMotion = useReducedMotion();
+  const resolvedLoadingIndicatorVariant = useResolvedLoadingIndicatorVariant(
+    loadingIndicatorVariant,
+    {
+      modelProvider: model.provider,
+    },
+  );
   const highlightedMessageIdSet = useMemo(
     () => new Set(highlightedMessageIds),
     [highlightedMessageIds],
@@ -357,7 +366,7 @@ export function TranscriptThread({
           }) ?? {};
         const { className, ...restWrapperProps } = wrapperProps;
         const claudeFooterMode =
-          loadingIndicatorVariant === "claude-mark" &&
+          resolvedLoadingIndicatorVariant === "claude-mark" &&
           message.role === "assistant" &&
           message.id === lastRenderableMessageId
             ? isLoading

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/transcript-thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/transcript-thread.tsx
@@ -17,10 +17,7 @@ import type { DisplayMode } from "@/stores/ui-playground-store";
 import type { ToolServerMap } from "@/lib/apis/mcp-tools-api";
 import type { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import { cn } from "@/lib/utils";
-import {
-  type LoadingIndicatorVariant,
-  useResolvedLoadingIndicatorVariant,
-} from "@/components/chat-v2/shared/loading-indicator-content";
+import { type LoadingIndicatorVariant } from "@/components/chat-v2/shared/loading-indicator-content";
 
 const NOOP = (..._args: unknown[]) => {};
 const TRANSCRIPT_SCROLL_SETTLE_MS = 120;
@@ -79,7 +76,7 @@ export interface TranscriptThreadProps extends MessageViewPassthroughProps {
   transcriptRef?: Ref<HTMLDivElement>;
   contentClassName?: string;
   isLoading?: boolean;
-  loadingIndicatorVariant?: LoadingIndicatorVariant;
+  resolvedLoadingIndicatorVariant?: LoadingIndicatorVariant;
   lastRenderableMessageId?: string | null;
   getMessageWrapperProps?: (
     args: MessageWrapperArgs,
@@ -200,19 +197,13 @@ export function TranscriptThread({
   transcriptRef,
   contentClassName,
   isLoading = false,
-  loadingIndicatorVariant,
+  resolvedLoadingIndicatorVariant,
   lastRenderableMessageId = null,
   getMessageWrapperProps,
 }: TranscriptThreadProps) {
   const contentRef = useRef<HTMLDivElement | null>(null);
   const messageRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const shouldReduceMotion = useReducedMotion();
-  const resolvedLoadingIndicatorVariant = useResolvedLoadingIndicatorVariant(
-    loadingIndicatorVariant,
-    {
-      modelProvider: model.provider,
-    },
-  );
   const highlightedMessageIdSet = useMemo(
     () => new Set(highlightedMessageIds),
     [highlightedMessageIds],

--- a/mcpjam-inspector/client/src/components/hosted/SandboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/SandboxChatPage.tsx
@@ -5,6 +5,7 @@ import { Loader2, Link2Off, ShieldX } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { ChatTabV2 } from "@/components/ChatTabV2";
+import { getLoadingIndicatorVariantForHostStyle } from "@/components/chat-v2/shared/loading-indicator-content";
 import type { ServerWithName } from "@/hooks/use-app-state";
 import { useHostedApiContext } from "@/hooks/hosted/use-hosted-api-context";
 import { useHostedOAuthGate } from "@/hooks/hosted/use-hosted-oauth-gate";
@@ -681,9 +682,9 @@ export function SandboxChatPage({
           )}
           minimalMode
           reasoningDisplayMode="hidden"
-          loadingIndicatorVariant={
-            hostStyle === "chatgpt" ? "chatgpt-dot" : "claude-mark"
-          }
+          loadingIndicatorVariant={getLoadingIndicatorVariantForHostStyle(
+            hostStyle,
+          )}
           hostedWorkspaceIdOverride={session.payload.workspaceId}
           hostedSelectedServerIdsOverride={sessionServersActive.map(
             (server) => server.serverId,

--- a/mcpjam-inspector/client/src/components/sandboxes/SandboxEditor.tsx
+++ b/mcpjam-inspector/client/src/components/sandboxes/SandboxEditor.tsx
@@ -54,6 +54,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { getLoadingIndicatorVariantForHostStyle } from "@/components/chat-v2/shared/loading-indicator-content";
 import { SandboxHostStyleProvider } from "@/contexts/sandbox-host-style-context";
 import { SandboxHostOnboardingOverlays } from "@/components/hosted/SandboxHostOnboardingOverlays";
 import { useSandboxHostIntroGate } from "@/components/hosted/useSandboxHostIntroGate";
@@ -1170,6 +1171,9 @@ export function SandboxEditor({
                       initialSystemPrompt={normalizedSystemPrompt}
                       initialTemperature={temperature}
                       initialRequireToolApproval={requireToolApproval}
+                      loadingIndicatorVariant={getLoadingIndicatorVariantForHostStyle(
+                        hostStyle,
+                      )}
                       onOAuthRequired={handlePreviewOAuthRequired}
                       sandboxComposerBlocked={introGate.composerBlocked}
                       sandboxComposerBlockedReason="Get started or authorize to send messages…"

--- a/mcpjam-inspector/client/src/components/sandboxes/__tests__/SandboxEditor.test.tsx
+++ b/mcpjam-inspector/client/src/components/sandboxes/__tests__/SandboxEditor.test.tsx
@@ -111,6 +111,7 @@ vi.mock("@/components/ChatTabV2", async () => {
       initialSystemPrompt?: string;
       initialTemperature?: number;
       initialRequireToolApproval?: boolean;
+      loadingIndicatorVariant?: string;
     }) => {
       React.useEffect(() => {
         mockPreviewMount(props);
@@ -233,6 +234,7 @@ describe("SandboxEditor preview", () => {
         initialSystemPrompt: "You are helpful.",
         initialTemperature: 0.4,
         initialRequireToolApproval: true,
+        loadingIndicatorVariant: "claude-mark",
       }),
     );
   });

--- a/mcpjam-inspector/client/src/components/sandboxes/builder/SandboxBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/sandboxes/builder/SandboxBuilderView.tsx
@@ -39,6 +39,7 @@ import { copyToClipboard } from "@/lib/clipboard";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
 import { getSandboxHostStyleShortLabel } from "@/lib/sandbox-host-style";
 import { ChatTabV2 } from "@/components/ChatTabV2";
+import { getLoadingIndicatorVariantForHostStyle } from "@/components/chat-v2/shared/loading-indicator-content";
 import type { ServerWithName } from "@/hooks/use-app-state";
 import { useHostedOAuthGate } from "@/hooks/hosted/use-hosted-oauth-gate";
 import type { HostedOAuthRequiredDetails } from "@/lib/hosted-oauth-required";
@@ -1150,11 +1151,9 @@ export function SandboxBuilderView({
                                   initialRequireToolApproval={
                                     draftSandboxConfig.requireToolApproval
                                   }
-                                  loadingIndicatorVariant={
-                                    draftSandboxConfig.hostStyle === "chatgpt"
-                                      ? "chatgpt-dot"
-                                      : "claude-mark"
-                                  }
+                                  loadingIndicatorVariant={getLoadingIndicatorVariantForHostStyle(
+                                    draftSandboxConfig.hostStyle,
+                                  )}
                                   onOAuthRequired={handlePreviewOAuthRequired}
                                   sandboxComposerBlocked={
                                     introGate.composerBlocked

--- a/mcpjam-inspector/client/src/components/shared/DisplayContextHeader.tsx
+++ b/mcpjam-inspector/client/src/components/shared/DisplayContextHeader.tsx
@@ -4,8 +4,8 @@
  * Reusable component for display context controls (device, locale, timezone, CSP, capabilities, safe area).
  * Extracted from PlaygroundMain to be shared between App Builder and Views pages.
  *
- * Reads/writes UI playground state via useUIPlaygroundStore and derives theme, locale, timezone,
- * display modes, device capabilities, and safe-area defaults from useClientConfigStore hostContext.
+ * Reads/writes shared host/theme preferences plus UI playground state and derives locale,
+ * timezone, display modes, device capabilities, and safe-area defaults from hostContext.
  */
 
 import { useState, useMemo, useCallback, useEffect, useRef } from "react";
@@ -172,10 +172,6 @@ export function DisplayContextHeader({
   const customViewport = useUIPlaygroundStore((s) => s.customViewport);
   const setCustomViewport = useUIPlaygroundStore((s) => s.setCustomViewport);
 
-  // Host style (Claude / ChatGPT)
-  const hostStyle = useUIPlaygroundStore((s) => s.hostStyle);
-  const setHostStyle = useUIPlaygroundStore((s) => s.setHostStyle);
-
   // CSP mode (ChatGPT Apps)
   const cspMode = useUIPlaygroundStore((s) => s.cspMode);
   const setCspMode = useUIPlaygroundStore((s) => s.setCspMode);
@@ -213,6 +209,8 @@ export function DisplayContextHeader({
     Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const setThemeMode = usePreferencesStore((s) => s.setThemeMode);
+  const hostStyle = usePreferencesStore((s) => s.hostStyle);
+  const setHostStyle = usePreferencesStore((s) => s.setHostStyle);
   const usesThemeOverride =
     themeModeOverride !== undefined && onThemeToggleOverride !== undefined;
   const effectiveThemeMode = usesThemeOverride ? themeModeOverride : themeMode;

--- a/mcpjam-inspector/client/src/components/shared/HostStylePillSelector.tsx
+++ b/mcpjam-inspector/client/src/components/shared/HostStylePillSelector.tsx
@@ -1,0 +1,61 @@
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import type { SandboxHostStyle } from "@/lib/sandbox-host-style";
+import { cn } from "@/lib/utils";
+
+interface HostStylePillSelectorProps {
+  value: SandboxHostStyle;
+  onValueChange: (hostStyle: SandboxHostStyle) => void;
+  className?: string;
+}
+
+export function HostStylePillSelector({
+  value,
+  onValueChange,
+  className,
+}: HostStylePillSelectorProps) {
+  return (
+    <div
+      className={cn(
+        "relative isolate w-full overflow-hidden rounded-full bg-muted/30 p-[1.5px] ring-1 ring-border/45",
+        className,
+      )}
+      data-selected-host-style={value}
+    >
+      <div
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute left-[1.5px] top-[1.5px] bottom-[1.5px] w-[calc(50%-1.5px)] rounded-full bg-background shadow-[0_1px_2px_rgba(0,0,0,0.08),0_0_0_1px_rgba(0,0,0,0.04)] transition-transform duration-200 ease-out motion-reduce:transition-none dark:shadow-[0_1px_2px_rgba(0,0,0,0.28),0_0_0_1px_rgba(255,255,255,0.06)]",
+          value === "claude" && "translate-x-full",
+        )}
+      />
+      <ToggleGroup
+        type="single"
+        value={value}
+        onValueChange={(nextValue) => {
+          if (nextValue === "chatgpt" || nextValue === "claude") {
+            onValueChange(nextValue);
+          }
+        }}
+        aria-label="Host style"
+        className="relative w-full rounded-full bg-transparent p-0"
+      >
+        <ToggleGroupItem
+          value="chatgpt"
+          size="sm"
+          className="z-10 h-[22px] min-w-0 flex-1 rounded-full border-0 bg-transparent px-2 text-[10px] font-medium tracking-[-0.01em] text-muted-foreground/90 first:rounded-full last:rounded-full hover:bg-transparent hover:text-foreground data-[state=on]:bg-transparent data-[state=on]:font-semibold data-[state=on]:text-foreground data-[state=on]:shadow-none"
+          aria-label="ChatGPT"
+        >
+          ChatGPT
+        </ToggleGroupItem>
+        <ToggleGroupItem
+          value="claude"
+          size="sm"
+          className="z-10 h-[22px] min-w-0 flex-1 rounded-full border-0 bg-transparent px-2 text-[10px] font-medium tracking-[-0.01em] text-muted-foreground/90 first:rounded-full last:rounded-full hover:bg-transparent hover:text-foreground data-[state=on]:bg-transparent data-[state=on]:font-semibold data-[state=on]:text-foreground data-[state=on]:shadow-none"
+          aria-label="Claude"
+        >
+          Claude
+        </ToggleGroupItem>
+      </ToggleGroup>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/shared/__tests__/DisplayContextHeader.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/__tests__/DisplayContextHeader.test.tsx
@@ -74,15 +74,15 @@ const {
   mockUpdateThemeMode: vi.fn(),
   mockPreferencesState: {
     themeMode: "light",
+    hostStyle: "claude",
     setThemeMode: vi.fn(),
+    setHostStyle: vi.fn(),
   },
   mockUIPlaygroundStore: {
     deviceType: "desktop",
     setDeviceType: vi.fn(),
     customViewport: { width: 1280, height: 800 },
     setCustomViewport: vi.fn(),
-    hostStyle: "claude",
-    setHostStyle: vi.fn(),
     cspMode: "widget-declared",
     setCspMode: vi.fn(),
     mcpAppsCspMode: "widget-declared",
@@ -164,6 +164,7 @@ describe("DisplayContextHeader", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPreferencesState.themeMode = "light";
+    mockPreferencesState.hostStyle = "claude";
   });
 
   it("uses the local theme override without writing global theme state", () => {
@@ -196,5 +197,21 @@ describe("DisplayContextHeader", () => {
 
     expect(mockPreferencesState.setThemeMode).toHaveBeenCalledWith("dark");
     expect(mockUpdateThemeMode).toHaveBeenCalledWith("dark");
+  });
+
+  it("writes Claude and ChatGPT host-style selections through shared preferences", () => {
+    render(<DisplayContextHeader protocol={null} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Claude" }));
+    fireEvent.click(screen.getByRole("button", { name: "ChatGPT" }));
+
+    expect(mockPreferencesState.setHostStyle).toHaveBeenNthCalledWith(
+      1,
+      "claude",
+    );
+    expect(mockPreferencesState.setHostStyle).toHaveBeenNthCalledWith(
+      2,
+      "chatgpt",
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/ui-playground/AppBuilderTab.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/AppBuilderTab.tsx
@@ -26,6 +26,7 @@ import { PlaygroundLeft } from "./PlaygroundLeft";
 import { PlaygroundMain } from "./PlaygroundMain";
 import SaveRequestDialog from "../tools/SaveRequestDialog";
 import { useUIPlaygroundStore } from "@/stores/ui-playground-store";
+import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { listTools } from "@/lib/apis/mcp-tools-api";
 import { generateFormFieldsFromSchema } from "@/lib/tool-form";
 import type { MCPServerConfig } from "@mcpjam/sdk/browser";
@@ -46,6 +47,7 @@ import { AppBuilderSkeleton } from "@/components/app-builder/AppBuilderSkeleton"
 import type { ServerFormData } from "@/shared/types.js";
 import type { ServerWithName } from "@/hooks/use-app-state";
 import { useSidebar } from "@/components/ui/sidebar";
+import { getLoadingIndicatorVariantForHostStyle } from "@/components/chat-v2/shared/loading-indicator-content";
 import { toast } from "sonner";
 import type { PlaygroundServerSelectorProps } from "@/components/ActiveServerSelector";
 
@@ -100,7 +102,6 @@ export function AppBuilderTab({
     formFields,
     isExecuting,
     deviceType,
-    hostStyle,
     isSidebarVisible,
     selectedProtocol,
     setTools,
@@ -119,6 +120,7 @@ export function AppBuilderTab({
     reset,
     setSidebarVisible,
   } = useUIPlaygroundStore();
+  const hostStyle = usePreferencesStore((s) => s.hostStyle);
 
   const { setOpen: setMcpSidebarOpen } = useSidebar();
 
@@ -389,9 +391,9 @@ export function AppBuilderTab({
             }
             initialInputTypewriter={firstRunComposerSeed}
             blockSubmitUntilServerConnected={firstRunComposerSeed}
-            loadingIndicatorVariant={
-              hostStyle === "chatgpt" ? "chatgpt-dot" : "claude-mark"
-            }
+            loadingIndicatorVariant={getLoadingIndicatorVariantForHostStyle(
+              hostStyle,
+            )}
             pulseSubmit={firstRunComposerSeed}
             showPostConnectGuide={false}
             onFirstMessageSent={

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -223,7 +223,7 @@ export function PlaygroundMain({
   disableChatInput = false,
   hideSaveViewButton = false,
   disabledInputPlaceholder = "Input disabled in Views",
-  loadingIndicatorVariant = "default",
+  loadingIndicatorVariant,
   initialInput,
   initialInputTypewriter = false,
   blockSubmitUntilServerConnected = false,
@@ -420,7 +420,7 @@ export function PlaygroundMain({
 
   // Host chat background: actual chat area colors from each host's UI
   // (separate from the 76 MCP spec widget design tokens)
-  const hostStyle = useUIPlaygroundStore((s) => s.hostStyle);
+  const hostStyle = usePreferencesStore((s) => s.hostStyle);
   const globalThemeMode = usePreferencesStore(
     (s) => s.themeMode,
   ) as ThreadThemeMode;

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/AppBuilderTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/AppBuilderTab.test.tsx
@@ -53,10 +53,15 @@ vi.mock("@/lib/mcp-ui/mcp-apps-utils", () => ({
 }));
 
 // Mock preferences store
+const mockPreferencesState = {
+  themeMode: "light",
+  hostStyle: "claude",
+  setHostStyle: vi.fn(),
+};
+
 vi.mock("@/stores/preferences/preferences-provider", () => ({
   usePreferencesStore: (selector: any) => {
-    const state = { themeMode: "light" };
-    return selector ? selector(state) : state;
+    return selector ? selector(mockPreferencesState) : mockPreferencesState;
   },
 }));
 
@@ -67,7 +72,6 @@ const mockUIPlaygroundStore = {
   formFields: [],
   isExecuting: false,
   deviceType: "mobile",
-  hostStyle: "claude",
   displayMode: "inline",
   globals: { locale: "en-US", theme: "light", timeZone: "UTC" },
   isSidebarVisible: true,
@@ -308,9 +312,9 @@ describe("AppBuilderTab", () => {
       tools: {},
       formFields: [],
       isExecuting: false,
-      hostStyle: "claude",
       isSidebarVisible: true,
     });
+    mockPreferencesState.hostStyle = "claude";
 
     // Reset onboarding state (default: dismissed, no overlay)
     Object.assign(mockOnboarding, {
@@ -495,7 +499,7 @@ describe("AppBuilderTab", () => {
 
     it("passes the Claude mark variant to PlaygroundMain when Claude host style is selected", async () => {
       const serverConfig = createServerConfig();
-      mockUIPlaygroundStore.hostStyle = "claude";
+      mockPreferencesState.hostStyle = "claude";
 
       render(
         <AppBuilderTab
@@ -514,7 +518,7 @@ describe("AppBuilderTab", () => {
 
     it("passes the pulsing dot variant to PlaygroundMain when ChatGPT host style is selected", async () => {
       const serverConfig = createServerConfig();
-      mockUIPlaygroundStore.hostStyle = "chatgpt";
+      mockPreferencesState.hostStyle = "chatgpt";
 
       render(
         <AppBuilderTab

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -424,7 +424,9 @@ vi.mock("../playground-helpers", () => ({
 const mockPreferencesState = {
   themeMode: "light",
   themePreset: "soft-pop",
+  hostStyle: "claude",
   setThemeMode: vi.fn(),
+  setHostStyle: vi.fn(),
 };
 
 vi.mock("@/stores/preferences/preferences-provider", () => ({
@@ -445,8 +447,6 @@ const mockUIPlaygroundStore = {
   customViewport: { width: 375, height: 667 },
   setCustomViewport: vi.fn(),
   setPlaygroundActive: vi.fn(),
-  hostStyle: "claude",
-  setHostStyle: vi.fn(),
   cspMode: "widget-declared",
   setCspMode: vi.fn(),
   mcpAppsCspMode: "widget-declared",
@@ -570,6 +570,7 @@ describe("PlaygroundMain", () => {
     capturedChatSessionOptions = null;
     mockPreferencesState.themeMode = "light";
     mockPreferencesState.themePreset = "soft-pop";
+    mockPreferencesState.hostStyle = "claude";
     mockSharedAppState.servers["test-server"] = {
       connectionStatus: "connected",
     };

--- a/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
@@ -34,10 +34,10 @@ import {
 import { CHATGPT_CHAT_BACKGROUND } from "@/config/chatgpt-host-context";
 import { CLAUDE_DESKTOP_CHAT_BACKGROUND } from "@/config/claude-desktop-host-context";
 import type { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
+import type { SandboxHostStyle } from "@/lib/sandbox-host-style";
 import type {
   DeviceType,
   DisplayMode,
-  HostStyle,
 } from "@/stores/ui-playground-store";
 import type { BroadcastChatTurnRequest } from "@/components/chat-v2/multi-model-chat-card";
 
@@ -98,7 +98,7 @@ interface MultiModelPlaygroundCardProps {
   hostedOAuthTokens?: Record<string, string>;
   displayMode: DisplayMode;
   onDisplayModeChange: (mode: DisplayMode) => void;
-  hostStyle: HostStyle;
+  hostStyle: SandboxHostStyle;
   effectiveThreadTheme: ThreadThemeMode;
   deviceType: DeviceType;
   selectedProtocol: UIType | null;

--- a/mcpjam-inspector/client/src/stores/preferences/__tests__/preferences-store.test.ts
+++ b/mcpjam-inspector/client/src/stores/preferences/__tests__/preferences-store.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  createPreferencesStore,
+  HOST_STYLE_KEY,
+  THEME_MODE_KEY,
+  THEME_PRESET_KEY,
+} from "../preferences-store";
+
+describe("preferences-store", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("initializes host style from the shared persisted key and persists updates", () => {
+    localStorage.setItem(HOST_STYLE_KEY, "chatgpt");
+
+    const store = createPreferencesStore({
+      themeMode: "light",
+      themePreset: "default",
+    });
+
+    expect(store.getState().hostStyle).toBe("chatgpt");
+
+    store.getState().setHostStyle("claude");
+
+    expect(store.getState().hostStyle).toBe("claude");
+    expect(localStorage.getItem(HOST_STYLE_KEY)).toBe("claude");
+  });
+
+  it("falls back to claude when the persisted host style is invalid", () => {
+    localStorage.setItem(HOST_STYLE_KEY, "invalid-host-style");
+
+    const store = createPreferencesStore({
+      themeMode: "light",
+      themePreset: "default",
+    });
+
+    expect(store.getState().hostStyle).toBe("claude");
+  });
+
+  it("continues persisting theme preferences alongside host style", () => {
+    const store = createPreferencesStore({
+      themeMode: "light",
+      themePreset: "default",
+    });
+
+    store.getState().setThemeMode("dark");
+    store.getState().setThemePreset("soft-pop");
+
+    expect(localStorage.getItem(THEME_MODE_KEY)).toBe("dark");
+    expect(localStorage.getItem(THEME_PRESET_KEY)).toBe("soft-pop");
+  });
+});

--- a/mcpjam-inspector/client/src/stores/preferences/preferences-provider.tsx
+++ b/mcpjam-inspector/client/src/stores/preferences/preferences-provider.tsx
@@ -11,14 +11,20 @@ export const PreferencesStoreProvider = ({
   children,
   themeMode,
   themePreset,
+  hostStyle,
 }: {
   children: React.ReactNode;
   themeMode: PreferencesState["themeMode"];
   themePreset: PreferencesState["themePreset"];
+  hostStyle?: PreferencesState["hostStyle"];
 }) => {
   const storeRef = useRef<StoreApi<PreferencesState> | null>(null);
 
-  storeRef.current ??= createPreferencesStore({ themeMode, themePreset });
+  storeRef.current ??= createPreferencesStore({
+    themeMode,
+    themePreset,
+    hostStyle,
+  });
 
   return (
     <PreferencesStoreContext.Provider value={storeRef.current}>

--- a/mcpjam-inspector/client/src/stores/preferences/preferences-store.ts
+++ b/mcpjam-inspector/client/src/stores/preferences/preferences-store.ts
@@ -1,21 +1,41 @@
 import { createStore } from "zustand/vanilla";
 
+import type { SandboxHostStyle } from "@/lib/sandbox-host-style";
 import type { ThemeMode, ThemePreset } from "@/types/preferences/theme";
 
 export type PreferencesState = {
   themeMode: ThemeMode;
   themePreset: ThemePreset;
+  hostStyle: SandboxHostStyle;
   setThemeMode: (mode: ThemeMode) => void;
   setThemePreset: (preset: ThemePreset) => void;
+  setHostStyle: (hostStyle: SandboxHostStyle) => void;
 };
 
 export const THEME_MODE_KEY = "themeMode";
 export const THEME_PRESET_KEY = "themePreset";
+export const HOST_STYLE_KEY = "mcpjam-ui-playground-host-style";
+
+function getStoredHostStyle(): SandboxHostStyle {
+  if (typeof window === "undefined") return "claude";
+
+  try {
+    const stored = localStorage.getItem(HOST_STYLE_KEY);
+    if (stored === "claude" || stored === "chatgpt") {
+      return stored;
+    }
+  } catch (error) {
+    console.warn("Failed to read persisted host style:", error);
+  }
+
+  return "claude";
+}
 
 export const createPreferencesStore = (init?: Partial<PreferencesState>) =>
   createStore<PreferencesState>()((set) => ({
     themeMode: init?.themeMode ?? "light",
     themePreset: init?.themePreset ?? "default",
+    hostStyle: init?.hostStyle ?? getStoredHostStyle(),
     setThemeMode: (mode) => {
       try {
         localStorage.setItem(THEME_MODE_KEY, mode);
@@ -31,5 +51,13 @@ export const createPreferencesStore = (init?: Partial<PreferencesState>) =>
         console.warn("Failed to persist theme preset:", error);
       }
       set({ themePreset: preset });
+    },
+    setHostStyle: (hostStyle) => {
+      try {
+        localStorage.setItem(HOST_STYLE_KEY, hostStyle);
+      } catch (error) {
+        console.warn("Failed to persist host style:", error);
+      }
+      set({ hostStyle });
     },
   }));

--- a/mcpjam-inspector/client/src/stores/ui-playground-store.ts
+++ b/mcpjam-inspector/client/src/stores/ui-playground-store.ts
@@ -12,7 +12,6 @@ import type { FormField } from "@/lib/tool-form";
 import { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 
 export type DeviceType = "mobile" | "tablet" | "desktop" | "custom";
-export type HostStyle = "claude" | "chatgpt";
 
 /** Device viewport configurations - shared across playground and MCP apps renderer */
 export const DEVICE_VIEWPORT_CONFIGS: Record<
@@ -137,9 +136,6 @@ interface UIPlaygroundState {
   // Custom viewport dimensions (for custom device type)
   customViewport: CustomViewport;
 
-  // Host style for MCP Apps (which host's design tokens to inject)
-  hostStyle: HostStyle;
-
   // Actions
   setTools: (tools: Record<string, Tool>) => void;
   setSelectedTool: (tool: string | null) => void;
@@ -172,7 +168,6 @@ interface UIPlaygroundState {
   setSafeAreaPreset: (preset: SafeAreaPreset) => void;
   setSafeAreaInsets: (insets: Partial<SafeAreaInsets>) => void;
   setCustomViewport: (viewport: Partial<CustomViewport>) => void;
-  setHostStyle: (style: HostStyle) => void;
   reset: () => void;
 }
 
@@ -189,8 +184,6 @@ const STORAGE_KEY_SIDEBAR = "mcpjam-ui-playground-sidebar-visible";
 const STORAGE_KEY_CUSTOM_VIEWPORT = "mcpjam-ui-playground-custom-viewport";
 const STORAGE_KEY_DEVICE_TYPE = "mcpjam-ui-playground-device-type";
 const STORAGE_KEY_SELECTED_PROTOCOL = "mcpjam-ui-playground-selected-protocol";
-const STORAGE_KEY_HOST_STYLE = "mcpjam-ui-playground-host-style";
-
 const getStoredVisibility = (key: string, defaultValue: boolean): boolean => {
   if (typeof window === "undefined") return defaultValue;
   const stored = localStorage.getItem(key);
@@ -213,15 +206,6 @@ const getStoredDeviceType = (): DeviceType => {
     return stored as DeviceType;
   }
   return "desktop";
-};
-
-const getStoredHostStyle = (): HostStyle => {
-  if (typeof window === "undefined") return "claude";
-  const stored = localStorage.getItem(STORAGE_KEY_HOST_STYLE);
-  if (stored && ["claude", "chatgpt"].includes(stored)) {
-    return stored as HostStyle;
-  }
-  return "claude";
 };
 
 const getStoredSelectedProtocol = (): UIType | null => {
@@ -277,7 +261,6 @@ const initialState = {
   safeAreaPreset: "none" as SafeAreaPreset,
   safeAreaInsets: SAFE_AREA_PRESETS["none"],
   customViewport: getStoredCustomViewport(),
-  hostStyle: getStoredHostStyle(),
 };
 
 export const useUIPlaygroundStore = create<UIPlaygroundState>((set) => ({
@@ -412,11 +395,6 @@ export const useUIPlaygroundStore = create<UIPlaygroundState>((set) => ({
       safeAreaInsets: { ...state.safeAreaInsets, ...insets },
     })),
 
-  setHostStyle: (hostStyle) => {
-    localStorage.setItem(STORAGE_KEY_HOST_STYLE, hostStyle);
-    return set({ hostStyle });
-  },
-
   setCustomViewport: (viewport) =>
     set((state) => {
       const newViewport = { ...state.customViewport, ...viewport };
@@ -447,8 +425,6 @@ export const useUIPlaygroundStore = create<UIPlaygroundState>((set) => ({
         capabilities: getDefaultCapabilities(storedDeviceType),
         // Preserve selected protocol from localStorage
         selectedProtocol: getStoredSelectedProtocol(),
-        // Preserve host style from localStorage
-        hostStyle: getStoredHostStyle(),
         // Preserve CSP modes (may be set via CLI config before reset fires)
         cspMode: state.cspMode,
         mcpAppsCspMode: state.mcpAppsCspMode,


### PR DESCRIPTION
Before, multiple chat surfaces made their own Claude/ChatGPT decisions in slightly different ways. This PR centralizes the shared host-style preference and mascot/pulse resolution logic, then updates those surfaces to use that shared behavior, so it’s more consistent and harder to regress.