### PR TITLE
Fix stale OAuth state after server reconnects

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
@@ -8,6 +8,7 @@ const {
   mockListServers,
   mockUseServerMutations,
   mockConvexQuery,
+  testConnectionMock,
   toastSuccess,
 } = vi.hoisted(() => ({
   mockHandleOAuthCallback: vi.fn(),
@@ -18,6 +19,7 @@ const {
     deleteServer: vi.fn(),
   })),
   mockConvexQuery: vi.fn(),
+  testConnectionMock: vi.fn(),
   toastSuccess: vi.fn(),
 }));
 
@@ -32,7 +34,7 @@ vi.mock("@/lib/config", () => ({
 }));
 
 vi.mock("@/state/mcp-api", () => ({
-  testConnection: vi.fn(),
+  testConnection: testConnectionMock,
   deleteServer: vi.fn(),
   listServers: mockListServers,
   reconnectServer: vi.fn(),
@@ -87,8 +89,13 @@ describe("useServerState hosted OAuth callback guards", () => {
     mockHandleOAuthCallback.mockReset();
     mockListServers.mockReset();
     mockConvexQuery.mockReset();
+    testConnectionMock.mockReset();
     toastSuccess.mockReset();
     mockListServers.mockResolvedValue({ success: true, servers: [] });
+    testConnectionMock.mockResolvedValue({
+      success: true,
+      initInfo: {},
+    });
   });
 
   it("defers hosted sandbox OAuth callbacks to App.tsx", async () => {
@@ -152,13 +159,15 @@ describe("useServerState hosted OAuth callback guards", () => {
       },
     });
 
+    const dispatch = vi.fn();
+
     renderHook(() =>
       useServerState({
         appState: {
           servers: {},
           selectedMultipleServers: [],
         } as any,
-        dispatch: vi.fn(),
+        dispatch,
         isLoading: false,
         isAuthenticated: true,
         isAuthLoading: false,
@@ -185,6 +194,17 @@ describe("useServerState hosted OAuth callback guards", () => {
           serverName: "asana",
         }),
         "oauth-code",
+      );
+    });
+
+    await waitFor(() => {
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "CONNECT_SUCCESS",
+          name: "asana",
+          useOAuth: true,
+          tokens: undefined,
+        }),
       );
     });
   });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -456,6 +456,145 @@ describe("useServerState OAuth callback failures", () => {
   });
 });
 
