### PR TITLE
Fix reconnect toggles to avoid launching OAuth consent

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -96,6 +96,7 @@ import {
 } from "./components/hosted/ChatboxChatPage";
 import { useHostedApiContext } from "./hooks/hosted/use-hosted-api-context";
 import { HOSTED_MODE, NON_PROD_LOCKDOWN } from "./lib/config";
+import { subscribeToOAuthDebuggerRequests } from "./lib/oauth/oauth-debugger-navigation";
 import {
   clearBillingSignInReturnPath,
   clearCheckoutIntentFromUrl,
@@ -682,6 +683,23 @@ export default function App() {
       ? currentHashRoute.organizationId
       : undefined,
   });
+  const oauthDebuggerServersRef = useRef(appState.servers);
+  oauthDebuggerServersRef.current = appState.servers;
+  const selectedServerRef = useRef(appState.selectedServer);
+  selectedServerRef.current = appState.selectedServer;
+  useEffect(() => {
+    return subscribeToOAuthDebuggerRequests(({ serverName }) => {
+      const matchedServerName = Object.entries(
+        oauthDebuggerServersRef.current,
+      ).find(
+        ([name, server]) => name === serverName || server.name === serverName,
+      )?.[0];
+
+      if (matchedServerName && matchedServerName !== selectedServerRef.current) {
+        setSelectedServer(matchedServerName);
+      }
+    });
+  }, [setSelectedServer]);
   const activeOrganizationName = effectiveOrganizations.find(
     (org) => org._id === activeOrganizationId,
   )?.name;

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -438,7 +438,10 @@ function SortableServerCard({
   onDisconnect: (name: string) => void;
   onReconnect: (
     name: string,
-    opts?: { forceOAuthFlow?: boolean }
+    opts?: {
+      forceOAuthFlow?: boolean;
+      allowInteractiveOAuthFlow?: boolean;
+    }
   ) => Promise<void>;
   onRemove: (name: string) => void;
   hostedServerId?: string;
@@ -485,7 +488,10 @@ interface ServersTabProps {
   onDisconnect: (serverName: string) => void;
   onReconnect: (
     serverName: string,
-    options?: { forceOAuthFlow?: boolean }
+    options?: {
+      forceOAuthFlow?: boolean;
+      allowInteractiveOAuthFlow?: boolean;
+    }
   ) => Promise<void>;
   onUpdate: (
     originalServerName: string,
@@ -958,7 +964,13 @@ export function ServersTab({
   );
 
   const handleReconnectServer = useCallback(
-    async (serverName: string, options?: { forceOAuthFlow?: boolean }) => {
+    async (
+      serverName: string,
+      options?: {
+        forceOAuthFlow?: boolean;
+        allowInteractiveOAuthFlow?: boolean;
+      },
+    ) => {
       focusLoggerOnServer(serverName);
       await onReconnect(serverName, options);
     },

--- a/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
@@ -230,7 +230,10 @@ vi.mock("../connection/ServerConnectionCard", () => ({
     needsReconnect?: boolean;
     onReconnect?: (
       serverName: string,
-      options?: { forceOAuthFlow?: boolean }
+      options?: {
+        forceOAuthFlow?: boolean;
+        allowInteractiveOAuthFlow?: boolean;
+      }
     ) => Promise<void>;
     onOpenDetailModal?: (server: ServerWithName, defaultTab: string) => void;
   }) => (

--- a/mcpjam-inspector/client/src/components/__tests__/logger-view.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/logger-view.test.tsx
@@ -23,6 +23,7 @@ vi.mock("@/stores/traffic-log-store", async () => {
 
 import { LoggerView } from "../logger-view";
 import { useTrafficLogStore } from "@/stores/traffic-log-store";
+import { subscribeToOAuthDebuggerRequests } from "@/lib/oauth/oauth-debugger-navigation";
 
 describe("LoggerView hosted rpc logs", () => {
   beforeEach(() => {
@@ -152,6 +153,50 @@ describe("LoggerView hosted rpc logs", () => {
         "Dynamic Client Registration - Dynamic Client Registration is not enabled for this project."
       )
     ).toBeInTheDocument();
+  });
+
+  it("shows an OAuth Debugger CTA when an oauth log row has error status", async () => {
+    const user = userEvent.setup();
+    const onOpenOAuthDebugger = vi.fn();
+    const unsubscribe = subscribeToOAuthDebuggerRequests(onOpenOAuthDebugger);
+    useTrafficLogStore.getState().addMcpServerLog({
+      id: "oauth:srv-1:interactive_connect:request_client_registration:err",
+      serverId: "srv-1",
+      serverName: "Learn",
+      direction: "OAUTH",
+      method: "Dynamic Client Registration",
+      timestamp: "2026-04-10T12:00:04.000Z",
+      payload: {
+        source: "interactive_connect",
+        step: "request_client_registration",
+        title: "Dynamic Client Registration",
+        status: "error",
+        message:
+          "The client submits metadata to register a public client with the authorization server.",
+        error: "dynamic_client_registration",
+      },
+      kind: "oauth",
+      oauthStatus: "error",
+    });
+
+    render(<LoggerView serverIds={["srv-1"]} />);
+
+    const rowLabel = screen.getByText(
+      "Dynamic Client Registration - dynamic_client_registration"
+    );
+    const entry = rowLabel.closest(".group");
+    expect(entry).toBeTruthy();
+    await user.hover(entry!);
+
+    const cta = screen.getByRole("link", {
+      name: "Continue in OAuth Debugger",
+    });
+    expect(cta).toHaveAttribute("href", "#oauth-flow");
+    await user.click(cta);
+    expect(onOpenOAuthDebugger).toHaveBeenCalledWith({
+      serverName: "Learn",
+    });
+    unsubscribe();
   });
 
   it("filters logs to the current session when sinceTimestamp is provided", () => {

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -90,7 +90,10 @@ interface ServerConnectionCardProps {
   onDisconnect: (serverName: string) => void;
   onReconnect: (
     serverName: string,
-    options?: { forceOAuthFlow?: boolean },
+    options?: {
+      forceOAuthFlow?: boolean;
+      allowInteractiveOAuthFlow?: boolean;
+    },
   ) => Promise<void>;
   onRemove?: (serverName: string) => void;
   serverTunnelUrl?: string | null;
@@ -221,7 +224,10 @@ export function ServerConnectionCard({
     }
   };
 
-  const handleReconnect = async (options?: { forceOAuthFlow?: boolean }) => {
+  const handleReconnect = async (options?: {
+    forceOAuthFlow?: boolean;
+    allowInteractiveOAuthFlow?: boolean;
+  }) => {
     setIsReconnecting(true);
     try {
       await onReconnect(server.name, options);
@@ -499,7 +505,9 @@ export function ServerConnectionCard({
                     if (!checked) {
                       onDisconnect(server.name);
                     } else {
-                      void handleReconnect();
+                      void handleReconnect({
+                        allowInteractiveOAuthFlow: false,
+                      });
                     }
                   }}
                   className="cursor-pointer scale-75"

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -46,7 +46,10 @@ interface ServerDetailModalProps {
   onDisconnect: (serverName: string) => void;
   onReconnect: (
     serverName: string,
-    options?: { forceOAuthFlow?: boolean },
+    options?: {
+      forceOAuthFlow?: boolean;
+      allowInteractiveOAuthFlow?: boolean;
+    },
   ) => Promise<void>;
   existingServerNames: string[];
 }
@@ -182,7 +185,10 @@ export function ServerDetailModal({
     }
   };
 
-  const handleConnect = async () => {
+  const handleConnect = async (options?: {
+    forceOAuthFlow?: boolean;
+    allowInteractiveOAuthFlow?: boolean;
+  }) => {
     setIsReconnecting(true);
     posthog.capture("server_detail_modal_connect_clicked", {
       platform: detectPlatform(),
@@ -190,12 +196,7 @@ export function ServerDetailModal({
       server_id: server.name,
     });
     try {
-      const shouldForceOAuth =
-        server.useOAuth === true || server.oauthTokens != null;
-      await onReconnect(
-        server.name,
-        shouldForceOAuth ? { forceOAuthFlow: true } : undefined,
-      );
+      await onReconnect(server.name, options);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error";
@@ -306,7 +307,9 @@ export function ServerDetailModal({
                   if (!checked) {
                     handleDisconnect();
                   } else {
-                    void handleConnect();
+                    void handleConnect({
+                      allowInteractiveOAuthFlow: false,
+                    });
                   }
                 }}
                 className="cursor-pointer scale-75"

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -253,7 +253,9 @@ describe("ServerConnectionCard", () => {
       const toggle = screen.getByRole("switch");
       fireEvent.click(toggle);
 
-      expect(onReconnect).toHaveBeenCalledWith("test-server", undefined);
+      expect(onReconnect).toHaveBeenCalledWith("test-server", {
+        allowInteractiveOAuthFlow: false,
+      });
     });
 
     it("catches rejected reconnect promises and clears reconnect loading state", async () => {

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
@@ -198,6 +198,23 @@ describe("ServerDetailModal", () => {
     ).toBeInTheDocument();
   });
 
+  it("uses the non-interactive reconnect path when toggling on from the detail modal", () => {
+    const onReconnect = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ServerDetailModal
+        {...defaultProps}
+        server={createServer({ connectionStatus: "disconnected" })}
+        onReconnect={onReconnect}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("switch"));
+
+    expect(onReconnect).toHaveBeenCalledWith("test-server", {
+      allowInteractiveOAuthFlow: false,
+    });
+  });
+
   it("does not show a conformance launch button in overview", () => {
     render(<ServerDetailModal {...defaultProps} defaultTab="overview" />);
 

--- a/mcpjam-inspector/client/src/components/logger-view.tsx
+++ b/mcpjam-inspector/client/src/components/logger-view.tsx
@@ -42,6 +42,10 @@ import {
   PopoverTrigger,
 } from "@mcpjam/design-system/popover";
 import { Filter, Settings2 } from "lucide-react";
+import {
+  OAUTH_DEBUGGER_HASH,
+  requestOpenOAuthDebugger,
+} from "@/lib/oauth/oauth-debugger-navigation";
 import { cn } from "@/lib/utils";
 
 type RpcDirection = "in" | "out" | string;
@@ -138,6 +142,22 @@ function getDisplayServerTitle(item: {
     return `${item.serverName} (${item.serverId})`;
   }
   return getDisplayServerLabel(item);
+}
+
+function getOAuthDebuggerTargetServerName(
+  item: Pick<RenderableRpcItem, "serverId" | "serverName">,
+  servers: Record<string, ServerWithName>,
+): string | undefined {
+  const candidates = [
+    item.serverName,
+    servers[item.serverId]?.name,
+    item.serverId,
+  ];
+
+  return candidates.find(
+    (candidate): candidate is string =>
+      typeof candidate === "string" && candidate.trim().length > 0,
+  );
 }
 
 function normalizeInlineSummary(text: string): string {
@@ -650,11 +670,18 @@ export function LoggerView({
                 ? "border-l-purple-500/50"
                 : "border-l-transparent";
 
+              const oauthDebuggerTargetServerName =
+                isOAuthTraffic && it.oauthStatus === "error"
+                  ? getOAuthDebuggerTargetServerName(it, appState.servers)
+                  : undefined;
+              const showOAuthDebuggerCta =
+                oauthDebuggerTargetServerName !== undefined;
+
               return (
                 <div
                   key={it.id}
                   className={cn(
-                    "border-b border-border border-l-2",
+                    "group border-b border-border border-l-2",
                     borderClass,
                     isError && "bg-destructive/5",
                     isExpanded && "bg-muted/20"
@@ -694,12 +721,54 @@ export function LoggerView({
                       {displayMethod}
                     </span>
                     <span
-                      className="hidden sm:inline text-muted-foreground truncate max-w-[120px] text-[11px]"
+                      className={cn(
+                        "hidden sm:inline text-muted-foreground truncate max-w-[120px] text-[11px]",
+                        showOAuthDebuggerCta &&
+                          "order-4 max-sm:order-5 group-hover:order-5 group-focus-within:order-5"
+                      )}
                       title={getDisplayServerTitle(it)}
                     >
                       {getDisplayServerLabel(it)}
                     </span>
-                    <span className="text-muted-foreground font-mono text-[11px] whitespace-nowrap tabular-nums">
+                    {showOAuthDebuggerCta && (
+                      <div
+                        className={cn(
+                          "order-5 max-sm:order-4 flex max-h-7 shrink-0 overflow-hidden transition-[max-width,opacity] duration-150 ease-out",
+                          "max-w-0 opacity-0",
+                          "max-sm:max-w-[min(100%,15rem)] max-sm:opacity-100",
+                          "group-hover:order-4 group-focus-within:order-4",
+                          "group-hover:max-w-[min(100%,15rem)] group-hover:opacity-100",
+                          "group-focus-within:max-w-[min(100%,15rem)] group-focus-within:opacity-100"
+                        )}
+                      >
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          className="h-6 shrink-0 px-2 text-[10px] leading-none"
+                          asChild
+                        >
+                          <a
+                            href={OAUTH_DEBUGGER_HASH}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              if (oauthDebuggerTargetServerName) {
+                                requestOpenOAuthDebugger(
+                                  oauthDebuggerTargetServerName,
+                                );
+                              }
+                            }}
+                          >
+                            Continue in OAuth Debugger
+                          </a>
+                        </Button>
+                      </div>
+                    )}
+                    <span
+                      className={cn(
+                        "text-muted-foreground font-mono text-[11px] whitespace-nowrap tabular-nums",
+                        showOAuthDebuggerCta && "order-6"
+                      )}
+                    >
                       {new Date(it.timestamp).toLocaleTimeString()}
                     </span>
                   </div>

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
@@ -393,6 +393,7 @@ describe("useServerState hosted OAuth callback guards", () => {
           useOAuth: true,
         }),
         expect.objectContaining({
+          allowInteractiveOAuthFlow: true,
           beforeRedirect: expect.any(Function),
         }),
       );
@@ -424,6 +425,7 @@ describe("useServerState hosted OAuth callback guards", () => {
           useOAuth: true,
         }),
         expect.objectContaining({
+          allowInteractiveOAuthFlow: true,
           beforeRedirect: expect.any(Function),
         }),
       );
@@ -454,9 +456,49 @@ describe("useServerState hosted OAuth callback guards", () => {
           useOAuth: true,
         }),
         expect.objectContaining({
+          allowInteractiveOAuthFlow: true,
           beforeRedirect: expect.any(Function),
         }),
       );
+    });
+  });
+
+  it("reports reauth instead of launching interactive OAuth during automatic readiness checks", async () => {
+    mockReconnectServer.mockResolvedValueOnce({
+      success: false,
+      error:
+        'Server "srv_asana" requires OAuth authentication. Please complete the OAuth flow first.',
+    });
+    mockEnsureAuthorizedForReconnect.mockResolvedValueOnce({
+      kind: "reauth_required",
+      error: "OAuth consent is required for asana. Click Reconnect to continue.",
+    });
+
+    const dispatch = vi.fn();
+    const { result } = renderHostedServerState(dispatch);
+    let readiness:
+      | Awaited<ReturnType<typeof result.current.ensureServersReady>>
+      | undefined;
+
+    await act(async () => {
+      readiness = await result.current.ensureServersReady(["asana"]);
+    });
+
+    expect(mockEnsureAuthorizedForReconnect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "asana",
+        useOAuth: true,
+      }),
+      expect.objectContaining({
+        allowInteractiveOAuthFlow: false,
+        beforeRedirect: expect.any(Function),
+      }),
+    );
+    expect(readiness).toEqual({
+      readyServerNames: [],
+      missingServerNames: [],
+      failedServerNames: [],
+      reauthServerNames: ["asana"],
     });
   });
 });

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -186,6 +186,7 @@ interface EnsureServerConnectionResult {
 
 interface ReconnectServerInternalOptions {
   forceOAuthFlow?: boolean;
+  allowInteractiveOAuthFlow?: boolean;
   select?: boolean;
   suppressErrors?: boolean;
 }
@@ -2004,12 +2005,32 @@ export function useServerState({
             onTraceUpdate: (oauthTrace: OAuthTrace) => {
               updateServerOAuthTrace(serverName, oauthTrace);
             },
+            allowInteractiveOAuthFlow: options?.allowInteractiveOAuthFlow,
           },
         );
         if (authResult.kind === "redirect") {
           return {
             status: "reauth",
             error: `Reauthenticate ${serverName} to continue.`,
+          };
+        }
+        if (authResult.kind === "reauth_required") {
+          if (isStaleOp(serverName, token)) {
+            return {
+              status: "reauth",
+              error: authResult.error,
+            };
+          }
+          dispatch({
+            type: "CONNECT_FAILURE",
+            name: serverName,
+            error: authResult.error,
+            oauthTrace: authResult.oauthTrace,
+          });
+          reportError(authResult.error);
+          return {
+            status: "reauth",
+            error: authResult.error,
           };
         }
         if (authResult.kind === "error") {
@@ -2109,9 +2130,16 @@ export function useServerState({
   );
 
   const handleReconnect = useCallback(
-    async (serverName: string, options?: { forceOAuthFlow?: boolean }) => {
+    async (
+      serverName: string,
+      options?: {
+        forceOAuthFlow?: boolean;
+        allowInteractiveOAuthFlow?: boolean;
+      },
+    ) => {
       await reconnectServerInternal(serverName, {
         forceOAuthFlow: options?.forceOAuthFlow,
+        allowInteractiveOAuthFlow: options?.allowInteractiveOAuthFlow ?? true,
         select: true,
       });
     },
@@ -2202,6 +2230,7 @@ export function useServerState({
             return [
               resolvedKey,
               await reconnectServerInternal(resolvedKey, {
+                allowInteractiveOAuthFlow: false,
                 select: false,
                 suppressErrors: true,
               }),

--- a/mcpjam-inspector/client/src/lib/config.ts
+++ b/mcpjam-inspector/client/src/lib/config.ts
@@ -16,6 +16,12 @@
  */
 export const HOSTED_MODE = import.meta.env.VITE_MCPJAM_HOSTED_MODE === "true";
 
+/**
+ * Controls redaction for live OAuth trace rendering.
+ * Redirect resume state and saved app state remain stripped/redacted separately.
+ */
+export const SANITIZE_OAUTH_TRACES = HOSTED_MODE;
+
 export const NON_PROD_LOCKDOWN =
   import.meta.env.VITE_MCPJAM_NONPROD_LOCKDOWN === "true";
 

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.test.ts
@@ -799,6 +799,19 @@ describe("mcp-oauth", () => {
       });
     });
 
+    it("keeps live oauth traces in memory while preserving redirect resume state", async () => {
+      const { initiateOAuth } = await import("../mcp-oauth");
+
+      const result = await initiateOAuth({
+        serverName: "asana",
+        serverUrl: "https://mcp.asana.com/v2/mcp",
+      });
+
+      expect(result.success).toBe(true);
+      expect(localStorage.getItem("mcp-oauth-trace-asana")).toBeNull();
+      expect(localStorage.getItem("mcp-oauth-flow-state-asana")).not.toBeNull();
+    });
+
     it("normalizes malformed persisted oauth trace history", async () => {
       const { appendOAuthTraceHttpHistory, loadOAuthTrace } = await import(
         "../oauth-trace"

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -20,6 +20,7 @@ import type {
   OAuthDiscoveryState,
   OAuthFlowState,
   OAuthProtocolVersion,
+  OAuthRequestResult,
   RegistrationStrategy2025_03_26,
   RegistrationStrategy2025_06_18,
   RegistrationStrategy2025_11_25,
@@ -28,7 +29,7 @@ import type {
 import type { HttpServerConfig } from "@mcpjam/sdk/browser";
 import { generateRandomString } from "./pkce";
 import { authFetch } from "@/lib/session-token";
-import { HOSTED_MODE } from "@/lib/config";
+import { HOSTED_MODE, SANITIZE_OAUTH_TRACES } from "@/lib/config";
 import { captureServerDetailModalOAuthResume } from "@/lib/server-detail-modal-resume";
 import {
   matchesHostedOAuthServerIdentity,
@@ -45,9 +46,7 @@ import {
   completeOAuthTraceStep,
   createOAuthTrace,
   failOAuthTraceStep,
-  loadOAuthTrace,
   mergeOAuthTraces,
-  saveOAuthTrace,
   startOAuthTraceStep,
   type OAuthTrace,
 } from "./oauth-trace";
@@ -292,23 +291,58 @@ function createHttpHistoryEntry(input: {
     timestamp: Date.now(),
     request: {
       method: input.method,
-      url: sanitizeOAuthUrl(input.url),
-      headers: sanitizeOAuthHeaders(input.headers ?? {}),
-      body: sanitizeOAuthTraceValue(input.body),
+      url: SANITIZE_OAUTH_TRACES ? sanitizeOAuthUrl(input.url) : input.url,
+      headers: traceOAuthHeaders(input.headers ?? {}),
+      body: traceOAuthValue(input.body),
     },
   };
 }
 
+function traceOAuthHeaders(
+  headers: Record<string, string>,
+): Record<string, string> {
+  return SANITIZE_OAUTH_TRACES
+    ? sanitizeOAuthHeaders(headers)
+    : { ...headers };
+}
+
+function traceOAuthValue(value: unknown): unknown {
+  return SANITIZE_OAUTH_TRACES ? sanitizeOAuthTraceValue(value) : value;
+}
+
+function parseOAuthResponseText(
+  text: string,
+  contentType: string,
+): unknown {
+  const looksJson =
+    contentType.includes("application/json") ||
+    contentType.includes("+json") ||
+    text.startsWith("{") ||
+    text.startsWith("[");
+
+  if (!looksJson) {
+    return text;
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
 async function readResponseBodyForTrace(response: Response): Promise<unknown> {
   try {
-    return sanitizeOAuthTraceValue(await response.clone().json());
-  } catch {
-    try {
-      const text = await response.clone().text();
-      return text ? sanitizeOAuthTraceValue(text) : null;
-    } catch {
+    const text = await response.clone().text();
+    if (!text) {
       return null;
     }
+
+    const contentType =
+      response.headers.get("content-type")?.toLowerCase() ?? "";
+    return traceOAuthValue(parseOAuthResponseText(text, contentType));
+  } catch {
+    return null;
   }
 }
 
@@ -322,6 +356,19 @@ function cloneEmptyFlowState(): OAuthFlowState {
 
 function cloneFlowState(state: OAuthFlowState): OAuthFlowState {
   return JSON.parse(JSON.stringify(state)) as OAuthFlowState;
+}
+
+function stripOAuthTraceDataFromFlowState(
+  state: OAuthFlowState
+): OAuthFlowState {
+  return {
+    ...cloneFlowState(state),
+    httpHistory: [],
+    infoLogs: [],
+    lastRequest: undefined,
+    lastResponse: undefined,
+    error: undefined,
+  };
 }
 
 function normalizeResponseHeaders(headers: Headers): Record<string, string> {
@@ -339,26 +386,7 @@ async function parseOAuthResponseBody(response: Response): Promise<unknown> {
   }
 
   const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
-  if (
-    contentType.includes("application/json") ||
-    contentType.includes("+json")
-  ) {
-    try {
-      return sanitizeOAuthTraceValue(JSON.parse(text));
-    } catch {
-      return sanitizeOAuthTraceValue(text);
-    }
-  }
-
-  if (text.startsWith("{") || text.startsWith("[")) {
-    try {
-      return sanitizeOAuthTraceValue(JSON.parse(text));
-    } catch {
-      return sanitizeOAuthTraceValue(text);
-    }
-  }
-
-  return sanitizeOAuthTraceValue(text);
+  return traceOAuthValue(parseOAuthResponseText(text, contentType));
 }
 
 function serializeOAuthRequestBody(
@@ -394,9 +422,13 @@ function saveOAuthFlowSession(
   serverName: string,
   session: StoredOAuthFlowSession
 ): void {
+  const persistedSession: StoredOAuthFlowSession = {
+    ...session,
+    state: stripOAuthTraceDataFromFlowState(session.state),
+  };
   localStorage.setItem(
     getFlowStateStorageKey(serverName),
-    JSON.stringify(session)
+    JSON.stringify(persistedSession)
   );
 }
 
@@ -420,7 +452,10 @@ function loadOAuthFlowSession(
       return undefined;
     }
 
-    return parsed;
+    return {
+      ...parsed,
+      state: stripOAuthTraceDataFromFlowState(parsed.state),
+    };
   } catch {
     return undefined;
   }
@@ -534,8 +569,30 @@ async function executeRequestViaProxy(
     status: proxied.status,
     statusText: proxied.statusText,
     headers: proxied.headers ?? {},
-    body: sanitizeOAuthTraceValue(proxied.body),
+    body: traceOAuthValue(proxied.body),
     ok: proxied.status >= 200 && proxied.status < 300,
+  };
+}
+
+async function createTraceResponseFromFetch(
+  response: Response,
+): Promise<HttpHistoryEntry["response"]> {
+  return {
+    status: response.status,
+    statusText: response.statusText,
+    headers: traceOAuthHeaders(Object.fromEntries(response.headers.entries())),
+    body: await readResponseBodyForTrace(response),
+  };
+}
+
+function createTraceResponseFromResult(
+  result: Pick<OAuthRequestResult, "status" | "statusText" | "headers" | "body">,
+): HttpHistoryEntry["response"] {
+  return {
+    status: result.status,
+    statusText: result.statusText,
+    headers: traceOAuthHeaders(result.headers ?? {}),
+    body: traceOAuthValue(result.body),
   };
 }
 
@@ -646,6 +703,23 @@ function buildOAuthTraceFromFlowState(input: {
     serverUrl: input.serverUrl,
     snapshot: projectOAuthTraceSnapshot({
       state: input.state,
+      sanitize: SANITIZE_OAUTH_TRACES,
+    }),
+  });
+}
+
+function buildStoredOAuthTrace(input: {
+  serverName: string;
+  serverUrl: string;
+  session: StoredOAuthFlowSession;
+}): OAuthTrace {
+  return buildOAuthTraceFromSnapshot({
+    source: "interactive_connect",
+    serverName: input.serverName,
+    serverUrl: input.serverUrl,
+    snapshot: projectOAuthTraceSnapshot({
+      state: input.session.state,
+      sanitize: true,
     }),
   });
 }
@@ -989,14 +1063,7 @@ function createOAuthFetchInterceptor(
             )
           ),
         });
-        entry.response = {
-          status: response.status,
-          statusText: response.statusText,
-          headers: sanitizeOAuthHeaders(
-            Object.fromEntries(response.headers.entries())
-          ),
-          body: await readResponseBodyForTrace(response),
-        };
+        entry.response = await createTraceResponseFromFetch(response);
         entry.duration = Date.now() - entry.timestamp;
         return response;
       }
@@ -1012,14 +1079,7 @@ function createOAuthFetchInterceptor(
 
       if (isMetadata) {
         const response = await authFetch(proxyUrl, { ...init, method: "GET" });
-        entry.response = {
-          status: response.status,
-          statusText: response.statusText,
-          headers: sanitizeOAuthHeaders(
-            Object.fromEntries(response.headers.entries())
-          ),
-          body: await readResponseBodyForTrace(response),
-        };
+        entry.response = await createTraceResponseFromFetch(response);
         entry.duration = Date.now() - entry.timestamp;
         return response;
       }
@@ -1040,25 +1100,18 @@ function createOAuthFetchInterceptor(
 
       // If the proxy call itself failed (e.g., auth error), return that response directly
       if (!response.ok) {
-        entry.response = {
-          status: response.status,
-          statusText: response.statusText,
-          headers: sanitizeOAuthHeaders(
-            Object.fromEntries(response.headers.entries())
-          ),
-          body: await readResponseBodyForTrace(response),
-        };
+        entry.response = await createTraceResponseFromFetch(response);
         entry.duration = Date.now() - entry.timestamp;
         return response;
       }
 
       const data = await response.json();
-      entry.response = {
+      entry.response = createTraceResponseFromResult({
         status: data.status,
         statusText: data.statusText,
-        headers: sanitizeOAuthHeaders(data.headers ?? {}),
-        body: sanitizeOAuthTraceValue(data.body),
-      };
+        headers: data.headers ?? {},
+        body: data.body,
+      });
       entry.duration = Date.now() - entry.timestamp;
       return new Response(JSON.stringify(data.body), {
         status: data.status,
@@ -1146,13 +1199,10 @@ interface HostedOAuthSessionProgressResponse {
 const HOSTED_OAUTH_PROGRESS_POLL_MS = 250;
 
 function publishOAuthTraceUpdate(
-  serverName: string | undefined,
+  _serverName: string | undefined,
   trace: OAuthTrace,
   onTraceUpdate?: (trace: OAuthTrace) => void
 ): OAuthTrace {
-  if (serverName) {
-    saveOAuthTrace(serverName, trace);
-  }
   onTraceUpdate?.(trace);
   return trace;
 }
@@ -1630,6 +1680,7 @@ export async function initiateOAuth(
       serverUrl: options.serverUrl,
       serverName: options.serverName,
       redirectUrl: provider.redirectUrl,
+      sanitizeTrace: SANITIZE_OAUTH_TRACES,
       requestExecutor,
       loadPreregisteredCredentials: async () => {
         const clientInformation = provider.clientInformation();
@@ -1781,11 +1832,11 @@ export async function completeHostedOAuthCallback(
 ): Promise<OAuthResult & { serverName?: string; expiresAt?: number | null }> {
   const serverName =
     context.serverName || localStorage.getItem("mcp-oauth-pending");
-  const previousTrace = serverName ? loadOAuthTrace(serverName) : undefined;
   const callbackTrace = createOAuthTrace({
     source: "hosted_callback",
     serverName: serverName ?? undefined,
   });
+  let previousTrace: OAuthTrace | undefined;
   const mergeHostedCallbackTrace = (backendTrace?: OAuthTrace): OAuthTrace =>
     backendTrace
       ? mergeOAuthTraces(callbackTrace, backendTrace)
@@ -1821,6 +1872,14 @@ export async function completeHostedOAuthCallback(
     if (!serverUrl) {
       throw new Error("Server URL not found for OAuth callback");
     }
+    const storedSession = loadOAuthFlowSession(serverName);
+    previousTrace = storedSession
+      ? buildStoredOAuthTrace({
+          serverName,
+          serverUrl,
+          session: storedSession,
+        })
+      : undefined;
     completeOAuthTraceStep(callbackTrace, "received_authorization_code", {
       message: context.sessionId
         ? "Hosted callback state restored from the shared backend session."
@@ -2056,10 +2115,11 @@ export async function handleOAuthCallback(
 ): Promise<OAuthResult & { serverName?: string }> {
   // Get pending server name from localStorage (needed before creating interceptor)
   const serverName = localStorage.getItem("mcp-oauth-pending");
-  const previousTrace = serverName ? loadOAuthTrace(serverName) : undefined;
 
   // Read registryServerId from stored OAuth config if present
   const oauthConfig = readStoredOAuthConfig(serverName);
+  let serverUrl: string | undefined;
+  let previousTrace: OAuthTrace | undefined;
 
   try {
     if (!serverName) {
@@ -2067,7 +2127,7 @@ export async function handleOAuthCallback(
     }
 
     // Get server URL
-    const serverUrl = localStorage.getItem(`mcp-serverUrl-${serverName}`);
+    serverUrl = localStorage.getItem(`mcp-serverUrl-${serverName}`) ?? undefined;
     if (!serverUrl) {
       throw new Error("Server URL not found for OAuth callback");
     }
@@ -2090,6 +2150,13 @@ export async function handleOAuthCallback(
     const fetchFn = createOAuthFetchInterceptor(oauthConfig, undefined);
     const requestExecutor = createOAuthRequestExecutor(fetchFn, serverUrl);
     const storedSession = loadOAuthFlowSession(serverName);
+    previousTrace = storedSession
+      ? buildStoredOAuthTrace({
+          serverName,
+          serverUrl,
+          session: storedSession,
+        })
+      : undefined;
 
     if (storedSession) {
       let state = cloneFlowState(storedSession.state);
@@ -2120,6 +2187,7 @@ export async function handleOAuthCallback(
       emitTraceSnapshot(
         projectOAuthTraceSnapshot({
           state: getState(),
+          sanitize: SANITIZE_OAUTH_TRACES,
         })
       );
 
@@ -2132,6 +2200,7 @@ export async function handleOAuthCallback(
         serverUrl,
         serverName,
         redirectUrl: provider.redirectUrl,
+        sanitizeTrace: SANITIZE_OAUTH_TRACES,
         requestExecutor,
         loadPreregisteredCredentials: async () => {
           const clientInformation = provider.clientInformation();
@@ -2275,9 +2344,10 @@ export async function handleOAuthCallback(
       source: "callback",
       serverName: serverName ?? undefined,
       serverUrl:
-        serverName != null
+        serverUrl ??
+        (serverName != null
           ? localStorage.getItem(`mcp-serverUrl-${serverName}`) ?? ""
-          : "",
+          : ""),
       state: {
         ...cloneEmptyFlowState(),
         currentStep: "received_authorization_code",

--- a/mcpjam-inspector/client/src/lib/oauth/oauth-debugger-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/oauth-debugger-navigation.ts
@@ -1,0 +1,59 @@
+export const OAUTH_DEBUGGER_HASH = "#oauth-flow";
+
+const OPEN_OAUTH_DEBUGGER_EVENT = "mcpjam:open-oauth-debugger";
+
+export interface OAuthDebuggerOpenRequest {
+  serverName: string;
+}
+
+export function requestOpenOAuthDebugger(serverName: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const trimmedServerName = serverName.trim();
+  if (!trimmedServerName) {
+    return;
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<OAuthDebuggerOpenRequest>(OPEN_OAUTH_DEBUGGER_EVENT, {
+      detail: { serverName: trimmedServerName },
+    }),
+  );
+}
+
+export function subscribeToOAuthDebuggerRequests(
+  onRequest: (request: OAuthDebuggerOpenRequest) => void,
+): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  const handleEvent = (event: Event) => {
+    const detail = (event as CustomEvent<Partial<OAuthDebuggerOpenRequest>>)
+      .detail;
+    if (!detail || typeof detail.serverName !== "string") {
+      return;
+    }
+
+    const trimmedServerName = detail.serverName.trim();
+    if (!trimmedServerName) {
+      return;
+    }
+
+    onRequest({ serverName: trimmedServerName });
+  };
+
+  window.addEventListener(
+    OPEN_OAUTH_DEBUGGER_EVENT,
+    handleEvent as EventListener,
+  );
+
+  return () => {
+    window.removeEventListener(
+      OPEN_OAUTH_DEBUGGER_EVENT,
+      handleEvent as EventListener,
+    );
+  };
+}

--- a/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/oauth-trace.ts
@@ -23,8 +23,10 @@ export interface OAuthTrace extends OAuthTraceSnapshot {
   serverUrl?: string;
 }
 
+const OAUTH_TRACE_STORAGE_PREFIX = "mcp-oauth-trace-";
+
 function storageKey(serverName: string): string {
-  return `mcp-oauth-trace-${serverName}`;
+  return `${OAUTH_TRACE_STORAGE_PREFIX}${serverName}`;
 }
 
 const MAX_OAUTH_TRACE_HTTP_HISTORY = 50;
@@ -273,6 +275,24 @@ export function loadOAuthTrace(serverName: string): OAuthTrace | undefined {
     return parsed;
   } catch {
     return undefined;
+  }
+}
+
+export function clearPersistedOAuthTraces(): void {
+  try {
+    const keysToRemove: string[] = [];
+    for (let index = 0; index < localStorage.length; index += 1) {
+      const key = localStorage.key(index);
+      if (key?.startsWith(OAUTH_TRACE_STORAGE_PREFIX)) {
+        keysToRemove.push(key);
+      }
+    }
+
+    keysToRemove.forEach((key) => {
+      localStorage.removeItem(key);
+    });
+  } catch {
+    // Ignore storage access failures; startup should continue without trace migration.
   }
 }
 

--- a/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ServerWithName } from "../app-types";
+
+const {
+  clearOAuthDataMock,
+  getStoredTokensMock,
+  initiateOAuthMock,
+  readStoredOAuthConfigMock,
+  refreshOAuthTokensMock,
+} = vi.hoisted(() => ({
+  clearOAuthDataMock: vi.fn(),
+  getStoredTokensMock: vi.fn(),
+  initiateOAuthMock: vi.fn(),
+  readStoredOAuthConfigMock: vi.fn(),
+  refreshOAuthTokensMock: vi.fn(),
+}));
+
+vi.mock("@/lib/oauth/mcp-oauth", () => ({
+  clearOAuthData: clearOAuthDataMock,
+  getStoredTokens: getStoredTokensMock,
+  hasOAuthConfig: vi.fn(),
+  initiateOAuth: initiateOAuthMock,
+  readStoredOAuthConfig: readStoredOAuthConfigMock,
+  refreshOAuthTokens: refreshOAuthTokensMock,
+}));
+
+import { ensureAuthorizedForReconnect } from "../oauth-orchestrator";
+
+describe("ensureAuthorizedForReconnect", () => {
+  const createServer = (
+    overrides: Partial<ServerWithName> = {},
+  ): ServerWithName =>
+    ({
+      name: "asana",
+      config: {
+        type: "http",
+        url: "https://mcp.asana.com/sse",
+      },
+      lastConnectionTime: new Date(),
+      connectionStatus: "disconnected",
+      retryCount: 0,
+      enabled: true,
+      useOAuth: true,
+      oauthTokens: {
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+      },
+      ...overrides,
+    }) as ServerWithName;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    getStoredTokensMock.mockReturnValue(undefined);
+    readStoredOAuthConfigMock.mockReturnValue({});
+  });
+
+  it("returns reauth_required instead of starting a fresh OAuth flow when interactive OAuth is disabled", async () => {
+    refreshOAuthTokensMock.mockResolvedValue({
+      success: false,
+      error: "invalid_grant",
+      oauthTrace: { steps: [] },
+    });
+
+    const result = await ensureAuthorizedForReconnect(createServer(), {
+      allowInteractiveOAuthFlow: false,
+    });
+
+    expect(refreshOAuthTokensMock).toHaveBeenCalledWith(
+      "asana",
+      expect.objectContaining({
+        onTraceUpdate: undefined,
+      }),
+    );
+    expect(readStoredOAuthConfigMock).not.toHaveBeenCalled();
+    expect(initiateOAuthMock).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "reauth_required",
+        error: expect.stringContaining("Click Reconnect"),
+      }),
+    );
+  });
+
+  it("still starts the browser flow when interactive OAuth is allowed", async () => {
+    refreshOAuthTokensMock.mockResolvedValue({
+      success: false,
+      error: "invalid_grant",
+    });
+    initiateOAuthMock.mockResolvedValue({ success: true });
+    const beforeRedirect = vi.fn();
+
+    const result = await ensureAuthorizedForReconnect(createServer(), {
+      allowInteractiveOAuthFlow: true,
+      beforeRedirect,
+    });
+
+    expect(beforeRedirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverName: "asana",
+        serverUrl: "https://mcp.asana.com/sse",
+      }),
+    );
+    expect(initiateOAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverName: "asana",
+        serverUrl: "https://mcp.asana.com/sse",
+      }),
+    );
+    expect(result).toEqual({ kind: "redirect" });
+  });
+});

--- a/mcpjam-inspector/client/src/state/__tests__/storage.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/storage.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { AppState, ServerWithName, Workspace } from "../app-types";
+import { loadAppState, saveAppState } from "../storage";
+
+function createServer(
+  name: string,
+  overrides: Partial<ServerWithName> = {},
+): ServerWithName {
+  return {
+    name,
+    config: { url: new URL("https://mcp.example.com") } as ServerWithName["config"],
+    connectionStatus: "connected",
+    lastConnectionTime: new Date("2026-04-10T12:00:00.000Z"),
+    retryCount: 0,
+    enabled: true,
+    ...overrides,
+  } as ServerWithName;
+}
+
+function createState(server: ServerWithName): AppState {
+  const workspace: Workspace = {
+    id: "default",
+    name: "Default",
+    servers: { [server.name]: server },
+    createdAt: new Date("2026-04-10T12:00:00.000Z"),
+    updatedAt: new Date("2026-04-10T12:00:00.000Z"),
+    isDefault: true,
+  };
+
+  return {
+    workspaces: { default: workspace },
+    activeWorkspaceId: "default",
+    servers: { [server.name]: server },
+    selectedServer: server.name,
+    selectedMultipleServers: [],
+    isMultiSelectMode: false,
+  };
+}
+
+describe("storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("does not persist live oauth traces in saved app state", () => {
+    const server = createServer("asana", {
+      lastOAuthTrace: {
+        version: 1,
+        source: "interactive_connect",
+        serverName: "asana",
+        currentStep: "token_request",
+        steps: [],
+        httpHistory: [],
+      },
+    });
+
+    saveAppState(createState(server));
+
+    const persistedState = JSON.parse(
+      localStorage.getItem("mcp-inspector-state") ?? "{}",
+    );
+    const persistedWorkspaces = JSON.parse(
+      localStorage.getItem("mcp-inspector-workspaces") ?? "{}",
+    );
+
+    expect(persistedState.servers.asana.lastOAuthTrace).toBeUndefined();
+    expect(
+      persistedWorkspaces.workspaces.default.servers.asana.lastOAuthTrace,
+    ).toBeUndefined();
+  });
+
+  it("drops persisted oauth traces on load and clears legacy trace storage", () => {
+    localStorage.setItem(
+      "mcp-oauth-trace-asana",
+      JSON.stringify({
+        version: 1,
+        source: "interactive_connect",
+        currentStep: "token_request",
+        steps: [],
+        httpHistory: [],
+      }),
+    );
+    localStorage.setItem(
+      "mcp-inspector-state",
+      JSON.stringify({
+        selectedServer: "asana",
+        servers: {
+          asana: {
+            name: "asana",
+            config: { url: "https://mcp.example.com" },
+            connectionStatus: "connected",
+            lastConnectionTime: "2026-04-10T12:00:00.000Z",
+            retryCount: 0,
+            enabled: true,
+            lastOAuthTrace: {
+              version: 1,
+              source: "interactive_connect",
+              currentStep: "token_request",
+              steps: [],
+              httpHistory: [],
+            },
+          },
+        },
+      }),
+    );
+
+    const state = loadAppState();
+
+    expect(state.servers.asana.lastOAuthTrace).toBeUndefined();
+    expect(localStorage.getItem("mcp-oauth-trace-asana")).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -17,14 +17,35 @@ export type OAuthReady = {
   oauthTrace?: OAuthTrace;
 };
 export type OAuthRedirect = { kind: "redirect" };
+export type OAuthReauthRequired = {
+  kind: "reauth_required";
+  error: string;
+  oauthTrace?: OAuthTrace;
+};
 export type OAuthError = { kind: "error"; error: string; oauthTrace?: OAuthTrace };
-export type OAuthResult = OAuthReady | OAuthRedirect | OAuthError;
+export type OAuthResult =
+  | OAuthReady
+  | OAuthRedirect
+  | OAuthReauthRequired
+  | OAuthError;
+
+function buildOAuthReauthRequired(
+  serverName: string,
+  oauthTrace?: OAuthTrace,
+): OAuthReauthRequired {
+  return {
+    kind: "reauth_required",
+    error: `OAuth consent is required for ${serverName}. Click Reconnect to continue.`,
+    oauthTrace,
+  };
+}
 
 export async function ensureAuthorizedForReconnect(
   server: ServerWithName,
   options?: {
     beforeRedirect?: (oauthOptions: MCPOAuthOptions) => void;
     onTraceUpdate?: (trace: OAuthTrace) => void;
+    allowInteractiveOAuthFlow?: boolean;
   },
 ): Promise<OAuthResult> {
   // If server is explicitly configured without OAuth, skip OAuth flow entirely
@@ -44,6 +65,7 @@ export async function ensureAuthorizedForReconnect(
   }
 
   // If OAuth was configured, try to refresh or re-initiate
+  let refreshTrace: OAuthTrace | undefined;
   if (server.oauthTokens) {
     // Try refresh first
     const refreshed = await refreshOAuthTokens(server.name, {
@@ -57,16 +79,29 @@ export async function ensureAuthorizedForReconnect(
         oauthTrace: refreshed.oauthTrace,
       };
     }
+    refreshTrace = refreshed.oauthTrace;
+  }
+
+  const storedServerUrl = localStorage.getItem(`mcp-serverUrl-${server.name}`);
+  const url = (server.config as any)?.url?.toString?.() || storedServerUrl;
+
+  if (options?.allowInteractiveOAuthFlow === false) {
+    if (url) {
+      return buildOAuthReauthRequired(server.name, refreshTrace);
+    }
+    return {
+      kind: "error",
+      error: "OAuth refresh failed and no URL present",
+      oauthTrace: refreshTrace,
+    };
   }
 
   // Fallback to a fresh OAuth flow if URL is present
   // This may redirect away; the hook should reflect oauth-flow state
-  const storedServerUrl = localStorage.getItem(`mcp-serverUrl-${server.name}`);
-  const storedClientInfo = localStorage.getItem(`mcp-client-${server.name}`);
-  const storedTokens = getStoredTokens(server.name);
-
-  const url = (server.config as any)?.url?.toString?.() || storedServerUrl;
   if (url) {
+    const storedClientInfo = localStorage.getItem(`mcp-client-${server.name}`);
+    const storedTokens = getStoredTokens(server.name);
+
     // Get stored OAuth configuration
     const oauthConfig = readStoredOAuthConfig(server.name);
     const clientInfo = storedClientInfo ? JSON.parse(storedClientInfo) : {};

--- a/mcpjam-inspector/client/src/state/storage.ts
+++ b/mcpjam-inspector/client/src/state/storage.ts
@@ -5,13 +5,22 @@ import {
   Workspace,
 } from "./app-types";
 import { isWorkspaceClientConfig } from "@/lib/client-config";
-import { loadOAuthTrace } from "@/lib/oauth/oauth-trace";
+import { clearPersistedOAuthTraces } from "@/lib/oauth/oauth-trace";
 
 const STORAGE_KEY = "mcp-inspector-state";
 const WORKSPACES_STORAGE_KEY = "mcp-inspector-workspaces";
 
+function omitLiveOAuthTrace<T extends { lastOAuthTrace?: unknown }>(
+  server: T,
+): Omit<T, "lastOAuthTrace"> {
+  const persistedServer = { ...server };
+  delete persistedServer.lastOAuthTrace;
+  return persistedServer;
+}
+
 function reviveServer(name: string, server: any): ServerWithName {
-  const cfg: any = server.config;
+  const persistedServer = omitLiveOAuthTrace(server ?? {});
+  const cfg: any = persistedServer.config;
   let nextCfg = cfg;
   if (cfg && typeof cfg.url === "string") {
     try {
@@ -21,23 +30,33 @@ function reviveServer(name: string, server: any): ServerWithName {
     }
   }
   return {
-    ...server,
-    name: server.name ?? name,
+    ...persistedServer,
+    name: persistedServer.name ?? name,
     config: nextCfg,
-    lastOAuthTrace:
-      server.lastOAuthTrace ??
-      (typeof window !== "undefined" ? loadOAuthTrace(server.name ?? name) : undefined),
-    connectionStatus: server.connectionStatus || "disconnected",
-    retryCount: server.retryCount || 0,
-    lastConnectionTime: server.lastConnectionTime
-      ? new Date(server.lastConnectionTime)
+    connectionStatus: persistedServer.connectionStatus || "disconnected",
+    retryCount: persistedServer.retryCount || 0,
+    lastConnectionTime: persistedServer.lastConnectionTime
+      ? new Date(persistedServer.lastConnectionTime)
       : new Date(),
-    enabled: server.enabled !== false,
+    enabled: persistedServer.enabled !== false,
   } as ServerWithName;
+}
+
+function serializeServerForStorage(server: ServerWithName) {
+  const persistedServer = omitLiveOAuthTrace(server);
+  const cfg: any = server.config;
+  const serializedConfig =
+    cfg && cfg.url instanceof URL ? { ...cfg, url: cfg.url.toString() } : cfg;
+
+  return {
+    ...persistedServer,
+    config: serializedConfig,
+  };
 }
 
 export function loadAppState(): AppState {
   try {
+    clearPersistedOAuthTraces();
     const raw = localStorage.getItem(STORAGE_KEY);
     const workspacesRaw = localStorage.getItem(WORKSPACES_STORAGE_KEY);
 
@@ -135,12 +154,7 @@ export function saveAppState(state: AppState) {
             ...workspace,
             servers: Object.fromEntries(
               Object.entries(workspace.servers).map(([name, server]) => {
-                const cfg: any = server.config;
-                const serializedConfig =
-                  cfg && cfg.url instanceof URL
-                    ? { ...cfg, url: cfg.url.toString() }
-                    : cfg;
-                return [name, { ...server, config: serializedConfig }];
+                return [name, serializeServerForStorage(server)];
               }),
             ),
           },
@@ -159,12 +173,7 @@ export function saveAppState(state: AppState) {
       isMultiSelectMode: state.isMultiSelectMode,
       servers: Object.fromEntries(
         Object.entries(state.servers).map(([name, server]) => {
-          const cfg: any = server.config;
-          const serializedConfig =
-            cfg && cfg.url instanceof URL
-              ? { ...cfg, url: cfg.url.toString() }
-              : cfg;
-          return [name, { ...server, config: serializedConfig }];
+          return [name, serializeServerForStorage(server)];
         }),
       ),
     };

--- a/sdk/src/oauth/state-machines/runner.ts
+++ b/sdk/src/oauth/state-machines/runner.ts
@@ -23,6 +23,8 @@ export type OAuthAuthorizationRequestResult =
 export interface OAuthStateMachineRunConfig
   extends OAuthStateMachineFactoryConfig {
   maxSteps?: number;
+  /** When true (default), trace snapshots redact secrets. Set false for local dev tooling. */
+  sanitizeTrace?: boolean;
   onAuthorizationRequest?: (input: {
     authorizationUrl: string;
     state: OAuthFlowState;
@@ -58,6 +60,7 @@ export async function runOAuthStateMachine(
     onAuthorizationRequest,
     onTraceUpdate,
     getState: providedGetState,
+    sanitizeTrace = true,
     ...machineConfig
   } = config;
 
@@ -73,6 +76,7 @@ export async function runOAuthStateMachine(
       trace: projectOAuthTraceSnapshot({
         state,
         context,
+        sanitize: sanitizeTrace,
       }),
       state,
       reason,

--- a/sdk/src/oauth/state-machines/trace.ts
+++ b/sdk/src/oauth/state-machines/trace.ts
@@ -283,6 +283,10 @@ function sanitizeOAuthHeaders(
   );
 }
 
+function cloneHttpHistoryEntry(entry: HttpHistoryEntry): HttpHistoryEntry {
+  return JSON.parse(JSON.stringify(entry)) as HttpHistoryEntry;
+}
+
 function sanitizeHttpHistoryEntry(entry: HttpHistoryEntry): HttpHistoryEntry {
   return {
     ...entry,
@@ -377,7 +381,8 @@ function inferStepEntry(
   context: OAuthTraceProjectionContext | undefined,
   step: OAuthFlowStep,
   condition: boolean,
-  details?: Record<string, unknown>,
+  details: Record<string, unknown> | undefined,
+  sanitize: boolean,
 ): void {
   if (!condition || entries.has(step)) {
     return;
@@ -390,14 +395,18 @@ function inferStepEntry(
     context.lastSyntheticTimestamp = timestamp;
   }
 
+  const projectedDetails =
+    details == null
+      ? undefined
+      : (sanitize
+          ? (sanitizeOAuthTraceValue(details) as Record<string, unknown>)
+          : (JSON.parse(JSON.stringify(details)) as Record<string, unknown>));
+
   entries.set(step, {
     step,
     startedAt: timestamp,
     completedAt: timestamp,
-    details:
-      details == null
-        ? undefined
-        : (sanitizeOAuthTraceValue(details) as Record<string, unknown>),
+    details: projectedDetails,
   });
 }
 
@@ -508,14 +517,19 @@ function usesRecoveredDynamicClientRegistrationFallback(
 export function projectOAuthTraceSnapshot(input: {
   state: OAuthFlowState;
   context?: OAuthTraceProjectionContext;
+  /**
+   * When true (default), redact tokens/secrets/PII from traces. SDK consumers
+   * that are local dev tools may set false to show raw request/response data.
+   */
+  sanitize?: boolean;
 }): OAuthTraceSnapshot {
-  const { state, context } = input;
+  const { state, context, sanitize: sanitizeTraces = true } = input;
   const trace: OAuthTraceSnapshot = {
     version: 1,
     currentStep: state.currentStep,
     steps: [],
     httpHistory: (state.httpHistory ?? []).map((entry) =>
-      sanitizeHttpHistoryEntry(entry),
+      sanitizeTraces ? sanitizeHttpHistoryEntry(entry) : cloneHttpHistoryEntry(entry),
     ),
     ...(state.error ? { error: state.error } : {}),
   };
@@ -527,9 +541,15 @@ export function projectOAuthTraceSnapshot(input: {
     const record = ensureStepEntry(entries, context, entry.step, entry.timestamp);
     if (!record.details) {
       record.details = {
-        request: sanitizeOAuthTraceValue(entry.request),
+        request: (sanitizeTraces
+          ? sanitizeOAuthTraceValue(entry.request)
+          : entry.request) as Record<string, unknown>,
         ...(entry.response
-          ? { response: sanitizeOAuthTraceValue(entry.response) }
+          ? {
+              response: (sanitizeTraces
+                ? sanitizeOAuthTraceValue(entry.response)
+                : entry.response) as Record<string, unknown>,
+            }
           : {}),
       };
     }
@@ -542,14 +562,16 @@ export function projectOAuthTraceSnapshot(input: {
   for (const log of state.infoLogs ?? []) {
     const record = ensureStepEntry(entries, context, log.step, log.timestamp);
     record.message = log.label;
-    const sanitizedLogData = sanitizeOAuthTraceValue(log.data);
+    const logData = sanitizeTraces
+      ? sanitizeOAuthTraceValue(log.data)
+      : log.data;
     if (
-      sanitizedLogData &&
-      typeof sanitizedLogData === "object" &&
-      sanitizedLogData !== null &&
-      !Array.isArray(sanitizedLogData)
+      logData &&
+      typeof logData === "object" &&
+      logData !== null &&
+      !Array.isArray(logData)
     ) {
-      record.details = sanitizedLogData as Record<string, unknown>;
+      record.details = logData as Record<string, unknown>;
     }
     if (log.error?.message) {
       record.error = log.error.message;
@@ -569,32 +591,73 @@ export function projectOAuthTraceSnapshot(input: {
     );
   }
 
-  inferStepEntry(entries, context, "request_client_registration", Boolean(state.clientId), {
-    clientId: state.clientId,
-  });
-  inferStepEntry(entries, context, "received_client_credentials", Boolean(state.clientId), {
-    clientId: state.clientId,
-  });
-  inferStepEntry(entries, context, "generate_pkce_parameters", Boolean(state.codeVerifier), {
-    codeVerifier: redactSensitiveValue(state.codeVerifier),
-  });
-  inferStepEntry(entries, context, "authorization_request", Boolean(state.authorizationUrl), {
-    authorizationUrl: state.authorizationUrl,
-  });
+  inferStepEntry(
+    entries,
+    context,
+    "request_client_registration",
+    Boolean(state.clientId),
+    {
+      clientId: state.clientId,
+    },
+    sanitizeTraces,
+  );
+  inferStepEntry(
+    entries,
+    context,
+    "received_client_credentials",
+    Boolean(state.clientId),
+    {
+      clientId: state.clientId,
+    },
+    sanitizeTraces,
+  );
+  inferStepEntry(
+    entries,
+    context,
+    "generate_pkce_parameters",
+    Boolean(state.codeVerifier),
+    {
+      codeVerifier: state.codeVerifier,
+    },
+    sanitizeTraces,
+  );
+  inferStepEntry(
+    entries,
+    context,
+    "authorization_request",
+    Boolean(state.authorizationUrl),
+    {
+      authorizationUrl: state.authorizationUrl,
+    },
+    sanitizeTraces,
+  );
   inferStepEntry(
     entries,
     context,
     "received_authorization_code",
     Boolean(state.authorizationCode),
-    state.authorizationCode
-      ? { code: redactSensitiveValue(state.authorizationCode) }
-      : undefined,
+    state.authorizationCode ? { code: state.authorizationCode } : undefined,
+    sanitizeTraces,
   );
-  inferStepEntry(entries, context, "received_access_token", Boolean(state.accessToken), {
-    tokenType: state.tokenType,
-    expiresIn: state.expiresIn,
-  });
-  inferStepEntry(entries, context, "complete", state.currentStep === "complete");
+  inferStepEntry(
+    entries,
+    context,
+    "received_access_token",
+    Boolean(state.accessToken),
+    {
+      tokenType: state.tokenType,
+      expiresIn: state.expiresIn,
+    },
+    sanitizeTraces,
+  );
+  inferStepEntry(
+    entries,
+    context,
+    "complete",
+    state.currentStep === "complete",
+    undefined,
+    sanitizeTraces,
+  );
 
   const registrationEntry = entries.get("request_client_registration");
   if (
@@ -617,7 +680,7 @@ export function projectOAuthTraceSnapshot(input: {
     !usesRecoveredDynamicClientRegistrationFallback(state) &&
     !entries.has(state.currentStep)
   ) {
-    inferStepEntry(entries, context, state.currentStep, true);
+    inferStepEntry(entries, context, state.currentStep, true, undefined, sanitizeTraces);
     const currentEntry = entries.get(state.currentStep);
     if (currentEntry) {
       currentEntry.error = state.error;

--- a/sdk/tests/oauth/trace-projection.test.ts
+++ b/sdk/tests/oauth/trace-projection.test.ts
@@ -62,4 +62,32 @@ describe("OAuth trace projection", () => {
       status: "success",
     });
   });
+
+  it("omits redaction for PKCE and authorization code when sanitize is false", () => {
+    const snapshot = projectOAuthTraceSnapshot({
+      state: {
+        ...EMPTY_OAUTH_FLOW_STATE,
+        currentStep: "complete",
+        codeVerifier: "full-code-verifier-secret-value",
+        authorizationCode: "auth-code-abc123",
+        authorizationUrl:
+          "https://auth.example.com/authorize?client_id=x&code_challenge=challengexxx",
+        httpHistory: [],
+        infoLogs: [],
+      },
+      sanitize: false,
+    });
+
+    const pkceStep = snapshot.steps.find(
+      (step) => step.step === "generate_pkce_parameters",
+    );
+    const codeStep = snapshot.steps.find(
+      (step) => step.step === "received_authorization_code",
+    );
+
+    expect(pkceStep?.details).toMatchObject({
+      codeVerifier: "full-code-verifier-secret-value",
+    });
+    expect(codeStep?.details).toMatchObject({ code: "auth-code-abc123" });
+  });
 });


### PR DESCRIPTION
## Summary
- Make the server-card and detail-modal toggles reuse existing auth only, so they do not start a fresh OAuth consent screen.
- Keep explicit Reconnect actions as the interactive path when a full OAuth flow is needed.
- Add OAuth debugger server selection via pub/sub so the CTA opens the right server context.
- Keep live OAuth traces in memory while preserving redacted persistence for reload/resume paths.

## Testing
- Added and updated unit tests for the reconnect toggle, hosted OAuth readiness checks, OAuth orchestrator behavior, logger CTA navigation, and trace persistence.
- Ran the targeted Vitest suites and a full client build successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth reconnect/orchestration and trace sanitization/persistence logic; mistakes could cause unwanted redirects or leak sensitive OAuth data in traces, especially in non-hosted builds.
> 
> **Overview**
> Prevents server enable/connect toggles (server cards + detail modal + readiness checks) from kicking off an interactive OAuth consent flow by threading a new `allowInteractiveOAuthFlow` flag through reconnect paths and returning a `reauth_required` result when consent is needed.
> 
> Adds an OAuth Debugger navigation pub/sub (`requestOpenOAuthDebugger` / `subscribeToOAuthDebuggerRequests`) and a LoggerView CTA on OAuth error rows that switches the selected server and deep-links to `#oauth-flow`.
> 
> Changes OAuth trace handling to keep *live* traces in-memory while stripping trace data from persisted OAuth flow sessions and saved app state, adds startup cleanup of legacy `mcp-oauth-trace-*` keys, and introduces configurable trace redaction (`SANITIZE_OAUTH_TRACES`, plus SDK `sanitizeTrace`/`sanitize` options) with updated tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0791ba631a9a31d0fdd9a0d1bbd3ad17e4306e55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->