### PR TITLE
full screen display mode regressed

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -220,7 +220,7 @@ export function ChatTabV2({
     [],
   );
   const [elicitationLoading, setElicitationLoading] = useState(false);
-  const [isWidgetFullscreen, setIsWidgetFullscreen] = useState(false);
+  const [, setIsWidgetFullscreen] = useState(false);
   const [broadcastRequest, setBroadcastRequest] =
     useState<BroadcastChatTurnRequest | null>(null);
   const [stopBroadcastRequestId, setStopBroadcastRequestId] = useState(0);
@@ -1945,12 +1945,7 @@ export function ChatTabV2({
           minSize={40}
           className="min-w-0"
         >
-          <div
-            className="flex flex-col bg-background h-full min-h-0 overflow-hidden"
-            style={{
-              transform: isWidgetFullscreen ? "none" : "translateZ(0)",
-            }}
-          >
+          <div className="flex flex-col bg-background h-full min-h-0 overflow-hidden">
             {isMultiModelLayoutMode ? (
               <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
                 {showTopTraceViewTabs ? (
@@ -2215,6 +2210,7 @@ export function ChatTabV2({
                                       setTraceViewMode("chat");
                                       setRevealedInChat(true);
                                     }}
+                                    onFullscreenChange={setIsWidgetFullscreen}
                                     rawGrowWithContent
                                     rawRequestPayloadHistory={{
                                       entries: requestPayloadHistory,
@@ -2252,6 +2248,7 @@ export function ChatTabV2({
                                   setTraceViewMode("chat");
                                   setRevealedInChat(true);
                                 }}
+                                onFullscreenChange={setIsWidgetFullscreen}
                                 rawRequestPayloadHistory={{
                                   entries: requestPayloadHistory,
                                   hasUiMessages: !isThreadEmpty,

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/TranscriptThread.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/TranscriptThread.test.tsx
@@ -263,6 +263,19 @@ describe("TranscriptThread", () => {
     expect(screen.getByTestId("message-assistant-1")).toBeInTheDocument();
   });
 
+  it("disables content-visibility containment while a fullscreen widget is active", () => {
+    render(
+      <TranscriptThread {...defaultProps} fullscreenWidgetId="tool-call-1" />,
+    );
+
+    const wrapper = document.querySelector(
+      '[data-message-id="assistant-1"]',
+    ) as HTMLElement | null;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.style.contentVisibility).toBe("");
+    expect(wrapper?.style.containIntrinsicSize).toBe("");
+  });
+
   it("uses the resolved Claude variant to attach an animated footer to the latest assistant message", () => {
     render(
       <TranscriptThread

--- a/mcpjam-inspector/client/src/components/chat-v2/multi-model-chat-card.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/multi-model-chat-card.tsx
@@ -105,7 +105,7 @@ export function MultiModelChatCard({
       };
     }[]
   >([]);
-  const [isWidgetFullscreen, setIsWidgetFullscreen] = useState(false);
+  const [, setIsWidgetFullscreen] = useState(false);
   const [traceViewMode, setTraceViewMode] = useState<ChatTraceViewMode>("chat");
   const [revealedInChat, setRevealedInChat] = useState(false);
   const lastBroadcastRequestIdRef = useRef<number | null>(null);
@@ -506,12 +506,7 @@ export function MultiModelChatCard({
         showComparisonChrome={showComparisonChrome}
       />
 
-      <div
-        className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
-        style={{
-          transform: isWidgetFullscreen ? "none" : "translateZ(0)",
-        }}
-      >
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         {errorMessage ? (
           <div className="px-3 pt-3">
             <ErrorBox
@@ -547,6 +542,9 @@ export function MultiModelChatCard({
                     hideToolbar
                     fillContent
                     onRevealNavigateToChat={navigateTraceRevealToChat}
+                  displayMode={displayMode}
+                  onDisplayModeChange={onDisplayModeChange}
+                    onFullscreenChange={setIsWidgetFullscreen}
                     rawGrowWithContent
                     rawRequestPayloadHistory={{
                       entries: requestPayloadHistory,
@@ -572,10 +570,13 @@ export function MultiModelChatCard({
                   fillContent
                   onRevealNavigateToChat={navigateTraceRevealToChat}
                   sendFollowUpMessage={handleSendFollowUp}
+                  displayMode={displayMode}
+                  onDisplayModeChange={onDisplayModeChange}
                   enableFullscreenChatOverlay
                   fullscreenChatPlaceholder={placeholder}
                   fullscreenChatSendBlocked={fullscreenChatSendBlocked}
                   onFullscreenChatStop={stop}
+                  onFullscreenChange={setIsWidgetFullscreen}
                   onToolApprovalResponse={addToolApprovalResponse}
                   rawRequestPayloadHistory={{
                     entries: requestPayloadHistory,
@@ -606,6 +607,9 @@ export function MultiModelChatCard({
                     hideToolbar
                     fillContent
                     onRevealNavigateToChat={navigateTraceRevealToChat}
+                    displayMode={displayMode}
+                    onDisplayModeChange={onDisplayModeChange}
+                    onFullscreenChange={setIsWidgetFullscreen}
                     rawRequestPayloadHistory={{
                       entries: requestPayloadHistory,
                       hasUiMessages: !isThreadEmpty,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/transcript-thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/transcript-thread.tsx
@@ -209,7 +209,9 @@ export function TranscriptThread({
     [highlightedMessageIds],
   );
   const shouldUseContentVisibility =
-    focusMessageId === null && highlightedMessageIds.length === 0;
+    focusMessageId === null &&
+    highlightedMessageIds.length === 0 &&
+    fullscreenWidgetId === null;
 
   useEffect(() => {
     if (!focusMessageId) {

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
@@ -100,6 +100,8 @@ interface TraceViewerProps {
   fullscreenChatDisabled?: boolean;
   fullscreenChatSendBlocked?: boolean;
   onFullscreenChatStop?: () => void;
+  /** Forwarded to `Thread` so ancestors can drop GPU transforms that trap `position: fixed` widgets. */
+  onFullscreenChange?: (isFullscreen: boolean) => void;
   /**
    * When set (live chat), Raw tab shows the resolved model request payload
    * (`system`, `tools`, `messages`) instead of the diagnostic trace blob.
@@ -184,9 +186,18 @@ export function TraceViewer({
   fullscreenChatDisabled = false,
   fullscreenChatSendBlocked,
   onFullscreenChatStop,
+  onFullscreenChange,
   rawRequestPayloadHistory = null,
   rawGrowWithContent = false,
 }: TraceViewerProps) {
+  // Live shells pass send and/or onFullscreenChange; eval/recorded traces keep interactive=false.
+  // When interactive is false, PartSwitch does not forward onRequestFullscreen, so widget fullscreen
+  // cannot notify ancestors to clear transforms that trap position:fixed.
+  const threadInteractive =
+    interactive ||
+    sendFollowUpMessage !== NOOP ||
+    onFullscreenChange != null;
+
   const [viewMode, setViewMode] = useState<
     "timeline" | "chat" | "raw" | "tools"
   >("timeline");
@@ -592,6 +603,7 @@ export function TraceViewer({
                 fullscreenChatDisabled={fullscreenChatDisabled}
                 fullscreenChatSendBlocked={fullscreenChatSendBlocked}
                 onFullscreenChatStop={onFullscreenChatStop}
+                onFullscreenChange={onFullscreenChange}
                 selectedProtocolOverrideIfBothExists={
                   selectedProtocolOverrideIfBothExists
                 }
@@ -599,7 +611,7 @@ export function TraceViewer({
                 toolRenderOverrides={adaptedTrace.toolRenderOverrides}
                 showSaveViewButton={false}
                 minimalMode={true}
-                interactive={interactive}
+                interactive={threadInteractive}
                 reasoningDisplayMode="collapsed"
                 focusMessageId={transcriptNavigation.focusMessageId}
                 highlightedMessageIds={

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -1632,6 +1632,10 @@ export function PlaygroundMain({
                                   onRevealNavigateToChat={() =>
                                     setTraceViewMode("chat")
                                   }
+                                  sendFollowUpMessage={handleSendFollowUp}
+                                  displayMode={displayMode}
+                                  onDisplayModeChange={handleDisplayModeChange}
+                                  onFullscreenChange={setIsWidgetFullscreen}
                                   rawGrowWithContent
                                   rawRequestPayloadHistory={{
                                     entries: requestPayloadHistory,
@@ -1661,6 +1665,10 @@ export function PlaygroundMain({
                               onRevealNavigateToChat={() =>
                                 setTraceViewMode("chat")
                               }
+                              sendFollowUpMessage={handleSendFollowUp}
+                              displayMode={displayMode}
+                              onDisplayModeChange={handleDisplayModeChange}
+                              onFullscreenChange={setIsWidgetFullscreen}
                               rawRequestPayloadHistory={{
                                 entries: requestPayloadHistory,
                                 hasUiMessages: !isThreadEmpty,
@@ -1723,7 +1731,6 @@ export function PlaygroundMain({
                           ? "100%"
                           : deviceConfig.height,
                       maxHeight: "100%",
-                      transform: isWidgetFullscreen ? "none" : "translateZ(0)",
                       backgroundColor: showPostConnectGuide
                         ? undefined
                         : hostBackgroundColor,

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -21,6 +21,7 @@ vi.mock("framer-motion", async (importOriginal) => {
 const mockThread = vi.fn();
 const mockFullscreenChatOverlay = vi.fn();
 const mockMultiModelPlaygroundCard = vi.fn();
+const mockTraceViewer = vi.fn();
 
 // Mock lucide-react icons
 vi.mock("lucide-react", () => ({
@@ -305,19 +306,21 @@ vi.mock("@/components/chat-v2/error", () => ({
 }));
 
 vi.mock("@/components/evals/trace-viewer", () => ({
-  TraceViewer: ({
-    forcedViewMode,
-    trace,
-  }: {
+  TraceViewer: (props: {
     forcedViewMode?: "chat" | "timeline" | "raw";
     trace?: unknown;
-  }) => (
-    <div
-      data-testid="trace-viewer"
-      data-mode={forcedViewMode ?? "timeline"}
-      data-trace={JSON.stringify(trace ?? null)}
-    />
-  ),
+    displayMode?: "inline" | "pip" | "fullscreen";
+    onDisplayModeChange?: (mode: "inline" | "pip" | "fullscreen") => void;
+  }) => {
+    mockTraceViewer(props);
+    return (
+      <div
+        data-testid="trace-viewer"
+        data-mode={props.forcedViewMode ?? "timeline"}
+        data-trace={JSON.stringify(props.trace ?? null)}
+      />
+    );
+  },
 }));
 
 vi.mock("@/components/evals/trace-view-mode-tabs", () => {
@@ -971,6 +974,25 @@ describe("PlaygroundMain", () => {
         screen.getByTestId("playground-trace-diagnostics"),
       ).toBeInTheDocument();
       expect(screen.getByTestId("thread")).toBeInTheDocument();
+    });
+
+    it("passes controlled display mode props into live trace viewers", () => {
+      mockUseChatSession.messages = [
+        { id: "1", role: "user", parts: [{ type: "text", text: "Hello" }] },
+      ];
+      mockUseChatSession.traceViewsSupported = true;
+      mockUseChatSession.hasTraceSnapshot = true;
+      mockUseChatSession.hasLiveTimelineContent = true;
+      mockUseChatSession.liveTraceEnvelope = sampleLiveTraceEnvelope;
+
+      render(<PlaygroundMain {...defaultProps} enableTraceViews={true} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Trace" }));
+
+      expect(mockTraceViewer).toHaveBeenCalled();
+      const props = mockTraceViewer.mock.calls.at(-1)?.[0];
+      expect(props.displayMode).toBe("inline");
+      expect(props.onDisplayModeChange).toEqual(expect.any(Function));
     });
 
     it("prefers the streamed live trace over the prelude trace once a snapshot exists", async () => {

--- a/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
@@ -164,7 +164,7 @@ export function MultiModelPlaygroundCard({
   const [traceViewMode, setTraceViewMode] =
     useState<PlaygroundTraceViewMode>("chat");
   const [revealedInChat, setRevealedInChat] = useState(false);
-  const [isWidgetFullscreen, setIsWidgetFullscreen] = useState(false);
+  const [, setIsWidgetFullscreen] = useState(false);
   const [preludeTraceExecutions, setPreludeTraceExecutions] = useState<
     PreludeTraceExecution[]
   >([]);
@@ -565,12 +565,7 @@ export function MultiModelPlaygroundCard({
         showComparisonChrome={showComparisonChrome}
       />
 
-      <div
-        className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
-        style={{
-          transform: isWidgetFullscreen ? "none" : "translateZ(0)",
-        }}
-      >
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         {errorMessage ? (
           <div className="px-3 pt-3">
             <ErrorBox
@@ -615,6 +610,7 @@ export function MultiModelPlaygroundCard({
                   fullscreenChatPlaceholder="Message…"
                   fullscreenChatSendBlocked={fullscreenChatSendBlocked}
                   onFullscreenChatStop={stop}
+                  onFullscreenChange={setIsWidgetFullscreen}
                   onToolApprovalResponse={addToolApprovalResponse}
                   rawRequestPayloadHistory={{
                     entries: requestPayloadHistory,
@@ -641,6 +637,9 @@ export function MultiModelPlaygroundCard({
                   hideToolbar
                   fillContent
                   onRevealNavigateToChat={navigateTraceRevealToChat}
+                  displayMode={displayMode}
+                  onDisplayModeChange={onDisplayModeChange}
+                  onFullscreenChange={setIsWidgetFullscreen}
                   rawRequestPayloadHistory={{
                     entries: requestPayloadHistory,
                     hasUiMessages: !isThreadEmpty,


### PR DESCRIPTION
A “fullscreen” widget was using position: fixed, but some parent elements were accidentally creating a local positioning/containment context. So instead of being fixed to the browser/app viewport, it was being fixed to the chat card

Before:

<img width="1440" height="759" alt="Screenshot 2026-04-14 at 5 24 22 PM" src="https://github.com/user-attachments/assets/0baea259-9242-4259-8b1f-79dfa2851021" />

After:

<img width="1440" height="757" alt="Screenshot 2026-04-14 at 5 24 32 PM" src="https://github.com/user-attachments/assets/d8889ff9-1b35-4fc9-9e06-a5d8306ce630" />

