### PR TITLE
Fix chatbox trace

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
@@ -5,15 +5,24 @@ import { toast } from "sonner";
 import { Button } from "@mcpjam/design-system/button";
 import { copyToClipboard } from "@/lib/clipboard";
 import type { ModelDefinition, ModelProvider } from "@/shared/types";
+import type { EvalTraceSpan } from "@/shared/eval-trace";
 import { TranscriptThread } from "@/components/chat-v2/thread/transcript-thread";
 import {
   adaptTraceToUiMessages,
   snapshotsToTraceWidgetSnapshots,
+  type TraceEnvelope,
   type TraceWidgetSnapshot,
 } from "@/components/evals/trace-viewer-adapter";
+import { TraceViewer } from "@/components/evals/trace-viewer";
+import {
+  ChatTraceViewModeHeaderBar,
+  type TraceViewMode,
+} from "@/components/evals/trace-view-mode-tabs";
 import {
   useSharedChatThread,
   useSharedChatWidgetSnapshots,
+  useSharedChatTurnTraces,
+  type SharedChatTurnTrace,
 } from "@/hooks/useSharedChatThreads";
 
 const NOOP = (..._args: unknown[]) => {};
@@ -22,14 +31,39 @@ interface ShareUsageThreadDetailProps {
   threadId: string;
 }
 
