### PR TITLE
Soundcheck: consolidate GITHUB_DISPATCH_PAT into GITHUB_PAT

### DIFF
--- a/soundcheck/README.md
+++ b/soundcheck/README.md
@@ -64,7 +64,7 @@ Read by the Soundcheck app at request time to populate tiles.
 | `RAILWAY_API_TOKEN` | Read Railway envs + deployments for dashboard tiles | 90 days |
 | `CONVEX_DEPLOY_KEY_STAGING` | Read backend-staging state | 90 days |
 | `CONVEX_DEPLOY_KEY_PROD` | Read backend-prod state | 90 days |
-| `GITHUB_PAT` | GitHub REST + Compare + Actions (fine-grained, read-only, scoped to both repos) | 90 days |
+| `GITHUB_PAT` | GitHub REST + Compare + Actions, plus `workflow_dispatch` for `release.yml` / `deploy-mcp-prod.yml` (fine-grained, scoped to both repos, `actions:read/write` + `contents:read` + `deployments:read` + `metadata:read`) | 90 days |
 | `WORKOS_API_KEY`, `WORKOS_CLIENT_ID`, `WORKOS_COOKIE_PASSWORD` | Auth | per existing WorkOS policy |
 | `MCPJAM_NONPROD_LOCKDOWN=true` | Employee gate on | n/a |
 | `MCPJAM_EMPLOYEE_EMAIL_DOMAINS=mcpjam.com` | Allowed email domains | n/a |

--- a/soundcheck/src/app/api/release/dispatch/route.ts
+++ b/soundcheck/src/app/api/release/dispatch/route.ts
@@ -12,9 +12,9 @@
  * write-scoped PAT.
  *
  * Write auth:
- *   - Reads `GITHUB_DISPATCH_PAT` (separate from the read-only `GITHUB_PAT`).
- *   - Fine-grained, scoped to `MCPJam/inspector` with `actions:write`. The
- *     same token covers both workflows — no separate MCP token needed.
+ *   - Reads `GITHUB_PAT` (same fine-grained token used for reads).
+ *   - Scoped to `MCPJam/inspector` with `actions:read/write`. The same
+ *     token covers both workflows — no separate MCP token needed.
  *
  * Audit:
  *   - Logs the signed-in email + dispatched inputs + which workflows fired
@@ -139,13 +139,13 @@ export async function POST(request: Request) {
     );
   }
 
