### PR TITLE
Fix staging 502 (round 2): inline SDK version in sentry.ts

### DIFF
--- a/.changeset/fix-sdk-sentry-package-json-require.md
+++ b/.changeset/fix-sdk-sentry-package-json-require.md
@@ -1,0 +1,6 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/inspector": patch
+---
+
+Inline the SDK version at build time instead of `require("../package.json")` in `sentry.ts`. The previous code used `createRequire(import.meta.url)` which broke for consumers that bundle the SDK (e.g. the inspector's server tsup config uses `noExternal: ["@mcpjam/sdk"]`) — the `require` resolved relative to the consumer's bundle, where no `package.json` lives. tsup's `define` now replaces `__MCPJAM_SDK_VERSION__` with a string literal at SDK build time, so the version survives re-bundling.

--- a/sdk/src/sentry.ts
+++ b/sdk/src/sentry.ts
@@ -1,13 +1,14 @@
 import { createHash } from "node:crypto";
-import { createRequire } from "node:module";
 import { EvalReportingError } from "./errors.js";
 
-const require = createRequire(import.meta.url);
-const packageJson = require("../package.json") as { version: string };
+// Injected at build time by tsup (see sdk/tsup.config.ts). Declared here so
+// TypeScript recognizes the identifier; esbuild replaces it with a string
+// literal, so the version survives re-bundling by SDK consumers.
+declare const __MCPJAM_SDK_VERSION__: string;
 
 const SDK_SENTRY_DSN =
   "https://490f3f2a8a287f8a9f86eea23c16c01e@o4510109778378752.ingest.us.sentry.io/4511018761125888";
-const SDK_VERSION = packageJson.version;
+const SDK_VERSION = __MCPJAM_SDK_VERSION__;
 const SDK_RELEASE = `@mcpjam/sdk@${SDK_VERSION}`;
 const API_KEY_HASH_LENGTH = 16;
 const CAPTURED_ERROR_SYMBOL = Symbol.for("@mcpjam/sdk/captured-eval-error");

--- a/sdk/tsup.config.ts
+++ b/sdk/tsup.config.ts
@@ -1,4 +1,12 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "tsup";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const { version: SDK_VERSION } = JSON.parse(
+  readFileSync(join(here, "package.json"), "utf8"),
+) as { version: string };
 
 export default defineConfig({
   entry: [
@@ -17,4 +25,7 @@ export default defineConfig({
   treeshake: true,
   minify: false,
   loader: { '.md': 'text' },
+  define: {
+    __MCPJAM_SDK_VERSION__: JSON.stringify(SDK_VERSION),
+  },
 });

--- a/sdk/vitest.config.ts
+++ b/sdk/vitest.config.ts
@@ -1,6 +1,19 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const here = dirname(fileURLToPath(import.meta.url));
+const { version: SDK_VERSION } = JSON.parse(
+  readFileSync(join(here, "package.json"), "utf8"),
+) as { version: string };
+
 export default defineConfig({
+  // Mirror the tsup `define` so __MCPJAM_SDK_VERSION__ resolves when vitest
+  // runs src/ directly (tsup's define only applies to the built output).
+  define: {
+    __MCPJAM_SDK_VERSION__: JSON.stringify(SDK_VERSION),
+  },
   test: {
     environment: "node",
     globals: true,


### PR DESCRIPTION
## Summary

Follow-up to #1833. After that fix, staging crashed with a different error:

```
Error: Cannot find module '../package.json'
Require stack:
- /usr/src/app/mcpjam-inspector/dist/server/index.js
```

**Cause:** `sdk/src/sentry.ts` did `require("../package.json")` at module load via `createRequire(import.meta.url)` to pull the SDK version string. That's fine when `sdk/dist/sentry.js` is loaded directly, but the inspector's server tsup config uses `noExternal: ["@mcpjam/sdk"]` — so SDK code gets inlined into `mcpjam-inspector/dist/server/index.js`, and `../package.json` then resolves to `mcpjam-inspector/dist/package.json`, which doesn't exist. The server process crashes on startup and Railway/Cloudflare returns 502.

**Fix:** inline the SDK version at build time via tsup's `define`. `esbuild` replaces `__MCPJAM_SDK_VERSION__` with a string literal, so the version is baked into `sdk/dist/*.js` and travels with the compiled output when downstream consumers re-bundle.

## Test plan

- [ ] CI passes
- [ ] Staging deploy starts successfully on Railway (`mcp-inspector` service, staging env)
- [ ] `staging.mcpjam.com` returns 200
- [ ] Sentry events from the SDK still show `release: @mcpjam/sdk@<version>` with the real version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes build/test configuration and replaces runtime version lookup with compile-time injection, which could break builds or Sentry release/version tagging if the define isn’t applied consistently across environments.
> 
> **Overview**
> Fixes SDK startup crashes in bundling consumers by removing the runtime `createRequire(...).require("../package.json")` from `sdk/src/sentry.ts` and instead reading the SDK version at build time.
> 
> `sdk/tsup.config.ts` now injects `__MCPJAM_SDK_VERSION__` (string literal) into the build, and `sdk/vitest.config.ts` mirrors the same define so tests running against `src/` resolve the identifier. A changeset bumps `@mcpjam/sdk` and `@mcpjam/inspector` with a patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 900de9fc7d3a2773fc0516170651a24eeadc15c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->