### PR TITLE
Continue in chat gets stuck when Raw is toggled

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -1260,7 +1260,9 @@ export function ChatTabV2({
       setSelectedModelIds([String(selectedModel.id)]);
     }
 
-    startChatWithMessages(evalChatHandoff.messages);
+    startChatWithMessages(evalChatHandoff.messages, {
+      requestPayloadHistory: evalChatHandoff.requestPayloadHistory,
+    });
     appliedEvalChatHandoffIdRef.current = evalChatHandoff.id;
 
     if (typeof evalChatHandoff.systemPrompt === "string") {

--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.trace-views.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.trace-views.test.tsx
@@ -180,14 +180,27 @@ vi.mock("@/components/evals/trace-viewer", () => ({
   TraceViewer: ({
     forcedViewMode,
     trace,
+    rawRequestPayloadHistory,
   }: {
     forcedViewMode?: "timeline" | "raw" | "chat";
     trace?: unknown;
+    rawRequestPayloadHistory?: {
+      entries: unknown[];
+      hasUiMessages: boolean;
+    } | null;
   }) => (
     <div
       data-testid="trace-viewer"
       data-mode={forcedViewMode ?? "timeline"}
       data-trace={JSON.stringify(trace ?? null)}
+      data-raw-history-length={String(
+        rawRequestPayloadHistory?.entries.length ?? 0,
+      )}
+      data-raw-has-ui-messages={
+        rawRequestPayloadHistory == null
+          ? "none"
+          : String(rawRequestPayloadHistory.hasUiMessages)
+      }
     />
   ),
 }));
@@ -324,6 +337,9 @@ describe("ChatTabV2 trace views", () => {
       hasLiveTimelineContent: false,
       traceViewsSupported: false,
       isStreaming: false,
+      startChatWithMessages: vi.fn(),
+      setSystemPrompt: vi.fn(),
+      setTemperature: vi.fn(),
     });
   });
 
@@ -370,6 +386,136 @@ describe("ChatTabV2 trace views", () => {
     expect(within(pending).getByTestId("trace-raw-view")).toBeInTheDocument();
     expect(screen.getByText(/Sample raw request/i)).toBeInTheDocument();
     expect(screen.getByTestId("chat-input")).toBeInTheDocument();
+  });
+
+  it("passes eval handoff raw history into the seeded chat session", async () => {
+    const handoff = {
+      id: "eval-handoff-1",
+      messages: [
+        {
+          id: "seed-user",
+          role: "user",
+          parts: [{ type: "text", text: "seeded prompt" }],
+        },
+        {
+          id: "seed-assistant",
+          role: "assistant",
+          parts: [{ type: "text", text: "seeded reply" }],
+        },
+      ],
+      serverNames: ["server-1"],
+      systemPrompt: "Be concise.",
+      temperature: 0.2,
+      requestPayloadHistory: [
+        {
+          turnId: "eval-turn-1",
+          promptIndex: 0,
+          stepIndex: 0,
+          payload: {
+            system: "Be concise.",
+            tools: {},
+            messages: [{ role: "user", content: "seeded prompt" }],
+          },
+        },
+      ],
+    };
+
+    render(
+      <ChatTabV2
+        {...defaultProps}
+        enableTraceViews={true}
+        evalChatHandoff={handoff}
+        onEvalChatHandoffConsumed={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockUseChatSession.startChatWithMessages).toHaveBeenCalledWith(
+        handoff.messages,
+        {
+          requestPayloadHistory: handoff.requestPayloadHistory,
+        },
+      );
+    });
+
+    expect(mockUseChatSession.setSystemPrompt).toHaveBeenCalledWith(
+      "Be concise.",
+    );
+    expect(mockUseChatSession.setTemperature).toHaveBeenCalledWith(0.2);
+  });
+
+  it("shows raw JSON immediately after an eval handoff seeds request payload history", async () => {
+    mockUseChatSession.traceViewsSupported = true;
+    mockUseChatSession.startChatWithMessages = vi.fn(
+      (messages: unknown[], options?: { requestPayloadHistory?: unknown[] }) => {
+        mockUseChatSession.messages = messages;
+        mockUseChatSession.requestPayloadHistory =
+          options?.requestPayloadHistory ?? [];
+      },
+    );
+
+    const handoff = {
+      id: "eval-handoff-raw-1",
+      messages: [
+        {
+          id: "seed-user",
+          role: "user",
+          parts: [{ type: "text", text: "seeded prompt" }],
+        },
+        {
+          id: "seed-assistant",
+          role: "assistant",
+          parts: [{ type: "text", text: "seeded reply" }],
+        },
+      ],
+      serverNames: ["server-1"],
+      requestPayloadHistory: [
+        {
+          turnId: "eval-turn-1",
+          promptIndex: 0,
+          stepIndex: 0,
+          payload: {
+            system: "Be concise.",
+            tools: {},
+            messages: [{ role: "user", content: "seeded prompt" }],
+          },
+        },
+      ],
+    };
+
+    const view = render(
+      <ChatTabV2
+        {...defaultProps}
+        enableTraceViews={true}
+        evalChatHandoff={handoff}
+        onEvalChatHandoffConsumed={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockUseChatSession.startChatWithMessages).toHaveBeenCalled();
+    });
+
+    view.rerender(
+      <ChatTabV2
+        {...defaultProps}
+        enableTraceViews={true}
+        evalChatHandoff={handoff}
+        onEvalChatHandoffConsumed={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Raw" }));
+
+    expect(screen.queryByTestId("chat-live-raw-pending")).not.toBeInTheDocument();
+    expect(screen.getByTestId("trace-viewer")).toHaveAttribute(
+      "data-raw-history-length",
+      "1",
+    );
+    expect(screen.getByTestId("trace-viewer")).toHaveAttribute(
+      "data-raw-has-ui-messages",
+      "true",
+    );
   });
 
   it("shows the Runs-style timeline empty state before the first streamed snapshot while keeping the thread mounted", () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-trace-tool-context.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-trace-tool-context.test.tsx
@@ -101,6 +101,17 @@ describe("useEvalTraceToolContext", () => {
     });
 
     expect(mockState.listTools).toHaveBeenCalledWith({ serverId: "alpha" });
+    expect(result.current.serializedTools).toEqual({
+      create_view: {
+        name: "create_view",
+        description: undefined,
+        inputSchema: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+      },
+    });
     expect(result.current.toolServerMap).toEqual({ create_view: "alpha" });
     expect(result.current.connectedServerIds).toContain("alpha");
   });

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -86,6 +86,7 @@ import type {
 } from "./types";
 import type { EvalExportDraftInput } from "@/lib/evals/eval-export";
 import type { EvalChatHandoff } from "@/lib/eval-chat-handoff";
