### PR TITLE
[codex] use batch hosted auth

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mcpClientManagerMock, disconnectAllServersMock } = vi.hoisted(() => ({
+  mcpClientManagerMock: vi.fn(),
+  disconnectAllServersMock: vi.fn(),
+}));
+
+vi.mock("@mcpjam/sdk", async () => {
+  const actual = await vi.importActual<typeof import("@mcpjam/sdk")>(
+    "@mcpjam/sdk"
+  );
+  return {
+    ...actual,
+    MCPClientManager: mcpClientManagerMock.mockImplementation(() => ({
+      disconnectAllServers: disconnectAllServersMock,
+    })),
+  };
+});
+
+import { createAuthorizedManager } from "../auth.js";
+import { WebRouteError } from "../errors.js";
+
+describe("web auth manager batching", () => {
+  const originalFetch = global.fetch;
+  const originalConvexHttpUrl = process.env.CONVEX_HTTP_URL;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CONVEX_HTTP_URL = "https://example.convex.site";
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalConvexHttpUrl === undefined) {
+      delete process.env.CONVEX_HTTP_URL;
+    } else {
+      process.env.CONVEX_HTTP_URL = originalConvexHttpUrl;
+    }
+  });
+
+  it("surfaces the first batch failure in input order", async () => {
+    global.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          results: {
+            "server-a": {
+              ok: false,
+              status: 403,
+              code: "FORBIDDEN",
+              message: "server-a failed",
+            },
+            "server-b": {
+              ok: false,
+              status: 404,
+              code: "NOT_FOUND",
+              message: "server-b failed",
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }) as typeof fetch;
+
+    await expect(
+      createAuthorizedManager(
+        "bearer-token",
+        "workspace-1",
+        ["server-b", "server-a"],
+        10_000
+      )
+    ).rejects.toMatchObject<WebRouteError>({
+      status: 404,
+      code: "NOT_FOUND",
+      message: "server-b failed",
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the request oauth token when the batch response does not include one", async () => {
+    global.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          results: {
+            "server-1": {
+              ok: true,
+              role: "member",
+              accessLevel: "workspace_member",
+              permissions: { chatOnly: false },
+              serverConfig: {
+                transportType: "http",
+                url: "https://server-1.example.com/mcp",
+                headers: { "X-Test": "yes" },
+                useOAuth: true,
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }) as typeof fetch;
+
+    const result = await createAuthorizedManager(
+      "bearer-token",
+      "workspace-1",
+      ["server-1"],
+      10_000,
+      {
+        "server-1": "request-token",
+      }
+    );
+
+    expect(result.oauthServerUrls).toEqual({
+      "server-1": "https://server-1.example.com/mcp",
+    });
+    expect(mcpClientManagerMock).toHaveBeenCalledWith(
+      {
+        "server-1": expect.objectContaining({
+          url: "https://server-1.example.com/mcp",
+          requestInit: {
+            headers: {
+              "X-Test": "yes",
+              Authorization: "Bearer request-token",
+            },
+          },
+        }),
+      },
+      expect.any(Object)
+    );
+  });
+
+  it("preserves oauthRequired error details when no token is available", async () => {
+    global.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          results: {
+            "server-1": {
+              ok: true,
+              role: "member",
+              accessLevel: "workspace_member",
+              permissions: { chatOnly: false },
+              serverConfig: {
+                transportType: "http",
+                url: "https://server-1.example.com/mcp",
+                headers: {},
+                useOAuth: true,
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }) as typeof fetch;
+
+    await expect(
+      createAuthorizedManager(
+        "bearer-token",
+        "workspace-1",
+        ["server-1"],
+        10_000
+      )
+    ).rejects.toMatchObject<WebRouteError>({
+      status: 401,
+      code: "UNAUTHORIZED",
+      details: {
+        oauthRequired: true,
+        serverId: "server-1",
+        serverUrl: "https://server-1.example.com/mcp",
+      },
+    });
+  });
+});

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -24,8 +24,9 @@ vi.mock("ai", async () => {
 });
 
 vi.mock("@mcpjam/sdk", async () => {
-  const actual =
-    await vi.importActual<typeof import("@mcpjam/sdk")>("@mcpjam/sdk");
+  const actual = await vi.importActual<typeof import("@mcpjam/sdk")>(
+    "@mcpjam/sdk"
+  );
   return {
     ...actual,
     isMCPAuthError: vi.fn().mockReturnValue(false),
@@ -56,8 +57,9 @@ vi.mock("../apps.js", () => ({
 }));
 
 vi.mock("@/shared/types", async () => {
-  const actual =
-    await vi.importActual<typeof import("@/shared/types")>("@/shared/types");
+  const actual = await vi.importActual<typeof import("@/shared/types")>(
+    "@/shared/types"
+  );
   return {
     ...actual,
     isMCPJamProvidedModel: vi.fn().mockReturnValue(true),
@@ -91,31 +93,42 @@ describe("web routes — chat-v2 hosted mode", () => {
           endedAt: 2,
           spans: [],
           modelId: "test-model",
-        },
+        }
       );
       options.onStreamComplete?.();
       return new Response("ok", { status: 200 });
     });
 
-    global.fetch = vi.fn(async (input) => {
-      if (String(input).endsWith("/web/authorize")) {
+    global.fetch = vi.fn(async (input, init) => {
+      if (String(input).endsWith("/web/authorize-batch")) {
+        const payload = JSON.parse(String(init?.body ?? "{}"));
+        const serverIds = Array.isArray(payload?.serverIds)
+          ? payload.serverIds
+          : [];
         return new Response(
           JSON.stringify({
-            authorized: true,
-            role: "member",
-            accessLevel: "shared_chat",
-            permissions: { chatOnly: false },
-            serverConfig: {
-              transportType: "http",
-              url: "https://server.example.com/mcp",
-              headers: {},
-              useOAuth: false,
-            },
+            results: Object.fromEntries(
+              serverIds.map((serverId: string) => [
+                serverId,
+                {
+                  ok: true,
+                  role: "member",
+                  accessLevel: "shared_chat",
+                  permissions: { chatOnly: false },
+                  serverConfig: {
+                    transportType: "http",
+                    url: `https://${serverId}.example.com/mcp`,
+                    headers: {},
+                    useOAuth: false,
+                  },
+                },
+              ])
+            ),
           }),
           {
             status: 200,
             headers: { "Content-Type": "application/json" },
-          },
+          }
         );
       }
 
@@ -151,7 +164,7 @@ describe("web routes — chat-v2 hosted mode", () => {
           name: "GPT-5 Mini",
         },
       },
-      token,
+      token
     );
 
     expect(response.status).toBe(200);
@@ -159,7 +172,7 @@ describe("web routes — chat-v2 hosted mode", () => {
     expect(prepareChatV2Mock).toHaveBeenCalledWith(
       expect.objectContaining({
         selectedServers: ["server-1"],
-      }),
+      })
     );
     expect(persistChatSessionToConvexMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -170,7 +183,7 @@ describe("web routes — chat-v2 hosted mode", () => {
         surface: "preview",
         modelId: "openai/gpt-5-mini",
         modelSource: "mcpjam",
-      }),
+      })
     );
   });
 
@@ -193,7 +206,7 @@ describe("web routes — chat-v2 hosted mode", () => {
           name: "Claude Opus 4.6",
         },
       },
-      token,
+      token
     );
 
     expect(response.status).toBe(200);
@@ -201,7 +214,42 @@ describe("web routes — chat-v2 hosted mode", () => {
       expect.objectContaining({
         chatboxToken: "chatbox-shared-token",
         workspaceId: "workspace-1",
-      }),
+      })
+    );
+  });
+
+  it("uses one authorize-batch request for multi-server hosted chat", async () => {
+    const { app, token } = createWebTestApp();
+
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        workspaceId: "workspace-1",
+        selectedServerIds: ["server-1", "server-2", "server-1"],
+        chatSessionId: "chat-session-batch",
+        messages: [{ role: "user", content: "hello" }],
+        model: {
+          id: "openai/gpt-5-mini",
+          provider: "openai",
+          name: "GPT-5 Mini",
+        },
+      },
+      token
+    );
+
+    expect(response.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.convex.site/web/authorize-batch",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          workspaceId: "workspace-1",
+          serverIds: ["server-1", "server-2"],
+          accessScope: "chat_v2",
+        }),
+      })
     );
   });
 
