### PR TITLE
Remove Playground beta badge from sidebar

### DIFF
--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -364,7 +364,6 @@ type EvalsSubnavItem = {
   icon: typeof Puzzle | typeof GitBranch;
   isActive: (activeTab?: string) => boolean;
   onClick: () => void;
-  beta?: boolean;
 };
 
 export function getEvalsSubnavItems(options: {
@@ -377,7 +376,6 @@ export function getEvalsSubnavItems(options: {
       icon: Puzzle,
       isActive: (activeTab) => activeTab === "evals",
       onClick: navigateToEvalsExploreList,
-      beta: true,
     },
   ];
 
@@ -401,7 +399,6 @@ export function SidebarEvalsNavGroup({
   disabledTooltip,
   activeTab,
   showRuns = true,
-  showPlaygroundBeta = false,
   playgroundEnabled = false,
 }: {
   title: string;
@@ -410,7 +407,6 @@ export function SidebarEvalsNavGroup({
   disabledTooltip?: string;
   activeTab?: string;
   showRuns?: boolean;
-  showPlaygroundBeta?: boolean;
   playgroundEnabled?: boolean;
 }) {
   const isEvalsFamily = activeTab === "evals" || activeTab === "ci-evals";
@@ -469,7 +465,8 @@ export function SidebarEvalsNavGroup({
             <SidebarMenuSub>
               {subnavItems.map((item) => {
                 const ItemIcon = item.icon;
-                const isItemPlaygroundLocked = item.beta && isPlaygroundLocked;
+                const isItemPlaygroundLocked =
+                  item.title === "Playground" && isPlaygroundLocked;
                 const isItemDisabled = disabled || isItemPlaygroundLocked;
 
                 const subnavButton = (
@@ -492,29 +489,6 @@ export function SidebarEvalsNavGroup({
                   >
                     <ItemIcon className="h-4 w-4" />
                     <span className="min-w-0 truncate">{item.title}</span>
-                    {item.beta && showPlaygroundBeta ? (
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Badge
-                            className="ml-auto rounded-full px-1.5 py-0 text-[10px] font-semibold leading-tight uppercase tracking-wider"
-                            onClick={(e) => {
-                              e.preventDefault();
-                              e.stopPropagation();
-                            }}
-                          >
-                            Beta
-                          </Badge>
-                        </TooltipTrigger>
-                        <TooltipContent
-                          side="right"
-                          sideOffset={6}
-                          className="max-w-[200px]"
-                        >
-                          This tab is a work in progress, data may not be
-                          persisted.
-                        </TooltipContent>
-                      </Tooltip>
-                    ) : null}
                   </SidebarMenuSubButton>
                 );
 
@@ -751,7 +725,6 @@ export function MCPSidebar({
                     disabledTooltip={evalsEntry.disabledTooltip}
                     activeTab={activeTab}
                     showRuns={evaluateRunsEnabled === true}
-                    showPlaygroundBeta={playgroundEnabled === true}
                     playgroundEnabled={playgroundEnabled === true}
                   />
                 ) : null}

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
@@ -265,7 +265,7 @@ describe("sidebar invite CTA", () => {
     expect(window.location.hash).toBe("#servers");
   });
 
-  it("enables Playground and shows the beta badge when the flag is on", () => {
+  it("enables Playground without a beta badge when the flag is on", () => {
     mockFeatureFlags["playground-enabled"] = true;
 
     renderSidebar();
@@ -275,12 +275,7 @@ describe("sidebar invite CTA", () => {
       .closest("button") as HTMLButtonElement;
     expect(playground).toBeInTheDocument();
     expect(playground).not.toHaveAttribute("aria-disabled");
-    expect(screen.getByText("Beta")).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "This tab is a work in progress, data may not be persisted.",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.queryByText("Beta")).not.toBeInTheDocument();
     expect(
       screen.queryByText("Coming soon. Playground is in beta."),
     ).not.toBeInTheDocument();


### PR DESCRIPTION
### Motivation
- Prevent the Playground sidebar label from being truncated in production by removing the extra `Beta` badge and related tooltip.
- Keep existing lock behaviour intact when the `playground-enabled` feature flag is off while decoupling the UI badge from that logic.

### Description
- Removed the `beta` field from `EvalsSubnavItem` and stopped setting it for the Playground subnav item in `client/src/components/mcp-sidebar.tsx`.
- Changed the Playground lock check to explicitly target the `"Playground"` subnav entry (`item.title === "Playground"`) instead of relying on `item.beta`.
- Removed the rendering of the `Beta` `Badge` and its tooltip from the sidebar sub-navigation UI in `client/src/components/mcp-sidebar.tsx` and removed the `showPlaygroundBeta` prop wiring.
- Updated the sidebar tests in `client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx` to assert that the Playground item is enabled without any `Beta` badge when `playground-enabled` is true, while preserving locked/tooltip assertions when the flag is off.

### Testing
- Ran the sidebar unit tests with `npm run test -- client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx` and all tests passed.
- The single test file executed: 6 tests, all succeeded (`Tests 6 passed (6)`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f19b38c868832b95e9cfb6ae562365)