### PR TITLE
[Billing Credits] PR-I3: Credit usage card

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -32,7 +32,7 @@ import { AuthTab } from "./components/AuthTab";
 import { OAuthFlowTab } from "./components/OAuthFlowTab";
 import { ConformanceTab } from "./components/conformance/ConformancePanel";
 import { XAAFlowTab } from "./components/xaa/XAAFlowTab";
-import { ErrorBoundary } from "./components/evals/ErrorBoundary";
+import { ErrorBoundary } from "./components/ui/error-boundary";
 import { AppBuilderTab } from "./components/ui-playground/AppBuilderTab";
 import { EmptyState } from "./components/ui/empty-state";
 import { isFirstRunEligible } from "./lib/onboarding-state";

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -44,7 +44,9 @@ import {
   detectPlatform,
   standardEventProps,
 } from "@/lib/PosthogUtils";
-import { ErrorBox } from "@/components/chat-v2/error";
+import { CreditTopupDialog } from "@/components/billing/CreditTopupDialog";
+import { TopupGatedErrorBox } from "@/components/billing/TopupGatedErrorBox";
+import { useCreditTopupReturnFlow } from "@/hooks/useCreditTopupReturnFlow";
 import { StickToBottom } from "use-stick-to-bottom";
 import { type MCPPromptResult } from "@/components/chat-v2/chat-input/prompts/mcp-prompts-popover";
 import type { SkillResult } from "@/components/chat-v2/chat-input/skills/skill-types";
