### PR TITLE
Add OAuth connection tracing

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -58,6 +58,7 @@ import { useConvexAuth } from "convex/react";
 import { HOSTED_MODE } from "@/lib/config";
 import { ShareServerDialog } from "./ShareServerDialog";
 import { useExploreCasesPrefetchOnConnect } from "@/hooks/use-explore-cases-prefetch-on-connect";
+import { getOAuthTraceFailureStep } from "@/lib/oauth/oauth-trace";
 
 function isHostedInsecureHttpServer(server: ServerWithName): boolean {
   if (!HOSTED_MODE || !("url" in server.config) || !server.config.url) {
@@ -153,6 +154,7 @@ export function ServerConnectionCard({
   const hasTunnel = Boolean(tunnelUrl);
   const hasError =
     server.connectionStatus === "failed" && Boolean(server.lastError);
+  const oauthFailureStep = getOAuthTraceFailureStep(server.lastOAuthTrace);
   const isHostedHttpReconnectBlocked = isHostedInsecureHttpServer(server);
   const isPendingConnection =
     server.connectionStatus === "connecting" ||
@@ -743,6 +745,11 @@ export function ServerConnectionCard({
               className="mt-3 rounded-md border border-red-300/40 bg-red-500/10 p-2 text-xs text-red-700 dark:text-red-300"
               onClick={(e) => e.stopPropagation()}
             >
+              {oauthFailureStep ? (
+                <div className="mb-1 font-medium">
+                  OAuth failed during {oauthFailureStep.title}
+                </div>
+              ) : null}
               <div className="break-all">
                 {isErrorExpanded
                   ? server.lastError

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -380,7 +380,9 @@ export function ServerDetailModal({
                 className="mt-0 flex-none absolute inset-0 overflow-y-auto bg-background"
               >
                 <div className="pl-1 pr-6">
-                  {!isConnected ? (
+                  {!isConnected &&
+                  !server.lastError &&
+                  !server.lastOAuthTrace ? (
                     <div className="flex items-center justify-center h-full min-h-[120px] text-sm text-muted-foreground">
                       Connect to view server overview
                     </div>

--- a/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import { ServerWithName } from "@/hooks/use-app-state";
 import { getStoredTokensState } from "@/lib/oauth/mcp-oauth";
+import { getOAuthTraceFailureStep } from "@/lib/oauth/oauth-trace";
 import { decodeJWT } from "@/lib/oauth/jwt-decoder";
 import { ScrollableJsonView } from "@/components/ui/json-editor";
 
@@ -43,6 +44,8 @@ export function ServerInfoContent({
   const instructions = initializationInfo?.instructions;
   const serverCapabilities = initializationInfo?.serverCapabilities;
   const clientCapabilities = initializationInfo?.clientCapabilities;
+  const oauthTrace = server.lastOAuthTrace;
+  const oauthFailureStep = getOAuthTraceFailureStep(oauthTrace);
 
   // Build capabilities list
   const capabilities: string[] = [];
@@ -178,6 +181,87 @@ export function ServerInfoContent({
     );
   };
 
+  const renderOAuthTraceSection = () => {
+    if (!oauthTrace) {
+      return null;
+    }
+
+    return (
+      <div className="space-y-3 text-xs pt-2">
+        <div className="text-sm font-medium text-muted-foreground">
+          Last OAuth Trace
+        </div>
+        <div className="space-y-3 rounded-md bg-muted/40 p-3">
+          <div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
+            <span>Source: {oauthTrace.source.replaceAll("_", " ")}</span>
+            <span>Current step: {oauthTrace.currentStep}</span>
+            {oauthFailureStep?.error ? (
+              <span className="text-destructive">
+                Failure: {oauthFailureStep.title}
+              </span>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            {oauthTrace.steps.map((step, index) => (
+              <div
+                key={`${step.step}-${index}-${step.startedAt}`}
+                className="rounded-md border border-border/40 bg-background/60 p-2"
+              >
+                <div className="flex flex-wrap items-center gap-2 text-sm">
+                  <span className="font-medium text-foreground">
+                    {step.title}
+                  </span>
+                  <span
+                    className={
+                      step.status === "error"
+                        ? "text-destructive"
+                        : step.status === "success"
+                          ? "text-emerald-600 dark:text-emerald-400"
+                          : "text-amber-600 dark:text-amber-400"
+                    }
+                  >
+                    {step.status}
+                  </span>
+                </div>
+                {step.message ? (
+                  <div className="mt-1 text-sm text-muted-foreground">
+                    {step.message}
+                  </div>
+                ) : null}
+                {step.error ? (
+                  <div className="mt-1 break-all text-sm text-destructive">
+                    {step.error}
+                  </div>
+                ) : null}
+                {step.details ? (
+                  <ScrollableJsonView
+                    value={step.details}
+                    showLineNumbers={false}
+                    containerClassName="mt-2 max-h-48 rounded-lg"
+                  />
+                ) : null}
+              </div>
+            ))}
+          </div>
+
+          {oauthTrace.httpHistory.length > 0 ? (
+            <div>
+              <div className="mb-2 text-sm font-medium text-muted-foreground">
+                HTTP History
+              </div>
+              <ScrollableJsonView
+                value={oauthTrace.httpHistory}
+                showLineNumbers={false}
+                containerClassName="max-h-96 rounded-lg"
+              />
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  };
+
   const renderIconRow = () => (
     <div>
       <div className="text-sm font-medium text-muted-foreground mb-1">Icon</div>
@@ -197,6 +281,16 @@ export function ServerInfoContent({
 
   return (
     <div className="space-y-4">
+      {server.lastError ? (
+        <div className="rounded-md border border-red-300/40 bg-red-500/10 p-3 text-sm text-red-700 dark:text-red-300">
+          <div className="font-medium">
+            {oauthFailureStep
+              ? `OAuth failed during ${oauthFailureStep.title}`
+              : "Last connection error"}
+          </div>
+          <div className="mt-1 break-all">{server.lastError}</div>
+        </div>
+      ) : null}
       {needsReconnect ? (
         <div className="rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-sm text-muted-foreground">
           Saved client capabilities differ from this server's last initialize
@@ -302,6 +396,7 @@ export function ServerInfoContent({
       )}
 
       {renderOAuthTokensSection()}
+      {renderOAuthTraceSection()}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -28,6 +28,7 @@ import {
   clearOAuthData,
   initiateOAuth,
 } from "@/lib/oauth/mcp-oauth";
+import type { OAuthTrace } from "@/lib/oauth/oauth-trace";
 import {
   clearHostedOAuthPendingState,
   getHostedOAuthCallbackContext,
@@ -220,13 +221,14 @@ export function useServerState({
   };
 
   const failPendingOAuthConnection = useCallback(
-    (errorMessage: string) => {
+    (errorMessage: string, oauthTrace?: OAuthTrace) => {
       const pendingServerName = localStorage.getItem("mcp-oauth-pending");
       if (pendingServerName) {
         dispatch({
           type: "CONNECT_FAILURE",
           name: pendingServerName,
           error: errorMessage,
+          oauthTrace,
         });
       }
 
@@ -734,6 +736,7 @@ export function useServerState({
                     ? undefined
                     : getStoredTokens(serverName),
                   useOAuth: true,
+                  oauthTrace: result.oauthTrace,
                 });
                 logger.info("OAuth connection successful", { serverName });
                 toast.success(
@@ -753,6 +756,7 @@ export function useServerState({
                 error:
                   connectionResult.error ||
                   "Connection test failed after OAuth",
+                oauthTrace: result.oauthTrace,
               });
               logger.error("OAuth connection test failed", {
                 serverName,
@@ -771,6 +775,7 @@ export function useServerState({
               type: "CONNECT_FAILURE",
               name: serverName,
               error: errorMessage,
+              oauthTrace: result.oauthTrace,
             });
             logger.error("OAuth connection test error", {
               serverName,
@@ -781,15 +786,30 @@ export function useServerState({
             );
           }
         } else {
-          throw new Error(result.error || "OAuth callback failed");
+          throw {
+            message: result.error || "OAuth callback failed",
+            oauthTrace: result.oauthTrace,
+          };
         }
       } catch (error) {
         const errorMessage =
-          error instanceof Error ? error.message : "Unknown error";
+          error instanceof Error
+            ? error.message
+            : typeof error === "object" &&
+                error !== null &&
+                "message" in error &&
+                typeof (error as { message?: unknown }).message === "string"
+              ? ((error as { message: string }).message)
+              : "Unknown error";
         toast.error(`Error completing OAuth flow: ${errorMessage}`);
         logger.error("OAuth callback failed", { error: errorMessage });
+        const oauthTrace =
+          typeof error === "object" && error !== null && "oauthTrace" in error
+            ? ((error as { oauthTrace?: OAuthTrace }).oauthTrace)
+            : undefined;
         const failedServerName =
-          failPendingOAuthConnection(errorMessage) ?? pendingServerName;
+          failPendingOAuthConnection(errorMessage, oauthTrace) ??
+          pendingServerName;
         if (failedServerName) {
           logger.warn("Marked pending OAuth connection as failed", {
             serverName: failedServerName,
@@ -1078,6 +1098,7 @@ export function useServerState({
                       ? undefined
                       : getStoredTokens(formData.name),
                   useOAuth: true,
+                  oauthTrace: oauthResult.oauthTrace,
                 });
                 toast.success("Connected successfully with OAuth!");
                 storeInitInfo(formData.name, connectionResult.initInfo).catch(
@@ -1093,6 +1114,7 @@ export function useServerState({
                   name: formData.name,
                   error:
                     connectionResult.error || "OAuth connection test failed",
+                  oauthTrace: oauthResult.oauthTrace,
                 });
                 toast.error(
                   `OAuth succeeded but connection failed: ${connectionResult.error}`,
@@ -1111,6 +1133,7 @@ export function useServerState({
             type: "CONNECT_FAILURE",
             name: formData.name,
             error: oauthResult.error || "OAuth initialization failed",
+            oauthTrace: oauthResult.oauthTrace,
           });
           toast.error(`OAuth initialization failed: ${oauthResult.error}`);
           return;
@@ -1705,6 +1728,7 @@ export function useServerState({
           type: "CONNECT_FAILURE",
           name: serverName,
           error: errorMessage,
+          oauthTrace: authResult.kind === "ready" ? authResult.oauthTrace : undefined,
         });
         logger.error("Reconnection failed", {
           serverName,
@@ -1775,6 +1799,7 @@ export function useServerState({
             type: "CONNECT_FAILURE",
             name: serverName,
             error: errorMessage,
+            oauthTrace: oauthResult.oauthTrace,
           });
           reportError(`OAuth failed: ${serverName}`);
           return {
@@ -1802,6 +1827,7 @@ export function useServerState({
                 ? undefined
                 : getStoredTokens(serverName),
             useOAuth: true,
+            oauthTrace: oauthResult.oauthTrace,
           });
           logger.info("Reconnection with fresh OAuth successful", {
             serverName,
@@ -1816,6 +1842,7 @@ export function useServerState({
           type: "CONNECT_FAILURE",
           name: serverName,
           error: errorMessage,
+          oauthTrace: oauthResult.oauthTrace,
         });
         reportError(errorMessage);
         return {
@@ -1942,6 +1969,7 @@ export function useServerState({
             type: "CONNECT_FAILURE",
             name: serverName,
             error: authResult.error,
+            oauthTrace: authResult.oauthTrace,
           });
           reportError(`Failed to connect: ${serverName}`);
           return {
@@ -1966,6 +1994,7 @@ export function useServerState({
             config: authResult.serverConfig,
             tokens: authResult.tokens,
             useOAuth: server.useOAuth === true || authResult.tokens != null,
+            oauthTrace: authResult.oauthTrace,
           });
           logger.info("Reconnection successful", { serverName, result });
           storeInitInfo(serverName, result.initInfo).catch((err) =>
@@ -1978,6 +2007,7 @@ export function useServerState({
           type: "CONNECT_FAILURE",
           name: serverName,
           error: errorMessage,
+          oauthTrace: authResult.oauthTrace,
         });
         logger.error("Reconnection failed", { serverName, result });
         reportError(errorMessage || `Failed to reconnect: ${serverName}`);

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1728,7 +1728,6 @@ export function useServerState({
           type: "CONNECT_FAILURE",
           name: serverName,
           error: errorMessage,
-          oauthTrace: authResult.kind === "ready" ? authResult.oauthTrace : undefined,
         });
         logger.error("Reconnection failed", {
           serverName,

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -741,6 +741,60 @@ describe("mcp-oauth", () => {
       );
     });
 
+    it("re-registers the OAuth client after invalid_client refresh failures", async () => {
+      localStorage.setItem(
+        "mcp-serverUrl-asana",
+        "https://mcp.asana.com/v2/mcp",
+      );
+      localStorage.setItem(
+        "mcp-client-asana",
+        JSON.stringify({
+          client_id: "stale-client-id",
+        }),
+      );
+      localStorage.setItem(
+        "mcp-tokens-asana",
+        JSON.stringify({
+          access_token: "old-access-token",
+          refresh_token: "stored-refresh-token",
+          token_type: "Bearer",
+        }),
+      );
+
+      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(createAsanaDiscoveryState());
+      mockFetchToken.mockRejectedValueOnce(
+        Object.assign(new Error("Client authentication failed"), {
+          code: "invalid_client",
+        }),
+      );
+      mockRegisterClient.mockResolvedValueOnce({
+        client_id: "new-client-id",
+      });
+      mockStartAuthorization.mockResolvedValueOnce({
+        authorizationUrl: new URL("https://app.asana.com/-/oauth_authorize"),
+        codeVerifier: "fresh-verifier",
+      });
+
+      const [{ getOAuthTraceFailureStep }, { initiateOAuth }] =
+        await Promise.all([
+          import("../oauth-trace"),
+          import("../mcp-oauth"),
+        ]);
+
+      const result = await initiateOAuth({
+        serverName: "asana",
+        serverUrl: "https://mcp.asana.com/v2/mcp",
+      });
+
+      expect(result.success).toBe(true);
+      expect(localStorage.getItem("mcp-client-asana")).toBe(
+        JSON.stringify({
+          client_id: "new-client-id",
+        }),
+      );
+      expect(getOAuthTraceFailureStep(result.oauthTrace)).toBeUndefined();
+    });
+
     it("preserves the original callback error and verifier when registry token exchange fails", async () => {
       authFetch.mockImplementationOnce(async (input: RequestInfo | URL) => {
         const url =

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -9,25 +9,31 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockDiscoverAuthorizationServerMetadata,
   mockDiscoverOAuthServerInfo,
+  mockExchangeAuthorization,
   mockFetchToken,
   mockGetConvexSiteUrl,
-  mockSdkAuth,
+  mockRegisterClient,
   mockSelectResourceURL,
+  mockStartAuthorization,
 } = vi.hoisted(() => ({
   mockDiscoverAuthorizationServerMetadata: vi.fn(),
   mockDiscoverOAuthServerInfo: vi.fn(),
+  mockExchangeAuthorization: vi.fn(),
   mockFetchToken: vi.fn(),
   mockGetConvexSiteUrl: vi.fn(),
-  mockSdkAuth: vi.fn(),
+  mockRegisterClient: vi.fn(),
   mockSelectResourceURL: vi.fn(),
+  mockStartAuthorization: vi.fn(),
 }));
 
 vi.mock("@mcpjam/sdk/browser", () => ({
-  auth: mockSdkAuth,
   discoverAuthorizationServerMetadata: mockDiscoverAuthorizationServerMetadata,
   discoverOAuthServerInfo: mockDiscoverOAuthServerInfo,
+  exchangeAuthorization: mockExchangeAuthorization,
   fetchToken: mockFetchToken,
+  registerClient: mockRegisterClient,
   selectResourceURL: mockSelectResourceURL,
+  startAuthorization: mockStartAuthorization,
 }));
 
 vi.mock("@/lib/session-token", () => ({
@@ -112,18 +118,43 @@ describe("mcp-oauth", () => {
     sessionStorage.clear();
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
-    mockSdkAuth.mockReset();
     mockDiscoverAuthorizationServerMetadata.mockReset();
     mockDiscoverOAuthServerInfo.mockReset();
+    mockExchangeAuthorization.mockReset();
     mockFetchToken.mockReset();
     mockGetConvexSiteUrl.mockReset();
+    mockRegisterClient.mockReset();
     mockGetConvexSiteUrl.mockReturnValue("https://test.convex.site");
     mockSelectResourceURL.mockReset();
+    mockStartAuthorization.mockReset();
+
+    mockDiscoverOAuthServerInfo.mockResolvedValue(createDiscoveryState());
+    mockDiscoverAuthorizationServerMetadata.mockResolvedValue(
+      createDiscoveryState().authorizationServerMetadata,
+    );
+    mockRegisterClient.mockResolvedValue({
+      client_id: "registered-client-id",
+    });
+    mockStartAuthorization.mockResolvedValue({
+      authorizationUrl: new URL("https://auth.example.com/authorize"),
+      codeVerifier: "test-verifier",
+    });
+    mockExchangeAuthorization.mockResolvedValue({
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      token_type: "Bearer",
+    });
 
     const sessionToken = await import("@/lib/session-token");
     authFetch = sessionToken.authFetch as ReturnType<typeof vi.fn>;
     authFetch.mockReset();
     mockSelectResourceURL.mockResolvedValue(undefined);
+
+    const oauthModule = await import("../mcp-oauth");
+    vi.spyOn(
+      oauthModule.MCPOAuthProvider.prototype,
+      "redirectToAuthorization",
+    ).mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -141,10 +172,15 @@ describe("mcp-oauth", () => {
     serverName: string = "asana",
     serverUrl: string = "https://mcp.asana.com/v2/mcp",
   ) {
-    mockSdkAuth.mockImplementationOnce(async (provider) => {
-      await provider.saveDiscoveryState?.(discoveryState);
-      await provider.saveCodeVerifier("test-verifier");
-      return "REDIRECT";
+    mockDiscoverOAuthServerInfo.mockResolvedValueOnce(discoveryState);
+    mockRegisterClient.mockResolvedValueOnce({
+      client_id: `${serverName}-client-id`,
+    });
+    mockStartAuthorization.mockResolvedValueOnce({
+      authorizationUrl: new URL(
+        `${discoveryState.authorizationServerMetadata.authorization_endpoint}?state=mock-state`,
+      ),
+      codeVerifier: "test-verifier",
     });
 
     const { initiateOAuth } = await import("../mcp-oauth");
@@ -155,7 +191,7 @@ describe("mcp-oauth", () => {
       useRegistryOAuthProxy,
     });
 
-    expect(result).toEqual({ success: true });
+    expect(result.success).toBe(true);
     return discoveryState;
   }
 
@@ -174,14 +210,17 @@ describe("mcp-oauth", () => {
         },
       );
       authFetch.mockResolvedValue(authErrorResponse);
-      mockSdkAuth.mockImplementation(async () => {
-        const response = await window.fetch(
+      mockDiscoverOAuthServerInfo.mockImplementation(async (_serverUrl, options) => {
+        const response = await options?.fetchFn?.(
           "https://example.com/.well-known/oauth-protected-resource/mcp",
         );
+        if (!response) {
+          throw new Error("Missing OAuth fetch function");
+        }
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
-        return "AUTHORIZED";
+        return createDiscoveryState();
       });
 
       const { initiateOAuth } = await import("../mcp-oauth");
@@ -206,14 +245,17 @@ describe("mcp-oauth", () => {
         },
       );
       authFetch.mockResolvedValue(authErrorResponse);
-      mockSdkAuth.mockImplementation(async () => {
-        const response = await window.fetch(
+      mockDiscoverOAuthServerInfo.mockImplementation(async (_serverUrl, options) => {
+        const response = await options?.fetchFn?.(
           "https://example.com/.well-known/oauth-protected-resource/mcp",
         );
+        if (!response) {
+          throw new Error("Missing OAuth fetch function");
+        }
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
-        return "AUTHORIZED";
+        return createDiscoveryState();
       });
 
       const { initiateOAuth } = await import("../mcp-oauth");
@@ -233,12 +275,15 @@ describe("mcp-oauth", () => {
         { status: 200 },
       );
       authFetch.mockResolvedValue(metadataResponse);
-      mockSdkAuth.mockImplementation(async (_provider: any, options: any) => {
-        const response = await options.fetchFn(
+      mockDiscoverOAuthServerInfo.mockImplementation(async (_serverUrl, options) => {
+        const response = await options?.fetchFn?.(
           "https://example.com/.well-known/oauth-protected-resource/mcp",
         );
+        if (!response) {
+          throw new Error("Missing OAuth fetch function");
+        }
         expect(response.ok).toBe(true);
-        return "REDIRECT";
+        return createDiscoveryState();
       });
 
       const { initiateOAuth } = await import("../mcp-oauth");
@@ -268,7 +313,8 @@ describe("mcp-oauth", () => {
           },
         }),
       );
-      mockSdkAuth.mockImplementationOnce(async (_provider, options) => {
+      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(createLinearDiscoveryState());
+      mockRegisterClient.mockImplementationOnce(async (_authServerUrl, options) => {
         const registrationBody = JSON.stringify({
           client_name: "MCPJam - Linear",
           redirect_uris: [`${window.location.origin}/oauth/callback`],
@@ -286,7 +332,7 @@ describe("mcp-oauth", () => {
           },
         );
         expect(response.ok).toBe(true);
-        return "REDIRECT";
+        return await response.json();
       });
 
       const { initiateOAuth } = await import("../mcp-oauth");
@@ -484,15 +530,14 @@ describe("mcp-oauth", () => {
 
     it("reuses cached discovery state after the callback reload", async () => {
       const discoveryState = createDiscoveryState();
-      mockSdkAuth.mockImplementationOnce(async (provider) => {
-        await provider.saveDiscoveryState?.(discoveryState);
-        await provider.saveCodeVerifier("code-verifier");
-        return "REDIRECT";
+      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(discoveryState);
+      mockStartAuthorization.mockResolvedValueOnce({
+        authorizationUrl: new URL("https://auth.example.com/authorize"),
+        codeVerifier: "code-verifier",
       });
-      mockFetchToken.mockImplementationOnce(async (provider, _url, options) => {
+      mockExchangeAuthorization.mockImplementationOnce(async (_url, options) => {
         expect(options?.authorizationCode).toBe("oauth-code");
-        expect(provider.discoveryState?.()).toEqual(discoveryState);
-        expect(provider.codeVerifier()).toBe("code-verifier");
+        expect(options?.codeVerifier).toBe("code-verifier");
         return {
           access_token: "access-token",
           refresh_token: "refresh-token",
@@ -507,7 +552,7 @@ describe("mcp-oauth", () => {
         serverName: "asana",
         serverUrl: "https://mcp.asana.com/sse",
       });
-      expect(initiateResult).toEqual({ success: true });
+      expect(initiateResult.success).toBe(true);
 
       const callbackResult = await handleOAuthCallback("oauth-code");
 
@@ -518,8 +563,8 @@ describe("mcp-oauth", () => {
       });
       expect(getStoredTokens("asana")?.access_token).toBe("access-token");
       expect(localStorage.getItem("mcp-discovery-asana")).not.toBeNull();
-      expect(mockSdkAuth).toHaveBeenCalledTimes(1);
-      expect(mockFetchToken).toHaveBeenCalledTimes(1);
+      expect(mockDiscoverOAuthServerInfo).toHaveBeenCalledTimes(1);
+      expect(mockExchangeAuthorization).toHaveBeenCalledTimes(1);
     });
 
     it("treats malformed stored token data as invalid instead of throwing", async () => {
@@ -558,8 +603,8 @@ describe("mcp-oauth", () => {
 
       const discoveryState = createAsanaDiscoveryState();
       await seedPendingOAuth("registry-asana", discoveryState, true);
-      mockFetchToken.mockImplementationOnce(
-        async (provider, authServerUrl, options) => {
+      mockExchangeAuthorization.mockImplementationOnce(
+        async (authServerUrl, options) => {
           expect(authServerUrl).toBe("https://app.asana.com");
           expect(options?.metadata?.token_endpoint).toBe(
             "https://app.asana.com/-/oauth_token",
@@ -571,8 +616,8 @@ describe("mcp-oauth", () => {
               body: new URLSearchParams({
                 grant_type: "authorization_code",
                 code: options!.authorizationCode!,
-                code_verifier: provider.codeVerifier(),
-                redirect_uri: String(provider.redirectUrl),
+                code_verifier: options!.codeVerifier,
+                redirect_uri: String(options!.redirectUri),
               }),
             },
           );
@@ -639,7 +684,9 @@ describe("mcp-oauth", () => {
         throw new Error(`Unexpected direct fetch to ${url}`);
       });
 
-      mockSdkAuth.mockImplementationOnce(async (_provider, options) => {
+      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(createAsanaDiscoveryState());
+      mockFetchToken.mockImplementationOnce(async (_provider, authServerUrl, options) => {
+        expect(authServerUrl).toBe("https://app.asana.com");
         const response = await options.fetchFn!(
           "https://app.asana.com/-/oauth_token",
           {
@@ -650,9 +697,7 @@ describe("mcp-oauth", () => {
             }),
           },
         );
-        const tokens = await response.json();
-        await _provider.saveTokens(tokens);
-        return "AUTHORIZED";
+        return await response.json();
       });
 
       localStorage.setItem(
@@ -719,8 +764,8 @@ describe("mcp-oauth", () => {
       });
 
       await seedPendingOAuth("registry-asana", undefined, true);
-      mockFetchToken.mockImplementationOnce(
-        async (provider, _authServerUrl, options) => {
+      mockExchangeAuthorization.mockImplementationOnce(
+        async (_authServerUrl, options) => {
           const response = await options!.fetchFn!(
             "https://app.asana.com/-/oauth_token",
             {
@@ -728,8 +773,8 @@ describe("mcp-oauth", () => {
               body: new URLSearchParams({
                 grant_type: "authorization_code",
                 code: options!.authorizationCode!,
-                code_verifier: provider.codeVerifier(),
-                redirect_uri: String(provider.redirectUrl),
+                code_verifier: options!.codeVerifier,
+                redirect_uri: String(options!.redirectUri),
               }),
             },
           );
@@ -768,8 +813,8 @@ describe("mcp-oauth", () => {
           },
         }),
       );
-      mockFetchToken.mockImplementationOnce(
-        async (provider, _authServerUrl, options) => {
+      mockExchangeAuthorization.mockImplementationOnce(
+        async (_authServerUrl, options) => {
           const response = await options!.fetchFn!(
             "https://app.asana.com/-/oauth_token",
             {
@@ -777,8 +822,8 @@ describe("mcp-oauth", () => {
               body: new URLSearchParams({
                 grant_type: "authorization_code",
                 code: options!.authorizationCode!,
-                code_verifier: provider.codeVerifier(),
-                redirect_uri: String(provider.redirectUrl),
+                code_verifier: options!.codeVerifier,
+                redirect_uri: String(options!.redirectUri),
               }),
             },
           );
@@ -833,8 +878,8 @@ describe("mcp-oauth", () => {
           },
         }),
       );
-      mockFetchToken.mockImplementationOnce(
-        async (provider, _authServerUrl, options) => {
+      mockExchangeAuthorization.mockImplementationOnce(
+        async (_authServerUrl, options) => {
           const response = await options!.fetchFn!(
             "https://app.asana.com/-/oauth_token",
             {
@@ -842,8 +887,8 @@ describe("mcp-oauth", () => {
               body: new URLSearchParams({
                 grant_type: "authorization_code",
                 code: options!.authorizationCode!,
-                code_verifier: provider.codeVerifier(),
-                redirect_uri: String(provider.redirectUrl),
+                code_verifier: options!.codeVerifier,
+                redirect_uri: String(options!.redirectUri),
               }),
             },
           );
@@ -902,8 +947,8 @@ describe("mcp-oauth", () => {
           },
         }),
       );
-      mockFetchToken.mockImplementationOnce(
-        async (provider, _authServerUrl, options) => {
+      mockExchangeAuthorization.mockImplementationOnce(
+        async (_authServerUrl, options) => {
           const response = await options!.fetchFn!(
             "https://mcp.linear.app/token",
             {
@@ -911,8 +956,8 @@ describe("mcp-oauth", () => {
               body: new URLSearchParams({
                 grant_type: "authorization_code",
                 code: options!.authorizationCode!,
-                code_verifier: provider.codeVerifier(),
-                redirect_uri: String(provider.redirectUrl),
+                code_verifier: options!.codeVerifier,
+                redirect_uri: String(options!.redirectUri),
               }),
             },
           );
@@ -963,7 +1008,8 @@ describe("mcp-oauth", () => {
         }),
       );
 
-      mockSdkAuth.mockImplementationOnce(async (_provider, options) => {
+      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(createLinearDiscoveryState());
+      mockFetchToken.mockImplementationOnce(async (_provider, _authServerUrl, options) => {
         const response = await options.fetchFn!(
           "https://mcp.linear.app/token",
           {
@@ -974,9 +1020,7 @@ describe("mcp-oauth", () => {
             }),
           },
         );
-        const tokens = await response.json();
-        await _provider.saveTokens(tokens);
-        return "AUTHORIZED";
+        return await response.json();
       });
 
       localStorage.setItem(

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -1,17 +1,22 @@
 /**
- * Clean OAuth implementation using only the official MCP SDK with CORS proxy support
+ * Production OAuth implementation using explicit SDK primitives with trace support.
  */
 
 import {
-  auth,
   discoverAuthorizationServerMetadata,
   discoverOAuthServerInfo,
+  exchangeAuthorization,
   fetchToken,
+  registerClient,
   selectResourceURL,
+  startAuthorization,
 } from "@mcpjam/sdk/browser";
 import type {
+  HttpHistoryEntry,
+  OAuthClientInformation,
   OAuthClientProvider,
   OAuthDiscoveryState,
+  OAuthTokens,
 } from "@mcpjam/sdk/browser";
 import type { HttpServerConfig } from "@mcpjam/sdk/browser";
 import { generateRandomString } from "./pkce";
@@ -21,6 +26,18 @@ import { captureServerDetailModalOAuthResume } from "@/lib/server-detail-modal-r
 import type { HostedOAuthCallbackContext } from "@/lib/hosted-oauth-callback";
 import { getRedirectUri } from "./constants";
 import { getConvexSiteUrl } from "@/lib/convex-site-url";
+import {
+  appendOAuthTraceHttpHistory,
+  clearOAuthTrace,
+  completeOAuthTraceStep,
+  createOAuthTrace,
+  failOAuthTraceStep,
+  loadOAuthTrace,
+  mergeOAuthTraces,
+  saveOAuthTrace,
+  startOAuthTraceStep,
+  type OAuthTrace,
+} from "./oauth-trace";
 
 // Store original fetch for restoration
 const originalFetch = window.fetch;
@@ -56,6 +73,79 @@ function clearStoredDiscoveryState(serverName: string): void {
 }
 
 type OAuthRequestFields = Record<string, string>;
+
+const SENSITIVE_FIELD_NAMES = new Set([
+  "access_token",
+  "refresh_token",
+  "id_token",
+  "client_secret",
+  "code",
+  "code_verifier",
+  "authorization",
+]);
+
+function redactSensitiveValue(value: unknown): string {
+  if (typeof value !== "string") {
+    return "[redacted]";
+  }
+
+  if (value.length <= 8) {
+    return "[redacted]";
+  }
+
+  return `${value.slice(0, 4)}...[redacted]...${value.slice(-2)}`;
+}
+
+function sanitizeOAuthTraceValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeOAuthTraceValue(item));
+  }
+
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entryValue]) => {
+      if (SENSITIVE_FIELD_NAMES.has(key.toLowerCase())) {
+        return [key, redactSensitiveValue(entryValue)];
+      }
+      return [key, sanitizeOAuthTraceValue(entryValue)];
+    }),
+  );
+}
+
+function sanitizeOAuthHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => {
+      if (SENSITIVE_FIELD_NAMES.has(key.toLowerCase())) {
+        return [key, redactSensitiveValue(value)];
+      }
+      return [key, value];
+    }),
+  );
+}
+
+function createHttpHistoryEntry(input: {
+  step: HttpHistoryEntry["step"];
+  method: string;
+  url: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}): HttpHistoryEntry {
+  return {
+    step: input.step,
+    timestamp: Date.now(),
+    request: {
+      method: input.method,
+      url: input.url,
+      headers: sanitizeOAuthHeaders(input.headers ?? {}),
+      body: sanitizeOAuthTraceValue(input.body),
+    },
+  };
+}
 
 export function readStoredOAuthConfig(
   serverName: string | null,
@@ -295,6 +385,7 @@ async function loadCallbackDiscoveryState(
  */
 function createOAuthFetchInterceptor(
   routingConfig: OAuthRoutingConfig = {},
+  trace?: OAuthTrace,
 ): typeof fetch {
   return async function interceptedFetch(
     input: RequestInfo | URL,
@@ -330,6 +421,30 @@ function createOAuthFetchInterceptor(
       return await originalFetch(input, init);
     }
 
+    const traceStep =
+      oauthGrantType === "authorization_code" ||
+      oauthGrantType === "refresh_token"
+        ? "token_request"
+        : url.includes("/register")
+          ? "request_client_registration"
+          : url.includes("oauth-protected-resource")
+            ? "request_resource_metadata"
+            : url.includes("/.well-known/")
+              ? "request_authorization_server_metadata"
+              : "authorization_request";
+    const entry = createHttpHistoryEntry({
+      step: traceStep,
+      method,
+      url,
+      headers: init?.headers
+        ? Object.fromEntries(new Headers(init.headers as HeadersInit))
+        : {},
+      body: serializedBody,
+    });
+    if (trace) {
+      appendOAuthTraceHttpHistory(trace, entry);
+    }
+
     // For registry servers, route token exchange/refresh through Convex HTTP actions
     if (isRegistryTokenRequest) {
       const convexSiteUrl = getConvexSiteUrl();
@@ -348,6 +463,15 @@ function createOAuthFetchInterceptor(
             ),
           ),
         });
+        entry.response = {
+          status: response.status,
+          statusText: response.statusText,
+          headers: sanitizeOAuthHeaders(
+            Object.fromEntries(response.headers.entries()),
+          ),
+          body: sanitizeOAuthTraceValue(await response.clone().json().catch(() => null)),
+        };
+        entry.duration = Date.now() - entry.timestamp;
         return response;
       }
     }
@@ -361,7 +485,17 @@ function createOAuthFetchInterceptor(
         : `${proxyBase}/proxy`;
 
       if (isMetadata) {
-        return await authFetch(proxyUrl, { ...init, method: "GET" });
+        const response = await authFetch(proxyUrl, { ...init, method: "GET" });
+        entry.response = {
+          status: response.status,
+          statusText: response.statusText,
+          headers: sanitizeOAuthHeaders(
+            Object.fromEntries(response.headers.entries()),
+          ),
+          body: sanitizeOAuthTraceValue(await response.clone().json().catch(() => null)),
+        };
+        entry.duration = Date.now() - entry.timestamp;
+        return response;
       }
 
       // For OAuth endpoints, serialize and proxy the full request
@@ -380,16 +514,36 @@ function createOAuthFetchInterceptor(
 
       // If the proxy call itself failed (e.g., auth error), return that response directly
       if (!response.ok) {
+        entry.response = {
+          status: response.status,
+          statusText: response.statusText,
+          headers: sanitizeOAuthHeaders(
+            Object.fromEntries(response.headers.entries()),
+          ),
+          body: sanitizeOAuthTraceValue(await response.clone().json().catch(() => null)),
+        };
+        entry.duration = Date.now() - entry.timestamp;
         return response;
       }
 
       const data = await response.json();
+      entry.response = {
+        status: data.status,
+        statusText: data.statusText,
+        headers: sanitizeOAuthHeaders(data.headers ?? {}),
+        body: sanitizeOAuthTraceValue(data.body),
+      };
+      entry.duration = Date.now() - entry.timestamp;
       return new Response(JSON.stringify(data.body), {
         status: data.status,
         statusText: data.statusText,
         headers: new Headers(data.headers),
       });
     } catch (error) {
+      entry.error = {
+        message: error instanceof Error ? error.message : String(error),
+      };
+      entry.duration = Date.now() - entry.timestamp;
       console.error("OAuth proxy failed, falling back to direct fetch:", error);
       return await originalFetch(input, init);
     }
@@ -437,12 +591,15 @@ export interface OAuthResult {
   success: boolean;
   serverConfig?: HttpServerConfig;
   error?: string;
+  oauthTrace?: OAuthTrace;
 }
 
 interface HostedOAuthCompletionResponse {
   success: boolean;
   expiresAt?: number | null;
   kind?: "generic" | "registry";
+  error?: string;
+  oauthTrace?: OAuthTrace;
 }
 
 /**
@@ -536,6 +693,18 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       `mcp-tokens-${this.serverName}`,
       JSON.stringify(tokens),
     );
+  }
+
+  prepareTokenRequest() {
+    const currentTokens = this.tokens();
+    if (!currentTokens?.refresh_token) {
+      return undefined;
+    }
+
+    return new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: currentTokens.refresh_token,
+    });
   }
 
   discoveryState(): OAuthDiscoveryState | undefined {
@@ -645,17 +814,128 @@ function readStoredClientInformation(
   }
 }
 
+async function resolveOAuthClientInformation(
+  provider: MCPOAuthProvider,
+  trace: OAuthTrace,
+  authorizationServerUrl: string,
+  metadata: OAuthDiscoveryState["authorizationServerMetadata"],
+  scope?: string,
+  fetchFn?: typeof fetch,
+): Promise<OAuthClientInformation> {
+  startOAuthTraceStep(trace, "request_client_registration", {
+    message: "Resolving OAuth client information.",
+  });
+
+  const existingClientInformation = await provider.clientInformation();
+  if (existingClientInformation?.client_id) {
+    completeOAuthTraceStep(trace, "request_client_registration", {
+      message: "Using stored or preregistered client information.",
+      details: {
+        clientId: existingClientInformation.client_id,
+      },
+    });
+    completeOAuthTraceStep(trace, "received_client_credentials", {
+      message: "Client credentials are ready.",
+      details: {
+        clientId: existingClientInformation.client_id,
+      },
+    });
+    return existingClientInformation;
+  }
+
+  try {
+    const registeredClient = await registerClient(authorizationServerUrl, {
+      metadata,
+      clientMetadata: provider.clientMetadata,
+      ...(scope ? { scope } : {}),
+      ...(fetchFn ? { fetchFn } : {}),
+    });
+    await provider.saveClientInformation(registeredClient);
+    completeOAuthTraceStep(trace, "request_client_registration", {
+      message: "Dynamic client registration completed.",
+      details: {
+        clientId: registeredClient.client_id,
+      },
+    });
+    completeOAuthTraceStep(trace, "received_client_credentials", {
+      message: "Client credentials are ready.",
+      details: {
+        clientId: registeredClient.client_id,
+      },
+    });
+    return registeredClient;
+  } catch (error) {
+    failOAuthTraceStep(trace, "request_client_registration", error, {
+      message: "Dynamic client registration failed.",
+    });
+    throw error;
+  }
+}
+
+async function attemptRefreshWithStoredTokens(
+  provider: MCPOAuthProvider,
+  trace: OAuthTrace,
+  authorizationServerUrl: string,
+  metadata: OAuthDiscoveryState["authorizationServerMetadata"],
+  resource: URL | null,
+  fetchFn: typeof fetch,
+): Promise<OAuthTokens | null> {
+  const existingTokens = provider.tokens();
+  if (!existingTokens?.refresh_token) {
+    return null;
+  }
+
+  startOAuthTraceStep(trace, "token_request", {
+    message: "Attempting to refresh stored OAuth tokens before redirecting.",
+  });
+
+  try {
+    const refreshedTokens = await fetchToken(provider, authorizationServerUrl, {
+      metadata,
+      ...(resource ? { resource } : {}),
+      fetchFn,
+    });
+    await provider.saveTokens(refreshedTokens);
+    completeOAuthTraceStep(trace, "token_request", {
+      message: "Stored refresh token succeeded.",
+    });
+    completeOAuthTraceStep(trace, "received_access_token", {
+      message: "Refreshed OAuth tokens are ready.",
+    });
+    completeOAuthTraceStep(trace, "complete", {
+      message: "OAuth completed using the stored refresh token.",
+    });
+    return refreshedTokens;
+  } catch (error) {
+    failOAuthTraceStep(trace, "token_request", error, {
+      message:
+        "Stored refresh token failed. Falling back to an interactive authorization flow.",
+    });
+    await provider.invalidateCredentials("tokens");
+    trace.error = undefined;
+    return null;
+  }
+}
+
 /**
  * Initiates OAuth flow for an MCP server
  */
 export async function initiateOAuth(
   options: MCPOAuthOptions,
 ): Promise<OAuthResult> {
-  // Build fetch interceptor — routes token requests through Convex for registry servers
-  const fetchFn = createOAuthFetchInterceptor({
-    registryServerId: options.registryServerId,
-    useRegistryOAuthProxy: options.useRegistryOAuthProxy,
+  const trace = createOAuthTrace({
+    source: "interactive_connect",
+    serverName: options.serverName,
+    serverUrl: options.serverUrl,
   });
+  // Build fetch interceptor — routes token requests through Convex for registry servers
+  const fetchFn = createOAuthFetchInterceptor(
+    {
+      registryServerId: options.registryServerId,
+      useRegistryOAuthProxy: options.useRegistryOAuthProxy,
+    },
+    trace,
+  );
 
   try {
     const provider = new MCPOAuthProvider(
@@ -702,32 +982,119 @@ export async function initiateOAuth(
       );
     }
 
-    const authArgs: any = { serverUrl: options.serverUrl, fetchFn };
-    if (options.scopes && options.scopes.length > 0) {
-      authArgs.scope = options.scopes.join(" ");
-    }
-    const result = await auth(provider, authArgs);
+    const requestedScope =
+      options.scopes && options.scopes.length > 0
+        ? options.scopes.join(" ")
+        : undefined;
 
-    if (result === "REDIRECT") {
+    startOAuthTraceStep(trace, "request_resource_metadata", {
+      message: "Discovering protected resource metadata.",
+    });
+    const discoveryState = await loadCallbackDiscoveryState(
+      provider,
+      options.serverUrl,
+      fetchFn,
+    );
+    completeOAuthTraceStep(trace, "request_resource_metadata", {
+      message: "Protected resource metadata loaded.",
+      details: {
+        authorizationServerUrl: discoveryState.authorizationServerUrl,
+        resource:
+          discoveryState.resourceMetadata?.resource ?? options.serverUrl,
+      },
+    });
+    completeOAuthTraceStep(trace, "received_resource_metadata", {
+      message: "Resource metadata is ready.",
+      details: {
+        authorizationServers:
+          discoveryState.resourceMetadata?.authorization_servers ?? [],
+      },
+    });
+
+    startOAuthTraceStep(trace, "request_authorization_server_metadata", {
+      message: "Loading authorization server metadata.",
+      details: {
+        authorizationServerUrl: discoveryState.authorizationServerUrl,
+      },
+    });
+    completeOAuthTraceStep(trace, "request_authorization_server_metadata", {
+      message: "Authorization server metadata loaded.",
+    });
+    completeOAuthTraceStep(trace, "received_authorization_server_metadata", {
+      message: "Authorization server metadata is ready.",
+      details: {
+        authorizationEndpoint:
+          discoveryState.authorizationServerMetadata?.authorization_endpoint,
+        tokenEndpoint:
+          discoveryState.authorizationServerMetadata?.token_endpoint,
+      },
+    });
+
+    const resource = await selectResourceURL(
+      options.serverUrl,
+      provider,
+      discoveryState.resourceMetadata,
+    );
+
+    const refreshedTokens = await attemptRefreshWithStoredTokens(
+      provider,
+      trace,
+      discoveryState.authorizationServerUrl,
+      discoveryState.authorizationServerMetadata,
+      resource ?? null,
+      fetchFn,
+    );
+    if (refreshedTokens) {
+      saveOAuthTrace(options.serverName, trace);
       return {
         success: true,
+        serverConfig: createServerConfig(options.serverUrl, refreshedTokens),
+        oauthTrace: trace,
       };
     }
 
-    if (result === "AUTHORIZED") {
-      const tokens = provider.tokens();
-      if (tokens) {
-        const serverConfig = createServerConfig(options.serverUrl, tokens);
-        return {
-          success: true,
-          serverConfig,
-        };
-      }
-    }
+    const clientInformation = await resolveOAuthClientInformation(
+      provider,
+      trace,
+      discoveryState.authorizationServerUrl,
+      discoveryState.authorizationServerMetadata,
+      requestedScope,
+      fetchFn,
+    );
+
+    startOAuthTraceStep(trace, "generate_pkce_parameters", {
+      message: "Generating PKCE verifier and challenge.",
+    });
+    const { authorizationUrl, codeVerifier } = await startAuthorization(
+      discoveryState.authorizationServerUrl,
+      {
+        metadata: discoveryState.authorizationServerMetadata,
+        clientInformation,
+        redirectUrl: provider.redirectUrl,
+        ...(requestedScope ? { scope: requestedScope } : {}),
+        state: provider.state(),
+        ...(resource ? { resource } : {}),
+      },
+    );
+    completeOAuthTraceStep(trace, "generate_pkce_parameters", {
+      message: "PKCE verifier and challenge are ready.",
+    });
+    startOAuthTraceStep(trace, "authorization_request", {
+      message: "Preparing authorization redirect.",
+    });
+    await provider.saveCodeVerifier(codeVerifier);
+    completeOAuthTraceStep(trace, "authorization_request", {
+      message: "Redirecting to the authorization server.",
+      details: {
+        authorizationUrl: authorizationUrl.toString(),
+      },
+    });
+    saveOAuthTrace(options.serverName, trace);
+    await provider.redirectToAuthorization(authorizationUrl);
 
     return {
-      success: false,
-      error: "OAuth flow failed",
+      success: true,
+      oauthTrace: trace,
     };
   } catch (error) {
     let errorMessage = "Unknown OAuth error";
@@ -751,9 +1118,15 @@ export async function initiateOAuth(
       }
     }
 
+    failOAuthTraceStep(trace, trace.currentStep, errorMessage, {
+      message: "OAuth initialization failed.",
+    });
+    saveOAuthTrace(options.serverName, trace);
+
     return {
       success: false,
       error: errorMessage,
+      oauthTrace: trace,
     };
   } finally {
     // Restore original fetch
@@ -762,23 +1135,24 @@ export async function initiateOAuth(
 }
 
 function formatOAuthCallbackError(error: unknown): string {
-  let errorMessage = "Unknown callback error";
+  const errorMessage =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "Unknown callback error";
 
-  if (error instanceof Error) {
-    errorMessage = error.message;
-
-    if (
-      errorMessage.includes("invalid_client") ||
-      errorMessage.includes("client_id")
-    ) {
-      return "Invalid client ID during token exchange. Please verify the client ID is correctly registered.";
-    }
-    if (errorMessage.includes("unauthorized_client")) {
-      return "Client not authorized for token exchange. The client ID may not match the one used for authorization.";
-    }
-    if (errorMessage.includes("invalid_grant")) {
-      return "Authorization code invalid or expired. Please try the OAuth flow again.";
-    }
+  if (
+    errorMessage.includes("invalid_client") ||
+    errorMessage.includes("client_id")
+  ) {
+    return "Invalid client ID during token exchange. Please verify the client ID is correctly registered.";
+  }
+  if (errorMessage.includes("unauthorized_client")) {
+    return "Client not authorized for token exchange. The client ID may not match the one used for authorization.";
+  }
+  if (errorMessage.includes("invalid_grant")) {
+    return "Authorization code invalid or expired. Please try the OAuth flow again.";
   }
 
   return errorMessage;
@@ -789,6 +1163,10 @@ export async function completeHostedOAuthCallback(
   authorizationCode: string,
 ): Promise<OAuthResult & { serverName?: string; expiresAt?: number | null }> {
   const serverName = context.serverName || localStorage.getItem("mcp-oauth-pending");
+  const callbackTrace = createOAuthTrace({
+    source: "hosted_callback",
+    serverName: serverName ?? undefined,
+  });
 
   try {
     if (!serverName) {
@@ -798,6 +1176,9 @@ export async function completeHostedOAuthCallback(
       throw new Error("Hosted OAuth callback is missing server context");
     }
 
+    startOAuthTraceStep(callbackTrace, "received_authorization_code", {
+      message: "Received hosted OAuth callback and loading stored callback state.",
+    });
     const serverUrl =
       context.serverUrl || localStorage.getItem(`mcp-serverUrl-${serverName}`);
     if (!serverUrl) {
@@ -813,6 +1194,13 @@ export async function completeHostedOAuthCallback(
     if (!clientInformation.client_id) {
       throw new Error("OAuth client ID not found");
     }
+    completeOAuthTraceStep(callbackTrace, "received_authorization_code", {
+      message: "Hosted callback state restored.",
+      details: {
+        serverUrl,
+        clientId: clientInformation.client_id,
+      },
+    });
 
     const convexSiteUrl = getConvexSiteUrl();
     const response = await authFetch(`${convexSiteUrl}/web/oauth/complete`, {
@@ -839,30 +1227,90 @@ export async function completeHostedOAuthCallback(
       }),
     });
 
+    const result =
+      (await response
+        .clone()
+        .json()
+        .catch(() => null)) as HostedOAuthCompletionResponse | null;
     if (!response.ok) {
       const responseText = await response.text();
-      throw new Error(responseText || `Hosted OAuth callback failed (${response.status})`);
+      throw {
+        message:
+          result?.error ||
+          responseText ||
+          `Hosted OAuth callback failed (${response.status})`,
+        oauthTrace: result?.oauthTrace,
+      };
     }
 
-    const result =
-      (await response.json()) as HostedOAuthCompletionResponse | null;
     if (!result?.success) {
-      throw new Error("Hosted OAuth callback failed");
+      throw {
+        message: result?.error || "Hosted OAuth callback failed",
+        oauthTrace: result?.oauthTrace,
+      };
     }
 
     localStorage.removeItem(`mcp-tokens-${serverName}`);
     localStorage.removeItem(`mcp-verifier-${serverName}`);
+    completeOAuthTraceStep(callbackTrace, "token_request", {
+      message: "Hosted token exchange succeeded.",
+    });
+    completeOAuthTraceStep(callbackTrace, "received_access_token", {
+      message: "Hosted access token is stored in the backend vault.",
+    });
+    completeOAuthTraceStep(callbackTrace, "complete", {
+      message: "Hosted OAuth callback completed successfully.",
+    });
+    const mergedTrace = mergeOAuthTraces(
+      loadOAuthTrace(serverName),
+      result.oauthTrace
+        ? mergeOAuthTraces(callbackTrace, result.oauthTrace)
+        : callbackTrace,
+    );
+    saveOAuthTrace(serverName, mergedTrace);
 
     return {
       success: true,
       serverName,
       serverConfig: createServerConfig(serverUrl),
       expiresAt: result.expiresAt ?? null,
+      oauthTrace: mergedTrace,
     };
   } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : typeof error === "object" &&
+            error !== null &&
+            "message" in error &&
+            typeof (error as { message?: unknown }).message === "string"
+          ? ((error as { message: string }).message)
+          : String(error);
+    failOAuthTraceStep(callbackTrace, callbackTrace.currentStep, message, {
+      message: "Hosted OAuth callback failed.",
+    });
+    const backendTrace =
+      typeof error === "object" && error !== null && "oauthTrace" in error
+        ? ((error as { oauthTrace?: OAuthTrace }).oauthTrace ?? undefined)
+        : undefined;
+    const mergedTrace =
+      serverName != null
+        ? mergeOAuthTraces(
+            loadOAuthTrace(serverName),
+            backendTrace
+              ? mergeOAuthTraces(callbackTrace, backendTrace)
+              : callbackTrace,
+          )
+        : backendTrace
+          ? mergeOAuthTraces(callbackTrace, backendTrace)
+          : callbackTrace;
+    if (serverName) {
+      saveOAuthTrace(serverName, mergedTrace);
+    }
     return {
       success: false,
-      error: formatOAuthCallbackError(error),
+      error: formatOAuthCallbackError(message),
+      oauthTrace: mergedTrace,
     };
   }
 }
@@ -875,12 +1323,16 @@ export async function handleOAuthCallback(
 ): Promise<OAuthResult & { serverName?: string }> {
   // Get pending server name from localStorage (needed before creating interceptor)
   const serverName = localStorage.getItem("mcp-oauth-pending");
+  const callbackTrace = createOAuthTrace({
+    source: "callback",
+    serverName: serverName ?? undefined,
+  });
 
   // Read registryServerId from stored OAuth config if present
   const oauthConfig = readStoredOAuthConfig(serverName);
 
   // Build fetch interceptor — routes token requests through Convex for registry servers
-  const fetchFn = createOAuthFetchInterceptor(oauthConfig);
+  const fetchFn = createOAuthFetchInterceptor(oauthConfig, callbackTrace);
 
   try {
     if (!serverName) {
@@ -892,6 +1344,12 @@ export async function handleOAuthCallback(
     if (!serverUrl) {
       throw new Error("Server URL not found for OAuth callback");
     }
+    startOAuthTraceStep(callbackTrace, "received_authorization_code", {
+      message: "Received OAuth callback and loading stored state.",
+      details: {
+        serverUrl,
+      },
+    });
 
     // Get stored client credentials if any
     const storedClientInfo = localStorage.getItem(`mcp-client-${serverName}`);
@@ -908,41 +1366,81 @@ export async function handleOAuthCallback(
       customClientId,
       customClientSecret,
     );
+    const clientInformation = await provider.clientInformation();
+    if (!clientInformation?.client_id) {
+      throw new Error("OAuth client ID not found");
+    }
     const discoveryState = await loadCallbackDiscoveryState(
       provider,
       serverUrl,
       fetchFn,
     );
+    completeOAuthTraceStep(callbackTrace, "received_authorization_code", {
+      message: "Callback state restored.",
+      details: {
+        clientId: clientInformation.client_id,
+      },
+    });
     const resource = await selectResourceURL(
       serverUrl,
       provider,
       discoveryState.resourceMetadata,
     );
-    const tokens = await fetchToken(
-      provider,
+    startOAuthTraceStep(callbackTrace, "token_request", {
+      message: "Exchanging authorization code for OAuth tokens.",
+    });
+    const tokens = await exchangeAuthorization(
       discoveryState.authorizationServerUrl,
       {
         metadata: discoveryState.authorizationServerMetadata,
-        resource,
         authorizationCode,
+        clientInformation,
+        codeVerifier: provider.codeVerifier(),
+        redirectUri: provider.redirectUrl,
+        ...(resource ? { resource } : {}),
         fetchFn,
       },
     );
     await provider.saveTokens(tokens);
+    completeOAuthTraceStep(callbackTrace, "token_request", {
+      message: "Authorization code exchange succeeded.",
+    });
+    completeOAuthTraceStep(callbackTrace, "received_access_token", {
+      message: "OAuth tokens were stored locally.",
+    });
+    completeOAuthTraceStep(callbackTrace, "complete", {
+      message: "OAuth callback completed successfully.",
+    });
 
     // Clean up pending state
     localStorage.removeItem("mcp-oauth-pending");
+    const mergedTrace = mergeOAuthTraces(
+      loadOAuthTrace(serverName),
+      callbackTrace,
+    );
+    saveOAuthTrace(serverName, mergedTrace);
 
     const serverConfig = createServerConfig(serverUrl, tokens);
     return {
       success: true,
       serverConfig,
       serverName, // Return server name so caller doesn't need to look it up
+      oauthTrace: mergedTrace,
     };
   } catch (error) {
+    failOAuthTraceStep(callbackTrace, callbackTrace.currentStep, error, {
+      message: "OAuth callback failed.",
+    });
+    const mergedTrace = serverName
+      ? mergeOAuthTraces(loadOAuthTrace(serverName), callbackTrace)
+      : callbackTrace;
+    if (serverName) {
+      saveOAuthTrace(serverName, mergedTrace);
+    }
     return {
       success: false,
       error: formatOAuthCallbackError(error),
+      oauthTrace: mergedTrace,
     };
   } finally {
     // Restore original fetch
@@ -1033,9 +1531,13 @@ export async function waitForTokens(
 export async function refreshOAuthTokens(
   serverName: string,
 ): Promise<OAuthResult> {
+  const trace = createOAuthTrace({
+    source: "refresh",
+    serverName,
+  });
   // Build fetch interceptor — routes token requests through Convex for registry servers
   const oauthConfig = readStoredOAuthConfig(serverName);
-  const fetchFn = createOAuthFetchInterceptor(oauthConfig);
+  const fetchFn = createOAuthFetchInterceptor(oauthConfig, trace);
 
   try {
     // Get stored client credentials if any
@@ -1068,25 +1570,56 @@ export async function refreshOAuthTokens(
       return {
         success: false,
         error: "No refresh token available",
+        oauthTrace: trace,
       };
     }
 
-    const result = await auth(provider, { serverUrl, fetchFn });
-
-    if (result === "AUTHORIZED") {
-      const tokens = provider.tokens();
-      if (tokens) {
-        const serverConfig = createServerConfig(serverUrl, tokens);
-        return {
-          success: true,
-          serverConfig,
-        };
-      }
-    }
-
+    startOAuthTraceStep(trace, "request_resource_metadata", {
+      message: "Refreshing OAuth tokens and rediscovering server metadata.",
+    });
+    const discoveryState = await loadCallbackDiscoveryState(
+      provider,
+      serverUrl,
+      fetchFn,
+    );
+    completeOAuthTraceStep(trace, "request_resource_metadata", {
+      message: "Protected resource metadata loaded.",
+    });
+    completeOAuthTraceStep(trace, "received_resource_metadata", {
+      message: "Resource metadata is ready.",
+    });
+    completeOAuthTraceStep(trace, "received_authorization_server_metadata", {
+      message: "Authorization server metadata is ready.",
+    });
+    const resource = await selectResourceURL(
+      serverUrl,
+      provider,
+      discoveryState.resourceMetadata,
+    );
+    startOAuthTraceStep(trace, "token_request", {
+      message: "Refreshing tokens with the stored refresh token.",
+    });
+    const tokens = await fetchToken(provider, discoveryState.authorizationServerUrl, {
+      metadata: discoveryState.authorizationServerMetadata,
+      ...(resource ? { resource } : {}),
+      fetchFn,
+    });
+    await provider.saveTokens(tokens);
+    completeOAuthTraceStep(trace, "token_request", {
+      message: "Refresh token exchange succeeded.",
+    });
+    completeOAuthTraceStep(trace, "received_access_token", {
+      message: "Refreshed OAuth tokens were stored locally.",
+    });
+    completeOAuthTraceStep(trace, "complete", {
+      message: "OAuth token refresh completed successfully.",
+    });
+    saveOAuthTrace(serverName, trace);
+    const serverConfig = createServerConfig(serverUrl, tokens);
     return {
-      success: false,
-      error: "Token refresh failed",
+      success: true,
+      serverConfig,
+      oauthTrace: trace,
     };
   } catch (error) {
     let errorMessage = "Unknown refresh error";
@@ -1110,9 +1643,15 @@ export async function refreshOAuthTokens(
       }
     }
 
+    failOAuthTraceStep(trace, trace.currentStep, errorMessage, {
+      message: "OAuth token refresh failed.",
+    });
+    saveOAuthTrace(serverName, trace);
+
     return {
       success: false,
       error: errorMessage,
+      oauthTrace: trace,
     };
   } finally {
     // Restore original fetch
@@ -1130,6 +1669,7 @@ export function clearOAuthData(serverName: string): void {
   localStorage.removeItem(`mcp-serverUrl-${serverName}`);
   localStorage.removeItem(`mcp-oauth-config-${serverName}`);
   clearStoredDiscoveryState(serverName);
+  clearOAuthTrace(serverName);
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -34,6 +34,7 @@ import {
   failOAuthTraceStep,
   loadOAuthTrace,
   mergeOAuthTraces,
+  resolveOAuthTraceStepError,
   saveOAuthTrace,
   startOAuthTraceStep,
   type OAuthTrace,
@@ -96,9 +97,39 @@ function redactSensitiveValue(value: unknown): string {
   return `${value.slice(0, 4)}...[redacted]...${value.slice(-2)}`;
 }
 
+function sanitizeOAuthTraceString(value: string): unknown {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+
+  const looksStructured =
+    trimmed.includes("=") ||
+    trimmed.includes("&") ||
+    ((trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+      (trimmed.startsWith("[") && trimmed.endsWith("]")));
+  if (looksStructured) {
+    const parsed = parseOAuthRequestFields(trimmed);
+    if (parsed) {
+      return sanitizeOAuthTraceValue(parsed);
+    }
+  }
+
+  return trimmed
+    .replace(
+      /\b(access_token|refresh_token|id_token|client_secret|code_verifier)\b(\s*[:=]\s*)([^\s&,;]+)/gi,
+      (_match, key: string, separator: string) => `${key}${separator}[redacted]`,
+    )
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+\b/gi, "Bearer [redacted]");
+}
+
 function sanitizeOAuthTraceValue(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map((item) => sanitizeOAuthTraceValue(item));
+  }
+
+  if (typeof value === "string") {
+    return sanitizeOAuthTraceString(value);
   }
 
   if (!value || typeof value !== "object") {
@@ -145,6 +176,51 @@ function createHttpHistoryEntry(input: {
       body: sanitizeOAuthTraceValue(input.body),
     },
   };
+}
+
+async function readResponseBodyForTrace(response: Response): Promise<unknown> {
+  try {
+    return sanitizeOAuthTraceValue(await response.clone().json());
+  } catch {
+    try {
+      const text = await response.clone().text();
+      return text ? sanitizeOAuthTraceValue(text) : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function getOAuthErrorCode(error: unknown): string | undefined {
+  if (error && typeof error === "object") {
+    const record = error as Record<string, unknown>;
+    if (typeof record.code === "string") {
+      return record.code.toLowerCase();
+    }
+    if (typeof record.error === "string") {
+      return record.error.toLowerCase();
+    }
+  }
+
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    if (message.includes("invalid_client")) {
+      return "invalid_client";
+    }
+    if (message.includes("unauthorized_client")) {
+      return "unauthorized_client";
+    }
+    if (message.includes("invalid_grant")) {
+      return "invalid_grant";
+    }
+  }
+
+  return undefined;
+}
+
+function shouldInvalidateOAuthClient(error: unknown): boolean {
+  const code = getOAuthErrorCode(error);
+  return code === "invalid_client" || code === "unauthorized_client";
 }
 
 export function readStoredOAuthConfig(
@@ -469,7 +545,7 @@ function createOAuthFetchInterceptor(
           headers: sanitizeOAuthHeaders(
             Object.fromEntries(response.headers.entries()),
           ),
-          body: sanitizeOAuthTraceValue(await response.clone().json().catch(() => null)),
+          body: await readResponseBodyForTrace(response),
         };
         entry.duration = Date.now() - entry.timestamp;
         return response;
@@ -492,7 +568,7 @@ function createOAuthFetchInterceptor(
           headers: sanitizeOAuthHeaders(
             Object.fromEntries(response.headers.entries()),
           ),
-          body: sanitizeOAuthTraceValue(await response.clone().json().catch(() => null)),
+          body: await readResponseBodyForTrace(response),
         };
         entry.duration = Date.now() - entry.timestamp;
         return response;
@@ -520,7 +596,7 @@ function createOAuthFetchInterceptor(
           headers: sanitizeOAuthHeaders(
             Object.fromEntries(response.headers.entries()),
           ),
-          body: sanitizeOAuthTraceValue(await response.clone().json().catch(() => null)),
+          body: await readResponseBodyForTrace(response),
         };
         entry.duration = Date.now() - entry.timestamp;
         return response;
@@ -907,12 +983,16 @@ async function attemptRefreshWithStoredTokens(
     });
     return refreshedTokens;
   } catch (error) {
+    const invalidClient = shouldInvalidateOAuthClient(error);
     failOAuthTraceStep(trace, "token_request", error, {
       message:
         "Stored refresh token failed. Falling back to an interactive authorization flow.",
     });
-    await provider.invalidateCredentials("tokens");
-    trace.error = undefined;
+    await provider.invalidateCredentials(invalidClient ? "all" : "tokens");
+    resolveOAuthTraceStepError(trace, "token_request", {
+      message:
+        "Stored refresh failure was recovered by falling back to an interactive OAuth flow.",
+    });
     return null;
   }
 }

--- a/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
@@ -20,6 +20,9 @@ export interface OAuthTraceStep {
   message?: string;
   error?: string;
   details?: Record<string, unknown>;
+  recovered?: boolean;
+  recoveredAt?: number;
+  recoveryMessage?: string;
   startedAt: number;
   completedAt?: number;
 }
@@ -39,8 +42,28 @@ function storageKey(serverName: string): string {
   return `mcp-oauth-trace-${serverName}`;
 }
 
+const MAX_OAUTH_TRACE_HTTP_HISTORY = 50;
+
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function trimHttpHistory(httpHistory: HttpHistoryEntry[]): HttpHistoryEntry[] {
+  if (httpHistory.length <= MAX_OAUTH_TRACE_HTTP_HISTORY) {
+    return httpHistory;
+  }
+
+  return httpHistory.slice(-MAX_OAUTH_TRACE_HTTP_HISTORY);
+}
+
+function buildPersistableTrace(
+  trace: OAuthTrace,
+  options: { dropHttpHistory?: boolean } = {},
+): OAuthTrace {
+  return clone({
+    ...trace,
+    httpHistory: options.dropHttpHistory ? [] : trimHttpHistory(trace.httpHistory),
+  });
 }
 
 export function createOAuthTrace(input: {
@@ -76,7 +99,23 @@ export function loadOAuthTrace(serverName: string): OAuthTrace | undefined {
 }
 
 export function saveOAuthTrace(serverName: string, trace: OAuthTrace): void {
-  localStorage.setItem(storageKey(serverName), JSON.stringify(trace));
+  try {
+    localStorage.setItem(
+      storageKey(serverName),
+      JSON.stringify(buildPersistableTrace(trace)),
+    );
+  } catch (error) {
+    console.warn("Failed to persist OAuth trace with HTTP history.", error);
+
+    try {
+      localStorage.setItem(
+        storageKey(serverName),
+        JSON.stringify(buildPersistableTrace(trace, { dropHttpHistory: true })),
+      );
+    } catch (retryError) {
+      console.warn("Failed to persist OAuth trace.", retryError);
+    }
+  }
 }
 
 export function clearOAuthTrace(serverName: string): void {
@@ -188,6 +227,30 @@ export function appendOAuthTraceHttpHistory(
   entry: HttpHistoryEntry,
 ): void {
   trace.httpHistory.push(entry);
+  trace.httpHistory = trimHttpHistory(trace.httpHistory);
+}
+
+export function resolveOAuthTraceStepError(
+  trace: OAuthTrace,
+  step: OAuthFlowStep,
+  input: { message?: string } = {},
+): void {
+  const existing = [...trace.steps]
+    .reverse()
+    .find((entry) => entry.step === step && entry.status === "error" && !entry.recovered);
+
+  if (!existing) {
+    return;
+  }
+
+  existing.recovered = true;
+  existing.recoveredAt = Date.now();
+  existing.recoveryMessage = input.message ?? existing.recoveryMessage;
+
+  const remainingFailure = [...trace.steps]
+    .reverse()
+    .find((entry) => entry.status === "error" && !entry.recovered);
+  trace.error = remainingFailure?.error;
 }
 
 export function mergeOAuthTraces(
@@ -195,11 +258,11 @@ export function mergeOAuthTraces(
   next: OAuthTrace,
 ): OAuthTrace {
   if (!base) {
-    return clone(next);
+    return buildPersistableTrace(next);
   }
 
-  return {
-    ...clone(base),
+  return buildPersistableTrace({
+    version: 1,
     source: next.source,
     serverName: next.serverName ?? base.serverName,
     serverUrl: next.serverUrl ?? base.serverUrl,
@@ -209,9 +272,9 @@ export function mergeOAuthTraces(
         left.startedAt - right.startedAt ||
         getStepIndex(left.step) - getStepIndex(right.step),
     ),
-    httpHistory: [...base.httpHistory, ...next.httpHistory],
+    httpHistory: trimHttpHistory([...base.httpHistory, ...next.httpHistory]),
     error: next.error ?? base.error,
-  };
+  });
 }
 
 export function getOAuthTraceFailureStep(
@@ -223,7 +286,7 @@ export function getOAuthTraceFailureStep(
 
   return [...trace.steps]
     .reverse()
-    .find((entry) => entry.status === "error");
+    .find((entry) => entry.status === "error" && !entry.recovered);
 }
 
 export function getOAuthTraceSummary(

--- a/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
@@ -1,0 +1,238 @@
+import {
+  getStepIndex,
+  getStepInfo,
+  type HttpHistoryEntry,
+  type OAuthFlowStep,
+} from "@mcpjam/sdk/browser";
+
+export type OAuthTraceSource =
+  | "interactive_connect"
+  | "callback"
+  | "refresh"
+  | "hosted_callback";
+
+export type OAuthTraceStepStatus = "pending" | "success" | "error";
+
+export interface OAuthTraceStep {
+  step: OAuthFlowStep;
+  title: string;
+  status: OAuthTraceStepStatus;
+  message?: string;
+  error?: string;
+  details?: Record<string, unknown>;
+  startedAt: number;
+  completedAt?: number;
+}
+
+export interface OAuthTrace {
+  version: 1;
+  source: OAuthTraceSource;
+  serverName?: string;
+  serverUrl?: string;
+  currentStep: OAuthFlowStep;
+  steps: OAuthTraceStep[];
+  httpHistory: HttpHistoryEntry[];
+  error?: string;
+}
+
+function storageKey(serverName: string): string {
+  return `mcp-oauth-trace-${serverName}`;
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function createOAuthTrace(input: {
+  source: OAuthTraceSource;
+  serverName?: string;
+  serverUrl?: string;
+}): OAuthTrace {
+  return {
+    version: 1,
+    source: input.source,
+    serverName: input.serverName,
+    serverUrl: input.serverUrl,
+    currentStep: "idle",
+    steps: [],
+    httpHistory: [],
+  };
+}
+
+export function loadOAuthTrace(serverName: string): OAuthTrace | undefined {
+  try {
+    const raw = localStorage.getItem(storageKey(serverName));
+    if (!raw) {
+      return undefined;
+    }
+    const parsed = JSON.parse(raw) as OAuthTrace;
+    if (parsed?.version !== 1 || !Array.isArray(parsed.steps)) {
+      return undefined;
+    }
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+export function saveOAuthTrace(serverName: string, trace: OAuthTrace): void {
+  localStorage.setItem(storageKey(serverName), JSON.stringify(trace));
+}
+
+export function clearOAuthTrace(serverName: string): void {
+  localStorage.removeItem(storageKey(serverName));
+}
+
+export function startOAuthTraceStep(
+  trace: OAuthTrace,
+  step: OAuthFlowStep,
+  input: {
+    message?: string;
+    details?: Record<string, unknown>;
+  } = {},
+): void {
+  const existing = trace.steps.find(
+    (entry) => entry.step === step && entry.status === "pending",
+  );
+  if (existing) {
+    existing.message = input.message ?? existing.message;
+    existing.details = input.details ?? existing.details;
+    trace.currentStep = step;
+    return;
+  }
+
+  trace.currentStep = step;
+  trace.error = undefined;
+  trace.steps.push({
+    step,
+    title: getStepInfo(step).title,
+    status: "pending",
+    message: input.message,
+    details: input.details,
+    startedAt: Date.now(),
+  });
+}
+
+export function completeOAuthTraceStep(
+  trace: OAuthTrace,
+  step: OAuthFlowStep,
+  input: {
+    message?: string;
+    details?: Record<string, unknown>;
+  } = {},
+): void {
+  const existing = [...trace.steps]
+    .reverse()
+    .find((entry) => entry.step === step && entry.status === "pending");
+
+  if (existing) {
+    existing.status = "success";
+    existing.message = input.message ?? existing.message;
+    existing.details = input.details ?? existing.details;
+    existing.completedAt = Date.now();
+  } else {
+    trace.steps.push({
+      step,
+      title: getStepInfo(step).title,
+      status: "success",
+      message: input.message,
+      details: input.details,
+      startedAt: Date.now(),
+      completedAt: Date.now(),
+    });
+  }
+
+  trace.currentStep = step;
+}
+
+export function failOAuthTraceStep(
+  trace: OAuthTrace,
+  step: OAuthFlowStep,
+  error: unknown,
+  input: {
+    message?: string;
+    details?: Record<string, unknown>;
+  } = {},
+): void {
+  const errorMessage =
+    error instanceof Error ? error.message : typeof error === "string" ? error : String(error);
+  const existing = [...trace.steps]
+    .reverse()
+    .find((entry) => entry.step === step && entry.status === "pending");
+
+  if (existing) {
+    existing.status = "error";
+    existing.message = input.message ?? existing.message;
+    existing.error = errorMessage;
+    existing.details = input.details ?? existing.details;
+    existing.completedAt = Date.now();
+  } else {
+    trace.steps.push({
+      step,
+      title: getStepInfo(step).title,
+      status: "error",
+      message: input.message,
+      error: errorMessage,
+      details: input.details,
+      startedAt: Date.now(),
+      completedAt: Date.now(),
+    });
+  }
+
+  trace.currentStep = step;
+  trace.error = errorMessage;
+}
+
+export function appendOAuthTraceHttpHistory(
+  trace: OAuthTrace,
+  entry: HttpHistoryEntry,
+): void {
+  trace.httpHistory.push(entry);
+}
+
+export function mergeOAuthTraces(
+  base: OAuthTrace | undefined,
+  next: OAuthTrace,
+): OAuthTrace {
+  if (!base) {
+    return clone(next);
+  }
+
+  return {
+    ...clone(base),
+    source: next.source,
+    serverName: next.serverName ?? base.serverName,
+    serverUrl: next.serverUrl ?? base.serverUrl,
+    currentStep: next.currentStep,
+    steps: [...base.steps, ...next.steps].sort(
+      (left, right) =>
+        left.startedAt - right.startedAt ||
+        getStepIndex(left.step) - getStepIndex(right.step),
+    ),
+    httpHistory: [...base.httpHistory, ...next.httpHistory],
+    error: next.error ?? base.error,
+  };
+}
+
+export function getOAuthTraceFailureStep(
+  trace: OAuthTrace | undefined,
+): OAuthTraceStep | undefined {
+  if (!trace) {
+    return undefined;
+  }
+
+  return [...trace.steps]
+    .reverse()
+    .find((entry) => entry.status === "error");
+}
+
+export function getOAuthTraceSummary(
+  trace: OAuthTrace | undefined,
+): string | undefined {
+  const failure = getOAuthTraceFailureStep(trace);
+  if (!failure?.error) {
+    return undefined;
+  }
+
+  return `${failure.title}: ${failure.error}`;
+}

--- a/mcpjam-inspector/client/src/state/app-reducer.ts
+++ b/mcpjam-inspector/client/src/state/app-reducer.ts
@@ -68,6 +68,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         lastConnectionTime: new Date(),
         retryCount: 0,
         lastError: undefined,
+        lastOAuthTrace: action.oauthTrace,
         oauthTokens: action.tokens,
         enabled: true,
         // Hosted workspace OAuth can succeed without browser-side tokens.
@@ -107,6 +108,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
           [action.name]: setStatus(existing, "failed", {
             retryCount: existing.retryCount,
             lastError: action.error,
+            lastOAuthTrace: action.oauthTrace,
           }),
         },
       };

--- a/mcpjam-inspector/client/src/state/app-types.ts
+++ b/mcpjam-inspector/client/src/state/app-types.ts
@@ -2,6 +2,7 @@ import type { MCPServerConfig } from "@mcpjam/sdk/browser";
 import { OauthTokens } from "@/shared/types.js";
 import type { OAuthTestProfile } from "@/lib/oauth/profile";
 import type { WorkspaceClientConfig } from "@/lib/client-config";
+import type { OAuthTrace } from "@/lib/oauth/oauth-trace";
 
 export type ConnectionStatus =
   | "connected"
@@ -41,6 +42,7 @@ export interface ServerWithName {
   connectionStatus: ConnectionStatus;
   retryCount: number;
   lastError?: string;
+  lastOAuthTrace?: OAuthTrace;
   enabled?: boolean;
   /** Whether OAuth is explicitly enabled for this server. When false, reconnect skips OAuth flow. */
   useOAuth?: boolean;
@@ -88,8 +90,14 @@ export type AppAction =
       config: MCPServerConfig;
       tokens?: OauthTokens;
       useOAuth?: boolean;
+      oauthTrace?: OAuthTrace;
     }
-  | { type: "CONNECT_FAILURE"; name: string; error: string }
+  | {
+      type: "CONNECT_FAILURE";
+      name: string;
+      error: string;
+      oauthTrace?: OAuthTrace;
+    }
   | {
       type: "RECONNECT_REQUEST";
       name: string;

--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -8,14 +8,16 @@ import {
   MCPOAuthOptions,
 } from "@/lib/oauth/mcp-oauth";
 import { ServerWithName } from "./app-types";
+import type { OAuthTrace } from "@/lib/oauth/oauth-trace";
 
 export type OAuthReady = {
   kind: "ready";
   serverConfig: any;
   tokens?: any;
+  oauthTrace?: OAuthTrace;
 };
 export type OAuthRedirect = { kind: "redirect" };
-export type OAuthError = { kind: "error"; error: string };
+export type OAuthError = { kind: "error"; error: string; oauthTrace?: OAuthTrace };
 export type OAuthResult = OAuthReady | OAuthRedirect | OAuthError;
 
 export async function ensureAuthorizedForReconnect(
@@ -49,6 +51,7 @@ export async function ensureAuthorizedForReconnect(
         kind: "ready",
         serverConfig: refreshed.serverConfig,
         tokens: getStoredTokens(server.name),
+        oauthTrace: refreshed.oauthTrace,
       };
     }
   }
@@ -85,12 +88,17 @@ export async function ensureAuthorizedForReconnect(
         kind: "ready",
         serverConfig: init.serverConfig,
         tokens: getStoredTokens(server.name),
+        oauthTrace: init.oauthTrace,
       };
     }
     if (init.success && !init.serverConfig) {
       return { kind: "redirect" };
     }
-    return { kind: "error", error: init.error || "OAuth init failed" };
+    return {
+      kind: "error",
+      error: init.error || "OAuth init failed",
+      oauthTrace: init.oauthTrace,
+    };
   }
 
   return { kind: "error", error: "OAuth refresh failed and no URL present" };


### PR DESCRIPTION
## Summary
- Replace the production browser OAuth helper path with explicit discovery, registration, PKCE, callback, and refresh steps
- Persist structured OAuth traces and surface the last failure in the connection UI
- Thread trace data through connection state and update OAuth tests for the new flow

## Testing
- Updated unit coverage for the OAuth flow to match the explicit request pipeline
- Validated trace plumbing through the connection state and UI paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Replaces the client OAuth connect/callback/refresh implementation and threads new trace data through connection state, which can affect authentication correctness and token handling. Although trace data is sanitized, it introduces new persistence and logging paths that must be reviewed for leakage and edge cases.
> 
> **Overview**
> Adds **persisted OAuth connection tracing** and surfaces it in the connection UI, including highlighting the failing OAuth step on `ServerConnectionCard` and rendering a full "Last OAuth Trace" (steps + HTTP history) in `ServerInfoContent`.
> 
> Refactors the browser OAuth implementation to use explicit SDK primitives (discovery, dynamic client registration, PKCE/start auth, code exchange, refresh) and records each stage into an `OAuthTrace` with **sanitized/redacted** request/response data; traces are saved/merged across interactive connect, callback, hosted callback, and refresh, and cleared with `clearOAuthData`.
> 
> Threads `oauthTrace` through connection orchestration and app state (`CONNECT_SUCCESS`/`CONNECT_FAILURE`, `ServerWithName.lastOAuthTrace`) and updates unit tests to mock the new SDK calls and validate behaviors like client re-registration after `invalid_client` failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae5cccb12841c6a98140365a2b8f28fca4764511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->