### PR TITLE
Fix html storing

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -14,6 +14,7 @@ const {
   stableStoreFns,
   mockSandboxPostMessage,
   sandboxedIframePropsRef,
+  sandboxProxyBehaviorRef,
 } = vi.hoisted(() => {
   const bridge = {
     sendToolInput: vi.fn(),
@@ -58,6 +59,7 @@ const {
     mockPostMessageTransport: vi.fn(),
     mockSandboxPostMessage: vi.fn(),
     sandboxedIframePropsRef: { current: null as any },
+    sandboxProxyBehaviorRef: { current: { autoReady: true } },
     stableStoreFns: stableFns,
     /** Simulate the widget completing initialization. */
     triggerReady: () => {
@@ -123,6 +125,10 @@ vi.mock("@/components/ui/sandboxed-iframe", () => ({
         mockSandboxPostMessage(message);
       },
     }));
+    React.useEffect(() => {
+      if (!sandboxProxyBehaviorRef.current.autoReady) return;
+      props.onProxyReady?.();
+    }, [props.onProxyReady]);
     return (
       <div
         data-testid="sandboxed-iframe"
@@ -229,6 +235,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     mockBridge.oninitialized = null;
     mockSandboxPostMessage.mockClear();
     sandboxedIframePropsRef.current = null;
+    sandboxProxyBehaviorRef.current.autoReady = true;
 
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
@@ -544,6 +551,39 @@ describe("MCPAppsRenderer tool input streaming", () => {
     await act(async () => {
       resolveConnect?.();
       await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(sandboxedIframePropsRef.current?.html).toBe(
+        "<html><body>widget</body></html>",
+      );
+    });
+  });
+
+  it("waits for the sandbox proxy before starting the bridge handshake", async () => {
+    sandboxProxyBehaviorRef.current.autoReady = false;
+
+    render(
+      <MCPAppsRenderer {...baseProps} cachedWidgetHtmlUrl="blob:cached" />,
+    );
+
+    await vi.waitFor(() => {
+      expect(stableStoreFns.setWidgetHtml).toHaveBeenCalledWith(
+        "call-1",
+        "<html><body>widget</body></html>",
+      );
+    });
+
+    expect(mockBridge.connect).not.toHaveBeenCalled();
+    expect(sandboxedIframePropsRef.current?.html).toBeNull();
+
+    await act(async () => {
+      sandboxedIframePropsRef.current?.onProxyReady?.();
+      await Promise.resolve();
+    });
+
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalledTimes(1);
     });
 
     await vi.waitFor(() => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -360,6 +360,7 @@ export function MCPAppsRenderer({
   const [reinitCount, setReinitCount] = useState(0);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [widgetHtml, setWidgetHtml] = useState<string | null>(null);
+  const [sandboxProxyReady, setSandboxProxyReady] = useState(false);
   const [bridgeTransportReady, setBridgeTransportReady] = useState(false);
   const isCachedReplay = !!cachedWidgetHtmlUrl;
   const [widgetCsp, setWidgetCsp] = useState<McpUiResourceCsp | undefined>(
@@ -1086,6 +1087,12 @@ export function MCPAppsRenderer({
 
   useEffect(() => {
     if (!widgetHtml) return;
+    if (!sandboxProxyReady) {
+      logWidgetDebug("host-to-ui", "debug/bridge-connect-skipped", {
+        reason: "sandbox-proxy-not-ready",
+      });
+      return;
+    }
     const iframe = sandboxRef.current?.getIframeElement();
     if (!iframe?.contentWindow) {
       logWidgetDebug("host-to-ui", "debug/bridge-connect-skipped", {
@@ -1200,6 +1207,7 @@ export function MCPAppsRenderer({
     serverId,
     toolCallId,
     widgetHtml,
+    sandboxProxyReady,
     registerBridgeHandlers,
     setWidgetModelContext,
     cspMode,
@@ -1530,6 +1538,7 @@ export function MCPAppsRenderer({
         permissions={widgetPermissions}
         permissive={widgetPermissive}
         onProxyReady={() => {
+          setSandboxProxyReady(true);
           logWidgetDebug("ui-to-host", "debug/sandbox-proxy-ready", {
             bridgeTransportReady,
             hasWidgetHtml,

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer-adapter.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer-adapter.test.ts
@@ -653,6 +653,67 @@ describe("adaptTraceToUiMessages", () => {
     });
   });
 
+  it("preserves widget metadata from tool output when result is simplified", () => {
+    const trace: TraceEnvelope = {
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool-call",
+              toolCallId: "call-widget-live",
+              toolName: "create_view",
+              input: { title: "Dog" },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-widget-live",
+              toolName: "create_view",
+              serverId: "server-1",
+              output: {
+                type: "json",
+                value: {
+                  _meta: {
+                    ui: { resourceUri: "ui://widget/create-view.html" },
+                  },
+                  structuredContent: {
+                    checkpointId: "checkpoint-1",
+                  },
+                },
+              },
+              result: {
+                structuredContent: {
+                  checkpointId: "checkpoint-1",
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = adaptTraceToUiMessages({
+      trace,
+      connectedServerIds: ["server-1"],
+    });
+    const toolPart = result.messages[0].parts.find(
+      (part) => part.type === "dynamic-tool",
+    ) as any;
+
+    expect(toolPart.output._meta.ui.resourceUri).toBe(
+      "ui://widget/create-view.html",
+    );
+    expect(toolPart.output._serverId).toBe("server-1");
+    expect(toolPart.output.structuredContent).toEqual({
+      checkpointId: "checkpoint-1",
+    });
+  });
+
   it("does not invent empty tool output when snapshot output is absent", () => {
     const overrides = buildToolRenderOverridesFromSnapshots([
       makeWidgetSnapshot({

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer-adapter.ts
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer-adapter.ts
@@ -294,6 +294,14 @@ function getToolInput(part: TraceContentPart): Record<string, unknown> {
 }
 
 function getToolResultPayload(part: TraceContentPart): unknown {
+  if (part.output !== undefined) {
+    const unwrappedOutput = unwrapTraceToolOutput(part.output);
+    return attachServerId(
+      unwrappedOutput,
+      typeof part.serverId === "string" ? part.serverId : undefined,
+    );
+  }
+
   if (part.result !== undefined) {
     return attachServerId(
       part.result,
@@ -301,11 +309,7 @@ function getToolResultPayload(part: TraceContentPart): unknown {
     );
   }
 
-  const unwrappedOutput = unwrapTraceToolOutput(part.output);
-  return attachServerId(
-    unwrappedOutput,
-    typeof part.serverId === "string" ? part.serverId : undefined,
-  );
+  return undefined;
 }
 
 function getToolResultDisplayValue(

--- a/mcpjam-inspector/client/src/lib/__tests__/transcript-to-ui-messages.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/transcript-to-ui-messages.test.ts
@@ -168,6 +168,63 @@ describe("transcriptToUIMessages", () => {
     expect(toolPart.output).toEqual({ ok: true });
   });
 
+  it("prefers raw tool output when a simplified result is also present", () => {
+    const rawOutput = {
+      type: "json",
+      value: {
+        _meta: {
+          ui: { resourceUri: "ui://widget/create-view.html" },
+          _serverId: "server-1",
+        },
+        structuredContent: { checkpointId: "checkpoint-1" },
+      },
+    };
+    const simplifiedResult = {
+      structuredContent: { checkpointId: "checkpoint-1" },
+    };
+    const transcript = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "call-widget-1",
+            toolName: "create_view",
+            args: {},
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "call-widget-1",
+            output: rawOutput,
+            result: simplifiedResult,
+          },
+        ],
+      },
+    ];
+
+    const merged = mergeTranscriptToolResults(transcript);
+    const mergedToolCall = ((merged[0] as { content: unknown[] }).content[0] ??
+      {}) as {
+      output?: unknown;
+      result?: unknown;
+    };
+    expect(mergedToolCall.output).toEqual(rawOutput);
+    expect(mergedToolCall.result).toEqual(simplifiedResult);
+
+    const messages = transcriptToUIMessages(transcript);
+    const toolPart = messages[0].parts[0] as {
+      type: string;
+      output: unknown;
+    };
+    expect(toolPart.type).toBe("dynamic-tool");
+    expect(toolPart.output).toEqual(rawOutput);
+  });
+
   it("merged tool history converts with convertToModelMessages", async () => {
     const transcript = [
       { role: "user", content: "search for cats" },

--- a/mcpjam-inspector/client/src/lib/transcript-to-ui-messages.ts
+++ b/mcpjam-inspector/client/src/lib/transcript-to-ui-messages.ts
@@ -157,13 +157,15 @@ function convertParts(content: unknown): UIMessage["parts"] {
       // at the top level (required for toolRenderOverrides lookup).
       // Use "output-available" state (not "result") — the rendering pipeline
       // (WidgetReplay) checks for this state to decide whether to render.
+      // Prefer the raw `output` payload when available because it preserves
+      // widget metadata like `_meta.ui.resourceUri` and `_serverId`.
       parts.push({
         type: "dynamic-tool",
         toolCallId: part.toolCallId ?? part.id ?? generateId(),
         toolName: part.toolName ?? "unknown",
         state: "output-available" as const,
         input: part.args ?? part.input ?? {},
-        output: part.result ?? {},
+        output: part.output ?? part.result ?? {},
       } as any);
     } else if (partType === "tool-result") {
       // Tool results are typically already captured via tool-call results

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -158,10 +158,6 @@ function normalizeToolInput(input: unknown): Record<string, unknown> {
 }
 
 function unwrapToolResultPayload(part: Record<string, unknown>): unknown {
-  if (part.result !== undefined) {
-    return part.result;
-  }
-
   const output = part.output;
   if (
     isRecord(output) &&
@@ -171,7 +167,11 @@ function unwrapToolResultPayload(part: Record<string, unknown>): unknown {
     return output.value;
   }
 
-  return output;
+  if (output !== undefined) {
+    return output;
+  }
+
+  return part.result;
 }
 
 function readServerIdFromToolOutput(value: unknown): string | undefined {

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -829,7 +829,12 @@ describe("mcpjam-stream-handler", () => {
           toolName: "read_docs",
           serverId: "docs-server",
           output: expect.objectContaining({
-            ok: true,
+            _meta: expect.objectContaining({
+              _serverId: "docs-server",
+            }),
+            value: expect.objectContaining({
+              ok: true,
+            }),
           }),
         }),
       ]),

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -594,7 +594,7 @@ function emitToolResults(
             typeof (part as any).serverId === "string"
               ? ((part as any).serverId as string)
               : undefined;
-          const rawOutput = (part as any).result ?? part.output;
+          const rawOutput = part.output ?? (part as any).result;
 
           let outputForUi = rawOutput;
           if (rawOutput && typeof rawOutput === "object") {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the ordering/selection of tool `output` vs `result` across client and server, which can affect widget replay and trace rendering. Adds a new readiness gate to the MCP Apps bridge handshake that could delay or prevent widget initialization if the proxy signal is missed.
> 
> **Overview**
> **Widget initialization is now gated on sandbox proxy readiness.** `MCPAppsRenderer` tracks `sandboxProxyReady` and skips `bridge.connect()` (with debug logging) until `SandboxedIframe` fires `onProxyReady`; tests were updated and a new test covers the handshake ordering.
> 
> **Tool-result handling now consistently prefers raw `output` over simplified `result` to preserve widget metadata.** The trace adapter and transcript conversion prefer `part.output` (keeping `_meta.ui.resourceUri` / `_serverId`), server-side stream emission and eval snapshot extraction were updated to use `output` first, and new tests assert metadata is preserved when both `output` and `result` exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45fcb25a90ec3dba437cae459e5fc04cf39cdc95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->