### PR TITLE
Add stdio transport hardening and shared CLI transport flags

### DIFF
--- a/cli/src/lib/server-config.ts
+++ b/cli/src/lib/server-config.ts
@@ -295,7 +295,7 @@ export function parseServerConfig(
   return {
     command,
     args: parseCommandArgs(options.args, options.commandArgs),
-    env: parseEnvironmentOption(options.env),
+    env: buildCliStdioEnvironment(options.env),
     ...(cwd ? { cwd } : {}),
     ...(clientCapabilities ? { clientCapabilities } : {}),
     stderr: "pipe",
@@ -379,6 +379,23 @@ function parseEnvironmentOption(
 
       return [key, envValue];
     }),
+  );
+}
+
+function buildCliStdioEnvironment(
+  values: string[] | undefined,
+): Record<string, string> {
+  return {
+    ...getProcessEnvironment(),
+    ...(parseEnvironmentOption(values) ?? {}),
+  };
+}
+
+function getProcessEnvironment(): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(process.env).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
   );
 }
 

--- a/cli/src/lib/server-config.ts
+++ b/cli/src/lib/server-config.ts
@@ -295,7 +295,7 @@ export function parseServerConfig(
   return {
     command,
     args: parseCommandArgs(options.args, options.commandArgs),
-    env: buildCliStdioEnvironment(options.env),
+    env: parseEnvironmentOption(options.env),
     ...(cwd ? { cwd } : {}),
     ...(clientCapabilities ? { clientCapabilities } : {}),
     stderr: "pipe",
@@ -379,23 +379,6 @@ function parseEnvironmentOption(
 
       return [key, envValue];
     }),
-  );
-}
-
-function buildCliStdioEnvironment(
-  values: string[] | undefined,
-): Record<string, string> {
-  return {
-    ...getProcessEnvironment(),
-    ...(parseEnvironmentOption(values) ?? {}),
-  };
-}
-
-function getProcessEnvironment(): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(process.env).filter(
-      (entry): entry is [string, string] => typeof entry[1] === "string",
-    ),
   );
 }
 

--- a/cli/src/lib/server-config.ts
+++ b/cli/src/lib/server-config.ts
@@ -12,7 +12,10 @@ export interface GlobalOptions {
   rpc: boolean;
 }
 
