### PR TITLE
Oauth logs

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -120,6 +120,7 @@ import {
   type OrganizationRouteSection,
 } from "./lib/hosted-navigation";
 import { buildOAuthTokensByServerId } from "./lib/oauth/oauth-tokens";
+import type { OAuthTrace } from "./lib/oauth/oauth-trace";
 import {
   formatBillingFeatureName,
   formatPlanName,
@@ -165,6 +166,7 @@ import { getEffectiveWorkspaceClientCapabilities } from "./lib/client-config";
 import { buildEvalsHash } from "./lib/evals-router";
 import { withTestingSurface } from "./lib/testing-surface";
 import { useClientConfigStore } from "./stores/client-config-store";
+import { ingestOAuthTraceLogs } from "./stores/traffic-log-store";
 import { clearGuestSession } from "./lib/guest-session";
 
 function getHostedOAuthCallbackErrorMessage(): string {
@@ -476,10 +478,26 @@ export default function App() {
       return;
     }
 
+    const handleLiveOAuthTrace = (oauthTrace: OAuthTrace) => {
+      const serverId = callbackContext.serverId ?? callbackContext.serverName;
+      if (!serverId) {
+        return;
+      }
+      ingestOAuthTraceLogs({
+        serverId,
+        serverName: callbackContext.serverName,
+        trace: oauthTrace,
+      });
+    };
+
     const completeCallback =
       isAuthenticated
-        ? completeHostedOAuthCallback(callbackContext, code)
-        : handleOAuthCallback(code);
+        ? completeHostedOAuthCallback(callbackContext, code, {
+            onTraceUpdate: handleLiveOAuthTrace,
+          })
+        : handleOAuthCallback(code, {
+            onTraceUpdate: handleLiveOAuthTrace,
+          });
 
     completeCallback
       .then((result) => {

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -451,6 +451,9 @@ describe("App hosted OAuth callback handling", () => {
           serverName: "asana",
         }),
         "oauth-code",
+        expect.objectContaining({
+          onTraceUpdate: expect.any(Function),
+        }),
       );
     });
   });
@@ -827,6 +830,9 @@ describe("App hosted OAuth callback handling", () => {
           serverName: "asana",
         }),
         "oauth-code",
+        expect.objectContaining({
+          onTraceUpdate: expect.any(Function),
+        }),
       );
     });
 

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -109,6 +109,14 @@ import { compareQuickConnectCatalogCards } from "@/lib/quick-connect-catalog-sor
 import { toast } from "sonner";
 
 const ORDER_STORAGE_KEY = "mcp-server-order";
+const LOGGER_FOCUS_STORAGE_KEY = "mcp-server-logger-focus";
+const LOGGER_FOCUS_TTL_MS = 15 * 60 * 1000;
+
+interface PersistedLoggerFocus {
+  workspaceId: string;
+  serverName: string;
+  sinceTimestamp: number;
+}
 
 function variantIsAlreadyInWorkspaceForQuickConnect(
   v: EnrichedRegistryServer,
@@ -167,6 +175,77 @@ function saveServerOrder(workspaceId: string, orderedNames: string[]): void {
     const all = raw ? JSON.parse(raw) : {};
     all[workspaceId] = orderedNames;
     localStorage.setItem(ORDER_STORAGE_KEY, JSON.stringify(all));
+  } catch {
+    // ignore
+  }
+}
+
+function clearPersistedLoggerFocus(): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    sessionStorage.removeItem(LOGGER_FOCUS_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+function readPersistedLoggerFocus(
+  workspaceId: string
+): PersistedLoggerFocus | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = sessionStorage.getItem(LOGGER_FOCUS_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<PersistedLoggerFocus> | null;
+    if (
+      !parsed ||
+      typeof parsed.workspaceId !== "string" ||
+      typeof parsed.serverName !== "string" ||
+      typeof parsed.sinceTimestamp !== "number"
+    ) {
+      clearPersistedLoggerFocus();
+      return null;
+    }
+
+    if (Date.now() - parsed.sinceTimestamp > LOGGER_FOCUS_TTL_MS) {
+      clearPersistedLoggerFocus();
+      return null;
+    }
+
+    if (parsed.workspaceId !== workspaceId) {
+      return null;
+    }
+
+    return {
+      workspaceId: parsed.workspaceId,
+      serverName: parsed.serverName,
+      sinceTimestamp: parsed.sinceTimestamp,
+    };
+  } catch {
+    clearPersistedLoggerFocus();
+    return null;
+  }
+}
+
+function writePersistedLoggerFocus(input: PersistedLoggerFocus): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    sessionStorage.setItem(
+      LOGGER_FOCUS_STORAGE_KEY,
+      JSON.stringify(input)
+    );
   } catch {
     // ignore
   }
