### PR TITLE
[codex] Use durable hosted OAuth callbacks

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -300,9 +300,14 @@ export default function App() {
     isLoading: isWorkOsLoading,
   } = useAuth();
   const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
-  const [hostedOAuthHandling, setHostedOAuthHandling] = useState(() =>
-    HOSTED_MODE ? getHostedOAuthCallbackContext() !== null : false,
-  );
+  const [hostedOAuthHandling, setHostedOAuthHandling] = useState(() => {
+    if (!HOSTED_MODE) {
+      return false;
+    }
+
+    const callbackContext = getHostedOAuthCallbackContext();
+    return callbackContext != null && callbackContext.surface !== "workspace";
+  });
   const [exitedSharedChat, setExitedSharedChat] = useState(false);
   const [exitedSandboxChat, setExitedSandboxChat] = useState(false);
   const sharedPathToken = HOSTED_MODE ? getSharedPathTokenFromLocation() : null;
@@ -406,7 +411,10 @@ export default function App() {
   // Handle hosted OAuth callback: claim the callback before any hosted page renders.
   useEffect(() => {
     const callbackContext = getHostedOAuthCallbackContext();
-    if (!callbackContext || callbackContext.surface === "workspace") return;
+    if (!callbackContext || callbackContext.surface === "workspace") {
+      setHostedOAuthHandling(false);
+      return;
+    }
 
     const urlParams = new URLSearchParams(window.location.search);
     const code = urlParams.get("code");

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -155,7 +155,10 @@ import {
   sanitizeHostedOAuthErrorMessage,
   writeHostedOAuthResumeMarker,
 } from "./lib/hosted-oauth-resume";
-import { handleOAuthCallback } from "./lib/oauth/mcp-oauth";
+import {
+  completeHostedOAuthCallback,
+  handleOAuthCallback,
+} from "./lib/oauth/mcp-oauth";
 import { getEffectiveWorkspaceClientCapabilities } from "./lib/client-config";
 import { buildEvalsHash } from "./lib/evals-router";
 import { withTestingSurface } from "./lib/testing-surface";
@@ -403,7 +406,7 @@ export default function App() {
   // Handle hosted OAuth callback: claim the callback before any hosted page renders.
   useEffect(() => {
     const callbackContext = getHostedOAuthCallbackContext();
-    if (!callbackContext) return;
+    if (!callbackContext || callbackContext.surface === "workspace") return;
 
     const urlParams = new URLSearchParams(window.location.search);
     const code = urlParams.get("code");
@@ -438,7 +441,12 @@ export default function App() {
       return;
     }
 
-    handleOAuthCallback(code)
+    const completeCallback =
+      isAuthenticated
+        ? completeHostedOAuthCallback(callbackContext, code)
+        : handleOAuthCallback(code);
+
+    completeCallback
       .then((result) => {
         if (result.success) {
           finalizeHostedOAuth(null);
@@ -467,7 +475,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [isAuthenticated]);
 
   usePostHogIdentify();
 

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -450,6 +450,33 @@ describe("App hosted OAuth callback handling", () => {
     });
   });
 
+  it("does not keep the hosted loading screen for workspace OAuth callbacks", async () => {
+    clearHostedOAuthPendingState();
+    clearSandboxSession();
+    writeHostedOAuthPendingMarker({
+      surface: "workspace",
+      workspaceId: "ws_1",
+      serverId: "srv_asana",
+      serverName: "asana",
+      serverUrl: "https://mcp.asana.com/sse",
+      accessScope: "workspace_member",
+      returnHash: "#servers",
+    });
+    localStorage.setItem("mcp-oauth-pending", "asana");
+    localStorage.setItem("mcp-serverUrl-asana", "https://mcp.asana.com/sse");
+
+    render(<App />);
+
+    expect(
+      screen.queryByTestId("hosted-oauth-loading"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Servers Tab")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockCompleteHostedOAuthCallback).not.toHaveBeenCalled();
+    });
+  });
+
   it("skips billing queries while a persisted org id is still being validated", () => {
     mockUseAppState.mockImplementation(() => ({
       ...createAppStateMock(),

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -28,6 +28,7 @@ const {
   createAppStateMock,
   mockAppBuilderTabMounts,
   mockConvexAuthState,
+  mockCompleteHostedOAuthCallback,
   mockHandleOAuthCallback,
   mockHostedShellGateState,
   mockMCPSidebar,
@@ -90,6 +91,7 @@ const {
       isAuthenticated: true,
       isLoading: false,
     },
+    mockCompleteHostedOAuthCallback: vi.fn(),
     mockHandleOAuthCallback: vi.fn(),
     mockHostedShellGateState: {
       value: "ready" as
@@ -199,6 +201,7 @@ vi.mock("../lib/theme-utils", () => ({
 }));
 
 vi.mock("../lib/oauth/mcp-oauth", () => ({
+  completeHostedOAuthCallback: mockCompleteHostedOAuthCallback,
   handleOAuthCallback: mockHandleOAuthCallback,
 }));
 
@@ -371,6 +374,7 @@ describe("App hosted OAuth callback handling", () => {
     mockWorkOsAuthState.signIn = vi.fn();
     mockWorkOsAuthState.user = null;
     mockWorkOsAuthState.isLoading = false;
+    mockCompleteHostedOAuthCallback.mockReset();
     mockHandleOAuthCallback.mockReset();
     mockOrganizationsTab.mockReset();
     mockOrganizationsTab.mockImplementation(() => <div />);
@@ -380,6 +384,9 @@ describe("App hosted OAuth callback handling", () => {
     mockMCPSidebar.mockImplementation(() => <div data-testid="mcp-sidebar" />);
     mockPosthogCapture.mockReset();
     mockAppBuilderTabMounts.mockReset();
+    mockCompleteHostedOAuthCallback.mockImplementation(
+      () => new Promise<never>(() => {}),
+    );
     mockHandleOAuthCallback.mockImplementation(
       () => new Promise<never>(() => {}),
     );
@@ -433,7 +440,13 @@ describe("App hosted OAuth callback handling", () => {
       screen.queryByRole("button", { name: "Authorize" }),
     ).not.toBeInTheDocument();
     await waitFor(() => {
-      expect(mockHandleOAuthCallback).toHaveBeenCalledWith("oauth-code");
+      expect(mockCompleteHostedOAuthCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          surface: "sandbox",
+          serverName: "asana",
+        }),
+        "oauth-code",
+      );
     });
   });
 
@@ -678,7 +691,13 @@ describe("App hosted OAuth callback handling", () => {
     render(<App />);
 
     await waitFor(() => {
-      expect(mockHandleOAuthCallback).toHaveBeenCalledWith("oauth-code");
+      expect(mockCompleteHostedOAuthCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          surface: "sandbox",
+          serverName: "asana",
+        }),
+        "oauth-code",
+      );
     });
 
     expect(setActiveOrganizationId).not.toHaveBeenCalled();
@@ -1823,7 +1842,7 @@ describe("App hosted OAuth callback handling", () => {
       serverUrl: "https://mcp.asana.com/sse",
       returnHash: "#sandboxes",
     });
-    mockHandleOAuthCallback.mockResolvedValue({
+    mockCompleteHostedOAuthCallback.mockResolvedValue({
       success: true,
       serverName: "asana",
       serverConfig: {

--- a/mcpjam-inspector/client/src/components/hosted/SandboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/SandboxChatPage.tsx
@@ -369,6 +369,9 @@ export function SandboxChatPage({
     surface: "sandbox",
     pendingKey: SANDBOX_OAUTH_PENDING_KEY,
     servers: oauthServers,
+    workspaceId: session?.payload.workspaceId ?? null,
+    sandboxToken: session?.token,
+    isAuthenticated,
   });
 
   const sandboxServerConfigs = useMemo(() => {

--- a/mcpjam-inspector/client/src/components/hosted/SharedServerChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/SharedServerChatPage.tsx
@@ -142,6 +142,9 @@ export function SharedServerChatPage({
     surface: "shared",
     pendingKey: SHARED_OAUTH_PENDING_KEY,
     servers: oauthServers,
+    workspaceId: session?.payload.workspaceId ?? null,
+    shareToken: session?.token,
+    isAuthenticated,
   });
 
   const oauthTokensForChat = useMemo(() => {

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/SandboxChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/SandboxChatPage.test.tsx
@@ -451,10 +451,7 @@ describe("SandboxChatPage", () => {
     });
 
     expect(screen.getByTestId("sandbox-chat-tab")).toBeInTheDocument();
-    expect(mockValidateHostedServer).toHaveBeenCalledWith(
-      "srv_asana",
-      "sandbox-token",
-    );
+    expect(mockValidateHostedServer).toHaveBeenCalledWith("srv_asana", null);
     expect(mockValidateHostedServer).toHaveBeenCalledTimes(1);
   });
 

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/SharedServerChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/SharedServerChatPage.test.tsx
@@ -253,10 +253,7 @@ describe("SharedServerChatPage", () => {
     });
 
     expect(screen.getByTestId("shared-chat-tab")).toBeInTheDocument();
-    expect(mockValidateHostedServer).toHaveBeenCalledWith(
-      "srv_asana",
-      "oauth-token",
-    );
+    expect(mockValidateHostedServer).toHaveBeenCalledWith("srv_asana", null);
     expect(mockValidateHostedServer).toHaveBeenCalledTimes(1);
   });
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
@@ -44,6 +44,7 @@ vi.mock("@/state/oauth-orchestrator", () => ({
 }));
 
 vi.mock("@/lib/oauth/mcp-oauth", () => ({
+  completeHostedOAuthCallback: mockHandleOAuthCallback,
   handleOAuthCallback: mockHandleOAuthCallback,
   getStoredTokens: vi.fn(),
   clearOAuthData: vi.fn(),
@@ -128,5 +129,63 @@ describe("useServerState hosted OAuth callback guards", () => {
       expect(mockHandleOAuthCallback).not.toHaveBeenCalled();
     });
     expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("completes hosted workspace OAuth callbacks through the backend path", async () => {
+    writeHostedOAuthPendingMarker({
+      surface: "workspace",
+      workspaceId: "ws_1",
+      serverId: "srv_asana",
+      serverName: "asana",
+      serverUrl: "https://mcp.asana.com/sse",
+      accessScope: "workspace_member",
+      returnHash: "#servers",
+    });
+    localStorage.setItem("mcp-oauth-pending", "asana");
+    localStorage.setItem("mcp-serverUrl-asana", "https://mcp.asana.com/sse");
+    mockHandleOAuthCallback.mockResolvedValue({
+      success: true,
+      serverName: "asana",
+      serverConfig: {
+        url: "https://mcp.asana.com/sse",
+        requestInit: { headers: {} },
+      },
+    });
+
+    renderHook(() =>
+      useServerState({
+        appState: {
+          servers: {},
+          selectedMultipleServers: [],
+        } as any,
+        dispatch: vi.fn(),
+        isLoading: false,
+        isAuthenticated: true,
+        isAuthLoading: false,
+        isLoadingWorkspaces: false,
+        useLocalFallback: false,
+        effectiveWorkspaces: {} as any,
+        effectiveActiveWorkspaceId: "ws_1",
+        activeWorkspaceServersFlat: [],
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockHandleOAuthCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          surface: "workspace",
+          workspaceId: "ws_1",
+          serverId: "srv_asana",
+          serverName: "asana",
+        }),
+        "oauth-code",
+      );
+    });
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -223,6 +223,7 @@ describe("useServerState OAuth callback failures", () => {
       "OAuth authorization failed: access_denied: User denied access",
     );
     expect(localStorage.getItem("mcp-oauth-pending")).toBeNull();
+    expect(window.location.pathname).toBe("/");
     expect(window.location.search).toBe("");
     expect(window.location.hash).toBe("#demo-server");
   });
@@ -251,6 +252,33 @@ describe("useServerState OAuth callback failures", () => {
       "Error completing OAuth flow: Token exchange failed",
     );
     expect(localStorage.getItem("mcp-oauth-pending")).toBeNull();
+  });
+
+  it("restores the app root after a successful browser OAuth callback", async () => {
+    localStorage.setItem("mcp-oauth-pending", "demo-server");
+    localStorage.setItem("mcp-oauth-return-hash", "#demo-server");
+    handleOAuthCallbackMock.mockResolvedValue({
+      success: true,
+      serverName: "demo-server",
+      serverConfig: {
+        type: "http",
+        url: "https://example.com/mcp",
+      },
+    });
+    window.history.replaceState({}, "", "/oauth/callback?code=test-code");
+
+    const dispatch = vi.fn();
+    renderUseServerState(dispatch);
+
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith(
+        "OAuth connection successful! Connected to demo-server.",
+      );
+    });
+
+    expect(window.location.pathname).toBe("/");
+    expect(window.location.search).toBe("");
+    expect(window.location.hash).toBe("#demo-server");
   });
 
   it("blocks connect while workspace client config sync is pending", async () => {

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
@@ -53,6 +53,7 @@ export interface HostedOAuthServerDescriptor {
 function buildHostedOAuthStateMap(
   oauthServers: HostedOAuthServerDescriptor[],
   surface: HostedOAuthSurface,
+  isAuthenticated: boolean,
   previous: Record<string, HostedOAuthState> = {},
 ): Record<string, HostedOAuthState> {
   const resumeMarker = readHostedOAuthResumeMarker(surface);
@@ -85,9 +86,12 @@ function buildHostedOAuthStateMap(
       status = "error";
       errorMessage = resumeMarker.errorMessage;
     } else if (matchesResume) {
-      status = hasToken ? "verifying" : "resuming";
+      status = hasToken || isAuthenticated ? "verifying" : "resuming";
       errorMessage = null;
     } else if (hasToken) {
+      status = existing?.status === "ready" ? "ready" : "verifying";
+      errorMessage = null;
+    } else if (isAuthenticated) {
       status = existing?.status === "ready" ? "ready" : "verifying";
       errorMessage = null;
     } else if (existing?.status === "error") {
@@ -144,7 +148,7 @@ async function waitForStoredAccessToken(
 
 async function validateWithRetry(
   serverId: string,
-  oauthAccessToken: string,
+  oauthAccessToken?: string,
 ): Promise<{ ok: true } | { ok: false; error: unknown }> {
   let lastError: unknown = null;
 
@@ -169,6 +173,10 @@ export interface UseHostedOAuthGateOptions {
   surface: HostedOAuthSurface;
   pendingKey: string;
   servers: HostedOAuthServerDescriptor[];
+  workspaceId?: string | null;
+  shareToken?: string;
+  sandboxToken?: string;
+  isAuthenticated?: boolean;
 }
 
 export interface UseHostedOAuthGateResult {
@@ -186,6 +194,10 @@ export function useHostedOAuthGate({
   surface,
   pendingKey,
   servers,
+  workspaceId,
+  shareToken,
+  sandboxToken,
+  isAuthenticated = false,
 }: UseHostedOAuthGateOptions): UseHostedOAuthGateResult {
   const oauthServers = useMemo(
     () => servers.filter((server) => server.useOAuth),
@@ -193,7 +205,7 @@ export function useHostedOAuthGate({
   );
   const [oauthStateByServerId, setOAuthStateByServerId] = useState<
     Record<string, HostedOAuthState>
-  >(() => buildHostedOAuthStateMap(oauthServers, surface));
+  >(() => buildHostedOAuthStateMap(oauthServers, surface, isAuthenticated));
   const oauthStateByServerIdRef = useRef(oauthStateByServerId);
   const processingServerIdsRef = useRef<Set<string>>(new Set());
   const isUnmountedRef = useRef(false);
@@ -211,9 +223,14 @@ export function useHostedOAuthGate({
 
   useEffect(() => {
     setOAuthStateByServerId((previous) =>
-      buildHostedOAuthStateMap(oauthServers, surface, previous),
+      buildHostedOAuthStateMap(
+        oauthServers,
+        surface,
+        isAuthenticated,
+        previous,
+      ),
     );
-  }, [oauthServers, surface]);
+  }, [oauthServers, surface, isAuthenticated]);
 
   useEffect(() => {
     if (oauthServers.length === 0) {
@@ -240,7 +257,7 @@ export function useHostedOAuthGate({
 
         if (isUnmountedRef.current) return;
 
-        if (!accessToken) {
+        if (!accessToken && !isAuthenticated) {
           clearHostedOAuthResumeMarker();
           setStoredOAuthTokenState(
             server.serverName,
@@ -271,10 +288,7 @@ export function useHostedOAuthGate({
           }));
         }
 
-        const validation = await validateWithRetry(
-          server.serverId,
-          accessToken,
-        );
+        const validation = await validateWithRetry(server.serverId, accessToken);
         if (isUnmountedRef.current) return;
 
         if (validation.ok) {
@@ -326,7 +340,7 @@ export function useHostedOAuthGate({
         void processServer(server, currentStatus);
       }
     }
-  }, [oauthServers, oauthStateByServerId, surface]);
+  }, [oauthServers, oauthStateByServerId, surface, isAuthenticated]);
 
   const authorizeServer = useCallback(
     async (server: HostedOAuthServerDescriptor) => {
@@ -359,8 +373,13 @@ export function useHostedOAuthGate({
         window.location.hash || `#${slugify(server.serverName)}`;
       writeHostedOAuthPendingMarker({
         surface,
+        workspaceId,
+        serverId: server.serverId,
         serverName: server.serverName,
         serverUrl: server.serverUrl,
+        accessScope: isAuthenticated ? "chat_v2" : undefined,
+        shareToken,
+        sandboxToken,
         returnHash,
       });
       localStorage.setItem(pendingKey, "true");
@@ -408,14 +427,14 @@ export function useHostedOAuthGate({
       setOAuthStateByServerId((previous) => ({
         ...previous,
         [server.serverId]: {
-          status: accessToken ? "verifying" : "resuming",
+          status: accessToken || isAuthenticated ? "verifying" : "resuming",
           errorMessage: null,
           serverUrl:
             previous[server.serverId]?.serverUrl ?? server.serverUrl ?? null,
         },
       }));
     },
-    [pendingKey, surface],
+    [isAuthenticated, pendingKey, sandboxToken, shareToken, surface, workspaceId],
   );
 
   const markOAuthRequired = useCallback(

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -99,6 +99,15 @@ function saveOAuthConfigToLocalStorage(formData: ServerFormData): void {
   }
 }
 
+function restorePathAfterOAuthCallback(
+  currentPathname: string,
+  savedHash: string,
+): string {
+  const basePath =
+    currentPathname === "/oauth/callback" ? "/" : currentPathname;
+  return `${basePath}${savedHash}`;
+}
+
 interface LoggerLike {
   info: (message: string, meta?: Record<string, unknown>) => void;
   warn: (message: string, meta?: Record<string, unknown>) => void;
@@ -789,7 +798,7 @@ export function useServerState({
       window.history.replaceState(
         {},
         document.title,
-        window.location.pathname + savedHash,
+        restorePathAfterOAuthCallback(window.location.pathname, savedHash),
       );
 
       handleOAuthCallbackComplete(
@@ -816,7 +825,7 @@ export function useServerState({
       window.history.replaceState(
         {},
         document.title,
-        window.location.pathname + savedHash,
+        restorePathAfterOAuthCallback(window.location.pathname, savedHash),
       );
     }
   }, [

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -22,12 +22,17 @@ import {
 import type { ServerFormData } from "@/shared/types.js";
 import { toMCPConfig } from "@/state/server-helpers";
 import {
+  completeHostedOAuthCallback,
   handleOAuthCallback,
   getStoredTokens,
   clearOAuthData,
   initiateOAuth,
 } from "@/lib/oauth/mcp-oauth";
-import { getHostedOAuthCallbackContext } from "@/lib/hosted-oauth-callback";
+import {
+  clearHostedOAuthPendingState,
+  getHostedOAuthCallbackContext,
+  writeHostedOAuthPendingMarker,
+} from "@/lib/hosted-oauth-callback";
 import { HOSTED_MODE } from "@/lib/config";
 import { injectHostedServerMapping } from "@/lib/apis/web/context";
 import type { OAuthTestProfile } from "@/lib/oauth/profile";
@@ -173,6 +178,7 @@ export function useServerState({
         });
       }
 
+      clearHostedOAuthPendingState();
       localStorage.removeItem("mcp-oauth-return-hash");
       localStorage.removeItem("mcp-oauth-pending");
 
@@ -182,6 +188,39 @@ export function useServerState({
   );
   const isStaleOp = (name: string, token: number) =>
     (opTokenRef.current.get(name) ?? 0) !== token;
+
+  const prepareHostedWorkspaceOAuthRedirect = useCallback(
+    (params: {
+      serverId?: string | null;
+      serverName: string;
+      serverUrl?: string | null;
+    }): boolean => {
+      if (
+        !HOSTED_MODE ||
+        !isAuthenticated ||
+        !effectiveActiveWorkspaceId ||
+        !params.serverId ||
+        !params.serverUrl
+      ) {
+        return false;
+      }
+
+      const returnHash = window.location.hash || "#servers";
+      clearHostedOAuthPendingState();
+      writeHostedOAuthPendingMarker({
+        surface: "workspace",
+        workspaceId: effectiveActiveWorkspaceId,
+        serverId: params.serverId,
+        serverName: params.serverName,
+        serverUrl: params.serverUrl,
+        accessScope: "workspace_member",
+        returnHash,
+      });
+      localStorage.setItem("mcp-oauth-return-hash", returnHash);
+      return true;
+    },
+    [effectiveActiveWorkspaceId, isAuthenticated],
+  );
 
   const activeWorkspace = useMemo(() => {
     const workspace = effectiveWorkspaces[effectiveActiveWorkspaceId];
@@ -593,13 +632,26 @@ export function useServerState({
   );
 
   const handleOAuthCallbackComplete = useCallback(
-    async (code: string) => {
+    async (
+      code: string,
+      hostedCallbackContext: ReturnType<typeof getHostedOAuthCallbackContext>,
+    ) => {
       const pendingServerName = localStorage.getItem("mcp-oauth-pending");
+      const isHostedWorkspaceCallback =
+        HOSTED_MODE &&
+        isAuthenticated &&
+        hostedCallbackContext?.surface === "workspace";
 
       try {
-        const result = await handleOAuthCallback(code);
+        const result = isHostedWorkspaceCallback
+          ? await completeHostedOAuthCallback(hostedCallbackContext, code)
+          : await handleOAuthCallback(code);
 
         localStorage.removeItem("mcp-oauth-return-hash");
+        if (isHostedWorkspaceCallback) {
+          clearHostedOAuthPendingState();
+          localStorage.removeItem("mcp-oauth-pending");
+        }
 
         if (result.success && result.serverConfig && result.serverName) {
           const serverName = result.serverName;
@@ -617,14 +669,16 @@ export function useServerState({
               serverName,
             );
             if (connectionResult.success) {
-              dispatch({
-                type: "CONNECT_SUCCESS",
-                name: serverName,
-                config: result.serverConfig,
-                tokens: getStoredTokens(serverName),
-              });
-              logger.info("OAuth connection successful", { serverName });
-              toast.success(
+                dispatch({
+                  type: "CONNECT_SUCCESS",
+                  name: serverName,
+                  config: result.serverConfig,
+                  tokens: isHostedWorkspaceCallback
+                    ? undefined
+                    : getStoredTokens(serverName),
+                });
+                logger.info("OAuth connection successful", { serverName });
+                toast.success(
                 `OAuth connection successful! Connected to ${serverName}.`,
               );
               storeInitInfo(serverName, connectionResult.initInfo).catch(
@@ -689,6 +743,7 @@ export function useServerState({
     [
       dispatch,
       failPendingOAuthConnection,
+      isAuthenticated,
       logger,
       storeInitInfo,
       guardedTestConnection,
@@ -719,8 +774,10 @@ export function useServerState({
     const hostedOAuthCallbackContext = HOSTED_MODE
       ? getHostedOAuthCallbackContext()
       : null;
+    const isHostedWorkspaceCallback =
+      hostedOAuthCallbackContext?.surface === "workspace";
     if (code) {
-      if (hostedOAuthCallbackContext) {
+      if (hostedOAuthCallbackContext && !isHostedWorkspaceCallback) {
         return; // Handled by App.tsx hosted OAuth interception
       }
       if (oauthCallbackHandledRef.current) {
@@ -735,9 +792,12 @@ export function useServerState({
         window.location.pathname + savedHash,
       );
 
-      handleOAuthCallbackComplete(code);
+      handleOAuthCallbackComplete(
+        code,
+        isHostedWorkspaceCallback ? hostedOAuthCallbackContext : null,
+      );
     } else if (error) {
-      if (hostedOAuthCallbackContext) {
+      if (hostedOAuthCallbackContext && !isHostedWorkspaceCallback) {
         return; // Handled by App.tsx hosted OAuth interception
       }
       const errorMessage = errorDescription
@@ -791,6 +851,7 @@ export function useServerState({
         select: true,
       });
       const token = nextOpToken(formData.name);
+      let hostedServerId: string | undefined;
 
       const serverEntryForSave: ServerWithName = {
         name: formData.name,
@@ -808,6 +869,7 @@ export function useServerState({
             serverEntryForSave,
           );
           if (serverId) {
+            hostedServerId = serverId;
             injectHostedServerMapping(formData.name, serverId);
           }
         } catch (err) {
@@ -914,6 +976,11 @@ export function useServerState({
           if (oauthInputs.scopes && oauthInputs.scopes.length > 0) {
             oauthOptions.scopes = oauthInputs.scopes;
           }
+          prepareHostedWorkspaceOAuthRedirect({
+            serverId: hostedServerId,
+            serverName: formData.name,
+            serverUrl: formData.url,
+          });
           const oauthResult = await initiateOAuth(oauthOptions);
           if (oauthResult.success) {
             if (oauthResult.serverConfig) {
@@ -927,7 +994,10 @@ export function useServerState({
                   type: "CONNECT_SUCCESS",
                   name: formData.name,
                   config: oauthResult.serverConfig,
-                  tokens: getStoredTokens(formData.name),
+                  tokens:
+                    HOSTED_MODE && isAuthenticated
+                      ? undefined
+                      : getStoredTokens(formData.name),
                 });
                 toast.success("Connected successfully with OAuth!");
                 storeInitInfo(formData.name, connectionResult.initInfo).catch(
@@ -1037,6 +1107,7 @@ export function useServerState({
       appState.workspaces,
       appState.activeWorkspaceId,
       notifyIfClientConfigSyncPending,
+      prepareHostedWorkspaceOAuthRedirect,
       resolveOAuthInitiationInputs,
       syncServerToConvex,
       logger,
@@ -1490,6 +1561,9 @@ export function useServerState({
         config: server.config,
       });
       const token = nextOpToken(serverName);
+      const hostedWorkspaceServerId = activeWorkspaceServersFlat?.find(
+        (remoteServer) => remoteServer.name === serverName,
+      )?._id;
 
       if (options?.forceOAuthFlow) {
         clearOAuthData(serverName);
@@ -1505,6 +1579,11 @@ export function useServerState({
           return;
         }
 
+        prepareHostedWorkspaceOAuthRedirect({
+          serverId: hostedWorkspaceServerId,
+          serverName,
+          serverUrl,
+        });
         const oauthResult = await initiateOAuth({
           serverName,
           serverUrl,
@@ -1533,7 +1612,10 @@ export function useServerState({
             type: "CONNECT_SUCCESS",
             name: serverName,
             config: oauthResult.serverConfig!,
-            tokens: getStoredTokens(serverName),
+            tokens:
+              HOSTED_MODE && isAuthenticated
+                ? undefined
+                : getStoredTokens(serverName),
           });
           logger.info("Reconnection with fresh OAuth successful", {
             serverName,
@@ -1552,8 +1634,18 @@ export function useServerState({
       }
 
       try {
-        const authResult: OAuthResult =
-          await ensureAuthorizedForReconnect(server);
+        const authResult: OAuthResult = await ensureAuthorizedForReconnect(
+          server,
+          {
+            beforeRedirect: (oauthOptions) => {
+              prepareHostedWorkspaceOAuthRedirect({
+                serverId: hostedWorkspaceServerId,
+                serverName,
+                serverUrl: oauthOptions.serverUrl,
+              });
+            },
+          },
+        );
         if (authResult.kind === "redirect") return;
         if (authResult.kind === "error") {
           if (isStaleOp(serverName, token)) return;
@@ -1608,11 +1700,14 @@ export function useServerState({
       }
     },
     [
+      activeWorkspaceServersFlat,
+      isAuthenticated,
       effectiveServers,
       storeInitInfo,
       logger,
       dispatch,
       notifyIfClientConfigSyncPending,
+      prepareHostedWorkspaceOAuthRedirect,
       guardedReconnectServer,
       withWorkspaceClientCapabilities,
     ],

--- a/mcpjam-inspector/client/src/lib/hosted-oauth-callback.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-oauth-callback.ts
@@ -11,8 +11,13 @@ import {
 
 export interface HostedOAuthPendingMarker {
   surface: HostedOAuthSurface;
+  workspaceId?: string | null;
+  serverId?: string | null;
   serverName: string;
   serverUrl: string | null;
+  accessScope?: "workspace_member" | "chat_v2";
+  shareToken?: string | null;
+  sandboxToken?: string | null;
   returnHash: string | null;
   startedAt: number;
 }
@@ -67,7 +72,12 @@ export function writeHostedOAuthPendingMarker(
       HOSTED_OAUTH_PENDING_STORAGE_KEY,
       JSON.stringify({
         ...marker,
+        workspaceId: marker.workspaceId ?? null,
+        serverId: marker.serverId ?? null,
         serverUrl: marker.serverUrl ?? null,
+        accessScope: marker.accessScope ?? null,
+        shareToken: marker.shareToken ?? null,
+        sandboxToken: marker.sandboxToken ?? null,
         returnHash: normalizeHostedOAuthReturnHash(marker.returnHash),
         startedAt: Date.now(),
       }),
@@ -86,7 +96,9 @@ export function readHostedOAuthPendingMarker(): HostedOAuthPendingMarker | null 
     if (
       !parsed ||
       typeof parsed !== "object" ||
-      (parsed.surface !== "sandbox" && parsed.surface !== "shared") ||
+      (parsed.surface !== "sandbox" &&
+        parsed.surface !== "shared" &&
+        parsed.surface !== "workspace") ||
       typeof parsed.serverName !== "string" ||
       typeof parsed.startedAt !== "number"
     ) {
@@ -101,8 +113,20 @@ export function readHostedOAuthPendingMarker(): HostedOAuthPendingMarker | null 
 
     return {
       surface: parsed.surface,
+      workspaceId:
+        typeof parsed.workspaceId === "string" ? parsed.workspaceId : null,
+      serverId: typeof parsed.serverId === "string" ? parsed.serverId : null,
       serverName: parsed.serverName,
       serverUrl: typeof parsed.serverUrl === "string" ? parsed.serverUrl : null,
+      accessScope:
+        parsed.accessScope === "workspace_member" ||
+        parsed.accessScope === "chat_v2"
+          ? parsed.accessScope
+          : undefined,
+      shareToken:
+        typeof parsed.shareToken === "string" ? parsed.shareToken : null,
+      sandboxToken:
+        typeof parsed.sandboxToken === "string" ? parsed.sandboxToken : null,
       returnHash: normalizeHostedOAuthReturnHash(parsed.returnHash),
       startedAt: parsed.startedAt,
     };
@@ -210,8 +234,13 @@ export function getHostedOAuthCallbackContext(): HostedOAuthCallbackContext | nu
 
   return {
     surface,
+    workspaceId: null,
+    serverId: null,
     serverName,
     serverUrl,
+    accessScope: undefined,
+    shareToken: null,
+    sandboxToken: null,
     returnHash: normalizeHostedOAuthReturnHash(
       localStorage.getItem("mcp-oauth-return-hash"),
     ),
@@ -231,6 +260,10 @@ export function resolveHostedOAuthReturnHash(
     return sandboxSession
       ? `#${slugify(sandboxSession.payload.name)}`
       : "#sandbox";
+  }
+
+  if (context.surface === "workspace") {
+    return "#servers";
   }
 
   const sharedSession = readSharedServerSession();

--- a/mcpjam-inspector/client/src/lib/hosted-oauth-resume.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-oauth-resume.ts
@@ -1,4 +1,4 @@
-export type HostedOAuthSurface = "sandbox" | "shared";
+export type HostedOAuthSurface = "sandbox" | "shared" | "workspace";
 
 export type HostedOAuthStatus =
   | "needs_auth"
@@ -55,7 +55,9 @@ export function readHostedOAuthResumeMarker(
     if (
       !parsed ||
       typeof parsed !== "object" ||
-      (parsed.surface !== "sandbox" && parsed.surface !== "shared") ||
+      (parsed.surface !== "sandbox" &&
+        parsed.surface !== "shared" &&
+        parsed.surface !== "workspace") ||
       typeof parsed.serverName !== "string" ||
       typeof parsed.completedAt !== "number"
     ) {

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -18,6 +18,7 @@ import { generateRandomString } from "./pkce";
 import { authFetch } from "@/lib/session-token";
 import { HOSTED_MODE } from "@/lib/config";
 import { captureServerDetailModalOAuthResume } from "@/lib/server-detail-modal-resume";
+import type { HostedOAuthCallbackContext } from "@/lib/hosted-oauth-callback";
 import { getRedirectUri } from "./constants";
 import { getConvexSiteUrl } from "@/lib/convex-site-url";
 
@@ -27,6 +28,11 @@ const originalFetch = window.fetch;
 interface StoredOAuthDiscoveryState {
   serverUrl: string;
   discoveryState: OAuthDiscoveryState;
+}
+
+interface StoredOAuthClientInformation {
+  client_id?: string;
+  client_secret?: string;
 }
 
 export interface StoredOAuthConfig {
@@ -433,6 +439,12 @@ export interface OAuthResult {
   error?: string;
 }
 
+interface HostedOAuthCompletionResponse {
+  success: boolean;
+  expiresAt?: number | null;
+  kind?: "generic" | "registry";
+}
+
 /**
  * Simple localStorage-based OAuth provider for MCP
  */
@@ -610,6 +622,29 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   }
 }
 
+function readStoredClientInformation(
+  serverName: string,
+): StoredOAuthClientInformation {
+  try {
+    const stored = localStorage.getItem(`mcp-client-${serverName}`);
+    if (!stored) {
+      return {};
+    }
+
+    const parsed = JSON.parse(stored) as StoredOAuthClientInformation;
+    return {
+      client_id:
+        typeof parsed.client_id === "string" ? parsed.client_id : undefined,
+      client_secret:
+        typeof parsed.client_secret === "string"
+          ? parsed.client_secret
+          : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
 /**
  * Initiates OAuth flow for an MCP server
  */
@@ -726,6 +761,112 @@ export async function initiateOAuth(
   }
 }
 
+function formatOAuthCallbackError(error: unknown): string {
+  let errorMessage = "Unknown callback error";
+
+  if (error instanceof Error) {
+    errorMessage = error.message;
+
+    if (
+      errorMessage.includes("invalid_client") ||
+      errorMessage.includes("client_id")
+    ) {
+      return "Invalid client ID during token exchange. Please verify the client ID is correctly registered.";
+    }
+    if (errorMessage.includes("unauthorized_client")) {
+      return "Client not authorized for token exchange. The client ID may not match the one used for authorization.";
+    }
+    if (errorMessage.includes("invalid_grant")) {
+      return "Authorization code invalid or expired. Please try the OAuth flow again.";
+    }
+  }
+
+  return errorMessage;
+}
+
+export async function completeHostedOAuthCallback(
+  context: HostedOAuthCallbackContext,
+  authorizationCode: string,
+): Promise<OAuthResult & { serverName?: string; expiresAt?: number | null }> {
+  const serverName = context.serverName || localStorage.getItem("mcp-oauth-pending");
+
+  try {
+    if (!serverName) {
+      throw new Error("No pending OAuth flow found");
+    }
+    if (!context.workspaceId || !context.serverId) {
+      throw new Error("Hosted OAuth callback is missing server context");
+    }
+
+    const serverUrl =
+      context.serverUrl || localStorage.getItem(`mcp-serverUrl-${serverName}`);
+    if (!serverUrl) {
+      throw new Error("Server URL not found for OAuth callback");
+    }
+
+    const codeVerifier = localStorage.getItem(`mcp-verifier-${serverName}`);
+    if (!codeVerifier) {
+      throw new Error("Code verifier not found");
+    }
+
+    const clientInformation = readStoredClientInformation(serverName);
+    if (!clientInformation.client_id) {
+      throw new Error("OAuth client ID not found");
+    }
+
+    const convexSiteUrl = getConvexSiteUrl();
+    const response = await authFetch(`${convexSiteUrl}/web/oauth/complete`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        workspaceId: context.workspaceId,
+        serverId: context.serverId,
+        serverUrl,
+        code: authorizationCode,
+        codeVerifier,
+        redirectUri: getRedirectUri(),
+        clientInformation: {
+          clientId: clientInformation.client_id,
+          ...(clientInformation.client_secret
+            ? { clientSecret: clientInformation.client_secret }
+            : {}),
+        },
+        ...(context.accessScope ? { accessScope: context.accessScope } : {}),
+        ...(context.shareToken ? { shareToken: context.shareToken } : {}),
+        ...(context.sandboxToken ? { sandboxToken: context.sandboxToken } : {}),
+      }),
+    });
+
+    if (!response.ok) {
+      const responseText = await response.text();
+      throw new Error(responseText || `Hosted OAuth callback failed (${response.status})`);
+    }
+
+    const result =
+      (await response.json()) as HostedOAuthCompletionResponse | null;
+    if (!result?.success) {
+      throw new Error("Hosted OAuth callback failed");
+    }
+
+    localStorage.removeItem(`mcp-tokens-${serverName}`);
+    localStorage.removeItem(`mcp-verifier-${serverName}`);
+
+    return {
+      success: true,
+      serverName,
+      serverConfig: createServerConfig(serverUrl),
+      expiresAt: result.expiresAt ?? null,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      error: formatOAuthCallbackError(error),
+    };
+  }
+}
+
 /**
  * Handles OAuth callback and completes the flow
  */
@@ -799,30 +940,9 @@ export async function handleOAuthCallback(
       serverName, // Return server name so caller doesn't need to look it up
     };
   } catch (error) {
-    let errorMessage = "Unknown callback error";
-
-    if (error instanceof Error) {
-      errorMessage = error.message;
-
-      // Provide more helpful error messages for common client ID issues
-      if (
-        errorMessage.includes("invalid_client") ||
-        errorMessage.includes("client_id")
-      ) {
-        errorMessage =
-          "Invalid client ID during token exchange. Please verify the client ID is correctly registered.";
-      } else if (errorMessage.includes("unauthorized_client")) {
-        errorMessage =
-          "Client not authorized for token exchange. The client ID may not match the one used for authorization.";
-      } else if (errorMessage.includes("invalid_grant")) {
-        errorMessage =
-          "Authorization code invalid or expired. Please try the OAuth flow again.";
-      }
-    }
-
     return {
       success: false,
-      error: errorMessage,
+      error: formatOAuthCallbackError(error),
     };
   } finally {
     // Restore original fetch
@@ -1015,7 +1135,10 @@ export function clearOAuthData(serverName: string): void {
 /**
  * Creates MCP server configuration with OAuth tokens
  */
-function createServerConfig(serverUrl: string, tokens: any): HttpServerConfig {
+export function createServerConfig(
+  serverUrl: string,
+  tokens?: { access_token?: string | null },
+): HttpServerConfig {
   // Note: We don't include authProvider in the config because it can't be serialized
   // when sent to the backend via JSON. The backend will use the Authorization header instead.
   // Token refresh should be handled separately if the token expires.
@@ -1023,7 +1146,7 @@ function createServerConfig(serverUrl: string, tokens: any): HttpServerConfig {
   return {
     url: serverUrl,
     requestInit: {
-      headers: tokens.access_token
+      headers: tokens?.access_token
         ? {
             Authorization: `Bearer ${tokens.access_token}`,
           }

--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -20,6 +20,9 @@ export type OAuthResult = OAuthReady | OAuthRedirect | OAuthError;
 
 export async function ensureAuthorizedForReconnect(
   server: ServerWithName,
+  options?: {
+    beforeRedirect?: (oauthOptions: MCPOAuthOptions) => void;
+  },
 ): Promise<OAuthResult> {
   // If server is explicitly configured without OAuth, skip OAuth flow entirely
   // This handles the case where a server was saved with "No Authentication"
@@ -75,6 +78,7 @@ export async function ensureAuthorizedForReconnect(
       registryServerId: oauthConfig.registryServerId,
       useRegistryOAuthProxy: oauthConfig.useRegistryOAuthProxy,
     } as MCPOAuthOptions;
+    options?.beforeRedirect?.(opts);
     const init = await initiateOAuth(opts);
     if (init.success && init.serverConfig) {
       return {

--- a/mcpjam-inspector/server/routes/web/__tests__/servers-doctor.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/servers-doctor.test.ts
@@ -11,6 +11,7 @@ vi.mock("@mcpjam/sdk", async () => {
 
   return {
     ...actual,
+    DEFAULT_RETRY_POLICY: actual.DEFAULT_RETRY_POLICY,
     runServerDoctor: runServerDoctorMock,
     isMCPAuthError: vi.fn().mockReturnValue(false),
   };
@@ -28,6 +29,11 @@ vi.mock("../../../utils/oauth-proxy.js", () => ({
   validateUrl: vi.fn().mockResolvedValue({
     url: new URL("https://guest.example.com/mcp"),
   }),
+}));
+
+vi.mock("../../apps/SandboxProxyHtml.bundled.js", () => ({
+  CHATGPT_APPS_SANDBOX_PROXY_HTML: "<html></html>",
+  MCP_APPS_SANDBOX_PROXY_HTML: "<html></html>",
 }));
 
 import webRoutes from "../index.js";
@@ -159,6 +165,68 @@ describe("web servers/doctor", () => {
           serverId: "srv-1",
           label: "Example",
           url: "https://server.example.com/mcp",
+        }),
+      }),
+    );
+  });
+
+  it("prefers the backend-issued oauthAccessToken when the request does not provide one", async () => {
+    global.fetch = vi.fn(async (input) => {
+      if (String(input).endsWith("/web/authorize")) {
+        return new Response(
+          JSON.stringify({
+            authorized: true,
+            role: "member",
+            accessLevel: "workspace_member",
+            oauthAccessToken: "durable-token",
+            permissions: { chatOnly: false },
+            serverConfig: {
+              transportType: "http",
+              url: "https://server.example.com/mcp",
+              headers: { "X-Test": "yes" },
+              useOAuth: true,
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      throw new Error(`Unexpected fetch: ${String(input)}`);
+    }) as typeof fetch;
+
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      (c as any).mcpClientManager = {};
+      await next();
+    });
+    app.route("/api/web", webRoutes);
+
+    const response = await postJson(
+      app,
+      "/api/web/servers/doctor",
+      {
+        workspaceId: "workspace-1",
+        serverId: "srv-1",
+        serverName: "Example",
+      },
+      "test-token",
+    );
+
+    const { status } = await expectJson<{ status: string }>(response);
+
+    expect(status).toBe(200);
+    expect(runServerDoctorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          requestInit: {
+            headers: {
+              "X-Test": "yes",
+              Authorization: "Bearer durable-token",
+            },
+          },
         }),
       }),
     );

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -134,6 +134,7 @@ export type ConvexAuthorizeResponse = {
   authorized: boolean;
   role: "owner" | "admin" | "member";
   accessLevel: "workspace_member" | "shared_chat";
+  oauthAccessToken?: string | null;
   permissions: {
     chatOnly: boolean;
   };
@@ -295,7 +296,7 @@ export async function createAuthorizedManager(
         shareToken: options?.shareToken,
         sandboxToken: options?.sandboxToken,
       });
-      const oauthToken = oauthTokens?.[serverId];
+      const oauthToken = auth.oauthAccessToken ?? oauthTokens?.[serverId];
 
       if (auth.serverConfig.useOAuth) {
         if (auth.serverConfig.url) {

--- a/mcpjam-inspector/server/routes/web/servers.ts
+++ b/mcpjam-inspector/server/routes/web/servers.ts
@@ -187,7 +187,7 @@ async function runHostedDoctor(
   const config = toHttpConfig(
     auth,
     timeoutMs,
-    body.oauthAccessToken,
+    auth.oauthAccessToken ?? body.oauthAccessToken,
     body.clientCapabilities,
   );
 


### PR DESCRIPTION
## What changed
- routes signed-in hosted OAuth callbacks through the backend completion endpoint instead of finishing them entirely in the browser
- expands the hosted pending OAuth marker so workspace, shared, and sandbox surfaces carry the server/workspace context needed to resume correctly
- prefers backend-issued `oauthAccessToken` values in hosted server auth and doctor flows, while keeping request-supplied browser tokens as a compatibility fallback
- updates the hosted OAuth gate and workspace reconnect flow so signed-in hosted sessions can resume without local browser token ownership
- adds/updates hosted OAuth tests for workspace, shared, sandbox, and hosted doctor behavior

## Why
Hosted authenticated sessions were still effectively browser-owned. When users left and came back after the token expired, the hosted app would fail with `invalid_token` / `Token has expired`, and logs/tools would disappear because auth failed before the hosted connection fully came up.

## Impact
Signed-in hosted sessions can now survive reloads and returning visits by relying on backend-owned OAuth state. Browser-held tokens are only a transition fallback instead of the primary source of truth.

## Root cause
The hosted app finished and resumed OAuth from client-owned storage, so refresh-token durability depended on local browser state and client metadata. That is the wrong ownership model for hosted authenticated flows.

## Validation
- `npm ci --legacy-peer-deps`
- `npm run verify`
- local hosted-mode smoke run against the updated non-prod Convex deployment
  - client: `http://localhost:5180/`
  - server: `http://127.0.0.1:6281/`
- targeted hosted route test coverage still passes under the root verify run, including `server/routes/web/__tests__/servers-doctor.test.ts`

## Paired backend PR
- MCPJam/mcpjam-backend#129

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth completion/resume logic across client and server, including token handling and redirect state; mistakes could break hosted sign-in/connect flows. Changes are scoped and covered by updated tests, lowering rollback risk.
> 
> **Overview**
> Signed-in *hosted* OAuth callbacks now complete via a new backend completion path (`completeHostedOAuthCallback`) instead of always exchanging tokens in-browser, improving durability across reloads/expired local storage.
> 
> Hosted OAuth pending/resume state is expanded to include `workspace` surface plus workspace/server identifiers, access scope, and share/sandbox tokens; `App` and `useHostedOAuthGate` use this context to avoid blocking workspace callbacks in the hosted shell and to allow verification when the user is authenticated even without a local access token.
> 
> Workspace connect/reconnect flows pre-write hosted pending markers before redirect and restore the app root after `/oauth/callback`; server-side authorization/doctor flows now prefer backend-issued `oauthAccessToken` with request-supplied tokens as a fallback. Tests are updated/added for hosted sandbox/shared/workspace callback handling and doctor token selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37cfc53626ca469aa6f46a591a6c742a55d9b1ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->