### PR TITLE
gate opus/sonnet 4.6 and gpt 5.4; add opus 4.7 (gated)

### DIFF
--- a/mcpjam-inspector/shared/__tests__/types.test.ts
+++ b/mcpjam-inspector/shared/__tests__/types.test.ts
@@ -16,9 +16,18 @@ describe("MCPJam-provided model classification", () => {
     expect(isMCPJamProvidedModel("openai/gpt-5.4")).toBe(true);
     expect(isMCPJamProvidedModel("qwen/qwen3.6-plus")).toBe(true);
     expect(isMCPJamGuestAllowedModel("openai/gpt-oss-120b")).toBe(true);
-    expect(isMCPJamGuestAllowedModel("openai/gpt-5.4")).toBe(true);
+    expect(isMCPJamGuestAllowedModel("openai/gpt-5.4")).toBe(false);
+    expect(isMCPJamGuestAllowedModel("openai/gpt-5.4-mini")).toBe(false);
+    expect(isMCPJamGuestAllowedModel("openai/gpt-5.4-nano")).toBe(false);
     expect(isMCPJamGuestAllowedModel("openai/gpt-5.4-pro")).toBe(false);
     expect(isMCPJamGuestAllowedModel("anthropic/claude-opus-4.6")).toBe(false);
+    expect(isMCPJamGuestAllowedModel("anthropic/claude-opus-4.6-fast")).toBe(
+      false,
+    );
+    expect(isMCPJamGuestAllowedModel("anthropic/claude-sonnet-4.6")).toBe(
+      false,
+    );
+    expect(isMCPJamGuestAllowedModel("anthropic/claude-opus-4.7")).toBe(false);
     expect(isMCPJamGuestAllowedModel("google/gemini-3.1-pro-preview")).toBe(
       false,
     );

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -119,6 +119,7 @@ const MCPJAM_PROVIDED_MODEL_IDS: string[] = [
   "anthropic/claude-opus-4.6-fast",
   "anthropic/claude-sonnet-4.6",
   "anthropic/claude-opus-4.6",
+  "anthropic/claude-opus-4.7",
   "openai/gpt-5.1-codex-mini",
   "openai/gpt-5-mini",
   "openai/gpt-5.4",
@@ -156,8 +157,14 @@ const MCPJAM_PROVIDED_MODEL_IDS: string[] = [
 ];
 
 const MCPJAM_GUEST_GATED_MODEL_IDS = [
+  "openai/gpt-5.4",
+  "openai/gpt-5.4-mini",
+  "openai/gpt-5.4-nano",
   "openai/gpt-5.4-pro",
+  "anthropic/claude-opus-4.6-fast",
+  "anthropic/claude-sonnet-4.6",
   "anthropic/claude-opus-4.6",
+  "anthropic/claude-opus-4.7",
   "google/gemini-3.1-pro-preview",
 ] as const;
 
@@ -451,6 +458,7 @@ export const SUPPORTED_MODELS: ModelDefinition[] = [
   ),
   freeModel("anthropic/claude-sonnet-4.6", "Claude Sonnet 4.6", "anthropic"),
   freeModel("anthropic/claude-opus-4.6", "Claude Opus 4.6", "anthropic"),
+  freeModel("anthropic/claude-opus-4.7", "Claude Opus 4.7", "anthropic"),
   {
     id: "openai/gpt-5.1-codex-mini",
     name: "GPT-5.1 Codex Mini (Free)",


### PR DESCRIPTION
## Summary

Added **Claude Opus 4.7** (`anthropic/claude-opus-4.7`) to the MCPJam model catalog, and gated these models to signed-in-only:

- Claude Opus 4.6, Opus 4.6 Fast, Sonnet 4.6
- GPT-5.4, 5.4 Mini, 5.4 Nano
- Claude Opus 4.7 (new)

Already gated before: `gpt-5.4-pro`, `claude-opus-4.6`, `gemini-3.1-pro-preview`.

Guests still see these models in the selector but they show as locked with a "Sign in to use MCPJam provided models" tooltip — same behavior as existing gated models.

## Notes

Token counting still works (char-based fallback handles unknown IDs), and backend real cost tracking/backfill is model-agnostic — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)