### PR TITLE
Soundcheck, pt1

### DIFF
--- a/soundcheck/src/app/page.tsx
+++ b/soundcheck/src/app/page.tsx
@@ -1,5 +1,10 @@
+import { Suspense } from "react";
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { isAllowedEmployeeEmail, isLockdownEnabled } from "@/lib/lockdown";
+import {
+  DeployDiff,
+  DeployDiffSkeleton
+} from "@/components/deploy-diff";
 
 export const dynamic = "force-dynamic";
 
@@ -18,7 +23,7 @@ export default async function Home() {
   }
 
   return (
-    <main className="p-8">
+    <main className="mx-auto max-w-5xl p-8">
       <header className="mb-8">
         <h1 className="text-2xl font-semibold">Soundcheck</h1>
         <p className="text-sm text-neutral-500">
@@ -26,16 +31,38 @@ export default async function Home() {
         </p>
       </header>
 
-      <section className="rounded-lg border border-neutral-200 p-6">
-        <h2 className="text-sm font-medium text-neutral-700">
-          Scaffold only
+      <section className="mb-6">
+        <h2 className="text-xs font-semibold uppercase tracking-wide text-neutral-400">
+          Deploy diff
         </h2>
-        <p className="mt-2 text-sm text-neutral-500">
-          Deploy-diff, release readiness, release progress stepper, and drift
-          alerts land in follow-up commits. See{" "}
-          <code>soundcheck/README.md</code> for the feature list.
+        <p className="mt-1 text-xs text-neutral-500">
+          What production is missing vs. staging. Use this to decide whether
+          to cut a release.
         </p>
       </section>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Suspense fallback={<DeployDiffSkeleton title="Inspector" />}>
+          <DeployDiff
+            title="Inspector"
+            owner="MCPJam"
+            repo="inspector"
+            stagingEnvironment="staging"
+            productionEnvironment="production"
+            repoUrl="https://github.com/MCPJam/inspector"
+          />
+        </Suspense>
+        <Suspense fallback={<DeployDiffSkeleton title="Backend" />}>
+          <DeployDiff
+            title="Backend"
+            owner="MCPJam"
+            repo="mcpjam-backend"
+            stagingEnvironment="backend-staging"
+            productionEnvironment="backend-production"
+            repoUrl="https://github.com/MCPJam/mcpjam-backend"
+          />
+        </Suspense>
+      </div>
     </main>
   );
 }

--- a/soundcheck/src/components/deploy-diff.tsx
+++ b/soundcheck/src/components/deploy-diff.tsx
@@ -44,7 +44,9 @@ function describeCategories(
   if (counts.feat > 0) parts.push(`${counts.feat} feature${counts.feat === 1 ? "" : "s"}`);
   if (counts.fix > 0) parts.push(`${counts.fix} fix${counts.fix === 1 ? "" : "es"}`);
   if (counts.chore > 0) parts.push(`${counts.chore} chore${counts.chore === 1 ? "" : "s"}`);
-  if (counts.other > 0) parts.push(`${counts.other} other`);
+  if (counts.other > 0) {
+    parts.push(`${counts.other} other commit${counts.other === 1 ? "" : "s"}`);
+  }
   return parts.length > 0 ? parts.join(", ") : `${total} commit${total === 1 ? "" : "s"}`;
 }
 