@@ -1591,6 +1593,45 @@ export function ChatTabV2({
   const showDisabledCallout = !effectiveHasMessages && shouldShowUpsell;
 
   const errorMessage = formatErrorMessage(error);
+
+  const [isTopupDialogOpen, setIsTopupDialogOpen] = useState(false);
+  const [pendingResendMessage, setPendingResendMessage] = useState("");
+
+  // Capture the most-recent user-typed message text at the moment it's
+  // sent, not by walking `messages` later. This avoids any per-render
+  // work in the chat hot path — the value is only updated in event
+  // handlers (which run after commit), so it's safe to read in the
+  // click handler below.
+  const lastSentUserMessageRef = useRef("");
+
+  const canShowTopupCta =
+    isConvexAuthenticated &&
+    errorMessage?.canTopUp === true &&
+    errorMessage?.code === "user_rate_limit";
+
+  const handleOpenTopupDialog = useCallback(() => {
+    const text = lastSentUserMessageRef.current;
+    if (!text) {
+      // Nothing to resend — no-op rather than opening a dialog that
+      // would carry an empty message into checkout.
+      return;
+    }
+    posthog.capture("credit_topup_cta_clicked", { source: "chat_banner" });
+    setPendingResendMessage(text);
+    setIsTopupDialogOpen(true);
+  }, [posthog]);
+
+  const handleTopupDialogOpenChange = useCallback((open: boolean) => {
+    setIsTopupDialogOpen(open);
+    if (!open) {
+      // Clear the snapshot when the dialog closes so we don't keep a
+      // stale message lingering in state until the next click.
+      setPendingResendMessage("");
+    }
+  }, []);
+
+  useCreditTopupReturnFlow({ chatSessionId, sendMessage });
+
   const traceViewerTrace = liveTraceEnvelope ?? {
     traceVersion: 1 as const,
     messages: [],
@@ -1823,6 +1864,7 @@ export function ChatTabV2({
           multi_model_count: 1,
           single_model_send: true,
         });
+        lastSentUserMessageRef.current = input;
         sendMessage({ text: input, files });
         setModelContextQueue([]);
       }
@@ -1865,6 +1907,7 @@ export function ChatTabV2({
         multi_model_count: 1,
         single_model_send: true,
       });
+      lastSentUserMessageRef.current = prompt;
       sendMessage({ text: prompt });
     }
     setInput("");
@@ -2042,7 +2085,7 @@ export function ChatTabV2({
                     errorFooterSlot={
                       errorMessage ? (
                         <div className="max-w-4xl mx-auto px-4 pt-4">
-                          <ErrorBox
+                          <TopupGatedErrorBox
                             message={errorMessage.message}
                             errorDetails={errorMessage.details}
                             code={errorMessage.code}
@@ -2051,6 +2094,8 @@ export function ChatTabV2({
                             isMCPJamPlatformError={
                               errorMessage.isMCPJamPlatformError
                             }
+                            canTopUp={canShowTopupCta}
+                            onTopUp={handleOpenTopupDialog}
                             onResetChat={handleResetAllChats}
                           />
                         </div>
@@ -2270,7 +2315,7 @@ export function ChatTabV2({
                       <div className="bg-background/80 backdrop-blur-sm border-t border-border flex-shrink-0">
                         {errorMessage && (
                           <div className="max-w-4xl mx-auto px-4 pt-4">
-                            <ErrorBox
+                            <TopupGatedErrorBox
                               message={errorMessage.message}
                               errorDetails={errorMessage.details}
                               code={errorMessage.code}
@@ -2279,6 +2324,8 @@ export function ChatTabV2({
                               isMCPJamPlatformError={
                                 errorMessage.isMCPJamPlatformError
                               }
+                              canTopUp={canShowTopupCta}
+                              onTopUp={handleOpenTopupDialog}
                               onResetChat={baseResetChat}
                             />
                           </div>
@@ -2308,9 +2355,10 @@ export function ChatTabV2({
                       <StickToBottom.Content className="flex flex-col min-h-0">
                         <Thread
                           messages={messages}
-                          sendFollowUpMessage={(text: string) =>
-                            sendMessage({ text })
-                          }
+                          sendFollowUpMessage={(text: string) => {
+                            lastSentUserMessageRef.current = text;
+                            sendMessage({ text });
+                          }}
                           model={selectedModel}
                           isLoading={isStreaming}
                           toolsMetadata={toolsMetadata}
@@ -2336,7 +2384,7 @@ export function ChatTabV2({
                     <div className="bg-background/80 backdrop-blur-sm border-t border-border flex-shrink-0">
                       {errorMessage && (
                         <div className="max-w-4xl mx-auto px-4 pt-4">
-                          <ErrorBox
+                          <TopupGatedErrorBox
                             message={errorMessage.message}
                             errorDetails={errorMessage.details}
                             code={errorMessage.code}
@@ -2345,6 +2393,8 @@ export function ChatTabV2({
                             isMCPJamPlatformError={
                               errorMessage.isMCPJamPlatformError
                             }
+                            canTopUp={canShowTopupCta}
+                            onTopUp={handleOpenTopupDialog}
                             onResetChat={baseResetChat}
                           />
                         </div>
@@ -2559,6 +2609,15 @@ export function ChatTabV2({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+      {isTopupDialogOpen && (
+        <CreditTopupDialog
+          open
+          onOpenChange={handleTopupDialogOpenChange}
+          chatSessionId={chatSessionId}
+          lastUserMessage={pendingResendMessage}
+          source="chat_banner"
+        />
+      )}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
@@ -279,6 +279,7 @@ vi.mock("@workos-inc/authkit-react", () => ({
 
 vi.mock("convex/react", () => ({
   useConvexAuth: (...args: unknown[]) => mockUseConvexAuth(...args),
+  useQuery: () => undefined,
 }));
 
 vi.mock("posthog-js/react", () => ({

--- a/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
@@ -1,0 +1,140 @@
+import { useState } from "react";
+import { Card, CardContent } from "@mcpjam/design-system/card";
+import { Progress } from "@mcpjam/design-system/progress";
+import { Skeleton } from "@mcpjam/design-system/skeleton";
+import { CreditTopupDialog } from "@/components/billing/CreditTopupDialog";
+import { TopupActionButton } from "@/components/billing/TopupActionButton";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { useCreditBalance } from "@/hooks/useCreditBalance";
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+const formatResetText = (resetAt: number): string => {
+  if (!resetAt || !Number.isFinite(resetAt)) return "resets daily";
+  const diffMs = resetAt - Date.now();
+  if (diffMs <= 0) return "resets shortly";
+  if (diffMs < MS_PER_HOUR) {
+    const minutes = Math.max(1, Math.round(diffMs / 60000));
+    return `resets in ${minutes}m`;
+  }
+  if (diffMs < MS_PER_DAY) {
+    const hours = Math.max(1, Math.round(diffMs / MS_PER_HOUR));
+    return `resets in ${hours}h`;
+  }
+  return "resets tomorrow";
+};
+
+interface CreditBalanceCardProps {
+  /** Optional override for the chat session id used by the top-up flow. */
+  chatSessionId?: string;
+}
+
+export function CreditBalanceCard({
+  chatSessionId,
+}: CreditBalanceCardProps = {}) {
+  const { balance, isLoading } = useCreditBalance();
+  const [isTopupOpen, setIsTopupOpen] = useState(false);
+
+  const hasPaidHistory = balance?.hasPurchaseHistory === true;
+  const paidPercentUsed =
+    balance?.paidPercentRemaining != null
+      ? 100 - balance.paidPercentRemaining
+      : 0;
+
+  return (
+    <Card className="border-border/60 py-6 shadow-sm">
+      <CardContent className="flex flex-col gap-5 px-4 sm:px-6">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-primary">
+              Credit usage
+            </p>
+            <p className="mt-1 text-sm font-semibold leading-snug">
+              Your model credits
+            </p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              Credits are linked to your user, not the organization.
+            </p>
+          </div>
+          <ErrorBoundary fallback={null}>
+            <TopupActionButton onClick={() => setIsTopupOpen(true)} />
+          </ErrorBoundary>
+        </div>
+
+        <UsageRow
+          label="Daily limit"
+          rightText={
+            isLoading || !balance
+              ? null
+              : `${Math.round(balance.freeDailyPercentUsed)}% used · ${formatResetText(balance.freeDailyResetAt)}`
+          }
+          fillPercent={
+            isLoading || !balance ? 0 : balance.freeDailyPercentUsed
+          }
+          isLoading={isLoading}
+          testId="usage-daily"
+        />
+
+        {!isLoading && hasPaidHistory && balance && (
+          <UsageRow
+            label="Paid credits"
+            rightText={
+              balance.paidPercentRemaining != null
+                ? `${Math.round(100 - balance.paidPercentRemaining)}% used`
+                : null
+            }
+            fillPercent={paidPercentUsed}
+            isLoading={false}
+            testId="usage-paid"
+          />
+        )}
+      </CardContent>
+      {isTopupOpen && (
+        <CreditTopupDialog
+          open
+          onOpenChange={setIsTopupOpen}
+          chatSessionId={chatSessionId ?? ""}
+          lastUserMessage=""
+          source="billing_page"
+        />
+      )}
+    </Card>
+  );
+}
+
+interface UsageRowProps {
+  label: string;
+  rightText: string | null;
+  fillPercent: number;
+  isLoading: boolean;
+  testId?: string;
+}
+
+function UsageRow({
+  label,
+  rightText,
+  fillPercent,
+  isLoading,
+  testId,
+}: UsageRowProps) {
+  return (
+    <div className="flex flex-col gap-2" data-testid={testId}>
+      <div className="flex items-center justify-between text-xs">
+        <span className="font-medium">{label}</span>
+        <span className="text-muted-foreground">
+          {isLoading || rightText == null ? (
+            <Skeleton className="h-3 w-24" />
+          ) : (
+            rightText
+          )}
+        </span>
+      </div>
+      {isLoading ? (
+        <Skeleton className="h-2 w-full rounded-full" />
+      ) : (
+        <Progress value={fillPercent} />
+      )}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { cn } from "@/lib/utils";
+import {
+  useCreditTopup,
+  type CreditTopupPreset,
+  type CreditTopupSource,
+} from "@/hooks/useCreditTopup";
+
+interface CreditTopupDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  chatSessionId: string;
+  lastUserMessage: string;
+  /** Surface the user came from. Forwarded to telemetry events. */
+  source: CreditTopupSource;
+}
+
+export function CreditTopupDialog({
+  open,
+  onOpenChange,
+  chatSessionId,
+  lastUserMessage,
+  source,
+}: CreditTopupDialogProps) {
+  const { presets, presetsLoading, startCheckout, isStartingCheckout } =
+    useCreditTopup();
+  const [selectedAmountCents, setSelectedAmountCents] = useState<number | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedAmountCents(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (open && presets && selectedAmountCents === null) {
+      setSelectedAmountCents(presets[0]?.amountCents ?? null);
+    }
+  }, [open, presets, selectedAmountCents]);
+
+  const selectedPreset: CreditTopupPreset | undefined = presets?.find(
+    (preset) => preset.amountCents === selectedAmountCents,
+  );
+
+  const handleConfirm = async () => {
+    if (!selectedPreset) return;
+    try {
+      await startCheckout({
+        amountCents: selectedPreset.amountCents,
+        chatSessionId,
+        lastUserMessage,
+        source,
+      });
+    } catch (err) {
+      const message =
+        err instanceof Error
+          ? err.message
+          : "Could not start checkout. Please try again.";
+      toast.error(message);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Top up to keep chatting</DialogTitle>
+          <DialogDescription>
+            Add credit to your account so you can keep using MCPJam models
+            without waiting for your daily limit to reset.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-4">
+          {presetsLoading ? (
+            <div className="text-sm text-muted-foreground">
+              Loading amounts…
+            </div>
+          ) : !presets || presets.length === 0 ? (
+            <div className="text-sm text-muted-foreground">
+              Top-up amounts are unavailable right now. Please try again later.
+            </div>
+          ) : (
+            <div className="grid grid-cols-3 gap-2" role="radiogroup">
+              {presets.map((preset) => {
+                const isSelected = preset.amountCents === selectedAmountCents;
+                return (
+                  <button
+                    key={preset.amountCents}
+                    type="button"
+                    role="radio"
+                    aria-checked={isSelected}
+                    onClick={() => setSelectedAmountCents(preset.amountCents)}
+                    className={cn(
+                      "flex flex-col items-center justify-center rounded-md border px-3 py-3 text-sm font-medium transition-colors",
+                      isSelected
+                        ? "border-primary bg-primary/10 text-foreground"
+                        : "border-border hover:border-foreground/40",
+                    )}
+                  >
+                    <span className="text-base">{preset.amountUsd}</span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+          {selectedPreset && (
+            <p className="text-xs text-muted-foreground">
+              A portion of your payment covers payment processing and platform
+              fees; the rest is added to your account balance.
+            </p>
+          )}
+        </div>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isStartingCheckout}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!selectedPreset || isStartingCheckout}
+          >
+            {isStartingCheckout
+              ? "Redirecting…"
+              : selectedPreset
+                ? `Continue with ${selectedPreset.amountUsd}`
+                : "Continue"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/TopupActionButton.tsx
+++ b/mcpjam-inspector/client/src/components/billing/TopupActionButton.tsx
@@ -1,0 +1,26 @@
+import { Button } from "@mcpjam/design-system/button";
+import { useCreditTopupPresets } from "@/hooks/useCreditTopup";
+
+interface TopupActionButtonProps {
+  onClick: () => void;
+}
+
+/**
+ * Renders the "Top up" button only when the topup preset endpoint has
+ * resolved with at least one preset. Avoids the dead-end UX where clicking
+ * the button opens a dialog that immediately shows "Top-up amounts are
+ * unavailable right now" because the backend is missing the function.
+ *
+ * Wrap this in an `<ErrorBoundary fallback={null}>` at the call site so a
+ * thrown query (e.g. function not deployed) collapses to nothing instead of
+ * surfacing a generic error UI.
+ */
+export function TopupActionButton({ onClick }: TopupActionButtonProps) {
+  const { presets } = useCreditTopupPresets();
+  if (!presets || presets.length === 0) return null;
+  return (
+    <Button type="button" size="sm" onClick={onClick}>
+      Top up
+    </Button>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/TopupGatedErrorBox.tsx
+++ b/mcpjam-inspector/client/src/components/billing/TopupGatedErrorBox.tsx
@@ -1,0 +1,32 @@
+import type { ComponentProps } from "react";
+
+import { ErrorBox } from "@/components/chat-v2/error";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { useCreditTopupPresets } from "@/hooks/useCreditTopup";
+
+type ErrorBoxProps = ComponentProps<typeof ErrorBox>;
+
+function GatedInner({ canTopUp, onTopUp, ...rest }: ErrorBoxProps) {
+  const { presets } = useCreditTopupPresets({ skip: canTopUp !== true });
+  const hasPresets = (presets?.length ?? 0) > 0;
+  const showCta = canTopUp === true && hasPresets;
+  return (
+    <ErrorBox
+      {...rest}
+      canTopUp={showCta}
+      onTopUp={showCta ? onTopUp : undefined}
+    />
+  );
+}
+
+export function TopupGatedErrorBox(props: ErrorBoxProps) {
+  const plainErrorBox = (
+    <ErrorBox {...props} canTopUp={false} onTopUp={undefined} />
+  );
+  if (props.canTopUp !== true) return plainErrorBox;
+  return (
+    <ErrorBoundary fallback={plainErrorBox}>
+      <GatedInner {...props} />
+    </ErrorBoundary>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CreditBalanceCard } from "../CreditBalanceCard";
+
+let balanceState:
+  | {
+      paidPercentRemaining: number | null;
+      hasPurchaseHistory: boolean;
+      freeDailyPercentUsed: number;
+      freeDailyResetAt: number;
+    }
+  | undefined = undefined;
+let isLoadingState = false;
+
+vi.mock("@/hooks/useCreditBalance", () => ({
+  useCreditBalance: () => ({
+    balance: balanceState,
+    isLoading: isLoadingState,
+  }),
+}));
+
+vi.mock("@/components/billing/CreditTopupDialog", () => ({
+  CreditTopupDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="topup-dialog" /> : null,
+}));
+
+// Stub the gated button so existing tests don't need to set up the preset
+// query. The button's gating logic is covered by TopupActionButton.test.tsx.
+vi.mock("@/components/billing/TopupActionButton", () => ({
+  TopupActionButton: ({ onClick }: { onClick: () => void }) => (
+    <button type="button" onClick={onClick}>
+      Top up
+    </button>
+  ),
+}));
+
+describe("CreditBalanceCard", () => {
+  beforeEach(() => {
+    balanceState = {
+      paidPercentRemaining: null,
+      hasPurchaseHistory: false,
+      freeDailyPercentUsed: 0,
+      freeDailyResetAt: Date.now() + 11 * 60 * 60 * 1000,
+    };
+    isLoadingState = false;
+  });
+
+  it("renders a skeleton state while balance is loading", () => {
+    isLoadingState = true;
+    balanceState = undefined;
+    render(<CreditBalanceCard />);
+
+    const dailyRow = screen.getByTestId("usage-daily");
+    expect(dailyRow).toBeInTheDocument();
+    expect(screen.queryByTestId("usage-paid")).not.toBeInTheDocument();
+  });
+
+  it("renders the daily-limit row without surfacing any dollar value", () => {
+    balanceState = {
+      paidPercentRemaining: null,
+      hasPurchaseHistory: false,
+      freeDailyPercentUsed: 9,
+      freeDailyResetAt: Date.now() + 11 * 60 * 60 * 1000,
+    };
+    render(<CreditBalanceCard />);
+
+    const dailyRow = screen.getByTestId("usage-daily");
+    expect(dailyRow).toHaveTextContent(/9% used/);
+    expect(dailyRow).toHaveTextContent(/resets/);
+    // Regression guard: free credit dollar value must never appear.
+    expect(dailyRow.textContent ?? "").not.toMatch(/\$/);
+  });
+
+  it("hides the paid-credits row when the user has never topped up", () => {
+    render(<CreditBalanceCard />);
+    expect(screen.queryByTestId("usage-paid")).not.toBeInTheDocument();
+  });
+
+  it("renders the paid-credits row as a bare percent, with no dollar value", () => {
+    // 32% remaining = 68% used. The bar's right-text is "X% used".
+    balanceState = {
+      paidPercentRemaining: 32,
+      hasPurchaseHistory: true,
+      freeDailyPercentUsed: 100,
+      freeDailyResetAt: Date.now() + 60 * 60 * 1000,
+    };
+    render(<CreditBalanceCard />);
+
+    const paidRow = screen.getByTestId("usage-paid");
+    expect(paidRow).toHaveTextContent(/68% used/);
+    // Regression guard: the paid-credits row must NEVER surface a dollar
+    // amount. Pairing a $ with a percent invites the user to compute a
+    // wrong remaining-dollars value, and any credited-domain dollar
+    // exposes the take rate when the user knows what they paid.
+    expect(paidRow.textContent ?? "").not.toMatch(/\$/);
+  });
+
+  it("opens the top-up dialog when the Top up button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<CreditBalanceCard />);
+
+    expect(screen.queryByTestId("topup-dialog")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Top up/i }));
+    expect(screen.getByTestId("topup-dialog")).toBeInTheDocument();
+  });
+
+  it("clarifies that credits are user-scoped, not org-scoped", () => {
+    render(<CreditBalanceCard />);
+    expect(screen.getByText(/Your model credits/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Credits are linked to your user, not the organization/),
+    ).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { CreditTopupDialog } from "../CreditTopupDialog";
+
+const startCheckoutMock = vi.fn();
+
+let presetsState: Array<{
+  amountCents: number;
+  amountUsd: string;
+}> | undefined = undefined;
+let presetsLoadingState = false;
+let isStartingCheckoutState = false;
+
+vi.mock("@/hooks/useCreditTopup", () => ({
+  useCreditTopup: () => ({
+    presets: presetsState,
+    presetsLoading: presetsLoadingState,
+    startCheckout: startCheckoutMock,
+    isStartingCheckout: isStartingCheckoutState,
+    error: null,
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+const DEFAULT_PRESETS = [
+  { amountCents: 500, amountUsd: "$5" },
+  { amountCents: 1000, amountUsd: "$10" },
+  { amountCents: 2000, amountUsd: "$20" },
+];
+
+describe("CreditTopupDialog", () => {
+  beforeEach(() => {
+    startCheckoutMock.mockReset();
+    presetsState = DEFAULT_PRESETS;
+    presetsLoadingState = false;
+    isStartingCheckoutState = false;
+  });
+
+  it("renders three preset chips with the correct labels", () => {
+    render(
+      <CreditTopupDialog
+        open
+        onOpenChange={vi.fn()}
+        chatSessionId="chat-1"
+        lastUserMessage="hello"
+        source="chat_banner"
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: "$5" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "$10" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "$20" })).toBeInTheDocument();
+  });
+
+  it("auto-selects the first preset and shows the fee copy without dollar amounts", () => {
+    render(
+      <CreditTopupDialog
+        open
+        onOpenChange={vi.fn()}
+        chatSessionId="chat-1"
+        lastUserMessage="hello"
+        source="chat_banner"
+      />,
+    );
+
+    expect(screen.getByRole("radio", { name: "$5" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
+    expect(
+      screen.getByText(
+        /A portion of your payment covers payment processing and platform fees/,
+      ),
+    ).toBeInTheDocument();
+    // Guard against regressions that surface a "credited" / "you'll receive
+    // $X.XX" dollar value (which would leak the take rate).
+    expect(screen.queryByText(/You'll receive \$/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/in model credit/)).not.toBeInTheDocument();
+  });
+
+  it("calls startCheckout with the selected amount and chat context", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreditTopupDialog
+        open
+        onOpenChange={vi.fn()}
+        chatSessionId="chat-1"
+        lastUserMessage="please continue"
+        source="chat_banner"
+      />,
+    );
+
+    await user.click(screen.getByRole("radio", { name: "$10" }));
+    await user.click(
+      screen.getByRole("button", { name: /Continue with \$10/ }),
+    );
+
+    expect(startCheckoutMock).toHaveBeenCalledTimes(1);
+    expect(startCheckoutMock).toHaveBeenCalledWith({
+      amountCents: 1000,
+      chatSessionId: "chat-1",
+      lastUserMessage: "please continue",
+      source: "chat_banner",
+    });
+  });
+
+  it("calls onOpenChange(false) when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <CreditTopupDialog
+        open
+        onOpenChange={onOpenChange}
+        chatSessionId="chat-1"
+        lastUserMessage="hello"
+        source="chat_banner"
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("shows a loading message while presets are fetching", () => {
+    presetsState = undefined;
+    presetsLoadingState = true;
+    render(
+      <CreditTopupDialog
+        open
+        onOpenChange={vi.fn()}
+        chatSessionId="chat-1"
+        lastUserMessage="hello"
+        source="chat_banner"
+      />,
+    );
+
+    expect(screen.getByText(/Loading amounts/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("radio", { name: "$5" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the unavailable message when no presets are returned", () => {
+    presetsState = undefined;
+    presetsLoadingState = false;
+    render(
+      <CreditTopupDialog
+        open
+        onOpenChange={vi.fn()}
+        chatSessionId="chat-1"
+        lastUserMessage="hello"
+        source="chat_banner"
+      />,
+    );
+
+    expect(
+      screen.getByText(/Top-up amounts are unavailable/),
+    ).toBeInTheDocument();
+  });
+
+  it("disables both buttons while a checkout is in flight", () => {
+    isStartingCheckoutState = true;
+    render(
+      <CreditTopupDialog
+        open
+        onOpenChange={vi.fn()}
+        chatSessionId="chat-1"
+        lastUserMessage="hello"
+        source="chat_banner"
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /Redirecting/ }),
+    ).toBeDisabled();
+  });
+});

--- a/mcpjam-inspector/client/src/components/billing/__tests__/TopupActionButton.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/TopupActionButton.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { TopupActionButton } from "../TopupActionButton";
+
+let presetsState: Array<{ amountCents: number; amountUsd: string }> | undefined;
+
+vi.mock("@/hooks/useCreditTopup", () => ({
+  useCreditTopupPresets: () => ({
+    presets: presetsState,
+    isLoading: presetsState === undefined,
+  }),
+}));
+
+describe("TopupActionButton", () => {
+  beforeEach(() => {
+    presetsState = [
+      { amountCents: 500, amountUsd: "$5" },
+      { amountCents: 1000, amountUsd: "$10" },
+      { amountCents: 2000, amountUsd: "$20" },
+    ];
+  });
+
+  it("renders the Top up button when presets are available", () => {
+    render(<TopupActionButton onClick={vi.fn()} />);
+    expect(screen.getByRole("button", { name: "Top up" })).toBeInTheDocument();
+  });
+
+  it("renders nothing while presets are loading", () => {
+    presetsState = undefined;
+    const { container } = render(<TopupActionButton onClick={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when presets resolve to an empty list", () => {
+    presetsState = [];
+    const { container } = render(<TopupActionButton onClick={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("calls onClick when the button is clicked", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(<TopupActionButton onClick={onClick} />);
+    await user.click(screen.getByRole("button", { name: "Top up" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/client/src/components/billing/__tests__/TopupGatedErrorBox.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/TopupGatedErrorBox.test.tsx
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { TopupGatedErrorBox } from "../TopupGatedErrorBox";
+
+let presetsState: Array<{ amountCents: number; amountUsd: string }> | undefined;
+let presetsLoadingState: boolean;
+let presetQueryShouldThrow = false;
+
+vi.mock("@/hooks/useCreditTopup", () => ({
+  useCreditTopupPresets: ({ skip }: { skip?: boolean } = {}) => {
+    if (skip) {
+      return { presets: undefined, isLoading: false };
+    }
+    if (presetQueryShouldThrow) {
+      throw new Error(
+        "Could not find public function for 'billing:getCreditTopupPresets'",
+      );
+    }
+    return { presets: presetsState, isLoading: presetsLoadingState };
+  },
+}));
+
+const RATE_LIMIT_PROPS = {
+  message: "Daily MCPJam model limit reached.",
+  code: "user_rate_limit",
+  isRetryable: false,
+  isMCPJamPlatformError: true,
+  onResetChat: () => {},
+};
+
+describe("TopupGatedErrorBox", () => {
+  beforeEach(() => {
+    presetsState = [
+      { amountCents: 500, amountUsd: "$5" },
+      { amountCents: 1000, amountUsd: "$10" },
+      { amountCents: 2000, amountUsd: "$20" },
+    ];
+    presetsLoadingState = false;
+    presetQueryShouldThrow = false;
+  });
+
+  it("does not render the Top up CTA when canTopUp is false", () => {
+    render(
+      <TopupGatedErrorBox
+        {...RATE_LIMIT_PROPS}
+        canTopUp={false}
+        onTopUp={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /Top up to keep chatting/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the Top up CTA when canTopUp is true and presets are available", () => {
+    render(
+      <TopupGatedErrorBox
+        {...RATE_LIMIT_PROPS}
+        canTopUp
+        onTopUp={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByRole("button", { name: /Top up to keep chatting/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the Top up CTA when canTopUp is true but presets are empty", () => {
+    presetsState = [];
+    render(
+      <TopupGatedErrorBox
+        {...RATE_LIMIT_PROPS}
+        canTopUp
+        onTopUp={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /Top up to keep chatting/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the Top up CTA while presets are still loading", () => {
+    presetsState = undefined;
+    presetsLoadingState = true;
+    render(
+      <TopupGatedErrorBox
+        {...RATE_LIMIT_PROPS}
+        canTopUp
+        onTopUp={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /Top up to keep chatting/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to a plain ErrorBox when the preset query throws", () => {
+    presetQueryShouldThrow = true;
+    // Suppress React's expected error log noise from the boundary catch.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <TopupGatedErrorBox
+        {...RATE_LIMIT_PROPS}
+        canTopUp
+        onTopUp={vi.fn()}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", { name: /Top up to keep chatting/ }),
+    ).not.toBeInTheDocument();
+    // The rate-limit copy is still rendered so the user understands what
+    // happened. ("Daily MCPJam model limit reached" appears in both the
+    // header label and the message body, so use getAllByText.)
+    expect(
+      screen.getAllByText(/Daily MCPJam model limit reached/).length,
+    ).toBeGreaterThanOrEqual(1);
+    errorSpy.mockRestore();
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/error.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/error.tsx
@@ -24,6 +24,8 @@ interface ErrorBoxProps {
   isRetryable?: boolean;
   isMCPJamPlatformError?: boolean;
   onRetry?: () => void;
+  canTopUp?: boolean;
+  onTopUp?: () => void;
 }
 
 const parseErrorDetails = (details: string | undefined) => {
@@ -45,6 +47,8 @@ export function ErrorBox({
   isRetryable,
   isMCPJamPlatformError,
   onRetry,
+  canTopUp,
+  onTopUp,
 }: ErrorBoxProps) {
   const [isErrorDetailsOpen, setIsErrorDetailsOpen] = useState(false);
   const errorDetailsJson = parseErrorDetails(errorDetails);
@@ -114,6 +118,11 @@ export function ErrorBox({
           )}
         </div>
         <div className="ml-auto flex flex-shrink-0 flex-wrap items-center gap-2">
+          {canTopUp && onTopUp && (
+            <Button type="button" onClick={onTopUp}>
+              Top up to keep chatting
+            </Button>
+          )}
           {isRetryable && onRetry && (
             <Button
               type="button"

--- a/mcpjam-inspector/client/src/components/chat-v2/error.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/error.tsx
@@ -50,7 +50,9 @@ export function ErrorBox({
   const errorDetailsJson = parseErrorDetails(errorDetails);
 
   const isMCPJamModelLimit =
-    code === "mcpjam_rate_limit" || /mcpjam[\w\s-]*model limit/i.test(message);
+    code === "mcpjam_rate_limit" ||
+    code === "user_rate_limit" ||
+    /mcpjam[\w\s-]*model limit/i.test(message);
 
   // Platform and quota errors use warning styling to indicate recoverable state.
   const isPlatformError = isMCPJamPlatformError === true || isMCPJamModelLimit;

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
@@ -33,12 +33,69 @@ describe("formatErrorMessage", () => {
     );
 
     expect(result).toEqual({
-      code: "mcpjam_rate_limit",
+      code: "user_rate_limit",
       message:
         "Add your own API key in Settings > LLM Providers to keep chatting now, or try again in 1 hour 15 minutes.",
       isRetryable: false,
       isMCPJamPlatformError: true,
     });
+  });
+
+  it("surfaces canTopUp when present", () => {
+    const result = formatErrorMessage(
+      JSON.stringify({
+        ok: false,
+        code: "user_rate_limit",
+        limitKind: "total",
+        error:
+          "Daily MCPJam model limit reached. Use BYOK or try again tomorrow.",
+        isRetryable: true,
+        retryAfter: 4500000,
+        details: "Try again in 75 minutes.",
+        canTopUp: true,
+      }),
+    );
+
+    expect(result).toEqual({
+      code: "user_rate_limit",
+      message:
+        "Add your own API key in Settings > LLM Providers to keep chatting now, or try again in 1 hour 15 minutes.",
+      isRetryable: false,
+      isMCPJamPlatformError: true,
+      canTopUp: true,
+    });
+  });
+
+  it("surfaces canTopUp:false for guests", () => {
+    const result = formatErrorMessage(
+      JSON.stringify({
+        code: "user_rate_limit",
+        error: "Daily MCPJam model limit reached.",
+        retryAfter: 4500000,
+        canTopUp: false,
+      }),
+    );
+
+    expect(result).toEqual({
+      code: "user_rate_limit",
+      message:
+        "Add your own API key in Settings > LLM Providers to keep chatting now, or try again in 1 hour 15 minutes.",
+      isRetryable: false,
+      isMCPJamPlatformError: true,
+      canTopUp: false,
+    });
+  });
+
+  it("omits canTopUp when the server does not send it", () => {
+    const result = formatErrorMessage(
+      JSON.stringify({
+        code: "user_rate_limit",
+        error: "Daily MCPJam model limit reached.",
+        retryAfter: 4500000,
+      }),
+    );
+
+    expect(result).not.toHaveProperty("canTopUp");
   });
 
   it("does not leak JSON delimiters from structured retry details", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
@@ -170,15 +170,22 @@ export interface FormattedError {
   statusCode?: number;
   isRetryable?: boolean;
   isMCPJamPlatformError?: boolean;
+  canTopUp?: boolean;
 }
 
+const USER_RATE_LIMIT_CODE = "user_rate_limit";
+const MCPJAM_RATE_LIMIT_CODE = "mcpjam_rate_limit";
+const RATE_LIMIT_CODES = new Set<string>([
+  USER_RATE_LIMIT_CODE,
+  MCPJAM_RATE_LIMIT_CODE,
+]);
+
 const MCPJAM_PLATFORM_CODES = [
-  "mcpjam_rate_limit",
+  USER_RATE_LIMIT_CODE,
+  MCPJAM_RATE_LIMIT_CODE,
   "mcpjam_api_error",
   "mcpjam_config_error",
 ];
-
-const MCPJAM_RATE_LIMIT_CODE = "mcpjam_rate_limit";
 const MCPJAM_MODEL_LIMIT_PATTERN = /mcpjam[\w\s-]*model limit/i;
 const MINUTES_PER_HOUR = 60;
 const MINUTES_PER_DAY = 24 * MINUTES_PER_HOUR;
@@ -330,7 +337,7 @@ const isMCPJamModelLimit = (
   message: unknown,
   details?: unknown,
 ) => {
-  if (code === MCPJAM_RATE_LIMIT_CODE) return true;
+  if (typeof code === "string" && RATE_LIMIT_CODES.has(code)) return true;
   if (typeof message === "string" && MCPJAM_MODEL_LIMIT_PATTERN.test(message)) {
     return true;
   }
@@ -343,13 +350,18 @@ const isMCPJamModelLimit = (
 
 const formatMCPJamModelLimit = (
   retryPhrase: string | null,
+  extras?: {
+    code?: string;
+    canTopUp?: boolean;
+  },
 ): FormattedError => ({
-  code: MCPJAM_RATE_LIMIT_CODE,
+  code: extras?.code ?? MCPJAM_RATE_LIMIT_CODE,
   message: retryPhrase
     ? `Add your own API key in Settings > LLM Providers to keep chatting now, or ${retryPhrase}.`
     : "Add your own API key in Settings > LLM Providers to keep chatting now, or wait until your daily limit resets.",
   isRetryable: false,
   isMCPJamPlatformError: true,
+  ...(extras?.canTopUp !== undefined ? { canTopUp: extras.canTopUp } : {}),
 });
 
 export function formatErrorMessage(error: unknown): FormattedError | null {
@@ -376,11 +388,17 @@ export function formatErrorMessage(error: unknown): FormattedError | null {
       const code = parsed.code;
       const message = parsed.error || parsed.message || "An error occurred";
       const details = normalizeDetails(parsed.details);
+      const canTopUp =
+        typeof parsed.canTopUp === "boolean" ? parsed.canTopUp : undefined;
 
       if (isMCPJamModelLimit(code, message, details)) {
         return formatMCPJamModelLimit(
           formatRetryAfter(parsed.retryAfter) ??
             extractRetryPhrase(parsed.details, message),
+          {
+            code: typeof code === "string" ? code : undefined,
+            canTopUp,
+          },
         );
       }
 
@@ -393,6 +411,7 @@ export function formatErrorMessage(error: unknown): FormattedError | null {
         isMCPJamPlatformError: code
           ? MCPJAM_PLATFORM_CODES.includes(code)
           : false,
+        ...(canTopUp !== undefined ? { canTopUp } : {}),
       };
     }
   } catch {

--- a/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
@@ -40,6 +40,8 @@ import {
 import { cn } from "@/lib/utils";
 import { buildComparePlanSectionsFromCatalog } from "@/components/organization/billing-compare-view-model";
 import { type ComparePlanCell } from "@/components/organization/compare-plan-marketing";
+import { CreditBalanceCard } from "@/components/billing/CreditBalanceCard";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
 
 const PLAN_ORDER: OrganizationPlan[] = [
   "free",
@@ -53,10 +55,6 @@ const POPULAR_PLAN: OrganizationPlan = "team";
 
 /** Defines org as the billed scope for plans and limits (vs workspaces). */
 const ORG_COMPARE_PLANS_NOTE = "Your organization is the billed unit.";
-
-const LLM_USAGE_SECTION_TITLE = "LLM Usage";
-const LLM_USAGE_SECTION_TOOLTIP =
-  "LLM usage billing isn’t live yet, so models are currently free. For paid plans, the table reflects the intended $5 per user per day rate limit and may change before billing launches.";
 
 function getPlanRank(plan: OrganizationPlan): number {
   return PLAN_ORDER.indexOf(plan);
@@ -697,6 +695,10 @@ export function OrganizationBillingSection({
         ) : null}
       </Dialog>
 
+      <ErrorBoundary fallback={null}>
+        <CreditBalanceCard />
+      </ErrorBoundary>
+
       {checkoutIntent ? (
         <div
           className="flex items-center gap-2 rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-sm text-muted-foreground"
@@ -917,31 +919,7 @@ export function OrganizationBillingSection({
                             colSpan={PLAN_ORDER.length + 1}
                           >
                             <div className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                              {section.title === LLM_USAGE_SECTION_TITLE ? (
-                                <span className="inline-flex items-center gap-1.5">
-                                  <span>{section.title}</span>
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <button
-                                        type="button"
-                                        className="inline-flex shrink-0 rounded-sm text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                                        aria-label="LLM usage pricing note"
-                                      >
-                                        <Info className="size-3.5" />
-                                      </button>
-                                    </TooltipTrigger>
-                                    <TooltipContent
-                                      side="right"
-                                      sideOffset={6}
-                                      className="max-w-[22rem] text-balance"
-                                    >
-                                      {LLM_USAGE_SECTION_TOOLTIP}
-                                    </TooltipContent>
-                                  </Tooltip>
-                                </span>
-                              ) : (
-                                section.title
-                              )}
+                              {section.title}
                             </div>
                           </TableCell>
                         </TableRow>

--- a/mcpjam-inspector/client/src/components/ui/error-boundary.tsx
+++ b/mcpjam-inspector/client/src/components/ui/error-boundary.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { AlertTriangle } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
-import { EmptyState } from "@/components/ui/empty-state";
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
@@ -14,6 +13,17 @@ interface ErrorBoundaryState {
   error: Error | null;
 }
 
+/**
+ * Domain-agnostic error boundary primitive.
+ *
+ * Fallback semantics:
+ * - `fallback={null}` → render nothing on error (intentional silence; e.g.
+ *   gracefully hiding an experimental tile when its query throws).
+ * - `fallback={<X />}` → render that fallback.
+ * - omitted OR `fallback={undefined}` → fall through to the default UI
+ *   (TS `?: ReactNode` treats `undefined` as "absent", which is what we
+ *   honor here via `!== undefined`).
+ */
 export class ErrorBoundary extends React.Component<
   ErrorBoundaryProps,
   ErrorBoundaryState
@@ -38,7 +48,7 @@ export class ErrorBoundary extends React.Component<
 
   render() {
     if (this.state.hasError) {
-      if (this.props.fallback) {
+      if (this.props.fallback !== undefined) {
         return this.props.fallback;
       }
 
@@ -60,28 +70,4 @@ export class ErrorBoundary extends React.Component<
 
     return this.props.children;
   }
-}
-
-/**
- * Error boundary specifically for evals tab
- */
-export function EvalsErrorBoundary({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return (
-    <ErrorBoundary
-      fallback={
-        <EmptyState
-          icon={AlertTriangle}
-          title="Something went wrong"
-          description="An error occurred while loading the evals tab. Please refresh the page."
-          className="h-[calc(100vh-200px)]"
-        />
-      }
-    >
-      {children}
-    </ErrorBoundary>
-  );
 }

--- a/mcpjam-inspector/client/src/components/ui/json-editor/json-editor.tsx
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/json-editor.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { copyToClipboard } from "@/lib/clipboard";
-import { ErrorBoundary } from "@/components/evals/ErrorBoundary";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { expandJsonStringsInValue, useJsonEditor } from "./use-json-editor";
 import { JsonEditorView } from "./json-editor-view";
 import { JsonEditorEdit } from "./json-editor-edit";

--- a/mcpjam-inspector/client/src/hooks/__tests__/useCreditTopup.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useCreditTopup.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// We mock convex/react so importing the hook module doesn't require a
+// provider — we only exercise the pure helpers (URL guard + sessionStorage
+// peek/clear), not the React hooks.
+vi.mock("convex/react", () => ({
+  useAction: () => () => Promise.resolve(null),
+  useQuery: () => undefined,
+}));
+
+import {
+  clearPendingTopup,
+  isAllowedCheckoutUrl,
+  peekPendingTopup,
+  stashPendingTopup,
+} from "../useCreditTopup";
+
+describe("isAllowedCheckoutUrl", () => {
+  it("accepts a real-looking Stripe Checkout URL", () => {
+    expect(
+      isAllowedCheckoutUrl(
+        "https://checkout.stripe.com/c/pay/cs_test_a1b2c3d4e5",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a different host even if the path looks like Stripe's", () => {
+    expect(
+      isAllowedCheckoutUrl("https://evil.example/c/pay/cs_test_a1b2c3d4e5"),
+    ).toBe(false);
+  });
+
+  it("rejects a hostname-prefix attack", () => {
+    expect(
+      isAllowedCheckoutUrl(
+        "https://checkout.stripe.com.evil.example/cs_test_xyz",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects http-only Stripe URLs", () => {
+    expect(isAllowedCheckoutUrl("http://checkout.stripe.com/cs_test_xyz")).toBe(
+      false,
+    );
+  });
+
+  it("rejects javascript: / data: schemes", () => {
+    expect(isAllowedCheckoutUrl("javascript:alert(1)")).toBe(false);
+    expect(isAllowedCheckoutUrl("data:text/html,<script>")).toBe(false);
+  });
+
+  it("rejects non-string inputs", () => {
+    expect(isAllowedCheckoutUrl(undefined)).toBe(false);
+    expect(isAllowedCheckoutUrl(null)).toBe(false);
+    expect(isAllowedCheckoutUrl(42)).toBe(false);
+    expect(isAllowedCheckoutUrl({})).toBe(false);
+  });
+});
+
+describe("peekPendingTopup / clearPendingTopup", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    window.sessionStorage.clear();
+  });
+
+  it("returns null when nothing is stashed", () => {
+    expect(peekPendingTopup()).toBeNull();
+  });
+
+  it("returns a freshly stashed entry without removing it", () => {
+    stashPendingTopup({ chatSessionId: "chat-1", message: "hi" });
+    const first = peekPendingTopup();
+    expect(first).not.toBeNull();
+    expect(first?.chatSessionId).toBe("chat-1");
+    expect(first?.message).toBe("hi");
+
+    // Critically: the entry should still be there after a peek.
+    const second = peekPendingTopup();
+    expect(second).not.toBeNull();
+    expect(second?.message).toBe("hi");
+  });
+
+  it("returns null and clears the entry when expired (>10 min old)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-30T12:00:00Z"));
+    stashPendingTopup({ chatSessionId: "chat-1", message: "hi" });
+
+    // Jump 11 minutes ahead — past the 10-min TTL.
+    vi.setSystemTime(new Date("2026-04-30T12:11:00Z"));
+    expect(peekPendingTopup()).toBeNull();
+
+    // After expiry the entry is gone, even on a second peek.
+    expect(window.sessionStorage.getItem("mcpjam.topup.pending")).toBeNull();
+  });
+
+  it("returns null and clears the entry when malformed", () => {
+    window.sessionStorage.setItem("mcpjam.topup.pending", "{not json");
+    expect(peekPendingTopup()).toBeNull();
+    expect(window.sessionStorage.getItem("mcpjam.topup.pending")).toBeNull();
+  });
+
+  it("returns null and clears the entry when shape is wrong", () => {
+    window.sessionStorage.setItem(
+      "mcpjam.topup.pending",
+      JSON.stringify({ chatSessionId: 42, message: null }),
+    );
+    expect(peekPendingTopup()).toBeNull();
+    expect(window.sessionStorage.getItem("mcpjam.topup.pending")).toBeNull();
+  });
+
+  it("clearPendingTopup removes a valid entry", () => {
+    stashPendingTopup({ chatSessionId: "chat-1", message: "hi" });
+    expect(peekPendingTopup()).not.toBeNull();
+    clearPendingTopup();
+    expect(peekPendingTopup()).toBeNull();
+    expect(window.sessionStorage.getItem("mcpjam.topup.pending")).toBeNull();
+  });
+
+  it("does not stash when chatSessionId or message is empty", () => {
+    stashPendingTopup({ chatSessionId: "", message: "hi" });
+    expect(peekPendingTopup()).toBeNull();
+    stashPendingTopup({ chatSessionId: "chat-1", message: "" });
+    expect(peekPendingTopup()).toBeNull();
+    stashPendingTopup({ chatSessionId: "", message: "" });
+    expect(peekPendingTopup()).toBeNull();
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/useCreditTopupReturnFlow.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useCreditTopupReturnFlow.test.tsx
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+// vi.mock is hoisted above imports — declare mock fns via vi.hoisted so
+// they're available when the factory runs.
+const { toastSuccessMock, toastErrorMock, posthogCaptureMock } = vi.hoisted(
+  () => ({
+    toastSuccessMock: vi.fn(),
+    toastErrorMock: vi.fn(),
+    posthogCaptureMock: vi.fn(),
+  }),
+);
+
+vi.mock("sonner", () => ({
+  toast: { success: toastSuccessMock, error: toastErrorMock },
+}));
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({ capture: posthogCaptureMock }),
+}));
+
+import {
+  clearPendingTopup,
+  stashPendingTopup,
+} from "../useCreditTopup";
+import { useCreditTopupReturnFlow } from "../useCreditTopupReturnFlow";
+
+const STASH_KEY = "mcpjam.topup.pending";
+
+let replaceStateSpy: ReturnType<typeof vi.spyOn>;
+let originalLocation: Location;
+
+function setLocationSearch(search: string) {
+  // jsdom doesn't let us reassign window.location, but we can stub the
+  // properties the hook reads. The hook reads .search, .pathname, .hash.
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      ...originalLocation,
+      search,
+      pathname: "/",
+      hash: "",
+    },
+  });
+}
+
+describe("useCreditTopupReturnFlow", () => {
+  beforeEach(() => {
+    toastSuccessMock.mockReset();
+    toastErrorMock.mockReset();
+    posthogCaptureMock.mockReset();
+    window.sessionStorage.clear();
+    originalLocation = window.location;
+    // Spy on replaceState so the hook's URL cleanup doesn't hit jsdom's
+    // SecurityError for cross-document URL changes.
+    replaceStateSpy = vi
+      .spyOn(window.history, "replaceState")
+      .mockImplementation(() => {});
+    setLocationSearch("");
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    replaceStateSpy.mockRestore();
+    window.sessionStorage.clear();
+  });
+
+  it("is a no-op when no topup query param is present", () => {
+    setLocationSearch("");
+    const sendMessage = vi.fn();
+    renderHook(() =>
+      useCreditTopupReturnFlow({
+        chatSessionId: "chat-1",
+        sendMessage,
+      }),
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+    expect(toastErrorMock).not.toHaveBeenCalled();
+    expect(replaceStateSpy).not.toHaveBeenCalled();
+  });
+
+  it("strips topup + session_id params and leaves stash alone on cancelled", () => {
+    setLocationSearch("?topup=cancelled&session_id=cs_test_xyz&keep=1");
+    stashPendingTopup({ chatSessionId: "chat-1", message: "hello" });
+
+    const sendMessage = vi.fn();
+    renderHook(() =>
+      useCreditTopupReturnFlow({
+        chatSessionId: "chat-1",
+        sendMessage,
+      }),
+    );
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    // URL was cleaned: replaceState called with only `keep=1` preserved.
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    expect(replaceStateSpy.mock.calls[0]?.[2]).toBe("/?keep=1");
+    // Stash preserved for retry.
+    expect(window.sessionStorage.getItem(STASH_KEY)).not.toBeNull();
+    // Telemetry: cancelled with stash present.
+    expect(posthogCaptureMock).toHaveBeenCalledWith(
+      "credit_topup_return_cancelled",
+      { had_pending_stash: true },
+    );
+  });
+
+  it("resends and clears stash on success when chat session matches", () => {
+    setLocationSearch("?topup=success&session_id=cs_test_xyz");
+    stashPendingTopup({ chatSessionId: "chat-1", message: "hello again" });
+
+    const sendMessage = vi.fn();
+    renderHook(() =>
+      useCreditTopupReturnFlow({
+        chatSessionId: "chat-1",
+        sendMessage,
+      }),
+    );
+
+    expect(sendMessage).toHaveBeenCalledWith({ text: "hello again" });
+    expect(toastSuccessMock).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem(STASH_KEY)).toBeNull();
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    expect(replaceStateSpy.mock.calls[0]?.[2]).toBe("/");
+    // Telemetry: success, stash present, session matched, resend executed.
+    expect(posthogCaptureMock).toHaveBeenCalledWith(
+      "credit_topup_return_success",
+      {
+        had_pending_stash: true,
+        chat_session_matched: true,
+        resend_executed: true,
+      },
+    );
+  });
+
+  it("clears stash on success when chat session does not match (does not resend)", () => {
+    setLocationSearch("?topup=success");
+    stashPendingTopup({
+      chatSessionId: "chat-other",
+      message: "from another tab",
+    });
+
+    const sendMessage = vi.fn();
+    renderHook(() =>
+      useCreditTopupReturnFlow({
+        chatSessionId: "chat-1",
+        sendMessage,
+      }),
+    );
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+    expect(window.sessionStorage.getItem(STASH_KEY)).toBeNull();
+    // Telemetry: success, stash present, session NOT matched, no resend.
+    expect(posthogCaptureMock).toHaveBeenCalledWith(
+      "credit_topup_return_success",
+      {
+        had_pending_stash: true,
+        chat_session_matched: false,
+        resend_executed: false,
+      },
+    );
+  });
+
+  it("preserves stash and surfaces an error toast when sendMessage throws", () => {
+    setLocationSearch("?topup=success");
+    stashPendingTopup({ chatSessionId: "chat-1", message: "retry me" });
+
+    const sendMessage = vi.fn().mockImplementation(() => {
+      throw new Error("send failed");
+    });
+
+    renderHook(() =>
+      useCreditTopupReturnFlow({
+        chatSessionId: "chat-1",
+        sendMessage,
+      }),
+    );
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(toastErrorMock).toHaveBeenCalledTimes(1);
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+    // Stash preserved so the user can retry.
+    expect(window.sessionStorage.getItem(STASH_KEY)).not.toBeNull();
+    // Telemetry: success, stash present, matched, but resend FAILED.
+    expect(posthogCaptureMock).toHaveBeenCalledWith(
+      "credit_topup_return_success",
+      {
+        had_pending_stash: true,
+        chat_session_matched: true,
+        resend_executed: false,
+      },
+    );
+  });
+
+  it("does nothing extra when topup=success arrives without a stash", () => {
+    setLocationSearch("?topup=success");
+    clearPendingTopup();
+
+    const sendMessage = vi.fn();
+    renderHook(() =>
+      useCreditTopupReturnFlow({
+        chatSessionId: "chat-1",
+        sendMessage,
+      }),
+    );
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(toastSuccessMock).not.toHaveBeenCalled();
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+    // Telemetry: success but no stash present.
+    expect(posthogCaptureMock).toHaveBeenCalledWith(
+      "credit_topup_return_success",
+      {
+        had_pending_stash: false,
+        chat_session_matched: false,
+        resend_executed: false,
+      },
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
@@ -1,0 +1,79 @@
+import { useConvexAuth, useQuery } from "convex/react";
+import { useMemo } from "react";
+
+export interface CreditBalanceState {
+  /**
+   * 0-100. Percent of the user's credited pool still remaining. The bar
+   * renders `100 - paidPercentRemaining` as "% used". Backend computes
+   * the percent so the inspector never sees the dollar denominator.
+   */
+  paidPercentRemaining: number | null;
+  /**
+   * Whether the user has ever topped up. Used to gate paid-bar
+   * visibility. Boolean-only — we deliberately don't expose the
+   * underlying dollar amount.
+   */
+  hasPurchaseHistory: boolean;
+  /**
+   * 0-100. Percent of today's free quota that's been consumed. Backend
+   * computes from rate-limiter bucket state — no client-side dollar
+   * denominator.
+   */
+  freeDailyPercentUsed: number;
+  /** Epoch ms when the daily bucket resets. */
+  freeDailyResetAt: number;
+}
+
+const clampPercent = (value: unknown): number => {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 100) return 100;
+  return value;
+};
+
+const optionalPercent = (value: unknown): number | null => {
+  if (value == null) return null;
+  return clampPercent(value);
+};
+
+const optionalNumber = (value: unknown, fallback = 0): number =>
+  typeof value === "number" && Number.isFinite(value) ? value : fallback;
+
+const normalizeBalance = (raw: unknown): CreditBalanceState | undefined => {
+  if (!raw || typeof raw !== "object") return undefined;
+  const r = raw as Record<string, unknown>;
+  // Accept either an explicit `hasPurchaseHistory: boolean` (preferred, new
+  // backend shape) or fall back to the legacy `lifetimePurchasedCents > 0`
+  // signal. Either is enough to know the user has topped up at least once.
+  // We DO NOT store the dollar value, so the inspector can't accidentally
+  // surface it.
+  const hasPurchaseHistory =
+    r.hasPurchaseHistory === true ||
+    (typeof r.lifetimePurchasedCents === "number" &&
+      Number.isFinite(r.lifetimePurchasedCents) &&
+      r.lifetimePurchasedCents > 0);
+  return {
+    paidPercentRemaining: optionalPercent(r.paidPercentRemaining),
+    hasPurchaseHistory,
+    freeDailyPercentUsed: clampPercent(r.freeDailyPercentUsed),
+    freeDailyResetAt: optionalNumber(r.freeDailyResetAt),
+  };
+};
+
+export function useCreditBalance() {
+  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const raw = useQuery(
+    "billing:getCreditBalance" as any,
+    isAuthenticated ? ({} as any) : "skip",
+  ) as unknown | undefined;
+  // Memoize on the raw query reference. Convex returns a stable reference
+  // when the underlying data is unchanged, so the normalized object stays
+  // referentially stable across renders. Keeps downstream effects/memos
+  // that depend on `balance` from re-running when nothing actually changed.
+  const balance = useMemo(() => normalizeBalance(raw), [raw]);
+  // Treat the bootstrap window as loading so the card shows a skeleton
+  // instead of flashing an empty zero state before the query resolves.
+  const isLoading =
+    isAuthLoading || (isAuthenticated && raw === undefined);
+  return { balance, isLoading };
+}

--- a/mcpjam-inspector/client/src/hooks/useCreditTopup.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditTopup.ts
@@ -1,0 +1,255 @@
+import { useAction, useQuery } from "convex/react";
+import { useCallback, useMemo, useState } from "react";
+import { usePostHog } from "posthog-js/react";
+
+export interface CreditTopupPreset {
+  amountCents: number;
+  amountUsd: string;
+}
+
+export interface PendingTopupContext {
+  chatSessionId: string;
+  message: string;
+  storedAt: number;
+}
+
+const SESSION_STORAGE_KEY = "mcpjam.topup.pending";
+const PENDING_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Allowed checkout URL prefix. Validating the prefix is a defense-in-depth
+ * check that prevents an open-redirect if a compromised or buggy server
+ * response ever returns an attacker-controlled URL —
+ * `window.location.assign` would otherwise navigate the user anywhere.
+ */
+const ALLOWED_CHECKOUT_URL_PREFIX = "https://checkout.stripe.com/";
+
+export function isAllowedCheckoutUrl(url: unknown): url is string {
+  return (
+    typeof url === "string" && url.startsWith(ALLOWED_CHECKOUT_URL_PREFIX)
+  );
+}
+
+const formatUsd = (cents: number) => {
+  const dollars = cents / 100;
+  return Number.isInteger(dollars) ? `$${dollars}` : `$${dollars.toFixed(2)}`;
+};
+
+interface RawPreset {
+  amountCents?: unknown;
+}
+
+const normalizePresets = (raw: unknown): CreditTopupPreset[] | undefined => {
+  // Accept either a bare array or a `{ presets: [...] }` wrapper. The
+  // backend may also ship extra fields like `takeRate` or per-item
+  // `creditedCents`; we deliberately ignore them so they can never reach
+  // the rendered UI.
+  let items: unknown = raw;
+  if (
+    raw &&
+    typeof raw === "object" &&
+    !Array.isArray(raw) &&
+    "presets" in raw
+  ) {
+    items = (raw as { presets?: unknown }).presets;
+  }
+  if (!Array.isArray(items)) return undefined;
+  const presets: CreditTopupPreset[] = [];
+  for (const item of items as RawPreset[]) {
+    if (typeof item?.amountCents !== "number") continue;
+    presets.push({
+      amountCents: item.amountCents,
+      amountUsd: formatUsd(item.amountCents),
+    });
+  }
+  return presets.length > 0 ? presets : undefined;
+};
+
+export function stashPendingTopup(context: {
+  chatSessionId: string;
+  message: string;
+}): void {
+  if (typeof window === "undefined") return;
+  // Don't stash a useless entry — empty chat-session id or empty message
+  // means the resume path can never act on it. Avoids cross-flow noise
+  // (e.g. billing-page-initiated topup writing a phantom entry that some
+  // future ?topup=success effect would have to filter out).
+  if (!context.chatSessionId || !context.message) return;
+  try {
+    const payload: PendingTopupContext = {
+      chatSessionId: context.chatSessionId,
+      message: context.message,
+      storedAt: Date.now(),
+    };
+    window.sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // sessionStorage unavailable; fall through silently
+  }
+}
+
+export function clearPendingTopup(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(SESSION_STORAGE_KEY);
+  } catch {
+    // noop
+  }
+}
+
+/**
+ * Non-destructive read of the pending top-up stash. Returns the entry if it
+ * exists, is well-formed, and is within the TTL window. Returns null
+ * otherwise — and on the null cases caused by a malformed or expired entry,
+ * removes the bad entry from sessionStorage.
+ *
+ * Callers MUST call `clearPendingTopup()` themselves once they've
+ * successfully acted on the entry. Splitting peek + clear avoids the
+ * footgun where a read-then-fail flow loses the user's pending message.
+ */
+export function peekPendingTopup(): PendingTopupContext | null {
+  if (typeof window === "undefined") return null;
+  let raw: string | null = null;
+  try {
+    raw = window.sessionStorage.getItem(SESSION_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<PendingTopupContext>;
+    if (
+      typeof parsed.chatSessionId !== "string" ||
+      typeof parsed.message !== "string" ||
+      typeof parsed.storedAt !== "number"
+    ) {
+      // Malformed entry — drop it.
+      clearPendingTopup();
+      return null;
+    }
+    if (Date.now() - parsed.storedAt > PENDING_TTL_MS) {
+      // Expired — drop it.
+      clearPendingTopup();
+      return null;
+    }
+    return {
+      chatSessionId: parsed.chatSessionId,
+      message: parsed.message,
+      storedAt: parsed.storedAt,
+    };
+  } catch {
+    clearPendingTopup();
+    return null;
+  }
+}
+
+/**
+ * Surface the user came from when initiating a top-up. Used as a property
+ * on `credit_topup_*` PostHog events so the funnel can be split between
+ * the chat-banner CTA and the billing-page Top up button.
+ */
+export type CreditTopupSource = "chat_banner" | "billing_page";
+
+interface StartCheckoutInput {
+  amountCents: number;
+  chatSessionId: string;
+  lastUserMessage: string;
+  returnUrl?: string;
+  source: CreditTopupSource;
+}
+
+export interface UseCreditTopupPresetsOptions {
+  /** When true, the underlying Convex query is skipped entirely. */
+  skip?: boolean;
+}
+
+export function useCreditTopupPresets(
+  options?: UseCreditTopupPresetsOptions,
+): { presets: CreditTopupPreset[] | undefined; isLoading: boolean } {
+  const skip = options?.skip === true;
+  const presetsRaw = useQuery(
+    "billing:getCreditTopupPresets" as any,
+    skip ? "skip" : (undefined as any),
+  ) as unknown | undefined;
+  // Memoize on the raw query reference. Convex returns a stable reference
+  // when the underlying data is unchanged, so the normalized array stays
+  // referentially stable across renders. Keeps downstream effects/memos
+  // that depend on `presets` from re-running when nothing actually changed.
+  const presets = useMemo(() => normalizePresets(presetsRaw), [presetsRaw]);
+  const isLoading = !skip && presetsRaw === undefined;
+  return { presets, isLoading };
+}
+
+export function useCreditTopup() {
+  const { presets, isLoading: presetsLoading } = useCreditTopupPresets();
+  const posthog = usePostHog();
+
+  const createCheckoutSession = useAction(
+    "billing:createCreditCheckoutSession" as any,
+  );
+
+  const [isStartingCheckout, setIsStartingCheckout] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const startCheckout = useCallback(
+    async ({
+      amountCents,
+      chatSessionId,
+      lastUserMessage,
+      returnUrl,
+      source,
+    }: StartCheckoutInput): Promise<void> => {
+      setIsStartingCheckout(true);
+      setError(null);
+      posthog?.capture("credit_topup_checkout_started", {
+        amount_cents: amountCents,
+        source,
+      });
+      stashPendingTopup({ chatSessionId, message: lastUserMessage });
+      // Track the most specific failure category we know about. Defaults to
+      // `action_threw` (the fallback when the Convex action itself rejects)
+      // and gets refined by the URL guards below.
+      let errorKind: "missing_url" | "invalid_url" | "action_threw" =
+        "action_threw";
+      try {
+        const result = (await createCheckoutSession({
+          amountCents,
+          ...(returnUrl ? { returnUrl } : {}),
+        } as any)) as { checkoutUrl?: string } | null;
+        const checkoutUrl = result?.checkoutUrl;
+        if (typeof checkoutUrl !== "string" || checkoutUrl.length === 0) {
+          errorKind = "missing_url";
+          throw new Error("Checkout URL missing from response");
+        }
+        if (!isAllowedCheckoutUrl(checkoutUrl)) {
+          // Defense-in-depth: don't navigate to URLs that aren't on the
+          // allowed checkout host even if the server told us to.
+          errorKind = "invalid_url";
+          throw new Error("Refusing to redirect to non-Stripe checkout URL");
+        }
+        window.location.assign(checkoutUrl);
+      } catch (err) {
+        posthog?.capture("credit_topup_checkout_failed", {
+          amount_cents: amountCents,
+          error_kind: errorKind,
+          source,
+        });
+        clearPendingTopup();
+        const message =
+          err instanceof Error ? err.message : "Failed to start checkout";
+        setError(message);
+        throw err;
+      } finally {
+        setIsStartingCheckout(false);
+      }
+    },
+    [createCheckoutSession, posthog],
+  );
+
+  return {
+    presets,
+    presetsLoading,
+    startCheckout,
+    isStartingCheckout,
+    error,
+  };
+}

--- a/mcpjam-inspector/client/src/hooks/useCreditTopupReturnFlow.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditTopupReturnFlow.ts
@@ -1,0 +1,95 @@
+import { useEffect } from "react";
+import { toast } from "sonner";
+import { usePostHog } from "posthog-js/react";
+
+import {
+  clearPendingTopup,
+  peekPendingTopup,
+} from "@/hooks/useCreditTopup";
+
+interface UseCreditTopupReturnFlowOptions {
+  /** Active chat session id used to validate the pending stash on success. */
+  chatSessionId: string;
+  /** Hook into the chat session's send to replay the user's last message. */
+  sendMessage: (args: { text: string }) => void;
+}
+
+/**
+ * Handles the chat-side fallout from a hosted-checkout return:
+ *
+ * - On `?topup=cancelled`: strip the URL params and leave the pending
+ *   stash alone (a retry within the TTL window should still resend the
+ *   queued message).
+ * - On `?topup=success`: strip the URL params, peek the stash
+ *   (non-destructive), and try to resend the user's queued message. The
+ *   stash is only cleared after the resend reports back successfully —
+ *   if `sendMessage` throws synchronously the stash is preserved so the
+ *   user can retry.
+ *
+ * Runs once on mount. `chatSessionId` and `sendMessage` are captured
+ * from the initial render — `chatSessionId` is stable for the lifetime
+ * of the chat session, and a new `sendMessage` reference would imply a
+ * fresh mount anyway.
+ */
+export function useCreditTopupReturnFlow({
+  chatSessionId,
+  sendMessage,
+}: UseCreditTopupReturnFlowOptions): void {
+  const posthog = usePostHog();
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const topupParam = params.get("topup");
+    if (topupParam !== "success" && topupParam !== "cancelled") return;
+
+    params.delete("topup");
+    params.delete("session_id");
+    const search = params.toString();
+    const cleanedUrl =
+      window.location.pathname +
+      (search ? `?${search}` : "") +
+      window.location.hash;
+    window.history.replaceState(null, "", cleanedUrl);
+
+    if (topupParam === "cancelled") {
+      const pending = peekPendingTopup();
+      posthog?.capture("credit_topup_return_cancelled", {
+        had_pending_stash: pending !== null,
+      });
+      return;
+    }
+
+    const pending = peekPendingTopup();
+    const hadPendingStash = pending !== null;
+    let chatSessionMatched = false;
+    let resendExecuted = false;
+
+    if (pending) {
+      chatSessionMatched = pending.chatSessionId === chatSessionId;
+      if (!chatSessionMatched) {
+        clearPendingTopup();
+      } else {
+        try {
+          sendMessage({ text: pending.message });
+          resendExecuted = true;
+          toast.success("Credits added — resuming your message.");
+          clearPendingTopup();
+        } catch {
+          toast.error(
+            "Credits added, but we couldn't resend your last message. Please send it again.",
+          );
+        }
+      }
+    }
+
+    posthog?.capture("credit_topup_return_success", {
+      had_pending_stash: hadPendingStash,
+      chat_session_matched: chatSessionMatched,
+      resend_executed: resendExecuted,
+    });
+    // Run once on mount; see fn-level comment for the rationale on the
+    // captured arguments.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}


### PR DESCRIPTION
## [Billing Credits] PR-I3: Credit usage card

Adds a usage card to the organization billing page. Two stacked progress
bars (daily limit + paid credits) gated on user state. Replaces the
placeholder copy that previously sat above the plan-comparison table.

### Visual

```
┌─ Credit usage ──────────────────────────────────┐
│ Your model credits                  [Top up]    │
│ Credits are linked to your user, not the org.   │
│                                                 │
│ Daily limit               9% used · resets 11h  │
│ ▓▓░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  │
│                                                 │
│ Paid credits                        30% used    │
│ ▓▓▓▓▓▓▓▓░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  │
└─────────────────────────────────────────────────┘
```

The paid bar is hidden until the user's first top-up. Both bars use a
bare percent ("X% used") with no dollar values surfaced anywhere on
the card.

### Changes
- New `useCreditBalance` hook. Calls the server's read-side balance
  endpoint, normalizes defensively, and `useMemo`s the result so
  consumers don't churn on every parent render. Auth-gated via
  `useConvexAuth().isAuthenticated` + Convex `"skip"` sentinel.
- New `CreditBalanceCard`: header + sub-line clarifying credits are
  user-scoped (not org-scoped) + two usage bars + Top up button.
- New `TopupActionButton`: renders the Top up button only when the
  preset endpoint resolves with at least one preset. Wrapped in an
  inner error boundary so a missing-function error collapses to no
  button rather than crashing the whole card.
- `OrganizationBillingSection` slots the card in above the
  plan-comparison view, wrapped in `<ErrorBoundary fallback={null}>`,
  and removes a stale placeholder note that surfaced an outdated
  per-user-per-day pricing line.
- Imports the relocated `ErrorBoundary` from
  `@/components/ui/error-boundary` (moved out of `evals/` in PR-I2 —
  no longer a domain-specific primitive).

### Why no dollar values

The card surfaces only percentages. Showing dollar amounts on the
paid-credits row would invite the user to compute a wrong remaining
dollar value (since the bar's denominator is in the credited domain,
not the paid domain). Bare percentages match the well-validated
gas-gauge UX pattern used by similar credit pages — the row label
("Daily limit", "Paid credits") tells the user what the pool is, and
the percent tells them where they are within it.

### Tests
- `CreditBalanceCard.test.tsx`: skeleton loading state, hidden paid
  bar before any top-up, paid row renders as `% used` only,
  top-up button opens dialog, regression guard that **neither** row
  ever renders a `$` character, lock-in test for the user-scope
  sub-line copy.
- `TopupActionButton.test.tsx`: renders only when presets are
  available, hides on loading + empty, click handler.
- `OrganizationsTab.billing.test.tsx`: extended `convex/react` mock
  to include `useQuery` stub for the new auth-gated hook.

### Stack
- PR-I1 ✅
- PR-I2 ✅
- **This PR** ← you are here

### Notes
- Marked draft. Backend Fix 6 (response payload trim) shipped in
  `mcpjam-backend#184`; remaining gate is full backend deploy to
  production.
- The activity-table feature considered earlier was dropped in design
  review — Stripe email receipts are the source of truth for payment
  history; in-inspector duplication added complexity and surface area
  without a clear win.

### Risk
Low. Net-new card on the billing page; only existing surface changed
is the removal of a stale tooltip line in the plan-comparison table
and a small semantic tightening of the shared `ErrorBoundary`
primitive (in PR-I2). The card handles missing data, missing
endpoints, and unauthenticated states without crashing.
