### PR TITLE
ui changes to playground

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
@@ -169,7 +169,7 @@ describe("SuiteHeader", () => {
     expect(onShowCasesSidebar).toHaveBeenCalled();
   });
 
-  it("fires the export callback when Export is clicked", async () => {
+  it("fires the export callback when Setup SDK is clicked", async () => {
     const user = userEvent.setup();
     const onOpenExportSuite = vi.fn();
 
@@ -182,7 +182,7 @@ describe("SuiteHeader", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: "Export" }));
+    await user.click(screen.getByRole("button", { name: "Setup SDK" }));
 
     expect(onOpenExportSuite).toHaveBeenCalledTimes(1);
   });

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -376,7 +376,7 @@ export function SuiteHeader(props: SuiteHeaderProps) {
         {onOpenExportSuite ? (
           <Button size="sm" variant="outline" onClick={onOpenExportSuite}>
             <Code2 className="mr-2 h-4 w-4" />
-            Export
+            Setup SDK
           </Button>
         ) : null}
 

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -1290,7 +1290,7 @@ export function TestTemplateEditor({
       ...Object.fromEntries(
         runModelValues.map((modelValue) => [
           modelValue,
-          "tools" as RunColumnTab,
+          "chat" as RunColumnTab,
         ]),
       ),
     }));
