### PR TITLE
[logging] inspector: add typed event foundation

### DIFF
--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -42,6 +42,7 @@ import { startGuestAuthProvisioningInBackground } from "./utils/convex-guest-aut
 import { fetchRemoteGuestJwks } from "./utils/guest-session-source.js";
 import { INSPECTOR_MCP_RETRY_POLICY } from "./utils/mcp-retry-policy.js";
 import { initXAAIdpKeyPair } from "./services/xaa-idp-keypair.js";
+import { requestLogContextMiddleware } from "./middleware/request-log-context.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -156,6 +157,9 @@ export function createHonoApp() {
   app.use("*", sessionAuthMiddleware);
 
   // ===== END SECURITY MIDDLEWARE =====
+
+  // 5. Request log context (only on /api/* to avoid static files)
+  app.use("/api/*", requestLogContextMiddleware);
 
   // Middleware - only enable HTTP request logging in dev mode or when --verbose is passed
   const enableHttpLogs =

--- a/mcpjam-inspector/server/app.ts
+++ b/mcpjam-inspector/server/app.ts
@@ -121,6 +121,12 @@ export function createHonoApp() {
     await next();
   });
 
+  // Request log context (mounted BEFORE the security stack so that 401s from
+  // session auth, 403s from origin validation, and hosted-mode 410 partition
+  // responses are still observed in Axiom — those are exactly the requests
+  // SREs want to see during an outage or attack).
+  app.use("/api/*", requestLogContextMiddleware);
+
   // ===== SECURITY MIDDLEWARE STACK =====
   // Order matters: headers -> origin validation -> strict partition -> session auth
 
