### PR TITLE
Soundcheck: surface MCP worker deploys

### DIFF
--- a/soundcheck/src/app/page.tsx
+++ b/soundcheck/src/app/page.tsx
@@ -21,6 +21,10 @@ import {
   DeployFailures,
   DeployFailuresSkeleton
 } from "@/components/deploy-failures";
+import {
+  McpDeployStatus,
+  McpDeployStatusSkeleton
+} from "@/components/mcp-deploy-status";
 import { RunRelease } from "@/components/run-release";
 import { ReleaseVerdict, ReleaseVerdictSkeleton } from "@/components/release-verdict";
 import { Section } from "@/components/ui";
@@ -77,9 +81,9 @@ export default async function Home() {
       <Section
         numeral="I"
         title="Deploy diff"
-        description="What production is missing vs. staging. The big number is the headline answer — use it to decide whether to cut a release today."
+        description="What's live where. Inspector + Backend compare production vs. staging; MCP has no prod yet, so it compares staging vs. main. The big number on each tile is the headline answer — use it to decide whether to cut a release today."
       >
-        <div className="grid gap-5 md:grid-cols-2">
+        <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
           <Suspense fallback={<DeployDiffSkeleton title="Inspector" />}>
             <DeployDiff
               title="Inspector"
@@ -99,6 +103,9 @@ export default async function Home() {
               productionEnvironment="backend-production"
               repoUrl="https://github.com/MCPJam/mcpjam-backend"
             />
+          </Suspense>
+          <Suspense fallback={<McpDeployStatusSkeleton />}>
+            <McpDeployStatus />
           </Suspense>
         </div>
       </Section>

--- a/soundcheck/src/components/deploy-diff.tsx
+++ b/soundcheck/src/components/deploy-diff.tsx
@@ -2,7 +2,7 @@ import {
   compareCommits,
   getLatestEnvironmentDeployment
 } from "@/lib/github";
-import { formatRelativeTime, shortSha } from "@/lib/format";
+import { formatRelativeTime, shortSha, truncate } from "@/lib/format";
 import { HeroStat, Sha, Tile, TileAction } from "@/components/ui";
 import type { StatusTone } from "@/components/ui";
 
@@ -204,11 +204,6 @@ export async function DeployDiff({
       </ul>
     </Tile>
   );
-}
-
-function truncate(s: string, max: number): string {
-  if (s.length <= max) return s;
-  return s.slice(0, max - 1).trimEnd() + "…";
 }
 
 export function DeployDiffSkeleton({ title }: { title: string }) {

--- a/soundcheck/src/components/deploy-failures.tsx
+++ b/soundcheck/src/components/deploy-failures.tsx
@@ -44,6 +44,18 @@ const TARGETS: Target[] = [
     workflowFile: "deploy-soundcheck.yml"
   },
   {
+    label: "MCP · deploy-mcp-staging.yml",
+    owner: "MCPJam",
+    repo: "inspector",
+    workflowFile: "deploy-mcp-staging.yml"
+  },
+  {
+    label: "MCP · pr-mcp-preview.yml",
+    owner: "MCPJam",
+    repo: "inspector",
+    workflowFile: "pr-mcp-preview.yml"
+  },
+  {
     label: "Backend · deploy-staging.yml",
     owner: "MCPJam",
     repo: "mcpjam-backend",

--- a/soundcheck/src/components/mcp-deploy-status.tsx
+++ b/soundcheck/src/components/mcp-deploy-status.tsx
@@ -153,6 +153,44 @@ export async function McpDeployStatus() {
   }
 
   const compareUrl = `${REPO_URL}/compare/${liveRun.headSha}...${mainHead.sha}`;
+
+  // Divergent-history guard: the SHAs differ but main isn't ahead of live.
+  // Usually means main was force-pushed or rolled back after the last
+  // successful staging deploy, so the worker is now running commits that
+  // aren't on main. Worth flagging — the normal "N commits ahead" framing
+  // would render "0 commits ahead" here, which is confusing.
+  if (diff.aheadBy === 0) {
+    return (
+      <Tile
+        title="MCP"
+        eyebrow={
+          diff.behindBy > 0 ? "Staging ahead of main" : "Diverged from main"
+        }
+        accent="warning"
+        action={<TileAction href={compareUrl}>compare</TileAction>}
+      >
+        <HeroStat
+          value={diff.behindBy}
+          tone="warning"
+          label={
+            diff.behindBy === 1 ? "commit not on main" : "commits not on main"
+          }
+          sublabel={
+            <>
+              Main was likely force-pushed or rolled back · live staging SHA{" "}
+              <Sha
+                href={`${REPO_URL}/commit/${liveRun.headSha}`}
+                sha={shortSha(liveRun.headSha)}
+              />{" "}
+              · last deployed {formatRelativeTime(deployedAt(liveRun))}
+            </>
+          }
+          href={compareUrl}
+        />
+      </Tile>
+    );
+  }
+
   const preview = diff.commits.slice(-6).reverse();
   const hidden = diff.aheadBy - preview.length;
   const tone = driftTone(diff.aheadBy, deployedAt(liveRun));

--- a/soundcheck/src/components/mcp-deploy-status.tsx
+++ b/soundcheck/src/components/mcp-deploy-status.tsx
@@ -28,7 +28,7 @@ import {
   type BranchHead,
   type WorkflowRun
 } from "@/lib/github";
-import { formatRelativeTime, shortSha } from "@/lib/format";
+import { formatRelativeTime, shortSha, truncate } from "@/lib/format";
 import { HeroStat, Sha, Tile, TileAction } from "@/components/ui";
 import type { StatusTone } from "@/components/ui";
 
@@ -200,7 +200,3 @@ export async function McpDeployStatus() {
   );
 }
 
-function truncate(s: string, max: number): string {
-  if (s.length <= max) return s;
-  return s.slice(0, max - 1).trimEnd() + "…";
-}

--- a/soundcheck/src/components/mcp-deploy-status.tsx
+++ b/soundcheck/src/components/mcp-deploy-status.tsx
@@ -1,0 +1,206 @@
+/**
+ * MCP staging drift tile.
+ *
+ * The MCP Cloudflare Worker has no production environment today — only
+ * `mcpjam-mcp-staging`, auto-deployed by deploy-mcp-staging.yml on every
+ * push to main. So the Deploy Diff shape (staging vs prod) doesn't apply.
+ * Instead, this tile answers: "what SHA is live on staging, and how many
+ * main commits are ahead of it?"
+ *
+ * Data:
+ *   - `live SHA` = `head_sha` of the latest successful `deploy-mcp-staging.yml`
+ *     run on main. Picking the latest *successful* run (not just latest
+ *     run) ensures a red deploy doesn't look like the current state.
+ *   - `main SHA` = head of the inspector repo's main branch.
+ *   - Drift = `compare/<live>...<main>`.
+ *
+ * Tone semantics: drift is almost always "info" for MCP because most main
+ * commits won't touch `mcp/` — a large count is expected and not a
+ * concern. Only genuinely stale deploys (>21d without an mcp-touching
+ * commit landing, which would imply the staging auto-deploy is broken)
+ * escalate to "warning".
+ */
+
+import {
+  compareCommits,
+  findLatestSuccessfulRun,
+  getBranchHead,
+  type BranchHead,
+  type WorkflowRun
+} from "@/lib/github";
+import { formatRelativeTime, shortSha } from "@/lib/format";
+import { HeroStat, Sha, Tile, TileAction } from "@/components/ui";
+import type { StatusTone } from "@/components/ui";
+
+const INSPECTOR = { owner: "MCPJam", repo: "inspector" };
+const MCP_STAGING_WORKFLOW = "deploy-mcp-staging.yml";
+const REPO_URL = "https://github.com/MCPJam/inspector";
+
+/**
+ * Prefer `runStartedAt` (when the current attempt began doing work) over
+ * `updatedAt` (last status transition — can drift on re-runs). Within a few
+ * seconds for a normal ~30s deploy, but semantically clearer for a tile
+ * whose headline claim is "last deployed".
+ */
+function deployedAt(run: WorkflowRun): string {
+  return run.runStartedAt ?? run.updatedAt;
+}
+
+function driftTone(aheadBy: number, liveDeployedIso: string): StatusTone {
+  if (aheadBy === 0) return "success";
+  const deployedMs = Date.parse(liveDeployedIso);
+  if (!Number.isFinite(deployedMs)) return "warning";
+  const ageDays = (Date.now() - deployedMs) / (24 * 60 * 60 * 1000);
+  // Most main commits don't touch `mcp/` — large aheadBy is expected, not
+  // alarming. Only stale-by-time (no mcp-touching deploy in 3 weeks) escalates.
+  if (ageDays > 21) return "warning";
+  return "info";
+}
+
+export function McpDeployStatusSkeleton() {
+  return (
+    <Tile title="MCP" eyebrow="Computing drift">
+      <div className="flex items-end gap-4">
+        <span className="display-hero text-6xl text-ink-700 animate-pulse">
+          …
+        </span>
+        <div className="pb-2">
+          <div className="h-3 w-32 rounded bg-ink-800 animate-pulse" />
+          <div className="mt-2 h-2.5 w-24 rounded bg-ink-800/60 animate-pulse" />
+        </div>
+      </div>
+    </Tile>
+  );
+}
+
+export async function McpDeployStatus() {
+  let liveRun: WorkflowRun | null;
+  let mainHead: BranchHead;
+  try {
+    [liveRun, mainHead] = await Promise.all([
+      findLatestSuccessfulRun(
+        INSPECTOR.owner,
+        INSPECTOR.repo,
+        MCP_STAGING_WORKFLOW,
+        "main"
+      ),
+      getBranchHead(INSPECTOR.owner, INSPECTOR.repo, "main")
+    ]);
+  } catch (err) {
+    return (
+      <Tile title="MCP" accent="failure">
+        <p className="text-sm text-signal-stop">
+          Failed to read MCP state: {(err as Error).message}
+        </p>
+      </Tile>
+    );
+  }
+
+  if (!liveRun) {
+    return (
+      <Tile title="MCP" accent="warning">
+        <p className="text-sm text-ink-400">
+          No successful{" "}
+          <code className="font-mono text-ink-200">deploy-mcp-staging.yml</code>{" "}
+          run on record.
+        </p>
+      </Tile>
+    );
+  }
+
+  const runAction = (
+    <TileAction href={liveRun.htmlUrl}>Run #{liveRun.id}</TileAction>
+  );
+
+  if (liveRun.headSha === mainHead.sha) {
+    return (
+      <Tile title="MCP" eyebrow="In sync" accent="success" action={runAction}>
+        <HeroStat
+          value="0"
+          tone="success"
+          label="Staging = main"
+          sublabel={
+            <>
+              On{" "}
+              <Sha
+                href={`${REPO_URL}/commit/${liveRun.headSha}`}
+                sha={shortSha(liveRun.headSha)}
+              />{" "}
+              · last deployed {formatRelativeTime(deployedAt(liveRun))}
+            </>
+          }
+        />
+      </Tile>
+    );
+  }
+
+  let diff;
+  try {
+    diff = await compareCommits(
+      INSPECTOR.owner,
+      INSPECTOR.repo,
+      liveRun.headSha,
+      mainHead.sha
+    );
+  } catch (err) {
+    return (
+      <Tile title="MCP" accent="failure" action={runAction}>
+        <p className="text-sm text-signal-stop">
+          Failed to compare commits: {(err as Error).message}
+        </p>
+      </Tile>
+    );
+  }
+
+  const compareUrl = `${REPO_URL}/compare/${liveRun.headSha}...${mainHead.sha}`;
+  const preview = diff.commits.slice(-6).reverse();
+  const hidden = diff.aheadBy - preview.length;
+  const tone = driftTone(diff.aheadBy, deployedAt(liveRun));
+
+  return (
+    <Tile
+      title="MCP"
+      eyebrow="Staging behind main"
+      accent={tone}
+      action={<TileAction href={compareUrl}>compare</TileAction>}
+    >
+      <HeroStat
+        value={diff.aheadBy}
+        tone={tone}
+        label={diff.aheadBy === 1 ? "commit ahead" : "commits ahead"}
+        sublabel={
+          <>
+            Most won&rsquo;t touch <code className="font-mono text-ink-200">mcp/</code>{" "}
+            · next deploy fires when one does · last deployed{" "}
+            {formatRelativeTime(deployedAt(liveRun))}
+          </>
+        }
+        href={compareUrl}
+      />
+
+      <div className="my-5 hairline" />
+
+      <ul className="space-y-2">
+        {preview.map((c) => (
+          <li key={c.sha} className="flex gap-3 text-xs leading-relaxed">
+            <Sha href={c.url} sha={shortSha(c.sha)} />
+            <div className="min-w-0 flex-1">
+              <span className="text-ink-100">{truncate(c.message, 84)}</span>
+              <span className="ml-2 text-ink-500">— {c.author}</span>
+            </div>
+          </li>
+        ))}
+        {hidden > 0 && (
+          <li className="pt-1 text-[11px] italic text-ink-500">
+            + {hidden} earlier commit{hidden === 1 ? "" : "s"}
+          </li>
+        )}
+      </ul>
+    </Tile>
+  );
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + "…";
+}

--- a/soundcheck/src/lib/format.ts
+++ b/soundcheck/src/lib/format.ts
@@ -37,3 +37,13 @@ export function formatElapsed(
 export function shortSha(sha: string): string {
   return sha.slice(0, 7);
 }
+
+/**
+ * Truncate a string to `max` characters, appending "…" when cut. Used to
+ * fit long commit subjects into the tile's single-line commit feed
+ * without wrapping. `max` counts the ellipsis as one character.
+ */
+export function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + "…";
+}

--- a/soundcheck/src/lib/github.ts
+++ b/soundcheck/src/lib/github.ts
@@ -375,6 +375,29 @@ export async function findSuccessfulRunForSha(
   );
 }
 
+/**
+ * Latest successful run of `workflowFile` on `branch`. Walks back through
+ * the most recent completed runs and returns the first `success`.
+ *
+ * Used by the MCP staging-drift tile: "what SHA was last successfully
+ * deployed?" For services without a production environment (like
+ * mcpjam-mcp-staging today), the SHA of the last green deploy workflow is
+ * the best proxy for "what's live right now".
+ */
+export async function findLatestSuccessfulRun(
+  owner: string,
+  repo: string,
+  workflowFile: string,
+  branch: string
+): Promise<WorkflowRun | null> {
+  const runs = await listWorkflowRuns(owner, repo, workflowFile, {
+    branch,
+    status: "completed",
+    perPage: 30
+  });
+  return runs.find((r) => r.conclusion === "success") ?? null;
+}
+
 export async function getMostRecentFailedRun(
   owner: string,
   repo: string,


### PR DESCRIPTION
## Summary

- Deploy Diff gets a third tile: **MCP** (staging vs. main, since there's no MCP production yet).
- Recent Failures adds rows for `deploy-mcp-staging.yml` and `pr-mcp-preview.yml`.
- New `findLatestSuccessfulRun` helper in `lib/github.ts`.

## Why

PR #1829 introduced `deploy-mcp-staging.yml` and PR #1831 introduced `pr-mcp-preview.yml`, but Soundcheck didn't know about either. A failed MCP staging deploy (exactly what we hit while debugging the CF secrets last session) would have been invisible on the dashboard — no Deploy Diff tile, no row in Recent Failures.

## What's in each piece

### MCP tile (`components/mcp-deploy-status.tsx`)

The worker has no production environment today. Soundcheck's existing `<DeployDiff>` assumes "prod vs. staging" which doesn't fit. So the MCP tile uses a different shape:

- `live SHA` = `head_sha` of the latest **successful** `deploy-mcp-staging.yml` run on `main`. Picking the latest *successful* run (not just latest) keeps a red deploy from looking like the current state.
- `main SHA` = `GET /repos/.../branches/main`'s head commit.
- Drift = `compare/<live>...<main>`, same API the Deploy Diff tile already uses.
- Empty state if no successful run has ever landed ("first deploy pending").
- Renders quietly when in sync, visibly when behind.

Note in the copy: most main commits won't touch `mcp/`, so the `aheadBy` count is noisier than it is for Inspector/Backend (the next deploy only fires when an mcp-touching commit lands). Called out inline so reviewers don't misread "42 commits behind" as alarm.

### Recent Failures rows

Two new entries in the `TARGETS` array in `components/deploy-failures.tsx`:
- `MCP · deploy-mcp-staging.yml`
- `MCP · pr-mcp-preview.yml`

Same per-workflow failure shape as existing rows — most-recent failure in last 7 days with failing job + check-run annotations inline.

### `findLatestSuccessfulRun` helper

Walks completed runs of a given workflow on a branch, returns the first with `conclusion === "success"`. Complements the existing `findSuccessfulRunForSha` (which matches a specific SHA) and `getMostRecentFailedRun` (which finds failures).

## Grid

Deploy Diff grid bumped to `md:grid-cols-2 xl:grid-cols-3` so Inspector / Backend / MCP all fit on wide screens and stack on narrow.

## Test plan

- [x] `npm run typecheck -w @mcpjam/soundcheck` — clean
- [x] `npm run lint -w @mcpjam/soundcheck` — clean
- [x] `npm run build -w @mcpjam/soundcheck` — clean
- [ ] After merge, deploy-soundcheck.yml fires, confirm https://soundcheck.mcpjam.com shows:
  - [ ] MCP tile in the Deploy Diff grid, populated with the latest successful `deploy-mcp-staging.yml` run
  - [ ] Recent Failures lists MCP rows (likely "No failures in the last 7d" for both since things are healthy post-PR #1831)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only changes that add read-only GitHub lookups and UI tiles; main risk is incorrect drift/failure reporting or increased API calls, not production behavior.
> 
> **Overview**
> Adds an **MCP** tile to the Deploy Diff section that reports staging drift vs `main` (using the latest successful `deploy-mcp-staging.yml` run as “live”), including edge-state handling for missing runs and divergent history.
> 
> Expands **Recent failures** to track MCP workflows (`deploy-mcp-staging.yml`, `pr-mcp-preview.yml`), adjusts the Deploy Diff grid/copy to fit the third tile, and factors string truncation into a shared `truncate` helper while introducing `findLatestSuccessfulRun` in `lib/github.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 839e259621973da5140b61d2889d86738dc00264. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->