### PR TITLE
Make commands explicit

### DIFF
--- a/cli/src/commands/tools.ts
+++ b/cli/src/commands/tools.ts
@@ -18,6 +18,7 @@ import {
 import { parseReporterFormat, writeReporterResult } from "../lib/reporting.js";
 import { createCliRpcLogCollector } from "../lib/rpc-logs.js";
 import { withRpcLogsIfRequested } from "../lib/rpc-helpers.js";
+import { normalizeInspectorFrontendUrl } from "../lib/inspector-api.js";
 import { listToolsWithMetadata } from "../lib/server-ops.js";
 import { summarizeServerDoctorTarget } from "../lib/server-doctor.js";
 import {
@@ -224,6 +225,9 @@ export function registerToolsCommands(program: Command): void {
           timeZone: trimOptional(options.timeZone),
         }
       : undefined;
+    const frontendUrl = options.ui
+      ? parseInspectorFrontendUrl(options.frontendUrl)
+      : undefined;
 
     let result: unknown;
     let commandError: unknown;
@@ -306,7 +310,7 @@ export function registerToolsCommands(program: Command): void {
         uiResult = await runUiRender({
           baseUrl: options.inspectorUrl,
           config,
-          frontendUrl: options.frontendUrl,
+          frontendUrl,
           openBrowser,
           params,
           renderContext: renderContext!,
@@ -429,6 +433,20 @@ function resolveInspectorOpenBrowser(
     return options.open;
   }
   return globalOptions.format === "human" && !globalOptions.quiet;
+}
+
+function parseInspectorFrontendUrl(
+  value: string | undefined,
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const frontendUrl = normalizeInspectorFrontendUrl(value);
+  if (!frontendUrl) {
+    throw usageError(`Invalid --frontend-url "${value}".`);
+  }
+  return frontendUrl;
 }
 
 export function resolveInspectorSkipDiscovery(

--- a/cli/src/commands/tools.ts
+++ b/cli/src/commands/tools.ts
@@ -53,6 +53,7 @@ interface ToolsCallOptions extends SharedServerTargetOptions {
   open?: boolean;
   attachOnly?: boolean;
   inspectorUrl?: string;
+  frontendUrl?: string;
   serverName?: string;
   protocol?: string;
   device?: string;
@@ -145,6 +146,10 @@ export function registerToolsCommands(program: Command): void {
         "Require an already-running Inspector browser client; do not start or open Inspector",
       )
       .option("--inspector-url <url>", "Local Inspector base URL (with --ui)")
+      .option(
+        "--frontend-url <url>",
+        "Inspector frontend URL (with --ui; overrides health-advertised frontend and skips discovery)",
+      )
       .option(
         "--server-name <name>",
         "Server name inside Inspector (with --ui)",
@@ -291,15 +296,21 @@ export function registerToolsCommands(program: Command): void {
           ? options.serverName.trim()
           : buildInspectorServerName(options);
       const openBrowser = resolveInspectorOpenBrowser(options, globalOptions);
+      const skipDiscovery = resolveInspectorSkipDiscovery(
+        options,
+        globalOptions,
+      );
       let uiResult: Record<string, unknown>;
 
       try {
         uiResult = await runUiRender({
           baseUrl: options.inspectorUrl,
           config,
+          frontendUrl: options.frontendUrl,
           openBrowser,
           params,
           renderContext: renderContext!,
+          skipDiscovery,
           serverName,
           startIfNeeded: resolveInspectorStartIfNeeded(options),
           timeoutMs: globalOptions.timeout,
@@ -418,6 +429,28 @@ function resolveInspectorOpenBrowser(
     return options.open;
   }
   return globalOptions.format === "human" && !globalOptions.quiet;
+}
+
+export function resolveInspectorSkipDiscovery(
+  options: Pick<ToolsCallOptions, "attachOnly" | "frontendUrl" | "open">,
+  globalOptions: GlobalOptions,
+): boolean {
+  if (typeof options.frontendUrl === "string" && options.frontendUrl.trim()) {
+    return true;
+  }
+  if (options.attachOnly) {
+    return true;
+  }
+  if (
+    (globalOptions.format === "json" || globalOptions.quiet) &&
+    options.open !== true
+  ) {
+    return true;
+  }
+  if (options.open === true) {
+    return false;
+  }
+  return false;
 }
 
 export function resolveInspectorStartIfNeeded(options: {

--- a/cli/src/lib/inspector-api.ts
+++ b/cli/src/lib/inspector-api.ts
@@ -33,7 +33,9 @@ type InspectorRequestInit = Omit<RequestInit, "body"> & {
 };
 
 export interface EnsureInspectorOptions extends InspectorApiClientOptions {
+  frontendUrl?: string;
   openBrowser?: boolean;
+  skipDiscovery?: boolean;
   startIfNeeded?: boolean;
   tab?: string;
   timeoutMs?: number;
@@ -115,6 +117,14 @@ export function normalizeInspectorFrontendUrl(
   }
 }
 
+function normalizeExplicitInspectorFrontendUrl(frontendUrl: string): string {
+  const normalized = normalizeInspectorFrontendUrl(frontendUrl);
+  if (!normalized) {
+    throw operationalError(`Invalid Inspector frontend URL "${frontendUrl}".`);
+  }
+  return normalized;
+}
+
 function canonicalizeInspectorFrontendUrl(
   baseUrl: string,
   frontendUrl: string | undefined,
@@ -165,42 +175,25 @@ export function buildInspectorBrowserUrl(
 export async function resolveInspectorBrowserBaseUrl(
   baseUrl: string,
   frontendUrl?: string,
+  options: { skipDiscovery?: boolean } = {},
 ): Promise<string> {
-  const normalizedFrontendUrl = canonicalizeInspectorFrontendUrl(
+  const fastResolution = await resolveInspectorBrowserBaseUrlFast(
     baseUrl,
-    normalizeInspectorFrontendUrl(frontendUrl),
+    frontendUrl,
   );
-  const candidates: InspectorFrontendCandidate[] = [];
-
-  if (normalizedFrontendUrl) {
-    const advertisedCandidate = await inspectInspectorFrontendCandidate(
-      baseUrl,
-      normalizedFrontendUrl,
-      "advertised",
-    );
-    candidates.push(advertisedCandidate);
-
-    if (isUsableInspectorFrontendCandidate(advertisedCandidate)) {
-      return advertisedCandidate.url;
-    }
+  if (fastResolution.browserBaseUrl) {
+    return fastResolution.browserBaseUrl;
   }
 
-  const baseCandidate = await inspectInspectorFrontendCandidate(
-    baseUrl,
-    baseUrl,
-    "base",
-  );
-  candidates.push(baseCandidate);
-
-  if (isUsableInspectorFrontendCandidate(baseCandidate)) {
-    return baseCandidate.url;
+  if (options.skipDiscovery) {
+    assertFastFrontendMismatch(fastResolution.candidates);
+    return fastResolution.normalizedFrontendUrl ?? baseUrl;
   }
 
   const discoveredCandidates = await discoverLocalInspectorFrontendCandidates(
     baseUrl,
-    normalizedFrontendUrl,
+    fastResolution.normalizedFrontendUrl,
   );
-  candidates.push(...discoveredCandidates);
 
   const usableDiscoveredCandidate = discoveredCandidates.find(
     isUsableInspectorFrontendCandidate,
@@ -209,6 +202,103 @@ export async function resolveInspectorBrowserBaseUrl(
     return usableDiscoveredCandidate.url;
   }
 
+  const candidates = [...fastResolution.candidates, ...discoveredCandidates];
+  assertFullFrontendMismatch(candidates);
+
+  return fastResolution.normalizedFrontendUrl ?? baseUrl;
+}
+
+interface InspectorBrowserBaseUrlFastResolution {
+  browserBaseUrl?: string;
+  candidates: InspectorFrontendCandidate[];
+  normalizedFrontendUrl?: string;
+}
+
+async function resolveInspectorBrowserBaseUrlFast(
+  baseUrl: string,
+  frontendUrl?: string,
+): Promise<InspectorBrowserBaseUrlFastResolution> {
+  const normalizedFrontendUrl = canonicalizeInspectorFrontendUrl(
+    baseUrl,
+    normalizeInspectorFrontendUrl(frontendUrl),
+  );
+  const targets: Array<{
+    source: InspectorFrontendCandidate["source"];
+    url: string;
+  }> = [];
+
+  if (normalizedFrontendUrl) {
+    targets.push({ source: "advertised", url: normalizedFrontendUrl });
+  }
+  if (!targets.some((target) => target.url === baseUrl)) {
+    targets.push({ source: "base", url: baseUrl });
+  }
+
+  const candidates = await inspectInspectorFrontendCandidates(
+    baseUrl,
+    targets,
+  );
+  const usableCandidate = candidates.find(isUsableInspectorFrontendCandidate);
+
+  return {
+    ...(usableCandidate
+      ? { browserBaseUrl: usableCandidate.url }
+      : {}),
+    candidates,
+    ...(normalizedFrontendUrl ? { normalizedFrontendUrl } : {}),
+  };
+}
+
+async function inspectInspectorFrontendCandidates(
+  apiBaseUrl: string,
+  targets: ReadonlyArray<{
+    source: InspectorFrontendCandidate["source"];
+    url: string;
+  }>,
+): Promise<InspectorFrontendCandidate[]> {
+  const settled = await Promise.allSettled(
+    targets.map((target) =>
+      inspectInspectorFrontendCandidate(apiBaseUrl, target.url, target.source),
+    ),
+  );
+
+  return settled.map((result, index) => {
+    if (result.status === "fulfilled") {
+      return result.value;
+    }
+    const target = targets[index]!;
+    return {
+      isFrontend: false,
+      originStatus: "unknown",
+      source: target.source,
+      url: target.url,
+    };
+  });
+}
+
+function assertFastFrontendMismatch(
+  candidates: InspectorFrontendCandidate[],
+): void {
+  const advertisedCandidate = candidates.find(
+    (candidate) => candidate.source === "advertised",
+  );
+  const rejectedLiveCandidate = candidates.find(
+    (candidate) => candidate.isFrontend && candidate.originStatus === "rejected",
+  );
+
+  if (!rejectedLiveCandidate) {
+    return;
+  }
+
+  if (advertisedCandidate === rejectedLiveCandidate) {
+    throw frontendMismatchError(undefined, rejectedLiveCandidate);
+  }
+  throw frontendMismatchError(advertisedCandidate, rejectedLiveCandidate);
+}
+
+function assertFullFrontendMismatch(
+  candidates: InspectorFrontendCandidate[],
+): void {
   const advertisedCandidate = candidates.find(
     (candidate) => candidate.source === "advertised",
   );
@@ -237,17 +327,21 @@ export async function resolveInspectorBrowserBaseUrl(
   if (rejectedLiveCandidate) {
     throw frontendMismatchError(advertisedCandidate, rejectedLiveCandidate);
   }
-
-  return normalizedFrontendUrl ?? baseUrl;
 }
 
 async function resolveInspectorBrowserBaseUrlForHealth(
   baseUrl: string,
   frontendUrl: string | undefined,
-  options: { hasActiveClient: boolean; openBrowser: boolean },
+  options: {
+    hasActiveClient: boolean;
+    openBrowser: boolean;
+    skipDiscovery?: boolean;
+  },
 ): Promise<string> {
   try {
-    return await resolveInspectorBrowserBaseUrl(baseUrl, frontendUrl);
+    return await resolveInspectorBrowserBaseUrl(baseUrl, frontendUrl, {
+      skipDiscovery: options.skipDiscovery,
+    });
   } catch (error) {
     if (options.hasActiveClient && !options.openBrowser) {
       return (
@@ -273,17 +367,20 @@ export async function ensureInspector(
   options: EnsureInspectorOptions = {},
 ): Promise<EnsureInspectorResult> {
   const baseUrl = normalizeInspectorBaseUrl(options.baseUrl);
+  const explicitFrontendUrl =
+    options.frontendUrl !== undefined
+      ? normalizeExplicitInspectorFrontendUrl(options.frontendUrl)
+      : undefined;
 
   const health = await getInspectorHealth(baseUrl);
   if (health.healthy) {
-    const browserBaseUrl = await resolveInspectorBrowserBaseUrlForHealth(
-      baseUrl,
-      health.frontendUrl,
-      {
+    const browserBaseUrl =
+      explicitFrontendUrl ??
+      (await resolveInspectorBrowserBaseUrlForHealth(baseUrl, health.frontendUrl, {
         hasActiveClient: health.hasActiveClient,
         openBrowser: options.openBrowser === true,
-      },
-    );
+        skipDiscovery: options.skipDiscovery,
+      }));
     const url = buildInspectorUrl(browserBaseUrl, options.tab);
     if (options.openBrowser && !health.hasActiveClient) {
       openUrl(url);
@@ -307,14 +404,17 @@ export async function ensureInspector(
   clearInspectorSessionTokenCache(baseUrl);
 
   const startedHealth = await getInspectorHealth(baseUrl);
-  const browserBaseUrl = await resolveInspectorBrowserBaseUrlForHealth(
-    baseUrl,
-    startedHealth.frontendUrl,
-    {
-      hasActiveClient: startedHealth.hasActiveClient,
-      openBrowser: options.openBrowser === true,
-    },
-  );
+  const browserBaseUrl =
+    explicitFrontendUrl ??
+    (await resolveInspectorBrowserBaseUrlForHealth(
+      baseUrl,
+      startedHealth.frontendUrl,
+      {
+        hasActiveClient: startedHealth.hasActiveClient,
+        openBrowser: options.openBrowser === true,
+        skipDiscovery: options.skipDiscovery,
+      },
+    ));
   const url = buildInspectorUrl(browserBaseUrl, options.tab);
 
   if (options.openBrowser) {
@@ -796,10 +896,12 @@ async function discoverLocalInspectorFrontendCandidates(
     }
   }
 
-  const inspectedCandidates = await Promise.all(
-    targets.map((candidate) =>
-      inspectInspectorFrontendCandidate(baseUrl, candidate, "discovered"),
-    ),
+  const inspectedCandidates = await inspectInspectorFrontendCandidates(
+    baseUrl,
+    targets.map((candidate) => ({
+      source: "discovered" as const,
+      url: candidate,
+    })),
   );
   return inspectedCandidates.filter((candidate) => candidate.isFrontend);
 }

--- a/cli/src/lib/inspector-render.ts
+++ b/cli/src/lib/inspector-render.ts
@@ -35,9 +35,11 @@ type InspectorUiRenderResult = InspectorAppRenderResult & {
 export async function runUiRender(options: {
   baseUrl?: string;
   config: MCPServerConfig;
+  frontendUrl?: string;
   openBrowser?: boolean;
   params: Record<string, unknown>;
   renderContext: AppRenderContext;
+  skipDiscovery?: boolean;
   serverName: string;
   startIfNeeded?: boolean;
   timeoutMs: number;
@@ -47,7 +49,9 @@ export async function runUiRender(options: {
   const client = new InspectorApiClient({ baseUrl: options.baseUrl });
   const openBrowser = options.openBrowser === true;
   const ensureResult = await client.ensure({
+    frontendUrl: options.frontendUrl,
     openBrowser,
+    skipDiscovery: options.skipDiscovery,
     startIfNeeded: options.startIfNeeded ?? true,
     tab: "app-builder",
     timeoutMs: options.timeoutMs,

--- a/cli/tests/inspector-api.test.ts
+++ b/cli/tests/inspector-api.test.ts
@@ -102,6 +102,71 @@ async function withServerOnAvailablePort(
     : new Error("No available port for test server.");
 }
 
+async function withServersOnConsecutiveAvailablePorts(
+  ports: number[],
+  handlers: [http.RequestListener, http.RequestListener],
+  fn: (baseUrls: [string, string]) => Promise<void>,
+): Promise<void> {
+  let lastError: unknown;
+
+  for (const port of ports) {
+    const servers = handlers.map((handler) => http.createServer(handler)) as [
+      http.Server,
+      http.Server,
+    ];
+    try {
+      await new Promise<void>((resolve, reject) => {
+        servers[0].once("error", reject);
+        servers[0].listen(port, "127.0.0.1", () => {
+          servers[0].off("error", reject);
+          resolve();
+        });
+      });
+      await new Promise<void>((resolve, reject) => {
+        servers[1].once("error", reject);
+        servers[1].listen(port + 1, "127.0.0.1", () => {
+          servers[1].off("error", reject);
+          resolve();
+        });
+      });
+
+      try {
+        await fn([
+          `http://127.0.0.1:${port}`,
+          `http://127.0.0.1:${port + 1}`,
+        ]);
+      } finally {
+        await Promise.all(
+          servers.map(
+            (server) =>
+              new Promise<void>((resolve, reject) => {
+                server.close((error) => (error ? reject(error) : resolve()));
+              }),
+          ),
+        );
+      }
+      return;
+    } catch (error) {
+      lastError = error;
+      await Promise.all(
+        servers.map(
+          (server) =>
+            new Promise<void>((resolve) => {
+              server.close(() => resolve());
+            }),
+        ),
+      );
+      if ((error as NodeJS.ErrnoException).code !== "EADDRINUSE") {
+        throw error;
+      }
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("No consecutive ports available for test servers.");
+}
+
 test("InspectorApiClient sends session token auth and supported endpoint payloads", async () => {
   const token = "session-token";
   const seen: Array<{ url?: string; auth?: string; body?: unknown }> = [];
@@ -407,6 +472,61 @@ test("ensureInspector reports the frontend URL from Inspector health", async () 
   );
 });
 
+test("ensureInspector with explicit frontendUrl skips advertised frontend probes", async () => {
+  let advertisedRootRequests = 0;
+
+  await withServer(
+    (frontendRequest, frontendResponse) => {
+      if (frontendRequest.method === "GET" && frontendRequest.url === "/") {
+        advertisedRootRequests += 1;
+        frontendResponse.writeHead(200, { "Content-Type": "text/html" });
+        frontendResponse.end(INSPECTOR_FRONTEND_HTML);
+        return;
+      }
+
+      frontendResponse.writeHead(404);
+      frontendResponse.end();
+    },
+    async (advertisedFrontendUrl) => {
+      await withServer(
+        (request, response) => {
+          if (request.method === "GET" && request.url === "/health") {
+            response.writeHead(200, { "Content-Type": "application/json" });
+            response.end(
+              JSON.stringify({
+                status: "ok",
+                hasActiveClient: true,
+                frontend: `${advertisedFrontendUrl}/`,
+              }),
+            );
+            return;
+          }
+
+          response.writeHead(404);
+          response.end();
+        },
+        async (baseUrl) => {
+          const result = await ensureInspector({
+            baseUrl,
+            frontendUrl: "http://localhost:9/inspector/?debug=1#old",
+            openBrowser: false,
+            tab: "app-builder",
+          });
+
+          assert.equal(advertisedRootRequests, 0);
+          assert.deepEqual(result, {
+            baseUrl,
+            frontendUrl: "http://localhost:9/inspector",
+            hasActiveClient: true,
+            url: "http://localhost:9/inspector/#app-builder",
+            started: false,
+          });
+        },
+      );
+    },
+  );
+});
+
 test("ensureInspector allows active attach when health frontend is stale", async () => {
   const staleFrontendUrl = "http://127.0.0.1:9";
 
@@ -449,6 +569,70 @@ test("ensureInspector allows active attach when health frontend is stale", async
   );
 });
 
+test("ensureInspector with skipDiscovery avoids nearby frontend port scans", async () => {
+  let nearbyRootRequests = 0;
+
+  await withServerOnAvailablePort(
+    [5181, 5182, 5183, 5184, 5185],
+    (frontendRequest, frontendResponse) => {
+      if (frontendRequest.method === "GET" && frontendRequest.url === "/") {
+        nearbyRootRequests += 1;
+        frontendResponse.writeHead(200, { "Content-Type": "text/html" });
+        frontendResponse.end(INSPECTOR_FRONTEND_HTML);
+        return;
+      }
+
+      frontendResponse.writeHead(404);
+      frontendResponse.end();
+    },
+    async (frontendUrl) => {
+      const frontendPort = Number(new URL(frontendUrl).port);
+      const staleFrontendUrl = `http://127.0.0.1:${frontendPort - 1}`;
+
+      await withServer(
+        (request, response) => {
+          if (request.method === "GET" && request.url === "/health") {
+            response.writeHead(200, { "Content-Type": "application/json" });
+            response.end(
+              JSON.stringify({
+                status: "ok",
+                hasActiveClient: true,
+                frontend: staleFrontendUrl,
+              }),
+            );
+            return;
+          }
+
+          if (
+            request.method === "GET" &&
+            request.url === "/api/session-token"
+          ) {
+            response.writeHead(200, { "Content-Type": "application/json" });
+            response.end(JSON.stringify({ token: "ok" }));
+            return;
+          }
+
+          response.writeHead(404);
+          response.end();
+        },
+        async (baseUrl) => {
+          const result = await ensureInspector({
+            baseUrl,
+            openBrowser: false,
+            skipDiscovery: true,
+            tab: "app-builder",
+          });
+
+          assert.equal(nearbyRootRequests, 0);
+          assert.equal(result.frontendUrl, staleFrontendUrl);
+          assert.equal(result.url, `${staleFrontendUrl}/#app-builder`);
+          assert.equal(result.started, false);
+        },
+      );
+    },
+  );
+});
+
 test("resolveInspectorBrowserBaseUrl discovers nearby dev frontend when health is stale", async () => {
   await withServer(
     (request, response) => {
@@ -483,6 +667,61 @@ test("resolveInspectorBrowserBaseUrl discovers nearby dev frontend when health i
             await resolveInspectorBrowserBaseUrl(baseUrl, staleFrontendUrl),
             frontendUrl,
           );
+        },
+      );
+    },
+  );
+});
+
+test("resolveInspectorBrowserBaseUrl prefers first usable discovered frontend deterministically", async () => {
+  await withServersOnConsecutiveAvailablePorts(
+    [5181, 5182, 5183, 5184],
+    [
+      (frontendRequest, frontendResponse) => {
+        if (frontendRequest.method === "GET" && frontendRequest.url === "/") {
+          frontendResponse.writeHead(200, { "Content-Type": "text/html" });
+          frontendResponse.end(INSPECTOR_FRONTEND_HTML);
+          return;
+        }
+
+        frontendResponse.writeHead(404);
+        frontendResponse.end();
+      },
+      (frontendRequest, frontendResponse) => {
+        if (frontendRequest.method === "GET" && frontendRequest.url === "/") {
+          frontendResponse.writeHead(200, { "Content-Type": "text/html" });
+          frontendResponse.end(INSPECTOR_FRONTEND_HTML);
+          return;
+        }
+
+        frontendResponse.writeHead(404);
+        frontendResponse.end();
+      },
+    ],
+    async ([firstFrontendUrl, secondFrontendUrl]) => {
+      const firstFrontendPort = Number(new URL(firstFrontendUrl).port);
+      const staleFrontendUrl = `http://127.0.0.1:${firstFrontendPort - 1}`;
+
+      await withServer(
+        (request, response) => {
+          if (
+            request.method === "GET" &&
+            request.url === "/api/session-token"
+          ) {
+            response.writeHead(200, { "Content-Type": "application/json" });
+            response.end(JSON.stringify({ token: "ok" }));
+            return;
+          }
+
+          response.writeHead(404);
+          response.end();
+        },
+        async (baseUrl) => {
+          assert.equal(
+            await resolveInspectorBrowserBaseUrl(baseUrl, staleFrontendUrl),
+            firstFrontendUrl,
+          );
+          assert.notEqual(firstFrontendUrl, secondFrontendUrl);
         },
       );
     },

--- a/cli/tests/tools-call-ui.test.ts
+++ b/cli/tests/tools-call-ui.test.ts
@@ -7,7 +7,10 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import type { AddressInfo } from "node:net";
-import { resolveInspectorStartIfNeeded } from "../src/commands/tools.js";
+import {
+  resolveInspectorSkipDiscovery,
+  resolveInspectorStartIfNeeded,
+} from "../src/commands/tools.js";
 import { buildInspectorServerName } from "../src/lib/inspector-render.js";
 
 const CLI_DIR = process.cwd().endsWith(`${path.sep}cli`)
@@ -93,7 +96,9 @@ async function readJsonBody(
 }
 
 async function startMockServer(options: {
+  frontendUrl?: string;
   hasActiveClient?: boolean;
+  serveFrontend?: boolean;
   toolResult?: unknown;
   toolRpcError?: { code: number; message: string };
   failRender?: boolean;
@@ -105,6 +110,12 @@ async function startMockServer(options: {
 
   const server = http.createServer(async (request, response) => {
     if (request.method === "GET" && request.url === "/") {
+      requests.push({ method: request.method, url: request.url });
+      if (options.serveFrontend === false) {
+        response.writeHead(404);
+        response.end();
+        return;
+      }
       response.writeHead(200, { "Content-Type": "text/html" });
       response.end(INSPECTOR_FRONTEND_HTML);
       return;
@@ -116,7 +127,7 @@ async function startMockServer(options: {
         JSON.stringify({
           status: "ok",
           hasActiveClient: options.hasActiveClient ?? true,
-          frontend: `http://${request.headers.host}/`,
+          frontend: options.frontendUrl ?? `http://${request.headers.host}/`,
         }),
       );
       return;
@@ -245,6 +256,59 @@ async function startMockServer(options: {
   };
 }
 
+async function startFrontendServerOnAvailablePort(ports: number[]) {
+  let lastError: unknown;
+
+  for (const port of ports) {
+    let rootRequests = 0;
+    const server = http.createServer((request, response) => {
+      if (request.method === "GET" && request.url === "/") {
+        rootRequests += 1;
+        response.writeHead(200, { "Content-Type": "text/html" });
+        response.end(INSPECTOR_FRONTEND_HTML);
+        return;
+      }
+
+      response.writeHead(404);
+      response.end();
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(port, "127.0.0.1", () => {
+          server.off("error", reject);
+          resolve();
+        });
+      });
+
+      return {
+        get rootRequests() {
+          return rootRequests;
+        },
+        url: `http://127.0.0.1:${port}`,
+        stop: async () => {
+          await new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
+          });
+        },
+      };
+    } catch (error) {
+      lastError = error;
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      if ((error as NodeJS.ErrnoException).code !== "EADDRINUSE") {
+        throw error;
+      }
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("No available port for frontend test server.");
+}
+
 test("tools call --ui executes once and sends the raw result to Inspector", async () => {
   const toolResult = {
     content: [{ type: "text", text: "view created" }],
@@ -338,6 +402,58 @@ test("tools call --ui executes once and sends the raw result to Inspector", asyn
   }
 });
 
+test("tools call --ui --frontend-url uses the explicit browser URL without probing frontend candidates", async () => {
+  const toolResult = { content: [{ type: "text", text: "view created" }] };
+  const server = await startMockServer({ toolResult });
+
+  try {
+    const explicitFrontendUrl = `http://localhost:${server.port}/inspector/?debug=1#old`;
+    const result = await runCli([
+      "--format",
+      "json",
+      "tools",
+      "call",
+      "--ui",
+      "--frontend-url",
+      explicitFrontendUrl,
+      "--inspector-url",
+      `http://127.0.0.1:${server.port}`,
+      "--url",
+      `http://127.0.0.1:${server.port}/mcp`,
+      "--tool-name",
+      "create_view",
+      "--tool-args",
+      "{}",
+    ]);
+
+    assert.equal(result.exitCode, 0, result.stderr);
+    const payload = JSON.parse(lastJsonLine(result.stdout)) as Record<
+      string,
+      any
+    >;
+    assert.equal(payload.success, true);
+    assert.equal(
+      payload.inspectorBrowserUrl,
+      `http://localhost:${server.port}/inspector/#app-builder`,
+    );
+    assert.equal(
+      payload.inspectorFrontendUrl,
+      `http://localhost:${server.port}/inspector`,
+    );
+    assert.equal(
+      payload.inspectorRender.browserUrl,
+      `http://localhost:${server.port}/inspector/#app-builder`,
+    );
+    assert.equal(payload.inspectorRender.browserOpenRequested, false);
+    assert.equal(
+      server.requests.some((entry) => entry.method === "GET" && entry.url === "/"),
+      false,
+    );
+  } finally {
+    await server.stop();
+  }
+});
+
 test("tools call without --ui preserves raw output and does not contact Inspector", async () => {
   const toolResult = { content: [{ type: "text", text: "plain result" }] };
   const server = await startMockServer({ toolResult });
@@ -410,6 +526,56 @@ test("tools call --ui in JSON mode does not open or wait without an active Inspe
   }
 });
 
+test("tools call --ui --quiet --format json does not scan nearby frontend ports", async () => {
+  const frontend = await startFrontendServerOnAvailablePort([
+    5181, 5182, 5183, 5184, 5185,
+  ]);
+  const frontendPort = Number(new URL(frontend.url).port);
+  const staleFrontendUrl = `http://127.0.0.1:${frontendPort - 1}`;
+  const toolResult = { content: [{ type: "text", text: "view created" }] };
+  const server = await startMockServer({
+    frontendUrl: staleFrontendUrl,
+    hasActiveClient: false,
+    serveFrontend: false,
+    toolResult,
+  });
+
+  try {
+    const result = await runCli([
+      "--format",
+      "json",
+      "--quiet",
+      "tools",
+      "call",
+      "--ui",
+      "--inspector-url",
+      `http://127.0.0.1:${server.port}`,
+      "--url",
+      `http://127.0.0.1:${server.port}/mcp`,
+      "--tool-name",
+      "create_view",
+      "--tool-args",
+      "{}",
+    ]);
+
+    assert.equal(result.exitCode, 1, result.stderr);
+    assert.equal(frontend.rootRequests, 0);
+    const payload = JSON.parse(lastJsonLine(result.stdout)) as Record<
+      string,
+      any
+    >;
+    assert.equal(payload.success, false);
+    assert.equal(
+      payload.inspectorBrowserUrl,
+      `${staleFrontendUrl}/#app-builder`,
+    );
+    assert.match(payload.error.message, /no active browser client/i);
+  } finally {
+    await server.stop();
+    await frontend.stop();
+  }
+});
+
 test("tools call --ui --open may render while waiting for a browser client", async () => {
   const toolResult = { content: [{ type: "text", text: "view created" }] };
   const server = await startMockServer({ hasActiveClient: false, toolResult });
@@ -447,6 +613,54 @@ test("tools call --ui --open may render while waiting for a browser client", asy
     );
   } finally {
     await server.stop();
+  }
+});
+
+test("tools call --ui --open can discover a nearby dev frontend", async () => {
+  const frontend = await startFrontendServerOnAvailablePort([
+    5181, 5182, 5183, 5184, 5185,
+  ]);
+  const frontendPort = Number(new URL(frontend.url).port);
+  const staleFrontendUrl = `http://127.0.0.1:${frontendPort - 1}`;
+  const toolResult = { content: [{ type: "text", text: "view created" }] };
+  const server = await startMockServer({
+    frontendUrl: staleFrontendUrl,
+    hasActiveClient: false,
+    serveFrontend: false,
+    toolResult,
+  });
+
+  try {
+    const result = await runCli([
+      "--format",
+      "json",
+      "tools",
+      "call",
+      "--ui",
+      "--open",
+      "--inspector-url",
+      `http://127.0.0.1:${server.port}`,
+      "--url",
+      `http://127.0.0.1:${server.port}/mcp`,
+      "--tool-name",
+      "create_view",
+      "--tool-args",
+      "{}",
+    ]);
+
+    assert.equal(result.exitCode, 0, result.stderr);
+    assert.ok(frontend.rootRequests > 0);
+    const payload = JSON.parse(lastJsonLine(result.stdout)) as Record<
+      string,
+      any
+    >;
+    assert.equal(payload.success, true);
+    assert.equal(payload.inspectorBrowserUrl, `${frontend.url}/#app-builder`);
+    assert.equal(payload.inspectorFrontendUrl, frontend.url);
+    assert.equal(payload.inspectorRender.browserOpenRequested, true);
+  } finally {
+    await server.stop();
+    await frontend.stop();
   }
 });
 
@@ -602,6 +816,13 @@ test("tools call --ui rejects reporter output", async () => {
   assert.match(result.stderr, /--ui cannot be used together with --reporter/);
 });
 
+test("tools call help lists frontend-url", async () => {
+  const result = await runCli(["tools", "call", "--help"]);
+
+  assert.equal(result.exitCode, 0, result.stderr);
+  assert.match(result.stdout, /--frontend-url <url>/);
+});
+
 test("tools call --ui rejects attach-only with open", async () => {
   const result = await runCli([
     "--format",
@@ -626,11 +847,80 @@ test("tools call --ui rejects attach-only with open", async () => {
   );
 });
 
+test("tools call --ui accepts frontend-url with open", async () => {
+  const toolResult = { content: [{ type: "text", text: "view created" }] };
+  const server = await startMockServer({
+    hasActiveClient: false,
+    serveFrontend: false,
+    toolResult,
+  });
+
+  try {
+    const result = await runCli([
+      "--format",
+      "json",
+      "tools",
+      "call",
+      "--ui",
+      "--open",
+      "--frontend-url",
+      `http://localhost:${server.port}/client`,
+      "--inspector-url",
+      `http://127.0.0.1:${server.port}`,
+      "--url",
+      `http://127.0.0.1:${server.port}/mcp`,
+      "--tool-name",
+      "create_view",
+      "--tool-args",
+      "{}",
+    ]);
+
+    assert.equal(result.exitCode, 0, result.stderr);
+    const payload = JSON.parse(lastJsonLine(result.stdout)) as Record<
+      string,
+      any
+    >;
+    assert.equal(payload.success, true);
+    assert.equal(
+      payload.inspectorBrowserUrl,
+      `http://localhost:${server.port}/client/#app-builder`,
+    );
+    assert.equal(payload.inspectorRender.browserOpenRequested, true);
+  } finally {
+    await server.stop();
+  }
+});
+
 test("tools call --ui treats no-open as startable but attach-only as strict attach", () => {
   assert.equal(resolveInspectorStartIfNeeded({}), true);
   assert.equal(resolveInspectorStartIfNeeded({ open: false }), true);
   assert.equal(resolveInspectorStartIfNeeded({ open: true }), true);
   assert.equal(resolveInspectorStartIfNeeded({ attachOnly: true }), false);
+});
+
+test("tools call --ui resolves discovery policy from output mode", () => {
+  const humanOptions = {
+    format: "human" as const,
+    quiet: false,
+    rpc: false,
+    telemetry: true,
+    timeout: 30_000,
+  };
+  const jsonOptions = { ...humanOptions, format: "json" as const };
+  const quietOptions = { ...humanOptions, quiet: true };
+
+  assert.equal(resolveInspectorSkipDiscovery({}, humanOptions), false);
+  assert.equal(resolveInspectorSkipDiscovery({ open: true }, jsonOptions), false);
+  assert.equal(resolveInspectorSkipDiscovery({}, jsonOptions), true);
+  assert.equal(resolveInspectorSkipDiscovery({}, quietOptions), true);
+  assert.equal(resolveInspectorSkipDiscovery({ attachOnly: true }, humanOptions), true);
+  assert.equal(
+    resolveInspectorSkipDiscovery(
+      { frontendUrl: "http://localhost:5173", open: true },
+      humanOptions,
+    ),
+    true,
+  );
 });
 
 test("tools call --ui validates render flags before executing the tool", async () => {

--- a/cli/tests/tools-call-ui.test.ts
+++ b/cli/tests/tools-call-ui.test.ts
@@ -957,6 +957,40 @@ test("tools call --ui validates render flags before executing the tool", async (
   }
 });
 
+test("tools call --ui validates frontend-url before executing the tool", async () => {
+  const server = await startMockServer({});
+
+  try {
+    const result = await runCli([
+      "--format",
+      "json",
+      "tools",
+      "call",
+      "--ui",
+      "--frontend-url",
+      "not a url",
+      "--inspector-url",
+      `http://127.0.0.1:${server.port}`,
+      "--url",
+      `http://127.0.0.1:${server.port}/mcp`,
+      "--tool-name",
+      "create_view",
+      "--tool-args",
+      "{}",
+    ]);
+
+    assert.equal(result.exitCode, 2);
+    assert.match(
+      (JSON.parse(result.stderr) as { error?: { message?: string } }).error
+        ?.message ?? "",
+      /Invalid --frontend-url "not a url"/,
+    );
+    assert.deepEqual(server.requests, []);
+  } finally {
+    await server.stop();
+  }
+});
+
 test("tools call --ui applies expect-success to the raw tool result", async () => {
   const errorToolResult = {
     isError: true,

--- a/docs/cli/apps-conformance.mdx
+++ b/docs/cli/apps-conformance.mdx
@@ -169,7 +169,7 @@ mcpjam apps conformance \
 
 Use `tools list` to find UI-capable tools. A tool has interactive UI when its metadata includes `_meta.ui.resourceUri`, deprecated `_meta["ui/resourceUri"]`, or `openai/outputTemplate` in `toolsMetadata`.
 
-Then use `tools call --ui` when you need to inspect the output of one UI-capable tool call. The CLI starts or attaches to the local Inspector backend, connects the target server, focuses App Builder in the active Inspector browser client, injects the already-completed tool result, and requests a UI snapshot. JSON/quiet invocations do not open a system browser by default, but they may start Inspector; pass `--open` for interactive use, use `--attach-only` to disallow startup, or open `http://127.0.0.1:6274/#app-builder` with browser automation before running the command.
+Then use `tools call --ui` when you need to inspect the output of one UI-capable tool call. The CLI starts or attaches to the local Inspector backend, connects the target server, focuses App Builder in the active Inspector browser client, injects the already-completed tool result, and requests a UI snapshot. `--inspector-url` is the Inspector backend/API URL; `--frontend-url` is the browser/client URL and skips frontend discovery. JSON/quiet invocations do not open a system browser or scan local frontend ports by default, but they may start Inspector; pass `--open` for interactive use and local dev frontend discovery, use `--attach-only` to disallow startup, browser opening, and discovery, or open `http://127.0.0.1:6274/#app-builder` with browser automation before running the command.
 
 ```bash
 mcpjam tools call \

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -109,7 +109,8 @@ Uses shared connection flags.
 | `--open` | Open Inspector in the system browser before rendering |
 | `--no-open` | Start/use Inspector without opening a system browser |
 | `--attach-only` | Require an already-running Inspector browser client; do not start or open Inspector |
-| `--inspector-url <url>` | Local Inspector base URL |
+| `--inspector-url <url>` | Local Inspector backend/API base URL |
+| `--frontend-url <url>` | Inspector frontend/browser base URL; skips frontend discovery |
 | `--server-name <name>` | Server name to use inside Inspector |
 | `--protocol <protocol>` | Render protocol: `mcp-apps` or `openai-sdk` |
 | `--device <device>` | Render device: `mobile`, `tablet`, `desktop`, or `custom` |
@@ -119,7 +120,7 @@ Uses shared connection flags.
 
 Plus shared connection flags.
 
-Without `--ui`, `tools call` returns the raw tool result. With `--ui`, it returns a compact envelope with `result`, `inspectorBrowserUrl`, and `inspectorRender` status. JSON/quiet invocations do not open a system browser by default, but they may start Inspector; use `--attach-only` when startup should be disallowed. Open `inspectorBrowserUrl` first with your browser automation, then rerun the command, or pass `--open` for interactive use. The Inspector path injects the completed tool result through `renderToolResult`; it does not call the tool a second time. Fresh tabs do not hydrate the injected render state; use the active Inspector client that received the render. Use `--debug-out` for the full render envelope including params and command responses. `--ui` cannot be combined with `--reporter`.
+Without `--ui`, `tools call` returns the raw tool result. With `--ui`, it returns a compact envelope with `result`, `inspectorBrowserUrl`, and `inspectorRender` status. `--inspector-url` points to the Inspector backend/API; pass `--frontend-url` when you already know the browser/client URL and want to skip health-advertised frontend checks and local dev port discovery. JSON/quiet invocations do not open a system browser or scan local frontend ports by default, but they may start Inspector; use `--attach-only` when startup, browser opening, and discovery should all be disallowed. Open `inspectorBrowserUrl` first with your browser automation, then rerun the command, or pass `--open` for interactive use. Human TTY and `--open` flows may discover local dev frontends. The Inspector path injects the completed tool result through `renderToolResult`; it does not call the tool a second time. Fresh tabs do not hydrate the injected render state; use the active Inspector client that received the render. Use `--debug-out` for the full render envelope including params and command responses. `--ui` cannot be combined with `--reporter`.
 
 ---
 

--- a/docs/cli/tools-resources-prompts.mdx
+++ b/docs/cli/tools-resources-prompts.mdx
@@ -45,9 +45,9 @@ mcpjam tools call --url https://your-server.com/mcp --access-token $TOKEN \
   --quiet --format json
 ```
 
-Without `--ui`, `tools call` returns the raw tool result. With `--ui`, it returns an envelope containing the raw `result`, `inspectorBrowserUrl`, and `inspectorRender` evidence. Browser automation should open `inspectorBrowserUrl`; `--inspector-url` is the local Inspector API base URL.
+Without `--ui`, `tools call` returns the raw tool result. With `--ui`, it returns an envelope containing the raw `result`, `inspectorBrowserUrl`, and `inspectorRender` evidence. Browser automation should open `inspectorBrowserUrl`; `--inspector-url` is the local Inspector backend/API base URL. If you already know the Inspector browser/client URL, pass `--frontend-url <url>` to use it directly and skip health-advertised frontend checks and local dev port discovery.
 
-For agent/browser automation, open `http://127.0.0.1:6274/#app-builder` in the automation browser first, then run `tools call --ui --quiet --format json`. JSON/quiet `--ui` will not open a system browser unless you pass `--open`, but it may start Inspector; add `--attach-only` when startup should be disallowed. The normal JSON output is compact; pass `--debug-out <path>` for the full render envelope.
+For agent/browser automation, open `http://127.0.0.1:6274/#app-builder` in the automation browser first, then run `tools call --ui --quiet --format json`. JSON/quiet `--ui` will not open a system browser or scan local frontend ports unless you pass `--open`, but it may start Inspector; add `--attach-only` when startup, browser opening, and discovery should be disallowed. Human TTY and `--open` flows may discover local dev frontends. The normal JSON output is compact; pass `--debug-out <path>` for the full render envelope.
 
 For a local stdio server:
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the `tools call --ui` Inspector connection flow by allowing an explicit `--frontend-url` and by skipping frontend discovery/port scans in JSON/quiet/attach-only modes, which could affect how users reach the Inspector UI in some environments.
> 
> **Overview**
> `tools call --ui` now supports `--frontend-url` to explicitly set the Inspector browser/client base URL (validated and normalized) and **bypass health-advertised frontend probing and local frontend discovery**.
> 
> Inspector URL resolution is refactored to support a `skipDiscovery` mode: JSON/quiet output (unless `--open`), `--attach-only`, or an explicit `--frontend-url` will avoid scanning nearby ports, while `--open` keeps discovery enabled for local dev.
> 
> Updates `ensureInspector`/`runUiRender` plumbing, adds deterministic candidate probing behavior, expands CLI/docs help text, and adds tests covering explicit frontend URLs, discovery skipping, and discovery ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 963cd8fa7696a6a2ba0f19477f78355c4f5d3733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->