### PR TITLE
sending incomplete mutation on chatbox-access settings

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxShareSection.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxShareSection.tsx
@@ -29,6 +29,27 @@ import {
 
 const INVITE_EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
+function buildChatboxUpdatePayload(
+  chatbox: ChatboxSettings,
+  allowGuestAccess: boolean,
+) {
+  return {
+    chatboxId: chatbox.chatboxId,
+    name: chatbox.name,
+    description: chatbox.description,
+    hostStyle: chatbox.hostStyle,
+    systemPrompt: chatbox.systemPrompt,
+    modelId: chatbox.modelId,
+    temperature: chatbox.temperature,
+    requireToolApproval: chatbox.requireToolApproval,
+    serverIds: chatbox.servers.map((server) => server.serverId),
+    optionalServerIds: chatbox.servers
+      .filter((server) => server.optional)
+      .map((server) => server.serverId),
+    allowGuestAccess,
+  };
+}
+
 interface ChatboxShareSectionProps {
   chatbox: ChatboxSettings;
   onUpdated?: (chatbox: ChatboxSettings) => void;
@@ -113,10 +134,9 @@ export function ChatboxShareSection({
         })) as ChatboxSettings;
       }
       if (target.allowGuestAccess !== next.allowGuestAccess) {
-        next = (await updateChatbox({
-          chatboxId: settings.chatboxId,
-          allowGuestAccess: target.allowGuestAccess,
-        })) as ChatboxSettings;
+        next = (await updateChatbox(
+          buildChatboxUpdatePayload(next, target.allowGuestAccess),
+        )) as ChatboxSettings;
       }
       updateSettings(next);
     } catch (error) {

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxShareSection.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxShareSection.test.tsx
@@ -1,7 +1,13 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChatboxSettings } from "@/hooks/useChatboxes";
 import { ChatboxShareSection } from "../ChatboxShareSection";
+
+const mockSetChatboxMode = vi.fn();
+const mockUpdateChatbox = vi.fn();
+const mockUpsertChatboxMember = vi.fn();
+const mockRemoveChatboxMember = vi.fn();
 
 vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isAuthenticated: true }),
