### PR TITLE
Chatbox nits

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/ChatboxesTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatboxesTab.test.tsx
@@ -214,7 +214,7 @@ vi.mock("../chatboxes/builder/ChatboxBuilderView", () => ({
         <h2>Builder view</h2>
         <p>Chatbox: {props.chatboxId ?? "new"}</p>
         <p>Draft: {props.draft?.name ?? "none"}</p>
-        <p>Workspace: {props.workspaceName ?? "unknown"}</p>
+        <p>Workspace: {props.workspaceId ?? "unknown"}</p>
         <p>View mode: {props.initialViewMode ?? "none"}</p>
         <button type="button" onClick={props.onBack}>
           Back to index
@@ -309,7 +309,7 @@ describe("ChatboxesTab", () => {
 
     expect(await screen.findByText("Builder view")).toBeInTheDocument();
     expect(screen.getByText("Chatbox: sbx-2")).toBeInTheDocument();
-    expect(screen.getByText("Workspace: Workspace One")).toBeInTheDocument();
+    expect(screen.getByText("Workspace: ws-1")).toBeInTheDocument();
   });
 
   it("opens the starter launcher from the new chatbox action", async () => {

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
@@ -10,6 +10,7 @@ import {
   Lock,
   Save,
   Trash2,
+  Users,
 } from "lucide-react";
 import { toast } from "sonner";
 import {
@@ -18,6 +19,11 @@ import {
   type ServerFormData,
 } from "@/shared/types";
 import type { ChatboxMode, ChatboxSettings } from "@/hooks/useChatboxes";
+import {
+  chatboxAccessPresetFromSettings,
+  settingsFromChatboxAccessPreset,
+  type ChatboxAccessPreset,
+} from "@/lib/chatbox-access-presets";
 import { useChatboxMutations } from "@/hooks/useChatboxes";
 import { useServerMutations } from "@/hooks/useWorkspaces";
 import { AddServerModal } from "@/components/connection/AddServerModal";
@@ -107,6 +113,7 @@ function isInsecureUrl(url: string | undefined): boolean {
 interface ChatboxEditorProps {
   chatbox?: ChatboxSettings | null;
   workspaceId: string;
+  workspaceName?: string | null;
   workspaceServers: WorkspaceServerOption[];
   onBack: () => void;
   onSaved?: (chatbox: ChatboxSettings) => void;
@@ -130,6 +137,7 @@ function createPlaygroundId(): string {
 export function ChatboxEditor({
   chatbox,
   workspaceId,
+  workspaceName,
   workspaceServers,
   onBack,
   onSaved,
@@ -298,6 +306,18 @@ export function ChatboxEditor({
     () => workspaceServers.filter((s) => s.transportType === "http"),
     [workspaceServers],
   );
+
+  const workspaceAccessLabel = workspaceName?.trim() || "Workspace";
+  const accessPreset = useMemo(
+    () => chatboxAccessPresetFromSettings(mode, allowGuestAccess),
+    [mode, allowGuestAccess],
+  );
+
+  const applyCreateAccessPreset = (preset: ChatboxAccessPreset) => {
+    const next = settingsFromChatboxAccessPreset(preset);
+    setMode(next.mode);
+    setAllowGuestAccess(next.allowGuestAccess);
+  };
 
   const previewToken = chatbox?.link?.token?.trim() || null;
   const canPreview = Boolean(previewToken);
@@ -484,23 +504,6 @@ export function ChatboxEditor({
     optionalServerIds,
     chatbox,
   ]);
-
-  const handleServerOptionalChange = (serverId: string, optional: boolean) => {
-    const requiredIds = selectedServerIds.filter(
-      (id) => !optionalServerIds.includes(id),
-    );
-    if (optional && requiredIds.length === 1 && requiredIds[0] === serverId) {
-      toast.error(
-        "Add another required server or mark another as required first.",
-      );
-      return;
-    }
-    setOptionalServerIds((current) =>
-      optional
-        ? [...new Set([...current, serverId])]
-        : current.filter((id) => id !== serverId),
-    );
-  };
 
   const handleToggleServer = (serverId: string, checked: boolean) => {
     setSelectedServerIds((current) => {
@@ -897,9 +900,7 @@ export function ChatboxEditor({
             <ServerSelectionEditor
               workspaceServers={workspaceServers as RemoteServer[]}
               selectedServerIds={selectedServerIds}
-              optionalServerIds={optionalServerIds}
               onToggleSelection={handleToggleServer}
-              onOptionalChange={handleServerOptionalChange}
               onOpenAdd={() => setIsAddServerOpen(true)}
             />
           </div>
@@ -972,18 +973,6 @@ export function ChatboxEditor({
                       onCheckedChange={setRequireToolApproval}
                     />
                   </div>
-                  <div className="flex items-center justify-between gap-3 rounded-md px-1 py-1.5">
-                    <div>
-                      <p className="text-sm">Allow guest access</p>
-                      <p className="text-[10px] text-muted-foreground">
-                        Unauthenticated visitors can use the chatbox link.
-                      </p>
-                    </div>
-                    <Switch
-                      checked={allowGuestAccess}
-                      onCheckedChange={setAllowGuestAccess}
-                    />
-                  </div>
                 </div>
               </div>
             </CollapsibleContent>
@@ -997,7 +986,11 @@ export function ChatboxEditor({
             <Label className="text-xs font-medium text-muted-foreground">
               Sharing
             </Label>
-            <ChatboxShareSection chatbox={chatbox} onUpdated={onSaved} />
+            <ChatboxShareSection
+              chatbox={chatbox}
+              workspaceName={workspaceName}
+              onUpdated={onSaved}
+            />
           </div>
         )}
 
@@ -1008,7 +1001,9 @@ export function ChatboxEditor({
             <p className="text-sm font-medium">General access</p>
             <div className="mt-2 flex items-start gap-3">
               <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted">
-                {mode === "any_signed_in_with_link" ? (
+                {accessPreset === "workspace" ? (
+                  <Users className="size-4 text-muted-foreground" />
+                ) : accessPreset === "link_guests" ? (
                   <Globe className="size-4 text-muted-foreground" />
                 ) : (
                   <Lock className="size-4 text-muted-foreground" />
@@ -1021,39 +1016,70 @@ export function ChatboxEditor({
                       type="button"
                       className="flex items-center gap-1 rounded-md px-1 py-0.5 text-sm font-medium hover:bg-muted/50 transition-colors"
                     >
-                      {mode === "any_signed_in_with_link"
-                        ? "Anyone with the link"
-                        : "Invited users only"}
+                      {accessPreset === "workspace"
+                        ? workspaceAccessLabel
+                        : accessPreset === "link_guests"
+                          ? "Anyone with the link (guests included)"
+                          : "Invited users only"}
                       <ChevronDown className="size-3.5 text-muted-foreground" />
                     </button>
                   </PopoverTrigger>
-                  <PopoverContent className="w-56 p-1" align="start">
+                  <PopoverContent className="w-72 p-1" align="start">
                     <button
                       type="button"
-                      className="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm hover:bg-muted/50"
-                      onClick={() => setMode("any_signed_in_with_link")}
+                      className="flex w-full flex-col items-start gap-0.5 rounded-md px-2 py-2 text-left text-sm hover:bg-muted/50"
+                      onClick={() => applyCreateAccessPreset("workspace")}
                     >
-                      <span>Anyone with the link</span>
-                      {mode === "any_signed_in_with_link" && (
-                        <Check className="size-3.5 text-muted-foreground" />
-                      )}
+                      <span className="flex w-full items-center justify-between gap-2 font-medium">
+                        {workspaceAccessLabel}
+                        {accessPreset === "workspace" ? (
+                          <Check className="size-3.5 shrink-0 text-muted-foreground" />
+                        ) : null}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        Signed-in workspace members can use the link. Guests
+                        cannot.
+                      </span>
                     </button>
                     <button
                       type="button"
-                      className="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm hover:bg-muted/50"
-                      onClick={() => setMode("invited_only")}
+                      className="flex w-full flex-col items-start gap-0.5 rounded-md px-2 py-2 text-left text-sm hover:bg-muted/50"
+                      onClick={() => applyCreateAccessPreset("invited_only")}
                     >
-                      <span>Invited users only</span>
-                      {mode === "invited_only" && (
-                        <Check className="size-3.5 text-muted-foreground" />
-                      )}
+                      <span className="flex w-full items-center justify-between gap-2 font-medium">
+                        Invited users only
+                        {accessPreset === "invited_only" ? (
+                          <Check className="size-3.5 shrink-0 text-muted-foreground" />
+                        ) : null}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        Only people you invite by email can open this chatbox.
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      className="flex w-full flex-col items-start gap-0.5 rounded-md px-2 py-2 text-left text-sm hover:bg-muted/50"
+                      onClick={() => applyCreateAccessPreset("link_guests")}
+                    >
+                      <span className="flex w-full items-center justify-between gap-2 font-medium">
+                        Anyone with the link (guests included)
+                        {accessPreset === "link_guests" ? (
+                          <Check className="size-3.5 shrink-0 text-muted-foreground" />
+                        ) : null}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        Anyone with the link, including guests without an
+                        account.
+                      </span>
                     </button>
                   </PopoverContent>
                 </Popover>
                 <p className="mt-0.5 px-1 text-xs text-muted-foreground">
-                  {mode === "any_signed_in_with_link"
-                    ? "Any signed-in user with the link can open this chatbox."
-                    : "Only people you've invited can access this chatbox."}
+                  {accessPreset === "workspace"
+                    ? "Signed-in members of this workspace can open the chatbox with the link."
+                    : accessPreset === "link_guests"
+                      ? "Anyone with the link can open this chatbox, including guests."
+                      : "Only people you invite by email can open this chatbox."}
                 </p>
               </div>
             </div>

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxShareSection.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxShareSection.tsx
@@ -1,141 +1,139 @@
 import { useEffect, useMemo, useState } from "react";
-import {
-  Check,
-  ChevronDown,
-  Copy,
-  Globe,
-  Link2,
-  Loader2,
-  Lock,
-  RotateCw,
-  X,
-} from "lucide-react";
+import { ChevronDown, Clock, Globe, Lock, Users } from "lucide-react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth } from "convex/react";
 import { toast } from "sonner";
 import { useProfilePicture } from "@/hooks/useProfilePicture";
 import {
   type ChatboxMember,
-  type ChatboxMode,
   type ChatboxSettings,
   useChatboxMutations,
 } from "@/hooks/useChatboxes";
 import { getInitials } from "@/lib/utils";
-import { buildChatboxLink } from "@/lib/chatbox-session";
+import {
+  chatboxAccessPresetFromSettings,
+  settingsFromChatboxAccessPreset,
+  type ChatboxAccessPreset,
+} from "@/lib/chatbox-access-presets";
 import { Avatar, AvatarFallback, AvatarImage } from "@mcpjam/design-system/avatar";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@mcpjam/design-system/popover";
-import { Separator } from "@mcpjam/design-system/separator";
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@mcpjam/design-system/dropdown-menu";
+
+const INVITE_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 interface ChatboxShareSectionProps {
   chatbox: ChatboxSettings;
   onUpdated?: (chatbox: ChatboxSettings) => void;
-  appearance?: "default" | "builder";
+  /** Shown as the workspace-wide access option label (e.g. current workspace name). */
   workspaceName?: string | null;
 }
 
 export function ChatboxShareSection({
   chatbox,
   onUpdated,
+  workspaceName,
 }: ChatboxShareSectionProps) {
   const { isAuthenticated } = useConvexAuth();
   const { user } = useAuth();
   const { profilePictureUrl } = useProfilePicture();
   const {
     setChatboxMode,
-    rotateChatboxLink,
+    updateChatbox,
     upsertChatboxMember,
     removeChatboxMember,
   } = useChatboxMutations();
 
   const [settings, setSettings] = useState<ChatboxSettings>(chatbox);
   const [email, setEmail] = useState("");
-  const [isMutating, setIsMutating] = useState(false);
+  const [isInviting, setIsInviting] = useState(false);
+  const [isModeBusy, setIsModeBusy] = useState(false);
+  const [isMemberBusy, setIsMemberBusy] = useState(false);
 
   useEffect(() => {
     setSettings(chatbox);
   }, [chatbox]);
 
+  const workspaceLabel = workspaceName?.trim() || "Workspace";
+
+  const accessPreset = chatboxAccessPresetFromSettings(
+    settings.mode,
+    settings.allowGuestAccess,
+  );
+
   const displayName =
     [user?.firstName, user?.lastName].filter(Boolean).join(" ") || "You";
   const displayInitials = getInitials(displayName);
-  const activeMembers = useMemo(
-    () => settings.members.filter((member) => !member.revokedAt),
-    [settings.members],
+  const selfEmailLower = user?.email?.toLowerCase() ?? "";
+
+  const { acceptedInvitees, pendingInvitees } = useMemo(() => {
+    const active = settings.members.filter((m) => !m.revokedAt);
+    const accepted = active.filter((m) => Boolean(m.userId));
+    const pending = active.filter((m) => !m.userId);
+    return { acceptedInvitees: accepted, pendingInvitees: pending };
+  }, [settings.members]);
+
+  const otherAccepted = useMemo(
+    () =>
+      acceptedInvitees.filter(
+        (m) => m.email.toLowerCase() !== selfEmailLower,
+      ),
+    [acceptedInvitees, selfEmailLower],
   );
+
+  const normalizedEmail = email.trim().toLowerCase();
+  const emailValidationError =
+    normalizedEmail && !INVITE_EMAIL_PATTERN.test(normalizedEmail)
+      ? "Enter a valid email address."
+      : null;
 
   const updateSettings = (next: ChatboxSettings) => {
     setSettings(next);
     onUpdated?.(next);
   };
 
-  const handleCopyLink = async () => {
-    const token = settings.link?.token?.trim();
-    if (!token) {
-      toast.error("Chatbox link unavailable");
-      return;
-    }
+  const handleAccessPresetChange = async (preset: ChatboxAccessPreset) => {
+    if (preset === accessPreset) return;
 
+    const target = settingsFromChatboxAccessPreset(preset);
+    setIsModeBusy(true);
     try {
-      await navigator.clipboard.writeText(
-        buildChatboxLink(token, settings.name),
-      );
-      toast.success("Chatbox link copied");
-    } catch {
-      toast.error("Failed to copy link");
-    }
-  };
-
-  const handleRotate = async () => {
-    setIsMutating(true);
-    try {
-      const next = (await rotateChatboxLink({
-        chatboxId: settings.chatboxId,
-      })) as ChatboxSettings;
-      updateSettings(next);
-      toast.success("Chatbox link rotated");
-    } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : "Failed to rotate chatbox link",
-      );
-    } finally {
-      setIsMutating(false);
-    }
-  };
-
-  const handleModeChange = async (mode: ChatboxMode) => {
-    if (mode === settings.mode) return;
-
-    setIsMutating(true);
-    try {
-      const next = (await setChatboxMode({
-        chatboxId: settings.chatboxId,
-        mode,
-      })) as ChatboxSettings;
+      let next = settings;
+      if (target.mode !== settings.mode) {
+        next = (await setChatboxMode({
+          chatboxId: settings.chatboxId,
+          mode: target.mode,
+        })) as ChatboxSettings;
+      }
+      if (target.allowGuestAccess !== next.allowGuestAccess) {
+        next = (await updateChatbox({
+          chatboxId: settings.chatboxId,
+          allowGuestAccess: target.allowGuestAccess,
+        })) as ChatboxSettings;
+      }
       updateSettings(next);
     } catch (error) {
       toast.error(
         error instanceof Error
           ? error.message
-          : "Failed to update chatbox mode",
+          : "Failed to update access settings",
       );
     } finally {
-      setIsMutating(false);
+      setIsModeBusy(false);
     }
   };
 
   const handleInvite = async () => {
-    const normalizedEmail = email.trim().toLowerCase();
-    if (!normalizedEmail) return;
+    if (!normalizedEmail || emailValidationError) return;
 
-    setIsMutating(true);
+    setIsInviting(true);
     try {
       const next = (await upsertChatboxMember({
         chatboxId: settings.chatboxId,
@@ -148,12 +146,12 @@ export function ChatboxShareSection({
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to invite");
     } finally {
-      setIsMutating(false);
+      setIsInviting(false);
     }
   };
 
   const handleRemoveMember = async (member: ChatboxMember) => {
-    setIsMutating(true);
+    setIsMemberBusy(true);
     try {
       const next = (await removeChatboxMember({
         chatboxId: settings.chatboxId,
@@ -166,9 +164,27 @@ export function ChatboxShareSection({
         error instanceof Error ? error.message : "Failed to remove member",
       );
     } finally {
-      setIsMutating(false);
+      setIsMemberBusy(false);
     }
   };
+
+  const accessTriggerSummary = () => {
+    switch (accessPreset) {
+      case "workspace":
+        return workspaceLabel;
+      case "invited_only":
+        return "Invited users only";
+      case "link_guests":
+        return "Anyone with the link (guests included)";
+    }
+  };
+
+  const AccessIcon =
+    accessPreset === "workspace"
+      ? Users
+      : accessPreset === "link_guests"
+        ? Globe
+        : Lock;
 
   if (!isAuthenticated) {
     return (
@@ -179,198 +195,237 @@ export function ChatboxShareSection({
   }
 
   return (
-    <>
-      <div className="flex gap-2 pt-4 pb-5">
-        <Input
-          value={email}
-          onChange={(event) => setEmail(event.target.value)}
-          placeholder="Add people by email"
-          className="flex-1"
-          onKeyDown={(event) => {
-            if (event.key === "Enter") {
-              event.preventDefault();
-              void handleInvite();
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <label className="text-sm font-medium" htmlFor="chatbox-share-email">
+          Invite with email
+        </label>
+        <div className="flex gap-2">
+          <div className="flex flex-1 items-center rounded-md border border-input focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
+            <Input
+              id="chatbox-share-email"
+              type="email"
+              placeholder="Add people, emails..."
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleInvite();
+                }
+              }}
+              aria-invalid={emailValidationError ? true : undefined}
+              className="flex-1 border-0 focus-visible:ring-0 focus-visible:ring-offset-0"
+            />
+          </div>
+          <Button
+            onClick={() => void handleInvite()}
+            disabled={
+              !normalizedEmail || !!emailValidationError || isInviting
             }
-          }}
-        />
-        <Button
-          onClick={() => void handleInvite()}
-          disabled={!email.trim() || isMutating}
-        >
-          {isMutating && email.trim() ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            "Invite"
-          )}
-        </Button>
+          >
+            {isInviting ? "..." : "Invite"}
+          </Button>
+        </div>
+        {emailValidationError ? (
+          <p className="text-sm text-destructive">{emailValidationError}</p>
+        ) : null}
       </div>
 
-      <div className="space-y-1">
-        <p className="text-sm font-medium">People with access</p>
-        <div className="max-h-[220px] overflow-y-auto -mx-1">
-          <div className="flex items-center gap-3 rounded-md px-1 py-1.5">
-            <Avatar className="size-8 shrink-0">
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Access settings</label>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground disabled:opacity-50"
+              disabled={isModeBusy}
+            >
+              <AccessIcon className="size-4 shrink-0" />
+              <span className="flex-1 text-left">{accessTriggerSummary()}</span>
+              <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            className="w-[--radix-dropdown-menu-trigger-width]"
+          >
+            <DropdownMenuRadioGroup
+              value={accessPreset}
+              onValueChange={(v) =>
+                void handleAccessPresetChange(v as ChatboxAccessPreset)
+              }
+            >
+              <DropdownMenuRadioItem value="workspace" className="items-start">
+                <div>
+                  <div className="flex items-center gap-2 font-medium">
+                    <Users className="size-4" />
+                    {workspaceLabel}
+                  </div>
+                  <p className="text-xs font-normal text-muted-foreground">
+                    Signed-in members of this workspace can open the chatbox
+                    with the link. Guests cannot.
+                  </p>
+                </div>
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem
+                value="invited_only"
+                className="items-start"
+              >
+                <div>
+                  <div className="flex items-center gap-2 font-medium">
+                    <Lock className="size-4" />
+                    Invited users only
+                  </div>
+                  <p className="text-xs font-normal text-muted-foreground">
+                    Only people you invite by email can open this chatbox.
+                  </p>
+                </div>
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem
+                value="link_guests"
+                className="items-start"
+              >
+                <div>
+                  <div className="flex items-center gap-2 font-medium">
+                    <Globe className="size-4" />
+                    Anyone with the link (guests included)
+                  </div>
+                  <p className="text-xs font-normal text-muted-foreground">
+                    Anyone with the link can open the chatbox, including guests
+                    without an account.
+                  </p>
+                </div>
+              </DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Has access</label>
+        <div className="max-h-[300px] space-y-1 overflow-y-auto">
+          <div className="flex items-center gap-3 rounded-md p-2">
+            <Avatar className="size-9">
               <AvatarImage src={profilePictureUrl} alt={displayName} />
-              <AvatarFallback className="text-xs">
+              <AvatarFallback className="text-sm">
                 {displayInitials}
               </AvatarFallback>
             </Avatar>
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-1.5">
-                <p className="truncate text-sm">{displayName}</p>
+                <p className="truncate text-sm font-medium">{displayName}</p>
                 <span className="text-xs text-muted-foreground">(you)</span>
               </div>
               <p className="truncate text-xs text-muted-foreground">
                 {user?.email}
               </p>
             </div>
-            <span className="shrink-0 text-xs text-muted-foreground">
+            <span className="shrink-0 text-sm text-muted-foreground">
               Owner
             </span>
           </div>
 
-          {activeMembers.length === 0 ? (
-            <p className="px-1 py-3 text-sm text-muted-foreground">
-              No one has been invited yet.
-            </p>
-          ) : (
-            activeMembers.map((member) => {
-              const name = member.user?.name || member.email;
-              const isPending = !member.userId;
-              const initials = getInitials(name);
-
-              return (
-                <div
-                  key={member._id}
-                  className="group flex items-center gap-3 rounded-md px-1 py-1.5 hover:bg-muted/40"
-                >
-                  <Avatar className="size-8 shrink-0">
-                    <AvatarImage src={member.user?.imageUrl} alt={name} />
-                    <AvatarFallback className="text-xs">
-                      {initials}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm">{name}</p>
-                    <p className="truncate text-xs text-muted-foreground">
-                      {member.email}
-                    </p>
+          {otherAccepted.map((member) => {
+            const name = member.user?.name || member.email;
+            const initials = getInitials(name);
+            return (
+              <div
+                key={member._id}
+                className="flex items-center gap-3 rounded-md p-2 hover:bg-muted/50"
+              >
+                <Avatar className="size-9">
+                  <AvatarImage
+                    src={member.user?.imageUrl || undefined}
+                    alt={name}
+                  />
+                  <AvatarFallback className="text-sm">{initials}</AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5">
+                    <p className="truncate text-sm font-medium">{name}</p>
                   </div>
-                  <div className="flex items-center gap-2">
-                    {isPending ? (
-                      <span className="text-xs text-muted-foreground">
-                        Pending
-                      </span>
-                    ) : null}
+                  <p className="truncate text-xs text-muted-foreground">
+                    {member.email}
+                  </p>
+                </div>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
                     <Button
                       variant="ghost"
-                      size="icon"
-                      className="size-7 opacity-0 group-hover:opacity-100"
+                      size="sm"
+                      className="shrink-0 gap-1 text-sm"
+                      disabled={isMemberBusy}
+                    >
+                      Member
+                      <ChevronDown className="size-3" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
                       onClick={() => void handleRemoveMember(member)}
                     >
-                      <X className="size-3.5" />
-                    </Button>
-                  </div>
+                      Remove access
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            );
+          })}
+
+          {otherAccepted.length === 0 && pendingInvitees.length === 0 ? (
+            <p className="px-2 py-2 text-sm text-muted-foreground">
+              No one has been invited yet.
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      {pendingInvitees.length > 0 ? (
+        <div className="space-y-2">
+          <label className="text-sm font-medium">Invited</label>
+          <div className="max-h-[220px] space-y-1 overflow-y-auto">
+            {pendingInvitees.map((member) => (
+              <div
+                key={member._id}
+                className="flex items-center gap-3 rounded-md p-2 hover:bg-muted/50"
+              >
+                <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted">
+                  <Clock className="size-4 text-muted-foreground" />
                 </div>
-              );
-            })
-          )}
-        </div>
-      </div>
-
-      <Separator className="my-5" />
-
-      <div className="space-y-4">
-        <div>
-          <p className="text-sm font-medium">General access</p>
-          <div className="mt-2 flex items-start gap-3">
-            <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted">
-              {settings.mode === "any_signed_in_with_link" ? (
-                <Globe className="size-4 text-muted-foreground" />
-              ) : (
-                <Lock className="size-4 text-muted-foreground" />
-              )}
-            </div>
-            <div className="min-w-0 flex-1">
-              <Popover>
-                <PopoverTrigger asChild>
-                  <button
-                    type="button"
-                    className="flex items-center gap-1 rounded-md px-1 py-0.5 text-sm font-medium hover:bg-muted/50 transition-colors"
-                  >
-                    {settings.mode === "any_signed_in_with_link"
-                      ? "Anyone with the link"
-                      : "Invited users only"}
-                    <ChevronDown className="size-3.5 text-muted-foreground" />
-                  </button>
-                </PopoverTrigger>
-                <PopoverContent className="w-56 p-1" align="start">
-                  <button
-                    type="button"
-                    className="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm hover:bg-muted/50"
-                    onClick={() =>
-                      void handleModeChange("any_signed_in_with_link")
-                    }
-                  >
-                    <span>Anyone with the link</span>
-                    {settings.mode === "any_signed_in_with_link" && (
-                      <Check className="size-3.5 text-muted-foreground" />
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    className="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm hover:bg-muted/50"
-                    onClick={() => void handleModeChange("invited_only")}
-                  >
-                    <span>Invited users only</span>
-                    {settings.mode === "invited_only" && (
-                      <Check className="size-3.5 text-muted-foreground" />
-                    )}
-                  </button>
-                </PopoverContent>
-              </Popover>
-              <p className="mt-0.5 px-1 text-xs text-muted-foreground">
-                {settings.mode === "any_signed_in_with_link"
-                  ? "Any signed-in user with the link can open this chatbox."
-                  : "Only people you've invited can access this chatbox."}
-              </p>
-            </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">{member.email}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Invitation pending — they can access after signing in
+                  </p>
+                </div>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="shrink-0 gap-1 text-sm"
+                      disabled={isMemberBusy}
+                    >
+                      Pending
+                      <ChevronDown className="size-3" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      className="text-destructive focus:text-destructive"
+                      onClick={() => void handleRemoveMember(member)}
+                    >
+                      Cancel invite
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            ))}
           </div>
         </div>
-
-        <div className="rounded-lg border p-3">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <Link2 className="size-4" />
-            Share link
-          </div>
-          <p className="mt-1 text-xs text-muted-foreground break-all">
-            {settings.link?.url || buildChatboxLink("", settings.name)}
-          </p>
-          <div className="mt-3 flex gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => void handleCopyLink()}
-            >
-              <Copy className="mr-1.5 size-3.5" />
-              Copy link
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => void handleRotate()}
-              disabled={isMutating}
-            >
-              {isMutating ? (
-                <Loader2 className="mr-1.5 size-3.5 animate-spin" />
-              ) : (
-                <RotateCw className="mr-1.5 size-3.5" />
-              )}
-              Rotate
-            </Button>
-          </div>
-        </div>
-      </div>
-    </>
+      ) : null}
+    </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
@@ -22,8 +22,12 @@ import { ShareUsageThreadList } from "@/components/connection/share-usage/ShareU
 import { ShareUsageThreadDetail } from "@/components/connection/share-usage/ShareUsageThreadDetail";
 import { UsageInsightsStrip } from "@/components/shared/usage-insights/UsageInsightsStrip";
 
+export type ChatboxUsagePanelSection = "sessions" | "insights";
+
 interface ChatboxUsagePanelProps {
   chatbox: ChatboxSettings;
+  /** Sessions: thread list and detail. Insights: usage dashboards only. */
+  section: ChatboxUsagePanelSection;
 }
 
 const PRESET_OPTIONS: { id: UsageFilterPreset; label: string }[] = [
@@ -33,7 +37,10 @@ const PRESET_OPTIONS: { id: UsageFilterPreset; label: string }[] = [
   { id: "no_feedback", label: "No feedback" },
 ];
 
-export function ChatboxUsagePanel({ chatbox }: ChatboxUsagePanelProps) {
+export function ChatboxUsagePanel({
+  chatbox,
+  section,
+}: ChatboxUsagePanelProps) {
   // Scope selection to the current chatbox so switching chatboxes can't briefly
   // render a detail pane for a thread belonging to the previous chatbox.
   const [selection, setSelection] = useState<{
@@ -147,17 +154,23 @@ export function ChatboxUsagePanel({ chatbox }: ChatboxUsagePanelProps) {
     }
   }, [rebuild, chatbox.chatboxId]);
 
+  if (section === "insights") {
+    return (
+      <div className="flex h-full min-h-0 flex-col overflow-auto">
+        <UsageInsightsStrip
+          breakdown={breakdown}
+          filter={filter}
+          onToggleChip={handleToggleChip}
+          onClearChip={handleClearChip}
+          onRebuild={handleRebuild}
+          rebuildBusy={rebuildBusy}
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="flex h-full flex-col">
-      <UsageInsightsStrip
-        breakdown={breakdown}
-        filter={filter}
-        onToggleChip={handleToggleChip}
-        onClearChip={handleClearChip}
-        onRebuild={handleRebuild}
-        rebuildBusy={rebuildBusy}
-      />
-
       <div className="flex flex-wrap gap-2 border-b px-5 py-3">
         {PRESET_OPTIONS.map(({ id, label }) => (
           <Button

--- a/mcpjam-inspector/client/src/components/chatboxes/ShareChatboxDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ShareChatboxDialog.tsx
@@ -1,34 +1,15 @@
-import { useEffect, useMemo, useState } from "react";
-import { Copy, Globe, Link2, Loader2, Lock, RotateCw, X } from "lucide-react";
-import { useAuth } from "@workos-inc/authkit-react";
+import { useEffect, useState } from "react";
 import { useConvexAuth } from "convex/react";
-import { toast } from "sonner";
-import { useProfilePicture } from "@/hooks/useProfilePicture";
-import {
-  type ChatboxMember,
-  type ChatboxMode,
-  type ChatboxSettings,
-  useChatboxMutations,
-} from "@/hooks/useChatboxes";
-import { getInitials } from "@/lib/utils";
-import { buildChatboxLink } from "@/lib/chatbox-session";
-import { Avatar, AvatarFallback, AvatarImage } from "@mcpjam/design-system/avatar";
+import type { ChatboxSettings } from "@/hooks/useChatboxes";
 import { Button } from "@mcpjam/design-system/button";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@mcpjam/design-system/dialog";
-import { Input } from "@mcpjam/design-system/input";
-import { Separator } from "@mcpjam/design-system/separator";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@mcpjam/design-system/select";
+import { ChatboxShareSection } from "@/components/chatboxes/ChatboxShareSection";
 
 interface ShareChatboxDialogProps {
   isOpen: boolean;
@@ -44,336 +25,36 @@ export function ShareChatboxDialog({
   onUpdated,
 }: ShareChatboxDialogProps) {
   const { isAuthenticated } = useConvexAuth();
-  const { user } = useAuth();
-  const { profilePictureUrl } = useProfilePicture();
-  const {
-    setChatboxMode,
-    rotateChatboxLink,
-    upsertChatboxMember,
-    removeChatboxMember,
-  } = useChatboxMutations();
-
   const [settings, setSettings] = useState<ChatboxSettings>(chatbox);
-  const [email, setEmail] = useState("");
-  const [isMutating, setIsMutating] = useState(false);
 
   useEffect(() => {
     setSettings(chatbox);
   }, [chatbox]);
 
-  useEffect(() => {
-    if (!isOpen) {
-      setEmail("");
-      setIsMutating(false);
-    }
-  }, [isOpen]);
-
-  const displayName =
-    [user?.firstName, user?.lastName].filter(Boolean).join(" ") || "You";
-  const displayInitials = getInitials(displayName);
-  const activeMembers = useMemo(
-    () => settings.members.filter((member) => !member.revokedAt),
-    [settings.members],
-  );
-
-  const updateSettings = (next: ChatboxSettings) => {
-    setSettings(next);
-    onUpdated?.(next);
-  };
-
-  const handleCopyLink = async () => {
-    const token = settings.link?.token?.trim();
-    if (!token) {
-      toast.error("Chatbox link unavailable");
-      return;
-    }
-
-    try {
-      await navigator.clipboard.writeText(
-        buildChatboxLink(token, settings.name),
-      );
-      toast.success("Chatbox link copied");
-    } catch {
-      toast.error("Failed to copy link");
-    }
-  };
-
-  const handleRotate = async () => {
-    setIsMutating(true);
-    try {
-      const next = (await rotateChatboxLink({
-        chatboxId: settings.chatboxId,
-      })) as ChatboxSettings;
-      updateSettings(next);
-      toast.success("Chatbox link rotated");
-    } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : "Failed to rotate chatbox link",
-      );
-    } finally {
-      setIsMutating(false);
-    }
-  };
-
-  const handleModeChange = async (mode: ChatboxMode) => {
-    if (mode === settings.mode) return;
-
-    setIsMutating(true);
-    try {
-      const next = (await setChatboxMode({
-        chatboxId: settings.chatboxId,
-        mode,
-      })) as ChatboxSettings;
-      updateSettings(next);
-    } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : "Failed to update chatbox mode",
-      );
-    } finally {
-      setIsMutating(false);
-    }
-  };
-
-  const handleInvite = async () => {
-    const normalizedEmail = email.trim().toLowerCase();
-    if (!normalizedEmail) return;
-
-    setIsMutating(true);
-    try {
-      const next = (await upsertChatboxMember({
-        chatboxId: settings.chatboxId,
-        email: normalizedEmail,
-        sendInviteEmail: true,
-      })) as ChatboxSettings;
-      updateSettings(next);
-      setEmail("");
-      toast.success(`Invited ${normalizedEmail}`);
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to invite");
-    } finally {
-      setIsMutating(false);
-    }
-  };
-
-  const handleRemoveMember = async (member: ChatboxMember) => {
-    setIsMutating(true);
-    try {
-      const next = (await removeChatboxMember({
-        chatboxId: settings.chatboxId,
-        memberIdOrEmail: member.email,
-      })) as ChatboxSettings;
-      updateSettings(next);
-      toast.success(`Removed ${member.email}`);
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to remove member",
-      );
-    } finally {
-      setIsMutating(false);
-    }
-  };
-
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="sm:max-w-[520px] gap-0">
+      <DialogContent className="sm:max-w-[520px]">
         <DialogHeader>
-          <DialogTitle>Share &ldquo;{settings.name}&rdquo;</DialogTitle>
+          <DialogTitle>Share &ldquo;{settings.name}&rdquo; Chatbox</DialogTitle>
+          <DialogDescription className="sr-only">
+            Invite people and manage access for this chatbox.
+          </DialogDescription>
         </DialogHeader>
 
         {!isAuthenticated ? (
-          <p className="pt-4 text-sm text-muted-foreground">
+          <p className="text-sm text-muted-foreground">
             Sign in to manage chatbox access.
           </p>
         ) : (
           <>
-            <div className="flex gap-2 pt-4 pb-5">
-              <Input
-                value={email}
-                onChange={(event) => setEmail(event.target.value)}
-                placeholder="Add people by email"
-                className="flex-1"
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    event.preventDefault();
-                    void handleInvite();
-                  }
-                }}
-              />
-              <Button
-                onClick={() => void handleInvite()}
-                disabled={!email.trim() || isMutating}
-              >
-                {isMutating && email.trim() ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  "Invite"
-                )}
-              </Button>
-            </div>
-
-            <div className="space-y-1">
-              <p className="text-sm font-medium">People with access</p>
-              <div className="max-h-[220px] overflow-y-auto -mx-1">
-                <div className="flex items-center gap-3 rounded-md px-1 py-1.5">
-                  <Avatar className="size-8 shrink-0">
-                    <AvatarImage src={profilePictureUrl} alt={displayName} />
-                    <AvatarFallback className="text-xs">
-                      {displayInitials}
-                    </AvatarFallback>
-                  </Avatar>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-1.5">
-                      <p className="truncate text-sm">{displayName}</p>
-                      <span className="text-xs text-muted-foreground">
-                        (you)
-                      </span>
-                    </div>
-                    <p className="truncate text-xs text-muted-foreground">
-                      {user?.email}
-                    </p>
-                  </div>
-                  <span className="shrink-0 text-xs text-muted-foreground">
-                    Owner
-                  </span>
-                </div>
-
-                {activeMembers.length === 0 ? (
-                  <p className="px-1 py-3 text-sm text-muted-foreground">
-                    No one has been invited yet.
-                  </p>
-                ) : (
-                  activeMembers.map((member) => {
-                    const name = member.user?.name || member.email;
-                    const isPending = !member.userId;
-                    const initials = getInitials(name);
-
-                    return (
-                      <div
-                        key={member._id}
-                        className="group flex items-center gap-3 rounded-md px-1 py-1.5 hover:bg-muted/40"
-                      >
-                        <Avatar className="size-8 shrink-0">
-                          <AvatarImage src={member.user?.imageUrl} alt={name} />
-                          <AvatarFallback className="text-xs">
-                            {initials}
-                          </AvatarFallback>
-                        </Avatar>
-                        <div className="min-w-0 flex-1">
-                          <p className="truncate text-sm">{name}</p>
-                          <p className="truncate text-xs text-muted-foreground">
-                            {member.email}
-                          </p>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          {isPending ? (
-                            <span className="text-xs text-muted-foreground">
-                              Pending
-                            </span>
-                          ) : null}
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="size-7 opacity-0 group-hover:opacity-100"
-                            onClick={() => void handleRemoveMember(member)}
-                          >
-                            <X className="size-3.5" />
-                          </Button>
-                        </div>
-                      </div>
-                    );
-                  })
-                )}
-              </div>
-            </div>
-
-            <Separator className="my-5" />
-
-            <div className="space-y-4">
-              <div className="grid gap-2">
-                <p className="text-sm font-medium">Access mode</p>
-                <Select
-                  value={settings.mode}
-                  onValueChange={(value) =>
-                    void handleModeChange(value as ChatboxMode)
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="invited_only">
-                      <div className="flex items-center gap-2">
-                        <Lock className="size-3.5" />
-                        Invite only
-                      </div>
-                    </SelectItem>
-                    <SelectItem value="any_signed_in_with_link">
-                      <div className="flex items-center gap-2">
-                        <Globe className="size-3.5" />
-                        Any signed-in user with the link
-                      </div>
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              <div className="rounded-lg border p-3">
-                <div className="flex items-center justify-between gap-3">
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium">Guest access</p>
-                    <p className="text-xs text-muted-foreground">
-                      {settings.allowGuestAccess
-                        ? "Guests can open this chatbox when the link mode allows it."
-                        : "Guests cannot open this chatbox. Signed-in access only."}
-                    </p>
-                  </div>
-                  {settings.allowGuestAccess ? (
-                    <Globe className="size-4 text-muted-foreground" />
-                  ) : (
-                    <Lock className="size-4 text-muted-foreground" />
-                  )}
-                </div>
-              </div>
-
-              <div className="rounded-lg border p-3">
-                <div className="flex items-center gap-2 text-sm font-medium">
-                  <Link2 className="size-4" />
-                  Share link
-                </div>
-                <p className="mt-1 text-xs text-muted-foreground break-all">
-                  {settings.link?.url || buildChatboxLink("", settings.name)}
-                </p>
-                <div className="mt-3 flex gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => void handleCopyLink()}
-                  >
-                    <Copy className="mr-1.5 size-3.5" />
-                    Copy link
-                  </Button>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => void handleRotate()}
-                    disabled={isMutating}
-                  >
-                    {isMutating ? (
-                      <Loader2 className="mr-1.5 size-3.5 animate-spin" />
-                    ) : (
-                      <RotateCw className="mr-1.5 size-3.5" />
-                    )}
-                    Rotate
-                  </Button>
-                </div>
-              </div>
-            </div>
-
-            <div className="flex justify-end pt-5">
+            <ChatboxShareSection
+              chatbox={settings}
+              onUpdated={(next) => {
+                setSettings(next);
+                onUpdated?.(next);
+              }}
+            />
+            <div className="flex justify-end pt-2">
               <Button size="sm" onClick={onClose}>
                 Done
               </Button>

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxShareSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxShareSection.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ChatboxSettings } from "@/hooks/useChatboxes";
+import { ChatboxShareSection } from "../ChatboxShareSection";
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => ({ isAuthenticated: true }),
+}));
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => ({
+    user: {
+      firstName: "Test",
+      lastName: "User",
+      email: "test@example.com",
+    },
+  }),
+}));
+
+vi.mock("@/hooks/useProfilePicture", () => ({
+  useProfilePicture: () => ({ profilePictureUrl: null }),
+}));
+
+vi.mock("@/hooks/useChatboxes", () => ({
+  useChatboxMutations: () => ({
+    setChatboxMode: vi.fn(),
+    updateChatbox: vi.fn(),
+    upsertChatboxMember: vi.fn(),
+    removeChatboxMember: vi.fn(),
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+function createChatbox(overrides: Partial<ChatboxSettings> = {}): ChatboxSettings {
+  return {
+    chatboxId: "cb-1",
+    workspaceId: "ws-1",
+    name: "My Chatbox",
+    hostStyle: "chatgpt",
+    systemPrompt: "",
+    modelId: "gpt-4",
+    temperature: 0.7,
+    requireToolApproval: false,
+    allowGuestAccess: false,
+    mode: "invited_only",
+    servers: [],
+    link: {
+      token: "t",
+      path: "/c/t",
+      url: "https://example.com/c/t",
+      rotatedAt: 0,
+      updatedAt: 0,
+    },
+    members: [],
+    ...overrides,
+  };
+}
+
+describe("ChatboxShareSection", () => {
+  it("renders the same section structure as the workspace share dialog", () => {
+    render(
+      <ChatboxShareSection chatbox={createChatbox()} workspaceName="Acme" />,
+    );
+
+    expect(screen.getByText("Invite with email")).toBeInTheDocument();
+    expect(screen.getByText("Access settings")).toBeInTheDocument();
+    expect(screen.getByText("Has access")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Invite", exact: true }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an Invited section when there are pending members", () => {
+    const chatbox = createChatbox({
+      members: [
+        {
+          _id: "m1",
+          chatboxId: "cb-1",
+          workspaceId: "ws-1",
+          email: "pending@example.com",
+          role: "chat",
+          invitedBy: "u1",
+          invitedAt: 1,
+          user: null,
+        },
+      ],
+    });
+
+    render(<ChatboxShareSection chatbox={chatbox} />);
+
+    expect(screen.getByText("Invited")).toBeInTheDocument();
+    expect(screen.getByText("pending@example.com")).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderExperience.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderExperience.tsx
@@ -56,14 +56,14 @@ export default function ChatboxBuilderExperience({
     workspaceId,
   });
   const workspaceName =
-    workspaces.find((workspace) => workspace._id === workspaceId)?.name ?? null;
+    workspaces.find((w) => w._id === workspaceId)?.name ?? null;
 
   const [selectedChatboxId, setSelectedChatboxId] = useState<string | null>(
     null,
   );
   const [draft, setDraft] = useState<ChatboxDraftConfig | null>(null);
   const [restoredViewMode, setRestoredViewMode] = useState<
-    "setup" | "preview" | "usage" | undefined
+    "setup" | "preview" | "usage" | "insights" | undefined
   >();
   const [starterLauncherOpen, setStarterLauncherOpen] = useState(false);
   const [deletingChatboxId, setDeletingChatboxId] = useState<string | null>(
@@ -98,9 +98,11 @@ export default function ChatboxBuilderExperience({
       if (vm === "builder") {
         setRestoredViewMode("setup");
       } else if (vm === "insights") {
-        setRestoredViewMode("usage");
+        setRestoredViewMode("insights");
       } else {
-        setRestoredViewMode(vm as "setup" | "preview" | "usage" | undefined);
+        setRestoredViewMode(
+          vm as "setup" | "preview" | "usage" | "insights" | undefined,
+        );
       }
     });
   }, [isCreateChatboxDisabled, isCreateChatboxLoading, workspaceId]);

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { toast } from "sonner";
 import {
   ArrowLeft,
@@ -11,7 +18,6 @@ import {
 import { ReactFlowProvider } from "@xyflow/react";
 import { useConvexAuth } from "convex/react";
 import { Button } from "@mcpjam/design-system/button";
-import { Badge } from "@mcpjam/design-system/badge";
 import { Card } from "@mcpjam/design-system/card";
 import {
   ResizableHandle,
@@ -82,7 +88,7 @@ interface ChatboxBuilderViewProps {
   workspaceServers: RemoteServer[];
   chatboxId?: string | null;
   draft: ChatboxDraftConfig | null;
-  initialViewMode?: "setup" | "preview" | "usage";
+  initialViewMode?: "setup" | "preview" | "usage" | "insights";
   onBack: () => void;
   onSavedDraft: (chatbox: ChatboxSettings) => void;
 }
@@ -92,15 +98,21 @@ const DESKTOP_SETUP_RAIL_DEFAULT_PERCENT = 60;
 const DESKTOP_SETUP_RAIL_MIN_PERCENT = 40;
 const DESKTOP_SETUP_RAIL_MAX_PERCENT = 70;
 
-type ViewMode = "setup" | "preview" | "usage";
+type ViewMode = "setup" | "preview" | "usage" | "insights";
 
 function normalizeInitialViewMode(
   mode: string | undefined,
 ): ViewMode | undefined {
   if (!mode) return undefined;
-  if (mode === "setup" || mode === "preview" || mode === "usage") return mode;
+  if (
+    mode === "setup" ||
+    mode === "preview" ||
+    mode === "usage" ||
+    mode === "insights"
+  ) {
+    return mode;
+  }
   if (mode === "builder") return "setup";
-  if (mode === "insights") return "usage";
   return undefined;
 }
 
@@ -111,10 +123,65 @@ function getSetupSectionForNode(nodeId: string | null): SetupSectionId {
   return "basics";
 }
 
+function ChatboxPreviewActionButtons({
+  variant,
+  hasSavedChatbox,
+  onCopyLink,
+  onOpenFullPreview,
+  onReloadPreview,
+}: {
+  variant: "sidebar" | "mobileHeader";
+  hasSavedChatbox: boolean;
+  onCopyLink: () => void;
+  onOpenFullPreview: () => void;
+  onReloadPreview: () => void;
+}) {
+  const showCopyLink = hasSavedChatbox;
+  const isSidebar = variant === "sidebar";
+  const buttonClass = isSidebar ? "w-full justify-start rounded-xl" : "rounded-xl";
+
+  return (
+    <div
+      className={
+        isSidebar
+          ? "flex flex-col gap-2"
+          : "flex w-full flex-wrap items-center justify-end gap-2"
+      }
+    >
+      {showCopyLink ? (
+        <Button
+          variant="outline"
+          className={buttonClass}
+          onClick={onCopyLink}
+        >
+          <Link2 className="mr-1.5 size-4 shrink-0" />
+          Copy link
+        </Button>
+      ) : null}
+      <Button
+        variant="outline"
+        className={buttonClass}
+        onClick={onOpenFullPreview}
+        disabled={!hasSavedChatbox}
+      >
+        <ExternalLink className="mr-1.5 size-4 shrink-0" />
+        Open full preview
+      </Button>
+      <Button
+        variant="outline"
+        className={buttonClass}
+        onClick={onReloadPreview}
+        disabled={!hasSavedChatbox}
+      >
+        <RefreshCw className="mr-1.5 size-4 shrink-0" />
+        Reload preview
+      </Button>
+    </div>
+  );
+}
+
 function ChatboxBuilderChrome({
   title,
-  subtitle,
-  headerMode,
   isDirty,
   isSaving,
   hasSavedChatbox,
@@ -122,15 +189,10 @@ function ChatboxBuilderChrome({
   viewMode,
   onBack,
   onSave,
-  onCopyLink,
-  onOpenFullPreview,
-  onReloadPreview,
-  onEditSetup,
+  mobilePreviewActions,
   onModeChange,
 }: {
   title: string;
-  subtitle?: string;
-  headerMode: "setup" | "preview" | "usage";
   isDirty: boolean;
   isSaving: boolean;
   hasSavedChatbox: boolean;
@@ -139,20 +201,18 @@ function ChatboxBuilderChrome({
   viewMode: ViewMode;
   onBack: () => void;
   onSave: () => void;
-  onCopyLink: () => void;
-  onOpenFullPreview: () => void;
-  onReloadPreview: () => void;
-  onEditSetup: () => void;
+  /** Preview-only actions shown under `md` when the config sidebar is hidden. */
+  mobilePreviewActions?: ReactNode;
   onModeChange: (mode: ViewMode) => void;
 }) {
   const saveDisabled =
     isSaving || (!isDirty && hasSavedChatbox) || setupHasBlockingSections;
-  const showCopyLink = hasSavedChatbox;
+  const saveLabel = hasSavedChatbox && isDirty ? "Save changes" : "Save";
 
   return (
-    <div className="shrink-0 border-b border-border/70">
-      <div className="flex flex-wrap items-center justify-between gap-4 px-6 py-4">
-        <div className="flex min-w-0 items-center gap-3">
+    <div className="shrink-0 border-b border-border/70 px-6 py-3">
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] md:items-center md:gap-x-4 md:gap-y-0">
+        <div className="order-1 flex min-w-0 items-center gap-3">
           <Button
             type="button"
             variant="ghost"
@@ -165,65 +225,50 @@ function ChatboxBuilderChrome({
             <ArrowLeft className="size-4" aria-hidden />
           </Button>
           <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-2">
-              <h2 className="truncate text-xl font-semibold">{title}</h2>
-              {isDirty && hasSavedChatbox ? (
-                <Badge
-                  variant="outline"
-                  className="border-amber-500/50 bg-amber-500/10 text-amber-800 dark:text-amber-300"
-                >
-                  Unsaved
-                </Badge>
-              ) : null}
-            </div>
-            {subtitle ? (
-              <p className="mt-0.5 truncate text-sm text-muted-foreground">
-                {subtitle}
-              </p>
-            ) : null}
+            <h2 className="truncate text-xl font-semibold">{title}</h2>
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center justify-end gap-2">
-          {showCopyLink ? (
-            <Button
-              variant="outline"
-              className="rounded-xl"
-              onClick={onCopyLink}
-            >
-              <Link2 className="mr-1.5 size-4" />
-              Copy link
-            </Button>
-          ) : null}
-          {headerMode === "preview" && (
-            <>
-              <Button
-                variant="outline"
-                className="rounded-xl"
-                onClick={onOpenFullPreview}
-                disabled={!hasSavedChatbox}
+        <nav
+          className="order-3 flex w-full justify-center gap-1 overflow-x-auto [-webkit-overflow-scrolling:touch] md:order-2 md:w-auto md:max-w-full md:py-0"
+          aria-label="Chatbox modes"
+        >
+          {(
+            [
+              ["setup", "Setup"],
+              ["preview", "Preview"],
+              ["usage", "Sessions"],
+              ["insights", "Insights"],
+            ] as const
+          ).map(([mode, label]) => {
+            const active = viewMode === mode;
+            const disabled =
+              mode === "preview" && !hasSavedChatbox
+                ? true
+                : (mode === "usage" || mode === "insights") && !hasSavedChatbox;
+            return (
+              <button
+                key={mode}
+                type="button"
+                disabled={disabled}
+                onClick={() => onModeChange(mode)}
+                className={`relative min-h-10 shrink-0 px-4 py-2 text-sm font-medium transition-colors sm:min-h-11 sm:px-5 sm:text-base md:min-h-10 md:px-4 lg:px-6 ${
+                  active
+                    ? "text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                } ${disabled ? "cursor-not-allowed opacity-40" : ""}`}
               >
-                <ExternalLink className="mr-1.5 size-4" />
-                Open full preview
-              </Button>
-              <Button
-                variant="outline"
-                className="rounded-xl"
-                onClick={onReloadPreview}
-                disabled={!hasSavedChatbox}
-              >
-                <RefreshCw className="mr-1.5 size-4" />
-                Reload preview
-              </Button>
-              <Button
-                variant="outline"
-                className="rounded-xl"
-                onClick={onEditSetup}
-              >
-                Edit setup
-              </Button>
-            </>
-          )}
+                {label}
+                {active ? (
+                  <span className="absolute inset-x-3 bottom-0 h-0.5 rounded-full bg-primary sm:inset-x-4 md:inset-x-3 lg:inset-x-6" />
+                ) : null}
+              </button>
+            );
+          })}
+        </nav>
+
+        <div className="order-2 flex flex-wrap items-center justify-end gap-2 md:order-3">
+          {mobilePreviewActions}
           <Button
             onClick={onSave}
             disabled={saveDisabled}
@@ -240,48 +285,9 @@ function ChatboxBuilderChrome({
             ) : (
               <Save className="mr-1.5 size-4" />
             )}
-            Save
+            {saveLabel}
           </Button>
         </div>
-      </div>
-
-      <div className="border-t border-border/60 px-6">
-        <nav
-          className="flex w-full justify-center gap-1 overflow-x-auto py-1"
-          aria-label="Chatbox modes"
-        >
-          {(
-            [
-              ["setup", "Setup"],
-              ["preview", "Preview"],
-              ["usage", "Usage"],
-            ] as const
-          ).map(([mode, label]) => {
-            const active = viewMode === mode;
-            const disabled =
-              mode === "preview" && !hasSavedChatbox
-                ? true
-                : mode === "usage" && !hasSavedChatbox;
-            return (
-              <button
-                key={mode}
-                type="button"
-                disabled={disabled}
-                onClick={() => onModeChange(mode)}
-                className={`relative min-h-12 shrink-0 px-6 py-3 text-base font-medium transition-colors ${
-                  active
-                    ? "text-foreground"
-                    : "text-muted-foreground hover:text-foreground"
-                } ${disabled ? "cursor-not-allowed opacity-40" : ""}`}
-              >
-                {label}
-                {active ? (
-                  <span className="absolute inset-x-6 bottom-0 h-0.5 rounded-full bg-primary" />
-                ) : null}
-              </button>
-            );
-          })}
-        </nav>
       </div>
     </div>
   );
@@ -894,31 +900,6 @@ export function ChatboxBuilderView({
     [createServer, workspaceId],
   );
 
-  const handleServerOptionalChange = useCallback(
-    (serverId: string, optional: boolean) => {
-      setDraftChatboxConfig((current) => {
-        const requiredIds = current.selectedServerIds.filter(
-          (id) => !current.optionalServerIds.includes(id),
-        );
-        if (
-          optional &&
-          requiredIds.length === 1 &&
-          requiredIds[0] === serverId
-        ) {
-          toast.error(
-            "Add another required server or mark another as required first.",
-          );
-          return current;
-        }
-        const nextOptional = optional
-          ? [...new Set([...current.optionalServerIds, serverId])]
-          : current.optionalServerIds.filter((id) => id !== serverId);
-        return { ...current, optionalServerIds: nextOptional };
-      });
-    },
-    [],
-  );
-
   const handleToggleServer = useCallback(
     (serverId: string, checked: boolean) => {
       setDraftChatboxConfig((current) => {
@@ -1000,7 +981,6 @@ export function ChatboxBuilderView({
       setIsAddServerOpen(true);
     },
     onToggleServer: handleToggleServer,
-    onServerOptionalChange: handleServerOptionalChange,
     inviteChatboxMember: chatboxId
       ? async (email: string) => {
           await upsertChatboxMember({
@@ -1033,18 +1013,6 @@ export function ChatboxBuilderView({
     <div className="flex h-full min-h-0 flex-col">
       <ChatboxBuilderChrome
         title={viewModel.title}
-        subtitle={
-          viewMode === "usage"
-            ? (chatbox?.description ?? undefined)
-            : viewModel.description || undefined
-        }
-        headerMode={
-          viewMode === "usage"
-            ? "usage"
-            : viewMode === "preview"
-              ? "preview"
-              : "setup"
-        }
         isDirty={isDirty}
         isSaving={isSaving}
         hasSavedChatbox={hasSavedChatbox}
@@ -1052,25 +1020,37 @@ export function ChatboxBuilderView({
         viewMode={viewMode}
         onBack={onBack}
         onSave={() => void saveChatbox()}
-        onCopyLink={() => void handleCopyLink()}
-        onOpenFullPreview={handleOpenFullPreview}
-        onReloadPreview={reloadPreview}
-        onEditSetup={() => setViewMode("setup")}
+        mobilePreviewActions={
+          viewMode === "preview" ? (
+            <div className="contents md:hidden">
+              <ChatboxPreviewActionButtons
+                variant="mobileHeader"
+                hasSavedChatbox={hasSavedChatbox}
+                onCopyLink={() => void handleCopyLink()}
+                onOpenFullPreview={handleOpenFullPreview}
+                onReloadPreview={reloadPreview}
+              />
+            </div>
+          ) : null
+        }
         onModeChange={(mode) => {
           if (mode === "preview" && !chatbox?.link?.token) {
             toast.error("Save the chatbox first to preview");
             return;
           }
-          if (mode === "usage" && !chatbox) {
+          if ((mode === "usage" || mode === "insights") && !chatbox) {
             return;
           }
           setViewMode(mode);
         }}
       />
 
-      {viewMode === "usage" && chatbox ? (
+      {(viewMode === "usage" || viewMode === "insights") && chatbox ? (
         <div className="min-h-0 flex-1">
-          <ChatboxUsagePanel chatbox={chatbox} />
+          <ChatboxUsagePanel
+            chatbox={chatbox}
+            section={viewMode === "insights" ? "insights" : "sessions"}
+          />
         </div>
       ) : (
         <div className="relative min-h-0 flex-1 p-4">
@@ -1207,7 +1187,7 @@ export function ChatboxBuilderView({
                           )}
                         </div>
                       </div>
-                      <div className="hidden w-full shrink-0 flex-col gap-4 rounded-[28px] border border-border/70 bg-card/50 p-4 md:flex md:w-[300px] lg:w-[320px]">
+                      <div className="hidden h-full min-h-0 w-full shrink-0 flex-col gap-4 rounded-[28px] border border-border/70 bg-card/50 p-4 md:flex md:w-[300px] lg:w-[320px]">
                         <div>
                           <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                             Chatbox config
@@ -1247,28 +1227,17 @@ export function ChatboxBuilderView({
                             </div>
                           </dl>
                         </div>
-                        <div className="border-t border-border/60 pt-4">
-                          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                            Current test status
-                          </p>
-                          <dl className="mt-3 space-y-2 text-sm">
-                            <div className="flex justify-between gap-2">
-                              <dt className="text-muted-foreground">State</dt>
-                              <dd>
-                                {pendingOAuthServers.length > 0
-                                  ? "Auth required"
-                                  : chatbox?.link?.token
-                                    ? "Ready to test"
-                                    : "Unavailable"}
-                              </dd>
-                            </div>
-                            <div className="flex justify-between gap-2">
-                              <dt className="text-muted-foreground">
-                                Tool calls (this run)
-                              </dt>
-                              <dd className="font-mono">—</dd>
-                            </div>
-                          </dl>
+                        <div
+                          className="mt-auto border-t border-border/60 pt-4"
+                          data-testid="chatbox-builder-preview-rail-actions"
+                        >
+                          <ChatboxPreviewActionButtons
+                            variant="sidebar"
+                            hasSavedChatbox={hasSavedChatbox}
+                            onCopyLink={() => void handleCopyLink()}
+                            onOpenFullPreview={handleOpenFullPreview}
+                            onReloadPreview={reloadPreview}
+                          />
                         </div>
                       </div>
                     </div>
@@ -1280,6 +1249,7 @@ export function ChatboxBuilderView({
                             viewModel={viewModel}
                             selectedNodeId={selectedNodeId}
                             canvasViewportRefitNonce={canvasViewportRefitNonce}
+                            builderModelId={draftChatboxConfig.modelId}
                             canvasServerPicker={{
                               workspaceServers,
                               selectedServerIds:

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxCanvas.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxCanvas.tsx
@@ -1,6 +1,7 @@
 import {
   createContext,
   memo,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -18,11 +19,20 @@ import {
   SmoothStepEdge,
   useNodesInitialized,
   useReactFlow,
+  useUpdateNodeInternals,
   type Node,
   type NodeProps,
   type EdgeProps,
 } from "@xyflow/react";
-import { Bot, CircleHelp, Network, Plus, Server } from "lucide-react";
+import {
+  Bot,
+  ChevronDown,
+  CircleHelp,
+  Loader2,
+  Network,
+  Plus,
+  Server,
+} from "lucide-react";
 import "@xyflow/react/dist/style.css";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
@@ -36,6 +46,13 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@mcpjam/design-system/tooltip";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@mcpjam/design-system/collapsible";
+import { HOSTED_MODE } from "@/lib/config";
+import { listTools } from "@/lib/apis/mcp-tools-api";
 import type { RemoteServer } from "@/hooks/useWorkspaces";
 import { WorkspaceServerPickerList } from "@/components/chatboxes/builder/setup-checklist-panel";
 import { MCPIcon } from "@/components/ui/mcp-icon";
@@ -63,7 +80,151 @@ export type ChatboxCanvasServerPickerProps = {
 
 const ChatboxCanvasContext = createContext<{
   canvasServerPicker?: ChatboxCanvasServerPickerProps;
+  /** Chatbox draft model; forwarded to tools/list when loading server tools. */
+  builderModelId?: string;
 }>({});
+
+const TOOLS_LIST_MAX_PAGES = 24;
+
+async function fetchAllToolNames(
+  serverId: string,
+  modelId: string | undefined,
+): Promise<string[]> {
+  const names: string[] = [];
+  let cursor: string | undefined;
+  for (let page = 0; page < TOOLS_LIST_MAX_PAGES; page++) {
+    const data = await listTools({ serverId, modelId, cursor });
+    for (const t of data.tools ?? []) {
+      if (typeof t.name === "string" && t.name.length > 0) {
+        names.push(t.name);
+      }
+    }
+    cursor =
+      typeof data.nextCursor === "string" && data.nextCursor.length > 0
+        ? data.nextCursor
+        : undefined;
+    if (!cursor) break;
+  }
+  return [...new Set(names)].sort((a, b) => a.localeCompare(b));
+}
+
+function ServerNodeToolsCollapsible({
+  nodeId,
+  serverDocumentId,
+  workspaceServers,
+  builderModelId,
+}: {
+  nodeId: string;
+  serverDocumentId: string;
+  workspaceServers: RemoteServer[] | undefined;
+  builderModelId: string | undefined;
+}) {
+  const updateNodeInternals = useUpdateNodeInternals();
+  const toolsListServerId = useMemo(
+    () =>
+      HOSTED_MODE
+        ? serverDocumentId
+        : (workspaceServers?.find((s) => s._id === serverDocumentId)?.name ??
+          serverDocumentId),
+    [serverDocumentId, workspaceServers],
+  );
+
+  const [open, setOpen] = useState(false);
+  const [toolNames, setToolNames] = useState<string[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    setToolNames(null);
+    setError(null);
+    setLoading(false);
+    setOpen(false);
+    inFlightRef.current = false;
+  }, [toolsListServerId]);
+
+  const load = useCallback(async () => {
+    if (!toolsListServerId || inFlightRef.current) return;
+    inFlightRef.current = true;
+    setLoading(true);
+    setError(null);
+    try {
+      const names = await fetchAllToolNames(toolsListServerId, builderModelId);
+      setToolNames(names);
+    } catch (e) {
+      const message =
+        e instanceof Error ? e.message : "Could not load tools for this server.";
+      setError(message);
+      setToolNames(null);
+    } finally {
+      inFlightRef.current = false;
+      setLoading(false);
+    }
+  }, [toolsListServerId, builderModelId]);
+
+  const onOpenChange = useCallback(
+    (next: boolean) => {
+      setOpen(next);
+      if (next && toolNames === null && !inFlightRef.current) {
+        void load();
+      }
+    },
+    [load, toolNames],
+  );
+
+  useEffect(() => {
+    updateNodeInternals(nodeId);
+  }, [nodeId, open, loading, toolNames, error, updateNodeInternals]);
+
+  const countSuffix =
+    toolNames === null ? "" : ` (${toolNames.length})`;
+
+  return (
+    <Collapsible open={open} onOpenChange={onOpenChange} className="mt-3">
+      <CollapsibleTrigger
+        type="button"
+        className="nodrag nopan pointer-events-auto flex w-full items-center justify-between gap-2 rounded-md border border-border/60 bg-muted/30 px-2 py-1.5 text-left text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        <span>
+          Tools
+          {countSuffix}
+        </span>
+        <ChevronDown
+          className={cn(
+            "size-3.5 shrink-0 opacity-70 transition-transform",
+            open && "rotate-180",
+          )}
+          aria-hidden
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="data-[state=closed]:animate-none">
+        <div className="mt-1.5 max-h-36 overflow-y-auto rounded-md border border-border/50 bg-background/80 px-2 py-1.5">
+          {loading ? (
+            <div className="flex items-center gap-2 py-1 text-[11px] text-muted-foreground">
+              <Loader2 className="size-3.5 animate-spin" aria-hidden />
+              Loading tools…
+            </div>
+          ) : error ? (
+            <p className="text-[11px] leading-snug text-destructive">{error}</p>
+          ) : toolNames && toolNames.length > 0 ? (
+            <ul className="space-y-0.5 text-[11px] leading-snug text-foreground">
+              {toolNames.map((name) => (
+                <li key={name} className="font-mono">
+                  {name}
+                </li>
+              ))}
+            </ul>
+          ) : toolNames ? (
+            <p className="text-[11px] text-muted-foreground">
+              No tools reported by this server.
+            </p>
+          ) : null}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
 
 const CHIP_STYLES = {
   neutral: "border-border/70 bg-muted/40 text-muted-foreground",
@@ -108,10 +269,12 @@ const plusHandleButtonClass =
   "nodrag nopan pointer-events-auto flex size-7 items-center justify-center rounded-full border border-border/60 bg-card text-muted-foreground shadow-sm transition-colors hover:bg-primary hover:text-primary-foreground hover:border-primary";
 
 const ChatboxNode = memo((props: NodeProps<Node<ChatboxBuilderNodeData>>) => {
-  const { data, selected } = props;
+  const { id, data, selected } = props;
   const [canvasPickerOpen, setCanvasPickerOpen] = useState(false);
   const Icon = getNodeIcon(data.kind);
-  const { canvasServerPicker } = useContext(ChatboxCanvasContext);
+  const { canvasServerPicker, builderModelId } = useContext(
+    ChatboxCanvasContext,
+  );
   const isHostPreview = data.kind === "host";
   const hostStyle = data.hostStyle ?? "claude";
   const hostLogoSrc = isHostPreview ? getChatboxHostLogo(hostStyle) : null;
@@ -137,16 +300,6 @@ const ChatboxNode = memo((props: NodeProps<Node<ChatboxBuilderNodeData>>) => {
       )}
       {isHostPreview ? (
         <>
-          <div className="mb-2 flex items-center justify-center gap-2">
-            {data.eyebrow ? (
-              <Badge
-                variant="secondary"
-                className="max-w-[min(100%,11rem)] whitespace-normal rounded-md px-2 py-0.5 text-center text-[10px] font-medium uppercase leading-tight tracking-wide text-muted-foreground"
-              >
-                {data.eyebrow}
-              </Badge>
-            ) : null}
-          </div>
           <div className="flex gap-3">
             <div className="flex size-11 shrink-0 items-center justify-center rounded-2xl border border-border/50 bg-background/80 shadow-inner">
               <img
@@ -156,20 +309,21 @@ const ChatboxNode = memo((props: NodeProps<Node<ChatboxBuilderNodeData>>) => {
               />
             </div>
             <div className="min-w-0 flex-1">
-              <p
-                className="truncate text-sm font-semibold leading-tight"
-                title={data.title}
-              >
-                {data.title}
-              </p>
               {data.subtitle ? (
                 <p
-                  className="mt-1 line-clamp-2 text-xs text-muted-foreground"
+                  className="truncate text-sm font-semibold leading-tight"
                   title={data.subtitle}
                 >
                   {data.subtitle}
                 </p>
-              ) : null}
+              ) : (
+                <p
+                  className="truncate text-sm font-semibold leading-tight"
+                  title={data.title}
+                >
+                  {data.title}
+                </p>
+              )}
               {data.detailLine ? (
                 <p
                   className="mt-1.5 text-[11px] text-muted-foreground/90"
@@ -222,6 +376,15 @@ const ChatboxNode = memo((props: NodeProps<Node<ChatboxBuilderNodeData>>) => {
                 </Badge>
               ))}
             </div>
+          ) : null}
+
+          {data.serverId ? (
+            <ServerNodeToolsCollapsible
+              nodeId={id}
+              serverDocumentId={data.serverId}
+              workspaceServers={canvasServerPicker?.workspaceServers}
+              builderModelId={builderModelId}
+            />
           ) : null}
         </>
       )}
@@ -493,6 +656,7 @@ interface ChatboxCanvasProps {
   onSelectNode: (nodeId: string) => void;
   onClearSelection: () => void;
   canvasServerPicker?: ChatboxCanvasServerPickerProps;
+  builderModelId?: string;
   /** Incremented by the builder shell when the setup canvas is shown again or mobile setup chrome changes. */
   canvasViewportRefitNonce?: number;
 }
@@ -503,6 +667,7 @@ export function ChatboxCanvas({
   onSelectNode,
   onClearSelection,
   canvasServerPicker,
+  builderModelId,
   canvasViewportRefitNonce = 0,
 }: ChatboxCanvasProps) {
   const canvasRef = useRef<HTMLDivElement | null>(null);
@@ -519,8 +684,8 @@ export function ChatboxCanvas({
     [viewModel.nodes],
   );
   const ctxValue = useMemo(
-    () => ({ canvasServerPicker }),
-    [canvasServerPicker],
+    () => ({ canvasServerPicker, builderModelId }),
+    [canvasServerPicker, builderModelId],
   );
 
   return (
@@ -545,11 +710,10 @@ export function ChatboxCanvas({
             <TooltipContent
               side="bottom"
               align="end"
-              className="max-w-[300px] text-balance text-sm"
+              className="max-w-[320px] text-balance text-sm"
             >
-              This diagram maps your chatbox: servers, tools, and the chat
-              experience. Choose a Claude-style or ChatGPT-style host and other
-              behavior in Setup. Preview shows what end users will see.
+              Everything you configure in the panel on the right is reflected in
+              this diagram.
             </TooltipContent>
           </Tooltip>
         </div>

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxIndexPage.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxIndexPage.tsx
@@ -23,17 +23,14 @@ import {
   TooltipTrigger,
 } from "@mcpjam/design-system/tooltip";
 import type { ChatboxListItem } from "@/hooks/useChatboxes";
-import {
-  getChatboxHostLogo,
-  getChatboxHostStyleShortLabel,
-} from "@/lib/chatbox-host-style";
+import { getChatboxHostStyleShortLabel } from "@/lib/chatbox-host-style";
 import { ChatboxDeleteConfirmDialog } from "@/components/chatboxes/ChatboxDeleteConfirmDialog";
 import { ChatboxIndexRowActionsMenu } from "./chatbox-index-row-actions";
 import { CHATBOX_BLANK_STARTER, CHATBOX_TEMPLATE_STARTERS } from "./drafts";
 import type { ChatboxStarterDefinition } from "./types";
 
 export type ChatboxOpenOptions = {
-  initialViewMode?: "setup" | "preview" | "usage";
+  initialViewMode?: "setup" | "preview" | "usage" | "insights";
 };
 
 // ---------------------------------------------------------------------------
@@ -59,9 +56,6 @@ function ChatboxSummaryCard({
   isDeleting: boolean;
   isDuplicating: boolean;
 }) {
-  const modeLabel =
-    chatbox.mode === "invited_only" ? "Invited only" : "Anyone with link";
-
   const serverList =
     chatbox.serverNames.length > 0
       ? chatbox.serverNames.join(" · ")
@@ -82,26 +76,6 @@ function ChatboxSummaryCard({
           isDeleting={isDeleting}
           isDuplicating={isDuplicating}
         />
-      </div>
-
-      <div className="flex flex-wrap items-center gap-1.5">
-        <Badge
-          variant="secondary"
-          className="gap-1.5 border-0 bg-muted/50 px-2 py-0 text-xs font-normal text-muted-foreground"
-        >
-          <img
-            src={getChatboxHostLogo(chatbox.hostStyle)}
-            alt=""
-            className="size-3"
-          />
-          {getChatboxHostStyleShortLabel(chatbox.hostStyle)}
-        </Badge>
-        <Badge
-          variant="secondary"
-          className="border-0 bg-muted/50 px-2 py-0 text-xs font-normal text-muted-foreground"
-        >
-          {modeLabel}
-        </Badge>
       </div>
 
       <p className="truncate text-sm text-muted-foreground">{serverList}</p>

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxBuilderView.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxBuilderView.test.tsx
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
+import type { ChatboxSettings } from "@/hooks/useChatboxes";
 import { ChatboxBuilderView } from "../ChatboxBuilderView";
-import { CHATBOX_STARTERS } from "../drafts";
+import { CHATBOX_STARTERS, toDraftConfig } from "../drafts";
 
 const { mockUseChatbox, mockChatTabV2 } = vi.hoisted(() => ({
   mockUseChatbox: vi.fn(() => ({ chatbox: null })),
@@ -71,6 +72,16 @@ vi.mock("../ChatboxCanvas", () => ({
   ChatboxCanvas: () => <div data-testid="chatbox-canvas" />,
 }));
 
+vi.mock("@/components/chatboxes/ChatboxUsagePanel", () => ({
+  ChatboxUsagePanel: ({
+    section,
+  }: {
+    section: "sessions" | "insights";
+  }) => (
+    <div data-testid="chatbox-usage-panel" data-section={section} />
+  ),
+}));
+
 const httpsServer = {
   _id: "srv-1",
   workspaceId: "ws-1",
@@ -82,7 +93,7 @@ const httpsServer = {
   updatedAt: 1,
 };
 
-function createSavedChatbox(hostStyle: "claude" | "chatgpt") {
+function createSavedChatbox(hostStyle: "claude" | "chatgpt"): ChatboxSettings {
   return {
     chatboxId: `sbx-${hostStyle}`,
     workspaceId: "ws-1",
@@ -117,6 +128,31 @@ describe("ChatboxBuilderView", () => {
     mockUseChatbox.mockReset();
     mockUseChatbox.mockReturnValue({ chatbox: null });
     mockChatTabV2.mockReset();
+  });
+
+  it("shows Save changes on the header save button when a saved chatbox is dirty (no Unsaved badge)", () => {
+    const chatbox = createSavedChatbox("claude");
+    mockUseChatbox.mockReturnValue({ chatbox });
+    const dirtyDraft = {
+      ...toDraftConfig(chatbox),
+      name: "Renamed in draft",
+      selectedServerIds: [httpsServer._id],
+    };
+    render(
+      <ChatboxBuilderView
+        workspaceId="ws-1"
+        workspaceServers={[httpsServer]}
+        chatboxId={chatbox.chatboxId}
+        draft={dirtyDraft}
+        onBack={() => {}}
+        onSavedDraft={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Save changes" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Unsaved")).not.toBeInTheDocument();
   });
 
   it("exposes return navigation as an icon button with a descriptive label", () => {
@@ -182,7 +218,7 @@ describe("ChatboxBuilderView", () => {
     expect(screen.getByRole("button", { name: /^Save$/i })).not.toBeDisabled();
   });
 
-  it("disables Preview and Usage until the chatbox is saved", () => {
+  it("disables Preview, Sessions, and Insights until the chatbox is saved", () => {
     const draft = CHATBOX_STARTERS.find((s) => s.id === "blank")!.createDraft(
       "openai/gpt-5-mini",
     );
@@ -197,7 +233,50 @@ describe("ChatboxBuilderView", () => {
     );
 
     expect(screen.getByRole("button", { name: "Preview" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Usage" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Sessions" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Insights" })).toBeDisabled();
+  });
+
+  it("passes sessions section to the usage panel for usage view mode", () => {
+    const chatbox = createSavedChatbox("claude");
+    mockUseChatbox.mockReturnValue({ chatbox });
+
+    render(
+      <ChatboxBuilderView
+        workspaceId="ws-1"
+        workspaceServers={[httpsServer]}
+        chatboxId={chatbox.chatboxId}
+        initialViewMode="usage"
+        onBack={() => {}}
+        onSavedDraft={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("chatbox-usage-panel")).toHaveAttribute(
+      "data-section",
+      "sessions",
+    );
+  });
+
+  it("passes insights section to the usage panel for insights view mode", () => {
+    const chatbox = createSavedChatbox("claude");
+    mockUseChatbox.mockReturnValue({ chatbox });
+
+    render(
+      <ChatboxBuilderView
+        workspaceId="ws-1"
+        workspaceServers={[httpsServer]}
+        chatboxId={chatbox.chatboxId}
+        initialViewMode="insights"
+        onBack={() => {}}
+        onSavedDraft={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("chatbox-usage-panel")).toHaveAttribute(
+      "data-section",
+      "insights",
+    );
   });
 
   it("renders the setup checklist on desktop while in setup mode", () => {
@@ -216,6 +295,33 @@ describe("ChatboxBuilderView", () => {
 
     expect(screen.getByRole("button", { name: /Basics/i })).toBeInTheDocument();
     expect(screen.getByTestId("chatbox-canvas")).toBeInTheDocument();
+  });
+
+  it("renders preview actions in the preview config rail", () => {
+    const chatbox = createSavedChatbox("claude");
+    mockUseChatbox.mockReturnValue({ chatbox });
+
+    render(
+      <ChatboxBuilderView
+        workspaceId="ws-1"
+        workspaceServers={[httpsServer]}
+        chatboxId={chatbox.chatboxId}
+        initialViewMode="preview"
+        onBack={() => {}}
+        onSavedDraft={() => {}}
+      />,
+    );
+
+    const rail = screen.getByTestId("chatbox-builder-preview-rail-actions");
+    expect(
+      within(rail).getByRole("button", { name: "Copy link" }),
+    ).toBeInTheDocument();
+    expect(
+      within(rail).getByRole("button", { name: "Open full preview" }),
+    ).toBeInTheDocument();
+    expect(
+      within(rail).getByRole("button", { name: "Reload preview" }),
+    ).toBeInTheDocument();
   });
 
   it("passes the pulsing dot loading variant for ChatGPT builder previews", () => {

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxCanvas.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxCanvas.test.tsx
@@ -175,13 +175,10 @@ describe("ChatboxCanvas", () => {
       </ReactFlowProvider>,
     );
 
-    const hostTitle = screen.getByText("Chat Interface");
-    expect(hostTitle).toHaveAttribute("title", "Chat Interface");
-
-    const nameSubtitle = screen.getByText(
+    const hostName = screen.getByText(
       "My very long chatbox name that might truncate in the UI",
     );
-    expect(nameSubtitle).toHaveAttribute(
+    expect(hostName).toHaveAttribute(
       "title",
       "My very long chatbox name that might truncate in the UI",
     );

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/setup-checklist-panel.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/setup-checklist-panel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import {
   computeSectionStatuses,
@@ -33,6 +33,61 @@ describe("SetupChecklistPanel", () => {
     expect(screen.getByRole("button", { name: /Basics/i })).toBeInTheDocument();
   });
 
+  it("shows a subdued checkmark label with Done for complete sections (not a colored pill)", () => {
+    render(
+      <SetupChecklistPanel
+        chatboxDraft={baseDraft}
+        savedChatbox={null}
+        workspaceServers={[]}
+        focusedSection={null}
+        isUnsavedNewDraft
+        onDraftChange={() => {}}
+        onOpenAddServer={() => {}}
+        onToggleServer={() => {}}
+      />,
+    );
+
+    const basicsRow = screen.getByRole("button", { name: /Basics/i });
+    expect(within(basicsRow).getByText("Done")).toBeInTheDocument();
+    expect(
+      within(basicsRow).queryByText("Complete", { exact: true }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses the same muted inline template for Optional, Default on, and Collapsed (no secondary badges)", () => {
+    render(
+      <SetupChecklistPanel
+        chatboxDraft={{
+          ...baseDraft,
+          welcomeDialog: { ...baseDraft.welcomeDialog, enabled: false },
+        }}
+        savedChatbox={null}
+        workspaceServers={[]}
+        focusedSection={null}
+        isUnsavedNewDraft
+        onDraftChange={() => {}}
+        onOpenAddServer={() => {}}
+        onToggleServer={() => {}}
+      />,
+    );
+
+    const welcomeRow = screen.getByRole("button", {
+      name: /Welcome Dialog Optional/i,
+    });
+    expect(within(welcomeRow).getByText("Optional")).toBeInTheDocument();
+    expect(welcomeRow.querySelector('[data-slot="badge"]')).toBeNull();
+
+    const feedbackRow = screen.getByRole("button", { name: /Feedback Default on/i });
+    expect(within(feedbackRow).getByText("Default on")).toBeInTheDocument();
+    expect(feedbackRow.querySelector('[data-slot="badge"]')).toBeNull();
+
+    const advancedRow = screen.getByRole("button", {
+      name: /Advanced Collapsed/i,
+    });
+    expect(within(advancedRow).getByText("Collapsed")).toBeInTheDocument();
+    expect(advancedRow.querySelector('[data-slot="badge"]')).toBeNull();
+  });
+
   it("renders mobile Done header when onCloseMobile is provided", () => {
     render(
       <SetupChecklistPanel
@@ -52,31 +107,13 @@ describe("SetupChecklistPanel", () => {
     expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
   });
 
-  it("uses a compact description field (2 rows)", () => {
+  it("shows draft access controls inline in Access (no General access heading)", () => {
     render(
       <SetupChecklistPanel
         chatboxDraft={baseDraft}
         savedChatbox={null}
         workspaceServers={[]}
-        focusedSection={null}
-        isUnsavedNewDraft
-        onDraftChange={() => {}}
-        onOpenAddServer={() => {}}
-        onToggleServer={() => {}}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: /Basics/i }));
-    const description = screen.getByLabelText(/Description/i);
-    expect(description).toHaveAttribute("rows", "2");
-  });
-
-  it("opens consolidated access settings in a dialog (no General access heading)", () => {
-    render(
-      <SetupChecklistPanel
-        chatboxDraft={baseDraft}
-        savedChatbox={null}
-        workspaceServers={[]}
+        workspaceName="Acme"
         focusedSection={null}
         isUnsavedNewDraft
         onDraftChange={() => {}}
@@ -87,18 +124,15 @@ describe("SetupChecklistPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Access/i }));
     expect(screen.queryByText("General access")).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /Configure access/i }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(screen.getByText("Acme")).toBeInTheDocument();
+    expect(screen.getByText("Invited users only")).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "Access settings" }),
+      screen.getByText("Anyone with the link (guests included)"),
     ).toBeInTheDocument();
-    const dialog = screen.getByRole("dialog");
-    expect(
-      within(dialog).getByText("Anyone with the link"),
-    ).toBeInTheDocument();
-    expect(within(dialog).getByText("Allow guest access")).toBeInTheDocument();
   });
 
-  it("shows invite-only save prompt in access dialog when chatbox is unsaved", () => {
+  it("shows invite-only save prompt in Access when chatbox is unsaved", () => {
     const internalDraft = CHATBOX_STARTERS.find(
       (s) => s.id === "internal-qa",
     )!.createDraft("openai/gpt-5-mini");
@@ -116,7 +150,6 @@ describe("SetupChecklistPanel", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: /Access/i }));
-    fireEvent.click(screen.getByRole("button", { name: /Configure access/i }));
     expect(
       screen.getByText(/Save the chatbox to invite people by email/i),
     ).toBeInTheDocument();
@@ -144,7 +177,6 @@ describe("SetupChecklistPanel", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: /Access/i }));
-    fireEvent.click(screen.getByRole("button", { name: /Configure access/i }));
     expect(screen.getByText("Invite people")).toBeInTheDocument();
     expect(
       screen.getByPlaceholderText(/colleague@company.com/i),
@@ -173,34 +205,19 @@ describe("ServerSelectionEditor", () => {
     useOAuth: false,
   };
 
-  it("uses a Required / Optional toggle for connect at start vs add later", () => {
-    const onOptionalChange = vi.fn();
+  it("lists selected servers with remove actions", () => {
     render(
       <ServerSelectionEditor
         workspaceServers={[httpServer, httpServerB]}
         selectedServerIds={[httpServer._id, httpServerB._id]}
-        optionalServerIds={[]}
         onToggleSelection={() => {}}
-        onOptionalChange={onOptionalChange}
         onOpenAdd={() => {}}
       />,
     );
 
-    expect(
-      screen.getAllByText(
-        "Require server to connect at start or allow tester to add later",
-      ),
-    ).toHaveLength(2);
-    const requiredButtons = screen.getAllByRole("radio", {
-      name: /Required: connect at start/i,
-    });
-    expect(requiredButtons[0]).toHaveAttribute("data-state", "on");
-    fireEvent.click(
-      screen.getAllByRole("radio", {
-        name: /Optional: tester adds later from chat/i,
-      })[0]!,
-    );
-    expect(onOptionalChange).toHaveBeenCalledWith(httpServer._id, true);
+    expect(screen.getByText("Linear MCP")).toBeInTheDocument();
+    expect(screen.getByText("Other MCP")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Remove" })).toHaveLength(2);
   });
 });
 

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/chatboxCanvasBuilder.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/chatboxCanvasBuilder.ts
@@ -69,7 +69,6 @@ function resolveHostState(
   return {
     kind: "host",
     title: "Chat Interface",
-    eyebrow: "Isolated Environment",
     subtitle: source?.name?.trim() || "Untitled chatbox",
     detailLine: `Model · ${modelName}`,
     hostStyle,
@@ -93,13 +92,7 @@ function resolveServerState(
     context.workspaceServers.find((item) => item._id === serverId) ?? null;
   const insecure = server?.url?.startsWith("http://") ?? false;
 
-  const chips: ChatboxBuilderNodeData["chips"] = [
-    chip(server?.useOAuth ? "OAuth" : "Direct"),
-    chip(
-      insecure ? "Requires HTTPS" : "HTTPS",
-      insecure ? "warning" : "success",
-    ),
-  ];
+  const chips: ChatboxBuilderNodeData["chips"] = [];
   if (optionalIds.includes(serverId)) {
     chips.push(chip("Optional", "info"));
   }

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/setup-checklist-panel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/setup-checklist-panel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown, Globe, Loader2, Lock, Plus } from "lucide-react";
+import { Check, ChevronDown, Loader2, Plus } from "lucide-react";
 import { toast } from "sonner";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
@@ -12,14 +12,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@mcpjam/design-system/collapsible";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@mcpjam/design-system/dialog";
 import {
   Popover,
   PopoverContent,
@@ -36,11 +28,15 @@ import {
 import { Separator } from "@mcpjam/design-system/separator";
 import { Slider } from "@mcpjam/design-system/slider";
 import { Switch } from "@mcpjam/design-system/switch";
-import { ToggleGroup, ToggleGroupItem } from "@mcpjam/design-system/toggle-group";
 import { Textarea } from "@mcpjam/design-system/textarea";
 import { ScrollArea } from "@mcpjam/design-system/scroll-area";
 import { ChatboxShareSection } from "@/components/chatboxes/ChatboxShareSection";
-import type { ChatboxSettings, ChatboxMode } from "@/hooks/useChatboxes";
+import type { ChatboxSettings } from "@/hooks/useChatboxes";
+import {
+  chatboxAccessPresetFromSettings,
+  settingsFromChatboxAccessPreset,
+  type ChatboxAccessPreset,
+} from "@/lib/chatbox-access-presets";
 import type { RemoteServer } from "@/hooks/useWorkspaces";
 import {
   getChatboxHostLogo,
@@ -50,7 +46,6 @@ import {
 import { isMCPJamProvidedModel, SUPPORTED_MODELS } from "@/shared/types";
 import { cn } from "@/lib/utils";
 import type { ChatboxDraftConfig } from "./types";
-import { countRequiredServers } from "./chatbox-server-optional";
 
 export type SetupSectionId =
   | "basics"
@@ -67,16 +62,17 @@ type SectionStatusKind =
   | "default_on"
   | "collapsed";
 
+const sectionStatusMetaClassName =
+  "inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground";
+
 function SectionStatusBadge({ kind }: { kind: SectionStatusKind }) {
   switch (kind) {
     case "complete":
       return (
-        <Badge
-          variant="outline"
-          className="border-emerald-600/55 bg-emerald-500/[0.14] px-3 py-0.5 text-emerald-900 dark:border-emerald-400/45 dark:bg-emerald-950/50 dark:text-emerald-200"
-        >
-          Complete
-        </Badge>
+        <span className={sectionStatusMetaClassName}>
+          <Check className="size-3.5 shrink-0" strokeWidth={2.25} aria-hidden />
+          Done
+        </span>
       );
     case "attention":
       return (
@@ -88,23 +84,11 @@ function SectionStatusBadge({ kind }: { kind: SectionStatusKind }) {
         </Badge>
       );
     case "optional":
-      return (
-        <Badge variant="secondary" className="font-normal">
-          Optional
-        </Badge>
-      );
+      return <span className={sectionStatusMetaClassName}>Optional</span>;
     case "default_on":
-      return (
-        <Badge variant="secondary" className="font-normal">
-          Default on
-        </Badge>
-      );
+      return <span className={sectionStatusMetaClassName}>Default on</span>;
     case "collapsed":
-      return (
-        <Badge variant="secondary" className="font-normal">
-          Collapsed
-        </Badge>
-      );
+      return <span className={sectionStatusMetaClassName}>Collapsed</span>;
     default:
       return null;
   }
@@ -230,23 +214,18 @@ export function WorkspaceServerPickerList({
 export function ServerSelectionEditor({
   workspaceServers,
   selectedServerIds,
-  optionalServerIds,
   onToggleSelection,
-  onOptionalChange,
   onOpenAdd,
 }: {
   workspaceServers: RemoteServer[];
   selectedServerIds: string[];
-  optionalServerIds: string[];
   onToggleSelection: (serverId: string, checked: boolean) => void;
-  onOptionalChange: (serverId: string, optional: boolean) => void;
   onOpenAdd: () => void;
 }) {
   const availableServers = workspaceServers.filter(
     (server) => server.transportType === "http",
   );
   const selectedServerSet = new Set(selectedServerIds);
-  const optionalServerSet = new Set(optionalServerIds);
   const selectedServers = availableServers.filter((server) =>
     selectedServerSet.has(server._id),
   );
@@ -260,13 +239,7 @@ export function ServerSelectionEditor({
 
   return (
     <div className="space-y-3">
-      <div>
-        <h3 className="text-sm font-semibold">MCP servers</h3>
-        <p className="mt-1 text-xs text-muted-foreground">
-          Pick HTTPS servers from the workspace, then set whether each connects
-          at start or only when the tester adds it from chat.
-        </p>
-      </div>
+      <h3 className="text-sm font-semibold">MCP servers</h3>
 
       <div className="flex min-w-0 gap-2">
         <Popover>
@@ -320,101 +293,29 @@ export function ServerSelectionEditor({
 
       {selectedServers.length > 0 ? (
         <div className="space-y-3">
-          {selectedServers.map((server) => {
-            const isOptional = optionalServerSet.has(server._id);
-            const requiredCount = countRequiredServers(
-              selectedServerIds,
-              optionalServerIds,
-            );
-            const cannotMarkOptional = !isOptional && requiredCount === 1;
-
-            return (
-              <Card
-                key={server._id}
-                className="gap-3 rounded-2xl p-3 py-4 shadow-sm"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <p className="font-medium leading-tight">{server.name}</p>
-                    <p className="mt-0.5 font-mono text-xs leading-snug text-muted-foreground">
-                      {server.url ?? "Workspace server"}
-                    </p>
-                    <div className="mt-2 flex flex-wrap gap-1.5">
-                      <Badge
-                        variant="outline"
-                        className="text-[11px] font-normal"
-                      >
-                        {server.useOAuth ? "OAuth" : "Direct"}
-                      </Badge>
-                      <Badge
-                        variant={
-                          isInsecureUrl(server.url) ? "secondary" : "outline"
-                        }
-                        className="text-[11px] font-normal"
-                      >
-                        {isInsecureUrl(server.url) ? "Requires HTTPS" : "HTTPS"}
-                      </Badge>
-                    </div>
-                  </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    className="shrink-0 text-destructive hover:text-destructive"
-                    onClick={() => onToggleSelection(server._id, false)}
-                  >
-                    Remove
-                  </Button>
-                </div>
-                <div className="space-y-1.5">
-                  <p
-                    className="text-xs font-medium leading-snug text-muted-foreground"
-                    id={`server-startup-${server._id}`}
-                  >
-                    Require server to connect at start or allow tester to add
-                    later
+          {selectedServers.map((server) => (
+            <Card
+              key={server._id}
+              className="gap-3 rounded-2xl p-3 py-4 shadow-sm"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="font-medium leading-tight">{server.name}</p>
+                  <p className="mt-0.5 font-mono text-xs leading-snug text-muted-foreground">
+                    {server.url ?? "Workspace server"}
                   </p>
-                  <ToggleGroup
-                    type="single"
-                    variant="outline"
-                    size="sm"
-                    className="w-full sm:w-auto"
-                    value={isOptional ? "optional" : "required"}
-                    onValueChange={(value) => {
-                      if (value === "optional") {
-                        if (cannotMarkOptional) {
-                          toast.message(
-                            "Add another server before marking this one optional. At least one server must connect when the chatbox opens.",
-                          );
-                          return;
-                        }
-                        onOptionalChange(server._id, true);
-                        return;
-                      }
-                      if (value === "required") {
-                        onOptionalChange(server._id, false);
-                      }
-                    }}
-                    aria-labelledby={`server-startup-${server._id}`}
-                  >
-                    <ToggleGroupItem
-                      value="required"
-                      className="flex-1 px-3 text-xs"
-                      aria-label="Required: connect at start"
-                    >
-                      Required
-                    </ToggleGroupItem>
-                    <ToggleGroupItem
-                      value="optional"
-                      className="flex-1 px-3 text-xs"
-                      aria-label="Optional: tester adds later from chat"
-                    >
-                      Optional
-                    </ToggleGroupItem>
-                  </ToggleGroup>
                 </div>
-              </Card>
-            );
-          })}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="shrink-0 text-destructive hover:text-destructive"
+                  onClick={() => onToggleSelection(server._id, false)}
+                >
+                  Remove
+                </Button>
+              </div>
+            </Card>
+          ))}
         </div>
       ) : null}
     </div>
@@ -467,17 +368,16 @@ export function SetupChecklistPanel({
   chatboxDraft,
   savedChatbox,
   workspaceServers,
-  workspaceName,
   focusedSection,
   /** True when creating a chatbox that has never been saved (no chatbox id yet). */
   isUnsavedNewDraft,
   onDraftChange,
   onOpenAddServer,
   onToggleServer,
-  onServerOptionalChange,
   onCloseMobile,
-  /** When the chatbox is saved, invite someone by email from the Access dialog (invite-only mode). */
+  /** When the chatbox is saved, invite by email from the Access section (invite-only draft). */
   inviteChatboxMember,
+  workspaceName,
 }: {
   chatboxDraft: ChatboxDraftConfig;
   savedChatbox: ChatboxSettings | null;
@@ -490,7 +390,6 @@ export function SetupChecklistPanel({
   ) => void;
   onOpenAddServer: () => void;
   onToggleServer: (serverId: string, checked: boolean) => void;
-  onServerOptionalChange: (serverId: string, optional: boolean) => void;
   onCloseMobile?: () => void;
   inviteChatboxMember?: (email: string) => Promise<void>;
 }) {
@@ -506,7 +405,6 @@ export function SetupChecklistPanel({
   const [openMap, setOpenMap] = useState<
     Partial<Record<SetupSectionId, boolean>>
   >({});
-  const [accessDialogOpen, setAccessDialogOpen] = useState(false);
   const [accessInviteEmail, setAccessInviteEmail] = useState("");
   const [accessInviteBusy, setAccessInviteBusy] = useState(false);
   const didAutoExpandRef = useRef(false);
@@ -608,26 +506,6 @@ export function SetupChecklistPanel({
                       }
                     />
                   </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="setup-chatbox-description">
-                      Description
-                    </Label>
-                    <Textarea
-                      id="setup-chatbox-description"
-                      rows={2}
-                      value={chatboxDraft.description}
-                      onChange={(event) =>
-                        onDraftChange((draft) => ({
-                          ...draft,
-                          description: event.target.value,
-                        }))
-                      }
-                    />
-                    <p className="text-xs text-muted-foreground">
-                      Optional — helpful for collaborators, not required for
-                      first save.
-                    </p>
-                  </div>
 
                   <Separator />
 
@@ -724,9 +602,7 @@ export function SetupChecklistPanel({
                   <ServerSelectionEditor
                     workspaceServers={workspaceServers}
                     selectedServerIds={chatboxDraft.selectedServerIds}
-                    optionalServerIds={chatboxDraft.optionalServerIds}
                     onToggleSelection={onToggleServer}
-                    onOptionalChange={onServerOptionalChange}
                     onOpenAdd={onOpenAddServer}
                   />
                 </div>
@@ -751,90 +627,55 @@ export function SetupChecklistPanel({
               />
               <CollapsibleContent className="pt-3 pb-1">
                 <div className="space-y-4 rounded-xl border border-border/50 bg-card/40 p-4">
-                  <div className="flex flex-col gap-3 rounded-2xl border border-border/70 bg-card/60 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
-                    <div className="flex min-w-0 items-start gap-3">
-                      <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-muted">
-                        {chatboxDraft.mode === "any_signed_in_with_link" ? (
-                          <Globe className="size-4 text-muted-foreground" />
-                        ) : (
-                          <Lock className="size-4 text-muted-foreground" />
-                        )}
-                      </div>
-                      <div className="min-w-0">
-                        <p className="text-sm font-medium">
-                          {chatboxDraft.mode === "any_signed_in_with_link"
-                            ? "Anyone with the link"
-                            : "Invited users only"}
-                        </p>
-                        <p className="mt-0.5 text-xs text-muted-foreground">
-                          {chatboxDraft.mode === "any_signed_in_with_link"
-                            ? "Any signed-in user with the link can open this chatbox."
-                            : "Only people you invite can access this chatbox."}{" "}
-                          Guest access{" "}
-                          {chatboxDraft.allowGuestAccess ? "on" : "off"}.
-                        </p>
-                      </div>
-                    </div>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="shrink-0 self-start sm:self-center"
-                      onClick={() => setAccessDialogOpen(true)}
-                    >
-                      Configure access
-                    </Button>
-                  </div>
-
-                  <Dialog
-                    open={accessDialogOpen}
-                    onOpenChange={setAccessDialogOpen}
-                  >
-                    <DialogContent className="sm:max-w-md">
-                      <DialogHeader>
-                        <DialogTitle>Access settings</DialogTitle>
-                        <DialogDescription>
-                          Choose who can open this chatbox and whether guests
-                          can use it without a full account.
-                        </DialogDescription>
-                      </DialogHeader>
+                  {savedChatbox ? (
+                    <ChatboxShareSection
+                      chatbox={savedChatbox}
+                      workspaceName={workspaceName}
+                    />
+                  ) : (
+                    <>
                       <div className="space-y-6">
                         <RadioGroup
-                          value={chatboxDraft.mode}
+                          value={chatboxAccessPresetFromSettings(
+                            chatboxDraft.mode,
+                            chatboxDraft.allowGuestAccess,
+                          )}
                           onValueChange={(value) =>
                             onDraftChange((draft) => ({
                               ...draft,
-                              mode: value as ChatboxMode,
+                              ...settingsFromChatboxAccessPreset(
+                                value as ChatboxAccessPreset,
+                              ),
                             }))
                           }
                           className="grid gap-2"
                         >
                           <label
-                            htmlFor="access-mode-link"
+                            htmlFor="access-preset-workspace"
                             className="flex cursor-pointer items-start gap-3 rounded-xl border border-border/70 bg-card/50 p-3 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring/50"
                           >
                             <RadioGroupItem
-                              value="any_signed_in_with_link"
-                              id="access-mode-link"
+                              value="workspace"
+                              id="access-preset-workspace"
                               className="mt-0.5"
                             />
                             <span className="min-w-0">
                               <span className="block text-sm font-medium">
-                                Anyone with the link
+                                {workspaceName?.trim() || "Workspace"}
                               </span>
                               <span className="mt-0.5 block text-xs text-muted-foreground">
-                                Any signed-in user with the link can open this
-                                chatbox.
+                                Signed-in members of this workspace can open the
+                                chatbox with the link. Guests cannot.
                               </span>
                             </span>
                           </label>
                           <label
-                            htmlFor="access-mode-invite"
+                            htmlFor="access-preset-invited"
                             className="flex cursor-pointer items-start gap-3 rounded-xl border border-border/70 bg-card/50 p-3 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring/50"
                           >
                             <RadioGroupItem
                               value="invited_only"
-                              id="access-mode-invite"
+                              id="access-preset-invited"
                               className="mt-0.5"
                             />
                             <span className="min-w-0">
@@ -843,8 +684,26 @@ export function SetupChecklistPanel({
                               </span>
                               <span className="mt-0.5 block text-xs text-muted-foreground">
                                 Only people you invite by email can open this
-                                chatbox. Workspace membership does not grant
-                                access by itself.
+                                chatbox.
+                              </span>
+                            </span>
+                          </label>
+                          <label
+                            htmlFor="access-preset-link-guests"
+                            className="flex cursor-pointer items-start gap-3 rounded-xl border border-border/70 bg-card/50 p-3 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring/50"
+                          >
+                            <RadioGroupItem
+                              value="link_guests"
+                              id="access-preset-link-guests"
+                              className="mt-0.5"
+                            />
+                            <span className="min-w-0">
+                              <span className="block text-sm font-medium">
+                                Anyone with the link (guests included)
+                              </span>
+                              <span className="mt-0.5 block text-xs text-muted-foreground">
+                                Anyone with the link can open the chatbox,
+                                including guests without an account.
                               </span>
                             </span>
                           </label>
@@ -855,7 +714,8 @@ export function SetupChecklistPanel({
                             <p className="text-xs text-muted-foreground">
                               Invite-only is email-based. Workspace membership
                               does not auto-include everyone—you invite each
-                              address (or use Share below for the full list).
+                              address (or use the section below once the chatbox
+                              is saved).
                             </p>
                             <div className="space-y-2">
                               <p className="text-sm font-semibold text-foreground">
@@ -905,58 +765,18 @@ export function SetupChecklistPanel({
                               </div>
                               {!inviteChatboxMember ? (
                                 <p className="text-xs text-muted-foreground">
-                                  Save the chatbox to invite people by email and
-                                  manage the share link.
+                                  Save the chatbox to invite people by email.
                                 </p>
                               ) : null}
                             </div>
                           </div>
                         ) : null}
-
-                        <div className="flex items-start justify-between gap-4 rounded-xl border border-border/70 bg-card/50 px-4 py-3">
-                          <div className="min-w-0">
-                            <p className="text-sm font-medium">
-                              Allow guest access
-                            </p>
-                            <p className="mt-0.5 text-xs text-muted-foreground">
-                              When the link mode allows it, guests can open
-                              without a full account.
-                            </p>
-                          </div>
-                          <Switch
-                            className="shrink-0"
-                            checked={chatboxDraft.allowGuestAccess}
-                            onCheckedChange={(checked) =>
-                              onDraftChange((draft) => ({
-                                ...draft,
-                                allowGuestAccess: checked,
-                              }))
-                            }
-                          />
-                        </div>
                       </div>
-                      <DialogFooter>
-                        <Button
-                          type="button"
-                          onClick={() => setAccessDialogOpen(false)}
-                        >
-                          Done
-                        </Button>
-                      </DialogFooter>
-                    </DialogContent>
-                  </Dialog>
-
-                  {savedChatbox ? (
-                    <ChatboxShareSection
-                      chatbox={savedChatbox}
-                      workspaceName={workspaceName}
-                      appearance="builder"
-                    />
-                  ) : (
-                    <p className="text-sm text-muted-foreground">
-                      Save the chatbox to manage invitations, rotate the share
-                      link, and copy the public URL.
-                    </p>
+                      <p className="text-sm text-muted-foreground">
+                        Save the chatbox to manage invitations and access
+                        settings for the hosted link.
+                      </p>
+                    </>
                   )}
                 </div>
               </CollapsibleContent>

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/types.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/types.ts
@@ -59,8 +59,6 @@ export interface ChatboxBuilderNodeData extends Record<string, unknown> {
   kind: ChatboxBuilderNodeKind;
   title: string;
   subtitle?: string;
-  /** Small label above the title (e.g. Isolated Environment on the host chat card). */
-  eyebrow?: string;
   /** Extra line under subtitle (e.g. model name on the host card). */
   detailLine?: string;
   chips: ChatboxBuilderChip[];

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadDetail.tsx
@@ -301,28 +301,31 @@ export function ShareUsageThreadDetail({
         onModeChange={setViewMode}
       />
 
-      {/* Content area */}
-      <div className="flex-1 min-h-0 overflow-y-auto">
+      {/* Content area: must be a flex column so TraceViewer (fillContent) is a flex item; otherwise
+          nested flex-1 / min-h-0 inside TraceTimeline collapses and the timeline paints empty. */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {viewMode === "chat" ? (
-          <TranscriptThread
-            messages={adaptedTrace.messages}
-            model={resolvedModel}
-            sendFollowUpMessage={NOOP}
-            toolsMetadata={{}}
-            toolServerMap={{}}
-            pipWidgetId={null}
-            fullscreenWidgetId={null}
-            onRequestPip={NOOP}
-            onExitPip={NOOP}
-            onRequestFullscreen={NOOP}
-            onExitFullscreen={NOOP}
-            toolRenderOverrides={adaptedTrace.toolRenderOverrides}
-            showSaveViewButton={false}
-            minimalMode={!isChatboxThread}
-            interactive={false}
-            reasoningDisplayMode={reasoningDisplayMode}
-            contentClassName="max-w-4xl space-y-8 px-4 py-4"
-          />
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <TranscriptThread
+              messages={adaptedTrace.messages}
+              model={resolvedModel}
+              sendFollowUpMessage={NOOP}
+              toolsMetadata={{}}
+              toolServerMap={{}}
+              pipWidgetId={null}
+              fullscreenWidgetId={null}
+              onRequestPip={NOOP}
+              onExitPip={NOOP}
+              onRequestFullscreen={NOOP}
+              onExitFullscreen={NOOP}
+              toolRenderOverrides={adaptedTrace.toolRenderOverrides}
+              showSaveViewButton={false}
+              minimalMode={!isChatboxThread}
+              interactive={false}
+              reasoningDisplayMode={reasoningDisplayMode}
+              contentClassName="max-w-4xl space-y-8 px-4 py-4"
+            />
+          </div>
         ) : (
           <TraceViewer
             trace={traceEnvelope}

--- a/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadList.tsx
+++ b/mcpjam-inspector/client/src/components/connection/share-usage/ShareUsageThreadList.tsx
@@ -173,11 +173,6 @@ function ThreadCard({
             <span className="truncate">{thread.themeClusterLabel}</span>
           </span>
         ) : null}
-        {thread.geoCountry ? (
-          <span className="rounded-full bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
-            {thread.geoCountry}
-          </span>
-        ) : null}
       </div>
       {thread.firstMessagePreview ? (
         <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/shared/usage-insights/UsageInsightsStrip.tsx
+++ b/mcpjam-inspector/client/src/components/shared/usage-insights/UsageInsightsStrip.tsx
@@ -37,17 +37,6 @@ function renderThemes(breakdown: UsageBreakdown | null | undefined): BarDatum[] 
   }));
 }
 
-function renderGeography(
-  breakdown: UsageBreakdown | null | undefined,
-): BarDatum[] {
-  if (!breakdown) return [];
-  return breakdown.geography.map((g) => ({
-    key: g.key,
-    label: g.label,
-    count: g.count,
-  }));
-}
-
 function renderUserSegment(
   breakdown: UsageBreakdown | null | undefined,
 ): StackedDatum[] {
@@ -95,7 +84,6 @@ export function UsageInsightsStrip({
 
   const latestRun = breakdown?.latestRun ?? null;
   const themes = renderThemes(breakdown);
-  const geography = renderGeography(breakdown);
   const userSegment = renderUserSegment(breakdown);
   const devices: BarDatum[] = breakdown?.deviceBreakdown ?? [];
   const languages: BarDatum[] = breakdown?.languageBreakdown ?? [];
@@ -211,24 +199,6 @@ export function UsageInsightsStrip({
                   ? "Clustering in progress…"
                   : "Click rebuild to generate themes"
             }
-          />
-
-          <UsageBarCard
-            title="Geography"
-            description="By country (from request headers)"
-            data={geography.map((g) => ({
-              ...g,
-              isSelected: isDimSelected("geoCountry", g.key),
-            }))}
-            onBarClick={(datum) => {
-              onToggleChip({
-                kind: "dimension",
-                key: "geoCountry",
-                value: datum.key,
-                label: `Country · ${datum.label}`,
-              });
-            }}
-            emptyState="No geography data captured"
           />
 
           <UsageStackedBarCard

--- a/mcpjam-inspector/client/src/hooks/chatbox-usage-filters.ts
+++ b/mcpjam-inspector/client/src/hooks/chatbox-usage-filters.ts
@@ -7,7 +7,6 @@ export type UsageFilterPreset =
   | "no_feedback";
 
 export type UsageDimensionKey =
-  | "geoCountry"
   | "deviceKind"
   | "visitorSegment"
   | "language"
@@ -91,8 +90,6 @@ export function threadMatchesChip(
     return thread.themeClusterId === chip.clusterId;
   }
   switch (chip.key) {
-    case "geoCountry":
-      return thread.geoCountry === chip.value;
     case "deviceKind":
       return thread.deviceKind === chip.value;
     case "visitorSegment":

--- a/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatThreads.ts
@@ -29,9 +29,6 @@ export interface SharedChatThread {
   themeClusterId?: string;
   themeClusterLabel?: string;
   themeKeywords?: string[];
-  geoCountry?: string;
-  geoRegion?: string;
-  geoCity?: string;
   deviceKind?: "desktop" | "mobile" | "tablet" | "bot";
   userAgentFamily?: string;
   authType?: "signedIn" | "guest";

--- a/mcpjam-inspector/client/src/hooks/useUsageInsights.ts
+++ b/mcpjam-inspector/client/src/hooks/useUsageInsights.ts
@@ -37,7 +37,6 @@ export type ClusterRunState = {
 
 export type UsageBreakdown = {
   themes: Array<{ clusterId: string; label: string; count: number }>;
-  geography: BreakdownBucket[];
   userBreakdown: FeedbackBucketCount[];
   deviceBreakdown: BreakdownBucket[];
   languageBreakdown: BreakdownBucket[];

--- a/mcpjam-inspector/client/src/lib/__tests__/chatbox-access-presets.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/chatbox-access-presets.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  chatboxAccessPresetFromSettings,
+  settingsFromChatboxAccessPreset,
+} from "../chatbox-access-presets";
+
+describe("chatboxAccessPresetFromSettings", () => {
+  it("maps invited-only mode regardless of legacy guest flag", () => {
+    expect(
+      chatboxAccessPresetFromSettings("invited_only", true),
+    ).toBe("invited_only");
+  });
+
+  it("maps link mode without guests to workspace preset", () => {
+    expect(
+      chatboxAccessPresetFromSettings("any_signed_in_with_link", false),
+    ).toBe("workspace");
+  });
+
+  it("maps link mode with guests to link_guests preset", () => {
+    expect(
+      chatboxAccessPresetFromSettings("any_signed_in_with_link", true),
+    ).toBe("link_guests");
+  });
+});
+
+describe("settingsFromChatboxAccessPreset", () => {
+  it("round-trips with fromSettings for normal cases", () => {
+    const presets = ["workspace", "invited_only", "link_guests"] as const;
+    for (const preset of presets) {
+      const s = settingsFromChatboxAccessPreset(preset);
+      expect(chatboxAccessPresetFromSettings(s.mode, s.allowGuestAccess)).toBe(
+        preset,
+      );
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/lib/chatbox-access-presets.ts
+++ b/mcpjam-inspector/client/src/lib/chatbox-access-presets.ts
@@ -1,0 +1,30 @@
+import type { ChatboxMode } from "@/hooks/useChatboxes";
+
+/** UI preset for chatbox access (maps to `mode` + `allowGuestAccess`). */
+export type ChatboxAccessPreset =
+  | "workspace"
+  | "invited_only"
+  | "link_guests";
+
+export function chatboxAccessPresetFromSettings(
+  mode: ChatboxMode,
+  allowGuestAccess: boolean,
+): ChatboxAccessPreset {
+  if (mode === "invited_only") {
+    return "invited_only";
+  }
+  return allowGuestAccess ? "link_guests" : "workspace";
+}
+
+export function settingsFromChatboxAccessPreset(
+  preset: ChatboxAccessPreset,
+): { mode: ChatboxMode; allowGuestAccess: boolean } {
+  switch (preset) {
+    case "workspace":
+      return { mode: "any_signed_in_with_link", allowGuestAccess: false };
+    case "link_guests":
+      return { mode: "any_signed_in_with_link", allowGuestAccess: true };
+    case "invited_only":
+      return { mode: "invited_only", allowGuestAccess: false };
+  }
+}

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -7,19 +7,11 @@ const MAX_RESPONSE_PREVIEW_CHARS = 200;
 
 /**
  * Headers worth forwarding from the browser request to the Convex ingestion
- * endpoint so that usage-insights enrichment (device, language, geo) works.
+ * endpoint so that usage-insights enrichment (device, language) works.
  */
 const ENRICHMENT_HEADERS_TO_FORWARD = [
   "user-agent",
   "accept-language",
-  // Geo headers injected by CDN/edge providers
-  "cf-ipcountry",
-  "x-vercel-ip-country",
-  "x-vercel-ip-country-region",
-  "x-vercel-ip-city",
-  "x-geo-country",
-  "x-geo-region",
-  "x-geo-city",
   // Client IP headers for visitor hashing
   "x-forwarded-for",
   "x-real-ip",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes chatbox access/sharing flows (mode + guest access mapping) and refactors builder navigation/usage panels, which could affect who can access chatboxes and what reviewers see in usage dashboards.
> 
> **Overview**
> Improves the chatbox builder experience by splitting `Usage` into **Sessions** vs **Insights**, adding preview action controls (copy/open/reload) to the preview rails/header, and wiring the builder to pass a `section` into `ChatboxUsagePanel`.
> 
> Refactors chatbox access configuration into a shared `ChatboxAccessPreset` abstraction (`workspace`/`invited_only`/`link_guests`) and updates both create-mode access picking and the share UI to use this preset-based model, including passing `workspaceName` through where needed.
> 
> Modernizes `ChatboxShareSection` and `ShareChatboxDialog` to a unified, dropdown-based access settings + invite management UI (with pending-invite handling and email validation), simplifies server selection by removing required/optional toggles in the setup/editor surfaces, and adds a canvas server-node tools list that fetches tools via `listTools` (paged) using the draft model id.
> 
> Separately removes geography tracking/filtering from usage insights (no geo breakdown, no geo chips, no geo headers forwarded on ingestion) and fixes a flex layout issue in `ShareUsageThreadDetail` so timeline/chat content renders correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f47548273ce8a440ba6a12f31c47745d7bdde3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->