### PR TITLE
PR preview: use REST API for backend branch check

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -95,11 +95,26 @@ jobs:
           PR_BRANCH: ${{ steps.meta.outputs.branch }}
         run: |
           set -euo pipefail
+          # GitHub returns 404 for both "branch missing" and "token can't see
+          # this repo" on private repos. Preflight a repo-level GET so only a
+          # real access failure hard-fails; after that, a 404 on the branch
+          # path unambiguously means the branch doesn't exist.
+          ACCESS_CODE=$(curl -sS -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${BACKEND_REPO}")
+          if [ "$ACCESS_CODE" != "200" ]; then
+            echo "::error::BACKEND_PREVIEW_DISPATCH_TOKEN cannot access ${BACKEND_REPO} (HTTP $ACCESS_CODE)"
+            exit 1
+          fi
+          # URL-encode slashes in the branch name for the path parameter.
+          ENCODED_BRANCH=$(jq -rn --arg s "$PR_BRANCH" '$s|@uri')
           HTTP_CODE=$(curl -sS -o /dev/null -w "%{http_code}" \
             -H "Authorization: Bearer ${TOKEN}" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${BACKEND_REPO}/branches/${PR_BRANCH}")
+            "https://api.github.com/repos/${BACKEND_REPO}/branches/${ENCODED_BRANCH}")
           case "$HTTP_CODE" in
             200) echo "exists=true" >> "$GITHUB_OUTPUT" ;;
             404) echo "exists=false" >> "$GITHUB_OUTPUT" ;;

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -95,17 +95,16 @@ jobs:
           PR_BRANCH: ${{ steps.meta.outputs.branch }}
         run: |
           set -euo pipefail
-          # -c http.extraheader= strips the AUTHORIZATION header that
-          # actions/checkout persists for GITHUB_TOKEN; otherwise git uses
-          # it instead of the URL-embedded PAT and 404s on the backend repo.
-          BACKEND_BRANCH=$(git -c http.extraheader= ls-remote --heads \
-            "https://x-access-token:${TOKEN}@github.com/${BACKEND_REPO}.git" \
-            "$PR_BRANCH")
-          if [ -n "$BACKEND_BRANCH" ]; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
+          HTTP_CODE=$(curl -sS -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${BACKEND_REPO}/branches/${PR_BRANCH}")
+          case "$HTTP_CODE" in
+            200) echo "exists=true" >> "$GITHUB_OUTPUT" ;;
+            404) echo "exists=false" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::Unexpected HTTP $HTTP_CODE checking ${BACKEND_REPO}/${PR_BRANCH}"; exit 1 ;;
+          esac
 
       - name: Create or refresh Railway preview environment
         run: |


### PR DESCRIPTION
## Summary
Replaces the `git ls-remote` backend-branch check in `upsert-preview` with a direct `curl` call to `GET /repos/:owner/:repo/branches/:branch`. Explicit 200/404/other handling — 200 dispatches, 404 falls back to staging, anything else hard-fails with the HTTP code.

## Why
[inspector#1845](https://github.com/MCPJam/inspector/pull/1845) tried to clear `http.extraheader` before `git ls-remote`, but `actions/checkout` persists the header under the URL-scoped key `http.https://github.com/.extraheader`, so the global `-c http.extraheader=` override didn't match. Result: git continued authenticating as `GITHUB_TOKEN` (inspector-only) and 404'd on `mcpjam-backend`, even with a correctly-scoped PAT.

The REST API path sends the PAT via `Authorization: Bearer` and nothing else — no git config in the way, no URL-embedded creds to be shadowed. Easier to reason about than the git credential precedence rules.

## Test plan
- [ ] Inspector PR with a matching backend branch → comment says `preview requested`, `sync-backend-preview` fires
- [ ] Inspector PR with no matching backend branch → comment says `staging fallback` (API returns 404, no error)
- [ ] Token revoked or scope dropped → step hard-fails with the HTTP code, not silently falls back

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes PR-preview deployment gating/dispatch behavior and adds new API-call dependencies (`curl`/`jq`) whose failures can block preview creation or backend dispatch.
> 
> **Overview**
> The PR preview workflow now checks for a matching backend branch using GitHub’s REST API (`GET /repos/...` then `GET /branches/...`) instead of `git ls-remote`, avoiding checkout/git credential header interference.
> 
> It adds explicit handling for **token access failures** (hard-fail with an error) vs **missing backend branches** (treat as `exists=false` for staging fallback), and URL-encodes branch names before querying.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97f887de455fda1fa45f5f2a19b692b7023f3050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->