### PR TITLE
PR preview: fail loud when backend branch lookup errors

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -94,7 +94,10 @@ jobs:
           TOKEN: ${{ secrets.BACKEND_PREVIEW_DISPATCH_TOKEN }}
           PR_BRANCH: ${{ steps.meta.outputs.branch }}
         run: |
-          BACKEND_BRANCH=$(git ls-remote --heads "https://x-access-token:${TOKEN}@github.com/${BACKEND_REPO}.git" "$PR_BRANCH" || true)
+          set -euo pipefail
+          BACKEND_BRANCH=$(git ls-remote --heads \
+            "https://x-access-token:${TOKEN}@github.com/${BACKEND_REPO}.git" \
+            "$PR_BRANCH")
           if [ -n "$BACKEND_BRANCH" ]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary
- Drops `|| true` on the `git ls-remote` in `upsert-preview` that detects a matching backend branch
- Adds `set -euo pipefail` so the step fails instead of silently falling back to staging

## Why
The suppression masked auth/network/permission failures as a missing branch. Observed on [inspector#1841](https://github.com/MCPJam/inspector/pull/1841) + [mcpjam-backend#137](https://github.com/MCPJam/mcpjam-backend/pull/137): the backend branch existed with an exact name match, yet the preview comment said `Backend target: staging fallback` and `sync-backend-preview` was `skipped` (no dispatch ever fired). With this change, the next regression surfaces as a red step instead of a wrong comment.

`ls-remote` still exits 0 with empty stdout when the ref doesn't exist, so a legitimate "no matching backend branch" continues to set `exists=false` — only real errors now fail.

## Test plan
- [ ] Open a PR on a branch that has no matching backend branch — step succeeds, comment says `staging fallback`
- [ ] Open a PR whose branch name matches an open backend PR head ref — step succeeds, comment says `preview requested`, `sync-backend-preview` runs
- [ ] (Regression sim) temporarily point `BACKEND_REPO` at a repo the token can't read — step fails with a visible error instead of silently falling back

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small GitHub Actions shell change; primary risk is increased CI failures when the backend repo/token is misconfigured, with no runtime/app behavior changes.
> 
> **Overview**
> Ensures the PR preview workflow **fails loudly** when the backend branch lookup errors instead of silently treating failures as “no matching branch” and falling back to staging.
> 
> In `.github/workflows/pr-preview.yml`, the backend-branch detection step now uses `set -euo pipefail` and removes `|| true` from `git ls-remote`, so auth/network/permission issues break the job while a legitimately missing ref still results in `exists=false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9aa967168f62fe3bd42b99b7f51676e8c2d64ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->