### PR TITLE
[codex] Fix OAuth resource indicator selection

### DIFF
--- a/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-06-18.ts
@@ -34,7 +34,11 @@ import {
   generateRandomString,
   generateCodeChallenge,
 } from "./shared/pkce.js";
-import { buildResourceMetadataUrl } from "./shared/urls.js";
+import {
+  buildResourceMetadataUrl,
+  canonicalizeResourceUrl,
+  resolveOAuthResourceIndicator,
+} from "./shared/urls.js";
 import {
   buildInitializeRequestBody,
   resolveInitializeProtocolVersion,
@@ -232,7 +236,14 @@ export function buildActions_2025_06_18(
               label: "method",
               value: flowState.codeChallengeMethod || "S256",
             },
-            { label: "resource", value: flowState.serverUrl || "—" },
+            {
+              label: "resource",
+              value:
+                resolveOAuthResourceIndicator(
+                  flowState.serverUrl,
+                  flowState.resourceMetadata
+                ) ?? "—",
+            },
             { label: "Protocol", value: "2025-06-18" },
           ]
         : undefined,
@@ -251,7 +262,14 @@ export function buildActions_2025_06_18(
               value:
                 flowState.codeChallenge?.substring(0, 12) + "..." || "S256",
             },
-            { label: "resource", value: flowState.serverUrl || "" },
+            {
+              label: "resource",
+              value:
+                resolveOAuthResourceIndicator(
+                  flowState.serverUrl,
+                  flowState.resourceMetadata
+                ) ?? "",
+            },
           ]
         : undefined,
     },
@@ -305,7 +323,14 @@ export function buildActions_2025_06_18(
       details: flowState.codeVerifier
         ? [
             { label: "grant_type", value: "authorization_code" },
-            { label: "resource", value: flowState.serverUrl || "" },
+            {
+              label: "resource",
+              value:
+                resolveOAuthResourceIndicator(
+                  flowState.serverUrl,
+                  flowState.resourceMetadata
+                ) ?? "",
+            },
           ]
         : undefined,
     },
