### PR TITLE
Soundcheck: promote MCP worker to mcp.mcpjam.com

### DIFF
--- a/.github/workflows/deploy-mcp-prod.yml
+++ b/.github/workflows/deploy-mcp-prod.yml
@@ -31,10 +31,13 @@ concurrency:
 
 env:
   NODE_VERSION: "24.14.0"
-  # Hardcoded for the same reason deploy-mcp-staging.yml hardcodes its
-  # URL: cloudflare/wrangler-action@v3 returns a malformed
+  # Resolved once here so the environment URL, smoke test, and job
+  # summary all point at the same target. Falls back to the known
+  # production hostname when the override var is unset — hardcoded in
+  # the fallback for the same reason deploy-mcp-staging.yml hardcodes
+  # its URL: cloudflare/wrangler-action@v3 returns a malformed
   # `deployment-url` output for custom-domain deploys (wrangler-action#396).
-  PRODUCTION_URL: "https://mcp.mcpjam.com"
+  PRODUCTION_URL: ${{ vars.MCP_WORKER_PRODUCTION_URL || 'https://mcp.mcpjam.com' }}
 
 jobs:
   deploy:
@@ -42,7 +45,7 @@ jobs:
     timeout-minutes: 30
     environment:
       name: mcp-production
-      url: ${{ vars.MCP_WORKER_PRODUCTION_URL || 'https://mcp.mcpjam.com' }}
+      url: ${{ env.PRODUCTION_URL }}
 
     steps:
       - name: Enforce main branch

