### PR TITLE
XAA 

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -293,6 +293,7 @@ export default function App() {
   const registryEnabled = useFeatureFlagEnabled("registry-enabled");
   const playgroundEnabled = useFeatureFlagEnabled("playground-enabled");
   const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-runs");
+  const xaaEnabled = useFeatureFlagEnabled("xaa");
   const {
     getAccessToken,
     signIn,
@@ -1250,6 +1251,8 @@ export default function App() {
       (clientConfigEnabled !== true || !isAuthenticated)
     ) {
       applyNavigation("servers", { updateHash: true });
+    } else if (activeTab === "xaa-flow" && xaaEnabled !== true) {
+      applyNavigation("servers", { updateHash: true });
     }
   }, [
     clientConfigEnabled,
@@ -1257,6 +1260,7 @@ export default function App() {
     learningEnabled,
     evaluateRunsFlagsLoaded,
     evaluateRunsEnabled,
+    xaaEnabled,
     isAuthenticated,
     activeTab,
     applyNavigation,
@@ -1522,7 +1526,7 @@ export default function App() {
     activeTab === "prompts" ||
     activeTab === "tasks" ||
     activeTab === "oauth-flow" ||
-    activeTab === "xaa-flow" ||
+    (activeTab === "xaa-flow" && xaaEnabled === true) ||
     activeTab === "chat" ||
     activeTab === "evals" ||
     activeTab === "views";
@@ -1531,7 +1535,8 @@ export default function App() {
     shouldShowActiveServerSelector
       ? {
           serverConfigs:
-            activeTab === "oauth-flow" || activeTab === "xaa-flow"
+            activeTab === "oauth-flow" ||
+            (activeTab === "xaa-flow" && xaaEnabled === true)
               ? appState.servers
               : workspaceServers,
           selectedServer: appState.selectedServer,
@@ -1797,7 +1802,7 @@ export default function App() {
               />
             </ErrorBoundary>
           )}
-          {activeTab === "xaa-flow" && (
+          {activeTab === "xaa-flow" && xaaEnabled === true && (
             <ErrorBoundary
               fallback={
                 <div className="flex items-center justify-center h-full text-muted-foreground">

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -31,6 +31,7 @@ import { WorkspaceClientConfigSync } from "./components/client-config/WorkspaceC
 import { TracingTab } from "./components/TracingTab";
 import { AuthTab } from "./components/AuthTab";
 import { OAuthFlowTab } from "./components/OAuthFlowTab";
+import { XAAFlowTab } from "./components/xaa/XAAFlowTab";
 import { ErrorBoundary } from "./components/evals/ErrorBoundary";
 import { AppBuilderTab } from "./components/ui-playground/AppBuilderTab";
 import { EmptyState } from "./components/ui/empty-state";
@@ -53,7 +54,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "./components/ui/dialog";
-import { useAppState } from "./hooks/use-app-state";
+import { useAppState, type ServerWithName } from "./hooks/use-app-state";
 import { PreferencesStoreProvider } from "./stores/preferences/preferences-provider";
 import { Toaster } from "./components/ui/sonner";
 import { useElectronOAuth } from "./hooks/useElectronOAuth";
@@ -658,7 +659,7 @@ export default function App() {
   const previousConnectedServersRef = useRef<Set<string> | null>(null);
   useEffect(() => {
     const connectedServers = new Set(
-      Object.entries(appState.servers)
+      Object.entries<ServerWithName>(appState.servers)
         .filter(([, server]) => server.connectionStatus === "connected")
         .map(([name]) => name),
     );
@@ -902,14 +903,17 @@ export default function App() {
   const guestServerConfigs = useMemo(
     () =>
       Object.fromEntries(
-        Object.entries(appState.servers).map(([name, s]) => [name, s.config]),
+        Object.entries<ServerWithName>(appState.servers).map(([name, server]) => [
+          name,
+          server.config,
+        ]),
       ),
     [appState.servers],
   );
   const guestOauthTokensByServerName = useMemo(
     () =>
       Object.fromEntries(
-        Object.entries(appState.servers)
+        Object.entries<ServerWithName>(appState.servers)
           .filter(([, server]) => !!server.oauthTokens?.access_token)
           .map(([name, server]) => [name, server.oauthTokens!.access_token]),
       ),
@@ -1518,6 +1522,7 @@ export default function App() {
     activeTab === "prompts" ||
     activeTab === "tasks" ||
     activeTab === "oauth-flow" ||
+    activeTab === "xaa-flow" ||
     activeTab === "chat" ||
     activeTab === "evals" ||
     activeTab === "views";
@@ -1526,7 +1531,9 @@ export default function App() {
     shouldShowActiveServerSelector
       ? {
           serverConfigs:
-            activeTab === "oauth-flow" ? appState.servers : workspaceServers,
+            activeTab === "oauth-flow" || activeTab === "xaa-flow"
+              ? appState.servers
+              : workspaceServers,
           selectedServer: appState.selectedServer,
           onServerChange: setSelectedServer,
           onConnect: handleConnect,
@@ -1787,6 +1794,22 @@ export default function App() {
                 onSaveServerConfig={saveServerConfigWithoutConnecting}
                 onConnectWithTokens={handleConnectWithTokensFromOAuthFlow}
                 onRefreshTokens={handleRefreshTokensFromOAuthFlow}
+              />
+            </ErrorBoundary>
+          )}
+          {activeTab === "xaa-flow" && (
+            <ErrorBoundary
+              fallback={
+                <div className="flex items-center justify-center h-full text-muted-foreground">
+                  Something went wrong in the XAA Debugger. Try refreshing the
+                  page.
+                </div>
+              }
+            >
+              <XAAFlowTab
+                serverConfigs={appState.servers}
+                selectedServerName={appState.selectedServer}
+                onSelectServer={setSelectedServer}
               />
             </ErrorBoundary>
           )}

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -256,6 +256,9 @@ vi.mock("../components/AuthTab", () => ({
 vi.mock("../components/OAuthFlowTab", () => ({
   OAuthFlowTab: () => <div />,
 }));
+vi.mock("../components/xaa/XAAFlowTab", () => ({
+  XAAFlowTab: () => <div data-testid="xaa-flow-tab">XAA Debugger Tab</div>,
+}));
 vi.mock("../components/ui-playground/AppBuilderTab", () => ({
   AppBuilderTab: ({
     onOnboardingChange,
@@ -2114,6 +2117,41 @@ describe("App hosted OAuth callback handling", () => {
 
     expect(window.location.hash).toBe("#/evals");
     expect(screen.queryByTestId("ci-evals-tab")).not.toBeInTheDocument();
+  });
+
+  it("redirects xaa-flow to Servers when the xaa flag is disabled", async () => {
+    clearHostedOAuthPendingState();
+    clearSandboxSession();
+    window.history.replaceState({}, "", "/#xaa-flow");
+    mockHandleOAuthCallback.mockReset();
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Servers Tab")).toBeInTheDocument();
+    });
+
+    expect(window.location.hash).toBe("#servers");
+    expect(screen.queryByTestId("xaa-flow-tab")).not.toBeInTheDocument();
+  });
+
+  it("renders xaa-flow when the xaa flag is enabled", async () => {
+    clearHostedOAuthPendingState();
+    clearSandboxSession();
+    window.history.replaceState({}, "", "/#xaa-flow");
+    mockHandleOAuthCallback.mockReset();
+    mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
+      flag === "xaa" ? true : false,
+    );
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("xaa-flow-tab")).toBeInTheDocument();
+    });
+
+    expect(window.location.hash).toBe("#xaa-flow");
+    expect(screen.queryByText("Servers Tab")).not.toBeInTheDocument();
   });
 
   it("still applies the CI billing redirect when evaluate-runs is enabled", async () => {

--- a/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
+++ b/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
@@ -54,6 +54,28 @@ describe("filterByFeatureFlags", () => {
     expect(titles).toEqual(["Always Visible"]);
   });
 
+  it("hides XAA Debugger when the xaa flag is off", () => {
+    const result = filterByFeatureFlags(
+      [
+        {
+          id: "others",
+          items: [
+            { title: "OAuth Debugger", url: "#oauth-flow", icon: FakeIcon },
+            {
+              title: "XAA Debugger",
+              url: "#xaa-flow",
+              icon: FakeIcon,
+              featureFlag: "xaa",
+            },
+          ],
+        },
+      ],
+      { xaa: false },
+    );
+
+    expect(result[0].items.map((i) => i.title)).toEqual(["OAuth Debugger"]);
+  });
+
   it("keeps Testing visible when unrelated flags are on", () => {
     const result = filterByFeatureFlags(makeSections(), {
       "registry-enabled": true,

--- a/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
+++ b/mcpjam-inspector/client/src/components/__tests__/mcp-sidebar-feature-flags.test.ts
@@ -208,6 +208,7 @@ describe("getHostedNavigationSections", () => {
             billingFeature: "evals",
           },
           { title: "OAuth Debugger", url: "#oauth-flow", icon: FakeIcon },
+          { title: "XAA Debugger", url: "#xaa-flow", icon: FakeIcon },
         ],
       },
     ]);
@@ -230,6 +231,11 @@ describe("getHostedNavigationSections", () => {
       {
         title: "OAuth Debugger",
         url: "#oauth-flow",
+        icon: FakeIcon,
+      },
+      {
+        title: "XAA Debugger",
+        url: "#xaa-flow",
         icon: FakeIcon,
       },
     ]);

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -255,6 +255,7 @@ const navigationSections: NavSection[] = [
         title: "XAA Debugger",
         url: "#xaa-flow",
         icon: ShieldCheck,
+        featureFlag: "xaa",
       },
       // {
       //   title: "Tracing",
@@ -541,6 +542,7 @@ export function MCPSidebar({
   const registryEnabled = useFeatureFlagEnabled("registry-enabled");
   const evalsEnabled = useFeatureFlagEnabled("evals-enabled");
   const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-runs");
+  const xaaEnabled = useFeatureFlagEnabled("xaa");
   const learnMoreEnabled = useFeatureFlagEnabled("learn-more-enabled");
   const { isAuthenticated } = useConvexAuth();
   const { user } = useAuth();
@@ -664,6 +666,7 @@ export function MCPSidebar({
       "client-config-enabled": !!clientConfigEnabled && isAuthenticated,
       "registry-enabled": registryEnabled === true,
       "evals-enabled": !!evalsEnabled,
+      xaa: xaaEnabled === true,
     }),
     [
       learningEnabled,
@@ -671,6 +674,7 @@ export function MCPSidebar({
       clientConfigEnabled,
       registryEnabled,
       evalsEnabled,
+      xaaEnabled,
       isAuthenticated,
     ],
   );

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -19,6 +19,7 @@ import {
   GitBranch,
   Puzzle,
   UserPlus,
+  ShieldCheck,
 } from "lucide-react";
 import { usePostHog, useFeatureFlagEnabled } from "posthog-js/react";
 import { standardEventProps } from "@/lib/PosthogUtils";
@@ -249,6 +250,11 @@ const navigationSections: NavSection[] = [
         title: "OAuth Debugger",
         url: "#oauth-flow",
         icon: Workflow,
+      },
+      {
+        title: "XAA Debugger",
+        url: "#xaa-flow",
+        icon: ShieldCheck,
       },
       // {
       //   title: "Tracing",

--- a/mcpjam-inspector/client/src/components/oauth/HTTPHistoryEntry.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/HTTPHistoryEntry.tsx
@@ -12,7 +12,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import type { LogErrorDetails, OAuthFlowStep } from "@mcpjam/sdk/browser";
+import type { LogErrorDetails } from "@mcpjam/sdk/browser";
 
 interface HTTPHistoryEntryProps {
   method: string;
@@ -25,7 +25,7 @@ interface HTTPHistoryEntryProps {
   responseHeaders?: Record<string, string>;
   responseBody?: any;
   error?: LogErrorDetails;
-  step?: OAuthFlowStep;
+  step?: string;
   defaultOpen?: boolean;
 }
 

--- a/mcpjam-inspector/client/src/components/oauth/shared/DiagramLayout.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/shared/DiagramLayout.tsx
@@ -10,7 +10,6 @@ import {
 import "@xyflow/react/dist/style.css";
 import { ActorNode } from "./ActorNode";
 import { CustomActionEdge } from "./CustomActionEdge";
-import type { OAuthFlowStep } from "@mcpjam/sdk/browser";
 
 const nodeTypes = {
   actor: ActorNode,
@@ -23,8 +22,8 @@ const edgeTypes = {
 interface DiagramLayoutProps {
   nodes: Node[];
   edges: Edge[];
-  currentStep: OAuthFlowStep;
-  focusedStep?: OAuthFlowStep | null;
+  currentStep: string;
+  focusedStep?: string | null;
 }
 
 export const DiagramLayout = ({

--- a/mcpjam-inspector/client/src/components/oauth/shared/diagramBuilder.ts
+++ b/mcpjam-inspector/client/src/components/oauth/shared/diagramBuilder.ts
@@ -1,5 +1,4 @@
 import type { Node, Edge } from "@xyflow/react";
-import type { OAuthFlowStep } from "@mcpjam/sdk/browser";
 import {
   ACTORS,
   ACTOR_X_POSITIONS,
@@ -9,18 +8,26 @@ import {
 import { getActionStatus } from "./utils";
 import type { Action, ActorNodeData } from "./types";
 
+export interface DiagramActorConfig {
+  actors: Record<string, { label: string; color: string }>;
+  actorXPositions: Record<string, number>;
+}
+
 export function buildNodesAndEdges(
   actions: Action[],
-  currentStep: OAuthFlowStep,
+  currentStep: string,
+  config: DiagramActorConfig = {
+    actors: ACTORS,
+    actorXPositions: ACTOR_X_POSITIONS,
+  },
 ): { nodes: Node[]; edges: Edge[] } {
   const totalActions = actions.length;
   const totalSegmentHeight = totalActions * ACTION_SPACING + 100;
+  const actorIds = Object.keys(config.actors);
 
-  // Create segments for each actor
-  const browserSegments: ActorNodeData["segments"] = [];
-  const clientSegments: ActorNodeData["segments"] = [];
-  const mcpServerSegments: ActorNodeData["segments"] = [];
-  const authServerSegments: ActorNodeData["segments"] = [];
+  const actorSegments = Object.fromEntries(
+    actorIds.map((actorId) => [actorId, [] as ActorNodeData["segments"]]),
+  ) as Record<string, ActorNodeData["segments"]>;
 
   let currentY = 0;
 
@@ -30,25 +37,12 @@ export function buildNodesAndEdges(
     // Add line segments before the action
     if (currentY < actionY) {
       const lineHeight = actionY - currentY;
-      browserSegments.push({
-        id: `browser-line-${index}`,
-        type: "line",
-        height: lineHeight,
-      });
-      clientSegments.push({
-        id: `client-line-${index}`,
-        type: "line",
-        height: lineHeight,
-      });
-      mcpServerSegments.push({
-        id: `mcp-line-${index}`,
-        type: "line",
-        height: lineHeight,
-      });
-      authServerSegments.push({
-        id: `auth-line-${index}`,
-        type: "line",
-        height: lineHeight,
+      actorIds.forEach((actorId) => {
+        actorSegments[actorId].push({
+          id: `${actorId}-line-${index}`,
+          type: "line",
+          height: lineHeight,
+        });
       });
       currentY = actionY;
     }
@@ -74,10 +68,9 @@ export function buildNodesAndEdges(
       }
     };
 
-    addSegmentForActor("browser", browserSegments);
-    addSegmentForActor("client", clientSegments);
-    addSegmentForActor("mcpServer", mcpServerSegments);
-    addSegmentForActor("authServer", authServerSegments);
+    actorIds.forEach((actorId) => {
+      addSegmentForActor(actorId, actorSegments[actorId]);
+    });
 
     currentY += SEGMENT_HEIGHT;
   });
@@ -85,79 +78,27 @@ export function buildNodesAndEdges(
   // Add final line segments
   const remainingHeight = totalSegmentHeight - currentY;
   if (remainingHeight > 0) {
-    browserSegments.push({
-      id: "browser-line-end",
-      type: "line",
-      height: remainingHeight,
-    });
-    clientSegments.push({
-      id: "client-line-end",
-      type: "line",
-      height: remainingHeight,
-    });
-    mcpServerSegments.push({
-      id: "mcp-line-end",
-      type: "line",
-      height: remainingHeight,
-    });
-    authServerSegments.push({
-      id: "auth-line-end",
-      type: "line",
-      height: remainingHeight,
+    actorIds.forEach((actorId) => {
+      actorSegments[actorId].push({
+        id: `${actorId}-line-end`,
+        type: "line",
+        height: remainingHeight,
+      });
     });
   }
 
-  // Create actor nodes
-  const nodes: Node[] = [
-    {
-      id: "actor-browser",
-      type: "actor",
-      position: { x: ACTOR_X_POSITIONS.browser, y: 0 },
-      data: {
-        label: ACTORS.browser.label,
-        color: ACTORS.browser.color,
-        totalHeight: totalSegmentHeight,
-        segments: browserSegments,
-      },
-      draggable: false,
+  const nodes: Node[] = actorIds.map((actorId) => ({
+    id: `actor-${actorId}`,
+    type: "actor",
+    position: { x: config.actorXPositions[actorId] ?? 0, y: 0 },
+    data: {
+      label: config.actors[actorId]?.label ?? actorId,
+      color: config.actors[actorId]?.color ?? "#94a3b8",
+      totalHeight: totalSegmentHeight,
+      segments: actorSegments[actorId],
     },
-    {
-      id: "actor-client",
-      type: "actor",
-      position: { x: ACTOR_X_POSITIONS.client, y: 0 },
-      data: {
-        label: ACTORS.client.label,
-        color: ACTORS.client.color,
-        totalHeight: totalSegmentHeight,
-        segments: clientSegments,
-      },
-      draggable: false,
-    },
-    {
-      id: "actor-mcpServer",
-      type: "actor",
-      position: { x: ACTOR_X_POSITIONS.mcpServer, y: 0 },
-      data: {
-        label: ACTORS.mcpServer.label,
-        color: ACTORS.mcpServer.color,
-        totalHeight: totalSegmentHeight,
-        segments: mcpServerSegments,
-      },
-      draggable: false,
-    },
-    {
-      id: "actor-authServer",
-      type: "actor",
-      position: { x: ACTOR_X_POSITIONS.authServer, y: 0 },
-      data: {
-        label: ACTORS.authServer.label,
-        color: ACTORS.authServer.color,
-        totalHeight: totalSegmentHeight,
-        segments: authServerSegments,
-      },
-      draggable: false,
-    },
-  ];
+    draggable: false,
+  }));
 
   // Create action edges
   const edges: Edge[] = actions.map((action) => {
@@ -172,10 +113,8 @@ export function buildNodesAndEdges(
         ? "#3b82f6"
         : "#d1d5db";
 
-    const sourceX =
-      ACTOR_X_POSITIONS[action.from as keyof typeof ACTOR_X_POSITIONS];
-    const targetX =
-      ACTOR_X_POSITIONS[action.to as keyof typeof ACTOR_X_POSITIONS];
+    const sourceX = config.actorXPositions[action.from] ?? 0;
+    const targetX = config.actorXPositions[action.to] ?? 0;
     const isLeftToRight = sourceX < targetX;
 
     return {

--- a/mcpjam-inspector/client/src/components/oauth/shared/utils.ts
+++ b/mcpjam-inspector/client/src/components/oauth/shared/utils.ts
@@ -4,7 +4,7 @@ import type { NodeStatus } from "./types";
 // Helper to determine status based on current step and actual action order
 export const getActionStatus = (
   actionStep: OAuthFlowStep | string,
-  currentStep: OAuthFlowStep,
+  currentStep: string,
   actionsInFlow: Array<{ id: string }>,
 ): NodeStatus => {
   // Find indices in the actual flow (not a hardcoded order)

--- a/mcpjam-inspector/client/src/components/xaa/IdJagInspector.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/IdJagInspector.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { AlertTriangle, CheckCircle2, Copy } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ScrollableJsonView } from "@/components/ui/json-editor";
+import type { XAADecodedJwt } from "@/lib/xaa/types";
+import type { NegativeTestMode } from "@/shared/xaa.js";
+import { NEGATIVE_TEST_MODE_DETAILS } from "@/shared/xaa.js";
+import { copyToClipboard } from "@/lib/clipboard";
+
+interface IdJagInspectorProps {
+  rawJwt: string;
+  decoded: XAADecodedJwt;
+  negativeTestMode: NegativeTestMode;
+}
+
+export function IdJagInspector({
+  rawJwt,
+  decoded,
+  negativeTestMode,
+}: IdJagInspectorProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    const success = await copyToClipboard(rawJwt);
+    if (!success) {
+      return;
+    }
+
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  };
+
+  return (
+    <div className="bg-background border border-border rounded-lg shadow-sm p-4 space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-semibold">ID-JAG Inspector</h3>
+            <Badge variant="secondary" className="text-[10px]">
+              {NEGATIVE_TEST_MODE_DETAILS[negativeTestMode].label}
+            </Badge>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Decode the assertion before sending it to the authorization server.
+            Broken claims are called out explicitly below.
+          </p>
+        </div>
+
+        <Button variant="outline" size="sm" onClick={handleCopy}>
+          <Copy className="h-3.5 w-3.5 mr-1" />
+          {copied ? "Copied" : "Copy JWT"}
+        </Button>
+      </div>
+
+      <div className="grid gap-2">
+        {decoded.issues.length === 0 ? (
+          <div className="flex items-center gap-2 text-xs text-green-700 dark:text-green-400 bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-900 rounded-md px-3 py-2">
+            <CheckCircle2 className="h-4 w-4" />
+            No structural issues detected in the decoded ID-JAG.
+          </div>
+        ) : (
+          decoded.issues.map((issue) => (
+            <div
+              key={`${issue.section}-${issue.field}`}
+              className="border border-red-300 dark:border-red-900 rounded-md bg-red-50 dark:bg-red-950/20 px-3 py-2"
+            >
+              <div className="flex items-center gap-2 text-xs font-medium text-red-700 dark:text-red-300">
+                <AlertTriangle className="h-4 w-4" />
+                {issue.label}
+              </div>
+              <div className="mt-1 text-xs text-red-700/90 dark:text-red-300/90">
+                Expected: {issue.expected}
+              </div>
+              <div className="text-xs text-red-700/90 dark:text-red-300/90">
+                Actual: {issue.actual}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-2">
+        <div>
+          <div className="text-xs font-medium text-muted-foreground mb-1">
+            Header
+          </div>
+          <ScrollableJsonView
+            value={decoded.header ?? { error: "Header could not be decoded" }}
+            containerClassName="rounded-sm bg-muted/20 p-2 max-h-[280px]"
+          />
+        </div>
+        <div>
+          <div className="text-xs font-medium text-muted-foreground mb-1">
+            Payload
+          </div>
+          <ScrollableJsonView
+            value={decoded.payload ?? { error: "Payload could not be decoded" }}
+            containerClassName="rounded-sm bg-muted/20 p-2 max-h-[280px]"
+          />
+        </div>
+      </div>
+
+      <div>
+        <div className="text-xs font-medium text-muted-foreground mb-1">
+          Signature
+        </div>
+        <div className="rounded-sm bg-muted/20 p-2 text-[11px] font-mono break-all text-muted-foreground">
+          {decoded.signature || "(missing)"}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/xaa/XAABootstrapDialog.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAABootstrapDialog.tsx
@@ -1,0 +1,104 @@
+import { Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { HOSTED_MODE } from "@/lib/config";
+import { copyToClipboard } from "@/lib/clipboard";
+
+interface XAABootstrapDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function getIssuerBaseUrl(): string {
+  if (typeof window === "undefined") {
+    return HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa";
+  }
+  return `${window.location.origin}${HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa"}`;
+}
+
+function CopyRow({
+  label,
+  value,
+}: {
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <div className="text-xs font-medium text-muted-foreground">{label}</div>
+      <div className="flex items-stretch gap-2">
+        <div className="min-w-0 flex-1 rounded-md border border-border bg-muted/30 px-3 py-2 font-mono text-xs break-all">
+          {value}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="shrink-0"
+          onClick={() => copyToClipboard(value)}
+          aria-label={`Copy ${label}`}
+        >
+          <Copy className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function XAABootstrapDialog({
+  open,
+  onOpenChange,
+}: XAABootstrapDialogProps) {
+  const issuerBaseUrl = getIssuerBaseUrl();
+  const jwksUrl = `${issuerBaseUrl}/.well-known/jwks.json`;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Register MCPJam as an identity issuer</DialogTitle>
+          <DialogDescription>
+            The target authorization server must trust this inspector before
+            the JWT-bearer token exchange can succeed.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <CopyRow label="Issuer URL" value={issuerBaseUrl} />
+          <CopyRow label="JWKS URL" value={jwksUrl} />
+
+          <ol className="list-decimal space-y-1.5 pt-1 pl-5 text-xs text-muted-foreground marker:text-muted-foreground">
+            <li>
+              Register the issuer (or JWKS URL) with your authorization server.
+            </li>
+            <li>
+              Set the ID-JAG <code className="font-mono">aud</code> to the
+              authorization server issuer.
+            </li>
+            <li>
+              Set the ID-JAG <code className="font-mono">resource</code> to the
+              MCP server resource identifier.
+            </li>
+            <li>
+              Register MCPJam with the authorization server using the client ID
+              from your config.
+            </li>
+          </ol>
+
+          {!HOSTED_MODE && (
+            <p className="text-xs text-muted-foreground">
+              Local URLs only work if the authorization server can reach this
+              machine (e.g. via a public tunnel).
+            </p>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/xaa/XAAConfigModal.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAConfigModal.tsx
@@ -1,39 +1,28 @@
-import { useEffect, useMemo, useState } from "react";
-import { Copy } from "lucide-react";
+import { useEffect, useState } from "react";
+import { ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { HOSTED_MODE } from "@/lib/config";
-import { copyToClipboard } from "@/lib/clipboard";
+import { cn } from "@/lib/utils";
 import type { XAADebugProfile } from "@/lib/xaa/profile";
-import {
-  NEGATIVE_TEST_MODES,
-  NEGATIVE_TEST_MODE_DETAILS,
-} from "@/shared/xaa.js";
 
 interface XAAConfigModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   value: XAADebugProfile;
   onSave: (profile: XAADebugProfile) => void;
-}
-
-function getIssuerBaseUrl(): string {
-  if (typeof window === "undefined") {
-    return HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa";
-  }
-
-  return `${window.location.origin}${HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa"}`;
 }
 
 export function XAAConfigModal({
@@ -44,19 +33,18 @@ export function XAAConfigModal({
 }: XAAConfigModalProps) {
   const [draft, setDraft] = useState(value);
   const [error, setError] = useState<string | null>(null);
-  const issuerBaseUrl = useMemo(() => getIssuerBaseUrl(), []);
-  const jwksUrl = `${issuerBaseUrl}/.well-known/jwks.json`;
+  const [identityOpen, setIdentityOpen] = useState(false);
 
   useEffect(() => {
     if (open) {
       setDraft(value);
       setError(null);
+      // Open the advanced section if the user has previously customized it.
+      const hasCustomIdentity =
+        Boolean(value.userId?.trim()) || Boolean(value.email?.trim());
+      setIdentityOpen(hasCustomIdentity);
     }
   }, [open, value]);
-
-  const handleCopy = async (text: string) => {
-    await copyToClipboard(text);
-  };
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -103,99 +91,103 @@ export function XAAConfigModal({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl">
+      <DialogContent className="max-w-xl flex max-h-[85vh] flex-col">
         <DialogHeader>
           <DialogTitle>Configure XAA Debugger</DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-6">
-          <div className="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
-            <div className="space-y-6">
-              <div className="space-y-3">
-                <div>
-                  <h3 className="text-sm font-semibold">Target configuration</h3>
-                  <p className="text-xs text-muted-foreground">
-                    These values describe the real MCP and authorization servers
-                    you want to validate against.
-                  </p>
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="xaa-server-url">MCP Server URL</Label>
-                  <Input
-                    id="xaa-server-url"
-                    value={draft.serverUrl}
-                    onChange={(event) =>
-                      setDraft((current) => ({
-                        ...current,
-                        serverUrl: event.target.value,
-                      }))
-                    }
-                    placeholder="https://mcp.example.com"
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="xaa-authz-issuer">
-                    Authorization Server Issuer
-                  </Label>
-                  <Input
-                    id="xaa-authz-issuer"
-                    value={draft.authzServerIssuer}
-                    onChange={(event) =>
-                      setDraft((current) => ({
-                        ...current,
-                        authzServerIssuer: event.target.value,
-                      }))
-                    }
-                    placeholder="https://auth.example.com"
-                  />
-                  <p className="text-xs text-muted-foreground">
-                    Optional. Leave blank to discover it from MCP resource metadata.
-                  </p>
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="xaa-client-id">Client ID</Label>
-                  <Input
-                    id="xaa-client-id"
-                    value={draft.clientId}
-                    onChange={(event) =>
-                      setDraft((current) => ({
-                        ...current,
-                        clientId: event.target.value,
-                      }))
-                    }
-                    placeholder="mcpjam-debugger"
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="xaa-scope">Scope</Label>
-                  <Textarea
-                    id="xaa-scope"
-                    value={draft.scope}
-                    onChange={(event) =>
-                      setDraft((current) => ({
-                        ...current,
-                        scope: event.target.value,
-                      }))
-                    }
-                    placeholder="read:tools read:resources"
-                    rows={2}
-                  />
-                </div>
+        <form
+          onSubmit={handleSubmit}
+          className="flex min-h-0 flex-1 flex-col"
+        >
+          <div className="flex-1 min-h-0 overflow-y-auto pr-1 space-y-5">
+            <div className="space-y-3">
+              <div className="space-y-2">
+                <Label htmlFor="xaa-server-url">
+                  MCP Server URL <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="xaa-server-url"
+                  value={draft.serverUrl}
+                  onChange={(event) =>
+                    setDraft((current) => ({
+                      ...current,
+                      serverUrl: event.target.value,
+                    }))
+                  }
+                  placeholder="https://mcp.example.com"
+                  autoFocus
+                />
               </div>
 
-              <div className="space-y-3">
-                <div>
-                  <h3 className="text-sm font-semibold">Test configuration</h3>
-                  <p className="text-xs text-muted-foreground">
-                    This controls the simulated user identity and the negative test
-                    mode used to mint the ID-JAG.
-                  </p>
-                </div>
+              <div className="space-y-2">
+                <Label htmlFor="xaa-authz-issuer">
+                  Authorization Server Issuer
+                </Label>
+                <Input
+                  id="xaa-authz-issuer"
+                  value={draft.authzServerIssuer}
+                  onChange={(event) =>
+                    setDraft((current) => ({
+                      ...current,
+                      authzServerIssuer: event.target.value,
+                    }))
+                  }
+                  placeholder="Auto-discovered from MCP resource metadata"
+                />
+              </div>
 
+              <div className="space-y-2">
+                <Label htmlFor="xaa-client-id">
+                  Client ID <span className="text-red-500">*</span>
+                </Label>
+                <Input
+                  id="xaa-client-id"
+                  value={draft.clientId}
+                  onChange={(event) =>
+                    setDraft((current) => ({
+                      ...current,
+                      clientId: event.target.value,
+                    }))
+                  }
+                  placeholder="mcpjam-debugger"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="xaa-scope">Scope</Label>
+                <Input
+                  id="xaa-scope"
+                  value={draft.scope}
+                  onChange={(event) =>
+                    setDraft((current) => ({
+                      ...current,
+                      scope: event.target.value,
+                    }))
+                  }
+                  placeholder="read:tools read:resources"
+                />
+              </div>
+            </div>
+
+            <Collapsible open={identityOpen} onOpenChange={setIdentityOpen}>
+              <CollapsibleTrigger className="flex w-full items-center justify-between rounded-md border border-border bg-muted/30 px-3 py-2 text-sm hover:bg-muted/50 transition-colors">
+                <span className="font-medium">Simulated identity</span>
+                <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                  {identityOpen ? "Hide" : "Customize"}
+                  <ChevronDown
+                    className={cn(
+                      "h-4 w-4 transition-transform",
+                      identityOpen && "rotate-180",
+                    )}
+                  />
+                </span>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="mt-3 space-y-3">
+                <p className="text-xs text-muted-foreground">
+                  The MCPJam issuer mints a mock ID token for this user.
+                  Defaults work for most flows.
+                </p>
                 <div className="grid gap-3 md:grid-cols-2">
                   <div className="space-y-2">
                     <Label htmlFor="xaa-user-id">User ID</Label>
@@ -227,105 +219,20 @@ export function XAAConfigModal({
                     />
                   </div>
                 </div>
-
-                <div className="space-y-2">
-                  <Label>Negative test mode</Label>
-                  <Select
-                    value={draft.negativeTestMode}
-                    onValueChange={(nextValue) =>
-                      setDraft((current) => ({
-                        ...current,
-                        negativeTestMode: nextValue as XAADebugProfile["negativeTestMode"],
-                      }))
-                    }
-                  >
-                    <SelectTrigger>
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {NEGATIVE_TEST_MODES.map((mode) => (
-                        <SelectItem key={mode} value={mode}>
-                          {NEGATIVE_TEST_MODE_DETAILS[mode].label}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">
-                    {NEGATIVE_TEST_MODE_DETAILS[draft.negativeTestMode].description}
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <div className="space-y-4 rounded-lg border border-border bg-muted/20 p-4">
-              <div>
-                <h3 className="text-sm font-semibold">Trust bootstrap</h3>
-                <p className="text-xs text-muted-foreground mt-1">
-                  The target authorization server must trust the synthetic issuer
-                  before the JWT bearer step can succeed.
-                </p>
-              </div>
-
-              <div className="space-y-3">
-                <div className="space-y-1">
-                  <div className="text-xs font-medium text-muted-foreground">
-                    Synthetic issuer URL
-                  </div>
-                  <div className="rounded-md bg-background border border-border px-3 py-2 text-xs break-all">
-                    {issuerBaseUrl}
-                  </div>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => handleCopy(issuerBaseUrl)}
-                  >
-                    <Copy className="h-3.5 w-3.5 mr-1" />
-                    Copy issuer URL
-                  </Button>
-                </div>
-
-                <div className="space-y-1">
-                  <div className="text-xs font-medium text-muted-foreground">
-                    Synthetic JWKS URL
-                  </div>
-                  <div className="rounded-md bg-background border border-border px-3 py-2 text-xs break-all">
-                    {jwksUrl}
-                  </div>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => handleCopy(jwksUrl)}
-                  >
-                    <Copy className="h-3.5 w-3.5 mr-1" />
-                    Copy JWKS URL
-                  </Button>
-                </div>
-              </div>
-
-              <Alert>
-                <AlertDescription className="text-xs space-y-2">
-                  <p>1. Register the synthetic issuer or JWKS with your authorization server.</p>
-                  <p>2. Make sure the ID-JAG `aud` value matches the authorization server issuer.</p>
-                  <p>3. Make sure the ID-JAG `resource` value matches the MCP server resource identifier.</p>
-                  <p>4. Register MCPJam with the target authorization server using the client ID above.</p>
-                </AlertDescription>
-              </Alert>
-
-              {!HOSTED_MODE && (
-                <p className="text-xs text-muted-foreground">
-                  Local desktop URLs are only usable if the target authorization
-                  server can reach this machine or a public tunnel in front of it.
-                </p>
-              )}
-            </div>
+              </CollapsibleContent>
+            </Collapsible>
           </div>
 
-          {error && <p className="text-sm text-red-600">{error}</p>}
+          {error && (
+            <p className="mt-3 text-sm text-red-600 flex-shrink-0">{error}</p>
+          )}
 
-          <DialogFooter>
-            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+          <DialogFooter className="mt-4 flex-shrink-0 border-t border-border pt-3">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+            >
               Cancel
             </Button>
             <Button type="submit">Save configuration</Button>

--- a/mcpjam-inspector/client/src/components/xaa/XAAConfigModal.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAConfigModal.tsx
@@ -1,0 +1,337 @@
+import { useEffect, useMemo, useState } from "react";
+import { Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { HOSTED_MODE } from "@/lib/config";
+import { copyToClipboard } from "@/lib/clipboard";
+import type { XAADebugProfile } from "@/lib/xaa/profile";
+import {
+  NEGATIVE_TEST_MODES,
+  NEGATIVE_TEST_MODE_DETAILS,
+} from "@/shared/xaa.js";
+
+interface XAAConfigModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  value: XAADebugProfile;
+  onSave: (profile: XAADebugProfile) => void;
+}
+
+function getIssuerBaseUrl(): string {
+  if (typeof window === "undefined") {
+    return HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa";
+  }
+
+  return `${window.location.origin}${HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa"}`;
+}
+
+export function XAAConfigModal({
+  open,
+  onOpenChange,
+  value,
+  onSave,
+}: XAAConfigModalProps) {
+  const [draft, setDraft] = useState(value);
+  const [error, setError] = useState<string | null>(null);
+  const issuerBaseUrl = useMemo(() => getIssuerBaseUrl(), []);
+  const jwksUrl = `${issuerBaseUrl}/.well-known/jwks.json`;
+
+  useEffect(() => {
+    if (open) {
+      setDraft(value);
+      setError(null);
+    }
+  }, [open, value]);
+
+  const handleCopy = async (text: string) => {
+    await copyToClipboard(text);
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedServerUrl = draft.serverUrl.trim();
+    const trimmedIssuer = draft.authzServerIssuer.trim();
+    const trimmedClientId = draft.clientId.trim();
+    const trimmedScope = draft.scope.trim();
+    const trimmedUserId = draft.userId.trim();
+    const trimmedEmail = draft.email.trim();
+
+    if (!trimmedServerUrl) {
+      setError("MCP Server URL is required.");
+      return;
+    }
+
+    if (!trimmedClientId) {
+      setError("Client ID is required.");
+      return;
+    }
+
+    try {
+      new URL(trimmedServerUrl);
+      if (trimmedIssuer) {
+        new URL(trimmedIssuer);
+      }
+    } catch {
+      setError("Enter valid HTTPS or HTTP URLs for the configured endpoints.");
+      return;
+    }
+
+    setError(null);
+    onSave({
+      serverUrl: trimmedServerUrl,
+      authzServerIssuer: trimmedIssuer,
+      clientId: trimmedClientId,
+      scope: trimmedScope,
+      userId: trimmedUserId || value.userId,
+      email: trimmedEmail || value.email,
+      negativeTestMode: draft.negativeTestMode,
+    });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Configure XAA Debugger</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
+            <div className="space-y-6">
+              <div className="space-y-3">
+                <div>
+                  <h3 className="text-sm font-semibold">Target configuration</h3>
+                  <p className="text-xs text-muted-foreground">
+                    These values describe the real MCP and authorization servers
+                    you want to validate against.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="xaa-server-url">MCP Server URL</Label>
+                  <Input
+                    id="xaa-server-url"
+                    value={draft.serverUrl}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        serverUrl: event.target.value,
+                      }))
+                    }
+                    placeholder="https://mcp.example.com"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="xaa-authz-issuer">
+                    Authorization Server Issuer
+                  </Label>
+                  <Input
+                    id="xaa-authz-issuer"
+                    value={draft.authzServerIssuer}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        authzServerIssuer: event.target.value,
+                      }))
+                    }
+                    placeholder="https://auth.example.com"
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Optional. Leave blank to discover it from MCP resource metadata.
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="xaa-client-id">Client ID</Label>
+                  <Input
+                    id="xaa-client-id"
+                    value={draft.clientId}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        clientId: event.target.value,
+                      }))
+                    }
+                    placeholder="mcpjam-debugger"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="xaa-scope">Scope</Label>
+                  <Textarea
+                    id="xaa-scope"
+                    value={draft.scope}
+                    onChange={(event) =>
+                      setDraft((current) => ({
+                        ...current,
+                        scope: event.target.value,
+                      }))
+                    }
+                    placeholder="read:tools read:resources"
+                    rows={2}
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <div>
+                  <h3 className="text-sm font-semibold">Test configuration</h3>
+                  <p className="text-xs text-muted-foreground">
+                    This controls the simulated user identity and the negative test
+                    mode used to mint the ID-JAG.
+                  </p>
+                </div>
+
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="xaa-user-id">User ID</Label>
+                    <Input
+                      id="xaa-user-id"
+                      value={draft.userId}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          userId: event.target.value,
+                        }))
+                      }
+                      placeholder="user-12345"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="xaa-email">Email</Label>
+                    <Input
+                      id="xaa-email"
+                      value={draft.email}
+                      onChange={(event) =>
+                        setDraft((current) => ({
+                          ...current,
+                          email: event.target.value,
+                        }))
+                      }
+                      placeholder="demo.user@example.com"
+                    />
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label>Negative test mode</Label>
+                  <Select
+                    value={draft.negativeTestMode}
+                    onValueChange={(nextValue) =>
+                      setDraft((current) => ({
+                        ...current,
+                        negativeTestMode: nextValue as XAADebugProfile["negativeTestMode"],
+                      }))
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {NEGATIVE_TEST_MODES.map((mode) => (
+                        <SelectItem key={mode} value={mode}>
+                          {NEGATIVE_TEST_MODE_DETAILS[mode].label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    {NEGATIVE_TEST_MODE_DETAILS[draft.negativeTestMode].description}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-4 rounded-lg border border-border bg-muted/20 p-4">
+              <div>
+                <h3 className="text-sm font-semibold">Trust bootstrap</h3>
+                <p className="text-xs text-muted-foreground mt-1">
+                  The target authorization server must trust the synthetic issuer
+                  before the JWT bearer step can succeed.
+                </p>
+              </div>
+
+              <div className="space-y-3">
+                <div className="space-y-1">
+                  <div className="text-xs font-medium text-muted-foreground">
+                    Synthetic issuer URL
+                  </div>
+                  <div className="rounded-md bg-background border border-border px-3 py-2 text-xs break-all">
+                    {issuerBaseUrl}
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleCopy(issuerBaseUrl)}
+                  >
+                    <Copy className="h-3.5 w-3.5 mr-1" />
+                    Copy issuer URL
+                  </Button>
+                </div>
+
+                <div className="space-y-1">
+                  <div className="text-xs font-medium text-muted-foreground">
+                    Synthetic JWKS URL
+                  </div>
+                  <div className="rounded-md bg-background border border-border px-3 py-2 text-xs break-all">
+                    {jwksUrl}
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleCopy(jwksUrl)}
+                  >
+                    <Copy className="h-3.5 w-3.5 mr-1" />
+                    Copy JWKS URL
+                  </Button>
+                </div>
+              </div>
+
+              <Alert>
+                <AlertDescription className="text-xs space-y-2">
+                  <p>1. Register the synthetic issuer or JWKS with your authorization server.</p>
+                  <p>2. Make sure the ID-JAG `aud` value matches the authorization server issuer.</p>
+                  <p>3. Make sure the ID-JAG `resource` value matches the MCP server resource identifier.</p>
+                  <p>4. Register MCPJam with the target authorization server using the client ID above.</p>
+                </AlertDescription>
+              </Alert>
+
+              {!HOSTED_MODE && (
+                <p className="text-xs text-muted-foreground">
+                  Local desktop URLs are only usable if the target authorization
+                  server can reach this machine or a public tunnel in front of it.
+                </p>
+              )}
+            </div>
+          </div>
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <DialogFooter>
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit">Save configuration</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDown,
   ChevronRight,
   Circle,
+  KeyRound,
   Loader2,
   Pencil,
   RotateCcw,
@@ -12,6 +13,13 @@ import {
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import { HTTPHistoryEntry } from "@/components/oauth/HTTPHistoryEntry";
 import { InfoLogEntry } from "@/components/oauth/InfoLogEntry";
@@ -25,7 +33,11 @@ import type {
   XAAFlowState,
   XAAFlowStep,
 } from "@/lib/xaa/types";
-import { NEGATIVE_TEST_MODE_DETAILS } from "@/shared/xaa.js";
+import {
+  NEGATIVE_TEST_MODES,
+  NEGATIVE_TEST_MODE_DETAILS,
+  type NegativeTestMode,
+} from "@/shared/xaa.js";
 
 interface XAAFlowLoggerProps {
   flowState: XAAFlowState;
@@ -36,6 +48,8 @@ interface XAAFlowLoggerProps {
     onConfigure: () => void;
     onReset?: () => void;
     onContinue?: () => void;
+    onChangeNegativeTestMode?: (mode: NegativeTestMode) => void;
+    onShowBootstrap?: () => void;
     continueLabel: string;
     continueDisabled?: boolean;
     resetDisabled?: boolean;
@@ -189,32 +203,63 @@ export function XAAFlowLogger({
         </div>
 
         {hasProfile && (
-          <div className="flex flex-wrap gap-1.5">
-            <Badge variant="secondary" className="text-xs">
-              {negativeModeSummary.label}
-            </Badge>
-            {summary.authzServerIssuer && (
-              <Badge variant="outline" className="text-xs">
-                AuthZ issuer set
-              </Badge>
-            )}
-            {summary.clientId && (
-              <Badge variant="outline" className="text-xs">
-                Client ID set
-              </Badge>
-            )}
-            {summary.scope && (
-              <Badge variant="outline" className="text-xs">
-                {summary.scope}
-              </Badge>
-            )}
-          </div>
-        )}
+          <>
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="flex items-center gap-1.5">
+                <span className="text-xs text-muted-foreground">Mode</span>
+                <Select
+                  value={summary.negativeTestMode}
+                  onValueChange={(nextValue) =>
+                    actions.onChangeNegativeTestMode?.(
+                      nextValue as NegativeTestMode,
+                    )
+                  }
+                  disabled={!actions.onChangeNegativeTestMode}
+                >
+                  <SelectTrigger className="h-7 w-[180px] text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {NEGATIVE_TEST_MODES.map((mode) => (
+                      <SelectItem
+                        key={mode}
+                        value={mode}
+                        className="text-xs"
+                      >
+                        {NEGATIVE_TEST_MODE_DETAILS[mode].label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {summary.clientId && (
+                <Badge variant="outline" className="text-xs">
+                  {summary.clientId}
+                </Badge>
+              )}
+              {summary.scope && (
+                <Badge variant="outline" className="text-xs">
+                  {summary.scope}
+                </Badge>
+              )}
+              {actions.onShowBootstrap && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="ml-auto h-7 text-xs"
+                  onClick={actions.onShowBootstrap}
+                >
+                  <KeyRound className="h-3 w-3 mr-1" />
+                  Register issuer
+                </Button>
+              )}
+            </div>
 
-        {hasProfile && (
-          <p className="text-xs text-muted-foreground">
-            {negativeModeSummary.description}
-          </p>
+            <p className="text-xs text-muted-foreground">
+              {negativeModeSummary.description}
+            </p>
+          </>
         )}
       </div>
 

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -1,0 +1,382 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  AlertCircle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Circle,
+  Loader2,
+  Pencil,
+  RotateCcw,
+} from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { HTTPHistoryEntry } from "@/components/oauth/HTTPHistoryEntry";
+import { InfoLogEntry } from "@/components/oauth/InfoLogEntry";
+import { IdJagInspector } from "./IdJagInspector";
+import {
+  getXAAStepInfo,
+  getXAAStepIndex,
+  XAA_STEP_ORDER,
+} from "@/lib/xaa/step-metadata";
+import type {
+  XAAFlowState,
+  XAAFlowStep,
+} from "@/lib/xaa/types";
+import { NEGATIVE_TEST_MODE_DETAILS } from "@/shared/xaa.js";
+
+interface XAAFlowLoggerProps {
+  flowState: XAAFlowState;
+  hasProfile: boolean;
+  activeStep?: XAAFlowStep | null;
+  onFocusStep?: (step: XAAFlowStep) => void;
+  actions: {
+    onConfigure: () => void;
+    onReset?: () => void;
+    onContinue?: () => void;
+    continueLabel: string;
+    continueDisabled?: boolean;
+    resetDisabled?: boolean;
+  };
+  summary: {
+    serverUrl?: string;
+    authzServerIssuer?: string;
+    clientId?: string;
+    scope?: string;
+    negativeTestMode: XAAFlowState["negativeTestMode"];
+  };
+}
+
+export function XAAFlowLogger({
+  flowState,
+  hasProfile,
+  activeStep,
+  onFocusStep,
+  actions,
+  summary,
+}: XAAFlowLoggerProps) {
+  const [expandedSteps, setExpandedSteps] = useState<Set<XAAFlowStep>>(
+    new Set(),
+  );
+
+  useEffect(() => {
+    setExpandedSteps(new Set([flowState.currentStep]));
+  }, [flowState.currentStep]);
+
+  const groups = useMemo(() => {
+    const steps = new Map<
+      XAAFlowStep,
+      {
+        step: XAAFlowStep;
+        infoEntries: NonNullable<XAAFlowState["infoLogs"]>;
+        httpEntries: NonNullable<XAAFlowState["httpHistory"]>;
+      }
+    >();
+
+    const ensureGroup = (step: XAAFlowStep) => {
+      if (!steps.has(step)) {
+        steps.set(step, {
+          step,
+          infoEntries: [],
+          httpEntries: [],
+        });
+      }
+
+      return steps.get(step)!;
+    };
+
+    (flowState.infoLogs || []).forEach((entry) => {
+      ensureGroup(entry.step as XAAFlowStep).infoEntries.push(entry);
+    });
+
+    (flowState.httpHistory || []).forEach((entry) => {
+      ensureGroup(entry.step as XAAFlowStep).httpEntries.push(entry);
+    });
+
+    return Array.from(steps.values()).sort(
+      (a, b) => getXAAStepIndex(a.step) - getXAAStepIndex(b.step),
+    );
+  }, [flowState.httpHistory, flowState.infoLogs]);
+
+  const currentStepIndex = getXAAStepIndex(flowState.currentStep);
+  const focusedStep = activeStep ?? flowState.currentStep;
+  const negativeModeSummary =
+    NEGATIVE_TEST_MODE_DETAILS[summary.negativeTestMode];
+
+  const toggleStep = (step: XAAFlowStep) => {
+    setExpandedSteps((previous) => {
+      const next = new Set(previous);
+      if (next.has(step)) {
+        next.delete(step);
+      } else {
+        next.add(step);
+      }
+      return next;
+    });
+  };
+
+  const getStatus = (step: XAAFlowStep) => {
+    const index = getXAAStepIndex(step);
+    if (flowState.isBusy && step === flowState.currentStep) {
+      return {
+        icon: Loader2,
+        className: "h-4 w-4 text-blue-500 animate-spin",
+        label: "In progress",
+      };
+    }
+
+    if (index < currentStepIndex || (!flowState.isBusy && index <= currentStepIndex)) {
+      return {
+        icon: CheckCircle2,
+        className: "h-4 w-4 text-green-600 dark:text-green-400",
+        label: "Complete",
+      };
+    }
+
+    if (index === currentStepIndex + 1) {
+      return {
+        icon: Circle,
+        className: "h-4 w-4 text-blue-500",
+        label: "Next",
+      };
+    }
+
+    return {
+      icon: Circle,
+      className: "h-4 w-4 text-muted-foreground",
+      label: "Pending",
+    };
+  };
+
+  return (
+    <div className="h-full border-l border-border flex flex-col">
+      <div className="bg-muted/30 border-b border-border px-4 py-3 space-y-3">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={actions.onConfigure}
+            className="min-w-0 flex-1 flex items-center gap-2 text-left border border-border hover:border-foreground/30 bg-background rounded-md px-3 py-2 transition-colors cursor-pointer group"
+          >
+            <p className="text-sm font-medium text-foreground break-all flex-1">
+              {summary.serverUrl || "Configure an MCP server URL to start."}
+            </p>
+            <span className="flex items-center gap-1 text-xs text-muted-foreground group-hover:text-foreground shrink-0">
+              <Pencil className="h-3 w-3" />
+              Edit
+            </span>
+          </button>
+          <div className="flex items-center gap-1 shrink-0">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={actions.onReset}
+              disabled={actions.resetDisabled || !actions.onReset}
+              className="h-7"
+            >
+              <RotateCcw className="h-3 w-3 mr-1" />
+              Reset
+            </Button>
+            <Button
+              size="sm"
+              onClick={actions.onContinue}
+              disabled={actions.continueDisabled || !actions.onContinue}
+              className="h-7"
+            >
+              {actions.continueLabel}
+            </Button>
+          </div>
+        </div>
+
+        {hasProfile && (
+          <div className="flex flex-wrap gap-1.5">
+            <Badge variant="secondary" className="text-xs">
+              {negativeModeSummary.label}
+            </Badge>
+            {summary.authzServerIssuer && (
+              <Badge variant="outline" className="text-xs">
+                AuthZ issuer set
+              </Badge>
+            )}
+            {summary.clientId && (
+              <Badge variant="outline" className="text-xs">
+                Client ID set
+              </Badge>
+            )}
+            {summary.scope && (
+              <Badge variant="outline" className="text-xs">
+                {summary.scope}
+              </Badge>
+            )}
+          </div>
+        )}
+
+        {hasProfile && (
+          <p className="text-xs text-muted-foreground">
+            {negativeModeSummary.description}
+          </p>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-auto bg-muted/30 p-4 space-y-4">
+        {flowState.error && (
+          <Alert variant="destructive" className="py-2">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription className="text-xs">
+              {flowState.error}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {flowState.idJag && flowState.idJagDecoded && (
+          <IdJagInspector
+            rawJwt={flowState.idJag}
+            decoded={flowState.idJagDecoded}
+            negativeTestMode={flowState.negativeTestMode}
+          />
+        )}
+
+        {!hasProfile ? (
+          <div className="bg-background border border-border rounded-lg p-6 space-y-3">
+            <h3 className="text-base font-semibold">Welcome to the XAA Debugger</h3>
+            <p className="text-sm text-muted-foreground">
+              Configure an MCP server, target authorization server, and client ID
+              to step through the full enterprise authorization flow.
+            </p>
+            <Button onClick={actions.onConfigure}>Configure Target</Button>
+          </div>
+        ) : groups.length === 0 ? (
+          <div className="text-center py-8 text-muted-foreground text-sm">
+            No activity yet. Click &quot;{actions.continueLabel}&quot; to begin.
+          </div>
+        ) : (
+          groups.map((group, index) => {
+            const stepInfo = getXAAStepInfo(group.step);
+            const status = getStatus(group.step);
+            const StatusIcon = status.icon;
+            const entryCount =
+              group.infoEntries.length + group.httpEntries.length;
+            const hasError = group.httpEntries.some((entry) => entry.error);
+
+            return (
+              <div
+                key={group.step}
+                className={cn(
+                  "bg-background border rounded-lg shadow-sm",
+                  focusedStep === group.step
+                    ? "border-blue-400 ring-1 ring-blue-400/20"
+                    : "border-border",
+                )}
+              >
+                <button
+                  onClick={() => toggleStep(group.step)}
+                  className="w-full px-4 py-3 flex items-start gap-3 text-left hover:bg-muted/40 rounded-t-lg"
+                >
+                  <div className="flex-shrink-0 mt-0.5">
+                    {expandedSteps.has(group.step) ? (
+                      <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                    )}
+                  </div>
+                  <StatusIcon className={status.className} />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span className="text-sm font-semibold">
+                        {index + 1}. {stepInfo.title}
+                      </span>
+                      <Badge variant="secondary" className="text-[10px] h-4 px-1.5">
+                        {entryCount}
+                      </Badge>
+                      {hasError && (
+                        <Badge
+                          variant="destructive"
+                          className="text-[10px] h-4 px-1.5"
+                        >
+                          Error
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {stepInfo.summary}
+                    </p>
+                  </div>
+                  {onFocusStep && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-7"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onFocusStep(group.step);
+                      }}
+                    >
+                      Focus
+                    </Button>
+                  )}
+                </button>
+
+                {expandedSteps.has(group.step) && (
+                  <div className="border-t bg-muted/20 p-4 space-y-3">
+                    {stepInfo.teachableMoments?.length ? (
+                      <div className="space-y-1">
+                        {stepInfo.teachableMoments.map((moment) => (
+                          <p
+                            key={moment}
+                            className="text-xs text-muted-foreground"
+                          >
+                            {moment}
+                          </p>
+                        ))}
+                      </div>
+                    ) : null}
+
+                    {group.infoEntries.map((entry) => (
+                      <InfoLogEntry
+                        key={entry.id}
+                        label={entry.label}
+                        timestamp={entry.timestamp}
+                        data={entry.data}
+                        level={entry.level}
+                        error={entry.error}
+                      />
+                    ))}
+
+                    {group.httpEntries.map((entry) => (
+                      <HTTPHistoryEntry
+                        key={`${entry.timestamp}-${entry.request.url}`}
+                        method={entry.request.method}
+                        url={entry.request.url}
+                        status={entry.response?.status}
+                        statusText={entry.response?.statusText}
+                        duration={entry.duration}
+                        requestHeaders={entry.request.headers}
+                        requestBody={entry.request.body}
+                        responseHeaders={entry.response?.headers}
+                        responseBody={entry.response?.body}
+                        error={entry.error}
+                        step={entry.step}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })
+        )}
+
+        {hasProfile && groups.length > 0 && flowState.currentStep !== "complete" && (
+          <div className="text-xs text-muted-foreground">
+            Remaining steps:{" "}
+            {
+              XAA_STEP_ORDER.filter(
+                (step) => getXAAStepIndex(step) > currentStepIndex,
+              ).length
+            }
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -8,6 +8,8 @@ import type { ServerWithName } from "@/hooks/use-app-state";
 import { XAASequenceDiagram } from "./XAASequenceDiagram";
 import { XAAFlowLogger } from "./XAAFlowLogger";
 import { XAAConfigModal } from "./XAAConfigModal";
+import { XAABootstrapDialog } from "./XAABootstrapDialog";
+import type { NegativeTestMode } from "@/shared/xaa.js";
 import {
   createInitialXAAFlowState,
   type XAAFlowState,
@@ -48,6 +50,7 @@ export function XAAFlowTab({
   onSelectServer,
 }: XAAFlowTabProps) {
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
+  const [isBootstrapDialogOpen, setIsBootstrapDialogOpen] = useState(false);
   const [focusedStep, setFocusedStep] = useState<XAAFlowStep | null>(null);
 
   const httpServers = useMemo(
@@ -89,12 +92,6 @@ export function XAAFlowTab({
   }, [activeServer, profile.serverUrl]);
 
   useEffect(() => {
-    if (!profile.serverUrl.trim()) {
-      setIsConfigModalOpen(true);
-    }
-  }, [profile.serverUrl]);
-
-  useEffect(() => {
     setFocusedStep(null);
   }, [flowState.currentStep]);
 
@@ -112,6 +109,19 @@ export function XAAFlowTab({
     setFlowState(buildFlowStateFromProfile(profileToApply));
     setFocusedStep(null);
   }, [profile]);
+
+  const handleChangeNegativeTestMode = useCallback(
+    (mode: NegativeTestMode) => {
+      setProfile((current) => {
+        const next = { ...current, negativeTestMode: mode };
+        saveStoredXAADebugProfile(next);
+        setFlowState(buildFlowStateFromProfile(next));
+        setFocusedStep(null);
+        return next;
+      });
+    },
+    [],
+  );
 
   const hasProfile = Boolean(profile.serverUrl.trim());
 
@@ -179,6 +189,8 @@ export function XAAFlowTab({
                 onConfigure: () => setIsConfigModalOpen(true),
                 onReset: hasProfile ? () => resetFlow() : undefined,
                 onContinue: continueDisabled ? undefined : handleAdvance,
+                onChangeNegativeTestMode: handleChangeNegativeTestMode,
+                onShowBootstrap: () => setIsBootstrapDialogOpen(true),
                 continueLabel,
                 continueDisabled,
                 resetDisabled: !hasProfile || flowState.isBusy,
@@ -204,6 +216,11 @@ export function XAAFlowTab({
           setProfile(nextProfile);
           resetFlow(nextProfile);
         }}
+      />
+
+      <XAABootstrapDialog
+        open={isBootstrapDialogOpen}
+        onOpenChange={setIsBootstrapDialogOpen}
       />
     </div>
   );

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import type { ServerWithName } from "@/hooks/use-app-state";
+import { XAASequenceDiagram } from "./XAASequenceDiagram";
+import { XAAFlowLogger } from "./XAAFlowLogger";
+import { XAAConfigModal } from "./XAAConfigModal";
+import {
+  createInitialXAAFlowState,
+  type XAAFlowState,
+  type XAAFlowStep,
+} from "@/lib/xaa/types";
+import {
+  deriveXAADebugProfileFromServer,
+  loadStoredXAADebugProfile,
+  saveStoredXAADebugProfile,
+  type XAADebugProfile,
+} from "@/lib/xaa/profile";
+import { createInspectorXAAStateMachine } from "@/lib/xaa/debug-state-machine-adapter";
+
+const isHttpServer = (server?: ServerWithName) =>
+  Boolean(server && "url" in server.config);
+
+function buildFlowStateFromProfile(profile: XAADebugProfile): XAAFlowState {
+  return createInitialXAAFlowState({
+    serverUrl: profile.serverUrl || undefined,
+    authzServerIssuer: profile.authzServerIssuer || undefined,
+    negativeTestMode: profile.negativeTestMode,
+    userId: profile.userId || undefined,
+    email: profile.email || undefined,
+    clientId: profile.clientId || undefined,
+    scope: profile.scope || undefined,
+  });
+}
+
+interface XAAFlowTabProps {
+  serverConfigs: Record<string, ServerWithName>;
+  selectedServerName: string;
+  onSelectServer: (serverName: string) => void;
+}
+
+export function XAAFlowTab({
+  serverConfigs,
+  selectedServerName,
+  onSelectServer,
+}: XAAFlowTabProps) {
+  const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
+  const [focusedStep, setFocusedStep] = useState<XAAFlowStep | null>(null);
+
+  const httpServers = useMemo(
+    () => Object.values(serverConfigs).filter((server) => isHttpServer(server)),
+    [serverConfigs],
+  );
+
+  const selectedServer =
+    selectedServerName !== "none"
+      ? serverConfigs[selectedServerName]
+      : undefined;
+  const activeServer = isHttpServer(selectedServer)
+    ? selectedServer
+    : undefined;
+
+  useEffect(() => {
+    if (!isHttpServer(selectedServer) && httpServers.length > 0) {
+      onSelectServer(httpServers[0].name);
+    }
+  }, [httpServers, onSelectServer, selectedServer]);
+
+  const [profile, setProfile] = useState(() =>
+    deriveXAADebugProfileFromServer(activeServer, loadStoredXAADebugProfile()),
+  );
+  const [flowState, setFlowState] = useState<XAAFlowState>(() =>
+    buildFlowStateFromProfile(
+      deriveXAADebugProfileFromServer(activeServer, loadStoredXAADebugProfile()),
+    ),
+  );
+
+  useEffect(() => {
+    if (profile.serverUrl.trim()) {
+      return;
+    }
+
+    const derived = deriveXAADebugProfileFromServer(activeServer, profile);
+    setProfile(derived);
+    setFlowState(buildFlowStateFromProfile(derived));
+  }, [activeServer, profile.serverUrl]);
+
+  useEffect(() => {
+    if (!profile.serverUrl.trim()) {
+      setIsConfigModalOpen(true);
+    }
+  }, [profile.serverUrl]);
+
+  useEffect(() => {
+    setFocusedStep(null);
+  }, [flowState.currentStep]);
+
+  const flowStateRef = useRef(flowState);
+  useEffect(() => {
+    flowStateRef.current = flowState;
+  }, [flowState]);
+
+  const updateFlowState = useCallback((updates: Partial<XAAFlowState>) => {
+    setFlowState((current) => ({ ...current, ...updates }));
+  }, []);
+
+  const resetFlow = useCallback((nextProfile?: XAADebugProfile) => {
+    const profileToApply = nextProfile ?? profile;
+    setFlowState(buildFlowStateFromProfile(profileToApply));
+    setFocusedStep(null);
+  }, [profile]);
+
+  const hasProfile = Boolean(profile.serverUrl.trim());
+
+  const xaaStateMachine = useMemo(() => {
+    return createInspectorXAAStateMachine({
+      state: flowStateRef.current,
+      getState: () => flowStateRef.current,
+      updateState: updateFlowState,
+      serverUrl: profile.serverUrl || "http://localhost",
+      negativeTestMode: profile.negativeTestMode,
+      userId: profile.userId,
+      email: profile.email,
+      clientId: profile.clientId,
+      scope: profile.scope,
+      authzServerIssuer: profile.authzServerIssuer,
+    });
+  }, [profile, updateFlowState]);
+
+  const handleAdvance = useCallback(async () => {
+    if (!hasProfile) {
+      setIsConfigModalOpen(true);
+      return;
+    }
+
+    await xaaStateMachine.proceedToNextStep();
+  }, [hasProfile, xaaStateMachine]);
+
+  const continueLabel = !hasProfile
+    ? "Configure Target"
+    : flowState.currentStep === "idle"
+      ? "Start"
+      : flowState.currentStep === "inspect_id_jag"
+        ? "Request Access Token"
+        : flowState.currentStep === "received_access_token"
+          ? "Call MCP Server"
+          : flowState.currentStep === "complete"
+            ? "Flow Complete"
+            : "Continue";
+
+  const continueDisabled =
+    !hasProfile || flowState.isBusy || flowState.currentStep === "complete";
+
+  return (
+    <div className="h-full flex flex-col bg-background">
+      <div className="flex-1 overflow-hidden">
+        <ResizablePanelGroup direction="horizontal" className="h-full">
+          <ResizablePanel defaultSize={52} minSize={30}>
+            <XAASequenceDiagram
+              flowState={flowState}
+              focusedStep={focusedStep}
+              hasProfile={hasProfile}
+              onConfigure={() => setIsConfigModalOpen(true)}
+            />
+          </ResizablePanel>
+
+          <ResizableHandle withHandle />
+
+          <ResizablePanel defaultSize={48} minSize={24} maxSize={52}>
+            <XAAFlowLogger
+              flowState={flowState}
+              hasProfile={hasProfile}
+              activeStep={focusedStep ?? flowState.currentStep}
+              onFocusStep={setFocusedStep}
+              actions={{
+                onConfigure: () => setIsConfigModalOpen(true),
+                onReset: hasProfile ? () => resetFlow() : undefined,
+                onContinue: continueDisabled ? undefined : handleAdvance,
+                continueLabel,
+                continueDisabled,
+                resetDisabled: !hasProfile || flowState.isBusy,
+              }}
+              summary={{
+                serverUrl: profile.serverUrl,
+                authzServerIssuer: profile.authzServerIssuer || undefined,
+                clientId: profile.clientId || undefined,
+                scope: profile.scope || undefined,
+                negativeTestMode: profile.negativeTestMode,
+              }}
+            />
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
+
+      <XAAConfigModal
+        open={isConfigModalOpen}
+        onOpenChange={setIsConfigModalOpen}
+        value={profile}
+        onSave={(nextProfile) => {
+          saveStoredXAADebugProfile(nextProfile);
+          setProfile(nextProfile);
+          resetFlow(nextProfile);
+        }}
+      />
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/xaa/XAASequenceDiagram.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAASequenceDiagram.tsx
@@ -1,0 +1,108 @@
+import { memo, useMemo } from "react";
+import { ReactFlowProvider } from "@xyflow/react";
+import { Settings } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { DiagramLayout, buildNodesAndEdges } from "@/components/oauth/shared";
+import { buildXAAActions } from "@/lib/xaa/sequence-actions";
+import type { XAAFlowState, XAAFlowStep } from "@/lib/xaa/types";
+
+const XAA_ACTORS = {
+  client: { label: "MCP Client", color: "#10b981" },
+  testIdp: { label: "MCPJam Issuer", color: "#ef4444" },
+  mcpServer: { label: "MCP Server", color: "#f59e0b" },
+  authServer: { label: "Authorization Server", color: "#3b82f6" },
+};
+
+const XAA_ACTOR_X_POSITIONS = {
+  client: 100,
+  testIdp: 360,
+  mcpServer: 650,
+  authServer: 930,
+};
+
+interface XAASequenceDiagramProps {
+  flowState: XAAFlowState;
+  focusedStep?: XAAFlowStep | null;
+  hasProfile?: boolean;
+  onConfigure?: () => void;
+}
+
+const XAADiagramContent = memo(
+  ({
+    flowState,
+    focusedStep,
+  }: Pick<XAASequenceDiagramProps, "flowState" | "focusedStep">) => {
+    const actions = useMemo(() => buildXAAActions(flowState), [flowState]);
+    const { nodes, edges } = useMemo(
+      () =>
+        buildNodesAndEdges(actions, flowState.currentStep, {
+          actors: XAA_ACTORS,
+          actorXPositions: XAA_ACTOR_X_POSITIONS,
+        }),
+      [actions, flowState.currentStep],
+    );
+
+    return (
+      <DiagramLayout
+        nodes={nodes}
+        edges={edges}
+        currentStep={flowState.currentStep}
+        focusedStep={focusedStep}
+      />
+    );
+  },
+);
+
+XAADiagramContent.displayName = "XAADiagramContent";
+
+export const XAASequenceDiagram = memo(
+  ({
+    flowState,
+    focusedStep,
+    hasProfile = true,
+    onConfigure,
+  }: XAASequenceDiagramProps) => {
+    return (
+      <div className="relative h-full w-full">
+        <div
+          className={
+            hasProfile
+              ? "h-full w-full"
+              : "h-full w-full opacity-30 pointer-events-none"
+          }
+        >
+          <ReactFlowProvider>
+            <XAADiagramContent
+              flowState={flowState}
+              focusedStep={focusedStep}
+            />
+          </ReactFlowProvider>
+        </div>
+
+        {!hasProfile && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="bg-background border border-border rounded-lg shadow-lg p-8 max-w-md text-center">
+              <div className="mx-auto w-12 h-12 rounded-full bg-muted flex items-center justify-center mb-4">
+                <Settings className="h-6 w-6 text-muted-foreground" />
+              </div>
+              <h3 className="text-lg font-semibold mb-2">
+                Configure XAA Target
+              </h3>
+              <p className="text-sm text-muted-foreground mb-6">
+                Add an MCP server URL, client ID, and target authorization
+                server to step through the synthetic XAA flow.
+              </p>
+              {onConfigure && (
+                <Button onClick={onConfigure} size="lg">
+                  Configure Target
+                </Button>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+XAASequenceDiagram.displayName = "XAASequenceDiagram";

--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-tab-policy.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-tab-policy.test.ts
@@ -67,6 +67,14 @@ describe("hosted-tab-policy", () => {
     expect(isHostedHashTabBlocked("oauth-flow")).toBe(false);
   });
 
+  it("allows xaa-flow in hosted sidebar", () => {
+    expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("xaa-flow");
+    expect(HOSTED_HASH_ALLOWED_TABS).toContain("xaa-flow");
+    expect(isHostedSidebarTabAllowed("xaa-flow")).toBe(true);
+    expect(isHostedHashTabAllowed("xaa-flow")).toBe(true);
+    expect(isHostedHashTabBlocked("xaa-flow")).toBe(false);
+  });
+
   it("allows learning in hosted navigation", () => {
     expect(HOSTED_SIDEBAR_ALLOWED_TABS).toContain("learning");
     expect(HOSTED_HASH_ALLOWED_TABS).toContain("learning");

--- a/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
@@ -18,6 +18,7 @@ export const HOSTED_SIDEBAR_ALLOWED_TABS = [
   "support",
   "settings",
   "oauth-flow",
+  "xaa-flow",
   "learning",
 ] as const;
 

--- a/mcpjam-inspector/client/src/lib/learn-more-content.ts
+++ b/mcpjam-inspector/client/src/lib/learn-more-content.ts
@@ -71,4 +71,13 @@ export const learnMoreContent: Record<string, LearnMoreEntry> = {
       "A visual, step-by-step interface for testing your MCP server's OAuth implementation. Walk through every step of the handshake with a live sequence diagram, inspect every network request, and validate against multiple spec versions and registration methods (CIMD, DCR, or pre-registration).",
     docsUrl: "https://docs.mcpjam.com/inspector/guided-oauth",
   },
+  "xaa-flow": {
+    title: "XAA Debugger",
+    videoUrl: "https://www.youtube.com/embed/tQSEnr4T5Qc",
+    description:
+      "Test enterprise XAA / ID-JAG authorization flows against real authorization servers.",
+    expandedDescription:
+      "A guided debugger for Cross-App Access style enterprise authorization. Issue a synthetic OIDC identity token, exchange it for a valid or intentionally broken ID-JAG, submit that assertion to your real authorization server, and then verify the resulting access token against your MCP server.",
+    docsUrl: "https://docs.mcpjam.com/inspector/guided-oauth",
+  },
 };

--- a/mcpjam-inspector/client/src/lib/oauth/jwt-decoder.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/jwt-decoder.ts
@@ -1,33 +1,44 @@
+export interface DecodedJwtParts {
+  header: Record<string, any> | null;
+  payload: Record<string, any> | null;
+  signature: string;
+}
+
+function decodeJwtPart(encoded: string): Record<string, any> | null {
+  try {
+    const base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+    const paddedBase64 = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+    return JSON.parse(atob(paddedBase64));
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Safely decode a JWT token without verification
  * Returns the decoded payload or null if invalid
  */
 export function decodeJWT(token: string): Record<string, any> | null {
-  try {
-    // JWT format: header.payload.signature
-    const parts = token.split(".");
-    if (parts.length !== 3) {
-      return null;
-    }
-
-    // Decode the payload (second part)
-    const payload = parts[1];
-
-    // Handle base64url decoding (replace - with + and _ with /)
-    const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
-
-    // Add padding if needed
-    const paddedBase64 = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
-
-    // Decode base64 to string
-    const decoded = atob(paddedBase64);
-
-    // Parse JSON
-    return JSON.parse(decoded);
-  } catch (error) {
-    console.error("Failed to decode JWT:", error);
+  const decoded = decodeJWTParts(token);
+  if (!decoded) {
+    console.error("Failed to decode JWT");
     return null;
   }
+
+  return decoded.payload;
+}
+
+export function decodeJWTParts(token: string): DecodedJwtParts | null {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    return null;
+  }
+
+  return {
+    header: decodeJwtPart(parts[0]),
+    payload: decodeJwtPart(parts[1]),
+    signature: parts[2],
+  };
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/state-machine.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it, vi } from "vitest";
+import { createXAAStateMachine } from "../state-machine";
+import { createInitialXAAFlowState, type XAAFlowState } from "../types";
+
+function encodePart(value: Record<string, any>): string {
+  return Buffer.from(JSON.stringify(value)).toString("base64url");
+}
+
+function makeJwt(
+  payload: Record<string, any>,
+  header: Record<string, any> = {
+    alg: "RS256",
+    typ: "oauth-id-jag+jwt",
+    kid: "xaa-idp-1",
+  },
+): string {
+  return `${encodePart(header)}.${encodePart(payload)}.signature`;
+}
+
+describe("createXAAStateMachine", () => {
+  it("walks the full happy path to completion", async () => {
+    let state: XAAFlowState = createInitialXAAFlowState({
+      serverUrl: "https://mcp.example.com",
+      clientId: "mcpjam-debugger",
+      userId: "user-12345",
+      email: "demo.user@example.com",
+      scope: "read:tools",
+    });
+
+    const idToken = makeJwt(
+      {
+        iss: "https://issuer.example/api/web/xaa",
+        sub: "user-12345",
+        email: "demo.user@example.com",
+      },
+      { alg: "RS256", typ: "JWT", kid: "xaa-idp-1" },
+    );
+    const idJag = makeJwt({
+      iss: "https://issuer.example/api/web/xaa",
+      sub: "user-12345",
+      aud: "https://auth.example.com",
+      resource: "https://mcp.example.com",
+      client_id: "mcpjam-debugger",
+      exp: Math.floor(Date.now() / 1000) + 300,
+      scope: "read:tools",
+    });
+
+    const executor = {
+      externalRequest: vi.fn(async (url: string) => {
+        if (url.includes(".well-known/oauth-protected-resource")) {
+          return {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: {
+              resource: "https://mcp.example.com",
+              authorization_servers: ["https://auth.example.com"],
+            },
+            ok: true,
+          };
+        }
+
+        if (url.includes(".well-known/oauth-authorization-server")) {
+          return {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: {
+              issuer: "https://auth.example.com",
+              token_endpoint: "https://auth.example.com/oauth/token",
+            },
+            ok: true,
+          };
+        }
+
+        return {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: { result: { serverInfo: { name: "demo" } } },
+          ok: true,
+        };
+      }),
+      internalRequest: vi.fn(async (path: string) => {
+        if (path === "/authenticate") {
+          return {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: { id_token: idToken },
+            ok: true,
+          };
+        }
+
+        if (path === "/token-exchange") {
+          return {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: { id_jag: idJag },
+            ok: true,
+          };
+        }
+
+        return {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: {
+              access_token: "access-token",
+              token_type: "Bearer",
+              expires_in: 300,
+            },
+          },
+          ok: true,
+        };
+      }),
+    };
+
+    const machine = createXAAStateMachine({
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: "https://mcp.example.com",
+      issuerBaseUrl: "https://issuer.example/api/web/xaa",
+      requestExecutor: executor,
+      clientId: "mcpjam-debugger",
+      userId: "user-12345",
+      email: "demo.user@example.com",
+      scope: "read:tools",
+    });
+
+    for (let index = 0; index < 7; index += 1) {
+      await machine.proceedToNextStep();
+    }
+
+    expect(state.currentStep).toBe("complete");
+    expect(state.accessToken).toBe("access-token");
+    expect(state.idJagDecoded?.issues).toHaveLength(0);
+    expect(executor.internalRequest).toHaveBeenCalledWith(
+      "/proxy/token",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+  });
+
+  it("passes the configured negative test mode to token exchange and flags the issue during inspection", async () => {
+    let state: XAAFlowState = createInitialXAAFlowState({
+      serverUrl: "https://mcp.example.com",
+      authzServerIssuer: "https://auth.example.com",
+      clientId: "mcpjam-debugger",
+      userId: "user-12345",
+      email: "demo.user@example.com",
+      negativeTestMode: "unknown_kid",
+    });
+
+    const idToken = makeJwt(
+      {
+        iss: "https://issuer.example/api/web/xaa",
+        sub: "user-12345",
+      },
+      { alg: "RS256", typ: "JWT", kid: "xaa-idp-1" },
+    );
+    const idJag = makeJwt(
+      {
+        iss: "https://issuer.example/api/web/xaa",
+        sub: "user-12345",
+        aud: "https://auth.example.com",
+        resource: "https://mcp.example.com",
+        client_id: "mcpjam-debugger",
+        exp: Math.floor(Date.now() / 1000) + 300,
+      },
+      { alg: "RS256", typ: "oauth-id-jag+jwt", kid: "nonexistent-key-id" },
+    );
+
+    const executor = {
+      externalRequest: vi.fn(async (url: string) => {
+        if (url.includes(".well-known/oauth-protected-resource")) {
+          return {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: {
+              resource: "https://mcp.example.com",
+              authorization_servers: ["https://auth.example.com"],
+            },
+            ok: true,
+          };
+        }
+
+        return {
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          body: {
+            issuer: "https://auth.example.com",
+            token_endpoint: "https://auth.example.com/oauth/token",
+          },
+          ok: true,
+        };
+      }),
+      internalRequest: vi.fn(async (path: string, init?: RequestInit) => {
+        if (path === "/authenticate") {
+          return {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: { id_token: idToken },
+            ok: true,
+          };
+        }
+
+        if (path === "/token-exchange") {
+          const parsedBody = JSON.parse(String(init?.body));
+          expect(parsedBody.negativeTestMode).toBe("unknown_kid");
+          return {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: { id_jag: idJag },
+            ok: true,
+          };
+        }
+
+        throw new Error("proxy/token should not run in this test");
+      }),
+    };
+
+    const machine = createXAAStateMachine({
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: "https://mcp.example.com",
+      issuerBaseUrl: "https://issuer.example/api/web/xaa",
+      requestExecutor: executor,
+      clientId: "mcpjam-debugger",
+      userId: "user-12345",
+      email: "demo.user@example.com",
+      negativeTestMode: "unknown_kid",
+      authzServerIssuer: "https://auth.example.com",
+    });
+
+    for (let index = 0; index < 5; index += 1) {
+      await machine.proceedToNextStep();
+    }
+
+    expect(state.currentStep).toBe("inspect_id_jag");
+    expect(state.idJagDecoded?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          field: "kid",
+        }),
+      ]),
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
@@ -1,6 +1,6 @@
 import { HOSTED_MODE } from "@/lib/config";
 import { authFetch } from "@/lib/session-token";
-import { proxyFetch } from "@/lib/oauth/state-machines/shared/helpers";
+import { createDebugRequestExecutor } from "@/lib/oauth/debug-state-machine-adapter";
 import { createXAAStateMachine } from "./state-machine";
 import type {
   BaseXAAStateMachineConfig,
@@ -13,6 +13,23 @@ const XAA_API_BASE = HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa";
 
 function responseHeadersToRecord(response: Response): Record<string, string> {
   return Object.fromEntries(response.headers.entries());
+}
+
+function normalizeHeaders(
+  headers?: HeadersInit | Record<string, string>,
+): Record<string, string> {
+  if (!headers) return {};
+  if (headers instanceof Headers) {
+    return Object.fromEntries(headers.entries());
+  }
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(
+      headers.map(([key, value]) => [key, String(value)]),
+    );
+  }
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key, String(value)]),
+  );
 }
 
 async function readResponseBody(response: Response): Promise<any> {
@@ -34,6 +51,8 @@ async function readResponseBody(response: Response): Promise<any> {
 }
 
 export function createXAADebugRequestExecutor(): XAARequestExecutor {
+  const debugRequestExecutor = createDebugRequestExecutor();
+
   return {
     internalRequest: async (
       path: string,
@@ -54,14 +73,12 @@ export function createXAADebugRequestExecutor(): XAARequestExecutor {
       url: string,
       init?: RequestInit,
     ): Promise<XAARequestResult> => {
-      const response = await proxyFetch(url, init);
-      return {
-        status: response.status,
-        statusText: response.statusText,
-        headers: response.headers,
-        body: response.body,
-        ok: response.ok,
-      };
+      return debugRequestExecutor({
+        url,
+        method: init?.method || "GET",
+        headers: normalizeHeaders(init?.headers),
+        body: init?.body,
+      });
     },
   };
 }

--- a/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/debug-state-machine-adapter.ts
@@ -1,0 +1,77 @@
+import { HOSTED_MODE } from "@/lib/config";
+import { authFetch } from "@/lib/session-token";
+import { proxyFetch } from "@/lib/oauth/state-machines/shared/helpers";
+import { createXAAStateMachine } from "./state-machine";
+import type {
+  BaseXAAStateMachineConfig,
+  XAARequestExecutor,
+  XAARequestResult,
+  XAAStateMachine,
+} from "./types";
+
+const XAA_API_BASE = HOSTED_MODE ? "/api/web/xaa" : "/api/mcp/xaa";
+
+function responseHeadersToRecord(response: Response): Record<string, string> {
+  return Object.fromEntries(response.headers.entries());
+}
+
+async function readResponseBody(response: Response): Promise<any> {
+  const contentType = response.headers.get("content-type") || "";
+
+  if (contentType.includes("application/json")) {
+    try {
+      return await response.json();
+    } catch {
+      return null;
+    }
+  }
+
+  try {
+    return await response.text();
+  } catch {
+    return null;
+  }
+}
+
+export function createXAADebugRequestExecutor(): XAARequestExecutor {
+  return {
+    internalRequest: async (
+      path: string,
+      init?: RequestInit,
+    ): Promise<XAARequestResult> => {
+      const response = await authFetch(`${XAA_API_BASE}${path}`, init);
+      const body = await readResponseBody(response);
+
+      return {
+        status: response.status,
+        statusText: response.statusText,
+        headers: responseHeadersToRecord(response),
+        body,
+        ok: response.ok,
+      };
+    },
+    externalRequest: async (
+      url: string,
+      init?: RequestInit,
+    ): Promise<XAARequestResult> => {
+      const response = await proxyFetch(url, init);
+      return {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+        body: response.body,
+        ok: response.ok,
+      };
+    },
+  };
+}
+
+export function createInspectorXAAStateMachine(
+  config: Omit<BaseXAAStateMachineConfig, "issuerBaseUrl" | "requestExecutor">,
+): XAAStateMachine {
+  return createXAAStateMachine({
+    ...config,
+    issuerBaseUrl: `${window.location.origin}${XAA_API_BASE}`,
+    requestExecutor: createXAADebugRequestExecutor(),
+  });
+}

--- a/mcpjam-inspector/client/src/lib/xaa/profile.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/profile.ts
@@ -1,0 +1,105 @@
+import type { ServerWithName } from "@/hooks/use-app-state";
+import type { HttpServerConfig } from "@mcpjam/sdk/browser";
+import {
+  DEFAULT_NEGATIVE_TEST_MODE,
+  isNegativeTestMode,
+  type NegativeTestMode,
+} from "@/shared/xaa.js";
+
+const XAA_PROFILE_STORAGE_KEY = "mcpjam-xaa-debugger-profile/v1";
+
+export interface XAADebugProfile {
+  serverUrl: string;
+  authzServerIssuer: string;
+  clientId: string;
+  scope: string;
+  userId: string;
+  email: string;
+  negativeTestMode: NegativeTestMode;
+}
+
+export const EMPTY_XAA_DEBUG_PROFILE: XAADebugProfile = {
+  serverUrl: "",
+  authzServerIssuer: "",
+  clientId: "",
+  scope: "",
+  userId: "user-12345",
+  email: "demo.user@example.com",
+  negativeTestMode: DEFAULT_NEGATIVE_TEST_MODE,
+};
+
+function toUrlString(value?: string | URL): string {
+  if (!value) return "";
+  if (typeof value === "string") return value;
+
+  try {
+    return value.toString();
+  } catch {
+    return "";
+  }
+}
+
+function sanitizeNegativeTestMode(value: unknown): NegativeTestMode {
+  return isNegativeTestMode(value) ? value : DEFAULT_NEGATIVE_TEST_MODE;
+}
+
+export function loadStoredXAADebugProfile(): XAADebugProfile {
+  try {
+    const raw = localStorage.getItem(XAA_PROFILE_STORAGE_KEY);
+    if (!raw) {
+      return EMPTY_XAA_DEBUG_PROFILE;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<XAADebugProfile>;
+    return {
+      ...EMPTY_XAA_DEBUG_PROFILE,
+      ...parsed,
+      negativeTestMode: sanitizeNegativeTestMode(parsed.negativeTestMode),
+    };
+  } catch {
+    return EMPTY_XAA_DEBUG_PROFILE;
+  }
+}
+
+export function saveStoredXAADebugProfile(profile: XAADebugProfile): void {
+  try {
+    localStorage.setItem(XAA_PROFILE_STORAGE_KEY, JSON.stringify(profile));
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+export function deriveXAADebugProfileFromServer(
+  server?: ServerWithName,
+  existingProfile: XAADebugProfile = EMPTY_XAA_DEBUG_PROFILE,
+): XAADebugProfile {
+  if (!server) {
+    return existingProfile;
+  }
+
+  const httpConfig =
+    "url" in server.config ? (server.config as HttpServerConfig) : null;
+
+  if (!httpConfig) {
+    return existingProfile;
+  }
+
+  const configuredScopes = Array.isArray((httpConfig as any).oauthScopes)
+    ? ((httpConfig as any).oauthScopes as string[]).join(" ")
+    : "";
+  const configuredClientId =
+    typeof (httpConfig as any).clientId === "string"
+      ? (httpConfig as any).clientId
+      : "";
+
+  return {
+    ...EMPTY_XAA_DEBUG_PROFILE,
+    ...existingProfile,
+    serverUrl: existingProfile.serverUrl || toUrlString(httpConfig.url),
+    clientId: existingProfile.clientId || configuredClientId,
+    scope: existingProfile.scope || configuredScopes,
+    negativeTestMode: sanitizeNegativeTestMode(
+      existingProfile.negativeTestMode,
+    ),
+  };
+}

--- a/mcpjam-inspector/client/src/lib/xaa/sequence-actions.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/sequence-actions.ts
@@ -1,0 +1,159 @@
+import type { Action } from "@/components/oauth/shared/types";
+import type { XAAFlowState } from "./types";
+import { NEGATIVE_TEST_MODE_DETAILS } from "@/shared/xaa.js";
+
+const XAA_PROTOCOL = "RFC 8693 + RFC 7523";
+
+function safePath(url?: string): string | undefined {
+  if (!url) return undefined;
+
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return url;
+  }
+}
+
+export function buildXAAActions(flowState: XAAFlowState): Action[] {
+  return [
+    {
+      id: "discover_resource_metadata",
+      label: "Fetch resource metadata",
+      description: "Client discovers RFC 9728 metadata from the MCP server.",
+      from: "client",
+      to: "mcpServer",
+      details: flowState.serverUrl
+        ? [{ label: "Target", value: safePath(flowState.resourceMetadataUrl) }]
+        : undefined,
+    },
+    {
+      id: "received_resource_metadata",
+      label: "Resource metadata",
+      description: "MCP server returns the resource identifier and auth server issuer.",
+      from: "mcpServer",
+      to: "client",
+      details: flowState.resourceUrl
+        ? [{ label: "resource", value: flowState.resourceUrl }]
+        : undefined,
+    },
+    {
+      id: "discover_authz_metadata",
+      label: "Fetch auth server metadata",
+      description: "Client discovers the authorization server token endpoint.",
+      from: "client",
+      to: "authServer",
+      details: flowState.authzServerIssuer
+        ? [{ label: "Issuer", value: flowState.authzServerIssuer }]
+        : undefined,
+    },
+    {
+      id: "received_authz_metadata",
+      label: "Auth server metadata",
+      description: "Authorization server returns issuer and token endpoint metadata.",
+      from: "authServer",
+      to: "client",
+      details: flowState.tokenEndpoint
+        ? [{ label: "Token", value: safePath(flowState.tokenEndpoint) }]
+        : undefined,
+    },
+    {
+      id: "user_authentication",
+      label: "Mock OIDC login",
+      description: "MCPJam synthetic issuer creates a mock enterprise ID token.",
+      from: "client",
+      to: "testIdp",
+      details: flowState.email
+        ? [{ label: "User", value: flowState.email }]
+        : undefined,
+    },
+    {
+      id: "received_identity_assertion",
+      label: "ID token issued",
+      description: "Synthetic issuer returns the mock identity assertion.",
+      from: "testIdp",
+      to: "client",
+      details: flowState.identityAssertion
+        ? [{ label: "Type", value: "OIDC ID token" }]
+        : undefined,
+    },
+    {
+      id: "token_exchange_request",
+      label: "Token exchange",
+      description: "Client exchanges the ID token for an ID-JAG with a selected test mode.",
+      from: "client",
+      to: "testIdp",
+      details: [
+        {
+          label: "Mode",
+          value: NEGATIVE_TEST_MODE_DETAILS[flowState.negativeTestMode].label,
+        },
+      ],
+    },
+    {
+      id: "received_id_jag",
+      label: "ID-JAG issued",
+      description: "Synthetic issuer returns a signed ID-JAG JWT.",
+      from: "testIdp",
+      to: "client",
+      details: flowState.idJag
+        ? [{ label: "Protocol", value: XAA_PROTOCOL }]
+        : undefined,
+    },
+    {
+      id: "inspect_id_jag",
+      label: "Inspect assertion",
+      description: "Client decodes the ID-JAG locally before submitting it downstream.",
+      from: "client",
+      to: "client",
+      details: flowState.idJagDecoded?.issues.length
+        ? [
+            {
+              label: "Issues",
+              value: String(flowState.idJagDecoded.issues.length),
+            },
+          ]
+        : [{ label: "Issues", value: "None" }],
+    },
+    {
+      id: "jwt_bearer_request",
+      label: "JWT bearer grant",
+      description: "Client submits the ID-JAG to the target authorization server.",
+      from: "client",
+      to: "authServer",
+      details: flowState.tokenEndpoint
+        ? [{ label: "Endpoint", value: safePath(flowState.tokenEndpoint) }]
+        : undefined,
+    },
+    {
+      id: "received_access_token",
+      label: "Access token",
+      description: "Authorization server returns an access token for the MCP resource.",
+      from: "authServer",
+      to: "client",
+      details: flowState.accessToken
+        ? [{ label: "token_type", value: flowState.tokenType || "Bearer" }]
+        : undefined,
+    },
+    {
+      id: "authenticated_mcp_request",
+      label: "Authenticated MCP request",
+      description: "Client retries an MCP initialize request with the issued access token.",
+      from: "client",
+      to: "mcpServer",
+      details: flowState.serverUrl
+        ? [{ label: "Target", value: safePath(flowState.serverUrl) }]
+        : undefined,
+    },
+    {
+      id: "complete",
+      label: "Authenticated response",
+      description: "MCP server accepts the access token and responds to the request.",
+      from: "mcpServer",
+      to: "client",
+      details: flowState.accessToken
+        ? [{ label: "Status", value: "Ready" }]
+        : undefined,
+    },
+  ];
+}

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -1,9 +1,4 @@
-import {
-  addInfoLog,
-  buildResourceMetadataUrl,
-  mergeHeadersForAuthServer,
-  toLogErrorDetails,
-} from "@/lib/oauth/state-machines/shared/helpers";
+import type { InfoLogLevel, LogErrorDetails } from "@mcpjam/sdk/browser";
 import { decodeJWTParts, formatJWTTimestamp } from "@/lib/oauth/jwt-decoder";
 import {
   NEGATIVE_TEST_MODE_DETAILS,
@@ -14,11 +9,117 @@ import type {
   BaseXAAStateMachineConfig,
   XAADecodedJwt,
   XAAFlowState,
+  XAAFlowStep,
   XAAJWTInspectionIssue,
+  XAAInfoLogEntry,
   XAARequestResult,
   XAAStateMachine,
 } from "./types";
 import { createInitialXAAFlowState } from "./types";
+
+interface AddInfoLogOptions {
+  level?: InfoLogLevel;
+  error?: LogErrorDetails;
+}
+
+function addInfoLog(
+  state: XAAFlowState,
+  step: XAAFlowStep,
+  id: string,
+  label: string,
+  data: any,
+  options: AddInfoLogOptions = {},
+): Array<XAAInfoLogEntry> {
+  const { level = "info", error } = options;
+
+  return [
+    ...(state.infoLogs || []),
+    {
+      id,
+      step,
+      label,
+      data,
+      timestamp: Date.now(),
+      level,
+      error,
+    },
+  ];
+}
+
+function toLogErrorDetails(error: unknown): LogErrorDetails {
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      details: {
+        name: error.name,
+        stack: error.stack,
+      },
+    };
+  }
+
+  if (typeof error === "string") {
+    return { message: error };
+  }
+
+  return {
+    message: "Unexpected error",
+    details: error,
+  };
+}
+
+function mergeHeadersForAuthServer(
+  customHeaders: Record<string, string> | undefined,
+  requestHeaders: Record<string, string> = {},
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+  const keysByLowercase = new Map<string, string>();
+
+  const applyHeaders = (headers: Record<string, string> | undefined) => {
+    if (!headers) return;
+
+    for (const [key, value] of Object.entries(headers)) {
+      const lowerKey = key.toLowerCase();
+      const previousKey = keysByLowercase.get(lowerKey);
+
+      if (previousKey && previousKey !== key) {
+        delete merged[previousKey];
+      }
+
+      keysByLowercase.set(lowerKey, key);
+      merged[key] = value;
+    }
+  };
+
+  applyHeaders(customHeaders);
+  applyHeaders(requestHeaders);
+
+  for (const key of Object.keys(merged)) {
+    if (key.toLowerCase() === "authorization") {
+      delete merged[key];
+    }
+  }
+
+  return merged;
+}
+
+function buildResourceMetadataUrl(serverUrl: string): string {
+  const url = new URL(serverUrl);
+
+  if (url.pathname !== "/" && url.pathname !== "") {
+    const pathname = url.pathname.endsWith("/")
+      ? url.pathname.slice(0, -1)
+      : url.pathname;
+    return new URL(
+      `/.well-known/oauth-protected-resource${pathname}`,
+      url.origin,
+    ).toString();
+  }
+
+  return new URL(
+    "/.well-known/oauth-protected-resource",
+    url.origin,
+  ).toString();
+}
 
 function canonicalizeResourceUrl(url: string): string {
   try {
@@ -308,7 +409,7 @@ export function createXAAStateMachine(
     id: string,
     label: string,
     data: any,
-    options?: Parameters<typeof addInfoLog>[5],
+    options?: AddInfoLogOptions,
   ) => {
     machine.updateState({
       infoLogs: addInfoLog(currentState(), step, id, label, data, options),

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -1,0 +1,1016 @@
+import {
+  addInfoLog,
+  buildResourceMetadataUrl,
+  mergeHeadersForAuthServer,
+  toLogErrorDetails,
+} from "@/lib/oauth/state-machines/shared/helpers";
+import { decodeJWTParts, formatJWTTimestamp } from "@/lib/oauth/jwt-decoder";
+import {
+  NEGATIVE_TEST_MODE_DETAILS,
+  type NegativeTestMode,
+  XAA_IDP_KID,
+} from "@/shared/xaa.js";
+import type {
+  BaseXAAStateMachineConfig,
+  XAADecodedJwt,
+  XAAFlowState,
+  XAAJWTInspectionIssue,
+  XAARequestResult,
+  XAAStateMachine,
+} from "./types";
+import { createInitialXAAFlowState } from "./types";
+
+function canonicalizeResourceUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.protocol = parsed.protocol.toLowerCase();
+    parsed.hostname = parsed.hostname.toLowerCase();
+    parsed.hash = "";
+
+    if (parsed.pathname !== "/" && parsed.pathname.endsWith("/")) {
+      parsed.pathname = parsed.pathname.slice(0, -1);
+    }
+
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+function buildAuthServerMetadataUrls(authServerUrl: string): string[] {
+  const url = new URL(authServerUrl);
+  const urls: string[] = [];
+
+  if (url.pathname === "/" || url.pathname === "") {
+    urls.push(
+      new URL("/.well-known/oauth-authorization-server", url.origin).toString(),
+    );
+    urls.push(
+      new URL("/.well-known/openid-configuration", url.origin).toString(),
+    );
+  } else {
+    const pathname = url.pathname.endsWith("/")
+      ? url.pathname.slice(0, -1)
+      : url.pathname;
+
+    urls.push(
+      new URL(
+        `/.well-known/oauth-authorization-server${pathname}`,
+        url.origin,
+      ).toString(),
+    );
+    urls.push(
+      new URL(
+        `/.well-known/openid-configuration${pathname}`,
+        url.origin,
+      ).toString(),
+    );
+    urls.push(
+      new URL(
+        `${pathname}/.well-known/openid-configuration`,
+        url.origin,
+      ).toString(),
+    );
+  }
+
+  return urls;
+}
+
+function extractErrorMessage(body: any, fallback: string): string {
+  if (typeof body === "string" && body.trim()) {
+    return body;
+  }
+
+  if (!body || typeof body !== "object") {
+    return fallback;
+  }
+
+  return (
+    body.error_description ||
+    body.error ||
+    body.message ||
+    body.statusText ||
+    fallback
+  );
+}
+
+function asRecord(
+  value: unknown,
+  label: string,
+): Record<string, any> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} did not return a JSON object`);
+  }
+
+  return value as Record<string, any>;
+}
+
+function formatClaimValue(value: unknown): string {
+  if (typeof value === "number") {
+    return `${value} (${formatJWTTimestamp(value)})`;
+  }
+
+  if (value === undefined) {
+    return "(missing)";
+  }
+
+  if (value === null) {
+    return "null";
+  }
+
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+
+  return String(value);
+}
+
+function buildIdJagInspection(
+  token: string,
+  expected: {
+    issuer: string;
+    audience: string;
+    resource: string;
+    clientId: string;
+    scope?: string;
+    negativeTestMode: NegativeTestMode;
+  },
+): XAADecodedJwt {
+  const decoded = decodeJWTParts(token);
+  const issues: XAAJWTInspectionIssue[] = [];
+
+  if (!decoded) {
+    return {
+      header: null,
+      payload: null,
+      signature: "",
+      issues: [
+        {
+          section: "payload",
+          field: "token",
+          label: "JWT parsing",
+          expected: "A well-formed three-part JWT",
+          actual: "The returned assertion could not be decoded.",
+        },
+      ],
+    };
+  }
+
+  const header = decoded.header || {};
+  const payload = decoded.payload || {};
+
+  const addIssue = (
+    section: XAAJWTInspectionIssue["section"],
+    field: string,
+    label: string,
+    expectedValue: unknown,
+    actualValue: unknown,
+  ) => {
+    issues.push({
+      section,
+      field,
+      label,
+      expected: formatClaimValue(expectedValue),
+      actual: formatClaimValue(actualValue),
+    });
+  };
+
+  if (header.typ !== "oauth-id-jag+jwt") {
+    addIssue(
+      "header",
+      "typ",
+      "JWT type",
+      "oauth-id-jag+jwt",
+      header.typ,
+    );
+  }
+
+  if (header.kid !== XAA_IDP_KID) {
+    addIssue("header", "kid", "Key identifier", XAA_IDP_KID, header.kid);
+  }
+
+  if (payload.iss !== expected.issuer) {
+    addIssue("payload", "iss", "Issuer", expected.issuer, payload.iss);
+  }
+
+  if (payload.sub !== undefined && String(payload.sub).trim() === "") {
+    addIssue("payload", "sub", "Subject", "Non-empty subject", payload.sub);
+  }
+
+  if (payload.sub === undefined) {
+    addIssue("payload", "sub", "Subject", "Present", payload.sub);
+  }
+
+  if (payload.aud !== expected.audience) {
+    addIssue(
+      "payload",
+      "aud",
+      "Audience",
+      expected.audience,
+      payload.aud,
+    );
+  }
+
+  if (payload.resource !== expected.resource) {
+    addIssue(
+      "payload",
+      "resource",
+      "Resource",
+      expected.resource,
+      payload.resource,
+    );
+  }
+
+  if (payload.client_id !== expected.clientId) {
+    addIssue(
+      "payload",
+      "client_id",
+      "Client ID",
+      expected.clientId,
+      payload.client_id,
+    );
+  }
+
+  if (typeof payload.exp !== "number" || payload.exp <= Date.now() / 1000) {
+    addIssue(
+      "payload",
+      "exp",
+      "Expiration",
+      "A future timestamp",
+      payload.exp,
+    );
+  }
+
+  if (expected.scope && payload.scope !== expected.scope) {
+    addIssue("payload", "scope", "Requested scopes", expected.scope, payload.scope);
+  }
+
+  if (expected.negativeTestMode === "bad_signature") {
+    addIssue(
+      "signature",
+      "signature",
+      "Signature / JWKS",
+      "Signed by the published XAA issuer key",
+      "Signed with a throwaway private key",
+    );
+  }
+
+  return {
+    header: decoded.header,
+    payload: decoded.payload,
+    signature: decoded.signature,
+    issues,
+  };
+}
+
+export function createXAAStateMachine(
+  config: BaseXAAStateMachineConfig,
+): XAAStateMachine {
+  const {
+    state,
+    getState,
+    updateState,
+    serverUrl,
+    issuerBaseUrl,
+    requestExecutor,
+    negativeTestMode,
+    userId,
+    email,
+    clientId,
+    scope,
+    authzServerIssuer,
+  } = config;
+
+  const machine: XAAStateMachine = {
+    state: createInitialXAAFlowState({
+      ...state,
+      serverUrl: state.serverUrl || serverUrl,
+      resourceUrl: state.resourceUrl || canonicalizeResourceUrl(serverUrl),
+      negativeTestMode: state.negativeTestMode || negativeTestMode,
+      userId: state.userId || userId,
+      email: state.email || email,
+      clientId: state.clientId || clientId,
+      scope: state.scope || scope,
+      authzServerIssuer: state.authzServerIssuer || authzServerIssuer,
+    }),
+    updateState: (updates) => {
+      machine.state = { ...machine.state, ...updates };
+      updateState(updates);
+    },
+    proceedToNextStep: async () => {},
+    resetFlow: () => {},
+  };
+
+  const currentState = (): XAAFlowState => getState?.() ?? machine.state;
+
+  const pushInfo = (
+    step: XAAFlowState["currentStep"],
+    id: string,
+    label: string,
+    data: any,
+    options?: Parameters<typeof addInfoLog>[5],
+  ) => {
+    machine.updateState({
+      infoLogs: addInfoLog(currentState(), step, id, label, data, options),
+    });
+  };
+
+  const runRequest = async (
+    step: XAAFlowState["currentStep"],
+    request: {
+      method: string;
+      url: string;
+      headers: Record<string, string>;
+      body?: any;
+    },
+    executor: () => Promise<XAARequestResult>,
+  ): Promise<XAARequestResult> => {
+    machine.updateState({
+      currentStep: step,
+      isBusy: true,
+      error: undefined,
+      lastRequest: request,
+      lastResponse: undefined,
+    });
+
+    const startedAt = Date.now();
+
+    try {
+      const result = await executor();
+      const response = {
+        status: result.status,
+        statusText: result.statusText,
+        headers: result.headers,
+        body: result.body,
+      };
+
+      machine.updateState({
+        isBusy: false,
+        lastResponse: response,
+        httpHistory: [
+          ...(currentState().httpHistory || []),
+          {
+            step,
+            timestamp: startedAt,
+            duration: Date.now() - startedAt,
+            request,
+            response,
+          },
+        ],
+      });
+
+      return result;
+    } catch (error) {
+      const details = toLogErrorDetails(error);
+
+      machine.updateState({
+        isBusy: false,
+        error: details.message,
+        httpHistory: [
+          ...(currentState().httpHistory || []),
+          {
+            step,
+            timestamp: startedAt,
+            duration: Date.now() - startedAt,
+            request,
+            error: details,
+          },
+        ],
+      });
+
+      pushInfo(step, `${step}-error-${startedAt}`, "Request failed", request, {
+        level: "error",
+        error: details,
+      });
+
+      throw error;
+    }
+  };
+
+  const discoverResourceMetadata = async () => {
+    const state = currentState();
+    const activeServerUrl = state.serverUrl || serverUrl;
+    const resourceMetadataUrl = buildResourceMetadataUrl(activeServerUrl);
+
+    const request = {
+      method: "GET",
+      url: resourceMetadataUrl,
+      headers: {
+        Accept: "application/json",
+      },
+    };
+
+    try {
+      const result = await runRequest(
+        "discover_resource_metadata",
+        request,
+        () => requestExecutor.externalRequest(resourceMetadataUrl, request),
+      );
+
+      if (!result.ok) {
+        throw new Error(
+          extractErrorMessage(
+            result.body,
+            `Resource metadata request failed with ${result.status}`,
+          ),
+        );
+      }
+
+      const resourceMetadata = asRecord(result.body, "Resource metadata");
+      const resolvedAuthzIssuer =
+        state.authzServerIssuer ||
+        (Array.isArray(resourceMetadata.authorization_servers)
+          ? resourceMetadata.authorization_servers[0]
+          : undefined);
+      const resolvedResource =
+        typeof resourceMetadata.resource === "string"
+          ? resourceMetadata.resource
+          : canonicalizeResourceUrl(activeServerUrl);
+
+      if (!resolvedAuthzIssuer) {
+        throw new Error(
+          "Resource metadata did not include `authorization_servers`, and no Authorization Server issuer was configured manually.",
+        );
+      }
+
+      machine.updateState({
+        currentStep: "received_resource_metadata",
+        resourceMetadataUrl,
+        resourceMetadata: resourceMetadata as XAAFlowState["resourceMetadata"],
+        resourceUrl: resolvedResource,
+        authzServerIssuer: resolvedAuthzIssuer,
+      });
+
+      pushInfo(
+        "received_resource_metadata",
+        "xaa-resource-metadata",
+        "Resource metadata",
+        {
+          resource: resolvedResource,
+          authorization_servers: resourceMetadata.authorization_servers,
+        },
+      );
+    } catch (error) {
+      if (!state.authzServerIssuer) {
+        machine.updateState({
+          currentStep: "discover_resource_metadata",
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to discover resource metadata",
+        });
+        return;
+      }
+
+      machine.updateState({
+        currentStep: "received_resource_metadata",
+        resourceMetadataUrl,
+        resourceUrl: canonicalizeResourceUrl(activeServerUrl),
+        error: undefined,
+      });
+
+      pushInfo(
+        "received_resource_metadata",
+        "xaa-resource-fallback",
+        "Resource metadata fallback",
+        {
+          message:
+            error instanceof Error ? error.message : "Resource metadata lookup failed",
+          using_authz_server_issuer: state.authzServerIssuer,
+        },
+        {
+          level: "warning",
+        },
+      );
+    }
+  };
+
+  const discoverAuthzMetadata = async () => {
+    const state = currentState();
+    const issuer = state.authzServerIssuer;
+
+    if (!issuer) {
+      machine.updateState({
+        currentStep: "discover_authz_metadata",
+        error:
+          "Authorization Server issuer is missing. Configure it manually or retry resource metadata discovery.",
+      });
+      return;
+    }
+
+    const urls = buildAuthServerMetadataUrls(issuer);
+    let lastError = "Authorization server metadata discovery failed.";
+
+    for (const url of urls) {
+      const request = {
+        method: "GET",
+        url,
+        headers: mergeHeadersForAuthServer(undefined, {
+          Accept: "application/json",
+        }),
+      };
+
+      try {
+        const result = await runRequest(
+          "discover_authz_metadata",
+          request,
+          () => requestExecutor.externalRequest(url, request),
+        );
+
+        if (!result.ok) {
+          lastError = extractErrorMessage(
+            result.body,
+            `Auth server metadata request failed with ${result.status}`,
+          );
+          continue;
+        }
+
+        const metadata = asRecord(result.body, "Authorization metadata");
+        if (typeof metadata.token_endpoint !== "string") {
+          throw new Error(
+            "Authorization metadata did not include a token_endpoint.",
+          );
+        }
+
+        const resolvedIssuer =
+          typeof metadata.issuer === "string" ? metadata.issuer : issuer;
+
+        machine.updateState({
+          currentStep: "received_authz_metadata",
+          authzMetadata: metadata as XAAFlowState["authzMetadata"],
+          authzServerIssuer: resolvedIssuer,
+          tokenEndpoint: metadata.token_endpoint,
+          error: undefined,
+        });
+
+        pushInfo(
+          "received_authz_metadata",
+          "xaa-authz-metadata",
+          "Authorization metadata",
+          {
+            issuer: resolvedIssuer,
+            token_endpoint: metadata.token_endpoint,
+            grant_types_supported: metadata.grant_types_supported,
+          },
+        );
+
+        return;
+      } catch (error) {
+        lastError =
+          error instanceof Error ? error.message : "Metadata request failed";
+      }
+    }
+
+    machine.updateState({
+      currentStep: "discover_authz_metadata",
+      error: lastError,
+    });
+  };
+
+  const authenticateUser = async () => {
+    const state = currentState();
+    const request = {
+      method: "POST",
+      url: "/authenticate",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: {
+        userId: state.userId,
+        email: state.email,
+        audience: state.clientId || "mcpjam-xaa-debugger",
+      },
+    };
+
+    try {
+      const result = await runRequest("user_authentication", request, () =>
+        requestExecutor.internalRequest("/authenticate", {
+          method: "POST",
+          headers: request.headers,
+          body: JSON.stringify(request.body),
+        }),
+      );
+
+      if (!result.ok) {
+        throw new Error(
+          extractErrorMessage(
+            result.body,
+            `Mock authentication failed with ${result.status}`,
+          ),
+        );
+      }
+
+      const body = asRecord(result.body, "Authentication response");
+      if (typeof body.id_token !== "string") {
+        throw new Error("Authentication response did not include an `id_token`.");
+      }
+
+      machine.updateState({
+        currentStep: "received_identity_assertion",
+        identityAssertion: body.id_token,
+        error: undefined,
+      });
+
+      pushInfo(
+        "received_identity_assertion",
+        "xaa-identity-assertion",
+        "Identity assertion issued",
+        {
+          userId: state.userId,
+          email: state.email,
+        },
+      );
+    } catch (error) {
+      machine.updateState({
+        currentStep: "user_authentication",
+        error:
+          error instanceof Error
+            ? error.message
+            : "Mock authentication failed",
+      });
+    }
+  };
+
+  const exchangeIdTokenForIdJag = async () => {
+    const state = currentState();
+
+    if (!state.identityAssertion) {
+      machine.updateState({
+        currentStep: "token_exchange_request",
+        error: "No identity assertion is available. Complete mock authentication first.",
+      });
+      return;
+    }
+
+    if (!state.authzServerIssuer) {
+      machine.updateState({
+        currentStep: "token_exchange_request",
+        error: "No authorization server issuer is available for the ID-JAG audience.",
+      });
+      return;
+    }
+
+    if (!state.clientId) {
+      machine.updateState({
+        currentStep: "token_exchange_request",
+        error: "Client ID is required for the ID-JAG `client_id` claim.",
+      });
+      return;
+    }
+
+    const request = {
+      method: "POST",
+      url: "/token-exchange",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: {
+        identityAssertion: state.identityAssertion,
+        audience: state.authzServerIssuer,
+        resource: state.resourceUrl || state.serverUrl,
+        clientId: state.clientId,
+        scope: state.scope,
+        negativeTestMode: state.negativeTestMode,
+      },
+    };
+
+    try {
+      const result = await runRequest("token_exchange_request", request, () =>
+        requestExecutor.internalRequest("/token-exchange", {
+          method: "POST",
+          headers: request.headers,
+          body: JSON.stringify(request.body),
+        }),
+      );
+
+      if (!result.ok) {
+        throw new Error(
+          extractErrorMessage(
+            result.body,
+            `Token exchange failed with ${result.status}`,
+          ),
+        );
+      }
+
+      const body = asRecord(result.body, "Token exchange response");
+      if (typeof body.id_jag !== "string") {
+        throw new Error("Token exchange response did not include an `id_jag`.");
+      }
+
+      machine.updateState({
+        currentStep: "received_id_jag",
+        idJag: body.id_jag,
+        idJagDecoded: null,
+        error: undefined,
+      });
+
+      pushInfo(
+        "received_id_jag",
+        "xaa-id-jag",
+        "ID-JAG issued",
+        {
+          negativeTestMode: state.negativeTestMode,
+          expectedFailure:
+            NEGATIVE_TEST_MODE_DETAILS[state.negativeTestMode].expectedFailure,
+        },
+      );
+    } catch (error) {
+      machine.updateState({
+        currentStep: "token_exchange_request",
+        error:
+          error instanceof Error ? error.message : "Token exchange failed",
+      });
+    }
+  };
+
+  const inspectIdJag = () => {
+    const state = currentState();
+    if (!state.idJag || !state.authzServerIssuer || !state.clientId) {
+      machine.updateState({
+        currentStep: "inspect_id_jag",
+        error:
+          "A complete ID-JAG, authorization server issuer, and client ID are required before inspection.",
+      });
+      return;
+    }
+
+    const inspection = buildIdJagInspection(state.idJag, {
+      issuer: issuerBaseUrl,
+      audience: state.authzServerIssuer,
+      resource: state.resourceUrl || state.serverUrl || serverUrl,
+      clientId: state.clientId,
+      scope: state.scope,
+      negativeTestMode: state.negativeTestMode,
+    });
+
+    machine.updateState({
+      currentStep: "inspect_id_jag",
+      idJagDecoded: inspection,
+      error: undefined,
+    });
+
+    pushInfo("inspect_id_jag", "xaa-id-jag-inspection", "ID-JAG inspection", {
+      issues: inspection.issues,
+      mode: state.negativeTestMode,
+    });
+  };
+
+  const requestAccessToken = async () => {
+    const state = currentState();
+
+    if (!state.idJag || !state.tokenEndpoint) {
+      machine.updateState({
+        currentStep: "jwt_bearer_request",
+        error:
+          "The flow is missing an ID-JAG or token endpoint. Finish discovery and token exchange first.",
+      });
+      return;
+    }
+
+    const request = {
+      method: "POST",
+      url: "/proxy/token",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: {
+        tokenEndpoint: state.tokenEndpoint,
+        assertion: state.idJag,
+        clientId: state.clientId,
+        scope: state.scope,
+        resource: state.resourceUrl || state.serverUrl,
+      },
+    };
+
+    try {
+      const result = await runRequest("jwt_bearer_request", request, () =>
+        requestExecutor.internalRequest("/proxy/token", {
+          method: "POST",
+          headers: request.headers,
+          body: JSON.stringify(request.body),
+        }),
+      );
+
+      if (!result.ok) {
+        throw new Error(
+          extractErrorMessage(
+            result.body,
+            `JWT bearer proxy failed with ${result.status}`,
+          ),
+        );
+      }
+
+      const proxyBody = asRecord(result.body, "JWT bearer response");
+      const upstreamStatus =
+        typeof proxyBody.status === "number" ? proxyBody.status : undefined;
+      const upstreamPayload = proxyBody.body;
+
+      if (!upstreamStatus || upstreamStatus < 200 || upstreamStatus >= 300) {
+        const detail = extractErrorMessage(
+          upstreamPayload,
+          `Authorization server returned ${proxyBody.status ?? "an unknown status"}.`,
+        );
+        machine.updateState({
+          currentStep: "jwt_bearer_request",
+          error: `${detail} Does the authorization server trust the synthetic issuer JWKS and support \`urn:ietf:params:oauth:grant-type:jwt-bearer\`?`,
+        });
+        pushInfo(
+          "jwt_bearer_request",
+          "xaa-jwt-bearer-failure",
+          "JWT bearer request failed",
+          {
+            status: proxyBody.status,
+            body: upstreamPayload,
+          },
+          { level: "error" },
+        );
+        return;
+      }
+
+      const tokenResponse = asRecord(upstreamPayload, "JWT bearer token response");
+      if (typeof tokenResponse.access_token !== "string") {
+        throw new Error(
+          "Authorization server response did not include an `access_token`.",
+        );
+      }
+
+      machine.updateState({
+        currentStep: "received_access_token",
+        accessToken: tokenResponse.access_token,
+        tokenType:
+          typeof tokenResponse.token_type === "string"
+            ? tokenResponse.token_type
+            : "Bearer",
+        expiresIn:
+          typeof tokenResponse.expires_in === "number"
+            ? tokenResponse.expires_in
+            : undefined,
+        error: undefined,
+      });
+
+      pushInfo(
+        "received_access_token",
+        "xaa-access-token",
+        "Access token issued",
+        {
+          token_type: tokenResponse.token_type,
+          expires_in: tokenResponse.expires_in,
+        },
+      );
+    } catch (error) {
+      machine.updateState({
+        currentStep: "jwt_bearer_request",
+        error:
+          error instanceof Error ? error.message : "JWT bearer request failed",
+      });
+    }
+  };
+
+  const callAuthenticatedMcp = async () => {
+    const state = currentState();
+
+    if (!state.accessToken || !state.serverUrl) {
+      machine.updateState({
+        currentStep: "authenticated_mcp_request",
+        error:
+          "An access token and MCP server URL are required before the final authenticated request.",
+      });
+      return;
+    }
+
+    const body = {
+      jsonrpc: "2.0",
+      id: "mcpjam-xaa-debugger",
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-11-25",
+        capabilities: {},
+        clientInfo: {
+          name: "MCPJam XAA Debugger",
+          version: "1.0.0",
+        },
+      },
+    };
+
+    const request = {
+      method: "POST",
+      url: state.serverUrl,
+      headers: {
+        Accept: "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${state.accessToken}`,
+      },
+      body,
+    };
+
+    try {
+      const result = await runRequest(
+        "authenticated_mcp_request",
+        request,
+        () =>
+          requestExecutor.externalRequest(state.serverUrl!, {
+            method: "POST",
+            headers: request.headers,
+            body: JSON.stringify(body),
+          }),
+      );
+
+      if (!result.ok) {
+        machine.updateState({
+          currentStep: "authenticated_mcp_request",
+          error: extractErrorMessage(
+            result.body,
+            `Authenticated MCP request failed with ${result.status}`,
+          ),
+        });
+        return;
+      }
+
+      machine.updateState({
+        currentStep: "complete",
+        error: undefined,
+      });
+
+      pushInfo(
+        "complete",
+        "xaa-authenticated-mcp",
+        "Authenticated MCP response",
+        {
+          status: result.status,
+          body: result.body,
+        },
+      );
+    } catch (error) {
+      machine.updateState({
+        currentStep: "authenticated_mcp_request",
+        error:
+          error instanceof Error
+            ? error.message
+            : "Authenticated MCP request failed",
+      });
+    }
+  };
+
+  machine.proceedToNextStep = async () => {
+    const step = currentState().currentStep;
+
+    switch (step) {
+      case "idle":
+      case "discover_resource_metadata":
+        await discoverResourceMetadata();
+        return;
+      case "received_resource_metadata":
+      case "discover_authz_metadata":
+        await discoverAuthzMetadata();
+        return;
+      case "received_authz_metadata":
+      case "user_authentication":
+        await authenticateUser();
+        return;
+      case "received_identity_assertion":
+      case "token_exchange_request":
+        await exchangeIdTokenForIdJag();
+        return;
+      case "received_id_jag":
+      case "inspect_id_jag":
+        if (step === "received_id_jag") {
+          inspectIdJag();
+          return;
+        }
+        await requestAccessToken();
+        return;
+      case "jwt_bearer_request":
+        await requestAccessToken();
+        return;
+      case "received_access_token":
+      case "authenticated_mcp_request":
+        await callAuthenticatedMcp();
+        return;
+      case "complete":
+        return;
+      default: {
+        const exhaustive: never = step;
+        throw new Error(`Unhandled XAA flow step: ${exhaustive}`);
+      }
+    }
+  };
+
+  machine.resetFlow = () => {
+    machine.updateState(
+      createInitialXAAFlowState({
+        serverUrl: currentState().serverUrl || serverUrl,
+        resourceUrl: canonicalizeResourceUrl(currentState().serverUrl || serverUrl),
+        negativeTestMode:
+          currentState().negativeTestMode || negativeTestMode,
+        userId: currentState().userId || userId,
+        email: currentState().email || email,
+        clientId: currentState().clientId || clientId,
+        scope: currentState().scope || scope,
+        authzServerIssuer:
+          currentState().authzServerIssuer || authzServerIssuer,
+      }),
+    );
+  };
+
+  return machine;
+}

--- a/mcpjam-inspector/client/src/lib/xaa/step-metadata.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/step-metadata.ts
@@ -1,0 +1,139 @@
+import type { XAAFlowStep } from "./types";
+
+export interface XAAStepInfo {
+  title: string;
+  summary: string;
+  teachableMoments?: string[];
+}
+
+export const XAA_STEP_ORDER: XAAFlowStep[] = [
+  "idle",
+  "discover_resource_metadata",
+  "received_resource_metadata",
+  "discover_authz_metadata",
+  "received_authz_metadata",
+  "user_authentication",
+  "received_identity_assertion",
+  "token_exchange_request",
+  "received_id_jag",
+  "inspect_id_jag",
+  "jwt_bearer_request",
+  "received_access_token",
+  "authenticated_mcp_request",
+  "complete",
+];
+
+export const XAA_STEP_METADATA: Record<XAAFlowStep, XAAStepInfo> = {
+  idle: {
+    title: "Idle",
+    summary: "The debugger is ready to walk through the XAA enterprise authorization flow.",
+    teachableMoments: [
+      "You need three aligned values before stage 3 works: trusted issuer, audience, and resource.",
+    ],
+  },
+  discover_resource_metadata: {
+    title: "Discover Resource Metadata",
+    summary: "Fetch RFC 9728 protected resource metadata from the target MCP server.",
+    teachableMoments: [
+      "This tells the client which authorization server should mint access tokens for the MCP server.",
+    ],
+  },
+  received_resource_metadata: {
+    title: "Resource Metadata Received",
+    summary: "Capture the MCP server resource identifier and linked authorization server issuer.",
+    teachableMoments: [
+      "The `resource` claim in the ID-JAG should line up with this metadata.",
+    ],
+  },
+  discover_authz_metadata: {
+    title: "Discover Authorization Metadata",
+    summary: "Fetch RFC 8414 or OIDC discovery metadata from the authorization server.",
+    teachableMoments: [
+      "The ID-JAG `aud` claim should match the authorization server issuer, not the token endpoint URL.",
+    ],
+  },
+  received_authz_metadata: {
+    title: "Authorization Metadata Received",
+    summary: "Inspect the issuer and token endpoint that will receive the JWT bearer assertion.",
+    teachableMoments: [
+      "If discovery fails, the authorization server issuer or well-known metadata is usually misconfigured.",
+    ],
+  },
+  user_authentication: {
+    title: "Mock User Authentication",
+    summary: "MCPJam issues a synthetic OIDC ID token for the simulated enterprise user.",
+    teachableMoments: [
+      "This is stage 1 of the XAA flow: a user identity assertion from the enterprise IdP.",
+    ],
+  },
+  received_identity_assertion: {
+    title: "Identity Assertion Ready",
+    summary: "The debugger stores the synthetic ID token that will be exchanged for an ID-JAG.",
+    teachableMoments: [
+      "The ID token is an input to token exchange; it is not sent directly to the target authorization server.",
+    ],
+  },
+  token_exchange_request: {
+    title: "RFC 8693 Token Exchange",
+    summary: "Exchange the synthetic ID token for an ID-JAG, optionally injecting a negative test mode.",
+    teachableMoments: [
+      "This is where broken assertions get created for audience, issuer, header, and claim validation tests.",
+    ],
+  },
+  received_id_jag: {
+    title: "ID-JAG Issued",
+    summary: "The synthetic issuer returns a signed ID-JAG JWT.",
+    teachableMoments: [
+      "A valid ID-JAG includes `iss`, `sub`, `aud`, `resource`, `client_id`, `jti`, `iat`, and `exp`.",
+    ],
+  },
+  inspect_id_jag: {
+    title: "Inspect ID-JAG",
+    summary: "Decode the header and payload locally before sending the assertion downstream.",
+    teachableMoments: [
+      "Use this step to confirm which field a negative test mode is intentionally breaking.",
+    ],
+  },
+  jwt_bearer_request: {
+    title: "RFC 7523 JWT Bearer Request",
+    summary: "Submit the ID-JAG to the target authorization server token endpoint through the debugger proxy.",
+    teachableMoments: [
+      "If this fails, check whether the server trusts the synthetic issuer JWKS and supports the JWT bearer grant.",
+    ],
+  },
+  received_access_token: {
+    title: "Access Token Received",
+    summary: "Store the access token returned by the authorization server.",
+    teachableMoments: [
+      "A successful response here proves the authorization server accepted the ID-JAG and policy checks passed.",
+    ],
+  },
+  authenticated_mcp_request: {
+    title: "Authenticated MCP Request",
+    summary: "Retry an MCP initialize request with the issued access token.",
+    teachableMoments: [
+      "This closes the loop: the access token has to work on the real MCP server, not just the token endpoint.",
+    ],
+  },
+  complete: {
+    title: "Flow Complete",
+    summary: "The debugger completed the synthetic XAA flow end-to-end.",
+    teachableMoments: [
+      "Switch negative test modes to probe specific authorization server validation paths.",
+    ],
+  },
+};
+
+export function getXAAStepInfo(step: XAAFlowStep): XAAStepInfo {
+  return (
+    XAA_STEP_METADATA[step] ?? {
+      title: step,
+      summary: "No additional information available for this step.",
+    }
+  );
+}
+
+export function getXAAStepIndex(step: XAAFlowStep): number {
+  const index = XAA_STEP_ORDER.indexOf(step);
+  return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+}

--- a/mcpjam-inspector/client/src/lib/xaa/types.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/types.ts
@@ -1,7 +1,4 @@
-import type {
-  HttpHistoryEntry,
-  InfoLogEntry,
-} from "@/lib/oauth/state-machines/types";
+import type { InfoLogLevel, LogErrorDetails } from "@mcpjam/sdk/browser";
 import {
   DEFAULT_NEGATIVE_TEST_MODE,
   type NegativeTestMode,
@@ -36,6 +33,35 @@ export interface XAADecodedJwt {
   payload: Record<string, unknown> | null;
   signature: string;
   issues: XAAJWTInspectionIssue[];
+}
+
+export interface XAAInfoLogEntry {
+  id: string;
+  step: XAAFlowStep;
+  label: string;
+  data: any;
+  timestamp: number;
+  level: InfoLogLevel;
+  error?: LogErrorDetails;
+}
+
+export interface XAAHttpHistoryEntry {
+  step: XAAFlowStep;
+  timestamp: number;
+  duration?: number;
+  request: {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    body?: any;
+  };
+  response?: {
+    status: number;
+    statusText: string;
+    headers: Record<string, string>;
+    body: any;
+  };
+  error?: LogErrorDetails;
 }
 
 export interface XAAFlowState {
@@ -83,8 +109,8 @@ export interface XAAFlowState {
     headers: Record<string, string>;
     body: any;
   };
-  httpHistory?: Array<HttpHistoryEntry>;
-  infoLogs?: Array<InfoLogEntry>;
+  httpHistory?: Array<XAAHttpHistoryEntry>;
+  infoLogs?: Array<XAAInfoLogEntry>;
   error?: string;
 }
 

--- a/mcpjam-inspector/client/src/lib/xaa/types.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/types.ts
@@ -1,0 +1,172 @@
+import type {
+  HttpHistoryEntry,
+  InfoLogEntry,
+} from "@/lib/oauth/state-machines/types";
+import {
+  DEFAULT_NEGATIVE_TEST_MODE,
+  type NegativeTestMode,
+} from "@/shared/xaa.js";
+
+export type XAAFlowStep =
+  | "idle"
+  | "discover_resource_metadata"
+  | "received_resource_metadata"
+  | "discover_authz_metadata"
+  | "received_authz_metadata"
+  | "user_authentication"
+  | "received_identity_assertion"
+  | "token_exchange_request"
+  | "received_id_jag"
+  | "inspect_id_jag"
+  | "jwt_bearer_request"
+  | "received_access_token"
+  | "authenticated_mcp_request"
+  | "complete";
+
+export interface XAAJWTInspectionIssue {
+  section: "header" | "payload" | "signature";
+  field: string;
+  label: string;
+  expected: string;
+  actual: string;
+}
+
+export interface XAADecodedJwt {
+  header: Record<string, unknown> | null;
+  payload: Record<string, unknown> | null;
+  signature: string;
+  issues: XAAJWTInspectionIssue[];
+}
+
+export interface XAAFlowState {
+  isBusy: boolean;
+  currentStep: XAAFlowStep;
+  serverUrl?: string;
+  resourceUrl?: string;
+  resourceMetadataUrl?: string;
+  resourceMetadata?: {
+    resource?: string;
+    authorization_servers?: string[];
+    bearer_methods_supported?: string[];
+    scopes_supported?: string[];
+  };
+  authzServerIssuer?: string;
+  authzMetadata?: {
+    issuer: string;
+    token_endpoint: string;
+    grant_types_supported?: string[];
+    response_types_supported?: string[];
+    scopes_supported?: string[];
+    token_endpoint_auth_methods_supported?: string[];
+  };
+  tokenEndpoint?: string;
+  negativeTestMode: NegativeTestMode;
+  userId?: string;
+  email?: string;
+  clientId?: string;
+  scope?: string;
+  identityAssertion?: string;
+  idJag?: string;
+  idJagDecoded?: XAADecodedJwt | null;
+  accessToken?: string;
+  tokenType?: string;
+  expiresIn?: number;
+  lastRequest?: {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    body?: any;
+  };
+  lastResponse?: {
+    status: number;
+    statusText: string;
+    headers: Record<string, string>;
+    body: any;
+  };
+  httpHistory?: Array<HttpHistoryEntry>;
+  infoLogs?: Array<InfoLogEntry>;
+  error?: string;
+}
+
+export interface XAARequestResult {
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: any;
+  ok: boolean;
+}
+
+export interface XAARequestExecutor {
+  internalRequest: (
+    path: string,
+    init?: RequestInit,
+  ) => Promise<XAARequestResult>;
+  externalRequest: (
+    url: string,
+    init?: RequestInit,
+  ) => Promise<XAARequestResult>;
+}
+
+export interface BaseXAAStateMachineConfig {
+  state: XAAFlowState;
+  getState?: () => XAAFlowState;
+  updateState: (updates: Partial<XAAFlowState>) => void;
+  serverUrl: string;
+  issuerBaseUrl: string;
+  requestExecutor: XAARequestExecutor;
+  scheduleAutoAdvance?: (next: () => void) => void;
+  negativeTestMode?: NegativeTestMode;
+  userId?: string;
+  email?: string;
+  clientId?: string;
+  scope?: string;
+  authzServerIssuer?: string;
+}
+
+export interface XAAStateMachine {
+  state: XAAFlowState;
+  updateState: (updates: Partial<XAAFlowState>) => void;
+  proceedToNextStep: () => Promise<void>;
+  resetFlow: () => void;
+}
+
+export const EMPTY_XAA_FLOW_STATE: XAAFlowState = {
+  isBusy: false,
+  currentStep: "idle",
+  serverUrl: undefined,
+  resourceUrl: undefined,
+  resourceMetadataUrl: undefined,
+  resourceMetadata: undefined,
+  authzServerIssuer: undefined,
+  authzMetadata: undefined,
+  tokenEndpoint: undefined,
+  negativeTestMode: DEFAULT_NEGATIVE_TEST_MODE,
+  userId: undefined,
+  email: undefined,
+  clientId: undefined,
+  scope: undefined,
+  identityAssertion: undefined,
+  idJag: undefined,
+  idJagDecoded: undefined,
+  accessToken: undefined,
+  tokenType: undefined,
+  expiresIn: undefined,
+  lastRequest: undefined,
+  lastResponse: undefined,
+  httpHistory: [],
+  infoLogs: [],
+  error: undefined,
+};
+
+export function createInitialXAAFlowState(
+  overrides: Partial<XAAFlowState> = {},
+): XAAFlowState {
+  return {
+    ...EMPTY_XAA_FLOW_STATE,
+    ...overrides,
+    negativeTestMode:
+      overrides.negativeTestMode ?? DEFAULT_NEGATIVE_TEST_MODE,
+    httpHistory: overrides.httpHistory ?? [],
+    infoLogs: overrides.infoLogs ?? [],
+  };
+}

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -37,6 +37,7 @@ import { loadInspectorEnv, warnOnConvexDevMisconfiguration } from "./env.js";
 import { startGuestAuthProvisioningInBackground } from "./utils/convex-guest-auth-sync.js";
 import { fetchRemoteGuestJwks } from "./utils/guest-session-source.js";
 import { INSPECTOR_MCP_RETRY_POLICY } from "./utils/mcp-retry-policy.js";
+import { initXAAIdpKeyPair } from "./services/xaa-idp-keypair.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -54,6 +55,7 @@ export function createHonoApp() {
 
   // Generate session token for API authentication
   generateSessionToken();
+  initXAAIdpKeyPair();
 
   startGuestAuthProvisioningInBackground();
 

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -97,6 +97,7 @@ import {
   ALLOWED_HOSTS,
 } from "./config";
 import "./types/hono"; // Type extensions
+import { initXAAIdpKeyPair } from "./services/xaa-idp-keypair";
 
 // Utility function to extract MCP server config from environment variables
 function getMCPConfigFromEnv() {
@@ -187,6 +188,7 @@ warnOnConvexDevMisconfiguration(loadedEnv);
 
 // Generate session token for API authentication
 generateSessionToken();
+initXAAIdpKeyPair();
 
 startGuestAuthProvisioningInBackground();
 const app = new Hono().onError((err, c) => {

--- a/mcpjam-inspector/server/middleware/session-auth.ts
+++ b/mcpjam-inspector/server/middleware/session-auth.ts
@@ -43,6 +43,7 @@ const UNPROTECTED_PREFIXES = [
   "/api/apps/chatgpt-apps/", // ChatGPT widgets - loaded in sandboxed iframes, can't send headers
   "/api/mcp/adapter-http/", // HTTP adapter for tunneled MCP clients - auth via URL secrecy
   "/api/mcp/manager-http/", // HTTP manager for tunneled MCP clients - auth via URL secrecy
+  "/api/mcp/xaa/.well-known/", // Public XAA issuer discovery + JWKS for external authorization servers
 ];
 
 /**

--- a/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/xaa.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { mkdtempSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import { securityHeadersMiddleware } from "../../../middleware/security-headers.js";
+import { originValidationMiddleware } from "../../../middleware/origin-validation.js";
+import { sessionAuthMiddleware } from "../../../middleware/session-auth.js";
+import {
+  generateSessionToken,
+  getSessionToken,
+} from "../../../services/session-token.js";
+import {
+  initXAAIdpKeyPair,
+  resetXAAIdpKeyPairForTests,
+} from "../../../services/xaa-idp-keypair.js";
+import xaa from "../xaa.js";
+
+function decodeJwtPayload(token: string): Record<string, any> {
+  const [, payload] = token.split(".");
+  return JSON.parse(Buffer.from(payload, "base64url").toString("utf-8"));
+}
+
+describe("mcp xaa routes", () => {
+  const originalKeyDir = process.env.XAA_IDP_KEY_DIR;
+  let tempDir: string;
+  let app: Hono;
+  let token: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "xaa-route-"));
+    process.env.XAA_IDP_KEY_DIR = tempDir;
+    resetXAAIdpKeyPairForTests();
+    initXAAIdpKeyPair();
+    token = generateSessionToken();
+
+    app = new Hono();
+    app.use("*", securityHeadersMiddleware);
+    app.use("*", originValidationMiddleware);
+    app.use("*", sessionAuthMiddleware);
+    app.route("/api/mcp/xaa", xaa);
+  });
+
+  afterEach(() => {
+    resetXAAIdpKeyPairForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalKeyDir === undefined) {
+      delete process.env.XAA_IDP_KEY_DIR;
+    } else {
+      process.env.XAA_IDP_KEY_DIR = originalKeyDir;
+    }
+  });
+
+  it("serves JWKS publicly without a session token", async () => {
+    const response = await app.request("/api/mcp/xaa/.well-known/jwks.json");
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.keys).toHaveLength(1);
+    expect(body.keys[0].kid).toBe("xaa-idp-1");
+  });
+
+  it("serves the discovery document publicly without a session token", async () => {
+    const response = await app.request(
+      "http://localhost/api/mcp/xaa/.well-known/openid-configuration",
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.issuer).toBe("http://localhost/api/mcp/xaa");
+    expect(body.jwks_uri).toBe(
+      "http://localhost/api/mcp/xaa/.well-known/jwks.json",
+    );
+  });
+
+  it("requires a session token for protected endpoints", async () => {
+    const response = await app.request("/api/mcp/xaa/authenticate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userId: "user-12345" }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it("authenticates and exchanges an ID token for a broken ID-JAG", async () => {
+    const headers = {
+      "Content-Type": "application/json",
+      "X-MCP-Session-Auth": `Bearer ${getSessionToken() || token}`,
+    };
+
+    const authenticateResponse = await app.request("/api/mcp/xaa/authenticate", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        userId: "user-12345",
+        email: "demo.user@example.com",
+      }),
+    });
+
+    expect(authenticateResponse.status).toBe(200);
+    const authenticateBody = await authenticateResponse.json();
+    expect(authenticateBody.id_token).toEqual(expect.any(String));
+
+    const tokenExchangeResponse = await app.request("/api/mcp/xaa/token-exchange", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        identityAssertion: authenticateBody.id_token,
+        audience: "https://auth.example.com",
+        resource: "https://mcp.example.com",
+        clientId: "mcpjam-debugger",
+        negativeTestMode: "wrong_audience",
+      }),
+    });
+
+    expect(tokenExchangeResponse.status).toBe(200);
+    const tokenExchangeBody = await tokenExchangeResponse.json();
+    const payload = decodeJwtPayload(tokenExchangeBody.id_jag);
+    expect(payload.aud).toBe("https://wrong-audience.example.com");
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/index.ts
+++ b/mcpjam-inspector/server/routes/mcp/index.ts
@@ -18,6 +18,7 @@ import tunnelsRoute from "./tunnels";
 import logLevel from "./log-level";
 import tasks from "./tasks";
 import skills from "./skills";
+import xaa from "./xaa";
 
 const mcp = new Hono();
 
@@ -62,6 +63,9 @@ mcp.route("/prompts", prompts);
 
 // OAuth proxy endpoints
 mcp.route("/oauth", oauth);
+
+// XAA synthetic issuer + debugger endpoints
+mcp.route("/xaa", xaa);
 
 // Export endpoints - REAL IMPLEMENTATION
 mcp.route("/export", exporter);

--- a/mcpjam-inspector/server/routes/mcp/xaa.ts
+++ b/mcpjam-inspector/server/routes/mcp/xaa.ts
@@ -1,0 +1,302 @@
+import { Hono } from "hono";
+import type { MiddlewareHandler } from "hono";
+import { z } from "zod";
+import {
+  DEFAULT_NEGATIVE_TEST_MODE,
+  isNegativeTestMode,
+  type NegativeTestMode,
+} from "../../../shared/xaa.js";
+import {
+  getXAAIdpJwks,
+  getXAAIssuerUrl,
+  initXAAIdpKeyPair,
+} from "../../services/xaa-idp-keypair.js";
+import {
+  issueIdJag,
+  issueMockIdToken,
+  issueNegativeIdJag,
+} from "../../services/xaa-idjag-signer.js";
+import {
+  executeOAuthProxy,
+  OAuthProxyError,
+} from "../../utils/oauth-proxy.js";
+import { logger } from "../../utils/logger.js";
+
+const authenticateSchema = z.object({
+  userId: z.string().trim().min(1).optional(),
+  email: z.string().trim().email().optional(),
+  audience: z.string().trim().min(1).optional(),
+});
+
+const tokenExchangeSchema = z.object({
+  identityAssertion: z.string().trim().min(1),
+  audience: z.string().trim().min(1),
+  resource: z.string().trim().min(1),
+  clientId: z.string().trim().min(1),
+  scope: z.string().trim().min(1).optional(),
+  negativeTestMode: z.string().trim().optional(),
+});
+
+const proxyTokenSchema = z.object({
+  tokenEndpoint: z.string().trim().min(1),
+  assertion: z.string().trim().min(1),
+  clientId: z.string().trim().min(1).optional(),
+  clientSecret: z.string().trim().min(1).optional(),
+  scope: z.string().trim().min(1).optional(),
+  resource: z.string().trim().min(1).optional(),
+  headers: z.record(z.string(), z.string()).optional(),
+});
+
+interface CreateXaaRouterOptions {
+  issuerBasePath: "/api/mcp" | "/api/web";
+  httpsOnlyProxy: boolean;
+  protectedMiddlewares?: MiddlewareHandler[];
+}
+
+type ParsedJwtPayload = {
+  sub?: string;
+  email?: string;
+};
+
+function toJsonError(
+  message: string,
+  options?: {
+    status?: number;
+    code?: string;
+    details?: Record<string, unknown>;
+  },
+) {
+  const status = options?.status ?? 500;
+  const code = options?.code ?? "INTERNAL_ERROR";
+
+  return Response.json(
+    {
+      code,
+      message,
+      error: message,
+      ...(options?.details ? { details: options.details } : {}),
+    },
+    { status },
+  );
+}
+
+function parseRequest<T>(schema: z.ZodSchema<T>, data: unknown): T {
+  const parsed = schema.safeParse(data);
+  if (!parsed.success) {
+    throw new Error(parsed.error.issues[0]?.message || "Request validation failed");
+  }
+  return parsed.data;
+}
+
+function getIssuerForRequest(requestUrl: string, issuerBasePath: string): string {
+  const origin = new URL(requestUrl).origin;
+  return getXAAIssuerUrl(`${origin}${issuerBasePath}`);
+}
+
+function decodeJwtPayloadUnsafe(token: string): ParsedJwtPayload {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new Error("Identity assertion must be a JWT");
+  }
+
+  try {
+    const payload = JSON.parse(
+      Buffer.from(parts[1], "base64url").toString("utf-8"),
+    ) as ParsedJwtPayload;
+    return payload;
+  } catch (error) {
+    throw new Error(
+      `Identity assertion payload is not valid JSON (${error instanceof Error ? error.message : String(error)})`,
+    );
+  }
+}
+
+function resolveNegativeTestMode(value?: string): NegativeTestMode {
+  if (!value) {
+    return DEFAULT_NEGATIVE_TEST_MODE;
+  }
+
+  if (!isNegativeTestMode(value)) {
+    throw new Error(`Unsupported negative test mode: ${value}`);
+  }
+
+  return value;
+}
+
+export function createXaaRouter(options: CreateXaaRouterOptions): Hono {
+  const router = new Hono();
+  const protectedMiddlewares = options.protectedMiddlewares ?? [];
+
+  if (protectedMiddlewares.length > 0) {
+    router.use("/authenticate", ...protectedMiddlewares);
+    router.use("/token-exchange", ...protectedMiddlewares);
+    router.use("/proxy/token", ...protectedMiddlewares);
+  }
+
+  router.get("/.well-known/jwks.json", (c) => {
+    initXAAIdpKeyPair();
+    return c.json(getXAAIdpJwks(), 200, {
+      "Cache-Control": "public, max-age=300",
+    });
+  });
+
+  router.get("/.well-known/openid-configuration", (c) => {
+    initXAAIdpKeyPair();
+    const issuer = getIssuerForRequest(c.req.url, options.issuerBasePath);
+
+    return c.json(
+      {
+        issuer,
+        jwks_uri: `${issuer}/.well-known/jwks.json`,
+        authorization_endpoint: `${issuer}/authenticate`,
+        token_endpoint: `${issuer}/token-exchange`,
+        response_types_supported: ["id_token"],
+        subject_types_supported: ["public"],
+        grant_types_supported: [
+          "urn:ietf:params:oauth:grant-type:token-exchange",
+        ],
+        token_endpoint_auth_methods_supported: [
+          "none",
+          "client_secret_post",
+        ],
+        id_token_signing_alg_values_supported: ["RS256"],
+      },
+      200,
+      {
+        "Cache-Control": "public, max-age=300",
+      },
+    );
+  });
+
+  router.post("/authenticate", async (c) => {
+    try {
+      const body = await c.req.json();
+      const { userId, email, audience } = parseRequest(authenticateSchema, body);
+      const issuer = getIssuerForRequest(c.req.url, options.issuerBasePath);
+      const subject = userId || "user-12345";
+      const resolvedEmail = email || "demo.user@example.com";
+      const issued = issueMockIdToken({
+        issuer,
+        subject,
+        email: resolvedEmail,
+        audience,
+      });
+
+      return c.json({
+        id_token: issued.token,
+        token_type: "Bearer",
+        expires_in: Math.max(
+          0,
+          Math.floor((issued.expiresAt - Date.now()) / 1000),
+        ),
+        user: {
+          sub: subject,
+          email: resolvedEmail,
+        },
+      });
+    } catch (error) {
+      return toJsonError(
+        error instanceof Error ? error.message : "Invalid authenticate request",
+        { status: 400, code: "VALIDATION_ERROR" },
+      );
+    }
+  });
+
+  router.post("/token-exchange", async (c) => {
+    try {
+      const body = await c.req.json();
+      const parsed = parseRequest(tokenExchangeSchema, body);
+      const negativeTestMode = resolveNegativeTestMode(parsed.negativeTestMode);
+      const issuer = getIssuerForRequest(c.req.url, options.issuerBasePath);
+      const identityPayload = decodeJwtPayloadUnsafe(parsed.identityAssertion);
+      const subject = identityPayload.sub || "user-12345";
+
+      const issued =
+        negativeTestMode === "valid"
+          ? issueIdJag({
+              issuer,
+              subject,
+              audience: parsed.audience,
+              resource: parsed.resource,
+              clientId: parsed.clientId,
+              scope: parsed.scope,
+            })
+          : issueNegativeIdJag(
+              {
+                issuer,
+                subject,
+                audience: parsed.audience,
+                resource: parsed.resource,
+                clientId: parsed.clientId,
+                scope: parsed.scope,
+              },
+              negativeTestMode,
+            );
+
+      return c.json({
+        id_jag: issued.token,
+        token_type: "N_A",
+        issued_token_type: "urn:ietf:params:oauth:token-type:jwt",
+        expires_in: Math.max(
+          0,
+          Math.floor((issued.expiresAt - Date.now()) / 1000),
+        ),
+        negative_test_mode: negativeTestMode,
+      });
+    } catch (error) {
+      return toJsonError(
+        error instanceof Error ? error.message : "Invalid token exchange request",
+        { status: 400, code: "VALIDATION_ERROR" },
+      );
+    }
+  });
+
+  router.post("/proxy/token", async (c) => {
+    try {
+      const body = await c.req.json();
+      const parsed = parseRequest(proxyTokenSchema, body);
+      const result = await executeOAuthProxy({
+        url: parsed.tokenEndpoint,
+        method: "POST",
+        body: {
+          grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+          assertion: parsed.assertion,
+          ...(parsed.clientId ? { client_id: parsed.clientId } : {}),
+          ...(parsed.clientSecret ? { client_secret: parsed.clientSecret } : {}),
+          ...(parsed.scope ? { scope: parsed.scope } : {}),
+          ...(parsed.resource ? { resource: parsed.resource } : {}),
+        },
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          ...(parsed.headers || {}),
+        },
+        httpsOnly: options.httpsOnlyProxy,
+      });
+
+      return c.json(result);
+    } catch (error) {
+      if (error instanceof OAuthProxyError) {
+        return toJsonError(error.message, {
+          status: error.status,
+          code:
+            error.status === 400 ? "VALIDATION_ERROR" : "SERVER_UNREACHABLE",
+        });
+      }
+
+      logger.error("[XAA Token Proxy] Error", error);
+      return toJsonError(
+        error instanceof Error ? error.message : "Unknown proxy error",
+        { status: 500, code: "INTERNAL_ERROR" },
+      );
+    }
+  });
+
+  return router;
+}
+
+const xaa = createXaaRouter({
+  issuerBasePath: "/api/mcp",
+  httpsOnlyProxy: false,
+});
+
+export default xaa;

--- a/mcpjam-inspector/server/routes/web/__tests__/xaa.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/xaa.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { mkdtempSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import xaaWeb from "../xaa.js";
+import {
+  initXAAIdpKeyPair,
+  resetXAAIdpKeyPairForTests,
+} from "../../../services/xaa-idp-keypair.js";
+
+function decodeJwtPayload(token: string): Record<string, any> {
+  const [, payload] = token.split(".");
+  return JSON.parse(Buffer.from(payload, "base64url").toString("utf-8"));
+}
+
+describe("web xaa routes", () => {
+  const originalKeyDir = process.env.XAA_IDP_KEY_DIR;
+  let tempDir: string;
+  let app: Hono;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "xaa-web-route-"));
+    process.env.XAA_IDP_KEY_DIR = tempDir;
+    resetXAAIdpKeyPairForTests();
+    initXAAIdpKeyPair();
+
+    app = new Hono();
+    app.route("/api/web/xaa", xaaWeb);
+  });
+
+  afterEach(() => {
+    resetXAAIdpKeyPairForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalKeyDir === undefined) {
+      delete process.env.XAA_IDP_KEY_DIR;
+    } else {
+      process.env.XAA_IDP_KEY_DIR = originalKeyDir;
+    }
+  });
+
+  it("serves public discovery endpoints without a bearer token", async () => {
+    const jwksResponse = await app.request("/api/web/xaa/.well-known/jwks.json");
+    const discoveryResponse = await app.request(
+      "https://www.mcpjam.com/api/web/xaa/.well-known/openid-configuration",
+    );
+
+    expect(jwksResponse.status).toBe(200);
+    expect(discoveryResponse.status).toBe(200);
+    const discoveryBody = await discoveryResponse.json();
+    expect(discoveryBody.issuer).toBe("https://www.mcpjam.com/api/web/xaa");
+  });
+
+  it("requires a bearer token for protected endpoints", async () => {
+    const response = await app.request("/api/web/xaa/authenticate", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userId: "user-12345" }),
+    });
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body).toEqual({
+      code: "UNAUTHORIZED",
+      message: "Bearer token required",
+    });
+  });
+
+  it("allows protected endpoints with any bearer token and preserves negative modes", async () => {
+    const headers = {
+      "Content-Type": "application/json",
+      Authorization: "Bearer workos-token",
+    };
+
+    const authenticateResponse = await app.request("/api/web/xaa/authenticate", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        userId: "user-12345",
+        email: "demo.user@example.com",
+      }),
+    });
+
+    expect(authenticateResponse.status).toBe(200);
+    const authenticateBody = await authenticateResponse.json();
+
+    const tokenExchangeResponse = await app.request("/api/web/xaa/token-exchange", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        identityAssertion: authenticateBody.id_token,
+        audience: "https://auth.example.com",
+        resource: "https://mcp.example.com",
+        clientId: "mcpjam-debugger",
+        negativeTestMode: "unknown_kid",
+      }),
+    });
+
+    expect(tokenExchangeResponse.status).toBe(200);
+    const tokenExchangeBody = await tokenExchangeResponse.json();
+    const payload = decodeJwtPayload(tokenExchangeBody.id_jag);
+    expect(payload.client_id).toBe("mcpjam-debugger");
+    expect(tokenExchangeBody.negative_test_mode).toBe("unknown_kid");
+  });
+});

--- a/mcpjam-inspector/server/routes/web/index.ts
+++ b/mcpjam-inspector/server/routes/web/index.ts
@@ -11,6 +11,7 @@ import sandboxes from "./sandboxes.js";
 import apps from "./apps.js";
 import evals from "./evals.js";
 import oauthWeb from "./oauth.js";
+import xaaWeb from "./xaa.js";
 import exporter from "./export.js";
 import guestSession from "./guest-session.js";
 import chatHistory from "./chat-history.js";
@@ -48,6 +49,7 @@ web.route("/export", exporter);
 web.route("/chat-v2", chatV2);
 web.route("/apps", apps);
 web.route("/oauth", oauthWeb);
+web.route("/xaa", xaaWeb);
 web.route("/guest-session", guestSession);
 web.route("/chat-history", chatHistory);
 

--- a/mcpjam-inspector/server/routes/web/xaa.ts
+++ b/mcpjam-inspector/server/routes/web/xaa.ts
@@ -1,0 +1,11 @@
+import { bearerAuthMiddleware } from "../../middleware/bearer-auth.js";
+import { guestRateLimitMiddleware } from "../../middleware/guest-rate-limit.js";
+import { createXaaRouter } from "../mcp/xaa.js";
+
+const xaaWeb = createXaaRouter({
+  issuerBasePath: "/api/web",
+  httpsOnlyProxy: true,
+  protectedMiddlewares: [bearerAuthMiddleware, guestRateLimitMiddleware],
+});
+
+export default xaaWeb;

--- a/mcpjam-inspector/server/services/__tests__/xaa-idjag-signer.test.ts
+++ b/mcpjam-inspector/server/services/__tests__/xaa-idjag-signer.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createPublicKey, createVerify, type JsonWebKey } from "crypto";
+import { mkdtempSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import {
+  getXAAIdpJwks,
+  initXAAIdpKeyPair,
+  resetXAAIdpKeyPairForTests,
+} from "../xaa-idp-keypair.js";
+import {
+  issueIdJag,
+  issueMockIdToken,
+  issueNegativeIdJag,
+} from "../xaa-idjag-signer.js";
+import {
+  NEGATIVE_TEST_MODES,
+  XAA_IDP_KID,
+  type NegativeTestMode,
+} from "../../../shared/xaa.js";
+
+function decodeJwt(token: string): {
+  header: Record<string, any>;
+  payload: Record<string, any>;
+  signature: Buffer;
+  signingInput: string;
+} {
+  const [encodedHeader, encodedPayload, encodedSignature] = token.split(".");
+
+  return {
+    header: JSON.parse(Buffer.from(encodedHeader, "base64url").toString("utf-8")),
+    payload: JSON.parse(
+      Buffer.from(encodedPayload, "base64url").toString("utf-8"),
+    ),
+    signature: Buffer.from(encodedSignature, "base64url"),
+    signingInput: `${encodedHeader}.${encodedPayload}`,
+  };
+}
+
+function verifyWithPublishedKey(token: string): boolean {
+  const jwk = getXAAIdpJwks().keys[0];
+  const publicKey = createPublicKey({
+    key: jwk as unknown as JsonWebKey,
+    format: "jwk",
+  });
+  const { signature, signingInput } = decodeJwt(token);
+  const verifier = createVerify("RSA-SHA256");
+  verifier.update(signingInput);
+  return verifier.verify(publicKey, signature);
+}
+
+describe("xaa-idjag-signer", () => {
+  const originalKeyDir = process.env.XAA_IDP_KEY_DIR;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "xaa-idp-"));
+    process.env.XAA_IDP_KEY_DIR = tempDir;
+    resetXAAIdpKeyPairForTests();
+    initXAAIdpKeyPair();
+  });
+
+  afterEach(() => {
+    resetXAAIdpKeyPairForTests();
+    rmSync(tempDir, { recursive: true, force: true });
+    if (originalKeyDir === undefined) {
+      delete process.env.XAA_IDP_KEY_DIR;
+    } else {
+      process.env.XAA_IDP_KEY_DIR = originalKeyDir;
+    }
+  });
+
+  it("issues a valid ID-JAG with the published signing key", () => {
+    const result = issueIdJag({
+      issuer: "https://issuer.example/api/web/xaa",
+      subject: "user-12345",
+      audience: "https://auth.example.com",
+      resource: "https://mcp.example.com",
+      clientId: "mcpjam-debugger",
+      scope: "read:tools",
+    });
+
+    const decoded = decodeJwt(result.token);
+
+    expect(decoded.header).toMatchObject({
+      alg: "RS256",
+      typ: "oauth-id-jag+jwt",
+      kid: XAA_IDP_KID,
+    });
+    expect(decoded.payload).toMatchObject({
+      iss: "https://issuer.example/api/web/xaa",
+      sub: "user-12345",
+      aud: "https://auth.example.com",
+      resource: "https://mcp.example.com",
+      client_id: "mcpjam-debugger",
+      scope: "read:tools",
+    });
+    expect(decoded.payload.jti).toEqual(expect.any(String));
+    expect(verifyWithPublishedKey(result.token)).toBe(true);
+  });
+
+  it("issues a mock ID token with the published signing key", () => {
+    const result = issueMockIdToken({
+      issuer: "https://issuer.example/api/web/xaa",
+      subject: "user-12345",
+      email: "demo.user@example.com",
+      audience: "mcpjam-debugger",
+    });
+
+    const decoded = decodeJwt(result.token);
+    expect(decoded.header).toMatchObject({
+      alg: "RS256",
+      typ: "JWT",
+      kid: XAA_IDP_KID,
+    });
+    expect(decoded.payload).toMatchObject({
+      iss: "https://issuer.example/api/web/xaa",
+      sub: "user-12345",
+      email: "demo.user@example.com",
+      aud: "mcpjam-debugger",
+    });
+    expect(verifyWithPublishedKey(result.token)).toBe(true);
+  });
+
+  const assertions: Record<
+    NegativeTestMode,
+    (decoded: ReturnType<typeof decodeJwt>) => void
+  > = {
+    valid: () => {},
+    bad_signature: () => {},
+    wrong_audience: (decoded) =>
+      expect(decoded.payload.aud).toBe("https://wrong-audience.example.com"),
+    expired: (decoded) =>
+      expect(decoded.payload.exp).toBeLessThan(Math.floor(Date.now() / 1000)),
+    missing_claims: (decoded) => {
+      expect(decoded.payload).not.toHaveProperty("sub");
+      expect(decoded.payload).not.toHaveProperty("resource");
+    },
+    invalid_type_header: (decoded) =>
+      expect(decoded.header.typ).toBe("JWT"),
+    wrong_issuer: (decoded) =>
+      expect(decoded.payload.iss).toBe("https://wrong-issuer.example.com"),
+    resource_mismatch: (decoded) =>
+      expect(decoded.payload.resource).toBe(
+        "https://wrong-resource.example.com",
+      ),
+    client_id_mismatch: (decoded) =>
+      expect(decoded.payload.client_id).toBe("wrong-client-id"),
+    unknown_kid: (decoded) =>
+      expect(decoded.header.kid).toBe("nonexistent-key-id"),
+    unknown_sub: (decoded) =>
+      expect(decoded.payload.sub).toBe("unknown-user-00000"),
+    scope_denial: (decoded) =>
+      expect(decoded.payload.scope).toBe("admin:superuser offline_access"),
+  };
+
+  for (const mode of NEGATIVE_TEST_MODES.filter(
+    (candidate) => candidate !== "valid",
+  )) {
+    it(`issues ${mode} ID-JAGs with the expected defect`, () => {
+      const result = issueNegativeIdJag(
+        {
+          issuer: "https://issuer.example/api/web/xaa",
+          subject: "user-12345",
+          audience: "https://auth.example.com",
+          resource: "https://mcp.example.com",
+          clientId: "mcpjam-debugger",
+          scope: "read:tools",
+        },
+        mode,
+      );
+
+      const decoded = decodeJwt(result.token);
+      assertions[mode](decoded);
+
+      if (mode === "bad_signature") {
+        expect(verifyWithPublishedKey(result.token)).toBe(false);
+      } else {
+        expect(verifyWithPublishedKey(result.token)).toBe(true);
+      }
+    });
+  }
+});

--- a/mcpjam-inspector/server/services/xaa-idjag-signer.ts
+++ b/mcpjam-inspector/server/services/xaa-idjag-signer.ts
@@ -1,0 +1,212 @@
+import {
+  createSign,
+  generateKeyPairSync,
+  randomUUID,
+  type KeyObject,
+} from "crypto";
+import {
+  getXAAIdpPrivateKey,
+  initXAAIdpKeyPair,
+} from "./xaa-idp-keypair.js";
+import {
+  DEFAULT_NEGATIVE_TEST_MODE,
+  type NegativeTestMode,
+  XAA_IDP_KID,
+} from "../../shared/xaa.js";
+
+const ID_JAG_TTL_S = 5 * 60;
+const ID_TOKEN_TTL_S = 5 * 60;
+
+type JwtHeader = Record<string, unknown>;
+type JwtPayload = Record<string, unknown>;
+
+export interface IssueIdJagParams {
+  issuer: string;
+  subject: string;
+  audience: string;
+  resource: string;
+  clientId: string;
+  scope?: string;
+}
+
+export interface IssueMockIdTokenParams {
+  issuer: string;
+  subject: string;
+  email: string;
+  audience?: string;
+}
+
+function base64url(input: string | Buffer): string {
+  const buffer = typeof input === "string" ? Buffer.from(input) : input;
+  return buffer.toString("base64url");
+}
+
+function signJwt(
+  header: JwtHeader,
+  payload: JwtPayload,
+  signingKey: KeyObject,
+): string {
+  const encodedHeader = base64url(JSON.stringify(header));
+  const encodedPayload = base64url(JSON.stringify(payload));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+  const signer = createSign("RSA-SHA256");
+  signer.update(signingInput);
+  const signature = signer.sign(signingKey, "base64url");
+
+  return `${signingInput}.${signature}`;
+}
+
+function createValidIdJagPayload(
+  params: IssueIdJagParams,
+  now: number,
+): JwtPayload {
+  return {
+    iss: params.issuer,
+    sub: params.subject,
+    aud: params.audience,
+    resource: params.resource,
+    client_id: params.clientId,
+    jti: randomUUID(),
+    iat: now,
+    exp: now + ID_JAG_TTL_S,
+    ...(params.scope ? { scope: params.scope } : {}),
+  };
+}
+
+function createValidIdJagHeader(): JwtHeader {
+  return {
+    alg: "RS256",
+    typ: "oauth-id-jag+jwt",
+    kid: XAA_IDP_KID,
+  };
+}
+
+export function issueIdJag(params: IssueIdJagParams): {
+  token: string;
+  header: JwtHeader;
+  payload: JwtPayload;
+  expiresAt: number;
+} {
+  initXAAIdpKeyPair();
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = createValidIdJagHeader();
+  const payload = createValidIdJagPayload(params, now);
+  const token = signJwt(header, payload, getXAAIdpPrivateKey());
+
+  return {
+    token,
+    header,
+    payload,
+    expiresAt: (payload.exp as number) * 1000,
+  };
+}
+
+export function issueNegativeIdJag(
+  params: IssueIdJagParams,
+  mode: NegativeTestMode = DEFAULT_NEGATIVE_TEST_MODE,
+): {
+  token: string;
+  header: JwtHeader;
+  payload: JwtPayload;
+  expiresAt: number;
+} {
+  if (mode === "valid") {
+    return issueIdJag(params);
+  }
+
+  initXAAIdpKeyPair();
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = createValidIdJagHeader();
+  const payload = createValidIdJagPayload(params, now);
+  let signingKey = getXAAIdpPrivateKey();
+
+  switch (mode) {
+    case "bad_signature": {
+      const pair = generateKeyPairSync("rsa", { modulusLength: 2048 });
+      signingKey = pair.privateKey;
+      break;
+    }
+    case "wrong_audience":
+      payload.aud = "https://wrong-audience.example.com";
+      break;
+    case "expired":
+      payload.iat = now - 2 * 60 * 60;
+      payload.exp = now - 60 * 60;
+      break;
+    case "missing_claims":
+      delete payload.sub;
+      delete payload.resource;
+      break;
+    case "invalid_type_header":
+      header.typ = "JWT";
+      break;
+    case "wrong_issuer":
+      payload.iss = "https://wrong-issuer.example.com";
+      break;
+    case "resource_mismatch":
+      payload.resource = "https://wrong-resource.example.com";
+      break;
+    case "client_id_mismatch":
+      payload.client_id = "wrong-client-id";
+      break;
+    case "unknown_kid":
+      header.kid = "nonexistent-key-id";
+      break;
+    case "unknown_sub":
+      payload.sub = "unknown-user-00000";
+      break;
+    case "scope_denial":
+      payload.scope = "admin:superuser offline_access";
+      break;
+    default: {
+      const exhaustive: never = mode;
+      throw new Error(`Unsupported XAA negative test mode: ${exhaustive}`);
+    }
+  }
+
+  const token = signJwt(header, payload, signingKey);
+
+  return {
+    token,
+    header,
+    payload,
+    expiresAt: Number(payload.exp) * 1000,
+  };
+}
+
+export function issueMockIdToken(params: IssueMockIdTokenParams): {
+  token: string;
+  header: JwtHeader;
+  payload: JwtPayload;
+  expiresAt: number;
+} {
+  initXAAIdpKeyPair();
+
+  const now = Math.floor(Date.now() / 1000);
+  const header: JwtHeader = {
+    alg: "RS256",
+    typ: "JWT",
+    kid: XAA_IDP_KID,
+  };
+  const payload: JwtPayload = {
+    iss: params.issuer,
+    sub: params.subject,
+    aud: params.audience || "mcpjam-xaa-debugger",
+    email: params.email,
+    iat: now,
+    exp: now + ID_TOKEN_TTL_S,
+    auth_time: now,
+    nonce: randomUUID(),
+  };
+  const token = signJwt(header, payload, getXAAIdpPrivateKey());
+
+  return {
+    token,
+    header,
+    payload,
+    expiresAt: (payload.exp as number) * 1000,
+  };
+}

--- a/mcpjam-inspector/server/services/xaa-idp-keypair.ts
+++ b/mcpjam-inspector/server/services/xaa-idp-keypair.ts
@@ -1,0 +1,178 @@
+import {
+  generateKeyPairSync,
+  createPrivateKey,
+  createPublicKey,
+  type KeyObject,
+} from "crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "fs";
+import os from "os";
+import path from "path";
+import { logger } from "../utils/logger.js";
+import { XAA_IDP_KID } from "../../shared/xaa.js";
+
+export type XAAIdpJwk = JsonWebKey & {
+  kid: string;
+  alg: string;
+  use: string;
+};
+
+let privateKey: KeyObject | undefined;
+let publicKey: KeyObject | undefined;
+let jwks: { keys: XAAIdpJwk[] } | undefined;
+
+function getLocalXAAKeyDir(): string {
+  return process.env.XAA_IDP_KEY_DIR || path.join(os.homedir(), ".mcpjam");
+}
+
+function getLocalXAAKeyPaths(): { privatePath: string; publicPath: string } {
+  const dir = getLocalXAAKeyDir();
+  return {
+    privatePath: path.join(dir, "xaa-idp-private.pem"),
+    publicPath: path.join(dir, "xaa-idp-public.pem"),
+  };
+}
+
+function setKeyPair(nextPrivateKey: KeyObject, nextPublicKey: KeyObject): void {
+  privateKey = nextPrivateKey;
+  publicKey = nextPublicKey;
+}
+
+function createAndPersistLocalKeyPair(): void {
+  const { privatePath, publicPath } = getLocalXAAKeyPaths();
+  const dir = path.dirname(privatePath);
+  mkdirSync(dir, { recursive: true });
+
+  const pair = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const privatePem = pair.privateKey.export({ type: "pkcs8", format: "pem" });
+  const publicPem = pair.publicKey.export({ type: "spki", format: "pem" });
+
+  writeFileSync(privatePath, privatePem);
+  writeFileSync(publicPath, publicPem);
+
+  try {
+    chmodSync(privatePath, 0o600);
+    chmodSync(publicPath, 0o644);
+  } catch {
+    // Best effort for filesystems without chmod semantics.
+  }
+
+  setKeyPair(createPrivateKey(privatePem), createPublicKey(publicPem));
+  logger.info(`XAA issuer: created signing key pair at ${dir}`);
+}
+
+function loadPersistedLocalKeyPair(): boolean {
+  const { privatePath, publicPath } = getLocalXAAKeyPaths();
+  if (!existsSync(privatePath) || !existsSync(publicPath)) {
+    return false;
+  }
+
+  try {
+    const privatePem = readFileSync(privatePath, "utf-8");
+    const publicPem = readFileSync(publicPath, "utf-8");
+    setKeyPair(createPrivateKey(privatePem), createPublicKey(publicPem));
+    logger.info(
+      `XAA issuer: using signing key pair from ${path.dirname(privatePath)}`,
+    );
+    return true;
+  } catch (error) {
+    logger.warn(
+      `XAA issuer: failed to load signing key pair, regenerating (${error instanceof Error ? error.message : String(error)})`,
+    );
+    return false;
+  }
+}
+
+function generateEphemeralKeyPair(): void {
+  const pair = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  setKeyPair(pair.privateKey, pair.publicKey);
+  logger.warn(
+    "XAA issuer: falling back to ephemeral signing keys; assertions will change after restart.",
+  );
+}
+
+function rebuildJwks(): void {
+  const exportedPublicKey = getXAAIdpPublicKeyObjectOrThrow().export({
+    format: "jwk",
+  });
+
+  jwks = {
+    keys: [
+      {
+        ...exportedPublicKey,
+        kid: XAA_IDP_KID,
+        alg: "RS256",
+        use: "sig",
+      },
+    ],
+  };
+}
+
+export function initXAAIdpKeyPair(): void {
+  if (privateKey && publicKey && jwks) {
+    return;
+  }
+
+  if (!loadPersistedLocalKeyPair()) {
+    try {
+      createAndPersistLocalKeyPair();
+    } catch (error) {
+      logger.warn(
+        `XAA issuer: failed to persist signing key pair, using ephemeral keys (${error instanceof Error ? error.message : String(error)})`,
+      );
+      generateEphemeralKeyPair();
+    }
+  }
+
+  rebuildJwks();
+}
+
+export function getXAAIssuerUrl(baseUrl: string): string {
+  const normalized = baseUrl.replace(/\/+$/, "");
+  return normalized.endsWith("/xaa") ? normalized : `${normalized}/xaa`;
+}
+
+export function getXAAIdpPrivateKey(): KeyObject {
+  if (!privateKey) {
+    throw new Error(
+      "XAA issuer keys not initialized. Call initXAAIdpKeyPair() first.",
+    );
+  }
+
+  return privateKey;
+}
+
+export function getXAAIdpPublicKeyObject(): KeyObject {
+  return getXAAIdpPublicKeyObjectOrThrow();
+}
+
+export function getXAAIdpJwks(): { keys: XAAIdpJwk[] } {
+  if (!jwks) {
+    throw new Error(
+      "XAA issuer keys not initialized. Call initXAAIdpKeyPair() first.",
+    );
+  }
+
+  return jwks;
+}
+
+function getXAAIdpPublicKeyObjectOrThrow(): KeyObject {
+  if (!publicKey) {
+    throw new Error(
+      "XAA issuer keys not initialized. Call initXAAIdpKeyPair() first.",
+    );
+  }
+
+  return publicKey;
+}
+
+export function resetXAAIdpKeyPairForTests(): void {
+  privateKey = undefined;
+  publicKey = undefined;
+  jwks = undefined;
+}

--- a/mcpjam-inspector/shared/xaa.ts
+++ b/mcpjam-inspector/shared/xaa.ts
@@ -1,0 +1,96 @@
+export const NEGATIVE_TEST_MODES = [
+  "valid",
+  "bad_signature",
+  "wrong_audience",
+  "expired",
+  "missing_claims",
+  "invalid_type_header",
+  "wrong_issuer",
+  "resource_mismatch",
+  "client_id_mismatch",
+  "unknown_kid",
+  "unknown_sub",
+  "scope_denial",
+] as const;
+
+export type NegativeTestMode = (typeof NEGATIVE_TEST_MODES)[number];
+
+export const DEFAULT_NEGATIVE_TEST_MODE: NegativeTestMode = "valid";
+export const XAA_IDP_KID = "xaa-idp-1";
+
+export const NEGATIVE_TEST_MODE_DETAILS: Record<
+  NegativeTestMode,
+  {
+    label: string;
+    description: string;
+    expectedFailure: string;
+  }
+> = {
+  valid: {
+    label: "Valid",
+    description: "Issue a well-formed ID-JAG for the happy path.",
+    expectedFailure: "No failure expected.",
+  },
+  bad_signature: {
+    label: "Bad Signature",
+    description: "Signs the JWT with a throwaway key instead of the published JWKS key.",
+    expectedFailure: "Authorization server should reject the signature.",
+  },
+  wrong_audience: {
+    label: "Wrong Audience",
+    description: "Sets `aud` to a different authorization server issuer.",
+    expectedFailure: "Authorization server should reject the audience.",
+  },
+  expired: {
+    label: "Expired",
+    description: "Backdates `exp` so the assertion is already expired.",
+    expectedFailure: "Authorization server should reject the expired assertion.",
+  },
+  missing_claims: {
+    label: "Missing Claims",
+    description: "Omits `sub` and `resource` from the ID-JAG payload.",
+    expectedFailure: "Authorization server should reject missing required claims.",
+  },
+  invalid_type_header: {
+    label: "Invalid `typ` Header",
+    description: "Uses `JWT` instead of `oauth-id-jag+jwt` in the JOSE header.",
+    expectedFailure: "Authorization server should reject the JWT type.",
+  },
+  wrong_issuer: {
+    label: "Wrong Issuer",
+    description: "Sets `iss` to an untrusted issuer value.",
+    expectedFailure: "Authorization server should reject the issuer.",
+  },
+  resource_mismatch: {
+    label: "Resource Mismatch",
+    description: "Sets `resource` to a different MCP server resource identifier.",
+    expectedFailure: "Authorization server should reject the resource claim.",
+  },
+  client_id_mismatch: {
+    label: "Client ID Mismatch",
+    description: "Sets `client_id` to a different OAuth client.",
+    expectedFailure: "Authorization server should reject the client identity.",
+  },
+  unknown_kid: {
+    label: "Unknown `kid`",
+    description: "Uses a JOSE `kid` value that does not exist in JWKS.",
+    expectedFailure: "Authorization server should fail JWKS key lookup.",
+  },
+  unknown_sub: {
+    label: "Unknown Subject",
+    description: "Sets `sub` to an unmapped user identifier.",
+    expectedFailure: "Authorization server should reject the unknown subject.",
+  },
+  scope_denial: {
+    label: "Scope Denial",
+    description: "Requests privileged scopes the mock user should not receive.",
+    expectedFailure: "Authorization server should reject the requested scopes.",
+  },
+};
+
+export function isNegativeTestMode(value: unknown): value is NegativeTestMode {
+  return (
+    typeof value === "string" &&
+    (NEGATIVE_TEST_MODES as readonly string[]).includes(value)
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Adds new auth-adjacent server endpoints (public JWKS/discovery, JWT issuance, and a token proxy) and relaxes session auth for specific XAA discovery paths, so misconfiguration could expose sensitive behavior or widen attack surface.
> 
> **Overview**
> Adds a new **feature-flagged** `XAA Debugger` flow (`#xaa-flow`) in the client, including sidebar navigation, hosted-tab policy updates, and tests to ensure the tab redirects when the `xaa` flag is off.
> 
> Introduces a new XAA debugging UI (sequence diagram + step log + config/bootstrap dialogs) plus local profile persistence and an end-to-end state machine that can issue/inspect ID-JAGs, run JWT-bearer token exchange, and replay an authenticated MCP `initialize` call.
> 
> On the server, adds `/api/mcp/xaa` and `/api/web/xaa` routes that act as a **synthetic OIDC issuer** (public discovery + JWKS) and protected endpoints for mock auth, ID-JAG token exchange (with negative test modes), and a token proxy; includes persisted RSA keypair management and extensive unit/route tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bc3de81091047b8e44d0d1cfb8af896dd8ab52a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->