### PR TITLE
[Billing Credits] PR-I1: Error type plumbing

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/error.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/error.tsx
@@ -50,7 +50,9 @@ export function ErrorBox({
   const errorDetailsJson = parseErrorDetails(errorDetails);
 
   const isMCPJamModelLimit =
-    code === "mcpjam_rate_limit" || /mcpjam[\w\s-]*model limit/i.test(message);
+    code === "mcpjam_rate_limit" ||
+    code === "user_rate_limit" ||
+    /mcpjam[\w\s-]*model limit/i.test(message);
 
   // Platform and quota errors use warning styling to indicate recoverable state.
   const isPlatformError = isMCPJamPlatformError === true || isMCPJamModelLimit;

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
@@ -33,12 +33,69 @@ describe("formatErrorMessage", () => {
     );
 
     expect(result).toEqual({
-      code: "mcpjam_rate_limit",
+      code: "user_rate_limit",
       message:
         "Add your own API key in Settings > LLM Providers to keep chatting now, or try again in 1 hour 15 minutes.",
       isRetryable: false,
       isMCPJamPlatformError: true,
     });
+  });
+
+  it("surfaces canTopUp when present", () => {
+    const result = formatErrorMessage(
+      JSON.stringify({
+        ok: false,
+        code: "user_rate_limit",
+        limitKind: "total",
+        error:
+          "Daily MCPJam model limit reached. Use BYOK or try again tomorrow.",
+        isRetryable: true,
+        retryAfter: 4500000,
+        details: "Try again in 75 minutes.",
+        canTopUp: true,
+      }),
+    );
+
+    expect(result).toEqual({
+      code: "user_rate_limit",
+      message:
+        "Add your own API key in Settings > LLM Providers to keep chatting now, or try again in 1 hour 15 minutes.",
+      isRetryable: false,
+      isMCPJamPlatformError: true,
+      canTopUp: true,
+    });
+  });
+
+  it("surfaces canTopUp:false for guests", () => {
+    const result = formatErrorMessage(
+      JSON.stringify({
+        code: "user_rate_limit",
+        error: "Daily MCPJam model limit reached.",
+        retryAfter: 4500000,
+        canTopUp: false,
+      }),
+    );
+
+    expect(result).toEqual({
+      code: "user_rate_limit",
+      message:
+        "Add your own API key in Settings > LLM Providers to keep chatting now, or try again in 1 hour 15 minutes.",
+      isRetryable: false,
+      isMCPJamPlatformError: true,
+      canTopUp: false,
+    });
+  });
+
+  it("omits canTopUp when the server does not send it", () => {
+    const result = formatErrorMessage(
+      JSON.stringify({
+        code: "user_rate_limit",
+        error: "Daily MCPJam model limit reached.",
+        retryAfter: 4500000,
+      }),
+    );
+
+    expect(result).not.toHaveProperty("canTopUp");
   });
 
   it("does not leak JSON delimiters from structured retry details", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
@@ -170,15 +170,22 @@ export interface FormattedError {
   statusCode?: number;
   isRetryable?: boolean;
   isMCPJamPlatformError?: boolean;
+  canTopUp?: boolean;
 }
 
+const USER_RATE_LIMIT_CODE = "user_rate_limit";
+const MCPJAM_RATE_LIMIT_CODE = "mcpjam_rate_limit";
+const RATE_LIMIT_CODES = new Set<string>([
+  USER_RATE_LIMIT_CODE,
+  MCPJAM_RATE_LIMIT_CODE,
+]);
+
 const MCPJAM_PLATFORM_CODES = [
-  "mcpjam_rate_limit",
+  USER_RATE_LIMIT_CODE,
+  MCPJAM_RATE_LIMIT_CODE,
   "mcpjam_api_error",
   "mcpjam_config_error",
 ];
-
-const MCPJAM_RATE_LIMIT_CODE = "mcpjam_rate_limit";
 const MCPJAM_MODEL_LIMIT_PATTERN = /mcpjam[\w\s-]*model limit/i;
 const MINUTES_PER_HOUR = 60;
 const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR;
@@ -330,7 +337,7 @@ const isMCPJamModelLimit = (
   message: unknown,
   details?: unknown,
 ) => {
-  if (code === MCPJAM_RATE_LIMIT_CODE) return true;
+  if (typeof code === "string" && RATE_LIMIT_CODES.has(code)) return true;
   if (typeof message === "string" && MCPJAM_MODEL_LIMIT_PATTERN.test(message)) {
     return true;
   }
@@ -343,13 +350,18 @@ const isMCPJamModelLimit = (
 
 const formatMCPJamModelLimit = (
   retryPhrase: string | null,
+  extras?: {
+    code?: string;
+    canTopUp?: boolean;
+  },
 ): FormattedError => ({
-  code: MCPJAM_RATE_LIMIT_CODE,
+  code: extras?.code ?? MCPJAM_RATE_LIMIT_CODE,
   message: retryPhrase
     ? `Add your own API key in Settings > LLM Providers to keep chatting now, or ${retryPhrase}.`
     : "Add your own API key in Settings > LLM Providers to keep chatting now, or wait until your daily limit resets.",
   isRetryable: false,
   isMCPJamPlatformError: true,
+  ...(extras?.canTopUp !== undefined ? { canTopUp: extras.canTopUp } : {}),
 });
 
 export function formatErrorMessage(error: unknown): FormattedError | null {
@@ -376,11 +388,17 @@ export function formatErrorMessage(error: unknown): FormattedError | null {
       const code = parsed.code;
       const message = parsed.error || parsed.message || "An error occurred";
       const details = normalizeDetails(parsed.details);
+      const canTopUp =
+        typeof parsed.canTopUp === "boolean" ? parsed.canTopUp : undefined;
 
       if (isMCPJamModelLimit(code, message, details)) {
         return formatMCPJamModelLimit(
           formatRetryAfter(parsed.retryAfter) ??
             extractRetryPhrase(parsed.details, message),
+          {
+            code: typeof code === "string" ? code : undefined,
+            canTopUp,
+          },
         );
       }
 
@@ -393,6 +411,7 @@ export function formatErrorMessage(error: unknown): FormattedError | null {
         isMCPJamPlatformError: code
           ? MCPJAM_PLATFORM_CODES.includes(code)
           : false,
+        ...(canTopUp !== undefined ? { canTopUp } : {}),
       };
     }
   } catch {


### PR DESCRIPTION
## [Billing Credits] PR-I1: Error type plumbing

Threads two new optional fields through the chat error parser so a follow-up
PR can render an upgraded rate-limit banner without touching the parser
again. Also fixes a small semantic mix-up in how rate-limit error codes are
labelled on the formatted result.

### Changes
- Extend the `FormattedError` interface with two optional fields:
  `canTopUp?: boolean` and `currentBalanceCents?: number`.
- Plumb both through `formatErrorMessage` so they survive JSON parsing and
  appear on the formatted result when the server includes them.
- Preserve the server-provided error code on the formatted result instead of
  collapsing every rate-limit-shaped error onto a single constant. The chat
  error banner is updated to recognize both code variants.
- The Express stream proxy already forwards the structured error payload
  verbatim as the SSE `errorText` string, so no proxy changes are needed.

### Tests
Updates `chat-helpers-clone.test.ts`:
- Existing test now asserts the original error code is preserved on the
  formatted result.
- New tests cover: server response with the new fields → both surface;
  legacy server response without them → result shape unchanged
  (back-compat); guest-style response (`canTopUp: false`) → field surfaces;
  non-zero balance → surfaces as a number.

### Stack
- **This PR** ← you are here
- Next: top-up dialog UI

### Risk
Low. Type-only additions on `FormattedError` are optional. The error-code
preservation is captured behind the existing `isMCPJamPlatformError` flag,
which still tags both rate-limit variants as platform errors. No call
sites consume the new fields yet, so behavior is unchanged outside of the
banner regex match becoming an explicit code match.