-  // ── 3. Require the write PAT to be configured ───────────────────────
-  const writeToken = process.env.GITHUB_DISPATCH_PAT;
+  // ── 3. Require the PAT to be configured ─────────────────────────────
+  const writeToken = process.env.GITHUB_PAT;
   if (!writeToken) {
     return NextResponse.json(
       {
         error:
-          "GITHUB_DISPATCH_PAT not configured on the server. Set a fine-grained PAT with actions:write on MCPJam/inspector."
+          "GITHUB_PAT not configured on the server. Set a fine-grained PAT with actions:read/write on MCPJam/inspector."
       },
       { status: 500 }
     );

--- a/soundcheck/src/components/run-release.tsx
+++ b/soundcheck/src/components/run-release.tsx
@@ -19,9 +19,8 @@
  * The confirmation modal quotes the final inputs back verbatim because
  * production-touching dispatches deserve a deliberate extra click.
  *
- * The client never sees `GITHUB_DISPATCH_PAT`. The server route
- * /api/release/dispatch holds the write token; this component only POSTs
- * JSON to it.
+ * The client never sees the GitHub PAT. The server route
+ * /api/release/dispatch holds it; this component only POSTs JSON to it.
  */
 
 import { useState, useTransition } from "react";

--- a/soundcheck/src/lib/github.ts
+++ b/soundcheck/src/lib/github.ts
@@ -3,11 +3,10 @@
  * needs: environment deployments, commit comparisons, workflow runs,
  * repo contents, and release dispatch.
  *
- * Auth: `GITHUB_PAT` must be a fine-grained token with read-only access to
- * `contents`, `deployments`, `metadata`, and `actions` on the inspector and
- * backend repos. The separate `GITHUB_DISPATCH_PAT` (only read by
- * `dispatchWorkflow`) holds the `actions:write` scope used to trigger the
- * Release workflow; keeping the two split limits the blast radius of a leak.
+ * Auth: `GITHUB_PAT` must be a fine-grained token scoped to the inspector
+ * and backend repos with `contents:read`, `deployments:read`, `metadata:read`,
+ * and `actions:read/write` — the write scope is what lets `dispatchWorkflow`
+ * fire `release.yml` and `deploy-mcp-prod.yml` from the dispatch route.
  */
 
 const GITHUB_API = "https://api.github.com";
@@ -544,11 +543,9 @@ export async function getJobAnnotations(
 /**
  * Dispatches a workflow via `POST /actions/workflows/{file}/dispatches`.
  *
- * Takes an explicit `token` instead of falling back to `GITHUB_PAT`. The
- * write PAT is read from `GITHUB_DISPATCH_PAT` by the caller (the
- * `/api/release/dispatch` route) and passed through here. Keeping the write
- * token out of the module-level env read means no accidental use of a
- * write-scoped token by one of the read helpers above.
+ * Takes an explicit `token` so the caller decides which env var sources it.
+ * Today the `/api/release/dispatch` route reads `GITHUB_PAT` — the same
+ * token used for reads, which carries `actions:read/write`.
  */
 export async function dispatchWorkflow(
   owner: string,


### PR DESCRIPTION
## Summary

- `/api/release/dispatch` now reads `GITHUB_PAT` instead of a separate `GITHUB_DISPATCH_PAT`.
- README accurately describes the Soundcheck PAT's scopes (was stale: "read-only").
- Doc comments in `src/lib/github.ts`, `src/app/api/release/dispatch/route.ts`, and `src/components/run-release.tsx` updated to match.

## Why

The code split the write scope into a separate `GITHUB_DISPATCH_PAT` on the theory that narrowing the blast radius of a leaked write token was worth the extra env var. In practice only one fine-grained Soundcheck PAT ever existed — it's scoped to `MCPJam/inspector` + `MCPJam/mcpjam-backend` and carries `actions:read/write`. Railway ended up with the same token stored under both variable names, which was a mental-model footgun:

1. The "Deploy MCP production" tile 500'd in production today because `GITHUB_DISPATCH_PAT` wasn't set on Railway (it had been missed during initial provisioning — the README never listed it). See [run 24617324967](https://github.com/MCPJam/inspector/actions/runs/24617324967) for the manual unblock via `gh workflow run`.
2. README described `GITHUB_PAT` as "read-only", which was stale — the actual PAT has `actions:write`.

One token, one env var, one rotation lifecycle.

## Rollout

1. Merge this PR.
2. `deploy-soundcheck.yml` auto-deploys the new code to `mcpjam-soundcheck` Railway service.
3. **Then** remove the now-orphan `GITHUB_DISPATCH_PAT` variable from the Railway service (removing it before the new code ships would break the currently-deployed dispatch route).

## Test plan

- [ ] After rollout step 2, "Run release" tile dispatches `deploy-mcp-prod.yml` without 500.
- [ ] After rollout step 3, "Run release" tile still works (verifies the code is reading `GITHUB_PAT`, not a stale reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the credential used to trigger GitHub Actions workflow dispatches for production deploys; misconfiguration of PAT scopes or env vars could break release/MCP deploy triggering.
> 
> **Overview**
> Soundcheck now uses a single `GITHUB_PAT` for both GitHub read calls and `workflow_dispatch`, removing the separate `GITHUB_DISPATCH_PAT` dependency in `/api/release/dispatch`.
> 
> Documentation/comments are updated to reflect the required fine-grained PAT scopes (`actions:read/write` plus read scopes) and the fact that the client never receives the token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ae70b504658ccd2a608f20801f8e456c4983a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->