@@ -223,7 +271,7 @@ describe("web routes — chat-v2 hosted mode", () => {
           name: "GPT-5 Mini",
         },
       },
-      token,
+      token
     );
 
     expect(response.status).toBe(200);
@@ -234,7 +282,7 @@ describe("web routes — chat-v2 hosted mode", () => {
         workspaceId: "workspace-1",
         sourceType: "direct",
         directVisibility: "workspace",
-      }),
+      })
     );
   });
 
@@ -268,7 +316,7 @@ describe("web routes — chat-v2 hosted mode", () => {
           name: "GPT-5 Mini",
         },
       },
-      token,
+      token
     );
 
     expect(response.status).toBe(500);
@@ -283,7 +331,7 @@ describe("web routes — chat-v2 hosted mode", () => {
             direction: "send",
           }),
         ],
-      }),
+      })
     );
   });
 });

--- a/mcpjam-inspector/server/routes/web/__tests__/rpc-logs.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/rpc-logs.test.ts
@@ -2,8 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 
 vi.mock("@mcpjam/sdk", async () => {
-  const actual =
-    await vi.importActual<typeof import("@mcpjam/sdk")>("@mcpjam/sdk");
+  const actual = await vi.importActual<typeof import("@mcpjam/sdk")>(
+    "@mcpjam/sdk"
+  );
 
   class MockMCPClientManager {
     private readonly rpcLogger?: (event: {
@@ -20,7 +21,7 @@ vi.mock("@mcpjam/sdk", async () => {
           message: unknown;
           serverId: string;
         }) => void;
-      },
+      }
     ) {
       this.rpcLogger = options?.rpcLogger;
     }
@@ -100,8 +101,8 @@ function createRpcLogsTestApp(): Hono {
       c,
       toolsListSchema,
       (manager, body) => listTools(manager, body),
-      { rpcLogs: false },
-    ),
+      { rpcLogs: false }
+    )
   );
   return app;
 }
