### PR TITLE
Replace GitHub icon with Star button showing star count

### DIFF
--- a/mcpjam-inspector/client/src/components/auth/auth-upper-area.tsx
+++ b/mcpjam-inspector/client/src/components/auth/auth-upper-area.tsx
@@ -3,7 +3,7 @@ import { useConvexAuth } from "convex/react";
 import { usePostHog } from "posthog-js/react";
 import { Button } from "@/components/ui/button";
 import { DiscordIcon } from "@/components/ui/discord-icon";
-import { GitHubIcon } from "@/components/ui/github-icon";
+import { GitHubStarButton } from "@/components/ui/github-star-button";
 import {
   ActiveServerSelector,
   ActiveServerSelectorProps,
@@ -34,18 +34,6 @@ export function AuthUpperArea({
         >
           <DiscordIcon className="h-10 w-10" />
           <span className="sr-only">Discord</span>
-        </a>
-      </Button>
-      <Button asChild size="icon" variant="ghost">
-        <a
-          href="https://github.com/MCPJam/inspector"
-          target="_blank"
-          rel="noreferrer"
-          aria-label="Visit the GitHub repository"
-          title="Visit the GitHub repository"
-        >
-          <GitHubIcon className="h-10 w-10" />
-          <span className="sr-only">GitHub</span>
         </a>
       </Button>
     </div>
@@ -95,6 +83,7 @@ export function AuthUpperArea({
             </Button>
           </>
         )}
+        <GitHubStarButton />
       </div>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/ui/github-star-button.tsx
+++ b/mcpjam-inspector/client/src/components/ui/github-star-button.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import { Star } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { GitHubIcon } from "@/components/ui/github-icon";
+
+const REPO = "MCPJam/inspector";
+const CACHE_KEY = `gh-stars:${REPO}`;
+const CACHE_TTL_MS = 60 * 60 * 1000;
+
+function formatCount(n: number): string {
+  if (n >= 1000) {
+    const k = n / 1000;
+    return `${k.toFixed(k >= 10 ? 0 : 1)}k`;
+  }
+  return n.toLocaleString();
+}
+
+function readCache(): number | null {
+  try {
+    const raw = sessionStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const { count, ts } = JSON.parse(raw) as { count: number; ts: number };
+    if (Date.now() - ts > CACHE_TTL_MS) return null;
+    return count;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(count: number) {
+  try {
+    sessionStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({ count, ts: Date.now() }),
+    );
+  } catch {
+    // ignore
+  }
+}
+
+export function GitHubStarButton() {
+  const [count, setCount] = useState<number | null>(() => readCache());
+
+  useEffect(() => {
+    if (count !== null) return;
+    let cancelled = false;
+    fetch(`https://api.github.com/repos/${REPO}`, {
+      headers: { Accept: "application/vnd.github+json" },
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (cancelled || !data) return;
+        const stars = data.stargazers_count;
+        if (typeof stars === "number") {
+          setCount(stars);
+          writeCache(stars);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [count]);
+
+  return (
+    <Button asChild variant="outline" size="sm" className="gap-1.5 px-2.5">
+      <a
+        href={`https://github.com/${REPO}`}
+        target="_blank"
+        rel="noreferrer"
+        aria-label={`Star ${REPO} on GitHub`}
+        title={`Star ${REPO} on GitHub`}
+      >
+        <GitHubIcon className="h-4 w-4" />
+        <Star className="h-3.5 w-3.5" />
+        <span className="text-xs font-medium">Star</span>
+        {count !== null && (
+          <span className="text-xs font-medium border-l border-border/60 pl-1.5 ml-0.5 text-muted-foreground">
+            {formatCount(count)}
+          </span>
+        )}
+      </a>
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- Replaces the GitHub ghost-icon button in the top-right navbar with a proper GitHub-style "Star" button that shows the live stargazer count for `MCPJam/inspector`.
- Fetches `stargazers_count` from the unauthenticated GitHub API and caches the result in `sessionStorage` for 1 hour so we don't hit rate limits.
- Moves the button to the far right of the header cluster — past the sign-in / create-account buttons — so it sits as the rightmost element and acts as the primary community CTA.

## Changes
- New component `client/src/components/ui/github-star-button.tsx` — outline Button with GitHub + Star icons, "Star" label, and formatted count (e.g. `1.2k`). Gracefully no-ops if the API fetch or sessionStorage read fails.
- `client/src/components/auth/auth-upper-area.tsx` — drops the old `GitHubIcon` ghost button and appends `<GitHubStarButton />` at the end of the right-hand cluster.

## Test plan
- [ ] Open the app: verify Discord icon + bell + sign-in / create-account render, and the Star button sits to their right.
- [ ] Star button shows "Star" + numeric count (check network tab for the `api.github.com/repos/MCPJam/inspector` call on first load).
- [ ] Reload the page: verify the count appears immediately without a second network request (sessionStorage cache).
- [ ] Clicking the button opens `https://github.com/MCPJam/inspector` in a new tab.
- [ ] Signed-in state: button still renders on the far right after the notification bell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)