@@ -426,6 +451,11 @@ export const createDebugOAuthStateMachine = (
 
   // Helper to get current state (use getState if provided, otherwise use initial state)
   const getCurrentState = () => (getState ? getState() : initialState);
+  const getResourceIndicator = () =>
+    resolveOAuthResourceIndicator(
+      serverUrl,
+      getCurrentState().resourceMetadata
+    ) ?? canonicalizeResourceUrl(serverUrl);
 
   const executeRequest = (url: string, options: RequestInit = {}) =>
     requestExecutor({
@@ -1445,7 +1475,7 @@ export const createDebugOAuthStateMachine = (
               {
                 code_challenge: codeChallenge,
                 method: "S256",
-                resource: state.serverUrl || "Unknown",
+                resource: getResourceIndicator(),
               },
             );
 
@@ -1481,9 +1511,7 @@ export const createDebugOAuthStateMachine = (
             );
             authUrl.searchParams.set("code_challenge_method", "S256");
             authUrl.searchParams.set("state", state.state || "");
-            if (state.serverUrl) {
-              authUrl.searchParams.set("resource", state.serverUrl);
-            }
+            authUrl.searchParams.set("resource", getResourceIndicator());
 
             const requestedScopeValue = resolveRequestedScopeValue({
               customScopes,
@@ -1568,9 +1596,7 @@ export const createDebugOAuthStateMachine = (
               tokenRequestBodyObj.code_verifier = state.codeVerifier;
             }
 
-            if (state.serverUrl) {
-              tokenRequestBodyObj.resource = state.serverUrl;
-            }
+            tokenRequestBodyObj.resource = getResourceIndicator();
 
             const tokenRequest = {
               method: "POST",
@@ -1635,9 +1661,7 @@ export const createDebugOAuthStateMachine = (
               }
 
               // Add resource parameter if available
-              if (state.serverUrl) {
-                tokenRequestBody.set("resource", state.serverUrl);
-              }
+              tokenRequestBody.set("resource", getResourceIndicator());
 
               // Make the token request via backend proxy
               const response = await executeRequest(
@@ -1757,13 +1781,16 @@ export const createDebugOAuthStateMachine = (
 
                   // Check if audience claim exists and validate it
                   if (formatted.aud) {
-                    const expectedResource = state.serverUrl;
+                    const expectedResource = getResourceIndicator();
                     const audArray = Array.isArray(formatted.aud)
                       ? formatted.aud
                       : [formatted.aud];
 
                     const isValidAudience = audArray.some(
-                      (aud: string) => aud === expectedResource,
+                      (aud: string) =>
+                        aud === expectedResource ||
+                        canonicalizeResourceUrl(aud) ===
+                          canonicalizeResourceUrl(expectedResource)
                     );
 
                     audienceNote._validation = {

--- a/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
+++ b/sdk/src/oauth/state-machines/debug-oauth-2025-11-25.ts
@@ -37,6 +37,7 @@ import {
 import {
   buildResourceMetadataUrl,
   canonicalizeResourceUrl,
+  resolveOAuthResourceIndicator,
 } from "./shared/urls.js";
 import {
   buildInitializeRequestBody,
@@ -336,9 +337,11 @@ export function buildActions_2025_11_25(
             },
             {
               label: "resource",
-              value: flowState.serverUrl
-                ? canonicalizeResourceUrl(flowState.serverUrl)
-                : "—",
+              value:
+                resolveOAuthResourceIndicator(
+                  flowState.serverUrl,
+                  flowState.resourceMetadata
+                ) ?? "—",
             },
             { label: "Protocol", value: "2025-11-25" },
           ]
@@ -360,9 +363,11 @@ export function buildActions_2025_11_25(
             },
             {
               label: "resource",
-              value: flowState.serverUrl
-                ? canonicalizeResourceUrl(flowState.serverUrl)
-                : "",
+              value:
+                resolveOAuthResourceIndicator(
+                  flowState.serverUrl,
+                  flowState.resourceMetadata
+                ) ?? "",
             },
           ]
         : undefined,
@@ -419,9 +424,11 @@ export function buildActions_2025_11_25(
             { label: "grant_type", value: "authorization_code" },
             {
               label: "resource",
-              value: flowState.serverUrl
-                ? canonicalizeResourceUrl(flowState.serverUrl)
-                : "",
+              value:
+                resolveOAuthResourceIndicator(
+                  flowState.serverUrl,
+                  flowState.resourceMetadata
+                ) ?? "",
             },
           ]
         : undefined,
@@ -542,8 +549,8 @@ export const createDebugOAuthStateMachine = (
     registrationStrategy = "cimd", // Default to CIMD for 2025-11-25
   } = config;
 
-  // Canonicalize the server URL once at initialization (per RFC 8707)
-  const canonicalServerUrl = canonicalizeResourceUrl(serverUrl);
+  // Fallback resource indicator used before protected-resource metadata exists.
+  const fallbackResourceIndicator = canonicalizeResourceUrl(serverUrl);
   const redirectUri = redirectUrl;
   const initializeProtocolVersion = resolveInitializeProtocolVersion("2025-11-25");
   const dynamicRegistrationDefaults = dynamicRegistration ?? {};
@@ -568,6 +575,11 @@ export const createDebugOAuthStateMachine = (
 
   // Helper to get current state (use getState if provided, otherwise use initial state)
   const getCurrentState = () => (getState ? getState() : initialState);
+  const getResourceIndicator = () =>
+    resolveOAuthResourceIndicator(
+      serverUrl,
+      getCurrentState().resourceMetadata
+    ) ?? fallbackResourceIndicator;
 
   const executeRequest = (url: string, options: RequestInit = {}) =>
     requestExecutor({
@@ -1734,7 +1746,7 @@ export const createDebugOAuthStateMachine = (
               {
                 code_challenge: codeChallenge,
                 method: "S256",
-                resource: canonicalServerUrl,
+                resource: getResourceIndicator(),
               }
             );
 
@@ -1770,7 +1782,7 @@ export const createDebugOAuthStateMachine = (
             );
             authUrl.searchParams.set("code_challenge_method", "S256");
             authUrl.searchParams.set("state", state.state || "");
-            authUrl.searchParams.set("resource", canonicalServerUrl);
+            authUrl.searchParams.set("resource", getResourceIndicator());
 
             const requestedScopeValue = resolveRequestedScopeValue({
               customScopes,
@@ -1855,7 +1867,7 @@ export const createDebugOAuthStateMachine = (
               tokenRequestBodyObj.code_verifier = state.codeVerifier;
             }
 
-            tokenRequestBodyObj.resource = canonicalServerUrl;
+            tokenRequestBodyObj.resource = getResourceIndicator();
 
             const tokenRequest = {
               method: "POST",
@@ -1919,8 +1931,8 @@ export const createDebugOAuthStateMachine = (
                 tokenRequestBody.set("client_secret", state.clientSecret);
               }
 
-              // Add resource parameter (canonicalized per RFC 8707)
-              tokenRequestBody.set("resource", canonicalServerUrl);
+              // Add resource parameter resolved from protected-resource metadata.
+              tokenRequestBody.set("resource", getResourceIndicator());
 
               // Make the token request via backend proxy
               const response = await executeRequest(
@@ -2040,13 +2052,16 @@ export const createDebugOAuthStateMachine = (
 
                   // Check if audience claim exists and validate it
                   if (formatted.aud) {
-                    const expectedResource = state.serverUrl;
+                    const expectedResource = getResourceIndicator();
                     const audArray = Array.isArray(formatted.aud)
                       ? formatted.aud
                       : [formatted.aud];
 
                     const isValidAudience = audArray.some(
-                      (aud: string) => aud === expectedResource
+                      (aud: string) =>
+                        aud === expectedResource ||
+                        canonicalizeResourceUrl(aud) ===
+                          canonicalizeResourceUrl(expectedResource)
                     );
 
                     audienceNote._validation = {

--- a/sdk/src/oauth/state-machines/shared/urls.ts
+++ b/sdk/src/oauth/state-machines/shared/urls.ts
@@ -6,12 +6,12 @@ export function buildResourceMetadataUrl(serverUrl: string): string {
       : url.pathname;
     return new URL(
       `/.well-known/oauth-protected-resource${pathname}`,
-      url.origin,
+      url.origin
     ).toString();
   }
   return new URL(
     "/.well-known/oauth-protected-resource",
-    url.origin,
+    url.origin
   ).toString();
 }
 
@@ -30,4 +30,77 @@ export function canonicalizeResourceUrl(url: string): string {
   } catch {
     return url;
   }
+}
+
+function stripFragment(value: string): string {
+  const hashIndex = value.indexOf("#");
+  return hashIndex === -1 ? value : value.slice(0, hashIndex);
+}
+
+function normalizePathForPrefix(pathname: string): string {
+  if (pathname === "/" || pathname === "") {
+    return "/";
+  }
+
+  return pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+}
+
+export function isOAuthResourceIndicatorAllowed(input: {
+  serverUrl: string;
+  resource: string;
+}): boolean {
+  try {
+    const requested = new URL(input.serverUrl);
+    const configured = new URL(input.resource);
+
+    if (requested.origin !== configured.origin) {
+      return false;
+    }
+
+    if (configured.search && configured.search !== requested.search) {
+      return false;
+    }
+
+    const requestedPath = normalizePathForPrefix(requested.pathname);
+    const configuredPath = normalizePathForPrefix(configured.pathname);
+
+    if (configuredPath === "/") {
+      return true;
+    }
+
+    return (
+      requestedPath === configuredPath ||
+      requestedPath.startsWith(`${configuredPath}/`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function resolveOAuthResourceIndicator(
+  serverUrl: string | undefined,
+  resourceMetadata?: { resource?: string }
+): string | undefined {
+  if (!serverUrl) {
+    return undefined;
+  }
+
+  const fallback = canonicalizeResourceUrl(serverUrl);
+  const advertisedResource = resourceMetadata?.resource?.trim();
+  if (!advertisedResource) {
+    return fallback;
+  }
+
+  const resource = stripFragment(advertisedResource);
+  if (
+    !resource ||
+    !isOAuthResourceIndicatorAllowed({
+      serverUrl,
+      resource,
+    })
+  ) {
+    return fallback;
+  }
+
+  return resource;
 }

--- a/sdk/tests/oauth/state-machine-regressions.test.ts
+++ b/sdk/tests/oauth/state-machine-regressions.test.ts
@@ -121,6 +121,62 @@ describe("OAuth state machine regressions", () => {
     expect(state.isInitiatingAuth).toBe(false);
   });
 
+  it("uses the protected-resource metadata resource for 2025-11-25 resource indicators", async () => {
+    let state = {
+      ...EMPTY_OAUTH_FLOW_STATE,
+      currentStep: "received_client_credentials" as const,
+      serverUrl: SERVER_URL,
+      resourceMetadata: {
+        resource: "https://mcp.example.com",
+      },
+      authorizationServerMetadata: {
+        authorization_endpoint: "https://auth.example.com/authorize",
+        token_endpoint: "https://auth.example.com/token",
+      },
+      clientId: "client-id",
+      infoLogs: [],
+      httpHistory: [],
+    };
+
+    const machine = createOAuthStateMachine({
+      protocolVersion: "2025-11-25",
+      registrationStrategy: "dcr",
+      state,
+      getState: () => state,
+      updateState: (updates) => {
+        state = { ...state, ...updates };
+      },
+      serverUrl: SERVER_URL,
+      serverName: "Test Server",
+      redirectUrl: REDIRECT_URI,
+      requestExecutor: jest.fn(),
+      dynamicRegistration: {
+        client_name: "Test Client",
+      },
+    });
+
+    await machine.proceedToNextStep();
+    await machine.proceedToNextStep();
+
+    expect(state.currentStep).toBe("authorization_request");
+    expect(
+      new URL(state.authorizationUrl ?? "").searchParams.get("resource")
+    ).toBe("https://mcp.example.com");
+
+    state = {
+      ...state,
+      currentStep: "received_authorization_code" as const,
+      authorizationCode: "auth-code",
+    };
+
+    await machine.proceedToNextStep();
+
+    expect(state.currentStep).toBe("token_request");
+    expect((state.lastRequest?.body as Record<string, string>).resource).toBe(
+      "https://mcp.example.com"
+    );
+  });
+
   it("clears isInitiatingAuth when strict DCR fails with a transport error in 2025-11-25", async () => {
     let state = {
       ...EMPTY_OAUTH_FLOW_STATE,
@@ -235,7 +291,7 @@ describe("OAuth state machine regressions", () => {
     expect(state.currentStep).toBe("request_client_registration");
     expect(state.clientId).toBeUndefined();
     expect(state.error).toBe(
-      "Dynamic Client Registration failed (400). Configure a pre-registered client or enable DCR on the authorization server.",
+      "Dynamic Client Registration failed (400). Configure a pre-registered client or enable DCR on the authorization server."
     );
     expect(state.isInitiatingAuth).toBe(false);
   });


### PR DESCRIPTION
## Summary

- Prefer the protected-resource metadata `resource` value when the browser OAuth state machine builds authorization and token resource indicators.
- Validate advertised resource indicators before use, with same-origin and path-prefix checks, and fall back to the canonical MCP endpoint URL when invalid or absent.
- Add a regression test for `/mcp` endpoints whose protected-resource metadata advertises the origin as the OAuth resource.

## Scope

This is not implemented as a literal guest-only conditional. The failing hosted guest path goes through the browser callback/debug state-machine path (`source: callback`), while signed-in hosted workspace callbacks typically complete through the hosted server-side callback path. The fix is scoped to that browser state-machine path rather than to SDK CLI login or conformance client-credentials helpers.

## Root Cause

The browser OAuth state machine was requesting tokens with `resource=https://.../mcp`. Servers like Linear and BART advertise the protected resource as the origin, e.g. `https://mcp.linear.app` or `https://bart.vanshaj.dev`. The authorization flow could complete, but the resulting access token had the wrong resource/audience for the MCP initialize request, so servers rejected it with `401 invalid_token`.

## Validation

- `npm run test -w @mcpjam/sdk -- --run tests/oauth/state-machine-regressions.test.ts`
- `npm run typecheck -w @mcpjam/sdk`
- `git diff --check HEAD~1..HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the OAuth `resource` parameter is selected for authorization/token requests and JWT audience checks, which can affect login/token issuance behavior across servers if the new validation/fallback logic is wrong.
> 
> **Overview**
> OAuth flows now **prefer the protected-resource metadata `resource` value** when computing the RFC8707 resource indicator, rather than always using the configured MCP endpoint URL.
> 
> Adds `resolveOAuthResourceIndicator` (with fragment stripping plus same-origin and path-prefix validation) and switches both `debug-oauth-2025-06-18` and `debug-oauth-2025-11-25` state machines to use it consistently for diagram display, auth URL construction, token requests, and decoded token `aud` validation.
> 
> Adds a regression test ensuring the 2025-11-25 state machine uses the advertised metadata `resource` for both authorization and token requests (and updates an expected error string formatting).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f8d685d34c9c3e49b37bb0c010c11a44d619578. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->