### PR TITLE
Update quota error copy and retry timing

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/error.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/error.tsx
@@ -49,7 +49,8 @@ export function ErrorBox({
   const [isErrorDetailsOpen, setIsErrorDetailsOpen] = useState(false);
   const errorDetailsJson = parseErrorDetails(errorDetails);
 
-  const isMCPJamModelLimit = code === "mcpjam_rate_limit";
+  const isMCPJamModelLimit =
+    code === "mcpjam_rate_limit" || /mcpjam[\w\s-]*model limit/i.test(message);
 
   // Platform and quota errors use warning styling to indicate recoverable state.
   const isPlatformError = isMCPJamPlatformError === true || isMCPJamModelLimit;
@@ -75,35 +76,42 @@ export function ErrorBox({
   const isAuthError = code === "auth_error";
 
   const errorLabel = isMCPJamModelLimit
-    ? "MCPJam model limit reached"
+    ? "Daily MCPJam model limit reached"
     : isPlatformError
-    ? "MCPJam platform issue"
-    : "An error occurred";
+      ? "MCPJam platform issue"
+      : "An error occurred";
   const errorPrefix = isMCPJamModelLimit ? `${errorLabel}.` : `${errorLabel}:`;
 
   return (
     <div
       className={cn("flex flex-col gap-3 border rounded p-4", containerClasses)}
     >
-      <div className="flex items-center gap-3">
+      <div className="flex items-start gap-3">
         <CircleAlert className={cn("h-6 w-6 flex-shrink-0", iconClasses)} />
-        <div className="flex-1">
-          <p className="text-sm leading-6">
-            {isAuthError ? (
-              message
-            ) : (
-              <>
-                <span className="font-medium">{errorPrefix}</span> {message}
-              </>
-            )}
-          </p>
+        <div className="min-w-0 flex-1">
+          {isMCPJamModelLimit && !isAuthError ? (
+            <>
+              <p className="text-sm font-medium leading-6">{errorLabel}</p>
+              <p className="text-sm leading-6 opacity-90">{message}</p>
+            </>
+          ) : (
+            <p className="text-sm leading-6">
+              {isAuthError ? (
+                message
+              ) : (
+                <>
+                  <span className="font-medium">{errorPrefix}</span> {message}
+                </>
+              )}
+            </p>
+          )}
           {isPlatformError && !isMCPJamModelLimit && (
             <p className="text-xs opacity-75 mt-0.5">
               This is a temporary issue on our end.
             </p>
           )}
         </div>
-        <div className="flex items-center gap-2 ml-auto flex-shrink-0">
+        <div className="ml-auto flex flex-shrink-0 flex-wrap items-center gap-2">
           {isRetryable && onRetry && (
             <Button
               type="button"

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
@@ -35,7 +35,7 @@ describe("formatErrorMessage", () => {
     expect(result).toEqual({
       code: "mcpjam_rate_limit",
       message:
-        "Add your own API key under LLM Providers in Settings to continue now, or try again in 75 minutes.",
+        "Add your own API key in Settings > LLM Providers to keep chatting now, or try again in 1 hour 15 minutes.",
       isRetryable: false,
       isMCPJamPlatformError: true,
     });
@@ -52,7 +52,25 @@ describe("formatErrorMessage", () => {
     expect(result).toEqual({
       code: "mcpjam_rate_limit",
       message:
-        "Add your own API key under LLM Providers in Settings to continue now, or try again in 75 minutes.",
+        "Add your own API key in Settings > LLM Providers to keep chatting now, or try again in 1 hour 15 minutes.",
+      isRetryable: false,
+      isMCPJamPlatformError: true,
+    });
+  });
+
+  it("turns large minute counts into readable reset copy", () => {
+    const result = formatErrorMessage(
+      JSON.stringify({
+        message:
+          "Daily MCPJam model limit reached. Use BYOK or try again tomorrow.",
+        details: "Try again in 1390 minutes.",
+      }),
+    );
+
+    expect(result).toEqual({
+      code: "mcpjam_rate_limit",
+      message:
+        "Add your own API key in Settings > LLM Providers to keep chatting now, or try again tomorrow.",
       isRetryable: false,
       isMCPJamPlatformError: true,
     });
@@ -66,7 +84,7 @@ describe("formatErrorMessage", () => {
     expect(result).toEqual({
       code: "mcpjam_rate_limit",
       message:
-        "Add your own API key under LLM Providers in Settings to continue now, or try again tomorrow.",
+        "Add your own API key in Settings > LLM Providers to keep chatting now, or try again tomorrow.",
       isRetryable: false,
       isMCPJamPlatformError: true,
     });

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
@@ -180,6 +180,8 @@ const MCPJAM_PLATFORM_CODES = [
 
 const MCPJAM_RATE_LIMIT_CODE = "mcpjam_rate_limit";
 const MCPJAM_MODEL_LIMIT_PATTERN = /mcpjam[\w\s-]*model limit/i;
+const MINUTES_PER_HOUR = 60;
+const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR;
 
 const normalizeDetails = (details: unknown): string | undefined => {
   if (details == null) return undefined;
@@ -194,6 +196,9 @@ const normalizeDetails = (details: unknown): string | undefined => {
 
 const lowercaseFirst = (value: string) =>
   value.length > 0 ? value[0].toLowerCase() + value.slice(1) : value;
+
+const pluralize = (value: number, unit: string) =>
+  `${value} ${unit}${value === 1 ? "" : "s"}`;
 
 const collectStringValues = (
   value: unknown,
@@ -228,17 +233,75 @@ const collectStringValues = (
   return strings;
 };
 
+const formatRetryMinutes = (minutes: number): string | null => {
+  if (!Number.isFinite(minutes) || minutes < 1) return null;
+
+  if (minutes < MINUTES_PER_HOUR) {
+    return `try again in ${pluralize(minutes, "minute")}`;
+  }
+
+  if (minutes >= 20 * MINUTES_PER_HOUR && minutes < 36 * MINUTES_PER_HOUR) {
+    return "try again tomorrow";
+  }
+
+  if (minutes < MINUTES_PER_DAY) {
+    const hours = Math.floor(minutes / MINUTES_PER_HOUR);
+    const remainingMinutes = minutes % MINUTES_PER_HOUR;
+    const hourText = pluralize(hours, "hour");
+
+    if (remainingMinutes < 5) {
+      return `try again in ${hourText}`;
+    }
+
+    return `try again in ${hourText} ${pluralize(remainingMinutes, "minute")}`;
+  }
+
+  const days = Math.max(2, Math.round(minutes / MINUTES_PER_DAY));
+  return `try again in about ${pluralize(days, "day")}`;
+};
+
 const formatRetryAfter = (retryAfter: unknown): string | null => {
   if (typeof retryAfter !== "number" || !Number.isFinite(retryAfter)) {
     return null;
   }
 
-  const minutes = Math.ceil(retryAfter / 60000);
-  if (minutes < 1) {
-    return null;
+  return formatRetryMinutes(Math.ceil(retryAfter / 60000));
+};
+
+const normalizeRetryPhrase = (phrase: string): string => {
+  const normalized = lowercaseFirst(phrase.trim().replace(/[.。]+$/, ""));
+  const durationMatch = normalized.match(
+    /\btry again\s+(?:in|after)\s+(\d+(?:\.\d+)?)\s*(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d)\b/i,
+  );
+
+  if (!durationMatch) {
+    return normalized;
   }
 
-  return `try again in ${minutes} minute${minutes === 1 ? "" : "s"}`;
+  const value = Number(durationMatch[1]);
+  const unit = durationMatch[2]?.toLowerCase();
+  if (!Number.isFinite(value) || !unit) {
+    return normalized;
+  }
+
+  let minutes: number;
+  if (
+    unit.startsWith("ms") ||
+    unit.startsWith("msec") ||
+    unit.startsWith("millisecond")
+  ) {
+    minutes = Math.ceil(value / 60000);
+  } else if (unit === "s" || unit.startsWith("sec")) {
+    minutes = Math.ceil(value / 60);
+  } else if (unit === "m" || unit.startsWith("min")) {
+    minutes = Math.ceil(value);
+  } else if (unit === "h" || unit.startsWith("hr") || unit.startsWith("hour")) {
+    minutes = Math.ceil(value * MINUTES_PER_HOUR);
+  } else {
+    minutes = Math.ceil(value * MINUTES_PER_DAY);
+  }
+
+  return formatRetryMinutes(minutes) ?? normalized;
 };
 
 const extractRetryPhrase = (...values: Array<unknown>): string | null => {
@@ -256,7 +319,7 @@ const extractRetryPhrase = (...values: Array<unknown>): string | null => {
 
     if (!match?.[0]) continue;
 
-    return lowercaseFirst(match[0].trim().replace(/[.。]+$/, ""));
+    return normalizeRetryPhrase(match[0]);
   }
 
   return null;
@@ -283,8 +346,8 @@ const formatMCPJamModelLimit = (
 ): FormattedError => ({
   code: MCPJAM_RATE_LIMIT_CODE,
   message: retryPhrase
-    ? `Add your own API key under LLM Providers in Settings to continue now, or ${retryPhrase}.`
-    : "Add your own API key under LLM Providers in Settings to continue now, or wait until your daily limit resets.",
+    ? `Add your own API key in Settings > LLM Providers to keep chatting now, or ${retryPhrase}.`
+    : "Add your own API key in Settings > LLM Providers to keep chatting now, or wait until your daily limit resets.",
   isRetryable: false,
   isMCPJamPlatformError: true,
 });


### PR DESCRIPTION
## Summary
- Make MCPJam quota errors read like a user-facing state instead of a raw exception
- Convert retry-after values into human-readable phrasing such as `1 hour 15 minutes` or `tomorrow`
- Add coverage for the readability path and the large-minute reset case

## Testing
- Added/updated unit tests for `formatErrorMessage`
- Ran formatting on the touched files
- Not run: full Vitest suite in this worktree because `vitest` is not installed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to client-side error classification/formatting and associated UI copy, with added unit coverage for new timing normalization paths.
> 
> **Overview**
> Updates chat error handling to better detect MCPJam model-limit/quota states (by code *and* message pattern) and present them as a user-facing daily limit message rather than a generic exception.
> 
> `formatErrorMessage` now normalizes retry hints across units and large minute counts into readable phrases (e.g. `1 hour 15 minutes`, `tomorrow`), and the `ErrorBox` layout/copy is adjusted to display a clearer label plus message for model-limit errors. Unit tests are updated/expanded to cover structured details parsing and the new retry-time phrasing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85bc4ee09b3732350fee45ff832596790cb9e2d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->