### PR TITLE
fix(evals): require tool assertions before Run in test template editor

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-validation.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-validation.test.tsx
@@ -188,4 +188,34 @@ describe("TestTemplateEditor prompt validation UI", () => {
     const runButton = screen.getByRole("button", { name: /^Run$/ });
     expect(runButton).toBeDisabled();
   });
+
+  it("disables Run when there are no tool assertions", async () => {
+    caseDoc.query = "Hello";
+    baseIteration.testCaseSnapshot.query = "Hello";
+
+    renderWithProviders(
+      <TestTemplateEditor
+        suiteId="suite-1"
+        selectedTestCaseId="case-1"
+        connectedServerNames={new Set(["srv"])}
+        workspaceId={null}
+        availableModels={[
+          {
+            provider: "openai",
+            model: "gpt-4",
+            label: "GPT-4",
+          } as any,
+        ]}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Hello")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: /^Run$/ })).toBeDisabled();
+    expect(
+      screen.getByText("Add at least one expected tool assertion before running."),
+    ).toBeInTheDocument();
+  });
 });

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -191,6 +191,10 @@ function deriveIsNegativeTestFromPromptTurns(
   return promptTurns.every((turn) => turn.expectedToolCalls.length === 0);
 }
 
+function hasAnyAssertedToolCall(promptTurns: PromptTurn[]): boolean {
+  return promptTurns.some((turn) => turn.expectedToolCalls.length > 0);
+}
+
 function compactModelLabel(name: string): string {
   return name.replace(/\s*\(Free\)\s*$/i, "").trim() || name;
 }
@@ -603,6 +607,11 @@ export function TestTemplateEditor({
     return validatePromptTurns(editForm.promptTurns);
   }, [editForm]);
 
+  const hasRequiredRunAssertions = useMemo(() => {
+    if (!editForm) return false;
+    return hasAnyAssertedToolCall(editForm.promptTurns);
+  }, [editForm]);
+
   const savePrimaryDisabled = !arePromptTurnsValid || isRunningCompare;
 
   const saveDisabledTooltip = useMemo(() => {
@@ -622,7 +631,8 @@ export function TestTemplateEditor({
     selectedModelValues.length === 0 ||
     isRunningCompare ||
     !canRun ||
-    !arePromptTurnsValid;
+    !arePromptTurnsValid ||
+    !hasRequiredRunAssertions;
 
   const runDisabledTooltip = useMemo(() => {
     if (!runPrimaryDisabled) {
@@ -633,6 +643,9 @@ export function TestTemplateEditor({
     }
     if (!canRun) {
       return "Configure suite servers before running.";
+    }
+    if (!hasRequiredRunAssertions) {
+      return "Add at least one expected tool assertion before running.";
     }
     if (!arePromptTurnsValid && editForm) {
       return (
@@ -658,10 +671,14 @@ export function TestTemplateEditor({
     canRun,
     missingServers,
     isRunningCompare,
+    hasRequiredRunAssertions,
     arePromptTurnsValid,
     editForm,
     ensureServersReady,
   ]);
+
+  const showInlineRunBlockedHint =
+    runPrimaryDisabled && !isRunningCompare && Boolean(runDisabledTooltip);
 
   const updatePromptTurn = (
     index: number,
@@ -1174,6 +1191,11 @@ export function TestTemplateEditor({
     );
     if (runModelValues.length === 0) {
       toast.error("Select at least one model to run.");
+      return;
+    }
+
+    if (!hasAnyAssertedToolCall(editForm.promptTurns)) {
+      toast.error("Add at least one expected tool assertion before running.");
       return;
     }
 
@@ -1930,7 +1952,7 @@ export function TestTemplateEditor({
                     </Button>
                   )
                 ) : null}
-                {runDisabledTooltip ? (
+                {runDisabledTooltip && !showInlineRunBlockedHint ? (
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span className="inline-flex items-center gap-2">
@@ -2012,7 +2034,7 @@ export function TestTemplateEditor({
                 )}
               </div>
             </div>
-            {runPrimaryDisabled && !isRunningCompare && runDisabledTooltip ? (
+            {showInlineRunBlockedHint ? (
               <p
                 className="text-xs leading-snug text-muted-foreground sm:text-right"
                 data-testid="test-template-run-blocked-hint"


### PR DESCRIPTION
## Summary
Users could start a test run with a prompt but **no expected tool calls** (no assertions), which is not a useful eval and matches product feedback. This enforces a clear invariant: **Run requires at least one tool assertion** across the prompt flow.

## Changes
- **Run gating:** `Run` stays disabled when there is no asserted expected tool on any prompt turn. Save validation is unchanged; only the run path is stricter.
- **Defense in depth:** `handleRunCompare` returns early with a toast if the invariant is not met, so a programmatic trigger cannot bypass the UI.
- **UX:** When the inline “blocked run” message is shown under the header actions, the **tooltip on the Run button is not duplicated** (same text was shown twice; now one primary explanation).
- **Tests:** Added coverage for a valid prompt with zero tool assertions; existing prompt-empty behavior remains.

## How to test
1. Open a test case in the template editor, enter a user prompt, leave **Add expected tool call** empty.
2. Confirm **Run** is disabled and the hint explains adding a tool assertion.
3. Add a complete expected tool; **Run** enables when other prerequisites (e.g. model, suite servers) are satisfied.

Made with [Cursor](https://cursor.com)