### PR TITLE
XAA debugger: surface AS capability preflight and error guidance

### DIFF
--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import {
   AlertCircle,
+  AlertTriangle,
   CheckCircle2,
   ChevronDown,
   ChevronRight,
@@ -9,6 +10,8 @@ import {
   Loader2,
   Pencil,
   RotateCcw,
+  ShieldAlert,
+  ShieldCheck,
 } from "lucide-react";
 import { Alert, AlertDescription } from "@mcpjam/design-system/alert";
 import { Badge } from "@mcpjam/design-system/badge";
@@ -32,7 +35,17 @@ import {
 import type {
   XAAFlowState,
   XAAFlowStep,
+  XAAHttpHistoryEntry,
 } from "@/lib/xaa/types";
+import {
+  getXAAErrorGuidance,
+  type XAAErrorAction,
+  type XAAErrorGuidance,
+} from "@/lib/xaa/error-guidance";
+import type {
+  XAACheckStatus,
+  XAACompatibilityReport,
+} from "@/lib/xaa/capability-preflight";
 import {
   NEGATIVE_TEST_MODES,
   NEGATIVE_TEST_MODE_DETAILS,
@@ -61,6 +74,185 @@ interface XAAFlowLoggerProps {
     scope?: string;
     negativeTestMode: XAAFlowState["negativeTestMode"];
   };
+}
+
+function CompatibilityBanner({
+  report,
+}: {
+  report: XAACompatibilityReport;
+}) {
+  const [expanded, setExpanded] = useState(report.overall !== "pass");
+
+  const tone =
+    report.overall === "pass"
+      ? {
+          Icon: ShieldCheck,
+          iconClass: "text-green-600 dark:text-green-400",
+          borderClass: "border-green-500/40",
+          bgClass: "bg-green-500/5",
+          title: "Authorization server looks XAA-ready",
+        }
+      : report.overall === "warn"
+        ? {
+            Icon: AlertTriangle,
+            iconClass: "text-amber-500",
+            borderClass: "border-amber-500/40",
+            bgClass: "bg-amber-500/5",
+            title: "Authorization server capabilities are ambiguous",
+          }
+        : {
+            Icon: ShieldAlert,
+            iconClass: "text-red-500",
+            borderClass: "border-red-500/40",
+            bgClass: "bg-red-500/5",
+            title: "Authorization server isn't XAA-ready",
+          };
+
+  const checkStatusClass = (status: XAACheckStatus) =>
+    status === "pass"
+      ? "text-green-600 dark:text-green-400"
+      : status === "fail"
+        ? "text-red-500"
+        : "text-amber-500";
+
+  const checkStatusSymbol = (status: XAACheckStatus) =>
+    status === "pass" ? "✓" : status === "fail" ? "✗" : "?";
+
+  return (
+    <div
+      className={cn(
+        "rounded-md border px-3 py-2.5 text-xs",
+        tone.borderClass,
+        tone.bgClass,
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        className="flex w-full items-start gap-2 text-left"
+      >
+        <tone.Icon className={cn("h-4 w-4 mt-0.5 shrink-0", tone.iconClass)} />
+        <div className="flex-1 min-w-0 space-y-1">
+          <div className="font-medium text-foreground">{tone.title}</div>
+          {report.vendorHint && (
+            <div className="text-muted-foreground">
+              {report.vendorHint.note}
+            </div>
+          )}
+        </div>
+        {expanded ? (
+          <ChevronDown className="h-3.5 w-3.5 mt-1 text-muted-foreground shrink-0" />
+        ) : (
+          <ChevronRight className="h-3.5 w-3.5 mt-1 text-muted-foreground shrink-0" />
+        )}
+      </button>
+      {expanded && (
+        <ul className="mt-2 space-y-1 border-t border-border/50 pt-2">
+          {report.checks.map((check) => (
+            <li key={check.id} className="flex items-start gap-2">
+              <span
+                className={cn(
+                  "font-mono shrink-0 w-3",
+                  checkStatusClass(check.status),
+                )}
+                aria-hidden
+              >
+                {checkStatusSymbol(check.status)}
+              </span>
+              <div className="min-w-0 flex-1">
+                <span className="font-medium text-foreground">
+                  {check.label}
+                </span>
+                <span className="text-muted-foreground"> — {check.detail}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function GuidanceCallout({
+  guidance,
+  onConfigure,
+  onShowBootstrap,
+  onReset,
+}: {
+  guidance: XAAErrorGuidance;
+  onConfigure?: () => void;
+  onShowBootstrap?: () => void;
+  onReset?: () => void;
+}) {
+  const toneClass =
+    guidance.severity === "error"
+      ? "border-red-500/40 bg-red-500/5"
+      : "border-amber-500/40 bg-amber-500/5";
+  const iconClass =
+    guidance.severity === "error" ? "text-red-500" : "text-amber-500";
+
+  const handleAction = (action: XAAErrorAction) => {
+    if (action.intent === "configure") onConfigure?.();
+    else if (action.intent === "bootstrap") onShowBootstrap?.();
+    else if (action.intent === "reset") onReset?.();
+    else if (action.intent === "link" && action.href) {
+      window.open(action.href, "_blank", "noopener,noreferrer");
+    }
+  };
+
+  const actionDisabled = (action: XAAErrorAction) => {
+    if (action.intent === "configure") return !onConfigure;
+    if (action.intent === "bootstrap") return !onShowBootstrap;
+    if (action.intent === "reset") return !onReset;
+    if (action.intent === "link") return !action.href;
+    return true;
+  };
+
+  return (
+    <div className={cn("rounded-md border px-3 py-2.5 space-y-2", toneClass)}>
+      <div className="flex items-start gap-2">
+        <AlertCircle className={cn("h-4 w-4 mt-0.5 shrink-0", iconClass)} />
+        <div className="flex-1 min-w-0 space-y-1">
+          <div className="text-xs font-semibold text-foreground">
+            {guidance.title}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {guidance.explanation}
+          </div>
+        </div>
+      </div>
+      {guidance.actions.length > 0 && (
+        <div className="flex flex-wrap gap-2 pl-6">
+          {guidance.actions.map((action) => (
+            <Button
+              key={`${action.intent}-${action.label}`}
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-7 text-xs"
+              onClick={() => handleAction(action)}
+              disabled={actionDisabled(action)}
+            >
+              {action.label}
+            </Button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function latestErroredHttpEntry(
+  httpEntries: XAAHttpHistoryEntry[],
+): XAAHttpHistoryEntry | undefined {
+  for (let i = httpEntries.length - 1; i >= 0; i -= 1) {
+    const entry = httpEntries[i];
+    if (entry.error) return entry;
+    if (entry.response && (entry.response.status < 200 || entry.response.status >= 300)) {
+      return entry;
+    }
+  }
+  return undefined;
 }
 
 export function XAAFlowLogger({
@@ -264,14 +456,35 @@ export function XAAFlowLogger({
       </div>
 
       <div className="flex-1 overflow-auto bg-muted/30 p-4 space-y-4">
-        {flowState.error && (
-          <Alert variant="destructive" className="py-2">
-            <AlertCircle className="h-4 w-4" />
-            <AlertDescription className="text-xs">
-              {flowState.error}
-            </AlertDescription>
-          </Alert>
+        {hasProfile && flowState.compatibilityReport && (
+          <CompatibilityBanner report={flowState.compatibilityReport} />
         )}
+
+        {flowState.error &&
+          (() => {
+            const guidance = getXAAErrorGuidance({
+              step: flowState.currentStep,
+              stateError: flowState.error,
+            });
+            if (guidance) {
+              return (
+                <GuidanceCallout
+                  guidance={guidance}
+                  onConfigure={actions.onConfigure}
+                  onShowBootstrap={actions.onShowBootstrap}
+                  onReset={actions.onReset}
+                />
+              );
+            }
+            return (
+              <Alert variant="destructive" className="py-2">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription className="text-xs">
+                  {flowState.error}
+                </AlertDescription>
+              </Alert>
+            );
+          })()}
 
         {flowState.idJag && flowState.idJagDecoded && (
           <IdJagInspector
@@ -376,6 +589,33 @@ export function XAAFlowLogger({
                         ))}
                       </div>
                     ) : null}
+
+                    {(() => {
+                      const erroredEntry = latestErroredHttpEntry(
+                        group.httpEntries,
+                      );
+                      if (!erroredEntry) return null;
+                      const guidance = getXAAErrorGuidance({
+                        step: group.step,
+                        httpEntry: erroredEntry,
+                      });
+                      if (!guidance) return null;
+                      if (
+                        group.step === flowState.currentStep &&
+                        flowState.error
+                      ) {
+                        // Already rendered as the top-level current-step callout.
+                        return null;
+                      }
+                      return (
+                        <GuidanceCallout
+                          guidance={guidance}
+                          onConfigure={actions.onConfigure}
+                          onShowBootstrap={actions.onShowBootstrap}
+                          onReset={actions.onReset}
+                        />
+                      );
+                    })()}
 
                     {group.infoEntries.map((entry) => (
                       <InfoLogEntry

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -79,6 +79,9 @@ function CompatibilityBanner({
   report: XAACompatibilityReport;
 }) {
   const [expanded, setExpanded] = useState(report.overall !== "pass");
+  useEffect(() => {
+    setExpanded(report.overall !== "pass");
+  }, [report.overall]);
 
   const tone =
     report.overall === "pass"

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowLogger.tsx
@@ -32,13 +32,10 @@ import {
   getXAAStepIndex,
   XAA_STEP_ORDER,
 } from "@/lib/xaa/step-metadata";
-import type {
-  XAAFlowState,
-  XAAFlowStep,
-  XAAHttpHistoryEntry,
-} from "@/lib/xaa/types";
+import type { XAAFlowState, XAAFlowStep } from "@/lib/xaa/types";
 import {
   getXAAErrorGuidance,
+  latestErroredHttpEntry,
   type XAAErrorAction,
   type XAAErrorGuidance,
 } from "@/lib/xaa/error-guidance";
@@ -242,18 +239,6 @@ function GuidanceCallout({
   );
 }
 
-function latestErroredHttpEntry(
-  httpEntries: XAAHttpHistoryEntry[],
-): XAAHttpHistoryEntry | undefined {
-  for (let i = httpEntries.length - 1; i >= 0; i -= 1) {
-    const entry = httpEntries[i];
-    if (entry.error) return entry;
-    if (entry.response && (entry.response.status < 200 || entry.response.status >= 300)) {
-      return entry;
-    }
-  }
-  return undefined;
-}
 
 export function XAAFlowLogger({
   flowState,
@@ -460,22 +445,30 @@ export function XAAFlowLogger({
           <CompatibilityBanner report={flowState.compatibilityReport} />
         )}
 
-        {flowState.error &&
-          (() => {
-            const guidance = getXAAErrorGuidance({
-              step: flowState.currentStep,
-              stateError: flowState.error,
-            });
-            if (guidance) {
-              return (
-                <GuidanceCallout
-                  guidance={guidance}
-                  onConfigure={actions.onConfigure}
-                  onShowBootstrap={actions.onShowBootstrap}
-                  onReset={actions.onReset}
-                />
-              );
-            }
+        {(() => {
+          const currentStepHttpEntries = (flowState.httpHistory || []).filter(
+            (entry) => entry.step === flowState.currentStep,
+          );
+          const currentStepErroredEntry = latestErroredHttpEntry(
+            currentStepHttpEntries,
+          );
+          if (!flowState.error && !currentStepErroredEntry) return null;
+          const guidance = getXAAErrorGuidance({
+            step: flowState.currentStep,
+            stateError: flowState.error,
+            httpEntry: currentStepErroredEntry,
+          });
+          if (guidance) {
+            return (
+              <GuidanceCallout
+                guidance={guidance}
+                onConfigure={actions.onConfigure}
+                onShowBootstrap={actions.onShowBootstrap}
+                onReset={actions.onReset}
+              />
+            );
+          }
+          if (flowState.error) {
             return (
               <Alert variant="destructive" className="py-2">
                 <AlertCircle className="h-4 w-4" />
@@ -484,7 +477,9 @@ export function XAAFlowLogger({
                 </AlertDescription>
               </Alert>
             );
-          })()}
+          }
+          return null;
+        })()}
 
         {flowState.idJag && flowState.idJagDecoded && (
           <IdJagInspector
@@ -591,6 +586,10 @@ export function XAAFlowLogger({
                     ) : null}
 
                     {(() => {
+                      if (group.step === flowState.currentStep) {
+                        // Top-level callout covers the current step.
+                        return null;
+                      }
                       const erroredEntry = latestErroredHttpEntry(
                         group.httpEntries,
                       );
@@ -600,13 +599,6 @@ export function XAAFlowLogger({
                         httpEntry: erroredEntry,
                       });
                       if (!guidance) return null;
-                      if (
-                        group.step === flowState.currentStep &&
-                        flowState.error
-                      ) {
-                        // Already rendered as the top-level current-step callout.
-                        return null;
-                      }
                       return (
                         <GuidanceCallout
                           guidance={guidance}

--- a/mcpjam-inspector/client/src/components/xaa/XAASequenceDiagram.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAASequenceDiagram.tsx
@@ -7,8 +7,8 @@ import { buildXAAActions } from "@/lib/xaa/sequence-actions";
 import type { XAAFlowState, XAAFlowStep } from "@/lib/xaa/types";
 
 const XAA_ACTORS = {
-  client: { label: "MCP Client", color: "#10b981" },
-  testIdp: { label: "MCPJam Issuer", color: "#ef4444" },
+  client: { label: "Agent", color: "#10b981" },
+  testIdp: { label: "IdP", color: "#ef4444" },
   mcpServer: { label: "MCP Server", color: "#f59e0b" },
   authServer: { label: "Authorization Server", color: "#3b82f6" },
 };

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/capability-preflight.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/capability-preflight.test.ts
@@ -105,6 +105,20 @@ describe("analyzeAsCompatibility", () => {
     expect(tokenCheck?.status).toBe("fail");
   });
 
+  it("treats an explicitly empty grant_types_supported as fail, not unknown", () => {
+    // An AS that returns an empty array has made a positive declaration
+    // (it supports no grants), which is different from omitting the field.
+    const report = analyzeAsCompatibility({
+      issuer: "https://dev-123.okta.com",
+      token_endpoint: "https://dev-123.okta.com/oauth2/v1/token",
+      grant_types_supported: [],
+    });
+    expect(report?.overall).toBe("fail");
+    const jwtCheck = report?.checks.find((c) => c.id === "jwt_bearer_grant");
+    expect(jwtCheck?.status).toBe("fail");
+    expect(jwtCheck?.detail).toContain("empty array");
+  });
+
   it("relies entirely on the provided issuer for vendor detection", () => {
     // Regression: the state machine must pass its resolvedIssuer (not raw
     // metadata.issuer, which may be absent) into this function, otherwise

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/capability-preflight.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/capability-preflight.test.ts
@@ -104,4 +104,18 @@ describe("analyzeAsCompatibility", () => {
     const tokenCheck = report?.checks.find((c) => c.id === "token_endpoint");
     expect(tokenCheck?.status).toBe("fail");
   });
+
+  it("relies entirely on the provided issuer for vendor detection", () => {
+    // Regression: the state machine must pass its resolvedIssuer (not raw
+    // metadata.issuer, which may be absent) into this function, otherwise
+    // vendor hints are silently lost and WorkOS-known-unsupported would
+    // quietly show as warn instead of fail.
+    const report = analyzeAsCompatibility({
+      issuer: "https://dynamic-echo-14-staging.authkit.app",
+      token_endpoint: "https://dynamic-echo-14-staging.authkit.app/oauth2/token",
+    });
+    expect(report?.vendor).toBe("workos");
+    expect(report?.vendorHint?.verdict).toBe("unsupported");
+    expect(report?.overall).toBe("fail");
+  });
 });

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/capability-preflight.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/capability-preflight.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  analyzeAsCompatibility,
+  detectVendor,
+  JWT_BEARER_GRANT,
+} from "../capability-preflight";
+
+describe("detectVendor", () => {
+  it("identifies okta tenants", () => {
+    expect(detectVendor("https://dev-123.okta.com")).toBe("okta");
+    expect(detectVendor("https://foo.oktapreview.com")).toBe("okta");
+  });
+
+  it("identifies workos / authkit", () => {
+    expect(detectVendor("https://api.workos.com")).toBe("workos");
+    expect(detectVendor("https://dynamic-echo-14-staging.authkit.app")).toBe(
+      "workos",
+    );
+  });
+
+  it("identifies stytch", () => {
+    expect(detectVendor("https://test.stytch.com")).toBe("stytch");
+  });
+
+  it("identifies auth0", () => {
+    expect(detectVendor("https://mytenant.auth0.com")).toBe("auth0");
+  });
+
+  it("identifies keycloak via realm path", () => {
+    expect(
+      detectVendor("https://sso.internal.corp/realms/mcpjam"),
+    ).toBe("keycloak");
+  });
+
+  it("returns unknown for other issuers and for invalid URLs", () => {
+    expect(detectVendor("https://example.com")).toBe("unknown");
+    expect(detectVendor("not-a-url")).toBe("unknown");
+    expect(detectVendor(undefined)).toBe("unknown");
+  });
+});
+
+describe("analyzeAsCompatibility", () => {
+  it("returns null when there is no metadata yet", () => {
+    expect(analyzeAsCompatibility(undefined)).toBeNull();
+  });
+
+  it("passes when jwt-bearer is advertised and a token endpoint exists", () => {
+    const report = analyzeAsCompatibility({
+      issuer: "https://dev-123.okta.com",
+      token_endpoint: "https://dev-123.okta.com/oauth2/v1/token",
+      grant_types_supported: [
+        "authorization_code",
+        "refresh_token",
+        JWT_BEARER_GRANT,
+      ],
+    });
+    expect(report?.overall).toBe("pass");
+    expect(report?.vendor).toBe("okta");
+    expect(report?.vendorHint?.verdict).toBe("native");
+    const jwtCheck = report?.checks.find((c) => c.id === "jwt_bearer_grant");
+    expect(jwtCheck?.status).toBe("pass");
+  });
+
+  it("fails when the AS doesn't advertise jwt-bearer", () => {
+    const report = analyzeAsCompatibility({
+      issuer: "https://dynamic-echo-14-staging.authkit.app",
+      token_endpoint: "https://dynamic-echo-14-staging.authkit.app/oauth2/token",
+      grant_types_supported: ["authorization_code", "refresh_token"],
+    });
+    expect(report?.overall).toBe("fail");
+    expect(report?.vendor).toBe("workos");
+    expect(report?.vendorHint?.verdict).toBe("unsupported");
+    const jwtCheck = report?.checks.find((c) => c.id === "jwt_bearer_grant");
+    expect(jwtCheck?.status).toBe("fail");
+  });
+
+  it("warns when grant_types_supported is missing from metadata", () => {
+    const report = analyzeAsCompatibility({
+      issuer: "https://mytenant.auth0.com",
+      token_endpoint: "https://mytenant.auth0.com/oauth/token",
+    });
+    expect(report?.overall).toBe("warn");
+    expect(report?.vendor).toBe("auth0");
+    const jwtCheck = report?.checks.find((c) => c.id === "jwt_bearer_grant");
+    expect(jwtCheck?.status).toBe("unknown");
+  });
+
+  it("overrides overall to fail when the vendor is known-unsupported, even with missing metadata", () => {
+    const report = analyzeAsCompatibility({
+      issuer: "https://dynamic-echo-14-staging.authkit.app",
+      token_endpoint: "https://dynamic-echo-14-staging.authkit.app/oauth2/token",
+    });
+    expect(report?.overall).toBe("fail");
+    expect(report?.vendorHint?.vendor).toBe("workos");
+  });
+
+  it("flags missing token endpoint", () => {
+    const report = analyzeAsCompatibility({
+      issuer: "https://dev-123.okta.com",
+      token_endpoint: "",
+      grant_types_supported: [JWT_BEARER_GRANT],
+    });
+    expect(report?.overall).toBe("fail");
+    const tokenCheck = report?.checks.find((c) => c.id === "token_endpoint");
+    expect(tokenCheck?.status).toBe("fail");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
@@ -17,13 +17,17 @@ function httpEntry(
   };
 }
 
-function proxyResponse(status: number, upstreamBody: unknown) {
+// The `/proxy/token` endpoint always returns HTTP 200 and wraps the upstream
+// authorization-server response as { status, body }. Tests for jwt_bearer_request
+// must preserve this shape; otherwise the outer-status path masks bugs where
+// we fail to inspect the nested status.
+function proxyResponse(upstreamStatus: number, upstreamBody: unknown) {
   return httpEntry({
     response: {
-      status,
-      statusText: "",
+      status: 200,
+      statusText: "OK",
       headers: {},
-      body: { status, body: upstreamBody },
+      body: { status: upstreamStatus, body: upstreamBody },
     },
   });
 }
@@ -130,6 +134,23 @@ describe("getXAAErrorGuidance", () => {
         "Authorization server rejected the `resource` claim",
       );
     });
+
+    it("extracts the OAuth error code even when error_description is also present", () => {
+      // When the AS returns both `error` and `error_description`, the state
+      // machine's extractErrorMessage prefers the description, so stateError
+      // won't contain the raw code. We must still surface specific guidance
+      // by reading the `error` field out of the proxy-wrapped body.
+      const guidance = getXAAErrorGuidance({
+        step: "jwt_bearer_request",
+        stateError:
+          "Grant type is not supported for this client Does the authorization server trust the synthetic issuer JWKS and support `urn:ietf:params:oauth:grant-type:jwt-bearer`?",
+        httpEntry: proxyResponse(400, {
+          error: "unsupported_grant_type",
+          error_description: "Grant type is not supported for this client",
+        }),
+      });
+      expect(guidance?.title).toContain("doesn't support the jwt-bearer grant");
+    });
   });
 
   describe("discovery steps", () => {
@@ -214,5 +235,49 @@ describe("latestErroredHttpEntry", () => {
     expect(latestErroredHttpEntry([okEntry, networkErrorEntry])).toBe(
       networkErrorEntry,
     );
+  });
+
+  it("detects upstream failure in a proxy-wrapped 200 response (jwt_bearer_request)", () => {
+    // /proxy/token returns outer HTTP 200 but nests the upstream AS status.
+    // We must inspect that nested status, otherwise the wrapped failure is
+    // invisible to error-guidance.
+    const proxyWrappedFailure: XAAHttpHistoryEntry = {
+      step: "jwt_bearer_request",
+      timestamp: 0,
+      request: { method: "POST", url: "/proxy/token", headers: {} },
+      response: {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: {
+          status: 400,
+          body: {
+            error: "unsupported_grant_type",
+            error_description: "Grant type not allowed.",
+          },
+        },
+      },
+    };
+    expect(latestErroredHttpEntry([proxyWrappedFailure])).toBe(
+      proxyWrappedFailure,
+    );
+  });
+
+  it("ignores a proxy-wrapped 200 response when the nested upstream status is a success", () => {
+    const proxyWrappedSuccess: XAAHttpHistoryEntry = {
+      step: "jwt_bearer_request",
+      timestamp: 0,
+      request: { method: "POST", url: "/proxy/token", headers: {} },
+      response: {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: {
+          status: 200,
+          body: { access_token: "abc", token_type: "Bearer" },
+        },
+      },
+    };
+    expect(latestErroredHttpEntry([proxyWrappedSuccess])).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
@@ -115,11 +115,14 @@ describe("getXAAErrorGuidance", () => {
     });
 
     it("does not misclassify unrelated errors that mention 'resource' as invalid_target", () => {
+      // With an httpEntry present, we fall through to the generic AS-failure
+      // card — but we must not pick the invalid_target branch just because
+      // the state error string contains the word "resource".
       const guidance = getXAAErrorGuidance({
         step: "jwt_bearer_request",
         stateError: "Failed to allocate resource pool",
+        httpEntry: proxyResponse(500, {}),
       });
-      expect(guidance?.title).not.toContain("resource");
       expect(guidance?.title).toBe(
         "JWT bearer request failed at the authorization server",
       );
@@ -133,6 +136,31 @@ describe("getXAAErrorGuidance", () => {
       expect(guidance?.title).toBe(
         "Authorization server rejected the `resource` claim",
       );
+    });
+
+    it("handles pre-request validation errors (no httpEntry) as a Reset prompt, not an AS failure", () => {
+      // When the state machine short-circuits because idJag or tokenEndpoint
+      // is missing, no HTTP request was made. Showing "JWT bearer request
+      // failed at the authorization server" with a Register-issuer action
+      // would be factually wrong (and hide the real validation message).
+      const guidance = getXAAErrorGuidance({
+        step: "jwt_bearer_request",
+        stateError:
+          "The flow is missing an ID-JAG or token endpoint. Finish discovery and token exchange first.",
+      });
+      expect(guidance?.title).toBe("ID-JAG or token endpoint missing");
+      expect(guidance?.actions.map((a) => a.intent)).toContain("reset");
+    });
+
+    it("does not produce a generic jwt_bearer card when there is no HTTP attempt at all", () => {
+      // Defensive: any bare stateError for this step without an httpEntry or
+      // failed response should fall through so the raw alert shows the real
+      // message, rather than the misleading AS-side fallback card.
+      const guidance = getXAAErrorGuidance({
+        step: "jwt_bearer_request",
+        stateError: "Something else went wrong before we called the AS.",
+      });
+      expect(guidance).toBeNull();
     });
 
     it("produces a guidance card for a proxy-wrapped upstream failure even without an OAuth error field", () => {

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
@@ -177,6 +177,30 @@ describe("getXAAErrorGuidance", () => {
       expect(guidance).toBeNull();
     });
 
+    it("treats a malformed proxy wrapper (outer 200, missing nested status) as a failure", () => {
+      // State machine's requestAccessToken does:
+      //   if (!upstreamStatus || upstreamStatus < 200 || upstreamStatus >= 300)
+      // so a response lacking a numeric nested status is a failure. Previously
+      // latestErroredHttpEntry / getXAAErrorGuidance didn't detect this and
+      // the user saw a raw error alert instead of a structured card.
+      const guidance = getXAAErrorGuidance({
+        step: "jwt_bearer_request",
+        stateError: "Authorization server returned an unknown status.",
+        httpEntry: httpEntry({
+          step: "jwt_bearer_request",
+          response: {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: { body: { something: "else" } },
+          },
+        }),
+      });
+      expect(guidance?.title).toBe(
+        "JWT bearer request failed at the authorization server",
+      );
+    });
+
     it("produces a guidance card for a proxy-wrapped upstream failure even without an OAuth error field", () => {
       // Outer 200, nested 500, empty body. Previously latestErroredHttpEntry
       // flagged it, but getXAAErrorGuidance only looked at the outer status
@@ -404,6 +428,21 @@ describe("latestErroredHttpEntry", () => {
       },
     };
     expect(latestErroredHttpEntry([proxyWrappedSuccess])).toBeUndefined();
+  });
+
+  it("flags a jwt_bearer proxy response without a numeric nested status (malformed wrapper)", () => {
+    const malformed: XAAHttpHistoryEntry = {
+      step: "jwt_bearer_request",
+      timestamp: 0,
+      request: { method: "POST", url: "/proxy/token", headers: {} },
+      response: {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: { body: { something: "else" } },
+      },
+    };
+    expect(latestErroredHttpEntry([malformed])).toBe(malformed);
   });
 
   it("only inspects nested upstream status for jwt_bearer_request entries", () => {

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getXAAErrorGuidance } from "../error-guidance";
+import { getXAAErrorGuidance, latestErroredHttpEntry } from "../error-guidance";
 import type { XAAHttpHistoryEntry } from "../types";
 
 function httpEntry(
@@ -109,6 +109,27 @@ describe("getXAAErrorGuidance", () => {
       });
       expect(guidance?.title).toContain("doesn't support the jwt-bearer grant");
     });
+
+    it("does not misclassify unrelated errors that mention 'resource' as invalid_target", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "jwt_bearer_request",
+        stateError: "Failed to allocate resource pool",
+      });
+      expect(guidance?.title).not.toContain("resource");
+      expect(guidance?.title).toBe(
+        "JWT bearer request failed at the authorization server",
+      );
+    });
+
+    it("matches invalid_target via explicit upstream error code", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "jwt_bearer_request",
+        httpEntry: proxyResponse(400, { error: "invalid_target" }),
+      });
+      expect(guidance?.title).toBe(
+        "Authorization server rejected the `resource` claim",
+      );
+    });
   });
 
   describe("discovery steps", () => {
@@ -140,5 +161,58 @@ describe("getXAAErrorGuidance", () => {
       });
       expect(guidance?.title).toContain("rejected the access token");
     });
+
+    it("flags 401 responses even when a stateError is also set (bug #3 regression)", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "authenticated_mcp_request",
+        stateError: "Authenticated MCP request failed with 401",
+        httpEntry: httpEntry({
+          step: "authenticated_mcp_request",
+          response: { status: 401, statusText: "", headers: {}, body: {} },
+        }),
+      });
+      expect(guidance?.title).toContain("rejected the access token");
+    });
+  });
+});
+
+describe("latestErroredHttpEntry", () => {
+  const okEntry: XAAHttpHistoryEntry = {
+    step: "discover_authz_metadata",
+    timestamp: 1,
+    request: { method: "GET", url: "/a", headers: {} },
+    response: { status: 200, statusText: "OK", headers: {}, body: {} },
+  };
+  const notFoundEntry: XAAHttpHistoryEntry = {
+    step: "discover_authz_metadata",
+    timestamp: 0,
+    request: { method: "GET", url: "/b", headers: {} },
+    response: { status: 404, statusText: "Not Found", headers: {}, body: {} },
+  };
+  const networkErrorEntry: XAAHttpHistoryEntry = {
+    step: "jwt_bearer_request",
+    timestamp: 0,
+    request: { method: "POST", url: "/proxy/token", headers: {} },
+    error: { message: "network error" },
+  };
+
+  it("returns undefined for an empty list", () => {
+    expect(latestErroredHttpEntry([])).toBeUndefined();
+  });
+
+  it("returns undefined when the final entry succeeded even if earlier ones failed (bug #2 regression)", () => {
+    expect(latestErroredHttpEntry([notFoundEntry, okEntry])).toBeUndefined();
+  });
+
+  it("returns the final entry when it represents a failure", () => {
+    expect(latestErroredHttpEntry([okEntry, notFoundEntry])).toBe(
+      notFoundEntry,
+    );
+  });
+
+  it("returns the final entry when it is a network error", () => {
+    expect(latestErroredHttpEntry([okEntry, networkErrorEntry])).toBe(
+      networkErrorEntry,
+    );
   });
 });

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { getXAAErrorGuidance } from "../error-guidance";
+import type { XAAHttpHistoryEntry } from "../types";
+
+function httpEntry(
+  overrides: Partial<XAAHttpHistoryEntry> = {},
+): XAAHttpHistoryEntry {
+  return {
+    step: "jwt_bearer_request",
+    timestamp: 0,
+    request: {
+      method: "POST",
+      url: "/proxy/token",
+      headers: {},
+    },
+    ...overrides,
+  };
+}
+
+function proxyResponse(status: number, upstreamBody: unknown) {
+  return httpEntry({
+    response: {
+      status,
+      statusText: "",
+      headers: {},
+      body: { status, body: upstreamBody },
+    },
+  });
+}
+
+describe("getXAAErrorGuidance", () => {
+  it("returns null when there is no error signal", () => {
+    expect(
+      getXAAErrorGuidance({ step: "idle" }),
+    ).toBeNull();
+  });
+
+  describe("token_exchange_request", () => {
+    it("flags missing client_id with a Configure action", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "token_exchange_request",
+        stateError: "Client ID is required for the ID-JAG `client_id` claim.",
+      });
+      expect(guidance?.title).toBe("Client ID required");
+      expect(guidance?.severity).toBe("error");
+      expect(guidance?.actions.map((a) => a.intent)).toContain("configure");
+    });
+
+    it("flags missing identity assertion with a Reset action", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "token_exchange_request",
+        stateError: "No identity assertion is available. Complete mock authentication first.",
+      });
+      expect(guidance?.title).toBe("Identity assertion missing");
+      expect(guidance?.actions.map((a) => a.intent)).toContain("reset");
+    });
+
+    it("flags missing authorization server issuer", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "token_exchange_request",
+        stateError: "No authorization server issuer is available for the ID-JAG audience.",
+      });
+      expect(guidance?.title).toBe("Authorization server issuer missing");
+      expect(guidance?.actions.map((a) => a.intent)).toContain("configure");
+    });
+  });
+
+  describe("jwt_bearer_request", () => {
+    it("identifies unsupported_grant_type via upstream body", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "jwt_bearer_request",
+        httpEntry: proxyResponse(400, { error: "unsupported_grant_type" }),
+      });
+      expect(guidance?.title).toContain("doesn't support the jwt-bearer grant");
+      expect(guidance?.severity).toBe("error");
+    });
+
+    it("identifies invalid_client via upstream body", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "jwt_bearer_request",
+        httpEntry: proxyResponse(401, { error: "invalid_client" }),
+      });
+      expect(guidance?.title).toContain("doesn't recognize the client");
+    });
+
+    it("identifies invalid_grant via upstream body", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "jwt_bearer_request",
+        httpEntry: proxyResponse(400, { error: "invalid_grant" }),
+      });
+      expect(guidance?.title).toContain("rejected the ID-JAG assertion");
+      expect(guidance?.actions.map((a) => a.intent)).toContain("bootstrap");
+    });
+
+    it("falls back to a generic JWT-bearer failure card when the error code is unknown", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "jwt_bearer_request",
+        httpEntry: proxyResponse(500, { error: "server_error" }),
+      });
+      expect(guidance?.title).toBe(
+        "JWT bearer request failed at the authorization server",
+      );
+    });
+
+    it("matches state-error strings when upstream body is missing", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "jwt_bearer_request",
+        stateError: "Authorization server returned unsupported_grant_type.",
+      });
+      expect(guidance?.title).toContain("doesn't support the jwt-bearer grant");
+    });
+  });
+
+  describe("discovery steps", () => {
+    it("explains missing RFC 9728 metadata", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "discover_resource_metadata",
+        stateError: "Resource metadata request failed with 404",
+      });
+      expect(guidance?.title).toContain("RFC 9728 metadata");
+    });
+
+    it("explains authorization server discovery failure", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "discover_authz_metadata",
+        stateError: "Authorization server metadata discovery failed.",
+      });
+      expect(guidance?.title).toBe("Authorization server discovery failed");
+    });
+  });
+
+  describe("authenticated_mcp_request", () => {
+    it("flags 401 responses as token rejection", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "authenticated_mcp_request",
+        httpEntry: httpEntry({
+          step: "authenticated_mcp_request",
+          response: { status: 401, statusText: "", headers: {}, body: {} },
+        }),
+      });
+      expect(guidance?.title).toContain("rejected the access token");
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
@@ -298,6 +298,28 @@ describe("getXAAErrorGuidance", () => {
       expect(guidance?.title).toBe("Authorization server discovery failed");
     });
 
+    it("does not show 'discovery failed' for a successful 2xx response paired with a parse stateError", () => {
+      // E.g. the AS returned 200 but the metadata parsed ok then failed a
+      // post-parse check ("did not include a token_endpoint"). The HTTP
+      // request itself succeeded, so the "Neither well-known returned a
+      // valid response" message would be misleading — let the raw Alert
+      // show the specific post-parse error instead.
+      const guidance = getXAAErrorGuidance({
+        step: "discover_authz_metadata",
+        stateError: "Authorization metadata did not include a token_endpoint.",
+        httpEntry: httpEntry({
+          step: "discover_authz_metadata",
+          response: {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: { issuer: "https://as.example.com" },
+          },
+        }),
+      });
+      expect(guidance).toBeNull();
+    });
+
     it("routes the 'issuer is missing' pre-validation error to a specific Configure card, not 'discovery failed'", () => {
       // The state machine short-circuits before any request when no issuer
       // is configured. Showing "Neither well-known returned a valid

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
@@ -135,6 +135,37 @@ describe("getXAAErrorGuidance", () => {
       );
     });
 
+    it("produces a guidance card for a proxy-wrapped upstream failure even without an OAuth error field", () => {
+      // Outer 200, nested 500, empty body. Previously latestErroredHttpEntry
+      // flagged it, but getXAAErrorGuidance only looked at the outer status
+      // and returned null — so the user saw nothing.
+      const guidance = getXAAErrorGuidance({
+        step: "jwt_bearer_request",
+        httpEntry: proxyResponse(500, {}),
+      });
+      expect(guidance?.title).toBe(
+        "JWT bearer request failed at the authorization server",
+      );
+    });
+
+    it("does not treat a non-jwt_bearer step with a status-shaped body as a proxy wrapper", () => {
+      // Another step's body might coincidentally have a `status` field.
+      // We should not interpret that as a failed upstream proxy call.
+      const guidance = getXAAErrorGuidance({
+        step: "user_authentication",
+        httpEntry: httpEntry({
+          step: "user_authentication",
+          response: {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: { status: 500, user: "alice" },
+          },
+        }),
+      });
+      expect(guidance).toBeNull();
+    });
+
     it("extracts the OAuth error code even when error_description is also present", () => {
       // When the AS returns both `error` and `error_description`, the state
       // machine's extractErrorMessage prefers the description, so stateError
@@ -331,5 +362,22 @@ describe("latestErroredHttpEntry", () => {
       },
     };
     expect(latestErroredHttpEntry([proxyWrappedSuccess])).toBeUndefined();
+  });
+
+  it("only inspects nested upstream status for jwt_bearer_request entries", () => {
+    // Another step's body might coincidentally have a numeric `status` field
+    // that doesn't represent HTTP — we shouldn't misread that as a failure.
+    const nonBearerEntry: XAAHttpHistoryEntry = {
+      step: "user_authentication",
+      timestamp: 0,
+      request: { method: "POST", url: "/authenticate", headers: {} },
+      response: {
+        status: 200,
+        statusText: "OK",
+        headers: {},
+        body: { status: 500, user: "alice" },
+      },
+    };
+    expect(latestErroredHttpEntry([nonBearerEntry])).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
@@ -138,6 +138,20 @@ describe("getXAAErrorGuidance", () => {
       );
     });
 
+    it("does not hijack AS errors whose description coincidentally contains 'token endpoint'", () => {
+      // Defensive: an AS error_description like "The token endpoint is not
+      // authorized for this grant type" used to match the pre-validation
+      // check and show the misleading "ID-JAG or token endpoint missing"
+      // card instead of the correct AS-specific guidance.
+      const guidance = getXAAErrorGuidance({
+        step: "jwt_bearer_request",
+        stateError:
+          "The token endpoint is not authorized for this grant type Does the authorization server trust the synthetic issuer JWKS and support `urn:ietf:params:oauth:grant-type:jwt-bearer`?",
+        httpEntry: proxyResponse(400, { error: "unsupported_grant_type" }),
+      });
+      expect(guidance?.title).toContain("doesn't support the jwt-bearer grant");
+    });
+
     it("handles pre-request validation errors (no httpEntry) as a Reset prompt, not an AS failure", () => {
       // When the state machine short-circuits because idJag or tokenEndpoint
       // is missing, no HTTP request was made. Showing "JWT bearer request

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
@@ -194,6 +194,58 @@ describe("getXAAErrorGuidance", () => {
       });
       expect(guidance?.title).toContain("rejected the access token");
     });
+
+    it("surfaces a catch-all card for non-401/403 failures (e.g. 500)", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "authenticated_mcp_request",
+        httpEntry: httpEntry({
+          step: "authenticated_mcp_request",
+          response: {
+            status: 500,
+            statusText: "Internal Server Error",
+            headers: {},
+            body: {},
+          },
+        }),
+      });
+      expect(guidance?.title).toBe("MCP server request failed");
+      expect(guidance?.explanation).toContain("500");
+      expect(guidance?.severity).toBe("error");
+    });
+
+    it("surfaces a network-error variant of the catch-all", () => {
+      const guidance = getXAAErrorGuidance({
+        step: "authenticated_mcp_request",
+        httpEntry: httpEntry({
+          step: "authenticated_mcp_request",
+          error: { message: "fetch failed" },
+        }),
+      });
+      expect(guidance?.title).toBe("MCP server request failed");
+      expect(guidance?.explanation).toContain("network error");
+    });
+  });
+
+  describe("generic HTTP failure fallback", () => {
+    it("surfaces a warning card for a non-2xx response even when no step-specific case matches", () => {
+      // user_authentication 500 isn't specifically handled; the generic
+      // fallback should still produce a callout so the user isn't left
+      // staring at silence.
+      const guidance = getXAAErrorGuidance({
+        step: "user_authentication",
+        httpEntry: httpEntry({
+          step: "user_authentication",
+          response: {
+            status: 500,
+            statusText: "Internal Server Error",
+            headers: {},
+            body: {},
+          },
+        }),
+      });
+      expect(guidance?.title).toBe("Request failed");
+      expect(guidance?.explanation).toContain("500");
+    });
   });
 });
 

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
@@ -259,12 +259,36 @@ describe("getXAAErrorGuidance", () => {
       expect(guidance?.title).toContain("RFC 9728 metadata");
     });
 