--- a/.github/workflows/deploy-mcp-prod.yml
+++ b/.github/workflows/deploy-mcp-prod.yml
@@ -1,0 +1,151 @@
+name: Deploy MCP Production
+
+# Manual promotion of the MCP Cloudflare Worker from staging
+# (mcp-staging.mcpjam.com) to production (mcp.mcpjam.com). Intentionally
+# workflow_dispatch-only — there's no auto-deploy-on-merge for prod,
+# matching release.yml's philosophy that production is a deliberate last
+# step, not a side effect of merging.
+#
+# Invocation paths:
+#   1. Soundcheck's "Deploy MCP production" tile (POST /api/mcp/dispatch).
+#   2. GitHub Actions UI → "Deploy MCP Production" → Run workflow.
+#
+# Reviewer gating lives on the `mcp-production` GitHub Environment in repo
+# Settings → Environments, not in this file. Keeping the gate in the
+# environment config means it applies uniformly to both invocation paths.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  deployments: write
+
+# Never cancel an in-flight production deploy just because a second
+# dispatch arrived. Mid-deploy cancellation can leave the worker in a
+# partially-provisioned state (cert attached, bindings not). Queue instead.
+concurrency:
+  group: mcp-production
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "24.14.0"
+  # Hardcoded for the same reason deploy-mcp-staging.yml hardcodes its
+  # URL: cloudflare/wrangler-action@v3 returns a malformed
+  # `deployment-url` output for custom-domain deploys (wrangler-action#396).
+  PRODUCTION_URL: "https://mcp.mcpjam.com"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: mcp-production
+      url: ${{ vars.MCP_WORKER_PRODUCTION_URL || 'https://mcp.mcpjam.com' }}
+
+    steps:
+      - name: Enforce main branch
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            echo "deploy-mcp-prod.yml must run from main" >&2
+            exit 1
+          fi
+
+      - name: Require Cloudflare credentials
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          if [ -z "$CLOUDFLARE_ACCOUNT_ID" ]; then
+            echo "Missing GitHub Actions secret: CLOUDFLARE_ACCOUNT_ID" >&2
+            exit 1
+          fi
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "Missing GitHub Actions secret: CLOUDFLARE_API_TOKEN" >&2
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Mirrors the staging gate in release.yml: refuse to promote a SHA
+      # that hasn't been verified on staging. Prevents "click prod button,
+      # realize staging was red" accidents.
+      - name: Require green staging deploy for candidate SHA
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const workflowId = "deploy-mcp-staging.yml";
+            const { owner, repo } = context.repo;
+            const headSha = context.sha;
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner,
+              repo,
+              workflow_id: workflowId,
+              branch: "main",
+              status: "completed",
+              per_page: 100,
+            });
+
+            const match = runs.find(
+              (run) => run.head_sha === headSha && run.conclusion === "success"
+            );
+
+            if (!match) {
+              core.setFailed(
+                `No successful ${workflowId} run found for ${headSha}. ` +
+                `Wait for the staging deploy to land on this SHA before promoting to production.`
+              );
+              return;
+            }
+
+            core.info(`Found successful staging deploy run ${match.id} for ${headSha}.`);
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install workspace dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Typecheck MCP worker
+        run: npm run typecheck -w @mcpjam/mcp
+
+      - name: Deploy production worker
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          workingDirectory: "mcp"
+          command: deploy --env production
+
+      - name: Smoke test landing page
+        run: |
+          # First deploy onto a new custom domain takes up to ~60s for
+          # Cloudflare to provision the edge cert and propagate the
+          # hostname. Budget 20 × 3s = ~60s of retries to cover it. Later
+          # deploys onto the existing hostname land near-instant but the
+          # retry loop is cheap.
+          for attempt in $(seq 1 20); do
+            if curl --fail --silent --show-error "$PRODUCTION_URL" | grep -q "MCPJam MCP"; then
+              echo "Smoke OK on attempt $attempt"
+              exit 0
+            fi
+            echo "Attempt $attempt returned non-200 or mismatched content; retrying in 3s…"
+            sleep 3
+          done
+          echo "Production URL never resolved correctly." >&2
+          exit 1
+
+      - name: Summarize production deployment
+        run: |
+          echo "## ✅ MCP production deployed" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Worker: \`mcpjam-mcp-production\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- URL: \`$PRODUCTION_URL\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- MCP endpoint: \`$PRODUCTION_URL/mcp\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-mcp-prod.yml
+++ b/.github/workflows/deploy-mcp-prod.yml
@@ -72,16 +72,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # Mirrors the staging gate in release.yml: refuse to promote a SHA
-      # that hasn't been verified on staging. Prevents "click prod button,
-      # realize staging was red" accidents.
-      - name: Require green staging deploy for candidate SHA
+      # Refuse to promote a SHA whose MCP build inputs haven't been
+      # verified on staging. The check is looser than an exact-SHA match
+      # because `deploy-mcp-staging.yml` only fires on mcp-relevant path
+      # changes — so most main commits legitimately never trigger a
+      # staging run for their SHA, and an exact-SHA gate would lock
+      # promotion out whenever main moved for unrelated reasons.
+      #
+      # Logic: find the latest successful staging run on main. If its
+      # SHA matches current main, done. Otherwise, compare the two SHAs
+      # and verify no mcp-relevant files changed between them — meaning
+      # what's live on staging is byte-identical (for the worker's
+      # purposes) to what we'd ship. The mcp-relevant path list mirrors
+      # deploy-mcp-staging.yml's `paths:` trigger filter, minus the
+      # workflow file itself (which isn't a build input).
+      - name: Require green staging for current MCP build inputs
         uses: actions/github-script@v7
         with:
           script: |
             const workflowId = "deploy-mcp-staging.yml";
             const { owner, repo } = context.repo;
             const headSha = context.sha;
+
             const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
               owner,
               repo,
@@ -91,19 +103,56 @@ jobs:
               per_page: 100,
             });
 
-            const match = runs.find(
-              (run) => run.head_sha === headSha && run.conclusion === "success"
-            );
-
-            if (!match) {
+            const latestSuccess = runs.find((run) => run.conclusion === "success");
+            if (!latestSuccess) {
               core.setFailed(
-                `No successful ${workflowId} run found for ${headSha}. ` +
-                `Wait for the staging deploy to land on this SHA before promoting to production.`
+                `No successful ${workflowId} run on main. Cannot promote.`
               );
               return;
             }
 
-            core.info(`Found successful staging deploy run ${match.id} for ${headSha}.`);
+            if (latestSuccess.head_sha === headSha) {
+              core.info(
+                `Latest successful staging run ${latestSuccess.id} is at ${headSha} — safe to promote.`
+              );
+              return;
+            }
+
+            // Different SHAs: check if the diff includes any MCP build input.
+            // GitHub's compare response caps `files` at 300; for the volumes
+            // we see between two main commits that's a non-issue, but if
+            // something ever needs a 300+ file diff it'll error loudly here.
+            const { data: diff } = await github.rest.repos.compareCommitsWithBasehead({
+              owner,
+              repo,
+              basehead: `${latestSuccess.head_sha}...${headSha}`,
+            });
+
+            const isMcpRelevant = (filename) =>
+              filename.startsWith("mcp/") ||
+              filename === "package.json" ||
+              filename === "package-lock.json" ||
+              filename === ".changeset/config.json";
+
+            const touched = (diff.files ?? [])
+              .map((f) => f.filename)
+              .filter(isMcpRelevant);
+
+            if (touched.length > 0) {
+              core.setFailed(
+                `Latest successful staging is at ${latestSuccess.head_sha.slice(0, 7)} ` +
+                `but current main ${headSha.slice(0, 7)} has MCP-relevant changes not yet on ` +
+                `staging: ${touched.join(", ")}. Wait for the next deploy-mcp-staging.yml run ` +
+                `to land before promoting.`
+              );
+              return;
+            }
+
+            core.info(
+              `Latest successful staging run ${latestSuccess.id} is at ` +
+              `${latestSuccess.head_sha.slice(0, 7)}; current main ${headSha.slice(0, 7)} ` +
+              `differs only in non-MCP paths — safe to promote.`
+            );
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy-mcp-prod.yml
+++ b/.github/workflows/deploy-mcp-prod.yml
@@ -131,11 +131,13 @@ jobs:
         run: |
           # First deploy onto a new custom domain takes up to ~60s for
           # Cloudflare to provision the edge cert and propagate the
-          # hostname. Budget 20 × 3s = ~60s of retries to cover it. Later
-          # deploys onto the existing hostname land near-instant but the
-          # retry loop is cheap.
+          # hostname. Each probe is bounded (--connect-timeout 3
+          # --max-time 6) so one hung TCP/TLS handshake can't blow past
+          # the retry budget and hold the mcp-production concurrency
+          # slot. Later deploys onto the existing hostname land
+          # near-instant but the retry loop is cheap.
           for attempt in $(seq 1 20); do
-            if curl --fail --silent --show-error "$PRODUCTION_URL" | grep -q "MCPJam MCP"; then
+            if curl --fail --silent --show-error --connect-timeout 3 --max-time 6 "$PRODUCTION_URL" | grep -q "MCPJam MCP"; then
               echo "Smoke OK on attempt $attempt"
               exit 0
             fi

--- a/.github/workflows/deploy-mcp-staging.yml
+++ b/.github/workflows/deploy-mcp-staging.yml
@@ -88,10 +88,11 @@ jobs:
         run: |
           # First deploy onto a new custom domain can take up to ~60s for
           # Cloudflare to provision the edge cert and propagate the
-          # hostname. Budget 20 × 3s = ~60s of retries (plus curl
-          # latency) so the cold-start case actually covers the window.
+          # hostname. Each probe is bounded (--connect-timeout 3
+          # --max-time 6) so one hung TCP/TLS handshake can't blow past
+          # the retry budget and hold the mcp-staging concurrency slot.
           for attempt in $(seq 1 20); do
-            if curl --fail --silent --show-error "$STAGING_URL" | grep -q "MCPJam MCP"; then
+            if curl --fail --silent --show-error --connect-timeout 3 --max-time 6 "$STAGING_URL" | grep -q "MCPJam MCP"; then
               echo "Smoke OK on attempt $attempt"
               exit 0
             fi

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -32,6 +32,7 @@ on:
       - "mcp/**"
       - ".github/workflows/pr-mcp-preview.yml"
       - ".github/workflows/deploy-mcp-staging.yml"
+      - ".github/workflows/deploy-mcp-prod.yml"
   repository_dispatch:
     types:
       - backend_preview_ready

--- a/soundcheck/src/app/api/mcp/dispatch/route.ts
+++ b/soundcheck/src/app/api/mcp/dispatch/route.ts
@@ -33,7 +33,30 @@ import { dispatchWorkflow } from "@/lib/github";
 
 export const dynamic = "force-dynamic";
 
-export async function POST() {
+/**
+ * Sentinel the in-app form sends. Required before auth. Catches a CSRF
+ * vector where a logged-in employee visits a malicious site that POSTs
+ * to this route — WorkOS AuthKit cookies with SameSite=None (used for
+ * cross-subdomain flows) would otherwise be attached to the request and
+ * pass `withAuth`. A plain HTML form can't set custom request headers,
+ * and a cross-origin `fetch` sending custom headers triggers a CORS
+ * preflight against this origin (which would fail), so requiring the
+ * header effectively restricts callers to same-origin JS.
+ */
+const EXPECTED_DISPATCH_HEADER = "x-soundcheck-action";
+const EXPECTED_DISPATCH_VALUE = "mcp-prod-dispatch";
+
+export async function POST(request: Request) {
+  // ── 0. Same-origin guard (cheap defense-in-depth) ───────────────────
+  if (
+    request.headers.get(EXPECTED_DISPATCH_HEADER) !== EXPECTED_DISPATCH_VALUE
+  ) {
+    return NextResponse.json(
+      { error: "Invalid dispatch request" },
+      { status: 403 }
+    );
+  }
+
   // ── 1. Enforce employee-only — unconditionally ──────────────────────
   // Same posture as /api/release/dispatch: this hands out a write-scoped
   // PAT to dispatch a production deploy. MCPJAM_NONPROD_LOCKDOWN being

--- a/soundcheck/src/app/api/mcp/dispatch/route.ts
+++ b/soundcheck/src/app/api/mcp/dispatch/route.ts
@@ -1,0 +1,103 @@
+/**
+ * POST /api/mcp/dispatch
+ *
+ * Server route for the "Deploy MCP production" button. Dispatches
+ * `deploy-mcp-prod.yml` on `main`. Re-checks WorkOS sign-in + employee
+ * email gate server-side before exposing the write-scoped PAT.
+ *
+ * Why a separate route from /api/release/dispatch:
+ *   - MCP is never part of release.yml's scope (it's ignored by Changesets
+ *     and deploys via its own Cloudflare pipeline). Conflating the two
+ *     would either force MCP into the release-plan contract or pollute
+ *     the release dispatch route with non-release concerns.
+ *   - Auditing is cleaner: `event: "soundcheck.mcp.dispatch"` is unique
+ *     enough to filter on in Railway logs without snarls of string parsing.
+ *
+ * Write auth:
+ *   - Reuses `GITHUB_DISPATCH_PAT`. The existing PAT is already scoped to
+ *     MCPJam/inspector with `actions:write`, which covers any workflow in
+ *     the repo — no new token is needed.
+ *
+ * Reviewer gate:
+ *   - Lives on the `mcp-production` GitHub Environment in repo settings,
+ *     not here. If configured, GitHub holds the dispatched run pending
+ *     approval; this route's response still returns `ok: true` because
+ *     dispatch succeeded — the operator watches the progress in GH Actions
+ *     (or, eventually, a Soundcheck progress tile for this workflow).
+ */
+
+import { NextResponse } from "next/server";
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { isAllowedEmployeeEmail } from "@/lib/lockdown";
+import { dispatchWorkflow } from "@/lib/github";
+
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  // ── 1. Enforce employee-only — unconditionally ──────────────────────
+  // Same posture as /api/release/dispatch: this hands out a write-scoped
+  // PAT to dispatch a production deploy. MCPJAM_NONPROD_LOCKDOWN being
+  // flipped off must not open this to every WorkOS tenant user.
+  const { user } = await withAuth({ ensureSignedIn: true });
+  let allowed = false;
+  try {
+    allowed = isAllowedEmployeeEmail(user.email);
+  } catch (err) {
+    console.error("mcp dispatch route: lockdown misconfigured:", err);
+    return NextResponse.json(
+      { error: "Server lockdown env not configured" },
+      { status: 500 }
+    );
+  }
+  if (!allowed) {
+    return NextResponse.json({ error: "Not authorized" }, { status: 403 });
+  }
+
+  // ── 2. Require the write PAT to be configured ───────────────────────
+  const writeToken = process.env.GITHUB_DISPATCH_PAT;
+  if (!writeToken) {
+    return NextResponse.json(
+      {
+        error:
+          "GITHUB_DISPATCH_PAT not configured on the server. Set a fine-grained PAT with actions:write on MCPJam/inspector."
+      },
+      { status: 500 }
+    );
+  }
+
+  // ── 3. Audit log ────────────────────────────────────────────────────
+  console.info(
+    JSON.stringify({
+      event: "soundcheck.mcp.dispatch",
+      email: user.email,
+      workflow: "deploy-mcp-prod.yml"
+    })
+  );
+
+  // ── 4. Dispatch ─────────────────────────────────────────────────────
+  try {
+    await dispatchWorkflow(
+      "MCPJam",
+      "inspector",
+      "deploy-mcp-prod.yml",
+      "main",
+      {},
+      writeToken
+    );
+  } catch (err) {
+    console.error("mcp dispatch route: workflow dispatch failed:", err);
+    return NextResponse.json(
+      {
+        error:
+          "Failed to dispatch deploy-mcp-prod.yml. Check Soundcheck server logs for details."
+      },
+      { status: 502 }
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    message:
+      "deploy-mcp-prod.yml dispatched. Watch the run in GitHub Actions; the MCP tile will reflect the new live SHA after deploy completes."
+  });
+}

--- a/soundcheck/src/app/api/release/dispatch/route.ts
+++ b/soundcheck/src/app/api/release/dispatch/route.ts
@@ -25,6 +25,17 @@ import { dispatchWorkflow } from "@/lib/github";
 
 export const dynamic = "force-dynamic";
 
+/**
+ * Same-origin sentinel. A plain HTML form (the classic CSRF vector)
+ * can't set custom request headers, and a cross-origin `fetch` with a
+ * custom header triggers a CORS preflight against this origin — which
+ * this route doesn't respond to, so the browser blocks the request.
+ * WorkOS AuthKit cookies with SameSite=None would otherwise attach to
+ * cross-site POSTs, so `withAuth` alone isn't sufficient.
+ */
+const EXPECTED_DISPATCH_HEADER = "x-soundcheck-action";
+const EXPECTED_DISPATCH_VALUE = "release-dispatch";
+
 type Scope = "packages-only" | "inspector-only" | "full";
 
 interface DispatchBody {
@@ -55,6 +66,16 @@ function parseBody(raw: unknown): DispatchBody | null {
 }
 
 export async function POST(request: Request) {
+  // ── 0. Same-origin guard (cheap defense-in-depth) ───────────────────
+  if (
+    request.headers.get(EXPECTED_DISPATCH_HEADER) !== EXPECTED_DISPATCH_VALUE
+  ) {
+    return NextResponse.json(
+      { error: "Invalid dispatch request" },
+      { status: 403 }
+    );
+  }
+
   // ── 1. Enforce employee-only — unconditionally ──────────────────────
   // Unlike the read tiles (which follow the MCPJAM_NONPROD_LOCKDOWN flag),
   // this route hands out the write-scoped PAT and dispatches production.

--- a/soundcheck/src/app/page.tsx
+++ b/soundcheck/src/app/page.tsx
@@ -88,7 +88,7 @@ export default async function Home() {
       <Section
         numeral="I"
         title="Deploy diff"
-        description="What's live where. Inspector + Backend compare production vs. staging; MCP has no prod yet, so it compares staging vs. main. The big number on each tile is the headline answer — use it to decide whether to cut a release today."
+        description="What's live where. Inspector + Backend compare production vs. staging; MCP compares its live staging SHA vs. main because the staging worker is the promotion candidate for mcp.mcpjam.com. The big number on each tile is the headline answer — use it to decide whether to cut a release (section III) or promote MCP (section VI) today."
       >
         <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
           <Suspense fallback={<DeployDiffSkeleton title="Inspector" />}>

--- a/soundcheck/src/app/page.tsx
+++ b/soundcheck/src/app/page.tsx
@@ -26,6 +26,7 @@ import {
   McpDeployStatusSkeleton
 } from "@/components/mcp-deploy-status";
 import { RunRelease } from "@/components/run-release";
+import { RunMcpProd } from "@/components/run-mcp-prod";
 import { ReleaseVerdict, ReleaseVerdictSkeleton } from "@/components/release-verdict";
 import { Section } from "@/components/ui";
 import { Card, CardContent } from "@mcpjam/design-system/card";
@@ -157,6 +158,16 @@ export default async function Home() {
         <Suspense fallback={<DeployFailuresSkeleton />}>
           <DeployFailures />
         </Suspense>
+      </Section>
+
+      <Section
+        numeral="VI"
+        title="MCP production"
+        description="The Cloudflare Worker behind mcp.mcpjam.com is on its own pipeline — not part of release.yml. Promote staging → production once the MCP tile in section I shows 0 drift."
+      >
+        <div className="grid gap-5 md:grid-cols-2">
+          <RunMcpProd />
+        </div>
       </Section>
 
       <footer className="mt-20 border-t border-border pt-6 text-[11px] text-muted-foreground md:flex md:items-center md:justify-between">

--- a/soundcheck/src/components/mcp-deploy-status.tsx
+++ b/soundcheck/src/components/mcp-deploy-status.tsx
@@ -1,11 +1,14 @@
 /**
  * MCP staging drift tile.
  *
- * The MCP Cloudflare Worker has no production environment today — only
- * `mcpjam-mcp-staging`, auto-deployed by deploy-mcp-staging.yml on every
- * push to main. So the Deploy Diff shape (staging vs prod) doesn't apply.
- * Instead, this tile answers: "what SHA is live on staging, and how many
- * main commits are ahead of it?"
+ * MCP production (mcp.mcpjam.com) deploys via deploy-mcp-prod.yml, which
+ * is gated on a green deploy-mcp-staging.yml run for the same main SHA —
+ * so "staging in sync with main" is the promotion-readiness signal. That
+ * means this tile shows staging vs. main (not staging vs. prod like the
+ * Inspector/Backend tiles): the staging worker is the promotion candidate
+ * for production, and main is what the next staging deploy would ship.
+ * Question answered: "what SHA is live on staging, and how many main
+ * commits are ahead of it?"
  *
  * Data:
  *   - `live SHA` = `head_sha` of the latest successful `deploy-mcp-staging.yml`

--- a/soundcheck/src/components/run-mcp-prod.tsx
+++ b/soundcheck/src/components/run-mcp-prod.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+/**
+ * Deploy MCP production tile — button + confirmation modal.
+ *
+ * The MCP Cloudflare Worker isn't part of release.yml's scope (Changesets
+ * ignores @mcpjam/mcp; it deploys via its own Cloudflare pipeline). This
+ * tile is the single user-facing path to promote whatever's currently on
+ * mcp-staging.mcpjam.com to mcp.mcpjam.com.
+ *
+ * The workflow itself (`deploy-mcp-prod.yml`) re-checks that the current
+ * main SHA has a green `deploy-mcp-staging.yml` run — clicking here
+ * without one fails at the workflow's preflight step rather than
+ * shipping a SHA that hasn't been verified on staging.
+ *
+ * No form inputs: unlike release.yml, this workflow has no scope/flags.
+ * Main head + green staging = the only valid dispatch shape, so the
+ * button carries all the state and the modal just surfaces the warning.
+ */
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@mcpjam/design-system/dialog";
+import { Badge, Tile } from "@/components/ui";
+
+export function RunMcpProd() {
+  const router = useRouter();
+  const [confirming, setConfirming] = useState(false);
+  const [feedback, setFeedback] = useState<
+    | { kind: "idle" }
+    | { kind: "ok"; message: string }
+    | { kind: "error"; message: string }
+  >({ kind: "idle" });
+  const [isPending, startTransition] = useTransition();
+
+  function onConfirm() {
+    setFeedback({ kind: "idle" });
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/mcp/dispatch", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" }
+        });
+        const json = (await res.json()) as {
+          error?: string;
+          message?: string;
+        };
+        if (!res.ok) {
+          setFeedback({
+            kind: "error",
+            message: json.error ?? `Dispatch failed: ${res.status}`
+          });
+          setConfirming(false);
+          return;
+        }
+        setFeedback({
+          kind: "ok",
+          message:
+            json.message ?? "deploy-mcp-prod.yml dispatched."
+        });
+        setConfirming(false);
+        // Mirrors the release button: give GitHub a beat to register the
+        // new run, then refresh so any downstream tile that reads
+        // workflow-run state (future MCP progress tile, etc.) picks it up.
+        setTimeout(() => router.refresh(), 4000);
+      } catch (err) {
+        setFeedback({
+          kind: "error",
+          message: (err as Error).message
+        });
+        setConfirming(false);
+      }
+    });
+  }
+
+  return (
+    <Tile
+      title="Deploy MCP production"
+      eyebrow="mcp.mcpjam.com"
+      accent="warning"
+    >
+      <p className="mb-5 text-xs leading-relaxed text-muted-foreground">
+        Dispatches{" "}
+        <span className="font-mono text-foreground">deploy-mcp-prod.yml</span>{" "}
+        on <span className="font-mono text-foreground">main</span>. The
+        workflow refuses unless{" "}
+        <span className="font-mono text-foreground">
+          deploy-mcp-staging.yml
+        </span>{" "}
+        is green for the current main SHA — check the MCP tile in
+        section&nbsp;I first.
+      </p>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          variant="destructive"
+          onClick={() => setConfirming(true)}
+          disabled={isPending}
+        >
+          Deploy MCP to production →
+        </Button>
+        {feedback.kind === "ok" ? (
+          <>
+            <Badge tone="success">dispatched</Badge>
+            <span className="text-xs text-muted-foreground">
+              {feedback.message}
+            </span>
+          </>
+        ) : null}
+        {feedback.kind === "error" ? (
+          <span className="text-xs text-destructive">{feedback.message}</span>
+        ) : null}
+      </div>
+
+      <ConfirmModal
+        open={confirming}
+        onOpenChange={(v) => !isPending && setConfirming(v)}
+        onConfirm={onConfirm}
+        busy={isPending}
+      />
+    </Tile>
+  );
+}
+
+function ConfirmModal({
+  open,
+  onOpenChange,
+  onConfirm,
+  busy
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  onConfirm: () => void;
+  busy: boolean;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent showCloseButton={!busy} className="sm:max-w-md">
+        <DialogHeader>
+          <div className="text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            Final confirmation
+          </div>
+          <DialogTitle className="text-xl">
+            Promote MCP to{" "}
+            <span className="font-mono text-[0.85em]">mcp.mcpjam.com</span>?
+          </DialogTitle>
+          <DialogDescription>
+            Fires{" "}
+            <span className="font-mono text-foreground">
+              deploy-mcp-prod.yml
+            </span>{" "}
+            on <span className="font-mono text-foreground">main</span>.
+          </DialogDescription>
+        </DialogHeader>
+
+        <p className="rounded-lg border border-warning/40 bg-warning/10 px-3 py-2.5 text-xs leading-relaxed text-warning">
+          The Cloudflare Worker behind{" "}
+          <span className="font-mono">mcp.mcpjam.com</span> will be
+          overwritten with the current main SHA. Any client connected to the
+          prod MCP endpoint sees the new build within seconds of the deploy
+          completing.
+        </p>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={busy}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={onConfirm}
+            disabled={busy}
+          >
+            {busy ? "Dispatching…" : "Deploy to production →"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/soundcheck/src/components/run-mcp-prod.tsx
+++ b/soundcheck/src/components/run-mcp-prod.tsx
@@ -47,7 +47,12 @@ export function RunMcpProd() {
       try {
         const res = await fetch("/api/mcp/dispatch", {
           method: "POST",
-          headers: { "Content-Type": "application/json" }
+          headers: {
+            "Content-Type": "application/json",
+            // Same-origin sentinel — the route rejects POSTs missing this
+            // header to close a CSRF vector. See route.ts for rationale.
+            "x-soundcheck-action": "mcp-prod-dispatch"
+          }
         });
         const json = (await res.json()) as {
           error?: string;

--- a/soundcheck/src/components/run-release.tsx
+++ b/soundcheck/src/components/run-release.tsx
@@ -83,7 +83,12 @@ export function RunRelease() {
       try {
         const res = await fetch("/api/release/dispatch", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            // Same-origin sentinel — the route rejects POSTs missing this
+            // header to close a CSRF vector. See route.ts for rationale.
+            "x-soundcheck-action": "release-dispatch"
+          },
           body: JSON.stringify({
             scope,
             deploy_backend_prod: deployBackend,


### PR DESCRIPTION
## Summary

- Adds [`.github/workflows/deploy-mcp-prod.yml`](../blob/claude/wonderful-keller-2bf137/.github/workflows/deploy-mcp-prod.yml) — `workflow_dispatch`-only, refuses to run unless `deploy-mcp-staging.yml` is green for the current main SHA, deploys `wrangler deploy --env production`, 20×3s smoke on `mcp.mcpjam.com` to absorb first-deploy cert provisioning.
- Adds [`soundcheck/src/app/api/mcp/dispatch/route.ts`](../blob/claude/wonderful-keller-2bf137/soundcheck/src/app/api/mcp/dispatch/route.ts) — `POST /api/mcp/dispatch`, reuses the employee-email gate + existing `GITHUB_DISPATCH_PAT`. Audit event `soundcheck.mcp.dispatch`.
- Adds [`soundcheck/src/components/run-mcp-prod.tsx`](../blob/claude/wonderful-keller-2bf137/soundcheck/src/components/run-mcp-prod.tsx) + [page.tsx change](../blob/claude/wonderful-keller-2bf137/soundcheck/src/app/page.tsx) — new Section VI "MCP production" tile with confirmation modal, destructive-variant styling matching `RunRelease`.
- [`pr-preview.yml`](../blob/claude/wonderful-keller-2bf137/.github/workflows/pr-preview.yml) `paths-ignore` gets the new workflow so MCP-only PRs still skip the Railway inspector preview.

## Why

MCP has always been deliberately outside `release.yml` (Changesets ignores `@mcpjam/mcp`; it deploys via its own Cloudflare pipeline). Soundcheck could dispatch `release.yml` but had no path for MCP production. This adds that path without entangling MCP with the release workflow's Changesets contract.

Backend side of this change is already done in code — [`convex/auth.config.ts`](https://github.com/MCPJam/mcpjam-backend/blob/main/convex/auth.config.ts) has the dynamic `AUTHKIT_DOMAIN` block (commit 30005b8b), and both staging/prod `AUTHKIT_DOMAIN` are wired as repo-level GitHub Actions vars.

## Reviewer nits

- `mcp-production` GitHub Environment isn't created yet. Reviewer protection should be configured in repo Settings → Environments, not in the workflow file. Recommend gating it on the same reviewers as `production` (`chelojimenez`, `ignaciojimenezr`, `prathmeshpatel`).
- Optional env var `MCP_WORKER_PRODUCTION_URL` for the deploy-history link in GH's environments UI; defaults to `https://mcp.mcpjam.com` if unset.
- Concurrency group is `mcp-production` with `cancel-in-progress: false` — opposite of the staging workflow. Rationale: cancelling a production deploy mid-upload can leave the worker in a partially-provisioned state (cert attached, bindings missing). Queue instead.

