### PR TITLE
fix(release): use dedicated push token for finalize job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -461,7 +461,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.BACKEND_PREVIEW_DISPATCH_TOKEN }}
+          token: ${{ secrets.RELEASE_PUSH_TOKEN }}
 
       - name: Download release patch
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- Swap `BACKEND_PREVIEW_DISPATCH_TOKEN` for a new `RELEASE_PUSH_TOKEN` secret on the `finalize` job's checkout, so the version-bump commit and release tag can actually push to `main`.

## Why
The last several Release workflow runs failed at the `Push release commit` step with `GH013: Repository rule violations found for refs/heads/main` (push declined — "Changes must be made through a pull request"). The `Standard BC` ruleset on `main` requires PRs and 2 status checks, and only allows bypass for **Organization admin** and **Repository admin** roles.

`BACKEND_PREVIEW_DISPATCH_TOKEN` belongs to an identity that isn't on the bypass list, so its push was rejected. `RELEASE_PUSH_TOKEN` is a fine-grained PAT issued under an account with Repository admin, which already inherits bypass via the existing role-based entry — no ruleset edits required.

## Required setup before merging
- [ ] Add a repo secret named `RELEASE_PUSH_TOKEN` containing a fine-grained PAT with `Contents: Read and write` on `MCPJam/inspector`. The PAT must be owned by an account with Organization admin or Repository admin role on this repo.

## Test plan
- [ ] After merging, manually dispatch the Release workflow and confirm the `finalize` job's `Push release commit` and `Create and push release tag` steps both succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)