+describe("useServerState auth mode regressions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    window.history.replaceState({}, "", "/");
+    useClientConfigStore.setState({
+      activeWorkspaceId: null,
+      defaultConfig: null,
+      savedConfig: undefined,
+      draftConfig: null,
+      clientCapabilitiesText: "{}",
+      hostContextText: "{}",
+      clientCapabilitiesError: null,
+      hostContextError: null,
+      isSaving: false,
+      isDirty: false,
+      pendingWorkspaceId: null,
+      pendingSavedConfig: undefined,
+      isAwaitingRemoteEcho: false,
+    });
+    getStoredTokensMock.mockReturnValue(undefined);
+    testConnectionMock.mockResolvedValue({
+      success: true,
+      initInfo: {},
+    });
+    initiateOAuthMock.mockResolvedValue({ success: true });
+    mockConvexQuery.mockResolvedValue(null);
+  });
+
+  it("dispatches explicit non-OAuth success when updating an OAuth server to direct auth", async () => {
+    const { deleteServer } = await import("@/state/mcp-api");
+    vi.mocked(deleteServer).mockResolvedValue({ success: true } as any);
+
+    const appState = createAppState();
+    const oauthServer = {
+      ...appState.servers["demo-server"],
+      connectionStatus: "connected" as const,
+      oauthTokens: {
+        access_token: "expired-token",
+        refresh_token: "refresh-token",
+      },
+      useOAuth: true,
+    };
+    appState.servers["demo-server"] = oauthServer as any;
+    appState.workspaces.default.servers["demo-server"] = {
+      ...oauthServer,
+    } as any;
+
+    const dispatch = vi.fn();
+    const { result } = renderUseServerState(dispatch, appState);
+
+    await act(async () => {
+      await result.current.handleUpdate("demo-server", {
+        name: "demo-server",
+        type: "http",
+        url: "https://example.com/mcp",
+        useOAuth: false,
+      });
+    });
+
+    const connectSuccessAction = dispatch.mock.calls
+      .map(([action]) => action)
+      .find(
+        (
+          action,
+        ): action is Extract<AppAction, { type: "CONNECT_SUCCESS" }> =>
+          action.type === "CONNECT_SUCCESS",
+      );
+
+    expect(connectSuccessAction).toMatchObject({
+      type: "CONNECT_SUCCESS",
+      name: "demo-server",
+      useOAuth: false,
+    });
+    expect(clearOAuthDataMock).toHaveBeenCalledWith("demo-server");
+    expect(initiateOAuthMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps reconnects on the direct path once a server is marked non-OAuth", async () => {
+    const { reconnectServer } = await import("@/state/mcp-api");
+    const { ensureAuthorizedForReconnect } =
+      await import("@/state/oauth-orchestrator");
+    vi.mocked(reconnectServer).mockResolvedValue({
+      success: true,
+      initInfo: {},
+    } as any);
+
+    const appState = createAppState();
+    const directServer = {
+      ...appState.servers["demo-server"],
+      connectionStatus: "connected" as const,
+      oauthTokens: undefined,
+      useOAuth: false,
+    };
+    appState.servers["demo-server"] = directServer as any;
+    appState.workspaces.default.servers["demo-server"] = {
+      ...directServer,
+    } as any;
+
+    vi.mocked(ensureAuthorizedForReconnect).mockResolvedValue({
+      kind: "ready",
+      serverConfig: directServer.config,
+      tokens: undefined,
+    } as any);
+
+    const dispatch = vi.fn();
+    const { result } = renderUseServerState(dispatch, appState);
+
+    await act(async () => {
+      await result.current.handleReconnect("demo-server");
+    });
+
+    expect(vi.mocked(ensureAuthorizedForReconnect)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "demo-server",
+        useOAuth: false,
+      }),
+      expect.any(Object),
+    );
+
+    const connectSuccessAction = dispatch.mock.calls
+      .map(([action]) => action)
+      .find(
+        (
+          action,
+        ): action is Extract<AppAction, { type: "CONNECT_SUCCESS" }> =>
+          action.type === "CONNECT_SUCCESS",
+      );
+
+    expect(connectSuccessAction).toMatchObject({
+      type: "CONNECT_SUCCESS",
+      name: "demo-server",
+      useOAuth: false,
+      tokens: undefined,
+    });
+    expect(initiateOAuthMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("useServerState authenticated fallback persistence", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -685,6 +685,7 @@ export function useServerState({
                   tokens: isHostedWorkspaceCallback
                     ? undefined
                     : getStoredTokens(serverName),
+                  useOAuth: true,
                 });
                 logger.info("OAuth connection successful", { serverName });
                 toast.success(
@@ -940,6 +941,7 @@ export function useServerState({
                 name: formData.name,
                 config: serverConfig,
                 tokens: existingTokens,
+                useOAuth: true,
               });
               toast.success(
                 "Connected successfully with existing OAuth tokens!",
@@ -1007,6 +1009,7 @@ export function useServerState({
                     HOSTED_MODE && isAuthenticated
                       ? undefined
                       : getStoredTokens(formData.name),
+                  useOAuth: true,
                 });
                 toast.success("Connected successfully with OAuth!");
                 storeInitInfo(formData.name, connectionResult.initInfo).catch(
@@ -1062,6 +1065,7 @@ export function useServerState({
             type: "CONNECT_SUCCESS",
             name: formData.name,
             config: mcpConfig,
+            useOAuth: formData.useOAuth ?? false,
           });
           const env = (mcpConfig as any).env;
           if (env && Object.keys(env).length > 0) {
@@ -1278,6 +1282,7 @@ export function useServerState({
             name: serverName,
             config: serverConfig,
             tokens: getStoredTokens(serverName),
+            useOAuth: true,
           });
           await storeInitInfo(serverName, result.initInfo);
           return { success: true };
@@ -1625,6 +1630,7 @@ export function useServerState({
               HOSTED_MODE && isAuthenticated
                 ? undefined
                 : getStoredTokens(serverName),
+            useOAuth: true,
           });
           logger.info("Reconnection with fresh OAuth successful", {
             serverName,
@@ -1677,6 +1683,7 @@ export function useServerState({
             name: serverName,
             config: authResult.serverConfig,
             tokens: authResult.tokens,
+            useOAuth: server.useOAuth === true || authResult.tokens != null,
           });
           logger.info("Reconnection successful", { serverName, result });
           storeInitInfo(serverName, result.initInfo).catch((err) =>
@@ -1871,6 +1878,7 @@ export function useServerState({
               type: "CONNECT_SUCCESS",
               name: originalServerName,
               config: mcpConfig,
+              useOAuth: true,
             });
             await storeInitInfo(originalServerName, result.initInfo);
             toast.success("Server configuration updated successfully!");

--- a/mcpjam-inspector/client/src/state/__tests__/app-reducer.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/app-reducer.test.ts
@@ -213,6 +213,63 @@ describe("appReducer", () => {
       expect(result.servers["oauth-server"].useOAuth).toBe(true);
     });
 
+    it("preserves OAuth mode when hosted auth succeeds without browser tokens", () => {
+      const server = createServer("oauth-server", {
+        connectionStatus: "connecting",
+        useOAuth: true,
+      });
+      const workspace: Workspace = {
+        id: "workspace-1",
+        name: "Test",
+        servers: { "oauth-server": server },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const state = createInitialState({
+        servers: { "oauth-server": server },
+        workspaces: { "workspace-1": workspace },
+        activeWorkspaceId: "workspace-1",
+      });
+
+      const result = appReducer(state, {
+        type: "CONNECT_SUCCESS",
+        name: "oauth-server",
+        config: server.config,
+      });
+
+      expect(result.servers["oauth-server"].useOAuth).toBe(true);
+      expect(result.servers["oauth-server"].oauthTokens).toBeUndefined();
+    });
+
+    it("allows explicit non-OAuth success to clear stale OAuth mode", () => {
+      const server = createServer("oauth-server", {
+        connectionStatus: "connecting",
+        useOAuth: true,
+      });
+      const workspace: Workspace = {
+        id: "workspace-1",
+        name: "Test",
+        servers: { "oauth-server": server },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+      const state = createInitialState({
+        servers: { "oauth-server": server },
+        workspaces: { "workspace-1": workspace },
+        activeWorkspaceId: "workspace-1",
+      });
+
+      const result = appReducer(state, {
+        type: "CONNECT_SUCCESS",
+        name: "oauth-server",
+        config: server.config,
+        useOAuth: false,
+      });
+
+      expect(result.servers["oauth-server"].useOAuth).toBe(false);
+      expect(result.servers["oauth-server"].oauthTokens).toBeUndefined();
+    });
+
     it("creates server if it does not exist (Convex-synced servers)", () => {
       const workspace: Workspace = {
         id: "workspace-1",

--- a/mcpjam-inspector/client/src/state/app-reducer.ts
+++ b/mcpjam-inspector/client/src/state/app-reducer.ts
@@ -60,6 +60,9 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         retryCount: 0,
         enabled: true,
       };
+      const shouldUseOAuth =
+        action.useOAuth ??
+        (baseServer.useOAuth === true || action.tokens != null);
       const nextServer = setStatus(baseServer, "connected", {
         config: action.config,
         lastConnectionTime: new Date(),
@@ -67,8 +70,9 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         lastError: undefined,
         oauthTokens: action.tokens,
         enabled: true,
-        // Track whether this server uses OAuth based on whether tokens were provided
-        useOAuth: action.tokens != null,
+        // Hosted workspace OAuth can succeed without browser-side tokens.
+        // Preserve explicit auth mode when the dispatch provides it.
+        useOAuth: shouldUseOAuth,
       });
       return {
         ...state,

--- a/mcpjam-inspector/client/src/state/app-types.ts
+++ b/mcpjam-inspector/client/src/state/app-types.ts
@@ -87,6 +87,7 @@ export type AppAction =
       name: string;
       config: MCPServerConfig;
       tokens?: OauthTokens;
+      useOAuth?: boolean;
     }
   | { type: "CONNECT_FAILURE"; name: string; error: string }
   | { type: "RECONNECT_REQUEST"; name: string; config: MCPServerConfig }


### PR DESCRIPTION
## Summary
- pass explicit `useOAuth` values on all `CONNECT_SUCCESS` paths in `use-server-state`
- prevent edited servers from retaining stale OAuth mode after switching to direct auth
- add hook regressions for direct-auth reconnects and hosted tokenless OAuth callback success

## Testing
- `npm run test -w @mcpjam/inspector -- client/src/state/__tests__/app-reducer.test.ts client/src/hooks/__tests__/use-server-state.test.tsx client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `CONNECT_SUCCESS` determines and persists `useOAuth`, affecting connect/reconnect behavior (including hosted tokenless OAuth). Risk is moderate because incorrect flags could send users down the wrong auth path or clear tokens unexpectedly.
> 
> **Overview**
> **Fixes stale OAuth mode after connect/reconnect.** `CONNECT_SUCCESS` now accepts an optional `useOAuth` flag and the reducer preserves existing OAuth mode (or explicit overrides) instead of inferring it solely from presence of tokens, which fixes hosted workspace OAuth success cases that have no browser tokens.
> 
> **Propagates explicit auth mode from the hook.** `useServerState` now dispatches `CONNECT_SUCCESS` with `useOAuth` across OAuth, direct-auth, update, and reconnect paths (including switching an OAuth server to direct auth), and adds regression tests covering tokenless hosted OAuth callbacks and direct-auth reconnect/update scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b34febd9e89326ac6b4e01881b09e864f2f4621e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->