### PR TITLE
Chatboxes map

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
@@ -1,8 +1,10 @@
+import type { RefObject } from "react";
 import {
   startTransition,
   useCallback,
   useDeferredValue,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -50,6 +52,66 @@ const GRAPH_SPREAD = 1400;
 const DEFAULT_GRAPH_WIDTH = 1200;
 const DEFAULT_GRAPH_HEIGHT = 840;
 const GRAPH_PADDING = 96;
+
+/** Dark `.app-theme-scope` fallbacks from `index.css` until the panel ref resolves tokens for canvas. */
+const DEFAULT_CANVAS_PALETTE = {
+  background: "oklch(0.2679 0.0036 106.6427)",
+  foreground: "oklch(0.8074 0.0142 93.0137)",
+  mutedForeground: "oklch(0.7713 0.0169 99.0657)",
+  border: "oklch(0.3618 0.0101 106.8928)",
+  card: "oklch(0.2679 0.0036 106.6427)",
+  primary: "oklch(0.6724 0.1308 38.7559)",
+} as const;
+
+type TopicMapCanvasPalette = {
+  background: string;
+  foreground: string;
+  mutedForeground: string;
+  border: string;
+  card: string;
+  primary: string;
+};
+
+function useTopicMapCanvasPalette(containerRef: RefObject<HTMLElement | null>) {
+  const [palette, setPalette] = useState<TopicMapCanvasPalette | null>(null);
+
+  const refresh = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const cs = getComputedStyle(el);
+    setPalette({
+      background: cs.getPropertyValue("--background").trim(),
+      foreground: cs.getPropertyValue("--foreground").trim(),
+      mutedForeground: cs.getPropertyValue("--muted-foreground").trim(),
+      border: cs.getPropertyValue("--border").trim(),
+      card: cs.getPropertyValue("--card").trim(),
+      primary: cs.getPropertyValue("--primary").trim(),
+    });
+  }, [containerRef]);
+
+  useLayoutEffect(() => {
+    refresh();
+    const el = containerRef.current;
+    if (!el || typeof MutationObserver === "undefined") return;
+    const observer = new MutationObserver(() => {
+      refresh();
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "style"],
+    });
+    const scope = el.closest(".app-theme-scope");
+    if (scope) {
+      observer.observe(scope, {
+        attributes: true,
+        attributeFilter: ["class", "style"],
+      });
+    }
+    return () => observer.disconnect();
+  }, [containerRef, refresh]);
+
+  return palette;
+}
 
 type SidebarTab = "info" | "filters" | "communities";
 
