### PR TITLE
Saving in progress test cases + actually deleting test cases from executions tab

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-executions-overview.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-executions-overview.test.tsx
@@ -102,6 +102,70 @@ describe("SuiteExecutionsOverview", () => {
     expect(screen.queryByText("Snapshot title")).toBeNull();
   });
 
+  it("hides executions whose test case no longer exists live", () => {
+    render(
+      <SuiteExecutionsOverview
+        cases={cases}
+        allIterations={[
+          iteration({ _id: "live" }),
+          iteration({
+            _id: "deleted",
+            testCaseId: "deleted-case",
+            suiteRunId: "run-deleted",
+            testCaseSnapshot: { title: "Deleted snapshot" } as any,
+          }),
+        ]}
+        onOpenIteration={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("suite-execution-row-live")).toBeInTheDocument();
+    expect(screen.queryByTestId("suite-execution-row-deleted")).toBeNull();
+    expect(screen.queryByText("Deleted snapshot")).toBeNull();
+  });
+
+  it("keeps run-linked executions without a test case id", () => {
+    render(
+      <SuiteExecutionsOverview
+        cases={cases}
+        allIterations={[
+          iteration({
+            _id: "run-linked",
+            testCaseId: undefined,
+            suiteRunId: "run-1",
+            testCaseSnapshot: { title: "Snapshot case" } as any,
+          }),
+        ]}
+        onOpenIteration={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("suite-execution-row-run-linked"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Snapshot case")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when all executions are filtered out", () => {
+    render(
+      <SuiteExecutionsOverview
+        cases={cases}
+        allIterations={[
+          iteration({
+            _id: "deleted-only",
+            testCaseId: "deleted-case",
+            suiteRunId: "run-deleted",
+            testCaseSnapshot: { title: "Deleted snapshot" } as any,
+          }),
+        ]}
+        onOpenIteration={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("No executions found.")).toBeInTheDocument();
+    expect(screen.queryByTestId(/suite-execution-row-/)).toBeNull();
+  });
+
   it("fires onOpenIteration when an openable row is clicked", async () => {
     const user = userEvent.setup();
     const onOpenIteration = vi.fn();

--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -229,7 +229,7 @@ describe("TestTemplateEditor run view from route", () => {
       .getByText(modelLabel, { selector: "div" })
       .closest(".rounded-2xl");
     expect(card).not.toBeNull();
-    return card!;
+    return card as HTMLElement;
   }
 
   function getMetricBar(card: HTMLElement, label: "Latency" | "Tokens") {
@@ -618,6 +618,87 @@ describe("TestTemplateEditor run view from route", () => {
     expect(retryRequest.provider).toBe("openai");
     expect(retryRequest.model).toBe("gpt-4");
     expect(updateTestCaseMutationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists unsaved test case draft fields before starting a compare run", async () => {
+    const user = userEvent.setup();
+    const draftCase = {
+      ...caseDoc,
+      title: "Untitled test case",
+      query: "",
+      isNegativeTest: false,
+      promptTurns: undefined,
+      expectedToolCalls: [],
+      lastMessageRun: undefined,
+    };
+
+    useQueryMock.mockImplementation((name: string, args: unknown) => {
+      if (name === "testSuites:listTestCases") return [draftCase];
+      if (name === "testSuites:getTestSuite") {
+        return { _id: "suite-1", environment: { servers: ["srv"] } };
+      }
+      if (name === "testSuites:listTestIterations" && args !== "skip") {
+        return [];
+      }
+      return undefined;
+    });
+
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        workspaceId={null}
+        availableModels={[
+          {
+            provider: "openai",
+            id: "gpt-4",
+            model: "gpt-4",
+            name: "GPT-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+      />,
+    );
+
+    await user.type(
+      await screen.findByPlaceholderText("Enter the user prompt…"),
+      "Find the latest incidents",
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Untitled test case" }),
+    );
+    const titleInput = screen.getByDisplayValue("Untitled test case");
+    await user.clear(titleInput);
+    await user.type(titleInput, "Named draft case");
+    await user.keyboard("{Enter}");
+
+    await user.click(screen.getByRole("button", { name: /^run$/i }));
+
+    await waitFor(() => {
+      expect(streamEvalTestCaseMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(updateTestCaseMutationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        testCaseId: "case-1",
+        title: "Named draft case",
+        query: "Find the latest incidents",
+        runs: 1,
+        expectedToolCalls: [],
+        isNegativeTest: true,
+        promptTurns: [
+          expect.objectContaining({
+            id: "turn-1",
+            prompt: "Find the latest incidents",
+            expectedToolCalls: [],
+          }),
+        ],
+      }),
+    );
+    expect(updateTestCaseMutationMock.mock.invocationCallOrder[0]).toBeLessThan(
+      streamEvalTestCaseMock.mock.invocationCallOrder[0],
+    );
   });
 
   it("renders an immediate chat preview instead of the generic spinner before the first stream event", async () => {

--- a/mcpjam-inspector/client/src/components/evals/suite-executions-overview.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-executions-overview.tsx
@@ -57,15 +57,19 @@ export function SuiteExecutionsOverview({
   const sortedIterations = useMemo(() => {
     const deduped = new Map<string, EvalIteration>();
     for (const iteration of allIterations) {
-      if (iteration?._id) {
-        deduped.set(iteration._id, iteration);
+      if (!iteration?._id) {
+        continue;
       }
+      if (iteration.testCaseId && !caseById.has(iteration.testCaseId)) {
+        continue;
+      }
+      deduped.set(iteration._id, iteration);
     }
     return Array.from(deduped.values()).sort(
       (a, b) =>
         getIterationRecencyTimestamp(b) - getIterationRecencyTimestamp(a),
     );
-  }, [allIterations]);
+  }, [allIterations, caseById]);
 
   return (
     <div className="flex max-h-[600px] flex-col rounded-xl border bg-card text-card-foreground">

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -25,7 +25,6 @@ import { toast } from "sonner";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import {
   listEvalTools,
-  runEvalTestCase,
   streamEvalTestCase,
 } from "@/lib/apis/evals-api";
 import { Button } from "@mcpjam/design-system/button";
@@ -762,20 +761,30 @@ export function TestTemplateEditor({
     }
   };
 
-  const persistSelectedCompareModels = async (modelValues: string[]) => {
-    if (!currentTestCase) {
-      return;
-    }
-
-    const nextModels = modelValues.map((modelValue) => {
+  const buildSelectedCompareModels = (
+    modelValues: string[],
+  ): Array<{ provider: string; model: string }> => {
+    return modelValues.map((modelValue) => {
       const { provider, model } = parseModelValue(modelValue);
       if (!provider || !model) {
         throw new Error(`Invalid model selection: ${modelValue}`);
       }
       return { provider, model };
     });
+  };
 
-    const currentModels = currentTestCase.models ?? [];
+  const persistCompareRunDraft = async (
+    savePayload: ReturnType<typeof buildSavePayload>,
+    modelValues: string[],
+  ) => {
+    if (!currentTestCase) {
+      return;
+    }
+
+    const nextModels = buildSelectedCompareModels(modelValues);
+
+    const currentModels: Array<{ provider: string; model: string }> =
+      currentTestCase.models ?? [];
     const modelsUnchanged =
       currentModels.length === nextModels.length &&
       currentModels.every(
@@ -784,13 +793,14 @@ export function TestTemplateEditor({
           model.model === nextModels[index]?.model,
       );
 
-    if (modelsUnchanged) {
+    if (!hasUnsavedChanges && modelsUnchanged) {
       return;
     }
 
     await updateTestCaseMutation({
       testCaseId: currentTestCase._id,
-      models: nextModels,
+      ...(hasUnsavedChanges ? savePayload : {}),
+      ...(modelsUnchanged ? {} : { models: nextModels }),
     });
   };
 
@@ -1145,13 +1155,13 @@ export function TestTemplateEditor({
 
     if (startsNewCompareSession) {
       try {
-        await persistSelectedCompareModels(selectedModelValues);
+        await persistCompareRunDraft(savePayload, selectedModelValues);
       } catch (error) {
-        console.error("Failed to save compare model selection:", error);
+        console.error("Failed to save test case before compare run:", error);
         toast.error(
           getBillingErrorMessage(
             error,
-            "Failed to save compare models before running",
+            "Failed to save test case before running",
           ),
         );
         return;
@@ -2340,6 +2350,7 @@ export function TestTemplateEditor({
                         testCase={currentTestCase}
                         serverNames={connectedServerList}
                         workspaceId={workspaceId}
+                        onContinueInChat={onContinueInChat}
                         onStreamingTraceLoaded={() =>
                           clearCompareStreamingState(record.modelValue)
                         }


### PR DESCRIPTION
The first change saves the in-progress test case before starting the compare/run flow, so going back while a run is happening no longer makes the case seem to disappear.

The second change is the executions-tab cleanup: deleted test cases were still showing there, and now those rows get filtered out. it’s fixing the Executions UI to not show the deleted test cases