### PR TITLE
Fix staging 502: add @cfworker/json-schema as direct dep

### DIFF
--- a/.changeset/fix-cfworker-json-schema.md
+++ b/.changeset/fix-cfworker-json-schema.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Add `@cfworker/json-schema` as a direct dependency. It is an optional peer dependency of `@modelcontextprotocol/client@2.0.0-alpha.2` but is required at runtime, so production installs (`npm ci --legacy-peer-deps`) were crashing on startup with `ERR_MODULE_NOT_FOUND`.

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -100,6 +100,7 @@
     "@ai-sdk/react": "^3.0.156",
     "@ai-sdk/xai": "^3.0.46",
     "@axiomhq/js": "^1.4.0",
+    "@cfworker/json-schema": "^4.1.1",
     "@convex-dev/auth": "^0.0.88",
     "@convex-dev/workos": "^0.0.1",
     "@dagrejs/dagre": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,6 +141,7 @@
         "@ai-sdk/react": "^3.0.156",
         "@ai-sdk/xai": "^3.0.46",
         "@axiomhq/js": "^1.4.0",
+        "@cfworker/json-schema": "^4.1.1",
         "@convex-dev/auth": "^0.0.88",
         "@convex-dev/workos": "^0.0.1",
         "@dagrejs/dagre": "^3.0.0",


### PR DESCRIPTION
## Summary

Staging (`staging.mcpjam.com`) has been returning 502 because the Railway container crashes on startup:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@cfworker/json-schema'
  imported from /usr/src/app/node_modules/@modelcontextprotocol/client/dist/src-RIHfgPRm.mjs
```

After the MCP SDK v2 upgrade (#1791), `@modelcontextprotocol/client@2.0.0-alpha.2` declares `@cfworker/json-schema` as an **optional peer dependency** but imports it at runtime. `npm ci --legacy-peer-deps` (what the Dockerfile uses) skips optional peers, so the module never lands in `node_modules` in the production image.

This promotes it to a direct dependency of `@mcpjam/inspector` so it's always installed.

## Test plan

- [ ] CI build passes
- [ ] Staging deploy comes up green on Railway (`mcp-inspector` service, staging env)
- [ ] `staging.mcpjam.com` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; main risk is potential version/duplication conflicts, but it’s a targeted fix for a missing runtime module.
> 
> **Overview**
> Fixes production startup failures by adding `@cfworker/json-schema` as a direct dependency of `@mcpjam/inspector`, ensuring it’s installed even when `npm ci --legacy-peer-deps` skips optional peer deps pulled in by `@modelcontextprotocol/client`.
> 
> Adds a patch changeset and updates the lockfile to reflect the new runtime dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fd50bdcff8db1913a0fd361e0e83c66f49d5ea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->