### PR TITLE
Preserve MCP output schemas in model requests

### DIFF
--- a/.changeset/curly-tools-smile.md
+++ b/.changeset/curly-tools-smile.md
@@ -1,0 +1,6 @@
+---
+"@mcpjam/sdk": patch
+"@mcpjam/inspector": patch
+---
+
+Expose MCP tool output schemas to model-facing descriptions and raw request payloads.

--- a/mcpjam-inspector/server/utils/__tests__/model-request-payload.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/model-request-payload.test.ts
@@ -116,6 +116,40 @@ describe("buildResolvedModelRequestPayload", () => {
     });
   });
 
+  it("serializes zod-backed output schemas before falling back to raw objects", () => {
+    const result = buildResolvedModelRequestPayload({
+      systemPrompt: "",
+      tools: {
+        classify: {
+          description: "Classify text",
+          parameters: z.object({
+            text: z.string(),
+          }),
+          outputSchema: z.object({
+            label: z.enum(["positive", "negative"]),
+            confidence: z.number(),
+          }),
+        },
+      } as any,
+      messages: [],
+    });
+
+    expect(result.tools.classify.outputSchema).toEqual(
+      expect.objectContaining({
+        type: "object",
+        properties: {
+          label: expect.objectContaining({
+            enum: ["positive", "negative"],
+          }),
+          confidence: expect.objectContaining({
+            type: "number",
+          }),
+        },
+        required: ["label", "confidence"],
+      })
+    );
+  });
+
   it("falls back to the empty object schema for raw MCP inputSchema", () => {
     const result = buildResolvedModelRequestPayload({
       systemPrompt: "",

--- a/mcpjam-inspector/server/utils/__tests__/model-request-payload.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/model-request-payload.test.ts
@@ -74,6 +74,48 @@ describe("buildResolvedModelRequestPayload", () => {
     });
   });
 
+  it("includes MCP output schemas in raw request payloads", () => {
+    const outputSchema = {
+      type: "object",
+      properties: {
+        x: {
+          type: "integer",
+          description: "Density of seagulls in the sky",
+        },
+      },
+      required: ["x"],
+    };
+
+    const result = buildResolvedModelRequestPayload({
+      systemPrompt: "",
+      tools: {
+        get_weather: {
+          description: "Get weather",
+          inputSchema: {
+            jsonSchema: {
+              type: "object",
+              properties: { city: { type: "string" } },
+              required: ["city"],
+            },
+          },
+          _mcpOutputSchema: outputSchema,
+        },
+      } as any,
+      messages: [],
+    });
+
+    expect(result.tools.get_weather).toEqual({
+      name: "get_weather",
+      description: "Get weather",
+      inputSchema: {
+        type: "object",
+        properties: { city: { type: "string" } },
+        required: ["city"],
+      },
+      outputSchema,
+    });
+  });
+
   it("falls back to the empty object schema for raw MCP inputSchema", () => {
     const result = buildResolvedModelRequestPayload({
       systemPrompt: "",

--- a/mcpjam-inspector/server/utils/model-request-payload.ts
+++ b/mcpjam-inspector/server/utils/model-request-payload.ts
@@ -25,6 +25,28 @@ function serializeToolSchema(schema: unknown): Record<string, unknown> {
   }
 }
 
+function serializeOptionalJsonSchema(
+  schema: unknown
+): Record<string, unknown> | undefined {
+  if (!schema) {
+    return undefined;
+  }
+
+  if (typeof schema === "object" && schema !== null && "jsonSchema" in schema) {
+    return (schema as { jsonSchema: Record<string, unknown> }).jsonSchema;
+  }
+
+  if (typeof schema === "object" && schema !== null && !Array.isArray(schema)) {
+    return schema as Record<string, unknown>;
+  }
+
+  try {
+    return z.toJSONSchema(schema as z.ZodType) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
 export function buildResolvedModelRequestPayload(options: {
   systemPrompt: string;
   tools: ToolSet;
@@ -39,11 +61,15 @@ export function buildResolvedModelRequestPayload(options: {
 
     const toolRecord = tool as Record<string, unknown>;
     const schema = toolRecord.parameters ?? toolRecord.inputSchema;
+    const outputSchema = serializeOptionalJsonSchema(
+      toolRecord.outputSchema ?? toolRecord._mcpOutputSchema
+    );
 
     serializedTools[name] = {
       name,
       description: toolRecord.description as string | undefined,
       inputSchema: serializeToolSchema(schema),
+      ...(outputSchema ? { outputSchema } : {}),
     };
   }
 

--- a/mcpjam-inspector/server/utils/model-request-payload.ts
+++ b/mcpjam-inspector/server/utils/model-request-payload.ts
@@ -36,13 +36,17 @@ function serializeOptionalJsonSchema(
     return (schema as { jsonSchema: Record<string, unknown> }).jsonSchema;
   }
 
-  if (typeof schema === "object" && schema !== null && !Array.isArray(schema)) {
-    return schema as Record<string, unknown>;
-  }
-
   try {
     return z.toJSONSchema(schema as z.ZodType) as Record<string, unknown>;
   } catch {
+    if (
+      typeof schema === "object" &&
+      schema !== null &&
+      !Array.isArray(schema)
+    ) {
+      return schema as Record<string, unknown>;
+    }
+
     return undefined;
   }
 }

--- a/mcpjam-inspector/shared/model-request-payload.ts
+++ b/mcpjam-inspector/shared/model-request-payload.ts
@@ -4,6 +4,7 @@ export interface SerializedModelRequestTool {
   name: string;
   description?: string;
   inputSchema?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
 }
 
 export interface ResolvedModelRequestPayload {

--- a/sdk/src/TestAgent.ts
+++ b/sdk/src/TestAgent.ts
@@ -28,7 +28,11 @@ import type {
   EvalWidgetSnapshotInput,
   MCPServerReplayConfig,
 } from "./eval-reporting-types.js";
-import { ensureJsonSchemaObject } from "./mcp-client-manager/tool-converters.js";
+import {
+  attachMcpOutputSchemaMetadata,
+  ensureJsonSchemaObject,
+  withMcpOutputSchemaDescription,
+} from "./mcp-client-manager/tool-converters.js";
 import { assertCallToolResult } from "./mcp-client-manager/result-guards.js";
 import { buildMcpAppWidgetSnapshot } from "./widget-snapshots.js";
 import { injectOpenAICompat } from "./widget-helpers.js";
@@ -87,7 +91,10 @@ function convertToToolSet(tools: Tool[]): ToolSet {
     }
 
     const converted = dynamicTool({
-      description: tool.description,
+      description: withMcpOutputSchemaDescription(
+        tool.description,
+        tool.outputSchema
+      ),
       inputSchema: jsonSchema(ensureJsonSchemaObject(tool.inputSchema)),
       execute: async (args, options) => {
         options?.abortSignal?.throwIfAborted?.();
@@ -95,6 +102,7 @@ function convertToToolSet(tools: Tool[]): ToolSet {
         return assertCallToolResult(result, `Tool "${tool.name}" result`);
       },
     });
+    attachMcpOutputSchemaMetadata(converted, tool.outputSchema);
 
     // Preserve _serverId like getToolsForAiSdk() does
     if (tool._meta?._serverId) {

--- a/sdk/src/mcp-client-manager/tool-converters.ts
+++ b/sdk/src/mcp-client-manager/tool-converters.ts
@@ -17,6 +17,8 @@ import {
 } from "ai";
 import { assertCallToolResult } from "./result-guards.js";
 
+export const MCP_OUTPUT_SCHEMA_PROPERTY = "_mcpOutputSchema";
+
 /**
  * Normalizes a schema to a valid JSON Schema object.
  * Many MCP tools omit the top-level type; Anthropic requires an object schema.
@@ -55,6 +57,43 @@ export function ensureJsonSchemaObject(schema: unknown): JSONSchema7 {
     properties: {},
     additionalProperties: false,
   } satisfies JSONSchema7;
+}
+
+function stringifyJsonSchema(schema: unknown): string | undefined {
+  if (!schema || typeof schema !== "object") {
+    return undefined;
+  }
+
+  try {
+    return JSON.stringify(schema);
+  } catch {
+    return undefined;
+  }
+}
+
+export function withMcpOutputSchemaDescription(
+  description: string | undefined,
+  outputSchema: unknown
+): string | undefined {
+  const outputSchemaText = stringifyJsonSchema(outputSchema);
+  if (!outputSchemaText) {
+    return description;
+  }
+
+  const descriptionText = description?.trim();
+  const schemaHint = `MCP output schema for structuredContent: ${outputSchemaText}`;
+
+  return descriptionText ? `${descriptionText}\n\n${schemaHint}` : schemaHint;
+}
+
+export function attachMcpOutputSchemaMetadata(
+  tool: Tool,
+  outputSchema: unknown
+): void {
+  if (outputSchema !== undefined) {
+    (tool as Record<string, unknown>)[MCP_OUTPUT_SCHEMA_PROPERTY] =
+      outputSchema;
+  }
 }
 
 /**
@@ -215,7 +254,11 @@ export async function convertMCPToolsToVercelTools(
   const tools: ToolSet = {};
 
   for (const toolDescription of listToolsResult.tools) {
-    const { name, description, inputSchema } = toolDescription;
+    const { name, description, inputSchema, outputSchema } = toolDescription;
+    const descriptionWithOutputSchema = withMcpOutputSchemaDescription(
+      description,
+      outputSchema
+    );
     const toolMeta = toolDescription._meta as
       | Record<string, unknown>
       | undefined;
@@ -254,7 +297,7 @@ export async function convertMCPToolsToVercelTools(
       // Automatic mode: normalize the schema and create a dynamic tool
       const normalizedInputSchema = ensureJsonSchemaObject(inputSchema);
       vercelTool = dynamicTool({
-        description,
+        description: descriptionWithOutputSchema,
         inputSchema: jsonSchema(normalizedInputSchema),
         execute,
         ...(toModelOutput ? { toModelOutput } : {}),
@@ -267,7 +310,7 @@ export async function convertMCPToolsToVercelTools(
         continue;
       }
       vercelTool = defineTool<unknown, CallToolResult>({
-        description,
+        description: descriptionWithOutputSchema,
         inputSchema: overrides[name].inputSchema,
         execute,
         ...(toModelOutput ? { toModelOutput } : {}),
@@ -275,6 +318,7 @@ export async function convertMCPToolsToVercelTools(
       });
     }
 
+    attachMcpOutputSchemaMetadata(vercelTool, outputSchema);
     tools[name] = vercelTool;
   }
 

--- a/sdk/tests/tool-converters.test.ts
+++ b/sdk/tests/tool-converters.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ListToolsResult } from "@modelcontextprotocol/client";
+import {
+  convertMCPToolsToVercelTools,
+  MCP_OUTPUT_SCHEMA_PROPERTY,
+} from "../src/mcp-client-manager/tool-converters";
+
+describe("convertMCPToolsToVercelTools", () => {
+  it("preserves MCP output schemas as model-visible metadata", async () => {
+    const outputSchema = {
+      type: "object",
+      properties: {
+        temperature: {
+          type: "number",
+          description: "Temperature in Celsius",
+        },
+        x: {
+          type: "integer",
+          description: "Density of seagulls in the sky",
+        },
+      },
+      required: ["temperature", "x"],
+    };
+
+    const tools = await convertMCPToolsToVercelTools(
+      {
+        tools: [
+          {
+            name: "get_weather",
+            description: "Get weather for a city.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                city: { type: "string" },
+              },
+              required: ["city"],
+            },
+            outputSchema,
+          },
+        ],
+      } as ListToolsResult,
+      {
+        callTool: vi.fn(),
+      }
+    );
+
+    const weatherTool = tools.get_weather as Record<string, unknown>;
+
+    expect(weatherTool.description).toContain("Get weather for a city.");
+    expect(weatherTool.description).toContain(
+      "MCP output schema for structuredContent:"
+    );
+    expect(weatherTool.description).toContain("Density of seagulls in the sky");
+    expect(weatherTool[MCP_OUTPUT_SCHEMA_PROPERTY]).toBe(outputSchema);
+    expect(weatherTool.outputSchema).toBeUndefined();
+  });
+
+  it("does not change descriptions when a tool has no output schema", async () => {
+    const tools = await convertMCPToolsToVercelTools(
+      {
+        tools: [
+          {
+            name: "echo",
+            description: "Echo a message.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                message: { type: "string" },
+              },
+              required: ["message"],
+            },
+          },
+        ],
+      } as ListToolsResult,
+      {
+        callTool: vi.fn(),
+      }
+    );
+
+    expect(tools.echo.description).toBe("Echo a message.");
+    expect(
+      (tools.echo as Record<string, unknown>)[MCP_OUTPUT_SCHEMA_PROPERTY]
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- include MCP tool `outputSchema` details in model-facing tool descriptions so providers can see `structuredContent` field meanings
- preserve the raw MCP output schema on converted tools without misusing AI SDK `tool.outputSchema` for the whole `CallToolResult`
- show output schemas in live raw request payloads for chat traces

Fixes #1956.

## Validation
- `npm run test -w @mcpjam/sdk -- tool-converters.test.ts`
- `npm run test -w @mcpjam/inspector -- model-request-payload.test.ts`
- `npm run typecheck -w @mcpjam/sdk`
- `npm run build -w @mcpjam/sdk`
- `npm run build:server -w @mcpjam/inspector`
- `git diff --check`