### PR TITLE
Add CLI update notifier

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,4 +1,6 @@
 import { Command, CommanderError } from "commander";
+import { realpathSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 import packageJson from "../package.json" with { type: "json" };
 import { registerAppsCommands } from "./commands/apps.js";
 import { registerProtocolCommands } from "./commands/conformance.js";
@@ -14,10 +16,22 @@ import {
   writeError,
 } from "./lib/output.js";
 import { addGlobalOptions } from "./lib/server-config.js";
+import { checkForUpdates } from "./lib/update-notifier.js";
 
 const pkgVersion = packageJson.version;
 
-async function main(argv: readonly string[] = process.argv): Promise<number> {
+export interface CliMainResult {
+  exitCode: number;
+  didRunCommand: boolean;
+}
+
+export interface CliEntrypointDependencies {
+  checkForUpdates?: (currentVersion: string) => void;
+}
+
+export async function main(
+  argv: readonly string[] = process.argv,
+): Promise<CliMainResult> {
   const program = addGlobalOptions(
     new Command()
       .name("mcpjam")
@@ -45,17 +59,26 @@ async function main(argv: readonly string[] = process.argv): Promise<number> {
 
   if (argv.length <= 2) {
     program.outputHelp();
-    return 0;
+    return {
+      exitCode: 0,
+      didRunCommand: false,
+    };
   }
 
   try {
     await program.parseAsync(argv as string[]);
     const exitCode = process.exitCode;
     if (typeof exitCode === "number") {
-      return exitCode;
+      return {
+        exitCode,
+        didRunCommand: true,
+      };
     }
 
-    return Number(exitCode ?? 0) || 0;
+    return {
+      exitCode: Number(exitCode ?? 0) || 0,
+      didRunCommand: true,
+    };
   } catch (error) {
     const format = detectOutputFormatFromArgv(argv);
 
@@ -64,19 +87,63 @@ async function main(argv: readonly string[] = process.argv): Promise<number> {
         error.code === "commander.helpDisplayed" ||
         error.code === "commander.version"
       ) {
-        return 0;
+        return {
+          exitCode: 0,
+          didRunCommand: false,
+        };
       }
 
       writeError(usageError(error.message), format);
-      return 2;
+      return {
+        exitCode: 2,
+        didRunCommand: false,
+      };
     }
 
     const normalizedError = normalizeCliError(error);
     writeError(normalizedError, format);
-    return normalizedError.exitCode;
+    return {
+      exitCode: normalizedError.exitCode,
+      didRunCommand: false,
+    };
   }
 }
 
-void main().then((exitCode) => {
-  process.exitCode = exitCode;
-});
+export async function runCliEntrypoint(
+  argv: readonly string[] = process.argv,
+  dependencies: CliEntrypointDependencies = {},
+): Promise<CliMainResult> {
+  const result = await main(argv);
+  process.exitCode = result.exitCode;
+
+  if (result.exitCode === 0 && result.didRunCommand) {
+    (dependencies.checkForUpdates ?? checkForUpdates)(pkgVersion);
+  }
+
+  return result;
+}
+
+export function isDirectRun(
+  importMetaUrl: string,
+  argv: readonly string[] = process.argv,
+): boolean {
+  const entrypoint = argv[1];
+  if (!entrypoint) {
+    return false;
+  }
+
+  const entrypointUrl = pathToFileURL(entrypoint).href;
+  if (importMetaUrl === entrypointUrl) {
+    return true;
+  }
+
+  try {
+    return importMetaUrl === pathToFileURL(realpathSync(entrypoint)).href;
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectRun(import.meta.url)) {
+  void runCliEntrypoint();
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -22,7 +22,7 @@ const pkgVersion = packageJson.version;
 
 export interface CliMainResult {
   exitCode: number;
-  didRunCommand: boolean;
+  shouldCheckForUpdates: boolean;
 }
 
 export interface CliEntrypointDependencies {
@@ -61,7 +61,7 @@ export async function main(
     program.outputHelp();
     return {
       exitCode: 0,
-      didRunCommand: false,
+      shouldCheckForUpdates: false,
     };
   }
 
@@ -71,13 +71,13 @@ export async function main(
     if (typeof exitCode === "number") {
       return {
         exitCode,
-        didRunCommand: true,
+        shouldCheckForUpdates: true,
       };
     }
 
     return {
       exitCode: Number(exitCode ?? 0) || 0,
-      didRunCommand: true,
+      shouldCheckForUpdates: true,
     };
   } catch (error) {
     const format = detectOutputFormatFromArgv(argv);
@@ -89,14 +89,14 @@ export async function main(
       ) {
         return {
           exitCode: 0,
-          didRunCommand: false,
+          shouldCheckForUpdates: false,
         };
       }
 
       writeError(usageError(error.message), format);
       return {
         exitCode: 2,
-        didRunCommand: false,
+        shouldCheckForUpdates: false,
       };
     }
 
@@ -104,7 +104,7 @@ export async function main(
     writeError(normalizedError, format);
     return {
       exitCode: normalizedError.exitCode,
-      didRunCommand: false,
+      shouldCheckForUpdates: false,
     };
   }
 }
@@ -116,7 +116,7 @@ export async function runCliEntrypoint(
   const result = await main(argv);
   process.exitCode = result.exitCode;
 
-  if (result.exitCode === 0 && result.didRunCommand) {
+  if (result.exitCode === 0 && result.shouldCheckForUpdates) {
     (dependencies.checkForUpdates ?? checkForUpdates)(pkgVersion);
   }
 
@@ -140,6 +140,7 @@ export function isDirectRun(
   try {
     return importMetaUrl === pathToFileURL(realpathSync(entrypoint)).href;
   } catch {
+    // If realpath resolution fails, fall back to the direct path comparison above.
     return false;
   }
 }

--- a/cli/src/lib/update-notifier.ts
+++ b/cli/src/lib/update-notifier.ts
@@ -1,0 +1,303 @@
+import { spawn as spawnChild, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const DEFAULT_UPDATE_PACKAGE_NAME = "@mcpjam/cli";
+export const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1_000;
+
+export interface UpdateCheckCache {
+  latestVersion: string;
+  checkedAt: number;
+}
+
+export interface SkipUpdateCheckOptions {
+  env?: NodeJS.ProcessEnv;
+  isStderrTTY?: boolean;
+}
+
+export type StderrLike = {
+  write(chunk: string): unknown;
+};
+
+export type SpawnBackgroundFetch = (
+  cachePath: string,
+  packageName: string,
+) => void;
+
+export interface UpdateNotifierOptions extends SkipUpdateCheckOptions {
+  packageName?: string;
+  cachePath?: string;
+  now?: number | (() => number);
+  stderr?: StderrLike;
+  spawnBackgroundFetch?: SpawnBackgroundFetch;
+}
+
+export interface CachePathOptions {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  homeDirectory?: string;
+}
+
+export interface SpawnBackgroundFetchOptions {
+  execPath?: string;
+  spawn?: typeof spawnChild;
+}
+
+const UPDATE_CACHE_FILE = "update-check.json";
+
+const BACKGROUND_FETCH_SCRIPT = String.raw`
+const fs = require("node:fs");
+const https = require("node:https");
+const path = require("node:path");
+
+const cachePath = process.argv[1];
+const packageName = process.argv[2];
+
+if (!cachePath || !packageName) {
+  process.exit(0);
+}
+
+const request = https.get(
+  "https://registry.npmjs.org/" + packageName + "/latest",
+  {
+    headers: {
+      accept: "application/json",
+      "user-agent": packageName + " update notifier",
+    },
+  },
+  (response) => {
+    if (response.statusCode !== 200) {
+      response.resume();
+      return;
+    }
+
+    response.setEncoding("utf8");
+    let body = "";
+
+    response.on("error", () => {});
+    response.on("data", (chunk) => {
+      body += chunk;
+      if (body.length > 1024 * 1024) {
+        request.destroy();
+      }
+    });
+
+    response.on("end", () => {
+      try {
+        const payload = JSON.parse(body);
+        if (typeof payload.version !== "string") {
+          return;
+        }
+
+        fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+        const temporaryPath = cachePath + "." + process.pid + ".tmp";
+        fs.writeFileSync(
+          temporaryPath,
+          JSON.stringify({
+            latestVersion: payload.version,
+            checkedAt: Date.now(),
+          }),
+          "utf8",
+        );
+        fs.renameSync(temporaryPath, cachePath);
+      } catch {
+      }
+    });
+  },
+);
+
+request.setTimeout(2500, () => {
+  request.destroy();
+});
+request.on("error", () => {});
+`;
+
+export function getUpdateCacheDir(options: CachePathOptions = {}): string {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const homeDirectory = options.homeDirectory ?? homedir();
+
+  if (platform === "win32") {
+    return join(
+      env.LOCALAPPDATA ?? join(homeDirectory, "AppData", "Local"),
+      "mcpjam",
+      "Cache",
+    );
+  }
+
+  if (platform === "darwin") {
+    return join(homeDirectory, "Library", "Caches", "mcpjam");
+  }
+
+  return join(env.XDG_CACHE_HOME ?? join(homeDirectory, ".cache"), "mcpjam");
+}
+
+export function getUpdateCachePath(options: CachePathOptions = {}): string {
+  return join(getUpdateCacheDir(options), UPDATE_CACHE_FILE);
+}
+
+export function readUpdateCache(cachePath: string): UpdateCheckCache | null {
+  try {
+    const payload = JSON.parse(readFileSync(cachePath, "utf8"));
+
+    if (
+      !payload ||
+      typeof payload !== "object" ||
+      Array.isArray(payload) ||
+      typeof payload.latestVersion !== "string" ||
+      typeof payload.checkedAt !== "number" ||
+      !Number.isFinite(payload.checkedAt)
+    ) {
+      return null;
+    }
+
+    return {
+      latestVersion: payload.latestVersion,
+      checkedAt: payload.checkedAt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function isUpdateCacheFresh(
+  cache: UpdateCheckCache,
+  now = Date.now(),
+): boolean {
+  return now - cache.checkedAt < UPDATE_CHECK_INTERVAL_MS;
+}
+
+export function shouldSkipUpdateCheck(
+  options: SkipUpdateCheckOptions = {},
+): boolean {
+  const env = options.env ?? process.env;
+  const isStderrTTY = options.isStderrTTY ?? Boolean(process.stderr.isTTY);
+
+  return Boolean(
+    env.CI ||
+      env.NO_UPDATE_NOTIFIER ||
+      env.MCPJAM_NO_UPDATE_CHECK ||
+      !isStderrTTY,
+  );
+}
+
+export function isNewerVersion(latest: unknown, current: unknown): boolean {
+  const latestVersion = parseStableVersion(latest);
+  const currentVersion = parseStableVersion(current);
+
+  if (!latestVersion || !currentVersion) {
+    return false;
+  }
+
+  for (let index = 0; index < latestVersion.length; index += 1) {
+    if (latestVersion[index] > currentVersion[index]) {
+      return true;
+    }
+    if (latestVersion[index] < currentVersion[index]) {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+export function spawnBackgroundFetch(
+  cachePath: string,
+  packageName = DEFAULT_UPDATE_PACKAGE_NAME,
+  options: SpawnBackgroundFetchOptions = {},
+): void {
+  try {
+    const spawn = options.spawn ?? spawnChild;
+    const child = spawn(
+      options.execPath ?? process.execPath,
+      ["-e", BACKGROUND_FETCH_SCRIPT, cachePath, packageName],
+      {
+        detached: true,
+        stdio: "ignore",
+      },
+    ) as ChildProcess;
+
+    child.on("error", () => {});
+    child.unref();
+  } catch {
+  }
+}
+
+export function printUpdateNotification(
+  currentVersion: string,
+  latestVersion: string,
+  packageName = DEFAULT_UPDATE_PACKAGE_NAME,
+  stderr: StderrLike = process.stderr,
+): void {
+  stderr.write(
+    `Update available: ${packageName} ${currentVersion} -> ${latestVersion}\n` +
+      `Run npm install -g ${packageName} to update\n`,
+  );
+}
+
+export function checkForUpdates(
+  currentVersion: string,
+  options: UpdateNotifierOptions = {},
+): void {
+  try {
+    const env = options.env ?? process.env;
+
+    if (
+      shouldSkipUpdateCheck({
+        env,
+        isStderrTTY: options.isStderrTTY,
+      })
+    ) {
+      return;
+    }
+
+    const now =
+      typeof options.now === "function"
+        ? options.now()
+        : options.now ?? Date.now();
+    const packageName = options.packageName ?? DEFAULT_UPDATE_PACKAGE_NAME;
+    const cachePath =
+      options.cachePath ??
+      getUpdateCachePath({
+        env,
+      });
+    const cache = readUpdateCache(cachePath);
+
+    if (cache && isUpdateCacheFresh(cache, now)) {
+      if (isNewerVersion(cache.latestVersion, currentVersion)) {
+        printUpdateNotification(
+          currentVersion,
+          cache.latestVersion,
+          packageName,
+          options.stderr,
+        );
+      }
+      return;
+    }
+
+    const fetchSpawner = options.spawnBackgroundFetch ?? spawnBackgroundFetch;
+    fetchSpawner(cachePath, packageName);
+  } catch {
+  }
+}
+
+function parseStableVersion(value: unknown): [number, number, number] | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.startsWith("v") ? value.slice(1) : value;
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(normalized);
+
+  if (!match) {
+    return null;
+  }
+
+  const parts = match.slice(1).map((part) => Number(part));
+  if (!parts.every((part) => Number.isSafeInteger(part) && part >= 0)) {
+    return null;
+  }
+
+  return [parts[0], parts[1], parts[2]];
+}

--- a/cli/src/lib/update-notifier.ts
+++ b/cli/src/lib/update-notifier.ts
@@ -58,8 +58,10 @@ if (!cachePath || !packageName) {
   process.exit(0);
 }
 
+const maxResponseBytes = 1024 * 1024;
+const registryPackageName = encodeURIComponent(packageName);
 const request = https.get(
-  "https://registry.npmjs.org/" + packageName + "/latest",
+  "https://registry.npmjs.org/" + registryPackageName + "/latest",
   {
     headers: {
       accept: "application/json",
@@ -72,19 +74,22 @@ const request = https.get(
       return;
     }
 
-    response.setEncoding("utf8");
-    let body = "";
+    const chunks = [];
+    let bytes = 0;
 
     response.on("error", () => {});
     response.on("data", (chunk) => {
-      body += chunk;
-      if (body.length > 1024 * 1024) {
+      bytes += chunk.length;
+      if (bytes > maxResponseBytes) {
         request.destroy();
+        return;
       }
+      chunks.push(chunk);
     });
 
     response.on("end", () => {
       try {
+        const body = Buffer.concat(chunks, bytes).toString("utf8");
         const payload = JSON.parse(body);
         if (typeof payload.version !== "string") {
           return;
@@ -120,7 +125,7 @@ export function getUpdateCacheDir(options: CachePathOptions = {}): string {
 
   if (platform === "win32") {
     return join(
-      env.LOCALAPPDATA ?? join(homeDirectory, "AppData", "Local"),
+      env.LOCALAPPDATA || join(homeDirectory, "AppData", "Local"),
       "mcpjam",
       "Cache",
     );
@@ -130,7 +135,7 @@ export function getUpdateCacheDir(options: CachePathOptions = {}): string {
     return join(homeDirectory, "Library", "Caches", "mcpjam");
   }
 
-  return join(env.XDG_CACHE_HOME ?? join(homeDirectory, ".cache"), "mcpjam");
+  return join(env.XDG_CACHE_HOME || join(homeDirectory, ".cache"), "mcpjam");
 }
 
 export function getUpdateCachePath(options: CachePathOptions = {}): string {

--- a/cli/src/lib/update-notifier.ts
+++ b/cli/src/lib/update-notifier.ts
@@ -46,7 +46,8 @@ export interface SpawnBackgroundFetchOptions {
 
 const UPDATE_CACHE_FILE = "update-check.json";
 
-const BACKGROUND_FETCH_SCRIPT = String.raw`
+// Keep this inline so the tsup single-file CLI bundle contains the fetcher.
+const BACKGROUND_FETCH_SCRIPT = `
 const fs = require("node:fs");
 const https = require("node:https");
 const path = require("node:path");
@@ -107,6 +108,7 @@ const request = https.get(
         );
         fs.renameSync(temporaryPath, cachePath);
       } catch {
+        // Silently ignore: update cache refresh is best-effort.
       }
     });
   },
@@ -162,6 +164,7 @@ export function readUpdateCache(cachePath: string): UpdateCheckCache | null {
       checkedAt: payload.checkedAt,
     };
   } catch {
+    // Silently ignore malformed or missing cache data; update checks are best-effort.
     return null;
   }
 }
@@ -226,6 +229,7 @@ export function spawnBackgroundFetch(
     child.on("error", () => {});
     child.unref();
   } catch {
+    // Silently ignore spawn failures; the CLI command has already completed.
   }
 }
 
@@ -269,8 +273,13 @@ export function checkForUpdates(
       });
     const cache = readUpdateCache(cachePath);
 
-    if (cache && isUpdateCacheFresh(cache, now)) {
-      if (isNewerVersion(cache.latestVersion, currentVersion)) {
+    if (cache) {
+      const hasNewerCachedVersion = isNewerVersion(
+        cache.latestVersion,
+        currentVersion,
+      );
+
+      if (hasNewerCachedVersion) {
         printUpdateNotification(
           currentVersion,
           cache.latestVersion,
@@ -278,12 +287,16 @@ export function checkForUpdates(
           options.stderr,
         );
       }
-      return;
+
+      if (isUpdateCacheFresh(cache, now)) {
+        return;
+      }
     }
 
     const fetchSpawner = options.spawnBackgroundFetch ?? spawnBackgroundFetch;
     fetchSpawner(cachePath, packageName);
   } catch {
+    // Silently ignore all notifier failures; update checks must never break CLI runs.
   }
 }
 

--- a/cli/tests/index.test.ts
+++ b/cli/tests/index.test.ts
@@ -48,14 +48,14 @@ test("main treats help and version output as non-command success", async () => {
     main(["node", "mcpjam", "--help"]),
   );
   assert.equal(helpRun.result.exitCode, 0);
-  assert.equal(helpRun.result.didRunCommand, false);
+  assert.equal(helpRun.result.shouldCheckForUpdates, false);
   assert.match(helpRun.stdout, /Usage: mcpjam/);
 
   const versionRun = await captureProcessOutput(() =>
     main(["node", "mcpjam", "--version"]),
   );
   assert.equal(versionRun.result.exitCode, 0);
-  assert.equal(versionRun.result.didRunCommand, false);
+  assert.equal(versionRun.result.shouldCheckForUpdates, false);
   assert.ok(versionRun.stdout.includes(pkgVersion));
 });
 
@@ -86,7 +86,7 @@ test("runCliEntrypoint invokes update check after successful commands", async ()
     );
 
     assert.equal(run.result.exitCode, 0, run.stderr);
-    assert.equal(run.result.didRunCommand, true);
+    assert.equal(run.result.shouldCheckForUpdates, true);
     assert.equal(checkedVersion, pkgVersion);
   } finally {
     await server.stop();
@@ -105,7 +105,7 @@ test("runCliEntrypoint does not append update text after usage errors", async ()
   );
 
   assert.equal(run.result.exitCode, 2);
-  assert.equal(run.result.didRunCommand, false);
+  assert.equal(run.result.shouldCheckForUpdates, false);
   assert.equal(checked, false);
   assert.match(run.stderr, /"USAGE_ERROR"/);
   assert.doesNotMatch(run.stderr, /unexpected update notice/);

--- a/cli/tests/index.test.ts
+++ b/cli/tests/index.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { startMockHttpServer } from "../../sdk/tests/mock-servers/index.js";
+import { main, runCliEntrypoint } from "../src/index.js";
+
+async function captureProcessOutput<T>(
+  fn: () => Promise<T>,
+): Promise<{
+  result: T;
+  stdout: string;
+  stderr: string;
+}> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const originalExitCode = process.exitCode;
+  let stdout = "";
+  let stderr = "";
+
+  process.exitCode = undefined;
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    stdout += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    const result = await fn();
+    return {
+      result,
+      stdout,
+      stderr,
+    };
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    process.exitCode = originalExitCode;
+  }
+}
+
+test("main treats help and version output as non-command success", async () => {
+  const helpRun = await captureProcessOutput(() =>
+    main(["node", "mcpjam", "--help"]),
+  );
+  assert.equal(helpRun.result.exitCode, 0);
+  assert.equal(helpRun.result.didRunCommand, false);
+  assert.match(helpRun.stdout, /Usage: mcpjam/);
+
+  const versionRun = await captureProcessOutput(() =>
+    main(["node", "mcpjam", "--version"]),
+  );
+  assert.equal(versionRun.result.exitCode, 0);
+  assert.equal(versionRun.result.didRunCommand, false);
+  assert.match(versionRun.stdout, /3\.0\.0/);
+});
+
+test("runCliEntrypoint invokes update check after successful commands", async () => {
+  const server = await startMockHttpServer();
+  let checkedVersion: string | null = null;
+
+  try {
+    const run = await captureProcessOutput(() =>
+      runCliEntrypoint(
+        [
+          "node",
+          "mcpjam",
+          "--format",
+          "json",
+          "server",
+          "export",
+          "--url",
+          server.url,
+          "--stable",
+        ],
+        {
+          checkForUpdates(version) {
+            checkedVersion = version;
+          },
+        },
+      ),
+    );
+
+    assert.equal(run.result.exitCode, 0, run.stderr);
+    assert.equal(run.result.didRunCommand, true);
+    assert.equal(checkedVersion, "3.0.0");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("runCliEntrypoint does not append update text after usage errors", async () => {
+  let checked = false;
+  const run = await captureProcessOutput(() =>
+    runCliEntrypoint(["node", "mcpjam", "not-a-command"], {
+      checkForUpdates() {
+        checked = true;
+        process.stderr.write("unexpected update notice\n");
+      },
+    }),
+  );
+
+  assert.equal(run.result.exitCode, 2);
+  assert.equal(run.result.didRunCommand, false);
+  assert.equal(checked, false);
+  assert.match(run.stderr, /"USAGE_ERROR"/);
+  assert.doesNotMatch(run.stderr, /unexpected update notice/);
+});

--- a/cli/tests/index.test.ts
+++ b/cli/tests/index.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { startMockHttpServer } from "../../sdk/tests/mock-servers/index.js";
+import packageJson from "../package.json" with { type: "json" };
 import { main, runCliEntrypoint } from "../src/index.js";
+
+const pkgVersion = packageJson.version;
 
 async function captureProcessOutput<T>(
   fn: () => Promise<T>,
@@ -53,7 +56,7 @@ test("main treats help and version output as non-command success", async () => {
   );
   assert.equal(versionRun.result.exitCode, 0);
   assert.equal(versionRun.result.didRunCommand, false);
-  assert.match(versionRun.stdout, /3\.0\.0/);
+  assert.ok(versionRun.stdout.includes(pkgVersion));
 });
 
 test("runCliEntrypoint invokes update check after successful commands", async () => {
@@ -84,7 +87,7 @@ test("runCliEntrypoint invokes update check after successful commands", async ()
 
     assert.equal(run.result.exitCode, 0, run.stderr);
     assert.equal(run.result.didRunCommand, true);
-    assert.equal(checkedVersion, "3.0.0");
+    assert.equal(checkedVersion, pkgVersion);
   } finally {
     await server.stop();
   }

--- a/cli/tests/update-notifier.test.ts
+++ b/cli/tests/update-notifier.test.ts
@@ -249,14 +249,47 @@ test("checkForUpdates stays quiet for fresh same or older cached versions", () =
   });
 });
 
-test("checkForUpdates spawns a background fetch for stale or missing cache", () => {
+test("checkForUpdates prints stale newer cache and refreshes in the background", () => {
+  withTempDir((directory) => {
+    const staleCachePath = join(directory, "stale.json");
+    const spawns: string[] = [];
+    let stderr = "";
+    writeCache(staleCachePath, {
+      latestVersion: "3.1.0",
+      checkedAt: 1_000,
+    });
+
+    const spawn: SpawnBackgroundFetch = (cachePath) => {
+      spawns.push(cachePath);
+    };
+
+    checkForUpdates("3.0.0", {
+      cachePath: staleCachePath,
+      env: {},
+      isStderrTTY: true,
+      now: 1_000 + UPDATE_CHECK_INTERVAL_MS,
+      stderr: {
+        write(chunk) {
+          stderr += chunk;
+          return true;
+        },
+      },
+      spawnBackgroundFetch: spawn,
+    });
+
+    assert.match(stderr, /Update available: @mcpjam\/cli 3\.0\.0 -> 3\.1\.0/);
+    assert.deepEqual(spawns, [staleCachePath]);
+  });
+});
+
+test("checkForUpdates spawns a background fetch for stale same-version or missing cache", () => {
   withTempDir((directory) => {
     const staleCachePath = join(directory, "stale.json");
     const missingCachePath = join(directory, "missing.json");
     const spawns: string[] = [];
     let stderr = "";
     writeCache(staleCachePath, {
-      latestVersion: "3.1.0",
+      latestVersion: "3.0.0",
       checkedAt: 1_000,
     });
 

--- a/cli/tests/update-notifier.test.ts
+++ b/cli/tests/update-notifier.test.ts
@@ -71,11 +71,31 @@ test("getUpdateCacheDir follows OS cache conventions", () => {
   );
   assert.equal(
     getUpdateCacheDir({
+      env: {
+        XDG_CACHE_HOME: "",
+      },
+      platform: "linux",
+      homeDirectory: "/home/mcpjam",
+    }),
+    join("/home/mcpjam", ".cache", "mcpjam"),
+  );
+  assert.equal(
+    getUpdateCacheDir({
       env: {},
       platform: "darwin",
       homeDirectory: "/Users/mcpjam",
     }),
     join("/Users/mcpjam", "Library", "Caches", "mcpjam"),
+  );
+  assert.equal(
+    getUpdateCacheDir({
+      env: {
+        LOCALAPPDATA: "",
+      },
+      platform: "win32",
+      homeDirectory: "C:\\Users\\mcpjam",
+    }),
+    join("C:\\Users\\mcpjam", "AppData", "Local", "mcpjam", "Cache"),
   );
   assert.equal(
     getUpdateCacheDir({
@@ -341,6 +361,7 @@ test("spawnBackgroundFetch starts a detached node process with positional args",
 
   assert.equal(command, "/usr/bin/node");
   assert.equal(args[0], "-e");
+  assert.match(args[1] ?? "", /encodeURIComponent\(packageName\)/);
   assert.equal(args[2], "/tmp/update-cache.json");
   assert.equal(args[3], "@mcpjam/cli");
   assert.deepEqual(options, {

--- a/cli/tests/update-notifier.test.ts
+++ b/cli/tests/update-notifier.test.ts
@@ -1,0 +1,352 @@
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  checkForUpdates,
+  getUpdateCacheDir,
+  isNewerVersion,
+  isUpdateCacheFresh,
+  readUpdateCache,
+  shouldSkipUpdateCheck,
+  spawnBackgroundFetch,
+  UPDATE_CHECK_INTERVAL_MS,
+  type SpawnBackgroundFetch,
+} from "../src/lib/update-notifier.js";
+
+function withTempDir(fn: (directory: string) => void) {
+  const directory = mkdtempSync(join(tmpdir(), "mcpjam-update-notifier-"));
+  try {
+    fn(directory);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+function writeCache(
+  cachePath: string,
+  cache: {
+    latestVersion: string;
+    checkedAt: number;
+  },
+) {
+  writeFileSync(cachePath, JSON.stringify(cache), "utf8");
+}
+
+test("isNewerVersion compares only stable semver versions", () => {
+  assert.equal(isNewerVersion("3.1.0", "3.0.0"), true);
+  assert.equal(isNewerVersion("4.0.0", "3.9.9"), true);
+  assert.equal(isNewerVersion("v3.0.1", "3.0.0"), true);
+  assert.equal(isNewerVersion("3.0.0", "3.0.0"), false);
+  assert.equal(isNewerVersion("2.9.9", "3.0.0"), false);
+  assert.equal(isNewerVersion("3.1.0-beta.1", "3.0.0"), false);
+  assert.equal(isNewerVersion("3.1", "3.0.0"), false);
+  assert.equal(isNewerVersion("3.1.0", "not-a-version"), false);
+  assert.equal(isNewerVersion(undefined, "3.0.0"), false);
+});
+
+test("getUpdateCacheDir follows OS cache conventions", () => {
+  assert.equal(
+    getUpdateCacheDir({
+      env: {},
+      platform: "linux",
+      homeDirectory: "/home/mcpjam",
+    }),
+    join("/home/mcpjam", ".cache", "mcpjam"),
+  );
+  assert.equal(
+    getUpdateCacheDir({
+      env: {
+        XDG_CACHE_HOME: "/tmp/xdg-cache",
+      },
+      platform: "linux",
+      homeDirectory: "/home/mcpjam",
+    }),
+    join("/tmp/xdg-cache", "mcpjam"),
+  );
+  assert.equal(
+    getUpdateCacheDir({
+      env: {},
+      platform: "darwin",
+      homeDirectory: "/Users/mcpjam",
+    }),
+    join("/Users/mcpjam", "Library", "Caches", "mcpjam"),
+  );
+  assert.equal(
+    getUpdateCacheDir({
+      env: {
+        LOCALAPPDATA: "C:\\Users\\mcpjam\\AppData\\Local",
+      },
+      platform: "win32",
+      homeDirectory: "C:\\Users\\mcpjam",
+    }),
+    join("C:\\Users\\mcpjam\\AppData\\Local", "mcpjam", "Cache"),
+  );
+});
+
+test("readUpdateCache returns valid cache data and ignores invalid cache files", () => {
+  withTempDir((directory) => {
+    const validCachePath = join(directory, "valid.json");
+    writeCache(validCachePath, {
+      latestVersion: "3.1.0",
+      checkedAt: 1_000,
+    });
+    assert.deepEqual(readUpdateCache(validCachePath), {
+      latestVersion: "3.1.0",
+      checkedAt: 1_000,
+    });
+
+    assert.equal(readUpdateCache(join(directory, "missing.json")), null);
+
+    const corruptCachePath = join(directory, "corrupt.json");
+    writeFileSync(corruptCachePath, "{", "utf8");
+    assert.equal(readUpdateCache(corruptCachePath), null);
+
+    const invalidSchemaPath = join(directory, "invalid-schema.json");
+    writeFileSync(
+      invalidSchemaPath,
+      JSON.stringify({
+        latestVersion: 3,
+        checkedAt: "yesterday",
+      }),
+      "utf8",
+    );
+    assert.equal(readUpdateCache(invalidSchemaPath), null);
+  });
+});
+
+test("isUpdateCacheFresh uses the 24 hour freshness window", () => {
+  assert.equal(
+    isUpdateCacheFresh(
+      {
+        latestVersion: "3.1.0",
+        checkedAt: 10_000,
+      },
+      10_000 + UPDATE_CHECK_INTERVAL_MS - 1,
+    ),
+    true,
+  );
+  assert.equal(
+    isUpdateCacheFresh(
+      {
+        latestVersion: "3.1.0",
+        checkedAt: 10_000,
+      },
+      10_000 + UPDATE_CHECK_INTERVAL_MS,
+    ),
+    false,
+  );
+});
+
+test("shouldSkipUpdateCheck respects CI, opt-out env vars, and non-TTY stderr", () => {
+  assert.equal(shouldSkipUpdateCheck({ env: {}, isStderrTTY: true }), false);
+  assert.equal(shouldSkipUpdateCheck({ env: {}, isStderrTTY: false }), true);
+  assert.equal(
+    shouldSkipUpdateCheck({ env: { CI: "true" }, isStderrTTY: true }),
+    true,
+  );
+  assert.equal(
+    shouldSkipUpdateCheck({
+      env: { NO_UPDATE_NOTIFIER: "1" },
+      isStderrTTY: true,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldSkipUpdateCheck({
+      env: { MCPJAM_NO_UPDATE_CHECK: "1" },
+      isStderrTTY: true,
+    }),
+    true,
+  );
+});
+
+test("checkForUpdates prints a fresh newer cached version to stderr", () => {
+  withTempDir((directory) => {
+    const cachePath = join(directory, "cache.json");
+    const spawns: string[] = [];
+    let stderr = "";
+    writeCache(cachePath, {
+      latestVersion: "3.1.0",
+      checkedAt: 1_000,
+    });
+
+    checkForUpdates("3.0.0", {
+      cachePath,
+      env: {},
+      isStderrTTY: true,
+      now: 1_000,
+      stderr: {
+        write(chunk) {
+          stderr += chunk;
+          return true;
+        },
+      },
+      spawnBackgroundFetch(path) {
+        spawns.push(path);
+      },
+    });
+
+    assert.match(stderr, /Update available: @mcpjam\/cli 3\.0\.0 -> 3\.1\.0/);
+    assert.match(stderr, /Run npm install -g @mcpjam\/cli to update/);
+    assert.deepEqual(spawns, []);
+  });
+});
+
+test("checkForUpdates stays quiet for fresh same or older cached versions", () => {
+  withTempDir((directory) => {
+    const cachePath = join(directory, "cache.json");
+    let stderr = "";
+    let spawnCount = 0;
+    writeCache(cachePath, {
+      latestVersion: "3.0.0",
+      checkedAt: 1_000,
+    });
+
+    checkForUpdates("3.0.0", {
+      cachePath,
+      env: {},
+      isStderrTTY: true,
+      now: 1_000,
+      stderr: {
+        write(chunk) {
+          stderr += chunk;
+          return true;
+        },
+      },
+      spawnBackgroundFetch() {
+        spawnCount += 1;
+      },
+    });
+
+    assert.equal(stderr, "");
+    assert.equal(spawnCount, 0);
+  });
+});
+
+test("checkForUpdates spawns a background fetch for stale or missing cache", () => {
+  withTempDir((directory) => {
+    const staleCachePath = join(directory, "stale.json");
+    const missingCachePath = join(directory, "missing.json");
+    const spawns: string[] = [];
+    let stderr = "";
+    writeCache(staleCachePath, {
+      latestVersion: "3.1.0",
+      checkedAt: 1_000,
+    });
+
+    const spawn: SpawnBackgroundFetch = (cachePath) => {
+      spawns.push(cachePath);
+    };
+
+    checkForUpdates("3.0.0", {
+      cachePath: staleCachePath,
+      env: {},
+      isStderrTTY: true,
+      now: 1_000 + UPDATE_CHECK_INTERVAL_MS,
+      stderr: {
+        write(chunk) {
+          stderr += chunk;
+          return true;
+        },
+      },
+      spawnBackgroundFetch: spawn,
+    });
+    checkForUpdates("3.0.0", {
+      cachePath: missingCachePath,
+      env: {},
+      isStderrTTY: true,
+      now: 1_000,
+      stderr: {
+        write(chunk) {
+          stderr += chunk;
+          return true;
+        },
+      },
+      spawnBackgroundFetch: spawn,
+    });
+
+    assert.equal(stderr, "");
+    assert.deepEqual(spawns, [staleCachePath, missingCachePath]);
+  });
+});
+
+test("checkForUpdates skips both notice and fetch when disabled", () => {
+  withTempDir((directory) => {
+    const cachePath = join(directory, "cache.json");
+    let stderr = "";
+    let spawnCount = 0;
+    writeCache(cachePath, {
+      latestVersion: "3.1.0",
+      checkedAt: 1_000,
+    });
+
+    checkForUpdates("3.0.0", {
+      cachePath,
+      env: {
+        MCPJAM_NO_UPDATE_CHECK: "1",
+      },
+      isStderrTTY: true,
+      now: 1_000,
+      stderr: {
+        write(chunk) {
+          stderr += chunk;
+          return true;
+        },
+      },
+      spawnBackgroundFetch() {
+        spawnCount += 1;
+      },
+    });
+
+    assert.equal(stderr, "");
+    assert.equal(spawnCount, 0);
+  });
+});
+
+test("spawnBackgroundFetch starts a detached node process with positional args", () => {
+  let command = "";
+  let args: readonly string[] = [];
+  let options: unknown;
+  let registeredEvent = "";
+  let unrefCalled = false;
+  const child = {
+    on(event: string) {
+      registeredEvent = event;
+      return child;
+    },
+    unref() {
+      unrefCalled = true;
+    },
+  };
+
+  spawnBackgroundFetch("/tmp/update-cache.json", "@mcpjam/cli", {
+    execPath: "/usr/bin/node",
+    spawn: ((
+      nextCommand: string,
+      nextArgs?: readonly string[],
+      nextOptions?: unknown,
+    ) => {
+      command = nextCommand;
+      args = nextArgs ?? [];
+      options = nextOptions;
+      return child;
+    }) as unknown as typeof import("node:child_process").spawn,
+  });
+
+  assert.equal(command, "/usr/bin/node");
+  assert.equal(args[0], "-e");
+  assert.equal(args[2], "/tmp/update-cache.json");
+  assert.equal(args[3], "@mcpjam/cli");
+  assert.deepEqual(options, {
+    detached: true,
+    stdio: "ignore",
+  });
+  assert.equal(registeredEvent, "error");
+  assert.equal(unrefCalled, true);
+});


### PR DESCRIPTION
## Summary
- Add a zero-dependency update notifier for `@mcpjam/cli` that reads a local cache, checks for newer releases, and refreshes stale data in a detached background Node process.
- Update the CLI entrypoint so update checks only run after successful interactive commands, while keeping help/version and error output clean.
- Add focused unit and integration-style tests for cache handling, semver comparison, skip logic, and entrypoint behavior.

## Testing
- Added unit coverage for cache parsing, freshness checks, version comparison, and opt-out behavior.
- Added entrypoint tests to confirm update checks run only after successful commands and do not append to usage errors.
- Local validation passed with the CLI test suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a network-backed update check that spawns a detached Node process and writes to a local cache; while best-effort and gated to successful interactive runs, it touches CLI startup/exit behavior and could affect user environments.
> 
> **Overview**
> Adds a zero-dependency CLI update notifier that reads a per-OS cache, compares stable semver versions, prints an update notice to stderr when newer, and refreshes stale/missing cache entries via a detached background Node fetch to the npm registry.
> 
> Refactors the CLI entrypoint so `main` returns `{ exitCode, shouldCheckForUpdates }`, introduces `runCliEntrypoint` to run `checkForUpdates` only after successful commands (not help/version/usage errors), and guards auto-execution with `isDirectRun`. Includes new tests covering notifier cache/skip/version logic and entrypoint behavior around when update checks run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a29072a3ca4a5173d97e7ce8ba4d6aa192e65fad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->