### PR TITLE
Fix responsive host navbar and remove display badge

### DIFF
--- a/mcpjam-inspector/client/src/components/shared/HostContextHeader.tsx
+++ b/mcpjam-inspector/client/src/components/shared/HostContextHeader.tsx
@@ -21,6 +21,7 @@ import {
   Moon,
   MousePointer2,
   Palette,
+  Settings2,
   Shield,
   Sun,
 } from "lucide-react";
@@ -37,9 +38,7 @@ import {
 } from "@mcpjam/design-system/tooltip";
 import type { WorkspaceHostContextDraft } from "@/lib/client-config";
 import {
-  extractEffectiveHostDisplayMode,
   extractHostDeviceCapabilities,
-  extractHostDisplayModes,
   extractHostLocale,
   extractHostTheme,
   extractHostTimeZone,
@@ -69,12 +68,6 @@ export { PRESET_DEVICE_CONFIGS } from "@/components/shared/host-context-constant
 const CUSTOM_DEVICE_BASE = {
   label: "Custom",
 };
-
-const DISPLAY_MODE_LABELS = {
-  inline: "Inline",
-  pip: "PiP",
-  fullscreen: "Fullscreen",
-} as const;
 
 export interface HostContextHeaderProps {
   activeWorkspaceId: string | null;
@@ -169,8 +162,6 @@ export function HostContextHeader({
   const timeZone = extractHostTimeZone(draftHostContext, fallbackTimeZone);
   const capabilities = extractHostDeviceCapabilities(draftHostContext);
   const effectiveThemeMode = extractHostTheme(draftHostContext) ?? themeMode;
-  const displayMode = extractEffectiveHostDisplayMode(draftHostContext);
-  const availableDisplayModes = extractHostDisplayModes(draftHostContext);
 
   const handleCapabilityToggle = useCallback(
     (key: "hover" | "touch") => {
@@ -190,8 +181,8 @@ export function HostContextHeader({
   }, [effectiveThemeMode, patchHostContext]);
 
   return (
-    <div className={className}>
-      <div className="flex items-center gap-4">
+    <div className={cn("min-w-0 max-w-full", className)}>
+      <div className="flex min-w-0 max-w-full items-center gap-3 overflow-x-auto overflow-y-hidden overscroll-x-contain [scrollbar-width:none] @max-[860px]/playground-header:gap-2 [&::-webkit-scrollbar]:hidden">
         <Popover open={devicePopoverOpen} onOpenChange={setDevicePopoverOpen}>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -199,11 +190,11 @@ export function HostContextHeader({
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-7 gap-1.5 border bg-background px-2 text-xs shadow-xs"
+                  className="h-7 shrink-0 gap-1.5 border bg-background px-2 text-xs shadow-xs"
                 >
                   {DeviceIcon ? <DeviceIcon className="h-3.5 w-3.5" /> : null}
-                  <span>{deviceConfig.label}</span>
-                  <span className="text-[10px] text-muted-foreground">
+                  <span className="whitespace-nowrap">{deviceConfig.label}</span>
+                  <span className="text-[10px] text-muted-foreground @max-[1020px]/playground-header:hidden">
                     {deviceConfig.width}x{deviceConfig.height}
                   </span>
                 </Button>
@@ -233,10 +224,12 @@ export function HostContextHeader({
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-7 gap-1.5 border bg-background px-2 text-xs shadow-xs"
+                  className="h-7 shrink-0 gap-1.5 border bg-background px-2 text-xs shadow-xs"
                 >
                   <Globe className="h-3.5 w-3.5" />
-                  <span>{locale}</span>
+                  <span className="whitespace-nowrap @max-[800px]/playground-header:sr-only">
+                    {locale}
+                  </span>
                 </Button>
               </PopoverTrigger>
             </TooltipTrigger>
@@ -260,10 +253,10 @@ export function HostContextHeader({
                 <Button
                   variant="ghost"
                   size="sm"
-                  className="h-7 gap-1.5 border bg-background px-2 text-xs shadow-xs"
+                  className="h-7 shrink-0 gap-1.5 border bg-background px-2 text-xs shadow-xs"
                 >
                   <Clock className="h-3.5 w-3.5" />
-                  <span>
+                  <span className="whitespace-nowrap @max-[920px]/playground-header:sr-only">
                     {TIMEZONE_OPTIONS.find((option) => option.zone === timeZone)
                       ?.label || timeZone}
                   </span>
@@ -283,23 +276,6 @@ export function HostContextHeader({
           </PopoverContent>
         </Popover>
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div className="flex items-center gap-1 rounded-md border bg-background px-2 py-1 shadow-xs">
-              <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                Display
-              </span>
-              <span className="text-xs">{DISPLAY_MODE_LABELS[displayMode]}</span>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent>
-            Available:{" "}
-            {availableDisplayModes
-              .map((mode) => DISPLAY_MODE_LABELS[mode])
-              .join(", ")}
-          </TooltipContent>
-        </Tooltip>
-
         <Popover open={cspPopoverOpen} onOpenChange={setCspPopoverOpen}>
           <Tooltip>
             <TooltipTrigger asChild>
@@ -308,7 +284,7 @@ export function HostContextHeader({
                   variant="ghost"
                   size="sm"
                   className={cn(
-                    "h-7 gap-1.5 border bg-background px-2 text-xs shadow-xs",
+                    "h-7 shrink-0 gap-1.5 border bg-background px-2 text-xs shadow-xs",
                     shouldBlink &&
                       activeCspMode === "widget-declared" &&
                       "animate-csp-alert-blink",
@@ -316,7 +292,9 @@ export function HostContextHeader({
                   onAnimationEnd={() => setShouldBlink(false)}
                 >
                   <Shield className="h-3.5 w-3.5" />
-                  <span>{activeCspMode === "permissive" ? "Permissive" : "Strict"}</span>
+                  <span className="whitespace-nowrap @max-[760px]/playground-header:sr-only">
+                    {activeCspMode === "permissive" ? "Permissive" : "Strict"}
+                  </span>
                 </Button>
               </PopoverTrigger>
             </TooltipTrigger>
@@ -333,7 +311,7 @@ export function HostContextHeader({
           </PopoverContent>
         </Popover>
 
-        <div className="flex items-center gap-0.5 rounded-md border bg-background p-0.5 shadow-xs">
+        <div className="flex shrink-0 items-center gap-0.5 rounded-md border bg-background p-0.5 shadow-xs">
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -375,7 +353,7 @@ export function HostContextHeader({
 
         <Tooltip>
           <TooltipTrigger asChild>
-            <div className="rounded-md border bg-background p-0.5 shadow-xs">
+            <div className="shrink-0 rounded-md border bg-background p-0.5 shadow-xs">
               <SafeAreaEditor />
             </div>
           </TooltipTrigger>
@@ -389,13 +367,16 @@ export function HostContextHeader({
             <Button
               variant="ghost"
               size="sm"
-              className="h-7 gap-1.5 border bg-background px-2 text-xs shadow-xs"
+              className="h-7 shrink-0 gap-1.5 border bg-background px-2 text-xs shadow-xs"
               data-testid="host-context-trigger"
               onClick={() => setHostContextDialogOpen(true)}
             >
-              <span>Host Context</span>
+              <Settings2 className="h-3.5 w-3.5" />
+              <span className="whitespace-nowrap @max-[700px]/playground-header:sr-only">
+                Host Context
+              </span>
               {hostContextDirty ? (
-                <span className="text-[10px] text-amber-600 dark:text-amber-400">
+                <span className="whitespace-nowrap text-[10px] text-amber-600 @max-[700px]/playground-header:sr-only dark:text-amber-400">
                   Unsaved
                 </span>
               ) : null}
@@ -411,8 +392,8 @@ export function HostContextHeader({
 
         <Tooltip>
           <TooltipTrigger asChild>
-            <div className="flex items-center gap-0.5 rounded-md border bg-background p-0.5 shadow-xs">
-              <div className="flex h-6 w-6 items-center justify-center">
+            <div className="flex shrink-0 items-center gap-0.5 rounded-md border bg-background p-0.5 shadow-xs">
+              <div className="flex h-6 w-6 items-center justify-center @max-[820px]/playground-header:hidden">
                 <Palette className="h-3.5 w-3.5 text-muted-foreground" />
               </div>
               {listHostStyles().map((host) => (
@@ -443,7 +424,7 @@ export function HostContextHeader({
                 size="icon"
                 onClick={handleThemeChange}
                 data-testid="host-context-theme-toggle"
-                className="h-7 w-7 border bg-background shadow-xs"
+                className="h-7 w-7 shrink-0 border bg-background shadow-xs"
               >
                 {effectiveThemeMode === "dark" ? (
                   <Sun className="h-3.5 w-3.5" />

--- a/mcpjam-inspector/client/src/components/shared/__tests__/HostContextHeader.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/__tests__/HostContextHeader.test.tsx
@@ -51,6 +51,7 @@ vi.mock("lucide-react", () => ({
   Globe: () => <span data-testid="icon-globe" />,
   Clock: () => <span data-testid="icon-clock" />,
   Shield: () => <span data-testid="icon-shield" />,
+  Settings2: () => <span data-testid="icon-settings" />,
   MousePointer2: () => <span data-testid="icon-mouse" />,
   Hand: () => <span data-testid="icon-hand" />,
   Palette: () => <span data-testid="icon-palette" />,
@@ -241,5 +242,14 @@ describe("HostContextHeader", () => {
     fireEvent.click(screen.getByTestId("host-context-trigger"));
 
     expect(screen.getByTestId("host-context-dialog")).toBeInTheDocument();
+  });
+
+  it("does not render the display-mode badge in the toolbar", () => {
+    render(
+      <HostContextHeader activeWorkspaceId="workspace-1" protocol={null} />,
+    );
+
+    expect(screen.queryByText("Display")).not.toBeInTheDocument();
+    expect(screen.queryByText("Inline")).not.toBeInTheDocument();
   });
 });

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -1503,7 +1503,7 @@ export function PlaygroundMain({
             )}
             data-testid="playground-main-header"
           >
-            <div className="flex min-w-0 max-w-full justify-center">
+            <div className="flex min-w-0 flex-1 justify-center overflow-hidden">
               <HostContextHeader
                 activeWorkspaceId={activeWorkspaceId}
                 onSaveHostContext={onSaveHostContext}


### PR DESCRIPTION
## Summary
- Tighten the playground header layout so the host context toolbar can shrink cleanly on smaller viewports without overflowing.
- Remove the inline display-mode badge from the host context controls.
- Add focused coverage for the toolbar no longer rendering the display badge.

## Testing
- `vitest` component test for `HostContextHeader`.
- `sdk` package build to restore the generated import used by the client build.
- `client` production build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and rendering changes plus a small test update; no auth, persistence, or data-handling logic is modified.
> 
> **Overview**
> Tightens the playground header/`HostContextHeader` layout so the host-context toolbar can **shrink and horizontally scroll** on small viewports without overflowing, including breakpoint-based hiding of secondary text.
> 
> Removes the inline **display-mode badge** from the toolbar (and related `client-config` extract usage), updates the Host Context trigger to use a `Settings2` icon, and adds a component test asserting the display badge no longer renders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65ca253d4550bf19ba5e3ae530546c165f2317b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->