@@ -112,25 +113,36 @@ describe("web hosted rpc logs", () => {
 
   beforeEach(() => {
     process.env.CONVEX_HTTP_URL = "https://convex.example.com";
-    global.fetch = vi.fn(async (input) => {
-      if (String(input).endsWith("/web/authorize")) {
+    global.fetch = vi.fn(async (input, init) => {
+      if (String(input).endsWith("/web/authorize-batch")) {
+        const payload = JSON.parse(String(init?.body ?? "{}"));
+        const serverIds = Array.isArray(payload?.serverIds)
+          ? payload.serverIds
+          : [];
         return new Response(
           JSON.stringify({
-            authorized: true,
-            role: "member",
-            accessLevel: "workspace_member",
-            permissions: { chatOnly: false },
-            serverConfig: {
-              transportType: "http",
-              url: "https://server.example.com/mcp",
-              headers: {},
-              useOAuth: false,
-            },
+            results: Object.fromEntries(
+              serverIds.map((serverId: string) => [
+                serverId,
+                {
+                  ok: true,
+                  role: "member",
+                  accessLevel: "workspace_member",
+                  permissions: { chatOnly: false },
+                  serverConfig: {
+                    transportType: "http",
+                    url: "https://server.example.com/mcp",
+                    headers: {},
+                    useOAuth: false,
+                  },
+                },
+              ])
+            ),
           }),
           {
             status: 200,
             headers: { "Content-Type": "application/json" },
-          },
+          }
         );
       }
 
@@ -158,7 +170,7 @@ describe("web hosted rpc logs", () => {
         serverId: "srv-1",
         serverName: "Notion",
       },
-      "test-token",
+      "test-token"
     );
 
     const { status, data } = await expectJson<{
@@ -184,7 +196,7 @@ describe("web hosted rpc logs", () => {
           serverName: "Notion",
           direction: "receive",
         }),
-      ]),
+      ])
     );
   });
 
@@ -199,7 +211,7 @@ describe("web hosted rpc logs", () => {
         serverIds: ["srv-1", "srv-2"],
         serverNames: ["Notion", "GitHub"],
       },
-      "test-token",
+      "test-token"
     );
 
     const { status, data } = await expectJson<{
@@ -222,7 +234,7 @@ describe("web hosted rpc logs", () => {
           serverId: "srv-2",
           serverName: "GitHub",
         }),
-      ]),
+      ])
     );
   });
 