@@ -23,10 +29,10 @@ vi.mock("@/hooks/useProfilePicture", () => ({
 
 vi.mock("@/hooks/useChatboxes", () => ({
   useChatboxMutations: () => ({
-    setChatboxMode: vi.fn(),
-    updateChatbox: vi.fn(),
-    upsertChatboxMember: vi.fn(),
-    removeChatboxMember: vi.fn(),
+    setChatboxMode: mockSetChatboxMode,
+    updateChatbox: mockUpdateChatbox,
+    upsertChatboxMember: mockUpsertChatboxMember,
+    removeChatboxMember: mockRemoveChatboxMember,
   }),
 }));
 
@@ -34,19 +40,42 @@ vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
+function createServers() {
+  return [
+    {
+      serverId: "server-required",
+      serverName: "Required Server",
+      useOAuth: false,
+      serverUrl: "https://required.example.com",
+      clientId: null,
+      oauthScopes: null,
+    },
+    {
+      serverId: "server-optional",
+      serverName: "Optional Server",
+      useOAuth: false,
+      serverUrl: "https://optional.example.com",
+      clientId: null,
+      oauthScopes: null,
+      optional: true,
+    },
+  ];
+}
+
 function createChatbox(overrides: Partial<ChatboxSettings> = {}): ChatboxSettings {
   return {
     chatboxId: "cb-1",
     workspaceId: "ws-1",
     name: "My Chatbox",
+    description: "Chatbox description",
     hostStyle: "chatgpt",
-    systemPrompt: "",
+    systemPrompt: "You are helpful.",
     modelId: "gpt-4",
     temperature: 0.7,
     requireToolApproval: false,
     allowGuestAccess: false,
     mode: "invited_only",
-    servers: [],
+    servers: createServers(),
     link: {
       token: "t",
       path: "/c/t",
@@ -59,7 +88,35 @@ function createChatbox(overrides: Partial<ChatboxSettings> = {}): ChatboxSetting
   };
 }
 
+function expectedUpdatePayload(
+  chatbox: ChatboxSettings,
+  allowGuestAccess: boolean,
+) {
+  return {
+    chatboxId: chatbox.chatboxId,
+    name: chatbox.name,
+    description: chatbox.description,
+    hostStyle: chatbox.hostStyle,
+    systemPrompt: chatbox.systemPrompt,
+    modelId: chatbox.modelId,
+    temperature: chatbox.temperature,
+    requireToolApproval: chatbox.requireToolApproval,
+    serverIds: chatbox.servers.map((server) => server.serverId),
+    optionalServerIds: chatbox.servers
+      .filter((server) => server.optional)
+      .map((server) => server.serverId),
+    allowGuestAccess,
+  };
+}
+
 describe("ChatboxShareSection", () => {
+  beforeEach(() => {
+    mockSetChatboxMode.mockReset();
+    mockUpdateChatbox.mockReset();
+    mockUpsertChatboxMember.mockReset();
+    mockRemoveChatboxMember.mockReset();
+  });
+
   it("renders the same section structure as the workspace share dialog", () => {
     render(
       <ChatboxShareSection chatbox={createChatbox()} workspaceName="Acme" />,
@@ -93,5 +150,162 @@ describe("ChatboxShareSection", () => {
 
     expect(screen.getByText("Invited")).toBeInTheDocument();
     expect(screen.getByText("pending@example.com")).toBeInTheDocument();
+  });
+
+  it("sends the full update payload after switching from guest link access to invited only", async () => {
+    const user = userEvent.setup();
+    const initialChatbox = createChatbox({
+      mode: "any_signed_in_with_link",
+      allowGuestAccess: true,
+    });
+    const modeUpdatedChatbox = createChatbox({
+      ...initialChatbox,
+      name: "Mode-updated Chatbox",
+      description: "Updated from setChatboxMode",
+      hostStyle: "claude",
+      systemPrompt: "Updated system prompt",
+      modelId: "claude-sonnet",
+      temperature: 0.2,
+      requireToolApproval: true,
+      mode: "invited_only",
+      allowGuestAccess: true,
+      servers: [
+        {
+          serverId: "server-mode-required",
+          serverName: "Mode Required Server",
+          useOAuth: false,
+          serverUrl: "https://mode-required.example.com",
+          clientId: null,
+          oauthScopes: null,
+        },
+        {
+          serverId: "server-mode-optional",
+          serverName: "Mode Optional Server",
+          useOAuth: false,
+          serverUrl: "https://mode-optional.example.com",
+          clientId: null,
+          oauthScopes: null,
+          optional: true,
+        },
+      ],
+    });
+    const fullyUpdatedChatbox = createChatbox({
+      ...modeUpdatedChatbox,
+      allowGuestAccess: false,
+    });
+    const onUpdated = vi.fn();
+    mockSetChatboxMode.mockResolvedValue(modeUpdatedChatbox);
+    mockUpdateChatbox.mockResolvedValue(fullyUpdatedChatbox);
+
+    render(
+      <ChatboxShareSection
+        chatbox={initialChatbox}
+        onUpdated={onUpdated}
+        workspaceName="Acme"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Anyone with the link (guests included)",
+      }),
+    );
+    await user.click(
+      await screen.findByRole("menuitemradio", {
+        name: /Invited users only/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockSetChatboxMode).toHaveBeenCalledWith({
+        chatboxId: "cb-1",
+        mode: "invited_only",
+      });
+    });
+    expect(mockUpdateChatbox).toHaveBeenCalledWith(
+      expectedUpdatePayload(modeUpdatedChatbox, false),
+    );
+    expect(mockSetChatboxMode).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(onUpdated).toHaveBeenCalledWith(fullyUpdatedChatbox);
+    });
+  });
+
+  it("sends the full update payload when enabling guest link access", async () => {
+    const user = userEvent.setup();
+    const initialChatbox = createChatbox({
+      mode: "any_signed_in_with_link",
+      allowGuestAccess: false,
+    });
+    const updatedChatbox = createChatbox({
+      ...initialChatbox,
+      allowGuestAccess: true,
+    });
+    const onUpdated = vi.fn();
+    mockUpdateChatbox.mockResolvedValue(updatedChatbox);
+
+    render(
+      <ChatboxShareSection
+        chatbox={initialChatbox}
+        onUpdated={onUpdated}
+        workspaceName="Acme"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Acme" }));
+    await user.click(
+      await screen.findByRole("menuitemradio", {
+        name: /Anyone with the link \(guests included\)/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockUpdateChatbox).toHaveBeenCalledWith(
+        expectedUpdatePayload(initialChatbox, true),
+      );
+    });
+    expect(mockSetChatboxMode).not.toHaveBeenCalled();
+    expect(onUpdated).toHaveBeenCalledWith(updatedChatbox);
+  });
+
+  it("sends the full update payload when disabling guest link access for workspace members", async () => {
+    const user = userEvent.setup();
+    const initialChatbox = createChatbox({
+      mode: "any_signed_in_with_link",
+      allowGuestAccess: true,
+    });
+    const updatedChatbox = createChatbox({
+      ...initialChatbox,
+      allowGuestAccess: false,
+    });
+    const onUpdated = vi.fn();
+    mockUpdateChatbox.mockResolvedValue(updatedChatbox);
+
+    render(
+      <ChatboxShareSection
+        chatbox={initialChatbox}
+        onUpdated={onUpdated}
+        workspaceName="Acme"
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "Anyone with the link (guests included)",
+      }),
+    );
+    await user.click(
+      await screen.findByRole("menuitemradio", {
+        name: /Acme/i,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockUpdateChatbox).toHaveBeenCalledWith(
+        expectedUpdatePayload(initialChatbox, false),
+      );
+    });
+    expect(mockSetChatboxMode).not.toHaveBeenCalled();
+    expect(onUpdated).toHaveBeenCalledWith(updatedChatbox);
   });
 });


### PR DESCRIPTION
## Summary
Fixes the chatbox Share panel Access settings dropdown by sending the full payload required by chatboxes:updateChatbox instead of an incomplete partial update.
Adds regression coverage for the access-setting transitions that were hitting this path.
## Context
The bug was that changing chatbox access reused updateChatbox, which is a large general-purpose mutation, even though this UI only needed to update access behavior.
## Follow-up
Add a dedicated narrow Convex mutation for chatbox access updates so this UI no longer depends on the full updateChatbox contract.

perhaps:
setChatboxAccess({
  chatboxId,
  mode,
  allowGuestAccess,
})
