### PR TITLE
Improve Electron update CTA flow

### DIFF
--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   Puzzle,
   UserPlus,
   ShieldCheck,
+  Upload,
 } from "lucide-react";
 import { usePostHog, useFeatureFlagEnabled } from "posthog-js/react";
 import { standardEventProps } from "@/lib/PosthogUtils";
@@ -525,7 +526,11 @@ export function MCPSidebar({
   const { user } = useAuth();
   const learningEnabled = !!learningFlagEnabled && isAuthenticated;
   const themeMode = usePreferencesStore((s) => s.themeMode);
-  const { updateReady, restartAndInstall } = useUpdateNotification();
+  const {
+    showUpdateButton,
+    updateButtonLabel,
+    requestInstall,
+  } = useUpdateNotification();
   const [showInviteDialog, setShowInviteDialog] = useState(false);
   const learnMore = useLearnMore();
   const { state, isMobile } = useSidebar();
@@ -649,14 +654,18 @@ export function MCPSidebar({
               />
             )}
           </div>
-          {updateReady && (
-            <div className="px-2 pb-2">
+          {showUpdateButton && updateButtonLabel && (
+            <div className="px-2 pb-2 group-data-[collapsible=icon]:px-0 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
               <Button
                 size="sm"
-                onClick={restartAndInstall}
-                className="w-full bg-primary hover:bg-primary/90 text-primary-foreground h-7 text-xs font-medium rounded-md"
+                onClick={requestInstall}
+                title={state === "collapsed" ? updateButtonLabel : undefined}
+                className="h-7 w-full gap-1.5 overflow-hidden rounded-md bg-primary text-xs font-medium text-primary-foreground hover:bg-primary/90 group-data-[collapsible=icon]:size-8 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:rounded-md group-data-[collapsible=icon]:px-0"
               >
-                Update & Restart
+                <Upload className="size-3.5 shrink-0" />
+                <span className="truncate group-data-[collapsible=icon]:hidden">
+                  {updateButtonLabel}
+                </span>
               </Button>
             </div>
           )}

--- a/mcpjam-inspector/client/src/hooks/__tests__/useUpdateNotification.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useUpdateNotification.test.ts
@@ -1,31 +1,79 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { useUpdateNotification } from "../useUpdateNotification";
+import {
+  IDLE_UPDATE_STATE,
+  type UpdateState,
+} from "@/shared/update-state";
 
-const STORAGE_KEY = "mcpjam-pending-update";
+const { mockToastError } = vi.hoisted(() => ({
+  mockToastError: vi.fn(),
+}));
 
-// Helper to set up window.electronAPI mock
-function setupElectronMock() {
-  const mockOnUpdateReady = vi.fn();
-  const mockRemoveUpdateReadyListener = vi.fn();
-  const mockRestartAndInstall = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: mockToastError,
+  },
+}));
+
+function createDeferredState(state: UpdateState) {
+  let resolve!: (value: UpdateState) => void;
+
+  const promise = new Promise<UpdateState>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return {
+    promise,
+    resolve: () => resolve(state),
+  };
+}
+
+function setupElectronMock(initialState: UpdateState | Promise<UpdateState>) {
+  const stateChangeCallbacks = new Set<(state: UpdateState) => void>();
+
+  const mockGetState = vi.fn().mockImplementation(() => initialState);
+  const mockOnStateChanged = vi
+    .fn()
+    .mockImplementation((callback: (state: UpdateState) => void) => {
+      stateChangeCallbacks.add(callback);
+
+      return () => {
+        stateChangeCallbacks.delete(callback);
+      };
+    });
+  const mockRequestInstall = vi.fn();
   const mockSimulateUpdate = vi.fn();
 
   window.isElectron = true;
   window.electronAPI = {
     update: {
-      onUpdateReady: mockOnUpdateReady,
-      removeUpdateReadyListener: mockRemoveUpdateReadyListener,
-      restartAndInstall: mockRestartAndInstall,
+      getState: mockGetState,
+      onStateChanged: mockOnStateChanged,
+      requestInstall: mockRequestInstall,
       simulateUpdate: mockSimulateUpdate,
     },
   } as any;
 
   return {
-    mockOnUpdateReady,
-    mockRemoveUpdateReadyListener,
-    mockRestartAndInstall,
+    mockGetState,
+    mockOnStateChanged,
+    mockRequestInstall,
     mockSimulateUpdate,
+    getSubscriberCount() {
+      return stateChangeCallbacks.size;
+    },
+    emitState(state: UpdateState) {
+      if (stateChangeCallbacks.size === 0) {
+        throw new Error("state change callback not registered");
+      }
+
+      act(() => {
+        for (const callback of stateChangeCallbacks) {
+          callback(state);
+        }
+      });
+    },
   };
 }
 
@@ -36,113 +84,184 @@ function clearElectronMock() {
 
 describe("useUpdateNotification", () => {
   beforeEach(() => {
-    localStorage.clear();
     clearElectronMock();
+    mockToastError.mockClear();
   });
 
   describe("initial state", () => {
-    it("returns null when no update is stored", () => {
+    it("returns the idle CTA state when not running in Electron", () => {
       const { result } = renderHook(() => useUpdateNotification());
-      expect(result.current.updateReady).toBeNull();
-    });
 
-    it("restores update info from localStorage", () => {
-      const stored = { version: "2.0.0", releaseNotes: "New stuff" };
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
-
-      const { result } = renderHook(() => useUpdateNotification());
-      expect(result.current.updateReady).toEqual(stored);
-    });
-
-    it("returns null when localStorage has invalid JSON", () => {
-      localStorage.setItem(STORAGE_KEY, "not-json{{{");
-
-      const { result } = renderHook(() => useUpdateNotification());
-      expect(result.current.updateReady).toBeNull();
+      expect(result.current.updateState).toEqual(IDLE_UPDATE_STATE);
+      expect(result.current.showUpdateButton).toBe(false);
+      expect(result.current.updateButtonLabel).toBeNull();
     });
   });
 
-  describe("Electron update listener", () => {
-    it("registers onUpdateReady listener in Electron", () => {
-      const { mockOnUpdateReady } = setupElectronMock();
+  describe("Electron update state", () => {
+    it("loads the initial snapshot and subscribes for updates", async () => {
+      const initialState: UpdateState = {
+        phase: "available",
+        installRequested: false,
+      };
+      const { mockGetState, mockOnStateChanged } = setupElectronMock(
+        Promise.resolve(initialState),
+      );
 
       renderHook(() => useUpdateNotification());
-      expect(mockOnUpdateReady).toHaveBeenCalledWith(expect.any(Function));
-    });
 
-    it("does not register listener when not in Electron", () => {
-      // window.isElectron is undefined
-      const { result } = renderHook(() => useUpdateNotification());
-      expect(result.current.updateReady).toBeNull();
-    });
-
-    it("sets updateReady and persists to localStorage when update arrives", () => {
-      const { mockOnUpdateReady } = setupElectronMock();
-
-      const { result } = renderHook(() => useUpdateNotification());
-
-      // Grab the callback that was passed to onUpdateReady
-      const callback = mockOnUpdateReady.mock.calls[0][0];
-      const updateInfo = { version: "3.0.0", releaseNotes: "Big release" };
-
-      act(() => {
-        callback(updateInfo);
+      expect(mockOnStateChanged).toHaveBeenCalledWith(expect.any(Function));
+      await waitFor(() => {
+        expect(mockGetState).toHaveBeenCalledTimes(1);
       });
+    });
 
-      expect(result.current.updateReady).toEqual(updateInfo);
-      expect(localStorage.getItem(STORAGE_KEY)).toBe(
-        JSON.stringify(updateInfo),
+    it("does not overwrite pushed state with a stale snapshot", async () => {
+      const deferredState = createDeferredState({
+        phase: "available",
+        installRequested: false,
+      });
+      const { emitState } = setupElectronMock(deferredState.promise);
+
+      const { result } = renderHook(() => useUpdateNotification());
+
+      emitState({
+        phase: "ready",
+        installRequested: false,
+        version: "3.0.0",
+        releaseNotes: "Big release",
+      });
+      deferredState.resolve();
+
+      await waitFor(() => {
+        expect(result.current.updateState).toEqual({
+          phase: "ready",
+          installRequested: false,
+          version: "3.0.0",
+          releaseNotes: "Big release",
+        });
+      });
+    });
+
+    it("removes only its own listener on unmount", () => {
+      const electronMock = setupElectronMock(
+        Promise.resolve({ ...IDLE_UPDATE_STATE }),
       );
-    });
 
-    it("removes listener on unmount", () => {
-      const { mockRemoveUpdateReadyListener } = setupElectronMock();
+      const firstHook = renderHook(() => useUpdateNotification());
+      const secondHook = renderHook(() => useUpdateNotification());
 
-      const { unmount } = renderHook(() => useUpdateNotification());
-      unmount();
+      expect(electronMock.getSubscriberCount()).toBe(2);
 
-      expect(mockRemoveUpdateReadyListener).toHaveBeenCalled();
+      firstHook.unmount();
+
+      expect(electronMock.getSubscriberCount()).toBe(1);
+
+      electronMock.emitState({
+        phase: "available",
+        installRequested: false,
+      });
+
+      expect(secondHook.result.current.updateState).toEqual({
+        phase: "available",
+        installRequested: false,
+      });
+
+      secondHook.unmount();
+
+      expect(electronMock.getSubscriberCount()).toBe(0);
     });
   });
 
-  describe("restartAndInstall", () => {
-    it("clears localStorage and calls Electron API", () => {
-      const { mockRestartAndInstall } = setupElectronMock();
-
-      // Simulate a stored update
-      localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: "2.0.0" }));
-
+  describe("button state", () => {
+    it("keeps a stable Update label across all visible phases and still shows error toasts", async () => {
+      const { emitState } = setupElectronMock(
+        Promise.resolve({ ...IDLE_UPDATE_STATE }),
+      );
       const { result } = renderHook(() => useUpdateNotification());
 
-      act(() => {
-        result.current.restartAndInstall();
+      emitState({
+        phase: "available",
+        installRequested: false,
       });
+      expect(result.current.showUpdateButton).toBe(true);
+      expect(result.current.updateButtonLabel).toBe("Update");
 
-      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
-      expect(mockRestartAndInstall).toHaveBeenCalled();
-    });
-
-    it("does nothing when not in Electron", () => {
-      const { result } = renderHook(() => useUpdateNotification());
-
-      // Should not throw
-      act(() => {
-        result.current.restartAndInstall();
+      emitState({
+        phase: "downloading",
+        installRequested: true,
       });
+      expect(result.current.updateButtonLabel).toBe("Update");
+
+      emitState({
+        phase: "ready",
+        installRequested: false,
+        version: "3.0.0",
+      });
+      expect(result.current.updateButtonLabel).toBe("Update");
+
+      emitState({
+        phase: "error",
+        installRequested: false,
+        errorMessage: "download failed",
+      });
+      expect(result.current.updateButtonLabel).toBe("Update");
+      expect(mockToastError).toHaveBeenCalledTimes(1);
+      expect(mockToastError).toHaveBeenCalledWith("download failed");
+
+      emitState({
+        phase: "error",
+        installRequested: false,
+        errorMessage: "download failed again",
+      });
+      expect(mockToastError).toHaveBeenCalledTimes(1);
+
+      emitState({
+        phase: "available",
+        installRequested: false,
+      });
+      emitState({
+        phase: "error",
+        installRequested: false,
+        errorMessage: "still failed",
+      });
+      expect(mockToastError).toHaveBeenCalledTimes(2);
+      expect(mockToastError).toHaveBeenLastCalledWith("still failed");
     });
   });
 
-  describe("simulateUpdate", () => {
-    it("calls Electron simulate API", () => {
-      const { mockSimulateUpdate } = setupElectronMock();
+  describe("actions", () => {
+    it("requests install through the Electron API", async () => {
+      const { mockRequestInstall } = setupElectronMock(
+        Promise.resolve({
+          phase: "available",
+          installRequested: false,
+        }),
+      );
+      const { result } = renderHook(() => useUpdateNotification());
 
+      await waitFor(() => {
+        expect(result.current.updateButtonLabel).toBe("Update");
+      });
+
+      act(() => {
+        result.current.requestInstall();
+      });
+
+      expect(mockRequestInstall).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls the dev-only simulate API when available", () => {
+      const { mockSimulateUpdate } = setupElectronMock(
+        Promise.resolve({ ...IDLE_UPDATE_STATE }),
+      );
       const { result } = renderHook(() => useUpdateNotification());
 
       act(() => {
         result.current.simulateUpdate();
       });
 
-      expect(mockSimulateUpdate).toHaveBeenCalled();
+      expect(mockSimulateUpdate).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
+++ b/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
@@ -1,63 +1,77 @@
-import { useEffect, useState, useCallback } from "react";
-
-interface UpdateInfo {
-  version: string;
-  releaseNotes?: string;
-}
-
-const STORAGE_KEY = "mcpjam-pending-update";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import {
+  IDLE_UPDATE_STATE,
+  type UpdateState,
+} from "@/shared/update-state";
 
 export function useUpdateNotification() {
-  const [updateReady, setUpdateReady] = useState<UpdateInfo | null>(() => {
-    // Check localStorage on initial load
-    if (typeof window !== "undefined") {
-      const saved = localStorage.getItem(STORAGE_KEY);
-      if (saved) {
-        try {
-          return JSON.parse(saved);
-        } catch {
-          return null;
-        }
-      }
-    }
-    return null;
+  const [updateState, setUpdateState] = useState<UpdateState>({
+    ...IDLE_UPDATE_STATE,
   });
+  const previousPhaseRef = useRef<UpdateState["phase"]>(IDLE_UPDATE_STATE.phase);
 
   useEffect(() => {
-    // Only set up if running in Electron
     if (!window.isElectron || !window.electronAPI?.update) {
       return;
     }
 
-    const handleUpdateReady = (info: UpdateInfo) => {
-      console.log("Update ready:", info);
-      setUpdateReady(info);
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(info));
+    let isMounted = true;
+    let receivedStatePush = false;
+
+    const handleStateChanged = (nextState: UpdateState) => {
+      receivedStatePush = true;
+
+      if (isMounted) {
+        setUpdateState(nextState);
+      }
     };
 
-    window.electronAPI.update.onUpdateReady(handleUpdateReady);
+    const unsubscribe = window.electronAPI.update.onStateChanged(handleStateChanged);
+
+    void window.electronAPI.update
+      .getState()
+      .then((nextState) => {
+        if (!receivedStatePush && isMounted) {
+          setUpdateState(nextState);
+        }
+      })
+      .catch(() => undefined);
 
     return () => {
-      window.electronAPI?.update?.removeUpdateReadyListener();
+      isMounted = false;
+      unsubscribe();
     };
   }, []);
 
-  const restartAndInstall = useCallback(() => {
-    if (window.electronAPI?.update) {
-      localStorage.removeItem(STORAGE_KEY);
-      window.electronAPI.update.restartAndInstall();
+  useEffect(() => {
+    if (
+      updateState.phase === "error" &&
+      previousPhaseRef.current !== "error"
+    ) {
+      toast.error(updateState.errorMessage ?? "Update failed. Please try again.");
     }
+
+    previousPhaseRef.current = updateState.phase;
+  }, [updateState.errorMessage, updateState.phase]);
+
+  const requestInstall = useCallback(() => {
+    window.electronAPI?.update?.requestInstall();
   }, []);
 
   const simulateUpdate = useCallback(() => {
-    if (window.electronAPI?.update) {
-      window.electronAPI.update.simulateUpdate?.();
-    }
+    window.electronAPI?.update?.simulateUpdate?.();
   }, []);
 
   return {
-    updateReady,
-    restartAndInstall,
+    updateState,
+    showUpdateButton: updateState.phase !== "idle",
+    updateButtonLabel: getUpdateButtonLabel(updateState),
+    requestInstall,
     simulateUpdate,
   };
+}
+
+function getUpdateButtonLabel(updateState: UpdateState): string | null {
+  return updateState.phase === "idle" ? null : "Update";
 }

--- a/mcpjam-inspector/client/src/types/electron.d.ts
+++ b/mcpjam-inspector/client/src/types/electron.d.ts
@@ -1,7 +1,4 @@
-export interface UpdateInfo {
-  version: string;
-  releaseNotes?: string;
-}
+import type { UpdateState } from "@/shared/update-state";
 
 export interface ElectronAPI {
   // App metadata
@@ -40,9 +37,9 @@ export interface ElectronAPI {
 
   // Update operations
   update: {
-    onUpdateReady: (callback: (info: UpdateInfo) => void) => void;
-    removeUpdateReadyListener: () => void;
-    restartAndInstall: () => void;
+    getState: () => Promise<UpdateState>;
+    onStateChanged: (callback: (state: UpdateState) => void) => () => void;
+    requestInstall: () => void;
     simulateUpdate?: () => void;
   };
 }

--- a/mcpjam-inspector/server/routes/web/__tests__/servers-doctor.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/servers-doctor.test.ts
@@ -31,7 +31,7 @@ vi.mock("../../../utils/oauth-proxy.js", () => ({
   }),
 }));
 
-vi.mock("../../apps/SandboxProxyHtml.bundled.js", () => ({
+vi.mock("../../apps/SandboxProxyHtml.bundled", () => ({
   CHATGPT_APPS_SANDBOX_PROXY_HTML: "<html></html>",
   MCP_APPS_SANDBOX_PROXY_HTML: "<html></html>",
 }));

--- a/mcpjam-inspector/server/routes/web/apps.ts
+++ b/mcpjam-inspector/server/routes/web/apps.ts
@@ -9,7 +9,7 @@ import { CORS_ORIGINS } from "../../config.js";
 import {
   CHATGPT_APPS_SANDBOX_PROXY_HTML,
   MCP_APPS_SANDBOX_PROXY_HTML,
-} from "../apps/SandboxProxyHtml.bundled.js";
+} from "../apps/SandboxProxyHtml.bundled";
 import {
   injectOpenAICompat,
   injectScripts,

--- a/mcpjam-inspector/shared/update-state.ts
+++ b/mcpjam-inspector/shared/update-state.ts
@@ -1,0 +1,19 @@
+export type UpdatePhase =
+  | "idle"
+  | "available"
+  | "downloading"
+  | "ready"
+  | "error";
+
+export interface UpdateState {
+  phase: UpdatePhase;
+  installRequested: boolean;
+  version?: string;
+  releaseNotes?: string;
+  errorMessage?: string;
+}
+
+export const IDLE_UPDATE_STATE: UpdateState = {
+  phase: "idle",
+  installRequested: false,
+};

--- a/mcpjam-inspector/src/ipc/listeners-register.ts
+++ b/mcpjam-inspector/src/ipc/listeners-register.ts
@@ -2,11 +2,9 @@ import { BrowserWindow } from "electron";
 import { registerAppListeners } from "./app/app-listeners.js";
 import { registerWindowListeners } from "./window/window-listeners.js";
 import { registerFileListeners } from "./files/file-listeners.js";
-import { registerUpdateListeners } from "./update/update-listeners.js";
 
 export function registerListeners(mainWindow: BrowserWindow): void {
   registerAppListeners(mainWindow);
   registerWindowListeners(mainWindow);
   registerFileListeners(mainWindow);
-  registerUpdateListeners(mainWindow);
 }

--- a/mcpjam-inspector/src/ipc/update/__tests__/update-controller.test.ts
+++ b/mcpjam-inspector/src/ipc/update/__tests__/update-controller.test.ts
@@ -1,0 +1,110 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { UpdateController } from "../update-controller.js";
+
+class MockAutoUpdater extends EventEmitter {
+  checkForUpdates = vi.fn();
+  quitAndInstall = vi.fn();
+}
+
+function createController() {
+  const updater = new MockAutoUpdater();
+  const logger = {
+    info: vi.fn(),
+    error: vi.fn(),
+  };
+  const onStateChange = vi.fn();
+
+  const controller = new UpdateController({
+    updater,
+    logger,
+    onStateChange,
+  });
+
+  controller.start();
+
+  return {
+    controller,
+    updater,
+    logger,
+    onStateChange,
+  };
+}
+
+describe("UpdateController", () => {
+  it("stores available state for late subscribers", () => {
+    const { controller, updater } = createController();
+
+    updater.emit("update-available");
+
+    expect(controller.getState()).toEqual({
+      phase: "available",
+      installRequested: false,
+    });
+  });
+
+  it("marks install intent during download without restarting immediately", () => {
+    const { controller, updater } = createController();
+
+    updater.emit("update-available");
+    controller.requestInstall();
+
+    expect(controller.getState()).toEqual({
+      phase: "downloading",
+      installRequested: true,
+    });
+    expect(updater.quitAndInstall).not.toHaveBeenCalled();
+  });
+
+  it("restarts immediately when a requested update finishes downloading", () => {
+    const { controller, updater } = createController();
+
+    updater.emit("update-available");
+    controller.requestInstall();
+    updater.emit("update-downloaded", {}, "Big release", "2.0.0");
+
+    expect(controller.getState()).toEqual({
+      phase: "ready",
+      installRequested: true,
+      version: "2.0.0",
+      releaseNotes: "Big release",
+    });
+    expect(updater.quitAndInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the app running when download completes without prior install intent", () => {
+    const { controller, updater } = createController();
+
+    updater.emit("update-downloaded", {}, "Big release", "2.0.0");
+
+    expect(controller.getState()).toEqual({
+      phase: "ready",
+      installRequested: false,
+      version: "2.0.0",
+      releaseNotes: "Big release",
+    });
+    expect(updater.quitAndInstall).not.toHaveBeenCalled();
+  });
+
+  it("moves to retryable error state and retries checks on a later click", () => {
+    const { controller, updater } = createController();
+
+    updater.emit("update-available");
+    controller.requestInstall();
+    updater.emit("error", new Error("download failed"));
+
+    expect(controller.getState()).toEqual({
+      phase: "error",
+      installRequested: false,
+      errorMessage: "download failed",
+    });
+
+    controller.requestInstall();
+
+    expect(controller.getState()).toEqual({
+      phase: "downloading",
+      installRequested: true,
+    });
+    expect(updater.checkForUpdates).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/src/ipc/update/update-controller.ts
+++ b/mcpjam-inspector/src/ipc/update/update-controller.ts
@@ -1,0 +1,197 @@
+import { IDLE_UPDATE_STATE, type UpdateState } from "../../../shared/update-state.js";
+
+interface LoggerLike {
+  info(message: unknown, ...optionalParams: unknown[]): void;
+  error(message: unknown, ...optionalParams: unknown[]): void;
+}
+
+interface UpdaterLike {
+  on(event: "checking-for-update", listener: () => void): this;
+  on(event: "update-available", listener: () => void): this;
+  on(event: "update-not-available", listener: () => void): this;
+  on(
+    event: "update-downloaded",
+    listener: (
+      event: unknown,
+      releaseNotes?: string | null,
+      releaseName?: string | null,
+    ) => void,
+  ): this;
+  on(event: "error", listener: (error: Error) => void): this;
+  checkForUpdates(): void;
+  quitAndInstall(): void;
+}
+
+interface UpdateControllerOptions {
+  updater: UpdaterLike;
+  logger: LoggerLike;
+  onStateChange?: (state: UpdateState) => void;
+}
+
+export class UpdateController {
+  private readonly updater: UpdaterLike;
+  private readonly logger: LoggerLike;
+  private readonly onStateChange?: (state: UpdateState) => void;
+  private state: UpdateState = { ...IDLE_UPDATE_STATE };
+  private started = false;
+
+  constructor({ updater, logger, onStateChange }: UpdateControllerOptions) {
+    this.updater = updater;
+    this.logger = logger;
+    this.onStateChange = onStateChange;
+  }
+
+  start(): void {
+    if (this.started) {
+      return;
+    }
+
+    this.started = true;
+
+    this.updater.on("checking-for-update", () => {
+      this.logger.info("Checking for updates...");
+    });
+
+    this.updater.on("update-available", () => {
+      this.logger.info("Update available, downloading...");
+
+      this.setState({
+        ...this.state,
+        phase: this.state.installRequested ? "downloading" : "available",
+        errorMessage: undefined,
+      });
+    });
+
+    this.updater.on("update-downloaded", (_event, releaseNotes, releaseName) => {
+      this.logger.info(`Update downloaded: ${releaseName ?? "new version"}`);
+
+      const nextState: UpdateState = {
+        phase: "ready",
+        installRequested: this.state.installRequested,
+        version: releaseName ?? this.state.version,
+        releaseNotes: releaseNotes ?? this.state.releaseNotes,
+      };
+
+      this.setState(nextState);
+
+      if (nextState.installRequested) {
+        this.applyUpdate();
+      }
+    });
+
+    this.updater.on("update-not-available", () => {
+      this.logger.info("No updates available");
+
+      if (this.state.phase === "idle") {
+        this.setState({ ...IDLE_UPDATE_STATE });
+      }
+    });
+
+    this.updater.on("error", (error) => {
+      this.handleUpdateError(error);
+    });
+  }
+
+  getState(): UpdateState {
+    return { ...this.state };
+  }
+
+  requestInstall(): void {
+    switch (this.state.phase) {
+      case "ready":
+        this.applyUpdate();
+        return;
+      case "available":
+      case "downloading":
+        this.setState({
+          ...this.state,
+          phase: "downloading",
+          installRequested: true,
+          errorMessage: undefined,
+        });
+        return;
+      case "error":
+        this.retryInstall();
+        return;
+      default:
+        return;
+    }
+  }
+
+  simulateReady(): void {
+    this.setState({
+      phase: "ready",
+      installRequested: false,
+      version: "99.0.0",
+      releaseNotes: "Simulated update for testing",
+    });
+  }
+
+  private retryInstall(): void {
+    this.setState({
+      ...this.state,
+      phase: "downloading",
+      installRequested: true,
+      errorMessage: undefined,
+    });
+
+    try {
+      this.updater.checkForUpdates();
+    } catch (error) {
+      this.handleUpdateError(error);
+    }
+  }
+
+  private applyUpdate(): void {
+    this.logger.info("Restarting app to install update...");
+
+    try {
+      this.updater.quitAndInstall();
+    } catch (error) {
+      this.handleUpdateError(error);
+    }
+  }
+
+  private handleUpdateError(error: unknown): void {
+    const normalizedError = normalizeError(error);
+    this.logger.error("Auto-updater error:", normalizedError);
+
+    if (this.state.phase === "idle" && !this.state.installRequested) {
+      return;
+    }
+
+    this.setState({
+      ...this.state,
+      phase: "error",
+      installRequested: false,
+      errorMessage: normalizedError.message,
+    });
+  }
+
+  private setState(nextState: UpdateState): void {
+    if (statesAreEqual(this.state, nextState)) {
+      return;
+    }
+
+    this.state = nextState;
+    this.onStateChange?.(this.getState());
+  }
+}
+
+function normalizeError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error(String(error));
+}
+
+function statesAreEqual(a: UpdateState, b: UpdateState): boolean {
+  return (
+    a.phase === b.phase &&
+    a.installRequested === b.installRequested &&
+    a.version === b.version &&
+    a.releaseNotes === b.releaseNotes &&
+    a.errorMessage === b.errorMessage
+  );
+}

--- a/mcpjam-inspector/src/ipc/update/update-listeners.ts
+++ b/mcpjam-inspector/src/ipc/update/update-listeners.ts
@@ -1,68 +1,60 @@
-import { ipcMain, BrowserWindow, autoUpdater } from "electron";
+import { ipcMain, BrowserWindow } from "electron";
 import log from "electron-log";
+import {
+  IDLE_UPDATE_STATE,
+  type UpdateState,
+} from "../../../shared/update-state.js";
+import type { UpdateController } from "./update-controller.js";
 
 const isDev = process.env.NODE_ENV === "development";
+export const GET_UPDATE_STATE_CHANNEL = "app:update:get-state";
+export const REQUEST_UPDATE_INSTALL_CHANNEL = "app:request-update-install";
+export const UPDATE_STATE_CHANGED_CHANNEL = "update-state-changed";
 
-export function registerUpdateListeners(mainWindow: BrowserWindow): void {
-  // Handle restart request from renderer
-  ipcMain.on("app:restart-for-update", (event) => {
-    if (event.sender.id !== mainWindow.webContents.id) {
+export function registerUpdateListeners(
+  getMainWindow: () => BrowserWindow | null,
+  updateController: UpdateController,
+): void {
+  ipcMain.handle(GET_UPDATE_STATE_CHANNEL, (event): UpdateState => {
+    if (!isTrustedSender(event.sender.id, getMainWindow())) {
       log.warn(
-        `Ignoring restart-for-update from untrusted sender (id: ${event.sender.id})`,
+        `Ignoring get-state request from untrusted sender (id: ${event.sender.id})`,
+      );
+      return { ...IDLE_UPDATE_STATE };
+    }
+
+    return updateController.getState();
+  });
+
+  ipcMain.on(REQUEST_UPDATE_INSTALL_CHANNEL, (event) => {
+    if (!isTrustedSender(event.sender.id, getMainWindow())) {
+      log.warn(
+        `Ignoring request-update-install from untrusted sender (id: ${event.sender.id})`,
       );
       return;
     }
-    log.info("Restarting app to install update...");
-    autoUpdater.quitAndInstall();
+
+    updateController.requestInstall();
   });
 
-  // Dev only: simulate update for testing UI
   if (isDev) {
     ipcMain.on("app:simulate-update", (event) => {
-      if (event.sender.id !== mainWindow.webContents.id) {
+      if (!isTrustedSender(event.sender.id, getMainWindow())) {
         log.warn(
           `Ignoring simulate-update from untrusted sender (id: ${event.sender.id})`,
         );
         return;
       }
-      log.info("Simulating update available (dev mode)");
-      if (mainWindow && mainWindow.webContents) {
-        mainWindow.webContents.send("update-ready", {
-          version: "99.0.0",
-          releaseNotes: "Simulated update for testing",
-        });
-      }
+
+      log.info("Simulating update ready (dev mode)");
+      updateController.simulateReady();
     });
   }
 }
 
-export function setupAutoUpdaterEvents(mainWindow: BrowserWindow): void {
-  // Listen for update-downloaded event from autoUpdater
-  autoUpdater.on("update-downloaded", (event, releaseNotes, releaseName) => {
-    log.info(`Update downloaded: ${releaseName}`);
-
-    // Notify renderer that update is ready
-    if (mainWindow && mainWindow.webContents) {
-      mainWindow.webContents.send("update-ready", {
-        version: releaseName || "new version",
-        releaseNotes: releaseNotes || "",
-      });
-    }
-  });
-
-  autoUpdater.on("checking-for-update", () => {
-    log.info("Checking for updates...");
-  });
-
-  autoUpdater.on("update-available", () => {
-    log.info("Update available, downloading...");
-  });
-
-  autoUpdater.on("update-not-available", () => {
-    log.info("No updates available");
-  });
-
-  autoUpdater.on("error", (error) => {
-    log.error("Auto-updater error:", error);
-  });
+function isTrustedSender(
+  senderId: number,
+  mainWindow: BrowserWindow | null,
+): boolean {
+  return senderId === mainWindow?.webContents.id;
 }

--- a/mcpjam-inspector/src/main.ts
+++ b/mcpjam-inspector/src/main.ts
@@ -7,18 +7,37 @@ Sentry.init({
   ipcMode: Sentry.IPCMode.Both, // Enables communication with renderer process
 });
 
-import { app, BrowserWindow, shell, Menu } from "electron";
+import { app, autoUpdater, BrowserWindow, shell, Menu } from "electron";
 import { serve } from "@hono/node-server";
 import path from "path";
 import { createHonoApp } from "../server/app.js";
 import log from "electron-log";
 import { updateElectronApp } from "update-electron-app";
+import type { UpdateState } from "../shared/update-state.js";
 import { registerListeners } from "./ipc/listeners-register.js";
-import { setupAutoUpdaterEvents } from "./ipc/update/update-listeners.js";
+import { UpdateController } from "./ipc/update/update-controller.js";
+import {
+  registerUpdateListeners,
+  UPDATE_STATE_CHANGED_CHANNEL,
+} from "./ipc/update/update-listeners.js";
 
 // Configure logging
 log.transports.file.level = "info";
 log.transports.console.level = "debug";
+
+let mainWindow: BrowserWindow | null = null;
+let server: any = null;
+let serverPort: number = 0;
+const isDev = !app.isPackaged;
+
+const updateController = new UpdateController({
+  updater: autoUpdater,
+  logger: log,
+  onStateChange: (state) => {
+    sendUpdateStateToRenderer(state);
+  },
+});
+updateController.start();
 
 // Enable auto-updater (with custom notification handling)
 updateElectronApp({
@@ -35,12 +54,6 @@ if (process.platform === "win32") {
 if (!app.isDefaultProtocolClient("mcpjam")) {
   app.setAsDefaultProtocolClient("mcpjam");
 }
-
-let mainWindow: BrowserWindow | null = null;
-let server: any = null;
-let serverPort: number = 0;
-
-const isDev = process.env.NODE_ENV === "development";
 
 async function startHonoServer(): Promise<number> {
   try {
@@ -95,6 +108,15 @@ function createMainWindow(serverUrl: string): BrowserWindow {
   if (isDev) {
     window.webContents.openDevTools();
   }
+
+  window.webContents.on("did-finish-load", () => {
+    if (!window.isDestroyed()) {
+      window.webContents.send(
+        UPDATE_STATE_CHANGED_CHANNEL,
+        updateController.getState(),
+      );
+    }
+  });
 
   // Show window when ready
   window.once("ready-to-show", () => {
@@ -210,9 +232,7 @@ app.whenReady().then(async () => {
 
     // Register IPC listeners
     registerListeners(mainWindow);
-
-    // Setup auto-updater events to notify renderer when update is ready
-    setupAutoUpdaterEvents(mainWindow);
+    registerUpdateListeners(() => mainWindow, updateController);
 
     log.info("MCPJam Electron app ready");
   } catch (error) {
@@ -252,6 +272,14 @@ app.on("activate", async () => {
     }
   }
 });
+
+function sendUpdateStateToRenderer(state: UpdateState): void {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return;
+  }
+
+  mainWindow.webContents.send(UPDATE_STATE_CHANGED_CHANNEL, state);
+}
 
 // Handle OAuth callback URLs
 app.on("open-url", (event, url) => {

--- a/mcpjam-inspector/src/preload.ts
+++ b/mcpjam-inspector/src/preload.ts
@@ -1,10 +1,9 @@
 import { contextBridge, ipcRenderer } from "electron";
+import type { UpdateState } from "../shared/update-state.js";
 
-// Update info type
-interface UpdateInfo {
-  version: string;
-  releaseNotes?: string;
-}
+const GET_UPDATE_STATE_CHANNEL = "app:update:get-state";
+const REQUEST_UPDATE_INSTALL_CHANNEL = "app:request-update-install";
+const UPDATE_STATE_CHANGED_CHANNEL = "update-state-changed";
 
 // Define the API interface
 interface ElectronAPI {
@@ -44,9 +43,9 @@ interface ElectronAPI {
 
   // Update operations
   update: {
-    onUpdateReady: (callback: (info: UpdateInfo) => void) => void;
-    removeUpdateReadyListener: () => void;
-    restartAndInstall: () => void;
+    getState: () => Promise<UpdateState>;
+    onStateChanged: (callback: (state: UpdateState) => void) => () => void;
+    requestInstall: () => void;
     simulateUpdate?: () => void; // Dev only - for testing
   };
 }
@@ -87,14 +86,20 @@ const electronAPI: ElectronAPI = {
   },
 
   update: {
-    onUpdateReady: (callback: (info: UpdateInfo) => void) => {
-      ipcRenderer.on("update-ready", (_, info: UpdateInfo) => callback(info));
+    getState: () => ipcRenderer.invoke(GET_UPDATE_STATE_CHANNEL),
+    onStateChanged: (callback: (state: UpdateState) => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, state: UpdateState) => {
+        callback(state);
+      };
+
+      ipcRenderer.on(UPDATE_STATE_CHANGED_CHANNEL, listener);
+
+      return () => {
+        ipcRenderer.removeListener(UPDATE_STATE_CHANGED_CHANNEL, listener);
+      };
     },
-    removeUpdateReadyListener: () => {
-      ipcRenderer.removeAllListeners("update-ready");
-    },
-    restartAndInstall: () => {
-      ipcRenderer.send("app:restart-for-update");
+    requestInstall: () => {
+      ipcRenderer.send(REQUEST_UPDATE_INSTALL_CHANNEL);
     },
     ...(process.env.NODE_ENV === "development"
       ? {

--- a/mcpjam-inspector/test/setup.ts
+++ b/mcpjam-inspector/test/setup.ts
@@ -1,0 +1,5 @@
+import { afterEach, vi } from "vitest";
+
+afterEach(() => {
+  vi.clearAllMocks();
+});

--- a/mcpjam-inspector/vite.renderer.config.mts
+++ b/mcpjam-inspector/vite.renderer.config.mts
@@ -31,7 +31,7 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       fs: {
-        allow: [resolve(__dirname, "./client/src/assets")],
+        allow: [resolve(__dirname, "./client")],
       },
       proxy: {
         "/api": {

--- a/mcpjam-inspector/vitest.desktop.config.ts
+++ b/mcpjam-inspector/vitest.desktop.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["src/**/__tests__/**/*.test.ts", "src/**/*.test.ts"],
+    exclude: ["node_modules", "dist", "client", "server", "shared"],
+    setupFiles: ["./test/setup.ts"],
+    testTimeout: 30000,
+    hookTimeout: 30000,
+  },
+});

--- a/mcpjam-inspector/vitest.workspace.ts
+++ b/mcpjam-inspector/vitest.workspace.ts
@@ -2,6 +2,13 @@ import { defineWorkspace } from "vitest/config";
 
 export default defineWorkspace([
   {
+    extends: "./vitest.desktop.config.ts",
+    test: {
+      name: "desktop",
+      root: ".",
+    },
+  },
+  {
     extends: "./server/vitest.config.ts",
     test: {
       name: "server",


### PR DESCRIPTION
This PR makes the Electron app show the update button earlier.

Before this change, the button only appeared after the update had already been downloaded.
Now, the app can show the button as soon as it knows a newer version exists.

It also keeps the existing restart flow:
- if the update is already downloaded, clicking the button restarts into the new version
- if the update is still in progress, the app remembers the user's intent and installs once the download finishes

## Why this changed

The old behavior was too late.
Users could be on an old version and see nothing, even though an update was already available.

## Extra fixes included
- expanded the Vite fs allow-list so `electron:dev` boots correctly

## Checks run

- desktop updater tests
- client hook tests
- server test for the sandbox proxy route
- full `npm run build`
