### PR TITLE
Add MCP retry policy support and stabilize hosted inspector flows

### DIFF
--- a/cli/src/commands/apps.ts
+++ b/cli/src/commands/apps.ts
@@ -7,27 +7,22 @@ import {
   type MCPAppsCheckId,
   type MCPAppsConformanceConfig,
 } from "@mcpjam/sdk";
-import {
-  buildChatGptWidgetContent,
-  buildMcpWidgetContent,
-} from "../lib/apps";
+import { buildChatGptWidgetContent, buildMcpWidgetContent } from "../lib/apps";
 import { withEphemeralManager } from "../lib/ephemeral";
 import { createCliRpcLogCollector } from "../lib/rpc-logs";
 import { withRpcLogsIfRequested } from "../lib/rpc-helpers";
 import {
+  addRetryOptions,
   addSharedServerOptions,
   describeTarget,
   getGlobalOptions,
   parseJsonRecord,
+  parseRetryPolicy,
   parseServerConfig,
   resolveAliasedStringOption,
   type SharedServerTargetOptions,
 } from "../lib/server-config";
-import {
-  setProcessExitCode,
-  usageError,
-  writeResult,
-} from "../lib/output";
+import { setProcessExitCode, usageError, writeResult } from "../lib/output";
 
 const APPS_CHECK_IDS_BY_CATEGORY: Record<
   MCPAppsCheckCategory,