## Test plan

- [ ] Typecheck passes (`npm run typecheck -w @mcpjam/soundcheck` — ran green locally)
- [ ] Lint passes (`npm run lint -w @mcpjam/soundcheck` — ran green locally)
- [ ] YAML parses (verified locally with `js-yaml`)
- [ ] Create the `mcp-production` GitHub Environment with reviewer gate before first dispatch
- [ ] Confirm no pre-existing `mcp.mcpjam.com` DNS stub in the Cloudflare zone (`custom_domain: true` refuses to attach if one exists; same gotcha documented for staging in the 2026-04-17 rollout entry)
- [ ] Smoke-dispatch from Soundcheck: click "Deploy MCP production" → confirm modal → watch the workflow run succeed → `curl https://mcp.mcpjam.com` returns the MCPJam MCP landing page
- [ ] Verify the staging-gate step correctly fails a dispatch when `deploy-mcp-staging.yml` has no green run for the current SHA (e.g., push a `mcp/`-touching commit, dispatch immediately before staging finishes)
- [ ] Redeploy backend prod once (`inspector_release_promote` with no other scope changes) to bake `AUTHKIT_DOMAIN=login.mcpjam.com` into prod Convex — only blocker for the `whoami` tool validating JWTs on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new production deployment workflow and a server-dispatched path that uses a write-scoped GitHub PAT; mistakes could trigger unintended production deploys or block promotions. Includes new preflight gating and CSRF-style request sentinels, but this still changes release/deploy control-plane behavior.
> 
> **Overview**
> Adds a manual **MCP staging → production promotion** path: a new `deploy-mcp-prod.yml` workflow dispatch deploys the Cloudflare Worker to production, queues concurrent deploys, runs a staging-green/build-inputs preflight, and performs a bounded-retry smoke test against the production URL.
> 
> Extends Soundcheck with a new Section VI **“MCP production”** tile (`RunMcpProd`) that dispatches the prod workflow via a new `POST /api/mcp/dispatch` route (employee-only, audit logged, requires `GITHUB_DISPATCH_PAT`). The existing `POST /api/release/dispatch` path is tightened with a same-origin sentinel header, and `pr-preview.yml`’s `paths-ignore` is updated to ignore the new prod workflow; MCP staging smoke tests now bound curl timeouts to avoid hanging concurrency slots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78ec53752d1248e408a8c4a9ee82555e5e5c0740. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->