### PR TITLE
playground available for guests

### DIFF
--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -207,7 +207,7 @@ export function EvalsTab({
   );
 
   useEffect(() => {
-    if (!selectedServer) {
+    if (!selectedServer || selectedServer === "none") {
       return;
     }
     if (!isDirectGuest) {

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { EmptyState } from "@/components/ui/empty-state";
 import { useEvalsRoute } from "@/lib/evals-router";
 import { useEvalTabContext } from "@/hooks/use-eval-tab-context";
+import { useIsDirectGuest } from "@/hooks/use-is-direct-guest";
 import { aggregateSuite } from "./evals/helpers";
 import { EvalTabGate } from "./evals/EvalTabGate";
 import {
@@ -23,6 +24,7 @@ import type { EvalChatHandoff } from "@/lib/eval-chat-handoff";
 import type { EvalCase } from "./evals/types";
 import { EXPLORE_SUITE_TAG, isExploreSuite } from "./evals/constants";
 import { getPlaygroundCasesRedirect } from "./evals/playground-route-preferences";
+import { useGuestEvalsStore } from "@/stores/guest-evals-store";
 
 interface EvalsTabProps {
   selectedServer?: string;
@@ -35,6 +37,23 @@ const EMPTY_CASES: EvalCase[] = [];
 /** Module-level guard so fast tab-switches (unmount/remount) don't duplicate suite creation. */
 const globalInitializedExplore = new Set<string>();
 
+function getExploreInitializationKey({
+  serverName,
+  isDirectGuest,
+  workspaceId,
+}: {
+  serverName: string;
+  isDirectGuest: boolean;
+  workspaceId?: string | null;
+}): string {
+  const scope = isDirectGuest
+    ? "guest"
+    : workspaceId
+      ? `workspace:${workspaceId}`
+      : "anonymous";
+  return `${scope}::${serverName}`;
+}
+
 export function EvalsTab({
   selectedServer,
   workspaceId,
@@ -44,6 +63,7 @@ export function EvalsTab({
   const { user } = useAuth();
   const route = useEvalsRoute();
   const appState = useSharedAppState();
+  const isDirectGuest = useIsDirectGuest({ workspaceId });
   const {
     connectedServerNames,
     userMap,
@@ -53,9 +73,11 @@ export function EvalsTab({
   } = useEvalTabContext({
     isAuthenticated,
     workspaceId: workspaceId ?? null,
+    isDirectGuest,
   });
   const updateSuiteMutation = useMutation("testSuites:updateTestSuite" as any);
-  const mutations = useEvalMutations();
+  const mutations = useEvalMutations({ isDirectGuest });
+  const ensureGuestSuite = useGuestEvalsStore((state) => state.ensureSuite);
 
   const [isPreparingExplore, setIsPreparingExplore] = useState(false);
 
@@ -70,6 +92,17 @@ export function EvalsTab({
 
   const hasPlaygroundServerTab =
     Boolean(selectedServer) && selectedServer !== "none";
+  const exploreInitializationKey = useMemo(
+    () =>
+      selectedServer
+        ? getExploreInitializationKey({
+            serverName: selectedServer,
+            isDirectGuest,
+            workspaceId,
+          })
+        : null,
+    [selectedServer, isDirectGuest, workspaceId],
+  );
 
   const overviewQueries = useEvalQueries({
     isAuthenticated: isAuthenticated && Boolean(workspaceId),
@@ -78,6 +111,7 @@ export function EvalsTab({
     deletingSuiteId: null,
     workspaceId: workspaceId ?? null,
     organizationId: null,
+    isDirectGuest,
   });
 
   const manualSuiteEntries = useMemo(
@@ -110,15 +144,32 @@ export function EvalsTab({
     selectedTestId,
     workspaceId: workspaceId ?? null,
     connectedServerNames,
+    isDirectGuest,
   });
+  const {
+    deletingSuiteId,
+    rerunningSuiteId,
+    cancellingRunId,
+    deletingRunId,
+    isGeneratingTests,
+    handleCreateTestCase,
+    handleGenerateTests,
+    handleRerun,
+    handleCancelRun,
+    handleDelete,
+    handleDeleteRun,
+    directDeleteRun,
+    directDeleteTestCase,
+  } = handlers;
 
   const queries = useEvalQueries({
     isAuthenticated: isAuthenticated && Boolean(workspaceId),
     user: workspaceId ? user : null,
     selectedSuiteId,
-    deletingSuiteId: handlers.deletingSuiteId,
+    deletingSuiteId,
     workspaceId: workspaceId ?? null,
     organizationId: null,
+    isDirectGuest,
   });
 
   const selectedSuite = queries.selectedSuite;
@@ -156,31 +207,52 @@ export function EvalsTab({
   );
 
   useEffect(() => {
-    if (
-      !selectedServer ||
-      !isServerConnected ||
-      !workspaceId ||
-      !isAuthenticated
-    ) {
+    if (!selectedServer) {
       return;
     }
-    // Wait until the overview query has loaded before deciding to create.
-    // Otherwise we might not find the existing suite and create a duplicate.
-    if (overviewQueries.isOverviewLoading) {
+    if (!isDirectGuest) {
+      // Signed-in path still waits for a live connection before calling the
+      // create mutation (and the auto-generate that follows).
+      if (!isServerConnected) {
+        return;
+      }
+      if (!workspaceId || !isAuthenticated) {
+        return;
+      }
+      // Wait until the overview query has loaded before deciding to create.
+      // Otherwise we might not find the existing suite and create a duplicate.
+      if (overviewQueries.isOverviewLoading) {
+        return;
+      }
+    }
+    // Guests mint the local suite as soon as the server is selected — we need
+    // the Explore surface to render even when the server is disconnected so
+    // the empty state matches what signed-in users see (their suite persists
+    // in Convex across sessions, ours has to be created here).
+    if (selectedSuiteId) {
       return;
     }
-    if (exploreSuiteEntry) {
+    if (!exploreInitializationKey) {
       return;
     }
-    if (globalInitializedExplore.has(selectedServer)) {
+    if (globalInitializedExplore.has(exploreInitializationKey)) {
       return;
     }
 
-    globalInitializedExplore.add(selectedServer);
+    globalInitializedExplore.add(exploreInitializationKey);
     setIsPreparingExplore(true);
 
     void (async () => {
       try {
+        if (isDirectGuest) {
+          // Guests get the suite shell only; skip auto-generation. They can
+          // add cases manually from the overview or click Generate to pull in
+          // suggestions. Keeps the initial landing deterministic and avoids
+          // hitting the generate endpoint before the user has opted in.
+          ensureGuestSuite(selectedServer);
+          return;
+        }
+
         const createdSuite = await mutations.createTestSuiteMutation({
           workspaceId,
           name: selectedServer,
@@ -195,10 +267,10 @@ export function EvalsTab({
           });
 
           // Auto-generate test cases for the newly created suite
-          handlers.handleGenerateTests(createdSuite._id, [selectedServer]);
+          handleGenerateTests(createdSuite._id, [selectedServer]);
         }
       } catch (error) {
-        globalInitializedExplore.delete(selectedServer);
+        globalInitializedExplore.delete(exploreInitializationKey);
         toast.error(
           getBillingErrorMessage(
             error,
@@ -211,40 +283,47 @@ export function EvalsTab({
     })();
   }, [
     isAuthenticated,
-    exploreSuiteEntry,
-    handlers,
+    handleGenerateTests,
     isServerConnected,
     mutations.createTestSuiteMutation,
     overviewQueries.isOverviewLoading,
     selectedServer,
+    selectedSuiteId,
+    exploreInitializationKey,
     updateSuiteMutation,
     workspaceId,
+    isDirectGuest,
+    ensureGuestSuite,
   ]);
 
   // Auto-generate when an explore suite exists but has no cases (e.g. previous generation failed)
   const hasAutoGeneratedRef = useRef(new Set<string>());
   useEffect(() => {
     if (
-      !exploreSuite ||
+      !selectedSuiteId ||
       !selectedServer ||
       !isServerConnected ||
-      handlers.isGeneratingTests
+      isGeneratingTests
     ) {
       return;
     }
+    // Guests opt into generation manually; don't auto-run on empty suites.
+    if (isDirectGuest) return;
     if (queries.isSuiteDetailsLoading) return;
     if (exploreCases.length > 0) return;
-    if (hasAutoGeneratedRef.current.has(exploreSuite._id)) return;
+    if (hasAutoGeneratedRef.current.has(selectedSuiteId)) return;
 
-    hasAutoGeneratedRef.current.add(exploreSuite._id);
-    handlers.handleGenerateTests(exploreSuite._id, [selectedServer]);
+    hasAutoGeneratedRef.current.add(selectedSuiteId);
+    handleGenerateTests(selectedSuiteId, [selectedServer]);
   }, [
-    exploreSuite,
     exploreCases.length,
+    handleGenerateTests,
+    isGeneratingTests,
     selectedServer,
+    selectedSuiteId,
     isServerConnected,
-    handlers,
     queries.isSuiteDetailsLoading,
+    isDirectGuest,
   ]);
 
   const playgroundNavigation = useMemo(
@@ -253,7 +332,7 @@ export function EvalsTab({
   );
 
   useEffect(() => {
-    if (!exploreSuite) return;
+    if (!selectedSuiteId) return;
     const testCaseIds = exploreCaseIdsSignature
       ? exploreCaseIdsSignature.split("\u0000")
       : [];
@@ -265,7 +344,7 @@ export function EvalsTab({
       : [];
     const redirectRoute = getPlaygroundCasesRedirect({
       route,
-      exploreSuiteId: exploreSuite._id,
+      exploreSuiteId: selectedSuiteId,
       isSuiteDetailsLoading: queries.isSuiteDetailsLoading,
       isSuiteRunsLoading: queries.isSuiteRunsLoading,
       runsCount: runsForSelectedSuite.length,
@@ -280,25 +359,25 @@ export function EvalsTab({
     navigatePlaygroundEvalsRoute(redirectRoute, { replace: true });
   }, [
     exploreCaseIdsSignature,
-    exploreSuite,
     exploreRunIdsSignature,
     iterationRunIdsSignature,
     queries.isSuiteDetailsLoading,
     queries.isSuiteRunsLoading,
     route,
     runsForSelectedSuite.length,
+    selectedSuiteId,
   ]);
 
   const handleGenerateMore = useCallback(async () => {
-    if (!exploreSuite || !selectedServer) return;
-    await handlers.handleGenerateTests(exploreSuite._id, [selectedServer]);
-  }, [exploreSuite, handlers, selectedServer]);
+    if (!selectedSuiteId || !selectedServer) return;
+    await handleGenerateTests(selectedSuiteId, [selectedServer]);
+  }, [handleGenerateTests, selectedServer, selectedSuiteId]);
 
   const handleDeleteTestCasesBatch = useCallback(
     async (testCaseIds: string[]) => {
       const settledDeletes = await Promise.allSettled(
         testCaseIds.map(async (id) => {
-          await handlers.directDeleteTestCase(id);
+          await directDeleteTestCase(id);
           return id;
         }),
       );
@@ -321,18 +400,18 @@ export function EvalsTab({
         );
       }
 
-      if (exploreSuite && selectedTestId && deletedIds.has(selectedTestId)) {
+      if (selectedSuiteId && selectedTestId && deletedIds.has(selectedTestId)) {
         navigatePlaygroundEvalsRoute(
           {
             type: "suite-overview",
-            suiteId: exploreSuite._id,
+            suiteId: selectedSuiteId,
             view: "test-cases",
           },
           { replace: true },
         );
       }
     },
-    [exploreSuite, handlers, selectedTestId],
+    [directDeleteTestCase, selectedSuiteId, selectedTestId],
   );
 
   const showExploreLoading =
@@ -359,6 +438,7 @@ export function EvalsTab({
     return (
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-4 pb-6 pt-4 sm:px-6">
         <SuiteIterationsView
+          isDirectGuest={isDirectGuest}
           suite={exploreSuite}
           cases={exploreCases}
           iterations={activeIterations}
@@ -373,22 +453,22 @@ export function EvalsTab({
             })
           }
           onCreateTestCase={async () =>
-            handlers.handleCreateTestCase(exploreSuite._id)
+            handleCreateTestCase(exploreSuite._id)
           }
           onGenerateTestCases={() => void handleGenerateMore()}
           canGenerateTestCases={Boolean(selectedServer && isServerConnected)}
-          isGeneratingTestCases={handlers.isGeneratingTests}
-          onRerun={handlers.handleRerun}
-          onCancelRun={handlers.handleCancelRun}
-          onDelete={handlers.handleDelete}
-          onDeleteRun={handlers.handleDeleteRun}
-          onDirectDeleteRun={handlers.directDeleteRun}
+          isGeneratingTestCases={isGeneratingTests}
+          onRerun={handleRerun}
+          onCancelRun={handleCancelRun}
+          onDelete={handleDelete}
+          onDeleteRun={handleDeleteRun}
+          onDirectDeleteRun={directDeleteRun}
           connectedServerNames={connectedServerNames}
           canDeleteSuite={canDeleteSuite}
-          rerunningSuiteId={handlers.rerunningSuiteId}
-          cancellingRunId={handlers.cancellingRunId}
-          deletingSuiteId={handlers.deletingSuiteId}
-          deletingRunId={handlers.deletingRunId}
+          rerunningSuiteId={rerunningSuiteId}
+          cancellingRunId={cancellingRunId}
+          deletingSuiteId={deletingSuiteId}
+          deletingRunId={deletingRunId}
           availableModels={availableModels}
           route={route}
           userMap={userMap}
@@ -440,6 +520,7 @@ export function EvalsTab({
       isAuthenticated={isAuthenticated}
       user={user}
       workspaceId={workspaceId}
+      isDirectGuest={isDirectGuest}
     >
       <div className="h-full flex flex-col overflow-hidden">
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
@@ -16,6 +16,9 @@ const mocks = vi.hoisted(() => ({
   navigatePlaygroundEvalsRoute: vi.fn(),
   createTestSuiteMutation: vi.fn(),
   updateSuiteMutation: vi.fn(),
+  handleGenerateTests: vi.fn(),
+  ensureGuestSuite: vi.fn(),
+  isDirectGuest: false,
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({
@@ -40,6 +43,10 @@ vi.mock("@/hooks/use-eval-tab-context", () => ({
     canDeleteRuns: false,
     availableModels: [],
   }),
+}));
+
+vi.mock("@/hooks/use-is-direct-guest", () => ({
+  useIsDirectGuest: () => mocks.isDirectGuest,
 }));
 
 vi.mock("@/state/app-state-context", () => ({
@@ -104,7 +111,7 @@ vi.mock("../evals/use-eval-handlers", () => ({
     cancellingRunId: null,
     runningTestCaseId: null,
     isGeneratingTests: false,
-    handleGenerateTests: vi.fn(),
+    handleGenerateTests: mocks.handleGenerateTests,
     handleCreateTestCase: vi.fn(),
     handleRerun: vi.fn(),
     handleCancelRun: vi.fn(),
@@ -117,6 +124,13 @@ vi.mock("../evals/use-eval-handlers", () => ({
     confirmDeleteRun: vi.fn(),
     confirmDeleteTestCase: vi.fn(),
   }),
+}));
+
+vi.mock("@/stores/guest-evals-store", () => ({
+  useGuestEvalsStore: (selector: (state: { ensureSuite: typeof mocks.ensureGuestSuite }) => unknown) =>
+    selector({
+      ensureSuite: mocks.ensureGuestSuite,
+    }),
 }));
 
 vi.mock("../evals/use-eval-queries", () => ({
@@ -217,6 +231,7 @@ function makeSuiteQueries(serverName: string, suiteId: string, testId: string) {
 describe("EvalsTab route guard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.isDirectGuest = false;
     mocks.route.current = {
       type: "test-edit",
       suiteId: "suite-a",
@@ -283,6 +298,58 @@ describe("EvalsTab route guard", () => {
           view: "test-cases",
         },
         { replace: true },
+      );
+    });
+  });
+
+  it("creates the signed-in suite after a guest initialized the same server in the same tab", async () => {
+    mocks.useEvalQueries.mockReturnValue({
+      suiteOverview: [],
+      suiteDetails: undefined,
+      suiteRuns: undefined,
+      selectedSuiteEntry: null,
+      selectedSuite: null,
+      sortedIterations: [],
+      runsForSelectedSuite: [],
+      activeIterations: [],
+      sortedSuites: [],
+      isOverviewLoading: false,
+      isSuiteDetailsLoading: false,
+      isSuiteRunsLoading: false,
+      enableOverviewQuery: true,
+      enableSuiteDetailsQuery: false,
+    });
+    mocks.createTestSuiteMutation.mockResolvedValue({ _id: "suite-created" });
+
+    mocks.isDirectGuest = true;
+    const view = render(
+      <EvalsTab selectedServer="server-a" workspaceId="ws-1" />,
+    );
+
+    await waitFor(() => {
+      expect(mocks.ensureGuestSuite).toHaveBeenCalledWith("server-a");
+    });
+
+    mocks.isDirectGuest = false;
+    view.rerender(<EvalsTab selectedServer="server-a" workspaceId="ws-1" />);
+
+    await waitFor(() => {
+      expect(mocks.createTestSuiteMutation).toHaveBeenCalledWith({
+        workspaceId: "ws-1",
+        name: "server-a",
+        description: "Explore cases for server-a",
+        environment: { servers: ["server-a"] },
+      });
+    });
+
+    await waitFor(() => {
+      expect(mocks.updateSuiteMutation).toHaveBeenCalledWith({
+        suiteId: "suite-created",
+        tags: ["explore"],
+      });
+      expect(mocks.handleGenerateTests).toHaveBeenCalledWith(
+        "suite-created",
+        ["server-a"],
       );
     });
   });

--- a/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
@@ -353,4 +353,31 @@ describe("EvalsTab route guard", () => {
       );
     });
   });
+
+  it("does not create a guest suite when selectedServer is \"none\"", async () => {
+    mocks.useEvalQueries.mockReturnValue({
+      suiteOverview: [],
+      suiteDetails: undefined,
+      suiteRuns: undefined,
+      selectedSuiteEntry: null,
+      selectedSuite: null,
+      sortedIterations: [],
+      runsForSelectedSuite: [],
+      activeIterations: [],
+      sortedSuites: [],
+      isOverviewLoading: false,
+      isSuiteDetailsLoading: false,
+      isSuiteRunsLoading: false,
+      enableOverviewQuery: true,
+      enableSuiteDetailsQuery: false,
+    });
+
+    mocks.isDirectGuest = true;
+
+    render(<EvalsTab selectedServer="none" workspaceId="ws-1" />);
+
+    await waitFor(() => {
+      expect(mocks.ensureGuestSuite).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/components/evals/EvalTabGate.tsx
+++ b/mcpjam-inspector/client/src/components/evals/EvalTabGate.tsx
@@ -10,6 +10,7 @@ export function EvalTabGate({
   isAuthenticated,
   user,
   workspaceId,
+  isDirectGuest = false,
   children,
 }: {
   variant: EvalTabGateVariant;
@@ -17,6 +18,12 @@ export function EvalTabGate({
   isAuthenticated: boolean;
   user: unknown;
   workspaceId: string | null | undefined;
+  /**
+   * True when the caller has classified this session as a hosted direct guest
+   * (no workspace, no share/sandbox token). Direct guests bypass the sign-in
+   * wall for the Playground variant only.
+   */
+  isDirectGuest?: boolean;
   children: ReactNode;
 }) {
   const Icon = variant === "playground" ? FlaskConical : GitBranch;
@@ -37,6 +44,10 @@ export function EvalTabGate({
   }
 
   if (variant === "playground") {
+    if (isDirectGuest) {
+      return <>{children}</>;
+    }
+
     if (!isAuthenticated || !user) {
       return (
         <div className="p-6">

--- a/mcpjam-inspector/client/src/components/evals/__tests__/iteration-details-ui.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/iteration-details-ui.test.tsx
@@ -206,6 +206,54 @@ describe("IterationDetails full layout (trace-first)", () => {
       container.querySelector('[data-testid="iteration-tool-calls-section"]'),
     ).toBeNull();
   });
+
+  it("renders inline guest trace data without fetching a blob", async () => {
+    const inlineIteration: EvalIteration = {
+      ...iteration,
+      _id: "guestiter-1",
+      messages: [{ role: "user", content: "hello" }] as EvalIteration["messages"],
+      spans: [
+        {
+          id: "step-1",
+          name: "Step 1",
+          category: "step",
+          startMs: 0,
+          endMs: 1,
+        },
+      ],
+      prompts: [
+        {
+          promptIndex: 0,
+          prompt: "hello",
+          expectedToolCalls: [],
+          actualToolCalls: [],
+          passed: true,
+          missing: [],
+          unexpected: [],
+          argumentMismatches: [],
+        },
+      ],
+    };
+
+    const { container } = render(
+      <IterationDetails
+        layoutMode="full"
+        iteration={inlineIteration}
+        testCase={testCase}
+      />,
+    );
+
+    const viewer = await screen.findByTestId("mock-trace-viewer");
+
+    expect(viewer).toHaveAttribute("data-chrome-density", "compact");
+    expect(mockGetBlob).not.toHaveBeenCalled();
+    expect(
+      container.querySelector('[data-testid="iteration-tool-calls-section"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="iteration-trace-section"]'),
+    ).not.toBeNull();
+  });
 });
 
 describe("IterationDetails trace blob load error", () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PreferencesStoreProvider } from "@/stores/preferences/preferences-provider";
+import { useGuestEvalsStore } from "@/stores/guest-evals-store";
 import { TestTemplateEditor } from "../test-template-editor";
 import type { EvalIteration } from "../types";
 
@@ -26,6 +27,7 @@ const useMutationMock = vi.hoisted(() => vi.fn(() => vi.fn()));
 const useQueryMock = vi.hoisted(() => vi.fn());
 const updateTestCaseMutationMock = vi.hoisted(() => vi.fn());
 const streamEvalTestCaseMock = vi.hoisted(() => vi.fn());
+const streamInlineEvalTestCaseGuestMock = vi.hoisted(() => vi.fn());
 const useAuthMock = vi.hoisted(() => ({
   getAccessToken: vi.fn().mockResolvedValue("token"),
 }));
@@ -57,9 +59,14 @@ vi.mock("@/state/app-state-context", () => ({
   }),
 }));
 
-vi.mock("@/hooks/useViews", () => ({
-  useWorkspaceServers: () => workspaceServersMock,
-}));
+vi.mock("@/hooks/useViews", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/hooks/useViews")>();
+  return {
+    ...actual,
+    useWorkspaceServers: () => workspaceServersMock,
+  };
+});
 
 vi.mock("@/stores/client-config-store", () => ({
   useClientConfigStore: (selector: (state: any) => unknown) =>
@@ -103,6 +110,8 @@ vi.mock("@/lib/PosthogUtils", () => ({
 vi.mock("@/lib/apis/evals-api", () => ({
   listEvalTools: vi.fn().mockResolvedValue([]),
   runEvalTestCase: vi.fn(),
+  streamInlineEvalTestCaseGuest: (...args: unknown[]) =>
+    streamInlineEvalTestCaseGuestMock(...args),
   streamEvalTestCase: (...args: unknown[]) => streamEvalTestCaseMock(...args),
 }));
 
@@ -216,6 +225,7 @@ describe("TestTemplateEditor run view from route", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    useGuestEvalsStore.setState({ serverBuckets: {} });
     useMutationMock.mockReturnValue(updateTestCaseMutationMock);
     useQueryMock.mockImplementation((name: string, args: unknown) => {
       if (name === "testSuites:listTestCases") {
@@ -573,6 +583,157 @@ describe("TestTemplateEditor run view from route", () => {
     expect(retryRequest.provider).toBe("openai");
     expect(retryRequest.model).toBe("gpt-4");
     expect(updateTestCaseMutationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("streams guest compare runs and stores completed guest iterations locally", async () => {
+    const user = userEvent.setup();
+    const delayedCompletion = createDeferred();
+    const guestSuiteId = "guestsuite-srv";
+    const guestSuite = {
+      _id: guestSuiteId,
+      createdBy: "__guest__",
+      name: "srv",
+      description: "Guest suite",
+      configRevision: "",
+      environment: { servers: ["srv"] },
+      createdAt: 1,
+      updatedAt: 1,
+      source: "ui",
+    };
+    useGuestEvalsStore.setState({
+      serverBuckets: {
+        srv: {
+          suite: guestSuite as any,
+          testCases: [caseDoc as any],
+          iterations: [],
+        },
+      },
+    });
+
+    streamInlineEvalTestCaseGuestMock.mockImplementation(
+      async (
+        request: {
+          provider: string;
+          model: string;
+          compareRunId?: string;
+        },
+        onEvent: (event: any) => void,
+      ) => {
+        const iterationId = `guestiter-${request.provider}-${request.model}`;
+        onEvent({
+          type: "trace_snapshot",
+          turnIndex: 0,
+          snapshotKind: "step_finish",
+          trace: {
+            traceVersion: 1,
+            messages: [{ role: "user", content: "hello" }],
+          },
+          actualToolCalls: [],
+          usage: {
+            inputTokens: 3,
+            outputTokens: 2,
+            totalTokens: 5,
+          },
+        });
+
+        if (request.provider === "anthropic") {
+          await delayedCompletion.promise;
+        }
+
+        onEvent({
+          type: "complete",
+          iterationId,
+          iteration: {
+            ...baseIteration,
+            _id: iterationId,
+            createdBy: "__guest__",
+            createdAt: Date.now(),
+            startedAt: Date.now(),
+            updatedAt: Date.now() + 100,
+            suiteRunId: undefined,
+            messages: [{ role: "user", content: "hello" }],
+            metadata: request.compareRunId
+              ? { compareRunId: request.compareRunId }
+              : undefined,
+            testCaseSnapshot: {
+              ...baseIteration.testCaseSnapshot!,
+              provider: request.provider,
+              model: request.model,
+            },
+          },
+        });
+      },
+    );
+
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteId={guestSuiteId}
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        workspaceId={null}
+        isDirectGuest
+        availableModels={[
+          {
+            provider: "openai",
+            id: "gpt-4",
+            model: "gpt-4",
+            name: "GPT-4",
+            label: "GPT-4",
+          } as any,
+          {
+            provider: "anthropic",
+            id: "claude-4.5-sonnet",
+            model: "claude-4.5-sonnet",
+            name: "Claude 4.5 Sonnet",
+            label: "Claude 4.5 Sonnet",
+          } as any,
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /run$/i })).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /add model to compare/i }),
+    );
+    await user.click(screen.getByText("Claude 4.5 Sonnet"));
+    await user.click(screen.getByRole("button", { name: /run compare/i }));
+
+    await waitFor(() => {
+      expect(streamInlineEvalTestCaseGuestMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(streamEvalTestCaseMock).not.toHaveBeenCalled();
+    expect(getMetricRunningSpinnerCount(getCompareCard("Claude 4.5 Sonnet"))).toBe(
+      2,
+    );
+
+    delayedCompletion.resolve();
+
+    await waitFor(() => {
+      expect(
+        useGuestEvalsStore
+          .getState()
+          .getBucketBySuiteId(guestSuiteId)
+          ?.iterations.length,
+      ).toBe(2);
+    });
+
+    const guestIterations =
+      useGuestEvalsStore
+        .getState()
+        .getBucketBySuiteId(guestSuiteId)
+        ?.iterations ?? [];
+    expect(guestIterations.every((iteration) => iteration.testCaseId === "case-1")).toBe(
+      true,
+    );
+    expect(
+      guestIterations.every(
+        (iteration) => iteration.metadata?.compareRunId != null,
+      ),
+    ).toBe(true);
   });
 
   it("renders running spinners in the eval compare metric bars", async () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-trace-blob.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-trace-blob.test.tsx
@@ -1,0 +1,74 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useEvalTraceBlob } from "../use-eval-trace-blob";
+import type { EvalIteration } from "../types";
+
+const mockGetBlob = vi.hoisted(() => vi.fn());
+
+vi.mock("convex/react", () => ({
+  useAction: () => mockGetBlob,
+}));
+
+describe("useEvalTraceBlob", () => {
+  beforeEach(() => {
+    mockGetBlob.mockReset();
+  });
+
+  it("builds trace data from inline guest iteration fields without fetching a blob", async () => {
+    const onTraceLoaded = vi.fn();
+    const iteration: EvalIteration = {
+      _id: "guestiter-1",
+      createdBy: "__guest__",
+      createdAt: 1,
+      updatedAt: 2,
+      iterationNumber: 1,
+      status: "completed",
+      result: "failed",
+      actualToolCalls: [],
+      tokensUsed: 42,
+      messages: [{ role: "user", content: "hello" }] as EvalIteration["messages"],
+      spans: [
+        {
+          id: "step-1",
+          name: "Step 1",
+          category: "step",
+          startMs: 0,
+          endMs: 1,
+        },
+      ],
+      prompts: [
+        {
+          promptIndex: 0,
+          prompt: "hello",
+          expectedToolCalls: [],
+          actualToolCalls: [],
+          passed: false,
+          missing: [],
+          unexpected: [],
+          argumentMismatches: [],
+        },
+      ],
+    };
+
+    const { result } = renderHook(() =>
+      useEvalTraceBlob({
+        iteration,
+        onTraceLoaded,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.blob).toEqual({
+        traceVersion: 1,
+        messages: [{ role: "user", content: "hello" }],
+        spans: iteration.spans,
+        prompts: iteration.prompts,
+      });
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(mockGetBlob).not.toHaveBeenCalled();
+    expect(onTraceLoaded).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
+++ b/mcpjam-inspector/client/src/components/evals/iteration-details.tsx
@@ -1,5 +1,4 @@
-import { useAction } from "convex/react";
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { EvalIteration, EvalCase } from "./types";
 import { TraceViewer } from "./trace-viewer";
 import {
@@ -31,6 +30,7 @@ import {
   resolveIterationDisplayExpectedToolCalls,
   resolvePromptTurns,
 } from "@/shared/prompt-turns";
+import { useEvalTraceBlob } from "./use-eval-trace-blob";
 
 const TOOL_ARGUMENT_BLOCK_THRESHOLD = 120;
 const TOOL_CALLS_SUMMARY_MAX_LEN = 160;
@@ -239,16 +239,8 @@ export function IterationDetails({
   /** Run-level case insight caption; shown under the trace toolbar or at top when no trace blob. */
   caseInsightSlot?: ReactNode;
 }) {
-  const getBlob = useAction(
-    "testSuites:getTestIterationBlob" as any,
-  ) as unknown as (args: { blobId: string }) => Promise<any>;
-
-  const [blob, setBlob] = useState<any>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const [blobRetryTick, setBlobRetryTick] = useState(0);
   const [isBlobErrorDetailsOpen, setIsBlobErrorDetailsOpen] = useState(false);
-  const prevBlobIdRef = useRef<string | undefined>(undefined);
   const [toolViewMode, setToolViewMode] = useState<"formatted" | "raw">(
     "formatted",
   );
@@ -263,40 +255,19 @@ export function IterationDetails({
   const [toolCallsSectionOpen, setToolCallsSectionOpen] = useState(() =>
     layoutMode === "full" ? iteration.result !== "passed" : true,
   );
+  const {
+    blob,
+    loading,
+    error,
+  } = useEvalTraceBlob({
+    iteration,
+    enabled: true,
+    retryKey: blobRetryTick,
+  });
 
   useEffect(() => {
-    let cancelled = false;
-    async function run() {
-      if (!iteration.blob) {
-        prevBlobIdRef.current = undefined;
-        setBlob(null);
-        setLoading(false);
-        setError(null);
-        return;
-      }
-      if (prevBlobIdRef.current !== iteration.blob) {
-        prevBlobIdRef.current = iteration.blob;
-        setIsBlobErrorDetailsOpen(false);
-      }
-      setLoading(true);
-      setError(null);
-      try {
-        const data = await getBlob({ blobId: iteration.blob });
-        if (!cancelled) setBlob(data);
-      } catch (e: any) {
-        if (!cancelled) {
-          setError(e?.message || "Failed to load blob");
-          console.error("Blob load error:", e);
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    }
-    run();
-    return () => {
-      cancelled = true;
-    };
-  }, [iteration.blob, getBlob, blobRetryTick]);
+    setIsBlobErrorDetailsOpen(false);
+  }, [iteration._id, iteration.blob]);
 
   useEffect(() => {
     if (layoutMode !== "full") return;
@@ -587,7 +558,12 @@ export function IterationDetails({
 
   const hasToolCalls =
     expectedToolCalls.length > 0 || actualToolCalls.length > 0;
-  const traceFirst = layoutMode === "full" && Boolean(iteration.blob);
+  const hasTraceData = blob != null;
+  const hasTraceSource =
+    Boolean(iteration.blob) || hasTraceData || loading || Boolean(error);
+  const waitingForTraceData =
+    Boolean(iteration.blob) && !hasTraceData && !error;
+  const traceFirst = layoutMode === "full" && hasTraceSource;
   const toolCallsSummary = formatToolCallsSummary(
     expectedToolCalls,
     actualToolCalls,
@@ -702,7 +678,7 @@ export function IterationDetails({
   );
 
   const toolCallsSection =
-    hasToolCalls && !iteration.blob ? (
+    hasToolCalls && !hasTraceSource ? (
       layoutMode === "full" ? (
         <Collapsible
           open={toolCallsSectionOpen}
@@ -754,7 +730,7 @@ export function IterationDetails({
       )
     ) : null;
 
-  const traceSection = iteration.blob ? (
+  const traceSection = hasTraceSource ? (
     <div
       className={cn(
         "flex flex-col",
@@ -770,7 +746,7 @@ export function IterationDetails({
         className={cn(
           layoutMode === "compact" && "rounded-md bg-muted/20 p-3",
           layoutMode === "full" &&
-            iteration.blob &&
+            hasTraceSource &&
             !error &&
             "flex min-h-0 flex-1 flex-col",
           layoutMode === "full" &&
@@ -779,7 +755,7 @@ export function IterationDetails({
             "min-h-[320px] flex flex-col justify-center",
         )}
       >
-        {loading ? (
+        {loading || waitingForTraceData ? (
           <div className="flex items-center justify-center py-8">
             <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
           </div>
@@ -812,7 +788,7 @@ export function IterationDetails({
   ) : null;
 
   const caseInsightFallback =
-    caseInsightSlot && !iteration.blob ? (
+    caseInsightSlot && !hasTraceSource ? (
       <div className="min-w-0" data-testid="iteration-case-insight-fallback">
         {caseInsightSlot}
       </div>

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -103,6 +103,7 @@ export function SuiteIterationsView({
   onRunTestCase,
   runningTestCaseId = null,
   onContinueInChat,
+  isDirectGuest = false,
 }: {
   suite: EvalSuite;
   cases: EvalCase[];
@@ -162,6 +163,8 @@ export function SuiteIterationsView({
   onRunTestCase?: (testCase: EvalCase) => void;
   runningTestCaseId?: string | null;
   onContinueInChat?: (handoff: Omit<EvalChatHandoff, "id">) => void;
+  /** When true, source all data from the guest evals store instead of Convex. */
+  isDirectGuest?: boolean;
 }) {
   const appState = useSharedAppState();
   // Derive view state from route
@@ -482,6 +485,7 @@ export function SuiteIterationsView({
                   connectedServerNames={connectedServerNames}
                   workspaceId={workspaceId}
                   availableModels={availableModels}
+                  isDirectGuest={isDirectGuest}
                   onExportDraft={handleOpenDraftExport}
                   openCompareFromRoute={
                     route.type === "test-edit" && Boolean(route.openCompare)
@@ -646,6 +650,7 @@ export function SuiteIterationsView({
                     )
                   ) : (
                     <TestCasesOverview
+                      isDirectGuest={isDirectGuest}
                       suite={suite}
                       cases={cases}
                       allIterations={allIterations}

--- a/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
@@ -73,6 +73,8 @@ interface TestCasesOverviewProps {
    * When set (e.g. playground), show run-style selection + batch delete for test cases.
    */
   onDeleteTestCasesBatch?: (testCaseIds: string[]) => Promise<void>;
+  /** When true, skip Convex hydration and trust the caller-provided `cases`/`allIterations`. */
+  isDirectGuest?: boolean;
 }
 
 export function TestCasesOverview({
@@ -90,11 +92,12 @@ export function TestCasesOverview({
   runningTestCaseId = null,
   blockTestCaseRuns = false,
   connectedServerNames,
+  isDirectGuest = false,
 }: TestCasesOverviewProps) {
   const convex = useConvex();
   const liveCases = useQuery(
     "testSuites:listTestCases" as any,
-    { suiteId: suite._id } as any,
+    isDirectGuest ? "skip" : ({ suiteId: suite._id } as any),
   ) as EvalCase[] | undefined;
   const [hydratedIterations, setHydratedIterations] = useState<EvalIteration[]>(
     [],
@@ -177,6 +180,10 @@ export function TestCasesOverview({
   }, [onDeleteTestCasesBatch, selectedCaseIds]);
 
   useEffect(() => {
+    if (isDirectGuest) {
+      setHydratedIterations((current) => (current.length === 0 ? current : []));
+      return;
+    }
     const localIterationIds = new Set(
       allIterations.map((iteration) => iteration._id),
     );
@@ -257,7 +264,7 @@ export function TestCasesOverview({
     return () => {
       cancelled = true;
     };
-  }, [allIterations, convex, effectiveCases]);
+  }, [allIterations, convex, effectiveCases, isDirectGuest]);
 
   const effectiveIterations = useMemo(() => {
     const deduped = new Map<string, EvalIteration>();
@@ -410,15 +417,20 @@ export function TestCasesOverview({
               const isThisCaseRunning = runningTestCaseId === testCase._id;
               const isAnotherCaseRunning =
                 runningTestCaseId != null && runningTestCaseId !== testCase._id;
+              // Guests rely on the local persistent MCP manager; skip the
+              // suite-server-connected gate and let the runner surface a
+              // connection error if the server is actually missing.
+              const serverGateBlocked =
+                !isDirectGuest && missingServers.length > 0;
               const runDisabled =
                 !onRunTestCase ||
                 blockTestCaseRuns ||
                 isAnotherCaseRunning ||
                 !hasModels ||
-                missingServers.length > 0 ||
+                serverGateBlocked ||
                 isThisCaseRunning;
               const disconnectedRunTooltip =
-                missingServers.length > 0
+                serverGateBlocked
                   ? `Connect: ${missingServers.join(", ")}`
                   : null;
 

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -123,8 +123,8 @@ interface TestTemplateEditorProps {
   openCompareIterationId?: string | null;
   /**
    * When true, reads/writes go through the guest evals store instead of Convex.
-   * The run/compare surfaces are disabled for guests in v1 — iteration state is
-   * still sourced from the local store so previously-run results remain visible.
+   * Guest runs and compare flows execute inline and persist iteration state in
+   * the local guest store.
    */
   isDirectGuest?: boolean;
 }

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { useAuth } from "@workos-inc/authkit-react";
+import { useGuestEvalsStore } from "@/stores/guest-evals-store";
 import posthog from "posthog-js";
 import {
   ArrowLeft,
@@ -27,6 +28,7 @@ import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import {
   listEvalTools,
   runEvalTestCase,
+  streamInlineEvalTestCaseGuest,
   streamEvalTestCase,
 } from "@/lib/apis/evals-api";
 import { Button } from "@/components/ui/button";
@@ -119,6 +121,12 @@ interface TestTemplateEditorProps {
   openCompareFromRoute?: boolean;
   /** Deep link: exact iteration to anchor compare hydration to. */
   openCompareIterationId?: string | null;
+  /**
+   * When true, reads/writes go through the guest evals store instead of Convex.
+   * The run/compare surfaces are disabled for guests in v1 — iteration state is
+   * still sourced from the local store so previously-run results remain visible.
+   */
+  isDirectGuest?: boolean;
 }
 
 const createEmptyPromptTurn = (index: number): PromptTurn => ({
@@ -300,6 +308,7 @@ export function TestTemplateEditor({
   onContinueInChat,
   openCompareFromRoute = false,
   openCompareIterationId = null,
+  isDirectGuest = false,
 }: TestTemplateEditorProps) {
   const { getAccessToken } = useAuth();
   const { getToken, hasToken } = useAiProviderKeys();
@@ -352,40 +361,83 @@ export function TestTemplateEditor({
   const compareRunUserStoppedRef = useRef(false);
   const initializedSelectionCaseRef = useRef<string | null>(null);
 
-  const testCases = useQuery("testSuites:listTestCases" as any, {
-    suiteId,
-  }) as any[] | undefined;
-  const updateTestCaseMutation = useMutation(
+  const guestBucket = useGuestEvalsStore((state) => {
+    if (!isDirectGuest) return null;
+    return (
+      Object.values(state.serverBuckets).find(
+        (bucket) => bucket.suite._id === suiteId,
+      ) ?? null
+    );
+  });
+  const guestUpdateTestCase = useGuestEvalsStore(
+    (state) => state.updateTestCase,
+  );
+
+  const convexTestCases = useQuery(
+    "testSuites:listTestCases" as any,
+    isDirectGuest ? "skip" : { suiteId },
+  ) as any[] | undefined;
+  const testCases = isDirectGuest
+    ? (guestBucket?.testCases ?? [])
+    : convexTestCases;
+
+  const convexUpdateTestCaseMutation = useMutation(
     "testSuites:updateTestCase" as any,
   );
+  const updateTestCaseMutation = isDirectGuest
+    ? async (args: { testCaseId: string; [key: string]: unknown }) => {
+        const { testCaseId, ...updates } = args;
+        guestUpdateTestCase(testCaseId, updates as any);
+        return null;
+      }
+    : convexUpdateTestCaseMutation;
 
   const currentTestCase = useMemo(() => {
     if (!testCases) return null;
     return testCases.find((tc: any) => tc._id === selectedTestCaseId) || null;
   }, [testCases, selectedTestCaseId]);
 
-  const routeCompareAnchorIteration = useQuery(
+  const convexRouteCompareAnchorIteration = useQuery(
     "testSuites:getTestIteration" as any,
-    routeCompareAnchorIterationId
+    !isDirectGuest && routeCompareAnchorIterationId
       ? { iterationId: routeCompareAnchorIterationId }
       : "skip",
   ) as EvalIteration | null | undefined;
-  const lastSavedIteration = useQuery(
+  const routeCompareAnchorIteration = isDirectGuest
+    ? (guestBucket?.iterations.find(
+        (i) => i._id === routeCompareAnchorIterationId,
+      ) ?? null)
+    : convexRouteCompareAnchorIteration;
+
+  const convexLastSavedIteration = useQuery(
     "testSuites:getTestIteration" as any,
-    currentTestCase?.lastMessageRun
+    !isDirectGuest && currentTestCase?.lastMessageRun
       ? { iterationId: currentTestCase.lastMessageRun }
       : "skip",
   ) as EvalIteration | undefined;
-  const recentIterations = useQuery(
+  const lastSavedIteration = isDirectGuest
+    ? (guestBucket?.iterations.find(
+        (i) => i._id === currentTestCase?.lastMessageRun,
+      ) ?? undefined)
+    : convexLastSavedIteration;
+
+  const convexRecentIterations = useQuery(
     "testSuites:listTestIterations" as any,
-    currentTestCase?._id
+    !isDirectGuest && currentTestCase?._id
       ? ({ testCaseId: currentTestCase._id, limit: 200 } as any)
       : "skip",
   ) as EvalIteration[] | undefined;
+  const recentIterations = isDirectGuest
+    ? (guestBucket?.iterations.filter(
+        (i) => i.testCaseId === currentTestCase?._id,
+      ) ?? [])
+    : convexRecentIterations;
 
-  const suite = useQuery("testSuites:getTestSuite" as any, {
-    suiteId,
-  }) as any;
+  const convexSuite = useQuery(
+    "testSuites:getTestSuite" as any,
+    isDirectGuest ? "skip" : { suiteId },
+  ) as any;
+  const suite = isDirectGuest ? (guestBucket?.suite ?? null) : convexSuite;
 
   useEffect(() => {
     setEditorMode(openCompareFromRoute ? "run" : "config");
@@ -447,7 +499,10 @@ export function TestTemplateEditor({
     );
   }, [suite, connectedServerNames]);
 
-  const canRun = missingServers.length === 0;
+  // Guests rely on the local persistent MCP manager; don't block Run on the
+  // connected-servers check — the runner surfaces a connection error if the
+  // server is genuinely missing.
+  const canRun = isDirectGuest || missingServers.length === 0;
 
   useEffect(() => {
     let cancelled = false;
@@ -1162,11 +1217,14 @@ export function TestTemplateEditor({
         });
 
         const preparedRun = await prepareSingleTestCaseRun({
-          workspaceId,
+          workspaceId: isDirectGuest ? null : workspaceId,
           suite,
           testCase: currentTestCase,
           selectedModel: modelValue,
-          getAccessToken,
+          // Guests have no WorkOS session; calling WorkOS `getAccessToken`
+          // directly throws `LoginRequiredError`. Swallow it — the inline
+          // guest path attaches the guest JWT separately.
+          getAccessToken: isDirectGuest ? async () => null : getAccessToken,
           getToken,
           hasToken,
           testCaseOverrides: {
@@ -1306,113 +1364,170 @@ export function TestTemplateEditor({
           compareAbortControllersRef.current[modelValue] = abortController;
 
           try {
-            await streamEvalTestCase(
-              {
-                ...request.request,
-                compareRunId,
-                skipLastMessageRunUpdate: true,
-              },
-              (event) => {
-                if (compareRequestGenByModelRef.current[modelValue] !== myGen)
-                  return;
+            const handleStreamEvent = (event: any) => {
+              if (compareRequestGenByModelRef.current[modelValue] !== myGen) {
+                return;
+              }
 
-                if (event.type === "complete") {
-                  const record = buildCompareRunRecord({
-                    modelValue,
-                    modelLabel,
-                    iteration: (event.iteration as EvalIteration) ?? null,
-                    completedAt: Date.now(),
-                  });
-                  setCompareRunRecords((previous) => ({
-                    ...previous,
-                    [modelValue]: {
-                      ...record,
-                      streamingTrace: previous[modelValue]?.streamingTrace,
-                      streamingDraftMessages:
-                        previous[modelValue]?.streamingDraftMessages,
-                      streamingActualToolCalls:
-                        previous[modelValue]?.streamingActualToolCalls,
-                      streamingMetrics: previous[modelValue]?.streamingMetrics,
-                    },
-                  }));
+              if (event.type === "complete") {
+                const iteration = event.iteration
+                  ? ({
+                      ...event.iteration,
+                      ...(isDirectGuest
+                        ? {
+                            testCaseId: currentTestCase._id,
+                            metadata: {
+                              ...(event.iteration.metadata ?? {}),
+                              compareRunId,
+                            },
+                          }
+                        : {}),
+                    } as EvalIteration)
+                  : null;
 
-                  posthog.capture("compare_model_completed", {
-                    location: "test_template_editor",
-                    platform: detectPlatform(),
-                    environment: detectEnvironment(),
-                    suite_id: suiteId,
-                    test_case_id: currentTestCase._id,
-                    compare_run_id: compareRunId,
-                    model: modelValue,
-                    result: record.result ?? "unknown",
-                    duration_ms: record.metrics.durationMs ?? null,
-                    tool_call_count: record.metrics.toolCallCount,
-                    mismatch_count: record.metrics.mismatchCount,
-                  });
-                  return;
+                if (isDirectGuest && iteration) {
+                  useGuestEvalsStore.getState().addIteration(iteration);
                 }
 
-                if (event.type === "error") {
-                  setCompareRunRecords((previous) => {
-                    const existing = previous[modelValue];
-                    const failedRecord: CompareRunRecord = {
-                      ...buildCompareRunRecord({
-                        modelValue,
-                        modelLabel,
-                        iteration: null,
-                        error: event.message,
-                        startedAt: existing?.startedAt ?? Date.now(),
-                        completedAt: Date.now(),
-                      }),
-                      status: "failed",
-                      error: event.message,
-                      streamingTrace: existing?.streamingTrace,
-                      streamingDraftMessages: existing?.streamingDraftMessages,
-                      streamingActualToolCalls:
-                        existing?.streamingActualToolCalls,
-                      streamingMetrics: existing?.streamingMetrics,
-                    };
-                    return {
-                      ...previous,
-                      [modelValue]: failedRecord,
-                    };
-                  });
-                  return;
-                }
+                const record = buildCompareRunRecord({
+                  modelValue,
+                  modelLabel,
+                  iteration,
+                  completedAt: Date.now(),
+                });
+                setCompareRunRecords((previous) => ({
+                  ...previous,
+                  [modelValue]: {
+                    ...record,
+                    streamingTrace: previous[modelValue]?.streamingTrace,
+                    streamingDraftMessages:
+                      previous[modelValue]?.streamingDraftMessages,
+                    streamingActualToolCalls:
+                      previous[modelValue]?.streamingActualToolCalls,
+                    streamingMetrics: previous[modelValue]?.streamingMetrics,
+                  },
+                }));
 
-                // Reduce stream event into progressive state
+                posthog.capture("compare_model_completed", {
+                  location: "test_template_editor",
+                  platform: detectPlatform(),
+                  environment: detectEnvironment(),
+                  suite_id: suiteId,
+                  test_case_id: currentTestCase._id,
+                  compare_run_id: compareRunId,
+                  model: modelValue,
+                  result: record.result ?? "unknown",
+                  duration_ms: record.metrics.durationMs ?? null,
+                  tool_call_count: record.metrics.toolCallCount,
+                  mismatch_count: record.metrics.mismatchCount,
+                });
+                return;
+              }
+
+              if (event.type === "error") {
                 setCompareRunRecords((previous) => {
                   const existing = previous[modelValue];
-                  if (!existing) return previous;
-                  const streamState = reduceEvalStreamEvent(
-                    {
-                      trace: existing.streamingTrace ?? null,
-                      draftMessages: existing.streamingDraftMessages ?? [],
-                      actualToolCalls: existing.streamingActualToolCalls ?? [],
-                      tokensUsed: existing.streamingMetrics?.tokensUsed ?? 0,
-                      toolCallCount:
-                        existing.streamingMetrics?.toolCallCount ?? 0,
-                      currentTurnIndex: initialEvalStreamState.currentTurnIndex,
-                    },
-                    event,
-                  );
+                  const failedRecord: CompareRunRecord = {
+                    ...buildCompareRunRecord({
+                      modelValue,
+                      modelLabel,
+                      iteration: null,
+                      error: event.message,
+                      startedAt: existing?.startedAt ?? Date.now(),
+                      completedAt: Date.now(),
+                    }),
+                    status: "failed",
+                    error: event.message,
+                    streamingTrace: existing?.streamingTrace,
+                    streamingDraftMessages: existing?.streamingDraftMessages,
+                    streamingActualToolCalls:
+                      existing?.streamingActualToolCalls,
+                    streamingMetrics: existing?.streamingMetrics,
+                  };
                   return {
                     ...previous,
-                    [modelValue]: {
-                      ...existing,
-                      streamingTrace: streamState.trace ?? undefined,
-                      streamingDraftMessages: streamState.draftMessages,
-                      streamingActualToolCalls: streamState.actualToolCalls,
-                      streamingMetrics: {
-                        tokensUsed: streamState.tokensUsed,
-                        toolCallCount: streamState.toolCallCount,
-                      },
-                    },
+                    [modelValue]: failedRecord,
                   };
                 });
-              },
-              abortController.signal,
-            );
+                return;
+              }
+
+              setCompareRunRecords((previous) => {
+                const existing = previous[modelValue];
+                if (!existing) return previous;
+                const streamState = reduceEvalStreamEvent(
+                  {
+                    trace: existing.streamingTrace ?? null,
+                    draftMessages: existing.streamingDraftMessages ?? [],
+                    actualToolCalls: existing.streamingActualToolCalls ?? [],
+                    tokensUsed: existing.streamingMetrics?.tokensUsed ?? 0,
+                    toolCallCount:
+                      existing.streamingMetrics?.toolCallCount ?? 0,
+                    currentTurnIndex: initialEvalStreamState.currentTurnIndex,
+                  },
+                  event,
+                );
+                return {
+                  ...previous,
+                  [modelValue]: {
+                    ...existing,
+                    streamingTrace: streamState.trace ?? undefined,
+                    streamingDraftMessages: streamState.draftMessages,
+                    streamingActualToolCalls: streamState.actualToolCalls,
+                    streamingMetrics: {
+                      tokensUsed: streamState.tokensUsed,
+                      toolCallCount: streamState.toolCallCount,
+                    },
+                  },
+                };
+              });
+            };
+
+            if (isDirectGuest) {
+              const serverName = suite.environment?.servers?.[0];
+              if (!serverName) {
+                throw new Error(
+                  "Guest runs need a server on this suite's environment.",
+                );
+              }
+              const [providerPart, ...modelParts] = modelValue.split("/");
+              await streamInlineEvalTestCaseGuest(
+                {
+                  serverNameOrId: serverName,
+                  provider: providerPart ?? "",
+                  model: modelParts.join("/"),
+                  compareRunId,
+                  modelApiKeys: request.request.modelApiKeys,
+                  test: {
+                    title: currentTestCase.title,
+                    query: savePayload.query,
+                    runs: savePayload.runs,
+                    expectedToolCalls:
+                      (savePayload.expectedToolCalls as Array<{
+                        toolName: string;
+                        arguments: Record<string, unknown>;
+                      }>) ?? [],
+                    isNegativeTest: savePayload.isNegativeTest,
+                    scenario: savePayload.scenario,
+                    expectedOutput: savePayload.expectedOutput,
+                    promptTurns: savePayload.promptTurns,
+                    advancedConfig: savePayload.advancedConfig,
+                  },
+                },
+                handleStreamEvent,
+                abortController.signal,
+              );
+            } else {
+              await streamEvalTestCase(
+                {
+                  ...request.request,
+                  compareRunId,
+                  skipLastMessageRunUpdate: true,
+                },
+                handleStreamEvent,
+                abortController.signal,
+              );
+            }
 
             // Stream completed — return the final record
             return new Promise<CompareRunRecord>((resolve) => {
@@ -1761,7 +1876,7 @@ export function TestTemplateEditor({
                     disabled={!editForm}
                   >
                     <Code2 className="mr-2 h-3.5 w-3.5" />
-                    Export
+                    Setup SDK
                   </Button>
                 ) : null}
                 {hasUnsavedChanges ? (

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -1,5 +1,9 @@
 import type { PromptTurn } from "@/shared/prompt-turns";
-import type { EvalTraceBlobV1 } from "@/shared/eval-trace";
+import type {
+  EvalTraceBlobV1,
+  EvalTraceSpan,
+  PromptTraceSummary,
+} from "@/shared/eval-trace";
 import type { EvalStreamToolCall } from "@/shared/eval-stream-events";
 import type { TraceMessage } from "./trace-viewer-adapter";
 
@@ -102,6 +106,9 @@ export type EvalIteration = {
   iterationNumber: number;
   updatedAt: number;
   blob?: string;
+  messages?: EvalTraceBlobV1["messages"];
+  spans?: EvalTraceSpan[];
+  prompts?: PromptTraceSummary[];
   status: "pending" | "running" | "completed" | "failed" | "cancelled";
   result: "pending" | "passed" | "failed" | "cancelled";
   actualToolCalls: Array<{

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -29,9 +29,11 @@ import {
   getEvalApiEndpoints,
   runEvals,
   runEvalTestCase,
+  runInlineEvalTestCaseGuest,
 } from "@/lib/apis/evals-api";
 import { generateAndPersistEvalTests } from "@/lib/evals/generate-and-persist-tests";
 import { collectUniqueModelsFromTestCases } from "@/lib/evals/collect-unique-suite-models";
+import { useGuestEvalsStore } from "@/stores/guest-evals-store";
 import {
   getDefaultTestCaseModelValue,
   prepareSingleTestCaseRun,
@@ -66,6 +68,8 @@ interface UseEvalHandlersProps {
    * routes (`#/ci-evals/...`). Defaults to main evals (`#/evals/...`).
    */
   evalsNavigationContext?: "evals" | "ci-evals";
+  /** When true, all Convex reads/writes are routed through the guest store. */
+  isDirectGuest?: boolean;
 }
 
 /**
@@ -80,6 +84,7 @@ export function useEvalHandlers({
   connectedServerNames,
   latestRunBySuiteId,
   evalsNavigationContext = "evals",
+  isDirectGuest = false,
 }: UseEvalHandlersProps) {
   const convex = useConvex();
   const { getAccessToken } = useAuth();
@@ -471,10 +476,12 @@ export function useEvalHandlers({
         const preparedResults = await Promise.allSettled(
           modelValuesToRun.map((selectedModel) =>
             prepareSingleTestCaseRun({
-              workspaceId,
+              workspaceId: isDirectGuest ? null : workspaceId,
               suite,
               testCase,
-              getAccessToken,
+              getAccessToken: isDirectGuest
+                ? async () => null
+                : getAccessToken,
               getToken,
               hasToken,
               selectedModel,
@@ -524,10 +531,62 @@ export function useEvalHandlers({
             });
 
             try {
-              const data = await runEvalTestCase({
-                ...preparedRun.request,
-                skipLastMessageRunUpdate: isMultiModelRun || undefined,
-              });
+              const data = isDirectGuest
+                ? await (async () => {
+                    const serverName = suite.environment?.servers?.[0];
+                    if (!serverName) {
+                      throw new Error(
+                        "Guest runs need a server connected to this suite.",
+                      );
+                    }
+                    const [providerPart, ...modelParts] =
+                      preparedRun.modelValue.split("/");
+                    const modelName = modelParts.join("/");
+                    const result = await runInlineEvalTestCaseGuest({
+                      serverNameOrId: serverName,
+                      provider: providerPart!,
+                      model: modelName,
+                      modelApiKeys: preparedRun.request.modelApiKeys,
+                      test: {
+                        title: testCase.title,
+                        query: testCase.query,
+                        runs: testCase.runs,
+                        expectedToolCalls:
+                          (testCase.expectedToolCalls as Array<{
+                            toolName: string;
+                            arguments: Record<string, unknown>;
+                          }>) ?? [],
+                        isNegativeTest: testCase.isNegativeTest,
+                        scenario: testCase.scenario,
+                        expectedOutput: testCase.expectedOutput,
+                        promptTurns: testCase.promptTurns,
+                        advancedConfig: testCase.advancedConfig,
+                      },
+                    });
+                    if (result?.iteration) {
+                      const storeIteration = {
+                        ...result.iteration,
+                        testCaseId: testCase._id,
+                      };
+                      useGuestEvalsStore
+                        .getState()
+                        .addIteration(storeIteration);
+                      if (!isMultiModelRun) {
+                        useGuestEvalsStore
+                          .getState()
+                          .setLastMessageRun(
+                            testCase._id,
+                            storeIteration._id ?? null,
+                          );
+                      }
+                      return { ...result, iteration: storeIteration };
+                    }
+                    return result;
+                  })()
+                : await runEvalTestCase({
+                    ...preparedRun.request,
+                    skipLastMessageRunUpdate: isMultiModelRun || undefined,
+                  });
               const iteration = data?.iteration;
 
               if (iteration) {
@@ -647,6 +706,7 @@ export function useEvalHandlers({
       getAccessToken,
       getToken,
       hasToken,
+      isDirectGuest,
     ],
   );
 
@@ -800,12 +860,17 @@ export function useEvalHandlers({
 
       try {
         // Get test cases for the suite to extract models
-        const testCases = await convex.query(
-          "testSuites:listTestCases" as any,
-          { suiteId },
-        );
+        const testCases = isDirectGuest
+          ? useGuestEvalsStore.getState().listTestCases(suiteId)
+          : await convex.query("testSuites:listTestCases" as any, {
+              suiteId,
+            });
 
-        const modelsToUse = collectUniqueModelsFromTestCases(testCases);
+        const collectedModels = collectUniqueModelsFromTestCases(testCases);
+        const modelsToUse =
+          collectedModels.length > 0
+            ? collectedModels
+            : [{ provider: "anthropic", model: "anthropic/claude-haiku-4.5" }];
 
         const testCaseId = await mutations.createTestCaseMutation({
           suiteId: suiteId,
@@ -849,6 +914,7 @@ export function useEvalHandlers({
       mutations.createTestCaseMutation,
       convex,
       navigateAfterTestCaseMutation,
+      isDirectGuest,
     ],
   );
 
@@ -980,8 +1046,17 @@ export function useEvalHandlers({
           workspaceId,
           suiteId,
           serverIds,
-          createTestCase: mutations.createTestCaseMutation,
+          createTestCase: mutations.createTestCaseMutation as (
+            input: any,
+          ) => Promise<unknown>,
           skipIfExistingCases: false,
+          isDirectGuest,
+          listExistingCases: isDirectGuest
+            ? () =>
+                useGuestEvalsStore.getState().listTestCases(suiteId) as Array<
+                  Record<string, unknown>
+                >
+            : undefined,
         });
 
         if (outcome.apiReturnedTests === 0) {
@@ -1017,6 +1092,7 @@ export function useEvalHandlers({
       convex,
       mutations.createTestCaseMutation,
       workspaceId,
+      isDirectGuest,
     ],
   );
 

--- a/mcpjam-inspector/client/src/components/evals/use-eval-mutations.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-mutations.ts
@@ -1,36 +1,123 @@
+import { useMemo } from "react";
 import { useMutation } from "convex/react";
+import { useGuestEvalsStore } from "@/stores/guest-evals-store";
 
 /**
  * Hook for all eval mutations (delete, duplicate, cancel, etc.)
+ *
+ * When `isDirectGuest` is true, returns wrappers that read/write the
+ * guest evals store instead of Convex. Mutations that have no meaning
+ * for guests (run/cancel/duplicate-suite) throw.
  */
-export function useEvalMutations() {
-  const deleteSuiteMutation = useMutation("testSuites:deleteTestSuite" as any);
-  const deleteRunMutation = useMutation("testSuites:deleteTestSuiteRun" as any);
-  const cancelRunMutation = useMutation("testSuites:cancelTestSuiteRun" as any);
-  const duplicateSuiteMutation = useMutation(
+export function useEvalMutations({
+  isDirectGuest = false,
+}: { isDirectGuest?: boolean } = {}) {
+  const convexDeleteSuite = useMutation("testSuites:deleteTestSuite" as any);
+  const convexDeleteRun = useMutation("testSuites:deleteTestSuiteRun" as any);
+  const convexCancelRun = useMutation("testSuites:cancelTestSuiteRun" as any);
+  const convexDuplicateSuite = useMutation(
     "testSuites:duplicateTestSuite" as any,
   );
-  const createTestCaseMutation = useMutation(
+  const convexCreateTestCase = useMutation(
     "testSuites:createTestCase" as any,
   );
-  const deleteTestCaseMutation = useMutation(
+  const convexDeleteTestCase = useMutation(
     "testSuites:deleteTestCase" as any,
   );
-  const duplicateTestCaseMutation = useMutation(
+  const convexDuplicateTestCase = useMutation(
     "testSuites:duplicateTestCase" as any,
   );
-  const createTestSuiteMutation = useMutation(
+  const convexCreateTestSuite = useMutation(
     "testSuites:createTestSuite" as any,
   );
 
-  return {
-    deleteSuiteMutation,
-    deleteRunMutation,
-    cancelRunMutation,
-    duplicateSuiteMutation,
-    createTestCaseMutation,
-    deleteTestCaseMutation,
-    duplicateTestCaseMutation,
-    createTestSuiteMutation,
-  };
+  const guestStore = useGuestEvalsStore;
+
+  const mutations = useMemo(() => {
+    if (!isDirectGuest) {
+      return {
+        deleteSuiteMutation: convexDeleteSuite,
+        deleteRunMutation: convexDeleteRun,
+        cancelRunMutation: convexCancelRun,
+        duplicateSuiteMutation: convexDuplicateSuite,
+        createTestCaseMutation: convexCreateTestCase,
+        deleteTestCaseMutation: convexDeleteTestCase,
+        duplicateTestCaseMutation: convexDuplicateTestCase,
+        createTestSuiteMutation: convexCreateTestSuite,
+      };
+    }
+
+    const guestUnsupported = async () => {
+      throw new Error("Not available in guest mode");
+    };
+
+    return {
+      deleteSuiteMutation: async ({ suiteId: _suiteId }: { suiteId: string }) => {
+        // Suites are created per server and managed via the explore flow;
+        // guests never need to delete a suite directly.
+        return null;
+      },
+      deleteRunMutation: guestUnsupported,
+      cancelRunMutation: guestUnsupported,
+      duplicateSuiteMutation: guestUnsupported,
+      createTestCaseMutation: async (input: {
+        suiteId: string;
+        title: string;
+        query: string;
+        models: Array<{ model: string; provider: string }>;
+        runs?: number;
+        expectedToolCalls?: Array<{
+          toolName: string;
+          arguments: Record<string, unknown>;
+        }>;
+        isNegativeTest?: boolean;
+        scenario?: string;
+        expectedOutput?: string;
+        promptTurns?: any;
+        advancedConfig?: Record<string, unknown>;
+      }) => {
+        const created = guestStore.getState().createTestCase(input);
+        return created?._id ?? null;
+      },
+      deleteTestCaseMutation: async ({
+        testCaseId,
+      }: {
+        testCaseId: string;
+      }) => {
+        guestStore.getState().deleteTestCase(testCaseId);
+        return null;
+      },
+      duplicateTestCaseMutation: async ({
+        testCaseId,
+      }: {
+        testCaseId: string;
+      }) => {
+        const copy = guestStore.getState().duplicateTestCase(testCaseId);
+        return copy ?? null;
+      },
+      createTestSuiteMutation: async (args: {
+        workspaceId?: string | null;
+        name: string;
+        description?: string;
+        environment?: { servers?: string[] };
+      }) => {
+        const serverName = args.environment?.servers?.[0] ?? args.name;
+        const suite = guestStore.getState().ensureSuite(serverName);
+        return suite;
+      },
+    };
+  }, [
+    isDirectGuest,
+    convexDeleteSuite,
+    convexDeleteRun,
+    convexCancelRun,
+    convexDuplicateSuite,
+    convexCreateTestCase,
+    convexDeleteTestCase,
+    convexDuplicateTestCase,
+    convexCreateTestSuite,
+    guestStore,
+  ]);
+
+  return mutations;
 }

--- a/mcpjam-inspector/client/src/components/evals/use-eval-queries.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-queries.ts
@@ -1,10 +1,25 @@
 import { useMemo } from "react";
 import { useQuery } from "convex/react";
+import { useShallow } from "zustand/react/shallow";
+import { useGuestEvalsStore } from "@/stores/guest-evals-store";
 import type {
+  EvalSuite,
   EvalSuiteOverviewEntry,
   SuiteDetailsQueryResponse,
   EvalSuiteRun,
 } from "./types";
+
+const EMPTY_GUEST_SUITES: EvalSuite[] = [];
+
+function buildGuestOverviewEntry(suite: EvalSuite): EvalSuiteOverviewEntry {
+  return {
+    suite,
+    latestRun: null,
+    recentRuns: [],
+    passRateTrend: [],
+    totals: { passed: 0, failed: 0, runs: 0 },
+  };
+}
 
 /**
  * Hook for fetching eval data (overview, suite details, and runs)
@@ -16,6 +31,7 @@ export function useEvalQueries({
   deletingSuiteId,
   workspaceId,
   organizationId,
+  isDirectGuest = false,
 }: {
   isAuthenticated: boolean;
   user: any;
@@ -23,10 +39,43 @@ export function useEvalQueries({
   deletingSuiteId: string | null;
   workspaceId: string | null;
   organizationId: string | null;
+  isDirectGuest?: boolean;
 }) {
-  // Overview query - list all suites
-  const enableOverviewQuery = isAuthenticated && !!user;
-  const suiteOverview = useQuery(
+  // ── Guest branch: all data sourced from the local store ────────────────
+  const guestSuites = useGuestEvalsStore(
+    useShallow((state) => {
+      if (!isDirectGuest) return EMPTY_GUEST_SUITES;
+      return Object.values(state.serverBuckets).map((bucket) => bucket.suite);
+    }),
+  );
+  const guestSelectedBucket = useGuestEvalsStore((state) => {
+    if (!isDirectGuest || !selectedSuiteId) return null;
+    return (
+      Object.values(state.serverBuckets).find(
+        (bucket) => bucket.suite._id === selectedSuiteId,
+      ) ?? null
+    );
+  });
+
+  const guestOverview = useMemo<EvalSuiteOverviewEntry[]>(() => {
+    if (!isDirectGuest) return [];
+    return guestSuites.map(buildGuestOverviewEntry);
+  }, [guestSuites, isDirectGuest]);
+
+  const guestSuiteDetails = useMemo<SuiteDetailsQueryResponse | undefined>(
+    () => {
+      if (!isDirectGuest || !guestSelectedBucket) return undefined;
+      return {
+        testCases: guestSelectedBucket.testCases,
+        iterations: guestSelectedBucket.iterations,
+      };
+    },
+    [guestSelectedBucket, isDirectGuest],
+  );
+
+  // Overview query - list all suites (skipped for guests)
+  const enableOverviewQuery = !isDirectGuest && isAuthenticated && !!user;
+  const suiteOverviewFromConvex = useQuery(
     "testSuites:getTestSuitesOverview" as any,
     enableOverviewQuery
       ? ({
@@ -36,24 +85,36 @@ export function useEvalQueries({
       : "skip",
   ) as EvalSuiteOverviewEntry[] | undefined;
 
+  const suiteOverview = isDirectGuest
+    ? guestOverview
+    : suiteOverviewFromConvex;
+
   // Suite details query - full suite data for selected suite
   const enableSuiteDetailsQuery =
+    !isDirectGuest &&
     isAuthenticated &&
     !!user &&
     !!selectedSuiteId &&
     deletingSuiteId !== selectedSuiteId;
-  const suiteDetails = useQuery(
+  const suiteDetailsFromConvex = useQuery(
     "testSuites:getAllTestCasesAndIterationsBySuite" as any,
     enableSuiteDetailsQuery ? ({ suiteId: selectedSuiteId } as any) : "skip",
   ) as SuiteDetailsQueryResponse | undefined;
 
-  // Suite runs query - runs for selected suite
-  const suiteRuns = useQuery(
+  const suiteDetails = isDirectGuest
+    ? guestSuiteDetails
+    : suiteDetailsFromConvex;
+
+  // Suite runs query - runs for selected suite (always empty for guests)
+  const suiteRunsFromConvex = useQuery(
     "testSuites:listTestSuiteRuns" as any,
     enableSuiteDetailsQuery
       ? ({ suiteId: selectedSuiteId, limit: 20 } as any)
       : "skip",
   ) as EvalSuiteRun[] | undefined;
+
+  const EMPTY_RUNS: EvalSuiteRun[] = useMemo(() => [], []);
+  const suiteRuns = isDirectGuest ? EMPTY_RUNS : suiteRunsFromConvex;
 
   // Loading states
   const isOverviewLoading = enableOverviewQuery && suiteOverview === undefined;
@@ -62,12 +123,18 @@ export function useEvalQueries({
   const isSuiteRunsLoading = enableSuiteDetailsQuery && suiteRuns === undefined;
 
   // Selected suite entry from overview
+  const guestSelectedSuiteEntry = useMemo(() => {
+    if (!isDirectGuest || !guestSelectedBucket) return null;
+    return buildGuestOverviewEntry(guestSelectedBucket.suite);
+  }, [guestSelectedBucket, isDirectGuest]);
+
   const selectedSuiteEntry = useMemo(() => {
+    if (isDirectGuest) return guestSelectedSuiteEntry;
     if (!selectedSuiteId || !suiteOverview) return null;
     return (
       suiteOverview.find((entry) => entry.suite._id === selectedSuiteId) ?? null
     );
-  }, [selectedSuiteId, suiteOverview]);
+  }, [guestSelectedSuiteEntry, isDirectGuest, selectedSuiteId, suiteOverview]);
 
   const selectedSuite = selectedSuiteEntry?.suite ?? null;
 

--- a/mcpjam-inspector/client/src/components/evals/use-eval-trace-blob.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-trace-blob.ts
@@ -1,15 +1,43 @@
 import { useAction } from "convex/react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { EvalTraceBlobV1 } from "@/shared/eval-trace";
 import type { EvalIteration } from "./types";
+
+function buildInlineTraceBlob(
+  iteration: EvalIteration | null,
+): EvalTraceBlobV1 | null {
+  if (!iteration) {
+    return null;
+  }
+
+  const hasMessages =
+    Array.isArray(iteration.messages) && iteration.messages.length > 0;
+  const hasSpans = Array.isArray(iteration.spans) && iteration.spans.length > 0;
+  const hasPrompts =
+    Array.isArray(iteration.prompts) && iteration.prompts.length > 0;
+
+  if (!hasMessages && !hasSpans && !hasPrompts) {
+    return null;
+  }
+
+  return {
+    traceVersion: 1,
+    messages: iteration.messages ?? [],
+    ...(hasSpans ? { spans: iteration.spans } : {}),
+    ...(hasPrompts ? { prompts: iteration.prompts } : {}),
+  };
+}
 
 export function useEvalTraceBlob({
   iteration,
   onTraceLoaded,
   enabled = true,
+  retryKey = 0,
 }: {
   iteration: EvalIteration | null;
   onTraceLoaded?: () => void;
   enabled?: boolean;
+  retryKey?: number;
 }) {
   const getBlob = useAction(
     "testSuites:getTestIterationBlob" as any,
@@ -23,6 +51,11 @@ export function useEvalTraceBlob({
     onTraceLoadedRef.current = onTraceLoaded;
   }, [onTraceLoaded]);
 
+  const inlineTraceBlob = useMemo(
+    () => buildInlineTraceBlob(iteration),
+    [iteration],
+  );
+
   useEffect(() => {
     let cancelled = false;
 
@@ -31,6 +64,14 @@ export function useEvalTraceBlob({
         setBlob(null);
         setLoading(false);
         setError(null);
+        return;
+      }
+
+      if (!iteration?.blob && inlineTraceBlob) {
+        setBlob(inlineTraceBlob);
+        setLoading(false);
+        setError(null);
+        onTraceLoadedRef.current?.();
         return;
       }
 
@@ -68,7 +109,7 @@ export function useEvalTraceBlob({
     return () => {
       cancelled = true;
     };
-  }, [enabled, getBlob, iteration?.blob]);
+  }, [enabled, getBlob, inlineTraceBlob, iteration?.blob, retryKey]);
 
   return {
     blob,

--- a/mcpjam-inspector/client/src/hooks/use-eval-tab-context.ts
+++ b/mcpjam-inspector/client/src/hooks/use-eval-tab-context.ts
@@ -2,19 +2,27 @@ import { useMemo } from "react";
 import { useSharedAppState } from "@/state/app-state-context";
 import { useWorkspaceMembers } from "@/hooks/useWorkspaces";
 import { useAvailableEvalModels } from "@/hooks/use-available-eval-models";
+import {
+  isMCPJamGuestAllowedModel,
+  isMCPJamProvidedModel,
+} from "@/shared/types";
+
+const GUEST_LOCKED_MODEL_REASON = "Sign in to use MCPJam provided models";
 
 export function useEvalTabContext({
   isAuthenticated,
   workspaceId,
+  isDirectGuest = false,
 }: {
   isAuthenticated: boolean;
   workspaceId: string | null;
+  isDirectGuest?: boolean;
 }) {
   const appState = useSharedAppState();
-  const { availableModels } = useAvailableEvalModels();
+  const { availableModels: rawAvailableModels } = useAvailableEvalModels();
   const { members, canManageMembers } = useWorkspaceMembers({
-    isAuthenticated,
-    workspaceId,
+    isAuthenticated: isDirectGuest ? false : isAuthenticated,
+    workspaceId: isDirectGuest ? null : workspaceId,
   });
 
   const connectedServerNames = useMemo(
@@ -27,12 +35,32 @@ export function useEvalTabContext({
     [appState.servers],
   );
 
+  // Mirror chat's guest model policy: keep the same hosted models visible but
+  // disable any MCPJam-provided model that guests cannot run.
+  const availableModels = useMemo(() => {
+    if (!isDirectGuest) return rawAvailableModels;
+    return rawAvailableModels
+      .filter((model) => isMCPJamProvidedModel(String(model.id)))
+      .map((model) => {
+        const modelId = String(model.id);
+        if (isMCPJamGuestAllowedModel(modelId)) {
+          return model;
+        }
+        return {
+          ...model,
+          disabled: true,
+          disabledReason: GUEST_LOCKED_MODEL_REASON,
+        };
+      });
+  }, [isDirectGuest, rawAvailableModels]);
+
   // Suite visibility already implies suite access; let the backend mutation
   // remain the source of truth for whether deletion is allowed.
   const canDeleteSuite = true;
-  const canDeleteRuns = !workspaceId || canManageMembers;
+  const canDeleteRuns = isDirectGuest || !workspaceId || canManageMembers;
 
   const userMap = useMemo(() => {
+    if (isDirectGuest) return new Map<string, { name: string; imageUrl?: string }>();
     if (!members) return undefined;
     const map = new Map<string, { name: string; imageUrl?: string }>();
     for (const member of members) {
@@ -44,7 +72,7 @@ export function useEvalTabContext({
       }
     }
     return map;
-  }, [members]);
+  }, [members, isDirectGuest]);
 
   return {
     connectedServerNames,

--- a/mcpjam-inspector/client/src/hooks/use-is-direct-guest.ts
+++ b/mcpjam-inspector/client/src/hooks/use-is-direct-guest.ts
@@ -1,0 +1,30 @@
+import { useAuth } from "@workos-inc/authkit-react";
+import { useConvexAuth } from "convex/react";
+
+/**
+ * True when the current session has no WorkOS/Convex identity and no workspace.
+ * "Direct guest" covers both hosted (mcpjam.com, no sign-in) and local (npx /
+ * electron without sign-in) surfaces. In both cases, eval data is kept in the
+ * local guest store, and runs use the inline path that skips Convex writes.
+ *
+ * Shared/sandbox guests (have workspaceId + share/sandbox token) are NOT direct
+ * guests; they still use Convex-backed flows via the share/sandbox token.
+ */
+export function useIsDirectGuest({
+  workspaceId,
+  shareToken,
+  sandboxToken,
+}: {
+  workspaceId?: string | null;
+  shareToken?: string | null;
+  sandboxToken?: string | null;
+} = {}): boolean {
+  const { isAuthenticated, isLoading } = useConvexAuth();
+  const { user } = useAuth();
+
+  if (isLoading) return false;
+  if (isAuthenticated || user) return false;
+  if (workspaceId) return false;
+  if (shareToken || sandboxToken) return false;
+  return true;
+}

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/evals-api.hosted.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/evals-api.hosted.test.ts
@@ -4,6 +4,7 @@ import { createFetchResponse } from "@/test";
 const authFetchMock = vi.fn();
 const listHostedToolsMock = vi.fn();
 const buildHostedServerBatchRequestMock = vi.fn();
+const buildHostedServerRequestMock = vi.fn();
 
 vi.mock("@/lib/config", () => ({
   HOSTED_MODE: true,
@@ -20,6 +21,8 @@ vi.mock("@/lib/apis/web/tools-api", () => ({
 vi.mock("@/lib/apis/web/context", () => ({
   buildHostedServerBatchRequest: (...args: unknown[]) =>
     buildHostedServerBatchRequestMock(...args),
+  buildHostedServerRequest: (...args: unknown[]) =>
+    buildHostedServerRequestMock(...args),
 }));
 
 import {
@@ -28,6 +31,7 @@ import {
   listEvalTools,
   runEvals,
   runEvalTestCase,
+  streamInlineEvalTestCaseGuest,
   streamEvalTestCase,
 } from "../evals-api";
 
@@ -54,6 +58,11 @@ describe("evals-api hosted mode", () => {
         };
       },
     );
+    buildHostedServerRequestMock.mockImplementation((serverName: string) => ({
+      serverUrl: `https://${serverName.toLowerCase().replace(/\s+/g, "-")}.example.com/mcp`,
+      serverHeaders: { Authorization: "Bearer guest-oauth-token" },
+      serverName,
+    }));
     authFetchMock.mockResolvedValue(createFetchResponse({ success: true }));
   });
 
@@ -227,6 +236,82 @@ describe("evals-api hosted mode", () => {
       expect.objectContaining({
         type: "complete",
         iteration: { _id: "iter-1" },
+      }),
+    ]);
+  });
+
+  it("uses /api/web/evals/stream-test-case-inline for hosted guest compare streaming", async () => {
+    const encoder = new TextEncoder();
+    authFetchMock.mockResolvedValueOnce(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              encoder.encode(
+                [
+                  'data: {"type":"trace_snapshot","turnIndex":0,"snapshotKind":"step_finish","trace":{"traceVersion":1,"messages":[{"role":"user","content":"Hello"}]},"actualToolCalls":[],"usage":{"inputTokens":1,"outputTokens":1,"totalTokens":2}}',
+                  "",
+                  'data: {"type":"complete","iteration":{"_id":"guestiter-1"}}',
+                  "",
+                ].join("\n"),
+              ),
+            );
+            controller.close();
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        },
+      ),
+    );
+
+    const events: unknown[] = [];
+    await streamInlineEvalTestCaseGuest(
+      {
+        serverNameOrId: "Server A",
+        model: "gpt-4",
+        provider: "openai",
+        compareRunId: "cmp_guest",
+        test: {
+          title: "Guest compare",
+          query: "Hello",
+        },
+      },
+      (event) => {
+        events.push(event);
+      },
+    );
+
+    expect(buildHostedServerRequestMock).toHaveBeenCalledWith("Server A");
+    expect(authFetchMock).toHaveBeenCalledWith(
+      "/api/web/evals/stream-test-case-inline",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+
+    const body = JSON.parse(authFetchMock.mock.calls[0][1].body);
+    expect(body).toMatchObject({
+      serverIds: ["__guest__"],
+      serverUrl: "https://server-a.example.com/mcp",
+      serverHeaders: { Authorization: "Bearer guest-oauth-token" },
+      model: "gpt-4",
+      provider: "openai",
+      compareRunId: "cmp_guest",
+      test: {
+        title: "Guest compare",
+        query: "Hello",
+      },
+    });
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "trace_snapshot",
+        snapshotKind: "step_finish",
+      }),
+      expect.objectContaining({
+        type: "complete",
+        iteration: { _id: "guestiter-1" },
       }),
     ]);
   });

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/evals-api.local.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/evals-api.local.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authFetchMock = vi.hoisted(() => vi.fn());
+const getGuestBearerTokenMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/config", () => ({
+  HOSTED_MODE: false,
+}));
+
+vi.mock("@/lib/session-token", () => ({
+  authFetch: (...args: unknown[]) => authFetchMock(...args),
+  getSessionToken: () => null,
+}));
+
+vi.mock("@/lib/guest-session", () => ({
+  getGuestBearerToken: (...args: unknown[]) => getGuestBearerTokenMock(...args),
+}));
+
+import {
+  runInlineEvalTestCaseGuest,
+  streamInlineEvalTestCaseGuest,
+} from "../evals-api";
+
+describe("evals-api local guest mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getGuestBearerTokenMock.mockResolvedValue(null);
+  });
+
+  it("fails fast when local guest inline run cannot obtain a guest token", async () => {
+    await expect(
+      runInlineEvalTestCaseGuest({
+        serverNameOrId: "server-a",
+        model: "claude-haiku-4.5",
+        provider: "anthropic",
+        test: {
+          title: "Guest inline run",
+          query: "hello",
+        },
+      }),
+    ).rejects.toThrow(
+      "Could not obtain a guest session. Try refreshing the page.",
+    );
+
+    expect(getGuestBearerTokenMock).toHaveBeenCalledTimes(1);
+    expect(authFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("fails fast when local guest inline streaming cannot obtain a guest token", async () => {
+    await expect(
+      streamInlineEvalTestCaseGuest(
+        {
+          serverNameOrId: "server-a",
+          model: "claude-haiku-4.5",
+          provider: "anthropic",
+          test: {
+            title: "Guest inline stream",
+            query: "hello",
+          },
+        },
+        vi.fn(),
+      ),
+    ).rejects.toThrow(
+      "Could not obtain a guest session. Try refreshing the page.",
+    );
+
+    expect(getGuestBearerTokenMock).toHaveBeenCalledTimes(1);
+    expect(authFetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/lib/apis/evals-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/evals-api.ts
@@ -302,6 +302,14 @@ function buildGuestEvalServerFragment(
   return serverPayload;
 }
 
+async function requireGuestSessionToken(): Promise<string> {
+  const guestToken = await getGuestBearerToken();
+  if (!guestToken) {
+    throw new Error("Could not obtain a guest session. Try refreshing the page.");
+  }
+  return guestToken;
+}
+
 /**
  * Guest-mode variant of `generateEvalTests`. In hosted mode, sends the direct
  * serverUrl body shape that `withEphemeralConnection`'s guest path recognizes.
@@ -323,12 +331,7 @@ export async function generateEvalTestsGuest({
     return postEvalRequest(EVALS_API_ENDPOINTS.hosted.generateTests, body);
   }
 
-  const guestToken = await getGuestBearerToken();
-  if (!guestToken) {
-    throw new Error(
-      "Could not obtain a guest session. Try refreshing the page.",
-    );
-  }
+  const guestToken = await requireGuestSessionToken();
   const body: JsonRecord = {
     serverIds: [serverNameOrId],
     convexAuthToken: guestToken,
@@ -383,7 +386,7 @@ export async function runInlineEvalTestCaseGuest(
 
   // Local mode: attach guest JWT so Convex-routed LLM calls (MCPJam models)
   // are authorized; direct provider calls via AI SDK ignore this token.
-  const guestToken = await getGuestBearerToken();
+  const guestToken = await requireGuestSessionToken();
   const body: JsonRecord = {
     serverIds: [request.serverNameOrId],
     model: request.model,
@@ -577,7 +580,7 @@ export async function streamInlineEvalTestCaseGuest(
     );
   }
 
-  const guestToken = await getGuestBearerToken();
+  const guestToken = await requireGuestSessionToken();
   const payload: JsonRecord = {
     serverIds: [request.serverNameOrId],
     model: request.model,

--- a/mcpjam-inspector/client/src/lib/apis/evals-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/evals-api.ts
@@ -4,9 +4,11 @@ import { getSessionToken } from "@/lib/session-token";
 import {
   buildHostedEvalServerBatchRequest,
   buildHostedServerBatchRequest,
+  buildHostedServerRequest,
 } from "@/lib/apis/web/context";
 import { listHostedTools } from "@/lib/apis/web/tools-api";
 import { authFetch } from "@/lib/session-token";
+import { getGuestBearerToken } from "@/lib/guest-session";
 import type { EvalStreamEvent } from "@/shared/eval-stream-events";
 import type { PromptTurn } from "@/shared/prompt-turns";
 
@@ -16,7 +18,9 @@ export const EVALS_API_ENDPOINTS = {
     generateTests: "/api/mcp/evals/generate-tests",
     generateNegativeTests: "/api/mcp/evals/generate-negative-tests",
     runTestCase: "/api/mcp/evals/run-test-case",
+    runTestCaseInline: "/api/mcp/evals/run-test-case-inline",
     streamTestCase: "/api/mcp/evals/stream-test-case",
+    streamTestCaseInline: "/api/mcp/evals/stream-test-case-inline",
     replayRun: "/api/mcp/evals/replay-run",
     traceRepairStart: "/api/mcp/evals/trace-repair/start",
     traceRepairStop: "/api/mcp/evals/trace-repair/stop",
@@ -26,7 +30,9 @@ export const EVALS_API_ENDPOINTS = {
     generateTests: "/api/web/evals/generate-tests",
     generateNegativeTests: "/api/web/evals/generate-negative-tests",
     runTestCase: "/api/web/evals/run-test-case",
+    runTestCaseInline: "/api/web/evals/run-test-case-inline",
     streamTestCase: "/api/web/evals/stream-test-case",
+    streamTestCaseInline: "/api/web/evals/stream-test-case-inline",
     replayRun: "/api/web/evals/replay-run",
     traceRepairStart: "/api/web/evals/trace-repair/start",
     traceRepairStop: "/api/web/evals/trace-repair/stop",
@@ -269,6 +275,205 @@ export async function generateEvalTests(
   });
 }
 
+type GuestServerPayload = {
+  serverUrl: string;
+  serverHeaders?: Record<string, string>;
+  serverName?: string;
+  oauthAccessToken?: string;
+  clientCapabilities?: Record<string, unknown>;
+};
+
+/**
+ * Shape the guest server descriptor into the body fragment that
+ * `withEphemeralConnection`'s guest path expects. Callers spread this into
+ * their request body alongside `serverIds: ["__guest__"]`.
+ */
+function buildGuestEvalServerFragment(
+  serverNameOrId: string,
+): GuestServerPayload {
+  const serverPayload = buildHostedServerRequest(
+    serverNameOrId,
+  ) as GuestServerPayload;
+  if (!serverPayload.serverUrl) {
+    throw new Error(
+      `Guest eval request requires a direct serverUrl for "${serverNameOrId}". Is the server configured locally?`,
+    );
+  }
+  return serverPayload;
+}
+
+/**
+ * Guest-mode variant of `generateEvalTests`. In hosted mode, sends the direct
+ * serverUrl body shape that `withEphemeralConnection`'s guest path recognizes.
+ * In local mode (npx/electron), sends the normal body shape to the local
+ * `/api/mcp/evals/generate-tests` and attaches a guest JWT as `convexAuthToken`
+ * so the Convex LLM proxy accepts the request.
+ */
+export async function generateEvalTestsGuest({
+  serverNameOrId,
+}: {
+  serverNameOrId: string;
+}): Promise<GenerateEvalTestsResponse> {
+  if (isHostedMode()) {
+    const serverPayload = buildGuestEvalServerFragment(serverNameOrId);
+    const body: JsonRecord = {
+      serverIds: ["__guest__"],
+      ...serverPayload,
+    };
+    return postEvalRequest(EVALS_API_ENDPOINTS.hosted.generateTests, body);
+  }
+
+  const guestToken = await getGuestBearerToken();
+  if (!guestToken) {
+    throw new Error(
+      "Could not obtain a guest session. Try refreshing the page.",
+    );
+  }
+  const body: JsonRecord = {
+    serverIds: [serverNameOrId],
+    convexAuthToken: guestToken,
+  };
+  return postEvalRequest(EVALS_API_ENDPOINTS.local.generateTests, body);
+}
+
+export type RunInlineEvalTestCaseGuestRequest = {
+  serverNameOrId: string;
+  model: string;
+  provider: string;
+  compareRunId?: string;
+  modelApiKeys?: Record<string, string>;
+  test: {
+    title: string;
+    query: string;
+    runs?: number;
+    expectedToolCalls?: Array<{
+      toolName: string;
+      arguments: Record<string, unknown>;
+    }>;
+    isNegativeTest?: boolean;
+    scenario?: string;
+    expectedOutput?: string;
+    promptTurns?: PromptTurn[];
+    advancedConfig?: Record<string, unknown>;
+  };
+};
+
+/**
+ * Guest-mode inline run. Hosted mode hits the hosted inline endpoint using the
+ * direct serverUrl body. Local mode (npx/electron) hits the local inline route
+ * which uses the persistent MCP client manager. Both paths run the test with
+ * an ephemeral recorder and return the full iteration object for local storage.
+ */
+export async function runInlineEvalTestCaseGuest(
+  request: RunInlineEvalTestCaseGuestRequest,
+): Promise<{ success: boolean; iteration: any }> {
+  if (isHostedMode()) {
+    const serverPayload = buildGuestEvalServerFragment(request.serverNameOrId);
+    const body: JsonRecord = {
+      serverIds: ["__guest__"],
+      ...serverPayload,
+      model: request.model,
+      provider: request.provider,
+      ...(request.compareRunId ? { compareRunId: request.compareRunId } : {}),
+      ...(request.modelApiKeys ? { modelApiKeys: request.modelApiKeys } : {}),
+      test: request.test as unknown as JsonRecord,
+    };
+    return postEvalRequest(EVALS_API_ENDPOINTS.hosted.runTestCaseInline, body);
+  }
+
+  // Local mode: attach guest JWT so Convex-routed LLM calls (MCPJam models)
+  // are authorized; direct provider calls via AI SDK ignore this token.
+  const guestToken = await getGuestBearerToken();
+  const body: JsonRecord = {
+    serverIds: [request.serverNameOrId],
+    model: request.model,
+    provider: request.provider,
+    ...(request.compareRunId ? { compareRunId: request.compareRunId } : {}),
+    ...(request.modelApiKeys ? { modelApiKeys: request.modelApiKeys } : {}),
+    test: request.test as unknown as JsonRecord,
+    ...(guestToken ? { convexAuthToken: guestToken } : {}),
+  };
+  return postEvalRequest(EVALS_API_ENDPOINTS.local.runTestCaseInline, body);
+}
+
+async function streamEvalRequest(
+  endpoint: string,
+  payload: JsonRecord,
+  onEvent: (event: EvalStreamEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const response = await authFetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    signal,
+  });
+
+  if (!response.ok) {
+    let errorMessage = `Request failed (${response.status})`;
+    try {
+      const body = await response.json();
+      if (typeof body?.error === "string") errorMessage = body.error;
+      else if (typeof body?.message === "string") errorMessage = body.message;
+    } catch {
+      // ignore parse errors
+    }
+    throw new Error(errorMessage);
+  }
+
+  const reader = response.body?.getReader();
+  if (!reader) {
+    throw new Error("No response body for streaming");
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+  const emitSseLine = (line: string) => {
+    const trimmedLine = line.trim();
+    if (!trimmedLine.startsWith("data: ")) {
+      return;
+    }
+    const data = trimmedLine.slice(6).trim();
+    if (!data || data === "[DONE]") {
+      return;
+    }
+    try {
+      const event = JSON.parse(data) as EvalStreamEvent;
+      onEvent(event);
+    } catch {
+      // ignore malformed lines
+    }
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || "";
+
+      for (const line of lines) {
+        emitSseLine(line);
+      }
+    }
+
+    buffer += decoder.decode();
+    for (const line of buffer.split("\n")) {
+      emitSseLine(line);
+    }
+  } finally {
+    try {
+      reader.releaseLock?.();
+    } catch {
+      // ignore
+    }
+  }
+}
+
 export async function generateNegativeEvalTests(
   request: GenerateTestsRequest,
 ): Promise<GenerateEvalTestsResponse> {
@@ -345,74 +550,47 @@ export async function streamEvalTestCase(
     ? (mergeHostedServerBatch(request) as JsonRecord)
     : (request as JsonRecord);
 
-  const response = await authFetch(endpoint, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-    signal,
-  });
+  return streamEvalRequest(endpoint, payload, onEvent, signal);
+}
 
-  if (!response.ok) {
-    let errorMessage = `Request failed (${response.status})`;
-    try {
-      const body = await response.json();
-      if (typeof body?.error === "string") errorMessage = body.error;
-      else if (typeof body?.message === "string") errorMessage = body.message;
-    } catch {
-      // ignore parse errors
-    }
-    throw new Error(errorMessage);
+export async function streamInlineEvalTestCaseGuest(
+  request: RunInlineEvalTestCaseGuestRequest,
+  onEvent: (event: EvalStreamEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (isHostedMode()) {
+    const serverPayload = buildGuestEvalServerFragment(request.serverNameOrId);
+    const payload: JsonRecord = {
+      serverIds: ["__guest__"],
+      ...serverPayload,
+      model: request.model,
+      provider: request.provider,
+      ...(request.compareRunId ? { compareRunId: request.compareRunId } : {}),
+      ...(request.modelApiKeys ? { modelApiKeys: request.modelApiKeys } : {}),
+      test: request.test as unknown as JsonRecord,
+    };
+    return streamEvalRequest(
+      EVALS_API_ENDPOINTS.hosted.streamTestCaseInline,
+      payload,
+      onEvent,
+      signal,
+    );
   }
 
-  const reader = response.body?.getReader();
-  if (!reader) {
-    throw new Error("No response body for streaming");
-  }
-
-  const decoder = new TextDecoder();
-  let buffer = "";
-  const emitSseLine = (line: string) => {
-    const trimmedLine = line.trim();
-    if (!trimmedLine.startsWith("data: ")) {
-      return;
-    }
-    const data = trimmedLine.slice(6).trim();
-    if (!data || data === "[DONE]") {
-      return;
-    }
-    try {
-      const event = JSON.parse(data) as EvalStreamEvent;
-      onEvent(event);
-    } catch {
-      // ignore malformed lines
-    }
+  const guestToken = await getGuestBearerToken();
+  const payload: JsonRecord = {
+    serverIds: [request.serverNameOrId],
+    model: request.model,
+    provider: request.provider,
+    ...(request.compareRunId ? { compareRunId: request.compareRunId } : {}),
+    ...(request.modelApiKeys ? { modelApiKeys: request.modelApiKeys } : {}),
+    test: request.test as unknown as JsonRecord,
+    ...(guestToken ? { convexAuthToken: guestToken } : {}),
   };
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
-      }
-
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop() || "";
-
-      for (const line of lines) {
-        emitSseLine(line);
-      }
-    }
-
-    buffer += decoder.decode();
-    for (const line of buffer.split("\n")) {
-      emitSseLine(line);
-    }
-  } finally {
-    try {
-      reader.releaseLock?.();
-    } catch {
-      // ignore
-    }
-  }
+  return streamEvalRequest(
+    EVALS_API_ENDPOINTS.local.streamTestCaseInline,
+    payload,
+    onEvent,
+    signal,
+  );
 }

--- a/mcpjam-inspector/client/src/lib/evals/generate-and-persist-tests.ts
+++ b/mcpjam-inspector/client/src/lib/evals/generate-and-persist-tests.ts
@@ -1,6 +1,7 @@
 import type { ConvexReactClient } from "convex/react";
 import {
   generateEvalTests,
+  generateEvalTestsGuest,
   type GeneratedEvalTestCase,
 } from "@/lib/apis/evals-api";
 import type { PromptTurn } from "@/shared/prompt-turns";
@@ -102,6 +103,14 @@ export type GenerateAndPersistEvalTestsOptions = {
   createTestCase: (input: CreateEvalTestCaseInput) => Promise<unknown>;
   /** When true, skips API call and creation if the suite already has test cases. */
   skipIfExistingCases?: boolean;
+  /**
+   * When true, uses the guest generate path (direct serverUrl, no Convex) and
+   * skips Convex-backed existing-case lookup. Caller is responsible for
+   * providing a `listExistingCases` function to mirror the same skip behavior.
+   */
+  isDirectGuest?: boolean;
+  /** Override the listing source (used for guest mode, where Convex is not available). */
+  listExistingCases?: () => Array<Record<string, unknown>> | Promise<Array<Record<string, unknown>>>;
 };
 
 export type GenerateAndPersistEvalTestsResult = {
@@ -121,16 +130,23 @@ export async function generateAndPersistEvalTests(
     serverIds,
     createTestCase,
     skipIfExistingCases = false,
+    isDirectGuest = false,
+    listExistingCases,
   } = options;
 
-  const existingTestCases = await convex.query(
-    "testSuites:listTestCases" as any,
-    { suiteId },
-  );
-
-  const existingList = Array.isArray(existingTestCases)
-    ? (existingTestCases as Array<Record<string, unknown>>)
-    : [];
+  let existingList: Array<Record<string, unknown>> = [];
+  if (listExistingCases) {
+    const listed = await listExistingCases();
+    existingList = Array.isArray(listed) ? listed : [];
+  } else if (!isDirectGuest) {
+    const existingTestCases = await convex.query(
+      "testSuites:listTestCases" as any,
+      { suiteId },
+    );
+    existingList = Array.isArray(existingTestCases)
+      ? (existingTestCases as Array<Record<string, unknown>>)
+      : [];
+  }
 
   if (skipIfExistingCases && existingList.length > 0) {
     return {
@@ -145,16 +161,21 @@ export async function generateAndPersistEvalTests(
     modelsToUse = defaultEvalModels();
   }
 
-  const accessToken = await getAccessToken();
-  if (!accessToken) {
+  // Guests don't have a WorkOS token; the guest JWT is attached via authFetch.
+  const accessToken = isDirectGuest
+    ? undefined
+    : (await getAccessToken()) ?? null;
+  if (!isDirectGuest && !accessToken) {
     throw new Error("Not authenticated");
   }
 
-  const result = await generateEvalTests({
-    workspaceId,
-    serverIds,
-    convexAuthToken: accessToken,
-  });
+  const result = isDirectGuest
+    ? await generateEvalTestsGuest({ serverNameOrId: serverIds[0]! })
+    : await generateEvalTests({
+        workspaceId,
+        serverIds,
+        convexAuthToken: accessToken,
+      });
 
   const tests = result.tests ?? [];
   if (tests.length === 0) {

--- a/mcpjam-inspector/client/src/stores/guest-evals-store.ts
+++ b/mcpjam-inspector/client/src/stores/guest-evals-store.ts
@@ -1,0 +1,354 @@
+import { create } from "zustand";
+import { persist, createJSONStorage } from "zustand/middleware";
+import type {
+  EvalCase,
+  EvalIteration,
+  EvalSuite,
+} from "@/components/evals/types";
+
+export const GUEST_USER_ID = "__guest__";
+
+/**
+ * Build a URL-safe suite id for the guest store. Server names can contain
+ * colons, spaces, parentheses, etc. which the browser URL-encodes in the
+ * hash — keeping the id free of those characters avoids a redirect loop
+ * where `route.suiteId` (decoded by the router) doesn't match the suite id
+ * we store (see `getPlaygroundCasesRedirect`).
+ */
+function guestSuiteId(serverName: string): string {
+  const safe = serverName.replace(/[^A-Za-z0-9_-]/g, "_");
+  return `guestsuite-${safe}`;
+}
+
+function makeIdSuffix(): string {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID().replace(/[^A-Za-z0-9]/g, "");
+  }
+  return `${Date.now()}${Math.random().toString(36).slice(2)}`;
+}
+
+function now(): number {
+  return Date.now();
+}
+
+type ServerBucket = {
+  suite: EvalSuite;
+  testCases: EvalCase[];
+  iterations: EvalIteration[];
+};
+
+interface GuestEvalsStoreState {
+  serverBuckets: Record<string, ServerBucket>;
+  ensureSuite: (serverName: string) => EvalSuite;
+  getSuite: (serverName: string) => EvalSuite | null;
+  getSuiteById: (suiteId: string) => EvalSuite | null;
+  getBucketBySuiteId: (suiteId: string) => ServerBucket | null;
+  listTestCases: (suiteId: string) => EvalCase[];
+  createTestCase: (input: {
+    suiteId: string;
+    title: string;
+    query: string;
+    models: Array<{ model: string; provider: string }>;
+    expectedToolCalls?: Array<{
+      toolName: string;
+      arguments: Record<string, unknown>;
+    }>;
+    runs?: number;
+    isNegativeTest?: boolean;
+    scenario?: string;
+    expectedOutput?: string;
+    promptTurns?: EvalCase["promptTurns"];
+    advancedConfig?: Record<string, unknown>;
+  }) => EvalCase | null;
+  updateTestCase: (testCaseId: string, updates: Partial<EvalCase>) => void;
+  deleteTestCase: (testCaseId: string) => void;
+  duplicateTestCase: (testCaseId: string) => EvalCase | null;
+  addIteration: (iteration: EvalIteration) => void;
+  updateIteration: (
+    iterationId: string,
+    updates: Partial<EvalIteration>,
+  ) => void;
+  deleteIteration: (iterationId: string) => void;
+  setLastMessageRun: (testCaseId: string, iterationId: string | null) => void;
+}
+
+function makeId(prefix: string): string {
+  return `guest${prefix}-${makeIdSuffix()}`;
+}
+
+function findBucketByTestCaseId(
+  state: GuestEvalsStoreState,
+  testCaseId: string,
+): [string, ServerBucket] | null {
+  for (const [serverName, bucket] of Object.entries(state.serverBuckets)) {
+    if (bucket.testCases.some((c) => c._id === testCaseId)) {
+      return [serverName, bucket];
+    }
+  }
+  return null;
+}
+
+function findBucketByIterationId(
+  state: GuestEvalsStoreState,
+  iterationId: string,
+): [string, ServerBucket] | null {
+  for (const [serverName, bucket] of Object.entries(state.serverBuckets)) {
+    if (bucket.iterations.some((i) => i._id === iterationId)) {
+      return [serverName, bucket];
+    }
+  }
+  return null;
+}
+
+export const useGuestEvalsStore = create<GuestEvalsStoreState>()(
+  persist(
+    (set, get) => ({
+      serverBuckets: {},
+
+      ensureSuite: (serverName) => {
+        const existing = get().serverBuckets[serverName];
+        if (existing) {
+          return existing.suite;
+        }
+        const suite: EvalSuite = {
+          _id: guestSuiteId(serverName),
+          createdBy: GUEST_USER_ID,
+          name: serverName,
+          description: `Explore cases for ${serverName}`,
+          configRevision: "",
+          environment: { servers: [serverName] },
+          createdAt: now(),
+          updatedAt: now(),
+          source: "ui",
+          runCounter: 0,
+          tags: ["explore"],
+        };
+        set((state) => ({
+          serverBuckets: {
+            ...state.serverBuckets,
+            [serverName]: {
+              suite,
+              testCases: [],
+              iterations: [],
+            },
+          },
+        }));
+        return suite;
+      },
+
+      getSuite: (serverName) =>
+        get().serverBuckets[serverName]?.suite ?? null,
+
+      getSuiteById: (suiteId) => {
+        for (const bucket of Object.values(get().serverBuckets)) {
+          if (bucket.suite._id === suiteId) return bucket.suite;
+        }
+        return null;
+      },
+
+      getBucketBySuiteId: (suiteId) => {
+        for (const bucket of Object.values(get().serverBuckets)) {
+          if (bucket.suite._id === suiteId) return bucket;
+        }
+        return null;
+      },
+
+      listTestCases: (suiteId) => {
+        const bucket = get().getBucketBySuiteId(suiteId);
+        return bucket?.testCases ?? [];
+      },
+
+      createTestCase: (input) => {
+        const state = get();
+        let matchedServer: string | null = null;
+        for (const [serverName, bucket] of Object.entries(state.serverBuckets)) {
+          if (bucket.suite._id === input.suiteId) {
+            matchedServer = serverName;
+            break;
+          }
+        }
+        if (!matchedServer) return null;
+
+        const testCase: EvalCase = {
+          _id: makeId("case"),
+          testSuiteId: input.suiteId,
+          createdBy: GUEST_USER_ID,
+          title: input.title,
+          query: input.query,
+          models: input.models,
+          runs: input.runs ?? 1,
+          expectedToolCalls: (input.expectedToolCalls ?? []) as EvalCase["expectedToolCalls"],
+          isNegativeTest: input.isNegativeTest,
+          scenario: input.scenario,
+          expectedOutput: input.expectedOutput,
+          promptTurns: input.promptTurns,
+          advancedConfig: input.advancedConfig,
+          _creationTime: now(),
+        };
+
+        set((current) => {
+          const bucket = current.serverBuckets[matchedServer!]!;
+          return {
+            serverBuckets: {
+              ...current.serverBuckets,
+              [matchedServer!]: {
+                ...bucket,
+                suite: { ...bucket.suite, updatedAt: now() },
+                testCases: [...bucket.testCases, testCase],
+              },
+            },
+          };
+        });
+
+        return testCase;
+      },
+
+      updateTestCase: (testCaseId, updates) => {
+        const match = findBucketByTestCaseId(get(), testCaseId);
+        if (!match) return;
+        const [serverName, bucket] = match;
+        set((current) => ({
+          serverBuckets: {
+            ...current.serverBuckets,
+            [serverName]: {
+              ...bucket,
+              suite: { ...bucket.suite, updatedAt: now() },
+              testCases: bucket.testCases.map((c) =>
+                c._id === testCaseId ? { ...c, ...updates } : c,
+              ),
+            },
+          },
+        }));
+      },
+
+      deleteTestCase: (testCaseId) => {
+        const match = findBucketByTestCaseId(get(), testCaseId);
+        if (!match) return;
+        const [serverName, bucket] = match;
+        set((current) => ({
+          serverBuckets: {
+            ...current.serverBuckets,
+            [serverName]: {
+              ...bucket,
+              suite: { ...bucket.suite, updatedAt: now() },
+              testCases: bucket.testCases.filter((c) => c._id !== testCaseId),
+              iterations: bucket.iterations.filter(
+                (i) => i.testCaseId !== testCaseId,
+              ),
+            },
+          },
+        }));
+      },
+
+      duplicateTestCase: (testCaseId) => {
+        const state = get();
+        const match = findBucketByTestCaseId(state, testCaseId);
+        if (!match) return null;
+        const [serverName, bucket] = match;
+        const source = bucket.testCases.find((c) => c._id === testCaseId);
+        if (!source) return null;
+
+        const copy: EvalCase = {
+          ...source,
+          _id: makeId("case"),
+          title: `${source.title} (copy)`,
+          _creationTime: now(),
+          lastMessageRun: null,
+        };
+
+        set((current) => {
+          const currentBucket = current.serverBuckets[serverName]!;
+          return {
+            serverBuckets: {
+              ...current.serverBuckets,
+              [serverName]: {
+                ...currentBucket,
+                suite: { ...currentBucket.suite, updatedAt: now() },
+                testCases: [...currentBucket.testCases, copy],
+              },
+            },
+          };
+        });
+
+        return copy;
+      },
+
+      addIteration: (iteration) => {
+        if (!iteration.testCaseId) return;
+        const match = findBucketByTestCaseId(get(), iteration.testCaseId);
+        if (!match) return;
+        const [serverName, bucket] = match;
+        set((current) => ({
+          serverBuckets: {
+            ...current.serverBuckets,
+            [serverName]: {
+              ...bucket,
+              iterations: [iteration, ...bucket.iterations],
+            },
+          },
+        }));
+      },
+
+      updateIteration: (iterationId, updates) => {
+        const match = findBucketByIterationId(get(), iterationId);
+        if (!match) return;
+        const [serverName, bucket] = match;
+        set((current) => ({
+          serverBuckets: {
+            ...current.serverBuckets,
+            [serverName]: {
+              ...bucket,
+              iterations: bucket.iterations.map((i) =>
+                i._id === iterationId ? { ...i, ...updates } : i,
+              ),
+            },
+          },
+        }));
+      },
+
+      deleteIteration: (iterationId) => {
+        const match = findBucketByIterationId(get(), iterationId);
+        if (!match) return;
+        const [serverName, bucket] = match;
+        set((current) => ({
+          serverBuckets: {
+            ...current.serverBuckets,
+            [serverName]: {
+              ...bucket,
+              iterations: bucket.iterations.filter(
+                (i) => i._id !== iterationId,
+              ),
+            },
+          },
+        }));
+      },
+
+      setLastMessageRun: (testCaseId, iterationId) => {
+        const match = findBucketByTestCaseId(get(), testCaseId);
+        if (!match) return;
+        const [serverName, bucket] = match;
+        set((current) => ({
+          serverBuckets: {
+            ...current.serverBuckets,
+            [serverName]: {
+              ...bucket,
+              testCases: bucket.testCases.map((c) =>
+                c._id === testCaseId
+                  ? { ...c, lastMessageRun: iterationId }
+                  : c,
+              ),
+            },
+          },
+        }));
+      },
+    }),
+    {
+      // v2: ID format changed from `guest:suite:…`/`guest:case:…` to
+      // URL-safe hyphen form. Old persisted data is abandoned on upgrade so
+      // stale colon-containing IDs don't re-trigger the router redirect loop.
+      name: "mcpjam_guest_evals_v2",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({ serverBuckets: state.serverBuckets }),
+    },
+  ),
+);

--- a/mcpjam-inspector/server/routes/mcp/__tests__/evals-inline-stream.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/evals-inline-stream.test.ts
@@ -1,0 +1,85 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const streamInlineEvalTestCaseWithManagerMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../shared/evals.js", async () => {
+  const actual = await vi.importActual<typeof import("../../shared/evals.js")>(
+    "../../shared/evals.js",
+  );
+  return {
+    ...actual,
+    streamInlineEvalTestCaseWithManager: (...args: unknown[]) =>
+      streamInlineEvalTestCaseWithManagerMock(...args),
+  };
+});
+
+import evalsRoutes from "../evals";
+
+function createApp() {
+  const app = new Hono();
+  app.route("/api/mcp/evals", evalsRoutes);
+  return app;
+}
+
+describe("mcp eval inline stream route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const encoder = new TextEncoder();
+    streamInlineEvalTestCaseWithManagerMock.mockResolvedValue(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              'data: {"type":"complete","iterationId":"guestiter-1","iteration":{"_id":"guestiter-1"}}\n\n',
+            ),
+          );
+          controller.close();
+        },
+      }),
+    );
+  });
+
+  it("streams guest inline compare runs from /api/mcp/evals/stream-test-case-inline", async () => {
+    const response = await createApp().request(
+      "/api/mcp/evals/stream-test-case-inline",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          serverIds: ["srv"],
+          model: "gpt-4",
+          provider: "openai",
+          compareRunId: "cmp_guest",
+          convexAuthToken: "guest-token",
+          test: {
+            title: "Guest compare",
+            query: "hello",
+          },
+        }),
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    await expect(response.text()).resolves.toContain('"type":"complete"');
+    expect(streamInlineEvalTestCaseWithManagerMock).toHaveBeenCalledTimes(1);
+    expect(
+      streamInlineEvalTestCaseWithManagerMock.mock.calls[0]?.[1],
+    ).toEqual(
+      expect.objectContaining({
+        serverIds: ["srv"],
+        model: "gpt-4",
+        provider: "openai",
+        compareRunId: "cmp_guest",
+      }),
+    );
+    expect(
+      streamInlineEvalTestCaseWithManagerMock.mock.calls[0]?.[2],
+    ).toEqual({
+      convexAuthToken: "guest-token",
+    });
+  });
+});

--- a/mcpjam-inspector/server/routes/mcp/evals.ts
+++ b/mcpjam-inspector/server/routes/mcp/evals.ts
@@ -10,11 +10,14 @@ import {
   GenerateNegativeTestsRequestSchema,
   GenerateTestsRequestSchema,
   RunEvalsRequestSchema,
+  RunInlineTestCaseRequestSchema,
   RunTestCaseRequestSchema,
   generateEvalTestsWithManager,
   generateNegativeEvalTestsWithManager,
   runEvalsWithManager,
   runEvalTestCaseWithManager,
+  runInlineEvalTestCaseWithManager,
+  streamInlineEvalTestCaseWithManager,
   streamEvalTestCaseWithManager,
 } from "../shared/evals.js";
 
@@ -240,6 +243,42 @@ evals.post("/run-test-case", async (c) => {
   }
 });
 
+/**
+ * Local inline run — used by the guest playground in npx/electron. Accepts the
+ * full test config inline so no Convex testCase record is required. Writes are
+ * captured by an in-memory recorder; the iteration is returned to the client.
+ * `convexAuthToken` (guest JWT) is only used by the Convex-routed LLM proxy
+ * when MCPJam-provided models are selected.
+ */
+evals.post("/run-test-case-inline", async (c) => {
+  try {
+    const body = await c.req.json();
+    const validationResult = RunInlineTestCaseRequestSchema.safeParse(body);
+    if (!validationResult.success) {
+      return c.json(
+        {
+          error: "Invalid request body",
+          details: validationResult.error.issues,
+        },
+        400,
+      );
+    }
+
+    return c.json(
+      await runInlineEvalTestCaseWithManager(
+        c.mcpClientManager,
+        validationResult.data,
+        {
+          convexAuthToken: validationResult.data.convexAuthToken ?? "",
+        },
+      ),
+    );
+  } catch (error) {
+    logger.error("[Error running inline test case]", error);
+    return jsonRouteError(c, error);
+  }
+});
+
 evals.post("/stream-test-case", async (c) => {
   try {
     const body = await c.req.json();
@@ -268,6 +307,41 @@ evals.post("/stream-test-case", async (c) => {
     });
   } catch (error) {
     logger.error("[Error streaming test case]", error);
+    return jsonRouteError(c, error);
+  }
+});
+
+evals.post("/stream-test-case-inline", async (c) => {
+  try {
+    const body = await c.req.json();
+    const validationResult = RunInlineTestCaseRequestSchema.safeParse(body);
+    if (!validationResult.success) {
+      return c.json(
+        {
+          error: "Invalid request body",
+          details: validationResult.error.issues,
+        },
+        400,
+      );
+    }
+
+    const stream = await streamInlineEvalTestCaseWithManager(
+      c.mcpClientManager,
+      validationResult.data,
+      {
+        convexAuthToken: validationResult.data.convexAuthToken ?? "",
+      },
+    );
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  } catch (error) {
+    logger.error("[Error streaming inline test case]", error);
     return jsonRouteError(c, error);
   }
 });

--- a/mcpjam-inspector/server/routes/shared/__tests__/evals-inline-stream.test.ts
+++ b/mcpjam-inspector/server/routes/shared/__tests__/evals-inline-stream.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const streamTestCaseMock = vi.hoisted(() => vi.fn());
+const convexSetAuthMock = vi.hoisted(() => vi.fn());
+
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: vi.fn().mockImplementation(() => ({
+    setAuth: convexSetAuthMock,
+  })),
+}));
+
+vi.mock("../../../services/evals-runner", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../../services/evals-runner")>(
+      "../../../services/evals-runner",
+    );
+  return {
+    ...actual,
+    streamTestCase: (...args: unknown[]) => streamTestCaseMock(...args),
+  };
+});
+
+import { streamInlineEvalTestCaseWithManager } from "../evals";
+
+describe("streamInlineEvalTestCaseWithManager", () => {
+  const originalConvexUrl = process.env.CONVEX_URL;
+  const originalConvexHttpUrl = process.env.CONVEX_HTTP_URL;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_URL = "https://convex.example";
+    process.env.CONVEX_HTTP_URL = "https://convex-http.example";
+  });
+
+  afterEach(() => {
+    if (originalConvexUrl === undefined) {
+      delete process.env.CONVEX_URL;
+    } else {
+      process.env.CONVEX_URL = originalConvexUrl;
+    }
+    if (originalConvexHttpUrl === undefined) {
+      delete process.env.CONVEX_HTTP_URL;
+    } else {
+      process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
+    }
+  });
+
+  it("aborts the inline runner when the response stream is cancelled", async () => {
+    let capturedAbortSignal: AbortSignal | undefined;
+    let resolveStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+    const onStreamComplete = vi.fn();
+    const getToolsForAiSdk = vi.fn().mockResolvedValue({});
+
+    streamTestCaseMock.mockImplementation(
+      async (params: { abortSignal?: AbortSignal }) => {
+        capturedAbortSignal = params.abortSignal;
+        resolveStarted();
+        await new Promise<void>((resolve) => {
+          if (params.abortSignal?.aborted) {
+            resolve();
+            return;
+          }
+          params.abortSignal?.addEventListener("abort", () => resolve(), {
+            once: true,
+          });
+        });
+        return [];
+      },
+    );
+
+    const stream = await streamInlineEvalTestCaseWithManager(
+      {
+        listServers: () => ["srv"],
+        getToolsForAiSdk,
+      } as any,
+      {
+        serverIds: ["srv"],
+        model: "gpt-4",
+        provider: "openai",
+        test: {
+          title: "Guest compare",
+          query: "hello",
+        },
+      },
+      {
+        convexAuthToken: "guest-token",
+        onStreamComplete,
+      },
+    );
+
+    const reader = stream.getReader();
+    const readPromise = reader.read();
+    await started;
+
+    await reader.cancel();
+    await expect(readPromise).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+
+    expect(getToolsForAiSdk).toHaveBeenCalledWith(["srv"]);
+    expect(capturedAbortSignal?.aborted).toBe(true);
+    expect(convexSetAuthMock).toHaveBeenCalledWith("guest-token");
+    expect(onStreamComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -785,6 +785,8 @@ export async function streamInlineEvalTestCaseWithManager(
   )) as Record<string, any>;
   const recorder = createEphemeralRunRecorder();
   const encoder = new TextEncoder();
+  const abortController = new AbortController();
+  let cancelled = false;
 
   const sseEncode = (event: EvalStreamEvent): Uint8Array =>
     encoder.encode(`data: ${JSON.stringify(event)}\n\n`);
@@ -802,6 +804,7 @@ export async function streamInlineEvalTestCaseWithManager(
           convexClient,
           suiteId: recorder.suiteId,
           runId: null,
+          abortSignal: abortController.signal,
           compareRunId,
           persist: false,
           emit: (event: EvalStreamEvent) => {
@@ -812,6 +815,10 @@ export async function streamInlineEvalTestCaseWithManager(
             }
           },
         });
+
+        if (cancelled || abortController.signal.aborted) {
+          return;
+        }
 
         const expectedIterationId = outcomes[0]?.iterationId;
         const iteration =
@@ -829,6 +836,10 @@ export async function streamInlineEvalTestCaseWithManager(
           );
         }
 
+        if (cancelled || abortController.signal.aborted) {
+          return;
+        }
+
         controller.enqueue(
           sseEncode({
             type: "complete",
@@ -837,6 +848,13 @@ export async function streamInlineEvalTestCaseWithManager(
           }),
         );
       } catch (error) {
+        if (
+          cancelled ||
+          abortController.signal.aborted ||
+          (error instanceof Error && error.name === "AbortError")
+        ) {
+          return;
+        }
         const message = error instanceof Error ? error.message : String(error);
         controller.enqueue(
           sseEncode({
@@ -856,6 +874,10 @@ export async function streamInlineEvalTestCaseWithManager(
         }
         options.onStreamComplete?.();
       }
+    },
+    cancel() {
+      cancelled = true;
+      abortController.abort();
     },
   });
 }

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -6,7 +6,10 @@ import {
   convertToEvalTestCases,
   generateNegativeTestCases,
 } from "../../services/negative-test-agent";
-import { startSuiteRunWithRecorder } from "../../services/evals/recorder";
+import {
+  createEphemeralRunRecorder,
+  startSuiteRunWithRecorder,
+} from "../../services/evals/recorder";
 import {
   captureToolSnapshotForEvalAuthoring,
   storeReplayConfig,
@@ -122,6 +125,57 @@ export const RunTestCaseRequestSchema = z.object({
 });
 
 export type RunTestCaseRequest = z.infer<typeof RunTestCaseRequestSchema>;
+
+/**
+ * Inline run request — carries the full test case config in the body so the
+ * runner never reads/writes Convex. Used by the guest playground where no
+ * Convex-backed testCase exists.
+ */
+export const RunInlineTestCaseRequestSchema = z.object({
+  model: z.string(),
+  provider: z.string(),
+  compareRunId: z.string().optional(),
+  serverIds: z
+    .array(z.string())
+    .min(1, { message: "At least one server must be selected" }),
+  modelApiKeys: z.record(z.string(), z.string()).optional(),
+  /**
+   * Optional bearer used only for Convex-routed LLM calls (MCPJam-provided
+   * models). Direct provider runs via AI SDK do not use this token. In hosted
+   * mode this is set from the Authorization header; in local mode the client
+   * passes a guest JWT inline.
+   */
+  convexAuthToken: z.string().optional(),
+  test: z.object({
+    title: z.string(),
+    query: z.string(),
+    runs: z.number().int().positive().optional(),
+    expectedToolCalls: z
+      .array(
+        z.object({
+          toolName: z.string(),
+          arguments: z.record(z.string(), z.any()),
+        }),
+      )
+      .optional(),
+    isNegativeTest: z.boolean().optional(),
+    scenario: z.string().optional(),
+    expectedOutput: z.string().optional(),
+    promptTurns: z.array(promptTurnSchema).optional(),
+    advancedConfig: z
+      .object({
+        system: z.string().optional(),
+        temperature: z.number().optional(),
+        toolChoice: toolChoiceSchema.optional(),
+      })
+      .passthrough()
+      .optional(),
+  }),
+});
+
+export type RunInlineTestCaseRequest = z.infer<
+  typeof RunInlineTestCaseRequestSchema
+>;
 
 export const GenerateTestsRequestSchema = z.object({
   serverIds: z
@@ -620,6 +674,190 @@ export async function runEvalTestCaseWithManager(
     message: "Test case completed successfully",
     iteration: latestIteration,
   };
+}
+
+/**
+ * Guest-mode counterpart to `runEvalTestCaseWithManager`. Runs an inline test
+ * case using an in-memory recorder so iterations never hit Convex. Returns the
+ * full iteration payload (with messages/spans) for the client to store locally.
+ *
+ * Callers: the guest inline run route. `convexAuthToken` is the guest JWT and
+ * is passed through so the streaming endpoint (for MCPJam-provided models)
+ * can still authorize the backend LLM call.
+ */
+export async function runInlineEvalTestCaseWithManager(
+  clientManager: MCPClientManager,
+  request: RunInlineTestCaseRequest,
+  options: { convexAuthToken: string },
+) {
+  const { model, provider, compareRunId, serverIds, modelApiKeys, test } =
+    request;
+  const resolvedServerIds = resolveServerIdsOrThrow(serverIds, clientManager);
+  const { convexClient, convexHttpUrl } = createConvexClients(
+    options.convexAuthToken,
+  );
+
+  const recorder = createEphemeralRunRecorder();
+  const testForRunner = {
+    title: test.title,
+    query: test.query,
+    runs: test.runs ?? 1,
+    model,
+    provider,
+    expectedToolCalls: (test.expectedToolCalls ?? []) as Array<{
+      toolName: string;
+      arguments: Record<string, any>;
+    }>,
+    isNegativeTest: test.isNegativeTest,
+    scenario: test.scenario,
+    expectedOutput: test.expectedOutput,
+    promptTurns: test.promptTurns as PromptTurn[] | undefined,
+    advancedConfig: test.advancedConfig,
+  };
+
+  await runEvalSuiteWithAiSdk({
+    suiteId: recorder.suiteId,
+    runId: null,
+    config: {
+      tests: [testForRunner],
+      environment: { servers: resolvedServerIds },
+    },
+    modelApiKeys: modelApiKeys ?? undefined,
+    convexClient,
+    convexHttpUrl,
+    convexAuthToken: options.convexAuthToken,
+    mcpClientManager: clientManager,
+    recorder,
+    persist: false,
+    compareRunId,
+  });
+
+  const [iteration] = recorder.getIterations();
+  if (!iteration) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Inline run did not produce an iteration",
+    );
+  }
+
+  return {
+    success: true,
+    message: "Test case completed successfully",
+    iteration,
+  };
+}
+
+export async function streamInlineEvalTestCaseWithManager(
+  clientManager: MCPClientManager,
+  request: RunInlineTestCaseRequest,
+  options: {
+    convexAuthToken: string;
+    onStreamComplete?: () => void;
+  },
+): Promise<ReadableStream<Uint8Array>> {
+  const { model, provider, compareRunId, serverIds, modelApiKeys, test } =
+    request;
+  const resolvedServerIds = resolveServerIdsOrThrow(serverIds, clientManager);
+  const { convexClient, convexHttpUrl } = createConvexClients(
+    options.convexAuthToken,
+  );
+
+  const testForRunner = {
+    title: test.title,
+    query: test.query,
+    runs: test.runs ?? 1,
+    model,
+    provider,
+    expectedToolCalls: (test.expectedToolCalls ?? []) as Array<{
+      toolName: string;
+      arguments: Record<string, any>;
+    }>,
+    isNegativeTest: test.isNegativeTest,
+    scenario: test.scenario,
+    expectedOutput: test.expectedOutput,
+    promptTurns: test.promptTurns as PromptTurn[] | undefined,
+    advancedConfig: test.advancedConfig,
+  };
+
+  const tools = (await clientManager.getToolsForAiSdk(
+    resolvedServerIds,
+  )) as Record<string, any>;
+  const recorder = createEphemeralRunRecorder();
+  const encoder = new TextEncoder();
+
+  const sseEncode = (event: EvalStreamEvent): Uint8Array =>
+    encoder.encode(`data: ${JSON.stringify(event)}\n\n`);
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        const outcomes = await streamTestCase({
+          test: testForRunner,
+          tools,
+          recorder,
+          modelApiKeys: modelApiKeys ?? undefined,
+          convexHttpUrl,
+          convexAuthToken: options.convexAuthToken,
+          convexClient,
+          suiteId: recorder.suiteId,
+          runId: null,
+          compareRunId,
+          persist: false,
+          emit: (event: EvalStreamEvent) => {
+            try {
+              controller.enqueue(sseEncode(event));
+            } catch {
+              // controller may be closed
+            }
+          },
+        });
+
+        const expectedIterationId = outcomes[0]?.iterationId;
+        const iteration =
+          recorder
+            .getIterations()
+            .find((record) => record._id === expectedIterationId) ??
+          recorder.getIterations()[0] ??
+          null;
+
+        if (!iteration) {
+          throw new WebRouteError(
+            500,
+            ErrorCode.INTERNAL_ERROR,
+            "Inline stream did not produce an iteration",
+          );
+        }
+
+        controller.enqueue(
+          sseEncode({
+            type: "complete",
+            iterationId: iteration._id,
+            iteration,
+          }),
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        controller.enqueue(
+          sseEncode({
+            type: "error",
+            message,
+            details:
+              error instanceof WebRouteError && error.details
+                ? JSON.stringify(error.details)
+                : undefined,
+          }),
+        );
+      } finally {
+        try {
+          controller.close();
+        } catch {
+          // already closed
+        }
+        options.onStreamComplete?.();
+      }
+    },
+  });
 }
 
 export async function generateEvalTestsWithManager(

--- a/mcpjam-inspector/server/routes/web/__tests__/evals-inline-guest.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/evals-inline-guest.test.ts
@@ -1,0 +1,129 @@
+import { mkdtempSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  streamInlineEvalTestCaseWithManagerMock,
+  disconnectAllServersMock,
+} = vi.hoisted(() => ({
+  streamInlineEvalTestCaseWithManagerMock: vi.fn(),
+  disconnectAllServersMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@mcpjam/sdk", async () => {
+  const actual =
+    await vi.importActual<typeof import("@mcpjam/sdk")>("@mcpjam/sdk");
+  return {
+    ...actual,
+    MCPClientManager: vi.fn().mockImplementation(() => ({
+      disconnectAllServers: disconnectAllServersMock,
+    })),
+  };
+});
+
+vi.mock("../../shared/evals.js", async () => {
+  const actual = await vi.importActual<typeof import("../../shared/evals.js")>(
+    "../../shared/evals.js",
+  );
+  return {
+    ...actual,
+    streamInlineEvalTestCaseWithManager: (...args: unknown[]) =>
+      streamInlineEvalTestCaseWithManagerMock(...args),
+  };
+});
+
+import { createWebTestApp, postJson } from "./helpers/test-app.js";
+import {
+  initGuestTokenSecret,
+  issueGuestToken,
+} from "../../../services/guest-token.js";
+
+describe("web eval guest inline stream route", () => {
+  const originalGuestJwtKeyDir = process.env.GUEST_JWT_KEY_DIR;
+  const originalLocalSigning = process.env.MCPJAM_USE_LOCAL_GUEST_SIGNING;
+  let testGuestKeyDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    testGuestKeyDir = mkdtempSync(
+      path.join(os.tmpdir(), "evals-inline-guest-"),
+    );
+    process.env.GUEST_JWT_KEY_DIR = testGuestKeyDir;
+    process.env.MCPJAM_USE_LOCAL_GUEST_SIGNING = "true";
+    initGuestTokenSecret();
+
+    const encoder = new TextEncoder();
+    streamInlineEvalTestCaseWithManagerMock.mockResolvedValue(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              'data: {"type":"complete","iterationId":"guestiter-1","iteration":{"_id":"guestiter-1"}}\n\n',
+            ),
+          );
+          controller.close();
+        },
+      }),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(testGuestKeyDir, { recursive: true, force: true });
+    if (originalGuestJwtKeyDir === undefined) {
+      delete process.env.GUEST_JWT_KEY_DIR;
+    } else {
+      process.env.GUEST_JWT_KEY_DIR = originalGuestJwtKeyDir;
+    }
+    if (originalLocalSigning === undefined) {
+      delete process.env.MCPJAM_USE_LOCAL_GUEST_SIGNING;
+    } else {
+      process.env.MCPJAM_USE_LOCAL_GUEST_SIGNING = originalLocalSigning;
+    }
+  });
+
+  it("streams hosted guest inline compare runs from /api/web/evals/stream-test-case-inline", async () => {
+    const { app } = createWebTestApp();
+    const { token } = issueGuestToken();
+
+    const response = await postJson(
+      app,
+      "/api/web/evals/stream-test-case-inline",
+      {
+        serverIds: ["__guest__"],
+        serverUrl: "https://guest.example.com/mcp",
+        model: "gpt-4",
+        provider: "openai",
+        compareRunId: "cmp_guest",
+        test: {
+          title: "Guest compare",
+          query: "hello",
+        },
+      },
+      token,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    await expect(response.text()).resolves.toContain('"type":"complete"');
+    expect(streamInlineEvalTestCaseWithManagerMock).toHaveBeenCalledTimes(1);
+    expect(
+      streamInlineEvalTestCaseWithManagerMock.mock.calls[0]?.[1],
+    ).toEqual(
+      expect.objectContaining({
+        workspaceId: "__guest__",
+        serverIds: ["__guest__"],
+        model: "gpt-4",
+        provider: "openai",
+        compareRunId: "cmp_guest",
+      }),
+    );
+    expect(
+      streamInlineEvalTestCaseWithManagerMock.mock.calls[0]?.[2],
+    ).toEqual(
+      expect.objectContaining({
+        convexAuthToken: token,
+      }),
+    );
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/evals-inline-guest.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/evals-inline-guest.test.ts
@@ -126,4 +126,35 @@ describe("web eval guest inline stream route", () => {
       }),
     );
   });
+
+  it("disconnects the temporary manager when inline stream setup fails before streaming starts", async () => {
+    const { app } = createWebTestApp();
+    const { token } = issueGuestToken();
+    streamInlineEvalTestCaseWithManagerMock.mockRejectedValueOnce(
+      new Error("stream setup failed"),
+    );
+
+    const response = await postJson(
+      app,
+      "/api/web/evals/stream-test-case-inline",
+      {
+        serverIds: ["__guest__"],
+        serverUrl: "https://guest.example.com/mcp",
+        model: "gpt-4",
+        provider: "openai",
+        test: {
+          title: "Guest compare",
+          query: "hello",
+        },
+      },
+      token,
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      code: "INTERNAL_ERROR",
+      message: "stream setup failed",
+    });
+    expect(disconnectAllServersMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/mcpjam-inspector/server/routes/web/evals.ts
+++ b/mcpjam-inspector/server/routes/web/evals.ts
@@ -1,26 +1,39 @@
 import { Hono } from "hono";
+import { MCPClientManager } from "@mcpjam/sdk";
 import { z } from "zod";
 import { createConvexClient } from "../../services/evals/route-helpers.js";
 import { executeSuiteReplayFromRun } from "../../services/evals/replay-suite-run.js";
 import { runTraceRepairJob } from "../../services/evals/trace-repair-runner.js";
 import { logger } from "../../utils/logger.js";
+import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
+import { OAuthProxyError, validateUrl } from "../../utils/oauth-proxy.js";
 import {
   createAuthorizedManager,
+  guestServerInputSchema,
   handleRoute,
   parseWithSchema,
   readJsonBody,
   withEphemeralConnection,
 } from "./auth.js";
-import { assertBearerToken, ErrorCode, WebRouteError } from "./errors.js";
+import {
+  assertBearerToken,
+  ErrorCode,
+  WebRouteError,
+  mapRuntimeError,
+  webError,
+} from "./errors.js";
 import {
   GenerateNegativeTestsRequestSchema,
   GenerateTestsRequestSchema,
   RunEvalsRequestSchema,
+  RunInlineTestCaseRequestSchema,
   RunTestCaseRequestSchema,
   generateEvalTestsWithManager,
   generateNegativeEvalTestsWithManager,
   runEvalsWithManager,
   runEvalTestCaseWithManager,
+  runInlineEvalTestCaseWithManager,
+  streamInlineEvalTestCaseWithManager,
   streamEvalTestCaseWithManager,
 } from "../shared/evals.js";
 
@@ -45,6 +58,15 @@ const hostedRunEvalsSchema = RunEvalsRequestSchema.omit({
 const hostedRunTestCaseSchema = RunTestCaseRequestSchema.omit({
   serverIds: true,
   convexAuthToken: true,
+}).extend(hostedBatchSchema.shape);
+
+/**
+ * Inline-run schema. Guests submit the full test config inline (no Convex
+ * testCaseId). The guest path in `withEphemeralConnection` adds a synthetic
+ * `workspaceId: "__guest__"` so this schema still parses.
+ */
+const hostedRunInlineTestCaseSchema = RunInlineTestCaseRequestSchema.omit({
+  serverIds: true,
 }).extend(hostedBatchSchema.shape);
 
 const hostedGenerateTestsSchema = GenerateTestsRequestSchema.omit({
@@ -116,6 +138,24 @@ evals.post("/run-test-case", async (c) =>
   ),
 );
 
+/**
+ * Guest inline run: runs a test case that only exists client-side. No Convex
+ * writes. Returns the full iteration object inline. Routed through
+ * `withEphemeralConnection` so the existing guest path (serverUrl + guest JWT)
+ * authorizes and connects without a workspace.
+ */
+evals.post("/run-test-case-inline", async (c) =>
+  withEphemeralConnection(
+    c,
+    hostedRunInlineTestCaseSchema,
+    (manager, body) =>
+      runInlineEvalTestCaseWithManager(manager, body, {
+        convexAuthToken: assertBearerToken(c),
+      }),
+    { rpcLogs: false },
+  ),
+);
+
 evals.post("/stream-test-case", async (c) => {
   const bearerToken = assertBearerToken(c);
   const rawBody = await readJsonBody<Record<string, unknown>>(c);
@@ -168,6 +208,90 @@ evals.post("/stream-test-case", async (c) => {
   } catch (error) {
     await manager.disconnectAllServers();
     throw error;
+  }
+});
+
+evals.post("/stream-test-case-inline", async (c) => {
+  const bearerToken = assertBearerToken(c);
+  const rawBody = await readJsonBody<Record<string, unknown>>(c);
+
+  try {
+    const guestId = c.get("guestId") as string | undefined;
+    if (!guestId) {
+      throw new WebRouteError(
+        401,
+        ErrorCode.UNAUTHORIZED,
+        "Valid guest token required. Please refresh the page to obtain a new session.",
+      );
+    }
+
+    const guestInput = parseWithSchema(guestServerInputSchema, rawBody);
+    try {
+      await validateUrl(guestInput.serverUrl, true);
+    } catch (error) {
+      if (error instanceof OAuthProxyError) {
+        throw new WebRouteError(
+          error.status,
+          ErrorCode.VALIDATION_ERROR,
+          error.message,
+        );
+      }
+      throw error;
+    }
+
+    const body = parseWithSchema(hostedRunInlineTestCaseSchema, {
+      ...rawBody,
+      workspaceId: "__guest__",
+      serverId: "__guest__",
+    });
+
+    const headers: Record<string, string> = {
+      ...(guestInput.serverHeaders ?? {}),
+    };
+    if (typeof rawBody.oauthAccessToken === "string") {
+      headers["Authorization"] = `Bearer ${rawBody.oauthAccessToken}`;
+    }
+
+    const manager = new MCPClientManager(
+      {
+        __guest__: {
+          url: guestInput.serverUrl,
+          capabilities: guestInput.clientCapabilities,
+          requestInit: { headers },
+          timeout: 60_000,
+        },
+      },
+      {
+        defaultTimeout: 60_000,
+        retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
+      },
+    );
+
+    const stream = await streamInlineEvalTestCaseWithManager(
+      manager,
+      body,
+      {
+        convexAuthToken: bearerToken,
+        onStreamComplete: () => manager.disconnectAllServers(),
+      },
+    );
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  } catch (error) {
+    const routeError = mapRuntimeError(error);
+    return webError(
+      c,
+      routeError.status,
+      routeError.code,
+      routeError.message,
+      routeError.details,
+    );
   }
 });
 

--- a/mcpjam-inspector/server/routes/web/evals.ts
+++ b/mcpjam-inspector/server/routes/web/evals.ts
@@ -214,6 +214,8 @@ evals.post("/stream-test-case", async (c) => {
 evals.post("/stream-test-case-inline", async (c) => {
   const bearerToken = assertBearerToken(c);
   const rawBody = await readJsonBody<Record<string, unknown>>(c);
+  let manager: MCPClientManager | null = null;
+  let stream: ReadableStream<Uint8Array> | null = null;
 
   try {
     const guestId = c.get("guestId") as string | undefined;
@@ -252,7 +254,7 @@ evals.post("/stream-test-case-inline", async (c) => {
       headers["Authorization"] = `Bearer ${rawBody.oauthAccessToken}`;
     }
 
-    const manager = new MCPClientManager(
+    manager = new MCPClientManager(
       {
         __guest__: {
           url: guestInput.serverUrl,
@@ -267,12 +269,13 @@ evals.post("/stream-test-case-inline", async (c) => {
       },
     );
 
-    const stream = await streamInlineEvalTestCaseWithManager(
-      manager,
+    const activeManager = manager;
+    stream = await streamInlineEvalTestCaseWithManager(
+      activeManager,
       body,
       {
         convexAuthToken: bearerToken,
-        onStreamComplete: () => manager.disconnectAllServers(),
+        onStreamComplete: () => activeManager.disconnectAllServers(),
       },
     );
 
@@ -284,6 +287,9 @@ evals.post("/stream-test-case-inline", async (c) => {
       },
     });
   } catch (error) {
+    if (manager && !stream) {
+      await manager.disconnectAllServers().catch(() => undefined);
+    }
     const routeError = mapRuntimeError(error);
     return webError(
       c,

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -99,6 +99,13 @@ export type RunEvalSuiteOptions = {
   recorder?: SuiteRunRecorder | null;
   testCaseId?: string; // For quick runs, associate iterations with a specific test case
   compareRunId?: string; // For quick compare runs, group related iterations in metadata
+  /**
+   * When false, the runner writes NOTHING to Convex. Used by the guest inline
+   * run path: the provided `recorder` handles iteration start/finish in memory
+   * and the iteration payload is returned to the caller. Defaults to true for
+   * back-compat with suite runs + authed quick runs.
+   */
+  persist?: boolean;
 };
 
 /** One executed iteration inside a suite/quick run (evaluation + optional persisted iteration id). */
@@ -471,6 +478,8 @@ type RunIterationBaseParams = {
   runId: string | null; // For cancellation checks
   abortSignal?: AbortSignal; // For aborting in-flight requests
   compareRunId?: string;
+  /** When false, skip all Convex reads/writes in this iteration. */
+  persist?: boolean;
 };
 
 type RunIterationAiSdkParams = RunIterationBaseParams & {
@@ -505,11 +514,12 @@ const runIterationWithAiSdk = async ({
   runId,
   abortSignal,
   compareRunId,
+  persist = true,
 }: RunIterationAiSdkParams) => {
   const resolvedTest = resolveEvalTestCase(test);
 
   // Check if run was cancelled before starting iteration
-  if (runId !== null) {
+  if (persist && runId !== null) {
     try {
       const currentRun = await convexClient.query(
         "testSuites:getTestSuiteRun" as any,
@@ -602,7 +612,9 @@ const runIterationWithAiSdk = async ({
 
   const iterationId = recorder
     ? await recorder.startIteration(iterationParams)
-    : await createIterationDirectly(convexClient, iterationParams);
+    : persist
+      ? await createIterationDirectly(convexClient, iterationParams)
+      : undefined;
 
   const baseMessages: ModelMessage[] = [];
   if (system) {
@@ -934,11 +946,12 @@ const runIterationViaBackend = async ({
   runId,
   abortSignal,
   compareRunId,
+  persist = true,
 }: RunIterationBackendParams) => {
   const resolvedTest = resolveEvalTestCase(test);
 
   // Check if run was cancelled before starting iteration
-  if (runId !== null) {
+  if (persist && runId !== null) {
     try {
       const currentRun = await convexClient.query(
         "testSuites:getTestSuiteRun" as any,
@@ -1022,7 +1035,9 @@ const runIterationViaBackend = async ({
 
   const iterationId = recorder
     ? await recorder.startIteration(iterationParams)
-    : await createIterationDirectly(convexClient, iterationParams);
+    : persist
+      ? await createIterationDirectly(convexClient, iterationParams)
+      : undefined;
 
   const toolDefs = Object.entries(tools).map(([name, tool]) => {
     const schema = (tool as any)?.inputSchema;
@@ -1455,6 +1470,7 @@ const runTestCase = async (params: {
   runId: string | null;
   abortSignal?: AbortSignal;
   compareRunId?: string;
+  persist?: boolean;
 }) => {
   const {
     test,
@@ -1469,6 +1485,7 @@ const runTestCase = async (params: {
     runId,
     abortSignal,
     compareRunId,
+    persist = true,
   } = params;
   const testCaseId = test.testCaseId || parentTestCaseId;
   const modelDefinition = buildModelDefinition(test);
@@ -1492,6 +1509,7 @@ const runTestCase = async (params: {
         runId,
         abortSignal,
         compareRunId,
+        persist,
       });
       outcomes.push(iterationOutcome);
       continue;
@@ -1510,6 +1528,7 @@ const runTestCase = async (params: {
       runId,
       abortSignal,
       compareRunId,
+      persist,
     });
     outcomes.push(iterationOutcome);
   }
@@ -1529,6 +1548,7 @@ export const runEvalSuiteWithAiSdk = async ({
   recorder: providedRecorder,
   testCaseId,
   compareRunId,
+  persist = true,
 }: RunEvalSuiteOptions): Promise<RunEvalSuiteWithAiSdkResult | undefined> => {
   const tests = config.tests ?? [];
   const serverIds = config.environment?.servers ?? [];
@@ -1537,10 +1557,11 @@ export const runEvalSuiteWithAiSdk = async ({
     throw new Error("No tests supplied for eval run");
   }
 
-  // For quick runs (runId === null), we don't need a recorder
+  // For quick runs (runId === null), we don't need a recorder unless one was
+  // provided (e.g. the ephemeral recorder used by the guest inline path).
   const recorder =
     runId === null
-      ? null
+      ? (providedRecorder ?? null)
       : (providedRecorder ??
         createSuiteRunRecorder({
           convexClient,
@@ -1598,6 +1619,7 @@ export const runEvalSuiteWithAiSdk = async ({
         suiteId,
         runId,
         abortSignal: abortController.signal,
+        persist,
       }),
     );
 
@@ -1753,13 +1775,14 @@ const streamIterationWithAiSdk = async ({
   abortSignal,
   emit,
   compareRunId,
+  persist = true,
 }: RunIterationAiSdkParams & {
   emit: StreamEmit;
 }): Promise<EvalIterationOutcome> => {
   const resolvedTest = resolveEvalTestCase(test);
 
   // Check if run was cancelled before starting iteration
-  if (runId !== null) {
+  if (persist && runId !== null) {
     try {
       const currentRun = await convexClient.query(
         "testSuites:getTestSuiteRun" as any,
@@ -1849,7 +1872,9 @@ const streamIterationWithAiSdk = async ({
 
   const iterationId = recorder
     ? await recorder.startIteration(iterationParams)
-    : await createIterationDirectly(convexClient, iterationParams);
+    : persist
+      ? await createIterationDirectly(convexClient, iterationParams)
+      : undefined;
 
   const baseMessages: ModelMessage[] = [];
   if (system) {
@@ -2143,7 +2168,7 @@ const streamIterationWithAiSdk = async ({
 
     if (recorder) {
       await recorder.finishIteration(finishParams);
-    } else {
+    } else if (persist) {
       await finishIterationDirectly(convexClient, finishParams);
     }
 
@@ -2262,7 +2287,7 @@ const streamIterationWithAiSdk = async ({
 
     if (recorder) {
       await recorder.finishIteration(failParams);
-    } else {
+    } else if (persist) {
       await finishIterationDirectly(convexClient, failParams);
     }
     return {
@@ -2285,13 +2310,14 @@ const streamIterationViaBackend = async ({
   abortSignal,
   emit,
   compareRunId,
+  persist = true,
 }: RunIterationBackendParams & {
   emit: StreamEmit;
 }): Promise<EvalIterationOutcome> => {
   const resolvedTest = resolveEvalTestCase(test);
 
   // Check if run was cancelled before starting iteration
-  if (runId !== null) {
+  if (persist && runId !== null) {
     try {
       const currentRun = await convexClient.query(
         "testSuites:getTestSuiteRun" as any,
@@ -2374,7 +2400,9 @@ const streamIterationViaBackend = async ({
 
   const iterationId = recorder
     ? await recorder.startIteration(iterationParams)
-    : await createIterationDirectly(convexClient, iterationParams);
+    : persist
+      ? await createIterationDirectly(convexClient, iterationParams)
+      : undefined;
 
   const toolDefs = Object.entries(tools).map(([name, tool]) => {
     const schema = (tool as any)?.inputSchema;
@@ -2958,7 +2986,7 @@ const streamIterationViaBackend = async ({
 
   if (recorder) {
     await recorder.finishIteration(finishParams);
-  } else {
+  } else if (persist) {
     await finishIterationDirectly(convexClient, finishParams);
   }
 
@@ -2982,6 +3010,7 @@ export const streamTestCase = async (params: {
   abortSignal?: AbortSignal;
   emit: StreamEmit;
   compareRunId?: string;
+  persist?: boolean;
 }) => {
   const {
     test,
@@ -2997,6 +3026,7 @@ export const streamTestCase = async (params: {
     abortSignal,
     emit,
     compareRunId,
+    persist = true,
   } = params;
   const testCaseId = test.testCaseId || parentTestCaseId;
   const modelDefinition = buildModelDefinition(test);
@@ -3021,6 +3051,7 @@ export const streamTestCase = async (params: {
         abortSignal,
         emit,
         compareRunId,
+        persist,
       });
       outcomes.push(iterationOutcome);
       continue;
@@ -3040,6 +3071,7 @@ export const streamTestCase = async (params: {
       abortSignal,
       emit,
       compareRunId,
+      persist,
     });
     outcomes.push(iterationOutcome);
   }

--- a/mcpjam-inspector/server/services/evals/__tests__/recorder.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/recorder.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { startSuiteRunWithRecorder } from "../recorder.js";
+import {
+  createEphemeralRunRecorder,
+  startSuiteRunWithRecorder,
+} from "../recorder.js";
 
 describe("startSuiteRunWithRecorder", () => {
   it("forwards tool snapshot metadata when creating a suite run", async () => {
@@ -151,5 +154,95 @@ describe("startSuiteRunWithRecorder", () => {
         },
       }),
     );
+  });
+});
+
+describe("createEphemeralRunRecorder", () => {
+  it("stores inline trace payloads with router-safe guest ids", async () => {
+    const recorder = createEphemeralRunRecorder();
+    const startedAt = 1_234;
+
+    expect(recorder.runId).toMatch(/^guestrun-[A-Za-z0-9_-]+$/);
+    expect(recorder.suiteId).toMatch(/^guestsuite-[A-Za-z0-9_-]+$/);
+
+    const iterationId = await recorder.startIteration({
+      testCaseId: "guestcase-1",
+      testCaseSnapshot: {
+        title: "Guest run",
+        query: "hello",
+        provider: "openai",
+        model: "gpt-4",
+        expectedToolCalls: [],
+      },
+      iterationNumber: 1,
+      startedAt,
+    });
+
+    expect(iterationId).toMatch(/^guestiter-[A-Za-z0-9_-]+$/);
+
+    await recorder.finishIteration({
+      iterationId,
+      passed: false,
+      toolsCalled: [{ toolName: "search", arguments: { q: "hello" } }],
+      usage: {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+      },
+      messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+      spans: [
+        {
+          id: "step-1",
+          name: "Search",
+          category: "step",
+          startMs: 0,
+          endMs: 1,
+        },
+      ],
+      prompts: [
+        {
+          promptIndex: 0,
+          prompt: "hello",
+          expectedToolCalls: [],
+          actualToolCalls: [{ toolName: "search", arguments: { q: "hello" } }],
+          passed: false,
+          missing: [],
+          unexpected: [],
+          argumentMismatches: [],
+        },
+      ],
+      resultSource: "derived",
+      metadata: { compareRunId: "cmp_guest_1" },
+      error: "No answer",
+    });
+
+    expect(recorder.getIterations()).toEqual([
+      expect.objectContaining({
+        _id: iterationId,
+        testCaseId: "guestcase-1",
+        startedAt,
+        status: "failed",
+        result: "failed",
+        tokensUsed: 15,
+        actualToolCalls: [{ toolName: "search", arguments: { q: "hello" } }],
+        messages: [
+          { role: "user", content: [{ type: "text", text: "hello" }] },
+        ],
+        spans: [
+          expect.objectContaining({
+            id: "step-1",
+            name: "Search",
+          }),
+        ],
+        prompts: [
+          expect.objectContaining({
+            prompt: "hello",
+            passed: false,
+          }),
+        ],
+        metadata: { compareRunId: "cmp_guest_1" },
+        error: "No answer",
+      }),
+    ]);
   });
 });

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -3,6 +3,7 @@ import type { ConvexHttpClient } from "convex/browser";
 import type { EvalTraceSpan } from "@/shared/eval-trace";
 import type { PromptTraceSummary } from "@/shared/eval-trace";
 import type { PromptTurn } from "@/shared/prompt-turns";
+import { randomUUID } from "node:crypto";
 import type { UsageTotals } from "./types";
 import { logger } from "../../utils/logger";
 import type { ServerToolSnapshot } from "../../utils/export-helpers.js";
@@ -275,6 +276,134 @@ export const createSuiteRunRecorder = ({
           new Error(errorMessage),
         );
       }
+    },
+  };
+};
+
+/**
+ * Captured output from a single ephemeral iteration run. Mirrors the
+ * `testIteration` fields the client needs to render results, without ever
+ * hitting Convex. Used by the guest inline run path.
+ */
+export type EphemeralIterationRecord = {
+  _id: string;
+  testCaseId?: string;
+  testCaseSnapshot?: {
+    title: string;
+    query: string;
+    provider: string;
+    model: string;
+    runs?: number;
+    expectedToolCalls: Array<{
+      toolName: string;
+      arguments: Record<string, any>;
+    }>;
+    isNegativeTest?: boolean;
+    expectedOutput?: string;
+    promptTurns?: PromptTurn[];
+    advancedConfig?: Record<string, unknown>;
+  };
+  iterationNumber: number;
+  startedAt: number;
+  createdAt: number;
+  updatedAt: number;
+  status: "pending" | "running" | "completed" | "failed" | "cancelled";
+  result: "pending" | "passed" | "failed" | "cancelled";
+  actualToolCalls: Array<{ toolName: string; arguments: Record<string, any> }>;
+  tokensUsed: number;
+  messages?: ModelMessage[];
+  spans?: EvalTraceSpan[];
+  prompts?: PromptTraceSummary[];
+  error?: string;
+  errorDetails?: string;
+  resultSource?: "reported" | "derived";
+  metadata?: Record<string, string | number | boolean>;
+};
+
+export type EphemeralRunRecorder = SuiteRunRecorder & {
+  getIterations(): EphemeralIterationRecord[];
+};
+
+/**
+ * In-memory recorder used by the guest inline run path. Captures iteration
+ * start/finish calls so the caller can return the full iteration payload
+ * without ever writing to Convex. The SuiteRunRecorder contract is still
+ * honored so the rest of the runner does not need to special-case guests.
+ */
+export const createEphemeralRunRecorder = (): EphemeralRunRecorder => {
+  const iterations = new Map<string, EphemeralIterationRecord>();
+  const makeGuestId = (prefix: "run" | "suite" | "iter") =>
+    `guest${prefix}-${randomUUID().replace(/[^A-Za-z0-9_-]/g, "")}`;
+
+  return {
+    runId: makeGuestId("run"),
+    suiteId: makeGuestId("suite"),
+    async startIteration({
+      testCaseId,
+      testCaseSnapshot,
+      iterationNumber,
+      startedAt,
+    }) {
+      const id = makeGuestId("iter");
+      iterations.set(id, {
+        _id: id,
+        testCaseId,
+        testCaseSnapshot,
+        iterationNumber,
+        startedAt,
+        createdAt: startedAt,
+        updatedAt: startedAt,
+        status: "running",
+        result: "pending",
+        actualToolCalls: [],
+        tokensUsed: 0,
+      });
+      return id;
+    },
+    async finishIteration({
+      iterationId,
+      passed,
+      toolsCalled,
+      usage,
+      messages,
+      spans,
+      prompts,
+      status,
+      startedAt,
+      error,
+      errorDetails,
+      resultSource,
+      metadata,
+    }) {
+      if (!iterationId) return;
+      const current = iterations.get(iterationId);
+      if (!current) return;
+      const iterationStatus = status ?? (passed ? "completed" : "failed");
+      const result = passed ? "passed" : "failed";
+      iterations.set(iterationId, {
+        ...current,
+        updatedAt: Date.now(),
+        startedAt: startedAt ?? current.startedAt,
+        status: iterationStatus,
+        result,
+        actualToolCalls: toolsCalled,
+        tokensUsed: usage.totalTokens ?? 0,
+        messages,
+        ...(spans?.length ? { spans } : {}),
+        ...(prompts?.length ? { prompts } : {}),
+        error,
+        errorDetails,
+        resultSource,
+        metadata,
+      });
+    },
+    async finalize() {
+      // no-op: guest inline runs are per-case, not wrapped in a suite run
+    },
+    getIterations() {
+      return Array.from(iterations.values()).sort(
+        (a, b) => a.iterationNumber - b.iterationNumber,
+      );
     },
   };
 };


### PR DESCRIPTION
## Summary

This PR makes `Evals -> Playground` work for direct guests in both hosted and local mode.

Direct guests can now:
- open Playground without signing in
- get a guest-only local suite for the selected server
- create, edit, delete, duplicate, and generate cases
- run single cases and multi-model Compare
- inspect chat, trace, and results from the normal Playground views

For direct guests, Playground data is stored only in the browser. Guest suites, test cases, and run results live in local storage and are never saved to Convex.

Guest runs still use the backend to actually execute MCP + model calls. The backend runs the test and sends the full result back immediately, but does not save guest eval data as normal Convex-backed suites/iterations.

If the user signs in later, the app goes back to the normal workspace-backed eval flow. Guest suites are not migrated and do not overwrite any signed-in suites or test cases.

## Key Changes

- Added direct-guest Playground support and local guest eval storage
- Added hosted/local inline guest run and stream endpoints for backend execution without guest Convex persistence
- Taught Playground trace/result views to use inline trace payloads when no Convex blob exists
- Wired guest Compare to stream live updates and persist completed iterations locally in the browser
- Fixed the same-tab guest -> login bug so a guest visit no longer blocks creation of the normal signed-in Explore suite

## Testing

Focused client/server coverage now checks:
- inline trace loading without blobs
- guest Compare streaming and local persistence
- hosted/local inline stream routes
- ephemeral recorder payloads and guest-safe ids
- guest -> signed-in suite creation in the same tab
