### PR TITLE
Fix hosted reconnects to reuse stored OAuth before prompting for consent

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useServerState } from "../use-server-state";
 import { writeHostedOAuthPendingMarker } from "@/lib/hosted-oauth-callback";
@@ -6,6 +6,8 @@ import { writeHostedOAuthPendingMarker } from "@/lib/hosted-oauth-callback";
 const {
   mockHandleOAuthCallback,
   mockListServers,
+  mockReconnectServer,
+  mockEnsureAuthorizedForReconnect,
   mockUseServerMutations,
   mockConvexQuery,
   testConnectionMock,
@@ -13,6 +15,8 @@ const {
 } = vi.hoisted(() => ({
   mockHandleOAuthCallback: vi.fn(),
   mockListServers: vi.fn(),
+  mockReconnectServer: vi.fn(),
+  mockEnsureAuthorizedForReconnect: vi.fn(),
   mockUseServerMutations: vi.fn(() => ({
     createServer: vi.fn(),
     updateServer: vi.fn(),
@@ -37,12 +41,12 @@ vi.mock("@/state/mcp-api", () => ({
   testConnection: testConnectionMock,
   deleteServer: vi.fn(),
   listServers: mockListServers,
-  reconnectServer: vi.fn(),
+  reconnectServer: mockReconnectServer,
   getInitializationInfo: vi.fn(),
 }));
 
 vi.mock("@/state/oauth-orchestrator", () => ({
-  ensureAuthorizedForReconnect: vi.fn(),
+  ensureAuthorizedForReconnect: mockEnsureAuthorizedForReconnect,
 }));
 
 vi.mock("@/lib/oauth/mcp-oauth", () => ({
@@ -81,6 +85,91 @@ vi.mock("../useWorkspaces", () => ({
   useServerMutations: mockUseServerMutations,
 }));
 
+function renderHostedServerState(dispatch = vi.fn()) {
+  return renderHook(() =>
+    useServerState({
+      appState: {
+        activeWorkspaceId: "ws_1",
+        workspaces: {
+          ws_1: {
+            id: "ws_1",
+            name: "Workspace",
+            servers: {
+              asana: {
+                name: "asana",
+                config: {
+                  type: "http",
+                  url: "https://mcp.asana.com/sse",
+                },
+                lastConnectionTime: new Date(),
+                connectionStatus: "disconnected",
+                retryCount: 0,
+                enabled: true,
+                useOAuth: true,
+              },
+            },
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        },
+        servers: {
+          asana: {
+            name: "asana",
+            config: {
+              type: "http",
+              url: "https://mcp.asana.com/sse",
+            },
+            lastConnectionTime: new Date(),
+            connectionStatus: "disconnected",
+            retryCount: 0,
+            enabled: true,
+            useOAuth: true,
+          },
+        },
+        selectedServer: "asana",
+        selectedMultipleServers: [],
+        isMultiSelectMode: false,
+      } as any,
+      dispatch,
+      isLoading: false,
+      isAuthenticated: true,
+      isAuthLoading: false,
+      isLoadingWorkspaces: false,
+      useLocalFallback: false,
+      effectiveWorkspaces: {
+        ws_1: {
+          id: "ws_1",
+          name: "Workspace",
+          servers: {
+            asana: {
+              name: "asana",
+              config: {
+                type: "http",
+                url: "https://mcp.asana.com/sse",
+              },
+              lastConnectionTime: new Date(),
+              connectionStatus: "disconnected",
+              retryCount: 0,
+              enabled: true,
+              useOAuth: true,
+            },
+          },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      } as any,
+      effectiveActiveWorkspaceId: "ws_1",
+      activeWorkspaceServersFlat: [{ _id: "srv_asana", name: "asana" }],
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+    }),
+  );
+}
+
 describe("useServerState hosted OAuth callback guards", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -88,10 +177,16 @@ describe("useServerState hosted OAuth callback guards", () => {
     window.history.replaceState({}, "", "/?code=oauth-code");
     mockHandleOAuthCallback.mockReset();
     mockListServers.mockReset();
+    mockReconnectServer.mockReset();
+    mockEnsureAuthorizedForReconnect.mockReset();
     mockConvexQuery.mockReset();
     testConnectionMock.mockReset();
     toastSuccess.mockReset();
     mockListServers.mockResolvedValue({ success: true, servers: [] });
+    mockReconnectServer.mockResolvedValue({
+      success: true,
+      initInfo: {},
+    });
     testConnectionMock.mockResolvedValue({
       success: true,
       initInfo: {},
@@ -204,6 +299,66 @@ describe("useServerState hosted OAuth callback guards", () => {
           name: "asana",
           useOAuth: true,
           tokens: undefined,
+        }),
+      );
+    });
+  });
+
+  it("reuses hosted stored OAuth credentials on reconnect before falling back to interactive OAuth", async () => {
+    const dispatch = vi.fn();
+    const { result } = renderHostedServerState(dispatch);
+
+    await act(async () => {
+      await result.current.handleReconnect("asana");
+    });
+
+    await waitFor(() => {
+      expect(mockReconnectServer).toHaveBeenCalledWith(
+        "asana",
+        expect.objectContaining({
+          type: "http",
+          url: "https://mcp.asana.com/sse",
+        }),
+      );
+    });
+
+    expect(mockEnsureAuthorizedForReconnect).not.toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "CONNECT_SUCCESS",
+        name: "asana",
+        useOAuth: true,
+        tokens: undefined,
+      }),
+    );
+  });
+
+  it("falls back to interactive OAuth when hosted stored-auth reconnect says authorization is required", async () => {
+    mockReconnectServer.mockRejectedValueOnce(
+      new Error(
+        'Server "srv_asana" requires OAuth authentication. Please complete the OAuth flow first.',
+      ),
+    );
+    mockEnsureAuthorizedForReconnect.mockResolvedValueOnce({
+      kind: "error",
+      error: "OAuth init failed",
+    });
+
+    const dispatch = vi.fn();
+    const { result } = renderHostedServerState(dispatch);
+
+    await act(async () => {
+      await result.current.handleReconnect("asana");
+    });
+
+    await waitFor(() => {
+      expect(mockEnsureAuthorizedForReconnect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "asana",
+          useOAuth: true,
+        }),
+        expect.objectContaining({
+          beforeRedirect: expect.any(Function),
         }),
       );
     });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
@@ -2,6 +2,7 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useServerState } from "../use-server-state";
 import { writeHostedOAuthPendingMarker } from "@/lib/hosted-oauth-callback";
+import { getDefaultClientCapabilities } from "@mcpjam/sdk/browser";
 
 const {
   mockHandleOAuthCallback,
@@ -85,7 +86,16 @@ vi.mock("../useWorkspaces", () => ({
   useServerMutations: mockUseServerMutations,
 }));
 
-function renderHostedServerState(dispatch = vi.fn()) {
+function renderHostedServerState(
+  dispatch = vi.fn(),
+  options?: {
+    workspaceClientConfig?: {
+      version: 1;
+      clientCapabilities: Record<string, unknown>;
+      hostContext: Record<string, unknown>;
+    };
+  },
+) {
   return renderHook(() =>
     useServerState({
       appState: {
@@ -94,6 +104,7 @@ function renderHostedServerState(dispatch = vi.fn()) {
           ws_1: {
             id: "ws_1",
             name: "Workspace",
+            clientConfig: options?.workspaceClientConfig,
             servers: {
               asana: {
                 name: "asana",
@@ -140,6 +151,7 @@ function renderHostedServerState(dispatch = vi.fn()) {
         ws_1: {
           id: "ws_1",
           name: "Workspace",
+          clientConfig: options?.workspaceClientConfig,
           servers: {
             asana: {
               name: "asana",
@@ -305,8 +317,20 @@ describe("useServerState hosted OAuth callback guards", () => {
   });
 
   it("reuses hosted stored OAuth credentials on reconnect before falling back to interactive OAuth", async () => {
+    const workspaceClientConfig = {
+      version: 1 as const,
+      clientCapabilities: {
+        ...(getDefaultClientCapabilities() as Record<string, unknown>),
+        experimental: {
+          workspaceProfile: {},
+        },
+      },
+      hostContext: {},
+    };
     const dispatch = vi.fn();
-    const { result } = renderHostedServerState(dispatch);
+    const { result } = renderHostedServerState(dispatch, {
+      workspaceClientConfig,
+    });
 
     await act(async () => {
       await result.current.handleReconnect("asana");
@@ -318,6 +342,11 @@ describe("useServerState hosted OAuth callback guards", () => {
         expect.objectContaining({
           type: "http",
           url: "https://mcp.asana.com/sse",
+          clientCapabilities: expect.objectContaining({
+            experimental: {
+              workspaceProfile: {},
+            },
+          }),
         }),
       );
     });
@@ -329,6 +358,9 @@ describe("useServerState hosted OAuth callback guards", () => {
         name: "asana",
         useOAuth: true,
         tokens: undefined,
+        config: expect.not.objectContaining({
+          clientCapabilities: expect.anything(),
+        }),
       }),
     );
   });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
@@ -366,6 +366,37 @@ describe("useServerState hosted OAuth callback guards", () => {
   });
 
   it("falls back to interactive OAuth when hosted stored-auth reconnect says authorization is required", async () => {
+    mockReconnectServer.mockResolvedValueOnce({
+      success: false,
+      error:
+        'Server "srv_asana" requires OAuth authentication. Please complete the OAuth flow first.',
+    });
+    mockEnsureAuthorizedForReconnect.mockResolvedValueOnce({
+      kind: "error",
+      error: "OAuth init failed",
+    });
+
+    const dispatch = vi.fn();
+    const { result } = renderHostedServerState(dispatch);
+
+    await act(async () => {
+      await result.current.handleReconnect("asana");
+    });
+
+    await waitFor(() => {
+      expect(mockEnsureAuthorizedForReconnect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "asana",
+          useOAuth: true,
+        }),
+        expect.objectContaining({
+          beforeRedirect: expect.any(Function),
+        }),
+      );
+    });
+  });
+
+  it("also falls back to interactive OAuth when hosted reconnect throws the same auth error", async () => {
     mockReconnectServer.mockRejectedValueOnce(
       new Error(
         'Server "srv_asana" requires OAuth authentication. Please complete the OAuth flow first.',

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -108,6 +108,19 @@ function restorePathAfterOAuthCallback(
   return `${basePath}${savedHash}`;
 }
 
+function requiresFreshOAuthAuthorization(errorMessage?: string): boolean {
+  if (!errorMessage) {
+    return false;
+  }
+
+  const normalized = errorMessage.toLowerCase();
+  return (
+    normalized.includes("requires oauth authentication") ||
+    (normalized.includes("authentication failed") &&
+      normalized.includes("invalid_token"))
+  );
+}
+
 interface LoggerLike {
   info: (message: string, meta?: Record<string, unknown>) => void;
   warn: (message: string, meta?: Record<string, unknown>) => void;
@@ -1646,6 +1659,50 @@ export function useServerState({
           error: result.error || "Reconnection failed after OAuth",
         });
         return;
+      }
+
+      if (HOSTED_MODE && isAuthenticated && server.useOAuth === true) {
+        const hostedReconnectConfig = withWorkspaceClientCapabilities(
+          server.config,
+        );
+        const result = await guardedReconnectServer(
+          serverName,
+          hostedReconnectConfig,
+        );
+        if (isStaleOp(serverName, token)) return;
+        if (result.success) {
+          dispatch({
+            type: "CONNECT_SUCCESS",
+            name: serverName,
+            config: hostedReconnectConfig,
+            tokens: undefined,
+            useOAuth: true,
+          });
+          logger.info("Hosted reconnect successful using stored OAuth", {
+            serverName,
+            result,
+          });
+          storeInitInfo(serverName, result.initInfo).catch((err) =>
+            logger.warn("Failed to fetch init info", { serverName, err }),
+          );
+          return;
+        }
+
+        if (!requiresFreshOAuthAuthorization(result.error)) {
+          dispatch({
+            type: "CONNECT_FAILURE",
+            name: serverName,
+            error: result.error || "Reconnection failed",
+          });
+          logger.error("Hosted reconnect failed", { serverName, result });
+          toast.error(result.error || `Failed to reconnect: ${serverName}`);
+          return;
+        }
+
+        logger.info(
+          "Hosted reconnect requires a fresh OAuth flow after stored credential lookup",
+          { serverName, error: result.error },
+        );
       }
 
       try {

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -108,7 +108,14 @@ function restorePathAfterOAuthCallback(
   return `${basePath}${savedHash}`;
 }
 
-function requiresFreshOAuthAuthorization(errorMessage?: string): boolean {
+function requiresFreshOAuthAuthorization(error: unknown): boolean {
+  const errorMessage =
+    typeof error === "string"
+      ? error
+      : error instanceof Error
+        ? error.message
+        : "";
+
   if (!errorMessage) {
     return false;
   }
@@ -1665,44 +1672,70 @@ export function useServerState({
         const hostedReconnectConfig = withWorkspaceClientCapabilities(
           server.config,
         );
-        const result = await guardedReconnectServer(
-          serverName,
-          hostedReconnectConfig,
-        );
-        if (isStaleOp(serverName, token)) return;
-        if (result.success) {
-          dispatch({
-            type: "CONNECT_SUCCESS",
-            name: serverName,
-            config: hostedReconnectConfig,
-            tokens: undefined,
-            useOAuth: true,
-          });
-          logger.info("Hosted reconnect successful using stored OAuth", {
+        try {
+          const result = await guardedReconnectServer(
             serverName,
-            result,
-          });
-          storeInitInfo(serverName, result.initInfo).catch((err) =>
-            logger.warn("Failed to fetch init info", { serverName, err }),
+            hostedReconnectConfig,
           );
-          return;
-        }
+          if (isStaleOp(serverName, token)) return;
+          if (result.success) {
+            dispatch({
+              type: "CONNECT_SUCCESS",
+              name: serverName,
+              config: hostedReconnectConfig,
+              tokens: undefined,
+              useOAuth: true,
+            });
+            logger.info("Hosted reconnect successful using stored OAuth", {
+              serverName,
+              result,
+            });
+            storeInitInfo(serverName, result.initInfo).catch((err) =>
+              logger.warn("Failed to fetch init info", { serverName, err }),
+            );
+            return;
+          }
 
-        if (!requiresFreshOAuthAuthorization(result.error)) {
-          dispatch({
-            type: "CONNECT_FAILURE",
-            name: serverName,
-            error: result.error || "Reconnection failed",
-          });
-          logger.error("Hosted reconnect failed", { serverName, result });
-          toast.error(result.error || `Failed to reconnect: ${serverName}`);
-          return;
-        }
+          if (!requiresFreshOAuthAuthorization(result.error)) {
+            dispatch({
+              type: "CONNECT_FAILURE",
+              name: serverName,
+              error: result.error || "Reconnection failed",
+            });
+            logger.error("Hosted reconnect failed", { serverName, result });
+            toast.error(result.error || `Failed to reconnect: ${serverName}`);
+            return;
+          }
 
-        logger.info(
-          "Hosted reconnect requires a fresh OAuth flow after stored credential lookup",
-          { serverName, error: result.error },
-        );
+          logger.info(
+            "Hosted reconnect requires a fresh OAuth flow after stored credential lookup",
+            { serverName, error: result.error },
+          );
+        } catch (error) {
+          if (isStaleOp(serverName, token)) return;
+
+          const errorMessage =
+            error instanceof Error ? error.message : "Unknown error";
+
+          if (!requiresFreshOAuthAuthorization(error)) {
+            dispatch({
+              type: "CONNECT_FAILURE",
+              name: serverName,
+              error: errorMessage,
+            });
+            logger.error("Hosted reconnect failed", {
+              serverName,
+              error: errorMessage,
+            });
+            toast.error(errorMessage || `Failed to reconnect: ${serverName}`);
+            return;
+          }
+
+          logger.info(
+            "Hosted reconnect requires a fresh OAuth flow after stored credential lookup",
+            { serverName, error: errorMessage },
+          );
+        }
       }
 
       try {

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1682,7 +1682,7 @@ export function useServerState({
             dispatch({
               type: "CONNECT_SUCCESS",
               name: serverName,
-              config: hostedReconnectConfig,
+              config: server.config,
               tokens: undefined,
               useOAuth: true,
             });


### PR DESCRIPTION
## Summary
- attempt hosted OAuth reconnects with the existing server config before launching a fresh OAuth flow
- keep consent prompts as a fallback only when the backend reports that authorization is actually missing or invalid
- surface non-OAuth reconnect failures immediately instead of redirecting users into consent again

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hosted OAuth reconnect decision logic and error parsing, which can affect when users are redirected for consent vs. shown failures; covered by new tests but still touches auth-adjacent behavior.
> 
> **Overview**
> Improves hosted-mode `handleReconnect` for OAuth-enabled servers by first attempting a backend `reconnectServer` using stored credentials (including workspace client capabilities), and treating it as a successful reconnect without launching a consent flow.
> 
> Adds `requiresFreshOAuthAuthorization` to detect auth-missing/invalid-token errors; only in those cases does reconnect fall back to `ensureAuthorizedForReconnect`, while other reconnect failures now surface immediately via `CONNECT_FAILURE` + toast/logging. Updates tests to cover the stored-credential path and both resolved/rejected auth-required fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61c9a4245318b22ffb0a5b02eff9686e2d553c92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->