@@ -130,12 +192,12 @@ function rebuildDisabled(run: ClusterRunState | null): boolean {
 }
 
 function formatRunTone(run: ClusterRunState | null): string {
-  if (!run) return "bg-white/10 text-slate-200";
-  if (run.status === "failed") return "bg-rose-500/15 text-rose-200";
+  if (!run) return "bg-muted text-muted-foreground";
+  if (run.status === "failed") return "bg-destructive/15 text-destructive";
   if (run.status === "running" || run.status === "queued") {
-    return "bg-amber-400/15 text-amber-100";
+    return "bg-pending/15 text-pending-foreground";
   }
-  return "bg-emerald-400/15 text-emerald-100";
+  return "bg-success/15 text-success";
 }
 
 function colorForCluster(clusterId: string | undefined, fallbackIndex?: number) {
@@ -164,6 +226,12 @@ function hexToRgba(hex: string, alpha: number) {
   const green = Number.parseInt(value.slice(2, 4), 16);
   const blue = Number.parseInt(value.slice(4, 6), 16);
   return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
+}
+
+/** Theme-aware translucent stroke for canvas (oklch-safe in modern browsers). */
+function faintLine(color: string, amountPercent: number) {
+  const base = color.trim() || DEFAULT_CANVAS_PALETTE.border;
+  return `color-mix(in oklch, ${base} ${amountPercent}%, transparent)`;
 }
 
 function matchesSearch(
@@ -275,6 +343,12 @@ export function ChatboxTopicMapPanel({
   const deferredSearch = useDeferredValue(searchQuery.trim().toLowerCase());
   const graphRef = useRef<GraphHandle | null>(null);
   const autoFitKeyRef = useRef<string | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const topicMapPalette = useTopicMapCanvasPalette(panelRef);
+  const canvasPalette = useMemo(
+    () => topicMapPalette ?? DEFAULT_CANVAS_PALETTE,
+    [topicMapPalette],
+  );
   const { ref: graphContainerRef, size } = useElementSize<HTMLDivElement>();
 
   const activeClusterIds = useMemo(
@@ -603,20 +677,20 @@ export function ChatboxTopicMapPanel({
       if (deferredSearch && isSearchMatch) {
         ctx.beginPath();
         ctx.strokeStyle = isSelected
-          ? "rgba(255,255,255,0.92)"
-          : "rgba(255,255,255,0.55)";
+          ? canvasPalette.foreground
+          : canvasPalette.mutedForeground;
         ctx.lineWidth = 1.4 / globalScale;
         ctx.arc(node.x, node.y, node.radius + 4.2, 0, 2 * Math.PI);
         ctx.stroke();
       }
 
       ctx.beginPath();
-      ctx.fillStyle = dimmed ? "rgba(122,138,164,0.26)" : node.color;
+      ctx.fillStyle = dimmed ? canvasPalette.mutedForeground : node.color;
       ctx.arc(node.x, node.y, node.radius, 0, 2 * Math.PI);
       ctx.fill();
 
       ctx.lineWidth = (isSelected ? 2.4 : isHovered ? 1.4 : 0.9) / globalScale;
-      ctx.strokeStyle = isSelected ? "#ffffff" : "rgba(6,10,24,0.75)";
+      ctx.strokeStyle = isSelected ? canvasPalette.foreground : canvasPalette.border;
       ctx.stroke();
 
       if (isSelected || isHovered) {
@@ -654,21 +728,21 @@ export function ChatboxTopicMapPanel({
           bubbleHeight,
           12 / globalScale,
         );
-        ctx.fillStyle = "rgba(8,12,26,0.92)";
-        ctx.strokeStyle = isSelected
-          ? "rgba(255,255,255,0.28)"
-          : "rgba(148,163,184,0.18)";
+        ctx.fillStyle = canvasPalette.card;
+        ctx.globalAlpha = dimmed ? 0.45 : 0.96;
+        ctx.strokeStyle = canvasPalette.border;
         ctx.lineWidth = 1 / globalScale;
         ctx.fill();
         ctx.stroke();
+        ctx.globalAlpha = 1;
 
         ctx.font = `${isSelected ? 600 : 500} ${titleFontSize}px ui-sans-serif, system-ui, sans-serif`;
-        ctx.fillStyle = "rgba(248,250,252,0.96)";
+        ctx.fillStyle = canvasPalette.foreground;
         ctx.fillText(label, bubbleX + paddingX, bubbleY + paddingY + titleFontSize * 0.82);
 
         if (preview) {
           ctx.font = `400 ${previewFontSize}px ui-sans-serif, system-ui, sans-serif`;
-          ctx.fillStyle = "rgba(203,213,225,0.82)";
+          ctx.fillStyle = canvasPalette.mutedForeground;
           ctx.fillText(
             preview,
             bubbleX + paddingX,
@@ -681,6 +755,10 @@ export function ChatboxTopicMapPanel({
       ctx.restore();
     },
     [
+      canvasPalette.border,
+      canvasPalette.card,
+      canvasPalette.foreground,
+      canvasPalette.mutedForeground,
       deferredSearch,
       hoveredNodeId,
       isNodeDimmed,
@@ -693,7 +771,9 @@ export function ChatboxTopicMapPanel({
     (link: GraphLink) => {
       const sourceId = getLinkEndpointId(link.source);
       const targetId = getLinkEndpointId(link.target);
-      if (!sourceId || !targetId) return "rgba(148,163,184,0.14)";
+      if (!sourceId || !targetId) {
+        return faintLine(canvasPalette.mutedForeground, 14);
+      }
       const sourceNode = nodeById.get(sourceId);
       const targetNode = nodeById.get(targetId);
       const dimmed =
@@ -708,9 +788,9 @@ export function ChatboxTopicMapPanel({
         hoveredNodeId != null &&
         (sourceId === hoveredNodeId || targetId === hoveredNodeId);
 
-      if (touchesSelection) return "rgba(255,255,255,0.42)";
+      if (touchesSelection) return faintLine(canvasPalette.foreground, 42);
       if (touchesHover && sourceNode) return hexToRgba(sourceNode.color, 0.34);
-      if (dimmed) return "rgba(148,163,184,0.06)";
+      if (dimmed) return faintLine(canvasPalette.mutedForeground, 6);
       if (
         sourceNode &&
         targetNode &&
@@ -719,9 +799,17 @@ export function ChatboxTopicMapPanel({
       ) {
         return hexToRgba(sourceNode.color, 0.22);
       }
-      return "rgba(148,163,184,0.14)";
+      return faintLine(canvasPalette.border, 28);
     },
-    [hoveredNodeId, isNodeDimmed, nodeById, selectedNodeId],
+    [
+      canvasPalette.border,
+      canvasPalette.foreground,
+      canvasPalette.mutedForeground,
+      hoveredNodeId,
+      isNodeDimmed,
+      nodeById,
+      selectedNodeId,
+    ],
   );
 
   const linkWidth = useCallback(
@@ -838,17 +926,6 @@ export function ChatboxTopicMapPanel({
     [graphData, isNodeDimmed],
   );
 
-  const runCopy =
-    latestRun?.status === "running"
-      ? "Updating historical topic map"
-      : latestRun?.status === "queued"
-        ? "Queued for rebuild"
-        : latestRun?.status === "failed"
-          ? "Last rebuild failed"
-          : snapshot
-            ? `${snapshot.stats.mappedSessionCount.toLocaleString()} mapped sessions`
-            : "No topic map yet";
-
   if (
     !snapshot &&
     (isLoading ||
@@ -856,12 +933,12 @@ export function ChatboxTopicMapPanel({
       latestRun?.status === "queued")
   ) {
     return (
-      <div className="flex h-full min-h-0 items-center justify-center bg-[#070917] text-slate-100">
+      <div className="flex h-full min-h-0 items-center justify-center bg-background text-foreground">
         <div className="flex max-w-sm flex-col items-center gap-3 text-center">
-          <LoaderCircle className="h-8 w-8 animate-spin text-cyan-200" />
+          <LoaderCircle className="h-8 w-8 animate-spin text-primary" />
           <div>
             <p className="text-sm font-medium">Building the historical topic map</p>
-            <p className="mt-1 text-xs text-slate-300/70">
+            <p className="mt-1 text-xs text-muted-foreground">
               Sessions are being summarized, clustered, and laid out for the graph.
             </p>
           </div>
@@ -872,12 +949,12 @@ export function ChatboxTopicMapPanel({
 
   if (!snapshot) {
     return (
-      <div className="flex h-full min-h-0 items-center justify-center bg-[#070917] text-slate-100">
+      <div className="flex h-full min-h-0 items-center justify-center bg-background text-foreground">
         <div className="flex max-w-md flex-col items-center gap-3 text-center">
           {latestRun?.status === "failed" ? (
-            <AlertTriangle className="h-8 w-8 text-rose-300" />
+            <AlertTriangle className="h-8 w-8 text-destructive" />
           ) : (
-            <Network className="h-8 w-8 text-slate-400" />
+            <Network className="h-8 w-8 text-muted-foreground" />
           )}
           <div>
             <p className="text-sm font-medium">
@@ -885,7 +962,7 @@ export function ChatboxTopicMapPanel({
                 ? "Topic map rebuild failed"
                 : "No topic map snapshot yet"}
             </p>
-            <p className="mt-1 text-xs text-slate-300/70">
+            <p className="mt-1 text-xs text-muted-foreground">
               {snapshotError ??
                 latestRun?.errorMessage ??
                 "Run a rebuild to summarize and cluster historical sessions."}
@@ -894,7 +971,6 @@ export function ChatboxTopicMapPanel({
           <Button
             type="button"
             variant="outline"
-            className="border-white/15 bg-white/5 text-slate-100 hover:bg-white/10"
             disabled={rebuildDisabled(latestRun) || rebuildBusy}
             onClick={onRebuild}
           >
@@ -907,36 +983,40 @@ export function ChatboxTopicMapPanel({
   }
 
   return (
-    <div className="flex h-full min-h-0 overflow-hidden bg-[#060914] text-slate-100">
+    <div
+      ref={panelRef}
+      className="flex h-full min-h-0 overflow-hidden bg-background text-foreground"
+    >
       <div className="relative min-w-0 flex-1 overflow-hidden">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(32,201,151,0.14),_transparent_24%),radial-gradient(circle_at_bottom_right,_rgba(96,165,250,0.16),_transparent_32%),linear-gradient(180deg,_rgba(10,13,27,0.96),_rgba(4,8,21,1))]" />
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/8 via-transparent to-muted/50" />
         <div
-          className="absolute inset-0 opacity-35"
-          style={{
-            backgroundImage:
-              "linear-gradient(rgba(148,163,184,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(148,163,184,0.05) 1px, transparent 1px)",
-            backgroundSize: "40px 40px",
-            maskImage:
-              "radial-gradient(circle at 50% 45%, rgba(0,0,0,0.95), rgba(0,0,0,0.18) 78%, transparent 100%)",
-          }}
+          className="pointer-events-none absolute inset-0 text-border/40 [background-image:linear-gradient(to_right,currentColor_1px,transparent_1px),linear-gradient(to_bottom,currentColor_1px,transparent_1px)] [background-size:40px_40px] opacity-60 [mask-image:radial-gradient(circle_at_50%_45%,black,transparent_100%)]"
         />
 
         <div className="absolute left-4 right-4 top-4 z-10 flex flex-wrap items-start justify-between gap-3">
           <div className="space-y-2">
             <div className="flex flex-wrap items-center gap-2">
-              <span className="rounded-full border border-white/8 bg-white/6 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.22em] text-slate-200/80">
+              <span className="rounded-full border border-border bg-muted/40 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
                 Historical Topic Map
               </span>
-              <span
-                className={cn(
-                  "rounded-full px-2.5 py-1 text-[11px] font-medium",
-                  formatRunTone(latestRun),
-                )}
-              >
-                {runCopy}
-              </span>
+              {latestRun?.status === "running" ||
+              latestRun?.status === "queued" ||
+              latestRun?.status === "failed" ? (
+                <span
+                  className={cn(
+                    "rounded-full px-2.5 py-1 text-[11px] font-medium",
+                    formatRunTone(latestRun),
+                  )}
+                >
+                  {latestRun?.status === "running"
+                    ? "Updating historical topic map"
+                    : latestRun?.status === "queued"
+                      ? "Queued for rebuild"
+                      : "Last rebuild failed"}
+                </span>
+              ) : null}
             </div>
-            <div className="flex flex-wrap items-center gap-2 text-[11px] text-slate-300/75">
+            <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
               <span>{snapshot.stats.nodeCount.toLocaleString()} visible nodes</span>
               <span>•</span>
               <span>{snapshot.stats.edgeCount.toLocaleString()} edges</span>
@@ -951,11 +1031,11 @@ export function ChatboxTopicMapPanel({
                 </>
               ) : null}
             </div>
-            <p className="text-[11px] text-slate-400/80">
+            <p className="text-[11px] text-muted-foreground">
               Drag the canvas to pan, scroll to zoom, click a node to inspect.
             </p>
             {snapshot.isSampled ? (
-              <div className="max-w-xl rounded-2xl border border-amber-300/20 bg-amber-300/10 px-3 py-2 text-[11px] text-amber-100/90">
+              <div className="max-w-xl rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] text-warning-foreground">
                 Showing a stable 10,000-session sample of{" "}
                 {snapshot.stats.mappedSessionCount.toLocaleString()} mapped
                 sessions for this chatbox.
@@ -964,19 +1044,13 @@ export function ChatboxTopicMapPanel({
           </div>
 
           <div className="flex flex-wrap items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              className="border-white/12 bg-white/[0.04] text-slate-100 hover:bg-white/[0.08]"
-              onClick={() => fitGraph()}
-            >
+            <Button type="button" variant="outline" onClick={() => fitGraph()}>
               <LocateFixed className="mr-2 h-3.5 w-3.5" />
               Fit view
             </Button>
             <Button
               type="button"
               variant="outline"
-              className="border-white/12 bg-white/[0.04] text-slate-100 hover:bg-white/[0.08]"
               disabled={rebuildDisabled(latestRun) || rebuildBusy}
               onClick={onRebuild}
             >
@@ -1046,8 +1120,8 @@ export function ChatboxTopicMapPanel({
                 size.height * 0.48,
                 size.height * 0.58,
               );
-              gradient.addColorStop(0, "rgba(255,255,255,0.02)");
-              gradient.addColorStop(1, "rgba(255,255,255,0)");
+              gradient.addColorStop(0, faintLine(canvasPalette.foreground, 3));
+              gradient.addColorStop(1, "transparent");
               ctx.fillStyle = gradient;
               ctx.fillRect(0, 0, size.width, size.height);
             }}
@@ -1055,13 +1129,12 @@ export function ChatboxTopicMapPanel({
         </div>
       </div>
 
-      <aside className="flex w-[372px] shrink-0 flex-col border-l border-white/10 bg-[#0b1020]/96 backdrop-blur-xl">
-        <div className="border-b border-white/10 p-4">
+      <aside className="flex w-[372px] shrink-0 flex-col border-l border-border bg-muted/30">
+        <div className="border-b border-border bg-muted/20 p-4">
           <SearchInput
             value={searchQuery}
             onValueChange={(value) => startTransition(() => setSearchQuery(value))}
             placeholder="Search nodes..."
-            className="text-slate-100"
           />
         </div>
 
@@ -1070,22 +1143,22 @@ export function ChatboxTopicMapPanel({
           onValueChange={(value) => setActiveTab(value as SidebarTab)}
           className="flex min-h-0 flex-1 flex-col"
         >
-          <TabsList className="grid grid-cols-3 rounded-none border-b border-white/10 bg-transparent p-0">
+          <TabsList className="grid grid-cols-3 rounded-none border-b border-border bg-muted/20 p-0">
             <TabsTrigger
               value="info"
-              className="rounded-none border-r border-white/10 data-[state=active]:bg-white/8"
+              className="rounded-none border-r border-border data-[state=active]:bg-muted data-[state=active]:text-foreground"
             >
               Info
             </TabsTrigger>
             <TabsTrigger
               value="filters"
-              className="rounded-none border-r border-white/10 data-[state=active]:bg-white/8"
+              className="rounded-none border-r border-border data-[state=active]:bg-muted data-[state=active]:text-foreground"
             >
               Filters
             </TabsTrigger>
             <TabsTrigger
               value="communities"
-              className="rounded-none data-[state=active]:bg-white/8"
+              className="rounded-none data-[state=active]:bg-muted data-[state=active]:text-foreground"
             >
               Communities
             </TabsTrigger>
@@ -1097,43 +1170,43 @@ export function ChatboxTopicMapPanel({
                 {selectedNode ? (
                   <>
                     <section className="space-y-3">
-                      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-slate-300/70">
+                      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                         <Info className="h-3.5 w-3.5" />
                         Node Info
                       </div>
-                      <div className="rounded-3xl border border-white/10 bg-white/[0.045] p-4 shadow-[0_20px_60px_rgba(4,8,21,0.35)]">
-                        <p className="break-all text-sm font-semibold text-slate-50">
+                      <div className="rounded-lg border border-border bg-card p-4 shadow-sm">
+                        <p className="break-all text-sm font-semibold text-foreground">
                           {selectedNode.id}
                         </p>
-                        <dl className="mt-3 space-y-2 text-xs text-slate-300/80">
+                        <dl className="mt-3 space-y-2 text-xs text-muted-foreground">
                           <div className="flex items-start justify-between gap-3">
                             <dt>Community</dt>
-                            <dd className="text-right text-slate-100">
+                            <dd className="text-right text-foreground">
                               {selectedNode.clusterLabel ?? "Unclustered"}
                             </dd>
                           </div>
                           <div className="flex items-start justify-between gap-3">
                             <dt>Started</dt>
-                            <dd className="text-right text-slate-100">
+                            <dd className="text-right text-foreground">
                               {format(new Date(selectedNode.startedAt), "yyyy-MM-dd")}
                             </dd>
                           </div>
                           <div className="flex items-start justify-between gap-3">
                             <dt>Messages</dt>
-                            <dd className="text-right text-slate-100">
+                            <dd className="text-right text-foreground">
                               {selectedNode.messageCount}
                             </dd>
                           </div>
                           <div className="flex items-start justify-between gap-3">
                             <dt>Degree</dt>
-                            <dd className="text-right text-slate-100">
+                            <dd className="text-right text-foreground">
                               {selectedNode.degree}
                             </dd>
                           </div>
                           {selectedNode.modelId ? (
                             <div className="flex items-start justify-between gap-3">
                               <dt>Model</dt>
-                              <dd className="max-w-[180px] text-right font-mono text-slate-100">
+                              <dd className="max-w-[180px] text-right font-mono text-foreground">
                                 {selectedNode.modelId}
                               </dd>
                             </div>
@@ -1143,17 +1216,17 @@ export function ChatboxTopicMapPanel({
                     </section>
 
                     <section className="space-y-3">
-                      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-slate-300/70">
+                      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                         <Sparkles className="h-3.5 w-3.5" />
                         Semantic Preview
                       </div>
-                      <div className="rounded-3xl border border-white/10 bg-white/[0.045] p-4 text-sm leading-6 text-slate-100/90 shadow-[0_20px_60px_rgba(4,8,21,0.35)]">
+                      <div className="rounded-lg border border-border bg-card p-4 text-sm leading-6 text-foreground shadow-sm">
                         {selectedNode.semanticPreview}
                       </div>
                     </section>
 
                     <section className="space-y-3">
-                      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-slate-300/70">
+                      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                         <Network className="h-3.5 w-3.5" />
                         Neighbors ({selectedNeighbors.length})
                       </div>
@@ -1164,27 +1237,27 @@ export function ChatboxTopicMapPanel({
                               key={neighbor.id}
                               type="button"
                               onClick={() => focusNode(neighbor.id, 2.25)}
-                              className="w-full rounded-3xl border border-white/10 bg-white/[0.045] px-3 py-3 text-left transition hover:bg-white/[0.08]"
+                              className="w-full rounded-lg border border-border bg-card px-3 py-3 text-left transition hover:bg-muted/50"
                             >
                               <div className="flex items-center gap-2">
                                 <span
                                   className="h-2.5 w-1 rounded-full"
                                   style={{ backgroundColor: neighbor.color }}
                                 />
-                                <span className="truncate text-xs font-medium text-slate-100">
+                                <span className="truncate text-xs font-medium text-foreground">
                                   {neighbor.clusterLabel ?? "Unclustered"}
                                 </span>
-                                <span className="ml-auto text-[11px] text-slate-300/70">
+                                <span className="ml-auto text-[11px] text-muted-foreground">
                                   {(neighbor.score * 100).toFixed(0)}%
                                 </span>
                               </div>
-                              <p className="mt-1 line-clamp-2 text-xs text-slate-300/80">
+                              <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
                                 {neighbor.semanticPreview}
                               </p>
                             </button>
                           ))
                         ) : (
-                          <div className="rounded-3xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
+                          <div className="rounded-lg border border-dashed border-border bg-muted/20 px-3 py-4 text-xs text-muted-foreground">
                             No reciprocal neighbors survived the graph pruning for
                             this node.
                           </div>
@@ -1193,7 +1266,7 @@ export function ChatboxTopicMapPanel({
                     </section>
                   </>
                 ) : (
-                  <div className="rounded-3xl border border-dashed border-white/10 bg-white/[0.03] p-4 text-sm text-slate-300/70">
+                  <div className="rounded-lg border border-dashed border-border bg-muted/20 p-4 text-sm text-muted-foreground">
                     Select a node to inspect its summary, community, and nearest
                     neighbors.
                   </div>
@@ -1206,7 +1279,7 @@ export function ChatboxTopicMapPanel({
             <ScrollArea className="h-full">
               <div className="space-y-5 p-4">
                 <section className="space-y-3">
-                  <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-slate-300/70">
+                  <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                     <Filter className="h-3.5 w-3.5" />
                     Active Community Filters
                   </div>
@@ -1217,14 +1290,14 @@ export function ChatboxTopicMapPanel({
                           key={chipKey(chip)}
                           type="button"
                           onClick={() => onClearChip(chipKey(chip))}
-                          className="rounded-full border border-white/10 bg-white/[0.06] px-3 py-1 text-xs text-slate-100 transition hover:bg-white/[0.1]"
+                          className="rounded-full border border-border bg-muted/50 px-3 py-1 text-xs text-foreground transition hover:bg-muted"
                         >
                           {chip.label ?? chip.clusterId}
                         </button>
                       ))}
                     </div>
                   ) : (
-                    <div className="rounded-3xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
+                    <div className="rounded-lg border border-dashed border-border bg-muted/20 px-3 py-4 text-xs text-muted-foreground">
                       No community filters are active. Pick a community from the
                       Communities tab to isolate it in the graph.
                     </div>
@@ -1232,7 +1305,7 @@ export function ChatboxTopicMapPanel({
                 </section>
 
                 <section className="space-y-3">
-                  <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-slate-300/70">
+                  <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                     <Sparkles className="h-3.5 w-3.5" />
                     Search Results
                   </div>
@@ -1244,31 +1317,31 @@ export function ChatboxTopicMapPanel({
                             key={node.id}
                             type="button"
                             onClick={() => focusNode(node.id, 2.2)}
-                            className="w-full rounded-3xl border border-white/10 bg-white/[0.045] px-3 py-3 text-left transition hover:bg-white/[0.08]"
+                            className="w-full rounded-lg border border-border bg-card px-3 py-3 text-left transition hover:bg-muted/50"
                           >
                             <div className="flex items-center justify-between gap-3">
-                              <span className="truncate text-xs font-medium text-slate-100">
+                              <span className="truncate text-xs font-medium text-foreground">
                                 {node.clusterLabel ?? "Unclustered"}
                               </span>
-                              <span className="text-[11px] text-slate-300/70">
+                              <span className="text-[11px] text-muted-foreground">
                                 {formatDistanceToNow(new Date(node.lastActivityAt), {
                                   addSuffix: true,
                                 })}
                               </span>
                             </div>
-                            <p className="mt-1 line-clamp-2 text-xs text-slate-300/80">
+                            <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
                               {node.semanticPreview}
                             </p>
                           </button>
                         ))}
                       </div>
                     ) : (
-                      <div className="rounded-3xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
+                      <div className="rounded-lg border border-dashed border-border bg-muted/20 px-3 py-4 text-xs text-muted-foreground">
                         No nodes matched “{deferredSearch}”.
                       </div>
                     )
                   ) : (
-                    <div className="rounded-3xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
+                    <div className="rounded-lg border border-dashed border-border bg-muted/20 px-3 py-4 text-xs text-muted-foreground">
                       Search by community label, semantic preview, session ID, or
                       model.
                     </div>
@@ -1299,10 +1372,10 @@ export function ChatboxTopicMapPanel({
                         })
                       }
                       className={cn(
-                        "w-full rounded-3xl border px-3 py-3 text-left transition",
+                        "w-full rounded-lg border px-3 py-3 text-left transition",
                         isActive
-                          ? "border-cyan-300/40 bg-cyan-300/10"
-                          : "border-white/10 bg-white/[0.045] hover:bg-white/[0.08]",
+                          ? "border-primary/40 bg-primary/10"
+                          : "border-border bg-card hover:bg-muted/50",
                       )}
                     >
                       <div className="flex items-start justify-between gap-3">
@@ -1312,15 +1385,15 @@ export function ChatboxTopicMapPanel({
                               className="h-2.5 w-2.5 rounded-full"
                               style={{ backgroundColor: swatch }}
                             />
-                            <p className="truncate text-sm font-semibold text-slate-50">
+                            <p className="truncate text-sm font-semibold text-foreground">
                               {community.label}
                             </p>
                           </div>
-                          <p className="mt-1 text-xs text-slate-300/75">
+                          <p className="mt-1 text-xs text-muted-foreground">
                             {community.summary}
                           </p>
                         </div>
-                        <span className="rounded-full bg-white/8 px-2 py-1 text-[11px] text-slate-100">
+                        <span className="rounded-full bg-secondary px-2 py-1 text-[11px] text-secondary-foreground">
                           {community.memberCount}
                         </span>
                       </div>
@@ -1329,7 +1402,7 @@ export function ChatboxTopicMapPanel({
                           {community.keywords.map((keyword) => (
                             <span
                               key={keyword}
-                              className="rounded-full border border-white/10 px-2 py-0.5 text-[11px] text-slate-300/80"
+                              className="rounded-full border border-border px-2 py-0.5 text-[11px] text-muted-foreground"
                             >
                               {keyword}
                             </span>

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
@@ -1,16 +1,20 @@
 import {
   startTransition,
+  useCallback,
   useDeferredValue,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
+import ForceGraph2D from "react-force-graph-2d";
 import { format, formatDistanceToNow } from "date-fns";
 import {
   AlertTriangle,
   Filter,
   Info,
   LoaderCircle,
+  LocateFixed,
   Network,
   RefreshCw,
   Sparkles,
@@ -29,28 +33,29 @@ import type { ClusterRunState } from "@/hooks/useUsageInsights";
 import { cn } from "@/lib/utils";
 
 const CLUSTER_COLORS = [
-  "#f87171",
-  "#fbbf24",
-  "#4ade80",
-  "#60a5fa",
-  "#c084fc",
   "#fb7185",
-  "#34d399",
-  "#38bdf8",
-  "#fde047",
-  "#a3e635",
-  "#f472b6",
+  "#f59e0b",
+  "#facc15",
+  "#4ade80",
   "#2dd4bf",
+  "#38bdf8",
+  "#60a5fa",
+  "#818cf8",
+  "#a78bfa",
+  "#e879f9",
+  "#f472b6",
+  "#f97316",
 ];
-const GRAPH_SPREAD = 1800;
+const GRAPH_SPREAD = 1400;
+const DEFAULT_GRAPH_WIDTH = 1200;
+const DEFAULT_GRAPH_HEIGHT = 840;
 const GRAPH_PADDING = 96;
-const GRAPH_VIEWPORT_WIDTH = 1600;
-const GRAPH_VIEWPORT_HEIGHT = 1000;
 
 type SidebarTab = "info" | "filters" | "communities";
 
 type GraphNode = {
   id: string;
+  sessionId: string;
   clusterId?: string;
   clusterLabel?: string;
   semanticPreview: string;
@@ -59,36 +64,39 @@ type GraphNode = {
   lastActivityAt: number;
   modelId?: string;
   degree: number;
+  seedX: number;
+  seedY: number;
   x: number;
   y: number;
-  fx: number;
-  fy: number;
+  vx: number;
+  vy: number;
+  fx?: number;
+  fy?: number;
   color: string;
   radius: number;
-  isDimmed: boolean;
-  isSearchMatch: boolean;
-  isSelected: boolean;
 };
 
 type GraphLink = {
-  source: string;
-  target: string;
+  source: string | GraphNode;
+  target: string | GraphNode;
   score: number;
-  isDimmed: boolean;
-  isSelected: boolean;
 };
 
-type ProjectedNode = GraphNode & {
-  screenX: number;
-  screenY: number;
-  screenRadius: number;
+type GraphData = {
+  nodes: GraphNode[];
+  links: GraphLink[];
 };
 
-type ProjectedLink = GraphLink & {
-  sourceX: number;
-  sourceY: number;
-  targetX: number;
-  targetY: number;
+type GraphHandle = {
+  zoomToFit?: (
+    durationMs?: number,
+    padding?: number,
+    nodeFilter?: (node: GraphNode) => boolean,
+  ) => void;
+  centerAt?: (x?: number, y?: number, durationMs?: number) => void;
+  zoom?: (scale: number, durationMs?: number) => void;
+  d3Force?: (forceName: string, forceFn?: unknown) => unknown;
+  d3ReheatSimulation?: () => void;
 };
 
 interface ChatboxTopicMapPanelProps {
@@ -130,9 +138,32 @@ function formatRunTone(run: ClusterRunState | null): string {
   return "bg-emerald-400/15 text-emerald-100";
 }
 
-function colorForCluster(clusterId: string | undefined, fallbackIndex: number) {
-  if (!clusterId) return "#94a3b8";
-  return CLUSTER_COLORS[fallbackIndex % CLUSTER_COLORS.length];
+function colorForCluster(clusterId: string | undefined, fallbackIndex?: number) {
+  if (!clusterId) return "#9aa4ba";
+  if (typeof fallbackIndex === "number" && Number.isFinite(fallbackIndex)) {
+    return CLUSTER_COLORS[Math.abs(fallbackIndex) % CLUSTER_COLORS.length];
+  }
+  let hash = 0;
+  for (let index = 0; index < clusterId.length; index += 1) {
+    hash = (hash * 31 + clusterId.charCodeAt(index)) >>> 0;
+  }
+  const colorIndex = hash % CLUSTER_COLORS.length;
+  return CLUSTER_COLORS[colorIndex];
+}
+
+function hexToRgba(hex: string, alpha: number) {
+  const normalized = hex.replace("#", "");
+  const value =
+    normalized.length === 3
+      ? normalized
+          .split("")
+          .map((character) => character + character)
+          .join("")
+      : normalized;
+  const red = Number.parseInt(value.slice(0, 2), 16);
+  const green = Number.parseInt(value.slice(2, 4), 16);
+  const blue = Number.parseInt(value.slice(4, 6), 16);
+  return `rgba(${red}, ${green}, ${blue}, ${alpha})`;
 }
 
 function matchesSearch(
@@ -156,6 +187,75 @@ function matchesSearch(
   return haystack.includes(query);
 }
 
+function getLinkEndpointId(endpoint: GraphLink["source"] | GraphLink["target"]) {
+  if (typeof endpoint === "string") return endpoint;
+  return endpoint?.id ?? null;
+}
+
+function drawRoundedRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+) {
+  const nextRadius = Math.min(radius, width / 2, height / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + nextRadius, y);
+  ctx.arcTo(x + width, y, x + width, y + height, nextRadius);
+  ctx.arcTo(x + width, y + height, x, y + height, nextRadius);
+  ctx.arcTo(x, y + height, x, y, nextRadius);
+  ctx.arcTo(x, y, x + width, y, nextRadius);
+  ctx.closePath();
+}
+
+function useElementSize<T extends HTMLElement>() {
+  const ref = useRef<T | null>(null);
+  const [size, setSize] = useState({
+    width: DEFAULT_GRAPH_WIDTH,
+    height: DEFAULT_GRAPH_HEIGHT,
+  });
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const update = (rect?: DOMRectReadOnly) => {
+      const width = Math.max(
+        360,
+        Math.round(rect?.width ?? element.clientWidth ?? DEFAULT_GRAPH_WIDTH),
+      );
+      const height = Math.max(
+        420,
+        Math.round(rect?.height ?? element.clientHeight ?? DEFAULT_GRAPH_HEIGHT),
+      );
+      setSize((current) =>
+        current.width === width && current.height === height
+          ? current
+          : { width, height },
+      );
+    };
+
+    update();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver((entries) => update(entries[0]?.contentRect));
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, size };
+}
+
+function linkDistance(score: number) {
+  return Math.max(56, 184 - score * 128);
+}
+
+function trimPreview(text: string) {
+  if (text.length <= 86) return text;
+  return `${text.slice(0, 83).trimEnd()}…`;
+}
+
 export function ChatboxTopicMapPanel({
   chatboxId,
   filter,
@@ -164,15 +264,18 @@ export function ChatboxTopicMapPanel({
   onRebuild,
   rebuildBusy,
 }: ChatboxTopicMapPanelProps) {
-  const { latestRun, snapshot, snapshotMetadata, snapshotError, isLoading } =
-    useChatboxTopicMap({
-      chatboxId,
-      enabled: true,
-    });
+  const { latestRun, snapshot, snapshotError, isLoading } = useChatboxTopicMap({
+    chatboxId,
+    enabled: true,
+  });
   const [activeTab, setActiveTab] = useState<SidebarTab>("info");
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const deferredSearch = useDeferredValue(searchQuery.trim().toLowerCase());
+  const graphRef = useRef<GraphHandle | null>(null);
+  const autoFitKeyRef = useRef<string | null>(null);
+  const { ref: graphContainerRef, size } = useElementSize<HTMLDivElement>();
 
   const activeClusterIds = useMemo(
     () =>
@@ -195,28 +298,14 @@ export function ChatboxTopicMapPanel({
     [snapshot?.clusters],
   );
 
-  const graphData = useMemo(() => {
+  const graphData = useMemo<GraphData | null>(() => {
     if (!snapshot) return null;
-    const nodes: GraphNode[] = snapshot.nodes.map((node) => {
-      const clusterMatch =
-        activeClusterIds.size === 0 ||
-        (node.clusterId ? activeClusterIds.has(node.clusterId) : false);
-      const searchMatch = matchesSearch(deferredSearch, {
-        sessionId: node.sessionId,
-        clusterLabel: node.clusterLabel,
-        semanticPreview: node.semanticPreview,
-        modelId: node.modelId,
-      });
-      const color = colorForCluster(
-        node.clusterId,
-        clusterColorIndex.get(node.clusterId ?? "") ?? 0,
-      );
-      const radius = Math.max(
-        2,
-        Math.min(7, 2 + Math.log1p(node.degree + node.messageCount) * 0.9),
-      );
+    const nodes = snapshot.nodes.map((node) => {
+      const x = node.x * GRAPH_SPREAD;
+      const y = node.y * GRAPH_SPREAD;
       return {
         id: node.sessionId,
+        sessionId: node.sessionId,
         clusterId: node.clusterId,
         clusterLabel: node.clusterLabel,
         semanticPreview: node.semanticPreview,
@@ -225,60 +314,120 @@ export function ChatboxTopicMapPanel({
         lastActivityAt: node.lastActivityAt,
         modelId: node.modelId,
         degree: node.degree,
-        x: node.x * GRAPH_SPREAD,
-        y: node.y * GRAPH_SPREAD,
-        fx: node.x * GRAPH_SPREAD,
-        fy: node.y * GRAPH_SPREAD,
-        color,
-        radius,
-        isDimmed: !clusterMatch || !searchMatch,
-        isSearchMatch: searchMatch,
-        isSelected: node.sessionId === selectedNodeId,
-      };
+        seedX: x,
+        seedY: y,
+        x,
+        y,
+        vx: 0,
+        vy: 0,
+        color: colorForCluster(
+          node.clusterId,
+          node.clusterId != null
+            ? clusterColorIndex.get(node.clusterId)
+            : undefined,
+        ),
+        radius: Math.max(
+          4.4,
+          Math.min(11.8, 4 + Math.log1p(node.degree + node.messageCount) * 1.3),
+        ),
+      } satisfies GraphNode;
     });
-
-    const dimmedNodes = new Map(nodes.map((node) => [node.id, node.isDimmed]));
-    const selectedEdges = new Set<string>();
-    if (selectedNodeId) {
-      snapshot.edges.forEach((edge) => {
-        if (edge.source === selectedNodeId || edge.target === selectedNodeId) {
-          selectedEdges.add(`${edge.source}:${edge.target}`);
-        }
-      });
-    }
-    const links: GraphLink[] = snapshot.edges.map((edge) => ({
-      source: edge.source,
-      target: edge.target,
-      score: edge.score,
-      isDimmed:
-        (dimmedNodes.get(edge.source) ?? false) ||
-        (dimmedNodes.get(edge.target) ?? false),
-      isSelected: selectedEdges.has(`${edge.source}:${edge.target}`),
-    }));
-
+    const links = snapshot.edges.map(
+      (edge) =>
+        ({
+          source: edge.source,
+          target: edge.target,
+          score: edge.score,
+        }) satisfies GraphLink,
+    );
     return { nodes, links };
-  }, [activeClusterIds, clusterColorIndex, deferredSearch, selectedNodeId, snapshot]);
+  }, [clusterColorIndex, snapshot]);
 
   const nodeById = useMemo(
-    () =>
-      new Map(
-        (graphData?.nodes ?? []).map((node) => [node.id, node]),
-      ),
+    () => new Map((graphData?.nodes ?? []).map((node) => [node.id, node])),
     [graphData?.nodes],
   );
+
+  const neighborsByNode = useMemo(() => {
+    const adjacency = new Map<string, Set<string>>();
+    for (const link of graphData?.links ?? []) {
+      const sourceId = getLinkEndpointId(link.source);
+      const targetId = getLinkEndpointId(link.target);
+      if (!sourceId || !targetId) continue;
+      if (!adjacency.has(sourceId)) adjacency.set(sourceId, new Set());
+      if (!adjacency.has(targetId)) adjacency.set(targetId, new Set());
+      adjacency.get(sourceId)!.add(targetId);
+      adjacency.get(targetId)!.add(sourceId);
+    }
+    return adjacency;
+  }, [graphData?.links]);
+
+  const searchMatchIds = useMemo(() => {
+    if (!graphData || !deferredSearch) return null;
+    return new Set(
+      graphData.nodes
+        .filter((node) =>
+          matchesSearch(deferredSearch, {
+            sessionId: node.sessionId,
+            clusterLabel: node.clusterLabel,
+            semanticPreview: node.semanticPreview,
+            modelId: node.modelId,
+          }),
+        )
+        .map((node) => node.id),
+    );
+  }, [deferredSearch, graphData]);
+
+  const focusNodeId = hoveredNodeId;
+
+  const focusedNeighborhood = useMemo(() => {
+    if (!focusNodeId) return null;
+    const focused = new Set<string>([focusNodeId]);
+    const neighbors = neighborsByNode.get(focusNodeId);
+    if (neighbors) {
+      for (const neighborId of neighbors) focused.add(neighborId);
+    }
+    return focused;
+  }, [focusNodeId, neighborsByNode]);
+
+  const isNodeDimmed = useCallback(
+    (node: GraphNode) => {
+      const clusterMatch =
+        activeClusterIds.size === 0 ||
+        (node.clusterId ? activeClusterIds.has(node.clusterId) : false);
+      const searchMatch =
+        searchMatchIds == null || searchMatchIds.has(node.id);
+      const focusMatch =
+        focusedNeighborhood == null || focusedNeighborhood.has(node.id);
+      return !(clusterMatch && searchMatch && focusMatch);
+    },
+    [activeClusterIds, focusedNeighborhood, searchMatchIds],
+  );
+
+  const searchMatches = useMemo(() => {
+    if (!graphData || !searchMatchIds) return [];
+    return graphData.nodes
+      .filter((node) => searchMatchIds.has(node.id))
+      .slice(0, 12);
+  }, [graphData, searchMatchIds]);
 
   const selectedNode = selectedNodeId ? nodeById.get(selectedNodeId) ?? null : null;
 
   const selectedNeighbors = useMemo(() => {
     if (!selectedNodeId || !graphData) return [];
     return graphData.links
-      .filter(
-        (edge) => edge.source === selectedNodeId || edge.target === selectedNodeId,
-      )
+      .filter((edge) => {
+        const sourceId = getLinkEndpointId(edge.source);
+        const targetId = getLinkEndpointId(edge.target);
+        return sourceId === selectedNodeId || targetId === selectedNodeId;
+      })
       .sort((left, right) => right.score - left.score)
       .map((edge) => {
+        const sourceId = getLinkEndpointId(edge.source);
+        const targetId = getLinkEndpointId(edge.target);
         const neighborId =
-          edge.source === selectedNodeId ? edge.target : edge.source;
+          sourceId === selectedNodeId ? targetId : sourceId;
+        if (!neighborId) return null;
         const node = nodeById.get(neighborId);
         return node
           ? {
@@ -293,13 +442,6 @@ export function ChatboxTopicMapPanel({
       .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
   }, [graphData, nodeById, selectedNodeId]);
 
-  const searchMatches = useMemo(() => {
-    if (!graphData || !deferredSearch) return [];
-    return graphData.nodes
-      .filter((node) => node.isSearchMatch)
-      .slice(0, 12);
-  }, [deferredSearch, graphData]);
-
   const communities = useMemo(
     () =>
       [...(snapshot?.clusters ?? [])].sort(
@@ -308,77 +450,392 @@ export function ChatboxTopicMapPanel({
     [snapshot?.clusters],
   );
 
+  const activeClusterChips = filter.chips.filter(
+    (chip): chip is Extract<UsageFilterChip, { kind: "cluster" }> =>
+      chip.kind === "cluster",
+  );
+
   useEffect(() => {
     if (!snapshot) {
       setSelectedNodeId(null);
       return;
     }
-    if (selectedNodeId && snapshot.nodes.some((node) => node.sessionId === selectedNodeId)) {
+    if (
+      selectedNodeId &&
+      snapshot.nodes.some((node) => node.sessionId === selectedNodeId)
+    ) {
       return;
     }
     setSelectedNodeId(snapshot.nodes[0]?.sessionId ?? null);
   }, [selectedNodeId, snapshot]);
 
-  const projectedGraph = useMemo(() => {
-    if (!graphData) {
-      return null;
+  useEffect(() => {
+    if (!graphData) return;
+    const graph = graphRef.current;
+    if (!graph) return;
+
+    const chargeForce = graph.d3Force?.("charge");
+    if (chargeForce && typeof (chargeForce as { strength?: unknown }).strength === "function") {
+      (chargeForce as {
+        strength: (value: (node: GraphNode) => number) => void;
+      }).strength((node) => -56 - node.degree * 14 - node.messageCount * 0.9);
     }
 
-    const nodes = graphData.nodes;
-    const xs = nodes.map((node) => node.fx ?? node.x ?? 0);
-    const ys = nodes.map((node) => node.fy ?? node.y ?? 0);
-    const minX = Math.min(...xs);
-    const maxX = Math.max(...xs);
-    const minY = Math.min(...ys);
-    const maxY = Math.max(...ys);
-    const spanX = Math.max(1, maxX - minX);
-    const spanY = Math.max(1, maxY - minY);
-    const availableWidth = Math.max(1, GRAPH_VIEWPORT_WIDTH - GRAPH_PADDING * 2);
-    const availableHeight = Math.max(1, GRAPH_VIEWPORT_HEIGHT - GRAPH_PADDING * 2);
-    const scale = Math.max(
-      0.05,
-      Math.min(availableWidth / spanX, availableHeight / spanY),
-    );
-    const offsetX = (GRAPH_VIEWPORT_WIDTH - spanX * scale) / 2;
-    const offsetY = (GRAPH_VIEWPORT_HEIGHT - spanY * scale) / 2;
+    const linkForce = graph.d3Force?.("link");
+    if (linkForce && typeof (linkForce as { distance?: unknown }).distance === "function") {
+      (
+        linkForce as {
+          distance: (value: (link: GraphLink) => number) => void;
+          strength?: (value: (link: GraphLink) => number) => void;
+        }
+      ).distance((link) => linkDistance(link.score));
+      if (typeof (linkForce as { strength?: unknown }).strength === "function") {
+        (
+          linkForce as {
+            strength: (value: (link: GraphLink) => number) => void;
+          }
+        ).strength((link) => Math.max(0.06, (link.score - 0.64) * 0.85));
+      }
+    }
 
-    const projectedNodes = nodes.map((node) => {
-      const graphX = node.fx ?? node.x ?? 0;
-      const graphY = node.fy ?? node.y ?? 0;
-      return {
-        ...node,
-        screenX: (graphX - minX) * scale + offsetX,
-        screenY: (graphY - minY) * scale + offsetY,
-        screenRadius: Math.max(4.5, node.radius * 1.5),
+    // Keep the simulation loosely anchored to the stored UMAP positions so the
+    // graph feels alive without drifting into an unreadable hairball.
+    graph.d3Force?.("seed", (() => {
+      let nodes: GraphNode[] = [];
+      const force = (alpha: number) => {
+        const pull = 0.08 * alpha;
+        for (const node of nodes) {
+          if (node.fx != null || node.fy != null) continue;
+          node.vx += (node.seedX - (node.x ?? 0)) * pull;
+          node.vy += (node.seedY - (node.y ?? 0)) * pull;
+        }
       };
-    });
-    const projectedById = new Map(
-      projectedNodes.map((node) => [node.id, node]),
-    );
-    const projectedLinks = graphData.links
-      .map((link) => {
-        const source = projectedById.get(link.source);
-        const target = projectedById.get(link.target);
-        if (!source || !target) return null;
-        return {
-          ...link,
-          sourceX: source.screenX,
-          sourceY: source.screenY,
-          targetX: target.screenX,
-          targetY: target.screenY,
-        };
-      })
-      .filter((link): link is ProjectedLink => link !== null);
+      force.initialize = (nextNodes: GraphNode[]) => {
+        nodes = nextNodes;
+      };
+      return force;
+    })());
 
-    return {
-      nodes: projectedNodes,
-      links: projectedLinks,
-    };
+    graph.d3ReheatSimulation?.();
   }, [graphData]);
 
-  const activeClusterChips = filter.chips.filter(
-    (chip): chip is Extract<UsageFilterChip, { kind: "cluster" }> =>
-      chip.kind === "cluster",
+  const fitGraph = useCallback(
+    (durationMs = 420) => {
+      graphRef.current?.zoomToFit?.(
+        durationMs,
+        GRAPH_PADDING,
+        (node) => !isNodeDimmed(node),
+      );
+    },
+    [isNodeDimmed],
+  );
+
+  const focusNode = useCallback(
+    (nodeId: string, zoomLevel = 2.1) => {
+      const node = nodeById.get(nodeId);
+      if (!node) return;
+      setSelectedNodeId(nodeId);
+      setActiveTab("info");
+      graphRef.current?.centerAt?.(node.x, node.y, 560);
+      graphRef.current?.zoom?.(zoomLevel, 560);
+    },
+    [nodeById],
+  );
+
+  useEffect(() => {
+    if (!snapshot) return;
+    const fitKey = `${snapshot.runId}:${size.width}x${size.height}`;
+    if (autoFitKeyRef.current === fitKey) return;
+    autoFitKeyRef.current = fitKey;
+    const timer = window.setTimeout(() => {
+      fitGraph(360);
+    }, 80);
+    return () => window.clearTimeout(timer);
+  }, [fitGraph, size.height, size.width, snapshot]);
+
+  const drawNode = useCallback(
+    (
+      node: GraphNode,
+      ctx: CanvasRenderingContext2D,
+      globalScale: number,
+    ) => {
+      const isSelected = node.id === selectedNodeId;
+      const isHovered = node.id === hoveredNodeId;
+      const isSearchMatch = searchMatchIds?.has(node.id) ?? false;
+      const dimmed = isNodeDimmed(node);
+      const label = node.clusterLabel ?? node.sessionId;
+
+      ctx.save();
+      ctx.globalAlpha = dimmed ? 0.16 : 1;
+
+      if (!dimmed) {
+        ctx.shadowColor = node.color;
+        ctx.shadowBlur = isSelected ? 32 : isHovered ? 22 : 16;
+      }
+
+      ctx.beginPath();
+      ctx.fillStyle = isSelected
+        ? hexToRgba(node.color, 0.2)
+        : isHovered
+          ? hexToRgba(node.color, 0.14)
+          : "transparent";
+      ctx.arc(node.x, node.y, node.radius + (isSelected ? 6 : isHovered ? 4 : 0), 0, 2 * Math.PI);
+      ctx.fill();
+
+      if (!dimmed) {
+        ctx.beginPath();
+        ctx.fillStyle = hexToRgba(
+          node.color,
+          isSelected ? 0.22 : isHovered ? 0.18 : 0.12,
+        );
+        ctx.arc(
+          node.x,
+          node.y,
+          node.radius + (isSelected ? 4.8 : isHovered ? 3.6 : 2.6),
+          0,
+          2 * Math.PI,
+        );
+        ctx.fill();
+      }
+
+      ctx.shadowBlur = 0;
+
+      if (deferredSearch && isSearchMatch) {
+        ctx.beginPath();
+        ctx.strokeStyle = isSelected
+          ? "rgba(255,255,255,0.92)"
+          : "rgba(255,255,255,0.55)";
+        ctx.lineWidth = 1.4 / globalScale;
+        ctx.arc(node.x, node.y, node.radius + 4.2, 0, 2 * Math.PI);
+        ctx.stroke();
+      }
+
+      ctx.beginPath();
+      ctx.fillStyle = dimmed ? "rgba(122,138,164,0.26)" : node.color;
+      ctx.arc(node.x, node.y, node.radius, 0, 2 * Math.PI);
+      ctx.fill();
+
+      ctx.lineWidth = (isSelected ? 2.4 : isHovered ? 1.4 : 0.9) / globalScale;
+      ctx.strokeStyle = isSelected ? "#ffffff" : "rgba(6,10,24,0.75)";
+      ctx.stroke();
+
+      if (isSelected || isHovered) {
+        const titleFontSize = (isSelected ? 13 : 11.5) / globalScale;
+        const previewFontSize = 10 / globalScale;
+        const titleY = node.y - node.radius - 15 / globalScale;
+        const paddingX = 10 / globalScale;
+        const paddingY = 8 / globalScale;
+        const preview = isSelected ? trimPreview(node.semanticPreview) : null;
+
+        ctx.font = `${isSelected ? 600 : 500} ${titleFontSize}px ui-sans-serif, system-ui, sans-serif`;
+        const titleWidth = ctx.measureText(label).width;
+        let bubbleWidth = titleWidth + paddingX * 2;
+        let bubbleHeight = titleFontSize + paddingY * 2;
+
+        if (preview) {
+          ctx.font = `400 ${previewFontSize}px ui-sans-serif, system-ui, sans-serif`;
+          bubbleWidth = Math.max(
+            bubbleWidth,
+            ctx.measureText(preview).width + paddingX * 2,
+          );
+          bubbleHeight += previewFontSize + 6 / globalScale;
+        }
+
+        const bubbleX = node.x + 12 / globalScale;
+        const bubbleY = titleY - bubbleHeight / 2;
+
+        ctx.save();
+        ctx.globalAlpha = dimmed ? 0.55 : 0.98;
+        drawRoundedRect(
+          ctx,
+          bubbleX,
+          bubbleY,
+          bubbleWidth,
+          bubbleHeight,
+          12 / globalScale,
+        );
+        ctx.fillStyle = "rgba(8,12,26,0.92)";
+        ctx.strokeStyle = isSelected
+          ? "rgba(255,255,255,0.28)"
+          : "rgba(148,163,184,0.18)";
+        ctx.lineWidth = 1 / globalScale;
+        ctx.fill();
+        ctx.stroke();
+
+        ctx.font = `${isSelected ? 600 : 500} ${titleFontSize}px ui-sans-serif, system-ui, sans-serif`;
+        ctx.fillStyle = "rgba(248,250,252,0.96)";
+        ctx.fillText(label, bubbleX + paddingX, bubbleY + paddingY + titleFontSize * 0.82);
+
+        if (preview) {
+          ctx.font = `400 ${previewFontSize}px ui-sans-serif, system-ui, sans-serif`;
+          ctx.fillStyle = "rgba(203,213,225,0.82)";
+          ctx.fillText(
+            preview,
+            bubbleX + paddingX,
+            bubbleY + bubbleHeight - paddingY,
+          );
+        }
+        ctx.restore();
+      }
+
+      ctx.restore();
+    },
+    [
+      deferredSearch,
+      hoveredNodeId,
+      isNodeDimmed,
+      searchMatchIds,
+      selectedNodeId,
+    ],
+  );
+
+  const linkColor = useCallback(
+    (link: GraphLink) => {
+      const sourceId = getLinkEndpointId(link.source);
+      const targetId = getLinkEndpointId(link.target);
+      if (!sourceId || !targetId) return "rgba(148,163,184,0.14)";
+      const sourceNode = nodeById.get(sourceId);
+      const targetNode = nodeById.get(targetId);
+      const dimmed =
+        !sourceNode ||
+        !targetNode ||
+        isNodeDimmed(sourceNode) ||
+        isNodeDimmed(targetNode);
+      const touchesSelection =
+        selectedNodeId != null &&
+        (sourceId === selectedNodeId || targetId === selectedNodeId);
+      const touchesHover =
+        hoveredNodeId != null &&
+        (sourceId === hoveredNodeId || targetId === hoveredNodeId);
+
+      if (touchesSelection) return "rgba(255,255,255,0.42)";
+      if (touchesHover && sourceNode) return hexToRgba(sourceNode.color, 0.34);
+      if (dimmed) return "rgba(148,163,184,0.06)";
+      if (
+        sourceNode &&
+        targetNode &&
+        sourceNode.clusterId &&
+        sourceNode.clusterId === targetNode.clusterId
+      ) {
+        return hexToRgba(sourceNode.color, 0.22);
+      }
+      return "rgba(148,163,184,0.14)";
+    },
+    [hoveredNodeId, isNodeDimmed, nodeById, selectedNodeId],
+  );
+
+  const linkWidth = useCallback(
+    (link: GraphLink) => {
+      const sourceId = getLinkEndpointId(link.source);
+      const targetId = getLinkEndpointId(link.target);
+      const touchesSelection =
+        selectedNodeId != null &&
+        (sourceId === selectedNodeId || targetId === selectedNodeId);
+      const touchesHover =
+        hoveredNodeId != null &&
+        (sourceId === hoveredNodeId || targetId === hoveredNodeId);
+      if (touchesSelection) return 1.9;
+      if (touchesHover) return 1.2;
+      const sourceNode = sourceId ? nodeById.get(sourceId) : null;
+      const targetNode = targetId ? nodeById.get(targetId) : null;
+      if (
+        !sourceNode ||
+        !targetNode ||
+        isNodeDimmed(sourceNode) ||
+        isNodeDimmed(targetNode)
+      ) {
+        return 0.45;
+      }
+      return 0.9;
+    },
+    [hoveredNodeId, isNodeDimmed, nodeById, selectedNodeId],
+  );
+
+  const drawClusterFields = useCallback(
+    (ctx: CanvasRenderingContext2D) => {
+      if (!graphData) return;
+
+      const clusters = new Map<
+        string,
+        {
+          color: string;
+          nodes: GraphNode[];
+          sumX: number;
+          sumY: number;
+        }
+      >();
+
+      for (const node of graphData.nodes) {
+        if (isNodeDimmed(node)) continue;
+        const clusterKey = node.clusterId ?? `unclustered:${node.id}`;
+        const existing = clusters.get(clusterKey);
+        if (existing) {
+          existing.nodes.push(node);
+          existing.sumX += node.x ?? node.seedX;
+          existing.sumY += node.y ?? node.seedY;
+          continue;
+        }
+        clusters.set(clusterKey, {
+          color: node.color,
+          nodes: [node],
+          sumX: node.x ?? node.seedX,
+          sumY: node.y ?? node.seedY,
+        });
+      }
+
+      for (const cluster of clusters.values()) {
+        if (cluster.nodes.length === 0) continue;
+
+        const centerX = cluster.sumX / cluster.nodes.length;
+        const centerY = cluster.sumY / cluster.nodes.length;
+
+        let spread = 0;
+        for (const node of cluster.nodes) {
+          const dx = (node.x ?? node.seedX) - centerX;
+          const dy = (node.y ?? node.seedY) - centerY;
+          spread = Math.max(spread, Math.hypot(dx, dy) + node.radius * 1.8);
+        }
+
+        const radius =
+          cluster.nodes.length === 1
+            ? Math.max(64, spread + 36)
+            : Math.max(120, spread + 92);
+        const gradient = ctx.createRadialGradient(
+          centerX,
+          centerY,
+          radius * 0.08,
+          centerX,
+          centerY,
+          radius,
+        );
+        gradient.addColorStop(
+          0,
+          hexToRgba(cluster.color, cluster.nodes.length > 1 ? 0.16 : 0.08),
+        );
+        gradient.addColorStop(
+          0.52,
+          hexToRgba(cluster.color, cluster.nodes.length > 1 ? 0.08 : 0.04),
+        );
+        gradient.addColorStop(1, "rgba(0,0,0,0)");
+
+        ctx.save();
+        ctx.globalCompositeOperation = "screen";
+        ctx.fillStyle = gradient;
+        ctx.beginPath();
+        ctx.arc(centerX, centerY, radius, 0, 2 * Math.PI);
+        ctx.fill();
+
+        if (cluster.nodes.length > 1) {
+          ctx.beginPath();
+          ctx.strokeStyle = hexToRgba(cluster.color, 0.18);
+          ctx.lineWidth = 1.1;
+          ctx.arc(centerX, centerY, radius * 0.72, 0, 2 * Math.PI);
+          ctx.stroke();
+        }
+        ctx.restore();
+      }
+    },
+    [graphData, isNodeDimmed],
   );
 
   const runCopy =
@@ -392,7 +849,12 @@ export function ChatboxTopicMapPanel({
             ? `${snapshot.stats.mappedSessionCount.toLocaleString()} mapped sessions`
             : "No topic map yet";
 
-  if (!snapshot && (isLoading || latestRun?.status === "running" || latestRun?.status === "queued")) {
+  if (
+    !snapshot &&
+    (isLoading ||
+      latestRun?.status === "running" ||
+      latestRun?.status === "queued")
+  ) {
     return (
       <div className="flex h-full min-h-0 items-center justify-center bg-[#070917] text-slate-100">
         <div className="flex max-w-sm flex-col items-center gap-3 text-center">
@@ -445,14 +907,24 @@ export function ChatboxTopicMapPanel({
   }
 
   return (
-    <div className="flex h-full min-h-0 overflow-hidden bg-[#070917] text-slate-100">
+    <div className="flex h-full min-h-0 overflow-hidden bg-[#060914] text-slate-100">
       <div className="relative min-w-0 flex-1 overflow-hidden">
-        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(34,197,94,0.14),_transparent_26%),radial-gradient(circle_at_bottom_right,_rgba(96,165,250,0.12),_transparent_30%),linear-gradient(180deg,_rgba(15,23,42,0.06),_rgba(2,6,23,0.18))]" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(32,201,151,0.14),_transparent_24%),radial-gradient(circle_at_bottom_right,_rgba(96,165,250,0.16),_transparent_32%),linear-gradient(180deg,_rgba(10,13,27,0.96),_rgba(4,8,21,1))]" />
+        <div
+          className="absolute inset-0 opacity-35"
+          style={{
+            backgroundImage:
+              "linear-gradient(rgba(148,163,184,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(148,163,184,0.05) 1px, transparent 1px)",
+            backgroundSize: "40px 40px",
+            maskImage:
+              "radial-gradient(circle at 50% 45%, rgba(0,0,0,0.95), rgba(0,0,0,0.18) 78%, transparent 100%)",
+          }}
+        />
 
         <div className="absolute left-4 right-4 top-4 z-10 flex flex-wrap items-start justify-between gap-3">
           <div className="space-y-2">
             <div className="flex flex-wrap items-center gap-2">
-              <span className="rounded-full bg-white/8 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.18em] text-slate-200/80">
+              <span className="rounded-full border border-white/8 bg-white/6 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.22em] text-slate-200/80">
                 Historical Topic Map
               </span>
               <span
@@ -479,6 +951,9 @@ export function ChatboxTopicMapPanel({
                 </>
               ) : null}
             </div>
+            <p className="text-[11px] text-slate-400/80">
+              Drag the canvas to pan, scroll to zoom, click a node to inspect.
+            </p>
             {snapshot.isSampled ? (
               <div className="max-w-xl rounded-2xl border border-amber-300/20 bg-amber-300/10 px-3 py-2 text-[11px] text-amber-100/90">
                 Showing a stable 10,000-session sample of{" "}
@@ -488,109 +963,99 @@ export function ChatboxTopicMapPanel({
             ) : null}
           </div>
 
-          <Button
-            type="button"
-            variant="outline"
-            className="border-white/15 bg-white/5 text-slate-100 hover:bg-white/10"
-            disabled={rebuildDisabled(latestRun) || rebuildBusy}
-            onClick={onRebuild}
-          >
-            <RefreshCw
-              className={cn(
-                "mr-2 h-3.5 w-3.5",
-                latestRun?.status === "running" && !latestRun.isStale
-                  ? "animate-spin"
-                  : "",
-              )}
-            />
-            {rebuildButtonLabel(latestRun)}
-          </Button>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="border-white/12 bg-white/[0.04] text-slate-100 hover:bg-white/[0.08]"
+              onClick={() => fitGraph()}
+            >
+              <LocateFixed className="mr-2 h-3.5 w-3.5" />
+              Fit view
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="border-white/12 bg-white/[0.04] text-slate-100 hover:bg-white/[0.08]"
+              disabled={rebuildDisabled(latestRun) || rebuildBusy}
+              onClick={onRebuild}
+            >
+              <RefreshCw
+                className={cn(
+                  "mr-2 h-3.5 w-3.5",
+                  latestRun?.status === "running" && !latestRun.isStale
+                    ? "animate-spin"
+                    : "",
+                )}
+              />
+              {rebuildButtonLabel(latestRun)}
+            </Button>
+          </div>
         </div>
 
-        <div className="h-full w-full">
-          {projectedGraph ? (
-            <svg
-              width="100%"
-              height="100%"
-              viewBox={`0 0 ${GRAPH_VIEWPORT_WIDTH} ${GRAPH_VIEWPORT_HEIGHT}`}
-              preserveAspectRatio="xMidYMid meet"
-              className="block h-full w-full"
-              role="img"
-              aria-label="Historical session topic map"
-            >
-              <g>
-                {projectedGraph.links.map((link) => (
-                  <line
-                    key={`${link.source}:${link.target}`}
-                    x1={link.sourceX}
-                    y1={link.sourceY}
-                    x2={link.targetX}
-                    y2={link.targetY}
-                    stroke={
-                      link.isSelected
-                        ? "rgba(248,250,252,0.6)"
-                        : link.isDimmed
-                          ? "rgba(148,163,184,0.08)"
-                          : "rgba(148,163,184,0.24)"
-                    }
-                    strokeWidth={link.isSelected ? 2 : link.isDimmed ? 0.75 : 1.2}
-                    strokeLinecap="round"
-                  />
-                ))}
-              </g>
-              <g>
-                {projectedGraph.nodes.map((node) => (
-                  <g
-                    key={node.id}
-                    role="button"
-                    tabIndex={0}
-                    aria-label={`Topic map node ${node.clusterLabel ?? node.id}`}
-                    onClick={() => {
-                      setSelectedNodeId(node.id);
-                      setActiveTab("info");
-                    }}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter" || event.key === " ") {
-                        event.preventDefault();
-                        setSelectedNodeId(node.id);
-                        setActiveTab("info");
-                      }
-                    }}
-                    className="cursor-pointer outline-none"
-                  >
-                    {node.isSearchMatch && deferredSearch ? (
-                      <circle
-                        cx={node.screenX}
-                        cy={node.screenY}
-                        r={node.screenRadius + 5}
-                        fill="transparent"
-                        stroke="rgba(248,250,252,0.72)"
-                        strokeWidth="2"
-                      />
-                    ) : null}
-                    <circle
-                      cx={node.screenX}
-                      cy={node.screenY}
-                      r={node.screenRadius + (node.isSelected ? 3 : 0)}
-                      fill={node.isSelected ? "rgba(255,255,255,0.14)" : "transparent"}
-                    />
-                    <circle
-                      cx={node.screenX}
-                      cy={node.screenY}
-                      r={node.screenRadius}
-                      fill={node.isDimmed ? "rgba(148,163,184,0.26)" : node.color}
-                      stroke={node.isSelected ? "#ffffff" : "rgba(15,23,42,0.55)"}
-                      strokeWidth={node.isSelected ? 2.5 : 1}
-                    />
-                  </g>
-                ))}
-              </g>
-            </svg>
-          ) : null}
+        <div ref={graphContainerRef} className="h-full w-full pt-20">
+          <ForceGraph2D
+            ref={graphRef as never}
+            graphData={graphData ?? { nodes: [], links: [] }}
+            width={size.width}
+            height={size.height}
+            backgroundColor="rgba(0,0,0,0)"
+            nodeCanvasObjectMode={() => "replace"}
+            nodeCanvasObject={drawNode}
+            nodeLabel={(node) => {
+              const graphNode = node as GraphNode;
+              return `${graphNode.clusterLabel ?? graphNode.sessionId}\n${graphNode.semanticPreview}`;
+            }}
+            linkColor={linkColor}
+            linkWidth={linkWidth}
+            linkCurvature={(link) => {
+              const sourceId = getLinkEndpointId((link as GraphLink).source);
+              const targetId = getLinkEndpointId((link as GraphLink).target);
+              const emphasized =
+                selectedNodeId != null &&
+                (sourceId === selectedNodeId || targetId === selectedNodeId);
+              return emphasized ? 0.12 : 0.045;
+            }}
+            autoPauseRedraw={false}
+            minZoom={0.35}
+            maxZoom={6}
+            warmupTicks={30}
+            cooldownTicks={150}
+            d3AlphaDecay={0.018}
+            d3VelocityDecay={0.28}
+            enableNodeDrag={false}
+            enablePanInteraction
+            enableZoomInteraction
+            showPointerCursor={(node) => !!node}
+            onNodeHover={(node) => {
+              setHoveredNodeId((node as GraphNode | null)?.id ?? null);
+            }}
+            onNodeClick={(node) => {
+              focusNode((node as GraphNode).id);
+            }}
+            onBackgroundClick={() => {
+              setHoveredNodeId(null);
+            }}
+            onRenderFramePre={(ctx) => {
+              drawClusterFields(ctx);
+              const gradient = ctx.createRadialGradient(
+                size.width * 0.52,
+                size.height * 0.48,
+                size.height * 0.04,
+                size.width * 0.52,
+                size.height * 0.48,
+                size.height * 0.58,
+              );
+              gradient.addColorStop(0, "rgba(255,255,255,0.02)");
+              gradient.addColorStop(1, "rgba(255,255,255,0)");
+              ctx.fillStyle = gradient;
+              ctx.fillRect(0, 0, size.width, size.height);
+            }}
+          />
         </div>
       </div>
 
-      <aside className="flex w-[360px] shrink-0 flex-col border-l border-white/10 bg-[#0d1120]">
+      <aside className="flex w-[372px] shrink-0 flex-col border-l border-white/10 bg-[#0b1020]/96 backdrop-blur-xl">
         <div className="border-b border-white/10 p-4">
           <SearchInput
             value={searchQuery}
@@ -608,19 +1073,19 @@ export function ChatboxTopicMapPanel({
           <TabsList className="grid grid-cols-3 rounded-none border-b border-white/10 bg-transparent p-0">
             <TabsTrigger
               value="info"
-              className="rounded-none border-r border-white/10 data-[state=active]:bg-white/10"
+              className="rounded-none border-r border-white/10 data-[state=active]:bg-white/8"
             >
               Info
             </TabsTrigger>
             <TabsTrigger
               value="filters"
-              className="rounded-none border-r border-white/10 data-[state=active]:bg-white/10"
+              className="rounded-none border-r border-white/10 data-[state=active]:bg-white/8"
             >
               Filters
             </TabsTrigger>
             <TabsTrigger
               value="communities"
-              className="rounded-none data-[state=active]:bg-white/10"
+              className="rounded-none data-[state=active]:bg-white/8"
             >
               Communities
             </TabsTrigger>
@@ -636,7 +1101,7 @@ export function ChatboxTopicMapPanel({
                         <Info className="h-3.5 w-3.5" />
                         Node Info
                       </div>
-                      <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                      <div className="rounded-3xl border border-white/10 bg-white/[0.045] p-4 shadow-[0_20px_60px_rgba(4,8,21,0.35)]">
                         <p className="break-all text-sm font-semibold text-slate-50">
                           {selectedNode.id}
                         </p>
@@ -682,7 +1147,7 @@ export function ChatboxTopicMapPanel({
                         <Sparkles className="h-3.5 w-3.5" />
                         Semantic Preview
                       </div>
-                      <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm leading-6 text-slate-100/90">
+                      <div className="rounded-3xl border border-white/10 bg-white/[0.045] p-4 text-sm leading-6 text-slate-100/90 shadow-[0_20px_60px_rgba(4,8,21,0.35)]">
                         {selectedNode.semanticPreview}
                       </div>
                     </section>
@@ -698,8 +1163,8 @@ export function ChatboxTopicMapPanel({
                             <button
                               key={neighbor.id}
                               type="button"
-                              onClick={() => setSelectedNodeId(neighbor.id)}
-                              className="w-full rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-left transition hover:bg-white/10"
+                              onClick={() => focusNode(neighbor.id, 2.25)}
+                              className="w-full rounded-3xl border border-white/10 bg-white/[0.045] px-3 py-3 text-left transition hover:bg-white/[0.08]"
                             >
                               <div className="flex items-center gap-2">
                                 <span
@@ -719,7 +1184,7 @@ export function ChatboxTopicMapPanel({
                             </button>
                           ))
                         ) : (
-                          <div className="rounded-2xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
+                          <div className="rounded-3xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
                             No reciprocal neighbors survived the graph pruning for
                             this node.
                           </div>
@@ -728,7 +1193,7 @@ export function ChatboxTopicMapPanel({
                     </section>
                   </>
                 ) : (
-                  <div className="rounded-2xl border border-dashed border-white/10 bg-white/[0.03] p-4 text-sm text-slate-300/70">
+                  <div className="rounded-3xl border border-dashed border-white/10 bg-white/[0.03] p-4 text-sm text-slate-300/70">
                     Select a node to inspect its summary, community, and nearest
                     neighbors.
                   </div>
@@ -752,14 +1217,14 @@ export function ChatboxTopicMapPanel({
                           key={chipKey(chip)}
                           type="button"
                           onClick={() => onClearChip(chipKey(chip))}
-                          className="rounded-full border border-white/10 bg-white/8 px-3 py-1 text-xs text-slate-100 transition hover:bg-white/12"
+                          className="rounded-full border border-white/10 bg-white/[0.06] px-3 py-1 text-xs text-slate-100 transition hover:bg-white/[0.1]"
                         >
                           {chip.label ?? chip.clusterId}
                         </button>
                       ))}
                     </div>
                   ) : (
-                    <div className="rounded-2xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
+                    <div className="rounded-3xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
                       No community filters are active. Pick a community from the
                       Communities tab to isolate it in the graph.
                     </div>
@@ -778,11 +1243,8 @@ export function ChatboxTopicMapPanel({
                           <button
                             key={node.id}
                             type="button"
-                            onClick={() => {
-                              setSelectedNodeId(node.id);
-                              setActiveTab("info");
-                            }}
-                            className="w-full rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-left transition hover:bg-white/10"
+                            onClick={() => focusNode(node.id, 2.2)}
+                            className="w-full rounded-3xl border border-white/10 bg-white/[0.045] px-3 py-3 text-left transition hover:bg-white/[0.08]"
                           >
                             <div className="flex items-center justify-between gap-3">
                               <span className="truncate text-xs font-medium text-slate-100">
@@ -801,12 +1263,12 @@ export function ChatboxTopicMapPanel({
                         ))}
                       </div>
                     ) : (
-                      <div className="rounded-2xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
+                      <div className="rounded-3xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
                         No nodes matched “{deferredSearch}”.
                       </div>
                     )
                   ) : (
-                    <div className="rounded-2xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
+                    <div className="rounded-3xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
                       Search by community label, semantic preview, session ID, or
                       model.
                     </div>
@@ -821,6 +1283,10 @@ export function ChatboxTopicMapPanel({
               <div className="space-y-3 p-4">
                 {communities.map((community) => {
                   const isActive = activeClusterIds.has(community.clusterId);
+                  const swatch = colorForCluster(
+                    community.clusterId,
+                    clusterColorIndex.get(community.clusterId) ?? 0,
+                  );
                   return (
                     <button
                       key={community.clusterId}
@@ -833,17 +1299,23 @@ export function ChatboxTopicMapPanel({
                         })
                       }
                       className={cn(
-                        "w-full rounded-2xl border px-3 py-3 text-left transition",
+                        "w-full rounded-3xl border px-3 py-3 text-left transition",
                         isActive
-                          ? "border-cyan-300/50 bg-cyan-300/10"
-                          : "border-white/10 bg-white/5 hover:bg-white/10",
+                          ? "border-cyan-300/40 bg-cyan-300/10"
+                          : "border-white/10 bg-white/[0.045] hover:bg-white/[0.08]",
                       )}
                     >
                       <div className="flex items-start justify-between gap-3">
-                        <div>
-                          <p className="text-sm font-semibold text-slate-50">
-                            {community.label}
-                          </p>
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span
+                              className="h-2.5 w-2.5 rounded-full"
+                              style={{ backgroundColor: swatch }}
+                            />
+                            <p className="truncate text-sm font-semibold text-slate-50">
+                              {community.label}
+                            </p>
+                          </div>
                           <p className="mt-1 text-xs text-slate-300/75">
                             {community.summary}
                           </p>

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
@@ -1,0 +1,877 @@
+import {
+  startTransition,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { format, formatDistanceToNow } from "date-fns";
+import {
+  AlertTriangle,
+  Filter,
+  Info,
+  LoaderCircle,
+  Network,
+  RefreshCw,
+  Sparkles,
+} from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { ScrollArea } from "@mcpjam/design-system/scroll-area";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@mcpjam/design-system/tabs";
+import { SearchInput } from "@/components/ui/search-input";
+import {
+  chipKey,
+  type UsageFilterChip,
+  type UsageFilterState,
+} from "@/hooks/chatbox-usage-filters";
+import { useChatboxTopicMap } from "@/hooks/useChatboxTopicMap";
+import type { ClusterRunState } from "@/hooks/useUsageInsights";
+import { cn } from "@/lib/utils";
+
+const CLUSTER_COLORS = [
+  "#f87171",
+  "#fbbf24",
+  "#4ade80",
+  "#60a5fa",
+  "#c084fc",
+  "#fb7185",
+  "#34d399",
+  "#38bdf8",
+  "#fde047",
+  "#a3e635",
+  "#f472b6",
+  "#2dd4bf",
+];
+const GRAPH_SPREAD = 1800;
+const GRAPH_PADDING = 96;
+const GRAPH_VIEWPORT_WIDTH = 1600;
+const GRAPH_VIEWPORT_HEIGHT = 1000;
+
+type SidebarTab = "info" | "filters" | "communities";
+
+type GraphNode = {
+  id: string;
+  clusterId?: string;
+  clusterLabel?: string;
+  semanticPreview: string;
+  messageCount: number;
+  startedAt: number;
+  lastActivityAt: number;
+  modelId?: string;
+  degree: number;
+  x: number;
+  y: number;
+  fx: number;
+  fy: number;
+  color: string;
+  radius: number;
+  isDimmed: boolean;
+  isSearchMatch: boolean;
+  isSelected: boolean;
+};
+
+type GraphLink = {
+  source: string;
+  target: string;
+  score: number;
+  isDimmed: boolean;
+  isSelected: boolean;
+};
+
+type ProjectedNode = GraphNode & {
+  screenX: number;
+  screenY: number;
+  screenRadius: number;
+};
+
+type ProjectedLink = GraphLink & {
+  sourceX: number;
+  sourceY: number;
+  targetX: number;
+  targetY: number;
+};
+
+interface ChatboxTopicMapPanelProps {
+  chatboxId: string;
+  filter: UsageFilterState;
+  onToggleChip: (chip: UsageFilterChip) => void;
+  onClearChip: (key: string) => void;
+  onRebuild: () => void;
+  rebuildBusy?: boolean;
+}
+
+function rebuildButtonLabel(run: ClusterRunState | null): string {
+  if (!run) return "Rebuild topic map";
+  if (run.isStale) return "Rebuild topic map";
+  switch (run.status) {
+    case "queued":
+      return "Queued…";
+    case "running":
+      return "Refreshing…";
+    case "failed":
+      return "Retry rebuild";
+    default:
+      return "Rebuild topic map";
+  }
+}
+
+function rebuildDisabled(run: ClusterRunState | null): boolean {
+  if (!run) return false;
+  if (run.isStale) return false;
+  return run.status === "queued" || run.status === "running";
+}
+
+function formatRunTone(run: ClusterRunState | null): string {
+  if (!run) return "bg-white/10 text-slate-200";
+  if (run.status === "failed") return "bg-rose-500/15 text-rose-200";
+  if (run.status === "running" || run.status === "queued") {
+    return "bg-amber-400/15 text-amber-100";
+  }
+  return "bg-emerald-400/15 text-emerald-100";
+}
+
+function colorForCluster(clusterId: string | undefined, fallbackIndex: number) {
+  if (!clusterId) return "#94a3b8";
+  return CLUSTER_COLORS[fallbackIndex % CLUSTER_COLORS.length];
+}
+
+function matchesSearch(
+  query: string,
+  node: {
+    sessionId: string;
+    clusterLabel?: string;
+    semanticPreview: string;
+    modelId?: string;
+  },
+) {
+  if (!query) return true;
+  const haystack = [
+    node.sessionId,
+    node.clusterLabel ?? "",
+    node.semanticPreview,
+    node.modelId ?? "",
+  ]
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(query);
+}
+
+export function ChatboxTopicMapPanel({
+  chatboxId,
+  filter,
+  onToggleChip,
+  onClearChip,
+  onRebuild,
+  rebuildBusy,
+}: ChatboxTopicMapPanelProps) {
+  const { latestRun, snapshot, snapshotMetadata, snapshotError, isLoading } =
+    useChatboxTopicMap({
+      chatboxId,
+      enabled: true,
+    });
+  const [activeTab, setActiveTab] = useState<SidebarTab>("info");
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const deferredSearch = useDeferredValue(searchQuery.trim().toLowerCase());
+
+  const activeClusterIds = useMemo(
+    () =>
+      new Set(
+        filter.chips.flatMap((chip) =>
+          chip.kind === "cluster" ? [chip.clusterId] : [],
+        ),
+      ),
+    [filter.chips],
+  );
+
+  const clusterColorIndex = useMemo(
+    () =>
+      new Map(
+        (snapshot?.clusters ?? []).map((cluster) => [
+          cluster.clusterId,
+          cluster.colorIndex,
+        ]),
+      ),
+    [snapshot?.clusters],
+  );
+
+  const graphData = useMemo(() => {
+    if (!snapshot) return null;
+    const nodes: GraphNode[] = snapshot.nodes.map((node) => {
+      const clusterMatch =
+        activeClusterIds.size === 0 ||
+        (node.clusterId ? activeClusterIds.has(node.clusterId) : false);
+      const searchMatch = matchesSearch(deferredSearch, {
+        sessionId: node.sessionId,
+        clusterLabel: node.clusterLabel,
+        semanticPreview: node.semanticPreview,
+        modelId: node.modelId,
+      });
+      const color = colorForCluster(
+        node.clusterId,
+        clusterColorIndex.get(node.clusterId ?? "") ?? 0,
+      );
+      const radius = Math.max(
+        2,
+        Math.min(7, 2 + Math.log1p(node.degree + node.messageCount) * 0.9),
+      );
+      return {
+        id: node.sessionId,
+        clusterId: node.clusterId,
+        clusterLabel: node.clusterLabel,
+        semanticPreview: node.semanticPreview,
+        messageCount: node.messageCount,
+        startedAt: node.startedAt,
+        lastActivityAt: node.lastActivityAt,
+        modelId: node.modelId,
+        degree: node.degree,
+        x: node.x * GRAPH_SPREAD,
+        y: node.y * GRAPH_SPREAD,
+        fx: node.x * GRAPH_SPREAD,
+        fy: node.y * GRAPH_SPREAD,
+        color,
+        radius,
+        isDimmed: !clusterMatch || !searchMatch,
+        isSearchMatch: searchMatch,
+        isSelected: node.sessionId === selectedNodeId,
+      };
+    });
+
+    const dimmedNodes = new Map(nodes.map((node) => [node.id, node.isDimmed]));
+    const selectedEdges = new Set<string>();
+    if (selectedNodeId) {
+      snapshot.edges.forEach((edge) => {
+        if (edge.source === selectedNodeId || edge.target === selectedNodeId) {
+          selectedEdges.add(`${edge.source}:${edge.target}`);
+        }
+      });
+    }
+    const links: GraphLink[] = snapshot.edges.map((edge) => ({
+      source: edge.source,
+      target: edge.target,
+      score: edge.score,
+      isDimmed:
+        (dimmedNodes.get(edge.source) ?? false) ||
+        (dimmedNodes.get(edge.target) ?? false),
+      isSelected: selectedEdges.has(`${edge.source}:${edge.target}`),
+    }));
+
+    return { nodes, links };
+  }, [activeClusterIds, clusterColorIndex, deferredSearch, selectedNodeId, snapshot]);
+
+  const nodeById = useMemo(
+    () =>
+      new Map(
+        (graphData?.nodes ?? []).map((node) => [node.id, node]),
+      ),
+    [graphData?.nodes],
+  );
+
+  const selectedNode = selectedNodeId ? nodeById.get(selectedNodeId) ?? null : null;
+
+  const selectedNeighbors = useMemo(() => {
+    if (!selectedNodeId || !graphData) return [];
+    return graphData.links
+      .filter(
+        (edge) => edge.source === selectedNodeId || edge.target === selectedNodeId,
+      )
+      .sort((left, right) => right.score - left.score)
+      .map((edge) => {
+        const neighborId =
+          edge.source === selectedNodeId ? edge.target : edge.source;
+        const node = nodeById.get(neighborId);
+        return node
+          ? {
+              id: neighborId,
+              score: edge.score,
+              clusterLabel: node.clusterLabel,
+              semanticPreview: node.semanticPreview,
+              color: node.color,
+            }
+          : null;
+      })
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
+  }, [graphData, nodeById, selectedNodeId]);
+
+  const searchMatches = useMemo(() => {
+    if (!graphData || !deferredSearch) return [];
+    return graphData.nodes
+      .filter((node) => node.isSearchMatch)
+      .slice(0, 12);
+  }, [deferredSearch, graphData]);
+
+  const communities = useMemo(
+    () =>
+      [...(snapshot?.clusters ?? [])].sort(
+        (left, right) => right.memberCount - left.memberCount,
+      ),
+    [snapshot?.clusters],
+  );
+
+  useEffect(() => {
+    if (!snapshot) {
+      setSelectedNodeId(null);
+      return;
+    }
+    if (selectedNodeId && snapshot.nodes.some((node) => node.sessionId === selectedNodeId)) {
+      return;
+    }
+    setSelectedNodeId(snapshot.nodes[0]?.sessionId ?? null);
+  }, [selectedNodeId, snapshot]);
+
+  const projectedGraph = useMemo(() => {
+    if (!graphData) {
+      return null;
+    }
+
+    const nodes = graphData.nodes;
+    const xs = nodes.map((node) => node.fx ?? node.x ?? 0);
+    const ys = nodes.map((node) => node.fy ?? node.y ?? 0);
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    const minY = Math.min(...ys);
+    const maxY = Math.max(...ys);
+    const spanX = Math.max(1, maxX - minX);
+    const spanY = Math.max(1, maxY - minY);
+    const availableWidth = Math.max(1, GRAPH_VIEWPORT_WIDTH - GRAPH_PADDING * 2);
+    const availableHeight = Math.max(1, GRAPH_VIEWPORT_HEIGHT - GRAPH_PADDING * 2);
+    const scale = Math.max(
+      0.05,
+      Math.min(availableWidth / spanX, availableHeight / spanY),
+    );
+    const offsetX = (GRAPH_VIEWPORT_WIDTH - spanX * scale) / 2;
+    const offsetY = (GRAPH_VIEWPORT_HEIGHT - spanY * scale) / 2;
+
+    const projectedNodes = nodes.map((node) => {
+      const graphX = node.fx ?? node.x ?? 0;
+      const graphY = node.fy ?? node.y ?? 0;
+      return {
+        ...node,
+        screenX: (graphX - minX) * scale + offsetX,
+        screenY: (graphY - minY) * scale + offsetY,
+        screenRadius: Math.max(4.5, node.radius * 1.5),
+      };
+    });
+    const projectedById = new Map(
+      projectedNodes.map((node) => [node.id, node]),
+    );
+    const projectedLinks = graphData.links
+      .map((link) => {
+        const source = projectedById.get(link.source);
+        const target = projectedById.get(link.target);
+        if (!source || !target) return null;
+        return {
+          ...link,
+          sourceX: source.screenX,
+          sourceY: source.screenY,
+          targetX: target.screenX,
+          targetY: target.screenY,
+        };
+      })
+      .filter((link): link is ProjectedLink => link !== null);
+
+    return {
+      nodes: projectedNodes,
+      links: projectedLinks,
+    };
+  }, [graphData]);
+
+  const activeClusterChips = filter.chips.filter(
+    (chip): chip is Extract<UsageFilterChip, { kind: "cluster" }> =>
+      chip.kind === "cluster",
+  );
+
+  const runCopy =
+    latestRun?.status === "running"
+      ? "Updating historical topic map"
+      : latestRun?.status === "queued"
+        ? "Queued for rebuild"
+        : latestRun?.status === "failed"
+          ? "Last rebuild failed"
+          : snapshot
+            ? `${snapshot.stats.mappedSessionCount.toLocaleString()} mapped sessions`
+            : "No topic map yet";
+
+  if (!snapshot && (isLoading || latestRun?.status === "running" || latestRun?.status === "queued")) {
+    return (
+      <div className="flex h-full min-h-0 items-center justify-center bg-[#070917] text-slate-100">
+        <div className="flex max-w-sm flex-col items-center gap-3 text-center">
+          <LoaderCircle className="h-8 w-8 animate-spin text-cyan-200" />
+          <div>
+            <p className="text-sm font-medium">Building the historical topic map</p>
+            <p className="mt-1 text-xs text-slate-300/70">
+              Sessions are being summarized, clustered, and laid out for the graph.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!snapshot) {
+    return (
+      <div className="flex h-full min-h-0 items-center justify-center bg-[#070917] text-slate-100">
+        <div className="flex max-w-md flex-col items-center gap-3 text-center">
+          {latestRun?.status === "failed" ? (
+            <AlertTriangle className="h-8 w-8 text-rose-300" />
+          ) : (
+            <Network className="h-8 w-8 text-slate-400" />
+          )}
+          <div>
+            <p className="text-sm font-medium">
+              {latestRun?.status === "failed"
+                ? "Topic map rebuild failed"
+                : "No topic map snapshot yet"}
+            </p>
+            <p className="mt-1 text-xs text-slate-300/70">
+              {snapshotError ??
+                latestRun?.errorMessage ??
+                "Run a rebuild to summarize and cluster historical sessions."}
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            className="border-white/15 bg-white/5 text-slate-100 hover:bg-white/10"
+            disabled={rebuildDisabled(latestRun) || rebuildBusy}
+            onClick={onRebuild}
+          >
+            <RefreshCw className="mr-2 h-3.5 w-3.5" />
+            {rebuildButtonLabel(latestRun)}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 overflow-hidden bg-[#070917] text-slate-100">
+      <div className="relative min-w-0 flex-1 overflow-hidden">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(34,197,94,0.14),_transparent_26%),radial-gradient(circle_at_bottom_right,_rgba(96,165,250,0.12),_transparent_30%),linear-gradient(180deg,_rgba(15,23,42,0.06),_rgba(2,6,23,0.18))]" />
+
+        <div className="absolute left-4 right-4 top-4 z-10 flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="rounded-full bg-white/8 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.18em] text-slate-200/80">
+                Historical Topic Map
+              </span>
+              <span
+                className={cn(
+                  "rounded-full px-2.5 py-1 text-[11px] font-medium",
+                  formatRunTone(latestRun),
+                )}
+              >
+                {runCopy}
+              </span>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 text-[11px] text-slate-300/75">
+              <span>{snapshot.stats.nodeCount.toLocaleString()} visible nodes</span>
+              <span>•</span>
+              <span>{snapshot.stats.edgeCount.toLocaleString()} edges</span>
+              <span>•</span>
+              <span>{snapshot.stats.clusterCount} communities</span>
+              {snapshot.stats.unmappedSessionCount > 0 ? (
+                <>
+                  <span>•</span>
+                  <span>
+                    {snapshot.stats.unmappedSessionCount.toLocaleString()} unmapped
+                  </span>
+                </>
+              ) : null}
+            </div>
+            {snapshot.isSampled ? (
+              <div className="max-w-xl rounded-2xl border border-amber-300/20 bg-amber-300/10 px-3 py-2 text-[11px] text-amber-100/90">
+                Showing a stable 10,000-session sample of{" "}
+                {snapshot.stats.mappedSessionCount.toLocaleString()} mapped
+                sessions for this chatbox.
+              </div>
+            ) : null}
+          </div>
+
+          <Button
+            type="button"
+            variant="outline"
+            className="border-white/15 bg-white/5 text-slate-100 hover:bg-white/10"
+            disabled={rebuildDisabled(latestRun) || rebuildBusy}
+            onClick={onRebuild}
+          >
+            <RefreshCw
+              className={cn(
+                "mr-2 h-3.5 w-3.5",
+                latestRun?.status === "running" && !latestRun.isStale
+                  ? "animate-spin"
+                  : "",
+              )}
+            />
+            {rebuildButtonLabel(latestRun)}
+          </Button>
+        </div>
+
+        <div className="h-full w-full">
+          {projectedGraph ? (
+            <svg
+              width="100%"
+              height="100%"
+              viewBox={`0 0 ${GRAPH_VIEWPORT_WIDTH} ${GRAPH_VIEWPORT_HEIGHT}`}
+              preserveAspectRatio="xMidYMid meet"
+              className="block h-full w-full"
+              role="img"
+              aria-label="Historical session topic map"
+            >
+              <g>
+                {projectedGraph.links.map((link) => (
+                  <line
+                    key={`${link.source}:${link.target}`}
+                    x1={link.sourceX}
+                    y1={link.sourceY}
+                    x2={link.targetX}
+                    y2={link.targetY}
+                    stroke={
+                      link.isSelected
+                        ? "rgba(248,250,252,0.6)"
+                        : link.isDimmed
+                          ? "rgba(148,163,184,0.08)"
+                          : "rgba(148,163,184,0.24)"
+                    }
+                    strokeWidth={link.isSelected ? 2 : link.isDimmed ? 0.75 : 1.2}
+                    strokeLinecap="round"
+                  />
+                ))}
+              </g>
+              <g>
+                {projectedGraph.nodes.map((node) => (
+                  <g
+                    key={node.id}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Topic map node ${node.clusterLabel ?? node.id}`}
+                    onClick={() => {
+                      setSelectedNodeId(node.id);
+                      setActiveTab("info");
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        setSelectedNodeId(node.id);
+                        setActiveTab("info");
+                      }
+                    }}
+                    className="cursor-pointer outline-none"
+                  >
+                    {node.isSearchMatch && deferredSearch ? (
+                      <circle
+                        cx={node.screenX}
+                        cy={node.screenY}
+                        r={node.screenRadius + 5}
+                        fill="transparent"
+                        stroke="rgba(248,250,252,0.72)"
+                        strokeWidth="2"
+                      />
+                    ) : null}
+                    <circle
+                      cx={node.screenX}
+                      cy={node.screenY}
+                      r={node.screenRadius + (node.isSelected ? 3 : 0)}
+                      fill={node.isSelected ? "rgba(255,255,255,0.14)" : "transparent"}
+                    />
+                    <circle
+                      cx={node.screenX}
+                      cy={node.screenY}
+                      r={node.screenRadius}
+                      fill={node.isDimmed ? "rgba(148,163,184,0.26)" : node.color}
+                      stroke={node.isSelected ? "#ffffff" : "rgba(15,23,42,0.55)"}
+                      strokeWidth={node.isSelected ? 2.5 : 1}
+                    />
+                  </g>
+                ))}
+              </g>
+            </svg>
+          ) : null}
+        </div>
+      </div>
+
+      <aside className="flex w-[360px] shrink-0 flex-col border-l border-white/10 bg-[#0d1120]">
+        <div className="border-b border-white/10 p-4">
+          <SearchInput
+            value={searchQuery}
+            onValueChange={(value) => startTransition(() => setSearchQuery(value))}
+            placeholder="Search nodes..."
+            className="text-slate-100"
+          />
+        </div>
+
+        <Tabs
+          value={activeTab}
+          onValueChange={(value) => setActiveTab(value as SidebarTab)}
+          className="flex min-h-0 flex-1 flex-col"
+        >
+          <TabsList className="grid grid-cols-3 rounded-none border-b border-white/10 bg-transparent p-0">
+            <TabsTrigger
+              value="info"
+              className="rounded-none border-r border-white/10 data-[state=active]:bg-white/10"
+            >
+              Info
+            </TabsTrigger>
+            <TabsTrigger
+              value="filters"
+              className="rounded-none border-r border-white/10 data-[state=active]:bg-white/10"
+            >
+              Filters
+            </TabsTrigger>
+            <TabsTrigger
+              value="communities"
+              className="rounded-none data-[state=active]:bg-white/10"
+            >
+              Communities
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="info" className="min-h-0 flex-1 data-[state=inactive]:hidden">
+            <ScrollArea className="h-full">
+              <div className="space-y-5 p-4">
+                {selectedNode ? (
+                  <>
+                    <section className="space-y-3">
+                      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-slate-300/70">
+                        <Info className="h-3.5 w-3.5" />
+                        Node Info
+                      </div>
+                      <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                        <p className="break-all text-sm font-semibold text-slate-50">
+                          {selectedNode.id}
+                        </p>
+                        <dl className="mt-3 space-y-2 text-xs text-slate-300/80">
+                          <div className="flex items-start justify-between gap-3">
+                            <dt>Community</dt>
+                            <dd className="text-right text-slate-100">
+                              {selectedNode.clusterLabel ?? "Unclustered"}
+                            </dd>
+                          </div>
+                          <div className="flex items-start justify-between gap-3">
+                            <dt>Started</dt>
+                            <dd className="text-right text-slate-100">
+                              {format(new Date(selectedNode.startedAt), "yyyy-MM-dd")}
+                            </dd>
+                          </div>
+                          <div className="flex items-start justify-between gap-3">
+                            <dt>Messages</dt>
+                            <dd className="text-right text-slate-100">
+                              {selectedNode.messageCount}
+                            </dd>
+                          </div>
+                          <div className="flex items-start justify-between gap-3">
+                            <dt>Degree</dt>
+                            <dd className="text-right text-slate-100">
+                              {selectedNode.degree}
+                            </dd>
+                          </div>
+                          {selectedNode.modelId ? (
+                            <div className="flex items-start justify-between gap-3">
+                              <dt>Model</dt>
+                              <dd className="max-w-[180px] text-right font-mono text-slate-100">
+                                {selectedNode.modelId}
+                              </dd>
+                            </div>
+                          ) : null}
+                        </dl>
+                      </div>
+                    </section>
+
+                    <section className="space-y-3">
+                      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-slate-300/70">
+                        <Sparkles className="h-3.5 w-3.5" />
+                        Semantic Preview
+                      </div>
+                      <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-sm leading-6 text-slate-100/90">
+                        {selectedNode.semanticPreview}
+                      </div>
+                    </section>
+
+                    <section className="space-y-3">
+                      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-slate-300/70">
+                        <Network className="h-3.5 w-3.5" />
+                        Neighbors ({selectedNeighbors.length})
+                      </div>
+                      <div className="space-y-2">
+                        {selectedNeighbors.length > 0 ? (
+                          selectedNeighbors.map((neighbor) => (
+                            <button
+                              key={neighbor.id}
+                              type="button"
+                              onClick={() => setSelectedNodeId(neighbor.id)}
+                              className="w-full rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-left transition hover:bg-white/10"
+                            >
+                              <div className="flex items-center gap-2">
+                                <span
+                                  className="h-2.5 w-1 rounded-full"
+                                  style={{ backgroundColor: neighbor.color }}
+                                />
+                                <span className="truncate text-xs font-medium text-slate-100">
+                                  {neighbor.clusterLabel ?? "Unclustered"}
+                                </span>
+                                <span className="ml-auto text-[11px] text-slate-300/70">
+                                  {(neighbor.score * 100).toFixed(0)}%
+                                </span>
+                              </div>
+                              <p className="mt-1 line-clamp-2 text-xs text-slate-300/80">
+                                {neighbor.semanticPreview}
+                              </p>
+                            </button>
+                          ))
+                        ) : (
+                          <div className="rounded-2xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
+                            No reciprocal neighbors survived the graph pruning for
+                            this node.
+                          </div>
+                        )}
+                      </div>
+                    </section>
+                  </>
+                ) : (
+                  <div className="rounded-2xl border border-dashed border-white/10 bg-white/[0.03] p-4 text-sm text-slate-300/70">
+                    Select a node to inspect its summary, community, and nearest
+                    neighbors.
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </TabsContent>
+
+          <TabsContent value="filters" className="min-h-0 flex-1 data-[state=inactive]:hidden">
+            <ScrollArea className="h-full">
+              <div className="space-y-5 p-4">
+                <section className="space-y-3">
+                  <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-slate-300/70">
+                    <Filter className="h-3.5 w-3.5" />
+                    Active Community Filters
+                  </div>
+                  {activeClusterChips.length > 0 ? (
+                    <div className="flex flex-wrap gap-2">
+                      {activeClusterChips.map((chip) => (
+                        <button
+                          key={chipKey(chip)}
+                          type="button"
+                          onClick={() => onClearChip(chipKey(chip))}
+                          className="rounded-full border border-white/10 bg-white/8 px-3 py-1 text-xs text-slate-100 transition hover:bg-white/12"
+                        >
+                          {chip.label ?? chip.clusterId}
+                        </button>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="rounded-2xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
+                      No community filters are active. Pick a community from the
+                      Communities tab to isolate it in the graph.
+                    </div>
+                  )}
+                </section>
+
+                <section className="space-y-3">
+                  <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-slate-300/70">
+                    <Sparkles className="h-3.5 w-3.5" />
+                    Search Results
+                  </div>
+                  {deferredSearch ? (
+                    searchMatches.length > 0 ? (
+                      <div className="space-y-2">
+                        {searchMatches.map((node) => (
+                          <button
+                            key={node.id}
+                            type="button"
+                            onClick={() => {
+                              setSelectedNodeId(node.id);
+                              setActiveTab("info");
+                            }}
+                            className="w-full rounded-2xl border border-white/10 bg-white/5 px-3 py-2 text-left transition hover:bg-white/10"
+                          >
+                            <div className="flex items-center justify-between gap-3">
+                              <span className="truncate text-xs font-medium text-slate-100">
+                                {node.clusterLabel ?? "Unclustered"}
+                              </span>
+                              <span className="text-[11px] text-slate-300/70">
+                                {formatDistanceToNow(new Date(node.lastActivityAt), {
+                                  addSuffix: true,
+                                })}
+                              </span>
+                            </div>
+                            <p className="mt-1 line-clamp-2 text-xs text-slate-300/80">
+                              {node.semanticPreview}
+                            </p>
+                          </button>
+                        ))}
+                      </div>
+                    ) : (
+                      <div className="rounded-2xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
+                        No nodes matched “{deferredSearch}”.
+                      </div>
+                    )
+                  ) : (
+                    <div className="rounded-2xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-4 text-xs text-slate-300/70">
+                      Search by community label, semantic preview, session ID, or
+                      model.
+                    </div>
+                  )}
+                </section>
+              </div>
+            </ScrollArea>
+          </TabsContent>
+
+          <TabsContent value="communities" className="min-h-0 flex-1 data-[state=inactive]:hidden">
+            <ScrollArea className="h-full">
+              <div className="space-y-3 p-4">
+                {communities.map((community) => {
+                  const isActive = activeClusterIds.has(community.clusterId);
+                  return (
+                    <button
+                      key={community.clusterId}
+                      type="button"
+                      onClick={() =>
+                        onToggleChip({
+                          kind: "cluster",
+                          clusterId: community.clusterId,
+                          label: community.label,
+                        })
+                      }
+                      className={cn(
+                        "w-full rounded-2xl border px-3 py-3 text-left transition",
+                        isActive
+                          ? "border-cyan-300/50 bg-cyan-300/10"
+                          : "border-white/10 bg-white/5 hover:bg-white/10",
+                      )}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-sm font-semibold text-slate-50">
+                            {community.label}
+                          </p>
+                          <p className="mt-1 text-xs text-slate-300/75">
+                            {community.summary}
+                          </p>
+                        </div>
+                        <span className="rounded-full bg-white/8 px-2 py-1 text-[11px] text-slate-100">
+                          {community.memberCount}
+                        </span>
+                      </div>
+                      {community.keywords.length > 0 ? (
+                        <div className="mt-3 flex flex-wrap gap-1.5">
+                          {community.keywords.map((keyword) => (
+                            <span
+                              key={keyword}
+                              className="rounded-full border border-white/10 px-2 py-0.5 text-[11px] text-slate-300/80"
+                            >
+                              {keyword}
+                            </span>
+                          ))}
+                        </div>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            </ScrollArea>
+          </TabsContent>
+        </Tabs>
+      </aside>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
@@ -10,23 +10,17 @@ import {
   useState,
 } from "react";
 import ForceGraph2D from "react-force-graph-2d";
-import { format, formatDistanceToNow } from "date-fns";
 import {
   AlertTriangle,
-  Filter,
-  Info,
   LoaderCircle,
   LocateFixed,
   Network,
   RefreshCw,
-  Sparkles,
 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { ScrollArea } from "@mcpjam/design-system/scroll-area";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@mcpjam/design-system/tabs";
 import { SearchInput } from "@/components/ui/search-input";
 import {
-  chipKey,
   type UsageFilterChip,
   type UsageFilterState,
 } from "@/hooks/chatbox-usage-filters";
@@ -112,8 +106,6 @@ function useTopicMapCanvasPalette(containerRef: RefObject<HTMLElement | null>) {
 
   return palette;
 }
-
-type SidebarTab = "info" | "filters" | "communities";
 
 type GraphNode = {
   id: string;
@@ -278,39 +270,79 @@ function drawRoundedRect(
   ctx.closePath();
 }
 
-function useElementSize<T extends HTMLElement>() {
+function useElementSize<T extends HTMLElement>(observeKey: unknown) {
   const ref = useRef<T | null>(null);
   const [size, setSize] = useState({
     width: DEFAULT_GRAPH_WIDTH,
     height: DEFAULT_GRAPH_HEIGHT,
   });
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const element = ref.current;
     if (!element) return;
 
-    const update = (rect?: DOMRectReadOnly) => {
+    const readSize = () => {
+      const rect = element.getBoundingClientRect();
+      const w = element.clientWidth || rect.width;
+      const h = element.clientHeight || rect.height;
       const width = Math.max(
         360,
-        Math.round(rect?.width ?? element.clientWidth ?? DEFAULT_GRAPH_WIDTH),
+        Math.round(w > 0 ? w : DEFAULT_GRAPH_WIDTH),
       );
       const height = Math.max(
         420,
-        Math.round(rect?.height ?? element.clientHeight ?? DEFAULT_GRAPH_HEIGHT),
+        Math.round(h > 0 ? h : DEFAULT_GRAPH_HEIGHT),
       );
+      return { width, height };
+    };
+
+    const update = () => {
+      const next = readSize();
       setSize((current) =>
-        current.width === width && current.height === height
+        current.width === next.width && current.height === next.height
           ? current
-          : { width, height },
+          : next,
       );
     };
 
     update();
-    if (typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver((entries) => update(entries[0]?.contentRect));
+
+    let raf1 = 0;
+    let raf2 = 0;
+    const schedulePostLayoutMeasure = () => {
+      cancelAnimationFrame(raf1);
+      cancelAnimationFrame(raf2);
+      raf1 = requestAnimationFrame(() => {
+        update();
+        raf2 = requestAnimationFrame(update);
+      });
+    };
+    schedulePostLayoutMeasure();
+
+    const onWindowResize = () => {
+      update();
+    };
+    window.addEventListener("resize", onWindowResize);
+
+    if (typeof ResizeObserver === "undefined") {
+      return () => {
+        cancelAnimationFrame(raf1);
+        cancelAnimationFrame(raf2);
+        window.removeEventListener("resize", onWindowResize);
+      };
+    }
+
+    const observer = new ResizeObserver(() => {
+      update();
+    });
     observer.observe(element);
-    return () => observer.disconnect();
-  }, []);
+    return () => {
+      cancelAnimationFrame(raf1);
+      cancelAnimationFrame(raf2);
+      window.removeEventListener("resize", onWindowResize);
+      observer.disconnect();
+    };
+  }, [observeKey]);
 
   return { ref, size };
 }
@@ -328,7 +360,7 @@ export function ChatboxTopicMapPanel({
   chatboxId,
   filter,
   onToggleChip,
-  onClearChip,
+  onClearChip: _onClearChip,
   onRebuild,
   rebuildBusy,
 }: ChatboxTopicMapPanelProps) {
@@ -336,7 +368,6 @@ export function ChatboxTopicMapPanel({
     chatboxId,
     enabled: true,
   });
-  const [activeTab, setActiveTab] = useState<SidebarTab>("info");
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
@@ -349,7 +380,8 @@ export function ChatboxTopicMapPanel({
     () => topicMapPalette ?? DEFAULT_CANVAS_PALETTE,
     [topicMapPalette],
   );
-  const { ref: graphContainerRef, size } = useElementSize<HTMLDivElement>();
+  const graphLayoutKey = snapshot?.runId ?? null;
+  const { ref: graphAreaRef, size } = useElementSize<HTMLDivElement>(graphLayoutKey);
 
   const activeClusterIds = useMemo(
     () =>
@@ -478,55 +510,12 @@ export function ChatboxTopicMapPanel({
     [activeClusterIds, focusedNeighborhood, searchMatchIds],
   );
 
-  const searchMatches = useMemo(() => {
-    if (!graphData || !searchMatchIds) return [];
-    return graphData.nodes
-      .filter((node) => searchMatchIds.has(node.id))
-      .slice(0, 12);
-  }, [graphData, searchMatchIds]);
-
-  const selectedNode = selectedNodeId ? nodeById.get(selectedNodeId) ?? null : null;
-
-  const selectedNeighbors = useMemo(() => {
-    if (!selectedNodeId || !graphData) return [];
-    return graphData.links
-      .filter((edge) => {
-        const sourceId = getLinkEndpointId(edge.source);
-        const targetId = getLinkEndpointId(edge.target);
-        return sourceId === selectedNodeId || targetId === selectedNodeId;
-      })
-      .sort((left, right) => right.score - left.score)
-      .map((edge) => {
-        const sourceId = getLinkEndpointId(edge.source);
-        const targetId = getLinkEndpointId(edge.target);
-        const neighborId =
-          sourceId === selectedNodeId ? targetId : sourceId;
-        if (!neighborId) return null;
-        const node = nodeById.get(neighborId);
-        return node
-          ? {
-              id: neighborId,
-              score: edge.score,
-              clusterLabel: node.clusterLabel,
-              semanticPreview: node.semanticPreview,
-              color: node.color,
-            }
-          : null;
-      })
-      .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
-  }, [graphData, nodeById, selectedNodeId]);
-
   const communities = useMemo(
     () =>
       [...(snapshot?.clusters ?? [])].sort(
         (left, right) => right.memberCount - left.memberCount,
       ),
     [snapshot?.clusters],
-  );
-
-  const activeClusterChips = filter.chips.filter(
-    (chip): chip is Extract<UsageFilterChip, { kind: "cluster" }> =>
-      chip.kind === "cluster",
   );
 
   useEffect(() => {
@@ -609,7 +598,6 @@ export function ChatboxTopicMapPanel({
       const node = nodeById.get(nodeId);
       if (!node) return;
       setSelectedNodeId(nodeId);
-      setActiveTab("info");
       graphRef.current?.centerAt?.(node.x, node.y, 560);
       graphRef.current?.zoom?.(zoomLevel, 560);
     },
@@ -987,21 +975,21 @@ export function ChatboxTopicMapPanel({
       ref={panelRef}
       className="flex h-full min-h-0 overflow-hidden bg-background text-foreground"
     >
-      <div className="relative min-w-0 flex-1 overflow-hidden">
+      <div
+        ref={graphAreaRef}
+        className="relative min-h-0 min-w-0 flex-1 overflow-hidden"
+      >
         <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/8 via-transparent to-muted/50" />
         <div
           className="pointer-events-none absolute inset-0 text-border/40 [background-image:linear-gradient(to_right,currentColor_1px,transparent_1px),linear-gradient(to_bottom,currentColor_1px,transparent_1px)] [background-size:40px_40px] opacity-60 [mask-image:radial-gradient(circle_at_50%_45%,black,transparent_100%)]"
         />
 
-        <div className="absolute left-4 right-4 top-4 z-10 flex flex-wrap items-start justify-between gap-3">
+        <div className="absolute left-4 right-4 top-4 z-10 flex flex-wrap items-start gap-3">
           <div className="space-y-2">
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="rounded-full border border-border bg-muted/40 px-2.5 py-1 text-[11px] font-medium uppercase tracking-[0.22em] text-muted-foreground">
-                Historical Topic Map
-              </span>
-              {latestRun?.status === "running" ||
-              latestRun?.status === "queued" ||
-              latestRun?.status === "failed" ? (
+            {latestRun?.status === "running" ||
+            latestRun?.status === "queued" ||
+            latestRun?.status === "failed" ? (
+              <div className="flex flex-wrap items-center gap-2">
                 <span
                   className={cn(
                     "rounded-full px-2.5 py-1 text-[11px] font-medium",
@@ -1014,26 +1002,8 @@ export function ChatboxTopicMapPanel({
                       ? "Queued for rebuild"
                       : "Last rebuild failed"}
                 </span>
-              ) : null}
-            </div>
-            <div className="flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
-              <span>{snapshot.stats.nodeCount.toLocaleString()} visible nodes</span>
-              <span>•</span>
-              <span>{snapshot.stats.edgeCount.toLocaleString()} edges</span>
-              <span>•</span>
-              <span>{snapshot.stats.clusterCount} communities</span>
-              {snapshot.stats.unmappedSessionCount > 0 ? (
-                <>
-                  <span>•</span>
-                  <span>
-                    {snapshot.stats.unmappedSessionCount.toLocaleString()} unmapped
-                  </span>
-                </>
-              ) : null}
-            </div>
-            <p className="text-[11px] text-muted-foreground">
-              Drag the canvas to pan, scroll to zoom, click a node to inspect.
-            </p>
+              </div>
+            ) : null}
             {snapshot.isSampled ? (
               <div className="max-w-xl rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-[11px] text-warning-foreground">
                 Showing a stable 10,000-session sample of{" "}
@@ -1042,32 +1012,9 @@ export function ChatboxTopicMapPanel({
               </div>
             ) : null}
           </div>
-
-          <div className="flex flex-wrap items-center gap-2">
-            <Button type="button" variant="outline" onClick={() => fitGraph()}>
-              <LocateFixed className="mr-2 h-3.5 w-3.5" />
-              Fit view
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={rebuildDisabled(latestRun) || rebuildBusy}
-              onClick={onRebuild}
-            >
-              <RefreshCw
-                className={cn(
-                  "mr-2 h-3.5 w-3.5",
-                  latestRun?.status === "running" && !latestRun.isStale
-                    ? "animate-spin"
-                    : "",
-                )}
-              />
-              {rebuildButtonLabel(latestRun)}
-            </Button>
-          </div>
         </div>
 
-        <div ref={graphContainerRef} className="h-full w-full pt-20">
+        <div className="h-full min-h-0 w-full">
           <ForceGraph2D
             ref={graphRef as never}
             graphData={graphData ?? { nodes: [], links: [] }}
@@ -1130,292 +1077,105 @@ export function ChatboxTopicMapPanel({
       </div>
 
       <aside className="flex w-[372px] shrink-0 flex-col border-l border-border bg-muted/30">
-        <div className="border-b border-border bg-muted/20 p-4">
+        <div className="space-y-3 border-b border-border bg-muted/20 p-4">
           <SearchInput
             value={searchQuery}
             onValueChange={(value) => startTransition(() => setSearchQuery(value))}
             placeholder="Search nodes..."
           />
+          <div className="flex flex-wrap items-center gap-2">
+            <Button type="button" variant="outline" onClick={() => fitGraph()}>
+              <LocateFixed className="mr-2 h-3.5 w-3.5" />
+              Fit view
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={rebuildDisabled(latestRun) || rebuildBusy}
+              onClick={onRebuild}
+            >
+              <RefreshCw
+                className={cn(
+                  "mr-2 h-3.5 w-3.5",
+                  latestRun?.status === "running" && !latestRun.isStale
+                    ? "animate-spin"
+                    : "",
+                )}
+              />
+              {rebuildButtonLabel(latestRun)}
+            </Button>
+          </div>
         </div>
 
-        <Tabs
-          value={activeTab}
-          onValueChange={(value) => setActiveTab(value as SidebarTab)}
-          className="flex min-h-0 flex-1 flex-col"
-        >
-          <TabsList className="grid grid-cols-3 rounded-none border-b border-border bg-muted/20 p-0">
-            <TabsTrigger
-              value="info"
-              className="rounded-none border-r border-border data-[state=active]:bg-muted data-[state=active]:text-foreground"
-            >
-              Info
-            </TabsTrigger>
-            <TabsTrigger
-              value="filters"
-              className="rounded-none border-r border-border data-[state=active]:bg-muted data-[state=active]:text-foreground"
-            >
-              Filters
-            </TabsTrigger>
-            <TabsTrigger
-              value="communities"
-              className="rounded-none data-[state=active]:bg-muted data-[state=active]:text-foreground"
-            >
-              Communities
-            </TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="info" className="min-h-0 flex-1 data-[state=inactive]:hidden">
-            <ScrollArea className="h-full">
-              <div className="space-y-5 p-4">
-                {selectedNode ? (
-                  <>
-                    <section className="space-y-3">
-                      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                        <Info className="h-3.5 w-3.5" />
-                        Node Info
-                      </div>
-                      <div className="rounded-lg border border-border bg-card p-4 shadow-sm">
-                        <p className="break-all text-sm font-semibold text-foreground">
-                          {selectedNode.id}
-                        </p>
-                        <dl className="mt-3 space-y-2 text-xs text-muted-foreground">
-                          <div className="flex items-start justify-between gap-3">
-                            <dt>Community</dt>
-                            <dd className="text-right text-foreground">
-                              {selectedNode.clusterLabel ?? "Unclustered"}
-                            </dd>
-                          </div>
-                          <div className="flex items-start justify-between gap-3">
-                            <dt>Started</dt>
-                            <dd className="text-right text-foreground">
-                              {format(new Date(selectedNode.startedAt), "yyyy-MM-dd")}
-                            </dd>
-                          </div>
-                          <div className="flex items-start justify-between gap-3">
-                            <dt>Messages</dt>
-                            <dd className="text-right text-foreground">
-                              {selectedNode.messageCount}
-                            </dd>
-                          </div>
-                          <div className="flex items-start justify-between gap-3">
-                            <dt>Degree</dt>
-                            <dd className="text-right text-foreground">
-                              {selectedNode.degree}
-                            </dd>
-                          </div>
-                          {selectedNode.modelId ? (
-                            <div className="flex items-start justify-between gap-3">
-                              <dt>Model</dt>
-                              <dd className="max-w-[180px] text-right font-mono text-foreground">
-                                {selectedNode.modelId}
-                              </dd>
-                            </div>
-                          ) : null}
-                        </dl>
-                      </div>
-                    </section>
-
-                    <section className="space-y-3">
-                      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                        <Sparkles className="h-3.5 w-3.5" />
-                        Semantic Preview
-                      </div>
-                      <div className="rounded-lg border border-border bg-card p-4 text-sm leading-6 text-foreground shadow-sm">
-                        {selectedNode.semanticPreview}
-                      </div>
-                    </section>
-
-                    <section className="space-y-3">
-                      <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                        <Network className="h-3.5 w-3.5" />
-                        Neighbors ({selectedNeighbors.length})
-                      </div>
-                      <div className="space-y-2">
-                        {selectedNeighbors.length > 0 ? (
-                          selectedNeighbors.map((neighbor) => (
-                            <button
-                              key={neighbor.id}
-                              type="button"
-                              onClick={() => focusNode(neighbor.id, 2.25)}
-                              className="w-full rounded-lg border border-border bg-card px-3 py-3 text-left transition hover:bg-muted/50"
-                            >
-                              <div className="flex items-center gap-2">
-                                <span
-                                  className="h-2.5 w-1 rounded-full"
-                                  style={{ backgroundColor: neighbor.color }}
-                                />
-                                <span className="truncate text-xs font-medium text-foreground">
-                                  {neighbor.clusterLabel ?? "Unclustered"}
-                                </span>
-                                <span className="ml-auto text-[11px] text-muted-foreground">
-                                  {(neighbor.score * 100).toFixed(0)}%
-                                </span>
-                              </div>
-                              <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
-                                {neighbor.semanticPreview}
-                              </p>
-                            </button>
-                          ))
-                        ) : (
-                          <div className="rounded-lg border border-dashed border-border bg-muted/20 px-3 py-4 text-xs text-muted-foreground">
-                            No reciprocal neighbors survived the graph pruning for
-                            this node.
-                          </div>
-                        )}
-                      </div>
-                    </section>
-                  </>
-                ) : (
-                  <div className="rounded-lg border border-dashed border-border bg-muted/20 p-4 text-sm text-muted-foreground">
-                    Select a node to inspect its summary, community, and nearest
-                    neighbors.
-                  </div>
-                )}
-              </div>
-            </ScrollArea>
-          </TabsContent>
-
-          <TabsContent value="filters" className="min-h-0 flex-1 data-[state=inactive]:hidden">
-            <ScrollArea className="h-full">
-              <div className="space-y-5 p-4">
-                <section className="space-y-3">
-                  <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                    <Filter className="h-3.5 w-3.5" />
-                    Active Community Filters
-                  </div>
-                  {activeClusterChips.length > 0 ? (
-                    <div className="flex flex-wrap gap-2">
-                      {activeClusterChips.map((chip) => (
-                        <button
-                          key={chipKey(chip)}
-                          type="button"
-                          onClick={() => onClearChip(chipKey(chip))}
-                          className="rounded-full border border-border bg-muted/50 px-3 py-1 text-xs text-foreground transition hover:bg-muted"
-                        >
-                          {chip.label ?? chip.clusterId}
-                        </button>
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="rounded-lg border border-dashed border-border bg-muted/20 px-3 py-4 text-xs text-muted-foreground">
-                      No community filters are active. Pick a community from the
-                      Communities tab to isolate it in the graph.
-                    </div>
-                  )}
-                </section>
-
-                <section className="space-y-3">
-                  <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-                    <Sparkles className="h-3.5 w-3.5" />
-                    Search Results
-                  </div>
-                  {deferredSearch ? (
-                    searchMatches.length > 0 ? (
-                      <div className="space-y-2">
-                        {searchMatches.map((node) => (
-                          <button
-                            key={node.id}
-                            type="button"
-                            onClick={() => focusNode(node.id, 2.2)}
-                            className="w-full rounded-lg border border-border bg-card px-3 py-3 text-left transition hover:bg-muted/50"
-                          >
-                            <div className="flex items-center justify-between gap-3">
-                              <span className="truncate text-xs font-medium text-foreground">
-                                {node.clusterLabel ?? "Unclustered"}
-                              </span>
-                              <span className="text-[11px] text-muted-foreground">
-                                {formatDistanceToNow(new Date(node.lastActivityAt), {
-                                  addSuffix: true,
-                                })}
-                              </span>
-                            </div>
-                            <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
-                              {node.semanticPreview}
-                            </p>
-                          </button>
-                        ))}
-                      </div>
-                    ) : (
-                      <div className="rounded-lg border border-dashed border-border bg-muted/20 px-3 py-4 text-xs text-muted-foreground">
-                        No nodes matched “{deferredSearch}”.
-                      </div>
-                    )
-                  ) : (
-                    <div className="rounded-lg border border-dashed border-border bg-muted/20 px-3 py-4 text-xs text-muted-foreground">
-                      Search by community label, semantic preview, session ID, or
-                      model.
-                    </div>
-                  )}
-                </section>
-              </div>
-            </ScrollArea>
-          </TabsContent>
-
-          <TabsContent value="communities" className="min-h-0 flex-1 data-[state=inactive]:hidden">
-            <ScrollArea className="h-full">
-              <div className="space-y-3 p-4">
-                {communities.map((community) => {
-                  const isActive = activeClusterIds.has(community.clusterId);
-                  const swatch = colorForCluster(
-                    community.clusterId,
-                    clusterColorIndex.get(community.clusterId) ?? 0,
-                  );
-                  return (
-                    <button
-                      key={community.clusterId}
-                      type="button"
-                      onClick={() =>
-                        onToggleChip({
-                          kind: "cluster",
-                          clusterId: community.clusterId,
-                          label: community.label,
-                        })
-                      }
-                      className={cn(
-                        "w-full rounded-lg border px-3 py-3 text-left transition",
-                        isActive
-                          ? "border-primary/40 bg-primary/10"
-                          : "border-border bg-card hover:bg-muted/50",
-                      )}
-                    >
-                      <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <div className="flex items-center gap-2">
-                            <span
-                              className="h-2.5 w-2.5 rounded-full"
-                              style={{ backgroundColor: swatch }}
-                            />
-                            <p className="truncate text-sm font-semibold text-foreground">
-                              {community.label}
-                            </p>
-                          </div>
-                          <p className="mt-1 text-xs text-muted-foreground">
-                            {community.summary}
+        <div className="flex min-h-0 flex-1 flex-col">
+          <div className="flex h-9 shrink-0 items-center border-b border-border bg-muted/20 px-4">
+            <span className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+              Clusters
+            </span>
+          </div>
+          <ScrollArea className="min-h-0 flex-1">
+            <div className="space-y-3 p-4">
+              {communities.map((community) => {
+                const isActive = activeClusterIds.has(community.clusterId);
+                const swatch = colorForCluster(
+                  community.clusterId,
+                  clusterColorIndex.get(community.clusterId) ?? 0,
+                );
+                return (
+                  <button
+                    key={community.clusterId}
+                    type="button"
+                    onClick={() =>
+                      onToggleChip({
+                        kind: "cluster",
+                        clusterId: community.clusterId,
+                        label: community.label,
+                      })
+                    }
+                    className={cn(
+                      "w-full rounded-lg border px-3 py-3 text-left transition",
+                      isActive
+                        ? "border-primary/40 bg-primary/10"
+                        : "border-border bg-card hover:bg-muted/50",
+                    )}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span
+                            className="h-2.5 w-2.5 rounded-full"
+                            style={{ backgroundColor: swatch }}
+                          />
+                          <p className="truncate text-sm font-semibold text-foreground">
+                            {community.label}
                           </p>
                         </div>
-                        <span className="rounded-full bg-secondary px-2 py-1 text-[11px] text-secondary-foreground">
-                          {community.memberCount}
-                        </span>
+                        <p className="mt-1 text-xs text-muted-foreground">
+                          {community.summary}
+                        </p>
                       </div>
-                      {community.keywords.length > 0 ? (
-                        <div className="mt-3 flex flex-wrap gap-1.5">
-                          {community.keywords.map((keyword) => (
-                            <span
-                              key={keyword}
-                              className="rounded-full border border-border px-2 py-0.5 text-[11px] text-muted-foreground"
-                            >
-                              {keyword}
-                            </span>
-                          ))}
-                        </div>
-                      ) : null}
-                    </button>
-                  );
-                })}
-              </div>
-            </ScrollArea>
-          </TabsContent>
-        </Tabs>
+                      <span className="rounded-full bg-secondary px-2 py-1 text-[11px] text-secondary-foreground">
+                        {community.memberCount}
+                      </span>
+                    </div>
+                    {community.keywords.length > 0 ? (
+                      <div className="mt-3 flex flex-wrap gap-1.5">
+                        {community.keywords.map((keyword) => (
+                          <span
+                            key={keyword}
+                            className="rounded-full border border-border px-2 py-0.5 text-[11px] text-muted-foreground"
+                          >
+                            {keyword}
+                          </span>
+                        ))}
+                      </div>
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          </ScrollArea>
+        </div>
       </aside>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
@@ -168,9 +168,17 @@ interface ChatboxTopicMapPanelProps {
   rebuildBusy?: boolean;
 }
 
-function rebuildButtonLabel(run: ClusterRunState | null): string {
+function rebuildButtonLabel(
+  run: ClusterRunState | null,
+  unmappedCount?: number,
+): string {
   if (!run) return "Rebuild clusters";
-  if (run.isStale) return "Rebuild clusters";
+  if (run.isStale) {
+    if (unmappedCount && unmappedCount > 0) {
+      return `Rebuild clusters \u00b7 ${unmappedCount.toLocaleString()} session${unmappedCount === 1 ? "" : "s"} not shown`;
+    }
+    return "Rebuild clusters \u00b7 new sessions available";
+  }
   switch (run.status) {
     case "queued":
       return "Queued…";
@@ -179,6 +187,9 @@ function rebuildButtonLabel(run: ClusterRunState | null): string {
     case "failed":
       return "Retry rebuild clusters";
     default:
+      if (unmappedCount && unmappedCount > 0) {
+        return `Rebuild clusters \u00b7 ${unmappedCount.toLocaleString()} session${unmappedCount === 1 ? "" : "s"} not shown`;
+      }
       return "Rebuild clusters";
   }
 }
@@ -1257,9 +1268,25 @@ export function ChatboxTopicMapPanel({
               <TooltipTrigger asChild>
                 <Button
                   type="button"
-                  variant="outline"
+                  variant={
+                    latestRun?.isStale ||
+                    (snapshot.stats.unmappedSessionCount > 0 &&
+                      latestRun?.status === "done")
+                      ? "default"
+                      : "outline"
+                  }
                   size="icon"
-                  aria-label={rebuildButtonLabel(latestRun)}
+                  className={cn(
+                    "relative",
+                    (latestRun?.isStale ||
+                      (snapshot.stats.unmappedSessionCount > 0 &&
+                        latestRun?.status === "done")) &&
+                      "bg-warning text-warning-foreground hover:bg-warning/90",
+                  )}
+                  aria-label={rebuildButtonLabel(
+                    latestRun,
+                    snapshot.stats.unmappedSessionCount,
+                  )}
                   disabled={rebuildDisabled(latestRun) || rebuildBusy}
                   onClick={onRebuild}
                 >
@@ -1271,10 +1298,21 @@ export function ChatboxTopicMapPanel({
                         : "",
                     )}
                   />
+                  {(latestRun?.isStale ||
+                    (snapshot.stats.unmappedSessionCount > 0 &&
+                      latestRun?.status === "done")) && (
+                    <span className="absolute -right-1 -top-1 flex h-2.5 w-2.5">
+                      <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-warning opacity-75" />
+                      <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-warning ring-2 ring-background" />
+                    </span>
+                  )}
                 </Button>
               </TooltipTrigger>
               <TooltipContent side="top" sideOffset={6}>
-                {rebuildButtonLabel(latestRun)}
+                {rebuildButtonLabel(
+                  latestRun,
+                  snapshot.stats.unmappedSessionCount,
+                )}
               </TooltipContent>
             </Tooltip>
           </div>

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
@@ -19,6 +19,11 @@ import {
 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { ScrollArea } from "@mcpjam/design-system/scroll-area";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
 import { SearchInput } from "@/components/ui/search-input";
 import {
   type UsageFilterChip,
@@ -112,6 +117,7 @@ type GraphNode = {
   sessionId: string;
   clusterId?: string;
   clusterLabel?: string;
+  semanticTitle?: string;
   semanticPreview: string;
   messageCount: number;
   startedAt: number;
@@ -163,17 +169,17 @@ interface ChatboxTopicMapPanelProps {
 }
 
 function rebuildButtonLabel(run: ClusterRunState | null): string {
-  if (!run) return "Rebuild topic map";
-  if (run.isStale) return "Rebuild topic map";
+  if (!run) return "Rebuild clusters";
+  if (run.isStale) return "Rebuild clusters";
   switch (run.status) {
     case "queued":
       return "Queued…";
     case "running":
       return "Refreshing…";
     case "failed":
-      return "Retry rebuild";
+      return "Retry rebuild clusters";
     default:
-      return "Rebuild topic map";
+      return "Rebuild clusters";
   }
 }
 
@@ -231,6 +237,7 @@ function matchesSearch(
   node: {
     sessionId: string;
     clusterLabel?: string;
+    semanticTitle?: string;
     semanticPreview: string;
     modelId?: string;
   },
@@ -239,6 +246,7 @@ function matchesSearch(
   const haystack = [
     node.sessionId,
     node.clusterLabel ?? "",
+    node.semanticTitle ?? "",
     node.semanticPreview,
     node.modelId ?? "",
   ]
@@ -356,6 +364,162 @@ function trimPreview(text: string) {
   return `${text.slice(0, 83).trimEnd()}…`;
 }
 
+/**
+ * Stopwords removed when deriving a single-word topic label from a session's
+ * `semanticPreview`. Covers standard English function words plus the generic
+ * chat-context terms that almost every session summary opens with
+ * (e.g. "The user wants to...", "User asked about...").
+ */
+const TOPIC_LABEL_STOPWORDS: ReadonlySet<string> = new Set([
+  "a",
+  "an",
+  "the",
+  "and",
+  "or",
+  "but",
+  "so",
+  "if",
+  "nor",
+  "yet",
+  "of",
+  "to",
+  "for",
+  "in",
+  "on",
+  "at",
+  "with",
+  "by",
+  "from",
+  "about",
+  "into",
+  "onto",
+  "over",
+  "under",
+  "between",
+  "through",
+  "during",
+  "as",
+  "is",
+  "are",
+  "was",
+  "were",
+  "be",
+  "been",
+  "being",
+  "am",
+  "have",
+  "has",
+  "had",
+  "do",
+  "does",
+  "did",
+  "will",
+  "would",
+  "should",
+  "can",
+  "could",
+  "may",
+  "might",
+  "must",
+  "i",
+  "you",
+  "he",
+  "she",
+  "it",
+  "we",
+  "they",
+  "me",
+  "him",
+  "her",
+  "us",
+  "them",
+  "my",
+  "your",
+  "his",
+  "its",
+  "our",
+  "their",
+  "this",
+  "that",
+  "these",
+  "those",
+  "user",
+  "users",
+  "assistant",
+  "chat",
+  "session",
+  "please",
+  "wants",
+  "want",
+  "wanted",
+  "needs",
+  "need",
+  "needed",
+  "asks",
+  "ask",
+  "asked",
+  "asking",
+  "requests",
+  "request",
+  "requested",
+  "requesting",
+  "seeks",
+  "seek",
+  "seeking",
+  "discusses",
+  "discussing",
+  "helps",
+  "help",
+  "helping",
+  "tries",
+  "trying",
+  "attempts",
+  "attempting",
+  "uses",
+  "use",
+  "using",
+]);
+
+function stripWordPunctuation(word: string): string {
+  return word.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, "");
+}
+
+/**
+ * First topical word in a session's `semanticPreview`, skipping stopwords and
+ * generic chat framing ("the user asked...", "user wants..."). Falls back to
+ * the first raw token, then the session id, so callers always get something
+ * printable for the hover chip / selected bubble title.
+ */
+export function topicLabelFromPreview(preview: string): string {
+  const trimmed = preview.trim();
+  if (!trimmed) return "";
+  const tokens = trimmed.split(/\s+/).map(stripWordPunctuation).filter(Boolean);
+  for (const token of tokens) {
+    if (!TOPIC_LABEL_STOPWORDS.has(token.toLowerCase())) {
+      return token;
+    }
+  }
+  return tokens[0] ?? "";
+}
+
+/**
+ * Short per-node label shown on hover and as the title of the click bubble.
+ * Derived from the session's own summary so sibling nodes inside the same
+ * cluster surface their distinct topics (e.g. "dog" vs "cat") instead of
+ * collapsing to the shared cluster keyword.
+ */
+export function topicMapNodeHoverLabel(node: {
+  semanticTitle?: string;
+  semanticPreview: string;
+  sessionId: string;
+}): string {
+  const fromTitle = node.semanticTitle?.trim();
+  if (fromTitle) return fromTitle;
+  const fromPreview = topicLabelFromPreview(node.semanticPreview);
+  if (fromPreview) return fromPreview;
+  return node.sessionId;
+}
+
 export function ChatboxTopicMapPanel({
   chatboxId,
   filter,
@@ -374,6 +538,7 @@ export function ChatboxTopicMapPanel({
   const deferredSearch = useDeferredValue(searchQuery.trim().toLowerCase());
   const graphRef = useRef<GraphHandle | null>(null);
   const autoFitKeyRef = useRef<string | null>(null);
+  const topicMapSelectionRunIdRef = useRef<string | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const topicMapPalette = useTopicMapCanvasPalette(panelRef);
   const canvasPalette = useMemo(
@@ -414,6 +579,7 @@ export function ChatboxTopicMapPanel({
         sessionId: node.sessionId,
         clusterId: node.clusterId,
         clusterLabel: node.clusterLabel,
+        semanticTitle: node.semanticTitle,
         semanticPreview: node.semanticPreview,
         messageCount: node.messageCount,
         startedAt: node.startedAt,
@@ -476,6 +642,7 @@ export function ChatboxTopicMapPanel({
           matchesSearch(deferredSearch, {
             sessionId: node.sessionId,
             clusterLabel: node.clusterLabel,
+            semanticTitle: node.semanticTitle,
             semanticPreview: node.semanticPreview,
             modelId: node.modelId,
           }),
@@ -520,13 +687,20 @@ export function ChatboxTopicMapPanel({
 
   useEffect(() => {
     if (!snapshot) {
+      topicMapSelectionRunIdRef.current = null;
       setSelectedNodeId(null);
       return;
     }
-    if (
-      selectedNodeId &&
-      snapshot.nodes.some((node) => node.sessionId === selectedNodeId)
-    ) {
+    const runId = snapshot.runId;
+    if (topicMapSelectionRunIdRef.current !== runId) {
+      topicMapSelectionRunIdRef.current = runId;
+      setSelectedNodeId(snapshot.nodes[0]?.sessionId ?? null);
+      return;
+    }
+    if (!selectedNodeId) {
+      return;
+    }
+    if (snapshot.nodes.some((node) => node.sessionId === selectedNodeId)) {
       return;
     }
     setSelectedNodeId(snapshot.nodes[0]?.sessionId ?? null);
@@ -625,7 +799,12 @@ export function ChatboxTopicMapPanel({
       const isHovered = node.id === hoveredNodeId;
       const isSearchMatch = searchMatchIds?.has(node.id) ?? false;
       const dimmed = isNodeDimmed(node);
-      const label = node.clusterLabel ?? node.sessionId;
+      // Title for both the hover chip and the selected bubble comes from the
+      // session's own summary so the bubble on click reads like
+      // "dog" + "The user requested a drawing of a dog..." rather than
+      // echoing the cluster label (which is already visible in the sidebar).
+      const hoverWord = topicMapNodeHoverLabel(node);
+      const fullLabel = hoverWord || node.sessionId;
 
       ctx.save();
       ctx.globalAlpha = dimmed ? 0.16 : 1;
@@ -681,30 +860,18 @@ export function ChatboxTopicMapPanel({
       ctx.strokeStyle = isSelected ? canvasPalette.foreground : canvasPalette.border;
       ctx.stroke();
 
-      if (isSelected || isHovered) {
-        const titleFontSize = (isSelected ? 13 : 11.5) / globalScale;
-        const previewFontSize = 10 / globalScale;
-        const titleY = node.y - node.radius - 15 / globalScale;
-        const paddingX = 10 / globalScale;
-        const paddingY = 8 / globalScale;
-        const preview = isSelected ? trimPreview(node.semanticPreview) : null;
+      if (isHovered && !isSelected && hoverWord) {
+        const titleFontSize = 11 / globalScale;
+        const paddingX = 9 / globalScale;
+        const paddingY = 7 / globalScale;
+        const gap = 10 / globalScale;
 
-        ctx.font = `${isSelected ? 600 : 500} ${titleFontSize}px ui-sans-serif, system-ui, sans-serif`;
-        const titleWidth = ctx.measureText(label).width;
-        let bubbleWidth = titleWidth + paddingX * 2;
-        let bubbleHeight = titleFontSize + paddingY * 2;
-
-        if (preview) {
-          ctx.font = `400 ${previewFontSize}px ui-sans-serif, system-ui, sans-serif`;
-          bubbleWidth = Math.max(
-            bubbleWidth,
-            ctx.measureText(preview).width + paddingX * 2,
-          );
-          bubbleHeight += previewFontSize + 6 / globalScale;
-        }
-
-        const bubbleX = node.x + 12 / globalScale;
-        const bubbleY = titleY - bubbleHeight / 2;
+        ctx.font = `600 ${titleFontSize}px ui-sans-serif, system-ui, sans-serif`;
+        const titleWidth = ctx.measureText(hoverWord).width;
+        const bubbleWidth = titleWidth + paddingX * 2;
+        const bubbleHeight = titleFontSize + paddingY * 2;
+        const bubbleX = node.x - bubbleWidth / 2;
+        const bubbleY = node.y - node.radius - gap - bubbleHeight;
 
         ctx.save();
         ctx.globalAlpha = dimmed ? 0.55 : 0.98;
@@ -714,7 +881,7 @@ export function ChatboxTopicMapPanel({
           bubbleY,
           bubbleWidth,
           bubbleHeight,
-          12 / globalScale,
+          10 / globalScale,
         );
         ctx.fillStyle = canvasPalette.card;
         ctx.globalAlpha = dimmed ? 0.45 : 0.96;
@@ -724,19 +891,72 @@ export function ChatboxTopicMapPanel({
         ctx.stroke();
         ctx.globalAlpha = 1;
 
-        ctx.font = `${isSelected ? 600 : 500} ${titleFontSize}px ui-sans-serif, system-ui, sans-serif`;
+        ctx.font = `600 ${titleFontSize}px ui-sans-serif, system-ui, sans-serif`;
         ctx.fillStyle = canvasPalette.foreground;
-        ctx.fillText(label, bubbleX + paddingX, bubbleY + paddingY + titleFontSize * 0.82);
+        ctx.fillText(
+          hoverWord,
+          bubbleX + paddingX,
+          bubbleY + paddingY + titleFontSize * 0.82,
+        );
+        ctx.restore();
+      }
 
-        if (preview) {
-          ctx.font = `400 ${previewFontSize}px ui-sans-serif, system-ui, sans-serif`;
-          ctx.fillStyle = canvasPalette.mutedForeground;
-          ctx.fillText(
-            preview,
-            bubbleX + paddingX,
-            bubbleY + bubbleHeight - paddingY,
-          );
-        }
+      if (isSelected) {
+        const titleFontSize = 13 / globalScale;
+        const previewFontSize = 10 / globalScale;
+        const paddingX = 10 / globalScale;
+        const paddingY = 8 / globalScale;
+        const gap = 12 / globalScale;
+        const preview = trimPreview(node.semanticPreview);
+
+        ctx.font = `600 ${titleFontSize}px ui-sans-serif, system-ui, sans-serif`;
+        const titleWidth = ctx.measureText(fullLabel).width;
+        let bubbleWidth = titleWidth + paddingX * 2;
+        let bubbleHeight = titleFontSize + paddingY * 2;
+
+        ctx.font = `400 ${previewFontSize}px ui-sans-serif, system-ui, sans-serif`;
+        bubbleWidth = Math.max(
+          bubbleWidth,
+          ctx.measureText(preview).width + paddingX * 2,
+        );
+        bubbleHeight += previewFontSize + 6 / globalScale;
+
+        const bubbleX = node.x - bubbleWidth / 2;
+        const bubbleY = node.y + node.radius + gap;
+
+        ctx.save();
+        ctx.globalAlpha = dimmed ? 0.55 : 0.98;
+        drawRoundedRect(
+          ctx,
+          bubbleX,
+          bubbleY,
+          bubbleWidth,
+          bubbleHeight,
+          14 / globalScale,
+        );
+        ctx.fillStyle = canvasPalette.card;
+        ctx.globalAlpha = dimmed ? 0.45 : 0.96;
+        ctx.strokeStyle = canvasPalette.border;
+        ctx.lineWidth = 1 / globalScale;
+        ctx.fill();
+        ctx.stroke();
+        ctx.globalAlpha = 1;
+
+        ctx.font = `600 ${titleFontSize}px ui-sans-serif, system-ui, sans-serif`;
+        ctx.fillStyle = canvasPalette.foreground;
+        ctx.fillText(
+          fullLabel,
+          bubbleX + paddingX,
+          bubbleY + paddingY + titleFontSize * 0.82,
+        );
+
+        ctx.font = `400 ${previewFontSize}px ui-sans-serif, system-ui, sans-serif`;
+        ctx.fillStyle = canvasPalette.mutedForeground;
+        ctx.fillText(
+          preview,
+          bubbleX + paddingX,
+          bubbleY + bubbleHeight - paddingY,
+        );
         ctx.restore();
       }
 
@@ -841,8 +1061,9 @@ export function ChatboxTopicMapPanel({
         }
       >();
 
+      // Cluster halos are always rendered regardless of hover/selection/search
+      // dimming so operators can see the full cluster landscape at all times.
       for (const node of graphData.nodes) {
-        if (isNodeDimmed(node)) continue;
         const clusterKey = node.clusterId ?? `unclustered:${node.id}`;
         const existing = clusters.get(clusterKey);
         if (existing) {
@@ -911,7 +1132,7 @@ export function ChatboxTopicMapPanel({
         ctx.restore();
       }
     },
-    [graphData, isNodeDimmed],
+    [graphData],
   );
 
   if (
@@ -1014,7 +1235,55 @@ export function ChatboxTopicMapPanel({
           </div>
         </div>
 
-        <div className="h-full min-h-0 w-full">
+        <div className="pointer-events-none absolute bottom-4 left-4 z-10 flex flex-wrap items-center gap-2">
+          <div className="pointer-events-auto flex flex-wrap items-center gap-2 rounded-lg border border-border bg-background/80 p-1.5 shadow-sm backdrop-blur">
+            <Tooltip delayDuration={200}>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  aria-label="Fit view"
+                  onClick={() => fitGraph()}
+                >
+                  <LocateFixed className="h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={6}>
+                Fit view
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip delayDuration={200}>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  aria-label={rebuildButtonLabel(latestRun)}
+                  disabled={rebuildDisabled(latestRun) || rebuildBusy}
+                  onClick={onRebuild}
+                >
+                  <RefreshCw
+                    className={cn(
+                      "h-3.5 w-3.5",
+                      latestRun?.status === "running" && !latestRun.isStale
+                        ? "animate-spin"
+                        : "",
+                    )}
+                  />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={6}>
+                {rebuildButtonLabel(latestRun)}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        </div>
+
+        <div
+          className="h-full min-h-0 w-full"
+          data-selected-session={selectedNodeId ?? ""}
+        >
           <ForceGraph2D
             ref={graphRef as never}
             graphData={graphData ?? { nodes: [], links: [] }}
@@ -1023,10 +1292,7 @@ export function ChatboxTopicMapPanel({
             backgroundColor="rgba(0,0,0,0)"
             nodeCanvasObjectMode={() => "replace"}
             nodeCanvasObject={drawNode}
-            nodeLabel={(node) => {
-              const graphNode = node as GraphNode;
-              return `${graphNode.clusterLabel ?? graphNode.sessionId}\n${graphNode.semanticPreview}`;
-            }}
+            nodeLabel={() => ""}
             linkColor={linkColor}
             linkWidth={linkWidth}
             linkCurvature={(link) => {
@@ -1056,6 +1322,7 @@ export function ChatboxTopicMapPanel({
             }}
             onBackgroundClick={() => {
               setHoveredNodeId(null);
+              setSelectedNodeId(null);
             }}
             onRenderFramePre={(ctx) => {
               drawClusterFields(ctx);
@@ -1083,36 +1350,9 @@ export function ChatboxTopicMapPanel({
             onValueChange={(value) => startTransition(() => setSearchQuery(value))}
             placeholder="Search nodes..."
           />
-          <div className="flex flex-wrap items-center gap-2">
-            <Button type="button" variant="outline" onClick={() => fitGraph()}>
-              <LocateFixed className="mr-2 h-3.5 w-3.5" />
-              Fit view
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={rebuildDisabled(latestRun) || rebuildBusy}
-              onClick={onRebuild}
-            >
-              <RefreshCw
-                className={cn(
-                  "mr-2 h-3.5 w-3.5",
-                  latestRun?.status === "running" && !latestRun.isStale
-                    ? "animate-spin"
-                    : "",
-                )}
-              />
-              {rebuildButtonLabel(latestRun)}
-            </Button>
-          </div>
         </div>
 
         <div className="flex min-h-0 flex-1 flex-col">
-          <div className="flex h-9 shrink-0 items-center border-b border-border bg-muted/20 px-4">
-            <span className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-              Clusters
-            </span>
-          </div>
           <ScrollArea className="min-h-0 flex-1">
             <div className="space-y-3 p-4">
               {communities.map((community) => {
@@ -1122,16 +1362,8 @@ export function ChatboxTopicMapPanel({
                   clusterColorIndex.get(community.clusterId) ?? 0,
                 );
                 return (
-                  <button
+                  <div
                     key={community.clusterId}
-                    type="button"
-                    onClick={() =>
-                      onToggleChip({
-                        kind: "cluster",
-                        clusterId: community.clusterId,
-                        label: community.label,
-                      })
-                    }
                     className={cn(
                       "w-full rounded-lg border px-3 py-3 text-left transition",
                       isActive
@@ -1139,38 +1371,50 @@ export function ChatboxTopicMapPanel({
                         : "border-border bg-card hover:bg-muted/50",
                     )}
                   >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span
-                            className="h-2.5 w-2.5 rounded-full"
-                            style={{ backgroundColor: swatch }}
-                          />
+                    <button
+                      type="button"
+                      className="w-full text-left"
+                      onClick={() =>
+                        onToggleChip({
+                          kind: "cluster",
+                          clusterId: community.clusterId,
+                          label: community.label,
+                        })
+                      }
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span
+                              className="h-2.5 w-2.5 rounded-full"
+                              style={{ backgroundColor: swatch }}
+                            />
                           <p className="truncate text-sm font-semibold text-foreground">
                             {community.label}
                           </p>
+                          </div>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {community.summary}
+                          </p>
                         </div>
-                        <p className="mt-1 text-xs text-muted-foreground">
-                          {community.summary}
-                        </p>
+                        <span className="rounded-full bg-secondary px-2 py-1 text-[11px] text-secondary-foreground">
+                          {community.memberCount}
+                        </span>
                       </div>
-                      <span className="rounded-full bg-secondary px-2 py-1 text-[11px] text-secondary-foreground">
-                        {community.memberCount}
-                      </span>
-                    </div>
+                    </button>
                     {community.keywords.length > 0 ? (
                       <div className="mt-3 flex flex-wrap gap-1.5">
                         {community.keywords.map((keyword) => (
                           <span
                             key={keyword}
-                            className="rounded-full border border-border px-2 py-0.5 text-[11px] text-muted-foreground"
+                            className="rounded-full border border-border bg-background px-2 py-0.5 text-[11px] text-muted-foreground"
                           >
                             {keyword}
                           </span>
                         ))}
                       </div>
                     ) : null}
-                  </button>
+                  </div>
                 );
               })}
             </div>

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxTopicMapPanel.tsx
@@ -1247,7 +1247,7 @@ export function ChatboxTopicMapPanel({
         </div>
 
         <div className="pointer-events-none absolute bottom-4 left-4 z-10 flex flex-wrap items-center gap-2">
-          <div className="pointer-events-auto flex flex-wrap items-center gap-2 rounded-lg border border-border bg-background/80 p-1.5 shadow-sm backdrop-blur">
+          <div className="pointer-events-auto flex flex-col items-center gap-2 rounded-lg border border-border bg-background/80 p-1.5 shadow-sm backdrop-blur">
             <Tooltip delayDuration={200}>
               <TooltipTrigger asChild>
                 <Button

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxUsagePanel.tsx
@@ -20,7 +20,7 @@ import {
 import { Button } from "@mcpjam/design-system/button";
 import { ShareUsageThreadList } from "@/components/connection/share-usage/ShareUsageThreadList";
 import { ShareUsageThreadDetail } from "@/components/connection/share-usage/ShareUsageThreadDetail";
-import { UsageInsightsStrip } from "@/components/shared/usage-insights/UsageInsightsStrip";
+import { ChatboxTopicMapPanel } from "@/components/chatboxes/ChatboxTopicMapPanel";
 
 export type ChatboxUsagePanelSection = "sessions" | "insights";
 
@@ -67,10 +67,11 @@ export function ChatboxUsagePanel({
     [chatbox.chatboxId],
   );
 
-  const { threads, breakdown, rebuild } = useUsageInsights({
+  const { threads, rebuild } = useUsageInsights({
     sourceType: "chatbox",
     sourceId: chatbox.chatboxId,
     filters: filter,
+    enabled: section === "sessions",
   });
 
   const sortedThreads = useMemo(() => {
@@ -156,9 +157,9 @@ export function ChatboxUsagePanel({
 
   if (section === "insights") {
     return (
-      <div className="flex h-full min-h-0 flex-col overflow-auto">
-        <UsageInsightsStrip
-          breakdown={breakdown}
+      <div className="flex h-full min-h-0 flex-col overflow-hidden">
+        <ChatboxTopicMapPanel
+          chatboxId={chatbox.chatboxId}
           filter={filter}
           onToggleChip={handleToggleChip}
           onClearChip={handleClearChip}

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatboxTopicMapPanel } from "../ChatboxTopicMapPanel";
@@ -177,7 +177,44 @@ beforeEach(() => {
 });
 
 describe("ChatboxTopicMapPanel", () => {
-  it("renders the selected node info and semantic preview", () => {
+  it("subscribes to ResizeObserver only after the graph pane mounts (post-loading)", () => {
+    const observed: Element[] = [];
+    const originalResizeObserver = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class ResizeObserverMock {
+      constructor(_cb: ResizeObserverCallback) {}
+      observe(target: Element) {
+        observed.push(target);
+      }
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    try {
+      mockUseChatboxTopicMap.mockReturnValue({
+        ...createDefaultChatboxTopicMapHookValue(),
+        snapshot: null,
+        isLoading: true,
+      });
+
+      const panelProps = {
+        chatboxId: "chatbox-1",
+        filter: EMPTY_FILTER,
+        onToggleChip: vi.fn(),
+        onClearChip: vi.fn(),
+        onRebuild: vi.fn(),
+      };
+
+      const { rerender } = render(<ChatboxTopicMapPanel {...panelProps} />);
+      expect(observed).toHaveLength(0);
+
+      mockUseChatboxTopicMap.mockReturnValue(createDefaultChatboxTopicMapHookValue());
+      rerender(<ChatboxTopicMapPanel {...panelProps} />);
+      expect(observed.length).toBeGreaterThan(0);
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+  });
+
+  it("renders cluster list with summaries in the sidebar", () => {
     render(
       <ChatboxTopicMapPanel
         chatboxId="chatbox-1"
@@ -188,14 +225,33 @@ describe("ChatboxTopicMapPanel", () => {
       />,
     );
 
-    expect(screen.getByText("Historical Topic Map")).toBeInTheDocument();
+    expect(screen.queryByText("Historical Topic Map")).not.toBeInTheDocument();
     expect(screen.queryByText("2 mapped sessions")).not.toBeInTheDocument();
-    expect(screen.getByText("session-a")).toBeInTheDocument();
+    expect(screen.getByText("Clusters")).toBeInTheDocument();
     expect(screen.getByText("Password resets")).toBeInTheDocument();
     expect(
-      screen.getByText("User needs to reset a forgotten password."),
+      screen.getByText("Reset and account recovery questions."),
     ).toBeInTheDocument();
-    expect(screen.getByText(/1 unmapped/i)).toBeInTheDocument();
+    expect(screen.getByText("Billing issues")).toBeInTheDocument();
+    expect(screen.getByText("Invoice and refund help.")).toBeInTheDocument();
+  });
+
+  it("renders Fit view and rebuild controls in the right panel", () => {
+    render(
+      <ChatboxTopicMapPanel
+        chatboxId="chatbox-1"
+        filter={EMPTY_FILTER}
+        onToggleChip={vi.fn()}
+        onClearChip={vi.fn()}
+        onRebuild={vi.fn()}
+      />,
+    );
+
+    const fitView = screen.getByRole("button", { name: /fit view/i });
+    const rebuild = screen.getByRole("button", { name: /rebuild topic map/i });
+    expect(fitView.compareDocumentPosition(rebuild)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
   });
 
   it("shows rebuild status in the header while a run is active", () => {
@@ -249,7 +305,7 @@ describe("ChatboxTopicMapPanel", () => {
       />,
     );
 
-    await user.click(screen.getByRole("tab", { name: "Communities" }));
+    expect(screen.getByText("Clusters")).toBeInTheDocument();
     await user.click(
       screen.getByRole("button", { name: /Billing issues Invoice and refund help/i }),
     );
@@ -261,10 +317,7 @@ describe("ChatboxTopicMapPanel", () => {
     });
   });
 
-  it("shows active cluster filters and search matches in the filters tab", async () => {
-    const user = userEvent.setup();
-    const onClearChip = vi.fn();
-
+  it("highlights active cluster selection in the list", () => {
     render(
       <ChatboxTopicMapPanel
         chatboxId="chatbox-1"
@@ -273,20 +326,14 @@ describe("ChatboxTopicMapPanel", () => {
           chips: [{ kind: "cluster", clusterId: "cluster-a", label: "Password resets" }],
         }}
         onToggleChip={vi.fn()}
-        onClearChip={onClearChip}
+        onClearChip={vi.fn()}
         onRebuild={vi.fn()}
       />,
     );
 
-    await user.type(screen.getByRole("searchbox", { name: "Search nodes..." }), "refund");
-    await user.click(screen.getByRole("tab", { name: "Filters" }));
-
-    expect(screen.getByRole("button", { name: "Password resets" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Password resets" }));
-    expect(onClearChip).toHaveBeenCalledWith("cluster:cluster-a");
-
-    await waitFor(() => {
-      expect(screen.getByText("Refund request after duplicate charge.")).toBeInTheDocument();
+    const clusterButton = screen.getByRole("button", {
+      name: /Password resets Reset and account recovery questions/i,
     });
+    expect(clusterButton).toHaveClass("border-primary/40");
   });
 });

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
@@ -1,0 +1,250 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatboxTopicMapPanel } from "../ChatboxTopicMapPanel";
+import type { UsageFilterState } from "@/hooks/chatbox-usage-filters";
+
+const { mockUseChatboxTopicMap } = vi.hoisted(() => ({
+  mockUseChatboxTopicMap: vi.fn(),
+}));
+
+vi.mock("react-force-graph-2d", async () => {
+  const React = await import("react");
+  return {
+    default: React.forwardRef(function MockForceGraph2D(
+      props: {
+        graphData?: { nodes?: Array<{ id: string }> };
+        onNodeClick?: (node: { id: string }) => void;
+      },
+      ref,
+    ) {
+      React.useImperativeHandle(ref, () => ({
+        zoomToFit: vi.fn(),
+      }));
+      return (
+        <div data-testid="force-graph">
+          {(props.graphData?.nodes ?? []).map((node) => (
+            <button
+              key={node.id}
+              type="button"
+              onClick={() => props.onNodeClick?.(node)}
+            >
+              Graph node {node.id}
+            </button>
+          ))}
+        </div>
+      );
+    }),
+  };
+});
+
+vi.mock("@/hooks/useChatboxTopicMap", () => ({
+  useChatboxTopicMap: (...args: unknown[]) => mockUseChatboxTopicMap(...args),
+}));
+
+const EMPTY_FILTER: UsageFilterState = {
+  preset: "all",
+  chips: [],
+};
+
+const SNAPSHOT = {
+  version: 1,
+  chatboxId: "chatbox-1",
+  runId: "run-1",
+  generatedAt: Date.now(),
+  isSampled: false,
+  stats: {
+    nodeCount: 2,
+    edgeCount: 1,
+    clusterCount: 2,
+    mappedSessionCount: 2,
+    unmappedSessionCount: 1,
+  },
+  clusters: [
+    {
+      clusterId: "cluster-a",
+      label: "Password resets",
+      summary: "Reset and account recovery questions.",
+      keywords: ["password", "reset"],
+      memberCount: 12,
+      colorIndex: 0,
+    },
+    {
+      clusterId: "cluster-b",
+      label: "Billing issues",
+      summary: "Invoice and refund help.",
+      keywords: ["billing", "refund"],
+      memberCount: 8,
+      colorIndex: 1,
+    },
+  ],
+  nodes: [
+    {
+      sessionId: "session-a",
+      x: 0.1,
+      y: 0.2,
+      degree: 1,
+      clusterId: "cluster-a",
+      clusterLabel: "Password resets",
+      semanticPreview: "User needs to reset a forgotten password.",
+      messageCount: 6,
+      startedAt: Date.UTC(2026, 2, 20),
+      lastActivityAt: Date.now() - 5 * 60 * 1000,
+      modelId: "openai/gpt-4o-mini",
+    },
+    {
+      sessionId: "session-b",
+      x: -0.1,
+      y: -0.2,
+      degree: 1,
+      clusterId: "cluster-b",
+      clusterLabel: "Billing issues",
+      semanticPreview: "Refund request after duplicate charge.",
+      messageCount: 4,
+      startedAt: Date.UTC(2026, 2, 22),
+      lastActivityAt: Date.now() - 2 * 60 * 1000,
+      modelId: "openai/gpt-4o-mini",
+    },
+  ],
+  edges: [
+    {
+      source: "session-a",
+      target: "session-b",
+      score: 0.82,
+    },
+  ],
+};
+
+beforeEach(() => {
+  mockUseChatboxTopicMap.mockReset();
+  mockUseChatboxTopicMap.mockReturnValue({
+    latestRun: {
+      _id: "run-1",
+      status: "done",
+      startedAt: Date.now() - 10_000,
+      finishedAt: Date.now() - 5_000,
+      sessionCount: 2,
+      clusterCount: 2,
+      errorMessage: null,
+      model: "openai/gpt-4o-mini",
+      topicMapVersion: 1,
+      edgeCount: 1,
+      sampleNodeCount: 2,
+      unmappedSessionCount: 1,
+      isSampled: false,
+      topicMapReady: true,
+      isStale: false,
+    },
+    snapshot: SNAPSHOT,
+    snapshotMetadata: {
+      runId: "run-1",
+      topicMapBlobUrl: "https://storage.example.com/topic-map.json",
+      topicMapVersion: 1,
+      edgeCount: 1,
+      sampleNodeCount: 2,
+      unmappedSessionCount: 1,
+      isSampled: false,
+      sessionCount: 2,
+      clusterCount: 2,
+    },
+    clusters: [
+      {
+        _id: "cluster-row-a",
+        label: "Password resets",
+        summary: "Reset and account recovery questions.",
+        keywords: ["password", "reset"],
+        memberCount: 12,
+        createdAt: Date.now(),
+      },
+      {
+        _id: "cluster-row-b",
+        label: "Billing issues",
+        summary: "Invoice and refund help.",
+        keywords: ["billing", "refund"],
+        memberCount: 8,
+        createdAt: Date.now(),
+      },
+    ],
+    snapshotError: null,
+    isLoading: false,
+    metadata: null,
+  });
+});
+
+describe("ChatboxTopicMapPanel", () => {
+  it("renders the selected node info and semantic preview", () => {
+    render(
+      <ChatboxTopicMapPanel
+        chatboxId="chatbox-1"
+        filter={EMPTY_FILTER}
+        onToggleChip={vi.fn()}
+        onClearChip={vi.fn()}
+        onRebuild={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Historical Topic Map")).toBeInTheDocument();
+    expect(screen.getByText("session-a")).toBeInTheDocument();
+    expect(screen.getByText("Password resets")).toBeInTheDocument();
+    expect(
+      screen.getByText("User needs to reset a forgotten password."),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/1 unmapped/i)).toBeInTheDocument();
+  });
+
+  it("lets operators toggle a community chip from the sidebar", async () => {
+    const user = userEvent.setup();
+    const onToggleChip = vi.fn();
+
+    render(
+      <ChatboxTopicMapPanel
+        chatboxId="chatbox-1"
+        filter={EMPTY_FILTER}
+        onToggleChip={onToggleChip}
+        onClearChip={vi.fn()}
+        onRebuild={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Communities" }));
+    await user.click(
+      screen.getByRole("button", { name: /Billing issues Invoice and refund help/i }),
+    );
+
+    expect(onToggleChip).toHaveBeenCalledWith({
+      kind: "cluster",
+      clusterId: "cluster-b",
+      label: "Billing issues",
+    });
+  });
+
+  it("shows active cluster filters and search matches in the filters tab", async () => {
+    const user = userEvent.setup();
+    const onClearChip = vi.fn();
+
+    render(
+      <ChatboxTopicMapPanel
+        chatboxId="chatbox-1"
+        filter={{
+          preset: "all",
+          chips: [{ kind: "cluster", clusterId: "cluster-a", label: "Password resets" }],
+        }}
+        onToggleChip={vi.fn()}
+        onClearChip={onClearChip}
+        onRebuild={vi.fn()}
+      />,
+    );
+
+    await user.type(screen.getByRole("searchbox", { name: "Search nodes..." }), "refund");
+    await user.click(screen.getByRole("tab", { name: "Filters" }));
+
+    expect(screen.getByRole("button", { name: "Password resets" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Password resets" }));
+    expect(onClearChip).toHaveBeenCalledWith("cluster:cluster-a");
+
+    await waitFor(() => {
+      expect(screen.getByText("Refund request after duplicate charge.")).toBeInTheDocument();
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ChatboxTopicMapPanel } from "../ChatboxTopicMapPanel";
+import {
+  ChatboxTopicMapPanel,
+  topicMapNodeHoverLabel,
+} from "../ChatboxTopicMapPanel";
 import type { UsageFilterState } from "@/hooks/chatbox-usage-filters";
 
 const { mockUseChatboxTopicMap } = vi.hoisted(() => ({
@@ -16,6 +19,7 @@ vi.mock("react-force-graph-2d", async () => {
       props: {
         graphData?: { nodes?: Array<{ id: string }> };
         onNodeClick?: (node: { id: string }) => void;
+        onBackgroundClick?: () => void;
       },
       ref,
     ) {
@@ -24,6 +28,13 @@ vi.mock("react-force-graph-2d", async () => {
       }));
       return (
         <div data-testid="force-graph">
+          <button
+            type="button"
+            data-testid="force-graph-background"
+            onClick={() => props.onBackgroundClick?.()}
+          >
+            Graph background
+          </button>
           {(props.graphData?.nodes ?? []).map((node) => (
             <button
               key={node.id}
@@ -87,6 +98,7 @@ const SNAPSHOT = {
       degree: 1,
       clusterId: "cluster-a",
       clusterLabel: "Password resets",
+      semanticTitle: "Password reset",
       semanticPreview: "User needs to reset a forgotten password.",
       messageCount: 6,
       startedAt: Date.UTC(2026, 2, 20),
@@ -100,6 +112,7 @@ const SNAPSHOT = {
       degree: 1,
       clusterId: "cluster-b",
       clusterLabel: "Billing issues",
+      semanticTitle: "Refund request",
       semanticPreview: "Refund request after duplicate charge.",
       messageCount: 4,
       startedAt: Date.UTC(2026, 2, 22),
@@ -176,6 +189,63 @@ beforeEach(() => {
   mockUseChatboxTopicMap.mockReturnValue(createDefaultChatboxTopicMapHookValue());
 });
 
+describe("topicMapNodeHoverLabel", () => {
+  it("prefers the cached semantic title when it exists", () => {
+    expect(
+      topicMapNodeHoverLabel({
+        semanticTitle: "Password reset",
+        semanticPreview: "User needs to reset a forgotten password.",
+        sessionId: "session-a",
+      }),
+    ).toBe("Password reset");
+  });
+
+  it("extracts the first topical word from the session summary, skipping articles and generic chat framing", () => {
+    expect(
+      topicMapNodeHoverLabel({
+        semanticPreview:
+          "The user requested a drawing of a dog, prompting the assistant to utilize a drawing tool.",
+        sessionId: "session-a",
+      }),
+    ).toBe("drawing");
+  });
+
+  it("strips surrounding punctuation from the chosen word", () => {
+    expect(
+      topicMapNodeHoverLabel({
+        semanticPreview: "User needs: billing help, urgently.",
+        sessionId: "session-a",
+      }),
+    ).toBe("billing");
+  });
+
+  it("prefers sibling-distinctive topics over shared cluster framing", () => {
+    // Two sessions in the same "Drawing requests" cluster should now surface
+    // their own subjects (dog vs cat) instead of both collapsing to the
+    // shared cluster keyword.
+    const dogNode = {
+      semanticPreview: "User asked for a drawing of a dog in watercolor.",
+      sessionId: "session-dog",
+    };
+    const catNode = {
+      semanticPreview: "User requested a pencil sketch of a cat on a couch.",
+      sessionId: "session-cat",
+    };
+    expect(topicMapNodeHoverLabel(dogNode)).not.toBe(
+      topicMapNodeHoverLabel(catNode),
+    );
+  });
+
+  it("falls back to the session id when the preview has no printable content", () => {
+    expect(
+      topicMapNodeHoverLabel({
+        semanticPreview: "   ",
+        sessionId: "sess-xyz",
+      }),
+    ).toBe("sess-xyz");
+  });
+});
+
 describe("ChatboxTopicMapPanel", () => {
   it("subscribes to ResizeObserver only after the graph pane mounts (post-loading)", () => {
     const observed: Element[] = [];
@@ -227,7 +297,6 @@ describe("ChatboxTopicMapPanel", () => {
 
     expect(screen.queryByText("Historical Topic Map")).not.toBeInTheDocument();
     expect(screen.queryByText("2 mapped sessions")).not.toBeInTheDocument();
-    expect(screen.getByText("Clusters")).toBeInTheDocument();
     expect(screen.getByText("Password resets")).toBeInTheDocument();
     expect(
       screen.getByText("Reset and account recovery questions."),
@@ -236,7 +305,7 @@ describe("ChatboxTopicMapPanel", () => {
     expect(screen.getByText("Invoice and refund help.")).toBeInTheDocument();
   });
 
-  it("renders Fit view and rebuild controls in the right panel", () => {
+  it("renders Fit view and rebuild controls overlayed on the canvas", () => {
     render(
       <ChatboxTopicMapPanel
         chatboxId="chatbox-1"
@@ -248,7 +317,7 @@ describe("ChatboxTopicMapPanel", () => {
     );
 
     const fitView = screen.getByRole("button", { name: /fit view/i });
-    const rebuild = screen.getByRole("button", { name: /rebuild topic map/i });
+    const rebuild = screen.getByRole("button", { name: /rebuild clusters/i });
     expect(fitView.compareDocumentPosition(rebuild)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
@@ -305,7 +374,6 @@ describe("ChatboxTopicMapPanel", () => {
       />,
     );
 
-    expect(screen.getByText("Clusters")).toBeInTheDocument();
     await user.click(
       screen.getByRole("button", { name: /Billing issues Invoice and refund help/i }),
     );
@@ -315,6 +383,24 @@ describe("ChatboxTopicMapPanel", () => {
       clusterId: "cluster-b",
       label: "Billing issues",
     });
+  });
+
+  it("renders cluster keywords as static chips without a popover", () => {
+    render(
+      <ChatboxTopicMapPanel
+        chatboxId="chatbox-1"
+        filter={EMPTY_FILTER}
+        onToggleChip={vi.fn()}
+        onClearChip={vi.fn()}
+        onRebuild={vi.fn()}
+      />,
+    );
+
+    const keywordChip = screen.getByText("password");
+    expect(keywordChip.tagName).toBe("SPAN");
+    expect(
+      screen.queryByRole("button", { name: "password" }),
+    ).not.toBeInTheDocument();
   });
 
   it("highlights active cluster selection in the list", () => {
@@ -334,6 +420,29 @@ describe("ChatboxTopicMapPanel", () => {
     const clusterButton = screen.getByRole("button", {
       name: /Password resets Reset and account recovery questions/i,
     });
-    expect(clusterButton).toHaveClass("border-primary/40");
+    expect(clusterButton.parentElement).toHaveClass("border-primary/40");
+  });
+
+  it("clears node selection when the graph background is clicked", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ChatboxTopicMapPanel
+        chatboxId="chatbox-1"
+        filter={EMPTY_FILTER}
+        onToggleChip={vi.fn()}
+        onClearChip={vi.fn()}
+        onRebuild={vi.fn()}
+      />,
+    );
+
+    const graphHost = screen.getByTestId("force-graph").parentElement;
+    expect(graphHost).toHaveAttribute("data-selected-session", "session-a");
+
+    await user.click(screen.getByRole("button", { name: /graph node session-b/i }));
+    expect(graphHost).toHaveAttribute("data-selected-session", "session-b");
+
+    await user.click(screen.getByTestId("force-graph-background"));
+    expect(graphHost).toHaveAttribute("data-selected-session", "");
   });
 });

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxTopicMapPanel.test.tsx
@@ -116,12 +116,11 @@ const SNAPSHOT = {
   ],
 };
 
-beforeEach(() => {
-  mockUseChatboxTopicMap.mockReset();
-  mockUseChatboxTopicMap.mockReturnValue({
+function createDefaultChatboxTopicMapHookValue() {
+  return {
     latestRun: {
       _id: "run-1",
-      status: "done",
+      status: "done" as const,
       startedAt: Date.now() - 10_000,
       finishedAt: Date.now() - 5_000,
       sessionCount: 2,
@@ -169,7 +168,12 @@ beforeEach(() => {
     snapshotError: null,
     isLoading: false,
     metadata: null,
-  });
+  };
+}
+
+beforeEach(() => {
+  mockUseChatboxTopicMap.mockReset();
+  mockUseChatboxTopicMap.mockReturnValue(createDefaultChatboxTopicMapHookValue());
 });
 
 describe("ChatboxTopicMapPanel", () => {
@@ -185,12 +189,50 @@ describe("ChatboxTopicMapPanel", () => {
     );
 
     expect(screen.getByText("Historical Topic Map")).toBeInTheDocument();
+    expect(screen.queryByText("2 mapped sessions")).not.toBeInTheDocument();
     expect(screen.getByText("session-a")).toBeInTheDocument();
     expect(screen.getByText("Password resets")).toBeInTheDocument();
     expect(
       screen.getByText("User needs to reset a forgotten password."),
     ).toBeInTheDocument();
     expect(screen.getByText(/1 unmapped/i)).toBeInTheDocument();
+  });
+
+  it("shows rebuild status in the header while a run is active", () => {
+    mockUseChatboxTopicMap.mockReturnValue({
+      ...createDefaultChatboxTopicMapHookValue(),
+      latestRun: {
+        _id: "run-2",
+        status: "running" as const,
+        startedAt: Date.now(),
+        finishedAt: null,
+        sessionCount: null,
+        clusterCount: null,
+        errorMessage: null,
+        model: "openai/gpt-4o-mini",
+        topicMapVersion: 1,
+        edgeCount: null,
+        sampleNodeCount: null,
+        unmappedSessionCount: null,
+        isSampled: false,
+        topicMapReady: false,
+        isStale: false,
+      },
+    });
+
+    render(
+      <ChatboxTopicMapPanel
+        chatboxId="chatbox-1"
+        filter={EMPTY_FILTER}
+        onToggleChip={vi.fn()}
+        onClearChip={vi.fn()}
+        onRebuild={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Updating historical topic map"),
+    ).toBeInTheDocument();
   });
 
   it("lets operators toggle a community chip from the sidebar", async () => {

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
@@ -1050,7 +1050,7 @@ export function ChatboxBuilderView({
       />
 
       {(viewMode === "usage" || viewMode === "insights") && chatbox ? (
-        <div className="min-h-0 flex-1">
+        <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
           <ChatboxUsagePanel
             chatbox={chatbox}
             section={viewMode === "insights" ? "insights" : "sessions"}

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
@@ -238,7 +238,7 @@ function ChatboxBuilderChrome({
               ["setup", "Setup"],
               ["preview", "Preview"],
               ["usage", "Sessions"],
-              ["insights", "Insights"],
+              ["insights", "Clusters"],
             ] as const
           ).map(([mode, label]) => {
             const active = viewMode === mode;

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxBuilderView.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxBuilderView.test.tsx
@@ -218,7 +218,7 @@ describe("ChatboxBuilderView", () => {
     expect(screen.getByRole("button", { name: /^Save$/i })).not.toBeDisabled();
   });
 
-  it("disables Preview, Sessions, and Insights until the chatbox is saved", () => {
+  it("disables Preview, Sessions, and Clusters until the chatbox is saved", () => {
     const draft = CHATBOX_STARTERS.find((s) => s.id === "blank")!.createDraft(
       "openai/gpt-5-mini",
     );
@@ -234,7 +234,7 @@ describe("ChatboxBuilderView", () => {
 
     expect(screen.getByRole("button", { name: "Preview" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Sessions" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Insights" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Clusters" })).toBeDisabled();
   });
 
   it("passes sessions section to the usage panel for usage view mode", () => {

--- a/mcpjam-inspector/client/src/hooks/useChatboxTopicMap.ts
+++ b/mcpjam-inspector/client/src/hooks/useChatboxTopicMap.ts
@@ -51,6 +51,7 @@ export type TopicMapSnapshot = {
     degree: number;
     clusterId?: string;
     clusterLabel?: string;
+    semanticTitle?: string;
     semanticPreview: string;
     messageCount: number;
     startedAt: number;

--- a/mcpjam-inspector/client/src/hooks/useChatboxTopicMap.ts
+++ b/mcpjam-inspector/client/src/hooks/useChatboxTopicMap.ts
@@ -1,0 +1,150 @@
+import { startTransition, useEffect, useState } from "react";
+import { useQuery } from "convex/react";
+import type { ClusterRunState } from "@/hooks/useUsageInsights";
+
+export type TopicMapCluster = {
+  _id: string;
+  label: string;
+  summary: string;
+  keywords: string[];
+  memberCount: number;
+  createdAt: number;
+};
+
+export type TopicMapSnapshotMetadata = {
+  runId: string;
+  topicMapBlobUrl: string | null;
+  topicMapVersion: number;
+  edgeCount: number;
+  sampleNodeCount: number;
+  unmappedSessionCount: number;
+  isSampled: boolean;
+  sessionCount: number;
+  clusterCount: number;
+};
+
+export type TopicMapSnapshot = {
+  version: number;
+  chatboxId: string;
+  runId: string;
+  generatedAt: number;
+  isSampled: boolean;
+  stats: {
+    nodeCount: number;
+    edgeCount: number;
+    clusterCount: number;
+    mappedSessionCount: number;
+    unmappedSessionCount: number;
+  };
+  clusters: Array<{
+    clusterId: string;
+    label: string;
+    summary: string;
+    keywords: string[];
+    memberCount: number;
+    colorIndex: number;
+  }>;
+  nodes: Array<{
+    sessionId: string;
+    x: number;
+    y: number;
+    degree: number;
+    clusterId?: string;
+    clusterLabel?: string;
+    semanticPreview: string;
+    messageCount: number;
+    startedAt: number;
+    lastActivityAt: number;
+    modelId?: string;
+  }>;
+  edges: Array<{
+    source: string;
+    target: string;
+    score: number;
+  }>;
+};
+
+type TopicMapQueryResult = {
+  latestRun: ClusterRunState | null;
+  snapshot: TopicMapSnapshotMetadata | null;
+  clusters: TopicMapCluster[];
+} | null;
+
+export function useChatboxTopicMap({
+  chatboxId,
+  enabled = true,
+}: {
+  chatboxId: string | null;
+  enabled?: boolean;
+}) {
+  const metadata = useQuery(
+    "chatSessions:getTopicMapSnapshot" as any,
+    enabled && chatboxId ? ({ chatboxId } as any) : "skip",
+  ) as TopicMapQueryResult | undefined;
+  const [snapshot, setSnapshot] = useState<TopicMapSnapshot | null>(null);
+  const [snapshotError, setSnapshotError] = useState<string | null>(null);
+  const [snapshotLoading, setSnapshotLoading] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      setSnapshot(null);
+      setSnapshotError(null);
+      setSnapshotLoading(false);
+      return;
+    }
+
+    const url = metadata?.snapshot?.topicMapBlobUrl ?? null;
+    if (!url) {
+      setSnapshot(null);
+      setSnapshotError(null);
+      setSnapshotLoading(false);
+      return;
+    }
+
+    const controller = new AbortController();
+    setSnapshotLoading(true);
+    setSnapshotError(null);
+
+    void fetch(url, { signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load topic map (${response.status})`);
+        }
+        return (await response.json()) as TopicMapSnapshot;
+      })
+      .then((nextSnapshot) => {
+        startTransition(() => {
+          setSnapshot(nextSnapshot);
+          setSnapshotLoading(false);
+        });
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        startTransition(() => {
+          setSnapshot(null);
+          setSnapshotLoading(false);
+          setSnapshotError(
+            error instanceof Error
+              ? error.message
+              : "Failed to load topic map snapshot.",
+          );
+        });
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [enabled, metadata?.snapshot?.runId, metadata?.snapshot?.topicMapBlobUrl]);
+
+  return {
+    metadata,
+    latestRun: metadata?.latestRun ?? null,
+    clusters: metadata?.clusters ?? [],
+    snapshot,
+    snapshotMetadata: metadata?.snapshot ?? null,
+    snapshotError,
+    isLoading:
+      enabled &&
+      (metadata === undefined || snapshotLoading || (metadata?.snapshot != null && snapshot == null && !snapshotError)),
+  };
+}

--- a/mcpjam-inspector/client/src/hooks/useUsageInsights.ts
+++ b/mcpjam-inspector/client/src/hooks/useUsageInsights.ts
@@ -32,6 +32,12 @@ export type ClusterRunState = {
   clusterCount: number;
   errorMessage: string | null;
   model?: string | null;
+  topicMapVersion?: number | null;
+  edgeCount?: number;
+  sampleNodeCount?: number;
+  unmappedSessionCount?: number;
+  isSampled?: boolean;
+  topicMapReady?: boolean;
   isStale: boolean;
 };
 
@@ -66,15 +72,17 @@ export function useUsageInsights({
   sourceType,
   sourceId,
   filters,
+  enabled = true,
 }: {
   sourceType: InsightsSourceType;
   sourceId: string | null;
   filters: UsageFilterState;
+  enabled?: boolean;
 }) {
   // v1 only wires chatbox sources. ServerShare will reuse this hook by
   // swapping the underlying queries once the backend parity lands.
   const chatboxArgs =
-    sourceType === "chatbox" && sourceId
+    enabled && sourceType === "chatbox" && sourceId
       ? ({
           chatboxId: sourceId,
           limit: 100,
@@ -83,7 +91,7 @@ export function useUsageInsights({
       : "skip";
 
   const breakdownArgs =
-    sourceType === "chatbox" && sourceId
+    enabled && sourceType === "chatbox" && sourceId
       ? ({
           chatboxId: sourceId,
           filters: toServerFilters(filters),

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -151,6 +151,7 @@
     "radix-ui": "^1.4.2",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-force-graph-2d": "^1.29.1",
     "react-hook-form": "^7.60.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^3.0.3",
@@ -168,7 +169,6 @@
     "zustand": "^5.0.6"
   },
   "devDependencies": {
-    "@mcpjam/design-system": "*",
     "@electron-forge/cli": "^7.11.1",
     "@electron-forge/maker-deb": "^7.11.1",
     "@electron-forge/maker-dmg": "^7.11.1",
@@ -180,6 +180,7 @@
     "@electron-forge/publisher-github": "^7.11.1",
     "@electron/fuses": "^2.0.0",
     "@eslint/eslintrc": "^3",
+    "@mcpjam/design-system": "*",
     "@playwright/test": "^1.54.2",
     "@tailwindcss/postcss": "^4.1.11",
     "@tailwindcss/vite": "^4.1.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "soundcheck",
         "mcp"
       ],
+      "dependencies": {
+        "react-force-graph-2d": "^1.29.1"
+      },
       "devDependencies": {
         "@changesets/cli": "^2.29.7",
         "@types/dagre": "^0.7.54"
@@ -422,7 +425,7 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
@@ -912,7 +915,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
       "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^3.0.0",
@@ -926,7 +929,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -936,7 +939,7 @@
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -950,7 +953,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -960,7 +963,7 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@axiomhq/js": {
@@ -2017,7 +2020,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2037,7 +2040,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
       "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2061,7 +2064,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
       "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2089,7 +2092,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2112,7 +2115,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
       "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2137,7 +2140,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -4377,7 +4380,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -5912,7 +5915,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -8156,7 +8159,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -12696,6 +12699,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -13465,7 +13474,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -13475,7 +13483,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -14851,6 +14859,15 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -15952,11 +15969,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -16178,7 +16205,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/bundle-name": {
@@ -16446,6 +16473,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/canvas-color-tracker/-/canvas-color-tracker-1.3.2.tgz",
+      "integrity": "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -17260,7 +17299,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -17281,7 +17320,7 @@
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
       "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^4.1.1",
@@ -17297,7 +17336,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -17418,6 +17457,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
     },
     "node_modules/d3-brush": {
       "version": "3.0.0",
@@ -17583,6 +17628,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
@@ -17624,6 +17685,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
     },
     "node_modules/d3-path": {
       "version": "3.1.0",
@@ -17840,7 +17907,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
       "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -17854,7 +17921,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -17951,7 +18018,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/decimal.js-light": {
@@ -19108,7 +19175,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -19119,7 +19185,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -20742,6 +20807,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/flora-colossus": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/flora-colossus/-/flora-colossus-2.0.0.tgz",
@@ -20819,6 +20898,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/force-graph": {
+      "version": "1.51.4",
+      "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.51.4.tgz",
+      "integrity": "sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "^1.3",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "float-tooltip": "^1.7",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/foreground-child": {
@@ -21862,7 +21967,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -21929,7 +22034,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -21943,7 +22048,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -22153,6 +22258,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/infer-owner": {
@@ -22740,7 +22854,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
@@ -23097,6 +23211,15 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/jest": {
@@ -24134,7 +24257,7 @@
       "version": "27.4.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
@@ -24174,7 +24297,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -24184,7 +24307,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -24198,7 +24321,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -24381,6 +24504,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/katex": {
       "version": "0.16.45",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
@@ -24518,7 +24653,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -24551,7 +24686,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24572,7 +24706,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24593,7 +24726,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24614,7 +24746,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24635,7 +24766,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24656,7 +24786,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -24680,7 +24809,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -24704,7 +24832,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -24728,7 +24855,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -24752,7 +24878,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24773,7 +24898,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25692,7 +25816,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
@@ -28493,7 +28617,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -28836,7 +28960,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -28855,7 +28979,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -28868,7 +28992,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -29399,7 +29522,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -29669,6 +29792,23 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/react-force-graph-2d/-/react-force-graph-2d-1.29.1.tgz",
+      "integrity": "sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.72.1",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.72.1.tgz",
@@ -29690,6 +29830,21 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -30759,7 +30914,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -30851,7 +31006,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -31512,7 +31667,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -31531,7 +31686,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -32222,7 +32377,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/synckit": {
@@ -32369,7 +32524,7 @@
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -32453,7 +32608,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/test-exclude": {
@@ -32637,6 +32792,12 @@
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "license": "MIT"
     },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
@@ -32705,7 +32866,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
       "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.28"
@@ -32718,7 +32879,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
       "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tmp": {
@@ -32822,7 +32983,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -32835,7 +32996,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -33183,7 +33344,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -33366,7 +33527,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -34351,7 +34512,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -34427,7 +34588,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -34532,7 +34693,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -34542,7 +34703,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
       "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^6.0.0",
@@ -35390,7 +35551,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -35410,7 +35571,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/xtend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -230,6 +230,7 @@
         "radix-ui": "^1.4.2",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-force-graph-2d": "^1.29.1",
         "react-hook-form": "^7.60.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
   "devDependencies": {
     "@changesets/cli": "^2.29.7",
     "@types/dagre": "^0.7.54"
+  },
+  "dependencies": {
+    "react-force-graph-2d": "^1.29.1"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new canvas-based force graph UI plus a new data-fetching hook that loads snapshot blobs, which can impact performance and error handling in the chatbox insights area.
> 
> **Overview**
> Replaces the chatbox *Insights* section with a new **Clusters / Historical Topic Map** view that renders session nodes and similarity edges in a `react-force-graph-2d` canvas, with hover/selection bubbles, search, cluster halo rendering, and sidebar cluster filtering.
> 
> Adds `useChatboxTopicMap` to query topic-map snapshot metadata via Convex and fetch the snapshot JSON blob (with loading/error states), and extends `ClusterRunState` to carry topic-map-related fields used for rebuild/status messaging.
> 
> Updates navigation/labels (`Insights` -> `Clusters`), gates `useUsageInsights` queries behind an `enabled` flag to avoid fetching threads/breakdowns when viewing clusters, and adds focused component tests for the new panel behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 109899740fe8a922b40b46b4d5b724cba55babe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->