@@ -245,7 +257,7 @@ describe("web hosted rpc logs", () => {
           serverId: "__guest__",
           serverName: "Excalidraw (App)",
         }),
-      ]),
+      ])
     );
   });
 
@@ -263,8 +275,8 @@ describe("web hosted rpc logs", () => {
           serverId: "srv-1",
           serverName: "Notion",
         },
-        "test-token",
-      ),
+        "test-token"
+      )
     );
     const second = await expectJson<{
       _rpcLogs: Array<{ serverName: string }>;
@@ -277,17 +289,17 @@ describe("web hosted rpc logs", () => {
           serverId: "srv-2",
           serverName: "GitHub",
         },
-        "test-token",
-      ),
+        "test-token"
+      )
     );
 
     expect(first.data._rpcLogs).toHaveLength(2);
     expect(second.data._rpcLogs).toHaveLength(2);
     expect(
-      first.data._rpcLogs.every((log) => log.serverName === "Notion"),
+      first.data._rpcLogs.every((log) => log.serverName === "Notion")
     ).toBe(true);
     expect(
-      second.data._rpcLogs.every((log) => log.serverName === "GitHub"),
+      second.data._rpcLogs.every((log) => log.serverName === "GitHub")
     ).toBe(true);
   });
 
@@ -302,7 +314,7 @@ describe("web hosted rpc logs", () => {
         serverId: "srv-1",
         serverName: "Notion",
       },
-      "test-token",
+      "test-token"
     );
 
     const { status, data } = await expectJson<{

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -50,7 +50,7 @@ export const workspaceServerSchema = refineHostedTokens(
     accessScope: z.enum(["workspace_member", "chat_v2"]).optional(),
     shareToken: z.string().min(1).optional(),
     chatboxToken: z.string().min(1).optional(),
-  }),
+  })
 );
 
 export const toolsListSchema = workspaceServerSchema.extend({
@@ -86,7 +86,7 @@ export const promptsListMultiSchema = refineHostedTokens(
     accessScope: z.enum(["workspace_member", "chat_v2"]).optional(),
     shareToken: z.string().min(1).optional(),
     chatboxToken: z.string().min(1).optional(),
-  }),
+  })
 );
 
 export const promptsGetSchema = workspaceServerSchema.extend({
@@ -110,7 +110,7 @@ export const hostedChatSchema = refineHostedTokens(
       shareToken: z.string().min(1).optional(),
       chatboxToken: z.string().min(1).optional(),
     })
-    .passthrough(),
+    .passthrough()
 );
 
 // ── Guest Schema ─────────────────────────────────────────────────────
@@ -146,6 +146,36 @@ export type ConvexAuthorizeResponse = {
   };
 };
 
+type AuthorizedServerConfigHolder = {
+  serverConfig: ConvexAuthorizeResponse["serverConfig"];
+};
+
+export type ConvexBatchAuthorizeFailure = {
+  ok: false;
+  status: number;
+  code: string;
+  message: string;
+};
+
+export type ConvexBatchAuthorizeSuccess = {
+  ok: true;
+  role: "owner" | "admin" | "member";
+  accessLevel: "workspace_member" | "shared_chat";
+  oauthAccessToken?: string | null;
+  permissions: {
+    chatOnly: boolean;
+  };
+  serverConfig: ConvexAuthorizeResponse["serverConfig"];
+};
+
+export type ConvexBatchAuthorizeResult =
+  | ConvexBatchAuthorizeFailure
+  | ConvexBatchAuthorizeSuccess;
+
+export type ConvexBatchAuthorizeResponse = {
+  results: Record<string, ConvexBatchAuthorizeResult>;
+};
+
 export async function authorizeServer(
   bearerToken: string,
   workspaceId: string,
@@ -154,14 +184,14 @@ export async function authorizeServer(
     accessScope?: "workspace_member" | "chat_v2";
     shareToken?: string;
     chatboxToken?: string;
-  },
+  }
 ): Promise<ConvexAuthorizeResponse> {
   const convexUrl = process.env.CONVEX_HTTP_URL;
   if (!convexUrl) {
     throw new WebRouteError(
       500,
       ErrorCode.INTERNAL_ERROR,
-      "Server missing CONVEX_HTTP_URL configuration",
+      "Server missing CONVEX_HTTP_URL configuration"
     );
   }
 
@@ -171,7 +201,7 @@ export async function authorizeServer(
       throw new WebRouteError(
         400,
         ErrorCode.VALIDATION_ERROR,
-        "shareToken and chatboxToken cannot both be provided",
+        "shareToken and chatboxToken cannot both be provided"
       );
     }
 
@@ -195,7 +225,7 @@ export async function authorizeServer(
     throw new WebRouteError(
       502,
       ErrorCode.SERVER_UNREACHABLE,
-      `Failed to reach authorization service: ${parseErrorMessage(error)}`,
+      `Failed to reach authorization service: ${parseErrorMessage(error)}`
     );
   }
 
@@ -220,24 +250,105 @@ export async function authorizeServer(
     throw new WebRouteError(
       403,
       ErrorCode.FORBIDDEN,
-      "Authorization denied for server",
+      "Authorization denied for server"
     );
   }
 
   return body as ConvexAuthorizeResponse;
 }
 
