### PR TITLE
feat(evals): Playground compare defaults to Results + Actual loading spinner

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -94,6 +94,7 @@ vi.mock("../trace-viewer", () => ({
     trace?: { messages?: Array<{ content?: unknown }> } | null;
     forcedViewMode?: string;
     isLoading?: boolean;
+    expectedToolCalls?: Array<{ toolName: string }>;
   }) => {
     mockTraceViewer(props);
     const firstMessage = props.trace?.messages?.[0]?.content;
@@ -106,6 +107,7 @@ vi.mock("../trace-viewer", () => ({
         data-first-message={
           typeof firstMessage === "string" ? firstMessage : "non-string"
         }
+        data-expected-tool-count={String(props.expectedToolCalls?.length ?? 0)}
       />
     );
   },
@@ -671,6 +673,85 @@ describe("TestTemplateEditor run view from route", () => {
       "Q",
     );
     expect(screen.queryByText("Running GPT-4…")).not.toBeInTheDocument();
+  });
+
+  it("renders a tools preview (not generic spinner) before the first stream event when the case has expected tool calls", async () => {
+    const user = userEvent.setup();
+    const caseWithTools = {
+      ...caseDoc,
+      isNegativeTest: false,
+      expectedToolCalls: [{ toolName: "create_view", arguments: {} }],
+    };
+
+    useQueryMock.mockImplementation((name: string, args: unknown) => {
+      if (name === "testSuites:listTestCases") return [caseWithTools];
+      if (name === "testSuites:getTestSuite") {
+        return { _id: "suite-1", environment: { servers: ["srv"] } };
+      }
+      if (name === "testSuites:listTestIterations" && args !== "skip") {
+        return [baseIteration];
+      }
+      if (
+        name === "testSuites:getTestIteration" &&
+        typeof args === "object" &&
+        args !== null &&
+        (args as { iterationId?: string }).iterationId === baseIteration._id
+      ) {
+        return baseIteration;
+      }
+      return undefined;
+    });
+
+    // Stream never resolves — keeps the run in "running, no iteration" state.
+    streamEvalTestCaseMock.mockImplementation(
+      async () => new Promise<void>(() => {}),
+    );
+
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        workspaceId={null}
+        availableModels={[
+          {
+            provider: "openai",
+            id: "gpt-4",
+            model: "gpt-4",
+            name: "GPT-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+      />,
+      { hostStyle: "claude" },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /run$/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /run$/i }));
+
+    await waitFor(() => {
+      expect(streamEvalTestCaseMock).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("mock-trace-viewer")).toBeInTheDocument();
+    });
+
+    // Must show tools view (not chat) and pass expected tool calls through.
+    expect(screen.getByTestId("mock-trace-viewer")).toHaveAttribute(
+      "data-view-mode",
+      "tools",
+    );
+    expect(screen.getByTestId("mock-trace-viewer")).toHaveAttribute(
+      "data-is-loading",
+      "true",
+    );
+    expect(screen.getByTestId("mock-trace-viewer")).toHaveAttribute(
+      "data-expected-tool-count",
+      "1",
+    );
+    // Generic spinner must not appear.
+    expect(screen.queryByText(/Running GPT-4/)).not.toBeInTheDocument();
   });
 
   it("replaces the initial preview with streamed chat messages as soon as live trace data exists", async () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -882,6 +882,10 @@ describe("TestTemplateEditor run view from route", () => {
 
     const card = getCompareCard("GPT-4");
 
+    // Default tab is Results when the case has expected tools — host-style pill is Chat-only.
+    expect(card.querySelector("[data-selected-host-style]")).toBeNull();
+
+    await user.click(within(card).getByRole("button", { name: /^Chat$/i }));
     expect(card.querySelector('[data-selected-host-style="claude"]')).not.toBe(
       null,
     );

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -811,6 +811,92 @@ describe("TestTemplateEditor run view from route", () => {
     });
   });
 
+  it("defaults to Results tab when expected tool calls are on a non-first prompt turn (multi-turn case)", async () => {
+    const user = userEvent.setup();
+    // Multi-turn case: turn 1 has no expected tool calls, turn 2 has one.
+    const multiTurnCase = {
+      ...caseDoc,
+      isNegativeTest: false,
+      expectedToolCalls: [],
+      promptTurns: [
+        {
+          id: "turn-1",
+          prompt: "First prompt",
+          expectedToolCalls: [],
+        },
+        {
+          id: "turn-2",
+          prompt: "Second prompt",
+          expectedToolCalls: [{ toolName: "some_tool", arguments: {} }],
+        },
+      ],
+    };
+
+    useQueryMock.mockImplementation((name: string, args: unknown) => {
+      if (name === "testSuites:listTestCases") {
+        return [multiTurnCase];
+      }
+      if (name === "testSuites:getTestSuite") {
+        return {
+          _id: "suite-1",
+          environment: { servers: ["srv"] },
+        };
+      }
+      if (name === "testSuites:listTestIterations" && args !== "skip") {
+        return [baseIteration];
+      }
+      if (
+        name === "testSuites:getTestIteration" &&
+        typeof args === "object" &&
+        args !== null &&
+        (args as { iterationId?: string }).iterationId === baseIteration._id
+      ) {
+        return baseIteration;
+      }
+      return undefined;
+    });
+    streamEvalTestCaseMock.mockImplementation(
+      async () => new Promise<void>(() => {}),
+    );
+
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        workspaceId={null}
+        availableModels={[
+          {
+            provider: "openai",
+            id: "gpt-4",
+            model: "gpt-4",
+            name: "GPT-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+      />,
+      { hostStyle: "claude" },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /run$/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /run$/i }));
+
+    await waitFor(() => {
+      expect(streamEvalTestCaseMock).toHaveBeenCalledTimes(1);
+    });
+
+    const card = getCompareCard("GPT-4");
+
+    // Default tab must be Results even when expected tools live only on turn 2+.
+    expect(card.querySelector("[data-selected-host-style]")).toBeNull();
+    expect(
+      within(card).getByRole("button", { name: /^Results$/i }),
+    ).toBeInTheDocument();
+  });
+
   it("shows the host-style pill only while the chat tab is active", async () => {
     const user = userEvent.setup();
     const caseWithExpectedToolCalls = {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -254,6 +254,7 @@ describe("TestTemplateEditor run view from route", () => {
       trace?: { messages?: Array<{ content?: unknown }> } | null;
       forcedViewMode?: string;
       isLoading?: boolean;
+      expectedToolCalls?: Array<{ toolName: string; arguments: Record<string, unknown> }>;
     };
   }
 
@@ -969,13 +970,15 @@ describe("TestTemplateEditor run view from route", () => {
       expect(streamEvalTestCaseMock).toHaveBeenCalledTimes(1);
     });
 
-    const card = getCompareCard("GPT-4");
-
-    // Default tab must be Results even when expected tools live only on turn 2+.
-    expect(card.querySelector("[data-selected-host-style]")).toBeNull();
-    expect(
-      within(card).getByRole("button", { name: /^Results$/i }),
-    ).toBeInTheDocument();
+    // The pre-stream preview TraceViewer must be rendered in tools mode with
+    // the expected tool call flattened from turn 2.
+    await waitFor(() => {
+      const props = getLatestTraceViewerProps();
+      expect(props.forcedViewMode).toBe("tools");
+      expect(props.expectedToolCalls).toEqual([
+        { toolName: "some_tool", arguments: {} },
+      ]);
+    });
   });
 
   it("shows the host-style pill only while the chat tab is active", async () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer.test.tsx
@@ -589,6 +589,21 @@ describe("TraceViewer", () => {
     expect(screen.getByText("Actual")).toBeInTheDocument();
   });
 
+  it("shows a loading spinner next to Actual in tools compare view when isLoading", () => {
+    render(
+      <TraceViewer
+        trace={simpleTextTrace}
+        estimatedDurationMs={100}
+        expectedToolCalls={[{ toolName: "a", arguments: {} }]}
+        actualToolCalls={[]}
+        forcedViewMode="tools"
+        isLoading
+      />,
+    );
+    expect(screen.getByTestId("trace-viewer-tools-compare")).toBeInTheDocument();
+    expect(screen.getByTestId("trace-viewer-actual-loading")).toBeInTheDocument();
+  });
+
   it("hides Tools tab when there are no expected or actual tool calls", async () => {
     render(<TraceViewer trace={simpleTextTrace} estimatedDurationMs={100} />);
     expect(await screen.findByText("Estimated total only")).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/evals/eval-trace-surface.tsx
+++ b/mcpjam-inspector/client/src/components/evals/eval-trace-surface.tsx
@@ -31,6 +31,8 @@ interface EvalTraceSurfaceProps {
   traceBlob?: TraceEnvelope | null;
   traceBlobLoading?: boolean;
   traceBlobError?: string | null;
+  /** Run in progress; shows beside "Actual" in Results (tools) mode, same signal as metric spinners. */
+  isLoading?: boolean;
   toolsMetadata: Record<string, Record<string, unknown>>;
   toolServerMap: ToolServerMap;
   connectedServerIds: string[];
@@ -78,6 +80,7 @@ export function EvalTraceSurface({
   traceBlob,
   traceBlobLoading,
   traceBlobError,
+  isLoading = false,
   toolsMetadata,
   toolServerMap,
   connectedServerIds,
@@ -188,6 +191,7 @@ export function EvalTraceSurface({
         <TraceViewer
           trace={activeTrace}
           model={traceModel}
+          isLoading={isLoading}
           toolsMetadata={toolsMetadata}
           toolServerMap={toolServerMap}
           connectedServerIds={connectedServerIds}

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -58,6 +58,7 @@ import {
 } from "./single-test-case-runner";
 import {
   deriveLegacyPromptFields,
+  flattenAssertedExpectedToolCalls,
   resolveIterationDisplayExpectedToolCalls,
   resolvePromptTurns,
   stripPromptTurnsFromAdvancedConfig,
@@ -1247,7 +1248,7 @@ export function TestTemplateEditor({
     compareHandlesInFlightRef.current += 1;
     setIsRunningCompare(true);
     const defaultRunColumnTab: RunColumnTab =
-      (savePayload.expectedToolCalls?.length ?? 0) > 0 ? "tools" : "chat";
+      flattenAssertedExpectedToolCalls(savePayload).length > 0 ? "tools" : "chat";
     setRunColumnTabByModel((previous) => ({
       ...previous,
       ...Object.fromEntries(

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -2659,7 +2659,7 @@ function RunColumn({
       </div>
     )
   ) : record.status === "running" && !record.iteration ? (
-    traceMode === "chat" && activeLiveChatTrace ? (
+    (traceMode === "chat" || traceMode === "tools") && activeLiveChatTrace ? (
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
         <TraceViewer
           trace={activeLiveChatTrace}
@@ -2668,8 +2668,10 @@ function RunColumn({
             name: record.modelLabel,
             provider: record.provider as any,
           }}
-          forcedViewMode="chat"
+          forcedViewMode={traceMode === "tools" ? "tools" : "chat"}
           isLoading={true}
+          expectedToolCalls={expectedToolCalls}
+          actualToolCalls={actualToolCalls}
           toolsMetadata={toolsMetadata}
           toolServerMap={toolServerMap}
           connectedServerIds={connectedServerIds}

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -1246,12 +1246,14 @@ export function TestTemplateEditor({
 
     compareHandlesInFlightRef.current += 1;
     setIsRunningCompare(true);
+    const defaultRunColumnTab: RunColumnTab =
+      (savePayload.expectedToolCalls?.length ?? 0) > 0 ? "tools" : "chat";
     setRunColumnTabByModel((previous) => ({
       ...previous,
       ...Object.fromEntries(
         runModelValues.map((modelValue) => [
           modelValue,
-          "chat" as RunColumnTab,
+          defaultRunColumnTab,
         ]),
       ),
     }));
@@ -2610,6 +2612,7 @@ function RunColumn({
           traceBlob={persistedTraceBlob}
           traceBlobLoading={persistedTraceLoading}
           traceBlobError={persistedTraceError}
+          isLoading={isRunningRecord}
           toolsMetadata={toolsMetadata}
           toolServerMap={toolServerMap}
           connectedServerIds={connectedServerIds}
@@ -2643,7 +2646,7 @@ function RunColumn({
         <TraceViewer
           trace={streamingTraceEnvelope}
           forcedViewMode={traceMode}
-          isLoading={traceMode === "chat" && isRunningRecord}
+          isLoading={isRunningRecord}
           expectedToolCalls={expectedToolCalls}
           actualToolCalls={actualToolCalls}
           toolsMetadata={toolsMetadata}

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -1247,8 +1247,9 @@ export function TestTemplateEditor({
 
     compareHandlesInFlightRef.current += 1;
     setIsRunningCompare(true);
+    const previewExpectedToolCalls = flattenAssertedExpectedToolCalls(savePayload);
     const defaultRunColumnTab: RunColumnTab =
-      flattenAssertedExpectedToolCalls(savePayload).length > 0 ? "tools" : "chat";
+      previewExpectedToolCalls.length > 0 ? "tools" : "chat";
     setRunColumnTabByModel((previous) => ({
       ...previous,
       ...Object.fromEntries(
@@ -1287,6 +1288,7 @@ export function TestTemplateEditor({
           completedAt: null,
           error: null,
           previewTrace: comparePreviewTrace,
+          previewExpectedToolCalls,
         };
       }
       for (const { modelValue, modelLabel, error } of preparationFailures) {
@@ -2383,10 +2385,15 @@ function RunColumn({
         record.completedAt ??
         record.modelValue,
     });
-  const expectedToolCalls = resolveIterationDisplayExpectedToolCalls(
-    record.iteration?.testCaseSnapshot,
-    testCase,
-  );
+  // Prefer the iteration snapshot (authoritative) once available; otherwise
+  // fall back to previewExpectedToolCalls captured from the in-memory form at
+  // run-start so unsaved edits are reflected in showToolsTab / the pre-stream
+  // Results preview before the persisted testCase is updated.
+  const expectedToolCalls = record.iteration?.testCaseSnapshot
+    ? resolveIterationDisplayExpectedToolCalls(record.iteration.testCaseSnapshot, null)
+    : record.previewExpectedToolCalls != null
+      ? record.previewExpectedToolCalls
+      : resolveIterationDisplayExpectedToolCalls(null, testCase);
   const actualToolCalls =
     record.iteration?.actualToolCalls ?? record.streamingActualToolCalls ?? [];
   const showToolsTab =

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
@@ -53,6 +53,10 @@ export type TraceViewerEvalToolCall = {
 interface TraceViewerProps {
   trace: TraceEnvelope | TraceMessage | TraceMessage[] | null;
   model?: ModelDefinition;
+  /**
+   * Chat: forwarded to the transcript `Thread`. Tools (Results): shows a spinner
+   * beside "Actual" while the run is still in progress.
+   */
   isLoading?: boolean;
   toolsMetadata?: Record<string, Record<string, any>>;
   toolServerMap?: ToolServerMap;
@@ -670,8 +674,15 @@ export function TraceViewer({
               )}
             </div>
             <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 rounded-md border border-border/40 bg-muted/10 p-3">
-              <div className="shrink-0 text-xs font-medium text-muted-foreground uppercase">
+              <div className="flex shrink-0 items-center gap-1.5 text-xs font-medium text-muted-foreground uppercase">
                 Actual
+                {isLoading ? (
+                  <Loader2
+                    className="h-3 w-3 shrink-0 animate-spin"
+                    aria-hidden
+                    data-testid="trace-viewer-actual-loading"
+                  />
+                ) : null}
               </div>
               {actualToolCalls.length === 0 ? (
                 <div className="text-xs text-muted-foreground italic">

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -1,4 +1,4 @@
-import type { PromptTurn } from "@/shared/prompt-turns";
+import type { PromptTurn, PromptTurnToolCall } from "@/shared/prompt-turns";
 import type { EvalTraceBlobV1 } from "@/shared/eval-trace";
 import type { EvalStreamToolCall } from "@/shared/eval-stream-events";
 import type { TraceEnvelope, TraceMessage } from "./trace-viewer-adapter";
@@ -155,6 +155,13 @@ export type CompareRunRecord = {
   };
   /** Immediate chat preview shown before the first live stream event arrives. */
   previewTrace?: TraceEnvelope | null;
+  /**
+   * Expected tool calls captured from the in-memory form at run-start time.
+   * Preferred over the persisted testCase snapshot until an iteration snapshot
+   * arrives, so unsaved edits (e.g. adding tools before saving) are reflected
+   * immediately in showToolsTab and the pre-stream Results preview.
+   */
+  previewExpectedToolCalls?: PromptTurnToolCall[] | null;
   /** Stable step-complete trace snapshots populated during streaming. */
   streamingTrace?: EvalTraceBlobV1;
   /** In-flight messages collected after the last authoritative snapshot. */


### PR DESCRIPTION
## Summary

Two UX improvements for **Evaluate → Playground** when you run a case, plus two bug fixes that complete the "Results-first" experience.

---

## Before vs after

### 1) Default tab after Run

| | **Before** | **After** |
|---|------------|-----------|
| **Behavior** | After clicking Run, the compare panel always opened on the **Chat** tab. | If the case has **at least one expected tool call across any prompt turn**, the panel opens on **Results**. |
| **Why the exception** | — | Cases with **no** expected tools still default to **Chat** so the existing streaming preview path keeps working. Negative tests also clear expected tools, so they stay on **Chat**. |

### 2) Loading feedback on Results

| | **Before** | **After** |
|---|------------|-----------|
| **Behavior** | **Latency** and **Tokens** showed spinners while the run was active. The **Results** view showed Expected vs Actual with no extra "still loading" cue next to **Actual**. | Same metric spinners as before. In **Results**, a spinner appears next to the **Actual** label while the run is in progress. |

### 3) Bug fix — multi-turn cases always defaulted to Chat

| | **Before (bug)** | **After (fix)** |
|---|------------|-----------|
| **Scenario** | A case with multiple prompt turns where expected tool calls live on **turn 2+** (turn 1 has none). Click Run → opens on **Chat**. | Correctly opens on **Results**. |
| **Root cause** | `defaultRunColumnTab` checked `savePayload.expectedToolCalls` (from `deriveLegacyPromptFields` — turn 1 only). | Replaced with `flattenAssertedExpectedToolCalls(savePayload)`, which aggregates across **all** turns and respects negative-test semantics. |

### 4) Bug fix — generic "Running…" spinner shown on Results before first stream event

| | **Before (bug)** | **After (fix)** |
|---|------------|-----------|
| **Scenario** | With Results as the default tab, the 1-2 second window before the first stream event showed a generic "Running {model}…" spinner instead of the Expected/Actual panel. | The Expected/Actual panel (with the Actual loading spinner) renders immediately on run start, matching what Chat already did with its preview trace. |
| **Root cause** | The preview branch condition was `traceMode === "chat" && activeLiveChatTrace`. Tools mode fell through to the generic spinner. | Condition extended to `(traceMode === "chat" || traceMode === "tools") && activeLiveChatTrace`; passes `forcedViewMode="tools"`, `expectedToolCalls`, and `actualToolCalls` for the tools path. |

---

## Files touched

- `test-template-editor.tsx` — default tab logic; pre-stream preview for tools mode; `isLoading` wiring
- `trace-viewer.tsx` — Actual spinner in tools compare
- `eval-trace-surface.tsx` — optional `isLoading` prop
- Tests: `trace-viewer.test.tsx`, `test-template-editor-open-compare-route.test.tsx` (new tests for multi-turn regression and tools preview; mock updated to expose `expectedToolCalls` count)

---

## How to verify manually

1. **Case with expected tool calls**: Run → panel opens on **Results** immediately, showing Expected tool calls and an Actual spinner (no "Running…" flash).
2. **Multi-turn case (expected tools on turn 2+)**: Same — opens on **Results**.
3. **While running**: Spinners on **Latency** / **Tokens** and next to **Actual** on **Results**.
4. **No expected tools**: Opens on **Chat** with streaming preview unchanged.

---

## Tests

`npm run test` — all Vitest coverage updated; 15 targeted eval tests pass locally.

Made with [Cursor](https://cursor.com)