### PR TITLE
fix(inspector): run bundle:sandbox-proxies in predev

### DIFF
--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -44,7 +44,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "predev": "npm run sdk:build",
+    "predev": "npm run sdk:build && npm run bundle:sandbox-proxies",
     "dev": "run-script-os",
     "dev:default": "concurrently \"npm run dev:server\" \"npm run dev:client\"",
     "dev:win32": "concurrently --raw \"npm run dev:server\" \"npm run dev:client\"",


### PR DESCRIPTION
## Problem

`npm run dev` loads server routes that import `SandboxProxyHtml.bundled.ts`. That file is **generated** by `scripts/bundle-sandbox-proxy-html.js` (`npm run bundle:sandbox-proxies`) and is **gitignored**, so it is missing after a fresh clone.

`predev` previously only ran `sdk:build`, so dev could fail immediately with `ERR_MODULE_NOT_FOUND` for that import.

## Change

Run `npm run bundle:sandbox-proxies` in `predev` after `sdk:build`, consistent with `pretest` and the full `build` pipeline, which already ensure this artifact exists.

## Result

`npm run dev -w @mcpjam/inspector` works on a clean tree without a separate manual bundling step. Each dev start runs one short HTML-bundling step after the SDK build.