### PR TITLE
Fix missing cfworker schema dependency

### DIFF
--- a/.changeset/fix-cfworker-json-schema.md
+++ b/.changeset/fix-cfworker-json-schema.md
@@ -1,5 +1,6 @@
 ---
-"@mcpjam/inspector": minor
+"@mcpjam/sdk": patch
+"@mcpjam/cli": patch
 ---
 
-Add `@cfworker/json-schema` as a direct dependency. It is an optional peer dependency of `@modelcontextprotocol/client@2.0.0-alpha.2` but is required at runtime, so production installs (`npm ci --legacy-peer-deps`) were crashing on startup with `ERR_MODULE_NOT_FOUND`.
+Add `@cfworker/json-schema` as a direct SDK dependency. It is an optional peer dependency of `@modelcontextprotocol/client@2.0.0-alpha.2` but is required at runtime, so isolated CLI and SDK installs were crashing on startup with `ERR_MODULE_NOT_FOUND`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -35842,6 +35842,7 @@
         "@ai-sdk/mistral": "^2.0.19",
         "@ai-sdk/openai": "^2.0.32",
         "@ai-sdk/xai": "^2.0.29",
+        "@cfworker/json-schema": "^4.1.1",
         "@modelcontextprotocol/client": "^2.0.0-alpha.2",
         "@openrouter/ai-sdk-provider": "^2.2.0",
         "ai": "^6.0.141",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -96,6 +96,7 @@
     "@ai-sdk/mistral": "^2.0.19",
     "@ai-sdk/openai": "^2.0.32",
     "@ai-sdk/xai": "^2.0.29",
+    "@cfworker/json-schema": "^4.1.1",
     "@modelcontextprotocol/client": "^2.0.0-alpha.2",
     "@openrouter/ai-sdk-provider": "^2.2.0",
     "ai": "^6.0.141",


### PR DESCRIPTION
## Summary
- Add `@cfworker/json-schema` as a direct dependency of `@mcpjam/sdk` so packaged SDK and CLI installs can resolve `@modelcontextprotocol/client` at runtime.
- Update the lockfile and changeset to release patch versions of `@mcpjam/sdk` and `@mcpjam/cli`.

## Testing
- Not run (not requested)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change to address a runtime module resolution failure; main risk is potential version/packaging incompatibilities from introducing a new direct dependency.
> 
> **Overview**
> Fixes startup crashes in isolated `@mcpjam/sdk`/`@mcpjam/cli` installs by adding `@cfworker/json-schema` as a direct `@mcpjam/sdk` dependency (it was only an optional peer of `@modelcontextprotocol/client`).
> 
> Updates the lockfile accordingly and adds a changeset to release patch versions of `@mcpjam/sdk` and `@mcpjam/cli`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd73ed7bcd1c838702a9099b91014c02ebdb357c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->