### PR TITLE
Redact values

### DIFF
--- a/cli/src/commands/server.ts
+++ b/cli/src/commands/server.ts
@@ -38,6 +38,7 @@ import {
   assertNoCredentialsFileAuthConflicts,
   resolveCredentialsFileAccessToken,
 } from "../lib/credentials-file.js";
+import { redactSensitiveValue } from "../lib/redaction.js";
 import {
   parseReporterFormat,
   writeJsonArtifact,
@@ -201,7 +202,10 @@ export function registerServerCommands(program: Command): void {
         throw operationalError("Probe did not return a result.");
       }
 
-      writeResult(result, globalOptions.format);
+      writeResult(
+        redactSensitiveValue(result) as typeof result,
+        globalOptions.format,
+      );
       if (result.status === "error") {
         setProcessExitCode(1);
       }
@@ -235,9 +239,10 @@ export function registerServerCommands(program: Command): void {
       retryPolicy,
     });
 
-    const jsonPayload = globalOptions.rpc
+    const rawPayload = globalOptions.rpc
       ? attachCliRpcLogs(result, collector)
       : result;
+    const jsonPayload = redactSensitiveValue(rawPayload) as typeof rawPayload;
     const artifactPath = options.out
       ? await writeDebugArtifact(options.out as string, jsonPayload)
       : undefined;

--- a/cli/src/commands/server.ts
+++ b/cli/src/commands/server.ts
@@ -249,7 +249,7 @@ export function registerServerCommands(program: Command): void {
 
     if (globalOptions.format === "human") {
       process.stdout.write(
-        `${formatServerDoctorHuman(result, { artifactPath })}\n`,
+        `${formatServerDoctorHuman(jsonPayload, { artifactPath })}\n`,
       );
     } else {
       writeResult(jsonPayload, globalOptions.format);

--- a/cli/tests/server-doctor.test.ts
+++ b/cli/tests/server-doctor.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import type { ProbeMcpServerResult, ServerDoctorResult } from "@mcpjam/sdk";
 import { writeDebugArtifact } from "../src/lib/debug-artifact.js";
+import { redactSensitiveValue } from "../src/lib/redaction.js";
 import {
   formatServerDoctorHuman,
   summarizeServerDoctorTarget,
@@ -235,4 +236,36 @@ test("formatServerDoctorHuman renders a concise summary and artifact path", () =
   assert.match(rendered, /^Status: oauth_required/m);
   assert.match(rendered, /^OAuth: required \(dcr, cimd\)$/m);
   assert.match(rendered, /^Artifact: \/tmp\/doctor\.json$/m);
+});
+
+test("server doctor JSON payload redacts probe Authorization headers", () => {
+  const probe = createProbeResult({
+    transport: {
+      selected: "streamable-http",
+      attempts: [
+        {
+          name: "streamable_initialize",
+          request: {
+            method: "POST",
+            url: "https://example.com/mcp",
+            headers: {
+              Authorization: "Bearer super-secret-token",
+              Accept: "application/json",
+            },
+          },
+          response: {
+            status: 200,
+            statusText: "OK",
+            headers: { "content-type": "application/json" },
+          },
+          durationMs: 12,
+        },
+      ],
+    },
+  });
+
+  const redacted = redactSensitiveValue({ probe }) as { probe: typeof probe };
+  const attempt = redacted.probe.transport.attempts[0]!;
+  assert.equal(attempt.request.headers.Authorization, "[REDACTED]");
+  assert.equal(attempt.request.headers.Accept, "application/json");
 });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: output formatting now runs through a redaction pass to avoid leaking tokens; changes are confined to CLI serialization paths and add a targeted test for Authorization header masking.
> 
> **Overview**
> CLI `server probe` and `server doctor` now redact sensitive fields (e.g., auth headers/tokens) before printing results or writing JSON artifacts, including when RPC logs are attached.
> 
> Adds a regression test ensuring `server doctor` JSON payloads mask probe `Authorization` headers while preserving non-sensitive headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79a93f40273ce68560df8704b89eeb3e46e382d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->