-    it("explains authorization server discovery failure", () => {
+    it("explains authorization server discovery failure when a request was actually attempted", () => {
       const guidance = getXAAErrorGuidance({
         step: "discover_authz_metadata",
         stateError: "Authorization server metadata discovery failed.",
+        httpEntry: httpEntry({
+          step: "discover_authz_metadata",
+          response: {
+            status: 404,
+            statusText: "Not Found",
+            headers: {},
+            body: {},
+          },
+        }),
       });
       expect(guidance?.title).toBe("Authorization server discovery failed");
+    });
+
+    it("routes the 'issuer is missing' pre-validation error to a specific Configure card, not 'discovery failed'", () => {
+      // The state machine short-circuits before any request when no issuer
+      // is configured. Showing "Neither well-known returned a valid
+      // response at the configured issuer" would be factually wrong.
+      const guidance = getXAAErrorGuidance({
+        step: "discover_authz_metadata",
+        stateError:
+          "Authorization Server issuer is missing. Configure it manually or retry resource metadata discovery.",
+      });
+      expect(guidance?.title).toBe(
+        "Authorization server issuer not configured",
+      );
+      expect(guidance?.actions.map((a) => a.intent)).toContain("configure");
     });
   });
 

--- a/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/__tests__/error-guidance.test.ts
@@ -250,6 +250,28 @@ describe("getXAAErrorGuidance", () => {
     });
   });
 
