### PR TITLE
Forward camera/mic permissions through every MCP app iframe layer

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/mcp-ui-resource-part.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/mcp-ui-resource-part.tsx
@@ -1,3 +1,4 @@
+import type { IframeHTMLAttributes } from "react";
 import {
   UIActionResult,
   UIResourceRenderer,
@@ -65,10 +66,16 @@ export function MCPUIResourcePart({
             borderRadius: "4px",
             minHeight: "400px",
           },
+          // permissions-policy must be delegated from the top frame down through every
+          // iframe; we forward camera/mic so embedded apps (e.g. video chat) work.
+          // `allow` is a valid iframe attribute but @mcp-ui/client types it via
+          // HTMLAttributes (which omits iframe-specific props), so we cast.
           iframeProps: {
             title: "Custom MCP Resource",
             className: "mcp-resource-frame",
-          },
+            allow:
+              "camera *; microphone *; fullscreen *; display-capture *; autoplay *; clipboard-write *",
+          } as IframeHTMLAttributes<HTMLIFrameElement>,
         }}
         remoteDomProps={{
           library: basicComponentLibrary,

--- a/mcpjam-inspector/client/src/components/ui/chatgpt-sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/chatgpt-sandboxed-iframe.tsx
@@ -216,11 +216,13 @@ export const ChatGPTSandboxedIframe = forwardRef<
   </style>
 </head>
 <body>
+  <!-- permissions-policy must be delegated from the top frame down through every
+       iframe; we forward camera/mic so embedded apps (e.g. video chat) work. -->
   <iframe
     id="middle"
     src="${sandboxProxyUrl}"
     sandbox="allow-scripts allow-same-origin allow-forms"
-    allow="local-network-access *; microphone *; midi *"
+    allow="local-network-access *; microphone *; midi *; camera *; fullscreen *; display-capture *; autoplay *; clipboard-write *"
   ></iframe>
   <iframe
     id="measurement"
@@ -294,12 +296,13 @@ export const ChatGPTSandboxedIframe = forwardRef<
   }, [url]);
 
   return (
+    // permissions-policy must be delegated from the top frame down through every
+    // iframe; we forward camera/mic so embedded apps (e.g. video chat) work.
     <iframe
       ref={outerIframeRef}
       src="about:blank"
       sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-forms"
-      // Permissions Policy matching ChatGPT's actual implementation
-      allow="local-network-access *; microphone *; midi *"
+      allow="local-network-access *; microphone *; midi *; camera *; fullscreen *; display-capture *; autoplay *; clipboard-write *"
       title={title}
       className={className}
       style={style}

--- a/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
@@ -179,13 +179,21 @@ export const SandboxedIframe = forwardRef<
     return () => window.removeEventListener("message", handleMessage);
   }, [handleMessage]);
 
-  // Build allow attribute for outer iframe based on requested permissions
+  // Build allow attribute for outer iframe based on requested permissions.
+  // permissions-policy must be delegated from the top frame down through every
+  // iframe; we forward camera/mic so embedded apps (e.g. video chat) work.
   const outerAllowAttribute = useMemo(() => {
-    const allowList = ["local-network-access *", "midi *"];
-    if (permissions?.camera) allowList.push("camera *");
-    if (permissions?.microphone) allowList.push("microphone *");
+    const allowList = [
+      "local-network-access *",
+      "midi *",
+      "camera *",
+      "microphone *",
+      "fullscreen *",
+      "display-capture *",
+      "autoplay *",
+      "clipboard-write *",
+    ];
     if (permissions?.geolocation) allowList.push("geolocation *");
-    if (permissions?.clipboardWrite) allowList.push("clipboard-write *");
     return allowList.join("; ");
   }, [permissions]);
 

--- a/mcpjam-inspector/server/routes/apps/chatgpt-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/chatgpt-apps/sandbox-proxy.html
@@ -62,10 +62,11 @@
       const inner = document.createElement("iframe");
       inner.style.cssText = "width:100%; height:100%; border:none;";
       inner.setAttribute("sandbox", DEFAULT_SANDBOX);
-      // Permissions Policy matching ChatGPT's actual implementation
+      // permissions-policy must be delegated from the top frame down through every
+      // iframe; we forward camera/mic so embedded apps (e.g. video chat) work.
       inner.setAttribute(
         "allow",
-        "local-network-access *; microphone *; midi *",
+        "local-network-access *; microphone *; midi *; camera *; fullscreen *; display-capture *; autoplay *; clipboard-write *",
       );
       document.body.appendChild(inner);
 

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -73,15 +73,21 @@
        *
        * Note: For srcdoc iframes, we use '*' allowlist since they don't have a defined origin.
        * This allows the sandboxed content to request these permissions.
+       *
+       * permissions-policy must be delegated from the top frame down through every
+       * iframe; we forward camera/mic so embedded apps (e.g. video chat) work.
        */
       function buildAllowAttribute(permissions) {
-        if (!permissions) return "";
-
-        const allowList = [];
-        if (permissions.camera) allowList.push("camera *");
-        if (permissions.microphone) allowList.push("microphone *");
-        if (permissions.geolocation) allowList.push("geolocation *");
-        if (permissions.clipboardWrite) allowList.push("clipboard-write *");
+        const allowList = [
+          "camera *",
+          "microphone *",
+          "fullscreen *",
+          "display-capture *",
+          "autoplay *",
+          "clipboard-write *",
+        ];
+        if (permissions && permissions.geolocation)
+          allowList.push("geolocation *");
 
         return allowList.join("; ");
       }
@@ -249,6 +255,9 @@ document.addEventListener('securitypolicyviolation', function(e) {
         "sandbox",
         "allow-scripts allow-same-origin allow-forms",
       );
+      // permissions-policy must be delegated from the top frame down through every
+      // iframe; we forward camera/mic so embedded apps (e.g. video chat) work.
+      inner.setAttribute("allow", buildAllowAttribute());
       document.body.appendChild(inner);
 
       // Handle messages from parent (host) and inner (guest UI)


### PR DESCRIPTION
Permissions-policy must be delegated from the top frame down through every iframe in the chain; the previous allow lists omitted camera/microphone (or gated them on widget-declared permissions metadata), so deeply nested apps like a third-party video room could never receive those permissions even when they set allow= themselves.

Always include camera, microphone, fullscreen, display-capture, autoplay, and clipboard-write on:
- the outer SandboxedIframe (mcp-apps)
- the inner srcdoc iframe inside mcp-apps sandbox-proxy.html
- the outer + middle iframes in ChatGPTSandboxedIframe
- the inner iframe in chatgpt-apps sandbox-proxy.html
- the @mcp-ui/client iframe in MCPUIResourcePart

Existing tokens (local-network-access, microphone, midi) are preserved. Sandbox attributes are unchanged.