### PR TITLE
Fix whoami UI gating by client capabilities

### DIFF
--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -3,13 +3,14 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/server";
 import type { ClientCapabilities } from "@modelcontextprotocol/sdk/types.js";
 import type { JWTPayload } from "jose";
-import { createSessionToolRegistrar } from "./tools/sessionToolRegistrar.js";
+import {
+  createSessionToolRegistrar,
+  type SessionToolRegistrar,
+} from "./tools/sessionToolRegistrar.js";
 import { registerDoctorTool } from "./tools/doctor.js";
 import { registerGetOrgTool } from "./tools/getOrg.js";
 import { registerGetWorkspacesTool } from "./tools/getWorkspaces.js";
 import { registerWhoamiTool } from "./tools/whoami.js";
-
-const UI_EXTENSION_ID = "io.modelcontextprotocol/ui";
 
 interface McpProps extends Record<string, unknown> {
   bearerToken: string;
@@ -17,6 +18,8 @@ interface McpProps extends Record<string, unknown> {
 }
 
 export class McpJamMcpServer extends McpAgent<Env, unknown, McpProps> {
+  private sessionToolRegistrar?: SessionToolRegistrar;
+
   server = new McpServer({
     name: "MCPJam MCP",
     version: "0.1.0",
@@ -31,39 +34,65 @@ export class McpJamMcpServer extends McpAgent<Env, unknown, McpProps> {
   }
 
   async init(): Promise<void> {
-    const registrar = createSessionToolRegistrar(this.server);
+    const initializeRequest = await this.getInitializeRequest();
+    const initializeClientCapabilities = (initializeRequest as
+      | { params?: { capabilities?: ClientCapabilities } }
+      | undefined)?.params?.capabilities;
+    const registrar = createSessionToolRegistrar(
+      this.server,
+      uiSupportsResourceMime(initializeClientCapabilities)
+    );
+    this.sessionToolRegistrar = registrar;
 
     registerWhoamiTool(registrar, this);
     registerDoctorTool(registrar, this);
     registerGetWorkspacesTool(registrar, this);
     registerGetOrgTool(registrar, this);
+  }
 
-    const initializeRequest = await this.getInitializeRequest();
-    const initializeClientCapabilities = (initializeRequest as
-      | { params?: { capabilities?: ClientCapabilities } }
-      | undefined)?.params?.capabilities;
+  override async onConnect(conn: any, context: { request: Request }): Promise<void> {
+    this.applyUiModeFromRawRequest(context.request);
+    await super.onConnect(conn, context as any);
+  }
 
-    registrar.setUiEnabled(isUiEnabled(initializeClientCapabilities));
+  private applyUiModeFromRawRequest(request: Request): void {
+    if (
+      !this.sessionToolRegistrar ||
+      this.getTransportType() !== "streamable-http" ||
+      request.headers.get("cf-mcp-method") !== "POST"
+    ) {
+      return;
+    }
 
-    this.server.server.oninitialized = () => {
-      registrar.setUiEnabled(
-        isUiEnabled(this.server.server.getClientCapabilities())
-      );
-    };
+    const payloadHeader = request.headers.get("cf-mcp-message");
+    if (!payloadHeader) {
+      return;
+    }
+
+    try {
+      const rawPayload = Buffer.from(payloadHeader, "base64").toString("utf-8");
+      const parsedBody = JSON.parse(rawPayload) as unknown;
+      const messages = Array.isArray(parsedBody) ? parsedBody : [parsedBody];
+
+      for (const message of messages) {
+        const clientCapabilities = getInitializeCapabilities(message);
+        if (!clientCapabilities) {
+          continue;
+        }
+
+        this.sessionToolRegistrar.setUiEnabled(
+          uiSupportsResourceMime(clientCapabilities),
+          { notify: false }
+        );
+        return;
+      }
+    } catch {
+      // Ignore malformed headers and let the transport surface the real error.
+    }
   }
 }
 
-function getUiCapability(
-  clientCapabilities: ClientCapabilities | undefined
-): { mimeTypes?: string[] } | undefined {
-  const extensions = (clientCapabilities as
-    | (ClientCapabilities & { extensions?: Record<string, unknown> })
-    | undefined)?.extensions;
-
-  return extensions?.[UI_EXTENSION_ID] as { mimeTypes?: string[] } | undefined;
-}
-
-function isUiEnabled(
+function uiSupportsResourceMime(
   clientCapabilities: ClientCapabilities | undefined
 ): boolean {
   return (
@@ -71,4 +100,31 @@ function isUiEnabled(
       RESOURCE_MIME_TYPE
     ) ?? false
   );
+}
+
+function getUiCapability(
+  clientCapabilities:
+    | (ClientCapabilities & { extensions?: Record<string, unknown> })
+    | undefined
+): { mimeTypes?: string[] } | undefined {
+  return clientCapabilities?.extensions?.["io.modelcontextprotocol/ui"] as
+    | { mimeTypes?: string[] }
+    | undefined;
+}
+
+function getInitializeCapabilities(
+  message: unknown
+): ClientCapabilities | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+
+  const initializeMessage = message as {
+    method?: unknown;
+    params?: { capabilities?: ClientCapabilities };
+  };
+
+  return initializeMessage.method === "initialize"
+    ? initializeMessage.params?.capabilities
+    : undefined;
 }

--- a/mcp/src/tools/sessionToolRegistrar.ts
+++ b/mcp/src/tools/sessionToolRegistrar.ts
@@ -1,10 +1,11 @@
 import {
   RESOURCE_MIME_TYPE,
-  registerAppResource,
+  RESOURCE_URI_META_KEY,
   registerAppTool,
 } from "@modelcontextprotocol/ext-apps/server";
 import type {
   McpServer,
+  RegisteredResource,
   RegisteredTool,
   ToolCallback,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -47,10 +48,39 @@ export interface SessionToolRegistrar {
     callback: ToolCallback<InputArgs>,
     ui?: ToolUiConfig<InputArgs>
   ): RegisteredTool;
-  setUiEnabled(enabled: boolean): void;
+  setUiEnabled(enabled: boolean, options?: SetUiEnabledOptions): void;
 }
 
-export function createSessionToolRegistrar(server: McpServer): SessionToolRegistrar {
+type SetUiEnabledOptions = {
+  notify?: boolean;
+};
+
+type MutableRegisteredTool = RegisteredTool & {
+  _meta?: Record<string, unknown>;
+  enabled: boolean;
+  handler: ToolCallback<any>;
+};
+
+type MutableRegisteredResource = RegisteredResource & {
+  enabled: boolean;
+};
+
+type UiAwareRegistration = {
+  plainCallback: ToolCallback<any>;
+  plainMeta: Record<string, unknown> | undefined;
+  resource: MutableRegisteredResource;
+  tool: MutableRegisteredTool;
+  uiCallback: ToolCallback<any>;
+  uiMeta: Record<string, unknown>;
+};
+
+export function createSessionToolRegistrar(
+  server: McpServer,
+  uiEnabled: boolean
+): SessionToolRegistrar {
+  const uiAwareRegistrations: UiAwareRegistration[] = [];
+  let currentUiEnabled = uiEnabled;
+
   return {
     registerTool<
       OutputArgs extends ZodRawShapeCompat | AnySchema,
@@ -65,26 +95,26 @@ export function createSessionToolRegistrar(server: McpServer): SessionToolRegist
         return server.registerTool(name, config, callback);
       }
 
-      const tool = registerAppTool(
-        server,
-        name,
-        {
-          ...config,
-          _meta: {
-            ...(config._meta ?? {}),
-            ui: {
-              resourceUri: ui.resourceUri,
-            },
-          },
-        } as any,
-        (ui.callback ?? callback) as any
-      );
+      const plainMeta = stripToolUiMeta(config._meta);
+      const uiMeta = createToolUiMeta(config._meta, ui.resourceUri);
+      const uiCallback = (ui.callback ?? callback) as ToolCallback<any>;
+      const tool = currentUiEnabled
+        ? registerAppTool(
+            server,
+            name,
+            {
+              ...config,
+              _meta: uiMeta,
+            } as any,
+            uiCallback as any
+          )
+        : server.registerTool(name, { ...config, _meta: plainMeta }, callback);
 
-      registerAppResource(
-        server,
+      const resource = server.registerResource(
         ui.resourceName ?? `${config.title ?? name} UI`,
         ui.resourceUri,
         {
+          mimeType: RESOURCE_MIME_TYPE,
           description:
             ui.resourceDescription ?? `${config.title ?? name} interactive UI`,
           _meta: ui.resourceMeta,
@@ -101,12 +131,98 @@ export function createSessionToolRegistrar(server: McpServer): SessionToolRegist
         })
       );
 
+      if (!currentUiEnabled) {
+        resource.disable();
+      }
+
+      uiAwareRegistrations.push({
+        plainCallback: callback as ToolCallback<any>,
+        plainMeta,
+        resource: resource as MutableRegisteredResource,
+        tool: tool as MutableRegisteredTool,
+        uiCallback,
+        uiMeta,
+      });
+
       return tool;
     },
-    setUiEnabled() {
-      // The hosted example server always advertises its app tool and relies on
-      // the host to ignore UI metadata when unsupported. Keep the method for
-      // compatibility with existing call sites.
+    setUiEnabled(enabled, options) {
+      if (currentUiEnabled === enabled) {
+        return;
+      }
+
+      currentUiEnabled = enabled;
+      const notify = options?.notify ?? true;
+
+      for (const registration of uiAwareRegistrations) {
+        applyUiEnabledState(registration, enabled, notify);
+      }
     },
   };
+}
+
+function applyUiEnabledState(
+  registration: UiAwareRegistration,
+  enabled: boolean,
+  notify: boolean
+): void {
+  if (notify) {
+    registration.tool.update({
+      _meta: enabled ? registration.uiMeta : (registration.plainMeta ?? {}),
+      callback: enabled
+        ? registration.uiCallback
+        : registration.plainCallback,
+    } as any);
+
+    if (enabled) {
+      registration.resource.enable();
+    } else {
+      registration.resource.disable();
+    }
+
+    return;
+  }
+
+  registration.tool._meta = enabled
+    ? registration.uiMeta
+    : (registration.plainMeta ?? {});
+  registration.tool.handler = enabled
+    ? registration.uiCallback
+    : registration.plainCallback;
+  registration.resource.enabled = enabled;
+}
+
+function createToolUiMeta(
+  meta: Record<string, unknown> | undefined,
+  resourceUri: string
+): Record<string, unknown> {
+  const uiMeta =
+    meta?.ui && typeof meta.ui === "object" && !Array.isArray(meta.ui)
+      ? (meta.ui as Record<string, unknown>)
+      : undefined;
+
+  return {
+    ...(stripToolUiMeta(meta) ?? {}),
+    ui: {
+      ...(uiMeta ?? {}),
+      resourceUri,
+    },
+    [RESOURCE_URI_META_KEY]: resourceUri,
+  };
+}
+
+function stripToolUiMeta(
+  meta: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!meta) {
+    return undefined;
+  }
+
+  const {
+    [RESOURCE_URI_META_KEY]: _resourceUri,
+    ui: _ui,
+    ...plainMeta
+  } = meta;
+
+  return Object.keys(plainMeta).length > 0 ? plainMeta : undefined;
 }


### PR DESCRIPTION
## Summary
- Gate the `whoami` app surface off the client’s UI extension and register the UI resource only when supported.
- Keep a fallback mutation path so the tool and resource handles can flip between UI and text-only behavior.
- Validate the behavior with `mcpjam` CLI against the live worker: UI-capable clients expose `ui://mcpjam/whoami.html` and `structuredContent`, while text-only clients do not.

## Testing
- `./node_modules/.bin/tsc -p mcp/tsconfig.json --noEmit`
- `mcpjam server export` and `resources list` against the live worker in both UI-capable and text-only modes
- `mcpjam tools call --tool-name whoami` in both modes to confirm `structuredContent` is only returned for UI-capable clients

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how tools and resources are registered/updated based on client capabilities and request headers, which could affect tool behavior and resource visibility across transports if mis-detected.
> 
> **Overview**
> Fixes UI gating so app-backed tools (e.g. `whoami`) only advertise UI metadata and expose their `ui://` resource when the client declares the UI extension with `RESOURCE_MIME_TYPE` support.
> 
> `createSessionToolRegistrar` now tracks UI-aware tool/resource registrations and can flip them between UI and plain modes by updating tool `_meta`/callback and enabling or disabling the registered resource (optionally without emitting update notifications).
> 
> `McpJamMcpServer` now initializes the registrar with capability-derived UI mode and, for `streamable-http`, parses Cloudflare MCP request headers (`cf-mcp-message`) on connect to set UI mode from the incoming `initialize` message when available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7ce744684653e64b76ff89becf63007d0d31c7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->