### PR TITLE
security: stop sending session token in SSE URL query params

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/session-token.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/session-token.test.ts
@@ -104,24 +104,26 @@ describe("session-token module", () => {
       (window as any).__MCP_SESSION_TOKEN__ = "url-token";
     });
 
-    it("adds token to URL without query params", () => {
+    it("returns URL without adding token query params", () => {
       const result = sessionToken.addTokenToUrl("/api/mcp/stream");
 
-      expect(result).toBe("/api/mcp/stream?_token=url-token");
+      expect(result).toBe("/api/mcp/stream");
     });
 
-    it("adds token to URL with existing query params", () => {
+    it("preserves existing query params without adding token", () => {
       const result = sessionToken.addTokenToUrl("/api/mcp/stream?serverId=foo");
 
-      expect(result).toBe("/api/mcp/stream?serverId=foo&_token=url-token");
+      expect(result).toBe("/api/mcp/stream?serverId=foo");
     });
 
-    it("returns same-origin URLs as relative paths", () => {
-      const result = sessionToken.addTokenToUrl(
-        `${window.location.origin}/api/mcp/stream`,
-      );
+    it("sets EventSource auth cookie", () => {
+      const cookieSpy = vi.spyOn(document, "cookie", "set");
 
-      expect(result).toBe("/api/mcp/stream?_token=url-token");
+      sessionToken.addTokenToUrl("/api/mcp/stream");
+
+      expect(cookieSpy).toHaveBeenCalledWith(
+        "mcp_session_auth=url-token; Path=/api/; SameSite=Strict",
+      );
     });
 
     it("returns original URL when no token is available", async () => {
@@ -145,7 +147,7 @@ describe("session-token module", () => {
       sessionToken.addTokenToUrl("/api/mcp/stream");
 
       expect(warnSpy).toHaveBeenCalledWith(
-        "[Auth] Session token not available for URL",
+        "[Auth] Session token not available for EventSource",
       );
     });
   });

--- a/mcpjam-inspector/client/src/lib/session-token.ts
+++ b/mcpjam-inspector/client/src/lib/session-token.ts
@@ -9,7 +9,7 @@
  * This module provides utilities to:
  * - Initialize the token before any API calls
  * - Get auth headers for fetch requests
- * - Add token to URLs for SSE/EventSource (which can't use headers)
+ * - Set a same-origin cookie for SSE/EventSource (which can't use headers)
  */
 
 import { HOSTED_MODE } from "@/lib/config";
@@ -108,6 +108,7 @@ export async function initializeSessionToken(): Promise<string> {
   // Check for injected token (production)
   if (window.__MCP_SESSION_TOKEN__) {
     cachedToken = window.__MCP_SESSION_TOKEN__;
+    setEventSourceAuthCookie(cachedToken);
     return cachedToken;
   }
 
@@ -120,6 +121,7 @@ export async function initializeSessionToken(): Promise<string> {
         }
         const data = await response.json();
         cachedToken = data.token;
+        setEventSourceAuthCookie(cachedToken);
         return cachedToken!;
       })
       .catch((error) => {
@@ -143,6 +145,7 @@ export function getSessionToken(): string {
   }
   if (window.__MCP_SESSION_TOKEN__) {
     cachedToken = window.__MCP_SESSION_TOKEN__;
+    setEventSourceAuthCookie(cachedToken);
     return cachedToken;
   }
   return "";
@@ -176,11 +179,27 @@ export function getAuthHeaders(): HeadersInit {
 }
 
 /**
- * Add token to URL as query parameter.
- * Required for SSE/EventSource which doesn't support custom headers.
+ * Set the same-origin cookie used by SSE/EventSource authentication.
+ * EventSource cannot send custom headers, and placing session tokens in URLs
+ * leaks them to browser history, referrer headers, and access logs.
+ */
+export function setEventSourceAuthCookie(token: string): void {
+  if (HOSTED_MODE || !token || typeof document === "undefined") {
+    return;
+  }
+
+  const secure = window.location.protocol === "https:" ? "; Secure" : "";
+  document.cookie = `mcp_session_auth=${encodeURIComponent(
+    token,
+  )}; Path=/api/; SameSite=Strict${secure}`;
+}
+
+/**
+ * Prepare a URL for SSE/EventSource without embedding credentials.
+ * Authentication is provided by the same-origin mcp_session_auth cookie.
  *
- * @param url - The URL to add token to (can be relative or absolute)
- * @returns URL with token as query parameter
+ * @param url - The EventSource URL
+ * @returns The original URL without a session token query parameter
  */
 export function addTokenToUrl(url: string): string {
   if (HOSTED_MODE) {
@@ -189,28 +208,12 @@ export function addTokenToUrl(url: string): string {
 
   const token = getSessionToken();
   if (!token) {
-    console.warn("[Auth] Session token not available for URL");
+    console.warn("[Auth] Session token not available for EventSource");
     return url;
   }
 
-  try {
-    // Parse URL (uses origin as base for relative URLs)
-    const parsed = new URL(url, window.location.origin);
-    parsed.searchParams.set("_token", token);
-
-    // Check if this is a same-origin URL
-    if (parsed.origin === window.location.origin) {
-      // Same-origin: return relative path (pathname + search)
-      return parsed.pathname + parsed.search;
-    } else {
-      // Cross-origin: preserve the full absolute URL
-      return parsed.href;
-    }
-  } catch {
-    // Fallback for unusual URL formats
-    const separator = url.includes("?") ? "&" : "?";
-    return `${url}${separator}_token=${encodeURIComponent(token)}`;
-  }
+  setEventSourceAuthCookie(token);
+  return url;
 }
 
 /**

--- a/mcpjam-inspector/server/__tests__/auth-integration.test.ts
+++ b/mcpjam-inspector/server/__tests__/auth-integration.test.ts
@@ -232,18 +232,18 @@ describe("Auth Integration", () => {
     });
   });
 
-  describe("query parameter authentication for SSE", () => {
-    it("accepts SSE route with token in query parameter", async () => {
-      const res = await app.request(
-        `/api/mcp/servers/rpc/stream?_token=${validToken}`,
-      );
+  describe("cookie authentication for SSE", () => {
+    it("accepts SSE route with token in same-origin cookie", async () => {
+      const res = await app.request("/api/mcp/servers/rpc/stream", {
+        headers: { Cookie: `mcp_session_auth=${validToken}` },
+      });
 
       expect(res.status).toBe(200);
     });
 
-    it("rejects SSE route with invalid query token", async () => {
+    it("rejects SSE route with token in query parameter", async () => {
       const res = await app.request(
-        "/api/mcp/servers/rpc/stream?_token=invalid",
+        `/api/mcp/servers/rpc/stream?_token=${validToken}`,
       );
 
       expect(res.status).toBe(401);

--- a/mcpjam-inspector/server/middleware/__tests__/session-auth.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/session-auth.test.ts
@@ -92,12 +92,12 @@ describe("sessionAuthMiddleware", () => {
       expect(data.message).toBe("protected route");
     });
 
-    it("allows request with valid token in query parameter", async () => {
+    it("rejects session tokens supplied in query parameters", async () => {
       const res = await app.request(`/api/mcp/test?_token=${validToken}`);
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(401);
       const data = await res.json();
-      expect(data.message).toBe("protected route");
+      expect(data.error).toBe("Unauthorized");
     });
 
     it("prefers header over query parameter when both present", async () => {
@@ -112,8 +112,10 @@ describe("sessionAuthMiddleware", () => {
       expect(res.status).toBe(200);
     });
 
-    it("falls back to query parameter when header is missing", async () => {
-      const res = await app.request(`/api/mcp/test?_token=${validToken}`);
+    it("falls back to cookie when header is missing", async () => {
+      const res = await app.request("/api/mcp/test", {
+        headers: { Cookie: `mcp_session_auth=${validToken}` },
+      });
 
       expect(res.status).toBe(200);
     });
@@ -148,7 +150,7 @@ describe("sessionAuthMiddleware", () => {
 
       expect(res.status).toBe(401);
       const data = await res.json();
-      expect(data.hint).toContain("?_token=");
+      expect(data.hint).toContain("mcp_session_auth cookie");
     });
 
     it("provides header hint for non-SSE routes without token", async () => {

--- a/mcpjam-inspector/server/middleware/__tests__/session-auth.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/session-auth.test.ts
@@ -120,6 +120,25 @@ describe("sessionAuthMiddleware", () => {
       expect(res.status).toBe(200);
     });
 
+    it("URL-decodes the session cookie value", async () => {
+      // Simulate client-side encodeURIComponent() from session-token.ts.
+      const encoded = encodeURIComponent(validToken);
+      const res = await app.request("/api/mcp/test", {
+        headers: { Cookie: `mcp_session_auth=${encoded}` },
+      });
+
+      expect(res.status).toBe(200);
+    });
+
+    it("rejects a cookie with malformed percent-encoding", async () => {
+      const res = await app.request("/api/mcp/test", {
+        // %ZZ is not valid percent-encoding and will make decodeURIComponent throw.
+        headers: { Cookie: `mcp_session_auth=%ZZ` },
+      });
+
+      expect(res.status).toBe(401);
+    });
+
     it("works with POST requests", async () => {
       const res = await app.request("/api/mcp/test", {
         method: "POST",

--- a/mcpjam-inspector/server/middleware/session-auth.ts
+++ b/mcpjam-inspector/server/middleware/session-auth.ts
@@ -5,10 +5,7 @@
  *
  * Token delivery methods:
  * 1. Header: X-MCP-Session-Auth: Bearer <token> (preferred for fetch API)
- * 2. Query param: ?_token=<token> (required for SSE/EventSource)
- *
- * The query parameter fallback is necessary because the EventSource API
- * does not support custom headers.
+ * 2. Cookie: mcp_session_auth=<token> (used for same-origin SSE/EventSource)
  *
  * SECURITY NOTE: When adding new routes, consider whether they should be protected.
  * Only add routes to UNPROTECTED_* if they:
@@ -47,13 +44,13 @@ const UNPROTECTED_PREFIXES = [
 
 /**
  * Scrub sensitive tokens from URLs for safe logging.
- * Replaces _token query parameter values with [REDACTED].
+ * Replaces legacy _token query parameter values with [REDACTED].
  */
 export function scrubTokenFromUrl(url: string): string {
   return url.replace(/([?&])_token=[^&]*/g, "$1_token=[REDACTED]");
 }
 
-// Routes that typically use query param auth (SSE endpoints)
+// Routes that typically use EventSource/SSE auth
 const SSE_ROUTES = [
   "/api/mcp/servers/rpc/stream",
   "/api/mcp/elicitation/stream",
@@ -70,7 +67,7 @@ function isSSERoute(path: string): boolean {
 
 /**
  * Session authentication middleware.
- * Validates the session token from header or query parameter.
+ * Validates the session token from header or same-origin cookie.
  */
 export async function sessionAuthMiddleware(
   c: Context,
@@ -113,9 +110,16 @@ export async function sessionAuthMiddleware(
     token = authHeader.substring(7);
   }
 
-  // Fall back to query parameter (required for SSE/EventSource)
+  // Fall back to a same-origin cookie for SSE/EventSource, which cannot set
+  // custom headers. Avoid accepting tokens in URLs because query parameters
+  // are commonly captured by browser history, referrer headers, and logs.
   if (!token) {
-    token = c.req.query("_token") ?? undefined;
+    token = c.req
+      .header("Cookie")
+      ?.split(";")
+      .map((part) => part.trim())
+      .find((part) => part.startsWith("mcp_session_auth="))
+      ?.substring("mcp_session_auth=".length);
   }
 
   // No token provided
@@ -125,7 +129,7 @@ export async function sessionAuthMiddleware(
         error: "Unauthorized",
         message: "Session token required.",
         hint: isSSERoute(path)
-          ? "SSE endpoints require ?_token=<token> query parameter"
+          ? "SSE endpoints require the mcp_session_auth cookie"
           : "Include X-MCP-Session-Auth: Bearer <token> header",
       },
       401,

--- a/mcpjam-inspector/server/middleware/session-auth.ts
+++ b/mcpjam-inspector/server/middleware/session-auth.ts
@@ -114,12 +114,23 @@ export async function sessionAuthMiddleware(
   // custom headers. Avoid accepting tokens in URLs because query parameters
   // are commonly captured by browser history, referrer headers, and logs.
   if (!token) {
-    token = c.req
+    const rawCookieValue = c.req
       .header("Cookie")
       ?.split(";")
       .map((part) => part.trim())
       .find((part) => part.startsWith("mcp_session_auth="))
       ?.substring("mcp_session_auth=".length);
+
+    if (rawCookieValue) {
+      try {
+        token = decodeURIComponent(rawCookieValue);
+      } catch {
+        // Malformed percent-encoding — treat as missing token so the
+        // request is rejected with 401 rather than validated against
+        // a corrupted value.
+        token = undefined;
+      }
+    }
   }
 
   // No token provided

--- a/mcpjam-inspector/server/routes/mcp/__tests__/http-adapters.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/http-adapters.test.ts
@@ -117,13 +117,11 @@ describe("HTTP Adapters Security", () => {
           expect(res.status).toBe(200);
         });
 
-        it("also accepts GET (SSE) with valid token in query param", async () => {
-          const res = await app.request(
-            `/api/mcp/${prefix}/test-server?_token=${validToken}`,
-            {
-              method: "GET",
-            },
-          );
+        it("also accepts GET (SSE) with valid token in cookie", async () => {
+          const res = await app.request(`/api/mcp/${prefix}/test-server`, {
+            method: "GET",
+            headers: { Cookie: `mcp_session_auth=${validToken}` },
+          });
 
           // SSE returns 200 with streaming response
           expect(res.status).toBe(200);
@@ -252,15 +250,13 @@ describe("HTTP Adapters Security", () => {
         });
 
         it("does not return Access-Control-Allow-Origin: * on GET (SSE) response", async () => {
-          const res = await app.request(
-            `/api/mcp/${prefix}/test-server?_token=${validToken}`,
-            {
-              method: "GET",
-              headers: {
-                Origin: "http://localhost:5173",
-              },
+          const res = await app.request(`/api/mcp/${prefix}/test-server`, {
+            method: "GET",
+            headers: {
+              Origin: "http://localhost:5173",
+              Cookie: `mcp_session_auth=${validToken}`,
             },
-          );
+          });
 
           expect(res.status).toBe(200);
 


### PR DESCRIPTION
## Summary

The inspector's session token is currently appended to SSE/EventSource URLs as a `?_token=<token>` query parameter. URL-embedded credentials are well known to leak into:

- Browser history
- HTTP `Referer` headers if the SSE-loaded page navigates externally
- Reverse-proxy and server access logs (which routinely record full request URLs)

This is a CWE-200 / CWE-598 (Information Exposure Through Query Strings in URL) hardening issue. Severity is modest — the inspector binds to localhost by default and origin validation blocks cross-origin requests — but the leak path is real and the token has no visible expiry, so anyone with retrospective access to logs or browser history can replay it.

**Affected files (before fix):**
- `mcpjam-inspector/client/src/lib/session-token.ts` — `addTokenToUrl()` appended `?_token=<token>` to every EventSource URL
- `mcpjam-inspector/server/middleware/session-auth.ts` — `sessionAuthMiddleware` accepted `c.req.query("_token")` as a credential source

**Data flow:** `__MCP_SESSION_TOKEN__` → `getSessionToken()` → `addTokenToUrl()` → `new EventSource(url)` → URL recorded in browser history / server logs.

## Fix

Replace the URL query parameter with a same-origin cookie scoped to the API:

- New helper `setEventSourceAuthCookie(token)` sets `mcp_session_auth=<token>; Path=/api/; SameSite=Strict` (and `Secure` when served over HTTPS). It is called from `initializeSessionToken()` and `getSessionToken()` so the cookie is in place before any `EventSource` connection is opened.
- `addTokenToUrl()` no longer mutates the URL — it just ensures the cookie is set and returns the URL untouched.
- `sessionAuthMiddleware` now reads the token from the `Cookie` header instead of `?_token=`. The `X-MCP-Session-Auth: Bearer <token>` header path used by `fetch()` callers is unchanged.
- The `scrubTokenFromUrl()` regex is left in place to redact any pre-existing log lines (defense-in-depth for historical logs).
- Error hints returned to clients updated to point at the cookie rather than the query parameter.

### Why a cookie and not just headers?

`EventSource` does not allow custom headers, which is exactly why the original code used a URL parameter. A same-origin cookie is the standard alternative recommended for this case. `SameSite=Strict` + `Path=/api/` + the existing origin-validation middleware closes the typical CSRF concern for cookie-based auth on a localhost developer tool.

## Tests

Updated tests reflect the new behavior:

- `client/src/lib/__tests__/session-token.test.ts` — `addTokenToUrl` no longer adds `?_token=`, and a new test asserts the auth cookie is set with the expected attributes.
- `server/middleware/__tests__/session-auth.test.ts` — accepts cookie-based auth, rejects missing-token requests with the new hint string.
- `server/__tests__/auth-integration.test.ts` and `server/routes/mcp/__tests__/http-adapters.test.ts` — SSE happy-path tests now send `Cookie: mcp_session_auth=...` instead of the query parameter.

I ran the affected vitest suites locally and they pass. No production code path still consumes `_token` (verified with grep across `mcpjam-inspector/`); the only remaining reference is the legacy log scrubber regex.

## Security analysis

- **Exploitability:** A user opens the inspector (default `http://127.0.0.1:6274`). Any SSE connection made by the UI persists `?_token=<token>` in browser history. If the same machine has a browsing-history sync extension, screen-recording / observability agent, or a reverse proxy in front (some Docker users do this), the token is exposed at rest. The token alone is sufficient to impersonate the session against the API.
- **Preconditions:** local-mode deployment (default), and either (a) read access to access logs / history, or (b) a referrer leak triggered by clicking an external link from an inspector page. None of these preconditions already grant API access — the token is the missing piece.
- **Mitigations the fix provides:** removes the leak vector entirely. The cookie is not exposed in URLs, is `SameSite=Strict` (no cross-site delivery), `Secure` over HTTPS, and scoped to `Path=/api/` (not sent to static assets). The `X-MCP-Session-Auth` header path is unchanged so `fetch` callers are unaffected.

## Adversarial review

Before submitting, I tried to disprove this finding. The two most credible objections are: (1) "the inspector binds to localhost so logs aren't exposed," and (2) "origin validation already prevents abuse." Neither fully closes the gap — localhost binding doesn't prevent a local proxy, screen recorder, or browser-history sync from capturing the URL, and origin validation doesn't help once the token has already been read out of a log file. The fix is small, behavior-preserving for the header path, and removes a textbook URL-credential anti-pattern.

cc @lewiswigmore
