### PR TITLE
Ensure Sign In button respects sidebar collapse

### DIFF
--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
@@ -45,6 +45,9 @@ describe("SidebarUser", () => {
   it("renders sign-in button when unauthenticated in hosted mode", () => {
     render(<SidebarUser />);
     expect(screen.getByText("Sign in")).toBeDefined();
+    expect(screen.getByRole("button", { name: "Sign in" }).className).toContain(
+      "data-[state=open]:bg-sidebar-accent",
+    );
   });
 
   it("calls signIn when button is clicked", () => {

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
@@ -45,7 +45,9 @@ describe("SidebarUser", () => {
   it("renders sign-in button when unauthenticated in hosted mode", () => {
     render(<SidebarUser />);
     expect(screen.getByText("Sign in")).toBeDefined();
-    expect(screen.getByRole("button", { name: "Sign in" }).className).toContain(
+    const signInButton = screen.getByRole("button", { name: "Sign in" });
+    expect(signInButton).toHaveAttribute("aria-label", "Sign in");
+    expect(signInButton.className).toContain(
       "data-[state=open]:bg-sidebar-accent",
     );
   });

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/sidebar";
 import { getInitials } from "@/lib/utils";
 import {
+  LogIn,
   Building2,
   ChevronsUpDown,
   CircleUser,
@@ -31,7 +32,6 @@ import { useProfilePicture } from "@/hooks/useProfilePicture";
 import { useOrganizationQueries } from "@/hooks/useOrganizations";
 import { CreateOrganizationDialog } from "@/components/organization/CreateOrganizationDialog";
 import { HOSTED_MODE } from "@/lib/config";
-import { Button } from "@mcpjam/design-system/button";
 import type { OrganizationRouteSection } from "@/lib/hosted-navigation";
 
 export function SidebarUser({
@@ -99,9 +99,16 @@ export function SidebarUser({
       return (
         <SidebarMenu>
           <SidebarMenuItem>
-            <Button variant="outline" size="sm" onClick={() => signIn()}>
-              Sign in
-            </Button>
+            <SidebarMenuButton
+              size="lg"
+              onClick={() => signIn()}
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            >
+              <LogIn className="size-4" />
+              <span className="truncate group-data-[collapsible=icon]:hidden">
+                Sign in
+              </span>
+            </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>
       );

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
@@ -102,6 +102,7 @@ export function SidebarUser({
             <SidebarMenuButton
               size="lg"
               onClick={() => signIn()}
+              aria-label="Sign in"
               className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
             >
               <LogIn className="size-4" />


### PR DESCRIPTION
### Motivation

- The Sign In control in the hosted sidebar floated out of the sidebar layout when the sidebar was collapsed, breaking the intended collapsed/expanded UI behavior.

### Description

- Replaced the hosted unauthenticated `Sign in` `Button` with the sidebar-aware `SidebarMenuButton` so the control participates in sidebar expand/collapse behavior in `client/src/components/sidebar/sidebar-user.tsx`.
- Added the `LogIn` icon and wrapped the label in a `group-data-[collapsible=icon]:hidden` span and kept the `data-[state=open]:*` styling so the label hides in collapsed mode and matches other sidebar rows.
- Removed the unused `Button` import and updated the component markup accordingly.
- Updated the test in `client/src/components/sidebar/__tests__/sidebar-user.test.tsx` to assert the Sign In button renders with the sidebar state styling and still calls `signIn` on click.

### Testing

- Ran `npm run test -- client/src/components/sidebar/__tests__/sidebar-user.test.tsx` and the test file completed successfully with 2 passed tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f19f98bfac832b9efc967d310df16c)