+/**
+ * Fetch span blobs from turn trace URLs and flatten into a single span array.
+ */
+async function hydrateSpans(
+  traces: SharedChatTurnTrace[],
+): Promise<EvalTraceSpan[]> {
+  const results = await Promise.all(
+    traces.map(async (trace) => {
+      if (!trace.spansBlobUrl) return [];
+      try {
+        const response = await fetch(trace.spansBlobUrl);
+        if (!response.ok) return [];
+        const parsed = await response.json();
+        return Array.isArray(parsed) ? (parsed as EvalTraceSpan[]) : [];
+      } catch {
+        return [];
+      }
+    }),
+  );
+  return results.flat();
+}
+
 export function ShareUsageThreadDetail({
   threadId,
 }: ShareUsageThreadDetailProps) {
   const { thread } = useSharedChatThread({ threadId });
   const { snapshots } = useSharedChatWidgetSnapshots({ threadId });
+  const { traces: turnTraces } = useSharedChatTurnTraces({ threadId });
   const [messages, setMessages] = useState<unknown[] | null>(null);
   const [isLoadingMessages, setIsLoadingMessages] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<TraceViewMode>("chat");
+  const [hydratedSpans, setHydratedSpans] = useState<EvalTraceSpan[]>([]);
 
   // Fetch messages from blob URL
   useEffect(() => {
@@ -76,13 +110,39 @@ export function ShareUsageThreadDetail({
     };
   }, [thread?.messagesBlobUrl]);
 
+  // Hydrate span blobs when turn traces arrive
+  useEffect(() => {
+    if (!turnTraces || turnTraces.length === 0) {
+      setHydratedSpans([]);
+      return;
+    }
+
+    let isActive = true;
+    void hydrateSpans(turnTraces).then((spans) => {
+      if (isActive) setHydratedSpans(spans);
+    });
+    return () => {
+      isActive = false;
+    };
+  }, [turnTraces]);
+
   // Transform snapshots to TraceWidgetSnapshot format
   const widgetSnapshots: TraceWidgetSnapshot[] = useMemo(() => {
     if (!snapshots || !thread) return [];
     return snapshotsToTraceWidgetSnapshots(snapshots);
   }, [snapshots, thread]);
 
-  // Adapt trace to UI messages
+  // Build a TraceEnvelope for the TraceViewer (timeline + raw)
+  const traceEnvelope: TraceEnvelope | null = useMemo(() => {
+    if (!messages) return null;
+    return {
+      messages: messages as any,
+      widgetSnapshots,
+      spans: hydratedSpans,
+    };
+  }, [messages, widgetSnapshots, hydratedSpans]);
+
+  // Adapt trace to UI messages for the chat view
   const adaptedTrace = useMemo(() => {
     if (!messages) return null;
     return adaptTraceToUiMessages({
@@ -100,6 +160,17 @@ export function ShareUsageThreadDetail({
     }),
     [thread?.modelId],
   );
+
+  // Compute trace timing from turn traces
+  const traceStartedAtMs = useMemo(() => {
+    if (!turnTraces || turnTraces.length === 0) return null;
+    return Math.min(...turnTraces.map((t: SharedChatTurnTrace) => t.startedAt));
+  }, [turnTraces]);
+
+  const traceEndedAtMs = useMemo(() => {
+    if (!turnTraces || turnTraces.length === 0) return null;
+    return Math.max(...turnTraces.map((t: SharedChatTurnTrace) => t.endedAt));
+  }, [turnTraces]);
 
   const handleCopySessionRef = useCallback(async () => {
     if (!thread) return;
@@ -224,27 +295,46 @@ export function ShareUsageThreadDetail({
         </div>
       </div>
 
-      {/* Messages */}
+      {/* Trace / Chat / Raw tabs */}
+      <ChatTraceViewModeHeaderBar
+        mode={viewMode}
+        onModeChange={setViewMode}
+      />
+
+      {/* Content area */}
       <div className="flex-1 min-h-0 overflow-y-auto">
-        <TranscriptThread
-          messages={adaptedTrace.messages}
-          model={resolvedModel}
-          sendFollowUpMessage={NOOP}
-          toolsMetadata={{}}
-          toolServerMap={{}}
-          pipWidgetId={null}
-          fullscreenWidgetId={null}
-          onRequestPip={NOOP}
-          onExitPip={NOOP}
-          onRequestFullscreen={NOOP}
-          onExitFullscreen={NOOP}
-          toolRenderOverrides={adaptedTrace.toolRenderOverrides}
-          showSaveViewButton={false}
-          minimalMode={!isChatboxThread}
-          interactive={false}
-          reasoningDisplayMode={reasoningDisplayMode}
-          contentClassName="max-w-4xl space-y-8 px-4 py-4"
-        />
+        {viewMode === "chat" ? (
+          <TranscriptThread
+            messages={adaptedTrace.messages}
+            model={resolvedModel}
+            sendFollowUpMessage={NOOP}
+            toolsMetadata={{}}
+            toolServerMap={{}}
+            pipWidgetId={null}
+            fullscreenWidgetId={null}
+            onRequestPip={NOOP}
+            onExitPip={NOOP}
+            onRequestFullscreen={NOOP}
+            onExitFullscreen={NOOP}
+            toolRenderOverrides={adaptedTrace.toolRenderOverrides}
+            showSaveViewButton={false}
+            minimalMode={!isChatboxThread}
+            interactive={false}
+            reasoningDisplayMode={reasoningDisplayMode}
+            contentClassName="max-w-4xl space-y-8 px-4 py-4"
+          />
+        ) : (
+          <TraceViewer
+            trace={traceEnvelope}
+            model={resolvedModel}
+            forcedViewMode={viewMode === "raw" ? "raw" : "timeline"}
+            hideToolbar
+            fillContent
+            traceStartedAtMs={traceStartedAtMs}
+            traceEndedAtMs={traceEndedAtMs}
+            interactive={false}
+          />
+        )}
       </div>
     </div>
   );

--- a/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
@@ -103,3 +103,32 @@ export function useSharedChatWidgetSnapshots({
 
   return { snapshots };
 }
+
+export interface SharedChatTurnTrace {
+  turnId: string;
+  promptIndex: number;
+  startedAt: number;
+  endedAt: number;
+  finishReason?: string;
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  };
+  spanCount: number;
+  modelId?: string;
+  spansBlobUrl?: string | null;
+}
+
+export function useSharedChatTurnTraces({
+  threadId,
+}: {
+  threadId: string | null;
+}) {
+  const traces = useQuery(
+    "chatSessions:getSessionTurnTraces" as any,
+    threadId ? ({ sessionId: threadId } as any) : "skip",
+  ) as SharedChatTurnTrace[] | undefined;
+
+  return { traces };
+}

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -19,6 +19,7 @@ import { logger } from "../../utils/logger";
 import { handleMCPJamFreeChatModel } from "../../utils/mcpjam-stream-handler";
 import {
   persistChatSessionToConvex,
+  pickEnrichmentHeaders,
   type PersistedTurnTrace,
 } from "../../utils/chat-ingestion.js";
 import type { ModelMessage } from "@ai-sdk/provider-utils";
@@ -577,6 +578,7 @@ chatV2.post("/", async (c) => {
                 },
                 expectedVersion: body.expectedVersion,
                 turnTrace,
+                forwardHeaders: pickEnrichmentHeaders(c.req.raw.headers),
               });
             }
           : undefined,
@@ -649,6 +651,7 @@ chatV2.post("/", async (c) => {
               },
               expectedVersion: body.expectedVersion,
               turnTrace,
+              forwardHeaders: pickEnrichmentHeaders(c.req.raw.headers),
             });
           }
         : undefined,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -12,7 +12,10 @@ import {
 import { WEB_STREAM_TIMEOUT_MS } from "../../config.js";
 import { prepareChatV2 } from "../../utils/chat-v2-orchestration.js";
 import { validateUrl, OAuthProxyError } from "../../utils/oauth-proxy.js";
-import { persistChatSessionToConvex } from "../../utils/chat-ingestion.js";
+import {
+  persistChatSessionToConvex,
+  pickEnrichmentHeaders,
+} from "../../utils/chat-ingestion.js";
 import {
   hostedChatSchema,
   guestServerInputSchema,
@@ -230,6 +233,7 @@ chatV2.post("/", async (c) => {
                     selectedServers: hasServer ? ["__guest__"] : [],
                   },
                   turnTrace,
+                  forwardHeaders: pickEnrichmentHeaders(c.req.raw.headers),
                 });
               }
             : undefined,
@@ -385,6 +389,7 @@ chatV2.post("/", async (c) => {
                     }
                   : {}),
                 turnTrace,
+                forwardHeaders: pickEnrichmentHeaders(c.req.raw.headers),
               });
             }
           : undefined,

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -5,6 +5,45 @@ import type { LiveChatTraceUsage } from "@/shared/live-chat-trace";
 const DEFAULT_INGEST_TIMEOUT_MS = 5_000;
 const MAX_RESPONSE_PREVIEW_CHARS = 200;
 
+/**
+ * Headers worth forwarding from the browser request to the Convex ingestion
+ * endpoint so that usage-insights enrichment (device, language, geo) works.
+ */
+const ENRICHMENT_HEADERS_TO_FORWARD = [
+  "user-agent",
+  "accept-language",
+  // Geo headers injected by CDN/edge providers
+  "cf-ipcountry",
+  "x-vercel-ip-country",
+  "x-vercel-ip-country-region",
+  "x-vercel-ip-city",
+  "x-geo-country",
+  "x-geo-region",
+  "x-geo-city",
+  // Client IP headers for visitor hashing
+  "x-forwarded-for",
+  "x-real-ip",
+  "cf-connecting-ip",
+] as const;
+
+/**
+ * Pick enrichment-relevant headers from an incoming request so they can be
+ * forwarded to the Convex `/ingest-chat` endpoint.
+ */
+export function pickEnrichmentHeaders(
+  reqHeaders: { get(name: string): string | null | undefined } | Headers,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const name of ENRICHMENT_HEADERS_TO_FORWARD) {
+    const value =
+      typeof reqHeaders.get === "function" ? reqHeaders.get(name) : undefined;
+    if (value) {
+      result[name] = value;
+    }
+  }
+  return result;
+}
+
 interface ResumeConfig {
   systemPrompt?: string;
   temperature?: number;
@@ -57,6 +96,8 @@ interface PersistChatSessionOptions {
   resumeConfig?: ResumeConfig;
   expectedVersion?: number;
   turnTrace?: PersistedTurnTrace;
+  /** Headers from the original browser request to forward for usage enrichment (user-agent, accept-language, geo headers). */
+  forwardHeaders?: Record<string, string>;
 }
 
 function isAbortError(error: unknown): boolean {
@@ -111,6 +152,7 @@ export async function persistChatSessionToConvex(
       headers: {
         "content-type": "application/json",
         authorization: options.authHeader,
+        ...options.forwardHeaders,
       },
       signal: controller.signal,
       body: JSON.stringify({


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the shared-thread viewer to fetch and render trace span blobs and adjusts server ingestion to forward selected request headers, which could affect trace display correctness and header/privacy handling if misconfigured.
> 
> **Overview**
> Fixes shared chatbox trace viewing by adding a *Chat / Trace / Raw* toggle and wiring `ShareUsageThreadDetail` to load per-turn trace metadata, fetch span blobs, and render them via `TraceViewer` with computed start/end timing.
> 
> Improves usage-insights enrichment during chat ingestion by introducing `pickEnrichmentHeaders` and forwarding a curated set of browser/edge headers (UA/language/geo/IP) from both `mcp` and `web` `chat-v2` routes into the Convex `/ingest-chat` request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5198567ecd9e1d2ec9a0c6d666e5a8e04f1c3df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->