### PR TITLE
[logging] inspector: convert chat ingest, tunnels, widgets to typed events

### DIFF
--- a/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/index.ts
@@ -9,6 +9,8 @@
 import { Hono } from "hono";
 import "../../../types/hono";
 import { logger } from "../../../utils/logger";
+import { getRequestLogger } from "../../../utils/request-logger";
+import { classifyWidgetError } from "../../../utils/error-classify";
 import { RESOURCE_MIME_TYPE } from "@modelcontextprotocol/ext-apps/app-bridge";
 import type {
   McpUiResourceCsp,
@@ -92,6 +94,12 @@ apps.post("/widget-content", async (c) => {
     const content = contents[0];
 
     if (!content) {
+      getRequestLogger(c, "routes.apps.mcp-apps").event("widget.resource.failed", {
+        widgetType: "mcp_apps",
+        resourceUri: resolvedResourceUri,
+        cspMode: effectiveCspMode,
+        errorCode: classifyWidgetError(null, "resource_missing"),
+      });
       return c.json({ error: "No content in resource" }, 404);
     }
 
@@ -116,6 +124,12 @@ apps.post("/widget-content", async (c) => {
     } else if ("blob" in content && typeof content.blob === "string") {
       html = Buffer.from(content.blob, "base64").toString("utf-8");
     } else {
+      getRequestLogger(c, "routes.apps.mcp-apps").event("widget.resource.failed", {
+        widgetType: "mcp_apps",
+        resourceUri: resolvedResourceUri,
+        cspMode: effectiveCspMode,
+        errorCode: classifyWidgetError(null, "html_missing"),
+      });
       return c.json({ error: "No HTML content in resource" }, 404);
     }
 
@@ -163,6 +177,12 @@ apps.post("/widget-content", async (c) => {
     });
 
     // Return JSON with HTML and metadata for CSP enforcement
+    getRequestLogger(c, "routes.apps.mcp-apps").event("widget.resource.served", {
+      widgetType: "mcp_apps",
+      resourceUri: resolvedResourceUri,
+      cspMode: effectiveCspMode,
+      mimeTypeValid,
+    });
     c.header("Cache-Control", "no-cache, no-store, must-revalidate");
     return c.json({
       html,
@@ -177,6 +197,10 @@ apps.post("/widget-content", async (c) => {
       mimeTypeWarning,
     });
   } catch (error) {
+    getRequestLogger(c, "routes.apps.mcp-apps").event("widget.resource.failed", {
+      widgetType: "mcp_apps",
+      errorCode: classifyWidgetError(error),
+    });
     logger.error("[MCP Apps] Error fetching resource", error);
     return c.json(
       { error: error instanceof Error ? error.message : "Unknown error" },

--- a/mcpjam-inspector/server/routes/mcp/oauth.ts
+++ b/mcpjam-inspector/server/routes/mcp/oauth.ts
@@ -1,6 +1,8 @@
 import { Hono } from "hono";
 import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { logger } from "../../utils/logger";
+import { getRequestLogger } from "../../utils/request-logger";
+import { classifyError } from "../../utils/error-classify";
 import {
   executeOAuthProxy,
   executeDebugOAuthProxy,
@@ -9,6 +11,15 @@ import {
 } from "../../utils/oauth-proxy.js";
 
 const oauth = new Hono();
+
+function safeHostname(url: string | undefined): string {
+  if (!url) return "unknown";
+  try {
+    return new URL(url).hostname || url;
+  } catch {
+    return url;
+  }
+}
 
 /**
  * Debug proxy for OAuth flow visualization and testing
@@ -20,17 +31,31 @@ const oauth = new Hono();
  * Body: { url: string, method?: string, body?: object, headers?: object }
  */
 oauth.post("/debug/proxy", async (c) => {
+  let proxyUrl: string | undefined;
   try {
     const { url, method, body, headers } = await c.req.json();
+    proxyUrl = url;
     const result = await executeDebugOAuthProxy({ url, method, body, headers });
     return c.json(result);
   } catch (error) {
+    const targetUrlHost = safeHostname(proxyUrl);
     if (error instanceof OAuthProxyError) {
+      getRequestLogger(c, "routes.mcp.oauth").event("mcp.oauth.proxy.failed", {
+        targetUrlHost,
+        oauthPhase: "proxy",
+        errorCode: classifyError(error),
+        statusCode: error.status,
+      });
       return c.json(
         { error: error.message },
         error.status as ContentfulStatusCode,
       );
     }
+    getRequestLogger(c, "routes.mcp.oauth").event("mcp.oauth.proxy.failed", {
+      targetUrlHost,
+      oauthPhase: "proxy",
+      errorCode: classifyError(error),
+    });
     logger.error("[OAuth Debug Proxy] Error", error);
     return c.json(
       {
@@ -50,17 +75,31 @@ oauth.post("/debug/proxy", async (c) => {
  * @deprecated Use /debug/proxy for debugging or implement proper OAuth client
  */
 oauth.post("/proxy", async (c) => {
+  let proxyUrl: string | undefined;
   try {
     const { url, method, body, headers } = await c.req.json();
+    proxyUrl = url;
     const result = await executeOAuthProxy({ url, method, body, headers });
     return c.json(result);
   } catch (error) {
+    const targetUrlHost = safeHostname(proxyUrl);
     if (error instanceof OAuthProxyError) {
+      getRequestLogger(c, "routes.mcp.oauth").event("mcp.oauth.proxy.failed", {
+        targetUrlHost,
+        oauthPhase: "proxy",
+        errorCode: classifyError(error),
+        statusCode: error.status,
+      });
       return c.json(
         { error: error.message },
         error.status as ContentfulStatusCode,
       );
     }
+    getRequestLogger(c, "routes.mcp.oauth").event("mcp.oauth.proxy.failed", {
+      targetUrlHost,
+      oauthPhase: "proxy",
+      errorCode: classifyError(error),
+    });
     logger.error("OAuth proxy error", error);
     return c.json(
       {
@@ -77,13 +116,13 @@ oauth.post("/proxy", async (c) => {
  * GET /api/mcp/oauth/metadata?url=https://mcp.asana.com/.well-known/oauth-authorization-server/sse
  */
 oauth.get("/metadata", async (c) => {
+  const metadataUrl = c.req.query("url");
   try {
-    const url = c.req.query("url");
-    if (!url) {
+    if (!metadataUrl) {
       return c.json({ error: "Missing url parameter" }, 400);
     }
 
-    const result = await fetchOAuthMetadata(url);
+    const result = await fetchOAuthMetadata(metadataUrl);
     if ("status" in result && result.status !== undefined) {
       return c.json(
         {
@@ -95,12 +134,24 @@ oauth.get("/metadata", async (c) => {
 
     return c.json(result.metadata);
   } catch (error) {
+    const targetUrlHost = safeHostname(metadataUrl);
     if (error instanceof OAuthProxyError) {
+      getRequestLogger(c, "routes.mcp.oauth").event("mcp.oauth.proxy.failed", {
+        targetUrlHost,
+        oauthPhase: "metadata",
+        errorCode: classifyError(error),
+        statusCode: error.status,
+      });
       return c.json(
         { error: error.message },
         error.status as ContentfulStatusCode,
       );
     }
+    getRequestLogger(c, "routes.mcp.oauth").event("mcp.oauth.proxy.failed", {
+      targetUrlHost,
+      oauthPhase: "metadata",
+      errorCode: classifyError(error),
+    });
     logger.error("OAuth metadata proxy error", error);
     return c.json(
       {

--- a/mcpjam-inspector/server/routes/mcp/tunnels.ts
+++ b/mcpjam-inspector/server/routes/mcp/tunnels.ts
@@ -1,9 +1,12 @@
 import { Hono } from "hono";
+import type { Context } from "hono";
 import { tunnelManager } from "../../services/tunnel-manager";
 import { LOCAL_SERVER_ADDR } from "../../config";
 import { cleanupOrphanedTunnels } from "../../services/tunnel-cleanup";
 import "../../types/hono";
 import { logger } from "../../utils/logger";
+import { getRequestLogger } from "../../utils/request-logger";
+import { classifyTunnelError } from "../../utils/error-classify";
 
 const tunnels = new Hono();
 
@@ -62,6 +65,14 @@ async function fetchNgrokToken(authHeader?: string): Promise<{
   };
 }
 
+function safeHostname(url: string): string {
+  try {
+    return new URL(url).hostname || url;
+  } catch {
+    return url;
+  }
+}
+
 // Report tunnel creation to Convex backend
 async function recordTunnel(
   serverId: string,
@@ -70,6 +81,7 @@ async function recordTunnel(
   domainId?: string,
   domain?: string,
   authHeader?: string,
+  c?: Context,
 ): Promise<void> {
   const convexUrl = process.env.CONVEX_HTTP_URL;
   if (!convexUrl) {
@@ -92,6 +104,14 @@ async function recordTunnel(
       body: JSON.stringify({ serverId, url, credentialId, domainId, domain }),
     });
   } catch (error) {
+    const tunnelKind = serverId === "shared" ? "shared" : "server";
+    if (c) {
+      getRequestLogger(c, "routes.mcp.tunnels").event("tunnel.record_failed", {
+        tunnelKind,
+        tunnelDomain: domain,
+        errorCode: classifyTunnelError(error, "convex_record_failed"),
+      });
+    }
     logger.error("Failed to record tunnel", error, { serverId, url });
     // Don't throw - tunnel is already created, just log the error
   }
@@ -167,6 +187,11 @@ tunnels.post("/create", async (c) => {
     // Check if tunnel already exists
     const existingUrl = tunnelManager.getTunnelUrl();
     if (existingUrl) {
+      getRequestLogger(c, "routes.mcp.tunnels").event("tunnel.created", {
+        tunnelKind: "shared",
+        tunnelDomain: safeHostname(existingUrl),
+        existed: true,
+      });
       return c.json({
         url: existingUrl,
         existed: true,
@@ -189,13 +214,24 @@ tunnels.post("/create", async (c) => {
       domainId,
       domain,
       authHeader,
+      c,
     );
 
+    getRequestLogger(c, "routes.mcp.tunnels").event("tunnel.created", {
+      tunnelKind: "shared",
+      tunnelDomain: domain,
+      existed: false,
+      credentialIdPresent: !!credentialId,
+    });
     return c.json({
       url,
       existed: false,
     });
   } catch (error: any) {
+    getRequestLogger(c, "routes.mcp.tunnels").event("tunnel.creation_failed", {
+      tunnelKind: "shared",
+      errorCode: classifyTunnelError(error),
+    });
     logger.error("Error creating tunnel", error);
     return c.json(
       {
@@ -214,6 +250,11 @@ tunnels.post("/create/:serverId", async (c) => {
   try {
     const existingUrl = tunnelManager.getServerTunnelUrl(serverId);
     if (existingUrl) {
+      getRequestLogger(c, "routes.mcp.tunnels").event("tunnel.created", {
+        tunnelKind: "server",
+        tunnelDomain: safeHostname(existingUrl),
+        existed: true,
+      });
       return c.json({
         url: existingUrl,
         existed: true,
@@ -236,6 +277,7 @@ tunnels.post("/create/:serverId", async (c) => {
       domainId,
       domain,
       authHeader,
+      c,
     );
 
     const serverTunnelUrl = tunnelManager.getServerTunnelUrl(serverId);
@@ -243,12 +285,22 @@ tunnels.post("/create/:serverId", async (c) => {
       throw new Error("Failed to build server tunnel URL");
     }
 
+    getRequestLogger(c, "routes.mcp.tunnels").event("tunnel.created", {
+      tunnelKind: "server",
+      tunnelDomain: domain,
+      existed: false,
+      credentialIdPresent: !!credentialId,
+    });
     return c.json({
       url: serverTunnelUrl,
       serverId,
       existed: false,
     });
   } catch (error: any) {
+    getRequestLogger(c, "routes.mcp.tunnels").event("tunnel.creation_failed", {
+      tunnelKind: "server",
+      errorCode: classifyTunnelError(error),
+    });
     logger.error("Error creating server-specific tunnel", error, { serverId });
     return c.json(
       {

--- a/mcpjam-inspector/server/utils/__tests__/chat-ingestion.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-ingestion.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Context } from "hono";
 import { persistChatSessionToConvex } from "../chat-ingestion";
 
 const mockLogger = vi.hoisted(() => ({
   warn: vi.fn(),
+  event: vi.fn(),
 }));
 
 vi.mock("../logger", () => ({
@@ -200,6 +202,125 @@ describe("chat-ingestion", () => {
         responsePreview: expect.stringContaining("VERSION_CONFLICT"),
       }),
     );
+  });
+
+  it("emits chat.session.persist.failed(version_conflict) via typed event when c is provided", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ code: "VERSION_CONFLICT" }), {
+        status: 409,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const c = { var: {}, set: vi.fn() } as unknown as Context;
+
+    await persistChatSessionToConvex(
+      {
+        chatSessionId: "evt-1",
+        modelId: "m",
+        modelSource: "mcpjam",
+        authHeader: "Bearer t",
+        startedAt: 1,
+        sourceType: "chatbox",
+      },
+      c,
+    );
+
+    expect(mockLogger.event).toHaveBeenCalledWith(
+      "chat.session.persist.failed",
+      expect.any(Object),
+      expect.objectContaining({ failureKind: "version_conflict" }),
+      undefined,
+    );
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it("emits chat.session.persist.failed(http_error) via typed event when c is provided", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response("Server Error", { status: 503 }),
+    );
+    const c = { var: {}, set: vi.fn() } as unknown as Context;
+
+    await persistChatSessionToConvex(
+      {
+        chatSessionId: "evt-2",
+        modelId: "m",
+        modelSource: "mcpjam",
+        authHeader: "Bearer t",
+        startedAt: 1,
+        sourceType: "direct",
+      },
+      c,
+    );
+
+    expect(mockLogger.event).toHaveBeenCalledWith(
+      "chat.session.persist.failed",
+      expect.any(Object),
+      expect.objectContaining({ failureKind: "http_error", statusCode: 503 }),
+      undefined,
+    );
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it("emits chat.session.persist.failed(timeout) via typed event when c is provided", async () => {
+    vi.useFakeTimers();
+    global.fetch = vi.fn().mockImplementation(
+      async (_input, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          if (signal instanceof AbortSignal) {
+            signal.addEventListener("abort", () => {
+              reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+            });
+          }
+        }),
+    ) as typeof fetch;
+    const c = { var: {}, set: vi.fn() } as unknown as Context;
+
+    const p = persistChatSessionToConvex(
+      {
+        chatSessionId: "evt-3",
+        modelId: "m",
+        modelSource: "mcpjam",
+        authHeader: "Bearer t",
+        startedAt: 1,
+        timeoutMs: 50,
+      },
+      c,
+    );
+    await vi.advanceTimersByTimeAsync(50);
+    await p;
+
+    expect(mockLogger.event).toHaveBeenCalledWith(
+      "chat.session.persist.failed",
+      expect.any(Object),
+      expect.objectContaining({ failureKind: "timeout" }),
+      undefined,
+    );
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it("emits chat.session.persist.failed(exception) via typed event when c is provided", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("network failure"));
+    const c = { var: {}, set: vi.fn() } as unknown as Context;
+
+    await persistChatSessionToConvex(
+      {
+        chatSessionId: "evt-4",
+        modelId: "m",
+        modelSource: "mcpjam",
+        authHeader: "Bearer t",
+        startedAt: 1,
+      },
+      c,
+    );
+
+    expect(mockLogger.event).toHaveBeenCalledWith(
+      "chat.session.persist.failed",
+      expect.any(Object),
+      expect.objectContaining({ failureKind: "exception" }),
+      expect.objectContaining({ error: expect.any(Error) }),
+    );
+    expect(mockLogger.warn).not.toHaveBeenCalled();
   });
 
   it("includes directVisibility when persisting a direct chat", async () => {

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -1,4 +1,6 @@
+import type { Context } from "hono";
 import { logger } from "./logger";
+import { getRequestLogger } from "./request-logger";
 import type { EvalTraceSpan } from "@/shared/eval-trace";
 import type { LiveChatTraceUsage } from "@/shared/live-chat-trace";
 
@@ -122,6 +124,7 @@ async function readResponsePreview(response: Response): Promise<string> {
 
 export async function persistChatSessionToConvex(
   options: PersistChatSessionOptions,
+  c?: Context,
 ): Promise<void> {
   const convexUrl = process.env.CONVEX_HTTP_URL;
   if (!convexUrl || !options.authHeader || !options.chatSessionId) {
@@ -188,29 +191,75 @@ export async function persistChatSessionToConvex(
 
     if (!response.ok) {
       const responsePreview = await readResponsePreview(response);
-      const logMessage =
-        response.status === 409 && responsePreview.includes("VERSION_CONFLICT")
-          ? "[chat-session-persistence] Chat session version conflict"
-          : `[chat-session-persistence] Failed to persist chat session (${response.status}): ${responsePreview}`;
-      logger.warn(logMessage, {
-        status: response.status,
-        responsePreview,
-      });
+      const isVersionConflict =
+        response.status === 409 &&
+        (response.headers.get("content-type")?.includes("application/json")
+          ? false
+          : responsePreview.includes("VERSION_CONFLICT"));
+      let failureKind: "version_conflict" | "http_error" = "http_error";
+
+      if (response.status === 409) {
+        let jsonCode: string | undefined;
+        try {
+          const cloned = response.clone();
+          const json = (await cloned.json()) as { code?: string };
+          jsonCode = json?.code;
+        } catch {
+          // ignored — use text fallback
+        }
+        if (
+          jsonCode === "VERSION_CONFLICT" ||
+          isVersionConflict ||
+          responsePreview.includes("VERSION_CONFLICT")
+        ) {
+          failureKind = "version_conflict";
+        }
+      }
+
+      if (c) {
+        const reqLogger = getRequestLogger(c, "utils.chat-ingestion");
+        reqLogger.event("chat.session.persist.failed", {
+          failureKind,
+          statusCode: response.status,
+          sourceType: options.sourceType,
+        });
+      } else {
+        const logMessage =
+          failureKind === "version_conflict"
+            ? "[chat-session-persistence] Chat session version conflict"
+            : `[chat-session-persistence] Failed to persist chat session (${response.status}): ${responsePreview}`;
+        logger.warn(logMessage, { status: response.status, responsePreview });
+      }
     }
   } catch (error) {
     if (isAbortError(error)) {
-      logger.warn(
-        "[chat-session-persistence] Timed out persisting chat session",
-        {
-          timeoutMs,
-        },
-      );
+      if (c) {
+        const reqLogger = getRequestLogger(c, "utils.chat-ingestion");
+        reqLogger.event("chat.session.persist.failed", {
+          failureKind: "timeout",
+          sourceType: options.sourceType,
+        });
+      } else {
+        logger.warn(
+          "[chat-session-persistence] Timed out persisting chat session",
+          { timeoutMs },
+        );
+      }
       return;
     }
 
-    logger.warn("[chat-session-persistence] Error persisting chat session", {
-      error: error instanceof Error ? error.message : String(error),
-    });
+    if (c) {
+      const reqLogger = getRequestLogger(c, "utils.chat-ingestion");
+      reqLogger.event(
+        "chat.session.persist.failed",
+        { failureKind: "exception", sourceType: options.sourceType },
+        { error: error instanceof Error ? error : undefined },
+      );
+    } else {
+      logger.warn("[chat-session-persistence] Error persisting chat session", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   } finally {
     clearTimeout(timeoutId);
   }


### PR DESCRIPTION
## Summary

- Converts `persistChatSessionToConvex` to emit `chat.session.persist.failed` typed events (with `version_conflict`, `http_error`, `timeout`, `exception` failure kinds) when a Hono `Context` is available; falls back to `logger.warn` for callers without a request context
- Converts the `widget-content` POST handler to emit `widget.resource.served` on success and `widget.resource.failed` (with `classifyWidgetError` error codes) on early-return 404s and catch errors
- Converts `tunnels.ts` `/create` and `/create/:serverId` to emit `tunnel.created` (for both new and pre-existing tunnels) and `tunnel.creation_failed` on catch; adds `tunnel.record_failed` inside `recordTunnel`'s catch block via an optional `c?: Context` parameter
- Converts OAuth proxy routes (`/debug/proxy`, `/proxy`, `/metadata`) to emit `mcp.oauth.proxy.failed` with `targetUrlHost`, `oauthPhase`, `errorCode`, and optional `statusCode`

## Test plan

- [x] 4 new tests for `chat-ingestion` event emission: VERSION_CONFLICT JSON, http_error, timeout/AbortError, exception
- [x] All 759 server tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)