### PR TITLE
Remove Slack last-test status badge from workspace settings

### DIFF
--- a/mcpjam-inspector/client/src/components/setting/WorkspaceSlackIntegrationSection.tsx
+++ b/mcpjam-inspector/client/src/components/setting/WorkspaceSlackIntegrationSection.tsx
@@ -186,19 +186,6 @@ export function WorkspaceSlackIntegrationSection({
               <Badge variant={isConnected ? "secondary" : "outline"}>
                 {isConnected ? "Connected" : "Not connected"}
               </Badge>
-              {status?.lastTestStatus ? (
-                <Badge
-                  variant={
-                    status.lastTestStatus === "success"
-                      ? "secondary"
-                      : "destructive"
-                  }
-                >
-                  {status.lastTestStatus === "success"
-                    ? "Last test passed"
-                    : "Last test failed"}
-                </Badge>
-              ) : null}
             </div>
             <p className="text-sm text-muted-foreground">
               Send workspace notifications to a Slack channel with an incoming


### PR DESCRIPTION
The header duplicated information already shown in the connected-state card (last tested time and error details).

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change in workspace Slack settings that removes a redundant status badge; no backend logic or data handling is modified.
> 
> **Overview**
> Removes the Slack *last test passed/failed* badge from the header of `WorkspaceSlackIntegrationSection`, leaving only the Connected/Not connected indicator.
> 
> The detailed last-tested time and any error messaging remain in the connected-state card, reducing duplicated status information in the settings UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0daaaab77654acaf8142bfab93c48219f52340f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->