### PR TITLE
Unify chatbox auth bootstrap

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -681,10 +681,10 @@ describe("MCPAppsRenderer tool input streaming", () => {
       mockBridge.onsizechange?.({ width: 400, height: 300 });
     });
 
-    expect(
-      (screen.getByTestId("sandboxed-iframe") as HTMLElement).style.visibility,
-    ).toBe("hidden");
-    expect(screen.getByText("Streaming tool arguments...")).toBeTruthy();
+    const iframe = screen.getByTestId("sandboxed-iframe") as HTMLElement;
+    expect(iframe.style.opacity).toBe("0");
+    expect(iframe.style.position).toBe("absolute");
+    expect(iframe.style.pointerEvents).toBe("none");
 
     const partialInput = { elements: '[{"type":"rectangle"' };
     rerender(
@@ -702,12 +702,10 @@ describe("MCPAppsRenderer tool input streaming", () => {
       });
     });
     await vi.waitFor(() => {
-      expect(
-        (screen.getByTestId("sandboxed-iframe") as HTMLElement).style
-          .visibility,
-      ).toBe("");
+      expect(iframe.style.opacity).toBe("1");
+      expect(iframe.style.position).toBe("");
+      expect(iframe.style.pointerEvents).toBe("");
     });
-    expect(screen.queryByText("Streaming tool arguments...")).toBeNull();
   });
 
   it("streams updated partial input values while still streaming", async () => {

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth } from "convex/react";
+import { usePostHog } from "posthog-js/react";
 import { Loader2, Link2Off, ShieldX } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@mcpjam/design-system/button";
@@ -10,8 +11,8 @@ import type { ServerWithName } from "@/hooks/use-app-state";
 import { useHostedApiContext } from "@/hooks/hosted/use-hosted-api-context";
 import { useHostedOAuthGate } from "@/hooks/hosted/use-hosted-oauth-gate";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
-import { getGuestBearerToken } from "@/lib/guest-session";
 import { getStoredTokens } from "@/lib/oauth/mcp-oauth";
+import { authFetch } from "@/lib/session-token";
 import {
   buildChatboxLink,
   clearChatboxSession,
@@ -64,21 +65,12 @@ const INVALID_CHATBOX_LINK_MESSAGE =
 const UNEXPECTED_CHATBOX_ERROR_MESSAGE =
   "We couldn't open this chatbox right now. Please try again or open MCPJam.";
 
-async function getHostedBearerHeader(
-  getAccessToken: () => Promise<string | undefined | null>,
-): Promise<string | null> {
-  try {
-    const workOsToken = await getAccessToken();
-    if (workOsToken) {
-      return `Bearer ${workOsToken}`;
-    }
-  } catch {
-    // Fall through to guest auth.
-  }
-
-  const guestToken = await getGuestBearerToken();
-  return guestToken ? `Bearer ${guestToken}` : null;
-}
+type ChatboxBootstrapAuthMode = "workos" | "guest";
+type ChatboxLandingState =
+  | "resolvingAuth"
+  | "bootstrapping"
+  | "ready"
+  | "denied";
 
 function sanitizeChatboxRouteErrorMessage(message: string): string {
   const normalized = message.replace(/\s+/g, " ").trim();
@@ -215,13 +207,34 @@ function getChatboxDisplayError(
   };
 }
 
+function getChatboxBootstrapAuthMode(
+  isAuthenticated: boolean,
+): ChatboxBootstrapAuthMode {
+  return isAuthenticated ? "workos" : "guest";
+}
+
+function isInteractiveSignInRequired(kind: ChatboxErrorKind): boolean {
+  return kind === "access_denied" || kind === "guest_blocked";
+}
+
 export function ChatboxChatPage({
   pathToken,
   onExitChatboxChat,
 }: ChatboxChatPageProps) {
-  const { getAccessToken, signIn } = useAuth();
+  const {
+    getAccessToken,
+    signIn,
+    user: workOsUser,
+    isLoading: isWorkOsLoading,
+  } = useAuth();
   const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const posthog = usePostHog();
+  const posthogRef = useRef(posthog);
   const themeMode = usePreferencesStore((s) => s.themeMode);
+
+  useEffect(() => {
+    posthogRef.current = posthog;
+  }, [posthog]);
 
   const playgroundParams = useMemo(() => {
     try {
@@ -262,10 +275,19 @@ export function ChatboxChatPage({
   const [session, setSession] = useState<ChatboxSession | null>(() =>
     readCurrentSession(),
   );
-  const [isResolving, setIsResolving] = useState(
+  const [isBootstrapping, setIsBootstrapping] = useState(
     Boolean(pathToken || playgroundParams),
   );
   const [routeError, setRouteError] = useState<ChatboxRouteError | null>(null);
+  const interactiveSignInEventKeyRef = useRef<string | null>(null);
+  const tokenFromPath = useMemo(() => pathToken?.trim() || null, [pathToken]);
+  const hasWorkOsUser = Boolean(workOsUser);
+  const isAuthSettling =
+    Boolean(tokenFromPath) &&
+    !playgroundParams &&
+    (isWorkOsLoading ||
+      isAuthLoading ||
+      (hasWorkOsUser && !isAuthenticated));
 
   const sessionServersRequired = useMemo(
     () => session?.payload.servers.filter((s) => !s.optional) ?? [],
@@ -422,15 +444,15 @@ export function ChatboxChatPage({
 
   useHostedApiContext({
     workspaceId: session?.payload.workspaceId ?? null,
-    serverIdsByName: hostedServerIdsByName,
+    serverIdsByName: session ? hostedServerIdsByName : {},
     getAccessToken,
     oauthTokensByServerId: oauthTokensForChat,
-    chatboxToken: session?.token,
+    chatboxToken: tokenFromPath ?? session?.token,
     isAuthenticated,
   });
 
   useEffect(() => {
-    if (isAuthLoading) {
+    if (isAuthSettling) {
       return;
     }
 
@@ -451,28 +473,24 @@ export function ChatboxChatPage({
             ),
           );
         }
-        setIsResolving(false);
+        setIsBootstrapping(false);
         return;
       }
 
-      const tokenFromPath = pathToken?.trim() || null;
-
       if (tokenFromPath) {
-        setIsResolving(true);
+        const authMode = getChatboxBootstrapAuthMode(isAuthenticated);
+        setIsBootstrapping(true);
         setRouteError(null);
+        posthogRef.current.capture("chatbox_bootstrap_started", {
+          surface: "chatbox",
+          auth_mode: authMode,
+          status: "started",
+        });
         try {
-          const authorization = await getHostedBearerHeader(getAccessToken);
-          if (!authorization) {
-            throw new Error(
-              "Unable to create a hosted session for this chatbox.",
-            );
-          }
-
-          const response = await fetch("/api/web/chatboxes/bootstrap", {
+          const response = await authFetch("/api/web/chatboxes/bootstrap", {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
-              Authorization: authorization,
             },
             body: JSON.stringify({ token: tokenFromPath }),
           });
@@ -497,6 +515,11 @@ export function ChatboxChatPage({
           if (window.location.hash !== `#${nextSlug}`) {
             window.history.replaceState({}, "", `/#${nextSlug}`);
           }
+          posthogRef.current.capture("chatbox_bootstrap_silent_success", {
+            surface: "chatbox",
+            auth_mode: authMode,
+            status: "success",
+          });
         } catch (error) {
           if (cancelled) return;
           setSession(null);
@@ -522,9 +545,16 @@ export function ChatboxChatPage({
           }
 
           setRouteError(nextError);
+          posthogRef.current.capture("chatbox_bootstrap_silent_failure", {
+            surface: "chatbox",
+            auth_mode: authMode,
+            status: "failure",
+            error_kind: displayError.kind,
+            http_status: nextError.status,
+          });
         } finally {
           if (!cancelled) {
-            setIsResolving(false);
+            setIsBootstrapping(false);
           }
         }
         return;
@@ -554,13 +584,48 @@ export function ChatboxChatPage({
     };
   }, [
     clearCurrentSession,
-    getAccessToken,
-    isAuthLoading,
-    pathToken,
+    isAuthenticated,
+    isAuthSettling,
     playgroundParams,
     readCurrentSession,
+    tokenFromPath,
     writeCurrentSession,
   ]);
+
+  const displayError = getChatboxDisplayError(routeError);
+  const landingState: ChatboxLandingState = isAuthSettling
+    ? "resolvingAuth"
+    : isBootstrapping
+      ? "bootstrapping"
+      : session
+        ? "ready"
+        : "denied";
+
+  useEffect(() => {
+    if (
+      landingState !== "denied" ||
+      isAuthenticated ||
+      !isInteractiveSignInRequired(displayError.kind)
+    ) {
+      interactiveSignInEventKeyRef.current = null;
+      return;
+    }
+
+    const authMode = getChatboxBootstrapAuthMode(isAuthenticated);
+    const eventKey = `${displayError.kind}:${authMode}:${routeError?.status ?? 0}`;
+    if (interactiveSignInEventKeyRef.current === eventKey) {
+      return;
+    }
+
+    interactiveSignInEventKeyRef.current = eventKey;
+    posthogRef.current.capture("interactive_signin_required", {
+      surface: "chatbox",
+      auth_mode: authMode,
+      status: "required",
+      error_kind: displayError.kind,
+      http_status: routeError?.status,
+    });
+  }, [displayError.kind, isAuthenticated, landingState, routeError?.status]);
 
   useEffect(() => {
     if (!session) return;
@@ -621,7 +686,6 @@ export function ChatboxChatPage({
 
   const hostStyle = session?.payload.hostStyle ?? "claude";
   const shellStyle = getChatboxShellStyle(hostStyle, themeMode);
-  const displayError = getChatboxDisplayError(routeError);
   const oauthPending = pendingOAuthServers.length > 0;
   const welcomeAvailable =
     (session?.payload.welcomeDialog?.enabled ?? true) &&
@@ -639,7 +703,10 @@ export function ChatboxChatPage({
     pendingOAuthServers.every(({ state }) => isHostedOAuthBusy(state.status));
 
   const renderContent = () => {
-    if (isResolving) {
+    if (
+      landingState === "resolvingAuth" ||
+      landingState === "bootstrapping"
+    ) {
       return (
         <div className="flex flex-1 items-center justify-center">
           <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
@@ -647,7 +714,7 @@ export function ChatboxChatPage({
       );
     }
 
-    if (!session) {
+    if (landingState === "denied") {
       const isAccessDenied = displayError.kind === "access_denied";
       const guestBlocked = displayError.kind === "guest_blocked";
 

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -87,7 +87,7 @@ function sanitizeChatboxRouteErrorMessage(message: string): string {
 function createChatboxRouteError(
   status: number,
   message: string,
-  code?: string,
+  code?: string
 ): ChatboxRouteError {
   const fallbackMessage = `Request failed with status ${status}`;
   const rawMessage = message.trim() || fallbackMessage;
@@ -141,7 +141,7 @@ function isChatboxRouteError(error: unknown): error is ChatboxRouteError {
 }
 
 function getChatboxDisplayError(
-  error: ChatboxRouteError | null,
+  error: ChatboxRouteError | null
 ): ChatboxDisplayError {
   if (!error) {
     return {
@@ -153,7 +153,7 @@ function getChatboxDisplayError(
 
   const normalizedMessage = error.message.toLowerCase();
   const requiresSignIn = normalizedMessage.includes(
-    "sign in to access this chatbox",
+    "sign in to access this chatbox"
   );
   const isAccessDenied = normalizedMessage.includes("don't have access");
   const isGuestBlocked =
@@ -165,7 +165,7 @@ function getChatboxDisplayError(
     normalizedMessage.includes("invalid or has expired") ||
     normalizedMessage.includes("invalid or expired");
   const isPlaygroundExpired = normalizedMessage.includes(
-    "playground session expired",
+    "playground session expired"
   );
 
   if (isPlaygroundExpired) {
@@ -208,7 +208,7 @@ function getChatboxDisplayError(
 }
 
 function getChatboxBootstrapAuthMode(
-  isAuthenticated: boolean,
+  isAuthenticated: boolean
 ): ChatboxBootstrapAuthMode {
   return isAuthenticated ? "workos" : "guest";
 }
@@ -261,7 +261,7 @@ export function ChatboxChatPage({
 
       writeChatboxSession(nextSession);
     },
-    [playgroundParams],
+    [playgroundParams]
   );
 
   const clearCurrentSession = useCallback(() => {
@@ -273,30 +273,27 @@ export function ChatboxChatPage({
   }, [playgroundParams]);
 
   const [session, setSession] = useState<ChatboxSession | null>(() =>
-    readCurrentSession(),
+    readCurrentSession()
   );
   const [isBootstrapping, setIsBootstrapping] = useState(
-    Boolean(pathToken || playgroundParams),
+    Boolean(pathToken || playgroundParams)
   );
   const [routeError, setRouteError] = useState<ChatboxRouteError | null>(null);
   const interactiveSignInEventKeyRef = useRef<string | null>(null);
   const tokenFromPath = useMemo(() => pathToken?.trim() || null, [pathToken]);
-  const hasWorkOsUser = Boolean(workOsUser);
   const isAuthSettling =
     Boolean(tokenFromPath) &&
     !playgroundParams &&
-    (isWorkOsLoading ||
-      isAuthLoading ||
-      (hasWorkOsUser && !isAuthenticated));
+    (isWorkOsLoading || isAuthLoading);
 
   const sessionServersRequired = useMemo(
     () => session?.payload.servers.filter((s) => !s.optional) ?? [],
-    [session],
+    [session]
   );
 
   const sessionServersOptional = useMemo(
     () => session?.payload.servers.filter((s) => s.optional) ?? [],
-    [session],
+    [session]
   );
 
   const [enabledOptionalServerIds, setEnabledOptionalServerIds] = useState<
@@ -307,7 +304,7 @@ export function ChatboxChatPage({
     if (!session?.token) return;
     try {
       const raw = sessionStorage.getItem(
-        chatboxEnabledOptionalStorageKey(session.token),
+        chatboxEnabledOptionalStorageKey(session.token)
       );
       if (!raw) {
         setEnabledOptionalServerIds((prev) => (prev.length === 0 ? prev : []));
@@ -316,12 +313,10 @@ export function ChatboxChatPage({
       const parsed = JSON.parse(raw) as unknown;
       if (!Array.isArray(parsed)) return;
       const optionalIdSet = new Set(
-        session.payload.servers
-          .filter((s) => s.optional)
-          .map((s) => s.serverId),
+        session.payload.servers.filter((s) => s.optional).map((s) => s.serverId)
       );
       const next = parsed.filter(
-        (id): id is string => typeof id === "string" && optionalIdSet.has(id),
+        (id): id is string => typeof id === "string" && optionalIdSet.has(id)
       );
       setEnabledOptionalServerIds((prev) => {
         if (
@@ -355,19 +350,19 @@ export function ChatboxChatPage({
     if (!session) return [];
     const enabled = new Set(enabledOptionalServerIds);
     const optionalActive = session.payload.servers.filter(
-      (s) => s.optional && enabled.has(s.serverId),
+      (s) => s.optional && enabled.has(s.serverId)
     );
     return [...sessionServersRequired, ...optionalActive];
   }, [session, sessionServersRequired, enabledOptionalServerIds]);
 
   const oauthServers = useMemo(
     () => sessionServersActive.map(bootstrapServerToHostedOAuthDescriptor),
-    [sessionServersActive],
+    [sessionServersActive]
   );
 
   const handleEnableChatboxOptionalServer = useCallback((serverId: string) => {
     setEnabledOptionalServerIds((prev) =>
-      prev.includes(serverId) ? prev : [...prev, serverId],
+      prev.includes(serverId) ? prev : [...prev, serverId]
     );
   }, []);
 
@@ -412,7 +407,7 @@ export function ChatboxChatPage({
           retryCount: 0,
           enabled: true,
         } satisfies ServerWithName,
-      ]),
+      ])
     );
   }, [session, sessionServersActive]);
 
@@ -423,7 +418,7 @@ export function ChatboxChatPage({
       sessionServersActive.flatMap((server) => [
         [server.serverName, server.serverId],
         [server.serverId, server.serverId],
-      ]),
+      ])
     );
   }, [session, sessionServersActive]);
 
@@ -436,7 +431,7 @@ export function ChatboxChatPage({
         return token ? ([server.serverId, token] as const) : null;
       })
       .filter((entry): entry is readonly [string, string] =>
-        Array.isArray(entry),
+        Array.isArray(entry)
       );
 
     return entries.length > 0 ? Object.fromEntries(entries) : undefined;
@@ -469,8 +464,8 @@ export function ChatboxChatPage({
           setRouteError(
             createChatboxRouteError(
               410,
-              "Playground session expired. Return to the builder to preview.",
-            ),
+              "Playground session expired. Return to the builder to preview."
+            )
           );
         }
         setIsBootstrapping(false);
@@ -531,7 +526,7 @@ export function ChatboxChatPage({
                 500,
                 error instanceof Error
                   ? error.message
-                  : "Unable to open this chatbox.",
+                  : "Unable to open this chatbox."
               );
           const displayError = getChatboxDisplayError(nextError);
 
@@ -573,7 +568,7 @@ export function ChatboxChatPage({
 
       setSession(null);
       setRouteError(
-        createChatboxRouteError(404, "Invalid or expired chatbox link"),
+        createChatboxRouteError(404, "Invalid or expired chatbox link")
       );
     };
 
@@ -592,14 +587,17 @@ export function ChatboxChatPage({
     writeCurrentSession,
   ]);
 
-  const displayError = getChatboxDisplayError(routeError);
+  const displayError = useMemo(
+    () => getChatboxDisplayError(routeError),
+    [routeError]
+  );
   const landingState: ChatboxLandingState = isAuthSettling
     ? "resolvingAuth"
     : isBootstrapping
-      ? "bootstrapping"
-      : session
-        ? "ready"
-        : "denied";
+    ? "bootstrapping"
+    : session
+    ? "ready"
+    : "denied";
 
   useEffect(() => {
     if (
@@ -612,7 +610,9 @@ export function ChatboxChatPage({
     }
 
     const authMode = getChatboxBootstrapAuthMode(isAuthenticated);
-    const eventKey = `${displayError.kind}:${authMode}:${routeError?.status ?? 0}`;
+    const eventKey = `${displayError.kind}:${authMode}:${
+      routeError?.status ?? 0
+    }`;
     if (interactiveSignInEventKeyRef.current === eventKey) {
       return;
     }
@@ -658,7 +658,7 @@ export function ChatboxChatPage({
 
     try {
       await navigator.clipboard.writeText(
-        buildChatboxLink(token, session.payload.name),
+        buildChatboxLink(token, session.payload.name)
       );
       toast.success("Chatbox link copied");
     } catch {
@@ -681,7 +681,7 @@ export function ChatboxChatPage({
     (details?: HostedOAuthRequiredDetails) => {
       markOAuthRequired(details);
     },
-    [markOAuthRequired],
+    [markOAuthRequired]
   );
 
   const hostStyle = session?.payload.hostStyle ?? "claude";
@@ -703,10 +703,7 @@ export function ChatboxChatPage({
     pendingOAuthServers.every(({ state }) => isHostedOAuthBusy(state.status));
 
   const renderContent = () => {
-    if (
-      landingState === "resolvingAuth" ||
-      landingState === "bootstrapping"
-    ) {
+    if (landingState === "resolvingAuth" || landingState === "bootstrapping") {
       return (
         <div className="flex flex-1 items-center justify-center">
           <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
@@ -752,16 +749,16 @@ export function ChatboxChatPage({
         <ChatTabV2
           connectedOrConnectingServerConfigs={chatboxServerConfigs}
           selectedServerNames={sessionServersActive.map(
-            (server) => server.serverName,
+            (server) => server.serverName
           )}
           minimalMode
           reasoningDisplayMode="hidden"
           loadingIndicatorVariant={getLoadingIndicatorVariantForHostStyle(
-            hostStyle,
+            hostStyle
           )}
           hostedWorkspaceIdOverride={session.payload.workspaceId}
           hostedSelectedServerIdsOverride={sessionServersActive.map(
-            (server) => server.serverId,
+            (server) => server.serverId
           )}
           hostedOAuthTokensOverride={oauthTokensForChat}
           hostedContext={{

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
@@ -139,7 +139,7 @@ describe("ChatboxChatPage", () => {
       ok: boolean;
       status: number;
       statusText: string;
-    }> = {},
+    }> = {}
   ) {
     return {
       ok: overrides.ok ?? true,
@@ -196,7 +196,7 @@ describe("ChatboxChatPage", () => {
         temperature: 0.4,
         requireToolApproval: true,
         servers: [],
-      }),
+      })
     );
   });
 
@@ -230,14 +230,14 @@ describe("ChatboxChatPage", () => {
 
     expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
     expect(
-      container.querySelector('[data-host-style="chatgpt"]'),
+      container.querySelector('[data-host-style="chatgpt"]')
     ).toBeInTheDocument();
     expect(screen.getByAltText("MCPJam")).toBeInTheDocument();
     expect(mockChatTabV2).toHaveBeenCalledWith(
       expect.objectContaining({
         reasoningDisplayMode: "hidden",
         loadingIndicatorVariant: "chatgpt-dot",
-      }),
+      })
     );
   });
 
@@ -267,7 +267,7 @@ describe("ChatboxChatPage", () => {
     expect(mockChatTabV2).toHaveBeenCalledWith(
       expect.objectContaining({
         loadingIndicatorVariant: "claude-mark",
-      }),
+      })
     );
   });
 
@@ -275,7 +275,7 @@ describe("ChatboxChatPage", () => {
     window.history.replaceState(
       {},
       "",
-      "/chatbox/demo/chatbox-token?playground=1&playgroundId=pg_123",
+      "/chatbox/demo/chatbox-token?playground=1&playgroundId=pg_123"
     );
 
     writePlaygroundSession({
@@ -309,7 +309,7 @@ describe("ChatboxChatPage", () => {
         hostedContext: expect.objectContaining({
           chatboxSurface: "preview",
         }),
-      }),
+      })
     );
   });
 
@@ -317,18 +317,18 @@ describe("ChatboxChatPage", () => {
     window.history.replaceState(
       {},
       "",
-      "/chatbox/demo/chatbox-token?playground=1&playgroundId=missing",
+      "/chatbox/demo/chatbox-token?playground=1&playgroundId=missing"
     );
 
     render(<ChatboxChatPage pathToken="chatbox-token" />);
 
     expect(
-      await screen.findByRole("heading", { name: "Preview unavailable" }),
+      await screen.findByRole("heading", { name: "Preview unavailable" })
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Playground session expired. Return to the builder to preview.",
-      ),
+        "Playground session expired. Return to the builder to preview."
+      )
     ).toBeInTheDocument();
   });
 
@@ -340,31 +340,31 @@ describe("ChatboxChatPage", () => {
           message:
             "Uncaught Error: This chatbox link is invalid or has expired. at resolveChatboxBootstrapForUser (../../convex/chatboxes.ts:309:14) at async handler (../../convex/chatboxes.ts:1088:6)",
         },
-        { ok: false, status: 404, statusText: "Not Found" },
-      ),
+        { ok: false, status: 404, statusText: "Not Found" }
+      )
     );
 
     render(<ChatboxChatPage pathToken="stale-token" />);
 
     expect(
-      await screen.findByRole("heading", { name: "Chatbox Link Unavailable" }),
+      await screen.findByRole("heading", { name: "Chatbox Link Unavailable" })
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "This chatbox link is invalid or expired. Ask the owner to share a new link if you still need access.",
-      ),
+        "This chatbox link is invalid or expired. Ask the owner to share a new link if you still need access."
+      )
     ).toBeInTheDocument();
     expect(screen.queryByText(/Uncaught Error:/)).not.toBeInTheDocument();
     expect(
-      screen.queryByText(/resolveChatboxBootstrapForUser/),
+      screen.queryByText(/resolveChatboxBootstrapForUser/)
     ).not.toBeInTheDocument();
   });
 
-  it("waits for WorkOS and Convex auth to settle before bootstrapping the link", async () => {
+  it("waits for active WorkOS and Convex loading to settle before bootstrapping the link", async () => {
     mockConvexAuthState.isAuthenticated = false;
-    mockConvexAuthState.isLoading = false;
+    mockConvexAuthState.isLoading = true;
     mockWorkOsAuthState.user = { id: "user_settling" };
-    mockWorkOsAuthState.isLoading = false;
+    mockWorkOsAuthState.isLoading = true;
 
     const { rerender } = render(<ChatboxChatPage pathToken="token-workos" />);
 
@@ -372,7 +372,7 @@ describe("ChatboxChatPage", () => {
     expect(
       screen.queryByRole("button", {
         name: "Sign in",
-      }),
+      })
     ).not.toBeInTheDocument();
     expect(mockUseHostedApiContext).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -380,9 +380,11 @@ describe("ChatboxChatPage", () => {
         serverIdsByName: {},
         chatboxToken: "token-workos",
         isAuthenticated: false,
-      }),
+      })
     );
 
+    mockWorkOsAuthState.isLoading = false;
+    mockConvexAuthState.isLoading = false;
     mockConvexAuthState.isAuthenticated = true;
     rerender(<ChatboxChatPage pathToken="token-workos" />);
 
@@ -392,7 +394,7 @@ describe("ChatboxChatPage", () => {
       "/api/web/chatboxes/bootstrap",
       expect.objectContaining({
         body: JSON.stringify({ token: "token-workos" }),
-      }),
+      })
     );
     expect(mockPosthogCapture).toHaveBeenCalledWith(
       "chatbox_bootstrap_started",
@@ -400,7 +402,36 @@ describe("ChatboxChatPage", () => {
         surface: "chatbox",
         auth_mode: "workos",
         status: "started",
-      }),
+      })
+    );
+  });
+
+  it("does not stay stuck resolving auth when WorkOS is hydrated but Convex remains unauthenticated", async () => {
+    mockConvexAuthState.isAuthenticated = false;
+    mockConvexAuthState.isLoading = false;
+    mockWorkOsAuthState.user = { id: "user_stalled_convex" };
+    mockWorkOsAuthState.isLoading = false;
+    mockAuthFetch.mockResolvedValueOnce(
+      createFetchResponse(
+        {
+          code: "FORBIDDEN",
+          message:
+            "You don't have access to Test Chatbox. This chatbox is invite-only - ask the owner to invite you.",
+        },
+        { ok: false, status: 403, statusText: "Forbidden" }
+      )
+    );
+
+    render(<ChatboxChatPage pathToken="token-stalled-convex" />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Access Denied" })
+    ).toBeInTheDocument();
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      "/api/web/chatboxes/bootstrap",
+      expect.objectContaining({
+        body: JSON.stringify({ token: "token-stalled-convex" }),
+      })
     );
   });
 
@@ -415,25 +446,25 @@ describe("ChatboxChatPage", () => {
           message:
             "You don't have access to Test Chatbox. This chatbox is invite-only - ask the owner to invite you.",
         },
-        { ok: false, status: 403, statusText: "Forbidden" },
-      ),
+        { ok: false, status: 403, statusText: "Forbidden" }
+      )
     );
 
     render(<ChatboxChatPage pathToken="token-denied" />);
 
     expect(
-      await screen.findByRole("heading", { name: "Access Denied" }),
+      await screen.findByRole("heading", { name: "Access Denied" })
     ).toBeInTheDocument();
 
     await userEvent.click(
       screen.getByRole("button", {
         name: "Sign in",
-      }),
+      })
     );
 
     expect(mockSignIn).toHaveBeenCalledTimes(1);
     expect(localStorage.getItem(CHATBOX_SIGN_IN_RETURN_PATH_STORAGE_KEY)).toBe(
-      "/chatbox/test/token-denied",
+      "/chatbox/test/token-denied"
     );
   });
 
@@ -447,8 +478,8 @@ describe("ChatboxChatPage", () => {
           message:
             "Guests cannot access Test Chatbox. This chatbox does not allow guest access.",
         },
-        { ok: false, status: 403, statusText: "Forbidden" },
-      ),
+        { ok: false, status: 403, statusText: "Forbidden" }
+      )
     );
 
     render(<ChatboxChatPage pathToken="token-guest-blocked" />);
@@ -456,16 +487,16 @@ describe("ChatboxChatPage", () => {
     expect(
       screen.queryByRole("button", {
         name: "Sign in",
-      }),
+      })
     ).not.toBeInTheDocument();
 
     expect(
-      await screen.findByRole("heading", { name: "Access Denied" }),
+      await screen.findByRole("heading", { name: "Access Denied" })
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", {
         name: "Sign in",
-      }),
+      })
     ).toBeInTheDocument();
     expect(mockPosthogCapture).toHaveBeenCalledWith(
       "interactive_signin_required",
@@ -474,7 +505,7 @@ describe("ChatboxChatPage", () => {
         auth_mode: "guest",
         status: "required",
         error_kind: "guest_blocked",
-      }),
+      })
     );
   });
 
@@ -488,19 +519,19 @@ describe("ChatboxChatPage", () => {
           message:
             "You don't have access to Test Chatbox. This chatbox is invite-only - ask the owner to invite you.",
         },
-        { ok: false, status: 403, statusText: "Forbidden" },
-      ),
+        { ok: false, status: 403, statusText: "Forbidden" }
+      )
     );
 
     render(<ChatboxChatPage pathToken="token-auth-denied" />);
 
     expect(
-      await screen.findByRole("heading", { name: "Access Denied" }),
+      await screen.findByRole("heading", { name: "Access Denied" })
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", {
         name: "Sign in",
-      }),
+      })
     ).not.toBeInTheDocument();
   });
 
@@ -515,22 +546,22 @@ describe("ChatboxChatPage", () => {
           message:
             "Uncaught Error: Internal database exploded at handler (../../convex/chatboxes.ts:1088:6)",
         },
-        { ok: false, status: 500, statusText: "Internal Server Error" },
-      ),
+        { ok: false, status: 500, statusText: "Internal Server Error" }
+      )
     );
 
     render(<ChatboxChatPage pathToken="broken-token" />);
 
     expect(
-      await screen.findByRole("heading", { name: "Chatbox Link Unavailable" }),
+      await screen.findByRole("heading", { name: "Chatbox Link Unavailable" })
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "We couldn't open this chatbox right now. Please try again or open MCPJam.",
-      ),
+        "We couldn't open this chatbox right now. Please try again or open MCPJam."
+      )
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(/Internal database exploded/),
+      screen.queryByText(/Internal database exploded/)
     ).not.toBeInTheDocument();
     expect(consoleError).toHaveBeenCalledWith(
       "[ChatboxChatPage] Failed to bootstrap chatbox",
@@ -540,7 +571,7 @@ describe("ChatboxChatPage", () => {
         message: "Internal database exploded",
         rawMessage:
           "Uncaught Error: Internal database exploded at handler (../../convex/chatboxes.ts:1088:6)",
-      }),
+      })
     );
   });
 
@@ -548,7 +579,7 @@ describe("ChatboxChatPage", () => {
     vi.useFakeTimers();
     let hasToken = false;
     mockGetStoredTokens.mockImplementation(() =>
-      hasToken ? { access_token: "chatbox-token" } : null,
+      hasToken ? { access_token: "chatbox-token" } : null
     );
 
     writeChatboxSession({
@@ -587,10 +618,10 @@ describe("ChatboxChatPage", () => {
     render(<ChatboxChatPage />);
 
     expect(
-      screen.getByRole("heading", { name: "Finishing authorization" }),
+      screen.getByRole("heading", { name: "Finishing authorization" })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Authorize" }),
+      screen.queryByRole("button", { name: "Authorize" })
     ).not.toBeInTheDocument();
 
     await act(async () => {
@@ -611,8 +642,8 @@ describe("ChatboxChatPage", () => {
     mockGetStoredTokens.mockReturnValue({ access_token: "stale-token" });
     mockValidateHostedServer.mockRejectedValue(
       new Error(
-        'Authentication failed for MCP server "mn70g96re2qn05cxjw7y4y26ah82jzgh": SSE error: SSE error: Non-200 status code (401)',
-      ),
+        'Authentication failed for MCP server "mn70g96re2qn05cxjw7y4y26ah82jzgh": SSE error: SSE error: Non-200 status code (401)'
+      )
     );
 
     writeChatboxSession({
@@ -646,7 +677,7 @@ describe("ChatboxChatPage", () => {
     render(<ChatboxChatPage />);
 
     expect(
-      screen.getByRole("heading", { name: "Finishing authorization" }),
+      screen.getByRole("heading", { name: "Finishing authorization" })
     ).toBeInTheDocument();
 
     await act(async () => {
@@ -654,17 +685,17 @@ describe("ChatboxChatPage", () => {
     });
 
     expect(
-      screen.getByRole("heading", { name: "Authorization Required" }),
+      screen.getByRole("heading", { name: "Authorization Required" })
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Your authorization expired or was rejected. Authorize again to continue.",
-      ),
+        "Your authorization expired or was rejected. Authorize again to continue."
+      )
     ).toBeInTheDocument();
     expect(screen.queryByText(/SSE error/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Non-200 status code/i)).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Authorize again" }),
+      screen.getByRole("button", { name: "Authorize again" })
     ).toBeInTheDocument();
     expect(consoleError).toHaveBeenCalledWith(
       "[useHostedOAuthGate] OAuth validation failed",
@@ -672,7 +703,7 @@ describe("ChatboxChatPage", () => {
         surface: "chatbox",
         serverId: "srv_asana",
         serverName: "asana",
-      }),
+      })
     );
   });
 
@@ -712,17 +743,17 @@ describe("ChatboxChatPage", () => {
     expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Trigger OAuth" }),
+      screen.getByRole("button", { name: "Trigger OAuth" })
     );
 
     expect(
-      screen.getByRole("heading", { name: "Authorization Required" }),
+      screen.getByRole("heading", { name: "Authorization Required" })
     ).toBeInTheDocument();
     expect(
-      screen.getByText("You'll return here automatically after consent."),
+      screen.getByText("You'll return here automatically after consent.")
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Authorize" }),
+      screen.getByRole("button", { name: "Authorize" })
     ).toBeInTheDocument();
   });
 
@@ -778,15 +809,15 @@ describe("ChatboxChatPage", () => {
     expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Trigger targeted OAuth" }),
+      screen.getByRole("button", { name: "Trigger targeted OAuth" })
     );
 
     expect(
-      screen.getByRole("heading", { name: "Authorization Required" }),
+      screen.getByRole("heading", { name: "Authorization Required" })
     ).toBeInTheDocument();
     expect(screen.getByText("asana")).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Authorize again" }),
+      screen.queryByRole("button", { name: "Authorize again" })
     ).not.toBeInTheDocument();
     expect(screen.queryByText("linear")).not.toBeInTheDocument();
   });
@@ -830,14 +861,14 @@ describe("ChatboxChatPage", () => {
       render(<ChatboxChatPage />);
 
       expect(
-        await screen.findByText("Welcome — thanks for trying this out."),
+        await screen.findByText("Welcome — thanks for trying this out.")
       ).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: "Get Started" }),
+        screen.getByRole("button", { name: "Get Started" })
       ).toBeInTheDocument();
       // Composer is blocked while the welcome is open
       expect(mockChatTabV2).toHaveBeenCalledWith(
-        expect.objectContaining({ chatboxComposerBlocked: true }),
+        expect.objectContaining({ chatboxComposerBlocked: true })
       );
     });
 
@@ -868,11 +899,11 @@ describe("ChatboxChatPage", () => {
       render(<ChatboxChatPage />);
 
       await userEvent.click(
-        await screen.findByRole("button", { name: "Get Started" }),
+        await screen.findByRole("button", { name: "Get Started" })
       );
 
       expect(
-        screen.queryByText("Welcome — thanks for trying this out."),
+        screen.queryByText("Welcome — thanks for trying this out.")
       ).not.toBeInTheDocument();
       expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
     });
@@ -905,10 +936,10 @@ describe("ChatboxChatPage", () => {
 
       expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
       expect(
-        screen.queryByText("This should not appear."),
+        screen.queryByText("This should not appear.")
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByRole("button", { name: "Get Started" }),
+        screen.queryByRole("button", { name: "Get Started" })
       ).not.toBeInTheDocument();
     });
 
@@ -940,7 +971,7 @@ describe("ChatboxChatPage", () => {
 
       expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
       expect(
-        screen.queryByRole("button", { name: "Get Started" }),
+        screen.queryByRole("button", { name: "Get Started" })
       ).not.toBeInTheDocument();
     });
   });

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
@@ -15,15 +15,23 @@ import {
 
 const {
   mockConvexAuthState,
+  mockWorkOsAuthState,
   mockGetAccessToken,
   mockSignIn,
   mockGetStoredTokens,
   mockInitiateOAuth,
   mockValidateHostedServer,
   mockChatTabV2,
+  mockUseHostedApiContext,
+  mockAuthFetch,
+  mockPosthogCapture,
 } = vi.hoisted(() => ({
   mockConvexAuthState: {
     isAuthenticated: true,
+    isLoading: false,
+  },
+  mockWorkOsAuthState: {
+    user: { id: "user_123" },
     isLoading: false,
   },
   mockGetAccessToken: vi.fn(),
@@ -32,6 +40,9 @@ const {
   mockInitiateOAuth: vi.fn(async () => ({ success: false })),
   mockValidateHostedServer: vi.fn(),
   mockChatTabV2: vi.fn(),
+  mockUseHostedApiContext: vi.fn(),
+  mockAuthFetch: vi.fn(),
+  mockPosthogCapture: vi.fn(),
 }));
 
 vi.mock("convex/react", () => ({
@@ -42,11 +53,23 @@ vi.mock("@workos-inc/authkit-react", () => ({
   useAuth: () => ({
     getAccessToken: mockGetAccessToken,
     signIn: mockSignIn,
+    user: mockWorkOsAuthState.user,
+    isLoading: mockWorkOsAuthState.isLoading,
   }),
 }));
 
 vi.mock("@/hooks/hosted/use-hosted-api-context", () => ({
-  useHostedApiContext: vi.fn(),
+  useHostedApiContext: mockUseHostedApiContext,
+}));
+
+vi.mock("@/lib/session-token", () => ({
+  authFetch: mockAuthFetch,
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({
+    capture: mockPosthogCapture,
+  }),
 }));
 
 vi.mock("@/lib/apis/web/servers-api", () => ({
@@ -138,12 +161,17 @@ describe("ChatboxChatPage", () => {
     window.history.replaceState({}, "", "/");
     mockConvexAuthState.isAuthenticated = true;
     mockConvexAuthState.isLoading = false;
+    mockWorkOsAuthState.user = { id: "user_123" };
+    mockWorkOsAuthState.isLoading = false;
     mockGetAccessToken.mockReset();
     mockSignIn.mockReset();
     mockGetStoredTokens.mockReset();
     mockInitiateOAuth.mockReset();
     mockValidateHostedServer.mockReset();
     mockChatTabV2.mockReset();
+    mockUseHostedApiContext.mockReset();
+    mockAuthFetch.mockReset();
+    mockPosthogCapture.mockReset();
 
     mockGetAccessToken.mockResolvedValue("workos-token");
     mockGetStoredTokens.mockReturnValue(null);
@@ -153,6 +181,23 @@ describe("ChatboxChatPage", () => {
       status: "connected",
       initInfo: null,
     });
+    mockAuthFetch.mockResolvedValue(
+      createFetchResponse({
+        workspaceId: "ws_1",
+        chatboxId: "sbx_1",
+        name: "Resolved Chatbox",
+        description: "Hosted chatbox",
+        hostStyle: "claude",
+        mode: "invited_only",
+        allowGuestAccess: false,
+        viewerIsWorkspaceMember: true,
+        systemPrompt: "You are helpful.",
+        modelId: "openai/gpt-5-mini",
+        temperature: 0.4,
+        requireToolApproval: true,
+        servers: [],
+      }),
+    );
   });
 
   afterEach(() => {
@@ -227,8 +272,6 @@ describe("ChatboxChatPage", () => {
   });
 
   it("loads playground sessions from local storage and skips bootstrap", async () => {
-    const fetchSpy = vi.fn();
-    vi.stubGlobal("fetch", fetchSpy);
     window.history.replaceState(
       {},
       "",
@@ -260,7 +303,7 @@ describe("ChatboxChatPage", () => {
     render(<ChatboxChatPage pathToken="chatbox-token" />);
 
     expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockAuthFetch).not.toHaveBeenCalled();
     expect(mockChatTabV2).toHaveBeenCalledWith(
       expect.objectContaining({
         hostedContext: expect.objectContaining({
@@ -290,17 +333,14 @@ describe("ChatboxChatPage", () => {
   });
 
   it("shows curated copy for an invalid or expired chatbox link", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        createFetchResponse(
-          {
-            code: "NOT_FOUND",
-            message:
-              "Uncaught Error: This chatbox link is invalid or has expired. at resolveChatboxBootstrapForUser (../../convex/chatboxes.ts:309:14) at async handler (../../convex/chatboxes.ts:1088:6)",
-          },
-          { ok: false, status: 404, statusText: "Not Found" },
-        ),
+    mockAuthFetch.mockResolvedValueOnce(
+      createFetchResponse(
+        {
+          code: "NOT_FOUND",
+          message:
+            "Uncaught Error: This chatbox link is invalid or has expired. at resolveChatboxBootstrapForUser (../../convex/chatboxes.ts:309:14) at async handler (../../convex/chatboxes.ts:1088:6)",
+        },
+        { ok: false, status: 404, statusText: "Not Found" },
       ),
     );
 
@@ -320,20 +360,62 @@ describe("ChatboxChatPage", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("waits for WorkOS and Convex auth to settle before bootstrapping the link", async () => {
+    mockConvexAuthState.isAuthenticated = false;
+    mockConvexAuthState.isLoading = false;
+    mockWorkOsAuthState.user = { id: "user_settling" };
+    mockWorkOsAuthState.isLoading = false;
+
+    const { rerender } = render(<ChatboxChatPage pathToken="token-workos" />);
+
+    expect(mockAuthFetch).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", {
+        name: "Sign in",
+      }),
+    ).not.toBeInTheDocument();
+    expect(mockUseHostedApiContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: null,
+        serverIdsByName: {},
+        chatboxToken: "token-workos",
+        isAuthenticated: false,
+      }),
+    );
+
+    mockConvexAuthState.isAuthenticated = true;
+    rerender(<ChatboxChatPage pathToken="token-workos" />);
+
+    expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
+    expect(mockAuthFetch).toHaveBeenCalledTimes(1);
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      "/api/web/chatboxes/bootstrap",
+      expect.objectContaining({
+        body: JSON.stringify({ token: "token-workos" }),
+      }),
+    );
+    expect(mockPosthogCapture).toHaveBeenCalledWith(
+      "chatbox_bootstrap_started",
+      expect.objectContaining({
+        surface: "chatbox",
+        auth_mode: "workos",
+        status: "started",
+      }),
+    );
+  });
+
   it("keeps the access denied sign-in path intact", async () => {
     mockConvexAuthState.isAuthenticated = false;
+    mockWorkOsAuthState.user = null;
     window.history.replaceState({}, "", "/chatbox/test/token-denied");
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        createFetchResponse(
-          {
-            code: "FORBIDDEN",
-            message:
-              "You don't have access to Test Chatbox. This chatbox is invite-only - ask the owner to invite you.",
-          },
-          { ok: false, status: 403, statusText: "Forbidden" },
-        ),
+    mockAuthFetch.mockResolvedValueOnce(
+      createFetchResponse(
+        {
+          code: "FORBIDDEN",
+          message:
+            "You don't have access to Test Chatbox. This chatbox is invite-only - ask the owner to invite you.",
+        },
+        { ok: false, status: 403, statusText: "Forbidden" },
       ),
     );
 
@@ -355,21 +437,85 @@ describe("ChatboxChatPage", () => {
     );
   });
 
+  it("shows the sign-in CTA for guest-blocked links only after bootstrap denies access", async () => {
+    mockConvexAuthState.isAuthenticated = false;
+    mockWorkOsAuthState.user = null;
+    mockAuthFetch.mockResolvedValueOnce(
+      createFetchResponse(
+        {
+          code: "FORBIDDEN",
+          message:
+            "Guests cannot access Test Chatbox. This chatbox does not allow guest access.",
+        },
+        { ok: false, status: 403, statusText: "Forbidden" },
+      ),
+    );
+
+    render(<ChatboxChatPage pathToken="token-guest-blocked" />);
+
+    expect(
+      screen.queryByRole("button", {
+        name: "Sign in",
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(
+      await screen.findByRole("heading", { name: "Access Denied" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Sign in",
+      }),
+    ).toBeInTheDocument();
+    expect(mockPosthogCapture).toHaveBeenCalledWith(
+      "interactive_signin_required",
+      expect.objectContaining({
+        surface: "chatbox",
+        auth_mode: "guest",
+        status: "required",
+        error_kind: "guest_blocked",
+      }),
+    );
+  });
+
+  it("does not show the sign-in CTA when an authenticated viewer is denied", async () => {
+    mockConvexAuthState.isAuthenticated = true;
+    mockWorkOsAuthState.user = { id: "user_denied" };
+    mockAuthFetch.mockResolvedValueOnce(
+      createFetchResponse(
+        {
+          code: "FORBIDDEN",
+          message:
+            "You don't have access to Test Chatbox. This chatbox is invite-only - ask the owner to invite you.",
+        },
+        { ok: false, status: 403, statusText: "Forbidden" },
+      ),
+    );
+
+    render(<ChatboxChatPage pathToken="token-auth-denied" />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Access Denied" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: "Sign in",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows a generic fallback for unexpected chatbox bootstrap failures", async () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(
-        createFetchResponse(
-          {
-            code: "INTERNAL_ERROR",
-            message:
-              "Uncaught Error: Internal database exploded at handler (../../convex/chatboxes.ts:1088:6)",
-          },
-          { ok: false, status: 500, statusText: "Internal Server Error" },
-        ),
+    mockAuthFetch.mockResolvedValueOnce(
+      createFetchResponse(
+        {
+          code: "INTERNAL_ERROR",
+          message:
+            "Uncaught Error: Internal database exploded at handler (../../convex/chatboxes.ts:1088:6)",
+        },
+        { ok: false, status: 500, statusText: "Internal Server Error" },
       ),
     );
 

--- a/mcpjam-inspector/client/src/lib/__tests__/session-token.hosted-retry.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/session-token.hosted-retry.test.ts
@@ -11,6 +11,12 @@ vi.mock("@/lib/config", () => ({
   HOSTED_MODE: true,
 }));
 
+vi.mock("posthog-js", () => ({
+  default: {
+    capture: vi.fn(),
+  },
+}));
+
 vi.mock("@/lib/guest-session", () => ({
   getGuestBearerToken: vi.fn(),
   forceRefreshGuestSession: vi.fn(),
@@ -35,6 +41,7 @@ import {
   resetTokenCache,
   shouldRetryHostedAuth401,
 } from "@/lib/apis/web/context";
+import posthog from "posthog-js";
 
 describe("authFetch hosted 401 retry", () => {
   beforeEach(() => {
@@ -43,13 +50,14 @@ describe("authFetch hosted 401 retry", () => {
     vi.mocked(forceRefreshGuestSession).mockReset();
     vi.mocked(shouldRetryHostedAuth401).mockReturnValue(true);
     vi.mocked(global.fetch).mockReset();
+    vi.mocked(posthog.capture).mockReset();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("retries with fresh token on 401 when hosted auth is guest-backed", async () => {
+  it("retries chatbox bootstrap once with a refreshed guest token after a 401", async () => {
     vi.mocked(getHostedAuthorizationHeader).mockResolvedValueOnce(
       "Bearer stale-token",
     );
@@ -63,10 +71,10 @@ describe("authFetch hosted 401 retry", () => {
         json: () => Promise.resolve({ success: true }),
       } as Response);
 
-    const response = await authFetch("/api/web/tools/list", {
+    const response = await authFetch("/api/web/chatboxes/bootstrap", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({}),
+      body: JSON.stringify({ token: "chatbox-token" }),
     });
 
     expect(response.status).toBe(200);
@@ -75,13 +83,18 @@ describe("authFetch hosted 401 retry", () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
     expect(global.fetch).toHaveBeenNthCalledWith(
       2,
-      "/api/web/tools/list",
+      "/api/web/chatboxes/bootstrap",
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: "Bearer fresh-token",
         }),
       }),
     );
+    expect(posthog.capture).toHaveBeenCalledWith("guest_refresh_success", {
+      surface: "chatbox",
+      auth_mode: "guest",
+      status: "success",
+    });
   });
 
   it("returns 401 if retry also fails (no infinite loop)", async () => {
@@ -168,12 +181,18 @@ describe("authFetch hosted 401 retry", () => {
       ok: false,
     } as Response);
 
-    const response = await authFetch("/api/web/test");
+    const response = await authFetch("/api/web/chatboxes/bootstrap");
 
     expect(response.status).toBe(401);
     expect(resetTokenCache).toHaveBeenCalledTimes(1);
     expect(forceRefreshGuestSession).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledTimes(1); // no retry
+    expect(posthog.capture).toHaveBeenCalledWith("guest_refresh_failure", {
+      surface: "chatbox",
+      auth_mode: "guest",
+      status: "failure",
+      error_kind: "guest_refresh_unavailable",
+    });
   });
 
   it("passes through successful responses without retry", async () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/session-token.hosted-retry.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/session-token.hosted-retry.test.ts
@@ -24,7 +24,7 @@ vi.mock("@/lib/guest-session", () => ({
 
 vi.mock("@/lib/apis/web/context", async () => {
   const actual = await vi.importActual<typeof import("@/lib/apis/web/context")>(
-    "@/lib/apis/web/context",
+    "@/lib/apis/web/context"
   );
   return {
     ...actual,
@@ -59,7 +59,7 @@ describe("authFetch hosted 401 retry", () => {
 
   it("retries chatbox bootstrap once with a refreshed guest token after a 401", async () => {
     vi.mocked(getHostedAuthorizationHeader).mockResolvedValueOnce(
-      "Bearer stale-token",
+      "Bearer stale-token"
     );
     vi.mocked(forceRefreshGuestSession).mockResolvedValue("fresh-token");
 
@@ -88,7 +88,7 @@ describe("authFetch hosted 401 retry", () => {
         headers: expect.objectContaining({
           Authorization: "Bearer fresh-token",
         }),
-      }),
+      })
     );
     expect(posthog.capture).toHaveBeenCalledWith("guest_refresh_success", {
       surface: "chatbox",
@@ -99,7 +99,7 @@ describe("authFetch hosted 401 retry", () => {
 
   it("returns 401 if retry also fails (no infinite loop)", async () => {
     vi.mocked(getHostedAuthorizationHeader).mockResolvedValueOnce(
-      "Bearer stale-token",
+      "Bearer stale-token"
     );
     vi.mocked(forceRefreshGuestSession).mockResolvedValue("still-bad-token");
 
@@ -111,11 +111,12 @@ describe("authFetch hosted 401 retry", () => {
 
     expect(response.status).toBe(401);
     expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(posthog.capture).not.toHaveBeenCalled();
   });
 
   it("does not retry on non-401 errors", async () => {
     vi.mocked(getHostedAuthorizationHeader).mockResolvedValue(
-      "Bearer some-token",
+      "Bearer some-token"
     );
 
     vi.mocked(global.fetch).mockResolvedValueOnce({
@@ -133,7 +134,7 @@ describe("authFetch hosted 401 retry", () => {
 
   it("does not retry when caller provided Authorization header", async () => {
     vi.mocked(getHostedAuthorizationHeader).mockResolvedValueOnce(
-      "Bearer stale-token",
+      "Bearer stale-token"
     );
 
     vi.mocked(global.fetch).mockResolvedValueOnce({
@@ -154,7 +155,7 @@ describe("authFetch hosted 401 retry", () => {
   it("does not retry when hosted auth is fully authenticated", async () => {
     vi.mocked(shouldRetryHostedAuth401).mockReturnValue(false);
     vi.mocked(getHostedAuthorizationHeader).mockResolvedValueOnce(
-      "Bearer workos-token",
+      "Bearer workos-token"
     );
 
     vi.mocked(global.fetch).mockResolvedValueOnce({
@@ -172,7 +173,7 @@ describe("authFetch hosted 401 retry", () => {
 
   it("returns original 401 when forceRefresh returns null", async () => {
     vi.mocked(getHostedAuthorizationHeader).mockResolvedValueOnce(
-      "Bearer stale-token",
+      "Bearer stale-token"
     );
     vi.mocked(forceRefreshGuestSession).mockResolvedValue(null);
 
@@ -197,7 +198,7 @@ describe("authFetch hosted 401 retry", () => {
 
   it("passes through successful responses without retry", async () => {
     vi.mocked(getHostedAuthorizationHeader).mockResolvedValue(
-      "Bearer good-token",
+      "Bearer good-token"
     );
 
     vi.mocked(global.fetch).mockResolvedValueOnce({

--- a/mcpjam-inspector/client/src/lib/session-token.ts
+++ b/mcpjam-inspector/client/src/lib/session-token.ts
@@ -19,6 +19,7 @@ import {
   shouldRetryHostedAuth401,
 } from "@/lib/apis/web/context";
 import { forceRefreshGuestSession } from "@/lib/guest-session";
+import posthog from "posthog-js";
 
 // Extend window type for the injected token
 declare global {
@@ -29,6 +30,30 @@ declare global {
 
 let cachedToken: string | null = null;
 let initPromise: Promise<string> | null = null;
+
+function resolveAuthFetchSurface(input: RequestInfo | URL): "chatbox" | null {
+  const rawUrl =
+    input instanceof URL
+      ? input.toString()
+      : typeof Request !== "undefined" && input instanceof Request
+        ? input.url
+        : String(input);
+  const baseOrigin =
+    typeof window !== "undefined" ? window.location.origin : "http://localhost";
+
+  try {
+    const parsed = new URL(rawUrl, baseOrigin);
+    if (parsed.pathname === "/api/web/chatboxes/bootstrap") {
+      return "chatbox";
+    }
+  } catch {
+    if (rawUrl === "/api/web/chatboxes/bootstrap") {
+      return "chatbox";
+    }
+  }
+
+  return null;
+}
 
 function mergeHeaders(
   ...headersList: Array<HeadersInit | undefined>
@@ -226,6 +251,7 @@ export async function authFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
 ): Promise<Response> {
+  const surface = resolveAuthFetchSurface(input);
   const hostedAuthHeader = await getHostedAuthorizationHeader();
   const callerProvidedAuthorization = hasAuthorizationHeader(init?.headers);
   const mergedInit = buildAuthFetchInit(init, hostedAuthHeader);
@@ -245,7 +271,23 @@ export async function authFetch(
   resetTokenCache();
   const refreshedGuestToken = await forceRefreshGuestSession();
   if (!refreshedGuestToken) {
+    if (surface) {
+      posthog.capture("guest_refresh_failure", {
+        surface,
+        auth_mode: "guest",
+        status: "failure",
+        error_kind: "guest_refresh_unavailable",
+      });
+    }
     return response;
+  }
+
+  if (surface) {
+    posthog.capture("guest_refresh_success", {
+      surface,
+      auth_mode: "guest",
+      status: "success",
+    });
   }
 
   const retryInit = buildAuthFetchInit(init, `Bearer ${refreshedGuestToken}`);

--- a/mcpjam-inspector/client/src/lib/session-token.ts
+++ b/mcpjam-inspector/client/src/lib/session-token.ts
@@ -31,28 +31,30 @@ declare global {
 let cachedToken: string | null = null;
 let initPromise: Promise<string> | null = null;
 
-function resolveAuthFetchSurface(input: RequestInfo | URL): "chatbox" | null {
+type AuthFetchSurface = "chatbox";
+
+const AUTH_FETCH_SURFACE_BY_PATH: Record<string, AuthFetchSurface> = {
+  "/api/web/chatboxes/bootstrap": "chatbox",
+};
+
+function resolveAuthFetchSurface(
+  input: RequestInfo | URL
+): AuthFetchSurface | null {
   const rawUrl =
     input instanceof URL
       ? input.toString()
       : typeof Request !== "undefined" && input instanceof Request
-        ? input.url
-        : String(input);
+      ? input.url
+      : String(input);
   const baseOrigin =
     typeof window !== "undefined" ? window.location.origin : "http://localhost";
 
   try {
     const parsed = new URL(rawUrl, baseOrigin);
-    if (parsed.pathname === "/api/web/chatboxes/bootstrap") {
-      return "chatbox";
-    }
+    return AUTH_FETCH_SURFACE_BY_PATH[parsed.pathname] ?? null;
   } catch {
-    if (rawUrl === "/api/web/chatboxes/bootstrap") {
-      return "chatbox";
-    }
+    return AUTH_FETCH_SURFACE_BY_PATH[rawUrl] ?? null;
   }
-
-  return null;
 }
 
 function mergeHeaders(
@@ -95,13 +97,13 @@ function hasAuthorizationHeader(headers?: HeadersInit): boolean {
   }
 
   return Object.keys(headers).some(
-    (key) => key.toLowerCase() === "authorization",
+    (key) => key.toLowerCase() === "authorization"
   );
 }
 
 function buildAuthFetchInit(
   init: RequestInit | undefined,
-  hostedAuthorizationHeader: string | null,
+  hostedAuthorizationHeader: string | null
 ): RequestInit {
   const sessionHeaders = getAuthHeaders();
   const hostedHeaders = hostedAuthorizationHeader
@@ -249,7 +251,7 @@ export function addTokenToUrl(url: string): string {
  */
 export async function authFetch(
   input: RequestInfo | URL,
-  init?: RequestInit,
+  init?: RequestInit
 ): Promise<Response> {
   const surface = resolveAuthFetchSurface(input);
   const hostedAuthHeader = await getHostedAuthorizationHeader();


### PR DESCRIPTION
## Summary
- route chatbox bootstrap through the shared hosted `authFetch` path instead of page-local bearer selection
- hold chatbox landing in explicit `resolvingAuth` and `bootstrapping` states until WorkOS/AuthKit and Convex auth have settled
- add PostHog instrumentation for silent bootstrap, interactive sign-in fallback, and guest refresh outcomes

## Why
`ChatboxChatPage` was choosing its own bearer and bootstrapping before the shared hosted auth state had settled. That created inconsistent revisit behavior, skipped the centralized guest-refresh retry path, and could flash the sign-in CTA before the page actually knew whether silent auth would succeed.

## Impact
Returning chatbox visitors now reuse the same hosted auth path as the rest of the app, guest retry behavior stays centralized, and the landing UI only asks users to sign in after a real denied result.

## Validation
- `npm run test -w @mcpjam/inspector -- client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx`
- `npm run test -w @mcpjam/inspector -- client/src/lib/__tests__/session-token.hosted-retry.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes chatbox bootstrap/auth settling logic and centralized hosted `authFetch` retry behavior, which can impact access flows and sign-in UX. Adds analytics events around auth/guest refresh that should be validated in production telemetry volume and correctness.
> 
> **Overview**
> Chatbox share-link bootstrap is now routed through the shared hosted `authFetch` path (removing page-local bearer selection), and the landing UI is refactored into explicit states (`resolvingAuth`/`bootstrapping`/`ready`/`denied`) to avoid bootstrapping or showing sign-in CTAs before WorkOS + Convex auth have settled.
> 
> Adds PostHog instrumentation for silent bootstrap start/success/failure, emits an `interactive_signin_required` event when access is denied for unauthenticated viewers, and extends `authFetch` to record guest token refresh success/failure for `/api/web/chatboxes/bootstrap` 401 retries. Tests are updated/expanded accordingly, plus a small MCP apps renderer test expectation change from `visibility` to opacity/position/pointer-events hiding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 258d5455f9768893bec95a9c1709f2b263dd16be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->