### PR TITLE
Oauth runner log panel

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/logger-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/logger-view.test.tsx
@@ -97,4 +97,28 @@ describe("LoggerView hosted rpc logs", () => {
       }),
     ]);
   });
+
+  it("renders oauth sequence steps as log entries", () => {
+    useTrafficLogStore.getState().addMcpServerLog({
+      id: "oauth:srv-1:interactive_connect:request_client_registration:1",
+      serverId: "srv-1",
+      serverName: "Notion",
+      direction: "OAUTH",
+      method: "Dynamic Client Registration",
+      timestamp: "2026-04-10T12:00:02.000Z",
+      payload: {
+        source: "interactive_connect",
+        step: "request_client_registration",
+        title: "Dynamic Client Registration",
+        status: "success",
+      },
+      kind: "oauth",
+      oauthStatus: "success",
+    });
+
+    render(<LoggerView serverIds={["srv-1"]} />);
+
+    expect(screen.getByText("Dynamic Client Registration")).toBeInTheDocument();
+    expect(screen.getByText("Notion")).toBeInTheDocument();
+  });
 });

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -58,6 +58,7 @@ import { useConvexAuth } from "convex/react";
 import { HOSTED_MODE } from "@/lib/config";
 import { ShareServerDialog } from "./ShareServerDialog";
 import { useExploreCasesPrefetchOnConnect } from "@/hooks/use-explore-cases-prefetch-on-connect";
