### PR TITLE
Add privacy-safe telemetry to the CLI

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -167,6 +167,8 @@ Use `--format json|human` for the raw command result. Use `--reporter json-summa
 
 `mcpjam` collects anonymous command-level telemetry so we can understand CLI usage and reliability. Events include the command/subcommand name, success/failure, exit code, duration, CLI version, Node version, OS, CPU architecture, transport type (`http` or `stdio`), `platform: "cli"`, and coarse CI metadata (`is_ci` and a provider enum such as `github_actions`).
 
+Telemetry is enabled by default. The first command invocation that is not opted out writes `telemetry.json` with `enabled: true` and a random install UUID.
+
 Telemetry uses a random install UUID stored at the same platform cache location as update checks, in `telemetry.json`. It does not collect raw argv, URLs, hostnames, ports, tokens, headers, environment values, working directories, file paths, tool/resource/prompt names, error messages, stack traces, repository names, branch names, workflow names, or CI job ids.
 
 Disable telemetry for one invocation with `--no-telemetry`, or persistently with:

--- a/cli/README.md
+++ b/cli/README.md
@@ -28,6 +28,7 @@ Options:
   --timeout <ms>     Request timeout in milliseconds (default: 30000)
   --rpc              Include RPC logs in JSON output
   --quiet            Suppress non-result progress output
+  --no-telemetry     Disable anonymous usage telemetry
   --format <format>  Output format
   -h, --help         display help for command
 
@@ -40,6 +41,7 @@ Commands:
   oauth              Run MCP OAuth login, proxy, and conformance flows
   protocol           MCP protocol inspection and conformance checks
   inspector          Start or attach to the local MCPJam Inspector
+  telemetry          Inspect and configure anonymous CLI telemetry
 ```
 
 ## Quick start
