### PR TITLE
Pin Railway builder to Dockerfile for mcp-inspector service

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "mcpjam-inspector/Dockerfile"
+  }
+}


### PR DESCRIPTION
## Summary
- `railway up --ci` has been failing on every inspector env (prod, staging, `pr-*`, `pr-be-*`) with `No start command detected` because Railway's default builder (Railpack) is being invoked instead of `mcpjam-inspector/Dockerfile`. Staging and production are still Online because they're serving older successful deploys — any re-deploy would hit the same wall.
- This PR pins the builder to `DOCKERFILE` and the path to `mcpjam-inspector/Dockerfile` in a root `railway.json`. Service Root Directory stays `/` so the Dockerfile's `COPY sdk/package.json ./sdk/package.json` (and siblings) still works with the monorepo root as build context.

## Scope
- Only affects services in the `triumphant-alignment` Railway project (inspector). Soundcheck is in a separate `mcpjam-soundcheck` project and is not touched.
- No Config-as-code Path is set on any service in `triumphant-alignment`, so the root `railway.json` is the right location.

## Test plan
- [ ] Merge this PR.
- [ ] Confirm `railway up --ci` on any inspector env logs `Using detected Dockerfile!` (not Railpack) on the next deploy.
- [ ] Re-run `upsert-preview` on `MCPJam/inspector#1859` (or push an empty commit) — `Deploy preview to Railway` should succeed and `steps.preview_domain.outputs.url` should be populated.
- [ ] Re-run the counterpart on `MCPJam/mcpjam-backend#145` so `pr-be-145` deploys successfully.
- [ ] Once both envs are healthy, inspector PR should exercise the reuse path (requires granting `BACKEND_PREVIEW_DISPATCH_TOKEN` the `pulls:read` scope, tracked separately).

https://claude.ai/code/session_01VoAzjkg2L5TuzNqyhnAyT5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects Railway build selection; main risk is mis-pointing the Dockerfile path and breaking deployments.
> 
> **Overview**
> Pins Railway builds to use the repo’s `mcpjam-inspector/Dockerfile` by adding a root `railway.json`, avoiding Railpack auto-detection issues during deploys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 011a10ff92281bde568fe1014dbf571f0ff2f4b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->