@@ -493,9 +572,14 @@ export function ServersTab({
   const [isActionMenuOpen, setIsActionMenuOpen] = useState(false);
   const [isClientConfigOpen, setIsClientConfigOpen] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
+  const persistedLoggerFocus = readPersistedLoggerFocus(activeWorkspaceId);
   const [focusedLoggerServerIds, setFocusedLoggerServerIds] = useState<
     string[] | undefined
-  >(undefined);
+  >(
+    persistedLoggerFocus ? [persistedLoggerFocus.serverName] : undefined
+  );
+  const [focusedLoggerSinceTimestamp, setFocusedLoggerSinceTimestamp] =
+    useState<number | undefined>(persistedLoggerFocus?.sinceTimestamp);
   const [detailModalState, setDetailModalState] = useState<{
     isOpen: boolean;
     serverName: string | null;
@@ -539,7 +623,11 @@ export function ServersTab({
   }, [allNames.join(","), activeWorkspaceId]);
 
   useEffect(() => {
-    setFocusedLoggerServerIds(undefined);
+    const persistedFocus = readPersistedLoggerFocus(activeWorkspaceId);
+    setFocusedLoggerServerIds(
+      persistedFocus ? [persistedFocus.serverName] : undefined
+    );
+    setFocusedLoggerSinceTimestamp(persistedFocus?.sinceTimestamp);
   }, [activeWorkspaceId]);
 
   const sensors = useSensors(
@@ -771,14 +859,23 @@ export function ServersTab({
     []
   );
 
-  const focusLoggerOnServer = useCallback((serverName: string | null) => {
-    const normalizedServerName = serverName?.trim();
-    if (!normalizedServerName) {
-      return;
-    }
+  const focusLoggerOnServer = useCallback(
+    (serverName: string | null, sinceTimestamp = Date.now()) => {
+      const normalizedServerName = serverName?.trim();
+      if (!normalizedServerName) {
+        return;
+      }
 
-    setFocusedLoggerServerIds([normalizedServerName]);
-  }, []);
+      setFocusedLoggerServerIds([normalizedServerName]);
+      setFocusedLoggerSinceTimestamp(sinceTimestamp);
+      writePersistedLoggerFocus({
+        workspaceId: activeWorkspaceId,
+        serverName: normalizedServerName,
+        sinceTimestamp,
+      });
+    },
+    [activeWorkspaceId]
+  );
 
   const handleCloseDetailModal = useCallback(() => {
     setDetailModalState((prev) => ({
@@ -929,9 +1026,49 @@ export function ServersTab({
   ]);
 
   const loggerServerIds =
-    pendingLoggerServerIds.length > 0
+    focusedLoggerServerIds && focusedLoggerServerIds.length > 0
+      ? focusedLoggerServerIds
+      : pendingLoggerServerIds.length > 0
       ? pendingLoggerServerIds
-      : focusedLoggerServerIds;
+      : undefined;
+  const loggerSinceTimestamp = useMemo(() => {
+    if (
+      loggerServerIds &&
+      focusedLoggerServerIds &&
+      focusedLoggerSinceTimestamp
+    ) {
+      const focusedIds = new Set(focusedLoggerServerIds);
+      if (loggerServerIds.some((serverId) => focusedIds.has(serverId))) {
+        return focusedLoggerSinceTimestamp;
+      }
+    }
+
+    if (
+      loggerServerIds?.includes(pendingDashboardOAuth?.serverName ?? "") &&
+      isPendingDashboardOAuthVisible
+    ) {
+      return pendingDashboardOAuth?.startedAt;
+    }
+
+    if (
+      loggerServerIds?.includes(pendingQuickConnect?.serverName ?? "") &&
+      isPendingQuickConnectVisible
+    ) {
+      return pendingQuickConnect?.createdAt;
+    }
+
+    return focusedLoggerSinceTimestamp;
+  }, [
+    focusedLoggerServerIds,
+    focusedLoggerSinceTimestamp,
+    isPendingDashboardOAuthVisible,
+    isPendingQuickConnectVisible,
+    loggerServerIds,
+    pendingDashboardOAuth?.serverName,
+    pendingDashboardOAuth?.startedAt,
+    pendingQuickConnect?.createdAt,
+    pendingQuickConnect?.serverName,
+  ]);
 
   const handleAddServerClick = () => {
     if (serverCreationGate.isDenied) {
@@ -1277,6 +1414,7 @@ export function ServersTab({
               <LoggerView
                 key={connectedCount}
                 serverIds={loggerServerIds}
+                sinceTimestamp={loggerSinceTimestamp}
                 onClose={toggleJsonRpcPanel}
               />
             </div>

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -53,7 +53,11 @@ import {
 } from "@/hooks/useRegistryServers";
 import { formatRegistryStarCount } from "@/lib/format-registry-star-count";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
-import { HoverCard, HoverCardContent, HoverCardTrigger } from "@mcpjam/design-system/hover-card";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@mcpjam/design-system/hover-card";
 import { BILLING_GATES, useWorkspaceBillingGate } from "@/lib/billing-gates";
 import {
   ResizablePanelGroup,
@@ -110,7 +114,7 @@ function variantIsAlreadyInWorkspaceForQuickConnect(
   v: EnrichedRegistryServer,
   workspaceServers: Record<string, ServerWithName>,
   pendingQuickConnect: PendingQuickConnectState | null,
-  isPendingQuickConnectVisible: boolean,
+  isPendingQuickConnectVisible: boolean
 ): boolean {
   const name = getRegistryServerName(v);
   const ws = workspaceServers[name];
@@ -136,15 +140,15 @@ function isQuickConnectCardExcludedByWorkspace(
   card: EnrichedRegistryCatalogCard,
   workspaceServers: Record<string, ServerWithName>,
   pendingQuickConnect: PendingQuickConnectState | null,
-  isPendingQuickConnectVisible: boolean,
+  isPendingQuickConnectVisible: boolean
 ): boolean {
   return card.variants.some((v) =>
     variantIsAlreadyInWorkspaceForQuickConnect(
       v,
       workspaceServers,
       pendingQuickConnect,
-      isPendingQuickConnectVisible,
-    ),
+      isPendingQuickConnectVisible
+    )
   );
 }
 
@@ -201,14 +205,14 @@ function ServersQuickConnectMiniCard({
 }) {
   const first = card.variants[0];
   const isPublisherVerified = card.variants.some(
-    (v) => v.publishStatus === "verified",
+    (v) => v.publishStatus === "verified"
   );
   const isPending =
     pendingQuickConnect?.sourceTab === "servers" &&
     card.variants.some(
       (v) =>
         v._id === pendingQuickConnect.registryServerId ||
-        getRegistryServerName(v) === pendingQuickConnect.serverName,
+        getRegistryServerName(v) === pendingQuickConnect.serverName
     );
 
   const description = first.description?.trim() ?? "";
@@ -316,7 +320,9 @@ function ServersQuickConnectMiniCard({
                 ) : null}
                 <span
                   className="inline-flex shrink-0 items-center gap-0.5 tabular-nums text-muted-foreground"
-                  aria-label={`${formatRegistryStarCount(card.starCount)} stars`}
+                  aria-label={`${formatRegistryStarCount(
+                    card.starCount
+                  )} stars`}
                 >
                   <Star className="h-3 w-3 shrink-0 text-amber-400/80 fill-amber-400/30 pointer-events-none" />
                   {formatRegistryStarCount(card.starCount)}
@@ -353,13 +359,13 @@ function SortableServerCard({
   onDisconnect: (name: string) => void;
   onReconnect: (
     name: string,
-    opts?: { forceOAuthFlow?: boolean },
+    opts?: { forceOAuthFlow?: boolean }
   ) => Promise<void>;
   onRemove: (name: string) => void;
   hostedServerId?: string;
   onOpenDetailModal?: (
     server: ServerWithName,
-    defaultTab: ServerDetailTab,
+    defaultTab: ServerDetailTab
   ) => void;
   workspaceId: string;
 }) {
@@ -400,12 +406,12 @@ interface ServersTabProps {
   onDisconnect: (serverName: string) => void;
   onReconnect: (
     serverName: string,
-    options?: { forceOAuthFlow?: boolean },
+    options?: { forceOAuthFlow?: boolean }
   ) => Promise<void>;
   onUpdate: (
     originalServerName: string,
     formData: ServerFormData,
-    skipAutoConnect?: boolean,
+    skipAutoConnect?: boolean
   ) => Promise<ServerUpdateResult>;
   onRemove: (serverName: string) => void;
   workspaces: Record<string, Workspace>;
@@ -415,14 +421,14 @@ interface ServersTabProps {
   isLoadingWorkspaces?: boolean;
   onWorkspaceShared?: (
     sharedWorkspaceId: string,
-    sourceWorkspaceId?: string,
+    sourceWorkspaceId?: string
   ) => void;
   onLeaveWorkspace?: () => void;
   isRegistryEnabled?: boolean;
   onNavigateToRegistry?: () => void;
   onSaveClientConfig?: (
     workspaceId: string,
-    clientConfig: WorkspaceClientConfig | undefined,
+    clientConfig: WorkspaceClientConfig | undefined
   ) => Promise<void>;
 }
 
@@ -487,6 +493,9 @@ export function ServersTab({
   const [isActionMenuOpen, setIsActionMenuOpen] = useState(false);
   const [isClientConfigOpen, setIsClientConfigOpen] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
+  const [focusedLoggerServerIds, setFocusedLoggerServerIds] = useState<
+    string[] | undefined
+  >(undefined);
   const [detailModalState, setDetailModalState] = useState<{
     isOpen: boolean;
     serverName: string | null;
@@ -504,7 +513,7 @@ export function ServersTab({
   // --- Self-contained local ordering (localStorage only, never synced to Convex) ---
   const allNames = useMemo(
     () => Object.keys(workspaceServers),
-    [workspaceServers],
+    [workspaceServers]
   );
 
   const [orderedServerNames, setOrderedServerNames] = useState<string[]>(() => {
@@ -529,8 +538,12 @@ export function ServersTab({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allNames.join(","), activeWorkspaceId]);
 
+  useEffect(() => {
+    setFocusedLoggerServerIds(undefined);
+  }, [activeWorkspaceId]);
+
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
   );
 
   const handleDragStart = (event: DragStartEvent) => {
@@ -541,7 +554,7 @@ export function ServersTab({
     const { active, over } = event;
     if (over && active.id !== over.id) {
       const oldIndex = orderedServerNames.findIndex(
-        (name) => name === active.id,
+        (name) => name === active.id
       );
       const newIndex = orderedServerNames.findIndex((name) => name === over.id);
       if (oldIndex !== -1 && newIndex !== -1) {
@@ -571,13 +584,13 @@ export function ServersTab({
               initializedCapabilities: server.initializationInfo
                 ?.clientCapabilities as Record<string, unknown> | undefined,
             }),
-        ]),
+        ])
       ),
-    [activeWorkspaceId, workspaceServers, workspaces],
+    [activeWorkspaceId, workspaceServers, workspaces]
   );
 
   const detailModalLiveServer = detailModalState.serverName
-    ? (workspaceServers[detailModalState.serverName] ?? null)
+    ? workspaceServers[detailModalState.serverName] ?? null
     : null;
   const detailModalServer =
     detailModalLiveServer ?? detailModalState.serverSnapshot;
@@ -681,8 +694,8 @@ export function ServersTab({
             card,
             workspaceServers,
             pendingQuickConnect,
-            isPendingQuickConnectVisible,
-          ),
+            isPendingQuickConnectVisible
+          )
       )
       .slice(0, 4);
   }, [
@@ -724,7 +737,7 @@ export function ServersTab({
         enabled: true,
       };
     },
-    [isPendingDashboardOAuthVisible, pendingDashboardOAuth?.serverName],
+    [isPendingDashboardOAuthVisible, pendingDashboardOAuth?.serverName]
   );
 
   const shouldShowQuickConnect =
@@ -755,8 +768,17 @@ export function ServersTab({
         serverSnapshot: server,
       }));
     },
-    [],
+    []
   );
+
+  const focusLoggerOnServer = useCallback((serverName: string | null) => {
+    const normalizedServerName = serverName?.trim();
+    if (!normalizedServerName) {
+      return;
+    }
+
+    setFocusedLoggerServerIds([normalizedServerName]);
+  }, []);
 
   const handleCloseDetailModal = useCallback(() => {
     setDetailModalState((prev) => ({
@@ -788,14 +810,14 @@ export function ServersTab({
           serverSnapshot: liveServer
             ? liveServer
             : prev.serverSnapshot
-              ? { ...prev.serverSnapshot, name: result.serverName }
-              : prev.serverSnapshot,
+            ? { ...prev.serverSnapshot, name: result.serverName }
+            : prev.serverSnapshot,
         };
       });
 
       return result;
     },
-    [onUpdate, workspaceServers],
+    [onUpdate, workspaceServers]
   );
 
   useEffect(() => {
@@ -825,9 +847,26 @@ export function ServersTab({
 
   const handleJsonImport = (servers: ServerFormData[]) => {
     servers.forEach((server) => {
+      focusLoggerOnServer(server.name);
       onConnect(server);
     });
   };
+
+  const handleConnectServer = useCallback(
+    (formData: ServerFormData) => {
+      focusLoggerOnServer(formData.name);
+      onConnect(formData);
+    },
+    [focusLoggerOnServer, onConnect]
+  );
+
+  const handleReconnectServer = useCallback(
+    async (serverName: string, options?: { forceOAuthFlow?: boolean }) => {
+      focusLoggerOnServer(serverName);
+      await onReconnect(serverName, options);
+    },
+    [focusLoggerOnServer, onReconnect]
+  );
 
   const clearPendingQuickConnectIfMatches = useCallback(
     (serverName: string) => {
@@ -837,11 +876,12 @@ export function ServersTab({
       clearPendingQuickConnect();
       setPendingQuickConnect(null);
     },
-    [pendingQuickConnect],
+    [pendingQuickConnect]
   );
 
   const handleQuickConnect = async (server: EnrichedRegistryServer) => {
     const serverName = getRegistryServerName(server);
+    focusLoggerOnServer(serverName);
     const nextPendingQuickConnect: PendingQuickConnectState = {
       serverName,
       registryServerId: server._id,
@@ -859,11 +899,45 @@ export function ServersTab({
     }
   };
 
+  const pendingLoggerServerIds = useMemo(() => {
+    const pendingServerIds = new Set<string>();
+
+    if (isPendingDashboardOAuthVisible && pendingDashboardOAuth?.serverName) {
+      pendingServerIds.add(pendingDashboardOAuth.serverName);
+    }
+
+    if (isPendingQuickConnectVisible && pendingQuickConnect?.serverName) {
+      pendingServerIds.add(pendingQuickConnect.serverName);
+    }
+
+    Object.entries(workspaceServers).forEach(([serverId, server]) => {
+      if (
+        server.connectionStatus === "connecting" ||
+        server.connectionStatus === "oauth-flow"
+      ) {
+        pendingServerIds.add(serverId);
+      }
+    });
+
+    return Array.from(pendingServerIds);
+  }, [
+    isPendingDashboardOAuthVisible,
+    isPendingQuickConnectVisible,
+    pendingDashboardOAuth?.serverName,
+    pendingQuickConnect?.serverName,
+    workspaceServers,
+  ]);
+
+  const loggerServerIds =
+    pendingLoggerServerIds.length > 0
+      ? pendingLoggerServerIds
+      : focusedLoggerServerIds;
+
   const handleAddServerClick = () => {
     if (serverCreationGate.isDenied) {
       toast.error(
         serverCreationGate.denialMessage ??
-          "Upgrade required to add more servers",
+          "Upgrade required to add more servers"
       );
       return;
     }
@@ -880,7 +954,7 @@ export function ServersTab({
     if (serverCreationGate.isDenied) {
       toast.error(
         serverCreationGate.denialMessage ??
-          "Upgrade required to add more servers",
+          "Upgrade required to add more servers"
       );
       return;
     }
@@ -971,7 +1045,7 @@ export function ServersTab({
       <div
         className={cn(
           "rounded-lg border border-border/50 bg-muted/15",
-          minimized ? "space-y-2 p-2" : "space-y-3 p-3",
+          minimized ? "space-y-2 p-2" : "space-y-3 p-3"
         )}
         data-testid="servers-quick-connect-section"
         data-minimized={minimized ? "true" : undefined}
@@ -980,7 +1054,7 @@ export function ServersTab({
           className={cn(
             minimized
               ? "flex flex-row flex-wrap items-center justify-between gap-x-3 gap-y-2"
-              : "flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-3",
+              : "flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between sm:gap-3"
           )}
         >
           {minimized ? (
@@ -995,7 +1069,7 @@ export function ServersTab({
                     "group inline-flex max-w-full items-center gap-1 rounded-md border border-border/40 bg-muted/10 px-1.5 py-1 text-left",
                     "text-[11px] font-semibold uppercase tracking-wide text-primary underline-offset-4 hover:underline",
                     "transition-colors hover:border-border/60 hover:bg-muted/25",
-                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                   )}
                   aria-expanded={quickConnectMiniCardsExpanded}
                   onClick={() =>
@@ -1006,7 +1080,7 @@ export function ServersTab({
                   <ChevronRight
                     className={cn(
                       "h-3 w-3 shrink-0 text-current opacity-90 transition-transform duration-200 group-hover:opacity-100",
-                      quickConnectMiniCardsExpanded && "rotate-90",
+                      quickConnectMiniCardsExpanded && "rotate-90"
                     )}
                     aria-hidden
                   />
@@ -1039,7 +1113,7 @@ export function ServersTab({
               size="sm"
               className={cn(
                 "h-auto shrink-0 p-0 text-xs",
-                minimized ? "self-center" : "self-start",
+                minimized ? "self-center" : "self-start"
               )}
               onClick={onNavigateToRegistry}
               data-testid="servers-quick-connect-browse-registry"
@@ -1145,7 +1219,7 @@ export function ServersTab({
                         clearPendingQuickConnectIfMatches(serverName);
                         onDisconnect(serverName);
                       }}
-                      onReconnect={onReconnect}
+                      onReconnect={handleReconnectServer}
                       onRemove={(serverName) => {
                         clearPendingQuickConnectIfMatches(serverName);
                         onRemove(serverName);
@@ -1170,7 +1244,7 @@ export function ServersTab({
                       clearPendingQuickConnectIfMatches(serverName);
                       onDisconnect(serverName);
                     }}
-                    onReconnect={onReconnect}
+                    onReconnect={handleReconnectServer}
                     onRemove={(serverName) => {
                       clearPendingQuickConnectIfMatches(serverName);
                       onRemove(serverName);
@@ -1200,7 +1274,11 @@ export function ServersTab({
             onCollapse={toggleJsonRpcPanel}
           >
             <div className="h-full flex flex-col bg-background border-l border-border">
-              <LoggerView key={connectedCount} onClose={toggleJsonRpcPanel} />
+              <LoggerView
+                key={connectedCount}
+                serverIds={loggerServerIds}
+                onClose={toggleJsonRpcPanel}
+              />
             </div>
           </ResizablePanel>
         </>
@@ -1305,7 +1383,7 @@ export function ServersTab({
             platform: detectPlatform(),
             environment: detectEnvironment(),
           });
-          onConnect(formData);
+          handleConnectServer(formData);
         }}
       />
 
@@ -1318,10 +1396,7 @@ export function ServersTab({
 
       {/* Client Config Dialog */}
       {clientConfigEnabled === true && onSaveClientConfig ? (
-        <Dialog
-          open={isClientConfigOpen}
-          onOpenChange={setIsClientConfigOpen}
-        >
+        <Dialog open={isClientConfigOpen} onOpenChange={setIsClientConfigOpen}>
           <DialogContent className="max-w-6xl w-[95vw] h-[85vh] p-0 overflow-hidden flex flex-col gap-0 sm:max-w-6xl">
             <DialogTitle className="sr-only">Client Config</DialogTitle>
             <DialogDescription className="sr-only">
@@ -1348,7 +1423,7 @@ export function ServersTab({
           defaultTab={detailModalState.defaultTab}
           onSubmit={handleSubmitDetailModal}
           onDisconnect={onDisconnect}
-          onReconnect={onReconnect}
+          onReconnect={handleReconnectServer}
           existingServerNames={Object.keys(workspaceServers)}
         />
       )}

--- a/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
@@ -329,7 +329,11 @@ vi.mock("../workspace/WorkspaceMembersFacepile", () => ({
 }));
 
 vi.mock("../logger-view", () => ({
-  LoggerView: (props: { serverIds?: string[]; onClose?: () => void }) => {
+  LoggerView: (props: {
+    serverIds?: string[];
+    sinceTimestamp?: number;
+    onClose?: () => void;
+  }) => {
     mockLoggerView(props);
     return <div data-testid="logger-view-stub" />;
   },
@@ -450,6 +454,7 @@ describe("ServersTab shared detail modal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    sessionStorage.clear();
     mockIsAuthenticated = false;
     mockCatalogCards = [];
     mockRegistryLoading = false;
@@ -597,8 +602,132 @@ describe("ServersTab shared detail modal", () => {
     expect(mockLoggerView).toHaveBeenLastCalledWith(
       expect.objectContaining({
         serverIds: ["linear"],
+        sinceTimestamp: expect.any(Number),
       })
     );
+  });
+
+  it("preserves explicit logger focus across remounts and does not widen it to other pending servers", async () => {
+    mockJsonRpcPanelVisible = true;
+
+    const linearServer = createServer({ name: "linear" });
+    const asanaServer = createServer({ name: "asana" });
+    const initialServers = {
+      linear: linearServer,
+      asana: asanaServer,
+    };
+
+    const firstRender = render(
+      <ServersTab
+        {...defaultProps}
+        workspaceServers={initialServers}
+        workspaces={{
+          "workspace-1": createWorkspace(initialServers),
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByText("Reconnect linear"));
+
+    await waitFor(() => {
+      expect(defaultProps.onReconnect).toHaveBeenCalledWith(
+        "linear",
+        undefined
+      );
+    });
+
+    const focusedLoggerProps = mockLoggerView.mock.lastCall?.[0] as
+      | {
+          serverIds?: string[];
+          sinceTimestamp?: number;
+        }
+      | undefined;
+    expect(focusedLoggerProps?.serverIds).toEqual(["linear"]);
+    expect(focusedLoggerProps?.sinceTimestamp).toEqual(expect.any(Number));
+
+    firstRender.unmount();
+    mockLoggerView.mockReset();
+
+    const remountedServers = {
+      linear: createServer({ name: "linear" }),
+      asana: createServer({ name: "asana", connectionStatus: "connecting" }),
+    };
+
+    render(
+      <ServersTab
+        {...defaultProps}
+        workspaceServers={remountedServers}
+        workspaces={{
+          "workspace-1": createWorkspace(remountedServers),
+        }}
+      />
+    );
+
+    expect(mockLoggerView).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        serverIds: ["linear"],
+        sinceTimestamp: focusedLoggerProps?.sinceTimestamp,
+      })
+    );
+  });
+
+  it("keeps persisted logger focus until the matching hosted workspace hydrates", async () => {
+    mockJsonRpcPanelVisible = true;
+    const persistedSinceTimestamp = Date.now();
+
+    const asanaServer = createServer({ name: "asana" });
+    const workspaceOne = createWorkspace({ asana: asanaServer });
+    const workspaceTwo = {
+      ...createWorkspace({ asana: asanaServer }),
+      id: "workspace-2",
+      name: "Hosted Workspace",
+    };
+
+    sessionStorage.setItem(
+      "mcp-server-logger-focus",
+      JSON.stringify({
+        workspaceId: "workspace-2",
+        serverName: "asana",
+        sinceTimestamp: persistedSinceTimestamp,
+      })
+    );
+
+    const { rerender } = render(
+      <ServersTab
+        {...defaultProps}
+        activeWorkspaceId="workspace-1"
+        workspaceServers={{ asana: asanaServer }}
+        workspaces={{
+          "workspace-1": workspaceOne,
+          "workspace-2": workspaceTwo,
+        }}
+      />
+    );
+
+    expect(sessionStorage.getItem("mcp-server-logger-focus")).toContain(
+      "\"workspaceId\":\"workspace-2\""
+    );
+
+    rerender(
+      <ServersTab
+        {...defaultProps}
+        activeWorkspaceId="workspace-2"
+        workspaceServers={{ asana: asanaServer }}
+        workspaces={{
+          "workspace-1": workspaceOne,
+          "workspace-2": workspaceTwo,
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockLoggerView).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          serverIds: ["asana"],
+          sinceTimestamp: persistedSinceTimestamp,
+        })
+      );
+    });
   });
 
   it("keeps the shared modal open after saving without a rename", async () => {

--- a/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
@@ -123,7 +123,9 @@ let mockIsAuthenticated = false;
 let mockCatalogCards: EnrichedRegistryCatalogCard[] = [];
 let mockRegistryLoading = false;
 let mockClientConfigFlagEnabled: boolean | undefined = false;
+let mockJsonRpcPanelVisible = false;
 const mockConnectRegistry = vi.fn();
+const mockLoggerView = vi.fn();
 const mockUseRegistryServers = vi.fn();
 const mockUseWorkspaceBillingGate = vi.fn();
 
@@ -136,11 +138,7 @@ vi.mock("posthog-js/react", () => ({
 }));
 
 vi.mock("../client-config/ClientConfigTab", () => ({
-  ClientConfigTab: ({
-    activeWorkspaceId,
-  }: {
-    activeWorkspaceId: string;
-  }) => (
+  ClientConfigTab: ({ activeWorkspaceId }: { activeWorkspaceId: string }) => (
     <div data-testid="client-config-tab-stub">
       ClientConfigTab:{activeWorkspaceId}
     </div>
@@ -166,8 +164,9 @@ vi.mock("convex/react", () => ({
 }));
 
 vi.mock("@/hooks/useRegistryServers", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@/hooks/useRegistryServers")>();
+  const actual = await importOriginal<
+    typeof import("@/hooks/useRegistryServers")
+  >();
   return {
     ...actual,
     useRegistryServers: (args: unknown) => {
@@ -197,7 +196,7 @@ vi.mock("@/hooks/use-ai-provider-keys", () => ({
 
 vi.mock("@/hooks/use-json-rpc-panel", () => ({
   useJsonRpcPanelVisibility: () => ({
-    isVisible: false,
+    isVisible: mockJsonRpcPanelVisible,
     toggle: vi.fn(),
   }),
 }));
@@ -224,15 +223,23 @@ vi.mock("../connection/ServerConnectionCard", () => ({
   ServerConnectionCard: ({
     server,
     needsReconnect,
+    onReconnect,
     onOpenDetailModal,
   }: {
     server: ServerWithName;
     needsReconnect?: boolean;
+    onReconnect?: (
+      serverName: string,
+      options?: { forceOAuthFlow?: boolean }
+    ) => Promise<void>;
     onOpenDetailModal?: (server: ServerWithName, defaultTab: string) => void;
   }) => (
     <div>
       <button onClick={() => onOpenDetailModal?.(server, "configuration")}>
         Open {server.name}
+      </button>
+      <button onClick={() => void onReconnect?.(server.name)}>
+        Reconnect {server.name}
       </button>
       {needsReconnect ? <span>Needs reconnect</span> : null}
       <div data-testid={`server-card-${server.name}`}>
@@ -255,7 +262,7 @@ vi.mock("../connection/ServerDetailModal", () => ({
     defaultTab: string;
     onSubmit: (
       formData: ServerFormData,
-      originalServerName: string,
+      originalServerName: string
     ) => Promise<ServerUpdateResult>;
     onClose: () => void;
   }) =>
@@ -275,7 +282,7 @@ vi.mock("../connection/ServerDetailModal", () => ({
                 command: "npx",
                 args: ["-y", "@modelcontextprotocol/server-test"],
               },
-              server.name,
+              server.name
             )
           }
         >
@@ -290,7 +297,7 @@ vi.mock("../connection/ServerDetailModal", () => ({
                 command: "npx",
                 args: ["-y", "@modelcontextprotocol/server-test"],
               },
-              server.name,
+              server.name
             )
           }
         >
@@ -322,7 +329,10 @@ vi.mock("../workspace/WorkspaceMembersFacepile", () => ({
 }));
 
 vi.mock("../logger-view", () => ({
-  LoggerView: () => null,
+  LoggerView: (props: { serverIds?: string[]; onClose?: () => void }) => {
+    mockLoggerView(props);
+    return <div data-testid="logger-view-stub" />;
+  },
 }));
 
 vi.mock("../ui/resizable", () => ({
@@ -444,6 +454,8 @@ describe("ServersTab shared detail modal", () => {
     mockCatalogCards = [];
     mockRegistryLoading = false;
     mockClientConfigFlagEnabled = false;
+    mockJsonRpcPanelVisible = false;
+    mockLoggerView.mockReset();
     mockUseWorkspaceBillingGate.mockImplementation(
       ({
         organizationId,
@@ -461,7 +473,7 @@ describe("ServersTab shared detail modal", () => {
         isLoading: false,
         isDenied: false,
         denialMessage: null,
-      }),
+      })
     );
     mockConnectRegistry.mockReset();
     mockConnectRegistry.mockImplementation(async (server) => {
@@ -484,10 +496,10 @@ describe("ServersTab shared detail modal", () => {
 
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByTestId("modal-server-name")).toHaveTextContent(
-      "test-server",
+      "test-server"
     );
     expect(screen.getByTestId("modal-default-tab")).toHaveTextContent(
-      "configuration",
+      "configuration"
     );
   });
 
@@ -495,14 +507,14 @@ describe("ServersTab shared detail modal", () => {
     render(<ServersTab {...defaultProps} isBillingContextPending={true} />);
 
     expect(
-      screen.getByTestId("servers-billing-context-pending"),
+      screen.getByTestId("servers-billing-context-pending")
     ).toBeInTheDocument();
     expect(screen.queryByText("Add Server")).not.toBeInTheDocument();
     expect(mockUseWorkspaceBillingGate).toHaveBeenCalledWith(
       expect.objectContaining({
         workspaceId: null,
         organizationId: null,
-      }),
+      })
     );
   });
 
@@ -513,7 +525,7 @@ describe("ServersTab shared detail modal", () => {
         workspaces={{}}
         activeWorkspaceId="none"
         workspaceServers={{}}
-      />,
+      />
     );
 
     expect(screen.getByTestId("servers-no-workspace")).toBeInTheDocument();
@@ -539,11 +551,53 @@ describe("ServersTab shared detail modal", () => {
           serverUrl: "https://example.com/mcp",
           startedAt: Date.now(),
         }}
-      />,
+      />
     );
 
     expect(screen.getByTestId("server-card-demo-server")).toHaveTextContent(
-      "demo-server:connecting",
+      "demo-server:connecting"
+    );
+  });
+
+  it("scopes the logger panel to the reconnect target server", async () => {
+    mockJsonRpcPanelVisible = true;
+
+    const linearServer = createServer({ name: "linear" });
+    const asanaServer = createServer({ name: "asana" });
+    const workspaceServers = {
+      linear: linearServer,
+      asana: asanaServer,
+    };
+
+    render(
+      <ServersTab
+        {...defaultProps}
+        workspaceServers={workspaceServers}
+        workspaces={{
+          "workspace-1": createWorkspace(workspaceServers),
+        }}
+      />
+    );
+
+    expect(mockLoggerView).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        serverIds: undefined,
+      })
+    );
+
+    fireEvent.click(screen.getByText("Reconnect linear"));
+
+    await waitFor(() => {
+      expect(defaultProps.onReconnect).toHaveBeenCalledWith(
+        "linear",
+        undefined
+      );
+    });
+
+    expect(mockLoggerView).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        serverIds: ["linear"],
+      })
     );
   });
 
@@ -556,12 +610,12 @@ describe("ServersTab shared detail modal", () => {
     await waitFor(() => {
       expect(defaultProps.onUpdate).toHaveBeenCalledWith(
         "test-server",
-        expect.objectContaining({ name: "test-server" }),
+        expect.objectContaining({ name: "test-server" })
       );
     });
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByTestId("modal-server-name")).toHaveTextContent(
-      "test-server",
+      "test-server"
     );
   });
 
@@ -604,7 +658,7 @@ describe("ServersTab shared detail modal", () => {
     await waitFor(() => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(screen.getByTestId("modal-connection-status")).toHaveTextContent(
-        "connecting",
+        "connecting"
       );
     });
   });
@@ -623,12 +677,12 @@ describe("ServersTab shared detail modal", () => {
     await waitFor(() => {
       expect(onUpdate).toHaveBeenCalledWith(
         "test-server",
-        expect.objectContaining({ name: "renamed-server" }),
+        expect.objectContaining({ name: "renamed-server" })
       );
     });
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     expect(screen.getByTestId("modal-server-name")).toHaveTextContent(
-      "renamed-server",
+      "renamed-server"
     );
   });
 
@@ -641,14 +695,14 @@ describe("ServersTab shared detail modal", () => {
     await waitFor(() => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(screen.getByTestId("modal-server-name")).toHaveTextContent(
-        "test-server",
+        "test-server"
       );
       expect(screen.getByTestId("modal-default-tab")).toHaveTextContent(
-        "configuration",
+        "configuration"
       );
     });
     expect(
-      localStorage.getItem("mcp-server-detail-modal-oauth-resume"),
+      localStorage.getItem("mcp-server-detail-modal-oauth-resume")
     ).toBeNull();
   });
 
@@ -686,7 +740,7 @@ describe("ServersTab shared detail modal", () => {
             }),
           }),
         }}
-      />,
+      />
     );
 
     expect(screen.queryByText("Needs reconnect")).not.toBeInTheDocument();
@@ -722,7 +776,7 @@ describe("ServersTab shared detail modal", () => {
             },
           },
         }}
-      />,
+      />
     );
 
     expect(screen.getByText("Needs reconnect")).toBeInTheDocument();
@@ -736,7 +790,7 @@ describe("ServersTab shared detail modal", () => {
     };
     const initializedCapabilities = mergeWorkspaceClientCapabilities(
       getDefaultClientCapabilities() as Record<string, unknown>,
-      serverCapabilities,
+      serverCapabilities
     );
 
     render(
@@ -768,7 +822,7 @@ describe("ServersTab shared detail modal", () => {
             }),
           }),
         }}
-      />,
+      />
     );
 
     expect(screen.queryByText("Needs reconnect")).not.toBeInTheDocument();
@@ -782,10 +836,10 @@ describe("ServersTab shared detail modal", () => {
 
     expect(screen.getByText("Quick Connect")).toBeInTheDocument();
     expect(
-      screen.getByTestId("servers-quick-connect-browse-registry"),
+      screen.getByTestId("servers-quick-connect-browse-registry")
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId("servers-quick-connect-mini-card"),
+      screen.getByTestId("servers-quick-connect-mini-card")
     ).toBeInTheDocument();
   });
 
@@ -804,15 +858,15 @@ describe("ServersTab shared detail modal", () => {
         url: "https://mcp.linear.app/mcp",
         useOAuth: true,
         registryServerId: "linear-1",
-      }),
+      })
     );
     expect(screen.getByText("Quick Connect")).toBeInTheDocument();
     expect(screen.getByText("Connecting Linear...")).toBeInTheDocument();
     expect(screen.getAllByText("Authorizing...").length).toBeGreaterThanOrEqual(
-      1,
+      1
     );
     expect(
-      screen.getByRole("button", { name: "Connect Linear" }),
+      screen.getByRole("button", { name: "Connect Linear" })
     ).toBeDisabled();
   });
 
@@ -846,16 +900,16 @@ describe("ServersTab shared detail modal", () => {
             }),
           }),
         }}
-      />,
+      />
     );
 
     expect(screen.getByText("Quick Connect")).toBeInTheDocument();
     expect(screen.getByText("Connecting Linear...")).toBeInTheDocument();
     expect(screen.getAllByText("Authorizing...").length).toBeGreaterThanOrEqual(
-      1,
+      1
     );
     expect(screen.getByTestId("server-card-Linear")).toHaveTextContent(
-      "Linear:oauth-flow",
+      "Linear:oauth-flow"
     );
   });
 
@@ -889,14 +943,14 @@ describe("ServersTab shared detail modal", () => {
             }),
           }),
         }}
-      />,
+      />
     );
 
     expect(
-      screen.getAllByText("Finishing setup...").length,
+      screen.getAllByText("Finishing setup...").length
     ).toBeGreaterThanOrEqual(1);
     expect(screen.getByTestId("server-card-Linear")).toHaveTextContent(
-      "Linear:connecting",
+      "Linear:connecting"
     );
   });
 
@@ -930,7 +984,7 @@ describe("ServersTab shared detail modal", () => {
             }),
           }),
         }}
-      />,
+      />
     );
 
     expect(screen.queryByText("Connecting Linear...")).not.toBeInTheDocument();
@@ -956,16 +1010,16 @@ describe("ServersTab shared detail modal", () => {
         workspaces={{
           "workspace-1": createWorkspace({ a: s1 }),
         }}
-      />,
+      />
     );
     expect(
-      screen.getByTestId("servers-quick-connect-section"),
+      screen.getByTestId("servers-quick-connect-section")
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId("servers-quick-connect-section"),
+      screen.getByTestId("servers-quick-connect-section")
     ).not.toHaveAttribute("data-minimized", "true");
     expect(
-      screen.getByTestId("servers-quick-connect-mini-card"),
+      screen.getByTestId("servers-quick-connect-mini-card")
     ).toBeInTheDocument();
 
     rerender(
@@ -975,16 +1029,16 @@ describe("ServersTab shared detail modal", () => {
         workspaces={{
           "workspace-1": createWorkspace({ a: s1, b: s2 }),
         }}
-      />,
+      />
     );
     expect(
-      screen.getByTestId("servers-quick-connect-section"),
+      screen.getByTestId("servers-quick-connect-section")
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId("servers-quick-connect-section"),
+      screen.getByTestId("servers-quick-connect-section")
     ).not.toHaveAttribute("data-minimized", "true");
     expect(
-      screen.getByTestId("servers-quick-connect-mini-card"),
+      screen.getByTestId("servers-quick-connect-mini-card")
     ).toBeInTheDocument();
 
     rerender(
@@ -994,28 +1048,28 @@ describe("ServersTab shared detail modal", () => {
         workspaces={{
           "workspace-1": createWorkspace(three),
         }}
-      />,
+      />
     );
     const minimized = screen.getByTestId("servers-quick-connect-section");
     expect(minimized).toBeInTheDocument();
     expect(minimized).toHaveAttribute("data-minimized", "true");
     expect(
-      screen.getByTestId("servers-quick-connect-mini-cards-toggle"),
+      screen.getByTestId("servers-quick-connect-mini-cards-toggle")
     ).toHaveTextContent(/Show \(1\)/);
     expect(
-      screen.queryByTestId("servers-tab-browse-registry-header-fallback"),
+      screen.queryByTestId("servers-tab-browse-registry-header-fallback")
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId("servers-quick-connect-mini-card"),
+      screen.queryByTestId("servers-quick-connect-mini-card")
     ).not.toBeInTheDocument();
     fireEvent.click(
-      screen.getByTestId("servers-quick-connect-mini-cards-toggle"),
+      screen.getByTestId("servers-quick-connect-mini-cards-toggle")
     );
     expect(
-      screen.getByTestId("servers-quick-connect-mini-card"),
+      screen.getByTestId("servers-quick-connect-mini-card")
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId("servers-quick-connect-mini-cards-toggle"),
+      screen.getByTestId("servers-quick-connect-mini-cards-toggle")
     ).toHaveTextContent(/Hide \(1\)/);
   });
 
@@ -1056,14 +1110,14 @@ describe("ServersTab shared detail modal", () => {
             }),
           }),
         }}
-      />,
+      />
     );
 
     expect(
-      screen.getByTestId("servers-quick-connect-section"),
+      screen.getByTestId("servers-quick-connect-section")
     ).toBeInTheDocument();
     expect(
-      screen.queryByTestId("servers-tab-browse-registry-header-fallback"),
+      screen.queryByTestId("servers-tab-browse-registry-header-fallback")
     ).not.toBeInTheDocument();
   });
 
@@ -1078,10 +1132,10 @@ describe("ServersTab shared detail modal", () => {
     expect(screen.getByLabelText("Verified publisher")).toBeInTheDocument();
     expect(screen.getByLabelText("42 stars")).toBeInTheDocument();
     expect(
-      screen.getByText("Interact with Linear issues."),
+      screen.getByText("Interact with Linear issues.")
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /star this server/i }),
+      screen.queryByRole("button", { name: /star this server/i })
     ).not.toBeInTheDocument();
   });
 
@@ -1099,10 +1153,10 @@ describe("ServersTab shared detail modal", () => {
     mockCatalogCards = [createLinearCatalogCard()];
 
     const { rerender } = render(
-      <ServersTab {...defaultProps} workspaceServers={{}} />,
+      <ServersTab {...defaultProps} workspaceServers={{}} />
     );
     expect(
-      screen.getByTestId("servers-quick-connect-section"),
+      screen.getByTestId("servers-quick-connect-section")
     ).toBeInTheDocument();
 
     const s1 = createServer({ name: "a" });
@@ -1117,14 +1171,14 @@ describe("ServersTab shared detail modal", () => {
         workspaces={{
           "workspace-1": createWorkspace(three),
         }}
-      />,
+      />
     );
 
     const minimized = screen.getByTestId("servers-quick-connect-section");
     expect(minimized).toBeInTheDocument();
     expect(minimized).toHaveAttribute("data-minimized", "true");
     expect(
-      screen.queryByTestId("servers-tab-browse-registry-header-fallback"),
+      screen.queryByTestId("servers-tab-browse-registry-header-fallback")
     ).not.toBeInTheDocument();
   });
 
@@ -1138,19 +1192,19 @@ describe("ServersTab shared detail modal", () => {
         isRegistryEnabled={false}
         onNavigateToRegistry={undefined}
         workspaceServers={{}}
-      />,
+      />
     );
 
     expect(
-      screen.queryByTestId("servers-quick-connect-section"),
+      screen.queryByTestId("servers-quick-connect-section")
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId("servers-tab-browse-registry-header-fallback"),
+      screen.queryByTestId("servers-tab-browse-registry-header-fallback")
     ).not.toBeInTheDocument();
     expect(mockUseRegistryServers).toHaveBeenCalledWith(
       expect.objectContaining({
         enabled: false,
-      }),
+      })
     );
   });
 
@@ -1167,14 +1221,14 @@ describe("ServersTab shared detail modal", () => {
             sharedWorkspaceId: "ws_shared_123",
           },
         }}
-      />,
+      />
     );
 
     expect(mockUseRegistryServers).toHaveBeenCalledWith(
       expect.objectContaining({
         enabled: true,
         workspaceId: "ws_shared_123",
-      }),
+      })
     );
   });
 
@@ -1188,14 +1242,14 @@ describe("ServersTab shared detail modal", () => {
         workspaces={{
           "workspace-1": createWorkspace(defaultProps.workspaceServers),
         }}
-      />,
+      />
     );
 
     expect(mockUseRegistryServers).toHaveBeenCalledWith(
       expect.objectContaining({
         enabled: true,
         workspaceId: null,
-      }),
+      })
     );
   });
 
@@ -1214,11 +1268,11 @@ describe("ServersTab shared detail modal", () => {
             Linear: createServer({ name: "Linear" }),
           }),
         }}
-      />,
+      />
     );
 
     expect(
-      screen.queryByTestId("servers-quick-connect-section"),
+      screen.queryByTestId("servers-quick-connect-section")
     ).not.toBeInTheDocument();
   });
 
@@ -1228,7 +1282,7 @@ describe("ServersTab shared detail modal", () => {
     render(<ServersTab {...defaultProps} />);
 
     expect(
-      screen.queryByRole("button", { name: /client config/i }),
+      screen.queryByRole("button", { name: /client config/i })
     ).not.toBeInTheDocument();
   });
 
@@ -1240,13 +1294,13 @@ describe("ServersTab shared detail modal", () => {
     const button = screen.getByRole("button", { name: /client config/i });
     expect(button).toBeInTheDocument();
     expect(
-      screen.queryByTestId("client-config-tab-stub"),
+      screen.queryByTestId("client-config-tab-stub")
     ).not.toBeInTheDocument();
 
     fireEvent.click(button);
 
     expect(screen.getByTestId("client-config-tab-stub")).toHaveTextContent(
-      "ClientConfigTab:workspace-1",
+      "ClientConfigTab:workspace-1"
     );
   });
 
@@ -1256,7 +1310,7 @@ describe("ServersTab shared detail modal", () => {
     render(<ServersTab {...defaultProps} onSaveClientConfig={undefined} />);
 
     expect(
-      screen.queryByRole("button", { name: /client config/i }),
+      screen.queryByRole("button", { name: /client config/i })
     ).not.toBeInTheDocument();
   });
 
@@ -1275,11 +1329,11 @@ describe("ServersTab shared detail modal", () => {
             "DualServer (App)": createServer({ name: "DualServer (App)" }),
           }),
         }}
-      />,
+      />
     );
 
     expect(
-      screen.queryByTestId("servers-quick-connect-section"),
+      screen.queryByTestId("servers-quick-connect-section")
     ).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/__tests__/logger-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/logger-view.test.tsx
@@ -121,4 +121,74 @@ describe("LoggerView hosted rpc logs", () => {
     expect(screen.getByText("Dynamic Client Registration")).toBeInTheDocument();
     expect(screen.getByText("Notion")).toBeInTheDocument();
   });
+
+  it("shows oauth failure detail inline for collapsed rows", () => {
+    useTrafficLogStore.getState().addMcpServerLog({
+      id: "oauth:srv-1:interactive_connect:request_client_registration:2",
+      serverId: "srv-1",
+      serverName: "Notion",
+      direction: "OAUTH",
+      method: "Dynamic Client Registration",
+      timestamp: "2026-04-10T12:00:03.000Z",
+      payload: {
+        source: "interactive_connect",
+        step: "request_client_registration",
+        title: "Dynamic Client Registration",
+        status: "success",
+        error: "Dynamic Client Registration is not enabled for this project.",
+        recovered: true,
+        recoveryMessage:
+          "Using pre-registered client credentials after registration failed.",
+      },
+      kind: "oauth",
+      oauthStatus: "success",
+      oauthRecovered: true,
+    });
+
+    render(<LoggerView serverIds={["srv-1"]} />);
+
+    expect(
+      screen.getByText(
+        "Dynamic Client Registration - Dynamic Client Registration is not enabled for this project."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("filters logs to the current session when sinceTimestamp is provided", () => {
+    useTrafficLogStore.getState().addMcpServerLog({
+      id: "oauth:srv-1:interactive_connect:request_client_registration:1",
+      serverId: "srv-1",
+      serverName: "Notion",
+      direction: "OAUTH",
+      method: "Old OAuth Flow",
+      timestamp: "2026-04-10T12:00:00.000Z",
+      payload: {
+        source: "interactive_connect",
+        step: "request_client_registration",
+        title: "Old OAuth Flow",
+        status: "success",
+      },
+      kind: "oauth",
+      oauthStatus: "success",
+    });
+    useTrafficLogStore.getState().addMcpServerLog({
+      id: "rpc:srv-1:initialize:2",
+      serverId: "srv-1",
+      serverName: "Notion",
+      direction: "SEND",
+      method: "initialize",
+      timestamp: "2026-04-10T12:00:02.000Z",
+      payload: { ok: true },
+    });
+
+    render(
+      <LoggerView
+        serverIds={["srv-1"]}
+        sinceTimestamp={Date.parse("2026-04-10T12:00:01.000Z")}
+      />
+    );
+
+    expect(screen.getByText("initialize")).toBeInTheDocument();
+    expect(screen.queryByText("Old OAuth Flow")).not.toBeInTheDocument();
+  });
 });

--- a/mcpjam-inspector/client/src/components/logger-view.tsx
+++ b/mcpjam-inspector/client/src/components/logger-view.tsx
@@ -71,6 +71,7 @@ interface RenderableRpcItem {
 
 interface LoggerViewProps {
   serverIds?: string[]; // Optional filter for specific server IDs
+  sinceTimestamp?: number; // Optional minimum timestamp (ms since epoch) for displayed logs
   onClose?: () => void; // Optional callback to close/hide the panel
   isLogLevelVisible?: boolean;
   isCollapsable?: boolean;
@@ -115,7 +116,7 @@ function buildOAuthTraceIngestionKey(trace: {
 }
 
 function normalizePayload(
-  payload: unknown,
+  payload: unknown
 ): Record<string, unknown> | unknown[] {
   if (payload !== null && typeof payload === "object")
     return payload as Record<string, unknown>;
@@ -137,6 +138,36 @@ function getDisplayServerTitle(item: {
     return `${item.serverName} (${item.serverId})`;
   }
   return getDisplayServerLabel(item);
+}
+
+function normalizeInlineSummary(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (normalized.length <= 96) {
+    return normalized;
+  }
+
+  return `${normalized.slice(0, 93).trimEnd()}...`;
+}
+
+function getOAuthInlineSummary(payload: unknown): string | undefined {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return undefined;
+  }
+
+  const data = payload as Record<string, unknown>;
+  const error = typeof data.error === "string" ? data.error : undefined;
+  const recoveryMessage =
+    typeof data.recoveryMessage === "string" ? data.recoveryMessage : undefined;
+  const message =
+    typeof data.message === "string" ? data.message : undefined;
+  const title = typeof data.title === "string" ? data.title : undefined;
+
+  const preferredSummary = error ?? recoveryMessage ?? message;
+  if (!preferredSummary || preferredSummary === title) {
+    return undefined;
+  }
+
+  return normalizeInlineSummary(preferredSummary);
 }
 
 function DirectionLabel({
@@ -163,23 +194,23 @@ function DirectionLabel({
     const className = oauthRecovered
       ? "text-amber-600 dark:text-amber-400"
       : oauthStatus === "error"
-        ? "text-destructive"
-        : oauthStatus === "pending"
-          ? "text-muted-foreground"
-          : "text-orange-600 dark:text-orange-400";
+      ? "text-destructive"
+      : oauthStatus === "pending"
+      ? "text-muted-foreground"
+      : "text-orange-600 dark:text-orange-400";
     const label = oauthRecovered
       ? "oauth ↺"
       : oauthStatus === "error"
-        ? "oauth !"
-        : oauthStatus === "pending"
-          ? "oauth …"
-          : "oauth ✓";
+      ? "oauth !"
+      : oauthStatus === "pending"
+      ? "oauth …"
+      : "oauth ✓";
 
     return (
       <span
         className={cn(
           "font-mono text-[10px] leading-none flex-shrink-0",
-          className,
+          className
         )}
       >
         {label}
@@ -194,7 +225,7 @@ function DirectionLabel({
         "font-mono text-[10px] leading-none flex-shrink-0",
         isSend
           ? "text-green-600 dark:text-green-400"
-          : "text-blue-600 dark:text-blue-400",
+          : "text-blue-600 dark:text-blue-400"
       )}
     >
       {isSend ? "req →" : "← res"}
@@ -204,6 +235,7 @@ function DirectionLabel({
 
 export function LoggerView({
   serverIds,
+  sinceTimestamp,
   onClose,
   isLogLevelVisible = true,
   isCollapsable = true,
@@ -217,7 +249,7 @@ export function LoggerView({
     Record<string, LoggingLevel>
   >({});
   const [sourceFilter, setSourceFilter] = useState<"all" | TrafficSource>(
-    "all",
+    "all"
   );
   const lastIngestedOAuthTraceKeysRef = useRef<Map<string, string>>(new Map());
 
@@ -236,7 +268,9 @@ export function LoggerView({
 
       const ingestionKey = buildOAuthTraceIngestionKey(server.lastOAuthTrace);
       nextKeys.set(serverId, ingestionKey);
-      if (lastIngestedOAuthTraceKeysRef.current.get(serverId) === ingestionKey) {
+      if (
+        lastIngestedOAuthTraceKeysRef.current.get(serverId) === ingestionKey
+      ) {
         return;
       }
 
@@ -292,7 +326,7 @@ export function LoggerView({
       Object.entries(appState.servers)
         .filter(([, server]) => server.connectionStatus === "connected")
         .map(([id, server]) => ({ id, server })),
-    [appState.servers],
+    [appState.servers]
   );
 
   const selectableServers = useMemo(() => {
@@ -346,7 +380,7 @@ export function LoggerView({
     const combined = [...mcpServerItems, ...mcpAppsItems];
     return combined.sort(
       (a, b) =>
-        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
     );
   }, [mcpServerItems, mcpAppsItems]);
 
@@ -364,8 +398,17 @@ export function LoggerView({
       result = result.filter(
         (item) =>
           serverIdSet.has(item.serverId) ||
-          (!!item.serverName && serverIdSet.has(item.serverName)),
+          (!!item.serverName && serverIdSet.has(item.serverName))
       );
+    }
+
+    if (sinceTimestamp != null) {
+      result = result.filter((item) => {
+        const itemTimestamp = new Date(item.timestamp).getTime();
+        return (
+          Number.isFinite(itemTimestamp) && itemTimestamp >= sinceTimestamp
+        );
+      });
     }
 
     // Filter by search query
@@ -382,7 +425,7 @@ export function LoggerView({
     }
 
     return result;
-  }, [allItems, searchQuery, serverIds, sourceFilter]);
+  }, [allItems, searchQuery, serverIds, sinceTimestamp, sourceFilter]);
 
   const totalItemCount = allItems.length;
   const filteredItemCount = filteredItems.length;
@@ -418,7 +461,7 @@ export function LoggerView({
                     <Filter
                       className={cn(
                         "h-3.5 w-3.5",
-                        sourceFilter !== "all" && "text-primary",
+                        sourceFilter !== "all" && "text-primary"
                       )}
                     />
                     {sourceFilter !== "all" && (
@@ -498,15 +541,15 @@ export function LoggerView({
                                     .then((res) => {
                                       if (res?.success)
                                         toast.success(
-                                          `Updated ${server.id} to ${level}`,
+                                          `Updated ${server.id} to ${level}`
                                         );
                                       else
                                         toast.error(
-                                          res?.error || "Failed to update",
+                                          res?.error || "Failed to update"
                                         );
                                     })
                                     .catch(() =>
-                                      toast.error("Failed to update"),
+                                      toast.error("Failed to update")
                                     );
                                 }}
                               >
@@ -587,6 +630,12 @@ export function LoggerView({
               const isExpanded = expanded.has(it.id);
               const isAppsTraffic = it.source === "mcp-apps";
               const isOAuthTraffic = it.source === "oauth";
+              const oauthInlineSummary = isOAuthTraffic
+                ? getOAuthInlineSummary(it.payload)
+                : undefined;
+              const displayMethod = oauthInlineSummary
+                ? `${it.method} - ${oauthInlineSummary}`
+                : it.method;
 
               const isError =
                 it.method === "error" ||
@@ -597,10 +646,10 @@ export function LoggerView({
               const borderClass = isError
                 ? "border-l-destructive"
                 : isAppsTraffic
-                  ? "border-l-purple-500/50"
-                  : isOAuthTraffic
-                    ? "border-l-orange-300/60"
-                    : "border-l-transparent";
+                ? "border-l-purple-500/50"
+                : isOAuthTraffic
+                ? "border-l-orange-300/60"
+                : "border-l-transparent";
 
               return (
                 <div
@@ -609,7 +658,7 @@ export function LoggerView({
                     "border-b border-border border-l-2",
                     borderClass,
                     isError && "bg-destructive/5",
-                    isExpanded && "bg-muted/20",
+                    isExpanded && "bg-muted/20"
                   )}
                 >
                   <div
@@ -619,7 +668,7 @@ export function LoggerView({
                     <ChevronRight
                       className={cn(
                         "h-3 w-3 flex-shrink-0 text-muted-foreground transition-transform duration-150",
-                        isExpanded && "rotate-90",
+                        isExpanded && "rotate-90"
                       )}
                     />
                     {isError ? (
@@ -635,11 +684,11 @@ export function LoggerView({
                     <span
                       className={cn(
                         "flex-1 min-w-0 font-mono text-xs truncate",
-                        isError ? "text-destructive" : "text-foreground",
+                        isError ? "text-destructive" : "text-foreground"
                       )}
-                      title={it.method}
+                      title={displayMethod}
                     >
-                      {it.method}
+                      {displayMethod}
                     </span>
                     <span
                       className="hidden sm:inline text-muted-foreground truncate max-w-[120px] text-[11px]"

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
@@ -301,6 +301,9 @@ describe("useServerState hosted OAuth callback guards", () => {
           serverName: "asana",
         }),
         "oauth-code",
+        expect.objectContaining({
+          onTraceUpdate: expect.any(Function),
+        }),
       );
     });
 

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
@@ -8,6 +8,7 @@ import {
   type SetStateAction,
 } from "react";
 import { getStoredTokens, initiateOAuth } from "@/lib/oauth/mcp-oauth";
+import type { OAuthTrace } from "@/lib/oauth/oauth-trace";
 import type { HostedOAuthRequiredDetails } from "@/lib/hosted-oauth-required";
 import {
   clearHostedOAuthPendingState,
@@ -25,6 +26,7 @@ import {
 } from "@/lib/hosted-oauth-resume";
 import { validateHostedServer } from "@/lib/apis/web/servers-api";
 import { slugify } from "@/lib/shared-server-session";
+import { ingestOAuthTraceLogs } from "@/stores/traffic-log-store";
 
 const INLINE_TOKEN_POLL_ATTEMPTS = 15;
 const RESUME_TOKEN_POLL_ATTEMPTS = 24;
@@ -390,6 +392,13 @@ export function useHostedOAuthGate({
         serverUrl: server.serverUrl,
         clientId: server.clientId ?? undefined,
         scopes: server.oauthScopes ?? undefined,
+        onTraceUpdate: (oauthTrace: OAuthTrace) => {
+          ingestOAuthTraceLogs({
+            serverId: server.serverId,
+            serverName: server.serverName,
+            trace: oauthTrace,
+          });
+        },
       });
 
       if (!result.success) {

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -243,6 +243,16 @@ export function useServerState({
     },
     [dispatch],
   );
+  const updateServerOAuthTrace = useCallback(
+    (serverName: string, oauthTrace: OAuthTrace) => {
+      dispatch({
+        type: "SET_SERVER_OAUTH_TRACE",
+        name: serverName,
+        oauthTrace,
+      });
+    },
+    [dispatch],
+  );
   const isStaleOp = (name: string, token: number) =>
     (opTokenRef.current.get(name) ?? 0) !== token;
 
@@ -703,11 +713,25 @@ export function useServerState({
         HOSTED_MODE &&
         isAuthenticated &&
         hostedCallbackContext?.surface === "workspace";
+      const handleLiveOAuthTrace = (oauthTrace: OAuthTrace) => {
+        const traceServerName =
+          oauthTrace.serverName ??
+          hostedCallbackContext?.serverName ??
+          pendingServerName ??
+          null;
+        if (traceServerName) {
+          updateServerOAuthTrace(traceServerName, oauthTrace);
+        }
+      };
 
       try {
         const result = isHostedWorkspaceCallback
-          ? await completeHostedOAuthCallback(hostedCallbackContext, code)
-          : await handleOAuthCallback(code);
+          ? await completeHostedOAuthCallback(hostedCallbackContext, code, {
+              onTraceUpdate: handleLiveOAuthTrace,
+            })
+          : await handleOAuthCallback(code, {
+              onTraceUpdate: handleLiveOAuthTrace,
+            });
 
         localStorage.removeItem("mcp-oauth-return-hash");
         if (isHostedWorkspaceCallback) {
@@ -828,6 +852,7 @@ export function useServerState({
       logger,
       storeInitInfo,
       guardedTestConnection,
+      updateServerOAuthTrace,
       withWorkspaceClientCapabilities,
     ],
   );
@@ -1079,6 +1104,9 @@ export function useServerState({
             customHeaders: formData.headers,
             protocolVersion: existingOAuthProfile?.protocolVersion,
             registrationStrategy: existingOAuthProfile?.registrationStrategy,
+            onTraceUpdate: (oauthTrace: OAuthTrace) => {
+              updateServerOAuthTrace(formData.name, oauthTrace);
+            },
           };
           if (oauthInputs.scopes && oauthInputs.scopes.length > 0) {
             oauthOptions.scopes = oauthInputs.scopes;
@@ -1226,6 +1254,7 @@ export function useServerState({
       logger,
       storeInitInfo,
       guardedTestConnection,
+      updateServerOAuthTrace,
       withWorkspaceClientCapabilities,
     ],
   );
@@ -1795,6 +1824,9 @@ export function useServerState({
               : undefined,
           protocolVersion: server.oauthFlowProfile?.protocolVersion,
           registrationStrategy: server.oauthFlowProfile?.registrationStrategy,
+          onTraceUpdate: (oauthTrace: OAuthTrace) => {
+            updateServerOAuthTrace(serverName, oauthTrace);
+          },
         });
 
         if (oauthResult.success && !oauthResult.serverConfig) {
@@ -1966,6 +1998,9 @@ export function useServerState({
                 serverUrl: oauthOptions.serverUrl,
               });
             },
+            onTraceUpdate: (oauthTrace: OAuthTrace) => {
+              updateServerOAuthTrace(serverName, oauthTrace);
+            },
           },
         );
         if (authResult.kind === "redirect") {
@@ -2065,6 +2100,7 @@ export function useServerState({
       dispatch,
       prepareHostedWorkspaceOAuthRedirect,
       guardedReconnectServer,
+      updateServerOAuthTrace,
       withWorkspaceClientCapabilities,
     ],
   );

--- a/mcpjam-inspector/client/src/lib/hosted-oauth-callback.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-oauth-callback.ts
@@ -15,6 +15,7 @@ export interface HostedOAuthPendingMarker {
   serverId?: string | null;
   serverName: string;
   serverUrl: string | null;
+  sessionId?: string | null;
   accessScope?: "workspace_member" | "chat_v2";
   shareToken?: string | null;
   chatboxToken?: string | null;
@@ -75,6 +76,7 @@ export function writeHostedOAuthPendingMarker(
         workspaceId: marker.workspaceId ?? null,
         serverId: marker.serverId ?? null,
         serverUrl: marker.serverUrl ?? null,
+        sessionId: marker.sessionId ?? null,
         accessScope: marker.accessScope ?? null,
         shareToken: marker.shareToken ?? null,
         chatboxToken: marker.chatboxToken ?? null,
@@ -111,16 +113,18 @@ export function readHostedOAuthPendingMarker(): HostedOAuthPendingMarker | null 
       return null;
     }
 
-    return {
-      surface: parsed.surface,
-      workspaceId:
-        typeof parsed.workspaceId === "string" ? parsed.workspaceId : null,
-      serverId: typeof parsed.serverId === "string" ? parsed.serverId : null,
-      serverName: parsed.serverName,
-      serverUrl: typeof parsed.serverUrl === "string" ? parsed.serverUrl : null,
-      accessScope:
-        parsed.accessScope === "workspace_member" ||
-        parsed.accessScope === "chat_v2"
+      return {
+        surface: parsed.surface,
+        workspaceId:
+          typeof parsed.workspaceId === "string" ? parsed.workspaceId : null,
+        serverId: typeof parsed.serverId === "string" ? parsed.serverId : null,
+        serverName: parsed.serverName,
+        serverUrl: typeof parsed.serverUrl === "string" ? parsed.serverUrl : null,
+        sessionId:
+          typeof parsed.sessionId === "string" ? parsed.sessionId : null,
+        accessScope:
+          parsed.accessScope === "workspace_member" ||
+          parsed.accessScope === "chat_v2"
           ? parsed.accessScope
           : undefined,
       shareToken:
@@ -238,6 +242,7 @@ export function getHostedOAuthCallbackContext(): HostedOAuthCallbackContext | nu
     serverId: null,
     serverName,
     serverUrl,
+    sessionId: null,
     accessScope: undefined,
     shareToken: null,
     chatboxToken: null,

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.hosted-session.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.hosted-session.test.ts
@@ -1,0 +1,310 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { authFetchMock, getConvexSiteUrlMock } = vi.hoisted(() => ({
+  authFetchMock: vi.fn(),
+  getConvexSiteUrlMock: vi.fn(),
+}));
+
+vi.mock("@/lib/session-token", () => ({
+  authFetch: authFetchMock,
+}));
+
+vi.mock("@/lib/convex-site-url", () => ({
+  getConvexSiteUrl: getConvexSiteUrlMock,
+}));
+
+describe("mcp-oauth hosted callback sessions", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    authFetchMock.mockReset();
+    getConvexSiteUrlMock.mockReset();
+    getConvexSiteUrlMock.mockReturnValue("https://test.convex.site");
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it("completes hosted callbacks with a shared session id without local verifier state", async () => {
+    authFetchMock.mockImplementation((url: string) => {
+      if (url === "https://test.convex.site/web/oauth/session/progress") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ success: false, error: "not found" }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          })
+        );
+      }
+
+      if (url === "https://test.convex.site/web/oauth/complete") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ success: true, expiresAt: 123 }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        );
+      }
+
+      throw new Error(`Unexpected authFetch URL: ${url}`);
+    });
+
+    const { completeHostedOAuthCallback } = await import("../mcp-oauth");
+    const result = await completeHostedOAuthCallback(
+      {
+        surface: "workspace",
+        workspaceId: "ws_1",
+        serverId: "srv_asana",
+        serverName: "asana",
+        serverUrl: "https://mcp.asana.com/sse",
+        sessionId: "hosted-session-1",
+        accessScope: "workspace_member",
+        shareToken: null,
+        chatboxToken: null,
+        returnHash: "#servers",
+        startedAt: Date.now(),
+      },
+      "oauth-code"
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.expiresAt).toBe(123);
+    expect(authFetchMock).toHaveBeenCalledWith(
+      "https://test.convex.site/web/oauth/complete",
+      expect.any(Object)
+    );
+
+    const completeCall = authFetchMock.mock.calls.find(
+      ([url]) => url === "https://test.convex.site/web/oauth/complete"
+    );
+    expect(completeCall).toBeDefined();
+
+    const [, requestInit] = completeCall as [string, RequestInit];
+    const sentBody = JSON.parse(String(requestInit.body));
+    expect(sentBody).toEqual({
+      workspaceId: "ws_1",
+      serverId: "srv_asana",
+      code: "oauth-code",
+      sessionId: "hosted-session-1",
+      accessScope: "workspace_member",
+    });
+  });
+
+  it("polls hosted session progress and emits live trace updates while the callback completes", async () => {
+    vi.useFakeTimers();
+    try {
+      const progressTrace = {
+        version: 1,
+        source: "hosted_callback",
+        currentStep: "token_request",
+        steps: [
+          {
+            step: "received_authorization_code",
+            title: "Authorization Code Received",
+            status: "success",
+            startedAt: 1,
+            completedAt: 2,
+          },
+          {
+            step: "token_request",
+            title: "Exchange Authorization Code",
+            status: "pending",
+            startedAt: 3,
+          },
+        ],
+        httpHistory: [],
+      } as const;
+
+      let resolveCompleteResponse: ((response: Response) => void) | undefined;
+      const completeResponsePromise = new Promise<Response>((resolve) => {
+        resolveCompleteResponse = resolve;
+      });
+
+      authFetchMock.mockImplementation((url: string) => {
+        if (url === "https://test.convex.site/web/oauth/session/progress") {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                success: true,
+                sessionId: "hosted-session-1",
+                status: "running",
+                updatedAt: 101,
+                oauthTrace: progressTrace,
+              }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              }
+            )
+          );
+        }
+
+        if (url === "https://test.convex.site/web/oauth/complete") {
+          return completeResponsePromise;
+        }
+
+        throw new Error(`Unexpected authFetch URL: ${url}`);
+      });
+
+      const onTraceUpdate = vi.fn();
+      const { completeHostedOAuthCallback } = await import("../mcp-oauth");
+      const resultPromise = completeHostedOAuthCallback(
+        {
+          surface: "workspace",
+          workspaceId: "ws_1",
+          serverId: "srv_asana",
+          serverName: "asana",
+          serverUrl: "https://mcp.asana.com/sse",
+          sessionId: "hosted-session-1",
+          accessScope: "workspace_member",
+          shareToken: null,
+          chatboxToken: null,
+          returnHash: "#servers",
+          startedAt: Date.now(),
+        },
+        "oauth-code",
+        { onTraceUpdate }
+      );
+
+      await vi.waitFor(() =>
+        expect(authFetchMock).toHaveBeenCalledWith(
+          "https://test.convex.site/web/oauth/session/progress",
+          expect.any(Object)
+        )
+      );
+      await vi.waitFor(() =>
+        expect(
+          onTraceUpdate.mock.calls.some(([trace]) =>
+            trace.steps.some(
+              (step) =>
+                step.step === "token_request" && step.status === "pending"
+            )
+          )
+        ).toBe(true)
+      );
+
+      resolveCompleteResponse?.(
+        new Response(JSON.stringify({ success: true, expiresAt: 456 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+
+      await vi.advanceTimersByTimeAsync(300);
+      const result = await resultPromise;
+
+      expect(result.success).toBe(true);
+      expect(result.expiresAt).toBe(456);
+      expect(authFetchMock).toHaveBeenCalledWith(
+        "https://test.convex.site/web/oauth/complete",
+        expect.any(Object)
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops waiting for hosted completion once session progress reports a terminal failure", async () => {
+    vi.useFakeTimers();
+    try {
+      const failureTrace = {
+        version: 1,
+        source: "hosted_callback",
+        currentStep: "token_request",
+        steps: [
+          {
+            step: "received_authorization_code",
+            title: "Authorization Code Received",
+            status: "success",
+            startedAt: 1,
+            completedAt: 2,
+          },
+          {
+            step: "token_request",
+            title: "Exchange Authorization Code",
+            status: "error",
+            startedAt: 3,
+            completedAt: 4,
+            error:
+              "Requested resource was not included in the authorization request",
+          },
+        ],
+        httpHistory: [],
+        error:
+          "Requested resource was not included in the authorization request",
+      } as const;
+
+      authFetchMock.mockImplementation((url: string) => {
+        if (url === "https://test.convex.site/web/oauth/session/progress") {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                success: true,
+                sessionId: "hosted-session-1",
+                status: "failed",
+                updatedAt: 201,
+                completedAt: 202,
+                lastError:
+                  "Requested resource was not included in the authorization request",
+                oauthTrace: failureTrace,
+              }),
+              {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+              }
+            )
+          );
+        }
+
+        if (url === "https://test.convex.site/web/oauth/complete") {
+          return new Promise<Response>(() => {
+            // Intentionally unresolved: terminal progress should end the callback.
+          });
+        }
+
+        throw new Error(`Unexpected authFetch URL: ${url}`);
+      });
+
+      const onTraceUpdate = vi.fn();
+      const { completeHostedOAuthCallback } = await import("../mcp-oauth");
+      const resultPromise = completeHostedOAuthCallback(
+        {
+          surface: "workspace",
+          workspaceId: "ws_1",
+          serverId: "srv_linear",
+          serverName: "linear",
+          serverUrl: "https://mcp.linear.app/mcp",
+          sessionId: "hosted-session-1",
+          accessScope: "workspace_member",
+          shareToken: null,
+          chatboxToken: null,
+          returnHash: "#servers",
+          startedAt: Date.now(),
+        },
+        "oauth-code",
+        { onTraceUpdate }
+      );
+
+      await vi.waitFor(() =>
+        expect(authFetchMock).toHaveBeenCalledWith(
+          "https://test.convex.site/web/oauth/session/progress",
+          expect.any(Object)
+        )
+      );
+      await vi.advanceTimersByTimeAsync(300);
+
+      const result = await resultPromise;
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain(
+        "Requested resource was not included in the authorization request"
+      );
+      expect(
+        onTraceUpdate.mock.calls.some(([trace]) =>
+          trace.steps.some(
+            (step) => step.step === "token_request" && step.status === "error"
+          )
+        )
+      ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.hosted-session.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.hosted-session.test.ts
@@ -196,6 +196,9 @@ describe("mcp-oauth hosted callback sessions", () => {
         "https://test.convex.site/web/oauth/complete",
         expect.any(Object)
       );
+      expect(result.oauthTrace?.steps.map((step) => step.step)).toEqual([
+        ...new Set(result.oauthTrace?.steps.map((step) => step.step)),
+      ]);
     } finally {
       vi.useRealTimers();
     }

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -28,11 +28,12 @@ const {
 
 vi.mock("@mcpjam/sdk/browser", async () => {
   const actual = await vi.importActual<typeof import("@mcpjam/sdk/browser")>(
-    "@mcpjam/sdk/browser",
+    "@mcpjam/sdk/browser"
   );
   return {
     ...actual,
-    discoverAuthorizationServerMetadata: mockDiscoverAuthorizationServerMetadata,
+    discoverAuthorizationServerMetadata:
+      mockDiscoverAuthorizationServerMetadata,
     discoverOAuthServerInfo: mockDiscoverOAuthServerInfo,
     exchangeAuthorization: mockExchangeAuthorization,
     fetchToken: mockFetchToken,
@@ -136,7 +137,7 @@ describe("mcp-oauth", () => {
 
     mockDiscoverOAuthServerInfo.mockResolvedValue(createDiscoveryState());
     mockDiscoverAuthorizationServerMetadata.mockResolvedValue(
-      createDiscoveryState().authorizationServerMetadata,
+      createDiscoveryState().authorizationServerMetadata
     );
     mockRegisterClient.mockResolvedValue({
       client_id: "registered-client-id",
@@ -159,7 +160,7 @@ describe("mcp-oauth", () => {
     const oauthModule = await import("../mcp-oauth");
     vi.spyOn(
       oauthModule.MCPOAuthProvider.prototype,
-      "redirectToAuthorization",
+      "redirectToAuthorization"
     ).mockResolvedValue(undefined);
   });
 
@@ -176,7 +177,7 @@ describe("mcp-oauth", () => {
     discoveryState: any = createAsanaDiscoveryState(),
     useRegistryOAuthProxy?: boolean,
     serverName: string = "asana",
-    serverUrl: string = "https://mcp.asana.com/v2/mcp",
+    serverUrl: string = "https://mcp.asana.com/v2/mcp"
   ) {
     mockDiscoverOAuthServerInfo.mockResolvedValueOnce(discoveryState);
     mockRegisterClient.mockResolvedValueOnce({
@@ -184,7 +185,7 @@ describe("mcp-oauth", () => {
     });
     mockStartAuthorization.mockResolvedValueOnce({
       authorizationUrl: new URL(
-        `${discoveryState.authorizationServerMetadata.authorization_endpoint}?state=mock-state`,
+        `${discoveryState.authorizationServerMetadata.authorization_endpoint}?state=mock-state`
       ),
       codeVerifier: "test-verifier",
     });
@@ -213,21 +214,23 @@ describe("mcp-oauth", () => {
           status: 401,
           statusText: "Unauthorized",
           headers: { "Content-Type": "application/json" },
-        },
+        }
       );
       authFetch.mockResolvedValue(authErrorResponse);
-      mockDiscoverOAuthServerInfo.mockImplementation(async (_serverUrl, options) => {
-        const response = await options?.fetchFn?.(
-          "https://example.com/.well-known/oauth-protected-resource/mcp",
-        );
-        if (!response) {
-          throw new Error("Missing OAuth fetch function");
+      mockDiscoverOAuthServerInfo.mockImplementation(
+        async (_serverUrl, options) => {
+          const response = await options?.fetchFn?.(
+            "https://example.com/.well-known/oauth-protected-resource/mcp"
+          );
+          if (!response) {
+            throw new Error("Missing OAuth fetch function");
+          }
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+          }
+          return createDiscoveryState();
         }
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
-        return createDiscoveryState();
-      });
+      );
 
       const { initiateOAuth } = await import("../mcp-oauth");
       const result = await initiateOAuth({
@@ -248,21 +251,23 @@ describe("mcp-oauth", () => {
         {
           status: 401,
           statusText: "Unauthorized",
-        },
+        }
       );
       authFetch.mockResolvedValue(authErrorResponse);
-      mockDiscoverOAuthServerInfo.mockImplementation(async (_serverUrl, options) => {
-        const response = await options?.fetchFn?.(
-          "https://example.com/.well-known/oauth-protected-resource/mcp",
-        );
-        if (!response) {
-          throw new Error("Missing OAuth fetch function");
+      mockDiscoverOAuthServerInfo.mockImplementation(
+        async (_serverUrl, options) => {
+          const response = await options?.fetchFn?.(
+            "https://example.com/.well-known/oauth-protected-resource/mcp"
+          );
+          if (!response) {
+            throw new Error("Missing OAuth fetch function");
+          }
+          if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+          }
+          return createDiscoveryState();
         }
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
-        return createDiscoveryState();
-      });
+      );
 
       const { initiateOAuth } = await import("../mcp-oauth");
       const result = await initiateOAuth({
@@ -279,7 +284,9 @@ describe("mcp-oauth", () => {
       vi.stubGlobal("fetch", directFetch);
 
       const sessionToken = await import("@/lib/session-token");
-      const isolatedAuthFetch = sessionToken.authFetch as ReturnType<typeof vi.fn>;
+      const isolatedAuthFetch = sessionToken.authFetch as ReturnType<
+        typeof vi.fn
+      >;
       isolatedAuthFetch.mockReset();
       isolatedAuthFetch.mockRejectedValueOnce(new Error("proxy exploded"));
 
@@ -288,11 +295,11 @@ describe("mcp-oauth", () => {
         async (_serverUrl, options) => {
           await expect(
             options?.fetchFn?.(
-              "https://example.com/.well-known/oauth-protected-resource/mcp",
-            ),
+              "https://example.com/.well-known/oauth-protected-resource/mcp"
+            )
           ).rejects.toThrow("proxy exploded");
           throw new Error("proxy exploded");
-        },
+        }
       );
 
       const { initiateOAuth } = await import("../mcp-oauth");
@@ -310,19 +317,21 @@ describe("mcp-oauth", () => {
         JSON.stringify({
           authorization_servers: ["https://auth.example.com"],
         }),
-        { status: 200 },
+        { status: 200 }
       );
       authFetch.mockResolvedValue(metadataResponse);
-      mockDiscoverOAuthServerInfo.mockImplementation(async (_serverUrl, options) => {
-        const response = await options?.fetchFn?.(
-          "https://example.com/.well-known/oauth-protected-resource/mcp",
-        );
-        if (!response) {
-          throw new Error("Missing OAuth fetch function");
+      mockDiscoverOAuthServerInfo.mockImplementation(
+        async (_serverUrl, options) => {
+          const response = await options?.fetchFn?.(
+            "https://example.com/.well-known/oauth-protected-resource/mcp"
+          );
+          if (!response) {
+            throw new Error("Missing OAuth fetch function");
+          }
+          expect(response.ok).toBe(true);
+          return createDiscoveryState();
         }
-        expect(response.ok).toBe(true);
-        return createDiscoveryState();
-      });
+      );
 
       const { initiateOAuth } = await import("../mcp-oauth");
       const result = await initiateOAuth({
@@ -333,10 +342,126 @@ describe("mcp-oauth", () => {
       expect(result.success).toBe(true);
       expect(authFetch).toHaveBeenCalledWith(
         expect.stringMatching(
-          /\/api\/mcp\/oauth\/metadata\?url=.*oauth-protected-resource/,
+          /\/api\/mcp\/oauth\/metadata\?url=.*oauth-protected-resource/
         ),
-        expect.objectContaining({ method: "GET" }),
+        expect.objectContaining({ method: "GET" })
       );
+    });
+
+    it("replays the initial MCP initialize through the proxy when browser transport fails", async () => {
+      vi.resetModules();
+      const browserFetch = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("Failed to fetch"));
+      vi.stubGlobal("fetch", browserFetch);
+
+      const sessionToken = await import("@/lib/session-token");
+      const isolatedAuthFetch = sessionToken.authFetch as ReturnType<
+        typeof vi.fn
+      >;
+      isolatedAuthFetch.mockReset();
+      isolatedAuthFetch.mockImplementation(async (input) => {
+        const url =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+            ? input.toString()
+            : input.url;
+
+        if (url === "/api/mcp/oauth/proxy") {
+          return createJsonResponse({
+            status: 401,
+            statusText: "Unauthorized",
+            headers: {
+              "content-type": "application/json",
+              "www-authenticate":
+                'Bearer resource_metadata="https://learn.mcpjam.com/.well-known/oauth-protected-resource"',
+            },
+            body: {
+              error: "Unauthorized",
+            },
+          });
+        }
+
+        if (url.includes("oauth-protected-resource")) {
+          return createJsonResponse({
+            resource: "https://learn.mcpjam.com/mcp",
+            authorization_servers: ["https://learn.mcpjam.com"],
+          });
+        }
+
+        if (
+          url.includes("oauth-authorization-server") ||
+          url.includes("openid-configuration")
+        ) {
+          return createJsonResponse({
+            issuer: "https://learn.mcpjam.com",
+            authorization_endpoint: "https://learn.mcpjam.com/authorize",
+            token_endpoint: "https://learn.mcpjam.com/token",
+            response_types_supported: ["code"],
+            code_challenge_methods_supported: ["S256"],
+          });
+        }
+
+        throw new Error(`Unexpected authFetch call to ${url}`);
+      });
+
+      const oauthModule = await import("../mcp-oauth");
+      vi.spyOn(
+        oauthModule.MCPOAuthProvider.prototype,
+        "redirectToAuthorization"
+      ).mockResolvedValue(undefined);
+      const { initiateOAuth } = oauthModule;
+      const result = await initiateOAuth({
+        serverName: "learn",
+        serverUrl: "https://learn.mcpjam.com/mcp",
+        clientId: "learn-client-id",
+      });
+
+      expect(result.success).toBe(true);
+      expect(browserFetch).toHaveBeenCalledWith(
+        "https://learn.mcpjam.com/mcp",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+          }),
+        })
+      );
+      const proxyCall = isolatedAuthFetch.mock.calls.find(
+        ([url]) => url === "/api/mcp/oauth/proxy"
+      );
+      expect(proxyCall).toBeDefined();
+      expect(proxyCall?.[1]).toMatchObject({
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      const proxyRequest = JSON.parse(
+        String((proxyCall?.[1] as RequestInit | undefined)?.body ?? "{}")
+      );
+      expect(proxyRequest).toMatchObject({
+        url: "https://learn.mcpjam.com/mcp",
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+      });
+      expect(JSON.parse(proxyRequest.body)).toEqual({
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-11-25",
+          capabilities: {},
+          clientInfo: {
+            name: "MCPJam Inspector",
+            version: "1.0.0",
+          },
+        },
+        id: 1,
+      });
     });
 
     it("preserves JSON bodies for dynamic client registration requests", async () => {
@@ -349,29 +474,33 @@ describe("mcp-oauth", () => {
             client_id: "linear-client-id",
             redirect_uris: [`${window.location.origin}/oauth/callback`],
           },
-        }),
+        })
       );
-      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(createLinearDiscoveryState());
-      mockRegisterClient.mockImplementationOnce(async (_authServerUrl, options) => {
-        const registrationBody = JSON.stringify({
-          client_name: "MCPJam - Linear",
-          redirect_uris: [`${window.location.origin}/oauth/callback`],
-          grant_types: ["authorization_code", "refresh_token"],
-          response_types: ["code"],
-          token_endpoint_auth_method: "none",
-        });
+      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(
+        createLinearDiscoveryState()
+      );
+      mockRegisterClient.mockImplementationOnce(
+        async (_authServerUrl, options) => {
+          const registrationBody = JSON.stringify({
+            client_name: "MCPJam - Linear",
+            redirect_uris: [`${window.location.origin}/oauth/callback`],
+            grant_types: ["authorization_code", "refresh_token"],
+            response_types: ["code"],
+            token_endpoint_auth_method: "none",
+          });
 
-        const response = await options.fetchFn!(
-          "https://mcp.linear.app/register",
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: registrationBody,
-          },
-        );
-        expect(response.ok).toBe(true);
-        return await response.json();
-      });
+          const response = await options.fetchFn!(
+            "https://mcp.linear.app/register",
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: registrationBody,
+            }
+          );
+          expect(response.ok).toBe(true);
+          return await response.json();
+        }
+      );
 
       const { initiateOAuth } = await import("../mcp-oauth");
       const result = await initiateOAuth({
@@ -398,7 +527,7 @@ describe("mcp-oauth", () => {
               token_endpoint_auth_method: "none",
             },
           }),
-        }),
+        })
       );
     });
   });
@@ -428,7 +557,7 @@ describe("mcp-oauth", () => {
           scopes: ["read", "write"],
           registryServerId: "registry-linear",
           useRegistryOAuthProxy: true,
-        }),
+        })
       );
 
       expect(readStoredOAuthConfig("linear")).toEqual({
@@ -439,8 +568,9 @@ describe("mcp-oauth", () => {
     });
 
     it("normalizes malformed persisted oauth trace history", async () => {
-      const { appendOAuthTraceHttpHistory, loadOAuthTrace } =
-        await import("../oauth-trace");
+      const { appendOAuthTraceHttpHistory, loadOAuthTrace } = await import(
+        "../oauth-trace"
+      );
 
       localStorage.setItem(
         "mcp-oauth-trace-linear",
@@ -450,7 +580,7 @@ describe("mcp-oauth", () => {
           currentStep: "idle",
           steps: [],
           httpHistory: null,
-        }),
+        })
       );
 
       const trace = loadOAuthTrace("linear");
@@ -464,7 +594,7 @@ describe("mcp-oauth", () => {
             url: "https://example.com",
             headers: {},
           },
-        }),
+        })
       ).not.toThrow();
     });
 
@@ -474,22 +604,22 @@ describe("mcp-oauth", () => {
       expect(
         isOAuthTokenGrantRequest("POST", {
           grant_type: "authorization_code",
-        }),
+        })
       ).toBe(true);
       expect(
         isOAuthTokenGrantRequest("POST", {
           grant_type: "refresh_token",
-        }),
+        })
       ).toBe(true);
       expect(
         isOAuthTokenGrantRequest("POST", {
           client_name: "MCPJam - Linear",
-        }),
+        })
       ).toBe(false);
       expect(
         isOAuthTokenGrantRequest("GET", {
           grant_type: "authorization_code",
-        }),
+        })
       ).toBe(false);
     });
 
@@ -502,7 +632,7 @@ describe("mcp-oauth", () => {
           useRegistryOAuthProxy: true,
           method: "POST",
           body: { grant_type: "authorization_code" },
-        }),
+        })
       ).toBe(true);
 
       expect(
@@ -511,7 +641,7 @@ describe("mcp-oauth", () => {
           useRegistryOAuthProxy: false,
           method: "POST",
           body: { grant_type: "authorization_code" },
-        }),
+        })
       ).toBe(false);
 
       expect(
@@ -520,7 +650,7 @@ describe("mcp-oauth", () => {
           useRegistryOAuthProxy: true,
           method: "POST",
           body: { client_name: "MCPJam - Asana" },
-        }),
+        })
       ).toBe(false);
     });
 
@@ -529,7 +659,7 @@ describe("mcp-oauth", () => {
       const discoveryState = createDiscoveryState();
       const provider = new MCPOAuthProvider(
         "asana",
-        "https://mcp.asana.com/sse",
+        "https://mcp.asana.com/sse"
       );
 
       await provider.saveDiscoveryState(discoveryState);
@@ -542,13 +672,13 @@ describe("mcp-oauth", () => {
       const discoveryState = createDiscoveryState();
       const originalProvider = new MCPOAuthProvider(
         "asana",
-        "https://mcp.asana.com/sse",
+        "https://mcp.asana.com/sse"
       );
       await originalProvider.saveDiscoveryState(discoveryState);
 
       const nextProvider = new MCPOAuthProvider(
         "asana",
-        "https://mcp.asana.com/alt-sse",
+        "https://mcp.asana.com/alt-sse"
       );
 
       expect(nextProvider.discoveryState()).toBeUndefined();
@@ -558,7 +688,7 @@ describe("mcp-oauth", () => {
       const { MCPOAuthProvider } = await import("../mcp-oauth");
       const provider = new MCPOAuthProvider(
         "asana",
-        "https://mcp.asana.com/sse",
+        "https://mcp.asana.com/sse"
       );
       await provider.saveDiscoveryState(createDiscoveryState());
 
@@ -572,7 +702,7 @@ describe("mcp-oauth", () => {
       const { MCPOAuthProvider } = await import("../mcp-oauth");
       const provider = new MCPOAuthProvider(
         "asana",
-        "https://mcp.asana.com/sse",
+        "https://mcp.asana.com/sse"
       );
       await provider.saveDiscoveryState(createDiscoveryState());
 
@@ -586,7 +716,7 @@ describe("mcp-oauth", () => {
       const { MCPOAuthProvider, clearOAuthData } = await import("../mcp-oauth");
       const provider = new MCPOAuthProvider(
         "asana",
-        "https://mcp.asana.com/sse",
+        "https://mcp.asana.com/sse"
       );
       await provider.saveDiscoveryState(createDiscoveryState());
 
@@ -603,15 +733,17 @@ describe("mcp-oauth", () => {
         authorizationUrl: new URL("https://auth.example.com/authorize"),
         codeVerifier: "code-verifier",
       });
-      mockExchangeAuthorization.mockImplementationOnce(async (_url, options) => {
-        expect(options?.authorizationCode).toBe("oauth-code");
-        expect(options?.codeVerifier).toBe("code-verifier");
-        return {
-          access_token: "access-token",
-          refresh_token: "refresh-token",
-          token_type: "Bearer",
-        };
-      });
+      mockExchangeAuthorization.mockImplementationOnce(
+        async (_url, options) => {
+          expect(options?.authorizationCode).toBe("oauth-code");
+          expect(options?.codeVerifier).toBe("code-verifier");
+          return {
+            access_token: "access-token",
+            refresh_token: "refresh-token",
+            token_type: "Bearer",
+          };
+        }
+      );
 
       const { getStoredTokens, handleOAuthCallback, initiateOAuth } =
         await import("../mcp-oauth");
@@ -637,8 +769,9 @@ describe("mcp-oauth", () => {
     });
 
     it("treats malformed stored token data as invalid instead of throwing", async () => {
-      const { getStoredTokens, getStoredTokensState } =
-        await import("../mcp-oauth");
+      const { getStoredTokens, getStoredTokensState } = await import(
+        "../mcp-oauth"
+      );
 
       localStorage.setItem("mcp-tokens-asana", '{"access_token":"broken"');
       localStorage.setItem("mcp-client-asana", '{"client_id":"broken"');
@@ -656,8 +789,8 @@ describe("mcp-oauth", () => {
           typeof input === "string"
             ? input
             : input instanceof URL
-              ? input.toString()
-              : input.url;
+            ? input.toString()
+            : input.url;
 
         if (url.includes("/registry/oauth/token")) {
           return createJsonResponse({
@@ -676,7 +809,7 @@ describe("mcp-oauth", () => {
         async (authServerUrl, options) => {
           expect(authServerUrl).toBe("https://app.asana.com");
           expect(options?.metadata?.token_endpoint).toBe(
-            "https://app.asana.com/-/oauth_token",
+            "https://app.asana.com/-/oauth_token"
           );
           const response = await options!.fetchFn!(
             "https://app.asana.com/-/oauth_token",
@@ -688,10 +821,10 @@ describe("mcp-oauth", () => {
                 code_verifier: options!.codeVerifier,
                 redirect_uri: String(options!.redirectUri),
               }),
-            },
+            }
           );
           return await response.json();
-        },
+        }
       );
 
       const { handleOAuthCallback } = await import("../mcp-oauth");
@@ -715,7 +848,7 @@ describe("mcp-oauth", () => {
             redirectUri: `${window.location.origin}/oauth/callback`,
             codeVerifier: "test-verifier",
           }),
-        }),
+        })
       );
     });
 
@@ -723,7 +856,7 @@ describe("mcp-oauth", () => {
       await seedPendingOAuth(
         "registry-asana",
         createAsanaDiscoveryState(),
-        true,
+        true
       );
 
       expect(localStorage.getItem("mcp-oauth-config-asana")).toBe(
@@ -732,7 +865,7 @@ describe("mcp-oauth", () => {
           useRegistryOAuthProxy: true,
           protocolVersion: "2025-11-25",
           registrationStrategy: "preregistered",
-        }),
+        })
       );
     });
 
@@ -742,8 +875,8 @@ describe("mcp-oauth", () => {
           typeof input === "string"
             ? input
             : input instanceof URL
-              ? input.toString()
-              : input.url;
+            ? input.toString()
+            : input.url;
 
         if (url.includes("/registry/oauth/refresh")) {
           return createJsonResponse({
@@ -756,32 +889,36 @@ describe("mcp-oauth", () => {
         throw new Error(`Unexpected direct fetch to ${url}`);
       });
 
-      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(createAsanaDiscoveryState());
-      mockFetchToken.mockImplementationOnce(async (_provider, authServerUrl, options) => {
-        expect(authServerUrl).toBe("https://app.asana.com");
-        const response = await options.fetchFn!(
-          "https://app.asana.com/-/oauth_token",
-          {
-            method: "POST",
-            body: new URLSearchParams({
-              grant_type: "refresh_token",
-              refresh_token: "stored-refresh-token",
-            }),
-          },
-        );
-        return await response.json();
-      });
+      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(
+        createAsanaDiscoveryState()
+      );
+      mockFetchToken.mockImplementationOnce(
+        async (_provider, authServerUrl, options) => {
+          expect(authServerUrl).toBe("https://app.asana.com");
+          const response = await options.fetchFn!(
+            "https://app.asana.com/-/oauth_token",
+            {
+              method: "POST",
+              body: new URLSearchParams({
+                grant_type: "refresh_token",
+                refresh_token: "stored-refresh-token",
+              }),
+            }
+          );
+          return await response.json();
+        }
+      );
 
       localStorage.setItem(
         "mcp-serverUrl-asana",
-        "https://mcp.asana.com/v2/mcp",
+        "https://mcp.asana.com/v2/mcp"
       );
       localStorage.setItem(
         "mcp-oauth-config-asana",
         JSON.stringify({
           registryServerId: "registry-asana",
           useRegistryOAuthProxy: true,
-        }),
+        })
       );
       localStorage.setItem(
         "mcp-tokens-asana",
@@ -789,7 +926,7 @@ describe("mcp-oauth", () => {
           access_token: "old-access-token",
           refresh_token: "stored-refresh-token",
           token_type: "Bearer",
-        }),
+        })
       );
 
       const { refreshOAuthTokens } = await import("../mcp-oauth");
@@ -809,20 +946,20 @@ describe("mcp-oauth", () => {
             grantType: "refresh_token",
             refreshToken: "stored-refresh-token",
           }),
-        }),
+        })
       );
     });
 
     it("re-registers the OAuth client after invalid_client refresh failures", async () => {
       localStorage.setItem(
         "mcp-serverUrl-asana",
-        "https://mcp.asana.com/v2/mcp",
+        "https://mcp.asana.com/v2/mcp"
       );
       localStorage.setItem(
         "mcp-client-asana",
         JSON.stringify({
           client_id: "stale-client-id",
-        }),
+        })
       );
       localStorage.setItem(
         "mcp-tokens-asana",
@@ -830,14 +967,16 @@ describe("mcp-oauth", () => {
           access_token: "old-access-token",
           refresh_token: "stored-refresh-token",
           token_type: "Bearer",
-        }),
+        })
       );
 
-      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(createAsanaDiscoveryState());
+      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(
+        createAsanaDiscoveryState()
+      );
       mockFetchToken.mockRejectedValueOnce(
         Object.assign(new Error("Client authentication failed"), {
           code: "invalid_client",
-        }),
+        })
       );
       mockRegisterClient.mockResolvedValueOnce({
         client_id: "new-client-id",
@@ -848,10 +987,7 @@ describe("mcp-oauth", () => {
       });
 
       const [{ getOAuthTraceFailureStep }, { initiateOAuth }] =
-        await Promise.all([
-          import("../oauth-trace"),
-          import("../mcp-oauth"),
-        ]);
+        await Promise.all([import("../oauth-trace"), import("../mcp-oauth")]);
 
       const result = await initiateOAuth({
         serverName: "asana",
@@ -862,7 +998,7 @@ describe("mcp-oauth", () => {
       expect(localStorage.getItem("mcp-client-asana")).toBe(
         JSON.stringify({
           client_id: "new-client-id",
-        }),
+        })
       );
       expect(getOAuthTraceFailureStep(result.oauthTrace)).toBeUndefined();
     });
@@ -873,8 +1009,8 @@ describe("mcp-oauth", () => {
           typeof input === "string"
             ? input
             : input instanceof URL
-              ? input.toString()
-              : input.url;
+            ? input.toString()
+            : input.url;
 
         if (url.includes("/registry/oauth/token")) {
           return createJsonResponse(
@@ -882,7 +1018,7 @@ describe("mcp-oauth", () => {
               error: "invalid_client",
               error_description: "Client authentication failed",
             },
-            401,
+            401
           );
         }
 
@@ -902,14 +1038,14 @@ describe("mcp-oauth", () => {
                 code_verifier: options!.codeVerifier,
                 redirect_uri: String(options!.redirectUri),
               }),
-            },
+            }
           );
           if (!response.ok) {
             const payload = await response.json();
             throw new Error(`${payload.error}: ${payload.error_description}`);
           }
           return await response.json();
-        },
+        }
       );
 
       const { handleOAuthCallback } = await import("../mcp-oauth");
@@ -918,7 +1054,7 @@ describe("mcp-oauth", () => {
       expect(callbackResult.success).toBe(false);
       expect(callbackResult.error).not.toBe("Code verifier not found");
       expect(callbackResult.error).toContain(
-        "Invalid client ID during token exchange",
+        "Invalid client ID during token exchange"
       );
       expect(localStorage.getItem("mcp-verifier-asana")).toBe("test-verifier");
     });
@@ -937,7 +1073,7 @@ describe("mcp-oauth", () => {
             refresh_token: "proxied-refresh-token",
             token_type: "Bearer",
           },
-        }),
+        })
       );
       mockExchangeAuthorization.mockImplementationOnce(
         async (_authServerUrl, options) => {
@@ -951,10 +1087,10 @@ describe("mcp-oauth", () => {
                 code_verifier: options!.codeVerifier,
                 redirect_uri: String(options!.redirectUri),
               }),
-            },
+            }
           );
           return await response.json();
-        },
+        }
       );
 
       const { handleOAuthCallback } = await import("../mcp-oauth");
@@ -978,7 +1114,7 @@ describe("mcp-oauth", () => {
               redirect_uri: `${window.location.origin}/oauth/callback`,
             },
           }),
-        }),
+        })
       );
     });
 
