### PR TITLE
Update reconnect indicator in server cards

### DIFF
--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -1546,12 +1546,12 @@ export function ServersTab({
       {/* Client Config Dialog */}
       {clientConfigEnabled === true && onSaveClientConfig ? (
         <Dialog open={isClientConfigOpen} onOpenChange={setIsClientConfigOpen}>
-          <DialogContent className="flex h-[88vh] w-[min(96vw,88rem)] max-w-[88rem] flex-col gap-0 overflow-hidden p-0 sm:max-w-[88rem]">
+          <DialogContent className="flex max-h-[88vh] w-[min(96vw,88rem)] max-w-[88rem] flex-col gap-0 overflow-hidden p-0 sm:max-w-[88rem]">
             <DialogTitle className="sr-only">Connection Settings</DialogTitle>
             <DialogDescription className="sr-only">
               Edit workspace connection settings and client capabilities.
             </DialogDescription>
-            <div className="min-h-0 flex-1 overflow-hidden">
+            <div className="min-h-0 overflow-hidden">
               <ClientConfigTab
                 activeWorkspaceId={activeWorkspaceId}
                 workspace={selectedWorkspace}

--- a/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
@@ -244,7 +244,9 @@ vi.mock("../connection/ServerConnectionCard", () => ({
       <button onClick={() => void onReconnect?.(server.name)}>
         Reconnect {server.name}
       </button>
-      {needsReconnect ? <span aria-label="Reconnect needed" /> : null}
+      {needsReconnect ? (
+        <span aria-label="Connection settings changed" />
+      ) : null}
       <div data-testid={`server-card-${server.name}`}>
         {server.name}:{server.connectionStatus}
       </div>
@@ -847,7 +849,7 @@ describe("ServersTab shared detail modal", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("surfaces reconnect warnings when workspace client capabilities changed", () => {
+  it("surfaces connection settings update indicators when workspace client capabilities changed", () => {
     const initializedCapabilities = getDefaultClientCapabilities() as Record<
       string,
       unknown
@@ -876,7 +878,9 @@ describe("ServersTab shared detail modal", () => {
     );
 
     expect(screen.queryByText("Needs reconnect")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Reconnect needed")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Connection settings changed")
+    ).not.toBeInTheDocument();
 
     rerender(
       <ServersTab
@@ -913,10 +917,12 @@ describe("ServersTab shared detail modal", () => {
     );
 
     expect(screen.queryByText("Needs reconnect")).not.toBeInTheDocument();
-    expect(screen.getByLabelText("Reconnect needed")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Connection settings changed")
+    ).toBeInTheDocument();
   });
 
-  it("does not surface reconnect warnings when server capability overrides already match initialize payload", () => {
+  it("does not surface connection settings update indicators when server capability overrides already match initialize payload", () => {
     const serverCapabilities = {
       experimental: {
         serverOverride: { enabled: true },
@@ -960,7 +966,9 @@ describe("ServersTab shared detail modal", () => {
     );
 
     expect(screen.queryByText("Needs reconnect")).not.toBeInTheDocument();
-    expect(screen.queryByLabelText("Reconnect needed")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Connection settings changed")
+    ).not.toBeInTheDocument();
   });
 
   it("renders Quick Connect module helper copy and Browse Registry in the section header", () => {

--- a/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
@@ -244,7 +244,7 @@ vi.mock("../connection/ServerConnectionCard", () => ({
       <button onClick={() => void onReconnect?.(server.name)}>
         Reconnect {server.name}
       </button>
-      {needsReconnect ? <span>Needs reconnect</span> : null}
+      {needsReconnect ? <span aria-label="Reconnect needed" /> : null}
       <div data-testid={`server-card-${server.name}`}>
         {server.name}:{server.connectionStatus}
       </div>
@@ -876,6 +876,7 @@ describe("ServersTab shared detail modal", () => {
     );
 
     expect(screen.queryByText("Needs reconnect")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Reconnect needed")).not.toBeInTheDocument();
 
     rerender(
       <ServersTab
@@ -911,7 +912,8 @@ describe("ServersTab shared detail modal", () => {
       />
     );
 
-    expect(screen.getByText("Needs reconnect")).toBeInTheDocument();
+    expect(screen.queryByText("Needs reconnect")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Reconnect needed")).toBeInTheDocument();
   });
 
   it("does not surface reconnect warnings when server capability overrides already match initialize payload", () => {
@@ -958,6 +960,7 @@ describe("ServersTab shared detail modal", () => {
     );
 
     expect(screen.queryByText("Needs reconnect")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Reconnect needed")).not.toBeInTheDocument();
   });
 
   it("renders Quick Connect module helper copy and Browse Registry in the section header", () => {

--- a/mcpjam-inspector/client/src/components/client-config/ClientConfigTab.tsx
+++ b/mcpjam-inspector/client/src/components/client-config/ClientConfigTab.tsx
@@ -12,11 +12,11 @@ import {
 import { useWorkspaceClientConfigSyncPending } from "@/hooks/use-workspace-client-config-sync-pending";
 import { useClientConfigStore } from "@/stores/client-config-store";
 
-/** Toolbar (~34px) + status bar (~28px) + a bit of breathing room. */
-const JSON_EDITOR_TOOLBAR_STATUS_PX = 72;
+/** Toolbar + status bar chrome around the editable JSON body. */
+const JSON_EDITOR_TOOLBAR_STATUS_PX = 64;
 const JSON_LINE_PX = 20;
-/** Extra vertical padding so the last line isn't hidden behind the status bar. */
-const JSON_TEXTAREA_VERTICAL_PAD_PX = 44;
+/** Minimal body padding so compact JSON doesn't leave a large blank editor well. */
+const JSON_TEXTAREA_VERTICAL_PAD_PX = 16;
 
 function useContentSizedJsonHeight(
   text: string,
@@ -91,13 +91,13 @@ export function ClientConfigTab({
 
   const connectionDefaultsHeight = useContentSizedJsonHeight(
     connectionDefaultsText,
-    7.5,
+    5.5,
     32,
     0.45,
   );
   const clientCapabilitiesHeight = useContentSizedJsonHeight(
     clientCapabilitiesText,
-    7.5,
+    5.5,
     36,
     0.5,
   );
@@ -160,7 +160,7 @@ export function ClientConfigTab({
   ];
 
   return (
-    <div className="h-full overflow-auto">
+    <div className="max-h-[88vh] overflow-auto">
       <div className="flex w-full min-w-0 flex-col gap-4 px-4 py-3 sm:px-5 sm:py-4">
         {/* Header — pr-8 keeps buttons clear of the dialog close ✕ */}
         <div className="flex items-center justify-between gap-4 pr-8">
@@ -195,9 +195,9 @@ export function ClientConfigTab({
         {reconnectServers.length > 0 && (
           <div className="flex items-center gap-2 rounded border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-amber-700 dark:text-amber-400">
             <AlertTriangle className="h-3 w-3 shrink-0" />
-            Capabilities changed for{" "}
-            {reconnectServers.map((s) => s.name).join(", ")} — reconnect to
-            apply.
+            Connection settings changed for{" "}
+            {reconnectServers.map((s) => s.name).join(", ")}. Turn the
+            connection off and on to apply.
           </div>
         )}
 

--- a/mcpjam-inspector/client/src/components/client-config/__tests__/ClientConfigTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/client-config/__tests__/ClientConfigTab.test.tsx
@@ -39,7 +39,7 @@ function resetClientConfigStore(defaultConfig: WorkspaceConnectionConfigDraft) {
   });
 }
 
-describe("ClientConfigTab reconnect warnings", () => {
+describe("ClientConfigTab connection settings warnings", () => {
   beforeEach(() => {
     const defaultConfig: WorkspaceConnectionConfigDraft = {
       version: 1,
@@ -119,5 +119,59 @@ describe("ClientConfigTab reconnect warnings", () => {
     );
 
     expect(screen.queryByText("Needs reconnect")).not.toBeInTheDocument();
+  });
+
+  it("prompts users to toggle the connection when settings changed", () => {
+    const initializedCapabilities = getDefaultClientCapabilities() as Record<
+      string,
+      unknown
+    >;
+
+    render(
+      <ClientConfigTab
+        activeWorkspaceId="workspace-1"
+        workspace={{
+          id: "workspace-1",
+          name: "Workspace 1",
+          clientConfig: {
+            version: 1,
+            clientCapabilities: {
+              elicitation: {},
+              experimental: {
+                inspectorProfile: true,
+              },
+            },
+            hostContext: {},
+          },
+          servers: {
+            "test-server": {
+              name: "test-server",
+              config: {
+                command: "npx",
+                args: ["-y", "@modelcontextprotocol/server-test"],
+              },
+              lastConnectionTime: new Date("2026-01-01T00:00:00.000Z"),
+              connectionStatus: "connected",
+              retryCount: 0,
+              enabled: true,
+              useOAuth: false,
+              initializationInfo: {
+                clientCapabilities: initializedCapabilities,
+              } as any,
+            },
+          },
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        }}
+        onSaveClientConfig={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/reconnect/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Connection settings changed for test-server\. Turn the connection off and on to apply\./,
+      ),
+    ).toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -16,6 +16,11 @@ import {
   DropdownMenuTrigger,
 } from "@mcpjam/design-system/dropdown-menu";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+import {
   MoreVertical,
   Link2Off,
   RefreshCw,
@@ -447,11 +452,6 @@ export function ServerConnectionCard({
                 <h3 className="truncate text-sm font-semibold text-foreground">
                   {server.name}
                 </h3>
-                {needsReconnect ? (
-                  <span className="rounded-full bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:text-amber-300">
-                    Needs reconnect
-                  </span>
-                ) : null}
                 {version && (
                   <span className="text-xs text-muted-foreground">
                     v{version}
@@ -495,6 +495,20 @@ export function ServerConnectionCard({
                       ? `${connectionStatusLabel} (${server.retryCount})`
                       : connectionStatusLabel}
                   </span>
+                  {needsReconnect ? (
+                    <Tooltip>
+                      <TooltipTrigger
+                        type="button"
+                        aria-label="Reconnect needed"
+                        className="inline-flex h-4 w-4 items-center justify-center rounded-full text-amber-600 outline-none transition-colors hover:text-amber-700 focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:text-amber-300 dark:hover:text-amber-200"
+                      >
+                        <RefreshCw className="h-3 w-3" />
+                      </TooltipTrigger>
+                      <TooltipContent side="top" variant="muted">
+                        Reconnect to apply the current workspace client profile.
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : null}
                 </span>
 
                 <Switch

--- a/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerConnectionCard.tsx
@@ -24,6 +24,7 @@ import {
   MoreVertical,
   Link2Off,
   RefreshCw,
+  Power,
   Loader2,
   Copy,
   Download,
@@ -499,13 +500,19 @@ export function ServerConnectionCard({
                     <Tooltip>
                       <TooltipTrigger
                         type="button"
-                        aria-label="Reconnect needed"
+                        aria-label="Connection settings changed"
                         className="inline-flex h-4 w-4 items-center justify-center rounded-full text-amber-600 outline-none transition-colors hover:text-amber-700 focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:text-amber-300 dark:hover:text-amber-200"
                       >
-                        <RefreshCw className="h-3 w-3" />
+                        <Power className="h-3 w-3" />
                       </TooltipTrigger>
-                      <TooltipContent side="top" variant="muted">
-                        Reconnect to apply the current workspace client profile.
+                      <TooltipContent
+                        side="top"
+                        sideOffset={4}
+                        variant="muted"
+                        className="max-w-48 px-2.5 text-left [text-wrap:normal]"
+                      >
+                        Turn the connection off and on to apply the new
+                        connection settings.
                       </TooltipContent>
                     </Tooltip>
                   ) : null}

--- a/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerInfoContent.tsx
@@ -455,8 +455,8 @@ export function ServerInfoContent({
       ) : null}
       {needsReconnect ? (
         <div className="rounded-md border border-amber-500/30 bg-amber-500/5 p-3 text-sm text-muted-foreground">
-          Saved client capabilities differ from this server's last initialize
-          payload. Reconnect the server to apply the workspace client profile.
+          Connection settings differ from this server's last initialize payload.
+          Turn the connection off and on to apply the new connection settings.
         </div>
       ) : null}
       {serverName && (

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerConnectionCard.test.tsx
@@ -203,6 +203,34 @@ describe("ServerConnectionCard", () => {
 
       expect(screen.getByText("Failed (3)")).toBeInTheDocument();
     });
+
+    it("shows a connection settings indicator without reconnect badge copy", () => {
+      const server = createServer({ connectionStatus: "connected" });
+      render(
+        <ServerConnectionCard
+          server={server}
+          {...defaultProps}
+          needsReconnect
+        />,
+      );
+
+      expect(screen.queryByText("Needs reconnect")).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Reconnect needed"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByLabelText("Connection settings changed"),
+      ).toBeInTheDocument();
+    });
+
+    it("does not show the connection settings indicator when settings match", () => {
+      const server = createServer({ connectionStatus: "connected" });
+      render(<ServerConnectionCard server={server} {...defaultProps} />);
+
+      expect(
+        screen.queryByLabelText("Connection settings changed"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe("toggle switch", () => {


### PR DESCRIPTION
## Summary
- Replace the inline "Needs reconnect" badge with a quieter amber `RefreshCw` tooltip indicator in `ServerConnectionCard`
- Keep the reconnect guidance in a tooltip with accessible trigger labeling
- Update `ServersTab` tests to assert the badge is gone and the aria-labeled indicator appears only when needed

## Testing
- `npm --prefix mcpjam-inspector test -- client/src/components/__tests__/ServersTab.test.tsx client/src/components/connection/__tests__/ServerConnectionCard.test.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily UI/copy and test updates around an existing reconnect-detection signal, with minimal behavioral change beyond how it’s displayed.
> 
> **Overview**
> Updates the *“needs reconnect”* UX across the inspector to be a quieter **connection-settings-changed** indicator: `ServerConnectionCard` drops the inline “Needs reconnect” badge in favor of an amber icon with an accessible tooltip that instructs users to toggle the connection off/on.
> 
> Aligns related copy and accessibility hooks in the connection settings surfaces (`ClientConfigTab`, `ServerInfoContent`) and adjusts the connection settings dialog/editor sizing to avoid oversized layouts; tests are updated/added to assert the new `aria-label="Connection settings changed"` behavior and the removal of the old badge text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4d23f022a6419d68c14398e69302629807ebad5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->