### PR TITLE
Remove client config feature gate

### DIFF
--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -38,7 +38,7 @@ import {
 import { JsonImportModal } from "./connection/JsonImportModal";
 import { ServerFormData } from "@/shared/types.js";
 import { MCPIcon } from "./ui/mcp-icon";
-import { usePostHog, useFeatureFlagEnabled } from "posthog-js/react";
+import { usePostHog } from "posthog-js/react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -537,7 +537,6 @@ export function ServersTab({
   onSaveClientConfig,
 }: ServersTabProps) {
   const posthog = usePostHog();
-  const clientConfigEnabled = useFeatureFlagEnabled("client-config-enabled");
   const { isAuthenticated } = useConvexAuth();
   const [pendingQuickConnect, setPendingQuickConnect] =
     useState<PendingQuickConnectState | null>(() => readPendingQuickConnect());
@@ -1132,7 +1131,7 @@ export function ServersTab({
 
   const renderServerActionsMenu = () => (
     <>
-      {clientConfigEnabled === true && onSaveClientConfig ? (
+      {onSaveClientConfig ? (
         <Button
           size="sm"
           variant="outline"

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -1543,7 +1543,7 @@ export function ServersTab({
       />
 
       {/* Client Config Dialog */}
-      {clientConfigEnabled === true && onSaveClientConfig ? (
+      {onSaveClientConfig ? (
         <Dialog open={isClientConfigOpen} onOpenChange={setIsClientConfigOpen}>
           <DialogContent className="flex max-h-[88vh] w-[min(96vw,88rem)] max-w-[88rem] flex-col gap-0 overflow-hidden p-0 sm:max-w-[88rem]">
             <DialogTitle className="sr-only">Connection Settings</DialogTitle>

--- a/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ServersTab.test.tsx
@@ -122,7 +122,6 @@ function createDualTypeCatalogCard(): EnrichedRegistryCatalogCard {
 let mockIsAuthenticated = false;
 let mockCatalogCards: EnrichedRegistryCatalogCard[] = [];
 let mockRegistryLoading = false;
-let mockClientConfigFlagEnabled: boolean | undefined = false;
 let mockJsonRpcPanelVisible = false;
 const mockConnectRegistry = vi.fn();
 const mockLoggerView = vi.fn();
@@ -133,8 +132,7 @@ vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({
     capture: vi.fn(),
   }),
-  useFeatureFlagEnabled: (flag: string) =>
-    flag === "client-config-enabled" ? mockClientConfigFlagEnabled : false,
+  useFeatureFlagEnabled: () => false,
 }));
 
 vi.mock("../client-config/ClientConfigTab", () => ({
@@ -463,7 +461,6 @@ describe("ServersTab shared detail modal", () => {
     mockIsAuthenticated = false;
     mockCatalogCards = [];
     mockRegistryLoading = false;
-    mockClientConfigFlagEnabled = false;
     mockJsonRpcPanelVisible = false;
     mockLoggerView.mockReset();
     mockUseWorkspaceBillingGate.mockImplementation(
@@ -1419,19 +1416,7 @@ describe("ServersTab shared detail modal", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("hides the Connection Settings button when the flag is disabled", () => {
-    mockClientConfigFlagEnabled = false;
-
-    render(<ServersTab {...defaultProps} />);
-
-    expect(
-      screen.queryByRole("button", { name: /connection settings/i })
-    ).not.toBeInTheDocument();
-  });
-
-  it("shows the Connection Settings button and opens the dialog when the flag is enabled", () => {
-    mockClientConfigFlagEnabled = true;
-
+  it("shows the Connection Settings button and opens the dialog", () => {
     render(<ServersTab {...defaultProps} />);
 
     const button = screen.getByRole("button", { name: /connection settings/i });
@@ -1448,8 +1433,6 @@ describe("ServersTab shared detail modal", () => {
   });
 
   it("hides the Connection Settings button when no save handler is provided", () => {
-    mockClientConfigFlagEnabled = true;
-
     render(<ServersTab {...defaultProps} onSaveClientConfig={undefined} />);
 
     expect(

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatboxChatPage } from "../ChatboxChatPage";
@@ -498,14 +498,16 @@ describe("ChatboxChatPage", () => {
         name: "Sign in",
       })
     ).toBeInTheDocument();
-    expect(mockPosthogCapture).toHaveBeenCalledWith(
-      "interactive_signin_required",
-      expect.objectContaining({
-        surface: "chatbox",
-        auth_mode: "guest",
-        status: "required",
-        error_kind: "guest_blocked",
-      })
+    await waitFor(() =>
+      expect(mockPosthogCapture).toHaveBeenCalledWith(
+        "interactive_signin_required",
+        expect.objectContaining({
+          surface: "chatbox",
+          auth_mode: "guest",
+          status: "required",
+          error_kind: "guest_blocked",
+        })
+      )
     );
   });
 


### PR DESCRIPTION
## Summary
- Remove the `client-config-enabled` PostHog flag from `ServersTab`
- Show the Connection Settings button whenever `onSaveClientConfig` is provided
- Update the `ServersTab` tests to match the new behavior

## Testing
- Updated unit coverage for the button visibility and dialog opening behavior
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI visibility change controlled by an existing prop, plus test-only adjustments; minimal impact outside the Servers tab rendering conditions.
> 
> **Overview**
> Removes the PostHog `client-config-enabled` feature gate from `ServersTab`, so **Connection Settings** UI is now shown solely when an `onSaveClientConfig` handler is provided (including the button and the dialog).
> 
> Updates `ServersTab` unit tests to drop flag-driven scenarios and assert the new always-on behavior when the handler exists, and adjusts a `ChatboxChatPage` test to `waitFor` the PostHog capture call to avoid async timing flakiness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6edcac96591516060131ec8238b9d2563b85b35d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->