### PR TITLE
Fix hosted Convex runtime config

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/runtime-config.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/runtime-config.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getRuntimeConvexSiteUrl,
+  getRuntimeConvexUrl,
+} from "../runtime-config";
+
+describe("runtime-config", () => {
+  beforeEach(() => {
+    delete (window as any).__MCP_RUNTIME_CONFIG__;
+  });
+
+  it("returns undefined when no runtime config was injected", () => {
+    expect(getRuntimeConvexUrl()).toBeUndefined();
+    expect(getRuntimeConvexSiteUrl()).toBeUndefined();
+  });
+
+  it("returns injected convex urls when present", () => {
+    (window as any).__MCP_RUNTIME_CONFIG__ = {
+      convexUrl: "https://runtime.convex.cloud",
+      convexSiteUrl: "https://runtime.convex.site",
+    };
+
+    expect(getRuntimeConvexUrl()).toBe("https://runtime.convex.cloud");
+    expect(getRuntimeConvexSiteUrl()).toBe("https://runtime.convex.site");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/convex-site-url.ts
+++ b/mcpjam-inspector/client/src/lib/convex-site-url.ts
@@ -1,10 +1,21 @@
+import {
+  getRuntimeConvexSiteUrl,
+  getRuntimeConvexUrl,
+} from "@/lib/runtime-config";
+
 /**
  * Derive the Convex HTTP actions URL (*.convex.site) from the Convex client URL.
  */
 export function getConvexSiteUrl(): string | null {
+  const runtimeSiteUrl = getRuntimeConvexSiteUrl();
+  if (runtimeSiteUrl) return runtimeSiteUrl;
+
   const siteUrl = import.meta.env.VITE_CONVEX_SITE_URL as string | undefined;
   if (siteUrl) return siteUrl;
-  const cloudUrl = import.meta.env.VITE_CONVEX_URL as string | undefined;
+
+  const cloudUrl =
+    getRuntimeConvexUrl() ??
+    (import.meta.env.VITE_CONVEX_URL as string | undefined);
   if (cloudUrl && typeof cloudUrl === "string") {
     return cloudUrl.replace(".convex.cloud", ".convex.site");
   }

--- a/mcpjam-inspector/client/src/lib/runtime-config.ts
+++ b/mcpjam-inspector/client/src/lib/runtime-config.ts
@@ -1,0 +1,35 @@
+export interface InspectorClientRuntimeConfig {
+  convexUrl?: string;
+  convexSiteUrl?: string;
+}
+
+declare global {
+  interface Window {
+    __MCP_RUNTIME_CONFIG__?: InspectorClientRuntimeConfig;
+  }
+}
+
+function getRuntimeConfig(): InspectorClientRuntimeConfig | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const runtimeConfig = window.__MCP_RUNTIME_CONFIG__;
+  if (!runtimeConfig || typeof runtimeConfig !== "object") {
+    return null;
+  }
+
+  return runtimeConfig;
+}
+
+function getNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+export function getRuntimeConvexUrl(): string | undefined {
+  return getNonEmptyString(getRuntimeConfig()?.convexUrl);
+}
+
+export function getRuntimeConvexSiteUrl(): string | undefined {
+  return getNonEmptyString(getRuntimeConfig()?.convexSiteUrl);
+}

--- a/mcpjam-inspector/client/src/main.tsx
+++ b/mcpjam-inspector/client/src/main.tsx
@@ -12,6 +12,7 @@ import { IframeRouterError } from "./components/IframeRouterError.jsx";
 import { initializeSessionToken } from "./lib/session-token.js";
 import { HOSTED_MODE } from "./lib/config";
 import { GuestConvexAuthBridge } from "./lib/guest-convex-auth";
+import { getRuntimeConvexUrl } from "./lib/runtime-config";
 
 // Initialize Sentry before React mounts
 initSentry();
@@ -37,7 +38,9 @@ if (isInIframe) {
     </StrictMode>
   );
 } else {
-  const convexUrl = import.meta.env.VITE_CONVEX_URL as string;
+  const buildConvexUrl = import.meta.env.VITE_CONVEX_URL as string | undefined;
+  const runtimeConvexUrl = getRuntimeConvexUrl();
+  const convexUrl = runtimeConvexUrl || buildConvexUrl || "";
   const workosClientId = import.meta.env.VITE_WORKOS_CLIENT_ID as string;
   const workosDevMode = (() => {
     const explicit = import.meta.env.VITE_WORKOS_DEV_MODE as string | undefined;
@@ -69,6 +72,20 @@ if (isInIframe) {
   if (!convexUrl) {
     console.warn(
       "[main] VITE_CONVEX_URL is not set; Convex features may not work."
+    );
+  }
+  if (
+    HOSTED_MODE &&
+    runtimeConvexUrl &&
+    buildConvexUrl &&
+    runtimeConvexUrl !== buildConvexUrl
+  ) {
+    console.warn(
+      "[main] Hosted runtime Convex URL overrides build-time VITE_CONVEX_URL.",
+      {
+        buildConvexUrl,
+        runtimeConvexUrl,
+      }
     );
   }
   if (!workosClientId) {

--- a/mcpjam-inspector/server/__tests__/env.test.ts
+++ b/mcpjam-inspector/server/__tests__/env.test.ts
@@ -8,7 +8,12 @@ import {
 import { tmpdir } from "os";
 import { join } from "path";
 import { afterEach, describe, expect, it } from "vitest";
-import { getInspectorEnvFileNames, loadInspectorEnv } from "../env.js";
+import {
+  getInspectorClientRuntimeConfig,
+  getInspectorClientRuntimeConfigScript,
+  getInspectorEnvFileNames,
+  loadInspectorEnv,
+} from "../env.js";
 
 const ORIGINAL_CONVEX_HTTP_URL = process.env.CONVEX_HTTP_URL;
 const ORIGINAL_PRIORITY_TEST = process.env.MCPJAM_ENV_PRIORITY_TEST;
@@ -78,5 +83,22 @@ describe("env loader", () => {
       process.chdir(originalCwd);
       rmSync(tempRoot, { force: true, recursive: true });
     }
+  });
+
+  it("derives hosted client runtime config from CONVEX_HTTP_URL", () => {
+    process.env.CONVEX_HTTP_URL = "https://demo-deployment.convex.site";
+
+    expect(getInspectorClientRuntimeConfig()).toEqual({
+      convexUrl: "https://demo-deployment.convex.cloud",
+      convexSiteUrl: "https://demo-deployment.convex.site",
+    });
+  });
+
+  it("serializes hosted client runtime config for html injection", () => {
+    process.env.CONVEX_HTTP_URL = "https://demo-deployment.convex.site";
+
+    expect(getInspectorClientRuntimeConfigScript()).toBe(
+      '<script>window.__MCP_RUNTIME_CONFIG__={"convexUrl":"https://demo-deployment.convex.cloud","convexSiteUrl":"https://demo-deployment.convex.site"};</script>',
+    );
   });
 });

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -33,7 +33,11 @@ import {
 } from "./middleware/session-auth.js";
 import { originValidationMiddleware } from "./middleware/origin-validation.js";
 import { securityHeadersMiddleware } from "./middleware/security-headers.js";
-import { loadInspectorEnv, warnOnConvexDevMisconfiguration } from "./env.js";
+import {
+  getInspectorClientRuntimeConfigScript,
+  loadInspectorEnv,
+  warnOnConvexDevMisconfiguration,
+} from "./env.js";
 import { startGuestAuthProvisioningInBackground } from "./utils/convex-guest-auth-sync.js";
 import { fetchRemoteGuestJwks } from "./utils/guest-session-source.js";
 import { INSPECTOR_MCP_RETRY_POLICY } from "./utils/mcp-retry-policy.js";
@@ -317,6 +321,11 @@ export function createHonoApp() {
           );
           const warningScript = `<script>console.error("MCPJam: Access via allowed host required for full functionality");</script>`;
           html = html.replace("</head>", `${warningScript}</head>`);
+        }
+
+        const runtimeConfigScript = getInspectorClientRuntimeConfigScript();
+        if (runtimeConfigScript) {
+          html = html.replace("</head>", `${runtimeConfigScript}</head>`);
         }
 
         return c.html(html);

--- a/mcpjam-inspector/server/env.ts
+++ b/mcpjam-inspector/server/env.ts
@@ -12,6 +12,11 @@ export interface LoadedInspectorEnv {
   mode: InspectorEnvMode;
 }
 
+export interface InspectorClientRuntimeConfig {
+  convexUrl?: string;
+  convexSiteUrl?: string;
+}
+
 function getInspectorEnvMode(): InspectorEnvMode {
   return process.env.NODE_ENV === "production" ? "production" : "development";
 }
@@ -80,6 +85,70 @@ export function loadInspectorEnv(serverDir: string): LoadedInspectorEnv {
     loadedFiles,
     mode,
   };
+}
+
+function normalizeUrlOrigin(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+
+  try {
+    return new URL(url).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+function replaceConvexHostnameSuffix(
+  url: string | undefined,
+  fromSuffix: string,
+  toSuffix: string,
+): string | undefined {
+  if (!url) return undefined;
+
+  try {
+    const parsed = new URL(url);
+    if (!parsed.hostname.endsWith(fromSuffix)) {
+      return undefined;
+    }
+    parsed.hostname = parsed.hostname.replace(fromSuffix, toSuffix);
+    return parsed.origin;
+  } catch {
+    return undefined;
+  }
+}
+
+export function getInspectorClientRuntimeConfig(): InspectorClientRuntimeConfig {
+  const convexSiteUrl =
+    normalizeUrlOrigin(process.env.CONVEX_HTTP_URL) ??
+    replaceConvexHostnameSuffix(
+      process.env.VITE_CONVEX_URL,
+      ".convex.cloud",
+      ".convex.site",
+    );
+
+  const convexUrl =
+    replaceConvexHostnameSuffix(
+      process.env.CONVEX_HTTP_URL,
+      ".convex.site",
+      ".convex.cloud",
+    ) ?? normalizeUrlOrigin(process.env.VITE_CONVEX_URL);
+
+  return {
+    convexUrl,
+    convexSiteUrl,
+  };
+}
+
+export function getInspectorClientRuntimeConfigScript(): string | null {
+  const runtimeConfig = getInspectorClientRuntimeConfig();
+  if (!runtimeConfig.convexUrl && !runtimeConfig.convexSiteUrl) {
+    return null;
+  }
+
+  const serializedConfig = JSON.stringify(runtimeConfig).replace(
+    /</g,
+    "\\u003c",
+  );
+  return `<script>window.__MCP_RUNTIME_CONFIG__=${serializedConfig};</script>`;
 }
 
 function getConvexDeploymentSlug(url: string | undefined): string | null {

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -11,7 +11,11 @@ import { readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { MCPClientManager } from "@mcpjam/sdk";
-import { loadInspectorEnv, warnOnConvexDevMisconfiguration } from "./env";
+import {
+  getInspectorClientRuntimeConfigScript,
+  loadInspectorEnv,
+  warnOnConvexDevMisconfiguration,
+} from "./env";
 import { INSPECTOR_MCP_RETRY_POLICY } from "./utils/mcp-retry-policy";
 
 // Security imports
@@ -415,6 +419,14 @@ if (process.env.NODE_ENV === "production") {
         );
         const warningScript = `<script>console.error("MCPJam: Access via localhost or allowed hosts required for full functionality");</script>`;
         htmlContent = htmlContent.replace("</head>", `${warningScript}</head>`);
+      }
+
+      const runtimeConfigScript = getInspectorClientRuntimeConfigScript();
+      if (runtimeConfigScript) {
+        htmlContent = htmlContent.replace(
+          "</head>",
+          `${runtimeConfigScript}</head>`,
+        );
       }
 
       // Inject MCP server config if provided via CLI


### PR DESCRIPTION
## Summary
- Inject the server’s active Convex URLs into hosted HTML at runtime.
- Make the client prefer runtime Convex config over baked Vite values.
- Add mismatch warnings and unit coverage for the runtime config path.

## Testing
- `vitest run server/__tests__/env.test.ts client/src/lib/__tests__/runtime-config.test.ts`
- `npm run build:server`
- `npm run build:client`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the hosted inspector derives and injects Convex URLs into `index.html`, which can break client connectivity if URL normalization/derivation is wrong. It also adds a new HTML-injected runtime config script path that must remain safe and correctly escaped.
> 
> **Overview**
> Fixes hosted-mode Convex configuration by **injecting the server’s active Convex URLs into the served HTML at runtime** (`window.__MCP_RUNTIME_CONFIG__`) and adding a client-side `runtime-config` reader.
> 
> The client now **prefers runtime Convex URLs over Vite build-time env vars** when creating the Convex client and when deriving the `*.convex.site` actions URL, and it logs a warning when hosted runtime config overrides the baked `VITE_CONVEX_URL`.
> 
> Adds unit tests covering server-side runtime config derivation/serialization from `CONVEX_HTTP_URL` and client-side runtime config lookup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf8671ff642ee27d08dcbff0d6131b9248d2e3f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->