### PR TITLE
handling autogenerated tests suites

### DIFF
--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -10,6 +10,7 @@ import { useWorkspaceServers } from "@/hooks/useViews";
 import { useEvalsRoute } from "@/lib/evals-router";
 import { useEvalTabContext } from "@/hooks/use-eval-tab-context";
 import { useIsDirectGuest } from "@/hooks/use-is-direct-guest";
+import { useSharedAppState } from "@/state/app-state-context";
 import { aggregateSuite } from "./evals/helpers";
 import { EvalTabGate } from "./evals/EvalTabGate";
 import {
@@ -33,12 +34,15 @@ import { usePlaygroundWorkspaceExecutions } from "./evals/use-playground-workspa
 import type { EvalIteration } from "./evals/types";
 import type { EvalChatHandoff } from "@/lib/eval-chat-handoff";
 import type { EnsureServersReadyResult } from "@/hooks/use-app-state";
-import { EXPLORE_SUITE_TAG, isExploreSuite } from "./evals/constants";
+import { isExploreSuite } from "./evals/constants";
 import { generateAndPersistEvalTests } from "@/lib/evals/generate-and-persist-tests";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 
 const FIRST_SUITE_EMPTY_DESCRIPTION =
   "A suite groups eval cases with the MCP servers they use. Create one, then generate cases or import a chat transcript.";
+
+const workspaceServerKey = (workspaceId: string, serverName: string) =>
+  `${workspaceId}::${serverName}`;
 
 // Module-scoped so an in-flight explore-suite create still blocks duplicate
 // creates if the EvalsTab unmounts and remounts before the create finishes.
@@ -62,8 +66,11 @@ export function EvalsTab({
   const convex = useConvex();
   const { user, getAccessToken } = useAuth();
   const route = useEvalsRoute();
+  const appState = useSharedAppState();
   const [workspaceBrowse, setWorkspaceBrowse] =
     useState<PlaygroundWorkspaceBrowse>("suites");
+  const [locallySuppressedServerKeys, setLocallySuppressedServerKeys] =
+    useState<string[]>([]);
   const isDirectGuest = useIsDirectGuest({ workspaceId });
   const {
     connectedServerNames,
@@ -260,9 +267,10 @@ export function EvalsTab({
   }, [overviewQueries.isOverviewLoading, route.type, selectedSuiteEntry, selectedSuiteId]);
 
   // ---------------------------------------------------------------------------
-  // Auto-create an explore suite for each connected server that doesn't have one
+  // Auto-create a Playground suite for each connected server that doesn't have
+  // one, unless that server's auto-suite has been explicitly deleted.
   // ---------------------------------------------------------------------------
-  const createTestSuiteMutation = mutations.createTestSuiteMutation;
+  const ensureAutoEvalSuiteMutation = mutations.ensureAutoEvalSuiteMutation;
   const createTestCaseMutation = mutations.createTestCaseMutation;
 
   useEffect(() => {
@@ -283,11 +291,15 @@ export function EvalsTab({
     );
 
     const inFlightKeyFor = (serverName: string) =>
-      `${workspaceId}::${serverName}`;
+      workspaceServerKey(workspaceId, serverName);
 
     const serversNeedingSuite = [...connectedServerNames].filter(
       (name) =>
         !serversWithExploreSuite.has(name) &&
+        appState.servers[name]?.autoEvalSuiteSuppressedAt === undefined &&
+        !locallySuppressedServerKeys.includes(
+          workspaceServerKey(workspaceId, name),
+        ) &&
         !explorePrefetchInFlight.has(inFlightKeyFor(name)),
     );
 
@@ -301,27 +313,32 @@ export function EvalsTab({
 
       void (async () => {
         try {
-          // Pass tags atomically in the initial create. A second mutation to
-          // tag would risk an orphan untagged suite if it failed, which would
-          // bypass `isExploreSuite` and let the next pass create a duplicate.
-          const createdSuite = await createTestSuiteMutation({
+          const result = await ensureAutoEvalSuiteMutation({
             workspaceId,
-            name: serverName,
-            description: `Explore cases for ${serverName}`,
-            environment: { servers: [serverName] },
-            tags: [EXPLORE_SUITE_TAG],
+            serverName,
+            mode: "auto",
           });
 
-          if (!createdSuite?._id) return;
+          if (result.status === "suppressed") {
+            setLocallySuppressedServerKeys((previous) =>
+              previous.includes(workspaceServerKey(workspaceId, serverName))
+                ? previous
+                : [...previous, workspaceServerKey(workspaceId, serverName)],
+            );
+            return;
+          }
+
+          if (result.status !== "created") {
+            return;
+          }
 
           const outcome = await generateAndPersistEvalTests({
             convex,
             getAccessToken,
             workspaceId,
-            suiteId: createdSuite._id,
+            suiteId: result.suite._id,
             serverIds: [serverName],
             createTestCase: createTestCaseMutation,
-            skipIfExistingCases: true,
           });
 
           if (outcome.createdCount > 0) {
@@ -331,7 +348,7 @@ export function EvalsTab({
               environment: detectEnvironment(),
               workspace_id: workspaceId,
               server_name: serverName,
-              suite_id: createdSuite._id,
+              suite_id: result.suite._id,
               generated_count: outcome.createdCount,
             });
           }
@@ -345,12 +362,14 @@ export function EvalsTab({
   }, [
     isAuthenticated,
     workspaceId,
+    appState.servers,
     connectedServerNames,
+    locallySuppressedServerKeys,
     visibleSuites,
     overviewQueries.isOverviewLoading,
     convex,
     getAccessToken,
-    createTestSuiteMutation,
+    ensureAutoEvalSuiteMutation,
     createTestCaseMutation,
   ]);
 
@@ -378,6 +397,77 @@ export function EvalsTab({
       }
 
       try {
+        const singleServerName =
+          payload.selectedServers.length === 1
+            ? payload.selectedServers[0]
+            : null;
+        const isSuppressedAutoSuiteRecreate = Boolean(
+          singleServerName &&
+            (appState.servers[singleServerName]?.autoEvalSuiteSuppressedAt !==
+              undefined ||
+              locallySuppressedServerKeys.includes(
+                workspaceServerKey(workspaceId, singleServerName),
+              )),
+        );
+
+        if (singleServerName && isSuppressedAutoSuiteRecreate) {
+          const result = await mutations.ensureAutoEvalSuiteMutation({
+            workspaceId,
+            serverName: singleServerName,
+            mode: "manual",
+          });
+
+          const nextDescription = payload.description ?? "";
+          const suiteUpdates: {
+            suiteId: string;
+            name?: string;
+            description?: string;
+          } = {
+            suiteId: result.suite._id,
+          };
+
+          if (payload.name !== result.suite.name) {
+            suiteUpdates.name = payload.name;
+          }
+          if (nextDescription !== (result.suite.description ?? "")) {
+            suiteUpdates.description = nextDescription;
+          }
+          if (
+            suiteUpdates.name !== undefined ||
+            suiteUpdates.description !== undefined
+          ) {
+            await mutations.updateTestSuiteMutation(suiteUpdates);
+          }
+
+          if (
+            result.status === "created" &&
+            connectedServerNames.has(singleServerName)
+          ) {
+            await generateAndPersistEvalTests({
+              convex,
+              getAccessToken,
+              workspaceId,
+              suiteId: result.suite._id,
+              serverIds: [singleServerName],
+              createTestCase: createTestCaseMutation,
+            });
+          }
+
+          setLocallySuppressedServerKeys((previous) =>
+            previous.filter(
+              (serverKey) =>
+                serverKey !== workspaceServerKey(workspaceId, singleServerName),
+            ),
+          );
+
+          toast.success("Suite created");
+          navigatePlaygroundEvalsRoute({
+            type: "suite-overview",
+            suiteId: result.suite._id,
+          });
+          return;
+        }
+
         const createdSuite = await mutations.createTestSuiteMutation({
           workspaceId,
           name: payload.name,
@@ -401,7 +491,18 @@ export function EvalsTab({
         throw error;
       }
     },
-    [mutations.createTestSuiteMutation, workspaceId],
+    [
+      appState.servers,
+      connectedServerNames,
+      convex,
+      createTestCaseMutation,
+      getAccessToken,
+      locallySuppressedServerKeys,
+      mutations.createTestSuiteMutation,
+      mutations.ensureAutoEvalSuiteMutation,
+      mutations.updateTestSuiteMutation,
+      workspaceId,
+    ],
   );
 
   const handleWorkspaceBrowseChange = useCallback(

--- a/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
@@ -3,6 +3,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+const { generateAndPersistEvalTestsMock } = vi.hoisted(() => ({
+  generateAndPersistEvalTestsMock: vi.fn().mockResolvedValue({
+    skippedBecauseExistingCases: false,
+    createdCount: 0,
+    apiReturnedTests: 0,
+    createdTestCaseIds: [],
+  }),
+}));
+
 const mocks = vi.hoisted(() => ({
   route: {
     current: { type: "suite-overview" as const, suiteId: "suite-a" },
@@ -10,10 +19,16 @@ const mocks = vi.hoisted(() => ({
   useEvalQueries: vi.fn(),
   navigatePlaygroundEvalsRoute: vi.fn(),
   createTestSuiteMutation: vi.fn(),
+  ensureAutoEvalSuiteMutation: vi.fn(),
   suiteIterationsView: vi.fn(),
   updateSuiteMutation: vi.fn(),
   handleGenerateTests: vi.fn(),
   isDirectGuest: false,
+  connectedServerNames: new Set(["server-a", "server-b"]),
+  appStateServers: {
+    "server-a": { connectionStatus: "connected" },
+    "server-b": { connectionStatus: "connected" },
+  } as Record<string, Record<string, unknown>>,
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({
@@ -36,17 +51,12 @@ vi.mock("posthog-js", () => ({
 }));
 
 vi.mock("@/lib/evals/generate-and-persist-tests", () => ({
-  generateAndPersistEvalTests: vi.fn().mockResolvedValue({
-    skippedBecauseExistingCases: false,
-    createdCount: 0,
-    apiReturnedTests: 0,
-    createdTestCaseIds: [],
-  }),
+  generateAndPersistEvalTests: generateAndPersistEvalTestsMock,
 }));
 
 vi.mock("@/hooks/use-eval-tab-context", () => ({
   useEvalTabContext: () => ({
-    connectedServerNames: new Set(["server-a", "server-b"]),
+    connectedServerNames: mocks.connectedServerNames,
     userMap: new Map(),
     canDeleteSuite: false,
     canDeleteRuns: false,
@@ -69,10 +79,7 @@ vi.mock("@/hooks/use-is-direct-guest", () => ({
 
 vi.mock("@/state/app-state-context", () => ({
   useSharedAppState: () => ({
-    servers: {
-      "server-a": { connectionStatus: "connected" },
-      "server-b": { connectionStatus: "connected" },
-    },
+    servers: mocks.appStateServers,
   }),
 }));
 
@@ -118,7 +125,30 @@ vi.mock("../evals/use-playground-workspace-executions", () => ({
 }));
 
 vi.mock("../evals/create-suite-dialog", () => ({
-  CreateSuiteDialog: () => null,
+  CreateSuiteDialog: ({
+    open,
+    onSubmit,
+  }: {
+    open: boolean;
+    onSubmit: (payload: {
+      name: string;
+      description?: string;
+      selectedServers: string[];
+    }) => Promise<void>;
+  }) =>
+    open ? (
+      <button
+        type="button"
+        onClick={() =>
+          void onSubmit({
+            name: "server-a",
+            selectedServers: ["server-a"],
+          })
+        }
+      >
+        Submit create suite
+      </button>
+    ) : null,
 }));
 
 vi.mock("../evals/suite-iterations-view", () => ({
@@ -131,6 +161,7 @@ vi.mock("../evals/suite-iterations-view", () => ({
 vi.mock("../evals/use-eval-mutations", () => ({
   useEvalMutations: () => ({
     createTestSuiteMutation: mocks.createTestSuiteMutation,
+    ensureAutoEvalSuiteMutation: mocks.ensureAutoEvalSuiteMutation,
     updateTestSuiteMutation: vi.fn().mockResolvedValue(undefined),
     createTestCaseMutation: vi.fn().mockResolvedValue("tc-1"),
   }),
@@ -226,7 +257,26 @@ function makeQueryState(selectedSuiteId: string | null) {
 describe("EvalsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    generateAndPersistEvalTestsMock.mockResolvedValue({
+      skippedBecauseExistingCases: false,
+      createdCount: 0,
+      apiReturnedTests: 0,
+      createdTestCaseIds: [],
+    });
     mocks.isDirectGuest = false;
+    mocks.ensureAutoEvalSuiteMutation.mockResolvedValue({
+      status: "created",
+      suite: {
+        _id: "suite-new",
+        name: "server-a",
+        description: "Explore cases for server-a",
+      },
+    });
+    mocks.appStateServers = {
+      "server-a": { connectionStatus: "connected" },
+      "server-b": { connectionStatus: "connected" },
+    };
+    mocks.connectedServerNames = new Set(["server-a", "server-b"]);
     mocks.route.current = { type: "suite-overview", suiteId: "suite-a" };
     mocks.useEvalQueries.mockImplementation(
       ({ selectedSuiteId }: { selectedSuiteId: string | null }) =>
@@ -287,6 +337,216 @@ describe("EvalsTab", () => {
         { type: "list" },
         { replace: true },
       );
+    });
+  });
+
+  it("auto-creates missing server suites through ensureAutoEvalSuiteForServer", async () => {
+    mocks.route.current = { type: "list" };
+    mocks.useEvalQueries.mockImplementation(
+      ({ selectedSuiteId }: { selectedSuiteId: string | null }) => {
+        const suiteB = makeSuiteEntry(["server-b"], "suite-b");
+        const selectedSuiteEntry =
+          selectedSuiteId === "suite-b" ? suiteB : null;
+
+        return {
+          suiteOverview: [suiteB],
+          suiteDetails: selectedSuiteEntry
+            ? { testCases: [], iterations: [] }
+            : undefined,
+          suiteRuns: selectedSuiteEntry ? [] : undefined,
+          selectedSuiteEntry,
+          selectedSuite: selectedSuiteEntry?.suite ?? null,
+          sortedIterations: [],
+          runsForSelectedSuite: [],
+          activeIterations: [],
+          sortedSuites: [suiteB],
+          isOverviewLoading: false,
+          isSuiteDetailsLoading: false,
+          isSuiteRunsLoading: false,
+          enableOverviewQuery: true,
+          enableSuiteDetailsQuery: Boolean(selectedSuiteId),
+        };
+      },
+    );
+
+    render(<EvalsTab workspaceId="ws-1" />);
+
+    await waitFor(() => {
+      expect(mocks.ensureAutoEvalSuiteMutation).toHaveBeenCalledWith({
+        workspaceId: "ws-1",
+        serverName: "server-a",
+        mode: "auto",
+      });
+    });
+
+    expect(mocks.createTestSuiteMutation).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-create suites again for suppressed servers", async () => {
+    mocks.route.current = { type: "list" };
+    mocks.appStateServers = {
+      "server-a": {
+        connectionStatus: "connected",
+        autoEvalSuiteSuppressedAt: 123,
+      },
+      "server-b": { connectionStatus: "connected" },
+    };
+    mocks.useEvalQueries.mockImplementation(
+      ({ selectedSuiteId }: { selectedSuiteId: string | null }) => {
+        const suiteB = makeSuiteEntry(["server-b"], "suite-b");
+        const selectedSuiteEntry =
+          selectedSuiteId === "suite-b" ? suiteB : null;
+
+        return {
+          suiteOverview: [suiteB],
+          suiteDetails: selectedSuiteEntry
+            ? { testCases: [], iterations: [] }
+            : undefined,
+          suiteRuns: selectedSuiteEntry ? [] : undefined,
+          selectedSuiteEntry,
+          selectedSuite: selectedSuiteEntry?.suite ?? null,
+          sortedIterations: [],
+          runsForSelectedSuite: [],
+          activeIterations: [],
+          sortedSuites: [suiteB],
+          isOverviewLoading: false,
+          isSuiteDetailsLoading: false,
+          isSuiteRunsLoading: false,
+          enableOverviewQuery: true,
+          enableSuiteDetailsQuery: Boolean(selectedSuiteId),
+        };
+      },
+    );
+
+    render(<EvalsTab workspaceId="ws-1" />);
+
+    await waitFor(() => {
+      expect(mocks.ensureAutoEvalSuiteMutation).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not leak local suppression across workspaces with the same server name", async () => {
+    mocks.route.current = { type: "list" };
+    mocks.appStateServers = {
+      "server-a": { connectionStatus: "connected" },
+      "server-b": { connectionStatus: "connected" },
+    };
+    mocks.useEvalQueries.mockImplementation(
+      ({ selectedSuiteId }: { selectedSuiteId: string | null }) => {
+        const suiteB = makeSuiteEntry(["server-b"], "suite-b");
+        const selectedSuiteEntry =
+          selectedSuiteId === "suite-b" ? suiteB : null;
+
+        return {
+          suiteOverview: [suiteB],
+          suiteDetails: selectedSuiteEntry
+            ? { testCases: [], iterations: [] }
+            : undefined,
+          suiteRuns: selectedSuiteEntry ? [] : undefined,
+          selectedSuiteEntry,
+          selectedSuite: selectedSuiteEntry?.suite ?? null,
+          sortedIterations: [],
+          runsForSelectedSuite: [],
+          activeIterations: [],
+          sortedSuites: [suiteB],
+          isOverviewLoading: false,
+          isSuiteDetailsLoading: false,
+          isSuiteRunsLoading: false,
+          enableOverviewQuery: true,
+          enableSuiteDetailsQuery: Boolean(selectedSuiteId),
+        };
+      },
+    );
+    mocks.ensureAutoEvalSuiteMutation.mockResolvedValue({
+      status: "suppressed",
+    });
+
+    const { rerender } = render(<EvalsTab workspaceId="ws-1" />);
+
+    await waitFor(() => {
+      expect(mocks.ensureAutoEvalSuiteMutation).toHaveBeenNthCalledWith(1, {
+        workspaceId: "ws-1",
+        serverName: "server-a",
+        mode: "auto",
+      });
+    });
+
+    rerender(<EvalsTab workspaceId="ws-2" />);
+
+    await waitFor(() => {
+      expect(mocks.ensureAutoEvalSuiteMutation).toHaveBeenNthCalledWith(2, {
+        workspaceId: "ws-2",
+        serverName: "server-a",
+        mode: "auto",
+      });
+    });
+  });
+
+  it("recreates a suppressed single-server suite from the create dialog", async () => {
+    const user = userEvent.setup();
+    mocks.route.current = { type: "create" };
+    mocks.appStateServers = {
+      "server-a": {
+        connectionStatus: "connected",
+        autoEvalSuiteSuppressedAt: 123,
+      },
+      "server-b": { connectionStatus: "connected" },
+    };
+
+    render(<EvalsTab workspaceId="ws-1" />);
+
+    await user.click(screen.getByRole("button", { name: "Submit create suite" }));
+
+    await waitFor(() => {
+      expect(mocks.ensureAutoEvalSuiteMutation).toHaveBeenCalledWith({
+        workspaceId: "ws-1",
+        serverName: "server-a",
+        mode: "manual",
+      });
+    });
+
+    expect(mocks.createTestSuiteMutation).not.toHaveBeenCalled();
+    expect(generateAndPersistEvalTestsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "ws-1",
+        suiteId: "suite-new",
+        serverIds: ["server-a"],
+      }),
+    );
+    expect(mocks.navigatePlaygroundEvalsRoute).toHaveBeenCalledWith({
+      type: "suite-overview",
+      suiteId: "suite-new",
+    });
+  });
+
+  it("recreates a suppressed single-server suite without generating cases when the server is disconnected", async () => {
+    const user = userEvent.setup();
+    mocks.route.current = { type: "create" };
+    mocks.appStateServers = {
+      "server-a": {
+        connectionStatus: "disconnected",
+        autoEvalSuiteSuppressedAt: 123,
+      },
+      "server-b": { connectionStatus: "connected" },
+    };
+    mocks.connectedServerNames = new Set(["server-b"]);
+
+    render(<EvalsTab workspaceId="ws-1" />);
+
+    await user.click(screen.getByRole("button", { name: "Submit create suite" }));
+
+    await waitFor(() => {
+      expect(mocks.ensureAutoEvalSuiteMutation).toHaveBeenCalledWith({
+        workspaceId: "ws-1",
+        serverName: "server-a",
+        mode: "manual",
+      });
+    });
+
+    expect(generateAndPersistEvalTestsMock).not.toHaveBeenCalled();
+    expect(mocks.navigatePlaygroundEvalsRoute).toHaveBeenCalledWith({
+      type: "suite-overview",
+      suiteId: "suite-new",
     });
   });
 

--- a/mcpjam-inspector/client/src/components/evals/use-eval-mutations.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-mutations.ts
@@ -21,6 +21,9 @@ export function useEvalMutations({
   const convexCreateTestSuite = useMutation(
     "testSuites:createTestSuite" as any
   );
+  const ensureAutoEvalSuiteMutation = useMutation(
+    "testSuites:ensureAutoEvalSuiteForServer" as any,
+  );
   const updateTestSuiteMutation = useMutation(
     "testSuites:updateTestSuite" as any,
   );
@@ -36,6 +39,7 @@ export function useEvalMutations({
         deleteTestCaseMutation: convexDeleteTestCase,
         duplicateTestCaseMutation: convexDuplicateTestCase,
         createTestSuiteMutation: convexCreateTestSuite,
+        ensureAutoEvalSuiteMutation,
         updateTestSuiteMutation,
       };
     }
@@ -53,6 +57,7 @@ export function useEvalMutations({
       deleteTestCaseMutation: convexDeleteTestCase,
       duplicateTestCaseMutation: guestUnsupported,
       createTestSuiteMutation: convexCreateTestSuite,
+      ensureAutoEvalSuiteMutation: guestUnsupported,
       updateTestSuiteMutation,
     };
   }, [
@@ -65,6 +70,7 @@ export function useEvalMutations({
     convexDeleteTestCase,
     convexDuplicateTestCase,
     convexCreateTestSuite,
+    ensureAutoEvalSuiteMutation,
     updateTestSuiteMutation,
   ]);
 

--- a/mcpjam-inspector/client/src/hooks/useWorkspaces.ts
+++ b/mcpjam-inspector/client/src/hooks/useWorkspaces.ts
@@ -31,6 +31,8 @@ export interface RemoteServer {
   workspaceId: string;
   name: string;
   enabled: boolean;
+  autoEvalSuiteId?: string;
+  autoEvalSuiteSuppressedAt?: number;
   transportType: "stdio" | "http";
   // STDIO fields
   command?: string;

--- a/mcpjam-inspector/client/src/lib/workspace-serialization.ts
+++ b/mcpjam-inspector/client/src/lib/workspace-serialization.ts
@@ -114,6 +114,8 @@ export function deserializeServersFromConvex(
     const server: ServerWithName = {
       name: serverData.name || serverId,
       config,
+      autoEvalSuiteId: serverData.autoEvalSuiteId,
+      autoEvalSuiteSuppressedAt: serverData.autoEvalSuiteSuppressedAt,
       lastConnectionTime: new Date(),
       connectionStatus: "disconnected" as ConnectionStatus,
       retryCount: 0,
@@ -168,6 +170,13 @@ export function serversHaveChanged(
     if (localServer.name !== remoteServer.name) return true;
     if (localServer.enabled !== remoteServer.enabled) return true;
     if (localServer.useOAuth !== remoteServer.useOAuth) return true;
+    if (localServer.autoEvalSuiteId !== remoteServer.autoEvalSuiteId)
+      return true;
+    if (
+      localServer.autoEvalSuiteSuppressedAt !==
+      remoteServer.autoEvalSuiteSuppressedAt
+    )
+      return true;
 
     // Get local URL
     const localUrl =

--- a/mcpjam-inspector/client/src/state/app-types.ts
+++ b/mcpjam-inspector/client/src/state/app-types.ts
@@ -36,6 +36,8 @@ export interface ServerWithName {
   config: MCPServerConfig;
   oauthTokens?: OauthTokens;
   oauthFlowProfile?: OAuthTestProfile;
+  autoEvalSuiteId?: string;
+  autoEvalSuiteSuppressedAt?: number;
   initializationInfo?: InitializationInfo;
   lastConnectionTime: Date;
   connectionStatus: ConnectionStatus;


### PR DESCRIPTION
## Backend PR

- Store auto-suite state on the workspace server row with:
  - `autoEvalSuiteId`
  - `autoEvalSuiteSuppressedAt`
- Add one backend path to decide whether to:
  - return the existing auto-suite
  - create a new one
  - or do nothing because auto-create was suppressed
- When a user deletes an auto-created suite, remember that and stop auto-creating it again
- If the user explicitly recreates it later, clear suppression and allow a fresh suite
- Drop the old legacy fallback so we only follow the new server-linked behavior going forward

## Inspector PR

- Update Playground to use the new backend auto-suite logic
- Keep auto-creating suites for connected servers when appropriate
- Stop silently recreating auto-suites after the user deletes them
- Let users manually recreate a deleted auto-suite from Playground
- Only generate starter test cases when the server is connected
- If the server is disconnected, still create the suite but leave it empty
- Keep a short-lived UI-only suppression marker per workspace + server so Playground doesn’t briefly auto-recreate a just-deleted suite before the backend suppression state finishes syncing