### PR TITLE
Close connections

### DIFF
--- a/sdk/src/oauth-conformance/auth-strategies/interactive.ts
+++ b/sdk/src/oauth-conformance/auth-strategies/interactive.ts
@@ -484,10 +484,13 @@ export async function createInteractiveAuthorizationSession(options?: {
       }
       pendingReject?.(new Error("Interactive authorization session closed"));
       clearPending();
-      // server.close() waits for keep-alive sockets to drain. Force-close
-      // any lingering browser callback connections so the process can exit.
-      server.closeAllConnections?.();
-      await closeServer(server);
+      // Stop accepting new connections, then drain idle keep-alive sockets
+      // so server.close() can resolve promptly. closeIdleConnections() is
+      // preferred over closeAllConnections() to avoid terminating any
+      // in-flight callback request mid-response.
+      const closed = closeServer(server);
+      server.closeIdleConnections?.();
+      await closed;
     },
   };
 }

--- a/sdk/src/oauth-conformance/auth-strategies/interactive.ts
+++ b/sdk/src/oauth-conformance/auth-strategies/interactive.ts
@@ -484,6 +484,9 @@ export async function createInteractiveAuthorizationSession(options?: {
       }
       pendingReject?.(new Error("Interactive authorization session closed"));
       clearPending();
+      // server.close() waits for keep-alive sockets to drain. Force-close
+      // any lingering browser callback connections so the process can exit.
+      server.closeAllConnections?.();
       await closeServer(server);
     },
   };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized change to server shutdown sequencing; main risk is altered connection teardown behavior on older Node versions or unusual keep-alive usage.
> 
> **Overview**
> Improves shutdown behavior for the interactive OAuth conformance callback server by draining idle keep-alive sockets when `stop()` is called.
> 
> `stop()` now initiates `server.close()` via `closeServer(server)`, calls `server.closeIdleConnections?.()` to allow the close to resolve promptly without killing in-flight requests, then awaits the close completion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5eb65b31357ceff8016069a3a93aa5e3bccf41a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->