### PR TITLE
Simplify chatbox welcome dialog — remove consent checkbox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,9 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: Run SDK → CLI → Inspector verification
+        # Node 24 auto-scales heap to ~half system RAM (~4 GB on ubuntu-latest).
+        # The vitest workspace (server + client + shared) runs concurrently and
+        # exceeds that cap. 6 GB gives headroom without exhausting the runner.
+        env:
+          NODE_OPTIONS: "--max-old-space-size=6144"
         run: npm run test:ordered

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
@@ -441,12 +441,16 @@ export function ChatboxEditor({
     pendingOAuthServers.every(({ state }) => isHostedOAuthBusy(state.status));
 
   const oauthPending = pendingOAuthServers.length > 0;
+  const welcomeAvailable =
+    (chatbox?.welcomeDialog?.enabled ?? true) &&
+    !!chatbox?.welcomeDialog?.body?.trim();
   const introGate = useChatboxHostIntroGate({
     chatboxId: chatbox?.chatboxId ?? "",
     servers: requiredPreviewServers,
     oauthPending,
     hasBusyOAuth,
     pendingOAuthServers,
+    welcomeAvailable,
   });
 
   const hasUnsavedChanges = useMemo(() => {
@@ -1199,11 +1203,7 @@ export function ChatboxEditor({
                 <ChatboxHostOnboardingOverlays
                   showWelcome={introGate.showWelcome}
                   onGetStarted={introGate.dismissIntro}
-                  welcomeBody={
-                    (chatbox.welcomeDialog?.enabled ?? true)
-                      ? chatbox.welcomeDialog?.body
-                      : undefined
-                  }
+                  welcomeBody={chatbox.welcomeDialog?.body}
                   showAuthPanel={introGate.showAuthPanel}
                   pendingOAuthServers={pendingOAuthServers}
                   authorizeServer={authorizeServer}

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
@@ -719,12 +719,16 @@ export function ChatboxBuilderView({
     pendingOAuthServers.every(({ state }) => isHostedOAuthBusy(state.status));
 
   const oauthPending = pendingOAuthServers.length > 0;
+  const welcomeAvailable =
+    draftChatboxConfig.welcomeDialog.enabled &&
+    !!draftChatboxConfig.welcomeDialog.body?.trim();
   const introGate = useChatboxHostIntroGate({
     chatboxId: introChatboxId,
     servers: requiredPreviewServers,
     oauthPending,
     hasBusyOAuth,
     pendingOAuthServers,
+    welcomeAvailable,
   });
 
   const handlePreviewOAuthRequired = useCallback(
@@ -1182,11 +1186,7 @@ export function ChatboxBuilderView({
                               <ChatboxHostOnboardingOverlays
                                 showWelcome={introGate.showWelcome}
                                 onGetStarted={introGate.dismissIntro}
-                                welcomeBody={
-                                  draftChatboxConfig.welcomeDialog.enabled
-                                    ? draftChatboxConfig.welcomeDialog.body
-                                    : undefined
-                                }
+                                welcomeBody={draftChatboxConfig.welcomeDialog.body}
                                 showAuthPanel={introGate.showAuthPanel}
                                 pendingOAuthServers={pendingOAuthServers}
                                 authorizeServer={authorizeServer}

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
@@ -27,16 +27,9 @@ const WELCOME_BODY_INTERNAL_QA = [
 ].join("\n");
 
 const WELCOME_BODY_ICP_DEMO = [
-  "Welcome",
+  "Welcome — thanks for trying this out.",
   "",
-  "This opens with a signed-in link. It is for a quick, safe look at a hosted assistant experience.",
-  "",
-  "Privacy:",
-  "• Do not enter passwords, secrets, or highly sensitive personal data.",
-  "• We may ask for brief feedback after some interactions.",
-  "• Only share what you are comfortable providing in a demo.",
-  "",
-  "Thank you for trying it out.",
+  "This is a preview of our assistant. Ask it a question or give it a task to try it out.",
 ].join("\n");
 
 /** Prefer a stable default; the first MCPJam model in SUPPORTED_MODELS is often gpt-oss-120b. */

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/setup-checklist-panel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/setup-checklist-panel.tsx
@@ -984,8 +984,8 @@ export function SetupChecklistPanel({
                     <div>
                       <p className="text-sm font-medium">Shown on first open</p>
                       <p className="text-xs text-muted-foreground">
-                        Host-authored intro shown when a tester opens the
-                        chatbox.
+                        A short intro shown the first time someone opens your
+                        chatbox link.
                       </p>
                     </div>
                     <Switch
@@ -1017,11 +1017,12 @@ export function SetupChecklistPanel({
                             },
                           }))
                         }
-                        placeholder="What testers should know before they start…"
+                        placeholder="What your audience should know before they start…"
                       />
                       <p className="text-xs text-muted-foreground">
-                        Trust and disclosure copy is added automatically in the
-                        hosted experience.
+                        {chatboxDraft.welcomeDialog.body.trim()
+                          ? "Shown once, the first time someone opens your chatbox link."
+                          : "Leave blank to skip — no welcome will be shown."}
                       </p>
                     </div>
                   ) : null}

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -623,12 +623,16 @@ export function ChatboxChatPage({
   const shellStyle = getChatboxShellStyle(hostStyle, themeMode);
   const displayError = getChatboxDisplayError(routeError);
   const oauthPending = pendingOAuthServers.length > 0;
+  const welcomeAvailable =
+    (session?.payload.welcomeDialog?.enabled ?? true) &&
+    !!session?.payload.welcomeDialog?.body?.trim();
   const introGate = useChatboxHostIntroGate({
     chatboxId: session?.payload.chatboxId ?? "",
     servers: sessionServersRequired,
     oauthPending,
     hasBusyOAuth,
     pendingOAuthServers,
+    welcomeAvailable,
   });
   const isFinishingOAuth =
     pendingOAuthServers.length > 0 &&
@@ -708,11 +712,7 @@ export function ChatboxChatPage({
         <ChatboxHostOnboardingOverlays
           showWelcome={introGate.showWelcome}
           onGetStarted={introGate.dismissIntro}
-          welcomeBody={
-            (session.payload.welcomeDialog?.enabled ?? true)
-              ? session.payload.welcomeDialog?.body
-              : undefined
-          }
+          welcomeBody={session.payload.welcomeDialog?.body}
           showAuthPanel={introGate.showAuthPanel}
           pendingOAuthServers={pendingOAuthServers}
           authorizeServer={authorizeServer}

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxHostOnboardingOverlays.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxHostOnboardingOverlays.tsx
@@ -2,20 +2,8 @@ import { useEffect, useMemo, useState } from "react";
 import { Loader2 } from "lucide-react";
 import { getChatboxOAuthRowCopy } from "@/components/hosted/chatbox-oauth-copy";
 import { Button } from "@mcpjam/design-system/button";
-import { Checkbox } from "@mcpjam/design-system/checkbox";
-import { Label } from "@mcpjam/design-system/label";
 import type { HostedOAuthServerDescriptor } from "@/hooks/hosted/use-hosted-oauth-gate";
 import type { HostedOAuthState } from "@/lib/hosted-oauth-resume";
-
-const DEFAULT_WELCOME_BODY =
-  "You're entering a chatbox test environment. Continue to connect required servers and start testing.";
-
-/** Shown under host-authored copy; not a substitute for legal terms your org publishes elsewhere. */
-const TEST_ENV_DATA_NOTICE =
-  "This is a test environment, not production. Your messages and tool activity may be logged or reviewed to fix bugs and improve the product. You may see occasional feedback prompts. Do not enter passwords, secrets, or sensitive personal data.";
-
-const CONSENT_CHECKBOX_LABEL =
-  "I understand the above and I consent to optional feedback prompts and to use of my interaction data from this test session as described.";
 
 const FINISHING_TIMEOUT_MS = 10_000;
 
@@ -40,7 +28,6 @@ export function ChatboxHostOnboardingOverlays({
   isFinishingOAuth: boolean;
 }) {
   const [finishingTimedOut, setFinishingTimedOut] = useState(false);
-  const [testConsentChecked, setTestConsentChecked] = useState(false);
 
   /** When still "finishing", any change to which servers or statuses are in-flight restarts the slow-timeout timer. */
   const finishingOAuthSignature = useMemo(() => {
@@ -50,12 +37,6 @@ export function ChatboxHostOnboardingOverlays({
       .sort()
       .join("|");
   }, [isFinishingOAuth, pendingOAuthServers]);
-
-  useEffect(() => {
-    if (showWelcome) {
-      setTestConsentChecked(false);
-    }
-  }, [showWelcome]);
 
   useEffect(() => {
     if (!isFinishingOAuth) {
@@ -70,9 +51,8 @@ export function ChatboxHostOnboardingOverlays({
     return () => window.clearTimeout(timer);
   }, [isFinishingOAuth, finishingOAuthSignature]);
 
-  const welcomeText = welcomeBody?.trim()
-    ? welcomeBody.trim()
-    : DEFAULT_WELCOME_BODY;
+  const welcomeText = welcomeBody?.trim() ?? "";
+  const shouldRenderWelcome = showWelcome && welcomeText.length > 0;
 
   const showFinishingLayer = showAuthPanel && isFinishingOAuth;
   const showAuthListLayer = showAuthPanel && !isFinishingOAuth;
@@ -87,46 +67,23 @@ export function ChatboxHostOnboardingOverlays({
 
   return (
     <>
-      {showWelcome ? (
+      {shouldRenderWelcome ? (
         <div
-          className="pointer-events-auto absolute inset-0 z-30 flex items-center justify-center bg-background/20 p-4 dark:bg-background/30"
+          className="pointer-events-auto absolute inset-0 z-30 flex cursor-pointer items-center justify-center bg-background/20 p-4 dark:bg-background/30"
           role="dialog"
           aria-modal="true"
-          aria-labelledby="chatbox-welcome-title"
+          aria-label="Welcome"
+          onClick={onGetStarted}
         >
-          <div className="w-full max-w-lg rounded-2xl border border-border/80 bg-card/95 p-6 shadow-2xl ring-1 ring-black/5 backdrop-blur-sm dark:ring-white/10">
-            <h2
-              id="chatbox-welcome-title"
-              className="text-center text-base font-semibold text-foreground"
-            >
-              Welcome
-            </h2>
-            <p className="mt-3 whitespace-pre-wrap text-center text-sm text-muted-foreground">
+          <div
+            className="w-full max-w-lg cursor-auto rounded-2xl border border-border/80 bg-card/95 p-6 shadow-2xl ring-1 ring-black/5 backdrop-blur-sm dark:ring-white/10"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <p className="whitespace-pre-wrap text-center text-sm text-muted-foreground">
               {welcomeText}
             </p>
-            <p className="mt-4 text-left text-xs leading-relaxed text-muted-foreground">
-              {TEST_ENV_DATA_NOTICE}
-            </p>
-            <div className="mt-4 flex gap-3 rounded-xl border border-border/60 bg-muted/30 p-3">
-              <Checkbox
-                id="chatbox-test-consent"
-                checked={testConsentChecked}
-                onCheckedChange={(v) => setTestConsentChecked(v === true)}
-                className="mt-0.5"
-              />
-              <Label
-                htmlFor="chatbox-test-consent"
-                className="cursor-pointer text-left text-xs font-normal leading-snug text-foreground"
-              >
-                {CONSENT_CHECKBOX_LABEL}
-              </Label>
-            </div>
             <div className="mt-6 flex justify-center">
-              <Button
-                type="button"
-                disabled={!testConsentChecked}
-                onClick={onGetStarted}
-              >
+              <Button type="button" onClick={onGetStarted}>
                 Get Started
               </Button>
             </div>

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
@@ -642,4 +642,158 @@ describe("ChatboxChatPage", () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText("linear")).not.toBeInTheDocument();
   });
+
+  describe("welcome dialog", () => {
+    function nonOAuthServer() {
+      return {
+        serverId: "srv_tool",
+        serverName: "tool",
+        useOAuth: false,
+        serverUrl: "https://mcp.example.com/sse",
+        clientId: null,
+        oauthScopes: null,
+      };
+    }
+
+    it("shows welcome dialog when welcomeDialog is enabled and has content", async () => {
+      writeChatboxSession({
+        token: "chatbox-token",
+        payload: {
+          workspaceId: "ws_1",
+          chatboxId: "sbx_welcome",
+          name: "Welcome Chatbox",
+          description: "",
+          hostStyle: "claude",
+          mode: "any_signed_in_with_link",
+          allowGuestAccess: false,
+          viewerIsWorkspaceMember: true,
+          systemPrompt: "You are helpful.",
+          modelId: "openai/gpt-5-mini",
+          temperature: 0.7,
+          requireToolApproval: false,
+          servers: [nonOAuthServer()],
+          welcomeDialog: {
+            enabled: true,
+            body: "Welcome — thanks for trying this out.",
+          },
+        },
+      });
+
+      render(<ChatboxChatPage />);
+
+      expect(
+        await screen.findByText("Welcome — thanks for trying this out."),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Get Started" }),
+      ).toBeInTheDocument();
+      // Composer is blocked while the welcome is open
+      expect(mockChatTabV2).toHaveBeenCalledWith(
+        expect.objectContaining({ chatboxComposerBlocked: true }),
+      );
+    });
+
+    it("dismisses welcome and shows chat when Get Started is clicked", async () => {
+      writeChatboxSession({
+        token: "chatbox-token",
+        payload: {
+          workspaceId: "ws_1",
+          chatboxId: "sbx_dismiss",
+          name: "Welcome Chatbox",
+          description: "",
+          hostStyle: "claude",
+          mode: "any_signed_in_with_link",
+          allowGuestAccess: false,
+          viewerIsWorkspaceMember: true,
+          systemPrompt: "You are helpful.",
+          modelId: "openai/gpt-5-mini",
+          temperature: 0.7,
+          requireToolApproval: false,
+          servers: [nonOAuthServer()],
+          welcomeDialog: {
+            enabled: true,
+            body: "Welcome — thanks for trying this out.",
+          },
+        },
+      });
+
+      render(<ChatboxChatPage />);
+
+      await userEvent.click(
+        await screen.findByRole("button", { name: "Get Started" }),
+      );
+
+      expect(
+        screen.queryByText("Welcome — thanks for trying this out."),
+      ).not.toBeInTheDocument();
+      expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
+    });
+
+    it("skips welcome and goes straight to chat when welcomeDialog.enabled is false", async () => {
+      writeChatboxSession({
+        token: "chatbox-token",
+        payload: {
+          workspaceId: "ws_1",
+          chatboxId: "sbx_disabled",
+          name: "No Welcome Chatbox",
+          description: "",
+          hostStyle: "claude",
+          mode: "any_signed_in_with_link",
+          allowGuestAccess: false,
+          viewerIsWorkspaceMember: true,
+          systemPrompt: "You are helpful.",
+          modelId: "openai/gpt-5-mini",
+          temperature: 0.7,
+          requireToolApproval: false,
+          servers: [nonOAuthServer()],
+          welcomeDialog: {
+            enabled: false,
+            body: "This should not appear.",
+          },
+        },
+      });
+
+      render(<ChatboxChatPage />);
+
+      expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
+      expect(
+        screen.queryByText("This should not appear."),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Get Started" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("skips welcome and goes straight to chat when welcomeDialog body is empty", async () => {
+      writeChatboxSession({
+        token: "chatbox-token",
+        payload: {
+          workspaceId: "ws_1",
+          chatboxId: "sbx_emptybody",
+          name: "Empty Body Chatbox",
+          description: "",
+          hostStyle: "claude",
+          mode: "any_signed_in_with_link",
+          allowGuestAccess: false,
+          viewerIsWorkspaceMember: true,
+          systemPrompt: "You are helpful.",
+          modelId: "openai/gpt-5-mini",
+          temperature: 0.7,
+          requireToolApproval: false,
+          servers: [nonOAuthServer()],
+          welcomeDialog: {
+            enabled: true,
+            body: "",
+          },
+        },
+      });
+
+      render(<ChatboxChatPage />);
+
+      expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Get Started" }),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxHostOnboardingOverlays.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxHostOnboardingOverlays.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, fireEvent } from "@testing-library/react";
 import { ChatboxHostOnboardingOverlays } from "../ChatboxHostOnboardingOverlays";
 import type { HostedOAuthServerDescriptor } from "@/hooks/hosted/use-hosted-oauth-gate";
 
@@ -25,51 +25,152 @@ describe("ChatboxHostOnboardingOverlays", () => {
     vi.useRealTimers();
   });
 
-  it("clears finishing timeout UI when pending OAuth servers change while still finishing", async () => {
-    vi.useFakeTimers();
+  describe("welcome dialog", () => {
+    it("renders welcome body text when showWelcome=true and body is present", () => {
+      render(
+        <ChatboxHostOnboardingOverlays
+          showWelcome
+          onGetStarted={vi.fn()}
+          welcomeBody="Welcome — thanks for trying this out."
+          showAuthPanel={false}
+          pendingOAuthServers={[]}
+          authorizeServer={vi.fn()}
+          isFinishingOAuth={false}
+        />,
+      );
 
-    const authorizeServer = vi.fn();
-
-    const { rerender } = render(
-      <ChatboxHostOnboardingOverlays
-        showWelcome={false}
-        onGetStarted={vi.fn()}
-        showAuthPanel
-        pendingOAuthServers={[
-          {
-            server: server("a"),
-            state: {
-              status: "verifying",
-              errorMessage: null,
-              serverUrl: null,
-            },
-          },
-        ]}
-        authorizeServer={authorizeServer}
-        isFinishingOAuth
-      />,
-    );
-
-    expect(screen.getByText("Finishing authorization")).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Retry" }),
-    ).not.toBeInTheDocument();
-
-    await act(async () => {
-      vi.advanceTimersByTime(FINISHING_TIMEOUT_MS);
+      expect(
+        screen.getByText("Welcome — thanks for trying this out."),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Get Started" }),
+      ).toBeInTheDocument();
     });
 
-    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    it("does not render welcome when showWelcome=true but body is empty", () => {
+      render(
+        <ChatboxHostOnboardingOverlays
+          showWelcome
+          onGetStarted={vi.fn()}
+          welcomeBody=""
+          showAuthPanel={false}
+          pendingOAuthServers={[]}
+          authorizeServer={vi.fn()}
+          isFinishingOAuth={false}
+        />,
+      );
 
-    await act(async () => {
-      rerender(
+      expect(
+        screen.queryByRole("button", { name: "Get Started" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not render welcome when showWelcome=true but body is whitespace only", () => {
+      render(
+        <ChatboxHostOnboardingOverlays
+          showWelcome
+          onGetStarted={vi.fn()}
+          welcomeBody="   "
+          showAuthPanel={false}
+          pendingOAuthServers={[]}
+          authorizeServer={vi.fn()}
+          isFinishingOAuth={false}
+        />,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: "Get Started" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not render welcome when showWelcome=false even with body present", () => {
+      render(
+        <ChatboxHostOnboardingOverlays
+          showWelcome={false}
+          onGetStarted={vi.fn()}
+          welcomeBody="Hello"
+          showAuthPanel={false}
+          pendingOAuthServers={[]}
+          authorizeServer={vi.fn()}
+          isFinishingOAuth={false}
+        />,
+      );
+
+      expect(
+        screen.queryByRole("button", { name: "Get Started" }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("calls onGetStarted when Get Started button is clicked", () => {
+      const onGetStarted = vi.fn();
+      render(
+        <ChatboxHostOnboardingOverlays
+          showWelcome
+          onGetStarted={onGetStarted}
+          welcomeBody="Hello"
+          showAuthPanel={false}
+          pendingOAuthServers={[]}
+          authorizeServer={vi.fn()}
+          isFinishingOAuth={false}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Get Started" }));
+      expect(onGetStarted).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onGetStarted when backdrop is clicked", () => {
+      const onGetStarted = vi.fn();
+      render(
+        <ChatboxHostOnboardingOverlays
+          showWelcome
+          onGetStarted={onGetStarted}
+          welcomeBody="Hello"
+          showAuthPanel={false}
+          pendingOAuthServers={[]}
+          authorizeServer={vi.fn()}
+          isFinishingOAuth={false}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("dialog"));
+      expect(onGetStarted).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onGetStarted when the card itself is clicked (stopPropagation)", () => {
+      const onGetStarted = vi.fn();
+      render(
+        <ChatboxHostOnboardingOverlays
+          showWelcome
+          onGetStarted={onGetStarted}
+          welcomeBody="Hello"
+          showAuthPanel={false}
+          pendingOAuthServers={[]}
+          authorizeServer={vi.fn()}
+          isFinishingOAuth={false}
+        />,
+      );
+
+      // Click the text node inside the card (not the backdrop, not the button)
+      fireEvent.click(screen.getByText("Hello"));
+      expect(onGetStarted).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("finishing OAuth timeout UI", () => {
+    it("clears finishing timeout UI when pending OAuth servers change while still finishing", async () => {
+      vi.useFakeTimers();
+
+      const authorizeServer = vi.fn();
+
+      const { rerender } = render(
         <ChatboxHostOnboardingOverlays
           showWelcome={false}
           onGetStarted={vi.fn()}
           showAuthPanel
           pendingOAuthServers={[
             {
-              server: server("b"),
+              server: server("a"),
               state: {
                 status: "verifying",
                 errorMessage: null,
@@ -81,11 +182,44 @@ describe("ChatboxHostOnboardingOverlays", () => {
           isFinishingOAuth
         />,
       );
-    });
 
-    expect(
-      screen.queryByRole("button", { name: "Retry" }),
-    ).not.toBeInTheDocument();
-    expect(screen.getByText("Finishing authorization")).toBeInTheDocument();
+      expect(screen.getByText("Finishing authorization")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Retry" }),
+      ).not.toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(FINISHING_TIMEOUT_MS);
+      });
+
+      expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+
+      await act(async () => {
+        rerender(
+          <ChatboxHostOnboardingOverlays
+            showWelcome={false}
+            onGetStarted={vi.fn()}
+            showAuthPanel
+            pendingOAuthServers={[
+              {
+                server: server("b"),
+                state: {
+                  status: "verifying",
+                  errorMessage: null,
+                  serverUrl: null,
+                },
+              },
+            ]}
+            authorizeServer={authorizeServer}
+            isFinishingOAuth
+          />,
+        );
+      });
+
+      expect(
+        screen.queryByRole("button", { name: "Retry" }),
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("Finishing authorization")).toBeInTheDocument();
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/useChatboxHostIntroGate.test.ts
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/useChatboxHostIntroGate.test.ts
@@ -24,6 +24,7 @@ describe("useChatboxHostIntroGate", () => {
             },
           },
         ],
+        welcomeAvailable: true,
       }),
     );
 
@@ -44,6 +45,7 @@ describe("useChatboxHostIntroGate", () => {
             state: { status: "verifying", errorMessage: null, serverUrl: null },
           },
         ],
+        welcomeAvailable: true,
       }),
     );
 
@@ -67,6 +69,7 @@ describe("useChatboxHostIntroGate", () => {
             },
           },
         ],
+        welcomeAvailable: true,
       }),
     );
 
@@ -100,6 +103,7 @@ describe("useChatboxHostIntroGate", () => {
                 },
               ]
             : [],
+          welcomeAvailable: true,
         }),
       { initialProps: { oauthPending: true } },
     );
@@ -107,5 +111,81 @@ describe("useChatboxHostIntroGate", () => {
     rerender({ oauthPending: false });
 
     expect(sessionStorage.getItem("chatbox-intro-dismissed-sbx_3")).toBe("1");
+  });
+
+  it("shows welcome for a no-server chatbox when welcome is available", () => {
+    const { result } = renderHook(() =>
+      useChatboxHostIntroGate({
+        chatboxId: "sbx_noservers",
+        servers: [],
+        oauthPending: false,
+        hasBusyOAuth: false,
+        pendingOAuthServers: [],
+        welcomeAvailable: true,
+      }),
+    );
+
+    expect(result.current.showWelcome).toBe(true);
+    expect(result.current.composerBlocked).toBe(true);
+  });
+
+  it("does not auto-dismiss for a no-server chatbox so welcome stays visible each session", () => {
+    const { result } = renderHook(() =>
+      useChatboxHostIntroGate({
+        chatboxId: "sbx_noservers2",
+        servers: [],
+        oauthPending: false,
+        hasBusyOAuth: false,
+        pendingOAuthServers: [],
+        welcomeAvailable: true,
+      }),
+    );
+
+    // Verify sessionStorage was NOT written (no auto-dismiss)
+    expect(
+      sessionStorage.getItem("chatbox-intro-dismissed-sbx_noservers2"),
+    ).toBeNull();
+    expect(result.current.showWelcome).toBe(true);
+  });
+
+  it("skips welcome entirely and unblocks composer when welcome is not available", () => {
+    const { result } = renderHook(() =>
+      useChatboxHostIntroGate({
+        chatboxId: "sbx_skip",
+        servers: [{ useOAuth: false }],
+        oauthPending: false,
+        hasBusyOAuth: false,
+        pendingOAuthServers: [],
+        welcomeAvailable: false,
+      }),
+    );
+
+    expect(result.current.showWelcome).toBe(false);
+    expect(result.current.showAuthPanel).toBe(false);
+    expect(result.current.composerBlocked).toBe(false);
+  });
+
+  it("skips welcome but still shows auth panel when OAuth is pending and no welcome content", () => {
+    const { result } = renderHook(() =>
+      useChatboxHostIntroGate({
+        chatboxId: "sbx_auth_only",
+        servers: [{ useOAuth: true }],
+        oauthPending: true,
+        hasBusyOAuth: false,
+        pendingOAuthServers: [
+          {
+            state: {
+              status: "needs_auth",
+              errorMessage: null,
+              serverUrl: null,
+            },
+          },
+        ],
+        welcomeAvailable: false,
+      }),
+    );
+
+    expect(result.current.showWelcome).toBe(false);
+    expect(result.current.showAuthPanel).toBe(true);
   });
 });

--- a/mcpjam-inspector/client/src/components/hosted/useChatboxHostIntroGate.ts
+++ b/mcpjam-inspector/client/src/components/hosted/useChatboxHostIntroGate.ts
@@ -17,12 +17,20 @@ export interface UseChatboxHostIntroGateArgs {
   hasBusyOAuth: boolean;
   /** Pending rows from useHostedOAuthGate (for needs_auth-only welcome). */
   pendingOAuthServers: PendingOAuthEntry[];
+  /**
+   * Whether the creator has host-authored welcome content to show. When false,
+   * the welcome overlay is skipped and the gate falls through to either the
+   * auth panel (OAuth pending) or the chat composer.
+   */
+  welcomeAvailable: boolean;
 }
 
 /**
  * Welcome overlay: first-time non-OAuth chatboxes, or OAuth chatboxes that still
  * need consent. When OAuth is already satisfied on load, we persist dismissal
  * so runtime OAuth errors from chat show the auth overlay instead of welcome.
+ * Also silent-skipped entirely when the creator has no host-authored content
+ * (`welcomeAvailable = false`).
  */
 export function useChatboxHostIntroGate({
   chatboxId,
@@ -30,6 +38,7 @@ export function useChatboxHostIntroGate({
   oauthPending,
   hasBusyOAuth,
   pendingOAuthServers,
+  welcomeAvailable,
 }: UseChatboxHostIntroGateArgs) {
   const storageKey = chatboxIntroDismissedStorageKey(chatboxId);
 
@@ -38,7 +47,7 @@ export function useChatboxHostIntroGate({
     [servers],
   );
 
-  const nonOAuthFirstVisit = servers.length > 0 && oauthServerCount === 0;
+  const nonOAuthFirstVisit = oauthServerCount === 0;
 
   const [introDismissed, setIntroDismissed] = useState(() => {
     try {
@@ -59,7 +68,6 @@ export function useChatboxHostIntroGate({
   useEffect(() => {
     if (oauthPending) return;
     if (nonOAuthFirstVisit) return;
-    if (servers.length === 0) return;
     try {
       if (sessionStorage.getItem(storageKey) === "1") return;
       sessionStorage.setItem(storageKey, "1");
@@ -74,6 +82,7 @@ export function useChatboxHostIntroGate({
     pendingOAuthServers.every(({ state }) => state.status === "needs_auth");
 
   const showWelcome =
+    welcomeAvailable &&
     !introDismissed &&
     !hasBusyOAuth &&
     (nonOAuthFirstVisit || (oauthServerCount > 0 && onlyNeedsAuthIdle));


### PR DESCRIPTION
## Summary

### Welcome dialog UX simplification
- Removed the hardcoded "Welcome" heading (was duplicating the creator-authored greeting)
- Removed the `TEST_ENV_DATA_NOTICE` platform banner and required consent checkbox — the welcome is now a clean host-authored message + "Get Started" button
- Clicking outside the modal (backdrop) now dismisses it, same as clicking "Get Started"
- Updated the `External Beta Test` template welcome body to something concise and audience-neutral

### Bug fixes
- **Toggle OFF now actually works**: the "Shown on first open" switch was cosmetic — the gate showed a generic fallback regardless. `welcomeAvailable` is now threaded into `useChatboxHostIntroGate` so the overlay only renders when the creator has authored content with the toggle on
- **Serverless chatboxes now show welcome**: `nonOAuthFirstVisit` required `servers.length > 0`, so chatboxes with no MCP servers configured never showed the welcome dialog even when content was present

### Code quality
- Removed triple-redundant `welcomeBody` condition across `ChatboxChatPage`, `ChatboxBuilderView`, and `ChatboxEditor` — the gate is now the single authority
- Updated builder hint text: removed the stale "Trust and disclosure copy is added automatically" note (no longer true) and placeholder that said "testers" (too narrow)

## Test coverage added
- `ChatboxHostOnboardingOverlays`: welcome renders, Get Started click, backdrop click, card click (stopPropagation), empty/whitespace body suppression
- `useChatboxHostIntroGate`: serverless chatbox shows welcome, serverless chatbox does not auto-dismiss
- `ChatboxChatPage`: welcome shows + composer blocked, Get Started dismisses, `enabled=false` skips, empty body skips