### PR TITLE
Soundcheck: document GITHUB_DISPATCH_PAT runtime secret

### DIFF
--- a/soundcheck/.env.example
+++ b/soundcheck/.env.example
@@ -15,3 +15,8 @@ RAILWAY_API_TOKEN=
 CONVEX_DEPLOY_KEY_STAGING=
 CONVEX_DEPLOY_KEY_PROD=
 GITHUB_PAT=
+
+# Write-scoped PAT used by the release dispatch route to trigger
+# release.yml and deploy-mcp-prod.yml via workflow_dispatch.
+# Fine-grained, Actions: Read and write on MCPJam/inspector.
+GITHUB_DISPATCH_PAT=

--- a/soundcheck/README.md
+++ b/soundcheck/README.md
@@ -65,6 +65,7 @@ Read by the Soundcheck app at request time to populate tiles.
 | `CONVEX_DEPLOY_KEY_STAGING` | Read backend-staging state | 90 days |
 | `CONVEX_DEPLOY_KEY_PROD` | Read backend-prod state | 90 days |
 | `GITHUB_PAT` | GitHub REST + Compare + Actions (fine-grained, read-only, scoped to both repos) | 90 days |
+| `GITHUB_DISPATCH_PAT` | `workflow_dispatch` for `release.yml` + `deploy-mcp-prod.yml` (fine-grained, **Actions: Read and write** on `MCPJam/inspector`) | 90 days |
 | `WORKOS_API_KEY`, `WORKOS_CLIENT_ID`, `WORKOS_COOKIE_PASSWORD` | Auth | per existing WorkOS policy |
 | `MCPJAM_NONPROD_LOCKDOWN=true` | Employee gate on | n/a |
 | `MCPJAM_EMPLOYEE_EMAIL_DOMAINS=mcpjam.com` | Allowed email domains | n/a |


### PR DESCRIPTION
## Summary

- Add `GITHUB_DISPATCH_PAT` to the Soundcheck runtime-secret table in `soundcheck/README.md` and to `soundcheck/.env.example`, so future Railway provisioning includes it.
- No code change — docs only.

## Why

The release dispatch route (`soundcheck/src/app/api/release/dispatch/route.ts:143`) requires `GITHUB_DISPATCH_PAT` to fire `workflow_dispatch` for `release.yml` and `deploy-mcp-prod.yml`, but the variable was never listed in the README secret table or `.env.example`. That gap meant the `mcpjam-soundcheck` Railway service was provisioned without it, and clicking **Run release → deploy_mcp_production** returns 500 with `GITHUB_DISPATCH_PAT not configured on the server`.

The production deploy was unblocked out of band by dispatching `deploy-mcp-prod.yml` directly via `gh workflow run` ([run 24617324967](https://github.com/MCPJam/inspector/actions/runs/24617324967)). The permanent fix — creating a fine-grained PAT (`Actions: Read and write` on `MCPJam/inspector`) and setting `GITHUB_DISPATCH_PAT` on the `mcpjam-soundcheck` Railway service — is an ops step, tracked here so the documentation no longer hides it.

## Test plan

- [ ] Docs rendering on GitHub shows `GITHUB_DISPATCH_PAT` in the runtime-secret table.
- [ ] After setting `GITHUB_DISPATCH_PAT` on Railway, **Run release** tile dispatches `deploy-mcp-prod.yml` without 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change; no runtime behavior is modified, but it documents a new write-scoped GitHub PAT that must be provisioned correctly in Railway.
> 
> **Overview**
> Documents `GITHUB_DISPATCH_PAT` as a required Soundcheck runtime secret by adding it to `.env.example` and the README runtime secrets table, including notes that it needs fine-grained **Actions: read/write** access to dispatch `release.yml` and `deploy-mcp-prod.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14165ba67a4b273e5ee15e618bbfec6c4cf832da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->