### PR TITLE
[codex] auto-deploy MCP worker to staging

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@mcpjam/soundcheck"]
+  "ignore": ["@mcpjam/soundcheck", "@mcpjam/mcp"]
 }

--- a/.github/workflows/deploy-mcp-staging.yml
+++ b/.github/workflows/deploy-mcp-staging.yml
@@ -1,0 +1,100 @@
+name: Deploy MCP Staging
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "mcp/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".changeset/config.json"
+      - ".github/workflows/deploy-mcp-staging.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  deployments: write
+
+concurrency:
+  group: mcp-staging
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "24.14.0"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: mcp-staging
+      url: ${{ vars.MCP_WORKER_STAGING_URL }}
+
+    steps:
+      - name: Enforce main branch
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "deploy-mcp-staging.yml must run from main" >&2
+            exit 1
+          fi
+
+      - name: Require Cloudflare credentials
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "Missing GitHub Actions secret: CLOUDFLARE_ACCOUNT_ID" >&2
+            exit 1
+          fi
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "Missing GitHub Actions secret: CLOUDFLARE_API_TOKEN" >&2
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install workspace dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Typecheck MCP worker
+        run: npm run typecheck -w @mcpjam/mcp
+
+      - name: Deploy staging worker
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          workingDirectory: "mcp"
+          command: deploy --env staging
+
+      - name: Smoke test landing page
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+        run: |
+          if [ -z "$DEPLOYMENT_URL" ]; then
+            echo "Wrangler action did not return a deployment URL." >&2
+            exit 1
+          fi
+
+          curl --fail --silent --show-error "$DEPLOYMENT_URL" | grep -q "MCPJam MCP"
+
+      - name: Summarize staging deployment
+        env:
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+        run: |
+          echo "## ✅ MCP staging deployed" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Worker: \`mcpjam-mcp-staging\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- URL: \`$DEPLOYMENT_URL\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- MCP endpoint: \`${DEPLOYMENT_URL%/}/mcp\`" >> "$GITHUB_STEP_SUMMARY"

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -16,6 +16,7 @@ via the `registerTools(server)` seam in [`src/server.ts`](./src/server.ts).
 
 ```sh
 npm run dev         # wrangler dev → http://localhost:8787
+npm run deploy:staging  # wrangler deploy --env staging → staging *.workers.dev
 npm run deploy      # wrangler deploy → *.workers.dev
 npm run typecheck   # tsc --noEmit
 npm run cf-typegen  # regenerate worker-configuration.d.ts
@@ -31,6 +32,25 @@ npm run dev
 
 Connect any MCP client to `http://localhost:8787/mcp`, list tools, and call
 `hello_world` with `{}` or `{"name": "Marcelo"}`.
+
+## Delivery model
+
+`@mcpjam/mcp` is a private workspace deploy target, not a published npm package.
+It is ignored by Changesets alongside `@mcpjam/soundcheck`.
+
+The intended rollout path is:
+
+- push to `main` → auto-deploy `mcpjam-mcp-staging` via GitHub Actions
+- manual production deployment remains a separate, explicit step
+
+The staging workflow expects these GitHub Actions secrets:
+
+- `CLOUDFLARE_ACCOUNT_ID`
+- `CLOUDFLARE_API_TOKEN`
+
+If you set a GitHub environment variable named `MCP_WORKER_STAGING_URL` on the
+`mcp-staging` environment, the deployment URL will also show up directly in the
+GitHub Environment UI.
 
 ## Architecture
 

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "start": "wrangler dev",
+    "deploy:staging": "wrangler deploy --env staging",
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
     "cf-typegen": "wrangler types"

--- a/mcp/wrangler.jsonc
+++ b/mcp/wrangler.jsonc
@@ -18,6 +18,25 @@
       }
     ]
   },
+  "env": {
+    "staging": {
+      "workers_dev": true,
+      "migrations": [
+        {
+          "tag": "v1",
+          "new_sqlite_classes": ["McpJamMcpServer"]
+        }
+      ],
+      "durable_objects": {
+        "bindings": [
+          {
+            "class_name": "McpJamMcpServer",
+            "name": "MCP_OBJECT"
+          }
+        ]
+      }
+    }
+  },
   "observability": {
     "enabled": true
   }


### PR DESCRIPTION
## Summary
- add a dedicated `deploy-mcp-staging.yml` workflow that deploys the `mcp/` Cloudflare Worker on pushes to `main`
- add a Wrangler `staging` environment so staging auto-deploy does not implicitly become production deploy
- mark `@mcpjam/mcp` as an internal deploy target rather than a Changesets-published package
- document the expected GitHub secrets and staging rollout path in the MCP package README

## Why
The new MCP Worker existed in the repo but had no delivery path. That meant merges did not produce a live endpoint, and there was no consistent way to tell whether staging was current.

This keeps the repo aligned with the existing delivery model:
- staging auto-deploys on merge to `main`
- production remains a manual, explicit step
- npm release scope stays limited to publishable packages

## Impact
- pushes to `main` that touch `mcp/` or root workspace manifests will deploy `mcpjam-mcp-staging`
- the workflow summary will show the deployed Worker URL and the `/mcp` endpoint
- `@mcpjam/mcp` will not participate in Changesets release planning

## Validation
- `npm run typecheck -w @mcpjam/mcp`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily CI/CD and deployment configuration changes; risk is in potentially mis-deploying or failing deployments due to new workflow triggers, Cloudflare credentials, or staging DO migration/env settings.
> 
> **Overview**
> Adds **automatic staging deployments** for the `mcp/` Cloudflare Worker via a new `deploy-mcp-staging.yml` workflow triggered by pushes to `main` (and manual dispatch), including dependency install, `@mcpjam/mcp` typecheck, Cloudflare Wrangler deploy, a simple curl smoke test, and a deployment summary.
> 
> Introduces a dedicated Wrangler `staging` environment (`wrangler.jsonc`) plus a matching `deploy:staging` script, and updates Changesets config to ignore `@mcpjam/mcp` so it’s treated as an internal deploy target rather than a publishable package. Documentation in `mcp/README.md` is updated to describe the staging rollout path and required Cloudflare secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fafb67a8743be9d7a62105c4aab51f8950624f97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->