### PR TITLE
Fix auth code

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
@@ -324,6 +324,71 @@ describe("useServerState hosted OAuth callback guards", () => {
     });
   });
 
+  it("forwards the OAuth callback state parameter to completeHostedOAuthCallback", async () => {
+    window.history.replaceState(
+      {},
+      "",
+      "/?code=oauth-code&state=expected-state-token",
+    );
+    writeHostedOAuthPendingMarker({
+      surface: "workspace",
+      workspaceId: "ws_1",
+      serverId: "srv_asana",
+      serverName: "asana",
+      serverUrl: "https://mcp.asana.com/sse",
+      accessScope: "workspace_member",
+      returnHash: "#servers",
+    });
+    localStorage.setItem("mcp-oauth-pending", "asana");
+    localStorage.setItem("mcp-serverUrl-asana", "https://mcp.asana.com/sse");
+    mockHandleOAuthCallback.mockResolvedValue({
+      success: true,
+      serverName: "asana",
+      serverConfig: {
+        url: "https://mcp.asana.com/sse",
+        requestInit: { headers: {} },
+      },
+    });
+
+    renderHook(() =>
+      useServerState({
+        appState: {
+          servers: {},
+          selectedMultipleServers: [],
+        } as any,
+        dispatch: vi.fn(),
+        isLoading: false,
+        isAuthenticated: true,
+        isAuthLoading: false,
+        isLoadingWorkspaces: false,
+        useLocalFallback: false,
+        effectiveWorkspaces: {} as any,
+        effectiveActiveWorkspaceId: "ws_1",
+        activeWorkspaceServersFlat: [],
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          debug: vi.fn(),
+        },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockHandleOAuthCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          surface: "workspace",
+          serverName: "asana",
+        }),
+        "oauth-code",
+        expect.objectContaining({
+          callbackState: "expected-state-token",
+          onTraceUpdate: expect.any(Function),
+        }),
+      );
+    });
+  });
+
   it("reuses hosted stored OAuth credentials on reconnect before falling back to interactive OAuth", async () => {
     const workspaceClientConfig = {
       version: 1 as const,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -958,6 +958,7 @@ export function useServerState({
   const handleOAuthCallbackComplete = useCallback(
     async (
       code: string,
+      state: string | null,
       hostedCallbackContext: ReturnType<typeof getHostedOAuthCallbackContext>,
     ) => {
       const pendingServerName = localStorage.getItem("mcp-oauth-pending");
@@ -979,6 +980,7 @@ export function useServerState({
       try {
         const result = isHostedWorkspaceCallback
           ? await completeHostedOAuthCallback(hostedCallbackContext, code, {
+              callbackState: state,
               onTraceUpdate: handleLiveOAuthTrace,
             })
           : await handleOAuthCallback(code, {
@@ -1181,6 +1183,7 @@ export function useServerState({
 
     const urlParams = new URLSearchParams(window.location.search);
     const code = urlParams.get("code");
+    const state = urlParams.get("state");
     const error = urlParams.get("error");
     const errorDescription = urlParams.get("error_description");
     const hostedOAuthCallbackContext = HOSTED_MODE
@@ -1226,6 +1229,7 @@ export function useServerState({
 
       handleOAuthCallbackComplete(
         code,
+        state,
         isHostedWorkspaceCallback ? hostedOAuthCallbackContext : null,
       );
     } else if (error) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches OAuth callback handling for hosted workspace flows; incorrect propagation could break logins or weaken CSRF/state validation if the backend relies on this value.
> 
> **Overview**
> Ensures hosted *workspace* OAuth callbacks propagate the `state` query parameter through `useServerState` into `completeHostedOAuthCallback`, by parsing `state` from the callback URL and threading it into `handleOAuthCallbackComplete`.
> 
> Adds a dedicated test asserting the `state` token is forwarded alongside the auth `code` when completing a hosted workspace OAuth callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cb951b120481435ee2adf8e43c30584f6f24610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->