### PR TITLE
Forward chatbox token + workspace to Convex /stream (shared chatbox)

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -174,6 +174,37 @@ describe("web routes — chat-v2 hosted mode", () => {
     );
   });
 
+  it("passes shared chatbox link context into the hosted model handler", async () => {
+    const { app, token } = createWebTestApp();
+
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        workspaceId: "workspace-1",
+        selectedServerIds: ["server-1"],
+        chatboxToken: "chatbox-shared-token",
+        surface: "share_link",
+        chatSessionId: "chat-session-shared",
+        messages: [{ role: "user", content: "hello from guest" }],
+        model: {
+          id: "anthropic/claude-opus-4.6",
+          provider: "anthropic",
+          name: "Claude Opus 4.6",
+        },
+      },
+      token,
+    );
+
+    expect(response.status).toBe(200);
+    expect(handleMCPJamFreeChatModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatboxToken: "chatbox-shared-token",
+        workspaceId: "workspace-1",
+      }),
+    );
+  });
+
   it("forwards directVisibility for hosted direct chats", async () => {
     const { app, token } = createWebTestApp();
 

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -351,6 +351,8 @@ chatV2.post("/", async (c) => {
         temperature: resolvedTemperature,
         tools: allTools as ToolSet,
         authHeader: c.req.header("authorization"),
+        chatboxToken,
+        workspaceId: hostedBody.workspaceId,
         mcpClientManager: manager,
         selectedServers: selectedServerIds,
         requireToolApproval,

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -77,6 +77,8 @@ export interface MCPJamHandlerOptions {
   temperature?: number;
   tools: ToolSet;
   authHeader?: string;
+  chatboxToken?: string;
+  workspaceId?: string;
   mcpClientManager: MCPClientManager;
   selectedServers?: string[];
   requireToolApproval?: boolean;
@@ -98,6 +100,8 @@ interface StepContext {
   toolDefs: ToolDefinition[];
   tools: ToolSet;
   authHeader?: string;
+  chatboxToken?: string;
+  workspaceId?: string;
   modelId: string;
   systemPrompt: string;
   temperature?: number;
@@ -877,6 +881,8 @@ async function processOneStep(
     toolDefs,
     tools,
     authHeader,
+    chatboxToken,
+    workspaceId,
     modelId,
     systemPrompt,
     temperature,
@@ -933,6 +939,8 @@ async function processOneStep(
       systemPrompt,
       ...(temperature !== undefined ? { temperature } : {}),
       tools: toolDefs,
+      ...(chatboxToken ? { chatboxToken } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
     }),
   });
 
@@ -1237,6 +1245,8 @@ export async function handleMCPJamFreeChatModel(
     temperature,
     tools,
     authHeader,
+    chatboxToken,
+    workspaceId,
     mcpClientManager,
     selectedServers,
     requireToolApproval,
@@ -1300,6 +1310,8 @@ export async function handleMCPJamFreeChatModel(
             toolDefs,
             tools,
             authHeader,
+            chatboxToken,
+            workspaceId,
             modelId,
             systemPrompt,
             temperature,


### PR DESCRIPTION
## Summary

**USER_A** shares a chatbox link. **USER_B** opens it as a guest. The inspector already knows which workspace and link context apply in hosted mode—but the **streaming path** did not send that context along with hosted model requests.

**Before:** The stream layer looked like a generic guest request missing shared-link context.

**After:** The hosted route passes the **same workspace + link context** into the stream handler so MCPJam’s hosted service can treat it consistently with the rest of the flow. (How requests are validated and applied is entirely on the server.)

---

## What changed

| Area | Change |
|------|--------|
| Hosted chat route | Pass link/workspace context into the stream handler |
| Stream handler | Forward that context on hosted model requests |

---

## Flow

```mermaid
flowchart LR
  B[Guest browser]
  I[Inspector]
  S[MCPJam hosted]
  B --> I
  I --> S
  style B fill:#e3f2fd
  style I fill:#fff3e0
  style S fill:#e8f5e9
```

---

## Tests

Hosted-mode test asserts shared-chatbox requests pass the expected context into the stream handler.
