### PR TITLE
Add skip_verify to Soundcheck release dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ on:
         required: false
         default: false
         type: boolean
+      skip_verify:
+        description: "Skip npm run verify during preflight"
+        required: false
+        default: false
+        type: boolean
 
 env:
   NODE_VERSION: "24.14.0"
@@ -66,6 +71,7 @@ jobs:
         run: npm ci --legacy-peer-deps
 
       - name: Verify workspace
+        if: ${{ !inputs.skip_verify }}
         run: npm run verify
 
       - name: Require green staging smoke for candidate SHA

--- a/soundcheck/src/app/api/release/dispatch/route.ts
+++ b/soundcheck/src/app/api/release/dispatch/route.ts
@@ -51,6 +51,7 @@ interface DispatchBody {
   deploy_backend_prod: boolean;
   promote_production: boolean;
   deploy_mcp_production: boolean;
+  skip_verify: boolean;
 }
 
 function isScope(value: unknown): value is Scope {
@@ -69,11 +70,18 @@ function parseBody(raw: unknown): DispatchBody | null {
   if (typeof body.deploy_backend_prod !== "boolean") return null;
   if (typeof body.promote_production !== "boolean") return null;
   if (typeof body.deploy_mcp_production !== "boolean") return null;
+  if (
+    body.skip_verify !== undefined &&
+    typeof body.skip_verify !== "boolean"
+  ) {
+    return null;
+  }
   return {
     scope: body.scope,
     deploy_backend_prod: body.deploy_backend_prod,
     promote_production: body.promote_production,
-    deploy_mcp_production: body.deploy_mcp_production
+    deploy_mcp_production: body.deploy_mcp_production,
+    skip_verify: body.skip_verify ?? false
   };
 }
 
@@ -121,7 +129,7 @@ export async function POST(request: Request) {
     return NextResponse.json(
       {
         error:
-          "Expected { scope, deploy_backend_prod, promote_production, deploy_mcp_production } with valid values"
+          "Expected { scope, deploy_backend_prod, promote_production, deploy_mcp_production } with optional boolean skip_verify"
       },
       { status: 400 }
     );
@@ -129,6 +137,7 @@ export async function POST(request: Request) {
 
   const runsRelease = parsed.scope !== "none";
   const runsMcp = parsed.deploy_mcp_production;
+  const effectiveSkipVerify = runsRelease && parsed.skip_verify;
   if (!runsRelease && !runsMcp) {
     return NextResponse.json(
       {
@@ -172,6 +181,7 @@ export async function POST(request: Request) {
       deploy_backend_prod: parsed.deploy_backend_prod,
       promote_production: parsed.promote_production,
       deploy_mcp_production: parsed.deploy_mcp_production,
+      skip_verify: effectiveSkipVerify,
       workflows_attempted: attemptedWorkflows
     })
   );
@@ -194,7 +204,8 @@ export async function POST(request: Request) {
           scope: parsed.scope,
           // Workflow dispatch inputs go over the wire as strings.
           deploy_backend_prod: String(parsed.deploy_backend_prod),
-          promote_production: String(parsed.promote_production)
+          promote_production: String(parsed.promote_production),
+          skip_verify: String(effectiveSkipVerify)
         },
         writeToken
       );
@@ -251,6 +262,7 @@ export async function POST(request: Request) {
       deploy_backend_prod: parsed.deploy_backend_prod,
       promote_production: parsed.promote_production,
       deploy_mcp_production: parsed.deploy_mcp_production,
+      skip_verify: effectiveSkipVerify,
       workflows_attempted: attemptedWorkflows,
       workflows_succeeded: succeeded.map((r) => r.workflow),
       workflows_failed: failed.map((r) => r.workflow)

--- a/soundcheck/src/components/run-release.tsx
+++ b/soundcheck/src/components/run-release.tsx
@@ -217,7 +217,7 @@ export function RunRelease() {
             checked={skipVerify}
             onChange={changeSkipVerify}
             disabled={!runsRelease}
-            description="Recovery-only: skip npm run verify; staging and Changesets gates still run."
+            description="Recovery-only: skips typechecks, tests, and inspector build; staging and Changesets gates still run."
           />
         </fieldset>
 

--- a/soundcheck/src/components/run-release.tsx
+++ b/soundcheck/src/components/run-release.tsx
@@ -57,6 +57,7 @@ export function RunRelease() {
   const [deployBackend, setDeployBackend] = useState(false);
   const [promoteProd, setPromoteProd] = useState(false);
   const [deployMcp, setDeployMcp] = useState(false);
+  const [skipVerify, setSkipVerify] = useState(false);
   const [confirming, setConfirming] = useState(false);
   const [feedback, setFeedback] = useState<
     | { kind: "idle" }
@@ -69,6 +70,7 @@ export function RunRelease() {
   const runsRelease = scope !== "none";
   const impactsProd = deployBackend || promoteProd || deployMcp;
   const hasAnyTarget = runsRelease || deployMcp;
+  const effectiveSkipVerify = runsRelease && skipVerify;
 
   // Reset gated flags when scope changes so a stale `true` can't slip into
   // the confirmation modal or the dispatch payload. The checkbox disabling
@@ -77,6 +79,7 @@ export function RunRelease() {
     setScope(next);
     if (next !== "full") setDeployBackend(false);
     if (next === "packages-only" || next === "none") setPromoteProd(false);
+    if (next === "none") setSkipVerify(false);
     setFeedback({ kind: "idle" });
   }
 
@@ -90,6 +93,10 @@ export function RunRelease() {
   }
   function changeDeployMcp(v: boolean) {
     setDeployMcp(v);
+    setFeedback({ kind: "idle" });
+  }
+  function changeSkipVerify(v: boolean) {
+    setSkipVerify(v);
     setFeedback({ kind: "idle" });
   }
 
@@ -109,7 +116,8 @@ export function RunRelease() {
             scope,
             deploy_backend_prod: deployBackend,
             promote_production: promoteProd,
-            deploy_mcp_production: deployMcp
+            deploy_mcp_production: deployMcp,
+            skip_verify: effectiveSkipVerify
           })
         });
         const json = (await res.json()) as {
@@ -201,6 +209,20 @@ export function RunRelease() {
 
         <fieldset className="space-y-2">
           <legend className="mb-2 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
+            Preflight
+          </legend>
+          <FlagRow
+            id="skip-verify"
+            name="skip_verify"
+            checked={skipVerify}
+            onChange={changeSkipVerify}
+            disabled={!runsRelease}
+            description="Recovery-only: skip npm run verify; staging and Changesets gates still run."
+          />
+        </fieldset>
+
+        <fieldset className="space-y-2">
+          <legend className="mb-2 text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground">
             Production flags
           </legend>
           <div className="space-y-2">
@@ -235,6 +257,13 @@ export function RunRelease() {
           <div className="rounded-lg border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning">
             <span className="font-medium">Heads up —</span> this run will touch
             production.
+          </div>
+        ) : null}
+
+        {effectiveSkipVerify ? (
+          <div className="rounded-lg border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning">
+            <span className="font-medium">Recovery mode:</span>{" "}
+            <span className="font-mono">npm run verify</span> will be skipped.
           </div>
         ) : null}
 
@@ -283,6 +312,7 @@ export function RunRelease() {
         deployBackend={deployBackend}
         promoteProd={promoteProd}
         deployMcp={deployMcp}
+        skipVerify={effectiveSkipVerify}
       />
     </Tile>
   );
@@ -336,7 +366,8 @@ function ConfirmModal({
   scope,
   deployBackend,
   promoteProd,
-  deployMcp
+  deployMcp,
+  skipVerify
 }: {
   open: boolean;
   onOpenChange: (v: boolean) => void;
@@ -346,6 +377,7 @@ function ConfirmModal({
   deployBackend: boolean;
   promoteProd: boolean;
   deployMcp: boolean;
+  skipVerify: boolean;
 }) {
   const impactsProd = deployBackend || promoteProd || deployMcp;
   const runsRelease = scope !== "none";
@@ -392,6 +424,19 @@ function ConfirmModal({
               }
             >
               {String(deployBackend)}
+            </dd>
+          </div>
+          <div className="flex gap-3">
+            <dt className="w-44 font-mono text-xs text-muted-foreground">
+              skip_verify
+            </dt>
+            <dd
+              className={
+                "font-mono text-xs " +
+                (skipVerify ? "text-warning" : "text-muted-foreground")
+              }
+            >
+              {String(runsRelease && skipVerify)}
             </dd>
           </div>
           <div className="flex gap-3">


### PR DESCRIPTION
## Summary
- Add a `skip_verify` workflow input to `release.yml` and skip only the `npm run verify` preflight step when enabled
- Thread `skip_verify` through Soundcheck’s release dispatch API and release form
- Surface the option in the confirmation modal and mark it as recovery-only in the UI

## Testing
- `git diff --check`
- YAML syntax validation for `.github/workflows/release.yml`
- Soundcheck TypeScript validation could not be completed in this worktree because dependencies are not installed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Allows bypassing the release preflight verification step, increasing the chance of publishing or promoting with failing tests/typechecks if misused. Scope is limited and explicitly labeled as recovery-only, but it impacts production release safety.
> 
> **Overview**
> Adds a new `skip_verify` workflow-dispatch input to `release.yml` that conditionally skips the `npm run verify` preflight step.
> 
> Threads this flag end-to-end through Soundcheck: the `/api/release/dispatch` route now validates and forwards `skip_verify` (only effective when `scope !== "none"`), audit-logs the effective value, and the Run Release UI exposes a *recovery-only* checkbox with confirmation-modal visibility and safeguards (disabled/cleared when release is not running).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e71072591cc0f5d5b14f65f38e6cfec5984db8cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->