### PR TITLE
server with oauth failing in dashboard

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -685,6 +685,23 @@ export default function App() {
     workOsUserEmail: workOsUser?.email ?? null,
     isLoadingRemoteWorkspaces: false,
   });
+  const baseHostedShellGateState = isHostedChatRoute
+    ? hostedChatShellGateState
+    : hostedShellGateState;
+  const pendingDashboardOAuthServer = pendingDashboardOAuth
+    ? workspaceServers[pendingDashboardOAuth.serverName]
+    : null;
+  const shouldShowPendingDashboardOAuthGate =
+    !!pendingDashboardOAuth &&
+    !pendingDashboardOAuthServer &&
+    baseHostedShellGateState !== "logged-out" &&
+    baseHostedShellGateState !== "restricted";
+  const effectiveHostedShellGateState = shouldShowPendingDashboardOAuthGate
+    ? "workspace-loading"
+    : baseHostedShellGateState;
+  const pendingDashboardOAuthMessage = pendingDashboardOAuth
+    ? `Finishing OAuth sign-in for ${pendingDashboardOAuth.serverName}...`
+    : undefined;
   const isOnboardingDecisionReady = hostedShellGateState === "ready";
   const isHostedDefaultRoute = currentHashRoute.normalizedTab === "servers";
   const shouldHoldHostedDefaultRouteForAuth =
