### PR TITLE
Fix connection hanging

### DIFF
--- a/cli/src/commands/oauth.ts
+++ b/cli/src/commands/oauth.ts
@@ -51,36 +51,61 @@ import {
   redactCredentialsFromResult,
   writeCredentialsFile,
 } from "../lib/credentials-file.js";
-import {
-  createCliRpcLogCollector,
-} from "../lib/rpc-logs.js";
+import { createCliRpcLogCollector } from "../lib/rpc-logs.js";
 import { summarizeServerDoctorTarget } from "../lib/server-doctor.js";
 import type { MCPServerConfig, OAuthLoginResult } from "@mcpjam/sdk";
 
 const DYNAMIC_CLIENT_ID_PLACEHOLDER = "__dynamic_registration_client__";
 const DYNAMIC_CLIENT_SECRET_PLACEHOLDER = "__dynamic_registration_secret__";
+const DEFAULT_OAUTH_STEP_TIMEOUT_MS = 120_000;
 
-function getOAuthFormat(
-  command: Command,
-): OAuthOutputFormat {
+function getOAuthFormat(command: Command): OAuthOutputFormat {
   const opts = command.optsWithGlobals() as { format?: string };
   return resolveOAuthOutputFormat(opts.format, process.stdout.isTTY);
 }
 
 function getOAuthConformanceFormat(
   command: Command,
-  reporter: ReporterFormat | undefined,
+  reporter: ReporterFormat | undefined
 ): OAuthOutputFormat {
   const opts = command.optsWithGlobals() as { format?: string };
   return resolveConformanceOutputFormatForCli(
     opts.format,
     process.stdout.isTTY,
-    reporter,
+    reporter
   );
 }
 
 function writeOAuthOutput(output: string): void {
   process.stdout.write(output.endsWith("\n") ? output : `${output}\n`);
+}
+
+function createOAuthProgressReporter(quiet?: boolean): {
+  onProgress: (message: string) => void;
+  clear: () => void;
+} {
+  let wroteInlineProgress = false;
+
+  return {
+    onProgress(message: string) {
+      if (quiet) {
+        return;
+      }
+
+      if (process.stderr.isTTY) {
+        wroteInlineProgress = true;
+        process.stderr.write(`\r\x1b[K${message}`);
+        return;
+      }
+
+      process.stderr.write(`${message}\n`);
+    },
+    clear() {
+      if (!quiet && process.stderr.isTTY && wroteInlineProgress) {
+        process.stderr.write("\r\x1b[K");
+      }
+    },
+  };
 }
 
 export function buildOAuthLoginDebugOutcome(options: {
@@ -115,7 +140,7 @@ export function buildOAuthLoginDebugOutcome(options: {
     result: options.result,
     error: buildCommandArtifactError(
       "OAUTH_LOGIN_INCOMPLETE",
-      options.result?.error?.message ?? "OAuth login did not complete.",
+      options.result?.error?.message ?? "OAuth login did not complete."
     ),
   };
 }
@@ -157,28 +182,28 @@ export function registerOAuthCommands(program: Command): void {
     .requiredOption("--url <url>", "MCP server URL")
     .option(
       "--protocol-version <version>",
-      "OAuth protocol override: 2025-03-26, 2025-06-18, or 2025-11-25",
+      "OAuth protocol override: 2025-03-26, 2025-06-18, or 2025-11-25"
     )
     .option(
       "--registration <strategy>",
-      "Registration override: dcr, preregistered, or cimd",
+      "Registration override: dcr, preregistered, or cimd"
     )
     .option(
       "--auth-mode <mode>",
       "Authorization mode: headless, interactive, or client_credentials",
-      "interactive",
+      "interactive"
     )
     .option(
       "--header <header>",
       'HTTP header in "Key: Value" format. Repeat to send multiple headers.',
       (value: string, previous: string[] = []) => [...previous, value],
-      [],
+      []
     )
     .option("--client-id <id>", "OAuth client ID")
     .option("--client-secret <secret>", "OAuth client secret")
     .option(
       "--client-metadata-url <url>",
-      "Client metadata URL used for CIMD registration",
+      "Client metadata URL used for CIMD registration"
     )
     .option("--redirect-url <url>", "OAuth redirect URL to use for the flow")
     .option("--scopes <scopes>", "Space-separated scope string")
@@ -186,42 +211,36 @@ export function registerOAuthCommands(program: Command): void {
       "--step-timeout <ms>",
       "Per-step timeout in milliseconds",
       (value: string) => parsePositiveInteger(value, "Step timeout"),
-      30_000,
+      DEFAULT_OAUTH_STEP_TIMEOUT_MS
     )
     .option(
       "--verify-tools",
-      "After OAuth succeeds, verify the token by listing MCP tools",
+      "After OAuth succeeds, verify the token by listing MCP tools"
     )
     .option(
       "--verify-call-tool <name>",
-      "After listing tools, also call the named tool",
+      "After listing tools, also call the named tool"
     )
-    .option(
-      "--debug-out <path>",
-      "Write a structured debug artifact to a file",
-    )
+    .option("--debug-out <path>", "Write a structured debug artifact to a file")
     .option(
       "--credentials-out <path>",
-      "Write OAuth credentials to <path> (mode 0600); stdout output has secret fields redacted to [SAVED_TO_FILE]",
+      "Write OAuth credentials to <path> (mode 0600); stdout output has secret fields redacted to [SAVED_TO_FILE]"
+    )
+    .option(
+      "--print-url",
+      "In interactive mode, print the consent URL to stderr instead of launching a browser"
     )
     .action(async (options, command) => {
       const globalOptions = getGlobalOptions(command);
       const format = getOAuthFormat(command);
-      const config = buildOAuthLoginConfig(
-        options as OAuthCommandOptions,
-        {
-          defaultAuthMode: "interactive",
-        },
-      );
+      const config = buildOAuthLoginConfig(options as OAuthCommandOptions, {
+        defaultAuthMode: "interactive",
+      });
       const snapshotCollector = options.debugOut
         ? createCliRpcLogCollector({ __cli__: config.serverUrl })
         : undefined;
-      const isTTY = process.stderr.isTTY && !globalOptions.quiet;
-      if (isTTY) {
-        config.onProgress = (message: string) => {
-          process.stderr.write(`\r\x1b[K${message}`);
-        };
-      }
+      const progress = createOAuthProgressReporter(globalOptions.quiet);
+      config.onProgress = progress.onProgress;
 
       let result: OAuthLoginResult | undefined;
       let commandError: unknown;
@@ -231,15 +250,13 @@ export function registerOAuthCommands(program: Command): void {
       } catch (error) {
         commandError = error;
       } finally {
-        if (isTTY) {
-          process.stderr.write("\r\x1b[K");
-        }
+        progress.clear();
       }
 
       const snapshotConfig = buildOAuthLoginSnapshotConfig(config, result);
       const target = summarizeServerDoctorTarget(
         config.serverUrl,
-        snapshotConfig,
+        snapshotConfig
       );
 
       let credentialsFilePath: string | undefined;
@@ -251,14 +268,20 @@ export function registerOAuthCommands(program: Command): void {
         hasCredentialsToSave(result)
       ) {
         try {
+          progress.onProgress("Saving OAuth credentials...");
           credentialsFilePath = await writeCredentialsFile(
             options.credentialsOut as string,
-            result,
+            result
+          );
+          progress.onProgress(
+            `OAuth credentials saved to ${credentialsFilePath}.`
           );
         } catch (error) {
           credentialsFileError = error;
+          progress.onProgress("Failed to save OAuth credentials.");
         }
       }
+      progress.clear();
 
       await writeCommandDebugArtifact({
         outputPath: options.debugOut as string | undefined,
@@ -266,7 +289,7 @@ export function registerOAuthCommands(program: Command): void {
         quiet: globalOptions.quiet,
         commandName: "oauth login",
         commandInput: summarizeOAuthLoginCommandInput(
-          options as OAuthCommandOptions,
+          options as OAuthCommandOptions
         ),
         target,
         outcome: buildOAuthLoginDebugOutcome({
@@ -279,7 +302,7 @@ export function registerOAuthCommands(program: Command): void {
               input: {
                 config: snapshotConfig,
                 target,
-                timeout: config.stepTimeout ?? 30_000,
+                timeout: config.stepTimeout ?? DEFAULT_OAUTH_STEP_TIMEOUT_MS,
               },
               collector: snapshotCollector,
             }
@@ -290,13 +313,16 @@ export function registerOAuthCommands(program: Command): void {
         throw commandError;
       }
       if (!result) {
-        throw cliError("INTERNAL_ERROR", "OAuth login did not return a result.");
+        throw cliError(
+          "INTERNAL_ERROR",
+          "OAuth login did not return a result."
+        );
       }
 
       if (options.credentialsOut) {
         writeResult(
           redactCredentialsFromResult(result, credentialsFilePath),
-          format,
+          format
         );
         if (credentialsFileError) {
           throw credentialsFileError;
@@ -315,28 +341,28 @@ export function registerOAuthCommands(program: Command): void {
     .requiredOption("--url <url>", "MCP server URL")
     .requiredOption(
       "--protocol-version <version>",
-      "OAuth protocol version: 2025-03-26, 2025-06-18, or 2025-11-25",
+      "OAuth protocol version: 2025-03-26, 2025-06-18, or 2025-11-25"
     )
     .requiredOption(
       "--registration <strategy>",
-      "Registration strategy: dcr, preregistered, or cimd",
+      "Registration strategy: dcr, preregistered, or cimd"
     )
     .option(
       "--auth-mode <mode>",
       "Authorization mode: headless, interactive, or client_credentials",
-      "interactive",
+      "interactive"
     )
     .option(
       "--header <header>",
       'HTTP header in "Key: Value" format. Repeat to send multiple headers.',
       (value: string, previous: string[] = []) => [...previous, value],
-      [],
+      []
     )
     .option("--client-id <id>", "OAuth client ID")
     .option("--client-secret <secret>", "OAuth client secret")
     .option(
       "--client-metadata-url <url>",
-      "Client metadata URL used for CIMD registration",
+      "Client metadata URL used for CIMD registration"
     )
     .option("--redirect-url <url>", "OAuth redirect URL to use for the flow")
     .option("--scopes <scopes>", "Space-separated scope string")
@@ -344,36 +370,40 @@ export function registerOAuthCommands(program: Command): void {
       "--step-timeout <ms>",
       "Per-step timeout in milliseconds",
       (value: string) => parsePositiveInteger(value, "Step timeout"),
-      30_000,
+      DEFAULT_OAUTH_STEP_TIMEOUT_MS
     )
     .option(
       "--verify-tools",
-      "After OAuth succeeds, verify the token by listing MCP tools",
+      "After OAuth succeeds, verify the token by listing MCP tools"
     )
     .option(
       "--verify-call-tool <name>",
-      "After listing tools, also call the named tool",
+      "After listing tools, also call the named tool"
     )
     .option(
       "--conformance-checks",
-      "Run additional OAuth negative checks (invalid client, invalid redirect, token format) after the main flow",
+      "Run additional OAuth negative checks (invalid client, invalid redirect, token format) after the main flow"
     )
     .option(
       "--credentials-out <path>",
-      "Write OAuth credentials to <path> (mode 0600); stdout output has secret fields redacted to [SAVED_TO_FILE]",
+      "Write OAuth credentials to <path> (mode 0600); stdout output has secret fields redacted to [SAVED_TO_FILE]"
     )
     .option(
       "--print-url",
-      "In interactive mode, print the consent URL to stderr instead of launching a browser",
+      "In interactive mode, print the consent URL to stderr instead of launching a browser"
     )
     .option(
       "--reporter <reporter>",
-      "Structured reporter output: json-summary or junit-xml",
+      "Structured reporter output: json-summary or junit-xml"
     )
     .action(async (options, command) => {
-      const reporter = parseReporterFormat(options.reporter as string | undefined);
+      const reporter = parseReporterFormat(
+        options.reporter as string | undefined
+      );
       const format = getOAuthConformanceFormat(command, reporter);
-      const config = buildOAuthConformanceConfig(options as OAuthCommandOptions);
+      const config = buildOAuthConformanceConfig(
+        options as OAuthCommandOptions
+      );
       const result = await new OAuthConformanceTest(config).run();
       let credentialsFilePath: string | undefined;
       let credentialsFileError: unknown;
@@ -382,7 +412,7 @@ export function registerOAuthCommands(program: Command): void {
         try {
           credentialsFilePath = await writeCredentialsFile(
             options.credentialsOut as string,
-            result,
+            result
           );
         } catch (error) {
           credentialsFileError = error;
@@ -394,7 +424,7 @@ export function registerOAuthCommands(program: Command): void {
           ? renderConformanceReporterResult(result, reporter)
           : renderOAuthConformanceResult(result, format, {
               credentialsFilePath,
-            }),
+            })
       );
       if (credentialsFileError) {
         throw credentialsFileError;
@@ -407,27 +437,29 @@ export function registerOAuthCommands(program: Command): void {
   oauth
     .command("conformance-suite")
     .description(
-      "Run a matrix of OAuth conformance flows from a JSON config file",
+      "Run a matrix of OAuth conformance flows from a JSON config file"
     )
     .requiredOption("--config <path>", "Path to JSON config file")
     .option(
       "--verify-tools",
-      "Enable post-auth tool listing verification on all flows",
+      "Enable post-auth tool listing verification on all flows"
     )
     .option(
       "--verify-call-tool <name>",
-      "Also call the named tool after listing",
+      "Also call the named tool after listing"
     )
     .option(
       "--credentials-out <path>",
-      "Write OAuth credentials from the first flow that returns credentials to <path> (mode 0600)",
+      "Write OAuth credentials from the first flow that returns credentials to <path> (mode 0600)"
     )
     .option(
       "--reporter <reporter>",
-      "Structured reporter output: json-summary or junit-xml",
+      "Structured reporter output: json-summary or junit-xml"
     )
     .action(async (options, command) => {
-      const reporter = parseReporterFormat(options.reporter as string | undefined);
+      const reporter = parseReporterFormat(
+        options.reporter as string | undefined
+      );
       const format = getOAuthConformanceFormat(command, reporter);
       const config = loadOAuthSuiteConfig(options.config as string);
 
@@ -444,7 +476,10 @@ export function registerOAuthCommands(program: Command): void {
         }
         config.defaults = {
           ...config.defaults,
-          verification: { ...config.defaults?.verification, ...cliVerification },
+          verification: {
+            ...config.defaults?.verification,
+            ...cliVerification,
+          },
         };
       }
 
@@ -454,14 +489,11 @@ export function registerOAuthCommands(program: Command): void {
       let credentialsFilePath: string | undefined;
       let credentialsFileError: unknown;
 
-      if (
-        options.credentialsOut &&
-        credentialsResultIndex !== undefined
-      ) {
+      if (options.credentialsOut && credentialsResultIndex !== undefined) {
         try {
           credentialsFilePath = await writeCredentialsFile(
             options.credentialsOut as string,
-            result.results[credentialsResultIndex],
+            result.results[credentialsResultIndex]
           );
         } catch (error) {
           credentialsFileError = error;
@@ -474,7 +506,7 @@ export function registerOAuthCommands(program: Command): void {
           : renderOAuthConformanceSuiteResult(result, format, {
               credentialsFilePath,
               credentialsResultIndex,
-            }),
+            })
       );
       if (credentialsFileError) {
         throw credentialsFileError;
@@ -503,11 +535,11 @@ export function registerOAuthCommands(program: Command): void {
       "--header <header>",
       'HTTP header in "Key: Value" format. Repeat to send multiple headers.',
       (value: string, previous: string[] = []) => [...previous, value],
-      [],
+      []
     )
     .option(
       "--body <value>",
-      "Request body as JSON, raw string, @path, or - for stdin",
+      "Request body as JSON, raw string, @path, or - for stdin"
     )
     .action(async (options, command) => {
       const format = getOAuthFormat(command);
@@ -524,16 +556,16 @@ export function registerOAuthCommands(program: Command): void {
       "--header <header>",
       'HTTP header in "Key: Value" format. Repeat to send multiple headers.',
       (value: string, previous: string[] = []) => [...previous, value],
-      [],
+      []
     )
     .option(
       "--body <value>",
-      "Request body as JSON, raw string, @path, or - for stdin",
+      "Request body as JSON, raw string, @path, or - for stdin"
     )
     .action(async (options, command) => {
       const format = getOAuthFormat(command);
       const result = await runOAuthDebugProxy(
-        options as OAuthProxyCommandOptions,
+        options as OAuthProxyCommandOptions
       );
       writeResult(result, format);
     });
@@ -543,37 +575,34 @@ export function buildOAuthConformanceConfig(
   options: OAuthCommandOptions,
   defaults?: {
     defaultAuthMode?: "headless" | "interactive" | "client_credentials";
-  },
+  }
 ): OAuthConformanceConfig {
   const serverUrl = options.url.trim();
   assertValidUrl(serverUrl, "server URL");
 
   const protocolVersion = parseRequiredProtocolVersion(options.protocolVersion);
   const registrationStrategy = parseRequiredRegistrationStrategy(
-    options.registration,
+    options.registration
   );
   const authMode = parseAuthMode(
-    options.authMode ?? defaults?.defaultAuthMode ?? "interactive",
+    options.authMode ?? defaults?.defaultAuthMode ?? "interactive"
   );
 
   if (options.printUrl && authMode !== "interactive") {
     throw usageError(
-      "--print-url only applies to --auth-mode interactive. Headless and client_credentials modes do not open a browser.",
+      "--print-url only applies to --auth-mode interactive. Headless and client_credentials modes do not open a browser."
     );
   }
 
-  if (
-    protocolVersion !== "2025-11-25" &&
-    registrationStrategy === "cimd"
-  ) {
+  if (protocolVersion !== "2025-11-25" && registrationStrategy === "cimd") {
     throw usageError(
-      `CIMD registration is not supported for protocol version ${protocolVersion}.`,
+      `CIMD registration is not supported for protocol version ${protocolVersion}.`
     );
   }
 
   if (authMode === "client_credentials" && registrationStrategy === "cimd") {
     throw usageError(
-      "--auth-mode client_credentials cannot be used with --registration cimd. CIMD is a browser-based registration flow and only works with --auth-mode headless or --auth-mode interactive. For client_credentials, use --registration dcr or --registration preregistered instead.",
+      "--auth-mode client_credentials cannot be used with --registration cimd. CIMD is a browser-based registration flow and only works with --auth-mode headless or --auth-mode interactive. For client_credentials, use --registration dcr or --registration preregistered instead."
     );
   }
 
@@ -584,7 +613,7 @@ export function buildOAuthConformanceConfig(
 
   if (registrationStrategy === "preregistered" && !clientId) {
     throw usageError(
-      "--client-id is required when --registration preregistered is used.",
+      "--client-id is required when --registration preregistered is used."
     );
   }
 
@@ -594,7 +623,7 @@ export function buildOAuthConformanceConfig(
     !clientSecret
   ) {
     throw usageError(
-      "--client-secret is required for preregistered client_credentials runs.",
+      "--client-secret is required for preregistered client_credentials runs."
     );
   }
 
@@ -630,13 +659,19 @@ export function buildOAuthConformanceConfig(
         }
       : undefined;
 
-  const auth = buildAuthConfig(authMode, registrationStrategy, clientId, clientSecret);
+  const auth = buildAuthConfig(
+    authMode,
+    registrationStrategy,
+    clientId,
+    clientSecret
+  );
 
   if (options.printUrl && auth.mode === "interactive") {
-    (auth as { openUrl?: (url: string) => Promise<void> }).openUrl =
-      async (url: string) => {
-        process.stderr.write(`OAUTH_CONSENT_URL: ${url}\n`);
-      };
+    (auth as { openUrl?: (url: string) => Promise<void> }).openUrl = async (
+      url: string
+    ) => {
+      process.stderr.write(`OAUTH_CONSENT_URL: ${url}\n`);
+    };
   }
 
   return {
@@ -648,14 +683,14 @@ export function buildOAuthConformanceConfig(
     scopes: options.scopes?.trim() || undefined,
     customHeaders,
     redirectUrl,
-    stepTimeout: options.stepTimeout ?? 30_000,
+    stepTimeout: options.stepTimeout ?? DEFAULT_OAUTH_STEP_TIMEOUT_MS,
     verification,
     oauthConformanceChecks: options.conformanceChecks ?? false,
   };
 }
 
 function findCredentialsResultIndex(
-  result: OAuthConformanceSuiteResult,
+  result: OAuthConformanceSuiteResult
 ): number | undefined {
   const index = result.results.findIndex(hasCredentialsToSave);
   return index >= 0 ? index : undefined;
@@ -665,7 +700,7 @@ export function buildOAuthLoginConfig(
   options: OAuthCommandOptions,
   defaults?: {
     defaultAuthMode?: "headless" | "interactive" | "client_credentials";
-  },
+  }
 ): OAuthLoginConfig {
   const serverUrl = options.url.trim();
   assertValidUrl(serverUrl, "server URL");
@@ -677,12 +712,12 @@ export function buildOAuthLoginConfig(
     ? parseRegistrationStrategy(options.registration)
     : undefined;
   const authMode = parseAuthMode(
-    options.authMode ?? defaults?.defaultAuthMode ?? "interactive",
+    options.authMode ?? defaults?.defaultAuthMode ?? "interactive"
   );
 
   if (options.printUrl && authMode !== "interactive") {
     throw usageError(
-      "--print-url only applies to --auth-mode interactive. Headless and client_credentials modes do not open a browser.",
+      "--print-url only applies to --auth-mode interactive. Headless and client_credentials modes do not open a browser."
     );
   }
 
@@ -692,13 +727,13 @@ export function buildOAuthLoginConfig(
     protocolVersion !== "2025-11-25"
   ) {
     throw usageError(
-      `CIMD registration is not supported for protocol version ${protocolVersion}.`,
+      `CIMD registration is not supported for protocol version ${protocolVersion}.`
     );
   }
 
   if (authMode === "client_credentials" && registrationStrategy === "cimd") {
     throw usageError(
-      "--auth-mode client_credentials cannot be used with --registration cimd. CIMD is a browser-based registration flow and only works with --auth-mode headless or --auth-mode interactive. For client_credentials, use --registration dcr or --registration preregistered instead.",
+      "--auth-mode client_credentials cannot be used with --registration cimd. CIMD is a browser-based registration flow and only works with --auth-mode headless or --auth-mode interactive. For client_credentials, use --registration dcr or --registration preregistered instead."
     );
   }
 
@@ -709,7 +744,7 @@ export function buildOAuthLoginConfig(
 
   if (registrationStrategy === "preregistered" && !clientId) {
     throw usageError(
-      "--client-id is required when --registration preregistered is used.",
+      "--client-id is required when --registration preregistered is used."
     );
   }
 
@@ -719,7 +754,7 @@ export function buildOAuthLoginConfig(
     !clientSecret
   ) {
     throw usageError(
-      "--client-secret is required for preregistered client_credentials runs.",
+      "--client-secret is required for preregistered client_credentials runs."
     );
   }
 
@@ -759,14 +794,15 @@ export function buildOAuthLoginConfig(
     authMode,
     registrationStrategy ?? "dcr",
     clientId,
-    clientSecret,
+    clientSecret
   );
 
   if (options.printUrl && auth.mode === "interactive") {
-    (auth as { openUrl?: (url: string) => Promise<void> }).openUrl =
-      async (url: string) => {
-        process.stderr.write(`OAUTH_CONSENT_URL: ${url}\n`);
-      };
+    (auth as { openUrl?: (url: string) => Promise<void> }).openUrl = async (
+      url: string
+    ) => {
+      process.stderr.write(`OAUTH_CONSENT_URL: ${url}\n`);
+    };
   }
 
   return {
@@ -780,14 +816,14 @@ export function buildOAuthLoginConfig(
     scopes: options.scopes?.trim() || undefined,
     customHeaders,
     redirectUrl,
-    stepTimeout: options.stepTimeout ?? 30_000,
+    stepTimeout: options.stepTimeout ?? DEFAULT_OAUTH_STEP_TIMEOUT_MS,
     verification,
     oauthConformanceChecks: false,
   };
 }
 
 export function summarizeOAuthLoginCommandInput(
-  options: OAuthCommandOptions,
+  options: OAuthCommandOptions
 ): Record<string, unknown> {
   return {
     serverUrl: options.url.trim(),
@@ -804,7 +840,7 @@ export function summarizeOAuthLoginCommandInput(
     hasClientSecret: Boolean(options.clientSecret),
     verifyTools: options.verifyTools ?? false,
     verifyCallTool: options.verifyCallTool ?? undefined,
-    stepTimeout: options.stepTimeout ?? 30_000,
+    stepTimeout: options.stepTimeout ?? DEFAULT_OAUTH_STEP_TIMEOUT_MS,
   };
 }
 
@@ -813,14 +849,14 @@ export function buildOAuthLoginSnapshotConfig(
     OAuthLoginConfig,
     "serverUrl" | "customHeaders" | "stepTimeout" | "client" | "auth"
   >,
-  result?: OAuthLoginResult,
+  result?: OAuthLoginResult
 ): MCPServerConfig {
   const baseConfig: MCPServerConfig = {
     url: config.serverUrl,
     ...(config.customHeaders
       ? { requestInit: { headers: config.customHeaders } }
       : {}),
-    timeout: config.stepTimeout ?? 30_000,
+    timeout: config.stepTimeout ?? DEFAULT_OAUTH_STEP_TIMEOUT_MS,
   };
   if (!result) {
     return baseConfig;
@@ -829,7 +865,9 @@ export function buildOAuthLoginSnapshotConfig(
   const clientId =
     result.credentials.clientId ??
     config.client?.preregistered?.clientId ??
-    (config.auth?.mode === "client_credentials" ? config.auth.clientId : undefined);
+    (config.auth?.mode === "client_credentials"
+      ? config.auth.clientId
+      : undefined);
   const clientSecret =
     result.credentials.clientSecret ??
     config.client?.preregistered?.clientSecret ??
@@ -860,7 +898,7 @@ function buildAuthConfig(
   authMode: "headless" | "interactive" | "client_credentials",
   registrationStrategy: OAuthCommandOptions["registration"],
   clientId: string | undefined,
-  clientSecret: string | undefined,
+  clientSecret: string | undefined
 ): NonNullable<OAuthConformanceConfig["auth"]> {
   switch (authMode) {
     case "headless":
@@ -872,9 +910,7 @@ function buildAuthConfig(
         mode: "client_credentials",
         clientId:
           clientId ??
-          (registrationStrategy === "dcr"
-            ? DYNAMIC_CLIENT_ID_PLACEHOLDER
-            : ""),
+          (registrationStrategy === "dcr" ? DYNAMIC_CLIENT_ID_PLACEHOLDER : ""),
         clientSecret:
           clientSecret ??
           (registrationStrategy === "dcr"
@@ -895,23 +931,25 @@ function assertValidUrl(value: string, label: string): void {
 }
 
 function parseProtocolVersion(
-  value: string,
+  value: string
 ): "2025-03-26" | "2025-06-18" | "2025-11-25" {
   if (VALID_PROTOCOL_VERSIONS.has(value)) {
     return value as "2025-03-26" | "2025-06-18" | "2025-11-25";
   }
 
   throw usageError(
-    `Invalid protocol version "${value}". Use ${[...VALID_PROTOCOL_VERSIONS].join(", ")}.`,
+    `Invalid protocol version "${value}". Use ${[
+      ...VALID_PROTOCOL_VERSIONS,
+    ].join(", ")}.`
   );
 }
 
 function parseRequiredProtocolVersion(
-  value: string | undefined,
+  value: string | undefined
 ): "2025-03-26" | "2025-06-18" | "2025-11-25" {
   if (!value) {
     throw usageError(
-      "--protocol-version is required for oauth conformance flows.",
+      "--protocol-version is required for oauth conformance flows."
     );
   }
 
@@ -919,38 +957,38 @@ function parseRequiredProtocolVersion(
 }
 
 function parseRegistrationStrategy(
-  value: string,
+  value: string
 ): "cimd" | "dcr" | "preregistered" {
   if (VALID_REGISTRATION_STRATEGIES.has(value)) {
     return value as "cimd" | "dcr" | "preregistered";
   }
 
   throw usageError(
-    `Invalid registration strategy "${value}". Use ${[...VALID_REGISTRATION_STRATEGIES].join(", ")}.`,
+    `Invalid registration strategy "${value}". Use ${[
+      ...VALID_REGISTRATION_STRATEGIES,
+    ].join(", ")}.`
   );
 }
 
 function parseRequiredRegistrationStrategy(
-  value: string | undefined,
+  value: string | undefined
 ): "cimd" | "dcr" | "preregistered" {
   if (!value) {
-    throw usageError(
-      "--registration is required for oauth conformance flows.",
-    );
+    throw usageError("--registration is required for oauth conformance flows.");
   }
 
   return parseRegistrationStrategy(value);
 }
 
 function parseAuthMode(
-  value: string,
+  value: string
 ): "headless" | "interactive" | "client_credentials" {
   if (VALID_AUTH_MODES.has(value)) {
     return value as "headless" | "interactive" | "client_credentials";
   }
 
   throw usageError(
-    `Invalid auth mode "${value}". Use ${[...VALID_AUTH_MODES].join(", ")}.`,
+    `Invalid auth mode "${value}". Use ${[...VALID_AUTH_MODES].join(", ")}.`
   );
 }
 
@@ -960,7 +998,7 @@ export async function runOAuthMetadata(url: string) {
     if ("status" in result && result.status !== undefined) {
       throw cliError(
         statusToErrorCode(result.status),
-        `Failed to fetch OAuth metadata: ${result.status} ${result.statusText}`,
+        `Failed to fetch OAuth metadata: ${result.status} ${result.statusText}`
       );
     }
 

--- a/cli/src/lib/debug-artifact.ts
+++ b/cli/src/lib/debug-artifact.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { chmod, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
   runServerDoctor,
@@ -64,7 +64,7 @@ export async function writeCommandDebugArtifact<TTarget = unknown>(
   options: CommandDebugArtifactOptions<TTarget>,
   dependencies: {
     runDoctor?: typeof runServerDoctor;
-  } = {},
+  } = {}
 ): Promise<string | undefined> {
   if (!options.outputPath) {
     return undefined;
@@ -81,10 +81,7 @@ export async function writeCommandDebugArtifact<TTarget = unknown>(
     outcome: options.outcome,
     snapshot: snapshotResult.snapshot,
     snapshotError: snapshotResult.snapshotError,
-    collectors: [
-      ...(options.collectors ?? []),
-      options.snapshot?.collector,
-    ],
+    collectors: [...(options.collectors ?? []), options.snapshot?.collector],
   });
   const artifactPath = await writeDebugArtifact(options.outputPath, payload);
 
@@ -131,7 +128,7 @@ export function buildDebugArtifactEnvelope<TTarget = unknown>(options: {
 export function buildCommandArtifactError(
   code: string,
   message: string,
-  details?: unknown,
+  details?: unknown
 ): StructuredCommandError {
   return {
     code,
@@ -142,7 +139,7 @@ export function buildCommandArtifactError(
 
 export async function writeDebugArtifact(
   outputPath: string,
-  payload: unknown,
+  payload: unknown
 ): Promise<string> {
   const resolvedPath = path.resolve(process.cwd(), outputPath);
   const redactedPayload = redactSensitiveValue(payload);
@@ -152,26 +149,33 @@ export async function writeDebugArtifact(
     await writeFile(
       resolvedPath,
       `${JSON.stringify(redactedPayload, null, 2)}\n`,
-      "utf8",
+      {
+        encoding: "utf8",
+        mode: 0o600,
+      }
     );
+    await chmod(resolvedPath, 0o600);
   } catch (error) {
     throw operationalError(
       `Failed to write debug artifact to "${resolvedPath}".`,
       {
         source: error instanceof Error ? error.message : String(error),
-      },
+      }
     );
   }
 
   return resolvedPath;
 }
 
-async function collectDoctorSnapshot<TTarget = unknown>(options: {
-  input: RunServerDoctorInput<TTarget>;
-  collector?: CliRpcLogCollector;
-}, dependencies: {
-  runDoctor?: typeof runServerDoctor;
-} = {}): Promise<{
+async function collectDoctorSnapshot<TTarget = unknown>(
+  options: {
+    input: RunServerDoctorInput<TTarget>;
+    collector?: CliRpcLogCollector;
+  },
+  dependencies: {
+    runDoctor?: typeof runServerDoctor;
+  } = {}
+): Promise<{
   snapshot: ServerDoctorResult<TTarget> | null;
   snapshotError: StructuredCommandError | null;
 }> {

--- a/cli/tests/debug-artifact.test.ts
+++ b/cli/tests/debug-artifact.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, stat } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -11,7 +11,9 @@ import {
 } from "../src/lib/debug-artifact.js";
 import { createCliRpcLogCollector } from "../src/lib/rpc-logs.js";
 
-function createDoctorResult<TTarget>(target: TTarget): ServerDoctorResult<TTarget> {
+function createDoctorResult<TTarget>(
+  target: TTarget
+): ServerDoctorResult<TTarget> {
   return {
     generatedAt: "2026-04-11T00:00:00.000Z",
     status: "ready" as const,
@@ -43,7 +45,7 @@ function createDoctorResult<TTarget>(target: TTarget): ServerDoctorResult<TTarge
 }
 
 test("buildDebugArtifactEnvelope merges rpc logs and redacts payloads", () => {
-  const primaryCollector = createCliRpcLogCollector({ "__cli__": "example" });
+  const primaryCollector = createCliRpcLogCollector({ __cli__: "example" });
   primaryCollector.rpcLogger({
     serverId: "__cli__",
     direction: "send",
@@ -54,7 +56,7 @@ test("buildDebugArtifactEnvelope merges rpc logs and redacts payloads", () => {
     },
   } as any);
 
-  const snapshotCollector = createCliRpcLogCollector({ "__cli__": "example" });
+  const snapshotCollector = createCliRpcLogCollector({ __cli__: "example" });
   snapshotCollector.rpcLogger({
     serverId: "__cli__",
     direction: "receive",
@@ -109,7 +111,9 @@ test("buildDebugArtifactEnvelope merges rpc logs and redacts payloads", () => {
 });
 
 test("writeCommandDebugArtifact writes a snapshot artifact and emits a human notice", async () => {
-  const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-debug-artifact-"));
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "mcpjam-debug-artifact-")
+  );
   const artifactPath = path.join(directory, "artifact.json");
   const originalWrite = process.stderr.write.bind(process.stderr);
   let stderr = "";
@@ -155,7 +159,7 @@ test("writeCommandDebugArtifact writes a snapshot artifact and emits a human not
             kind: "http",
             label: "https://example.com/mcp",
           } as TTarget),
-      },
+      }
     );
 
     const contents = JSON.parse(await readFile(writtenPath!, "utf8"));
@@ -163,6 +167,7 @@ test("writeCommandDebugArtifact writes a snapshot artifact and emits a human not
     assert.equal(contents.command.name, "server validate");
     assert.equal(contents.outcome.status, "success");
     assert.equal(contents.snapshot.status, "ready");
+    assert.equal((await stat(writtenPath!)).mode & 0o777, 0o600);
     assert.match(stderr, /Debug artifact:/);
     assert.match(stderr, /artifact\.json/);
   } finally {
@@ -171,7 +176,9 @@ test("writeCommandDebugArtifact writes a snapshot artifact and emits a human not
 });
 
 test("writeCommandDebugArtifact suppresses human notice when quiet", async () => {
-  const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-debug-artifact-"));
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "mcpjam-debug-artifact-")
+  );
   const artifactPath = path.join(directory, "quiet.json");
   const originalWrite = process.stderr.write.bind(process.stderr);
   let stderr = "";
@@ -201,7 +208,9 @@ test("writeCommandDebugArtifact suppresses human notice when quiet", async () =>
 });
 
 test("writeCommandDebugArtifact preserves command failure and records snapshot errors", async () => {
-  const directory = await mkdtemp(path.join(os.tmpdir(), "mcpjam-debug-artifact-"));
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), "mcpjam-debug-artifact-")
+  );
   const artifactPath = path.join(directory, "failure.json");
 
   const writtenPath = await writeCommandDebugArtifact(
@@ -243,7 +252,7 @@ test("writeCommandDebugArtifact preserves command failure and records snapshot e
       runDoctor: async () => {
         throw new Error("snapshot timed out");
       },
-    },
+    }
   );
 
   const contents = JSON.parse(await readFile(writtenPath!, "utf8"));

--- a/cli/tests/oauth.test.ts
+++ b/cli/tests/oauth.test.ts
@@ -18,6 +18,7 @@ test("buildOAuthConformanceConfig defaults to interactive auth", () => {
 
   assert.equal(config.auth?.mode, "interactive");
   assert.equal(config.registrationStrategy, "cimd");
+  assert.equal(config.stepTimeout, 120_000);
 });
 
 test("buildOAuthConformanceConfig can default login flows to interactive auth", () => {
@@ -29,7 +30,7 @@ test("buildOAuthConformanceConfig can default login flows to interactive auth", 
     },
     {
       defaultAuthMode: "interactive",
-    },
+    }
   );
 
   assert.equal(config.auth?.mode, "interactive");
@@ -149,6 +150,7 @@ test("buildOAuthLoginConfig defaults login flows to automatic protocol and regis
   assert.equal(config.protocolVersion, undefined);
   assert.equal(config.registrationStrategy, undefined);
   assert.equal(config.auth?.mode, "interactive");
+  assert.equal(config.stepTimeout, 120_000);
 });
 
 test("buildOAuthLoginDebugOutcome records credential file write failures", () => {
@@ -183,6 +185,17 @@ test("buildOAuthConformanceConfig sets openUrl for print-url in interactive mode
   assert.equal(typeof (config.auth as any).openUrl, "function");
 });
 
+test("buildOAuthLoginConfig sets openUrl for print-url in interactive mode", () => {
+  const config = buildOAuthLoginConfig({
+    url: "https://example.com/mcp",
+    authMode: "interactive",
+    printUrl: true,
+  });
+
+  assert.equal(config.auth?.mode, "interactive");
+  assert.equal(typeof (config.auth as any).openUrl, "function");
+});
+
 test("buildOAuthConformanceConfig rejects print-url with headless mode", () => {
   assert.throws(
     () =>
@@ -195,7 +208,25 @@ test("buildOAuthConformanceConfig rejects print-url with headless mode", () => {
       }),
     (error) =>
       error instanceof CliError &&
-      error.message.includes("--print-url only applies to --auth-mode interactive"),
+      error.message.includes(
+        "--print-url only applies to --auth-mode interactive"
+      )
+  );
+});
+
+test("buildOAuthLoginConfig rejects print-url with headless mode", () => {
+  assert.throws(
+    () =>
+      buildOAuthLoginConfig({
+        url: "https://example.com/mcp",
+        authMode: "headless",
+        printUrl: true,
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.message.includes(
+        "--print-url only applies to --auth-mode interactive"
+      )
   );
 });
 
@@ -213,7 +244,9 @@ test("buildOAuthConformanceConfig rejects print-url with client_credentials mode
       }),
     (error) =>
       error instanceof CliError &&
-      error.message.includes("--print-url only applies to --auth-mode interactive"),
+      error.message.includes(
+        "--print-url only applies to --auth-mode interactive"
+      )
   );
 });
 
@@ -227,7 +260,7 @@ test("buildOAuthConformanceConfig rejects unsupported combinations", () => {
       }),
     (error) =>
       error instanceof CliError &&
-      error.message.includes("CIMD registration is not supported"),
+      error.message.includes("CIMD registration is not supported")
   );
 
   assert.throws(
@@ -240,9 +273,15 @@ test("buildOAuthConformanceConfig rejects unsupported combinations", () => {
       }),
     (error) =>
       error instanceof CliError &&
-      error.message.includes("--auth-mode client_credentials cannot be used with --registration cimd") &&
-      error.message.includes("only works with --auth-mode headless or --auth-mode interactive") &&
-      error.message.includes("use --registration dcr or --registration preregistered"),
+      error.message.includes(
+        "--auth-mode client_credentials cannot be used with --registration cimd"
+      ) &&
+      error.message.includes(
+        "only works with --auth-mode headless or --auth-mode interactive"
+      ) &&
+      error.message.includes(
+        "use --registration dcr or --registration preregistered"
+      )
   );
 
   assert.throws(
@@ -256,7 +295,7 @@ test("buildOAuthConformanceConfig rejects unsupported combinations", () => {
       }),
     (error) =>
       error instanceof CliError &&
-      error.message.includes("--client-secret is required"),
+      error.message.includes("--client-secret is required")
   );
 });
 
@@ -271,7 +310,7 @@ test("buildOAuthConformanceConfig rejects an invalid redirectUrl", () => {
       }),
     (error) =>
       error instanceof CliError &&
-      error.message.includes("Invalid redirect URL"),
+      error.message.includes("Invalid redirect URL")
   );
 });
 
@@ -332,7 +371,8 @@ test("buildOAuthLoginSnapshotConfig prefers access tokens over refresh tokens", 
         supportsDcr: true,
       },
       canonicalResource: "https://example.com/mcp",
-      summary: "Automatic discovery resolved to Dynamic Client Registration (DCR).",
+      summary:
+        "Automatic discovery resolved to Dynamic Client Registration (DCR).",
     },
     credentials: {
       accessToken: "access-token",

--- a/docs/cli/oauth-conformance.mdx
+++ b/docs/cli/oauth-conformance.mdx
@@ -313,7 +313,7 @@ oauth-conformance:
 | `--redirect-url <url>` | No | Auto-generated | OAuth redirect URL |
 | `--scopes <scopes>` | No | | Space-separated scope string |
 | `--header <header>` | No | | HTTP header `Key: Value` (repeatable) |
-| `--step-timeout <ms>` | No | `30000` | Per-step timeout |
+| `--step-timeout <ms>` | No | `120000` | Per-step timeout |
 | `--verify-tools` | No | | After OAuth, connect and list tools |
 | `--verify-call-tool <name>` | No | | Also call the named tool (implies `--verify-tools`) |
 | `--conformance-checks` | No | | Run additional negative OAuth checks after the main flow |
@@ -325,6 +325,12 @@ oauth-conformance:
   For interactive conformance runs, a custom `--redirect-url` must still be an
   `http://localhost` or `http://127.0.0.1` loopback URL. Custom callback paths
   are supported.
+</Note>
+
+<Note>
+  If an interactive login times out or you return to an old callback tab,
+  restart the OAuth flow. Authorization codes are single-use, and stale
+  callbacks will not complete the current run.
 </Note>
 
 ### `oauth conformance-suite`

--- a/docs/cli/oauth-login.mdx
+++ b/docs/cli/oauth-login.mdx
@@ -111,16 +111,24 @@ Same as `oauth proxy` but routes through the debug proxy path. Use when testing 
 | `--redirect-url <url>` | No | Auto-generated | OAuth redirect URL |
 | `--scopes <scopes>` | No | | Space-separated scope string |
 | `--header <header>` | No | | HTTP header `Key: Value` (repeatable) |
-| `--step-timeout <ms>` | No | `30000` | Per-step timeout |
+| `--step-timeout <ms>` | No | `120000` | Per-step timeout |
 | `--verify-tools` | No | | After login, connect and list tools |
 | `--verify-call-tool <name>` | No | | After listing, also call a named tool |
 | `--credentials-out <path>` | No | | Write OAuth credentials to file (mode 0600); stdout output has secret fields redacted |
 | `--debug-out <path>` | No | | Write debug artifact to file |
+| `--print-url` | No | | Print consent URL to stderr instead of launching a browser |
 
 <Note>
   For interactive login, a custom `--redirect-url` must still be an
   `http://localhost` or `http://127.0.0.1` loopback URL. Custom callback paths
   are supported.
+</Note>
+
+<Note>
+  In terminals or agents that cannot open a browser reliably, pass
+  `--print-url` and open the printed `OAUTH_CONSENT_URL` yourself. If an
+  interactive login times out, restart `oauth login`; authorization codes are
+  single-use.
 </Note>
 
 ## Using tokens from login

--- a/docs/cli/reference.mdx
+++ b/docs/cli/reference.mdx
@@ -179,11 +179,12 @@ Plus shared connection flags.
 | `--redirect-url <url>` | No | Auto-generated | OAuth redirect URL |
 | `--scopes <scopes>` | No | | Space-separated scope string |
 | `--header <header>` | No | | HTTP header `Key: Value` (repeatable) |
-| `--step-timeout <ms>` | No | `30000` | Per-step timeout |
+| `--step-timeout <ms>` | No | `120000` | Per-step timeout |
 | `--verify-tools` | No | | After login, list tools |
 | `--verify-call-tool <name>` | No | | Also call the named tool |
 | `--credentials-out <path>` | No | | Write OAuth credentials to file (mode 0600); stdout has secrets redacted |
 | `--debug-out <path>` | No | | Write debug artifact to file |
+| `--print-url` | No | | Print consent URL to stderr (interactive only) |
 
 ### `oauth conformance`
 
@@ -199,7 +200,7 @@ Plus shared connection flags.
 | `--redirect-url <url>` | No | Auto-generated | OAuth redirect URL |
 | `--scopes <scopes>` | No | | Space-separated scope string |
 | `--header <header>` | No | | HTTP header `Key: Value` (repeatable) |
-| `--step-timeout <ms>` | No | `30000` | Per-step timeout |
+| `--step-timeout <ms>` | No | `120000` | Per-step timeout |
 | `--verify-tools` | No | | After OAuth, list tools |
 | `--verify-call-tool <name>` | No | | Also call the named tool |
 | `--conformance-checks` | No | | Run additional negative OAuth checks, including DCR redirect URI policy and redirect-mismatch probes |

--- a/docs/sdk/reference/oauth-conformance.mdx
+++ b/docs/sdk/reference/oauth-conformance.mdx
@@ -51,7 +51,7 @@ console.log(result.steps);    // Step-by-step results with HTTP traces
 | `customHeaders` | `Record<string, string>` | No | | Extra HTTP headers |
 | `redirectUrl` | `string` | No | Auto-generated | OAuth redirect URL |
 | `fetchFn` | `typeof fetch` | No | `fetch` | Custom fetch for recording/replay |
-| `stepTimeout` | `number` | No | `30000` | Per-step timeout in ms |
+| `stepTimeout` | `number` | No | `120000` | Per-step timeout in ms |
 | `oauthConformanceChecks` | `boolean` | No | `false` | Run 6 additional negative checks post-flow |
 
 ### OAuthConformanceAuthConfig

--- a/sdk/src/oauth-conformance/auth-strategies/interactive.ts
+++ b/sdk/src/oauth-conformance/auth-strategies/interactive.ts
@@ -379,7 +379,9 @@ export async function createInteractiveAuthorizationSession(options?: {
 
     const state = requestUrl.searchParams.get("state") ?? undefined;
     if (activeExpectedState !== undefined && state !== activeExpectedState) {
-      const message = `Authorization state mismatch. Expected ${activeExpectedState}, received ${state ?? "missing"}`;
+      const message = `Authorization state mismatch. Expected ${activeExpectedState}, received ${
+        state ?? "missing"
+      }`;
       res.statusCode = 400;
       res.setHeader("Content-Type", "text/html; charset=utf-8");
       res.end(
@@ -394,6 +396,24 @@ export async function createInteractiveAuthorizationSession(options?: {
       failPending(new Error(message));
       return;
     }
+
+    if (!pendingResolve) {
+      res.statusCode = 410;
+      res.setHeader("Content-Type", "text/html; charset=utf-8");
+      res.end(
+        renderCallbackPage({
+          tone: "error",
+          title: "Authorization session expired",
+          message: "Restart the OAuth login flow from the terminal.",
+          detail:
+            "The CLI is no longer waiting for this browser callback. Authorization codes are single-use, so start a new login attempt.",
+          caption: "You can close this window.",
+        })
+      );
+      return;
+    }
+
+    const resolveAuthorization = pendingResolve;
 
     res.statusCode = 200;
     res.setHeader("Content-Type", "text/html; charset=utf-8");
@@ -411,7 +431,7 @@ export async function createInteractiveAuthorizationSession(options?: {
       timeoutHandle = undefined;
     }
 
-    pendingResolve?.({ code, state });
+    resolveAuthorization({ code, state });
     clearPending();
   });
 
@@ -484,6 +504,9 @@ export async function createInteractiveAuthorizationSession(options?: {
       }
       pendingReject?.(new Error("Interactive authorization session closed"));
       clearPending();
+      // server.close() waits for keep-alive sockets to drain. Force-close
+      // any lingering browser callback connections so the process can exit.
+      server.closeAllConnections?.();
       await closeServer(server);
     },
   };

--- a/sdk/src/oauth-conformance/validation.ts
+++ b/sdk/src/oauth-conformance/validation.ts
@@ -20,21 +20,18 @@ function deriveServerName(serverUrl: string): string {
 }
 
 function normalizeAuthConfig(
-  auth: OAuthConformanceConfig["auth"],
+  auth: OAuthConformanceConfig["auth"]
 ): OAuthConformanceAuthConfig {
   return auth ?? { mode: "interactive" };
 }
 
 function normalizeClientConfig(
   client: OAuthConformanceConfig["client"],
-  registrationStrategy: OAuthConformanceConfig["registrationStrategy"],
+  registrationStrategy: OAuthConformanceConfig["registrationStrategy"]
 ): OAuthConformanceClientConfig {
   const normalized = client ?? {};
 
-  if (
-    registrationStrategy === "cimd" &&
-    !normalized.clientIdMetadataUrl
-  ) {
+  if (registrationStrategy === "cimd" && !normalized.clientIdMetadataUrl) {
     return {
       ...normalized,
       clientIdMetadataUrl: DEFAULT_MCPJAM_CLIENT_ID_METADATA_URL,
@@ -45,7 +42,7 @@ function normalizeClientConfig(
 }
 
 export function normalizeOAuthConformanceConfig(
-  config: OAuthConformanceConfig,
+  config: OAuthConformanceConfig
 ): NormalizedOAuthConformanceConfig {
   const serverUrl = config.serverUrl.trim();
   if (!serverUrl) {
@@ -55,7 +52,7 @@ export function normalizeOAuthConformanceConfig(
   const auth = normalizeAuthConfig(config.auth);
   const client = normalizeClientConfig(
     config.client,
-    config.registrationStrategy,
+    config.registrationStrategy
   );
 
   if (
@@ -63,7 +60,7 @@ export function normalizeOAuthConformanceConfig(
     config.registrationStrategy === "cimd"
   ) {
     throw new Error(
-      `CIMD registration is not supported for protocol version ${config.protocolVersion}`,
+      `CIMD registration is not supported for protocol version ${config.protocolVersion}`
     );
   }
 
@@ -72,7 +69,7 @@ export function normalizeOAuthConformanceConfig(
     config.registrationStrategy === "cimd"
   ) {
     throw new Error(
-      "client_credentials cannot be used with the cimd registration strategy",
+      "client_credentials cannot be used with the cimd registration strategy"
     );
   }
 
@@ -81,7 +78,7 @@ export function normalizeOAuthConformanceConfig(
     !client.preregistered?.clientId
   ) {
     throw new Error(
-      "client.preregistered.clientId is required for preregistered registration",
+      "client.preregistered.clientId is required for preregistered registration"
     );
   }
 
@@ -91,16 +88,13 @@ export function normalizeOAuthConformanceConfig(
     !client.preregistered?.clientSecret
   ) {
     throw new Error(
-      "client.preregistered.clientSecret is required for preregistered client_credentials runs",
+      "client.preregistered.clientSecret is required for preregistered client_credentials runs"
     );
   }
 
-  if (
-    config.registrationStrategy === "cimd" &&
-    !client.clientIdMetadataUrl
-  ) {
+  if (config.registrationStrategy === "cimd" && !client.clientIdMetadataUrl) {
     throw new Error(
-      "client.clientIdMetadataUrl is required for CIMD registration",
+      "client.clientIdMetadataUrl is required for CIMD registration"
     );
   }
 
@@ -115,9 +109,10 @@ export function normalizeOAuthConformanceConfig(
     customHeaders: config.customHeaders,
     redirectUrl: config.redirectUrl,
     fetchFn: config.fetchFn ?? fetch,
-    stepTimeout: config.stepTimeout ?? 30_000,
+    stepTimeout: config.stepTimeout ?? 120_000,
     verification: {
-      listTools: config.verification?.listTools ?? !!config.verification?.callTool,
+      listTools:
+        config.verification?.listTools ?? !!config.verification?.callTool,
       callTool: config.verification?.callTool,
       timeout: config.verification?.timeout ?? 30_000,
     },

--- a/sdk/src/oauth-login.ts
+++ b/sdk/src/oauth-login.ts
@@ -25,9 +25,7 @@ import {
   createInteractiveAuthorizationSession,
   type InteractiveAuthorizationSession,
 } from "./oauth-conformance/auth-strategies/interactive.js";
-import {
-  normalizeOAuthConformanceConfig,
-} from "./oauth-conformance/validation.js";
+import { normalizeOAuthConformanceConfig } from "./oauth-conformance/validation.js";
 import type {
   ClientCredentialsResult,
   NormalizedOAuthConformanceConfig,
@@ -89,7 +87,7 @@ export interface OAuthLoginDependencies {
   createDefaultRedirectUrl?: () => string;
 }
 
-const DEFAULT_OAUTH_LOGIN_STEP_TIMEOUT_MS = 30_000;
+const DEFAULT_OAUTH_LOGIN_STEP_TIMEOUT_MS = 120_000;
 
 function cloneEmptyFlowState(): OAuthFlowState {
   return {
@@ -111,13 +109,90 @@ function normalizeResponseHeaders(headers: Headers): Record<string, string> {
   return normalized;
 }
 
+async function parseSseResponseBody(response: Response): Promise<unknown> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    return { transport: "sse", events: [], mcpResponse: null };
+  }
+
+  const decoder = new TextDecoder();
+  const events: Array<{ event?: string; data?: unknown; id?: string }> = [];
+  let currentEvent: Record<string, unknown> = {};
+  let buffer = "";
+  const maxReadTime = 5000;
+  const startTime = Date.now();
+
+  try {
+    while (Date.now() - startTime < maxReadTime) {
+      const { done, value } = await Promise.race([
+        reader.read(),
+        new Promise<{ done: boolean; value: undefined }>((_, reject) =>
+          setTimeout(() => reject(new Error("Read timeout")), 1000)
+        ),
+      ]);
+
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split(/\r?\n/);
+      buffer = lines.pop() || "";
+
+      for (const line of lines) {
+        if (line.startsWith("event:")) {
+          currentEvent.event = line.substring(6).trim();
+        } else if (line.startsWith("data:")) {
+          const data = line.substring(5).trim();
+          try {
+            currentEvent.data = JSON.parse(data);
+          } catch {
+            currentEvent.data = data;
+          }
+        } else if (line.startsWith("id:")) {
+          currentEvent.id = line.substring(3).trim();
+        } else if (line === "") {
+          if (Object.keys(currentEvent).length > 0) {
+            events.push({ ...currentEvent });
+            currentEvent = {};
+          }
+        }
+      }
+
+      if (events.length >= 1) break;
+    }
+  } catch {
+    // Read timeout or stream error — return whatever we collected
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // ignore cancel errors
+    }
+  }
+
+  return {
+    transport: "sse",
+    events,
+    isOldTransport: events[0]?.event === "endpoint",
+    endpoint: events[0]?.event === "endpoint" ? events[0].data : null,
+    mcpResponse:
+      events.find((event) => event.event === "message" || !event.event)
+        ?.data ?? null,
+    rawBuffer: buffer,
+  };
+}
+
 async function parseResponseBody(response: Response): Promise<unknown> {
+  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
+
+  if (contentType.includes("text/event-stream")) {
+    return parseSseResponseBody(response);
+  }
+
   const text = await response.text();
   if (!text) {
     return undefined;
   }
 
-  const contentType = response.headers.get("content-type")?.toLowerCase() ?? "";
   if (
     contentType.includes("application/json") ||
     contentType.includes("+json")
@@ -142,7 +217,7 @@ async function parseResponseBody(response: Response): Promise<unknown> {
 
 function serializeRequestBody(
   body: OAuthHttpRequest["body"],
-  headers: Record<string, string>,
+  headers: Record<string, string>
 ): BodyInit | undefined {
   if (body === undefined || body === null) {
     return undefined;
@@ -154,7 +229,7 @@ function serializeRequestBody(
 
   const contentType =
     Object.entries(headers).find(
-      ([key]) => key.toLowerCase() === "content-type",
+      ([key]) => key.toLowerCase() === "content-type"
     )?.[1] ?? "";
 
   if (contentType.includes("application/x-www-form-urlencoded")) {
@@ -162,7 +237,7 @@ function serializeRequestBody(
       Object.entries(body as Record<string, string>).map(([key, value]) => [
         key,
         String(value),
-      ]),
+      ])
     ).toString();
   }
 
@@ -170,19 +245,19 @@ function serializeRequestBody(
 }
 
 function normalizeLoginAuthConfig(
-  auth: OAuthLoginConfig["auth"],
-) : NonNullable<OAuthConformanceConfig["auth"]> {
+  auth: OAuthLoginConfig["auth"]
+): NonNullable<OAuthConformanceConfig["auth"]> {
   return auth ?? { mode: "interactive" };
 }
 
 function normalizeLoginClientConfig(
-  client: OAuthLoginConfig["client"],
+  client: OAuthLoginConfig["client"]
 ): NonNullable<OAuthConformanceConfig["client"]> {
   return client ?? {};
 }
 
 function resolveRequestedProtocolMode(
-  input: Pick<OAuthLoginConfig, "protocolMode" | "protocolVersion">,
+  input: Pick<OAuthLoginConfig, "protocolMode" | "protocolVersion">
 ): OAuthProtocolMode {
   if (input.protocolMode) {
     return input.protocolMode;
@@ -192,7 +267,7 @@ function resolveRequestedProtocolMode(
 }
 
 function resolveRequestedRegistrationMode(
-  input: Pick<OAuthLoginConfig, "registrationMode" | "registrationStrategy">,
+  input: Pick<OAuthLoginConfig, "registrationMode" | "registrationStrategy">
 ): OAuthRegistrationMode {
   if (input.registrationMode) {
     return input.registrationMode;
@@ -202,7 +277,7 @@ function resolveRequestedRegistrationMode(
 }
 
 function toAuthorizationPlanInput(
-  input: OAuthLoginConfig,
+  input: OAuthLoginConfig
 ): Parameters<typeof resolveAuthorizationPlan>[0] {
   const auth = normalizeLoginAuthConfig(input.auth);
   const client = normalizeLoginClientConfig(input.client);
@@ -221,7 +296,7 @@ function toAuthorizationPlanInput(
 }
 
 async function resolveOAuthLoginAuthorizationPlan(
-  input: OAuthLoginConfig,
+  input: OAuthLoginConfig
 ): Promise<ResolvedAuthorizationPlan> {
   const basePlan = resolveAuthorizationPlan(toAuthorizationPlanInput(input));
 
@@ -245,7 +320,7 @@ async function resolveOAuthLoginAuthorizationPlan(
 
 function mergeDynamicRegistration(
   config: NormalizedOAuthConformanceConfig,
-  redirectUrl: string,
+  redirectUrl: string
 ): NormalizedOAuthConformanceConfig["client"]["dynamicRegistration"] {
   const defaults =
     config.auth.mode === "client_credentials"
@@ -264,9 +339,8 @@ function mergeDynamicRegistration(
     merged.redirect_uris = config.client.dynamicRegistration?.redirect_uris ?? [
       redirectUrl,
     ];
-    merged.response_types = config.client.dynamicRegistration?.response_types ?? [
-      "code",
-    ];
+    merged.response_types = config.client.dynamicRegistration
+      ?.response_types ?? ["code"];
   }
 
   return merged;
@@ -275,7 +349,7 @@ function mergeDynamicRegistration(
 async function runVerification(
   config: NormalizedOAuthConformanceConfig,
   state: OAuthFlowState,
-  verificationConfig: OAuthVerificationConfig,
+  verificationConfig: OAuthVerificationConfig
 ): Promise<VerificationResult | undefined> {
   if (!verificationConfig.listTools || !state.accessToken) {
     return undefined;
@@ -321,7 +395,7 @@ async function runVerification(
           await manager.executeTool(
             serverId,
             verificationConfig.callTool.name,
-            verificationConfig.callTool.params ?? {},
+            verificationConfig.callTool.params ?? {}
           );
           result.callTool = {
             passed: true,
@@ -339,7 +413,7 @@ async function runVerification(
       },
       {
         timeout: verificationConfig.timeout ?? 30_000,
-      },
+      }
     );
   } catch (error) {
     if (!result.listTools) {
@@ -360,7 +434,7 @@ function buildResult(
   redirectUrl: string,
   state: OAuthFlowState,
   verification?: VerificationResult,
-  error?: string,
+  error?: string
 ): OAuthLoginResult {
   return {
     completed: state.currentStep === "complete" && !error,
@@ -391,7 +465,7 @@ function buildResult(
 function buildBlockedPlanResult(
   input: OAuthLoginConfig,
   authorizationPlan: ResolvedAuthorizationPlan,
-  state: OAuthFlowState,
+  state: OAuthFlowState
 ): OAuthLoginResult {
   const auth = normalizeLoginAuthConfig(input.auth);
 
@@ -408,8 +482,7 @@ function buildBlockedPlanResult(
     authorizationPlan,
     credentials: {},
     error: {
-      message:
-        authorizationPlan.blockers[0] ?? authorizationPlan.summary,
+      message: authorizationPlan.blockers[0] ?? authorizationPlan.summary,
     },
     state,
   };
@@ -417,7 +490,7 @@ function buildBlockedPlanResult(
 
 export async function runOAuthLogin(
   input: OAuthLoginConfig,
-  deps: OAuthLoginDependencies = {},
+  deps: OAuthLoginDependencies = {}
 ): Promise<OAuthLoginResult> {
   let state = cloneEmptyFlowState();
   let redirectUrl =
@@ -461,15 +534,16 @@ export async function runOAuthLogin(
       });
     }
 
-    redirectUrl =
-      interactiveSession?.redirectUrl ??
-      redirectUrl;
+    redirectUrl = interactiveSession?.redirectUrl ?? redirectUrl;
+    if (config.auth.mode === "interactive" && interactiveSession) {
+      config.onProgress(`Listening for OAuth callback at ${redirectUrl}...`);
+    }
 
     const trackedRequest: TrackedRequestFn = async (request, options = {}) => {
       const controller = new AbortController();
       const timeoutHandle = setTimeout(
         () => controller.abort(),
-        config.stepTimeout,
+        config.stepTimeout
       );
 
       try {
@@ -525,9 +599,12 @@ export async function runOAuthLogin(
       const flowResult = await runOAuthStateMachine({
         ...machineConfig,
         maxSteps: 40,
-        onAuthorizationRequest: async ({ authorizationUrl, state: flowState }) => {
+        onAuthorizationRequest: async ({
+          authorizationUrl,
+          state: flowState,
+        }) => {
           try {
-            config.onProgress("Opening browser for authorization...");
+            config.onProgress("Opening authorization URL...");
             const authorizationResult =
               config.auth.mode === "interactive"
                 ? await interactiveSession!.authorize({
@@ -578,21 +655,21 @@ export async function runOAuthLogin(
           redirectUrl,
           resultState,
           undefined,
-          flowResult.error.message,
+          flowResult.error.message
         );
       }
 
       const verification = await runVerification(
         config,
         flowResult.state,
-        config.verification,
+        config.verification
       );
       return buildResult(
         config,
         authorizationPlan,
         redirectUrl,
         flowResult.state,
-        verification,
+        verification
       );
     }
 
@@ -613,7 +690,7 @@ export async function runOAuthLogin(
             redirectUrl,
             state,
             undefined,
-            "Missing token endpoint for client_credentials flow.",
+            "Missing token endpoint for client_credentials flow."
           );
         }
 
@@ -627,14 +704,13 @@ export async function runOAuthLogin(
             redirectUrl,
             state,
             undefined,
-            "Dynamic registration produced a public client and cannot be used for client_credentials.",
+            "Dynamic registration produced a public client and cannot be used for client_credentials."
           );
         }
 
         try {
           const tokenResult: ClientCredentialsResult = await (
-            deps.performClientCredentialsGrant ??
-            performClientCredentialsGrant
+            deps.performClientCredentialsGrant ?? performClientCredentialsGrant
           )({
             tokenEndpoint: state.authorizationServerMetadata.token_endpoint,
             clientId: state.clientId || config.auth.clientId,
@@ -667,7 +743,7 @@ export async function runOAuthLogin(
             redirectUrl,
             state,
             undefined,
-            error instanceof Error ? error.message : String(error),
+            error instanceof Error ? error.message : String(error)
           );
         }
       }
@@ -682,7 +758,7 @@ export async function runOAuthLogin(
           redirectUrl,
           state,
           undefined,
-          error instanceof Error ? error.message : String(error),
+          error instanceof Error ? error.message : String(error)
         );
       }
 
@@ -693,7 +769,7 @@ export async function runOAuthLogin(
           redirectUrl,
           state,
           undefined,
-          state.error || `Step ${startStep} did not advance.`,
+          state.error || `Step ${startStep} did not advance.`
         );
       }
     }
@@ -705,7 +781,7 @@ export async function runOAuthLogin(
         redirectUrl,
         state,
         undefined,
-        "OAuth login exceeded its step guard.",
+        "OAuth login exceeded its step guard."
       );
     }
 
@@ -715,14 +791,14 @@ export async function runOAuthLogin(
     const verification = await runVerification(
       config,
       state,
-      config.verification,
+      config.verification
     );
     return buildResult(
       config,
       authorizationPlan,
       redirectUrl,
       state,
-      verification,
+      verification
     );
   } finally {
     await interactiveSession?.stop().catch(() => undefined);

--- a/sdk/tests/oauth-conformance/interactive.test.ts
+++ b/sdk/tests/oauth-conformance/interactive.test.ts
@@ -44,6 +44,36 @@ describe("interactive authorization session", () => {
     }
   });
 
+  it("does not show success when the callback arrives after timeout", async () => {
+    const session = await createInteractiveAuthorizationSession();
+
+    try {
+      const resultPromise = session.authorize({
+        authorizationUrl: "https://auth.example.com/authorize",
+        expectedState: "expected-state",
+        timeoutMs: 10,
+        openUrl: async () => undefined,
+      });
+
+      await expect(resultPromise).rejects.toThrow(
+        /Interactive authorization timed out/
+      );
+
+      const response = await fetch(
+        `${session.redirectUrl}?code=late-code&state=expected-state`
+      );
+      expect(response.status).toBe(410);
+      expect(response.headers.get("content-type")).toContain("text/html");
+
+      const html = await response.text();
+      expect(html).toContain("Authorization session expired");
+      expect(html).toContain("Authorization codes are single-use");
+      expect(html).not.toContain("Authorization complete");
+    } finally {
+      await session.stop().catch(() => undefined);
+    }
+  });
+
   it("accepts custom loopback callback paths", async () => {
     const session = await createInteractiveAuthorizationSession({
       redirectUrl: "http://127.0.0.1:0/oauth/custom-callback",
@@ -58,7 +88,7 @@ describe("interactive authorization session", () => {
         timeoutMs: 2_000,
         openUrl: async () => {
           await fetch(
-            `${session.redirectUrl}?code=test-code&state=expected-state`,
+            `${session.redirectUrl}?code=test-code&state=expected-state`
           );
         },
       });

--- a/sdk/tests/oauth-login.probe-timeout.test.ts
+++ b/sdk/tests/oauth-login.probe-timeout.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 function jsonResponse(
   body: unknown,
   status = 200,
-  headers: Record<string, string> = {},
+  headers: Record<string, string> = {}
 ): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -46,8 +46,7 @@ describe("runOAuthLogin automatic probe timeout", () => {
           authorization_servers: [authServerUrl],
           scopes_supported: ["openid", "profile", "mcp"],
         },
-        authorizationServerMetadataUrl:
-          `${authServerUrl}/.well-known/oauth-authorization-server`,
+        authorizationServerMetadataUrl: `${authServerUrl}/.well-known/oauth-authorization-server`,
         authorizationServerMetadata: {
           issuer: authServerUrl,
           authorization_endpoint: `${authServerUrl}/authorize`,
@@ -64,9 +63,9 @@ describe("runOAuthLogin automatic probe timeout", () => {
     });
 
     vi.doMock("../src/server-probe.js", async () => {
-      const actual = await vi.importActual<typeof import("../src/server-probe.js")>(
-        "../src/server-probe.js",
-      );
+      const actual = await vi.importActual<
+        typeof import("../src/server-probe.js")
+      >("../src/server-probe.js");
 
       return {
         ...actual,
@@ -133,14 +132,14 @@ describe("runOAuthLogin automatic probe timeout", () => {
         completeHeadlessAuthorization: vi.fn(async () => ({
           code: "auth-code",
         })),
-      },
+      }
     );
 
     expect(mockProbeMcpServer).toHaveBeenCalledWith(
       expect.objectContaining({
         url: serverUrl,
-        timeoutMs: 30_000,
-      }),
+        timeoutMs: 120_000,
+      })
     );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches OAuth login/conformance flow control and HTTP response parsing (including interactive callback handling), which can affect authentication reliability and timeouts. Changes are well-scoped with added tests/docs but impact a critical path (auth/login).
> 
> **Overview**
> **OAuth CLI login/conformance usability improvements.** Increases the default per-step OAuth timeout from `30_000` to `120_000`, adds `--print-url` to `oauth login` (prints `OAUTH_CONSENT_URL` instead of opening a browser), and refactors progress reporting to work cleanly on both TTY and non-TTY stderr while emitting status during credential file saves.
> 
> **Fixes for hanging/expired interactive callbacks in the SDK.** The interactive callback server now returns a clear `410` "session expired" page if the browser redirect arrives after the CLI has timed out, and `stop()` force-closes lingering keep-alive connections to avoid the process hanging on shutdown.
> 
> **Better diagnostics and security hardening.** `runOAuthLogin` now parses `text/event-stream` (SSE) response bodies for debug visibility, and debug artifact files are written with `0600` permissions (with tests updated to assert mode) alongside updated docs reflecting the new timeout default and guidance for stale callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df98a027bef6182fa3da5f1fbc722702681034df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->