@@ -160,6 +162,27 @@ echo '{"query":"setup guide"}' | mcpjam tools call --url $URL --access-token $TO
 ```
 
 Use `--format json|human` for the raw command result. Use `--reporter json-summary|junit-xml` on conformance and diff commands when CI needs a report artifact. `server validate` uses `--debug-out` for validation artifacts.
+
+## Telemetry
+
+`mcpjam` collects anonymous command-level telemetry so we can understand CLI usage and reliability. Events include the command/subcommand name, success/failure, exit code, duration, CLI version, Node version, OS, CPU architecture, transport type (`http` or `stdio`), `platform: "cli"`, and coarse CI metadata (`is_ci` and a provider enum such as `github_actions`).
+
+Telemetry uses a random install UUID stored at the same platform cache location as update checks, in `telemetry.json`. It does not collect raw argv, URLs, hostnames, ports, tokens, headers, environment values, working directories, file paths, tool/resource/prompt names, error messages, stack traces, repository names, branch names, workflow names, or CI job ids.
+
+Disable telemetry for one invocation with `--no-telemetry`, or persistently with:
+
+```bash
+mcpjam telemetry disable
+```
+
+Check or re-enable it with:
+
+```bash
+mcpjam telemetry status
+mcpjam telemetry enable
+```
+
+Set `DO_NOT_TRACK=1` or `MCPJAM_TELEMETRY_DISABLED=1` to disable telemetry through the environment. Set `MCPJAM_TELEMETRY_DEBUG=1` to print the sanitized telemetry payload to stderr instead of sending it.
 
 ## GitHub Actions
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "@mcpjam/sdk": "^1.0.0",
-    "commander": "^12.1.0"
+    "commander": "^12.1.0",
+    "posthog-node": "^5.24.10"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/cli/src/commands/telemetry.ts
+++ b/cli/src/commands/telemetry.ts
@@ -1,0 +1,83 @@
+import { Command } from "commander";
+import { writeResult, type OutputFormat } from "../lib/output.js";
+import { getGlobalOptions } from "../lib/server-config.js";
+import {
+  formatTelemetryStatusHuman,
+  getTelemetryStatus,
+  setTelemetryEnabled,
+  type TelemetryOptions,
+} from "../lib/telemetry.js";
+
+interface TelemetryCommandOptions {
+  telemetry?: boolean;
+}
+
+export function registerTelemetryCommands(
+  program: Command,
+  telemetryOptions: TelemetryOptions = {},
+): void {
+  const telemetry = program
+    .command("telemetry")
+    .description("Inspect and configure anonymous CLI telemetry");
+
+  telemetry
+    .command("status")
+    .description("Show the current telemetry status")
+    .action((_options, command) => {
+      writeTelemetryStatus(
+        resolveTelemetryStatus(command, telemetryOptions),
+        getGlobalOptions(command).format,
+      );
+    });
+
+  telemetry
+    .command("disable")
+    .description("Disable anonymous CLI telemetry")
+    .action((_options, command) => {
+      setTelemetryEnabled(false, telemetryOptions);
+      writeTelemetryStatus(
+        resolveTelemetryStatus(command, telemetryOptions),
+        getGlobalOptions(command).format,
+      );
+    });
+
+  telemetry
+    .command("enable")
+    .description("Enable anonymous CLI telemetry")
+    .action((_options, command) => {
+      setTelemetryEnabled(true, telemetryOptions);
+      writeTelemetryStatus(
+        resolveTelemetryStatus(command, telemetryOptions),
+        getGlobalOptions(command).format,
+      );
+    });
+}
+
+function resolveTelemetryStatus(
+  command: Command,
+  telemetryOptions: TelemetryOptions,
+) {
+  const options = command.optsWithGlobals() as TelemetryCommandOptions;
+  return getTelemetryStatus({
+    ...telemetryOptions,
+    commandOptOut: options.telemetry === false,
+  });
+}
+
+function writeTelemetryStatus(
+  status: ReturnType<typeof getTelemetryStatus>,
+  format: OutputFormat,
+): void {
+  if (format === "human") {
+    process.stdout.write(formatTelemetryStatusHuman(status));
+    return;
+  }
+
+  writeResult(
+    {
+      success: true,
+      telemetry: status,
+    },
+    format,
+  );
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -82,17 +82,8 @@ export async function main(
 
   try {
     await program.parseAsync(argv as string[]);
-    const exitCode = process.exitCode;
-    if (typeof exitCode === "number") {
-      captureCommandEvent(exitCode, exitCode === 0 ? undefined : "UNKNOWN_ERROR");
-      await telemetry.flush();
-      return {
-        exitCode,
-        shouldCheckForUpdates: true,
-      };
-    }
-
-    const normalizedExitCode = Number(exitCode ?? 0) || 0;
+    const normalizedExitCode =
+      typeof process.exitCode === "number" ? process.exitCode : 0;
     captureCommandEvent(
       normalizedExitCode,
       normalizedExitCode === 0 ? undefined : "UNKNOWN_ERROR",

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -8,6 +8,7 @@ import { registerOAuthCommands } from "./commands/oauth.js";
 import { registerPromptCommands } from "./commands/prompts.js";
 import { registerResourcesCommands } from "./commands/resources.js";
 import { registerServerCommands } from "./commands/server.js";
+import { registerTelemetryCommands } from "./commands/telemetry.js";
 import { registerToolsCommands } from "./commands/tools.js";
 import { registerInspectorCommands } from "./commands/inspector.js";
 import {
@@ -17,6 +18,11 @@ import {
   writeError,
 } from "./lib/output.js";
 import { addGlobalOptions } from "./lib/server-config.js";
+import {
+  captureCommandEvent,
+  initTelemetry,
+  type TelemetryOptions,
+} from "./lib/telemetry.js";
 import { checkForUpdates } from "./lib/update-notifier.js";
 
 const pkgVersion = packageJson.version;
@@ -26,12 +32,17 @@ export interface CliMainResult {
   shouldCheckForUpdates: boolean;
 }
 
-export interface CliEntrypointDependencies {
+export interface CliMainDependencies {
+  telemetry?: TelemetryOptions;
+}
+
+export interface CliEntrypointDependencies extends CliMainDependencies {
   checkForUpdates?: (currentVersion: string) => void;
 }
 
 export async function main(
   argv: readonly string[] = process.argv,
+  dependencies: CliMainDependencies = {},
 ): Promise<CliMainResult> {
   const program = addGlobalOptions(
     new Command()
@@ -49,6 +60,7 @@ export async function main(
         },
       }),
   );
+  const telemetry = initTelemetry(program, pkgVersion, dependencies.telemetry);
 
   registerServerCommands(program);
   registerToolsCommands(program);
@@ -58,6 +70,7 @@ export async function main(
   registerOAuthCommands(program);
   registerProtocolCommands(program);
   registerInspectorCommands(program);
+  registerTelemetryCommands(program, dependencies.telemetry);
 
   if (argv.length <= 2) {
     program.outputHelp();
@@ -71,14 +84,22 @@ export async function main(
     await program.parseAsync(argv as string[]);
     const exitCode = process.exitCode;
     if (typeof exitCode === "number") {
+      captureCommandEvent(exitCode, exitCode === 0 ? undefined : "UNKNOWN_ERROR");
+      await telemetry.flush();
       return {
         exitCode,
         shouldCheckForUpdates: true,
       };
     }
 
+    const normalizedExitCode = Number(exitCode ?? 0) || 0;
+    captureCommandEvent(
+      normalizedExitCode,
+      normalizedExitCode === 0 ? undefined : "UNKNOWN_ERROR",
+    );
+    await telemetry.flush();
     return {
-      exitCode: Number(exitCode ?? 0) || 0,
+      exitCode: normalizedExitCode,
       shouldCheckForUpdates: true,
     };
   } catch (error) {
@@ -89,6 +110,7 @@ export async function main(
         error.code === "commander.helpDisplayed" ||
         error.code === "commander.version"
       ) {
+        await telemetry.flush();
         return {
           exitCode: 0,
           shouldCheckForUpdates: false,
@@ -96,6 +118,8 @@ export async function main(
       }
 
       writeError(usageError(error.message), format);
+      captureCommandEvent(2, "USAGE_ERROR");
+      await telemetry.flush();
       return {
         exitCode: 2,
         shouldCheckForUpdates: false,
@@ -104,6 +128,8 @@ export async function main(
 
     const normalizedError = normalizeCliError(error);
     writeError(normalizedError, format);
+    captureCommandEvent(normalizedError.exitCode, normalizedError.code);
+    await telemetry.flush();
     return {
       exitCode: normalizedError.exitCode,
       shouldCheckForUpdates: false,
@@ -115,7 +141,7 @@ export async function runCliEntrypoint(
   argv: readonly string[] = process.argv,
   dependencies: CliEntrypointDependencies = {},
 ): Promise<CliMainResult> {
-  const result = await main(argv);
+  const result = await main(argv, dependencies);
   process.exitCode = result.exitCode;
 
   if (result.exitCode === 0 && result.shouldCheckForUpdates) {

--- a/cli/src/lib/server-config.ts
+++ b/cli/src/lib/server-config.ts
@@ -16,6 +16,7 @@ export interface GlobalOptions {
   timeout: number;
   rpc: boolean;
   quiet: boolean;
+  telemetry: boolean;
 }
 
 type TransportType = "http" | "stdio";
@@ -109,6 +110,7 @@ export function getGlobalOptions(command: Command): GlobalOptions {
     timeout: options.timeout ?? 30_000,
     rpc: options.rpc ?? false,
     quiet: options.quiet ?? false,
+    telemetry: options.telemetry ?? true,
   };
 }
 
@@ -370,6 +372,7 @@ export function addGlobalOptions(program: Command): Command {
     )
     .option("--rpc", "Include RPC logs in JSON output")
     .option("--quiet", "Suppress non-result progress output")
+    .option("--no-telemetry", "Disable anonymous usage telemetry")
     .option("--format <format>", "Output format");
 }
 

--- a/cli/src/lib/telemetry.ts
+++ b/cli/src/lib/telemetry.ts
@@ -1,0 +1,553 @@
+import { randomUUID } from "node:crypto";
+import {
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import type { Command } from "commander";
+import { PostHog } from "posthog-node";
+import {
+  getUpdateCacheDir,
+  type CachePathOptions,
+  type StderrLike,
+} from "./update-notifier.js";
+
+const POSTHOG_KEY = "phc_dTOPniyUNU2kD8Jx8yHMXSqiZHM8I91uWopTMX6EBE9";
+const POSTHOG_HOST = "https://us.i.posthog.com";
+const TELEMETRY_STATE_FILE = "telemetry.json";
+const TELEMETRY_EVENT_NAME = "cli_command";
+const TELEMETRY_STATE_VERSION = 1;
+const DEFAULT_FLUSH_TIMEOUT_MS = 3_000;
+
+const SAFE_ERROR_CODES = new Set([
+  "USAGE_ERROR",
+  "TIMEOUT",
+  "AUTH_FAILED",
+  "TRANSPORT_ERROR",
+  "SERVER_ERROR",
+  "NETWORK_ERROR",
+  "UNKNOWN_ERROR",
+]);
+
+export type TelemetryDisableReason =
+  | "--no-telemetry"
+  | "DO_NOT_TRACK"
+  | "MCPJAM_TELEMETRY_DISABLED"
+  | "state";
+
+export type TelemetryTransport = "http" | "stdio";
+
+export interface TelemetryState {
+  version: 1;
+  enabled: boolean;
+  installId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TelemetryStatus {
+  enabled: boolean;
+  installId: string | null;
+  installIdCreated: boolean;
+  stateFile: string;
+  debugMode: boolean;
+  disableReason: TelemetryDisableReason | null;
+}
+
+export interface TelemetryClient {
+  capture(event: {
+    distinctId: string;
+    event: string;
+    properties: Record<string, unknown>;
+  }): void;
+  flush(): Promise<void>;
+}
+
+export interface TelemetryOptions extends CachePathOptions {
+  statePath?: string;
+  env?: NodeJS.ProcessEnv;
+  stderr?: StderrLike;
+  createClient?: () => TelemetryClient;
+  createId?: () => string;
+  now?: () => Date;
+  flushTimeoutMs?: number;
+}
+
+export interface TelemetryController {
+  flush(): Promise<void>;
+}
+
+interface TelemetryDecision {
+  enabled: boolean;
+  disableReason: TelemetryDisableReason | null;
+  state: TelemetryState | null;
+  stateFile: string;
+  debugMode: boolean;
+}
+
+interface ActiveTelemetryRun {
+  cliVersion: string;
+  options: TelemetryOptions;
+  command?: string;
+  commandOptOut: boolean;
+  startedAtMs?: number;
+  transport?: TelemetryTransport;
+  shouldCapture: boolean;
+  captured: boolean;
+  client?: TelemetryClient;
+  fallbackInstallId?: string;
+}
+
+let activeRun: ActiveTelemetryRun | null = null;
+
+export function getTelemetryStatePath(options: TelemetryOptions = {}): string {
+  return options.statePath ?? join(getUpdateCacheDir(options), TELEMETRY_STATE_FILE);
+}
+
+export function readTelemetryState(
+  options: TelemetryOptions = {},
+): TelemetryState | null {
+  try {
+    const payload = JSON.parse(readFileSync(getTelemetryStatePath(options), "utf8"));
+    return parseTelemetryState(payload);
+  } catch {
+    return null;
+  }
+}
+
+export function getTelemetryStatus(
+  options: TelemetryOptions & { commandOptOut?: boolean } = {},
+): TelemetryStatus {
+  const decision = resolveTelemetryDecision({
+    ...options,
+    commandOptOut: options.commandOptOut ?? false,
+  });
+
+  return {
+    enabled: decision.enabled,
+    installId: decision.state?.installId ?? null,
+    installIdCreated: Boolean(decision.state?.installId),
+    stateFile: decision.stateFile,
+    debugMode: decision.debugMode,
+    disableReason: decision.disableReason,
+  };
+}
+
+export function setTelemetryEnabled(
+  enabled: boolean,
+  options: TelemetryOptions = {},
+): TelemetryState {
+  const stateFile = getTelemetryStatePath(options);
+  const existing = readTelemetryState(options);
+  const now = getNow(options);
+  const createdAt = existing?.createdAt ?? now;
+  const installId = enabled
+    ? existing?.installId ?? createInstallId(options)
+    : existing?.installId;
+  const nextState: TelemetryState = {
+    version: TELEMETRY_STATE_VERSION,
+    enabled,
+    ...(installId ? { installId } : {}),
+    createdAt,
+    updatedAt: now,
+  };
+
+  writeTelemetryState(stateFile, nextState);
+  return nextState;
+}
+
+export function formatTelemetryStatusHuman(status: TelemetryStatus): string {
+  const lines = [
+    `Telemetry: ${status.enabled ? "enabled" : "disabled"}`,
+    `Install ID: ${status.installId ?? "not created yet"}`,
+    `State file: ${status.stateFile}`,
+    `Debug mode: ${status.debugMode ? "on" : "off"}`,
+  ];
+
+  if (status.disableReason) {
+    lines.push(`Disable reason: ${status.disableReason}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+export function initTelemetry(
+  program: Command,
+  cliVersion: string,
+  options: TelemetryOptions = {},
+): TelemetryController {
+  const run: ActiveTelemetryRun = {
+    cliVersion,
+    options,
+    commandOptOut: false,
+    shouldCapture: false,
+    captured: false,
+  };
+  activeRun = run;
+
+  program.hook("preAction", (_thisCommand, actionCommand) => {
+    if (activeRun !== run) {
+      return;
+    }
+
+    const commandPath = getCommandPath(actionCommand);
+    run.command = commandPath.join(" ");
+    run.commandOptOut = isCommandTelemetryOptedOut(actionCommand);
+    run.startedAtMs = Date.now();
+    run.transport = detectTransport(actionCommand);
+    run.shouldCapture = commandPath[0] !== "telemetry";
+    run.captured = false;
+  });
+
+  return {
+    async flush() {
+      const client = run.client;
+      if (!client) {
+        return;
+      }
+
+      try {
+        await withTimeout(
+          client.flush(),
+          options.flushTimeoutMs ?? DEFAULT_FLUSH_TIMEOUT_MS,
+        );
+      } catch {
+        // Telemetry is best-effort and must never affect CLI behavior.
+      }
+    },
+  };
+}
+
+export function captureCommandEvent(
+  exitCode: number,
+  errorCode?: string,
+): void {
+  const run = activeRun;
+  if (
+    !run ||
+    !run.shouldCapture ||
+    run.captured ||
+    !run.startedAtMs ||
+    !run.command
+  ) {
+    return;
+  }
+
+  run.captured = true;
+
+  try {
+    const decision = resolveTelemetryDecision({
+      ...run.options,
+      commandOptOut: run.commandOptOut,
+    });
+
+    if (!decision.enabled) {
+      return;
+    }
+
+    const distinctId = resolveInstallId(run, decision.state);
+    const properties: Record<string, unknown> = {
+      platform: "cli",
+      command: run.command,
+      success: exitCode === 0,
+      exit_code: exitCode,
+      duration_ms: Math.max(0, Date.now() - run.startedAtMs),
+      cli_version: run.cliVersion,
+      os: process.platform,
+      arch: process.arch,
+      node_version: process.version,
+      is_ci: isCi(run.options.env),
+      ci_name: detectCiName(run.options.env),
+    };
+
+    if (run.transport) {
+      properties.transport = run.transport;
+    }
+
+    const safeErrorCode =
+      exitCode === 0 ? undefined : normalizeTelemetryErrorCode(errorCode);
+    if (safeErrorCode) {
+      properties.error_code = safeErrorCode;
+    }
+
+    if (decision.debugMode) {
+      writeDebugPayload(run.options, distinctId, properties);
+      return;
+    }
+
+    const client = getOrCreateClient(run);
+    client.capture({
+      distinctId,
+      event: TELEMETRY_EVENT_NAME,
+      properties,
+    });
+  } catch {
+    // Telemetry is best-effort and must never affect CLI behavior.
+  }
+}
+
+function resolveTelemetryDecision(
+  options: TelemetryOptions & { commandOptOut: boolean },
+): TelemetryDecision {
+  const stateFile = getTelemetryStatePath(options);
+  const state = readTelemetryState(options);
+  const envDisableReason = getEnvDisableReason(options.env);
+  const disableReason = options.commandOptOut
+    ? "--no-telemetry"
+    : envDisableReason ?? (state?.enabled === false ? "state" : null);
+
+  return {
+    enabled: disableReason === null,
+    disableReason,
+    state,
+    stateFile,
+    debugMode: isDebugMode(options.env),
+  };
+}
+
+function getEnvDisableReason(
+  env: NodeJS.ProcessEnv = process.env,
+): TelemetryDisableReason | null {
+  if (env.DO_NOT_TRACK === "1") {
+    return "DO_NOT_TRACK";
+  }
+
+  if (env.MCPJAM_TELEMETRY_DISABLED === "1") {
+    return "MCPJAM_TELEMETRY_DISABLED";
+  }
+
+  return null;
+}
+
+function resolveInstallId(
+  run: ActiveTelemetryRun,
+  state: TelemetryState | null,
+): string {
+  if (state?.installId) {
+    return state.installId;
+  }
+
+  try {
+    const nextState = setTelemetryEnabled(true, run.options);
+    if (nextState.installId) {
+      return nextState.installId;
+    }
+  } catch {
+    // Fall through to a per-run id if cache writes fail.
+  }
+
+  run.fallbackInstallId ??= createInstallId(run.options);
+  return run.fallbackInstallId;
+}
+
+function getOrCreateClient(run: ActiveTelemetryRun): TelemetryClient {
+  run.client ??=
+    run.options.createClient?.() ??
+    (new PostHog(POSTHOG_KEY, {
+      host: POSTHOG_HOST,
+    }) as TelemetryClient);
+  return run.client;
+}
+
+function writeDebugPayload(
+  options: TelemetryOptions,
+  distinctId: string,
+  properties: Record<string, unknown>,
+): void {
+  const stderr = options.stderr ?? process.stderr;
+  stderr.write(
+    `MCPJam telemetry debug: ${JSON.stringify({
+      event: TELEMETRY_EVENT_NAME,
+      distinct_id: distinctId,
+      properties,
+    })}\n`,
+  );
+}
+
+function getCommandPath(actionCommand: Command): string[] {
+  const names: string[] = [];
+  let current: Command | null = actionCommand;
+
+  while (current) {
+    const name = current.name();
+    if (name && name !== "mcpjam") {
+      names.unshift(name);
+    }
+    current = current.parent ?? null;
+  }
+
+  return names;
+}
+
+function isCommandTelemetryOptedOut(actionCommand: Command): boolean {
+  const options = actionCommand.optsWithGlobals() as { telemetry?: unknown };
+  return options.telemetry === false;
+}
+
+function detectTransport(actionCommand: Command): TelemetryTransport | undefined {
+  const options = actionCommand.optsWithGlobals() as Record<string, unknown>;
+
+  if (typeof options.url === "string" && options.url.trim().length > 0) {
+    return "http";
+  }
+
+  if (typeof options.command === "string" && options.command.trim().length > 0) {
+    return "stdio";
+  }
+
+  return undefined;
+}
+
+function normalizeTelemetryErrorCode(value: string | undefined): string {
+  if (value && SAFE_ERROR_CODES.has(value)) {
+    return value;
+  }
+
+  if (value === "SERVER_UNREACHABLE") {
+    return "NETWORK_ERROR";
+  }
+
+  if (value?.includes("AUTH") || value?.includes("UNAUTHORIZED")) {
+    return "AUTH_FAILED";
+  }
+
+  if (value?.includes("TIMEOUT")) {
+    return "TIMEOUT";
+  }
+
+  if (value?.includes("TRANSPORT")) {
+    return "TRANSPORT_ERROR";
+  }
+
+  if (value?.includes("NETWORK") || value?.includes("UNREACHABLE")) {
+    return "NETWORK_ERROR";
+  }
+
+  if (value?.includes("SERVER")) {
+    return "SERVER_ERROR";
+  }
+
+  return "UNKNOWN_ERROR";
+}
+
+function isCi(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(
+    env.CI ||
+      env.GITHUB_ACTIONS ||
+      env.GITLAB_CI ||
+      env.CIRCLECI ||
+      env.BUILDKITE ||
+      env.JENKINS_URL ||
+      env.JENKINS_HOME ||
+      env.VERCEL ||
+      env.NETLIFY,
+  );
+}
+
+function isDebugMode(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.MCPJAM_TELEMETRY_DEBUG === "1";
+}
+
+function detectCiName(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.GITHUB_ACTIONS) {
+    return "github_actions";
+  }
+  if (env.GITLAB_CI) {
+    return "gitlab_ci";
+  }
+  if (env.CIRCLECI) {
+    return "circleci";
+  }
+  if (env.BUILDKITE) {
+    return "buildkite";
+  }
+  if (env.JENKINS_URL || env.JENKINS_HOME) {
+    return "jenkins";
+  }
+  if (env.VERCEL) {
+    return "vercel";
+  }
+  if (env.NETLIFY) {
+    return "netlify";
+  }
+  return "unknown";
+}
+
+function parseTelemetryState(value: unknown): TelemetryState | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const payload = value as Record<string, unknown>;
+  if (
+    payload.version !== TELEMETRY_STATE_VERSION ||
+    typeof payload.enabled !== "boolean" ||
+    typeof payload.createdAt !== "string" ||
+    typeof payload.updatedAt !== "string"
+  ) {
+    return null;
+  }
+
+  if (
+    payload.installId !== undefined &&
+    (typeof payload.installId !== "string" || !isValidUuid(payload.installId))
+  ) {
+    return null;
+  }
+
+  return {
+    version: TELEMETRY_STATE_VERSION,
+    enabled: payload.enabled,
+    ...(typeof payload.installId === "string"
+      ? { installId: payload.installId }
+      : {}),
+    createdAt: payload.createdAt,
+    updatedAt: payload.updatedAt,
+  };
+}
+
+function isValidUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  );
+}
+
+function writeTelemetryState(stateFile: string, state: TelemetryState): void {
+  mkdirSync(dirname(stateFile), { recursive: true });
+  const temporaryPath = `${stateFile}.${process.pid}.${Date.now()}.tmp`;
+  writeFileSync(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  renameSync(temporaryPath, stateFile);
+}
+
+function getNow(options: TelemetryOptions): string {
+  return (options.now?.() ?? new Date()).toISOString();
+}
+
+function createInstallId(options: TelemetryOptions): string {
+  return options.createId?.() ?? randomUUID();
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T | void> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(resolve, timeoutMs);
+        timeout.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/cli/src/lib/telemetry.ts
+++ b/cli/src/lib/telemetry.ts
@@ -248,6 +248,7 @@ export function captureCommandEvent(
     }
 
     const distinctId = resolveInstallId(run, decision.state);
+    const isCiRun = isCi(run.options.env);
     const properties: Record<string, unknown> = {
       platform: "cli",
       command: run.command,
@@ -258,9 +259,12 @@ export function captureCommandEvent(
       os: process.platform,
       arch: process.arch,
       node_version: process.version,
-      is_ci: isCi(run.options.env),
-      ci_name: detectCiName(run.options.env),
+      is_ci: isCiRun,
     };
+
+    if (isCiRun) {
+      properties.ci_name = detectCiName(run.options.env);
+    }
 
     if (run.transport) {
       properties.transport = run.transport;
@@ -509,7 +513,7 @@ function parseTelemetryState(value: unknown): TelemetryState | null {
 }
 
 function isValidUuid(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
     value,
   );
 }

--- a/cli/src/lib/telemetry.ts
+++ b/cli/src/lib/telemetry.ts
@@ -64,7 +64,7 @@ export interface TelemetryEvent {
 
 export interface TelemetryClient {
   capture(event: TelemetryEvent): void | Promise<void>;
-  flush(): Promise<void>;
+  flush(timeoutMs?: number): Promise<void>;
 }
 
 export interface TelemetryOptions extends CachePathOptions {
@@ -213,9 +213,10 @@ export function initTelemetry(
       }
 
       try {
+        const timeoutMs = options.flushTimeoutMs ?? DEFAULT_FLUSH_TIMEOUT_MS;
         await withTimeout(
-          flushClient(run, client),
-          options.flushTimeoutMs ?? DEFAULT_FLUSH_TIMEOUT_MS,
+          flushClient(run, client, timeoutMs),
+          timeoutMs,
         );
       } catch {
         // Telemetry is best-effort and must never affect CLI behavior.
@@ -227,13 +228,14 @@ export function initTelemetry(
 async function flushClient(
   run: ActiveTelemetryRun,
   client: TelemetryClient,
+  timeoutMs: number,
 ): Promise<void> {
   const pendingCaptures = run.pendingCaptures.splice(0);
   if (pendingCaptures.length > 0) {
     await Promise.allSettled(pendingCaptures);
   }
 
-  await client.flush();
+  await client.flush(timeoutMs);
 }
 
 export function captureCommandEvent(
@@ -383,8 +385,8 @@ class PostHogTelemetryClient implements TelemetryClient {
     return this.client.captureImmediate(event);
   }
 
-  async flush(): Promise<void> {
-    await this.client.flush();
+  async flush(timeoutMs: number = DEFAULT_FLUSH_TIMEOUT_MS): Promise<void> {
+    await this.client.shutdown(timeoutMs);
   }
 }
 

--- a/cli/src/lib/telemetry.ts
+++ b/cli/src/lib/telemetry.ts
@@ -56,12 +56,14 @@ export interface TelemetryStatus {
   disableReason: TelemetryDisableReason | null;
 }
 
+export interface TelemetryEvent {
+  distinctId: string;
+  event: string;
+  properties: Record<string, unknown>;
+}
+
 export interface TelemetryClient {
-  capture(event: {
-    distinctId: string;
-    event: string;
-    properties: Record<string, unknown>;
-  }): void;
+  capture(event: TelemetryEvent): void | Promise<void>;
   flush(): Promise<void>;
 }
 
@@ -96,6 +98,7 @@ interface ActiveTelemetryRun {
   transport?: TelemetryTransport;
   shouldCapture: boolean;
   captured: boolean;
+  pendingCaptures: Promise<void>[];
   client?: TelemetryClient;
   fallbackInstallId?: string;
 }
@@ -184,6 +187,7 @@ export function initTelemetry(
     commandOptOut: false,
     shouldCapture: false,
     captured: false,
+    pendingCaptures: [],
   };
   activeRun = run;
 
@@ -210,7 +214,7 @@ export function initTelemetry(
 
       try {
         await withTimeout(
-          client.flush(),
+          flushClient(run, client),
           options.flushTimeoutMs ?? DEFAULT_FLUSH_TIMEOUT_MS,
         );
       } catch {
@@ -218,6 +222,18 @@ export function initTelemetry(
       }
     },
   };
+}
+
+async function flushClient(
+  run: ActiveTelemetryRun,
+  client: TelemetryClient,
+): Promise<void> {
+  const pendingCaptures = run.pendingCaptures.splice(0);
+  if (pendingCaptures.length > 0) {
+    await Promise.allSettled(pendingCaptures);
+  }
+
+  await client.flush();
 }
 
 export function captureCommandEvent(
@@ -282,11 +298,14 @@ export function captureCommandEvent(
     }
 
     const client = getOrCreateClient(run);
-    client.capture({
+    const pendingCapture = client.capture({
       distinctId,
       event: TELEMETRY_EVENT_NAME,
       properties,
     });
+    if (pendingCapture) {
+      run.pendingCaptures.push(pendingCapture.catch(() => {}));
+    }
   } catch {
     // Telemetry is best-effort and must never affect CLI behavior.
   }
@@ -349,10 +368,24 @@ function resolveInstallId(
 function getOrCreateClient(run: ActiveTelemetryRun): TelemetryClient {
   run.client ??=
     run.options.createClient?.() ??
-    (new PostHog(POSTHOG_KEY, {
-      host: POSTHOG_HOST,
-    }) as TelemetryClient);
+    new PostHogTelemetryClient(
+      new PostHog(POSTHOG_KEY, {
+        host: POSTHOG_HOST,
+      }),
+    );
   return run.client;
+}
+
+class PostHogTelemetryClient implements TelemetryClient {
+  constructor(private readonly client: PostHog) {}
+
+  capture(event: TelemetryEvent): Promise<void> {
+    return this.client.captureImmediate(event);
+  }
+
+  async flush(): Promise<void> {
+    await this.client.flush();
+  }
 }
 
 function writeDebugPayload(

--- a/cli/tests/agent-friendly-cli.test.ts
+++ b/cli/tests/agent-friendly-cli.test.ts
@@ -19,7 +19,11 @@ async function runCli(
   return await new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [TSX_CLI_PATH, CLI_ENTRY_PATH, ...args], {
       cwd: CLI_DIR,
-      env: { ...process.env, MCPJAM_CLI_DISABLE_BROWSER_OPEN: "1" },
+      env: {
+        ...process.env,
+        MCPJAM_CLI_DISABLE_BROWSER_OPEN: "1",
+        MCPJAM_TELEMETRY_DISABLED: "1",
+      },
       stdio: ["pipe", "pipe", "pipe"],
     });
     let stdout = "";

--- a/cli/tests/apps-debug.test.ts
+++ b/cli/tests/apps-debug.test.ts
@@ -25,7 +25,11 @@ async function runCli(args: string[]): Promise<{
       {
         cwd: CLI_DIR,
         encoding: "utf8",
-        env: { ...process.env, MCPJAM_CLI_DISABLE_BROWSER_OPEN: "1" },
+        env: {
+          ...process.env,
+          MCPJAM_CLI_DISABLE_BROWSER_OPEN: "1",
+          MCPJAM_TELEMETRY_DISABLED: "1",
+        },
       },
       (error, stdout, stderr) => {
         if (

--- a/cli/tests/index.test.ts
+++ b/cli/tests/index.test.ts
@@ -5,6 +5,12 @@ import packageJson from "../package.json" with { type: "json" };
 import { main, runCliEntrypoint } from "../src/index.js";
 
 const pkgVersion = packageJson.version;
+const telemetryDisabled = {
+  env: {
+    ...process.env,
+    MCPJAM_TELEMETRY_DISABLED: "1",
+  },
+};
 
 async function captureProcessOutput<T>(
   fn: () => Promise<T>,
@@ -45,14 +51,14 @@ async function captureProcessOutput<T>(
 
 test("main treats help and version output as non-command success", async () => {
   const helpRun = await captureProcessOutput(() =>
-    main(["node", "mcpjam", "--help"]),
+    main(["node", "mcpjam", "--help"], { telemetry: telemetryDisabled }),
   );
   assert.equal(helpRun.result.exitCode, 0);
   assert.equal(helpRun.result.shouldCheckForUpdates, false);
   assert.match(helpRun.stdout, /Usage: mcpjam/);
 
   const versionRun = await captureProcessOutput(() =>
-    main(["node", "mcpjam", "--version"]),
+    main(["node", "mcpjam", "--version"], { telemetry: telemetryDisabled }),
   );
   assert.equal(versionRun.result.exitCode, 0);
   assert.equal(versionRun.result.shouldCheckForUpdates, false);
@@ -78,6 +84,7 @@ test("runCliEntrypoint invokes update check after successful commands", async ()
           "--stable",
         ],
         {
+          telemetry: telemetryDisabled,
           checkForUpdates(version) {
             checkedVersion = version;
           },
@@ -97,6 +104,7 @@ test("runCliEntrypoint does not append update text after usage errors", async ()
   let checked = false;
   const run = await captureProcessOutput(() =>
     runCliEntrypoint(["node", "mcpjam", "not-a-command"], {
+      telemetry: telemetryDisabled,
       checkForUpdates() {
         checked = true;
         process.stderr.write("unexpected update notice\n");

--- a/cli/tests/server-rpc.test.ts
+++ b/cli/tests/server-rpc.test.ts
@@ -24,6 +24,7 @@ async function runCli(args: string[]): Promise<{
       {
         cwd: CLI_DIR,
         encoding: "utf8",
+        env: { ...process.env, MCPJAM_TELEMETRY_DISABLED: "1" },
       },
       (error, stdout, stderr) => {
         if (error && typeof (error as NodeJS.ErrnoException).code !== "number") {

--- a/cli/tests/telemetry.test.ts
+++ b/cli/tests/telemetry.test.ts
@@ -342,6 +342,51 @@ test("successful command emits one allowlisted CLI event with CI tags", async ()
   assert.doesNotMatch(JSON.stringify(event), /sensitive-workflow/);
 });
 
+test("telemetry flush waits for async client captures", async () => {
+  const statePath = await createStatePath();
+  const events: CapturedEvent[] = [];
+  let flushCount = 0;
+
+  const run = await captureProcessOutput(() =>
+    main(
+      [
+        "node",
+        "mcpjam",
+        "--format",
+        "json",
+        "inspector",
+        "stop",
+        "--inspector-url",
+        "http://127.0.0.1:1",
+      ],
+      {
+        telemetry: {
+          statePath,
+          env: cleanTelemetryEnv(),
+          createId: () => UUID_A,
+          createClient: () => ({
+            capture(event) {
+              return new Promise<void>((resolve) => {
+                setTimeout(() => {
+                  events.push(event);
+                  resolve();
+                }, 25);
+              });
+            },
+            async flush() {
+              flushCount += 1;
+            },
+          }),
+        },
+      },
+    ),
+  );
+
+  assert.equal(run.result.exitCode, 0, run.stderr);
+  assert.equal(events.length, 1);
+  assert.equal(flushCount, 1);
+});
+
 test("non-CI command omits ci_name", async () => {
   const statePath = await createStatePath();
   const recorder = createRecordingClient();

--- a/cli/tests/telemetry.test.ts
+++ b/cli/tests/telemetry.test.ts
@@ -1,0 +1,456 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { startMockHttpServer } from "../../sdk/tests/mock-servers/index.js";
+import { main } from "../src/index.js";
+import {
+  getTelemetryStatus,
+  readTelemetryState,
+  setTelemetryEnabled,
+  type TelemetryClient,
+  type TelemetryOptions,
+} from "../src/lib/telemetry.js";
+
+const UUID_A = "11111111-1111-4111-8111-111111111111";
+const UUID_B = "22222222-2222-4222-8222-222222222222";
+
+type CapturedEvent = Parameters<TelemetryClient["capture"]>[0];
+
+async function createStatePath(): Promise<string> {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-telemetry-"));
+  return path.join(directory, "telemetry.json");
+}
+
+function cleanTelemetryEnv(
+  overrides: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const key of [
+    "DO_NOT_TRACK",
+    "MCPJAM_TELEMETRY_DISABLED",
+    "MCPJAM_TELEMETRY_DEBUG",
+    "CI",
+    "GITHUB_ACTIONS",
+    "GITLAB_CI",
+    "CIRCLECI",
+    "BUILDKITE",
+    "JENKINS_URL",
+    "JENKINS_HOME",
+    "VERCEL",
+    "NETLIFY",
+  ]) {
+    delete env[key];
+  }
+  return { ...env, ...overrides };
+}
+
+function createRecordingClient(): {
+  events: CapturedEvent[];
+  createClient: () => TelemetryClient;
+  flushes: () => number;
+} {
+  const events: CapturedEvent[] = [];
+  let flushCount = 0;
+
+  return {
+    events,
+    createClient: () => ({
+      capture(event) {
+        events.push(event);
+      },
+      async flush() {
+        flushCount += 1;
+      },
+    }),
+    flushes: () => flushCount,
+  };
+}
+
+async function captureProcessOutput<T>(
+  fn: () => Promise<T>,
+): Promise<{
+  result: T;
+  stdout: string;
+  stderr: string;
+}> {
+  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const originalExitCode = process.exitCode;
+  let stdout = "";
+  let stderr = "";
+
+  process.exitCode = undefined;
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    stdout += String(chunk);
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    stderr += String(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    const result = await fn();
+    return {
+      result,
+      stdout,
+      stderr,
+    };
+  } finally {
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+    process.exitCode = originalExitCode;
+  }
+}
+
+test("telemetry state creates, reuses, disables, enables, and replaces invalid state", async () => {
+  const statePath = await createStatePath();
+  const env = cleanTelemetryEnv();
+
+  assert.deepEqual(getTelemetryStatus({ statePath, env }), {
+    enabled: true,
+    installId: null,
+    installIdCreated: false,
+    stateFile: statePath,
+    debugMode: false,
+    disableReason: null,
+  });
+
+  const disabled = setTelemetryEnabled(false, {
+    statePath,
+    env,
+    now: () => new Date("2026-01-01T00:00:00.000Z"),
+  });
+  assert.equal(disabled.enabled, false);
+  assert.equal(disabled.installId, undefined);
+
+  const enabled = setTelemetryEnabled(true, {
+    statePath,
+    env,
+    createId: () => UUID_A,
+    now: () => new Date("2026-01-01T00:00:01.000Z"),
+  });
+  assert.equal(enabled.enabled, true);
+  assert.equal(enabled.installId, UUID_A);
+
+  const disabledAgain = setTelemetryEnabled(false, {
+    statePath,
+    env,
+    createId: () => UUID_B,
+  });
+  assert.equal(disabledAgain.installId, UUID_A);
+
+  await writeFile(
+    statePath,
+    '{"version":1,"enabled":true,"installId":"not-a-uuid","createdAt":"x","updatedAt":"x"}\n',
+    "utf8",
+  );
+  const replaced = setTelemetryEnabled(true, {
+    statePath,
+    env,
+    createId: () => UUID_B,
+  });
+  assert.equal(replaced.installId, UUID_B);
+});
+
+test("telemetry opt-outs prevent client creation and state creation", async () => {
+  for (const scenario of [
+    {
+      name: "flag",
+      argv: ["node", "mcpjam", "--no-telemetry", "server", "probe", "--url", "not-a-url"],
+      env: cleanTelemetryEnv(),
+    },
+    {
+      name: "DO_NOT_TRACK",
+      argv: ["node", "mcpjam", "server", "probe", "--url", "not-a-url"],
+      env: cleanTelemetryEnv({ DO_NOT_TRACK: "1" }),
+    },
+    {
+      name: "MCPJAM_TELEMETRY_DISABLED",
+      argv: ["node", "mcpjam", "server", "probe", "--url", "not-a-url"],
+      env: cleanTelemetryEnv({ MCPJAM_TELEMETRY_DISABLED: "1" }),
+    },
+  ]) {
+    const statePath = await createStatePath();
+    let clientCreated = false;
+
+    const run = await captureProcessOutput(() =>
+      main(scenario.argv, {
+        telemetry: {
+          statePath,
+          env: scenario.env,
+          createClient() {
+            clientCreated = true;
+            throw new Error(`client created for ${scenario.name}`);
+          },
+        },
+      }),
+    );
+
+    assert.equal(run.result.exitCode, 2);
+    assert.equal(clientCreated, false);
+    assert.equal(readTelemetryState({ statePath, env: scenario.env }), null);
+  }
+});
+
+test("persisted disabled state prevents telemetry until re-enabled", async () => {
+  const statePath = await createStatePath();
+  const env = cleanTelemetryEnv();
+  setTelemetryEnabled(false, { statePath, env });
+
+  const recorder = createRecordingClient();
+  const run = await captureProcessOutput(() =>
+    main(["node", "mcpjam", "server", "probe", "--url", "not-a-url"], {
+      telemetry: {
+        statePath,
+        env,
+        createClient: recorder.createClient,
+      },
+    }),
+  );
+
+  assert.equal(run.result.exitCode, 2);
+  assert.equal(recorder.events.length, 0);
+  assert.equal(readTelemetryState({ statePath, env })?.installId, undefined);
+});
+
+test("debug mode logs sanitized payloads and does not send", async () => {
+  const statePath = await createStatePath();
+  const env = cleanTelemetryEnv({ MCPJAM_TELEMETRY_DEBUG: "1" });
+  let clientCreated = false;
+
+  const run = await captureProcessOutput(() =>
+    main(["node", "mcpjam", "server", "probe", "--url", "not-a-url"], {
+      telemetry: {
+        statePath,
+        env,
+        createId: () => UUID_A,
+        createClient() {
+          clientCreated = true;
+          throw new Error("debug mode should not send");
+        },
+      },
+    }),
+  );
+
+  assert.equal(run.result.exitCode, 2);
+  assert.equal(clientCreated, false);
+  assert.match(run.stderr, /MCPJam telemetry debug:/);
+  assert.match(run.stderr, /"event":"cli_command"/);
+  assert.match(run.stderr, /"distinct_id":"11111111-1111-4111-8111-111111111111"/);
+});
+
+test("telemetry status, disable, and enable support human and JSON output", async () => {
+  const statePath = await createStatePath();
+  const env = cleanTelemetryEnv();
+  const telemetry: TelemetryOptions = {
+    statePath,
+    env,
+    createId: () => UUID_A,
+  };
+
+  const initialStatus = await captureProcessOutput(() =>
+    main(["node", "mcpjam", "--format", "human", "telemetry", "status"], {
+      telemetry,
+    }),
+  );
+  assert.equal(initialStatus.result.exitCode, 0);
+  assert.match(initialStatus.stdout, /Telemetry: enabled/);
+  assert.match(initialStatus.stdout, /Install ID: not created yet/);
+  assert.equal(readTelemetryState({ statePath, env }), null);
+
+  const disabled = await captureProcessOutput(() =>
+    main(["node", "mcpjam", "--format", "json", "telemetry", "disable"], {
+      telemetry,
+    }),
+  );
+  const disabledPayload = JSON.parse(disabled.stdout) as {
+    telemetry: { enabled: boolean; installId: string | null; disableReason: string };
+  };
+  assert.equal(disabled.result.exitCode, 0);
+  assert.equal(disabledPayload.telemetry.enabled, false);
+  assert.equal(disabledPayload.telemetry.installId, null);
+  assert.equal(disabledPayload.telemetry.disableReason, "state");
+
+  const enabled = await captureProcessOutput(() =>
+    main(["node", "mcpjam", "--format", "json", "telemetry", "enable"], {
+      telemetry,
+    }),
+  );
+  const enabledPayload = JSON.parse(enabled.stdout) as {
+    telemetry: { enabled: boolean; installId: string | null; disableReason: string | null };
+  };
+  assert.equal(enabled.result.exitCode, 0);
+  assert.equal(enabledPayload.telemetry.enabled, true);
+  assert.equal(enabledPayload.telemetry.installId, UUID_A);
+  assert.equal(enabledPayload.telemetry.disableReason, null);
+});
+
+test("successful command emits one allowlisted CLI event with CI tags", async () => {
+  const statePath = await createStatePath();
+  const server = await startMockHttpServer();
+  const recorder = createRecordingClient();
+
+  try {
+    const run = await captureProcessOutput(() =>
+      main(
+        [
+          "node",
+          "mcpjam",
+          "--format",
+          "json",
+          "server",
+          "export",
+          "--url",
+          server.url,
+          "--stable",
+        ],
+        {
+          telemetry: {
+            statePath,
+            env: cleanTelemetryEnv({
+              CI: "true",
+              GITHUB_ACTIONS: "true",
+              GITHUB_WORKFLOW: "sensitive-workflow",
+            }),
+            createId: () => UUID_A,
+            createClient: recorder.createClient,
+          },
+        },
+      ),
+    );
+
+    assert.equal(run.result.exitCode, 0, run.stderr);
+    assert.equal(recorder.events.length, 1);
+    assert.equal(recorder.flushes(), 1);
+
+    const event = recorder.events[0];
+    assert.equal(event.distinctId, UUID_A);
+    assert.equal(event.event, "cli_command");
+    assert.deepEqual(event.properties, {
+      platform: "cli",
+      command: "server export",
+      success: true,
+      exit_code: 0,
+      duration_ms: event.properties.duration_ms,
+      cli_version: "3.0.0",
+      os: process.platform,
+      arch: process.arch,
+      node_version: process.version,
+      is_ci: true,
+      ci_name: "github_actions",
+      transport: "http",
+    });
+    assert.equal(typeof event.properties.duration_ms, "number");
+    assert.doesNotMatch(JSON.stringify(event), /sensitive-workflow/);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("action-level failures emit sanitized errors without sensitive argv values", async () => {
+  const statePath = await createStatePath();
+  const recorder = createRecordingClient();
+  const sensitiveValues = [
+    "https://secret.example/mcp",
+    "secret-token",
+    "Authorization: Bearer secret-header",
+    "/tmp/secret-debug.json",
+  ];
+
+  const run = await captureProcessOutput(() =>
+    main(
+      [
+        "node",
+        "mcpjam",
+        "--format",
+        "json",
+        "server",
+        "probe",
+        "--url",
+        sensitiveValues[0],
+        "--access-token",
+        sensitiveValues[1],
+        "--header",
+        sensitiveValues[2],
+        "--debug-out",
+        sensitiveValues[3],
+        "--protocol-version",
+        "bad-version",
+      ],
+      {
+        telemetry: {
+          statePath,
+          env: cleanTelemetryEnv(),
+          createId: () => UUID_A,
+          createClient: recorder.createClient,
+        },
+      },
+    ),
+  );
+
+  assert.equal(run.result.exitCode, 2);
+  assert.equal(recorder.events.length, 1);
+  const eventText = JSON.stringify(recorder.events[0]);
+  assert.equal(recorder.events[0].properties.error_code, "USAGE_ERROR");
+  for (const sensitiveValue of sensitiveValues) {
+    assert.doesNotMatch(eventText, new RegExp(escapeRegExp(sensitiveValue)));
+  }
+});
+
+test("help, version, unknown commands, and telemetry commands emit no telemetry", async () => {
+  for (const argv of [
+    ["node", "mcpjam"],
+    ["node", "mcpjam", "--help"],
+    ["node", "mcpjam", "--version"],
+    ["node", "mcpjam", "not-a-command"],
+    ["node", "mcpjam", "telemetry", "status"],
+    ["node", "mcpjam", "telemetry", "disable"],
+    ["node", "mcpjam", "telemetry", "enable"],
+  ]) {
+    const statePath = await createStatePath();
+    const recorder = createRecordingClient();
+    const run = await captureProcessOutput(() =>
+      main(argv, {
+        telemetry: {
+          statePath,
+          env: cleanTelemetryEnv(),
+          createId: () => UUID_A,
+          createClient: recorder.createClient,
+        },
+      }),
+    );
+
+    assert.equal(recorder.events.length, 0, `${argv.join(" ")} emitted telemetry`);
+    assert.ok([0, 2].includes(run.result.exitCode));
+  }
+});
+
+test("capture falls back to a per-run UUID when the telemetry file cannot be written", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-telemetry-"));
+  const parentFile = path.join(directory, "not-a-directory");
+  await writeFile(parentFile, "x", "utf8");
+  const recorder = createRecordingClient();
+
+  const run = await captureProcessOutput(() =>
+    main(["node", "mcpjam", "server", "probe", "--url", "not-a-url"], {
+      telemetry: {
+        statePath: path.join(parentFile, "telemetry.json"),
+        env: cleanTelemetryEnv(),
+        createId: () => UUID_A,
+        createClient: recorder.createClient,
+      },
+    }),
+  );
+
+  assert.equal(run.result.exitCode, 2);
+  assert.equal(recorder.events.length, 1);
+  assert.equal(recorder.events[0].distinctId, UUID_A);
+  await assert.rejects(readFile(path.join(parentFile, "telemetry.json"), "utf8"));
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/cli/tests/telemetry.test.ts
+++ b/cli/tests/telemetry.test.ts
@@ -346,6 +346,7 @@ test("telemetry flush waits for async client captures", async () => {
   const statePath = await createStatePath();
   const events: CapturedEvent[] = [];
   let flushCount = 0;
+  let flushTimeoutMs: number | undefined;
 
   const run = await captureProcessOutput(() =>
     main(
@@ -373,8 +374,9 @@ test("telemetry flush waits for async client captures", async () => {
                 }, 25);
               });
             },
-            async flush() {
+            async flush(timeoutMs) {
               flushCount += 1;
+              flushTimeoutMs = timeoutMs;
             },
           }),
         },
@@ -385,6 +387,7 @@ test("telemetry flush waits for async client captures", async () => {
   assert.equal(run.result.exitCode, 0, run.stderr);
   assert.equal(events.length, 1);
   assert.equal(flushCount, 1);
+  assert.equal(flushTimeoutMs, 3_000);
 });
 
 test("non-CI command omits ci_name", async () => {

--- a/cli/tests/telemetry.test.ts
+++ b/cli/tests/telemetry.test.ts
@@ -3,7 +3,6 @@ import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { startMockHttpServer } from "../../sdk/tests/mock-servers/index.js";
 import { main } from "../src/index.js";
 import {
   getTelemetryStatus,
@@ -290,64 +289,78 @@ test("telemetry status, disable, and enable support human and JSON output", asyn
 
 test("successful command emits one allowlisted CLI event with CI tags", async () => {
   const statePath = await createStatePath();
-  const server = await startMockHttpServer();
   const recorder = createRecordingClient();
 
-  try {
-    const run = await captureProcessOutput(() =>
-      main(
-        [
-          "node",
-          "mcpjam",
-          "--format",
-          "json",
-          "server",
-          "export",
-          "--url",
-          server.url,
-          "--stable",
-        ],
-        {
-          telemetry: {
-            statePath,
-            env: cleanTelemetryEnv({
-              CI: "true",
-              GITHUB_ACTIONS: "true",
-              GITHUB_WORKFLOW: "sensitive-workflow",
-            }),
-            createId: () => UUID_A,
-            createClient: recorder.createClient,
-          },
+  const run = await captureProcessOutput(() =>
+    main(
+      [
+        "node",
+        "mcpjam",
+        "--format",
+        "json",
+        "inspector",
+        "stop",
+        "--inspector-url",
+        "http://127.0.0.1:1",
+      ],
+      {
+        telemetry: {
+          statePath,
+          env: cleanTelemetryEnv({
+            CI: "true",
+            GITHUB_ACTIONS: "true",
+            GITHUB_WORKFLOW: "sensitive-workflow",
+          }),
+          createId: () => UUID_A,
+          createClient: recorder.createClient,
         },
-      ),
-    );
+      },
+    ),
+  );
 
-    assert.equal(run.result.exitCode, 0, run.stderr);
-    assert.equal(recorder.events.length, 1);
-    assert.equal(recorder.flushes(), 1);
+  assert.equal(run.result.exitCode, 0, run.stderr);
+  assert.equal(recorder.events.length, 1);
+  assert.equal(recorder.flushes(), 1);
 
-    const event = recorder.events[0];
-    assert.equal(event.distinctId, UUID_A);
-    assert.equal(event.event, "cli_command");
-    assert.deepEqual(event.properties, {
-      platform: "cli",
-      command: "server export",
-      success: true,
-      exit_code: 0,
-      duration_ms: event.properties.duration_ms,
-      cli_version: "3.0.0",
-      os: process.platform,
-      arch: process.arch,
-      node_version: process.version,
-      is_ci: true,
-      ci_name: "github_actions",
-      transport: "http",
-    });
-    assert.equal(typeof event.properties.duration_ms, "number");
-    assert.doesNotMatch(JSON.stringify(event), /sensitive-workflow/);
-  } finally {
-    await server.stop();
-  }
+  const event = recorder.events[0];
+  assert.equal(event.distinctId, UUID_A);
+  assert.equal(event.event, "cli_command");
+  assert.deepEqual(event.properties, {
+    platform: "cli",
+    command: "inspector stop",
+    success: true,
+    exit_code: 0,
+    duration_ms: event.properties.duration_ms,
+    cli_version: "3.0.0",
+    os: process.platform,
+    arch: process.arch,
+    node_version: process.version,
+    is_ci: true,
+    ci_name: "github_actions",
+  });
+  assert.equal(typeof event.properties.duration_ms, "number");
+  assert.doesNotMatch(JSON.stringify(event), /sensitive-workflow/);
+});
+
+test("non-CI command omits ci_name", async () => {
+  const statePath = await createStatePath();
+  const recorder = createRecordingClient();
+
+  const run = await captureProcessOutput(() =>
+    main(["node", "mcpjam", "server", "probe", "--url", "not-a-url"], {
+      telemetry: {
+        statePath,
+        env: cleanTelemetryEnv(),
+        createId: () => UUID_A,
+        createClient: recorder.createClient,
+      },
+    }),
+  );
+
+  assert.equal(run.result.exitCode, 2);
+  assert.equal(recorder.events.length, 1);
+  assert.equal(recorder.events[0].properties.is_ci, false);
+  assert.equal("ci_name" in recorder.events[0].properties, false);
 });
 
 test("action-level failures emit sanitized errors without sensitive argv values", async () => {

--- a/docs/cli/overview.mdx
+++ b/docs/cli/overview.mdx
@@ -43,6 +43,7 @@ npx -y @mcpjam/cli@latest --help
 | [`resources`](/cli/tools-resources-prompts) | Read resources and templates | `list`, `read`, `templates` |
 | [`prompts`](/cli/tools-resources-prompts) | Fetch prompts | `list`, `get` |
 | [`protocol`](/cli/reference) | MCP protocol conformance checks | `conformance`, `conformance-suite` |
+| [`telemetry`](/cli/telemetry) | Inspect and configure anonymous CLI telemetry | `status`, `disable`, `enable` |
 
 ## Global flags
 
@@ -53,6 +54,7 @@ These flags apply to every command.
 | `--timeout <ms>` | `30000` | Request timeout in milliseconds |
 | `--rpc` | off | Include raw JSON-RPC request/response logs in JSON output under `_rpcLogs` |
 | `--quiet` | off | Suppress non-result progress output on stderr |
+| `--no-telemetry` | off | Disable anonymous telemetry for this invocation |
 | `--format <format>` | `human` on TTY, `json` when piped | Raw output format (`json` or `human`) |
 | `-v, --version` | | Print the CLI version |
 

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -13,6 +13,7 @@ Complete flag tables for every `mcpjam` command. For guides and recipes, see the
 | `--timeout <ms>` | `30000` | Request timeout in milliseconds |
 | `--rpc` | off | Include raw JSON-RPC logs in JSON output under `_rpcLogs` |
 | `--quiet` | off | Suppress non-result progress output on stderr |
+| `--no-telemetry` | off | Disable anonymous telemetry for this invocation |
 | `--format <format>` | `human` on TTY, `json` when piped | Raw output format (`json` or `human`) |
 | `-v, --version` | | Print the CLI version |
 
@@ -376,6 +377,24 @@ Stop the local Inspector if it is running.
 | Flag | Required | Description |
 |------|----------|-------------|
 | `--inspector-url <url>` | No | Local Inspector base URL |
+
+---
+
+## `telemetry` commands
+
+Telemetry commands inspect and configure anonymous CLI telemetry. They never emit telemetry events themselves.
+
+### `telemetry status`
+
+Shows the effective telemetry state, install ID state, state file path, debug mode, and disable reason when disabled. This command does not create an install ID.
+
+### `telemetry disable`
+
+Persistently disables anonymous CLI telemetry by writing `enabled: false` to the telemetry state file. If no install ID exists yet, this command does not create one.
+
+### `telemetry enable`
+
+Persistently enables anonymous CLI telemetry. If no install ID exists yet, this command creates a random install UUID.
 
 ---
 

--- a/docs/cli/telemetry.mdx
+++ b/docs/cli/telemetry.mdx
@@ -1,0 +1,85 @@
+---
+title: "CLI Telemetry"
+description: "Anonymous command-level telemetry, opt-outs, and debug mode"
+icon: "activity"
+---
+
+`mcpjam` collects anonymous command-level telemetry so we can understand CLI usage and reliability. Telemetry is designed for aggregate product insight, not user or server inspection.
+
+Telemetry is enabled by default. The first command invocation that is not opted out writes `telemetry.json` with `enabled: true` and a random install UUID.
+
+## What's collected
+
+The CLI emits one `cli_command` event after a command action starts. Event properties are limited to:
+
+| Property | Description |
+|----------|-------------|
+| `platform` | Always `cli` |
+| `command` | Command and subcommand names only, such as `server probe` |
+| `success` | Whether the command exited successfully |
+| `exit_code` | CLI exit code |
+| `duration_ms` | Command duration in milliseconds |
+| `error_code` | Normalized error code, not the error message |
+| `cli_version` | Installed CLI version |
+| `os` | Operating system, such as `darwin`, `linux`, or `win32` |
+| `arch` | CPU architecture |
+| `node_version` | Node.js version |
+| `transport` | `http` or `stdio`, inferred from flag presence |
+| `is_ci` | Whether the command appears to be running in CI |
+| `ci_name` | Coarse CI provider enum, such as `github_actions`, only when in CI |
+
+## What's not collected
+
+Telemetry does not collect raw argv, URLs, hostnames, ports, tokens, headers, environment values, working directories, file paths, tool names, resource names, prompt names, error messages, stack traces, repository names, branch names, workflow names, or CI job IDs.
+
+## Install ID
+
+Telemetry uses a random install UUID as the event `distinct_id`. The UUID is stored in the same platform cache directory used by update checks, in a `telemetry.json` file:
+
+| Platform | Cache directory |
+|----------|-----------------|
+| macOS | `~/Library/Caches/mcpjam` |
+| Linux | `$XDG_CACHE_HOME/mcpjam` or `~/.cache/mcpjam` |
+| Windows | `%LOCALAPPDATA%\\mcpjam\\Cache` |
+
+The install ID is created on the first real telemetry capture or when you run `mcpjam telemetry enable`. Running `mcpjam telemetry disable` before an ID exists does not create one.
+
+## Opt out
+
+Disable telemetry for one invocation:
+
+```bash
+mcpjam --no-telemetry server doctor --url https://your-server.com/mcp
+```
+
+Disable telemetry persistently:
+
+```bash
+mcpjam telemetry disable
+```
+
+Check or re-enable telemetry:
+
+```bash
+mcpjam telemetry status
+mcpjam telemetry enable
+```
+
+Environment opt-outs:
+
+| Variable | Effect |
+|----------|--------|
+| `DO_NOT_TRACK=1` | Disable telemetry |
+| `MCPJAM_TELEMETRY_DISABLED=1` | Disable telemetry |
+
+`--no-telemetry` overrides environment and persisted state for the current invocation. Disable environment variables override persisted state.
+
+## Debug mode
+
+Set `MCPJAM_TELEMETRY_DEBUG=1` to print the exact sanitized payload to stderr instead of sending it:
+
+```bash
+MCPJAM_TELEMETRY_DEBUG=1 mcpjam server probe --url https://your-server.com/mcp
+```
+
+Debug mode only logs when telemetry is otherwise enabled. If `--no-telemetry`, `DO_NOT_TRACK=1`, `MCPJAM_TELEMETRY_DISABLED=1`, or persisted disabled state applies, no payload is logged or sent.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -49,6 +49,7 @@
           "cli/apps-conformance",
           "cli/tools-resources-prompts",
           "cli/ci",
+          "cli/telemetry",
           "cli/reference"
         ]
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
       "version": "3.0.0",
       "dependencies": {
         "@mcpjam/sdk": "^1.0.0",
-        "commander": "^12.1.0"
+        "commander": "^12.1.0",
+        "posthog-node": "^5.24.10"
       },
       "bin": {
         "mcpjam": "dist/index.js"


### PR DESCRIPTION
## Summary
- Add PostHog-backed CLI telemetry with a persisted random install UUID in the existing cache directory
- Support `mcpjam telemetry status|enable|disable`, `--no-telemetry`, `DO_NOT_TRACK=1`, and `MCPJAM_TELEMETRY_DISABLED=1`
- Emit only allowlisted command-level properties, tag CI usage coarsely, and support debug log-only mode
- Document telemetry behavior in the CLI README

## Testing
- Added unit and integration coverage for state file handling, opt-outs, debug mode, CI tagging, and payload allowlisting
- Verified the CLI package typechecks, builds, and passes the full test suite

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds always-on-by-default network telemetry and new persisted state in the CLI cache directory; although payload is allowlisted and best-effort, it touches CLI lifecycle/exit handling and introduces a third-party dependency (`posthog-node`).
> 
> **Overview**
> Adds **anonymous, command-level telemetry** to `mcpjam`, backed by PostHog, including a persisted install UUID stored alongside the existing update-check cache.
> 
> Introduces a global `--no-telemetry` flag plus env/state opt-outs (`DO_NOT_TRACK=1`, `MCPJAM_TELEMETRY_DISABLED=1`) and a debug mode (`MCPJAM_TELEMETRY_DEBUG=1`) that prints the sanitized payload instead of sending it; the CLI now captures one `cli_command` event per non-`telemetry` command and flushes on success/error paths.
> 
> Adds `mcpjam telemetry status|enable|disable` commands, updates docs/README to describe what is and is not collected, and extends tests to disable telemetry by default while adding dedicated unit coverage for state handling, opt-outs, CI tagging, and payload allowlisting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c77dcc591eabfcd7aac908123aef1b226268489. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->