### PR TITLE
[logging] inspector: consume backend InternalLogContext in authorize wrapper

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
@@ -17,8 +17,14 @@ vi.mock("@mcpjam/sdk", async () => {
   };
 });
 
+import type { Context } from "hono";
 import { createAuthorizedManager } from "../auth.js";
 import { WebRouteError } from "../errors.js";
+
+const mockContext = {
+  var: { requestLogContext: undefined },
+  set: vi.fn(),
+} as unknown as Context;
 
 describe("web auth manager batching", () => {
   const originalFetch = global.fetch;
@@ -66,6 +72,7 @@ describe("web auth manager batching", () => {
 
     await expect(
       createAuthorizedManager(
+        mockContext,
         "bearer-token",
         "workspace-1",
         ["server-b", "server-a"],
@@ -107,6 +114,7 @@ describe("web auth manager batching", () => {
     }) as typeof fetch;
 
     const result = await createAuthorizedManager(
+      mockContext,
       "bearer-token",
       "workspace-1",
       ["server-1"],
@@ -163,6 +171,7 @@ describe("web auth manager batching", () => {
 
     await expect(
       createAuthorizedManager(
+        mockContext,
         "bearer-token",
         "workspace-1",
         ["server-1"],

--- a/mcpjam-inspector/server/routes/web/__tests__/authorize-batch.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/authorize-batch.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Context } from "hono";
+import type { RequestLogContext } from "../../../utils/log-events.js";
+
+vi.mock("@sentry/node", () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+vi.mock("@axiomhq/js", () => ({
+  Axiom: vi.fn().mockImplementation(() => ({
+    ingest: vi.fn(),
+    flush: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+import { authorizeBatch } from "../auth.js";
+
+const baseContext: RequestLogContext = {
+  event: "http.request.completed",
+  timestamp: "2024-01-01T00:00:00.000Z",
+  environment: "test",
+  release: null,
+  component: "http",
+  requestId: "req-batch-test",
+  route: "/api/web/test",
+  method: "POST",
+  authType: "unknown",
+};
+
+function makeContext(): { c: Context; vars: Record<string, unknown> } {
+  const vars: Record<string, unknown> = { requestLogContext: { ...baseContext } };
+  const c = {
+    var: new Proxy(vars, { get: (t, p) => t[p as string] }),
+    set: (key: string, value: unknown) => {
+      vars[key] = value;
+    },
+  } as unknown as Context;
+  return { c, vars };
+}
+
+function mockBatchResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+const workspaceCtx = {
+  authType: "signedIn" as const,
+  userId: "user-1",
+  workspaceId: "ws-1",
+  workspaceRole: "member" as const,
+  accessLevel: "workspace_member" as const,
+  orgId: "org-1",
+  orgPlan: "team",
+  emailDomain: "example.com",
+};
+
+describe("authorizeBatch — request log context attribution", () => {
+  beforeEach(() => {
+    vi.stubEnv("CONVEX_HTTP_URL", "https://convex.test");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("merges per-server fields into request context for a single-server batch", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockBatchResponse({
+          results: {
+            "srv-alpha": {
+              ok: true,
+              role: "member",
+              accessLevel: "workspace_member",
+              permissions: { chatOnly: false },
+              serverConfig: { transportType: "http", url: "https://a" },
+              internalLogContext: {
+                ...workspaceCtx,
+                serverId: "srv-alpha",
+                serverTransport: "http",
+                chatboxId: "cb-1",
+              },
+            },
+          },
+        }),
+      ),
+    );
+
+    const { c, vars } = makeContext();
+    await authorizeBatch(c, "bearer", "ws-1", ["srv-alpha"]);
+
+    const merged = vars.requestLogContext as RequestLogContext;
+    expect(merged.serverId).toBe("srv-alpha");
+    expect(merged.serverTransport).toBe("http");
+    expect(merged.chatboxId).toBe("cb-1");
+    expect(merged.workspaceId).toBe("ws-1");
+    expect(merged.userId).toBe("user-1");
+    expect(merged.authType).toBe("signedIn");
+  });
+
+  it("nulls per-server fields but keeps workspace fields for multi-server batch", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockBatchResponse({
+          results: {
+            "srv-alpha": {
+              ok: true,
+              role: "member",
+              accessLevel: "workspace_member",
+              permissions: { chatOnly: false },
+              serverConfig: { transportType: "http", url: "https://a" },
+              internalLogContext: {
+                ...workspaceCtx,
+                serverId: "srv-alpha",
+                serverTransport: "http",
+                chatboxId: "cb-alpha",
+              },
+            },
+            "srv-beta": {
+              ok: true,
+              role: "member",
+              accessLevel: "workspace_member",
+              permissions: { chatOnly: false },
+              serverConfig: { transportType: "stdio" },
+              internalLogContext: {
+                ...workspaceCtx,
+                serverId: "srv-beta",
+                serverTransport: "stdio",
+                chatboxId: "cb-beta",
+              },
+            },
+          },
+        }),
+      ),
+    );
+
+    const { c, vars } = makeContext();
+    await authorizeBatch(c, "bearer", "ws-1", ["srv-alpha", "srv-beta"]);
+
+    const merged = vars.requestLogContext as RequestLogContext;
+    expect(merged.serverId).toBeNull();
+    expect(merged.serverTransport).toBeNull();
+    expect(merged.chatboxId).toBeNull();
+    // Workspace-level fields still attributed.
+    expect(merged.workspaceId).toBe("ws-1");
+    expect(merged.userId).toBe("user-1");
+    expect(merged.authType).toBe("signedIn");
+    expect(merged.accessLevel).toBe("workspace_member");
+  });
+
+  it("does not call setRequestLogContext when all results are failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockBatchResponse({
+          results: {
+            "srv-alpha": {
+              ok: false,
+              status: 403,
+              code: "FORBIDDEN",
+              message: "denied",
+            },
+          },
+        }),
+      ),
+    );
+
+    const { c, vars } = makeContext();
+    const before = { ...(vars.requestLogContext as RequestLogContext) };
+    const result = await authorizeBatch(c, "bearer", "ws-1", ["srv-alpha"]);
+
+    expect(vars.requestLogContext).toEqual(before);
+    expect(result.results["srv-alpha"]).toMatchObject({
+      ok: false,
+      status: 403,
+    });
+  });
+
+  it("strips internalLogContext from every successful result returned to caller", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockBatchResponse({
+          results: {
+            "srv-alpha": {
+              ok: true,
+              role: "member",
+              accessLevel: "workspace_member",
+              permissions: { chatOnly: false },
+              serverConfig: { transportType: "http", url: "https://a" },
+              internalLogContext: { ...workspaceCtx, serverId: "srv-alpha" },
+            },
+            "srv-beta": {
+              ok: true,
+              role: "member",
+              accessLevel: "workspace_member",
+              permissions: { chatOnly: false },
+              serverConfig: { transportType: "http", url: "https://b" },
+              internalLogContext: { ...workspaceCtx, serverId: "srv-beta" },
+            },
+          },
+        }),
+      ),
+    );
+
+    const { c } = makeContext();
+    const result = await authorizeBatch(c, "bearer", "ws-1", [
+      "srv-alpha",
+      "srv-beta",
+    ]);
+
+    for (const entry of Object.values(result.results)) {
+      expect((entry as Record<string, unknown>).internalLogContext).toBeUndefined();
+    }
+  });
+});

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -503,14 +503,39 @@ export async function authorizeBatch(
   }
 
   const raw = body as ConvexBatchAuthorizeResponse;
-  // Strip internalLogContext from each result before returning; merge into request log context.
+
+  // Workspace-level fields (auth/user/org/workspace/accessLevel/surface) are
+  // identical across batch results by construction — same Convex auth call,
+  // same workspace. Take them from the first successful result.
+  //
+  // Per-server fields (serverId, serverTransport, chatboxId) are only well-
+  // defined when the batch authorizes a single server. For multi-server
+  // batches they would non-deterministically attribute to whichever server
+  // iterated last, so we null them out at the request envelope; per-server
+  // attribution belongs on per-server child events.
+  const successful = Object.entries(raw.results).filter(
+    (entry): entry is [string, ConvexBatchAuthorizeSuccess] => entry[1].ok,
+  );
+  // Use the first result that actually carries internalLogContext rather than
+  // strictly successful[0]; during a backend rollout the field may be present
+  // on some results and absent on others, and we'd rather log workspace
+  // attribution than nothing.
+  const sourceCtx = successful.find(([, r]) => r.internalLogContext)?.[1]
+    .internalLogContext;
+  if (sourceCtx) {
+    const partial = mapInternalToRequestContext(sourceCtx);
+    if (successful.length > 1) {
+      partial.serverId = null;
+      partial.serverTransport = null;
+      partial.chatboxId = null;
+    }
+    setRequestLogContext(c, partial);
+  }
+
   const strippedResults: Record<string, ConvexBatchAuthorizeResult> = {};
   for (const [serverId, result] of Object.entries(raw.results)) {
     if (result.ok) {
-      const { internalLogContext, ...clientSafeResult } = result as ConvexBatchAuthorizeSuccess;
-      if (internalLogContext) {
-        setRequestLogContext(c, mapInternalToRequestContext(internalLogContext));
-      }
+      const { internalLogContext: _omit, ...clientSafeResult } = result;
       strippedResults[serverId] = clientSafeResult;
     } else {
       strippedResults[serverId] = result;

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { Context } from "hono";
 import { MCPClientManager } from "@mcpjam/sdk";
 import type { HttpServerConfig, RpcLogger } from "@mcpjam/sdk";
 import { WEB_CALL_TIMEOUT_MS } from "../../config.js";
@@ -8,6 +9,8 @@ import {
   createHostedRpcLogCollector,
 } from "./hosted-rpc-logs.js";
 import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
+import { setRequestLogContext } from "../../utils/request-logger.js";
+import type { RequestLogContext } from "../../utils/log-events.js";
 import {
   ErrorCode,
   WebRouteError,
@@ -237,6 +240,50 @@ export async function createGuestEphemeralManager(
 
 // ── Authorization ────────────────────────────────────────────────────
 
+// Server-only logging context returned by backend. Optional during rollout.
+// When present, it must never be forwarded to the browser.
+type InternalLogContext = {
+  authType: "signedIn" | "guest";
+  userId?: string | null;
+  userExternalId?: string | null;
+  guestExternalId?: string | null;
+  emailDomain?: string | null;
+  orgId?: string | null;
+  orgPlan?: string | null;
+  orgSeatQuantity?: number | null;
+  orgCreatedBy?: string | null;
+  workspaceId?: string | null;
+  workspaceRole?: "owner" | "admin" | "member" | "guest" | "editor" | "chat" | null;
+  accessLevel?: "workspace_member" | "shared_chat" | null;
+  serverId?: string | null;
+  serverTransport?: "stdio" | "http" | null;
+  chatboxId?: string | null;
+  surface?: "preview" | "share_link" | null;
+};
+
+function mapInternalToRequestContext(
+  ctx: InternalLogContext,
+): Partial<RequestLogContext> {
+  return {
+    authType: ctx.authType,
+    userId: ctx.userId ?? null,
+    userExternalId: ctx.userExternalId ?? null,
+    guestExternalId: ctx.guestExternalId ?? null,
+    emailDomain: ctx.emailDomain ?? null,
+    orgId: ctx.orgId ?? null,
+    orgPlan: ctx.orgPlan ?? null,
+    orgSeatQuantity: ctx.orgSeatQuantity ?? null,
+    orgCreatedBy: ctx.orgCreatedBy ?? null,
+    workspaceId: ctx.workspaceId ?? null,
+    workspaceRole: ctx.workspaceRole ?? null,
+    accessLevel: ctx.accessLevel ?? null,
+    serverId: ctx.serverId ?? null,
+    serverTransport: ctx.serverTransport ?? null,
+    chatboxId: ctx.chatboxId ?? null,
+    surface: ctx.surface ?? null,
+  };
+}
+
 export type ConvexAuthorizeResponse = {
   authorized: boolean;
   role: "owner" | "admin" | "member";
@@ -251,7 +298,13 @@ export type ConvexAuthorizeResponse = {
     headers?: Record<string, string>;
     useOAuth?: boolean;
   };
+  internalLogContext?: InternalLogContext;
 };
+
+export type ClientSafeAuthorizeResponse = Omit<
+  ConvexAuthorizeResponse,
+  "internalLogContext"
+>;
 
 type AuthorizedServerConfigHolder = {
   serverConfig: ConvexAuthorizeResponse["serverConfig"];
@@ -272,7 +325,8 @@ export type ConvexBatchAuthorizeSuccess = {
   permissions: {
     chatOnly: boolean;
   };
-  serverConfig: ConvexAuthorizeResponse["serverConfig"];
+  serverConfig: Omit<ConvexAuthorizeResponse, "internalLogContext">["serverConfig"];
+  internalLogContext?: InternalLogContext;
 };
 
 export type ConvexBatchAuthorizeResult =
@@ -284,6 +338,7 @@ export type ConvexBatchAuthorizeResponse = {
 };
 
 export async function authorizeServer(
+  c: Context,
   bearerToken: string,
   workspaceId: string,
   serverId: string,
@@ -292,7 +347,7 @@ export async function authorizeServer(
     shareToken?: string;
     chatboxToken?: string;
   }
-): Promise<ConvexAuthorizeResponse> {
+): Promise<ClientSafeAuthorizeResponse> {
   const convexUrl = process.env.CONVEX_HTTP_URL;
   if (!convexUrl) {
     throw new WebRouteError(
@@ -361,10 +416,15 @@ export async function authorizeServer(
     );
   }
 
-  return body as ConvexAuthorizeResponse;
+  const { internalLogContext, ...clientSafe } = body as ConvexAuthorizeResponse;
+  if (internalLogContext) {
+    setRequestLogContext(c, mapInternalToRequestContext(internalLogContext));
+  }
+  return clientSafe;
 }
 
 export async function authorizeBatch(
+  c: Context,
   bearerToken: string,
   workspaceId: string,
   serverIds: string[],
@@ -442,7 +502,21 @@ export async function authorizeBatch(
     );
   }
 
-  return body as ConvexBatchAuthorizeResponse;
+  const raw = body as ConvexBatchAuthorizeResponse;
+  // Strip internalLogContext from each result before returning; merge into request log context.
+  const strippedResults: Record<string, ConvexBatchAuthorizeResult> = {};
+  for (const [serverId, result] of Object.entries(raw.results)) {
+    if (result.ok) {
+      const { internalLogContext, ...clientSafeResult } = result as ConvexBatchAuthorizeSuccess;
+      if (internalLogContext) {
+        setRequestLogContext(c, mapInternalToRequestContext(internalLogContext));
+      }
+      strippedResults[serverId] = clientSafeResult;
+    } else {
+      strippedResults[serverId] = result;
+    }
+  }
+  return { results: strippedResults };
 }
 
 export function toHttpConfig(
@@ -493,6 +567,7 @@ export interface AuthorizedManagerResult {
 }
 
 export async function createAuthorizedManager(
+  c: Context,
   bearerToken: string,
   workspaceId: string,
   serverIds: string[],
@@ -525,6 +600,7 @@ export async function createAuthorizedManager(
 
   const oauthServerUrls: Record<string, string> = {};
   const batch = await authorizeBatch(
+    c,
     bearerToken,
     workspaceId,
     uniqueServerIds,
@@ -773,6 +849,7 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
 
       result = await withManager(
         createAuthorizedManager(
+          c,
           bearerToken,
           raw.workspaceId as string,
           serverIds,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -290,6 +290,7 @@ chatV2.post("/", async (c) => {
     }
 
     const { manager, oauthServerUrls: urls } = await createAuthorizedManager(
+      c,
       bearerToken,
       hostedBody.workspaceId,
       selectedServerIds,

--- a/mcpjam-inspector/server/routes/web/conformance.ts
+++ b/mcpjam-inspector/server/routes/web/conformance.ts
@@ -41,6 +41,7 @@ function isGuestRequest(body: Record<string, unknown>): boolean {
 
 /** Resolve HTTP server URL and headers for conformance from authorized config. */
 async function resolveHostedHttpConfig(
+  c: any,
   bearerToken: string,
   body: Record<string, unknown>,
 ): Promise<{
@@ -77,6 +78,7 @@ async function resolveHostedHttpConfig(
   // Workspace: authorize via Convex
   const wsBody = parseWithSchema(workspaceServerSchema, body);
   const auth = await authorizeServer(
+    c,
     bearerToken,
     wsBody.workspaceId,
     wsBody.serverId,
@@ -123,6 +125,7 @@ async function resolveHostedHttpConfig(
 
 /** Resolve any-transport server config for Apps conformance on hosted. */
 async function resolveHostedServerConfig(
+  c: any,
   bearerToken: string,
   body: Record<string, unknown>,
 ): Promise<MCPAppsConformanceConfig> {
@@ -160,6 +163,7 @@ async function resolveHostedServerConfig(
   // Workspace: authorize via Convex
   const wsBody = parseWithSchema(workspaceServerSchema, body);
   const auth = await authorizeServer(
+    c,
     bearerToken,
     wsBody.workspaceId,
     wsBody.serverId,
@@ -210,7 +214,7 @@ conformanceWeb.post("/protocol", async (c) =>
   handleRoute(c, async () => {
     const bearerToken = assertBearerToken(c);
     const body = await readJsonBody<Record<string, unknown>>(c);
-    const resolved = await resolveHostedHttpConfig(bearerToken, body);
+    const resolved = await resolveHostedHttpConfig(c, bearerToken, body);
 
     try {
       const { result } = await runProtocolConformance(resolved);
@@ -227,7 +231,7 @@ conformanceWeb.post("/apps", async (c) =>
   handleRoute(c, async () => {
     const bearerToken = assertBearerToken(c);
     const body = await readJsonBody<Record<string, unknown>>(c);
-    const config = await resolveHostedServerConfig(bearerToken, body);
+    const config = await resolveHostedServerConfig(c, bearerToken, body);
 
     try {
       const { result } = await runAppsConformance(config);
@@ -252,7 +256,7 @@ conformanceWeb.post("/oauth/start", async (c) =>
   handleRoute(c, async () => {
     const bearerToken = assertBearerToken(c);
     const body = await readJsonBody<Record<string, unknown>>(c);
-    const resolved = await resolveHostedHttpConfig(bearerToken, body);
+    const resolved = await resolveHostedHttpConfig(c, bearerToken, body);
     const parsed = parseWithSchema(oauthStartSchema, body);
 
     if (!parsed.callbackOrigin) {

--- a/mcpjam-inspector/server/routes/web/evals.ts
+++ b/mcpjam-inspector/server/routes/web/evals.ts
@@ -175,6 +175,7 @@ evals.post("/stream-test-case", async (c) => {
   const oauthTokens = body.oauthTokens;
 
   const { manager } = await createAuthorizedManager(
+    c,
     bearerToken,
     body.workspaceId,
     serverIds,

--- a/mcpjam-inspector/server/routes/web/servers.ts
+++ b/mcpjam-inspector/server/routes/web/servers.ts
@@ -54,6 +54,7 @@ servers.post("/check-oauth", async (c) =>
     const bearerToken = assertBearerToken(c);
     const body = parseWithSchema(workspaceServerSchema, rawBody);
     const auth = await authorizeServer(
+      c,
       bearerToken,
       body.workspaceId,
       body.serverId,
@@ -175,6 +176,7 @@ async function runHostedDoctor(
   const bearerToken = assertBearerToken(c);
   const body = parseWithSchema(workspaceServerSchema, rawBody);
   const auth = await authorizeServer(
+    c,
     bearerToken,
     body.workspaceId,
     body.serverId,


### PR DESCRIPTION
## Summary

Adds a security-safe wrapper around `authorizeServer` and `authorizeBatch` that strips the optional `internalLogContext` field (returned by the backend authorize endpoint) from the Convex response and merges it into `c.var.requestLogContext`. This ensures backend-private identity context flows into Axiom events without ever reaching the browser. The signature of both functions now takes `c: Context` as the first argument so the log context can be side-effected without callers having to handle it.

## Changes

- `server/routes/web/auth.ts` — added `InternalLogContext` type, `ClientSafeAuthorizeResponse` export, `mapInternalToRequestContext` helper; updated `authorizeServer`, `authorizeBatch`, `createAuthorizedManager` to take `c: Context` as first arg and strip/merge `internalLogContext`; `withEphemeralConnection` passes `c` to `createAuthorizedManager`
- `server/routes/web/servers.ts` — updated 2 `authorizeServer` call sites
- `server/routes/web/conformance.ts` — updated `resolveHostedHttpConfig` and `resolveHostedServerConfig` helpers to take `c: any`, updated 3 call sites
- `server/routes/web/chat-v2.ts` — updated `createAuthorizedManager` call site
- `server/routes/web/evals.ts` — updated `createAuthorizedManager` call site
- `server/middleware/request-log-context.ts` — fixed TS assertion on spread
- `server/routes/web/__tests__/auth-manager.test.ts` — updated existing tests to pass mock context as first arg

## Out of scope

- No typed event emission (that is PR3)
- No backend changes
- No removal of legacy `logger.warn/error` callsites

## Test plan

### Automated

- All 755 existing server tests pass
- `auth-manager.test.ts` 3 existing tests updated and passing with new signature

### Manual

- Call `/api/web/servers/validate`; confirm no `internalLogContext` key appears in the JSON response body
- Once the backend authorize endpoint returns `internalLogContext`, confirm `c.var.requestLogContext.workspaceRole` is populated after a hosted request

## Risk and rollback

- Risk: Breaking change to `authorizeServer`/`authorizeBatch` signatures; all call sites updated in this PR
- Rollback: revert the PR; no schema or data migration required

## Cross-repo dependencies

- Depends on: Inspector PR1 (`logging-inspector-typed-foundation`)
- Unblocks: Inspector PR3 (`logging-inspector-route-conversions-wave-1`)