### PR TITLE
Add OAuth conformance credential handoff and redaction

### DIFF
--- a/cli/src/commands/conformance.ts
+++ b/cli/src/commands/conformance.ts
@@ -48,7 +48,7 @@ export function registerProtocolCommands(program: Command): void {
     .option("--access-token <token>", "Bearer access token for HTTP servers")
     .option(
       "--credentials-file <path>",
-      "Load OAuth access token from a file created by oauth login --credentials-out",
+      "Load OAuth access token from a file created by oauth login or oauth conformance --credentials-out",
     )
     .option(
       "--header <header>",

--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -1,5 +1,6 @@
 import {
   type OAuthConformanceConfig,
+  type OAuthConformanceSuiteResult,
   type OAuthLoginConfig,
   type OAuthVerificationConfig,
   OAuthConformanceTest,
@@ -358,6 +359,10 @@ export function registerOAuthCommands(program: Command): void {
       "Run additional OAuth negative checks (invalid client, invalid redirect, token format) after the main flow",
     )
     .option(
+      "--credentials-out <path>",
+      "Write OAuth credentials to <path> (mode 0600); stdout output has secret fields redacted to [SAVED_TO_FILE]",
+    )
+    .option(
       "--print-url",
       "In interactive mode, print the consent URL to stderr instead of launching a browser",
     )
@@ -370,12 +375,30 @@ export function registerOAuthCommands(program: Command): void {
       const format = getOAuthConformanceFormat(command, reporter);
       const config = buildOAuthConformanceConfig(options as OAuthCommandOptions);
       const result = await new OAuthConformanceTest(config).run();
+      let credentialsFilePath: string | undefined;
+      let credentialsFileError: unknown;
+
+      if (options.credentialsOut && hasCredentialsToSave(result)) {
+        try {
+          credentialsFilePath = await writeCredentialsFile(
+            options.credentialsOut as string,
+            result,
+          );
+        } catch (error) {
+          credentialsFileError = error;
+        }
+      }
 
       writeOAuthOutput(
         reporter
           ? renderConformanceReporterResult(result, reporter)
-          : renderOAuthConformanceResult(result, format),
+          : renderOAuthConformanceResult(result, format, {
+              credentialsFilePath,
+            }),
       );
+      if (credentialsFileError) {
+        throw credentialsFileError;
+      }
       if (!result.passed) {
         setProcessExitCode(1);
       }
@@ -394,6 +417,10 @@ export function registerOAuthCommands(program: Command): void {
     .option(
       "--verify-call-tool <name>",
       "Also call the named tool after listing",
+    )
+    .option(
+      "--credentials-out <path>",
+      "Write OAuth credentials from the first flow that returns credentials to <path> (mode 0600)",
     )
     .option(
       "--reporter <reporter>",
@@ -423,12 +450,35 @@ export function registerOAuthCommands(program: Command): void {
 
       const suite = new OAuthConformanceSuite(config);
       const result = await suite.run();
+      const credentialsResultIndex = findCredentialsResultIndex(result);
+      let credentialsFilePath: string | undefined;
+      let credentialsFileError: unknown;
+
+      if (
+        options.credentialsOut &&
+        credentialsResultIndex !== undefined
+      ) {
+        try {
+          credentialsFilePath = await writeCredentialsFile(
+            options.credentialsOut as string,
+            result.results[credentialsResultIndex],
+          );
+        } catch (error) {
+          credentialsFileError = error;
+        }
+      }
 
       writeOAuthOutput(
         reporter
           ? renderConformanceReporterResult(result, reporter)
-          : renderOAuthConformanceSuiteResult(result, format),
+          : renderOAuthConformanceSuiteResult(result, format, {
+              credentialsFilePath,
+              credentialsResultIndex,
+            }),
       );
+      if (credentialsFileError) {
+        throw credentialsFileError;
+      }
       if (!result.passed) {
         setProcessExitCode(1);
       }
@@ -602,6 +652,13 @@ export function buildOAuthConformanceConfig(
     verification,
     oauthConformanceChecks: options.conformanceChecks ?? false,
   };
+}
+
+function findCredentialsResultIndex(
+  result: OAuthConformanceSuiteResult,
+): number | undefined {
+  const index = result.results.findIndex(hasCredentialsToSave);
+  return index >= 0 ? index : undefined;
 }
 
 export function buildOAuthLoginConfig(

--- a/cli/src/commands/server.ts
+++ b/cli/src/commands/server.ts
@@ -69,7 +69,7 @@ export function registerServerCommands(program: Command): void {
       )
       .option(
         "--credentials-file <path>",
-        "Load OAuth access token from a file created by oauth login --credentials-out",
+        "Load OAuth access token from a file created by oauth login or oauth conformance --credentials-out",
       )
       .option(
         "--header <header>",

--- a/cli/src/lib/credentials-file.ts
+++ b/cli/src/lib/credentials-file.ts
@@ -2,7 +2,6 @@ import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { chmod, mkdir, rename, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
-import type { OAuthLoginResult } from "@mcpjam/sdk";
 import { redactSensitiveValue } from "./redaction.js";
 import { operationalError, usageError } from "./output.js";
 
@@ -21,6 +20,19 @@ export interface CredentialsFileContents {
   protocolVersion?: string;
 }
 
+export interface CredentialsFileSource {
+  serverUrl: string;
+  protocolVersion?: string;
+  credentials?: {
+    accessToken?: string;
+    refreshToken?: string;
+    clientId?: string;
+    clientSecret?: string;
+    tokenType?: string;
+    expiresIn?: number;
+  };
+}
+
 export type CredentialsFileAuth =
   | {
       accessToken: string;
@@ -37,7 +49,7 @@ export type CredentialsFileAuth =
 
 export async function writeCredentialsFile(
   outputPath: string,
-  result: OAuthLoginResult,
+  result: CredentialsFileSource,
   now = new Date(),
 ): Promise<string> {
   const resolvedPath = path.resolve(process.cwd(), outputPath);
@@ -178,11 +190,12 @@ export function assertNoCredentialsFileAuthConflicts(
 }
 
 export function redactCredentialsFromResult(
-  result: OAuthLoginResult,
+  result: CredentialsFileSource,
   credentialsFilePath?: string,
 ): object {
   const redacted = redactSensitiveValue(result) as Record<string, unknown>;
-  const credentials = result.credentials;
+  const credentials = result.credentials ?? {};
+  const hasCredentials = Object.keys(credentials).length > 0;
   const secretMarker = credentialsFilePath ? "[SAVED_TO_FILE]" : "[REDACTED]";
   const redactedCredentials = {
     ...((redacted.credentials ?? {}) as Record<string, unknown>),
@@ -198,44 +211,47 @@ export function redactCredentialsFromResult(
 
   return {
     ...redacted,
-    credentials: redactedCredentials,
+    ...(hasCredentials ? { credentials: redactedCredentials } : {}),
     ...(credentialsFilePath ? { credentialsFile: credentialsFilePath } : {}),
   };
 }
 
-export function hasCredentialsToSave(result: OAuthLoginResult): boolean {
-  return Boolean(result.credentials.accessToken || result.credentials.refreshToken);
+export function hasCredentialsToSave(result: CredentialsFileSource): boolean {
+  return Boolean(
+    result.credentials?.accessToken || result.credentials?.refreshToken,
+  );
 }
 
 function buildCredentialsFileContents(
-  result: OAuthLoginResult,
+  result: CredentialsFileSource,
   now: Date,
 ): CredentialsFileContents {
   if (!hasCredentialsToSave(result)) {
-    throw usageError("OAuth login did not return usable credentials to save.");
+    throw usageError("OAuth flow did not return usable credentials to save.");
   }
 
+  const credentials = result.credentials ?? {};
   const expiresAt =
-    typeof result.credentials.expiresIn === "number" &&
-    Number.isFinite(result.credentials.expiresIn)
-      ? new Date(now.getTime() + result.credentials.expiresIn * 1000).toISOString()
+    typeof credentials.expiresIn === "number" &&
+    Number.isFinite(credentials.expiresIn)
+      ? new Date(now.getTime() + credentials.expiresIn * 1000).toISOString()
       : undefined;
 
   return {
     version: CREDENTIALS_FILE_VERSION,
     serverUrl: result.serverUrl,
-    ...(result.credentials.accessToken
-      ? { accessToken: result.credentials.accessToken }
+    ...(credentials.accessToken
+      ? { accessToken: credentials.accessToken }
       : {}),
-    ...(result.credentials.refreshToken
-      ? { refreshToken: result.credentials.refreshToken }
+    ...(credentials.refreshToken
+      ? { refreshToken: credentials.refreshToken }
       : {}),
-    ...(result.credentials.clientId ? { clientId: result.credentials.clientId } : {}),
-    ...(result.credentials.clientSecret
-      ? { clientSecret: result.credentials.clientSecret }
+    ...(credentials.clientId ? { clientId: credentials.clientId } : {}),
+    ...(credentials.clientSecret
+      ? { clientSecret: credentials.clientSecret }
       : {}),
-    ...(result.credentials.tokenType
-      ? { tokenType: result.credentials.tokenType }
+    ...(credentials.tokenType
+      ? { tokenType: credentials.tokenType }
       : {}),
     ...(expiresAt ? { expiresAt } : {}),
     ...(result.protocolVersion ? { protocolVersion: result.protocolVersion } : {}),

--- a/cli/src/lib/oauth-output.ts
+++ b/cli/src/lib/oauth-output.ts
@@ -4,12 +4,23 @@ import {
   type ConformanceResult,
   type OAuthConformanceSuiteResult,
 } from "@mcpjam/sdk";
+import { redactCredentialsFromResult } from "./credentials-file.js";
 import {
   usageError,
   type OutputFormat,
 } from "./output.js";
+import { redactSensitiveValue } from "./redaction.js";
 
 export type OAuthOutputFormat = OutputFormat;
+
+export interface OAuthConformanceRenderOptions {
+  credentialsFilePath?: string;
+}
+
+export interface OAuthConformanceSuiteRenderOptions
+  extends OAuthConformanceRenderOptions {
+  credentialsResultIndex?: number;
+}
 
 export function parseOAuthOutputFormat(value: string): OAuthOutputFormat {
   if (value === "json" || value === "human") {
@@ -31,23 +42,67 @@ export function resolveOAuthOutputFormat(
 export function renderOAuthConformanceResult(
   result: ConformanceResult,
   format: OAuthOutputFormat,
+  options: OAuthConformanceRenderOptions = {},
 ): string {
   switch (format) {
     case "human":
       return formatOAuthConformanceHuman(result);
     case "json":
-      return JSON.stringify(result);
+      return JSON.stringify(redactOAuthConformanceResult(result, options));
   }
 }
 
 export function renderOAuthConformanceSuiteResult(
   result: OAuthConformanceSuiteResult,
   format: OAuthOutputFormat,
+  options: OAuthConformanceSuiteRenderOptions = {},
 ): string {
   switch (format) {
     case "human":
       return formatOAuthConformanceSuiteHuman(result);
     case "json":
-      return JSON.stringify(result);
+      return JSON.stringify(redactOAuthConformanceSuiteResult(result, options));
   }
+}
+
+function redactOAuthConformanceResult(
+  result: ConformanceResult,
+  options: OAuthConformanceRenderOptions,
+): object {
+  if (options.credentialsFilePath && result.credentials) {
+    return redactCredentialsFromResult(result, options.credentialsFilePath);
+  }
+
+  return redactSensitiveValue(result) as object;
+}
+
+function redactOAuthConformanceSuiteResult(
+  result: OAuthConformanceSuiteResult,
+  options: OAuthConformanceSuiteRenderOptions,
+): object {
+  const redacted = redactSensitiveValue(result) as OAuthConformanceSuiteResult & {
+    credentialsFile?: string;
+  };
+
+  if (options.credentialsFilePath) {
+    redacted.credentialsFile = options.credentialsFilePath;
+  }
+
+  const resultIndex = options.credentialsResultIndex;
+  if (
+    options.credentialsFilePath &&
+    resultIndex !== undefined &&
+    result.results[resultIndex]?.credentials &&
+    redacted.results[resultIndex]
+  ) {
+    redacted.results[resultIndex] = {
+      ...redacted.results[resultIndex],
+      ...redactCredentialsFromResult(
+        result.results[resultIndex],
+        options.credentialsFilePath,
+      ),
+    };
+  }
+
+  return redacted;
 }

--- a/cli/src/lib/oauth-output.ts
+++ b/cli/src/lib/oauth-output.ts
@@ -44,11 +44,13 @@ export function renderOAuthConformanceResult(
   format: OAuthOutputFormat,
   options: OAuthConformanceRenderOptions = {},
 ): string {
+  const redactedResult = redactOAuthConformanceResult(result, options);
+
   switch (format) {
     case "human":
-      return formatOAuthConformanceHuman(result);
+      return formatOAuthConformanceHuman(redactedResult);
     case "json":
-      return JSON.stringify(redactOAuthConformanceResult(result, options));
+      return JSON.stringify(redactedResult);
   }
 }
 
@@ -57,29 +59,36 @@ export function renderOAuthConformanceSuiteResult(
   format: OAuthOutputFormat,
   options: OAuthConformanceSuiteRenderOptions = {},
 ): string {
+  const redactedResult = redactOAuthConformanceSuiteResult(result, options);
+
   switch (format) {
     case "human":
-      return formatOAuthConformanceSuiteHuman(result);
+      return formatOAuthConformanceSuiteHuman(redactedResult);
     case "json":
-      return JSON.stringify(redactOAuthConformanceSuiteResult(result, options));
+      return JSON.stringify(redactedResult);
   }
 }
 
 function redactOAuthConformanceResult(
   result: ConformanceResult,
   options: OAuthConformanceRenderOptions,
-): object {
+): ConformanceResult & { credentialsFile?: string } {
   if (options.credentialsFilePath && result.credentials) {
-    return redactCredentialsFromResult(result, options.credentialsFilePath);
+    return redactCredentialsFromResult(
+      result,
+      options.credentialsFilePath,
+    ) as ConformanceResult & { credentialsFile?: string };
   }
 
-  return redactSensitiveValue(result) as object;
+  return redactSensitiveValue(result) as ConformanceResult & {
+    credentialsFile?: string;
+  };
 }
 
 function redactOAuthConformanceSuiteResult(
   result: OAuthConformanceSuiteResult,
   options: OAuthConformanceSuiteRenderOptions,
-): object {
+): OAuthConformanceSuiteResult & { credentialsFile?: string } {
   const redacted = redactSensitiveValue(result) as OAuthConformanceSuiteResult & {
     credentialsFile?: string;
   };

--- a/cli/src/lib/server-config.ts
+++ b/cli/src/lib/server-config.ts
@@ -71,7 +71,7 @@ export function addSharedServerOptions(command: Command): Command {
     )
     .option(
       "--credentials-file <path>",
-      "Load OAuth credentials from a file created by oauth login --credentials-out",
+      "Load OAuth credentials from a file created by oauth login or oauth conformance --credentials-out",
     )
     .option(
       "--header <header>",

--- a/cli/tests/credentials-file.test.ts
+++ b/cli/tests/credentials-file.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import type { OAuthLoginResult } from "@mcpjam/sdk";
+import type { ConformanceResult, OAuthLoginResult } from "@mcpjam/sdk";
 import {
   readCredentialsFile,
   redactCredentialsFromResult,
@@ -50,6 +50,30 @@ function createOAuthLoginResult(
   };
 }
 
+function createOAuthConformanceResult(
+  overrides: Partial<ConformanceResult> = {},
+): ConformanceResult {
+  return {
+    passed: true,
+    serverUrl: "https://example.com/mcp",
+    protocolVersion: "2025-11-25",
+    registrationStrategy: "dcr",
+    steps: [],
+    summary: "OAuth conformance passed",
+    durationMs: 10,
+    ...overrides,
+    credentials: {
+      accessToken: "conformance-access-token",
+      refreshToken: "conformance-refresh-token",
+      clientId: "conformance-client-id",
+      clientSecret: "conformance-client-secret",
+      tokenType: "Bearer",
+      expiresIn: 1800,
+      ...overrides.credentials,
+    },
+  };
+}
+
 async function writeCredentialsJson(contents: object): Promise<string> {
   const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-creds-test-"));
   const filePath = path.join(directory, "credentials.json");
@@ -81,6 +105,28 @@ test("writeCredentialsFile writes versioned JSON with secret-safe permissions", 
     clientSecret: "client-secret",
     tokenType: "bearer",
     expiresAt: "2026-04-26T13:00:00.000Z",
+    protocolVersion: "2025-11-25",
+  });
+});
+
+test("writeCredentialsFile accepts oauth conformance results", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-creds-test-"));
+  const filePath = path.join(directory, "conformance-credentials.json");
+
+  await writeCredentialsFile(filePath, createOAuthConformanceResult(), NOW);
+
+  const fileMode = (await stat(filePath)).mode & 0o777;
+  assert.equal(fileMode, 0o600);
+  const payload = JSON.parse(await readFile(filePath, "utf8"));
+  assert.deepEqual(payload, {
+    version: 1,
+    serverUrl: "https://example.com/mcp",
+    accessToken: "conformance-access-token",
+    refreshToken: "conformance-refresh-token",
+    clientId: "conformance-client-id",
+    clientSecret: "conformance-client-secret",
+    tokenType: "Bearer",
+    expiresAt: "2026-04-26T12:30:00.000Z",
     protocolVersion: "2025-11-25",
   });
 });

--- a/cli/tests/oauth-output.test.ts
+++ b/cli/tests/oauth-output.test.ts
@@ -35,26 +35,63 @@ function createSingleResult(): ConformanceResult {
           request: {
             method: "GET",
             url: "https://auth.example.com/authorize",
-            headers: {},
+            headers: { Authorization: "Bearer request-token" },
           },
           response: {
             status: 200,
             statusText: "OK",
             headers: { "content-type": "text/html" },
-            body: "<html><head><title>Log in</title></head><body>Sign in</body></html>",
+            body: {
+              access_token: "nested-access-token",
+              refresh_token: "nested-refresh-token",
+              id_token: "nested-id-token",
+            },
           },
           duration: 10,
         },
-        httpAttempts: [],
+        httpAttempts: [
+          {
+            step: "token_request",
+            timestamp: 0,
+            request: {
+              method: "POST",
+              url: "https://auth.example.com/token",
+              headers: { Authorization: "Bearer attempt-token" },
+              body: {
+                code: "authorization-code",
+                client_secret: "attempt-client-secret",
+              },
+            },
+            response: {
+              status: 200,
+              statusText: "OK",
+              headers: { "content-type": "application/json" },
+              body: {
+                access_token: "attempt-access-token",
+                refresh_token: "attempt-refresh-token",
+                id_token: "attempt-id-token",
+              },
+            },
+          },
+        ],
         error: {
           message:
             "Headless authorization requires auto-consent. The authorization endpoint returned a 200 response instead of redirecting back with a code.",
+          details: "Authorization: Bearer error-token access_token=error-token",
         },
       },
     ],
     summary:
       "OAuth conformance failed at received_authorization_code: Headless authorization requires auto-consent.",
     durationMs: 40,
+    credentials: {
+      accessToken: "result-access-token",
+      refreshToken: "result-refresh-token",
+      clientId: "client-id",
+      clientSecret: "result-client-secret",
+      tokenType: "bearer",
+      expiresIn: 3600,
+    },
   };
 }
 
@@ -102,10 +139,42 @@ test("renderOAuthConformanceResult uses the SDK human formatter for human output
   );
 });
 
-test("renderOAuthConformanceResult preserves raw JSON output", () => {
+test("renderOAuthConformanceResult redacts sensitive JSON output", () => {
   const result = createSingleResult();
+  const output = renderOAuthConformanceResult(result, "json");
+  const payload = JSON.parse(output);
 
-  assert.equal(renderOAuthConformanceResult(result, "json"), JSON.stringify(result));
+  assert.equal(payload.credentials.accessToken, "[REDACTED]");
+  assert.equal(payload.credentials.refreshToken, "[REDACTED]");
+  assert.equal(payload.credentials.clientSecret, "[REDACTED]");
+  assert.equal(payload.credentials.clientId, "client-id");
+  assert.equal(payload.credentials.tokenType, "bearer");
+  assert.equal(payload.steps[0].http.request.headers.Authorization, "[REDACTED]");
+  assert.equal(payload.steps[0].http.response.body.access_token, "[REDACTED]");
+  assert.equal(payload.steps[0].httpAttempts[0].request.body.code, "[REDACTED]");
+  assert.equal(
+    payload.steps[0].httpAttempts[0].response.body.refresh_token,
+    "[REDACTED]",
+  );
+  assert.doesNotMatch(
+    output,
+    /result-access-token|result-refresh-token|nested-access-token|attempt-access-token|attempt-refresh-token|attempt-client-secret|error-token/,
+  );
+});
+
+test("renderOAuthConformanceResult marks credentials saved to file", () => {
+  const result = createSingleResult();
+  const output = renderOAuthConformanceResult(result, "json", {
+    credentialsFilePath: "/tmp/credentials.json",
+  });
+  const payload = JSON.parse(output);
+
+  assert.equal(payload.credentials.accessToken, "[SAVED_TO_FILE]");
+  assert.equal(payload.credentials.refreshToken, "[SAVED_TO_FILE]");
+  assert.equal(payload.credentials.clientSecret, "[SAVED_TO_FILE]");
+  assert.equal(payload.credentials.clientId, "client-id");
+  assert.equal(payload.credentialsFile, "/tmp/credentials.json");
+  assert.equal(payload.steps[0].http.response.body.access_token, "[REDACTED]");
 });
 
 test("renderOAuthConformanceSuiteResult uses the SDK human formatter for human output", () => {
@@ -117,11 +186,29 @@ test("renderOAuthConformanceSuiteResult uses the SDK human formatter for human o
   );
 });
 
-test("renderOAuthConformanceSuiteResult preserves raw JSON output", () => {
+test("renderOAuthConformanceSuiteResult redacts sensitive JSON output", () => {
   const result = createSuiteResult();
+  const output = renderOAuthConformanceSuiteResult(result, "json");
+  const payload = JSON.parse(output);
 
+  assert.equal(payload.results[0].credentials.accessToken, "[REDACTED]");
   assert.equal(
-    renderOAuthConformanceSuiteResult(result, "json"),
-    JSON.stringify(result),
+    payload.results[0].steps[0].httpAttempts[0].request.headers.Authorization,
+    "[REDACTED]",
   );
+  assert.doesNotMatch(output, /result-access-token|attempt-access-token/);
+});
+
+test("renderOAuthConformanceSuiteResult marks selected flow credentials saved", () => {
+  const result = createSuiteResult();
+  const output = renderOAuthConformanceSuiteResult(result, "json", {
+    credentialsFilePath: "/tmp/suite-credentials.json",
+    credentialsResultIndex: 0,
+  });
+  const payload = JSON.parse(output);
+
+  assert.equal(payload.credentialsFile, "/tmp/suite-credentials.json");
+  assert.equal(payload.results[0].credentialsFile, "/tmp/suite-credentials.json");
+  assert.equal(payload.results[0].credentials.accessToken, "[SAVED_TO_FILE]");
+  assert.equal(payload.results[0].credentials.clientSecret, "[SAVED_TO_FILE]");
 });

--- a/cli/tests/oauth-output.test.ts
+++ b/cli/tests/oauth-output.test.ts
@@ -1,8 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  formatOAuthConformanceHuman,
-  formatOAuthConformanceSuiteHuman,
   type ConformanceResult,
   type OAuthConformanceSuiteResult,
 } from "@mcpjam/sdk";
@@ -130,12 +128,15 @@ test("parseOAuthOutputFormat rejects reporter formats as unsupported raw output"
   );
 });
 
-test("renderOAuthConformanceResult uses the SDK human formatter for human output", () => {
+test("renderOAuthConformanceResult redacts sensitive human output", () => {
   const result = createSingleResult();
+  const output = renderOAuthConformanceResult(result, "human");
 
-  assert.equal(
-    renderOAuthConformanceResult(result, "human"),
-    formatOAuthConformanceHuman(result),
+  assert.match(output, /OAuth conformance: FAILED/);
+  assert.match(output, /\[REDACTED\]/);
+  assert.doesNotMatch(
+    output,
+    /result-access-token|result-refresh-token|result-client-secret|nested-access-token|nested-refresh-token|nested-id-token|attempt-access-token|attempt-refresh-token|attempt-id-token|attempt-client-secret|error-token/,
   );
 });
 
@@ -177,12 +178,15 @@ test("renderOAuthConformanceResult marks credentials saved to file", () => {
   assert.equal(payload.steps[0].http.response.body.access_token, "[REDACTED]");
 });
 
-test("renderOAuthConformanceSuiteResult uses the SDK human formatter for human output", () => {
+test("renderOAuthConformanceSuiteResult redacts sensitive human output", () => {
   const result = createSuiteResult();
+  const output = renderOAuthConformanceSuiteResult(result, "human");
 
-  assert.equal(
-    renderOAuthConformanceSuiteResult(result, "human"),
-    formatOAuthConformanceSuiteHuman(result),
+  assert.match(output, /OAuth conformance suite: FAILED/);
+  assert.match(output, /\[REDACTED\]/);
+  assert.doesNotMatch(
+    output,
+    /result-access-token|result-refresh-token|result-client-secret|nested-access-token|nested-refresh-token|nested-id-token|attempt-access-token|attempt-refresh-token|attempt-id-token|attempt-client-secret|error-token/,
   );
 });
 

--- a/docs/cli/oauth-conformance.mdx
+++ b/docs/cli/oauth-conformance.mdx
@@ -229,6 +229,28 @@ Three silent-failure modes this catches:
 | `--verify-tools` | After OAuth, connect to the MCP server and call `tools/list` |
 | `--verify-call-tool <name>` | Also call the named tool (implies `--verify-tools`) |
 
+## Reuse credentials safely
+
+Use `--credentials-out <path>` when a conformance run should hand credentials to
+later connected commands. The file is written with `0600` permissions and can be
+passed to commands such as `tools list`, `apps conformance`, `resources list`,
+and `server doctor` with `--credentials-file <path>`.
+
+```bash
+mcpjam oauth conformance \
+  --url https://your-server.com/mcp \
+  --protocol-version 2025-11-25 \
+  --registration dcr \
+  --credentials-out creds.json
+
+mcpjam tools list \
+  --url https://your-server.com/mcp \
+  --credentials-file creds.json
+```
+
+Raw JSON output redacts OAuth secrets by default. `--credentials-out` is the
+supported way to persist live tokens.
+
 ## Troubleshooting
 
 | Step that failed | Likely cause | Fix |
@@ -295,6 +317,7 @@ oauth-conformance:
 | `--verify-tools` | No | | After OAuth, connect and list tools |
 | `--verify-call-tool <name>` | No | | Also call the named tool (implies `--verify-tools`) |
 | `--conformance-checks` | No | | Run additional negative OAuth checks after the main flow |
+| `--credentials-out <path>` | No | | Write OAuth credentials to file (mode 0600); stdout has secrets redacted |
 | `--print-url` | No | | Print consent URL to stderr instead of launching a browser |
 | `--reporter <reporter>` | No | | `json-summary` or `junit-xml` CI report output |
 
@@ -311,6 +334,7 @@ oauth-conformance:
 | `--config <path>` | Yes | | Path to JSON config file |
 | `--verify-tools` | No | | Enable tool listing on all flows |
 | `--verify-call-tool <name>` | No | | Call the named tool after listing |
+| `--credentials-out <path>` | No | | Write OAuth credentials from the first flow that returns credentials to file (mode 0600) |
 | `--reporter <reporter>` | No | | `json-summary` or `junit-xml` CI report output |
 
 <Note>

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -34,7 +34,7 @@ All server commands accept the shared connection flags below, plus command-speci
 | `--refresh-token <token>` | OAuth refresh token |
 | `--client-id <id>` | OAuth client ID (with `--refresh-token`) |
 | `--client-secret <secret>` | OAuth client secret (with `--refresh-token`) |
-| `--credentials-file <path>` | Load OAuth credentials from a file created by `oauth login --credentials-out` |
+| `--credentials-file <path>` | Load OAuth credentials from a file created by `oauth login --credentials-out` or `oauth conformance --credentials-out` |
 | `--header <header>` | HTTP header `Key: Value` (repeatable) |
 | `--client-capabilities <json>` | Client capabilities as inline JSON, `@path`, or `-` for stdin |
 | `--command <command>` | Stdio server command |
@@ -202,6 +202,7 @@ Plus shared connection flags.
 | `--verify-tools` | No | | After OAuth, list tools |
 | `--verify-call-tool <name>` | No | | Also call the named tool |
 | `--conformance-checks` | No | | Run additional negative OAuth checks, including DCR redirect URI policy and redirect-mismatch probes |
+| `--credentials-out <path>` | No | | Write OAuth credentials to file (mode 0600); stdout has secrets redacted |
 | `--print-url` | No | | Print consent URL to stderr (interactive only) |
 | `--reporter <reporter>` | No | | `json-summary` or `junit-xml` CI report output |
 
@@ -212,6 +213,7 @@ Plus shared connection flags.
 | `--config <path>` | Yes | | Path to JSON config file |
 | `--verify-tools` | No | | Enable tool listing on all flows |
 | `--verify-call-tool <name>` | No | | Call the named tool after listing |
+| `--credentials-out <path>` | No | | Write OAuth credentials from the first flow that returns credentials to file (mode 0600) |
 | `--reporter <reporter>` | No | | `json-summary` or `junit-xml` CI report output |
 
 ### `oauth metadata`
@@ -239,7 +241,7 @@ Plus shared connection flags.
 |------|----------|---------|-------------|
 | `--url <url>` | Yes | | MCP server URL |
 | `--access-token <token>` | No | | Bearer access token |
-| `--credentials-file <path>` | No | | Load OAuth credentials from a file created by `oauth login --credentials-out` |
+| `--credentials-file <path>` | No | | Load OAuth credentials from a file created by `oauth login --credentials-out` or `oauth conformance --credentials-out` |
 | `--header <header>` | No | | HTTP header `Key: Value` (repeatable) |
 | `--check-timeout <ms>` | No | `15000` | Per-check timeout in milliseconds |
 | `--category <category>` | No | all | Restrict checks to one or more categories |
@@ -270,7 +272,7 @@ Use `--format json|human` for raw output and `--reporter json-summary|junit-xml`
 | `--refresh-token <token>` | OAuth refresh token |
 | `--client-id <id>` | OAuth client ID (with `--refresh-token`) |
 | `--client-secret <secret>` | OAuth client secret (with `--refresh-token`) |
-| `--credentials-file <path>` | Load OAuth credentials from a file created by `oauth login --credentials-out` |
+| `--credentials-file <path>` | Load OAuth credentials from a file created by `oauth login --credentials-out` or `oauth conformance --credentials-out` |
 | `--header <header>` | HTTP header `Key: Value` (repeatable) |
 | `--client-capabilities <json>` | Client capabilities as inline JSON, `@path`, or `-` for stdin |
 | `--command <command>` | Stdio server command |

--- a/docs/cli/server-inspection.mdx
+++ b/docs/cli/server-inspection.mdx
@@ -112,7 +112,7 @@ Every `server` subcommand accepts these flags for specifying how to connect:
 | `--refresh-token <token>` | OAuth refresh token |
 | `--client-id <id>` | OAuth client ID (used with `--refresh-token`) |
 | `--client-secret <secret>` | OAuth client secret (used with `--refresh-token`) |
-| `--credentials-file <path>` | Load OAuth credentials from a file created by `oauth login --credentials-out` |
+| `--credentials-file <path>` | Load OAuth credentials from a file created by `oauth login --credentials-out` or `oauth conformance --credentials-out` |
 | `--header <header>` | HTTP header in `Key: Value` format (repeatable) |
 | `--client-capabilities <json>` | Client capabilities as inline JSON, `@path`, or `-` for stdin |
 | `--command <command>` | Command for a stdio server |

--- a/sdk/src/oauth-conformance/formatter.ts
+++ b/sdk/src/oauth-conformance/formatter.ts
@@ -5,6 +5,8 @@ import type {
 } from "./types.js";
 
 const BODY_SNIPPET_LIMIT = 140;
+const SENSITIVE_OAUTH_KEYS =
+  "access_token|refresh_token|client_secret|id_token|code|code_verifier|accessToken|refreshToken|clientSecret|idToken|codeVerifier";
 
 type BodySummary =
   | {
@@ -41,15 +43,15 @@ function redactSensitiveStrings(value: string): string {
       "$1[REDACTED]",
     )
     .replace(
-      /([?&](?:access_token|refresh_token|client_secret|code)=)([^&#\s]+)/gi,
+      new RegExp(`([?&](?:${SENSITIVE_OAUTH_KEYS})=)([^&#\\s]+)`, "gi"),
       "$1[REDACTED]",
     )
     .replace(
-      /("(?:access_token|refresh_token|client_secret|code)"\s*:\s*")([^"]*)(")/gi,
+      new RegExp(`("(?:${SENSITIVE_OAUTH_KEYS})"\\s*:\\s*")([^"]*)(")`, "gi"),
       '$1[REDACTED]$3',
     )
     .replace(
-      /('(?:access_token|refresh_token|client_secret|code)'\s*:\s*')([^']*)(')/gi,
+      new RegExp(`('(?:${SENSITIVE_OAUTH_KEYS})'\\s*:\\s*')([^']*)(')`, "gi"),
       "$1[REDACTED]$3",
     );
 }

--- a/sdk/src/oauth-conformance/runner.ts
+++ b/sdk/src/oauth-conformance/runner.ts
@@ -40,6 +40,7 @@ import {
   type NormalizedOAuthConformanceConfig,
   type OAuthConformanceCheckId,
   type OAuthConformanceConfig,
+  type OAuthConformanceCredentials,
   type StepResult,
   type TrackedRequestFn,
   type VerificationResult,
@@ -205,6 +206,21 @@ function buildSummary(
   }
 
   return `OAuth conformance failed at ${firstFailure.step}: ${firstFailure.error?.message || "Unknown error"}`;
+}
+
+function buildCredentials(
+  state: OAuthFlowState,
+): OAuthConformanceCredentials | undefined {
+  const credentials: OAuthConformanceCredentials = {
+    ...(state.clientId ? { clientId: state.clientId } : {}),
+    ...(state.clientSecret ? { clientSecret: state.clientSecret } : {}),
+    ...(state.accessToken ? { accessToken: state.accessToken } : {}),
+    ...(state.refreshToken ? { refreshToken: state.refreshToken } : {}),
+    ...(state.tokenType ? { tokenType: state.tokenType } : {}),
+    ...(state.expiresIn !== undefined ? { expiresIn: state.expiresIn } : {}),
+  };
+
+  return Object.keys(credentials).length > 0 ? credentials : undefined;
 }
 
 function mergeConformanceDynamicRegistration(
@@ -818,6 +834,7 @@ export class OAuthConformanceTest {
       steps,
       summary: buildSummary(this.config, steps, passed),
       durationMs,
+      credentials: buildCredentials(state),
       verification,
     };
   }

--- a/sdk/src/oauth-conformance/types.ts
+++ b/sdk/src/oauth-conformance/types.ts
@@ -152,7 +152,17 @@ export interface ConformanceResult {
   steps: StepResult[];
   summary: string;
   durationMs: number;
+  credentials?: OAuthConformanceCredentials;
   verification?: VerificationResult;
+}
+
+export interface OAuthConformanceCredentials {
+  clientId?: string;
+  clientSecret?: string;
+  accessToken?: string;
+  refreshToken?: string;
+  tokenType?: string;
+  expiresIn?: number;
 }
 
 export interface NormalizedOAuthConformanceConfig {

--- a/sdk/tests/oauth-conformance/formatter.test.ts
+++ b/sdk/tests/oauth-conformance/formatter.test.ts
@@ -260,7 +260,7 @@ describe("OAuth conformance human formatter", () => {
             message: "Invalid redirect was accepted",
             details: {
               evidence:
-                'Authorization: Bearer tok /?code=abc&access_token=xyz {"client_secret":"shh","refresh_token":"ref"}',
+                'Authorization: Bearer tok /?code=abc&access_token=xyz&id_token=id {"client_secret":"shh"}',
             },
           },
         },
@@ -273,13 +273,13 @@ describe("OAuth conformance human formatter", () => {
     expect(output).toContain("Authorization: Bearer [REDACTED]");
     expect(output).toContain("code=[REDACTED]");
     expect(output).toContain("access_token=[REDACTED]");
+    expect(output).toContain("id_token=[REDACTED]");
     expect(output).toContain('"client_secret":"[REDACTED]"');
-    expect(output).toContain('"refresh_token":"[REDACTED]"');
     expect(output).not.toContain("Bearer tok");
     expect(output).not.toContain("code=abc");
     expect(output).not.toContain("access_token=xyz");
+    expect(output).not.toContain("id_token=id");
     expect(output).not.toContain('"client_secret":"shh"');
-    expect(output).not.toContain('"refresh_token":"ref"');
   });
 });
 

--- a/sdk/tests/oauth-conformance/runner.test.ts
+++ b/sdk/tests/oauth-conformance/runner.test.ts
@@ -112,6 +112,13 @@ describe("OAuthConformanceTest", () => {
     const result = await test.run();
 
     expect(result.passed).toBe(true);
+    expect(result.credentials).toMatchObject({
+      clientId: DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      tokenType: "Bearer",
+      expiresIn: 3600,
+    });
     expect(result.steps.map((step) => step.step)).toEqual([
       "request_without_token",
       "received_401_unauthorized",

--- a/skills/mcp-inspector/SKILL.md
+++ b/skills/mcp-inspector/SKILL.md
@@ -5,7 +5,7 @@ description: Interpret and use `mcpjam` probe, doctor, OAuth, apps conformance, 
 
 # MCPJam CLI Investigation
 
-Use this skill when analyzing MCP server behavior from `mcpjam` output. The goal is to separate:
+Use this skill when analyzing MCP server behavior from `mcpjam` or MCP Inspector output. The goal is to separate:
 
 - real protocol issues
 - interoperability warnings
@@ -16,10 +16,13 @@ Use this skill when analyzing MCP server behavior from `mcpjam` output. The goal
 
 When the user wants to connect to a server and use it:
 
-1. Discover tools: `tools list --url <url> --quiet --format json`.
+1. Probe the server first: `server probe --url <url> --quiet --format json`.
+   - Use the probe to learn auth posture, resource metadata, authorization-server metadata, and registration strategies before assuming the connected surface is public.
+2. If the probe shows `oauth_required`, authenticate with `oauth login --credentials-out <path>` or run `oauth conformance --credentials-out <path>` when the task is specifically to test the OAuth flow.
+3. Discover tools: `tools list --url <url> --credentials-file <path> --quiet --format json`.
    - Tools with `_meta.ui.resourceUri`, deprecated `_meta["ui/resourceUri"]`, or `openai/outputTemplate` in `toolsMetadata` have interactive UI.
-2. Execute a tool: `tools call --url <url> --tool-name <name> --tool-args <json>`.
-3. Execute with UI: `tools call --url <url> --tool-name <name> --tool-args <json> --ui`.
+4. Execute a tool: `tools call --url <url> --tool-name <name> --tool-args <json> --credentials-file <path>`.
+5. Execute with UI: `tools call --url <url> --tool-name <name> --tool-args <json> --credentials-file <path> --ui`.
    - `--ui` starts Inspector and renders the completed result in App Builder.
    - Use `--ui` only when the tool has UI metadata or the user explicitly asks to see UI.
 
@@ -37,7 +40,7 @@ When the user asks to investigate, audit, or triage, use the Investigation workf
 
 1. Start with the narrowest command that actually proves the claim.
 2. If the command may fail, you want a reusable handoff artifact, or CI should retain evidence, add `--debug-out <path>` to `server probe`, `server validate`, `tools call`, or `oauth login`.
-3. If the probe shows `oauth_required` and the task is to inspect the server surface, continue with `oauth login` or another supported auth flow to obtain reusable credentials before judging post-auth behavior. For multi-command connected sessions, use `--credentials-out <path>` to persist tokens and `--credentials-file <path>` on later commands; read `references/cli-surface-notes.md` for access-token-only exceptions. When a token is already available (CI, M2M, env var), pass `--access-token` or `--oauth-access-token` directly.
+3. If the probe shows `oauth_required` and the task is to inspect the server surface, continue with `oauth login` or another supported auth flow to obtain reusable credentials before judging post-auth behavior. For multi-command connected sessions, use `--credentials-out <path>` on `oauth login`, `oauth conformance`, or `oauth conformance-suite` to persist tokens and `--credentials-file <path>` on later commands; read `references/cli-surface-notes.md` for access-token-only exceptions. When a token is already available (CI, M2M, env var), prefer a credentials file when possible and pass `--access-token` or `--oauth-access-token` only as an escape hatch.
 4. After successful auth, inspect the connected surface with direct commands such as `server info`, `server capabilities`, `tools list`, `resources list/read/templates`, and `prompts list/get`.
 5. Use `server doctor --out <path>` when you need one breadth-first snapshot instead of several single-purpose command outputs.
 6. If the output came from `server doctor` or a `--debug-out` artifact, split it into primary command evidence, probe evidence, and connected-sweep evidence.
@@ -117,7 +120,7 @@ Use `pending` instead of manufacturing a `medium` or `high` security severity fr
 - `server doctor`: combined triage artifact for probe plus connected behavior. Good for breadth, not always sufficient to prove wire-level behavior by itself.
 - `oauth metadata`, `oauth proxy`, `oauth debug-proxy`: exact endpoint and metadata inspection when conformance output looks surprising.
 - `oauth login`: obtain reusable credentials and verify the authenticated MCP path. Use `--credentials-out <path>` to save tokens to disk (mode 0600) so later connected commands can use `--credentials-file <path>` without manual token extraction; check `references/cli-surface-notes.md` for commands that require a non-expired access token. Use this when the goal is to inspect a server that requires OAuth, then follow it with connected commands rather than stopping at the login result.
-- `oauth conformance`, `oauth conformance-suite`: flow-level auth checks. Treat these as targeted probes, not a complete security review. When `--conformance-checks` is enabled, the command can directly probe DCR non-loopback `http://` redirects, invalid client rejection, authorization-endpoint redirect mismatch handling, invalid bearer-token rejection at the MCP server, and token-endpoint redirect mismatch handling.
+- `oauth conformance`, `oauth conformance-suite`: flow-level auth checks. Treat these as targeted probes, not a complete security review. Use `--credentials-out <path>` when a passing flow should hand credentials to later connected commands; use `--credentials-file <path>` after that instead of extracting tokens from JSON output. Raw JSON output redacts OAuth secrets by default. When `--conformance-checks` is enabled, the command can directly probe DCR non-loopback `http://` redirects, invalid client rejection, authorization-endpoint redirect mismatch handling, invalid bearer-token rejection at the MCP server, and token-endpoint redirect mismatch handling.
 - `apps conformance`: server-side MCP Apps checks for `_meta.ui.resourceUri`, `ui://` resources, `resources/read`, HTML MIME and payload shape, and `_meta.ui` metadata. Use this for MCP Apps surface triage.
 - `server info`, `server capabilities`, `server validate`, `server ping`, `server export`: connected behavior after initialization and auth.
 - `tools list` and `tools call`, `resources list/read/templates`, `prompts list/get/list-multi`: direct post-connect capability checks. With `--ui`, `tools call` renders the completed tool result in Inspector and reports `inspectorRender` as UI command/render evidence.

--- a/skills/mcp-inspector/references/cli-surface-notes.md
+++ b/skills/mcp-inspector/references/cli-surface-notes.md
@@ -35,11 +35,13 @@ If a higher-priority surface contradicts a lower-priority summary, trust the hig
 
 ### `--credentials-out` / `--credentials-file`
 
-- `--credentials-out` is supported on `oauth login`. Writes OAuth credentials to a JSON file with `0600` permissions. Depending on the flow, the file may include access token, refresh token, client ID, and client secret. Stdout output has secret fields redacted to `[SAVED_TO_FILE]`.
+- `--credentials-out` is supported on `oauth login`, `oauth conformance`, and `oauth conformance-suite`. Writes OAuth credentials to a JSON file with `0600` permissions. Depending on the flow, the file may include access token, refresh token, client ID, and client secret. Stdout output has secret fields redacted to `[SAVED_TO_FILE]`.
+- On `oauth conformance-suite`, `--credentials-out` writes credentials from the first flow that returns usable credentials.
 - `--credentials-file` is supported on `server` commands (including `server probe`), `tools` commands, `resources` commands, `prompts` commands, `protocol conformance`, and `apps` commands. Reads credentials from a file created by `--credentials-out`.
 - The CLI validates that the credential file's server URL matches the target URL, checks token expiry (with a 60-second skew buffer), and rejects conflicts with individual token flags.
 - Connected commands such as `tools list`, `resources list`, `prompts list`, `server doctor`, and `apps` commands can use refresh-token credentials from the file when the saved access token is expired. `protocol conformance` and `server probe` require a non-expired access token from the file.
 - Credentials files are not debug artifacts — they contain live secrets. Do not confuse with `--debug-out` artifacts that redact secrets.
+- Do not extract tokens from `oauth conformance --format json`; default output redacts OAuth secrets and credentials should move between commands through the credentials file.
 
 ### `--debug-out`
 
@@ -68,6 +70,7 @@ If a higher-priority surface contradicts a lower-priority summary, trust the hig
 ### `oauth login`, `oauth conformance`, `oauth conformance-suite`
 
 - These are targeted flow tests, not a full security audit.
+- Use `--credentials-out <path>` when conformance is the auth handoff for later connected commands, then pass that path with `--credentials-file`.
 - `oauth conformance --conformance-checks` adds targeted negative probes for:
   - DCR acceptance of non-loopback `http://` redirect URIs
   - invalid client rejection at the token endpoint


### PR DESCRIPTION
## Summary
- Add `--credentials-out` to `oauth conformance` and `oauth conformance-suite` so OAuth handoff works through files instead of token extraction.
- Redact OAuth secrets from default conformance JSON output and mark saved credentials as `[SAVED_TO_FILE]` when persisted.
- Update shared help text, docs, and the mcp-inspector skill to treat conformance as a credential producer.
- Extend the OAuth conformance result shape to expose credentials for downstream saving.

## Testing
- Added/updated unit tests for OAuth conformance output redaction, credentials-file writing, and suite credential persistence.
- Added SDK coverage for credential capture and tighter redaction behavior.
- Verified with CLI and SDK typecheck plus targeted CLI/SDK test runs and an SDK build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new credential persistence paths and changes default OAuth conformance output redaction, which could impact how tokens are stored/consumed and how CI parses JSON output.
> 
> **Overview**
> Adds `--credentials-out` support to `oauth conformance` and `oauth conformance-suite`, enabling conformance runs to persist credentials to the same 0600 JSON file format used by `oauth login` (suite writes the first flow that yields credentials).
> 
> Changes default OAuth conformance raw output to **redact OAuth secrets** in both human and JSON formats, and when credentials are saved, replaces secret fields with `[SAVED_TO_FILE]` and includes `credentialsFile` metadata. The credentials-file helper now accepts a generalized `CredentialsFileSource` (not just login results), and the SDK conformance runner exposes captured `credentials` on `ConformanceResult`.
> 
> Updates help text/docs/skill guidance to treat conformance as a credential producer and adjusts SDK/CLI tests to cover credential capture, file writing, and expanded redaction (e.g., `id_token`, `code_verifier`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8b82bf41ad7375940c3cc096b733c1b7b82506b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->