### PR TITLE
Soundcheck: editorial redesign for at-a-glance grok

### DIFF
--- a/soundcheck/src/app/globals.css
+++ b/soundcheck/src/app/globals.css
@@ -220,9 +220,9 @@ body::after {
   }
 }
 
-/* Focus ring — warm, accessible */
+/* Focus ring — warm, accessible. The ring inherits whatever radius the
+   focused element already has; we don't force a shape on it. */
 :focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px rgba(232, 195, 102, 0.6);
-  border-radius: 6px;
 }

--- a/soundcheck/src/app/globals.css
+++ b/soundcheck/src/app/globals.css
@@ -3,11 +3,226 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: light dark;
+  color-scheme: dark;
+
+  --bg-base: #0a0a0c;
+  --bg-panel: #111116;
+  --bg-panel-raised: #16161d;
+  --edge-hairline: rgba(245, 244, 239, 0.06);
+  --edge-strong: rgba(245, 244, 239, 0.12);
+  --text-primary: #f5f4ef;
+  --text-secondary: #9a9aa0;
+  --text-muted: #5a5a68;
+}
+
+html,
+body {
+  background: var(--bg-base);
+  color: var(--text-primary);
 }
 
 body {
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
-    Roboto, Helvetica, Arial, sans-serif;
   margin: 0;
+  font-feature-settings:
+    "ss01" on,
+    "cv11" on;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  min-height: 100vh;
+  position: relative;
+}
+
+/* Atmospheric background: radial warm glow + film grain.
+   Both are purely decorative, pointer-events:none. */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  background:
+    radial-gradient(
+      ellipse 80% 60% at 20% 0%,
+      rgba(232, 195, 102, 0.04),
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse 60% 50% at 90% 10%,
+      rgba(140, 180, 216, 0.035),
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse 100% 70% at 50% 120%,
+      rgba(127, 217, 154, 0.025),
+      transparent 60%
+    );
+  pointer-events: none;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  opacity: 0.035;
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.6 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+/* Selection matches the editorial feel */
+::selection {
+  background: rgba(232, 195, 102, 0.25);
+  color: #f5f4ef;
+}
+
+/* Thin, warm scrollbar */
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: rgba(245, 244, 239, 0.08);
+  border-radius: 10px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(245, 244, 239, 0.15);
+  background-clip: padding-box;
+  border: 2px solid transparent;
+}
+
+/* Hairline divider utility */
+.hairline {
+  background-image: linear-gradient(
+    to right,
+    transparent,
+    var(--edge-hairline) 12%,
+    var(--edge-hairline) 88%,
+    transparent
+  );
+  height: 1px;
+}
+
+/* Panel — the base card surface. Slightly raised, subtle inner highlight. */
+.panel {
+  background:
+    linear-gradient(
+      180deg,
+      rgba(245, 244, 239, 0.015),
+      transparent 40%
+    ),
+    var(--bg-panel);
+  border: 1px solid var(--edge-hairline);
+  border-radius: 14px;
+  box-shadow:
+    0 1px 0 rgba(245, 244, 239, 0.03) inset,
+    0 20px 60px -20px rgba(0, 0, 0, 0.5);
+}
+
+.panel-accent-go {
+  border-left: 2px solid rgba(127, 217, 154, 0.7);
+}
+.panel-accent-stop {
+  border-left: 2px solid rgba(240, 141, 135, 0.75);
+}
+.panel-accent-wait {
+  border-left: 2px solid rgba(232, 195, 102, 0.75);
+}
+.panel-accent-info {
+  border-left: 2px solid rgba(140, 180, 216, 0.5);
+}
+
+/* Roman-numeral section marker */
+.numeral {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: var(--text-muted);
+  letter-spacing: 0.01em;
+}
+
+.display-hero {
+  font-family: var(--font-display);
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  line-height: 0.95;
+}
+
+/* Monospace tag used for SHAs — slight tracking in, subtle uppercase weight */
+.tag-mono {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  color: var(--text-secondary);
+}
+
+/* Glow status dots — more refined than solid circles */
+.dot {
+  position: relative;
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.02);
+}
+.dot::after {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border-radius: 9999px;
+  background: currentColor;
+  opacity: 0.2;
+  filter: blur(4px);
+}
+.dot-go {
+  background: #7fd99a;
+  color: #7fd99a;
+}
+.dot-stop {
+  background: #f08d87;
+  color: #f08d87;
+}
+.dot-wait {
+  background: #e8c366;
+  color: #e8c366;
+}
+.dot-info {
+  background: #8cb4d8;
+  color: #8cb4d8;
+}
+.dot-run {
+  background: #8cb4d8;
+  color: #8cb4d8;
+  animation: pulse-soft 1.6s ease-in-out infinite;
+}
+.dot-neutral {
+  background: #3a3a48;
+  color: #3a3a48;
+}
+.dot-neutral::after {
+  display: none;
+}
+
+@keyframes pulse-soft {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(0.85);
+    opacity: 0.55;
+  }
+}
+
+/* Focus ring — warm, accessible */
+:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(232, 195, 102, 0.6);
+  border-radius: 6px;
 }

--- a/soundcheck/src/app/layout.tsx
+++ b/soundcheck/src/app/layout.tsx
@@ -1,9 +1,31 @@
 import type { Metadata } from "next";
+import { Instrument_Serif, Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
+const display = Instrument_Serif({
+  subsets: ["latin"],
+  weight: ["400"],
+  style: ["normal", "italic"],
+  variable: "--font-display",
+  display: "swap"
+});
+
+const sans = Geist({
+  subsets: ["latin"],
+  variable: "--font-sans",
+  display: "swap"
+});
+
+const mono = Geist_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono",
+  display: "swap"
+});
+
 export const metadata: Metadata = {
-  title: "Soundcheck",
-  description: "MCPJam internal deployment dashboard"
+  title: "Soundcheck — MCPJam ops",
+  description:
+    "MCPJam internal deployment dashboard. Staging vs. production, release readiness, and dispatch — in one place."
 };
 
 export default function RootLayout({
@@ -12,8 +34,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body>{children}</body>
+    <html
+      lang="en"
+      className={`${display.variable} ${sans.variable} ${mono.variable}`}
+    >
+      <body className="font-sans antialiased">{children}</body>
     </html>
   );
 }

--- a/soundcheck/src/app/page.tsx
+++ b/soundcheck/src/app/page.tsx
@@ -22,6 +22,7 @@ import {
   DeployFailuresSkeleton
 } from "@/components/deploy-failures";
 import { RunRelease } from "@/components/run-release";
+import { ReleaseVerdict, ReleaseVerdictSkeleton } from "@/components/release-verdict";
 import { Section } from "@/components/ui";
 
 export const dynamic = "force-dynamic";