@@ -54,7 +49,9 @@ export interface AppsConformanceOptions extends SharedServerTargetOptions {
 export function registerAppsCommands(program: Command): void {
   const apps = program
     .command("apps")
-    .description("MCP Apps utilities, widget extraction, and conformance checks");
+    .description(
+      "MCP Apps utilities, widget extraction, and conformance checks",
+    );
 
   addSharedServerOptions(
     apps
@@ -96,26 +93,32 @@ export function registerAppsCommands(program: Command): void {
     }
   });
 
-  addSharedServerOptions(
-    apps
-      .command("mcp-widget")
-      .description("Fetch hosted-style MCP App widget content")
-      .option("--resource-uri <uri>", "Widget resource URI")
-      .option("--uri <uri>", "Alias for --resource-uri")
-      .requiredOption("--tool-id <id>", "Tool call id used for runtime injection")
-      .requiredOption("--tool-name <name>", "Tool name used for runtime injection")
-      .option("--tool-input <json>", "Tool input payload as JSON")
-      .option("--tool-output <json>", "Tool output payload as JSON")
-      .option("--theme <theme>", "Widget theme: light or dark")
-      .option(
-        "--csp-mode <mode>",
-        "CSP mode: permissive or widget-declared",
-      )
-      .option("--template <uri>", "Optional ui:// template override")
-      .option("--view-mode <mode>", "Widget view mode")
-      .option("--view-params <json>", "Widget view params as JSON"),
+  addRetryOptions(
+    addSharedServerOptions(
+      apps
+        .command("mcp-widget")
+        .description("Fetch hosted-style MCP App widget content")
+        .option("--resource-uri <uri>", "Widget resource URI")
+        .option("--uri <uri>", "Alias for --resource-uri")
+        .requiredOption(
+          "--tool-id <id>",
+          "Tool call id used for runtime injection",
+        )
+        .requiredOption(
+          "--tool-name <name>",
+          "Tool name used for runtime injection",
+        )
+        .option("--tool-input <json>", "Tool input payload as JSON")
+        .option("--tool-output <json>", "Tool output payload as JSON")
+        .option("--theme <theme>", "Widget theme: light or dark")
+        .option("--csp-mode <mode>", "CSP mode: permissive or widget-declared")
+        .option("--template <uri>", "Optional ui:// template override")
+        .option("--view-mode <mode>", "Widget view mode")
+        .option("--view-params <json>", "Widget view params as JSON"),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
+    const retryPolicy = parseRetryPolicy(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -152,35 +155,48 @@ export function registerAppsCommands(program: Command): void {
       {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
+        retryPolicy,
       },
     );
 
-    writeResult(withRpcLogsIfRequested(result, collector, globalOptions), globalOptions.format);
+    writeResult(
+      withRpcLogsIfRequested(result, collector, globalOptions),
+      globalOptions.format,
+    );
   });
 
-  addSharedServerOptions(
-    apps
-      .command("chatgpt-widget")
-      .description("Fetch hosted-style ChatGPT App widget content")
-      .option("--resource-uri <uri>", "Widget resource URI")
-      .option("--uri <uri>", "Alias for --resource-uri")
-      .requiredOption("--tool-id <id>", "Tool call id used for runtime injection")
-      .requiredOption("--tool-name <name>", "Tool name used for runtime injection")
-      .option("--tool-input <json>", "Tool input payload as JSON")
-      .option("--tool-output <json>", "Tool output payload as JSON")
-      .option(
-        "--tool-response-metadata <json>",
-        "Tool response metadata as a JSON object",
-      )
-      .option("--theme <theme>", "Widget theme: light or dark")
-      .option(
-        "--csp-mode <mode>",
-        "CSP mode: permissive or widget-declared",
-      )
-      .option("--locale <locale>", "Locale override")
-      .option("--device-type <type>", "Device type: mobile, tablet, or desktop"),
+  addRetryOptions(
+    addSharedServerOptions(
+      apps
+        .command("chatgpt-widget")
+        .description("Fetch hosted-style ChatGPT App widget content")
+        .option("--resource-uri <uri>", "Widget resource URI")
+        .option("--uri <uri>", "Alias for --resource-uri")
+        .requiredOption(
+          "--tool-id <id>",
+          "Tool call id used for runtime injection",
+        )
+        .requiredOption(
+          "--tool-name <name>",
+          "Tool name used for runtime injection",
+        )
+        .option("--tool-input <json>", "Tool input payload as JSON")
+        .option("--tool-output <json>", "Tool output payload as JSON")
+        .option(
+          "--tool-response-metadata <json>",
+          "Tool response metadata as a JSON object",
+        )
+        .option("--theme <theme>", "Widget theme: light or dark")
+        .option("--csp-mode <mode>", "CSP mode: permissive or widget-declared")
+        .option("--locale <locale>", "Locale override")
+        .option(
+          "--device-type <type>",
+          "Device type: mobile, tablet, or desktop",
+        ),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
+    const retryPolicy = parseRetryPolicy(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -221,10 +237,14 @@ export function registerAppsCommands(program: Command): void {
       {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
+        retryPolicy,
       },
     );
 
-    writeResult(withRpcLogsIfRequested(result, collector, globalOptions), globalOptions.format);
+    writeResult(
+      withRpcLogsIfRequested(result, collector, globalOptions),
+      globalOptions.format,
+    );
   });
 }
 

--- a/cli/src/commands/prompts.ts
+++ b/cli/src/commands/prompts.ts
@@ -4,10 +4,12 @@ import { withEphemeralManager } from "../lib/ephemeral";
 import { createCliRpcLogCollector } from "../lib/rpc-logs";
 import { withRpcLogsIfRequested } from "../lib/rpc-helpers";
 import {
+  addRetryOptions,
   addSharedServerOptions,
   describeTarget,
   getGlobalOptions,
   parsePromptArguments,
+  parseRetryPolicy,
   parseServerConfig,
   resolveAliasedStringOption,
 } from "../lib/server-config";
@@ -18,13 +20,16 @@ export function registerPromptCommands(program: Command): void {
     .command("prompts")
     .description("List and fetch MCP prompts");
 
-  addSharedServerOptions(
-    prompts
-      .command("list")
-      .description("List prompts exposed by an MCP server")
-      .option("--cursor <cursor>", "Pagination cursor"),
+  addRetryOptions(
+    addSharedServerOptions(
+      prompts
+        .command("list")
+        .description("List prompts exposed by an MCP server")
+        .option("--cursor <cursor>", "Pagination cursor"),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
+    const retryPolicy = parseRetryPolicy(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -41,21 +46,28 @@ export function registerPromptCommands(program: Command): void {
       {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
+        retryPolicy,
       },
     );
 
-    writeResult(withRpcLogsIfRequested(result, collector, globalOptions), globalOptions.format);
+    writeResult(
+      withRpcLogsIfRequested(result, collector, globalOptions),
+      globalOptions.format,
+    );
   });
 
-  addSharedServerOptions(
-    prompts
-      .command("get")
-      .description("Get a named prompt from an MCP server")
-      .option("--prompt-name <prompt>", "Prompt name")
-      .option("--name <prompt>", "Alias for --prompt-name")
-      .option("--prompt-args <json>", "Prompt arguments as a JSON object"),
+  addRetryOptions(
+    addSharedServerOptions(
+      prompts
+        .command("get")
+        .description("Get a named prompt from an MCP server")
+        .option("--prompt-name <prompt>", "Prompt name")
+        .option("--name <prompt>", "Alias for --prompt-name")
+        .option("--prompt-args <json>", "Prompt arguments as a JSON object"),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
+    const retryPolicy = parseRetryPolicy(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -86,9 +98,13 @@ export function registerPromptCommands(program: Command): void {
       {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
+        retryPolicy,
       },
     );
 
-    writeResult(withRpcLogsIfRequested(result, collector, globalOptions), globalOptions.format);
+    writeResult(
+      withRpcLogsIfRequested(result, collector, globalOptions),
+      globalOptions.format,
+    );
   });
 }

--- a/cli/src/commands/resources.ts
+++ b/cli/src/commands/resources.ts
@@ -4,9 +4,11 @@ import { withEphemeralManager } from "../lib/ephemeral";
 import { createCliRpcLogCollector } from "../lib/rpc-logs";
 import { withRpcLogsIfRequested } from "../lib/rpc-helpers";
 import {
+  addRetryOptions,
   addSharedServerOptions,
   describeTarget,
   getGlobalOptions,
+  parseRetryPolicy,
   parseServerConfig,
   resolveAliasedStringOption,
 } from "../lib/server-config";
@@ -17,13 +19,16 @@ export function registerResourcesCommands(program: Command): void {
     .command("resources")
     .description("List and read MCP resources");
 
-  addSharedServerOptions(
-    resources
-      .command("list")
-      .description("List resources exposed by an MCP server")
-      .option("--cursor <cursor>", "Pagination cursor"),
+  addRetryOptions(
+    addSharedServerOptions(
+      resources
+        .command("list")
+        .description("List resources exposed by an MCP server")
+        .option("--cursor <cursor>", "Pagination cursor"),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
+    const retryPolicy = parseRetryPolicy(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -40,20 +45,27 @@ export function registerResourcesCommands(program: Command): void {
       {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
+        retryPolicy,
       },
     );
 
-    writeResult(withRpcLogsIfRequested(result, collector, globalOptions), globalOptions.format);
+    writeResult(
+      withRpcLogsIfRequested(result, collector, globalOptions),
+      globalOptions.format,
+    );
   });
 
-  addSharedServerOptions(
-    resources
-      .command("read")
-      .description("Read a resource from an MCP server")
-      .option("--resource-uri <uri>", "Resource URI")
-      .option("--uri <uri>", "Alias for --resource-uri"),
+  addRetryOptions(
+    addSharedServerOptions(
+      resources
+        .command("read")
+        .description("Read a resource from an MCP server")
+        .option("--resource-uri <uri>", "Resource URI")
+        .option("--uri <uri>", "Alias for --resource-uri"),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
+    const retryPolicy = parseRetryPolicy(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -74,23 +86,31 @@ export function registerResourcesCommands(program: Command): void {
 
     const result = await withEphemeralManager(
       config,
-      (manager, serverId) => readResource(manager, { serverId, uri: resourceUri }),
+      (manager, serverId) =>
+        readResource(manager, { serverId, uri: resourceUri }),
       {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
+        retryPolicy,
       },
     );
 
-    writeResult(withRpcLogsIfRequested(result, collector, globalOptions), globalOptions.format);
+    writeResult(
+      withRpcLogsIfRequested(result, collector, globalOptions),
+      globalOptions.format,
+    );
   });
 
-  addSharedServerOptions(
-    resources
-      .command("templates")
-      .description("List resource templates exposed by an MCP server")
-      .option("--cursor <cursor>", "Pagination cursor"),
+  addRetryOptions(
+    addSharedServerOptions(
+      resources
+        .command("templates")
+        .description("List resource templates exposed by an MCP server")
+        .option("--cursor <cursor>", "Pagination cursor"),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
+    const retryPolicy = parseRetryPolicy(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -110,9 +130,13 @@ export function registerResourcesCommands(program: Command): void {
       {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
+        retryPolicy,
       },
     );
 
-    writeResult(withRpcLogsIfRequested(result, collector, globalOptions), globalOptions.format);
+    writeResult(
+      withRpcLogsIfRequested(result, collector, globalOptions),
+      globalOptions.format,
+    );
   });
 }

--- a/cli/src/commands/server.ts
+++ b/cli/src/commands/server.ts
@@ -14,162 +14,181 @@ import {
 } from "../lib/server-doctor";
 import { exportServerSnapshot } from "../lib/server-ops";
 import {
+  addRetryOptions,
   addSharedServerOptions,
   describeTarget,
   getGlobalOptions,
   parseHeadersOption,
+  parseRetryPolicy,
   parseServerConfig,
   parsePositiveInteger,
   resolveHttpAccessToken,
 } from "../lib/server-config";
-import { operationalError, setProcessExitCode, usageError, writeResult } from "../lib/output";
+import {
+  operationalError,
+  setProcessExitCode,
+  usageError,
+  writeResult,
+} from "../lib/output";
 
 export function registerServerCommands(program: Command): void {
   const server = program
     .command("server")
     .description("Inspect MCP server connectivity and capabilities");
 
-  server
-    .command("probe")
-    .description("Probe an HTTP MCP server without using the full client connect flow")
-    .requiredOption("--url <url>", "HTTP MCP server URL")
-    .option("--access-token <token>", "Bearer access token for HTTP servers")
-    .option(
-      "--oauth-access-token <token>",
-      "OAuth bearer access token for HTTP servers",
-    )
-    .option(
-      "--header <header>",
-      'HTTP header in "Key: Value" format. Repeat to send multiple headers.',
-      (value: string, previous: string[] = []) => [...previous, value],
-      [],
-    )
-    .option(
-      "--client-capabilities <json>",
-      "Client capabilities advertised in the initialize probe as a JSON object",
-    )
-    .option(
-      "--protocol-version <version>",
-      "OAuth/MCP protocol version hint used for the initialize probe",
-      "2025-11-25",
-    )
-    .option(
-      "--timeout <ms>",
-      "Request timeout in milliseconds",
-      (value: string) => parsePositiveInteger(value, "Timeout"),
-    )
-    .option(
-      "--debug-out <path>",
-      "Write a structured debug artifact to a file",
-    )
-    .action(async (options, command) => {
-      const globalOptions = getGlobalOptions(command);
-      const protocolVersion = options.protocolVersion as
-        | "2025-03-26"
-        | "2025-06-18"
-        | "2025-11-25";
-      const config = parseServerConfig({
-        ...options,
-        timeout: options.timeout ?? globalOptions.timeout,
-      });
-      const target = describeTarget(options);
-      const targetSummary = summarizeServerDoctorTarget(target, config);
-      const snapshotCollector = options.debugOut
-        ? createCliRpcLogCollector({ __cli__: target })
-        : undefined;
-
-      if (
-        protocolVersion !== "2025-03-26" &&
-        protocolVersion !== "2025-06-18" &&
-        protocolVersion !== "2025-11-25"
-      ) {
-        throw usageError(
-          `Invalid protocol version "${options.protocolVersion}".`,
-        );
-      }
-
-      let result: Awaited<ReturnType<typeof probeMcpServer>> | undefined;
-      let commandError: unknown;
-
-      try {
-        const probeUrl = "url" in config ? config.url : undefined;
-        if (!probeUrl) {
-          throw usageError("HTTP probe requires --url.");
-        }
-
-        result = await probeMcpServer({
-          url: probeUrl,
-          protocolVersion,
-          headers: parseHeadersOption(options.header),
-          accessToken: resolveHttpAccessToken(options),
-          clientCapabilities:
-            "clientCapabilities" in config ? config.clientCapabilities : undefined,
-          timeoutMs: options.timeout ?? globalOptions.timeout,
-        });
-      } catch (error) {
-        commandError = error;
-      }
-
-      await writeCommandDebugArtifact({
-        outputPath: options.debugOut as string | undefined,
-        format: globalOptions.format,
-        commandName: "server probe",
-        commandInput: {
-          protocolVersion,
-          clientCapabilities:
-            "clientCapabilities" in config ? config.clientCapabilities : undefined,
-        },
-        target: targetSummary,
-        outcome: commandError
-          ? {
-              status: "error",
-              error: commandError,
-            }
-          : result?.status === "error"
-            ? {
-                status: "error",
-                result,
-                error: buildCommandArtifactError(
-                  "PROBE_FAILED",
-                  result.error ?? "Probe failed.",
-                ),
-              }
-            : {
-                status: "success",
-                result,
-              },
-        snapshot: options.debugOut
-          ? {
-              input: {
-                config,
-                target: targetSummary,
-                timeout: options.timeout ?? globalOptions.timeout,
-              },
-              collector: snapshotCollector,
-            }
-          : undefined,
-      });
-
-      if (commandError) {
-        throw commandError;
-      }
-      if (!result) {
-        throw operationalError("Probe did not return a result.");
-      }
-
-      writeResult(result, globalOptions.format);
-      if (result.status === "error") {
-        setProcessExitCode(1);
-      }
-    });
-
-  addSharedServerOptions(
+  addRetryOptions(
     server
-      .command("doctor")
-      .description("Run a stateless diagnostic sweep against an MCP server")
-      .option("--out <path>", "Write the doctor JSON artifact to a file"),
+      .command("probe")
+      .description(
+        "Probe an HTTP MCP server without using the full client connect flow",
+      )
+      .requiredOption("--url <url>", "HTTP MCP server URL")
+      .option("--access-token <token>", "Bearer access token for HTTP servers")
+      .option(
+        "--oauth-access-token <token>",
+        "OAuth bearer access token for HTTP servers",
+      )
+      .option(
+        "--header <header>",
+        'HTTP header in "Key: Value" format. Repeat to send multiple headers.',
+        (value: string, previous: string[] = []) => [...previous, value],
+        [],
+      )
+      .option(
+        "--client-capabilities <json>",
+        "Client capabilities advertised in the initialize probe as a JSON object",
+      )
+      .option(
+        "--protocol-version <version>",
+        "OAuth/MCP protocol version hint used for the initialize probe",
+        "2025-11-25",
+      )
+      .option(
+        "--timeout <ms>",
+        "Request timeout in milliseconds",
+        (value: string) => parsePositiveInteger(value, "Timeout"),
+      )
+      .option(
+        "--debug-out <path>",
+        "Write a structured debug artifact to a file",
+      ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
+    const retryPolicy = parseRetryPolicy(options);
+    const protocolVersion = options.protocolVersion as
+      | "2025-03-26"
+      | "2025-06-18"
+      | "2025-11-25";
+    const config = parseServerConfig({
+      ...options,
+      timeout: options.timeout ?? globalOptions.timeout,
+    });
+    const target = describeTarget(options);
+    const targetSummary = summarizeServerDoctorTarget(target, config);
+    const snapshotCollector = options.debugOut
+      ? createCliRpcLogCollector({ __cli__: target })
+      : undefined;
+
+    if (
+      protocolVersion !== "2025-03-26" &&
+      protocolVersion !== "2025-06-18" &&
+      protocolVersion !== "2025-11-25"
+    ) {
+      throw usageError(
+        `Invalid protocol version "${options.protocolVersion}".`,
+      );
+    }
+
+    let result: Awaited<ReturnType<typeof probeMcpServer>> | undefined;
+    let commandError: unknown;
+
+    try {
+      const probeUrl = "url" in config ? config.url : undefined;
+      if (!probeUrl) {
+        throw usageError("HTTP probe requires --url.");
+      }
+
+      result = await probeMcpServer({
+        url: probeUrl,
+        protocolVersion,
+        headers: parseHeadersOption(options.header),
+        accessToken: resolveHttpAccessToken(options),
+        clientCapabilities:
+          "clientCapabilities" in config
+            ? config.clientCapabilities
+            : undefined,
+        timeoutMs: options.timeout ?? globalOptions.timeout,
+        retryPolicy,
+      });
+    } catch (error) {
+      commandError = error;
+    }
+
+    await writeCommandDebugArtifact({
+      outputPath: options.debugOut as string | undefined,
+      format: globalOptions.format,
+      commandName: "server probe",
+      commandInput: {
+        protocolVersion,
+        clientCapabilities:
+          "clientCapabilities" in config
+            ? config.clientCapabilities
+            : undefined,
+      },
+      target: targetSummary,
+      outcome: commandError
+        ? {
+            status: "error",
+            error: commandError,
+          }
+        : result?.status === "error"
+          ? {
+              status: "error",
+              result,
+              error: buildCommandArtifactError(
+                "PROBE_FAILED",
+                result.error ?? "Probe failed.",
+              ),
+            }
+          : {
+              status: "success",
+              result,
+            },
+      snapshot: options.debugOut
+        ? {
+            input: {
+              config,
+              target: targetSummary,
+              timeout: options.timeout ?? globalOptions.timeout,
+            },
+            collector: snapshotCollector,
+          }
+        : undefined,
+    });
+
+    if (commandError) {
+      throw commandError;
+    }
+    if (!result) {
+      throw operationalError("Probe did not return a result.");
+    }
+
+    writeResult(result, globalOptions.format);
+    if (result.status === "error") {
+      setProcessExitCode(1);
+    }
+  });
+
+  addRetryOptions(
+    addSharedServerOptions(
+      server
+        .command("doctor")
+        .description("Run a stateless diagnostic sweep against an MCP server")
+        .option("--out <path>", "Write the doctor JSON artifact to a file"),
+    ),
+  ).action(async (options, command) => {
+    const globalOptions = getGlobalOptions(command);
+    const retryPolicy = parseRetryPolicy(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -180,14 +199,13 @@ export function registerServerCommands(program: Command): void {
     });
     const doctorTarget = summarizeServerDoctorTarget(target, config);
 
-    const result = await runServerDoctor(
-      {
-        config,
-        target: doctorTarget,
-        timeout: globalOptions.timeout,
-        rpcLogger: collector?.rpcLogger,
-      },
-    );
+    const result = await runServerDoctor({
+      config,
+      target: doctorTarget,
+      timeout: globalOptions.timeout,
+      rpcLogger: collector?.rpcLogger,
+      retryPolicy,
+    });
 
     const jsonPayload = globalOptions.rpc
       ? attachCliRpcLogs(result, collector)
@@ -209,12 +227,15 @@ export function registerServerCommands(program: Command): void {
     }
   });
 
-  addSharedServerOptions(
-    server
-      .command("info")
-      .description("Get initialization info for an MCP server"),
+  addRetryOptions(
+    addSharedServerOptions(
+      server
+        .command("info")
+        .description("Get initialization info for an MCP server"),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
+    const retryPolicy = parseRetryPolicy(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -239,27 +260,34 @@ export function registerServerCommands(program: Command): void {
       {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
+        retryPolicy,
       },
     );
 
-    writeResult(withRpcLogsIfRequested(result, collector, globalOptions), globalOptions.format);
+    writeResult(
+      withRpcLogsIfRequested(result, collector, globalOptions),
+      globalOptions.format,
+    );
   });
 
-  addSharedServerOptions(
-    server
-      .command("validate")
-      .description("Connect to a server and verify the debugger surface works"),
+  addRetryOptions(
+    addSharedServerOptions(
+      server
+        .command("validate")
+        .description(
+          "Connect to a server and verify the debugger surface works",
+        ),
+    ),
   )
-    .option(
-      "--debug-out <path>",
-      "Write a structured debug artifact to a file",
-    )
+    .option("--debug-out <path>", "Write a structured debug artifact to a file")
     .action(async (options, command) => {
       const globalOptions = getGlobalOptions(command);
+      const retryPolicy = parseRetryPolicy(options);
       const target = describeTarget(options);
-      const primaryCollector = globalOptions.rpc || options.debugOut
-        ? createCliRpcLogCollector({ __cli__: target })
-        : undefined;
+      const primaryCollector =
+        globalOptions.rpc || options.debugOut
+          ? createCliRpcLogCollector({ __cli__: target })
+          : undefined;
       const snapshotCollector = options.debugOut
         ? createCliRpcLogCollector({ __cli__: target })
         : undefined;
@@ -294,6 +322,7 @@ export function registerServerCommands(program: Command): void {
           {
             timeout: globalOptions.timeout,
             rpcLogger: primaryCollector?.rpcLogger,
+            retryPolicy,
           },
         );
       } catch (error) {
@@ -338,10 +367,13 @@ export function registerServerCommands(program: Command): void {
       );
     });
 
-  addSharedServerOptions(
-    server.command("ping").description("Ping an MCP server"),
+  addRetryOptions(
+    addSharedServerOptions(
+      server.command("ping").description("Ping an MCP server"),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
+    const retryPolicy = parseRetryPolicy(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -361,18 +393,25 @@ export function registerServerCommands(program: Command): void {
       {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
+        retryPolicy,
       },
     );
 
-    writeResult(withRpcLogsIfRequested(result, collector, globalOptions), globalOptions.format);
+    writeResult(
+      withRpcLogsIfRequested(result, collector, globalOptions),
+      globalOptions.format,
+    );
   });
 
-  addSharedServerOptions(
-    server
-      .command("capabilities")
-      .description("Get resolved server capabilities"),
+  addRetryOptions(
+    addSharedServerOptions(
+      server
+        .command("capabilities")
+        .description("Get resolved server capabilities"),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
+    const retryPolicy = parseRetryPolicy(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -391,16 +430,27 @@ export function registerServerCommands(program: Command): void {
       {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
+        retryPolicy,
       },
     );
 
-    writeResult(withRpcLogsIfRequested(result, collector, globalOptions), globalOptions.format);
+    writeResult(
+      withRpcLogsIfRequested(result, collector, globalOptions),
+      globalOptions.format,
+    );
   });
 
-  addSharedServerOptions(
-    server.command("export").description("Export server tools, resources, prompts, and capabilities"),
+  addRetryOptions(
+    addSharedServerOptions(
+      server
+        .command("export")
+        .description(
+          "Export server tools, resources, prompts, and capabilities",
+        ),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
+    const retryPolicy = parseRetryPolicy(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -416,9 +466,13 @@ export function registerServerCommands(program: Command): void {
       {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
+        retryPolicy,
       },
     );
 
-    writeResult(withRpcLogsIfRequested(result, collector, globalOptions), globalOptions.format);
+    writeResult(
+      withRpcLogsIfRequested(result, collector, globalOptions),
+      globalOptions.format,
+    );
   });
 }

--- a/cli/src/commands/tools.ts
+++ b/cli/src/commands/tools.ts
@@ -7,10 +7,12 @@ import { withRpcLogsIfRequested } from "../lib/rpc-helpers";
 import { listToolsWithMetadata } from "../lib/server-ops";
 import { summarizeServerDoctorTarget } from "../lib/server-doctor";
 import {
+  addRetryOptions,
   addSharedServerOptions,
   describeTarget,
   getGlobalOptions,
   parseJsonRecord,
+  parseRetryPolicy,
   parseServerConfig,
   resolveAliasedStringOption,
 } from "../lib/server-config";
@@ -21,14 +23,17 @@ export function registerToolsCommands(program: Command): void {
     .command("tools")
     .description("List and invoke MCP server tools");
 
-  addSharedServerOptions(
-    tools
-      .command("list")
-      .description("List tools exposed by an MCP server")
-      .option("--cursor <cursor>", "Pagination cursor")
-      .option("--model-id <model>", "Model id used for token counting"),
+  addRetryOptions(
+    addSharedServerOptions(
+      tools
+        .command("list")
+        .description("List tools exposed by an MCP server")
+        .option("--cursor <cursor>", "Pagination cursor")
+        .option("--model-id <model>", "Model id used for token counting"),
+    ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
+    const retryPolicy = parseRetryPolicy(options);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -49,10 +54,14 @@ export function registerToolsCommands(program: Command): void {
       {
         timeout: globalOptions.timeout,
         rpcLogger: collector?.rpcLogger,
+        retryPolicy,
       },
     );
 
-    writeResult(withRpcLogsIfRequested(result, collector, globalOptions), globalOptions.format);
+    writeResult(
+      withRpcLogsIfRequested(result, collector, globalOptions),
+      globalOptions.format,
+    );
   });
 
   addSharedServerOptions(
@@ -70,9 +79,10 @@ export function registerToolsCommands(program: Command): void {
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
     const target = describeTarget(options);
-    const primaryCollector = globalOptions.rpc || options.debugOut
-      ? createCliRpcLogCollector({ __cli__: target })
-      : undefined;
+    const primaryCollector =
+      globalOptions.rpc || options.debugOut
+        ? createCliRpcLogCollector({ __cli__: target })
+        : undefined;
     const snapshotCollector = options.debugOut
       ? createCliRpcLogCollector({ __cli__: target })
       : undefined;

--- a/cli/src/lib/ephemeral.ts
+++ b/cli/src/lib/ephemeral.ts
@@ -1,17 +1,22 @@
 import {
   withEphemeralClient,
   type MCPServerConfig,
+  type RetryPolicy,
   type RpcLogger,
 } from "@mcpjam/sdk";
 
 export interface EphemeralManagerOptions {
   timeout?: number;
   rpcLogger?: RpcLogger;
+  retryPolicy?: RetryPolicy;
 }
 
 export async function withEphemeralManager<T>(
   config: MCPServerConfig,
-  fn: (manager: import("@mcpjam/sdk").MCPClientManager, serverId: string) => Promise<T>,
+  fn: (
+    manager: import("@mcpjam/sdk").MCPClientManager,
+    serverId: string,
+  ) => Promise<T>,
   options?: EphemeralManagerOptions,
 ): Promise<T> {
   return withEphemeralClient(config, fn, {
@@ -19,5 +24,6 @@ export async function withEphemeralManager<T>(
     clientName: "mcpjam",
     timeout: options?.timeout ?? 30_000,
     rpcLogger: options?.rpcLogger,
+    retryPolicy: options?.retryPolicy,
   });
 }

--- a/cli/src/lib/server-config.ts
+++ b/cli/src/lib/server-config.ts
@@ -137,8 +137,13 @@ export function parseRetryPolicy(
     return undefined;
   }
 
+  const retries = options.retries ?? DEFAULT_RETRY_POLICY.retries;
+  if (options.retryDelayMs !== undefined && retries === 0) {
+    throw usageError("--retry-delay-ms requires --retries to be greater than 0.");
+  }
+
   return {
-    retries: options.retries ?? DEFAULT_RETRY_POLICY.retries,
+    retries,
     retryDelayMs: options.retryDelayMs ?? DEFAULT_RETRY_POLICY.retryDelayMs,
   };
 }

--- a/cli/src/lib/server-config.ts
+++ b/cli/src/lib/server-config.ts
@@ -1,10 +1,10 @@
-import type { MCPServerConfig } from "@mcpjam/sdk";
-import { Command } from "commander";
 import {
-  resolveOutputFormat,
-  type OutputFormat,
-  usageError,
-} from "./output";
+  DEFAULT_RETRY_POLICY,
+  type MCPServerConfig,
+  type RetryPolicy,
+} from "@mcpjam/sdk";
+import { Command } from "commander";
+import { resolveOutputFormat, type OutputFormat, usageError } from "./output";
 
 export interface GlobalOptions {
   format: OutputFormat;
@@ -25,6 +25,8 @@ export interface SharedServerTargetOptions {
   commandArgs?: string[];
   env?: string[];
   timeout?: number;
+  retries?: number;
+  retryDelayMs?: number;
 }
 
 function collectString(value: string, previous: string[] = []): string[] {
@@ -39,14 +41,8 @@ export function addSharedServerOptions(command: Command): Command {
       "--oauth-access-token <token>",
       "OAuth bearer access token for HTTP servers",
     )
-    .option(
-      "--refresh-token <token>",
-      "OAuth refresh token for HTTP servers",
-    )
-    .option(
-      "--client-id <id>",
-      "OAuth client ID used with --refresh-token",
-    )
+    .option("--refresh-token <token>", "OAuth refresh token for HTTP servers")
+    .option("--client-id <id>", "OAuth client ID used with --refresh-token")
     .option(
       "--client-secret <secret>",
       "OAuth client secret used with --refresh-token",
@@ -77,7 +73,10 @@ export function addSharedServerOptions(command: Command): Command {
 export function getGlobalOptions(command: Command): GlobalOptions {
   const options = command.optsWithGlobals() as Partial<GlobalOptions>;
   return {
-    format: resolveOutputFormat(options.format as string | undefined, process.stdout.isTTY),
+    format: resolveOutputFormat(
+      options.format as string | undefined,
+      process.stdout.isTTY,
+    ),
     timeout: options.timeout ?? 30_000,
     rpc: options.rpc ?? false,
   };
@@ -90,6 +89,45 @@ export function parsePositiveInteger(value: string, label = "Value"): number {
   }
 
   return parsed;
+}
+
+export function parseNonNegativeInteger(
+  value: string,
+  label = "Value",
+): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw usageError(`${label} must be a non-negative integer.`);
+  }
+
+  return parsed;
+}
+
+export function addRetryOptions(command: Command): Command {
+  return command
+    .option(
+      "--retries <count>",
+      "Retry transient failures this many times",
+      (value: string) => parseNonNegativeInteger(value, "Retries"),
+    )
+    .option(
+      "--retry-delay-ms <ms>",
+      "Fixed delay between retries in milliseconds",
+      (value: string) => parseNonNegativeInteger(value, "Retry delay"),
+    );
+}
+
+export function parseRetryPolicy(
+  options: Pick<SharedServerTargetOptions, "retries" | "retryDelayMs">,
+): RetryPolicy | undefined {
+  if (options.retries === undefined && options.retryDelayMs === undefined) {
+    return undefined;
+  }
+
+  return {
+    retries: options.retries ?? DEFAULT_RETRY_POLICY.retries,
+    retryDelayMs: options.retryDelayMs ?? DEFAULT_RETRY_POLICY.retryDelayMs,
+  };
 }
 
 export function parseHeadersOption(
@@ -177,7 +215,9 @@ export function resolveAliasedStringOption(
         value: normalized,
       };
     })
-    .filter((entry): entry is { flag: string; value: string } => entry !== undefined);
+    .filter(
+      (entry): entry is { flag: string; value: string } => entry !== undefined,
+    );
 
   const flagsText = aliases.map((alias) => alias.flag).join(" or ");
 
@@ -383,11 +423,7 @@ export function resolveHttpAccessToken(
   const accessToken = options.accessToken?.trim();
   const oauthAccessToken = options.oauthAccessToken?.trim();
 
-  if (
-    accessToken &&
-    oauthAccessToken &&
-    accessToken !== oauthAccessToken
-  ) {
+  if (accessToken && oauthAccessToken && accessToken !== oauthAccessToken) {
     throw usageError(
       "--access-token and --oauth-access-token must match when both are provided.",
     );

--- a/cli/tests/server-config.test.ts
+++ b/cli/tests/server-config.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  parseNonNegativeInteger,
   parseJsonRecord,
+  parseRetryPolicy,
   parseServerConfig,
   resolveAliasedStringOption,
 } from "../src/lib/server-config";
@@ -78,10 +80,7 @@ test("parseServerConfig preserves commas inside stdio args and env values", () =
   const config = parseServerConfig({
     command: "node",
     commandArgs: ['{"a":1,"b":2}', "--list=one,two"],
-    env: [
-      "NO_PROXY=127.0.0.1,localhost",
-      'JSON_PAYLOAD={"a":1,"b":2}',
-    ],
+    env: ["NO_PROXY=127.0.0.1,localhost", 'JSON_PAYLOAD={"a":1,"b":2}'],
   });
 
   assert.equal("command" in config, true);
@@ -125,7 +124,9 @@ test("parseServerConfig rejects missing and mixed targets", () => {
     (error) =>
       error instanceof CliError &&
       error.exitCode === 2 &&
-      error.message.includes("--access-token, --oauth-access-token, --refresh-token, --client-id, --client-secret, and --header can only be used"),
+      error.message.includes(
+        "--access-token, --oauth-access-token, --refresh-token, --client-id, --client-secret, and --header can only be used",
+      ),
   );
 
   assert.throws(
@@ -137,7 +138,9 @@ test("parseServerConfig rejects missing and mixed targets", () => {
       }),
     (error) =>
       error instanceof CliError &&
-      error.message.includes("--access-token and --oauth-access-token must match"),
+      error.message.includes(
+        "--access-token and --oauth-access-token must match",
+      ),
   );
 
   assert.throws(
@@ -153,7 +156,10 @@ test("parseServerConfig rejects missing and mixed targets", () => {
 });
 
 test("parseJsonRecord rejects non-object JSON", () => {
-  assert.equal(parseJsonRecord('{"message":"hello"}', "Tool parameters")?.message, "hello");
+  assert.equal(
+    parseJsonRecord('{"message":"hello"}', "Tool parameters")?.message,
+    "hello",
+  );
 
   assert.throws(
     () => parseJsonRecord('["hello"]', "Tool parameters"),
@@ -161,6 +167,34 @@ test("parseJsonRecord rejects non-object JSON", () => {
       error instanceof CliError &&
       error.message.includes("Tool parameters must be a JSON object"),
   );
+});
+
+test("parseNonNegativeInteger accepts zero and rejects negatives", () => {
+  assert.equal(parseNonNegativeInteger("0", "Retries"), 0);
+  assert.equal(parseNonNegativeInteger("12", "Retries"), 12);
+
+  assert.throws(
+    () => parseNonNegativeInteger("-1", "Retries"),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("Retries must be a non-negative integer"),
+  );
+});
+
+test("parseRetryPolicy preserves explicit values and fills defaults", () => {
+  assert.deepEqual(parseRetryPolicy({ retries: 2, retryDelayMs: 1500 }), {
+    retries: 2,
+    retryDelayMs: 1500,
+  });
+  assert.deepEqual(parseRetryPolicy({ retries: 3 }), {
+    retries: 3,
+    retryDelayMs: 3000,
+  });
+  assert.deepEqual(parseRetryPolicy({ retryDelayMs: 250 }), {
+    retries: 0,
+    retryDelayMs: 250,
+  });
+  assert.equal(parseRetryPolicy({}), undefined);
 });
 
 test("resolveAliasedStringOption accepts either alias and preserves matching values", () => {

--- a/cli/tests/server-config.test.ts
+++ b/cli/tests/server-config.test.ts
@@ -328,11 +328,18 @@ test("parseRetryPolicy preserves explicit values and fills defaults", () => {
     retries: 3,
     retryDelayMs: 3000,
   });
-  assert.deepEqual(parseRetryPolicy({ retryDelayMs: 250 }), {
-    retries: 0,
-    retryDelayMs: 250,
-  });
   assert.equal(parseRetryPolicy({}), undefined);
+});
+
+test("parseRetryPolicy rejects retryDelayMs without retries", () => {
+  assert.throws(
+    () => parseRetryPolicy({ retryDelayMs: 250 }),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes(
+        "--retry-delay-ms requires --retries to be greater than 0",
+      ),
+  );
 });
 
 test("resolveAliasedStringOption accepts either alias and preserves matching values", () => {

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -36,6 +36,7 @@ import { securityHeadersMiddleware } from "./middleware/security-headers.js";
 import { loadInspectorEnv, warnOnConvexDevMisconfiguration } from "./env.js";
 import { startGuestAuthProvisioningInBackground } from "./utils/convex-guest-auth-sync.js";
 import { fetchRemoteGuestJwks } from "./utils/guest-session-source.js";
+import { INSPECTOR_MCP_RETRY_POLICY } from "./utils/mcp-retry-policy.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -70,6 +71,7 @@ export function createHonoApp() {
   const mcpClientManager = new MCPClientManager(
     {},
     {
+      retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
       rpcLogger: ({ direction, message, serverId }) => {
         rpcLogBus.publish({
           serverId,

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -12,6 +12,7 @@ import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { MCPClientManager } from "@mcpjam/sdk";
 import { loadInspectorEnv, warnOnConvexDevMisconfiguration } from "./env";
+import { INSPECTOR_MCP_RETRY_POLICY } from "./utils/mcp-retry-policy";
 
 // Security imports
 import {
@@ -211,6 +212,7 @@ const strictModeResponse = (c: any, path: string) =>
 const mcpClientManager = new MCPClientManager(
   {},
   {
+    retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
     rpcLogger: ({ direction, message, serverId }) => {
       rpcLogBus.publish({
         serverId,

--- a/mcpjam-inspector/server/routes/mcp/__tests__/connect.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/connect.test.ts
@@ -160,6 +160,9 @@ describe("POST /api/mcp/connect", () => {
         "Connection failed for server failing-server",
       );
       expect(data.details).toBe("Connection refused");
+      expect(mcpClientManager.removeServer).toHaveBeenCalledWith(
+        "failing-server",
+      );
     });
 
     it("disconnects existing connection before reconnecting", async () => {

--- a/mcpjam-inspector/server/routes/mcp/connect.ts
+++ b/mcpjam-inspector/server/routes/mcp/connect.ts
@@ -74,6 +74,15 @@ connect.post("/", async (c) => {
         status: "connected",
       });
     } catch (error) {
+      try {
+        await mcpClientManager.removeServer(serverId);
+      } catch (cleanupError) {
+        console.debug(
+          `Failed to remove MCP server ${serverId} after connection failure`,
+          cleanupError,
+        );
+      }
+
       return c.json(
         {
           success: false,

--- a/mcpjam-inspector/server/routes/web/__tests__/guest-oauth-auth.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/guest-oauth-auth.test.ts
@@ -2,11 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   managerConfigsMock,
+  managerOptionsMock,
   getToolsForAiSdkMock,
   getInitializationInfoMock,
   disconnectAllServersMock,
 } = vi.hoisted(() => ({
   managerConfigsMock: vi.fn(),
+  managerOptionsMock: vi.fn(),
   getToolsForAiSdkMock: vi.fn(),
   getInitializationInfoMock: vi.fn(),
   disconnectAllServersMock: vi.fn(),
@@ -17,14 +19,17 @@ vi.mock("@mcpjam/sdk", async () => {
     await vi.importActual<typeof import("@mcpjam/sdk")>("@mcpjam/sdk");
   return {
     ...actual,
-    MCPClientManager: vi.fn().mockImplementation((configs: unknown) => {
-      managerConfigsMock(configs);
-      return {
-        getToolsForAiSdk: getToolsForAiSdkMock,
-        getInitializationInfo: getInitializationInfoMock,
-        disconnectAllServers: disconnectAllServersMock,
-      };
-    }),
+    MCPClientManager: vi
+      .fn()
+      .mockImplementation((configs: unknown, options: unknown) => {
+        managerConfigsMock(configs);
+        managerOptionsMock(options);
+        return {
+          getToolsForAiSdk: getToolsForAiSdkMock,
+          getInitializationInfo: getInitializationInfoMock,
+          disconnectAllServers: disconnectAllServersMock,
+        };
+      }),
   };
 });
 
@@ -38,6 +43,7 @@ describe("web routes — guest OAuth validation", () => {
   beforeEach(() => {
     initGuestTokenSecret();
     managerConfigsMock.mockReset();
+    managerOptionsMock.mockReset();
     getToolsForAiSdkMock.mockReset();
     getInitializationInfoMock.mockReset();
     disconnectAllServersMock.mockReset();
@@ -90,5 +96,13 @@ describe("web routes — guest OAuth validation", () => {
         timeout: expect.any(Number),
       },
     });
+    expect(managerOptionsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        retryPolicy: {
+          retries: 0,
+          retryDelayMs: 3000,
+        },
+      }),
+    );
   });
 });

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -7,6 +7,7 @@ import {
   attachHostedRpcLogs,
   createHostedRpcLogCollector,
 } from "./hosted-rpc-logs.js";
+import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
 import {
   ErrorCode,
   WebRouteError,
@@ -324,6 +325,7 @@ export async function createAuthorizedManager(
   const manager = new MCPClientManager(Object.fromEntries(configEntries), {
     defaultTimeout: timeoutMs,
     rpcLogger: options?.rpcLogger,
+    retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
   });
   return { manager, oauthServerUrls };
 }
@@ -511,6 +513,7 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
         {
           defaultTimeout: timeoutMs,
           rpcLogger: rpcCollector?.rpcLogger,
+          retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
         },
       );
 

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -29,6 +29,7 @@ import {
   attachHostedRpcLogs,
   createHostedRpcLogCollector,
 } from "./hosted-rpc-logs.js";
+import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
 
 const chatV2 = new Hono();
 
@@ -154,6 +155,7 @@ chatV2.post("/", async (c) => {
           {
             defaultTimeout: WEB_STREAM_TIMEOUT_MS,
             rpcLogger: rpcCollector.rpcLogger,
+            retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
           },
         );
       } else {
@@ -163,6 +165,7 @@ chatV2.post("/", async (c) => {
           {
             defaultTimeout: WEB_STREAM_TIMEOUT_MS,
             rpcLogger: rpcCollector.rpcLogger,
+            retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
           },
         );
       }

--- a/mcpjam-inspector/server/services/evals/__tests__/route-helpers.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/route-helpers.test.ts
@@ -169,6 +169,10 @@ describe("buildReplayManager", () => {
       {
         defaultTimeout: expect.any(Number),
         lazyConnect: true,
+        retryPolicy: {
+          retries: 0,
+          retryDelayMs: 3000,
+        },
       },
     );
   });

--- a/mcpjam-inspector/server/services/evals/route-helpers.ts
+++ b/mcpjam-inspector/server/services/evals/route-helpers.ts
@@ -9,6 +9,7 @@ import {
   buildServerToolSnapshotDebug,
   exportConnectedServerToolSnapshotForEvalAuthoring,
 } from "../../utils/export-helpers.js";
+import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
 
 const INSPECTOR_SERVICE_TOKEN_HEADER = "X-Inspector-Service-Token";
 
@@ -192,6 +193,7 @@ export function buildReplayManager(replayConfig: ReplayConfig) {
     {
       defaultTimeout: WEB_CALL_TIMEOUT_MS,
       lazyConnect: true,
+      retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
     },
   );
 }
@@ -202,10 +204,10 @@ function isMcpAlreadyConnectedError(error: unknown): boolean {
 
 /**
  * Await MCP connections for all replay servers. The manager constructor starts
- * connects in the background; failed connects call resetState and remove the
- * server before callers run (e.g. runEvalTestCaseWithManager awaits getTestCase
- * between resolveServerIdsOrThrow and getToolsForAiSdk). Explicit connect
- * ensures stable state or a clear connection error.
+ * connects in the background; failed connects clear only live state while
+ * preserving registered server inventory. Explicit connect ensures replay
+ * runners see a stable connection or a clear connection error before making
+ * follow-on SDK calls.
  */
 export async function connectReplayManagerServers(
   manager: MCPClientManager,

--- a/mcpjam-inspector/server/utils/mcp-retry-policy.ts
+++ b/mcpjam-inspector/server/utils/mcp-retry-policy.ts
@@ -1,0 +1,5 @@
+import { DEFAULT_RETRY_POLICY, type RetryPolicy } from "@mcpjam/sdk";
+
+export const INSPECTOR_MCP_RETRY_POLICY: RetryPolicy = {
+  ...DEFAULT_RETRY_POLICY,
+};

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -164,7 +164,7 @@ const test = new OAuthConformanceTest({
 });
 
 const result = await test.run();
-console.log(result.passed);  // true
+console.log(result.passed); // true
 console.log(result.summary); // "OAuth conformance passed for ..."
 
 // Suite: test multiple flows at once
@@ -172,12 +172,24 @@ const suite = new OAuthConformanceSuite({
   serverUrl: "https://your-server.com/mcp",
   defaults: { verification: { listTools: true } },
   flows: [
-    { protocolVersion: "2025-11-25", registrationStrategy: "cimd", auth: { mode: "interactive" } },
-    { protocolVersion: "2025-11-25", registrationStrategy: "dcr", auth: { mode: "interactive" } },
+    {
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "cimd",
+      auth: { mode: "interactive" },
+    },
+    {
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "dcr",
+      auth: { mode: "interactive" },
+    },
     {
       protocolVersion: "2025-11-25",
       registrationStrategy: "preregistered",
-      auth: { mode: "client_credentials", clientId: "id", clientSecret: "secret" },
+      auth: {
+        mode: "client_credentials",
+        clientId: "id",
+        clientSecret: "secret",
+      },
       client: { preregistered: { clientId: "id", clientSecret: "secret" } },
     },
   ],
@@ -286,6 +298,40 @@ await manager.pingServer("everything");
 // Disconnect
 await manager.disconnectServer("everything");
 ```
+
+Retry policy is SDK-owned and disabled by default. To enable transient retries for connection and read-style manager operations, pass a manager-level policy:
+
+```ts
+const manager = new MCPClientManager(
+  {},
+  {
+    retryPolicy: {
+      retries: 2,
+      retryDelayMs: 3000,
+    },
+  }
+);
+```
+
+The manager applies that policy to `connectToServer()` when called directly and to read/diagnostic methods such as `listTools`, `listResources`, `readResource`, `listPrompts`, `getPrompt`, `pingServer`, and task reads. Read retries wrap the full connect plus RPC operation, so a single retry budget covers reconnect and the follow-on request together.
+
+Tool execution stays single-shot unless you opt in explicitly at the call site:
+
+```ts
+await manager.executeTool(
+  "everything",
+  "add",
+  { a: 1, b: 2 },
+  {
+    retry: {
+      retries: 1,
+      retryDelayMs: 1000,
+    },
+  }
+);
+```
+
+`withEphemeralClient()`, `probeMcpServer()`, and `runServerDoctor()` also accept the same `retryPolicy` shape. Retry classifiers are intentionally conservative in v1: transient network/connect/reset/DNS/timeout failures and HTTP `408`, `425`, `429`, and `5xx` are retryable; auth, validation, and method-unavailable errors are not.
 
 </details>
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -22,6 +22,8 @@ export type {
   MCPConnectionStatus,
   ServerSummary,
   MCPServerSummary,
+  RegisteredServerState,
+  LiveClientState,
 } from "./mcp-client-manager/index.js";
 
 // Handler and callback types
@@ -42,6 +44,7 @@ export type {
   ToolExecuteOptions,
   AiSdkTool,
   ExecuteToolArguments,
+  ExecuteToolRequest,
   TaskOptions,
   ClientCapabilityOptions,
   MCPTask,
@@ -84,6 +87,13 @@ export {
   isAuthError,
   isMCPAuthError,
 } from "./mcp-client-manager/index.js";
+export type { RetryPolicy } from "./retry.js";
+export {
+  DEFAULT_RETRY_POLICY,
+  isRetryableTransientError,
+  normalizeRetryPolicy,
+  retryWithPolicy,
+} from "./retry.js";
 export { EvalReportingError, SdkError } from "./errors.js";
 export { probeMcpServer } from "./server-probe.js";
 export type {
@@ -253,11 +263,7 @@ export {
   buildCspMetaContent,
   buildChatGptRuntimeHead,
 } from "./widget-helpers.js";
-export type {
-  CspMode,
-  WidgetCspMeta,
-  CspConfig,
-} from "./widget-helpers.js";
+export type { CspMode, WidgetCspMeta, CspConfig } from "./widget-helpers.js";
 
 // OAuth proxy helpers (shared by inspector server routes and the CLI)
 export {
@@ -267,10 +273,7 @@ export {
   executeDebugOAuthProxy,
   fetchOAuthMetadata,
 } from "./oauth-proxy.js";
-export type {
-  OAuthProxyRequest,
-  OAuthProxyResponse,
-} from "./oauth-proxy.js";
+export type { OAuthProxyRequest, OAuthProxyResponse } from "./oauth-proxy.js";
 
 // Skill reference (SKILL.md content for agent brief generation)
 export { EXPLORE_TO_SDK_EVALS_SKILL_MD, SKILL_MD } from "./skill-reference.js";
@@ -291,7 +294,10 @@ export type {
 } from "./oauth-conformance/index.js";
 
 // MCP conformance
-export { MCPConformanceTest, MCPConformanceSuite } from "./mcp-conformance/index.js";
+export {
+  MCPConformanceTest,
+  MCPConformanceSuite,
+} from "./mcp-conformance/index.js";
 export type {
   MCPCheckCategory,
   MCPCheckId,

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -232,7 +232,7 @@ export class MCPClientManager {
    */
   getConnectionStatus(serverId: string): MCPConnectionStatus {
     const state = this.liveClientStates.get(serverId);
-    if (state?.promise) return "connecting";
+    if (state?.retryPromise || state?.connectPromise) return "connecting";
     if (state?.client) return "connected";
     return "disconnected";
   }
@@ -314,21 +314,40 @@ export class MCPClientManager {
     if (liveState?.client) {
       throw new Error(`MCP server "${serverId}" is already connected.`);
     }
-    if (liveState?.promise) {
-      return liveState.promise;
+    if (liveState?.retryPromise) {
+      return liveState.retryPromise;
     }
 
     const timeout = config.timeout ?? this.defaultTimeout;
     this.registerServer(serverId, config, timeout);
 
-    return retryWithPolicy({
-      policy: this.defaultRetryPolicy,
-      operation: () => this.connectToServerOnce(serverId),
-      shouldRetryError: (error) => isRetryableTransientError(error),
-      onRetry: async () => {
-        await this.destroyLiveState(serverId);
-      },
-    });
+    const state: LiveClientState = liveState ?? {};
+    const retryPromise = Promise.resolve().then(() =>
+      retryWithPolicy({
+        policy: this.defaultRetryPolicy,
+        operation: () => this.connectToServerOnce(serverId),
+        shouldRetryError: (error) => isRetryableTransientError(error),
+        onRetry: async () => {
+          await this.destroyLiveState(serverId, {
+            preserveRetryPromise: true,
+          });
+        },
+      })
+    );
+    state.retryPromise = retryPromise;
+    this.liveClientStates.set(serverId, state);
+
+    try {
+      return await retryPromise;
+    } finally {
+      const latestState = this.liveClientStates.get(serverId);
+      if (latestState?.retryPromise === retryPromise) {
+        latestState.retryPromise = undefined;
+        if (!latestState.client && !latestState.connectPromise) {
+          this.liveClientStates.delete(serverId);
+        }
+      }
+    }
   }
 
   /**
@@ -1028,8 +1047,8 @@ export class MCPClientManager {
       throw new Error(`MCP server "${serverId}" is already connected.`);
     }
 
-    if (existingState?.promise) {
-      return existingState.promise;
+    if (existingState?.connectPromise) {
+      return existingState.connectPromise;
     }
 
     const state: LiveClientState = existingState ?? {};
@@ -1041,7 +1060,7 @@ export class MCPClientManager {
       registeredState.timeout,
       state
     );
-    state.promise = connectionPromise;
+    state.connectPromise = connectionPromise;
     this.liveClientStates.set(serverId, state);
     return connectionPromise;
   }
@@ -1076,7 +1095,7 @@ export class MCPClientManager {
 
       client.onclose = () => {
         if (this.liveClientStates.get(serverId) === state) {
-          this.clearLiveState(serverId);
+          this.clearLiveState(serverId, { preservePendingPromises: true });
         }
       };
 
@@ -1106,7 +1125,7 @@ export class MCPClientManager {
 
       state.client = client;
       state.transport = transport;
-      state.promise = undefined;
+      state.connectPromise = undefined;
       this.liveClientStates.set(serverId, state);
 
       // Set logging level (ignore errors)
@@ -1122,7 +1141,9 @@ export class MCPClientManager {
       if (transport) {
         await this.safeCloseTransport(transport);
       }
-      this.clearLiveState(serverId);
+      this.clearLiveState(serverId, {
+        preserveRetryPromise: Boolean(state.retryPromise),
+      });
       throw error;
     }
   }
@@ -1377,8 +1398,12 @@ export class MCPClientManager {
     if (!this.registeredServers.has(serverId)) {
       throw new Error(`Unknown MCP server "${serverId}".`);
     }
-    if (state?.promise) {
-      await state.promise;
+    if (state?.retryPromise) {
+      await state.retryPromise;
+      return;
+    }
+    if (state?.connectPromise) {
+      await state.connectPromise;
       return;
     }
     await this.connectToServerOnce(serverId);
@@ -1392,28 +1417,63 @@ export class MCPClientManager {
     return state.client;
   }
 
-  private clearLiveState(serverId: string): void {
+  private clearLiveState(
+    serverId: string,
+    options?: {
+      preservePendingPromises?: boolean;
+      preserveRetryPromise?: boolean;
+    }
+  ): void {
     const state = this.liveClientStates.get(serverId);
     state?.stdioStderrCleanup?.();
-    this.liveClientStates.delete(serverId);
+
+    if (!state) {
+      this.toolsMetadataCache.delete(serverId);
+      return;
+    }
+
+    delete state.client;
+    delete state.transport;
+    delete state.stdioStderrCleanup;
+    if (!options?.preservePendingPromises) {
+      delete state.connectPromise;
+    }
+    if (!options?.preservePendingPromises && !options?.preserveRetryPromise) {
+      delete state.retryPromise;
+      delete state.authProvider;
+    }
+
+    if (state.connectPromise || state.retryPromise) {
+      this.liveClientStates.set(serverId, state);
+    } else {
+      this.liveClientStates.delete(serverId);
+    }
     this.toolsMetadataCache.delete(serverId);
   }
 
-  private async destroyLiveState(serverId: string): Promise<void> {
+  private async destroyLiveState(
+    serverId: string,
+    options?: {
+      preservePendingPromises?: boolean;
+      preserveRetryPromise?: boolean;
+    }
+  ): Promise<void> {
     const state = this.liveClientStates.get(serverId);
-    this.clearLiveState(serverId);
+    const client = state?.client;
+    const transport = state?.transport;
+    this.clearLiveState(serverId, options);
     if (!state) {
       return;
     }
 
     try {
-      await state.client?.close();
+      await client?.close();
     } catch {
       // Ignore close errors
     }
 
-    if (state.transport) {
-      await this.safeCloseTransport(state.transport);
+    if (transport) {
+      await this.safeCloseTransport(transport);
     }
   }
 
@@ -1451,16 +1511,19 @@ export class MCPClientManager {
     }
 
     if (config.refreshToken) {
+      const configuredRefreshToken = config.refreshToken.trim();
       const currentAccessToken =
         liveState?.authProvider?.tokens()?.access_token;
       const currentRefreshToken = liveState?.authProvider
-        ?.prepareTokenRequest()
-        .get("refresh_token");
+          ?.prepareTokenRequest()
+          .get("refresh_token");
       const clientId = config.clientId?.trim();
       const clientSecret = config.clientSecret?.trim();
 
       if (currentRefreshToken && currentRefreshToken.trim()) {
         replayConfig.refreshToken = currentRefreshToken.trim();
+      } else if (configuredRefreshToken) {
+        replayConfig.refreshToken = configuredRefreshToken;
       } else if (currentAccessToken && currentAccessToken.trim()) {
         replayConfig.accessToken = currentAccessToken.trim();
       }
@@ -1626,7 +1689,7 @@ export class MCPClientManager {
     return Boolean(
       value &&
       typeof value === "object" &&
-      ("request" in value || "task" in value || "retry" in value)
+      ("request" in value || "retry" in value)
     );
   }
 
@@ -1656,7 +1719,8 @@ export class MCPClientManager {
       async () => {
         await this.ensureConnected(serverId);
         return operation(this.getClientOrThrow(serverId));
-      }
+      },
+      { resetConnectionOnRetry: false }
     );
   }
 
@@ -1664,7 +1728,10 @@ export class MCPClientManager {
     serverId: string,
     options: RequestOptions | undefined,
     retryPolicy: RetryPolicy,
-    operation: () => Promise<T>
+    operation: () => Promise<T>,
+    config: {
+      resetConnectionOnRetry?: boolean;
+    } = {}
   ): Promise<T> {
     return retryWithPolicy({
       policy: retryPolicy,
@@ -1672,7 +1739,9 @@ export class MCPClientManager {
       operation: async () => operation(),
       shouldRetryError: (error) => isRetryableTransientError(error),
       onRetry: async () => {
-        await this.destroyLiveState(serverId);
+        if (config.resetConnectionOnRetry) {
+          await this.destroyLiveState(serverId);
+        }
       },
     });
   }

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -1668,9 +1668,9 @@ export class MCPClientManager {
   ): Promise<T> {
     return retryWithPolicy({
       policy: retryPolicy,
+      signal: options?.signal,
       operation: async () => operation(),
-      shouldRetryError: (error) =>
-        !options?.signal?.aborted && isRetryableTransientError(error),
+      shouldRetryError: (error) => isRetryableTransientError(error),
       onRetry: async () => {
         await this.destroyLiveState(serverId);
       },

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -128,6 +128,7 @@ export class MCPClientManager {
   private readonly registeredServers = new Map<string, RegisteredServerState>();
   private readonly liveClientStates = new Map<string, LiveClientState>();
   private readonly toolsMetadataCache = new Map<string, Map<string, any>>();
+  private readonly retryAbortControllers = new Map<string, Set<AbortController>>();
 
   // Managers for specific features
   private readonly notificationManager = new NotificationManager();
@@ -320,16 +321,19 @@ export class MCPClientManager {
 
     const timeout = config.timeout ?? this.defaultTimeout;
     this.registerServer(serverId, config, timeout);
+    const { signal, cleanup } = this.createRetrySignal(serverId);
 
     const state: LiveClientState = liveState ?? {};
     const retryPromise = Promise.resolve().then(() =>
       retryWithPolicy({
         policy: this.defaultRetryPolicy,
-        operation: () => this.connectToServerOnce(serverId),
+        signal,
+        operation: () => this.connectToServerOnce(serverId, signal),
         shouldRetryError: (error) => isRetryableTransientError(error),
         onRetry: async () => {
           await this.destroyLiveState(serverId, {
             preserveRetryPromise: true,
+            abortRetryOperations: false,
           });
         },
       })
@@ -340,6 +344,7 @@ export class MCPClientManager {
     try {
       return await retryPromise;
     } finally {
+      cleanup();
       const latestState = this.liveClientStates.get(serverId);
       if (latestState?.retryPromise === retryPromise) {
         latestState.retryPromise = undefined;
@@ -355,7 +360,10 @@ export class MCPClientManager {
    */
   async disconnectServer(serverId: string): Promise<void> {
     const state = this.liveClientStates.get(serverId);
-    if (!state) return;
+    if (!state) {
+      this.abortRetrySignals(serverId);
+      return;
+    }
     await this.destroyLiveState(serverId);
   }
 
@@ -374,7 +382,12 @@ export class MCPClientManager {
    * Disconnects from all servers.
    */
   async disconnectAllServers(): Promise<void> {
-    const serverIds = Array.from(this.liveClientStates.keys());
+    const serverIds = Array.from(
+      new Set([
+        ...this.liveClientStates.keys(),
+        ...this.retryAbortControllers.keys(),
+      ])
+    );
     await Promise.all(serverIds.map((id) => this.disconnectServer(id)));
   }
 
@@ -572,8 +585,8 @@ export class MCPClientManager {
     taskOptions?: TaskOptions
   ) {
     const request = this.normalizeExecuteToolRequest(options, taskOptions);
-    const operation = async () => {
-      await this.ensureConnected(serverId);
+    const operation = async (signal?: AbortSignal) => {
+      await this.ensureConnected(serverId, signal);
       const client = this.getClientOrThrow(serverId);
       const mergedOptions = this.withProgressHandler(serverId, request.request);
       const callParams = { name: toolName, arguments: args };
@@ -1036,7 +1049,12 @@ export class MCPClientManager {
     return state;
   }
 
-  private async connectToServerOnce(serverId: string): Promise<Client> {
+  private async connectToServerOnce(
+    serverId: string,
+    signal?: AbortSignal
+  ): Promise<Client> {
+    this.throwIfAborted(signal);
+
     const registeredState = this.registeredServers.get(serverId);
     if (!registeredState) {
       throw new Error(`Unknown MCP server "${serverId}".`);
@@ -1048,7 +1066,7 @@ export class MCPClientManager {
     }
 
     if (existingState?.connectPromise) {
-      return existingState.connectPromise;
+      return this.awaitWithAbort(existingState.connectPromise, signal);
     }
 
     const state: LiveClientState = existingState ?? {};
@@ -1062,7 +1080,7 @@ export class MCPClientManager {
     );
     state.connectPromise = connectionPromise;
     this.liveClientStates.set(serverId, state);
-    return connectionPromise;
+    return this.awaitWithAbort(connectionPromise, signal);
   }
 
   private async performConnection(
@@ -1391,7 +1409,12 @@ export class MCPClientManager {
     return new Error(message);
   }
 
-  private async ensureConnected(serverId: string): Promise<void> {
+  private async ensureConnected(
+    serverId: string,
+    signal?: AbortSignal
+  ): Promise<void> {
+    this.throwIfAborted(signal);
+
     const state = this.liveClientStates.get(serverId);
     if (state?.client) return;
 
@@ -1399,14 +1422,14 @@ export class MCPClientManager {
       throw new Error(`Unknown MCP server "${serverId}".`);
     }
     if (state?.retryPromise) {
-      await state.retryPromise;
+      await this.awaitWithAbort(state.retryPromise, signal);
       return;
     }
     if (state?.connectPromise) {
-      await state.connectPromise;
+      await this.awaitWithAbort(state.connectPromise, signal);
       return;
     }
-    await this.connectToServerOnce(serverId);
+    await this.connectToServerOnce(serverId, signal);
   }
 
   private getClientOrThrow(serverId: string): Client {
@@ -1456,8 +1479,13 @@ export class MCPClientManager {
     options?: {
       preservePendingPromises?: boolean;
       preserveRetryPromise?: boolean;
+      abortRetryOperations?: boolean;
     }
   ): Promise<void> {
+    if (options?.abortRetryOperations !== false) {
+      this.abortRetrySignals(serverId);
+    }
+
     const state = this.liveClientStates.get(serverId);
     const client = state?.client;
     const transport = state?.transport;
@@ -1716,8 +1744,8 @@ export class MCPClientManager {
       serverId,
       options,
       this.defaultRetryPolicy,
-      async () => {
-        await this.ensureConnected(serverId);
+      async (signal) => {
+        await this.ensureConnected(serverId, signal);
         return operation(this.getClientOrThrow(serverId));
       },
       { resetConnectionOnRetry: false }
@@ -1728,21 +1756,150 @@ export class MCPClientManager {
     serverId: string,
     options: RequestOptions | undefined,
     retryPolicy: RetryPolicy,
-    operation: () => Promise<T>,
+    operation: (signal?: AbortSignal) => Promise<T>,
     config: {
       resetConnectionOnRetry?: boolean;
     } = {}
   ): Promise<T> {
-    return retryWithPolicy({
-      policy: retryPolicy,
-      signal: options?.signal,
-      operation: async () => operation(),
-      shouldRetryError: (error) => isRetryableTransientError(error),
-      onRetry: async () => {
-        if (config.resetConnectionOnRetry) {
-          await this.destroyLiveState(serverId);
+    const { signal, cleanup } = this.createRetrySignal(serverId, options?.signal);
+
+    try {
+      return await retryWithPolicy({
+        policy: retryPolicy,
+        signal,
+        operation: async () => this.awaitWithAbort(operation(signal), signal),
+        shouldRetryError: (error) => isRetryableTransientError(error),
+        onRetry: async () => {
+          if (config.resetConnectionOnRetry) {
+            await this.destroyLiveState(serverId, {
+              abortRetryOperations: false,
+            });
+          }
+        },
+      });
+    } finally {
+      cleanup();
+    }
+  }
+
+  private createRetrySignal(
+    serverId: string,
+    callerSignal?: AbortSignal
+  ): { signal: AbortSignal; cleanup: () => void } {
+    const controller = new AbortController();
+    let controllers = this.retryAbortControllers.get(serverId);
+    if (!controllers) {
+      controllers = new Set();
+      this.retryAbortControllers.set(serverId, controllers);
+    }
+    controllers.add(controller);
+
+    const abortFromCaller = () => {
+      if (!controller.signal.aborted) {
+        controller.abort(callerSignal?.reason);
+      }
+    };
+
+    if (callerSignal?.aborted) {
+      abortFromCaller();
+    } else {
+      callerSignal?.addEventListener("abort", abortFromCaller, { once: true });
+    }
+
+    return {
+      signal: controller.signal,
+      cleanup: () => {
+        callerSignal?.removeEventListener("abort", abortFromCaller);
+        const currentControllers = this.retryAbortControllers.get(serverId);
+        if (!currentControllers) {
+          return;
+        }
+        currentControllers.delete(controller);
+        if (currentControllers.size === 0) {
+          this.retryAbortControllers.delete(serverId);
         }
       },
+    };
+  }
+
+  private abortRetrySignals(serverId: string): void {
+    const controllers = this.retryAbortControllers.get(serverId);
+    if (!controllers) {
+      return;
+    }
+
+    this.retryAbortControllers.delete(serverId);
+    const error = new Error(`MCP server "${serverId}" was disconnected.`);
+    error.name = "AbortError";
+
+    for (const controller of controllers) {
+      if (!controller.signal.aborted) {
+        controller.abort(error);
+      }
+    }
+  }
+
+  private throwIfAborted(signal?: AbortSignal): void {
+    if (!signal?.aborted) {
+      return;
+    }
+
+    if (signal.reason instanceof Error) {
+      throw signal.reason;
+    }
+
+    const error = new Error(
+      signal.reason == null
+        ? "The operation was aborted."
+        : String(signal.reason)
+    );
+    error.name = "AbortError";
+    throw error;
+  }
+
+  private async awaitWithAbort<T>(
+    promise: Promise<T>,
+    signal?: AbortSignal
+  ): Promise<T> {
+    this.throwIfAborted(signal);
+
+    if (!signal) {
+      return promise;
+    }
+
+    return await new Promise<T>((resolve, reject) => {
+      const onAbort = () => {
+        cleanup();
+        reject(
+          signal.reason instanceof Error
+            ? signal.reason
+            : Object.assign(
+                new Error(
+                  signal.reason == null
+                    ? "The operation was aborted."
+                    : String(signal.reason)
+                ),
+                { name: "AbortError" }
+              )
+        );
+      };
+
+      const cleanup = () => {
+        signal.removeEventListener("abort", onAbort);
+      };
+
+      signal.addEventListener("abort", onAbort, { once: true });
+
+      promise.then(
+        (value) => {
+          cleanup();
+          resolve(value);
+        },
+        (error) => {
+          cleanup();
+          reject(error);
+        }
+      );
     });
   }
 }

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -9,10 +9,7 @@ import {
 } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import {
-  CallToolResultSchema,
-  CreateTaskResultSchema,
-} from "@modelcontextprotocol/sdk/types.js";
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.js";
 import type {
@@ -27,12 +24,14 @@ import type {
   MCPServerConfig,
   StdioServerConfig,
   HttpServerConfig,
-  ManagedClientState,
+  RegisteredServerState,
+  LiveClientState,
   MCPConnectionStatus,
   ServerSummary,
   ClientCapabilityOptions,
   ExecuteToolArguments,
   TaskOptions,
+  ExecuteToolRequest,
   ClientRequestOptions,
   ListResourcesParams,
   ListResourceTemplatesParams,
@@ -60,6 +59,12 @@ import {
 import { isMethodUnavailableError, formatError } from "./error-utils.js";
 import { MCPAuthError, isAuthError } from "./errors.js";
 import {
+  type RetryPolicy,
+  isRetryableTransientError,
+  normalizeRetryPolicy,
+  retryWithPolicy,
+} from "../retry.js";
+import {
   buildRequestInit,
   normalizeHeaders,
   getExistingAuthorization,
@@ -78,6 +83,7 @@ import {
 } from "./notification-handlers.js";
 import { ElicitationManager } from "./elicitation.js";
 import {
+  CreateTaskResultSchema,
   listTasks as tasksListTasks,
   getTask as tasksGetTask,
   getTaskResult as tasksGetTaskResult,
@@ -120,7 +126,8 @@ import {
  */
 export class MCPClientManager {
   // State management
-  private readonly clientStates = new Map<string, ManagedClientState>();
+  private readonly registeredServers = new Map<string, RegisteredServerState>();
+  private readonly liveClientStates = new Map<string, LiveClientState>();
   private readonly toolsMetadataCache = new Map<string, Map<string, any>>();
 
   // Managers for specific features
@@ -135,6 +142,7 @@ export class MCPClientManager {
   private readonly defaultLogJsonRpc: boolean;
   private readonly defaultRpcLogger?: RpcLogger;
   private readonly defaultProgressHandler?: ProgressHandler;
+  private readonly defaultRetryPolicy: RetryPolicy;
   private readonly lazyConnect: boolean;
 
   // Progress token counter for uniqueness
@@ -161,6 +169,7 @@ export class MCPClientManager {
     this.defaultLogJsonRpc = options.defaultLogJsonRpc ?? false;
     this.defaultRpcLogger = options.rpcLogger;
     this.defaultProgressHandler = options.progressHandler;
+    this.defaultRetryPolicy = normalizeRetryPolicy(options.retryPolicy);
     this.lazyConnect = options.lazyConnect ?? false;
 
     // Start connecting to all configured servers (unless replay/trace-repair use explicit connect)
@@ -179,33 +188,41 @@ export class MCPClientManager {
    * Lists all registered server IDs.
    */
   listServers(): string[] {
-    return Array.from(this.clientStates.keys());
+    return Array.from(this.registeredServers.keys());
   }
 
   /**
    * Checks if a server is registered.
    */
   hasServer(serverId: string): boolean {
-    return this.clientStates.has(serverId);
+    return this.registeredServers.has(serverId);
   }
 
   /**
    * Gets summaries for all registered servers.
    */
   getServerSummaries(): ServerSummary[] {
-    return Array.from(this.clientStates.entries()).map(([serverId, state]) => ({
-      id: serverId,
-      status: this.getConnectionStatus(serverId),
-      config: state.config,
-    }));
+    return Array.from(this.registeredServers.entries()).map(
+      ([serverId, state]) => ({
+        id: serverId,
+        status: this.getConnectionStatus(serverId),
+        config: state.config,
+      })
+    );
   }
 
   /**
    * Gets replayable HTTP server configs for eval reporting.
    */
   getServerReplayConfigs(): MCPServerReplayConfig[] {
-    return Array.from(this.clientStates.entries())
-      .map(([serverId, state]) => this.buildServerReplayConfig(serverId, state))
+    return Array.from(this.registeredServers.entries())
+      .map(([serverId, state]) =>
+        this.buildServerReplayConfig(
+          serverId,
+          state,
+          this.liveClientStates.get(serverId)
+        )
+      )
       .filter(
         (config): config is MCPServerReplayConfig => config !== undefined
       );
@@ -215,7 +232,7 @@ export class MCPClientManager {
    * Gets the connection status for a server.
    */
   getConnectionStatus(serverId: string): MCPConnectionStatus {
-    const state = this.clientStates.get(serverId);
+    const state = this.liveClientStates.get(serverId);
     if (state?.promise) return "connecting";
     if (state?.client) return "connected";
     return "disconnected";
@@ -225,32 +242,34 @@ export class MCPClientManager {
    * Gets the configuration for a server.
    */
   getServerConfig(serverId: string): MCPServerConfig | undefined {
-    return this.clientStates.get(serverId)?.config;
+    return this.registeredServers.get(serverId)?.config;
   }
 
   /**
    * Gets the capabilities reported by a server.
    */
   getServerCapabilities(serverId: string): ServerCapabilities | undefined {
-    return this.clientStates.get(serverId)?.client?.getServerCapabilities();
+    return this.liveClientStates.get(serverId)?.client?.getServerCapabilities();
   }
 
   /**
    * Gets the underlying MCP Client for a server.
    */
   getClient(serverId: string): Client | undefined {
-    return this.clientStates.get(serverId)?.client;
+    return this.liveClientStates.get(serverId)?.client;
   }
 
   /**
    * Gets initialization information for a connected server.
    */
   getInitializationInfo(serverId: string) {
-    const state = this.clientStates.get(serverId);
-    const client = state?.client;
+    const configState = this.registeredServers.get(serverId);
+    const liveState = this.liveClientStates.get(serverId);
+    const client = liveState?.client;
     if (!client) return undefined;
 
-    const config = state.config;
+    const config = configState?.config;
+    if (!config) return undefined;
     let transportType: string;
     if (this.isStdioConfig(config)) {
       transportType = "stdio";
@@ -263,8 +282,8 @@ export class MCPClientManager {
     }
 
     let protocolVersion: string | undefined;
-    if (state.transport) {
-      protocolVersion = (state.transport as any)._protocolVersion;
+    if (liveState.transport) {
+      protocolVersion = (liveState.transport as any)._protocolVersion;
     }
 
     return {
@@ -292,53 +311,34 @@ export class MCPClientManager {
     serverId: string,
     config: MCPServerConfig
   ): Promise<Client> {
-    const timeout = config.timeout ?? this.defaultTimeout;
-    const existingState = this.clientStates.get(serverId);
-
-    if (existingState?.client) {
+    const liveState = this.liveClientStates.get(serverId);
+    if (liveState?.client) {
       throw new Error(`MCP server "${serverId}" is already connected.`);
     }
-
-    const state: ManagedClientState = existingState ?? { config, timeout };
-    state.config = config;
-    state.timeout = timeout;
-    state.authProvider = undefined;
-
-    // Reuse existing connection promise if in-flight
-    if (state.promise) {
-      this.clientStates.set(serverId, state);
-      return state.promise;
+    if (liveState?.promise) {
+      return liveState.promise;
     }
 
-    const connectionPromise = this.performConnection(
-      serverId,
-      config,
-      timeout,
-      state
-    );
-    state.promise = connectionPromise;
-    this.clientStates.set(serverId, state);
+    const timeout = config.timeout ?? this.defaultTimeout;
+    this.registerServer(serverId, config, timeout);
 
-    return connectionPromise;
+    return retryWithPolicy({
+      policy: this.defaultRetryPolicy,
+      operation: () => this.connectToServerOnce(serverId),
+      shouldRetryError: (error) => isRetryableTransientError(error),
+      onRetry: async () => {
+        await this.destroyLiveState(serverId);
+      },
+    });
   }
 
   /**
    * Disconnects from a server.
    */
   async disconnectServer(serverId: string): Promise<void> {
-    const state = this.clientStates.get(serverId);
-    if (!state?.client) return;
-
-    try {
-      await state.client.close();
-    } catch {
-      // Ignore close errors
-    } finally {
-      if (state.transport) {
-        await this.safeCloseTransport(state.transport);
-      }
-      this.resetState(serverId);
-    }
+    const state = this.liveClientStates.get(serverId);
+    if (!state) return;
+    await this.destroyLiveState(serverId);
   }
 
   /**
@@ -346,6 +346,8 @@ export class MCPClientManager {
    */
   async removeServer(serverId: string): Promise<void> {
     await this.disconnectServer(serverId);
+    this.registeredServers.delete(serverId);
+    this.toolsMetadataCache.delete(serverId);
     this.notificationManager.clearServer(serverId);
     this.elicitationManager.clearServer(serverId);
   }
@@ -354,13 +356,8 @@ export class MCPClientManager {
    * Disconnects from all servers.
    */
   async disconnectAllServers(): Promise<void> {
-    const serverIds = this.listServers();
+    const serverIds = Array.from(this.liveClientStates.keys());
     await Promise.all(serverIds.map((id) => this.disconnectServer(id)));
-
-    for (const serverId of serverIds) {
-      this.notificationManager.clearServer(serverId);
-      this.elicitationManager.clearServer(serverId);
-    }
   }
 
   // ===========================================================================
@@ -375,23 +372,22 @@ export class MCPClientManager {
     params?: Parameters<Client["listTools"]>[0],
     options?: ClientRequestOptions
   ): Promise<ListToolsResult> {
-    await this.ensureConnected(serverId);
-    const client = this.getClientOrThrow(serverId);
-
-    try {
-      const result = await client.listTools(
-        params,
-        this.withTimeout(serverId, options)
-      );
-      this.cacheToolsMetadata(serverId, result.tools);
-      return result;
-    } catch (error) {
-      if (isMethodUnavailableError(error, "tools/list")) {
-        this.toolsMetadataCache.set(serverId, new Map());
-        return { tools: [] } as ListToolsResult;
+    return this.runRetryableReadOperation(serverId, options, async (client) => {
+      try {
+        const result = await client.listTools(
+          params,
+          this.withTimeout(serverId, options)
+        );
+        this.cacheToolsMetadata(serverId, result.tools);
+        return result;
+      } catch (error) {
+        if (isMethodUnavailableError(error, "tools/list")) {
+          this.toolsMetadataCache.set(serverId, new Map());
+          return { tools: [] } as ListToolsResult;
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
   /**
@@ -412,7 +408,6 @@ export class MCPClientManager {
 
     const toolLists = await Promise.all(
       targetIds.map(async (serverId) => {
-        await this.ensureConnected(serverId);
         const result = await this.listTools(serverId);
 
         // Attach execute function to each tool
@@ -488,7 +483,6 @@ export class MCPClientManager {
     const perServerTools = await Promise.all(
       ids.map(async (id) => {
         try {
-          await this.ensureConnected(id);
           const listToolsResult = await this.listTools(id);
 
           const tools = await convertMCPToolsToVercelTools(listToolsResult, {
@@ -542,34 +536,57 @@ export class MCPClientManager {
   async executeTool(
     serverId: string,
     toolName: string,
-    args: ExecuteToolArguments = {},
+    args?: ExecuteToolArguments,
     options?: ClientRequestOptions,
     taskOptions?: TaskOptions
+  ): Promise<CallToolResult | Record<string, unknown>>;
+  async executeTool(
+    serverId: string,
+    toolName: string,
+    args: ExecuteToolArguments | undefined,
+    options: ExecuteToolRequest
+  ): Promise<CallToolResult | Record<string, unknown>>;
+  async executeTool(
+    serverId: string,
+    toolName: string,
+    args: ExecuteToolArguments = {},
+    options?: ClientRequestOptions | ExecuteToolRequest,
+    taskOptions?: TaskOptions
   ) {
-    await this.ensureConnected(serverId);
-    const client = this.getClientOrThrow(serverId);
+    const request = this.normalizeExecuteToolRequest(options, taskOptions);
+    const operation = async () => {
+      await this.ensureConnected(serverId);
+      const client = this.getClientOrThrow(serverId);
+      const mergedOptions = this.withProgressHandler(serverId, request.request);
+      const callParams = { name: toolName, arguments: args };
 
-    const mergedOptions = this.withProgressHandler(serverId, options);
-    const callParams = { name: toolName, arguments: args };
+      if (request.task !== undefined) {
+        const taskValue =
+          request.task.ttl !== undefined ? { ttl: request.task.ttl } : {};
+        const result = await client.request(
+          { method: "tools/call", params: { ...callParams, task: taskValue } },
+          CreateTaskResultSchema,
+          mergedOptions
+        );
+        return {
+          task: result.task,
+          _meta: {
+            "io.modelcontextprotocol/model-immediate-response": `Task ${result.task.taskId} created with status: ${result.task.status}`,
+          },
+        };
+      }
 
-    if (taskOptions !== undefined) {
-      // Task-augmented tool call per MCP Tasks spec
-      const taskValue =
-        taskOptions.ttl !== undefined ? { ttl: taskOptions.ttl } : {};
-      const result = await client.request(
-        { method: "tools/call", params: { ...callParams, task: taskValue } },
-        CreateTaskResultSchema,
-        mergedOptions
-      );
-      return {
-        task: result.task,
-        _meta: {
-          "io.modelcontextprotocol/model-immediate-response": `Task ${result.task.taskId} created with status: ${result.task.status}`,
-        },
-      };
-    }
+      return client.callTool(callParams, CallToolResultSchema, mergedOptions);
+    };
 
-    return client.callTool(callParams, CallToolResultSchema, mergedOptions);
+    return request.retry
+      ? this.runRetriedOperation(
+          serverId,
+          request.request,
+          request.retry,
+          operation
+        )
+      : operation();
   }
 
   // ===========================================================================
@@ -584,22 +601,21 @@ export class MCPClientManager {
     params?: ListResourcesParams,
     options?: ClientRequestOptions
   ) {
-    await this.ensureConnected(serverId);
-    const client = this.getClientOrThrow(serverId);
-
-    try {
-      return await client.listResources(
-        params,
-        this.withTimeout(serverId, options)
-      );
-    } catch (error) {
-      if (isMethodUnavailableError(error, "resources/list")) {
-        return { resources: [] } as Awaited<
-          ReturnType<Client["listResources"]>
-        >;
+    return this.runRetryableReadOperation(serverId, options, async (client) => {
+      try {
+        return await client.listResources(
+          params,
+          this.withTimeout(serverId, options)
+        );
+      } catch (error) {
+        if (isMethodUnavailableError(error, "resources/list")) {
+          return { resources: [] } as Awaited<
+            ReturnType<Client["listResources"]>
+          >;
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
   /**
@@ -610,11 +626,8 @@ export class MCPClientManager {
     params: ReadResourceParams,
     options?: ClientRequestOptions
   ) {
-    await this.ensureConnected(serverId);
-    const client = this.getClientOrThrow(serverId);
-    return client.readResource(
-      params,
-      this.withProgressHandler(serverId, options)
+    return this.runRetryableReadOperation(serverId, options, (client) =>
+      client.readResource(params, this.withProgressHandler(serverId, options))
     );
   }
 
@@ -658,11 +671,8 @@ export class MCPClientManager {
     params?: ListResourceTemplatesParams,
     options?: ClientRequestOptions
   ) {
-    await this.ensureConnected(serverId);
-    const client = this.getClientOrThrow(serverId);
-    return client.listResourceTemplates(
-      params,
-      this.withTimeout(serverId, options)
+    return this.runRetryableReadOperation(serverId, options, (client) =>
+      client.listResourceTemplates(params, this.withTimeout(serverId, options))
     );
   }
 
@@ -678,26 +688,24 @@ export class MCPClientManager {
     params?: ListPromptsParams,
     options?: ClientRequestOptions
   ) {
-    await this.ensureConnected(serverId);
-    const client = this.getClientOrThrow(serverId);
-
-    // Skip if server doesn't advertise prompts capability
-    const capabilities = client.getServerCapabilities();
-    if (capabilities && !capabilities.prompts) {
-      return { prompts: [] } as Awaited<ReturnType<Client["listPrompts"]>>;
-    }
-
-    try {
-      return await client.listPrompts(
-        params,
-        this.withTimeout(serverId, options)
-      );
-    } catch (error) {
-      if (isMethodUnavailableError(error, "prompts/list")) {
+    return this.runRetryableReadOperation(serverId, options, async (client) => {
+      const capabilities = client.getServerCapabilities();
+      if (capabilities && !capabilities.prompts) {
         return { prompts: [] } as Awaited<ReturnType<Client["listPrompts"]>>;
       }
-      throw error;
-    }
+
+      try {
+        return await client.listPrompts(
+          params,
+          this.withTimeout(serverId, options)
+        );
+      } catch (error) {
+        if (isMethodUnavailableError(error, "prompts/list")) {
+          return { prompts: [] } as Awaited<ReturnType<Client["listPrompts"]>>;
+        }
+        throw error;
+      }
+    });
   }
 
   /**
@@ -708,11 +716,8 @@ export class MCPClientManager {
     params: GetPromptParams,
     options?: ClientRequestOptions
   ) {
-    await this.ensureConnected(serverId);
-    const client = this.getClientOrThrow(serverId);
-    return client.getPrompt(
-      params,
-      this.withProgressHandler(serverId, options)
+    return this.runRetryableReadOperation(serverId, options, (client) =>
+      client.getPrompt(params, this.withProgressHandler(serverId, options))
     );
   }
 
@@ -727,14 +732,15 @@ export class MCPClientManager {
     serverId: string,
     options?: RequestOptions
   ): Promise<Awaited<ReturnType<Client["ping"]>>> {
-    const client = this.getClientOrThrow(serverId);
-    try {
-      return await client.ping(options);
-    } catch (error) {
-      throw new Error(
-        `Failed to ping MCP server "${serverId}": ${error instanceof Error ? error.message : "Unknown error"}`
-      );
-    }
+    return this.runRetryableReadOperation(serverId, options, async (client) => {
+      try {
+        return await client.ping(options);
+      } catch (error) {
+        throw new Error(
+          `Failed to ping MCP server "${serverId}": ${error instanceof Error ? error.message : "Unknown error"}`
+        );
+      }
+    });
   }
 
   /**
@@ -753,7 +759,7 @@ export class MCPClientManager {
    * Gets the session ID for a Streamable HTTP server.
    */
   getSessionIdByServer(serverId: string): string | undefined {
-    const state = this.clientStates.get(serverId);
+    const state = this.liveClientStates.get(serverId);
     if (!state?.transport) {
       throw new Error(`Unknown MCP server "${serverId}".`);
     }
@@ -779,7 +785,7 @@ export class MCPClientManager {
   ): void {
     this.notificationManager.addHandler(serverId, schema, handler);
 
-    const client = this.clientStates.get(serverId)?.client;
+    const client = this.liveClientStates.get(serverId)?.client;
     if (client) {
       client.setNotificationHandler(
         schema,
@@ -840,12 +846,12 @@ export class MCPClientManager {
    * Sets a server-specific elicitation handler.
    */
   setElicitationHandler(serverId: string, handler: ElicitationHandler): void {
-    if (!this.clientStates.has(serverId)) {
+    if (!this.registeredServers.has(serverId)) {
       throw new Error(`Unknown MCP server "${serverId}".`);
     }
     this.elicitationManager.setHandler(serverId, handler);
 
-    const client = this.clientStates.get(serverId)?.client;
+    const client = this.liveClientStates.get(serverId)?.client;
     if (client) {
       this.elicitationManager.applyToClient(serverId, client);
     }
@@ -856,7 +862,7 @@ export class MCPClientManager {
    */
   clearElicitationHandler(serverId: string): void {
     this.elicitationManager.clearHandler(serverId);
-    const client = this.clientStates.get(serverId)?.client;
+    const client = this.liveClientStates.get(serverId)?.client;
     if (client) {
       if (this.elicitationManager.getGlobalCallback()) {
         this.elicitationManager.applyToClient(serverId, client);
@@ -871,7 +877,7 @@ export class MCPClientManager {
    */
   setElicitationCallback(callback: ElicitationCallback): void {
     this.elicitationManager.setGlobalCallback(callback);
-    for (const [serverId, state] of this.clientStates.entries()) {
+    for (const [serverId, state] of this.liveClientStates.entries()) {
       if (state.client) {
         this.elicitationManager.applyToClient(serverId, state.client);
       }
@@ -883,7 +889,7 @@ export class MCPClientManager {
    */
   clearElicitationCallback(): void {
     this.elicitationManager.clearGlobalCallback();
-    for (const [serverId, state] of this.clientStates.entries()) {
+    for (const [serverId, state] of this.liveClientStates.entries()) {
       if (!state.client) continue;
       if (this.elicitationManager.getHandler(serverId)) {
         this.elicitationManager.applyToClient(serverId, state.client);
@@ -919,20 +925,20 @@ export class MCPClientManager {
     cursor?: string,
     options?: ClientRequestOptions
   ) {
-    await this.ensureConnected(serverId);
-    const client = this.getClientOrThrow(serverId);
-    try {
-      return await tasksListTasks(
-        client,
-        cursor,
-        this.withTimeout(serverId, options)
-      );
-    } catch (error) {
-      if (isMethodUnavailableError(error, "tasks/list")) {
-        return { tasks: [] };
+    return this.runRetryableReadOperation(serverId, options, async (client) => {
+      try {
+        return await tasksListTasks(
+          client,
+          cursor,
+          this.withTimeout(serverId, options)
+        );
+      } catch (error) {
+        if (isMethodUnavailableError(error, "tasks/list")) {
+          return { tasks: [] };
+        }
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
   /**
@@ -943,9 +949,9 @@ export class MCPClientManager {
     taskId: string,
     options?: ClientRequestOptions
   ) {
-    await this.ensureConnected(serverId);
-    const client = this.getClientOrThrow(serverId);
-    return tasksGetTask(client, taskId, this.withTimeout(serverId, options));
+    return this.runRetryableReadOperation(serverId, options, (client) =>
+      tasksGetTask(client, taskId, this.withTimeout(serverId, options))
+    );
   }
 
   /**
@@ -956,12 +962,8 @@ export class MCPClientManager {
     taskId: string,
     options?: ClientRequestOptions
   ) {
-    await this.ensureConnected(serverId);
-    const client = this.getClientOrThrow(serverId);
-    return tasksGetTaskResult(
-      client,
-      taskId,
-      this.withTimeout(serverId, options)
+    return this.runRetryableReadOperation(serverId, options, (client) =>
+      tasksGetTaskResult(client, taskId, this.withTimeout(serverId, options))
     );
   }
 
@@ -1003,14 +1005,58 @@ export class MCPClientManager {
   // Private Helpers
   // ===========================================================================
 
+  private registerServer(
+    serverId: string,
+    config: MCPServerConfig,
+    timeout: number
+  ): RegisteredServerState {
+    const state: RegisteredServerState = {
+      config,
+      timeout,
+    };
+    this.registeredServers.set(serverId, state);
+    return state;
+  }
+
+  private async connectToServerOnce(serverId: string): Promise<Client> {
+    const registeredState = this.registeredServers.get(serverId);
+    if (!registeredState) {
+      throw new Error(`Unknown MCP server "${serverId}".`);
+    }
+
+    const existingState = this.liveClientStates.get(serverId);
+    if (existingState?.client) {
+      throw new Error(`MCP server "${serverId}" is already connected.`);
+    }
+
+    if (existingState?.promise) {
+      return existingState.promise;
+    }
+
+    const state: LiveClientState = existingState ?? {};
+    state.authProvider = undefined;
+
+    const connectionPromise = this.performConnection(
+      serverId,
+      registeredState.config,
+      registeredState.timeout,
+      state
+    );
+    state.promise = connectionPromise;
+    this.liveClientStates.set(serverId, state);
+    return connectionPromise;
+  }
+
   private async performConnection(
     serverId: string,
     config: MCPServerConfig,
     timeout: number,
-    state: ManagedClientState
+    state: LiveClientState
   ): Promise<Client> {
+    let client: Client | undefined;
+    let transport: Transport | undefined;
     try {
-      const client = new Client(
+      client = new Client(
         {
           name: this.defaultClientName ?? serverId,
           version: config.version ?? this.defaultClientVersion,
@@ -1029,9 +1075,8 @@ export class MCPClientManager {
         client.onerror = (error) => config.onError?.(error);
       }
 
-      client.onclose = () => this.resetState(serverId);
+      client.onclose = () => this.clearLiveState(serverId);
 
-      let transport: Transport;
       if (this.isStdioConfig(config)) {
         transport = await this.connectViaStdio(
           serverId,
@@ -1049,17 +1094,31 @@ export class MCPClientManager {
         );
       }
 
+      if (this.liveClientStates.get(serverId) !== state) {
+        await client.close().catch(() => undefined);
+        await this.safeCloseTransport(transport);
+        throw new Error(`MCP server "${serverId}" connection was cancelled.`);
+      }
+
       state.client = client;
       state.transport = transport;
       state.promise = undefined;
-      this.clientStates.set(serverId, state);
+      this.liveClientStates.set(serverId, state);
 
       // Set logging level (ignore errors)
       this.setLoggingLevel(serverId, "debug").catch(() => {});
 
       return client;
     } catch (error) {
-      this.resetState(serverId);
+      try {
+        await client?.close();
+      } catch {
+        // Ignore close errors
+      }
+      if (transport) {
+        await this.safeCloseTransport(transport);
+      }
+      this.clearLiveState(serverId);
       throw error;
     }
   }
@@ -1092,7 +1151,7 @@ export class MCPClientManager {
     client: Client,
     config: HttpServerConfig,
     timeout: number,
-    state: ManagedClientState
+    state: LiveClientState
   ): Promise<Transport> {
     const url = new URL(config.url);
 
@@ -1230,35 +1289,54 @@ export class MCPClientManager {
   }
 
   private async ensureConnected(serverId: string): Promise<void> {
-    const state = this.clientStates.get(serverId);
+    const state = this.liveClientStates.get(serverId);
     if (state?.client) return;
 
-    if (!state) {
+    if (!this.registeredServers.has(serverId)) {
       throw new Error(`Unknown MCP server "${serverId}".`);
     }
-    if (state.promise) {
+    if (state?.promise) {
       await state.promise;
       return;
     }
-    await this.connectToServer(serverId, state.config);
+    await this.connectToServerOnce(serverId);
   }
 
   private getClientOrThrow(serverId: string): Client {
-    const state = this.clientStates.get(serverId);
+    const state = this.liveClientStates.get(serverId);
     if (!state?.client) {
       throw new Error(`MCP server "${serverId}" is not connected.`);
     }
     return state.client;
   }
 
-  private resetState(serverId: string): void {
-    this.clientStates.delete(serverId);
+  private clearLiveState(serverId: string): void {
+    this.liveClientStates.delete(serverId);
     this.toolsMetadataCache.delete(serverId);
+  }
+
+  private async destroyLiveState(serverId: string): Promise<void> {
+    const state = this.liveClientStates.get(serverId);
+    this.clearLiveState(serverId);
+    if (!state) {
+      return;
+    }
+
+    try {
+      await state.client?.close();
+    } catch {
+      // Ignore close errors
+    }
+
+    if (state.transport) {
+      await this.safeCloseTransport(state.transport);
+    }
   }
 
   private buildServerReplayConfig(
     serverId: string,
-    state: ManagedClientState
+    state: RegisteredServerState,
+    liveState?: LiveClientState
   ): MCPServerReplayConfig | undefined {
     const { config } = state;
     if (!this.isHttpConfig(config)) {
@@ -1289,8 +1367,9 @@ export class MCPClientManager {
     }
 
     if (config.refreshToken) {
-      const currentAccessToken = state.authProvider?.tokens()?.access_token;
-      const currentRefreshToken = state.authProvider
+      const currentAccessToken =
+        liveState?.authProvider?.tokens()?.access_token;
+      const currentRefreshToken = liveState?.authProvider
         ?.prepareTokenRequest()
         .get("refresh_token");
       const clientId = config.clientId?.trim();
@@ -1391,7 +1470,7 @@ export class MCPClientManager {
     serverId: string,
     options?: RequestOptions
   ): RequestOptions {
-    const state = this.clientStates.get(serverId);
+    const state = this.registeredServers.get(serverId);
     const timeout = state?.timeout ?? this.defaultTimeout;
 
     if (!options) return { timeout };
@@ -1455,5 +1534,62 @@ export class MCPClientManager {
 
   private isStdioConfig(config: MCPServerConfig): config is StdioServerConfig {
     return "command" in config;
+  }
+
+  private isExecuteToolRequest(
+    value: ClientRequestOptions | ExecuteToolRequest | undefined
+  ): value is ExecuteToolRequest {
+    return Boolean(
+      value &&
+      typeof value === "object" &&
+      ("request" in value || "task" in value || "retry" in value)
+    );
+  }
+
+  private normalizeExecuteToolRequest(
+    options?: ClientRequestOptions | ExecuteToolRequest,
+    taskOptions?: TaskOptions
+  ): ExecuteToolRequest {
+    if (this.isExecuteToolRequest(options)) {
+      return options;
+    }
+
+    return {
+      request: options,
+      task: taskOptions,
+    };
+  }
+
+  private async runRetryableReadOperation<T>(
+    serverId: string,
+    options: RequestOptions | undefined,
+    operation: (client: Client) => Promise<T>
+  ): Promise<T> {
+    return this.runRetriedOperation(
+      serverId,
+      options,
+      this.defaultRetryPolicy,
+      async () => {
+        await this.ensureConnected(serverId);
+        return operation(this.getClientOrThrow(serverId));
+      }
+    );
+  }
+
+  private async runRetriedOperation<T>(
+    serverId: string,
+    options: RequestOptions | undefined,
+    retryPolicy: RetryPolicy,
+    operation: () => Promise<T>
+  ): Promise<T> {
+    return retryWithPolicy({
+      policy: retryPolicy,
+      operation: async () => operation(),
+      shouldRetryError: (error) =>
+        !options?.signal?.aborted && isRetryableTransientError(error),
+      onRetry: async () => {
+        await this.destroyLiveState(serverId);
+      },
+    });
   }
 }

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -763,15 +763,9 @@ export class MCPClientManager {
     serverId: string,
     options?: RequestOptions
   ): Promise<Awaited<ReturnType<Client["ping"]>>> {
-    return this.runRetryableReadOperation(serverId, options, async (client) => {
-      try {
-        return await client.ping(options);
-      } catch (error) {
-        throw new Error(
-          `Failed to ping MCP server "${serverId}": ${error instanceof Error ? error.message : "Unknown error"}`
-        );
-      }
-    });
+    return this.runRetryableReadOperation(serverId, options, async (client) =>
+      client.ping(options)
+    );
   }
 
   /**
@@ -1072,11 +1066,13 @@ export class MCPClientManager {
     const state: LiveClientState = existingState ?? {};
     state.authProvider = undefined;
 
-    const connectionPromise = this.performConnection(
-      serverId,
-      registeredState.config,
-      registeredState.timeout,
-      state
+    const connectionPromise = Promise.resolve().then(() =>
+      this.performConnection(
+        serverId,
+        registeredState.config,
+        registeredState.timeout,
+        state
+      )
     );
     state.connectPromise = connectionPromise;
     this.liveClientStates.set(serverId, state);
@@ -1113,7 +1109,7 @@ export class MCPClientManager {
 
       client.onclose = () => {
         if (this.liveClientStates.get(serverId) === state) {
-          this.clearLiveState(serverId, { preservePendingPromises: true });
+          this.clearClosedPendingConnectionState(serverId, state);
         }
       };
 
@@ -1468,6 +1464,35 @@ export class MCPClientManager {
 
     if (state.connectPromise || state.retryPromise) {
       this.liveClientStates.set(serverId, state);
+    } else {
+      this.liveClientStates.delete(serverId);
+    }
+    this.toolsMetadataCache.delete(serverId);
+  }
+
+  private clearClosedPendingConnectionState(
+    serverId: string,
+    state: LiveClientState
+  ): void {
+    state.stdioStderrCleanup?.();
+
+    const nextState: LiveClientState = {};
+    if (state.connectPromise) {
+      nextState.connectPromise = state.connectPromise;
+    }
+    if (state.retryPromise) {
+      nextState.retryPromise = state.retryPromise;
+    }
+    if (state.authProvider) {
+      nextState.authProvider = state.authProvider;
+    }
+
+    delete state.client;
+    delete state.transport;
+    delete state.stdioStderrCleanup;
+
+    if (nextState.connectPromise || nextState.retryPromise) {
+      this.liveClientStates.set(serverId, nextState);
     } else {
       this.liveClientStates.delete(serverId);
     }

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -22,6 +22,8 @@ export type {
   MCPConnectionStatus,
   ServerSummary,
   ManagedClientState,
+  RegisteredServerState,
+  LiveClientState,
 } from "./types.js";
 export type { MCPServerReplayConfig } from "../eval-reporting-types.js";
 
@@ -38,7 +40,11 @@ export type {
 } from "./types.js";
 
 // Types - Tool execution
-export type { ExecuteToolArguments, TaskOptions } from "./types.js";
+export type {
+  ExecuteToolArguments,
+  TaskOptions,
+  ExecuteToolRequest,
+} from "./types.js";
 
 // Types - Request options
 export type {
@@ -98,6 +104,14 @@ export {
   isAuthError,
   isMCPAuthError,
 } from "./errors.js";
+
+export type { RetryPolicy } from "../retry.js";
+export {
+  DEFAULT_RETRY_POLICY,
+  isRetryableTransientError,
+  normalizeRetryPolicy,
+  retryWithPolicy,
+} from "../retry.js";
 
 // Task utilities
 export {

--- a/sdk/src/mcp-client-manager/tasks.ts
+++ b/sdk/src/mcp-client-manager/tasks.ts
@@ -43,6 +43,13 @@ export const ListTasksResultSchema = z.object({
 });
 
 /**
+ * Result schema for task-augmented tool calls.
+ */
+export const CreateTaskResultSchema = z.object({
+  task: TaskSchema,
+});
+
+/**
  * Task status notification schema
  * Per spec, notification includes the full Task object
  */

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -10,6 +10,7 @@ import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.j
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { RefreshTokenOAuthProvider } from "./refresh-token-auth-provider.js";
+import type { RetryPolicy } from "../retry.js";
 import type {
   ElicitRequest,
   ElicitResult,
@@ -154,8 +155,24 @@ export type ServerSummary = {
  * Internal state for a managed client connection
  */
 export interface ManagedClientState {
+  client?: Client;
+  transport?: Transport;
+  authProvider?: RefreshTokenOAuthProvider;
+  promise?: Promise<Client>;
+}
+
+/**
+ * Persistent server registration/configuration state.
+ */
+export interface RegisteredServerState {
   config: MCPServerConfig;
   timeout: number;
+}
+
+/**
+ * Live connection state for a registered server.
+ */
+export interface LiveClientState {
   client?: Client;
   transport?: Transport;
   authProvider?: RefreshTokenOAuthProvider;
@@ -222,6 +239,8 @@ export interface MCPClientManagerOptions {
   rpcLogger?: RpcLogger;
   /** Global progress handler */
   progressHandler?: ProgressHandler;
+  /** Default retry policy for retryable manager operations */
+  retryPolicy?: RetryPolicy;
   /**
    * When true, do not connect in the constructor; callers must use connectToServer
    * (e.g. connectReplayManagerServers) to avoid racing eager connects.
@@ -245,6 +264,18 @@ export type TaskOptions = {
   /** Time-to-live for the task in milliseconds */
   ttl?: number;
 };
+
+/**
+ * Preferred executeTool options shape.
+ */
+export interface ExecuteToolRequest {
+  /** Request options for the tool call */
+  request?: ClientRequestOptions;
+  /** Task options for task-augmented tool calls */
+  task?: TaskOptions;
+  /** Explicit retry policy for tool execution */
+  retry?: RetryPolicy;
+}
 
 // ============================================================================
 // Elicitation Types

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -152,12 +152,19 @@ export type ServerSummary = {
 };
 
 /**
- * Internal state for a managed client connection
+ * Shared state for managed client connections.
  */
-export interface ManagedClientState {
+export interface BaseClientState {
   client?: Client;
   transport?: Transport;
   authProvider?: RefreshTokenOAuthProvider;
+}
+
+/**
+ * Internal state for a managed client connection.
+ * Retained for compatibility with external type consumers.
+ */
+export interface ManagedClientState extends BaseClientState {
   promise?: Promise<Client>;
 }
 
@@ -172,12 +179,10 @@ export interface RegisteredServerState {
 /**
  * Live connection state for a registered server.
  */
-export interface LiveClientState {
-  client?: Client;
-  transport?: Transport;
-  authProvider?: RefreshTokenOAuthProvider;
+export interface LiveClientState extends BaseClientState {
   stdioStderrCleanup?: () => void;
-  promise?: Promise<Client>;
+  connectPromise?: Promise<Client>;
+  retryPromise?: Promise<Client>;
 }
 
 // ============================================================================

--- a/sdk/src/operations.ts
+++ b/sdk/src/operations.ts
@@ -10,6 +10,7 @@ import { MCPClientManager } from "./mcp-client-manager/index.js";
 import type {
   MCPServerConfig,
   RpcLogger,
+  RetryPolicy,
 } from "./mcp-client-manager/index.js";
 
 // ── Param types ─────────────────────────────────────────────────────
@@ -53,17 +54,19 @@ export interface WithEphemeralClientOptions {
   timeout?: number;
   /** Optional RPC logger for request/response tracing. */
   rpcLogger?: RpcLogger;
+  /** Retry policy for the ephemeral manager and initial connect. */
+  retryPolicy?: RetryPolicy;
 }
 
 // ── Resources ───────────────────────────────────────────────────────
 
 export async function listResources(
   manager: MCPClientManager,
-  params: ListResourcesParams,
+  params: ListResourcesParams
 ) {
   const result = await manager.listResources(
     params.serverId,
-    params.cursor ? { cursor: params.cursor } : undefined,
+    params.cursor ? { cursor: params.cursor } : undefined
   );
   return {
     resources: result.resources ?? [],
@@ -73,7 +76,7 @@ export async function listResources(
 
 export async function readResource(
   manager: MCPClientManager,
-  params: ReadResourceParams,
+  params: ReadResourceParams
 ) {
   const content = await manager.readResource(params.serverId, {
     uri: params.uri,
@@ -85,11 +88,11 @@ export async function readResource(
 
 export async function listPrompts(
   manager: MCPClientManager,
-  params: ListPromptsParams,
+  params: ListPromptsParams
 ) {
   const result = await manager.listPrompts(
     params.serverId,
-    params.cursor ? { cursor: params.cursor } : undefined,
+    params.cursor ? { cursor: params.cursor } : undefined
   );
   return {
     prompts: result.prompts ?? [],
@@ -99,7 +102,7 @@ export async function listPrompts(
 
 export async function listPromptsMulti(
   manager: MCPClientManager,
-  params: ListPromptsMultiParams,
+  params: ListPromptsMultiParams
 ) {
   const promptsByServer: Record<string, unknown[]> = {};
   const errors: Record<string, string> = {};
@@ -115,7 +118,7 @@ export async function listPromptsMulti(
         errors[serverId] = errorMessage;
         promptsByServer[serverId] = [];
       }
-    }),
+    })
   );
 
   const payload: Record<string, unknown> = { prompts: promptsByServer };
@@ -127,14 +130,14 @@ export async function listPromptsMulti(
 
 export async function getPrompt(
   manager: MCPClientManager,
-  params: GetPromptParams,
+  params: GetPromptParams
 ) {
   const promptArguments = params.arguments
     ? Object.fromEntries(
         Object.entries(params.arguments).map(([key, value]) => [
           key,
           String(value),
-        ]),
+        ])
       )
     : undefined;
 
@@ -149,11 +152,11 @@ export async function getPrompt(
 
 export async function listTools(
   manager: MCPClientManager,
-  params: ListToolsParams,
+  params: ListToolsParams
 ) {
   const result = await manager.listTools(
     params.serverId,
-    params.cursor ? { cursor: params.cursor } : undefined,
+    params.cursor ? { cursor: params.cursor } : undefined
   );
   return {
     tools: result.tools ?? [],
@@ -166,7 +169,7 @@ export async function listTools(
 export async function withEphemeralClient<T>(
   config: MCPServerConfig,
   fn: (manager: MCPClientManager, serverId: string) => Promise<T>,
-  options?: WithEphemeralClientOptions,
+  options?: WithEphemeralClientOptions
 ): Promise<T> {
   const serverId = options?.serverId ?? "__ephemeral__";
   const manager = new MCPClientManager(
@@ -175,8 +178,9 @@ export async function withEphemeralClient<T>(
       defaultTimeout: options?.timeout ?? 30_000,
       defaultClientName: options?.clientName ?? "mcpjam-sdk",
       lazyConnect: true,
+      retryPolicy: options?.retryPolicy,
       ...(options?.rpcLogger ? { rpcLogger: options.rpcLogger } : {}),
-    },
+    }
   );
 
   try {
@@ -193,7 +197,7 @@ export async function withEphemeralClient<T>(
 
 export async function withDisposableManager<T>(
   managerOrPromise: MCPClientManager | Promise<MCPClientManager>,
-  fn: (manager: MCPClientManager) => Promise<T>,
+  fn: (manager: MCPClientManager) => Promise<T>
 ): Promise<T> {
   const manager = await managerOrPromise;
   try {

--- a/sdk/src/retry.ts
+++ b/sdk/src/retry.ts
@@ -1,0 +1,183 @@
+import { isMethodUnavailableError } from "./mcp-client-manager/error-utils.js";
+import { isAuthError } from "./mcp-client-manager/errors.js";
+
+export interface RetryPolicy {
+  retries: number;
+  retryDelayMs: number;
+}
+
+export const DEFAULT_RETRY_POLICY: RetryPolicy = {
+  retries: 0,
+  retryDelayMs: 3_000,
+};
+
+export interface RetryExecutionOptions<T> {
+  policy?: RetryPolicy;
+  operation: (attempt: number) => Promise<T>;
+  shouldRetryError?: (error: unknown, attempt: number) => boolean;
+  shouldRetryResult?: (result: T, attempt: number) => boolean;
+  onRetry?: (input: {
+    attempt: number;
+    error?: unknown;
+    result?: T;
+  }) => Promise<void> | void;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function extractHttpStatusCode(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+
+  const statusCode =
+    "statusCode" in error && typeof error.statusCode === "number"
+      ? error.statusCode
+      : undefined;
+  if (statusCode !== undefined) {
+    return statusCode;
+  }
+
+  const numericCode =
+    "code" in error && typeof error.code === "number" ? error.code : undefined;
+  if (numericCode !== undefined) {
+    return numericCode;
+  }
+
+  if (!(error instanceof Error)) {
+    return undefined;
+  }
+
+  const match = error.message.match(/\b(?:http|status)[:\s]+(\d{3})\b/i);
+  if (!match) {
+    return undefined;
+  }
+
+  const parsed = Number(match[1]);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function extractNodeErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+
+  return "code" in error && typeof error.code === "string"
+    ? error.code
+    : undefined;
+}
+
+export function normalizeRetryPolicy(policy?: RetryPolicy): RetryPolicy {
+  return {
+    retries: Math.max(0, policy?.retries ?? DEFAULT_RETRY_POLICY.retries),
+    retryDelayMs: Math.max(
+      0,
+      policy?.retryDelayMs ?? DEFAULT_RETRY_POLICY.retryDelayMs
+    ),
+  };
+}
+
+export function isRetryableTransientError(error: unknown): boolean {
+  if (isAuthError(error).isAuth) {
+    return false;
+  }
+
+  if (isMethodUnavailableError(error, "rpc")) {
+    return false;
+  }
+
+  const statusCode = extractHttpStatusCode(error);
+  if (statusCode === 408 || statusCode === 425 || statusCode === 429) {
+    return true;
+  }
+  if (statusCode !== undefined && statusCode >= 500 && statusCode <= 599) {
+    return true;
+  }
+
+  const nodeCode = extractNodeErrorCode(error)?.toUpperCase();
+  if (
+    nodeCode &&
+    new Set([
+      "ECONNREFUSED",
+      "ECONNRESET",
+      "EAI_AGAIN",
+      "ENETDOWN",
+      "ENETUNREACH",
+      "ENOTFOUND",
+      "EPIPE",
+      "ETIMEDOUT",
+      "UND_ERR_CONNECT_TIMEOUT",
+      "UND_ERR_HEADERS_TIMEOUT",
+      "UND_ERR_SOCKET",
+    ]).has(nodeCode)
+  ) {
+    return true;
+  }
+
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  if (error.name === "AbortError" || message.includes("aborted")) {
+    return false;
+  }
+
+  return [
+    "connection reset",
+    "connection refused",
+    "connection terminated",
+    "connect timeout",
+    "dns lookup",
+    "econn",
+    "eai_again",
+    "enotfound",
+    "etimedout",
+    "fetch failed",
+    "network error",
+    "network request failed",
+    "socket hang up",
+    "timed out",
+    "timeout",
+    "temporarily unavailable",
+  ].some((pattern) => message.includes(pattern));
+}
+
+export async function retryWithPolicy<T>({
+  policy,
+  operation,
+  shouldRetryError,
+  shouldRetryResult,
+  onRetry,
+}: RetryExecutionOptions<T>): Promise<T> {
+  const normalized = normalizeRetryPolicy(policy);
+
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      const result = await operation(attempt);
+      const shouldRetry =
+        attempt < normalized.retries &&
+        (shouldRetryResult?.(result, attempt) ?? false);
+
+      if (!shouldRetry) {
+        return result;
+      }
+
+      await onRetry?.({ attempt, result });
+      await delay(normalized.retryDelayMs);
+    } catch (error) {
+      const shouldRetry =
+        attempt < normalized.retries &&
+        (shouldRetryError?.(error, attempt) ?? false);
+
+      if (!shouldRetry) {
+        throw error;
+      }
+
+      await onRetry?.({ attempt, error });
+      await delay(normalized.retryDelayMs);
+    }
+  }
+}

--- a/sdk/src/retry.ts
+++ b/sdk/src/retry.ts
@@ -24,6 +24,20 @@ export interface RetryExecutionOptions<T> {
   }) => Promise<void> | void;
 }
 
+const RETRYABLE_NODE_ERROR_CODES = new Set([
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EAI_AGAIN",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "EPIPE",
+  "ETIMEDOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
 function toAbortError(reason: unknown): Error {
   if (reason instanceof Error) {
     return reason;
@@ -134,27 +148,15 @@ export function isRetryableTransientError(error: unknown): boolean {
   if (statusCode === 408 || statusCode === 425 || statusCode === 429) {
     return true;
   }
+  if (statusCode === 501) {
+    return false;
+  }
   if (statusCode !== undefined && statusCode >= 500 && statusCode <= 599) {
     return true;
   }
 
   const nodeCode = extractNodeErrorCode(error)?.toUpperCase();
-  if (
-    nodeCode &&
-    new Set([
-      "ECONNREFUSED",
-      "ECONNRESET",
-      "EAI_AGAIN",
-      "ENETDOWN",
-      "ENETUNREACH",
-      "ENOTFOUND",
-      "EPIPE",
-      "ETIMEDOUT",
-      "UND_ERR_CONNECT_TIMEOUT",
-      "UND_ERR_HEADERS_TIMEOUT",
-      "UND_ERR_SOCKET",
-    ]).has(nodeCode)
-  ) {
+  if (nodeCode && RETRYABLE_NODE_ERROR_CODES.has(nodeCode)) {
     return true;
   }
 

--- a/sdk/src/retry.ts
+++ b/sdk/src/retry.ts
@@ -13,6 +13,7 @@ export const DEFAULT_RETRY_POLICY: RetryPolicy = {
 
 export interface RetryExecutionOptions<T> {
   policy?: RetryPolicy;
+  signal?: AbortSignal;
   operation: (attempt: number) => Promise<T>;
   shouldRetryError?: (error: unknown, attempt: number) => boolean;
   shouldRetryResult?: (result: T, attempt: number) => boolean;
@@ -23,8 +24,49 @@ export interface RetryExecutionOptions<T> {
   }) => Promise<void> | void;
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function toAbortError(reason: unknown): Error {
+  if (reason instanceof Error) {
+    return reason;
+  }
+
+  const error = new Error(
+    reason == null ? "The operation was aborted." : String(reason)
+  );
+  error.name = "AbortError";
+  return error;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw toAbortError(signal.reason);
+  }
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  throwIfAborted(signal);
+
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      cleanup();
+      reject(toAbortError(signal?.reason));
+    };
+
+    const cleanup = () => {
+      signal?.removeEventListener("abort", onAbort);
+    };
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 function extractHttpStatusCode(error: unknown): number | undefined {
@@ -147,6 +189,7 @@ export function isRetryableTransientError(error: unknown): boolean {
 
 export async function retryWithPolicy<T>({
   policy,
+  signal,
   operation,
   shouldRetryError,
   shouldRetryResult,
@@ -155,6 +198,8 @@ export async function retryWithPolicy<T>({
   const normalized = normalizeRetryPolicy(policy);
 
   for (let attempt = 0; ; attempt += 1) {
+    throwIfAborted(signal);
+
     try {
       const result = await operation(attempt);
       const shouldRetry =
@@ -166,7 +211,7 @@ export async function retryWithPolicy<T>({
       }
 
       await onRetry?.({ attempt, result });
-      await delay(normalized.retryDelayMs);
+      await delay(normalized.retryDelayMs, signal);
     } catch (error) {
       const shouldRetry =
         attempt < normalized.retries &&
@@ -177,7 +222,7 @@ export async function retryWithPolicy<T>({
       }
 
       await onRetry?.({ attempt, error });
-      await delay(normalized.retryDelayMs);
+      await delay(normalized.retryDelayMs, signal);
     }
   }
 }

--- a/sdk/src/server-doctor.ts
+++ b/sdk/src/server-doctor.ts
@@ -4,6 +4,7 @@ import { isMethodUnavailableError } from "./mcp-client-manager/index.js";
 import type {
   MCPClientManager,
   MCPServerConfig,
+  RetryPolicy,
   RpcLogger,
 } from "./mcp-client-manager/index.js";
 import type { ProbeMcpServerResult } from "./server-probe.js";
@@ -77,12 +78,17 @@ export interface RunServerDoctorInput<TTarget = unknown> {
   target: TTarget;
   timeout: number;
   rpcLogger?: RpcLogger;
+  retryPolicy?: RetryPolicy;
 }
 
 type WithConnectedManager = <T>(
   config: MCPServerConfig,
   fn: (manager: MCPClientManager, serverId: string) => Promise<T>,
-  options?: { timeout?: number; rpcLogger?: RpcLogger },
+  options?: {
+    timeout?: number;
+    rpcLogger?: RpcLogger;
+    retryPolicy?: RetryPolicy;
+  }
 ) => Promise<T>;
 
 export interface ServerDoctorDependencies {
@@ -92,7 +98,7 @@ export interface ServerDoctorDependencies {
 
 export async function runServerDoctor<TTarget = unknown>(
   input: RunServerDoctorInput<TTarget>,
-  dependencies: ServerDoctorDependencies = {},
+  dependencies: ServerDoctorDependencies = {}
 ): Promise<ServerDoctorResult<TTarget>> {
   const probeServer = dependencies.probeServer ?? probeMcpServer;
   const withManager =
@@ -101,6 +107,7 @@ export async function runServerDoctor<TTarget = unknown>(
       withEphemeralClient(config, fn, {
         timeout: options?.timeout,
         rpcLogger: options?.rpcLogger,
+        retryPolicy: options?.retryPolicy,
         serverId: "__cli__",
         clientName: "mcpjam",
       }));
@@ -149,18 +156,21 @@ export async function runServerDoctor<TTarget = unknown>(
           ? { accessToken: resolveProbeAccessToken(input.config) }
           : {}),
         ...(resolveDoctorClientCapabilities(input.config)
-          ? { clientCapabilities: resolveDoctorClientCapabilities(input.config) }
+          ? {
+              clientCapabilities: resolveDoctorClientCapabilities(input.config),
+            }
           : {}),
         timeoutMs: input.timeout,
+        retryPolicy: input.retryPolicy,
       });
       result.checks.probe = summarizeProbeCheck(
         result.probe,
-        hasConnectionCredentials(input.config),
+        hasConnectionCredentials(input.config)
       );
     } catch (error) {
       const structured = normalizeServerDoctorError(error);
       result.checks.probe = errorCheck(
-        `HTTP probe failed: ${structured.message}`,
+        `HTTP probe failed: ${structured.message}`
       );
       result.error = structured;
     }
@@ -172,8 +182,7 @@ export async function runServerDoctor<TTarget = unknown>(
       result.status = "oauth_required";
       result.connection = {
         status: "skipped",
-        detail:
-          "Server requires OAuth before a connection can be established.",
+        detail: "Server requires OAuth before a connection can be established.",
       };
       result.checks.connection = skippedCheck(result.connection.detail);
       result.error = {
@@ -194,11 +203,13 @@ export async function runServerDoctor<TTarget = unknown>(
   try {
     const collected = await withManager(
       input.config,
-      (manager, serverId) => collectConnectedServerDoctorState(manager, serverId),
+      (manager, serverId) =>
+        collectConnectedServerDoctorState(manager, serverId),
       {
         timeout: input.timeout,
         rpcLogger: input.rpcLogger,
-      },
+        retryPolicy: input.retryPolicy,
+      }
     );
 
     result.connection = {
@@ -243,7 +254,7 @@ export async function runServerDoctor<TTarget = unknown>(
 
 export async function collectConnectedServerDoctorState(
   manager: MCPClientManager,
-  serverId: string,
+  serverId: string
 ): Promise<ConnectedServerDoctorState> {
   const errors: ServerDoctorError[] = [];
   const initInfo = manager.getInitializationInfo(serverId) ?? null;
@@ -279,7 +290,9 @@ export async function collectConnectedServerDoctorState(
     checks: {
       initialization: initInfo
         ? okCheck("Initialization info captured.")
-        : errorCheck("Server connected but did not return initialization info."),
+        : errorCheck(
+            "Server connected but did not return initialization info."
+          ),
       capabilities: capabilities
         ? okCheck("Server capabilities captured.")
         : errorCheck("Server connected but did not advertise capabilities."),
@@ -298,7 +311,11 @@ export function normalizeServerDoctorError(error: unknown): ServerDoctorError {
   }
 
   const message =
-    error instanceof Error ? error.message : typeof error === "string" ? error : "Unknown error";
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "Unknown error";
   const lower = message.toLowerCase();
 
   if (lower.includes("timed out") || lower.includes("timeout")) {
@@ -328,7 +345,7 @@ function isServerDoctorError(error: unknown): error is ServerDoctorError {
 
 async function collectTools(
   manager: MCPClientManager,
-  serverId: string,
+  serverId: string
 ): Promise<{
   tools: unknown[];
   toolsMetadata: Record<string, unknown>;
@@ -356,7 +373,7 @@ async function collectTools(
 
 async function collectResources(
   manager: MCPClientManager,
-  serverId: string,
+  serverId: string
 ): Promise<{
   resources: unknown[];
   check: ServerDoctorCheck;
@@ -381,7 +398,7 @@ async function collectResources(
 
 async function collectPrompts(
   manager: MCPClientManager,
-  serverId: string,
+  serverId: string
 ): Promise<{
   prompts: unknown[];
   check: ServerDoctorCheck;
@@ -406,7 +423,7 @@ async function collectPrompts(
 
 async function collectResourceTemplates(
   manager: MCPClientManager,
-  serverId: string,
+  serverId: string
 ): Promise<{
   resourceTemplates: unknown[];
   check: ServerDoctorCheck;
@@ -418,7 +435,7 @@ async function collectResourceTemplates(
     return {
       resourceTemplates,
       check: okCheck(
-        describeCount(resourceTemplates.length, "resource template"),
+        describeCount(resourceTemplates.length, "resource template")
       ),
     };
   } catch (error) {
@@ -462,13 +479,13 @@ function resolveProbeAccessToken(config: MCPServerConfig): string | undefined {
 }
 
 function resolveDoctorClientCapabilities(
-  config: MCPServerConfig,
+  config: MCPServerConfig
 ): Record<string, unknown> | undefined {
   return config.clientCapabilities ?? config.capabilities;
 }
 
 function extractHeaders(
-  headers: HeadersInit | undefined,
+  headers: HeadersInit | undefined
 ): Record<string, string> {
   if (!headers) {
     return {};
@@ -484,35 +501,35 @@ function extractHeaders(
 
   if (Array.isArray(headers)) {
     return Object.fromEntries(
-      headers.map(([key, value]) => [key, String(value)]),
+      headers.map(([key, value]) => [key, String(value)])
     );
   }
 
   return Object.fromEntries(
-    Object.entries(headers).map(([key, value]) => [key, String(value)]),
+    Object.entries(headers).map(([key, value]) => [key, String(value)])
   );
 }
 
 function summarizeProbeCheck(
   probe: ProbeMcpServerResult,
-  hasCredentials: boolean,
+  hasCredentials: boolean
 ): ServerDoctorCheck {
   switch (probe.status) {
     case "ready":
       return okCheck(
         `HTTP initialize probe succeeded via ${
           probe.transport.selected ?? "unknown transport"
-        }.`,
+        }.`
       );
     case "oauth_required":
       return hasCredentials
         ? okCheck(
-            "Unauthenticated probe requires OAuth; continuing with provided credentials.",
+            "Unauthenticated probe requires OAuth; continuing with provided credentials."
           )
         : errorCheck("Server requires OAuth before it can be connected.");
     case "reachable":
       return errorCheck(
-        "HTTP endpoint was reachable, but the initialize probe did not complete successfully.",
+        "HTTP endpoint was reachable, but the initialize probe did not complete successfully."
       );
     case "error":
       return errorCheck(probe.error ?? "HTTP probe failed.");
@@ -524,9 +541,12 @@ function summarizeProbeCheck(
 }
 
 function deriveDoctorStatus<TTarget>(
-  result: ServerDoctorResult<TTarget>,
+  result: ServerDoctorResult<TTarget>
 ): ServerDoctorResult<TTarget>["status"] {
-  if (result.probe?.status === "oauth_required" && result.connection.status === "skipped") {
+  if (
+    result.probe?.status === "oauth_required" &&
+    result.connection.status === "skipped"
+  ) {
     return "oauth_required";
   }
 
@@ -540,7 +560,10 @@ function deriveDoctorStatus<TTarget>(
 }
 
 function hasConnectionCredentials(config: MCPServerConfig): boolean {
-  return "url" in config && Boolean(resolveProbeAccessToken(config) || config.refreshToken);
+  return (
+    "url" in config &&
+    Boolean(resolveProbeAccessToken(config) || config.refreshToken)
+  );
 }
 
 function okCheck(detail: string): ServerDoctorCheck {
@@ -559,12 +582,13 @@ function describeCount(count: number, label: string): string {
   return `${count} ${label}${count === 1 ? "" : "s"} discovered.`;
 }
 
-function isUnsupportedMethodError(
-  error: unknown,
-  method: string,
-): boolean {
+function isUnsupportedMethodError(error: unknown, method: string): boolean {
   const message =
-    error instanceof Error ? error.message : typeof error === "string" ? error : "";
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "";
   const lower = message.toLowerCase();
   const normalizedMethod = method.toLowerCase();
 

--- a/sdk/src/server-probe.ts
+++ b/sdk/src/server-probe.ts
@@ -1,6 +1,10 @@
 import { discoverOAuthProtectedResourceMetadata } from "@modelcontextprotocol/sdk/client/auth.js";
 import { buildResourceMetadataUrl } from "./oauth/state-machines/shared/urls.js";
-import { type RetryPolicy, retryWithPolicy } from "./retry.js";
+import {
+  type RetryPolicy,
+  isRetryableTransientError,
+  retryWithPolicy,
+} from "./retry.js";
 import type { OAuthProtocolVersion } from "./oauth/state-machines/types.js";
 
 export interface ProbeMcpServerConfig {
@@ -840,7 +844,7 @@ async function probeMcpServerOnce(
       protocolVersion,
       attempts,
       error instanceof Error ? error.message : String(error),
-      true
+      isRetryableTransientError(error)
     );
   }
 }

--- a/sdk/src/server-probe.ts
+++ b/sdk/src/server-probe.ts
@@ -1,8 +1,7 @@
 import { discoverOAuthProtectedResourceMetadata } from "@modelcontextprotocol/sdk/client/auth.js";
 import { buildResourceMetadataUrl } from "./oauth/state-machines/shared/urls.js";
-import type {
-  OAuthProtocolVersion,
-} from "./oauth/state-machines/types.js";
+import { type RetryPolicy, retryWithPolicy } from "./retry.js";
+import type { OAuthProtocolVersion } from "./oauth/state-machines/types.js";
 
 export interface ProbeMcpServerConfig {
   url: string;
@@ -14,6 +13,7 @@ export interface ProbeMcpServerConfig {
   fetchFn?: typeof fetch;
   clientName?: string;
   clientVersion?: string;
+  retryPolicy?: RetryPolicy;
 }
 
 export interface ProbeHttpAttempt {
@@ -82,13 +82,13 @@ type ParsedHttpResponse = {
 };
 
 function normalizeProtocolVersion(
-  value: OAuthProtocolVersion | undefined,
+  value: OAuthProtocolVersion | undefined
 ): OAuthProtocolVersion {
   return value ?? "2025-11-25";
 }
 
 function normalizeHeaders(
-  headers: Headers | HeadersInit | undefined,
+  headers: Headers | HeadersInit | undefined
 ): Record<string, string> {
   if (!headers) {
     return {};
@@ -102,25 +102,25 @@ function normalizeHeaders(
 }
 
 function lowerCaseHeaders(
-  headers: Record<string, string>,
+  headers: Record<string, string>
 ): Record<string, string> {
   return Object.fromEntries(
-    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value])
   );
 }
 
 function removeAuthorizationHeader(
-  headers: Record<string, string>,
+  headers: Record<string, string>
 ): Record<string, string> {
   return Object.fromEntries(
     Object.entries(headers).filter(
-      ([key]) => key.toLowerCase() !== "authorization",
-    ),
+      ([key]) => key.toLowerCase() !== "authorization"
+    )
   );
 }
 
 function initializeProtocolVersion(
-  protocolVersion: OAuthProtocolVersion,
+  protocolVersion: OAuthProtocolVersion
 ): string {
   switch (protocolVersion) {
     case "2025-03-26":
@@ -137,7 +137,7 @@ function initializeProtocolVersion(
 
 function buildAuthServerMetadataUrls(
   protocolVersion: OAuthProtocolVersion,
-  authServerUrl: string,
+  authServerUrl: string
 ): string[] {
   const url = new URL(authServerUrl);
   const urls: string[] = [];
@@ -145,10 +145,13 @@ function buildAuthServerMetadataUrls(
   if (protocolVersion === "2025-11-25") {
     if (url.pathname === "/" || url.pathname === "") {
       urls.push(
-        new URL("/.well-known/oauth-authorization-server", url.origin).toString(),
+        new URL(
+          "/.well-known/oauth-authorization-server",
+          url.origin
+        ).toString()
       );
       urls.push(
-        new URL("/.well-known/openid-configuration", url.origin).toString(),
+        new URL("/.well-known/openid-configuration", url.origin).toString()
       );
       return urls;
     }
@@ -159,27 +162,27 @@ function buildAuthServerMetadataUrls(
     urls.push(
       new URL(
         `/.well-known/oauth-authorization-server${pathname}`,
-        url.origin,
-      ).toString(),
+        url.origin
+      ).toString()
     );
     urls.push(
       new URL(
         `/.well-known/openid-configuration${pathname}`,
-        url.origin,
-      ).toString(),
+        url.origin
+      ).toString()
     );
     urls.push(
       new URL(
         `${pathname}/.well-known/openid-configuration`,
-        url.origin,
-      ).toString(),
+        url.origin
+      ).toString()
     );
     return urls;
   }
 
   if (url.pathname === "/" || url.pathname === "") {
     urls.push(
-      new URL("/.well-known/oauth-authorization-server", url.origin).toString(),
+      new URL("/.well-known/oauth-authorization-server", url.origin).toString()
     );
     return urls;
   }
@@ -190,11 +193,11 @@ function buildAuthServerMetadataUrls(
   urls.push(
     new URL(
       `/.well-known/oauth-authorization-server${pathname}`,
-      url.origin,
-    ).toString(),
+      url.origin
+    ).toString()
   );
   urls.push(
-    new URL("/.well-known/oauth-authorization-server", url.origin).toString(),
+    new URL("/.well-known/oauth-authorization-server", url.origin).toString()
   );
   return urls;
 }
@@ -213,7 +216,7 @@ function parseJsonBody(text: string): unknown {
 }
 
 async function readResponseBody(
-  response: Response,
+  response: Response
 ): Promise<{ body?: unknown; contentType?: string }> {
   const contentType = response.headers.get("content-type") ?? undefined;
   if (contentType?.includes("text/event-stream")) {
@@ -241,31 +244,59 @@ async function readResponseBody(
   };
 }
 
-function withTimeoutSignal(
-  timeoutMs: number | undefined,
-): { signal: AbortSignal | undefined; cleanup: () => void } {
+function withTimeoutSignal(timeoutMs: number | undefined): {
+  signal: AbortSignal | undefined;
+  cleanup: () => void;
+  didTimeout: () => boolean;
+} {
   if (!timeoutMs) {
     return {
       signal: undefined,
       cleanup: () => undefined,
+      didTimeout: () => false,
     };
   }
 
   const controller = new AbortController();
-  const handle = setTimeout(() => controller.abort(), timeoutMs);
+  let timedOut = false;
+  const handle = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
   return {
     signal: controller.signal,
     cleanup: () => clearTimeout(handle),
+    didTimeout: () => timedOut,
   };
+}
+
+function createTimeoutError(
+  timeoutMs: number | undefined
+): Error & { code: string } {
+  const error = new Error(
+    timeoutMs ? `Request timed out after ${timeoutMs}ms` : "Request timed out"
+  ) as Error & { code: string };
+  error.name = "TimeoutError";
+  error.code = "ETIMEDOUT";
+  return error;
+}
+
+function isRetryableProbeStatus(status: number): boolean {
+  return (
+    status === 408 ||
+    status === 425 ||
+    status === 429 ||
+    (status >= 500 && status !== 501)
+  );
 }
 
 async function performRequest(
   fetchFn: typeof fetch,
   attempt: ProbeHttpAttempt,
-  timeoutMs: number | undefined,
+  timeoutMs: number | undefined
 ): Promise<ParsedHttpResponse> {
   const startedAt = Date.now();
-  const { signal, cleanup } = withTimeoutSignal(timeoutMs);
+  const { signal, cleanup, didTimeout } = withTimeoutSignal(timeoutMs);
 
   try {
     const response = await fetchFn(attempt.request.url, {
@@ -298,10 +329,13 @@ async function performRequest(
       contentType: parsedBody.contentType,
     };
   } catch (error) {
+    const requestError = didTimeout() ? createTimeoutError(timeoutMs) : error;
     attempt.durationMs = Date.now() - startedAt;
     attempt.error =
-      error instanceof Error ? error.message : String(error);
-    throw error;
+      requestError instanceof Error
+        ? requestError.message
+        : String(requestError);
+    throw requestError;
   } finally {
     cleanup();
   }
@@ -309,7 +343,7 @@ async function performRequest(
 
 function extractInitializeInfo(
   body: unknown,
-  contentType: string | undefined,
+  contentType: string | undefined
 ): ProbeInitializeInfo | undefined {
   if (
     body &&
@@ -317,13 +351,15 @@ function extractInitializeInfo(
     "result" in body &&
     (body as { result?: { protocolVersion?: unknown } }).result?.protocolVersion
   ) {
-    const result = (body as {
-      result: {
-        protocolVersion?: string;
-        serverInfo?: unknown;
-        capabilities?: unknown;
-      };
-    }).result;
+    const result = (
+      body as {
+        result: {
+          protocolVersion?: string;
+          serverInfo?: unknown;
+          capabilities?: unknown;
+        };
+      }
+    ).result;
 
     return {
       protocolVersion: result.protocolVersion,
@@ -342,7 +378,9 @@ function extractInitializeInfo(
   return undefined;
 }
 
-function buildInitializeRequest(config: ProbeMcpServerConfig): ProbeHttpAttempt {
+function buildInitializeRequest(
+  config: ProbeMcpServerConfig
+): ProbeHttpAttempt {
   const protocolVersion = normalizeProtocolVersion(config.protocolVersion);
   const accessToken = config.accessToken?.trim();
   const headers: Record<string, string> = {
@@ -403,11 +441,9 @@ function buildSseProbeRequest(config: ProbeMcpServerConfig): ProbeHttpAttempt {
 
 function resolveRegistrationStrategies(
   protocolVersion: OAuthProtocolVersion,
-  authServerMetadata: Record<string, unknown> | undefined,
+  authServerMetadata: Record<string, unknown> | undefined
 ): Array<"preregistered" | "dcr" | "cimd"> {
-  const strategies: Array<"preregistered" | "dcr" | "cimd"> = [
-    "preregistered",
-  ];
+  const strategies: Array<"preregistered" | "dcr" | "cimd"> = ["preregistered"];
 
   if (authServerMetadata?.registration_endpoint) {
     strategies.push("dcr");
@@ -427,14 +463,14 @@ async function discoverOAuthDetails(
   config: ProbeMcpServerConfig,
   attempts: ProbeHttpAttempt[],
   optional: boolean,
-  wwwAuthenticateHeader: string | undefined,
+  wwwAuthenticateHeader: string | undefined
 ): Promise<ProbeOAuthDetails> {
   const protocolVersion = normalizeProtocolVersion(config.protocolVersion);
   const metadataHeaders = removeAuthorizationHeader(
-    normalizeHeaders(config.headers),
+    normalizeHeaders(config.headers)
   );
   const resourceMetadataUrlFromHeader = wwwAuthenticateHeader?.match(
-    /resource_metadata="([^"]+)"/,
+    /resource_metadata="([^"]+)"/
   )?.[1];
   const resourceMetadataUrl =
     resourceMetadataUrlFromHeader ?? buildResourceMetadataUrl(config.url);
@@ -457,17 +493,18 @@ async function discoverOAuthDetails(
         ...metadataHeaders,
         ...normalizeHeaders(init.headers),
       };
-      const attempt = resourceMetadataAttempt.request.url === url
-        ? resourceMetadataAttempt
-        : {
-            name: "resource_metadata" as const,
-            request: {
-              method: init.method ?? "GET",
-              url,
-              headers: mergedHeaders,
-            },
-            durationMs: 0,
-          };
+      const attempt =
+        resourceMetadataAttempt.request.url === url
+          ? resourceMetadataAttempt
+          : {
+              name: "resource_metadata" as const,
+              request: {
+                method: init.method ?? "GET",
+                url,
+                headers: mergedHeaders,
+              },
+              durationMs: 0,
+            };
       if (attempt !== resourceMetadataAttempt) {
         attempts.push(attempt);
       } else {
@@ -478,7 +515,7 @@ async function discoverOAuthDetails(
       const response = await performRequest(
         config.fetchFn ?? fetch,
         attempt,
-        config.timeoutMs,
+        config.timeoutMs
       );
 
       return new Response(
@@ -487,7 +524,7 @@ async function discoverOAuthDetails(
           status: response.status,
           statusText: response.statusText,
           headers: response.headers,
-        },
+        }
       );
     };
 
@@ -496,18 +533,16 @@ async function discoverOAuthDetails(
       resourceMetadataUrlFromHeader
         ? { resourceMetadataUrl: resourceMetadataUrlFromHeader }
         : undefined,
-      loggingFetch,
+      loggingFetch
     );
 
     const authorizationServerUrl =
       metadata.authorization_servers?.[0] ?? config.url;
     const authMetadataUrls = buildAuthServerMetadataUrls(
       protocolVersion,
-      authorizationServerUrl,
+      authorizationServerUrl
     );
-    let authorizationServerMetadata:
-      | Record<string, unknown>
-      | undefined;
+    let authorizationServerMetadata: Record<string, unknown> | undefined;
     let authorizationServerMetadataUrl: string | undefined;
     let lastAuthError: string | undefined;
 
@@ -527,7 +562,7 @@ async function discoverOAuthDetails(
         const response = await performRequest(
           config.fetchFn ?? fetch,
           authAttempt,
-          config.timeoutMs,
+          config.timeoutMs
         );
 
         if (
@@ -536,7 +571,10 @@ async function discoverOAuthDetails(
           response.body &&
           typeof response.body === "object"
         ) {
-          authorizationServerMetadata = response.body as Record<string, unknown>;
+          authorizationServerMetadata = response.body as Record<
+            string,
+            unknown
+          >;
           authorizationServerMetadataUrl = authMetadataUrl;
           lastAuthError = undefined;
           break;
@@ -544,8 +582,7 @@ async function discoverOAuthDetails(
 
         lastAuthError = `HTTP ${response.status} ${response.statusText}`;
       } catch (error) {
-        lastAuthError =
-          error instanceof Error ? error.message : String(error);
+        lastAuthError = error instanceof Error ? error.message : String(error);
       }
     }
 
@@ -559,7 +596,7 @@ async function discoverOAuthDetails(
       authorizationServerMetadata,
       registrationStrategies: resolveRegistrationStrategies(
         protocolVersion,
-        authorizationServerMetadata,
+        authorizationServerMetadata
       ),
       ...(lastAuthError ? { discoveryError: lastAuthError } : {}),
     };
@@ -579,8 +616,7 @@ async function discoverOAuthDetails(
       wwwAuthenticate: wwwAuthenticateHeader,
       resourceMetadataUrl,
       registrationStrategies: ["preregistered"],
-      discoveryError:
-        error instanceof Error ? error.message : String(error),
+      discoveryError: error instanceof Error ? error.message : String(error),
     };
   }
 }
@@ -593,11 +629,38 @@ function baseOAuthResult(): ProbeOAuthDetails {
   };
 }
 
-export async function probeMcpServer(
+type ProbeMcpServerAttemptResult = {
+  result: ProbeMcpServerResult;
+  retryable: boolean;
+};
+
+function createProbeErrorResult(
   config: ProbeMcpServerConfig,
-): Promise<ProbeMcpServerResult> {
+  protocolVersion: OAuthProtocolVersion,
+  attempts: ProbeHttpAttempt[],
+  error: string,
+  retryable: boolean
+): ProbeMcpServerAttemptResult {
+  return {
+    result: {
+      url: config.url,
+      protocolVersion,
+      status: "error",
+      transport: {
+        attempts,
+      },
+      oauth: baseOAuthResult(),
+      error,
+    },
+    retryable,
+  };
+}
+
+async function probeMcpServerOnce(
+  config: ProbeMcpServerConfig,
+  attempts: ProbeHttpAttempt[]
+): Promise<ProbeMcpServerAttemptResult> {
   const protocolVersion = normalizeProtocolVersion(config.protocolVersion);
-  const attempts: ProbeHttpAttempt[] = [];
   const initializeAttempt = buildInitializeRequest(config);
   attempts.push(initializeAttempt);
 
@@ -605,82 +668,17 @@ export async function probeMcpServer(
     const initializeResponse = await performRequest(
       config.fetchFn ?? fetch,
       initializeAttempt,
-      config.timeoutMs,
+      config.timeoutMs
     );
     const initializeInfo = extractInitializeInfo(
       initializeResponse.body,
-      initializeResponse.contentType,
+      initializeResponse.contentType
     );
-    const wwwAuthenticate =
-      initializeResponse.headers["www-authenticate"];
+    const wwwAuthenticate = initializeResponse.headers["www-authenticate"];
 
     if (initializeResponse.status === 401) {
       return {
-        url: config.url,
-        protocolVersion,
-        status: "oauth_required",
-        transport: {
-          attempts,
-        },
-        oauth: await discoverOAuthDetails(
-          config,
-          attempts,
-          false,
-          wwwAuthenticate,
-        ),
-      };
-    }
-
-    if (initializeResponse.status >= 200 && initializeResponse.status < 300) {
-      const oauth = config.accessToken
-        ? baseOAuthResult()
-        : await discoverOAuthDetails(config, attempts, true, undefined)
-            .catch(() => baseOAuthResult());
-      if (initializeInfo) {
-        return {
-          url: config.url,
-          protocolVersion,
-          status: "ready",
-          transport: {
-            selected: "streamable-http",
-            attempts,
-          },
-          initialize: initializeInfo,
-          oauth,
-        };
-      }
-
-      return {
-        url: config.url,
-        protocolVersion,
-        status: "reachable",
-        transport: {
-          attempts,
-        },
-        oauth,
-        error: "Server responded to initialize but did not return a recognizable MCP initialize result.",
-      };
-    }
-
-    const shouldTrySse =
-      initializeResponse.status === 404 ||
-      initializeResponse.status === 405 ||
-      initializeResponse.status === 406 ||
-      initializeResponse.status === 415 ||
-      initializeResponse.status === 501;
-
-    if (shouldTrySse) {
-      const sseAttempt = buildSseProbeRequest(config);
-      attempts.push(sseAttempt);
-      const sseResponse = await performRequest(
-        config.fetchFn ?? fetch,
-        sseAttempt,
-        config.timeoutMs,
-      );
-      const wwwAuthenticateSse = sseResponse.headers["www-authenticate"];
-
-      if (sseResponse.status === 401) {
-        return {
+        result: {
           url: config.url,
           protocolVersion,
           status: "oauth_required",
@@ -691,8 +689,96 @@ export async function probeMcpServer(
             config,
             attempts,
             false,
-            wwwAuthenticateSse,
+            wwwAuthenticate
           ),
+        },
+        retryable: false,
+      };
+    }
+
+    if (initializeResponse.status >= 200 && initializeResponse.status < 300) {
+      const oauth = config.accessToken
+        ? baseOAuthResult()
+        : await discoverOAuthDetails(config, attempts, true, undefined).catch(
+            () => baseOAuthResult()
+          );
+      if (initializeInfo) {
+        return {
+          result: {
+            url: config.url,
+            protocolVersion,
+            status: "ready",
+            transport: {
+              selected: "streamable-http",
+              attempts,
+            },
+            initialize: initializeInfo,
+            oauth,
+          },
+          retryable: false,
+        };
+      }
+
+      return {
+        result: {
+          url: config.url,
+          protocolVersion,
+          status: "reachable",
+          transport: {
+            attempts,
+          },
+          oauth,
+          error:
+            "Server responded to initialize but did not return a recognizable MCP initialize result.",
+        },
+        retryable: false,
+      };
+    }
+
+    const shouldTrySse =
+      initializeResponse.status === 404 ||
+      initializeResponse.status === 405 ||
+      initializeResponse.status === 406 ||
+      initializeResponse.status === 415 ||
+      initializeResponse.status === 501;
+
+    if (!shouldTrySse && isRetryableProbeStatus(initializeResponse.status)) {
+      return createProbeErrorResult(
+        config,
+        protocolVersion,
+        attempts,
+        `Server responded with HTTP ${initializeResponse.status} ${initializeResponse.statusText} to the initialize probe.`,
+        true
+      );
+    }
+
+    if (shouldTrySse) {
+      const sseAttempt = buildSseProbeRequest(config);
+      attempts.push(sseAttempt);
+      const sseResponse = await performRequest(
+        config.fetchFn ?? fetch,
+        sseAttempt,
+        config.timeoutMs
+      );
+      const wwwAuthenticateSse = sseResponse.headers["www-authenticate"];
+
+      if (sseResponse.status === 401) {
+        return {
+          result: {
+            url: config.url,
+            protocolVersion,
+            status: "oauth_required",
+            transport: {
+              attempts,
+            },
+            oauth: await discoverOAuthDetails(
+              config,
+              attempts,
+              false,
+              wwwAuthenticateSse
+            ),
+          },
+          retryable: false,
         };
       }
 
@@ -703,44 +789,70 @@ export async function probeMcpServer(
       ) {
         const oauth = config.accessToken
           ? baseOAuthResult()
-          : await discoverOAuthDetails(config, attempts, true, undefined)
-              .catch(() => baseOAuthResult());
+          : await discoverOAuthDetails(config, attempts, true, undefined).catch(
+              () => baseOAuthResult()
+            );
         return {
-          url: config.url,
-          protocolVersion,
-          status: "ready",
-          transport: {
-            selected: "sse",
-            attempts,
+          result: {
+            url: config.url,
+            protocolVersion,
+            status: "ready",
+            transport: {
+              selected: "sse",
+              attempts,
+            },
+            initialize: {
+              contentType: sseResponse.contentType,
+            },
+            oauth,
           },
-          initialize: {
-            contentType: sseResponse.contentType,
-          },
-          oauth,
+          retryable: false,
         };
+      }
+
+      if (isRetryableProbeStatus(sseResponse.status)) {
+        return createProbeErrorResult(
+          config,
+          protocolVersion,
+          attempts,
+          `Server responded with HTTP ${sseResponse.status} ${sseResponse.statusText} to the SSE probe.`,
+          true
+        );
       }
     }
 
     return {
-      url: config.url,
-      protocolVersion,
-      status: "reachable",
-      transport: {
-        attempts,
+      result: {
+        url: config.url,
+        protocolVersion,
+        status: "reachable",
+        transport: {
+          attempts,
+        },
+        oauth: baseOAuthResult(),
+        error: `Server responded with HTTP ${initializeResponse.status} ${initializeResponse.statusText} to the initialize probe.`,
       },
-      oauth: baseOAuthResult(),
-      error: `Server responded with HTTP ${initializeResponse.status} ${initializeResponse.statusText} to the initialize probe.`,
+      retryable: false,
     };
   } catch (error) {
-    return {
-      url: config.url,
+    return createProbeErrorResult(
+      config,
       protocolVersion,
-      status: "error",
-      transport: {
-        attempts,
-      },
-      oauth: baseOAuthResult(),
-      error: error instanceof Error ? error.message : String(error),
-    };
+      attempts,
+      error instanceof Error ? error.message : String(error),
+      true
+    );
   }
+}
+
+export async function probeMcpServer(
+  config: ProbeMcpServerConfig
+): Promise<ProbeMcpServerResult> {
+  const attempts: ProbeHttpAttempt[] = [];
+  const outcome = await retryWithPolicy({
+    policy: config.retryPolicy,
+    operation: () => probeMcpServerOnce(config, attempts),
+    shouldRetryResult: (result) => result.retryable,
+  });
+  return outcome.result;
 }

--- a/sdk/tests/MCPClientManager.test.ts
+++ b/sdk/tests/MCPClientManager.test.ts
@@ -958,6 +958,38 @@ describe("MCPClientManager", () => {
       expect(connectSpy).toHaveBeenCalledTimes(1);
     });
 
+    it("stops direct connect retries after disconnect during backoff", async () => {
+      manager = new MCPClientManager(
+        {},
+        {
+          lazyConnect: true,
+          retryPolicy: {
+            retries: 1,
+            retryDelayMs: 25,
+          },
+        }
+      );
+
+      const connectSpy = jest
+        .spyOn(manager as any, "connectToServerOnce")
+        .mockRejectedValue(
+          Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })
+        );
+
+      const promise = manager.connectToServer("retry-disconnect", {
+        command: "node",
+        args: ["server.js"],
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      await manager.disconnectServer("retry-disconnect");
+
+      await expect(promise).rejects.toThrow(
+        'MCP server "retry-disconnect" was disconnected.'
+      );
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+    });
+
     it("retries read operations as a single ensureConnected plus RPC budget", async () => {
       const fakeClient = {
         listTools: jest
@@ -1055,6 +1087,44 @@ describe("MCPClientManager", () => {
 
       await expect(promise).rejects.toThrow("Request cancelled");
       expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(fakeClient.listTools).toHaveBeenCalledTimes(1);
+    });
+
+    it("stops read retries after disconnect during backoff", async () => {
+      manager = new MCPClientManager(
+        {},
+        {
+          lazyConnect: true,
+          retryPolicy: {
+            retries: 1,
+            retryDelayMs: 25,
+          },
+        }
+      );
+
+      const fakeClient = {
+        listTools: jest
+          .fn()
+          .mockRejectedValueOnce(
+            Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })
+          )
+          .mockResolvedValueOnce({ tools: [] }),
+      };
+
+      seedRegisteredServer(manager, "retry-read-disconnect", {
+        command: "node",
+        args: ["server.js"],
+      });
+      seedLiveState(manager, "retry-read-disconnect", { client: fakeClient });
+
+      const promise = manager.listTools("retry-read-disconnect");
+
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      await manager.disconnectServer("retry-read-disconnect");
+
+      await expect(promise).rejects.toThrow(
+        'MCP server "retry-read-disconnect" was disconnected.'
+      );
       expect(fakeClient.listTools).toHaveBeenCalledTimes(1);
     });
 

--- a/sdk/tests/MCPClientManager.test.ts
+++ b/sdk/tests/MCPClientManager.test.ts
@@ -1,4 +1,4 @@
-import { MCPClientManager } from "../src/mcp-client-manager";
+import { MCPAuthError, MCPClientManager } from "../src/mcp-client-manager";
 import {
   startMockHttpServer,
   startMockStreamableHttpServer,
@@ -6,6 +6,26 @@ import {
   MOCK_RESOURCES,
   MOCK_PROMPTS,
 } from "./mock-servers";
+
+function seedRegisteredServer(
+  manager: MCPClientManager,
+  serverId: string,
+  config: Record<string, unknown>,
+  timeout = 1000
+): void {
+  (manager as any).registeredServers.set(serverId, {
+    config,
+    timeout,
+  });
+}
+
+function seedLiveState(
+  manager: MCPClientManager,
+  serverId: string,
+  liveState: Record<string, unknown>
+): void {
+  (manager as any).liveClientStates.set(serverId, liveState);
+}
 
 describe("MCPClientManager", () => {
   describe("constructor", () => {
@@ -91,6 +111,8 @@ describe("MCPClientManager", () => {
       await manager.disconnectServer("everything");
 
       expect(manager.getConnectionStatus("everything")).toBe("disconnected");
+      expect(manager.hasServer("everything")).toBe(true);
+      expect(manager.listServers()).toContain("everything");
     }, 30000);
   });
 
@@ -204,17 +226,14 @@ describe("MCPClientManager", () => {
 
     it("skips non-replayable HTTP configs with custom request state", () => {
       const replayManager = new MCPClientManager();
-      (replayManager as any).clientStates.set("custom-http", {
-        config: {
-          url: "https://example.com/mcp",
-          accessToken: "at_test",
-          requestInit: {
-            headers: {
-              "X-Custom": "1",
-            },
+      seedRegisteredServer(replayManager, "custom-http", {
+        url: "https://example.com/mcp",
+        accessToken: "at_test",
+        requestInit: {
+          headers: {
+            "X-Custom": "1",
           },
         },
-        timeout: 1000,
       });
 
       expect(replayManager.getServerReplayConfigs()).toEqual([]);
@@ -222,15 +241,12 @@ describe("MCPClientManager", () => {
 
     it("returns tokenless replay configs for public HTTP servers with empty headers", () => {
       const replayManager = new MCPClientManager();
-      (replayManager as any).clientStates.set("public-http", {
-        config: {
-          url: "https://example.com/mcp",
-          requestInit: {
-            headers: {},
-          },
-          preferSSE: true,
+      seedRegisteredServer(replayManager, "public-http", {
+        url: "https://example.com/mcp",
+        requestInit: {
+          headers: {},
         },
-        timeout: 1000,
+        preferSSE: true,
       });
 
       expect(replayManager.getServerReplayConfigs()).toEqual([
@@ -244,12 +260,9 @@ describe("MCPClientManager", () => {
 
     it("skips stdio servers when building replay configs", () => {
       const replayManager = new MCPClientManager();
-      (replayManager as any).clientStates.set("stdio-server", {
-        config: {
-          command: "node",
-          args: ["server.js"],
-        },
-        timeout: 1000,
+      seedRegisteredServer(replayManager, "stdio-server", {
+        command: "node",
+        args: ["server.js"],
       });
 
       expect(replayManager.getServerReplayConfigs()).toEqual([]);
@@ -257,14 +270,11 @@ describe("MCPClientManager", () => {
 
     it("skips HTTP configs with unsupported requestInit options", () => {
       const replayManager = new MCPClientManager();
-      (replayManager as any).clientStates.set("request-http", {
-        config: {
-          url: "https://example.com/mcp",
-          requestInit: {
-            method: "POST",
-          },
+      seedRegisteredServer(replayManager, "request-http", {
+        url: "https://example.com/mcp",
+        requestInit: {
+          method: "POST",
         },
-        timeout: 1000,
       });
 
       expect(replayManager.getServerReplayConfigs()).toEqual([]);
@@ -272,16 +282,13 @@ describe("MCPClientManager", () => {
 
     it("extracts bearer auth from requestInit headers for replay configs", () => {
       const replayManager = new MCPClientManager();
-      (replayManager as any).clientStates.set("header-http", {
-        config: {
-          url: "https://example.com/mcp",
-          requestInit: {
-            headers: {
-              Authorization: "Bearer at_from_headers",
-            },
+      seedRegisteredServer(replayManager, "header-http", {
+        url: "https://example.com/mcp",
+        requestInit: {
+          headers: {
+            Authorization: "Bearer at_from_headers",
           },
         },
-        timeout: 1000,
       });
 
       expect(replayManager.getServerReplayConfigs()).toEqual([
@@ -584,6 +591,173 @@ describe("MCPClientManager", () => {
         })
       ).rejects.toThrow('MCP server "duplicate" is already connected');
     }, 30000);
+
+    it("preserves server inventory after a failed connect attempt", async () => {
+      await expect(
+        manager.connectToServer("failing-http", {
+          url: "http://127.0.0.1:9/mcp",
+          timeout: 250,
+        })
+      ).rejects.toThrow();
+
+      expect(manager.hasServer("failing-http")).toBe(true);
+      expect(manager.listServers()).toContain("failing-http");
+      expect(manager.getConnectionStatus("failing-http")).toBe("disconnected");
+    });
+  });
+
+  describe("retry support", () => {
+    let manager: MCPClientManager;
+
+    beforeEach(() => {
+      manager = new MCPClientManager(
+        {},
+        {
+          lazyConnect: true,
+          retryPolicy: {
+            retries: 1,
+            retryDelayMs: 0,
+          },
+        }
+      );
+    });
+
+    afterEach(async () => {
+      jest.restoreAllMocks();
+      await manager.disconnectAllServers();
+    });
+
+    it("retries direct connectToServer calls on transient failures", async () => {
+      const client = {} as any;
+      const connectSpy = jest
+        .spyOn(manager as any, "connectToServerOnce")
+        .mockRejectedValueOnce(
+          Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })
+        )
+        .mockResolvedValueOnce(client);
+
+      await expect(
+        manager.connectToServer("retry-connect", {
+          command: "node",
+          args: ["server.js"],
+        })
+      ).resolves.toBe(client);
+
+      expect(connectSpy).toHaveBeenCalledTimes(2);
+      expect(manager.hasServer("retry-connect")).toBe(true);
+    });
+
+    it("does not retry direct connectToServer calls on auth errors", async () => {
+      const connectSpy = jest
+        .spyOn(manager as any, "connectToServerOnce")
+        .mockRejectedValue(new MCPAuthError("Unauthorized", 401));
+
+      await expect(
+        manager.connectToServer("auth-connect", {
+          command: "node",
+          args: ["server.js"],
+        })
+      ).rejects.toThrow("Unauthorized");
+
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries read operations as a single ensureConnected plus RPC budget", async () => {
+      const fakeClient = {
+        listTools: jest
+          .fn()
+          .mockRejectedValueOnce(
+            Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })
+          )
+          .mockResolvedValueOnce({ tools: [] }),
+      };
+
+      seedRegisteredServer(manager, "retry-read", {
+        command: "node",
+        args: ["server.js"],
+      });
+
+      const connectSpy = jest
+        .spyOn(manager as any, "connectToServerOnce")
+        .mockImplementation(async (serverId: string) => {
+          seedLiveState(manager, serverId, { client: fakeClient });
+          return fakeClient as any;
+        });
+
+      await expect(manager.listTools("retry-read")).resolves.toEqual({
+        tools: [],
+      });
+
+      expect(connectSpy).toHaveBeenCalledTimes(2);
+      expect(fakeClient.listTools).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps executeTool single-shot by default", async () => {
+      const fakeClient = {
+        callTool: jest
+          .fn()
+          .mockRejectedValue(
+            Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })
+          ),
+      };
+
+      seedRegisteredServer(manager, "tool-default", {
+        command: "node",
+        args: ["server.js"],
+      });
+      seedLiveState(manager, "tool-default", { client: fakeClient });
+
+      await expect(
+        manager.executeTool("tool-default", "echo", { message: "hello" })
+      ).rejects.toThrow("timed out");
+
+      expect(fakeClient.callTool).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries executeTool only when explicit retry options are provided", async () => {
+      const fakeClient = {
+        callTool: jest
+          .fn()
+          .mockRejectedValueOnce(
+            Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })
+          )
+          .mockResolvedValueOnce({
+            content: [{ type: "text", text: "ok" }],
+          }),
+      };
+
+      seedRegisteredServer(manager, "tool-retry", {
+        command: "node",
+        args: ["server.js"],
+      });
+      seedLiveState(manager, "tool-retry", { client: fakeClient });
+
+      const connectSpy = jest
+        .spyOn(manager as any, "connectToServerOnce")
+        .mockImplementation(async (serverId: string) => {
+          seedLiveState(manager, serverId, { client: fakeClient });
+          return fakeClient as any;
+        });
+
+      await expect(
+        manager.executeTool(
+          "tool-retry",
+          "echo",
+          { message: "hello" },
+          {
+            retry: {
+              retries: 1,
+              retryDelayMs: 0,
+            },
+          }
+        )
+      ).resolves.toEqual({
+        content: [{ type: "text", text: "ok" }],
+      });
+
+      expect(fakeClient.callTool).toHaveBeenCalledTimes(2);
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("multiple servers", () => {
@@ -669,6 +843,11 @@ describe("MCPClientManager", () => {
 
       expect(manager.getConnectionStatus("disc-a")).toBe("disconnected");
       expect(manager.getConnectionStatus("disc-b")).toBe("disconnected");
+      expect(manager.hasServer("disc-a")).toBe(true);
+      expect(manager.hasServer("disc-b")).toBe(true);
+      expect(manager.listServers()).toEqual(
+        expect.arrayContaining(["disc-a", "disc-b"])
+      );
     }, 30000);
   });
 });

--- a/sdk/tests/MCPClientManager.test.ts
+++ b/sdk/tests/MCPClientManager.test.ts
@@ -551,6 +551,24 @@ describe("MCPClientManager", () => {
         },
       ]);
     });
+
+    it("preserves refresh-token replay configs without live client state", () => {
+      const replayManager = new MCPClientManager();
+      seedRegisteredServer(replayManager, "oauth-refresh", {
+        url: "https://example.com/mcp",
+        refreshToken: "rt_test",
+        clientId: "client_id",
+      });
+
+      expect(replayManager.getServerReplayConfigs()).toEqual([
+        {
+          serverId: "oauth-refresh",
+          url: "https://example.com/mcp",
+          refreshToken: "rt_test",
+          clientId: "client_id",
+        },
+      ]);
+    });
   });
 
   describe("HTTP server (streamable)", () => {
@@ -899,6 +917,32 @@ describe("MCPClientManager", () => {
       expect(manager.hasServer("retry-connect")).toBe(true);
     });
 
+    it("shares the retried direct connect promise across concurrent callers", async () => {
+      const client = {} as any;
+      const connectSpy = jest
+        .spyOn(manager as any, "connectToServerOnce")
+        .mockRejectedValueOnce(
+          Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })
+        )
+        .mockResolvedValueOnce(client);
+
+      const first = manager.connectToServer("retry-shared", {
+        command: "node",
+        args: ["server.js"],
+      });
+      const second = manager.connectToServer("retry-shared", {
+        command: "node",
+        args: ["server.js"],
+      });
+
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        client,
+        client,
+      ]);
+
+      expect(connectSpy).toHaveBeenCalledTimes(2);
+    });
+
     it("does not retry direct connectToServer calls on auth errors", async () => {
       const connectSpy = jest
         .spyOn(manager as any, "connectToServerOnce")
@@ -940,8 +984,34 @@ describe("MCPClientManager", () => {
         tools: [],
       });
 
-      expect(connectSpy).toHaveBeenCalledTimes(2);
+      expect(connectSpy).toHaveBeenCalledTimes(1);
       expect(fakeClient.listTools).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries read operations without tearing down an existing live session", async () => {
+      const fakeClient = {
+        listTools: jest
+          .fn()
+          .mockRejectedValueOnce(
+            Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })
+          )
+          .mockResolvedValueOnce({ tools: [] }),
+      };
+
+      seedRegisteredServer(manager, "retry-live-read", {
+        command: "node",
+        args: ["server.js"],
+      });
+      seedLiveState(manager, "retry-live-read", { client: fakeClient });
+
+      const destroySpy = jest.spyOn(manager as any, "destroyLiveState");
+
+      await expect(manager.listTools("retry-live-read")).resolves.toEqual({
+        tools: [],
+      });
+
+      expect(fakeClient.listTools).toHaveBeenCalledTimes(2);
+      expect(destroySpy).not.toHaveBeenCalled();
     });
 
     it("does not retry read operations after the caller aborts during backoff", async () => {
@@ -1052,7 +1122,7 @@ describe("MCPClientManager", () => {
       });
 
       expect(fakeClient.callTool).toHaveBeenCalledTimes(2);
-      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(connectSpy).not.toHaveBeenCalled();
     });
 
     it("does not retry executeTool after the caller aborts during backoff", async () => {
@@ -1103,6 +1173,42 @@ describe("MCPClientManager", () => {
       await expect(promise).rejects.toThrow("Tool request cancelled");
       expect(fakeClient.callTool).toHaveBeenCalledTimes(1);
       expect(connectSpy).toHaveBeenCalledTimes(0);
+    });
+
+    it("treats legacy request options with a task field as request options", async () => {
+      const fakeClient = {
+        callTool: jest.fn().mockResolvedValue({
+          content: [{ type: "text", text: "ok" }],
+        }),
+        request: jest.fn(),
+      };
+
+      seedRegisteredServer(manager, "legacy-request-options", {
+        command: "node",
+        args: ["server.js"],
+      });
+      seedLiveState(manager, "legacy-request-options", { client: fakeClient });
+
+      await expect(
+        manager.executeTool(
+          "legacy-request-options",
+          "echo",
+          { message: "hello" },
+          {
+            timeout: 500,
+            task: { ttl: 60 },
+          } as any
+        )
+      ).resolves.toEqual({
+        content: [{ type: "text", text: "ok" }],
+      });
+
+      expect(fakeClient.callTool).toHaveBeenCalledTimes(1);
+      expect(fakeClient.callTool.mock.calls[0]?.[2]).toMatchObject({
+        timeout: 500,
+        task: { ttl: 60 },
+      });
+      expect(fakeClient.request).not.toHaveBeenCalled();
     });
   });
 

--- a/sdk/tests/MCPClientManager.test.ts
+++ b/sdk/tests/MCPClientManager.test.ts
@@ -944,6 +944,50 @@ describe("MCPClientManager", () => {
       expect(fakeClient.listTools).toHaveBeenCalledTimes(2);
     });
 
+    it("does not retry read operations after the caller aborts during backoff", async () => {
+      manager = new MCPClientManager(
+        {},
+        {
+          lazyConnect: true,
+          retryPolicy: {
+            retries: 1,
+            retryDelayMs: 25,
+          },
+        }
+      );
+
+      const abortController = new AbortController();
+      const fakeClient = {
+        listTools: jest
+          .fn()
+          .mockRejectedValueOnce(
+            Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })
+          )
+          .mockResolvedValueOnce({ tools: [] }),
+      };
+
+      seedRegisteredServer(manager, "retry-read-abort", {
+        command: "node",
+        args: ["server.js"],
+      });
+
+      const connectSpy = jest
+        .spyOn(manager as any, "connectToServerOnce")
+        .mockImplementation(async (serverId: string) => {
+          seedLiveState(manager, serverId, { client: fakeClient });
+          return fakeClient as any;
+        });
+
+      const promise = manager.listTools("retry-read-abort", undefined, {
+        signal: abortController.signal,
+      });
+      setTimeout(() => abortController.abort(new Error("Request cancelled")), 5);
+
+      await expect(promise).rejects.toThrow("Request cancelled");
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(fakeClient.listTools).toHaveBeenCalledTimes(1);
+    });
+
     it("keeps executeTool single-shot by default", async () => {
       const fakeClient = {
         callTool: jest
@@ -1009,6 +1053,56 @@ describe("MCPClientManager", () => {
 
       expect(fakeClient.callTool).toHaveBeenCalledTimes(2);
       expect(connectSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry executeTool after the caller aborts during backoff", async () => {
+      const abortController = new AbortController();
+      const fakeClient = {
+        callTool: jest
+          .fn()
+          .mockRejectedValueOnce(
+            Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })
+          )
+          .mockResolvedValueOnce({
+            content: [{ type: "text", text: "ok" }],
+          }),
+      };
+
+      seedRegisteredServer(manager, "tool-retry-abort", {
+        command: "node",
+        args: ["server.js"],
+      });
+      seedLiveState(manager, "tool-retry-abort", { client: fakeClient });
+
+      const connectSpy = jest
+        .spyOn(manager as any, "connectToServerOnce")
+        .mockImplementation(async (serverId: string) => {
+          seedLiveState(manager, serverId, { client: fakeClient });
+          return fakeClient as any;
+        });
+
+      const promise = manager.executeTool(
+        "tool-retry-abort",
+        "echo",
+        { message: "hello" },
+        {
+          request: {
+            signal: abortController.signal,
+          },
+          retry: {
+            retries: 1,
+            retryDelayMs: 25,
+          },
+        }
+      );
+      setTimeout(
+        () => abortController.abort(new Error("Tool request cancelled")),
+        5
+      );
+
+      await expect(promise).rejects.toThrow("Tool request cancelled");
+      expect(fakeClient.callTool).toHaveBeenCalledTimes(1);
+      expect(connectSpy).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/sdk/tests/MCPClientManager.test.ts
+++ b/sdk/tests/MCPClientManager.test.ts
@@ -1020,6 +1020,29 @@ describe("MCPClientManager", () => {
       expect(fakeClient.listTools).toHaveBeenCalledTimes(2);
     });
 
+    it("retries pingServer using the original transport error details", async () => {
+      const fakeClient = {
+        ping: jest
+          .fn()
+          .mockRejectedValueOnce(
+            Object.assign(new Error("server unavailable"), {
+              statusCode: 503,
+            })
+          )
+          .mockResolvedValueOnce(undefined),
+      };
+
+      seedRegisteredServer(manager, "retry-ping", {
+        command: "node",
+        args: ["server.js"],
+      });
+      seedLiveState(manager, "retry-ping", { client: fakeClient });
+
+      await expect(manager.pingServer("retry-ping")).resolves.toBeUndefined();
+
+      expect(fakeClient.ping).toHaveBeenCalledTimes(2);
+    });
+
     it("retries read operations without tearing down an existing live session", async () => {
       const fakeClient = {
         listTools: jest
@@ -1044,6 +1067,43 @@ describe("MCPClientManager", () => {
 
       expect(fakeClient.listTools).toHaveBeenCalledTimes(2);
       expect(destroySpy).not.toHaveBeenCalled();
+    });
+
+    it("cancels a connect when the client closes during the handshake", async () => {
+      const fakeTransport = {
+        close: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const connectViaStdioSpy = jest
+        .spyOn(manager as any, "connectViaStdio")
+        .mockImplementation(
+          async (
+            _serverId: string,
+            client: { onclose?: () => void },
+            _config: unknown,
+            _timeout: number,
+            _state: unknown
+          ) => {
+            client.onclose?.();
+            return fakeTransport as any;
+          }
+        );
+
+      await expect(
+        manager.connectToServer("closed-during-connect", {
+          command: "node",
+          args: ["server.js"],
+        })
+      ).rejects.toThrow(
+        'MCP server "closed-during-connect" connection was cancelled.'
+      );
+
+      expect(connectViaStdioSpy).toHaveBeenCalledTimes(1);
+      expect(fakeTransport.close).toHaveBeenCalled();
+      expect(manager.getConnectionStatus("closed-during-connect")).toBe(
+        "disconnected"
+      );
+      expect(manager.getClient("closed-during-connect")).toBeUndefined();
     });
 
     it("does not retry read operations after the caller aborts during backoff", async () => {

--- a/sdk/tests/refresh-token-auth.test.ts
+++ b/sdk/tests/refresh-token-auth.test.ts
@@ -456,7 +456,7 @@ describe("MCPClientManager refreshToken integration", () => {
       const result = await manager.listTools("oauth-server");
       expect(result.tools.length).toBe(MOCK_TOOLS.length);
       expect(
-        (manager as any).liveClientStates.get("oauth-server").authProvider
+        (manager as any).liveClientStates.get("oauth-server")?.authProvider
       ).toBeInstanceOf(RefreshTokenOAuthProvider);
       expect(manager.getServerReplayConfigs()).toEqual([
         expect.objectContaining({

--- a/sdk/tests/refresh-token-auth.test.ts
+++ b/sdk/tests/refresh-token-auth.test.ts
@@ -456,7 +456,7 @@ describe("MCPClientManager refreshToken integration", () => {
       const result = await manager.listTools("oauth-server");
       expect(result.tools.length).toBe(MOCK_TOOLS.length);
       expect(
-        (manager as any).clientStates.get("oauth-server").authProvider
+        (manager as any).liveClientStates.get("oauth-server").authProvider
       ).toBeInstanceOf(RefreshTokenOAuthProvider);
       expect(manager.getServerReplayConfigs()).toEqual([
         expect.objectContaining({
@@ -469,7 +469,10 @@ describe("MCPClientManager refreshToken integration", () => {
       expect(manager.getServerReplayConfigs()[0]?.accessToken).toBeUndefined();
 
       await manager.disconnectAllServers();
-      expect((manager as any).clientStates.get("oauth-server")).toBeUndefined();
+      expect(
+        (manager as any).liveClientStates.get("oauth-server")
+      ).toBeUndefined();
+      expect(manager.hasServer("oauth-server")).toBe(true);
     } finally {
       await stop();
     }

--- a/sdk/tests/retry.test.ts
+++ b/sdk/tests/retry.test.ts
@@ -1,0 +1,27 @@
+import { retryWithPolicy } from "../src/retry";
+
+describe("retryWithPolicy", () => {
+  it("does not start another attempt when aborted during backoff", async () => {
+    const abortController = new AbortController();
+    const operation = jest
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error("timed out"), { code: "ETIMEDOUT" })
+      );
+
+    const promise = retryWithPolicy({
+      policy: {
+        retries: 1,
+        retryDelayMs: 25,
+      },
+      signal: abortController.signal,
+      operation: async () => operation(),
+      shouldRetryError: () => true,
+    });
+
+    setTimeout(() => abortController.abort(new Error("Request cancelled")), 5);
+
+    await expect(promise).rejects.toThrow("Request cancelled");
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/sdk/tests/retry.test.ts
+++ b/sdk/tests/retry.test.ts
@@ -1,6 +1,14 @@
-import { retryWithPolicy } from "../src/retry";
+import { isRetryableTransientError, retryWithPolicy } from "../src/retry";
 
 describe("retryWithPolicy", () => {
+  it("does not treat HTTP 501 as retryable", () => {
+    expect(
+      isRetryableTransientError(
+        Object.assign(new Error("HTTP 501"), { statusCode: 501 })
+      )
+    ).toBe(false);
+  });
+
   it("does not start another attempt when aborted during backoff", async () => {
     const abortController = new AbortController();
     const operation = jest

--- a/sdk/tests/server-doctor.test.ts
+++ b/sdk/tests/server-doctor.test.ts
@@ -5,7 +5,7 @@ import {
 import type { ProbeMcpServerResult } from "../src/server-probe";
 
 function createProbeResult(
-  overrides: Partial<ProbeMcpServerResult> = {},
+  overrides: Partial<ProbeMcpServerResult> = {}
 ): ProbeMcpServerResult {
   return {
     url: "https://example.com/mcp",
@@ -33,15 +33,21 @@ function createMockManager(overrides: Record<string, any> = {}) {
   return {
     listTools: jest
       .fn()
-      .mockResolvedValue({ tools: [{ name: "echo", description: "Echo input" }] }),
+      .mockResolvedValue({
+        tools: [{ name: "echo", description: "Echo input" }],
+      }),
     getAllToolsMetadata: jest.fn().mockReturnValue({ echo: { title: "Echo" } }),
     listResources: jest
       .fn()
       .mockResolvedValue({ resources: [{ uri: "file://note", name: "Note" }] }),
-    listPrompts: jest.fn().mockResolvedValue({ prompts: [{ name: "summarize" }] }),
+    listPrompts: jest
+      .fn()
+      .mockResolvedValue({ prompts: [{ name: "summarize" }] }),
     listResourceTemplates: jest
       .fn()
-      .mockResolvedValue({ resourceTemplates: [{ uriTemplate: "note://{id}" }] }),
+      .mockResolvedValue({
+        resourceTemplates: [{ uriTemplate: "note://{id}" }],
+      }),
     getInitializationInfo: jest.fn().mockReturnValue({
       protocolVersion: "2025-11-25",
       serverInfo: { name: "Example" },
@@ -63,7 +69,11 @@ describe("collectConnectedServerDoctorState", () => {
       protocolVersion: "2025-11-25",
       serverInfo: { name: "Example" },
     });
-    expect(result.capabilities).toEqual({ tools: {}, resources: {}, prompts: {} });
+    expect(result.capabilities).toEqual({
+      tools: {},
+      resources: {},
+      prompts: {},
+    });
     expect(result.tools).toEqual([{ name: "echo", description: "Echo input" }]);
     expect(result.toolsMetadata).toEqual({ echo: { title: "Echo" } });
     expect(result.resources).toEqual([{ uri: "file://note", name: "Note" }]);
@@ -104,7 +114,7 @@ describe("runServerDoctor", () => {
       {
         probeServer: jest.fn().mockResolvedValue(createProbeResult()),
         withManager: async (_config, fn) => fn(createMockManager(), "srv"),
-      },
+      }
     );
 
     expect(result.status).toBe("ready");
@@ -142,13 +152,13 @@ describe("runServerDoctor", () => {
                 "https://example.com/.well-known/oauth-protected-resource",
               registrationStrategies: ["dcr", "cimd"],
             },
-          }),
+          })
         ),
         withManager: async () => {
           connected = true;
           throw new Error("should not connect");
         },
-      },
+      }
     );
 
     expect(result.status).toBe("oauth_required");
@@ -184,18 +194,55 @@ describe("runServerDoctor", () => {
               optional: false,
               registrationStrategies: ["dcr"],
             },
-          }),
+          })
         ),
         withManager: async (_config, fn) => {
           connected = true;
           return fn(createMockManager(), "srv");
         },
-      },
+      }
     );
 
     expect(connected).toBe(true);
     expect(result.status).toBe("ready");
     expect(result.checks.probe.status).toBe("ok");
-    expect(result.checks.probe.detail).toMatch(/continuing with provided credentials/i);
+    expect(result.checks.probe.detail).toMatch(
+      /continuing with provided credentials/i
+    );
+  });
+
+  it("passes retry policy through probe and ephemeral manager dependencies", async () => {
+    const retryPolicy = {
+      retries: 2,
+      retryDelayMs: 250,
+    };
+    const probeServer = jest.fn().mockResolvedValue(createProbeResult());
+    const withManager = jest.fn(
+      async (_config, fn, options?: { retryPolicy?: typeof retryPolicy }) => {
+        expect(options?.retryPolicy).toEqual(retryPolicy);
+        return fn(createMockManager(), "srv");
+      }
+    );
+
+    await runServerDoctor(
+      {
+        config: {
+          url: "https://example.com/mcp",
+          timeout: 4_000,
+        },
+        target: { label: "https://example.com/mcp" },
+        timeout: 4_000,
+        retryPolicy,
+      },
+      {
+        probeServer,
+        withManager,
+      }
+    );
+
+    expect(probeServer).toHaveBeenCalledWith(
+      expect.objectContaining({ retryPolicy })
+    );
+    expect(withManager).toHaveBeenCalled();
   });
 });

--- a/sdk/tests/server-probe.test.ts
+++ b/sdk/tests/server-probe.test.ts
@@ -220,4 +220,24 @@ describe("probeMcpServer", () => {
     expect(result.status).toBe("reachable");
     expect(result.transport.attempts).toHaveLength(2);
   });
+
+  it("does not retry deterministic probe failures", async () => {
+    const serverUrl = "https://mcp.example.com/mcp";
+    const fetchFn: typeof fetch = jest.fn(async () => {
+      throw new TypeError("malformed request");
+    }) as typeof fetch;
+
+    const result = await probeMcpServer({
+      url: serverUrl,
+      fetchFn,
+      retryPolicy: {
+        retries: 3,
+        retryDelayMs: 0,
+      },
+    });
+
+    expect(result.status).toBe("error");
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(result.transport.attempts).toHaveLength(1);
+  });
 });

--- a/sdk/tests/server-probe.test.ts
+++ b/sdk/tests/server-probe.test.ts
@@ -3,7 +3,7 @@ import { probeMcpServer } from "../src/server-probe.js";
 function jsonResponse(
   body: unknown,
   status = 200,
-  headers: Record<string, string> = {},
+  headers: Record<string, string> = {}
 ): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -109,12 +109,115 @@ describe("probeMcpServer", () => {
     expect(result.oauth.required).toBe(true);
     expect(result.oauth.resourceMetadataUrl).toBe(resourceMetadataUrl);
     expect(result.oauth.authorizationServerMetadataUrl).toBe(
-      `${authServerUrl}/.well-known/oauth-authorization-server`,
+      `${authServerUrl}/.well-known/oauth-authorization-server`
     );
     expect(result.oauth.registrationStrategies).toEqual([
       "preregistered",
       "dcr",
       "cimd",
     ]);
+  });
+
+  it("retries transient probe failures and preserves attempts across retries", async () => {
+    const serverUrl = "https://mcp.example.com/mcp";
+    let initializeCalls = 0;
+
+    const fetchFn: typeof fetch = jest.fn(async (input) => {
+      const url = String(input);
+
+      if (url !== serverUrl) {
+        return jsonResponse({ error: "unexpected" }, 404);
+      }
+
+      initializeCalls += 1;
+      if (initializeCalls === 1) {
+        throw Object.assign(new Error("connect timeout"), {
+          code: "ETIMEDOUT",
+        });
+      }
+
+      return jsonResponse(
+        {
+          jsonrpc: "2.0",
+          result: {
+            protocolVersion: "2025-11-25",
+            serverInfo: { name: "mock-server", version: "1.0.0" },
+            capabilities: { tools: {} },
+          },
+        },
+        200,
+        {}
+      );
+    }) as typeof fetch;
+
+    const result = await probeMcpServer({
+      url: serverUrl,
+      accessToken: "token",
+      fetchFn,
+      retryPolicy: {
+        retries: 1,
+        retryDelayMs: 0,
+      },
+    });
+
+    expect(result.status).toBe("ready");
+    expect(initializeCalls).toBe(2);
+    expect(result.transport.attempts).toHaveLength(2);
+    expect(result.transport.attempts[0]?.error).toContain("timeout");
+  });
+
+  it("does not retry oauth_required responses", async () => {
+    const serverUrl = "https://mcp.example.com/mcp";
+    let initializeCalls = 0;
+
+    const fetchFn: typeof fetch = jest.fn(async (input) => {
+      const url = String(input);
+
+      if (url === serverUrl) {
+        initializeCalls += 1;
+        return new Response(null, { status: 401 });
+      }
+
+      return jsonResponse({ error: "missing" }, 404);
+    }) as typeof fetch;
+
+    const result = await probeMcpServer({
+      url: serverUrl,
+      fetchFn,
+      retryPolicy: {
+        retries: 3,
+        retryDelayMs: 0,
+      },
+    });
+
+    expect(result.status).toBe("oauth_required");
+    expect(initializeCalls).toBe(1);
+  });
+
+  it("does not retry reachable transport mismatch responses", async () => {
+    const serverUrl = "https://mcp.example.com/mcp";
+
+    const fetchFn: typeof fetch = jest.fn(async (_input, init) => {
+      if ((init?.method ?? "GET") === "POST") {
+        return jsonResponse({ error: "unsupported" }, 415);
+      }
+
+      return jsonResponse({ error: "missing" }, 404, {
+        "Content-Type": "application/json",
+      });
+    }) as typeof fetch;
+
+    const result = await probeMcpServer({
+      url: serverUrl,
+      accessToken: "token",
+      fetchFn,
+      retryPolicy: {
+        retries: 3,
+        retryDelayMs: 0,
+      },
+    });
+
+    expect(result.status).toBe("reachable");
+    expect(result.transport.attempts).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- add configurable retry policy support across the CLI, SDK probe/doctor flows, and server auth/chat routes
- expose and document retry behavior in the SDK, including MCP client manager updates and probe error handling
- fix hosted inspector state issues that could crash organization views and tighten workspace/server state handling
- polish multi-model chat selector behavior and extend coverage for retry, OAuth, workspace, and UI flows

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Broad changes to core connectivity paths (SDK `MCPClientManager`, CLI server operations, and inspector server) add retry behavior and restructure connection state, which could affect connection lifecycle, error handling, and cleanup across many commands/routes.
> 
> **Overview**
> Adds an SDK-level **retry policy** (`RetryPolicy`, `retryWithPolicy`, transient-error classification) and wires it through `probeMcpServer`, `runServerDoctor`, and `withEphemeralClient`/CLI ephemeral flows.
> 
> Refactors `MCPClientManager` to separate **registered server inventory** from **live connection state**, adds abort-aware retry orchestration for `connectToServer` and read/diagnostic operations (`listTools/resources/prompts`, `readResource`, `pingServer`, tasks), and introduces an explicit `ExecuteToolRequest` shape so tool calls stay *single-shot by default* but can opt into per-call retries.
> 
> Extends the CLI with `--retries`/`--retry-delay-ms` options (validated via `parseRetryPolicy`) across multiple commands and passes `retryPolicy` into SDK calls; updates the hosted inspector to use a centralized `INSPECTOR_MCP_RETRY_POLICY` and improves connection-failure cleanup by removing failed servers. Tests and docs are updated to cover the new retry behavior and revised manager state semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b026ca703e2ef13eeea245438686c89991b4d945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->