### PR TITLE
playground for guests

### DIFF
--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useCallback, useEffect, useRef, useState } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth, useMutation } from "convex/react";
-import { FlaskConical, Loader2 } from "lucide-react";
+import { FlaskConical, Loader2, Puzzle } from "lucide-react";
 import { toast } from "sonner";
 import { EmptyState } from "@/components/ui/empty-state";
 import { useEvalsRoute } from "@/lib/evals-router";
@@ -241,7 +241,7 @@ export function EvalsTab({
         const createdSuite = await mutations.createTestSuiteMutation({
           ...(isDirectGuest ? {} : { workspaceId }),
           name: selectedServer,
-          description: `Explore cases for ${selectedServer}`,
+          description: `Test cases for ${selectedServer}`,
           environment: { servers: [selectedServer] },
         });
 
@@ -263,7 +263,7 @@ export function EvalsTab({
         toast.error(
           getBillingErrorMessage(
             error,
-            "Failed to create the Explore workspace"
+            "Failed to create the Playground workspace"
           )
         );
       } finally {
@@ -512,8 +512,8 @@ export function EvalsTab({
             <div className="flex flex-1 items-center justify-center px-4 py-10 sm:px-6">
               <EmptyState
                 icon={FlaskConical}
-                title="Select a server to explore"
-                description="Pick a server from the header to view Explore cases. Connect it to run tests or generate new cases."
+                title="Select a server to start testing"
+                description="Pick a server from the header to open Playground. Connect it to run tests or generate new cases."
                 className="h-auto min-h-[240px]"
               />
             </div>
@@ -521,15 +521,15 @@ export function EvalsTab({
             <div className="flex min-h-[240px] flex-1 flex-col items-center justify-center px-4 sm:px-6">
               <Loader2 className="h-8 w-8 animate-spin text-primary" />
               <p className="mt-4 text-sm text-muted-foreground">
-                Preparing the Explore workspace for {selectedServer}...
+                Preparing Playground for {selectedServer}...
               </p>
             </div>
           ) : !exploreSuite ? (
             <div className="flex flex-1 items-center justify-center px-4 py-10 sm:px-6">
               <EmptyState
-                icon={FlaskConical}
-                title="Explore is waiting on a connected server"
-                description="Reconnect the server or pick another one from the header to start generating cases."
+                icon={Puzzle}
+                title={`Start ${selectedServer} to generate tests`}
+                description="Playground can automatically generate test cases once a server is connected."
                 className="h-auto min-h-[240px]"
               />
             </div>

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { EmptyState } from "@/components/ui/empty-state";
 import { useEvalsRoute } from "@/lib/evals-router";
 import { useEvalTabContext } from "@/hooks/use-eval-tab-context";
+import { useIsDirectGuest } from "@/hooks/use-is-direct-guest";
 import { aggregateSuite } from "./evals/helpers";
 import { EvalTabGate } from "./evals/EvalTabGate";
 import {
@@ -35,6 +36,23 @@ const EMPTY_CASES: EvalCase[] = [];
 /** Module-level guard so fast tab-switches (unmount/remount) don't duplicate suite creation. */
 const globalInitializedExplore = new Set<string>();
 
+function getExploreInitializationKey({
+  serverName,
+  isDirectGuest,
+  workspaceId,
+}: {
+  serverName: string;
+  isDirectGuest: boolean;
+  workspaceId?: string | null;
+}): string {
+  const scope = isDirectGuest
+    ? "guest"
+    : workspaceId
+    ? `workspace:${workspaceId}`
+    : "anonymous";
+  return `${scope}::${serverName}`;
+}
+
 export function EvalsTab({
   selectedServer,
   workspaceId,
@@ -44,6 +62,7 @@ export function EvalsTab({
   const { user } = useAuth();
   const route = useEvalsRoute();
   const appState = useSharedAppState();
+  const isDirectGuest = useIsDirectGuest({ workspaceId });
   const {
     connectedServerNames,
     userMap,
@@ -53,9 +72,10 @@ export function EvalsTab({
   } = useEvalTabContext({
     isAuthenticated,
     workspaceId: workspaceId ?? null,
+    isDirectGuest,
   });
   const updateSuiteMutation = useMutation("testSuites:updateTestSuite" as any);
-  const mutations = useEvalMutations();
+  const mutations = useEvalMutations({ isDirectGuest });
 
   const [isPreparingExplore, setIsPreparingExplore] = useState(false);
 
@@ -70,6 +90,17 @@ export function EvalsTab({
 
   const hasPlaygroundServerTab =
     Boolean(selectedServer) && selectedServer !== "none";
+  const exploreInitializationKey = useMemo(
+    () =>
+      selectedServer
+        ? getExploreInitializationKey({
+            serverName: selectedServer,
+            isDirectGuest,
+            workspaceId,
+          })
+        : null,
+    [selectedServer, isDirectGuest, workspaceId]
+  );
 
   const overviewQueries = useEvalQueries({
     isAuthenticated: isAuthenticated && Boolean(workspaceId),
@@ -78,14 +109,15 @@ export function EvalsTab({
     deletingSuiteId: null,
     workspaceId: workspaceId ?? null,
     organizationId: null,
+    isDirectGuest,
   });
 
   const manualSuiteEntries = useMemo(
     () =>
       overviewQueries.sortedSuites.filter(
-        (entry) => entry.suite.source !== "sdk",
+        (entry) => entry.suite.source !== "sdk"
       ),
-    [overviewQueries.sortedSuites],
+    [overviewQueries.sortedSuites]
   );
 
   const exploreSuiteEntry = useMemo(() => {
@@ -94,7 +126,7 @@ export function EvalsTab({
       manualSuiteEntries.find(
         (entry) =>
           isExploreSuite(entry.suite) &&
-          entry.suite.environment?.servers?.[0] === selectedServer,
+          entry.suite.environment?.servers?.[0] === selectedServer
       ) ?? null
     );
   }, [manualSuiteEntries, selectedServer, hasPlaygroundServerTab]);
@@ -110,15 +142,32 @@ export function EvalsTab({
     selectedTestId,
     workspaceId: workspaceId ?? null,
     connectedServerNames,
+    isDirectGuest,
   });
+  const {
+    deletingSuiteId,
+    rerunningSuiteId,
+    cancellingRunId,
+    deletingRunId,
+    isGeneratingTests,
+    handleCreateTestCase,
+    handleGenerateTests,
+    handleRerun,
+    handleCancelRun,
+    handleDelete,
+    handleDeleteRun,
+    directDeleteRun,
+    directDeleteTestCase,
+  } = handlers;
 
   const queries = useEvalQueries({
     isAuthenticated: isAuthenticated && Boolean(workspaceId),
     user: workspaceId ? user : null,
     selectedSuiteId,
-    deletingSuiteId: handlers.deletingSuiteId,
+    deletingSuiteId,
     workspaceId: workspaceId ?? null,
     organizationId: null,
+    isDirectGuest,
   });
 
   const selectedSuite = queries.selectedSuite;
@@ -132,57 +181,65 @@ export function EvalsTab({
     return aggregateSuite(
       selectedSuite,
       suiteDetails.testCases,
-      activeIterations,
+      activeIterations
     );
   }, [selectedSuite, suiteDetails, activeIterations]);
   const exploreSuite = selectedSuite;
   const exploreCases = suiteDetails?.testCases ?? EMPTY_CASES;
   const exploreCaseIdsSignature = useMemo(
     () => exploreCases.map((testCase) => testCase._id).join("\u0000"),
-    [exploreCases],
+    [exploreCases]
   );
   const exploreRunIdsSignature = useMemo(
     () => runsForSelectedSuite.map((run) => run._id).join("\u0000"),
-    [runsForSelectedSuite],
+    [runsForSelectedSuite]
   );
   const iterationRunIdsSignature = useMemo(
     () =>
       sortedIterations
         .flatMap((iteration) =>
-          iteration.suiteRunId ? [iteration.suiteRunId] : [],
+          iteration.suiteRunId ? [iteration.suiteRunId] : []
         )
         .join("\u0000"),
-    [sortedIterations],
+    [sortedIterations]
   );
 
   useEffect(() => {
-    if (
-      !selectedServer ||
-      !isServerConnected ||
-      !workspaceId ||
-      !isAuthenticated
-    ) {
+    if (!selectedServer || selectedServer === "none") {
       return;
+    }
+    if (!isDirectGuest) {
+      // Signed-in path still waits for a live connection before calling the
+      // create mutation (and the auto-generate that follows).
+      if (!isServerConnected) {
+        return;
+      }
+      if (!workspaceId || !isAuthenticated) {
+        return;
+      }
     }
     // Wait until the overview query has loaded before deciding to create.
     // Otherwise we might not find the existing suite and create a duplicate.
     if (overviewQueries.isOverviewLoading) {
       return;
     }
-    if (exploreSuiteEntry) {
+    if (selectedSuiteId) {
       return;
     }
-    if (globalInitializedExplore.has(selectedServer)) {
+    if (!exploreInitializationKey) {
+      return;
+    }
+    if (globalInitializedExplore.has(exploreInitializationKey)) {
       return;
     }
 
-    globalInitializedExplore.add(selectedServer);
+    globalInitializedExplore.add(exploreInitializationKey);
     setIsPreparingExplore(true);
 
     void (async () => {
       try {
         const createdSuite = await mutations.createTestSuiteMutation({
-          workspaceId,
+          ...(isDirectGuest ? {} : { workspaceId }),
           name: selectedServer,
           description: `Explore cases for ${selectedServer}`,
           environment: { servers: [selectedServer] },
@@ -194,16 +251,20 @@ export function EvalsTab({
             tags: [EXPLORE_SUITE_TAG],
           });
 
-          // Auto-generate test cases for the newly created suite
-          handlers.handleGenerateTests(createdSuite._id, [selectedServer]);
+          if (!isDirectGuest) {
+            // Signed-in workspaces auto-generate starter cases.
+            // Direct guests keep the lighter PR 1848 behavior and opt in
+            // manually so we do not hit the generation endpoint on load.
+            handleGenerateTests(createdSuite._id, [selectedServer]);
+          }
         }
       } catch (error) {
-        globalInitializedExplore.delete(selectedServer);
+        globalInitializedExplore.delete(exploreInitializationKey);
         toast.error(
           getBillingErrorMessage(
             error,
-            "Failed to create the Explore workspace",
-          ),
+            "Failed to create the Explore workspace"
+          )
         );
       } finally {
         setIsPreparingExplore(false);
@@ -211,49 +272,55 @@ export function EvalsTab({
     })();
   }, [
     isAuthenticated,
-    exploreSuiteEntry,
-    handlers,
+    handleGenerateTests,
     isServerConnected,
     mutations.createTestSuiteMutation,
     overviewQueries.isOverviewLoading,
     selectedServer,
+    selectedSuiteId,
+    exploreInitializationKey,
     updateSuiteMutation,
     workspaceId,
+    isDirectGuest,
   ]);
 
   // Auto-generate when an explore suite exists but has no cases (e.g. previous generation failed)
   const hasAutoGeneratedRef = useRef(new Set<string>());
   useEffect(() => {
     if (
-      !exploreSuite ||
+      !selectedSuiteId ||
       !selectedServer ||
       !isServerConnected ||
-      handlers.isGeneratingTests
+      isGeneratingTests
     ) {
       return;
     }
+    // Guests opt into generation manually; don't auto-run on empty suites.
+    if (isDirectGuest) return;
     if (queries.isSuiteDetailsLoading) return;
     if (exploreCases.length > 0) return;
-    if (hasAutoGeneratedRef.current.has(exploreSuite._id)) return;
+    if (hasAutoGeneratedRef.current.has(selectedSuiteId)) return;
 
-    hasAutoGeneratedRef.current.add(exploreSuite._id);
-    handlers.handleGenerateTests(exploreSuite._id, [selectedServer]);
+    hasAutoGeneratedRef.current.add(selectedSuiteId);
+    handleGenerateTests(selectedSuiteId, [selectedServer]);
   }, [
-    exploreSuite,
     exploreCases.length,
+    handleGenerateTests,
+    isGeneratingTests,
     selectedServer,
+    selectedSuiteId,
     isServerConnected,
-    handlers,
     queries.isSuiteDetailsLoading,
+    isDirectGuest,
   ]);
 
   const playgroundNavigation = useMemo(
     () => createPlaygroundSuiteNavigation(),
-    [],
+    []
   );
 
   useEffect(() => {
-    if (!exploreSuite) return;
+    if (!selectedSuiteId) return;
     const testCaseIds = exploreCaseIdsSignature
       ? exploreCaseIdsSignature.split("\u0000")
       : [];
@@ -265,7 +332,7 @@ export function EvalsTab({
       : [];
     const redirectRoute = getPlaygroundCasesRedirect({
       route,
-      exploreSuiteId: exploreSuite._id,
+      exploreSuiteId: selectedSuiteId,
       isSuiteDetailsLoading: queries.isSuiteDetailsLoading,
       isSuiteRunsLoading: queries.isSuiteRunsLoading,
       testCaseIds,
@@ -279,35 +346,35 @@ export function EvalsTab({
     navigatePlaygroundEvalsRoute(redirectRoute, { replace: true });
   }, [
     exploreCaseIdsSignature,
-    exploreSuite,
     exploreRunIdsSignature,
     iterationRunIdsSignature,
     queries.isSuiteDetailsLoading,
     queries.isSuiteRunsLoading,
     route,
+    selectedSuiteId,
   ]);
 
   const handleGenerateMore = useCallback(async () => {
-    if (!exploreSuite || !selectedServer) return;
-    await handlers.handleGenerateTests(exploreSuite._id, [selectedServer]);
-  }, [exploreSuite, handlers, selectedServer]);
+    if (!selectedSuiteId || !selectedServer) return;
+    await handleGenerateTests(selectedSuiteId, [selectedServer]);
+  }, [handleGenerateTests, selectedServer, selectedSuiteId]);
 
   const handleDeleteTestCasesBatch = useCallback(
     async (testCaseIds: string[]) => {
       const settledDeletes = await Promise.allSettled(
         testCaseIds.map(async (id) => {
-          await handlers.directDeleteTestCase(id);
+          await directDeleteTestCase(id);
           return id;
-        }),
+        })
       );
       const deletedIds = new Set(
         settledDeletes.flatMap((result) =>
-          result.status === "fulfilled" ? [result.value] : [],
-        ),
+          result.status === "fulfilled" ? [result.value] : []
+        )
       );
       const failedDeletes = settledDeletes.filter(
         (result): result is PromiseRejectedResult =>
-          result.status === "rejected",
+          result.status === "rejected"
       );
 
       if (failedDeletes.length > 0) {
@@ -315,30 +382,30 @@ export function EvalsTab({
         toast.error(
           `Failed to delete ${failedDeletes.length} test case${
             failedDeletes.length === 1 ? "" : "s"
-          }.`,
+          }.`
         );
       }
 
-      if (exploreSuite && selectedTestId && deletedIds.has(selectedTestId)) {
+      if (selectedSuiteId && selectedTestId && deletedIds.has(selectedTestId)) {
         navigatePlaygroundEvalsRoute(
           {
             type: "suite-overview",
-            suiteId: exploreSuite._id,
+            suiteId: selectedSuiteId,
             view: "test-cases",
           },
-          { replace: true },
+          { replace: true }
         );
       }
     },
-    [exploreSuite, handlers, selectedTestId],
+    [directDeleteTestCase, selectedSuiteId, selectedTestId]
   );
 
   const showExploreLoading =
     isPreparingExplore ||
     (selectedServer &&
-      isServerConnected &&
       !exploreSuite &&
-      queries.isOverviewLoading);
+      queries.isOverviewLoading &&
+      (isDirectGuest || isServerConnected));
 
   const renderExploreMainPanel = () => {
     if (!exploreSuite) return null;
@@ -357,6 +424,7 @@ export function EvalsTab({
     return (
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-4 pb-6 pt-4 sm:px-6">
         <SuiteIterationsView
+          isDirectGuest={isDirectGuest}
           suite={exploreSuite}
           cases={exploreCases}
           iterations={activeIterations}
@@ -370,23 +438,21 @@ export function EvalsTab({
               openCompare: true,
             })
           }
-          onCreateTestCase={async () =>
-            handlers.handleCreateTestCase(exploreSuite._id)
-          }
+          onCreateTestCase={async () => handleCreateTestCase(exploreSuite._id)}
           onGenerateTestCases={() => void handleGenerateMore()}
           canGenerateTestCases={Boolean(selectedServer && isServerConnected)}
-          isGeneratingTestCases={handlers.isGeneratingTests}
-          onRerun={handlers.handleRerun}
-          onCancelRun={handlers.handleCancelRun}
-          onDelete={handlers.handleDelete}
-          onDeleteRun={handlers.handleDeleteRun}
-          onDirectDeleteRun={handlers.directDeleteRun}
+          isGeneratingTestCases={isGeneratingTests}
+          onRerun={handleRerun}
+          onCancelRun={handleCancelRun}
+          onDelete={handleDelete}
+          onDeleteRun={handleDeleteRun}
+          onDirectDeleteRun={directDeleteRun}
           connectedServerNames={connectedServerNames}
           canDeleteSuite={canDeleteSuite}
-          rerunningSuiteId={handlers.rerunningSuiteId}
-          cancellingRunId={handlers.cancellingRunId}
-          deletingSuiteId={handlers.deletingSuiteId}
-          deletingRunId={handlers.deletingRunId}
+          rerunningSuiteId={rerunningSuiteId}
+          cancellingRunId={cancellingRunId}
+          deletingSuiteId={deletingSuiteId}
+          deletingRunId={deletingRunId}
           availableModels={availableModels}
           route={route}
           userMap={userMap}
@@ -405,7 +471,7 @@ export function EvalsTab({
                       tc,
                       {
                         location: "test_cases_overview",
-                      },
+                      }
                     );
                     const firstIterationId =
                       data?.iteration?._id ??
@@ -418,7 +484,7 @@ export function EvalsTab({
                         {
                           openCompare: true,
                           iteration: firstIterationId,
-                        },
+                        }
                       );
                     }
                   })();
@@ -438,6 +504,7 @@ export function EvalsTab({
       isAuthenticated={isAuthenticated}
       user={user}
       workspaceId={workspaceId}
+      isDirectGuest={isDirectGuest}
     >
       <div className="h-full flex flex-col overflow-hidden">
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
@@ -16,6 +16,8 @@ const mocks = vi.hoisted(() => ({
   navigatePlaygroundEvalsRoute: vi.fn(),
   createTestSuiteMutation: vi.fn(),
   updateSuiteMutation: vi.fn(),
+  handleGenerateTests: vi.fn(),
+  isDirectGuest: false,
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({
@@ -40,6 +42,10 @@ vi.mock("@/hooks/use-eval-tab-context", () => ({
     canDeleteRuns: false,
     availableModels: [],
   }),
+}));
+
+vi.mock("@/hooks/use-is-direct-guest", () => ({
+  useIsDirectGuest: () => mocks.isDirectGuest,
 }));
 
 vi.mock("@/state/app-state-context", () => ({
@@ -104,7 +110,7 @@ vi.mock("../evals/use-eval-handlers", () => ({
     cancellingRunId: null,
     runningTestCaseId: null,
     isGeneratingTests: false,
-    handleGenerateTests: vi.fn(),
+    handleGenerateTests: mocks.handleGenerateTests,
     handleCreateTestCase: vi.fn(),
     handleRerun: vi.fn(),
     handleCancelRun: vi.fn(),
@@ -217,6 +223,7 @@ function makeSuiteQueries(serverName: string, suiteId: string, testId: string) {
 describe("EvalsTab route guard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.isDirectGuest = false;
     mocks.route.current = {
       type: "test-edit",
       suiteId: "suite-a",
@@ -262,13 +269,13 @@ describe("EvalsTab route guard", () => {
         }
 
         return overview;
-      },
+      }
     );
   });
 
   it("redirects stale compare routes to the newly selected server's cases view", async () => {
     const view = render(
-      <EvalsTab selectedServer="server-a" workspaceId="ws-1" />,
+      <EvalsTab selectedServer="server-a" workspaceId="ws-1" />
     );
 
     expect(mocks.navigatePlaygroundEvalsRoute).not.toHaveBeenCalled();
@@ -282,8 +289,94 @@ describe("EvalsTab route guard", () => {
           suiteId: "suite-b",
           view: "test-cases",
         },
-        { replace: true },
+        { replace: true }
       );
+    });
+  });
+
+  it("creates a guest suite shell first, then creates the signed-in suite when auth state changes", async () => {
+    mocks.useEvalQueries.mockReturnValue({
+      suiteOverview: [],
+      suiteDetails: undefined,
+      suiteRuns: undefined,
+      selectedSuiteEntry: null,
+      selectedSuite: null,
+      sortedIterations: [],
+      runsForSelectedSuite: [],
+      activeIterations: [],
+      sortedSuites: [],
+      isOverviewLoading: false,
+      isSuiteDetailsLoading: false,
+      isSuiteRunsLoading: false,
+      enableOverviewQuery: true,
+      enableSuiteDetailsQuery: false,
+    });
+    mocks.createTestSuiteMutation.mockResolvedValue({ _id: "suite-created" });
+
+    mocks.isDirectGuest = true;
+    const view = render(
+      <EvalsTab selectedServer="server-a" workspaceId="ws-1" />
+    );
+
+    await waitFor(() => {
+      expect(mocks.createTestSuiteMutation).toHaveBeenCalledWith({
+        name: "server-a",
+        description: "Explore cases for server-a",
+        environment: { servers: ["server-a"] },
+      });
+      expect(mocks.updateSuiteMutation).toHaveBeenCalledWith({
+        suiteId: "suite-created",
+        tags: ["explore"],
+      });
+    });
+
+    mocks.isDirectGuest = false;
+    view.rerender(<EvalsTab selectedServer="server-a" workspaceId="ws-1" />);
+
+    await waitFor(() => {
+      expect(mocks.createTestSuiteMutation).toHaveBeenNthCalledWith(2, {
+        workspaceId: "ws-1",
+        name: "server-a",
+        description: "Explore cases for server-a",
+        environment: { servers: ["server-a"] },
+      });
+    });
+
+    await waitFor(() => {
+      expect(mocks.updateSuiteMutation).toHaveBeenCalledWith({
+        suiteId: "suite-created",
+        tags: ["explore"],
+      });
+      expect(mocks.handleGenerateTests).toHaveBeenCalledWith("suite-created", [
+        "server-a",
+      ]);
+    });
+  });
+
+  it('does not create a guest suite when selectedServer is "none"', async () => {
+    mocks.useEvalQueries.mockReturnValue({
+      suiteOverview: [],
+      suiteDetails: undefined,
+      suiteRuns: undefined,
+      selectedSuiteEntry: null,
+      selectedSuite: null,
+      sortedIterations: [],
+      runsForSelectedSuite: [],
+      activeIterations: [],
+      sortedSuites: [],
+      isOverviewLoading: false,
+      isSuiteDetailsLoading: false,
+      isSuiteRunsLoading: false,
+      enableOverviewQuery: true,
+      enableSuiteDetailsQuery: false,
+    });
+
+    mocks.isDirectGuest = true;
+
+    render(<EvalsTab selectedServer="none" workspaceId="ws-1" />);
+
+    await waitFor(() => {
+      expect(mocks.createTestSuiteMutation).not.toHaveBeenCalled();
     });
   });
 });

--- a/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
@@ -321,7 +321,7 @@ describe("EvalsTab route guard", () => {
     await waitFor(() => {
       expect(mocks.createTestSuiteMutation).toHaveBeenCalledWith({
         name: "server-a",
-        description: "Explore cases for server-a",
+        description: "Test cases for server-a",
         environment: { servers: ["server-a"] },
       });
       expect(mocks.updateSuiteMutation).toHaveBeenCalledWith({
@@ -337,7 +337,7 @@ describe("EvalsTab route guard", () => {
       expect(mocks.createTestSuiteMutation).toHaveBeenNthCalledWith(2, {
         workspaceId: "ws-1",
         name: "server-a",
-        description: "Explore cases for server-a",
+        description: "Test cases for server-a",
         environment: { servers: ["server-a"] },
       });
     });

--- a/mcpjam-inspector/client/src/components/evals/EvalTabGate.tsx
+++ b/mcpjam-inspector/client/src/components/evals/EvalTabGate.tsx
@@ -10,6 +10,7 @@ export function EvalTabGate({
   isAuthenticated,
   user,
   workspaceId,
+  isDirectGuest = false,
   children,
 }: {
   variant: EvalTabGateVariant;
@@ -17,6 +18,12 @@ export function EvalTabGate({
   isAuthenticated: boolean;
   user: unknown;
   workspaceId: string | null | undefined;
+  /**
+   * True when the caller has classified this session as a hosted direct guest
+   * (no workspace, no share/sandbox token). Direct guests bypass the sign-in
+   * wall for the Playground variant only.
+   */
+  isDirectGuest?: boolean;
   children: ReactNode;
 }) {
   const Icon = variant === "playground" ? FlaskConical : GitBranch;
@@ -37,6 +44,10 @@ export function EvalTabGate({
   }
 
   if (variant === "playground") {
+    if (isDirectGuest) {
+      return <>{children}</>;
+    }
+
     if (!isAuthenticated || !user) {
       return (
         <div className="p-6">

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -17,7 +17,7 @@ function renderWithProviders(
       hostStyle={hostStyle}
     >
       {ui}
-    </PreferencesStoreProvider>,
+    </PreferencesStoreProvider>
   );
 }
 
@@ -34,6 +34,9 @@ const useQueryMock = vi.hoisted(() => vi.fn());
 const updateTestCaseMutationMock = vi.hoisted(() => vi.fn());
 const streamEvalTestCaseMock = vi.hoisted(() => vi.fn());
 const mockTraceViewer = vi.hoisted(() => vi.fn());
+const getGuestBearerTokenMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue("guest-token")
+);
 const useAuthMock = vi.hoisted(() => ({
   getAccessToken: vi.fn().mockResolvedValue("token"),
 }));
@@ -65,9 +68,13 @@ vi.mock("@/state/app-state-context", () => ({
   }),
 }));
 
-vi.mock("@/hooks/useViews", () => ({
-  useWorkspaceServers: () => workspaceServersMock,
-}));
+vi.mock("@/hooks/useViews", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/hooks/useViews")>();
+  return {
+    ...actual,
+    useWorkspaceServers: () => workspaceServersMock,
+  };
+});
 
 vi.mock("@/stores/client-config-store", () => ({
   useClientConfigStore: (selector: (state: any) => unknown) =>
@@ -133,6 +140,10 @@ vi.mock("@/lib/PosthogUtils", () => ({
   standardEventProps: () => ({}),
 }));
 
+vi.mock("@/lib/guest-session", () => ({
+  getGuestBearerToken: () => getGuestBearerTokenMock(),
+}));
+
 vi.mock("@/lib/apis/evals-api", () => ({
   listEvalTools: vi.fn().mockResolvedValue([]),
   runEvalTestCase: vi.fn(),
@@ -140,7 +151,7 @@ vi.mock("@/lib/apis/evals-api", () => ({
 }));
 
 vi.mock("convex/react", () => ({
-  useMutation: (_name: unknown) => useMutationMock(),
+  useMutation: (name: unknown) => useMutationMock(name),
   useQuery: (name: unknown, args: unknown) => useQueryMock(name, args),
   useAction: () => vi.fn(),
   useConvexAuth: () => useConvexAuthMock,
@@ -210,7 +221,7 @@ describe("TestTemplateEditor run view from route", () => {
         (_value, index) => ({
           toolName: `tool-${index + 1}`,
           arguments: { index: index + 1 },
-        }),
+        })
       ),
       tokensUsed: params.tokensUsed,
       metadata: params.compareRunId
@@ -261,7 +272,13 @@ describe("TestTemplateEditor run view from route", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockTraceViewer.mockReset();
-    useMutationMock.mockReturnValue(updateTestCaseMutationMock);
+    useMutationMock.mockImplementation((name: string) => {
+      if (name === "testSuites:updateTestCase") {
+        return updateTestCaseMutationMock;
+      }
+      return vi.fn();
+    });
+    getGuestBearerTokenMock.mockResolvedValue("guest-token");
     useQueryMock.mockImplementation((name: string, args: unknown) => {
       if (name === "testSuites:listTestCases") {
         return [caseDoc];
@@ -297,7 +314,7 @@ describe("TestTemplateEditor run view from route", () => {
           type: "complete";
           iterationId: string;
           iteration: EvalIteration;
-        }) => void,
+        }) => void
       ) => {
         const iterationId = `iter-${request.provider}-${request.model}`;
         onEvent({
@@ -320,7 +337,7 @@ describe("TestTemplateEditor run view from route", () => {
             },
           },
         });
-      },
+      }
     );
   });
 
@@ -339,7 +356,7 @@ describe("TestTemplateEditor run view from route", () => {
           } as any,
         ]}
         openCompareFromRoute
-      />,
+      />
     );
 
     await waitFor(() => {
@@ -351,7 +368,7 @@ describe("TestTemplateEditor run view from route", () => {
       limit: 200,
     });
     expect(
-      screen.getByRole("button", { name: /retry all/i }),
+      screen.getByRole("button", { name: /retry all/i })
     ).toBeInTheDocument();
   });
 
@@ -408,7 +425,7 @@ describe("TestTemplateEditor run view from route", () => {
           } as any,
         ]}
         openCompareFromRoute
-      />,
+      />
     );
 
     expect(screen.getByText("Loading results...")).toBeInTheDocument();
@@ -431,12 +448,12 @@ describe("TestTemplateEditor run view from route", () => {
           ]}
           openCompareFromRoute
         />
-      </PreferencesStoreProvider>,
+      </PreferencesStoreProvider>
     );
 
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: /retry all/i }),
+        screen.getByRole("button", { name: /retry all/i })
       ).toBeInTheDocument();
     });
   });
@@ -498,12 +515,12 @@ describe("TestTemplateEditor run view from route", () => {
         ]}
         openCompareFromRoute
         openCompareIterationId={clickedIteration._id}
-      />,
+      />
     );
 
     await waitFor(() => {
       expect(screen.getByTestId("eval-trace-surface")).toHaveTextContent(
-        clickedIteration._id,
+        clickedIteration._id
       );
     });
   });
@@ -523,7 +540,7 @@ describe("TestTemplateEditor run view from route", () => {
           } as any,
         ]}
         onExportDraft={vi.fn()}
-      />,
+      />
     );
 
     await waitFor(() => {
@@ -566,7 +583,7 @@ describe("TestTemplateEditor run view from route", () => {
             label: "Gemini 2.5 Pro",
           } as any,
         ]}
-      />,
+      />
     );
 
     await waitFor(() => {
@@ -574,11 +591,11 @@ describe("TestTemplateEditor run view from route", () => {
     });
 
     await user.click(
-      screen.getByRole("button", { name: /add model to compare/i }),
+      screen.getByRole("button", { name: /add model to compare/i })
     );
     await user.click(screen.getByText("Claude 4.5 Sonnet"));
     await user.click(
-      screen.getByRole("button", { name: /add model to compare/i }),
+      screen.getByRole("button", { name: /add model to compare/i })
     );
     await user.click(screen.getByText("Gemini 2.5 Pro"));
 
@@ -597,7 +614,7 @@ describe("TestTemplateEditor run view from route", () => {
     });
 
     const initialCompareRunIds = streamEvalTestCaseMock.mock.calls.map(
-      ([request]) => (request as { compareRunId?: string }).compareRunId,
+      ([request]) => (request as { compareRunId?: string }).compareRunId
     );
     expect(new Set(initialCompareRunIds).size).toBe(1);
     expect(initialCompareRunIds[0]).toMatch(/^cmp_/);
@@ -1220,7 +1237,7 @@ describe("TestTemplateEditor run view from route", () => {
           type: "complete";
           iterationId: string;
           iteration: EvalIteration;
-        }) => void,
+        }) => void
       ) => {
         const complete = (params: {
           id: string;
@@ -1268,7 +1285,7 @@ describe("TestTemplateEditor run view from route", () => {
           tokensUsed: 333,
           toolCallCount: 3,
         });
-      },
+      }
     );
 
     renderWithProviders(
@@ -1300,7 +1317,7 @@ describe("TestTemplateEditor run view from route", () => {
             label: "Gemini 2.5 Pro",
           } as any,
         ]}
-      />,
+      />
     );
 
     await waitFor(() => {
@@ -1308,11 +1325,11 @@ describe("TestTemplateEditor run view from route", () => {
     });
 
     await user.click(
-      screen.getByRole("button", { name: /add model to compare/i }),
+      screen.getByRole("button", { name: /add model to compare/i })
     );
     await user.click(screen.getByText("Claude 4.5 Sonnet"));
     await user.click(
-      screen.getByRole("button", { name: /add model to compare/i }),
+      screen.getByRole("button", { name: /add model to compare/i })
     );
     await user.click(screen.getByText("Gemini 2.5 Pro"));
 
@@ -1349,7 +1366,7 @@ describe("TestTemplateEditor run view from route", () => {
           type: "complete";
           iterationId: string;
           iteration: EvalIteration;
-        }) => void,
+        }) => void
       ) => {
         const complete = (params: {
           id: string;
@@ -1397,7 +1414,7 @@ describe("TestTemplateEditor run view from route", () => {
           tokensUsed: 333,
           toolCallCount: 3,
         });
-      },
+      }
     );
 
     renderWithProviders(
@@ -1429,7 +1446,7 @@ describe("TestTemplateEditor run view from route", () => {
             label: "Gemini 2.5 Pro",
           } as any,
         ]}
-      />,
+      />
     );
 
     await waitFor(() => {
@@ -1437,11 +1454,11 @@ describe("TestTemplateEditor run view from route", () => {
     });
 
     await user.click(
-      screen.getByRole("button", { name: /add model to compare/i }),
+      screen.getByRole("button", { name: /add model to compare/i })
     );
     await user.click(screen.getByText("Claude 4.5 Sonnet"));
     await user.click(
-      screen.getByRole("button", { name: /add model to compare/i }),
+      screen.getByRole("button", { name: /add model to compare/i })
     );
     await user.click(screen.getByText("Gemini 2.5 Pro"));
 
@@ -1460,7 +1477,7 @@ describe("TestTemplateEditor run view from route", () => {
     await waitFor(() => {
       expect(getMetricRunningSpinnerCount(compareCard)).toBe(0);
       expect(
-        within(compareCard).queryByLabelText("Running"),
+        within(compareCard).queryByLabelText("Running")
       ).not.toBeInTheDocument();
       expect(within(compareCard).getByLabelText("Passed")).toBeInTheDocument();
     });
@@ -1481,7 +1498,7 @@ describe("TestTemplateEditor run view from route", () => {
           type: "complete";
           iterationId: string;
           iteration: EvalIteration;
-        }) => void,
+        }) => void
       ) => {
         const complete = (params: {
           id: string;
@@ -1529,7 +1546,7 @@ describe("TestTemplateEditor run view from route", () => {
           tokensUsed: 333,
           toolCallCount: 3,
         });
-      },
+      }
     );
 
     renderWithProviders(
@@ -1561,7 +1578,7 @@ describe("TestTemplateEditor run view from route", () => {
             label: "Gemini 2.5 Pro",
           } as any,
         ]}
-      />,
+      />
     );
 
     await waitFor(() => {
@@ -1569,11 +1586,11 @@ describe("TestTemplateEditor run view from route", () => {
     });
 
     await user.click(
-      screen.getByRole("button", { name: /add model to compare/i }),
+      screen.getByRole("button", { name: /add model to compare/i })
     );
     await user.click(screen.getByText("Claude 4.5 Sonnet"));
     await user.click(
-      screen.getByRole("button", { name: /add model to compare/i }),
+      screen.getByRole("button", { name: /add model to compare/i })
     );
     await user.click(screen.getByText("Gemini 2.5 Pro"));
 
@@ -1617,7 +1634,7 @@ describe("TestTemplateEditor run view from route", () => {
           type: "complete";
           iterationId: string;
           iteration: EvalIteration;
-        }) => void,
+        }) => void
       ) => {
         const complete = (params: {
           id: string;
@@ -1667,7 +1684,7 @@ describe("TestTemplateEditor run view from route", () => {
           toolCallCount: 1,
           result: "failed",
         });
-      },
+      }
     );
 
     renderWithProviders(
@@ -1699,7 +1716,7 @@ describe("TestTemplateEditor run view from route", () => {
             label: "Gemini 2.5 Pro",
           } as any,
         ]}
-      />,
+      />
     );
 
     await waitFor(() => {
@@ -1707,11 +1724,11 @@ describe("TestTemplateEditor run view from route", () => {
     });
 
     await user.click(
-      screen.getByRole("button", { name: /add model to compare/i }),
+      screen.getByRole("button", { name: /add model to compare/i })
     );
     await user.click(screen.getByText("Claude 4.5 Sonnet"));
     await user.click(
-      screen.getByRole("button", { name: /add model to compare/i }),
+      screen.getByRole("button", { name: /add model to compare/i })
     );
     await user.click(screen.getByText("Gemini 2.5 Pro"));
 
@@ -1729,7 +1746,7 @@ describe("TestTemplateEditor run view from route", () => {
       expect(openAiScope.getByText("1.1s")).toHaveClass("text-emerald-700");
       expect(openAiScope.getByText("100")).toHaveClass("text-emerald-700");
       expect(openAiScope.getByText("2 tool calls")).toHaveClass(
-        "text-emerald-700",
+        "text-emerald-700"
       );
     });
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
@@ -39,6 +39,8 @@ vi.mock("convex/react", () => ({
   useConvex: () => ({
     query: mockConvexQuery,
   }),
+  useMutation: () => vi.fn().mockResolvedValue(undefined),
+  useAction: () => vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock useAiProviderKeys (mutable for replay-without-keys coverage)

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -47,13 +47,13 @@ export interface SuiteNavigation {
     suiteId: string,
     runId: string,
     iteration?: string,
-    options?: { insightsFocus?: boolean; replace?: boolean },
+    options?: { insightsFocus?: boolean; replace?: boolean }
   ) => void;
   toTestDetail: (suiteId: string, testId: string, iteration?: string) => void;
   toTestEdit: (
     suiteId: string,
     testId: string,
-    options?: { openCompare?: boolean; replace?: boolean; iteration?: string },
+    options?: { openCompare?: boolean; replace?: boolean; iteration?: string }
   ) => void;
   toSuiteEdit: (suiteId: string) => void;
 }
@@ -105,6 +105,7 @@ export function SuiteIterationsView({
   onRunTestCase,
   runningTestCaseId = null,
   onContinueInChat,
+  isDirectGuest = false,
 }: {
   suite: EvalSuite;
   cases: EvalCase[];
@@ -164,6 +165,8 @@ export function SuiteIterationsView({
   onRunTestCase?: (testCase: EvalCase) => void;
   runningTestCaseId?: string | null;
   onContinueInChat?: (handoff: Omit<EvalChatHandoff, "id">) => void;
+  /** When true, this is rendering the direct-guest eval playground flow. */
+  isDirectGuest?: boolean;
 }) {
   const appState = useSharedAppState();
   // Derive view state from route
@@ -205,7 +208,7 @@ export function SuiteIterationsView({
     onRunDetailSortByChange ?? setRunDetailSortBy;
   const [defaultMinimumPassRate, setDefaultMinimumPassRate] = useState(100);
   const [editedDescription, setEditedDescription] = useState(
-    suite.description || "",
+    suite.description || ""
   );
   const [isEditingDescription, setIsEditingDescription] = useState(false);
   const [exportState, setExportState] = useState<{
@@ -223,13 +226,13 @@ export function SuiteIterationsView({
     iterations,
     allIterations,
     runs,
-    aggregate,
+    aggregate
   );
 
   const { caseGroupsForSelectedRun, selectedRunChartData } = useRunDetailData(
     selectedRunId,
     allIterations,
-    effectiveRunDetailSortBy,
+    effectiveRunDetailSortBy
   );
 
   // Selected run details
@@ -241,7 +244,7 @@ export function SuiteIterationsView({
 
   // Derive selectedIterationId from route
   const selectedIterationId =
-    route.type === "run-detail" ? (route.iteration ?? null) : null;
+    route.type === "run-detail" ? route.iteration ?? null : null;
 
   // Auto-select the first iteration when on run-detail with iterations but no ?iteration= param.
   useEffect(() => {
@@ -259,7 +262,7 @@ export function SuiteIterationsView({
       navigation.toRunDetail(
         route.suiteId,
         route.runId,
-        caseGroupsForSelectedRun[0]._id,
+        caseGroupsForSelectedRun[0]._id
       );
     }
   }, [route, caseGroupsForSelectedRun, navigation]);
@@ -283,12 +286,12 @@ export function SuiteIterationsView({
         try {
           localStorage.setItem(
             `suite-${suite._id}-criteria-rate`,
-            String(suite.defaultPassCriteria.minimumPassRate),
+            String(suite.defaultPassCriteria.minimumPassRate)
           );
         } catch (error) {
           console.warn(
             "Failed to sync default pass criteria to localStorage",
-            error,
+            error
           );
         }
       }
@@ -318,7 +321,7 @@ export function SuiteIterationsView({
         toast.success("Suite description updated");
       } catch (error) {
         toast.error(
-          getBillingErrorMessage(error, "Failed to update suite description"),
+          getBillingErrorMessage(error, "Failed to update suite description")
         );
         console.error("Failed to update suite description:", error);
         setEditedDescription(suite.description || "");
@@ -335,7 +338,7 @@ export function SuiteIterationsView({
         setEditedDescription(suite.description || "");
       }
     },
-    [suite.description],
+    [suite.description]
   );
 
   const handleUpdateTests = async (models: any[]) => {
@@ -401,7 +404,7 @@ export function SuiteIterationsView({
       }
     }
     return [...providers].filter(
-      (p) => !hasToken(p.toLowerCase() as keyof ProviderTokens),
+      (p) => !hasToken(p.toLowerCase() as keyof ProviderTokens)
     );
   }, [cases, hasToken]);
 
@@ -409,7 +412,7 @@ export function SuiteIterationsView({
     () =>
       replayingRunId != null &&
       runs.some(
-        (run) => run._id === replayingRunId && run.hasServerReplayConfig,
+        (run) => run._id === replayingRunId && run.hasServerReplayConfig
       ) &&
       runs
         .filter((run) => run.hasServerReplayConfig)
@@ -418,7 +421,7 @@ export function SuiteIterationsView({
           const bTime = b.completedAt ?? b.createdAt ?? 0;
           return bTime - aTime;
         })[0]?._id === replayingRunId,
-    [replayingRunId, runs],
+    [replayingRunId, runs]
   );
 
   const shouldReduceMotion = useReducedMotion();
@@ -510,14 +513,13 @@ export function SuiteIterationsView({
                   connectedServerNames={connectedServerNames}
                   workspaceId={workspaceId}
                   availableModels={availableModels}
+                  isDirectGuest={isDirectGuest}
                   onExportDraft={handleOpenDraftExport}
                   openCompareFromRoute={
                     route.type === "test-edit" && Boolean(route.openCompare)
                   }
                   openCompareIterationId={
-                    route.type === "test-edit"
-                      ? (route.iteration ?? null)
-                      : null
+                    route.type === "test-edit" ? route.iteration ?? null : null
                   }
                   onBackToList={() =>
                     navigation.toSuiteOverview(suite._id, "test-cases")
@@ -530,7 +532,7 @@ export function SuiteIterationsView({
                     navigation.toRunDetail(
                       suite._id,
                       iteration.suiteRunId,
-                      iteration._id,
+                      iteration._id
                     );
                   }}
                 />
@@ -538,12 +540,12 @@ export function SuiteIterationsView({
             ) : viewMode === "test-detail" && selectedTestId ? (
               (() => {
                 const selectedCase = cases.find(
-                  (c) => c._id === selectedTestId,
+                  (c) => c._id === selectedTestId
                 );
                 if (!selectedCase) return null;
 
                 const caseIterations = allIterations.filter(
-                  (iter) => iter.testCaseId === selectedTestId,
+                  (iter) => iter.testCaseId === selectedTestId
                 );
 
                 return (
@@ -565,7 +567,7 @@ export function SuiteIterationsView({
                         handleOpenTestCaseExport(selectedCase)
                       }
                       serverNames={(suite.environment?.servers || []).filter(
-                        (name) => connectedServerNames.has(name),
+                        (name) => connectedServerNames.has(name)
                       )}
                       suiteName={suite.name}
                       onNavigateToSuite={() =>
@@ -709,6 +711,7 @@ export function SuiteIterationsView({
                     )
                   ) : (
                     <TestCasesOverview
+                      isDirectGuest={isDirectGuest}
                       suite={suite}
                       cases={cases}
                       allIterations={allIterations}
@@ -741,7 +744,7 @@ export function SuiteIterationsView({
                       onRunTestCase={onRunTestCase}
                       runningTestCaseId={runningTestCaseId}
                       blockTestCaseRuns={Boolean(
-                        rerunningSuiteId || replayingRunId,
+                        rerunningSuiteId || replayingRunId
                       )}
                       connectedServerNames={connectedServerNames}
                     />
@@ -767,7 +770,7 @@ export function SuiteIterationsView({
                   runDetailSortBy={effectiveRunDetailSortBy}
                   onSortChange={effectiveRunDetailSortChange}
                   serverNames={(suite.environment?.servers || []).filter(
-                    (name) => connectedServerNames.has(name),
+                    (name) => connectedServerNames.has(name)
                   )}
                   selectedIterationId={selectedIterationId}
                   onSelectIteration={handleSelectIteration}
@@ -780,7 +783,7 @@ export function SuiteIterationsView({
                             route.suiteId,
                             route.runId,
                             undefined,
-                            { insightsFocus: true },
+                            { insightsFocus: true }
                           )
                       : undefined
                   }
@@ -858,7 +861,7 @@ export function SuiteIterationsView({
                   setDefaultMinimumPassRate(rate);
                   localStorage.setItem(
                     `suite-${suite._id}-criteria-rate`,
-                    String(rate),
+                    String(rate)
                   );
                   try {
                     await updateSuite({
@@ -870,11 +873,11 @@ export function SuiteIterationsView({
                     toast.success("Suite updated successfully");
                   } catch (error) {
                     toast.error(
-                      getBillingErrorMessage(error, "Failed to update suite"),
+                      getBillingErrorMessage(error, "Failed to update suite")
                     );
                     console.error("Failed to update suite:", error);
                     setDefaultMinimumPassRate(
-                      suite.defaultPassCriteria?.minimumPassRate ?? 100,
+                      suite.defaultPassCriteria?.minimumPassRate ?? 100
                     );
                   }
                 }}

--- a/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
@@ -73,6 +73,8 @@ interface TestCasesOverviewProps {
    * When set (e.g. playground), show run-style selection + batch delete for test cases.
    */
   onDeleteTestCasesBatch?: (testCaseIds: string[]) => Promise<void>;
+  /** When true, the surrounding view is the direct-guest eval playground. */
+  isDirectGuest?: boolean;
 }
 
 export function TestCasesOverview({
@@ -90,17 +92,18 @@ export function TestCasesOverview({
   runningTestCaseId = null,
   blockTestCaseRuns = false,
   connectedServerNames,
+  isDirectGuest = false,
 }: TestCasesOverviewProps) {
   const convex = useConvex();
   const liveCases = useQuery(
     "testSuites:listTestCases" as any,
-    { suiteId: suite._id } as any,
+    { suiteId: suite._id } as any
   ) as EvalCase[] | undefined;
   const [hydratedIterations, setHydratedIterations] = useState<EvalIteration[]>(
-    [],
+    []
   );
   const [selectedCaseIds, setSelectedCaseIds] = useState<Set<string>>(
-    new Set(),
+    new Set()
   );
   const [showBatchDeleteModal, setShowBatchDeleteModal] = useState(false);
   const [isBatchDeleting, setIsBatchDeleting] = useState(false);
@@ -130,7 +133,7 @@ export function TestCasesOverview({
     }
 
     const liveCaseById = new Map(
-      liveCases.map((testCase) => [testCase._id, testCase] as const),
+      liveCases.map((testCase) => [testCase._id, testCase] as const)
     );
     const mergedCases = cases.map((testCase) => ({
       ...testCase,
@@ -166,7 +169,7 @@ export function TestCasesOverview({
       setSelectedCaseIds(new Set());
       setShowBatchDeleteModal(false);
       toast.success(
-        `Deleted ${ids.length} test case${ids.length === 1 ? "" : "s"}`,
+        `Deleted ${ids.length} test case${ids.length === 1 ? "" : "s"}`
       );
     } catch (error) {
       console.error("Failed to delete test cases:", error);
@@ -178,14 +181,14 @@ export function TestCasesOverview({
 
   useEffect(() => {
     const localIterationIds = new Set(
-      allIterations.map((iteration) => iteration._id),
+      allIterations.map((iteration) => iteration._id)
     );
     const localCaseIds = new Set(
       allIterations
         .map((iteration) => iteration.testCaseId)
         .filter(
-          (testCaseId): testCaseId is string => typeof testCaseId === "string",
-        ),
+          (testCaseId): testCaseId is string => typeof testCaseId === "string"
+        )
     );
     const casesNeedingHydration = effectiveCases.filter((testCase) => {
       const missingSavedIteration =
@@ -208,7 +211,7 @@ export function TestCasesOverview({
           try {
             const iterations = (await convex.query(
               "testSuites:listTestIterations" as any,
-              { testCaseId: testCase._id } as any,
+              { testCaseId: testCase._id } as any
             )) as EvalIteration[] | undefined;
 
             if (Array.isArray(iterations) && iterations.length > 0) {
@@ -217,7 +220,7 @@ export function TestCasesOverview({
           } catch (error) {
             console.error(
               "Failed to hydrate test case iterations from listTestIterations:",
-              error,
+              error
             );
           }
 
@@ -228,17 +231,17 @@ export function TestCasesOverview({
           try {
             const iteration = (await convex.query(
               "testSuites:getTestIteration" as any,
-              { iterationId: testCase.lastMessageRun } as any,
+              { iterationId: testCase.lastMessageRun } as any
             )) as EvalIteration | null;
             return iteration ? [iteration] : [];
           } catch (error) {
             console.error(
               "Failed to hydrate saved iteration from getTestIteration:",
-              error,
+              error
             );
             return [];
           }
-        }),
+        })
       );
 
       if (cancelled) {
@@ -273,7 +276,7 @@ export function TestCasesOverview({
   const testCaseStats = useMemo(() => {
     return effectiveCases.map((testCase) => {
       const caseIterations = effectiveIterations.filter(
-        (iter) => iter.testCaseId === testCase._id,
+        (iter) => iter.testCaseId === testCase._id
       );
       let lastRunIteration: EvalIteration | null = null;
       for (const iter of caseIterations) {
@@ -297,7 +300,9 @@ export function TestCasesOverview({
   const missingSuiteServers =
     connectedServerNames == null
       ? []
-      : suiteServers.filter((serverName) => !connectedServerNames.has(serverName));
+      : suiteServers.filter(
+          (serverName) => !connectedServerNames.has(serverName)
+        );
   const showPersistentBatchHeader =
     batchDelete && hideViewModeSelect && testCaseStats.length > 0;
   const showDisconnectedPlaygroundEmptyState =
@@ -393,6 +398,13 @@ export function TestCasesOverview({
                 description="Playground can automatically generate test cases once a server is connected."
                 className="h-auto min-h-[240px]"
               />
+            ) : hideViewModeSelect ? (
+              <EmptyState
+                icon={Puzzle}
+                title="No test cases yet"
+                description="Click Generate to create a starter set from your tools, or New case to add one manually."
+                className="h-auto min-h-[240px]"
+              />
             ) : (
               <div className="px-4 py-12 text-center text-sm text-muted-foreground">
                 No cases found.
@@ -404,23 +416,27 @@ export function TestCasesOverview({
                 connectedServerNames == null
                   ? []
                   : suiteServers.filter(
-                      (serverName) => !connectedServerNames.has(serverName),
+                      (serverName) => !connectedServerNames.has(serverName)
                     );
               const hasModels = Boolean(testCase.models?.length);
               const isThisCaseRunning = runningTestCaseId === testCase._id;
               const isAnotherCaseRunning =
                 runningTestCaseId != null && runningTestCaseId !== testCase._id;
+              // Guests rely on the local persistent MCP manager; skip the
+              // suite-server-connected gate and let the runner surface a
+              // connection error if the server is actually missing.
+              const serverGateBlocked =
+                !isDirectGuest && missingServers.length > 0;
               const runDisabled =
                 !onRunTestCase ||
                 blockTestCaseRuns ||
                 isAnotherCaseRunning ||
                 !hasModels ||
-                missingServers.length > 0 ||
+                serverGateBlocked ||
                 isThisCaseRunning;
-              const disconnectedRunTooltip =
-                missingServers.length > 0
-                  ? `Connect: ${missingServers.join(", ")}`
-                  : null;
+              const disconnectedRunTooltip = serverGateBlocked
+                ? `Connect: ${missingServers.join(", ")}`
+                : null;
 
               const lastRunResult = lastRunIteration
                 ? computeIterationResult(lastRunIteration)
@@ -429,17 +445,17 @@ export function TestCasesOverview({
                 lastRunResult === "passed"
                   ? "Passed"
                   : lastRunResult === "failed"
-                    ? "Failed"
-                    : lastRunResult === "cancelled"
-                      ? "Cancelled"
-                      : lastRunResult === "pending"
-                        ? "Running"
-                        : "Never run";
+                  ? "Failed"
+                  : lastRunResult === "cancelled"
+                  ? "Cancelled"
+                  : lastRunResult === "pending"
+                  ? "Running"
+                  : "Never run";
               const lastRunTimestamp = lastRunIteration
-                ? (lastRunIteration.updatedAt ??
+                ? lastRunIteration.updatedAt ??
                   lastRunIteration.startedAt ??
                   lastRunIteration.createdAt ??
-                  null)
+                  null
                 : null;
               const showLastRunFailed = lastRunResult === "failed";
               const caseTitle = testCase.title || "Untitled test case";
@@ -477,7 +493,7 @@ export function TestCasesOverview({
                 "Never run"
               );
               const lastRunOpenable = Boolean(
-                onOpenLastRun && lastRunIteration?._id,
+                onOpenLastRun && lastRunIteration?._id
               );
               const lastRunAriaLabel =
                 lastRunIteration && lastRunOpenable
@@ -614,7 +630,9 @@ export function TestCasesOverview({
                           toggleCaseSelection(testCase._id)
                         }
                         onClick={(e) => e.stopPropagation()}
-                        aria-label={`Select case ${testCase.title || "Untitled test case"}`}
+                        aria-label={`Select case ${
+                          testCase.title || "Untitled test case"
+                        }`}
                       />
                     </div>
                     {caseRowClickTarget}

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -94,6 +94,7 @@ import type {
 import type { EvalExportDraftInput } from "@/lib/evals/eval-export";
 import type { EvalChatHandoff } from "@/lib/eval-chat-handoff";
 import { ProviderLogo } from "@/components/chat-v2/chat-input/model/provider-logo";
+import { getGuestBearerToken } from "@/lib/guest-session";
 import {
   reduceEvalStreamEvent,
   initialEvalStreamState,
@@ -132,6 +133,12 @@ interface TestTemplateEditorProps {
   openCompareFromRoute?: boolean;
   /** Deep link: exact iteration to anchor compare hydration to. */
   openCompareIterationId?: string | null;
+  /**
+   * When true, this is rendering the direct-guest eval playground flow.
+   * Guests still use the inline runner for direct server access, but the saved
+   * suite/case/iteration state lives in Convex.
+   */
+  isDirectGuest?: boolean;
 }
 
 const createEmptyPromptTurn = (index: number): PromptTurn => ({
@@ -144,7 +151,7 @@ const validateExpectedToolCalls = (
   toolCalls: Array<{
     toolName: string;
     arguments: Record<string, any>;
-  }>,
+  }>
 ): boolean => {
   for (const toolCall of toolCalls) {
     if (!toolCall.toolName || toolCall.toolName.trim() === "") {
@@ -163,7 +170,7 @@ const validateExpectedToolCalls = (
 
 /** When every step has no asserted tool calls, the case expects no tool usage (stored as isNegativeTest). */
 function deriveIsNegativeTestFromPromptTurns(
-  promptTurns: PromptTurn[],
+  promptTurns: PromptTurn[]
 ): boolean {
   return promptTurns.every((turn) => turn.expectedToolCalls.length === 0);
 }
@@ -187,20 +194,20 @@ const validatePromptTurns = (promptTurns: PromptTurn[]): boolean => {
   }
 
   const assertedTurns = promptTurns.filter(
-    (turn) => turn.expectedToolCalls.length > 0,
+    (turn) => turn.expectedToolCalls.length > 0
   );
   if (assertedTurns.length === 0) {
     return false;
   }
 
   return assertedTurns.every((turn) =>
-    validateExpectedToolCalls(turn.expectedToolCalls),
+    validateExpectedToolCalls(turn.expectedToolCalls)
   );
 };
 
 /** Short message when Run/Save are blocked by prompt or expected-tool validation. */
 export function getPromptTurnBlockReason(
-  promptTurns: PromptTurn[],
+  promptTurns: PromptTurn[]
 ): string | null {
   if (!Array.isArray(promptTurns) || promptTurns.length === 0) {
     return "Configure at least one prompt step.";
@@ -254,20 +261,17 @@ const normalizeForComparison = (value: any): any => {
   if (typeof value === "object") {
     return Object.keys(value)
       .sort()
-      .reduce(
-        (acc, key) => {
-          acc[key] = normalizeForComparison(value[key]);
-          return acc;
-        },
-        {} as Record<string, any>,
-      );
+      .reduce((acc, key) => {
+        acc[key] = normalizeForComparison(value[key]);
+        return acc;
+      }, {} as Record<string, any>);
   }
 
   return value;
 };
 
 function normalizeAdvancedConfig(
-  advancedConfig: Record<string, unknown> | undefined,
+  advancedConfig: Record<string, unknown> | undefined
 ): Record<string, unknown> | undefined {
   const stripped = stripPromptTurnsFromAdvancedConfig(advancedConfig);
   if (!stripped) {
@@ -297,7 +301,7 @@ function normalizeAdvancedConfig(
 }
 
 function readCompareRunIdFromIteration(
-  iteration: Pick<EvalIteration, "metadata"> | null | undefined,
+  iteration: Pick<EvalIteration, "metadata"> | null | undefined
 ) {
   const compareRunId = iteration?.metadata?.compareRunId;
   return typeof compareRunId === "string" && compareRunId.trim().length > 0
@@ -317,6 +321,7 @@ export function TestTemplateEditor({
   onContinueInChat,
   openCompareFromRoute = false,
   openCompareIterationId = null,
+  isDirectGuest = false,
 }: TestTemplateEditorProps) {
   const { getAccessToken } = useAuth();
   const { getToken, hasToken } = useAiProviderKeys();
@@ -325,7 +330,7 @@ export function TestTemplateEditor({
   const [editForm, setEditForm] = useState<TestTemplate | null>(null);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editorMode, setEditorMode] = useState<EditorMode>(
-    openCompareFromRoute ? "run" : "config",
+    openCompareFromRoute ? "run" : "config"
   );
   const [availableTools, setAvailableTools] = useState<
     Array<{
@@ -343,7 +348,7 @@ export function TestTemplateEditor({
   const [routeCompareAnchorIterationId, setRouteCompareAnchorIterationId] =
     useState<string | null>(openCompareIterationId);
   const [activeCompareRunId, setActiveCompareRunId] = useState<string | null>(
-    null,
+    null
   );
   const [runColumnTabByModel, setRunColumnTabByModel] = useState<
     Record<string, RunColumnTab>
@@ -352,7 +357,7 @@ export function TestTemplateEditor({
     string | null
   >(null);
   const [expandedPromptTurnIds, setExpandedPromptTurnIds] = useState<string[]>(
-    [],
+    []
   );
   const [isRunningCompare, setIsRunningCompare] = useState(false);
   /** Concurrent compare `handleRunCompare` calls; used only for global `isRunningCompare`. */
@@ -365,18 +370,21 @@ export function TestTemplateEditor({
   const compareRequestGenByModelRef = useRef<Record<string, number>>({});
   /** Per-model AbortControllers for cancelling superseded streaming runs. */
   const compareAbortControllersRef = useRef<Record<string, AbortController>>(
-    {},
+    {}
   );
   /** True when the user clicked Stop for the current batch (suppresses failure toasts). */
   const compareRunUserStoppedRef = useRef(false);
   const initializedSelectionCaseRef = useRef<string | null>(null);
+  const updateTestCaseMutation = useMutation(
+    "testSuites:updateTestCase" as any
+  ) as unknown as (args: {
+    testCaseId: string;
+    [key: string]: unknown;
+  }) => Promise<unknown>;
 
   const testCases = useQuery("testSuites:listTestCases" as any, {
     suiteId,
   }) as any[] | undefined;
-  const updateTestCaseMutation = useMutation(
-    "testSuites:updateTestCase" as any,
-  );
 
   const currentTestCase = useMemo(() => {
     if (!testCases) return null;
@@ -387,24 +395,24 @@ export function TestTemplateEditor({
     "testSuites:getTestIteration" as any,
     routeCompareAnchorIterationId
       ? { iterationId: routeCompareAnchorIterationId }
-      : "skip",
+      : "skip"
   ) as EvalIteration | null | undefined;
+
   const lastSavedIteration = useQuery(
     "testSuites:getTestIteration" as any,
     currentTestCase?.lastMessageRun
       ? { iterationId: currentTestCase.lastMessageRun }
-      : "skip",
+      : "skip"
   ) as EvalIteration | undefined;
+
   const recentIterations = useQuery(
     "testSuites:listTestIterations" as any,
     currentTestCase?._id
       ? ({ testCaseId: currentTestCase._id, limit: 200 } as any)
-      : "skip",
+      : "skip"
   ) as EvalIteration[] | undefined;
 
-  const suite = useQuery("testSuites:getTestSuite" as any, {
-    suiteId,
-  }) as any;
+  const suite = useQuery("testSuites:getTestSuite" as any, { suiteId }) as any;
 
   useEffect(() => {
     setEditorMode(openCompareFromRoute ? "run" : "config");
@@ -462,11 +470,14 @@ export function TestTemplateEditor({
     if (!suite) return [];
     const suiteServers = suite.environment?.servers || [];
     return suiteServers.filter(
-      (server: string) => !connectedServerNames.has(server),
+      (server: string) => !connectedServerNames.has(server)
     );
   }, [suite, connectedServerNames]);
 
-  const canRun = missingServers.length === 0;
+  // Guests rely on the local persistent MCP manager; don't block Run on the
+  // connected-servers check — the runner surfaces a connection error if the
+  // server is genuinely missing.
+  const canRun = isDirectGuest || missingServers.length === 0;
 
   useEffect(() => {
     let cancelled = false;
@@ -525,27 +536,27 @@ export function TestTemplateEditor({
 
   const currentPromptTurns = useMemo(
     () => (currentTestCase ? resolvePromptTurns(currentTestCase) : []),
-    [currentTestCase],
+    [currentTestCase]
   );
   const currentAdvancedConfig = useMemo(
     () => normalizeAdvancedConfig(currentTestCase?.advancedConfig),
-    [currentTestCase],
+    [currentTestCase]
   );
 
   const hasUnsavedChanges = useMemo(() => {
     if (!editForm || !currentTestCase) return false;
 
     const normalizedPromptTurns = JSON.stringify(
-      normalizeForComparison(editForm.promptTurns),
+      normalizeForComparison(editForm.promptTurns)
     );
     const normalizedCurrentPromptTurns = JSON.stringify(
-      normalizeForComparison(currentPromptTurns),
+      normalizeForComparison(currentPromptTurns)
     );
     const normalizedAdvancedConfig = JSON.stringify(
-      normalizeForComparison(editForm.advancedConfig || {}),
+      normalizeForComparison(editForm.advancedConfig || {})
     );
     const normalizedCurrentAdvancedConfig = JSON.stringify(
-      normalizeForComparison(currentAdvancedConfig || {}),
+      normalizeForComparison(currentAdvancedConfig || {})
     );
 
     const normalizedScenario = (editForm.scenario ?? "").trim();
@@ -623,12 +634,12 @@ export function TestTemplateEditor({
 
   const updatePromptTurn = (
     index: number,
-    updater: (turn: PromptTurn) => PromptTurn,
+    updater: (turn: PromptTurn) => PromptTurn
   ) => {
     setEditForm((current) => {
       if (!current) return current;
       const nextTurns = current.promptTurns.map((turn, turnIndex) =>
-        turnIndex === index ? updater(turn) : turn,
+        turnIndex === index ? updater(turn) : turn
       );
       return { ...current, promptTurns: nextTurns };
     });
@@ -668,15 +679,15 @@ export function TestTemplateEditor({
 
       const removedTurnId = current.promptTurns[index]?.id;
       const nextTurns = current.promptTurns.filter(
-        (_turn, turnIndex) => turnIndex !== index,
+        (_turn, turnIndex) => turnIndex !== index
       );
       setExpandedPromptTurnIds((previous) => {
         const nextExpanded = previous.filter((id) => id !== removedTurnId);
         return nextExpanded.length > 0
           ? nextExpanded
           : nextTurns[0]
-            ? [nextTurns[0].id]
-            : [];
+          ? [nextTurns[0].id]
+          : [];
       });
 
       return {
@@ -690,13 +701,13 @@ export function TestTemplateEditor({
     setExpandedPromptTurnIds((current) =>
       current.includes(turnId)
         ? current.filter((id) => id !== turnId)
-        : [...current, turnId],
+        : [...current, turnId]
     );
   };
 
   const buildSavePayload = (form: TestTemplate) => {
     const isNegativeTest = deriveIsNegativeTestFromPromptTurns(
-      form.promptTurns,
+      form.promptTurns
     );
     const normalizedPromptTurns = isNegativeTest
       ? form.promptTurns.map((turn) => ({
@@ -745,7 +756,7 @@ export function TestTemplateEditor({
     if (!validatePromptTurns(editForm.promptTurns)) {
       toast.error(
         getPromptTurnBlockReason(editForm.promptTurns) ??
-          "Fix the test configuration before saving.",
+          "Fix the test configuration before saving."
       );
       return;
     }
@@ -792,7 +803,7 @@ export function TestTemplateEditor({
       currentModels.every(
         (model, index) =>
           model.provider === nextModels[index]?.provider &&
-          model.model === nextModels[index]?.model,
+          model.model === nextModels[index]?.model
       );
 
     if (!hasUnsavedChanges && modelsUnchanged) {
@@ -808,21 +819,21 @@ export function TestTemplateEditor({
 
   const latestHistoricalCompareRunId = useMemo(
     () => resolveLatestCompareRunId(recentIterations ?? []),
-    [recentIterations],
+    [recentIterations]
   );
   const routeCompareAnchorModelValue = useMemo(
     () =>
       routeCompareAnchorIteration
         ? resolveIterationModelValue(
             routeCompareAnchorIteration,
-            currentTestCase,
+            currentTestCase
           )
         : null,
-    [currentTestCase, routeCompareAnchorIteration],
+    [currentTestCase, routeCompareAnchorIteration]
   );
   const routeCompareAnchorRunId = useMemo(
     () => readCompareRunIdFromIteration(routeCompareAnchorIteration),
-    [routeCompareAnchorIteration],
+    [routeCompareAnchorIteration]
   );
 
   const modelOptions = useMemo(() => {
@@ -832,19 +843,19 @@ export function TestTemplateEditor({
   const modelLabelByValue = useMemo(
     () =>
       Object.fromEntries(
-        modelOptions.map((option) => [option.value, option.label] as const),
+        modelOptions.map((option) => [option.value, option.label] as const)
       ),
-    [modelOptions],
+    [modelOptions]
   );
 
   const modelOptionByValue = useMemo(
     () =>
       Object.fromEntries(
         modelOptions.map(
-          (option) => [option.value, option] as [string, TestCaseModelOption],
-        ),
+          (option) => [option.value, option] as [string, TestCaseModelOption]
+        )
       ),
-    [modelOptions],
+    [modelOptions]
   );
 
   useEffect(() => {
@@ -877,7 +888,7 @@ export function TestTemplateEditor({
       ? [
           routeCompareAnchorModelValue,
           ...initialSelectedModels.filter(
-            (modelValue) => modelValue !== routeCompareAnchorModelValue,
+            (modelValue) => modelValue !== routeCompareAnchorModelValue
           ),
         ].slice(0, 3)
       : initialSelectedModels;
@@ -902,7 +913,7 @@ export function TestTemplateEditor({
       const next = [
         routeCompareAnchorModelValue,
         ...current.filter(
-          (modelValue) => modelValue !== routeCompareAnchorModelValue,
+          (modelValue) => modelValue !== routeCompareAnchorModelValue
         ),
       ].slice(0, 3);
 
@@ -929,7 +940,7 @@ export function TestTemplateEditor({
         testCase: currentTestCase,
         existingRecords: current,
         preferredIteration: routeCompareAnchorIteration ?? null,
-      }),
+      })
     );
   }, [
     currentTestCase,
@@ -964,7 +975,7 @@ export function TestTemplateEditor({
   useEffect(() => {
     setPersistedTestCaseModelValue(
       selectedTestCaseId,
-      selectedModelValues[0] ?? null,
+      selectedModelValues[0] ?? null
     );
   }, [selectedModelValues, selectedTestCaseId]);
 
@@ -1004,16 +1015,16 @@ export function TestTemplateEditor({
     setMobileVisibleModelValue((current) =>
       current && selectedModelValues.includes(current)
         ? current
-        : (selectedModelValues[0] ?? null),
+        : selectedModelValues[0] ?? null
     );
   }, [selectedModelValues]);
 
   const addableModelOptions = useMemo(
     () =>
       modelOptions.filter(
-        (option) => !selectedModelValues.includes(option.value),
+        (option) => !selectedModelValues.includes(option.value)
       ),
-    [modelOptions, selectedModelValues],
+    [modelOptions, selectedModelValues]
   );
 
   const selectedCompareRecords = useMemo(
@@ -1030,14 +1041,14 @@ export function TestTemplateEditor({
           iteration: null,
         });
       }),
-    [compareRunRecords, modelLabelByValue, selectedModelValues],
+    [compareRunRecords, modelLabelByValue, selectedModelValues]
   );
 
   const hasRunViewContent = selectedCompareRecords.some(
     (record) =>
       record.iteration != null ||
       record.status === "running" ||
-      Boolean(record.error),
+      Boolean(record.error)
   );
 
   const openRunView = useCallback(
@@ -1046,7 +1057,7 @@ export function TestTemplateEditor({
       setMobileVisibleModelValue((current) =>
         current && selectedModelValues.includes(current)
           ? current
-          : (selectedModelValues[0] ?? null),
+          : selectedModelValues[0] ?? null
       );
       posthog.capture("compare_run_view_opened", {
         location: "test_template_editor",
@@ -1058,7 +1069,7 @@ export function TestTemplateEditor({
         models: selectedModelValues,
       });
     },
-    [currentTestCase?._id, selectedModelValues, suiteId],
+    [currentTestCase?._id, selectedModelValues, suiteId]
   );
 
   const handleAddModel = (modelValue: string) => {
@@ -1072,7 +1083,7 @@ export function TestTemplateEditor({
 
   const handleRemoveModel = (modelValue: string) => {
     setSelectedModelValues((previous) =>
-      previous.filter((value) => value !== modelValue),
+      previous.filter((value) => value !== modelValue)
     );
   };
 
@@ -1100,7 +1111,7 @@ export function TestTemplateEditor({
       }
       const next = [...previous];
       const otherIndex = next.findIndex(
-        (v, idx) => v === newValue && idx !== index,
+        (v, idx) => v === newValue && idx !== index
       );
       if (otherIndex >= 0) {
         next[otherIndex] = next[index];
@@ -1113,7 +1124,7 @@ export function TestTemplateEditor({
   const handleStopCompare = useCallback(() => {
     compareRunUserStoppedRef.current = true;
     for (const controller of Object.values(
-      compareAbortControllersRef.current,
+      compareAbortControllersRef.current
     )) {
       controller.abort();
     }
@@ -1128,7 +1139,7 @@ export function TestTemplateEditor({
     }
 
     const runModelValues = (options?.modelValues ?? selectedModelValues).filter(
-      Boolean,
+      Boolean
     );
     if (runModelValues.length === 0) {
       toast.error("Select at least one model to run.");
@@ -1138,7 +1149,7 @@ export function TestTemplateEditor({
     if (!validatePromptTurns(editForm.promptTurns)) {
       toast.error(
         getPromptTurnBlockReason(editForm.promptTurns) ??
-          "Fix the test configuration before running.",
+          "Fix the test configuration before running."
       );
       return;
     }
@@ -1150,7 +1161,7 @@ export function TestTemplateEditor({
     compareRunUserStoppedRef.current = false;
     const reusableCompareRunId =
       options?.sessionMode === "reuse"
-        ? (activeCompareRunId ?? latestHistoricalCompareRunId)
+        ? activeCompareRunId ?? latestHistoricalCompareRunId
         : null;
     const compareRunId = reusableCompareRunId ?? createCompareSessionId();
     const startsNewCompareSession = reusableCompareRunId == null;
@@ -1187,7 +1198,7 @@ export function TestTemplateEditor({
       runModelValues.map(async (modelValue) => {
         const modelLabel = resolveModelOptionLabel(
           modelValue,
-          modelLabelByValue,
+          modelLabelByValue
         );
         const advancedConfig = mergeAdvancedConfigWithOverride({
           baseAdvancedConfig: savePayload.advancedConfig,
@@ -1195,11 +1206,13 @@ export function TestTemplateEditor({
         });
 
         const preparedRun = await prepareSingleTestCaseRun({
-          workspaceId,
+          workspaceId: isDirectGuest ? null : workspaceId,
           suite,
           testCase: currentTestCase,
           selectedModel: modelValue,
-          getAccessToken,
+          getAccessToken: isDirectGuest
+            ? getGuestBearerToken
+            : getAccessToken,
           getToken,
           hasToken,
           testCaseOverrides: {
@@ -1218,7 +1231,7 @@ export function TestTemplateEditor({
           modelLabel,
           request: preparedRun,
         };
-      }),
+      })
     );
 
     for (const [index, preparedResult] of preparedResults.entries()) {
@@ -1232,7 +1245,7 @@ export function TestTemplateEditor({
 
       console.error(
         `Failed to prepare compare run for model ${modelValue}:`,
-        preparedResult.reason,
+        preparedResult.reason
       );
       preparationFailures.push({
         modelValue,
@@ -1245,8 +1258,8 @@ export function TestTemplateEditor({
       toast.error(
         getBillingErrorMessage(
           preparationFailures[0]?.error,
-          "Failed to prepare compare run",
-        ),
+          "Failed to prepare compare run"
+        )
       );
       return;
     }
@@ -1565,7 +1578,7 @@ export function TestTemplateEditor({
       );
 
       const successfulCount = completedRecords.filter(
-        (record) => record.iteration != null,
+        (record) => record.iteration != null
       ).length;
       if (compareRunUserStoppedRef.current) {
         toast.message("Compare run stopped.");
@@ -1573,13 +1586,13 @@ export function TestTemplateEditor({
         toast.success(
           `Compare run finished across ${totalRequestedModels} model${
             totalRequestedModels === 1 ? "" : "s"
-          }.`,
+          }.`
         );
       } else if (successfulCount > 0) {
         toast.error(
           `${successfulCount}/${totalRequestedModels} model${
             totalRequestedModels === 1 ? "" : "s"
-          } completed successfully.`,
+          } completed successfully.`
         );
       } else {
         toast.error("Compare run failed for all selected models.");
@@ -1606,7 +1619,7 @@ export function TestTemplateEditor({
     } catch (error) {
       console.error("Failed to clear latest result:", error);
       toast.error(
-        getBillingErrorMessage(error, "Failed to clear latest result"),
+        getBillingErrorMessage(error, "Failed to clear latest result")
       );
     }
   };
@@ -1656,14 +1669,14 @@ export function TestTemplateEditor({
   }
 
   const connectedServerList = (suite?.environment?.servers || []).filter(
-    (name: string) => connectedServerNames.has(name),
+    (name: string) => connectedServerNames.has(name)
   );
   const runGridClassName =
     selectedCompareRecords.length <= 1
       ? "lg:grid-cols-1"
       : selectedCompareRecords.length === 2
-        ? "lg:grid-cols-2"
-        : "lg:grid-cols-3";
+      ? "lg:grid-cols-2"
+      : "lg:grid-cols-3";
   const latestAvailableIteration =
     routeCompareAnchorIteration ??
     recentIterations?.[0] ??
@@ -1683,28 +1696,28 @@ export function TestTemplateEditor({
           ariaOpen: "Open last run, failed",
         }
       : latestAvailableResult === "passed"
-        ? {
-            dotClass:
-              "size-1.5 shrink-0 rounded-full bg-emerald-500 dark:bg-emerald-400",
-            buttonTextClass: "text-emerald-700 dark:text-emerald-300",
-            ariaResults: "View results, last run passed",
-            ariaOpen: "Open last run passed",
-          }
-        : latestAvailableResult === "cancelled"
-          ? {
-              dotClass:
-                "size-1.5 shrink-0 rounded-full bg-amber-500 dark:bg-amber-400",
-              buttonTextClass: "text-amber-800 dark:text-amber-200",
-              ariaResults: "View results, last run stopped",
-              ariaOpen: "Open last run stopped",
-            }
-          : {
-              dotClass:
-                "size-1.5 shrink-0 rounded-full bg-amber-500 dark:bg-amber-400 animate-pulse motion-reduce:animate-none",
-              buttonTextClass: "text-amber-800 dark:text-amber-200",
-              ariaResults: "View results, run in progress",
-              ariaOpen: "Open last run, in progress",
-            };
+      ? {
+          dotClass:
+            "size-1.5 shrink-0 rounded-full bg-emerald-500 dark:bg-emerald-400",
+          buttonTextClass: "text-emerald-700 dark:text-emerald-300",
+          ariaResults: "View results, last run passed",
+          ariaOpen: "Open last run passed",
+        }
+      : latestAvailableResult === "cancelled"
+      ? {
+          dotClass:
+            "size-1.5 shrink-0 rounded-full bg-amber-500 dark:bg-amber-400",
+          buttonTextClass: "text-amber-800 dark:text-amber-200",
+          ariaResults: "View results, last run stopped",
+          ariaOpen: "Open last run stopped",
+        }
+      : {
+          dotClass:
+            "size-1.5 shrink-0 rounded-full bg-amber-500 dark:bg-amber-400 animate-pulse motion-reduce:animate-none",
+          buttonTextClass: "text-amber-800 dark:text-amber-200",
+          ariaResults: "View results, run in progress",
+          ariaOpen: "Open last run, in progress",
+        };
   const latestAvailableIsSaved =
     Boolean(latestAvailableIteration?._id) &&
     latestAvailableIteration?._id === currentTestCase.lastMessageRun;
@@ -1777,7 +1790,7 @@ export function TestTemplateEditor({
                       size="sm"
                       className={cn(
                         "h-8 gap-1.5 px-2 text-xs",
-                        latestRunNavCue.buttonTextClass,
+                        latestRunNavCue.buttonTextClass
                       )}
                       aria-label={latestRunNavCue.ariaResults}
                       onClick={() => openRunView("config_toggle")}
@@ -1792,7 +1805,7 @@ export function TestTemplateEditor({
                       size="sm"
                       className={cn(
                         "h-8 gap-1.5 px-2 text-xs",
-                        latestRunNavCue.buttonTextClass,
+                        latestRunNavCue.buttonTextClass
                       )}
                       aria-label={latestRunNavCue.ariaOpen}
                       onClick={() =>
@@ -1998,7 +2011,7 @@ export function TestTemplateEditor({
                             const option = modelOptionByValue[modelValue];
                             const label = resolveModelOptionLabel(
                               modelValue,
-                              modelLabelByValue,
+                              modelLabelByValue
                             );
                             const isSingleSelection =
                               selectedModelValues.length === 1;
@@ -2052,11 +2065,11 @@ export function TestTemplateEditor({
                                           onClick={() =>
                                             isSingleSelection
                                               ? handlePrimaryModelChange(
-                                                  opt.value,
+                                                  opt.value
                                                 )
                                               : handleReplaceModelAt(
                                                   index,
-                                                  opt.value,
+                                                  opt.value
                                                 )
                                           }
                                         >
@@ -2136,7 +2149,7 @@ export function TestTemplateEditor({
                         aria-label="Use lead model only"
                         onClick={() =>
                           setSelectedModelValues((previous) =>
-                            previous.slice(0, 1),
+                            previous.slice(0, 1)
                           )
                         }
                       >
@@ -2345,7 +2358,7 @@ export function TestTemplateEditor({
                   // to content and scroll this panel instead.
                   "max-lg:auto-rows-min max-lg:overflow-y-auto",
                   "lg:auto-rows-[minmax(0,1fr)] lg:overflow-hidden",
-                  runGridClassName,
+                  runGridClassName
                 )}
               >
                 {selectedCompareRecords.map((record) => {
@@ -2358,7 +2371,7 @@ export function TestTemplateEditor({
                       key={record.modelValue}
                       className={cn(
                         showOnMobile ? "block" : "hidden",
-                        "min-h-0 min-w-0 flex flex-col lg:block",
+                        "min-h-0 min-w-0 flex flex-col lg:block"
                       )}
                     >
                       <RunColumn
@@ -2447,19 +2460,18 @@ function RunColumn({
 
   const effectiveActiveTab: RunColumnTab =
     activeTab === "tools" && !showToolsTab ? "timeline" : activeTab;
-
   const traceMode =
     effectiveActiveTab === "chat"
       ? "chat"
       : effectiveActiveTab === "timeline"
-        ? "timeline"
-        : effectiveActiveTab === "raw"
-          ? "raw"
-          : "tools";
+      ? "timeline"
+      : effectiveActiveTab === "raw"
+      ? "raw"
+      : "tools";
   const streamingTraceEnvelope = useMemo(
     () =>
       mergeStreamingTrace(record.streamingTrace, record.streamingDraftMessages),
-    [record.streamingDraftMessages, record.streamingTrace],
+    [record.streamingDraftMessages, record.streamingTrace]
   );
   const {
     blob: persistedTraceBlob,
@@ -2541,7 +2553,6 @@ function RunColumn({
   const toolCount =
     record.streamingMetrics?.toolCallCount ?? record.metrics.toolCallCount;
   const isRunningRecord = record.status === "running";
-
   const toSummaryStatus = (
     r: CompareRunRecord,
   ): MultiModelCardSummary["status"] => {
@@ -2780,7 +2791,7 @@ function RunColumn({
                   record.status === "running" &&
                     record.iteration == null &&
                     !hasStreamingTrace &&
-                    "animate-spin",
+                    "animate-spin"
                 )}
               />
               Retry

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -2536,6 +2536,8 @@ function RunColumn({
     toolServerMap,
     toolsMetadata,
   ]);
+  // Keep the handoff payload logic wired up while the action itself is hidden.
+  void continueInChatPayload;
   const hasStreamingTrace = streamingTraceEnvelope != null;
   const previewTrace = record.previewTrace ?? null;
   const activeLiveChatTrace: TraceEnvelope | null =
@@ -2758,21 +2760,7 @@ function RunColumn({
         tabsInline
         actionsSlot={
           <>
-            {onContinueInChat ? (
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                className="h-7 shrink-0 px-2 text-[11px]"
-                onClick={() =>
-                  continueInChatPayload &&
-                  onContinueInChat(continueInChatPayload)
-                }
-                disabled={!continueInChatPayload}
-              >
-                Continue in Chat
-              </Button>
-            ) : null}
+            {/* Continue in Chat is temporarily hidden while guest playground testing is in progress. */}
             <Button
               type="button"
               size="sm"

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -33,13 +33,14 @@ import {
 } from "@/lib/apis/evals-api";
 import { generateAndPersistEvalTests } from "@/lib/evals/generate-and-persist-tests";
 import { collectUniqueModelsFromTestCases } from "@/lib/evals/collect-unique-suite-models";
+import { getGuestBearerToken } from "@/lib/guest-session";
 import {
   getDefaultTestCaseModelValue,
   prepareSingleTestCaseRun,
 } from "./single-test-case-runner";
 
 function getConfiguredTestCaseModelValues(
-  testCase: Pick<EvalCase, "models">,
+  testCase: Pick<EvalCase, "models">
 ): string[] {
   const modelValues = new Set<string>();
 
@@ -67,6 +68,8 @@ interface UseEvalHandlersProps {
    * routes (`#/ci-evals/...`). Defaults to main evals (`#/evals/...`).
    */
   evalsNavigationContext?: "evals" | "ci-evals";
+  /** When true, this uses the direct-guest eval playground flow. */
+  isDirectGuest?: boolean;
 }
 
 /**
@@ -81,6 +84,7 @@ export function useEvalHandlers({
   connectedServerNames,
   latestRunBySuiteId,
   evalsNavigationContext = "evals",
+  isDirectGuest = false,
 }: UseEvalHandlersProps) {
   const convex = useConvex();
   const { getAccessToken } = useAuth();
@@ -89,20 +93,20 @@ export function useEvalHandlers({
   // Action states
   const [rerunningSuiteId, setRerunningSuiteId] = useState<string | null>(null);
   const [runningTestCaseId, setRunningTestCaseId] = useState<string | null>(
-    null,
+    null
   );
   const [replayingRunId, setReplayingRunId] = useState<string | null>(null);
   const [cancellingRunId, setCancellingRunId] = useState<string | null>(null);
   const [deletingSuiteId, setDeletingSuiteId] = useState<string | null>(null);
   const [suiteToDelete, setSuiteToDelete] = useState<EvalSuite | null>(null);
   const [duplicatingSuiteId, setDuplicatingSuiteId] = useState<string | null>(
-    null,
+    null
   );
   const [deletingRunId, setDeletingRunId] = useState<string | null>(null);
   const [runToDelete, setRunToDelete] = useState<string | null>(null);
   const [isCreatingTestCase, setIsCreatingTestCase] = useState(false);
   const [deletingTestCaseId, setDeletingTestCaseId] = useState<string | null>(
-    null,
+    null
   );
   const [duplicatingTestCaseId, setDuplicatingTestCaseId] = useState<
     string | null
@@ -130,7 +134,7 @@ export function useEvalHandlers({
         navigateToEvalsRoute(route as EvalsRoute);
       }
     },
-    [evalsNavigationContext],
+    [evalsNavigationContext]
   );
 
   // Query to get test cases for a suite
@@ -139,7 +143,7 @@ export function useEvalHandlers({
       try {
         const testCases = await convex.query(
           "testSuites:listTestCases" as any,
-          { suiteId },
+          { suiteId }
         );
         return testCases;
       } catch (error) {
@@ -147,7 +151,7 @@ export function useEvalHandlers({
         return [];
       }
     },
-    [convex],
+    [convex]
   );
 
   const getSuiteExecutionContext = useCallback(
@@ -198,7 +202,7 @@ export function useEvalHandlers({
         const tokenKey = provider.toLowerCase() as keyof ProviderTokens;
         if (!hasToken(tokenKey)) {
           toast.error(
-            `Please add your ${provider} API key in Settings before running evals`,
+            `Please add your ${provider} API key in Settings before running evals`
           );
           return null;
         }
@@ -216,20 +220,20 @@ export function useEvalHandlers({
         providersNeeded,
       };
     },
-    [getTestCasesForRerun, getToken, hasToken],
+    [getTestCasesForRerun, getToken, hasToken]
   );
 
   const handleReplayRun = useCallback(
     async (
       suite: EvalSuite,
       run: Pick<EvalSuiteRun, "_id" | "hasServerReplayConfig" | "passCriteria">,
-      options?: { minimumPassRate?: number },
+      options?: { minimumPassRate?: number }
     ) => {
       if (rerunningSuiteId || replayingRunId) return;
 
       if (!run.hasServerReplayConfig) {
         toast.error(
-          "This CI run can't be replayed because it doesn't have stored replay config.",
+          "This CI run can't be replayed because it doesn't have stored replay config."
         );
         return;
       }
@@ -308,7 +312,7 @@ export function useEvalHandlers({
           getBillingErrorMessage(error, "Failed to replay eval run"),
           {
             id: replayToastId,
-          },
+          }
         );
       } finally {
         setReplayingRunId(null);
@@ -320,7 +324,7 @@ export function useEvalHandlers({
       selectedSuiteEntry,
       getSuiteExecutionContext,
       getAccessToken,
-    ],
+    ]
   );
 
   // Rerun handler
@@ -354,7 +358,9 @@ export function useEvalHandlers({
         }
         if (rerunEligibility.missingServers.length > 0) {
           toast.error(
-            `Connect ${rerunEligibility.missingServers.join(", ")} to run this suite.`,
+            `Connect ${rerunEligibility.missingServers.join(
+              ", "
+            )} to run this suite.`
           );
           return;
         }
@@ -439,14 +445,14 @@ export function useEvalHandlers({
       workspaceId,
       getSuiteExecutionContext,
       handleReplayRun,
-    ],
+    ]
   );
 
   const handleRunTestCase = useCallback(
     async (
       suite: EvalSuite,
       testCase: EvalCase,
-      options?: { location?: string; selectedModel?: string | null },
+      options?: { location?: string; selectedModel?: string | null }
     ) => {
       if (runningTestCaseId || rerunningSuiteId || replayingRunId) {
         return null;
@@ -472,18 +478,20 @@ export function useEvalHandlers({
         const preparedResults = await Promise.allSettled(
           modelValuesToRun.map((selectedModel) =>
             prepareSingleTestCaseRun({
-              workspaceId,
+              workspaceId: isDirectGuest ? null : workspaceId,
               suite,
               testCase,
-              getAccessToken,
+              getAccessToken: isDirectGuest
+                ? getGuestBearerToken
+                : getAccessToken,
               getToken,
               hasToken,
               selectedModel,
-            }),
-          ),
+            })
+          )
         );
         const preparedRuns = preparedResults.flatMap((result) =>
-          result.status === "fulfilled" ? [result.value] : [],
+          result.status === "fulfilled" ? [result.value] : []
         );
         const preparationFailures = preparedResults.flatMap((result, index) =>
           result.status === "rejected"
@@ -493,13 +501,13 @@ export function useEvalHandlers({
                   error: result.reason,
                 },
               ]
-            : [],
+            : []
         );
 
         for (const failure of preparationFailures) {
           console.error(
             `Failed to prepare test case for model ${failure.modelValue}:`,
-            failure.error,
+            failure.error
           );
         }
 
@@ -507,8 +515,8 @@ export function useEvalHandlers({
           toast.error(
             getBillingErrorMessage(
               preparationFailures[0]?.error,
-              "Failed to run test case",
-            ),
+              "Failed to run test case"
+            )
           );
           return null;
         }
@@ -559,7 +567,7 @@ export function useEvalHandlers({
             } catch (error) {
               console.error(
                 `Failed to run test case for model ${preparedRun.modelValue}:`,
-                error,
+                error
               );
               return {
                 ok: false as const,
@@ -567,26 +575,26 @@ export function useEvalHandlers({
                 error,
               };
             }
-          }),
+          })
         );
 
         const successfulRuns = runResults.filter(
           (
-            result,
+            result
           ): result is {
             ok: true;
             modelValue: string;
             data: any;
-          } => result.ok,
+          } => result.ok
         );
         const failedRuns = runResults.filter(
           (
-            result,
+            result
           ): result is {
             ok: false;
             modelValue: string;
             error: unknown;
-          } => !result.ok,
+          } => !result.ok
         );
         const totalModelsRequested = modelValuesToRun.length;
         const totalFailedRuns = [
@@ -602,20 +610,20 @@ export function useEvalHandlers({
           toast.success(
             isMultiModelRun
               ? `Test completed across ${totalModelsRequested} models!`
-              : "Test completed successfully!",
+              : "Test completed successfully!"
           );
         } else if (successfulRuns.length > 0) {
           toast.error(
             `${successfulRuns.length}/${totalModelsRequested} model${
               totalModelsRequested === 1 ? "" : "s"
-            } completed successfully.`,
+            } completed successfully.`
           );
         } else {
           toast.error(
             getBillingErrorMessage(
               totalFailedRuns[0]?.error,
-              "Failed to run test case",
-            ),
+              "Failed to run test case"
+            )
           );
         }
 
@@ -648,7 +656,9 @@ export function useEvalHandlers({
       getAccessToken,
       getToken,
       hasToken,
-    ],
+      isDirectGuest,
+      convex,
+    ]
   );
 
   // Delete handler - opens confirmation modal
@@ -657,7 +667,7 @@ export function useEvalHandlers({
       if (deletingSuiteId) return;
       setSuiteToDelete(suite);
     },
-    [deletingSuiteId],
+    [deletingSuiteId]
   );
 
   // Confirm deletion - actually performs the deletion
@@ -723,13 +733,13 @@ export function useEvalHandlers({
       } catch (error) {
         console.error("Failed to duplicate suite:", error);
         toast.error(
-          getBillingErrorMessage(error, "Failed to duplicate test suite"),
+          getBillingErrorMessage(error, "Failed to duplicate test suite")
         );
       } finally {
         setDuplicatingSuiteId(null);
       }
     },
-    [duplicatingSuiteId, mutations.duplicateSuiteMutation],
+    [duplicatingSuiteId, mutations.duplicateSuiteMutation]
   );
 
   // Cancel handler
@@ -749,7 +759,7 @@ export function useEvalHandlers({
         setCancellingRunId(null);
       }
     },
-    [cancellingRunId, mutations.cancelRunMutation],
+    [cancellingRunId, mutations.cancelRunMutation]
   );
 
   // Delete run handler - opens confirmation modal (for single run from detail view)
@@ -758,7 +768,7 @@ export function useEvalHandlers({
       if (deletingRunId) return;
       setRunToDelete(runId);
     },
-    [deletingRunId],
+    [deletingRunId]
   );
 
   // Direct delete function - actually performs the deletion (for batch delete)
@@ -771,7 +781,7 @@ export function useEvalHandlers({
         throw error;
       }
     },
-    [mutations.deleteRunMutation],
+    [mutations.deleteRunMutation]
   );
 
   // Confirm run deletion - actually performs the deletion
@@ -800,13 +810,18 @@ export function useEvalHandlers({
       setIsCreatingTestCase(true);
 
       try {
-        // Get test cases for the suite to extract models
         const testCases = await convex.query(
           "testSuites:listTestCases" as any,
-          { suiteId },
+          {
+            suiteId,
+          }
         );
 
-        const modelsToUse = collectUniqueModelsFromTestCases(testCases);
+        const collectedModels = collectUniqueModelsFromTestCases(testCases);
+        const modelsToUse =
+          collectedModels.length > 0
+            ? collectedModels
+            : [{ provider: "anthropic", model: "anthropic/claude-haiku-4.5" }];
 
         const testCaseId = await mutations.createTestCaseMutation({
           suiteId: suiteId,
@@ -838,7 +853,7 @@ export function useEvalHandlers({
       } catch (error) {
         console.error("Failed to create test case:", error);
         toast.error(
-          getBillingErrorMessage(error, "Failed to create test case"),
+          getBillingErrorMessage(error, "Failed to create test case")
         );
         return null;
       } finally {
@@ -850,7 +865,7 @@ export function useEvalHandlers({
       mutations.createTestCaseMutation,
       convex,
       navigateAfterTestCaseMutation,
-    ],
+    ]
   );
 
   // Handle delete test case - opens confirmation modal
@@ -859,7 +874,7 @@ export function useEvalHandlers({
       if (deletingTestCaseId) return;
       setTestCaseToDelete({ id: testCaseId, title: testCaseTitle });
     },
-    [deletingTestCaseId],
+    [deletingTestCaseId]
   );
 
   /** Perform deletion only (no modal). Used for playground batch delete. */
@@ -867,7 +882,7 @@ export function useEvalHandlers({
     async (testCaseId: string) => {
       await mutations.deleteTestCaseMutation({ testCaseId });
     },
-    [mutations.deleteTestCaseMutation],
+    [mutations.deleteTestCaseMutation]
   );
 
   // Confirm test case deletion
@@ -894,7 +909,7 @@ export function useEvalHandlers({
             : {
                 type: "suite-overview",
                 suiteId: selectedSuiteId,
-              },
+              }
         );
       }
 
@@ -953,7 +968,7 @@ export function useEvalHandlers({
       } catch (error) {
         console.error("Failed to duplicate test case:", error);
         toast.error(
-          getBillingErrorMessage(error, "Failed to duplicate test case"),
+          getBillingErrorMessage(error, "Failed to duplicate test case")
         );
         return null;
       } finally {
@@ -964,7 +979,7 @@ export function useEvalHandlers({
       duplicatingTestCaseId,
       mutations.duplicateTestCaseMutation,
       navigateAfterTestCaseMutation,
-    ],
+    ]
   );
 
   // Generate tests handler - calls API and creates test cases
@@ -981,8 +996,15 @@ export function useEvalHandlers({
           workspaceId,
           suiteId,
           serverIds,
-          createTestCase: mutations.createTestCaseMutation,
+          createTestCase: mutations.createTestCaseMutation as (
+            input: any
+          ) => Promise<unknown>,
           skipIfExistingCases: false,
+          isDirectGuest,
+          listExistingCases: () =>
+            convex.query("testSuites:listTestCases" as any, {
+              suiteId,
+            }) as Promise<Array<Record<string, unknown>>>,
         });
 
         if (outcome.apiReturnedTests === 0) {
@@ -992,7 +1014,9 @@ export function useEvalHandlers({
 
         if (outcome.createdCount > 0) {
           toast.success(
-            `Generated ${outcome.createdCount} test case${outcome.createdCount > 1 ? "s" : ""}`,
+            `Generated ${outcome.createdCount} test case${
+              outcome.createdCount > 1 ? "s" : ""
+            }`
           );
 
           posthog.capture("eval_tests_generated_from_sidebar", {
@@ -1006,7 +1030,7 @@ export function useEvalHandlers({
       } catch (error) {
         console.error("Failed to generate tests:", error);
         toast.error(
-          getBillingErrorMessage(error, "Failed to generate test cases"),
+          getBillingErrorMessage(error, "Failed to generate test cases")
         );
       } finally {
         setIsGeneratingTests(false);
@@ -1018,7 +1042,8 @@ export function useEvalHandlers({
       convex,
       mutations.createTestCaseMutation,
       workspaceId,
-    ],
+      isDirectGuest,
+    ]
   );
 
   return {

--- a/mcpjam-inspector/client/src/components/evals/use-eval-mutations.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-mutations.ts
@@ -1,36 +1,66 @@
+import { useMemo } from "react";
 import { useMutation } from "convex/react";
 
 /**
  * Hook for all eval mutations (delete, duplicate, cancel, etc.)
  */
-export function useEvalMutations() {
-  const deleteSuiteMutation = useMutation("testSuites:deleteTestSuite" as any);
-  const deleteRunMutation = useMutation("testSuites:deleteTestSuiteRun" as any);
-  const cancelRunMutation = useMutation("testSuites:cancelTestSuiteRun" as any);
-  const duplicateSuiteMutation = useMutation(
-    "testSuites:duplicateTestSuite" as any,
+export function useEvalMutations({
+  isDirectGuest = false,
+}: { isDirectGuest?: boolean } = {}) {
+  const convexDeleteSuite = useMutation("testSuites:deleteTestSuite" as any);
+  const convexDeleteRun = useMutation("testSuites:deleteTestSuiteRun" as any);
+  const convexCancelRun = useMutation("testSuites:cancelTestSuiteRun" as any);
+  const convexDuplicateSuite = useMutation(
+    "testSuites:duplicateTestSuite" as any
   );
-  const createTestCaseMutation = useMutation(
-    "testSuites:createTestCase" as any,
+  const convexCreateTestCase = useMutation("testSuites:createTestCase" as any);
+  const convexDeleteTestCase = useMutation("testSuites:deleteTestCase" as any);
+  const convexDuplicateTestCase = useMutation(
+    "testSuites:duplicateTestCase" as any
   );
-  const deleteTestCaseMutation = useMutation(
-    "testSuites:deleteTestCase" as any,
-  );
-  const duplicateTestCaseMutation = useMutation(
-    "testSuites:duplicateTestCase" as any,
-  );
-  const createTestSuiteMutation = useMutation(
-    "testSuites:createTestSuite" as any,
+  const convexCreateTestSuite = useMutation(
+    "testSuites:createTestSuite" as any
   );
 
-  return {
-    deleteSuiteMutation,
-    deleteRunMutation,
-    cancelRunMutation,
-    duplicateSuiteMutation,
-    createTestCaseMutation,
-    deleteTestCaseMutation,
-    duplicateTestCaseMutation,
-    createTestSuiteMutation,
-  };
+  const mutations = useMemo(() => {
+    if (!isDirectGuest) {
+      return {
+        deleteSuiteMutation: convexDeleteSuite,
+        deleteRunMutation: convexDeleteRun,
+        cancelRunMutation: convexCancelRun,
+        duplicateSuiteMutation: convexDuplicateSuite,
+        createTestCaseMutation: convexCreateTestCase,
+        deleteTestCaseMutation: convexDeleteTestCase,
+        duplicateTestCaseMutation: convexDuplicateTestCase,
+        createTestSuiteMutation: convexCreateTestSuite,
+      };
+    }
+
+    const guestUnsupported = async () => {
+      throw new Error("Not available for guests yet. Sign in to use this.");
+    };
+
+    return {
+      deleteSuiteMutation: convexDeleteSuite,
+      deleteRunMutation: guestUnsupported,
+      cancelRunMutation: guestUnsupported,
+      duplicateSuiteMutation: guestUnsupported,
+      createTestCaseMutation: convexCreateTestCase,
+      deleteTestCaseMutation: convexDeleteTestCase,
+      duplicateTestCaseMutation: guestUnsupported,
+      createTestSuiteMutation: convexCreateTestSuite,
+    };
+  }, [
+    isDirectGuest,
+    convexDeleteSuite,
+    convexDeleteRun,
+    convexCancelRun,
+    convexDuplicateSuite,
+    convexCreateTestCase,
+    convexDeleteTestCase,
+    convexDuplicateTestCase,
+    convexCreateTestSuite,
+  ]);
+
+  return mutations;
 }

--- a/mcpjam-inspector/client/src/components/evals/use-eval-queries.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-queries.ts
@@ -17,6 +17,7 @@ export function useEvalQueries({
   deletingSuiteId,
   workspaceId,
   organizationId,
+  isDirectGuest = false,
 }: {
   isAuthenticated: boolean;
   user: any;
@@ -24,45 +25,45 @@ export function useEvalQueries({
   deletingSuiteId: string | null;
   workspaceId: string | null;
   organizationId: string | null;
+  isDirectGuest?: boolean;
 }) {
-  // Overview query - list all suites
-  const enableOverviewQuery = isAuthenticated && !!user;
+  const hasActorAccess = isDirectGuest || (isAuthenticated && !!user);
+
+  const suiteOverviewArgs = useMemo(() => {
+    if (workspaceId) {
+      return { workspaceId } as const;
+    }
+    if (organizationId && !isDirectGuest) {
+      return { organizationId } as const;
+    }
+    return {} as const;
+  }, [isDirectGuest, organizationId, workspaceId]);
+
+  const enableOverviewQuery = hasActorAccess;
   const suiteOverview = useQuery(
     "testSuites:getTestSuitesOverview" as any,
-    enableOverviewQuery
-      ? ({
-          ...(workspaceId ? { workspaceId } : {}),
-          ...(!workspaceId && organizationId ? { organizationId } : {}),
-        } as any)
-      : "skip",
+    enableOverviewQuery ? (suiteOverviewArgs as any) : "skip"
   ) as EvalSuiteOverviewEntry[] | undefined;
 
-  // Suite details query - full suite data for selected suite
   const enableSuiteDetailsQuery =
-    isAuthenticated &&
-    !!user &&
-    !!selectedSuiteId &&
-    deletingSuiteId !== selectedSuiteId;
+    hasActorAccess && !!selectedSuiteId && deletingSuiteId !== selectedSuiteId;
   const suiteDetails = useQuery(
     "testSuites:getAllTestCasesAndIterationsBySuite" as any,
-    enableSuiteDetailsQuery ? ({ suiteId: selectedSuiteId } as any) : "skip",
+    enableSuiteDetailsQuery ? ({ suiteId: selectedSuiteId } as any) : "skip"
   ) as SuiteDetailsQueryResponse | undefined;
 
-  // Suite runs query - runs for selected suite
   const suiteRuns = useQuery(
     "testSuites:listTestSuiteRuns" as any,
     enableSuiteDetailsQuery
       ? ({ suiteId: selectedSuiteId, limit: 20 } as any)
-      : "skip",
+      : "skip"
   ) as EvalSuiteRun[] | undefined;
 
-  // Loading states
   const isOverviewLoading = enableOverviewQuery && suiteOverview === undefined;
   const isSuiteDetailsLoading =
     enableSuiteDetailsQuery && suiteDetails === undefined;
   const isSuiteRunsLoading = enableSuiteDetailsQuery && suiteRuns === undefined;
 
-  // Selected suite entry from overview
   const selectedSuiteEntry = useMemo(() => {
     if (!selectedSuiteId || !suiteOverview) return null;
     return (
@@ -72,7 +73,6 @@ export function useEvalQueries({
 
   const selectedSuite = selectedSuiteEntry?.suite ?? null;
 
-  // Sorted iterations by date
   const sortedIterations = useMemo(() => {
     if (!suiteDetails) return [];
     return [...suiteDetails.iterations].sort(
@@ -81,10 +81,9 @@ export function useEvalQueries({
     );
   }, [suiteDetails]);
 
-  // Runs array
   const runsForSelectedSuite = useMemo(
     () => (suiteRuns ? [...suiteRuns] : []),
-    [suiteRuns],
+    [suiteRuns]
   );
 
   const activeIterations = useMemo(() => {
@@ -93,11 +92,10 @@ export function useEvalQueries({
     const runIds = new Set(suiteRuns.map((run) => run._id));
 
     return sortedIterations.filter(
-      (iteration) => !iteration.suiteRunId || runIds.has(iteration.suiteRunId),
+      (iteration) => !iteration.suiteRunId || runIds.has(iteration.suiteRunId)
     );
   }, [sortedIterations, suiteRuns]);
 
-  // Sorted suites for sidebar
   const sortedSuites = useMemo(() => {
     if (!suiteOverview) return [];
     return [...suiteOverview].sort((a, b) => {
@@ -118,22 +116,18 @@ export function useEvalQueries({
   }, [suiteOverview]);
 
   return {
-    // Raw data
     suiteOverview,
     suiteDetails,
     suiteRuns,
-    // Computed data
     selectedSuiteEntry,
     selectedSuite,
     sortedIterations,
     runsForSelectedSuite,
     activeIterations,
     sortedSuites,
-    // Loading states
     isOverviewLoading,
     isSuiteDetailsLoading,
     isSuiteRunsLoading,
-    // Query enabled flags
     enableOverviewQuery,
     enableSuiteDetailsQuery,
   };

--- a/mcpjam-inspector/client/src/hooks/use-eval-tab-context.ts
+++ b/mcpjam-inspector/client/src/hooks/use-eval-tab-context.ts
@@ -6,10 +6,17 @@ import { useAvailableEvalModels } from "@/hooks/use-available-eval-models";
 export function useEvalTabContext({
   isAuthenticated,
   workspaceId,
+  isDirectGuest = false,
 }: {
   isAuthenticated: boolean;
   workspaceId: string | null;
+  /**
+   * Present so callers can thread guest context; not consumed here — Convex
+   * mutations enforce guest policy server-side via the foundation actor helper.
+   */
+  isDirectGuest?: boolean;
 }) {
+  void isDirectGuest;
   const appState = useSharedAppState();
   const { availableModels } = useAvailableEvalModels();
   const { members, canManageMembers } = useWorkspaceMembers({

--- a/mcpjam-inspector/client/src/hooks/use-is-direct-guest.ts
+++ b/mcpjam-inspector/client/src/hooks/use-is-direct-guest.ts
@@ -1,0 +1,30 @@
+import { useAuth } from "@workos-inc/authkit-react";
+import { useConvexAuth } from "convex/react";
+
+/**
+ * True when the current session has no WorkOS/Convex identity and no workspace.
+ * "Direct guest" covers both hosted (mcpjam.com, no sign-in) and local (npx /
+ * electron without sign-in) surfaces. In both cases, eval playground data is
+ * treated as guest-owned personal data rather than workspace data.
+ *
+ * Shared/sandbox guests (have workspaceId + share/sandbox token) are NOT direct
+ * guests; they still use Convex-backed flows via the share/sandbox token.
+ */
+export function useIsDirectGuest({
+  workspaceId,
+  shareToken,
+  sandboxToken,
+}: {
+  workspaceId?: string | null;
+  shareToken?: string | null;
+  sandboxToken?: string | null;
+} = {}): boolean {
+  const { isAuthenticated, isLoading } = useConvexAuth();
+  const { user } = useAuth();
+
+  if (isLoading) return false;
+  if (isAuthenticated || user) return false;
+  if (workspaceId) return false;
+  if (shareToken || sandboxToken) return false;
+  return true;
+}

--- a/mcpjam-inspector/client/src/lib/apis/__tests__/evals-api.hosted.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/__tests__/evals-api.hosted.test.ts
@@ -4,6 +4,8 @@ import { createFetchResponse } from "@/test";
 const authFetchMock = vi.fn();
 const listHostedToolsMock = vi.fn();
 const buildHostedServerBatchRequestMock = vi.fn();
+const buildHostedServerRequestMock = vi.fn();
+const isGuestModeMock = vi.fn(() => false);
 
 vi.mock("@/lib/config", () => ({
   HOSTED_MODE: true,
@@ -20,6 +22,9 @@ vi.mock("@/lib/apis/web/tools-api", () => ({
 vi.mock("@/lib/apis/web/context", () => ({
   buildHostedServerBatchRequest: (...args: unknown[]) =>
     buildHostedServerBatchRequestMock(...args),
+  buildHostedServerRequest: (...args: unknown[]) =>
+    buildHostedServerRequestMock(...args),
+  isGuestMode: () => isGuestModeMock(),
 }));
 
 import {
@@ -34,6 +39,7 @@ import {
 describe("evals-api hosted mode", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    isGuestModeMock.mockReturnValue(false);
     buildHostedServerBatchRequestMock.mockImplementation(
       (serverNames: string[]) => {
         const serverIds = serverNames.map((serverName) =>
@@ -54,6 +60,13 @@ describe("evals-api hosted mode", () => {
         };
       },
     );
+    buildHostedServerRequestMock.mockReturnValue({
+      serverUrl: "https://guest.example.com/mcp",
+      serverName: "Guest Server",
+      serverHeaders: { "X-Guest": "yes" },
+      oauthAccessToken: "guest-oauth-token",
+      clientCapabilities: { sampling: true },
+    });
     authFetchMock.mockResolvedValue(createFetchResponse({ success: true }));
   });
 
@@ -84,6 +97,23 @@ describe("evals-api hosted mode", () => {
       storageServerIds: ["Server A", "Server B"],
     });
     expect(body).not.toHaveProperty("convexAuthToken");
+  });
+
+  it("rejects direct guest full-suite runs before workspace lookup", async () => {
+    isGuestModeMock.mockReturnValue(true);
+
+    await expect(
+      runEvals({
+        workspaceId: null,
+        suiteName: "Guest Suite",
+        tests: [],
+        serverIds: ["Guest Server"],
+        convexAuthToken: "guest-convex-token",
+      }),
+    ).rejects.toThrow("Not available for guests yet. Sign in to use this.");
+
+    expect(buildHostedServerBatchRequestMock).not.toHaveBeenCalled();
+    expect(authFetchMock).not.toHaveBeenCalled();
   });
 
   it("uses /api/web/evals/generate-tests for hosted test generation", async () => {
@@ -158,6 +188,92 @@ describe("evals-api hosted mode", () => {
     expect(body).not.toHaveProperty("convexAuthToken");
   });
 
+  it("posts direct guest quick runs with the guest server payload", async () => {
+    isGuestModeMock.mockReturnValue(true);
+
+    await runEvalTestCase({
+      workspaceId: null,
+      testCaseId: "guest-case-1",
+      model: "openai/gpt-5-mini",
+      provider: "openai",
+      serverIds: ["Guest Server"],
+      convexAuthToken: "guest-convex-token",
+    });
+
+    expect(buildHostedServerRequestMock).toHaveBeenCalledWith("Guest Server");
+    expect(buildHostedServerBatchRequestMock).not.toHaveBeenCalled();
+
+    const body = JSON.parse(authFetchMock.mock.calls[0][1].body);
+    expect(body).toMatchObject({
+      serverUrl: "https://guest.example.com/mcp",
+      serverName: "Guest Server",
+      serverHeaders: { "X-Guest": "yes" },
+      oauthAccessToken: "guest-oauth-token",
+      clientCapabilities: { sampling: true },
+      testCaseId: "guest-case-1",
+      model: "openai/gpt-5-mini",
+      provider: "openai",
+    });
+    expect(body).not.toHaveProperty("workspaceId");
+    expect(body).not.toHaveProperty("serverIds");
+    expect(body).not.toHaveProperty("convexAuthToken");
+  });
+
+  it("posts direct guest generation with the guest server payload", async () => {
+    isGuestModeMock.mockReturnValue(true);
+
+    await generateEvalTests({
+      workspaceId: null,
+      serverIds: ["Guest Server"],
+      convexAuthToken: "guest-convex-token",
+    });
+
+    expect(authFetchMock).toHaveBeenCalledWith(
+      "/api/web/evals/generate-tests",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+
+    const body = JSON.parse(authFetchMock.mock.calls[0][1].body);
+    expect(body).toMatchObject({
+      serverUrl: "https://guest.example.com/mcp",
+      serverName: "Guest Server",
+      serverHeaders: { "X-Guest": "yes" },
+      oauthAccessToken: "guest-oauth-token",
+      clientCapabilities: { sampling: true },
+    });
+    expect(body).not.toHaveProperty("workspaceId");
+    expect(body).not.toHaveProperty("serverIds");
+    expect(body).not.toHaveProperty("convexAuthToken");
+  });
+
+  it("posts direct guest negative generation with the guest server payload", async () => {
+    isGuestModeMock.mockReturnValue(true);
+
+    await generateNegativeEvalTests({
+      workspaceId: null,
+      serverIds: ["Guest Server"],
+      convexAuthToken: "guest-convex-token",
+    });
+
+    expect(authFetchMock).toHaveBeenCalledWith(
+      "/api/web/evals/generate-negative-tests",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+
+    const body = JSON.parse(authFetchMock.mock.calls[0][1].body);
+    expect(body).toMatchObject({
+      serverUrl: "https://guest.example.com/mcp",
+      serverName: "Guest Server",
+    });
+    expect(body).not.toHaveProperty("workspaceId");
+    expect(body).not.toHaveProperty("serverIds");
+    expect(body).not.toHaveProperty("convexAuthToken");
+  });
+
   it("uses /api/web/evals/stream-test-case and parses SSE events", async () => {
     const encoder = new TextEncoder();
     authFetchMock.mockResolvedValueOnce(
@@ -229,6 +345,60 @@ describe("evals-api hosted mode", () => {
         iteration: { _id: "iter-1" },
       }),
     ]);
+  });
+
+  it("posts direct guest compare streams with the guest server payload", async () => {
+    isGuestModeMock.mockReturnValue(true);
+    const encoder = new TextEncoder();
+    authFetchMock.mockResolvedValueOnce(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(
+              encoder.encode('data: {"type":"complete"}\n\n'),
+            );
+            controller.close();
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        },
+      ),
+    );
+
+    await streamEvalTestCase(
+      {
+        workspaceId: null,
+        testCaseId: "guest-case-1",
+        model: "openai/gpt-5-mini",
+        provider: "openai",
+        serverIds: ["Guest Server"],
+        convexAuthToken: "guest-convex-token",
+        compareRunId: "cmp_guest",
+      },
+      () => {},
+    );
+
+    expect(authFetchMock).toHaveBeenCalledWith(
+      "/api/web/evals/stream-test-case",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+
+    const body = JSON.parse(authFetchMock.mock.calls[0][1].body);
+    expect(body).toMatchObject({
+      serverUrl: "https://guest.example.com/mcp",
+      serverName: "Guest Server",
+      testCaseId: "guest-case-1",
+      model: "openai/gpt-5-mini",
+      provider: "openai",
+      compareRunId: "cmp_guest",
+    });
+    expect(body).not.toHaveProperty("workspaceId");
+    expect(body).not.toHaveProperty("serverIds");
+    expect(body).not.toHaveProperty("convexAuthToken");
   });
 
   it("uses hosted tool listing instead of /api/mcp/list-tools", async () => {

--- a/mcpjam-inspector/client/src/lib/apis/evals-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/evals-api.ts
@@ -3,7 +3,9 @@ import { isHostedMode, runByMode } from "@/lib/apis/mode-client";
 import { getSessionToken } from "@/lib/session-token";
 import {
   buildHostedEvalServerBatchRequest,
+  buildHostedServerRequest,
   buildHostedServerBatchRequest,
+  isGuestMode,
 } from "@/lib/apis/web/context";
 import { listHostedTools } from "@/lib/apis/web/tools-api";
 import { authFetch } from "@/lib/session-token";
@@ -34,6 +36,8 @@ export const EVALS_API_ENDPOINTS = {
 } as const;
 
 type JsonRecord = Record<string, unknown>;
+const GUEST_UNSUPPORTED_MESSAGE =
+  "Not available for guests yet. Sign in to use this.";
 
 type EvalRequestWithServers = {
   workspaceId?: string | null;
@@ -155,6 +159,30 @@ function mergeHostedServerBatch<
   };
 }
 
+function mergeHostedEvalServerRequest<
+  T extends EvalRequestWithServers & { convexAuthToken?: string | null },
+>(request: T): JsonRecord {
+  if (!isGuestMode()) {
+    return mergeHostedServerBatch(request) as JsonRecord;
+  }
+
+  const {
+    convexAuthToken: _convexAuthToken,
+    serverIds,
+    workspaceId: _workspaceId,
+    ...requestWithoutHostedAuth
+  } = request;
+
+  if (serverIds.length !== 1) {
+    throw new Error("Guest eval playground supports one server at a time");
+  }
+
+  return {
+    ...requestWithoutHostedAuth,
+    ...buildHostedServerRequest(serverIds[0]!),
+  };
+}
+
 async function postEvalRequest<TResponse>(
   path: string,
   payload: JsonRecord,
@@ -227,11 +255,16 @@ export async function runEvals(request: RunEvalsRequest): Promise<any> {
   return runByMode({
     local: () =>
       postEvalRequest(EVALS_API_ENDPOINTS.local.run, request as JsonRecord),
-    hosted: () =>
-      postEvalRequest(EVALS_API_ENDPOINTS.hosted.run, {
+    hosted: () => {
+      if (isGuestMode()) {
+        throw new Error(GUEST_UNSUPPORTED_MESSAGE);
+      }
+
+      return postEvalRequest(EVALS_API_ENDPOINTS.hosted.run, {
         ...mergeHostedServerBatch(request),
         storageServerIds: request.storageServerIds ?? request.serverIds,
-      } as JsonRecord),
+      } as JsonRecord);
+    },
   });
 }
 
@@ -247,7 +280,7 @@ export async function runEvalTestCase(
     hosted: () =>
       postEvalRequest(
         EVALS_API_ENDPOINTS.hosted.runTestCase,
-        mergeHostedServerBatch(request) as JsonRecord,
+        mergeHostedEvalServerRequest(request),
       ),
   });
 }
@@ -264,7 +297,7 @@ export async function generateEvalTests(
     hosted: () =>
       postEvalRequest(
         EVALS_API_ENDPOINTS.hosted.generateTests,
-        mergeHostedServerBatch(request) as JsonRecord,
+        mergeHostedEvalServerRequest(request),
       ),
   });
 }
@@ -281,7 +314,7 @@ export async function generateNegativeEvalTests(
     hosted: () =>
       postEvalRequest(
         EVALS_API_ENDPOINTS.hosted.generateNegativeTests,
-        mergeHostedServerBatch(request) as JsonRecord,
+        mergeHostedEvalServerRequest(request),
       ),
   });
 }
@@ -342,7 +375,7 @@ export async function streamEvalTestCase(
     : EVALS_API_ENDPOINTS.local.streamTestCase;
 
   const payload = isHostedMode()
-    ? (mergeHostedServerBatch(request) as JsonRecord)
+    ? mergeHostedEvalServerRequest(request)
     : (request as JsonRecord);
 
   const response = await authFetch(endpoint, {

--- a/mcpjam-inspector/client/src/lib/evals/__tests__/generate-and-persist-tests.test.ts
+++ b/mcpjam-inspector/client/src/lib/evals/__tests__/generate-and-persist-tests.test.ts
@@ -5,7 +5,12 @@ vi.mock("@/lib/apis/evals-api", () => ({
   generateEvalTests: vi.fn(),
 }));
 
+vi.mock("@/lib/guest-session", () => ({
+  getGuestBearerToken: vi.fn(),
+}));
+
 import { generateEvalTests } from "@/lib/apis/evals-api";
+import { getGuestBearerToken } from "@/lib/guest-session";
 
 describe("generateAndPersistEvalTests", () => {
   const mockQuery = vi.fn();
@@ -17,6 +22,7 @@ describe("generateAndPersistEvalTests", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAccessToken.mockResolvedValue("token");
+    vi.mocked(getGuestBearerToken).mockResolvedValue("guest-token");
     vi.mocked(generateEvalTests).mockResolvedValue({
       success: true,
       tests: [],
@@ -122,5 +128,32 @@ describe("generateAndPersistEvalTests", () => {
         ],
       }),
     );
+  });
+
+  it("uses the guest bearer token for direct guest generation", async () => {
+    mockQuery.mockResolvedValue([]);
+    vi.mocked(generateEvalTests).mockResolvedValue({
+      success: true,
+      tests: [{ title: "T", query: "q", runs: 1, expectedToolCalls: [] }],
+    });
+    mockCreateTestCase.mockResolvedValue({});
+
+    await generateAndPersistEvalTests({
+      convex,
+      getAccessToken: mockGetAccessToken,
+      workspaceId: null,
+      suiteId: "suite",
+      serverIds: ["srv"],
+      createTestCase: mockCreateTestCase,
+      isDirectGuest: true,
+    });
+
+    expect(getGuestBearerToken).toHaveBeenCalledTimes(1);
+    expect(mockGetAccessToken).not.toHaveBeenCalled();
+    expect(generateEvalTests).toHaveBeenCalledWith({
+      workspaceId: null,
+      serverIds: ["srv"],
+      convexAuthToken: "guest-token",
+    });
   });
 });

--- a/mcpjam-inspector/client/src/lib/evals/generate-and-persist-tests.ts
+++ b/mcpjam-inspector/client/src/lib/evals/generate-and-persist-tests.ts
@@ -3,6 +3,7 @@ import {
   generateEvalTests,
   type GeneratedEvalTestCase,
 } from "@/lib/apis/evals-api";
+import { getGuestBearerToken } from "@/lib/guest-session";
 import type { PromptTurn } from "@/shared/prompt-turns";
 
 export type CreateEvalTestCaseInput = {
@@ -102,6 +103,15 @@ export type GenerateAndPersistEvalTestsOptions = {
   createTestCase: (input: CreateEvalTestCaseInput) => Promise<unknown>;
   /** When true, skips API call and creation if the suite already has test cases. */
   skipIfExistingCases?: boolean;
+  /**
+   * When true, guests are running generation and should use the guest bearer
+   * token instead of a WorkOS token.
+   */
+  isDirectGuest?: boolean;
+  /** Override case listing; used when the caller already has the suite's cases. */
+  listExistingCases?: () =>
+    | Array<Record<string, unknown>>
+    | Promise<Array<Record<string, unknown>>>;
 };
 
 export type GenerateAndPersistEvalTestsResult = {
@@ -121,16 +131,23 @@ export async function generateAndPersistEvalTests(
     serverIds,
     createTestCase,
     skipIfExistingCases = false,
+    isDirectGuest = false,
+    listExistingCases,
   } = options;
 
-  const existingTestCases = await convex.query(
-    "testSuites:listTestCases" as any,
-    { suiteId },
-  );
-
-  const existingList = Array.isArray(existingTestCases)
-    ? (existingTestCases as Array<Record<string, unknown>>)
-    : [];
+  let existingList: Array<Record<string, unknown>> = [];
+  if (listExistingCases) {
+    const listed = await listExistingCases();
+    existingList = Array.isArray(listed) ? listed : [];
+  } else {
+    const existingTestCases = await convex.query(
+      "testSuites:listTestCases" as any,
+      { suiteId },
+    );
+    existingList = Array.isArray(existingTestCases)
+      ? (existingTestCases as Array<Record<string, unknown>>)
+      : [];
+  }
 
   if (skipIfExistingCases && existingList.length > 0) {
     return {
@@ -145,7 +162,9 @@ export async function generateAndPersistEvalTests(
     modelsToUse = defaultEvalModels();
   }
 
-  const accessToken = await getAccessToken();
+  const accessToken = isDirectGuest
+    ? await getGuestBearerToken()
+    : await getAccessToken();
   if (!accessToken) {
     throw new Error("Not authenticated");
   }

--- a/mcpjam-inspector/client/src/lib/evals/generate-and-persist-tests.ts
+++ b/mcpjam-inspector/client/src/lib/evals/generate-and-persist-tests.ts
@@ -170,7 +170,7 @@ export async function generateAndPersistEvalTests(
   }
 
   const result = await generateEvalTests({
-    workspaceId,
+    workspaceId: isDirectGuest ? null : workspaceId,
     serverIds,
     convexAuthToken: accessToken,
   });

--- a/mcpjam-inspector/client/src/lib/guest-convex-auth.tsx
+++ b/mcpjam-inspector/client/src/lib/guest-convex-auth.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { useAuth } from "@workos-inc/authkit-react";
+import { getGuestBearerToken } from "@/lib/guest-session";
+
+type GuestCapableConvexClient = {
+  setAuth: (
+    fetchToken: (args: {
+      forceRefreshToken: boolean;
+    }) => Promise<string | null | undefined>
+  ) => void;
+};
+
+/**
+ * Keeps Convex queries/mutations guest-authenticated when there is no WorkOS
+ * session. This lets direct guests use normal Convex-backed flows without
+ * pretending they are signed-in users.
+ */
+export function GuestConvexAuthBridge({
+  client,
+}: {
+  client: GuestCapableConvexClient;
+}) {
+  const { isLoading, user } = useAuth();
+
+  useEffect(() => {
+    if (isLoading || user) {
+      return;
+    }
+
+    client.setAuth(async () => await getGuestBearerToken());
+  }, [client, isLoading, user]);
+
+  return null;
+}

--- a/mcpjam-inspector/client/src/lib/guest-convex-auth.tsx
+++ b/mcpjam-inspector/client/src/lib/guest-convex-auth.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
-import { getGuestBearerToken } from "@/lib/guest-session";
+import { forceRefreshGuestSession, getGuestBearerToken } from "@/lib/guest-session";
 
 type GuestCapableConvexClient = {
   setAuth: (
@@ -27,7 +27,9 @@ export function GuestConvexAuthBridge({
       return;
     }
 
-    client.setAuth(async () => await getGuestBearerToken());
+    client.setAuth(({ forceRefreshToken }) =>
+      forceRefreshToken ? forceRefreshGuestSession() : getGuestBearerToken()
+    );
   }, [client, isLoading, user]);
 
   return null;

--- a/mcpjam-inspector/client/src/main.tsx
+++ b/mcpjam-inspector/client/src/main.tsx
@@ -11,6 +11,7 @@ import { initSentry } from "./lib/sentry.js";
 import { IframeRouterError } from "./components/IframeRouterError.jsx";
 import { initializeSessionToken } from "./lib/session-token.js";
 import { HOSTED_MODE } from "./lib/config";
+import { GuestConvexAuthBridge } from "./lib/guest-convex-auth";
 
 // Initialize Sentry before React mounts
 initSentry();
@@ -33,7 +34,7 @@ if (isInIframe) {
   root.render(
     <StrictMode>
       <IframeRouterError />
-    </StrictMode>,
+    </StrictMode>
   );
 } else {
   const convexUrl = import.meta.env.VITE_CONVEX_URL as string;
@@ -67,12 +68,12 @@ if (isInIframe) {
   // Warn if critical env vars are missing
   if (!convexUrl) {
     console.warn(
-      "[main] VITE_CONVEX_URL is not set; Convex features may not work.",
+      "[main] VITE_CONVEX_URL is not set; Convex features may not work."
     );
   }
   if (!workosClientId) {
     console.warn(
-      "[main] VITE_WORKOS_CLIENT_ID is not set; authentication will not work.",
+      "[main] VITE_WORKOS_CLIENT_ID is not set; authentication will not work."
     );
   }
 
@@ -110,6 +111,7 @@ if (isInIframe) {
       {...workosClientOptions}
     >
       <ConvexProviderWithAuthKit client={convex} useAuth={useAuth}>
+        <GuestConvexAuthBridge client={convex} />
         <App />
       </ConvexProviderWithAuthKit>
     </AuthKitProvider>
@@ -126,7 +128,7 @@ if (isInIframe) {
         console.log("[Auth] Session token initialized");
       } else {
         console.log(
-          "[Auth] Hosted mode active, skipping session token bootstrap",
+          "[Auth] Hosted mode active, skipping session token bootstrap"
         );
       }
     } catch (error) {
@@ -177,7 +179,7 @@ if (isInIframe) {
               Restart App
             </button>
           </div>
-        </StrictMode>,
+        </StrictMode>
       );
       return;
     }
@@ -187,7 +189,7 @@ if (isInIframe) {
         <PostHogProvider apiKey={getPostHogKey()} options={getPostHogOptions()}>
           {Providers}
         </PostHogProvider>
-      </StrictMode>,
+      </StrictMode>
     );
   }
 

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -49,7 +49,7 @@ vi.mock("../../../utils/mcpjam-stream-handler.js", () => ({
 
 vi.mock("../../../utils/chat-ingestion.js", () => ({
   persistChatSessionToConvex: persistChatSessionToConvexMock,
-  pickEnrichmentHeaders: () => ({}),
+  pickEnrichmentHeaders: vi.fn(() => ({})),
 }));
 
 vi.mock("../apps.js", () => ({

--- a/mcpjam-inspector/server/routes/web/__tests__/evals.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/evals.test.ts
@@ -1,9 +1,16 @@
 import { Hono } from "hono";
+import { mkdtempSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { bearerAuthMiddleware } from "../../../middleware/bearer-auth.js";
 import { guestRateLimitMiddleware } from "../../../middleware/guest-rate-limit.js";
 import evalsRoutes from "../evals.js";
 import { mapRuntimeError, webError } from "../errors.js";
+import {
+  initGuestTokenSecret,
+  issueGuestToken,
+} from "../../../services/guest-token.js";
 
 const {
   runEvalsWithManagerMock,
@@ -11,6 +18,7 @@ const {
   streamEvalTestCaseWithManagerMock,
   generateEvalTestsWithManagerMock,
   generateNegativeEvalTestsWithManagerMock,
+  managerConfigsMock,
   disconnectAllServersMock,
 } = vi.hoisted(() => ({
   runEvalsWithManagerMock: vi.fn(),
@@ -18,6 +26,7 @@ const {
   streamEvalTestCaseWithManagerMock: vi.fn(),
   generateEvalTestsWithManagerMock: vi.fn(),
   generateNegativeEvalTestsWithManagerMock: vi.fn(),
+  managerConfigsMock: vi.fn(),
   disconnectAllServersMock: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -26,11 +35,28 @@ vi.mock("@mcpjam/sdk", async () => {
     await vi.importActual<typeof import("@mcpjam/sdk")>("@mcpjam/sdk");
   return {
     ...actual,
-    MCPClientManager: vi.fn().mockImplementation(() => ({
-      disconnectAllServers: disconnectAllServersMock,
-    })),
+    MCPClientManager: vi.fn().mockImplementation((configs: unknown) => {
+      managerConfigsMock(configs);
+      return {
+        disconnectAllServers: disconnectAllServersMock,
+      };
+    }),
   };
 });
+
+vi.mock("../../../utils/oauth-proxy.js", () => ({
+  OAuthProxyError: class OAuthProxyError extends Error {
+    constructor(
+      public readonly status: number,
+      message: string,
+    ) {
+      super(message);
+    }
+  },
+  validateUrl: vi.fn().mockResolvedValue({
+    url: new URL("https://guest.example.com/mcp"),
+  }),
+}));
 
 vi.mock("../../shared/evals.js", async () => {
   const actual = await vi.importActual<typeof import("../../shared/evals.js")>(
@@ -176,13 +202,30 @@ async function expectJson<T = unknown>(
 }
 
 function stubAuthorizeResponse(options?: { useOAuth?: boolean }) {
+  const serverConfig = {
+    transportType: "http" as const,
+    url: "https://server.example.com/mcp",
+    headers: {},
+    useOAuth: options?.useOAuth ?? false,
+  };
+
   vi.stubGlobal(
     "fetch",
     vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      if (String(input).endsWith("/web/authorize-batch")) {
-        const payload = JSON.parse(String(init?.body ?? "{}"));
-        const serverIds = Array.isArray(payload?.serverIds)
-          ? (payload.serverIds as string[])
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+      if (url.endsWith("/web/authorize-batch")) {
+        const rawBody =
+          typeof init?.body === "string"
+            ? (JSON.parse(init.body) as { serverIds?: string[] })
+            : null;
+        const serverIds = Array.isArray(rawBody?.serverIds)
+          ? rawBody.serverIds
           : [];
         return new Response(
           JSON.stringify({
@@ -194,12 +237,7 @@ function stubAuthorizeResponse(options?: { useOAuth?: boolean }) {
                   role: "member",
                   accessLevel: "workspace_member",
                   permissions: { chatOnly: false },
-                  serverConfig: {
-                    transportType: "http",
-                    url: `https://${serverId}.example.com/mcp`,
-                    headers: {},
-                    useOAuth: options?.useOAuth ?? false,
-                  },
+                  serverConfig,
                 },
               ]),
             ),
@@ -211,22 +249,48 @@ function stubAuthorizeResponse(options?: { useOAuth?: boolean }) {
         );
       }
 
-      throw new Error(`Unexpected fetch: ${String(input)}`);
+      return new Response(
+        JSON.stringify({
+          authorized: true,
+          role: "member",
+          accessLevel: "workspace_member",
+          permissions: { chatOnly: false },
+          serverConfig,
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }),
   );
 }
 
 describe("web routes — evals", () => {
   const originalConvexHttpUrl = process.env.CONVEX_HTTP_URL;
+  const originalGuestJwtKeyDir = process.env.GUEST_JWT_KEY_DIR;
+  let testGuestKeyDir: string | null = null;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    testGuestKeyDir = mkdtempSync(path.join(os.tmpdir(), "evals-guest-test-"));
+    process.env.GUEST_JWT_KEY_DIR = testGuestKeyDir;
+    initGuestTokenSecret();
     process.env.CONVEX_HTTP_URL = "https://example.convex.site";
     stubAuthorizeResponse();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    if (testGuestKeyDir) {
+      rmSync(testGuestKeyDir, { recursive: true, force: true });
+      testGuestKeyDir = null;
+    }
+    if (originalGuestJwtKeyDir === undefined) {
+      delete process.env.GUEST_JWT_KEY_DIR;
+    } else {
+      process.env.GUEST_JWT_KEY_DIR = originalGuestJwtKeyDir;
+    }
     if (originalConvexHttpUrl === undefined) {
       delete process.env.CONVEX_HTTP_URL;
     } else {
@@ -350,5 +414,165 @@ describe("web routes — evals", () => {
         convexAuthToken: token,
       }),
     );
+  });
+
+  it("runs direct guest quick evals with the synthetic guest server", async () => {
+    runEvalTestCaseWithManagerMock.mockResolvedValueOnce({
+      success: true,
+      iteration: { _id: "guest-iter-1" },
+    });
+    const { app } = createEvalsTestApp();
+    const { token } = issueGuestToken();
+
+    const response = await postJson(
+      app,
+      "/api/web/evals/run-test-case",
+      {
+        serverUrl: "https://guest.example.com/mcp",
+        serverName: "Guest Server",
+        serverHeaders: { "X-Guest": "yes" },
+        oauthAccessToken: "fresh-oauth-token",
+        testCaseId: "guest-case-1",
+        model: "openai/gpt-5-mini",
+        provider: "openai",
+      },
+      token,
+    );
+
+    const { status, data } = await expectJson(response);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      iteration: { _id: "guest-iter-1" },
+    });
+    expect(runEvalTestCaseWithManagerMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        workspaceId: "__guest__",
+        serverIds: ["__guest__"],
+        testCaseId: "guest-case-1",
+        convexAuthToken: token,
+      }),
+    );
+    expect(managerConfigsMock).toHaveBeenCalledWith({
+      __guest__: expect.objectContaining({
+        url: "https://guest.example.com/mcp",
+        requestInit: {
+          headers: {
+            "X-Guest": "yes",
+            Authorization: "Bearer fresh-oauth-token",
+          },
+        },
+      }),
+    });
+  });
+
+  it("generates direct guest eval tests with the synthetic guest server", async () => {
+    generateEvalTestsWithManagerMock.mockResolvedValueOnce({
+      success: true,
+      tests: [{ title: "Generated guest test" }],
+    });
+    const { app } = createEvalsTestApp();
+    const { token } = issueGuestToken();
+
+    const response = await postJson(
+      app,
+      "/api/web/evals/generate-tests",
+      {
+        serverUrl: "https://guest.example.com/mcp",
+        serverName: "Guest Server",
+      },
+      token,
+    );
+
+    const { status, data } = await expectJson(response);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      tests: [{ title: "Generated guest test" }],
+    });
+    expect(generateEvalTestsWithManagerMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        workspaceId: "__guest__",
+        serverIds: ["__guest__"],
+        convexAuthToken: token,
+      }),
+    );
+  });
+
+  it("streams direct guest compare quick runs with the synthetic guest server", async () => {
+    const encoder = new TextEncoder();
+    streamEvalTestCaseWithManagerMock.mockResolvedValueOnce(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: {"type":"complete"}\n\n'));
+          controller.close();
+        },
+      }),
+    );
+    const { app } = createEvalsTestApp();
+    const { token } = issueGuestToken();
+
+    const response = await postJson(
+      app,
+      "/api/web/evals/stream-test-case",
+      {
+        serverUrl: "https://guest.example.com/mcp",
+        serverName: "Guest Server",
+        testCaseId: "guest-case-1",
+        model: "openai/gpt-5-mini",
+        provider: "openai",
+        compareRunId: "cmp_guest",
+      },
+      token,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    await expect(response.text()).resolves.toContain('"type":"complete"');
+    expect(streamEvalTestCaseWithManagerMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        workspaceId: "__guest__",
+        serverIds: ["__guest__"],
+        testCaseId: "guest-case-1",
+        compareRunId: "cmp_guest",
+        convexAuthToken: token,
+      }),
+      expect.objectContaining({
+        onStreamComplete: expect.any(Function),
+      }),
+    );
+  });
+
+  it("rejects direct guest full suite eval runs", async () => {
+    const { app } = createEvalsTestApp();
+    const { token } = issueGuestToken();
+
+    const response = await postJson(
+      app,
+      "/api/web/evals/run",
+      {
+        serverUrl: "https://guest.example.com/mcp",
+        serverName: "Guest Server",
+        suiteName: "Guest Suite",
+        tests: [],
+      },
+      token,
+    );
+    const { status, data } = await expectJson<{
+      code: string;
+      message: string;
+    }>(response);
+
+    expect(status).toBe(403);
+    expect(data).toEqual({
+      code: "FEATURE_NOT_SUPPORTED",
+      message: "Not available for guests yet. Sign in to use this.",
+    });
+    expect(runEvalsWithManagerMock).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -39,6 +39,7 @@ function refineHostedTokens<T extends z.ZodRawShape>(schema: z.ZodObject<T>) {
 }
 
 const clientCapabilitiesSchema = z.record(z.string(), z.unknown());
+export const GUEST_SERVER_ID = "__guest__";
 
 export const workspaceServerSchema = refineHostedTokens(
   z.object({
@@ -119,6 +120,7 @@ export const guestServerInputSchema = z.object({
   serverUrl: z.string().min(1),
   serverName: z.string().min(1).optional(),
   serverHeaders: z.record(z.string(), z.string()).optional(),
+  oauthAccessToken: z.string().optional(),
   clientCapabilities: clientCapabilitiesSchema.optional(),
 });
 
@@ -126,6 +128,85 @@ export const guestServerInputSchema = z.object({
 
 export function buildSingleServerOAuthTokens(serverId: string, token?: string) {
   return token ? { [serverId]: token } : undefined;
+}
+
+export function isGuestServerRequestBody(
+  rawBody: Record<string, unknown>,
+): boolean {
+  return typeof rawBody.serverUrl === "string" && !rawBody.workspaceId;
+}
+
+function requireGuestId(c: any): string {
+  const guestId = c.get("guestId") as string | undefined;
+  if (!guestId) {
+    throw new WebRouteError(
+      401,
+      ErrorCode.UNAUTHORIZED,
+      "Valid guest token required. Please refresh the page to obtain a new session.",
+    );
+  }
+  return guestId;
+}
+
+export async function createGuestEphemeralManager(
+  c: any,
+  rawBody: Record<string, unknown>,
+  options?: { timeoutMs?: number; rpcLogger?: RpcLogger },
+): Promise<{
+  manager: InstanceType<typeof MCPClientManager>;
+  augmentedBody: Record<string, unknown>;
+}> {
+  requireGuestId(c);
+
+  const guestInput = parseWithSchema(guestServerInputSchema, rawBody);
+
+  try {
+    await validateUrl(guestInput.serverUrl, true);
+  } catch (err) {
+    if (err instanceof OAuthProxyError) {
+      throw new WebRouteError(
+        err.status,
+        ErrorCode.VALIDATION_ERROR,
+        err.message,
+      );
+    }
+    throw err;
+  }
+
+  const timeoutMs = options?.timeoutMs ?? WEB_CALL_TIMEOUT_MS;
+  const headers: Record<string, string> = {
+    ...(guestInput.serverHeaders ?? {}),
+  };
+
+  if (guestInput.oauthAccessToken) {
+    headers["Authorization"] = `Bearer ${guestInput.oauthAccessToken}`;
+  }
+
+  const httpConfig: HttpServerConfig = {
+    url: guestInput.serverUrl,
+    capabilities: guestInput.clientCapabilities,
+    requestInit: {
+      headers,
+    },
+    timeout: timeoutMs,
+  };
+
+  return {
+    manager: new MCPClientManager(
+      { [GUEST_SERVER_ID]: httpConfig },
+      {
+        defaultTimeout: timeoutMs,
+        rpcLogger: options?.rpcLogger,
+        retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
+      },
+    ),
+    augmentedBody: {
+      ...rawBody,
+      workspaceId: GUEST_SERVER_ID,
+      serverId: GUEST_SERVER_ID,
+      serverIds: [GUEST_SERVER_ID],
+    },
+  };
 }
 
 // ── Authorization ────────────────────────────────────────────────────
@@ -571,7 +652,11 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
     manager: InstanceType<typeof MCPClientManager>,
     body: z.infer<S>
   ) => Promise<T>,
-  options?: { timeoutMs?: number; rpcLogs?: boolean }
+  options?: {
+    timeoutMs?: number;
+    rpcLogs?: boolean;
+    guestUnsupportedMessage?: string;
+  },
 ) {
   let rpcCollector: ReturnType<typeof createHostedRpcLogCollector> | undefined;
 
@@ -586,8 +671,7 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
     // This is more robust than relying solely on guestId from middleware, which
     // may not be set when the guest token is expired/invalid but the client still
     // sends a guest-shaped body.
-    const isGuestRequest =
-      typeof rawBody.serverUrl === "string" && !rawBody.workspaceId;
+    const isGuestRequest = isGuestServerRequestBody(rawBody);
 
     let result: T;
 
@@ -602,69 +686,25 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
         );
       }
 
-      // Validate guest-specific fields (serverUrl is required)
-      const guestInput = parseWithSchema(guestServerInputSchema, rawBody);
-
-      // Safety: HTTPS-only, no private/reserved IPs
-      try {
-        await validateUrl(guestInput.serverUrl, true);
-      } catch (err) {
-        if (err instanceof OAuthProxyError) {
-          throw new WebRouteError(
-            err.status,
-            ErrorCode.VALIDATION_ERROR,
-            err.message
-          );
-        }
-        throw err;
+      if (options?.guestUnsupportedMessage) {
+        throw new WebRouteError(
+          403,
+          ErrorCode.FEATURE_NOT_SUPPORTED,
+          options.guestUnsupportedMessage,
+        );
       }
 
-      const timeoutMs = options?.timeoutMs ?? WEB_CALL_TIMEOUT_MS;
-
-      // Inject synthetic IDs so downstream schema parsing works unchanged
-      const augmentedBody = {
-        ...rawBody,
-        workspaceId: "__guest__",
-        serverId: "__guest__",
-      };
-      const body = parseWithSchema(schema, augmentedBody);
-
-      // Create ephemeral manager directly from guest-provided config
-      const headers: Record<string, string> = {
-        ...(guestInput.serverHeaders ?? {}),
-      };
-
-      // Allow callers to supply a fresh OAuth bearer explicitly. This avoids
-      // depending on reactive client state having already persisted updated
-      // Authorization headers after an OAuth callback completes.
-      if (
-        typeof (body as { oauthAccessToken?: unknown }).oauthAccessToken ===
-        "string"
-      ) {
-        headers["Authorization"] = `Bearer ${
-          (body as { oauthAccessToken: string }).oauthAccessToken
-        }`;
-      }
-
-      const httpConfig: HttpServerConfig = {
-        url: guestInput.serverUrl,
-        capabilities: guestInput.clientCapabilities,
-        requestInit: {
-          headers,
-        },
-        timeout: timeoutMs,
-      };
-
-      const manager = new MCPClientManager(
-        { __guest__: httpConfig },
+      const { manager, augmentedBody } = await createGuestEphemeralManager(
+        c,
+        rawBody,
         {
-          defaultTimeout: timeoutMs,
+          timeoutMs: options?.timeoutMs,
           rpcLogger: rpcCollector?.rpcLogger,
-          retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
-        }
+        },
       );
 
       try {
+        const body = parseWithSchema(schema, augmentedBody);
         result = await fn(manager, body as z.infer<S>);
       } finally {
         await manager.disconnectAllServers();

--- a/mcpjam-inspector/server/routes/web/evals.ts
+++ b/mcpjam-inspector/server/routes/web/evals.ts
@@ -5,8 +5,10 @@ import { executeSuiteReplayFromRun } from "../../services/evals/replay-suite-run
 import { runTraceRepairJob } from "../../services/evals/trace-repair-runner.js";
 import { logger } from "../../utils/logger.js";
 import {
+  createGuestEphemeralManager,
   createAuthorizedManager,
   handleRoute,
+  isGuestServerRequestBody,
   parseWithSchema,
   readJsonBody,
   withEphemeralConnection,
@@ -25,6 +27,8 @@ import {
 } from "../shared/evals.js";
 
 const evals = new Hono();
+const GUEST_UNSUPPORTED_MESSAGE =
+  "Not available for guests yet. Sign in to use this.";
 
 const hostedBatchSchema = z.object({
   workspaceId: z.string().min(1),
@@ -99,7 +103,10 @@ evals.post("/run", async (c) =>
         ...body,
         convexAuthToken: assertBearerToken(c),
       }),
-    { rpcLogs: false },
+    {
+      rpcLogs: false,
+      guestUnsupportedMessage: GUEST_UNSUPPORTED_MESSAGE,
+    },
   ),
 );
 
@@ -119,13 +126,52 @@ evals.post("/run-test-case", async (c) =>
 evals.post("/stream-test-case", async (c) => {
   const bearerToken = assertBearerToken(c);
   const rawBody = await readJsonBody<Record<string, unknown>>(c);
+  const WEB_CALL_TIMEOUT_MS = 60_000;
+
+  if (isGuestServerRequestBody(rawBody)) {
+    const { manager, augmentedBody } = await createGuestEphemeralManager(
+      c,
+      rawBody,
+      { timeoutMs: WEB_CALL_TIMEOUT_MS },
+    );
+
+    try {
+      const body = parseWithSchema(
+        hostedRunTestCaseSchema,
+        augmentedBody,
+      ) as z.infer<typeof hostedRunTestCaseSchema>;
+      const stream = await streamEvalTestCaseWithManager(
+        manager,
+        {
+          ...(body as z.infer<typeof hostedRunTestCaseSchema> & {
+            serverIds: string[];
+          }),
+          convexAuthToken: bearerToken,
+        },
+        {
+          onStreamComplete: () => manager.disconnectAllServers(),
+        },
+      );
+
+      return new Response(stream, {
+        headers: {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+      });
+    } catch (error) {
+      await manager.disconnectAllServers();
+      throw error;
+    }
+  }
+
   const body = parseWithSchema(hostedRunTestCaseSchema, rawBody) as z.infer<
     typeof hostedRunTestCaseSchema
   >;
 
   const serverIds = body.serverIds;
   const oauthTokens = body.oauthTokens;
-  const WEB_CALL_TIMEOUT_MS = 60_000;
 
   const { manager } = await createAuthorizedManager(
     bearerToken,


### PR DESCRIPTION
## Summary

This PR lets guests use the eval playground without signing in.

Guests can:
- create eval test cases
- generate test cases
- run a single test case
- use the compare/run view

## Backend

The backend now keeps each guest’s eval data separate.

That means:
- a guest can see their own eval test cases
- another guest cannot see or edit them
- guest evals do not mix with signed-in workspace evals

## Inspector

The inspector now sends guest eval requests using the guest’s temporary MCP server URL.

This matches existing guest behavior in the app:
- guests do not get permanent saved server IDs
- the backend temporarily labels the guest server as `__guest__`
- guest OAuth tokens are passed through to that temporary connection

## Follow-up
This PR does not change guest token/session behavior on browser refresh.

If a guest reloads the page and gets a new guest identity, their saved guest eval data may still appear to disappear after reload.

We’ll handle keeping guest tokens/identity stable across refresh in a follow-up PR.

If you want, I can also tighten this into a slightly more polished PR-description version you can paste as-is.




## Tests

Added tests for:
- guest eval separation
- guest quick runs
- guest Run / Generate / Compare
- blocking guest access to full-suite eval runs
