### PR TITLE
Add hosted OAuth token reveal to server details

### DIFF
--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -848,11 +848,15 @@ export function ServersTab({
 
   const activeWorkspace = workspaces[activeWorkspaceId];
   const sharedWorkspaceId = activeWorkspace?.sharedWorkspaceId;
+  const hostedWorkspaceId = sharedWorkspaceId ?? activeWorkspaceId;
   const { serversRecord: sharedWorkspaceServersRecord } =
     useRemoteWorkspaceServers({
       workspaceId: sharedWorkspaceId ?? null,
       isAuthenticated,
     });
+  const detailModalHostedServerId = detailModalServer
+    ? sharedWorkspaceServersRecord[detailModalServer.name]?._id
+    : undefined;
   const handleOpenDetailModal = useCallback(
     (server: ServerWithName, defaultTab: ServerDetailTab) => {
       setDetailModalState((prev) => ({
@@ -1571,6 +1575,8 @@ export function ServersTab({
           onReconnect={handleReconnectServer}
           existingServerNames={Object.keys(workspaceServers)}
           workspaceClientConfig={selectedWorkspace?.clientConfig}
+          workspaceId={hostedWorkspaceId}
+          hostedServerId={detailModalHostedServerId}
         />
       )}
     </div>

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -55,6 +55,8 @@ interface ServerDetailModalProps {
   ) => Promise<void>;
   existingServerNames: string[];
   workspaceClientConfig?: Workspace["clientConfig"];
+  workspaceId?: string | null;
+  hostedServerId?: string | null;
 }
 
 export function ServerDetailModal({
@@ -68,6 +70,8 @@ export function ServerDetailModal({
   onReconnect,
   existingServerNames,
   workspaceClientConfig,
+  workspaceId = null,
+  hostedServerId = null,
 }: ServerDetailModalProps) {
   const posthog = usePostHog();
   const [activeTab, setActiveTab] = useState<ServerDetailTab>(defaultTab);
@@ -411,6 +415,8 @@ export function ServerDetailModal({
                     <ServerInfoContent
                       server={server}
                       needsReconnect={needsReconnect}
+                      workspaceId={workspaceId}
+                      hostedServerId={hostedServerId}
                     />
                   )}
                 </div>

--- a/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
@@ -250,11 +250,6 @@ export function ServerInfoContent({
           OAuth Tokens
         </div>
         <div className="space-y-3 rounded-md bg-muted/40 p-3">
-          <div className="text-sm text-muted-foreground">
-            OAuth credential is stored in Vault for this account. Reveal tokens
-            only when you need to inspect or copy them.
-          </div>
-
           {hostedTokenError ? (
             <div className="rounded-md border border-destructive/30 bg-destructive/10 p-2 text-sm text-destructive">
               {hostedTokenError}

--- a/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
@@ -1,12 +1,20 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Copy,
   Check,
   ExternalLink,
   ChevronDown,
   ChevronRight,
+  Eye,
+  EyeOff,
+  Loader2,
 } from "lucide-react";
 import { ServerWithName } from "@/hooks/use-app-state";
+import {
+  fetchHostedOAuthTokens,
+  type HostedOAuthTokensResult,
+} from "@/lib/apis/hosted-oauth-tokens-api";
+import { HOSTED_MODE } from "@/lib/config";
 import { getStoredTokensState } from "@/lib/oauth/mcp-oauth";
 import { getOAuthTraceFailureStep } from "@/lib/oauth/oauth-trace";
 import { decodeJWT } from "@/lib/oauth/jwt-decoder";
@@ -15,14 +23,23 @@ import { ScrollableJsonView } from "@/components/ui/json-editor";
 interface ServerInfoContentProps {
   server: ServerWithName;
   needsReconnect?: boolean;
+  workspaceId?: string | null;
+  hostedServerId?: string | null;
 }
 
 export function ServerInfoContent({
   server,
   needsReconnect = false,
+  workspaceId = null,
+  hostedServerId = null,
 }: ServerInfoContentProps) {
   const [copiedField, setCopiedField] = useState<string | null>(null);
   const [expandedTokens, setExpandedTokens] = useState<Set<string>>(new Set());
+  const [hostedTokenResult, setHostedTokenResult] =
+    useState<HostedOAuthTokensResult | null>(null);
+  const [isLoadingHostedTokens, setIsLoadingHostedTokens] = useState(false);
+  const [hostedTokenError, setHostedTokenError] = useState<string | null>(null);
+  const hostedRevealRequestIdRef = useRef(0);
 
   const storedTokensState = server.oauthTokens
     ? { tokens: undefined, isInvalid: false }
@@ -31,6 +48,13 @@ export function ServerInfoContent({
   const hasInvalidStoredAuthData =
     server.oauthTokens == null && storedTokensState.isInvalid;
   const isHttpServer = "url" in server.config;
+  const shouldShowHostedOAuthVaultSection =
+    HOSTED_MODE &&
+    server.useOAuth === true &&
+    isHttpServer &&
+    oauthTokens == null;
+  const canRevealHostedOAuthTokens =
+    shouldShowHostedOAuthVaultSection && !!workspaceId && !!hostedServerId;
 
   const initializationInfo = server.initializationInfo;
 
@@ -46,6 +70,22 @@ export function ServerInfoContent({
   const clientCapabilities = initializationInfo?.clientCapabilities;
   const oauthTrace = server.lastOAuthTrace;
   const oauthFailureStep = getOAuthTraceFailureStep(oauthTrace);
+
+  useEffect(() => {
+    hostedRevealRequestIdRef.current += 1;
+    setHostedTokenResult(null);
+    setHostedTokenError(null);
+    setIsLoadingHostedTokens(false);
+    setExpandedTokens((prev) => {
+      const next = new Set(prev);
+      for (const key of next) {
+        if (key.startsWith("hosted")) {
+          next.delete(key);
+        }
+      }
+      return next;
+    });
+  }, [server.name, workspaceId, hostedServerId]);
 
   // Build capabilities list
   const capabilities: string[] = [];
@@ -75,42 +115,102 @@ export function ServerInfoContent({
     });
   };
 
+  const revealHostedTokens = async () => {
+    if (!workspaceId || !hostedServerId || isLoadingHostedTokens) return;
+
+    const requestId = ++hostedRevealRequestIdRef.current;
+    setHostedTokenError(null);
+    setIsLoadingHostedTokens(true);
+
+    try {
+      const result = await fetchHostedOAuthTokens({
+        workspaceId,
+        serverId: hostedServerId,
+      });
+      if (hostedRevealRequestIdRef.current === requestId) {
+        setHostedTokenResult(result);
+      }
+    } catch (error) {
+      if (hostedRevealRequestIdRef.current === requestId) {
+        setHostedTokenResult(null);
+        setHostedTokenError(
+          error instanceof Error
+            ? error.message
+            : "Failed to reveal hosted OAuth tokens",
+        );
+      }
+    } finally {
+      if (hostedRevealRequestIdRef.current === requestId) {
+        setIsLoadingHostedTokens(false);
+      }
+    }
+  };
+
   const renderToken = (
     label: string,
     tokenValue: string | undefined,
     tokenKey: string,
+    options?: { maskedByDefault?: boolean },
   ) => {
     if (!tokenValue) return null;
-    const decoded = decodeJWT(tokenValue);
+    const isExpanded = expandedTokens.has(tokenKey);
+    const isMasked = options?.maskedByDefault === true && !isExpanded;
+    const shouldDecodeJwt = !isMasked && tokenValue.split(".").length === 3;
+    const decoded = shouldDecodeJwt ? decodeJWT(tokenValue) : null;
+    const displayValue = isMasked
+      ? "****************"
+      : isExpanded || options?.maskedByDefault || tokenValue.length <= 50
+        ? tokenValue
+        : `${tokenValue.substring(0, 50)}...`;
+    const showDecodedControls =
+      decoded && (!options?.maskedByDefault || isExpanded);
 
     return (
       <div>
         <span className="text-muted-foreground font-medium">{label}:</span>
         <div
-          className="font-mono text-foreground break-all bg-background/50 p-2 rounded mt-1 relative group cursor-pointer hover:bg-background/70 transition-colors"
+          className="font-mono text-foreground break-all bg-background/50 p-2 rounded mt-1 group cursor-pointer hover:bg-background/70 transition-colors"
           onClick={() => toggleTokenExpansion(tokenKey)}
         >
-          <div className="pr-8">
-            {expandedTokens.has(tokenKey) || tokenValue.length <= 50
-              ? tokenValue
-              : `${tokenValue.substring(0, 50)}...`}
+          <div className="flex items-start gap-2">
+            <div className="min-w-0 flex-1">{displayValue}</div>
+            {options?.maskedByDefault ? (
+              <button
+                type="button"
+                aria-label={`${isExpanded ? "Hide" : "Reveal"} ${label}`}
+                title={`${isExpanded ? "Hide" : "Reveal"} ${label}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleTokenExpansion(tokenKey);
+                }}
+                className="mt-0.5 flex-shrink-0 p-1 text-muted-foreground/60 hover:text-foreground transition-colors cursor-pointer"
+              >
+                {isExpanded ? (
+                  <EyeOff className="h-3 w-3" />
+                ) : (
+                  <Eye className="h-3 w-3" />
+                )}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              aria-label={`Copy ${label}`}
+              title={`Copy ${label}`}
+              onClick={(e) => {
+                e.stopPropagation();
+                copyToClipboard(tokenValue, tokenKey);
+              }}
+              className="mt-0.5 flex-shrink-0 p-1 text-muted-foreground/50 hover:text-foreground transition-colors cursor-pointer"
+            >
+              {copiedField === tokenKey ? (
+                <Check className="h-3 w-3 text-green-500" />
+              ) : (
+                <Copy className="h-3 w-3" />
+              )}
+            </button>
           </div>
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              copyToClipboard(tokenValue, tokenKey);
-            }}
-            className="absolute top-1 right-1 p-1 text-muted-foreground/50 hover:text-foreground transition-colors cursor-pointer"
-          >
-            {copiedField === tokenKey ? (
-              <Check className="h-3 w-3 text-green-500" />
-            ) : (
-              <Copy className="h-3 w-3" />
-            )}
-          </button>
         </div>
-        {decoded && (
+        {showDecodedControls && (
           <div className="mt-1">
             <button
               type="button"
@@ -137,10 +237,91 @@ export function ServerInfoContent({
     );
   };
 
+  const renderHostedOAuthVaultSection = () => {
+    const tokens = hostedTokenResult?.tokens;
+    const formattedExpiresAt =
+      typeof hostedTokenResult?.expiresAt === "number"
+        ? new Date(hostedTokenResult.expiresAt).toLocaleString()
+        : null;
+
+    return (
+      <div className="space-y-3 text-xs pt-2">
+        <div className="text-sm font-medium text-muted-foreground">
+          OAuth Tokens
+        </div>
+        <div className="space-y-3 rounded-md bg-muted/40 p-3">
+          <div className="text-sm text-muted-foreground">
+            OAuth credential is stored in Vault for this account. Reveal tokens
+            only when you need to inspect or copy them.
+          </div>
+
+          {hostedTokenError ? (
+            <div className="rounded-md border border-destructive/30 bg-destructive/10 p-2 text-sm text-destructive">
+              {hostedTokenError}
+            </div>
+          ) : null}
+
+          {!tokens ? (
+            canRevealHostedOAuthTokens ? (
+              <button
+                type="button"
+                onClick={() => void revealHostedTokens()}
+                disabled={isLoadingHostedTokens}
+                className="inline-flex items-center gap-2 rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isLoadingHostedTokens ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : null}
+                {isLoadingHostedTokens ? "Revealing..." : "Reveal tokens"}
+              </button>
+            ) : (
+              <div className="rounded-md bg-background/60 p-2 text-sm text-muted-foreground">
+                Token reveal is unavailable until this server is synced to the
+                hosted workspace.
+              </div>
+            )
+          ) : (
+            <>
+              {renderToken(
+                "Access Token",
+                tokens.access_token,
+                "hostedAccessToken",
+                { maskedByDefault: true },
+              )}
+              {renderToken(
+                "Refresh Token",
+                tokens.refresh_token,
+                "hostedRefreshToken",
+                { maskedByDefault: true },
+              )}
+              {renderToken("ID Token", tokens.id_token, "hostedIdToken", {
+                maskedByDefault: true,
+              })}
+
+              <div className="flex flex-wrap gap-4 text-muted-foreground pt-1">
+                <span>
+                  Source: Vault ({hostedTokenResult?.kind ?? "generic"})
+                </span>
+                <span>Type: {tokens.token_type || "Bearer"}</span>
+                {tokens.expires_in ? (
+                  <span>Expires in: {tokens.expires_in}s</span>
+                ) : null}
+                {tokens.scope ? <span>Scope: {tokens.scope}</span> : null}
+                {formattedExpiresAt ? (
+                  <span>Expires at: {formattedExpiresAt}</span>
+                ) : null}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  };
+
   const renderOAuthTokensSection = () => {
     if (!isHttpServer) return null;
 
-    if (hasInvalidStoredAuthData) {
+    if (hasInvalidStoredAuthData && !shouldShowHostedOAuthVaultSection) {
       return (
         <div className="space-y-3 text-xs pt-2">
           <div className="text-sm font-medium text-muted-foreground">
@@ -151,6 +332,10 @@ export function ServerInfoContent({
           </div>
         </div>
       );
+    }
+
+    if (shouldShowHostedOAuthVaultSection) {
+      return renderHostedOAuthVaultSection();
     }
 
     if (!oauthTokens) return null;

--- a/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
@@ -239,10 +239,6 @@ export function ServerInfoContent({
 
   const renderHostedOAuthVaultSection = () => {
     const tokens = hostedTokenResult?.tokens;
-    const formattedExpiresAt =
-      typeof hostedTokenResult?.expiresAt === "number"
-        ? new Date(hostedTokenResult.expiresAt).toLocaleString()
-        : null;
 
     return (
       <div className="space-y-3 text-xs pt-2">
@@ -292,20 +288,6 @@ export function ServerInfoContent({
               {renderToken("ID Token", tokens.id_token, "hostedIdToken", {
                 maskedByDefault: true,
               })}
-
-              <div className="flex flex-wrap gap-4 text-muted-foreground pt-1">
-                <span>
-                  Source: Vault ({hostedTokenResult?.kind ?? "generic"})
-                </span>
-                <span>Type: {tokens.token_type || "Bearer"}</span>
-                {tokens.expires_in ? (
-                  <span>Expires in: {tokens.expires_in}s</span>
-                ) : null}
-                {tokens.scope ? <span>Scope: {tokens.scope}</span> : null}
-                {formattedExpiresAt ? (
-                  <span>Expires at: {formattedExpiresAt}</span>
-                ) : null}
-              </div>
             </>
           )}
         </div>

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.hosted.test.tsx
@@ -155,6 +155,8 @@ describe("ServerDetailModal hosted reconnect", () => {
     });
     expect(screen.getAllByText("****************").length).toBeGreaterThan(0);
     expect(screen.queryByText("hosted-access-token")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Source: Vault/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Expires in:/)).not.toBeInTheDocument();
 
     await user.click(
       screen.getByRole("button", { name: "Reveal Access Token" }),

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.hosted.test.tsx
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ServerWithName } from "@/hooks/use-app-state";
+
+const mockFetchHostedOAuthTokens = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/config", () => ({
   HOSTED_MODE: true,
@@ -20,6 +23,11 @@ vi.mock("sonner", () => ({
 
 vi.mock("@/lib/apis/mcp-tools-api", () => ({
   listTools: vi.fn().mockResolvedValue({ tools: [], toolsMetadata: {} }),
+}));
+
+vi.mock("@/lib/apis/hosted-oauth-tokens-api", () => ({
+  fetchHostedOAuthTokens: (...args: unknown[]) =>
+    mockFetchHostedOAuthTokens(...args),
 }));
 
 vi.mock("@/lib/mcp-ui/mcp-apps-utils", () => ({
@@ -65,6 +73,12 @@ describe("ServerDetailModal hosted reconnect", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+      configurable: true,
+    });
   });
 
   it("allows interactive OAuth reconnect for OAuth servers without tokens", () => {
@@ -83,5 +97,92 @@ describe("ServerDetailModal hosted reconnect", () => {
     expect(onReconnect).toHaveBeenCalledWith("test-server", {
       allowInteractiveOAuthFlow: true,
     });
+  });
+
+  it("reveals vault-backed OAuth tokens on demand without writing localStorage", async () => {
+    const user = userEvent.setup();
+    const writeTextSpy = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
+    mockFetchHostedOAuthTokens.mockResolvedValue({
+      tokens: {
+        access_token: "hosted-access-token",
+        refresh_token: "hosted-refresh-token",
+        id_token: "hosted-id-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "read write",
+      },
+      expiresAt: 1_900_000_000_000,
+      kind: "generic",
+    });
+
+    render(
+      <ServerDetailModal
+        {...defaultProps}
+        server={createServer({
+          connectionStatus: "connected",
+          useOAuth: true,
+        })}
+        defaultTab="overview"
+        workspaceId="workspace_123"
+        hostedServerId="server_123"
+      />,
+    );
+
+    expect(
+      screen.getByText(/OAuth credential is stored in Vault/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("hosted-access-token")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Reveal tokens" }));
+
+    await waitFor(() => {
+      expect(mockFetchHostedOAuthTokens).toHaveBeenCalledWith({
+        workspaceId: "workspace_123",
+        serverId: "server_123",
+      });
+    });
+    expect(screen.getAllByText("****************").length).toBeGreaterThan(0);
+    expect(screen.queryByText("hosted-access-token")).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Reveal Access Token" }),
+    );
+    expect(screen.getByText("hosted-access-token")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Copy Access Token" }));
+    expect(writeTextSpy).toHaveBeenCalledWith("hosted-access-token");
+    expect(setItemSpy).not.toHaveBeenCalled();
+    expect(localStorage.getItem("mcp-tokens-test-server")).toBeNull();
+    writeTextSpy.mockRestore();
+    setItemSpy.mockRestore();
+  });
+
+  it("renders inline errors when hosted OAuth token reveal fails", async () => {
+    const user = userEvent.setup();
+    mockFetchHostedOAuthTokens.mockRejectedValue(
+      new Error("No hosted OAuth credential found"),
+    );
+
+    render(
+      <ServerDetailModal
+        {...defaultProps}
+        server={createServer({
+          connectionStatus: "connected",
+          useOAuth: true,
+        })}
+        defaultTab="overview"
+        workspaceId="workspace_123"
+        hostedServerId="server_123"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reveal tokens" }));
+
+    expect(
+      await screen.findByText("No hosted OAuth credential found"),
+    ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.hosted.test.tsx
@@ -132,7 +132,10 @@ describe("ServerDetailModal hosted reconnect", () => {
     );
 
     expect(
-      screen.getByText(/OAuth credential is stored in Vault/),
+      screen.queryByText(/OAuth credential is stored in Vault/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Reveal tokens" }),
     ).toBeInTheDocument();
     expect(screen.queryByText("hosted-access-token")).not.toBeInTheDocument();
 

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
@@ -243,6 +243,31 @@ describe("ServerDetailModal", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("renders local OAuth tokens from localStorage in overview", () => {
+    localStorage.setItem(
+      "mcp-tokens-test-server",
+      JSON.stringify({
+        access_token: "local-access-token",
+        refresh_token: "local-refresh-token",
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "read",
+      }),
+    );
+
+    render(
+      <ServerDetailModal
+        {...defaultProps}
+        server={createServer({ useOAuth: true })}
+        defaultTab="overview"
+      />,
+    );
+
+    expect(screen.getByText("local-access-token")).toBeInTheDocument();
+    expect(screen.getByText("local-refresh-token")).toBeInTheDocument();
+    expect(screen.getByText("Scope: read")).toBeInTheDocument();
+  });
+
   it("submits the configuration form without closing the modal", async () => {
     const onSubmit = vi.fn().mockResolvedValue({
       ok: true,

--- a/mcpjam-inspector/client/src/lib/apis/hosted-oauth-tokens-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/hosted-oauth-tokens-api.ts
@@ -1,0 +1,95 @@
+import { WebApiError } from "@/lib/apis/web/base";
+import { getConvexSiteUrl } from "@/lib/convex-site-url";
+import { authFetch } from "@/lib/session-token";
+
+export interface HostedOAuthTokens {
+  access_token?: string;
+  refresh_token?: string;
+  id_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  scope?: string;
+}
+
+export interface HostedOAuthTokensResult {
+  tokens: HostedOAuthTokens;
+  expiresAt: number | null;
+  kind: "generic" | "registry";
+}
+
+export interface FetchHostedOAuthTokensRequest {
+  workspaceId: string;
+  serverId: string;
+}
+
+function getHostedOAuthTokensBaseUrl(): string {
+  const site = getConvexSiteUrl();
+  if (!site) {
+    throw new WebApiError(
+      0,
+      "NO_CONVEX_SITE",
+      "Convex site URL is not configured (VITE_CONVEX_URL or VITE_CONVEX_SITE_URL)",
+    );
+  }
+  return site.replace(/\/$/, "");
+}
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function throwFromFailedResponse(response: Response, body: unknown): never {
+  const record =
+    body && typeof body === "object" ? (body as Record<string, unknown>) : null;
+  const code =
+    typeof record?.code === "string"
+      ? record.code
+      : typeof record?.error === "string"
+        ? record.error
+        : null;
+  const message =
+    typeof record?.message === "string"
+      ? record.message
+      : typeof record?.error === "string"
+        ? record.error
+        : `Request failed (${response.status})`;
+  throw new WebApiError(response.status, code, message);
+}
+
+export async function fetchHostedOAuthTokens(
+  request: FetchHostedOAuthTokensRequest,
+): Promise<HostedOAuthTokensResult> {
+  const base = getHostedOAuthTokensBaseUrl();
+  const response = await authFetch(`${base}/web/oauth/tokens`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+  const body = await readJsonBody(response);
+  if (!response.ok) {
+    throwFromFailedResponse(response, body);
+  }
+
+  const result =
+    body && typeof body === "object" ? (body as Record<string, unknown>) : null;
+  if (!result?.success || !result.tokens || typeof result.tokens !== "object") {
+    throw new WebApiError(
+      response.status,
+      null,
+      "Hosted OAuth token response was invalid",
+    );
+  }
+
+  const kind = result.kind === "registry" ? "registry" : "generic";
+  return {
+    tokens: result.tokens as HostedOAuthTokens,
+    expiresAt: typeof result.expiresAt === "number" ? result.expiresAt : null,
+    kind,
+  };
+}

--- a/mcpjam-inspector/client/src/lib/apis/hosted-oauth-tokens-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/hosted-oauth-tokens-api.ts
@@ -1,6 +1,4 @@
-import { WebApiError } from "@/lib/apis/web/base";
-import { getConvexSiteUrl } from "@/lib/convex-site-url";
-import { authFetch } from "@/lib/session-token";
+import { webPost, WebApiError } from "@/lib/apis/web/base";
 
 export interface HostedOAuthTokens {
   access_token?: string;
@@ -22,66 +20,19 @@ export interface FetchHostedOAuthTokensRequest {
   serverId: string;
 }
 
-function getHostedOAuthTokensBaseUrl(): string {
-  const site = getConvexSiteUrl();
-  if (!site) {
-    throw new WebApiError(
-      0,
-      "NO_CONVEX_SITE",
-      "Convex site URL is not configured (VITE_CONVEX_URL or VITE_CONVEX_SITE_URL)",
-    );
-  }
-  return site.replace(/\/$/, "");
-}
-
-async function readJsonBody(response: Response): Promise<unknown> {
-  const text = await response.text();
-  if (!text) return null;
-  try {
-    return JSON.parse(text);
-  } catch {
-    return null;
-  }
-}
-
-function throwFromFailedResponse(response: Response, body: unknown): never {
-  const record =
-    body && typeof body === "object" ? (body as Record<string, unknown>) : null;
-  const code =
-    typeof record?.code === "string"
-      ? record.code
-      : typeof record?.error === "string"
-        ? record.error
-        : null;
-  const message =
-    typeof record?.message === "string"
-      ? record.message
-      : typeof record?.error === "string"
-        ? record.error
-        : `Request failed (${response.status})`;
-  throw new WebApiError(response.status, code, message);
-}
-
 export async function fetchHostedOAuthTokens(
   request: FetchHostedOAuthTokensRequest,
 ): Promise<HostedOAuthTokensResult> {
-  const base = getHostedOAuthTokensBaseUrl();
-  const response = await authFetch(`${base}/web/oauth/tokens`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(request),
-  });
-  const body = await readJsonBody(response);
-  if (!response.ok) {
-    throwFromFailedResponse(response, body);
-  }
-
+  const body = await webPost<FetchHostedOAuthTokensRequest, unknown>(
+    "/api/web/oauth/tokens",
+    request,
+  );
   const result =
     body && typeof body === "object" ? (body as Record<string, unknown>) : null;
   if (!result?.success || !result.tokens || typeof result.tokens !== "object") {
     throw new WebApiError(
-      response.status,
-      null,
+      0,
+      "INVALID_RESPONSE",
       "Hosted OAuth token response was invalid",
     );
   }

--- a/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/oauth.test.ts
@@ -245,4 +245,55 @@ describe("web routes — oauth session forwarding", () => {
       },
     );
   });
+
+  it("POST /tokens forwards the bearer-authenticated token reveal to Convex", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          success: true,
+          tokens: {
+            access_token: "access-token",
+            refresh_token: "refresh-token",
+          },
+          expiresAt: null,
+          kind: "generic",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const payload = {
+      workspaceId: "ws_1",
+      serverId: "srv_1",
+    };
+
+    const response = await postJson(app, "/api/web/oauth/tokens", payload, token);
+    const { status, data } = await expectJson(response);
+
+    expect(status).toBe(200);
+    expect(data).toEqual({
+      success: true,
+      tokens: {
+        access_token: "access-token",
+        refresh_token: "refresh-token",
+      },
+      expiresAt: null,
+      kind: "generic",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.convex.site/web/oauth/tokens",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(payload),
+      },
+    );
+  });
 });

--- a/mcpjam-inspector/server/routes/web/oauth.ts
+++ b/mcpjam-inspector/server/routes/web/oauth.ts
@@ -82,6 +82,28 @@ function getConvexHttpUrl(): string {
   return convexUrl;
 }
 
+async function proxyConvexOAuthPost(c: Context, path: string) {
+  const convexUrl = getConvexHttpUrl();
+  const authorization = c.req.header("authorization");
+  const payload = await c.req.json();
+  const response = await fetch(`${convexUrl}${path}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(authorization ? { Authorization: authorization } : {}),
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const bodyText = await response.text();
+  return new Response(bodyText, {
+    status: response.status,
+    headers: {
+      "Content-Type": response.headers.get("content-type") ?? "application/json",
+    },
+  });
+}
+
 /**
  * Proxy OAuth token exchange and client registration requests.
  * POST /api/web/oauth/proxy
@@ -153,26 +175,15 @@ oauthWeb.get("/metadata", async (c) => {
 
 oauthWeb.post("/session", async (c) => {
   try {
-    const convexUrl = getConvexHttpUrl();
-    const authorization = c.req.header("authorization");
-    const payload = await c.req.json();
-    const response = await fetch(`${convexUrl}/web/oauth/session`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        ...(authorization ? { Authorization: authorization } : {}),
-      },
-      body: JSON.stringify(payload),
-    });
+    return await proxyConvexOAuthPost(c, "/web/oauth/session");
+  } catch (error) {
+    return webErrorCompat(c, toRouteError(error));
+  }
+});
 
-    const bodyText = await response.text();
-    return new Response(bodyText, {
-      status: response.status,
-      headers: {
-        "Content-Type":
-          response.headers.get("content-type") ?? "application/json",
-      },
-    });
+oauthWeb.post("/tokens", async (c) => {
+  try {
+    return await proxyConvexOAuthPost(c, "/web/oauth/tokens");
   } catch (error) {
     return webErrorCompat(c, toRouteError(error));
   }


### PR DESCRIPTION
## Summary
- Add a hosted `/web/oauth/tokens` endpoint that authorizes the signed-in credential owner, reads Vault-backed OAuth credentials, and refreshes expired tokens before returning them.
- Thread hosted workspace/server IDs into the server detail modal and add an on-demand vault reveal section in the Overview tab for hosted OAuth servers.
- Keep tokens component-local, masked by default, and copyable without writing them back to app state or `localStorage`.

## Testing
- `vitest run tests/convex/hostedOAuthCredentialsNode.test.ts tests/convex/mcpHttpAuthFallback.test.ts`
- `vitest run client/src/components/connection/__tests__/ServerDetailModal.test.tsx client/src/components/connection/__tests__/ServerDetailModal.hosted.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated `/api/web/oauth/tokens` proxy and UI to reveal and copy OAuth tokens, which is security-sensitive because it exposes credentials on demand. Risk is mitigated by masking-by-default and keeping revealed tokens component-local, but it still changes token handling paths.
> 
> **Overview**
> Adds a bearer-authenticated `POST /api/web/oauth/tokens` route that proxies token-reveal requests through to Convex (refactoring shared Convex POST proxy logic used by `/session`).
> 
> Updates the server details flow to pass hosted `workspaceId`/`serverId` into `ServerDetailModal` and `ServerInfoContent`, and in hosted mode adds an *on-demand* “Reveal tokens” section for OAuth servers without local tokens; revealed values are **masked by default**, can be individually revealed/copied, and are not persisted to app state or `localStorage`.
> 
> Expands client/server tests to cover hosted token reveal success/failure, masking/copy behavior, and local token rendering from `localStorage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 612c54b63446dea0b62dda88da19f62188d38195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->