### PR TITLE
changing tabs in playground

### DIFF
--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -137,6 +137,23 @@ export function EvalsTab({
   }, [selectedSuite, suiteDetails, activeIterations]);
   const exploreSuite = selectedSuite;
   const exploreCases = suiteDetails?.testCases ?? EMPTY_CASES;
+  const exploreCaseIdsSignature = useMemo(
+    () => exploreCases.map((testCase) => testCase._id).join("\u0000"),
+    [exploreCases],
+  );
+  const exploreRunIdsSignature = useMemo(
+    () => runsForSelectedSuite.map((run) => run._id).join("\u0000"),
+    [runsForSelectedSuite],
+  );
+  const iterationRunIdsSignature = useMemo(
+    () =>
+      sortedIterations
+        .flatMap((iteration) =>
+          iteration.suiteRunId ? [iteration.suiteRunId] : [],
+        )
+        .join("\u0000"),
+    [sortedIterations],
+  );
 
   useEffect(() => {
     if (
@@ -237,17 +254,24 @@ export function EvalsTab({
 
   useEffect(() => {
     if (!exploreSuite) return;
+    const testCaseIds = exploreCaseIdsSignature
+      ? exploreCaseIdsSignature.split("\u0000")
+      : [];
+    const runIds = exploreRunIdsSignature
+      ? exploreRunIdsSignature.split("\u0000")
+      : [];
+    const iterationRunIds = iterationRunIdsSignature
+      ? iterationRunIdsSignature.split("\u0000")
+      : [];
     const redirectRoute = getPlaygroundCasesRedirect({
       route,
       exploreSuiteId: exploreSuite._id,
       isSuiteDetailsLoading: queries.isSuiteDetailsLoading,
       isSuiteRunsLoading: queries.isSuiteRunsLoading,
       runsCount: runsForSelectedSuite.length,
-      testCaseIds: exploreCases.map((testCase) => testCase._id),
-      runIds: runsForSelectedSuite.map((run) => run._id),
-      iterationRunIds: sortedIterations.flatMap((iteration) =>
-        iteration.suiteRunId ? [iteration.suiteRunId] : [],
-      ),
+      testCaseIds,
+      runIds,
+      iterationRunIds,
     });
     if (!redirectRoute) {
       return;
@@ -255,13 +279,14 @@ export function EvalsTab({
 
     navigatePlaygroundEvalsRoute(redirectRoute, { replace: true });
   }, [
-    exploreCases,
+    exploreCaseIdsSignature,
     exploreSuite,
+    exploreRunIdsSignature,
+    iterationRunIdsSignature,
     queries.isSuiteDetailsLoading,
     queries.isSuiteRunsLoading,
     route,
-    runsForSelectedSuite,
-    sortedIterations,
+    runsForSelectedSuite.length,
   ]);
 
   const handleGenerateMore = useCallback(async () => {

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -22,7 +22,7 @@ import { getBillingErrorMessage } from "@/lib/billing-entitlements";
 import type { EvalChatHandoff } from "@/lib/eval-chat-handoff";
 import type { EvalCase } from "./evals/types";
 import { EXPLORE_SUITE_TAG, isExploreSuite } from "./evals/constants";
-import { shouldAutoOpenPlaygroundCasesView } from "./evals/playground-route-preferences";
+import { getPlaygroundCasesRedirect } from "./evals/playground-route-preferences";
 
 interface EvalsTabProps {
   selectedServer?: string;
@@ -237,31 +237,31 @@ export function EvalsTab({
 
   useEffect(() => {
     if (!exploreSuite) return;
-    if (
-      !shouldAutoOpenPlaygroundCasesView({
-        route,
-        exploreSuiteId: exploreSuite._id,
-        isSuiteDetailsLoading: queries.isSuiteDetailsLoading,
-        runsCount: runsForSelectedSuite.length,
-      })
-    ) {
+    const redirectRoute = getPlaygroundCasesRedirect({
+      route,
+      exploreSuiteId: exploreSuite._id,
+      isSuiteDetailsLoading: queries.isSuiteDetailsLoading,
+      isSuiteRunsLoading: queries.isSuiteRunsLoading,
+      runsCount: runsForSelectedSuite.length,
+      testCaseIds: exploreCases.map((testCase) => testCase._id),
+      runIds: runsForSelectedSuite.map((run) => run._id),
+      iterationRunIds: sortedIterations.flatMap((iteration) =>
+        iteration.suiteRunId ? [iteration.suiteRunId] : [],
+      ),
+    });
+    if (!redirectRoute) {
       return;
     }
 
-    navigatePlaygroundEvalsRoute(
-      {
-        type: "suite-overview",
-        suiteId: exploreSuite._id,
-        view: "test-cases",
-      },
-      { replace: route.type !== "test-detail" && route.type !== "test-edit" },
-    );
+    navigatePlaygroundEvalsRoute(redirectRoute, { replace: true });
   }, [
-    exploreCases.length,
+    exploreCases,
     exploreSuite,
     queries.isSuiteDetailsLoading,
+    queries.isSuiteRunsLoading,
     route,
-    runsForSelectedSuite.length,
+    runsForSelectedSuite,
+    sortedIterations,
   ]);
 
   const handleGenerateMore = useCallback(async () => {

--- a/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
@@ -1,0 +1,289 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  route: {
+    current: {
+      type: "test-edit" as const,
+      suiteId: "suite-a",
+      testId: "case-a",
+      openCompare: true,
+      iteration: "iter-a",
+    },
+  },
+  useEvalQueries: vi.fn(),
+  navigatePlaygroundEvalsRoute: vi.fn(),
+  createTestSuiteMutation: vi.fn(),
+  updateSuiteMutation: vi.fn(),
+}));
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({
+    user: { id: "user-1" },
+  }),
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({
+    isAuthenticated: true,
+    isLoading: false,
+  }),
+  useMutation: () => mocks.updateSuiteMutation,
+}));
+
+vi.mock("@/hooks/use-eval-tab-context", () => ({
+  useEvalTabContext: () => ({
+    connectedServerNames: new Set(["server-a", "server-b"]),
+    userMap: new Map(),
+    canDeleteSuite: false,
+    canDeleteRuns: false,
+    availableModels: [],
+  }),
+}));
+
+vi.mock("@/state/app-state-context", () => ({
+  useSharedAppState: () => ({
+    servers: {
+      "server-a": { connectionStatus: "connected" },
+      "server-b": { connectionStatus: "connected" },
+    },
+  }),
+}));
+
+vi.mock("@/lib/evals-router", () => ({
+  useEvalsRoute: () => mocks.route.current,
+}));
+
+vi.mock("../evals/helpers", () => ({
+  aggregateSuite: () => null,
+}));
+
+vi.mock("../evals/create-suite-navigation", () => ({
+  navigatePlaygroundEvalsRoute: (...args: unknown[]) =>
+    mocks.navigatePlaygroundEvalsRoute(...args),
+  createPlaygroundSuiteNavigation: () => ({
+    toSuiteOverview: vi.fn(),
+    toRunDetail: vi.fn(),
+    toTestDetail: vi.fn(),
+    toTestEdit: vi.fn(),
+    toSuiteEdit: vi.fn(),
+  }),
+}));
+
+vi.mock("../evals/EvalTabGate", () => ({
+  EvalTabGate: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../evals/ConfirmationDialogs", () => ({
+  ConfirmationDialogs: () => null,
+}));
+
+vi.mock("../evals/suite-iterations-view", () => ({
+  SuiteIterationsView: () => <div data-testid="suite-iterations-view" />,
+}));
+
+vi.mock("../evals/use-eval-mutations", () => ({
+  useEvalMutations: () => ({
+    createTestSuiteMutation: mocks.createTestSuiteMutation,
+  }),
+}));
+
+vi.mock("../evals/use-eval-handlers", () => ({
+  useEvalHandlers: () => ({
+    deletingSuiteId: null,
+    suiteToDelete: null,
+    setSuiteToDelete: vi.fn(),
+    runToDelete: null,
+    setRunToDelete: vi.fn(),
+    testCaseToDelete: null,
+    setTestCaseToDelete: vi.fn(),
+    deletingRunId: null,
+    deletingTestCaseId: null,
+    rerunningSuiteId: null,
+    cancellingRunId: null,
+    runningTestCaseId: null,
+    isGeneratingTests: false,
+    handleGenerateTests: vi.fn(),
+    handleCreateTestCase: vi.fn(),
+    handleRerun: vi.fn(),
+    handleCancelRun: vi.fn(),
+    handleDelete: vi.fn(),
+    handleDeleteRun: vi.fn(),
+    directDeleteRun: vi.fn().mockResolvedValue(undefined),
+    directDeleteTestCase: vi.fn().mockResolvedValue(undefined),
+    handleRunTestCase: vi.fn().mockResolvedValue(undefined),
+    confirmDelete: vi.fn(),
+    confirmDeleteRun: vi.fn(),
+    confirmDeleteTestCase: vi.fn(),
+  }),
+}));
+
+vi.mock("../evals/use-eval-queries", () => ({
+  useEvalQueries: (...args: unknown[]) => mocks.useEvalQueries(...args),
+}));
+
+import { EvalsTab } from "../EvalsTab";
+
+function makeSuiteEntry(serverName: string, suiteId: string) {
+  return {
+    suite: {
+      _id: suiteId,
+      createdBy: "user-1",
+      name: serverName,
+      description: "",
+      configRevision: "rev-1",
+      environment: { servers: [serverName] },
+      createdAt: 1,
+      updatedAt: 1,
+      source: "ui" as const,
+      tags: ["explore"],
+    },
+    latestRun: null,
+    recentRuns: [],
+    passRateTrend: [],
+    totals: { passed: 0, failed: 0, runs: 0 },
+  };
+}
+
+function makeSuiteQueries(serverName: string, suiteId: string, testId: string) {
+  const entry = makeSuiteEntry(serverName, suiteId);
+  return {
+    suiteOverview: [makeSuiteEntry("server-a", "suite-a"), entry],
+    suiteDetails: {
+      testCases: [
+        {
+          _id: testId,
+          testSuiteId: suiteId,
+          createdBy: "user-1",
+          title: `${serverName} case`,
+          query: "Q",
+          models: [{ provider: "openai", model: "gpt-4" }],
+          runs: 1,
+          expectedToolCalls: [],
+        },
+      ],
+      iterations: [],
+    },
+    suiteRuns: [
+      {
+        _id: `${suiteId}-run-1`,
+        suiteId,
+        createdBy: "user-1",
+        runNumber: 1,
+        configRevision: "rev-1",
+        configSnapshot: {
+          tests: [],
+          environment: { servers: [serverName] },
+        },
+        status: "completed" as const,
+        result: "passed" as const,
+        summary: { total: 1, passed: 1, failed: 0, passRate: 1 },
+        createdAt: 1,
+        completedAt: 2,
+      },
+    ],
+    selectedSuiteEntry: entry,
+    selectedSuite: entry.suite,
+    sortedIterations: [],
+    runsForSelectedSuite: [
+      {
+        _id: `${suiteId}-run-1`,
+        suiteId,
+        createdBy: "user-1",
+        runNumber: 1,
+        configRevision: "rev-1",
+        configSnapshot: {
+          tests: [],
+          environment: { servers: [serverName] },
+        },
+        status: "completed" as const,
+        result: "passed" as const,
+        summary: { total: 1, passed: 1, failed: 0, passRate: 1 },
+        createdAt: 1,
+        completedAt: 2,
+      },
+    ],
+    activeIterations: [],
+    sortedSuites: [makeSuiteEntry("server-a", "suite-a"), entry],
+    isOverviewLoading: false,
+    isSuiteDetailsLoading: false,
+    isSuiteRunsLoading: false,
+    enableOverviewQuery: true,
+    enableSuiteDetailsQuery: true,
+  };
+}
+
+describe("EvalsTab route guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.route.current = {
+      type: "test-edit",
+      suiteId: "suite-a",
+      testId: "case-a",
+      openCompare: true,
+      iteration: "iter-a",
+    };
+    mocks.useEvalQueries.mockImplementation(
+      ({ selectedSuiteId }: { selectedSuiteId: string | null }) => {
+        const overview = {
+          suiteOverview: [
+            makeSuiteEntry("server-a", "suite-a"),
+            makeSuiteEntry("server-b", "suite-b"),
+          ],
+          suiteDetails: undefined,
+          suiteRuns: undefined,
+          selectedSuiteEntry: null,
+          selectedSuite: null,
+          sortedIterations: [],
+          runsForSelectedSuite: [],
+          activeIterations: [],
+          sortedSuites: [
+            makeSuiteEntry("server-a", "suite-a"),
+            makeSuiteEntry("server-b", "suite-b"),
+          ],
+          isOverviewLoading: false,
+          isSuiteDetailsLoading: false,
+          isSuiteRunsLoading: false,
+          enableOverviewQuery: true,
+          enableSuiteDetailsQuery: false,
+        };
+
+        if (!selectedSuiteId) {
+          return overview;
+        }
+
+        if (selectedSuiteId === "suite-a") {
+          return makeSuiteQueries("server-a", "suite-a", "case-a");
+        }
+
+        if (selectedSuiteId === "suite-b") {
+          return makeSuiteQueries("server-b", "suite-b", "case-b");
+        }
+
+        return overview;
+      },
+    );
+  });
+
+  it("redirects stale compare routes to the newly selected server's cases view", async () => {
+    const view = render(
+      <EvalsTab selectedServer="server-a" workspaceId="ws-1" />,
+    );
+
+    expect(mocks.navigatePlaygroundEvalsRoute).not.toHaveBeenCalled();
+
+    view.rerender(<EvalsTab selectedServer="server-b" workspaceId="ws-1" />);
+
+    await waitFor(() => {
+      expect(mocks.navigatePlaygroundEvalsRoute).toHaveBeenCalledWith(
+        {
+          type: "suite-overview",
+          suiteId: "suite-b",
+          view: "test-cases",
+        },
+        { replace: true },
+      );
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/playground-route-preferences.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/playground-route-preferences.test.ts
@@ -1,75 +1,197 @@
 import { describe, expect, it } from "vitest";
-import { shouldAutoOpenPlaygroundCasesView } from "../playground-route-preferences";
+import { getPlaygroundCasesRedirect } from "../playground-route-preferences";
 
-describe("shouldAutoOpenPlaygroundCasesView", () => {
-  it("opens cases when returning to the list route", () => {
+const defaultParams = {
+  exploreSuiteId: "suite-1",
+  isSuiteDetailsLoading: false,
+  isSuiteRunsLoading: false,
+  runsCount: 1,
+  testCaseIds: ["case-1"],
+  runIds: ["run-1"],
+  iterationRunIds: ["run-1"],
+};
+
+describe("getPlaygroundCasesRedirect", () => {
+  it("redirects the list route to the cases overview", () => {
     expect(
-      shouldAutoOpenPlaygroundCasesView({
+      getPlaygroundCasesRedirect({
+        ...defaultParams,
         route: { type: "list" },
-        exploreSuiteId: "suite-1",
-        isSuiteDetailsLoading: false,
-        runsCount: 0,
       }),
-    ).toBe(true);
+    ).toEqual({
+      type: "suite-overview",
+      suiteId: "suite-1",
+      view: "test-cases",
+    });
   });
 
-  it("opens cases when an explore suite has cases but no suite runs", () => {
+  it("redirects a stale test-edit route from another suite", () => {
     expect(
-      shouldAutoOpenPlaygroundCasesView({
+      getPlaygroundCasesRedirect({
+        ...defaultParams,
         route: {
-          type: "suite-overview",
-          suiteId: "suite-1",
-          view: "runs",
+          type: "test-edit",
+          suiteId: "suite-old",
+          testId: "case-old",
+          openCompare: true,
         },
-        exploreSuiteId: "suite-1",
-        isSuiteDetailsLoading: false,
-        runsCount: 0,
       }),
-    ).toBe(true);
+    ).toEqual({
+      type: "suite-overview",
+      suiteId: "suite-1",
+      view: "test-cases",
+    });
+  });
+
+  it("redirects a stale test-detail route from another suite", () => {
+    expect(
+      getPlaygroundCasesRedirect({
+        ...defaultParams,
+        route: {
+          type: "test-detail",
+          suiteId: "suite-old",
+          testId: "case-old",
+        },
+      }),
+    ).toEqual({
+      type: "suite-overview",
+      suiteId: "suite-1",
+      view: "test-cases",
+    });
+  });
+
+  it("redirects a stale run-detail route from another suite", () => {
+    expect(
+      getPlaygroundCasesRedirect({
+        ...defaultParams,
+        route: {
+          type: "run-detail",
+          suiteId: "suite-old",
+          runId: "run-old",
+        },
+      }),
+    ).toEqual({
+      type: "suite-overview",
+      suiteId: "suite-1",
+      view: "test-cases",
+    });
+  });
+
+  it("keeps a valid same-suite test-edit route", () => {
+    expect(
+      getPlaygroundCasesRedirect({
+        ...defaultParams,
+        route: {
+          type: "test-edit",
+          suiteId: "suite-1",
+          testId: "case-1",
+          openCompare: true,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("redirects missing same-suite test routes after details load", () => {
+    expect(
+      getPlaygroundCasesRedirect({
+        ...defaultParams,
+        route: {
+          type: "test-detail",
+          suiteId: "suite-1",
+          testId: "case-missing",
+        },
+      }),
+    ).toEqual({
+      type: "suite-overview",
+      suiteId: "suite-1",
+      view: "test-cases",
+    });
+  });
+
+  it("waits for suite details before rejecting a same-suite test route", () => {
+    expect(
+      getPlaygroundCasesRedirect({
+        ...defaultParams,
+        isSuiteDetailsLoading: true,
+        route: {
+          type: "test-edit",
+          suiteId: "suite-1",
+          testId: "case-missing",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("waits for suite runs before rejecting a same-suite run route", () => {
+    expect(
+      getPlaygroundCasesRedirect({
+        ...defaultParams,
+        isSuiteRunsLoading: true,
+        route: {
+          type: "run-detail",
+          suiteId: "suite-1",
+          runId: "run-missing",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps a same-suite run route when iterations still reference that run", () => {
+    expect(
+      getPlaygroundCasesRedirect({
+        ...defaultParams,
+        runIds: [],
+        iterationRunIds: ["run-older"],
+        route: {
+          type: "run-detail",
+          suiteId: "suite-1",
+          runId: "run-older",
+        },
+      }),
+    ).toBeNull();
   });
 
   it("opens cases when an explore suite has no suite runs yet", () => {
     expect(
-      shouldAutoOpenPlaygroundCasesView({
+      getPlaygroundCasesRedirect({
+        ...defaultParams,
+        runsCount: 0,
         route: {
           type: "suite-overview",
           suiteId: "suite-1",
           view: "runs",
         },
-        exploreSuiteId: "suite-1",
-        isSuiteDetailsLoading: false,
-        runsCount: 0,
       }),
-    ).toBe(true);
+    ).toEqual({
+      type: "suite-overview",
+      suiteId: "suite-1",
+      view: "test-cases",
+    });
   });
 
   it("does not override the cases view once it is already selected", () => {
     expect(
-      shouldAutoOpenPlaygroundCasesView({
+      getPlaygroundCasesRedirect({
+        ...defaultParams,
         route: {
           type: "suite-overview",
           suiteId: "suite-1",
           view: "test-cases",
         },
-        exploreSuiteId: "suite-1",
-        isSuiteDetailsLoading: false,
-        runsCount: 0,
       }),
-    ).toBe(false);
+    ).toBeNull();
   });
 
-  it("does not redirect when suite runs exist", () => {
+  it("does not redirect the runs overview when suite runs exist", () => {
     expect(
-      shouldAutoOpenPlaygroundCasesView({
+      getPlaygroundCasesRedirect({
+        ...defaultParams,
         route: {
           type: "suite-overview",
           suiteId: "suite-1",
           view: "runs",
         },
-        exploreSuiteId: "suite-1",
-        isSuiteDetailsLoading: false,
-        runsCount: 2,
       }),
-    ).toBe(false);
+    ).toBeNull();
   });
 });

--- a/mcpjam-inspector/client/src/components/evals/playground-route-preferences.ts
+++ b/mcpjam-inspector/client/src/components/evals/playground-route-preferences.ts
@@ -1,28 +1,91 @@
 import type { EvalRoute } from "@/lib/eval-route-types";
 
-export function shouldAutoOpenPlaygroundCasesView(params: {
+function buildCasesOverviewRoute(suiteId: string): EvalRoute {
+  return {
+    type: "suite-overview",
+    suiteId,
+    view: "test-cases",
+  };
+}
+
+function getRouteSuiteId(route: EvalRoute): string | null {
+  switch (route.type) {
+    case "suite-overview":
+    case "run-detail":
+    case "test-detail":
+    case "test-edit":
+    case "suite-edit":
+      return route.suiteId;
+    default:
+      return null;
+  }
+}
+
+export function getPlaygroundCasesRedirect(params: {
   route: EvalRoute;
   exploreSuiteId: string | null;
   isSuiteDetailsLoading: boolean;
+  isSuiteRunsLoading: boolean;
   runsCount: number;
+  testCaseIds: string[];
+  runIds: string[];
+  iterationRunIds: string[];
 }) {
-  const { route, exploreSuiteId, isSuiteDetailsLoading, runsCount } = params;
+  const {
+    route,
+    exploreSuiteId,
+    isSuiteDetailsLoading,
+    isSuiteRunsLoading,
+    runsCount,
+    testCaseIds,
+    runIds,
+    iterationRunIds,
+  } = params;
 
-  if (!exploreSuiteId || isSuiteDetailsLoading) {
-    return false;
+  if (!exploreSuiteId) {
+    return null;
   }
+
+  const fallbackRoute = buildCasesOverviewRoute(exploreSuiteId);
 
   if (route.type === "list") {
-    return true;
+    return fallbackRoute;
   }
 
-  if (route.type !== "suite-overview") {
-    return false;
+  const routeSuiteId = getRouteSuiteId(route);
+  if (routeSuiteId && routeSuiteId !== exploreSuiteId) {
+    return fallbackRoute;
   }
 
-  if (route.suiteId !== exploreSuiteId || route.view === "test-cases") {
-    return false;
+  if (route.type === "suite-overview") {
+    if (route.view === "test-cases") {
+      return null;
+    }
+
+    if (isSuiteRunsLoading) {
+      return null;
+    }
+
+    return runsCount === 0 ? fallbackRoute : null;
   }
 
-  return runsCount === 0;
+  if (route.type === "test-detail" || route.type === "test-edit") {
+    if (isSuiteDetailsLoading) {
+      return null;
+    }
+
+    return testCaseIds.includes(route.testId) ? null : fallbackRoute;
+  }
+
+  if (route.type === "run-detail") {
+    if (isSuiteRunsLoading) {
+      return null;
+    }
+
+    return runIds.includes(route.runId) || iterationRunIds.includes(route.runId)
+      ? null
+      : fallbackRoute;
+  }
+
+  return null;
 }


### PR DESCRIPTION
Summary
Fixes a Playground bug where switching servers while viewing test results could leave the page stuck on Loading test case....

Now, if you switch to another server, the app sends you to that server’s test cases screen instead. If there are no test cases yet, you’ll see the normal empty state.

Tests
Added a small regression test for the server-switch flow and updated the route helper tests.

Verified with targeted Vitest runs for:

playground-route-preferences.test.ts
create-suite-navigation.test.ts
EvalsTab.test.tsx

Before:


https://github.com/user-attachments/assets/0f6f0e7b-b18d-446a-a0ad-72798670a7df



After:

https://github.com/user-attachments/assets/2634e1bb-8800-4aa3-865e-8e4b008a60b3

