### PR TITLE
Redirect Electron OAuth to browser 

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -44,6 +44,7 @@ import { OrganizationsTab } from "./components/OrganizationsTab";
 import { SupportTab } from "./components/SupportTab";
 import { RegistryTab } from "./components/RegistryTab";
 import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
+import OAuthDesktopReturnNotice from "./components/oauth/OAuthDesktopReturnNotice";
 import { MCPSidebar } from "./components/mcp-sidebar";
 import { SidebarInset, SidebarProvider } from "./components/ui/sidebar";
 import {
@@ -167,6 +168,7 @@ import {
   completeHostedOAuthCallback,
   handleOAuthCallback,
 } from "./lib/oauth/mcp-oauth";
+import { buildElectronMcpCallbackUrl } from "./hooks/use-server-state";
 import { getEffectiveProjectClientCapabilities } from "./lib/client-config";
 import { buildEvalsHash } from "./lib/evals-router";
 import { withTestingSurface } from "./lib/testing-surface";
@@ -669,6 +671,7 @@ export default function App() {
     "/oauth/callback/debug"
   );
   const isOAuthCallback = window.location.pathname === "/callback";
+  const electronMcpCallbackUrl = buildElectronMcpCallbackUrl();
 
   useEffect(() => {
     if (!isOAuthCallback) {
@@ -1852,6 +1855,12 @@ export default function App() {
 
   if (isDebugCallback) {
     return <OAuthDebugCallback />;
+  }
+
+  if (electronMcpCallbackUrl) {
+    return (
+      <OAuthDesktopReturnNotice returnToElectronUrl={electronMcpCallbackUrl} />
+    );
   }
 
   if (hostedOAuthHandling) {

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -277,6 +277,8 @@ vi.mock("../lib/theme-utils", () => ({
 vi.mock("../lib/oauth/mcp-oauth", () => ({
   completeHostedOAuthCallback: mockCompleteHostedOAuthCallback,
   handleOAuthCallback: mockHandleOAuthCallback,
+  isElectronMcpCallbackState: (state: string | null | undefined) =>
+    Boolean(state?.startsWith("electron_mcp:")),
 }));
 
 vi.mock("../lib/guest-session", () => ({

--- a/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
@@ -429,6 +429,42 @@ export const OAuthFlowTab = ({
       }
     };
 
+    const handleElectronOAuthCallback = (event: Event) => {
+      const callbackUrl = (event as CustomEvent<string>).detail;
+      if (!callbackUrl) {
+        return;
+      }
+
+      try {
+        const parsed = new URL(callbackUrl);
+        if (parsed.searchParams.get("flow") !== "debug") {
+          return;
+        }
+
+        const error = parsed.searchParams.get("error");
+        const errorDescription = parsed.searchParams.get("error_description");
+        if (error) {
+          if (exchangeTimeoutRef.current) {
+            clearTimeout(exchangeTimeoutRef.current);
+            exchangeTimeoutRef.current = null;
+          }
+
+          updateOAuthFlowState({
+            error: errorDescription ?? error,
+          });
+          return;
+        }
+
+        const code = parsed.searchParams.get("code");
+        const state = parsed.searchParams.get("state");
+        if (code) {
+          processOAuthCallback(code, state);
+        }
+      } catch (error) {
+        console.error("Failed to process Electron OAuth callback:", error);
+      }
+    };
+
     let channel: BroadcastChannel | null = null;
     try {
       channel = new BroadcastChannel("oauth_callback_channel");
@@ -442,8 +478,16 @@ export const OAuthFlowTab = ({
     }
 
     window.addEventListener("message", handleMessage);
+    window.addEventListener(
+      "electron-oauth-callback",
+      handleElectronOAuthCallback as EventListener,
+    );
     return () => {
       window.removeEventListener("message", handleMessage);
+      window.removeEventListener(
+        "electron-oauth-callback",
+        handleElectronOAuthCallback as EventListener,
+      );
       channel?.close();
     };
   }, [oauthStateMachine, updateOAuthFlowState]);

--- a/mcpjam-inspector/client/src/components/oauth/OAuthAuthorizationModal.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthAuthorizationModal.tsx
@@ -16,6 +16,34 @@ export const OAuthAuthorizationModal = ({
   const popupRef = useRef<Window | null>(null);
   const hasOpenedRef = useRef(false);
 
+  const openAuthorizationPopup = () => {
+    const width = 600;
+    const height = 700;
+    const left = window.screenX + (window.outerWidth - width) / 2;
+    const top = window.screenY + (window.outerHeight - height) / 2;
+
+    // Use unique window name each time to prevent reusing old popup with stale auth code
+    const uniqueWindowName = `oauth_authorization_${Date.now()}`;
+    popupRef.current = window.open(
+      authorizationUrl,
+      uniqueWindowName,
+      `width=${width},height=${height},left=${left},top=${top},toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes`,
+    );
+
+    // Monitor popup closure
+    const checkPopupClosed = setInterval(() => {
+      if (popupRef.current?.closed) {
+        clearInterval(checkPopupClosed);
+        onOpenChange(false);
+        hasOpenedRef.current = false;
+      }
+    }, 500);
+
+    return () => {
+      clearInterval(checkPopupClosed);
+    };
+  };
+
   // Listen for OAuth callback messages from popup
   useEffect(() => {
     // Method 1: Listen via window.postMessage (standard approach)
@@ -63,33 +91,37 @@ export const OAuthAuthorizationModal = ({
   useEffect(() => {
     if (open && !hasOpenedRef.current) {
       hasOpenedRef.current = true;
+      let cleanup: (() => void) | undefined;
+      let cancelled = false;
 
-      const width = 600;
-      const height = 700;
-      const left = window.screenX + (window.outerWidth - width) / 2;
-      const top = window.screenY + (window.outerHeight - height) / 2;
+      if (window.isElectron && window.electronAPI?.app?.openExternal) {
+        void (async () => {
+          try {
+            await window.electronAPI.app.openExternal(authorizationUrl);
+            if (cancelled) return;
+            onOpenChange(false);
+            hasOpenedRef.current = false;
+          } catch (error) {
+            console.error(
+              "[OAuth Popup] Failed to open system browser:",
+              error,
+            );
+            if (cancelled) return;
+            cleanup = openAuthorizationPopup();
+          }
+        })();
 
-      // Use unique window name each time to prevent reusing old popup with stale auth code
-      const uniqueWindowName = `oauth_authorization_${Date.now()}`;
-      console.log("authorizationUrl", authorizationUrl);
-      popupRef.current = window.open(
-        authorizationUrl,
-        uniqueWindowName,
-        `width=${width},height=${height},left=${left},top=${top},toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes`,
-      );
+        return () => {
+          cancelled = true;
+          cleanup?.();
+        };
+      }
 
-      // Monitor popup closure
-      const checkPopupClosed = setInterval(() => {
-        if (popupRef.current?.closed) {
-          clearInterval(checkPopupClosed);
-          onOpenChange(false);
-          hasOpenedRef.current = false;
-        }
-      }, 500);
+      cleanup = openAuthorizationPopup();
 
-      // Cleanup
       return () => {
-        clearInterval(checkPopupClosed);
+        cancelled = true;
+        cleanup?.();
       };
     }
 

--- a/mcpjam-inspector/client/src/components/oauth/OAuthDebugCallback.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthDebugCallback.tsx
@@ -5,9 +5,24 @@ import {
 } from "@/lib/oauth/oauthUtils";
 import { CheckCircle2, XCircle } from "lucide-react";
 
+export function buildElectronDebugCallbackUrl(): string {
+  const callbackUrl = new URL("mcpjam://oauth/callback");
+  callbackUrl.searchParams.set("flow", "debug");
+
+  const params = new URLSearchParams(window.location.search);
+  for (const [key, value] of params.entries()) {
+    callbackUrl.searchParams.append(key, value);
+  }
+
+  return callbackUrl.toString();
+}
+
 export default function OAuthDebugCallback() {
   const callbackParams = parseOAuthCallbackParams(window.location.search);
   const [codeSent, setCodeSent] = useState(false);
+  const [returnToElectronUrl, setReturnToElectronUrl] = useState<string | null>(
+    null,
+  );
   const hasAttemptedSendRef = useRef(false);
 
   useEffect(() => {
@@ -16,7 +31,28 @@ export default function OAuthDebugCallback() {
       return;
     }
 
-    // If successful and we have a code, send it to the parent window
+    const isInPopup = Boolean(window.opener && !window.opener.closed);
+    const isNamedOAuthPopup = window.name.startsWith("oauth_authorization_");
+
+    // Electron cold-start debug callbacks do not have a live opener session to
+    // hand results back to, so keep the callback visible instead of attempting
+    // popup behavior in the only app window.
+    if (window.isElectron && !isInPopup) {
+      return;
+    }
+
+    // System-browser debug callbacks need to bounce back into the Electron app.
+    // Browser popup flows may lose `window.opener` due to COOP, so preserve the
+    // fallback path for our named OAuth popup windows.
+    if (!window.isElectron && !isInPopup && !isNamedOAuthPopup) {
+      hasAttemptedSendRef.current = true;
+      const electronUrl = buildElectronDebugCallbackUrl();
+      setReturnToElectronUrl(electronUrl);
+      window.location.replace(electronUrl);
+      return;
+    }
+
+    // If successful and we have a code, send it to the parent window.
     if (callbackParams.successful && callbackParams.code) {
       hasAttemptedSendRef.current = true;
       try {
@@ -28,9 +64,6 @@ export default function OAuthDebugCallback() {
           code: callbackParams.code,
           state: stateParam,
         };
-
-        // Check if we're in a popup window
-        const isInPopup = window.opener && !window.opener.closed;
 
         // Method 1: Try window.opener (works most of the time)
         if (isInPopup) {
@@ -97,6 +130,13 @@ export default function OAuthDebugCallback() {
                 <p className="mt-4 text-xs text-muted-foreground">
                   Return to the OAuth Flow tab and paste the code to continue.
                 </p>
+                {window.isElectron && !window.opener && (
+                  <p className="mt-3 text-xs text-muted-foreground">
+                    The debug session is no longer attached to a popup window.
+                    Reopen the OAuth Flow tab in MCPJam Inspector and start the
+                    flow again to exchange a fresh code.
+                  </p>
+                )}
               </>
             )}
           </>
@@ -111,7 +151,28 @@ export default function OAuthDebugCallback() {
             <div className="text-xs text-muted-foreground whitespace-pre-wrap">
               {generateOAuthErrorDescription(callbackParams)}
             </div>
+            {window.isElectron && !window.opener && (
+              <p className="mt-3 text-xs text-muted-foreground">
+                The debug session is no longer active in a popup window. Return
+                to MCPJam Inspector and start a new flow to retry.
+              </p>
+            )}
           </>
+        )}
+        {!window.isElectron && returnToElectronUrl && (
+          <div className="mt-4 space-y-2 text-xs text-muted-foreground">
+            <p>
+              MCPJam Desktop should open automatically. If you are back in the
+              browser, please close this page and continue in MCPJam Desktop.
+            </p>
+            <p>
+              If nothing happened,{" "}
+              <a className="underline" href={returnToElectronUrl}>
+                click here
+              </a>
+              .
+            </p>
+          </div>
         )}
       </div>
     </div>

--- a/mcpjam-inspector/client/src/components/oauth/OAuthDesktopReturnNotice.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthDesktopReturnNotice.tsx
@@ -1,0 +1,60 @@
+import { useEffect } from "react";
+
+interface OAuthDesktopReturnNoticeProps {
+  returnToElectronUrl: string;
+}
+
+const attemptedDesktopReturnUrls = new Set<string>();
+
+export function redirectBrowserCallbackToElectron(
+  returnToElectronUrl: string,
+  navigate: Pick<Location, "replace"> = window.location,
+) {
+  if (window.isElectron) {
+    return;
+  }
+
+  navigate.replace(returnToElectronUrl);
+}
+
+export const desktopReturnRuntime = {
+  redirect: redirectBrowserCallbackToElectron,
+};
+
+export function resetDesktopReturnAttemptsForTests() {
+  attemptedDesktopReturnUrls.clear();
+}
+
+export default function OAuthDesktopReturnNotice({
+  returnToElectronUrl,
+}: OAuthDesktopReturnNoticeProps) {
+  useEffect(() => {
+    // React StrictMode replays effects in development, so guard the custom
+    // protocol handoff to avoid showing duplicate "Open Electron?" prompts.
+    if (attemptedDesktopReturnUrls.has(returnToElectronUrl)) {
+      return;
+    }
+
+    attemptedDesktopReturnUrls.add(returnToElectronUrl);
+    desktopReturnRuntime.redirect(returnToElectronUrl);
+  }, [returnToElectronUrl]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <div className="w-full max-w-md rounded-md border bg-secondary p-4">
+        <p className="text-sm font-medium">Continue in MCPJam Desktop</p>
+        <p className="mt-2 text-xs text-muted-foreground">
+          MCPJam Desktop should open automatically. If you are back in the
+          browser, please close this page and continue in MCPJam Desktop.
+        </p>
+        <p className="mt-3 text-xs text-muted-foreground">
+          If nothing happened,{" "}
+          <a className="underline" href={returnToElectronUrl}>
+            click here
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/oauth/OAuthFlowProgressSimple.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/OAuthFlowProgressSimple.tsx
@@ -1,6 +1,6 @@
 import { OAuthFlowState, OAuthStep } from "@/lib/types/oauth-flow-types";
 import { CheckCircle2, Circle, ExternalLink } from "lucide-react";
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useRef } from "react";
 import type { OAuthClientInformation } from "@mcpjam/sdk/browser";
 import { Button } from "@mcpjam/design-system/button";
 import { DebugMCPOAuthClientProvider } from "@/lib/oauth/debug-oauth-provider";
@@ -79,6 +79,7 @@ export const OAuthFlowProgressSimple = ({
   const [clientInfo, setClientInfo] = useState<OAuthClientInformation | null>(
     null,
   );
+  const processedElectronCodeRef = useRef<string | null>(null);
 
   // Track if authorization modal is open
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
@@ -110,6 +111,63 @@ export const OAuthFlowProgressSimple = ({
     flowState.oauthClientInfo,
     currentStepIdx,
   ]);
+
+  useEffect(() => {
+    const handleElectronOAuthCallback = (event: Event) => {
+      const callbackUrl = (event as CustomEvent<string>).detail;
+      if (!callbackUrl) {
+        return;
+      }
+
+      try {
+        const parsed = new URL(callbackUrl);
+        if (parsed.searchParams.get("flow") !== "debug") {
+          return;
+        }
+
+        const error = parsed.searchParams.get("error");
+        const errorDescription = parsed.searchParams.get("error_description");
+        if (error) {
+          updateFlowState({
+            latestError: new Error(errorDescription ?? error),
+            validationError: null,
+          });
+          return;
+        }
+
+        const code = parsed.searchParams.get("code");
+        if (!code || processedElectronCodeRef.current === code) {
+          return;
+        }
+
+        processedElectronCodeRef.current = code;
+        updateFlowState({
+          authorizationCode: code,
+          latestError: null,
+          validationError: null,
+          statusMessage: {
+            type: "success",
+            message:
+              "Authorization received from your browser. Click Continue to exchange the code.",
+          },
+        });
+      } catch (error) {
+        console.error("Failed to process Electron OAuth callback:", error);
+      }
+    };
+
+    window.addEventListener(
+      "electron-oauth-callback",
+      handleElectronOAuthCallback as EventListener,
+    );
+
+    return () => {
+      window.removeEventListener(
+        "electron-oauth-callback",
+        handleElectronOAuthCallback as EventListener,
+      );
+    };
+  }, [updateFlowState]);
 
   // Helper to get step props
   const getStepProps = (stepName: OAuthStep) => ({

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthAuthorizationModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthAuthorizationModal.test.tsx
@@ -1,0 +1,90 @@
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OAuthAuthorizationModal } from "../OAuthAuthorizationModal";
+
+describe("OAuthAuthorizationModal", () => {
+  const openExternal = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.isElectron = true;
+    window.electronAPI = {
+      app: {
+        openExternal,
+      },
+    } as any;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("closes immediately after Electron opens the system browser", async () => {
+    const onOpenChange = vi.fn();
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    openExternal.mockResolvedValue(undefined);
+
+    render(
+      <OAuthAuthorizationModal
+        open={true}
+        onOpenChange={onOpenChange}
+        authorizationUrl="https://auth.example.com/authorize"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(openExternal).toHaveBeenCalledWith(
+        "https://auth.example.com/authorize",
+      );
+    });
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the popup flow when Electron browser launch fails", async () => {
+    const onOpenChange = vi.fn();
+    const popupWindow = { closed: false } as Window;
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockImplementation(() => popupWindow);
+
+    openExternal.mockRejectedValue(new Error("system browser unavailable"));
+
+    const { unmount } = render(
+      <OAuthAuthorizationModal
+        open={true}
+        onOpenChange={onOpenChange}
+        authorizationUrl="https://auth.example.com/authorize"
+      />,
+    );
+
+    try {
+      await waitFor(() => {
+        expect(openExternal).toHaveBeenCalledWith(
+          "https://auth.example.com/authorize",
+        );
+      });
+      await waitFor(() => {
+        expect(openSpy).toHaveBeenCalled();
+      });
+
+      expect(openSpy).toHaveBeenCalledWith(
+        "https://auth.example.com/authorize",
+        expect.stringMatching(/^oauth_authorization_/),
+        expect.any(String),
+      );
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(onOpenChange).not.toHaveBeenCalled();
+    } finally {
+      unmount();
+      consoleErrorSpy.mockRestore();
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthDebugCallback.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthDebugCallback.test.tsx
@@ -1,0 +1,21 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildElectronDebugCallbackUrl } from "../OAuthDebugCallback";
+
+describe("OAuthDebugCallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.isElectron = false;
+    window.name = "";
+    window.history.replaceState(
+      {},
+      "",
+      "/oauth/callback/debug?code=test-code&state=test-state",
+    );
+  });
+
+  it("builds the Electron deep-link callback URL for browser returns", () => {
+    expect(buildElectronDebugCallbackUrl()).toBe(
+      "mcpjam://oauth/callback?flow=debug&code=test-code&state=test-state",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthDesktopReturnNotice.test.tsx
+++ b/mcpjam-inspector/client/src/components/oauth/__tests__/OAuthDesktopReturnNotice.test.tsx
@@ -1,0 +1,64 @@
+import { StrictMode } from "react";
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import OAuthDesktopReturnNotice, {
+  desktopReturnRuntime,
+  redirectBrowserCallbackToElectron,
+  resetDesktopReturnAttemptsForTests,
+} from "../OAuthDesktopReturnNotice";
+
+describe("OAuthDesktopReturnNotice", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    resetDesktopReturnAttemptsForTests();
+    window.isElectron = false;
+  });
+
+  it("tries to return browser callbacks to Electron automatically", () => {
+    const replace = vi.fn();
+
+    redirectBrowserCallbackToElectron("mcpjam://oauth/callback?code=123", {
+      replace,
+    });
+
+    expect(replace).toHaveBeenCalledWith("mcpjam://oauth/callback?code=123");
+  });
+
+  it("shows the desktop return message", () => {
+    window.isElectron = true;
+
+    render(
+      <OAuthDesktopReturnNotice returnToElectronUrl="mcpjam://oauth/callback?code=123" />,
+    );
+
+    expect(screen.getByText("Continue in MCPJam Desktop")).toBeInTheDocument();
+  });
+
+  it("does not redirect again inside Electron", () => {
+    const replace = vi.fn();
+    window.isElectron = true;
+
+    redirectBrowserCallbackToElectron("mcpjam://oauth/callback?code=123", {
+      replace,
+    });
+
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("only launches the Electron callback once in StrictMode", () => {
+    const redirectSpy = vi
+      .spyOn(desktopReturnRuntime, "redirect")
+      .mockImplementation(() => {});
+
+    render(
+      <StrictMode>
+        <OAuthDesktopReturnNotice returnToElectronUrl="mcpjam://oauth/callback?code=456" />
+      </StrictMode>,
+    );
+
+    expect(redirectSpy).toHaveBeenCalledTimes(1);
+    expect(redirectSpy).toHaveBeenCalledWith(
+      "mcpjam://oauth/callback?code=456",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
@@ -131,4 +131,20 @@ describe("SidebarUser", () => {
     expect(creditUsage).toHaveAttribute("data-variant", "full");
     expect(creditUsage).toHaveClass("px-1", "pb-1");
   });
+
+  it("returns logout to the app origin instead of the callback route", () => {
+    authState.user = {
+      email: "owner@example.com",
+      firstName: "Owner",
+      lastName: "Example",
+    };
+
+    render(<SidebarUser />);
+
+    fireEvent.click(screen.getByText("Log out"));
+
+    expect(authState.signOutMock).toHaveBeenCalledWith({
+      returnTo: window.location.origin,
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
@@ -60,12 +60,7 @@ export function SidebarUser({ activeOrganizationId }: SidebarUserProps = {}) {
   const initials = getInitials(displayName);
 
   const handleSignOut = () => {
-    const isElectron = (window as any).isElectron;
-    const returnTo =
-      isElectron && import.meta.env.DEV
-        ? "http://localhost:8080/callback"
-        : window.location.origin;
-    signOut({ returnTo });
+    signOut({ returnTo: window.location.origin });
   };
 
   const avatarUrl = profilePictureUrl;

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.test.tsx
@@ -90,6 +90,11 @@ vi.mock("@/components/chat-v2/model-compare-card-header", () => ({
   },
 }));
 
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: <T,>(selector: (state: any) => T): T =>
+    selector({ hostCapabilitiesOverride: null }),
+}));
+
 vi.mock("@/contexts/chatbox-host-style-context", () => ({
   ChatboxHostStyleProvider: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
@@ -62,6 +62,8 @@ vi.mock("@/lib/oauth/mcp-oauth", () => ({
   getStoredTokens: vi.fn(),
   clearOAuthData: vi.fn(),
   initiateOAuth: vi.fn(),
+  isElectronMcpCallbackState: (state: string | null | undefined) =>
+    Boolean(state?.startsWith("electron_mcp:")),
   readStoredOAuthConfig: readStoredOAuthConfigMock,
 }));
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -313,6 +313,7 @@ describe("useServerState OAuth callback failures", () => {
     vi.clearAllMocks();
     localStorage.clear();
     window.history.replaceState({}, "", "/");
+    window.isElectron = false;
     useClientConfigStore.setState({
       activeProjectId: null,
       defaultConfig: null,
@@ -457,6 +458,49 @@ describe("useServerState OAuth callback failures", () => {
     } finally {
       consoleErrorSpy.mockRestore();
     }
+  });
+
+  it("completes Electron in-app fallback callbacks in the renderer", async () => {
+    window.isElectron = true;
+    localStorage.setItem("mcp-oauth-pending", "demo-server");
+    localStorage.setItem("mcp-oauth-return-hash", "#demo-server");
+    handleOAuthCallbackMock.mockResolvedValue({
+      success: true,
+      serverName: "demo-server",
+      serverConfig: {
+        type: "http",
+        url: "https://example.com/mcp",
+      },
+    });
+    window.history.replaceState(
+      {},
+      "",
+      "/oauth/callback?code=test-code&state=electron_mcp:test-state",
+    );
+
+    expect(buildElectronMcpCallbackUrl()).toBeNull();
+
+    const dispatch = vi.fn();
+    renderUseServerState(dispatch);
+
+    await waitFor(() => {
+      expect(handleOAuthCallbackMock).toHaveBeenCalledWith(
+        "test-code",
+        expect.objectContaining({
+          onTraceUpdate: expect.any(Function),
+        }),
+      );
+    });
+    await waitFor(() => {
+      expect(toastSuccess).toHaveBeenCalledWith(
+        "OAuth connection successful! Connected to demo-server.",
+      );
+    });
+
+    expect(window.location.pathname).toBe("/");
+    expect(window.location.search).toBe("");
+    expect(window.location.hash).toBe("#demo-server");
+    expect(localStorage.getItem("mcp-oauth-pending")).toBeNull();
   });
 
   it("ignores regular browser OAuth callbacks that are not tagged for Electron", () => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -3,13 +3,17 @@ import { flushSync } from "react-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppState, AppAction, ServerWithName } from "@/state/app-types";
 import {
+  buildElectronMcpCallbackUrl,
+  shouldRetryOAuthConnectionFailure,
+  useServerState,
+} from "../use-server-state";
+import {
   CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE,
   PROJECT_NOT_PROVISIONED_ERROR_MESSAGE,
 } from "@/lib/client-config";
 import type { ProjectClientConfig } from "@/lib/client-config";
 import { useClientConfigStore } from "@/stores/client-config-store";
 import { useHostContextStore } from "@/stores/host-context-store";
-import { useServerState } from "../use-server-state";
 
 const {
   toastError,
@@ -72,14 +76,18 @@ vi.mock("@/state/oauth-orchestrator", () => ({
   ensureAuthorizedForReconnect: vi.fn(),
 }));
 
-vi.mock("@/lib/oauth/mcp-oauth", () => ({
-  completeHostedOAuthCallback: completeHostedOAuthCallbackMock,
-  handleOAuthCallback: handleOAuthCallbackMock,
-  getStoredTokens: getStoredTokensMock,
-  clearOAuthData: clearOAuthDataMock,
-  initiateOAuth: initiateOAuthMock,
-  readStoredOAuthConfig: readStoredOAuthConfigMock,
-}));
+vi.mock("@/lib/oauth/mcp-oauth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/oauth/mcp-oauth")>();
+  return {
+    ...actual,
+    completeHostedOAuthCallback: completeHostedOAuthCallbackMock,
+    handleOAuthCallback: handleOAuthCallbackMock,
+    getStoredTokens: getStoredTokensMock,
+    clearOAuthData: clearOAuthDataMock,
+    initiateOAuth: initiateOAuthMock,
+    readStoredOAuthConfig: readStoredOAuthConfigMock,
+  };
+});
 
 vi.mock("@/lib/apis/web/context", () => ({
   injectHostedServerMapping: vi.fn(),
@@ -195,6 +203,12 @@ function renderUseServerState(
       },
     })
   );
+}
+
+async function flushAsyncWork(iterations = 5): Promise<void> {
+  for (let index = 0; index < iterations; index += 1) {
+    await Promise.resolve();
+  }
 }
 
 beforeEach(() => {
@@ -404,6 +418,143 @@ describe("useServerState OAuth callback failures", () => {
       "Error completing OAuth flow: Token exchange failed"
     );
     expect(localStorage.getItem("mcp-oauth-pending")).toBeNull();
+  });
+
+  it("bounces browser OAuth callbacks back into Electron when the OAuth state is tagged for desktop", async () => {
+    window.isElectron = false;
+    window.history.replaceState(
+      {},
+      "",
+      "/oauth/callback?code=test-code&state=electron_mcp:test-state",
+    );
+
+    expect(buildElectronMcpCallbackUrl()).toBe(
+      "mcpjam://oauth/callback?flow=mcp&code=test-code&state=electron_mcp%3Atest-state",
+    );
+  });
+
+  it("defers Electron-tagged browser callbacks to the App-level desktop return notice", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    window.isElectron = false;
+    window.history.replaceState(
+      {},
+      "",
+      "/oauth/callback?code=test-code&state=electron_mcp:test-state",
+    );
+
+    try {
+      const dispatch = vi.fn();
+      renderUseServerState(dispatch);
+      await flushAsyncWork();
+
+      expect(handleOAuthCallbackMock).not.toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+        "Not implemented: navigation to another Document",
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it("ignores regular browser OAuth callbacks that are not tagged for Electron", () => {
+    window.isElectron = false;
+    window.history.replaceState(
+      {},
+      "",
+      "/oauth/callback?code=test-code&state=test-state",
+    );
+
+    expect(buildElectronMcpCallbackUrl()).toBeNull();
+  });
+
+  it("detects retryable transport errors after OAuth", () => {
+    expect(
+      shouldRetryOAuthConnectionFailure(
+        "Streamable HTTP error: Request timed out. SSE error: SSE error: Non-200 status code (404).",
+      ),
+    ).toBe(true);
+    expect(
+      shouldRetryOAuthConnectionFailure(
+        "OAuth failed with invalid_client from the authorization server",
+      ),
+    ).toBe(false);
+  });
+
+  it("retries transient connection failures once after a successful OAuth callback", async () => {
+    vi.useFakeTimers();
+
+    localStorage.setItem("mcp-oauth-pending", "demo-server");
+    localStorage.setItem(
+      "mcp-serverUrl-demo-server",
+      "https://example.com/mcp",
+    );
+    localStorage.setItem("mcp-oauth-return-hash", "#demo-server");
+    window.history.replaceState({}, "", "/oauth/callback?code=test-code");
+
+    handleOAuthCallbackMock.mockResolvedValue({
+      success: true,
+      serverName: "demo-server",
+      serverConfig: {
+        url: "https://example.com/mcp",
+        requestInit: {
+          headers: {
+            Authorization: "Bearer token",
+          },
+        },
+      },
+    });
+    getStoredTokensMock.mockReturnValue({
+      access_token: "token",
+    } as any);
+    testConnectionMock
+      .mockResolvedValueOnce({
+        success: false,
+        error:
+          'Connection failed for server demo-server: Failed to connect to MCP server "demo-server" using HTTP transports. Streamable HTTP error: Request timed out. SSE error: SSE error: Non-200 status code (404).',
+      } as any)
+      .mockResolvedValueOnce({
+        success: true,
+        initInfo: null,
+      } as any);
+
+    try {
+      const dispatch = vi.fn();
+      renderUseServerState(dispatch);
+
+      await act(async () => {
+        await flushAsyncWork();
+      });
+
+      expect(handleOAuthCallbackMock).toHaveBeenCalledWith(
+        "test-code",
+        expect.objectContaining({
+          onTraceUpdate: expect.any(Function),
+        })
+      );
+      expect(testConnectionMock).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1500);
+        await flushAsyncWork();
+      });
+
+      expect(testConnectionMock).toHaveBeenCalledTimes(2);
+
+      expect(toastSuccess).toHaveBeenCalledWith(
+        "OAuth connection successful! Connected to demo-server.",
+      );
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "CONNECT_SUCCESS",
+          name: "demo-server",
+        }),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("restores the app root after a successful browser OAuth callback", async () => {

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1522,6 +1522,8 @@ export function useServerState({
         localStorage.removeItem("mcp-oauth-return-hash");
         if (isHostedProjectCallback) {
           clearHostedOAuthPendingState();
+        }
+        if (result.success) {
           localStorage.removeItem("mcp-oauth-pending");
         }
 

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -27,6 +27,7 @@ import {
   getStoredTokens,
   clearOAuthData,
   initiateOAuth,
+  isElectronMcpCallbackState,
   readStoredOAuthConfig,
 } from "@/lib/oauth/mcp-oauth";
 import type { OAuthTrace } from "@/lib/oauth/oauth-trace";
@@ -203,6 +204,41 @@ function saveOAuthConfigToLocalStorage(formData: ServerFormData): void {
   }
 }
 
+export function buildElectronMcpCallbackUrl(): string | null {
+  if (window.isElectron || window.location.pathname !== "/oauth/callback") {
+    return null;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  if (!params.get("code") && !params.get("error")) {
+    return null;
+  }
+
+  // Electron-started MCP OAuth explicitly tags the state parameter so the
+  // browser callback can hand control back to the desktop app without relying
+  // on browser-local storage heuristics.
+  if (!isElectronMcpCallbackState(params.get("state"))) {
+    return null;
+  }
+
+  const callbackUrl = new URL("mcpjam://oauth/callback");
+  callbackUrl.searchParams.set("flow", "mcp");
+
+  for (const [key, value] of params.entries()) {
+    callbackUrl.searchParams.append(key, value);
+  }
+
+  return callbackUrl.toString();
+}
+
+const OAUTH_CONNECTION_RETRY_DELAY_MS = 1500;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
 function readStoredClientCredentials(serverName: string): {
   clientId?: string;
   clientSecret?: string;
@@ -377,6 +413,29 @@ function requiresFreshOAuthAuthorization(error: unknown): boolean {
     ) ||
     (normalized.includes("authentication failed") &&
       normalized.includes("invalid_token"))
+  );
+}
+
+export function shouldRetryOAuthConnectionFailure(
+  errorMessage?: string,
+): boolean {
+  if (!errorMessage) {
+    return false;
+  }
+
+  const normalized = errorMessage.toLowerCase();
+  if (
+    normalized.includes("authentication failed") ||
+    normalized.includes("invalid_client") ||
+    normalized.includes("unauthorized_client")
+  ) {
+    return false;
+  }
+
+  return (
+    normalized.includes("request timed out") ||
+    normalized.includes("streamable http error") ||
+    normalized.includes("sse error: sse error: non-200 status code (404)")
   );
 }
 
@@ -1340,6 +1399,46 @@ export function useServerState({
     [dispatch, fetchAndStoreInitInfo]
   );
 
+  const testConnectionAfterOAuth = useCallback(
+    async (serverConfig: MCPServerConfig, serverName: string) => {
+      try {
+        const firstResult = await guardedTestConnection(
+          serverConfig,
+          serverName
+        );
+        if (
+          firstResult.success ||
+          !shouldRetryOAuthConnectionFailure(firstResult.error)
+        ) {
+          return firstResult;
+        }
+
+        logger.warn(
+          "Retrying OAuth connection after transient transport error",
+          {
+            serverName,
+            error: firstResult.error,
+          },
+        );
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown connection error";
+        if (!shouldRetryOAuthConnectionFailure(errorMessage)) {
+          throw error;
+        }
+
+        logger.warn("Retrying OAuth connection after transport exception", {
+          serverName,
+          error: errorMessage,
+        });
+      }
+
+      await delay(OAUTH_CONNECTION_RETRY_DELAY_MS);
+      return guardedTestConnection(serverConfig, serverName);
+    },
+    [guardedTestConnection, logger]
+  );
+
   const resolveOAuthInitiationInputs = useCallback(
     async (
       formData: ServerFormData
@@ -1489,7 +1588,7 @@ export function useServerState({
           });
 
           try {
-            const connectionResult = await guardedTestConnection(
+            const connectionResult = await testConnectionAfterOAuth(
               withProjectConnectionDefaults(mergedServerConfig),
               serverName
             );
@@ -1591,6 +1690,7 @@ export function useServerState({
       logger,
       persistServerToLocalProject,
       storeInitInfo,
+      testConnectionAfterOAuth,
       guardedTestConnection,
       syncServerToConvex,
       updateServerOAuthTrace,
@@ -1620,9 +1720,13 @@ export function useServerState({
     const state = urlParams.get("state");
     const error = urlParams.get("error");
     const errorDescription = urlParams.get("error_description");
+    const electronCallbackUrl = buildElectronMcpCallbackUrl();
     const hostedOAuthCallbackContext = HOSTED_MODE
       ? getHostedOAuthCallbackContext()
       : null;
+    if (electronCallbackUrl) {
+      return;
+    }
     const isHostedProjectCallback =
       hostedOAuthCallbackContext?.surface === "project";
     if (code) {

--- a/mcpjam-inspector/client/src/hooks/useElectronOAuth.ts
+++ b/mcpjam-inspector/client/src/hooks/useElectronOAuth.ts
@@ -8,12 +8,21 @@ export function useElectronOAuth() {
     }
 
     const handleOAuthCallback = (url: string) => {
-      console.log("Electron OAuth callback received:", url);
-
       try {
         // Parse the callback URL to extract tokens/parameters
         const urlObj = new URL(url);
+        const flow = urlObj.searchParams.get("flow");
         const params = new URLSearchParams(urlObj.search);
+
+        window.dispatchEvent(
+          new CustomEvent<string>("electron-oauth-callback", {
+            detail: url,
+          }),
+        );
+
+        if (flow === "mcp" || flow === "debug") {
+          return;
+        }
 
         // Extract the code and state from the callback
         const code = params.get("code");
@@ -26,8 +35,6 @@ export function useElectronOAuth() {
         }
 
         if (code) {
-          console.log("OAuth code received, redirecting to callback page");
-
           // Redirect to the callback page with the code and state
           // This mimics what would happen in a browser OAuth flow
           const callbackUrl = new URL("/callback", window.location.origin);

--- a/mcpjam-inspector/client/src/lib/__tests__/electron-hosted-auth.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/electron-hosted-auth.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildElectronHostedAuthCallbackUrl,
+  createElectronHostedAuthState,
+  ELECTRON_HOSTED_AUTH_STATE_KEY,
+  isElectronHostedAuthCallback,
+  parseElectronHostedAuthState,
+  resolveWorkosRedirectUri,
+} from "../electron-hosted-auth";
+
+describe("electron hosted auth helpers", () => {
+  it("tags object state for Electron hosted auth", () => {
+    expect(createElectronHostedAuthState({ foo: "bar" })).toEqual({
+      foo: "bar",
+      [ELECTRON_HOSTED_AUTH_STATE_KEY]: true,
+    });
+  });
+
+  it("parses tagged Electron hosted auth state", () => {
+    expect(
+      parseElectronHostedAuthState(
+        JSON.stringify({
+          [ELECTRON_HOSTED_AUTH_STATE_KEY]: true,
+          foo: "bar",
+        }),
+      ),
+    ).toEqual({
+      [ELECTRON_HOSTED_AUTH_STATE_KEY]: true,
+      foo: "bar",
+    });
+  });
+
+  it("builds a desktop callback url for browser Electron callbacks", () => {
+    const state = JSON.stringify({
+      [ELECTRON_HOSTED_AUTH_STATE_KEY]: true,
+    });
+    const location = {
+      pathname: "/callback",
+      search: `?code=test-code&state=${encodeURIComponent(state)}`,
+    } as Pick<Location, "pathname" | "search">;
+
+    expect(isElectronHostedAuthCallback(location)).toBe(true);
+    expect(buildElectronHostedAuthCallbackUrl(location)).toBe(
+      `mcpjam://oauth/callback?code=test-code&state=${encodeURIComponent(state)}`,
+    );
+  });
+
+  it("uses the browser callback path for Electron launches", () => {
+    expect(
+      resolveWorkosRedirectUri({
+        envRedirect: "mcpjam://oauth/callback",
+        isElectron: true,
+        location: {
+          origin: "http://localhost:5173",
+          pathname: "/",
+          protocol: "http:",
+          search: "",
+        } as Pick<Location, "origin" | "pathname" | "protocol" | "search">,
+      }),
+    ).toBe("http://localhost:5173/callback");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/electron-hosted-auth.ts
+++ b/mcpjam-inspector/client/src/lib/electron-hosted-auth.ts
@@ -1,0 +1,109 @@
+export const ELECTRON_HOSTED_AUTH_STATE_KEY =
+  "__mcpjam_electron_hosted_auth";
+
+type AuthCallbackLocation = Pick<
+  Location,
+  "origin" | "pathname" | "protocol" | "search"
+>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function createElectronHostedAuthState(
+  state?: unknown,
+): Record<string, unknown> {
+  if (isRecord(state)) {
+    return {
+      ...state,
+      [ELECTRON_HOSTED_AUTH_STATE_KEY]: true,
+    };
+  }
+
+  if (state === undefined) {
+    return {
+      [ELECTRON_HOSTED_AUTH_STATE_KEY]: true,
+    };
+  }
+
+  return {
+    [ELECTRON_HOSTED_AUTH_STATE_KEY]: true,
+    originalState: state,
+  };
+}
+
+export function parseElectronHostedAuthState(
+  rawState: string | null,
+): Record<string, unknown> | null {
+  if (!rawState) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(rawState);
+    if (
+      isRecord(parsed) &&
+      parsed[ELECTRON_HOSTED_AUTH_STATE_KEY] === true
+    ) {
+      return parsed;
+    }
+  } catch {
+    // Ignore malformed state values.
+  }
+
+  return null;
+}
+
+export function isElectronHostedAuthCallback(
+  location: Pick<Location, "pathname" | "search">,
+): boolean {
+  if (location.pathname !== "/callback") {
+    return false;
+  }
+
+  const params = new URLSearchParams(location.search);
+  if (!params.get("code") && !params.get("error")) {
+    return false;
+  }
+
+  return parseElectronHostedAuthState(params.get("state")) !== null;
+}
+
+export function buildElectronHostedAuthCallbackUrl(
+  location: Pick<Location, "pathname" | "search">,
+): string | null {
+  if (!isElectronHostedAuthCallback(location)) {
+    return null;
+  }
+
+  const callbackUrl = new URL("mcpjam://oauth/callback");
+  const params = new URLSearchParams(location.search);
+
+  for (const [key, value] of params.entries()) {
+    callbackUrl.searchParams.append(key, value);
+  }
+
+  return callbackUrl.toString();
+}
+
+export function resolveWorkosRedirectUri(options: {
+  envRedirect?: string;
+  isElectron: boolean;
+  location: AuthCallbackLocation;
+}): string {
+  const { envRedirect, isElectron, location } = options;
+  const isBrowserHttp =
+    location.protocol === "http:" || location.protocol === "https:";
+
+  if (isElectron) {
+    return isBrowserHttp
+      ? `${location.origin}/callback`
+      : envRedirect ?? "mcpjam://oauth/callback";
+  }
+
+  if (isBrowserHttp) {
+    return `${location.origin}/callback`;
+  }
+
+  return envRedirect ?? `${location.origin}/callback`;
+}

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/constants.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/constants.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   MCPJAM_HOSTED_APP_ORIGIN,
+  getRedirectUri,
   resolveBrowserOAuthRedirectOrigin,
 } from "../constants";
 
@@ -39,5 +40,21 @@ describe("resolveBrowserOAuthRedirectOrigin", () => {
         new URL("https://www.mcpjam.com/oauth/callback")
       )
     ).toBe(MCPJAM_HOSTED_APP_ORIGIN);
+  });
+});
+
+describe("getRedirectUri", () => {
+  afterEach(() => {
+    delete window.isElectron;
+  });
+
+  it("uses the browser callback route when the Electron preload flag is present", () => {
+    window.isElectron = true;
+
+    expect(getRedirectUri()).toBe(`${window.location.origin}/oauth/callback`);
+  });
+
+  it("uses the browser callback route outside Electron", () => {
+    expect(getRedirectUri()).toBe(`${window.location.origin}/oauth/callback`);
   });
 });

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.hosted-session.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.hosted-session.test.ts
@@ -56,7 +56,6 @@ describe("mcp-oauth hosted callback sessions", () => {
         serverUrl: "https://mcp.asana.com/sse",
         sessionId: "hosted-session-1",
         accessScope: "project_member",
-        
         chatboxId: null,
         returnHash: "#servers",
         startedAt: Date.now(),
@@ -125,7 +124,6 @@ describe("mcp-oauth hosted callback sessions", () => {
         serverUrl: "https://mcp.asana.com/sse",
         sessionId: "hosted-session-1",
         accessScope: "project_member",
-        
         chatboxId: null,
         returnHash: "#servers",
         startedAt: Date.now(),
@@ -199,7 +197,6 @@ describe("mcp-oauth hosted callback sessions", () => {
         serverUrl: "https://mcp.linear.app",
         sessionId: "hosted-session-1",
         accessScope: "project_member",
-        
         chatboxId: null,
         returnHash: "#servers",
         startedAt: Date.now(),
@@ -342,7 +339,6 @@ describe("mcp-oauth hosted callback sessions", () => {
           serverUrl: "https://mcp.asana.com/sse",
           sessionId: "hosted-session-1",
           accessScope: "project_member",
-          
           chatboxId: null,
           returnHash: "#servers",
           startedAt: Date.now(),
@@ -464,7 +460,6 @@ describe("mcp-oauth hosted callback sessions", () => {
           serverUrl: "https://mcp.linear.app/mcp",
           sessionId: "hosted-session-1",
           accessScope: "project_member",
-          
           chatboxId: null,
           returnHash: "#servers",
           startedAt: Date.now(),

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -976,8 +976,8 @@ describe("mcp-oauth", () => {
       const navigateSpy = vi
         .spyOn(provider, "navigateToUrl")
         .mockImplementation(() => {});
-      const consoleErrorSpy = vi
-        .spyOn(console, "error")
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
         .mockImplementation(() => {});
       const openExternal = vi
         .fn()
@@ -1008,7 +1008,49 @@ describe("mcp-oauth", () => {
       expect(navigateSpy).toHaveBeenCalledWith(
         "https://auth.example.com/authorize",
       );
-      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "Failed to open system browser for MCP OAuth; continuing inside MCPJam Desktop:",
+        expect.any(Error),
+      );
+    });
+
+    it("falls back to in-app navigation when Electron browser opener is unavailable", async () => {
+      vi.restoreAllMocks();
+      const { MCPOAuthProvider } = await import("../mcp-oauth");
+      const provider = new MCPOAuthProvider(
+        "asana",
+        "https://mcp.asana.com/sse",
+      );
+      const navigateSpy = vi
+        .spyOn(provider, "navigateToUrl")
+        .mockImplementation(() => {});
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      Object.defineProperty(window, "isElectron", {
+        configurable: true,
+        writable: true,
+        value: true,
+      });
+      Object.defineProperty(window, "electronAPI", {
+        configurable: true,
+        writable: true,
+        value: {
+          app: {},
+        },
+      });
+
+      await provider.redirectToAuthorization(
+        new URL("https://auth.example.com/authorize"),
+      );
+
+      expect(navigateSpy).toHaveBeenCalledWith(
+        "https://auth.example.com/authorize",
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "System browser opener is unavailable for MCP OAuth; continuing inside MCPJam Desktop.",
+      );
     });
 
     it("explains why automatic mode resolved to DCR when CIMD support was not advertised", async () => {

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -232,6 +232,8 @@ describe("mcp-oauth", () => {
     mockRunOAuthStateMachine.mockReset();
     mockGetConvexSiteUrl.mockReturnValue("https://test.convex.site");
     mockSelectResourceURL.mockReset();
+    window.isElectron = false;
+    delete window.electronAPI;
     mockStartAuthorization.mockReset();
 
     vi.stubGlobal(
@@ -425,6 +427,8 @@ describe("mcp-oauth", () => {
     vi.unstubAllGlobals();
     localStorage.clear();
     sessionStorage.clear();
+    window.isElectron = false;
+    delete window.electronAPI;
   });
 
   async function seedPendingOAuth(
@@ -885,6 +889,128 @@ describe("mcp-oauth", () => {
   });
 
   describe("persisted discovery state", () => {
+    it("tags Electron-started OAuth state for desktop callback recovery", async () => {
+      const { MCPOAuthProvider } = await import("../mcp-oauth");
+      const provider = new MCPOAuthProvider(
+        "asana",
+        "https://mcp.asana.com/sse",
+      );
+
+      window.isElectron = true;
+
+      expect(provider.state()).toMatch(/^electron_mcp:mock-random-string$/);
+    });
+
+    it("keeps the browser callback redirect URI in Electron", async () => {
+      window.isElectron = true;
+
+      const { MCPOAuthProvider } = await import("../mcp-oauth");
+      const provider = new MCPOAuthProvider(
+        "asana",
+        "https://mcp.asana.com/sse",
+      );
+
+      expect(provider.redirectUrl).toBe(
+        `${window.location.origin}/oauth/callback`,
+      );
+      expect(provider.clientMetadata.redirect_uris).toEqual([
+        `${window.location.origin}/oauth/callback`,
+      ]);
+    });
+
+    it("tags state-machine authorization URLs before opening the browser in Electron", async () => {
+      window.isElectron = true;
+      mockStartAuthorization.mockImplementationOnce(async (_url, options) => {
+        const authorizationUrl = new URL("https://auth.example.com/authorize");
+        authorizationUrl.searchParams.set("state", "mock-state");
+        authorizationUrl.searchParams.set(
+          "redirect_uri",
+          String((options as { redirectUri?: string }).redirectUri),
+        );
+        return {
+          authorizationUrl,
+          codeVerifier: "test-verifier",
+        };
+      });
+
+      const { MCPOAuthProvider, initiateOAuth } = await import("../mcp-oauth");
+      const redirectSpy = vi
+        .spyOn(MCPOAuthProvider.prototype, "redirectToAuthorization")
+        .mockResolvedValue(undefined);
+
+      const result = await initiateOAuth({
+        serverName: "example",
+        serverUrl: "https://example.com",
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.success).toBe(true);
+      const openedUrl = redirectSpy.mock.calls.at(-1)?.[0] as URL;
+      expect(openedUrl.searchParams.get("state")).toBe(
+        "electron_mcp:mock-state",
+      );
+      expect(openedUrl.searchParams.get("redirect_uri")).toBe(
+        `${window.location.origin}/oauth/callback`,
+      );
+    });
+
+    it("keeps browser OAuth state untagged", async () => {
+      const { MCPOAuthProvider } = await import("../mcp-oauth");
+      const provider = new MCPOAuthProvider(
+        "asana",
+        "https://mcp.asana.com/sse",
+      );
+
+      window.isElectron = false;
+
+      expect(provider.state()).toBe("mock-random-string");
+    });
+
+    it("falls back to in-app navigation when Electron browser open fails", async () => {
+      vi.restoreAllMocks();
+      const { MCPOAuthProvider } = await import("../mcp-oauth");
+      const provider = new MCPOAuthProvider(
+        "asana",
+        "https://mcp.asana.com/sse",
+      );
+      const navigateSpy = vi
+        .spyOn(provider, "navigateToUrl")
+        .mockImplementation(() => {});
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const openExternal = vi
+        .fn()
+        .mockRejectedValue(new Error("system browser unavailable"));
+
+      Object.defineProperty(window, "isElectron", {
+        configurable: true,
+        writable: true,
+        value: true,
+      });
+      Object.defineProperty(window, "electronAPI", {
+        configurable: true,
+        writable: true,
+        value: {
+          app: {
+            openExternal,
+          },
+        },
+      });
+
+      await provider.redirectToAuthorization(
+        new URL("https://auth.example.com/authorize"),
+      );
+
+      expect(openExternal).toHaveBeenCalledWith(
+        "https://auth.example.com/authorize",
+      );
+      expect(navigateSpy).toHaveBeenCalledWith(
+        "https://auth.example.com/authorize",
+      );
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
     it("explains why automatic mode resolved to DCR when CIMD support was not advertised", async () => {
       mockDiscoverOAuthServerInfo.mockResolvedValue(createAsanaDiscoveryState());
 

--- a/mcpjam-inspector/client/src/lib/oauth/constants.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/constants.ts
@@ -43,11 +43,6 @@ export function resolveBrowserOAuthRedirectOrigin(
 }
 
 export function getRedirectUri(): string {
-  // Check if running in Electron with custom protocol support
-  if (typeof window !== "undefined" && (window as any).electron) {
-    return "mcpjam://oauth/callback";
-  }
-
   if (typeof window !== "undefined") {
     return `${resolveBrowserOAuthRedirectOrigin(
       window.location

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -73,6 +73,8 @@ interface StoredOAuthDiscoveryState {
   discoveryState: OAuthDiscoveryState;
 }
 
+const ELECTRON_MCP_CALLBACK_STATE_PREFIX = "electron_mcp:";
+
 interface StoredOAuthClientInformation {
   client_id?: string;
   client_secret?: string;
@@ -1479,6 +1481,48 @@ export interface OAuthResult {
   oauthResourceUrl?: string;
 }
 
+export function buildMCPOAuthState(): string {
+  const state = generateRandomString(32);
+  if (window.isElectron) {
+    return `${ELECTRON_MCP_CALLBACK_STATE_PREFIX}${state}`;
+  }
+  return state;
+}
+
+export function isElectronMcpCallbackState(
+  state: string | null | undefined,
+): boolean {
+  return Boolean(state && state.startsWith(ELECTRON_MCP_CALLBACK_STATE_PREFIX));
+}
+
+function tagElectronMcpCallbackState(state: string | null | undefined): string {
+  if (isElectronMcpCallbackState(state)) {
+    return state!;
+  }
+
+  return `${ELECTRON_MCP_CALLBACK_STATE_PREFIX}${
+    state || generateRandomString(32)
+  }`;
+}
+
+function buildElectronMcpAuthorizationRequest(authorizationUrl: string): {
+  authorizationUrl: string;
+  state?: string;
+} {
+  if (typeof window === "undefined" || !window.isElectron) {
+    return { authorizationUrl };
+  }
+
+  try {
+    const url = new URL(authorizationUrl);
+    const state = tagElectronMcpCallbackState(url.searchParams.get("state"));
+    url.searchParams.set("state", state);
+    return { authorizationUrl: url.toString(), state };
+  } catch {
+    return { authorizationUrl };
+  }
+}
+
 interface HostedOAuthCompletionResponse {
   success: boolean;
   expiresAt?: number | null;
@@ -1885,7 +1929,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   }
 
   state(): string {
-    return generateRandomString(32);
+    return buildMCPOAuthState();
   }
 
   get redirectUrl(): string {
@@ -2072,7 +2116,24 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     if (window.location.hash) {
       localStorage.setItem("mcp-oauth-return-hash", window.location.hash);
     }
-    window.location.href = authorizationUrl.toString();
+
+    if (window.isElectron && window.electronAPI?.app?.openExternal) {
+      try {
+        await window.electronAPI.app.openExternal(authorizationUrl.toString());
+        return;
+      } catch (error) {
+        console.error(
+          "Failed to open system browser for MCP OAuth, falling back to in-app navigation:",
+          error,
+        );
+      }
+    }
+
+    this.navigateToUrl(authorizationUrl.toString());
+  }
+
+  navigateToUrl(url: string) {
+    window.location.assign(url);
   }
 
   async saveCodeVerifier(codeVerifier: string) {
@@ -2448,12 +2509,14 @@ export async function initiateOAuth(
         emitTraceSnapshot(snapshot);
       },
       onAuthorizationRequest: async ({ authorizationUrl }) => {
+        const electronAuthorization =
+          buildElectronMcpAuthorizationRequest(authorizationUrl);
         const resourceMetadata = getState().resourceMetadata as
           | { resource?: unknown }
           | undefined;
         const oauthResourceUrl = resolveOAuthResourceUrl({
           serverUrl: options.serverUrl,
-          authorizationUrl,
+          authorizationUrl: electronAuthorization.authorizationUrl,
           configuredResourceUrl: options.resourceUrl,
           resourceMetadata,
         });
@@ -2462,10 +2525,15 @@ export async function initiateOAuth(
         // authorization URL is updated to the redirected one so the callback
         // path round-trips the same resource.
         const redirectedAuthorizationUrl = withOAuthResourceParam(
-          authorizationUrl,
+          electronAuthorization.authorizationUrl,
           oauthResourceUrl
         );
-        updateState({ authorizationUrl: redirectedAuthorizationUrl });
+        updateState({
+          authorizationUrl: redirectedAuthorizationUrl,
+          ...(electronAuthorization.state
+            ? { state: electronAuthorization.state }
+            : {}),
+        });
         writeStoredOAuthConfig(options.serverName, {
           resourceUrl: oauthResourceUrl,
         });

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -2109,6 +2109,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   }
 
   async redirectToAuthorization(authorizationUrl: URL) {
+    const authorizationUrlString = authorizationUrl.toString();
     captureServerDetailModalOAuthResume(this.serverName);
     // Store server name for callback recovery
     localStorage.setItem("mcp-oauth-pending", this.serverName);
@@ -2117,19 +2118,28 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       localStorage.setItem("mcp-oauth-return-hash", window.location.hash);
     }
 
-    if (window.isElectron && window.electronAPI?.app?.openExternal) {
-      try {
-        await window.electronAPI.app.openExternal(authorizationUrl.toString());
-        return;
-      } catch (error) {
-        console.error(
-          "Failed to open system browser for MCP OAuth, falling back to in-app navigation:",
-          error,
+    if (window.isElectron) {
+      if (window.electronAPI?.app?.openExternal) {
+        try {
+          await window.electronAPI.app.openExternal(authorizationUrlString);
+          return;
+        } catch (error) {
+          console.warn(
+            "Failed to open system browser for MCP OAuth; continuing inside MCPJam Desktop:",
+            error,
+          );
+        }
+      } else {
+        console.warn(
+          "System browser opener is unavailable for MCP OAuth; continuing inside MCPJam Desktop.",
         );
       }
+
+      this.navigateToUrl(authorizationUrlString);
+      return;
     }
 
-    this.navigateToUrl(authorizationUrl.toString());
+    this.navigateToUrl(authorizationUrlString);
   }
 
   navigateToUrl(url: string) {

--- a/mcpjam-inspector/client/src/main.tsx
+++ b/mcpjam-inspector/client/src/main.tsx
@@ -10,7 +10,12 @@ import { ConvexProviderWithAuthKit } from "@convex-dev/workos";
 import { initSentry } from "./lib/sentry.js";
 import { IframeRouterError } from "./components/IframeRouterError.jsx";
 import { initializeSessionToken } from "./lib/session-token.js";
+import OAuthDesktopReturnNotice from "./components/oauth/OAuthDesktopReturnNotice";
 import { HOSTED_MODE } from "./lib/config";
+import {
+  buildElectronHostedAuthCallbackUrl,
+  resolveWorkosRedirectUri,
+} from "./lib/electron-hosted-auth";
 import { useUnifiedConvexAuth } from "./lib/unified-convex-auth";
 import { getRuntimeConvexUrl } from "./lib/runtime-config";
 
@@ -59,14 +64,16 @@ if (isInIframe) {
     const envRedirect =
       (import.meta.env.VITE_WORKOS_REDIRECT_URI as string) || undefined;
     if (typeof window === "undefined") return envRedirect ?? "/callback";
-    const isBrowserHttp =
-      window.location.protocol === "http:" ||
-      window.location.protocol === "https:";
-    if (isBrowserHttp) return `${window.location.origin}/callback`;
-    if (envRedirect) return envRedirect;
-    if ((window as any)?.isElectron) return "mcpjam://oauth/callback";
-    return `${window.location.origin}/callback`;
+    return resolveWorkosRedirectUri({
+      envRedirect,
+      isElectron: window.isElectron === true,
+      location: window.location,
+    });
   })();
+  const electronHostedAuthCallbackUrl =
+    typeof window === "undefined" || window.isElectron
+      ? null
+      : buildElectronHostedAuthCallbackUrl(window.location);
 
   // Warn if critical env vars are missing
   if (!convexUrl) {
@@ -154,6 +161,17 @@ if (isInIframe) {
   // Async bootstrap to initialize session token before rendering
   async function bootstrap() {
     const root = createRoot(document.getElementById("root")!);
+
+    if (electronHostedAuthCallbackUrl) {
+      root.render(
+        <StrictMode>
+          <OAuthDesktopReturnNotice
+            returnToElectronUrl={electronHostedAuthCallbackUrl}
+          />
+        </StrictMode>,
+      );
+      return;
+    }
 
     try {
       if (!HOSTED_MODE) {

--- a/mcpjam-inspector/client/src/types/electron.d.ts
+++ b/mcpjam-inspector/client/src/types/electron.d.ts
@@ -8,6 +8,7 @@ export interface ElectronAPI {
   app: {
     getVersion: () => Promise<string>;
     getPlatform: () => Promise<string>;
+    openExternal: (url: string) => Promise<void>;
   };
 
   // File operations

--- a/mcpjam-inspector/server/__tests__/app-listeners.test.ts
+++ b/mcpjam-inspector/server/__tests__/app-listeners.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  getVersionMock,
+  ipcHandleMock,
+  logInfoMock,
+  logWarnMock,
+  openExternalMock,
+  registeredHandlers,
+} = vi.hoisted(() => {
+  const registeredHandlers = new Map<string, any>();
+
+  return {
+    getVersionMock: vi.fn(() => "2.2.0"),
+    ipcHandleMock: vi.fn((channel: string, handler: any) => {
+      registeredHandlers.set(channel, handler);
+    }),
+    logInfoMock: vi.fn(),
+    logWarnMock: vi.fn(),
+    openExternalMock: vi.fn(),
+    registeredHandlers,
+  };
+});
+
+vi.mock("electron", () => ({
+  app: {
+    getVersion: getVersionMock,
+  },
+  ipcMain: {
+    handle: ipcHandleMock,
+  },
+  shell: {
+    openExternal: openExternalMock,
+  },
+}));
+
+vi.mock("electron-log", () => ({
+  default: {
+    info: logInfoMock,
+    warn: logWarnMock,
+  },
+}));
+
+import { registerAppListeners } from "../../src/ipc/app/app-listeners.js";
+
+function createWindow(id: number) {
+  return {
+    webContents: {
+      id,
+    },
+  };
+}
+
+function getOpenExternalHandler() {
+  const handler = registeredHandlers.get("app:open-external");
+  expect(handler).toBeTypeOf("function");
+  return handler;
+}
+
+describe("registerAppListeners", () => {
+  let currentMainWindow: ReturnType<typeof createWindow> | null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registeredHandlers.clear();
+    currentMainWindow = createWindow(1);
+
+    registerAppListeners(() => currentMainWindow as any);
+  });
+
+  it("accepts open-external requests from the current main window", async () => {
+    const openExternal = getOpenExternalHandler();
+
+    await expect(
+      openExternal({ sender: { id: 1 } }, "https://example.com/oauth"),
+    ).resolves.toBeUndefined();
+
+    expect(openExternalMock).toHaveBeenCalledWith("https://example.com/oauth");
+    expect(logWarnMock).not.toHaveBeenCalled();
+  });
+
+  it("trusts the replacement window after the main window changes", async () => {
+    const openExternal = getOpenExternalHandler();
+
+    currentMainWindow = createWindow(2);
+
+    await expect(
+      openExternal({ sender: { id: 2 } }, "https://example.com/oauth"),
+    ).resolves.toBeUndefined();
+
+    expect(openExternalMock).toHaveBeenCalledWith("https://example.com/oauth");
+    expect(logWarnMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects stale senders after the trusted window changes", async () => {
+    const openExternal = getOpenExternalHandler();
+
+    currentMainWindow = createWindow(2);
+
+    await expect(
+      openExternal({ sender: { id: 1 } }, "https://example.com/oauth"),
+    ).rejects.toThrow("Refusing external open from untrusted renderer");
+
+    expect(openExternalMock).not.toHaveBeenCalled();
+    expect(logWarnMock).toHaveBeenCalledWith(
+      "Ignoring open-external from untrusted sender (id: 1)",
+    );
+  });
+});

--- a/mcpjam-inspector/server/__tests__/app-listeners.test.ts
+++ b/mcpjam-inspector/server/__tests__/app-listeners.test.ts
@@ -62,6 +62,7 @@ describe("registerAppListeners", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
     registeredHandlers.clear();
     currentMainWindow = createWindow(1);
 
@@ -104,6 +105,21 @@ describe("registerAppListeners", () => {
     expect(openExternalMock).not.toHaveBeenCalled();
     expect(logWarnMock).toHaveBeenCalledWith(
       "Ignoring open-external from untrusted sender (id: 1)",
+    );
+  });
+
+  it("can force open-external to fail in development for OAuth fallback testing", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("MCPJAM_FORCE_ELECTRON_OAUTH_FALLBACK", "true");
+    const openExternal = getOpenExternalHandler();
+
+    await expect(
+      openExternal({ sender: { id: 1 } }, "https://example.com/oauth"),
+    ).rejects.toThrow("Forced open-external failure for OAuth fallback test");
+
+    expect(openExternalMock).not.toHaveBeenCalled();
+    expect(logWarnMock).toHaveBeenCalledWith(
+      "Forcing open-external failure for Electron OAuth fallback test",
     );
   });
 });

--- a/mcpjam-inspector/src/ipc/app/app-listeners.ts
+++ b/mcpjam-inspector/src/ipc/app/app-listeners.ts
@@ -1,6 +1,10 @@
-import { ipcMain, app, BrowserWindow } from "electron";
+import { ipcMain, app, shell } from "electron";
+import type { BrowserWindow } from "electron";
+import log from "electron-log";
 
-export function registerAppListeners(mainWindow: BrowserWindow): void {
+export function registerAppListeners(
+  getMainWindow: () => BrowserWindow | null,
+): void {
   // Get app version
   ipcMain.handle("app:version", () => {
     return app.getVersion();
@@ -9,5 +13,31 @@ export function registerAppListeners(mainWindow: BrowserWindow): void {
   // Get platform
   ipcMain.handle("app:platform", () => {
     return process.platform;
+  });
+
+  ipcMain.handle("app:open-external", async (event, url: string) => {
+    const mainWindow = getMainWindow();
+
+    if (!mainWindow || event.sender.id !== mainWindow.webContents.id) {
+      log.warn(
+        `Ignoring open-external from untrusted sender (id: ${event.sender.id})`,
+      );
+      throw new Error("Refusing external open from untrusted renderer");
+    }
+
+    let parsedUrl: URL;
+
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      throw new Error("Refusing to open invalid external URL");
+    }
+
+    if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+      throw new Error("Refusing to open non-HTTP external URL");
+    }
+
+    log.info("Renderer requested system browser open");
+    await shell.openExternal(parsedUrl.toString());
   });
 }

--- a/mcpjam-inspector/src/ipc/app/app-listeners.ts
+++ b/mcpjam-inspector/src/ipc/app/app-listeners.ts
@@ -37,6 +37,14 @@ export function registerAppListeners(
       throw new Error("Refusing to open non-HTTP external URL");
     }
 
+    if (
+      process.env.NODE_ENV === "development" &&
+      process.env.MCPJAM_FORCE_ELECTRON_OAUTH_FALLBACK === "true"
+    ) {
+      log.warn("Forcing open-external failure for Electron OAuth fallback test");
+      throw new Error("Forced open-external failure for OAuth fallback test");
+    }
+
     log.info("Renderer requested system browser open");
     await shell.openExternal(parsedUrl.toString());
   });

--- a/mcpjam-inspector/src/ipc/listeners-register.ts
+++ b/mcpjam-inspector/src/ipc/listeners-register.ts
@@ -1,11 +1,14 @@
-import { BrowserWindow } from "electron";
+import type { BrowserWindow } from "electron";
 import { registerAppListeners } from "./app/app-listeners.js";
 import { registerWindowListeners } from "./window/window-listeners.js";
 import { registerFileListeners } from "./files/file-listeners.js";
 import { registerUpdateListeners } from "./update/update-listeners.js";
 
-export function registerListeners(mainWindow: BrowserWindow): void {
-  registerAppListeners(mainWindow);
+export function registerListeners(
+  mainWindow: BrowserWindow,
+  getMainWindow: () => BrowserWindow | null = () => mainWindow,
+): void {
+  registerAppListeners(getMainWindow);
   registerWindowListeners(mainWindow);
   registerFileListeners(mainWindow);
   registerUpdateListeners(mainWindow);

--- a/mcpjam-inspector/src/main.ts
+++ b/mcpjam-inspector/src/main.ts
@@ -39,8 +39,116 @@ if (!app.isDefaultProtocolClient("mcpjam")) {
 let mainWindow: BrowserWindow | null = null;
 let server: any = null;
 let serverPort: number = 0;
+let pendingProtocolUrl: string | null = null;
+let appBootstrapped = false;
+const ELECTRON_MCP_CALLBACK_STATE_PREFIX = "electron_mcp:";
 
 const isDev = process.env.NODE_ENV === "development";
+
+function getServerUrl(): string {
+  return `http://127.0.0.1:${serverPort}`;
+}
+
+function getRendererBaseUrl(): string {
+  return isDev ? MAIN_WINDOW_VITE_DEV_SERVER_URL : getServerUrl();
+}
+
+function findOAuthCallbackUrl(args: string[]): string | undefined {
+  return args.find((arg) => arg.startsWith("mcpjam://oauth/callback"));
+}
+
+function isSafeExternalUrl(url: string): boolean {
+  try {
+    const urlObj = new URL(url);
+    return urlObj.protocol === "http:" || urlObj.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function isHostedAuthNavigation(url: string): boolean {
+  try {
+    const urlObj = new URL(url);
+    return (
+      (urlObj.protocol === "http:" || urlObj.protocol === "https:") &&
+      urlObj.pathname.endsWith("/user_management/authorize") &&
+      urlObj.searchParams.has("client_id") &&
+      urlObj.searchParams.has("redirect_uri") &&
+      urlObj.searchParams.get("response_type") === "code"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function createElectronHostedAuthNavigationUrl(url: string): string {
+  try {
+    const urlObj = new URL(url);
+    const rawState = urlObj.searchParams.get("state");
+    let parsedState: unknown = undefined;
+
+    if (rawState) {
+      try {
+        parsedState = JSON.parse(rawState);
+      } catch {
+        parsedState = rawState;
+      }
+    }
+
+    const nextState =
+      parsedState && typeof parsedState === "object" && !Array.isArray(parsedState)
+        ? {
+            ...(parsedState as Record<string, unknown>),
+            __mcpjam_electron_hosted_auth: true,
+          }
+        : parsedState === undefined
+          ? {
+              __mcpjam_electron_hosted_auth: true,
+            }
+          : {
+              __mcpjam_electron_hosted_auth: true,
+              originalState: parsedState,
+            };
+
+    urlObj.searchParams.set("state", JSON.stringify(nextState));
+    return urlObj.toString();
+  } catch {
+    return url;
+  }
+}
+
+function isElectronMcpCallbackUrl(callbackUrl: URL): boolean {
+  return (
+    callbackUrl.searchParams.get("flow") === "mcp" ||
+    Boolean(
+      callbackUrl.searchParams
+        .get("state")
+        ?.startsWith(ELECTRON_MCP_CALLBACK_STATE_PREFIX),
+    )
+  );
+}
+
+function buildRendererCallbackUrl(
+  callbackUrl: URL,
+  baseUrl: string,
+): URL | null {
+  const flow = callbackUrl.searchParams.get("flow");
+
+  if (flow === "debug") {
+    return null;
+  }
+
+  const isMcpCallback = isElectronMcpCallbackUrl(callbackUrl);
+  const rendererPath = isMcpCallback ? "/oauth/callback" : "/callback";
+  const rendererUrl = new URL(rendererPath, baseUrl);
+
+  for (const [key, value] of callbackUrl.searchParams.entries()) {
+    if (key === "flow") continue;
+    rendererUrl.searchParams.append(key, value);
+  }
+
+  return rendererUrl;
+}
 
 async function startHonoServer(): Promise<number> {
   try {
@@ -96,6 +204,34 @@ function createMainWindow(serverUrl: string): BrowserWindow {
     window.webContents.openDevTools();
   }
 
+  const maybeOpenExternalNavigation = (
+    event: { preventDefault: () => void },
+    url: string,
+    isMainFrame: boolean,
+  ) => {
+    if (!isMainFrame || !isHostedAuthNavigation(url)) {
+      return;
+    }
+
+    log.info("Opening hosted auth in system browser");
+    event.preventDefault();
+    void shell.openExternal(createElectronHostedAuthNavigationUrl(url));
+  };
+
+  window.webContents.on(
+    "will-navigate",
+    (event, url, _isInPlace, isMainFrame) => {
+      maybeOpenExternalNavigation(event, url, isMainFrame);
+    },
+  );
+
+  window.webContents.on(
+    "will-redirect",
+    (event, url, _isInPlace, isMainFrame) => {
+      maybeOpenExternalNavigation(event, url, isMainFrame);
+    },
+  );
+
   // Show window when ready
   window.once("ready-to-show", () => {
     window.show();
@@ -111,6 +247,65 @@ function createMainWindow(serverUrl: string): BrowserWindow {
   });
 
   return window;
+}
+
+async function handleOAuthCallbackUrl(url: string): Promise<void> {
+  if (!url.startsWith("mcpjam://oauth/callback")) {
+    return;
+  }
+
+  if (!appBootstrapped) {
+    pendingProtocolUrl = url;
+    return;
+  }
+
+  try {
+    log.info("OAuth callback received");
+
+    const parsed = new URL(url);
+    const callbackFlow = parsed.searchParams.get("flow");
+    const isMcpCallback = isElectronMcpCallbackUrl(parsed);
+    const hadMainWindow = Boolean(mainWindow);
+
+    if (serverPort === 0) {
+      serverPort = await startHonoServer();
+    }
+
+    const baseUrl = getRendererBaseUrl();
+    const rendererCallbackUrl = buildRendererCallbackUrl(parsed, baseUrl);
+
+    if (!mainWindow) {
+      if (rendererCallbackUrl) {
+        mainWindow = createMainWindow(baseUrl);
+        mainWindow.loadURL(rendererCallbackUrl.toString());
+      } else {
+        const debugCallbackUrl = new URL("/oauth/callback/debug", baseUrl);
+        for (const [key, value] of parsed.searchParams.entries()) {
+          if (key === "flow") continue;
+          debugCallbackUrl.searchParams.append(key, value);
+        }
+        mainWindow = createMainWindow(baseUrl);
+        mainWindow.loadURL(debugCallbackUrl.toString());
+      }
+    } else if (rendererCallbackUrl) {
+      mainWindow.loadURL(rendererCallbackUrl.toString());
+    }
+
+    if (mainWindow?.webContents && callbackFlow === "debug" && hadMainWindow) {
+      mainWindow.webContents.send("oauth-callback", url);
+    } else if (
+      mainWindow?.webContents &&
+      !isMcpCallback &&
+      callbackFlow !== "debug"
+    ) {
+      mainWindow.webContents.send("oauth-callback", url);
+    }
+
+    if (mainWindow?.isMinimized()) mainWindow.restore();
+    mainWindow?.focus();
+  } catch (error) {
+    log.error("Failed processing OAuth callback URL:", error);
+  }
 }
 
 function createAppMenu(): void {
@@ -202,17 +397,32 @@ app.whenReady().then(async () => {
   try {
     // Start the embedded Hono server
     serverPort = await startHonoServer();
-    const serverUrl = `http://127.0.0.1:${serverPort}`;
+    const serverUrl = getServerUrl();
 
     // Create the main window
     createAppMenu();
     mainWindow = createMainWindow(serverUrl);
 
     // Register IPC listeners
-    registerListeners(mainWindow);
+    registerListeners(mainWindow, () => mainWindow);
 
     // Setup auto-updater events to notify renderer when update is ready
     setupAutoUpdaterEvents(mainWindow);
+
+    appBootstrapped = true;
+
+    if (pendingProtocolUrl) {
+      const protocolUrl = pendingProtocolUrl;
+      pendingProtocolUrl = null;
+      await handleOAuthCallbackUrl(protocolUrl);
+    }
+
+    if (process.platform !== "darwin") {
+      const protocolUrl = findOAuthCallbackUrl(process.argv);
+      if (protocolUrl) {
+        await handleOAuthCallbackUrl(protocolUrl);
+      }
+    }
 
     log.info("MCPJam Electron app ready");
   } catch (error) {
@@ -238,14 +448,12 @@ app.on("activate", async () => {
   // On macOS, re-create window when the dock icon is clicked
   if (BrowserWindow.getAllWindows().length === 0) {
     if (serverPort > 0) {
-      const serverUrl = `http://127.0.0.1:${serverPort}`;
-      mainWindow = createMainWindow(serverUrl);
+      mainWindow = createMainWindow(getServerUrl());
     } else {
       // Restart server if needed
       try {
         serverPort = await startHonoServer();
-        const serverUrl = `http://127.0.0.1:${serverPort}`;
-        mainWindow = createMainWindow(serverUrl);
+        mainWindow = createMainWindow(getServerUrl());
       } catch (error) {
         log.error("Failed to restart server:", error);
       }
@@ -256,127 +464,50 @@ app.on("activate", async () => {
 // Handle OAuth callback URLs
 app.on("open-url", (event, url) => {
   event.preventDefault();
-  log.info("OAuth callback received:", url);
-
-  if (!url.startsWith("mcpjam://oauth/callback")) {
-    return;
-  }
-
-  try {
-    const parsed = new URL(url);
-    const code = parsed.searchParams.get("code") ?? "";
-    const state = parsed.searchParams.get("state") ?? "";
-
-    // Compute the base URL the renderer should load
-    const baseUrl = isDev
-      ? MAIN_WINDOW_VITE_DEV_SERVER_URL
-      : `http://127.0.0.1:${serverPort}`;
-
-    const callbackUrl = new URL("/callback", baseUrl);
-    if (code) callbackUrl.searchParams.set("code", code);
-    if (state) callbackUrl.searchParams.set("state", state);
-
-    // Ensure a window exists, then load the callback route directly
-    if (!mainWindow) {
-      mainWindow = createMainWindow(baseUrl);
-    }
-    mainWindow.loadURL(callbackUrl.toString());
-
-    // Still emit the event for any listeners
-    if (mainWindow && mainWindow.webContents) {
-      mainWindow.webContents.send("oauth-callback", url);
-    }
-
-    if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.focus();
-    }
-  } catch (e) {
-    log.error("Failed processing OAuth callback URL:", e);
-  }
+  void handleOAuthCallbackUrl(url);
 });
 
 // Security: Prevent new window creation, but allow OAuth popups
 app.on("web-contents-created", (_, contents) => {
-  contents.setWindowOpenHandler(({ url, features }) => {
+  contents.setWindowOpenHandler(({ url, frameName }) => {
     try {
-      const urlObj = new URL(url);
+      // The OAuth debugger popup explicitly names its window with the
+      // `oauth_authorization_` prefix so it can keep window.opener semantics.
+      if (frameName.startsWith("oauth_authorization_")) {
+        return {
+          action: "allow",
+          createWindow: (options) => {
+            const popup = new BrowserWindow({
+              ...options,
+              parent: mainWindow || undefined,
+              modal: false,
+              show: false,
+              webPreferences: {
+                ...options.webPreferences,
+                nodeIntegration: false,
+                contextIsolation: true,
+                preload: path.join(__dirname, "preload.js"),
+              },
+            });
 
-      // Allow OAuth authorization popups to be created within Electron
-      // OAuth authorization URLs are typically external HTTPS URLs
-      // Check if this looks like an OAuth flow (external HTTPS URL)
-      const isOAuthFlow =
-        urlObj.protocol === "https:" &&
-        // Common OAuth authorization endpoint patterns
-        (urlObj.pathname.includes("/oauth") ||
-          urlObj.pathname.includes("/authorize") ||
-          urlObj.pathname.includes("/auth") ||
-          urlObj.searchParams.has("client_id") ||
-          urlObj.searchParams.has("response_type"));
+            popup.once("ready-to-show", () => {
+              popup.show();
+            });
 
-      if (isOAuthFlow) {
-        // Parse window features to create popup window
-        const width = features?.includes("width=")
-          ? parseInt(features.match(/width=(\d+)/)?.[1] || "600")
-          : 600;
-        const height = features?.includes("height=")
-          ? parseInt(features.match(/height=(\d+)/)?.[1] || "700")
-          : 700;
-
-        // Create a new BrowserWindow for OAuth popup
-        const popup = new BrowserWindow({
-          width,
-          height,
-          webPreferences: {
-            nodeIntegration: false,
-            contextIsolation: true,
-            preload: path.join(__dirname, "preload.js"),
+            return popup.webContents;
           },
-          parent: mainWindow || undefined,
-          modal: false,
-          show: false,
-        });
-
-        // Load the OAuth URL
-        popup.loadURL(url);
-
-        // Show window when ready
-        popup.once("ready-to-show", () => {
-          popup.show();
-        });
-
-        // Handle OAuth callback redirects
-        popup.webContents.on("will-redirect", (event, navigationUrl) => {
-          try {
-            const redirectUrl = new URL(navigationUrl);
-            // If redirecting to our callback URL, handle it
-            if (
-              redirectUrl.protocol === "mcpjam:" ||
-              redirectUrl.pathname.includes("/callback") ||
-              redirectUrl.pathname.includes("/oauth/callback")
-            ) {
-              // Let the redirect happen, the callback handler will process it
-              // But we need to ensure the popup can communicate back
-            }
-          } catch (e) {
-            // Invalid URL, ignore
-          }
-        });
-
-        // Clean up when popup closes
-        popup.on("closed", () => {
-          // Popup closed, cleanup handled automatically
-        });
-
-        return { action: "allow" };
+        };
       }
 
-      // For all other URLs, open externally
-      shell.openExternal(url);
+      if (isSafeExternalUrl(url)) {
+        void shell.openExternal(url);
+      } else {
+        log.warn("Refusing to open non-HTTP URL from window.open");
+      }
       return { action: "deny" };
-    } catch (e) {
-      // If URL parsing fails, open externally as fallback
-      shell.openExternal(url);
+    } catch (error) {
+      // Invalid URLs are denied to avoid passing unsafe schemes to the shell.
+      log.error("Failed handling window.open URL:", error);
       return { action: "deny" };
     }
   });
@@ -395,8 +526,12 @@ const gotTheLock = app.requestSingleInstanceLock();
 if (!gotTheLock) {
   app.quit();
 } else {
-  app.on("second-instance", () => {
-    // Someone tried to run a second instance, focus our window instead
+  app.on("second-instance", (_event, argv) => {
+    const protocolUrl = findOAuthCallbackUrl(argv);
+    if (protocolUrl) {
+      void handleOAuthCallbackUrl(protocolUrl);
+    }
+
     if (mainWindow) {
       if (mainWindow.isMinimized()) mainWindow.restore();
       mainWindow.focus();

--- a/mcpjam-inspector/src/preload.ts
+++ b/mcpjam-inspector/src/preload.ts
@@ -12,6 +12,7 @@ interface ElectronAPI {
   app: {
     getVersion: () => Promise<string>;
     getPlatform: () => Promise<string>;
+    openExternal: (url: string) => Promise<void>;
   };
 
   // File operations
@@ -56,6 +57,7 @@ const electronAPI: ElectronAPI = {
   app: {
     getVersion: () => ipcRenderer.invoke("app:version"),
     getPlatform: () => ipcRenderer.invoke("app:platform"),
+    openExternal: (url) => ipcRenderer.invoke("app:open-external", url),
   },
 
   files: {

--- a/mcpjam-inspector/vite.renderer.config.mts
+++ b/mcpjam-inspector/vite.renderer.config.mts
@@ -31,12 +31,19 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       fs: {
-        allow: [resolve(__dirname, "./client/src/assets")],
+        allow: [resolve(__dirname, "./client"), resolve(__dirname, "./shared")],
       },
       proxy: {
         "/api": {
           target: "http://localhost:6274",
           changeOrigin: true,
+        },
+        // Proxy WorkOS API calls during Electron local dev to avoid browser CORS
+        // issues and match the web client Vite config behavior.
+        "/user_management": {
+          target: "https://api.workos.com",
+          changeOrigin: true,
+          secure: true,
         },
       },
     },


### PR DESCRIPTION
## Summary

- Electron account sign-in/sign-up now go through the system browser instead of trying to finish inside the app.
- Electron server/integration OAuth also uses the system browser.
- The OAuth debugger in Electron follows the same browser-based flow.
- Electron-launched auth is tagged so the browser callback knows it should hand control back to the desktop app.
- After MCP OAuth finishes in the browser, users see a clear “Continue in MCPJam Desktop” handoff page.

## Testing

- Added focused coverage for Electron browser launch, callback handoff, and MCP OAuth state tagging.
- Ran the focused OAuth, callback, and Electron listener tests.
