### PR TITLE
oauth debugger now defaults to dcr

### DIFF
--- a/mcpjam-inspector/client/src/components/oauth/OAuthFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthFlowLogger.tsx
@@ -348,12 +348,20 @@ export function OAuthFlowLogger({
             {/* Configuration badges */}
             <div className="flex flex-wrap gap-1.5">
               {summary.protocol && (
-                <Badge variant="secondary" className="text-xs">
+                <Badge
+                  variant="secondary"
+                  className="text-xs cursor-pointer hover:bg-secondary/80"
+                  onClick={actions?.onConfigure}
+                >
                   {summary.protocol}
                 </Badge>
               )}
               {summary.registration && (
-                <Badge variant="secondary" className="text-xs">
+                <Badge
+                  variant="secondary"
+                  className="text-xs cursor-pointer hover:bg-secondary/80"
+                  onClick={actions?.onConfigure}
+                >
                   {summary.registration}
                 </Badge>
               )}

--- a/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthProfileModal.tsx
@@ -271,7 +271,7 @@ export function OAuthProfileModal({
               required
             />
           </div>
-          <div className="space-y-6 max-h-[65vh] overflow-y-auto pr-1 pb-4">
+          <div className="space-y-6 max-h-[65vh] overflow-y-auto px-1 pb-4">
             <div className="space-y-4">
               <div className="space-y-2">
                 <Label

--- a/mcpjam-inspector/client/src/lib/oauth/profile.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/profile.ts
@@ -27,5 +27,5 @@ export const EMPTY_OAUTH_TEST_PROFILE: OAuthTestProfile = {
   scopes: "",
   customHeaders: [],
   protocolVersion: "2025-11-25",
-  registrationStrategy: "cimd",
+  registrationStrategy: "dcr",
 };


### PR DESCRIPTION
Default the inspector OAuth debugger to DCR , make the protocol and registration badges reopen the config modal, and tighten the modal padding/highlight a bit.

This only changes the default inside the inspector’s OAuth debugger flow, not the SDK or the global protocol default.

https://github.com/user-attachments/assets/d71c0265-fd5e-49c1-9d97-689b17ef446a

