### PR TITLE
playground:improve thread and add hoststyles

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/compare-playground-helpers.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/compare-playground-helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildComparePreviewTrace,
   buildHistoricalCompareRunRecords,
   buildCompareRunRecord,
   mergeAdvancedConfigWithOverride,
@@ -121,6 +122,37 @@ describe("compare-playground-helpers", () => {
     expect(record.status).toBe("cancelled");
     expect(record.result).toBe("cancelled");
     expect(record.metrics.durationMs).toBe(4000);
+  });
+
+  it("builds a one-message preview trace from the first non-empty prompt turn", () => {
+    expect(
+      buildComparePreviewTrace([
+        {
+          id: "turn-1",
+          prompt: "   ",
+          expectedToolCalls: [],
+        },
+        {
+          id: "turn-2",
+          prompt: "Tell me a joke",
+          expectedToolCalls: [],
+        },
+      ]),
+    ).toEqual({
+      messages: [{ role: "user", content: "Tell me a joke" }],
+    });
+  });
+
+  it("returns no preview trace when every prompt turn is empty", () => {
+    expect(
+      buildComparePreviewTrace([
+        {
+          id: "turn-1",
+          prompt: " ",
+          expectedToolCalls: [],
+        },
+      ]),
+    ).toBeNull();
   });
 
   it("computes mismatch counts for a compare run record", () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -1,14 +1,21 @@
 import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { PreferencesStoreProvider } from "@/stores/preferences/preferences-provider";
 import { TestTemplateEditor } from "../test-template-editor";
 import type { EvalIteration } from "../types";
 
-function renderWithProviders(ui: ReactElement) {
+function renderWithProviders(
+  ui: ReactElement,
+  { hostStyle = "claude" as const } = {},
+) {
   return render(
-    <PreferencesStoreProvider themeMode="light" themePreset="default">
+    <PreferencesStoreProvider
+      themeMode="light"
+      themePreset="default"
+      hostStyle={hostStyle}
+    >
       {ui}
     </PreferencesStoreProvider>,
   );
@@ -26,6 +33,7 @@ const useMutationMock = vi.hoisted(() => vi.fn(() => vi.fn()));
 const useQueryMock = vi.hoisted(() => vi.fn());
 const updateTestCaseMutationMock = vi.hoisted(() => vi.fn());
 const streamEvalTestCaseMock = vi.hoisted(() => vi.fn());
+const mockTraceViewer = vi.hoisted(() => vi.fn());
 const useAuthMock = vi.hoisted(() => ({
   getAccessToken: vi.fn().mockResolvedValue("token"),
 }));
@@ -81,6 +89,28 @@ vi.mock("../eval-trace-surface", () => ({
   ),
 }));
 
+vi.mock("../trace-viewer", () => ({
+  TraceViewer: (props: {
+    trace?: { messages?: Array<{ content?: unknown }> } | null;
+    forcedViewMode?: string;
+    isLoading?: boolean;
+  }) => {
+    mockTraceViewer(props);
+    const firstMessage = props.trace?.messages?.[0]?.content;
+    return (
+      <div
+        data-testid="mock-trace-viewer"
+        data-view-mode={props.forcedViewMode ?? "timeline"}
+        data-is-loading={String(Boolean(props.isLoading))}
+        data-message-count={String(props.trace?.messages?.length ?? 0)}
+        data-first-message={
+          typeof firstMessage === "string" ? firstMessage : "non-string"
+        }
+      />
+    );
+  },
+}));
+
 vi.mock("@/hooks/use-ai-provider-keys", () => ({
   useAiProviderKeys: () => ({
     getToken: vi.fn().mockResolvedValue("key"),
@@ -98,6 +128,7 @@ vi.mock("posthog-js", () => ({
 vi.mock("@/lib/PosthogUtils", () => ({
   detectEnvironment: () => "test",
   detectPlatform: () => "web",
+  standardEventProps: () => ({}),
 }));
 
 vi.mock("@/lib/apis/evals-api", () => ({
@@ -214,8 +245,19 @@ describe("TestTemplateEditor run view from route", () => {
       .length;
   }
 
+  function getLatestTraceViewerProps() {
+    const lastCall = mockTraceViewer.mock.calls.at(-1)?.[0];
+    expect(lastCall).toBeDefined();
+    return lastCall as {
+      trace?: { messages?: Array<{ content?: unknown }> } | null;
+      forcedViewMode?: string;
+      isLoading?: boolean;
+    };
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
+    mockTraceViewer.mockReset();
     useMutationMock.mockReturnValue(updateTestCaseMutationMock);
     useQueryMock.mockImplementation((name: string, args: unknown) => {
       if (name === "testSuites:listTestCases") {
@@ -573,6 +615,290 @@ describe("TestTemplateEditor run view from route", () => {
     expect(retryRequest.provider).toBe("openai");
     expect(retryRequest.model).toBe("gpt-4");
     expect(updateTestCaseMutationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders an immediate chat preview instead of the generic spinner before the first stream event", async () => {
+    const user = userEvent.setup();
+
+    streamEvalTestCaseMock.mockImplementation(
+      async () => new Promise<void>(() => {}),
+    );
+
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        workspaceId={null}
+        availableModels={[
+          {
+            provider: "openai",
+            id: "gpt-4",
+            model: "gpt-4",
+            name: "GPT-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+      />,
+      { hostStyle: "claude" },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /run$/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /run$/i }));
+
+    await waitFor(() => {
+      expect(streamEvalTestCaseMock).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("mock-trace-viewer")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("mock-trace-viewer")).toHaveAttribute(
+      "data-view-mode",
+      "chat",
+    );
+    expect(screen.getByTestId("mock-trace-viewer")).toHaveAttribute(
+      "data-is-loading",
+      "true",
+    );
+    expect(screen.getByTestId("mock-trace-viewer")).toHaveAttribute(
+      "data-message-count",
+      "1",
+    );
+    expect(screen.getByTestId("mock-trace-viewer")).toHaveAttribute(
+      "data-first-message",
+      "Q",
+    );
+    expect(screen.queryByText("Running GPT-4…")).not.toBeInTheDocument();
+  });
+
+  it("replaces the initial preview with streamed chat messages as soon as live trace data exists", async () => {
+    const user = userEvent.setup();
+    let emitEvent:
+      | ((
+          event:
+            | { type: "turn_start"; turnIndex: number; prompt: string }
+            | { type: "text_delta"; content: string },
+        ) => void)
+      | null = null;
+
+    streamEvalTestCaseMock.mockImplementation(
+      async (
+        _request: unknown,
+        onEvent: (
+          event:
+            | { type: "turn_start"; turnIndex: number; prompt: string }
+            | { type: "text_delta"; content: string },
+        ) => void,
+      ) => {
+        emitEvent = onEvent;
+        return new Promise<void>(() => {});
+      },
+    );
+
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        workspaceId={null}
+        availableModels={[
+          {
+            provider: "openai",
+            id: "gpt-4",
+            model: "gpt-4",
+            name: "GPT-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+      />,
+      { hostStyle: "claude" },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /run$/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /run$/i }));
+
+    await waitFor(() => {
+      expect(streamEvalTestCaseMock).toHaveBeenCalledTimes(1);
+      expect(getLatestTraceViewerProps().trace?.messages?.[0]?.content).toBe(
+        "Q",
+      );
+    });
+
+    act(() => {
+      emitEvent?.({
+        type: "turn_start",
+        turnIndex: 0,
+        prompt: "Streamed prompt",
+      });
+    });
+
+    await waitFor(() => {
+      const props = getLatestTraceViewerProps();
+      expect(props.isLoading).toBe(true);
+      expect(props.trace?.messages).toHaveLength(1);
+      expect(props.trace?.messages?.[0]?.content).toBe("Streamed prompt");
+    });
+  });
+
+  it("keeps the host-style pill shared across compare columns", async () => {
+    const user = userEvent.setup();
+
+    streamEvalTestCaseMock.mockImplementation(
+      async () => new Promise<void>(() => {}),
+    );
+
+    const view = renderWithProviders(
+      <TestTemplateEditor
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        workspaceId={null}
+        availableModels={[
+          {
+            provider: "openai",
+            id: "gpt-4",
+            model: "gpt-4",
+            name: "GPT-4",
+            label: "GPT-4",
+          } as any,
+          {
+            provider: "anthropic",
+            id: "claude-4.5-sonnet",
+            model: "claude-4.5-sonnet",
+            name: "Claude 4.5 Sonnet",
+            label: "Claude 4.5 Sonnet",
+          } as any,
+        ]}
+      />,
+      { hostStyle: "claude" },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /run$/i })).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", { name: /add model to compare/i }),
+    );
+    await user.click(screen.getByText("Claude 4.5 Sonnet"));
+    await user.click(screen.getByRole("button", { name: /run compare/i }));
+
+    await waitFor(() => {
+      expect(streamEvalTestCaseMock).toHaveBeenCalledTimes(2);
+    });
+
+    expect(
+      view.container.querySelectorAll('[data-selected-host-style="claude"]'),
+    ).toHaveLength(2);
+
+    await user.click(
+      within(getCompareCard("GPT-4")).getByRole("radio", {
+        name: "ChatGPT",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        view.container.querySelectorAll(
+          '[data-selected-host-style="chatgpt"]',
+        ),
+      ).toHaveLength(2);
+    });
+  });
+
+  it("shows the host-style pill only while the chat tab is active", async () => {
+    const user = userEvent.setup();
+    const caseWithExpectedToolCalls = {
+      ...caseDoc,
+      isNegativeTest: false,
+      expectedToolCalls: [
+        {
+          toolName: "create_view",
+          arguments: { shape: "box" },
+        },
+      ],
+    };
+
+    useQueryMock.mockImplementation((name: string, args: unknown) => {
+      if (name === "testSuites:listTestCases") {
+        return [caseWithExpectedToolCalls];
+      }
+      if (name === "testSuites:getTestSuite") {
+        return {
+          _id: "suite-1",
+          environment: { servers: ["srv"] },
+        };
+      }
+      if (name === "testSuites:listTestIterations" && args !== "skip") {
+        return [baseIteration];
+      }
+      if (
+        name === "testSuites:getTestIteration" &&
+        typeof args === "object" &&
+        args !== null &&
+        (args as { iterationId?: string }).iterationId === baseIteration._id
+      ) {
+        return baseIteration;
+      }
+      return undefined;
+    });
+    streamEvalTestCaseMock.mockImplementation(
+      async () => new Promise<void>(() => {}),
+    );
+
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        workspaceId={null}
+        availableModels={[
+          {
+            provider: "openai",
+            id: "gpt-4",
+            model: "gpt-4",
+            name: "GPT-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+      />,
+      { hostStyle: "claude" },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /run$/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /run$/i }));
+
+    await waitFor(() => {
+      expect(streamEvalTestCaseMock).toHaveBeenCalledTimes(1);
+    });
+
+    const card = getCompareCard("GPT-4");
+
+    expect(card.querySelector('[data-selected-host-style="claude"]')).not.toBe(
+      null,
+    );
+
+    await user.click(within(card).getByRole("button", { name: /^Trace$/i }));
+    expect(card.querySelector("[data-selected-host-style]")).toBeNull();
+
+    await user.click(within(card).getByRole("button", { name: /^Chat$/i }));
+    expect(card.querySelector('[data-selected-host-style="claude"]')).not.toBe(
+      null,
+    );
+
+    await user.click(within(card).getByRole("button", { name: /^Raw$/i }));
+    expect(card.querySelector("[data-selected-host-style]")).toBeNull();
+
+    await user.click(within(card).getByRole("button", { name: /^Results$/i }));
+    expect(card.querySelector("[data-selected-host-style]")).toBeNull();
   });
 
   it("renders running spinners in the eval compare metric bars", async () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer.test.tsx
@@ -21,10 +21,50 @@ vi.mock("@/components/ui/resizable", () => ({
   ResizableHandle: () => <div data-testid="resizable-handle" />,
 }));
 
-const { mockMessageView, mockJsonEditor } = vi.hoisted(() => ({
+const {
+  mockMessageView,
+  mockJsonEditor,
+  mockScrollToBottom,
+  mockStickToBottomContext,
+} = vi.hoisted(() => ({
   mockMessageView: vi.fn(),
   mockJsonEditor: vi.fn(),
+  mockScrollToBottom: vi.fn(),
+  mockStickToBottomContext: { isAtBottom: true },
 }));
+
+vi.mock("use-stick-to-bottom", () => {
+  const StickToBottomComponent = ({
+    children,
+    className,
+  }: {
+    children: ReactNode;
+    className?: string;
+  }) => (
+    <div data-testid="stick-to-bottom" className={className}>
+      {children}
+    </div>
+  );
+  StickToBottomComponent.Content = ({
+    children,
+    className,
+  }: {
+    children: ReactNode;
+    className?: string;
+  }) => (
+    <div data-testid="stick-to-bottom-content" className={className}>
+      {children}
+    </div>
+  );
+
+  return {
+    StickToBottom: StickToBottomComponent,
+    useStickToBottomContext: () => ({
+      isAtBottom: mockStickToBottomContext.isAtBottom,
+      scrollToBottom: mockScrollToBottom,
+    }),
+  };
+});
 
 vi.mock("@/stores/preferences/preferences-provider", () => ({
   usePreferencesStore: (selector: (state: { themeMode: string }) => unknown) =>
@@ -98,6 +138,10 @@ const simpleTextTrace = {
       content: [{ type: "text", text: "Hi there!" }],
     },
   ],
+};
+
+const userOnlyTrace = {
+  messages: [{ role: "user", content: "Hello" }],
 };
 
 const reasoningTrace = {
@@ -443,6 +487,7 @@ function renderInScrollHost(ui: ReactNode) {
 describe("TraceViewer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockStickToBottomContext.isAtBottom = true;
   });
 
   afterEach(() => {
@@ -478,6 +523,28 @@ describe("TraceViewer", () => {
     expect(screen.getByTestId("json-editor")).toBeInTheDocument();
     fireEvent.click(screen.getByTitle("Trace"));
     expect(await screen.findByText("Estimated total only")).toBeInTheDocument();
+  });
+
+  it("uses the shared stick-to-bottom shell in chat mode", () => {
+    render(<TraceViewer trace={simpleTextTrace} forcedViewMode="chat" />);
+
+    expect(screen.getByTestId("trace-viewer-chat")).toBeInTheDocument();
+    expect(screen.getByTestId("stick-to-bottom")).toBeInTheDocument();
+    expect(screen.getByTestId("stick-to-bottom-content")).toBeInTheDocument();
+  });
+
+  it("shows the shared scroll-to-bottom button when chat is off bottom", () => {
+    mockStickToBottomContext.isAtBottom = false;
+
+    render(<TraceViewer trace={simpleTextTrace} forcedViewMode="chat" />);
+
+    fireEvent.click(
+      within(screen.getByTestId("stick-to-bottom")).getByRole("button"),
+    );
+
+    expect(mockScrollToBottom).toHaveBeenCalledWith({
+      animation: "smooth",
+    });
   });
 
   it("leaves Raw on Escape", async () => {
@@ -1091,6 +1158,68 @@ describe("TraceViewer", () => {
         }),
       }),
     );
+  });
+
+  it("shows the GPT loading indicator when an OpenAI trace is still loading", () => {
+    render(
+      <TraceViewer
+        trace={userOnlyTrace}
+        model={{
+          id: "openai/gpt-4o",
+          name: "GPT-4o",
+          provider: "openai",
+        }}
+        isLoading
+      />,
+    );
+    openChatTab();
+
+    expect(screen.getByTestId("loading-indicator-dot")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("loading-indicator-claude"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the Claude loading indicator when an Anthropic trace is still loading", () => {
+    render(
+      <TraceViewer
+        trace={userOnlyTrace}
+        model={{
+          id: "anthropic/claude-sonnet-4.5",
+          name: "Claude Sonnet 4.5",
+          provider: "anthropic",
+        }}
+        isLoading
+      />,
+    );
+    openChatTab();
+
+    expect(screen.getByTestId("loading-indicator-claude")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("loading-indicator-dot"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides loading indicators when the trace is not loading", () => {
+    render(
+      <TraceViewer
+        trace={userOnlyTrace}
+        model={{
+          id: "openai/gpt-4o",
+          name: "GPT-4o",
+          provider: "openai",
+        }}
+        isLoading={false}
+      />,
+    );
+    openChatTab();
+
+    expect(
+      screen.queryByTestId("loading-indicator-dot"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("loading-indicator-claude"),
+    ).not.toBeInTheDocument();
   });
 
   // --- Widget fallback ---

--- a/mcpjam-inspector/client/src/components/evals/compare-playground-helpers.ts
+++ b/mcpjam-inspector/client/src/components/evals/compare-playground-helpers.ts
@@ -4,6 +4,7 @@ import {
   type ModelProvider,
 } from "@/shared/types";
 import { matchToolCalls } from "@/shared/eval-matching";
+import type { PromptTurn } from "@/shared/prompt-turns";
 import { computeIterationResult } from "./pass-criteria";
 import type {
   CompareModelOverride,
@@ -11,6 +12,7 @@ import type {
   EvalCase,
   EvalIteration,
 } from "./types";
+import type { TraceEnvelope } from "./trace-viewer-adapter";
 
 const KNOWN_MODEL_PROVIDERS: ModelProvider[] = [
   "anthropic",
@@ -62,6 +64,25 @@ export function resolveModelOptionLabel(
   modelLabelByValue: Record<string, string>,
 ) {
   return modelLabelByValue[modelValue] ?? modelValue;
+}
+
+export function buildComparePreviewTrace(
+  promptTurns: PromptTurn[],
+): TraceEnvelope | null {
+  const firstPrompt = promptTurns.find((turn) => turn.prompt.trim().length > 0);
+
+  if (!firstPrompt) {
+    return null;
+  }
+
+  return {
+    messages: [
+      {
+        role: "user",
+        content: firstPrompt.prompt,
+      },
+    ],
+  };
 }
 
 const MISMATCH_METADATA_KEYS = [

--- a/mcpjam-inspector/client/src/components/evals/compare-run-chat-surface.tsx
+++ b/mcpjam-inspector/client/src/components/evals/compare-run-chat-surface.tsx
@@ -36,6 +36,7 @@ function ErrorState({ message }: { message: string }) {
 export function CompareRunChatSurface({
   iteration,
   traceModel,
+  isLoading = false,
   emptyMessage = "Run this test to inspect trace details.",
   fallbackTrace = null,
   onTraceLoaded,
@@ -49,6 +50,7 @@ export function CompareRunChatSurface({
 }: {
   iteration: EvalIteration | null;
   traceModel?: ModelDefinition | null;
+  isLoading?: boolean;
   emptyMessage?: string;
   fallbackTrace?: TraceEnvelope | null;
   onTraceLoaded?: () => void;
@@ -103,6 +105,7 @@ export function CompareRunChatSurface({
         <TraceViewer
           trace={activeTrace}
           model={traceModel ?? undefined}
+          isLoading={isLoading}
           toolsMetadata={toolsMetadata}
           toolServerMap={toolServerMap}
           connectedServerIds={connectedServerIds}

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -14,7 +14,6 @@ import {
   Code2,
   Loader2,
   MoreHorizontal,
-  MoreVertical,
   Play,
   Plus,
   RotateCw,
@@ -68,7 +67,12 @@ import { normalizeToolChoice } from "@/shared/tool-choice";
 import { cn } from "@/lib/utils";
 import { computeIterationResult } from "./pass-criteria";
 import {
+  ChatboxHostStyleProvider,
+  ChatboxHostThemeProvider,
+} from "@/contexts/chatbox-host-style-context";
+import {
   buildHistoricalCompareRunRecords,
+  buildComparePreviewTrace,
   buildCompareRunRecord,
   createCompareSessionId,
   mergeAdvancedConfigWithOverride,
@@ -95,7 +99,13 @@ import {
 import { TraceViewer } from "./trace-viewer";
 import { useEvalTraceToolContext } from "./use-eval-trace-tool-context";
 import { useEvalTraceBlob } from "./use-eval-trace-blob";
-import { adaptTraceToUiMessages } from "./trace-viewer-adapter";
+import {
+  adaptTraceToUiMessages,
+  type TraceEnvelope,
+} from "./trace-viewer-adapter";
+import { getChatboxShellStyle } from "@/lib/chatbox-host-style";
+import { HostStylePillSelector } from "@/components/shared/HostStylePillSelector";
+import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 
 interface TestTemplate {
   title: string;
@@ -153,6 +163,10 @@ function deriveIsNegativeTestFromPromptTurns(
   promptTurns: PromptTurn[],
 ): boolean {
   return promptTurns.every((turn) => turn.expectedToolCalls.length === 0);
+}
+
+function compactModelLabel(name: string): string {
+  return name.replace(/\s*\(Free\)\s*$/i, "").trim() || name;
 }
 
 const validatePromptTurns = (promptTurns: PromptTurn[]): boolean => {
@@ -1114,6 +1128,9 @@ export function TestTemplateEditor({
     }
 
     const savePayload = buildSavePayload(editForm);
+    const comparePreviewTrace = buildComparePreviewTrace(
+      resolvePromptTurns(savePayload),
+    );
     compareRunUserStoppedRef.current = false;
     const reusableCompareRunId =
       options?.sessionMode === "reuse"
@@ -1266,6 +1283,7 @@ export function TestTemplateEditor({
           startedAt,
           completedAt: null,
           error: null,
+          previewTrace: comparePreviewTrace,
         };
       }
       for (const { modelValue, modelLabel, error } of preparationFailures) {
@@ -1902,7 +1920,7 @@ export function TestTemplateEditor({
                   ) : null}
 
                   <div className="flex min-w-0 flex-1 items-center gap-2">
-                    <div className="flex min-w-0 flex-1 items-center gap-2.5 overflow-x-auto py-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                    <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto py-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                       {selectedModelValues.length === 0 ? (
                         modelOptions.length === 0 ? (
                           <span className="text-[13px] text-muted-foreground">
@@ -1916,21 +1934,10 @@ export function TestTemplateEditor({
                             <DropdownMenuTrigger asChild>
                               <button
                                 type="button"
-                                className="inline-flex h-8 min-w-[12.5rem] max-w-full items-center gap-2 rounded-lg border border-[#E5E7EB] bg-white px-3 text-left text-[13px] font-medium text-foreground shadow-none hover:bg-[#fafafa] dark:border-border dark:bg-background dark:hover:bg-muted/40"
+                                className="inline-flex h-8 max-w-[180px] shrink-0 items-center gap-2 rounded-full border border-border/60 bg-white px-2.5 text-left text-xs font-medium text-foreground shadow-none transition-colors hover:bg-muted/80 dark:bg-background dark:hover:bg-muted/40"
                               >
                                 <Plus className="h-3.5 w-3.5 shrink-0" />
-                                <span>Add Model</span>
-                                <span className="ml-auto flex shrink-0 items-center gap-1 pl-1">
-                                  <span className="flex h-5 min-w-[1.35rem] items-center justify-center rounded border border-[#e8e8e8] bg-[#f4f4f5] px-1 font-sans text-[10px] font-semibold leading-none text-foreground dark:border-border dark:bg-muted">
-                                    {typeof navigator !== "undefined" &&
-                                    navigator.platform.includes("Mac")
-                                      ? "⌘"
-                                      : "Ctrl"}
-                                  </span>
-                                  <span className="flex h-5 min-w-[1.35rem] items-center justify-center rounded border border-[#e8e8e8] bg-[#f4f4f5] px-1 font-sans text-[10px] font-semibold leading-none text-foreground dark:border-border dark:bg-muted">
-                                    K
-                                  </span>
-                                </span>
+                                <span className="truncate">Add model</span>
                               </button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent
@@ -1963,30 +1970,34 @@ export function TestTemplateEditor({
                               <div
                                 key={modelValue}
                                 className={cn(
-                                  "flex h-8 shrink-0 items-center gap-0.5 rounded-lg border px-1.5",
+                                  "flex h-8 max-w-[180px] shrink-0 items-center gap-1 rounded-full border px-2",
                                   index === 0
-                                    ? "border-[#e8c7b8] bg-[#fff8f5] dark:border-orange-200/35 dark:bg-orange-500/8"
-                                    : "border-[#e0e0e0] bg-[#f5f5f5] dark:border-border dark:bg-muted/45",
+                                    ? "border-primary/25 bg-primary/5 text-foreground"
+                                    : "border-border/50 bg-muted/30 text-muted-foreground",
                                 )}
                               >
-                                <div className="flex h-5 w-5 shrink-0 items-center justify-center overflow-hidden rounded-full border border-[#ebebeb] bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04)] dark:border-border dark:bg-background">
-                                  <div className="flex scale-[1.2] items-center justify-center">
-                                    <ProviderLogo
-                                      provider={option?.provider ?? "custom"}
-                                    />
-                                  </div>
-                                </div>
-                                <span className="max-w-[9.5rem] truncate text-[13px] font-medium text-foreground">
-                                  {label}
+                                <ProviderLogo
+                                  provider={option?.provider ?? "custom"}
+                                  className="size-3.5 shrink-0"
+                                />
+                                <span
+                                  className={cn(
+                                    "min-w-0 flex-1 truncate text-xs font-medium",
+                                    index === 0
+                                      ? "text-foreground"
+                                      : "text-muted-foreground",
+                                  )}
+                                >
+                                  {compactModelLabel(label)}
                                 </span>
                                 <DropdownMenu>
                                   <DropdownMenuTrigger asChild>
                                     <button
                                       type="button"
-                                      className="rounded p-0.5 text-[#9e9e9e] hover:bg-black/[0.04] hover:text-foreground dark:hover:bg-white/10"
+                                      className="shrink-0 rounded-full p-0.5 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
                                       aria-label={`Model options (${label})`}
                                     >
-                                      <MoreVertical className="h-3.5 w-3.5" />
+                                      <MoreHorizontal className="h-3.5 w-3.5" />
                                     </button>
                                   </DropdownMenuTrigger>
                                   <DropdownMenuContent
@@ -2041,7 +2052,7 @@ export function TestTemplateEditor({
                                 </DropdownMenu>
                                 <button
                                   type="button"
-                                  className="rounded p-0.5 text-[#9e9e9e] hover:bg-black/[0.04] hover:text-foreground dark:hover:bg-white/10"
+                                  className="shrink-0 rounded-full p-0.5 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
                                   aria-label={`Remove ${label}`}
                                   onClick={() => handleRemoveModel(modelValue)}
                                 >
@@ -2056,7 +2067,7 @@ export function TestTemplateEditor({
                               <DropdownMenuTrigger asChild>
                                 <button
                                   type="button"
-                                  className="flex h-7 w-7 shrink-0 items-center justify-center rounded border border-[#e0e0e0] bg-white text-foreground hover:bg-[#fafafa] dark:border-border dark:bg-background dark:hover:bg-muted/50"
+                                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border/60 bg-white text-foreground transition-colors hover:bg-muted/80 dark:bg-background dark:hover:bg-muted/50"
                                   aria-label="Add model to compare"
                                 >
                                   <Plus className="h-3.5 w-3.5" />
@@ -2356,6 +2367,9 @@ function RunColumn({
   onTabChange: (tab: RunColumnTab) => void;
   onRetry: () => void;
 }) {
+  const themeMode = usePreferencesStore((state) => state.themeMode);
+  const hostStyle = usePreferencesStore((state) => state.hostStyle);
+  const setHostStyle = usePreferencesStore((state) => state.setHostStyle);
   const { toolsMetadata, toolServerMap, connectedServerIds } =
     useEvalTraceToolContext({
       serverNames,
@@ -2484,11 +2498,16 @@ function RunColumn({
     toolsMetadata,
   ]);
   const hasStreamingTrace = streamingTraceEnvelope != null;
+  const previewTrace = record.previewTrace ?? null;
+  const activeLiveChatTrace: TraceEnvelope | null =
+    (hasStreamingTrace ? streamingTraceEnvelope : previewTrace) ?? null;
   const isWaitingForFirstTimelineSnapshot =
     traceMode === "timeline" &&
     record.iteration == null &&
     record.streamingTrace == null &&
     hasStreamingTrace;
+  const shouldRenderChatShell = effectiveActiveTab === "chat";
+  const shellStyle = getChatboxShellStyle(hostStyle, themeMode);
 
   const displayTokens =
     record.streamingMetrics?.tokensUsed ?? record.metrics.tokensUsed;
@@ -2557,6 +2576,146 @@ function RunColumn({
     maxTokens > 0
       ? Math.min(100, Math.max(4, (displayTokens / maxTokens) * 100))
       : 0;
+  const renderedRunContent = record.iteration ? (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+      {traceMode === "chat" ? (
+        <CompareRunChatSurface
+          iteration={record.iteration}
+          traceModel={{
+            id: record.model,
+            name: record.modelLabel,
+            provider: record.provider as any,
+          }}
+          isLoading={isRunningRecord}
+          emptyMessage={`No ${activeTab} data is available for this run.`}
+          fallbackTrace={streamingTraceEnvelope}
+          onTraceLoaded={onStreamingTraceLoaded}
+          toolsMetadata={toolsMetadata}
+          toolServerMap={toolServerMap}
+          connectedServerIds={connectedServerIds}
+          traceBlob={persistedTraceBlob}
+          traceBlobLoading={persistedTraceLoading}
+          traceBlobError={persistedTraceError}
+        />
+      ) : (
+        <EvalTraceSurface
+          iteration={record.iteration}
+          testCase={testCase}
+          mode={traceMode}
+          emptyMessage={`No ${activeTab} data is available for this run.`}
+          fallbackTrace={streamingTraceEnvelope}
+          fallbackActualToolCalls={actualToolCalls}
+          onTraceLoaded={onStreamingTraceLoaded}
+          onNavigateToChat={() => onTabChange("chat")}
+          traceBlob={persistedTraceBlob}
+          traceBlobLoading={persistedTraceLoading}
+          traceBlobError={persistedTraceError}
+          toolsMetadata={toolsMetadata}
+          toolServerMap={toolServerMap}
+          connectedServerIds={connectedServerIds}
+        />
+      )}
+    </div>
+  ) : hasStreamingTrace ? (
+    isWaitingForFirstTimelineSnapshot ? (
+      <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-border/50 bg-muted/10 px-6 py-10 text-center">
+        <div className="max-w-sm">
+          <div className="text-sm font-medium">
+            Timeline appears after the first step completes
+          </div>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Chat and raw output are already streaming for the current in-flight
+            step.
+          </p>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="mt-3"
+            onClick={() => onTabChange("chat")}
+          >
+            Switch to Chat
+          </Button>
+        </div>
+      </div>
+    ) : (
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <TraceViewer
+          trace={streamingTraceEnvelope}
+          forcedViewMode={traceMode}
+          isLoading={traceMode === "chat" && isRunningRecord}
+          expectedToolCalls={expectedToolCalls}
+          actualToolCalls={actualToolCalls}
+          toolsMetadata={toolsMetadata}
+          toolServerMap={toolServerMap}
+          connectedServerIds={connectedServerIds}
+          hideToolbar
+          fillContent
+        />
+      </div>
+    )
+  ) : record.status === "running" && !record.iteration ? (
+    traceMode === "chat" && activeLiveChatTrace ? (
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <TraceViewer
+          trace={activeLiveChatTrace}
+          model={{
+            id: record.model,
+            name: record.modelLabel,
+            provider: record.provider as any,
+          }}
+          forcedViewMode="chat"
+          isLoading={true}
+          toolsMetadata={toolsMetadata}
+          toolServerMap={toolServerMap}
+          connectedServerIds={connectedServerIds}
+          hideToolbar
+          fillContent
+        />
+      </div>
+    ) : (
+      <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-border/50 bg-muted/10">
+        <div className="flex items-center gap-3 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span>
+            {record.isRetrying ? "Retrying" : "Running"} {record.modelLabel}…
+          </span>
+        </div>
+      </div>
+    )
+  ) : record.status === "cancelled" && !record.iteration ? (
+    <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-amber-500/25 bg-amber-500/5 px-6 py-10">
+      <div className="max-w-sm text-center">
+        <div className="text-sm font-medium text-amber-800 dark:text-amber-200">
+          {record.modelLabel} stopped
+        </div>
+        <p className="mt-2 text-sm text-muted-foreground">
+          This run was stopped before it finished. Partial trace and metrics
+          may still be visible in the tabs above.
+        </p>
+      </div>
+    </div>
+  ) : record.status === "failed" && !record.iteration ? (
+    <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-destructive/30 bg-destructive/5 px-6 py-10">
+      <div className="max-w-sm text-center">
+        <div className="text-sm font-medium text-destructive">
+          {record.modelLabel} failed
+        </div>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {record.error || "No run data is available for this model."}
+        </p>
+      </div>
+    </div>
+  ) : (
+    <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-dashed border-border/60 bg-muted/10 px-6 py-10 text-center">
+      <div>
+        <div className="text-sm font-medium">No run yet</div>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Run compare to load this model’s chat, trace, and tool details.
+        </p>
+      </div>
+    </div>
+  );
 
   return (
     <div className="flex h-auto min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl border border-border/60 bg-card/40 lg:h-full">
@@ -2753,124 +2912,37 @@ function RunColumn({
       </div>
 
       <div className="flex min-w-0 max-lg:min-h-[min(52vh,26rem)] flex-1 flex-col overflow-hidden p-3 lg:min-h-0">
-        {record.iteration ? (
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-            {traceMode === "chat" ? (
-              <CompareRunChatSurface
-                iteration={record.iteration}
-                traceModel={{
-                  id: record.model,
-                  name: record.modelLabel,
-                  provider: record.provider as any,
-                }}
-                emptyMessage={`No ${activeTab} data is available for this run.`}
-                fallbackTrace={streamingTraceEnvelope}
-                onTraceLoaded={onStreamingTraceLoaded}
-                toolsMetadata={toolsMetadata}
-                toolServerMap={toolServerMap}
-                connectedServerIds={connectedServerIds}
-                traceBlob={persistedTraceBlob}
-                traceBlobLoading={persistedTraceLoading}
-                traceBlobError={persistedTraceError}
-              />
-            ) : (
-              <EvalTraceSurface
-                iteration={record.iteration}
-                testCase={testCase}
-                mode={traceMode}
-                emptyMessage={`No ${activeTab} data is available for this run.`}
-                fallbackTrace={streamingTraceEnvelope}
-                fallbackActualToolCalls={actualToolCalls}
-                onTraceLoaded={onStreamingTraceLoaded}
-                onNavigateToChat={() => onTabChange("chat")}
-                traceBlob={persistedTraceBlob}
-                traceBlobLoading={persistedTraceLoading}
-                traceBlobError={persistedTraceError}
-                toolsMetadata={toolsMetadata}
-                toolServerMap={toolServerMap}
-                connectedServerIds={connectedServerIds}
-              />
-            )}
-          </div>
-        ) : hasStreamingTrace ? (
-          isWaitingForFirstTimelineSnapshot ? (
-            <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-border/50 bg-muted/10 px-6 py-10 text-center">
-              <div className="max-w-sm">
-                <div className="text-sm font-medium">
-                  Timeline appears after the first step completes
+        {shouldRenderChatShell ? (
+          <ChatboxHostStyleProvider value={hostStyle}>
+            <ChatboxHostThemeProvider value={themeMode}>
+              <div
+                className={cn(
+                  "chatbox-host-shell app-theme-scope flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-xl border border-border/50",
+                  themeMode === "dark" && "dark",
+                )}
+                data-host-style={hostStyle}
+                style={shellStyle}
+              >
+                <div className="shrink-0 px-3 pt-3">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="shrink-0 text-[9px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                      Host Styles
+                    </p>
+                    <HostStylePillSelector
+                      className="w-[164px] shrink-0"
+                      value={hostStyle}
+                      onValueChange={setHostStyle}
+                    />
+                  </div>
                 </div>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  Chat and raw output are already streaming for the current
-                  in-flight step.
-                </p>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  className="mt-3"
-                  onClick={() => onTabChange("chat")}
-                >
-                  Switch to Chat
-                </Button>
+                <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden p-3 pt-2">
+                  {renderedRunContent}
+                </div>
               </div>
-            </div>
-          ) : (
-            <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-              <TraceViewer
-                trace={streamingTraceEnvelope}
-                forcedViewMode={traceMode}
-                expectedToolCalls={expectedToolCalls}
-                actualToolCalls={actualToolCalls}
-                toolsMetadata={toolsMetadata}
-                toolServerMap={toolServerMap}
-                connectedServerIds={connectedServerIds}
-                hideToolbar
-                fillContent
-              />
-            </div>
-          )
-        ) : record.status === "running" && !record.iteration ? (
-          <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-border/50 bg-muted/10">
-            <div className="flex items-center gap-3 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              <span>
-                {record.isRetrying ? "Retrying" : "Running"} {record.modelLabel}
-                …
-              </span>
-            </div>
-          </div>
-        ) : record.status === "cancelled" && !record.iteration ? (
-          <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-amber-500/25 bg-amber-500/5 px-6 py-10">
-            <div className="max-w-sm text-center">
-              <div className="text-sm font-medium text-amber-800 dark:text-amber-200">
-                {record.modelLabel} stopped
-              </div>
-              <p className="mt-2 text-sm text-muted-foreground">
-                This run was stopped before it finished. Partial trace and
-                metrics may still be visible in the tabs above.
-              </p>
-            </div>
-          </div>
-        ) : record.status === "failed" && !record.iteration ? (
-          <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-destructive/30 bg-destructive/5 px-6 py-10">
-            <div className="max-w-sm text-center">
-              <div className="text-sm font-medium text-destructive">
-                {record.modelLabel} failed
-              </div>
-              <p className="mt-2 text-sm text-muted-foreground">
-                {record.error || "No run data is available for this model."}
-              </p>
-            </div>
-          </div>
+            </ChatboxHostThemeProvider>
+          </ChatboxHostStyleProvider>
         ) : (
-          <div className="flex min-h-0 flex-1 items-center justify-center rounded-xl border border-dashed border-border/60 bg-muted/10 px-6 py-10 text-center">
-            <div>
-              <div className="text-sm font-medium">No run yet</div>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Run compare to load this model’s chat, trace, and tool details.
-              </p>
-            </div>
-          </div>
+          renderedRunContent
         )}
       </div>
     </div>

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
@@ -8,7 +8,9 @@ import {
 } from "react";
 import type { ContentBlock } from "@modelcontextprotocol/client";
 import { Loader2, Minus, Plus } from "lucide-react";
+import { StickToBottom } from "use-stick-to-bottom";
 import { Button } from "@mcpjam/design-system/button";
+import { ScrollToBottomButton } from "@/components/chat-v2/shared/scroll-to-bottom-button";
 import type { ModelDefinition, ModelProvider } from "@/shared/types";
 import type { EvalTraceSpan } from "@/shared/eval-trace";
 import type { ToolServerMap } from "@/lib/apis/mcp-tools-api";
@@ -51,6 +53,7 @@ export type TraceViewerEvalToolCall = {
 interface TraceViewerProps {
   trace: TraceEnvelope | TraceMessage | TraceMessage[] | null;
   model?: ModelDefinition;
+  isLoading?: boolean;
   toolsMetadata?: Record<string, Record<string, any>>;
   toolServerMap?: ToolServerMap;
   connectedServerIds?: string[];
@@ -158,6 +161,7 @@ function getRecordedSpans(
 export function TraceViewer({
   trace,
   model,
+  isLoading = false,
   toolsMetadata = {},
   toolServerMap = {},
   connectedServerIds = [],
@@ -575,55 +579,66 @@ export function TraceViewer({
           ) : (
             <div
               className={cn(
-                "min-w-0 rounded-md border border-border/30 bg-background/50",
+                "min-w-0 rounded-md border border-border/30 bg-background/50 flex flex-col",
                 fillContent
-                  ? "min-h-0 flex-1 overflow-auto"
-                  : "min-h-0 max-h-[min(70vh,36rem)] overflow-auto",
+                  ? "min-h-0 flex-1 overflow-hidden"
+                  : "min-h-0 max-h-[min(70vh,36rem)] overflow-hidden",
               )}
               data-testid="trace-viewer-chat"
             >
-              <Thread
-                messages={adaptedTrace.messages}
-                sendFollowUpMessage={sendFollowUpMessage}
-                model={resolvedModel}
-                isLoading={false}
-                toolsMetadata={toolsMetadata}
-                toolServerMap={toolServerMap}
-                onWidgetStateChange={onWidgetStateChange}
-                onModelContextUpdate={onModelContextUpdate}
-                displayMode={displayMode}
-                onDisplayModeChange={onDisplayModeChange}
-                enableFullscreenChatOverlay={enableFullscreenChatOverlay}
-                fullscreenChatPlaceholder={fullscreenChatPlaceholder}
-                fullscreenChatDisabled={fullscreenChatDisabled}
-                fullscreenChatSendBlocked={fullscreenChatSendBlocked}
-                onFullscreenChatStop={onFullscreenChatStop}
-                onFullscreenChange={onFullscreenChange}
-                selectedProtocolOverrideIfBothExists={
-                  selectedProtocolOverrideIfBothExists
-                }
-                onToolApprovalResponse={onToolApprovalResponse}
-                toolRenderOverrides={adaptedTrace.toolRenderOverrides}
-                showSaveViewButton={false}
-                minimalMode={true}
-                interactive={threadInteractive}
-                reasoningDisplayMode="collapsed"
-                focusMessageId={transcriptNavigation.focusMessageId}
-                highlightedMessageIds={
-                  transcriptNavigation.highlightedMessageIds
-                }
-                navigationKey={transcriptNavigation.navigationKey}
-                contentClassName="min-w-0 mx-auto w-full max-w-4xl space-y-8 px-4 pt-2"
-                getMessageWrapperProps={({ message }) => {
-                  const sourceRange =
-                    adaptedTrace.uiMessageSourceRanges[message.id];
-                  return {
-                    "data-source-range": sourceRange
-                      ? `${sourceRange.startIndex}-${sourceRange.endIndex}`
-                      : undefined,
-                  };
-                }}
-              />
+              <StickToBottom
+                className="relative flex min-h-0 flex-1 flex-col"
+                resize="smooth"
+                initial="smooth"
+              >
+                <div className="relative flex-1 min-h-0">
+                  <StickToBottom.Content className="flex flex-col min-h-0">
+                    <Thread
+                      messages={adaptedTrace.messages}
+                      sendFollowUpMessage={sendFollowUpMessage}
+                      model={resolvedModel}
+                      isLoading={isLoading}
+                      toolsMetadata={toolsMetadata}
+                      toolServerMap={toolServerMap}
+                      onWidgetStateChange={onWidgetStateChange}
+                      onModelContextUpdate={onModelContextUpdate}
+                      displayMode={displayMode}
+                      onDisplayModeChange={onDisplayModeChange}
+                      enableFullscreenChatOverlay={enableFullscreenChatOverlay}
+                      fullscreenChatPlaceholder={fullscreenChatPlaceholder}
+                      fullscreenChatDisabled={fullscreenChatDisabled}
+                      fullscreenChatSendBlocked={fullscreenChatSendBlocked}
+                      onFullscreenChatStop={onFullscreenChatStop}
+                      onFullscreenChange={onFullscreenChange}
+                      selectedProtocolOverrideIfBothExists={
+                        selectedProtocolOverrideIfBothExists
+                      }
+                      onToolApprovalResponse={onToolApprovalResponse}
+                      toolRenderOverrides={adaptedTrace.toolRenderOverrides}
+                      showSaveViewButton={false}
+                      minimalMode={true}
+                      interactive={threadInteractive}
+                      reasoningDisplayMode="collapsed"
+                      focusMessageId={transcriptNavigation.focusMessageId}
+                      highlightedMessageIds={
+                        transcriptNavigation.highlightedMessageIds
+                      }
+                      navigationKey={transcriptNavigation.navigationKey}
+                      contentClassName="min-w-0 mx-auto w-full max-w-4xl space-y-8 px-4 pt-2"
+                      getMessageWrapperProps={({ message }) => {
+                        const sourceRange =
+                          adaptedTrace.uiMessageSourceRanges[message.id];
+                        return {
+                          "data-source-range": sourceRange
+                            ? `${sourceRange.startIndex}-${sourceRange.endIndex}`
+                            : undefined,
+                        };
+                      }}
+                    />
+                  </StickToBottom.Content>
+                  <ScrollToBottomButton />
+                </div>
+              </StickToBottom>
             </div>
           ))}
 

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -1,7 +1,7 @@
 import type { PromptTurn } from "@/shared/prompt-turns";
 import type { EvalTraceBlobV1 } from "@/shared/eval-trace";
 import type { EvalStreamToolCall } from "@/shared/eval-stream-events";
-import type { TraceMessage } from "./trace-viewer-adapter";
+import type { TraceEnvelope, TraceMessage } from "./trace-viewer-adapter";
 
 export type EvalSuiteConfigTest = {
   title: string;
@@ -153,6 +153,8 @@ export type CompareRunRecord = {
     argumentMismatchCount: number | null;
     mismatchCount: number | null;
   };
+  /** Immediate chat preview shown before the first live stream event arrives. */
+  previewTrace?: TraceEnvelope | null;
   /** Stable step-complete trace snapshots populated during streaming. */
   streamingTrace?: EvalTraceBlobV1;
   /** In-flight messages collected after the last authoritative snapshot. */

--- a/mcpjam-inspector/client/src/components/shared/HostStylePillSelector.tsx
+++ b/mcpjam-inspector/client/src/components/shared/HostStylePillSelector.tsx
@@ -1,5 +1,8 @@
 import { ToggleGroup, ToggleGroupItem } from "@mcpjam/design-system/toggle-group";
-import type { ChatboxHostStyle } from "@/lib/chatbox-host-style";
+import {
+  getChatboxHostLogo,
+  type ChatboxHostStyle,
+} from "@/lib/chatbox-host-style";
 import { cn } from "@/lib/utils";
 
 interface HostStylePillSelectorProps {
@@ -45,7 +48,15 @@ export function HostStylePillSelector({
           className="z-10 h-[22px] min-w-0 flex-1 rounded-full border-0 bg-transparent px-2 text-[10px] font-medium tracking-[-0.01em] text-muted-foreground/90 first:rounded-full last:rounded-full hover:bg-transparent hover:text-foreground data-[state=on]:bg-transparent data-[state=on]:font-semibold data-[state=on]:text-foreground data-[state=on]:shadow-none"
           aria-label="ChatGPT"
         >
-          ChatGPT
+          <span className="inline-flex items-center gap-1">
+            <img
+              src={getChatboxHostLogo("chatgpt")}
+              alt=""
+              aria-hidden="true"
+              className="h-3 w-3 shrink-0 object-contain"
+            />
+            <span>ChatGPT</span>
+          </span>
         </ToggleGroupItem>
         <ToggleGroupItem
           value="claude"
@@ -53,7 +64,15 @@ export function HostStylePillSelector({
           className="z-10 h-[22px] min-w-0 flex-1 rounded-full border-0 bg-transparent px-2 text-[10px] font-medium tracking-[-0.01em] text-muted-foreground/90 first:rounded-full last:rounded-full hover:bg-transparent hover:text-foreground data-[state=on]:bg-transparent data-[state=on]:font-semibold data-[state=on]:text-foreground data-[state=on]:shadow-none"
           aria-label="Claude"
         >
-          Claude
+          <span className="inline-flex items-center gap-1">
+            <img
+              src={getChatboxHostLogo("claude")}
+              alt=""
+              aria-hidden="true"
+              className="h-3 w-3 shrink-0 object-contain"
+            />
+            <span>Claude</span>
+          </span>
         </ToggleGroupItem>
       </ToggleGroup>
     </div>


### PR DESCRIPTION
## Summary
- Your prompt shows up right away — when you hit Run, each compare column instantly shows the message you sent, instead of making you stare at a loading spinner while the model warms up.
- Claude/ChatGPT style toggle in every column — a small pill with the Claude and ChatGPT logos lives above each chat. It only shows on the Chat tab, and flipping it in one column flips it in the others too.
- Chat scrolls with you + a thinking dot that matches the model — the chat now auto-scrolls to the latest message as it streams, and you'll see Claude's dot for Claude runs and ChatGPT's dot for GPT runs while the model is thinking.
- Cleaner model chips — the selected models now show as rounded pills with their provider logo, and the "Add model" button is simpler and less cluttered.
Refreshed model chips — rounded pills with provider logos; Add-model trigger simplified.
## Test plan
Run a single model — prompt bubble appears instantly, then streams.
sin completar
Run Compare with two models — pill toggle in one column updates both.
sin completar
Switch Chat / Trace / Raw / Results — pill shows only on Chat.
sin completar
Cancel + fail a run — empty states still render inside the chat shell.
sin completar
Claude vs GPT loading dots match the provider.


Before:

https://github.com/user-attachments/assets/61d4c9a4-fa10-4579-bc34-e08f19dc3400

After:

https://github.com/user-attachments/assets/e3bd80e3-2752-4fd2-be2b-5fb20647d55b

host style decision is now in test screen:
<img width="1177" height="482" alt="image" src="https://github.com/user-attachments/assets/91c9edb4-98b0-4a6d-bdd4-b99dadcfdeb6" />