@@ -990,7 +1126,7 @@ describe("mcp-oauth", () => {
         createAsanaDiscoveryState(),
         false,
         "asana",
-        "https://mcp.asana.com/v2/mcp",
+        "https://mcp.asana.com/v2/mcp"
       );
       authFetch.mockResolvedValueOnce(
         createJsonResponse({
@@ -1002,7 +1138,7 @@ describe("mcp-oauth", () => {
             refresh_token: "asana-refresh-token",
             token_type: "Bearer",
           },
-        }),
+        })
       );
       mockExchangeAuthorization.mockImplementationOnce(
         async (_authServerUrl, options) => {
@@ -1016,10 +1152,10 @@ describe("mcp-oauth", () => {
                 code_verifier: options!.codeVerifier,
                 redirect_uri: String(options!.redirectUri),
               }),
-            },
+            }
           );
           return await response.json();
-        },
+        }
       );
 
       const { handleOAuthCallback } = await import("../mcp-oauth");
@@ -1043,11 +1179,11 @@ describe("mcp-oauth", () => {
               redirect_uri: `${window.location.origin}/oauth/callback`,
             },
           }),
-        }),
+        })
       );
       expect(authFetch).not.toHaveBeenCalledWith(
         expect.stringMatching(/\.convex\.site\/registry\/oauth\/token$/),
-        expect.anything(),
+        expect.anything()
       );
     });
 
