### PR TITLE
[codex] Improve MCPJam model limit messaging

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/error.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/error.tsx
@@ -49,8 +49,10 @@ export function ErrorBox({
   const [isErrorDetailsOpen, setIsErrorDetailsOpen] = useState(false);
   const errorDetailsJson = parseErrorDetails(errorDetails);
 
-  // Platform errors use warning styling to indicate "not your fault"
-  const isPlatformError = isMCPJamPlatformError === true;
+  const isMCPJamModelLimit = code === "mcpjam_rate_limit";
+
+  // Platform and quota errors use warning styling to indicate recoverable state.
+  const isPlatformError = isMCPJamPlatformError === true || isMCPJamModelLimit;
 
   const containerClasses = isPlatformError
     ? "border-warning bg-warning/20 text-warning-foreground"
@@ -72,9 +74,12 @@ export function ErrorBox({
 
   const isAuthError = code === "auth_error";
 
-  const errorLabel = isPlatformError
+  const errorLabel = isMCPJamModelLimit
+    ? "MCPJam model limit reached"
+    : isPlatformError
     ? "MCPJam platform issue"
     : "An error occurred";
+  const errorPrefix = isMCPJamModelLimit ? `${errorLabel}.` : `${errorLabel}:`;
 
   return (
     <div
@@ -84,9 +89,15 @@ export function ErrorBox({
         <CircleAlert className={cn("h-6 w-6 flex-shrink-0", iconClasses)} />
         <div className="flex-1">
           <p className="text-sm leading-6">
-            {isAuthError ? message : `${errorLabel}: ${message}`}
+            {isAuthError ? (
+              message
+            ) : (
+              <>
+                <span className="font-medium">{errorPrefix}</span> {message}
+              </>
+            )}
           </p>
-          {isPlatformError && (
+          {isPlatformError && !isMCPJamModelLimit && (
             <p className="text-xs opacity-75 mt-0.5">
               This is a temporary issue on our end.
             </p>

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { UIMessage } from "ai";
-import { cloneUiMessages } from "../chat-helpers";
+import { cloneUiMessages, formatErrorMessage } from "../chat-helpers";
 
 describe("cloneUiMessages", () => {
   it("deep-clones so mutations do not affect the source", () => {
@@ -17,5 +17,39 @@ describe("cloneUiMessages", () => {
     expect(copy[0]?.parts).not.toBe(original[0]?.parts);
     (copy[0]?.parts[0] as { text?: string }).text = "b";
     expect((original[0]?.parts[0] as { text?: string }).text).toBe("a");
+  });
+});
+
+describe("formatErrorMessage", () => {
+  it("turns MCPJam model-limit JSON into actionable quota copy", () => {
+    const result = formatErrorMessage(
+      JSON.stringify({
+        error:
+          "Daily MCPJam model limit reached. Use BYOK or try again tomorrow.",
+        details: "Try again in 75 minutes.",
+      }),
+    );
+
+    expect(result).toEqual({
+      code: "mcpjam_rate_limit",
+      message:
+        "Add your own API key under LLM Providers in Settings to continue now, or try again in 75 minutes.",
+      isRetryable: false,
+      isMCPJamPlatformError: true,
+    });
+  });
+
+  it("recognizes plain MCPJam model-limit messages", () => {
+    const result = formatErrorMessage(
+      "Daily MCPJam model limit reached. Use BYOK or try again tomorrow.",
+    );
+
+    expect(result).toEqual({
+      code: "mcpjam_rate_limit",
+      message:
+        "Add your own API key under LLM Providers in Settings to continue now, or try again tomorrow.",
+      isRetryable: false,
+      isMCPJamPlatformError: true,
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
@@ -24,9 +24,28 @@ describe("formatErrorMessage", () => {
   it("turns MCPJam model-limit JSON into actionable quota copy", () => {
     const result = formatErrorMessage(
       JSON.stringify({
+        code: "user_rate_limit",
         error:
           "Daily MCPJam model limit reached. Use BYOK or try again tomorrow.",
+        retryAfter: 4500000,
         details: "Try again in 75 minutes.",
+      }),
+    );
+
+    expect(result).toEqual({
+      code: "mcpjam_rate_limit",
+      message:
+        "Add your own API key under LLM Providers in Settings to continue now, or try again in 75 minutes.",
+      isRetryable: false,
+      isMCPJamPlatformError: true,
+    });
+  });
+
+  it("does not leak JSON delimiters from structured retry details", () => {
+    const result = formatErrorMessage(
+      JSON.stringify({
+        error: "Daily MCPJam model limit reached.",
+        details: { hint: "Try again in 75 minutes" },
       }),
     );
 

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
@@ -178,6 +178,72 @@ const MCPJAM_PLATFORM_CODES = [
   "mcpjam_config_error",
 ];
 
+const MCPJAM_RATE_LIMIT_CODE = "mcpjam_rate_limit";
+const MCPJAM_MODEL_LIMIT_PATTERN = /mcpjam[\w\s-]*model limit/i;
+
+const normalizeDetails = (details: unknown): string | undefined => {
+  if (details == null) return undefined;
+  if (typeof details === "string") return details;
+
+  try {
+    return JSON.stringify(details);
+  } catch {
+    return String(details);
+  }
+};
+
+const lowercaseFirst = (value: string) =>
+  value.length > 0 ? value[0].toLowerCase() + value.slice(1) : value;
+
+const extractRetryPhrase = (...values: Array<unknown>): string | null => {
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+
+    const sentence = value
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => /try again/i.test(line));
+
+    if (!sentence) continue;
+
+    const match = sentence.match(
+      /try again(?:\s+(?:in|after|tomorrow|later)\b[^.]*)?/i,
+    );
+    if (!match?.[0]) continue;
+
+    return lowercaseFirst(match[0].trim().replace(/[.。]+$/, ""));
+  }
+
+  return null;
+};
+
+const isMCPJamModelLimit = (
+  code: unknown,
+  message: unknown,
+  details?: unknown,
+) => {
+  if (code === MCPJAM_RATE_LIMIT_CODE) return true;
+  if (typeof message === "string" && MCPJAM_MODEL_LIMIT_PATTERN.test(message)) {
+    return true;
+  }
+  if (typeof details === "string" && MCPJAM_MODEL_LIMIT_PATTERN.test(details)) {
+    return true;
+  }
+
+  return false;
+};
+
+const formatMCPJamModelLimit = (
+  retryPhrase: string | null,
+): FormattedError => ({
+  code: MCPJAM_RATE_LIMIT_CODE,
+  message: retryPhrase
+    ? `Add your own API key under LLM Providers in Settings to continue now, or ${retryPhrase}.`
+    : "Add your own API key under LLM Providers in Settings to continue now, or wait until your daily limit resets.",
+  isRetryable: false,
+  isMCPJamPlatformError: true,
+});
+
 export function formatErrorMessage(error: unknown): FormattedError | null {
   if (!error) return null;
 
@@ -201,10 +267,15 @@ export function formatErrorMessage(error: unknown): FormattedError | null {
       // Handle structured error with code
       const code = parsed.code;
       const message = parsed.error || parsed.message || "An error occurred";
+      const details = normalizeDetails(parsed.details);
+
+      if (isMCPJamModelLimit(code, message, details)) {
+        return formatMCPJamModelLimit(extractRetryPhrase(details, message));
+      }
 
       return {
         message,
-        details: parsed.details,
+        details,
         code,
         statusCode: parsed.statusCode,
         isRetryable: parsed.isRetryable,
@@ -215,6 +286,10 @@ export function formatErrorMessage(error: unknown): FormattedError | null {
     }
   } catch {
     // Return as-is
+  }
+
+  if (isMCPJamModelLimit(undefined, errorString)) {
+    return formatMCPJamModelLimit(extractRetryPhrase(errorString));
   }
 
   return { message: errorString };

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
@@ -195,10 +195,54 @@ const normalizeDetails = (details: unknown): string | undefined => {
 const lowercaseFirst = (value: string) =>
   value.length > 0 ? value[0].toLowerCase() + value.slice(1) : value;
 
-const extractRetryPhrase = (...values: Array<unknown>): string | null => {
-  for (const value of values) {
-    if (typeof value !== "string") continue;
+const collectStringValues = (
+  value: unknown,
+  strings: string[] = [],
+  seen = new WeakSet<object>(),
+): string[] => {
+  if (typeof value === "string") {
+    strings.push(value);
+    return strings;
+  }
 
+  if (!value || typeof value !== "object") {
+    return strings;
+  }
+
+  if (seen.has(value)) {
+    return strings;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectStringValues(item, strings, seen);
+    }
+    return strings;
+  }
+
+  for (const item of Object.values(value)) {
+    collectStringValues(item, strings, seen);
+  }
+
+  return strings;
+};
+
+const formatRetryAfter = (retryAfter: unknown): string | null => {
+  if (typeof retryAfter !== "number" || !Number.isFinite(retryAfter)) {
+    return null;
+  }
+
+  const minutes = Math.ceil(retryAfter / 60000);
+  if (minutes < 1) {
+    return null;
+  }
+
+  return `try again in ${minutes} minute${minutes === 1 ? "" : "s"}`;
+};
+
+const extractRetryPhrase = (...values: Array<unknown>): string | null => {
+  for (const value of values.flatMap((item) => collectStringValues(item))) {
     const sentence = value
       .split(/\r?\n/)
       .map((line) => line.trim())
@@ -207,8 +251,9 @@ const extractRetryPhrase = (...values: Array<unknown>): string | null => {
     if (!sentence) continue;
 
     const match = sentence.match(
-      /try again(?:\s+(?:in|after|tomorrow|later)\b[^.]*)?/i,
+      /\btry again(?:\s+(?:in|after)\s+[^.。,;}\]"'\n]+|\s+(?:tomorrow|later))?/i,
     );
+
     if (!match?.[0]) continue;
 
     return lowercaseFirst(match[0].trim().replace(/[.。]+$/, ""));
@@ -270,7 +315,10 @@ export function formatErrorMessage(error: unknown): FormattedError | null {
       const details = normalizeDetails(parsed.details);
 
       if (isMCPJamModelLimit(code, message, details)) {
-        return formatMCPJamModelLimit(extractRetryPhrase(details, message));
+        return formatMCPJamModelLimit(
+          formatRetryAfter(parsed.retryAfter) ??
+            extractRetryPhrase(parsed.details, message),
+        );
       }
 
       return {


### PR DESCRIPTION
## Summary
- Detect MCPJam model-limit errors from structured JSON and plain text responses.
- Replace the generic destructive error copy with warning-style quota messaging that points users to LLM Providers in Settings or the retry window.
- Add formatter coverage for retry-window extraction and plain-text model-limit messages.

## Why
The previous alert mixed a generic error prefix with quota copy and hid the useful retry time in the details drawer. This makes the state feel like a crash instead of an expected usage limit.

## Validation
- npm run test -- --run client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts

## Notes
- Created from a clean worktree based on origin/main.
- The original dirty checkout was left with only the unrelated pre-existing changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/formatting change that only affects how model-limit errors are detected and displayed; main risk is misclassifying non-quota errors as quota warnings due to new pattern matching.
> 
> **Overview**
> Updates `formatErrorMessage` to detect MCPJam model-limit conditions from both structured JSON and plain-text errors, normalize `details`, and extract a human retry window from `retryAfter`/embedded text to generate actionable BYOK guidance.
> 
> Adjusts `ErrorBox` to treat `mcpjam_rate_limit` as a warning-style (recoverable) state with a dedicated label/prefix and without the generic “temporary issue” copy, and adds tests covering quota-message formatting and retry-phrase extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15f99226fa5c19c77c51638f456eac4cb046901c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->