@@ -2407,12 +2407,6 @@ function RunColumn({
   const showToolsTab =
     expectedToolCalls.length > 0 || actualToolCalls.length > 0;
 
-  useEffect(() => {
-    if (!showToolsTab && activeTab === "tools") {
-      onTabChange("timeline");
-    }
-  }, [showToolsTab, activeTab, onTabChange]);
-
   const effectiveActiveTab: RunColumnTab =
     activeTab === "tools" && !showToolsTab ? "timeline" : activeTab;
 
@@ -2605,11 +2599,11 @@ function RunColumn({
               {record.modelLabel}
             </div>
             {record.result === "passed" ? (
-              <span className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-emerald-500/15 text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-300">
+              <span className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-emerald-500/15 text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-300" aria-label={statusLabel}>
                 Pass
               </span>
             ) : record.result === "failed" || record.status === "failed" ? (
-              <span className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-rose-500/15 text-rose-700 dark:bg-rose-400/20 dark:text-rose-300">
+              <span className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-rose-500/15 text-rose-700 dark:bg-rose-400/20 dark:text-rose-300" aria-label={statusLabel}>
                 Fail
               </span>
             ) : null}

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -1290,7 +1290,7 @@ export function TestTemplateEditor({
       ...Object.fromEntries(
         runModelValues.map((modelValue) => [
           modelValue,
-          "chat" as RunColumnTab,
+          "tools" as RunColumnTab,
         ]),
       ),
     }));
@@ -2337,12 +2337,11 @@ export function TestTemplateEditor({
                         testCase={currentTestCase}
                         serverNames={connectedServerList}
                         workspaceId={workspaceId}
-                        onContinueInChat={onContinueInChat}
                         onStreamingTraceLoaded={() =>
                           clearCompareStreamingState(record.modelValue)
                         }
                         activeTab={
-                          runColumnTabByModel[record.modelValue] ?? "timeline"
+                          runColumnTabByModel[record.modelValue] ?? "tools"
                         }
                         onTabChange={(tab) =>
                           handleRunColumnTabChange(record.modelValue, tab)
@@ -2414,6 +2413,9 @@ function RunColumn({
     }
   }, [showToolsTab, activeTab, onTabChange]);
 
+  const effectiveActiveTab: RunColumnTab =
+    activeTab === "tools" && !showToolsTab ? "timeline" : activeTab;
+
   /** Status marker: pastel fills aligned with metric bar accent colors. */
   const statusIndicatorClass =
     record.status === "running"
@@ -2444,11 +2446,11 @@ function RunColumn({
       ? `${Math.round(record.metrics.durationMs / 100) / 10}s`
       : "—";
   const traceMode =
-    activeTab === "chat"
+    effectiveActiveTab === "chat"
       ? "chat"
-      : activeTab === "timeline"
+      : effectiveActiveTab === "timeline"
         ? "timeline"
-        : activeTab === "raw"
+        : effectiveActiveTab === "raw"
           ? "raw"
           : "tools";
   const streamingTraceEnvelope = useMemo(
@@ -2597,21 +2599,34 @@ function RunColumn({
   return (
     <div className="flex h-auto min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl border border-border/60 bg-card/40 lg:h-full">
       <div className="shrink-0 border-b px-3 py-2">
-        <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-1.5">
             <div className="truncate text-sm font-semibold leading-tight">
               {record.modelLabel}
             </div>
+            {record.result === "passed" ? (
+              <span className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-emerald-500/15 text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-300">
+                Pass
+              </span>
+            ) : record.result === "failed" || record.status === "failed" ? (
+              <span className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-rose-500/15 text-rose-700 dark:bg-rose-400/20 dark:text-rose-300">
+                Fail
+              </span>
+            ) : null}
           </div>
-          <span
-            role="img"
-            className={cn(
-              "inline-flex shrink-0 rounded-full",
-              statusIndicatorClass,
-            )}
-            aria-label={statusLabel}
-            title={statusLabel}
-          />
+          {record.result !== "passed" &&
+          record.result !== "failed" &&
+          record.status !== "failed" ? (
+            <span
+              role="img"
+              className={cn(
+                "inline-flex shrink-0 rounded-full",
+                statusIndicatorClass,
+              )}
+              aria-label={statusLabel}
+              title={statusLabel}
+            />
+          ) : null}
         </div>
 
         {/* Metric comparison bars */}
@@ -2717,7 +2732,7 @@ function RunColumn({
         <div className="mt-1.5 flex flex-wrap items-center justify-between gap-2">
           <div className="flex min-w-0 flex-wrap items-center gap-1.5">
             <TraceViewModeTabs
-              mode={activeTab}
+              mode={effectiveActiveTab}
               onModeChange={onTabChange}
               showToolsTab={showToolsTab}
               className="[&_button]:px-1.5 [&_button]:py-0.5 [&_button]:text-[11px] [&_svg]:h-3 [&_svg]:w-3"

--- a/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
@@ -55,6 +55,18 @@ export function TraceViewModeTabs({
         className,
       )}
     >
+      {showToolsTab ? (
+        <button
+          type="button"
+          onClick={() => handleModeChange("tools")}
+          className={tabClass(mode === "tools")}
+          title="Expected vs actual tool calls"
+          data-testid="trace-viewer-tools-tab"
+        >
+          <GitCompare className="h-3 w-3 shrink-0" />
+          <span className="truncate">Results</span>
+        </button>
+      ) : null}
       <button
         type="button"
         onClick={() => handleModeChange("timeline")}
@@ -82,18 +94,6 @@ export function TraceViewModeTabs({
         <Code2 className="h-3 w-3 shrink-0" />
         <span className="truncate">Raw</span>
       </button>
-      {showToolsTab ? (
-        <button
-          type="button"
-          onClick={() => handleModeChange("tools")}
-          className={tabClass(mode === "tools")}
-          title="Expected vs actual tool calls"
-          data-testid="trace-viewer-tools-tab"
-        >
-          <GitCompare className="h-3 w-3 shrink-0" />
-          <span className="truncate">Tools</span>
-        </button>
-      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Results tab first in playground test view

The "Tools" tab in the test run results panel has been renamed to "Results" and moved to the first position in the tab bar. It now opens by default when viewing run results, so you land on the pass/fail tool call comparison straight away instead of the trace.

For test cases with no tool calls, the Results tab is hidden and Trace is shown instead — same as before.

Before:

https://github.com/user-attachments/assets/f7be0e79-93ea-4b82-9f13-8843b3208122

After:

https://github.com/user-attachments/assets/3a8121b5-96d0-4a90-9e15-a668666e8e76

