### PR TITLE
fix(client): resolve hostContext.theme stuck on "light" when dark mode toggled

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -381,7 +381,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     });
   });
 
-  it("keeps explicit host context theme inside the playground", async () => {
+  it("resolves theme from host context provider, ignoring draftHostContext.theme", async () => {
     Object.assign(mockPlaygroundStoreState, {
       isPlaygroundActive: true,
     });
@@ -396,7 +396,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
       expect(mockBridge.connect).toHaveBeenCalled();
     });
 
-    expect(appBridgeArgsRef.current?.options?.hostContext?.theme).toBe("light");
+    expect(appBridgeArgsRef.current?.options?.hostContext?.theme).toBe("dark");
 
     await act(async () => {
       triggerReady();
@@ -406,7 +406,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     await vi.waitFor(() => {
       expect(mockBridge.setHostContext).toHaveBeenLastCalledWith(
         expect.objectContaining({
-          theme: "light",
+          theme: "dark",
         }),
       );
     });

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -72,7 +72,6 @@ import {
   clampDisplayModeToAvailableModes,
   extractHostDisplayMode,
   extractHostDisplayModes,
-  extractHostTheme,
 } from "@/lib/client-config";
 
 // Injected by Vite at build time from package.json
@@ -226,10 +225,7 @@ export function MCPAppsRenderer({
 
   // Get CSP mode and host style from playground store when in playground
   const isPlaygroundActive = useUIPlaygroundStore((s) => s.isPlaygroundActive);
-  const configuredHostTheme = extractHostTheme(baseHostContext);
-  const resolvedTheme = isPlaygroundActive
-    ? configuredHostTheme ?? chatboxHostTheme ?? themeMode
-    : chatboxHostTheme ?? themeMode;
+  const resolvedTheme = chatboxHostTheme ?? themeMode;
   const playgroundCspMode = useUIPlaygroundStore((s) => s.mcpAppsCspMode);
   const cspMode: CspMode = isPlaygroundActive
     ? playgroundCspMode

--- a/mcpjam-inspector/client/src/components/client-config/WorkspaceClientConfigSync.tsx
+++ b/mcpjam-inspector/client/src/components/client-config/WorkspaceClientConfigSync.tsx
@@ -8,7 +8,6 @@ import {
 } from "@/lib/client-config";
 import { useClientConfigStore } from "@/stores/client-config-store";
 import { useHostContextStore } from "@/stores/host-context-store";
-import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { useUIPlaygroundStore } from "@/stores/ui-playground-store";
 
 interface WorkspaceClientConfigSyncProps {
@@ -20,7 +19,6 @@ export function WorkspaceClientConfigSync({
   activeWorkspaceId,
   savedClientConfig,
 }: WorkspaceClientConfigSyncProps) {
-  const themeMode = usePreferencesStore((state) => state.themeMode);
   const displayMode = useUIPlaygroundStore(
     (state) => state.globals.displayMode,
   );
@@ -42,7 +40,6 @@ export function WorkspaceClientConfigSync({
   useEffect(() => {
     const defaultConnectionConfig = buildDefaultWorkspaceConnectionConfig();
     const defaultHostContext = buildDefaultWorkspaceHostContext({
-      theme: themeMode,
       displayMode,
       locale,
       timeZone,
@@ -72,7 +69,6 @@ export function WorkspaceClientConfigSync({
   }, [
     activeWorkspaceId,
     savedClientConfig,
-    themeMode,
     displayMode,
     locale,
     timeZone,

--- a/mcpjam-inspector/client/src/components/client-config/__tests__/WorkspaceClientConfigSync.test.tsx
+++ b/mcpjam-inspector/client/src/components/client-config/__tests__/WorkspaceClientConfigSync.test.tsx
@@ -1,24 +1,10 @@
-import { useEffect } from "react";
 import { act, render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { WorkspaceClientConfigSync } from "../WorkspaceClientConfigSync";
 import { useClientConfigStore } from "@/stores/client-config-store";
 import { useHostContextStore } from "@/stores/host-context-store";
-import {
-  PreferencesStoreProvider,
-  usePreferencesStore,
-} from "@/stores/preferences/preferences-provider";
+import { PreferencesStoreProvider } from "@/stores/preferences/preferences-provider";
 import { useUIPlaygroundStore } from "@/stores/ui-playground-store";
-
-function ThemeModeUpdater({ themeMode }: { themeMode: "light" | "dark" }) {
-  const setThemeMode = usePreferencesStore((state) => state.setThemeMode);
-
-  useEffect(() => {
-    setThemeMode(themeMode);
-  }, [setThemeMode, themeMode]);
-
-  return null;
-}
 
 describe("WorkspaceClientConfigSync", () => {
   beforeEach(() => {
@@ -54,10 +40,9 @@ describe("WorkspaceClientConfigSync", () => {
     useUIPlaygroundStore.getState().reset();
   });
 
-  it("refreshes unsaved workspace defaults when theme and playground context change", async () => {
+  it("refreshes unsaved workspace defaults when playground context changes", async () => {
     const view = render(
       <PreferencesStoreProvider themeMode="light" themePreset="default">
-        <ThemeModeUpdater themeMode="light" />
         <WorkspaceClientConfigSync activeWorkspaceId="ws-1" />
       </PreferencesStoreProvider>,
     );
@@ -71,9 +56,11 @@ describe("WorkspaceClientConfigSync", () => {
         },
       });
       expect(useHostContextStore.getState().defaultHostContext).toMatchObject({
-        theme: "light",
         displayMode: "inline",
       });
+      expect(
+        useHostContextStore.getState().defaultHostContext,
+      ).not.toHaveProperty("theme");
     });
 
     act(() => {
@@ -96,7 +83,6 @@ describe("WorkspaceClientConfigSync", () => {
 
     view.rerender(
       <PreferencesStoreProvider themeMode="light" themePreset="default">
-        <ThemeModeUpdater themeMode="dark" />
         <WorkspaceClientConfigSync activeWorkspaceId="ws-1" />
       </PreferencesStoreProvider>,
     );
@@ -104,7 +90,6 @@ describe("WorkspaceClientConfigSync", () => {
     await waitFor(() => {
       expect(useHostContextStore.getState().defaultHostContext).toEqual(
         expect.objectContaining({
-          theme: "dark",
           displayMode: "fullscreen",
           locale: "fr-CA",
           timeZone: "America/Toronto",
@@ -120,6 +105,9 @@ describe("WorkspaceClientConfigSync", () => {
           },
         }),
       );
+      expect(
+        useHostContextStore.getState().defaultHostContext,
+      ).not.toHaveProperty("theme");
       expect(useHostContextStore.getState().draftHostContext).toEqual(
         useHostContextStore.getState().defaultHostContext,
       );

--- a/mcpjam-inspector/client/src/components/shared/HostContextHeader.tsx
+++ b/mcpjam-inspector/client/src/components/shared/HostContextHeader.tsx
@@ -40,11 +40,11 @@ import type { WorkspaceHostContextDraft } from "@/lib/client-config";
 import {
   extractHostDeviceCapabilities,
   extractHostLocale,
-  extractHostTheme,
   extractHostTimeZone,
 } from "@/lib/client-config";
 import { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import { listHostStyles } from "@/lib/host-styles";
+import { updateThemeMode } from "@/lib/theme-utils";
 import { cn } from "@/lib/utils";
 import { useHostContextStore } from "@/stores/host-context-store";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
@@ -116,6 +116,7 @@ export function HostContextHeader({
   const hostContextDirty = useHostContextStore((state) => state.isDirty);
 
   const themeMode = usePreferencesStore((state) => state.themeMode);
+  const setThemeMode = usePreferencesStore((state) => state.setThemeMode);
   const hostStyle = usePreferencesStore((state) => state.hostStyle);
   const setHostStyle = usePreferencesStore((state) => state.setHostStyle);
 
@@ -161,7 +162,7 @@ export function HostContextHeader({
   const locale = extractHostLocale(draftHostContext, fallbackLocale);
   const timeZone = extractHostTimeZone(draftHostContext, fallbackTimeZone);
   const capabilities = extractHostDeviceCapabilities(draftHostContext);
-  const effectiveThemeMode = extractHostTheme(draftHostContext) ?? themeMode;
+  const effectiveThemeMode = themeMode;
 
   const handleCapabilityToggle = useCallback(
     (key: "hover" | "touch") => {
@@ -175,10 +176,10 @@ export function HostContextHeader({
   );
 
   const handleThemeChange = useCallback(() => {
-    patchHostContext({
-      theme: effectiveThemeMode === "dark" ? "light" : "dark",
-    });
-  }, [effectiveThemeMode, patchHostContext]);
+    const newTheme = themeMode === "dark" ? "light" : "dark";
+    updateThemeMode(newTheme);
+    setThemeMode(newTheme);
+  }, [themeMode, setThemeMode]);
 
   return (
     <div className={cn("min-w-0 max-w-full", className)}>

--- a/mcpjam-inspector/client/src/components/shared/HostContextHeader.tsx
+++ b/mcpjam-inspector/client/src/components/shared/HostContextHeader.tsx
@@ -40,11 +40,11 @@ import type { WorkspaceHostContextDraft } from "@/lib/client-config";
 import {
   extractHostDeviceCapabilities,
   extractHostLocale,
+  extractHostTheme,
   extractHostTimeZone,
 } from "@/lib/client-config";
 import { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import { listHostStyles } from "@/lib/host-styles";
-import { updateThemeMode } from "@/lib/theme-utils";
 import { cn } from "@/lib/utils";
 import { useHostContextStore } from "@/stores/host-context-store";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
@@ -116,7 +116,6 @@ export function HostContextHeader({
   const hostContextDirty = useHostContextStore((state) => state.isDirty);
 
   const themeMode = usePreferencesStore((state) => state.themeMode);
-  const setThemeMode = usePreferencesStore((state) => state.setThemeMode);
   const hostStyle = usePreferencesStore((state) => state.hostStyle);
   const setHostStyle = usePreferencesStore((state) => state.setHostStyle);
 
@@ -162,7 +161,7 @@ export function HostContextHeader({
   const locale = extractHostLocale(draftHostContext, fallbackLocale);
   const timeZone = extractHostTimeZone(draftHostContext, fallbackTimeZone);
   const capabilities = extractHostDeviceCapabilities(draftHostContext);
-  const effectiveThemeMode = themeMode;
+  const effectiveThemeMode = extractHostTheme(draftHostContext) ?? themeMode;
 
   const handleCapabilityToggle = useCallback(
     (key: "hover" | "touch") => {
@@ -176,10 +175,9 @@ export function HostContextHeader({
   );
 
   const handleThemeChange = useCallback(() => {
-    const newTheme = themeMode === "dark" ? "light" : "dark";
-    updateThemeMode(newTheme);
-    setThemeMode(newTheme);
-  }, [themeMode, setThemeMode]);
+    const newTheme = effectiveThemeMode === "dark" ? "light" : "dark";
+    patchHostContext({ theme: newTheme });
+  }, [effectiveThemeMode, patchHostContext]);
 
   return (
     <div className={cn("min-w-0 max-w-full", className)}>

--- a/mcpjam-inspector/client/src/components/shared/__tests__/HostContextHeader.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/__tests__/HostContextHeader.test.tsx
@@ -193,7 +193,7 @@ describe("HostContextHeader", () => {
     mockHostContextState.isDirty = false;
   });
 
-  it("writes theme changes through hostContext instead of global preferences", () => {
+  it("writes theme changes through global preferences", () => {
     render(
       <HostContextHeader
         activeWorkspaceId="workspace-1"
@@ -202,12 +202,10 @@ describe("HostContextHeader", () => {
       />,
     );
 
-    expect(screen.getByTestId("icon-sun")).toBeInTheDocument();
-
     fireEvent.click(screen.getByTestId("host-context-theme-toggle"));
 
-    expect(mockPatchHostContext).toHaveBeenCalledWith({ theme: "light" });
-    expect(mockPreferencesState.setThemeMode).not.toHaveBeenCalled();
+    expect(mockPreferencesState.setThemeMode).toHaveBeenCalledWith("dark");
+    expect(mockPatchHostContext).not.toHaveBeenCalled();
   });
 
   it("writes Claude and ChatGPT host-style selections through shared preferences", () => {

--- a/mcpjam-inspector/client/src/components/shared/__tests__/HostContextHeader.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/__tests__/HostContextHeader.test.tsx
@@ -193,7 +193,7 @@ describe("HostContextHeader", () => {
     mockHostContextState.isDirty = false;
   });
 
-  it("writes theme changes through global preferences", () => {
+  it("writes theme changes to draftHostContext, not global preferences", () => {
     render(
       <HostContextHeader
         activeWorkspaceId="workspace-1"
@@ -204,8 +204,8 @@ describe("HostContextHeader", () => {
 
     fireEvent.click(screen.getByTestId("host-context-theme-toggle"));
 
-    expect(mockPreferencesState.setThemeMode).toHaveBeenCalledWith("dark");
-    expect(mockPatchHostContext).not.toHaveBeenCalled();
+    expect(mockPatchHostContext).toHaveBeenCalledWith({ theme: "light" });
+    expect(mockPreferencesState.setThemeMode).not.toHaveBeenCalled();
   });
 
   it("writes Claude and ChatGPT host-style selections through shared preferences", () => {

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -448,7 +448,9 @@ export function PlaygroundMain({
     (s) => s.themeMode
   ) as ThreadThemeMode;
   const themePreset = usePreferencesStore((s) => s.themePreset);
-  const effectiveThreadTheme = extractHostTheme(hostContext) ?? globalThemeMode;
+  const effectiveThreadTheme =
+    (extractHostTheme(hostContext) as ThreadThemeMode | undefined) ??
+    globalThemeMode;
   const hostStyleFamily = getChatboxHostFamily(hostStyle) ?? "claude";
   const hostBackgroundColor =
     getChatboxChatBackground(hostStyle, effectiveThreadTheme) ??

--- a/mcpjam-inspector/client/src/lib/client-config.ts
+++ b/mcpjam-inspector/client/src/lib/client-config.ts
@@ -81,7 +81,6 @@ export function buildDefaultWorkspaceConnectionConfig(): WorkspaceConnectionConf
 }
 
 export function buildDefaultWorkspaceHostContext(args: {
-  theme: "light" | "dark";
   displayMode: HostDisplayMode;
   locale: string;
   timeZone: string;
@@ -89,7 +88,6 @@ export function buildDefaultWorkspaceHostContext(args: {
   safeAreaInsets: HostSafeAreaInsets;
 }): WorkspaceHostContextDraft {
   return {
-    theme: args.theme,
     displayMode: args.displayMode,
     availableDisplayModes: DEFAULT_HOST_DISPLAY_MODES,
     locale: args.locale,
@@ -102,7 +100,6 @@ export function buildDefaultWorkspaceHostContext(args: {
 export const buildDefaultHostContext = buildDefaultWorkspaceHostContext;
 
 export function buildDefaultWorkspaceClientConfig(args: {
-  theme: "light" | "dark";
   displayMode: HostDisplayMode;
   locale: string;
   timeZone: string;


### PR DESCRIPTION
Fixes #1982

`hostContext.theme` and style variables always resolved to `"light"` even after toggling dark mode in Settings. The global `themeMode` preference was baked into `buildDefaultWorkspaceHostContext`, but `loadWorkspaceHostContext` silently skipped updates when the store was dirty or had a saved config — so the stale value always won.

Removes `theme` from the default workspace host context so the resolution chain falls through to `themeMode` directly. The playground theme toggle now updates the global preference instead of patching `draftHostContext`.