### PR TITLE
only show oauth servers for debugger or xaa

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1656,11 +1656,7 @@ export default function App() {
   const activeServerSelectorProps: ActiveServerSelectorProps | undefined =
     shouldShowActiveServerSelector
       ? {
-          serverConfigs:
-            activeTab === "oauth-flow" ||
-            (activeTab === "xaa-flow" && xaaEnabled === true)
-              ? appState.servers
-              : workspaceServers,
+          serverConfigs: workspaceServers,
           selectedServer: appState.selectedServer,
           onServerChange: setSelectedServer,
           onConnect: handleConnect,
@@ -1668,7 +1664,12 @@ export default function App() {
           isMultiSelectEnabled: activeTab === "chat",
           onMultiServerToggle: toggleServerSelection,
           selectedMultipleServers: appState.selectedMultipleServers,
-          showOnlyOAuthServers: false,
+          showOnlyOAuthServers:
+            activeTab === "oauth-flow" ||
+            (activeTab === "xaa-flow" && xaaEnabled === true),
+          autoSelectFilteredServer:
+            activeTab !== "oauth-flow" &&
+            !(activeTab === "xaa-flow" && xaaEnabled === true),
           showOnlyServersWithViews: activeTab === "views",
           serversWithViews: serversWithViews,
           hasMessages: false,
@@ -1943,7 +1944,6 @@ export default function App() {
               <XAAFlowTab
                 serverConfigs={appState.servers}
                 selectedServerName={appState.selectedServer}
-                onSelectServer={setSelectedServer}
               />
             </ErrorBoundary>
           )}

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -32,6 +32,7 @@ const {
   mockConvexAuthState,
   mockCompleteHostedOAuthCallback,
   mockHandleOAuthCallback,
+  mockHeader,
   mockHostedShellGateState,
   mockMCPSidebar,
   mockOrganizationsTab,
@@ -128,6 +129,7 @@ const {
     mockUseFeatureFlagEnabled: vi.fn(),
     mockUseQuery: vi.fn(() => undefined),
     mockChatboxesTab: vi.fn(() => <div>Chatboxes Tab</div>),
+    mockHeader: vi.fn((_props: unknown) => <div data-testid="app-header" />),
     mockWorkOsAuthState: {
       getAccessToken: vi.fn(),
       signIn: vi.fn(),
@@ -330,7 +332,7 @@ vi.mock("../components/LoadingScreen", () => ({
   default: () => <div data-testid="hosted-oauth-loading" />,
 }));
 vi.mock("../components/Header", () => ({
-  Header: () => <div data-testid="app-header" />,
+  Header: (props: unknown) => mockHeader(props),
 }));
 vi.mock("../components/hosted/HostedShellGate", () => ({
   HostedShellGate: ({ children }: { children?: ReactNode }) => (
@@ -385,6 +387,10 @@ describe("App hosted OAuth callback handling", () => {
     mockOrganizationsTab.mockImplementation(() => <div />);
     mockChatboxesTab.mockReset();
     mockChatboxesTab.mockImplementation(() => <div>Chatboxes Tab</div>);
+    mockHeader.mockReset();
+    mockHeader.mockImplementation((_props: unknown) => (
+      <div data-testid="app-header" />
+    ));
     mockMCPSidebar.mockReset();
     mockMCPSidebar.mockImplementation(() => <div data-testid="mcp-sidebar" />);
     mockPosthogCapture.mockReset();
@@ -2275,6 +2281,135 @@ describe("App hosted OAuth callback handling", () => {
 
     expect(window.location.hash).toBe("#xaa-flow");
     expect(screen.queryByText("Servers Tab")).not.toBeInTheDocument();
+  });
+
+  it("passes OAuth-only workspace server selector props on the XAA Debugger tab", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    window.history.replaceState({}, "", "/#xaa-flow");
+    mockHandleOAuthCallback.mockReset();
+    mockUseFeatureFlagEnabled.mockImplementation((flag: string) =>
+      flag === "xaa" ? true : false,
+    );
+    const appStateMock = createAppStateMock();
+    const currentWorkspaceServers = {
+      "current-workspace-xaa-oauth": {
+        name: "current-workspace-xaa-oauth",
+        config: { url: "https://current-xaa.example/mcp" },
+        connectionStatus: "connected",
+        enabled: true,
+        retryCount: 0,
+        useOAuth: true,
+        lastConnectionTime: new Date("2024-01-01"),
+      },
+    };
+    appStateMock.workspaceServers = currentWorkspaceServers;
+    appStateMock.appState.servers = {
+      ...currentWorkspaceServers,
+      "other-workspace-xaa-oauth": {
+        name: "other-workspace-xaa-oauth",
+        config: { url: "https://other-xaa.example/mcp" },
+        connectionStatus: "connected",
+        enabled: true,
+        retryCount: 0,
+        useOAuth: true,
+        lastConnectionTime: new Date("2024-01-02"),
+      },
+    };
+    mockUseAppState.mockImplementation(() => appStateMock);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockHeader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activeServerSelectorProps: expect.objectContaining({
+            showOnlyOAuthServers: true,
+            autoSelectFilteredServer: false,
+          }),
+        }),
+      );
+    });
+
+    const latestProps = mockHeader.mock.calls.at(-1)?.[0] as {
+      activeServerSelectorProps?: { serverConfigs?: unknown };
+    };
+    expect(latestProps.activeServerSelectorProps?.serverConfigs).toBe(
+      currentWorkspaceServers,
+    );
+  });
+
+  it("passes OAuth-only server selector props on the OAuth Debugger tab", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    window.history.replaceState({}, "", "/#oauth-flow");
+    mockHandleOAuthCallback.mockReset();
+    const appStateMock = createAppStateMock();
+    const currentWorkspaceServers = {
+      "current-workspace-oauth": {
+        name: "current-workspace-oauth",
+        config: { url: "https://current.example/mcp" },
+        connectionStatus: "connected",
+        enabled: true,
+        retryCount: 0,
+        useOAuth: true,
+        lastConnectionTime: new Date("2024-01-01"),
+      },
+    };
+    appStateMock.workspaceServers = currentWorkspaceServers;
+    appStateMock.appState.servers = {
+      ...currentWorkspaceServers,
+      "other-workspace-oauth": {
+        name: "other-workspace-oauth",
+        config: { url: "https://other.example/mcp" },
+        connectionStatus: "connected",
+        enabled: true,
+        retryCount: 0,
+        useOAuth: true,
+        lastConnectionTime: new Date("2024-01-02"),
+      },
+    };
+    mockUseAppState.mockImplementation(() => appStateMock);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockHeader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activeServerSelectorProps: expect.objectContaining({
+            showOnlyOAuthServers: true,
+            autoSelectFilteredServer: false,
+          }),
+        }),
+      );
+    });
+
+    const latestProps = mockHeader.mock.calls.at(-1)?.[0] as {
+      activeServerSelectorProps?: { serverConfigs?: unknown };
+    };
+    expect(latestProps.activeServerSelectorProps?.serverConfigs).toBe(
+      currentWorkspaceServers,
+    );
+  });
+
+  it("leaves the header server selector unfiltered outside the OAuth Debugger tab", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    window.history.replaceState({}, "", "/#tools");
+    mockHandleOAuthCallback.mockReset();
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockHeader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activeServerSelectorProps: expect.objectContaining({
+            showOnlyOAuthServers: false,
+            autoSelectFilteredServer: true,
+          }),
+        }),
+      );
+    });
   });
 
   it("still applies the CI billing redirect when evaluate-runs is enabled", async () => {

--- a/mcpjam-inspector/client/src/components/ActiveServerSelector.tsx
+++ b/mcpjam-inspector/client/src/components/ActiveServerSelector.tsx
@@ -35,6 +35,7 @@ export interface ActiveServerSelectorProps {
   onReconnect?: (serverName: string) => Promise<void>;
   showOnlyOAuthServers?: boolean; // Only show servers that use OAuth
   showOnlyServersWithViews?: boolean; // Only show servers that have saved views
+  autoSelectFilteredServer?: boolean; // Auto-select when current selection is hidden by filters
   serversWithViews?: Set<string>; // Set of server names that have saved views
   hasMessages?: boolean; // Reserved for callers that still compute this
   className?: string;
@@ -87,6 +88,7 @@ export function ActiveServerSelector({
   onReconnect,
   showOnlyOAuthServers = false,
   showOnlyServersWithViews = false,
+  autoSelectFilteredServer = true,
   serversWithViews,
   className,
 }: ActiveServerSelectorProps) {
@@ -103,8 +105,9 @@ export function ActiveServerSelector({
     const isHttpServer = "url" in server.config;
     if (!isHttpServer) return false;
 
-    // Check if server has OAuth tokens, OAuth config in localStorage, or is in oauth-flow state
+    // Check if server is configured for OAuth, has OAuth state, or is mid-flow.
     return !!(
+      server.useOAuth === true ||
       server.oauthTokens ||
       hasOAuthConfig(server.name) ||
       server.connectionStatus === "oauth-flow"
@@ -119,7 +122,13 @@ export function ActiveServerSelector({
 
   // Auto-select first available server if current selection is not in the list
   useEffect(() => {
-    if (isMultiSelectEnabled || hasNoServersWithViews) return;
+    if (
+      !autoSelectFilteredServer ||
+      isMultiSelectEnabled ||
+      hasNoServersWithViews
+    ) {
+      return;
+    }
 
     const serverNames = servers.map(([name]) => name);
     const isCurrentSelectionValid = serverNames.includes(selectedServer);
@@ -142,6 +151,7 @@ export function ActiveServerSelector({
     isMultiSelectEnabled,
     onServerChange,
     hasNoServersWithViews,
+    autoSelectFilteredServer,
   ]);
 
   const handleServerClick = (name: string) => {

--- a/mcpjam-inspector/client/src/components/ActiveServerSelector.tsx
+++ b/mcpjam-inspector/client/src/components/ActiveServerSelector.tsx
@@ -104,6 +104,7 @@ export function ActiveServerSelector({
   const isOAuthServer = (server: ServerWithName): boolean => {
     const isHttpServer = "url" in server.config;
     if (!isHttpServer) return false;
+    if (server.useOAuth === false) return false;
 
     // Check if server is configured for OAuth, has OAuth state, or is mid-flow.
     return !!(

--- a/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/OAuthFlowTab.tsx
@@ -112,8 +112,10 @@ export const OAuthFlowTab = ({
     useState(false);
   const [isApplyingTokens, setIsApplyingTokens] = useState(false);
 
-  const httpServers = useMemo(
-    () => Object.values(serverConfigs).filter((server) => isHttpServer(server)),
+  const httpServerCount = useMemo(
+    () =>
+      Object.values(serverConfigs).filter((server) => isHttpServer(server))
+        .length,
     [serverConfigs],
   );
 
@@ -124,12 +126,6 @@ export const OAuthFlowTab = ({
   const activeServer = isHttpServer(selectedServer)
     ? selectedServer
     : undefined;
-
-  useEffect(() => {
-    if (!isHttpServer(selectedServer) && httpServers.length > 0) {
-      onSelectServer(httpServers[0].name);
-    }
-  }, [selectedServer, httpServers, onSelectServer]);
 
   useEffect(() => {
     if (
@@ -143,10 +139,10 @@ export const OAuthFlowTab = ({
   }, [pendingServerSelection, serverConfigs, onSelectServer]);
 
   useEffect(() => {
-    if (httpServers.length === 0) {
+    if (httpServerCount === 0) {
       setIsProfileModalOpen(true);
     }
-  }, [httpServers.length]);
+  }, [httpServerCount]);
 
   const profile = useMemo(
     () => deriveOAuthProfileFromServer(activeServer),

--- a/mcpjam-inspector/client/src/components/__tests__/ActiveServerSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ActiveServerSelector.test.tsx
@@ -200,7 +200,9 @@ describe("ActiveServerSelector", () => {
 
     it("filters to OAuth HTTP servers when requested", () => {
       vi.mocked(hasOAuthConfig).mockImplementation(
-        (serverName) => serverName === "stored-config-oauth",
+        (serverName) =>
+          serverName === "stored-config-oauth" ||
+          serverName === "opted-out-stored-config",
       );
       const httpConfig = {
         transportType: "streamableHttp",
@@ -223,16 +225,30 @@ describe("ActiveServerSelector", () => {
         "token-oauth": createServer({
           name: "token-oauth",
           config: httpConfig,
+          useOAuth: undefined,
           oauthTokens,
         }),
         "stored-config-oauth": createServer({
           name: "stored-config-oauth",
           config: httpConfig,
+          useOAuth: undefined,
         }),
         "flow-oauth": createServer({
           name: "flow-oauth",
           config: httpConfig,
+          useOAuth: undefined,
           connectionStatus: "oauth-flow",
+        }),
+        "opted-out-token-oauth": createServer({
+          name: "opted-out-token-oauth",
+          config: httpConfig,
+          useOAuth: false,
+          oauthTokens,
+        }),
+        "opted-out-stored-config": createServer({
+          name: "opted-out-stored-config",
+          config: httpConfig,
+          useOAuth: false,
         }),
         "plain-http": createServer({
           name: "plain-http",
@@ -258,6 +274,12 @@ describe("ActiveServerSelector", () => {
       expect(screen.getByText("token-oauth")).toBeInTheDocument();
       expect(screen.getByText("stored-config-oauth")).toBeInTheDocument();
       expect(screen.getByText("flow-oauth")).toBeInTheDocument();
+      expect(
+        screen.queryByText("opted-out-token-oauth"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("opted-out-stored-config"),
+      ).not.toBeInTheDocument();
       expect(screen.queryByText("plain-http")).not.toBeInTheDocument();
       expect(
         screen.queryByText("stdio-with-oauth-state"),

--- a/mcpjam-inspector/client/src/components/__tests__/ActiveServerSelector.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ActiveServerSelector.test.tsx
@@ -11,6 +11,7 @@ import {
   type ActiveServerSelectorProps,
 } from "../ActiveServerSelector";
 import type { ServerWithName } from "@/hooks/use-app-state";
+import { hasOAuthConfig } from "@/lib/oauth/mcp-oauth";
 
 // Mock posthog
 vi.mock("posthog-js/react", () => ({
@@ -195,6 +196,72 @@ describe("ActiveServerSelector", () => {
 
       expect(screen.queryByText("server-1")).not.toBeInTheDocument();
       expect(screen.getByText("server-2")).toBeInTheDocument();
+    });
+
+    it("filters to OAuth HTTP servers when requested", () => {
+      vi.mocked(hasOAuthConfig).mockImplementation(
+        (serverName) => serverName === "stored-config-oauth",
+      );
+      const httpConfig = {
+        transportType: "streamableHttp",
+        url: "http://localhost:3000/mcp",
+      } as const;
+      const oauthTokens = {
+        client_id: "client-id",
+        client_secret: "client-secret",
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+        expires_in: 3600,
+        scope: "read",
+      };
+      const serverConfigs = {
+        "explicit-oauth": createServer({
+          name: "explicit-oauth",
+          config: httpConfig,
+          useOAuth: true,
+        }),
+        "token-oauth": createServer({
+          name: "token-oauth",
+          config: httpConfig,
+          oauthTokens,
+        }),
+        "stored-config-oauth": createServer({
+          name: "stored-config-oauth",
+          config: httpConfig,
+        }),
+        "flow-oauth": createServer({
+          name: "flow-oauth",
+          config: httpConfig,
+          connectionStatus: "oauth-flow",
+        }),
+        "plain-http": createServer({
+          name: "plain-http",
+          config: httpConfig,
+        }),
+        "stdio-with-oauth-state": createServer({
+          name: "stdio-with-oauth-state",
+          useOAuth: true,
+          oauthTokens,
+        }),
+      };
+
+      render(
+        <ActiveServerSelector
+          {...defaultProps}
+          serverConfigs={serverConfigs}
+          selectedServer="explicit-oauth"
+          showOnlyOAuthServers={true}
+        />,
+      );
+
+      expect(screen.getByText("explicit-oauth")).toBeInTheDocument();
+      expect(screen.getByText("token-oauth")).toBeInTheDocument();
+      expect(screen.getByText("stored-config-oauth")).toBeInTheDocument();
+      expect(screen.getByText("flow-oauth")).toBeInTheDocument();
+      expect(screen.queryByText("plain-http")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("stdio-with-oauth-state"),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -526,6 +593,44 @@ describe("ActiveServerSelector", () => {
       );
 
       // Give time for any effects to run
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(onServerChange).not.toHaveBeenCalled();
+    });
+
+    it("does not auto-select a filtered server when auto-selection is disabled", async () => {
+      const onServerChange = vi.fn();
+      const httpConfig = {
+        transportType: "streamableHttp",
+        url: "http://localhost:3000/mcp",
+      } as const;
+      const serverConfigs = {
+        "selected-plain-http": createServer({
+          name: "selected-plain-http",
+          config: httpConfig,
+        }),
+        "visible-oauth": createServer({
+          name: "visible-oauth",
+          config: httpConfig,
+          useOAuth: true,
+          lastConnectionTime: new Date("2024-01-03"),
+        }),
+      };
+
+      render(
+        <ActiveServerSelector
+          {...defaultProps}
+          serverConfigs={serverConfigs}
+          selectedServer="selected-plain-http"
+          onServerChange={onServerChange}
+          showOnlyOAuthServers={true}
+          autoSelectFilteredServer={false}
+        />,
+      );
+
+      expect(screen.queryByText("selected-plain-http")).not.toBeInTheDocument();
+      expect(screen.getByText("visible-oauth")).toBeInTheDocument();
+
       await new Promise((r) => setTimeout(r, 50));
 
       expect(onServerChange).not.toHaveBeenCalled();

--- a/mcpjam-inspector/client/src/components/__tests__/OAuthFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OAuthFlowTab.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { OAuthFlowTab } from "../OAuthFlowTab";
+import type { ServerWithName } from "@/hooks/use-app-state";
+
+vi.mock("posthog-js", () => ({
+  default: {
+    capture: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/PosthogUtils", () => ({
+  detectEnvironment: vi.fn().mockReturnValue("test"),
+  detectPlatform: vi.fn().mockReturnValue("web"),
+}));
+
+vi.mock("@mcpjam/sdk/browser", () => ({
+  EMPTY_OAUTH_FLOW_STATE: {
+    currentStep: "metadata_discovery",
+    isInitiatingAuth: false,
+    httpHistory: [],
+  },
+}));
+
+vi.mock("@/lib/oauth/debug-state-machine-adapter", () => ({
+  createInspectorOAuthStateMachine: vi.fn(),
+}));
+
+vi.mock("@/components/oauth/OAuthSequenceDiagram", () => ({
+  OAuthSequenceDiagram: () => <div data-testid="oauth-sequence-diagram" />,
+}));
+
+vi.mock("@/components/oauth/OAuthAuthorizationModal", () => ({
+  OAuthAuthorizationModal: () => null,
+}));
+
+vi.mock("../ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: () => <div />,
+}));
+
+vi.mock("../oauth/OAuthProfileModal", () => ({
+  OAuthProfileModal: () => null,
+}));
+
+vi.mock("../oauth/OAuthFlowLogger", () => ({
+  OAuthFlowLogger: ({
+    summary,
+  }: {
+    summary: { label: string; description: string };
+  }) => (
+    <div data-testid="oauth-flow-logger">
+      <div>{summary.label}</div>
+      <div>{summary.description}</div>
+    </div>
+  ),
+}));
+
+vi.mock("../oauth/RefreshTokensConfirmModal", () => ({
+  RefreshTokensConfirmModal: () => null,
+}));
+
+describe("OAuthFlowTab", () => {
+  const createServer = (
+    overrides: Partial<ServerWithName> = {},
+  ): ServerWithName =>
+    ({
+      name: "test-server",
+      connectionStatus: "connected",
+      enabled: true,
+      retryCount: 0,
+      useOAuth: false,
+      lastConnectionTime: new Date("2024-01-01"),
+      config: {
+        transportType: "stdio",
+        command: "node",
+        args: ["server.js"],
+      },
+      ...overrides,
+    } as ServerWithName);
+
+  it("does not select the first HTTP server when opened with a non-HTTP selection", async () => {
+    const onSelectServer = vi.fn();
+    const serverConfigs = {
+      "selected-stdio": createServer({ name: "selected-stdio" }),
+      "available-oauth": createServer({
+        name: "available-oauth",
+        useOAuth: true,
+        config: {
+          url: "https://example.com/mcp",
+        },
+      }),
+    };
+
+    render(
+      <OAuthFlowTab
+        serverConfigs={serverConfigs}
+        selectedServerName="selected-stdio"
+        onSelectServer={onSelectServer}
+      />,
+    );
+
+    expect(screen.getByTestId("oauth-flow-logger")).toHaveTextContent(
+      "No target configured",
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(onSelectServer).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -90,8 +90,7 @@ describe("XAAFlowTab", () => {
       ...overrides,
     } as ServerWithName);
 
-  it("does not select the first HTTP server when opened with a non-HTTP selection", async () => {
-    const onSelectServer = vi.fn();
+  it("shows no configured target when opened with a non-HTTP selection", () => {
     const serverConfigs = {
       "selected-stdio": createServer({ name: "selected-stdio" }),
       "available-oauth": createServer({
@@ -113,9 +112,5 @@ describe("XAAFlowTab", () => {
     expect(screen.getByTestId("xaa-flow-logger")).toHaveTextContent(
       "No target configured",
     );
-
-    await new Promise((r) => setTimeout(r, 50));
-
-    expect(onSelectServer).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/XAAFlowTab.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { XAAFlowTab } from "../xaa/XAAFlowTab";
+import type { ServerWithName } from "@/hooks/use-app-state";
+
+vi.mock("../ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizablePanel: ({ children }: { children?: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  ResizableHandle: () => <div />,
+}));
+
+vi.mock("../xaa/XAASequenceDiagram", () => ({
+  XAASequenceDiagram: () => <div data-testid="xaa-sequence-diagram" />,
+}));
+
+vi.mock("../xaa/XAAFlowLogger", () => ({
+  XAAFlowLogger: ({
+    summary,
+  }: {
+    summary: { serverUrl?: string };
+  }) => (
+    <div data-testid="xaa-flow-logger">
+      {summary.serverUrl || "No target configured"}
+    </div>
+  ),
+}));
+
+vi.mock("../xaa/XAAConfigModal", () => ({
+  XAAConfigModal: () => null,
+}));
+
+vi.mock("../xaa/XAABootstrapDialog", () => ({
+  XAABootstrapDialog: () => null,
+}));
+
+vi.mock("@/lib/xaa/debug-state-machine-adapter", () => ({
+  createInspectorXAAStateMachine: () => ({
+    proceedToNextStep: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/xaa/profile", () => {
+  const emptyProfile = {
+    serverUrl: "",
+    authzServerIssuer: "",
+    negativeTestMode: "none",
+    userId: "",
+    email: "",
+    clientId: "",
+    scope: "",
+  };
+
+  return {
+    loadStoredXAADebugProfile: () => emptyProfile,
+    saveStoredXAADebugProfile: vi.fn(),
+    deriveXAADebugProfileFromServer: (
+      server: ServerWithName | undefined,
+      fallback = emptyProfile,
+    ) => ({
+      ...fallback,
+      serverUrl:
+        server && "url" in server.config && server.config.url
+          ? server.config.url.toString()
+          : "",
+    }),
+  };
+});
+
+describe("XAAFlowTab", () => {
+  const createServer = (
+    overrides: Partial<ServerWithName> = {},
+  ): ServerWithName =>
+    ({
+      name: "test-server",
+      connectionStatus: "connected",
+      enabled: true,
+      retryCount: 0,
+      useOAuth: false,
+      lastConnectionTime: new Date("2024-01-01"),
+      config: {
+        transportType: "stdio",
+        command: "node",
+        args: ["server.js"],
+      },
+      ...overrides,
+    } as ServerWithName);
+
+  it("does not select the first HTTP server when opened with a non-HTTP selection", async () => {
+    const onSelectServer = vi.fn();
+    const serverConfigs = {
+      "selected-stdio": createServer({ name: "selected-stdio" }),
+      "available-oauth": createServer({
+        name: "available-oauth",
+        useOAuth: true,
+        config: {
+          url: "https://example.com/mcp",
+        },
+      }),
+    };
+
+    render(
+      <XAAFlowTab
+        serverConfigs={serverConfigs}
+        selectedServerName="selected-stdio"
+      />,
+    );
+
+    expect(screen.getByTestId("xaa-flow-logger")).toHaveTextContent(
+      "No target configured",
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(onSelectServer).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
+++ b/mcpjam-inspector/client/src/components/xaa/XAAFlowTab.tsx
@@ -41,22 +41,15 @@ function buildFlowStateFromProfile(profile: XAADebugProfile): XAAFlowState {
 interface XAAFlowTabProps {
   serverConfigs: Record<string, ServerWithName>;
   selectedServerName: string;
-  onSelectServer: (serverName: string) => void;
 }
 
 export function XAAFlowTab({
   serverConfigs,
   selectedServerName,
-  onSelectServer,
 }: XAAFlowTabProps) {
   const [isConfigModalOpen, setIsConfigModalOpen] = useState(false);
   const [isBootstrapDialogOpen, setIsBootstrapDialogOpen] = useState(false);
   const [focusedStep, setFocusedStep] = useState<XAAFlowStep | null>(null);
-
-  const httpServers = useMemo(
-    () => Object.values(serverConfigs).filter((server) => isHttpServer(server)),
-    [serverConfigs],
-  );
 
   const selectedServer =
     selectedServerName !== "none"
@@ -65,12 +58,6 @@ export function XAAFlowTab({
   const activeServer = isHttpServer(selectedServer)
     ? selectedServer
     : undefined;
-
-  useEffect(() => {
-    if (!isHttpServer(selectedServer) && httpServers.length > 0) {
-      onSelectServer(httpServers[0].name);
-    }
-  }, [httpServers, onSelectServer, selectedServer]);
 
   const [profile, setProfile] = useState(() =>
     deriveXAADebugProfileFromServer(activeServer, loadStoredXAADebugProfile()),


### PR DESCRIPTION
## Summary

- In OAuth Debugger and XAA Debugger, the top server bar now shows only OAuth servers from the current workspace.
- Uses existing server OAuth state to decide which servers appear in those debugger bars.
- The new OAuth-only filter does not change the app’s current server when you simply visit either debugger.
- Clicking a server in the top server bar still changes the app’s current server, same as before.

## Testing

- `npm test -- client/src/components/__tests__/ActiveServerSelector.test.tsx client/src/components/__tests__/OAuthFlowTab.test.tsx client/src/components/__tests__/XAAFlowTab.test.tsx client/src/__tests__/App.hosted-oauth.test.tsx`