@@ -1059,7 +1195,7 @@ describe("mcp-oauth", () => {
         createLinearDiscoveryState(),
         false,
         "linear",
-        "https://mcp.linear.app/mcp",
+        "https://mcp.linear.app/mcp"
       );
       authFetch.mockResolvedValueOnce(
         createJsonResponse({
@@ -1071,7 +1207,7 @@ describe("mcp-oauth", () => {
             refresh_token: "linear-refresh-token",
             token_type: "Bearer",
           },
-        }),
+        })
       );
       mockExchangeAuthorization.mockImplementationOnce(
         async (_authServerUrl, options) => {
@@ -1085,10 +1221,10 @@ describe("mcp-oauth", () => {
                 code_verifier: options!.codeVerifier,
                 redirect_uri: String(options!.redirectUri),
               }),
-            },
+            }
           );
           return await response.json();
-        },
+        }
       );
 
       const { handleOAuthCallback } = await import("../mcp-oauth");
@@ -1112,11 +1248,11 @@ describe("mcp-oauth", () => {
               redirect_uri: `${window.location.origin}/oauth/callback`,
             },
           }),
-        }),
+        })
       );
       expect(authFetch).not.toHaveBeenCalledWith(
         expect.stringMatching(/\.convex\.site\/registry\/oauth\/token$/),
-        expect.anything(),
+        expect.anything()
       );
     });
 
@@ -1131,31 +1267,35 @@ describe("mcp-oauth", () => {
             refresh_token: "new-linear-refresh-token",
             token_type: "Bearer",
           },
-        }),
+        })
       );
 
-      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(createLinearDiscoveryState());
-      mockFetchToken.mockImplementationOnce(async (_provider, _authServerUrl, options) => {
-        const response = await options.fetchFn!(
-          "https://mcp.linear.app/token",
-          {
-            method: "POST",
-            body: new URLSearchParams({
-              grant_type: "refresh_token",
-              refresh_token: "stored-refresh-token",
-            }),
-          },
-        );
-        return await response.json();
-      });
+      mockDiscoverOAuthServerInfo.mockResolvedValueOnce(
+        createLinearDiscoveryState()
+      );
+      mockFetchToken.mockImplementationOnce(
+        async (_provider, _authServerUrl, options) => {
+          const response = await options.fetchFn!(
+            "https://mcp.linear.app/token",
+            {
+              method: "POST",
+              body: new URLSearchParams({
+                grant_type: "refresh_token",
+                refresh_token: "stored-refresh-token",
+              }),
+            }
+          );
+          return await response.json();
+        }
+      );
 
       localStorage.setItem(
         "mcp-serverUrl-linear",
-        "https://mcp.linear.app/mcp",
+        "https://mcp.linear.app/mcp"
       );
       localStorage.setItem(
         "mcp-oauth-config-linear",
-        JSON.stringify({ registryServerId: "registry-linear" }),
+        JSON.stringify({ registryServerId: "registry-linear" })
       );
       localStorage.setItem(
         "mcp-tokens-linear",
@@ -1163,7 +1303,7 @@ describe("mcp-oauth", () => {
           access_token: "old-linear-access-token",
           refresh_token: "stored-refresh-token",
           token_type: "Bearer",
-        }),
+        })
       );
 
       const { refreshOAuthTokens } = await import("../mcp-oauth");
@@ -1184,11 +1324,11 @@ describe("mcp-oauth", () => {
               refresh_token: "stored-refresh-token",
             },
           }),
