### PR TITLE
PR preview: bypass actions/checkout extraheader for backend ls-remote

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -95,7 +95,10 @@ jobs:
           PR_BRANCH: ${{ steps.meta.outputs.branch }}
         run: |
           set -euo pipefail
-          BACKEND_BRANCH=$(git ls-remote --heads \
+          # -c http.extraheader= strips the AUTHORIZATION header that
+          # actions/checkout persists for GITHUB_TOKEN; otherwise git uses
+          # it instead of the URL-embedded PAT and 404s on the backend repo.
+          BACKEND_BRANCH=$(git -c http.extraheader= ls-remote --heads \
             "https://x-access-token:${TOKEN}@github.com/${BACKEND_REPO}.git" \
             "$PR_BRANCH")
           if [ -n "$BACKEND_BRANCH" ]; then


### PR DESCRIPTION
## Summary
- `git ls-remote` for the matching backend branch now runs with `-c http.extraheader=` to drop the `AUTHORIZATION` header that `actions/checkout` persists
- Fixes the 100% "Backend target: staging fallback" regression that became *visible* after [inspector#1843](https://github.com/MCPJam/inspector/pull/1843) made `ls-remote` failures loud

## Root cause
`actions/checkout@v4` sets `http.https://github.com/.extraheader` to a basic-auth header backed by the workflow's `GITHUB_TOKEN`. That header takes precedence over URL-embedded credentials, so `git ls-remote https://x-access-token:<PAT>@github.com/MCPJam/mcpjam-backend.git` was actually authenticating as `GITHUB_TOKEN` (scoped to `MCPJam/inspector` only) and 404ing on the backend repo — no matter what scope the PAT had.

Verified locally:
- `curl` with the PAT → `HTTP 200` on `mcpjam-backend`
- `git ls-remote` with the PAT → returns the SHA
- Same PAT inside GitHub Actions → `Repository not found`

`-c http.extraheader=` is scoped to this single `git` invocation — it doesn't affect the `actions/checkout` credentials persisted for the rest of the job.

## Test plan
- [ ] After merge, run `pr-preview` on an open inspector PR that has a matching backend branch — comment should say `Backend target: preview requested`, `sync-backend-preview` should fire
- [ ] For an inspector PR with no matching backend branch, the comment should still say `staging fallback` (empty ls-remote is a normal exit 0)
- [ ] (Regression sim) pointing `BACKEND_REPO` at an inaccessible repo should still hard-fail the step, not silently fall back — the loud-fail behavior from #1843 is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `pr-preview` GitHub Actions workflow’s authentication behavior for cross-repo `git ls-remote`, which can affect whether backend preview dispatching triggers. Change is small and scoped to a single command invocation.
> 
> **Overview**
> Ensures the PR preview workflow correctly detects a matching backend branch by running `git ls-remote` with `-c http.extraheader=` so the URL-embedded PAT is used instead of the `actions/checkout`-persisted `AUTHORIZATION` header.
> 
> This prevents false 404s during backend branch lookup and restores expected behavior where backend preview is requested when the branch exists (rather than always falling back to staging).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c323b9737d7f739f93baed264176622ca6332df3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->