@@ -157,9 +163,6 @@ export function createHonoApp() {
   app.use("*", sessionAuthMiddleware);
 
   // ===== END SECURITY MIDDLEWARE =====
-
-  // 5. Request log context (only on /api/* to avoid static files)
-  app.use("/api/*", requestLogContextMiddleware);
 
   // Middleware - only enable HTTP request logging in dev mode or when --verbose is passed
   const enableHttpLogs =

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -34,7 +34,6 @@ import { inAppBrowserMiddleware } from "./middleware/in-app-browser";
 import { startGuestAuthProvisioningInBackground } from "./utils/convex-guest-auth-sync";
 
 import { getSystemLogger } from "./utils/request-logger";
-import { resolveEnvironment, resolveRelease } from "./utils/log-events";
 
 const sysLogger = getSystemLogger("process");
 
@@ -42,32 +41,26 @@ const sysLogger = getSystemLogger("process");
 // This prevents the server from crashing when MCP connections are closed while
 // requests are pending - the SDK rejects pending promises on connection close
 process.on("unhandledRejection", (reason, _promise) => {
-  // Check if this is an expected MCP connection close error
   const isMcpConnectionClosed =
     reason instanceof Error &&
     (reason.message.includes("Connection closed") ||
       reason.name === "McpError");
 
   if (isMcpConnectionClosed) {
-    sysLogger.event(
-      "mcp.connection.closed_with_pending_requests",
-      {
-        environment: resolveEnvironment(),
-        release: resolveRelease(),
-        requestId: null,
-        route: null,
-        method: null,
-        authType: "system" as const,
-      },
-      { errorCode: "connection_closed" },
-    );
-  } else {
-    // Log unexpected rejections as warnings
-    appLogger.warn("Unhandled promise rejection", {
-      reason: reason instanceof Error ? reason.message : String(reason),
-      stack: reason instanceof Error ? reason.stack : undefined,
+    sysLogger.event("mcp.connection.closed_with_pending_requests", {
+      errorCode: "connection_closed",
     });
+    return;
   }
+
+  sysLogger.event(
+    "process.unhandled_rejection",
+    { errorCode: reason instanceof Error ? reason.name : "unknown" },
+    {
+      error: reason instanceof Error ? reason : undefined,
+      sentry: true,
+    },
+  );
 });
 
 const __filename = fileURLToPath(import.meta.url);

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -33,6 +33,11 @@ import { securityHeadersMiddleware } from "./middleware/security-headers";
 import { inAppBrowserMiddleware } from "./middleware/in-app-browser";
 import { startGuestAuthProvisioningInBackground } from "./utils/convex-guest-auth-sync";
 
+import { getSystemLogger } from "./utils/request-logger";
+import { resolveEnvironment, resolveRelease } from "./utils/log-events";
+
+const sysLogger = getSystemLogger("process");
+
 // Handle unhandled promise rejections gracefully (Node.js v24+ throws by default)
 // This prevents the server from crashing when MCP connections are closed while
 // requests are pending - the SDK rejects pending promises on connection close
@@ -44,10 +49,18 @@ process.on("unhandledRejection", (reason, _promise) => {
       reason.name === "McpError");
 
   if (isMcpConnectionClosed) {
-    // Log at debug level - this is expected during disconnect operations
-    appLogger.debug("MCP connection closed with pending requests", {
-      message: reason.message,
-    });
+    sysLogger.event(
+      "mcp.connection.closed_with_pending_requests",
+      {
+        environment: resolveEnvironment(),
+        release: resolveRelease(),
+        requestId: null,
+        route: null,
+        method: null,
+        authType: "system" as const,
+      },
+      { errorCode: "connection_closed" },
+    );
   } else {
     // Log unexpected rejections as warnings
     appLogger.warn("Unhandled promise rejection", {

--- a/mcpjam-inspector/server/middleware/__tests__/request-log-context.middleware.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/request-log-context.middleware.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Hono } from "hono";
 
 vi.mock("@sentry/node", () => ({
@@ -57,10 +57,9 @@ describe("requestLogContextMiddleware", () => {
     expect(capturedCtx.method).toBe("GET");
     expect(capturedCtx.authType).toBe("unknown");
     expect(capturedCtx.environment).toBeDefined();
-    expect(capturedCtx.release).toBeDefined();
   });
 
-  it("sets x-request-id response header", async () => {
+  it("sets x-request-id response header via c.header()", async () => {
     const app = createTestApp();
     app.get("/api/web/test", (c) => c.json({ ok: true }));
 
@@ -78,33 +77,77 @@ describe("requestLogContextMiddleware", () => {
     expect(res.headers.get("x-request-id")).toBe("my-custom-id");
   });
 
-  it("emits exactly one http.request.completed for a 200 response and zero http.request.failed", async () => {
+  it("emits exactly one http.request.completed for a 200 response", async () => {
     const app = createTestApp();
     app.get("/api/web/test", (c) => c.json({ ok: true }));
 
     await app.request("/api/web/test");
 
     const calls = vi.mocked(logger.event).mock.calls;
-    const completedCalls = calls.filter(([name]) => name === "http.request.completed");
-    const failedCalls = calls.filter(([name]) => name === "http.request.failed");
+    const completedCalls = calls.filter(
+      ([name]) => name === "http.request.completed",
+    );
+    const failedCalls = calls.filter(
+      ([name]) => name === "http.request.failed",
+    );
 
     expect(completedCalls).toHaveLength(1);
     expect(failedCalls).toHaveLength(0);
     expect((completedCalls[0][2] as any).statusCode).toBe(200);
   });
 
-  it("emits exactly one http.request.failed for a 500 response and zero http.request.completed", async () => {
+  it("emits exactly one http.request.failed for a 500 response with no Sentry forwarding", async () => {
     const app = createTestApp();
     app.get("/api/web/test", (c) => c.json({ error: "boom" }, 500));
 
     await app.request("/api/web/test");
 
     const calls = vi.mocked(logger.event).mock.calls;
-    const completedCalls = calls.filter(([name]) => name === "http.request.completed");
-    const failedCalls = calls.filter(([name]) => name === "http.request.failed");
-
+    const failedCalls = calls.filter(
+      ([name]) => name === "http.request.failed",
+    );
     expect(failedCalls).toHaveLength(1);
-    expect(completedCalls).toHaveLength(0);
+
+    // Sentry forwarding must NOT be opted into by middleware — the route's
+    // error handler / Sentry middleware owns capture for this exception.
+    const options = failedCalls[0][3] as { sentry?: boolean } | undefined;
+    expect(options?.sentry).not.toBe(true);
+  });
+
+  it("emits http.request.failed when an upstream short-circuit returns 5xx (auth-failure scenario)", async () => {
+    // Simulates a security middleware (e.g. session auth) returning 503 before
+    // the route handler runs. With the middleware mounted before the security
+    // stack, that response must still be observed.
+    const app = new Hono();
+    app.use("/api/*", requestLogContextMiddleware);
+    app.use("/api/*", async (c) => c.json({ error: "service down" }, 503));
+    app.get("/api/web/test", (c) => c.json({ ok: true }));
+
+    await app.request("/api/web/test");
+
+    const failed = vi
+      .mocked(logger.event)
+      .mock.calls.filter(([name]) => name === "http.request.failed");
+    expect(failed).toHaveLength(1);
+    expect((failed[0][2] as any).statusCode).toBe(503);
+  });
+
+  it("emits http.request.completed when an upstream short-circuit returns 401/403", async () => {
+    // 4xx short-circuits (e.g. unauthenticated requests) are not failures from
+    // the server's perspective but still need to be observed for traffic
+    // accounting and security-incident triage.
+    const app = new Hono();
+    app.use("/api/*", requestLogContextMiddleware);
+    app.use("/api/*", async (c) => c.json({ error: "unauthorized" }, 401));
+    app.get("/api/web/test", (c) => c.json({ ok: true }));
+
+    await app.request("/api/web/test");
+
+    const completed = vi
+      .mocked(logger.event)
+      .mock.calls.filter(([name]) => name === "http.request.completed");
+    expect(completed).toHaveLength(1);
+    expect((completed[0][2] as any).statusCode).toBe(401);
   });
 
   it("does not emit anything for /api/mcp/health", async () => {
@@ -125,21 +168,42 @@ describe("requestLogContextMiddleware", () => {
     expect(vi.mocked(logger.event)).not.toHaveBeenCalled();
   });
 
+  it("treats any */health or */healthz suffix as a probe (broader than the exact set)", async () => {
+    const app = createTestApp();
+    app.get("/api/web/health", (c) => c.json({ ok: true }));
+    app.get("/api/web/probe/healthz", (c) => c.json({ ok: true }));
+
+    await app.request("/api/web/health");
+    await app.request("/api/web/probe/healthz");
+
+    expect(vi.mocked(logger.event)).not.toHaveBeenCalled();
+  });
+
+  it("normalizes a trailing slash in the health-path check", async () => {
+    const app = createTestApp();
+    app.get("/api/mcp/health/", (c) => c.json({ ok: true }));
+
+    await app.request("/api/mcp/health/");
+
+    expect(vi.mocked(logger.event)).not.toHaveBeenCalled();
+  });
+
   it("does not use raw URL as route for a 404 (uses pattern or 'unmatched')", async () => {
     const app = createTestApp();
 
     await app.request("/api/web/nonexistent");
 
     const calls = vi.mocked(logger.event).mock.calls;
-    const completedCalls = calls.filter(([name]) => name === "http.request.completed");
+    const completedCalls = calls.filter(
+      ([name]) => name === "http.request.completed",
+    );
     if (completedCalls.length > 0) {
       const base = completedCalls[0][1] as any;
-      // route should be a pattern (e.g. /api/*) or "unmatched", never the raw URL
       expect(base.route).not.toContain("nonexistent");
     }
   });
 
-  it("skips emission for SSE streaming routes", async () => {
+  it("emits http.stream.opened for SSE responses (no longer silently dropped)", async () => {
     const app = createTestApp();
     app.get("/api/web/stream", (c) => {
       c.header("Content-Type", "text/event-stream");
@@ -149,10 +213,40 @@ describe("requestLogContextMiddleware", () => {
     await app.request("/api/web/stream");
 
     const calls = vi.mocked(logger.event).mock.calls;
-    const httpCalls = calls.filter(
-      ([name]) => name === "http.request.completed" || name === "http.request.failed",
+    const opened = calls.filter(([name]) => name === "http.stream.opened");
+    const completed = calls.filter(
+      ([name]) => name === "http.request.completed",
     );
-    expect(httpCalls).toHaveLength(0);
+    const failed = calls.filter(([name]) => name === "http.request.failed");
+
+    expect(opened).toHaveLength(1);
+    expect(completed).toHaveLength(0);
+    expect(failed).toHaveLength(0);
+  });
+
+  it("emits http.stream.closed when the consumer finishes reading the SSE body", async () => {
+    const app = createTestApp();
+    app.get("/api/web/stream", (c) => {
+      c.header("Content-Type", "text/event-stream");
+      return c.body("data: hello\n\n");
+    });
+
+    const res = await app.request("/api/web/stream");
+    // Drain the body so the TransformStream's flush() fires.
+    if (res.body) {
+      const reader = res.body.getReader();
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+    }
+
+    const closed = vi
+      .mocked(logger.event)
+      .mock.calls.filter(([name]) => name === "http.stream.closed");
+    expect(closed).toHaveLength(1);
+    expect((closed[0][2] as any).durationMs).toBeGreaterThanOrEqual(0);
   });
 
   it("re-throws exceptions after emitting http.request.failed", async () => {
@@ -165,8 +259,9 @@ describe("requestLogContextMiddleware", () => {
     const res = await app.request("/api/web/explode");
     expect(res.status).toBe(500);
 
-    const calls = vi.mocked(logger.event).mock.calls;
-    const failedCalls = calls.filter(([name]) => name === "http.request.failed");
-    expect(failedCalls).toHaveLength(1);
+    const failed = vi
+      .mocked(logger.event)
+      .mock.calls.filter(([name]) => name === "http.request.failed");
+    expect(failed).toHaveLength(1);
   });
 });

--- a/mcpjam-inspector/server/middleware/__tests__/request-log-context.middleware.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/request-log-context.middleware.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+
+vi.mock("@sentry/node", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+vi.mock("@axiomhq/js", () => ({
+  Axiom: vi.fn().mockImplementation(() => ({
+    ingest: vi.fn(),
+    flush: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    flush: vi.fn(),
+    event: vi.fn(),
+    systemEvent: vi.fn(),
+  },
+}));
+
+import { requestLogContextMiddleware } from "../request-log-context.js";
+import { logger } from "../../utils/logger.js";
+
+function createTestApp() {
+  const app = new Hono();
+  app.use("/api/*", requestLogContextMiddleware);
+  return app;
+}
+
+describe("requestLogContextMiddleware", () => {
+  beforeEach(() => {
+    vi.mocked(logger.event).mockClear();
+    vi.mocked(logger.systemEvent).mockClear();
+  });
+
+  it("populates requestLogContext for an API request", async () => {
+    const app = createTestApp();
+    let capturedCtx: any;
+
+    app.get("/api/web/test", (c) => {
+      capturedCtx = c.var.requestLogContext;
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request("/api/web/test", { method: "GET" });
+    expect(res.status).toBe(200);
+
+    expect(capturedCtx).toBeDefined();
+    expect(capturedCtx.requestId).toBeTruthy();
+    expect(capturedCtx.method).toBe("GET");
+    expect(capturedCtx.authType).toBe("unknown");
+    expect(capturedCtx.environment).toBeDefined();
+    expect(capturedCtx.release).toBeDefined();
+  });
+
+  it("sets x-request-id response header", async () => {
+    const app = createTestApp();
+    app.get("/api/web/test", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/api/web/test");
+    expect(res.headers.get("x-request-id")).toBeTruthy();
+  });
+
+  it("uses x-request-id from incoming request if provided", async () => {
+    const app = createTestApp();
+    app.get("/api/web/test", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/api/web/test", {
+      headers: { "x-request-id": "my-custom-id" },
+    });
+    expect(res.headers.get("x-request-id")).toBe("my-custom-id");
+  });
+
+  it("emits exactly one http.request.completed for a 200 response and zero http.request.failed", async () => {
+    const app = createTestApp();
+    app.get("/api/web/test", (c) => c.json({ ok: true }));
+
+    await app.request("/api/web/test");
+
+    const calls = vi.mocked(logger.event).mock.calls;
+    const completedCalls = calls.filter(([name]) => name === "http.request.completed");
+    const failedCalls = calls.filter(([name]) => name === "http.request.failed");
+
+    expect(completedCalls).toHaveLength(1);
+    expect(failedCalls).toHaveLength(0);
+    expect((completedCalls[0][2] as any).statusCode).toBe(200);
+  });
+
+  it("emits exactly one http.request.failed for a 500 response and zero http.request.completed", async () => {
+    const app = createTestApp();
+    app.get("/api/web/test", (c) => c.json({ error: "boom" }, 500));
+
+    await app.request("/api/web/test");
+
+    const calls = vi.mocked(logger.event).mock.calls;
+    const completedCalls = calls.filter(([name]) => name === "http.request.completed");
+    const failedCalls = calls.filter(([name]) => name === "http.request.failed");
+
+    expect(failedCalls).toHaveLength(1);
+    expect(completedCalls).toHaveLength(0);
+  });
+
+  it("does not emit anything for /api/mcp/health", async () => {
+    const app = createTestApp();
+    app.get("/api/mcp/health", (c) => c.json({ status: "ok" }));
+
+    await app.request("/api/mcp/health");
+
+    expect(vi.mocked(logger.event)).not.toHaveBeenCalled();
+  });
+
+  it("does not emit anything for /api/apps/health", async () => {
+    const app = createTestApp();
+    app.get("/api/apps/health", (c) => c.json({ status: "ok" }));
+
+    await app.request("/api/apps/health");
+
+    expect(vi.mocked(logger.event)).not.toHaveBeenCalled();
+  });
+
+  it("does not use raw URL as route for a 404 (uses pattern or 'unmatched')", async () => {
+    const app = createTestApp();
+
+    await app.request("/api/web/nonexistent");
+
+    const calls = vi.mocked(logger.event).mock.calls;
+    const completedCalls = calls.filter(([name]) => name === "http.request.completed");
+    if (completedCalls.length > 0) {
+      const base = completedCalls[0][1] as any;
+      // route should be a pattern (e.g. /api/*) or "unmatched", never the raw URL
+      expect(base.route).not.toContain("nonexistent");
+    }
+  });
+
+  it("skips emission for SSE streaming routes", async () => {
+    const app = createTestApp();
+    app.get("/api/web/stream", (c) => {
+      c.header("Content-Type", "text/event-stream");
+      return c.body("data: hello\n\n");
+    });
+
+    await app.request("/api/web/stream");
+
+    const calls = vi.mocked(logger.event).mock.calls;
+    const httpCalls = calls.filter(
+      ([name]) => name === "http.request.completed" || name === "http.request.failed",
+    );
+    expect(httpCalls).toHaveLength(0);
+  });
+
+  it("re-throws exceptions after emitting http.request.failed", async () => {
+    const app = createTestApp();
+    app.get("/api/web/explode", () => {
+      throw new Error("unexpected failure");
+    });
+    app.onError((err, c) => c.json({ error: err.message }, 500));
+
+    const res = await app.request("/api/web/explode");
+    expect(res.status).toBe(500);
+
+    const calls = vi.mocked(logger.event).mock.calls;
+    const failedCalls = calls.filter(([name]) => name === "http.request.failed");
+    expect(failedCalls).toHaveLength(1);
+  });
+});

--- a/mcpjam-inspector/server/middleware/__tests__/request-log-context.middleware.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/request-log-context.middleware.test.ts
@@ -77,6 +77,40 @@ describe("requestLogContextMiddleware", () => {
     expect(res.headers.get("x-request-id")).toBe("my-custom-id");
   });
 
+  it("rejects an inbound x-request-id that is too short", async () => {
+    const app = createTestApp();
+    app.get("/api/web/test", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/api/web/test", {
+      headers: { "x-request-id": "short" },
+    });
+    expect(res.headers.get("x-request-id")).not.toBe("short");
+    expect(res.headers.get("x-request-id")).toMatch(/^[A-Za-z0-9_-]{8,128}$/);
+  });
+
+  it("rejects an inbound x-request-id that is excessively long (cardinality blowup)", async () => {
+    const app = createTestApp();
+    app.get("/api/web/test", (c) => c.json({ ok: true }));
+
+    const oversized = "a".repeat(2048);
+    const res = await app.request("/api/web/test", {
+      headers: { "x-request-id": oversized },
+    });
+    expect(res.headers.get("x-request-id")).not.toBe(oversized);
+    expect(res.headers.get("x-request-id")?.length).toBeLessThanOrEqual(128);
+  });
+
+  it("rejects an inbound x-request-id with disallowed characters", async () => {
+    const app = createTestApp();
+    app.get("/api/web/test", (c) => c.json({ ok: true }));
+
+    const res = await app.request("/api/web/test", {
+      headers: { "x-request-id": "abc def!@#$%" },
+    });
+    expect(res.headers.get("x-request-id")).not.toBe("abc def!@#$%");
+    expect(res.headers.get("x-request-id")).toMatch(/^[A-Za-z0-9_-]{8,128}$/);
+  });
+
   it("emits exactly one http.request.completed for a 200 response", async () => {
     const app = createTestApp();
     app.get("/api/web/test", (c) => c.json({ ok: true }));

--- a/mcpjam-inspector/server/middleware/request-log-context.ts
+++ b/mcpjam-inspector/server/middleware/request-log-context.ts
@@ -1,0 +1,93 @@
+import type { Context, Next } from "hono";
+import { randomUUID } from "node:crypto";
+import {
+  resolveEnvironment,
+  resolveRelease,
+  type RequestLogContext,
+} from "../utils/log-events.js";
+import { getRequestLogger } from "../utils/request-logger.js";
+import { classifyError } from "../utils/error-classify.js";
+
+const ENVIRONMENT = resolveEnvironment();
+const RELEASE = resolveRelease();
+
+const HEALTH_PATHS = new Set([
+  "/api/mcp/health",
+  "/api/apps/health",
+  "/health",
+]);
+
+function isStreaming(c: Context): boolean {
+  const ct = c.res.headers.get("content-type") ?? "";
+  if (ct.includes("text/event-stream")) return true;
+  const te = c.res.headers.get("transfer-encoding") ?? "";
+  if (te.toLowerCase().includes("chunked")) return true;
+  return false;
+}
+
+export async function requestLogContextMiddleware(c: Context, next: Next) {
+  const path = c.req.path;
+  if (HEALTH_PATHS.has(path)) {
+    return next();
+  }
+
+  const startedAt = Date.now();
+  const requestId = c.req.header("x-request-id") ?? randomUUID();
+  c.res.headers.set("x-request-id", requestId);
+
+  const baseContext: RequestLogContext = {
+    event: "http.request.completed",
+    timestamp: new Date().toISOString(),
+    environment: ENVIRONMENT,
+    release: RELEASE,
+    component: "http",
+    requestId,
+    route: "pending",
+    method: c.req.method,
+    authType: "unknown",
+  };
+
+  c.set("requestLogContext", baseContext);
+
+  let thrown: unknown = null;
+  try {
+    await next();
+  } catch (err) {
+    thrown = err;
+  }
+
+  // routePath is set by the matched handler after next(); read it now
+  const route = c.req.routePath || "unmatched";
+
+  if (isStreaming(c) && !thrown) {
+    return;
+  }
+
+  const status = c.res.status;
+  const durationMs = Date.now() - startedAt;
+  const reqLogger = getRequestLogger(c, "http");
+
+  const enriched: RequestLogContext = {
+    ...c.var.requestLogContext,
+    component: "http",
+    route,
+    durationMs,
+    statusCode: status,
+  };
+  c.set("requestLogContext", enriched);
+
+  if (thrown || status >= 500) {
+    reqLogger.event(
+      "http.request.failed",
+      {
+        statusCode: thrown ? 500 : status,
+        errorCode: thrown ? classifyError(thrown) : "internal_error",
+      },
+      { error: thrown instanceof Error ? thrown : undefined },
+    );
+    if (thrown) throw thrown;
+    return;
+  }
+
+  reqLogger.event("http.request.completed", { statusCode: status });
+}

--- a/mcpjam-inspector/server/middleware/request-log-context.ts
+++ b/mcpjam-inspector/server/middleware/request-log-context.ts
@@ -83,7 +83,7 @@ export async function requestLogContextMiddleware(c: Context, next: Next) {
         statusCode: thrown ? 500 : status,
         errorCode: thrown ? classifyError(thrown) : "internal_error",
       },
-      { error: thrown instanceof Error ? thrown : undefined },
+      { error: thrown instanceof Error ? thrown : undefined, sentry: false },
     );
     if (thrown) throw thrown;
     return;

--- a/mcpjam-inspector/server/middleware/request-log-context.ts
+++ b/mcpjam-inspector/server/middleware/request-log-context.ts
@@ -1,4 +1,5 @@
 import type { Context, Next } from "hono";
+import { HTTPException } from "hono/http-exception";
 import { randomUUID } from "node:crypto";
 import {
   resolveEnvironment,
@@ -76,18 +77,22 @@ export async function requestLogContextMiddleware(c: Context, next: Next) {
   };
   c.set("requestLogContext", enriched);
 
-  if (thrown || status >= 500) {
+  const effectiveStatus = thrown
+    ? thrown instanceof HTTPException ? thrown.status : 500
+    : status;
+
+  if (effectiveStatus >= 500) {
     reqLogger.event(
       "http.request.failed",
       {
-        statusCode: thrown ? 500 : status,
+        statusCode: effectiveStatus,
         errorCode: thrown ? classifyError(thrown) : "internal_error",
       },
       { error: thrown instanceof Error ? thrown : undefined, sentry: false },
     );
-    if (thrown) throw thrown;
-    return;
+  } else {
+    reqLogger.event("http.request.completed", { statusCode: effectiveStatus });
   }
 
-  reqLogger.event("http.request.completed", { statusCode: status });
+  if (thrown) throw thrown;
 }

--- a/mcpjam-inspector/server/middleware/request-log-context.ts
+++ b/mcpjam-inspector/server/middleware/request-log-context.ts
@@ -7,16 +7,24 @@ import {
   type RequestLogContext,
 } from "../utils/log-events.js";
 import { getRequestLogger } from "../utils/request-logger.js";
+import { logger } from "../utils/logger.js";
 import { classifyError } from "../utils/error-classify.js";
 
-const ENVIRONMENT = resolveEnvironment();
-const RELEASE = resolveRelease();
-
-const HEALTH_PATHS = new Set([
+// Exact-match health endpoints we know about; anything else ending in
+// "/health" or "/healthz" is also treated as a probe.
+const EXACT_HEALTH_PATHS = new Set([
   "/api/mcp/health",
   "/api/apps/health",
   "/health",
 ]);
+
+function isHealthPath(path: string): boolean {
+  const normalized = path.endsWith("/") && path.length > 1
+    ? path.slice(0, -1)
+    : path;
+  if (EXACT_HEALTH_PATHS.has(normalized)) return true;
+  return normalized.endsWith("/health") || normalized.endsWith("/healthz");
+}
 
 function isStreaming(c: Context): boolean {
   const ct = c.res.headers.get("content-type") ?? "";
@@ -27,20 +35,19 @@ function isStreaming(c: Context): boolean {
 }
 
 export async function requestLogContextMiddleware(c: Context, next: Next) {
-  const path = c.req.path;
-  if (HEALTH_PATHS.has(path)) {
+  if (isHealthPath(c.req.path)) {
     return next();
   }
 
   const startedAt = Date.now();
   const requestId = c.req.header("x-request-id") ?? randomUUID();
-  c.res.headers.set("x-request-id", requestId);
+  c.header("x-request-id", requestId);
 
   const baseContext: RequestLogContext = {
     event: "http.request.completed",
     timestamp: new Date().toISOString(),
-    environment: ENVIRONMENT,
-    release: RELEASE,
+    environment: resolveEnvironment(),
+    release: resolveRelease(),
     component: "http",
     requestId,
     route: "pending",
@@ -60,38 +67,71 @@ export async function requestLogContextMiddleware(c: Context, next: Next) {
   // routePath is set by the matched handler after next(); read it now
   const route = c.req.routePath || "unmatched";
 
-  if (isStreaming(c) && !thrown) {
-    return;
-  }
-
   const status = c.res.status;
-  const durationMs = Date.now() - startedAt;
   const reqLogger = getRequestLogger(c, "http");
 
   const enriched: RequestLogContext = {
-    ...c.var.requestLogContext,
+    ...(c.var.requestLogContext as RequestLogContext),
     component: "http",
     route,
-    durationMs,
     statusCode: status,
   };
   c.set("requestLogContext", enriched);
 
+  // Streaming responses: emit `http.stream.opened` synchronously, and wrap
+  // the body with a TransformStream so we can emit `http.stream.closed` with
+  // the actual stream lifetime when the consumer finishes reading. Without
+  // this, SSE/MCP routes would generate zero telemetry.
+  if (isStreaming(c) && !thrown) {
+    reqLogger.event("http.stream.opened", { statusCode: status });
+
+    const body = c.res.body;
+    if (body) {
+      const closedCtx: RequestLogContext = { ...enriched };
+      const ts = new TransformStream({
+        flush() {
+          const durationMs = Date.now() - startedAt;
+          logger.event(
+            "http.stream.closed",
+            { ...closedCtx, durationMs },
+            { statusCode: closedCtx.statusCode ?? status, durationMs },
+          );
+        },
+      });
+      c.res = new Response(body.pipeThrough(ts), {
+        status: c.res.status,
+        statusText: c.res.statusText,
+        headers: c.res.headers,
+      });
+    }
+    return;
+  }
+
+  const durationMs = Date.now() - startedAt;
+  c.set("requestLogContext", { ...enriched, durationMs });
+
   const effectiveStatus = thrown
-    ? thrown instanceof HTTPException ? thrown.status : 500
+    ? thrown instanceof HTTPException
+      ? thrown.status
+      : 500
     : status;
 
   if (effectiveStatus >= 500) {
+    // Sentry capture is owned by the route's error handler / Sentry middleware;
+    // we deliberately don't forward here (default is sentry: false) to avoid
+    // double-capture for the same exception.
     reqLogger.event(
       "http.request.failed",
       {
         statusCode: effectiveStatus,
         errorCode: thrown ? classifyError(thrown) : "internal_error",
       },
-      { error: thrown instanceof Error ? thrown : undefined, sentry: false },
+      { error: thrown instanceof Error ? thrown : undefined },
     );
   } else {
-    reqLogger.event("http.request.completed", { statusCode: effectiveStatus });
+    reqLogger.event("http.request.completed", {
+      statusCode: effectiveStatus,
+    });
   }
 
   if (thrown) throw thrown;

--- a/mcpjam-inspector/server/middleware/request-log-context.ts
+++ b/mcpjam-inspector/server/middleware/request-log-context.ts
@@ -26,6 +26,14 @@ function isHealthPath(path: string): boolean {
   return normalized.endsWith("/health") || normalized.endsWith("/healthz");
 }
 
+// Inbound `x-request-id` is reflected in the response and stored in every
+// emitted log event. Without a guard, an attacker could forge log lines with
+// embedded newlines/control chars, blow up logging-backend cardinality with
+// arbitrarily long values, or inject characters that break downstream queries.
+// Accept the inbound value only if it matches a conservative shape; otherwise
+// mint a fresh UUID.
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
+
 function isStreaming(c: Context): boolean {
   const ct = c.res.headers.get("content-type") ?? "";
   if (ct.includes("text/event-stream")) return true;
@@ -40,7 +48,11 @@ export async function requestLogContextMiddleware(c: Context, next: Next) {
   }
 
   const startedAt = Date.now();
-  const requestId = c.req.header("x-request-id") ?? randomUUID();
+  const inboundRequestId = c.req.header("x-request-id");
+  const requestId =
+    inboundRequestId && REQUEST_ID_PATTERN.test(inboundRequestId)
+      ? inboundRequestId
+      : randomUUID();
   c.header("x-request-id", requestId);
 
   const baseContext: RequestLogContext = {

--- a/mcpjam-inspector/server/types/hono.ts
+++ b/mcpjam-inspector/server/types/hono.ts
@@ -1,4 +1,5 @@
 import type { MCPClientManager } from "@mcpjam/sdk";
+import type { RequestLogContext } from "../utils/log-events.js";
 
 // Extend Hono's context with our custom variables
 declare module "hono" {
@@ -8,5 +9,6 @@ declare module "hono" {
 
   interface ContextVariableMap {
     guestId?: string;
+    requestLogContext?: RequestLogContext;
   }
 }

--- a/mcpjam-inspector/server/utils/__tests__/log-scrubber.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/log-scrubber.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { scrubLogPayload } from "../log-scrubber.js";
+
+describe("scrubLogPayload", () => {
+  describe("forbidden key names", () => {
+    it("redacts Authorization header key", () => {
+      expect(scrubLogPayload({ Authorization: "Bearer abc" })).toEqual({
+        Authorization: "[redacted]",
+      });
+    });
+
+    it("redacts accessToken key", () => {
+      expect(scrubLogPayload({ accessToken: "xyz" })).toEqual({
+        accessToken: "[redacted]",
+      });
+    });
+
+    it("redacts token key", () => {
+      expect(scrubLogPayload({ token: "secret123" })).toEqual({
+        token: "[redacted]",
+      });
+    });
+
+    it("redacts cookie key", () => {
+      expect(scrubLogPayload({ cookie: "session=abc" })).toEqual({
+        cookie: "[redacted]",
+      });
+    });
+
+    it("redacts password key", () => {
+      expect(scrubLogPayload({ password: "hunter2" })).toEqual({
+        password: "[redacted]",
+      });
+    });
+
+    it("redacts secret key", () => {
+      expect(scrubLogPayload({ clientSecret: "shh" })).toEqual({
+        clientSecret: "[redacted]",
+      });
+    });
+
+    it("redacts apiKey key (case-insensitive)", () => {
+      expect(scrubLogPayload({ apiKey: "sk-123" })).toEqual({
+        apiKey: "[redacted]",
+      });
+    });
+
+    it("redacts email key", () => {
+      expect(scrubLogPayload({ email: "user@example.com" })).toEqual({
+        email: "[redacted]",
+      });
+    });
+
+    it("does NOT redact emailDomain (allowlisted)", () => {
+      expect(
+        scrubLogPayload({ email: "a@b.com", emailDomain: "b.com" }),
+      ).toEqual({
+        email: "[redacted]",
+        emailDomain: "b.com",
+      });
+    });
+
+    it("redacts stripeCustomer key", () => {
+      expect(scrubLogPayload({ stripeCustomer: "cus_123" })).toEqual({
+        stripeCustomer: "[redacted]",
+      });
+    });
+  });
+
+  describe("string value patterns", () => {
+    it("replaces Bearer token in string values", () => {
+      const result = scrubLogPayload({ note: "Bearer eyJhbGc.eyJ.sig" });
+      expect((result as any).note).toContain("Bearer [redacted-token]");
+    });
+
+    it("replaces JWT-like strings", () => {
+      const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+      const result = scrubLogPayload({ note: jwt }) as any;
+      expect(result.note).toBe("[redacted-jwt]");
+    });
+
+    it("replaces email-like strings in values", () => {
+      const result = scrubLogPayload({ message: "contact user@example.com today" }) as any;
+      expect(result.message).toContain("[redacted-email]");
+      expect(result.message).not.toContain("user@example.com");
+    });
+
+    it("replaces sk- secret key patterns", () => {
+      const result = scrubLogPayload({ note: "sk-abcdefghijklmnopqrstuvwx" }) as any;
+      expect(result.note).toContain("[redacted-secret]");
+    });
+  });
+
+  describe("recursion", () => {
+    it("recurses into nested objects", () => {
+      const input = {
+        outer: {
+          inner: {
+            token: "secret",
+            safe: "value",
+          },
+        },
+      };
+      expect(scrubLogPayload(input)).toEqual({
+        outer: {
+          inner: {
+            token: "[redacted]",
+            safe: "value",
+          },
+        },
+      });
+    });
+
+    it("recurses into arrays", () => {
+      const input = {
+        items: [{ token: "abc" }, { safe: "ok" }],
+      };
+      expect(scrubLogPayload(input)).toEqual({
+        items: [{ token: "[redacted]" }, { safe: "ok" }],
+      });
+    });
+
+    it("handles null and undefined values", () => {
+      expect(scrubLogPayload(null)).toBeNull();
+      expect(scrubLogPayload(undefined)).toBeUndefined();
+    });
+
+    it("passes through numbers unchanged", () => {
+      expect(scrubLogPayload({ count: 42 })).toEqual({ count: 42 });
+    });
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/log-scrubber.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/log-scrubber.test.ts
@@ -129,4 +129,34 @@ describe("scrubLogPayload", () => {
       expect(scrubLogPayload({ count: 42 })).toEqual({ count: 42 });
     });
   });
+
+  describe("cycle protection", () => {
+    it("breaks circular object references with the [circular] sentinel", () => {
+      const a: Record<string, unknown> = { name: "a" };
+      const b: Record<string, unknown> = { name: "b", a };
+      a.b = b; // a -> b -> a
+
+      const result = scrubLogPayload(a) as any;
+      expect(result.name).toBe("a");
+      expect(result.b.name).toBe("b");
+      expect(result.b.a).toBe("[circular]");
+    });
+
+    it("breaks self-referential objects", () => {
+      const o: Record<string, unknown> = { name: "self" };
+      o.self = o;
+
+      const result = scrubLogPayload(o) as any;
+      expect(result.name).toBe("self");
+      expect(result.self).toBe("[circular]");
+    });
+
+    it("breaks circular references through arrays", () => {
+      const o: Record<string, unknown> = { items: [] as unknown[] };
+      (o.items as unknown[]).push(o);
+
+      const result = scrubLogPayload(o) as any;
+      expect(result.items[0]).toBe("[circular]");
+    });
+  });
 });

--- a/mcpjam-inspector/server/utils/__tests__/logger.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/logger.test.ts
@@ -213,24 +213,25 @@ describe("logger", () => {
       );
     });
 
-    it("calls Sentry.captureException for *.failed events with an Error", () => {
+    it("calls Sentry.captureException only when sentry: true is opted in with an Error", () => {
       const err = new Error("boom");
       logger.event(
         "http.request.failed",
         baseRequestContext,
         { statusCode: 500, errorCode: "unhandled_exception" },
-        { error: err },
+        { error: err, sentry: true },
       );
 
       expect(captureException).toHaveBeenCalledWith(err, expect.any(Object));
       expect(captureMessage).not.toHaveBeenCalled();
     });
 
-    it("calls Sentry.captureMessage for *.failed events without an Error", () => {
+    it("calls Sentry.captureMessage when sentry: true is opted in without an Error", () => {
       logger.event(
         "http.request.failed",
         baseRequestContext,
         { statusCode: 500, errorCode: "internal_error" },
+        { sentry: true },
       );
 
       expect(captureMessage).toHaveBeenCalledWith(
@@ -239,21 +240,23 @@ describe("logger", () => {
       );
     });
 
-    it("does not call Sentry for non-failed events (http.request.completed)", () => {
-      logger.event("http.request.completed", baseRequestContext, { statusCode: 200 });
-
-      expect(captureException).not.toHaveBeenCalled();
-      expect(captureMessage).not.toHaveBeenCalled();
-    });
-
-    it("does not call Sentry when sentry: false is passed", () => {
+    it("does not call Sentry by default for *.failed events (opt-in only)", () => {
       const err = new Error("boom");
       logger.event(
         "http.request.failed",
         baseRequestContext,
         { statusCode: 500, errorCode: "internal_error" },
-        { error: err, sentry: false },
+        { error: err },
       );
+
+      expect(captureException).not.toHaveBeenCalled();
+      expect(captureMessage).not.toHaveBeenCalled();
+    });
+
+    it("does not call Sentry for non-failed events when no opt-in is passed", () => {
+      logger.event("http.request.completed", baseRequestContext, {
+        statusCode: 200,
+      });
 
       expect(captureException).not.toHaveBeenCalled();
       expect(captureMessage).not.toHaveBeenCalled();

--- a/mcpjam-inspector/server/utils/__tests__/logger.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/logger.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { RequestLogContext, SystemLogContext } from "../log-events.js";
 
 // Mock Sentry before importing logger
 vi.mock("@sentry/node", () => ({
@@ -15,6 +16,30 @@ vi.mock("@axiomhq/js", () => ({
     flush: mockFlush,
   })),
 }));
+
+const baseRequestContext: RequestLogContext = {
+  event: "http.request.completed",
+  timestamp: "2024-01-01T00:00:00.000Z",
+  environment: "test",
+  release: null,
+  component: "http",
+  requestId: "req-abc",
+  route: "/api/web/test",
+  method: "GET",
+  authType: "unknown",
+};
+
+const baseSystemContext: SystemLogContext = {
+  event: "mcp.connection.closed_with_pending_requests",
+  timestamp: "2024-01-01T00:00:00.000Z",
+  environment: "test",
+  release: null,
+  component: "process",
+  requestId: null,
+  route: null,
+  method: null,
+  authType: "system",
+};
 
 describe("logger", () => {
   beforeEach(() => {
@@ -145,6 +170,129 @@ describe("logger", () => {
         await logger.flush();
         expect(mockFlush).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe("logger.event", () => {
+    let logger: (typeof import("../logger.js"))["logger"];
+    let captureException: ReturnType<typeof vi.fn>;
+    let captureMessage: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+      vi.stubEnv("AXIOM_TOKEN", "test-token");
+      vi.stubEnv("AXIOM_DATASET", "test-dataset");
+      vi.stubEnv("NODE_ENV", "production");
+
+      const mod = await import("../logger.js");
+      logger = mod.logger;
+
+      const sentry = await import("@sentry/node");
+      captureException = vi.mocked(sentry.captureException);
+      captureMessage = vi.mocked(sentry.captureMessage);
+      captureException.mockClear();
+      captureMessage.mockClear();
+    });
+
+    it("ingests a typed event to Axiom with all required fields", () => {
+      logger.event("http.request.completed", baseRequestContext, { statusCode: 200 });
+
+      expect(mockIngest).toHaveBeenCalledWith(
+        "test-dataset",
+        [
+          expect.objectContaining({
+            event: "http.request.completed",
+            environment: "test",
+            requestId: "req-abc",
+            route: "/api/web/test",
+            method: "GET",
+            component: "http",
+            authType: "unknown",
+            statusCode: 200,
+          }),
+        ],
+      );
+    });
+
+    it("calls Sentry.captureException for *.failed events with an Error", () => {
+      const err = new Error("boom");
+      logger.event(
+        "http.request.failed",
+        baseRequestContext,
+        { statusCode: 500, errorCode: "unhandled_exception" },
+        { error: err },
+      );
+
+      expect(captureException).toHaveBeenCalledWith(err, expect.any(Object));
+      expect(captureMessage).not.toHaveBeenCalled();
+    });
+
+    it("calls Sentry.captureMessage for *.failed events without an Error", () => {
+      logger.event(
+        "http.request.failed",
+        baseRequestContext,
+        { statusCode: 500, errorCode: "internal_error" },
+      );
+
+      expect(captureMessage).toHaveBeenCalledWith(
+        "http.request.failed",
+        expect.objectContaining({ level: "error" }),
+      );
+    });
+
+    it("does not call Sentry for non-failed events (http.request.completed)", () => {
+      logger.event("http.request.completed", baseRequestContext, { statusCode: 200 });
+
+      expect(captureException).not.toHaveBeenCalled();
+      expect(captureMessage).not.toHaveBeenCalled();
+    });
+
+    it("does not call Sentry when sentry: false is passed", () => {
+      const err = new Error("boom");
+      logger.event(
+        "http.request.failed",
+        baseRequestContext,
+        { statusCode: 500, errorCode: "internal_error" },
+        { error: err, sentry: false },
+      );
+
+      expect(captureException).not.toHaveBeenCalled();
+      expect(captureMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("logger.systemEvent", () => {
+    let logger: (typeof import("../logger.js"))["logger"];
+
+    beforeEach(async () => {
+      vi.stubEnv("AXIOM_TOKEN", "test-token");
+      vi.stubEnv("AXIOM_DATASET", "test-dataset");
+      vi.stubEnv("NODE_ENV", "production");
+
+      const mod = await import("../logger.js");
+      logger = mod.logger;
+      mockIngest.mockClear();
+    });
+
+    it("ingests a system event to Axiom with system envelope (requestId/route/method all null)", () => {
+      logger.systemEvent(
+        "mcp.connection.closed_with_pending_requests",
+        baseSystemContext,
+        { errorCode: "connection_closed" },
+      );
+
+      expect(mockIngest).toHaveBeenCalledWith(
+        "test-dataset",
+        [
+          expect.objectContaining({
+            event: "mcp.connection.closed_with_pending_requests",
+            requestId: null,
+            route: null,
+            method: null,
+            authType: "system",
+            errorCode: "connection_closed",
+          }),
+        ],
+      );
     });
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/request-logger.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/request-logger.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Context } from "hono";
+import type { RequestLogContext } from "../log-events.js";
+
+vi.mock("@sentry/node", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+vi.mock("@axiomhq/js", () => ({
+  Axiom: vi.fn().mockImplementation(() => ({
+    ingest: vi.fn(),
+    flush: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+function makeContext(ctx?: Partial<RequestLogContext>): Context {
+  const vars: Record<string, unknown> = {};
+  if (ctx) {
+    vars["requestLogContext"] = ctx;
+  }
+  return {
+    var: new Proxy(vars, {
+      get: (target, prop) => target[prop as string],
+    }),
+    set: (key: string, value: unknown) => {
+      vars[key] = value;
+    },
+  } as unknown as Context;
+}
+
+const baseContext: RequestLogContext = {
+  event: "http.request.completed",
+  timestamp: "2024-01-01T00:00:00.000Z",
+  environment: "test",
+  release: null,
+  component: "http",
+  requestId: "req-123",
+  route: "/api/web/test",
+  method: "GET",
+  authType: "unknown",
+};
+
+describe("getRequestLogger", () => {
+  it("calls logger.event with the request context merged with component", async () => {
+    vi.stubEnv("AXIOM_TOKEN", "test-token");
+    vi.stubEnv("AXIOM_DATASET", "test-dataset");
+    vi.stubEnv("NODE_ENV", "production");
+    vi.resetModules();
+
+    const { getRequestLogger } = await import("../request-logger.js");
+    const { logger } = await import("../logger.js");
+    const eventSpy = vi.spyOn(logger, "event");
+
+    const c = makeContext(baseContext);
+    const reqLogger = getRequestLogger(c, "routes.web.test");
+
+    reqLogger.event("http.request.completed", { statusCode: 200 });
+
+    expect(eventSpy).toHaveBeenCalledWith(
+      "http.request.completed",
+      expect.objectContaining({ component: "routes.web.test", requestId: "req-123" }),
+      { statusCode: 200 },
+      undefined,
+    );
+
+    vi.unstubAllEnvs();
+  });
+});
+
+describe("setRequestLogContext", () => {
+  it("merges partial fields into existing requestLogContext", async () => {
+    vi.resetModules();
+    const { setRequestLogContext } = await import("../request-logger.js");
+
+    const vars: Record<string, unknown> = { requestLogContext: { ...baseContext } };
+    const c = {
+      var: new Proxy(vars, { get: (t, p) => t[p as string] }),
+      set: (key: string, value: unknown) => { vars[key] = value; },
+    } as unknown as Context;
+
+    setRequestLogContext(c, { authType: "signedIn", userId: "user-abc" });
+
+    const updated = vars["requestLogContext"] as RequestLogContext;
+    expect(updated.authType).toBe("signedIn");
+    expect(updated.userId).toBe("user-abc");
+    expect(updated.requestId).toBe("req-123");
+  });
+
+  it("does nothing when requestLogContext is not set", async () => {
+    vi.resetModules();
+    const { setRequestLogContext } = await import("../request-logger.js");
+
+    const vars: Record<string, unknown> = {};
+    const c = {
+      var: new Proxy(vars, { get: (t, p) => t[p as string] }),
+      set: (key: string, value: unknown) => { vars[key] = value; },
+    } as unknown as Context;
+
+    expect(() => setRequestLogContext(c, { authType: "signedIn" })).not.toThrow();
+    expect(vars["requestLogContext"]).toBeUndefined();
+  });
+});
+
+describe("getSystemLogger", () => {
+  it("calls logger.systemEvent with system envelope", async () => {
+    vi.resetModules();
+    const { getSystemLogger } = await import("../request-logger.js");
+    const { logger } = await import("../logger.js");
+    const systemEventSpy = vi.spyOn(logger, "systemEvent");
+
+    const sysLogger = getSystemLogger("process");
+    sysLogger.event(
+      "mcp.connection.closed_with_pending_requests",
+      {
+        environment: "test",
+        release: null,
+        requestId: null,
+        route: null,
+        method: null,
+        authType: "system" as const,
+      },
+      { errorCode: "connection_closed" },
+    );
+
+    expect(systemEventSpy).toHaveBeenCalledWith(
+      "mcp.connection.closed_with_pending_requests",
+      expect.objectContaining({
+        component: "process",
+        authType: "system",
+        requestId: null,
+        route: null,
+        method: null,
+      }),
+      { errorCode: "connection_closed" },
+      undefined,
+    );
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/request-logger.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/request-logger.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import type { Context } from "hono";
 import type { RequestLogContext } from "../log-events.js";
 
@@ -59,12 +59,27 @@ describe("getRequestLogger", () => {
 
     expect(eventSpy).toHaveBeenCalledWith(
       "http.request.completed",
-      expect.objectContaining({ component: "routes.web.test", requestId: "req-123" }),
+      expect.objectContaining({
+        component: "routes.web.test",
+        requestId: "req-123",
+      }),
       { statusCode: 200 },
       undefined,
     );
 
     vi.unstubAllEnvs();
+  });
+
+  it("throws when requestLogContext is missing (middleware not mounted)", async () => {
+    vi.resetModules();
+    const { getRequestLogger } = await import("../request-logger.js");
+
+    const c = makeContext(); // no context set
+    const reqLogger = getRequestLogger(c, "routes.web.test");
+
+    expect(() =>
+      reqLogger.event("http.request.completed", { statusCode: 200 }),
+    ).toThrow(/requestLogContextMiddleware/);
   });
 });
 
@@ -73,10 +88,14 @@ describe("setRequestLogContext", () => {
     vi.resetModules();
     const { setRequestLogContext } = await import("../request-logger.js");
 
-    const vars: Record<string, unknown> = { requestLogContext: { ...baseContext } };
+    const vars: Record<string, unknown> = {
+      requestLogContext: { ...baseContext },
+    };
     const c = {
       var: new Proxy(vars, { get: (t, p) => t[p as string] }),
-      set: (key: string, value: unknown) => { vars[key] = value; },
+      set: (key: string, value: unknown) => {
+        vars[key] = value;
+      },
     } as unknown as Context;
 
     setRequestLogContext(c, { authType: "signedIn", userId: "user-abc" });
@@ -94,46 +113,67 @@ describe("setRequestLogContext", () => {
     const vars: Record<string, unknown> = {};
     const c = {
       var: new Proxy(vars, { get: (t, p) => t[p as string] }),
-      set: (key: string, value: unknown) => { vars[key] = value; },
+      set: (key: string, value: unknown) => {
+        vars[key] = value;
+      },
     } as unknown as Context;
 
-    expect(() => setRequestLogContext(c, { authType: "signedIn" })).not.toThrow();
+    expect(() =>
+      setRequestLogContext(c, { authType: "signedIn" }),
+    ).not.toThrow();
     expect(vars["requestLogContext"]).toBeUndefined();
   });
 });
 
 describe("getSystemLogger", () => {
-  it("calls logger.systemEvent with system envelope", async () => {
+  it("auto-fills the system envelope so callers only pass payload", async () => {
+    vi.stubEnv("ENVIRONMENT", "test");
     vi.resetModules();
     const { getSystemLogger } = await import("../request-logger.js");
     const { logger } = await import("../logger.js");
     const systemEventSpy = vi.spyOn(logger, "systemEvent");
 
     const sysLogger = getSystemLogger("process");
-    sysLogger.event(
-      "mcp.connection.closed_with_pending_requests",
-      {
-        environment: "test",
-        release: null,
-        requestId: null,
-        route: null,
-        method: null,
-        authType: "system" as const,
-      },
-      { errorCode: "connection_closed" },
-    );
+    sysLogger.event("mcp.connection.closed_with_pending_requests", {
+      errorCode: "connection_closed",
+    });
 
     expect(systemEventSpy).toHaveBeenCalledWith(
       "mcp.connection.closed_with_pending_requests",
       expect.objectContaining({
         component: "process",
         authType: "system",
+        environment: "test",
         requestId: null,
         route: null,
         method: null,
       }),
       { errorCode: "connection_closed" },
       undefined,
+    );
+
+    vi.unstubAllEnvs();
+  });
+
+  it("forwards options (error, sentry: true) for opt-in Sentry capture", async () => {
+    vi.resetModules();
+    const { getSystemLogger } = await import("../request-logger.js");
+    const { logger } = await import("../logger.js");
+    const systemEventSpy = vi.spyOn(logger, "systemEvent");
+
+    const err = new Error("boom");
+    const sysLogger = getSystemLogger("process");
+    sysLogger.event(
+      "process.unhandled_rejection",
+      { errorCode: "Error" },
+      { error: err, sentry: true },
+    );
+
+    expect(systemEventSpy).toHaveBeenCalledWith(
+      "process.unhandled_rejection",
+      expect.objectContaining({ component: "process", authType: "system" }),
+      { errorCode: "Error" },
+      { error: err, sentry: true },
     );
   });
 });

--- a/mcpjam-inspector/server/utils/error-classify.ts
+++ b/mcpjam-inspector/server/utils/error-classify.ts
@@ -1,0 +1,28 @@
+export function classifyError(error: unknown): string {
+  if (!error) return "unknown";
+  if (error instanceof Error) {
+    if (error.name === "AbortError") return "abort";
+    if (error.message.includes("Connection closed")) return "connection_closed";
+    if (error.name === "McpError") return "mcp_error";
+    return "unhandled_exception";
+  }
+  return "unknown";
+}
+
+export function classifyWidgetError(error: unknown, hint?: string): string {
+  if (hint === "resource_missing") return "resource_missing";
+  if (hint === "html_missing") return "html_missing";
+  if (hint === "template_invalid") return "template_invalid";
+  if (hint === "read_resource_failed") return "read_resource_failed";
+  if (error instanceof Error) {
+    if (error.message.includes("readResource")) return "read_resource_failed";
+  }
+  return "unknown";
+}
+
+export function classifyTunnelError(error: unknown, hint?: string): string {
+  if (hint === "fetch_ngrok_token_failed") return "fetch_ngrok_token_failed";
+  if (hint === "ngrok_create_failed") return "ngrok_create_failed";
+  if (hint === "convex_record_failed") return "convex_record_failed";
+  return "unknown";
+}

--- a/mcpjam-inspector/server/utils/log-events.ts
+++ b/mcpjam-inspector/server/utils/log-events.ts
@@ -1,0 +1,152 @@
+export type Environment =
+  | "prod"
+  | "staging"
+  | "preview"
+  | "dev"
+  | "local"
+  | "test";
+
+export type AuthType = "signedIn" | "guest" | "system" | "unknown";
+
+export type WorkspaceRole =
+  | "owner"
+  | "admin"
+  | "member"
+  | "guest"
+  | "editor"
+  | "chat";
+
+export type AccessLevel = "workspace_member" | "shared_chat";
+export type Surface = "preview" | "share_link";
+export type ServerTransport = "stdio" | "http";
+
+interface CommonLogContext {
+  event: LogEventName;
+  timestamp: string;
+  environment: Environment;
+  release: string | null;
+  component: string;
+  durationMs?: number;
+
+  authType: AuthType;
+  userId?: string | null;
+  userExternalId?: string | null;
+  guestExternalId?: string | null;
+  emailDomain?: string | null;
+  orgId?: string | null;
+  orgPlan?: string | null;
+  orgSeatQuantity?: number | null;
+  orgCreatedBy?: string | null;
+  workspaceId?: string | null;
+  workspaceRole?: WorkspaceRole | null;
+  accessLevel?: AccessLevel | null;
+  serverId?: string | null;
+  sessionId?: string | null;
+  chatboxId?: string | null;
+  surface?: Surface | null;
+  serverTransport?: ServerTransport | null;
+  statusCode?: number | null;
+}
+
+export interface RequestLogContext extends CommonLogContext {
+  requestId: string;
+  route: string;
+  method: string;
+}
+
+export interface SystemLogContext extends CommonLogContext {
+  requestId: null;
+  route: null;
+  method: null;
+  authType: "system" | "unknown";
+}
+
+export type BaseLogContext = RequestLogContext | SystemLogContext;
+
+export type RequestEventMap = {
+  "http.request.completed": { statusCode: number };
+  "http.request.failed": { statusCode: number; errorCode: string };
+  "mcp.oauth.proxy.failed": {
+    targetUrlHost: string;
+    oauthPhase: "metadata" | "proxy" | "token";
+    errorCode: string;
+    statusCode?: number;
+  };
+  "tunnel.created": {
+    tunnelKind: "shared" | "server";
+    tunnelDomain: string;
+    existed: boolean;
+    credentialIdPresent?: boolean;
+  };
+  "tunnel.creation_failed": {
+    tunnelKind: "shared" | "server";
+    errorCode: string;
+    credentialIdPresent?: boolean;
+    tunnelDomain?: string;
+  };
+  "tunnel.record_failed": {
+    tunnelKind: "shared" | "server";
+    tunnelDomain?: string;
+    errorCode: string;
+  };
+  "chat.session.persist.failed": {
+    failureKind: "timeout" | "http_error" | "exception" | "version_conflict";
+    statusCode?: number;
+    sourceType?: "serverShare" | "chatbox" | "direct";
+  };
+  "widget.resource.served": {
+    widgetType: "mcp_apps" | "chatgpt_apps";
+    resourceUri: string;
+    cspMode: "permissive" | "widget-declared";
+    mimeTypeValid?: boolean;
+  };
+  "widget.resource.failed": {
+    widgetType: "mcp_apps" | "chatgpt_apps";
+    resourceUri?: string;
+    cspMode?: "permissive" | "widget-declared";
+    errorCode: string;
+  };
+};
+
+export type SystemEventMap = {
+  "mcp.connection.closed_with_pending_requests": { errorCode: string };
+};
+
+export type LogEventName = keyof RequestEventMap | keyof SystemEventMap;
+
+export type RequestEventPayload<E extends keyof RequestEventMap> =
+  RequestLogContext & { event: E } & RequestEventMap[E];
+
+export type SystemEventPayload<E extends keyof SystemEventMap> =
+  SystemLogContext & { event: E } & SystemEventMap[E];
+
+export function resolveEnvironment(): Environment {
+  const fromEnv = process.env.ENVIRONMENT;
+  const allowed: Environment[] = [
+    "prod",
+    "staging",
+    "preview",
+    "dev",
+    "local",
+    "test",
+  ];
+  if (fromEnv && allowed.includes(fromEnv as Environment)) {
+    return fromEnv as Environment;
+  }
+  if (process.env.NODE_ENV === "test") return "test";
+  if (process.env.NODE_ENV === "production") {
+    console.warn(
+      "[logging] ENVIRONMENT not set in production; defaulting to 'prod'",
+    );
+    return "prod";
+  }
+  return "dev";
+}
+
+export function resolveRelease(): string | null {
+  return (
+    process.env.RAILWAY_GIT_COMMIT_SHA ??
+    process.env.GIT_SHA ??
+    null
+  );
+}

--- a/mcpjam-inspector/server/utils/log-events.ts
+++ b/mcpjam-inspector/server/utils/log-events.ts
@@ -66,6 +66,8 @@ export type BaseLogContext = RequestLogContext | SystemLogContext;
 export type RequestEventMap = {
   "http.request.completed": { statusCode: number };
   "http.request.failed": { statusCode: number; errorCode: string };
+  "http.stream.opened": { statusCode: number };
+  "http.stream.closed": { statusCode: number; durationMs: number };
   "mcp.oauth.proxy.failed": {
     targetUrlHost: string;
     oauthPhase: "metadata" | "proxy" | "token";
@@ -110,6 +112,7 @@ export type RequestEventMap = {
 
 export type SystemEventMap = {
   "mcp.connection.closed_with_pending_requests": { errorCode: string };
+  "process.unhandled_rejection": { errorCode: string };
 };
 
 export type LogEventName = keyof RequestEventMap | keyof SystemEventMap;
@@ -120,24 +123,26 @@ export type RequestEventPayload<E extends keyof RequestEventMap> =
 export type SystemEventPayload<E extends keyof SystemEventMap> =
   SystemLogContext & { event: E } & SystemEventMap[E];
 
-let cachedEnvironment: Environment | undefined;
+// Resolve ENVIRONMENT per call (no module-level cache) so changes to
+// process.env in tests or after a config reload take effect on the next emit.
+// The "missing in production" warning still fires only once via warnedMissingEnv.
 let warnedMissingEnv = false;
 
+const ALLOWED_ENVIRONMENTS: Environment[] = [
+  "prod",
+  "staging",
+  "preview",
+  "dev",
+  "local",
+  "test",
+];
+
 export function resolveEnvironment(): Environment {
-  if (cachedEnvironment) return cachedEnvironment;
   const fromEnv = process.env.ENVIRONMENT;
-  const allowed: Environment[] = [
-    "prod",
-    "staging",
-    "preview",
-    "dev",
-    "local",
-    "test",
-  ];
-  if (fromEnv && allowed.includes(fromEnv as Environment)) {
-    return (cachedEnvironment = fromEnv as Environment);
+  if (fromEnv && ALLOWED_ENVIRONMENTS.includes(fromEnv as Environment)) {
+    return fromEnv as Environment;
   }
-  if (process.env.NODE_ENV === "test") return (cachedEnvironment = "test");
+  if (process.env.NODE_ENV === "test") return "test";
   if (process.env.NODE_ENV === "production") {
     if (!warnedMissingEnv) {
       warnedMissingEnv = true;
@@ -145,9 +150,9 @@ export function resolveEnvironment(): Environment {
         "[logging] ENVIRONMENT not set in production; defaulting to 'prod'\n",
       );
     }
-    return (cachedEnvironment = "prod");
+    return "prod";
   }
-  return (cachedEnvironment = "dev");
+  return "dev";
 }
 
 export function resolveRelease(): string | null {

--- a/mcpjam-inspector/server/utils/log-events.ts
+++ b/mcpjam-inspector/server/utils/log-events.ts
@@ -120,7 +120,11 @@ export type RequestEventPayload<E extends keyof RequestEventMap> =
 export type SystemEventPayload<E extends keyof SystemEventMap> =
   SystemLogContext & { event: E } & SystemEventMap[E];
 
+let cachedEnvironment: Environment | undefined;
+let warnedMissingEnv = false;
+
 export function resolveEnvironment(): Environment {
+  if (cachedEnvironment) return cachedEnvironment;
   const fromEnv = process.env.ENVIRONMENT;
   const allowed: Environment[] = [
     "prod",
@@ -131,16 +135,19 @@ export function resolveEnvironment(): Environment {
     "test",
   ];
   if (fromEnv && allowed.includes(fromEnv as Environment)) {
-    return fromEnv as Environment;
+    return (cachedEnvironment = fromEnv as Environment);
   }
-  if (process.env.NODE_ENV === "test") return "test";
+  if (process.env.NODE_ENV === "test") return (cachedEnvironment = "test");
   if (process.env.NODE_ENV === "production") {
-    console.warn(
-      "[logging] ENVIRONMENT not set in production; defaulting to 'prod'",
-    );
-    return "prod";
+    if (!warnedMissingEnv) {
+      warnedMissingEnv = true;
+      process.stderr.write(
+        "[logging] ENVIRONMENT not set in production; defaulting to 'prod'\n",
+      );
+    }
+    return (cachedEnvironment = "prod");
   }
-  return "dev";
+  return (cachedEnvironment = "dev");
 }
 
 export function resolveRelease(): string | null {

--- a/mcpjam-inspector/server/utils/log-scrubber.ts
+++ b/mcpjam-inspector/server/utils/log-scrubber.ts
@@ -1,0 +1,59 @@
+const FORBIDDEN_KEY_SUBSTRINGS = [
+  "authorization",
+  "cookie",
+  "password",
+  "token",
+  "secret",
+  "apikey",
+  "pkceverifier",
+  "pkcechallenge",
+  "stripecustomer",
+  "stripesubscription",
+  "stripeprice",
+  "x-mcp-session-auth",
+  "x-api-key",
+];
+
+const ALLOWLISTED_KEYS = new Set(["emaildomain"]);
+
+const TOKEN_LIKE = /\bBearer\s+[A-Za-z0-9._\-+/=]+\b/gi;
+const EMAIL_LIKE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const SK_KEY_LIKE = /\bsk-[A-Za-z0-9]{16,}\b/g;
+const JWT_LIKE =
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
+
+function isForbiddenKey(key: string): boolean {
+  const lower = key.toLowerCase();
+  if (ALLOWLISTED_KEYS.has(lower)) return false;
+  if (lower === "email" || lower.endsWith("email")) return true;
+  return FORBIDDEN_KEY_SUBSTRINGS.some((s) => lower.includes(s));
+}
+
+function scrubString(s: string): string {
+  return s
+    .replace(TOKEN_LIKE, "Bearer [redacted-token]")
+    .replace(JWT_LIKE, "[redacted-jwt]")
+    .replace(EMAIL_LIKE, "[redacted-email]")
+    .replace(SK_KEY_LIKE, "[redacted-secret]");
+}
+
+export function scrubLogPayload<T>(value: T): T {
+  return scrubValue(value) as T;
+}
+
+function scrubValue(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (typeof value === "string") return scrubString(value);
+  if (typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(scrubValue);
+
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (isForbiddenKey(k)) {
+      out[k] = "[redacted]";
+      continue;
+    }
+    out[k] = scrubValue(v);
+  }
+  return out;
+}

--- a/mcpjam-inspector/server/utils/log-scrubber.ts
+++ b/mcpjam-inspector/server/utils/log-scrubber.ts
@@ -38,10 +38,10 @@ function scrubString(s: string): string {
 }
 
 export function scrubLogPayload<T>(value: T): T {
-  return scrubValue(value) as T;
+  return scrubValue(value, new WeakSet()) as T;
 }
 
-function scrubValue(value: unknown): unknown {
+function scrubValue(value: unknown, seen: WeakSet<object>): unknown {
   if (value === null || value === undefined) return value;
   if (typeof value === "string") return scrubString(value);
   if (typeof value !== "object") return value;
@@ -56,7 +56,9 @@ function scrubValue(value: unknown): unknown {
   if (typeof Buffer !== "undefined" && Buffer.isBuffer(value)) {
     return "[buffer]";
   }
-  if (Array.isArray(value)) return value.map(scrubValue);
+  if (seen.has(value)) return "[circular]";
+  seen.add(value);
+  if (Array.isArray(value)) return value.map((v) => scrubValue(v, seen));
 
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
@@ -64,7 +66,7 @@ function scrubValue(value: unknown): unknown {
       out[k] = "[redacted]";
       continue;
     }
-    out[k] = scrubValue(v);
+    out[k] = scrubValue(v, seen);
   }
   return out;
 }

--- a/mcpjam-inspector/server/utils/log-scrubber.ts
+++ b/mcpjam-inspector/server/utils/log-scrubber.ts
@@ -45,6 +45,17 @@ function scrubValue(value: unknown): unknown {
   if (value === null || value === undefined) return value;
   if (typeof value === "string") return scrubString(value);
   if (typeof value !== "object") return value;
+  if (value instanceof Date) return value.toISOString();
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: scrubString(value.message),
+      stack: value.stack ? scrubString(value.stack) : undefined,
+    };
+  }
+  if (typeof Buffer !== "undefined" && Buffer.isBuffer(value)) {
+    return "[buffer]";
+  }
   if (Array.isArray(value)) return value.map(scrubValue);
 
   const out: Record<string, unknown> = {};

--- a/mcpjam-inspector/server/utils/logger.ts
+++ b/mcpjam-inspector/server/utils/logger.ts
@@ -1,5 +1,13 @@
 import * as Sentry from "@sentry/node";
 import { Axiom } from "@axiomhq/js";
+import type {
+  LogEventName,
+  RequestEventMap,
+  SystemEventMap,
+  RequestLogContext,
+  SystemLogContext,
+} from "./log-events.js";
+import { scrubLogPayload } from "./log-scrubber.js";
 
 const isVerbose = () => process.env.VERBOSE_LOGS === "true";
 const isDev = () => process.env.NODE_ENV !== "production";
@@ -13,6 +21,12 @@ const axiom =
 const dataset = process.env.AXIOM_DATASET ?? "";
 
 const environment = process.env.ENVIRONMENT ?? "unknown";
+
+type SentryOptions = { error?: unknown; sentry?: boolean };
+
+function shouldSendToSentry(eventName: LogEventName): boolean {
+  return eventName.endsWith(".failed");
+}
 
 function ingestToAxiom(
   level: "info" | "warn" | "error" | "debug",
@@ -86,6 +100,72 @@ export const logger = {
    */
   async flush() {
     await axiom?.flush();
+  },
+
+  event<E extends keyof RequestEventMap>(
+    eventName: E,
+    base: RequestLogContext,
+    payload: RequestEventMap[E],
+    options?: SentryOptions,
+  ): void {
+    const fullPayload = scrubLogPayload({
+      ...base,
+      ...payload,
+      event: eventName,
+      timestamp: new Date().toISOString(),
+    });
+
+    if (axiom) {
+      axiom.ingest(dataset, [fullPayload]);
+    }
+
+    if (shouldSendToSentry(eventName) && options?.sentry !== false) {
+      if (options?.error instanceof Error) {
+        Sentry.captureException(options.error, { extra: fullPayload as Record<string, unknown> });
+      } else {
+        Sentry.captureMessage(eventName, {
+          level: "error",
+          extra: fullPayload as Record<string, unknown>,
+        });
+      }
+    }
+
+    if (shouldLog()) {
+      console.log(`[event] ${eventName}`, fullPayload);
+    }
+  },
+
+  systemEvent<E extends keyof SystemEventMap>(
+    eventName: E,
+    base: SystemLogContext,
+    payload: SystemEventMap[E],
+    options?: SentryOptions,
+  ): void {
+    const fullPayload = scrubLogPayload({
+      ...base,
+      ...payload,
+      event: eventName,
+      timestamp: new Date().toISOString(),
+    });
+
+    if (axiom) {
+      axiom.ingest(dataset, [fullPayload]);
+    }
+
+    if (shouldSendToSentry(eventName) && options?.sentry !== false) {
+      if (options?.error instanceof Error) {
+        Sentry.captureException(options.error, { extra: fullPayload as Record<string, unknown> });
+      } else {
+        Sentry.captureMessage(eventName, {
+          level: "error",
+          extra: fullPayload as Record<string, unknown>,
+        });
+      }
+    }
+
+    if (shouldLog()) {
+      console.log(`[event] ${eventName}`, fullPayload);
+    }
   },
 };
 

--- a/mcpjam-inspector/server/utils/logger.ts
+++ b/mcpjam-inspector/server/utils/logger.ts
@@ -22,11 +22,13 @@ const dataset = process.env.AXIOM_DATASET ?? "";
 
 const environment = process.env.ENVIRONMENT ?? "unknown";
 
+/**
+ * Sentry capture for typed events is **opt-in**: pass `{ sentry: true }` at the
+ * callsite that owns the error. Auto-capture for any heuristic (e.g. ".failed"
+ * suffix) was removed because it caused double-capture when both middleware
+ * and the route's error handler fired Sentry for the same exception.
+ */
 type SentryOptions = { error?: unknown; sentry?: boolean };
-
-function shouldSendToSentry(eventName: LogEventName): boolean {
-  return eventName.endsWith(".failed");
-}
 
 function ingestToAxiom(
   level: "info" | "warn" | "error" | "debug",
@@ -108,34 +110,7 @@ export const logger = {
     payload: RequestEventMap[E],
     options?: SentryOptions,
   ): void {
-    const fullPayload = scrubLogPayload({
-      ...base,
-      ...payload,
-      event: eventName,
-      timestamp: new Date().toISOString(),
-    });
-
-    if (axiom) {
-      axiom.ingest(dataset, [fullPayload]);
-    }
-
-    if (shouldSendToSentry(eventName) && options?.sentry !== false) {
-      if (options?.error instanceof Error) {
-        Sentry.captureException(options.error, { extra: fullPayload as Record<string, unknown> });
-      } else {
-        Sentry.captureMessage(eventName, {
-          level: "error",
-          extra: {
-            ...fullPayload as Record<string, unknown>,
-            ...(options?.error !== undefined ? { rawError: String(options.error) } : {}),
-          },
-        });
-      }
-    }
-
-    if (shouldLog()) {
-      console.log(`[event] ${eventName}`, fullPayload);
-    }
+    emit(eventName, base, payload, options);
   },
 
   systemEvent<E extends keyof SystemEventMap>(
@@ -144,35 +119,59 @@ export const logger = {
     payload: SystemEventMap[E],
     options?: SentryOptions,
   ): void {
-    const fullPayload = scrubLogPayload({
-      ...base,
-      ...payload,
-      event: eventName,
-      timestamp: new Date().toISOString(),
-    });
-
-    if (axiom) {
-      axiom.ingest(dataset, [fullPayload]);
-    }
-
-    if (shouldSendToSentry(eventName) && options?.sentry !== false) {
-      if (options?.error instanceof Error) {
-        Sentry.captureException(options.error, { extra: fullPayload as Record<string, unknown> });
-      } else {
-        Sentry.captureMessage(eventName, {
-          level: "error",
-          extra: {
-            ...fullPayload as Record<string, unknown>,
-            ...(options?.error !== undefined ? { rawError: String(options.error) } : {}),
-          },
-        });
-      }
-    }
-
-    if (shouldLog()) {
-      console.log(`[event] ${eventName}`, fullPayload);
-    }
+    emit(eventName, base, payload, options);
   },
 };
+
+/**
+ * Internal emit shared by `logger.event` and `logger.systemEvent`.
+ *
+ * - `timestamp` is set at emit time; this is the event-observation time and
+ *   is what Axiom indexes as `_time`. Request-start time is recoverable from
+ *   `timestamp - durationMs` for HTTP events.
+ * - Sentry is opt-in via `options.sentry === true`; the caller that owns the
+ *   error decides whether to forward it.
+ * - `*.failed` events route their console echo to stderr.
+ */
+function emit(
+  eventName: LogEventName,
+  base: RequestLogContext | SystemLogContext,
+  payload: Record<string, unknown>,
+  options?: SentryOptions,
+): void {
+  const fullPayload = scrubLogPayload({
+    ...base,
+    ...payload,
+    event: eventName,
+    timestamp: new Date().toISOString(),
+  }) as Record<string, unknown>;
+
+  if (axiom) {
+    axiom.ingest(dataset, [fullPayload]);
+  }
+
+  if (options?.sentry === true) {
+    if (options.error instanceof Error) {
+      Sentry.captureException(options.error, { extra: fullPayload });
+    } else {
+      Sentry.captureMessage(eventName, {
+        level: "error",
+        extra: {
+          ...fullPayload,
+          ...(options.error !== undefined
+            ? { rawError: String(options.error) }
+            : {}),
+        },
+      });
+    }
+  }
+
+  if (shouldLog()) {
+    const consoleFn = eventName.endsWith(".failed")
+      ? console.error
+      : console.log;
+    consoleFn(`[event] ${eventName}`, fullPayload);
+  }
+}
 
 process.on("beforeExit", () => logger.flush());

--- a/mcpjam-inspector/server/utils/logger.ts
+++ b/mcpjam-inspector/server/utils/logger.ts
@@ -125,7 +125,10 @@ export const logger = {
       } else {
         Sentry.captureMessage(eventName, {
           level: "error",
-          extra: fullPayload as Record<string, unknown>,
+          extra: {
+            ...fullPayload as Record<string, unknown>,
+            ...(options?.error !== undefined ? { rawError: String(options.error) } : {}),
+          },
         });
       }
     }
@@ -158,7 +161,10 @@ export const logger = {
       } else {
         Sentry.captureMessage(eventName, {
           level: "error",
-          extra: fullPayload as Record<string, unknown>,
+          extra: {
+            ...fullPayload as Record<string, unknown>,
+            ...(options?.error !== undefined ? { rawError: String(options.error) } : {}),
+          },
         });
       }
     }

--- a/mcpjam-inspector/server/utils/request-logger.ts
+++ b/mcpjam-inspector/server/utils/request-logger.ts
@@ -1,0 +1,53 @@
+import type { Context } from "hono";
+import type {
+  RequestLogContext,
+  RequestEventMap,
+  SystemLogContext,
+  SystemEventMap,
+} from "./log-events.js";
+import { logger } from "./logger.js";
+
+export function getRequestLogger(c: Context, component: string) {
+  return {
+    event<E extends keyof RequestEventMap>(
+      eventName: E,
+      payload: RequestEventMap[E],
+      options?: { error?: unknown; sentry?: boolean },
+    ): void {
+      const base: RequestLogContext = {
+        ...(c.var.requestLogContext as RequestLogContext),
+        component,
+      };
+      logger.event(eventName, base, payload, options);
+    },
+  };
+}
+
+export function getSystemLogger(component: string) {
+  return {
+    event<E extends keyof SystemEventMap>(
+      eventName: E,
+      partial: Omit<SystemLogContext, "event" | "timestamp" | "component"> &
+        Partial<Pick<SystemLogContext, "component">>,
+      payload: SystemEventMap[E],
+      options?: { error?: unknown; sentry?: boolean },
+    ): void {
+      const base: SystemLogContext = {
+        ...partial,
+        component,
+        event: eventName,
+        timestamp: new Date().toISOString(),
+      } as SystemLogContext;
+      logger.systemEvent(eventName, base, payload, options);
+    },
+  };
+}
+
+export function setRequestLogContext(
+  c: Context,
+  partial: Partial<RequestLogContext>,
+): void {
+  const current = c.var.requestLogContext;
+  if (!current) return;
+  c.set("requestLogContext", { ...current, ...partial });
+}

--- a/mcpjam-inspector/server/utils/request-logger.ts
+++ b/mcpjam-inspector/server/utils/request-logger.ts
@@ -1,43 +1,67 @@
 import type { Context } from "hono";
-import type {
-  RequestLogContext,
-  RequestEventMap,
-  SystemLogContext,
-  SystemEventMap,
+import {
+  resolveEnvironment,
+  resolveRelease,
+  type RequestLogContext,
+  type RequestEventMap,
+  type SystemLogContext,
+  type SystemEventMap,
 } from "./log-events.js";
 import { logger } from "./logger.js";
 
+type SentryOptions = { error?: unknown; sentry?: boolean };
+
+/**
+ * Returns a request-scoped logger that auto-attaches the per-request
+ * `RequestLogContext` populated by `requestLogContextMiddleware`.
+ *
+ * Throws if the middleware did not run for this route. That signals a real
+ * wiring bug (callsite is mounted outside `/api/*`, or the middleware is
+ * missing) — failing loudly here prevents emitting events with malformed
+ * envelopes that would otherwise pass type checks.
+ */
 export function getRequestLogger(c: Context, component: string) {
   return {
     event<E extends keyof RequestEventMap>(
       eventName: E,
       payload: RequestEventMap[E],
-      options?: { error?: unknown; sentry?: boolean },
+      options?: SentryOptions,
     ): void {
-      const base: RequestLogContext = {
-        ...(c.var.requestLogContext as RequestLogContext),
-        component,
-      };
-      logger.event(eventName, base, payload, options);
+      const ctx = c.var.requestLogContext;
+      if (!ctx) {
+        throw new Error(
+          `getRequestLogger("${component}") called without requestLogContext — ` +
+            `is requestLogContextMiddleware mounted on this route?`,
+        );
+      }
+      logger.event(eventName, { ...ctx, component }, payload, options);
     },
   };
 }
 
+/**
+ * Returns a system logger pre-bound to a component. The system envelope
+ * (environment, release, requestId/route/method nulls, authType "system") is
+ * filled automatically — callers only pass the event name and payload.
+ */
 export function getSystemLogger(component: string) {
   return {
     event<E extends keyof SystemEventMap>(
       eventName: E,
-      partial: Omit<SystemLogContext, "event" | "timestamp" | "component"> &
-        Partial<Pick<SystemLogContext, "component">>,
       payload: SystemEventMap[E],
-      options?: { error?: unknown; sentry?: boolean },
+      options?: SentryOptions,
     ): void {
       const base: SystemLogContext = {
-        ...partial,
-        component,
         event: eventName,
         timestamp: new Date().toISOString(),
-      } as SystemLogContext;
+        environment: resolveEnvironment(),
+        release: resolveRelease(),
+        component,
+        requestId: null,
+        route: null,
+        method: null,
+        authType: "system",
+      };
       logger.systemEvent(eventName, base, payload, options);
     },
   };


### PR DESCRIPTION
## Summary

Adds the typed event foundation for structured, safe, queryable logging across the inspector. Adds `logger.event()` and `logger.systemEvent()`, a recursive scrubber, request-scoped log context middleware (mounted only on `/api/*`), and the `unhandledRejection` system event. No route handlers are converted in this PR; that work begins in Inspector PR3 once the backend authorize endpoints return `internalLogContext`.

## Changes

- `server/utils/log-events.ts` — typed event map, `RequestLogContext`, `SystemLogContext`, `resolveEnvironment()`, `resolveRelease()`
- `server/utils/log-scrubber.ts` — recursive scrubber that redacts forbidden keys and string patterns (tokens, emails, secrets, JWTs)
- `server/utils/request-logger.ts` — `getRequestLogger()`, `getSystemLogger()`, `setRequestLogContext()` helpers
- `server/utils/error-classify.ts` — `classifyError()`, `classifyWidgetError()`, `classifyTunnelError()` helpers
- `server/middleware/request-log-context.ts` — auto-emit middleware for `http.request.completed/failed`, skips health endpoints and SSE streams
- `server/utils/logger.ts` — added `logger.event()` and `logger.systemEvent()` with Axiom + Sentry routing
- `server/types/hono.ts` — added `requestLogContext?: RequestLogContext` to `ContextVariableMap`
- `server/app.ts` — mount `requestLogContextMiddleware` on `/api/*` only
- `server/index.ts` — replace MCP-closed `unhandledRejection` branch with typed system event
- New test files: `log-scrubber.test.ts`, `request-logger.test.ts`, `request-log-context.middleware.test.ts`
- Updated: `logger.test.ts` with `logger.event` and `logger.systemEvent` coverage

## Out of scope

- No route handler conversions (those are PR3)
- No backend `internalLogContext` consumption (PR2)
- No ESLint rule changes
- No removal of existing `logger.error/warn/info/debug` callsites

## Test plan

### Automated

- `log-scrubber.test.ts` — forbidden keys, allowlisted `emailDomain`, recursion, string-pattern scrubbing (18 tests)
- `request-logger.test.ts` — `getRequestLogger`, `setRequestLogContext`, `getSystemLogger` shape (4 tests)
- `request-log-context.middleware.test.ts` — happy path, 5xx, health skip, SSE skip, exception re-throw, x-request-id header (10 tests)
- `logger.test.ts` (extended) — `logger.event` Axiom shape, Sentry routing, `logger.systemEvent` system envelope (6 new tests)

### Manual

- Start the inspector server and make API requests; verify `x-request-id` appears in response headers
- Trigger a 5xx response and confirm `http.request.failed` is emitted in Axiom
- Kill an MCP connection; confirm `mcp.connection.closed_with_pending_requests` is emitted with `authType: "system"`

## Risk and rollback

- Risk: Middleware adds overhead to every `/api/*` request; scrubber is called on every event
- Rollback: revert the PR; no schema or data migration required

## Cross-repo dependencies

- Depends on: none
- Unblocks: Inspector PR2 (`logging-inspector-authorize-wrapper`)