### PR TITLE
[Billing Credits] PR-I4: Wallet-locked + concurrency error states

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -1630,6 +1630,20 @@ export function ChatTabV2({
     }
   }, []);
 
+  // Concurrency-throttle retry: re-submit the user's last typed message via
+  // the same source-tracking ref the topup CTA uses. The retry button only
+  // ever surfaces on the concurrency banner (see `onRetry` gate below), so
+  // we don't risk firing this on unrelated retryable errors.
+  const handleRetryConcurrencyMessage = useCallback(() => {
+    const text = lastSentUserMessageRef.current;
+    if (!text) return;
+    sendMessage({ text });
+  }, [sendMessage]);
+
+  const isConcurrencyThrottle =
+    errorMessage?.code === "user_rate_limit" &&
+    errorMessage?.limitKind === "concurrency";
+
   useCreditTopupReturnFlow({ chatSessionId, sendMessage });
 
   const traceViewerTrace = liveTraceEnvelope ?? {
@@ -2096,6 +2110,14 @@ export function ChatTabV2({
                             }
                             canTopUp={canShowTopupCta}
                             onTopUp={handleOpenTopupDialog}
+                            walletLocked={errorMessage.walletLocked}
+                            limitKind={errorMessage.limitKind}
+                            retryAfterMs={errorMessage.retryAfterMs}
+                            onRetry={
+                              isConcurrencyThrottle
+                                ? handleRetryConcurrencyMessage
+                                : undefined
+                            }
                             onResetChat={handleResetAllChats}
                           />
                         </div>
@@ -2326,6 +2348,14 @@ export function ChatTabV2({
                               }
                               canTopUp={canShowTopupCta}
                               onTopUp={handleOpenTopupDialog}
+                              walletLocked={errorMessage.walletLocked}
+                              limitKind={errorMessage.limitKind}
+                              retryAfterMs={errorMessage.retryAfterMs}
+                              onRetry={
+                                isConcurrencyThrottle
+                                  ? handleRetryConcurrencyMessage
+                                  : undefined
+                              }
                               onResetChat={baseResetChat}
                             />
                           </div>
@@ -2395,6 +2425,14 @@ export function ChatTabV2({
                             }
                             canTopUp={canShowTopupCta}
                             onTopUp={handleOpenTopupDialog}
+                            walletLocked={errorMessage.walletLocked}
+                            limitKind={errorMessage.limitKind}
+                            retryAfterMs={errorMessage.retryAfterMs}
+                            onRetry={
+                              isConcurrencyThrottle
+                                ? handleRetryConcurrencyMessage
+                                : undefined
+                            }
                             onResetChat={baseResetChat}
                           />
                         </div>

--- a/mcpjam-inspector/client/src/components/chat-v2/error.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/error.tsx
@@ -3,6 +3,7 @@ import {
   ChevronDown,
   ChevronRight,
   RefreshCw,
+  ShieldAlert,
 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { useState } from "react";
@@ -26,6 +27,14 @@ interface ErrorBoxProps {
   onRetry?: () => void;
   canTopUp?: boolean;
   onTopUp?: () => void;
+  /** When true, render the locked-account banner instead of any other state. */
+  walletLocked?: boolean;
+  /** Sub-classification of a rate-limit error. `"concurrency"` triggers the
+   * transient retry banner. */
+  limitKind?: "total" | "concurrency";
+  /** Raw retry hint in milliseconds. Used by the concurrency banner to render
+   * second-level granularity ("Retry in N seconds"). */
+  retryAfterMs?: number;
 }
 
 const parseErrorDetails = (details: string | undefined) => {
@@ -49,14 +58,30 @@ export function ErrorBox({
   onRetry,
   canTopUp,
   onTopUp,
+  walletLocked,
+  limitKind,
+  retryAfterMs,
 }: ErrorBoxProps) {
   const [isErrorDetailsOpen, setIsErrorDetailsOpen] = useState(false);
   const errorDetailsJson = parseErrorDetails(errorDetails);
 
+  // Three priority states for the rate-limit-adjacent variants. Order
+  // matters: walletLocked is the highest-priority terminal state (no
+  // self-serve recovery), then the concurrency throttle (transient,
+  // user-driven retry), then everything else falls back to the existing
+  // model-limit / generic error rendering.
+  const isWalletLocked = walletLocked === true;
+  const isConcurrencyThrottle =
+    !isWalletLocked &&
+    code === "user_rate_limit" &&
+    limitKind === "concurrency";
+
   const isMCPJamModelLimit =
-    code === "mcpjam_rate_limit" ||
-    code === "user_rate_limit" ||
-    /mcpjam[\w\s-]*model limit/i.test(message);
+    !isWalletLocked &&
+    !isConcurrencyThrottle &&
+    (code === "mcpjam_rate_limit" ||
+      code === "user_rate_limit" ||
+      /mcpjam[\w\s-]*model limit/i.test(message));
 
   // Platform and quota errors use warning styling to indicate recoverable state.
   const isPlatformError = isMCPJamPlatformError === true || isMCPJamModelLimit;
@@ -87,6 +112,78 @@ export function ErrorBox({
       ? "MCPJam platform issue"
       : "An error occurred";
   const errorPrefix = isMCPJamModelLimit ? `${errorLabel}.` : `${errorLabel}:`;
+
+  if (isWalletLocked) {
+    // Server has paused this account from spending or topping up. The user
+    // cannot self-serve out of this; only support can clear it. Render a
+    // dedicated locked-state banner with a contact link — no top-up, no
+    // retry, just a way to reach out.
+    return (
+      <div className="flex flex-col gap-3 border rounded p-4 border-warning bg-warning/20 text-warning-foreground">
+        <div className="flex items-start gap-3">
+          <ShieldAlert className="h-6 w-6 flex-shrink-0 text-warning" />
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium leading-6">
+              Account under review
+            </p>
+            <p className="text-sm leading-6 opacity-90">
+              We&apos;ve paused this account while a recent payment is
+              reviewed.{" "}
+              <a
+                className="underline hover:no-underline"
+                href="mailto:founders@mcpjam.com?subject=MCPJam%20Account%20Review"
+              >
+                Reach out to support
+              </a>{" "}
+              to get back in.
+            </p>
+          </div>
+          <div className="ml-auto flex flex-shrink-0 flex-wrap items-center gap-2">
+            <Button type="button" variant="outline" onClick={onResetChat}>
+              Reset chat
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isConcurrencyThrottle) {
+    // Another credit-funded chat is still in flight server-side. Short
+    // wait, then retry — render a transient-feeling banner with a retry
+    // button. Top-up doesn't help here; just wait it out.
+    const retrySeconds = Math.max(
+      1,
+      Math.ceil((retryAfterMs ?? 0) / 1000),
+    );
+    return (
+      <div className="flex flex-col gap-2 border rounded p-3 border-border bg-muted/40 text-foreground">
+        <div className="flex items-start gap-3">
+          <CircleAlert className="h-4 w-4 flex-shrink-0 text-muted-foreground mt-0.5" />
+          <div className="min-w-0 flex-1">
+            <p className="text-xs leading-5">
+              Another credit-funded chat is finishing. Retry in{" "}
+              {retrySeconds} second{retrySeconds === 1 ? "" : "s"}.
+            </p>
+          </div>
+          <div className="ml-auto flex flex-shrink-0 flex-wrap items-center gap-2">
+            {onRetry && (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={onRetry}
+                className="gap-1.5"
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+                Retry
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/__tests__/chat-helpers-clone.test.ts
@@ -63,6 +63,7 @@ describe("formatErrorMessage", () => {
       isRetryable: false,
       isMCPJamPlatformError: true,
       canTopUp: true,
+      limitKind: "total",
     });
   });
 
@@ -145,5 +146,64 @@ describe("formatErrorMessage", () => {
       isRetryable: false,
       isMCPJamPlatformError: true,
     });
+  });
+
+  it("surfaces walletLocked: true on the formatted error", () => {
+    const result = formatErrorMessage(
+      JSON.stringify({
+        ok: false,
+        code: "wallet_locked",
+        limitKind: "total",
+        error: "Top-up is unavailable on this account. Contact support to resolve.",
+        isRetryable: false,
+        retryAfter: 0,
+        details:
+          "A recent payment was disputed. Wallet spend is paused pending review.",
+        canTopUp: false,
+        walletLocked: true,
+      }),
+    );
+
+    expect(result?.walletLocked).toBe(true);
+    expect(result?.code).toBe("wallet_locked");
+    expect(result?.canTopUp).toBe(false);
+    expect(result?.limitKind).toBe("total");
+  });
+
+  it("surfaces limitKind: \"concurrency\" with retryAfterMs for the throttle case", () => {
+    const result = formatErrorMessage(
+      JSON.stringify({
+        ok: false,
+        code: "user_rate_limit",
+        limitKind: "concurrency",
+        error: "Another credit-funded chat is still in flight.",
+        isRetryable: true,
+        retryAfter: 8000,
+        details: "Try again in 8 seconds.",
+        canTopUp: false,
+      }),
+    );
+
+    expect(result?.code).toBe("user_rate_limit");
+    expect(result?.limitKind).toBe("concurrency");
+    expect(result?.retryAfterMs).toBe(8000);
+    expect(result?.canTopUp).toBe(false);
+    expect(result).not.toHaveProperty("walletLocked");
+  });
+
+  it("does not crash on a legacy 429 without walletLocked or limitKind", () => {
+    const result = formatErrorMessage(
+      JSON.stringify({
+        code: "user_rate_limit",
+        error: "Daily MCPJam model limit reached.",
+        retryAfter: 4500000,
+        canTopUp: true,
+      }),
+    );
+
+    expect(result?.code).toBe("user_rate_limit");
+    expect(result?.canTopUp).toBe(true);
+    expect(result).not.toHaveProperty("walletLocked");
+    expect(result).not.toHaveProperty("limitKind");
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/chat-helpers.ts
@@ -171,6 +171,27 @@ export interface FormattedError {
   isRetryable?: boolean;
   isMCPJamPlatformError?: boolean;
   canTopUp?: boolean;
+  /**
+   * `true` when the server has paused this account from spending credits or
+   * starting a new top-up. The user cannot self-serve out of this state —
+   * the UI should render a contact-support message rather than any retry or
+   * top-up affordance.
+   */
+  walletLocked?: boolean;
+  /**
+   * Sub-classification of a rate-limit error.
+   *  - `"total"`: the user's daily credit budget is exhausted (the existing
+   *    happy-path rate-limit error; pairs with `canTopUp` to drive the CTA).
+   *  - `"concurrency"`: another credit-funded chat is still in flight; the
+   *    user just needs to wait a few seconds and retry. No top-up CTA.
+   */
+  limitKind?: "total" | "concurrency";
+  /**
+   * Raw `retryAfter` in milliseconds, surfaced for UIs that need
+   * second-level granularity (the existing `formatRetryAfter` rounds up to
+   * minutes). Used by the concurrency-throttle banner.
+   */
+  retryAfterMs?: number;
 }
 
 const USER_RATE_LIMIT_CODE = "user_rate_limit";
@@ -353,6 +374,8 @@ const formatMCPJamModelLimit = (
   extras?: {
     code?: string;
     canTopUp?: boolean;
+    limitKind?: "total" | "concurrency";
+    retryAfterMs?: number;
   },
 ): FormattedError => ({
   code: extras?.code ?? MCPJAM_RATE_LIMIT_CODE,
@@ -362,6 +385,10 @@ const formatMCPJamModelLimit = (
   isRetryable: false,
   isMCPJamPlatformError: true,
   ...(extras?.canTopUp !== undefined ? { canTopUp: extras.canTopUp } : {}),
+  ...(extras?.limitKind !== undefined ? { limitKind: extras.limitKind } : {}),
+  ...(extras?.retryAfterMs !== undefined
+    ? { retryAfterMs: extras.retryAfterMs }
+    : {}),
 });
 
 export function formatErrorMessage(error: unknown): FormattedError | null {
@@ -390,6 +417,26 @@ export function formatErrorMessage(error: unknown): FormattedError | null {
       const details = normalizeDetails(parsed.details);
       const canTopUp =
         typeof parsed.canTopUp === "boolean" ? parsed.canTopUp : undefined;
+      const walletLocked =
+        typeof parsed.walletLocked === "boolean"
+          ? parsed.walletLocked
+          : undefined;
+      const limitKind =
+        parsed.limitKind === "total" || parsed.limitKind === "concurrency"
+          ? parsed.limitKind
+          : undefined;
+      // `retryAfterMs` is only meaningful for the concurrency banner (which
+      // needs second-level granularity). The existing rate-limit copy
+      // already embeds a humanized retry phrase in `message`, so emitting
+      // raw ms there would duplicate information AND retroactively widen
+      // the FormattedError shape that legacy callers / tests assert via
+      // `toEqual`. Gate strictly on `limitKind === "concurrency"`.
+      const retryAfterMs =
+        limitKind === "concurrency" &&
+        typeof parsed.retryAfter === "number" &&
+        Number.isFinite(parsed.retryAfter)
+          ? parsed.retryAfter
+          : undefined;
 
       if (isMCPJamModelLimit(code, message, details)) {
         return formatMCPJamModelLimit(
@@ -398,6 +445,8 @@ export function formatErrorMessage(error: unknown): FormattedError | null {
           {
             code: typeof code === "string" ? code : undefined,
             canTopUp,
+            limitKind,
+            retryAfterMs,
           },
         );
       }
@@ -412,6 +461,9 @@ export function formatErrorMessage(error: unknown): FormattedError | null {
           ? MCPJAM_PLATFORM_CODES.includes(code)
           : false,
         ...(canTopUp !== undefined ? { canTopUp } : {}),
+        ...(walletLocked !== undefined ? { walletLocked } : {}),
+        ...(limitKind !== undefined ? { limitKind } : {}),
+        ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
       };
     }
   } catch {

--- a/mcpjam-inspector/client/src/hooks/useCreditTopup.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditTopup.ts
@@ -234,10 +234,27 @@ export function useCreditTopup() {
           source,
         });
         clearPendingTopup();
+
+        // Re-shape known server-side rate-limit responses into a friendlier,
+        // bounded user message. The dialog's existing toast displays
+        // `error.message` verbatim, so re-throwing a sanitized Error is
+        // enough to surface the right copy without double-toasting.
+        let surfaced: unknown = err;
+        if (
+          err instanceof Error &&
+          err.message.includes("Too many top-up attempts")
+        ) {
+          surfaced = new Error(
+            "You've hit the top-up rate limit. Try again in a few minutes.",
+          );
+        }
+
         const message =
-          err instanceof Error ? err.message : "Failed to start checkout";
+          surfaced instanceof Error
+            ? surfaced.message
+            : "Failed to start checkout";
         setError(message);
-        throw err;
+        throw surfaced;
       } finally {
         setIsStartingCheckout(false);
       }


### PR DESCRIPTION
## [Billing Credits] PR-I4: Wallet-locked + concurrency error states

The server now returns two new error states the inspector currently renders
generically. This PR threads the new fields through the chat error parser
and renders distinct UX for each, plus tightens one top-up dialog edge case.

### What's new

**1. Wallet-locked banner** — when the server marks an account as paused
(`walletLocked: true`), the chat error renders a dedicated "Account under
review" banner with a contact-support link. No top-up button, no retry —
the user can't self-serve out of this state.

```
┌─ Account under review ───────────────────────────────────┐
│ ⛨  We've paused this account while a recent payment is   │
│    reviewed. Reach out to support to get back in.        │
│                                          [Reset chat]    │
└──────────────────────────────────────────────────────────┘
```

**2. Concurrency-throttle retry UI** — when the server returns a
rate-limit with `limitKind: "concurrency"`, the chat error renders a
transient banner with a small Retry button and a seconds-level
countdown. No top-up CTA (topping up doesn't help — the user just needs
to wait).

```
┌─ Another credit-funded chat is finishing. Retry in 8 seconds. [Retry]
```

**3. Existing rate-limit + canTopUp path** — unchanged. Daily quota
exhausted with a paid wallet option still shows the existing
"Top up to keep chatting" CTA.

### Implementation

- **`chat-helpers.ts`**: `FormattedError` gains three optional fields
  (`walletLocked?: boolean`, `limitKind?: "total" | "concurrency"`,
  `retryAfterMs?: number`). Both parser branches (rate-limit and
  generic-structured) defensively extract them. `retryAfterMs` is
  emitted only for the concurrency case so the existing `toEqual`
  assertions on rate-limit results stay tight.
- **`error.tsx`**: two new early-return branches at the top of the
  component for the locked and concurrency states. The existing
  rate-limit / generic / auth-error paths are unchanged.
- **`ChatTabV2.tsx`**: a new `handleRetryConcurrencyMessage` callback
  reuses the existing `lastSentUserMessageRef` to resubmit the user's
  last typed message. The `onRetry` prop is gated on the error being a
  concurrency throttle so unrelated retryable errors don't surface a
  Retry button.
- **`useCreditTopup.ts`**: the `startCheckout` catch block now detects
  the server's "Too many top-up attempts" message and re-throws a
  sanitized "You've hit the top-up rate limit. Try again in a few
  minutes." The dialog's existing toast picks up the new message, so
  no double-toast and no unhandled propagation.

### Tests

Added 3 parser tests in `chat-helpers-clone.test.ts`:
- Wallet-locked field passes through.
- Concurrency `limitKind` + `retryAfterMs` pass through together.
- Legacy 429 without either field — both undefined, no crash.

The one existing assertion that turned out to be sensitive to the new
`limitKind: "total"` field (the JSON included it but the assertion
didn't) was extended to expect it.

`error.tsx` has no existing render-test pattern, so per the spec the
new states get manual verification rather than fabricated tests.

### Verification (manual)

- Craft a 429 with `walletLocked: true` → "Account under review"
  banner, no top-up, mailto link present.
- Craft a 429 with `limitKind: "concurrency"` and `retryAfter: 8000` →
  transient banner with "Retry in 8 seconds" + Retry button. Click
  Retry → resubmits the last typed user message.
- Existing daily-limit + canTopUp path → unchanged.
- Simulate `createCreditCheckoutSession` rejecting with "Too many
  top-up attempts. Try again in 5 minutes." → toast surfaces the
  friendlier sanitized copy; dialog doesn't crash.

Local run of all touched suites green:
- `chat-helpers-clone.test.ts` — 12 tests
- `client/src/components/billing` — 23 tests across 5 files
- `client/src/hooks/__tests__/useCreditTopup*` — 19 tests across 2 files
- `client/src/components/chat-v2/**` and `OrganizationsTab.billing.test.tsx` — 444 tests across 38 files

### Stack

This PR is a logical follow-up to PR-I3 (the existing billing-credits
stack), but submitted independently against `main` rather than stacked.
It builds on the `FormattedError` infrastructure introduced in PR-I1, so
expect to rebase once the I-stack merges.

**Rebased 2026-05-01** onto the redesigned PR-I3 tip — the I3 design
simplification (drop dollar values from the bars, retire the activity
table, switch to `hasPurchaseHistory` boolean) does not interact with
this PR's scope. Diff cleanly reapplied with no conflicts.

### Risk

Low. All new fields are optional; missing or wrong-type values default
to `undefined` (no crash, no false positives). The new UI states are
gated on explicit fields, so legacy responses keep their existing
rendering. The dialog's existing error path remains the same — only the
message it surfaces is now sanitized.
