### PR TITLE
Oauth nit

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -448,6 +448,7 @@ export default function App() {
     const urlParams = new URLSearchParams(window.location.search);
     const code = urlParams.get("code");
     const error = urlParams.get("error");
+    const state = urlParams.get("state");
 
     let cancelled = false;
     setHostedOAuthHandling(true);
@@ -493,6 +494,7 @@ export default function App() {
     const completeCallback =
       isAuthenticated
         ? completeHostedOAuthCallback(callbackContext, code, {
+            callbackState: state,
             onTraceUpdate: handleLiveOAuthTrace,
           })
         : handleOAuthCallback(code, {

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.hosted-session.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.hosted-session.test.ts
@@ -61,7 +61,10 @@ describe("mcp-oauth hosted callback sessions", () => {
         returnHash: "#servers",
         startedAt: Date.now(),
       },
-      "oauth-code"
+      "oauth-code",
+      {
+        callbackState: "oauth-state-1",
+      }
     );
 
     expect(result.success).toBe(true);
@@ -70,6 +73,67 @@ describe("mcp-oauth hosted callback sessions", () => {
       "https://test.convex.site/web/oauth/complete",
       expect.any(Object)
     );
+
+    const completeCall = authFetchMock.mock.calls.find(
+      ([url]) => url === "https://test.convex.site/web/oauth/complete"
+    );
+    expect(completeCall).toBeDefined();
+
+    const [, requestInit] = completeCall as [string, RequestInit];
+    const sentBody = JSON.parse(String(requestInit.body));
+    expect(sentBody).toEqual({
+      workspaceId: "ws_1",
+      serverId: "srv_asana",
+      code: "oauth-code",
+      state: "oauth-state-1",
+      sessionId: "hosted-session-1",
+      accessScope: "workspace_member",
+    });
+  });
+
+  it("allows hosted callbacks to complete when the provider omits state", async () => {
+    authFetchMock.mockImplementation((url: string) => {
+      if (url === "https://test.convex.site/web/oauth/session/progress") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ success: false, error: "not found" }), {
+            status: 404,
+            headers: { "Content-Type": "application/json" },
+          })
+        );
+      }
+
+      if (url === "https://test.convex.site/web/oauth/complete") {
+        return Promise.resolve(
+          new Response(JSON.stringify({ success: true, expiresAt: 789 }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        );
+      }
+
+      throw new Error(`Unexpected authFetch URL: ${url}`);
+    });
+
+    const { completeHostedOAuthCallback } = await import("../mcp-oauth");
+    const result = await completeHostedOAuthCallback(
+      {
+        surface: "workspace",
+        workspaceId: "ws_1",
+        serverId: "srv_asana",
+        serverName: "asana",
+        serverUrl: "https://mcp.asana.com/sse",
+        sessionId: "hosted-session-1",
+        accessScope: "workspace_member",
+        shareToken: null,
+        chatboxToken: null,
+        returnHash: "#servers",
+        startedAt: Date.now(),
+      },
+      "oauth-code"
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.expiresAt).toBe(789);
 
     const completeCall = authFetchMock.mock.calls.find(
       ([url]) => url === "https://test.convex.site/web/oauth/complete"
@@ -160,7 +224,7 @@ describe("mcp-oauth hosted callback sessions", () => {
           startedAt: Date.now(),
         },
         "oauth-code",
-        { onTraceUpdate }
+        { callbackState: "oauth-state-2", onTraceUpdate }
       );
 
       await vi.waitFor(() =>
@@ -282,7 +346,7 @@ describe("mcp-oauth hosted callback sessions", () => {
           startedAt: Date.now(),
         },
         "oauth-code",
-        { onTraceUpdate }
+        { callbackState: "oauth-state-3", onTraceUpdate }
       );
 
       await vi.waitFor(() =>

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -1161,10 +1161,19 @@ function waitForMs(ms: number): Promise<void> {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
 }
 
+function readHostedOAuthExpectedState(state: OAuthFlowState): string {
+  const expectedState =
+    typeof state.state === "string" ? state.state.trim() : "";
+  if (!expectedState) {
+    throw new Error("OAuth state not ready for hosted callback session.");
+  }
+
+  return expectedState;
+}
+
 async function createHostedOAuthSessionIfNeeded(input: {
   serverName: string;
   serverUrl: string;
-  authorizationUrl: string;
   redirectUrl: string;
   state: OAuthFlowState;
 }): Promise<string | undefined> {
@@ -1199,6 +1208,7 @@ async function createHostedOAuthSessionIfNeeded(input: {
   if (!codeVerifier) {
     throw new Error("Code verifier not ready for hosted callback session.");
   }
+  const expectedState = readHostedOAuthExpectedState(input.state);
 
   const response = await authFetch("/api/web/oauth/session", {
     method: "POST",
@@ -1210,15 +1220,12 @@ async function createHostedOAuthSessionIfNeeded(input: {
       serverId: pendingMarker.serverId,
       codeVerifier,
       redirectUri: input.redirectUrl,
+      expectedState,
       clientInformation: {
         clientId,
         ...(input.state.clientSecret
           ? { clientSecret: input.state.clientSecret }
           : {}),
-      },
-      flowState: {
-        ...cloneFlowState(input.state),
-        authorizationUrl: input.authorizationUrl,
       },
       ...(pendingMarker.accessScope
         ? { accessScope: pendingMarker.accessScope }
@@ -1646,7 +1653,6 @@ export async function initiateOAuth(
         await createHostedOAuthSessionIfNeeded({
           serverName: options.serverName,
           serverUrl: options.serverUrl,
-          authorizationUrl,
           redirectUrl: provider.redirectUrl,
           state: getState(),
         });
@@ -1768,7 +1774,10 @@ function formatOAuthCallbackError(error: unknown): string {
 export async function completeHostedOAuthCallback(
   context: HostedOAuthCallbackContext,
   authorizationCode: string,
-  options: { onTraceUpdate?: (trace: OAuthTrace) => void } = {}
+  options: {
+    callbackState?: string | null;
+    onTraceUpdate?: (trace: OAuthTrace) => void;
+  } = {}
 ): Promise<OAuthResult & { serverName?: string; expiresAt?: number | null }> {
   const serverName =
     context.serverName || localStorage.getItem("mcp-oauth-pending");
@@ -1845,6 +1854,10 @@ export async function completeHostedOAuthCallback(
     const legacyCodeVerifier = context.sessionId
       ? undefined
       : localStorage.getItem(`mcp-verifier-${serverName}`);
+    const callbackState =
+      typeof options.callbackState === "string"
+        ? options.callbackState.trim()
+        : "";
     if (!context.sessionId && !legacyCodeVerifier) {
       throw new Error("Code verifier not found");
     }
@@ -1908,7 +1921,10 @@ export async function completeHostedOAuthCallback(
           serverId: context.serverId,
           code: authorizationCode,
           ...(context.sessionId
-            ? { sessionId: context.sessionId }
+            ? {
+                sessionId: context.sessionId,
+                ...(callbackState ? { state: callbackState } : {}),
+              }
             : {
                 serverUrl,
                 codeVerifier: legacyCodeVerifier,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches hosted OAuth session creation and callback completion logic, which can break sign-in if state handling mismatches provider behavior. Covered by updated tests including a case where the provider omits `state`.
> 
> **Overview**
> **Hosted OAuth callbacks now propagate `state`.** The app reads `state` from the callback URL and passes it into `completeHostedOAuthCallback`.
> 
> On the hosted-session path, `mcp-oauth` now records an `expectedState` when creating the backend session and includes the callback `state` (when present) in the `/web/oauth/complete` payload. Tests are updated to assert the new request body and to ensure callbacks still succeed when `state` is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23d0ce7b4a8457725829fbd150241bfbca533da4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->