@@ -93,7 +95,7 @@ export async function DeployDiff({
     return (
       <Tile title={title}>
         <p className="text-sm text-neutral-500">
-          No production deployment recorded yet for{" "}
+          No successful production deployment recorded for{" "}
           <code>{productionEnvironment}</code>.
         </p>
       </Tile>
@@ -103,7 +105,7 @@ export async function DeployDiff({
     return (
       <Tile title={title}>
         <p className="text-sm text-neutral-500">
-          No staging deployment recorded yet for{" "}
+          No successful staging deployment recorded for{" "}
           <code>{stagingEnvironment}</code>.
         </p>
       </Tile>
@@ -156,6 +158,14 @@ export async function DeployDiff({
   const breakdown = describeCategories(counts, diff.aheadBy);
   const compareUrl = `${repoUrl}/compare/${production.sha}...${staging.sha}`;
 
+  // GitHub Compare returns commits in chronological order (oldest first).
+  // Flip so the newest work shows up on top — that's what matters when
+  // deciding "should we cut a release?". Overflow count uses `aheadBy`
+  // rather than `commits.length` because the compare endpoint caps commits
+  // at 250 for wide diffs.
+  const preview = diff.commits.slice(-8).reverse();
+  const hidden = diff.aheadBy - preview.length;
+
   return (
     <Tile title={title}>
       <p className="text-sm text-neutral-500">
@@ -173,7 +183,7 @@ export async function DeployDiff({
       </p>
 
       <ul className="mt-4 space-y-1">
-        {diff.commits.slice(0, 8).map((c) => (
+        {preview.map((c) => (
           <li key={c.sha} className="text-xs text-neutral-500">
             <a
               href={c.url}
@@ -189,9 +199,9 @@ export async function DeployDiff({
             <span className="text-neutral-400">— {c.author}</span>
           </li>
         ))}
-        {diff.commits.length > 8 && (
+        {hidden > 0 && (
           <li className="text-xs text-neutral-400">
-            + {diff.commits.length - 8} more
+            + {hidden} earlier commit{hidden === 1 ? "" : "s"}
           </li>
         )}
       </ul>

--- a/soundcheck/src/components/deploy-diff.tsx
+++ b/soundcheck/src/components/deploy-diff.tsx
@@ -1,0 +1,208 @@
+import {
+  compareCommits,
+  getLatestEnvironmentDeployment
+} from "@/lib/github";
+
+interface Props {
+  title: string;
+  owner: string;
+  repo: string;
+  stagingEnvironment: string;
+  productionEnvironment: string;
+  /** Public repo URL for linking SHAs in the staging+production sync case. */
+  repoUrl: string;
+}
+
+function formatRelativeTime(iso: string): string {
+  const diffMs = Date.now() - new Date(iso).getTime();
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diffMs >= day) return `${Math.floor(diffMs / day)}d ago`;
+  if (diffMs >= hour) return `${Math.floor(diffMs / hour)}h ago`;
+  if (diffMs >= minute) return `${Math.floor(diffMs / minute)}m ago`;
+  return "just now";
+}
+
+type Category = "feat" | "fix" | "chore" | "other";
+
+function categorize(message: string): Category {
+  const m = message.toLowerCase();
+  if (/^feat(\(|:|!)/.test(m)) return "feat";
+  if (/^fix(\(|:|!)/.test(m)) return "fix";
+  if (/^(chore|docs|refactor|test|build|ci|style|perf)(\(|:|!)/.test(m)) {
+    return "chore";
+  }
+  return "other";
+}
+
+function describeCategories(
+  counts: Record<Category, number>,
+  total: number
+): string {
+  const parts: string[] = [];
+  if (counts.feat > 0) parts.push(`${counts.feat} feature${counts.feat === 1 ? "" : "s"}`);
+  if (counts.fix > 0) parts.push(`${counts.fix} fix${counts.fix === 1 ? "" : "es"}`);
+  if (counts.chore > 0) parts.push(`${counts.chore} chore${counts.chore === 1 ? "" : "s"}`);
+  if (counts.other > 0) parts.push(`${counts.other} other`);
+  return parts.length > 0 ? parts.join(", ") : `${total} commit${total === 1 ? "" : "s"}`;
+}
+
+function Tile({
+  title,
+  children
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-neutral-200 dark:border-neutral-800 p-6 bg-white/0">
+      <h3 className="text-sm font-medium text-neutral-700 dark:text-neutral-200">
+        {title}
+      </h3>
+      <div className="mt-3">{children}</div>
+    </section>
+  );
+}
+
+export async function DeployDiff({
+  title,
+  owner,
+  repo,
+  stagingEnvironment,
+  productionEnvironment,
+  repoUrl
+}: Props) {
+  let staging, production;
+  try {
+    [staging, production] = await Promise.all([
+      getLatestEnvironmentDeployment(owner, repo, stagingEnvironment),
+      getLatestEnvironmentDeployment(owner, repo, productionEnvironment)
+    ]);
+  } catch (err) {
+    return (
+      <Tile title={title}>
+        <p className="text-sm text-red-500">
+          Failed to read deployments: {(err as Error).message}
+        </p>
+      </Tile>
+    );
+  }
+
+  if (!production) {
+    return (
+      <Tile title={title}>
+        <p className="text-sm text-neutral-500">
+          No production deployment recorded yet for{" "}
+          <code>{productionEnvironment}</code>.
+        </p>
+      </Tile>
+    );
+  }
+  if (!staging) {
+    return (
+      <Tile title={title}>
+        <p className="text-sm text-neutral-500">
+          No staging deployment recorded yet for{" "}
+          <code>{stagingEnvironment}</code>.
+        </p>
+      </Tile>
+    );
+  }
+
+  if (staging.sha === production.sha) {
+    return (
+      <Tile title={title}>
+        <p className="text-sm text-neutral-500">
+          In sync on{" "}
+          <a
+            href={`${repoUrl}/commit/${production.sha}`}
+            className="font-mono text-neutral-400 hover:underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            {production.sha.slice(0, 7)}
+          </a>
+          . Last promoted {formatRelativeTime(production.createdAt)}.
+        </p>
+      </Tile>
+    );
+  }
+
+  let diff;
+  try {
+    diff = await compareCommits(owner, repo, production.sha, staging.sha);
+  } catch (err) {
+    return (
+      <Tile title={title}>
+        <p className="text-sm text-red-500">
+          Failed to compare commits: {(err as Error).message}
+        </p>
+      </Tile>
+    );
+  }
+
+  const counts: Record<Category, number> = {
+    feat: 0,
+    fix: 0,
+    chore: 0,
+    other: 0
+  };
+  for (const c of diff.commits) {
+    counts[categorize(c.message)]++;
+  }
+
+  const commitWord = diff.aheadBy === 1 ? "commit" : "commits";
+  const breakdown = describeCategories(counts, diff.aheadBy);
+  const compareUrl = `${repoUrl}/compare/${production.sha}...${staging.sha}`;
+
+  return (
+    <Tile title={title}>
+      <p className="text-sm text-neutral-500">
+        Production is{" "}
+        <a
+          href={compareUrl}
+          className="font-medium text-neutral-700 dark:text-neutral-200 hover:underline"
+          target="_blank"
+          rel="noreferrer"
+        >
+          {diff.aheadBy} {commitWord} behind staging
+        </a>{" "}
+        ({breakdown}). Last promoted{" "}
+        {formatRelativeTime(production.createdAt)}.
+      </p>
+
+      <ul className="mt-4 space-y-1">
+        {diff.commits.slice(0, 8).map((c) => (
+          <li key={c.sha} className="text-xs text-neutral-500">
+            <a
+              href={c.url}
+              className="font-mono text-neutral-400 hover:underline"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {c.sha.slice(0, 7)}
+            </a>{" "}
+            <span className="text-neutral-700 dark:text-neutral-200">
+              {c.message}
+            </span>{" "}
+            <span className="text-neutral-400">— {c.author}</span>
+          </li>
+        ))}
+        {diff.commits.length > 8 && (
+          <li className="text-xs text-neutral-400">
+            + {diff.commits.length - 8} more
+          </li>
+        )}
+      </ul>
+    </Tile>
+  );
+}
+
+export function DeployDiffSkeleton({ title }: { title: string }) {
+  return (
+    <Tile title={title}>
+      <p className="text-sm text-neutral-400">Loading…</p>
+    </Tile>
+  );
+}

--- a/soundcheck/src/lib/github.ts
+++ b/soundcheck/src/lib/github.ts
@@ -29,9 +29,27 @@ async function githubFetch(path: string): Promise<unknown> {
     next: { revalidate: 30 }
   });
   if (!res.ok) {
-    const body = await res.text();
+    // Log the full body server-side for debugging, but surface only a
+    // parsed `message` field (if present) in the user-facing error — avoids
+    // dumping unfiltered upstream JSON into the rendered DOM.
+    const rawBody = await res.text();
+    console.error(`GitHub API ${res.status} for ${path}:`, rawBody);
+    let upstreamMessage: string | null = null;
+    const contentType = res.headers.get("content-type") ?? "";
+    if (contentType.includes("application/json")) {
+      try {
+        const parsed = JSON.parse(rawBody) as { message?: unknown };
+        if (typeof parsed.message === "string") {
+          upstreamMessage = parsed.message;
+        }
+      } catch {
+        // malformed JSON; fall through to generic message
+      }
+    }
     throw new Error(
-      `GitHub API ${res.status} for ${path}: ${body.slice(0, 200)}`
+      upstreamMessage
+        ? `GitHub API ${res.status}: ${upstreamMessage}`
+        : `GitHub API ${res.status} for ${path}`
     );
   }
   return res.json();
@@ -45,33 +63,55 @@ export interface DeploymentInfo {
   url: string;
 }
 
+async function getLatestDeploymentStatus(
+  owner: string,
+  repo: string,
+  deploymentId: number
+): Promise<string | null> {
+  const path = `/repos/${owner}/${repo}/deployments/${deploymentId}/statuses?per_page=1`;
+  const data = (await githubFetch(path)) as Array<{ state: string }>;
+  return data[0]?.state ?? null;
+}
+
 /**
- * Latest deployment for a GitHub Environment (the records every job with an
- * `environment:` clause creates). Returns null if the environment has no
- * deployment history.
+ * Latest successful deployment for a GitHub Environment.
+ *
+ * The list-deployments endpoint returns every deployment regardless of
+ * status — including `pending`, `in_progress`, and `failure`. For the
+ * dashboard we want the SHA that is actually running, so we walk back
+ * through the most recent deployments and return the first whose latest
+ * status is `success` (deployed cleanly) or `inactive` (deployed cleanly
+ * but has since been superseded — still what was last live if no newer
+ * deployment has reached `success` yet).
  */
 export async function getLatestEnvironmentDeployment(
   owner: string,
   repo: string,
   environment: string
 ): Promise<DeploymentInfo | null> {
-  const path = `/repos/${owner}/${repo}/deployments?environment=${encodeURIComponent(environment)}&per_page=1`;
+  const path = `/repos/${owner}/${repo}/deployments?environment=${encodeURIComponent(environment)}&per_page=10`;
   const data = (await githubFetch(path)) as Array<{
+    id: number;
     sha: string;
     created_at: string;
     creator: { login: string } | null;
     environment: string;
     url: string;
   }>;
-  if (data.length === 0) return null;
-  const d = data[0];
-  return {
-    sha: d.sha,
-    createdAt: d.created_at,
-    creator: d.creator?.login ?? null,
-    environment: d.environment,
-    url: d.url
-  };
+
+  for (const d of data) {
+    const state = await getLatestDeploymentStatus(owner, repo, d.id);
+    if (state === "success" || state === "inactive") {
+      return {
+        sha: d.sha,
+        createdAt: d.created_at,
+        creator: d.creator?.login ?? null,
+        environment: d.environment,
+        url: d.url
+      };
+    }
+  }
+  return null;
 }
 
 export interface CompareCommit {
@@ -89,7 +129,11 @@ export interface CompareResult {
 }
 
 /**
- * Commits reachable from `head` but not `base`. `aheadBy` is the count.
+ * Commits reachable from `head` but not `base`. `aheadBy` is the true count.
+ *
+ * The compare endpoint caps `commits` at 250 items, so for very wide diffs
+ * `commits.length` can be less than `aheadBy`. Always use `aheadBy` when
+ * reporting counts to the user; the `commits` array is only for preview.
  */
 export async function compareCommits(
   owner: string,

--- a/soundcheck/src/lib/github.ts
+++ b/soundcheck/src/lib/github.ts
@@ -1,0 +1,121 @@
+/**
+ * Thin wrapper around the GitHub REST API for the reads Soundcheck
+ * needs: latest environment deployments and commit comparisons.
+ *
+ * Auth: `GITHUB_PAT` must be a fine-grained token with read-only access to
+ * `contents`, `deployments`, `metadata`, and `actions` on the inspector and
+ * backend repos.
+ */
+
+const GITHUB_API = "https://api.github.com";
+
+function authHeaders(): Record<string, string> {
+  const token = process.env.GITHUB_PAT;
+  if (!token) {
+    throw new Error("GITHUB_PAT is not set");
+  }
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28"
+  };
+}
+
+async function githubFetch(path: string): Promise<unknown> {
+  const res = await fetch(`${GITHUB_API}${path}`, {
+    headers: authHeaders(),
+    // Short revalidation: dashboard data is live-ish, GitHub rate limits are
+    // generous enough that this is fine.
+    next: { revalidate: 30 }
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(
+      `GitHub API ${res.status} for ${path}: ${body.slice(0, 200)}`
+    );
+  }
+  return res.json();
+}
+
+export interface DeploymentInfo {
+  sha: string;
+  createdAt: string;
+  creator: string | null;
+  environment: string;
+  url: string;
+}
+
+/**
+ * Latest deployment for a GitHub Environment (the records every job with an
+ * `environment:` clause creates). Returns null if the environment has no
+ * deployment history.
+ */
+export async function getLatestEnvironmentDeployment(
+  owner: string,
+  repo: string,
+  environment: string
+): Promise<DeploymentInfo | null> {
+  const path = `/repos/${owner}/${repo}/deployments?environment=${encodeURIComponent(environment)}&per_page=1`;
+  const data = (await githubFetch(path)) as Array<{
+    sha: string;
+    created_at: string;
+    creator: { login: string } | null;
+    environment: string;
+    url: string;
+  }>;
+  if (data.length === 0) return null;
+  const d = data[0];
+  return {
+    sha: d.sha,
+    createdAt: d.created_at,
+    creator: d.creator?.login ?? null,
+    environment: d.environment,
+    url: d.url
+  };
+}
+
+export interface CompareCommit {
+  sha: string;
+  message: string;
+  author: string;
+  date: string;
+  url: string;
+}
+
+export interface CompareResult {
+  aheadBy: number;
+  behindBy: number;
+  commits: CompareCommit[];
+}
+
+/**
+ * Commits reachable from `head` but not `base`. `aheadBy` is the count.
+ */
+export async function compareCommits(
+  owner: string,
+  repo: string,
+  base: string,
+  head: string
+): Promise<CompareResult> {
+  const path = `/repos/${owner}/${repo}/compare/${base}...${head}`;
+  const data = (await githubFetch(path)) as {
+    ahead_by: number;
+    behind_by: number;
+    commits: Array<{
+      sha: string;
+      commit: { message: string; author: { name: string; date: string } };
+      html_url: string;
+    }>;
+  };
+  return {
+    aheadBy: data.ahead_by,
+    behindBy: data.behind_by,
+    commits: data.commits.map((c) => ({
+      sha: c.sha,
+      message: c.commit.message.split("\n")[0],
+      author: c.commit.author.name,
+      date: c.commit.author.date,
+      url: c.html_url
+    }))
+  };
+}


### PR DESCRIPTION
First real feature after the scaffold. Answers "should we cut a release today?" by showing, per env pair, what production is missing vs. staging — with PR counts by category and the top 8 commits.

Implementation:
- soundcheck/src/lib/github.ts: thin REST wrapper. Two calls per tile — GET /repos/{owner}/{repo}/deployments?environment=... (per env, 1 record) and GET /compare/{prod}...{staging}. Uses `next: { revalidate: 30 }` so tiles refresh every 30s without hammering GitHub.
- soundcheck/src/components/deploy-diff.tsx: async server component that fetches both envs in parallel, categorizes commits by conventional-commit prefix, and renders the tile. Handles missing deployments, sync state, and fetch errors without crashing the page.
- soundcheck/src/app/page.tsx: two tiles, one per repo (inspector + backend), wrapped in Suspense so each renders independently.

Data source rationale: GitHub Environments records every `environment:` clause as a Deployment, so current SHA per env is exactly one API call. No Railway or Convex API needed for this slice.

Requires: GITHUB_PAT in the Railway env for mcpjam-soundcheck service, fine-grained and scoped read-only to MCPJam/inspector and MCPJam/mcpjam-backend (Contents, Deployments, Metadata).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new server-side calls to the GitHub API using a PAT and deployment/compare logic; misconfiguration or API/rate-limit issues could impact dashboard availability and error handling.
> 
> **Overview**
> Adds a **Deploy Diff** dashboard to the Soundcheck home page, showing whether production is behind staging for the `inspector` and `mcpjam-backend` repos, with independent loading via `Suspense`.
> 
> Introduces an async `DeployDiff` server component that fetches latest successful deployments per environment, compares SHAs, categorizes commit messages (feat/fix/chore/other), and renders a short commit preview with links plus clear empty/sync/error states.
> 
> Adds a small `lib/github.ts` REST wrapper that reads `GITHUB_PAT`, fetches GitHub deployments/compare data with 30s revalidation, and sanitizes upstream errors before surfacing messages to the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41089871a6b36370fa926eba38d2a96b78db9502. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->