### PR TITLE
Soundcheck: fix invalid list semantics in JobStepper

### DIFF
--- a/soundcheck/src/components/release-progress.tsx
+++ b/soundcheck/src/components/release-progress.tsx
@@ -229,20 +229,23 @@ function JobStepper({ jobs }: { jobs: WorkflowJob[] }) {
   const known = JOB_ORDER.map((n) => ({ name: n, job: byName.get(n) ?? null }));
   const unknown = jobs.filter((j) => !JOB_ORDER.includes(j.name));
 
+  // Rail sits in a positioning wrapper so the <ol> only contains <li> children
+  // (valid list semantics for a11y trees / screen readers).
   return (
-    <ol className="relative space-y-0.5">
-      {/* connecting rail behind the dots */}
+    <div className="relative">
       <div
         className="pointer-events-none absolute bottom-2 left-[3px] top-2 w-px bg-border"
         aria-hidden
       />
-      {known.map(({ name, job }) => (
-        <JobRow key={name} name={name} job={job} />
-      ))}
-      {unknown.map((job) => (
-        <JobRow key={job.name} name={job.name} job={job} />
-      ))}
-    </ol>
+      <ol className="relative space-y-0.5">
+        {known.map(({ name, job }) => (
+          <JobRow key={name} name={name} job={job} />
+        ))}
+        {unknown.map((job) => (
+          <JobRow key={job.name} name={job.name} job={job} />
+        ))}
+      </ol>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1850. The release-progress `JobStepper` had a decorative rail `<div>` as a direct child of `<ol>`, which breaks list semantics — screen readers expect a list to contain only `<li>` elements. Flagged by CodeRabbit on #1850 but the dogfood PR was merged before the fix landed.

## Fix

Move the rail `<div>` out of the `<ol>` and into a positioning wrapper, so the `<ol>` only holds `<li>` children. Visually identical — the rail is still absolutely positioned behind the job dots.

[soundcheck/src/components/release-progress.tsx:232](soundcheck/src/components/release-progress.tsx#L232)

```diff
-    <ol className="relative space-y-0.5">
-      <div className="... absolute ..." aria-hidden />
-      {known.map(...)}
-    </ol>
+    <div className="relative">
+      <div className="... absolute ..." aria-hidden />
+      <ol className="relative space-y-0.5">
+        {known.map(...)}
+      </ol>
+    </div>
```

## Test plan

- [x] `npm run typecheck -w @mcpjam/soundcheck`
- [ ] Eyeball the release-progress tile in Soundcheck — rail should render identically behind the job stepper dots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI markup change limited to the release progress stepper; behavior and data flow are unchanged, with only potential for minor layout regression.
> 
> **Overview**
> Fixes invalid list markup in the release-progress `JobStepper` by wrapping the stepper in a positioning `div` and keeping the decorative rail outside the `<ol>`, so the list contains only `<li>` elements for better accessibility.
> 
> Rendering and job ordering remain the same; this is a structural DOM/a11y adjustment only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a901fed9aba3ba6dd31630d25bd3632fe3cadb86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->