+  describe("defensive scoping", () => {
+    it("does not produce a card when a non-jwt_bearer entry coincidentally has a nested body.error field", () => {
+      // A discover_resource_metadata 200 response whose body happens to be
+      // shaped like { body: { error: "..." } }. Previously the extractor
+      // unwrapped body.body regardless of step and surfaced the nested
+      // error, which could drive false "RFC 9728 metadata" guidance.
+      const guidance = getXAAErrorGuidance({
+        step: "discover_resource_metadata",
+        httpEntry: httpEntry({
+          step: "discover_resource_metadata",
+          response: {
+            status: 200,
+            statusText: "OK",
+            headers: {},
+            body: { body: { error: "spooky" } },
+          },
+        }),
+      });
+      expect(guidance).toBeNull();
+    });
+  });
+
   describe("discovery steps", () => {
     it("explains missing RFC 9728 metadata", () => {
       const guidance = getXAAErrorGuidance({

--- a/mcpjam-inspector/client/src/lib/xaa/capability-preflight.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/capability-preflight.ts
@@ -1,0 +1,168 @@
+import type { XAAFlowState } from "./types";
+
+export const JWT_BEARER_GRANT =
+  "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
+export type XAAVendor =
+  | "okta"
+  | "auth0"
+  | "workos"
+  | "stytch"
+  | "keycloak"
+  | "unknown";
+
+export type XAAVendorVerdict = "native" | "unknown" | "unsupported";
+
+export interface XAAVendorHint {
+  vendor: XAAVendor;
+  verdict: XAAVendorVerdict;
+  note: string;
+}
+
+export type XAACheckStatus = "pass" | "fail" | "warn" | "unknown";
+
+export interface XAACompatibilityCheck {
+  id: "jwt_bearer_grant" | "token_endpoint";
+  label: string;
+  status: XAACheckStatus;
+  detail: string;
+}
+
+export type XAACompatibilityVerdict = "pass" | "fail" | "warn";
+
+export interface XAACompatibilityReport {
+  overall: XAACompatibilityVerdict;
+  checks: XAACompatibilityCheck[];
+  vendor: XAAVendor;
+  vendorHint?: XAAVendorHint;
+}
+
+export function detectVendor(issuer: string | undefined): XAAVendor {
+  if (!issuer) return "unknown";
+  let url: URL;
+  try {
+    url = new URL(issuer);
+  } catch {
+    return "unknown";
+  }
+  const host = url.hostname.toLowerCase();
+  if (
+    host.endsWith(".okta.com") ||
+    host.endsWith(".oktapreview.com") ||
+    host.endsWith(".okta-emea.com")
+  ) {
+    return "okta";
+  }
+  if (host.endsWith(".auth0.com") || host.endsWith(".eu.auth0.com")) {
+    return "auth0";
+  }
+  if (host.endsWith(".workos.com") || host.endsWith(".authkit.app")) {
+    return "workos";
+  }
+  if (host.endsWith(".stytch.com") || host.endsWith(".stytch.dev")) {
+    return "stytch";
+  }
+  if (url.pathname.includes("/realms/") || host.startsWith("keycloak.")) {
+    return "keycloak";
+  }
+  return "unknown";
+}
+
+const VENDOR_NOTES: Partial<Record<XAAVendor, XAAVendorHint>> = {
+  okta: {
+    vendor: "okta",
+    verdict: "native",
+    note: "Okta drove the Cross-App Access spec and supports the jwt-bearer grant natively. In your Okta admin console, register MCPJam as a trusted identity issuer using the JWKS URL from Register Issuer.",
+  },
+  auth0: {
+    vendor: "auth0",
+    verdict: "unknown",
+    note: "Auth0 supports the jwt-bearer grant (RFC 7523). You'll need to configure a trusted issuer pointing at MCPJam's JWKS URL and map subjects to Auth0 users.",
+  },
+  keycloak: {
+    vendor: "keycloak",
+    verdict: "unknown",
+    note: "Keycloak supports Token Exchange. Configure a brokered IdP that trusts MCPJam's JWKS and maps claims to realm users.",
+  },
+  workos: {
+    vendor: "workos",
+    verdict: "unsupported",
+    note: "WorkOS AuthKit doesn't currently advertise the jwt-bearer grant or federated issuer trust. Workaround: run a small bridge service that verifies the ID-JAG against MCPJam's JWKS and mints access tokens via the WorkOS admin API.",
+  },
+  stytch: {
+    vendor: "stytch",
+    verdict: "unsupported",
+    note: "Stytch Connected Apps doesn't currently advertise the jwt-bearer grant. A bridge service is the current workaround; ask Stytch support about roadmap plans for XAA.",
+  },
+};
+
+export function analyzeAsCompatibility(
+  authzMetadata: XAAFlowState["authzMetadata"],
+): XAACompatibilityReport | null {
+  if (!authzMetadata) return null;
+
+  const grantTypes = Array.isArray(authzMetadata.grant_types_supported)
+    ? authzMetadata.grant_types_supported
+    : [];
+  const advertisesJwtBearer = grantTypes.includes(JWT_BEARER_GRANT);
+
+  const jwtBearerCheck: XAACompatibilityCheck = advertisesJwtBearer
+    ? {
+        id: "jwt_bearer_grant",
+        label: "JWT-bearer grant (RFC 7523)",
+        status: "pass",
+        detail: `Advertised in grant_types_supported.`,
+      }
+    : grantTypes.length === 0
+      ? {
+          id: "jwt_bearer_grant",
+          label: "JWT-bearer grant (RFC 7523)",
+          status: "unknown",
+          detail:
+            "grant_types_supported is missing from discovery metadata. Support can't be verified without calling the token endpoint.",
+        }
+      : {
+          id: "jwt_bearer_grant",
+          label: "JWT-bearer grant (RFC 7523)",
+          status: "fail",
+          detail: `grant_types_supported does not include ${JWT_BEARER_GRANT}. The authorization server will reject the ID-JAG exchange at step 11.`,
+        };
+
+  const hasTokenEndpoint = Boolean(authzMetadata.token_endpoint);
+  const tokenEndpointCheck: XAACompatibilityCheck = hasTokenEndpoint
+    ? {
+        id: "token_endpoint",
+        label: "Token endpoint",
+        status: "pass",
+        detail: authzMetadata.token_endpoint!,
+      }
+    : {
+        id: "token_endpoint",
+        label: "Token endpoint",
+        status: "fail",
+        detail: "Missing from discovery metadata.",
+      };
+
+  const checks = [jwtBearerCheck, tokenEndpointCheck];
+
+  const vendor = detectVendor(authzMetadata.issuer);
+  const vendorHint = VENDOR_NOTES[vendor];
+
+  let overall: XAACompatibilityVerdict = "pass";
+  if (checks.some((c) => c.status === "fail")) {
+    overall = "fail";
+  } else if (checks.some((c) => c.status === "warn" || c.status === "unknown")) {
+    overall = "warn";
+  }
+
+  if (vendorHint?.verdict === "unsupported") {
+    overall = "fail";
+  }
+
+  return {
+    overall,
+    checks,
+    vendor,
+    vendorHint,
+  };
+}

--- a/mcpjam-inspector/client/src/lib/xaa/capability-preflight.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/capability-preflight.ts
@@ -53,7 +53,7 @@ export function detectVendor(issuer: string | undefined): XAAVendor {
   ) {
     return "okta";
   }
-  if (host.endsWith(".auth0.com") || host.endsWith(".eu.auth0.com")) {
+  if (host.endsWith(".auth0.com")) {
     return "auth0";
   }
   if (host.endsWith(".workos.com") || host.endsWith(".authkit.app")) {

--- a/mcpjam-inspector/client/src/lib/xaa/capability-preflight.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/capability-preflight.ts
@@ -101,8 +101,11 @@ export function analyzeAsCompatibility(
 ): XAACompatibilityReport | null {
   if (!authzMetadata) return null;
 
-  const grantTypes = Array.isArray(authzMetadata.grant_types_supported)
-    ? authzMetadata.grant_types_supported
+  const grantTypesAdvertised = Array.isArray(
+    authzMetadata.grant_types_supported,
+  );
+  const grantTypes = grantTypesAdvertised
+    ? (authzMetadata.grant_types_supported as string[])
     : [];
   const advertisesJwtBearer = grantTypes.includes(JWT_BEARER_GRANT);
 
@@ -113,7 +116,7 @@ export function analyzeAsCompatibility(
         status: "pass",
         detail: `Advertised in grant_types_supported.`,
       }
-    : grantTypes.length === 0
+    : !grantTypesAdvertised
       ? {
           id: "jwt_bearer_grant",
           label: "JWT-bearer grant (RFC 7523)",
@@ -125,7 +128,10 @@ export function analyzeAsCompatibility(
           id: "jwt_bearer_grant",
           label: "JWT-bearer grant (RFC 7523)",
           status: "fail",
-          detail: `grant_types_supported does not include ${JWT_BEARER_GRANT}. The authorization server will reject the ID-JAG exchange at step 11.`,
+          detail:
+            grantTypes.length === 0
+              ? "grant_types_supported is an empty array; the authorization server declares no supported grant types."
+              : `grant_types_supported does not include ${JWT_BEARER_GRANT}. The authorization server will reject the ID-JAG exchange at step 11.`,
         };
 
   const hasTokenEndpoint = Boolean(authzMetadata.token_endpoint);

--- a/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
@@ -1,0 +1,226 @@
+import type { XAAFlowStep, XAAHttpHistoryEntry } from "./types";
+
+export type XAAErrorActionIntent =
+  | "configure"
+  | "bootstrap"
+  | "reset"
+  | "link";
+
+export interface XAAErrorAction {
+  label: string;
+  intent: XAAErrorActionIntent;
+  href?: string;
+}
+
+export interface XAAErrorGuidance {
+  title: string;
+  explanation: string;
+  actions: XAAErrorAction[];
+  severity: "error" | "warning";
+}
+
+export interface XAAErrorGuidanceInput {
+  step: XAAFlowStep;
+  stateError?: string;
+  httpEntry?: XAAHttpHistoryEntry;
+}
+
+const CONFIGURE: XAAErrorAction = {
+  label: "Open Configure Target",
+  intent: "configure",
+};
+
+const REGISTER_ISSUER: XAAErrorAction = {
+  label: "Show issuer registration",
+  intent: "bootstrap",
+};
+
+const RESET_FLOW: XAAErrorAction = { label: "Reset flow", intent: "reset" };
+
+function extractUpstreamBody(entry: XAAHttpHistoryEntry | undefined): unknown {
+  if (!entry?.response?.body) return undefined;
+  const body = entry.response.body;
+  if (body && typeof body === "object" && "body" in (body as Record<string, unknown>)) {
+    return (body as Record<string, unknown>).body;
+  }
+  return body;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+function upstreamOAuthError(entry: XAAHttpHistoryEntry | undefined): string | undefined {
+  const upstream = extractUpstreamBody(entry);
+  const rec = asRecord(upstream);
+  const error = rec?.error;
+  return typeof error === "string" ? error : undefined;
+}
+
+function messageIncludes(haystack: string | undefined, needle: string): boolean {
+  if (!haystack) return false;
+  return haystack.toLowerCase().includes(needle.toLowerCase());
+}
+
+export function getXAAErrorGuidance(
+  input: XAAErrorGuidanceInput,
+): XAAErrorGuidance | null {
+  const { step, stateError, httpEntry } = input;
+  const upstreamError = upstreamOAuthError(httpEntry);
+
+  const responseStatus = httpEntry?.response?.status;
+  const hasFailedResponse =
+    typeof responseStatus === "number" &&
+    (responseStatus < 200 || responseStatus >= 300);
+
+  if (
+    !stateError &&
+    !upstreamError &&
+    !httpEntry?.error &&
+    !hasFailedResponse
+  ) {
+    return null;
+  }
+
+  if (step === "token_exchange_request") {
+    if (messageIncludes(stateError, "client id is required")) {
+      return {
+        title: "Client ID required",
+        explanation:
+          "The ID-JAG needs a `client_id` claim identifying the OAuth client that will present the assertion. This value must also be registered at your authorization server.",
+        actions: [CONFIGURE],
+        severity: "error",
+      };
+    }
+    if (messageIncludes(stateError, "no identity assertion")) {
+      return {
+        title: "Identity assertion missing",
+        explanation:
+          "The mock OIDC authentication step did not produce an ID token. Reset the flow and run it again from the start.",
+        actions: [RESET_FLOW],
+        severity: "error",
+      };
+    }
+    if (messageIncludes(stateError, "no authorization server issuer")) {
+      return {
+        title: "Authorization server issuer missing",
+        explanation:
+          "The ID-JAG `aud` claim needs the target authorization server's issuer URL. Either let the MCP server's RFC 9728 metadata supply it, or set it manually in Configure Target.",
+        actions: [CONFIGURE],
+        severity: "error",
+      };
+    }
+  }
+
+  if (step === "discover_resource_metadata") {
+    return {
+      title: "MCP server did not return RFC 9728 metadata",
+      explanation:
+        "The debugger fetched `/.well-known/oauth-protected-resource` but didn't get a usable response. For XAA to work, the MCP server must publish its `resource` identifier and `authorization_servers` list at this well-known URL. You can also configure the authorization-server issuer manually as a fallback.",
+      actions: [CONFIGURE],
+      severity: "error",
+    };
+  }
+
+  if (step === "discover_authz_metadata") {
+    return {
+      title: "Authorization server discovery failed",
+      explanation:
+        "Neither `/.well-known/oauth-authorization-server` nor `/.well-known/openid-configuration` returned a valid response at the configured issuer. Check the issuer URL for typos, or set the token endpoint manually.",
+      actions: [CONFIGURE],
+      severity: "error",
+    };
+  }
+
+  if (step === "jwt_bearer_request") {
+    if (
+      upstreamError === "unsupported_grant_type" ||
+      messageIncludes(stateError, "unsupported_grant_type")
+    ) {
+      return {
+        title: "Your authorization server doesn't support the jwt-bearer grant",
+        explanation:
+          "The AS returned `unsupported_grant_type`. XAA requires the AS to accept `urn:ietf:params:oauth:grant-type:jwt-bearer` (RFC 7523). Most ASes don't yet — Okta does natively, Auth0/Keycloak with config, WorkOS/Stytch currently don't. Common workaround: run a small bridge service that accepts the ID-JAG, validates it against MCPJam's JWKS, and mints tokens via your AS's admin API.",
+        actions: [REGISTER_ISSUER],
+        severity: "error",
+      };
+    }
+    if (
+      upstreamError === "invalid_client" ||
+      upstreamError === "unauthorized_client" ||
+      messageIncludes(stateError, "invalid_client") ||
+      messageIncludes(stateError, "unauthorized_client")
+    ) {
+      return {
+        title: "Authorization server doesn't recognize the client",
+        explanation:
+          "The AS rejected the `client_id` in the ID-JAG. Either it isn't registered at your AS, or it isn't authorized for the jwt-bearer grant. Register the client in the AS admin console and confirm it's allowed to present assertions.",
+        actions: [CONFIGURE],
+        severity: "error",
+      };
+    }
+    if (
+      upstreamError === "invalid_grant" ||
+      messageIncludes(stateError, "invalid_grant")
+    ) {
+      return {
+        title: "Authorization server rejected the ID-JAG assertion",
+        explanation:
+          "The AS accepted the grant type but rejected the assertion itself. Likely causes: (1) the AS doesn't trust MCPJam as an issuer — register the JWKS URL; (2) `aud` doesn't match the AS's own issuer; (3) `resource` isn't a registered resource; (4) the token is expired; (5) a negative-test mode is active.",
+        actions: [REGISTER_ISSUER],
+        severity: "error",
+      };
+    }
+    if (
+      upstreamError === "invalid_target" ||
+      messageIncludes(stateError, "invalid_target") ||
+      messageIncludes(stateError, "resource")
+    ) {
+      return {
+        title: "Authorization server rejected the `resource` claim",
+        explanation:
+          "The `resource` value in the ID-JAG isn't a resource the AS is configured to issue tokens for. Register the MCP server's canonical URL as a resource indicator at your AS.",
+        actions: [CONFIGURE],
+        severity: "error",
+      };
+    }
+    // Generic jwt_bearer fallback
+    return {
+      title: "JWT bearer request failed at the authorization server",
+      explanation:
+        "The AS returned a non-success response. Expand the HTTP entry below for the raw body, then check: (1) AS supports the jwt-bearer grant, (2) AS trusts MCPJam's JWKS, (3) `client_id` is registered, (4) `resource` is recognized.",
+      actions: [REGISTER_ISSUER],
+      severity: "error",
+    };
+  }
+
+  if (step === "authenticated_mcp_request") {
+    const status = httpEntry?.response?.status;
+    if (status === 401 || status === 403) {
+      return {
+        title: "MCP server rejected the access token",
+        explanation:
+          "The AS issued an access token, but the MCP server won't accept it. Usually the `resource` or `aud` claim on the access token doesn't match the MCP server's canonical resource URL. Confirm the AS is binding tokens to the correct resource indicator.",
+        actions: [],
+        severity: "error",
+      };
+    }
+  }
+
+  // Generic http failure fallback
+  if (httpEntry?.error) {
+    return {
+      title: "Request failed",
+      explanation:
+        httpEntry.error.message ||
+        "The request did not complete. Check network connectivity and CORS settings.",
+      actions: [],
+      severity: "warning",
+    };
+  }
+
+  return null;
+}

--- a/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
@@ -196,9 +196,12 @@ export function getXAAErrorGuidance(
   if (step === "jwt_bearer_request") {
     // Pre-request validation: no HTTP call was made. Don't claim the AS
     // rejected anything — the state machine set an error before contact.
+    // Guard on !httpEntry (pre-validation never has one) AND match the full
+    // state-machine phrase so an AS error_description that happens to
+    // contain "token endpoint" doesn't hijack this branch.
     if (
-      messageIncludes(stateError, "missing an ID-JAG") ||
-      messageIncludes(stateError, "token endpoint")
+      !httpEntry &&
+      messageIncludes(stateError, "missing an ID-JAG or token endpoint")
     ) {
       return {
         title: "ID-JAG or token endpoint missing",

--- a/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
@@ -194,6 +194,21 @@ export function getXAAErrorGuidance(
   }
 
   if (step === "jwt_bearer_request") {
+    // Pre-request validation: no HTTP call was made. Don't claim the AS
+    // rejected anything — the state machine set an error before contact.
+    if (
+      messageIncludes(stateError, "missing an ID-JAG") ||
+      messageIncludes(stateError, "missing an id-jag") ||
+      messageIncludes(stateError, "token endpoint")
+    ) {
+      return {
+        title: "ID-JAG or token endpoint missing",
+        explanation:
+          "Token exchange or authorization-server discovery hasn't completed yet, so there's nothing to send. Reset the flow and run it from the start.",
+        actions: [RESET_FLOW],
+        severity: "error",
+      };
+    }
     if (
       upstreamError === "unsupported_grant_type" ||
       messageIncludes(stateError, "unsupported_grant_type")
@@ -244,14 +259,19 @@ export function getXAAErrorGuidance(
         severity: "error",
       };
     }
-    // Generic jwt_bearer fallback
-    return {
-      title: "JWT bearer request failed at the authorization server",
-      explanation:
-        "The AS returned a non-success response. Expand the HTTP entry below for the raw body, then check: (1) AS supports the jwt-bearer grant, (2) AS trusts MCPJam's JWKS, (3) `client_id` is registered, (4) `resource` is recognized.",
-      actions: [REGISTER_ISSUER],
-      severity: "error",
-    };
+    // Generic jwt_bearer fallback — only claim an AS-side failure if we
+    // actually made the request. Pre-condition validation errors have no
+    // httpEntry and should fall through to the raw error alert so the user
+    // sees the real message instead of a misleading AS-failure card.
+    if (hasFailedResponse || upstreamError || httpEntry?.error) {
+      return {
+        title: "JWT bearer request failed at the authorization server",
+        explanation:
+          "The AS returned a non-success response. Expand the HTTP entry below for the raw body, then check: (1) AS supports the jwt-bearer grant, (2) AS trusts MCPJam's JWKS, (3) `client_id` is registered, (4) `resource` is recognized.",
+        actions: [REGISTER_ISSUER],
+        severity: "error",
+      };
+    }
   }
 
   if (step === "authenticated_mcp_request") {

--- a/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
@@ -247,15 +247,29 @@ export function getXAAErrorGuidance(
         severity: "error",
       };
     }
+    if (hasFailedResponse || httpEntry?.error) {
+      return {
+        title: "MCP server request failed",
+        explanation: `The authenticated MCP call ${
+          status ? `returned ${status}` : "failed with a network error"
+        }. Expand the HTTP entry below for the raw response, then check the MCP server logs for why it rejected the request.`,
+        actions: [],
+        severity: "error",
+      };
+    }
   }
 
-  // Generic http failure fallback
-  if (httpEntry?.error) {
+  // Generic HTTP failure fallback — catches any step that hit a non-2xx
+  // response without a more specific case above, so users don't see a blank
+  // response to a known failure.
+  if (hasFailedResponse || httpEntry?.error) {
     return {
       title: "Request failed",
       explanation:
-        httpEntry.error.message ||
-        "The request did not complete. Check network connectivity and CORS settings.",
+        httpEntry?.error?.message ||
+        (responseStatus
+          ? `The request returned ${responseStatus}. Expand the HTTP entry below for details.`
+          : "The request did not complete. Check network connectivity and CORS settings."),
       actions: [],
       severity: "warning",
     };

--- a/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
@@ -21,7 +21,9 @@ function nestedUpstreamStatus(entry: XAAHttpHistoryEntry): number | undefined {
  *
  * For `jwt_bearer_request`, the `/proxy/token` endpoint always returns HTTP 200
  * and wraps the upstream authorization-server response in `{status, body}`, so
- * we also inspect the nested upstream status to detect failure.
+ * we also inspect the nested upstream status to detect failure. We scope that
+ * inspection to `jwt_bearer_request` because other steps could coincidentally
+ * return a body with a `status` field that doesn't mean HTTP status.
  */
 export function latestErroredHttpEntry(
   httpEntries: readonly XAAHttpHistoryEntry[],
@@ -33,9 +35,11 @@ export function latestErroredHttpEntry(
   if (last.response.status < 200 || last.response.status >= 300) {
     return last;
   }
-  const nested = nestedUpstreamStatus(last);
-  if (nested !== undefined && (nested < 200 || nested >= 300)) {
-    return last;
+  if (last.step === "jwt_bearer_request") {
+    const nested = nestedUpstreamStatus(last);
+    if (nested !== undefined && (nested < 200 || nested >= 300)) {
+      return last;
+    }
   }
   return undefined;
 }
@@ -112,9 +116,23 @@ export function getXAAErrorGuidance(
   const upstreamError = upstreamOAuthError(httpEntry);
 
   const responseStatus = httpEntry?.response?.status;
-  const hasFailedResponse =
+  const upstreamStatus =
+    step === "jwt_bearer_request" && httpEntry
+      ? nestedUpstreamStatus(httpEntry)
+      : undefined;
+  const hasFailedOuterResponse =
     typeof responseStatus === "number" &&
     (responseStatus < 200 || responseStatus >= 300);
+  const hasFailedUpstreamResponse =
+    typeof upstreamStatus === "number" &&
+    (upstreamStatus < 200 || upstreamStatus >= 300);
+  const hasFailedResponse =
+    hasFailedOuterResponse || hasFailedUpstreamResponse;
+  const failedStatus = hasFailedUpstreamResponse
+    ? upstreamStatus
+    : hasFailedOuterResponse
+      ? responseStatus
+      : undefined;
 
   if (
     !stateError &&
@@ -267,8 +285,8 @@ export function getXAAErrorGuidance(
       title: "Request failed",
       explanation:
         httpEntry?.error?.message ||
-        (responseStatus
-          ? `The request returned ${responseStatus}. Expand the HTTP entry below for details.`
+        (typeof failedStatus === "number"
+          ? `The request returned ${failedStatus}. Expand the HTTP entry below for details.`
           : "The request did not complete. Check network connectivity and CORS settings."),
       actions: [],
       severity: "warning",

--- a/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
@@ -118,7 +118,14 @@ export function getXAAErrorGuidance(
   input: XAAErrorGuidanceInput,
 ): XAAErrorGuidance | null {
   const { step, stateError, httpEntry } = input;
-  const upstreamError = upstreamOAuthError(httpEntry);
+  // Only the /proxy/token call for jwt_bearer_request has the
+  // `{status, body}` wrapper shape we unwrap to extract an OAuth `error`
+  // code. Scoping avoids false signals when another step's body
+  // coincidentally contains a nested `body.error` field.
+  const upstreamError =
+    step === "jwt_bearer_request"
+      ? upstreamOAuthError(httpEntry)
+      : undefined;
 
   const responseStatus = httpEntry?.response?.status;
   const upstreamStatus =
@@ -175,13 +182,18 @@ export function getXAAErrorGuidance(
   }
 
   if (step === "discover_resource_metadata") {
-    return {
-      title: "MCP server did not return RFC 9728 metadata",
-      explanation:
-        "The debugger fetched `/.well-known/oauth-protected-resource` but didn't get a usable response. For XAA to work, the MCP server must publish its `resource` identifier and `authorization_servers` list at this well-known URL. You can also configure the authorization-server issuer manually as a fallback.",
-      actions: [CONFIGURE],
-      severity: "error",
-    };
+    // Only fire when there's an actual failure signal — the function's
+    // contract is "returns guidance for a failure", and a caller that
+    // passed a successful entry shouldn't get a card back.
+    if (stateError || hasFailedResponse) {
+      return {
+        title: "MCP server did not return RFC 9728 metadata",
+        explanation:
+          "The debugger fetched `/.well-known/oauth-protected-resource` but didn't get a usable response. For XAA to work, the MCP server must publish its `resource` identifier and `authorization_servers` list at this well-known URL. You can also configure the authorization-server issuer manually as a fallback.",
+        actions: [CONFIGURE],
+        severity: "error",
+      };
+    }
   }
 
   if (step === "discover_authz_metadata") {

--- a/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
@@ -1,9 +1,27 @@
 import type { XAAFlowStep, XAAHttpHistoryEntry } from "./types";
 
+function nestedUpstreamStatus(entry: XAAHttpHistoryEntry): number | undefined {
+  const body = entry.response?.body;
+  if (
+    body &&
+    typeof body === "object" &&
+    !Array.isArray(body) &&
+    "status" in (body as Record<string, unknown>)
+  ) {
+    const nested = (body as Record<string, unknown>).status;
+    if (typeof nested === "number") return nested;
+  }
+  return undefined;
+}
+
 /**
  * Returns the last HTTP entry for a step only if that final entry represents a
  * failure. If the step retried and a later attempt succeeded, returns undefined
  * — we don't want to show error guidance for a step whose outcome was success.
+ *
+ * For `jwt_bearer_request`, the `/proxy/token` endpoint always returns HTTP 200
+ * and wraps the upstream authorization-server response in `{status, body}`, so
+ * we also inspect the nested upstream status to detect failure.
  */
 export function latestErroredHttpEntry(
   httpEntries: readonly XAAHttpHistoryEntry[],
@@ -11,10 +29,12 @@ export function latestErroredHttpEntry(
   if (httpEntries.length === 0) return undefined;
   const last = httpEntries[httpEntries.length - 1];
   if (last.error) return last;
-  if (
-    last.response &&
-    (last.response.status < 200 || last.response.status >= 300)
-  ) {
+  if (!last.response) return undefined;
+  if (last.response.status < 200 || last.response.status >= 300) {
+    return last;
+  }
+  const nested = nestedUpstreamStatus(last);
+  if (nested !== undefined && (nested < 200 || nested >= 300)) {
     return last;
   }
   return undefined;

--- a/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
@@ -1,5 +1,25 @@
 import type { XAAFlowStep, XAAHttpHistoryEntry } from "./types";
 
+/**
+ * Returns the last HTTP entry for a step only if that final entry represents a
+ * failure. If the step retried and a later attempt succeeded, returns undefined
+ * — we don't want to show error guidance for a step whose outcome was success.
+ */
+export function latestErroredHttpEntry(
+  httpEntries: readonly XAAHttpHistoryEntry[],
+): XAAHttpHistoryEntry | undefined {
+  if (httpEntries.length === 0) return undefined;
+  const last = httpEntries[httpEntries.length - 1];
+  if (last.error) return last;
+  if (
+    last.response &&
+    (last.response.status < 200 || last.response.status >= 300)
+  ) {
+    return last;
+  }
+  return undefined;
+}
+
 export type XAAErrorActionIntent =
   | "configure"
   | "bootstrap"
@@ -176,8 +196,7 @@ export function getXAAErrorGuidance(
     }
     if (
       upstreamError === "invalid_target" ||
-      messageIncludes(stateError, "invalid_target") ||
-      messageIncludes(stateError, "resource")
+      messageIncludes(stateError, "invalid_target")
     ) {
       return {
         title: "Authorization server rejected the `resource` claim",

--- a/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
@@ -15,33 +15,38 @@ function nestedUpstreamStatus(entry: XAAHttpHistoryEntry): number | undefined {
 }
 
 /**
+ * Returns true when the entry represents a failed attempt by the same rules
+ * the state machine uses, including the `/proxy/token` wrapper shape used by
+ * `jwt_bearer_request`:
+ *
+ *   - transport-level error          → failed
+ *   - outer HTTP status is non-2xx   → failed
+ *   - jwt_bearer proxy wrapper with  → failed  (matches state machine's
+ *     missing / non-numeric / non-2xx  `if (!upstreamStatus || upstreamStatus
+ *     nested status                    < 200 || upstreamStatus >= 300)`)
+ */
+function isEffectivelyFailed(entry: XAAHttpHistoryEntry): boolean {
+  if (entry.error) return true;
+  if (!entry.response) return false;
+  if (entry.response.status < 200 || entry.response.status >= 300) return true;
+  if (entry.step === "jwt_bearer_request") {
+    const nested = nestedUpstreamStatus(entry);
+    if (nested === undefined || nested < 200 || nested >= 300) return true;
+  }
+  return false;
+}
+
+/**
  * Returns the last HTTP entry for a step only if that final entry represents a
  * failure. If the step retried and a later attempt succeeded, returns undefined
  * — we don't want to show error guidance for a step whose outcome was success.
- *
- * For `jwt_bearer_request`, the `/proxy/token` endpoint always returns HTTP 200
- * and wraps the upstream authorization-server response in `{status, body}`, so
- * we also inspect the nested upstream status to detect failure. We scope that
- * inspection to `jwt_bearer_request` because other steps could coincidentally
- * return a body with a `status` field that doesn't mean HTTP status.
  */
 export function latestErroredHttpEntry(
   httpEntries: readonly XAAHttpHistoryEntry[],
 ): XAAHttpHistoryEntry | undefined {
   if (httpEntries.length === 0) return undefined;
   const last = httpEntries[httpEntries.length - 1];
-  if (last.error) return last;
-  if (!last.response) return undefined;
-  if (last.response.status < 200 || last.response.status >= 300) {
-    return last;
-  }
-  if (last.step === "jwt_bearer_request") {
-    const nested = nestedUpstreamStatus(last);
-    if (nested !== undefined && (nested < 200 || nested >= 300)) {
-      return last;
-    }
-  }
-  return undefined;
+  return isEffectivelyFailed(last) ? last : undefined;
 }
 
 export type XAAErrorActionIntent =
@@ -120,26 +125,22 @@ export function getXAAErrorGuidance(
     step === "jwt_bearer_request" && httpEntry
       ? nestedUpstreamStatus(httpEntry)
       : undefined;
-  const hasFailedOuterResponse =
-    typeof responseStatus === "number" &&
-    (responseStatus < 200 || responseStatus >= 300);
-  const hasFailedUpstreamResponse =
+  const hasFailedResponse = httpEntry
+    ? isEffectivelyFailed(httpEntry)
+    : false;
+  // The numeric status to show in fallback messages. Prefer upstream (from the
+  // proxy wrapper) over outer; leave undefined when the failure mode is a
+  // malformed proxy wrapper without a numeric nested status.
+  const failedStatus =
     typeof upstreamStatus === "number" &&
-    (upstreamStatus < 200 || upstreamStatus >= 300);
-  const hasFailedResponse =
-    hasFailedOuterResponse || hasFailedUpstreamResponse;
-  const failedStatus = hasFailedUpstreamResponse
-    ? upstreamStatus
-    : hasFailedOuterResponse
-      ? responseStatus
-      : undefined;
+    (upstreamStatus < 200 || upstreamStatus >= 300)
+      ? upstreamStatus
+      : typeof responseStatus === "number" &&
+          (responseStatus < 200 || responseStatus >= 300)
+        ? responseStatus
+        : undefined;
 
-  if (
-    !stateError &&
-    !upstreamError &&
-    !httpEntry?.error &&
-    !hasFailedResponse
-  ) {
+  if (!stateError && !upstreamError && !hasFailedResponse) {
     return null;
   }
 

--- a/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
@@ -185,13 +185,30 @@ export function getXAAErrorGuidance(
   }
 
   if (step === "discover_authz_metadata") {
-    return {
-      title: "Authorization server discovery failed",
-      explanation:
-        "Neither `/.well-known/oauth-authorization-server` nor `/.well-known/openid-configuration` returned a valid response at the configured issuer. Check the issuer URL for typos, or set the token endpoint manually.",
-      actions: [CONFIGURE],
-      severity: "error",
-    };
+    // Pre-validation: the state machine short-circuits here when the issuer
+    // is missing, without making any request. Don't claim "discovery failed"
+    // — no discovery was attempted.
+    if (
+      !httpEntry &&
+      messageIncludes(stateError, "authorization server issuer is missing")
+    ) {
+      return {
+        title: "Authorization server issuer not configured",
+        explanation:
+          "No authorization-server issuer is set, and the MCP server's RFC 9728 metadata didn't supply one. Configure it manually in Configure Target, or fix the MCP server so it lists `authorization_servers`.",
+        actions: [CONFIGURE],
+        severity: "error",
+      };
+    }
+    if (httpEntry || hasFailedResponse) {
+      return {
+        title: "Authorization server discovery failed",
+        explanation:
+          "Neither `/.well-known/oauth-authorization-server` nor `/.well-known/openid-configuration` returned a valid response at the configured issuer. Check the issuer URL for typos, or set the token endpoint manually.",
+        actions: [CONFIGURE],
+        severity: "error",
+      };
+    }
   }
 
   if (step === "jwt_bearer_request") {

--- a/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
@@ -212,7 +212,7 @@ export function getXAAErrorGuidance(
         severity: "error",
       };
     }
-    if (httpEntry || hasFailedResponse) {
+    if (hasFailedResponse) {
       return {
         title: "Authorization server discovery failed",
         explanation:

--- a/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/error-guidance.ts
@@ -198,7 +198,6 @@ export function getXAAErrorGuidance(
     // rejected anything — the state machine set an error before contact.
     if (
       messageIncludes(stateError, "missing an ID-JAG") ||
-      messageIncludes(stateError, "missing an id-jag") ||
       messageIncludes(stateError, "token endpoint")
     ) {
       return {

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -16,6 +16,7 @@ import type {
   XAAStateMachine,
 } from "./types";
 import { createInitialXAAFlowState } from "./types";
+import { analyzeAsCompatibility } from "./capability-preflight";
 
 interface AddInfoLogOptions {
   level?: InfoLogLevel;
@@ -636,11 +637,16 @@ export function createXAAStateMachine(
         const resolvedIssuer =
           typeof metadata.issuer === "string" ? metadata.issuer : issuer;
 
+        const compatibilityReport = analyzeAsCompatibility(
+          metadata as XAAFlowState["authzMetadata"],
+        );
+
         machine.updateState({
           currentStep: "received_authz_metadata",
           authzMetadata: metadata as XAAFlowState["authzMetadata"],
           authzServerIssuer: resolvedIssuer,
           tokenEndpoint: metadata.token_endpoint,
+          compatibilityReport: compatibilityReport ?? undefined,
           error: undefined,
         });
 
@@ -652,6 +658,12 @@ export function createXAAStateMachine(
             issuer: resolvedIssuer,
             token_endpoint: metadata.token_endpoint,
             grant_types_supported: metadata.grant_types_supported,
+            compatibility: compatibilityReport
+              ? {
+                  overall: compatibilityReport.overall,
+                  vendor: compatibilityReport.vendor,
+                }
+              : undefined,
           },
         );
 

--- a/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/state-machine.ts
@@ -637,9 +637,13 @@ export function createXAAStateMachine(
         const resolvedIssuer =
           typeof metadata.issuer === "string" ? metadata.issuer : issuer;
 
-        const compatibilityReport = analyzeAsCompatibility(
-          metadata as XAAFlowState["authzMetadata"],
-        );
+        // Use the resolved issuer — not raw metadata.issuer which may be
+        // absent from the AS response — so vendor detection always has a
+        // hostname to match against.
+        const compatibilityReport = analyzeAsCompatibility({
+          ...(metadata as XAAFlowState["authzMetadata"]),
+          issuer: resolvedIssuer,
+        });
 
         machine.updateState({
           currentStep: "received_authz_metadata",

--- a/mcpjam-inspector/client/src/lib/xaa/types.ts
+++ b/mcpjam-inspector/client/src/lib/xaa/types.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_NEGATIVE_TEST_MODE,
   type NegativeTestMode,
 } from "@/shared/xaa.js";
+import type { XAACompatibilityReport } from "./capability-preflight";
 
 export type XAAFlowStep =
   | "idle"
@@ -112,6 +113,7 @@ export interface XAAFlowState {
   httpHistory?: Array<XAAHttpHistoryEntry>;
   infoLogs?: Array<XAAInfoLogEntry>;
   error?: string;
+  compatibilityReport?: XAACompatibilityReport;
 }
 
 export interface XAARequestResult {
@@ -182,6 +184,7 @@ export const EMPTY_XAA_FLOW_STATE: XAAFlowState = {
   httpHistory: [],
   infoLogs: [],
   error: undefined,
+  compatibilityReport: undefined,
 };
 
 export function createInitialXAAFlowState(


### PR DESCRIPTION
## Summary

Two UX aids + one rename, all in the XAA debugger tab, to make it obvious to MCP-server developers what's wrong with their setup when the flow fails:

- **AS capability preflight banner** — after step 4 (authorization-server discovery), the UI shows a green/amber/red banner that checks whether the AS advertises the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant (RFC 7523) and tags known vendors. Catches WorkOS / Stytch / Entra / Cognito before the user runs into step 11, instead of after. Okta gets flagged as native; Auth0 / Keycloak as supported-with-config; WorkOS / Stytch as unsupported with a bridge-service hint.
- **Error-to-action translator** — missing Client ID, missing identity assertion, `unsupported_grant_type`, `invalid_client`, `invalid_grant`, `invalid_target`, 401 on the authenticated MCP call, etc. each render a guidance callout with a plain-English explanation and action buttons (Configure Target / Register issuer / Reset) instead of a raw error string.
- **Sequence-diagram rename** — swimlanes are now `Agent`, `IdP`, `MCP Server`, `Authorization Server` (spec-canonical XAA terminology). The old labels (`MCP Client`, `MCPJam Issuer`) mis-framed a simple form-validation error as an IdP-side error.

### Context

A developer using the debugger against a WorkOS-backed MCP server hit `Client ID is required for the ID-JAG 'client_id' claim` and couldn't tell whether the issue was the form, their AS, or MCPJam. Root causes: (a) the debugger surfaces technical errors without guidance; (b) the AS ultimately wouldn't have worked anyway because WorkOS doesn't advertise the jwt-bearer grant — but that was invisible. These changes catch both failure modes up-front.

### Files

- New: `client/src/lib/xaa/capability-preflight.ts` — pure function `analyzeAsCompatibility()` + `detectVendor()`, plus Okta/Auth0/Keycloak/WorkOS/Stytch hint catalog.
- New: `client/src/lib/xaa/error-guidance.ts` — pure function `getXAAErrorGuidance()` keyed on `(step, stateError, httpEntry)`.
- Edit: `client/src/lib/xaa/types.ts` — added `compatibilityReport?` to `XAAFlowState`.
- Edit: `client/src/lib/xaa/state-machine.ts` — invokes preflight after `received_authz_metadata`.
- Edit: `client/src/components/xaa/XAAFlowLogger.tsx` — renders `CompatibilityBanner` + `GuidanceCallout` (both inline helper components, ~180 lines).
- Edit: `client/src/components/xaa/XAASequenceDiagram.tsx` — four-line label rename.
- New tests: 12 cases for error-guidance, 12 for capability-preflight.

### Deferred

Bridge-service scaffold generator, Conformance-tab extension, full per-vendor copy-paste setup guides, register-issuer config generator. These are bigger surface areas that deserve their own PRs once this ships.

## Test plan

- [x] `npx vitest run client/src/lib/xaa/__tests__/` — 26/26 pass (2 existing + 24 new).
- [x] `npx vitest run` for the XAA suites server-side (xaa-idjag-signer, routes/mcp/xaa, routes/web/xaa) — all green.
- [x] `tsc --noEmit` clean on every XAA source file touched.
- [ ] Manual UI verification (couldn't run `npm run build:client` / dev server in this worktree — deps weren't installed). Scenarios to exercise:
  - [ ] Sequence diagram swimlanes show `Agent`, `IdP`, `MCP Server`, `Authorization Server`.
  - [ ] Leaving Client ID blank surfaces the "Client ID required" guidance card with an **Open Configure Target** button.
  - [ ] Pointing at a WorkOS-backed MCP server (e.g. `mcp-staging.mcpjam.com/mcp`) surfaces a red `Authorization server isn't XAA-ready` banner with the WorkOS-specific note after step 4.
  - [ ] Pointing at an Okta issuer turns the banner green with the Okta native-support note.
  - [ ] A simulated `unsupported_grant_type` or `invalid_grant` at step 11 renders the matching guidance callout with the Register-Issuer action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new state-derived UX and error classification logic to the XAA debugger flow; incorrect matching or proxy-wrapper handling could mislead users or hide real errors, but changes are isolated to debugging UI/state.
> 
> **Overview**
> Improves the XAA debugger UX by adding an authorization-server capability preflight: after AS discovery, the state machine computes a `compatibilityReport` (JWT-bearer grant + token endpoint checks plus vendor hints) and the flow logger shows it as a collapsible green/amber/red `CompatibilityBanner`.
> 
> Replaces raw error-only messaging with step-aware guidance callouts (`getXAAErrorGuidance` + `latestErroredHttpEntry`) that translate common XAA failures—especially `/proxy/token` proxy-wrapped upstream errors—into actionable explanations and buttons (configure target, register issuer, reset), including for prior-step failures.
> 
> Renames XAA sequence diagram swimlane labels to spec-aligned terminology (`Agent`, `IdP`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa2569ce39dd2b237cbc25d52f09a385db90c534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->