### PR TITLE
feat(evals): eval playground UI improvements — shared header, key ordering, style polish

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -1975,7 +1975,6 @@ export function ChatTabV2({
                 {showTopTraceViewTabs ? (
                   <ChatTraceViewModeHeaderBar
                     mode={activeTraceViewMode}
-                    activeVariant="sidebar"
                     onModeChange={(mode) => {
                       if (mode === "tools") {
                         return;
@@ -2189,7 +2188,6 @@ export function ChatTabV2({
                 {showTopTraceViewTabs ? (
                   <ChatTraceViewModeHeaderBar
                     mode={activeTraceViewMode}
-                    activeVariant="sidebar"
                     onModeChange={(mode) => {
                       if (mode === "tools") {
                         return;

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-compare-card-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-compare-card-header.test.tsx
@@ -421,7 +421,7 @@ describe("ModelCompareCardHeader", () => {
     expect(screen.getByText("gpt-4o")).toBeInTheDocument();
   });
 
-  it("shows Pass pill instead of status dot when result is passed", () => {
+  it("shows Passed pill instead of status dot when result is passed", () => {
     render(
       <ModelCompareCardHeader
         model={model}
@@ -440,7 +440,7 @@ describe("ModelCompareCardHeader", () => {
     expect(screen.queryByLabelText("Ready")).not.toBeInTheDocument();
   });
 
-  it("shows Fail pill instead of status dot when result is failed", () => {
+  it("shows Failed pill instead of status dot when result is failed", () => {
     render(
       <ModelCompareCardHeader
         model={model}

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-compare-card-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/model-compare-card-header.test.tsx
@@ -366,4 +366,157 @@ describe("ModelCompareCardHeader", () => {
     expect(screen.getByText("111")).toHaveClass("text-emerald-700");
     expect(screen.getByText("1 tool call")).toHaveClass("text-emerald-700");
   });
+
+  it("shows amber static dot (no pulse) with label Stopped for cancelled status", () => {
+    render(
+      <ModelCompareCardHeader
+        model={model}
+        summary={makeSummary({ status: "cancelled", durationMs: null })}
+        allSummaries={[]}
+        mode="chat"
+        onModeChange={vi.fn()}
+        showTraceTabs={false}
+        showComparisonChrome={true}
+        compactCompareHeader={false}
+      />,
+    );
+
+    const dot = screen.getByRole("img", { name: "Stopped" });
+    expect(dot).toBeInTheDocument();
+    expect(dot).toHaveClass("bg-amber-500/45");
+    expect(dot).not.toHaveClass("animate-pulse");
+  });
+
+  it("uses modelLabel override instead of model.name when provided", () => {
+    render(
+      <ModelCompareCardHeader
+        model={model}
+        modelLabel="My Custom Label"
+        summary={idleSummary}
+        allSummaries={[]}
+        mode="chat"
+        onModeChange={vi.fn()}
+        showTraceTabs={false}
+        showComparisonChrome={true}
+      />,
+    );
+
+    expect(screen.getByText("My Custom Label")).toBeInTheDocument();
+    expect(screen.queryByText(/Claude Haiku/)).not.toBeInTheDocument();
+  });
+
+  it("renders modelLabel without a model prop", () => {
+    render(
+      <ModelCompareCardHeader
+        modelLabel="gpt-4o"
+        summary={idleSummary}
+        allSummaries={[]}
+        mode="chat"
+        onModeChange={vi.fn()}
+        showTraceTabs={false}
+        showComparisonChrome={true}
+      />,
+    );
+
+    expect(screen.getByText("gpt-4o")).toBeInTheDocument();
+  });
+
+  it("shows Pass pill instead of status dot when result is passed", () => {
+    render(
+      <ModelCompareCardHeader
+        model={model}
+        summary={makeSummary({ status: "ready" })}
+        allSummaries={[]}
+        mode="chat"
+        onModeChange={vi.fn()}
+        showTraceTabs={false}
+        showComparisonChrome={true}
+        compactCompareHeader={false}
+        result="passed"
+      />,
+    );
+
+    expect(screen.getByText("Passed")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Ready")).not.toBeInTheDocument();
+  });
+
+  it("shows Fail pill instead of status dot when result is failed", () => {
+    render(
+      <ModelCompareCardHeader
+        model={model}
+        summary={makeSummary({ status: "error" })}
+        allSummaries={[]}
+        mode="chat"
+        onModeChange={vi.fn()}
+        showTraceTabs={false}
+        showComparisonChrome={true}
+        compactCompareHeader={false}
+        result="failed"
+      />,
+    );
+
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.queryByRole("img", { name: "Failed" })).not.toBeInTheDocument();
+  });
+
+  it("renders inline tabs with Results tab and actionsSlot when tabsInline is true", () => {
+    const handleModeChange = vi.fn();
+    render(
+      <ModelCompareCardHeader
+        model={model}
+        summary={idleSummary}
+        allSummaries={[]}
+        mode="tools"
+        onModeChange={handleModeChange}
+        showTraceTabs={true}
+        showComparisonChrome={true}
+        tabsInline={true}
+        showToolsTab={true}
+        actionsSlot={<button type="button">Retry</button>}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Results/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Trace/i })).toBeInTheDocument();
+  });
+
+  it("renders full-width ChatTraceViewModeHeaderBar when tabsInline is false", () => {
+    render(
+      <ModelCompareCardHeader
+        model={model}
+        summary={idleSummary}
+        allSummaries={[]}
+        mode="chat"
+        onModeChange={vi.fn()}
+        showTraceTabs={true}
+        showComparisonChrome={true}
+        tabsInline={false}
+      />,
+    );
+
+    expect(screen.getByTitle("Trace")).toBeInTheDocument();
+    expect(screen.queryByText("Results")).not.toBeInTheDocument();
+  });
+
+  it("renders footerNote content below the metric bars", () => {
+    render(
+      <ModelCompareCardHeader
+        model={model}
+        summary={idleSummary}
+        allSummaries={[]}
+        mode="chat"
+        onModeChange={vi.fn()}
+        showTraceTabs={false}
+        showComparisonChrome={true}
+        footerNote={<>2 mismatches across expected tool calls.</>}
+      />,
+    );
+
+    expect(
+      screen.getByText("2 mismatches across expected tool calls."),
+    ).toBeInTheDocument();
+  });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/model-compare-card-header.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/model-compare-card-header.tsx
@@ -343,7 +343,6 @@ export function ModelCompareCardHeader({
       {showTraceTabs && !tabsInline ? (
         <ChatTraceViewModeHeaderBar
           mode={mode}
-          activeVariant="sidebar"
           onModeChange={onModeChange}
           className={!showComparisonChrome ? className : undefined}
         />

--- a/mcpjam-inspector/client/src/components/chat-v2/model-compare-card-header.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/model-compare-card-header.tsx
@@ -1,12 +1,19 @@
+import { type ReactNode } from "react";
 import { Loader2 } from "lucide-react";
 import type { ModelDefinition } from "@/shared/types";
 import {
   ChatTraceViewModeHeaderBar,
+  TraceViewModeTabs,
   type TraceViewMode,
 } from "@/components/evals/trace-view-mode-tabs";
 import { cn } from "@/lib/utils";
 
-export type MultiModelCardStatus = "idle" | "ready" | "running" | "error";
+export type MultiModelCardStatus =
+  | "idle"
+  | "ready"
+  | "running"
+  | "error"
+  | "cancelled";
 
 export interface MultiModelCardSummary {
   modelId: string;
@@ -31,6 +38,7 @@ function formatCardDuration(durationMs: number | null): string {
 
 export function ModelCompareCardHeader({
   model,
+  modelLabel: modelLabelProp,
   summary,
   allSummaries,
   mode,
@@ -39,22 +47,45 @@ export function ModelCompareCardHeader({
   showComparisonChrome = true,
   /** When true (default), hides the status dot and Tools row — latency/tokens only. Set false for full compare metrics. */
   compactCompareHeader = true,
+  result,
+  showToolsTab = false,
+  tabsInline = false,
+  actionsSlot,
+  footerNote,
   className,
 }: {
-  model: ModelDefinition;
+  /** Full model definition (used in Chat multi-model). Optional when `modelLabel` is provided. */
+  model?: ModelDefinition;
+  /** Override for the displayed model name; takes precedence over `model.name`. */
+  modelLabel?: string;
   summary: MultiModelCardSummary | null;
   allSummaries: MultiModelCardSummary[];
-  mode: "chat" | "timeline" | "raw";
-  onModeChange: (mode: "chat" | "timeline" | "raw") => void;
+  mode: TraceViewMode;
+  onModeChange: (mode: TraceViewMode) => void;
   showTraceTabs: boolean;
   /** When false, hides model title and Latency/Tokens/Tools rows (single-model-in-compare mode). */
   showComparisonChrome?: boolean;
   compactCompareHeader?: boolean;
+  /** When set, shows a Pass/Fail pill instead of the status dot. */
+  result?: "passed" | "failed" | null;
+  /** Include a Results tab alongside Trace/Chat/Raw. Only applies when `tabsInline` is true. */
+  showToolsTab?: boolean;
+  /**
+   * When true, tabs are rendered inline inside the metrics block (with `actionsSlot`) rather
+   * than as a full-width strip below it. Use this for eval playground cards.
+   */
+  tabsInline?: boolean;
+  /** Extra action buttons placed to the right of the inline tab strip. */
+  actionsSlot?: ReactNode;
+  /** Short note shown below the metrics block (e.g. mismatch count). */
+  footerNote?: ReactNode;
   className?: string;
 }) {
   if (!showComparisonChrome && !showTraceTabs) {
     return null;
   }
+
+  const displayName = modelLabelProp ?? model?.name ?? "";
 
   const isErroredSummary = summary?.status === "error";
   const comparableSummaries = allSummaries.filter(
@@ -117,19 +148,23 @@ export function ModelCompareCardHeader({
   const statusIndicatorClass =
     summary?.status === "running"
       ? "size-3 bg-amber-500/45 dark:bg-amber-400/40 animate-pulse motion-reduce:animate-none"
-      : summary?.status === "error"
-        ? "size-3 bg-rose-500/45 dark:bg-rose-400/40"
-        : summary?.status === "ready"
-          ? "size-3 bg-primary/22 dark:bg-primary/20"
-          : "size-3 bg-muted";
+      : summary?.status === "cancelled"
+        ? "size-3 bg-amber-500/45 dark:bg-amber-400/40"
+        : summary?.status === "error"
+          ? "size-3 bg-rose-500/45 dark:bg-rose-400/40"
+          : summary?.status === "ready"
+            ? "size-3 bg-primary/22 dark:bg-primary/20"
+            : "size-3 bg-muted";
   const statusLabel =
     summary?.status === "running"
       ? "Running"
-      : summary?.status === "error"
-        ? "Failed"
-        : summary?.status === "ready"
-          ? "Ready"
-          : "Idle";
+      : summary?.status === "cancelled"
+        ? "Stopped"
+        : summary?.status === "error"
+          ? "Failed"
+          : summary?.status === "ready"
+            ? "Ready"
+            : "Idle";
   const toolCallLabel =
     currentToolCount === 1 ? "1 tool call" : `${currentToolCount} tool calls`;
 
@@ -139,17 +174,32 @@ export function ModelCompareCardHeader({
         <div
           className={cn(
             "shrink-0 border-b border-border/60 px-3 py-2",
-            showTraceTabs && "border-b-0",
+            showTraceTabs && !tabsInline && "border-b-0",
             className,
           )}
         >
           <div className="flex items-start justify-between gap-2">
-            <div className="min-w-0">
+            <div className="flex min-w-0 items-center gap-1.5">
               <div className="truncate text-sm font-semibold leading-tight">
-                {model.name}
+                {displayName}
               </div>
+              {!compactCompareHeader && result === "passed" ? (
+                <span
+                  className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-emerald-500/15 text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-300"
+                  aria-label="Passed"
+                >
+                  Passed
+                </span>
+              ) : !compactCompareHeader && result === "failed" ? (
+                <span
+                  className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-rose-500/15 text-rose-700 dark:bg-rose-400/20 dark:text-rose-300"
+                  aria-label="Failed"
+                >
+                  Failed
+                </span>
+              ) : null}
             </div>
-            {!compactCompareHeader ? (
+            {!compactCompareHeader && result == null ? (
               <span
                 role="img"
                 className={cn(
@@ -182,7 +232,7 @@ export function ModelCompareCardHeader({
                         "h-full rounded-sm transition-all duration-300",
                         isFastest
                           ? "bg-emerald-500/25 dark:bg-emerald-400/20"
-                          : "bg-primary/10",
+                          : "bg-sidebar-accent",
                       )}
                       style={{
                         width: `${hasComparison ? durationBarPct : 100}%`,
@@ -222,7 +272,7 @@ export function ModelCompareCardHeader({
                         "h-full rounded-sm transition-all duration-300",
                         isFewestTokens
                           ? "bg-emerald-500/25 dark:bg-emerald-400/20"
-                          : "bg-primary/10",
+                          : "bg-sidebar-accent",
                       )}
                       style={{
                         width: `${hasComparison ? tokensBarPct : 100}%`,
@@ -261,19 +311,36 @@ export function ModelCompareCardHeader({
               </div>
             ) : null}
           </div>
+
+          {showTraceTabs && tabsInline ? (
+            <div className="mt-1.5 flex flex-wrap items-center justify-between gap-2">
+              <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                <TraceViewModeTabs
+                  mode={mode}
+                  onModeChange={onModeChange}
+                  showToolsTab={showToolsTab}
+                  className="[&_button]:px-1.5 [&_button]:py-0.5 [&_button]:text-[11px] [&_svg]:h-3 [&_svg]:w-3"
+                />
+              </div>
+              {actionsSlot ? (
+                <div className="flex items-center gap-1">{actionsSlot}</div>
+              ) : null}
+            </div>
+          ) : null}
+
+          {footerNote ? (
+            <div className="mt-1.5 text-[10px] leading-snug text-muted-foreground">
+              {footerNote}
+            </div>
+          ) : null}
         </div>
       ) : null}
 
-      {showTraceTabs ? (
+      {showTraceTabs && !tabsInline ? (
         <ChatTraceViewModeHeaderBar
-          mode={mode as TraceViewMode}
+          mode={mode}
           activeVariant="sidebar"
-          onModeChange={(nextMode) => {
-            if (nextMode === "tools") {
-              return;
-            }
-            onModeChange(nextMode as typeof mode);
-          }}
+          onModeChange={onModeChange}
           className={!showComparisonChrome ? className : undefined}
         />
       ) : null}

--- a/mcpjam-inspector/client/src/components/chat-v2/model-compare-card-header.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/model-compare-card-header.tsx
@@ -87,10 +87,14 @@ export function ModelCompareCardHeader({
 
   const displayName = modelLabelProp ?? model?.name ?? "";
 
-  const isErroredSummary = summary?.status === "error";
+  const isNonComparableSummary =
+    summary?.status === "error" || summary?.status === "cancelled";
   const comparableSummaries = allSummaries.filter(
     (item) =>
-      item.status !== "error" && item.durationMs != null && item.durationMs > 0,
+      item.status !== "error" &&
+      item.status !== "cancelled" &&
+      item.durationMs != null &&
+      item.durationMs > 0,
   );
   const durationValues = comparableSummaries
     .map((item) => item.durationMs ?? 0)
@@ -121,17 +125,17 @@ export function ModelCompareCardHeader({
 
   const isFastest =
     canHighlightWinner &&
-    !isErroredSummary &&
+    !isNonComparableSummary &&
     currentDuration > 0 &&
     currentDuration === minDuration;
   const isFewestTokens =
     canHighlightWinner &&
-    !isErroredSummary &&
+    !isNonComparableSummary &&
     currentTokens > 0 &&
     currentTokens === minTokens;
   const isFewestTools =
     canHighlightWinner &&
-    !isErroredSummary &&
+    !isNonComparableSummary &&
     currentToolCount > 0 &&
     currentToolCount === minToolCount;
   const isRunningSummary = summary?.status === "running";

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-cases-overview.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-cases-overview.test.tsx
@@ -112,7 +112,7 @@ describe("TestCasesOverview", () => {
     const row = await screen.findByTestId("test-case-row-case-1");
 
     await waitFor(() => {
-      expect(within(row).getByText("Passed")).toBeInTheDocument();
+      expect(within(row).getByLabelText("Passed")).toBeInTheDocument();
     });
 
     expect(within(row).queryByText(/^1$/)).not.toBeInTheDocument();
@@ -171,7 +171,7 @@ describe("TestCasesOverview", () => {
       expect(within(row).getByText("Failed")).toBeInTheDocument();
     });
     expect(within(row).getByLabelText("Last run failed")).toBeInTheDocument();
-    expect(within(row).queryByText("Passed")).not.toBeInTheDocument();
+    expect(within(row).queryByLabelText("Passed")).not.toBeInTheDocument();
   });
 
   it("does not show the failure indicator when the latest iteration passed", async () => {
@@ -220,7 +220,7 @@ describe("TestCasesOverview", () => {
     const row = await screen.findByTestId("test-case-row-case-1");
 
     await waitFor(() => {
-      expect(within(row).getByText("Passed")).toBeInTheDocument();
+      expect(within(row).getByLabelText("Passed")).toBeInTheDocument();
     });
     expect(
       within(row).queryByLabelText("Last run failed"),
@@ -276,7 +276,7 @@ describe("TestCasesOverview", () => {
       />,
     );
 
-    await user.click(screen.getByText("Passed"));
+    await user.click(screen.getByLabelText("Passed"));
 
     expect(onTestCaseClick).toHaveBeenCalledTimes(1);
     expect(onTestCaseClick).toHaveBeenCalledWith("case-1");

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-cases-overview.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-cases-overview.test.tsx
@@ -168,7 +168,7 @@ describe("TestCasesOverview", () => {
     const row = await screen.findByTestId("test-case-row-case-1");
 
     await waitFor(() => {
-      expect(within(row).getByText("Failed")).toBeInTheDocument();
+      expect(within(row).getByLabelText("Failed")).toBeInTheDocument();
     });
     expect(within(row).getByLabelText("Last run failed")).toBeInTheDocument();
     expect(within(row).queryByLabelText("Passed")).not.toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-view-mode-tabs.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-view-mode-tabs.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { TraceViewModeTabs } from "../trace-view-mode-tabs";
 
 describe("TraceViewModeTabs", () => {
-  it("keeps the default active styling when no variant is requested", () => {
+  it("uses sidebar-accent active styling for the selected tab (default)", () => {
     render(
       <TraceViewModeTabs
         mode="chat"
@@ -13,12 +13,12 @@ describe("TraceViewModeTabs", () => {
     );
 
     expect(screen.getByRole("button", { name: "Chat" })).toHaveClass(
-      "bg-primary/10",
-      "text-foreground",
+      "bg-sidebar-accent",
+      "text-sidebar-accent-foreground",
     );
   });
 
-  it("can opt into the sidebar active styling when explicitly requested", () => {
+  it("matches the same active styling when activeVariant is sidebar", () => {
     render(
       <TraceViewModeTabs
         mode="chat"

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-view-mode-tabs.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-view-mode-tabs.test.tsx
@@ -18,13 +18,13 @@ describe("TraceViewModeTabs", () => {
     );
   });
 
-  it("matches the same active styling when activeVariant is sidebar", () => {
+  it("matches the same active styling in fullWidth layout", () => {
     render(
       <TraceViewModeTabs
         mode="chat"
         onModeChange={vi.fn()}
         showToolsTab={false}
-        activeVariant="sidebar"
+        layout="fullWidth"
       />,
     );
 

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer.test.tsx
@@ -604,6 +604,37 @@ describe("TraceViewer", () => {
     expect(screen.getByTestId("trace-viewer-actual-loading")).toBeInTheDocument();
   });
 
+  it("normalises actual tool call key order so toolName always precedes arguments", async () => {
+    // Build the entry with arguments appearing BEFORE toolName (via JSON.parse,
+    // which preserves property order) so the test fails unless TraceViewer
+    // normalises the key order at render time.
+    const argsFirstEntry = JSON.parse(
+      '{"arguments": {"path": "/x"}, "toolName": "read_me"}',
+    ) as { toolName: string; arguments: Record<string, unknown> };
+
+    // Sanity check: the input really does have arguments first.
+    expect(Object.keys(argsFirstEntry)).toEqual(["arguments", "toolName"]);
+
+    render(
+      <TraceViewer
+        trace={simpleTextTrace}
+        estimatedDurationMs={100}
+        expectedToolCalls={[{ toolName: "read_me", arguments: {} }]}
+        actualToolCalls={[argsFirstEntry]}
+        forcedViewMode="tools"
+      />,
+    );
+
+    const editors = screen.getAllByTestId("json-editor");
+    const actualEditor = editors[1];
+    const serialized = actualEditor.textContent ?? "";
+    const toolNameIdx = serialized.indexOf('"toolName"');
+    const argumentsIdx = serialized.indexOf('"arguments"');
+    expect(toolNameIdx).toBeGreaterThanOrEqual(0);
+    expect(argumentsIdx).toBeGreaterThanOrEqual(0);
+    expect(toolNameIdx).toBeLessThan(argumentsIdx);
+  });
+
   it("hides Tools tab when there are no expected or actual tool calls", async () => {
     render(<TraceViewer trace={simpleTextTrace} estimatedDurationMs={100} />);
     expect(await screen.findByText("Estimated total only")).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
@@ -451,9 +451,21 @@ export function TestCasesOverview({
                   Passed
                 </span>
               );
+              const failBadge = (
+                <span
+                  className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-rose-500/15 text-rose-700 dark:bg-rose-400/20 dark:text-rose-300"
+                  aria-label="Failed"
+                >
+                  Failed
+                </span>
+              );
               const lastRunSummary = lastRunIteration ? (
                 <>
-                  {lastRunResult === "passed" ? passBadge : lastRunLabel}
+                  {lastRunResult === "passed"
+                    ? passBadge
+                    : lastRunResult === "failed"
+                      ? failBadge
+                      : lastRunLabel}
                   {lastRunTimestamp ? (
                     <span className="font-normal">
                       {" "}

--- a/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-cases-overview.tsx
@@ -443,9 +443,17 @@ export function TestCasesOverview({
                 : null;
               const showLastRunFailed = lastRunResult === "failed";
               const caseTitle = testCase.title || "Untitled test case";
+              const passBadge = (
+                <span
+                  className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-emerald-500/15 text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-300"
+                  aria-label="Passed"
+                >
+                  Passed
+                </span>
+              );
               const lastRunSummary = lastRunIteration ? (
                 <>
-                  {lastRunLabel}
+                  {lastRunResult === "passed" ? passBadge : lastRunLabel}
                   {lastRunTimestamp ? (
                     <span className="font-normal">
                       {" "}

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -1461,6 +1461,24 @@ export function TestTemplateEditor({
               let resolved!: CompareRunRecord;
               setCompareRunRecords((previous) => {
                 const existing = previous[modelValue];
+                // Guard against a stale abort overwriting a newer retry: if
+                // the request generation for this model no longer matches
+                // the one that started this attempt, another run has
+                // superseded us and we must not persist a "cancelled" record
+                // over the newer run's state.
+                if (
+                  compareRequestGenByModelRef.current[modelValue] !== myGen
+                ) {
+                  resolved =
+                    existing ??
+                    buildCompareRunRecord({
+                      modelValue,
+                      modelLabel,
+                      iteration: null,
+                      completedAt: Date.now(),
+                    });
+                  return previous;
+                }
                 const base = buildCompareRunRecord({
                   modelValue,
                   modelLabel,
@@ -2324,6 +2342,7 @@ export function TestTemplateEditor({
                         testCase={currentTestCase}
                         serverNames={connectedServerList}
                         workspaceId={workspaceId}
+                        onContinueInChat={onContinueInChat}
                         onStreamingTraceLoaded={() =>
                           clearCompareStreamingState(record.modelValue)
                         }

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -2342,7 +2342,6 @@ export function TestTemplateEditor({
                         testCase={currentTestCase}
                         serverNames={connectedServerList}
                         workspaceId={workspaceId}
-                        onContinueInChat={onContinueInChat}
                         onStreamingTraceLoaded={() =>
                           clearCompareStreamingState(record.modelValue)
                         }

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -44,7 +44,10 @@ import {
 import { TestCasePromptFlow } from "./test-case-prompt-flow";
 import { CompareRunChatSurface } from "./compare-run-chat-surface";
 import { EvalTraceSurface } from "./eval-trace-surface";
-import { TraceViewModeTabs } from "./trace-view-mode-tabs";
+import {
+  ModelCompareCardHeader,
+  type MultiModelCardSummary,
+} from "@/components/chat-v2/model-compare-card-header";
 import { useAiProviderKeys } from "@/hooks/use-ai-provider-keys";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
 import type { ModelDefinition } from "@/shared/types";
@@ -2402,35 +2405,6 @@ function RunColumn({
   const effectiveActiveTab: RunColumnTab =
     activeTab === "tools" && !showToolsTab ? "timeline" : activeTab;
 
-  /** Status marker: pastel fills aligned with metric bar accent colors. */
-  const statusIndicatorClass =
-    record.status === "running"
-      ? "size-3 bg-amber-500/45 dark:bg-amber-400/40 animate-pulse motion-reduce:animate-none"
-      : record.status === "cancelled" || record.result === "cancelled"
-        ? "size-3 bg-amber-500/45 dark:bg-amber-400/40"
-        : record.status === "failed" || record.result === "failed"
-          ? "size-3 bg-rose-500/45 dark:bg-rose-400/40"
-          : record.result === "passed"
-            ? "size-3 bg-emerald-500/45 dark:bg-emerald-400/40"
-            : "size-3 bg-primary/22 dark:bg-primary/20";
-  const statusLabel =
-    record.status === "running"
-      ? record.isRetrying
-        ? "Retrying"
-        : "Running"
-      : record.status === "cancelled" || record.result === "cancelled"
-        ? "Stopped"
-        : record.status === "failed"
-          ? "Failed"
-          : record.result === "passed"
-            ? "Passed"
-            : record.result === "failed"
-              ? "Failed"
-              : "Ready";
-  const durationLabel =
-    record.metrics.durationMs != null
-      ? `${Math.round(record.metrics.durationMs / 100) / 10}s`
-      : "—";
   const traceMode =
     effectiveActiveTab === "chat"
       ? "chat"
@@ -2523,69 +2497,53 @@ function RunColumn({
     record.streamingMetrics?.tokensUsed ?? record.metrics.tokensUsed;
   const toolCount =
     record.streamingMetrics?.toolCallCount ?? record.metrics.toolCallCount;
-  const toolCallLabel =
-    toolCount === 1 ? "1 tool call" : `${toolCount} tool calls`;
-  const isFailedCompareRecord =
-    record.status === "failed" || record.result === "failed";
   const isRunningRecord = record.status === "running";
 
-  // Compute relative metrics across all completed records for comparison bars
-  const comparableRecords = allRecords.filter(
-    (r) =>
-      r.status !== "failed" &&
-      r.result !== "failed" &&
-      r.metrics.durationMs != null &&
-      r.metrics.durationMs > 0 &&
-      (r.status === "completed" || r.iteration != null),
-  );
-  const allDurations = comparableRecords
-    .map((r) => r.metrics.durationMs!)
-    .filter(Boolean);
-  const allTokens = comparableRecords
-    .map((r) => r.metrics.tokensUsed)
-    .filter((t) => t > 0);
-  const allToolCounts = comparableRecords
-    .map((r) => r.metrics.toolCallCount)
-    .filter((t) => t > 0);
+  const toSummaryStatus = (
+    r: CompareRunRecord,
+  ): MultiModelCardSummary["status"] => {
+    if (r.status === "running") return "running";
+    if (r.status === "cancelled" || r.result === "cancelled") return "cancelled";
+    if (r.status === "failed" || r.result === "failed") return "error";
+    if (r.iteration != null || r.status === "completed") return "ready";
+    return "idle";
+  };
 
-  const maxDuration = allDurations.length > 0 ? Math.max(...allDurations) : 0;
-  const minDuration = allDurations.length > 0 ? Math.min(...allDurations) : 0;
-  const maxTokens = allTokens.length > 0 ? Math.max(...allTokens) : 0;
-  const minTokens = allTokens.length > 0 ? Math.min(...allTokens) : 0;
-  const minToolCount =
-    allToolCounts.length > 0 ? Math.min(...allToolCounts) : 0;
+  const runColumnSummary: MultiModelCardSummary = {
+    modelId: record.modelValue,
+    durationMs: record.metrics.durationMs,
+    tokens: displayTokens,
+    toolCount,
+    status: toSummaryStatus(record),
+    hasMessages:
+      record.iteration != null ||
+      record.streamingTrace != null ||
+      (record.streamingDraftMessages?.length ?? 0) > 0,
+  };
 
-  const currentDuration = record.metrics.durationMs ?? 0;
-  const hasComparison = comparableRecords.length > 1;
-  const hasAnyRunningRecord = allRecords.some(
-    (item) => item.status === "running",
-  );
-  const canHighlightWinner = hasComparison && !hasAnyRunningRecord;
+  const allRunSummaries: MultiModelCardSummary[] = allRecords.map((r) => {
+    const rTokens = r.streamingMetrics?.tokensUsed ?? r.metrics.tokensUsed;
+    const rToolCount =
+      r.streamingMetrics?.toolCallCount ?? r.metrics.toolCallCount;
+    return {
+      modelId: r.modelValue,
+      durationMs: r.metrics.durationMs,
+      tokens: rTokens,
+      toolCount: rToolCount,
+      status: toSummaryStatus(r),
+      hasMessages:
+        r.iteration != null ||
+        r.streamingTrace != null ||
+        (r.streamingDraftMessages?.length ?? 0) > 0,
+    };
+  });
 
-  const isFastest =
-    canHighlightWinner &&
-    !isFailedCompareRecord &&
-    currentDuration === minDuration &&
-    currentDuration > 0;
-  const isFewestTokens =
-    canHighlightWinner &&
-    !isFailedCompareRecord &&
-    displayTokens === minTokens &&
-    displayTokens > 0;
-  const isFewestTools =
-    canHighlightWinner &&
-    !isFailedCompareRecord &&
-    toolCount === minToolCount &&
-    toolCount > 0;
-
-  const durationBarPct =
-    maxDuration > 0
-      ? Math.min(100, Math.max(4, (currentDuration / maxDuration) * 100))
-      : 0;
-  const tokensBarPct =
-    maxTokens > 0
-      ? Math.min(100, Math.max(4, (displayTokens / maxTokens) * 100))
-      : 0;
+  const runColumnResult: "passed" | "failed" | null =
+    record.result === "passed"
+      ? "passed"
+      : record.result === "failed" || record.status === "failed"
+        ? "failed"
+        : null;
   const renderedRunContent = record.iteration ? (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col">
       {traceMode === "chat" ? (
@@ -2732,147 +2690,20 @@ function RunColumn({
 
   return (
     <div className="flex h-auto min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl border border-border/60 bg-card/40 lg:h-full">
-      <div className="shrink-0 border-b px-3 py-2">
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex min-w-0 items-center gap-1.5">
-            <div className="truncate text-sm font-semibold leading-tight">
-              {record.modelLabel}
-            </div>
-            {record.result === "passed" ? (
-              <span className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-emerald-500/15 text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-300" aria-label={statusLabel}>
-                Pass
-              </span>
-            ) : record.result === "failed" || record.status === "failed" ? (
-              <span className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-rose-500/15 text-rose-700 dark:bg-rose-400/20 dark:text-rose-300" aria-label={statusLabel}>
-                Fail
-              </span>
-            ) : null}
-          </div>
-          {record.result !== "passed" &&
-          record.result !== "failed" &&
-          record.status !== "failed" ? (
-            <span
-              role="img"
-              className={cn(
-                "inline-flex shrink-0 rounded-full",
-                statusIndicatorClass,
-              )}
-              aria-label={statusLabel}
-              title={statusLabel}
-            />
-          ) : null}
-        </div>
-
-        {/* Metric comparison bars */}
-        <div className="mt-2 space-y-1.5">
-          {/* Latency */}
-          <div className="flex items-center gap-2">
-            <span className="flex w-[52px] shrink-0 items-center gap-1 text-[10px] text-muted-foreground">
-              <span>Latency</span>
-              {isRunningRecord ? (
-                <Loader2
-                  data-testid="metric-running-spinner"
-                  className="h-3 w-3 shrink-0 animate-spin"
-                  aria-hidden
-                />
-              ) : null}
-            </span>
-            <div className="relative flex min-w-0 flex-1 items-center">
-              <div className="h-[14px] w-full rounded-sm bg-muted/40 overflow-hidden">
-                {currentDuration > 0 && (
-                  <div
-                    className={cn(
-                      "h-full rounded-sm transition-all duration-300",
-                      isFastest
-                        ? "bg-emerald-500/25 dark:bg-emerald-400/20"
-                        : "bg-primary/10",
-                    )}
-                    style={{
-                      width: `${hasComparison ? durationBarPct : 100}%`,
-                    }}
-                  />
-                )}
-              </div>
-              <span
-                className={cn(
-                  "absolute inset-0 flex items-center px-1.5 text-[10px] font-medium tabular-nums",
-                  isFastest
-                    ? "text-emerald-700 dark:text-emerald-400"
-                    : "text-foreground",
-                )}
-              >
-                {durationLabel}
-              </span>
-            </div>
-          </div>
-
-          {/* Tokens */}
-          <div className="flex items-center gap-2">
-            <span className="flex w-[52px] shrink-0 items-center gap-1 text-[10px] text-muted-foreground">
-              <span>Tokens</span>
-              {isRunningRecord ? (
-                <Loader2
-                  data-testid="metric-running-spinner"
-                  className="h-3 w-3 shrink-0 animate-spin"
-                  aria-hidden
-                />
-              ) : null}
-            </span>
-            <div className="relative flex min-w-0 flex-1 items-center">
-              <div className="h-[14px] w-full rounded-sm bg-muted/40 overflow-hidden">
-                {displayTokens > 0 && (
-                  <div
-                    className={cn(
-                      "h-full rounded-sm transition-all duration-300",
-                      isFewestTokens
-                        ? "bg-emerald-500/25 dark:bg-emerald-400/20"
-                        : "bg-primary/10",
-                    )}
-                    style={{ width: `${hasComparison ? tokensBarPct : 100}%` }}
-                  />
-                )}
-              </div>
-              <span
-                className={cn(
-                  "absolute inset-0 flex items-center px-1.5 text-[10px] font-medium tabular-nums",
-                  isFewestTokens
-                    ? "text-emerald-700 dark:text-emerald-400"
-                    : "text-foreground",
-                )}
-              >
-                {displayTokens.toLocaleString()}
-              </span>
-            </div>
-          </div>
-
-          {/* Tool Calls */}
-          <div className="flex items-center gap-2">
-            <span className="w-[52px] shrink-0 text-[10px] text-muted-foreground">
-              Tools
-            </span>
-            <span
-              className={cn(
-                "text-[10px] font-medium tabular-nums px-1.5",
-                isFewestTools
-                  ? "text-emerald-700 dark:text-emerald-400"
-                  : "text-foreground",
-              )}
-            >
-              {toolCallLabel}
-            </span>
-          </div>
-        </div>
-
-        <div className="mt-1.5 flex flex-wrap items-center justify-between gap-2">
-          <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-            <TraceViewModeTabs
-              mode={effectiveActiveTab}
-              onModeChange={onTabChange}
-              showToolsTab={showToolsTab}
-              className="[&_button]:px-1.5 [&_button]:py-0.5 [&_button]:text-[11px] [&_svg]:h-3 [&_svg]:w-3"
-            />
-          </div>
-          <div className="flex items-center gap-1">
+      <ModelCompareCardHeader
+        modelLabel={record.modelLabel}
+        summary={runColumnSummary}
+        allSummaries={allRunSummaries}
+        mode={effectiveActiveTab}
+        onModeChange={onTabChange}
+        showTraceTabs
+        showComparisonChrome
+        compactCompareHeader={false}
+        result={runColumnResult}
+        showToolsTab={showToolsTab}
+        tabsInline
+        actionsSlot={
+          <>
             {onContinueInChat ? (
               <Button
                 type="button"
@@ -2911,18 +2742,19 @@ function RunColumn({
               />
               Retry
             </Button>
-          </div>
-        </div>
-
-        {record.metrics.mismatchCount != null &&
-        record.metrics.mismatchCount > 0 ? (
-          <div className="mt-1.5 text-[10px] leading-snug text-muted-foreground">
-            {record.metrics.mismatchCount} mismatch
-            {record.metrics.mismatchCount === 1 ? "" : "es"} across expected
-            tool calls.
-          </div>
-        ) : null}
-      </div>
+          </>
+        }
+        footerNote={
+          record.metrics.mismatchCount != null &&
+          record.metrics.mismatchCount > 0 ? (
+            <>
+              {record.metrics.mismatchCount} mismatch
+              {record.metrics.mismatchCount === 1 ? "" : "es"} across expected
+              tool calls.
+            </>
+          ) : null
+        }
+      />
 
       <div className="flex min-w-0 max-lg:min-h-[min(52vh,26rem)] flex-1 flex-col overflow-hidden p-3 lg:min-h-0">
         {shouldRenderChatShell ? (

--- a/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
@@ -14,7 +14,7 @@ export function TraceViewModeTabs({
   onModeChange,
   showToolsTab,
   layout = "default",
-  activeVariant = "default",
+  activeVariant: _activeVariant = "default",
   className,
 }: {
   mode: TraceViewMode;
@@ -22,6 +22,7 @@ export function TraceViewModeTabs({
   showToolsTab: boolean;
   /** `fullWidth`: equal-width segments across the container (e.g. chat trace header). */
   layout?: "default" | "fullWidth";
+  /** Retained for compatibility; active tab always uses sidebar-accent styling. */
   activeVariant?: "default" | "sidebar";
   className?: string;
 }) {
@@ -41,9 +42,7 @@ export function TraceViewModeTabs({
       "inline-flex min-w-0 items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors",
       fullWidth && "min-h-8 flex-1 basis-0 justify-center",
       active
-        ? activeVariant === "sidebar"
-          ? "bg-sidebar-accent font-medium text-sidebar-accent-foreground"
-          : "bg-primary/10 font-medium text-foreground"
+        ? "bg-sidebar-accent font-medium text-sidebar-accent-foreground"
         : "text-muted-foreground hover:text-foreground",
     );
 

--- a/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-view-mode-tabs.tsx
@@ -14,7 +14,6 @@ export function TraceViewModeTabs({
   onModeChange,
   showToolsTab,
   layout = "default",
-  activeVariant: _activeVariant = "default",
   className,
 }: {
   mode: TraceViewMode;
@@ -22,8 +21,6 @@ export function TraceViewModeTabs({
   showToolsTab: boolean;
   /** `fullWidth`: equal-width segments across the container (e.g. chat trace header). */
   layout?: "default" | "fullWidth";
-  /** Retained for compatibility; active tab always uses sidebar-accent styling. */
-  activeVariant?: "default" | "sidebar";
   className?: string;
 }) {
   const fullWidth = layout === "fullWidth";
@@ -104,12 +101,10 @@ export function TraceViewModeTabs({
 export function ChatTraceViewModeHeaderBar({
   mode,
   onModeChange,
-  activeVariant = "default",
   className,
 }: {
   mode: TraceViewMode;
   onModeChange: (mode: TraceViewMode) => void;
-  activeVariant?: "default" | "sidebar";
   className?: string;
 }) {
   return (
@@ -125,7 +120,6 @@ export function ChatTraceViewModeHeaderBar({
           mode={mode}
           onModeChange={onModeChange}
           showToolsTab={false}
-          activeVariant={activeVariant}
         />
       </div>
     </div>

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
@@ -691,6 +691,11 @@ export function TraceViewer({
               ) : (
                 <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-md border border-border/30 bg-background/50">
                   <JsonEditor
+                    // Reconstruct each entry as a new object so JSON.stringify
+                    // always serialises toolName before arguments, matching the
+                    // key order of expectedToolCalls. The server stores objects
+                    // in alphabetical key order (arguments < toolName), so the
+                    // normalisation must happen here at the display boundary.
                     value={actualToolCalls.map(({ toolName, arguments: args }) => ({
                       toolName,
                       arguments: args,

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
@@ -691,7 +691,10 @@ export function TraceViewer({
               ) : (
                 <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-md border border-border/30 bg-background/50">
                   <JsonEditor
-                    value={actualToolCalls}
+                    value={actualToolCalls.map(({ toolName, arguments: args }) => ({
+                      toolName,
+                      arguments: args,
+                    }))}
                     viewOnly
                     collapsible
                     defaultExpandDepth={2}

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -1467,7 +1467,6 @@ export function PlaygroundMain({
           {showTraceViewTabs ? (
             <ChatTraceViewModeHeaderBar
               mode={activeTraceViewMode}
-              activeVariant="sidebar"
               onModeChange={(mode) => {
                 if (mode === "tools") {
                   return;

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -327,17 +327,11 @@ vi.mock("@/components/evals/trace-view-mode-tabs", () => {
   const tabs = ({
     mode,
     onModeChange,
-    activeVariant,
   }: {
     mode: "chat" | "timeline" | "raw";
     onModeChange: (mode: "chat" | "timeline" | "raw" | "tools") => void;
-    activeVariant?: "default" | "sidebar";
   }) => (
-    <div
-      data-testid="trace-view-tabs"
-      data-mode={mode}
-      data-active-variant={activeVariant ?? "default"}
-    >
+    <div data-testid="trace-view-tabs" data-mode={mode}>
       <button onClick={() => onModeChange("chat")}>Chat</button>
       <button onClick={() => onModeChange("timeline")}>Trace</button>
       <button onClick={() => onModeChange("raw")}>Raw</button>
@@ -349,17 +343,12 @@ vi.mock("@/components/evals/trace-view-mode-tabs", () => {
     ChatTraceViewModeHeaderBar: ({
       mode,
       onModeChange,
-      activeVariant,
     }: {
       mode: "chat" | "timeline" | "raw";
       onModeChange: (mode: "chat" | "timeline" | "raw" | "tools") => void;
-      activeVariant?: "default" | "sidebar";
     }) => (
-      <div
-        data-testid="chat-trace-view-mode-header-bar"
-        data-active-variant={activeVariant ?? "default"}
-      >
-        {tabs({ mode, onModeChange, activeVariant })}
+      <div data-testid="chat-trace-view-mode-header-bar">
+        {tabs({ mode, onModeChange })}
       </div>
     ),
   };
@@ -924,7 +913,7 @@ describe("PlaygroundMain", () => {
       expect(screen.getByTestId("trace-view-tabs")).toBeInTheDocument();
     });
 
-    it("uses the sidebar active variant for the trace header tabs", () => {
+    it("renders the shared trace header tabs", () => {
       mockUseChatSession.messages = [];
       mockUseChatSession.traceViewsSupported = true;
 
@@ -932,11 +921,8 @@ describe("PlaygroundMain", () => {
 
       expect(
         screen.getByTestId("chat-trace-view-mode-header-bar"),
-      ).toHaveAttribute("data-active-variant", "sidebar");
-      expect(screen.getByTestId("trace-view-tabs")).toHaveAttribute(
-        "data-active-variant",
-        "sidebar",
-      );
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("trace-view-tabs")).toBeInTheDocument();
     });
 
     it("shows the sample raw JSON empty state on an empty thread when Raw is selected", () => {


### PR DESCRIPTION
## Summary

This PR is a focused cleanup/refactor of the eval compare playground header and trace tabs, plus a few correctness fixes:

1. Reuse `ModelCompareCardHeader` in eval `RunColumn` instead of duplicating a bespoke header block.
2. Keep tools/result rendering and default-tab behavior correct for multi-turn + unsaved expected-tool-call cases.
3. Normalize Actual tool-call key order in the Results JSON pane to match Expected.
4. Align pass/fail status presentation in both compare cards and the case list.
5. Remove the dead `activeVariant` tab API now that tab active styling is unified.

---

## 1) Reuse shared header in eval compare cards

**Files:**
- `client/src/components/chat-v2/model-compare-card-header.tsx`
- `client/src/components/evals/test-template-editor.tsx`

`RunColumn` previously contained a large bespoke header (model label, pass/fail badge, status dot, latency/tokens/tools rows, tabs, actions, mismatch note). This PR replaces that with `ModelCompareCardHeader` and adapters from `CompareRunRecord -> MultiModelCardSummary`.

### `ModelCompareCardHeader` extensions used by eval cards

- `modelLabel?: string`
- `result?: "passed" | "failed" | null`
- `showToolsTab?: boolean`
- `tabsInline?: boolean`
- `actionsSlot?: ReactNode`
- `footerNote?: ReactNode`
- `mode/onModeChange` widened to `TraceViewMode` (`timeline | chat | raw | tools`)
- `MultiModelCardStatus` includes `"cancelled"`

This keeps chat multi-model and eval compare cards on one shared header component while preserving the eval-specific inline layout.

---

## 2) Tools/Results behavior and run-state correctness fixes

**Files:**
- `client/src/components/evals/test-template-editor.tsx`
- `client/src/components/evals/types.ts`
- `client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx`

### Included fixes

- **Results default tab is based on flattened expected tool calls from the in-memory payload** (not only persisted fields), including multi-turn cases.
- Added `previewExpectedToolCalls` to `CompareRunRecord` so pre-stream tools preview and `showToolsTab` reflect unsaved edits until iteration snapshot is available.
- Pre-stream rendering supports tools mode (`traceMode === "chat" || traceMode === "tools"`) so selecting Results no longer falls back to generic spinner before first stream event.
- Abort catch path now guards by request generation to prevent stale abort writes from clobbering newer retries.
- `onContinueInChat` is intentionally **not** forwarded into eval `RunColumn` in this PR, so the playground UI surface remains unchanged from `main` (no visible Continue in Chat button there).

---

## 3) Actual tool-call key order normalization

**File:** `client/src/components/evals/trace-viewer.tsx`

In Results view, Actual tool calls are re-mapped to `{ toolName, arguments }` at render time so JSON display order matches Expected.

A code comment explains why normalization is done at the display boundary.

---

## 4) Status/pill and winner-highlighting updates

**Files:**
- `client/src/components/chat-v2/model-compare-card-header.tsx`
- `client/src/components/evals/test-cases-overview.tsx`
- related tests

### Changes

- Compare-card pills use **Passed/Failed** text and are rendered inline next to model label.
- Case list uses styled **Passed** and **Failed** pills for consistency.
- Cancelled runs are shown as **Stopped** (amber static dot) instead of falling through to idle visuals.
- Winner highlighting excludes non-comparable summaries (`error` and `cancelled`) so stopped runs cannot win on partial metrics.

---

## 5) Trace tab API cleanup (new)

**Files:**
- `client/src/components/evals/trace-view-mode-tabs.tsx`
- `client/src/components/ChatTabV2.tsx`
- `client/src/components/ui-playground/PlaygroundMain.tsx`
- `client/src/components/chat-v2/model-compare-card-header.tsx`
- related tests

`TraceViewModeTabs` active styling was already unified to `sidebar-accent`. The `activeVariant` prop had become a no-op, so this PR removes it from:

- `TraceViewModeTabs`
- `ChatTraceViewModeHeaderBar`
- all callsites and test mocks/assertions

This removes a misleading API and keeps behavior unchanged.

---

## Tests

Updated/added coverage includes:

- `model-compare-card-header.test.tsx`
- `trace-viewer.test.tsx` (includes real key-order normalization assertion with args-first input)
- `test-template-editor-open-compare-route.test.tsx`
- `test-cases-overview.test.tsx`
- `trace-view-mode-tabs.test.tsx`
- `ui-playground/__tests__/PlaygroundMain.test.tsx`

Targeted suites covering these areas pass locally, and branch CI is expected to validate full matrix.

Made with [Cursor](https://cursor.com)