### PR TITLE
Add quiet reporter and JSON input ergonomics

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -159,7 +159,7 @@ echo '{"query":"setup guide"}' | mcpjam tools call --url $URL --access-token $TO
   --tool-name search_docs --tool-args - --quiet --format json
 ```
 
-Use `--format json|human` for the raw command result. Use `--reporter json-summary|junit-xml` on conformance, validation, and diff commands when CI needs a report artifact.
+Use `--format json|human` for the raw command result. Use `--reporter json-summary|junit-xml` on conformance and diff commands when CI needs a report artifact. `server validate` uses `--debug-out` for validation artifacts.
 
 ## GitHub Actions
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -27,6 +27,7 @@ Options:
   -v, --version      output the CLI version
   --timeout <ms>     Request timeout in milliseconds (default: 30000)
   --rpc              Include RPC logs in JSON output
+  --quiet            Suppress non-result progress output
   --format <format>  Output format
   -h, --help         display help for command
 
@@ -58,7 +59,7 @@ mcpjam apps conformance --url https://your-server.com/mcp --access-token $TOKEN
 
 # MCP Apps render debugging in Inspector
 mcpjam apps debug --url https://your-server.com/mcp --access-token $TOKEN \
-  --tool-name create_view --params '{"projectId":"demo"}' --ui --format json
+  --tool-name create_view --params @params.json --ui --quiet --format json
 
 # List tools with full schemas
 mcpjam tools list --url https://your-server.com/mcp --access-token $TOKEN --format json
@@ -94,7 +95,7 @@ diff <(jq -S . before.json) <(jq -S . after.json)
 Cover the full registration × protocol version × auth mode matrix from a single config file. Outputs JUnit XML.
 
 ```bash
-mcpjam oauth conformance-suite --config ./oauth-matrix.json --format junit-xml > report.xml
+mcpjam oauth conformance-suite --config ./oauth-matrix.json --reporter junit-xml > report.xml
 ```
 
 ### Verify tokens work end-to-end
@@ -145,6 +146,20 @@ Pipe the full schema inventory into your own linter, review it in a PR, or check
 mcpjam tools list --url $URL --access-token $TOKEN --format json \
   | jq '.tools[] | {name, description, inputSchema}'
 ```
+
+### JSON input ergonomics
+
+JSON-valued flags accept inline JSON, `@path`, or `-` for stdin:
+
+```bash
+mcpjam tools call --url $URL --access-token $TOKEN \
+  --tool-name search_docs --tool-args @params.json --quiet --format json
+
+echo '{"query":"setup guide"}' | mcpjam tools call --url $URL --access-token $TOKEN \
+  --tool-name search_docs --tool-args - --quiet --format json
+```
+
+Use `--format json|human` for the raw command result. Use `--reporter json-summary|junit-xml` on conformance, validation, and diff commands when CI needs a report artifact.
 
 ## GitHub Actions
 

