### PR TITLE
fix(mcp): pass tool outputSchema to Vercel AI SDK dynamicTool

### DIFF
--- a/sdk/src/TestAgent.ts
+++ b/sdk/src/TestAgent.ts
@@ -89,6 +89,7 @@ function convertToToolSet(tools: Tool[]): ToolSet {
     const converted = dynamicTool({
       description: tool.description,
       inputSchema: jsonSchema(ensureJsonSchemaObject(tool.inputSchema)),
+      ...(tool.outputSchema ? { outputSchema: jsonSchema(tool.outputSchema as any) } : {}),
       execute: async (args, options) => {
         options?.abortSignal?.throwIfAborted?.();
         const result = await tool.execute(args as Record<string, unknown>);

--- a/sdk/src/mcp-client-manager/tool-converters.ts
+++ b/sdk/src/mcp-client-manager/tool-converters.ts
@@ -215,7 +215,7 @@ export async function convertMCPToolsToVercelTools(
   const tools: ToolSet = {};
 
   for (const toolDescription of listToolsResult.tools) {
-    const { name, description, inputSchema } = toolDescription;
+    const { name, description, inputSchema, outputSchema } = toolDescription;
     const toolMeta = toolDescription._meta as
       | Record<string, unknown>
       | undefined;
@@ -257,6 +257,7 @@ export async function convertMCPToolsToVercelTools(
         description,
         inputSchema: jsonSchema(normalizedInputSchema),
         execute,
+        ...(outputSchema ? { outputSchema: jsonSchema(outputSchema as any) } : {}),
         ...(toModelOutput ? { toModelOutput } : {}),
         ...(needsApproval != null ? { needsApproval } : {}),
       });


### PR DESCRIPTION
Fixes #1956

## Problem

When an MCP server declares a tool with an `outputSchema`, the inspector reads it for client-side validation and UI display, but does NOT include it in the structured tool definitions sent to the LLM via the Vercel AI SDK. As a result, the LLM cannot interpret custom response fields defined in the output schema.

## Changes

- **File 1**: `sdk/src/mcp-client-manager/tool-converters.ts`
  - Extract `outputSchema` from the MCP tool description alongside `name`, `description`, and `inputSchema`
  - Pass `outputSchema` to `dynamicTool()` when available (automatic mode)

- **File 2**: `sdk/src/TestAgent.ts`
  - Same fix: include `outputSchema` in the `dynamicTool()` call for the test agent's tool conversion

## Impact

Before this fix, an MCP tool like:
```python
@mcp.tool()
def get_weather(city: str) -> WeatherData:
    ...
```
Where `WeatherData` has a custom field `x: int`, would not pass the output schema to the LLM. The LLM could not interpret the `x` field in the response.

After this fix, the output schema is included in the tool definition, allowing the LLM to correctly understand and use all response fields.