-        }),
+        })
       );
       expect(authFetch).not.toHaveBeenCalledWith(
         expect.stringMatching(/\.convex\.site\/registry\/oauth\/refresh$/),
-        expect.anything(),
+        expect.anything()
       );
     });
   });

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/oauth-trace.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/oauth-trace.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+
+import { mergeOAuthTraces, type OAuthTrace } from "../oauth-trace";
+
+describe("oauth-trace mergeOAuthTraces", () => {
+  it("collapses duplicate resume steps from the callback half of a local OAuth flow", () => {
+    const interactiveTrace: OAuthTrace = {
+      version: 1,
+      source: "interactive_connect",
+      serverName: "asana",
+      serverUrl: "https://mcp.asana.com/sse",
+      currentStep: "authorization_request",
+      steps: [
+        {
+          step: "request_client_registration",
+          title: "Dynamic Client Registration",
+          status: "success",
+          message: "Registered OAuth client.",
+          startedAt: 100,
+          completedAt: 120,
+        },
+        {
+          step: "authorization_request",
+          title: "Authorization Request Ready",
+          status: "success",
+          message: "Redirecting to the OAuth provider.",
+          startedAt: 130,
+          completedAt: 150,
+        },
+      ],
+      httpHistory: [],
+    };
+
+    const callbackTrace: OAuthTrace = {
+      version: 1,
+      source: "callback",
+      serverName: "asana",
+      serverUrl: "https://mcp.asana.com/sse",
+      currentStep: "complete",
+      steps: [
+        {
+          step: "request_client_registration",
+          title: "Dynamic Client Registration",
+          status: "success",
+          startedAt: 500,
+          completedAt: 510,
+        },
+        {
+          step: "authorization_request",
+          title: "Authorization Request Ready",
+          status: "success",
+          startedAt: 520,
+          completedAt: 530,
+        },
+        {
+          step: "received_authorization_code",
+          title: "Authorization Code Received",
+          status: "success",
+          startedAt: 540,
+          completedAt: 550,
+        },
+        {
+          step: "token_request",
+          title: "Exchange Authorization Code",
+          status: "success",
+          startedAt: 560,
+          completedAt: 580,
+        },
+        {
+          step: "complete",
+          title: "Flow Complete",
+          status: "success",
+          startedAt: 590,
+          completedAt: 600,
+        },
+      ],
+      httpHistory: [],
+    };
+
+    const mergedTrace = mergeOAuthTraces(interactiveTrace, callbackTrace);
+
+    expect(mergedTrace.steps.map((step) => step.step)).toEqual([
+      "request_client_registration",
+      "authorization_request",
+      "received_authorization_code",
+      "token_request",
+      "complete",
+    ]);
+    expect(mergedTrace.steps[0]?.message).toBe("Registered OAuth client.");
+    expect(mergedTrace.steps[0]?.startedAt).toBe(100);
+    expect(mergedTrace.steps[1]?.message).toBe(
+      "Redirecting to the OAuth provider.",
+    );
+  });
+
+  it("keeps the latest terminal state when hosted progress replays an earlier pending step", () => {
+    const callbackScaffoldTrace: OAuthTrace = {
+      version: 1,
+      source: "hosted_callback",
+      serverName: "learn",
+      currentStep: "received_authorization_code",
+      steps: [
+        {
+          step: "received_authorization_code",
+          title: "Authorization Code Received",
+          status: "success",
+          message: "Hosted callback state restored.",
+          startedAt: 1000,
+          completedAt: 1010,
+        },
+      ],
+      httpHistory: [],
+    };
+
+    const backendProgressTrace: OAuthTrace = {
+      version: 1,
+      source: "hosted_callback",
+      serverName: "learn",
+      currentStep: "token_request",
+      steps: [
+        {
+          step: "received_authorization_code",
+          title: "Authorization Code Received",
+          status: "success",
+          startedAt: 10,
+          completedAt: 20,
+        },
+        {
+          step: "token_request",
+          title: "Exchange Authorization Code",
+          status: "pending",
+          startedAt: 30,
+        },
+      ],
+      httpHistory: [],
+    };
+
+    const completedTrace: OAuthTrace = {
+      version: 1,
+      source: "hosted_callback",
+      serverName: "learn",
+      currentStep: "complete",
+      steps: [
+        {
+          step: "token_request",
+          title: "Exchange Authorization Code",
+          status: "success",
+          message: "Hosted token exchange succeeded.",
+          startedAt: 40,
+          completedAt: 50,
+        },
+        {
+          step: "complete",
+          title: "Flow Complete",
+          status: "success",
+          startedAt: 60,
+          completedAt: 70,
+        },
+      ],
+      httpHistory: [],
+    };
+
+    const mergedProgressTrace = mergeOAuthTraces(
+      callbackScaffoldTrace,
+      backendProgressTrace,
+    );
+    const mergedCompleteTrace = mergeOAuthTraces(
+      mergedProgressTrace,
+      completedTrace,
+    );
+
+    expect(
+      mergedCompleteTrace.steps.filter((step) => step.step === "token_request"),
+    ).toEqual([
+      expect.objectContaining({
+        status: "success",
+        message: "Hosted token exchange succeeded.",
+      }),
+    ]);
+    expect(
+      mergedCompleteTrace.steps.filter(
+        (step) => step.step === "received_authorization_code",
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -460,18 +460,123 @@ function resolveOAuthRegistrationStrategy(
   return DEFAULT_OAUTH_REGISTRATION_STRATEGY;
 }
 
-function createOAuthRequestExecutor(fetchFn: typeof fetch) {
-  return async (request: HttpHistoryEntry["request"]) => {
-    const response = await fetchFn(request.url, {
+function normalizeProxyTargetUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    parsed.protocol = parsed.protocol.toLowerCase();
+    parsed.hostname = parsed.hostname.toLowerCase();
+    parsed.hash = "";
+
+    if (parsed.pathname !== "/" && parsed.pathname.endsWith("/")) {
+      parsed.pathname = parsed.pathname.slice(0, -1);
+    }
+
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+function shouldRetryMcpRequestViaProxy(
+  request: HttpHistoryEntry["request"],
+  serverUrl: string | undefined
+): boolean {
+  if (!serverUrl) {
+    return false;
+  }
+
+  return (
+    normalizeProxyTargetUrl(request.url) === normalizeProxyTargetUrl(serverUrl)
+  );
+}
+
+async function executeRequestViaProxy(
+  request: HttpHistoryEntry["request"]
+): Promise<{
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: unknown;
+  ok: boolean;
+}> {
+  const proxyBase = HOSTED_MODE ? "/api/web/oauth" : "/api/mcp/oauth";
+  const response = await authFetch(`${proxyBase}/proxy`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      url: request.url,
       method: request.method,
       headers: request.headers,
-      body: serializeOAuthRequestBody(request.body, request.headers),
-    });
+      body: request.body,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await parseOAuthResponseBody(response);
+    const message =
+      body &&
+      typeof body === "object" &&
+      "error" in body &&
+      typeof (body as { error?: unknown }).error === "string"
+        ? (body as { error: string }).error
+        : `MCP request proxy failed (${response.status})`;
+    throw new Error(message);
+  }
+
+  const proxied = (await response.json()) as {
+    status: number;
+    statusText: string;
+    headers?: Record<string, string>;
+    body: unknown;
+  };
+
+  return {
+    status: proxied.status,
+    statusText: proxied.statusText,
+    headers: proxied.headers ?? {},
+    body: sanitizeOAuthTraceValue(proxied.body),
+    ok: proxied.status >= 200 && proxied.status < 300,
+  };
+}
+
+function createOAuthRequestExecutor(fetchFn: typeof fetch, serverUrl?: string) {
+  return async (request: HttpHistoryEntry["request"]) => {
+    let response:
+      | {
+          status: number;
+          statusText: string;
+          headers: Record<string, string>;
+          body: unknown;
+          ok: boolean;
+        }
+      | undefined;
+
+    try {
+      const directResponse = await fetchFn(request.url, {
+        method: request.method,
+        headers: request.headers,
+        body: serializeOAuthRequestBody(request.body, request.headers),
+      });
+      response = {
+        status: directResponse.status,
+        statusText: directResponse.statusText,
+        headers: normalizeResponseHeaders(directResponse.headers),
+        body: await parseOAuthResponseBody(directResponse),
+        ok: directResponse.ok,
+      };
+    } catch (error) {
+      if (!shouldRetryMcpRequestViaProxy(request, serverUrl)) {
+        throw error;
+      }
+
+      response = await executeRequestViaProxy(request);
+    }
+
     return {
       status: response.status,
       statusText: response.statusText,
-      headers: normalizeResponseHeaders(response.headers),
-      body: await parseOAuthResponseBody(response),
+      headers: response.headers,
+      body: response.body,
       ok: response.ok,
     };
   };
@@ -1459,7 +1564,10 @@ export async function initiateOAuth(
       },
       undefined
     );
-    const requestExecutor = createOAuthRequestExecutor(fetchFn);
+    const requestExecutor = createOAuthRequestExecutor(
+      fetchFn,
+      options.serverUrl
+    );
 
     // Store server URL for callback recovery
     localStorage.setItem(
@@ -1964,7 +2072,7 @@ export async function handleOAuthCallback(
       customClientSecret
     );
     const fetchFn = createOAuthFetchInterceptor(oauthConfig, undefined);
-    const requestExecutor = createOAuthRequestExecutor(fetchFn);
+    const requestExecutor = createOAuthRequestExecutor(fetchFn, serverUrl);
     const storedSession = loadOAuthFlowSession(serverName);
 
     if (storedSession) {

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -9,9 +9,8 @@ import {
   exchangeAuthorization,
   fetchToken,
   getBrowserDebugDynamicRegistrationMetadata,
-  getStepIndex,
-  getStepInfo,
   EMPTY_OAUTH_FLOW_STATE,
+  projectOAuthTraceSnapshot,
   runOAuthStateMachine,
   selectResourceURL,
 } from "@mcpjam/sdk/browser";
@@ -24,17 +23,24 @@ import type {
   RegistrationStrategy2025_03_26,
   RegistrationStrategy2025_06_18,
   RegistrationStrategy2025_11_25,
+  OAuthTraceSnapshot,
 } from "@mcpjam/sdk/browser";
 import type { HttpServerConfig } from "@mcpjam/sdk/browser";
 import { generateRandomString } from "./pkce";
 import { authFetch } from "@/lib/session-token";
 import { HOSTED_MODE } from "@/lib/config";
 import { captureServerDetailModalOAuthResume } from "@/lib/server-detail-modal-resume";
-import type { HostedOAuthCallbackContext } from "@/lib/hosted-oauth-callback";
+import {
+  matchesHostedOAuthServerIdentity,
+  readHostedOAuthPendingMarker,
+  writeHostedOAuthPendingMarker,
+  type HostedOAuthCallbackContext,
+} from "@/lib/hosted-oauth-callback";
 import { getRedirectUri } from "./constants";
 import { getConvexSiteUrl } from "@/lib/convex-site-url";
 import {
   appendOAuthTraceHttpHistory,
+  buildOAuthTraceFromSnapshot,
   clearOAuthTrace,
   completeOAuthTraceStep,
   createOAuthTrace,
@@ -151,7 +157,7 @@ function isSensitiveHeaderName(key: string): boolean {
     SENSITIVE_FIELD_NAMES.has(normalized) ||
     SENSITIVE_HEADER_PATTERNS.some((pattern) => pattern.test(key)) ||
     /(^|_)(token|secret|password|credential|cookie|auth)(_|$)/.test(
-      normalized,
+      normalized
     ) ||
     /(^|_)api_?key(_|$)/.test(normalized)
   );
@@ -162,7 +168,7 @@ function isSensitiveQueryParamName(key: string): boolean {
   return (
     SENSITIVE_FIELD_NAMES.has(normalized) ||
     /(^|_)(token|secret|password|credential|cookie|auth)(_|$)/.test(
-      normalized,
+      normalized
     ) ||
     /(^|_)api_?key(_|$)/.test(normalized)
   );
@@ -193,8 +199,8 @@ function sanitizeOAuthTraceString(value: string): unknown {
   const looksStructured =
     trimmed.includes("=") ||
     trimmed.includes("&") ||
-    ((trimmed.startsWith("{") && trimmed.endsWith("}")) ||
-      (trimmed.startsWith("[") && trimmed.endsWith("]")));
+    (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+    (trimmed.startsWith("[") && trimmed.endsWith("]"));
   if (looksStructured) {
     const parsed = parseOAuthRequestFields(trimmed);
     if (parsed) {
@@ -205,7 +211,7 @@ function sanitizeOAuthTraceString(value: string): unknown {
   return trimmed
     .replace(
       /\b(access_token|refresh_token|id_token|client_secret|code_verifier)\b(\s*[:=]\s*)([^\s&,;]+)/gi,
-      (_match, key: string, separator: string) => `${key}${separator}[redacted]`,
+      (_match, key: string, separator: string) => `${key}${separator}[redacted]`
     )
     .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+\b/gi, "Bearer [redacted]");
 }
@@ -225,7 +231,7 @@ function sanitizeOAuthUrl(rawUrl: string): string {
   } catch {
     return rawUrl.replace(
       /\bBearer\s+[A-Za-z0-9._~+/=-]+\b/gi,
-      "Bearer [redacted]",
+      "Bearer [redacted]"
     );
   }
 }
@@ -249,7 +255,7 @@ function sanitizeOAuthTraceValue(value: unknown): unknown {
         return [key, redactSensitiveValue(entryValue)];
       }
       return [key, sanitizeOAuthTraceValue(entryValue)];
-    }),
+    })
   );
 }
 
@@ -262,7 +268,7 @@ function sanitizeOAuthHeaderValue(value: string): string {
 }
 
 function sanitizeOAuthHeaders(
-  headers: Record<string, string>,
+  headers: Record<string, string>
 ): Record<string, string> {
   return Object.fromEntries(
     Object.entries(headers).map(([key, value]) => {
@@ -270,7 +276,7 @@ function sanitizeOAuthHeaders(
         return [key, redactSensitiveValue(value)];
       }
       return [key, sanitizeOAuthHeaderValue(value)];
-    }),
+    })
   );
 }
 
@@ -318,9 +324,7 @@ function cloneFlowState(state: OAuthFlowState): OAuthFlowState {
   return JSON.parse(JSON.stringify(state)) as OAuthFlowState;
 }
 
-function normalizeResponseHeaders(
-  headers: Headers,
-): Record<string, string> {
+function normalizeResponseHeaders(headers: Headers): Record<string, string> {
   const normalized: Record<string, string> = {};
   headers.forEach((value, key) => {
     normalized[key.toLowerCase()] = value;
@@ -359,7 +363,7 @@ async function parseOAuthResponseBody(response: Response): Promise<unknown> {
 
 function serializeOAuthRequestBody(
   body: HttpHistoryEntry["request"]["body"],
-  headers: Record<string, string>,
+  headers: Record<string, string>
 ): BodyInit | undefined {
   if (body === undefined || body === null) {
     return undefined;
@@ -371,7 +375,7 @@ function serializeOAuthRequestBody(
 
   const contentType =
     Object.entries(headers).find(
-      ([key]) => key.toLowerCase() === "content-type",
+      ([key]) => key.toLowerCase() === "content-type"
     )?.[1] ?? "";
 
   if (contentType.includes("application/x-www-form-urlencoded")) {
@@ -379,7 +383,7 @@ function serializeOAuthRequestBody(
       Object.entries(body as Record<string, string>).map(([key, value]) => [
         key,
         String(value),
-      ]),
+      ])
     ).toString();
   }
 
@@ -388,16 +392,16 @@ function serializeOAuthRequestBody(
 
 function saveOAuthFlowSession(
   serverName: string,
-  session: StoredOAuthFlowSession,
+  session: StoredOAuthFlowSession
 ): void {
   localStorage.setItem(
     getFlowStateStorageKey(serverName),
-    JSON.stringify(session),
+    JSON.stringify(session)
   );
 }
 
 function loadOAuthFlowSession(
-  serverName: string,
+  serverName: string
 ): StoredOAuthFlowSession | undefined {
   try {
     const raw = localStorage.getItem(getFlowStateStorageKey(serverName));
@@ -426,36 +430,8 @@ function clearOAuthFlowSession(serverName: string): void {
   localStorage.removeItem(getFlowStateStorageKey(serverName));
 }
 
-function sanitizeHttpHistoryEntry(entry: HttpHistoryEntry): HttpHistoryEntry {
-  return {
-    ...entry,
-    request: {
-      ...entry.request,
-      headers: sanitizeOAuthHeaders(entry.request.headers),
-      body: sanitizeOAuthTraceValue(entry.request.body),
-    },
-    ...(entry.response
-      ? {
-          response: {
-            ...entry.response,
-            headers: sanitizeOAuthHeaders(entry.response.headers),
-            body: sanitizeOAuthTraceValue(entry.response.body),
-          },
-        }
-      : {}),
-    ...(entry.error
-      ? {
-          error: {
-            ...entry.error,
-            details: sanitizeOAuthTraceValue(entry.error.details),
-          },
-        }
-      : {}),
-  };
-}
-
 function resolveOAuthProtocolVersion(
-  options: Pick<MCPOAuthOptions, "protocolVersion">,
+  options: Pick<MCPOAuthOptions, "protocolVersion">
 ): OAuthProtocolVersion {
   return options.protocolVersion ?? DEFAULT_OAUTH_PROTOCOL_VERSION;
 }
@@ -463,8 +439,11 @@ function resolveOAuthProtocolVersion(
 function resolveOAuthRegistrationStrategy(
   options: Pick<
     MCPOAuthOptions,
-    "registrationStrategy" | "clientId" | "clientSecret" | "useRegistryOAuthProxy"
-  >,
+    | "registrationStrategy"
+    | "clientId"
+    | "clientSecret"
+    | "useRegistryOAuthProxy"
+  >
 ): OAuthRegistrationStrategy {
   if (options.registrationStrategy) {
     return options.registrationStrategy;
@@ -500,7 +479,7 @@ function createOAuthRequestExecutor(fetchFn: typeof fetch) {
 
 function saveDiscoveryStateFromFlowState(
   provider: MCPOAuthProvider,
-  state: OAuthFlowState,
+  state: OAuthFlowState
 ): Promise<void> {
   if (!state.authorizationServerUrl) {
     return Promise.resolve();
@@ -523,7 +502,7 @@ function saveDiscoveryStateFromFlowState(
 
 async function persistOAuthStateArtifacts(
   provider: MCPOAuthProvider,
-  state: OAuthFlowState,
+  state: OAuthFlowState
 ): Promise<void> {
   if (state.clientId) {
     await provider.saveClientInformation({
@@ -556,189 +535,18 @@ function buildOAuthTraceFromFlowState(input: {
   serverUrl?: string;
   state: OAuthFlowState;
 }): OAuthTrace {
-  const trace = createOAuthTrace({
+  return buildOAuthTraceFromSnapshot({
     source: input.source,
     serverName: input.serverName,
     serverUrl: input.serverUrl,
+    snapshot: projectOAuthTraceSnapshot({
+      state: input.state,
+    }),
   });
-  const state = input.state;
-  const currentStepIndex = getStepIndex(state.currentStep);
-  trace.currentStep = state.currentStep;
-  trace.error = state.error;
-  trace.httpHistory = (state.httpHistory ?? []).map((entry) =>
-    sanitizeHttpHistoryEntry(entry),
-  );
-
-  const entries = new Map<
-    string,
-    {
-      step: HttpHistoryEntry["step"];
-      startedAt: number;
-      completedAt?: number;
-      message?: string;
-      details?: Record<string, unknown>;
-      error?: string;
-    }
-  >();
-
-  const ensureStep = (step: HttpHistoryEntry["step"], timestamp: number) => {
-    const existing = entries.get(step);
-    if (existing) {
-      existing.startedAt = Math.min(existing.startedAt, timestamp);
-      existing.completedAt = Math.max(
-        existing.completedAt ?? timestamp,
-        timestamp,
-      );
-      return existing;
-    }
-
-    const created = {
-      step,
-      startedAt: timestamp,
-      completedAt: timestamp,
-    };
-    entries.set(step, created);
-    return created;
-  };
-
-  for (const entry of state.httpHistory ?? []) {
-    const record = ensureStep(entry.step, entry.timestamp);
-    if (!record.details) {
-      record.details = {
-        request: sanitizeOAuthTraceValue(entry.request),
-        ...(entry.response
-          ? { response: sanitizeOAuthTraceValue(entry.response) }
-          : {}),
-      };
-    }
-    if (entry.error?.message) {
-      record.error = entry.error.message;
-    }
-  }
-
-  for (const log of state.infoLogs ?? []) {
-    const record = ensureStep(log.step, log.timestamp);
-    record.message = log.label;
-    const sanitizedLogData = sanitizeOAuthTraceValue(log.data);
-    if (
-      sanitizedLogData &&
-      typeof sanitizedLogData === "object" &&
-      sanitizedLogData !== null &&
-      !Array.isArray(sanitizedLogData)
-    ) {
-      record.details = sanitizedLogData as Record<string, unknown>;
-    }
-    if (log.error?.message) {
-      record.error = log.error.message;
-    }
-  }
-
-  const baseTimestamp = Math.max(
-    Date.now(),
-    ...(state.httpHistory ?? []).map((entry) => entry.timestamp),
-    ...(state.infoLogs ?? []).map((entry) => entry.timestamp),
-  );
-  let syntheticTimestamp = baseTimestamp;
-  const inferStep = (
-    step: HttpHistoryEntry["step"],
-    condition: boolean,
-    details?: Record<string, unknown>,
-  ) => {
-    if (!condition || entries.has(step)) {
-      return;
-    }
-
-    syntheticTimestamp += 1;
-    entries.set(step, {
-      step,
-      startedAt: syntheticTimestamp,
-      completedAt: syntheticTimestamp,
-      details:
-        details == null
-          ? undefined
-          : (sanitizeOAuthTraceValue(details) as Record<string, unknown>),
-    });
-  };
-
-  inferStep("request_client_registration", Boolean(state.clientId), {
-    clientId: state.clientId,
-  });
-  inferStep("received_client_credentials", Boolean(state.clientId), {
-    clientId: state.clientId,
-  });
-  inferStep("generate_pkce_parameters", Boolean(state.codeVerifier), {
-    codeVerifier: redactSensitiveValue(state.codeVerifier),
-  });
-  inferStep("authorization_request", Boolean(state.authorizationUrl), {
-    authorizationUrl: state.authorizationUrl,
-  });
-  inferStep(
-    "received_authorization_code",
-    Boolean(state.authorizationCode),
-    state.authorizationCode
-      ? { code: redactSensitiveValue(state.authorizationCode) }
-      : undefined,
-  );
-  inferStep("received_access_token", Boolean(state.accessToken), {
-    tokenType: state.tokenType,
-    expiresIn: state.expiresIn,
-  });
-  inferStep("complete", state.currentStep === "complete");
-
-  if (state.error && !entries.has(state.currentStep)) {
-    syntheticTimestamp += 1;
-    entries.set(state.currentStep, {
-      step: state.currentStep,
-      startedAt: syntheticTimestamp,
-      completedAt: syntheticTimestamp,
-      error: state.error,
-    });
-  }
-
-  trace.steps = Array.from(entries.values())
-    .sort(
-      (left, right) =>
-        left.startedAt - right.startedAt ||
-        getStepIndex(left.step) - getStepIndex(right.step),
-    )
-    .map((entry) => {
-      const stepIndex = getStepIndex(entry.step);
-      const status =
-        entry.error || (entry.step === state.currentStep && state.error)
-          ? "error"
-          : stepIndex < currentStepIndex ||
-              state.currentStep === "complete" ||
-              (entry.step === state.currentStep &&
-                ((entry.step === "authorization_request" &&
-                  Boolean(state.authorizationUrl)) ||
-                  (entry.step === "received_authorization_code" &&
-                    Boolean(state.authorizationCode)) ||
-                  (entry.step === "received_access_token" &&
-                    Boolean(state.accessToken)) ||
-                  (entry.step === "complete" &&
-                    state.currentStep === "complete")))
-            ? "success"
-            : entry.step === state.currentStep
-              ? "pending"
-              : "success";
-
-      return {
-        step: entry.step,
-        title: getStepInfo(entry.step).title,
-        status,
-        message: entry.message ?? getStepInfo(entry.step).summary,
-        ...(entry.error ? { error: entry.error } : {}),
-        ...(entry.details ? { details: entry.details } : {}),
-        startedAt: entry.startedAt,
-        completedAt: status === "pending" ? undefined : entry.completedAt,
-      };
-    });
-
-  return trace;
 }
 
 export function readStoredOAuthConfig(
-  serverName: string | null,
+  serverName: string | null
 ): StoredOAuthConfig {
   if (!serverName) {
     return {
@@ -791,8 +599,8 @@ export function readStoredOAuthConfig(
     ) {
       config.customHeaders = Object.fromEntries(
         Object.entries(parsed.customHeaders).filter(
-          ([, value]) => typeof value === "string",
-        ) as Array<[string, string]>,
+          ([, value]) => typeof value === "string"
+        ) as Array<[string, string]>
       );
     }
 
@@ -814,7 +622,7 @@ export function buildStoredOAuthConfig(
     | "customHeaders"
     | "protocolVersion"
     | "registrationStrategy"
-  >,
+  >
 ): StoredOAuthConfig {
   const config: StoredOAuthConfig = {
     registryServerId: options.registryServerId,
@@ -835,7 +643,7 @@ export function buildStoredOAuthConfig(
 }
 
 function parseOAuthRequestFields(
-  body: unknown,
+  body: unknown
 ): OAuthRequestFields | undefined {
   if (!body) return undefined;
 
@@ -900,7 +708,7 @@ function getOAuthGrantType(body: unknown): string | undefined {
 
 export function isOAuthTokenGrantRequest(
   method: string,
-  body: unknown,
+  body: unknown
 ): body is OAuthRequestFields {
   if (method !== "POST") {
     return false;
@@ -916,7 +724,7 @@ type OAuthRoutingRequestConfig = OAuthRoutingConfig & {
 };
 
 export function shouldUseRegistryOAuthProxy(
-  config: OAuthRoutingRequestConfig,
+  config: OAuthRoutingRequestConfig
 ): config is OAuthRoutingRequestConfig & {
   body: OAuthRequestFields;
 } {
@@ -930,7 +738,7 @@ export function shouldUseRegistryOAuthProxy(
 
 function toConvexOAuthPayload(
   registryServerId: string,
-  fields: OAuthRequestFields,
+  fields: OAuthRequestFields
 ): Record<string, string> {
   const payload: Record<string, string> = {
     registryServerId,
@@ -962,7 +770,7 @@ function toConvexOAuthPayload(
 async function loadCallbackDiscoveryState(
   provider: MCPOAuthProvider,
   serverUrl: string,
-  fetchFn: typeof fetch,
+  fetchFn: typeof fetch
 ): Promise<OAuthDiscoveryState> {
   const cachedState = await provider.discoveryState();
   if (cachedState?.authorizationServerUrl) {
@@ -970,7 +778,7 @@ async function loadCallbackDiscoveryState(
       cachedState.authorizationServerMetadata ??
       (await discoverAuthorizationServerMetadata(
         cachedState.authorizationServerUrl,
-        { fetchFn },
+        { fetchFn }
       ));
 
     const discoveryState: OAuthDiscoveryState = {
@@ -998,11 +806,11 @@ async function loadCallbackDiscoveryState(
  */
 function createOAuthFetchInterceptor(
   routingConfig: OAuthRoutingConfig = {},
-  trace?: OAuthTrace,
+  trace?: OAuthTrace
 ): typeof fetch {
   return async function interceptedFetch(
     input: RequestInfo | URL,
-    init?: RequestInit,
+    init?: RequestInit
   ): Promise<Response> {
     const method = (init?.method || "GET").toUpperCase();
     const serializedBody = init?.body
@@ -1012,8 +820,8 @@ function createOAuthFetchInterceptor(
       typeof input === "string"
         ? input
         : input instanceof URL
-          ? input.toString()
-          : input.url;
+        ? input.toString()
+        : input.url;
     const oauthGrantType = getOAuthGrantType(serializedBody);
     const registryTokenRequest = {
       ...routingConfig,
@@ -1039,12 +847,12 @@ function createOAuthFetchInterceptor(
       oauthGrantType === "refresh_token"
         ? "token_request"
         : url.includes("/register")
-          ? "request_client_registration"
-          : url.includes("oauth-protected-resource")
-            ? "request_resource_metadata"
-            : url.includes("/.well-known/")
-              ? "request_authorization_server_metadata"
-              : "authorization_request";
+        ? "request_client_registration"
+        : url.includes("oauth-protected-resource")
+        ? "request_resource_metadata"
+        : url.includes("/.well-known/")
+        ? "request_authorization_server_metadata"
+        : "authorization_request";
     const entry = createHttpHistoryEntry({
       step: traceStep,
       method,
@@ -1072,15 +880,15 @@ function createOAuthFetchInterceptor(
           body: JSON.stringify(
             toConvexOAuthPayload(
               routingConfig.registryServerId!,
-              registryTokenRequest.body,
-            ),
+              registryTokenRequest.body
+            )
           ),
         });
         entry.response = {
           status: response.status,
           statusText: response.statusText,
           headers: sanitizeOAuthHeaders(
-            Object.fromEntries(response.headers.entries()),
+            Object.fromEntries(response.headers.entries())
           ),
           body: await readResponseBodyForTrace(response),
         };
@@ -1103,7 +911,7 @@ function createOAuthFetchInterceptor(
           status: response.status,
           statusText: response.statusText,
           headers: sanitizeOAuthHeaders(
-            Object.fromEntries(response.headers.entries()),
+            Object.fromEntries(response.headers.entries())
           ),
           body: await readResponseBodyForTrace(response),
         };
@@ -1131,7 +939,7 @@ function createOAuthFetchInterceptor(
           status: response.status,
           statusText: response.statusText,
           headers: sanitizeOAuthHeaders(
-            Object.fromEntries(response.headers.entries()),
+            Object.fromEntries(response.headers.entries())
           ),
           body: await readResponseBodyForTrace(response),
         };
@@ -1201,6 +1009,7 @@ export interface MCPOAuthOptions {
   useRegistryOAuthProxy?: boolean;
   protocolVersion?: OAuthProtocolVersion;
   registrationStrategy?: OAuthRegistrationStrategy;
+  onTraceUpdate?: (trace: OAuthTrace) => void;
 }
 
 export interface OAuthResult {
@@ -1218,6 +1027,176 @@ interface HostedOAuthCompletionResponse {
   oauthTrace?: OAuthTrace;
 }
 
+interface HostedOAuthSessionProgressResponse {
+  success: boolean;
+  sessionId?: string;
+  status?: "pending" | "running" | "succeeded" | "failed";
+  updatedAt?: number;
+  completedAt?: number;
+  lastError?: string;
+  error?: string;
+  oauthTrace?: OAuthTrace;
+}
+
+const HOSTED_OAUTH_PROGRESS_POLL_MS = 250;
+
+function publishOAuthTraceUpdate(
+  serverName: string | undefined,
+  trace: OAuthTrace,
+  onTraceUpdate?: (trace: OAuthTrace) => void
+): OAuthTrace {
+  if (serverName) {
+    saveOAuthTrace(serverName, trace);
+  }
+  onTraceUpdate?.(trace);
+  return trace;
+}
+
+function waitForMs(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+async function createHostedOAuthSessionIfNeeded(input: {
+  serverName: string;
+  serverUrl: string;
+  authorizationUrl: string;
+  redirectUrl: string;
+  state: OAuthFlowState;
+}): Promise<string | undefined> {
+  if (!HOSTED_MODE) {
+    return undefined;
+  }
+
+  const pendingMarker = readHostedOAuthPendingMarker();
+  if (
+    !pendingMarker?.workspaceId ||
+    !pendingMarker.serverId ||
+    !matchesHostedOAuthServerIdentity(
+      {
+        serverName: pendingMarker.serverName,
+        serverUrl: pendingMarker.serverUrl,
+      },
+      {
+        serverName: input.serverName,
+        serverUrl: input.serverUrl,
+      }
+    )
+  ) {
+    return undefined;
+  }
+
+  const clientId = input.state.clientId;
+  if (!clientId) {
+    throw new Error("OAuth client ID not ready for hosted callback session.");
+  }
+
+  const codeVerifier = input.state.codeVerifier;
+  if (!codeVerifier) {
+    throw new Error("Code verifier not ready for hosted callback session.");
+  }
+
+  const response = await authFetch("/api/web/oauth/session", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      workspaceId: pendingMarker.workspaceId,
+      serverId: pendingMarker.serverId,
+      codeVerifier,
+      redirectUri: input.redirectUrl,
+      clientInformation: {
+        clientId,
+        ...(input.state.clientSecret
+          ? { clientSecret: input.state.clientSecret }
+          : {}),
+      },
+      flowState: {
+        ...cloneFlowState(input.state),
+        authorizationUrl: input.authorizationUrl,
+      },
+      ...(pendingMarker.accessScope
+        ? { accessScope: pendingMarker.accessScope }
+        : {}),
+      ...(pendingMarker.shareToken
+        ? { shareToken: pendingMarker.shareToken }
+        : {}),
+      ...(pendingMarker.chatboxToken
+        ? { chatboxToken: pendingMarker.chatboxToken }
+        : {}),
+    }),
+  });
+  const result = (await response
+    .clone()
+    .json()
+    .catch(() => null)) as {
+    success?: boolean;
+    sessionId?: string;
+    error?: string;
+  } | null;
+
+  if (
+    !response.ok ||
+    !result?.success ||
+    typeof result.sessionId !== "string"
+  ) {
+    throw new Error(
+      result?.error || `Hosted OAuth session failed (${response.status})`
+    );
+  }
+
+  writeHostedOAuthPendingMarker({
+    ...pendingMarker,
+    sessionId: result.sessionId,
+  });
+  return result.sessionId;
+}
+
+async function readHostedOAuthSessionProgress(input: {
+  convexSiteUrl: string;
+  context: HostedOAuthCallbackContext;
+}): Promise<HostedOAuthSessionProgressResponse | null> {
+  if (
+    !input.context.workspaceId ||
+    !input.context.serverId ||
+    !input.context.sessionId
+  ) {
+    return null;
+  }
+
+  const response = await authFetch(
+    `${input.convexSiteUrl}/web/oauth/session/progress`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        workspaceId: input.context.workspaceId,
+        serverId: input.context.serverId,
+        sessionId: input.context.sessionId,
+        ...(input.context.accessScope
+          ? { accessScope: input.context.accessScope }
+          : {}),
+        ...(input.context.shareToken
+          ? { shareToken: input.context.shareToken }
+          : {}),
+        ...(input.context.chatboxToken
+          ? { chatboxToken: input.context.chatboxToken }
+          : {}),
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    return null;
+  }
+
+  return (await response
+    .json()
+    .catch(() => null)) as HostedOAuthSessionProgressResponse | null;
+}
+
 /**
  * Simple localStorage-based OAuth provider for MCP
  */
@@ -1232,7 +1211,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     serverName: string,
     serverUrl: string,
     customClientId?: string,
-    customClientSecret?: string,
+    customClientSecret?: string
   ) {
     this.serverName = serverName;
     this.serverUrl = serverUrl;
@@ -1295,7 +1274,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   async saveClientInformation(clientInformation: any) {
     localStorage.setItem(
       `mcp-client-${this.serverName}`,
-      JSON.stringify(clientInformation),
+      JSON.stringify(clientInformation)
     );
   }
 
@@ -1307,7 +1286,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   async saveTokens(tokens: any) {
     localStorage.setItem(
       `mcp-tokens-${this.serverName}`,
-      JSON.stringify(tokens),
+      JSON.stringify(tokens)
     );
   }
 
@@ -1325,7 +1304,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
 
   discoveryState(): OAuthDiscoveryState | undefined {
     const stored = localStorage.getItem(
-      getDiscoveryStorageKey(this.serverName),
+      getDiscoveryStorageKey(this.serverName)
     );
     if (!stored) {
       return undefined;
@@ -1354,7 +1333,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     };
     localStorage.setItem(
       getDiscoveryStorageKey(this.serverName),
-      JSON.stringify(payload),
+      JSON.stringify(payload)
     );
   }
 
@@ -1382,7 +1361,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   }
 
   async invalidateCredentials(
-    scope: "all" | "client" | "tokens" | "verifier" | "discovery",
+    scope: "all" | "client" | "tokens" | "verifier" | "discovery"
   ) {
     switch (scope) {
       case "all":
@@ -1408,7 +1387,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
 }
 
 function readStoredClientInformation(
-  serverName: string,
+  serverName: string
 ): StoredOAuthClientInformation {
   try {
     const stored = localStorage.getItem(`mcp-client-${serverName}`);
@@ -1434,20 +1413,42 @@ function readStoredClientInformation(
  * Initiates OAuth flow for an MCP server
  */
 export async function initiateOAuth(
-  options: MCPOAuthOptions,
+  options: MCPOAuthOptions
 ): Promise<OAuthResult> {
   let state = cloneEmptyFlowState();
   const updateState = (updates: Partial<OAuthFlowState>) => {
     state = { ...state, ...updates };
   };
   const getState = () => state;
+  const emitTraceSnapshot = (snapshot: OAuthTraceSnapshot) =>
+    publishOAuthTraceUpdate(
+      options.serverName,
+      buildOAuthTraceFromSnapshot({
+        source: "interactive_connect",
+        serverName: options.serverName,
+        serverUrl: options.serverUrl,
+        snapshot,
+      }),
+      options.onTraceUpdate
+    );
+  const emitTraceFromState = (nextState: OAuthFlowState) =>
+    publishOAuthTraceUpdate(
+      options.serverName,
+      buildOAuthTraceFromFlowState({
+        source: "interactive_connect",
+        serverName: options.serverName,
+        serverUrl: options.serverUrl,
+        state: nextState,
+      }),
+      options.onTraceUpdate
+    );
 
   try {
     const provider = new MCPOAuthProvider(
       options.serverName,
       options.serverUrl,
       options.clientId,
-      options.clientSecret,
+      options.clientSecret
     );
     const protocolVersion = resolveOAuthProtocolVersion(options);
     const registrationStrategy = resolveOAuthRegistrationStrategy(options);
@@ -1456,14 +1457,14 @@ export async function initiateOAuth(
         registryServerId: options.registryServerId,
         useRegistryOAuthProxy: options.useRegistryOAuthProxy,
       },
-      undefined,
+      undefined
     );
     const requestExecutor = createOAuthRequestExecutor(fetchFn);
 
     // Store server URL for callback recovery
     localStorage.setItem(
       `mcp-serverUrl-${options.serverName}`,
-      options.serverUrl,
+      options.serverUrl
     );
     localStorage.setItem("mcp-oauth-pending", options.serverName);
 
@@ -1475,13 +1476,13 @@ export async function initiateOAuth(
     });
     localStorage.setItem(
       `mcp-oauth-config-${options.serverName}`,
-      JSON.stringify(oauthConfig),
+      JSON.stringify(oauthConfig)
     );
 
     // Store custom client credentials if provided, so they can be retrieved during callback
     if (options.clientId || options.clientSecret) {
       const existingClientInfo = localStorage.getItem(
-        `mcp-client-${options.serverName}`,
+        `mcp-client-${options.serverName}`
       );
       const existingJson = existingClientInfo
         ? JSON.parse(existingClientInfo)
@@ -1497,7 +1498,7 @@ export async function initiateOAuth(
 
       localStorage.setItem(
         `mcp-client-${options.serverName}`,
-        JSON.stringify(updatedClientInfo),
+        JSON.stringify(updatedClientInfo)
       );
     }
 
@@ -1530,7 +1531,17 @@ export async function initiateOAuth(
       customScopes: requestedScope,
       customHeaders: options.customHeaders,
       authMode: "interactive",
+      onTraceUpdate: ({ trace: snapshot }) => {
+        emitTraceSnapshot(snapshot);
+      },
       onAuthorizationRequest: async ({ authorizationUrl }) => {
+        await createHostedOAuthSessionIfNeeded({
+          serverName: options.serverName,
+          serverUrl: options.serverUrl,
+          authorizationUrl,
+          redirectUrl: provider.redirectUrl,
+          state: getState(),
+        });
         await persistOAuthStateArtifacts(provider, getState());
         saveOAuthFlowSession(options.serverName, {
           version: 1,
@@ -1538,25 +1549,13 @@ export async function initiateOAuth(
           registrationStrategy,
           state: cloneFlowState(getState()),
         });
-        const redirectTrace = buildOAuthTraceFromFlowState({
-          source: "interactive_connect",
-          serverName: options.serverName,
-          serverUrl: options.serverUrl,
-          state: getState(),
-        });
-        saveOAuthTrace(options.serverName, redirectTrace);
+        emitTraceFromState(getState());
         await provider.redirectToAuthorization(new URL(authorizationUrl));
         return { type: "redirect" };
       },
     });
 
-    const trace = buildOAuthTraceFromFlowState({
-      source: "interactive_connect",
-      serverName: options.serverName,
-      serverUrl: options.serverUrl,
-      state: flowResult.state,
-    });
-    saveOAuthTrace(options.serverName, trace);
+    const trace = emitTraceFromState(flowResult.state);
 
     if (flowResult.error) {
       return {
@@ -1621,7 +1620,7 @@ export async function initiateOAuth(
         error: errorMessage,
       },
     });
-    saveOAuthTrace(options.serverName, trace);
+    publishOAuthTraceUpdate(options.serverName, trace, options.onTraceUpdate);
 
     return {
       success: false,
@@ -1639,8 +1638,8 @@ function formatOAuthCallbackError(error: unknown): string {
     error instanceof Error
       ? error.message
       : typeof error === "string"
-        ? error
-        : "Unknown callback error";
+      ? error
+      : "Unknown callback error";
 
   if (
     errorMessage.includes("invalid_client") ||
@@ -1661,12 +1660,30 @@ function formatOAuthCallbackError(error: unknown): string {
 export async function completeHostedOAuthCallback(
   context: HostedOAuthCallbackContext,
   authorizationCode: string,
+  options: { onTraceUpdate?: (trace: OAuthTrace) => void } = {}
 ): Promise<OAuthResult & { serverName?: string; expiresAt?: number | null }> {
-  const serverName = context.serverName || localStorage.getItem("mcp-oauth-pending");
+  const serverName =
+    context.serverName || localStorage.getItem("mcp-oauth-pending");
+  const previousTrace = serverName ? loadOAuthTrace(serverName) : undefined;
   const callbackTrace = createOAuthTrace({
     source: "hosted_callback",
     serverName: serverName ?? undefined,
   });
+  const mergeHostedCallbackTrace = (backendTrace?: OAuthTrace): OAuthTrace =>
+    backendTrace
+      ? mergeOAuthTraces(callbackTrace, backendTrace)
+      : callbackTrace;
+  const emitTrace = (trace: OAuthTrace) =>
+    publishOAuthTraceUpdate(
+      serverName,
+      previousTrace ? mergeOAuthTraces(previousTrace, trace) : trace,
+      options.onTraceUpdate
+    );
+  let stopProgressPolling = false;
+  let progressPollingPromise: Promise<void> | null = null;
+  let resolveTerminalProgressFailure:
+    | ((failure: { message: string; oauthTrace?: OAuthTrace }) => void)
+    | null = null;
 
   try {
     if (!serverName) {
@@ -1677,78 +1694,166 @@ export async function completeHostedOAuthCallback(
     }
 
     startOAuthTraceStep(callbackTrace, "received_authorization_code", {
-      message: "Received hosted OAuth callback and loading stored callback state.",
+      message: context.sessionId
+        ? "Received hosted OAuth callback and restoring server-side callback state."
+        : "Received hosted OAuth callback and loading stored callback state.",
     });
+    emitTrace(callbackTrace);
     const serverUrl =
       context.serverUrl || localStorage.getItem(`mcp-serverUrl-${serverName}`);
     if (!serverUrl) {
       throw new Error("Server URL not found for OAuth callback");
     }
-
-    const codeVerifier = localStorage.getItem(`mcp-verifier-${serverName}`);
-    if (!codeVerifier) {
-      throw new Error("Code verifier not found");
-    }
-
-    const clientInformation = readStoredClientInformation(serverName);
-    if (!clientInformation.client_id) {
-      throw new Error("OAuth client ID not found");
-    }
     completeOAuthTraceStep(callbackTrace, "received_authorization_code", {
-      message: "Hosted callback state restored.",
+      message: context.sessionId
+        ? "Hosted callback state restored from the shared backend session."
+        : "Hosted callback state restored.",
       details: {
         serverUrl,
-        clientId: clientInformation.client_id,
+        ...(context.sessionId
+          ? { sessionId: context.sessionId }
+          : (() => {
+              const clientInformation = readStoredClientInformation(serverName);
+              return clientInformation.client_id
+                ? { clientId: clientInformation.client_id }
+                : {};
+            })()),
       },
     });
+    emitTrace(callbackTrace);
 
     const convexSiteUrl = getConvexSiteUrl();
-    const response = await authFetch(`${convexSiteUrl}/web/oauth/complete`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        workspaceId: context.workspaceId,
-        serverId: context.serverId,
-        serverUrl,
-        code: authorizationCode,
-        codeVerifier,
-        redirectUri: getRedirectUri(),
-        clientInformation: {
-          clientId: clientInformation.client_id,
-          ...(clientInformation.client_secret
-            ? { clientSecret: clientInformation.client_secret }
-            : {}),
-        },
-        ...(context.accessScope ? { accessScope: context.accessScope } : {}),
-        ...(context.shareToken ? { shareToken: context.shareToken } : {}),
-        ...(context.chatboxToken ? { chatboxToken: context.chatboxToken } : {}),
-      }),
-    });
+    const terminalProgressFailurePromise =
+      context.sessionId && convexSiteUrl
+        ? new Promise<{ message: string; oauthTrace?: OAuthTrace }>(
+            (resolve) => {
+              resolveTerminalProgressFailure = resolve;
+            }
+          )
+        : null;
+    const legacyClientInformation = context.sessionId
+      ? undefined
+      : readStoredClientInformation(serverName);
+    const legacyCodeVerifier = context.sessionId
+      ? undefined
+      : localStorage.getItem(`mcp-verifier-${serverName}`);
+    if (!context.sessionId && !legacyCodeVerifier) {
+      throw new Error("Code verifier not found");
+    }
+    if (!context.sessionId && !legacyClientInformation?.client_id) {
+      throw new Error("OAuth client ID not found");
+    }
 
-    const result =
-      (await response
+    if (context.sessionId && convexSiteUrl) {
+      let lastProgressUpdateAt = -1;
+      progressPollingPromise = (async () => {
+        while (!stopProgressPolling) {
+          try {
+            const progress = await readHostedOAuthSessionProgress({
+              convexSiteUrl,
+              context,
+            });
+            if (
+              progress?.success &&
+              progress.oauthTrace &&
+              typeof progress.updatedAt === "number" &&
+              progress.updatedAt !== lastProgressUpdateAt
+            ) {
+              lastProgressUpdateAt = progress.updatedAt;
+              emitTrace(mergeHostedCallbackTrace(progress.oauthTrace));
+            }
+            if (progress?.success && progress.status === "failed") {
+              stopProgressPolling = true;
+              resolveTerminalProgressFailure?.({
+                message:
+                  progress.lastError ||
+                  progress.error ||
+                  "Hosted OAuth callback failed",
+                oauthTrace: progress.oauthTrace,
+              });
+              break;
+            }
+            if (progress?.success && progress.status === "succeeded") {
+              stopProgressPolling = true;
+              break;
+            }
+          } catch {
+            // Best effort only; final callback response remains authoritative.
+          }
+
+          if (stopProgressPolling) {
+            break;
+          }
+          await waitForMs(HOSTED_OAUTH_PROGRESS_POLL_MS);
+        }
+      })();
+    }
+
+    const completionPromise = (async () => {
+      const response = await authFetch(`${convexSiteUrl}/web/oauth/complete`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          workspaceId: context.workspaceId,
+          serverId: context.serverId,
+          code: authorizationCode,
+          ...(context.sessionId
+            ? { sessionId: context.sessionId }
+            : {
+                serverUrl,
+                codeVerifier: legacyCodeVerifier,
+                redirectUri: getRedirectUri(),
+                clientInformation: {
+                  clientId: legacyClientInformation!.client_id!,
+                  ...(legacyClientInformation?.client_secret
+                    ? { clientSecret: legacyClientInformation.client_secret }
+                    : {}),
+                },
+              }),
+          ...(context.accessScope ? { accessScope: context.accessScope } : {}),
+          ...(context.shareToken ? { shareToken: context.shareToken } : {}),
+          ...(context.chatboxToken
+            ? { chatboxToken: context.chatboxToken }
+            : {}),
+        }),
+      });
+
+      const result = (await response
         .clone()
         .json()
         .catch(() => null)) as HostedOAuthCompletionResponse | null;
-    if (!response.ok) {
-      const responseText = await response.text();
-      throw {
-        message:
-          result?.error ||
-          responseText ||
-          `Hosted OAuth callback failed (${response.status})`,
-        oauthTrace: result?.oauthTrace,
-      };
-    }
+      if (!response.ok) {
+        const responseText = await response.text();
+        throw {
+          message:
+            result?.error ||
+            responseText ||
+            `Hosted OAuth callback failed (${response.status})`,
+          oauthTrace: result?.oauthTrace,
+        };
+      }
 
-    if (!result?.success) {
-      throw {
-        message: result?.error || "Hosted OAuth callback failed",
-        oauthTrace: result?.oauthTrace,
-      };
-    }
+      if (!result?.success) {
+        throw {
+          message: result?.error || "Hosted OAuth callback failed",
+          oauthTrace: result?.oauthTrace,
+        };
+      }
+
+      return result;
+    })();
+    const result = terminalProgressFailurePromise
+      ? await Promise.race([
+          completionPromise,
+          terminalProgressFailurePromise.then<HostedOAuthCompletionResponse>(
+            (failure) => {
+              throw failure;
+            }
+          ),
+        ])
+      : await completionPromise;
 
     localStorage.removeItem(`mcp-tokens-${serverName}`);
     localStorage.removeItem(`mcp-verifier-${serverName}`);
@@ -1761,13 +1866,13 @@ export async function completeHostedOAuthCallback(
     completeOAuthTraceStep(callbackTrace, "complete", {
       message: "Hosted OAuth callback completed successfully.",
     });
-    const mergedTrace = mergeOAuthTraces(
-      loadOAuthTrace(serverName),
-      result.oauthTrace
-        ? mergeOAuthTraces(callbackTrace, result.oauthTrace)
-        : callbackTrace,
-    );
-    saveOAuthTrace(serverName, mergedTrace);
+    const mergedTrace = previousTrace
+      ? mergeOAuthTraces(
+          previousTrace,
+          mergeHostedCallbackTrace(result.oauthTrace)
+        )
+      : mergeHostedCallbackTrace(result.oauthTrace);
+    publishOAuthTraceUpdate(serverName, mergedTrace, options.onTraceUpdate);
     clearOAuthFlowSession(serverName);
 
     return {
@@ -1782,31 +1887,29 @@ export async function completeHostedOAuthCallback(
       error instanceof Error
         ? error.message
         : typeof error === "object" &&
-            error !== null &&
-            "message" in error &&
-            typeof (error as { message?: unknown }).message === "string"
-          ? ((error as { message: string }).message)
-          : String(error);
+          error !== null &&
+          "message" in error &&
+          typeof (error as { message?: unknown }).message === "string"
+        ? (error as { message: string }).message
+        : String(error);
     failOAuthTraceStep(callbackTrace, callbackTrace.currentStep, message, {
       message: "Hosted OAuth callback failed.",
     });
     const backendTrace =
       typeof error === "object" && error !== null && "oauthTrace" in error
-        ? ((error as { oauthTrace?: OAuthTrace }).oauthTrace ?? undefined)
+        ? (error as { oauthTrace?: OAuthTrace }).oauthTrace ?? undefined
         : undefined;
     const mergedTrace =
       serverName != null
-        ? mergeOAuthTraces(
-            loadOAuthTrace(serverName),
-            backendTrace
-              ? mergeOAuthTraces(callbackTrace, backendTrace)
-              : callbackTrace,
-          )
-        : backendTrace
-          ? mergeOAuthTraces(callbackTrace, backendTrace)
-          : callbackTrace;
+        ? previousTrace
+          ? mergeOAuthTraces(
+              previousTrace,
+              mergeHostedCallbackTrace(backendTrace)
+            )
+          : mergeHostedCallbackTrace(backendTrace)
+        : mergeHostedCallbackTrace(backendTrace);
     if (serverName) {
-      saveOAuthTrace(serverName, mergedTrace);
+      publishOAuthTraceUpdate(serverName, mergedTrace, options.onTraceUpdate);
       clearOAuthFlowSession(serverName);
     }
     return {
@@ -1814,6 +1917,9 @@ export async function completeHostedOAuthCallback(
       error: formatOAuthCallbackError(message),
       oauthTrace: mergedTrace,
     };
+  } finally {
+    stopProgressPolling = true;
+    await progressPollingPromise?.catch(() => undefined);
   }
 }
 
@@ -1822,9 +1928,11 @@ export async function completeHostedOAuthCallback(
  */
 export async function handleOAuthCallback(
   authorizationCode: string,
+  options: { onTraceUpdate?: (trace: OAuthTrace) => void } = {}
 ): Promise<OAuthResult & { serverName?: string }> {
   // Get pending server name from localStorage (needed before creating interceptor)
   const serverName = localStorage.getItem("mcp-oauth-pending");
+  const previousTrace = serverName ? loadOAuthTrace(serverName) : undefined;
 
   // Read registryServerId from stored OAuth config if present
   const oauthConfig = readStoredOAuthConfig(serverName);
@@ -1853,7 +1961,7 @@ export async function handleOAuthCallback(
       serverName,
       serverUrl,
       customClientId,
-      customClientSecret,
+      customClientSecret
     );
     const fetchFn = createOAuthFetchInterceptor(oauthConfig, undefined);
     const requestExecutor = createOAuthRequestExecutor(fetchFn);
@@ -1865,12 +1973,31 @@ export async function handleOAuthCallback(
         state = { ...state, ...updates };
       };
       const getState = () => state;
+      const emitTraceSnapshot = (snapshot: OAuthTraceSnapshot) =>
+        publishOAuthTraceUpdate(
+          serverName,
+          mergeOAuthTraces(
+            previousTrace,
+            buildOAuthTraceFromSnapshot({
+              source: "callback",
+              serverName,
+              serverUrl,
+              snapshot,
+            })
+          ),
+          options.onTraceUpdate
+        );
 
       updateState({
         currentStep: "received_authorization_code",
         authorizationCode,
         error: undefined,
       });
+      emitTraceSnapshot(
+        projectOAuthTraceSnapshot({
+          state: getState(),
+        })
+      );
 
       const flowResult = await runOAuthStateMachine({
         protocolVersion: storedSession.protocolVersion,
@@ -1891,7 +2018,7 @@ export async function handleOAuthCallback(
         },
         dynamicRegistration: {
           ...getBrowserDebugDynamicRegistrationMetadata(
-            storedSession.protocolVersion,
+            storedSession.protocolVersion
           ),
           ...provider.clientMetadata,
         },
@@ -1899,6 +2026,9 @@ export async function handleOAuthCallback(
         customScopes: oauthConfig.scopes?.join(" "),
         customHeaders: oauthConfig.customHeaders,
         authMode: "interactive",
+        onTraceUpdate: ({ trace: snapshot }) => {
+          emitTraceSnapshot(snapshot);
+        },
       });
 
       const callbackTrace = buildOAuthTraceFromFlowState({
@@ -1907,17 +2037,18 @@ export async function handleOAuthCallback(
         serverUrl,
         state: flowResult.state,
       });
-      const mergedTrace = mergeOAuthTraces(
-        loadOAuthTrace(serverName),
-        callbackTrace,
-      );
-      saveOAuthTrace(serverName, mergedTrace);
+      const mergedTrace = mergeOAuthTraces(previousTrace, callbackTrace);
+      publishOAuthTraceUpdate(serverName, mergedTrace, options.onTraceUpdate);
 
-      if (flowResult.error || !flowResult.completed || !flowResult.state.accessToken) {
+      if (
+        flowResult.error ||
+        !flowResult.completed ||
+        !flowResult.state.accessToken
+      ) {
         return {
           success: false,
           error: formatOAuthCallbackError(
-            flowResult.error?.message || flowResult.state.error,
+            flowResult.error?.message || flowResult.state.error
           ),
           oauthTrace: mergedTrace,
         };
@@ -1941,12 +2072,19 @@ export async function handleOAuthCallback(
       source: "callback",
       serverName: serverName ?? undefined,
     });
+    const emitTrace = (trace: OAuthTrace) =>
+      publishOAuthTraceUpdate(
+        serverName,
+        mergeOAuthTraces(previousTrace, trace),
+        options.onTraceUpdate
+      );
     startOAuthTraceStep(callbackTrace, "received_authorization_code", {
       message: "Received OAuth callback and loading stored state.",
       details: {
         serverUrl,
       },
     });
+    emitTrace(callbackTrace);
     const clientInformation = await provider.clientInformation();
     if (!clientInformation?.client_id) {
       throw new Error("OAuth client ID not found");
@@ -1954,7 +2092,7 @@ export async function handleOAuthCallback(
     const discoveryState = await loadCallbackDiscoveryState(
       provider,
       serverUrl,
-      fetchFn,
+      fetchFn
     );
     completeOAuthTraceStep(callbackTrace, "received_authorization_code", {
       message: "Callback state restored.",
@@ -1962,14 +2100,16 @@ export async function handleOAuthCallback(
         clientId: clientInformation.client_id,
       },
     });
+    emitTrace(callbackTrace);
     const resource = await selectResourceURL(
       serverUrl,
       provider,
-      discoveryState.resourceMetadata,
+      discoveryState.resourceMetadata
     );
     startOAuthTraceStep(callbackTrace, "token_request", {
       message: "Exchanging authorization code for OAuth tokens.",
     });
+    emitTrace(callbackTrace);
     const tokens = await exchangeAuthorization(
       discoveryState.authorizationServerUrl,
       {
@@ -1980,7 +2120,7 @@ export async function handleOAuthCallback(
         redirectUri: provider.redirectUrl,
         ...(resource ? { resource } : {}),
         fetchFn,
-      },
+      }
     );
     await provider.saveTokens(tokens);
     completeOAuthTraceStep(callbackTrace, "token_request", {
@@ -1996,11 +2136,8 @@ export async function handleOAuthCallback(
     // Clean up pending state
     localStorage.removeItem("mcp-oauth-pending");
     localStorage.removeItem(`mcp-verifier-${serverName}`);
-    const mergedTrace = mergeOAuthTraces(
-      loadOAuthTrace(serverName),
-      callbackTrace,
-    );
-    saveOAuthTrace(serverName, mergedTrace);
+    const mergedTrace = mergeOAuthTraces(previousTrace, callbackTrace);
+    publishOAuthTraceUpdate(serverName, mergedTrace, options.onTraceUpdate);
 
     const serverConfig = createServerConfig(serverUrl, tokens);
     return {
@@ -2015,7 +2152,7 @@ export async function handleOAuthCallback(
       serverName: serverName ?? undefined,
       serverUrl:
         serverName != null
-          ? (localStorage.getItem(`mcp-serverUrl-${serverName}`) ?? "")
+          ? localStorage.getItem(`mcp-serverUrl-${serverName}`) ?? ""
           : "",
       state: {
         ...cloneEmptyFlowState(),
@@ -2024,10 +2161,10 @@ export async function handleOAuthCallback(
       },
     });
     const mergedTrace = serverName
-      ? mergeOAuthTraces(loadOAuthTrace(serverName), callbackTrace)
+      ? mergeOAuthTraces(previousTrace, callbackTrace)
       : callbackTrace;
     if (serverName) {
-      saveOAuthTrace(serverName, mergedTrace);
+      publishOAuthTraceUpdate(serverName, mergedTrace, options.onTraceUpdate);
     }
     return {
       success: false,
@@ -2085,7 +2222,7 @@ export function hasOAuthConfig(serverName: string): boolean {
   const storedServerUrl = localStorage.getItem(`mcp-serverUrl-${serverName}`);
   const storedClientInfo = localStorage.getItem(`mcp-client-${serverName}`);
   const storedOAuthConfig = localStorage.getItem(
-    `mcp-oauth-config-${serverName}`,
+    `mcp-oauth-config-${serverName}`
   );
   const storedTokens = getStoredTokens(serverName);
 
@@ -2102,7 +2239,7 @@ export function hasOAuthConfig(serverName: string): boolean {
  */
 export async function waitForTokens(
   serverName: string,
-  timeoutMs: number = 5000,
+  timeoutMs: number = 5000
 ): Promise<any> {
   const startTime = Date.now();
 
@@ -2122,11 +2259,14 @@ export async function waitForTokens(
  */
 export async function refreshOAuthTokens(
   serverName: string,
+  options: { onTraceUpdate?: (trace: OAuthTrace) => void } = {}
 ): Promise<OAuthResult> {
   const trace = createOAuthTrace({
     source: "refresh",
     serverName,
   });
+  const emitTrace = () =>
+    publishOAuthTraceUpdate(serverName, trace, options.onTraceUpdate);
   // Build fetch interceptor — routes token requests through Convex for registry servers
   const oauthConfig = readStoredOAuthConfig(serverName);
   const fetchFn = createOAuthFetchInterceptor(oauthConfig, trace);
@@ -2144,6 +2284,7 @@ export async function refreshOAuthTokens(
     // Get server URL
     const serverUrl = localStorage.getItem(`mcp-serverUrl-${serverName}`);
     if (!serverUrl) {
+      emitTrace();
       return {
         success: false,
         error: "Server URL not found for token refresh",
@@ -2154,11 +2295,12 @@ export async function refreshOAuthTokens(
       serverName,
       serverUrl,
       customClientId,
-      customClientSecret,
+      customClientSecret
     );
     const existingTokens = provider.tokens();
 
     if (!existingTokens?.refresh_token) {
+      emitTrace();
       return {
         success: false,
         error: "No refresh token available",
@@ -2169,10 +2311,11 @@ export async function refreshOAuthTokens(
     startOAuthTraceStep(trace, "request_resource_metadata", {
       message: "Refreshing OAuth tokens and rediscovering server metadata.",
     });
+    emitTrace();
     const discoveryState = await loadCallbackDiscoveryState(
       provider,
       serverUrl,
-      fetchFn,
+      fetchFn
     );
     completeOAuthTraceStep(trace, "request_resource_metadata", {
       message: "Protected resource metadata loaded.",
@@ -2183,19 +2326,25 @@ export async function refreshOAuthTokens(
     completeOAuthTraceStep(trace, "received_authorization_server_metadata", {
       message: "Authorization server metadata is ready.",
     });
+    emitTrace();
     const resource = await selectResourceURL(
       serverUrl,
       provider,
-      discoveryState.resourceMetadata,
+      discoveryState.resourceMetadata
     );
     startOAuthTraceStep(trace, "token_request", {
       message: "Refreshing tokens with the stored refresh token.",
     });
-    const tokens = await fetchToken(provider, discoveryState.authorizationServerUrl, {
-      metadata: discoveryState.authorizationServerMetadata,
-      ...(resource ? { resource } : {}),
-      fetchFn,
-    });
+    emitTrace();
+    const tokens = await fetchToken(
+      provider,
+      discoveryState.authorizationServerUrl,
+      {
+        metadata: discoveryState.authorizationServerMetadata,
+        ...(resource ? { resource } : {}),
+        fetchFn,
+      }
+    );
     await provider.saveTokens(tokens);
     completeOAuthTraceStep(trace, "token_request", {
       message: "Refresh token exchange succeeded.",
@@ -2206,7 +2355,7 @@ export async function refreshOAuthTokens(
     completeOAuthTraceStep(trace, "complete", {
       message: "OAuth token refresh completed successfully.",
     });
-    saveOAuthTrace(serverName, trace);
+    emitTrace();
     const serverConfig = createServerConfig(serverUrl, tokens);
     return {
       success: true,
@@ -2238,7 +2387,7 @@ export async function refreshOAuthTokens(
     failOAuthTraceStep(trace, trace.currentStep, errorMessage, {
       message: "OAuth token refresh failed.",
     });
-    saveOAuthTrace(serverName, trace);
+    emitTrace();
 
     return {
       success: false,
@@ -2270,7 +2419,7 @@ export function clearOAuthData(serverName: string): void {
  */
 export function createServerConfig(
   serverUrl: string,
-  tokens?: { access_token?: string | null },
+  tokens?: { access_token?: string | null }
 ): HttpServerConfig {
   // Note: We don't include authProvider in the config because it can't be serialized
   // when sent to the backend via JSON. The backend will use the Authorization header instead.

--- a/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
@@ -3,6 +3,9 @@ import {
   getStepInfo,
   type HttpHistoryEntry,
   type OAuthFlowStep,
+  type OAuthTraceSnapshot,
+  type OAuthTraceStepSnapshot,
+  type OAuthTraceStepStatus,
 } from "@mcpjam/sdk/browser";
 
 export type OAuthTraceSource =
@@ -11,31 +14,13 @@ export type OAuthTraceSource =
   | "refresh"
   | "hosted_callback";
 
-export type OAuthTraceStepStatus = "pending" | "success" | "error";
+export type { OAuthTraceStepStatus };
+export type OAuthTraceStep = OAuthTraceStepSnapshot;
 
-export interface OAuthTraceStep {
-  step: OAuthFlowStep;
-  title: string;
-  status: OAuthTraceStepStatus;
-  message?: string;
-  error?: string;
-  details?: Record<string, unknown>;
-  recovered?: boolean;
-  recoveredAt?: number;
-  recoveryMessage?: string;
-  startedAt: number;
-  completedAt?: number;
-}
-
-export interface OAuthTrace {
-  version: 1;
+export interface OAuthTrace extends OAuthTraceSnapshot {
   source: OAuthTraceSource;
   serverName?: string;
   serverUrl?: string;
-  currentStep: OAuthFlowStep;
-  steps: OAuthTraceStep[];
-  httpHistory: HttpHistoryEntry[];
-  error?: string;
 }
 
 function storageKey(serverName: string): string {
@@ -79,6 +64,24 @@ export function createOAuthTrace(input: {
     currentStep: "idle",
     steps: [],
     httpHistory: [],
+  };
+}
+
+export function buildOAuthTraceFromSnapshot(input: {
+  source: OAuthTraceSource;
+  serverName?: string;
+  serverUrl?: string;
+  snapshot: OAuthTraceSnapshot;
+}): OAuthTrace {
+  return {
+    version: input.snapshot.version,
+    source: input.source,
+    serverName: input.serverName,
+    serverUrl: input.serverUrl,
+    currentStep: input.snapshot.currentStep,
+    steps: input.snapshot.steps,
+    httpHistory: input.snapshot.httpHistory,
+    ...(input.snapshot.error ? { error: input.snapshot.error } : {}),
   };
 }
 

--- a/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
@@ -33,12 +33,184 @@ function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
+function maxDefined(
+  ...values: Array<number | undefined>
+): number | undefined {
+  const defined = values.filter((value): value is number => value != null);
+  if (defined.length === 0) {
+    return undefined;
+  }
+
+  return Math.max(...defined);
+}
+
 function trimHttpHistory(httpHistory: HttpHistoryEntry[]): HttpHistoryEntry[] {
   if (httpHistory.length <= MAX_OAUTH_TRACE_HTTP_HISTORY) {
     return httpHistory;
   }
 
   return httpHistory.slice(-MAX_OAUTH_TRACE_HTTP_HISTORY);
+}
+
+function isNonEmptyString(value: string | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function pickPreferredStepText(input: {
+  existing?: string;
+  incoming?: string;
+  title: string;
+}): string | undefined {
+  const { existing, incoming, title } = input;
+  if (!isNonEmptyString(incoming)) {
+    return existing;
+  }
+  if (!isNonEmptyString(existing)) {
+    return incoming;
+  }
+
+  const existingIsGeneric = existing === title;
+  const incomingIsGeneric = incoming === title;
+
+  if (existingIsGeneric && !incomingIsGeneric) {
+    return incoming;
+  }
+  if (!existingIsGeneric && incomingIsGeneric) {
+    return existing;
+  }
+
+  return incoming;
+}
+
+function mergeStepDetails(
+  existing?: Record<string, unknown>,
+  incoming?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (!existing) {
+    return incoming;
+  }
+  if (!incoming) {
+    return existing;
+  }
+
+  return {
+    ...existing,
+    ...incoming,
+  };
+}
+
+function mergeStepStatus(
+  existing: OAuthTraceStepStatus,
+  incoming: OAuthTraceStepStatus,
+): OAuthTraceStepStatus {
+  if (incoming === "pending" && existing !== "pending") {
+    return existing;
+  }
+
+  return incoming;
+}
+
+function mergeStepEntries(
+  existing: OAuthTraceStepSnapshot,
+  incoming: OAuthTraceStepSnapshot,
+): OAuthTraceStepSnapshot {
+  const title = incoming.title || existing.title;
+  const status = mergeStepStatus(existing.status, incoming.status);
+  const message = pickPreferredStepText({
+    existing: existing.message,
+    incoming: incoming.message,
+    title,
+  });
+  const recoveryMessage = pickPreferredStepText({
+    existing: existing.recoveryMessage,
+    incoming: incoming.recoveryMessage,
+    title,
+  });
+  const completedAt =
+    status === "pending"
+      ? undefined
+      : maxDefined(existing.completedAt, incoming.completedAt);
+  const details = mergeStepDetails(existing.details, incoming.details);
+  const recovered = existing.recovered === true || incoming.recovered === true;
+  const recoveredAt = maxDefined(existing.recoveredAt, incoming.recoveredAt);
+  const error =
+    status === "error" || recovered
+      ? incoming.error ?? existing.error
+      : undefined;
+
+  return {
+    step: incoming.step,
+    title,
+    status,
+    ...(message ? { message } : {}),
+    ...(error ? { error } : {}),
+    ...(details ? { details } : {}),
+    ...(recovered ? { recovered } : {}),
+    ...(recoveredAt ? { recoveredAt } : {}),
+    ...(recoveryMessage ? { recoveryMessage } : {}),
+    startedAt: Math.min(existing.startedAt, incoming.startedAt),
+    ...(completedAt ? { completedAt } : {}),
+  };
+}
+
+function mergeTraceSteps(
+  baseSteps: OAuthTraceStepSnapshot[],
+  nextSteps: OAuthTraceStepSnapshot[],
+): OAuthTraceStepSnapshot[] {
+  const merged = new Map<OAuthFlowStep, OAuthTraceStepSnapshot>();
+
+  [...baseSteps, ...nextSteps].forEach((step) => {
+    const existing = merged.get(step.step);
+    if (!existing) {
+      merged.set(step.step, clone(step));
+      return;
+    }
+
+    merged.set(step.step, mergeStepEntries(existing, step));
+  });
+
+  return Array.from(merged.values()).sort(
+    (left, right) =>
+      left.startedAt - right.startedAt ||
+      getStepIndex(left.step) - getStepIndex(right.step),
+  );
+}
+
+function buildHttpHistoryEntryKey(entry: HttpHistoryEntry): string {
+  return JSON.stringify({
+    step: entry.step,
+    timestamp: entry.timestamp,
+    request: entry.request,
+    response: entry.response,
+    error: entry.error,
+  });
+}
+
+function mergeHttpHistory(
+  baseHttpHistory: HttpHistoryEntry[],
+  nextHttpHistory: HttpHistoryEntry[],
+): HttpHistoryEntry[] {
+  const merged = new Map<string, HttpHistoryEntry>();
+
+  [...baseHttpHistory, ...nextHttpHistory].forEach((entry) => {
+    merged.set(buildHttpHistoryEntryKey(entry), clone(entry));
+  });
+
+  return trimHttpHistory(
+    Array.from(merged.values()).sort(
+      (left, right) => left.timestamp - right.timestamp,
+    ),
+  );
+}
+
+function deriveTraceError(
+  steps: OAuthTraceStepSnapshot[],
+  fallback?: string,
+): string | undefined {
+  const failureStep = [...steps]
+    .reverse()
+    .find((step) => step.status === "error" && !step.recovered);
+  return failureStep?.error ?? fallback;
 }
 
 function buildPersistableTrace(
@@ -267,19 +439,19 @@ export function mergeOAuthTraces(
     return buildPersistableTrace(next);
   }
 
+  const steps = mergeTraceSteps(base.steps, next.steps);
+  const httpHistory = mergeHttpHistory(base.httpHistory, next.httpHistory);
+  const error = deriveTraceError(steps, next.error);
+
   return buildPersistableTrace({
     version: 1,
     source: next.source,
     serverName: next.serverName ?? base.serverName,
     serverUrl: next.serverUrl ?? base.serverUrl,
     currentStep: next.currentStep,
-    steps: [...base.steps, ...next.steps].sort(
-      (left, right) =>
-        left.startedAt - right.startedAt ||
-        getStepIndex(left.step) - getStepIndex(right.step),
-    ),
-    httpHistory: trimHttpHistory([...base.httpHistory, ...next.httpHistory]),
-    error: next.error ?? base.error,
+    steps,
+    httpHistory,
+    ...(error ? { error } : {}),
   });
 }
 

--- a/mcpjam-inspector/client/src/state/__tests__/mcp-api.hosted.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/mcp-api.hosted.test.ts
@@ -33,6 +33,7 @@ import { reconnectServer, testConnection } from "../mcp-api";
 
 describe("mcp-api hosted-mode reconnect hardening", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     validateHostedServerMock.mockReset();
     webPostMock.mockReset();
     buildGuestServerRequestMock.mockReset();
@@ -74,6 +75,21 @@ describe("mcp-api hosted-mode reconnect hardening", () => {
     expect(result).toEqual({
       success: false,
       error: "Boom",
+    });
+  });
+
+  it("times out hung hosted validation requests", async () => {
+    vi.useFakeTimers();
+    validateHostedServerMock.mockReturnValueOnce(new Promise(() => {}));
+
+    const resultPromise = testConnection({} as MCPServerConfig, "server-timeout");
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    await expect(resultPromise).resolves.toEqual({
+      success: false,
+      error:
+        "Connection attempt timed out after 20 seconds. The server may not exist or is not responding.",
     });
   });
 

--- a/mcpjam-inspector/client/src/state/app-reducer.ts
+++ b/mcpjam-inspector/client/src/state/app-reducer.ts
@@ -253,6 +253,37 @@ export function appReducer(state: AppState, action: AppAction): AppState {
       };
     }
 
+    case "SET_SERVER_OAUTH_TRACE": {
+      const activeWorkspace = state.workspaces[state.activeWorkspaceId];
+      const existing =
+        state.servers[action.name] ?? activeWorkspace?.servers[action.name];
+      if (!existing) return state;
+
+      const nextServer = {
+        ...existing,
+        lastOAuthTrace: action.oauthTrace,
+      };
+
+      return {
+        ...state,
+        servers: {
+          ...state.servers,
+          [action.name]: nextServer,
+        },
+        workspaces: {
+          ...state.workspaces,
+          [state.activeWorkspaceId]: {
+            ...activeWorkspace,
+            servers: {
+              ...activeWorkspace.servers,
+              [action.name]: nextServer,
+            },
+            updatedAt: new Date(),
+          },
+        },
+      };
+    }
+
     case "CREATE_WORKSPACE": {
       return {
         ...state,

--- a/mcpjam-inspector/client/src/state/app-types.ts
+++ b/mcpjam-inspector/client/src/state/app-types.ts
@@ -115,6 +115,11 @@ export type AppAction =
       name: string;
       initInfo: InitializationInfo;
     }
+  | {
+      type: "SET_SERVER_OAUTH_TRACE";
+      name: string;
+      oauthTrace?: OAuthTrace;
+    }
   | { type: "CREATE_WORKSPACE"; workspace: Workspace }
   | {
       type: "UPDATE_WORKSPACE";

--- a/mcpjam-inspector/client/src/state/mcp-api.ts
+++ b/mcpjam-inspector/client/src/state/mcp-api.ts
@@ -9,6 +9,8 @@ import {
 import { webPost } from "@/lib/apis/web/base";
 import { buildGuestServerRequest, isGuestMode } from "@/lib/apis/web/context";
 
+const HOSTED_VALIDATE_TIMEOUT_MS = 20_000;
+
 /**
  * Extracts an OAuth access token from an HttpServerConfig's Authorization header.
  * Returns undefined if the config isn't an HTTP config or has no Bearer token.
@@ -59,16 +61,22 @@ async function safeValidateHostedServer(
         serverId,
       );
 
-      return await webPost<typeof request, HostedServerValidateResponse>(
-        "/api/web/servers/validate",
-        request,
+      return await withTimeout(
+        webPost<typeof request, HostedServerValidateResponse>(
+          "/api/web/servers/validate",
+          request,
+        ),
+        HOSTED_VALIDATE_TIMEOUT_MS,
       );
     }
 
-    return await validateHostedServer(
-      serverId,
-      extractOAuthToken(serverConfig),
-      serverConfig.capabilities as Record<string, unknown> | undefined,
+    return await withTimeout(
+      validateHostedServer(
+        serverId,
+        extractOAuthToken(serverConfig),
+        serverConfig.capabilities as Record<string, unknown> | undefined,
+      ),
+      HOSTED_VALIDATE_TIMEOUT_MS,
     );
   } catch (error) {
     return {
@@ -103,6 +111,32 @@ async function authFetchWithTimeout(
     }
     throw error;
   }
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  return await new Promise<T>((resolve, reject) => {
+    const timeoutId = window.setTimeout(() => {
+      reject(
+        new Error(
+          `Connection attempt timed out after ${timeoutMs / 1000} seconds. The server may not exist or is not responding.`,
+        ),
+      );
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        window.clearTimeout(timeoutId);
+        resolve(value);
+      },
+      (error) => {
+        window.clearTimeout(timeoutId);
+        reject(error);
+      },
+    );
+  });
 }
 
 export async function testConnection(

--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -24,6 +24,7 @@ export async function ensureAuthorizedForReconnect(
   server: ServerWithName,
   options?: {
     beforeRedirect?: (oauthOptions: MCPOAuthOptions) => void;
+    onTraceUpdate?: (trace: OAuthTrace) => void;
   },
 ): Promise<OAuthResult> {
   // If server is explicitly configured without OAuth, skip OAuth flow entirely
@@ -45,7 +46,9 @@ export async function ensureAuthorizedForReconnect(
   // If OAuth was configured, try to refresh or re-initiate
   if (server.oauthTokens) {
     // Try refresh first
-    const refreshed = await refreshOAuthTokens(server.name);
+    const refreshed = await refreshOAuthTokens(server.name, {
+      onTraceUpdate: options?.onTraceUpdate,
+    });
     if (refreshed.success && refreshed.serverConfig) {
       return {
         kind: "ready",
@@ -94,6 +97,7 @@ export async function ensureAuthorizedForReconnect(
         server.oauthTokens?.client_secret || clientInfo?.client_secret;
     }
     options?.beforeRedirect?.(opts);
+    opts.onTraceUpdate = options?.onTraceUpdate;
     const init = await initiateOAuth(opts);
     if (init.success && init.serverConfig) {
       return {

--- a/mcpjam-inspector/client/src/state/storage.ts
+++ b/mcpjam-inspector/client/src/state/storage.ts
@@ -5,11 +5,12 @@ import {
   Workspace,
 } from "./app-types";
 import { isWorkspaceClientConfig } from "@/lib/client-config";
+import { loadOAuthTrace } from "@/lib/oauth/oauth-trace";
 
 const STORAGE_KEY = "mcp-inspector-state";
 const WORKSPACES_STORAGE_KEY = "mcp-inspector-workspaces";
 
-function reviveServer(server: any): ServerWithName {
+function reviveServer(name: string, server: any): ServerWithName {
   const cfg: any = server.config;
   let nextCfg = cfg;
   if (cfg && typeof cfg.url === "string") {
@@ -21,7 +22,11 @@ function reviveServer(server: any): ServerWithName {
   }
   return {
     ...server,
+    name: server.name ?? name,
     config: nextCfg,
+    lastOAuthTrace:
+      server.lastOAuthTrace ??
+      (typeof window !== "undefined" ? loadOAuthTrace(server.name ?? name) : undefined),
     connectionStatus: server.connectionStatus || "disconnected",
     retryCount: server.retryCount || 0,
     lastConnectionTime: server.lastConnectionTime
@@ -54,7 +59,7 @@ export function loadAppState(): AppState {
                   : undefined,
                 servers: Object.fromEntries(
                   Object.entries(workspace.servers || {}).map(
-                    ([name, server]) => [name, reviveServer(server)],
+                    ([name, server]) => [name, reviveServer(name, server)],
                   ),
                 ),
                 createdAt: new Date(workspace.createdAt),
@@ -79,7 +84,7 @@ export function loadAppState(): AppState {
           migratedServers = Object.fromEntries(
             Object.entries(parsed.servers || {}).map(([name, server]) => [
               name,
-              reviveServer(server),
+              reviveServer(name, server),
             ]),
           );
         } catch (e) {

--- a/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createWebTestApp,
   expectJson,
@@ -194,5 +194,55 @@ describe("web routes — oauth error contract", () => {
       message: "connect ECONNREFUSED",
       error: "connect ECONNREFUSED",
     });
+  });
+});
+
+describe("web routes — oauth session forwarding", () => {
+  const { app, token } = createWebTestApp();
+
+  beforeEach(() => {
+    vi.stubEnv("CONVEX_HTTP_URL", "https://example.convex.site");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("POST /session forwards the bearer-authenticated session bootstrap to Convex", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(JSON.stringify({ success: true, sessionId: "session-123" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const payload = {
+      workspaceId: "ws_1",
+      serverId: "srv_1",
+      codeVerifier: "verifier",
+      redirectUri: "http://localhost:5173/oauth/callback",
+      clientInformation: {
+        clientId: "client-id",
+      },
+    };
+
+    const response = await postJson(app, "/api/web/oauth/session", payload, token);
+    const { status, data } = await expectJson(response);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({ success: true, sessionId: "session-123" });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.convex.site/web/oauth/session",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      },
+    );
   });
 });

--- a/mcpjam-inspector/server/routes/web/oauth.ts
+++ b/mcpjam-inspector/server/routes/web/oauth.ts
@@ -58,6 +58,19 @@ function toRouteError(error: unknown): WebRouteError {
   return mapRuntimeError(error);
 }
 
+function getConvexHttpUrl(): string {
+  const convexUrl = process.env.CONVEX_HTTP_URL;
+  if (!convexUrl) {
+    throw new WebRouteError(
+      500,
+      ErrorCode.INTERNAL_ERROR,
+      "Server missing CONVEX_HTTP_URL configuration",
+    );
+  }
+
+  return convexUrl;
+}
+
 /**
  * Proxy OAuth token exchange and client registration requests.
  * POST /api/web/oauth/proxy
@@ -108,6 +121,33 @@ oauthWeb.get("/metadata", async (c) => {
     }
 
     return c.json(result.metadata);
+  } catch (error) {
+    return webErrorCompat(c, toRouteError(error));
+  }
+});
+
+oauthWeb.post("/session", async (c) => {
+  try {
+    const convexUrl = getConvexHttpUrl();
+    const authorization = c.req.header("authorization");
+    const payload = await c.req.json();
+    const response = await fetch(`${convexUrl}/web/oauth/session`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(authorization ? { Authorization: authorization } : {}),
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const bodyText = await response.text();
+    return new Response(bodyText, {
+      status: response.status,
+      headers: {
+        "Content-Type":
+          response.headers.get("content-type") ?? "application/json",
+      },
+    });
   } catch (error) {
     return webErrorCompat(c, toRouteError(error));
   }

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -97,6 +97,16 @@ export type {
   OAuthStateMachineRunResult,
 } from "./oauth/state-machines/runner.js";
 export {
+  createOAuthTraceProjectionContext,
+  projectOAuthTraceSnapshot,
+} from "./oauth/state-machines/trace.js";
+export type {
+  OAuthTraceProjectionContext,
+  OAuthTraceSnapshot,
+  OAuthTraceStepSnapshot,
+  OAuthTraceStepStatus,
+} from "./oauth/state-machines/trace.js";
+export {
   getStepInfo,
   getStepIndex,
 } from "./oauth/state-machines/shared/step-metadata.js";

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -196,6 +196,16 @@ export type {
   OAuthStateMachineRunConfig,
   OAuthStateMachineRunResult,
 } from "./oauth/state-machines/runner.js";
+export {
+  createOAuthTraceProjectionContext,
+  projectOAuthTraceSnapshot,
+} from "./oauth/state-machines/trace.js";
+export type {
+  OAuthTraceProjectionContext,
+  OAuthTraceSnapshot,
+  OAuthTraceStepSnapshot,
+  OAuthTraceStepStatus,
+} from "./oauth/state-machines/trace.js";
 
 // EvalAgent interface (for deterministic testing without concrete TestAgent)
 export type { EvalAgent, PromptOptions } from "./EvalAgent.js";

--- a/sdk/src/oauth-login.ts
+++ b/sdk/src/oauth-login.ts
@@ -293,7 +293,8 @@ export async function runOAuthLogin(
     oauthConformanceChecks: false,
   });
   let state = cloneEmptyFlowState();
-  let redirectUrl = config.redirectUrl;
+  let redirectUrl =
+    config.redirectUrl ?? (deps.createDefaultRedirectUrl ?? createDefaultRedirectUrl)();
   let interactiveSession: InteractiveAuthorizationSession | undefined;
 
   const updateState = (updates: Partial<OAuthFlowState>) => {
@@ -313,8 +314,7 @@ export async function runOAuthLogin(
 
     redirectUrl =
       interactiveSession?.redirectUrl ??
-      config.redirectUrl ??
-      (deps.createDefaultRedirectUrl ?? createDefaultRedirectUrl)();
+      redirectUrl;
 
     const trackedRequest: TrackedRequestFn = async (request, options = {}) => {
       const controller = new AbortController();
@@ -358,7 +358,7 @@ export async function runOAuthLogin(
       serverUrl: config.serverUrl,
       serverName: config.serverName,
       redirectUrl,
-      requestExecutor: (request) => trackedRequest(request),
+      requestExecutor: (request: OAuthHttpRequest) => trackedRequest(request),
       loadPreregisteredCredentials: async () => ({
         clientId: config.client.preregistered?.clientId,
         clientSecret: config.client.preregistered?.clientSecret,

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-03-26.ts
@@ -388,6 +388,40 @@ export const createDebugOAuthStateMachine = (
       body: options.body as any,
     });
 
+  const loadFallbackPreregisteredClient = async (note: string) => {
+    const { clientId, clientSecret } =
+      (await loadPreregisteredCredentials?.({
+        serverName,
+        serverUrl,
+      })) ?? {};
+
+    if (!clientId) {
+      return undefined;
+    }
+
+    const preregInfo: Record<string, any> = {
+      "Client ID": clientId,
+      "Client Secret": clientSecret
+        ? "Configured"
+        : "Not provided (public client)",
+      "Token Auth Method": clientSecret ? "client_secret_post" : "none",
+      Note: note,
+    };
+
+    return {
+      clientId,
+      clientSecret: clientSecret || undefined,
+      tokenEndpointAuthMethod: clientSecret ? "client_secret_post" : "none",
+      infoLogs: addInfoLog(
+        getCurrentState(),
+        "received_client_credentials",
+        "preregistered-fallback",
+        "Pre-registered Client",
+        preregInfo,
+      ),
+    };
+  };
+
   const machine: OAuthStateMachine = {
     state: initialState,
     updateState,
@@ -840,11 +874,28 @@ export const createDebugOAuthStateMachine = (
                 return;
               }
 
-              // No registration endpoint - use mock client ID
+              const fallbackClient =
+                await loadFallbackPreregisteredClient(
+                  "Authorization server did not advertise registration_endpoint; using pre-registered client credentials.",
+                );
+
+              if (!fallbackClient) {
+                updateState({
+                  error:
+                    "Authorization server metadata does not include a registration_endpoint. Configure a pre-registered client or use a different registration strategy.",
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
+
               updateState({
-                currentStep: "generate_pkce_parameters",
-                clientId: "mock-client-id-for-demo",
-                tokenEndpointAuthMethod: "none",
+                currentStep: "received_client_credentials",
+                clientId: fallbackClient.clientId,
+                clientSecret: fallbackClient.clientSecret,
+                tokenEndpointAuthMethod:
+                  fallbackClient.tokenEndpointAuthMethod,
+                infoLogs: fallbackClient.infoLogs,
+                error: undefined,
                 isInitiatingAuth: false,
               });
             }
@@ -889,9 +940,7 @@ export const createDebugOAuthStateMachine = (
               }
 
               if (!response.ok) {
-                const registrationError = strictConformance
-                  ? `Dynamic Client Registration failed (${response.status}).`
-                  : `Dynamic Client Registration failed (${response.status}). Using fallback client ID.`;
+                const registrationError = `Dynamic Client Registration failed (${response.status}).`;
 
                 updateState({
                   lastResponse: registrationResponseData,
@@ -903,13 +952,28 @@ export const createDebugOAuthStateMachine = (
                   return;
                 }
 
-                const fallbackClientId = "preregistered-client-id";
+                const fallbackClient =
+                  await loadFallbackPreregisteredClient(
+                    `Dynamic Client Registration failed (${response.status}); using pre-registered client credentials.`,
+                  );
+
+                if (!fallbackClient) {
+                  updateState({
+                    error:
+                      `${registrationError} Configure a pre-registered client or enable DCR on the authorization server.`,
+                    isInitiatingAuth: false,
+                  });
+                  return;
+                }
 
                 updateState({
                   currentStep: "received_client_credentials",
-                  clientId: fallbackClientId,
-                  clientSecret: undefined,
-                  tokenEndpointAuthMethod: "none",
+                  clientId: fallbackClient.clientId,
+                  clientSecret: fallbackClient.clientSecret,
+                  tokenEndpointAuthMethod:
+                    fallbackClient.tokenEndpointAuthMethod,
+                  infoLogs: fallbackClient.infoLogs,
+                  error: undefined,
                   isInitiatingAuth: false,
                 });
               } else {
@@ -985,25 +1049,40 @@ export const createDebugOAuthStateMachine = (
                   Date.now() - (lastEntry.timestamp || Date.now());
               }
 
+              const registrationError = `Client registration failed: ${error instanceof Error ? error.message : String(error)}`;
+
               updateState({
                 lastResponse: errorResponse,
                 httpHistory: updatedHistoryError,
-                error: strictConformance
-                  ? `Client registration failed: ${error instanceof Error ? error.message : String(error)}`
-                  : `Client registration failed: ${error instanceof Error ? error.message : String(error)}. Using fallback.`,
+                error: registrationError,
               });
 
               if (strictConformance) {
                 return;
               }
 
-              const fallbackClientId = "preregistered-client-id";
+              const fallbackClient =
+                await loadFallbackPreregisteredClient(
+                  "Client registration failed; using pre-registered client credentials.",
+                );
+
+              if (!fallbackClient) {
+                updateState({
+                  error:
+                    `${registrationError}. Configure a pre-registered client or enable DCR on the authorization server.`,
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
 
               updateState({
                 currentStep: "received_client_credentials",
-                clientId: fallbackClientId,
-                clientSecret: undefined,
-                tokenEndpointAuthMethod: "none",
+                clientId: fallbackClient.clientId,
+                clientSecret: fallbackClient.clientSecret,
+                tokenEndpointAuthMethod:
+                  fallbackClient.tokenEndpointAuthMethod,
+                infoLogs: fallbackClient.infoLogs,
+                error: undefined,
                 isInitiatingAuth: false,
               });
             }

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -435,6 +435,40 @@ export const createDebugOAuthStateMachine = (
       body: options.body as any,
     });
 
+  const loadFallbackPreregisteredClient = async (note: string) => {
+    const { clientId, clientSecret } =
+      (await loadPreregisteredCredentials?.({
+        serverName,
+        serverUrl,
+      })) ?? {};
+
+    if (!clientId) {
+      return undefined;
+    }
+
+    const preregInfo: Record<string, any> = {
+      "Client ID": clientId,
+      "Client Secret": clientSecret
+        ? "Configured"
+        : "Not provided (public client)",
+      "Token Auth Method": clientSecret ? "client_secret_post" : "none",
+      Note: note,
+    };
+
+    return {
+      clientId,
+      clientSecret: clientSecret || undefined,
+      tokenEndpointAuthMethod: clientSecret ? "client_secret_post" : "none",
+      infoLogs: addInfoLog(
+        getCurrentState(),
+        "received_client_credentials",
+        "preregistered-fallback",
+        "Pre-registered Client",
+        preregInfo,
+      ),
+    };
+  };
+
   // Create machine object that can reference itself
   const machine: OAuthStateMachine = {
     state: initialState,
@@ -1174,11 +1208,28 @@ export const createDebugOAuthStateMachine = (
                 return;
               }
 
-              // No registration endpoint and DCR strategy - skip to PKCE generation with a mock client ID
+              const fallbackClient =
+                await loadFallbackPreregisteredClient(
+                  "Authorization server did not advertise registration_endpoint; using pre-registered client credentials.",
+                );
+
+              if (!fallbackClient) {
+                updateState({
+                  error:
+                    "Authorization server metadata does not include a registration_endpoint. Configure a pre-registered client or use a different registration strategy.",
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
+
               updateState({
-                currentStep: "generate_pkce_parameters",
-                clientId: "mock-client-id-for-demo",
-                tokenEndpointAuthMethod: "none", // Public client
+                currentStep: "received_client_credentials",
+                clientId: fallbackClient.clientId,
+                clientSecret: fallbackClient.clientSecret,
+                tokenEndpointAuthMethod:
+                  fallbackClient.tokenEndpointAuthMethod,
+                infoLogs: fallbackClient.infoLogs,
+                error: undefined,
                 isInitiatingAuth: false,
               });
             }
@@ -1226,9 +1277,7 @@ export const createDebugOAuthStateMachine = (
 
               if (!response.ok) {
                 // Registration failed - could be server doesn't support DCR or request was invalid
-                const registrationError = strictConformance
-                  ? `Dynamic Client Registration failed (${response.status}).`
-                  : `Dynamic Client Registration failed (${response.status}). Using fallback client ID.`;
+                const registrationError = `Dynamic Client Registration failed (${response.status}).`;
 
                 // Update state with error but continue with fallback
                 updateState({
@@ -1241,14 +1290,28 @@ export const createDebugOAuthStateMachine = (
                   return;
                 }
 
-                // Fall back to mock client ID (simulating preregistered client)
-                const fallbackClientId = "preregistered-client-id";
+                const fallbackClient =
+                  await loadFallbackPreregisteredClient(
+                    `Dynamic Client Registration failed (${response.status}); using pre-registered client credentials.`,
+                  );
+
+                if (!fallbackClient) {
+                  updateState({
+                    error:
+                      `${registrationError} Configure a pre-registered client or enable DCR on the authorization server.`,
+                    isInitiatingAuth: false,
+                  });
+                  return;
+                }
 
                 updateState({
                   currentStep: "received_client_credentials",
-                  clientId: fallbackClientId,
-                  clientSecret: undefined,
-                  tokenEndpointAuthMethod: "none", // Assume public client
+                  clientId: fallbackClient.clientId,
+                  clientSecret: fallbackClient.clientSecret,
+                  tokenEndpointAuthMethod:
+                    fallbackClient.tokenEndpointAuthMethod,
+                  infoLogs: fallbackClient.infoLogs,
+                  error: undefined,
                   isInitiatingAuth: false,
                 });
               } else {
@@ -1327,26 +1390,40 @@ export const createDebugOAuthStateMachine = (
                   Date.now() - (lastEntry.timestamp || Date.now());
               }
 
+              const registrationError = `Client registration failed: ${error instanceof Error ? error.message : String(error)}`;
+
               updateState({
                 lastResponse: errorResponse,
                 httpHistory: updatedHistoryError,
-                error: strictConformance
-                  ? `Client registration failed: ${error instanceof Error ? error.message : String(error)}`
-                  : `Client registration failed: ${error instanceof Error ? error.message : String(error)}. Using fallback.`,
+                error: registrationError,
               });
 
               if (strictConformance) {
                 return;
               }
 
-              // Fall back to mock client ID
-              const fallbackClientId = "preregistered-client-id";
+              const fallbackClient =
+                await loadFallbackPreregisteredClient(
+                  "Client registration failed; using pre-registered client credentials.",
+                );
+
+              if (!fallbackClient) {
+                updateState({
+                  error:
+                    `${registrationError}. Configure a pre-registered client or enable DCR on the authorization server.`,
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
 
               updateState({
                 currentStep: "received_client_credentials",
-                clientId: fallbackClientId,
-                clientSecret: undefined,
-                tokenEndpointAuthMethod: "none", // Assume public client
+                clientId: fallbackClient.clientId,
+                clientSecret: fallbackClient.clientSecret,
+                tokenEndpointAuthMethod:
+                  fallbackClient.tokenEndpointAuthMethod,
+                infoLogs: fallbackClient.infoLogs,
+                error: undefined,
                 isInitiatingAuth: false,
               });
             }

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -577,6 +577,40 @@ export const createDebugOAuthStateMachine = (
       body: options.body as any,
     });
 
+  const loadFallbackPreregisteredClient = async (note: string) => {
+    const { clientId, clientSecret } =
+      (await loadPreregisteredCredentials?.({
+        serverName,
+        serverUrl,
+      })) ?? {};
+
+    if (!clientId) {
+      return undefined;
+    }
+
+    const preregInfo: Record<string, any> = {
+      "Client ID": clientId,
+      "Client Secret": clientSecret
+        ? "Configured"
+        : "Not provided (public client)",
+      "Token Auth Method": clientSecret ? "client_secret_post" : "none",
+      Note: note,
+    };
+
+    return {
+      clientId,
+      clientSecret: clientSecret || undefined,
+      tokenEndpointAuthMethod: clientSecret ? "client_secret_post" : "none",
+      infoLogs: addInfoLog(
+        getCurrentState(),
+        "received_client_credentials",
+        "preregistered-fallback",
+        "Pre-registered Client",
+        preregInfo,
+      ),
+    };
+  };
+
   // Create machine object that can reference itself
   const machine: OAuthStateMachine = {
     state: initialState,
@@ -1329,11 +1363,28 @@ export const createDebugOAuthStateMachine = (
                 return;
               }
 
-              // No registration endpoint and DCR strategy - skip to PKCE generation with a mock client ID
+              const fallbackClient =
+                await loadFallbackPreregisteredClient(
+                  "Authorization server did not advertise registration_endpoint; using pre-registered client credentials.",
+                );
+
+              if (!fallbackClient) {
+                updateState({
+                  error:
+                    "Authorization server metadata does not include a registration_endpoint. Configure a pre-registered client or use a different registration strategy.",
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
+
               updateState({
-                currentStep: "generate_pkce_parameters",
-                clientId: "mock-client-id-for-demo",
-                tokenEndpointAuthMethod: "none", // Public client
+                currentStep: "received_client_credentials",
+                clientId: fallbackClient.clientId,
+                clientSecret: fallbackClient.clientSecret,
+                tokenEndpointAuthMethod:
+                  fallbackClient.tokenEndpointAuthMethod,
+                infoLogs: fallbackClient.infoLogs,
+                error: undefined,
                 isInitiatingAuth: false,
               });
             }
@@ -1381,9 +1432,7 @@ export const createDebugOAuthStateMachine = (
 
               if (!response.ok) {
                 // Registration failed - could be server doesn't support DCR or request was invalid
-                const registrationError = strictConformance
-                  ? `Dynamic Client Registration failed (${response.status}).`
-                  : `Dynamic Client Registration failed (${response.status}). Using fallback client ID.`;
+                const registrationError = `Dynamic Client Registration failed (${response.status}).`;
 
                 // Update state with error but continue with fallback
                 updateState({
@@ -1397,14 +1446,28 @@ export const createDebugOAuthStateMachine = (
                   return;
                 }
 
-                // Fall back to mock client ID (simulating preregistered client)
-                const fallbackClientId = "preregistered-client-id";
+                const fallbackClient =
+                  await loadFallbackPreregisteredClient(
+                    `Dynamic Client Registration failed (${response.status}); using pre-registered client credentials.`,
+                  );
+
+                if (!fallbackClient) {
+                  updateState({
+                    error:
+                      `${registrationError} Configure a pre-registered client or enable DCR on the authorization server.`,
+                    isInitiatingAuth: false,
+                  });
+                  return;
+                }
 
                 updateState({
                   currentStep: "received_client_credentials",
-                  clientId: fallbackClientId,
-                  clientSecret: undefined,
-                  tokenEndpointAuthMethod: "none", // Assume public client
+                  clientId: fallbackClient.clientId,
+                  clientSecret: fallbackClient.clientSecret,
+                  tokenEndpointAuthMethod:
+                    fallbackClient.tokenEndpointAuthMethod,
+                  infoLogs: fallbackClient.infoLogs,
+                  error: undefined,
                   isInitiatingAuth: false,
                 });
               } else {
@@ -1483,9 +1546,7 @@ export const createDebugOAuthStateMachine = (
                   Date.now() - (lastEntry.timestamp || Date.now());
               }
 
-              const registrationError = strictConformance
-                ? `Client registration failed: ${error instanceof Error ? error.message : String(error)}`
-                : `Client registration failed: ${error instanceof Error ? error.message : String(error)}. Using fallback.`;
+              const registrationError = `Client registration failed: ${error instanceof Error ? error.message : String(error)}`;
 
               updateState({
                 lastResponse: errorResponse,
@@ -1498,14 +1559,28 @@ export const createDebugOAuthStateMachine = (
                 return;
               }
 
-              // Fall back to mock client ID
-              const fallbackClientId = "preregistered-client-id";
+              const fallbackClient =
+                await loadFallbackPreregisteredClient(
+                  "Client registration failed; using pre-registered client credentials.",
+                );
+
+              if (!fallbackClient) {
+                updateState({
+                  error:
+                    `${registrationError}. Configure a pre-registered client or enable DCR on the authorization server.`,
+                  isInitiatingAuth: false,
+                });
+                return;
+              }
 
               updateState({
                 currentStep: "received_client_credentials",
-                clientId: fallbackClientId,
-                clientSecret: undefined,
-                tokenEndpointAuthMethod: "none", // Assume public client
+                clientId: fallbackClient.clientId,
+                clientSecret: fallbackClient.clientSecret,
+                tokenEndpointAuthMethod:
+                  fallbackClient.tokenEndpointAuthMethod,
+                infoLogs: fallbackClient.infoLogs,
+                error: undefined,
                 isInitiatingAuth: false,
               });
             }

--- a/sdk/src/oauth/state-machines/runner.ts
+++ b/sdk/src/oauth/state-machines/runner.ts
@@ -4,6 +4,12 @@ import type {
   OAuthFlowState,
 } from "./types.js";
 import type { OAuthStateMachineFactoryConfig } from "./factory.js";
+import {
+  createOAuthTraceProjectionContext,
+  projectOAuthTraceSnapshot,
+  type OAuthTraceProjectionContext,
+  type OAuthTraceSnapshot,
+} from "./trace.js";
 
 export type OAuthAuthorizationRequestResult =
   | {
@@ -21,6 +27,11 @@ export interface OAuthStateMachineRunConfig
     authorizationUrl: string;
     state: OAuthFlowState;
   }) => MaybePromise<OAuthAuthorizationRequestResult>;
+  onTraceUpdate?: (input: {
+    trace: OAuthTraceSnapshot;
+    state: OAuthFlowState;
+    reason: "state_update" | "redirect" | "error" | "complete";
+  }) => void;
 }
 
 export interface OAuthStateMachineRunResult {
@@ -45,16 +56,33 @@ export async function runOAuthStateMachine(
   const {
     maxSteps = 40,
     onAuthorizationRequest,
+    onTraceUpdate,
     getState: providedGetState,
     ...machineConfig
   } = config;
 
   let localState = config.state;
+  const traceProjectionContext = createOAuthTraceProjectionContext();
+  const getState = providedGetState ?? (() => localState);
+  const emitTrace = (
+    reason: "state_update" | "redirect" | "error" | "complete",
+    state = getState(),
+    context: OAuthTraceProjectionContext = traceProjectionContext,
+  ) => {
+    onTraceUpdate?.({
+      trace: projectOAuthTraceSnapshot({
+        state,
+        context,
+      }),
+      state,
+      reason,
+    });
+  };
   const updateState = (updates: Partial<OAuthFlowState>) => {
     localState = { ...localState, ...updates };
     config.updateState(updates);
+    emitTrace("state_update", localState);
   };
-  const getState = providedGetState ?? (() => localState);
   const machine = createOAuthStateMachine({
     ...machineConfig,
     getState,
@@ -68,6 +96,9 @@ export async function runOAuthStateMachine(
 
     if (currentState.currentStep === "authorization_request") {
       if (!currentState.authorizationUrl) {
+        updateState({
+          error: "Authorization URL was not generated.",
+        });
         return {
           completed: false,
           redirected: false,
@@ -79,6 +110,9 @@ export async function runOAuthStateMachine(
       }
 
       if (!onAuthorizationRequest) {
+        updateState({
+          error: "Authorization request requires an authorization handler.",
+        });
         return {
           completed: false,
           redirected: false,
@@ -97,6 +131,7 @@ export async function runOAuthStateMachine(
         });
 
         if (authorizationResult.type === "redirect") {
+          emitTrace("redirect");
           return {
             completed: false,
             redirected: true,
@@ -112,6 +147,9 @@ export async function runOAuthStateMachine(
         });
         continue;
       } catch (error) {
+        updateState({
+          error: normalizeError(error).message,
+        });
         return {
           completed: false,
           redirected: false,
@@ -127,6 +165,13 @@ export async function runOAuthStateMachine(
     try {
       await machine.proceedToNextStep();
     } catch (error) {
+      if (!getState().error) {
+        updateState({
+          error: normalizeError(error).message,
+        });
+      } else {
+        emitTrace("error");
+      }
       return {
         completed: false,
         redirected: false,
@@ -137,12 +182,20 @@ export async function runOAuthStateMachine(
 
     const nextState = getState();
     if (nextState.currentStep === startingStep) {
+      if (!nextState.error) {
+        updateState({
+          error: `Step ${startingStep} did not advance.`,
+        });
+      } else {
+        emitTrace("error", nextState);
+      }
       return {
         completed: false,
         redirected: false,
-        state: nextState,
+        state: getState(),
         error: {
-          message: nextState.error || `Step ${startingStep} did not advance.`,
+          message:
+            getState().error || `Step ${startingStep} did not advance.`,
         },
       };
     }
@@ -150,16 +203,20 @@ export async function runOAuthStateMachine(
 
   const finalState = getState();
   if (guard >= maxSteps && finalState.currentStep !== "complete") {
+    updateState({
+      error: "OAuth login exceeded its step guard.",
+    });
     return {
       completed: false,
       redirected: false,
-      state: finalState,
+      state: getState(),
       error: {
         message: "OAuth login exceeded its step guard.",
       },
     };
   }
 
+  emitTrace(finalState.currentStep === "complete" ? "complete" : "state_update");
   return {
     completed: finalState.currentStep === "complete",
     redirected: false,

--- a/sdk/src/oauth/state-machines/trace.ts
+++ b/sdk/src/oauth/state-machines/trace.ts
@@ -1,0 +1,542 @@
+import {
+  getStepIndex,
+  getStepInfo,
+} from "./shared/step-metadata.js";
+import type {
+  HttpHistoryEntry,
+  OAuthFlowState,
+  OAuthFlowStep,
+} from "./types.js";
+
+export type OAuthTraceStepStatus = "pending" | "success" | "error";
+
+export interface OAuthTraceStepSnapshot {
+  step: OAuthFlowStep;
+  title: string;
+  status: OAuthTraceStepStatus;
+  message?: string;
+  error?: string;
+  details?: Record<string, unknown>;
+  recovered?: boolean;
+  recoveredAt?: number;
+  recoveryMessage?: string;
+  startedAt: number;
+  completedAt?: number;
+}
+
+export interface OAuthTraceSnapshot {
+  version: 1;
+  currentStep: OAuthFlowStep;
+  steps: OAuthTraceStepSnapshot[];
+  httpHistory: HttpHistoryEntry[];
+  error?: string;
+}
+
+export interface OAuthTraceProjectionContext {
+  syntheticStepTimestamps: Partial<Record<OAuthFlowStep, number>>;
+  lastSyntheticTimestamp: number;
+}
+
+type OAuthTraceEntryDraft = {
+  step: OAuthFlowStep;
+  startedAt: number;
+  completedAt?: number;
+  message?: string;
+  details?: Record<string, unknown>;
+  error?: string;
+};
+
+type OAuthRequestFields = Record<string, string>;
+
+const SENSITIVE_FIELD_NAMES = new Set([
+  "access_token",
+  "refresh_token",
+  "id_token",
+  "client_secret",
+  "code",
+  "code_verifier",
+  "authorization_code",
+  "authorization",
+  "cookie",
+  "set_cookie",
+  "api_key",
+]);
+
+const SENSITIVE_HEADER_PATTERNS = [
+  /^authorization$/i,
+  /^proxy-authorization$/i,
+  /^cookie$/i,
+  /^set-cookie$/i,
+  /^x-api-key$/i,
+  /^api-key$/i,
+  /^apikey$/i,
+  /^x-auth-token$/i,
+  /^x-csrf-token$/i,
+  /^x-session-token$/i,
+  /^x-access-token$/i,
+  /^x-refresh-token$/i,
+  /^x-client-secret$/i,
+  /^x-credential$/i,
+];
+
+function normalizeSensitiveKey(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .toLowerCase();
+}
+
+function isSensitiveTraceFieldName(key: string): boolean {
+  return SENSITIVE_FIELD_NAMES.has(normalizeSensitiveKey(key));
+}
+
+function isSensitiveHeaderName(key: string): boolean {
+  const normalized = normalizeSensitiveKey(key);
+  return (
+    SENSITIVE_FIELD_NAMES.has(normalized) ||
+    SENSITIVE_HEADER_PATTERNS.some((pattern) => pattern.test(key)) ||
+    /(^|_)(token|secret|password|credential|cookie|auth)(_|$)/.test(
+      normalized,
+    ) ||
+    /(^|_)api_?key(_|$)/.test(normalized)
+  );
+}
+
+function isSensitiveQueryParamName(key: string): boolean {
+  const normalized = normalizeSensitiveKey(key);
+  return (
+    SENSITIVE_FIELD_NAMES.has(normalized) ||
+    /(^|_)(token|secret|password|credential|cookie|auth)(_|$)/.test(
+      normalized,
+    ) ||
+    /(^|_)api_?key(_|$)/.test(normalized)
+  );
+}
+
+function redactSensitiveValue(value: unknown): string {
+  if (typeof value !== "string") {
+    return "[redacted]";
+  }
+
+  if (value.length <= 8) {
+    return "[redacted]";
+  }
+
+  return `${value.slice(0, 4)}...[redacted]...${value.slice(-2)}`;
+}
+
+function parseOAuthRequestFields(
+  body: unknown,
+): OAuthRequestFields | undefined {
+  if (!body) return undefined;
+
+  if (typeof body === "string") {
+    const trimmed = body.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+
+    if (
+      (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+      (trimmed.startsWith("[") && trimmed.endsWith("]"))
+    ) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (
+          typeof parsed === "object" &&
+          parsed !== null &&
+          !Array.isArray(parsed)
+        ) {
+          const entries = Object.entries(parsed).flatMap(([key, value]) => {
+            if (typeof value === "string") {
+              return [[key, value] as const];
+            }
+            if (typeof value === "number" || typeof value === "boolean") {
+              return [[key, String(value)] as const];
+            }
+            return [];
+          });
+          return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+        }
+      } catch {
+        // Fall through to URLSearchParams parsing.
+      }
+    }
+
+    const params = new URLSearchParams(trimmed);
+    const entries = Object.fromEntries(params.entries());
+    return Object.keys(entries).length > 0 ? entries : undefined;
+  }
+
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return undefined;
+  }
+
+  const entries = Object.entries(body).flatMap(([key, value]) => {
+    if (typeof value === "string") {
+      return [[key, value] as const];
+    }
+    if (typeof value === "number" || typeof value === "boolean") {
+      return [[key, String(value)] as const];
+    }
+    return [];
+  });
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+function sanitizeOAuthUrl(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl);
+    for (const key of [...url.searchParams.keys()]) {
+      if (isSensitiveQueryParamName(key)) {
+        url.searchParams.set(key, "[redacted]");
+      }
+    }
+    if (url.hash) {
+      url.hash = "#[redacted]";
+    }
+    return url.toString();
+  } catch {
+    return rawUrl.replace(
+      /\bBearer\s+[A-Za-z0-9._~+/=-]+\b/gi,
+      "Bearer [redacted]",
+    );
+  }
+}
+
+function sanitizeOAuthTraceString(value: string): unknown {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return value;
+  }
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return sanitizeOAuthUrl(trimmed);
+  }
+
+  const looksStructured =
+    trimmed.includes("=") ||
+    trimmed.includes("&") ||
+    ((trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+      (trimmed.startsWith("[") && trimmed.endsWith("]")));
+  if (looksStructured) {
+    const parsed = parseOAuthRequestFields(trimmed);
+    if (parsed) {
+      return sanitizeOAuthTraceValue(parsed);
+    }
+  }
+
+  return trimmed
+    .replace(
+      /\b(access_token|refresh_token|id_token|client_secret|code_verifier)\b(\s*[:=]\s*)([^\s&,;]+)/gi,
+      (_match, key: string, separator: string) =>
+        `${key}${separator}[redacted]`,
+    )
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+\b/gi, "Bearer [redacted]");
+}
+
+function sanitizeOAuthTraceValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeOAuthTraceValue(item));
+  }
+
+  if (typeof value === "string") {
+    return sanitizeOAuthTraceString(value);
+  }
+
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entryValue]) => {
+      if (isSensitiveTraceFieldName(key)) {
+        return [key, redactSensitiveValue(entryValue)];
+      }
+      return [key, sanitizeOAuthTraceValue(entryValue)];
+    }),
+  );
+}
+
+function sanitizeOAuthHeaderValue(value: string): string {
+  const sanitized = sanitizeOAuthTraceString(value);
+  if (typeof sanitized === "string") {
+    return sanitized;
+  }
+  return redactSensitiveValue(value);
+}
+
+function sanitizeOAuthHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => {
+      if (isSensitiveHeaderName(key)) {
+        return [key, redactSensitiveValue(value)];
+      }
+      return [key, sanitizeOAuthHeaderValue(value)];
+    }),
+  );
+}
+
+function sanitizeHttpHistoryEntry(entry: HttpHistoryEntry): HttpHistoryEntry {
+  return {
+    ...entry,
+    request: {
+      ...entry.request,
+      headers: sanitizeOAuthHeaders(entry.request.headers),
+      body: sanitizeOAuthTraceValue(entry.request.body),
+    },
+    ...(entry.response
+      ? {
+          response: {
+            ...entry.response,
+            headers: sanitizeOAuthHeaders(entry.response.headers),
+            body: sanitizeOAuthTraceValue(entry.response.body),
+          },
+        }
+      : {}),
+    ...(entry.error
+      ? {
+          error: {
+            ...entry.error,
+            details: sanitizeOAuthTraceValue(entry.error.details),
+          },
+        }
+      : {}),
+  };
+}
+
+export function createOAuthTraceProjectionContext(): OAuthTraceProjectionContext {
+  return {
+    syntheticStepTimestamps: {},
+    lastSyntheticTimestamp: 0,
+  };
+}
+
+function readStableStepTimestamp(
+  context: OAuthTraceProjectionContext | undefined,
+  step: OAuthFlowStep,
+  fallback: number,
+): number {
+  if (!context) {
+    return fallback;
+  }
+
+  const existing = context.syntheticStepTimestamps[step];
+  if (typeof existing === "number") {
+    return existing;
+  }
+
+  return fallback;
+}
+
+function ensureStepEntry(
+  entries: Map<OAuthFlowStep, OAuthTraceEntryDraft>,
+  context: OAuthTraceProjectionContext | undefined,
+  step: OAuthFlowStep,
+  timestamp: number,
+): OAuthTraceEntryDraft {
+  const stableTimestamp = readStableStepTimestamp(context, step, timestamp);
+  const existing = entries.get(step);
+  if (existing) {
+    existing.startedAt = Math.min(existing.startedAt, stableTimestamp);
+    existing.completedAt = Math.max(
+      existing.completedAt ?? stableTimestamp,
+      timestamp,
+    );
+    return existing;
+  }
+
+  const created: OAuthTraceEntryDraft = {
+    step,
+    startedAt: stableTimestamp,
+    completedAt: timestamp,
+  };
+  entries.set(step, created);
+  return created;
+}
+
+function inferStepEntry(
+  entries: Map<OAuthFlowStep, OAuthTraceEntryDraft>,
+  context: OAuthTraceProjectionContext | undefined,
+  step: OAuthFlowStep,
+  condition: boolean,
+  details?: Record<string, unknown>,
+): void {
+  if (!condition || entries.has(step)) {
+    return;
+  }
+
+  let timestamp = Date.now();
+  if (context) {
+    timestamp = Math.max(timestamp, context.lastSyntheticTimestamp + 1);
+    context.syntheticStepTimestamps[step] = timestamp;
+    context.lastSyntheticTimestamp = timestamp;
+  }
+
+  entries.set(step, {
+    step,
+    startedAt: timestamp,
+    completedAt: timestamp,
+    details:
+      details == null
+        ? undefined
+        : (sanitizeOAuthTraceValue(details) as Record<string, unknown>),
+  });
+}
+
+function didCurrentStepReachSuccess(
+  entryStep: OAuthFlowStep,
+  state: OAuthFlowState,
+): boolean {
+  if (entryStep !== state.currentStep) {
+    return false;
+  }
+
+  switch (entryStep) {
+    case "authorization_request":
+      return Boolean(state.authorizationUrl);
+    case "received_authorization_code":
+      return Boolean(state.authorizationCode);
+    case "received_access_token":
+      return Boolean(state.accessToken);
+    case "complete":
+      return state.currentStep === "complete";
+    default:
+      return false;
+  }
+}
+
+export function projectOAuthTraceSnapshot(input: {
+  state: OAuthFlowState;
+  context?: OAuthTraceProjectionContext;
+}): OAuthTraceSnapshot {
+  const { state, context } = input;
+  const trace: OAuthTraceSnapshot = {
+    version: 1,
+    currentStep: state.currentStep,
+    steps: [],
+    httpHistory: (state.httpHistory ?? []).map((entry) =>
+      sanitizeHttpHistoryEntry(entry),
+    ),
+    ...(state.error ? { error: state.error } : {}),
+  };
+
+  const currentStepIndex = getStepIndex(state.currentStep);
+  const entries = new Map<OAuthFlowStep, OAuthTraceEntryDraft>();
+
+  for (const entry of state.httpHistory ?? []) {
+    const record = ensureStepEntry(entries, context, entry.step, entry.timestamp);
+    if (!record.details) {
+      record.details = {
+        request: sanitizeOAuthTraceValue(entry.request),
+        ...(entry.response
+          ? { response: sanitizeOAuthTraceValue(entry.response) }
+          : {}),
+      };
+    }
+    if (entry.error?.message) {
+      record.error = entry.error.message;
+    }
+  }
+
+  for (const log of state.infoLogs ?? []) {
+    const record = ensureStepEntry(entries, context, log.step, log.timestamp);
+    record.message = log.label;
+    const sanitizedLogData = sanitizeOAuthTraceValue(log.data);
+    if (
+      sanitizedLogData &&
+      typeof sanitizedLogData === "object" &&
+      sanitizedLogData !== null &&
+      !Array.isArray(sanitizedLogData)
+    ) {
+      record.details = sanitizedLogData as Record<string, unknown>;
+    }
+    if (log.error?.message) {
+      record.error = log.error.message;
+    }
+  }
+
+  const baseTimestamp = Math.max(
+    Date.now(),
+    ...(state.httpHistory ?? []).map((entry) => entry.timestamp),
+    ...(state.infoLogs ?? []).map((entry) => entry.timestamp),
+    context?.lastSyntheticTimestamp ?? 0,
+  );
+  if (context) {
+    context.lastSyntheticTimestamp = Math.max(
+      context.lastSyntheticTimestamp,
+      baseTimestamp,
+    );
+  }
+
+  inferStepEntry(entries, context, "request_client_registration", Boolean(state.clientId), {
+    clientId: state.clientId,
+  });
+  inferStepEntry(entries, context, "received_client_credentials", Boolean(state.clientId), {
+    clientId: state.clientId,
+  });
+  inferStepEntry(entries, context, "generate_pkce_parameters", Boolean(state.codeVerifier), {
+    codeVerifier: redactSensitiveValue(state.codeVerifier),
+  });
+  inferStepEntry(entries, context, "authorization_request", Boolean(state.authorizationUrl), {
+    authorizationUrl: state.authorizationUrl,
+  });
+  inferStepEntry(
+    entries,
+    context,
+    "received_authorization_code",
+    Boolean(state.authorizationCode),
+    state.authorizationCode
+      ? { code: redactSensitiveValue(state.authorizationCode) }
+      : undefined,
+  );
+  inferStepEntry(entries, context, "received_access_token", Boolean(state.accessToken), {
+    tokenType: state.tokenType,
+    expiresIn: state.expiresIn,
+  });
+  inferStepEntry(entries, context, "complete", state.currentStep === "complete");
+
+  if (state.error && !entries.has(state.currentStep)) {
+    inferStepEntry(entries, context, state.currentStep, true);
+    const currentEntry = entries.get(state.currentStep);
+    if (currentEntry) {
+      currentEntry.error = state.error;
+    }
+  }
+
+  trace.steps = Array.from(entries.values())
+    .sort(
+      (left, right) =>
+        left.startedAt - right.startedAt ||
+        getStepIndex(left.step) - getStepIndex(right.step),
+    )
+    .map((entry) => {
+      const stepIndex = getStepIndex(entry.step);
+      const status =
+        entry.error || (entry.step === state.currentStep && state.error)
+          ? "error"
+          : stepIndex < currentStepIndex ||
+              state.currentStep === "complete" ||
+              didCurrentStepReachSuccess(entry.step, state)
+            ? "success"
+            : entry.step === state.currentStep
+              ? "pending"
+              : "success";
+
+      return {
+        step: entry.step,
+        title: getStepInfo(entry.step).title,
+        status,
+        message: entry.message ?? getStepInfo(entry.step).summary,
+        ...(entry.error ? { error: entry.error } : {}),
+        ...(entry.details ? { details: entry.details } : {}),
+        startedAt: entry.startedAt,
+        completedAt: status === "pending" ? undefined : entry.completedAt,
+      } satisfies OAuthTraceStepSnapshot;
+    });
+
+  return trace;
+}

--- a/sdk/src/oauth/state-machines/trace.ts
+++ b/sdk/src/oauth/state-machines/trace.ts
@@ -44,6 +44,9 @@ type OAuthTraceEntryDraft = {
   message?: string;
   details?: Record<string, unknown>;
   error?: string;
+  recovered?: boolean;
+  recoveredAt?: number;
+  recoveryMessage?: string;
 };
 
 type OAuthRequestFields = Record<string, string>;
@@ -308,6 +311,17 @@ function sanitizeHttpHistoryEntry(entry: HttpHistoryEntry): HttpHistoryEntry {
   };
 }
 
+function maxDefined(
+  ...values: Array<number | undefined>
+): number | undefined {
+  const defined = values.filter((value): value is number => value != null);
+  if (defined.length === 0) {
+    return undefined;
+  }
+
+  return Math.max(...defined);
+}
+
 export function createOAuthTraceProjectionContext(): OAuthTraceProjectionContext {
   return {
     syntheticStepTimestamps: {},
@@ -409,6 +423,88 @@ function didCurrentStepReachSuccess(
   }
 }
 
+function extractResponseErrorMessage(
+  response: HttpHistoryEntry["response"],
+): string | undefined {
+  if (!response || response.status < 400) {
+    return undefined;
+  }
+
+  const body = response.body;
+  if (body && typeof body === "object" && !Array.isArray(body)) {
+    const data = body as Record<string, unknown>;
+    const errorType =
+      typeof data.error_type === "string" ? data.error_type : undefined;
+    const errorMessage =
+      typeof data.error_message === "string"
+        ? data.error_message
+        : typeof data.error_description === "string"
+          ? data.error_description
+          : typeof data.message === "string"
+            ? data.message
+            : undefined;
+    if (errorType && errorMessage) {
+      return `${errorType}: ${errorMessage}`;
+    }
+
+    if (
+      typeof data.error === "string" &&
+      typeof data.error_description === "string"
+    ) {
+      return `${data.error}: ${data.error_description}`;
+    }
+
+    if (typeof data.error === "string") {
+      return data.error;
+    }
+
+    const nestedError = data.error;
+    if (
+      nestedError &&
+      typeof nestedError === "object" &&
+      !Array.isArray(nestedError) &&
+      typeof (nestedError as Record<string, unknown>).message === "string"
+    ) {
+      return (nestedError as Record<string, unknown>).message as string;
+    }
+
+    if (errorMessage) {
+      return errorMessage;
+    }
+  }
+
+  return `HTTP ${response.status} ${response.statusText}`;
+}
+
+function inferHttpHistoryEntryError(entry: HttpHistoryEntry): string | undefined {
+  if (entry.error?.message) {
+    return entry.error.message;
+  }
+
+  if (entry.step === "request_client_registration") {
+    return extractResponseErrorMessage(entry.response);
+  }
+
+  return undefined;
+}
+
+function usesRecoveredDynamicClientRegistrationFallback(
+  state: OAuthFlowState,
+): boolean {
+  if (!state.error || !state.clientId) {
+    return false;
+  }
+
+  if (getStepIndex(state.currentStep) <= getStepIndex("request_client_registration")) {
+    return false;
+  }
+
+  return (
+    state.error.startsWith("Dynamic Client Registration failed") ||
+    state.error.startsWith("Client registration failed:")
+  );
+}
+
 export function projectOAuthTraceSnapshot(input: {
   state: OAuthFlowState;
   context?: OAuthTraceProjectionContext;
@@ -437,8 +533,9 @@ export function projectOAuthTraceSnapshot(input: {
           : {}),
       };
     }
-    if (entry.error?.message) {
-      record.error = entry.error.message;
+    const entryError = inferHttpHistoryEntryError(entry);
+    if (entryError) {
+      record.error = entryError;
     }
   }
 
@@ -499,7 +596,27 @@ export function projectOAuthTraceSnapshot(input: {
   });
   inferStepEntry(entries, context, "complete", state.currentStep === "complete");
 
-  if (state.error && !entries.has(state.currentStep)) {
+  const registrationEntry = entries.get("request_client_registration");
+  if (
+    registrationEntry?.error &&
+    getStepIndex(state.currentStep) > getStepIndex("request_client_registration") &&
+    Boolean(state.clientId)
+  ) {
+    registrationEntry.recovered = true;
+    registrationEntry.recoveredAt = maxDefined(
+      registrationEntry.recoveredAt,
+      registrationEntry.completedAt,
+      entries.get("received_client_credentials")?.startedAt,
+    );
+    registrationEntry.recoveryMessage =
+      "Using pre-registered client credentials after registration failed.";
+  }
+
+  if (
+    state.error &&
+    !usesRecoveredDynamicClientRegistrationFallback(state) &&
+    !entries.has(state.currentStep)
+  ) {
     inferStepEntry(entries, context, state.currentStep, true);
     const currentEntry = entries.get(state.currentStep);
     if (currentEntry) {
@@ -515,8 +632,15 @@ export function projectOAuthTraceSnapshot(input: {
     )
     .map((entry) => {
       const stepIndex = getStepIndex(entry.step);
+      const usesStateError =
+        entry.step === state.currentStep &&
+        Boolean(state.error) &&
+        !usesRecoveredDynamicClientRegistrationFallback(state);
+      const error = entry.error ?? (usesStateError ? state.error : undefined);
       const status =
-        entry.error || (entry.step === state.currentStep && state.error)
+        entry.recovered
+          ? "success"
+          : error
           ? "error"
           : stepIndex < currentStepIndex ||
               state.currentStep === "complete" ||
@@ -531,8 +655,11 @@ export function projectOAuthTraceSnapshot(input: {
         title: getStepInfo(entry.step).title,
         status,
         message: entry.message ?? getStepInfo(entry.step).summary,
-        ...(entry.error ? { error: entry.error } : {}),
+        ...(error ? { error } : {}),
         ...(entry.details ? { details: entry.details } : {}),
+        ...(entry.recovered ? { recovered: true } : {}),
+        ...(entry.recoveredAt ? { recoveredAt: entry.recoveredAt } : {}),
+        ...(entry.recoveryMessage ? { recoveryMessage: entry.recoveryMessage } : {}),
         startedAt: entry.startedAt,
         completedAt: status === "pending" ? undefined : entry.completedAt,
       } satisfies OAuthTraceStepSnapshot;

--- a/sdk/tests/oauth/state-machine-regressions.test.ts
+++ b/sdk/tests/oauth/state-machine-regressions.test.ts
@@ -173,4 +173,139 @@ describe("OAuth state machine regressions", () => {
     expect(state.error).toBe("Client registration failed: boom");
     expect(state.isInitiatingAuth).toBe(false);
   });
+
+  it("does not continue to authorization with a fake client id when DCR fails without preregistered credentials", async () => {
+    let state = {
+      ...EMPTY_OAUTH_FLOW_STATE,
+      currentStep: "request_client_registration" as const,
+      authorizationServerMetadata: {
+        registration_endpoint: REGISTRATION_ENDPOINT,
+      },
+      lastRequest: {
+        method: "POST",
+        url: REGISTRATION_ENDPOINT,
+        headers: {},
+        body: { client_name: "Test Client" },
+      },
+      httpHistory: [
+        {
+          step: "request_client_registration" as const,
+          timestamp: Date.now(),
+          request: {
+            method: "POST",
+            url: REGISTRATION_ENDPOINT,
+            headers: {},
+            body: { client_name: "Test Client" },
+          },
+        },
+      ],
+      infoLogs: [],
+      isInitiatingAuth: true,
+    };
+
+    const machine = createOAuthStateMachine({
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "dcr",
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_URL,
+      serverName: "Test Server",
+      redirectUrl: REDIRECT_URI,
+      requestExecutor: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        body: {
+          error_type: "dynamic_client_registration_not_enabled",
+          error_message: "DCR is disabled",
+        },
+      }),
+      dynamicRegistration: {
+        client_name: "Test Client",
+      },
+      loadPreregisteredCredentials: jest.fn().mockResolvedValue({}),
+    });
+
+    await machine.proceedToNextStep();
+
+    expect(state.currentStep).toBe("request_client_registration");
+    expect(state.clientId).toBeUndefined();
+    expect(state.error).toBe(
+      "Dynamic Client Registration failed (400). Configure a pre-registered client or enable DCR on the authorization server.",
+    );
+    expect(state.isInitiatingAuth).toBe(false);
+  });
+
+  it("falls back to configured preregistered credentials when DCR fails in 2025-11-25", async () => {
+    let state = {
+      ...EMPTY_OAUTH_FLOW_STATE,
+      currentStep: "request_client_registration" as const,
+      authorizationServerMetadata: {
+        registration_endpoint: REGISTRATION_ENDPOINT,
+      },
+      lastRequest: {
+        method: "POST",
+        url: REGISTRATION_ENDPOINT,
+        headers: {},
+        body: { client_name: "Test Client" },
+      },
+      httpHistory: [
+        {
+          step: "request_client_registration" as const,
+          timestamp: Date.now(),
+          request: {
+            method: "POST",
+            url: REGISTRATION_ENDPOINT,
+            headers: {},
+            body: { client_name: "Test Client" },
+          },
+        },
+      ],
+      infoLogs: [],
+      isInitiatingAuth: true,
+    };
+
+    const machine = createOAuthStateMachine({
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "dcr",
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_URL,
+      serverName: "Test Server",
+      redirectUrl: REDIRECT_URI,
+      requestExecutor: jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+        headers: {},
+        body: {
+          error_type: "dynamic_client_registration_not_enabled",
+          error_message: "DCR is disabled",
+        },
+      }),
+      dynamicRegistration: {
+        client_name: "Test Client",
+      },
+      loadPreregisteredCredentials: jest.fn().mockResolvedValue({
+        clientId: "configured-client-id",
+        clientSecret: "configured-secret",
+      }),
+    });
+
+    await machine.proceedToNextStep();
+
+    expect(state.currentStep).toBe("received_client_credentials");
+    expect(state.clientId).toBe("configured-client-id");
+    expect(state.clientSecret).toBe("configured-secret");
+    expect(state.tokenEndpointAuthMethod).toBe("client_secret_post");
+    expect(state.error).toBeUndefined();
+    expect(state.isInitiatingAuth).toBe(false);
+  });
 });

--- a/sdk/tests/oauth/trace-projection.test.ts
+++ b/sdk/tests/oauth/trace-projection.test.ts
@@ -1,0 +1,65 @@
+import { projectOAuthTraceSnapshot } from "../../src/oauth/state-machines/trace.js";
+import { EMPTY_OAUTH_FLOW_STATE } from "../../src/oauth/state-machines/types.js";
+
+describe("OAuth trace projection", () => {
+  it("keeps DCR fallback failures attached to the registration step", () => {
+    const snapshot = projectOAuthTraceSnapshot({
+      state: {
+        ...EMPTY_OAUTH_FLOW_STATE,
+        currentStep: "authorization_request",
+        clientId: "configured-client-id",
+        authorizationUrl: "https://auth.example.com/authorize?client_id=test",
+        httpHistory: [
+          {
+            step: "request_client_registration",
+            timestamp: 1_000,
+            request: {
+              method: "POST",
+              url: "https://auth.example.com/register",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: {
+                client_name: "MCPJam Inspector",
+              },
+            },
+            response: {
+              status: 400,
+              statusText: "Bad Request",
+              headers: {
+                "content-type": "application/json",
+              },
+              body: {
+                error_type: "dynamic_client_registration_not_enabled",
+                error_message:
+                  "Dynamic Client Registration is not enabled for this project.",
+              },
+            },
+          },
+        ],
+        infoLogs: [],
+      },
+    });
+
+    const registrationStep = snapshot.steps.find(
+      (step) => step.step === "request_client_registration",
+    );
+    const authorizationStep = snapshot.steps.find(
+      (step) => step.step === "authorization_request",
+    );
+
+    expect(registrationStep).toMatchObject({
+      step: "request_client_registration",
+      status: "success",
+      recovered: true,
+      recoveryMessage:
+        "Using pre-registered client credentials after registration failed.",
+      error:
+        "dynamic_client_registration_not_enabled: Dynamic Client Registration is not enabled for this project.",
+    });
+    expect(authorizationStep).toMatchObject({
+      step: "authorization_request",
+      status: "success",
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches OAuth initiation/callback code paths and adds hosted-session polling plus additional state persisted in storage; mistakes could break logins or leave users stuck mid-flow. UI/logging changes are otherwise additive and covered by new/updated tests.
> 
> **Overview**
> Adds **end-to-end OAuth trace streaming** into the traffic logger: OAuth flows now accept `onTraceUpdate` callbacks and immediately ingest trace steps into `traffic-log-store`, so the logger panel can show live progress during connect/reconnect and hosted callbacks.
> 
> Introduces **hosted OAuth callback sessions** by persisting a `sessionId` in the hosted pending marker and enhancing `completeHostedOAuthCallback` to poll `/web/oauth/session/progress`, merge traces, and short-circuit on terminal failure. The Servers tab/logger UI is updated to *auto-focus* the logger on the server being connected/reconnected (persisted briefly in `sessionStorage`) and `LoggerView` can filter by `serverIds` and `sinceTimestamp`, including showing inline OAuth error/recovery summaries for collapsed rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d59be363a4bcd04e2a7c72c2a155b47448f9b6d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->