+type TransportType = "http" | "stdio";
+
 export interface SharedServerTargetOptions {
+  transport?: TransportType;
   url?: string;
   accessToken?: string;
   oauthAccessToken?: string;
@@ -22,8 +25,10 @@ export interface SharedServerTargetOptions {
   header?: string[];
   clientCapabilities?: string | Record<string, unknown>;
   command?: string;
+  args?: string[];
   commandArgs?: string[];
   env?: string[];
+  cwd?: string;
   timeout?: number;
 }
 
@@ -33,6 +38,10 @@ function collectString(value: string, previous: string[] = []): string[] {
 
 export function addSharedServerOptions(command: Command): Command {
   return command
+    .option(
+      "--transport <transport>",
+      'Explicit transport type: "http" or "stdio"',
+    )
     .option("--url <url>", "HTTP MCP server URL")
     .option("--access-token <token>", "Bearer access token for HTTP servers")
     .option(
@@ -63,15 +72,19 @@ export function addSharedServerOptions(command: Command): Command {
     )
     .option("--command <command>", "Command for a stdio MCP server")
     .option(
+      "--args <arg...>",
+      "Preferred stdio command arguments. Pass multiple values or repeat the flag.",
+    )
+    .option(
       "--command-args <arg>",
-      "Stdio command argument. Repeat to pass multiple arguments.",
+      "Legacy stdio command argument. Repeat to pass multiple arguments.",
       collectString,
     )
     .option(
-      "--env <env>",
-      'Stdio environment assignment in "KEY=VALUE" format. Repeat to pass multiple assignments.',
-      collectString,
-    );
+      "-e, --env <env...>",
+      'Stdio environment assignment in "KEY=VALUE" format. Pass multiple values or repeat the flag.',
+    )
+    .option("--cwd <path>", "Working directory for the stdio MCP server process");
 }
 
 export function getGlobalOptions(command: Command): GlobalOptions {
@@ -204,21 +217,21 @@ export function parseServerConfig(
   const command = options.command?.trim();
   const hasUrl = Boolean(url);
   const hasCommand = Boolean(command);
+  const transport = resolveTargetTransport(options, hasUrl, hasCommand);
+  const cwd = options.cwd?.trim();
   const clientCapabilities = resolveClientCapabilities(
     options.clientCapabilities,
   );
 
-  if (hasUrl === hasCommand) {
-    throw usageError("Specify exactly one target: either --url or --command.");
-  }
-
-  if (hasUrl && url) {
+  if (transport === "http" && url) {
     if (
+      (options.args?.length ?? 0) > 0 ||
       (options.commandArgs?.length ?? 0) > 0 ||
-      (options.env?.length ?? 0) > 0
+      (options.env?.length ?? 0) > 0 ||
+      cwd
     ) {
       throw usageError(
-        "--command-args and --env can only be used together with --command.",
+        "--args, --command-args, --env, and --cwd can only be used together with --command.",
       );
     }
 
@@ -281,10 +294,11 @@ export function parseServerConfig(
 
   return {
     command,
-    args: parseCommandArgs(options.commandArgs),
+    args: parseCommandArgs(options.args, options.commandArgs),
     env: parseEnvironmentOption(options.env),
+    ...(cwd ? { cwd } : {}),
     ...(clientCapabilities ? { clientCapabilities } : {}),
-    stderr: "ignore",
+    stderr: "pipe",
     timeout: options.timeout,
   };
 }
@@ -325,12 +339,17 @@ function parseHeader(entry: string): [string, string] {
   return [key, value];
 }
 
-function parseCommandArgs(values: string[] | undefined): string[] | undefined {
-  if (!values || values.length === 0) {
+function parseCommandArgs(
+  values: string[] | undefined,
+  legacyValues: string[] | undefined,
+): string[] | undefined {
+  const combined = [...(values ?? []), ...(legacyValues ?? [])];
+
+  if (combined.length === 0) {
     return undefined;
   }
 
-  return values;
+  return combined;
 }
 
 function parseEnvironmentOption(
@@ -375,6 +394,58 @@ function resolveClientCapabilities(
   }
 
   return parseUnknownRecord(value, "Client capabilities");
+}
+
+function resolveTargetTransport(
+  options: SharedServerTargetOptions,
+  hasUrl: boolean,
+  hasCommand: boolean,
+): TransportType {
+  const transport = resolveTransportOption(options.transport);
+
+  if (!transport) {
+    if (hasUrl === hasCommand) {
+      throw usageError("Specify exactly one target: either --url or --command.");
+    }
+
+    return hasUrl ? "http" : "stdio";
+  }
+
+  if (transport === "http") {
+    if (!hasUrl) {
+      throw usageError("--transport http requires --url.");
+    }
+    if (hasCommand) {
+      throw usageError("--command can only be used with --transport stdio.");
+    }
+
+    return transport;
+  }
+
+  if (!hasCommand) {
+    throw usageError("--transport stdio requires --command.");
+  }
+  if (hasUrl) {
+    throw usageError("--url can only be used with --transport http.");
+  }
+
+  return transport;
+}
+
+function resolveTransportOption(
+  value: string | undefined,
+): TransportType | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (value === "http" || value === "stdio") {
+    return value;
+  }
+
+  throw usageError(
+    `Invalid transport "${value}". Use "http" or "stdio".`,
+  );
 }
 
 export function resolveHttpAccessToken(

--- a/cli/tests/server-config.test.ts
+++ b/cli/tests/server-config.test.ts
@@ -1,6 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { Command } from "commander";
 import {
+  addSharedServerOptions,
   parseJsonRecord,
   parseServerConfig,
   resolveAliasedStringOption,
@@ -57,9 +59,12 @@ test("parseServerConfig accepts refresh-token auth for HTTP servers", () => {
 
 test("parseServerConfig builds a stdio config with args and env", () => {
   const config = parseServerConfig({
+    transport: "stdio",
     command: "node",
-    commandArgs: ["server.js", "--flag"],
+    args: ["server.js"],
+    commandArgs: ["--flag"],
     env: ["FOO=bar", "BAZ=qux"],
+    cwd: "/tmp/mcpjam-test",
     timeout: 5000,
   });
 
@@ -70,14 +75,16 @@ test("parseServerConfig builds a stdio config with args and env", () => {
     FOO: "bar",
     BAZ: "qux",
   });
-  assert.equal(config.stderr, "ignore");
+  assert.equal(config.cwd, "/tmp/mcpjam-test");
+  assert.equal(config.stderr, "pipe");
   assert.equal(config.timeout, 5000);
 });
 
 test("parseServerConfig preserves commas inside stdio args and env values", () => {
   const config = parseServerConfig({
     command: "node",
-    commandArgs: ['{"a":1,"b":2}', "--list=one,two"],
+    args: ['{"a":1,"b":2}'],
+    commandArgs: ["--list=one,two"],
     env: [
       "NO_PROXY=127.0.0.1,localhost",
       'JSON_PAYLOAD={"a":1,"b":2}',
@@ -119,13 +126,14 @@ test("parseServerConfig rejects missing and mixed targets", () => {
   assert.throws(
     () =>
       parseServerConfig({
+        transport: "http",
         command: "node",
+        url: "https://example.com/mcp",
         header: ["X-Test: yes"],
       }),
     (error) =>
       error instanceof CliError &&
-      error.exitCode === 2 &&
-      error.message.includes("--access-token, --oauth-access-token, --refresh-token, --client-id, --client-secret, and --header can only be used"),
+      error.exitCode === 2,
   );
 
   assert.throws(
@@ -150,6 +158,111 @@ test("parseServerConfig rejects missing and mixed targets", () => {
       error instanceof CliError &&
       error.message.includes("--client-id is required"),
   );
+
+  assert.throws(
+    () =>
+      parseServerConfig({
+        transport: "socket" as "http",
+        url: "https://example.com/mcp",
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes('Invalid transport "socket"'),
+  );
+
+  assert.throws(
+    () =>
+      parseServerConfig({
+        transport: "http",
+        command: "node",
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("--transport http requires --url"),
+  );
+
+  assert.throws(
+    () =>
+      parseServerConfig({
+        transport: "stdio",
+        url: "https://example.com/mcp",
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("--transport stdio requires --command"),
+  );
+
+  assert.throws(
+    () =>
+      parseServerConfig({
+        transport: "http",
+        url: "https://example.com/mcp",
+        command: "node",
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("--command can only be used with --transport stdio"),
+  );
+
+  assert.throws(
+    () =>
+      parseServerConfig({
+        transport: "stdio",
+        url: "https://example.com/mcp",
+        command: "node",
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("--url can only be used with --transport http"),
+  );
+});
+
+test("parseServerConfig rejects stdio-only flags on HTTP targets", () => {
+  assert.throws(
+    () =>
+      parseServerConfig({
+        url: "https://example.com/mcp",
+        args: ["-y", "@modelcontextprotocol/server-everything"],
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("--args, --command-args, --env, and --cwd"),
+  );
+});
+
+test("addSharedServerOptions parses modern stdio aliases", () => {
+  const command = addSharedServerOptions(
+    new Command().exitOverride().allowExcessArguments(false),
+  );
+
+  command.parse([
+    "node",
+    "test",
+    "--transport",
+    "stdio",
+    "--command",
+    "npx",
+    "--args",
+    "-y",
+    "@modelcontextprotocol/server-everything",
+    "--command-args",
+    "mcp",
+    "--command-args",
+    "start",
+    "-e",
+    "FOO=bar",
+    "BAR=baz",
+    "--cwd",
+    "/tmp/stdin-server",
+  ]);
+
+  const options = command.opts();
+  assert.equal(options.transport, "stdio");
+  assert.equal(options.command, "npx");
+  assert.deepEqual(options.args, ["-y", "@modelcontextprotocol/server-everything"]);
+  assert.deepEqual(options.commandArgs, ["mcp", "start"]);
+  assert.deepEqual(options.env, ["FOO=bar", "BAR=baz"]);
+  assert.equal(options.cwd, "/tmp/stdin-server");
 });
 
 test("parseJsonRecord rejects non-object JSON", () => {

--- a/cli/tests/server-config.test.ts
+++ b/cli/tests/server-config.test.ts
@@ -77,7 +77,7 @@ test("parseServerConfig builds a stdio config with args and env", () => {
     assert.equal("command" in config, true);
     assert.equal(config.command, "node");
     assert.deepEqual(config.args, ["server.js", "--flag"]);
-    assert.equal(config.env?.[inheritedEnvKey], "from-parent");
+    assert.equal(config.env?.[inheritedEnvKey], undefined);
     assert.equal(config.env?.FOO, "bar");
     assert.equal(config.env?.BAZ, "qux");
     assert.equal(config.cwd, "/tmp/mcpjam-test");

--- a/cli/tests/server-config.test.ts
+++ b/cli/tests/server-config.test.ts
@@ -58,26 +58,38 @@ test("parseServerConfig accepts refresh-token auth for HTTP servers", () => {
 });
 
 test("parseServerConfig builds a stdio config with args and env", () => {
-  const config = parseServerConfig({
-    transport: "stdio",
-    command: "node",
-    args: ["server.js"],
-    commandArgs: ["--flag"],
-    env: ["FOO=bar", "BAZ=qux"],
-    cwd: "/tmp/mcpjam-test",
-    timeout: 5000,
-  });
+  const inheritedEnvKey = "MCPJAM_TEST_CLI_INHERITED_ENV";
+  const originalInheritedEnv = process.env[inheritedEnvKey];
 
-  assert.equal("command" in config, true);
-  assert.equal(config.command, "node");
-  assert.deepEqual(config.args, ["server.js", "--flag"]);
-  assert.deepEqual(config.env, {
-    FOO: "bar",
-    BAZ: "qux",
-  });
-  assert.equal(config.cwd, "/tmp/mcpjam-test");
-  assert.equal(config.stderr, "pipe");
-  assert.equal(config.timeout, 5000);
+  process.env[inheritedEnvKey] = "from-parent";
+
+  try {
+    const config = parseServerConfig({
+      transport: "stdio",
+      command: "node",
+      args: ["server.js"],
+      commandArgs: ["--flag"],
+      env: ["FOO=bar", "BAZ=qux"],
+      cwd: "/tmp/mcpjam-test",
+      timeout: 5000,
+    });
+
+    assert.equal("command" in config, true);
+    assert.equal(config.command, "node");
+    assert.deepEqual(config.args, ["server.js", "--flag"]);
+    assert.equal(config.env?.[inheritedEnvKey], "from-parent");
+    assert.equal(config.env?.FOO, "bar");
+    assert.equal(config.env?.BAZ, "qux");
+    assert.equal(config.cwd, "/tmp/mcpjam-test");
+    assert.equal(config.stderr, "pipe");
+    assert.equal(config.timeout, 5000);
+  } finally {
+    if (originalInheritedEnv === undefined) {
+      delete process.env[inheritedEnvKey];
+    } else {
+      process.env[inheritedEnvKey] = originalInheritedEnv;
+    }
+  }
 });
 
 test("parseServerConfig preserves commas inside stdio args and env values", () => {
@@ -93,10 +105,8 @@ test("parseServerConfig preserves commas inside stdio args and env values", () =
 
   assert.equal("command" in config, true);
   assert.deepEqual(config.args, ['{"a":1,"b":2}', "--list=one,two"]);
-  assert.deepEqual(config.env, {
-    NO_PROXY: "127.0.0.1,localhost",
-    JSON_PAYLOAD: '{"a":1,"b":2}',
-  });
+  assert.equal(config.env?.NO_PROXY, "127.0.0.1,localhost");
+  assert.equal(config.env?.JSON_PAYLOAD, '{"a":1,"b":2}');
 });
 
 test("parseServerConfig rejects missing and mixed targets", () => {

--- a/cli/tests/server-config.test.ts
+++ b/cli/tests/server-config.test.ts
@@ -149,6 +149,20 @@ test("parseServerConfig rejects missing and mixed targets", () => {
   assert.throws(
     () =>
       parseServerConfig({
+        command: "node",
+        header: ["X-Test: yes"],
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.exitCode === 2 &&
+      error.message.includes(
+        "--access-token, --oauth-access-token, --refresh-token, --client-id, --client-secret, and --header can only be used together with --url.",
+      ),
+  );
+
+  assert.throws(
+    () =>
+      parseServerConfig({
         url: "https://example.com/mcp",
         accessToken: "one",
         oauthAccessToken: "two",

--- a/docs/cli/apps-conformance.mdx
+++ b/docs/cli/apps-conformance.mdx
@@ -124,6 +124,8 @@ mcpjam apps conformance \
 Stdio child processes inherit the parent shell environment by default. Use
 `-e/--env` to add values or override inherited ones when the app server needs
 project-specific configuration.
+`--transport` is optional; without it, `--url` implies HTTP and `--command`
+implies stdio.
 
 ## Notes
 

--- a/docs/cli/apps-conformance.mdx
+++ b/docs/cli/apps-conformance.mdx
@@ -24,7 +24,7 @@ mcpjam apps conformance --url https://your-server.com/mcp
 For a local stdio server:
 
 ```bash
-mcpjam apps conformance --command node --command-args server.js
+mcpjam apps conformance --command node --args server.js --cwd /path/to/project
 ```
 
 ## What it checks
@@ -106,6 +106,7 @@ mcpjam apps conformance \
 
 | Flag | Description |
 |------|-------------|
+| `--transport <transport>` | Explicit transport type (`http` or `stdio`) |
 | `--url <url>` | HTTP MCP server URL |
 | `--access-token <token>` | Bearer access token |
 | `--oauth-access-token <token>` | OAuth bearer access token |
@@ -115,8 +116,14 @@ mcpjam apps conformance \
 | `--header <header>` | HTTP header in `Key: Value` format (repeatable) |
 | `--client-capabilities <json>` | Client capabilities JSON object |
 | `--command <command>` | Command for a stdio server |
-| `--command-args <arg>` | Stdio command argument (repeatable) |
-| `--env <env>` | Stdio environment `KEY=VALUE` (repeatable) |
+| `--args <arg...>` | Preferred stdio command arguments |
+| `--command-args <arg>` | Legacy stdio command argument (repeatable) |
+| `-e, --env <env...>` | Stdio environment `KEY=VALUE` values |
+| `--cwd <path>` | Working directory for the stdio child process |
+
+Stdio child processes inherit the parent shell environment by default. Use
+`-e/--env` to add values or override inherited ones when the app server needs
+project-specific configuration.
 
 ## Notes
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -69,6 +69,10 @@ The CLI auto-detects whether stdout is a terminal:
 
 The CLI supports two transport modes, selected by which flags you pass:
 
+- `--url ...` selects HTTP.
+- `--command ...` selects stdio.
+- `--transport http|stdio` is optional and acts as an explicit override/validator when you want the CLI to reject mismatched flags early.
+
 ### HTTP (Streamable HTTP / SSE)
 
 ```bash
@@ -96,6 +100,13 @@ mcpjam server doctor --command node --args server.js --cwd /path/to/project -e A
 
 Stdio child processes inherit the parent shell environment by default. Use
 `-e/--env` to add values or override inherited ones for the spawned server.
+Structured debug artifacts only record the explicit env keys you pass through
+`-e/--env`; inherited shell variables are not enumerated.
+
+<Note>
+  `oauth ...` and `protocol conformance` are HTTP-only command groups. They do
+  not accept stdio targets.
+</Note>
 
 ## Exit codes
 

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -91,8 +91,11 @@ mcpjam server doctor --url https://your-server.com/mcp --header "X-API-Key: $KEY
 ### Stdio (local subprocess)
 
 ```bash
-mcpjam server doctor --command node --command-args server.js --env API_KEY=$KEY
+mcpjam server doctor --command node --args server.js --cwd /path/to/project -e API_KEY=$KEY
 ```
+
+Stdio child processes inherit the parent shell environment by default. Use
+`-e/--env` to add values or override inherited ones for the spawned server.
 
 ## Exit codes
 

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -25,6 +25,7 @@ All server commands accept the shared connection flags below, plus command-speci
 
 | Flag | Description |
 |------|-------------|
+| `--transport <transport>` | Explicit transport type (`http` or `stdio`) |
 | `--url <url>` | HTTP MCP server URL |
 | `--access-token <token>` | Bearer access token |
 | `--oauth-access-token <token>` | OAuth bearer access token |
@@ -34,8 +35,10 @@ All server commands accept the shared connection flags below, plus command-speci
 | `--header <header>` | HTTP header `Key: Value` (repeatable) |
 | `--client-capabilities <json>` | Client capabilities JSON object |
 | `--command <command>` | Stdio server command |
-| `--command-args <arg>` | Stdio command argument (repeatable) |
-| `--env <env>` | Stdio environment `KEY=VALUE` (repeatable) |
+| `--args <arg...>` | Preferred stdio command arguments |
+| `--command-args <arg>` | Legacy stdio command argument (repeatable) |
+| `-e, --env <env...>` | Stdio environment `KEY=VALUE` values |
+| `--cwd <path>` | Working directory for the stdio child process |
 
 ### `server probe`
 
@@ -217,6 +220,7 @@ Supports `--format json` and `--format human`. `junit-xml` is not supported on p
 
 | Flag | Description |
 |------|-------------|
+| `--transport <transport>` | Explicit transport type (`http` or `stdio`) |
 | `--url <url>` | HTTP MCP server URL |
 | `--access-token <token>` | Bearer access token |
 | `--oauth-access-token <token>` | OAuth bearer access token |
@@ -226,8 +230,10 @@ Supports `--format json` and `--format human`. `junit-xml` is not supported on p
 | `--header <header>` | HTTP header `Key: Value` (repeatable) |
 | `--client-capabilities <json>` | Client capabilities JSON object |
 | `--command <command>` | Stdio server command |
-| `--command-args <arg>` | Stdio command argument (repeatable) |
-| `--env <env>` | Stdio environment `KEY=VALUE` (repeatable) |
+| `--args <arg...>` | Preferred stdio command arguments |
+| `--command-args <arg>` | Legacy stdio command argument (repeatable) |
+| `-e, --env <env...>` | Stdio environment `KEY=VALUE` values |
+| `--cwd <path>` | Working directory for the stdio child process |
 
 ### `apps conformance`
 

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -40,6 +40,14 @@ All server commands accept the shared connection flags below, plus command-speci
 | `-e, --env <env...>` | Stdio environment `KEY=VALUE` values |
 | `--cwd <path>` | Working directory for the stdio child process |
 
+Transport selection is inferred from `--url` vs `--command` when
+`--transport` is omitted. Use `--transport http|stdio` when you want an
+explicit validation step.
+
+For stdio targets, child processes inherit the parent shell environment by
+default. `-e/--env` adds or overrides child env values, and structured debug
+artifacts only record the explicit env keys you passed on the command line.
+
 ### `server probe`
 
 No additional flags beyond shared connection flags.
@@ -234,6 +242,10 @@ Supports `--format json` and `--format human`. `junit-xml` is not supported on p
 | `--command-args <arg>` | Legacy stdio command argument (repeatable) |
 | `-e, --env <env...>` | Stdio environment `KEY=VALUE` values |
 | `--cwd <path>` | Working directory for the stdio child process |
+
+Apps conformance shares the same transport inference rules as the rest of the
+CLI: `--url` implies HTTP, `--command` implies stdio, and `--transport` is an
+optional explicit override.
 
 ### `apps conformance`
 

--- a/docs/cli/server-inspection.mdx
+++ b/docs/cli/server-inspection.mdx
@@ -44,7 +44,7 @@ mcpjam server doctor --url https://your-server.com/mcp
 mcpjam server doctor --url https://your-server.com/mcp --rpc --out doctor.json
 
 # Stdio server
-mcpjam server doctor --command node --command-args server.js
+mcpjam server doctor --command node --args server.js --cwd /path/to/project
 ```
 
 **What it returns:**
@@ -103,6 +103,7 @@ Every `server` subcommand accepts these flags for specifying how to connect:
 
 | Flag | Description |
 |------|-------------|
+| `--transport <transport>` | Explicit transport type (`http` or `stdio`) |
 | `--url <url>` | HTTP MCP server URL |
 | `--access-token <token>` | Bearer access token |
 | `--oauth-access-token <token>` | OAuth bearer access token |
@@ -112,8 +113,14 @@ Every `server` subcommand accepts these flags for specifying how to connect:
 | `--header <header>` | HTTP header in `Key: Value` format (repeatable) |
 | `--client-capabilities <json>` | Client capabilities as a JSON object |
 | `--command <command>` | Command for a stdio server |
-| `--command-args <arg>` | Stdio command argument (repeatable) |
-| `--env <env>` | Stdio environment `KEY=VALUE` (repeatable) |
+| `--args <arg...>` | Preferred stdio command arguments |
+| `--command-args <arg>` | Legacy stdio command argument (repeatable) |
+| `-e, --env <env...>` | Stdio environment `KEY=VALUE` values |
+| `--cwd <path>` | Working directory for the stdio child process |
+
+Stdio child processes inherit the parent shell environment by default. Use
+`-e/--env` to add values or override inherited ones, and `--cwd` when the
+command must run from a project directory.
 
 ## Common patterns
 

--- a/docs/cli/server-inspection.mdx
+++ b/docs/cli/server-inspection.mdx
@@ -54,6 +54,8 @@ mcpjam server doctor --command node --args server.js --cwd /path/to/project
 - Counts: tools, resources, resource templates, prompts
 
 The `--out <path>` flag writes the full JSON artifact to a file — useful for handoff to another engineer or agent.
+For stdio targets, those artifacts only record the explicit env keys you passed
+via `-e/--env`; inherited shell variables are not enumerated.
 
 ### `server info`
 
@@ -121,6 +123,8 @@ Every `server` subcommand accepts these flags for specifying how to connect:
 Stdio child processes inherit the parent shell environment by default. Use
 `-e/--env` to add values or override inherited ones, and `--cwd` when the
 command must run from a project directory.
+If you pass `--transport`, the CLI validates that it matches the target flags
+you provided instead of silently inferring the transport.
 
 ## Common patterns
 

--- a/docs/cli/tools-resources-prompts.mdx
+++ b/docs/cli/tools-resources-prompts.mdx
@@ -31,6 +31,16 @@ Tool arguments are passed as a JSON string. The result includes the tool's respo
   trace for debugging.
 </Note>
 
+For a local stdio server:
+
+```bash
+mcpjam tools list \
+  --command npx \
+  --args -y @modelcontextprotocol/server-everything \
+  --cwd $PWD \
+  -e DEBUG=1
+```
+
 ## Resources
 
 ### List resources
@@ -105,3 +115,6 @@ mcpjam tools list --url https://mcp.excalidraw.com/mcp
 mcpjam tools call --url https://mcp.excalidraw.com/mcp \
   --tool-name read_me
 ```
+
+Stdio child processes inherit the parent shell environment by default. Use
+`-e/--env` to add values or override inherited ones for local subprocesses.

--- a/docs/cli/tools-resources-prompts.mdx
+++ b/docs/cli/tools-resources-prompts.mdx
@@ -28,7 +28,9 @@ Tool arguments are passed as a JSON string. The result includes the tool's respo
 
 <Note>
   `tools call` supports `--debug-out <path>` to capture the full request/response
-  trace for debugging.
+  trace for debugging. For stdio targets, the artifact records only the
+  explicit env keys passed through `-e/--env`; inherited shell variables are
+  not enumerated.
 </Note>
 
 For a local stdio server:

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -5,7 +5,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
   StdioClientTransport,
-  getDefaultEnvironment,
 } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
@@ -1077,7 +1076,7 @@ export class MCPClientManager {
     const underlying = new StdioClientTransport({
       command: config.command,
       args: config.args,
-      env: { ...getDefaultEnvironment(), ...(config.env ?? {}) },
+      env: { ...this.getProcessEnvironment(), ...(config.env ?? {}) },
       stderr: config.stderr,
       cwd: config.cwd,
     });
@@ -1247,6 +1246,15 @@ export class MCPClientManager {
     }
   }
 
+  private getProcessEnvironment(): Record<string, string> {
+    return Object.fromEntries(
+      Object.entries(process.env).filter(
+        (entry): entry is [string, string] =>
+          typeof entry[1] === "string" && !entry[1].startsWith("()")
+      )
+    );
+  }
+
   private createStdioStderrDrain(
     transport: StdioClientTransport
   ): { cleanup: () => void; getCapturedOutput: () => string } {
@@ -1287,13 +1295,12 @@ export class MCPClientManager {
     error: unknown,
     stderrOutput: string
   ): Error {
-    if (!stderrOutput) {
-      return error instanceof Error ? error : new Error(String(error));
-    }
-
     const baseMessage =
       error instanceof Error ? error.message : String(error);
-    const message = `Failed to connect to MCP server "${serverId}" via stdio: ${baseMessage}\n\nChild process stderr:\n${stderrOutput}`;
+    const stderrSection = stderrOutput
+      ? `\n\nChild process stderr:\n${stderrOutput}`
+      : "";
+    const message = `Failed to connect to MCP server "${serverId}" via stdio: ${baseMessage}${stderrSection}`;
 
     if (error instanceof Error) {
       return new Error(message, { cause: error });

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -5,7 +5,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
   StdioClientTransport,
-  getDefaultEnvironment,
 } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
@@ -1073,7 +1072,7 @@ export class MCPClientManager {
     const underlying = new StdioClientTransport({
       command: config.command,
       args: config.args,
-      env: { ...getDefaultEnvironment(), ...(config.env ?? {}) },
+      env: { ...this.getProcessEnvironment(), ...(config.env ?? {}) },
       stderr: config.stderr,
       cwd: config.cwd,
     });
@@ -1083,7 +1082,20 @@ export class MCPClientManager {
       ? wrapTransportForLogging(serverId, logger, underlying)
       : underlying;
 
-    await client.connect(transport, { timeout });
+    const stopStderrCapture = this.captureStdioStartupStderr(underlying);
+
+    try {
+      await client.connect(transport, { timeout });
+    } catch (error) {
+      throw this.annotateStdioConnectError(
+        serverId,
+        error,
+        stopStderrCapture()
+      );
+    } finally {
+      stopStderrCapture();
+    }
+
     return underlying;
   }
 
@@ -1227,6 +1239,65 @@ export class MCPClientManager {
     } catch {
       // Ignore close errors
     }
+  }
+
+  private getProcessEnvironment(): Record<string, string> {
+    return Object.fromEntries(
+      Object.entries(process.env).filter(
+        (entry): entry is [string, string] => typeof entry[1] === "string"
+      )
+    );
+  }
+
+  private captureStdioStartupStderr(
+    transport: StdioClientTransport
+  ): () => string {
+    const stderrStream = transport.stderr as NodeJS.ReadableStream | null;
+    if (!stderrStream) {
+      return () => "";
+    }
+
+    const maxCapturedChars = 16_384;
+    let captured = "";
+    let stopped = false;
+    const onData = (chunk: Buffer | string) => {
+      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      captured += text;
+      if (captured.length > maxCapturedChars) {
+        captured = captured.slice(-maxCapturedChars);
+      }
+    };
+
+    stderrStream.on("data", onData);
+
+    return () => {
+      if (!stopped) {
+        stopped = true;
+        stderrStream.removeListener("data", onData);
+      }
+
+      return captured.trim();
+    };
+  }
+
+  private annotateStdioConnectError(
+    serverId: string,
+    error: unknown,
+    stderrOutput: string
+  ): Error {
+    if (!stderrOutput) {
+      return error instanceof Error ? error : new Error(String(error));
+    }
+
+    const baseMessage =
+      error instanceof Error ? error.message : String(error);
+    const message = `Failed to connect to MCP server "${serverId}" via stdio: ${baseMessage}\n\nChild process stderr:\n${stderrOutput}`;
+
+    if (error instanceof Error) {
+      return new Error(message, { cause: error });
+    }
+
+    return new Error(message);
   }
 
   private async ensureConnected(serverId: string): Promise<void> {

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -5,6 +5,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
   StdioClientTransport,
+  getDefaultEnvironment,
 } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
@@ -333,6 +334,8 @@ export class MCPClientManager {
     } catch {
       // Ignore close errors
     } finally {
+      state.stdioStderrCleanup?.();
+      state.stdioStderrCleanup = undefined;
       if (state.transport) {
         await this.safeCloseTransport(state.transport);
       }
@@ -1036,7 +1039,8 @@ export class MCPClientManager {
           serverId,
           client,
           config,
-          timeout
+          timeout,
+          state
         );
       } else {
         transport = await this.connectViaHttp(
@@ -1067,12 +1071,13 @@ export class MCPClientManager {
     serverId: string,
     client: Client,
     config: StdioServerConfig,
-    timeout: number
+    timeout: number,
+    state: ManagedClientState
   ): Promise<Transport> {
     const underlying = new StdioClientTransport({
       command: config.command,
       args: config.args,
-      env: { ...this.getProcessEnvironment(), ...(config.env ?? {}) },
+      env: { ...getDefaultEnvironment(), ...(config.env ?? {}) },
       stderr: config.stderr,
       cwd: config.cwd,
     });
@@ -1082,20 +1087,21 @@ export class MCPClientManager {
       ? wrapTransportForLogging(serverId, logger, underlying)
       : underlying;
 
-    const stopStderrCapture = this.captureStdioStartupStderr(underlying);
+    const stderrDrain = this.createStdioStderrDrain(underlying);
 
     try {
       await client.connect(transport, { timeout });
     } catch (error) {
+      const stderrOutput = stderrDrain.getCapturedOutput();
+      stderrDrain.cleanup();
       throw this.annotateStdioConnectError(
         serverId,
         error,
-        stopStderrCapture()
+        stderrOutput
       );
-    } finally {
-      stopStderrCapture();
     }
 
+    state.stdioStderrCleanup = stderrDrain.cleanup;
     return underlying;
   }
 
@@ -1241,20 +1247,15 @@ export class MCPClientManager {
     }
   }
 
-  private getProcessEnvironment(): Record<string, string> {
-    return Object.fromEntries(
-      Object.entries(process.env).filter(
-        (entry): entry is [string, string] => typeof entry[1] === "string"
-      )
-    );
-  }
-
-  private captureStdioStartupStderr(
+  private createStdioStderrDrain(
     transport: StdioClientTransport
-  ): () => string {
+  ): { cleanup: () => void; getCapturedOutput: () => string } {
     const stderrStream = transport.stderr as NodeJS.ReadableStream | null;
     if (!stderrStream) {
-      return () => "";
+      return {
+        cleanup: () => {},
+        getCapturedOutput: () => "",
+      };
     }
 
     const maxCapturedChars = 16_384;
@@ -1270,13 +1271,14 @@ export class MCPClientManager {
 
     stderrStream.on("data", onData);
 
-    return () => {
-      if (!stopped) {
-        stopped = true;
-        stderrStream.removeListener("data", onData);
-      }
-
-      return captured.trim();
+    return {
+      cleanup: () => {
+        if (!stopped) {
+          stopped = true;
+          stderrStream.removeListener("data", onData);
+        }
+      },
+      getCapturedOutput: () => captured.trim(),
     };
   }
 
@@ -1323,6 +1325,8 @@ export class MCPClientManager {
   }
 
   private resetState(serverId: string): void {
+    const state = this.clientStates.get(serverId);
+    state?.stdioStderrCleanup?.();
     this.clientStates.delete(serverId);
     this.toolsMetadataCache.delete(serverId);
   }

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -159,6 +159,7 @@ export interface ManagedClientState {
   client?: Client;
   transport?: Transport;
   authProvider?: RefreshTokenOAuthProvider;
+  stdioStderrCleanup?: () => void;
   promise?: Promise<Client>;
 }
 

--- a/sdk/tests/MCPClientManager.test.ts
+++ b/sdk/tests/MCPClientManager.test.ts
@@ -1,4 +1,7 @@
 import { MCPClientManager } from "../src/mcp-client-manager";
+import { realpathSync, rmSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import {
   startMockHttpServer,
   startMockStreamableHttpServer,
@@ -6,6 +9,69 @@ import {
   MOCK_RESOURCES,
   MOCK_PROMPTS,
 } from "./mock-servers";
+
+function extractSingleText(result: unknown): string {
+  return (result as any).content[0].text;
+}
+
+function buildInlineCwdServerScript(): string {
+  const sdkCjsRoot = path.dirname(
+    require.resolve("@modelcontextprotocol/sdk/package.json")
+  );
+  const serverIndexPath = JSON.stringify(
+    path.join(sdkCjsRoot, "server", "index.js")
+  );
+  const serverStdioPath = JSON.stringify(
+    path.join(sdkCjsRoot, "server", "stdio.js")
+  );
+  const typesPath = JSON.stringify(path.join(sdkCjsRoot, "types.js"));
+
+  return `
+    const { Server } = require(${serverIndexPath});
+    const { StdioServerTransport } = require(${serverStdioPath});
+    const {
+      CallToolRequestSchema,
+      ListToolsRequestSchema
+    } = require(${typesPath});
+
+    const server = new Server(
+      { name: "cwd-test-server", version: "1.0.0" },
+      { capabilities: { tools: {} } }
+    );
+
+    server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: [
+        {
+          name: "cwd",
+          description: "Returns the current working directory",
+          inputSchema: {
+            type: "object",
+            properties: {},
+            additionalProperties: false
+          }
+        }
+      ]
+    }));
+
+    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      if (request.params.name !== "cwd") {
+        return {
+          content: [{ type: "text", text: "unknown tool" }],
+          isError: true
+        };
+      }
+
+      return {
+        content: [{ type: "text", text: process.cwd() }]
+      };
+    });
+
+    server.connect(new StdioServerTransport()).catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+  `;
+}
 
 describe("MCPClientManager", () => {
   describe("constructor", () => {
@@ -92,6 +158,88 @@ describe("MCPClientManager", () => {
 
       expect(manager.getConnectionStatus("everything")).toBe("disconnected");
     }, 30000);
+  });
+
+  describe("STDIO transport hardening", () => {
+    let manager: MCPClientManager;
+    const inheritedEnvKey = "MCPJAM_TEST_INHERITED_ENV";
+    const overrideEnvKey = "MCPJAM_TEST_OVERRIDE_ENV";
+
+    beforeEach(() => {
+      manager = new MCPClientManager();
+    });
+
+    afterEach(async () => {
+      delete process.env[inheritedEnvKey];
+      delete process.env[overrideEnvKey];
+      await manager.disconnectAllServers();
+    });
+
+    it("inherits parent process env for stdio servers", async () => {
+      process.env[inheritedEnvKey] = "from-parent";
+
+      await manager.connectToServer("env-inherit", {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-everything"],
+      });
+
+      const result = await manager.executeTool("env-inherit", "get-env", {});
+      const env = JSON.parse(extractSingleText(result));
+
+      expect(env[inheritedEnvKey]).toBe("from-parent");
+    }, 30000);
+
+    it("lets explicit stdio env override inherited parent values", async () => {
+      process.env[overrideEnvKey] = "from-parent";
+
+      await manager.connectToServer("env-override", {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-everything"],
+        env: {
+          [overrideEnvKey]: "from-config",
+        },
+      });
+
+      const result = await manager.executeTool("env-override", "get-env", {});
+      const env = JSON.parse(extractSingleText(result));
+
+      expect(env[overrideEnvKey]).toBe("from-config");
+    }, 30000);
+
+    it("passes cwd to stdio child processes", async () => {
+      const cwd = mkdtempSync(path.join(tmpdir(), "mcpjam-cwd-test-"));
+      const resolvedCwd = realpathSync(cwd);
+
+      try {
+        await manager.connectToServer("cwd-server", {
+          command: process.execPath,
+          args: [
+            "-e",
+            buildInlineCwdServerScript(),
+          ],
+          cwd,
+        });
+
+        const result = await manager.executeTool("cwd-server", "cwd", {});
+        expect(extractSingleText(result)).toBe(resolvedCwd);
+      } finally {
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    }, 15000);
+
+    it("surfaces startup stderr when a stdio server fails to initialize", async () => {
+      await expect(
+        manager.connectToServer("stderr-failure", {
+          command: process.execPath,
+          args: [
+            "-e",
+            'console.error("stdio startup failed"); process.exit(1);',
+          ],
+          stderr: "pipe",
+          timeout: 1000,
+        })
+      ).rejects.toThrow(/stdio startup failed/);
+    }, 10000);
   });
 
   describe("HTTP server", () => {

--- a/sdk/tests/MCPClientManager.test.ts
+++ b/sdk/tests/MCPClientManager.test.ts
@@ -73,6 +73,65 @@ function buildInlineCwdServerScript(): string {
   `;
 }
 
+function buildInlineStderrFloodServerScript(): string {
+  const sdkCjsRoot = path.dirname(
+    require.resolve("@modelcontextprotocol/sdk/package.json")
+  );
+  const serverIndexPath = JSON.stringify(
+    path.join(sdkCjsRoot, "server", "index.js")
+  );
+  const serverStdioPath = JSON.stringify(
+    path.join(sdkCjsRoot, "server", "stdio.js")
+  );
+  const typesPath = JSON.stringify(path.join(sdkCjsRoot, "types.js"));
+
+  return `
+    const { Server } = require(${serverIndexPath});
+    const { StdioServerTransport } = require(${serverStdioPath});
+    const {
+      CallToolRequestSchema,
+      ListToolsRequestSchema
+    } = require(${typesPath});
+
+    const server = new Server(
+      { name: "stderr-flood-server", version: "1.0.0" },
+      { capabilities: { tools: {} } }
+    );
+
+    const floodChunk = "x".repeat(64 * 1024);
+    const flood = setInterval(() => {
+      for (let i = 0; i < 8; i += 1) {
+        process.stderr.write(floodChunk);
+      }
+    }, 10);
+
+    server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: [
+        {
+          name: "ping",
+          description: "Responds even while stderr is noisy",
+          inputSchema: {
+            type: "object",
+            properties: {},
+            additionalProperties: false
+          }
+        }
+      ]
+    }));
+
+    server.setRequestHandler(CallToolRequestSchema, async () => ({
+      content: [{ type: "text", text: "pong" }]
+    }));
+
+    server.connect(new StdioServerTransport()).catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+
+    process.on("exit", () => clearInterval(flood));
+  `;
+}
+
 describe("MCPClientManager", () => {
   describe("constructor", () => {
     it("should create an instance with empty config", () => {
@@ -175,7 +234,7 @@ describe("MCPClientManager", () => {
       await manager.disconnectAllServers();
     });
 
-    it("inherits parent process env for stdio servers", async () => {
+    it("does not inherit arbitrary parent env for stdio servers", async () => {
       process.env[inheritedEnvKey] = "from-parent";
 
       await manager.connectToServer("env-inherit", {
@@ -186,11 +245,12 @@ describe("MCPClientManager", () => {
       const result = await manager.executeTool("env-inherit", "get-env", {});
       const env = JSON.parse(extractSingleText(result));
 
-      expect(env[inheritedEnvKey]).toBe("from-parent");
+      expect(env[inheritedEnvKey]).toBeUndefined();
     }, 30000);
 
-    it("lets explicit stdio env override inherited parent values", async () => {
+    it("lets explicit stdio env override parent values without inheriting arbitrary keys", async () => {
       process.env[overrideEnvKey] = "from-parent";
+      process.env[inheritedEnvKey] = "from-parent";
 
       await manager.connectToServer("env-override", {
         command: "npx",
@@ -204,6 +264,7 @@ describe("MCPClientManager", () => {
       const env = JSON.parse(extractSingleText(result));
 
       expect(env[overrideEnvKey]).toBe("from-config");
+      expect(env[inheritedEnvKey]).toBeUndefined();
     }, 30000);
 
     it("passes cwd to stdio child processes", async () => {
@@ -240,6 +301,23 @@ describe("MCPClientManager", () => {
         })
       ).rejects.toThrow(/stdio startup failed/);
     }, 10000);
+
+    it("keeps draining stderr after startup for noisy stdio servers", async () => {
+      await manager.connectToServer("stderr-flood", {
+        command: process.execPath,
+        args: [
+          "-e",
+          buildInlineStderrFloodServerScript(),
+        ],
+        stderr: "pipe",
+        timeout: 5000,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 250));
+
+      const result = await manager.executeTool("stderr-flood", "ping", {});
+      expect(extractSingleText(result)).toBe("pong");
+    }, 15000);
   });
 
   describe("HTTP server", () => {

--- a/sdk/tests/MCPClientManager.test.ts
+++ b/sdk/tests/MCPClientManager.test.ts
@@ -223,18 +223,30 @@ describe("MCPClientManager", () => {
     let manager: MCPClientManager;
     const inheritedEnvKey = "MCPJAM_TEST_INHERITED_ENV";
     const overrideEnvKey = "MCPJAM_TEST_OVERRIDE_ENV";
+    let previousInheritedEnv: string | undefined;
+    let previousOverrideEnv: string | undefined;
 
     beforeEach(() => {
+      previousInheritedEnv = process.env[inheritedEnvKey];
+      previousOverrideEnv = process.env[overrideEnvKey];
       manager = new MCPClientManager();
     });
 
     afterEach(async () => {
-      delete process.env[inheritedEnvKey];
-      delete process.env[overrideEnvKey];
       await manager.disconnectAllServers();
+      if (previousInheritedEnv === undefined) {
+        delete process.env[inheritedEnvKey];
+      } else {
+        process.env[inheritedEnvKey] = previousInheritedEnv;
+      }
+      if (previousOverrideEnv === undefined) {
+        delete process.env[overrideEnvKey];
+      } else {
+        process.env[overrideEnvKey] = previousOverrideEnv;
+      }
     });
 
-    it("does not inherit arbitrary parent env for stdio servers", async () => {
+    it("inherits parent process env for stdio servers", async () => {
       process.env[inheritedEnvKey] = "from-parent";
 
       await manager.connectToServer("env-inherit", {
@@ -245,12 +257,11 @@ describe("MCPClientManager", () => {
       const result = await manager.executeTool("env-inherit", "get-env", {});
       const env = JSON.parse(extractSingleText(result));
 
-      expect(env[inheritedEnvKey]).toBeUndefined();
+      expect(env[inheritedEnvKey]).toBe("from-parent");
     }, 30000);
 
-    it("lets explicit stdio env override parent values without inheriting arbitrary keys", async () => {
+    it("lets explicit stdio env override inherited parent values", async () => {
       process.env[overrideEnvKey] = "from-parent";
-      process.env[inheritedEnvKey] = "from-parent";
 
       await manager.connectToServer("env-override", {
         command: "npx",
@@ -264,7 +275,6 @@ describe("MCPClientManager", () => {
       const env = JSON.parse(extractSingleText(result));
 
       expect(env[overrideEnvKey]).toBe("from-config");
-      expect(env[inheritedEnvKey]).toBeUndefined();
     }, 30000);
 
     it("passes cwd to stdio child processes", async () => {
@@ -300,6 +310,22 @@ describe("MCPClientManager", () => {
           timeout: 1000,
         })
       ).rejects.toThrow(/stdio startup failed/);
+    }, 10000);
+
+    it("keeps stdio server context for silent initialization failures", async () => {
+      await expect(
+        manager.connectToServer("silent-timeout", {
+          command: process.execPath,
+          args: [
+            "-e",
+            "setInterval(() => {}, 1000);",
+          ],
+          stderr: "pipe",
+          timeout: 200,
+        })
+      ).rejects.toThrow(
+        /Failed to connect to MCP server "silent-timeout" via stdio: MCP error -32001: Request timed out/
+      );
     }, 10000);
 
     it("keeps draining stderr after startup for noisy stdio servers", async () => {


### PR DESCRIPTION
## Summary
- add shared CLI transport parsing for `--transport`, `--args`, `-e/--env`, and `--cwd`
- keep `--command-args` as a legacy alias while normalizing stdio args and tightening HTTP vs stdio validation
- make stdio child processes inherit the parent environment, pipe `stderr`, and surface startup `stderr` on connection failures
- update CLI docs to prefer the new stdio syntax and document env inheritance/overrides
- add parser and SDK tests covering transport validation, env precedence, `cwd`, and startup error reporting

## Testing
- `npm --prefix ./cli test -- tests/server-config.test.ts`
- `npm --prefix ./sdk test -- MCPClientManager.test.ts`
- `npm --prefix ./cli run typecheck`
- `npm --prefix ./sdk run typecheck`
- smoke tested `tools list` and `get-env` against `npx @modelcontextprotocol/server-everything`
- smoke tested `tools list` against `npx -y convex@latest mcp start`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI target parsing and SDK stdio connection behavior (env inheritance, cwd, stderr piping/error annotation), which can affect how subprocess-based servers start and how failures are reported.
> 
> **Overview**
> Adds explicit transport selection/validation to the CLI via `--transport http|stdio`, plus modern stdio flags `--args`, `-e/--env`, and `--cwd` (keeping `--command-args` as a legacy alias) and tighter rejection of stdio-only flags on HTTP targets.
> 
> Hardens SDK stdio connections by inheriting the parent process environment, defaulting stdio `stderr` to `pipe`, continuously draining/capturing startup stderr, and surfacing that stderr in connection errors while ensuring drain cleanup on disconnect/reset.
> 
> Updates CLI docs and tests to use the new stdio syntax, document env inheritance/overrides, and cover transport validation, args merging, cwd handling, and improved stdio failure reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05f3b9c14a49d50abc51f0c30022b4d1873ab7fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->