+export async function authorizeBatch(
+  bearerToken: string,
+  workspaceId: string,
+  serverIds: string[],
+  options?: {
+    accessScope?: "workspace_member" | "chat_v2";
+    shareToken?: string;
+    chatboxToken?: string;
+  }
+): Promise<ConvexBatchAuthorizeResponse> {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  if (!convexUrl) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing CONVEX_HTTP_URL configuration"
+    );
+  }
+
+  let response: Response;
+  try {
+    if (options?.shareToken && options?.chatboxToken) {
+      throw new WebRouteError(
+        400,
+        ErrorCode.VALIDATION_ERROR,
+        "shareToken and chatboxToken cannot both be provided"
+      );
+    }
+
+    response = await fetch(`${convexUrl}/web/authorize-batch`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${bearerToken}`,
+      },
+      body: JSON.stringify({
+        workspaceId,
+        serverIds,
+        ...(options?.accessScope ? { accessScope: options.accessScope } : {}),
+        ...(options?.shareToken ? { shareToken: options.shareToken } : {}),
+        ...(options?.chatboxToken
+          ? { chatboxToken: options.chatboxToken }
+          : {}),
+      }),
+    });
+  } catch (error) {
+    throw new WebRouteError(
+      502,
+      ErrorCode.SERVER_UNREACHABLE,
+      `Failed to reach authorization service: ${parseErrorMessage(error)}`
+    );
+  }
+
+  let body: any = null;
+  try {
+    body = await response.json();
+  } catch {
+    // ignored
+  }
+
+  if (!response.ok) {
+    const code =
+      typeof body?.code === "string" ? body.code : ErrorCode.INTERNAL_ERROR;
+    const message =
+      typeof body?.message === "string"
+        ? body.message
+        : `Authorization failed (${response.status})`;
+    throw new WebRouteError(response.status, code as ErrorCode, message);
+  }
+
+  if (!body?.results || typeof body.results !== "object") {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Authorization response is missing batch results"
+    );
+  }
+
+  return body as ConvexBatchAuthorizeResponse;
+}
+
 export function toHttpConfig(
-  authResponse: ConvexAuthorizeResponse,
+  authResponse: AuthorizedServerConfigHolder,
   timeoutMs: number,
   oauthAccessToken?: string,
-  clientCapabilities?: Record<string, unknown>,
+  clientCapabilities?: Record<string, unknown>
 ): HttpServerConfig {
   if (authResponse.serverConfig.transportType !== "http") {
     throw new WebRouteError(
       400,
       ErrorCode.FEATURE_NOT_SUPPORTED,
-      "Only HTTP transport is supported in hosted mode",
+      "Only HTTP transport is supported in hosted mode"
     );
   }
 
@@ -245,7 +356,7 @@ export function toHttpConfig(
     throw new WebRouteError(
       500,
       ErrorCode.INTERNAL_ERROR,
-      "Authorized server is missing URL",
+      "Authorized server is missing URL"
     );
   }
 
@@ -285,43 +396,78 @@ export async function createAuthorizedManager(
     shareToken?: string;
     chatboxToken?: string;
     rpcLogger?: RpcLogger;
-  },
+  }
 ): Promise<AuthorizedManagerResult> {
   const uniqueServerIds = Array.from(new Set(serverIds));
+  if (uniqueServerIds.length === 0) {
+    return {
+      manager: new MCPClientManager(
+        {},
+        {
+          defaultTimeout: timeoutMs,
+          rpcLogger: options?.rpcLogger,
+          retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
+        }
+      ),
+      oauthServerUrls: {},
+    };
+  }
+
   const oauthServerUrls: Record<string, string> = {};
-  const configEntries = await Promise.all(
-    uniqueServerIds.map(async (serverId) => {
-      const auth = await authorizeServer(bearerToken, workspaceId, serverId, {
-        accessScope: options?.accessScope,
-        shareToken: options?.shareToken,
-        chatboxToken: options?.chatboxToken,
-      });
-      const oauthToken = auth.oauthAccessToken ?? oauthTokens?.[serverId];
-
-      if (auth.serverConfig.useOAuth) {
-        if (auth.serverConfig.url) {
-          oauthServerUrls[serverId] = auth.serverConfig.url;
-        }
-        if (!oauthToken) {
-          throw new WebRouteError(
-            401,
-            ErrorCode.UNAUTHORIZED,
-            `Server "${serverId}" requires OAuth authentication. Please complete the OAuth flow first.`,
-            {
-              oauthRequired: true,
-              serverId,
-              serverUrl: auth.serverConfig.url,
-            },
-          );
-        }
-      }
-
-      return [
-        serverId,
-        toHttpConfig(auth, timeoutMs, oauthToken, clientCapabilities),
-      ] as const;
-    }),
+  const batch = await authorizeBatch(
+    bearerToken,
+    workspaceId,
+    uniqueServerIds,
+    {
+      accessScope: options?.accessScope,
+      shareToken: options?.shareToken,
+      chatboxToken: options?.chatboxToken,
+    }
   );
+
+  const configEntries = uniqueServerIds.map((serverId) => {
+    const auth = batch.results[serverId];
+    if (!auth) {
+      throw new WebRouteError(
+        500,
+        ErrorCode.INTERNAL_ERROR,
+        `Authorization response is missing result for server "${serverId}"`
+      );
+    }
+
+    if (!auth.ok) {
+      throw new WebRouteError(
+        auth.status,
+        auth.code as ErrorCode,
+        auth.message
+      );
+    }
+
+    const oauthToken = auth.oauthAccessToken ?? oauthTokens?.[serverId];
+
+    if (auth.serverConfig.useOAuth) {
+      if (auth.serverConfig.url) {
+        oauthServerUrls[serverId] = auth.serverConfig.url;
+      }
+      if (!oauthToken) {
+        throw new WebRouteError(
+          401,
+          ErrorCode.UNAUTHORIZED,
+          `Server "${serverId}" requires OAuth authentication. Please complete the OAuth flow first.`,
+          {
+            oauthRequired: true,
+            serverId,
+            serverUrl: auth.serverConfig.url,
+          }
+        );
+      }
+    }
+
+    return [
+      serverId,
+      toHttpConfig(auth, timeoutMs, oauthToken, clientCapabilities),
+    ] as const;
+  });
 
   const manager = new MCPClientManager(Object.fromEntries(configEntries), {
     defaultTimeout: timeoutMs,
@@ -333,7 +479,7 @@ export async function createAuthorizedManager(
 
 export async function withManager<T>(
   managerPromise: Promise<MCPClientManager> | Promise<AuthorizedManagerResult>,
-  fn: (manager: MCPClientManager) => Promise<T>,
+  fn: (manager: MCPClientManager) => Promise<T>
 ): Promise<T> {
   const result = await managerPromise;
   const manager =
@@ -348,7 +494,7 @@ export async function withManager<T>(
 export async function handleRoute<T>(
   c: any,
   handler: () => Promise<T>,
-  successStatus = 200,
+  successStatus = 200
 ) {
   try {
     const result = await handler();
@@ -360,7 +506,7 @@ export async function handleRoute<T>(
       routeError.status,
       routeError.code,
       routeError.message,
-      routeError.details,
+      routeError.details
     );
   }
 }
@@ -388,7 +534,7 @@ function resolveConnectionParams(body: Record<string, unknown>): {
     serverIds: [body.serverId as string],
     oauthTokens: buildSingleServerOAuthTokens(
       body.serverId as string,
-      body.oauthAccessToken as string | undefined,
+      body.oauthAccessToken as string | undefined
     ),
   };
 }
@@ -423,9 +569,9 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
   schema: S,
   fn: (
     manager: InstanceType<typeof MCPClientManager>,
-    body: z.infer<S>,
+    body: z.infer<S>
   ) => Promise<T>,
-  options?: { timeoutMs?: number; rpcLogs?: boolean },
+  options?: { timeoutMs?: number; rpcLogs?: boolean }
 ) {
   let rpcCollector: ReturnType<typeof createHostedRpcLogCollector> | undefined;
 
@@ -452,7 +598,7 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
         throw new WebRouteError(
           401,
           ErrorCode.UNAUTHORIZED,
-          "Valid guest token required. Please refresh the page to obtain a new session.",
+          "Valid guest token required. Please refresh the page to obtain a new session."
         );
       }
 
@@ -467,7 +613,7 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
           throw new WebRouteError(
             err.status,
             ErrorCode.VALIDATION_ERROR,
-            err.message,
+            err.message
           );
         }
         throw err;
@@ -515,7 +661,7 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
           defaultTimeout: timeoutMs,
           rpcLogger: rpcCollector?.rpcLogger,
           retryPolicy: INSPECTOR_MCP_RETRY_POLICY,
-        },
+        }
       );
 
       try {
@@ -559,9 +705,9 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
             shareToken,
             chatboxToken,
             rpcLogger: rpcCollector?.rpcLogger,
-          },
+          }
         ),
-        (manager) => fn(manager, body as z.infer<S>),
+        (manager) => fn(manager, body as z.infer<S>)
       );
     }
 
@@ -574,7 +720,7 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
       routeError.code,
       routeError.message,
       routeError.details,
-      rpcCollector?.buildEnvelope(),
+      rpcCollector?.buildEnvelope()
     );
   }
 }


### PR DESCRIPTION
## What changed
- replace per-server hosted manager authorization with a single `authorizeBatch(...)` call
- keep `authorizeServer(...)` in place for single-server routes like doctor and conformance
- add focused tests for manager batching, hosted chat batching, and hosted RPC logs under the new path

## Why
Hosted multi-server manager setup was still issuing one `/web/authorize` request per selected server. This switches manager-backed hosted flows to the new backend batch route while preserving the existing per-server OAuth-required behavior.

## Impact
- hosted chat and eval manager setup now uses one auth request even when multiple servers are selected
- single-server inspection routes continue to use `/web/authorize`
- failures are surfaced deterministically in input order

## Root cause
`createAuthorizedManager(...)` fanned out hosted auth requests across selected servers, which repeated the same Convex authorization work and added avoidable tail latency.

## Validation
- `npx vitest run server/routes/web/__tests__/auth-manager.test.ts server/routes/web/__tests__/chat-v2.hosted.test.ts server/routes/web/__tests__/rpc-logs.test.ts server/routes/web/__tests__/servers-doctor.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hosted authorization flow to use a new `/web/authorize-batch` endpoint, which can affect all multi-server hosted routes if the batch contract or error mapping differs from the prior per-server calls. Risk is mitigated by added focused tests around ordering, OAuth-required behavior, and rpc-log handling.
> 
> **Overview**
> **Hosted multi-server manager setup now authorizes via a single batch call.** `createAuthorizedManager` switches from fanning out `/web/authorize` per server to one `/web/authorize-batch` request (deduping server IDs and handling empty selections), then builds per-server configs from the batch results.
> 
> **Error and OAuth behaviors are preserved/clarified for batch results.** Batch failures are surfaced deterministically in the input server order, missing batch entries throw a 500, and OAuth-required servers still return `UNAUTHORIZED` with `oauthRequired` details when no token is available (preferring backend-issued tokens when present).
> 
> **Tests updated/added to lock in batching behavior.** New `auth-manager` tests cover batch error ordering and OAuth token fallbacks; hosted `chat-v2` and hosted rpc-log tests are updated to mock `/web/authorize-batch` and verify a single auth request for multi-server flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba1c553e81cfe527ddc8da98ce65fc818d2c5dea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->