+import { getOAuthTraceFailureStep } from "@/lib/oauth/oauth-trace";
 
 function isHostedInsecureHttpServer(server: ServerWithName): boolean {
   if (!HOSTED_MODE || !("url" in server.config) || !server.config.url) {
@@ -153,6 +154,7 @@ export function ServerConnectionCard({
   const hasTunnel = Boolean(tunnelUrl);
   const hasError =
     server.connectionStatus === "failed" && Boolean(server.lastError);
+  const oauthFailureStep = getOAuthTraceFailureStep(server.lastOAuthTrace);
   const isHostedHttpReconnectBlocked = isHostedInsecureHttpServer(server);
   const isPendingConnection =
     server.connectionStatus === "connecting" ||
@@ -743,6 +745,11 @@ export function ServerConnectionCard({
               className="mt-3 rounded-md border border-red-300/40 bg-red-500/10 p-2 text-xs text-red-700 dark:text-red-300"
               onClick={(e) => e.stopPropagation()}
             >
+              {oauthFailureStep ? (
+                <div className="mb-1 font-medium">
+                  OAuth failed during {oauthFailureStep.title}
+                </div>
+              ) : null}
               <div className="break-all">
                 {isErrorExpanded
                   ? server.lastError

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -380,7 +380,9 @@ export function ServerDetailModal({
                 className="mt-0 flex-none absolute inset-0 overflow-y-auto bg-background"
               >
                 <div className="pl-1 pr-6">
-                  {!isConnected ? (
+                  {!isConnected &&
+                  !server.lastError &&
+                  !server.lastOAuthTrace ? (
                     <div className="flex items-center justify-center h-full min-h-[120px] text-sm text-muted-foreground">
                       Connect to view server overview
                     </div>

--- a/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import { ServerWithName } from "@/hooks/use-app-state";
 import { getStoredTokensState } from "@/lib/oauth/mcp-oauth";
+import { getOAuthTraceFailureStep } from "@/lib/oauth/oauth-trace";
 import { decodeJWT } from "@/lib/oauth/jwt-decoder";
 import { ScrollableJsonView } from "@/components/ui/json-editor";
 
@@ -43,6 +44,8 @@ export function ServerInfoContent({
   const instructions = initializationInfo?.instructions;
   const serverCapabilities = initializationInfo?.serverCapabilities;
   const clientCapabilities = initializationInfo?.clientCapabilities;
+  const oauthTrace = server.lastOAuthTrace;
+  const oauthFailureStep = getOAuthTraceFailureStep(oauthTrace);
 
   // Build capabilities list
   const capabilities: string[] = [];
@@ -178,6 +181,87 @@ export function ServerInfoContent({
     );
   };
 
+  const renderOAuthTraceSection = () => {
+    if (!oauthTrace) {
+      return null;
+    }
+
+    return (
+      <div className="space-y-3 text-xs pt-2">
+        <div className="text-sm font-medium text-muted-foreground">
+          Last OAuth Trace
+        </div>
+        <div className="space-y-3 rounded-md bg-muted/40 p-3">
+          <div className="flex flex-wrap gap-3 text-sm text-muted-foreground">
+            <span>Source: {oauthTrace.source.replaceAll("_", " ")}</span>
+            <span>Current step: {oauthTrace.currentStep}</span>
+            {oauthFailureStep?.error ? (
+              <span className="text-destructive">
+                Failure: {oauthFailureStep.title}
+              </span>
+            ) : null}
+          </div>
+
+          <div className="space-y-2">
+            {oauthTrace.steps.map((step, index) => (
+              <div
+                key={`${step.step}-${index}-${step.startedAt}`}
+                className="rounded-md border border-border/40 bg-background/60 p-2"
+              >
+                <div className="flex flex-wrap items-center gap-2 text-sm">
+                  <span className="font-medium text-foreground">
+                    {step.title}
+                  </span>
+                  <span
+                    className={
+                      step.status === "error"
+                        ? "text-destructive"
+                        : step.status === "success"
+                          ? "text-emerald-600 dark:text-emerald-400"
+                          : "text-amber-600 dark:text-amber-400"
+                    }
+                  >
+                    {step.status}
+                  </span>
+                </div>
+                {step.message ? (
+                  <div className="mt-1 text-sm text-muted-foreground">
+                    {step.message}
+                  </div>
+                ) : null}
+                {step.error ? (
+                  <div className="mt-1 break-all text-sm text-destructive">
+                    {step.error}
+                  </div>
+                ) : null}
+                {step.details ? (
+                  <ScrollableJsonView
+                    value={step.details}
+                    showLineNumbers={false}
+                    containerClassName="mt-2 max-h-48 rounded-lg"
+                  />
+                ) : null}
+              </div>
+            ))}
+          </div>
+
+          {oauthTrace.httpHistory.length > 0 ? (
+            <div>
+              <div className="mb-2 text-sm font-medium text-muted-foreground">
+                HTTP History
+              </div>
+              <ScrollableJsonView
+                value={oauthTrace.httpHistory}
+                showLineNumbers={false}
+                containerClassName="max-h-96 rounded-lg"
+              />
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  };
+
   const renderIconRow = () => (
     <div>
       <div className="text-sm font-medium text-muted-foreground mb-1">Icon</div>
@@ -197,6 +281,16 @@ export function ServerInfoContent({
 
   return (
     <div className="space-y-4">
+      {server.lastError ? (
+        <div className="rounded-md border border-red-300/40 bg-red-500/10 p-3 text-sm text-red-700 dark:text-red-300">
+          <div className="font-medium">
+            {oauthFailureStep
+              ? `OAuth failed during ${oauthFailureStep.title}`
+              : "Last connection error"}
+          </div>
+          <div className="mt-1 break-all">{server.lastError}</div>
+        </div>
+      ) : null}
       {needsReconnect ? (
         <div className="rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-sm text-muted-foreground">
           Saved client capabilities differ from this server's last initialize
@@ -302,6 +396,7 @@ export function ServerInfoContent({
       )}
 
       {renderOAuthTokensSection()}
+      {renderOAuthTraceSection()}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/logger-view.tsx
+++ b/mcpjam-inspector/client/src/components/logger-view.tsx
@@ -18,6 +18,7 @@ import {
   SelectValue,
 } from "@mcpjam/design-system/select";
 import {
+  ingestOAuthTraceLogs,
   useTrafficLogStore,
   subscribeToRpcStream,
   type UiLogEvent,
@@ -44,7 +45,7 @@ import { Filter, Settings2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 type RpcDirection = "in" | "out" | string;
-type TrafficSource = "mcp-server" | "mcp-apps";
+type TrafficSource = "mcp-server" | "mcp-apps" | "oauth";
 
 interface RpcEventMessage {
   serverId: string;
@@ -62,6 +63,8 @@ interface RenderableRpcItem {
   timestamp: string;
   payload: unknown;
   source: TrafficSource;
+  oauthStatus?: "pending" | "success" | "error";
+  oauthRecovered?: boolean;
   protocol?: UiProtocol;
   widgetId?: string;
 }
@@ -113,15 +116,47 @@ function getDisplayServerTitle(item: {
 function DirectionLabel({
   direction,
   source,
+  oauthStatus,
+  oauthRecovered,
 }: {
   direction: string;
   source: TrafficSource;
+  oauthStatus?: "pending" | "success" | "error";
+  oauthRecovered?: boolean;
 }) {
   if (source === "mcp-apps") {
     const isHostToUi = direction === "HOST→UI";
     return (
       <span className="font-mono text-[10px] leading-none flex-shrink-0 text-purple-500">
         {isHostToUi ? "host → view" : "view → host"}
+      </span>
+    );
+  }
+
+  if (source === "oauth") {
+    const className = oauthRecovered
+      ? "text-amber-600 dark:text-amber-400"
+      : oauthStatus === "error"
+        ? "text-destructive"
+        : oauthStatus === "pending"
+          ? "text-muted-foreground"
+          : "text-orange-600 dark:text-orange-400";
+    const label = oauthRecovered
+      ? "oauth ↺"
+      : oauthStatus === "error"
+        ? "oauth !"
+        : oauthStatus === "pending"
+          ? "oauth …"
+          : "oauth ✓";
+
+    return (
+      <span
+        className={cn(
+          "font-mono text-[10px] leading-none flex-shrink-0",
+          className,
+        )}
+      >
+        {label}
       </span>
     );
   }
@@ -164,6 +199,20 @@ export function LoggerView({
   const mcpServerRpcItems = useTrafficLogStore((s) => s.mcpServerItems);
   const clearLogs = useTrafficLogStore((s) => s.clear);
 
+  useEffect(() => {
+    Object.entries(appState.servers).forEach(([serverId, server]) => {
+      if (!server.lastOAuthTrace) {
+        return;
+      }
+
+      ingestOAuthTraceLogs({
+        serverId,
+        serverName: server.name,
+        trace: server.lastOAuthTrace,
+      });
+    });
+  }, [appState.servers]);
+
   // Convert UI log items to renderable format
   const mcpAppsItems = useMemo<RenderableRpcItem[]>(() => {
     return uiLogItems.map((item: UiLogEvent) => ({
@@ -190,7 +239,12 @@ export function LoggerView({
       method: item.method,
       timestamp: item.timestamp,
       payload: item.payload,
-      source: "mcp-server" as TrafficSource,
+      source:
+        item.kind === "oauth"
+          ? ("oauth" as TrafficSource)
+          : ("mcp-server" as TrafficSource),
+      oauthStatus: item.oauthStatus,
+      oauthRecovered: item.oauthRecovered,
     }));
   }, [mcpServerRpcItems]);
 
@@ -351,6 +405,9 @@ export function LoggerView({
                     >
                       Server
                     </DropdownMenuRadioItem>
+                    <DropdownMenuRadioItem value="oauth" className="text-xs">
+                      OAuth
+                    </DropdownMenuRadioItem>
                     <DropdownMenuRadioItem value="mcp-apps" className="text-xs">
                       Apps
                     </DropdownMenuRadioItem>
@@ -492,16 +549,21 @@ export function LoggerView({
             {filteredItems.map((it) => {
               const isExpanded = expanded.has(it.id);
               const isAppsTraffic = it.source === "mcp-apps";
+              const isOAuthTraffic = it.source === "oauth";
 
               const isError =
-                it.method === "error" || it.method === "csp-violation";
+                it.method === "error" ||
+                it.method === "csp-violation" ||
+                (isOAuthTraffic && it.oauthStatus === "error");
 
               // Left border: 2px — red for errors, purple for Apps, transparent for MCP Server
               const borderClass = isError
                 ? "border-l-destructive"
                 : isAppsTraffic
                   ? "border-l-purple-500/50"
-                  : "border-l-transparent";
+                  : isOAuthTraffic
+                    ? "border-l-orange-300/60"
+                    : "border-l-transparent";
 
               return (
                 <div
@@ -529,6 +591,8 @@ export function LoggerView({
                       <DirectionLabel
                         direction={it.direction}
                         source={it.source}
+                        oauthStatus={it.oauthStatus}
+                        oauthRecovered={it.oauthRecovered}
                       />
                     )}
                     <span

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -28,6 +28,7 @@ import {
   clearOAuthData,
   initiateOAuth,
 } from "@/lib/oauth/mcp-oauth";
+import type { OAuthTrace } from "@/lib/oauth/oauth-trace";
 import {
   clearHostedOAuthPendingState,
   getHostedOAuthCallbackContext,
@@ -220,13 +221,14 @@ export function useServerState({
   };
 
   const failPendingOAuthConnection = useCallback(
-    (errorMessage: string) => {
+    (errorMessage: string, oauthTrace?: OAuthTrace) => {
       const pendingServerName = localStorage.getItem("mcp-oauth-pending");
       if (pendingServerName) {
         dispatch({
           type: "CONNECT_FAILURE",
           name: pendingServerName,
           error: errorMessage,
+          oauthTrace,
         });
       }
 
@@ -734,6 +736,7 @@ export function useServerState({
                     ? undefined
                     : getStoredTokens(serverName),
                   useOAuth: true,
+                  oauthTrace: result.oauthTrace,
                 });
                 logger.info("OAuth connection successful", { serverName });
                 toast.success(
@@ -753,6 +756,7 @@ export function useServerState({
                 error:
                   connectionResult.error ||
                   "Connection test failed after OAuth",
+                oauthTrace: result.oauthTrace,
               });
               logger.error("OAuth connection test failed", {
                 serverName,
@@ -771,6 +775,7 @@ export function useServerState({
               type: "CONNECT_FAILURE",
               name: serverName,
               error: errorMessage,
+              oauthTrace: result.oauthTrace,
             });
             logger.error("OAuth connection test error", {
               serverName,
@@ -781,15 +786,30 @@ export function useServerState({
             );
           }
         } else {
-          throw new Error(result.error || "OAuth callback failed");
+          throw {
+            message: result.error || "OAuth callback failed",
+            oauthTrace: result.oauthTrace,
+          };
         }
       } catch (error) {
         const errorMessage =
-          error instanceof Error ? error.message : "Unknown error";
+          error instanceof Error
+            ? error.message
+            : typeof error === "object" &&
+                error !== null &&
+                "message" in error &&
+                typeof (error as { message?: unknown }).message === "string"
+              ? ((error as { message: string }).message)
+              : "Unknown error";
         toast.error(`Error completing OAuth flow: ${errorMessage}`);
         logger.error("OAuth callback failed", { error: errorMessage });
+        const oauthTrace =
+          typeof error === "object" && error !== null && "oauthTrace" in error
+            ? ((error as { oauthTrace?: OAuthTrace }).oauthTrace)
+            : undefined;
         const failedServerName =
-          failPendingOAuthConnection(errorMessage) ?? pendingServerName;
+          failPendingOAuthConnection(errorMessage, oauthTrace) ??
+          pendingServerName;
         if (failedServerName) {
           logger.warn("Marked pending OAuth connection as failed", {
             serverName: failedServerName,
@@ -1078,6 +1098,7 @@ export function useServerState({
                       ? undefined
                       : getStoredTokens(formData.name),
                   useOAuth: true,
+                  oauthTrace: oauthResult.oauthTrace,
                 });
                 toast.success("Connected successfully with OAuth!");
                 storeInitInfo(formData.name, connectionResult.initInfo).catch(
@@ -1093,6 +1114,7 @@ export function useServerState({
                   name: formData.name,
                   error:
                     connectionResult.error || "OAuth connection test failed",
+                  oauthTrace: oauthResult.oauthTrace,
                 });
                 toast.error(
                   `OAuth succeeded but connection failed: ${connectionResult.error}`,
@@ -1111,6 +1133,7 @@ export function useServerState({
             type: "CONNECT_FAILURE",
             name: formData.name,
             error: oauthResult.error || "OAuth initialization failed",
+            oauthTrace: oauthResult.oauthTrace,
           });
           toast.error(`OAuth initialization failed: ${oauthResult.error}`);
           return;
@@ -1705,6 +1728,7 @@ export function useServerState({
           type: "CONNECT_FAILURE",
           name: serverName,
           error: errorMessage,
+          oauthTrace: authResult.kind === "ready" ? authResult.oauthTrace : undefined,
         });
         logger.error("Reconnection failed", {
           serverName,
@@ -1775,6 +1799,7 @@ export function useServerState({
             type: "CONNECT_FAILURE",
             name: serverName,
             error: errorMessage,
+            oauthTrace: oauthResult.oauthTrace,
           });
           reportError(`OAuth failed: ${serverName}`);
           return {
@@ -1802,6 +1827,7 @@ export function useServerState({
                 ? undefined
                 : getStoredTokens(serverName),
             useOAuth: true,
+            oauthTrace: oauthResult.oauthTrace,
           });
           logger.info("Reconnection with fresh OAuth successful", {
             serverName,
@@ -1816,6 +1842,7 @@ export function useServerState({
           type: "CONNECT_FAILURE",
           name: serverName,
           error: errorMessage,
+          oauthTrace: oauthResult.oauthTrace,
         });
         reportError(errorMessage);
         return {
@@ -1942,6 +1969,7 @@ export function useServerState({
             type: "CONNECT_FAILURE",
             name: serverName,
             error: authResult.error,
+            oauthTrace: authResult.oauthTrace,
           });
           reportError(`Failed to connect: ${serverName}`);
           return {
@@ -1966,6 +1994,7 @@ export function useServerState({
             config: authResult.serverConfig,
             tokens: authResult.tokens,
             useOAuth: server.useOAuth === true || authResult.tokens != null,
+            oauthTrace: authResult.oauthTrace,
           });
           logger.info("Reconnection successful", { serverName, result });
           storeInitInfo(serverName, result.initInfo).catch((err) =>
@@ -1978,6 +2007,7 @@ export function useServerState({
           type: "CONNECT_FAILURE",
           name: serverName,
           error: errorMessage,
+          oauthTrace: authResult.oauthTrace,
         });
         logger.error("Reconnection failed", { serverName, result });
         reportError(errorMessage || `Failed to reconnect: ${serverName}`);

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1064,6 +1064,8 @@ export function useServerState({
           });
 
           const oauthInputs = await resolveOAuthInitiationInputs(formData);
+          const existingOAuthProfile =
+            appState.servers[formData.name]?.oauthFlowProfile;
           const oauthOptions: any = {
             serverName: formData.name,
             serverUrl: formData.url,
@@ -1071,6 +1073,9 @@ export function useServerState({
             clientSecret: oauthInputs.clientSecret,
             registryServerId: oauthInputs.registryServerId,
             useRegistryOAuthProxy: oauthInputs.useRegistryOAuthProxy,
+            customHeaders: formData.headers,
+            protocolVersion: existingOAuthProfile?.protocolVersion,
+            registrationStrategy: existingOAuthProfile?.registrationStrategy,
           };
           if (oauthInputs.scopes && oauthInputs.scopes.length > 0) {
             oauthOptions.scopes = oauthInputs.scopes;
@@ -1208,6 +1213,7 @@ export function useServerState({
     [
       dispatch,
       isAuthenticated,
+      appState.servers,
       appState.workspaces,
       appState.activeWorkspaceId,
       notifyIfClientConfigSyncPending,
@@ -1778,6 +1784,14 @@ export function useServerState({
         const oauthResult = await initiateOAuth({
           serverName,
           serverUrl,
+          customHeaders:
+            "requestInit" in server.config &&
+            server.config.requestInit?.headers &&
+            !Array.isArray(server.config.requestInit.headers)
+              ? (server.config.requestInit.headers as Record<string, string>)
+              : undefined,
+          protocolVersion: server.oauthFlowProfile?.protocolVersion,
+          registrationStrategy: server.oauthFlowProfile?.registrationStrategy,
         });
 
         if (oauthResult.success && !oauthResult.serverConfig) {

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -1728,7 +1728,6 @@ export function useServerState({
           type: "CONNECT_FAILURE",
           name: serverName,
           error: errorMessage,
-          oauthTrace: authResult.kind === "ready" ? authResult.oauthTrace : undefined,
         });
         logger.error("Reconnection failed", {
           serverName,

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -741,6 +741,60 @@ describe("mcp-oauth", () => {
       );
     });
 
+    it("re-registers the OAuth client after invalid_client refresh failures", async () => {
+      localStorage.setItem(
+        "mcp-serverUrl-asana",
+        "https://mcp.asana.com/v2/mcp",
+      );
+      localStorage.setItem(
+        "mcp-client-asana",
+        JSON.stringify({
+          client_id: "stale-client-id",
+        }),
+      );
+      localStorage.setItem(
+        "mcp-tokens-asana",
+        JSON.stringify({
+          access_token: "old-access-token",
+          refresh_token: "stored-refresh-token",
+          token_type: "Bearer",
+        }),
+      );
+
+      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(createAsanaDiscoveryState());
+      mockFetchToken.mockRejectedValueOnce(
+        Object.assign(new Error("Client authentication failed"), {
+          code: "invalid_client",
+        }),
+      );
+      mockRegisterClient.mockResolvedValueOnce({
+        client_id: "new-client-id",
+      });
+      mockStartAuthorization.mockResolvedValueOnce({
+        authorizationUrl: new URL("https://app.asana.com/-/oauth_authorize"),
+        codeVerifier: "fresh-verifier",
+      });
+
+      const [{ getOAuthTraceFailureStep }, { initiateOAuth }] =
+        await Promise.all([
+          import("../oauth-trace"),
+          import("../mcp-oauth"),
+        ]);
+
+      const result = await initiateOAuth({
+        serverName: "asana",
+        serverUrl: "https://mcp.asana.com/v2/mcp",
+      });
+
+      expect(result.success).toBe(true);
+      expect(localStorage.getItem("mcp-client-asana")).toBe(
+        JSON.stringify({
+          client_id: "new-client-id",
+        }),
+      );
+      expect(getOAuthTraceFailureStep(result.oauthTrace)).toBeUndefined();
+    });
+
     it("preserves the original callback error and verifier when registry token exchange fails", async () => {
       authFetch.mockImplementationOnce(async (input: RequestInfo | URL) => {
         const url =

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -9,25 +9,31 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockDiscoverAuthorizationServerMetadata,
   mockDiscoverOAuthServerInfo,
+  mockExchangeAuthorization,
   mockFetchToken,
   mockGetConvexSiteUrl,
-  mockSdkAuth,
+  mockRegisterClient,
   mockSelectResourceURL,
+  mockStartAuthorization,
 } = vi.hoisted(() => ({
   mockDiscoverAuthorizationServerMetadata: vi.fn(),
   mockDiscoverOAuthServerInfo: vi.fn(),
+  mockExchangeAuthorization: vi.fn(),
   mockFetchToken: vi.fn(),
   mockGetConvexSiteUrl: vi.fn(),
-  mockSdkAuth: vi.fn(),
+  mockRegisterClient: vi.fn(),
   mockSelectResourceURL: vi.fn(),
+  mockStartAuthorization: vi.fn(),
 }));
 
 vi.mock("@mcpjam/sdk/browser", () => ({
-  auth: mockSdkAuth,
   discoverAuthorizationServerMetadata: mockDiscoverAuthorizationServerMetadata,
   discoverOAuthServerInfo: mockDiscoverOAuthServerInfo,
+  exchangeAuthorization: mockExchangeAuthorization,
   fetchToken: mockFetchToken,
+  registerClient: mockRegisterClient,
   selectResourceURL: mockSelectResourceURL,
+  startAuthorization: mockStartAuthorization,
 }));
 
 vi.mock("@/lib/session-token", () => ({
@@ -112,18 +118,43 @@ describe("mcp-oauth", () => {
     sessionStorage.clear();
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
-    mockSdkAuth.mockReset();
     mockDiscoverAuthorizationServerMetadata.mockReset();
     mockDiscoverOAuthServerInfo.mockReset();
+    mockExchangeAuthorization.mockReset();
     mockFetchToken.mockReset();
     mockGetConvexSiteUrl.mockReset();
+    mockRegisterClient.mockReset();
     mockGetConvexSiteUrl.mockReturnValue("https://test.convex.site");
     mockSelectResourceURL.mockReset();
+    mockStartAuthorization.mockReset();
+
+    mockDiscoverOAuthServerInfo.mockResolvedValue(createDiscoveryState());
+    mockDiscoverAuthorizationServerMetadata.mockResolvedValue(
+      createDiscoveryState().authorizationServerMetadata,
+    );
+    mockRegisterClient.mockResolvedValue({
+      client_id: "registered-client-id",
+    });
+    mockStartAuthorization.mockResolvedValue({
+      authorizationUrl: new URL("https://auth.example.com/authorize"),
+      codeVerifier: "test-verifier",
+    });
+    mockExchangeAuthorization.mockResolvedValue({
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      token_type: "Bearer",
+    });
 
     const sessionToken = await import("@/lib/session-token");
     authFetch = sessionToken.authFetch as ReturnType<typeof vi.fn>;
     authFetch.mockReset();
     mockSelectResourceURL.mockResolvedValue(undefined);
+
+    const oauthModule = await import("../mcp-oauth");
+    vi.spyOn(
+      oauthModule.MCPOAuthProvider.prototype,
+      "redirectToAuthorization",
+    ).mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -141,10 +172,15 @@ describe("mcp-oauth", () => {
     serverName: string = "asana",
     serverUrl: string = "https://mcp.asana.com/v2/mcp",
   ) {
-    mockSdkAuth.mockImplementationOnce(async (provider) => {
-      await provider.saveDiscoveryState?.(discoveryState);
-      await provider.saveCodeVerifier("test-verifier");
-      return "REDIRECT";
+    mockDiscoverOAuthServerInfo.mockResolvedValueOnce(discoveryState);
+    mockRegisterClient.mockResolvedValueOnce({
+      client_id: `${serverName}-client-id`,
+    });
+    mockStartAuthorization.mockResolvedValueOnce({
+      authorizationUrl: new URL(
+        `${discoveryState.authorizationServerMetadata.authorization_endpoint}?state=mock-state`,
+      ),
+      codeVerifier: "test-verifier",
     });
 
     const { initiateOAuth } = await import("../mcp-oauth");
@@ -155,7 +191,7 @@ describe("mcp-oauth", () => {
       useRegistryOAuthProxy,
     });
 
-    expect(result).toEqual({ success: true });
+    expect(result.success).toBe(true);
     return discoveryState;
   }
 
@@ -174,14 +210,17 @@ describe("mcp-oauth", () => {
         },
       );
       authFetch.mockResolvedValue(authErrorResponse);
-      mockSdkAuth.mockImplementation(async () => {
-        const response = await window.fetch(
+      mockDiscoverOAuthServerInfo.mockImplementation(async (_serverUrl, options) => {
+        const response = await options?.fetchFn?.(
           "https://example.com/.well-known/oauth-protected-resource/mcp",
         );
+        if (!response) {
+          throw new Error("Missing OAuth fetch function");
+        }
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
-        return "AUTHORIZED";
+        return createDiscoveryState();
       });
 
       const { initiateOAuth } = await import("../mcp-oauth");
@@ -206,14 +245,17 @@ describe("mcp-oauth", () => {
         },
       );
       authFetch.mockResolvedValue(authErrorResponse);
-      mockSdkAuth.mockImplementation(async () => {
-        const response = await window.fetch(
+      mockDiscoverOAuthServerInfo.mockImplementation(async (_serverUrl, options) => {
+        const response = await options?.fetchFn?.(
           "https://example.com/.well-known/oauth-protected-resource/mcp",
         );
+        if (!response) {
+          throw new Error("Missing OAuth fetch function");
+        }
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}`);
         }
-        return "AUTHORIZED";
+        return createDiscoveryState();
       });
 
       const { initiateOAuth } = await import("../mcp-oauth");
@@ -233,12 +275,15 @@ describe("mcp-oauth", () => {
         { status: 200 },
       );
       authFetch.mockResolvedValue(metadataResponse);
-      mockSdkAuth.mockImplementation(async (_provider: any, options: any) => {
-        const response = await options.fetchFn(
+      mockDiscoverOAuthServerInfo.mockImplementation(async (_serverUrl, options) => {
+        const response = await options?.fetchFn?.(
           "https://example.com/.well-known/oauth-protected-resource/mcp",
         );
+        if (!response) {
+          throw new Error("Missing OAuth fetch function");
+        }
         expect(response.ok).toBe(true);
-        return "REDIRECT";
+        return createDiscoveryState();
       });
 
       const { initiateOAuth } = await import("../mcp-oauth");
@@ -268,7 +313,8 @@ describe("mcp-oauth", () => {
           },
         }),
       );
-      mockSdkAuth.mockImplementationOnce(async (_provider, options) => {
+      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(createLinearDiscoveryState());
+      mockRegisterClient.mockImplementationOnce(async (_authServerUrl, options) => {
         const registrationBody = JSON.stringify({
           client_name: "MCPJam - Linear",
           redirect_uris: [`${window.location.origin}/oauth/callback`],
@@ -286,7 +332,7 @@ describe("mcp-oauth", () => {
           },
         );
         expect(response.ok).toBe(true);
-        return "REDIRECT";
+        return await response.json();
       });
 
       const { initiateOAuth } = await import("../mcp-oauth");
@@ -484,15 +530,14 @@ describe("mcp-oauth", () => {
 
     it("reuses cached discovery state after the callback reload", async () => {
       const discoveryState = createDiscoveryState();
-      mockSdkAuth.mockImplementationOnce(async (provider) => {
-        await provider.saveDiscoveryState?.(discoveryState);
-        await provider.saveCodeVerifier("code-verifier");
-        return "REDIRECT";
+      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(discoveryState);
+      mockStartAuthorization.mockResolvedValueOnce({
+        authorizationUrl: new URL("https://auth.example.com/authorize"),
+        codeVerifier: "code-verifier",
       });
-      mockFetchToken.mockImplementationOnce(async (provider, _url, options) => {
+      mockExchangeAuthorization.mockImplementationOnce(async (_url, options) => {
         expect(options?.authorizationCode).toBe("oauth-code");
-        expect(provider.discoveryState?.()).toEqual(discoveryState);
-        expect(provider.codeVerifier()).toBe("code-verifier");
+        expect(options?.codeVerifier).toBe("code-verifier");
         return {
           access_token: "access-token",
           refresh_token: "refresh-token",
@@ -507,7 +552,7 @@ describe("mcp-oauth", () => {
         serverName: "asana",
         serverUrl: "https://mcp.asana.com/sse",
       });
-      expect(initiateResult).toEqual({ success: true });
+      expect(initiateResult.success).toBe(true);
 
       const callbackResult = await handleOAuthCallback("oauth-code");
 
@@ -518,8 +563,8 @@ describe("mcp-oauth", () => {
       });
       expect(getStoredTokens("asana")?.access_token).toBe("access-token");
       expect(localStorage.getItem("mcp-discovery-asana")).not.toBeNull();
-      expect(mockSdkAuth).toHaveBeenCalledTimes(1);
-      expect(mockFetchToken).toHaveBeenCalledTimes(1);
+      expect(mockDiscoverOAuthServerInfo).toHaveBeenCalledTimes(1);
+      expect(mockExchangeAuthorization).toHaveBeenCalledTimes(1);
     });
 
     it("treats malformed stored token data as invalid instead of throwing", async () => {
@@ -558,8 +603,8 @@ describe("mcp-oauth", () => {
 
       const discoveryState = createAsanaDiscoveryState();
       await seedPendingOAuth("registry-asana", discoveryState, true);
-      mockFetchToken.mockImplementationOnce(
-        async (provider, authServerUrl, options) => {
+      mockExchangeAuthorization.mockImplementationOnce(
+        async (authServerUrl, options) => {
           expect(authServerUrl).toBe("https://app.asana.com");
           expect(options?.metadata?.token_endpoint).toBe(
             "https://app.asana.com/-/oauth_token",
@@ -571,8 +616,8 @@ describe("mcp-oauth", () => {
               body: new URLSearchParams({
                 grant_type: "authorization_code",
                 code: options!.authorizationCode!,
-                code_verifier: provider.codeVerifier(),
-                redirect_uri: String(provider.redirectUrl),
+                code_verifier: options!.codeVerifier,
+                redirect_uri: String(options!.redirectUri),
               }),
             },
           );
@@ -639,7 +684,9 @@ describe("mcp-oauth", () => {
         throw new Error(`Unexpected direct fetch to ${url}`);
       });
 
-      mockSdkAuth.mockImplementationOnce(async (_provider, options) => {
+      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(createAsanaDiscoveryState());
+      mockFetchToken.mockImplementationOnce(async (_provider, authServerUrl, options) => {
+        expect(authServerUrl).toBe("https://app.asana.com");
         const response = await options.fetchFn!(
           "https://app.asana.com/-/oauth_token",
           {
@@ -650,9 +697,7 @@ describe("mcp-oauth", () => {
             }),
           },
         );
-        const tokens = await response.json();
-        await _provider.saveTokens(tokens);
-        return "AUTHORIZED";
+        return await response.json();
       });
 
       localStorage.setItem(
@@ -719,8 +764,8 @@ describe("mcp-oauth", () => {
       });
 
       await seedPendingOAuth("registry-asana", undefined, true);
-      mockFetchToken.mockImplementationOnce(
-        async (provider, _authServerUrl, options) => {
+      mockExchangeAuthorization.mockImplementationOnce(
+        async (_authServerUrl, options) => {
           const response = await options!.fetchFn!(
             "https://app.asana.com/-/oauth_token",
             {
@@ -728,8 +773,8 @@ describe("mcp-oauth", () => {
               body: new URLSearchParams({
                 grant_type: "authorization_code",
                 code: options!.authorizationCode!,
-                code_verifier: provider.codeVerifier(),
-                redirect_uri: String(provider.redirectUrl),
+                code_verifier: options!.codeVerifier,
+                redirect_uri: String(options!.redirectUri),
               }),
             },
           );
@@ -768,8 +813,8 @@ describe("mcp-oauth", () => {
           },
         }),
       );
-      mockFetchToken.mockImplementationOnce(
-        async (provider, _authServerUrl, options) => {
+      mockExchangeAuthorization.mockImplementationOnce(
+        async (_authServerUrl, options) => {
           const response = await options!.fetchFn!(
             "https://app.asana.com/-/oauth_token",
             {
@@ -777,8 +822,8 @@ describe("mcp-oauth", () => {
               body: new URLSearchParams({
                 grant_type: "authorization_code",
                 code: options!.authorizationCode!,
-                code_verifier: provider.codeVerifier(),
-                redirect_uri: String(provider.redirectUrl),
+                code_verifier: options!.codeVerifier,
+                redirect_uri: String(options!.redirectUri),
               }),
             },
           );
@@ -833,8 +878,8 @@ describe("mcp-oauth", () => {
           },
         }),
       );
-      mockFetchToken.mockImplementationOnce(
-        async (provider, _authServerUrl, options) => {
+      mockExchangeAuthorization.mockImplementationOnce(
+        async (_authServerUrl, options) => {
           const response = await options!.fetchFn!(
             "https://app.asana.com/-/oauth_token",
             {
@@ -842,8 +887,8 @@ describe("mcp-oauth", () => {
               body: new URLSearchParams({
                 grant_type: "authorization_code",
                 code: options!.authorizationCode!,
-                code_verifier: provider.codeVerifier(),
-                redirect_uri: String(provider.redirectUrl),
+                code_verifier: options!.codeVerifier,
+                redirect_uri: String(options!.redirectUri),
               }),
             },
           );
@@ -902,8 +947,8 @@ describe("mcp-oauth", () => {
           },
         }),
       );
-      mockFetchToken.mockImplementationOnce(
-        async (provider, _authServerUrl, options) => {
+      mockExchangeAuthorization.mockImplementationOnce(
+        async (_authServerUrl, options) => {
           const response = await options!.fetchFn!(
             "https://mcp.linear.app/token",
             {
@@ -911,8 +956,8 @@ describe("mcp-oauth", () => {
               body: new URLSearchParams({
                 grant_type: "authorization_code",
                 code: options!.authorizationCode!,
-                code_verifier: provider.codeVerifier(),
-                redirect_uri: String(provider.redirectUrl),
+                code_verifier: options!.codeVerifier,
+                redirect_uri: String(options!.redirectUri),
               }),
             },
           );
@@ -963,7 +1008,8 @@ describe("mcp-oauth", () => {
         }),
       );
 
-      mockSdkAuth.mockImplementationOnce(async (_provider, options) => {
+      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(createLinearDiscoveryState());
+      mockFetchToken.mockImplementationOnce(async (_provider, _authServerUrl, options) => {
         const response = await options.fetchFn!(
           "https://mcp.linear.app/token",
           {
@@ -974,9 +1020,7 @@ describe("mcp-oauth", () => {
             }),
           },
         );
-        const tokens = await response.json();
-        await _provider.saveTokens(tokens);
-        return "AUTHORIZED";
+        return await response.json();
       });
 
       localStorage.setItem(

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -26,15 +26,21 @@ const {
   mockStartAuthorization: vi.fn(),
 }));
 
-vi.mock("@mcpjam/sdk/browser", () => ({
-  discoverAuthorizationServerMetadata: mockDiscoverAuthorizationServerMetadata,
-  discoverOAuthServerInfo: mockDiscoverOAuthServerInfo,
-  exchangeAuthorization: mockExchangeAuthorization,
-  fetchToken: mockFetchToken,
-  registerClient: mockRegisterClient,
-  selectResourceURL: mockSelectResourceURL,
-  startAuthorization: mockStartAuthorization,
-}));
+vi.mock("@mcpjam/sdk/browser", async () => {
+  const actual = await vi.importActual<typeof import("@mcpjam/sdk/browser")>(
+    "@mcpjam/sdk/browser",
+  );
+  return {
+    ...actual,
+    discoverAuthorizationServerMetadata: mockDiscoverAuthorizationServerMetadata,
+    discoverOAuthServerInfo: mockDiscoverOAuthServerInfo,
+    exchangeAuthorization: mockExchangeAuthorization,
+    fetchToken: mockFetchToken,
+    registerClient: mockRegisterClient,
+    selectResourceURL: mockSelectResourceURL,
+    startAuthorization: mockStartAuthorization,
+  };
+});
 
 vi.mock("@/lib/session-token", () => ({
   authFetch: vi.fn(),

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -1,17 +1,22 @@
 /**
- * Clean OAuth implementation using only the official MCP SDK with CORS proxy support
+ * Production OAuth implementation using explicit SDK primitives with trace support.
  */
 
 import {
-  auth,
   discoverAuthorizationServerMetadata,
   discoverOAuthServerInfo,
+  exchangeAuthorization,
   fetchToken,
+  registerClient,
   selectResourceURL,
+  startAuthorization,
 } from "@mcpjam/sdk/browser";
 import type {
+  HttpHistoryEntry,
+  OAuthClientInformation,
   OAuthClientProvider,
   OAuthDiscoveryState,
+  OAuthTokens,
 } from "@mcpjam/sdk/browser";
 import type { HttpServerConfig } from "@mcpjam/sdk/browser";
 import { generateRandomString } from "./pkce";
@@ -21,6 +26,18 @@ import { captureServerDetailModalOAuthResume } from "@/lib/server-detail-modal-r
 import type { HostedOAuthCallbackContext } from "@/lib/hosted-oauth-callback";
 import { getRedirectUri } from "./constants";
 import { getConvexSiteUrl } from "@/lib/convex-site-url";
+import {
+  appendOAuthTraceHttpHistory,
+  clearOAuthTrace,
+  completeOAuthTraceStep,
+  createOAuthTrace,
+  failOAuthTraceStep,
+  loadOAuthTrace,
+  mergeOAuthTraces,
+  saveOAuthTrace,
+  startOAuthTraceStep,
+  type OAuthTrace,
+} from "./oauth-trace";
 
 // Store original fetch for restoration
 const originalFetch = window.fetch;
@@ -56,6 +73,79 @@ function clearStoredDiscoveryState(serverName: string): void {
 }
 
 type OAuthRequestFields = Record<string, string>;
+
+const SENSITIVE_FIELD_NAMES = new Set([
+  "access_token",
+  "refresh_token",
+  "id_token",
+  "client_secret",
+  "code",
+  "code_verifier",
+  "authorization",
+]);
+
+function redactSensitiveValue(value: unknown): string {
+  if (typeof value !== "string") {
+    return "[redacted]";
+  }
+
+  if (value.length <= 8) {
+    return "[redacted]";
+  }
+
+  return `${value.slice(0, 4)}...[redacted]...${value.slice(-2)}`;
+}
+
+function sanitizeOAuthTraceValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeOAuthTraceValue(item));
+  }
+
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entryValue]) => {
+      if (SENSITIVE_FIELD_NAMES.has(key.toLowerCase())) {
+        return [key, redactSensitiveValue(entryValue)];
+      }
+      return [key, sanitizeOAuthTraceValue(entryValue)];
+    }),
+  );
+}
+
+function sanitizeOAuthHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => {
+      if (SENSITIVE_FIELD_NAMES.has(key.toLowerCase())) {
+        return [key, redactSensitiveValue(value)];
+      }
+      return [key, value];
+    }),
+  );
+}
+
+function createHttpHistoryEntry(input: {
+  step: HttpHistoryEntry["step"];
+  method: string;
+  url: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+}): HttpHistoryEntry {
+  return {
+    step: input.step,
+    timestamp: Date.now(),
+    request: {
+      method: input.method,
+      url: input.url,
+      headers: sanitizeOAuthHeaders(input.headers ?? {}),
+      body: sanitizeOAuthTraceValue(input.body),
+    },
+  };
+}
 
 export function readStoredOAuthConfig(
   serverName: string | null,
@@ -295,6 +385,7 @@ async function loadCallbackDiscoveryState(
  */
 function createOAuthFetchInterceptor(
   routingConfig: OAuthRoutingConfig = {},
+  trace?: OAuthTrace,
 ): typeof fetch {
   return async function interceptedFetch(
     input: RequestInfo | URL,
@@ -330,6 +421,30 @@ function createOAuthFetchInterceptor(
       return await originalFetch(input, init);
     }
 
+    const traceStep =
+      oauthGrantType === "authorization_code" ||
+      oauthGrantType === "refresh_token"
+        ? "token_request"
+        : url.includes("/register")
+          ? "request_client_registration"
+          : url.includes("oauth-protected-resource")
+            ? "request_resource_metadata"
+            : url.includes("/.well-known/")
+              ? "request_authorization_server_metadata"
+              : "authorization_request";
+    const entry = createHttpHistoryEntry({
+      step: traceStep,
+      method,
+      url,
+      headers: init?.headers
+        ? Object.fromEntries(new Headers(init.headers as HeadersInit))
+        : {},
+      body: serializedBody,
+    });
+    if (trace) {
+      appendOAuthTraceHttpHistory(trace, entry);
+    }
+
     // For registry servers, route token exchange/refresh through Convex HTTP actions
     if (isRegistryTokenRequest) {
       const convexSiteUrl = getConvexSiteUrl();
@@ -348,6 +463,15 @@ function createOAuthFetchInterceptor(
             ),
           ),
         });
+        entry.response = {
+          status: response.status,
+          statusText: response.statusText,
+          headers: sanitizeOAuthHeaders(
+            Object.fromEntries(response.headers.entries()),
+          ),
+          body: sanitizeOAuthTraceValue(await response.clone().json().catch(() => null)),
+        };
+        entry.duration = Date.now() - entry.timestamp;
         return response;
       }
     }
@@ -361,7 +485,17 @@ function createOAuthFetchInterceptor(
         : `${proxyBase}/proxy`;
 
       if (isMetadata) {
-        return await authFetch(proxyUrl, { ...init, method: "GET" });
+        const response = await authFetch(proxyUrl, { ...init, method: "GET" });
+        entry.response = {
+          status: response.status,
+          statusText: response.statusText,
+          headers: sanitizeOAuthHeaders(
+            Object.fromEntries(response.headers.entries()),
+          ),
+          body: sanitizeOAuthTraceValue(await response.clone().json().catch(() => null)),
+        };
+        entry.duration = Date.now() - entry.timestamp;
+        return response;
       }
 
       // For OAuth endpoints, serialize and proxy the full request
@@ -380,16 +514,36 @@ function createOAuthFetchInterceptor(
 
       // If the proxy call itself failed (e.g., auth error), return that response directly
       if (!response.ok) {
+        entry.response = {
+          status: response.status,
+          statusText: response.statusText,
+          headers: sanitizeOAuthHeaders(
+            Object.fromEntries(response.headers.entries()),
+          ),
+          body: sanitizeOAuthTraceValue(await response.clone().json().catch(() => null)),
+        };
+        entry.duration = Date.now() - entry.timestamp;
         return response;
       }
 
       const data = await response.json();
+      entry.response = {
+        status: data.status,
+        statusText: data.statusText,
+        headers: sanitizeOAuthHeaders(data.headers ?? {}),
+        body: sanitizeOAuthTraceValue(data.body),
+      };
+      entry.duration = Date.now() - entry.timestamp;
       return new Response(JSON.stringify(data.body), {
         status: data.status,
         statusText: data.statusText,
         headers: new Headers(data.headers),
       });
     } catch (error) {
+      entry.error = {
+        message: error instanceof Error ? error.message : String(error),
+      };
+      entry.duration = Date.now() - entry.timestamp;
       console.error("OAuth proxy failed, falling back to direct fetch:", error);
       return await originalFetch(input, init);
     }
@@ -437,12 +591,15 @@ export interface OAuthResult {
   success: boolean;
   serverConfig?: HttpServerConfig;
   error?: string;
+  oauthTrace?: OAuthTrace;
 }
 
 interface HostedOAuthCompletionResponse {
   success: boolean;
   expiresAt?: number | null;
   kind?: "generic" | "registry";
+  error?: string;
+  oauthTrace?: OAuthTrace;
 }
 
 /**
@@ -536,6 +693,18 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       `mcp-tokens-${this.serverName}`,
       JSON.stringify(tokens),
     );
+  }
+
+  prepareTokenRequest() {
+    const currentTokens = this.tokens();
+    if (!currentTokens?.refresh_token) {
+      return undefined;
+    }
+
+    return new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: currentTokens.refresh_token,
+    });
   }
 
   discoveryState(): OAuthDiscoveryState | undefined {
@@ -645,17 +814,128 @@ function readStoredClientInformation(
   }
 }
 
+async function resolveOAuthClientInformation(
+  provider: MCPOAuthProvider,
+  trace: OAuthTrace,
+  authorizationServerUrl: string,
+  metadata: OAuthDiscoveryState["authorizationServerMetadata"],
+  scope?: string,
+  fetchFn?: typeof fetch,
+): Promise<OAuthClientInformation> {
+  startOAuthTraceStep(trace, "request_client_registration", {
+    message: "Resolving OAuth client information.",
+  });
+
+  const existingClientInformation = await provider.clientInformation();
+  if (existingClientInformation?.client_id) {
+    completeOAuthTraceStep(trace, "request_client_registration", {
+      message: "Using stored or preregistered client information.",
+      details: {
+        clientId: existingClientInformation.client_id,
+      },
+    });
+    completeOAuthTraceStep(trace, "received_client_credentials", {
+      message: "Client credentials are ready.",
+      details: {
+        clientId: existingClientInformation.client_id,
+      },
+    });
+    return existingClientInformation;
+  }
+
+  try {
+    const registeredClient = await registerClient(authorizationServerUrl, {
+      metadata,
+      clientMetadata: provider.clientMetadata,
+      ...(scope ? { scope } : {}),
+      ...(fetchFn ? { fetchFn } : {}),
+    });
+    await provider.saveClientInformation(registeredClient);
+    completeOAuthTraceStep(trace, "request_client_registration", {
+      message: "Dynamic client registration completed.",
+      details: {
+        clientId: registeredClient.client_id,
+      },
+    });
+    completeOAuthTraceStep(trace, "received_client_credentials", {
+      message: "Client credentials are ready.",
+      details: {
+        clientId: registeredClient.client_id,
+      },
+    });
+    return registeredClient;
+  } catch (error) {
+    failOAuthTraceStep(trace, "request_client_registration", error, {
+      message: "Dynamic client registration failed.",
+    });
+    throw error;
+  }
+}
+
+async function attemptRefreshWithStoredTokens(
+  provider: MCPOAuthProvider,
+  trace: OAuthTrace,
+  authorizationServerUrl: string,
+  metadata: OAuthDiscoveryState["authorizationServerMetadata"],
+  resource: URL | null,
+  fetchFn: typeof fetch,
+): Promise<OAuthTokens | null> {
+  const existingTokens = provider.tokens();
+  if (!existingTokens?.refresh_token) {
+    return null;
+  }
+
+  startOAuthTraceStep(trace, "token_request", {
+    message: "Attempting to refresh stored OAuth tokens before redirecting.",
+  });
+
+  try {
+    const refreshedTokens = await fetchToken(provider, authorizationServerUrl, {
+      metadata,
+      ...(resource ? { resource } : {}),
+      fetchFn,
+    });
+    await provider.saveTokens(refreshedTokens);
+    completeOAuthTraceStep(trace, "token_request", {
+      message: "Stored refresh token succeeded.",
+    });
+    completeOAuthTraceStep(trace, "received_access_token", {
+      message: "Refreshed OAuth tokens are ready.",
+    });
+    completeOAuthTraceStep(trace, "complete", {
+      message: "OAuth completed using the stored refresh token.",
+    });
+    return refreshedTokens;
+  } catch (error) {
+    failOAuthTraceStep(trace, "token_request", error, {
+      message:
+        "Stored refresh token failed. Falling back to an interactive authorization flow.",
+    });
+    await provider.invalidateCredentials("tokens");
+    trace.error = undefined;
+    return null;
+  }
+}
+
 /**
  * Initiates OAuth flow for an MCP server
  */
 export async function initiateOAuth(
   options: MCPOAuthOptions,
 ): Promise<OAuthResult> {
-  // Build fetch interceptor — routes token requests through Convex for registry servers
-  const fetchFn = createOAuthFetchInterceptor({
-    registryServerId: options.registryServerId,
-    useRegistryOAuthProxy: options.useRegistryOAuthProxy,
+  const trace = createOAuthTrace({
+    source: "interactive_connect",
+    serverName: options.serverName,
+    serverUrl: options.serverUrl,
   });
+  // Build fetch interceptor — routes token requests through Convex for registry servers
+  const fetchFn = createOAuthFetchInterceptor(
+    {
+      registryServerId: options.registryServerId,
+      useRegistryOAuthProxy: options.useRegistryOAuthProxy,
+    },
+    trace,
+  );
 
   try {
     const provider = new MCPOAuthProvider(
@@ -702,32 +982,119 @@ export async function initiateOAuth(
       );
     }
 
-    const authArgs: any = { serverUrl: options.serverUrl, fetchFn };
-    if (options.scopes && options.scopes.length > 0) {
-      authArgs.scope = options.scopes.join(" ");
-    }
-    const result = await auth(provider, authArgs);
+    const requestedScope =
+      options.scopes && options.scopes.length > 0
+        ? options.scopes.join(" ")
+        : undefined;
 
-    if (result === "REDIRECT") {
+    startOAuthTraceStep(trace, "request_resource_metadata", {
+      message: "Discovering protected resource metadata.",
+    });
+    const discoveryState = await loadCallbackDiscoveryState(
+      provider,
+      options.serverUrl,
+      fetchFn,
+    );
+    completeOAuthTraceStep(trace, "request_resource_metadata", {
+      message: "Protected resource metadata loaded.",
+      details: {
+        authorizationServerUrl: discoveryState.authorizationServerUrl,
+        resource:
+          discoveryState.resourceMetadata?.resource ?? options.serverUrl,
+      },
+    });
+    completeOAuthTraceStep(trace, "received_resource_metadata", {
+      message: "Resource metadata is ready.",
+      details: {
+        authorizationServers:
+          discoveryState.resourceMetadata?.authorization_servers ?? [],
+      },
+    });
+
+    startOAuthTraceStep(trace, "request_authorization_server_metadata", {
+      message: "Loading authorization server metadata.",
+      details: {
+        authorizationServerUrl: discoveryState.authorizationServerUrl,
+      },
+    });
+    completeOAuthTraceStep(trace, "request_authorization_server_metadata", {
+      message: "Authorization server metadata loaded.",
+    });
+    completeOAuthTraceStep(trace, "received_authorization_server_metadata", {
+      message: "Authorization server metadata is ready.",
+      details: {
+        authorizationEndpoint:
+          discoveryState.authorizationServerMetadata?.authorization_endpoint,
+        tokenEndpoint:
+          discoveryState.authorizationServerMetadata?.token_endpoint,
+      },
+    });
+
+    const resource = await selectResourceURL(
+      options.serverUrl,
+      provider,
+      discoveryState.resourceMetadata,
+    );
+
+    const refreshedTokens = await attemptRefreshWithStoredTokens(
+      provider,
+      trace,
+      discoveryState.authorizationServerUrl,
+      discoveryState.authorizationServerMetadata,
+      resource ?? null,
+      fetchFn,
+    );
+    if (refreshedTokens) {
+      saveOAuthTrace(options.serverName, trace);
       return {
         success: true,
+        serverConfig: createServerConfig(options.serverUrl, refreshedTokens),
+        oauthTrace: trace,
       };
     }
 
-    if (result === "AUTHORIZED") {
-      const tokens = provider.tokens();
-      if (tokens) {
-        const serverConfig = createServerConfig(options.serverUrl, tokens);
-        return {
-          success: true,
-          serverConfig,
-        };
-      }
-    }
+    const clientInformation = await resolveOAuthClientInformation(
+      provider,
+      trace,
+      discoveryState.authorizationServerUrl,
+      discoveryState.authorizationServerMetadata,
+      requestedScope,
+      fetchFn,
+    );
+
+    startOAuthTraceStep(trace, "generate_pkce_parameters", {
+      message: "Generating PKCE verifier and challenge.",
+    });
+    const { authorizationUrl, codeVerifier } = await startAuthorization(
+      discoveryState.authorizationServerUrl,
+      {
+        metadata: discoveryState.authorizationServerMetadata,
+        clientInformation,
+        redirectUrl: provider.redirectUrl,
+        ...(requestedScope ? { scope: requestedScope } : {}),
+        state: provider.state(),
+        ...(resource ? { resource } : {}),
+      },
+    );
+    completeOAuthTraceStep(trace, "generate_pkce_parameters", {
+      message: "PKCE verifier and challenge are ready.",
+    });
+    startOAuthTraceStep(trace, "authorization_request", {
+      message: "Preparing authorization redirect.",
+    });
+    await provider.saveCodeVerifier(codeVerifier);
+    completeOAuthTraceStep(trace, "authorization_request", {
+      message: "Redirecting to the authorization server.",
+      details: {
+        authorizationUrl: authorizationUrl.toString(),
+      },
+    });
+    saveOAuthTrace(options.serverName, trace);
+    await provider.redirectToAuthorization(authorizationUrl);
 
     return {
-      success: false,
-      error: "OAuth flow failed",
+      success: true,
+      oauthTrace: trace,
     };
   } catch (error) {
     let errorMessage = "Unknown OAuth error";
@@ -751,9 +1118,15 @@ export async function initiateOAuth(
       }
     }
 
+    failOAuthTraceStep(trace, trace.currentStep, errorMessage, {
+      message: "OAuth initialization failed.",
+    });
+    saveOAuthTrace(options.serverName, trace);
+
     return {
       success: false,
       error: errorMessage,
+      oauthTrace: trace,
     };
   } finally {
     // Restore original fetch
@@ -762,23 +1135,24 @@ export async function initiateOAuth(
 }
 
 function formatOAuthCallbackError(error: unknown): string {
-  let errorMessage = "Unknown callback error";
+  const errorMessage =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : "Unknown callback error";
 
-  if (error instanceof Error) {
-    errorMessage = error.message;
-
-    if (
-      errorMessage.includes("invalid_client") ||
-      errorMessage.includes("client_id")
-    ) {
-      return "Invalid client ID during token exchange. Please verify the client ID is correctly registered.";
-    }
-    if (errorMessage.includes("unauthorized_client")) {
-      return "Client not authorized for token exchange. The client ID may not match the one used for authorization.";
-    }
-    if (errorMessage.includes("invalid_grant")) {
-      return "Authorization code invalid or expired. Please try the OAuth flow again.";
-    }
+  if (
+    errorMessage.includes("invalid_client") ||
+    errorMessage.includes("client_id")
+  ) {
+    return "Invalid client ID during token exchange. Please verify the client ID is correctly registered.";
+  }
+  if (errorMessage.includes("unauthorized_client")) {
+    return "Client not authorized for token exchange. The client ID may not match the one used for authorization.";
+  }
+  if (errorMessage.includes("invalid_grant")) {
+    return "Authorization code invalid or expired. Please try the OAuth flow again.";
   }
 
   return errorMessage;
@@ -789,6 +1163,10 @@ export async function completeHostedOAuthCallback(
   authorizationCode: string,
 ): Promise<OAuthResult & { serverName?: string; expiresAt?: number | null }> {
   const serverName = context.serverName || localStorage.getItem("mcp-oauth-pending");
+  const callbackTrace = createOAuthTrace({
+    source: "hosted_callback",
+    serverName: serverName ?? undefined,
+  });
 
   try {
     if (!serverName) {
@@ -798,6 +1176,9 @@ export async function completeHostedOAuthCallback(
       throw new Error("Hosted OAuth callback is missing server context");
     }
 
+    startOAuthTraceStep(callbackTrace, "received_authorization_code", {
+      message: "Received hosted OAuth callback and loading stored callback state.",
+    });
     const serverUrl =
       context.serverUrl || localStorage.getItem(`mcp-serverUrl-${serverName}`);
     if (!serverUrl) {
@@ -813,6 +1194,13 @@ export async function completeHostedOAuthCallback(
     if (!clientInformation.client_id) {
       throw new Error("OAuth client ID not found");
     }
+    completeOAuthTraceStep(callbackTrace, "received_authorization_code", {
+      message: "Hosted callback state restored.",
+      details: {
+        serverUrl,
+        clientId: clientInformation.client_id,
+      },
+    });
 
     const convexSiteUrl = getConvexSiteUrl();
     const response = await authFetch(`${convexSiteUrl}/web/oauth/complete`, {
@@ -839,30 +1227,90 @@ export async function completeHostedOAuthCallback(
       }),
     });
 
+    const result =
+      (await response
+        .clone()
+        .json()
+        .catch(() => null)) as HostedOAuthCompletionResponse | null;
     if (!response.ok) {
       const responseText = await response.text();
-      throw new Error(responseText || `Hosted OAuth callback failed (${response.status})`);
+      throw {
+        message:
+          result?.error ||
+          responseText ||
+          `Hosted OAuth callback failed (${response.status})`,
+        oauthTrace: result?.oauthTrace,
+      };
     }
 
-    const result =
-      (await response.json()) as HostedOAuthCompletionResponse | null;
     if (!result?.success) {
-      throw new Error("Hosted OAuth callback failed");
+      throw {
+        message: result?.error || "Hosted OAuth callback failed",
+        oauthTrace: result?.oauthTrace,
+      };
     }
 
     localStorage.removeItem(`mcp-tokens-${serverName}`);
     localStorage.removeItem(`mcp-verifier-${serverName}`);
+    completeOAuthTraceStep(callbackTrace, "token_request", {
+      message: "Hosted token exchange succeeded.",
+    });
+    completeOAuthTraceStep(callbackTrace, "received_access_token", {
+      message: "Hosted access token is stored in the backend vault.",
+    });
+    completeOAuthTraceStep(callbackTrace, "complete", {
+      message: "Hosted OAuth callback completed successfully.",
+    });
+    const mergedTrace = mergeOAuthTraces(
+      loadOAuthTrace(serverName),
+      result.oauthTrace
+        ? mergeOAuthTraces(callbackTrace, result.oauthTrace)
+        : callbackTrace,
+    );
+    saveOAuthTrace(serverName, mergedTrace);
 
     return {
       success: true,
       serverName,
       serverConfig: createServerConfig(serverUrl),
       expiresAt: result.expiresAt ?? null,
+      oauthTrace: mergedTrace,
     };
   } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : typeof error === "object" &&
+            error !== null &&
+            "message" in error &&
+            typeof (error as { message?: unknown }).message === "string"
+          ? ((error as { message: string }).message)
+          : String(error);
+    failOAuthTraceStep(callbackTrace, callbackTrace.currentStep, message, {
+      message: "Hosted OAuth callback failed.",
+    });
+    const backendTrace =
+      typeof error === "object" && error !== null && "oauthTrace" in error
+        ? ((error as { oauthTrace?: OAuthTrace }).oauthTrace ?? undefined)
+        : undefined;
+    const mergedTrace =
+      serverName != null
+        ? mergeOAuthTraces(
+            loadOAuthTrace(serverName),
+            backendTrace
+              ? mergeOAuthTraces(callbackTrace, backendTrace)
+              : callbackTrace,
+          )
+        : backendTrace
+          ? mergeOAuthTraces(callbackTrace, backendTrace)
+          : callbackTrace;
+    if (serverName) {
+      saveOAuthTrace(serverName, mergedTrace);
+    }
     return {
       success: false,
-      error: formatOAuthCallbackError(error),
+      error: formatOAuthCallbackError(message),
+      oauthTrace: mergedTrace,
     };
   }
 }
@@ -875,12 +1323,16 @@ export async function handleOAuthCallback(
 ): Promise<OAuthResult & { serverName?: string }> {
   // Get pending server name from localStorage (needed before creating interceptor)
   const serverName = localStorage.getItem("mcp-oauth-pending");
+  const callbackTrace = createOAuthTrace({
+    source: "callback",
+    serverName: serverName ?? undefined,
+  });
 
   // Read registryServerId from stored OAuth config if present
   const oauthConfig = readStoredOAuthConfig(serverName);
 
   // Build fetch interceptor — routes token requests through Convex for registry servers
-  const fetchFn = createOAuthFetchInterceptor(oauthConfig);
+  const fetchFn = createOAuthFetchInterceptor(oauthConfig, callbackTrace);
 
   try {
     if (!serverName) {
@@ -892,6 +1344,12 @@ export async function handleOAuthCallback(
     if (!serverUrl) {
       throw new Error("Server URL not found for OAuth callback");
     }
+    startOAuthTraceStep(callbackTrace, "received_authorization_code", {
+      message: "Received OAuth callback and loading stored state.",
+      details: {
+        serverUrl,
+      },
+    });
 
     // Get stored client credentials if any
     const storedClientInfo = localStorage.getItem(`mcp-client-${serverName}`);
@@ -908,41 +1366,81 @@ export async function handleOAuthCallback(
       customClientId,
       customClientSecret,
     );
+    const clientInformation = await provider.clientInformation();
+    if (!clientInformation?.client_id) {
+      throw new Error("OAuth client ID not found");
+    }
     const discoveryState = await loadCallbackDiscoveryState(
       provider,
       serverUrl,
       fetchFn,
     );
+    completeOAuthTraceStep(callbackTrace, "received_authorization_code", {
+      message: "Callback state restored.",
+      details: {
+        clientId: clientInformation.client_id,
+      },
+    });
     const resource = await selectResourceURL(
       serverUrl,
       provider,
       discoveryState.resourceMetadata,
     );
-    const tokens = await fetchToken(
-      provider,
+    startOAuthTraceStep(callbackTrace, "token_request", {
+      message: "Exchanging authorization code for OAuth tokens.",
+    });
+    const tokens = await exchangeAuthorization(
       discoveryState.authorizationServerUrl,
       {
         metadata: discoveryState.authorizationServerMetadata,
-        resource,
         authorizationCode,
+        clientInformation,
+        codeVerifier: provider.codeVerifier(),
+        redirectUri: provider.redirectUrl,
+        ...(resource ? { resource } : {}),
         fetchFn,
       },
     );
     await provider.saveTokens(tokens);
+    completeOAuthTraceStep(callbackTrace, "token_request", {
+      message: "Authorization code exchange succeeded.",
+    });
+    completeOAuthTraceStep(callbackTrace, "received_access_token", {
+      message: "OAuth tokens were stored locally.",
+    });
+    completeOAuthTraceStep(callbackTrace, "complete", {
+      message: "OAuth callback completed successfully.",
+    });
 
     // Clean up pending state
     localStorage.removeItem("mcp-oauth-pending");
+    const mergedTrace = mergeOAuthTraces(
+      loadOAuthTrace(serverName),
+      callbackTrace,
+    );
+    saveOAuthTrace(serverName, mergedTrace);
 
     const serverConfig = createServerConfig(serverUrl, tokens);
     return {
       success: true,
       serverConfig,
       serverName, // Return server name so caller doesn't need to look it up
+      oauthTrace: mergedTrace,
     };
   } catch (error) {
+    failOAuthTraceStep(callbackTrace, callbackTrace.currentStep, error, {
+      message: "OAuth callback failed.",
+    });
+    const mergedTrace = serverName
+      ? mergeOAuthTraces(loadOAuthTrace(serverName), callbackTrace)
+      : callbackTrace;
+    if (serverName) {
+      saveOAuthTrace(serverName, mergedTrace);
+    }
     return {
       success: false,
       error: formatOAuthCallbackError(error),
+      oauthTrace: mergedTrace,
     };
   } finally {
     // Restore original fetch
@@ -1033,9 +1531,13 @@ export async function waitForTokens(
 export async function refreshOAuthTokens(
   serverName: string,
 ): Promise<OAuthResult> {
+  const trace = createOAuthTrace({
+    source: "refresh",
+    serverName,
+  });
   // Build fetch interceptor — routes token requests through Convex for registry servers
   const oauthConfig = readStoredOAuthConfig(serverName);
-  const fetchFn = createOAuthFetchInterceptor(oauthConfig);
+  const fetchFn = createOAuthFetchInterceptor(oauthConfig, trace);
 
   try {
     // Get stored client credentials if any
@@ -1068,25 +1570,56 @@ export async function refreshOAuthTokens(
       return {
         success: false,
         error: "No refresh token available",
+        oauthTrace: trace,
       };
     }
 
-    const result = await auth(provider, { serverUrl, fetchFn });
-
-    if (result === "AUTHORIZED") {
-      const tokens = provider.tokens();
-      if (tokens) {
-        const serverConfig = createServerConfig(serverUrl, tokens);
-        return {
-          success: true,
-          serverConfig,
-        };
-      }
-    }
-
+    startOAuthTraceStep(trace, "request_resource_metadata", {
+      message: "Refreshing OAuth tokens and rediscovering server metadata.",
+    });
+    const discoveryState = await loadCallbackDiscoveryState(
+      provider,
+      serverUrl,
+      fetchFn,
+    );
+    completeOAuthTraceStep(trace, "request_resource_metadata", {
+      message: "Protected resource metadata loaded.",
+    });
+    completeOAuthTraceStep(trace, "received_resource_metadata", {
+      message: "Resource metadata is ready.",
+    });
+    completeOAuthTraceStep(trace, "received_authorization_server_metadata", {
+      message: "Authorization server metadata is ready.",
+    });
+    const resource = await selectResourceURL(
+      serverUrl,
+      provider,
+      discoveryState.resourceMetadata,
+    );
+    startOAuthTraceStep(trace, "token_request", {
+      message: "Refreshing tokens with the stored refresh token.",
+    });
+    const tokens = await fetchToken(provider, discoveryState.authorizationServerUrl, {
+      metadata: discoveryState.authorizationServerMetadata,
+      ...(resource ? { resource } : {}),
+      fetchFn,
+    });
+    await provider.saveTokens(tokens);
+    completeOAuthTraceStep(trace, "token_request", {
+      message: "Refresh token exchange succeeded.",
+    });
+    completeOAuthTraceStep(trace, "received_access_token", {
+      message: "Refreshed OAuth tokens were stored locally.",
+    });
+    completeOAuthTraceStep(trace, "complete", {
+      message: "OAuth token refresh completed successfully.",
+    });
+    saveOAuthTrace(serverName, trace);
+    const serverConfig = createServerConfig(serverUrl, tokens);
     return {
-      success: false,
-      error: "Token refresh failed",
+      success: true,
+      serverConfig,
+      oauthTrace: trace,
     };
   } catch (error) {
     let errorMessage = "Unknown refresh error";
@@ -1110,9 +1643,15 @@ export async function refreshOAuthTokens(
       }
     }
 
+    failOAuthTraceStep(trace, trace.currentStep, errorMessage, {
+      message: "OAuth token refresh failed.",
+    });
+    saveOAuthTrace(serverName, trace);
+
     return {
       success: false,
       error: errorMessage,
+      oauthTrace: trace,
     };
   } finally {
     // Restore original fetch
@@ -1130,6 +1669,7 @@ export function clearOAuthData(serverName: string): void {
   localStorage.removeItem(`mcp-serverUrl-${serverName}`);
   localStorage.removeItem(`mcp-oauth-config-${serverName}`);
   clearStoredDiscoveryState(serverName);
+  clearOAuthTrace(serverName);
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -1,22 +1,29 @@
 /**
- * Production OAuth implementation using explicit SDK primitives with trace support.
+ * Production OAuth implementation using the SDK state-machine runner with trace support.
  */
 
 import {
+  DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
   discoverAuthorizationServerMetadata,
   discoverOAuthServerInfo,
   exchangeAuthorization,
   fetchToken,
-  registerClient,
+  getBrowserDebugDynamicRegistrationMetadata,
+  getStepIndex,
+  getStepInfo,
+  EMPTY_OAUTH_FLOW_STATE,
+  runOAuthStateMachine,
   selectResourceURL,
-  startAuthorization,
 } from "@mcpjam/sdk/browser";
 import type {
   HttpHistoryEntry,
-  OAuthClientInformation,
   OAuthClientProvider,
   OAuthDiscoveryState,
-  OAuthTokens,
+  OAuthFlowState,
+  OAuthProtocolVersion,
+  RegistrationStrategy2025_03_26,
+  RegistrationStrategy2025_06_18,
+  RegistrationStrategy2025_11_25,
 } from "@mcpjam/sdk/browser";
 import type { HttpServerConfig } from "@mcpjam/sdk/browser";
 import { generateRandomString } from "./pkce";
@@ -34,7 +41,6 @@ import {
   failOAuthTraceStep,
   loadOAuthTrace,
   mergeOAuthTraces,
-  resolveOAuthTraceStepError,
   saveOAuthTrace,
   startOAuthTraceStep,
   type OAuthTrace,
@@ -53,16 +59,37 @@ interface StoredOAuthClientInformation {
   client_secret?: string;
 }
 
+type OAuthRegistrationStrategy =
+  | RegistrationStrategy2025_03_26
+  | RegistrationStrategy2025_06_18
+  | RegistrationStrategy2025_11_25;
+
 export interface StoredOAuthConfig {
   scopes?: string[];
   customHeaders?: Record<string, string>;
   registryServerId?: string;
   useRegistryOAuthProxy?: boolean;
+  protocolVersion?: OAuthProtocolVersion;
+  registrationStrategy?: OAuthRegistrationStrategy;
 }
 
 interface OAuthRoutingConfig {
   registryServerId?: string;
   useRegistryOAuthProxy?: boolean;
+}
+
+interface StoredOAuthFlowSession {
+  version: 1;
+  protocolVersion: OAuthProtocolVersion;
+  registrationStrategy: OAuthRegistrationStrategy;
+  state: OAuthFlowState;
+}
+
+const DEFAULT_OAUTH_PROTOCOL_VERSION: OAuthProtocolVersion = "2025-11-25";
+const DEFAULT_OAUTH_REGISTRATION_STRATEGY: OAuthRegistrationStrategy = "dcr";
+
+function getFlowStateStorageKey(serverName: string): string {
+  return `mcp-oauth-flow-state-${serverName}`;
 }
 
 function getDiscoveryStorageKey(serverName: string): string {
@@ -191,36 +218,434 @@ async function readResponseBodyForTrace(response: Response): Promise<unknown> {
   }
 }
 
-function getOAuthErrorCode(error: unknown): string | undefined {
-  if (error && typeof error === "object") {
-    const record = error as Record<string, unknown>;
-    if (typeof record.code === "string") {
-      return record.code.toLowerCase();
-    }
-    if (typeof record.error === "string") {
-      return record.error.toLowerCase();
-    }
-  }
-
-  if (error instanceof Error) {
-    const message = error.message.toLowerCase();
-    if (message.includes("invalid_client")) {
-      return "invalid_client";
-    }
-    if (message.includes("unauthorized_client")) {
-      return "unauthorized_client";
-    }
-    if (message.includes("invalid_grant")) {
-      return "invalid_grant";
-    }
-  }
-
-  return undefined;
+function cloneEmptyFlowState(): OAuthFlowState {
+  return {
+    ...EMPTY_OAUTH_FLOW_STATE,
+    httpHistory: [],
+    infoLogs: [],
+  };
 }
 
-function shouldInvalidateOAuthClient(error: unknown): boolean {
-  const code = getOAuthErrorCode(error);
-  return code === "invalid_client" || code === "unauthorized_client";
+function cloneFlowState(state: OAuthFlowState): OAuthFlowState {
+  return JSON.parse(JSON.stringify(state)) as OAuthFlowState;
+}
+
+function normalizeResponseHeaders(
+  headers: Headers,
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    normalized[key.toLowerCase()] = value;
+  });
+  return normalized;
+}
+
+async function parseOAuthResponseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) {
+    return undefined;
+  }
+
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+  if (
+    contentType.includes("application/json") ||
+    contentType.includes("+json")
+  ) {
+    try {
+      return sanitizeOAuthTraceValue(JSON.parse(text));
+    } catch {
+      return sanitizeOAuthTraceValue(text);
+    }
+  }
+
+  if (text.startsWith("{") || text.startsWith("[")) {
+    try {
+      return sanitizeOAuthTraceValue(JSON.parse(text));
+    } catch {
+      return sanitizeOAuthTraceValue(text);
+    }
+  }
+
+  return sanitizeOAuthTraceValue(text);
+}
+
+function serializeOAuthRequestBody(
+  body: HttpHistoryEntry["request"]["body"],
+  headers: Record<string, string>,
+): BodyInit | undefined {
+  if (body === undefined || body === null) {
+    return undefined;
+  }
+
+  if (typeof body === "string" || body instanceof URLSearchParams) {
+    return body;
+  }
+
+  const contentType =
+    Object.entries(headers).find(
+      ([key]) => key.toLowerCase() === "content-type",
+    )?.[1] ?? "";
+
+  if (contentType.includes("application/x-www-form-urlencoded")) {
+    return new URLSearchParams(
+      Object.entries(body as Record<string, string>).map(([key, value]) => [
+        key,
+        String(value),
+      ]),
+    ).toString();
+  }
+
+  return JSON.stringify(body);
+}
+
+function saveOAuthFlowSession(
+  serverName: string,
+  session: StoredOAuthFlowSession,
+): void {
+  localStorage.setItem(
+    getFlowStateStorageKey(serverName),
+    JSON.stringify(session),
+  );
+}
+
+function loadOAuthFlowSession(
+  serverName: string,
+): StoredOAuthFlowSession | undefined {
+  try {
+    const raw = localStorage.getItem(getFlowStateStorageKey(serverName));
+    if (!raw) {
+      return undefined;
+    }
+
+    const parsed = JSON.parse(raw) as StoredOAuthFlowSession;
+    if (
+      parsed?.version !== 1 ||
+      !parsed.state ||
+      (parsed.protocolVersion !== "2025-03-26" &&
+        parsed.protocolVersion !== "2025-06-18" &&
+        parsed.protocolVersion !== "2025-11-25")
+    ) {
+      return undefined;
+    }
+
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+function clearOAuthFlowSession(serverName: string): void {
+  localStorage.removeItem(getFlowStateStorageKey(serverName));
+}
+
+function sanitizeHttpHistoryEntry(entry: HttpHistoryEntry): HttpHistoryEntry {
+  return {
+    ...entry,
+    request: {
+      ...entry.request,
+      headers: sanitizeOAuthHeaders(entry.request.headers),
+      body: sanitizeOAuthTraceValue(entry.request.body),
+    },
+    ...(entry.response
+      ? {
+          response: {
+            ...entry.response,
+            headers: sanitizeOAuthHeaders(entry.response.headers),
+            body: sanitizeOAuthTraceValue(entry.response.body),
+          },
+        }
+      : {}),
+    ...(entry.error
+      ? {
+          error: {
+            ...entry.error,
+            details: sanitizeOAuthTraceValue(entry.error.details),
+          },
+        }
+      : {}),
+  };
+}
+
+function resolveOAuthProtocolVersion(
+  options: Pick<MCPOAuthOptions, "protocolVersion">,
+): OAuthProtocolVersion {
+  return options.protocolVersion ?? DEFAULT_OAUTH_PROTOCOL_VERSION;
+}
+
+function resolveOAuthRegistrationStrategy(
+  options: Pick<
+    MCPOAuthOptions,
+    "registrationStrategy" | "clientId" | "clientSecret" | "useRegistryOAuthProxy"
+  >,
+  provider: MCPOAuthProvider,
+): OAuthRegistrationStrategy {
+  if (options.registrationStrategy) {
+    return options.registrationStrategy;
+  }
+
+  const storedClient = provider.clientInformation();
+  if (
+    options.useRegistryOAuthProxy ||
+    options.clientId ||
+    options.clientSecret ||
+    storedClient?.client_id
+  ) {
+    return "preregistered";
+  }
+
+  return DEFAULT_OAUTH_REGISTRATION_STRATEGY;
+}
+
+function createOAuthRequestExecutor(fetchFn: typeof fetch) {
+  return async (request: HttpHistoryEntry["request"]) => {
+    const response = await fetchFn(request.url, {
+      method: request.method,
+      headers: request.headers,
+      body: serializeOAuthRequestBody(request.body, request.headers),
+    });
+    return {
+      status: response.status,
+      statusText: response.statusText,
+      headers: normalizeResponseHeaders(response.headers),
+      body: await parseOAuthResponseBody(response),
+      ok: response.ok,
+    };
+  };
+}
+
+function saveDiscoveryStateFromFlowState(
+  provider: MCPOAuthProvider,
+  state: OAuthFlowState,
+): Promise<void> {
+  if (!state.authorizationServerUrl) {
+    return Promise.resolve();
+  }
+
+  return provider.saveDiscoveryState({
+    authorizationServerUrl: state.authorizationServerUrl,
+    ...(state.resourceMetadata
+      ? {
+          resourceMetadata: state.resourceMetadata,
+        }
+      : {}),
+    ...(state.authorizationServerMetadata
+      ? {
+          authorizationServerMetadata: state.authorizationServerMetadata,
+        }
+      : {}),
+  });
+}
+
+async function persistOAuthStateArtifacts(
+  provider: MCPOAuthProvider,
+  state: OAuthFlowState,
+): Promise<void> {
+  if (state.clientId) {
+    await provider.saveClientInformation({
+      client_id: state.clientId,
+      ...(state.clientSecret ? { client_secret: state.clientSecret } : {}),
+    });
+  }
+
+  if (state.codeVerifier) {
+    await provider.saveCodeVerifier(state.codeVerifier);
+  }
+
+  if (state.accessToken) {
+    await provider.saveTokens({
+      access_token: state.accessToken,
+      ...(state.refreshToken ? { refresh_token: state.refreshToken } : {}),
+      ...(state.tokenType ? { token_type: state.tokenType } : {}),
+      ...(typeof state.expiresIn === "number"
+        ? { expires_in: state.expiresIn }
+        : {}),
+    });
+  }
+
+  await saveDiscoveryStateFromFlowState(provider, state);
+}
+
+function buildOAuthTraceFromFlowState(input: {
+  source: "interactive_connect" | "callback";
+  serverName?: string;
+  serverUrl?: string;
+  state: OAuthFlowState;
+}): OAuthTrace {
+  const trace = createOAuthTrace({
+    source: input.source,
+    serverName: input.serverName,
+    serverUrl: input.serverUrl,
+  });
+  const state = input.state;
+  const currentStepIndex = getStepIndex(state.currentStep);
+  trace.currentStep = state.currentStep;
+  trace.error = state.error;
+  trace.httpHistory = (state.httpHistory ?? []).map((entry) =>
+    sanitizeHttpHistoryEntry(entry),
+  );
+
+  const entries = new Map<
+    string,
+    {
+      step: HttpHistoryEntry["step"];
+      startedAt: number;
+      completedAt?: number;
+      message?: string;
+      details?: Record<string, unknown>;
+      error?: string;
+    }
+  >();
+
+  const ensureStep = (step: HttpHistoryEntry["step"], timestamp: number) => {
+    const existing = entries.get(step);
+    if (existing) {
+      existing.startedAt = Math.min(existing.startedAt, timestamp);
+      existing.completedAt = Math.max(
+        existing.completedAt ?? timestamp,
+        timestamp,
+      );
+      return existing;
+    }
+
+    const created = {
+      step,
+      startedAt: timestamp,
+      completedAt: timestamp,
+    };
+    entries.set(step, created);
+    return created;
+  };
+
+  for (const entry of state.httpHistory ?? []) {
+    const record = ensureStep(entry.step, entry.timestamp);
+    if (!record.details) {
+      record.details = {
+        request: sanitizeOAuthTraceValue(entry.request),
+        ...(entry.response
+          ? { response: sanitizeOAuthTraceValue(entry.response) }
+          : {}),
+      };
+    }
+    if (entry.error?.message) {
+      record.error = entry.error.message;
+    }
+  }
+
+  for (const log of state.infoLogs ?? []) {
+    const record = ensureStep(log.step, log.timestamp);
+    record.message = log.label;
+    if (
+      log.data &&
+      typeof sanitizeOAuthTraceValue(log.data) === "object" &&
+      sanitizeOAuthTraceValue(log.data) !== null &&
+      !Array.isArray(sanitizeOAuthTraceValue(log.data))
+    ) {
+      record.details = sanitizeOAuthTraceValue(log.data) as Record<string, unknown>;
+    }
+    if (log.error?.message) {
+      record.error = log.error.message;
+    }
+  }
+
+  const baseTimestamp = Math.max(
+    Date.now(),
+    ...(state.httpHistory ?? []).map((entry) => entry.timestamp),
+    ...(state.infoLogs ?? []).map((entry) => entry.timestamp),
+  );
+  let syntheticTimestamp = baseTimestamp;
+  const inferStep = (
+    step: HttpHistoryEntry["step"],
+    condition: boolean,
+    details?: Record<string, unknown>,
+  ) => {
+    if (!condition || entries.has(step)) {
+      return;
+    }
+
+    syntheticTimestamp += 1;
+    entries.set(step, {
+      step,
+      startedAt: syntheticTimestamp,
+      completedAt: syntheticTimestamp,
+      details,
+    });
+  };
+
+  inferStep("request_client_registration", Boolean(state.clientId), {
+    clientId: state.clientId,
+  });
+  inferStep("received_client_credentials", Boolean(state.clientId), {
+    clientId: state.clientId,
+  });
+  inferStep("generate_pkce_parameters", Boolean(state.codeVerifier), {
+    codeVerifier: redactSensitiveValue(state.codeVerifier),
+  });
+  inferStep("authorization_request", Boolean(state.authorizationUrl), {
+    authorizationUrl: state.authorizationUrl,
+  });
+  inferStep(
+    "received_authorization_code",
+    Boolean(state.authorizationCode),
+    state.authorizationCode
+      ? { code: redactSensitiveValue(state.authorizationCode) }
+      : undefined,
+  );
+  inferStep("received_access_token", Boolean(state.accessToken), {
+    tokenType: state.tokenType,
+    expiresIn: state.expiresIn,
+  });
+  inferStep("complete", state.currentStep === "complete");
+
+  if (state.error && !entries.has(state.currentStep)) {
+    syntheticTimestamp += 1;
+    entries.set(state.currentStep, {
+      step: state.currentStep,
+      startedAt: syntheticTimestamp,
+      completedAt: syntheticTimestamp,
+      error: state.error,
+    });
+  }
+
+  trace.steps = Array.from(entries.values())
+    .sort(
+      (left, right) =>
+        left.startedAt - right.startedAt ||
+        getStepIndex(left.step) - getStepIndex(right.step),
+    )
+    .map((entry) => {
+      const stepIndex = getStepIndex(entry.step);
+      const status =
+        entry.error || (entry.step === state.currentStep && state.error)
+          ? "error"
+          : stepIndex < currentStepIndex ||
+              state.currentStep === "complete" ||
+              (entry.step === state.currentStep &&
+                ((entry.step === "authorization_request" &&
+                  Boolean(state.authorizationUrl)) ||
+                  (entry.step === "received_authorization_code" &&
+                    Boolean(state.authorizationCode)) ||
+                  (entry.step === "received_access_token" &&
+                    Boolean(state.accessToken)) ||
+                  (entry.step === "complete" &&
+                    state.currentStep === "complete")))
+            ? "success"
+            : entry.step === state.currentStep
+              ? "pending"
+              : "success";
+
+      return {
+        step: entry.step,
+        title: getStepInfo(entry.step).title,
+        status,
+        message: entry.message ?? getStepInfo(entry.step).summary,
+        ...(entry.error ? { error: entry.error } : {}),
+        ...(entry.details ? { details: entry.details } : {}),
+        startedAt: entry.startedAt,
+        completedAt: status === "pending" ? undefined : entry.completedAt,
+      };
+    });
+
+  return trace;
 }
 
 export function readStoredOAuthConfig(
@@ -249,6 +674,18 @@ export function readStoredOAuthConfig(
           ? parsed.registryServerId
           : undefined,
       useRegistryOAuthProxy: parsed?.useRegistryOAuthProxy === true,
+      protocolVersion:
+        parsed?.protocolVersion === "2025-03-26" ||
+        parsed?.protocolVersion === "2025-06-18" ||
+        parsed?.protocolVersion === "2025-11-25"
+          ? parsed.protocolVersion
+          : undefined,
+      registrationStrategy:
+        parsed?.registrationStrategy === "cimd" ||
+        parsed?.registrationStrategy === "dcr" ||
+        parsed?.registrationStrategy === "preregistered"
+          ? parsed.registrationStrategy
+          : undefined,
     };
 
     if (
@@ -282,16 +719,27 @@ export function readStoredOAuthConfig(
 export function buildStoredOAuthConfig(
   options: Pick<
     MCPOAuthOptions,
-    "scopes" | "registryServerId" | "useRegistryOAuthProxy"
+    | "scopes"
+    | "registryServerId"
+    | "useRegistryOAuthProxy"
+    | "customHeaders"
+    | "protocolVersion"
+    | "registrationStrategy"
   >,
 ): StoredOAuthConfig {
   const config: StoredOAuthConfig = {
     registryServerId: options.registryServerId,
     useRegistryOAuthProxy: options.useRegistryOAuthProxy === true,
+    protocolVersion: options.protocolVersion,
+    registrationStrategy: options.registrationStrategy,
   };
 
   if (options.scopes && options.scopes.length > 0) {
     config.scopes = options.scopes;
+  }
+
+  if (options.customHeaders && Object.keys(options.customHeaders).length > 0) {
+    config.customHeaders = options.customHeaders;
   }
 
   return config;
@@ -655,12 +1103,15 @@ export interface MCPOAuthOptions {
   serverName: string;
   serverUrl: string;
   scopes?: string[];
+  customHeaders?: Record<string, string>;
   clientId?: string;
   clientSecret?: string;
   /** Registry record identifier for bookkeeping and optional Convex token exchange */
   registryServerId?: string;
   /** True only for registry servers with backend-managed preregistered OAuth credentials */
   useRegistryOAuthProxy?: boolean;
+  protocolVersion?: OAuthProtocolVersion;
+  registrationStrategy?: OAuthRegistrationStrategy;
 }
 
 export interface OAuthResult {
@@ -890,132 +1341,17 @@ function readStoredClientInformation(
   }
 }
 
-async function resolveOAuthClientInformation(
-  provider: MCPOAuthProvider,
-  trace: OAuthTrace,
-  authorizationServerUrl: string,
-  metadata: OAuthDiscoveryState["authorizationServerMetadata"],
-  scope?: string,
-  fetchFn?: typeof fetch,
-): Promise<OAuthClientInformation> {
-  startOAuthTraceStep(trace, "request_client_registration", {
-    message: "Resolving OAuth client information.",
-  });
-
-  const existingClientInformation = await provider.clientInformation();
-  if (existingClientInformation?.client_id) {
-    completeOAuthTraceStep(trace, "request_client_registration", {
-      message: "Using stored or preregistered client information.",
-      details: {
-        clientId: existingClientInformation.client_id,
-      },
-    });
-    completeOAuthTraceStep(trace, "received_client_credentials", {
-      message: "Client credentials are ready.",
-      details: {
-        clientId: existingClientInformation.client_id,
-      },
-    });
-    return existingClientInformation;
-  }
-
-  try {
-    const registeredClient = await registerClient(authorizationServerUrl, {
-      metadata,
-      clientMetadata: provider.clientMetadata,
-      ...(scope ? { scope } : {}),
-      ...(fetchFn ? { fetchFn } : {}),
-    });
-    await provider.saveClientInformation(registeredClient);
-    completeOAuthTraceStep(trace, "request_client_registration", {
-      message: "Dynamic client registration completed.",
-      details: {
-        clientId: registeredClient.client_id,
-      },
-    });
-    completeOAuthTraceStep(trace, "received_client_credentials", {
-      message: "Client credentials are ready.",
-      details: {
-        clientId: registeredClient.client_id,
-      },
-    });
-    return registeredClient;
-  } catch (error) {
-    failOAuthTraceStep(trace, "request_client_registration", error, {
-      message: "Dynamic client registration failed.",
-    });
-    throw error;
-  }
-}
-
-async function attemptRefreshWithStoredTokens(
-  provider: MCPOAuthProvider,
-  trace: OAuthTrace,
-  authorizationServerUrl: string,
-  metadata: OAuthDiscoveryState["authorizationServerMetadata"],
-  resource: URL | null,
-  fetchFn: typeof fetch,
-): Promise<OAuthTokens | null> {
-  const existingTokens = provider.tokens();
-  if (!existingTokens?.refresh_token) {
-    return null;
-  }
-
-  startOAuthTraceStep(trace, "token_request", {
-    message: "Attempting to refresh stored OAuth tokens before redirecting.",
-  });
-
-  try {
-    const refreshedTokens = await fetchToken(provider, authorizationServerUrl, {
-      metadata,
-      ...(resource ? { resource } : {}),
-      fetchFn,
-    });
-    await provider.saveTokens(refreshedTokens);
-    completeOAuthTraceStep(trace, "token_request", {
-      message: "Stored refresh token succeeded.",
-    });
-    completeOAuthTraceStep(trace, "received_access_token", {
-      message: "Refreshed OAuth tokens are ready.",
-    });
-    completeOAuthTraceStep(trace, "complete", {
-      message: "OAuth completed using the stored refresh token.",
-    });
-    return refreshedTokens;
-  } catch (error) {
-    const invalidClient = shouldInvalidateOAuthClient(error);
-    failOAuthTraceStep(trace, "token_request", error, {
-      message:
-        "Stored refresh token failed. Falling back to an interactive authorization flow.",
-    });
-    await provider.invalidateCredentials(invalidClient ? "all" : "tokens");
-    resolveOAuthTraceStepError(trace, "token_request", {
-      message:
-        "Stored refresh failure was recovered by falling back to an interactive OAuth flow.",
-    });
-    return null;
-  }
-}
-
 /**
  * Initiates OAuth flow for an MCP server
  */
 export async function initiateOAuth(
   options: MCPOAuthOptions,
 ): Promise<OAuthResult> {
-  const trace = createOAuthTrace({
-    source: "interactive_connect",
-    serverName: options.serverName,
-    serverUrl: options.serverUrl,
-  });
-  // Build fetch interceptor — routes token requests through Convex for registry servers
-  const fetchFn = createOAuthFetchInterceptor(
-    {
-      registryServerId: options.registryServerId,
-      useRegistryOAuthProxy: options.useRegistryOAuthProxy,
-    },
-    trace,
-  );
+  let state = cloneEmptyFlowState();
+  const updateState = (updates: Partial<OAuthFlowState>) => {
+    state = { ...state, ...updates };
+  };
+  const getState = () => state;
 
   try {
     const provider = new MCPOAuthProvider(
@@ -1024,6 +1360,19 @@ export async function initiateOAuth(
       options.clientId,
       options.clientSecret,
     );
+    const protocolVersion = resolveOAuthProtocolVersion(options);
+    const registrationStrategy = resolveOAuthRegistrationStrategy(
+      options,
+      provider,
+    );
+    const fetchFn = createOAuthFetchInterceptor(
+      {
+        registryServerId: options.registryServerId,
+        useRegistryOAuthProxy: options.useRegistryOAuthProxy,
+      },
+      undefined,
+    );
+    const requestExecutor = createOAuthRequestExecutor(fetchFn);
 
     // Store server URL for callback recovery
     localStorage.setItem(
@@ -1066,114 +1415,89 @@ export async function initiateOAuth(
       options.scopes && options.scopes.length > 0
         ? options.scopes.join(" ")
         : undefined;
-
-    startOAuthTraceStep(trace, "request_resource_metadata", {
-      message: "Discovering protected resource metadata.",
-    });
-    const discoveryState = await loadCallbackDiscoveryState(
-      provider,
-      options.serverUrl,
-      fetchFn,
-    );
-    completeOAuthTraceStep(trace, "request_resource_metadata", {
-      message: "Protected resource metadata loaded.",
-      details: {
-        authorizationServerUrl: discoveryState.authorizationServerUrl,
-        resource:
-          discoveryState.resourceMetadata?.resource ?? options.serverUrl,
+    const flowResult = await runOAuthStateMachine({
+      protocolVersion,
+      registrationStrategy,
+      state,
+      getState,
+      updateState,
+      serverUrl: options.serverUrl,
+      serverName: options.serverName,
+      redirectUrl: provider.redirectUrl,
+      requestExecutor,
+      loadPreregisteredCredentials: async () => {
+        const clientInformation = provider.clientInformation();
+        return {
+          clientId: clientInformation?.client_id,
+          clientSecret: clientInformation?.client_secret,
+        };
+      },
+      dynamicRegistration: {
+        ...getBrowserDebugDynamicRegistrationMetadata(protocolVersion),
+        ...provider.clientMetadata,
+      },
+      clientIdMetadataUrl: DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
+      customScopes: requestedScope,
+      customHeaders: options.customHeaders,
+      authMode: "interactive",
+      onAuthorizationRequest: async ({ authorizationUrl }) => {
+        await persistOAuthStateArtifacts(provider, getState());
+        saveOAuthFlowSession(options.serverName, {
+          version: 1,
+          protocolVersion,
+          registrationStrategy,
+          state: cloneFlowState(getState()),
+        });
+        const redirectTrace = buildOAuthTraceFromFlowState({
+          source: "interactive_connect",
+          serverName: options.serverName,
+          serverUrl: options.serverUrl,
+          state: getState(),
+        });
+        saveOAuthTrace(options.serverName, redirectTrace);
+        await provider.redirectToAuthorization(new URL(authorizationUrl));
+        return { type: "redirect" };
       },
     });
-    completeOAuthTraceStep(trace, "received_resource_metadata", {
-      message: "Resource metadata is ready.",
-      details: {
-        authorizationServers:
-          discoveryState.resourceMetadata?.authorization_servers ?? [],
-      },
-    });
 
-    startOAuthTraceStep(trace, "request_authorization_server_metadata", {
-      message: "Loading authorization server metadata.",
-      details: {
-        authorizationServerUrl: discoveryState.authorizationServerUrl,
-      },
+    const trace = buildOAuthTraceFromFlowState({
+      source: "interactive_connect",
+      serverName: options.serverName,
+      serverUrl: options.serverUrl,
+      state: flowResult.state,
     });
-    completeOAuthTraceStep(trace, "request_authorization_server_metadata", {
-      message: "Authorization server metadata loaded.",
-    });
-    completeOAuthTraceStep(trace, "received_authorization_server_metadata", {
-      message: "Authorization server metadata is ready.",
-      details: {
-        authorizationEndpoint:
-          discoveryState.authorizationServerMetadata?.authorization_endpoint,
-        tokenEndpoint:
-          discoveryState.authorizationServerMetadata?.token_endpoint,
-      },
-    });
+    saveOAuthTrace(options.serverName, trace);
 
-    const resource = await selectResourceURL(
-      options.serverUrl,
-      provider,
-      discoveryState.resourceMetadata,
-    );
-
-    const refreshedTokens = await attemptRefreshWithStoredTokens(
-      provider,
-      trace,
-      discoveryState.authorizationServerUrl,
-      discoveryState.authorizationServerMetadata,
-      resource ?? null,
-      fetchFn,
-    );
-    if (refreshedTokens) {
-      saveOAuthTrace(options.serverName, trace);
+    if (flowResult.error) {
       return {
-        success: true,
-        serverConfig: createServerConfig(options.serverUrl, refreshedTokens),
+        success: false,
+        error: formatOAuthCallbackError(flowResult.error.message),
         oauthTrace: trace,
       };
     }
 
-    const clientInformation = await resolveOAuthClientInformation(
-      provider,
-      trace,
-      discoveryState.authorizationServerUrl,
-      discoveryState.authorizationServerMetadata,
-      requestedScope,
-      fetchFn,
-    );
+    if (flowResult.redirected) {
+      return {
+        success: true,
+        oauthTrace: trace,
+      };
+    }
 
-    startOAuthTraceStep(trace, "generate_pkce_parameters", {
-      message: "Generating PKCE verifier and challenge.",
-    });
-    const { authorizationUrl, codeVerifier } = await startAuthorization(
-      discoveryState.authorizationServerUrl,
-      {
-        metadata: discoveryState.authorizationServerMetadata,
-        clientInformation,
-        redirectUrl: provider.redirectUrl,
-        ...(requestedScope ? { scope: requestedScope } : {}),
-        state: provider.state(),
-        ...(resource ? { resource } : {}),
-      },
-    );
-    completeOAuthTraceStep(trace, "generate_pkce_parameters", {
-      message: "PKCE verifier and challenge are ready.",
-    });
-    startOAuthTraceStep(trace, "authorization_request", {
-      message: "Preparing authorization redirect.",
-    });
-    await provider.saveCodeVerifier(codeVerifier);
-    completeOAuthTraceStep(trace, "authorization_request", {
-      message: "Redirecting to the authorization server.",
-      details: {
-        authorizationUrl: authorizationUrl.toString(),
-      },
-    });
-    saveOAuthTrace(options.serverName, trace);
-    await provider.redirectToAuthorization(authorizationUrl);
+    if (flowResult.completed && flowResult.state.accessToken) {
+      await persistOAuthStateArtifacts(provider, flowResult.state);
+      clearOAuthFlowSession(options.serverName);
+      return {
+        success: true,
+        serverConfig: createServerConfig(options.serverUrl, {
+          access_token: flowResult.state.accessToken,
+        }),
+        oauthTrace: trace,
+      };
+    }
 
     return {
-      success: true,
+      success: false,
+      error: "OAuth flow did not complete.",
       oauthTrace: trace,
     };
   } catch (error) {
@@ -1198,8 +1522,14 @@ export async function initiateOAuth(
       }
     }
 
-    failOAuthTraceStep(trace, trace.currentStep, errorMessage, {
-      message: "OAuth initialization failed.",
+    const trace = buildOAuthTraceFromFlowState({
+      source: "interactive_connect",
+      serverName: options.serverName,
+      serverUrl: options.serverUrl,
+      state: {
+        ...getState(),
+        error: errorMessage,
+      },
     });
     saveOAuthTrace(options.serverName, trace);
 
@@ -1348,6 +1678,7 @@ export async function completeHostedOAuthCallback(
         : callbackTrace,
     );
     saveOAuthTrace(serverName, mergedTrace);
+    clearOAuthFlowSession(serverName);
 
     return {
       success: true,
@@ -1386,6 +1717,7 @@ export async function completeHostedOAuthCallback(
           : callbackTrace;
     if (serverName) {
       saveOAuthTrace(serverName, mergedTrace);
+      clearOAuthFlowSession(serverName);
     }
     return {
       success: false,
@@ -1403,16 +1735,9 @@ export async function handleOAuthCallback(
 ): Promise<OAuthResult & { serverName?: string }> {
   // Get pending server name from localStorage (needed before creating interceptor)
   const serverName = localStorage.getItem("mcp-oauth-pending");
-  const callbackTrace = createOAuthTrace({
-    source: "callback",
-    serverName: serverName ?? undefined,
-  });
 
   // Read registryServerId from stored OAuth config if present
   const oauthConfig = readStoredOAuthConfig(serverName);
-
-  // Build fetch interceptor — routes token requests through Convex for registry servers
-  const fetchFn = createOAuthFetchInterceptor(oauthConfig, callbackTrace);
 
   try {
     if (!serverName) {
@@ -1424,12 +1749,6 @@ export async function handleOAuthCallback(
     if (!serverUrl) {
       throw new Error("Server URL not found for OAuth callback");
     }
-    startOAuthTraceStep(callbackTrace, "received_authorization_code", {
-      message: "Received OAuth callback and loading stored state.",
-      details: {
-        serverUrl,
-      },
-    });
 
     // Get stored client credentials if any
     const storedClientInfo = localStorage.getItem(`mcp-client-${serverName}`);
@@ -1446,6 +1765,97 @@ export async function handleOAuthCallback(
       customClientId,
       customClientSecret,
     );
+    const fetchFn = createOAuthFetchInterceptor(oauthConfig, undefined);
+    const requestExecutor = createOAuthRequestExecutor(fetchFn);
+    const storedSession = loadOAuthFlowSession(serverName);
+
+    if (storedSession) {
+      let state = cloneFlowState(storedSession.state);
+      const updateState = (updates: Partial<OAuthFlowState>) => {
+        state = { ...state, ...updates };
+      };
+      const getState = () => state;
+
+      updateState({
+        currentStep: "received_authorization_code",
+        authorizationCode,
+        error: undefined,
+      });
+
+      const flowResult = await runOAuthStateMachine({
+        protocolVersion: storedSession.protocolVersion,
+        registrationStrategy: storedSession.registrationStrategy,
+        state,
+        getState,
+        updateState,
+        serverUrl,
+        serverName,
+        redirectUrl: provider.redirectUrl,
+        requestExecutor,
+        loadPreregisteredCredentials: async () => {
+          const clientInformation = provider.clientInformation();
+          return {
+            clientId: clientInformation?.client_id,
+            clientSecret: clientInformation?.client_secret,
+          };
+        },
+        dynamicRegistration: {
+          ...getBrowserDebugDynamicRegistrationMetadata(
+            storedSession.protocolVersion,
+          ),
+          ...provider.clientMetadata,
+        },
+        clientIdMetadataUrl: DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
+        customScopes: oauthConfig.scopes?.join(" "),
+        customHeaders: oauthConfig.customHeaders,
+        authMode: "interactive",
+      });
+
+      const callbackTrace = buildOAuthTraceFromFlowState({
+        source: "callback",
+        serverName,
+        serverUrl,
+        state: flowResult.state,
+      });
+      const mergedTrace = mergeOAuthTraces(
+        loadOAuthTrace(serverName),
+        callbackTrace,
+      );
+      saveOAuthTrace(serverName, mergedTrace);
+
+      if (flowResult.error || !flowResult.completed || !flowResult.state.accessToken) {
+        return {
+          success: false,
+          error: formatOAuthCallbackError(
+            flowResult.error?.message || flowResult.state.error,
+          ),
+          oauthTrace: mergedTrace,
+        };
+      }
+
+      await persistOAuthStateArtifacts(provider, flowResult.state);
+      clearOAuthFlowSession(serverName);
+      localStorage.removeItem("mcp-oauth-pending");
+      return {
+        success: true,
+        serverConfig: createServerConfig(serverUrl, {
+          access_token: flowResult.state.accessToken,
+        }),
+        serverName,
+        oauthTrace: mergedTrace,
+      };
+    }
+
+    const callbackTrace = createOAuthTrace({
+      source: "callback",
+      serverName: serverName ?? undefined,
+    });
+    startOAuthTraceStep(callbackTrace, "received_authorization_code", {
+      message: "Received OAuth callback and loading stored state.",
+      details: {
+        serverUrl,
+      },
+    });
     const clientInformation = await provider.clientInformation();
     if (!clientInformation?.client_id) {
       throw new Error("OAuth client ID not found");
@@ -1508,8 +1918,18 @@ export async function handleOAuthCallback(
       oauthTrace: mergedTrace,
     };
   } catch (error) {
-    failOAuthTraceStep(callbackTrace, callbackTrace.currentStep, error, {
-      message: "OAuth callback failed.",
+    const callbackTrace = buildOAuthTraceFromFlowState({
+      source: "callback",
+      serverName: serverName ?? undefined,
+      serverUrl:
+        serverName != null
+          ? (localStorage.getItem(`mcp-serverUrl-${serverName}`) ?? "")
+          : "",
+      state: {
+        ...cloneEmptyFlowState(),
+        currentStep: "received_authorization_code",
+        error: formatOAuthCallbackError(error),
+      },
     });
     const mergedTrace = serverName
       ? mergeOAuthTraces(loadOAuthTrace(serverName), callbackTrace)
@@ -1749,6 +2169,7 @@ export function clearOAuthData(serverName: string): void {
   localStorage.removeItem(`mcp-serverUrl-${serverName}`);
   localStorage.removeItem(`mcp-oauth-config-${serverName}`);
   clearStoredDiscoveryState(serverName);
+  clearOAuthFlowSession(serverName);
   clearOAuthTrace(serverName);
 }
 

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -34,6 +34,7 @@ import {
   failOAuthTraceStep,
   loadOAuthTrace,
   mergeOAuthTraces,
+  resolveOAuthTraceStepError,
   saveOAuthTrace,
   startOAuthTraceStep,
   type OAuthTrace,
@@ -96,9 +97,39 @@ function redactSensitiveValue(value: unknown): string {
   return `${value.slice(0, 4)}...[redacted]...${value.slice(-2)}`;
 }
 
+function sanitizeOAuthTraceString(value: string): unknown {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+
+  const looksStructured =
+    trimmed.includes("=") ||
+    trimmed.includes("&") ||
+    ((trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+      (trimmed.startsWith("[") && trimmed.endsWith("]")));
+  if (looksStructured) {
+    const parsed = parseOAuthRequestFields(trimmed);
+    if (parsed) {
+      return sanitizeOAuthTraceValue(parsed);
+    }
+  }
+
+  return trimmed
+    .replace(
+      /\b(access_token|refresh_token|id_token|client_secret|code_verifier)\b(\s*[:=]\s*)([^\s&,;]+)/gi,
+      (_match, key: string, separator: string) => `${key}${separator}[redacted]`,
+    )
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+\b/gi, "Bearer [redacted]");
+}
+
 function sanitizeOAuthTraceValue(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map((item) => sanitizeOAuthTraceValue(item));
+  }
+
+  if (typeof value === "string") {
+    return sanitizeOAuthTraceString(value);
   }
 
   if (!value || typeof value !== "object") {
@@ -145,6 +176,51 @@ function createHttpHistoryEntry(input: {
       body: sanitizeOAuthTraceValue(input.body),
     },
   };
+}
+
+async function readResponseBodyForTrace(response: Response): Promise<unknown> {
+  try {
+    return sanitizeOAuthTraceValue(await response.clone().json());
+  } catch {
+    try {
+      const text = await response.clone().text();
+      return text ? sanitizeOAuthTraceValue(text) : null;
+    } catch {
+      return null;
+    }
+  }
+}
+
+function getOAuthErrorCode(error: unknown): string | undefined {
+  if (error && typeof error === "object") {
+    const record = error as Record<string, unknown>;
+    if (typeof record.code === "string") {
+      return record.code.toLowerCase();
+    }
+    if (typeof record.error === "string") {
+      return record.error.toLowerCase();
+    }
+  }
+
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    if (message.includes("invalid_client")) {
+      return "invalid_client";
+    }
+    if (message.includes("unauthorized_client")) {
+      return "unauthorized_client";
+    }
+    if (message.includes("invalid_grant")) {
+      return "invalid_grant";
+    }
+  }
+
+  return undefined;
+}
+
+function shouldInvalidateOAuthClient(error: unknown): boolean {
+  const code = getOAuthErrorCode(error);
+  return code === "invalid_client" || code === "unauthorized_client";
 }
 
 export function readStoredOAuthConfig(
@@ -469,7 +545,7 @@ function createOAuthFetchInterceptor(
           headers: sanitizeOAuthHeaders(
             Object.fromEntries(response.headers.entries()),
           ),
-          body: sanitizeOAuthTraceValue(await response.clone().json().catch(() => null)),
+          body: await readResponseBodyForTrace(response),
         };
         entry.duration = Date.now() - entry.timestamp;
         return response;
@@ -492,7 +568,7 @@ function createOAuthFetchInterceptor(
           headers: sanitizeOAuthHeaders(
             Object.fromEntries(response.headers.entries()),
           ),
-          body: sanitizeOAuthTraceValue(await response.clone().json().catch(() => null)),
+          body: await readResponseBodyForTrace(response),
         };
         entry.duration = Date.now() - entry.timestamp;
         return response;
@@ -520,7 +596,7 @@ function createOAuthFetchInterceptor(
           headers: sanitizeOAuthHeaders(
             Object.fromEntries(response.headers.entries()),
           ),
-          body: sanitizeOAuthTraceValue(await response.clone().json().catch(() => null)),
+          body: await readResponseBodyForTrace(response),
         };
         entry.duration = Date.now() - entry.timestamp;
         return response;
@@ -907,12 +983,16 @@ async function attemptRefreshWithStoredTokens(
     });
     return refreshedTokens;
   } catch (error) {
+    const invalidClient = shouldInvalidateOAuthClient(error);
     failOAuthTraceStep(trace, "token_request", error, {
       message:
         "Stored refresh token failed. Falling back to an interactive authorization flow.",
     });
-    await provider.invalidateCredentials("tokens");
-    trace.error = undefined;
+    await provider.invalidateCredentials(invalidClient ? "all" : "tokens");
+    resolveOAuthTraceStepError(trace, "token_request", {
+      message:
+        "Stored refresh failure was recovered by falling back to an interactive OAuth flow.",
+    });
     return null;
   }
 }

--- a/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
@@ -20,6 +20,9 @@ export interface OAuthTraceStep {
   message?: string;
   error?: string;
   details?: Record<string, unknown>;
+  recovered?: boolean;
+  recoveredAt?: number;
+  recoveryMessage?: string;
   startedAt: number;
   completedAt?: number;
 }
@@ -39,8 +42,28 @@ function storageKey(serverName: string): string {
   return `mcp-oauth-trace-${serverName}`;
 }
 
+const MAX_OAUTH_TRACE_HTTP_HISTORY = 50;
+
 function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function trimHttpHistory(httpHistory: HttpHistoryEntry[]): HttpHistoryEntry[] {
+  if (httpHistory.length <= MAX_OAUTH_TRACE_HTTP_HISTORY) {
+    return httpHistory;
+  }
+
+  return httpHistory.slice(-MAX_OAUTH_TRACE_HTTP_HISTORY);
+}
+
+function buildPersistableTrace(
+  trace: OAuthTrace,
+  options: { dropHttpHistory?: boolean } = {},
+): OAuthTrace {
+  return clone({
+    ...trace,
+    httpHistory: options.dropHttpHistory ? [] : trimHttpHistory(trace.httpHistory),
+  });
 }
 
 export function createOAuthTrace(input: {
@@ -76,7 +99,23 @@ export function loadOAuthTrace(serverName: string): OAuthTrace | undefined {
 }
 
 export function saveOAuthTrace(serverName: string, trace: OAuthTrace): void {
-  localStorage.setItem(storageKey(serverName), JSON.stringify(trace));
+  try {
+    localStorage.setItem(
+      storageKey(serverName),
+      JSON.stringify(buildPersistableTrace(trace)),
+    );
+  } catch (error) {
+    console.warn("Failed to persist OAuth trace with HTTP history.", error);
+
+    try {
+      localStorage.setItem(
+        storageKey(serverName),
+        JSON.stringify(buildPersistableTrace(trace, { dropHttpHistory: true })),
+      );
+    } catch (retryError) {
+      console.warn("Failed to persist OAuth trace.", retryError);
+    }
+  }
 }
 
 export function clearOAuthTrace(serverName: string): void {
@@ -188,6 +227,30 @@ export function appendOAuthTraceHttpHistory(
   entry: HttpHistoryEntry,
 ): void {
   trace.httpHistory.push(entry);
+  trace.httpHistory = trimHttpHistory(trace.httpHistory);
+}
+
+export function resolveOAuthTraceStepError(
+  trace: OAuthTrace,
+  step: OAuthFlowStep,
+  input: { message?: string } = {},
+): void {
+  const existing = [...trace.steps]
+    .reverse()
+    .find((entry) => entry.step === step && entry.status === "error" && !entry.recovered);
+
+  if (!existing) {
+    return;
+  }
+
+  existing.recovered = true;
+  existing.recoveredAt = Date.now();
+  existing.recoveryMessage = input.message ?? existing.recoveryMessage;
+
+  const remainingFailure = [...trace.steps]
+    .reverse()
+    .find((entry) => entry.status === "error" && !entry.recovered);
+  trace.error = remainingFailure?.error;
 }
 
 export function mergeOAuthTraces(
@@ -195,11 +258,11 @@ export function mergeOAuthTraces(
   next: OAuthTrace,
 ): OAuthTrace {
   if (!base) {
-    return clone(next);
+    return buildPersistableTrace(next);
   }
 
-  return {
-    ...clone(base),
+  return buildPersistableTrace({
+    version: 1,
     source: next.source,
     serverName: next.serverName ?? base.serverName,
     serverUrl: next.serverUrl ?? base.serverUrl,
@@ -209,9 +272,9 @@ export function mergeOAuthTraces(
         left.startedAt - right.startedAt ||
         getStepIndex(left.step) - getStepIndex(right.step),
     ),
-    httpHistory: [...base.httpHistory, ...next.httpHistory],
+    httpHistory: trimHttpHistory([...base.httpHistory, ...next.httpHistory]),
     error: next.error ?? base.error,
-  };
+  });
 }
 
 export function getOAuthTraceFailureStep(
@@ -223,7 +286,7 @@ export function getOAuthTraceFailureStep(
 
   return [...trace.steps]
     .reverse()
-    .find((entry) => entry.status === "error");
+    .find((entry) => entry.status === "error" && !entry.recovered);
 }
 
 export function getOAuthTraceSummary(

--- a/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
@@ -1,0 +1,238 @@
+import {
+  getStepIndex,
+  getStepInfo,
+  type HttpHistoryEntry,
+  type OAuthFlowStep,
+} from "@mcpjam/sdk/browser";
+
+export type OAuthTraceSource =
+  | "interactive_connect"
+  | "callback"
+  | "refresh"
+  | "hosted_callback";
+
+export type OAuthTraceStepStatus = "pending" | "success" | "error";
+
+export interface OAuthTraceStep {
+  step: OAuthFlowStep;
+  title: string;
+  status: OAuthTraceStepStatus;
+  message?: string;
+  error?: string;
+  details?: Record<string, unknown>;
+  startedAt: number;
+  completedAt?: number;
+}
+
+export interface OAuthTrace {
+  version: 1;
+  source: OAuthTraceSource;
+  serverName?: string;
+  serverUrl?: string;
+  currentStep: OAuthFlowStep;
+  steps: OAuthTraceStep[];
+  httpHistory: HttpHistoryEntry[];
+  error?: string;
+}
+
+function storageKey(serverName: string): string {
+  return `mcp-oauth-trace-${serverName}`;
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export function createOAuthTrace(input: {
+  source: OAuthTraceSource;
+  serverName?: string;
+  serverUrl?: string;
+}): OAuthTrace {
+  return {
+    version: 1,
+    source: input.source,
+    serverName: input.serverName,
+    serverUrl: input.serverUrl,
+    currentStep: "idle",
+    steps: [],
+    httpHistory: [],
+  };
+}
+
+export function loadOAuthTrace(serverName: string): OAuthTrace | undefined {
+  try {
+    const raw = localStorage.getItem(storageKey(serverName));
+    if (!raw) {
+      return undefined;
+    }
+    const parsed = JSON.parse(raw) as OAuthTrace;
+    if (parsed?.version !== 1 || !Array.isArray(parsed.steps)) {
+      return undefined;
+    }
+    return parsed;
+  } catch {
+    return undefined;
+  }
+}
+
+export function saveOAuthTrace(serverName: string, trace: OAuthTrace): void {
+  localStorage.setItem(storageKey(serverName), JSON.stringify(trace));
+}
+
+export function clearOAuthTrace(serverName: string): void {
+  localStorage.removeItem(storageKey(serverName));
+}
+
+export function startOAuthTraceStep(
+  trace: OAuthTrace,
+  step: OAuthFlowStep,
+  input: {
+    message?: string;
+    details?: Record<string, unknown>;
+  } = {},
+): void {
+  const existing = trace.steps.find(
+    (entry) => entry.step === step && entry.status === "pending",
+  );
+  if (existing) {
+    existing.message = input.message ?? existing.message;
+    existing.details = input.details ?? existing.details;
+    trace.currentStep = step;
+    return;
+  }
+
+  trace.currentStep = step;
+  trace.error = undefined;
+  trace.steps.push({
+    step,
+    title: getStepInfo(step).title,
+    status: "pending",
+    message: input.message,
+    details: input.details,
+    startedAt: Date.now(),
+  });
+}
+
+export function completeOAuthTraceStep(
+  trace: OAuthTrace,
+  step: OAuthFlowStep,
+  input: {
+    message?: string;
+    details?: Record<string, unknown>;
+  } = {},
+): void {
+  const existing = [...trace.steps]
+    .reverse()
+    .find((entry) => entry.step === step && entry.status === "pending");
+
+  if (existing) {
+    existing.status = "success";
+    existing.message = input.message ?? existing.message;
+    existing.details = input.details ?? existing.details;
+    existing.completedAt = Date.now();
+  } else {
+    trace.steps.push({
+      step,
+      title: getStepInfo(step).title,
+      status: "success",
+      message: input.message,
+      details: input.details,
+      startedAt: Date.now(),
+      completedAt: Date.now(),
+    });
+  }
+
+  trace.currentStep = step;
+}
+
+export function failOAuthTraceStep(
+  trace: OAuthTrace,
+  step: OAuthFlowStep,
+  error: unknown,
+  input: {
+    message?: string;
+    details?: Record<string, unknown>;
+  } = {},
+): void {
+  const errorMessage =
+    error instanceof Error ? error.message : typeof error === "string" ? error : String(error);
+  const existing = [...trace.steps]
+    .reverse()
+    .find((entry) => entry.step === step && entry.status === "pending");
+
+  if (existing) {
+    existing.status = "error";
+    existing.message = input.message ?? existing.message;
+    existing.error = errorMessage;
+    existing.details = input.details ?? existing.details;
+    existing.completedAt = Date.now();
+  } else {
+    trace.steps.push({
+      step,
+      title: getStepInfo(step).title,
+      status: "error",
+      message: input.message,
+      error: errorMessage,
+      details: input.details,
+      startedAt: Date.now(),
+      completedAt: Date.now(),
+    });
+  }
+
+  trace.currentStep = step;
+  trace.error = errorMessage;
+}
+
+export function appendOAuthTraceHttpHistory(
+  trace: OAuthTrace,
+  entry: HttpHistoryEntry,
+): void {
+  trace.httpHistory.push(entry);
+}
+
+export function mergeOAuthTraces(
+  base: OAuthTrace | undefined,
+  next: OAuthTrace,
+): OAuthTrace {
+  if (!base) {
+    return clone(next);
+  }
+
+  return {
+    ...clone(base),
+    source: next.source,
+    serverName: next.serverName ?? base.serverName,
+    serverUrl: next.serverUrl ?? base.serverUrl,
+    currentStep: next.currentStep,
+    steps: [...base.steps, ...next.steps].sort(
+      (left, right) =>
+        left.startedAt - right.startedAt ||
+        getStepIndex(left.step) - getStepIndex(right.step),
+    ),
+    httpHistory: [...base.httpHistory, ...next.httpHistory],
+    error: next.error ?? base.error,
+  };
+}
+
+export function getOAuthTraceFailureStep(
+  trace: OAuthTrace | undefined,
+): OAuthTraceStep | undefined {
+  if (!trace) {
+    return undefined;
+  }
+
+  return [...trace.steps]
+    .reverse()
+    .find((entry) => entry.status === "error");
+}
+
+export function getOAuthTraceSummary(
+  trace: OAuthTrace | undefined,
+): string | undefined {
+  const failure = getOAuthTraceFailureStep(trace);
+  if (!failure?.error) {
+    return undefined;
+  }
+
+  return `${failure.title}: ${failure.error}`;
+}

--- a/mcpjam-inspector/client/src/state/app-reducer.ts
+++ b/mcpjam-inspector/client/src/state/app-reducer.ts
@@ -68,6 +68,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
         lastConnectionTime: new Date(),
         retryCount: 0,
         lastError: undefined,
+        lastOAuthTrace: action.oauthTrace,
         oauthTokens: action.tokens,
         enabled: true,
         // Hosted workspace OAuth can succeed without browser-side tokens.
@@ -107,6 +108,7 @@ export function appReducer(state: AppState, action: AppAction): AppState {
           [action.name]: setStatus(existing, "failed", {
             retryCount: existing.retryCount,
             lastError: action.error,
+            lastOAuthTrace: action.oauthTrace,
           }),
         },
       };

--- a/mcpjam-inspector/client/src/state/app-types.ts
+++ b/mcpjam-inspector/client/src/state/app-types.ts
@@ -2,6 +2,7 @@ import type { MCPServerConfig } from "@mcpjam/sdk/browser";
 import { OauthTokens } from "@/shared/types.js";
 import type { OAuthTestProfile } from "@/lib/oauth/profile";
 import type { WorkspaceClientConfig } from "@/lib/client-config";
+import type { OAuthTrace } from "@/lib/oauth/oauth-trace";
 
 export type ConnectionStatus =
   | "connected"
@@ -41,6 +42,7 @@ export interface ServerWithName {
   connectionStatus: ConnectionStatus;
   retryCount: number;
   lastError?: string;
+  lastOAuthTrace?: OAuthTrace;
   enabled?: boolean;
   /** Whether OAuth is explicitly enabled for this server. When false, reconnect skips OAuth flow. */
   useOAuth?: boolean;
@@ -88,8 +90,14 @@ export type AppAction =
       config: MCPServerConfig;
       tokens?: OauthTokens;
       useOAuth?: boolean;
+      oauthTrace?: OAuthTrace;
     }
-  | { type: "CONNECT_FAILURE"; name: string; error: string }
+  | {
+      type: "CONNECT_FAILURE";
+      name: string;
+      error: string;
+      oauthTrace?: OAuthTrace;
+    }
   | {
       type: "RECONNECT_REQUEST";
       name: string;

--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -78,8 +78,13 @@ export async function ensureAuthorizedForReconnect(
       clientSecret:
         server.oauthTokens?.client_secret || clientInfo?.client_secret,
       scopes: oauthConfig.scopes,
+      customHeaders: oauthConfig.customHeaders,
       registryServerId: oauthConfig.registryServerId,
       useRegistryOAuthProxy: oauthConfig.useRegistryOAuthProxy,
+      protocolVersion: server.oauthFlowProfile?.protocolVersion ?? oauthConfig.protocolVersion,
+      registrationStrategy:
+        server.oauthFlowProfile?.registrationStrategy ??
+        oauthConfig.registrationStrategy,
     } as MCPOAuthOptions;
     options?.beforeRedirect?.(opts);
     const init = await initiateOAuth(opts);

--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -8,14 +8,16 @@ import {
   MCPOAuthOptions,
 } from "@/lib/oauth/mcp-oauth";
 import { ServerWithName } from "./app-types";
+import type { OAuthTrace } from "@/lib/oauth/oauth-trace";
 
 export type OAuthReady = {
   kind: "ready";
   serverConfig: any;
   tokens?: any;
+  oauthTrace?: OAuthTrace;
 };
 export type OAuthRedirect = { kind: "redirect" };
-export type OAuthError = { kind: "error"; error: string };
+export type OAuthError = { kind: "error"; error: string; oauthTrace?: OAuthTrace };
 export type OAuthResult = OAuthReady | OAuthRedirect | OAuthError;
 
 export async function ensureAuthorizedForReconnect(
@@ -49,6 +51,7 @@ export async function ensureAuthorizedForReconnect(
         kind: "ready",
         serverConfig: refreshed.serverConfig,
         tokens: getStoredTokens(server.name),
+        oauthTrace: refreshed.oauthTrace,
       };
     }
   }
@@ -85,12 +88,17 @@ export async function ensureAuthorizedForReconnect(
         kind: "ready",
         serverConfig: init.serverConfig,
         tokens: getStoredTokens(server.name),
+        oauthTrace: init.oauthTrace,
       };
     }
     if (init.success && !init.serverConfig) {
       return { kind: "redirect" };
     }
-    return { kind: "error", error: init.error || "OAuth init failed" };
+    return {
+      kind: "error",
+      error: init.error || "OAuth init failed",
+      oauthTrace: init.oauthTrace,
+    };
   }
 
   return { kind: "error", error: "OAuth refresh failed and no URL present" };

--- a/mcpjam-inspector/client/src/stores/traffic-log-store.ts
+++ b/mcpjam-inspector/client/src/stores/traffic-log-store.ts
@@ -13,13 +13,20 @@ import { create } from "zustand";
 import { addTokenToUrl } from "@/lib/session-token";
 import { HOSTED_MODE } from "@/lib/config";
 import type { HostedRpcLogEvent } from "@/shared/hosted-rpc-log";
+import type {
+  OAuthTrace,
+  OAuthTraceSource,
+  OAuthTraceStepStatus,
+} from "@/lib/oauth/oauth-trace";
 
 export type UiProtocol = "mcp-apps" | "openai-apps";
+export type McpServerLogKind = "rpc" | "oauth";
 
 export interface UiLogEvent {
   id: string;
   widgetId: string; // toolCallId
   serverId: string;
+  serverName?: string;
   direction: "host-to-ui" | "ui-to-host";
   protocol: UiProtocol;
   method: string;
@@ -35,13 +42,17 @@ export interface McpServerRpcItem {
   method: string;
   timestamp: string;
   payload: unknown;
+  kind?: McpServerLogKind;
+  oauthStatus?: OAuthTraceStepStatus;
+  oauthSource?: OAuthTraceSource;
+  oauthRecovered?: boolean;
 }
 
 interface TrafficLogState {
   items: UiLogEvent[];
   mcpServerItems: McpServerRpcItem[];
   addLog: (event: Omit<UiLogEvent, "id" | "timestamp">) => void;
-  addMcpServerLog: (item: Omit<McpServerRpcItem, "id">) => void;
+  addMcpServerLog: (item: Omit<McpServerRpcItem, "id"> & { id?: string }) => void;
   clear: () => void;
 }
 
@@ -63,10 +74,16 @@ export const useTrafficLogStore = create<TrafficLogState>((set) => ({
   addMcpServerLog: (item) => {
     const newItem: McpServerRpcItem = {
       ...item,
-      id: `${item.timestamp}-${Math.random().toString(36).slice(2)}`,
+      id: item.id ?? `${item.timestamp}-${Math.random().toString(36).slice(2)}`,
     };
     set((state) => ({
-      mcpServerItems: [newItem, ...state.mcpServerItems].slice(0, MAX_ITEMS),
+      mcpServerItems: state.mcpServerItems.some(
+        (existing) => existing.id === newItem.id,
+      )
+        ? state.mcpServerItems.map((existing) =>
+            existing.id === newItem.id ? newItem : existing,
+          )
+        : [newItem, ...state.mcpServerItems].slice(0, MAX_ITEMS),
     }));
   },
   clear: () => set({ items: [], mcpServerItems: [] }),
@@ -86,6 +103,47 @@ export function ingestHostedRpcLogs(logs: HostedRpcLogEvent[]): void {
       method: extractMethod(log.message),
       timestamp: log.timestamp,
       payload: log.message,
+    });
+  });
+}
+
+export function ingestOAuthTraceLogs(input: {
+  serverId: string;
+  serverName?: string;
+  trace: OAuthTrace;
+}): void {
+  const { serverId, serverName, trace } = input;
+  if (!trace || !Array.isArray(trace.steps) || trace.steps.length === 0) {
+    return;
+  }
+
+  const store = useTrafficLogStore.getState();
+  trace.steps.forEach((step) => {
+    const timestamp = new Date(step.completedAt ?? step.startedAt).toISOString();
+    store.addMcpServerLog({
+      id: `oauth:${serverId}:${trace.source}:${step.step}:${step.startedAt}`,
+      serverId,
+      serverName,
+      direction: "OAUTH",
+      method: step.title,
+      timestamp,
+      payload: {
+        source: trace.source,
+        step: step.step,
+        title: step.title,
+        status: step.status,
+        message: step.message,
+        error: step.error,
+        details: step.details,
+        recovered: step.recovered,
+        recoveredAt: step.recoveredAt,
+        recoveryMessage: step.recoveryMessage,
+        httpHistory: trace.httpHistory.filter((entry) => entry.step === step.step),
+      },
+      kind: "oauth",
+      oauthStatus: step.status,
+      oauthSource: trace.source,
+      oauthRecovered: step.recovered === true,
     });
   });
 }

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -90,6 +90,12 @@ export {
   getDefaultRegistrationStrategy,
   getSupportedRegistrationStrategies,
 } from "./oauth/state-machines/factory.js";
+export { runOAuthStateMachine } from "./oauth/state-machines/runner.js";
+export type {
+  OAuthAuthorizationRequestResult,
+  OAuthStateMachineRunConfig,
+  OAuthStateMachineRunResult,
+} from "./oauth/state-machines/runner.js";
 export {
   getStepInfo,
   getStepIndex,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -190,6 +190,12 @@ export type {
   OAuthLoginDependencies,
   OAuthLoginResult,
 } from "./oauth-login.js";
+export { runOAuthStateMachine } from "./oauth/state-machines/runner.js";
+export type {
+  OAuthAuthorizationRequestResult,
+  OAuthStateMachineRunConfig,
+  OAuthStateMachineRunResult,
+} from "./oauth/state-machines/runner.js";
 
 // EvalAgent interface (for deterministic testing without concrete TestAgent)
 export type { EvalAgent, PromptOptions } from "./EvalAgent.js";

--- a/sdk/src/oauth-login.ts
+++ b/sdk/src/oauth-login.ts
@@ -5,6 +5,7 @@ import {
   getConformanceClientCredentialsDynamicRegistrationMetadata,
 } from "./oauth/client-identity.js";
 import { createOAuthStateMachine } from "./oauth/state-machines/factory.js";
+import { runOAuthStateMachine } from "./oauth/state-machines/runner.js";
 import {
   EMPTY_OAUTH_FLOW_STATE,
   type OAuthFlowState,
@@ -348,7 +349,7 @@ export async function runOAuthLogin(
       }
     };
 
-    const machine = createOAuthStateMachine({
+    const machineConfig = {
       protocolVersion: config.protocolVersion,
       registrationStrategy: config.registrationStrategy,
       state,
@@ -369,7 +370,67 @@ export async function runOAuthLogin(
       customScopes: config.scopes,
       customHeaders: config.customHeaders,
       authMode: config.auth.mode,
-    });
+    } as const;
+
+    if (config.auth.mode !== "client_credentials") {
+      const flowResult = await runOAuthStateMachine({
+        ...machineConfig,
+        maxSteps: 40,
+        onAuthorizationRequest: async ({ authorizationUrl, state: flowState }) => {
+          try {
+            config.onProgress("Opening browser for authorization...");
+            const authorizationResult =
+              config.auth.mode === "interactive"
+                ? await interactiveSession!.authorize({
+                    authorizationUrl,
+                    expectedState: flowState.state,
+                    timeoutMs: config.stepTimeout,
+                    openUrl: config.auth.openUrl,
+                  })
+                : await (
+                    deps.completeHeadlessAuthorization ??
+                    completeHeadlessAuthorization
+                  )({
+                    authorizationUrl,
+                    redirectUrl,
+                    expectedState: flowState.state,
+                    request: trackedRequest,
+                  });
+
+            config.onProgress("Authorization received, exchanging token...");
+            return {
+              type: "authorization_code" as const,
+              authorizationCode: authorizationResult.code,
+            };
+          } catch (error) {
+            updateState({
+              currentStep: "received_authorization_code",
+              error: error instanceof Error ? error.message : String(error),
+            });
+            throw error;
+          }
+        },
+      });
+
+      if (flowResult.error) {
+        return buildResult(
+          config,
+          redirectUrl,
+          flowResult.state,
+          undefined,
+          flowResult.error.message,
+        );
+      }
+
+      const verification = await runVerification(
+        config,
+        flowResult.state,
+        config.verification,
+      );
+      return buildResult(config, redirectUrl, flowResult.state, verification);
+    }
+
+    const machine = createOAuthStateMachine(machineConfig);
 
     let guard = 0;
     while (state.currentStep !== "complete" && guard < 40) {
@@ -436,59 +497,6 @@ export async function runOAuthLogin(
             config,
             redirectUrl,
             state,
-            undefined,
-            error instanceof Error ? error.message : String(error),
-          );
-        }
-      }
-
-      if (state.currentStep === "authorization_request") {
-        if (!state.authorizationUrl) {
-          return buildResult(
-            config,
-            redirectUrl,
-            state,
-            undefined,
-            "Authorization URL was not generated.",
-          );
-        }
-
-        try {
-          config.onProgress("Opening browser for authorization...");
-          const authorizationResult =
-            config.auth.mode === "interactive"
-              ? await interactiveSession!.authorize({
-                  authorizationUrl: state.authorizationUrl,
-                  expectedState: state.state,
-                  timeoutMs: config.stepTimeout,
-                  openUrl: config.auth.openUrl,
-                })
-              : await (
-                  deps.completeHeadlessAuthorization ??
-                  completeHeadlessAuthorization
-                )({
-                  authorizationUrl: state.authorizationUrl,
-                  redirectUrl,
-                  expectedState: state.state,
-                  request: trackedRequest,
-                });
-
-          config.onProgress("Authorization received, exchanging token...");
-          updateState({
-            currentStep: "received_authorization_code",
-            authorizationCode: authorizationResult.code,
-            error: undefined,
-          });
-          continue;
-        } catch (error) {
-          return buildResult(
-            config,
-            redirectUrl,
-            {
-              ...state,
-              currentStep: "received_authorization_code",
-              error: error instanceof Error ? error.message : String(error),
-            },
             undefined,
             error instanceof Error ? error.message : String(error),
           );

--- a/sdk/src/oauth/state-machines/runner.ts
+++ b/sdk/src/oauth/state-machines/runner.ts
@@ -1,0 +1,176 @@
+import { createOAuthStateMachine } from "./factory.js";
+import type {
+  MaybePromise,
+  OAuthFlowState,
+} from "./types.js";
+import type { OAuthStateMachineFactoryConfig } from "./factory.js";
+
+export type OAuthAuthorizationRequestResult =
+  | {
+      type: "authorization_code";
+      authorizationCode: string;
+    }
+  | {
+      type: "redirect";
+    };
+
+export interface OAuthStateMachineRunConfig
+  extends OAuthStateMachineFactoryConfig {
+  maxSteps?: number;
+  onAuthorizationRequest?: (input: {
+    authorizationUrl: string;
+    state: OAuthFlowState;
+  }) => MaybePromise<OAuthAuthorizationRequestResult>;
+}
+
+export interface OAuthStateMachineRunResult {
+  completed: boolean;
+  redirected: boolean;
+  authorizationUrl?: string;
+  state: OAuthFlowState;
+  error?: {
+    message: string;
+  };
+}
+
+function normalizeError(error: unknown): { message: string } {
+  return {
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+export async function runOAuthStateMachine(
+  config: OAuthStateMachineRunConfig,
+): Promise<OAuthStateMachineRunResult> {
+  const {
+    maxSteps = 40,
+    onAuthorizationRequest,
+    getState: providedGetState,
+    ...machineConfig
+  } = config;
+
+  let localState = config.state;
+  const updateState = (updates: Partial<OAuthFlowState>) => {
+    localState = { ...localState, ...updates };
+    config.updateState(updates);
+  };
+  const getState = providedGetState ?? (() => localState);
+  const machine = createOAuthStateMachine({
+    ...machineConfig,
+    getState,
+    updateState,
+  });
+
+  let guard = 0;
+  while (getState().currentStep !== "complete" && guard < maxSteps) {
+    guard += 1;
+    const currentState = getState();
+
+    if (currentState.currentStep === "authorization_request") {
+      if (!currentState.authorizationUrl) {
+        return {
+          completed: false,
+          redirected: false,
+          state: getState(),
+          error: {
+            message: "Authorization URL was not generated.",
+          },
+        };
+      }
+
+      if (!onAuthorizationRequest) {
+        return {
+          completed: false,
+          redirected: false,
+          authorizationUrl: currentState.authorizationUrl,
+          state: getState(),
+          error: {
+            message: "Authorization request requires an authorization handler.",
+          },
+        };
+      }
+
+      try {
+        const authorizationResult = await onAuthorizationRequest({
+          authorizationUrl: currentState.authorizationUrl,
+          state: currentState,
+        });
+
+        if (authorizationResult.type === "redirect") {
+          return {
+            completed: false,
+            redirected: true,
+            authorizationUrl: currentState.authorizationUrl,
+            state: getState(),
+          };
+        }
+
+        updateState({
+          currentStep: "received_authorization_code",
+          authorizationCode: authorizationResult.authorizationCode,
+          error: undefined,
+        });
+        continue;
+      } catch (error) {
+        return {
+          completed: false,
+          redirected: false,
+          authorizationUrl: currentState.authorizationUrl,
+          state: getState(),
+          error: normalizeError(error),
+        };
+      }
+    }
+
+    const startingStep = currentState.currentStep;
+
+    try {
+      await machine.proceedToNextStep();
+    } catch (error) {
+      return {
+        completed: false,
+        redirected: false,
+        state: getState(),
+        error: normalizeError(error),
+      };
+    }
+
+    const nextState = getState();
+    if (nextState.currentStep === startingStep) {
+      return {
+        completed: false,
+        redirected: false,
+        state: nextState,
+        error: {
+          message: nextState.error || `Step ${startingStep} did not advance.`,
+        },
+      };
+    }
+  }
+
+  const finalState = getState();
+  if (guard >= maxSteps && finalState.currentStep !== "complete") {
+    return {
+      completed: false,
+      redirected: false,
+      state: finalState,
+      error: {
+        message: "OAuth login exceeded its step guard.",
+      },
+    };
+  }
+
+  return {
+    completed: finalState.currentStep === "complete",
+    redirected: false,
+    authorizationUrl: finalState.authorizationUrl,
+    state: finalState,
+    ...(finalState.error
+      ? {
+          error: {
+            message: finalState.error,
+          },
+        }
+      : {}),
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Large refactor of OAuth initiation/callback/refresh flow to a new SDK runner with persisted state and detailed tracing, plus new UI surfaces for those traces; mistakes could break login/refresh or leak sensitive data if redaction is incomplete.
> 
> **Overview**
> Refactors the client OAuth implementation to use a new SDK `runOAuthStateMachine` runner, persisting flow state across redirects and producing a structured `OAuthTrace` (steps + bounded HTTP history) with redaction/sanitization.
> 
> Plumbs `oauthTrace` through connection/reconnect paths (`CONNECT_SUCCESS`/`CONNECT_FAILURE`, `ensureAuthorizedForReconnect`) and exposes it in the UI: the server card/error panels now identify the OAuth step that failed, the server detail overview renders the full “Last OAuth Trace”, and `LoggerView` ingests trace steps as filterable `oauth` log entries with status/recovered indicators.
> 
> Adds the new `oauth-trace` module and corresponding store/test updates (deduping log IDs, OAuth log kind/status fields), and exports the runner from the SDK for browser/node usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34238f7ec86155ef054e8b862a0d7fb69b5bd62e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->