### PR TITLE
Add getWorkspaces and getOrg MCP tools

### DIFF
--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -2,6 +2,8 @@ import { McpAgent } from "agents/mcp";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { JWTPayload } from "jose";
 import { registerDoctorTool } from "./tools/doctor.js";
+import { registerGetOrgTool } from "./tools/getOrg.js";
+import { registerGetWorkspacesTool } from "./tools/getWorkspaces.js";
 import { registerWhoamiTool } from "./tools/whoami.js";
 
 interface McpProps extends Record<string, unknown> {
@@ -26,5 +28,7 @@ export class McpJamMcpServer extends McpAgent<Env, unknown, McpProps> {
   async init(): Promise<void> {
     registerWhoamiTool(this.server, this);
     registerDoctorTool(this.server, this);
+    registerGetWorkspacesTool(this.server, this);
+    registerGetOrgTool(this.server, this);
   }
 }

--- a/mcp/src/tools/getOrg.ts
+++ b/mcp/src/tools/getOrg.ts
@@ -1,0 +1,70 @@
+import { ConvexHttpClient } from "convex/browser";
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpJamMcpServer } from "../server.js";
+
+type Organization = {
+  _id: string;
+  name: string;
+  description?: string;
+  imageUrl?: string;
+  logoUrl?: string;
+  createdBy: string;
+  createdAt: number;
+  updatedAt: number;
+  myRole?: string;
+};
+
+export function registerGetOrgTool(
+  server: McpServer,
+  agent: McpJamMcpServer
+): void {
+  server.registerTool(
+    "getOrg",
+    {
+      title: "Get one of my MCPJam organizations",
+      description:
+        "Returns the authenticated user's organization by ID. The ID must match an org the caller belongs to.",
+      inputSchema: z.object({
+        organizationId: z.string().min(1),
+      }),
+    },
+    async ({ organizationId }) => {
+      const token = agent.bearerToken;
+      if (!token) {
+        return toolError("No bearer token on the request.");
+      }
+
+      const client = new ConvexHttpClient(agent.runtimeEnv.CONVEX_URL);
+      client.setAuth(token);
+
+      const orgs = (await client.query(
+        "organizations:getMyOrganizations" as any,
+        {}
+      )) as Organization[];
+
+      const match = orgs.find((o) => o._id === organizationId);
+      if (!match) {
+        return toolError(
+          `Organization ${organizationId} not found or not accessible.`
+        );
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(match, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}
+
+function toolError(message: string) {
+  return {
+    isError: true,
+    content: [{ type: "text" as const, text: message }],
+  };
+}

--- a/mcp/src/tools/getWorkspaces.ts
+++ b/mcp/src/tools/getWorkspaces.ts
@@ -1,0 +1,67 @@
+import { ConvexHttpClient } from "convex/browser";
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { McpJamMcpServer } from "../server.js";
+
+type RemoteWorkspace = {
+  _id: string;
+  name: string;
+  description?: string;
+  icon?: string;
+  organizationId: string;
+  ownerId: string;
+  visibility?: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export function registerGetWorkspacesTool(
+  server: McpServer,
+  agent: McpJamMcpServer
+): void {
+  server.registerTool(
+    "getWorkspaces",
+    {
+      title: "List my MCPJam workspaces",
+      description:
+        "Returns the authenticated user's workspaces. Pass organizationId to filter to a single organization.",
+      inputSchema: z.object({
+        organizationId: z.string().min(1).optional(),
+      }),
+    },
+    async ({ organizationId }) => {
+      const token = agent.bearerToken;
+      if (!token) {
+        return toolError("No bearer token on the request.");
+      }
+
+      const client = new ConvexHttpClient(agent.runtimeEnv.CONVEX_URL);
+      client.setAuth(token);
+
+      const workspaces = (await client.query(
+        "workspaces:getMyWorkspaces" as any,
+        {}
+      )) as RemoteWorkspace[];
+
+      const filtered = organizationId
+        ? workspaces.filter((w) => w.organizationId === organizationId)
+        : workspaces;
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(filtered, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}
+
+function toolError(message: string) {
+  return {
+    isError: true,
+    content: [{ type: "text" as const, text: message }],
+  };
+}


### PR DESCRIPTION
## Summary
- Adds two new tools to the hosted MCPJam MCP server (Cloudflare Worker in `mcp/`): `getWorkspaces` and `getOrg`.
- `getWorkspaces` takes an optional `organizationId` and returns the caller's workspaces, filtered client-side to mirror `filterWorkspacesForOrganization` in `useWorkspaces.ts`.
- `getOrg` takes a required `organizationId` and returns the single matching org from the caller's memberships.

## Why
`doctor` requires `organizationId` and `workspaceId`, but MCP clients had no way to discover those IDs — users had to find them in the web app first. These tools close that gap so workspace/org lookup can happen entirely over MCP.

Both are thin wrappers over existing Convex queries (`workspaces:getMyWorkspaces`, `organizations:getMyOrganizations`) already used by the web client, and follow the exact registration pattern from `whoami.ts`.

## Test plan
- [ ] `cd mcp && pnpm dev` (or `npm run dev`) boots the worker without errors.
- [ ] From a connected MCP client with a valid AuthKit bearer:
  - [ ] `getWorkspaces` with `{}` returns all workspaces.
  - [ ] `getWorkspaces` with `{ organizationId: "<known>" }` returns only that org's workspaces.
  - [ ] `getOrg` with `{ organizationId: "<known>" }` returns the single org record.
  - [ ] `getOrg` with a bogus ID returns `isError: true` + "not found or not accessible".
- [ ] `whoami` and `doctor` still register and work (regression check on `init()`).

Note: the two pre-existing `tsc` errors in `mcp/` (SDK dup, `@mcpjam/sdk/worker` resolution) are unchanged — no new errors introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds two new read-only MCP tools that query Convex using the caller’s bearer token; risk is low but depends on correct authorization in the underlying Convex queries and client-side filtering.
> 
> **Overview**
> Adds two new hosted MCP tools, `getWorkspaces` and `getOrg`, to let MCP clients discover organization and workspace IDs without using the web app.
> 
> The tools are registered in `McpJamMcpServer.init()` and both call existing Convex queries with the request bearer token, returning JSON text (with `getWorkspaces` optionally filtering by `organizationId`, and `getOrg` returning an error if the requested org isn’t in the caller’s memberships).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6db3857a885356b33e9608291b21758117891149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->