+import { buildEvalRequestPayloadHistory } from "@/lib/eval-request-payload-history";
 import { ProviderLogo } from "@/components/chat-v2/chat-input/model/provider-logo";
 import {
   reduceEvalStreamEvent,
@@ -2389,7 +2390,13 @@ function RunColumn({
   onTabChange: (tab: RunColumnTab) => void;
   onRetry: () => void;
 }) {
-  const { toolsMetadata, toolServerMap, connectedServerIds } =
+  const {
+    toolsMetadata,
+    serializedTools,
+    toolServerMap,
+    connectedServerIds,
+    isReady: isToolContextReady,
+  } =
     useEvalTraceToolContext({
       serverNames,
       workspaceId,
@@ -2465,14 +2472,41 @@ function RunColumn({
     onTraceLoaded: onStreamingTraceLoaded,
     enabled: !!record.iteration,
   });
-  const continueInChatPayload = useMemo(() => {
-    if (!onContinueInChat) {
-      return null;
-    }
-
-    const sourceTrace = (persistedTraceBlob ??
-      streamingTraceEnvelope) as Record<string, unknown> | null;
-
+  const sourceTrace = useMemo(
+    () =>
+      (persistedTraceBlob ?? streamingTraceEnvelope) as {
+        messages?: unknown[];
+        spans?: Array<{
+          id: string;
+          category: "step" | "llm" | "tool" | "error";
+          startMs: number;
+          endMs: number;
+          promptIndex?: number;
+          stepIndex?: number;
+          messageStartIndex?: number;
+          messageEndIndex?: number;
+        }>;
+      } | null,
+    [persistedTraceBlob, streamingTraceEnvelope],
+  );
+  const advancedConfig = useMemo(
+    () =>
+      record.iteration?.testCaseSnapshot?.advancedConfig ??
+      testCase?.advancedConfig,
+    [
+      record.iteration?.testCaseSnapshot?.advancedConfig,
+      testCase?.advancedConfig,
+    ],
+  );
+  const continueInChatSystemPrompt =
+    typeof advancedConfig?.system === "string"
+      ? advancedConfig.system
+      : undefined;
+  const continueInChatTemperature =
+    typeof advancedConfig?.temperature === "number"
+      ? advancedConfig.temperature
+      : undefined;
+  const continueInChatMessages = useMemo(() => {
     if (!sourceTrace) {
       return null;
     }
@@ -2484,40 +2518,63 @@ function RunColumn({
       connectedServerIds,
     });
 
-    if (adaptedTrace.messages.length === 0) {
-      return null;
+    return adaptedTrace.messages.length > 0 ? adaptedTrace.messages : null;
+  }, [connectedServerIds, sourceTrace, toolServerMap, toolsMetadata]);
+  const canContinueInChat = useMemo(() => {
+    if (!onContinueInChat || !sourceTrace || !continueInChatMessages) {
+      return false;
     }
 
-    const advancedConfig =
-      record.iteration?.testCaseSnapshot?.advancedConfig ??
-      testCase?.advancedConfig;
-    const systemPrompt =
-      typeof advancedConfig?.system === "string"
-        ? advancedConfig.system
-        : undefined;
-    const temperature =
-      typeof advancedConfig?.temperature === "number"
-        ? advancedConfig.temperature
-        : undefined;
+    if (!isToolContextReady) {
+      return false;
+    }
 
-    return {
-      messages: adaptedTrace.messages,
+    return (
+      buildEvalRequestPayloadHistory({
+        trace: sourceTrace,
+        systemPrompt: continueInChatSystemPrompt,
+        tools: serializedTools,
+      }).length > 0
+    );
+  }, [
+    continueInChatMessages,
+    continueInChatSystemPrompt,
+    isToolContextReady,
+    onContinueInChat,
+    serializedTools,
+    sourceTrace,
+  ]);
+  const handleContinueInChat = useCallback(() => {
+    if (!onContinueInChat || !sourceTrace || !continueInChatMessages) {
+      return;
+    }
+
+    const requestPayloadHistory = buildEvalRequestPayloadHistory({
+      trace: sourceTrace,
+      systemPrompt: continueInChatSystemPrompt,
+      tools: serializedTools,
+    });
+    if (requestPayloadHistory.length === 0) {
+      return;
+    }
+
+    onContinueInChat({
+      messages: continueInChatMessages,
       serverNames,
       modelId: record.model,
-      systemPrompt,
-      temperature,
-    } satisfies Omit<EvalChatHandoff, "id">;
+      systemPrompt: continueInChatSystemPrompt,
+      temperature: continueInChatTemperature,
+      requestPayloadHistory,
+    });
   }, [
-    connectedServerIds,
+    continueInChatMessages,
+    continueInChatSystemPrompt,
+    continueInChatTemperature,
     onContinueInChat,
-    persistedTraceBlob,
-    record.iteration?.testCaseSnapshot?.advancedConfig,
     record.model,
+    serializedTools,
     serverNames,
-    streamingTraceEnvelope,
-    testCase?.advancedConfig,
-    toolServerMap,
-    toolsMetadata,
+    sourceTrace,
   ]);
   const hasStreamingTrace = streamingTraceEnvelope != null;
   const isWaitingForFirstTimelineSnapshot =
@@ -2730,11 +2787,8 @@ function RunColumn({
                 size="sm"
                 variant="outline"
                 className="h-7 shrink-0 px-2 text-[11px]"
-                onClick={() =>
-                  continueInChatPayload &&
-                  onContinueInChat(continueInChatPayload)
-                }
-                disabled={!continueInChatPayload}
+                onClick={handleContinueInChat}
+                disabled={!canContinueInChat}
               >
                 Continue in Chat
               </Button>

--- a/mcpjam-inspector/client/src/components/evals/use-eval-trace-tool-context.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-trace-tool-context.ts
@@ -1,21 +1,24 @@
 import { useEffect, useMemo, useState } from "react";
 import { useConvexAuth } from "convex/react";
-import {
-  listTools,
-  type ListToolsResultWithMetadata,
-  type ToolServerMap,
-} from "@/lib/apis/mcp-tools-api";
+import { listTools, type ToolServerMap } from "@/lib/apis/mcp-tools-api";
 import { HOSTED_MODE } from "@/lib/config";
 import { CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE } from "@/lib/client-config";
 import { buildOAuthTokensByServerId } from "@/lib/oauth/oauth-tokens";
 import { useWorkspaceServers } from "@/hooks/useViews";
 import { useSharedAppState } from "@/state/app-state-context";
 import { useClientConfigStore } from "@/stores/client-config-store";
+import type { SerializedModelRequestTool } from "@/shared/model-request-payload";
 
 const EMPTY_SERVER_NAMES: string[] = [];
+const DEFAULT_INPUT_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  properties: {},
+  additionalProperties: false,
+};
 
 type EvalTraceToolContextState = {
   toolsMetadata: Record<string, Record<string, unknown>>;
+  serializedTools: Record<string, SerializedModelRequestTool>;
   toolServerMap: ToolServerMap;
   connectedServerIds: string[];
   hostedSelectedServerIds: string[];
@@ -30,6 +33,7 @@ function buildEmptyState(
 ): EvalTraceToolContextState {
   return {
     toolsMetadata: {},
+    serializedTools: {},
     toolServerMap: {},
     connectedServerIds: [],
     hostedSelectedServerIds: [],
@@ -61,6 +65,14 @@ function isTransientHostedToolContextError(error: unknown): boolean {
     withMessage.message.startsWith("Hosted server not found for ") ||
     /\b(401|403)\b|unauthorized|forbidden/i.test(withMessage.message)
   );
+}
+
+function normalizeToolInputSchema(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+
+  return DEFAULT_INPUT_SCHEMA;
 }
 
 export function useEvalTraceToolContext({
@@ -143,6 +155,7 @@ export function useEvalTraceToolContext({
       setState((previous) =>
         buildEmptyState({
           toolsMetadata: previous.toolsMetadata,
+          serializedTools: previous.serializedTools,
           toolServerMap: previous.toolServerMap,
           connectedServerIds: previous.connectedServerIds,
           hostedSelectedServerIds,
@@ -158,6 +171,7 @@ export function useEvalTraceToolContext({
     setState((previous) =>
       buildEmptyState({
         toolsMetadata: previous.toolsMetadata,
+        serializedTools: previous.serializedTools,
         toolServerMap: previous.toolServerMap,
         connectedServerIds: previous.connectedServerIds,
         hostedSelectedServerIds,
@@ -180,6 +194,8 @@ export function useEvalTraceToolContext({
         }
 
         const nextToolsMetadata: Record<string, Record<string, unknown>> = {};
+        const nextSerializedTools: Record<string, SerializedModelRequestTool> =
+          {};
         const nextToolServerMap: ToolServerMap = {};
         const nextConnectedServerIds = new Set<string>();
         const hostedServerIdByName = new Map(
@@ -202,6 +218,16 @@ export function useEvalTraceToolContext({
 
           for (const tool of result.tools ?? []) {
             nextToolServerMap[tool.name] = resolvedServerId;
+            nextSerializedTools[tool.name] = {
+              name: tool.name,
+              description:
+                typeof tool.description === "string"
+                  ? tool.description
+                  : undefined,
+              inputSchema: normalizeToolInputSchema(
+                (tool as { inputSchema?: unknown }).inputSchema,
+              ),
+            };
           }
 
           if (result.toolsMetadata) {
@@ -216,6 +242,7 @@ export function useEvalTraceToolContext({
         setState(
           buildEmptyState({
             toolsMetadata: nextToolsMetadata,
+            serializedTools: nextSerializedTools,
             toolServerMap: nextToolServerMap,
             connectedServerIds: Array.from(nextConnectedServerIds),
             hostedSelectedServerIds,
@@ -232,6 +259,7 @@ export function useEvalTraceToolContext({
           setState((previous) =>
             buildEmptyState({
               toolsMetadata: previous.toolsMetadata,
+              serializedTools: previous.serializedTools,
               toolServerMap: previous.toolServerMap,
               connectedServerIds: previous.connectedServerIds,
               hostedSelectedServerIds,

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.fork.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.fork.test.tsx
@@ -352,7 +352,20 @@ describe("useChatSession fork preservation", () => {
           role: "assistant",
           parts: [{ type: "text", text: "seeded reply" }],
         } as any,
-      ]);
+      ], {
+        requestPayloadHistory: [
+          {
+            turnId: "eval-turn-1",
+            promptIndex: 0,
+            stepIndex: 0,
+            payload: {
+              system: "Be concise.",
+              tools: {},
+              messages: [{ role: "user", content: "seeded prompt" }],
+            },
+          },
+        ],
+      });
     });
 
     await waitFor(() => {
@@ -369,6 +382,18 @@ describe("useChatSession fork preservation", () => {
         id: "seed-assistant",
         role: "assistant",
         parts: [{ type: "text", text: "seeded reply" }],
+      },
+    ]);
+    expect(result.current.requestPayloadHistory).toEqual([
+      {
+        turnId: "eval-turn-1",
+        promptIndex: 0,
+        stepIndex: 0,
+        payload: {
+          system: "Be concise.",
+          tools: {},
+          messages: [{ role: "user", content: "seeded prompt" }],
+        },
       },
     ]);
   });

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -203,6 +203,7 @@ export interface UseChatSessionReturn {
     options?: {
       resetReason?: ChatSessionResetReason;
       toolRenderOverrides?: Record<string, ToolRenderOverride>;
+      requestPayloadHistory?: LiveChatTraceRequestPayloadEntry[];
     },
   ) => void;
   loadChatSession: (
@@ -321,6 +322,7 @@ interface PendingSessionHydration {
   sessionId: string;
   messages: UIMessage[];
   resumedVersion: number | null;
+  requestPayloadHistory?: LiveChatTraceRequestPayloadEntry[];
   toolRenderOverrides?: Record<
     string,
     import("@/components/chat-v2/thread/tool-render-overrides").ToolRenderOverride
@@ -341,6 +343,38 @@ function createEmptyLiveTraceState(): LiveTraceAccumulatorState {
     activeTurnId: null,
     activeTurnHasSnapshot: false,
     anySnapshotSeen: false,
+  };
+}
+
+function createLiveTraceStateFromRequestPayloadHistory(
+  requestPayloadHistory?: LiveChatTraceRequestPayloadEntry[],
+): LiveTraceAccumulatorState {
+  const base = createEmptyLiveTraceState();
+  if (!Array.isArray(requestPayloadHistory) || requestPayloadHistory.length === 0) {
+    return base;
+  }
+
+  return {
+    ...base,
+    requestPayloadHistory: requestPayloadHistory.map((entry) => ({
+      ...entry,
+      payload: {
+        ...entry.payload,
+        tools: Object.fromEntries(
+          Object.entries(entry.payload.tools ?? {}).map(([toolName, tool]) => [
+            toolName,
+            {
+              ...tool,
+              inputSchema:
+                tool.inputSchema && typeof tool.inputSchema === "object"
+                  ? { ...tool.inputSchema }
+                  : tool.inputSchema,
+            },
+          ]),
+        ),
+        messages: [...entry.payload.messages],
+      },
+    })),
   };
 }
 
@@ -799,6 +833,10 @@ export function useChatSession({
   const pendingSessionHydrationRef = useRef<PendingSessionHydration | null>(
     null,
   );
+  const nextLiveTraceSeedRef = useRef<{
+    sessionId: string;
+    requestPayloadHistory: LiveChatTraceRequestPayloadEntry[];
+  } | null>(null);
   const selectedServersSignature = useMemo(
     () => selectedServers.join("\u0000"),
     [selectedServers],
@@ -847,6 +885,7 @@ export function useChatSession({
   );
   const clearPendingSessionHydration = useCallback(() => {
     const pendingHydration = pendingSessionHydrationRef.current;
+    nextLiveTraceSeedRef.current = null;
     if (!pendingHydration) {
       return;
     }
@@ -1135,11 +1174,20 @@ export function useChatSession({
         setPersistedSnapshotToolCallIds(
           hydration.persistedSnapshotToolCallIds ?? [],
         );
+        setLiveTraceState(
+          createLiveTraceStateFromRequestPayloadHistory(
+            hydration.requestPayloadHistory,
+          ),
+        );
         setHydrationTick((t) => t + 1);
         return Promise.resolve();
       }
 
       return new Promise<void>((resolve) => {
+        nextLiveTraceSeedRef.current = {
+          sessionId: hydration.sessionId,
+          requestPayloadHistory: hydration.requestPayloadHistory ?? [],
+        };
         pendingSessionHydrationRef.current = {
           ...hydration,
           resolve,
@@ -1147,7 +1195,12 @@ export function useChatSession({
         setChatSessionId(hydration.sessionId);
       });
     },
-    [clearPendingSessionHydration, baseSetMessages, syncResumedVersion],
+    [
+      clearPendingSessionHydration,
+      baseSetMessages,
+      syncResumedVersion,
+      syncRestoredToolRenderOverrides,
+    ],
   );
 
   const [traceTranscriptFromUi, setTraceTranscriptFromUi] = useState<
@@ -1236,6 +1289,17 @@ export function useChatSession({
     livePreviewSpanCount > 0 || (liveTraceEnvelope?.spans?.length ?? 0) > 0;
 
   useEffect(() => {
+    const pendingSeed = nextLiveTraceSeedRef.current;
+    if (pendingSeed?.sessionId === chatSessionId) {
+      nextLiveTraceSeedRef.current = null;
+      setLiveTraceState(
+        createLiveTraceStateFromRequestPayloadHistory(
+          pendingSeed.requestPayloadHistory,
+        ),
+      );
+      return;
+    }
+
     setLiveTraceState(createEmptyLiveTraceState());
   }, [chatSessionId]);
 
@@ -1265,10 +1329,15 @@ export function useChatSession({
         ) {
           const nextSessionId = generateId();
           clearPendingSessionHydration();
+          nextLiveTraceSeedRef.current = {
+            sessionId: nextSessionId,
+            requestPayloadHistory: [],
+          };
           pendingSessionHydrationRef.current = {
             sessionId: nextSessionId,
             messages: nextMessages,
             resumedVersion: null,
+            requestPayloadHistory: [],
             persistedSnapshotToolCallIds: [],
           };
           queueMicrotask(() => {
@@ -1340,6 +1409,7 @@ export function useChatSession({
   const resetChat = useCallback(() => {
     skipNextForkDetectionRef.current = true;
     clearPendingSessionHydration();
+    nextLiveTraceSeedRef.current = null;
     setChatSessionId(generateId());
     setMessages([]);
     setPersistedSnapshotToolCallIds([]);
@@ -1359,6 +1429,7 @@ export function useChatSession({
       options?: {
         resetReason?: ChatSessionResetReason;
         toolRenderOverrides?: Record<string, ToolRenderOverride>;
+        requestPayloadHistory?: LiveChatTraceRequestPayloadEntry[];
       },
     ) => {
       skipNextForkDetectionRef.current = true;
@@ -1366,6 +1437,7 @@ export function useChatSession({
         sessionId: generateId(),
         messages,
         resumedVersion: null,
+        requestPayloadHistory: options?.requestPayloadHistory,
         toolRenderOverrides: options?.toolRenderOverrides,
         persistedSnapshotToolCallIds: [],
       });

--- a/mcpjam-inspector/client/src/lib/__tests__/eval-request-payload-history.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/eval-request-payload-history.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+import { buildEvalRequestPayloadHistory } from "../eval-request-payload-history";
+
+const serializedTools = {
+  lookup_weather: {
+    name: "lookup_weather",
+    description: "Get weather for a city",
+    inputSchema: {
+      type: "object",
+      properties: {
+        city: { type: "string" },
+      },
+      required: ["city"],
+    },
+  },
+};
+
+describe("buildEvalRequestPayloadHistory", () => {
+  it("builds a single-turn raw request without including the assistant reply", () => {
+    const history = buildEvalRequestPayloadHistory({
+      trace: {
+        messages: [
+          { role: "system", content: "You are helpful." },
+          { role: "user", content: "What is the weather in SF?" },
+          { role: "assistant", content: "It is 62F." },
+        ],
+        spans: [
+          {
+            id: "llm-1",
+            name: "Model response",
+            category: "llm",
+            startMs: 0,
+            endMs: 100,
+            promptIndex: 0,
+            stepIndex: 0,
+            messageStartIndex: 2,
+            messageEndIndex: 2,
+          },
+        ],
+      },
+      systemPrompt: "Be concise.",
+      tools: serializedTools,
+    });
+
+    expect(history).toEqual([
+      {
+        turnId: "eval-turn-1",
+        promptIndex: 0,
+        stepIndex: 0,
+        payload: {
+          system: "Be concise.",
+          tools: serializedTools,
+          messages: [
+            { role: "system", content: "You are helpful." },
+            { role: "user", content: "What is the weather in SF?" },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("builds ordered raw payloads for multi-turn eval traces", () => {
+    const history = buildEvalRequestPayloadHistory({
+      trace: {
+        messages: [
+          { role: "system", content: "You are helpful." },
+          { role: "user", content: "First question" },
+          { role: "assistant", content: "First answer" },
+          { role: "user", content: "Second question" },
+          { role: "assistant", content: "Second answer" },
+        ],
+        spans: [
+          {
+            id: "llm-2",
+            name: "Model response",
+            category: "llm",
+            startMs: 100,
+            endMs: 200,
+            promptIndex: 1,
+            stepIndex: 0,
+            messageStartIndex: 4,
+            messageEndIndex: 4,
+          },
+          {
+            id: "llm-1",
+            name: "Model response",
+            category: "llm",
+            startMs: 0,
+            endMs: 100,
+            promptIndex: 0,
+            stepIndex: 0,
+            messageStartIndex: 2,
+            messageEndIndex: 2,
+          },
+        ],
+      },
+      systemPrompt: "Be concise.",
+      tools: {},
+    });
+
+    expect(history).toEqual([
+      {
+        turnId: "eval-turn-1",
+        promptIndex: 0,
+        stepIndex: 0,
+        payload: {
+          system: "Be concise.",
+          tools: {},
+          messages: [
+            { role: "system", content: "You are helpful." },
+            { role: "user", content: "First question" },
+          ],
+        },
+      },
+      {
+        turnId: "eval-turn-2",
+        promptIndex: 1,
+        stepIndex: 0,
+        payload: {
+          system: "Be concise.",
+          tools: {},
+          messages: [
+            { role: "system", content: "You are helpful." },
+            { role: "user", content: "First question" },
+            { role: "assistant", content: "First answer" },
+            { role: "user", content: "Second question" },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("builds separate raw payloads for multiple model steps in one turn", () => {
+    const history = buildEvalRequestPayloadHistory({
+      trace: {
+        messages: [
+          { role: "system", content: "You are helpful." },
+          { role: "user", content: "Book me a table" },
+          { role: "assistant", content: [{ type: "tool-call", toolName: "lookup_weather" }] },
+          { role: "tool", content: [{ type: "tool-result", toolName: "lookup_weather", result: "Sunny" }] },
+          { role: "assistant", content: "Booked." },
+        ],
+        spans: [
+          {
+            id: "llm-step-1",
+            name: "First model step",
+            category: "llm",
+            startMs: 0,
+            endMs: 50,
+            promptIndex: 0,
+            stepIndex: 0,
+            messageStartIndex: 2,
+            messageEndIndex: 2,
+          },
+          {
+            id: "llm-step-2",
+            name: "Second model step",
+            category: "llm",
+            startMs: 51,
+            endMs: 100,
+            promptIndex: 0,
+            stepIndex: 1,
+            messageStartIndex: 4,
+            messageEndIndex: 4,
+          },
+        ],
+      },
+      systemPrompt: "Be concise.",
+      tools: serializedTools,
+    });
+
+    expect(history).toEqual([
+      {
+        turnId: "eval-turn-1",
+        promptIndex: 0,
+        stepIndex: 0,
+        payload: {
+          system: "Be concise.",
+          tools: serializedTools,
+          messages: [
+            { role: "system", content: "You are helpful." },
+            { role: "user", content: "Book me a table" },
+          ],
+        },
+      },
+      {
+        turnId: "eval-turn-1",
+        promptIndex: 0,
+        stepIndex: 1,
+        payload: {
+          system: "Be concise.",
+          tools: serializedTools,
+          messages: [
+            { role: "system", content: "You are helpful." },
+            { role: "user", content: "Book me a table" },
+            {
+              role: "assistant",
+              content: [{ type: "tool-call", toolName: "lookup_weather" }],
+            },
+            {
+              role: "tool",
+              content: [
+                {
+                  type: "tool-result",
+                  toolName: "lookup_weather",
+                  result: "Sunny",
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it("drops spans whose input cannot be reconstructed exactly", () => {
+    const history = buildEvalRequestPayloadHistory({
+      trace: {
+        messages: [{ role: "assistant", content: "No prior context" }],
+        spans: [
+          {
+            id: "llm-0",
+            name: "Model response",
+            category: "llm",
+            startMs: 0,
+            endMs: 100,
+            promptIndex: 0,
+            stepIndex: 0,
+            messageStartIndex: 0,
+            messageEndIndex: 0,
+          },
+        ],
+      },
+      systemPrompt: "Be concise.",
+      tools: {},
+    });
+
+    expect(history).toEqual([]);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/eval-chat-handoff.ts
+++ b/mcpjam-inspector/client/src/lib/eval-chat-handoff.ts
@@ -1,4 +1,5 @@
 import type { UIMessage } from "@ai-sdk/react";
+import type { LiveChatTraceRequestPayloadEntry } from "@/shared/live-chat-trace";
 
 export type EvalChatHandoff = {
   id: string;
@@ -7,4 +8,5 @@ export type EvalChatHandoff = {
   modelId?: string;
   systemPrompt?: string;
   temperature?: number;
+  requestPayloadHistory?: LiveChatTraceRequestPayloadEntry[];
 };

--- a/mcpjam-inspector/client/src/lib/eval-request-payload-history.ts
+++ b/mcpjam-inspector/client/src/lib/eval-request-payload-history.ts
@@ -1,0 +1,178 @@
+import type { EvalTraceSpan } from "@/shared/eval-trace";
+import type { LiveChatTraceRequestPayloadEntry } from "@/shared/live-chat-trace";
+import type {
+  ResolvedModelRequestPayload,
+  SerializedModelRequestTool,
+} from "@/shared/model-request-payload";
+
+type EvalTraceLike = {
+  messages?: ResolvedModelRequestPayload["messages"] | null;
+  spans?: EvalTraceSpan[] | null;
+} | null;
+
+type TranscriptRange = {
+  startIndex: number;
+  endIndex: number;
+};
+
+function getTranscriptRange(
+  startIndex?: number,
+  endIndex?: number,
+): TranscriptRange | null {
+  if (
+    !Number.isInteger(startIndex) ||
+    !Number.isInteger(endIndex) ||
+    startIndex! < 0 ||
+    endIndex! < startIndex!
+  ) {
+    return null;
+  }
+
+  return {
+    startIndex: startIndex!,
+    endIndex: endIndex!,
+  };
+}
+
+/**
+ * Reconstruct the exact model input for a recorded LLM span:
+ * all transcript messages up to, but not including, the first assistant reply
+ * contained within the span's message range.
+ */
+function getLlmInputMessages(
+  messages: ResolvedModelRequestPayload["messages"],
+  startIndex?: number,
+  endIndex?: number,
+): ResolvedModelRequestPayload["messages"] {
+  const range = getTranscriptRange(startIndex, endIndex);
+  if (!range) {
+    return [];
+  }
+
+  const slice = messages.slice(range.startIndex, range.endIndex + 1);
+  if (slice.length === 0) {
+    return [];
+  }
+
+  let firstAssistantInSlice = -1;
+  for (let index = 0; index < slice.length; index += 1) {
+    if (slice[index]?.role === "assistant") {
+      firstAssistantInSlice = index;
+      break;
+    }
+  }
+
+  if (firstAssistantInSlice < 0) {
+    return messages.slice(0, range.endIndex + 1);
+  }
+
+  const absoluteFirstAssistant = range.startIndex + firstAssistantInSlice;
+  if (absoluteFirstAssistant === 0) {
+    return [];
+  }
+
+  return messages.slice(0, absoluteFirstAssistant);
+}
+
+function cloneSerializedTools(
+  tools: Record<string, SerializedModelRequestTool>,
+): Record<string, SerializedModelRequestTool> {
+  return Object.fromEntries(
+    Object.entries(tools).map(([name, tool]) => [
+      name,
+      {
+        ...tool,
+        inputSchema:
+          tool.inputSchema && typeof tool.inputSchema === "object"
+            ? { ...tool.inputSchema }
+            : tool.inputSchema,
+      },
+    ]),
+  );
+}
+
+export function buildEvalRequestPayloadHistory(options: {
+  trace: EvalTraceLike;
+  systemPrompt?: string;
+  tools?: Record<string, SerializedModelRequestTool>;
+}): LiveChatTraceRequestPayloadEntry[] {
+  const messages = options.trace?.messages;
+  const spans = options.trace?.spans;
+  if (!Array.isArray(messages) || messages.length === 0 || !Array.isArray(spans)) {
+    return [];
+  }
+
+  const orderedLlmSpans = spans
+    .filter(
+      (span) =>
+        span.category === "llm" &&
+        typeof span.messageStartIndex === "number" &&
+        typeof span.messageEndIndex === "number" &&
+        span.messageStartIndex >= 0 &&
+        span.messageEndIndex >= span.messageStartIndex,
+    )
+    .sort((left, right) => {
+      const promptDelta = (left.promptIndex ?? 0) - (right.promptIndex ?? 0);
+      if (promptDelta !== 0) {
+        return promptDelta;
+      }
+
+      const stepDelta = (left.stepIndex ?? 0) - (right.stepIndex ?? 0);
+      if (stepDelta !== 0) {
+        return stepDelta;
+      }
+
+      const startDelta = left.startMs - right.startMs;
+      if (startDelta !== 0) {
+        return startDelta;
+      }
+
+      const endDelta = left.endMs - right.endMs;
+      if (endDelta !== 0) {
+        return endDelta;
+      }
+
+      return left.id.localeCompare(right.id);
+    });
+
+  if (orderedLlmSpans.length === 0) {
+    return [];
+  }
+
+  const seenPromptSteps = new Set<string>();
+  const resolvedTools = cloneSerializedTools(options.tools ?? {});
+  const resolvedSystemPrompt = options.systemPrompt ?? "";
+  const history: LiveChatTraceRequestPayloadEntry[] = [];
+
+  for (const span of orderedLlmSpans) {
+    const promptIndex = span.promptIndex ?? 0;
+    const stepIndex = span.stepIndex ?? 0;
+    const promptStepKey = `${promptIndex}:${stepIndex}`;
+    if (seenPromptSteps.has(promptStepKey)) {
+      continue;
+    }
+
+    const inputMessages = getLlmInputMessages(
+      messages,
+      span.messageStartIndex,
+      span.messageEndIndex,
+    );
+    if (inputMessages.length === 0) {
+      continue;
+    }
+
+    seenPromptSteps.add(promptStepKey);
+    history.push({
+      turnId: `eval-turn-${promptIndex + 1}`,
+      promptIndex,
+      stepIndex,
+      payload: {
+        system: resolvedSystemPrompt,
+        tools: cloneSerializedTools(resolvedTools),
+        messages: [...inputMessages],
+      },
+    });
+  }
+
+  return history;
+}


### PR DESCRIPTION
This fixes Continue in Chat from eval results so the Raw tab no longer gets stuck loading.

What changed:

when you click Continue in Chat, we now rebuild the eval run’s request payload history from the saved trace
we also fetch the current tool definitions and pass the raw payloads into the new chat session
the new chat is seeded with both the visible messages and the raw request history, so Raw shows real JSON immediately
Tests were added/updated for payload reconstruction, handoff seeding, and Raw rendering after handoff.