@@ -31,29 +32,54 @@ export default async function Home() {
 
   if (isLockdownEnabled() && !isAllowedEmployeeEmail(user.email)) {
     return (
-      <main className="p-8">
-        <h1 className="text-xl font-semibold">Not authorized</h1>
-        <p className="mt-2 text-sm text-neutral-500">
-          Soundcheck is restricted to MCPJam employees.
-        </p>
+      <main className="mx-auto max-w-xl px-6 py-24">
+        <div className="panel panel-accent-stop p-8">
+          <h1 className="display-hero text-3xl text-ink-100">Not authorized.</h1>
+          <p className="mt-3 text-sm text-ink-400">
+            Soundcheck is restricted to MCPJam employees. If you think this is
+            a mistake, reach out in <span className="font-mono text-ink-200">#ops</span>.
+          </p>
+        </div>
       </main>
     );
   }
 
   return (
-    <main className="mx-auto max-w-5xl p-8">
-      <header className="mb-8">
-        <h1 className="text-2xl font-semibold">Soundcheck</h1>
-        <p className="text-sm text-neutral-500">
-          Signed in as {user.email}
-        </p>
+    <main className="mx-auto max-w-6xl px-6 py-14 md:px-10 md:py-20">
+      {/* Wordmark + meta */}
+      <header className="mb-12 flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+        <div>
+          <div className="text-[10px] font-medium uppercase tracking-[0.22em] text-ink-500">
+            MCPJam · internal ops
+          </div>
+          <h1 className="display-hero mt-3 text-6xl md:text-7xl text-ink-50">
+            Soundcheck<span className="text-signal-wait">.</span>
+          </h1>
+          <p className="mt-3 max-w-xl text-sm leading-relaxed text-ink-400">
+            One control plane for the release pipeline. Everything below
+            answers a question you&rsquo;d otherwise go hunting for across
+            GitHub, Railway, Convex, Cloudflare, and npm.
+          </p>
+        </div>
+        <div className="text-xs text-ink-500">
+          <div>Signed in as</div>
+          <div className="mt-0.5 font-mono text-ink-200">{user.email}</div>
+        </div>
       </header>
 
+      {/* Verdict strip — instant "go / hold" */}
+      <div className="mb-14">
+        <Suspense fallback={<ReleaseVerdictSkeleton />}>
+          <ReleaseVerdict />
+        </Suspense>
+      </div>
+
       <Section
+        numeral="I"
         title="Deploy diff"
-        description="What production is missing vs. staging. Use this to decide whether to cut a release."
+        description="What production is missing vs. staging. The big number is the headline answer — use it to decide whether to cut a release today."
       >
-        <div className="grid gap-4 md:grid-cols-2">
+        <div className="grid gap-5 md:grid-cols-2">
           <Suspense fallback={<DeployDiffSkeleton title="Inspector" />}>
             <DeployDiff
               title="Inspector"
@@ -78,6 +104,7 @@ export default async function Home() {
       </Section>
 
       <Section
+        numeral="II"
         title="Release readiness"
         description="Checks that mirror release.yml's preflight gates. Green across the board means the Release workflow will pass preflight."
       >
@@ -87,10 +114,11 @@ export default async function Home() {
       </Section>
 
       <Section
+        numeral="III"
         title="Release preview & dispatch"
-        description="What Release would publish from main right now, and the button to dispatch it."
+        description="What Release would publish from main right now, and the one button that sends it."
       >
-        <div className="grid gap-4 md:grid-cols-2">
+        <div className="grid gap-5 md:grid-cols-2">
           <Suspense fallback={<ReleaseDryRunSkeleton />}>
             <ReleaseDryRun />
           </Suspense>
@@ -99,8 +127,9 @@ export default async function Home() {
       </Section>
 
       <Section
+        numeral="IV"
         title="Release progress"
-        description="In-flight release.yml run, with a per-job stepper. Polls every 10s while a run is live."
+        description="In-flight release.yml run with a per-job stepper. Polls every 10s while a run is live."
       >
         <Suspense fallback={<ReleaseProgressSkeleton />}>
           <ReleaseProgress />
@@ -108,6 +137,7 @@ export default async function Home() {
       </Section>
 
       <Section
+        numeral="V"
         title="Recent failures"
         description="Most recent failure per deploy workflow (last 7 days). Check-run annotations inline so you don't have to open GH Actions."
       >
@@ -115,6 +145,32 @@ export default async function Home() {
           <DeployFailures />
         </Suspense>
       </Section>
+
+      <footer className="mt-20 border-t border-ink-800/60 pt-6 text-[11px] text-ink-500 md:flex md:items-center md:justify-between">
+        <div>
+          <span className="font-mono">@mcpjam/soundcheck</span> — private
+          workspace · deploys independently · never published.
+        </div>
+        <div className="mt-2 md:mt-0">
+          <a
+            href="https://github.com/MCPJam/inspector/tree/main/soundcheck"
+            target="_blank"
+            rel="noreferrer"
+            className="hover:text-ink-200"
+          >
+            source ↗
+          </a>
+          <span className="mx-2 text-ink-700">·</span>
+          <a
+            href="https://github.com/MCPJam/inspector/actions/workflows/release.yml"
+            target="_blank"
+            rel="noreferrer"
+            className="hover:text-ink-200"
+          >
+            release.yml ↗
+          </a>
+        </div>
+      </footer>
     </main>
   );
 }

--- a/soundcheck/src/components/deploy-diff.tsx
+++ b/soundcheck/src/components/deploy-diff.tsx
@@ -28,12 +28,13 @@ function categorize(message: string): Category {
   return "other";
 }
 
-const CATEGORY_LABEL: Record<Category, string> = {
-  feat: "features",
-  fix: "fixes",
-  chore: "chores",
-  other: "other"
-};
+function categoryLabel(cat: Category, count: number): string {
+  if (cat === "other") return "other";
+  if (count === 1) {
+    return cat === "feat" ? "feature" : cat === "fix" ? "fix" : "chore";
+  }
+  return cat === "feat" ? "features" : cat === "fix" ? "fixes" : "chores";
+}
 
 const CATEGORY_COLOR: Record<Category, string> = {
   feat: "text-signal-go",
@@ -43,9 +44,13 @@ const CATEGORY_COLOR: Record<Category, string> = {
 };
 
 function driftTone(aheadBy: number, promotedIso: string): StatusTone {
-  const ageDays =
-    (Date.now() - new Date(promotedIso).getTime()) / (24 * 60 * 60 * 1000);
   if (aheadBy === 0) return "success";
+  // An unparseable promoted-at shouldn't silently resolve to the low-severity
+  // "info" tone — it usually means the deployment record is ancient or
+  // malformed. Treat it as "warning" so the tile at least flags attention.
+  const promotedMs = Date.parse(promotedIso);
+  if (!Number.isFinite(promotedMs)) return "warning";
+  const ageDays = (Date.now() - promotedMs) / (24 * 60 * 60 * 1000);
   if (aheadBy > 100 || ageDays > 21) return "warning";
   return "info";
 }
@@ -170,7 +175,9 @@ export async function DeployDiff({
           counts[cat] > 0 ? (
             <span key={cat} className={CATEGORY_COLOR[cat]}>
               <span className="tabular-nums">{counts[cat]}</span>
-              <span className="ml-1 text-ink-500">{CATEGORY_LABEL[cat]}</span>
+              <span className="ml-1 text-ink-500">
+                {categoryLabel(cat, counts[cat])}
+              </span>
             </span>
           ) : null
         )}

--- a/soundcheck/src/components/deploy-diff.tsx
+++ b/soundcheck/src/components/deploy-diff.tsx
@@ -3,7 +3,8 @@ import {
   getLatestEnvironmentDeployment
 } from "@/lib/github";
 import { formatRelativeTime, shortSha } from "@/lib/format";
-import { Tile } from "@/components/ui";
+import { HeroStat, Sha, Tile, TileAction } from "@/components/ui";
+import type { StatusTone } from "@/components/ui";
 
 interface Props {
   title: string;
@@ -27,18 +28,26 @@ function categorize(message: string): Category {
   return "other";
 }
 
-function describeCategories(
-  counts: Record<Category, number>,
-  total: number
-): string {
-  const parts: string[] = [];
-  if (counts.feat > 0) parts.push(`${counts.feat} feature${counts.feat === 1 ? "" : "s"}`);
-  if (counts.fix > 0) parts.push(`${counts.fix} fix${counts.fix === 1 ? "" : "es"}`);
-  if (counts.chore > 0) parts.push(`${counts.chore} chore${counts.chore === 1 ? "" : "s"}`);
-  if (counts.other > 0) {
-    parts.push(`${counts.other} other commit${counts.other === 1 ? "" : "s"}`);
-  }
-  return parts.length > 0 ? parts.join(", ") : `${total} commit${total === 1 ? "" : "s"}`;
+const CATEGORY_LABEL: Record<Category, string> = {
+  feat: "features",
+  fix: "fixes",
+  chore: "chores",
+  other: "other"
+};
+
+const CATEGORY_COLOR: Record<Category, string> = {
+  feat: "text-signal-go",
+  fix: "text-signal-wait",
+  chore: "text-ink-300",
+  other: "text-ink-400"
+};
+
+function driftTone(aheadBy: number, promotedIso: string): StatusTone {
+  const ageDays =
+    (Date.now() - new Date(promotedIso).getTime()) / (24 * 60 * 60 * 1000);
+  if (aheadBy === 0) return "success";
+  if (aheadBy > 100 || ageDays > 21) return "warning";
+  return "info";
 }
 
 export async function DeployDiff({
@@ -57,8 +66,8 @@ export async function DeployDiff({
     ]);
   } catch (err) {
     return (
-      <Tile title={title}>
-        <p className="text-sm text-red-500">
+      <Tile title={title} accent="failure">
+        <p className="text-sm text-signal-stop">
           Failed to read deployments: {(err as Error).message}
         </p>
       </Tile>
@@ -67,20 +76,23 @@ export async function DeployDiff({
 
   if (!production) {
     return (
-      <Tile title={title}>
-        <p className="text-sm text-neutral-500">
+      <Tile title={title} accent="warning">
+        <p className="text-sm text-ink-400">
           No successful production deployment recorded for{" "}
-          <code>{productionEnvironment}</code>.
+          <code className="font-mono text-ink-200">
+            {productionEnvironment}
+          </code>
+          .
         </p>
       </Tile>
     );
   }
   if (!staging) {
     return (
-      <Tile title={title}>
-        <p className="text-sm text-neutral-500">
+      <Tile title={title} accent="warning">
+        <p className="text-sm text-ink-400">
           No successful staging deployment recorded for{" "}
-          <code>{stagingEnvironment}</code>.
+          <code className="font-mono text-ink-200">{stagingEnvironment}</code>.
         </p>
       </Tile>
     );
@@ -88,19 +100,23 @@ export async function DeployDiff({
 
   if (staging.sha === production.sha) {
     return (
-      <Tile title={title}>
-        <p className="text-sm text-neutral-500">
-          In sync on{" "}
-          <a
-            href={`${repoUrl}/commit/${production.sha}`}
-            className="font-mono text-neutral-400 hover:underline"
-            target="_blank"
-            rel="noreferrer"
-          >
-            {shortSha(production.sha)}
-          </a>
-          . Last promoted {formatRelativeTime(production.createdAt)}.
-        </p>
+      <Tile
+        title={title}
+        eyebrow="In sync"
+        accent="success"
+        action={<TileAction href={`${repoUrl}/commits/main`}>history</TileAction>}
+      >
+        <HeroStat
+          value="0"
+          tone="success"
+          label="Staging = production"
+          sublabel={
+            <>
+              On <Sha href={`${repoUrl}/commit/${production.sha}`} sha={shortSha(production.sha)} />
+              {" "}· last promoted {formatRelativeTime(production.createdAt)}
+            </>
+          }
+        />
       </Tile>
     );
   }
@@ -110,8 +126,8 @@ export async function DeployDiff({
     diff = await compareCommits(owner, repo, production.sha, staging.sha);
   } catch (err) {
     return (
-      <Tile title={title}>
-        <p className="text-sm text-red-500">
+      <Tile title={title} accent="failure">
+        <p className="text-sm text-signal-stop">
           Failed to compare commits: {(err as Error).message}
         </p>
       </Tile>
@@ -128,53 +144,53 @@ export async function DeployDiff({
     counts[categorize(c.message)]++;
   }
 
-  const commitWord = diff.aheadBy === 1 ? "commit" : "commits";
-  const breakdown = describeCategories(counts, diff.aheadBy);
   const compareUrl = `${repoUrl}/compare/${production.sha}...${staging.sha}`;
-
-  // GitHub Compare returns commits in chronological order (oldest first).
-  // Flip so the newest work shows up on top — that's what matters when
-  // deciding "should we cut a release?". Overflow count uses `aheadBy`
-  // rather than `commits.length` because the compare endpoint caps commits
-  // at 250 for wide diffs.
-  const preview = diff.commits.slice(-8).reverse();
+  const preview = diff.commits.slice(-6).reverse();
   const hidden = diff.aheadBy - preview.length;
+  const tone = driftTone(diff.aheadBy, production.createdAt);
 
   return (
-    <Tile title={title}>
-      <p className="text-sm text-neutral-500">
-        Production is{" "}
-        <a
-          href={compareUrl}
-          className="font-medium text-neutral-700 dark:text-neutral-200 hover:underline"
-          target="_blank"
-          rel="noreferrer"
-        >
-          {diff.aheadBy} {commitWord} behind staging
-        </a>{" "}
-        ({breakdown}). Last promoted{" "}
-        {formatRelativeTime(production.createdAt)}.
-      </p>
+    <Tile
+      title={title}
+      eyebrow="Production behind staging"
+      accent={tone}
+      action={<TileAction href={compareUrl}>compare</TileAction>}
+    >
+      <HeroStat
+        value={diff.aheadBy}
+        tone={tone}
+        label={diff.aheadBy === 1 ? "commit ahead" : "commits ahead"}
+        sublabel={`Last promoted ${formatRelativeTime(production.createdAt)}`}
+        href={compareUrl}
+      />
 
-      <ul className="mt-4 space-y-1">
+      {/* Category breakdown — small strip with typed counts */}
+      <div className="mt-5 flex flex-wrap gap-x-5 gap-y-1 text-[11px] font-medium uppercase tracking-wider">
+        {(Object.keys(counts) as Category[]).map((cat) =>
+          counts[cat] > 0 ? (
+            <span key={cat} className={CATEGORY_COLOR[cat]}>
+              <span className="tabular-nums">{counts[cat]}</span>
+              <span className="ml-1 text-ink-500">{CATEGORY_LABEL[cat]}</span>
+            </span>
+          ) : null
+        )}
+      </div>
+
+      <div className="my-5 hairline" />
+
+      {/* Commit feed */}
+      <ul className="space-y-2">
         {preview.map((c) => (
-          <li key={c.sha} className="text-xs text-neutral-500">
-            <a
-              href={c.url}
-              className="font-mono text-neutral-400 hover:underline"
-              target="_blank"
-              rel="noreferrer"
-            >
-              {shortSha(c.sha)}
-            </a>{" "}
-            <span className="text-neutral-700 dark:text-neutral-200">
-              {c.message}
-            </span>{" "}
-            <span className="text-neutral-400">— {c.author}</span>
+          <li key={c.sha} className="group flex gap-3 text-xs leading-relaxed">
+            <Sha href={c.url} sha={shortSha(c.sha)} />
+            <div className="min-w-0 flex-1">
+              <span className="text-ink-100">{truncate(c.message, 84)}</span>
+              <span className="ml-2 text-ink-500">— {c.author}</span>
+            </div>
           </li>
         ))}
         {hidden > 0 && (
-          <li className="text-xs text-neutral-400">
+          <li className="pt-1 text-[11px] italic text-ink-500">
             + {hidden} earlier commit{hidden === 1 ? "" : "s"}
           </li>
         )}
@@ -183,10 +199,23 @@ export async function DeployDiff({
   );
 }
 
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + "…";
+}
+
 export function DeployDiffSkeleton({ title }: { title: string }) {
   return (
-    <Tile title={title}>
-      <p className="text-sm text-neutral-400">Loading…</p>
+    <Tile title={title} eyebrow="Computing diff">
+      <div className="flex items-end gap-4">
+        <span className="display-hero text-6xl text-ink-700 animate-pulse">
+          …
+        </span>
+        <div className="pb-2">
+          <div className="h-3 w-32 rounded bg-ink-800 animate-pulse" />
+          <div className="mt-2 h-2.5 w-24 rounded bg-ink-800/60 animate-pulse" />
+        </div>
+      </div>
     </Tile>
   );
 }

--- a/soundcheck/src/components/deploy-failures.tsx
+++ b/soundcheck/src/components/deploy-failures.tsx
@@ -3,12 +3,7 @@
  *
  * One row per tracked workflow. For each, the most recent failed run within
  * the lookback window (default 7d) — with the failing job, the failing
- * step, and check-run annotations surfaced inline. The annotations API
- * gives us structured error lines (path, line, message) without needing
- * to download and parse the log zip.
- *
- * If a workflow has no failures in the lookback window, its row reads
- * "No failures in the last Nd" — which is itself useful signal.
+ * step, and check-run annotations surfaced inline.
  */
 
 import {
@@ -19,7 +14,7 @@ import {
   type WorkflowJob,
   type WorkflowRun
 } from "@/lib/github";
-import { Badge, Tile } from "@/components/ui";
+import { Badge, Sha, Tile } from "@/components/ui";
 import { formatRelativeTime, shortSha } from "@/lib/format";
 
 interface Target {
@@ -66,8 +61,8 @@ const LOOKBACK_DAYS = 7;
 
 export function DeployFailuresSkeleton() {
   return (
-    <Tile title="Recent failures">
-      <p className="text-sm text-neutral-400">Scanning workflows…</p>
+    <Tile title="Recent failures" eyebrow="Scanning workflows">
+      <p className="text-sm text-ink-400">Scanning workflows…</p>
     </Tile>
   );
 }
@@ -78,16 +73,33 @@ export async function DeployFailures() {
   ).toISOString();
 
   const rows = await Promise.all(
-    TARGETS.map((t) => buildRow(t, since).catch((err) => ({
-      target: t,
-      state: "error" as const,
-      message: (err as Error).message
-    })))
+    TARGETS.map((t) =>
+      buildRow(t, since).catch(
+        (err) =>
+          ({
+            target: t,
+            state: "error" as const,
+            message: (err as Error).message
+          }) as const
+      )
+    )
   );
 
+  const failureCount = rows.filter((r) => r.state === "failed").length;
+  const accent =
+    failureCount > 0 ? "failure" : rows.some((r) => r.state === "error") ? "warning" : "success";
+
   return (
-    <Tile title={`Recent failures (last ${LOOKBACK_DAYS}d)`}>
-      <ul className="space-y-4">
+    <Tile
+      title={`Recent failures · last ${LOOKBACK_DAYS} days`}
+      eyebrow={
+        failureCount === 0
+          ? "Nothing failing — clean week"
+          : `${failureCount} workflow${failureCount === 1 ? "" : "s"} with recent failures`
+      }
+      accent={accent}
+    >
+      <ul className="-mt-2 divide-y divide-ink-800/60">
         {rows.map((row) => (
           <FailureRow key={row.target.label} row={row} />
         ))}
@@ -116,17 +128,13 @@ async function buildRow(target: Target, since: string): Promise<Row> {
   );
   if (!failed) return { target, state: "healthy" };
 
-  // Pick the first failing job and pull its annotations. Logs zip is too
-  // heavy for a tile; annotations give us the actual error lines.
   let failingJob: WorkflowJob | null = null;
   let annotations: CheckRunAnnotation[] = [];
   try {
     const jobs = await getWorkflowRunJobs(target.owner, target.repo, failed.id);
     failingJob =
       jobs.find(
-        (j) =>
-          j.conclusion === "failure" ||
-          j.conclusion === "timed_out"
+        (j) => j.conclusion === "failure" || j.conclusion === "timed_out"
       ) ?? null;
     if (failingJob?.checkRunUrl) {
       annotations = await getJobAnnotations(
@@ -136,8 +144,6 @@ async function buildRow(target: Target, since: string): Promise<Row> {
       );
     }
   } catch (err) {
-    // We still have the run + conclusion — surface the run without inline
-    // diagnostics rather than failing the entire row.
     console.error(`Failed to enrich failure for ${target.label}:`, err);
   }
   return { target, state: "failed", run: failed, failingJob, annotations };
@@ -146,89 +152,86 @@ async function buildRow(target: Target, since: string): Promise<Row> {
 function FailureRow({ row }: { row: Row }) {
   if (row.state === "healthy") {
     return (
-      <li className="flex items-baseline gap-3">
+      <li className="flex items-center gap-3 py-3">
         <Badge tone="success">ok</Badge>
-        <div className="text-sm text-neutral-500">
-          <span className="text-neutral-700 dark:text-neutral-200">
-            {row.target.label}
-          </span>{" "}
-          — no failures in the last {LOOKBACK_DAYS}d
+        <div className="text-sm text-ink-300">
+          <span className="text-ink-100">{row.target.label}</span>
+          <span className="ml-2 text-ink-500">
+            — no failures in the last {LOOKBACK_DAYS}d
+          </span>
         </div>
       </li>
     );
   }
   if (row.state === "error") {
     return (
-      <li className="flex items-baseline gap-3">
+      <li className="flex items-center gap-3 py-3">
         <Badge tone="warning">error</Badge>
-        <div className="text-sm text-neutral-500">
-          <span className="text-neutral-700 dark:text-neutral-200">
-            {row.target.label}
-          </span>{" "}
-          — {row.message}
+        <div className="text-sm text-ink-300">
+          <span className="text-ink-100">{row.target.label}</span>
+          <span className="ml-2 text-ink-500">— {row.message}</span>
         </div>
       </li>
     );
   }
 
   const { run, failingJob, annotations } = row;
-  // Mirror the job filter above: a timed-out job's failing step is still
-  // the most useful thing to show, and silently dropping it would hide the
-  // primary signal of the row.
   const failingStep = failingJob?.steps.find(
     (s) => s.conclusion === "failure" || s.conclusion === "timed_out"
   );
   return (
-    <li className="space-y-2">
-      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm">
+    <li className="space-y-2 py-4">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1.5 text-sm">
         <Badge tone="failure">{run.conclusion ?? "failed"}</Badge>
-        <span className="text-neutral-700 dark:text-neutral-200">
-          {row.target.label}
-        </span>
-        <span className="text-xs text-neutral-500">
+        <span className="font-medium text-ink-100">{row.target.label}</span>
+        <span className="text-xs text-ink-500">
           run{" "}
           <a
             href={run.htmlUrl}
             target="_blank"
             rel="noreferrer"
-            className="hover:underline"
+            className="text-ink-200 hover:text-signal-wait hover:underline underline-offset-4 decoration-ink-600"
           >
             #{run.id}
           </a>{" "}
           · {formatRelativeTime(run.updatedAt)} · on{" "}
-          <span className="font-mono">{shortSha(run.headSha)}</span>
-          {run.actor ? <> · by {run.actor}</> : null}
+          <Sha sha={shortSha(run.headSha)} />
+          {run.actor ? (
+            <>
+              {" "}· by <span className="text-ink-200">{run.actor}</span>
+            </>
+          ) : null}
         </span>
       </div>
 
       {failingJob ? (
-        <div className="ml-0 text-xs text-neutral-500">
+        <div className="text-xs text-ink-400">
           <a
             href={failingJob.htmlUrl}
             target="_blank"
             rel="noreferrer"
-            className="font-mono text-neutral-700 hover:underline dark:text-neutral-200"
+            className="font-mono text-ink-100 hover:text-signal-wait hover:underline underline-offset-4 decoration-ink-600"
           >
             {failingJob.name}
           </a>
           {failingStep ? (
             <>
-              {" "}
-              failed at step {failingStep.number}:{" "}
-              <span className="text-neutral-700 dark:text-neutral-200">
-                {failingStep.name}
-              </span>
+              {" "}failed at step {failingStep.number}:{" "}
+              <span className="text-ink-100">{failingStep.name}</span>
             </>
           ) : null}
         </div>
       ) : null}
 
       {annotations.length > 0 ? (
-        <ul className="space-y-0.5 rounded border border-red-500/20 bg-red-500/5 p-2">
+        <ul className="space-y-0.5 rounded-lg border border-signal-stop/20 bg-signal-stop/5 p-3">
           {annotations.slice(0, 6).map((a, i) => (
-            <li key={i} className="font-mono text-[11px] leading-tight text-red-700 dark:text-red-400">
+            <li
+              key={i}
+              className="font-mono text-[11px] leading-tight text-signal-stop"
+            >
               {a.path ? (
-                <span className="text-red-500/80">
+                <span className="text-signal-stop/70">
                   {a.path}
                   {a.startLine ? `:${a.startLine}` : ""}:{" "}
                 </span>
@@ -238,7 +241,7 @@ function FailureRow({ row }: { row: Row }) {
             </li>
           ))}
           {annotations.length > 6 ? (
-            <li className="text-[11px] text-neutral-500">
+            <li className="text-[11px] italic text-ink-500">
               + {annotations.length - 6} more — see full logs
             </li>
           ) : null}

--- a/soundcheck/src/components/release-dry-run.tsx
+++ b/soundcheck/src/components/release-dry-run.tsx
@@ -6,9 +6,6 @@
  * (with their descriptions = release-note bodies), the projected
  * release_tag, which scopes are valid, and whether desktop artifacts will
  * build.
- *
- * Uses the GitHub contents API to read `.changeset/*.md` + the three
- * package.json files on `main`, so no monorepo checkout is needed.
  */
 
 import { getBranchHead } from "@/lib/github";
@@ -18,15 +15,17 @@ import {
   fetchPendingChangesets,
   type PackageBumpPlan
 } from "@/lib/changesets";
-import { Badge, Tile } from "@/components/ui";
+import { Badge, Tile, TileAction } from "@/components/ui";
 import { shortSha } from "@/lib/format";
 
 const INSPECTOR = { owner: "MCPJam", repo: "inspector" };
 
 export function ReleaseDryRunSkeleton() {
   return (
-    <Tile title="Release dry-run">
-      <p className="text-sm text-neutral-400">Computing projected versions…</p>
+    <Tile title="Release dry-run" eyebrow="Computing plan">
+      <p className="text-sm text-ink-400">
+        Computing projected versions…
+      </p>
     </Tile>
   );
 }
@@ -37,8 +36,8 @@ export async function ReleaseDryRun() {
     head = await getBranchHead(INSPECTOR.owner, INSPECTOR.repo, "main");
   } catch (err) {
     return (
-      <Tile title="Release dry-run">
-        <p className="text-sm text-red-500">
+      <Tile title="Release dry-run" accent="failure">
+        <p className="text-sm text-signal-stop">
           Failed to read main: {(err as Error).message}
         </p>
       </Tile>
@@ -53,8 +52,8 @@ export async function ReleaseDryRun() {
     ]);
   } catch (err) {
     return (
-      <Tile title="Release dry-run">
-        <p className="text-sm text-red-500">
+      <Tile title="Release dry-run" accent="failure">
+        <p className="text-sm text-signal-stop">
           Failed to read release inputs: {(err as Error).message}
         </p>
       </Tile>
@@ -62,32 +61,38 @@ export async function ReleaseDryRun() {
   }
 
   const plan = buildReleasePlan({ changesets, currentVersions });
+  const commitUrl = `https://github.com/${INSPECTOR.owner}/${INSPECTOR.repo}/commit/${head.sha}`;
   const titleAction = (
-    <a
-      href={`https://github.com/${INSPECTOR.owner}/${INSPECTOR.repo}/commit/${head.sha}`}
-      target="_blank"
-      rel="noreferrer"
-      className="font-mono hover:underline"
-    >
-      main @ {shortSha(head.sha)}
-    </a>
+    <TileAction href={commitUrl}>main @ {shortSha(head.sha)}</TileAction>
   );
 
   if (plan.packages.length === 0) {
     return (
-      <Tile title="Release dry-run" action={titleAction}>
-        <p className="text-sm text-neutral-500">
-          No pending changesets. `npx changeset status` would report zero
-          releases, and the Release workflow would fail preflight.
+      <Tile
+        title="Release dry-run"
+        eyebrow="Nothing to publish"
+        accent="warning"
+        action={titleAction}
+      >
+        <p className="text-sm leading-relaxed text-ink-400">
+          No pending changesets.{" "}
+          <code className="font-mono text-ink-200">npx changeset status</code>{" "}
+          would report zero releases, and the Release workflow would fail
+          preflight.
         </p>
       </Tile>
     );
   }
 
   return (
-    <Tile title="Release dry-run" action={titleAction}>
-      <div className="space-y-4">
-        <ul className="space-y-3">
+    <Tile
+      title="Release dry-run"
+      eyebrow={`${plan.packages.length} package${plan.packages.length === 1 ? "" : "s"} would bump`}
+      accent="info"
+      action={titleAction}
+    >
+      <div className="space-y-5">
+        <ul className="space-y-4">
           {plan.packages.map((pkg) => (
             <PackageRow
               key={pkg.name}
@@ -99,22 +104,25 @@ export async function ReleaseDryRun() {
           ))}
         </ul>
 
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-t border-neutral-100 pt-3 text-xs text-neutral-500 dark:border-neutral-900">
-          {plan.releaseTag ? (
-            <span>
-              Tag: <span className="font-mono text-neutral-700 dark:text-neutral-200">{plan.releaseTag}</span>
-            </span>
-          ) : (
-            <span>Tag: none (no inspector bump)</span>
-          )}
+        <div className="hairline" />
+
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-xs text-ink-400">
           <span>
-            Desktop artifacts:{" "}
-            <span className="font-medium text-neutral-700 dark:text-neutral-200">
-              {plan.buildDesktopArtifacts ? "yes (mac + windows)" : "no"}
+            <span className="text-ink-500">Tag</span>:{" "}
+            {plan.releaseTag ? (
+              <span className="font-mono text-ink-100">{plan.releaseTag}</span>
+            ) : (
+              <span className="text-ink-500">none (no inspector bump)</span>
+            )}
+          </span>
+          <span>
+            <span className="text-ink-500">Desktop artifacts</span>:{" "}
+            <span className="text-ink-100">
+              {plan.buildDesktopArtifacts ? "mac + windows" : "no"}
             </span>
           </span>
           <span className="flex items-center gap-1.5">
-            Valid scopes:
+            <span className="text-ink-500">Valid scopes</span>:
             {plan.validScopes.length === 0 ? (
               <Badge tone="failure">none</Badge>
             ) : (
@@ -138,31 +146,36 @@ function PackageRow({
   pkg: PackageBumpPlan;
   notesByChangeset: Record<string, string>;
 }) {
+  const bumpTone =
+    pkg.bumpType === "major"
+      ? "warning"
+      : pkg.bumpType === "minor"
+        ? "info"
+        : "neutral";
   return (
     <li className="space-y-1.5">
-      <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-sm">
-        <span className="font-mono text-neutral-700 dark:text-neutral-200">
-          {pkg.name}
-        </span>
-        <span className="font-mono text-xs text-neutral-400">
+      <div className="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
+        <span className="font-mono text-sm text-ink-100">{pkg.name}</span>
+        <span className="font-mono text-xs text-ink-500 tabular-nums">
           {pkg.currentVersion}
         </span>
-        <span className="text-xs text-neutral-400">→</span>
-        <span className="font-mono text-xs font-semibold text-neutral-700 dark:text-neutral-200">
+        <span className="text-xs text-ink-600">→</span>
+        <span className="font-mono text-xs font-semibold text-signal-go tabular-nums">
           {pkg.newVersion}
         </span>
-        <Badge tone={pkg.bumpType === "major" ? "warning" : pkg.bumpType === "minor" ? "info" : "neutral"}>
-          {pkg.bumpType}
-        </Badge>
+        <Badge tone={bumpTone}>{pkg.bumpType}</Badge>
       </div>
-      <ul className="ml-0 space-y-1 pl-0">
+      <ul className="space-y-1 border-l border-ink-800 pl-3">
         {pkg.changesets.map((csName) => {
           const note = notesByChangeset[csName]?.trim() ?? "";
           const firstLine = note.split(/\r?\n/)[0] || "(no description)";
           return (
-            <li key={csName} className="flex gap-2 text-xs text-neutral-500">
-              <span className="font-mono text-neutral-400">{csName}</span>
-              <span className="text-neutral-500">— {firstLine}</span>
+            <li
+              key={csName}
+              className="flex gap-2 text-xs leading-relaxed text-ink-400"
+            >
+              <span className="font-mono text-ink-500">{csName}</span>
+              <span className="text-ink-300">— {firstLine}</span>
             </li>
           );
         })}

--- a/soundcheck/src/components/release-progress.tsx
+++ b/soundcheck/src/components/release-progress.tsx
@@ -19,7 +19,14 @@ import {
   type WorkflowJob,
   type WorkflowRun
 } from "@/lib/github";
-import { Badge, StatusDot, Tile, type StatusTone } from "@/components/ui";
+import {
+  Badge,
+  Sha,
+  StatusDot,
+  Tile,
+  TileAction,
+  type StatusTone
+} from "@/components/ui";
 import { formatElapsed, formatRelativeTime, shortSha } from "@/lib/format";
 import { ReleaseProgressRefresher } from "@/components/release-progress-refresher";
 
@@ -40,8 +47,8 @@ const JOB_ORDER = [
 
 export function ReleaseProgressSkeleton() {
   return (
-    <Tile title="Release progress">
-      <p className="text-sm text-neutral-400">Checking for an active run…</p>
+    <Tile title="Release progress" eyebrow="Checking…">
+      <p className="text-sm text-ink-400">Checking for an active run…</p>
     </Tile>
   );
 }
@@ -70,8 +77,8 @@ export async function ReleaseProgress() {
     activeRun = inProgress[0] ?? queued[0] ?? null;
   } catch (err) {
     return (
-      <Tile title="Release progress">
-        <p className="text-sm text-red-500">
+      <Tile title="Release progress" accent="failure">
+        <p className="text-sm text-signal-stop">
           Failed to read workflow runs: {(err as Error).message}
         </p>
       </Tile>
@@ -99,8 +106,8 @@ export async function ReleaseProgress() {
     }
     if (!last) {
       return (
-        <Tile title="Release progress">
-          <p className="text-sm text-neutral-500">
+        <Tile title="Release progress" eyebrow="No runs yet">
+          <p className="text-sm text-ink-400">
             No release.yml runs on record yet.
           </p>
         </Tile>
@@ -120,8 +127,8 @@ export async function ReleaseProgress() {
     );
   } catch (err) {
     return (
-      <Tile title="Release progress">
-        <p className="text-sm text-red-500">
+      <Tile title="Release progress" accent="failure">
+        <p className="text-sm text-signal-stop">
           Active run {activeRun.id}, but failed to read jobs: {(err as Error).message}
         </p>
       </Tile>
@@ -131,30 +138,30 @@ export async function ReleaseProgress() {
   return (
     <Tile
       title="Release progress"
+      eyebrow="Live run"
+      accent="running"
       action={
-        <a
-          href={activeRun.htmlUrl}
-          target="_blank"
-          rel="noreferrer"
-          className="hover:underline"
-        >
-          Run #{activeRun.id} ↗
-        </a>
+        <TileAction href={activeRun.htmlUrl}>Run #{activeRun.id}</TileAction>
       }
     >
-      <div className="mb-3 flex flex-wrap items-baseline gap-x-3 text-xs text-neutral-500">
+      <div className="mb-5 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-ink-400">
         <Badge tone="running">running</Badge>
         <span>
-          on{" "}
-          <span className="font-mono text-neutral-700 dark:text-neutral-200">
+          <span className="font-mono text-ink-200">
             {activeRun.headBranch ?? "main"}
           </span>{" "}
-          @{" "}
-          <span className="font-mono">{shortSha(activeRun.headSha)}</span>
+          @ <Sha sha={shortSha(activeRun.headSha)} />
         </span>
-        {activeRun.actor ? <span>triggered by {activeRun.actor}</span> : null}
+        {activeRun.actor ? (
+          <span className="text-ink-500">
+            triggered by{" "}
+            <span className="text-ink-200">{activeRun.actor}</span>
+          </span>
+        ) : null}
         {activeRun.runStartedAt ? (
-          <span>started {formatRelativeTime(activeRun.runStartedAt)}</span>
+          <span className="text-ink-500">
+            started {formatRelativeTime(activeRun.runStartedAt)}
+          </span>
         ) : null}
       </div>
 
@@ -176,38 +183,37 @@ function CompletedRunTile({ run }: { run: WorkflowRun }) {
   return (
     <Tile
       title="Release progress"
-      action={
-        <a
-          href={run.htmlUrl}
-          target="_blank"
-          rel="noreferrer"
-          className="hover:underline"
-        >
-          Run #{run.id} ↗
-        </a>
-      }
+      eyebrow="No active run — showing last completed"
+      accent={tone}
+      action={<TileAction href={run.htmlUrl}>Run #{run.id}</TileAction>}
     >
-      <div className="flex flex-wrap items-baseline gap-x-3 text-sm text-neutral-500">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm">
         <Badge tone={tone}>{run.conclusion ?? "unknown"}</Badge>
-        <span className="text-neutral-700 dark:text-neutral-200">
+        <span className="text-ink-200">
           {run.displayTitle || "release.yml"}
         </span>
-        <span>
-          on <span className="font-mono">{shortSha(run.headSha)}</span>
+        <span className="text-xs text-ink-400">
+          on <Sha sha={shortSha(run.headSha)} />
         </span>
-        <span>finished {formatRelativeTime(run.updatedAt)}</span>
-        {run.actor ? <span>by {run.actor}</span> : null}
+        <span className="text-xs text-ink-500">
+          finished {formatRelativeTime(run.updatedAt)}
+        </span>
+        {run.actor ? (
+          <span className="text-xs text-ink-500">
+            by <span className="text-ink-200">{run.actor}</span>
+          </span>
+        ) : null}
       </div>
-      <p className="mt-3 text-xs text-neutral-500">
-        No release.yml run currently in-flight. Trigger one from the panel
-        below or{" "}
+      <p className="mt-4 text-xs leading-relaxed text-ink-400">
+        No release.yml run currently in flight. Trigger one from the panel in
+        the previous section, or{" "}
         <a
           href={`https://github.com/${INSPECTOR.owner}/${INSPECTOR.repo}/actions/workflows/${RELEASE_WORKFLOW}`}
           target="_blank"
           rel="noreferrer"
-          className="hover:underline"
+          className="text-ink-200 underline underline-offset-4 decoration-ink-600 hover:text-signal-wait"
         >
-          from GitHub
+          open on GitHub
         </a>
         .
       </p>
@@ -224,7 +230,12 @@ function JobStepper({ jobs }: { jobs: WorkflowJob[] }) {
   const unknown = jobs.filter((j) => !JOB_ORDER.includes(j.name));
 
   return (
-    <ol className="space-y-1.5">
+    <ol className="relative space-y-0.5">
+      {/* connecting rail behind the dots */}
+      <div
+        className="pointer-events-none absolute bottom-2 left-[3px] top-2 w-px bg-ink-800/80"
+        aria-hidden
+      />
       {known.map(({ name, job }) => (
         <JobRow key={name} name={name} job={job} />
       ))}
@@ -238,23 +249,29 @@ function JobStepper({ jobs }: { jobs: WorkflowJob[] }) {
 function JobRow({ name, job }: { name: string; job: WorkflowJob | null }) {
   if (!job) {
     return (
-      <li className="flex items-center gap-3 text-sm text-neutral-500">
-        <StatusDot tone="neutral" />
-        <span className="font-mono text-xs">{name}</span>
-        <span className="text-xs text-neutral-400">pending / not scheduled</span>
+      <li className="relative flex items-center gap-3 py-1.5 pl-0 text-sm">
+        <span className="relative z-10 bg-[var(--bg-panel)] pr-0.5">
+          <StatusDot tone="neutral" />
+        </span>
+        <span className="font-mono text-xs text-ink-400">{name}</span>
+        <span className="text-[11px] uppercase tracking-wider text-ink-500">
+          pending
+        </span>
       </li>
     );
   }
   const tone = jobTone(job);
   const elapsed = formatElapsed(job.startedAt, job.completedAt);
   return (
-    <li className="flex items-center gap-3 text-sm">
-      <StatusDot tone={tone} />
+    <li className="relative flex items-center gap-3 py-1.5 pl-0 text-sm">
+      <span className="relative z-10 bg-[var(--bg-panel)] pr-0.5">
+        <StatusDot tone={tone} />
+      </span>
       <a
         href={job.htmlUrl}
         target="_blank"
         rel="noreferrer"
-        className="font-mono text-xs text-neutral-700 hover:underline dark:text-neutral-200"
+        className="font-mono text-xs text-ink-100 hover:text-signal-wait hover:underline underline-offset-4 decoration-ink-600"
       >
         {job.name}
       </a>
@@ -262,7 +279,9 @@ function JobRow({ name, job }: { name: string; job: WorkflowJob | null }) {
         {job.status === "completed" ? job.conclusion ?? "done" : job.status}
       </Badge>
       {elapsed ? (
-        <span className="text-xs text-neutral-500">{elapsed}</span>
+        <span className="font-mono text-[11px] text-ink-500 tabular-nums">
+          {elapsed}
+        </span>
       ) : null}
       {tone === "failure" ? <FailingStep job={job} /> : null}
     </li>
@@ -278,7 +297,7 @@ function FailingStep({ job }: { job: WorkflowJob }) {
   );
   if (!failing) return null;
   return (
-    <span className="text-xs text-red-500">
+    <span className="text-xs text-signal-stop">
       failed at step {failing.number}: {failing.name}
     </span>
   );

--- a/soundcheck/src/components/release-progress.tsx
+++ b/soundcheck/src/components/release-progress.tsx
@@ -97,8 +97,8 @@ export async function ReleaseProgress() {
       );
     } catch (err) {
       return (
-        <Tile title="Release progress">
-          <p className="text-sm text-red-500">
+        <Tile title="Release progress" accent="failure">
+          <p className="text-sm text-signal-stop">
             Failed to read workflow runs: {(err as Error).message}
           </p>
         </Tile>

--- a/soundcheck/src/components/release-readiness.tsx
+++ b/soundcheck/src/components/release-readiness.tsx
@@ -40,18 +40,18 @@ interface CheckRow {
 
 function Row({ row }: { row: CheckRow }) {
   return (
-    <li className="flex items-start gap-3 py-1.5">
+    <li className="group flex items-start gap-4 py-3">
       <span className="mt-1.5 shrink-0">
         <StatusDot tone={row.tone} />
       </span>
       <div className="min-w-0 flex-1">
-        <div className="text-sm text-neutral-700 dark:text-neutral-200">
+        <div className="text-sm text-ink-100">
           {row.href ? (
             <a
               href={row.href}
               target="_blank"
               rel="noreferrer"
-              className="hover:underline"
+              className="transition-colors group-hover:text-signal-wait hover:underline underline-offset-4 decoration-ink-700"
             >
               {row.label}
             </a>
@@ -59,7 +59,9 @@ function Row({ row }: { row: CheckRow }) {
             row.label
           )}
         </div>
-        <div className="text-xs text-neutral-500">{row.detail}</div>
+        <div className="mt-0.5 text-xs leading-relaxed text-ink-400">
+          {row.detail}
+        </div>
       </div>
     </li>
   );
@@ -67,8 +69,8 @@ function Row({ row }: { row: CheckRow }) {
 
 export function ReleaseReadinessSkeleton() {
   return (
-    <Tile title="Release readiness">
-      <p className="text-sm text-neutral-400">Loading checks…</p>
+    <Tile title="Release readiness" eyebrow="Preflight mirror">
+      <p className="text-sm text-ink-400">Loading checks…</p>
     </Tile>
   );
 }
@@ -221,9 +223,23 @@ export async function ReleaseReadiness() {
     });
   }
 
+  // Derive a top-line tile accent from the rows: red beats amber beats neutral.
+  const hasFailure = rows.some((r) => r.tone === "failure");
+  const hasWarning = rows.some((r) => r.tone === "warning");
+  const accent = hasFailure ? "failure" : hasWarning ? "warning" : "success";
+  const summary = hasFailure
+    ? "Preflight will fail — see blockers below."
+    : hasWarning
+      ? "Preflight will pass, but check the nudges."
+      : "All checks green. You can ship.";
+
   return (
-    <Tile title="Release readiness">
-      <ul className="-mt-1 divide-y divide-neutral-100 dark:divide-neutral-900">
+    <Tile
+      title="Release readiness"
+      eyebrow={summary}
+      accent={accent}
+    >
+      <ul className="-mt-1 divide-y divide-ink-800/60">
         {rows.map((row, i) => (
           <Row key={i} row={row} />
         ))}

--- a/soundcheck/src/components/release-verdict.tsx
+++ b/soundcheck/src/components/release-verdict.tsx
@@ -1,0 +1,133 @@
+/**
+ * Release Verdict strip. Answers "can I ship right now?" in one glance,
+ * before the operator reads anything else below it.
+ *
+ * Inputs, in priority order:
+ *   1. Is a release.yml run already in flight? → In flight.
+ *   2. Is inspector main at a SHA with a green deploy-staging.yml?
+ *      + Are there pending changesets?  → Go.
+ *   3. Otherwise describe the blocker. → Hold / Caution.
+ *
+ * This component does its own fetches rather than reading from the readiness
+ * tile, so the verdict renders even if the readiness tile is still streaming.
+ */
+
+import {
+  findSuccessfulRunForSha,
+  getBranchHead,
+  listWorkflowRuns
+} from "@/lib/github";
+import { fetchPendingChangesets } from "@/lib/changesets";
+import { shortSha } from "@/lib/format";
+import { Verdict } from "@/components/ui";
+
+const INSPECTOR = { owner: "MCPJam", repo: "inspector" };
+
+export function ReleaseVerdictSkeleton() {
+  return (
+    <div className="panel p-6 md:p-8">
+      <div className="text-[10px] font-medium uppercase tracking-[0.18em] text-ink-500">
+        Release verdict
+      </div>
+      <div className="mt-2 flex items-baseline gap-3">
+        <span className="display-hero text-2xl md:text-3xl text-ink-400">
+          Reading…
+        </span>
+        <span className="text-sm text-ink-500">Checking main &amp; staging</span>
+      </div>
+    </div>
+  );
+}
+
+export async function ReleaseVerdict() {
+  // 1. Active release run?
+  try {
+    const [inProgress, queued] = await Promise.all([
+      listWorkflowRuns(INSPECTOR.owner, INSPECTOR.repo, "release.yml", {
+        status: "in_progress",
+        perPage: 1,
+        revalidate: 10
+      }),
+      listWorkflowRuns(INSPECTOR.owner, INSPECTOR.repo, "release.yml", {
+        status: "queued",
+        perPage: 1,
+        revalidate: 10
+      })
+    ]);
+    const active = inProgress[0] ?? queued[0];
+    if (active) {
+      return (
+        <Verdict
+          tone="running"
+          headline="A release is already running."
+          detail={`release.yml is ${inProgress[0] ? "in progress" : "queued"} on ${shortSha(active.headSha)}${active.actor ? ` — triggered by ${active.actor}` : ""}. Watch the stepper below.`}
+        />
+      );
+    }
+  } catch {
+    /* fall through — we still want to render a verdict if this single read fails */
+  }
+
+  // 2. Staging green for main HEAD + pending changesets?
+  let headSha: string | null = null;
+  try {
+    const head = await getBranchHead(
+      INSPECTOR.owner,
+      INSPECTOR.repo,
+      "main"
+    );
+    headSha = head.sha;
+  } catch (err) {
+    return (
+      <Verdict
+        tone="warning"
+        headline="Can't read main."
+        detail={(err as Error).message}
+      />
+    );
+  }
+
+  const [stagingRun, changesets] = await Promise.all([
+    findSuccessfulRunForSha(
+      INSPECTOR.owner,
+      INSPECTOR.repo,
+      "deploy-staging.yml",
+      "main",
+      headSha
+    ).catch(() => null),
+    fetchPendingChangesets(INSPECTOR.owner, INSPECTOR.repo, headSha).catch(
+      () => null
+    )
+  ]);
+
+  if (!stagingRun) {
+    return (
+      <Verdict
+        tone="failure"
+        headline={`Hold — staging isn't green for ${shortSha(headSha)}.`}
+        detail="release.yml preflight will refuse until deploy-staging.yml succeeds on this exact SHA. Wait for it, or investigate recent failures below."
+      />
+    );
+  }
+
+  if (!changesets || changesets.length === 0) {
+    return (
+      <Verdict
+        tone="warning"
+        headline="No pending changesets on main."
+        detail={`Staging is green on ${shortSha(headSha)}, but there's nothing to publish. release.yml preflight will exit with no plan.`}
+      />
+    );
+  }
+
+  const pkgCount = new Set(
+    changesets.flatMap((c) => Object.keys(c.bumps))
+  ).size;
+  return (
+    <Verdict
+      tone="success"
+      headline="Go — all preflight gates are clear."
+      detail={`Staging is green on ${shortSha(headSha)}. ${changesets.length} pending changeset${changesets.length === 1 ? "" : "s"} across ${pkgCount} package${pkgCount === 1 ? "" : "s"}. Dispatch when ready.`}
+    />
+  );
+}

--- a/soundcheck/src/components/release-verdict.tsx
+++ b/soundcheck/src/components/release-verdict.tsx
@@ -87,7 +87,7 @@ export async function ReleaseVerdict() {
     );
   }
 
-  const [stagingRun, changesets] = await Promise.all([
+  const [stagingRun, changesetsResult] = await Promise.all([
     findSuccessfulRunForSha(
       INSPECTOR.owner,
       INSPECTOR.repo,
@@ -95,22 +95,39 @@ export async function ReleaseVerdict() {
       "main",
       headSha
     ).catch(() => null),
-    fetchPendingChangesets(INSPECTOR.owner, INSPECTOR.repo, headSha).catch(
-      () => null
-    )
+    // Keep fetch errors distinct from "zero changesets": both would render as
+    // "nothing to publish" otherwise, and a silent API failure would let the
+    // verdict confidently lie.
+    fetchPendingChangesets(INSPECTOR.owner, INSPECTOR.repo, headSha)
+      .then((list) => ({ kind: "ok" as const, list }))
+      .catch((err: unknown) => ({
+        kind: "error" as const,
+        message: (err as Error).message
+      }))
   ]);
 
   if (!stagingRun) {
     return (
       <Verdict
         tone="failure"
-        headline={`Hold — staging isn't green for ${shortSha(headSha)}.`}
+        headline={`Staging isn't green for ${shortSha(headSha)}.`}
         detail="release.yml preflight will refuse until deploy-staging.yml succeeds on this exact SHA. Wait for it, or investigate recent failures below."
       />
     );
   }
 
-  if (!changesets || changesets.length === 0) {
+  if (changesetsResult.kind === "error") {
+    return (
+      <Verdict
+        tone="warning"
+        headline="Can't read pending changesets."
+        detail={`Staging is green on ${shortSha(headSha)}, but the changeset lookup failed: ${changesetsResult.message}. Check the readiness tile below.`}
+      />
+    );
+  }
+
+  const changesets = changesetsResult.list;
+  if (changesets.length === 0) {
     return (
       <Verdict
         tone="warning"
@@ -126,7 +143,7 @@ export async function ReleaseVerdict() {
   return (
     <Verdict
       tone="success"
-      headline="Go — all preflight gates are clear."
+      headline="All preflight gates are clear."
       detail={`Staging is green on ${shortSha(headSha)}. ${changesets.length} pending changeset${changesets.length === 1 ? "" : "s"} across ${pkgCount} package${pkgCount === 1 ? "" : "s"}. Dispatch when ready.`}
     />
   );

--- a/soundcheck/src/components/run-release.tsx
+++ b/soundcheck/src/components/run-release.tsx
@@ -90,23 +90,29 @@ export function RunRelease() {
   }
 
   return (
-    <Tile title="Run release">
-      <p className="mb-3 text-xs text-neutral-500">
-        Dispatches <span className="font-mono">release.yml</span> on{" "}
-        <span className="font-mono">main</span>. This is the one path to
-        production.
+    <Tile
+      title="Run release"
+      eyebrow="The one path to production"
+      accent={impactsProd ? "warning" : "info"}
+    >
+      <p className="mb-5 text-xs leading-relaxed text-ink-400">
+        Dispatches{" "}
+        <span className="font-mono text-ink-200">release.yml</span> on{" "}
+        <span className="font-mono text-ink-200">main</span>. Confirmation
+        required; the server re-checks your email before touching the write
+        token.
       </p>
 
-      <div className="space-y-4">
+      <div className="space-y-5">
         <fieldset className="space-y-2">
-          <legend className="text-xs font-medium text-neutral-700 dark:text-neutral-200">
-            scope
+          <legend className="mb-2 text-[10px] font-medium uppercase tracking-[0.14em] text-ink-500">
+            Scope
           </legend>
-          <div className="space-y-1.5">
+          <div className="space-y-2">
             {(["full", "packages-only", "inspector-only"] as const).map((s) => (
               <label
                 key={s}
-                className="flex cursor-pointer items-center gap-2 text-sm"
+                className={`flex cursor-pointer items-center gap-3 rounded-lg border px-3 py-2 text-sm transition-colors ${scope === s ? "border-signal-wait/40 bg-signal-wait/5" : "border-ink-800 hover:border-ink-700 hover:bg-ink-800/30"}`}
               >
                 <input
                   type="radio"
@@ -114,73 +120,81 @@ export function RunRelease() {
                   value={s}
                   checked={scope === s}
                   onChange={() => changeScope(s)}
-                  className="accent-neutral-800 dark:accent-neutral-200"
+                  className="accent-signal-wait"
                 />
-                <span className="font-mono text-xs text-neutral-700 dark:text-neutral-200">
-                  {s}
-                </span>
-                <span className="text-xs text-neutral-500">{SCOPE_HINT[s]}</span>
+                <span className="font-mono text-xs text-ink-100">{s}</span>
+                <span className="text-xs text-ink-400">{SCOPE_HINT[s]}</span>
               </label>
             ))}
           </div>
         </fieldset>
 
-        <div className="space-y-1.5">
-          <label className="flex cursor-pointer items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={deployBackend}
-              onChange={(e) => setDeployBackend(e.target.checked)}
-              className="accent-neutral-800 dark:accent-neutral-200"
-              disabled={scope !== "full"}
-            />
-            <span className="font-mono text-xs text-neutral-700 dark:text-neutral-200">
-              deploy_backend_prod
-            </span>
-            <span className="text-xs text-neutral-500">
-              dispatch backend prod deploy (scope=full only)
-            </span>
-          </label>
-          <label className="flex cursor-pointer items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={promoteProd}
-              onChange={(e) => setPromoteProd(e.target.checked)}
-              className="accent-neutral-800 dark:accent-neutral-200"
-              disabled={scope === "packages-only"}
-            />
-            <span className="font-mono text-xs text-neutral-700 dark:text-neutral-200">
-              promote_production
-            </span>
-            <span className="text-xs text-neutral-500">
-              deploy inspector to Railway prod after publish
-            </span>
-          </label>
-        </div>
+        <fieldset className="space-y-2">
+          <legend className="mb-2 text-[10px] font-medium uppercase tracking-[0.14em] text-ink-500">
+            Production flags
+          </legend>
+          <div className="space-y-2">
+            <label className={`flex cursor-pointer items-start gap-3 rounded-lg border border-ink-800 px-3 py-2 text-sm ${scope !== "full" ? "opacity-50" : "hover:border-ink-700"}`}>
+              <input
+                type="checkbox"
+                checked={deployBackend}
+                onChange={(e) => setDeployBackend(e.target.checked)}
+                className="mt-0.5 accent-signal-wait"
+                disabled={scope !== "full"}
+              />
+              <div className="min-w-0">
+                <div className="font-mono text-xs text-ink-100">
+                  deploy_backend_prod
+                </div>
+                <div className="mt-0.5 text-xs text-ink-400">
+                  Dispatch backend production deploy (scope=full only).
+                </div>
+              </div>
+            </label>
+            <label className={`flex cursor-pointer items-start gap-3 rounded-lg border border-ink-800 px-3 py-2 text-sm ${scope === "packages-only" ? "opacity-50" : "hover:border-ink-700"}`}>
+              <input
+                type="checkbox"
+                checked={promoteProd}
+                onChange={(e) => setPromoteProd(e.target.checked)}
+                className="mt-0.5 accent-signal-wait"
+                disabled={scope === "packages-only"}
+              />
+              <div className="min-w-0">
+                <div className="font-mono text-xs text-ink-100">
+                  promote_production
+                </div>
+                <div className="mt-0.5 text-xs text-ink-400">
+                  Deploy inspector to Railway prod after publish.
+                </div>
+              </div>
+            </label>
+          </div>
+        </fieldset>
 
         {impactsProd ? (
-          <div className="rounded border border-amber-500/30 bg-amber-500/5 p-2 text-xs text-amber-700 dark:text-amber-400">
-            This run will touch production.
+          <div className="rounded-lg border border-signal-wait/30 bg-signal-wait/5 px-3 py-2 text-xs text-signal-wait">
+            <span className="font-medium">Heads up —</span> this run will
+            touch production.
           </div>
         ) : null}
 
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-3 pt-1">
           <button
             type="button"
             onClick={onSubmit}
             disabled={isPending}
-            className="rounded bg-neutral-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-neutral-700 disabled:opacity-50 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-white"
+            className={`rounded-full px-5 py-2 text-xs font-medium tracking-wide transition-all disabled:opacity-50 ${impactsProd ? "bg-signal-wait text-ink-950 hover:bg-signal-wait/90 shadow-[0_0_20px_-5px_rgba(232,195,102,0.6)]" : "bg-ink-100 text-ink-950 hover:bg-white"}`}
           >
-            Run release…
+            Run release →
           </button>
           {feedback.kind === "ok" ? (
-            <Badge tone="success">dispatched</Badge>
+            <>
+              <Badge tone="success">dispatched</Badge>
+              <span className="text-xs text-ink-400">{feedback.message}</span>
+            </>
           ) : null}
           {feedback.kind === "error" ? (
-            <span className="text-xs text-red-500">{feedback.message}</span>
-          ) : null}
-          {feedback.kind === "ok" ? (
-            <span className="text-xs text-neutral-500">{feedback.message}</span>
+            <span className="text-xs text-signal-stop">{feedback.message}</span>
           ) : null}
         </div>
       </div>
@@ -256,60 +270,75 @@ function ConfirmModal({
     return () => window.removeEventListener("keydown", onKey);
   }, [busy, onCancel]);
 
+  const impactsProd = deployBackend || promoteProd;
   return (
     <div
       role="dialog"
       aria-modal="true"
       aria-labelledby="confirm-release-title"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/75 backdrop-blur-sm p-4"
     >
       <div
         ref={dialogRef}
-        className="w-full max-w-md rounded-lg border border-neutral-200 bg-white p-6 text-neutral-900 shadow-xl dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-100"
+        className={`panel w-full max-w-md p-7 text-ink-100 ${impactsProd ? "panel-accent-wait" : "panel-accent-info"}`}
       >
-        <h2 id="confirm-release-title" className="text-base font-semibold">
-          Confirm release dispatch
+        <div className="text-[10px] font-medium uppercase tracking-[0.18em] text-ink-500">
+          Final confirmation
+        </div>
+        <h2
+          id="confirm-release-title"
+          className="display-hero mt-1 text-2xl text-ink-100"
+        >
+          Dispatch{" "}
+          <span className="font-mono text-[0.85em]">release.yml</span>?
         </h2>
-        <p className="mt-2 text-sm text-neutral-600 dark:text-neutral-400">
-          This will dispatch{" "}
-          <span className="font-mono">release.yml</span> on{" "}
-          <span className="font-mono">main</span> with:
+        <p className="mt-3 text-sm leading-relaxed text-ink-400">
+          Fires on{" "}
+          <span className="font-mono text-ink-200">main</span> with these
+          inputs:
         </p>
-        <ul className="mt-3 space-y-1 text-sm">
-          <li>
-            <span className="font-mono text-xs text-neutral-500">scope</span>:{" "}
-            <span className="font-mono font-semibold">{scope}</span>
-          </li>
-          <li>
-            <span className="font-mono text-xs text-neutral-500">
+
+        <dl className="mt-4 space-y-2 border-l border-ink-800 pl-4 text-sm">
+          <div className="flex gap-3">
+            <dt className="w-44 font-mono text-xs text-ink-500">scope</dt>
+            <dd className="font-mono text-xs text-ink-100">{scope}</dd>
+          </div>
+          <div className="flex gap-3">
+            <dt className="w-44 font-mono text-xs text-ink-500">
               deploy_backend_prod
-            </span>
-            :{" "}
-            <span className="font-mono font-semibold">
+            </dt>
+            <dd
+              className={`font-mono text-xs ${deployBackend ? "text-signal-wait" : "text-ink-400"}`}
+            >
               {String(deployBackend)}
-            </span>
-          </li>
-          <li>
-            <span className="font-mono text-xs text-neutral-500">
+            </dd>
+          </div>
+          <div className="flex gap-3">
+            <dt className="w-44 font-mono text-xs text-ink-500">
               promote_production
-            </span>
-            :{" "}
-            <span className="font-mono font-semibold">{String(promoteProd)}</span>
-          </li>
-        </ul>
-        {(deployBackend || promoteProd) ? (
-          <p className="mt-4 rounded border border-amber-500/30 bg-amber-500/5 p-2 text-xs text-amber-700 dark:text-amber-400">
+            </dt>
+            <dd
+              className={`font-mono text-xs ${promoteProd ? "text-signal-wait" : "text-ink-400"}`}
+            >
+              {String(promoteProd)}
+            </dd>
+          </div>
+        </dl>
+
+        {impactsProd ? (
+          <p className="mt-5 rounded-lg border border-signal-wait/30 bg-signal-wait/5 px-3 py-2.5 text-xs leading-relaxed text-signal-wait">
             This is the one path to production. Release.yml will refuse to run
             unless deploy-staging.yml is green for the current main SHA.
           </p>
         ) : null}
-        <div className="mt-6 flex justify-end gap-2">
+
+        <div className="mt-7 flex justify-end gap-2">
           <button
             ref={cancelRef}
             type="button"
             onClick={onCancel}
             disabled={busy}
-            className="rounded border border-neutral-200 px-3 py-1.5 text-xs font-medium text-neutral-700 hover:bg-neutral-100 disabled:opacity-50 dark:border-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-900"
+            className="rounded-full border border-ink-700 px-4 py-2 text-xs font-medium text-ink-200 transition-colors hover:bg-ink-800 disabled:opacity-50"
           >
             Cancel
           </button>
@@ -317,9 +346,9 @@ function ConfirmModal({
             type="button"
             onClick={onConfirm}
             disabled={busy}
-            className="rounded bg-neutral-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-neutral-700 disabled:opacity-50 dark:bg-neutral-100 dark:text-neutral-900 dark:hover:bg-white"
+            className={`rounded-full px-5 py-2 text-xs font-medium tracking-wide transition-all disabled:opacity-50 ${impactsProd ? "bg-signal-wait text-ink-950 hover:bg-signal-wait/90 shadow-[0_0_20px_-5px_rgba(232,195,102,0.6)]" : "bg-ink-100 text-ink-950 hover:bg-white"}`}
           >
-            {busy ? "Dispatching…" : "Dispatch release"}
+            {busy ? "Dispatching…" : "Dispatch release →"}
           </button>
         </div>
       </div>

--- a/soundcheck/src/components/run-release.tsx
+++ b/soundcheck/src/components/run-release.tsx
@@ -41,6 +41,19 @@ export function RunRelease() {
     setScope(next);
     if (next !== "full") setDeployBackend(false);
     if (next === "packages-only") setPromoteProd(false);
+    // Any edit to the form is implicitly "I'm preparing the next dispatch" —
+    // clear stale success/error feedback from an earlier run so the chip
+    // next to the button always reflects the current form state.
+    setFeedback({ kind: "idle" });
+  }
+
+  function changeDeployBackend(v: boolean) {
+    setDeployBackend(v);
+    setFeedback({ kind: "idle" });
+  }
+  function changePromoteProd(v: boolean) {
+    setPromoteProd(v);
+    setFeedback({ kind: "idle" });
   }
 
   function onSubmit() {
@@ -138,7 +151,7 @@ export function RunRelease() {
               <input
                 type="checkbox"
                 checked={deployBackend}
-                onChange={(e) => setDeployBackend(e.target.checked)}
+                onChange={(e) => changeDeployBackend(e.target.checked)}
                 className="mt-0.5 accent-signal-wait"
                 disabled={scope !== "full"}
               />
@@ -155,7 +168,7 @@ export function RunRelease() {
               <input
                 type="checkbox"
                 checked={promoteProd}
-                onChange={(e) => setPromoteProd(e.target.checked)}
+                onChange={(e) => changePromoteProd(e.target.checked)}
                 className="mt-0.5 accent-signal-wait"
                 disabled={scope === "packages-only"}
               />

--- a/soundcheck/src/components/ui.tsx
+++ b/soundcheck/src/components/ui.tsx
@@ -1,88 +1,128 @@
 /**
- * Shared UI primitives for Soundcheck tiles. Keep this tiny — it's only here
- * because the same `<Tile>` shell is now used by 5+ components, and the
- * status dots / badges / monospace commits need to render identically across
- * readiness, progress, failures, and deploy-diff.
+ * Shared UI primitives for Soundcheck tiles. Editorial-meets-ops aesthetic:
+ * warm off-black panels with a hairline edge, display serif for numbers and
+ * verdicts, Geist for body, Geist Mono for SHAs. Status tone is carried via
+ * `.panel-accent-*` on the left edge of tiles and the `.dot-*` glow primitives.
  */
 
 import type { ReactNode } from "react";
 
+export type StatusTone =
+  | "success"
+  | "failure"
+  | "warning"
+  | "info"
+  | "running"
+  | "neutral";
+
+const PANEL_ACCENT: Record<StatusTone, string> = {
+  success: "panel-accent-go",
+  failure: "panel-accent-stop",
+  warning: "panel-accent-wait",
+  info: "panel-accent-info",
+  running: "panel-accent-info",
+  neutral: ""
+};
+
 export function Tile({
   title,
+  eyebrow,
   action,
+  accent = "neutral",
   children
 }: {
   title: string;
-  /** Optional top-right content (usually a "View in GitHub" link). */
+  /** Optional short label above the title, uppercase + tracked. */
+  eyebrow?: string;
+  /** Top-right content (usually a "View ↗" link). */
   action?: ReactNode;
+  /** Tone strip on the left edge; carries the tile's overall status signal. */
+  accent?: StatusTone;
   children: ReactNode;
 }) {
   return (
-    <section className="rounded-lg border border-neutral-200 dark:border-neutral-800 p-6 bg-white/0">
-      <div className="flex items-start justify-between gap-2">
-        <h3 className="text-sm font-medium text-neutral-700 dark:text-neutral-200">
-          {title}
-        </h3>
+    <section
+      className={`panel ${PANEL_ACCENT[accent]} p-6 relative overflow-hidden`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          {eyebrow ? (
+            <div className="mb-1 text-[10px] font-medium uppercase tracking-[0.14em] text-ink-500">
+              {eyebrow}
+            </div>
+          ) : null}
+          <h3 className="text-[15px] font-medium text-ink-100">{title}</h3>
+        </div>
         {action ? (
-          <div className="text-xs text-neutral-400">{action}</div>
+          <div className="shrink-0 text-xs text-ink-400">{action}</div>
         ) : null}
       </div>
-      <div className="mt-3">{children}</div>
+      <div className="mt-4">{children}</div>
     </section>
   );
 }
 
+/**
+ * A numbered editorial section header. Roman numeral dropcap + display-serif
+ * title + muted description. Creates rhythm down the page.
+ */
 export function Section({
+  numeral,
   title,
   description,
   children
 }: {
+  numeral: string;
   title: string;
   description?: string;
   children: ReactNode;
 }) {
   return (
-    <div className="mb-10">
-      <div className="mb-4">
-        <h2 className="text-xs font-semibold uppercase tracking-wide text-neutral-400">
-          {title}
-        </h2>
-        {description ? (
-          <p className="mt-1 text-xs text-neutral-500">{description}</p>
-        ) : null}
-      </div>
-      {children}
-    </div>
+    <section className="mb-14 animate-fade-up">
+      <header className="mb-5 flex items-baseline gap-4">
+        <span className="numeral select-none w-8 shrink-0 text-right">
+          {numeral}
+        </span>
+        <div className="min-w-0 flex-1">
+          <h2 className="display-hero text-[1.65rem] text-ink-100">{title}</h2>
+          {description ? (
+            <p className="mt-1.5 max-w-2xl text-sm leading-relaxed text-ink-400">
+              {description}
+            </p>
+          ) : null}
+        </div>
+      </header>
+      <div className="pl-0 md:pl-12">{children}</div>
+    </section>
   );
 }
 
-export type StatusTone = "success" | "failure" | "warning" | "info" | "running" | "neutral";
-
 const DOT_CLASSES: Record<StatusTone, string> = {
-  success: "bg-emerald-500",
-  failure: "bg-red-500",
-  warning: "bg-amber-500",
-  info: "bg-sky-500",
-  running: "bg-sky-500 animate-pulse",
-  neutral: "bg-neutral-400 dark:bg-neutral-600"
+  success: "dot dot-go",
+  failure: "dot dot-stop",
+  warning: "dot dot-wait",
+  info: "dot dot-info",
+  running: "dot dot-run",
+  neutral: "dot dot-neutral"
 };
 
 export function StatusDot({ tone }: { tone: StatusTone }) {
-  return (
-    <span
-      className={`inline-block h-2 w-2 rounded-full ${DOT_CLASSES[tone]}`}
-      aria-hidden
-    />
-  );
+  return <span className={DOT_CLASSES[tone]} aria-hidden />;
 }
 
 const BADGE_CLASSES: Record<StatusTone, string> = {
-  success: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
-  failure: "bg-red-500/10 text-red-700 dark:text-red-400",
-  warning: "bg-amber-500/10 text-amber-700 dark:text-amber-500",
-  info: "bg-sky-500/10 text-sky-700 dark:text-sky-400",
-  running: "bg-sky-500/10 text-sky-700 dark:text-sky-400",
-  neutral: "bg-neutral-200/60 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400"
+  success:
+    "bg-signal-go/10 text-signal-go ring-1 ring-inset ring-signal-go/25",
+  failure:
+    "bg-signal-stop/10 text-signal-stop ring-1 ring-inset ring-signal-stop/30",
+  warning:
+    "bg-signal-wait/10 text-signal-wait ring-1 ring-inset ring-signal-wait/30",
+  info:
+    "bg-signal-info/10 text-signal-info ring-1 ring-inset ring-signal-info/25",
+  running:
+    "bg-signal-info/10 text-signal-info ring-1 ring-inset ring-signal-info/25",
+  neutral:
+    "bg-ink-800 text-ink-300 ring-1 ring-inset ring-ink-700"
 };
 
 export function Badge({
@@ -94,9 +134,155 @@ export function Badge({
 }) {
   return (
     <span
-      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide ${BADGE_CLASSES[tone]}`}
+      className={`inline-flex items-center rounded-full px-2 py-0.5 font-mono text-[10px] font-medium uppercase tracking-[0.08em] ${BADGE_CLASSES[tone]}`}
     >
       {children}
     </span>
+  );
+}
+
+/**
+ * Big editorial number — used for hero stats like "251 commits behind".
+ * Intentionally huge, intentionally italic-serif. Signals "this is the
+ * headline answer on this tile."
+ */
+export function HeroStat({
+  value,
+  tone = "neutral",
+  label,
+  sublabel,
+  href
+}: {
+  value: string | number;
+  tone?: StatusTone;
+  label: string;
+  sublabel?: ReactNode;
+  href?: string;
+}) {
+  const toneClass =
+    tone === "success"
+      ? "text-signal-go"
+      : tone === "failure"
+        ? "text-signal-stop"
+        : tone === "warning"
+          ? "text-signal-wait"
+          : tone === "info" || tone === "running"
+            ? "text-signal-info"
+            : "text-ink-100";
+  const num = (
+    <span className={`display-hero text-6xl md:text-7xl ${toneClass}`}>
+      {value}
+    </span>
+  );
+  return (
+    <div className="flex items-end gap-4">
+      {href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer"
+          className="transition-opacity hover:opacity-80"
+        >
+          {num}
+        </a>
+      ) : (
+        num
+      )}
+      <div className="pb-2">
+        <div className="text-sm font-medium text-ink-100">{label}</div>
+        {sublabel ? (
+          <div className="mt-0.5 text-xs text-ink-400">{sublabel}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The page-level verdict strip. Answers "can I ship right now?" in one glance,
+ * before the operator has to read anything else.
+ */
+export function Verdict({
+  tone,
+  headline,
+  detail
+}: {
+  tone: StatusTone;
+  headline: string;
+  detail: string;
+}) {
+  const accent = PANEL_ACCENT[tone];
+  const label =
+    tone === "success"
+      ? "Go"
+      : tone === "failure"
+        ? "Hold"
+        : tone === "warning"
+          ? "Caution"
+          : tone === "running"
+            ? "In flight"
+            : "Check";
+  return (
+    <div className={`panel ${accent} px-6 py-5 md:px-8 md:py-6`}>
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex items-center gap-4">
+          <StatusDot tone={tone} />
+          <div>
+            <div className="text-[10px] font-medium uppercase tracking-[0.18em] text-ink-500">
+              Release verdict
+            </div>
+            <div className="mt-0.5 flex items-baseline gap-3">
+              <span className="display-hero text-2xl md:text-3xl text-ink-100">
+                {label}.
+              </span>
+              <span className="text-sm text-ink-200">{headline}</span>
+            </div>
+          </div>
+        </div>
+        <p className="max-w-md text-xs leading-relaxed text-ink-400 md:text-right">
+          {detail}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Inline SHA link — styled as a small mono tag, hover underline.
+ */
+export function Sha({ href, sha }: { href?: string; sha: string }) {
+  if (!href) return <span className="tag-mono">{sha}</span>;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="tag-mono hover:text-ink-100 hover:underline underline-offset-4 decoration-ink-600"
+    >
+      {sha}
+    </a>
+  );
+}
+
+/**
+ * Link action for tile top-right. Small, understated, with a trailing arrow.
+ */
+export function TileAction({
+  href,
+  children
+}: {
+  href: string;
+  children: ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="inline-flex items-center gap-1 text-xs text-ink-400 transition-colors hover:text-ink-100"
+    >
+      {children}
+      <span className="text-ink-500">↗</span>
+    </a>
   );
 }

--- a/soundcheck/tailwind.config.ts
+++ b/soundcheck/tailwind.config.ts
@@ -3,7 +3,50 @@ import type { Config } from "tailwindcss";
 const config: Config = {
   content: ["./src/**/*.{ts,tsx}"],
   theme: {
-    extend: {}
+    extend: {
+      fontFamily: {
+        display: ["var(--font-display)", "Georgia", "serif"],
+        sans: ["var(--font-sans)", "system-ui", "sans-serif"],
+        mono: ["var(--font-mono)", "ui-monospace", "monospace"]
+      },
+      colors: {
+        ink: {
+          950: "#0a0a0c",
+          900: "#0f0f12",
+          850: "#14141a",
+          800: "#1a1a22",
+          750: "#20202a",
+          700: "#2a2a36",
+          600: "#3a3a48",
+          500: "#5a5a68",
+          400: "#7a7a85",
+          300: "#9a9aa0",
+          200: "#c4c4c6",
+          100: "#e8e7e3",
+          50: "#f5f4ef"
+        },
+        signal: {
+          go: "#7fd99a",
+          stop: "#f08d87",
+          wait: "#e8c366",
+          info: "#8cb4d8"
+        }
+      },
+      keyframes: {
+        "pulse-soft": {
+          "0%, 100%": { opacity: "1", transform: "scale(1)" },
+          "50%": { opacity: "0.6", transform: "scale(0.85)" }
+        },
+        "fade-up": {
+          "0%": { opacity: "0", transform: "translateY(8px)" },
+          "100%": { opacity: "1", transform: "translateY(0)" }
+        }
+      },
+      animation: {
+        "pulse-soft": "pulse-soft 1.6s ease-in-out infinite",
+        "fade-up": "fade-up 0.5s ease-out both"
+      }
+    }
   },
   plugins: []
 };

--- a/soundcheck/tailwind.config.ts
+++ b/soundcheck/tailwind.config.ts
@@ -33,17 +33,12 @@ const config: Config = {
         }
       },
       keyframes: {
-        "pulse-soft": {
-          "0%, 100%": { opacity: "1", transform: "scale(1)" },
-          "50%": { opacity: "0.6", transform: "scale(0.85)" }
-        },
         "fade-up": {
           "0%": { opacity: "0", transform: "translateY(8px)" },
           "100%": { opacity: "1", transform: "translateY(0)" }
         }
       },
       animation: {
-        "pulse-soft": "pulse-soft 1.6s ease-in-out infinite",
         "fade-up": "fade-up 0.5s ease-out both"
       }
     }


### PR DESCRIPTION
## Summary

Redesigns Soundcheck so the answer to **\"can I ship right now?\"** is visible before you read anything else, without changing any of the underlying data fetching or decision logic.

- **Release Verdict strip** at the top synthesizes active runs, staging status for main HEAD, and pending changesets into a single Go/Hold/Caution/In-flight line.
- **Deploy-diff tiles** lead with a hero number (e.g. \"251 commits ahead\"), categorized feature/fix/chore breakdown, and a trimmed commit feed.
- **Numbered editorial sections** (I–V) with Instrument Serif display font + Geist body + Geist Mono for SHAs; warm off-black panels with film-grain + radial-glow atmosphere.
- **Consistent tile language** across readiness, progress, dry-run, failures, and run-release — each tile carries its status on a left-edge tone strip.
- **Refined Run Release flow**: the confirmation modal and dispatch button read as intentional production moments (warm amber accent when prod flags are set, neutral when not).

## What's NOT changing

- No changes to data sources (GitHub REST, Changesets config, env gating) or fetch semantics.
- No changes to `release.yml`, `deploy-soundcheck.yml`, or any CI pipeline.
- `lockdown.ts` / employee-email gate untouched.
- No new runtime deps. Uses `next/font/google` for Instrument Serif, Geist, and Geist Mono — all tree-shaken self-hosted via Next 15.

## Files

- **New:** `soundcheck/src/components/release-verdict.tsx` — the top-of-page verdict synthesizer.
- **Heavy restyle:** `ui.tsx` (new primitives: `Verdict`, `HeroStat`, `Sha`, `TileAction`, redesigned `Tile` + `Section`), `page.tsx`, `deploy-diff.tsx`, `globals.css`, `tailwind.config.ts`, `layout.tsx`.
- **Lighter restyle:** `release-readiness.tsx`, `release-progress.tsx`, `release-dry-run.tsx`, `deploy-failures.tsx`, `run-release.tsx` — class-level updates so they inherit the shared aesthetic; behavior unchanged.

## Test plan

- [ ] Sign in at `soundcheck.mcpjam.com` after deploy; confirm the Verdict strip renders and reflects the actual state of main (Go when staging green + pending changesets; Hold when not).
- [ ] Confirm deploy-diff tiles render with the hero number + commit feed for both Inspector and Backend.
- [ ] Confirm Release Readiness, Dry-run, Progress, and Failures tiles render without regressing data.
- [ ] Open the Run Release modal; confirm Tab/Shift-Tab focus trap and Escape-to-dismiss still work.
- [ ] Dispatch a release (dry-run: scope=full, flags off) to confirm the POST path still works.
- [ ] Sanity check on narrow viewport (<= 768px): verdict stacks, numbered sections drop their left indent, tile grid becomes single column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily styling/layout and new presentation components, with only minor display logic tweaks (e.g., tone derivation/truncation) and no changes to release dispatch/auth or data sources.
> 
> **Overview**
> Adds a new top-of-page **`ReleaseVerdict`** strip that synthesizes release in-flight status, staging-green-for-main, and pending changesets into a single Go/Hold/Caution/In-flight message.
> 
> Overhauls Soundcheck’s look-and-feel to a dark “editorial” design: new global CSS variables/background effects, Tailwind `ink`/`signal` palette + font families, and Next `next/font` setup. Refactors shared primitives in `ui.tsx` (new `Verdict`, `HeroStat`, `Sha`, `TileAction`, plus `Tile`/`Section` eyebrow + accent support) and updates all tiles (`deploy-diff`, readiness, dry-run, progress, failures, run-release modal) to use consistent accenting and more at-a-glance summaries (hero commit drift, categorized breakdown, readiness tile summary/accent, and feedback reset on form edits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd650e3f2e19e0ec6f83a8f9919ca512fa03b16f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->