### PR TITLE
Fix capability advertising for elicitation and reconnect checks

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
@@ -774,6 +774,37 @@ describe("ServersTab shared detail modal", () => {
     expect(screen.queryByText("Needs reconnect")).not.toBeInTheDocument();
   });
 
+  it("does not surface reconnect warnings when initialize only adds runtime elicitation support", () => {
+    const initializedCapabilities = {
+      ...(getDefaultClientCapabilities() as Record<string, unknown>),
+      elicitation: {},
+    };
+
+    render(
+      <ServersTab
+        {...defaultProps}
+        workspaceServers={{
+          "test-server": createServer({
+            initializationInfo: {
+              clientCapabilities: initializedCapabilities,
+            } as any,
+          }),
+        }}
+        workspaces={{
+          "workspace-1": createWorkspace({
+            "test-server": createServer({
+              initializationInfo: {
+                clientCapabilities: initializedCapabilities,
+              } as any,
+            }),
+          }),
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("Needs reconnect")).not.toBeInTheDocument();
+  });
+
   it("renders Quick Connect module helper copy and Browse Registry in the section header", () => {
     mockIsAuthenticated = true;
     mockCatalogCards = [createLinearCatalogCard()];

--- a/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
@@ -774,37 +774,6 @@ describe("ServersTab shared detail modal", () => {
     expect(screen.queryByText("Needs reconnect")).not.toBeInTheDocument();
   });
 
-  it("does not surface reconnect warnings when initialize only adds runtime elicitation support", () => {
-    const initializedCapabilities = {
-      ...(getDefaultClientCapabilities() as Record<string, unknown>),
-      elicitation: {},
-    };
-
-    render(
-      <ServersTab
-        {...defaultProps}
-        workspaceServers={{
-          "test-server": createServer({
-            initializationInfo: {
-              clientCapabilities: initializedCapabilities,
-            } as any,
-          }),
-        }}
-        workspaces={{
-          "workspace-1": createWorkspace({
-            "test-server": createServer({
-              initializationInfo: {
-                clientCapabilities: initializedCapabilities,
-              } as any,
-            }),
-          }),
-        }}
-      />,
-    );
-
-    expect(screen.queryByText("Needs reconnect")).not.toBeInTheDocument();
-  });
-
   it("renders Quick Connect module helper copy and Browse Registry in the section header", () => {
     mockIsAuthenticated = true;
     mockCatalogCards = [createLinearCatalogCard()];

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -351,14 +351,12 @@ describe("useServerState OAuth callback failures", () => {
           workspaceProfile: {},
         },
         sampling: {},
-        elicitation: {},
       },
       clientCapabilities: {
         experimental: {
           workspaceProfile: {},
         },
         sampling: {},
-        elicitation: {},
       },
     });
   });

--- a/mcpjam-inspector/client/src/lib/client-config.ts
+++ b/mcpjam-inspector/client/src/lib/client-config.ts
@@ -1,8 +1,8 @@
 import type { ClientCapabilityOptions } from "@mcpjam/sdk/browser";
 import {
-  applyRuntimeClientCapabilities,
   getDefaultClientCapabilities,
   mergeClientCapabilities,
+  normalizeClientCapabilities,
 } from "@mcpjam/sdk/browser";
 
 export type WorkspaceClientConfig = {
@@ -45,12 +45,6 @@ export const DEFAULT_HOST_DISPLAY_MODES: HostDisplayMode[] = [
   "pip",
   "fullscreen",
 ];
-
-// The inspector server installs a global elicitation callback during app boot,
-// so reconnect comparisons should match that on-wire initialize payload.
-const INSPECTOR_RUNTIME_CLIENT_CAPABILITIES = {
-  elicitation: true,
-} as const;
 
 export function buildDefaultHostContext(args: {
   theme: "light" | "dark";
@@ -158,9 +152,8 @@ export function getEffectiveServerClientCapabilities(args: {
 export function normalizeWorkspaceClientCapabilities(
   capabilities?: Record<string, unknown>,
 ): ClientCapabilityOptions {
-  return applyRuntimeClientCapabilities(
+  return normalizeClientCapabilities(
     capabilities as ClientCapabilityOptions | undefined,
-    INSPECTOR_RUNTIME_CLIENT_CAPABILITIES,
   );
 }
 

--- a/mcpjam-inspector/client/src/lib/client-config.ts
+++ b/mcpjam-inspector/client/src/lib/client-config.ts
@@ -1,7 +1,7 @@
 import type { ClientCapabilityOptions } from "@mcpjam/sdk/browser";
 import {
+  applyRuntimeClientCapabilities,
   getDefaultClientCapabilities,
-  normalizeClientCapabilities,
   mergeClientCapabilities,
 } from "@mcpjam/sdk/browser";
 
@@ -45,6 +45,12 @@ export const DEFAULT_HOST_DISPLAY_MODES: HostDisplayMode[] = [
   "pip",
   "fullscreen",
 ];
+
+// The inspector server installs a global elicitation callback during app boot,
+// so reconnect comparisons should match that on-wire initialize payload.
+const INSPECTOR_RUNTIME_CLIENT_CAPABILITIES = {
+  elicitation: true,
+} as const;
 
 export function buildDefaultHostContext(args: {
   theme: "light" | "dark";
@@ -141,17 +147,20 @@ export function getEffectiveServerClientCapabilities(args: {
     args.workspaceCapabilities ??
     getEffectiveWorkspaceClientCapabilities(args.workspaceClientConfig);
 
-  return mergeWorkspaceClientCapabilities(
-    workspaceCapabilities as Record<string, unknown>,
-    args.serverCapabilities,
+  return normalizeWorkspaceClientCapabilities(
+    mergeWorkspaceClientCapabilities(
+      workspaceCapabilities as Record<string, unknown>,
+      args.serverCapabilities,
+    ) as Record<string, unknown>,
   );
 }
 
 export function normalizeWorkspaceClientCapabilities(
   capabilities?: Record<string, unknown>,
 ): ClientCapabilityOptions {
-  return normalizeClientCapabilities(
+  return applyRuntimeClientCapabilities(
     capabilities as ClientCapabilityOptions | undefined,
+    INSPECTOR_RUNTIME_CLIENT_CAPABILITIES,
   );
 }
 

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -5,6 +5,7 @@
  */
 
 export {
+  applyRuntimeClientCapabilities,
   MCP_UI_EXTENSION_ID,
   MCP_UI_RESOURCE_MIME_TYPE,
   getDefaultClientCapabilities,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -73,6 +73,7 @@ export {
   scrubMetaAndStructuredContentFromToolResult,
 } from "./mcp-client-manager/index.js";
 export {
+  applyRuntimeClientCapabilities,
   MCP_UI_EXTENSION_ID,
   MCP_UI_RESOURCE_MIME_TYPE,
   getDefaultClientCapabilities,

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -93,9 +93,9 @@ import {
   type ToolSchemaOverrides,
 } from "./tool-converters.js";
 import {
+  applyRuntimeClientCapabilities,
   getDefaultClientCapabilities,
   mergeClientCapabilities,
-  normalizeClientCapabilities,
 } from "./capabilities.js";
 import {
   assertCallToolResult,
@@ -292,7 +292,9 @@ export class MCPClientManager {
       serverCapabilities: client.getServerCapabilities(),
       serverVersion: client.getServerVersion(),
       instructions: client.getInstructions(),
-      clientCapabilities: this.buildCapabilities(config),
+      clientCapabilities:
+        liveState.initializedClientCapabilities ??
+        this.buildCapabilities(serverId, config),
     };
   }
 
@@ -883,8 +885,9 @@ export class MCPClientManager {
     }
     this.elicitationManager.setHandler(serverId, handler);
 
-    const client = this.liveClientStates.get(serverId)?.client;
-    if (client) {
+    const state = this.liveClientStates.get(serverId);
+    const client = state?.client;
+    if (client && this.hasNegotiatedElicitation(state)) {
       this.elicitationManager.applyToClient(serverId, client);
     }
   }
@@ -894,9 +897,13 @@ export class MCPClientManager {
    */
   clearElicitationHandler(serverId: string): void {
     this.elicitationManager.clearHandler(serverId);
-    const client = this.liveClientStates.get(serverId)?.client;
+    const state = this.liveClientStates.get(serverId);
+    const client = state?.client;
     if (client) {
-      if (this.elicitationManager.getGlobalCallback()) {
+      if (
+        this.elicitationManager.getGlobalCallback() &&
+        this.hasNegotiatedElicitation(state)
+      ) {
         this.elicitationManager.applyToClient(serverId, client);
       } else {
         this.elicitationManager.removeFromClient(client);
@@ -910,7 +917,7 @@ export class MCPClientManager {
   setElicitationCallback(callback: ElicitationCallback): void {
     this.elicitationManager.setGlobalCallback(callback);
     for (const [serverId, state] of this.liveClientStates.entries()) {
-      if (state.client) {
+      if (state.client && this.hasNegotiatedElicitation(state)) {
         this.elicitationManager.applyToClient(serverId, state.client);
       }
     }
@@ -923,7 +930,10 @@ export class MCPClientManager {
     this.elicitationManager.clearGlobalCallback();
     for (const [serverId, state] of this.liveClientStates.entries()) {
       if (!state.client) continue;
-      if (this.elicitationManager.getHandler(serverId)) {
+      if (
+        this.elicitationManager.getHandler(serverId) &&
+        this.hasNegotiatedElicitation(state)
+      ) {
         this.elicitationManager.applyToClient(serverId, state.client);
       } else {
         this.elicitationManager.removeFromClient(state.client);
@@ -1094,13 +1104,14 @@ export class MCPClientManager {
   ): Promise<Client> {
     let client: Client | undefined;
     let transport: Transport | undefined;
+    const clientCapabilities = this.buildCapabilities(serverId, config);
     try {
       client = new Client(
         {
           name: this.defaultClientName ?? serverId,
           version: config.version ?? this.defaultClientVersion,
         },
-        { capabilities: this.buildCapabilities(config) }
+        { capabilities: clientCapabilities }
       );
 
       // Apply handlers
@@ -1146,6 +1157,7 @@ export class MCPClientManager {
 
       state.client = client;
       state.transport = transport;
+      state.initializedClientCapabilities = clientCapabilities;
       state.connectPromise = undefined;
       this.liveClientStates.set(serverId, state);
 
@@ -1461,6 +1473,7 @@ export class MCPClientManager {
     delete state.client;
     delete state.transport;
     delete state.stdioStderrCleanup;
+    delete state.initializedClientCapabilities;
     if (!options?.preservePendingPromises) {
       delete state.connectPromise;
     }
@@ -1497,6 +1510,7 @@ export class MCPClientManager {
     delete state.client;
     delete state.transport;
     delete state.stdioStderrCleanup;
+    delete state.initializedClientCapabilities;
 
     if (nextState.connectPromise || nextState.retryPromise) {
       this.liveClientStates.set(serverId, nextState);
@@ -1707,15 +1721,24 @@ export class MCPClientManager {
     return mergedOptions;
   }
 
-  private buildCapabilities(config: MCPServerConfig): ClientCapabilityOptions {
-    if (config.clientCapabilities) {
-      return normalizeClientCapabilities(config.clientCapabilities);
-    }
+  private buildCapabilities(
+    serverId: string,
+    config: MCPServerConfig
+  ): ClientCapabilityOptions {
+    const configuredCapabilities =
+      config.clientCapabilities ??
+      mergeClientCapabilities(this.defaultCapabilities, config.capabilities);
 
-    return mergeClientCapabilities(
-      this.defaultCapabilities,
-      config.capabilities
-    );
+    return applyRuntimeClientCapabilities(configuredCapabilities, {
+      elicitation: this.elicitationManager.hasHandler(serverId),
+    });
+  }
+
+  private hasNegotiatedElicitation(state?: LiveClientState): boolean {
+    const capabilities = state?.initializedClientCapabilities as
+      | Record<string, unknown>
+      | undefined;
+    return capabilities?.elicitation != null;
   }
 
   private resolveRpcLogger(config: MCPServerConfig): RpcLogger | undefined {

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -96,6 +96,7 @@ import {
   applyRuntimeClientCapabilities,
   getDefaultClientCapabilities,
   mergeClientCapabilities,
+  normalizeClientCapabilities,
 } from "./capabilities.js";
 import {
   assertCallToolResult,
@@ -1119,7 +1120,9 @@ export class MCPClientManager {
       if (this.defaultProgressHandler) {
         applyProgressHandler(serverId, client, this.defaultProgressHandler);
       }
-      this.elicitationManager.applyToClient(serverId, client);
+      if ((clientCapabilities as Record<string, unknown>).elicitation != null) {
+        this.elicitationManager.applyToClient(serverId, client);
+      }
 
       if (config.onError) {
         client.onerror = (error) => config.onError?.(error);
@@ -1725,12 +1728,24 @@ export class MCPClientManager {
     serverId: string,
     config: MCPServerConfig
   ): ClientCapabilityOptions {
+    const hasElicitationHandler = this.elicitationManager.hasHandler(serverId);
+    if (config.clientCapabilities) {
+      const exactCapabilities = normalizeClientCapabilities(
+        config.clientCapabilities
+      ) as Record<string, unknown>;
+
+      if (!hasElicitationHandler) {
+        delete exactCapabilities.elicitation;
+      }
+
+      return exactCapabilities as ClientCapabilityOptions;
+    }
+
     const configuredCapabilities =
-      config.clientCapabilities ??
       mergeClientCapabilities(this.defaultCapabilities, config.capabilities);
 
     return applyRuntimeClientCapabilities(configuredCapabilities, {
-      elicitation: this.elicitationManager.hasHandler(serverId),
+      elicitation: hasElicitationHandler,
     });
   }
 

--- a/sdk/src/mcp-client-manager/capabilities.ts
+++ b/sdk/src/mcp-client-manager/capabilities.ts
@@ -52,15 +52,29 @@ export function getDefaultClientCapabilities(): ClientCapabilityOptions {
 export function normalizeClientCapabilities(
   capabilities?: ClientCapabilityOptions
 ): ClientCapabilityOptions {
-  const normalized: ClientCapabilityOptions = {
+  return {
     ...(capabilities ?? {}),
   };
+}
 
-  if (!normalized.elicitation) {
-    normalized.elicitation = {};
+/**
+ * Adds runtime-gated capabilities that are only valid when the corresponding
+ * handlers are actually installed on the client.
+ */
+export function applyRuntimeClientCapabilities(
+  capabilities?: ClientCapabilityOptions,
+  runtime?: { elicitation?: boolean }
+): ClientCapabilityOptions {
+  const resolved = normalizeClientCapabilities(capabilities) as Record<
+    string,
+    unknown
+  >;
+
+  if (runtime?.elicitation && resolved.elicitation == null) {
+    resolved.elicitation = {};
   }
 
-  return normalized;
+  return resolved as ClientCapabilityOptions;
 }
 
 export function mergeClientCapabilities(
@@ -97,5 +111,5 @@ export function mergeClientCapabilities(
     }
   }
 
-  return normalizeClientCapabilities(merged as ClientCapabilityOptions);
+  return merged as ClientCapabilityOptions;
 }

--- a/sdk/src/mcp-client-manager/elicitation.ts
+++ b/sdk/src/mcp-client-manager/elicitation.ts
@@ -77,6 +77,13 @@ export class ElicitationManager {
   }
 
   /**
+   * Returns whether this server will have an elicitation handler installed.
+   */
+  hasHandler(serverId: string): boolean {
+    return this.handlers.has(serverId) || this.globalCallback !== undefined;
+  }
+
+  /**
    * Gets the pending elicitations map.
    * Useful for external code that needs to add resolvers.
    *

--- a/sdk/src/mcp-client-manager/index.ts
+++ b/sdk/src/mcp-client-manager/index.ts
@@ -90,6 +90,7 @@ export {
 export { buildRequestInit } from "./transport-utils.js";
 export { isMethodUnavailableError, formatError } from "./error-utils.js";
 export {
+  applyRuntimeClientCapabilities,
   MCP_UI_EXTENSION_ID,
   MCP_UI_RESOURCE_MIME_TYPE,
   getDefaultClientCapabilities,

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -185,6 +185,7 @@ export interface LiveClientState extends BaseClientState {
   stdioStderrCleanup?: () => void;
   connectPromise?: Promise<Client>;
   retryPromise?: Promise<Client>;
+  initializedClientCapabilities?: ClientCapabilityOptions;
 }
 
 // ============================================================================

--- a/sdk/tests/MCPClientManager.test.ts
+++ b/sdk/tests/MCPClientManager.test.ts
@@ -826,6 +826,33 @@ describe("MCPClientManager", () => {
       await manager.disconnectServer("elicitation-enabled-test");
     }, 30000);
 
+    it("should keep exact clientCapabilities free of elicitation when not explicitly configured", async () => {
+      manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+      await manager.connectToServer("exact-caps-no-elicitation-test", {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-everything"],
+        clientCapabilities: {
+          experimental: {
+            exactPath: {},
+          },
+        } as any,
+      });
+
+      const info = manager.getInitializationInfo(
+        "exact-caps-no-elicitation-test"
+      );
+      expect(info).toBeDefined();
+      expect(info!.clientCapabilities).toMatchObject({
+        experimental: {
+          exactPath: {},
+        },
+      });
+      expect(info!.clientCapabilities).not.toHaveProperty("elicitation");
+
+      await manager.disconnectServer("exact-caps-no-elicitation-test");
+    }, 30000);
+
     it("should preserve the initialize payload after elicitation is enabled post-connect", async () => {
       await manager.connectToServer("late-elicitation-test", {
         command: "npx",

--- a/sdk/tests/MCPClientManager.test.ts
+++ b/sdk/tests/MCPClientManager.test.ts
@@ -711,8 +711,8 @@ describe("MCPClientManager", () => {
         experimental: {
           inspectorProfile: {},
         },
-        elicitation: {},
       });
+      expect(info!.clientCapabilities).not.toHaveProperty("elicitation");
 
       const extensions = (info!.clientCapabilities as Record<string, unknown>)
         .extensions as Record<string, unknown>;
@@ -753,8 +753,8 @@ describe("MCPClientManager", () => {
           experimental: {
             inspectorProfile: {},
           },
-          elicitation: {},
         });
+        expect(info!.clientCapabilities).not.toHaveProperty("elicitation");
         expect(
           (
             (info!.clientCapabilities as Record<string, unknown>).extensions as
@@ -791,8 +791,8 @@ describe("MCPClientManager", () => {
         experimental: {
           exactPath: {},
         },
-        elicitation: {},
       });
+      expect(info!.clientCapabilities).not.toHaveProperty("elicitation");
       expect(info!.clientCapabilities).not.toMatchObject({
         experimental: {
           legacyPath: {},
@@ -807,6 +807,44 @@ describe("MCPClientManager", () => {
       ).toBeUndefined();
 
       await manager.disconnectServer("custom-caps-test");
+    }, 30000);
+
+    it("should advertise elicitation when a global callback is registered before connect", async () => {
+      manager.setElicitationCallback(() => ({ action: "cancel" } as any));
+
+      await manager.connectToServer("elicitation-enabled-test", {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-everything"],
+      });
+
+      const info = manager.getInitializationInfo("elicitation-enabled-test");
+      expect(info).toBeDefined();
+      expect(info!.clientCapabilities).toMatchObject({
+        elicitation: {},
+      });
+
+      await manager.disconnectServer("elicitation-enabled-test");
+    }, 30000);
+
+    it("should preserve the initialize payload after elicitation is enabled post-connect", async () => {
+      await manager.connectToServer("late-elicitation-test", {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-everything"],
+      });
+
+      const before = manager.getInitializationInfo("late-elicitation-test");
+      expect(before).toBeDefined();
+      expect(before!.clientCapabilities).not.toHaveProperty("elicitation");
+
+      expect(() =>
+        manager.setElicitationCallback(() => ({ action: "cancel" } as any))
+      ).not.toThrow();
+
+      const after = manager.getInitializationInfo("late-elicitation-test");
+      expect(after).toBeDefined();
+      expect(after!.clientCapabilities).not.toHaveProperty("elicitation");
+
+      await manager.disconnectServer("late-elicitation-test");
     }, 30000);
 
     it("should remove server", async () => {

--- a/sdk/tests/apps-conformance/validation.test.ts
+++ b/sdk/tests/apps-conformance/validation.test.ts
@@ -20,7 +20,6 @@ describe("normalizeMCPAppsConformanceConfig", () => {
       experimental: {
         customClient: {},
       },
-      elicitation: {},
     });
     expect(
       (

--- a/sdk/tests/browser-entry.test.ts
+++ b/sdk/tests/browser-entry.test.ts
@@ -36,9 +36,42 @@ describe("browser entrypoint", () => {
     expect((merged as Record<string, unknown>).extensions).toEqual({});
   });
 
+  it("does not inject elicitation when normalizing client capabilities", () => {
+    expect(
+      browser.normalizeClientCapabilities({
+        experimental: {
+          inspectorProfile: true,
+        },
+      } as any)
+    ).toEqual({
+      experimental: {
+        inspectorProfile: true,
+      },
+    });
+  });
+
+  it("can advertise runtime-gated capabilities when handlers exist", () => {
+    expect(
+      browser.applyRuntimeClientCapabilities(
+        {
+          experimental: {
+            inspectorProfile: true,
+          },
+        } as any,
+        { elicitation: true }
+      )
+    ).toEqual({
+      experimental: {
+        inspectorProfile: true,
+      },
+      elicitation: {},
+    });
+  });
+
   it("exports browser-safe capability helpers without MCPClientManager", () => {
     expect(browser.MCP_UI_EXTENSION_ID).toBe("io.modelcontextprotocol/ui");
     expect(browser.MCP_UI_RESOURCE_MIME_TYPE).toBe("text/html;profile=mcp-app");
+    expect(typeof browser.applyRuntimeClientCapabilities).toBe("function");
     expect(typeof browser.redactSensitiveValue).toBe("function");
     expect(browser.getDefaultClientCapabilities()).toEqual({
       extensions: {


### PR DESCRIPTION
## Summary
- Stop injecting `elicitation` during generic capability normalization and only advertise it when a handler is actually installed
- Preserve the exact capabilities used at `initialize` so `getInitializationInfo` reflects the on-wire payload
- Align inspector reconnect detection with the same runtime-aware capability calculation
- Add/update SDK and inspector tests for capability merging, late handler registration, and reconnect warnings

## Testing
- `npm run test -w @mcpjam/sdk -- MCPClientManager.test.ts browser-entry.test.ts apps-conformance/validation.test.ts`
- `npm run test -w @mcpjam/inspector -- client/src/components/__tests__/ServersTab.test.tsx client/src/components/client-config/__tests__/ClientConfigTab.test.tsx client/src/hooks/__tests__/use-server-state.test.tsx`
- `npm run build -w @mcpjam/sdk`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts capability negotiation/advertising in `MCPClientManager` and inspector reconnect detection; incorrect handling could cause servers to see different `initialize` capabilities than expected or skip installing elicitation handlers.
> 
> **Overview**
> Stops auto-injecting `elicitation` during generic capability normalization and instead adds it only when an elicitation handler/callback is actually registered via a new `applyRuntimeClientCapabilities` helper.
> 
> `MCPClientManager` now builds capabilities with server-aware runtime gating, conditionally installs elicitation handlers only when negotiated, and stores the exact `initialize` client capabilities in live state so `getInitializationInfo()` reflects the on-wire payload even if handlers are registered later.
> 
> Inspector capability merging/reconnect checks are aligned by normalizing the merged workspace+server capabilities before comparing/passing them, and tests across the SDK browser entrypoint, conformance validation, and inspector reconnect flows are updated/added to cover these cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ddeefaacca3f7fbe8eddc43e241e75e14e2ea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->