### PR TITLE
Handle missing hosted OAuth refresh tokens

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
@@ -429,4 +429,34 @@ describe("useServerState hosted OAuth callback guards", () => {
       );
     });
   });
+
+  it("falls back to interactive OAuth when hosted reconnect reports a missing refresh token", async () => {
+    mockReconnectServer.mockResolvedValueOnce({
+      success: false,
+      error: "Stored hosted OAuth credential is missing refresh_token",
+    });
+    mockEnsureAuthorizedForReconnect.mockResolvedValueOnce({
+      kind: "error",
+      error: "OAuth init failed",
+    });
+
+    const dispatch = vi.fn();
+    const { result } = renderHostedServerState(dispatch);
+
+    await act(async () => {
+      await result.current.handleReconnect("asana");
+    });
+
+    await waitFor(() => {
+      expect(mockEnsureAuthorizedForReconnect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "asana",
+          useOAuth: true,
+        }),
+        expect.objectContaining({
+          beforeRedirect: expect.any(Function),
+        }),
+      );
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -130,6 +130,9 @@ function requiresFreshOAuthAuthorization(error: unknown): boolean {
   const normalized = errorMessage.toLowerCase();
   return (
     normalized.includes("requires oauth authentication") ||
+    normalized.includes(
+      "stored hosted oauth credential is missing refresh_token",
+    ) ||
     (normalized.includes("authentication failed") &&
       normalized.includes("invalid_token"))
   );


### PR DESCRIPTION
## Summary
- Treat the hosted OAuth missing-refresh-token error as a reauth signal during reconnect
- Add a regression test covering the fallback from stored credential lookup to interactive OAuth

## Testing
- Added unit coverage in `use-server-state.hosted-oauth.test.tsx`
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to error-string detection for hosted OAuth reconnect plus a focused regression test; main risk is false-positive matching if backend error text changes.
> 
> **Overview**
> Hosted OAuth reconnect now treats the backend error `Stored hosted OAuth credential is missing refresh_token` as a *reauth required* signal, triggering the interactive OAuth fallback instead of failing the reconnect.
> 
> Adds a regression test in `use-server-state.hosted-oauth.test.tsx` to verify `handleReconnect` calls `ensureAuthorizedForReconnect` when this missing-refresh-token error is returned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fd2e0df65f0e66fa448175b6fd0a063250869c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->