--- a/cli/src/commands/apps-debug.ts
+++ b/cli/src/commands/apps-debug.ts
@@ -52,7 +52,7 @@ export function registerAppsDebugCommand(parent: Command): void {
         .description("Debug an MCP App tool call from the CLI")
         .requiredOption("--tool-name <name>", "Tool name to execute")
         .option(
-          "--params <json|@file>",
+          "--params <json>",
           "Tool parameters as JSON, @path, or - for stdin",
         )
         .option(

--- a/cli/src/commands/apps-debug.ts
+++ b/cli/src/commands/apps-debug.ts
@@ -1,5 +1,4 @@
 import { Command } from "commander";
-import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { type MCPServerConfig, type RetryPolicy } from "@mcpjam/sdk";
 import { withEphemeralManager } from "../lib/ephemeral.js";
@@ -54,7 +53,7 @@ export function registerAppsDebugCommand(parent: Command): void {
         .requiredOption("--tool-name <name>", "Tool name to execute")
         .option(
           "--params <json|@file>",
-          "Tool parameters as JSON or @path to a JSON file",
+          "Tool parameters as JSON, @path, or - for stdin",
         )
         .option(
           "--ui",
@@ -86,10 +85,7 @@ export function registerAppsDebugCommand(parent: Command): void {
     const retryPolicy = parseRetryPolicy(options);
     const target = describeTarget(options);
     const toolName = options.toolName as string;
-    const params = await parseJsonRecordOrFile(
-      options.params,
-      "Tool parameters",
-    );
+    const params = parseJsonRecord(options.params, "Tool parameters") ?? {};
     const serverName =
       typeof options.serverName === "string" && options.serverName.trim()
         ? options.serverName.trim()
@@ -164,35 +160,6 @@ export function registerAppsDebugCommand(parent: Command): void {
 // ---------------------------------------------------------------------------
 // Internals
 // ---------------------------------------------------------------------------
-
-async function parseJsonRecordOrFile(
-  value: string | undefined,
-  label: string,
-): Promise<Record<string, unknown>> {
-  if (value === undefined) {
-    return {};
-  }
-
-  if (!value.startsWith("@")) {
-    return parseJsonRecord(value, label) ?? {};
-  }
-
-  const filePath = value.slice(1);
-  if (!filePath) {
-    throw usageError(`${label} file path is required after @.`);
-  }
-
-  let content: string;
-  try {
-    content = await readFile(filePath, "utf8");
-  } catch (error) {
-    throw usageError(`Failed to read ${label} file "${filePath}".`, {
-      source: error instanceof Error ? error.message : String(error),
-    });
-  }
-
-  return parseJsonRecord(content, label) ?? {};
-}
 
 async function runSdkAppsDebug(options: {
   config: MCPServerConfig;

--- a/cli/src/commands/apps.ts
+++ b/cli/src/commands/apps.ts
@@ -15,13 +15,12 @@ import {
 } from "../lib/apps.js";
 import { loadAppsSuiteConfig } from "../lib/config-file.js";
 import {
-  renderConformanceReporterResult,
-  renderConformanceResult,
-  resolveConformanceOutputFormat,
+  renderConformanceForCli,
+  resolveConformanceOutputFormatForCli,
   type ConformanceOutputFormat,
 } from "../lib/conformance-output.js";
 import { parseJsonInputValue } from "../lib/json-input.js";
-import { parseReporterFormat } from "../lib/reporting.js";
+import { parseReporterFormat, type ReporterFormat } from "../lib/reporting.js";
 import { withEphemeralManager } from "../lib/ephemeral.js";
 import { createCliRpcLogCollector } from "../lib/rpc-logs.js";
 import { withRpcLogsIfRequested } from "../lib/rpc-helpers.js";
@@ -60,10 +59,7 @@ export interface AppsConformanceOptions extends SharedServerTargetOptions {
   checkId?: string[];
 }
 
-function getConformanceGlobals(
-  command: Command,
-  options: { resolveFormat: boolean } = { resolveFormat: true },
-): {
+function getConformanceGlobals(command: Command, reporter?: ReporterFormat): {
   format: ConformanceOutputFormat;
   timeout: number;
   rpc: boolean;
@@ -77,12 +73,11 @@ function getConformanceGlobals(
   };
 
   return {
-    format: options.resolveFormat
-      ? resolveConformanceOutputFormat(
-          globalOptions.format,
-          process.stdout.isTTY,
-        )
-      : "json",
+    format: resolveConformanceOutputFormatForCli(
+      globalOptions.format,
+      process.stdout.isTTY,
+      reporter,
+    ),
     timeout: globalOptions.timeout ?? 30_000,
     rpc: globalOptions.rpc ?? false,
     quiet: globalOptions.quiet ?? false,
@@ -122,9 +117,7 @@ export function registerAppsCommands(program: Command): void {
       ),
   ).action(async (options, command) => {
     const reporter = parseReporterFormat(options.reporter as string | undefined);
-    const globalOptions = getConformanceGlobals(command, {
-      resolveFormat: !reporter,
-    });
+    const globalOptions = getConformanceGlobals(command, reporter);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -146,9 +139,7 @@ export function registerAppsCommands(program: Command): void {
           globalOptions,
         ) as typeof result);
     writeConformanceOutput(
-      reporter
-        ? renderConformanceReporterResult(outputResult, reporter)
-        : renderConformanceResult(outputResult, globalOptions.format),
+      renderConformanceForCli(outputResult, reporter, globalOptions.format),
     );
     if (!result.passed) {
       setProcessExitCode(1);
@@ -165,9 +156,7 @@ export function registerAppsCommands(program: Command): void {
     )
     .action(async (options, command) => {
       const reporter = parseReporterFormat(options.reporter as string | undefined);
-      const globalOptions = getConformanceGlobals(command, {
-        resolveFormat: !reporter,
-      });
+      const globalOptions = getConformanceGlobals(command, reporter);
       const config = loadAppsSuiteConfig(options.config as string);
       const target = config.target.command ?? config.target.url ?? "apps-suite";
       const collector = globalOptions.rpc
@@ -190,9 +179,7 @@ export function registerAppsCommands(program: Command): void {
             globalOptions,
           ) as typeof result);
       writeConformanceOutput(
-        reporter
-          ? renderConformanceReporterResult(outputResult, reporter)
-          : renderConformanceResult(outputResult, globalOptions.format),
+        renderConformanceForCli(outputResult, reporter, globalOptions.format),
       );
       if (!result.passed) {
         setProcessExitCode(1);

--- a/cli/src/commands/apps.ts
+++ b/cli/src/commands/apps.ts
@@ -60,24 +60,32 @@ export interface AppsConformanceOptions extends SharedServerTargetOptions {
   checkId?: string[];
 }
 
-function getConformanceGlobals(command: Command): {
+function getConformanceGlobals(
+  command: Command,
+  options: { resolveFormat: boolean } = { resolveFormat: true },
+): {
   format: ConformanceOutputFormat;
   timeout: number;
   rpc: boolean;
+  quiet: boolean;
 } {
-  const options = command.optsWithGlobals() as {
+  const globalOptions = command.optsWithGlobals() as {
     format?: string;
     timeout?: number;
     rpc?: boolean;
+    quiet?: boolean;
   };
 
   return {
-    format: resolveConformanceOutputFormat(
-      options.format,
-      process.stdout.isTTY,
-    ),
-    timeout: options.timeout ?? 30_000,
-    rpc: options.rpc ?? false,
+    format: options.resolveFormat
+      ? resolveConformanceOutputFormat(
+          globalOptions.format,
+          process.stdout.isTTY,
+        )
+      : "json",
+    timeout: globalOptions.timeout ?? 30_000,
+    rpc: globalOptions.rpc ?? false,
+    quiet: globalOptions.quiet ?? false,
   };
 }
 
@@ -113,8 +121,10 @@ export function registerAppsCommands(program: Command): void {
         "Structured reporter output: json-summary or junit-xml",
       ),
   ).action(async (options, command) => {
-    const globalOptions = getConformanceGlobals(command);
     const reporter = parseReporterFormat(options.reporter as string | undefined);
+    const globalOptions = getConformanceGlobals(command, {
+      resolveFormat: !reporter,
+    });
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -128,11 +138,13 @@ export function registerAppsCommands(program: Command): void {
     };
     const result = await new MCPAppsConformanceTest(config).run();
 
-    const outputResult = withRpcLogsIfRequested(
-      result,
-      collector,
-      globalOptions,
-    ) as typeof result;
+    const outputResult = reporter
+      ? result
+      : (withRpcLogsIfRequested(
+          result,
+          collector,
+          globalOptions,
+        ) as typeof result);
     writeConformanceOutput(
       reporter
         ? renderConformanceReporterResult(outputResult, reporter)
@@ -152,8 +164,10 @@ export function registerAppsCommands(program: Command): void {
       "Structured reporter output: json-summary or junit-xml",
     )
     .action(async (options, command) => {
-      const globalOptions = getConformanceGlobals(command);
       const reporter = parseReporterFormat(options.reporter as string | undefined);
+      const globalOptions = getConformanceGlobals(command, {
+        resolveFormat: !reporter,
+      });
       const config = loadAppsSuiteConfig(options.config as string);
       const target = config.target.command ?? config.target.url ?? "apps-suite";
       const collector = globalOptions.rpc
@@ -168,11 +182,13 @@ export function registerAppsCommands(program: Command): void {
       });
       const result = await suite.run();
 
-      const outputResult = withRpcLogsIfRequested(
-        result,
-        collector,
-        globalOptions,
-      ) as typeof result;
+      const outputResult = reporter
+        ? result
+        : (withRpcLogsIfRequested(
+            result,
+            collector,
+            globalOptions,
+          ) as typeof result);
       writeConformanceOutput(
         reporter
           ? renderConformanceReporterResult(outputResult, reporter)
@@ -236,7 +252,7 @@ export function registerAppsCommands(program: Command): void {
           toolId: options.toolId as string,
           toolName: options.toolName as string,
           toolInput: parseJsonRecord(options.toolInput, "Tool input") ?? {},
-          toolOutput: parseJsonValue(options.toolOutput, "Tool output"),
+          toolOutput: parseJsonInputValue(options.toolOutput, "Tool output"),
           theme: parseTheme(options.theme),
           cspMode: parseCspMode(options.cspMode),
           template: options.template as string | undefined,
@@ -310,7 +326,7 @@ export function registerAppsCommands(program: Command): void {
           toolId: options.toolId as string,
           toolName: options.toolName as string,
           toolInput: parseJsonRecord(options.toolInput, "Tool input") ?? {},
-          toolOutput: parseJsonValue(options.toolOutput, "Tool output"),
+          toolOutput: parseJsonInputValue(options.toolOutput, "Tool output"),
           toolResponseMetadata:
             parseJsonRecord(
               options.toolResponseMetadata,
@@ -333,10 +349,6 @@ export function registerAppsCommands(program: Command): void {
       globalOptions.format,
     );
   });
-}
-
-function parseJsonValue(value: string | undefined, label: string): unknown {
-  return parseJsonInputValue(value, label);
 }
 
 function parseCspMode(

--- a/cli/src/commands/apps.ts
+++ b/cli/src/commands/apps.ts
@@ -15,10 +15,13 @@ import {
 } from "../lib/apps.js";
 import { loadAppsSuiteConfig } from "../lib/config-file.js";
 import {
+  renderConformanceReporterResult,
   renderConformanceResult,
   resolveConformanceOutputFormat,
   type ConformanceOutputFormat,
 } from "../lib/conformance-output.js";
+import { parseJsonInputValue } from "../lib/json-input.js";
+import { parseReporterFormat } from "../lib/reporting.js";
 import { withEphemeralManager } from "../lib/ephemeral.js";
 import { createCliRpcLogCollector } from "../lib/rpc-logs.js";
 import { withRpcLogsIfRequested } from "../lib/rpc-helpers.js";
@@ -104,9 +107,14 @@ export function registerAppsCommands(program: Command): void {
         "Specific check ID to run. Repeat for multiple. Default: all.",
         (value: string, previous: string[] = []) => [...previous, value],
         [],
+      )
+      .option(
+        "--reporter <reporter>",
+        "Structured reporter output: json-summary or junit-xml",
       ),
   ).action(async (options, command) => {
     const globalOptions = getConformanceGlobals(command);
+    const reporter = parseReporterFormat(options.reporter as string | undefined);
     const target = describeTarget(options);
     const collector = globalOptions.rpc
       ? createCliRpcLogCollector({ __cli__: target })
@@ -120,15 +128,15 @@ export function registerAppsCommands(program: Command): void {
     };
     const result = await new MCPAppsConformanceTest(config).run();
 
+    const outputResult = withRpcLogsIfRequested(
+      result,
+      collector,
+      globalOptions,
+    ) as typeof result;
     writeConformanceOutput(
-      renderConformanceResult(
-        withRpcLogsIfRequested(
-          result,
-          collector,
-          globalOptions,
-        ) as typeof result,
-        globalOptions.format,
-      ),
+      reporter
+        ? renderConformanceReporterResult(outputResult, reporter)
+        : renderConformanceResult(outputResult, globalOptions.format),
     );
     if (!result.passed) {
       setProcessExitCode(1);
@@ -139,8 +147,13 @@ export function registerAppsCommands(program: Command): void {
     .command("conformance-suite")
     .description("Run MCP Apps conformance runs from a JSON config file")
     .requiredOption("--config <path>", "Path to JSON config file")
+    .option(
+      "--reporter <reporter>",
+      "Structured reporter output: json-summary or junit-xml",
+    )
     .action(async (options, command) => {
       const globalOptions = getConformanceGlobals(command);
+      const reporter = parseReporterFormat(options.reporter as string | undefined);
       const config = loadAppsSuiteConfig(options.config as string);
       const target = config.target.command ?? config.target.url ?? "apps-suite";
       const collector = globalOptions.rpc
@@ -155,15 +168,15 @@ export function registerAppsCommands(program: Command): void {
       });
       const result = await suite.run();
 
+      const outputResult = withRpcLogsIfRequested(
+        result,
+        collector,
+        globalOptions,
+      ) as typeof result;
       writeConformanceOutput(
-        renderConformanceResult(
-          withRpcLogsIfRequested(
-            result,
-            collector,
-            globalOptions,
-          ) as typeof result,
-          globalOptions.format,
-        ),
+        reporter
+          ? renderConformanceReporterResult(outputResult, reporter)
+          : renderConformanceResult(outputResult, globalOptions.format),
       );
       if (!result.passed) {
         setProcessExitCode(1);
@@ -186,13 +199,22 @@ export function registerAppsCommands(program: Command): void {
           "--tool-name <name>",
           "Tool name used for runtime injection",
         )
-        .option("--tool-input <json>", "Tool input payload as JSON")
-        .option("--tool-output <json>", "Tool output payload as JSON")
+        .option(
+          "--tool-input <json>",
+          "Tool input payload as JSON, @path, or - for stdin",
+        )
+        .option(
+          "--tool-output <json>",
+          "Tool output payload as JSON, @path, or - for stdin",
+        )
         .option("--theme <theme>", "Widget theme: light or dark")
         .option("--csp-mode <mode>", "CSP mode: permissive or widget-declared")
         .option("--template <uri>", "Optional ui:// template override")
         .option("--view-mode <mode>", "Widget view mode")
-        .option("--view-params <json>", "Widget view params as JSON"),
+        .option(
+          "--view-params <json>",
+          "Widget view params as JSON, @path, or - for stdin",
+        ),
     ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);
@@ -214,7 +236,7 @@ export function registerAppsCommands(program: Command): void {
           toolId: options.toolId as string,
           toolName: options.toolName as string,
           toolInput: parseJsonRecord(options.toolInput, "Tool input") ?? {},
-          toolOutput: parseJsonValue(options.toolOutput),
+          toolOutput: parseJsonValue(options.toolOutput, "Tool output"),
           theme: parseTheme(options.theme),
           cspMode: parseCspMode(options.cspMode),
           template: options.template as string | undefined,
@@ -248,11 +270,17 @@ export function registerAppsCommands(program: Command): void {
           "--tool-name <name>",
           "Tool name used for runtime injection",
         )
-        .option("--tool-input <json>", "Tool input payload as JSON")
-        .option("--tool-output <json>", "Tool output payload as JSON")
+        .option(
+          "--tool-input <json>",
+          "Tool input payload as JSON, @path, or - for stdin",
+        )
+        .option(
+          "--tool-output <json>",
+          "Tool output payload as JSON, @path, or - for stdin",
+        )
         .option(
           "--tool-response-metadata <json>",
-          "Tool response metadata as a JSON object",
+          "Tool response metadata as JSON, @path, or - for stdin",
         )
         .option("--theme <theme>", "Widget theme: light or dark")
         .option("--csp-mode <mode>", "CSP mode: permissive or widget-declared")
@@ -282,7 +310,7 @@ export function registerAppsCommands(program: Command): void {
           toolId: options.toolId as string,
           toolName: options.toolName as string,
           toolInput: parseJsonRecord(options.toolInput, "Tool input") ?? {},
-          toolOutput: parseJsonValue(options.toolOutput),
+          toolOutput: parseJsonValue(options.toolOutput, "Tool output"),
           toolResponseMetadata:
             parseJsonRecord(
               options.toolResponseMetadata,
@@ -307,18 +335,8 @@ export function registerAppsCommands(program: Command): void {
   });
 }
 
-function parseJsonValue(value: string | undefined): unknown {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  try {
-    return JSON.parse(value);
-  } catch (error) {
-    throw usageError("Value must be valid JSON.", {
-      source: error instanceof Error ? error.message : String(error),
-    });
-  }
+function parseJsonValue(value: string | undefined, label: string): unknown {
+  return parseJsonInputValue(value, label);
 }
 
 function parseCspMode(

--- a/cli/src/commands/conformance.ts
+++ b/cli/src/commands/conformance.ts
@@ -80,7 +80,6 @@ export function registerProtocolCommands(program: Command): void {
       "Structured reporter output: json-summary or junit-xml",
     )
     .action(async (options, command) => {
-      const format = getFormat(command);
       const reporter = parseReporterFormat(options.reporter as string | undefined);
       const config = buildConfig(options as ProtocolConformanceOptions);
       const result = await new MCPConformanceTest(config).run();
@@ -88,7 +87,7 @@ export function registerProtocolCommands(program: Command): void {
       writeConformanceOutput(
         reporter
           ? renderConformanceReporterResult(result, reporter)
-          : renderConformanceResult(result, format),
+          : renderConformanceResult(result, getFormat(command)),
       );
       if (!result.passed) {
         setProcessExitCode(1);
@@ -106,7 +105,6 @@ export function registerProtocolCommands(program: Command): void {
       "Structured reporter output: json-summary or junit-xml",
     )
     .action(async (options, command) => {
-      const format = getFormat(command);
       const reporter = parseReporterFormat(options.reporter as string | undefined);
       const config = loadProtocolSuiteConfig(options.config as string);
       const result = await new MCPConformanceSuite(config).run();
@@ -114,7 +112,7 @@ export function registerProtocolCommands(program: Command): void {
       writeConformanceOutput(
         reporter
           ? renderConformanceReporterResult(result, reporter)
-          : renderConformanceResult(result, format),
+          : renderConformanceResult(result, getFormat(command)),
       );
       if (!result.passed) {
         setProcessExitCode(1);

--- a/cli/src/commands/conformance.ts
+++ b/cli/src/commands/conformance.ts
@@ -8,10 +8,12 @@ import {
 import { Command } from "commander";
 import { loadProtocolSuiteConfig } from "../lib/config-file.js";
 import {
+  renderConformanceReporterResult,
   renderConformanceResult,
   resolveConformanceOutputFormat,
   type ConformanceOutputFormat,
 } from "../lib/conformance-output.js";
+import { parseReporterFormat } from "../lib/reporting.js";
 import {
   parseHeadersOption,
   parsePositiveInteger,
@@ -73,12 +75,21 @@ export function registerProtocolCommands(program: Command): void {
       (value: string, previous: string[] = []) => [...previous, value],
       [],
     )
+    .option(
+      "--reporter <reporter>",
+      "Structured reporter output: json-summary or junit-xml",
+    )
     .action(async (options, command) => {
       const format = getFormat(command);
+      const reporter = parseReporterFormat(options.reporter as string | undefined);
       const config = buildConfig(options as ProtocolConformanceOptions);
       const result = await new MCPConformanceTest(config).run();
 
-      writeConformanceOutput(renderConformanceResult(result, format));
+      writeConformanceOutput(
+        reporter
+          ? renderConformanceReporterResult(result, reporter)
+          : renderConformanceResult(result, format),
+      );
       if (!result.passed) {
         setProcessExitCode(1);
       }
@@ -90,12 +101,21 @@ export function registerProtocolCommands(program: Command): void {
       "Run a matrix of MCP protocol conformance checks from a JSON config file",
     )
     .requiredOption("--config <path>", "Path to JSON config file")
+    .option(
+      "--reporter <reporter>",
+      "Structured reporter output: json-summary or junit-xml",
+    )
     .action(async (options, command) => {
       const format = getFormat(command);
+      const reporter = parseReporterFormat(options.reporter as string | undefined);
       const config = loadProtocolSuiteConfig(options.config as string);
       const result = await new MCPConformanceSuite(config).run();
 
-      writeConformanceOutput(renderConformanceResult(result, format));
+      writeConformanceOutput(
+        reporter
+          ? renderConformanceReporterResult(result, reporter)
+          : renderConformanceResult(result, format),
+      );
       if (!result.passed) {
         setProcessExitCode(1);
       }

--- a/cli/src/commands/conformance.ts
+++ b/cli/src/commands/conformance.ts
@@ -8,9 +8,8 @@ import {
 import { Command } from "commander";
 import { loadProtocolSuiteConfig } from "../lib/config-file.js";
 import {
-  renderConformanceReporterResult,
-  renderConformanceResult,
-  resolveConformanceOutputFormat,
+  renderConformanceForCli,
+  resolveConformanceOutputFormatForCli,
   type ConformanceOutputFormat,
 } from "../lib/conformance-output.js";
 import { parseReporterFormat } from "../lib/reporting.js";
@@ -81,14 +80,11 @@ export function registerProtocolCommands(program: Command): void {
     )
     .action(async (options, command) => {
       const reporter = parseReporterFormat(options.reporter as string | undefined);
+      const format = getFormat(command, reporter);
       const config = buildConfig(options as ProtocolConformanceOptions);
       const result = await new MCPConformanceTest(config).run();
 
-      writeConformanceOutput(
-        reporter
-          ? renderConformanceReporterResult(result, reporter)
-          : renderConformanceResult(result, getFormat(command)),
-      );
+      writeConformanceOutput(renderConformanceForCli(result, reporter, format));
       if (!result.passed) {
         setProcessExitCode(1);
       }
@@ -106,23 +102,27 @@ export function registerProtocolCommands(program: Command): void {
     )
     .action(async (options, command) => {
       const reporter = parseReporterFormat(options.reporter as string | undefined);
+      const format = getFormat(command, reporter);
       const config = loadProtocolSuiteConfig(options.config as string);
       const result = await new MCPConformanceSuite(config).run();
 
-      writeConformanceOutput(
-        reporter
-          ? renderConformanceReporterResult(result, reporter)
-          : renderConformanceResult(result, getFormat(command)),
-      );
+      writeConformanceOutput(renderConformanceForCli(result, reporter, format));
       if (!result.passed) {
         setProcessExitCode(1);
       }
     });
 }
 
-function getFormat(command: Command): ConformanceOutputFormat {
+function getFormat(
+  command: Command,
+  reporter: ReturnType<typeof parseReporterFormat>,
+): ConformanceOutputFormat {
   const opts = command.optsWithGlobals() as { format?: string };
-  return resolveConformanceOutputFormat(opts.format, process.stdout.isTTY);
+  return resolveConformanceOutputFormatForCli(
+    opts.format,
+    process.stdout.isTTY,
+    reporter,
+  );
 }
 
 function writeConformanceOutput(output: string): void {

--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -12,6 +12,7 @@ import {
 } from "@mcpjam/sdk";
 import { Command } from "commander";
 import {
+  getGlobalOptions,
   parseHeadersOption,
   parsePositiveInteger,
 } from "../lib/server-config.js";
@@ -33,6 +34,9 @@ import {
   resolveOAuthOutputFormat,
   type OAuthOutputFormat,
 } from "../lib/oauth-output.js";
+import { renderConformanceReporterResult } from "../lib/conformance-output.js";
+import { readInputSource } from "../lib/json-input.js";
+import { parseReporterFormat } from "../lib/reporting.js";
 import {
   buildCommandArtifactError,
   type DebugArtifactOutcome,
@@ -58,13 +62,7 @@ function getOAuthFormat(command: Command): OAuthOutputFormat {
 }
 
 function getStructuredOAuthFormat(command: Command): "json" | "human" {
-  const format = getOAuthFormat(command);
-  if (format === "junit-xml") {
-    throw usageError(
-      'The oauth metadata/proxy commands only support --format "json" or "human".',
-    );
-  }
-  return format;
+  return getOAuthFormat(command);
 }
 
 function writeOAuthOutput(output: string): void {
@@ -193,6 +191,7 @@ export function registerOAuthCommands(program: Command): void {
       "Write OAuth credentials to <path> (mode 0600); stdout output has secret fields redacted to [SAVED_TO_FILE]",
     )
     .action(async (options, command) => {
+      const globalOptions = getGlobalOptions(command);
       const format = getStructuredOAuthFormat(command);
       const config = buildOAuthLoginConfig(
         options as OAuthCommandOptions,
@@ -203,7 +202,7 @@ export function registerOAuthCommands(program: Command): void {
       const snapshotCollector = options.debugOut
         ? createCliRpcLogCollector({ __cli__: config.serverUrl })
         : undefined;
-      const isTTY = process.stderr.isTTY;
+      const isTTY = process.stderr.isTTY && !globalOptions.quiet;
       if (isTTY) {
         config.onProgress = (message: string) => {
           process.stderr.write(`\r\x1b[K${message}`);
@@ -250,6 +249,7 @@ export function registerOAuthCommands(program: Command): void {
       await writeCommandDebugArtifact({
         outputPath: options.debugOut as string | undefined,
         format,
+        quiet: globalOptions.quiet,
         commandName: "oauth login",
         commandInput: summarizeOAuthLoginCommandInput(
           options as OAuthCommandOptions,
@@ -348,12 +348,21 @@ export function registerOAuthCommands(program: Command): void {
       "--print-url",
       "In interactive mode, print the consent URL to stderr instead of launching a browser",
     )
+    .option(
+      "--reporter <reporter>",
+      "Structured reporter output: json-summary or junit-xml",
+    )
     .action(async (options, command) => {
       const format = getOAuthFormat(command);
+      const reporter = parseReporterFormat(options.reporter as string | undefined);
       const config = buildOAuthConformanceConfig(options as OAuthCommandOptions);
       const result = await new OAuthConformanceTest(config).run();
 
-      writeOAuthOutput(renderOAuthConformanceResult(result, format));
+      writeOAuthOutput(
+        reporter
+          ? renderConformanceReporterResult(result, reporter)
+          : renderOAuthConformanceResult(result, format),
+      );
       if (!result.passed) {
         setProcessExitCode(1);
       }
@@ -373,8 +382,13 @@ export function registerOAuthCommands(program: Command): void {
       "--verify-call-tool <name>",
       "Also call the named tool after listing",
     )
+    .option(
+      "--reporter <reporter>",
+      "Structured reporter output: json-summary or junit-xml",
+    )
     .action(async (options, command) => {
       const format = getOAuthFormat(command);
+      const reporter = parseReporterFormat(options.reporter as string | undefined);
       const config = loadOAuthSuiteConfig(options.config as string);
 
       if (options.verifyTools || options.verifyCallTool) {
@@ -397,7 +411,11 @@ export function registerOAuthCommands(program: Command): void {
       const suite = new OAuthConformanceSuite(config);
       const result = await suite.run();
 
-      writeOAuthOutput(renderOAuthConformanceSuiteResult(result, format));
+      writeOAuthOutput(
+        reporter
+          ? renderConformanceReporterResult(result, reporter)
+          : renderOAuthConformanceSuiteResult(result, format),
+      );
       if (!result.passed) {
         setProcessExitCode(1);
       }
@@ -423,7 +441,10 @@ export function registerOAuthCommands(program: Command): void {
       (value: string, previous: string[] = []) => [...previous, value],
       [],
     )
-    .option("--body <value>", "Request body as JSON or raw string")
+    .option(
+      "--body <value>",
+      "Request body as JSON, raw string, @path, or - for stdin",
+    )
     .action(async (options, command) => {
       const result = await runOAuthProxy(options as OAuthProxyCommandOptions);
       writeResult(result, getStructuredOAuthFormat(command));
@@ -440,7 +461,10 @@ export function registerOAuthCommands(program: Command): void {
       (value: string, previous: string[] = []) => [...previous, value],
       [],
     )
-    .option("--body <value>", "Request body as JSON or raw string")
+    .option(
+      "--body <value>",
+      "Request body as JSON, raw string, @path, or - for stdin",
+    )
     .action(async (options, command) => {
       const result = await runOAuthDebugProxy(
         options as OAuthProxyCommandOptions,
@@ -906,10 +930,12 @@ export function parseProxyBody(value: string | undefined): unknown {
     return undefined;
   }
 
+  const source = readInputSource(value, "Request body");
+
   try {
-    return JSON.parse(value);
+    return JSON.parse(source);
   } catch {
-    return value;
+    return source;
   }
 }
 

--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -61,17 +61,21 @@ const DYNAMIC_CLIENT_SECRET_PLACEHOLDER = "__dynamic_registration_secret__";
 
 function getOAuthFormat(
   command: Command,
-  reporter?: ReporterFormat,
 ): OAuthOutputFormat {
   const opts = command.optsWithGlobals() as { format?: string };
-  if (reporter) {
-    return resolveConformanceOutputFormatForCli(
-      opts.format,
-      process.stdout.isTTY,
-      reporter,
-    );
-  }
   return resolveOAuthOutputFormat(opts.format, process.stdout.isTTY);
+}
+
+function getOAuthConformanceFormat(
+  command: Command,
+  reporter: ReporterFormat | undefined,
+): OAuthOutputFormat {
+  const opts = command.optsWithGlobals() as { format?: string };
+  return resolveConformanceOutputFormatForCli(
+    opts.format,
+    process.stdout.isTTY,
+    reporter,
+  );
 }
 
 function writeOAuthOutput(output: string): void {
@@ -363,7 +367,7 @@ export function registerOAuthCommands(program: Command): void {
     )
     .action(async (options, command) => {
       const reporter = parseReporterFormat(options.reporter as string | undefined);
-      const format = getOAuthFormat(command, reporter);
+      const format = getOAuthConformanceFormat(command, reporter);
       const config = buildOAuthConformanceConfig(options as OAuthCommandOptions);
       const result = await new OAuthConformanceTest(config).run();
 
@@ -397,7 +401,7 @@ export function registerOAuthCommands(program: Command): void {
     )
     .action(async (options, command) => {
       const reporter = parseReporterFormat(options.reporter as string | undefined);
-      const format = getOAuthFormat(command, reporter);
+      const format = getOAuthConformanceFormat(command, reporter);
       const config = loadOAuthSuiteConfig(options.config as string);
 
       if (options.verifyTools || options.verifyCallTool) {
@@ -435,8 +439,9 @@ export function registerOAuthCommands(program: Command): void {
     .description("Fetch OAuth metadata from a URL")
     .requiredOption("--url <url>", "OAuth metadata URL")
     .action(async (options, command) => {
+      const format = getOAuthFormat(command);
       const result = await runOAuthMetadata(options.url as string);
-      writeResult(result, getOAuthFormat(command));
+      writeResult(result, format);
     });
 
   oauth
@@ -455,8 +460,9 @@ export function registerOAuthCommands(program: Command): void {
       "Request body as JSON, raw string, @path, or - for stdin",
     )
     .action(async (options, command) => {
+      const format = getOAuthFormat(command);
       const result = await runOAuthProxy(options as OAuthProxyCommandOptions);
-      writeResult(result, getOAuthFormat(command));
+      writeResult(result, format);
     });
 
   oauth
@@ -475,10 +481,11 @@ export function registerOAuthCommands(program: Command): void {
       "Request body as JSON, raw string, @path, or - for stdin",
     )
     .action(async (options, command) => {
+      const format = getOAuthFormat(command);
       const result = await runOAuthDebugProxy(
         options as OAuthProxyCommandOptions,
       );
-      writeResult(result, getOAuthFormat(command));
+      writeResult(result, format);
     });
 }
 

--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -34,9 +34,12 @@ import {
   resolveOAuthOutputFormat,
   type OAuthOutputFormat,
 } from "../lib/oauth-output.js";
-import { renderConformanceReporterResult } from "../lib/conformance-output.js";
+import {
+  renderConformanceReporterResult,
+  resolveConformanceOutputFormatForCli,
+} from "../lib/conformance-output.js";
 import { readInputSource } from "../lib/json-input.js";
-import { parseReporterFormat } from "../lib/reporting.js";
+import { parseReporterFormat, type ReporterFormat } from "../lib/reporting.js";
 import {
   buildCommandArtifactError,
   type DebugArtifactOutcome,
@@ -56,8 +59,18 @@ import type { MCPServerConfig, OAuthLoginResult } from "@mcpjam/sdk";
 const DYNAMIC_CLIENT_ID_PLACEHOLDER = "__dynamic_registration_client__";
 const DYNAMIC_CLIENT_SECRET_PLACEHOLDER = "__dynamic_registration_secret__";
 
-function getOAuthFormat(command: Command): OAuthOutputFormat {
+function getOAuthFormat(
+  command: Command,
+  reporter?: ReporterFormat,
+): OAuthOutputFormat {
   const opts = command.optsWithGlobals() as { format?: string };
+  if (reporter) {
+    return resolveConformanceOutputFormatForCli(
+      opts.format,
+      process.stdout.isTTY,
+      reporter,
+    );
+  }
   return resolveOAuthOutputFormat(opts.format, process.stdout.isTTY);
 }
 
@@ -350,13 +363,14 @@ export function registerOAuthCommands(program: Command): void {
     )
     .action(async (options, command) => {
       const reporter = parseReporterFormat(options.reporter as string | undefined);
+      const format = getOAuthFormat(command, reporter);
       const config = buildOAuthConformanceConfig(options as OAuthCommandOptions);
       const result = await new OAuthConformanceTest(config).run();
 
       writeOAuthOutput(
         reporter
           ? renderConformanceReporterResult(result, reporter)
-          : renderOAuthConformanceResult(result, getOAuthFormat(command)),
+          : renderOAuthConformanceResult(result, format),
       );
       if (!result.passed) {
         setProcessExitCode(1);
@@ -383,6 +397,7 @@ export function registerOAuthCommands(program: Command): void {
     )
     .action(async (options, command) => {
       const reporter = parseReporterFormat(options.reporter as string | undefined);
+      const format = getOAuthFormat(command, reporter);
       const config = loadOAuthSuiteConfig(options.config as string);
 
       if (options.verifyTools || options.verifyCallTool) {
@@ -408,7 +423,7 @@ export function registerOAuthCommands(program: Command): void {
       writeOAuthOutput(
         reporter
           ? renderConformanceReporterResult(result, reporter)
-          : renderOAuthConformanceSuiteResult(result, getOAuthFormat(command)),
+          : renderOAuthConformanceSuiteResult(result, format),
       );
       if (!result.passed) {
         setProcessExitCode(1);

--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -61,10 +61,6 @@ function getOAuthFormat(command: Command): OAuthOutputFormat {
   return resolveOAuthOutputFormat(opts.format, process.stdout.isTTY);
 }
 
-function getStructuredOAuthFormat(command: Command): "json" | "human" {
-  return getOAuthFormat(command);
-}
-
 function writeOAuthOutput(output: string): void {
   process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
 }
@@ -192,7 +188,7 @@ export function registerOAuthCommands(program: Command): void {
     )
     .action(async (options, command) => {
       const globalOptions = getGlobalOptions(command);
-      const format = getStructuredOAuthFormat(command);
+      const format = getOAuthFormat(command);
       const config = buildOAuthLoginConfig(
         options as OAuthCommandOptions,
         {
@@ -353,7 +349,6 @@ export function registerOAuthCommands(program: Command): void {
       "Structured reporter output: json-summary or junit-xml",
     )
     .action(async (options, command) => {
-      const format = getOAuthFormat(command);
       const reporter = parseReporterFormat(options.reporter as string | undefined);
       const config = buildOAuthConformanceConfig(options as OAuthCommandOptions);
       const result = await new OAuthConformanceTest(config).run();
@@ -361,7 +356,7 @@ export function registerOAuthCommands(program: Command): void {
       writeOAuthOutput(
         reporter
           ? renderConformanceReporterResult(result, reporter)
-          : renderOAuthConformanceResult(result, format),
+          : renderOAuthConformanceResult(result, getOAuthFormat(command)),
       );
       if (!result.passed) {
         setProcessExitCode(1);
@@ -387,7 +382,6 @@ export function registerOAuthCommands(program: Command): void {
       "Structured reporter output: json-summary or junit-xml",
     )
     .action(async (options, command) => {
-      const format = getOAuthFormat(command);
       const reporter = parseReporterFormat(options.reporter as string | undefined);
       const config = loadOAuthSuiteConfig(options.config as string);
 
@@ -414,7 +408,7 @@ export function registerOAuthCommands(program: Command): void {
       writeOAuthOutput(
         reporter
           ? renderConformanceReporterResult(result, reporter)
-          : renderOAuthConformanceSuiteResult(result, format),
+          : renderOAuthConformanceSuiteResult(result, getOAuthFormat(command)),
       );
       if (!result.passed) {
         setProcessExitCode(1);
@@ -427,7 +421,7 @@ export function registerOAuthCommands(program: Command): void {
     .requiredOption("--url <url>", "OAuth metadata URL")
     .action(async (options, command) => {
       const result = await runOAuthMetadata(options.url as string);
-      writeResult(result, getStructuredOAuthFormat(command));
+      writeResult(result, getOAuthFormat(command));
     });
 
   oauth
@@ -447,7 +441,7 @@ export function registerOAuthCommands(program: Command): void {
     )
     .action(async (options, command) => {
       const result = await runOAuthProxy(options as OAuthProxyCommandOptions);
-      writeResult(result, getStructuredOAuthFormat(command));
+      writeResult(result, getOAuthFormat(command));
     });
 
   oauth
@@ -469,7 +463,7 @@ export function registerOAuthCommands(program: Command): void {
       const result = await runOAuthDebugProxy(
         options as OAuthProxyCommandOptions,
       );
-      writeResult(result, getStructuredOAuthFormat(command));
+      writeResult(result, getOAuthFormat(command));
     });
 }
 

--- a/cli/src/commands/prompts.ts
+++ b/cli/src/commands/prompts.ts
@@ -63,7 +63,10 @@ export function registerPromptCommands(program: Command): void {
         .description("Get a named prompt from an MCP server")
         .option("--prompt-name <prompt>", "Prompt name")
         .option("--name <prompt>", "Alias for --prompt-name")
-        .option("--prompt-args <json>", "Prompt arguments as a JSON object"),
+        .option(
+          "--prompt-args <json>",
+          "Prompt arguments as JSON, @path, or - for stdin",
+        ),
     ),
   ).action(async (options, command) => {
     const globalOptions = getGlobalOptions(command);

--- a/cli/src/commands/server.ts
+++ b/cli/src/commands/server.ts
@@ -79,7 +79,7 @@ export function registerServerCommands(program: Command): void {
       )
       .option(
         "--client-capabilities <json>",
-        "Client capabilities advertised in the initialize probe as a JSON object",
+        "Client capabilities as JSON, @path, or - for stdin",
       )
       .option(
         "--protocol-version <version>",
@@ -154,6 +154,7 @@ export function registerServerCommands(program: Command): void {
       await writeCommandDebugArtifact({
         outputPath: options.debugOut as string | undefined,
         format: globalOptions.format,
+        quiet: globalOptions.quiet,
         commandName: "server probe",
         commandInput: {
           protocolVersion,
@@ -357,6 +358,7 @@ export function registerServerCommands(program: Command): void {
       await writeCommandDebugArtifact({
         outputPath: options.debugOut as string | undefined,
         format: globalOptions.format,
+        quiet: globalOptions.quiet,
         commandName: "server validate",
         commandInput: {},
         target: targetSummary,

--- a/cli/src/commands/tools.ts
+++ b/cli/src/commands/tools.ts
@@ -75,7 +75,10 @@ export function registerToolsCommands(program: Command): void {
       .description("Call an MCP tool")
       .option("--tool-name <tool>", "Tool name")
       .option("--name <tool>", "Alias for --tool-name")
-      .option("--tool-args <json>", "Tool parameter object as JSON")
+      .option(
+        "--tool-args <json>",
+        "Tool parameter object as JSON, @path, or - for stdin",
+      )
       .option("--params <json>", "Alias for --tool-args")
       .option(
         "--validate-response",
@@ -158,6 +161,7 @@ export function registerToolsCommands(program: Command): void {
     await writeCommandDebugArtifact({
       outputPath: options.debugOut as string | undefined,
       format: globalOptions.format,
+      quiet: globalOptions.quiet,
       commandName: "tools call",
       commandInput: {
         toolName,

--- a/cli/src/lib/conformance-output.ts
+++ b/cli/src/lib/conformance-output.ts
@@ -4,7 +4,11 @@ import {
   toConformanceReport,
   type SupportedConformanceResult,
 } from "@mcpjam/sdk";
-import { usageError, type OutputFormat } from "./output.js";
+import {
+  rejectReporterFormatAsOutputFormat,
+  usageError,
+  type OutputFormat,
+} from "./output.js";
 import type { ReporterFormat } from "./reporting.js";
 
 export type ConformanceOutputFormat = OutputFormat;
@@ -16,11 +20,7 @@ export function parseConformanceOutputFormat(
     return value;
   }
 
-  if (value === "junit-xml") {
-    throw usageError(
-      'Invalid output format "junit-xml". Use --reporter junit-xml for CI reporter output.',
-    );
-  }
+  rejectReporterFormatAsOutputFormat(value);
 
   throw usageError(
     `Invalid output format "${value}". Use "json" or "human".`,

--- a/cli/src/lib/conformance-output.ts
+++ b/cli/src/lib/conformance-output.ts
@@ -34,6 +34,28 @@ export function resolveConformanceOutputFormat(
   return parseConformanceOutputFormat(value ?? (isTTY ? "human" : "json"));
 }
 
+export function resolveConformanceOutputFormatForCli(
+  value: string | undefined,
+  isTTY: boolean | undefined,
+  reporter: ReporterFormat | undefined,
+): ConformanceOutputFormat {
+  if (reporter === undefined || value === undefined) {
+    return resolveConformanceOutputFormat(value, isTTY);
+  }
+
+  if (value === "json" || value === "human") {
+    return value;
+  }
+
+  if (value === "junit-xml" || value === "json-summary") {
+    return "json";
+  }
+
+  throw usageError(
+    `Invalid output format "${value}". Use "json" or "human".`,
+  );
+}
+
 export function renderConformanceResult(
   result: SupportedConformanceResult,
   format: ConformanceOutputFormat,
@@ -58,4 +80,14 @@ export function renderConformanceReporterResult(
     case "junit-xml":
       return renderConformanceReportJUnitXml(report);
   }
+}
+
+export function renderConformanceForCli(
+  result: SupportedConformanceResult,
+  reporter: ReporterFormat | undefined,
+  format: ConformanceOutputFormat,
+): string {
+  return reporter
+    ? renderConformanceReporterResult(result, reporter)
+    : renderConformanceResult(result, format);
 }

--- a/cli/src/lib/conformance-output.ts
+++ b/cli/src/lib/conformance-output.ts
@@ -1,21 +1,29 @@
 import {
+  renderConformanceReportJson,
   renderConformanceReportJUnitXml,
   toConformanceReport,
   type SupportedConformanceResult,
 } from "@mcpjam/sdk";
 import { usageError, type OutputFormat } from "./output.js";
+import type { ReporterFormat } from "./reporting.js";
 
-export type ConformanceOutputFormat = OutputFormat | "junit-xml";
+export type ConformanceOutputFormat = OutputFormat;
 
 export function parseConformanceOutputFormat(
   value: string,
 ): ConformanceOutputFormat {
-  if (value === "json" || value === "human" || value === "junit-xml") {
+  if (value === "json" || value === "human") {
     return value;
   }
 
+  if (value === "junit-xml") {
+    throw usageError(
+      'Invalid output format "junit-xml". Use --reporter junit-xml for CI reporter output.',
+    );
+  }
+
   throw usageError(
-    `Invalid output format "${value}". Use "json", "human", or "junit-xml".`,
+    `Invalid output format "${value}". Use "json" or "human".`,
   );
 }
 
@@ -35,7 +43,19 @@ export function renderConformanceResult(
       return JSON.stringify(result, null, 2);
     case "json":
       return JSON.stringify(result);
+  }
+}
+
+export function renderConformanceReporterResult(
+  result: SupportedConformanceResult,
+  reporter: ReporterFormat,
+): string {
+  const report = toConformanceReport(result);
+
+  switch (reporter) {
+    case "json-summary":
+      return JSON.stringify(renderConformanceReportJson(report));
     case "junit-xml":
-      return renderConformanceReportJUnitXml(toConformanceReport(result));
+      return renderConformanceReportJUnitXml(report);
   }
 }

--- a/cli/src/lib/debug-artifact.ts
+++ b/cli/src/lib/debug-artifact.ts
@@ -52,6 +52,7 @@ export interface CommandDebugArtifactOptions<TTarget = unknown> {
   commandInput: unknown;
   target: TTarget;
   outcome: DebugArtifactOutcome;
+  quiet?: boolean;
   snapshot?: {
     input: RunServerDoctorInput<TTarget>;
     collector?: CliRpcLogCollector;
@@ -87,7 +88,7 @@ export async function writeCommandDebugArtifact<TTarget = unknown>(
   });
   const artifactPath = await writeDebugArtifact(options.outputPath, payload);
 
-  if (options.format === "human") {
+  if (options.format === "human" && !options.quiet) {
     process.stderr.write(`Debug artifact: ${artifactPath}\n`);
   }
 

--- a/cli/src/lib/json-input.ts
+++ b/cli/src/lib/json-input.ts
@@ -1,73 +1,107 @@
 import { readFileSync } from "node:fs";
 import { usageError } from "./output.js";
 
-let stdinConsumer: string | undefined;
+export type JsonInputReadFile = (
+  path: Parameters<typeof readFileSync>[0],
+  encoding: BufferEncoding,
+) => string;
 
-export function resetJsonInputStdinForTests(): void {
-  stdinConsumer = undefined;
-}
+const readTextFile: JsonInputReadFile = (path, encoding) =>
+  readFileSync(path, encoding);
 
-export function readInputSource(value: string, label: string): string {
-  if (value === "-") {
-    if (stdinConsumer) {
-      throw usageError(
-        `Cannot read ${label} from stdin because stdin was already consumed by ${stdinConsumer}. Use @file for one of the JSON inputs.`,
-      );
+export class JsonInputContext {
+  private stdinConsumer: string | undefined;
+
+  constructor(private readonly readFile: JsonInputReadFile = readTextFile) {}
+
+  readInputSource(value: string, label: string): string {
+    if (value === "-") {
+      if (this.stdinConsumer) {
+        throw usageError(
+          `Cannot read ${label} from stdin because stdin was already consumed by ${this.stdinConsumer}. Use @file for one of the JSON inputs.`,
+        );
+      }
+
+      this.stdinConsumer = label;
+      try {
+        return this.readFile(0, "utf8");
+      } catch (error) {
+        throw usageError(`Failed to read ${label} from stdin.`, {
+          source: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
 
-    stdinConsumer = label;
-    return readFileSync(0, "utf8");
+    if (!value.startsWith("@")) {
+      return value;
+    }
+
+    const filePath = value.slice(1);
+    if (!filePath) {
+      throw usageError(`${label} file path is required after @.`);
+    }
+
+    try {
+      return this.readFile(filePath, "utf8");
+    } catch (error) {
+      throw usageError(`Failed to read ${label} file "${filePath}".`, {
+        source: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
-  if (!value.startsWith("@")) {
-    return value;
+  parseJsonInputValue(value: string | undefined, label: string): unknown {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    const source = this.readInputSource(value, label);
+    if (source.trim() === "") {
+      throw usageError(`${label} input is empty.`);
+    }
+
+    try {
+      return JSON.parse(source);
+    } catch (error) {
+      throw usageError(`${label} must be valid JSON.`, {
+        source: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
-  const filePath = value.slice(1);
-  if (!filePath) {
-    throw usageError(`${label} file path is required after @.`);
-  }
+  parseJsonInputRecord(
+    value: string | undefined,
+    label: string,
+  ): Record<string, unknown> | undefined {
+    const parsed = this.parseJsonInputValue(value, label);
+    if (parsed === undefined) {
+      return undefined;
+    }
 
-  try {
-    return readFileSync(filePath, "utf8");
-  } catch (error) {
-    throw usageError(`Failed to read ${label} file "${filePath}".`, {
-      source: error instanceof Error ? error.message : String(error),
-    });
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw usageError(`${label} must be a JSON object.`);
+    }
+
+    return parsed as Record<string, unknown>;
   }
+}
+
+const defaultJsonInputContext = new JsonInputContext();
+
+export function readInputSource(value: string, label: string): string {
+  return defaultJsonInputContext.readInputSource(value, label);
 }
 
 export function parseJsonInputValue(
   value: string | undefined,
   label: string,
 ): unknown {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  const source = readInputSource(value, label);
-
-  try {
-    return JSON.parse(source);
-  } catch (error) {
-    throw usageError(`${label} must be valid JSON.`, {
-      source: error instanceof Error ? error.message : String(error),
-    });
-  }
+  return defaultJsonInputContext.parseJsonInputValue(value, label);
 }
 
 export function parseJsonInputRecord(
   value: string | undefined,
   label: string,
 ): Record<string, unknown> | undefined {
-  const parsed = parseJsonInputValue(value, label);
-  if (parsed === undefined) {
-    return undefined;
-  }
-
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw usageError(`${label} must be a JSON object.`);
-  }
-
-  return parsed as Record<string, unknown>;
+  return defaultJsonInputContext.parseJsonInputRecord(value, label);
 }

--- a/cli/src/lib/json-input.ts
+++ b/cli/src/lib/json-input.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from "node:fs";
+import { usageError } from "./output.js";
+
+let stdinConsumer: string | undefined;
+
+export function resetJsonInputStdinForTests(): void {
+  stdinConsumer = undefined;
+}
+
+export function readInputSource(value: string, label: string): string {
+  if (value === "-") {
+    if (stdinConsumer) {
+      throw usageError(
+        `Cannot read ${label} from stdin because stdin was already consumed by ${stdinConsumer}. Use @file for one of the JSON inputs.`,
+      );
+    }
+
+    stdinConsumer = label;
+    return readFileSync(0, "utf8");
+  }
+
+  if (!value.startsWith("@")) {
+    return value;
+  }
+
+  const filePath = value.slice(1);
+  if (!filePath) {
+    throw usageError(`${label} file path is required after @.`);
+  }
+
+  try {
+    return readFileSync(filePath, "utf8");
+  } catch (error) {
+    throw usageError(`Failed to read ${label} file "${filePath}".`, {
+      source: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export function parseJsonInputValue(
+  value: string | undefined,
+  label: string,
+): unknown {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const source = readInputSource(value, label);
+
+  try {
+    return JSON.parse(source);
+  } catch (error) {
+    throw usageError(`${label} must be valid JSON.`, {
+      source: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export function parseJsonInputRecord(
+  value: string | undefined,
+  label: string,
+): Record<string, unknown> | undefined {
+  const parsed = parseJsonInputValue(value, label);
+  if (parsed === undefined) {
+    return undefined;
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw usageError(`${label} must be a JSON object.`);
+  }
+
+  return parsed as Record<string, unknown>;
+}

--- a/cli/src/lib/json-input.ts
+++ b/cli/src/lib/json-input.ts
@@ -22,9 +22,10 @@ export class JsonInputContext {
         );
       }
 
-      this.stdinConsumer = label;
       try {
-        return this.readFile(0, "utf8");
+        const contents = this.readFile(0, "utf8");
+        this.stdinConsumer = label;
+        return contents;
       } catch (error) {
         throw usageError(`Failed to read ${label} from stdin.`, {
           source: error instanceof Error ? error.message : String(error),

--- a/cli/src/lib/oauth-output.ts
+++ b/cli/src/lib/oauth-output.ts
@@ -5,7 +5,6 @@ import {
   type OAuthConformanceSuiteResult,
 } from "@mcpjam/sdk";
 import {
-  rejectReporterFormatAsOutputFormat,
   usageError,
   type OutputFormat,
 } from "./output.js";
@@ -16,8 +15,6 @@ export function parseOAuthOutputFormat(value: string): OAuthOutputFormat {
   if (value === "json" || value === "human") {
     return value;
   }
-
-  rejectReporterFormatAsOutputFormat(value);
 
   throw usageError(
     `Invalid output format "${value}". Use "json" or "human".`,

--- a/cli/src/lib/oauth-output.ts
+++ b/cli/src/lib/oauth-output.ts
@@ -1,22 +1,26 @@
 import {
   formatOAuthConformanceHuman,
   formatOAuthConformanceSuiteHuman,
-  renderConformanceReportJUnitXml,
   type ConformanceResult,
   type OAuthConformanceSuiteResult,
-  toConformanceReport,
 } from "@mcpjam/sdk";
 import { usageError, type OutputFormat } from "./output.js";
 
-export type OAuthOutputFormat = OutputFormat | "junit-xml";
+export type OAuthOutputFormat = OutputFormat;
 
 export function parseOAuthOutputFormat(value: string): OAuthOutputFormat {
-  if (value === "json" || value === "human" || value === "junit-xml") {
+  if (value === "json" || value === "human") {
     return value;
   }
 
+  if (value === "junit-xml") {
+    throw usageError(
+      'Invalid output format "junit-xml". Use --reporter junit-xml for CI reporter output.',
+    );
+  }
+
   throw usageError(
-    `Invalid output format "${value}". Use "json", "human", or "junit-xml".`,
+    `Invalid output format "${value}". Use "json" or "human".`,
   );
 }
 
@@ -34,8 +38,6 @@ export function renderOAuthConformanceResult(
   switch (format) {
     case "human":
       return formatOAuthConformanceHuman(result);
-    case "junit-xml":
-      return renderConformanceReportJUnitXml(toConformanceReport(result));
     case "json":
       return JSON.stringify(result);
   }
@@ -48,8 +50,6 @@ export function renderOAuthConformanceSuiteResult(
   switch (format) {
     case "human":
       return formatOAuthConformanceSuiteHuman(result);
-    case "junit-xml":
-      return renderConformanceReportJUnitXml(toConformanceReport(result));
     case "json":
       return JSON.stringify(result);
   }

--- a/cli/src/lib/oauth-output.ts
+++ b/cli/src/lib/oauth-output.ts
@@ -4,7 +4,11 @@ import {
   type ConformanceResult,
   type OAuthConformanceSuiteResult,
 } from "@mcpjam/sdk";
-import { usageError, type OutputFormat } from "./output.js";
+import {
+  rejectReporterFormatAsOutputFormat,
+  usageError,
+  type OutputFormat,
+} from "./output.js";
 
 export type OAuthOutputFormat = OutputFormat;
 
@@ -13,11 +17,7 @@ export function parseOAuthOutputFormat(value: string): OAuthOutputFormat {
     return value;
   }
 
-  if (value === "junit-xml") {
-    throw usageError(
-      'Invalid output format "junit-xml". Use --reporter junit-xml for CI reporter output.',
-    );
-  }
+  rejectReporterFormatAsOutputFormat(value);
 
   throw usageError(
     `Invalid output format "${value}". Use "json" or "human".`,

--- a/cli/src/lib/output.ts
+++ b/cli/src/lib/output.ts
@@ -133,9 +133,9 @@ export function parseOutputFormat(value: string): OutputFormat {
 }
 
 export function rejectReporterFormatAsOutputFormat(value: string): void {
-  if (value === "junit-xml") {
+  if (value === "junit-xml" || value === "json-summary") {
     throw usageError(
-      'Invalid output format "junit-xml". Use --reporter junit-xml for CI reporter output.',
+      `Invalid output format "${value}". Use --reporter ${value} for CI reporter output.`,
     );
   }
 }

--- a/cli/src/lib/output.ts
+++ b/cli/src/lib/output.ts
@@ -127,13 +127,17 @@ export function parseOutputFormat(value: string): OutputFormat {
     return value;
   }
 
+  rejectReporterFormatAsOutputFormat(value);
+
+  throw usageError(`Invalid output format "${value}". Use "json" or "human".`);
+}
+
+export function rejectReporterFormatAsOutputFormat(value: string): void {
   if (value === "junit-xml") {
     throw usageError(
       'Invalid output format "junit-xml". Use --reporter junit-xml for CI reporter output.',
     );
   }
-
-  throw usageError(`Invalid output format "${value}". Use "json" or "human".`);
 }
 
 export function resolveOutputFormat(

--- a/cli/src/lib/output.ts
+++ b/cli/src/lib/output.ts
@@ -127,6 +127,12 @@ export function parseOutputFormat(value: string): OutputFormat {
     return value;
   }
 
+  if (value === "junit-xml") {
+    throw usageError(
+      'Invalid output format "junit-xml". Use --reporter junit-xml for CI reporter output.',
+    );
+  }
+
   throw usageError(`Invalid output format "${value}". Use "json" or "human".`);
 }
 

--- a/cli/src/lib/server-config.ts
+++ b/cli/src/lib/server-config.ts
@@ -9,11 +9,13 @@ import {
   assertNoCredentialsFileAuthConflicts,
   resolveCredentialsFileAuth,
 } from "./credentials-file.js";
+import { parseJsonInputRecord } from "./json-input.js";
 
 export interface GlobalOptions {
   format: OutputFormat;
   timeout: number;
   rpc: boolean;
+  quiet: boolean;
 }
 
 type TransportType = "http" | "stdio";
@@ -78,7 +80,7 @@ export function addSharedServerOptions(command: Command): Command {
     )
     .option(
       "--client-capabilities <json>",
-      "Client capabilities advertised to the server as a JSON object",
+      "Client capabilities as JSON, @path, or - for stdin",
     )
     .option("--command <command>", "Command for a stdio MCP server")
     .option(
@@ -106,6 +108,7 @@ export function getGlobalOptions(command: Command): GlobalOptions {
     ),
     timeout: options.timeout ?? 30_000,
     rpc: options.rpc ?? false,
+    quiet: options.quiet ?? false,
   };
 }
 
@@ -177,24 +180,7 @@ export function parseJsonRecord(
   value: string | undefined,
   label: string,
 ): Record<string, unknown> | undefined {
-  if (value === undefined) {
-    return undefined;
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(value);
-  } catch (error) {
-    throw usageError(`${label} must be valid JSON.`, {
-      source: error instanceof Error ? error.message : String(error),
-    });
-  }
-
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw usageError(`${label} must be a JSON object.`);
-  }
-
-  return parsed as Record<string, unknown>;
+  return parseJsonInputRecord(value, label);
 }
 
 export function parseUnknownRecord(
@@ -383,6 +369,7 @@ export function addGlobalOptions(program: Command): Command {
       30_000,
     )
     .option("--rpc", "Include RPC logs in JSON output")
+    .option("--quiet", "Suppress non-result progress output")
     .option("--format <format>", "Output format");
 }
 

--- a/cli/tests/agent-friendly-cli.test.ts
+++ b/cli/tests/agent-friendly-cli.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import path from "node:path";
+import test from "node:test";
+import { startMockStreamableHttpServer } from "../../sdk/tests/mock-servers/index.js";
+
+const CLI_DIR = process.cwd().endsWith(`${path.sep}cli`)
+  ? process.cwd()
+  : path.join(process.cwd(), "cli");
+const requireFromCli = createRequire(path.join(CLI_DIR, "package.json"));
+const TSX_CLI_PATH = requireFromCli.resolve("tsx/cli");
+const CLI_ENTRY_PATH = path.join(CLI_DIR, "src", "index.ts");
+
+async function runCli(
+  args: string[],
+  input?: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [TSX_CLI_PATH, CLI_ENTRY_PATH, ...args], {
+      cwd: CLI_DIR,
+      env: { ...process.env, MCPJAM_CLI_DISABLE_BROWSER_OPEN: "1" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ exitCode: code ?? 0, stdout, stderr });
+    });
+
+    child.stdin.end(input ?? "");
+  });
+}
+
+test("--format junit-xml is rejected for conformance commands", async () => {
+  const protocol = await runCli([
+    "--format",
+    "junit-xml",
+    "protocol",
+    "conformance",
+    "--url",
+    "https://example.com/mcp",
+  ]);
+  assert.equal(protocol.exitCode, 2);
+  assert.match(protocol.stderr, /--reporter junit-xml/);
+
+  const oauth = await runCli([
+    "--format",
+    "junit-xml",
+    "oauth",
+    "conformance",
+    "--url",
+    "https://example.com/mcp",
+    "--protocol-version",
+    "2025-11-25",
+    "--registration",
+    "dcr",
+  ]);
+  assert.equal(oauth.exitCode, 2);
+  assert.match(oauth.stderr, /--reporter junit-xml/);
+
+  const apps = await runCli([
+    "--format",
+    "junit-xml",
+    "apps",
+    "conformance",
+    "--url",
+    "https://example.com/mcp",
+  ]);
+  assert.equal(apps.exitCode, 2);
+  assert.match(apps.stderr, /--reporter junit-xml/);
+});
+
+test("protocol conformance supports junit reporter output", async () => {
+  const server = await startMockStreamableHttpServer();
+
+  try {
+    const result = await runCli([
+      "--format",
+      "json",
+      "protocol",
+      "conformance",
+      "--url",
+      server.url,
+      "--check-id",
+      "ping",
+      "--reporter",
+      "junit-xml",
+    ]);
+
+    assert.notEqual(result.exitCode, 2, result.stderr);
+    assert.match(result.stdout, /^<\?xml version="1\.0"/);
+    assert.match(result.stdout, /<testsuites/);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("JSON options accept stdin and reject duplicate stdin consumers", async () => {
+  const valid = await runCli(
+    [
+      "--format",
+      "json",
+      "server",
+      "probe",
+      "--url",
+      "http://127.0.0.1:9/mcp",
+      "--timeout",
+      "1",
+      "--client-capabilities",
+      "-",
+    ],
+    '{"sampling":{}}\n',
+  );
+  assert.notEqual(valid.exitCode, 2);
+
+  const invalid = await runCli(
+    [
+      "--format",
+      "json",
+      "server",
+      "probe",
+      "--url",
+      "http://127.0.0.1:9/mcp",
+      "--timeout",
+      "1",
+      "--client-capabilities",
+      "-",
+    ],
+    "{",
+  );
+  assert.equal(invalid.exitCode, 2);
+  assert.match(invalid.stderr, /Client capabilities must be valid JSON/);
+
+  const duplicate = await runCli(
+    [
+      "--format",
+      "json",
+      "tools",
+      "call",
+      "--command",
+      "node",
+      "--client-capabilities",
+      "-",
+      "--tool-name",
+      "echo",
+      "--tool-args",
+      "-",
+    ],
+    '{"sampling":{}}\n',
+  );
+  assert.equal(duplicate.exitCode, 2);
+  assert.match(duplicate.stderr, /stdin was already consumed/);
+});

--- a/cli/tests/agent-friendly-cli.test.ts
+++ b/cli/tests/agent-friendly-cli.test.ts
@@ -34,8 +34,12 @@ async function runCli(
       stderr += chunk;
     });
     child.on("error", reject);
-    child.on("close", (code) => {
-      resolve({ exitCode: code ?? 0, stdout, stderr });
+    child.on("close", (code, signal) => {
+      if (code === null) {
+        reject(new Error(`CLI terminated by signal ${signal}`));
+        return;
+      }
+      resolve({ exitCode: code, stdout, stderr });
     });
 
     child.stdin.end(input ?? "");
@@ -87,7 +91,7 @@ test("protocol conformance supports junit reporter output", async () => {
   try {
     const result = await runCli([
       "--format",
-      "json",
+      "junit-xml",
       "protocol",
       "conformance",
       "--url",
@@ -101,6 +105,7 @@ test("protocol conformance supports junit reporter output", async () => {
     assert.notEqual(result.exitCode, 2, result.stderr);
     assert.match(result.stdout, /^<\?xml version="1\.0"/);
     assert.match(result.stdout, /<testsuites/);
+    assert.doesNotMatch(result.stdout, /^\{/);
   } finally {
     await server.stop();
   }

--- a/cli/tests/agent-friendly-cli.test.ts
+++ b/cli/tests/agent-friendly-cli.test.ts
@@ -111,6 +111,54 @@ test("protocol conformance supports junit reporter output", async () => {
   }
 });
 
+test("conformance commands reject unknown formats before reporter output", async () => {
+  const protocol = await runCli([
+    "--format",
+    "xml",
+    "protocol",
+    "conformance",
+    "--url",
+    "https://example.com/mcp",
+    "--reporter",
+    "junit-xml",
+  ]);
+  assert.equal(protocol.exitCode, 2);
+  assert.match(protocol.stderr, /Invalid output format/);
+  assert.match(protocol.stderr, /xml/);
+
+  const oauth = await runCli([
+    "--format",
+    "xml",
+    "oauth",
+    "conformance",
+    "--url",
+    "https://example.com/mcp",
+    "--protocol-version",
+    "2025-11-25",
+    "--registration",
+    "dcr",
+    "--reporter",
+    "junit-xml",
+  ]);
+  assert.equal(oauth.exitCode, 2);
+  assert.match(oauth.stderr, /Invalid output format/);
+  assert.match(oauth.stderr, /xml/);
+
+  const apps = await runCli([
+    "--format",
+    "xml",
+    "apps",
+    "conformance",
+    "--url",
+    "https://example.com/mcp",
+    "--reporter",
+    "junit-xml",
+  ]);
+  assert.equal(apps.exitCode, 2);
+  assert.match(apps.stderr, /Invalid output format/);
+  assert.match(apps.stderr, /xml/);
+});
+
 test("JSON options accept stdin and reject duplicate stdin consumers", async () => {
   const valid = await runCli(
     [

--- a/cli/tests/agent-friendly-cli.test.ts
+++ b/cli/tests/agent-friendly-cli.test.ts
@@ -159,6 +159,32 @@ test("conformance commands reject unknown formats before reporter output", async
   assert.match(apps.stderr, /xml/);
 });
 
+test("OAuth raw commands reject reporter formats without suggesting unsupported reporter", async () => {
+  const metadata = await runCli([
+    "--format",
+    "junit-xml",
+    "oauth",
+    "metadata",
+    "--url",
+    "https://example.com/.well-known/oauth-protected-resource",
+  ]);
+  assert.equal(metadata.exitCode, 2);
+  assert.match(metadata.stderr, /Use \\"json\\" or \\"human\\"/);
+  assert.doesNotMatch(metadata.stderr, /--reporter/);
+
+  const proxy = await runCli([
+    "--format",
+    "json-summary",
+    "oauth",
+    "proxy",
+    "--url",
+    "https://example.com/token",
+  ]);
+  assert.equal(proxy.exitCode, 2);
+  assert.match(proxy.stderr, /Use \\"json\\" or \\"human\\"/);
+  assert.doesNotMatch(proxy.stderr, /--reporter/);
+});
+
 test("JSON options accept stdin and reject duplicate stdin consumers", async () => {
   const valid = await runCli(
     [

--- a/cli/tests/conformance-output.test.ts
+++ b/cli/tests/conformance-output.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  renderConformanceReportJson,
   renderConformanceReportJUnitXml,
   toConformanceReport,
   type MCPAppsConformanceResult,
@@ -8,6 +9,7 @@ import {
 } from "@mcpjam/sdk";
 import {
   parseConformanceOutputFormat,
+  renderConformanceReporterResult,
   renderConformanceResult,
   resolveConformanceOutputFormat,
 } from "../src/lib/conformance-output.js";
@@ -85,7 +87,6 @@ function createAppsResult(): MCPAppsConformanceResult {
 test("resolveConformanceOutputFormat defaults to human on TTY and json otherwise", () => {
   assert.equal(resolveConformanceOutputFormat(undefined, true), "human");
   assert.equal(resolveConformanceOutputFormat(undefined, false), "json");
-  assert.equal(resolveConformanceOutputFormat("junit-xml", true), "junit-xml");
 });
 
 test("parseConformanceOutputFormat rejects unsupported formats", () => {
@@ -94,14 +95,24 @@ test("parseConformanceOutputFormat rejects unsupported formats", () => {
     (error) =>
       error instanceof CliError && error.message.includes("Invalid output format"),
   );
+  assert.throws(
+    () => parseConformanceOutputFormat("junit-xml"),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("Use --reporter junit-xml"),
+  );
 });
 
-test("renderConformanceResult uses byte-identical JUnit XML from the shared SDK helper", () => {
+test("renderConformanceReporterResult emits conformance reporter output", () => {
   const result = createProtocolResult();
 
   assert.equal(
-    renderConformanceResult(result, "junit-xml"),
+    renderConformanceReporterResult(result, "junit-xml"),
     renderConformanceReportJUnitXml(toConformanceReport(result)),
+  );
+  assert.equal(
+    renderConformanceReporterResult(result, "json-summary"),
+    JSON.stringify(renderConformanceReportJson(toConformanceReport(result))),
   );
 });
 

--- a/cli/tests/conformance-output.test.ts
+++ b/cli/tests/conformance-output.test.ts
@@ -9,9 +9,11 @@ import {
 } from "@mcpjam/sdk";
 import {
   parseConformanceOutputFormat,
+  renderConformanceForCli,
   renderConformanceReporterResult,
   renderConformanceResult,
   resolveConformanceOutputFormat,
+  resolveConformanceOutputFormatForCli,
 } from "../src/lib/conformance-output.js";
 import { CliError } from "../src/lib/output.js";
 
@@ -101,6 +103,32 @@ test("parseConformanceOutputFormat rejects unsupported formats", () => {
       error instanceof CliError &&
       error.message.includes("Use --reporter junit-xml"),
   );
+  assert.throws(
+    () => parseConformanceOutputFormat("json-summary"),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("Use --reporter json-summary"),
+  );
+});
+
+test("resolveConformanceOutputFormatForCli validates format before reporter output", () => {
+  assert.equal(
+    resolveConformanceOutputFormatForCli("json", false, "junit-xml"),
+    "json",
+  );
+  assert.equal(
+    resolveConformanceOutputFormatForCli("junit-xml", false, "junit-xml"),
+    "json",
+  );
+  assert.equal(
+    resolveConformanceOutputFormatForCli("json-summary", false, "junit-xml"),
+    "json",
+  );
+  assert.throws(
+    () => resolveConformanceOutputFormatForCli("typo", false, "junit-xml"),
+    (error) =>
+      error instanceof CliError && error.message.includes("Invalid output format"),
+  );
 });
 
 test("renderConformanceReporterResult emits conformance reporter output", () => {
@@ -113,6 +141,10 @@ test("renderConformanceReporterResult emits conformance reporter output", () => 
   assert.equal(
     renderConformanceReporterResult(result, "json-summary"),
     JSON.stringify(renderConformanceReportJson(toConformanceReport(result))),
+  );
+  assert.equal(
+    renderConformanceForCli(result, "junit-xml", "json"),
+    renderConformanceReportJUnitXml(toConformanceReport(result)),
   );
 });
 

--- a/cli/tests/debug-artifact.test.ts
+++ b/cli/tests/debug-artifact.test.ts
@@ -181,24 +181,18 @@ test("writeCommandDebugArtifact suppresses human notice when quiet", async () =>
   }) as typeof process.stderr.write;
 
   try {
-    await writeCommandDebugArtifact(
-      {
-        outputPath: artifactPath,
-        format: "human",
-        quiet: true,
-        commandName: "server validate",
-        commandInput: {},
-        target: "https://example.com/mcp",
-        outcome: {
-          status: "success",
-          result: { success: true },
-        },
+    await writeCommandDebugArtifact({
+      outputPath: artifactPath,
+      format: "human",
+      quiet: true,
+      commandName: "server validate",
+      commandInput: {},
+      target: "https://example.com/mcp",
+      outcome: {
+        status: "success",
+        result: { success: true },
       },
-      {
-        runDoctor: async <TTarget>() =>
-          createDoctorResult("https://example.com/mcp" as TTarget),
-      },
-    );
+    });
 
     assert.equal(stderr, "");
   } finally {

--- a/cli/tests/debug-artifact.test.ts
+++ b/cli/tests/debug-artifact.test.ts
@@ -170,6 +170,42 @@ test("writeCommandDebugArtifact writes a snapshot artifact and emits a human not
   }
 });
 
+test("writeCommandDebugArtifact suppresses human notice when quiet", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-debug-artifact-"));
+  const artifactPath = path.join(directory, "quiet.json");
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  let stderr = "";
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    await writeCommandDebugArtifact(
+      {
+        outputPath: artifactPath,
+        format: "human",
+        quiet: true,
+        commandName: "server validate",
+        commandInput: {},
+        target: "https://example.com/mcp",
+        outcome: {
+          status: "success",
+          result: { success: true },
+        },
+      },
+      {
+        runDoctor: async <TTarget>() =>
+          createDoctorResult("https://example.com/mcp" as TTarget),
+      },
+    );
+
+    assert.equal(stderr, "");
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+});
+
 test("writeCommandDebugArtifact preserves command failure and records snapshot errors", async () => {
   const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-debug-artifact-"));
   const artifactPath = path.join(directory, "failure.json");

--- a/cli/tests/json-input.test.ts
+++ b/cli/tests/json-input.test.ts
@@ -109,4 +109,10 @@ test("parseJsonInputValue wraps stdin read failures", () => {
       error instanceof CliError &&
       error.message.includes("Failed to read Params from stdin"),
   );
+  assert.throws(
+    () => context.parseJsonInputValue("-", "Retry"),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("Failed to read Retry from stdin"),
+  );
 });

--- a/cli/tests/json-input.test.ts
+++ b/cli/tests/json-input.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  parseJsonInputRecord,
+  parseJsonInputValue,
+  resetJsonInputStdinForTests,
+} from "../src/lib/json-input.js";
+import { CliError } from "../src/lib/output.js";
+
+async function writeJson(contents: string): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-json-input-"));
+  const filePath = path.join(directory, "input.json");
+  await writeFile(filePath, contents, "utf8");
+  return filePath;
+}
+
+test("parseJsonInputRecord accepts inline JSON and @file", async () => {
+  resetJsonInputStdinForTests();
+  assert.deepEqual(parseJsonInputRecord('{"a":1}', "Params"), { a: 1 });
+
+  const filePath = await writeJson('{"fromFile":true}\n');
+  assert.deepEqual(parseJsonInputRecord(`@${filePath}`, "Params"), {
+    fromFile: true,
+  });
+});
+
+test("parseJsonInputValue accepts non-object JSON values", async () => {
+  resetJsonInputStdinForTests();
+  const filePath = await writeJson('"hello"\n');
+
+  assert.equal(parseJsonInputValue(`@${filePath}`, "Tool output"), "hello");
+});
+
+test("parseJsonInputRecord rejects invalid JSON, missing files, and non-objects", async () => {
+  resetJsonInputStdinForTests();
+  assert.throws(
+    () => parseJsonInputRecord("{", "Params"),
+    (error) =>
+      error instanceof CliError && error.message.includes("must be valid JSON"),
+  );
+  assert.throws(
+    () => parseJsonInputRecord("@", "Params"),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("file path is required"),
+  );
+  assert.throws(
+    () => parseJsonInputRecord("@/definitely/missing.json", "Params"),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("Failed to read Params file"),
+  );
+
+  const filePath = await writeJson("[1,2,3]\n");
+  assert.throws(
+    () => parseJsonInputRecord(`@${filePath}`, "Params"),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("must be a JSON object"),
+  );
+});

--- a/cli/tests/json-input.test.ts
+++ b/cli/tests/json-input.test.ts
@@ -1,54 +1,66 @@
 import assert from "node:assert/strict";
-import { mkdtemp, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import {
-  parseJsonInputRecord,
-  parseJsonInputValue,
-  resetJsonInputStdinForTests,
+  JsonInputContext,
 } from "../src/lib/json-input.js";
 import { CliError } from "../src/lib/output.js";
 
+const tempDirectories: string[] = [];
+
+test.after(async () => {
+  await Promise.all(
+    tempDirectories.map((directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  );
+});
+
 async function writeJson(contents: string): Promise<string> {
   const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-json-input-"));
+  tempDirectories.push(directory);
   const filePath = path.join(directory, "input.json");
   await writeFile(filePath, contents, "utf8");
   return filePath;
 }
 
 test("parseJsonInputRecord accepts inline JSON and @file", async () => {
-  resetJsonInputStdinForTests();
-  assert.deepEqual(parseJsonInputRecord('{"a":1}', "Params"), { a: 1 });
+  const context = new JsonInputContext();
+  assert.deepEqual(context.parseJsonInputRecord('{"a":1}', "Params"), { a: 1 });
 
   const filePath = await writeJson('{"fromFile":true}\n');
-  assert.deepEqual(parseJsonInputRecord(`@${filePath}`, "Params"), {
+  assert.deepEqual(context.parseJsonInputRecord(`@${filePath}`, "Params"), {
     fromFile: true,
   });
 });
 
 test("parseJsonInputValue accepts non-object JSON values", async () => {
-  resetJsonInputStdinForTests();
+  const context = new JsonInputContext();
   const filePath = await writeJson('"hello"\n');
 
-  assert.equal(parseJsonInputValue(`@${filePath}`, "Tool output"), "hello");
+  assert.equal(
+    context.parseJsonInputValue(`@${filePath}`, "Tool output"),
+    "hello",
+  );
 });
 
 test("parseJsonInputRecord rejects invalid JSON, missing files, and non-objects", async () => {
-  resetJsonInputStdinForTests();
+  const context = new JsonInputContext();
   assert.throws(
-    () => parseJsonInputRecord("{", "Params"),
+    () => context.parseJsonInputRecord("{", "Params"),
     (error) =>
       error instanceof CliError && error.message.includes("must be valid JSON"),
   );
   assert.throws(
-    () => parseJsonInputRecord("@", "Params"),
+    () => context.parseJsonInputRecord("@", "Params"),
     (error) =>
       error instanceof CliError &&
       error.message.includes("file path is required"),
   );
   assert.throws(
-    () => parseJsonInputRecord("@/definitely/missing.json", "Params"),
+    () => context.parseJsonInputRecord("@/definitely/missing.json", "Params"),
     (error) =>
       error instanceof CliError &&
       error.message.includes("Failed to read Params file"),
@@ -56,9 +68,45 @@ test("parseJsonInputRecord rejects invalid JSON, missing files, and non-objects"
 
   const filePath = await writeJson("[1,2,3]\n");
   assert.throws(
-    () => parseJsonInputRecord(`@${filePath}`, "Params"),
+    () => context.parseJsonInputRecord(`@${filePath}`, "Params"),
     (error) =>
       error instanceof CliError &&
       error.message.includes("must be a JSON object"),
+  );
+});
+
+test("parseJsonInputRecord rejects empty JSON input", async () => {
+  const context = new JsonInputContext();
+  const filePath = await writeJson("\n");
+
+  assert.throws(
+    () => context.parseJsonInputRecord(`@${filePath}`, "Params"),
+    (error) =>
+      error instanceof CliError && error.message.includes("input is empty"),
+  );
+});
+
+test("parseJsonInputValue rejects duplicate stdin consumers", () => {
+  const context = new JsonInputContext(() => '{"ok":true}');
+
+  assert.deepEqual(context.parseJsonInputValue("-", "First"), { ok: true });
+  assert.throws(
+    () => context.parseJsonInputValue("-", "Second"),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("stdin was already consumed by First"),
+  );
+});
+
+test("parseJsonInputValue wraps stdin read failures", () => {
+  const context = new JsonInputContext(() => {
+    throw new Error("EAGAIN");
+  });
+
+  assert.throws(
+    () => context.parseJsonInputValue("-", "Params"),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("Failed to read Params from stdin"),
   );
 });

--- a/cli/tests/oauth-output.test.ts
+++ b/cli/tests/oauth-output.test.ts
@@ -9,12 +9,10 @@ import {
 import {
   renderOAuthConformanceResult,
   renderOAuthConformanceSuiteResult,
+  parseOAuthOutputFormat,
   resolveOAuthOutputFormat,
 } from "../src/lib/oauth-output.js";
-import {
-  singleResultToJUnitXml,
-  suiteResultToJUnitXml,
-} from "../src/lib/junit-xml.js";
+import { CliError } from "../src/lib/output.js";
 
 function createSingleResult(): ConformanceResult {
   return {
@@ -78,7 +76,15 @@ test("resolveOAuthOutputFormat defaults to human on TTY and json otherwise", () 
   assert.equal(resolveOAuthOutputFormat(undefined, false), "json");
   assert.equal(resolveOAuthOutputFormat("json", true), "json");
   assert.equal(resolveOAuthOutputFormat("human", false), "human");
-  assert.equal(resolveOAuthOutputFormat("junit-xml", true), "junit-xml");
+});
+
+test("parseOAuthOutputFormat rejects junit-xml and points to reporter", () => {
+  assert.throws(
+    () => parseOAuthOutputFormat("junit-xml"),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("Use --reporter junit-xml"),
+  );
 });
 
 test("renderOAuthConformanceResult uses the SDK human formatter for human output", () => {
@@ -90,14 +96,10 @@ test("renderOAuthConformanceResult uses the SDK human formatter for human output
   );
 });
 
-test("renderOAuthConformanceResult preserves raw JSON and junit-xml output", () => {
+test("renderOAuthConformanceResult preserves raw JSON output", () => {
   const result = createSingleResult();
 
   assert.equal(renderOAuthConformanceResult(result, "json"), JSON.stringify(result));
-  assert.equal(
-    renderOAuthConformanceResult(result, "junit-xml"),
-    singleResultToJUnitXml(result),
-  );
 });
 
 test("renderOAuthConformanceSuiteResult uses the SDK human formatter for human output", () => {
@@ -109,15 +111,11 @@ test("renderOAuthConformanceSuiteResult uses the SDK human formatter for human o
   );
 });
 
-test("renderOAuthConformanceSuiteResult preserves raw JSON and junit-xml output", () => {
+test("renderOAuthConformanceSuiteResult preserves raw JSON output", () => {
   const result = createSuiteResult();
 
   assert.equal(
     renderOAuthConformanceSuiteResult(result, "json"),
     JSON.stringify(result),
-  );
-  assert.equal(
-    renderOAuthConformanceSuiteResult(result, "junit-xml"),
-    suiteResultToJUnitXml(result),
   );
 });

--- a/cli/tests/oauth-output.test.ts
+++ b/cli/tests/oauth-output.test.ts
@@ -85,6 +85,12 @@ test("parseOAuthOutputFormat rejects junit-xml and points to reporter", () => {
       error instanceof CliError &&
       error.message.includes("Use --reporter junit-xml"),
   );
+  assert.throws(
+    () => parseOAuthOutputFormat("json-summary"),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("Use --reporter json-summary"),
+  );
 });
 
 test("renderOAuthConformanceResult uses the SDK human formatter for human output", () => {

--- a/cli/tests/oauth-output.test.ts
+++ b/cli/tests/oauth-output.test.ts
@@ -78,18 +78,18 @@ test("resolveOAuthOutputFormat defaults to human on TTY and json otherwise", () 
   assert.equal(resolveOAuthOutputFormat("human", false), "human");
 });
 
-test("parseOAuthOutputFormat rejects junit-xml and points to reporter", () => {
+test("parseOAuthOutputFormat rejects reporter formats as unsupported raw output", () => {
   assert.throws(
     () => parseOAuthOutputFormat("junit-xml"),
     (error) =>
       error instanceof CliError &&
-      error.message.includes("Use --reporter junit-xml"),
+      error.message.includes('Use "json" or "human"'),
   );
   assert.throws(
     () => parseOAuthOutputFormat("json-summary"),
     (error) =>
       error instanceof CliError &&
-      error.message.includes("Use --reporter json-summary"),
+      error.message.includes('Use "json" or "human"'),
   );
 });
 

--- a/cli/tests/output.test.ts
+++ b/cli/tests/output.test.ts
@@ -40,4 +40,10 @@ test("parseOutputFormat keeps reporter formats out of --format", () => {
       error instanceof CliError &&
       error.message.includes("Use --reporter junit-xml"),
   );
+  assert.throws(
+    () => parseOutputFormat("json-summary"),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("Use --reporter json-summary"),
+  );
 });

--- a/cli/tests/output.test.ts
+++ b/cli/tests/output.test.ts
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  CliError,
   detectOutputFormatFromArgv,
+  parseOutputFormat,
   resolveOutputFormat,
 } from "../src/lib/output.js";
 
@@ -28,5 +30,14 @@ test("detectOutputFormatFromArgv respects explicit flags and TTY defaults", () =
   assert.equal(
     detectOutputFormatFromArgv(["node", "cli", "--format=json"], true),
     "json",
+  );
+});
+
+test("parseOutputFormat keeps reporter formats out of --format", () => {
+  assert.throws(
+    () => parseOutputFormat("junit-xml"),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes("Use --reporter junit-xml"),
   );
 });

--- a/cli/tests/server-config.test.ts
+++ b/cli/tests/server-config.test.ts
@@ -54,6 +54,22 @@ test("parseServerConfig accepts oauth access token and client capabilities", () 
   });
 });
 
+test("parseServerConfig accepts client capabilities from @file", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-capabilities-"));
+  const capabilitiesPath = path.join(directory, "capabilities.json");
+  await writeFile(capabilitiesPath, '{"sampling":{},"roots":{}}\n', "utf8");
+
+  const config = parseServerConfig({
+    url: "https://example.com/mcp",
+    clientCapabilities: `@${capabilitiesPath}`,
+  });
+
+  assert.deepEqual(config.clientCapabilities, {
+    sampling: {},
+    roots: {},
+  });
+});
+
 test("parseServerConfig accepts refresh-token auth for HTTP servers", () => {
   const config = parseServerConfig({
     url: "https://example.com/mcp",

--- a/docs/cli/apps-conformance.mdx
+++ b/docs/cli/apps-conformance.mdx
@@ -32,7 +32,7 @@ You can emit CI-friendly JUnit XML from either the single-run or suite command:
 ```bash
 mcpjam apps conformance \
   --url https://your-server.com/mcp \
-  --format junit-xml > apps-report.xml
+  --reporter junit-xml > apps-report.xml
 ```
 
 To reproduce one tool result in the local Inspector:
@@ -41,8 +41,9 @@ To reproduce one tool result in the local Inspector:
 mcpjam apps debug \
   --url https://your-server.com/mcp \
   --tool-name create_view \
-  --params '{"projectId":"demo"}' \
+  --params @params.json \
   --ui \
+  --quiet \
   --format json
 ```
 
@@ -119,7 +120,7 @@ Run it with:
 ```bash
 mcpjam apps conformance-suite \
   --config ./apps-conformance.json \
-  --format junit-xml > apps-report.xml
+  --reporter junit-xml > apps-report.xml
 ```
 
 `target` uses the same shared server shape as the rest of the CLI, so it can point at either:
@@ -213,7 +214,7 @@ Large tool results can appear in `execution`, the render command result, and the
 | `--client-id <id>` | OAuth client ID (with `--refresh-token`) |
 | `--client-secret <secret>` | OAuth client secret (with `--refresh-token`) |
 | `--header <header>` | HTTP header in `Key: Value` format (repeatable) |
-| `--client-capabilities <json>` | Client capabilities JSON object |
+| `--client-capabilities <json>` | Client capabilities as inline JSON, `@path`, or `-` for stdin |
 | `--command <command>` | Command for a stdio server |
 | `--args <arg...>` | Preferred stdio command arguments |
 | `--command-args <arg>` | Legacy stdio command argument (repeatable) |

--- a/docs/cli/ci.mdx
+++ b/docs/cli/ci.mdx
@@ -190,7 +190,7 @@ Run the full registration x protocol version x auth mode matrix from a config fi
         run: |
           npx -y @mcpjam/cli@latest oauth conformance-suite \
             --config ./oauth-matrix.json \
-            --format junit-xml > report.xml
+            --reporter junit-xml > report.xml
 
       - name: Upload test report
         uses: actions/upload-artifact@v4
@@ -211,7 +211,7 @@ Run a repeatable matrix of protocol check selections from a config file and publ
         run: |
           npx -y @mcpjam/cli@latest protocol conformance-suite \
             --config ./protocol-conformance.json \
-            --format junit-xml > protocol-report.xml
+            --reporter junit-xml > protocol-report.xml
 
       - name: Upload protocol report
         uses: actions/upload-artifact@v4
@@ -230,7 +230,7 @@ Run the server-side MCP Apps surface checks from a config file and publish JUnit
         run: |
           npx -y @mcpjam/cli@latest apps conformance-suite \
             --config ./apps-conformance.json \
-            --format junit-xml > apps-report.xml
+            --reporter junit-xml > apps-report.xml
 
       - name: Upload apps report
         uses: actions/upload-artifact@v4
@@ -240,7 +240,7 @@ Run the server-side MCP Apps surface checks from a config file and publish JUnit
           path: apps-report.xml
 ```
 
-Single-run `protocol conformance` and `apps conformance` also accept `--format junit-xml` when you only need one target/check selection instead of a suite config file.
+Single-run `protocol conformance`, `oauth conformance`, and `apps conformance` also accept `--reporter junit-xml` when you only need one target/check selection instead of a suite config file.
 
 ---
 
@@ -345,7 +345,7 @@ mcp-oauth-conformance:
     - |
       npx -y @mcpjam/cli@latest oauth conformance-suite \
         --config ./oauth-matrix.json \
-        --format junit-xml > report.xml
+        --reporter junit-xml > report.xml
   artifacts:
     when: always
     reports:

--- a/docs/cli/oauth-conformance.mdx
+++ b/docs/cli/oauth-conformance.mdx
@@ -11,7 +11,7 @@ The OAuth conformance module runs real OAuth handshakes against your MCP server 
 - **Each MCP client exercises OAuth slightly differently.** Passing conformance means your server works for all of them.
 - **OAuth bugs are silent.** A valid-looking token can be rejected by MCP authentication downstream. Users see "failed to connect" with no context. `--verify-tools` catches this.
 - **3 registration strategies x 3 protocol versions x 3 auth modes** = 27 possible flow combinations. The suite runner covers the matrix in one invocation.
-- **CI-ready output.** `--format junit-xml` for dashboards. Exit 0/1/2 for scripts.
+- **CI-ready output.** `--reporter junit-xml` for dashboards. Exit 0/1/2 for scripts.
 
 ## Quick start
 
@@ -269,7 +269,7 @@ oauth-conformance:
   script:
     - npx -y @mcpjam/cli@latest oauth conformance-suite
         --config ./oauth-tests.json
-        --format junit-xml > report.xml
+        --reporter junit-xml > report.xml
   artifacts:
     reports:
       junit: report.xml
@@ -296,6 +296,7 @@ oauth-conformance:
 | `--verify-call-tool <name>` | No | | Also call the named tool (implies `--verify-tools`) |
 | `--conformance-checks` | No | | Run additional negative OAuth checks after the main flow |
 | `--print-url` | No | | Print consent URL to stderr instead of launching a browser |
+| `--reporter <reporter>` | No | | `json-summary` or `junit-xml` CI report output |
 
 <Note>
   For interactive conformance runs, a custom `--redirect-url` must still be an
@@ -310,7 +311,7 @@ oauth-conformance:
 | `--config <path>` | Yes | | Path to JSON config file |
 | `--verify-tools` | No | | Enable tool listing on all flows |
 | `--verify-call-tool <name>` | No | | Call the named tool after listing |
-| `--format <fmt>` | No | Auto-detected | `json`, `human`, or `junit-xml` |
+| `--reporter <reporter>` | No | | `json-summary` or `junit-xml` CI report output |
 
 <Note>
   `--verify-tools` and `--verify-call-tool` on the suite command are forced

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -52,7 +52,8 @@ These flags apply to every command.
 |------|---------|-------------|
 | `--timeout <ms>` | `30000` | Request timeout in milliseconds |
 | `--rpc` | off | Include raw JSON-RPC request/response logs in JSON output under `_rpcLogs` |
-| `--format <format>` | `human` on TTY, `json` when piped | Output format (`json` or `human`; `junit-xml` is available on protocol, OAuth, and apps conformance commands) |
+| `--quiet` | off | Suppress non-result progress output on stderr |
+| `--format <format>` | `human` on TTY, `json` when piped | Raw output format (`json` or `human`) |
 | `-v, --version` | | Print the CLI version |
 
 ## Output formats
@@ -61,10 +62,17 @@ The CLI auto-detects whether stdout is a terminal:
 
 - **Interactive terminal** — defaults to `--format human`. For most commands this is pretty-printed JSON; `server doctor` and the OAuth conformance commands provide dedicated human-readable summaries.
 - **Piped or redirected** (CI, `| jq`, agent invocation) — defaults to `--format json`, the full structured result.
-- **Conformance in CI** — `protocol conformance`, `protocol conformance-suite`, `oauth conformance`, `oauth conformance-suite`, `apps conformance`, and `apps conformance-suite` also support `--format junit-xml`.
+- **Conformance in CI** — `protocol conformance`, `protocol conformance-suite`, `oauth conformance`, `oauth conformance-suite`, `apps conformance`, and `apps conformance-suite` support `--reporter junit-xml` and `--reporter json-summary`.
 - **Explicit `--format`** always wins over the auto-detected default.
 
-**For agents**: raw JSON is the source of truth. Human format is a lossy presentation layer. If you're parsing output programmatically, always pass `--format json`.
+**For agents**: raw JSON is the source of truth. Human format is a lossy presentation layer. If you're parsing output programmatically, pass `--quiet --format json`.
+
+JSON-valued flags accept inline JSON, `@path`, or `-` for stdin. Use files or stdin for large payloads to avoid shell escaping issues:
+
+```bash
+echo '{"key":"value"}' | mcpjam tools call --url $URL --access-token $TOKEN \
+  --tool-name my_tool --tool-args - --quiet --format json
+```
 
 ## Connecting to servers
 
@@ -135,14 +143,14 @@ mcpjam server doctor --url https://your-server.com/mcp --oauth-access-token $TOK
 # 4. Exercise tools directly
 mcpjam tools list --url https://your-server.com/mcp --access-token $TOKEN
 mcpjam tools call --url https://your-server.com/mcp --access-token $TOKEN \
-  --tool-name my_tool --tool-args '{"key": "value"}'
+  --tool-name my_tool --tool-args @params.json --quiet --format json
 
 # 5. If the server exposes MCP Apps, validate the ui:// surface
 mcpjam apps conformance --url https://your-server.com/mcp --access-token $TOKEN
 
 # 6. Reproduce one MCP App tool result in Inspector's App Builder
 mcpjam apps debug --url https://your-server.com/mcp --access-token $TOKEN \
-  --tool-name my_app_tool --params '{"key":"value"}' --ui --format json
+  --tool-name my_app_tool --params @params.json --ui --quiet --format json
 ```
 
 ## What's next

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -12,7 +12,8 @@ Complete flag tables for every `mcpjam` command. For guides and recipes, see the
 |------|---------|-------------|
 | `--timeout <ms>` | `30000` | Request timeout in milliseconds |
 | `--rpc` | off | Include raw JSON-RPC logs in JSON output under `_rpcLogs` |
-| `--format <format>` | `human` on TTY, `json` when piped | Output format (`json` or `human`; `junit-xml` is available on protocol, OAuth, and apps conformance commands) |
+| `--quiet` | off | Suppress non-result progress output on stderr |
+| `--format <format>` | `human` on TTY, `json` when piped | Raw output format (`json` or `human`) |
 | `-v, --version` | | Print the CLI version |
 
 ---
@@ -34,7 +35,7 @@ All server commands accept the shared connection flags below, plus command-speci
 | `--client-secret <secret>` | OAuth client secret (with `--refresh-token`) |
 | `--credentials-file <path>` | Load OAuth credentials from a file created by `oauth login --credentials-out` |
 | `--header <header>` | HTTP header `Key: Value` (repeatable) |
-| `--client-capabilities <json>` | Client capabilities JSON object |
+| `--client-capabilities <json>` | Client capabilities as inline JSON, `@path`, or `-` for stdin |
 | `--command <command>` | Stdio server command |
 | `--args <arg...>` | Preferred stdio command arguments |
 | `--command-args <arg>` | Legacy stdio command argument (repeatable) |
@@ -97,8 +98,9 @@ Uses shared connection flags.
 |------|-------------|
 | `--tool-name <name>` | Name of the tool to call |
 | `--name <name>` | Legacy alias for `--tool-name` |
-| `--tool-args <json>` | Tool arguments as a JSON string |
+| `--tool-args <json>` | Tool arguments as inline JSON, `@path`, or `-` for stdin |
 | `--params <json>` | Legacy alias for `--tool-args` |
+| `--reporter <reporter>` | `json-summary` or `junit-xml` validation report output |
 | `--debug-out <path>` | Write debug artifact to file |
 
 Plus shared connection flags.
@@ -138,7 +140,7 @@ Uses shared connection flags.
 |------|-------------|
 | `--prompt-name <name>` | Name of the prompt |
 | `--name <name>` | Legacy alias for `--prompt-name` |
-| `--prompt-args <json>` | Prompt arguments as a JSON string |
+| `--prompt-args <json>` | Prompt arguments as inline JSON, `@path`, or `-` for stdin |
 
 Plus shared connection flags.
 
@@ -185,6 +187,7 @@ Plus shared connection flags.
 | `--verify-call-tool <name>` | No | | Also call the named tool |
 | `--conformance-checks` | No | | Run additional negative OAuth checks, including DCR redirect URI policy and redirect-mismatch probes |
 | `--print-url` | No | | Print consent URL to stderr (interactive only) |
+| `--reporter <reporter>` | No | | `json-summary` or `junit-xml` CI report output |
 
 ### `oauth conformance-suite`
 
@@ -193,6 +196,7 @@ Plus shared connection flags.
 | `--config <path>` | Yes | | Path to JSON config file |
 | `--verify-tools` | No | | Enable tool listing on all flows |
 | `--verify-call-tool <name>` | No | | Call the named tool after listing |
+| `--reporter <reporter>` | No | | `json-summary` or `junit-xml` CI report output |
 
 ### `oauth metadata`
 
@@ -207,7 +211,7 @@ Plus shared connection flags.
 | `--url <url>` | Yes | | OAuth request URL |
 | `--method <method>` | No | `GET` | HTTP method |
 | `--header <header>` | No | | HTTP header `Key: Value` (repeatable) |
-| `--body <value>` | No | | Request body (JSON or raw string) |
+| `--body <value>` | No | | Request body as JSON, raw string, `@path`, or `-` for stdin |
 
 ---
 
@@ -224,15 +228,16 @@ Plus shared connection flags.
 | `--check-timeout <ms>` | No | `15000` | Per-check timeout in milliseconds |
 | `--category <category>` | No | all | Restrict checks to one or more categories |
 | `--check-id <id>` | No | all | Restrict checks to one or more check IDs |
+| `--reporter <reporter>` | No | | `json-summary` or `junit-xml` CI report output |
 
-Supports `--format json`, `--format human`, and `--format junit-xml`.
+Use `--format json|human` for raw output and `--reporter json-summary|junit-xml` for CI reports.
 
 ### `protocol conformance-suite`
 
 | Flag | Required | Default | Description |
 |------|----------|---------|-------------|
 | `--config <path>` | Yes | | Path to JSON config file |
-| `--format <fmt>` | No | Auto-detected | `json`, `human`, or `junit-xml` |
+| `--reporter <reporter>` | No | | `json-summary` or `junit-xml` CI report output |
 
 ---
 
@@ -251,7 +256,7 @@ Supports `--format json`, `--format human`, and `--format junit-xml`.
 | `--client-secret <secret>` | OAuth client secret (with `--refresh-token`) |
 | `--credentials-file <path>` | Load OAuth credentials from a file created by `oauth login --credentials-out` |
 | `--header <header>` | HTTP header `Key: Value` (repeatable) |
-| `--client-capabilities <json>` | Client capabilities JSON object |
+| `--client-capabilities <json>` | Client capabilities as inline JSON, `@path`, or `-` for stdin |
 | `--command <command>` | Stdio server command |
 | `--args <arg...>` | Preferred stdio command arguments |
 | `--command-args <arg>` | Legacy stdio command argument (repeatable) |
@@ -270,15 +275,16 @@ MCP Apps server-side conformance checks. Uses shared connection flags plus:
 |------|-------------|
 | `--category <category>` | Check category to run (`tools`, `resources`). Repeatable |
 | `--check-id <id>` | Specific check id to run. Repeatable |
+| `--reporter <reporter>` | `json-summary` or `junit-xml` CI report output |
 
-Supports `--format json`, `--format human`, and `--format junit-xml`.
+Use `--format json|human` for raw output and `--reporter json-summary|junit-xml` for CI reports.
 
 ### `apps conformance-suite`
 
 | Flag | Required | Default | Description |
 |------|----------|---------|-------------|
 | `--config <path>` | Yes | | Path to JSON config file |
-| `--format <fmt>` | No | Auto-detected | `json`, `human`, or `junit-xml` |
+| `--reporter <reporter>` | No | | `json-summary` or `junit-xml` CI report output |
 
 ### `apps debug`
 
@@ -287,7 +293,7 @@ Execute one MCP App tool and optionally render the result in the local Inspector
 | Flag | Required | Description |
 |------|----------|-------------|
 | `--tool-name <name>` | Yes | Tool name to execute |
-| `--params <json-or-@file>` | No | Tool parameters as JSON or `@path` to a JSON file |
+| `--params <json>` | No | Tool parameters as inline JSON, `@path`, or `-` for stdin |
 | `--ui` | No | Start or attach to Inspector and render the result in App Builder |
 | `--inspector-url <url>` | No | Local Inspector base URL |
 | `--server-name <name>` | No | Server name to use inside Inspector |
@@ -313,13 +319,13 @@ Fetch hosted-style MCP App widget content.
 | `--resource-uri <uri>` | Yes | Widget resource URI |
 | `--tool-id <id>` | Yes | Tool call ID used for runtime injection |
 | `--tool-name <name>` | Yes | Tool name used for runtime injection |
-| `--tool-input <json>` | No | Tool input payload as JSON |
-| `--tool-output <json>` | No | Tool output payload as JSON |
+| `--tool-input <json>` | No | Tool input payload as inline JSON, `@path`, or `-` for stdin |
+| `--tool-output <json>` | No | Tool output payload as inline JSON, `@path`, or `-` for stdin |
 | `--theme <theme>` | No | Widget theme: `light` or `dark` |
 | `--csp-mode <mode>` | No | CSP mode: `permissive` or `widget-declared` |
 | `--template <uri>` | No | Optional `ui://` template override |
 | `--view-mode <mode>` | No | Widget view mode |
-| `--view-params <json>` | No | Widget view params as JSON |
+| `--view-params <json>` | No | Widget view params as inline JSON, `@path`, or `-` for stdin |
 
 Plus shared connection flags.
 
@@ -332,9 +338,9 @@ Fetch hosted-style ChatGPT App widget content.
 | `--resource-uri <uri>` | Yes | Widget resource URI |
 | `--tool-id <id>` | Yes | Tool call ID used for runtime injection |
 | `--tool-name <name>` | Yes | Tool name used for runtime injection |
-| `--tool-input <json>` | No | Tool input payload as JSON |
-| `--tool-output <json>` | No | Tool output payload as JSON |
-| `--tool-response-metadata <json>` | No | Tool response metadata as a JSON object |
+| `--tool-input <json>` | No | Tool input payload as inline JSON, `@path`, or `-` for stdin |
+| `--tool-output <json>` | No | Tool output payload as inline JSON, `@path`, or `-` for stdin |
+| `--tool-response-metadata <json>` | No | Tool response metadata as inline JSON, `@path`, or `-` for stdin |
 | `--theme <theme>` | No | Widget theme: `light` or `dark` |
 | `--csp-mode <mode>` | No | CSP mode: `permissive` or `widget-declared` |
 | `--locale <locale>` | No | Locale override |

--- a/docs/cli/server-inspection.mdx
+++ b/docs/cli/server-inspection.mdx
@@ -114,7 +114,7 @@ Every `server` subcommand accepts these flags for specifying how to connect:
 | `--client-secret <secret>` | OAuth client secret (used with `--refresh-token`) |
 | `--credentials-file <path>` | Load OAuth credentials from a file created by `oauth login --credentials-out` |
 | `--header <header>` | HTTP header in `Key: Value` format (repeatable) |
-| `--client-capabilities <json>` | Client capabilities as a JSON object |
+| `--client-capabilities <json>` | Client capabilities as inline JSON, `@path`, or `-` for stdin |
 | `--command <command>` | Command for a stdio server |
 | `--args <arg...>` | Preferred stdio command arguments |
 | `--command-args <arg>` | Legacy stdio command argument (repeatable) |

--- a/docs/cli/tools-resources-prompts.mdx
+++ b/docs/cli/tools-resources-prompts.mdx
@@ -21,10 +21,10 @@ Returns every tool the server exposes, including names, descriptions, and input 
 ```bash
 mcpjam tools call --url https://your-server.com/mcp --access-token $TOKEN \
   --tool-name search_docs \
-  --tool-args '{"query": "authentication"}'
+  --tool-args @params.json --quiet --format json
 ```
 
-Tool arguments are passed as a JSON string. The result includes the tool's response content.
+Tool arguments can be inline JSON, `@path`, or `-` for stdin. The result includes the tool's response content.
 
 <Note>
   `tools call` supports `--debug-out <path>` to capture the full request/response
@@ -104,8 +104,16 @@ mcpjam tools list --url $URL --access-token $TOKEN --format json \
 # Call it
 mcpjam tools call --url $URL --access-token $TOKEN \
   --tool-name search_docs \
-  --tool-args '{"query": "setup guide"}' \
+  --tool-args @params.json \
+  --quiet \
   --format json
+```
+
+For generated payloads, pipe JSON through stdin:
+
+```bash
+echo '{"query":"setup guide"}' | mcpjam tools call --url $URL --access-token $TOKEN \
+  --tool-name search_docs --tool-args - --quiet --format json
 ```
 
 ### Using a credentials file
@@ -120,7 +128,7 @@ mcpjam oauth login --url https://your-server.com/mcp --credentials-out creds.jso
 mcpjam tools list --url https://your-server.com/mcp --credentials-file creds.json
 mcpjam resources list --url https://your-server.com/mcp --credentials-file creds.json
 mcpjam tools call --url https://your-server.com/mcp --credentials-file creds.json \
-  --tool-name search_docs --tool-args '{"query": "setup guide"}'
+  --tool-name search_docs --tool-args @params.json --quiet --format json
 ```
 
 ### No-auth servers

--- a/skills/mcp-inspector/SKILL.md
+++ b/skills/mcp-inspector/SKILL.md
@@ -110,7 +110,7 @@ Use `pending` instead of manufacturing a `medium` or `high` security severity fr
 - `server info`, `server capabilities`, `server validate`, `server ping`, `server export`: connected behavior after initialization and auth.
 - `tools list` and `tools call`, `resources list/read/templates`, `prompts list/get/list-multi`: direct post-connect capability checks.
 - Prefer `--quiet --format json`. Add `--rpc` when available if you need request and response evidence rather than a summary. Add `--debug-out` when you need a failure-safe artifact, not as a replacement for raw evidence.
-- Use `--reporter junit-xml` or `--reporter json-summary` for CI report artifacts on conformance, validation, and diff commands. Do not use `--format junit-xml`; `--format` is only for raw `json` or `human` output.
+- Use `--reporter junit-xml` or `--reporter json-summary` for CI report artifacts on conformance and diff commands. `server validate` does not accept `--reporter`; use `--debug-out` for validation artifacts. Do not use `--format junit-xml`; `--format` is only for raw `json` or `human` output.
 - For JSON-valued options, prefer `@path` or `-` stdin over shell-escaped inline JSON when payloads are generated or contain quotes. For example: `mcpjam tools call --url <target> --tool-name <name> --tool-args @params.json --quiet --format json`.
 
 ## Output contract

--- a/skills/mcp-inspector/SKILL.md
+++ b/skills/mcp-inspector/SKILL.md
@@ -28,8 +28,8 @@ Use this skill when analyzing MCP server behavior from `mcpjam-cli` output. The 
 4. After successful auth, inspect the connected surface with direct commands such as `server info`, `server capabilities`, `tools list`, `resources list/read/templates`, and `prompts list/get`.
 5. Use `server doctor --out <path>` when you need one breadth-first snapshot instead of several single-purpose command outputs.
 6. If the output came from `server doctor` or a `--debug-out` artifact, split it into primary command evidence, probe evidence, and connected-sweep evidence.
-7. If the claim is specifically about MCP Apps tool metadata or `ui://` resources, start with `apps conformance --format json` before dropping to `tools list` or `resources read`.
-8. If the claim is about an MCP App tool result rendering in Inspector, use `apps debug --tool-name <name> --params <json|@file> --ui --format json`. Prefer `--out <path>` when the tool result or snapshot may be large.
+7. If the claim is specifically about MCP Apps tool metadata or `ui://` resources, start with `apps conformance --quiet --format json` before dropping to `tools list` or `resources read`.
+8. If the claim is about an MCP App tool result rendering in Inspector, use `apps debug --tool-name <name> --params <json|@file|-> --ui --quiet --format json`. Prefer `--out <path>` when the tool result or snapshot may be large.
 9. If a field may be CLI-added or SDK-normalized, read `references/cli-surface-notes.md` before concluding anything.
 10. If the claim depends on MCP semantics, read `references/mcp-2025-11-25-interpretation.md`.
 11. If the task involves security review, read `references/security-best-practices.md` for the full checklist and follow the security review workflow below.
@@ -41,7 +41,7 @@ Use this when the task is to assess an MCP server's security posture. All checks
 
 ### Phase 1: Observe (read-only)
 
-Run `server probe --url <target> --format json` first. Add `oauth metadata` or `server doctor --out <path>` only when they clarify the picture.
+Run `server probe --url <target> --quiet --format json` first. Add `oauth metadata` or `server doctor --out <path>` only when they clarify the picture.
 
 - Record an initial auth signal:
   - `full-auth candidate`: probe `status` is `oauth_required`
@@ -109,7 +109,9 @@ Use `pending` instead of manufacturing a `medium` or `high` security severity fr
 - `apps debug`: one MCP App tool execution plus optional Inspector App Builder rendering. With `--ui`, treat `execution` as the tool result and `inspectorRender` as UI command/render evidence; render errors are not automatically tool execution errors.
 - `server info`, `server capabilities`, `server validate`, `server ping`, `server export`: connected behavior after initialization and auth.
 - `tools list` and `tools call`, `resources list/read/templates`, `prompts list/get/list-multi`: direct post-connect capability checks.
-- Prefer `--format json`. Add `--rpc` when available if you need request and response evidence rather than a summary. Add `--debug-out` when you need a failure-safe artifact, not as a replacement for raw evidence.
+- Prefer `--quiet --format json`. Add `--rpc` when available if you need request and response evidence rather than a summary. Add `--debug-out` when you need a failure-safe artifact, not as a replacement for raw evidence.
+- Use `--reporter junit-xml` or `--reporter json-summary` for CI report artifacts on conformance, validation, and diff commands. Do not use `--format junit-xml`; `--format` is only for raw `json` or `human` output.
+- For JSON-valued options, prefer `@path` or `-` stdin over shell-escaped inline JSON when payloads are generated or contain quotes. For example: `mcpjam tools call --url <target> --tool-name <name> --tool-args @params.json --quiet --format json`.
 
 ## Output contract
 


### PR DESCRIPTION
## Summary
- Add global `--quiet` to suppress non-result progress and debug-artifact noise
- Split raw `--format` output from structured `--reporter` output for conformance commands
- Add shared JSON input handling for inline JSON, `@path`, and `-` stdin across CLI JSON flags
- Update CLI docs and `skills/mcp-inspector/SKILL.md` to match the new command contract

## Testing
- Added unit coverage for quiet behavior, reporter parsing, and shared JSON input parsing
- Added CLI regression tests for `--format junit-xml` rejection, `--reporter junit-xml`, and duplicate stdin usage
- Ran the CLI typecheck and full test suite successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple CLI entrypoints and output contracts (`--format` vs `--reporter`, new stdin/file parsing), which could affect automation scripts and edge-case parsing, though changes are well-tested and mostly additive.
> 
> **Overview**
> Adds a global `--quiet` flag to suppress progress/noise on stderr (including OAuth login progress and the “Debug artifact:” notice) while preserving existing stdout results.
> 
> Standardizes JSON-valued CLI flags to accept inline JSON, `@path`, or `-` stdin via a new shared parser (`json-input.ts`), and updates affected commands (`tools call`, `apps debug`/widgets, `server probe` client capabilities, `prompts get`, and OAuth proxy body).
> 
> Splits *raw output* from *CI reporter output* by introducing `--reporter json-summary|junit-xml` on protocol/apps/oauth conformance (and aligning output-format validation to reject reporter formats in `--format`), with docs/examples updated accordingly and new regression/unit tests covering reporter behavior and stdin consumption rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6da1902d0463089a314ffbbd3eebabfd2b2e5b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->