### PR TITLE
forgot to push nits :(

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/multi-model-chat-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/multi-model-chat-card.test.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { useState, type ComponentProps } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { UIMessage } from "ai";
 import { MultiModelChatCard } from "../multi-model-chat-card";
@@ -27,6 +27,8 @@ vi.mock("use-stick-to-bottom", () => {
 });
 
 const startChatWithMessages = vi.fn();
+const mockTraceViewer = vi.fn();
+const mockModelCompareCardHeader = vi.fn();
 
 const mockUseChatSession = {
   messages: [],
@@ -58,7 +60,27 @@ vi.mock("@/components/chat-v2/thread", () => ({
 }));
 
 vi.mock("@/components/evals/trace-viewer", () => ({
-  TraceViewer: () => <div data-testid="trace-viewer" />,
+  TraceViewer: (props: {
+    forcedViewMode?: "timeline" | "chat" | "raw" | "tools";
+    onRevealNavigateToChat?: () => void;
+    displayMode?: unknown;
+    onDisplayModeChange?: unknown;
+  }) => {
+    mockTraceViewer(props);
+    return (
+      <div data-testid="trace-viewer">
+        <div data-testid="trace-viewer-mode">
+          {props.forcedViewMode ?? "timeline"}
+        </div>
+        <button
+          type="button"
+          onClick={() => props.onRevealNavigateToChat?.()}
+        >
+          Reveal Trace Chat
+        </button>
+      </div>
+    );
+  },
 }));
 
 vi.mock("@/components/chat-v2/error", () => ({
@@ -77,9 +99,23 @@ vi.mock("@/components/chat-v2/shared/chat-helpers", async (importOriginal) => {
 });
 
 vi.mock("../model-compare-card-header", () => ({
-  ModelCompareCardHeader: ({ model }: { model: { name: string } }) => (
-    <div data-testid="compare-card-header">{model.name}</div>
-  ),
+  ModelCompareCardHeader: (props: {
+    model: { name: string };
+    onModeChange: (mode: "chat" | "timeline" | "raw") => void;
+  }) => {
+    mockModelCompareCardHeader(props);
+    return (
+      <div>
+        <div data-testid="compare-card-header">{props.model.name}</div>
+        <button type="button" onClick={() => props.onModeChange("raw")}>
+          Switch to Raw
+        </button>
+        <button type="button" onClick={() => props.onModeChange("timeline")}>
+          Switch to Timeline
+        </button>
+      </div>
+    );
+  },
 }));
 
 const model = {
@@ -135,11 +171,55 @@ const seedMessages: UIMessage[] = [
     role: "user",
     parts: [{ type: "text", text: "hello" }],
   },
+  {
+    id: "a1",
+    role: "assistant",
+    parts: [{ type: "text", text: "hi there" }],
+  },
 ];
+
+function renderCard(
+  overrides: Partial<ComponentProps<typeof MultiModelChatCard>> = {},
+) {
+  return render(
+    <MultiModelChatCard
+      model={model}
+      comparisonSummaries={[]}
+      selectedServers={[]}
+      selectedServerInstructions={{}}
+      broadcastRequest={null}
+      stopRequestId={0}
+      placeholder="Message"
+      reasoningDisplayMode="inline"
+      initialSystemPrompt=""
+      initialTemperature={0.7}
+      initialRequireToolApproval={false}
+      onSummaryChange={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
 
 describe("MultiModelChatCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseChatSession.messages = [];
+    mockUseChatSession.setMessages = vi.fn();
+    mockUseChatSession.sendMessage = vi.fn();
+    mockUseChatSession.stop = vi.fn();
+    mockUseChatSession.status = "ready";
+    mockUseChatSession.error = undefined;
+    mockUseChatSession.chatSessionId = "chat-session-1";
+    mockUseChatSession.toolsMetadata = {};
+    mockUseChatSession.toolServerMap = {};
+    mockUseChatSession.liveTraceEnvelope = null;
+    mockUseChatSession.requestPayloadHistory = [];
+    mockUseChatSession.hasTraceSnapshot = false;
+    mockUseChatSession.hasLiveTimelineContent = false;
+    mockUseChatSession.traceViewsSupported = true;
+    mockUseChatSession.isStreaming = false;
+    mockUseChatSession.addToolApprovalResponse = vi.fn();
+    mockUseChatSession.systemPrompt = "";
   });
 
   it("does not loop when parent passes inline summary handlers", () => {
@@ -260,5 +340,44 @@ describe("MultiModelChatCard", () => {
     await waitFor(() => {
       expect(mockUseChatSession.stop).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("does not pass display-mode props into raw and timeline compare trace viewers", () => {
+    mockUseChatSession.messages = seedMessages;
+    mockUseChatSession.hasLiveTimelineContent = true;
+
+    renderCard();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to Raw" }));
+
+    expect(screen.getByTestId("trace-viewer")).toBeInTheDocument();
+    expect(screen.getByTestId("trace-viewer-mode")).toHaveTextContent("raw");
+    expect(mockTraceViewer).toHaveBeenCalled();
+    let props = mockTraceViewer.mock.calls.at(-1)?.[0];
+    expect(props.displayMode).toBeUndefined();
+    expect(props.onDisplayModeChange).toBeUndefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to Timeline" }));
+
+    expect(screen.getByTestId("trace-viewer-mode")).toHaveTextContent(
+      "timeline",
+    );
+    props = mockTraceViewer.mock.calls.at(-1)?.[0];
+    expect(props.displayMode).toBeUndefined();
+    expect(props.onDisplayModeChange).toBeUndefined();
+  });
+
+  it("does not pass display-mode props into the revealed compare trace chat branch", () => {
+    mockUseChatSession.messages = seedMessages;
+
+    renderCard();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch to Raw" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reveal Trace Chat" }));
+
+    expect(screen.getByTestId("trace-viewer-mode")).toHaveTextContent("chat");
+    const props = mockTraceViewer.mock.calls.at(-1)?.[0];
+    expect(props.displayMode).toBeUndefined();
+    expect(props.onDisplayModeChange).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/multi-model-chat-card.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/multi-model-chat-card.tsx
@@ -542,8 +542,6 @@ export function MultiModelChatCard({
                     hideToolbar
                     fillContent
                     onRevealNavigateToChat={navigateTraceRevealToChat}
-                  displayMode={displayMode}
-                  onDisplayModeChange={onDisplayModeChange}
                     onFullscreenChange={setIsWidgetFullscreen}
                     rawGrowWithContent
                     rawRequestPayloadHistory={{
@@ -570,8 +568,6 @@ export function MultiModelChatCard({
                   fillContent
                   onRevealNavigateToChat={navigateTraceRevealToChat}
                   sendFollowUpMessage={handleSendFollowUp}
-                  displayMode={displayMode}
-                  onDisplayModeChange={onDisplayModeChange}
                   enableFullscreenChatOverlay
                   fullscreenChatPlaceholder={placeholder}
                   fullscreenChatSendBlocked={fullscreenChatSendBlocked}
@@ -607,8 +603,6 @@ export function MultiModelChatCard({
                     hideToolbar
                     fillContent
                     onRevealNavigateToChat={navigateTraceRevealToChat}
-                    displayMode={displayMode}
-                    onDisplayModeChange={onDisplayModeChange}
                     onFullscreenChange={setIsWidgetFullscreen}
                     rawRequestPayloadHistory={{
                       entries: requestPayloadHistory,

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer.test.tsx
@@ -1165,4 +1165,15 @@ describe("TraceViewer", () => {
     expect(lastCall.interactive).toBe(false);
     expect(lastCall.minimalMode).toBe(true);
   });
+
+  it("keeps trace chat read-only when only onFullscreenChange is provided", () => {
+    render(
+      <TraceViewer trace={toolTrace} onFullscreenChange={vi.fn()} />,
+    );
+    openChatTab();
+
+    const lastCall = mockMessageView.mock.calls[0][0];
+    expect(lastCall.interactive).toBe(false);
+    expect(lastCall.minimalMode).toBe(true);
+  });
 });

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
@@ -190,13 +190,8 @@ export function TraceViewer({
   rawRequestPayloadHistory = null,
   rawGrowWithContent = false,
 }: TraceViewerProps) {
-  // Live shells pass send and/or onFullscreenChange; eval/recorded traces keep interactive=false.
-  // When interactive is false, PartSwitch does not forward onRequestFullscreen, so widget fullscreen
-  // cannot notify ancestors to clear transforms that trap position:fixed.
-  const threadInteractive =
-    interactive ||
-    sendFollowUpMessage !== NOOP ||
-    onFullscreenChange != null;
+  // Only live chat shells should opt into the interactive widget path.
+  const threadInteractive = interactive || sendFollowUpMessage !== NOOP;
 
   const [viewMode, setViewMode] = useState<
     "timeline" | "chat" | "raw" | "tools"


### PR DESCRIPTION
follow up for #1800 

Removed invalid displayMode / onDisplayModeChange forwarding from compare-mode MultiModelChatCard trace viewers. Those values were not owned by the compare card and were only needed in the single-model surfaces.
Tightened TraceViewer interactivity so onFullscreenChange alone no longer enables the full interactive widget path. Trace chat stays read-only unless it is actually in an interactive/live-chat mode.
Added regression tests covering the compare trace branches and the read-only fullscreen callback case.