@@ -2037,10 +2054,11 @@ export default function App() {
           inert={shouldShowBillingHandoffOverlay || undefined}
         >
           <HostedShellGate
-            state={
-              isHostedChatRoute
-                ? hostedChatShellGateState
-                : hostedShellGateState
+            state={effectiveHostedShellGateState}
+            loadingMessage={
+              shouldShowPendingDashboardOAuthGate
+                ? pendingDashboardOAuthMessage
+                : undefined
             }
             onSignIn={() => {
               if (sharedPathToken) {

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -650,6 +650,7 @@ export default function App() {
     setActiveOrganizationId,
     clearConvexActiveWorkspaceSelection,
     clearLocalFallbackWorkspaceSelection,
+    pendingDashboardOAuth,
     isCloudSyncActive,
   } = useAppState({
     currentUserId: workOsUser?.id ?? null,
@@ -1671,6 +1672,7 @@ export default function App() {
               workspaces={workspaces}
               activeWorkspaceId={activeWorkspaceId}
               organizationId={activeWorkspaceBillingOrganizationId}
+              pendingDashboardOAuth={pendingDashboardOAuth}
               isBillingContextPending={isBillingContextPending}
               isLoadingWorkspaces={isLoadingRemoteWorkspaces}
               onWorkspaceShared={handleWorkspaceShared}

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -393,33 +393,6 @@ function SortableServerCard({
   );
 }
 
-function PendingDashboardOAuthCard({
-  pendingOAuth,
-}: {
-  pendingOAuth: PendingDashboardOAuthState;
-}) {
-  return (
-    <Card className="border-blue-500/30 bg-blue-500/5 p-5">
-      <div className="flex items-start gap-3">
-        <Loader2 className="mt-0.5 h-5 w-5 animate-spin text-blue-500" />
-        <div className="min-w-0">
-          <p className="text-sm font-semibold">
-            {`Connecting ${pendingOAuth.serverName}...`}
-          </p>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Finishing OAuth sign-in. This can take a few seconds.
-          </p>
-          {pendingOAuth.serverUrl ? (
-            <p className="mt-2 truncate font-mono text-xs text-muted-foreground/80">
-              {pendingOAuth.serverUrl}
-            </p>
-          ) : null}
-        </div>
-      </div>
-    </Card>
-  );
-}
-
 interface ServersTabProps {
   workspaceServers: Record<string, ServerWithName>;
   pendingDashboardOAuth?: PendingDashboardOAuthState | null;
@@ -684,10 +657,7 @@ export function ServersTab({
     !!pendingDashboardOAuth &&
     pendingDashboardOAuthServer?.connectionStatus !== "connected" &&
     pendingDashboardOAuthServer?.connectionStatus !== "failed";
-  const shouldRenderPendingDashboardOAuthCard =
-    isPendingDashboardOAuthVisible && !pendingDashboardOAuthServer;
-  const hasAnyServers =
-    connectedCount > 0 || shouldRenderPendingDashboardOAuthCard;
+  const hasAnyServers = connectedCount > 0;
   const pendingQuickConnectServer =
     pendingQuickConnect?.sourceTab === "servers"
       ? workspaceServers[pendingQuickConnect.serverName]
@@ -1160,12 +1130,6 @@ export function ServersTab({
               strategy={rectSortingStrategy}
             >
               <div className="grid grid-cols-1 lg:grid-cols-1 xl:grid-cols-2 gap-6">
-                {shouldRenderPendingDashboardOAuthCard &&
-                pendingDashboardOAuth ? (
-                  <PendingDashboardOAuthCard
-                    pendingOAuth={pendingDashboardOAuth}
-                  />
-                ) : null}
                 {orderedServerNames.map((name) => {
                   const server = workspaceServers[name];
                   if (!server) return null;

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -15,7 +15,11 @@ import {
   MessageSquareText,
   Settings,
 } from "lucide-react";
-import { ServerWithName, type ServerUpdateResult } from "@/hooks/use-app-state";
+import type {
+  PendingDashboardOAuthState,
+  ServerUpdateResult,
+  ServerWithName,
+} from "@/hooks/use-app-state";
 import { ServerConnectionCard } from "./connection/ServerConnectionCard";
 import { AddServerModal } from "./connection/AddServerModal";
 import { ClientConfigTab } from "./client-config/ClientConfigTab";
@@ -389,8 +393,36 @@ function SortableServerCard({
   );
 }
 
+function PendingDashboardOAuthCard({
+  pendingOAuth,
+}: {
+  pendingOAuth: PendingDashboardOAuthState;
+}) {
+  return (
+    <Card className="border-blue-500/30 bg-blue-500/5 p-5">
+      <div className="flex items-start gap-3">
+        <Loader2 className="mt-0.5 h-5 w-5 animate-spin text-blue-500" />
+        <div className="min-w-0">
+          <p className="text-sm font-semibold">
+            {`Connecting ${pendingOAuth.serverName}...`}
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Finishing OAuth sign-in. This can take a few seconds.
+          </p>
+          {pendingOAuth.serverUrl ? (
+            <p className="mt-2 truncate font-mono text-xs text-muted-foreground/80">
+              {pendingOAuth.serverUrl}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
 interface ServersTabProps {
   workspaceServers: Record<string, ServerWithName>;
+  pendingDashboardOAuth?: PendingDashboardOAuthState | null;
   onConnect: (formData: ServerFormData) => void;
   onDisconnect: (serverName: string) => void;
   onReconnect: (
@@ -423,6 +455,7 @@ interface ServersTabProps {
 
 export function ServersTab({
   workspaceServers,
+  pendingDashboardOAuth,
   onConnect,
   onDisconnect,
   onReconnect,
@@ -644,7 +677,17 @@ export function ServersTab({
   }, [pendingQuickConnect, workspaceServers]);
 
   const connectedCount = Object.keys(workspaceServers).length;
-  const hasAnyServers = connectedCount > 0;
+  const pendingDashboardOAuthServer = pendingDashboardOAuth
+    ? workspaceServers[pendingDashboardOAuth.serverName]
+    : null;
+  const isPendingDashboardOAuthVisible =
+    !!pendingDashboardOAuth &&
+    pendingDashboardOAuthServer?.connectionStatus !== "connected" &&
+    pendingDashboardOAuthServer?.connectionStatus !== "failed";
+  const shouldRenderPendingDashboardOAuthCard =
+    isPendingDashboardOAuthVisible && !pendingDashboardOAuthServer;
+  const hasAnyServers =
+    connectedCount > 0 || shouldRenderPendingDashboardOAuthCard;
   const pendingQuickConnectServer =
     pendingQuickConnect?.sourceTab === "servers"
       ? workspaceServers[pendingQuickConnect.serverName]
@@ -693,6 +736,26 @@ export function ServersTab({
       setQuickConnectMiniCardsExpanded(true);
     }
   }, [totalServerCards]);
+
+  const getDisplayServer = useCallback(
+    (server: ServerWithName): ServerWithName => {
+      if (
+        !isPendingDashboardOAuthVisible ||
+        pendingDashboardOAuth?.serverName !== server.name ||
+        server.connectionStatus === "connected" ||
+        server.connectionStatus === "failed"
+      ) {
+        return server;
+      }
+
+      return {
+        ...server,
+        connectionStatus: "connecting",
+        enabled: true,
+      };
+    },
+    [isPendingDashboardOAuthVisible, pendingDashboardOAuth?.serverName],
+  );
 
   const shouldShowQuickConnect =
     isRegistryEnabled &&
@@ -1097,15 +1160,22 @@ export function ServersTab({
               strategy={rectSortingStrategy}
             >
               <div className="grid grid-cols-1 lg:grid-cols-1 xl:grid-cols-2 gap-6">
+                {shouldRenderPendingDashboardOAuthCard &&
+                pendingDashboardOAuth ? (
+                  <PendingDashboardOAuthCard
+                    pendingOAuth={pendingDashboardOAuth}
+                  />
+                ) : null}
                 {orderedServerNames.map((name) => {
                   const server = workspaceServers[name];
                   if (!server) return null;
+                  const displayServer = getDisplayServer(server);
                   return (
                     <SortableServerCard
                       key={name}
                       id={name}
                       dndDisabled={false}
-                      server={server}
+                      server={displayServer}
                       needsReconnect={reconnectWarningByServerName[name]}
                       onDisconnect={(serverName) => {
                         clearPendingQuickConnectIfMatches(serverName);
@@ -1128,7 +1198,7 @@ export function ServersTab({
               {activeServer ? (
                 <div style={{ opacity: 0.85 }}>
                   <ServerConnectionCard
-                    server={activeServer}
+                    server={getDisplayServer(activeServer)}
                     needsReconnect={
                       reconnectWarningByServerName[activeServer.name]
                     }

--- a/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
@@ -520,6 +520,52 @@ describe("ServersTab shared detail modal", () => {
     expect(screen.queryByText("Add Your First Server")).not.toBeInTheDocument();
   });
 
+  it("shows a dashboard OAuth spinner card when the pending server is not loaded yet", () => {
+    render(
+      <ServersTab
+        {...defaultProps}
+        workspaceServers={{}}
+        workspaces={{ "workspace-1": createWorkspace({}) }}
+        pendingDashboardOAuth={{
+          serverName: "demo-server",
+          serverUrl: "https://example.com/mcp",
+          startedAt: Date.now(),
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Connecting demo-server...")).toBeInTheDocument();
+    expect(screen.getByText("https://example.com/mcp")).toBeInTheDocument();
+    expect(screen.queryByText("Add Your First Server")).not.toBeInTheDocument();
+  });
+
+  it("shows an existing pending dashboard OAuth server as connecting", () => {
+    const pendingServer = createServer({
+      name: "demo-server",
+      connectionStatus: "disconnected",
+      enabled: false,
+    });
+
+    render(
+      <ServersTab
+        {...defaultProps}
+        workspaceServers={{ "demo-server": pendingServer }}
+        workspaces={{
+          "workspace-1": createWorkspace({ "demo-server": pendingServer }),
+        }}
+        pendingDashboardOAuth={{
+          serverName: "demo-server",
+          serverUrl: "https://example.com/mcp",
+          startedAt: Date.now(),
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("server-card-demo-server")).toHaveTextContent(
+      "demo-server:connecting",
+    );
+  });
+
   it("keeps the shared modal open after saving without a rename", async () => {
     render(<ServersTab {...defaultProps} />);
 

--- a/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
@@ -520,25 +520,6 @@ describe("ServersTab shared detail modal", () => {
     expect(screen.queryByText("Add Your First Server")).not.toBeInTheDocument();
   });
 
-  it("shows a dashboard OAuth spinner card when the pending server is not loaded yet", () => {
-    render(
-      <ServersTab
-        {...defaultProps}
-        workspaceServers={{}}
-        workspaces={{ "workspace-1": createWorkspace({}) }}
-        pendingDashboardOAuth={{
-          serverName: "demo-server",
-          serverUrl: "https://example.com/mcp",
-          startedAt: Date.now(),
-        }}
-      />,
-    );
-
-    expect(screen.getByText("Connecting demo-server...")).toBeInTheDocument();
-    expect(screen.getByText("https://example.com/mcp")).toBeInTheDocument();
-    expect(screen.queryByText("Add Your First Server")).not.toBeInTheDocument();
-  });
-
   it("shows an existing pending dashboard OAuth server as connecting", () => {
     const pendingServer = createServer({
       name: "demo-server",

--- a/mcpjam-inspector/client/src/components/hosted/HostedShellGate.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/HostedShellGate.tsx
@@ -11,6 +11,7 @@ export type HostedShellGateState =
 
 interface HostedShellGateProps {
   state: HostedShellGateState;
+  loadingMessage?: string;
   onSignIn?: () => void;
   onSignOut?: () => void;
   children: ReactNode;
@@ -31,11 +32,16 @@ function getGateCopy(state: HostedShellGateState): string {
 
 export function HostedShellGate({
   state,
+  loadingMessage,
   onSignIn,
   onSignOut,
   children,
 }: HostedShellGateProps) {
   const isBlocked = state !== "ready" && state !== "auth-loading";
+  const copy =
+    loadingMessage && state === "workspace-loading"
+      ? loadingMessage
+      : getGateCopy(state);
 
   return (
     <div className="relative h-full min-h-0">
@@ -66,7 +72,7 @@ export function HostedShellGate({
             ) : (
               <Loader2 className="mb-4 h-5 w-5 animate-spin text-muted-foreground" />
             )}
-            <p className="text-sm text-foreground">{getGateCopy(state)}</p>
+            <p className="text-sm text-foreground">{copy}</p>
             {state === "logged-out" && (
               <Button
                 type="button"

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/HostedShellGate.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/HostedShellGate.test.tsx
@@ -41,6 +41,21 @@ describe("HostedShellGate", () => {
     expect(screen.getByText("Preparing workspace...")).toBeInTheDocument();
   });
 
+  it("shows custom workspace loading copy", () => {
+    render(
+      <HostedShellGate
+        state="workspace-loading"
+        loadingMessage="Finishing OAuth sign-in for demo-server..."
+      >
+        <div>App Content</div>
+      </HostedShellGate>,
+    );
+
+    expect(
+      screen.getByText("Finishing OAuth sign-in for demo-server..."),
+    ).toBeInTheDocument();
+  });
+
   it("shows sign in call-to-action when logged out", () => {
     const onSignIn = vi.fn();
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.test.tsx
@@ -140,8 +140,10 @@ function createLoadedAppState(selectedServerState?: {
 
 describe("useAppState active organization recovery", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
     localStorage.clear();
+    window.history.replaceState({}, "", "/");
     loadAppStateMock.mockReturnValue(initialAppState);
     Object.assign(workspaceStateValue, {
       effectiveWorkspaces: {},
@@ -417,4 +419,94 @@ describe("useAppState active organization recovery", () => {
       });
     },
   );
+
+  it("tracks missing dashboard OAuth callbacks without seeding a temporary server", async () => {
+    loadAppStateMock.mockReturnValue({
+      ...initialAppState,
+      workspaces: {
+        default: {
+          ...initialAppState.workspaces.default,
+          servers: {},
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      },
+      servers: {},
+    });
+    localStorage.setItem("mcp-oauth-pending", "demo-server");
+    localStorage.setItem("mcp-serverUrl-demo-server", "https://example.com/mcp");
+    window.history.replaceState({}, "", "/oauth/callback?code=test-code");
+
+    const { result } = renderHook(() =>
+      useAppState({
+        currentUserId: "user-1",
+        routeOrganizationId: undefined,
+        hasOrganizations: false,
+        isLoadingOrganizations: false,
+        validOrganizations: [],
+      }),
+    );
+
+    await waitFor(() => {
+      expect(result.current.pendingDashboardOAuth).toEqual(
+        expect.objectContaining({
+          serverName: "demo-server",
+          serverUrl: "https://example.com/mcp",
+        }),
+      );
+    });
+
+    const lastWorkspaceArgs = useWorkspaceStateMock.mock.calls.at(-1)?.[0];
+    expect(lastWorkspaceArgs?.appState.servers).toEqual({});
+  });
+
+  it("clears missing dashboard OAuth UI state after the safety timeout", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    try {
+      loadAppStateMock.mockReturnValue({
+        ...initialAppState,
+        workspaces: {
+          default: {
+            ...initialAppState.workspaces.default,
+            servers: {},
+            createdAt: new Date("2026-01-01T00:00:00.000Z"),
+            updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+          },
+        },
+        servers: {},
+      });
+      localStorage.setItem("mcp-oauth-pending", "demo-server");
+      localStorage.setItem(
+        "mcp-serverUrl-demo-server",
+        "https://example.com/mcp",
+      );
+      window.history.replaceState({}, "", "/oauth/callback?code=test-code");
+
+      const { result } = renderHook(() =>
+        useAppState({
+          currentUserId: "user-1",
+          routeOrganizationId: undefined,
+          hasOrganizations: false,
+          isLoadingOrganizations: false,
+          validOrganizations: [],
+        }),
+      );
+
+      expect(result.current.pendingDashboardOAuth).toEqual(
+        expect.objectContaining({
+          serverName: "demo-server",
+          serverUrl: "https://example.com/mcp",
+        }),
+      );
+
+      act(() => {
+        vi.advanceTimersByTime(30_000);
+      });
+
+      expect(result.current.pendingDashboardOAuth).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.test.tsx
@@ -374,4 +374,47 @@ describe("useAppState active organization recovery", () => {
       expect(result.current.isSelectedServerSyncing).toBe(false);
     });
   });
+
+  it.each(["chatbox", "shared"] as const)(
+    "does not patch dashboard server state for hosted %s OAuth callbacks",
+    async (surface) => {
+      loadAppStateMock.mockReturnValue(
+        createLoadedAppState({
+          name: "demo-server",
+          connectionStatus: "disconnected",
+        }),
+      );
+      localStorage.setItem(
+        "mcp-hosted-oauth-pending",
+        JSON.stringify({
+          surface,
+          serverName: "demo-server",
+          serverUrl: "https://example.com/mcp",
+          returnHash: "#demo",
+          startedAt: Date.now(),
+        }),
+      );
+      localStorage.setItem("mcp-oauth-pending", "demo-server");
+      window.history.replaceState({}, "", "/oauth/callback?code=test-code");
+
+      renderHook(() =>
+        useAppState({
+          currentUserId: "user-1",
+          routeOrganizationId: undefined,
+          hasOrganizations: false,
+          isLoadingOrganizations: false,
+          validOrganizations: [],
+        }),
+      );
+
+      await waitFor(() => {
+        const lastWorkspaceArgs =
+          useWorkspaceStateMock.mock.calls.at(-1)?.[0];
+        expect(
+          lastWorkspaceArgs?.appState.servers["demo-server"]
+            ?.connectionStatus,
+        ).toBe("disconnected");
+      });
+    },
+  );
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -709,3 +709,65 @@ describe("useServerState authenticated fallback persistence", () => {
     expect(toastSuccess).toHaveBeenCalledWith("Server configuration updated");
   });
 });
+
+describe("useServerState OAuth callback in-flight dispatch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("dispatches CONNECT_REQUEST for the pending server before token exchange completes", async () => {
+    const { listServers } = await import("@/state/mcp-api");
+    vi.mocked(listServers).mockResolvedValue({ success: true, servers: [] } as any);
+
+    localStorage.setItem("mcp-oauth-pending", "demo-server");
+    localStorage.setItem("mcp-oauth-return-hash", "#demo-server");
+    localStorage.setItem("mcp-serverUrl-demo-server", "https://example.com/mcp");
+
+    // Slow token exchange — controllable promise so we can assert before it resolves
+    let resolveTokenExchange!: (value: unknown) => void;
+    handleOAuthCallbackMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveTokenExchange = resolve;
+      }),
+    );
+
+    window.history.replaceState({}, "", "/oauth/callback?code=test-code");
+
+    const dispatch = vi.fn();
+    renderUseServerState(dispatch);
+
+    // The early CONNECT_REQUEST must fire before the token exchange resolves
+    await waitFor(() => {
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "CONNECT_REQUEST",
+          name: "demo-server",
+        }),
+      );
+    });
+
+    // Token exchange hasn't finished yet — no CONNECT_SUCCESS dispatched
+    expect(
+      dispatch.mock.calls.some(([a]) => a.type === "CONNECT_SUCCESS"),
+    ).toBe(false);
+
+    // Now let the token exchange complete and verify the full happy path
+    resolveTokenExchange({
+      success: true,
+      serverName: "demo-server",
+      serverConfig: { type: "http", url: "https://example.com/mcp" },
+    });
+
+    await waitFor(() => {
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "CONNECT_SUCCESS",
+          name: "demo-server",
+          useOAuth: true,
+        }),
+      );
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -2,7 +2,11 @@ import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useConvexAuth } from "convex/react";
 import { useLogger } from "./use-logger";
-import { initialAppState, type ServerWithName } from "@/state/app-types";
+import {
+  initialAppState,
+  type AppState,
+  type ServerWithName,
+} from "@/state/app-types";
 import { appReducer } from "@/state/app-reducer";
 import { loadAppState, saveAppState } from "@/state/storage";
 import { useWorkspaceState } from "./use-workspace-state";
@@ -12,6 +16,7 @@ import {
   readStoredActiveOrganizationId,
   writeStoredActiveOrganizationId,
 } from "@/lib/active-organization-storage";
+import { HOSTED_OAUTH_PENDING_STORAGE_KEY } from "@/lib/hosted-oauth-callback";
 
 export type { ServerWithName } from "@/state/app-types";
 export type { ServerUpdateResult } from "./use-server-state";
@@ -37,6 +42,77 @@ function createDefaultWorkspace() {
     createdAt: new Date(),
     updatedAt: new Date(),
   };
+}
+
+// Resolves the server name for a pending OAuth callback by checking the
+// hosted OAuth marker first (preferred), then the legacy localStorage key.
+function resolvePendingOAuthServerName(): string | null {
+  if (typeof window === "undefined") return null;
+  if (!new URLSearchParams(window.location.search).has("code")) return null;
+
+  try {
+    const raw = localStorage.getItem(HOSTED_OAUTH_PENDING_STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as {
+        serverName?: unknown;
+        surface?: unknown;
+      } | null;
+      if (parsed?.surface === "chatbox" || parsed?.surface === "shared") {
+        return null;
+      }
+      if (
+        parsed?.surface === "workspace" &&
+        typeof parsed.serverName === "string" &&
+        parsed.serverName
+      ) {
+        return parsed.serverName;
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return localStorage.getItem("mcp-oauth-pending");
+}
+
+// Patches the loaded state so a pending OAuth server starts as "connecting"
+// rather than "disconnected", preventing a flash on the first rendered frame.
+function patchStateForPendingOAuth(
+  state: AppState,
+  serverName: string,
+): AppState {
+  const existing = state.servers[serverName];
+  if (existing) {
+    return {
+      ...state,
+      servers: {
+        ...state.servers,
+        [serverName]: { ...existing, connectionStatus: "connecting" },
+      },
+    };
+  }
+  // Server not yet in local state (e.g. hosted mode) — seed a minimal entry.
+  const storedUrl = localStorage.getItem(`mcp-serverUrl-${serverName}`);
+  if (!storedUrl) return state;
+  try {
+    new URL(storedUrl);
+    return {
+      ...state,
+      servers: {
+        ...state.servers,
+        [serverName]: {
+          name: serverName,
+          config: { url: storedUrl } as ServerWithName["config"],
+          lastConnectionTime: new Date(),
+          connectionStatus: "connecting",
+          retryCount: 0,
+          enabled: true,
+          useOAuth: true,
+        } as ServerWithName,
+      },
+    };
+  } catch {
+    return state;
+  }
 }
 
 export function buildDisconnectedRuntimeServers(
@@ -213,7 +289,11 @@ export function useAppState({
   useEffect(() => {
     try {
       const loaded = loadAppState();
-      dispatch({ type: "HYDRATE_STATE", payload: loaded });
+      const pendingOAuthServerName = resolvePendingOAuthServerName();
+      const hydratedState = pendingOAuthServerName
+        ? patchStateForPendingOAuth(loaded, pendingOAuthServerName)
+        : loaded;
+      dispatch({ type: "HYDRATE_STATE", payload: hydratedState });
     } catch (error) {
       logger.error("Failed to load saved state", {
         error: error instanceof Error ? error.message : "Unknown error",

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -21,6 +21,14 @@ import { HOSTED_OAUTH_PENDING_STORAGE_KEY } from "@/lib/hosted-oauth-callback";
 export type { ServerWithName } from "@/state/app-types";
 export type { ServerUpdateResult } from "./use-server-state";
 
+export interface PendingDashboardOAuthState {
+  serverName: string;
+  serverUrl: string | null;
+  startedAt: number;
+}
+
+const PENDING_DASHBOARD_OAUTH_UI_TIMEOUT_MS = 30 * 1000;
+
 interface ActiveOrganizationSelection {
   organizationId?: string;
   userId: string | null;
@@ -44,9 +52,9 @@ function createDefaultWorkspace() {
   };
 }
 
-// Resolves the server name for a pending OAuth callback by checking the
-// hosted OAuth marker first (preferred), then the legacy localStorage key.
-function resolvePendingOAuthServerName(): string | null {
+// Resolves dashboard/server-list OAuth callbacks only. Hosted chatbox/shared
+// callbacks are handled by App.tsx and must not affect server-card state.
+function readPendingDashboardOAuth(): PendingDashboardOAuthState | null {
   if (typeof window === "undefined") return null;
   if (!new URLSearchParams(window.location.search).has("code")) return null;
 
@@ -55,6 +63,8 @@ function resolvePendingOAuthServerName(): string | null {
     if (raw) {
       const parsed = JSON.parse(raw) as {
         serverName?: unknown;
+        serverUrl?: unknown;
+        startedAt?: unknown;
         surface?: unknown;
       } | null;
       if (parsed?.surface === "chatbox" || parsed?.surface === "shared") {
@@ -65,54 +75,48 @@ function resolvePendingOAuthServerName(): string | null {
         typeof parsed.serverName === "string" &&
         parsed.serverName
       ) {
-        return parsed.serverName;
+        return {
+          serverName: parsed.serverName,
+          serverUrl:
+            typeof parsed.serverUrl === "string" ? parsed.serverUrl : null,
+          startedAt:
+            typeof parsed.startedAt === "number" ? parsed.startedAt : Date.now(),
+        };
       }
     }
   } catch {
     // ignore
   }
-  return localStorage.getItem("mcp-oauth-pending");
+  const serverName = localStorage.getItem("mcp-oauth-pending");
+  if (!serverName) return null;
+  return {
+    serverName,
+    serverUrl: localStorage.getItem(`mcp-serverUrl-${serverName}`),
+    startedAt: Date.now(),
+  };
 }
 
-// Patches the loaded state so a pending OAuth server starts as "connecting"
-// rather than "disconnected", preventing a flash on the first rendered frame.
+// Patches only existing server state. Missing servers are represented by
+// pendingDashboardOAuth UI state instead of fake temporary server objects.
 function patchStateForPendingOAuth(
   state: AppState,
-  serverName: string,
+  pendingOAuth: PendingDashboardOAuthState,
 ): AppState {
-  const existing = state.servers[serverName];
-  if (existing) {
-    return {
-      ...state,
-      servers: {
-        ...state.servers,
-        [serverName]: { ...existing, connectionStatus: "connecting" },
-      },
-    };
-  }
-  // Server not yet in local state (e.g. hosted mode) — seed a minimal entry.
-  const storedUrl = localStorage.getItem(`mcp-serverUrl-${serverName}`);
-  if (!storedUrl) return state;
-  try {
-    new URL(storedUrl);
-    return {
-      ...state,
-      servers: {
-        ...state.servers,
-        [serverName]: {
-          name: serverName,
-          config: { url: storedUrl } as ServerWithName["config"],
-          lastConnectionTime: new Date(),
-          connectionStatus: "connecting",
-          retryCount: 0,
-          enabled: true,
-          useOAuth: true,
-        } as ServerWithName,
-      },
-    };
-  } catch {
+  const existing = state.servers[pendingOAuth.serverName];
+  if (!existing) {
     return state;
   }
+
+  return {
+    ...state,
+    servers: {
+      ...state.servers,
+      [pendingOAuth.serverName]: {
+        ...existing,
+        connectionStatus: "connecting",
+      },
+    },
+  };
 }
 
 export function buildDisconnectedRuntimeServers(
@@ -145,6 +149,9 @@ export function useAppState({
   const logger = useLogger("Connections");
   const [appState, dispatch] = useReducer(appReducer, initialAppState);
   const [isLoading, setIsLoading] = useState(true);
+  const [pendingDashboardOAuth, setPendingDashboardOAuth] =
+    useState<PendingDashboardOAuthState | null>(null);
+  const hasHydratedAppStateRef = useRef(false);
 
   const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
 
@@ -287,11 +294,23 @@ export function useAppState({
   ]);
 
   useEffect(() => {
+    if (hasHydratedAppStateRef.current) return;
+    hasHydratedAppStateRef.current = true;
+
     try {
       const loaded = loadAppState();
-      const pendingOAuthServerName = resolvePendingOAuthServerName();
-      const hydratedState = pendingOAuthServerName
-        ? patchStateForPendingOAuth(loaded, pendingOAuthServerName)
+      const pendingOAuth = readPendingDashboardOAuth();
+      setPendingDashboardOAuth((current) => {
+        if (
+          current?.serverName === pendingOAuth?.serverName &&
+          current?.serverUrl === pendingOAuth?.serverUrl
+        ) {
+          return current;
+        }
+        return pendingOAuth;
+      });
+      const hydratedState = pendingOAuth
+        ? patchStateForPendingOAuth(loaded, pendingOAuth)
         : loaded;
       dispatch({ type: "HYDRATE_STATE", payload: hydratedState });
     } catch (error) {
@@ -306,6 +325,38 @@ export function useAppState({
   useEffect(() => {
     if (!isLoading) saveAppState(appState);
   }, [appState, isLoading]);
+
+  useEffect(() => {
+    if (!pendingDashboardOAuth) return;
+    const pendingServer = appState.servers[pendingDashboardOAuth.serverName];
+    if (
+      pendingServer?.connectionStatus === "connected" ||
+      pendingServer?.connectionStatus === "failed"
+    ) {
+      setPendingDashboardOAuth(null);
+    }
+  }, [appState.servers, pendingDashboardOAuth]);
+
+  useEffect(() => {
+    if (!pendingDashboardOAuth) return;
+
+    const elapsedMs = Date.now() - pendingDashboardOAuth.startedAt;
+    if (elapsedMs >= PENDING_DASHBOARD_OAUTH_UI_TIMEOUT_MS) {
+      setPendingDashboardOAuth(null);
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setPendingDashboardOAuth((current) =>
+        current?.serverName === pendingDashboardOAuth.serverName &&
+        current.startedAt === pendingDashboardOAuth.startedAt
+          ? null
+          : current,
+      );
+    }, PENDING_DASHBOARD_OAUTH_UI_TIMEOUT_MS - elapsedMs);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [pendingDashboardOAuth]);
 
   const workspaceState = useWorkspaceState({
     appState,
@@ -498,6 +549,7 @@ export function useAppState({
     setActiveOrganizationId,
     clearConvexActiveWorkspaceSelection,
     clearLocalFallbackWorkspaceSelection,
+    pendingDashboardOAuth,
 
     workspaceServers: serverState.workspaceServers,
     connectedOrConnectingServerConfigs:

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -815,6 +815,50 @@ export function useServerState({
       }
       oauthCallbackHandledRef.current = true;
 
+      // Dispatch "connecting" immediately so SYNC_AGENT_STATUS (which fires
+      // concurrently) cannot set the server back to "disconnected" while the
+      // token exchange is still in flight.
+      // Prefer the hostedOAuthCallbackContext server name (already validated),
+      // fall back to the legacy localStorage key.
+      const earlyPendingName =
+        hostedOAuthCallbackContext?.serverName ??
+        localStorage.getItem("mcp-oauth-pending");
+      if (earlyPendingName) {
+        const earlyServer = effectiveServers[earlyPendingName];
+        if (earlyServer) {
+          dispatch({
+            type: "CONNECT_REQUEST",
+            name: earlyPendingName,
+            config: earlyServer.config,
+            select: true,
+          });
+        } else {
+          const earlyUrl =
+            hostedOAuthCallbackContext?.serverUrl ??
+            localStorage.getItem(`mcp-serverUrl-${earlyPendingName}`);
+          if (earlyUrl) {
+            try {
+              new URL(earlyUrl);
+              dispatch({
+                type: "UPSERT_SERVER",
+                name: earlyPendingName,
+                server: {
+                  name: earlyPendingName,
+                  config: { url: earlyUrl } as MCPServerConfig,
+                  lastConnectionTime: new Date(),
+                  connectionStatus: "connecting",
+                  retryCount: 0,
+                  enabled: true,
+                  useOAuth: true,
+                } as ServerWithName,
+              });
+            } catch {
+              // ignore invalid URL
+            }
+          }
+        }
+      }
+
       const savedHash = localStorage.getItem("mcp-oauth-return-hash") || "";
       window.history.replaceState(
         {},

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -832,30 +832,6 @@ export function useServerState({
             config: earlyServer.config,
             select: true,
           });
-        } else {
-          const earlyUrl =
-            hostedOAuthCallbackContext?.serverUrl ??
-            localStorage.getItem(`mcp-serverUrl-${earlyPendingName}`);
-          if (earlyUrl) {
-            try {
-              new URL(earlyUrl);
-              dispatch({
-                type: "UPSERT_SERVER",
-                name: earlyPendingName,
-                server: {
-                  name: earlyPendingName,
-                  config: { url: earlyUrl } as MCPServerConfig,
-                  lastConnectionTime: new Date(),
-                  connectionStatus: "connecting",
-                  retryCount: 0,
-                  enabled: true,
-                  useOAuth: true,
-                } as ServerWithName,
-              });
-            } catch {
-              // ignore invalid URL
-            }
-          }
         }
       }
 


### PR DESCRIPTION
This PR fixes the brief disconnected flash after returning from OAuth.

## How it works:

Before OAuth redirect, we already store the pending server name in browser storage.
On page load after OAuth callback, we read that pending server name.
If the server already exists in app state, we mark/display it as connecting immediately.
If the server is not loaded yet, we show a low-probability fallback loading overlay: Finishing OAuth sign-in for <server>....
