### PR TITLE
Revert "Introduce Solo plan: rename Starter → Solo in inspector UI"

### DIFF
--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -107,11 +107,11 @@ interface ScheduledBillingChangeCancellationState {
 
 function shouldConfirmPaidUpgrade(
   billingStatus: OrganizationBillingStatus | undefined,
-  tier: "starter" | "solo" | "team",
+  tier: "starter" | "team",
 ): boolean {
   return (
     tier === "team" &&
-    (billingStatus?.plan === "starter" || billingStatus?.plan === "solo") &&
+    billingStatus?.plan === "starter" &&
     (billingStatus.subscriptionStatus === "active" ||
       billingStatus.subscriptionStatus === "trialing")
   );
@@ -170,7 +170,7 @@ function getScheduledBillingChangeCancellationState(
   const scheduledBillingInterval = billingStatus.stripeScheduledBillingInterval;
 
   if (
-    (currentPlan !== "starter" && currentPlan !== "solo" && currentPlan !== "team") ||
+    (currentPlan !== "starter" && currentPlan !== "team") ||
     currentBillingInterval == null ||
     scheduledPlan == null ||
     scheduledBillingInterval == null
@@ -796,7 +796,7 @@ function OrganizationPage({
 
     if (
       currentPlan === "team" &&
-      (targetPlan === "starter" || targetPlan === "solo") &&
+      targetPlan === "starter" &&
       billingStatus?.billingInterval != null
     ) {
       setPendingDowngradeConfirmation({
@@ -809,7 +809,7 @@ function OrganizationPage({
     }
 
     if (
-      (currentPlan === "starter" || currentPlan === "solo" || currentPlan === "team") &&
+      (currentPlan === "starter" || currentPlan === "team") &&
       targetPlan === "free"
     ) {
       setPendingDowngradeConfirmation({
@@ -858,7 +858,7 @@ function OrganizationPage({
 
       const result = await startPlanChange(
         getBillingReturnUrl(),
-        pendingDowngradeConfirmation.targetPlan as "starter",
+        "starter",
         pendingDowngradeConfirmation.targetBillingInterval ?? "monthly",
         { confirmPaidPlanChange: false },
       );
@@ -895,7 +895,7 @@ function OrganizationPage({
   };
 
   const executeManualPlanChange = async (
-    tier: "starter" | "solo" | "team",
+    tier: "starter" | "team",
     billingInterval: "monthly" | "annual",
     options: CheckoutNavigationOptions = {},
   ) => {
@@ -931,7 +931,7 @@ function OrganizationPage({
   };
 
   const handlePlanChange = async (
-    tier: "starter" | "solo" | "team",
+    tier: "starter" | "team",
     billingInterval: "monthly" | "annual",
     options: CheckoutNavigationOptions = {},
   ) => {
@@ -1550,7 +1550,7 @@ function OrganizationPage({
             <AlertDialogTitle>
               {pendingDowngradeConfirmation?.targetPlan === "free"
                 ? "Return to Free at renewal?"
-                : `Downgrade to ${formatPlanName(pendingDowngradeConfirmation?.targetPlan)}?`}
+                : "Downgrade to Starter?"}
             </AlertDialogTitle>
             <AlertDialogDescription className="space-y-2">
               {pendingDowngradeConfirmation?.targetPlan === "free" ? (
@@ -1575,7 +1575,7 @@ function OrganizationPage({
                     This downgrade takes effect at renewal, not now.
                   </span>
                   <span className="block">
-                    {pendingDowngradeTargetLabel ?? "Solo"} begins{" "}
+                    {pendingDowngradeTargetLabel ?? "Starter"} begins{" "}
                     {pendingDowngradeEffectiveDate ??
                       "at the end of the current billing period"}
                     .
@@ -1592,7 +1592,7 @@ function OrganizationPage({
             <span className="font-medium text-foreground">
               {pendingDowngradeConfirmation?.targetPlan === "free"
                 ? "Stripe will open a cancellation flow that keeps paid access active until renewal."
-                : `${pendingDowngradeTargetLabel ?? "Solo"} will replace ${
+                : `${pendingDowngradeTargetLabel ?? "Starter"} will replace ${
                     pendingDowngradeCurrentLabel ?? "the current plan"
                   } at renewal.`}
             </span>
@@ -1634,14 +1634,14 @@ function OrganizationPage({
             <AlertDialogDescription className="space-y-2">
               <span className="block">
                 This upgrade takes effect immediately and updates your existing
-                Solo subscription in place.
+                Starter subscription in place.
               </span>
               <span className="block">
                 We do not send you through Stripe Checkout.
               </span>
               <span className="block">
                 Stripe prorates the rest of your current billing period instead
-                of waiting until renewal, so unused Solo time is factored
+                of waiting until renewal, so unused Starter time is factored
                 into the Team change.
               </span>
             </AlertDialogDescription>

--- a/mcpjam-inspector/client/src/components/__tests__/ChatboxesTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatboxesTab.test.tsx
@@ -70,7 +70,7 @@ function createPlanCatalog() {
       },
       starter: {
         plan: "starter",
-        displayName: "Solo",
+        displayName: "Starter",
         billingModel: "flat",
         isSelfServe: true,
         prices: { monthly: 6100, annual: 58800 },

--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
@@ -72,7 +72,7 @@ function createPlanCatalog() {
       },
       starter: {
         plan: "starter",
-        displayName: "Solo",
+        displayName: "Starter",
         billingModel: "flat",
         isSelfServe: true,
         prices: { monthly: 6100, annual: 58800 },
@@ -517,7 +517,7 @@ describe("OrganizationsTab billing", () => {
       screen.queryByRole("button", { name: "Change to monthly" }),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Keep Solo annual plan" }),
+      screen.getByRole("button", { name: "Keep Starter annual plan" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Manage plan" }),
@@ -628,7 +628,7 @@ describe("OrganizationsTab billing", () => {
     expect(
       screen.getByTestId("current-plan-scheduled-change"),
     ).toHaveTextContent(
-      "Solo monthly starts Apr 1, 2027. Team annual remains active until then.",
+      "Starter monthly starts Apr 1, 2027. Team annual remains active until then.",
     );
     expect(
       screen.getByRole("button", { name: "Keep Team annual plan" }),
@@ -640,7 +640,7 @@ describe("OrganizationsTab billing", () => {
     await waitFor(() => {
       expect(
         screen.getByText(
-          "This cancels the pending change to Solo monthly on Apr 1, 2027. Team annual remains active.",
+          "This cancels the pending change to Starter monthly on Apr 1, 2027. Team annual remains active.",
         ),
       ).toBeInTheDocument();
     });
@@ -670,7 +670,7 @@ describe("OrganizationsTab billing", () => {
     expect(
       screen.getByTestId("current-plan-scheduled-change"),
     ).toHaveTextContent(
-      "Solo monthly starts Apr 1, 2027. Team annual remains active until then.",
+      "Starter monthly starts Apr 1, 2027. Team annual remains active until then.",
     );
     expect(
       screen.queryByRole("button", { name: "Keep Team annual plan" }),
@@ -696,7 +696,7 @@ describe("OrganizationsTab billing", () => {
 
     render(<OrganizationsTab organizationId="org-1" />);
 
-    expect(screen.getByText("Solo Trial")).toBeInTheDocument();
+    expect(screen.getByText("Starter Trial")).toBeInTheDocument();
     expect(
       screen.getByText("7-day trial · no active subscription yet"),
     ).toBeInTheDocument();
@@ -721,10 +721,10 @@ describe("OrganizationsTab billing", () => {
 
     render(<OrganizationsTab organizationId="org-1" />);
 
-    expect(screen.getByText("Solo")).toBeInTheDocument();
+    expect(screen.getByText("Starter")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Simulation active. Limits and access use Solo, while billing remains on Free.",
+        "Simulation active. Limits and access use Starter, while billing remains on Free.",
       ),
     ).toBeInTheDocument();
     expect(
@@ -784,7 +784,7 @@ describe("OrganizationsTab billing", () => {
 
     expect(screen.getByText("Plans & Billing")).toBeInTheDocument();
     expect(screen.getAllByText("Current plan").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Solo").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Starter").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Team").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Enterprise").length).toBeGreaterThan(0);
   });
@@ -974,11 +974,11 @@ describe("OrganizationsTab billing", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Solo includes up to 3 members and 2 workspaces for $61/mo flat.",
+        "Starter includes up to 3 members and 2 workspaces for $61/mo flat.",
       ),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Upgrade to Solo" }),
+      screen.getByRole("button", { name: "Upgrade to Starter" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Add member" })).toBeDisabled();
   });
@@ -1061,7 +1061,7 @@ describe("OrganizationsTab billing", () => {
       screen.getByText("Ask an organization owner to review billing options."),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Upgrade to Solo" }),
+      screen.queryByRole("button", { name: "Upgrade to Starter" }),
     ).not.toBeInTheDocument();
   });
 
@@ -1150,7 +1150,7 @@ describe("OrganizationsTab billing", () => {
     render(<OrganizationsTab organizationId="org-1" section="billing" />);
 
     expect(
-      within(getPlanColumn("Solo")).getByRole("button", {
+      within(getPlanColumn("Starter")).getByRole("button", {
         name: "Upgrade",
       }),
     ).toBeDisabled();
@@ -1184,7 +1184,7 @@ describe("OrganizationsTab billing", () => {
     expect(screen.getByText("Upgrade to Team?")).toBeInTheDocument();
     expect(
       screen.getByText(
-        "This upgrade takes effect immediately and updates your existing Solo subscription in place.",
+        "This upgrade takes effect immediately and updates your existing Starter subscription in place.",
       ),
     ).toBeInTheDocument();
     expect(
@@ -1192,7 +1192,7 @@ describe("OrganizationsTab billing", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        "Stripe prorates the rest of your current billing period instead of waiting until renewal, so unused Solo time is factored into the Team change.",
+        "Stripe prorates the rest of your current billing period instead of waiting until renewal, so unused Starter time is factored into the Team change.",
       ),
     ).toBeInTheDocument();
     expect(
@@ -1354,12 +1354,12 @@ describe("OrganizationsTab billing", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /^Monthly$/ }));
     fireEvent.click(
-      within(getPlanColumn("Solo")).getByRole("button", {
+      within(getPlanColumn("Starter")).getByRole("button", {
         name: "Downgrade",
       }),
     );
 
-    expect(screen.getByText("Downgrade to Solo?")).toBeInTheDocument();
+    expect(screen.getByText("Downgrade to Starter?")).toBeInTheDocument();
     expect(
       screen.getByText("This downgrade takes effect at renewal, not now."),
     ).toBeInTheDocument();
@@ -1379,7 +1379,7 @@ describe("OrganizationsTab billing", () => {
     });
     expect(openSpy).not.toHaveBeenCalled();
     expect(toast.success).toHaveBeenCalledWith(
-      "Downgrade to Solo monthly scheduled for renewal.",
+      "Downgrade to Starter monthly scheduled for renewal.",
     );
 
     view.rerender(<OrganizationsTab organizationId="org-1" />);
@@ -1387,7 +1387,7 @@ describe("OrganizationsTab billing", () => {
     expect(
       screen.getByTestId("current-plan-scheduled-change"),
     ).toHaveTextContent(
-      "Solo monthly starts Apr 1, 2027. Team annual remains active until then.",
+      "Starter monthly starts Apr 1, 2027. Team annual remains active until then.",
     );
     expect(
       screen.getByRole("button", { name: "Keep Team annual plan" }),
@@ -1434,7 +1434,7 @@ describe("OrganizationsTab billing", () => {
       screen.getByText("This cancellation takes effect at renewal, not now."),
     ).toBeInTheDocument();
     expect(
-      screen.getByText("Solo annual remains active until Apr 1, 2027."),
+      screen.getByText("Starter annual remains active until Apr 1, 2027."),
     ).toBeInTheDocument();
     expect(
       screen.getByText("After that, the organization returns to Free."),

--- a/mcpjam-inspector/client/src/components/billing/__tests__/BillingUpsellGate.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/BillingUpsellGate.test.tsx
@@ -19,7 +19,7 @@ describe("BillingUpsellGate", () => {
 
     expect(screen.getByText("Generate Evals")).toBeInTheDocument();
     expect(
-      screen.getByText(/Included in Solo and above/i),
+      screen.getByText(/Included in Starter and above/i),
     ).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /upgrade/i }));
     expect(onNavigate).toHaveBeenCalledTimes(1);

--- a/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
@@ -59,9 +59,7 @@ const LLM_USAGE_SECTION_TOOLTIP =
   "LLM usage billing isn’t live yet, so models are currently free. For paid plans, the table reflects the intended $5 per user per day rate limit and may change before billing launches.";
 
 function getPlanRank(plan: OrganizationPlan): number {
-  // "solo" is the canonical rename of "starter" — treat them as the same tier.
-  const normalized = plan === "solo" ? "starter" : plan;
-  return PLAN_ORDER.indexOf(normalized);
+  return PLAN_ORDER.indexOf(plan);
 }
 
 function getPlanColumnCta(params: {
@@ -76,7 +74,7 @@ function getPlanColumnCta(params: {
     billingInterval: BillingInterval,
   ) => void;
   onStartPlanChange: (
-    plan: "starter" | "solo" | "team",
+    plan: "starter" | "team",
     billingInterval: BillingInterval,
   ) => Promise<void>;
   billingInterval: BillingInterval;
@@ -98,9 +96,7 @@ function getPlanColumnCta(params: {
     billingInterval,
   } = params;
 
-  const isSoloPlan = (p: OrganizationPlan) => p === "starter" || p === "solo";
-  const isCurrentPlan =
-    currentPlan === plan || (isSoloPlan(currentPlan) && isSoloPlan(plan));
+  const isCurrentPlan = currentPlan === plan;
   const isHigherTier = getPlanRank(plan) > getPlanRank(currentPlan);
   const isDowngrade = getPlanRank(plan) < getPlanRank(currentPlan);
   const isEnterprisePlan = plan === "enterprise";
@@ -132,7 +128,7 @@ function getPlanColumnCta(params: {
   }
 
   if (isHigherTier && entry.isSelfServe) {
-    if (plan !== "starter" && plan !== "solo" && plan !== "team") {
+    if (plan !== "starter" && plan !== "team") {
       return { label: "Unavailable", disabled: true, variant: "outline" };
     }
     return {
@@ -160,7 +156,7 @@ function formatCurrency(
   }).format(amount);
 }
 
-/** Price line for the compare table; Solo uses flat `/mo` (3-seat cap), Team uses `/seat/mo`. */
+/** Price line for the compare table; Starter uses flat `/mo` (3-seat cap), Team uses `/seat/mo`. */
 function formatPlanPriceLabel(
   plan: OrganizationPlan,
   amountInCents: number | null,
@@ -171,7 +167,7 @@ function formatPlanPriceLabel(
     return interval === "annual" ? "Custom annual" : "Custom pricing";
   }
 
-  if (plan === "starter" || plan === "solo") {
+  if (plan === "starter") {
     if (interval === "monthly") {
       return `${formatCurrency(amountInCents / 100, currency, 0)}/mo`;
     }
@@ -433,7 +429,7 @@ function BillingIntervalToggle({
         Annual
         <span
           className="shrink-0 rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary sm:px-2 sm:text-xs"
-          title="Solo: savings vs paying the monthly rate for 12 months."
+          title="Starter: savings vs paying the monthly rate for 12 months (e.g. $61×12 vs $588/year)."
         >
           -{annualDiscountPct}%
         </span>
@@ -461,18 +457,18 @@ interface OrganizationBillingSectionProps {
   isLoadingBilling: boolean;
   isLoadingPlanCatalog: boolean;
   isStartingPlanChange: boolean;
-  pendingPlanChangeTarget: "starter" | "solo" | "team" | null;
+  pendingPlanChangeTarget: "starter" | "team" | null;
   isOpeningPortal: boolean;
   onDowngradePlan: (
     plan: OrganizationPlan,
     billingInterval: BillingInterval,
   ) => Promise<void>;
   onStartPlanChange: (
-    plan: "starter" | "solo" | "team",
+    plan: "starter" | "team",
     billingInterval: BillingInterval,
   ) => Promise<void>;
   onStartAutoPlanChange?: (
-    plan: "starter" | "solo" | "team",
+    plan: "starter" | "team",
     billingInterval: BillingInterval,
   ) => Promise<void>;
   checkoutIntent?: CheckoutIntentWithOrganization | null;
@@ -854,7 +850,7 @@ export function OrganizationBillingSection({
                           pendingPlanChangeTarget === plan &&
                           (cta.label === "Upgrade" ||
                             cta.label === "Downgrade") &&
-                          (plan === "starter" || plan === "solo" || plan === "team");
+                          (plan === "starter" || plan === "team");
                         const showCtaSpinner = showPlanChangeSpinner;
                         const isPopular = plan === POPULAR_PLAN;
                         return (

--- a/mcpjam-inspector/client/src/components/organization/OrganizationCurrentPlanPanel.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationCurrentPlanPanel.tsx
@@ -247,7 +247,7 @@ export function OrganizationCurrentPlanPanel({
     billingConfigured &&
     canManageBilling &&
     !isTrial &&
-    (currentPlan === "starter" || currentPlan === "solo" || currentPlan === "team") &&
+    (currentPlan === "starter" || currentPlan === "team") &&
     billingStatus.billingInterval != null &&
     scheduledChangeDetailLine == null &&
     !billingStatus.stripeCancelAtPeriodEnd;

--- a/mcpjam-inspector/client/src/components/organization/billing-compare-view-model.ts
+++ b/mcpjam-inspector/client/src/components/organization/billing-compare-view-model.ts
@@ -33,7 +33,7 @@ function formatSeatLimit(
     return t("1 (just you)");
   }
   const value =
-    plan === "starter" || plan === "solo"
+    plan === "starter"
       ? (entry.includedSeats ?? entry.limits.maxMembers)
       : entry.limits.maxMembers;
   if (value == null) {

--- a/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizationBilling.ts
@@ -1,7 +1,7 @@
 import { useAction, useMutation, useQuery } from "convex/react";
 import { useCallback, useState } from "react";
 
-export type OrganizationPlan = "free" | "starter" | "solo" | "team" | "enterprise";
+export type OrganizationPlan = "free" | "starter" | "team" | "enterprise";
 export type BillingInterval = "monthly" | "annual";
 export type BillingModel = "free" | "flat" | "per_seat" | "contact";
 export type BillingFeatureName =
@@ -110,7 +110,7 @@ export interface PlanCatalogEntry {
   includedSeats: number | null;
   seatMinimum: number | null;
   checkout: {
-    plan: "starter" | "solo" | "team";
+    plan: "starter" | "team";
     supportedIntervals: BillingInterval[];
   } | null;
 }
@@ -129,7 +129,7 @@ export interface OrganizationPlanChangeSnapshot {
   stripeSubscriptionItemId?: string;
   stripePriceId?: string;
   stripeSeatQuantity?: number;
-  stripeScheduledPlan?: "starter" | "solo" | "team" | null;
+  stripeScheduledPlan?: "starter" | "team" | null;
   stripeScheduledBillingInterval?: BillingInterval | null;
   stripeScheduledPriceId?: string | null;
   stripeScheduledEffectiveAt?: number | null;
@@ -243,7 +243,7 @@ export function useOrganizationBilling(
 
   const [isStartingPlanChange, setIsStartingPlanChange] = useState(false);
   const [pendingPlanChangeTarget, setPendingPlanChangeTarget] = useState<
-    "starter" | "solo" | "team" | null
+    "starter" | "team" | null
   >(null);
   const [isOpeningPortal, setIsOpeningPortal] = useState(false);
   const [
@@ -257,7 +257,7 @@ export function useOrganizationBilling(
   const startPlanChange = useCallback(
     async (
       returnUrl: string,
-      tier: "starter" | "solo" | "team" = "solo",
+      tier: "starter" | "team" = "starter",
       billingInterval: BillingInterval = "monthly",
       options: StartOrganizationPlanChangeOptions = {},
     ): Promise<OrganizationPlanChangeResult> => {

--- a/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/billing-entitlements.test.ts
@@ -16,7 +16,7 @@ const minimalCatalogEntry = (
 ): PlanCatalogEntry =>
   ({
     plan: "starter",
-    displayName: "Solo",
+    displayName: "Starter",
     isSelfServe: true,
     prices,
     features: {} as PlanCatalogEntry["features"],
@@ -177,7 +177,7 @@ describe("getBillingErrorMessage", () => {
     );
 
     expect(message).toBe(
-      "Chatboxes is not included in the Free plan. Upgrade to Solo to continue.",
+      "Chatboxes is not included in the Free plan. Upgrade to Starter to continue.",
     );
   });
 
@@ -196,7 +196,7 @@ describe("getBillingErrorMessage", () => {
     );
 
     expect(message).toBe(
-      "Chatboxes is not included in the Free plan. Ask an organization owner to upgrade to Solo.",
+      "Chatboxes is not included in the Free plan. Ask an organization owner to upgrade to Starter.",
     );
   });
 

--- a/mcpjam-inspector/client/src/lib/billing-checkout-intent-guard.ts
+++ b/mcpjam-inspector/client/src/lib/billing-checkout-intent-guard.ts
@@ -6,12 +6,11 @@ import type {
 const PLAN_RANK: Record<OrganizationPlan, number> = {
   free: 0,
   starter: 1,
-  solo: 1,
   team: 2,
   enterprise: 3,
 };
 
-export type CheckoutPlanTier = "starter" | "solo" | "team";
+export type CheckoutPlanTier = "starter" | "team";
 
 export type CheckoutIntentGuardResult =
   | { proceed: true }

--- a/mcpjam-inspector/client/src/lib/billing-deep-link.ts
+++ b/mcpjam-inspector/client/src/lib/billing-deep-link.ts
@@ -1,6 +1,6 @@
 import type { BillingInterval } from "@/hooks/useOrganizationBilling";
 
-export type CheckoutPlanTier = "starter" | "solo" | "team";
+export type CheckoutPlanTier = "starter" | "team";
 
 export interface CheckoutIntent {
   plan: CheckoutPlanTier;
@@ -15,7 +15,7 @@ export type CheckoutIntentWithOrganization = CheckoutIntent & {
 const STORAGE_KEY = "mcpjam:checkout-intent";
 const SIGN_IN_RETURN_PATH_STORAGE_KEY = "mcpjam:billing-signin-return-path";
 
-const VALID_PLANS = new Set<CheckoutPlanTier>(["starter", "solo", "team"]);
+const VALID_PLANS = new Set<CheckoutPlanTier>(["starter", "team"]);
 const VALID_INTERVALS = new Set<BillingInterval>(["monthly", "annual"]);
 
 function parseSearchParams(search: string): URLSearchParams {

--- a/mcpjam-inspector/client/src/lib/billing-entitlements.ts
+++ b/mcpjam-inspector/client/src/lib/billing-entitlements.ts
@@ -24,9 +24,8 @@ export function getAnnualDiscountPercent(
   if (!planCatalog) {
     return 0;
   }
-  const entry = planCatalog.plans.solo ?? planCatalog.plans.starter;
-  const monthly = entry?.prices.monthly;
-  const annual = entry?.prices.annual;
+  const monthly = planCatalog.plans.starter.prices.monthly;
+  const annual = planCatalog.plans.starter.prices.annual;
   if (monthly == null || annual == null || monthly <= 0) {
     return 0;
   }
@@ -176,8 +175,7 @@ export function formatPlanName(
     case "free":
       return "Free";
     case "starter":
-    case "solo":
-      return "Solo";
+      return "Starter";
     case "team":
       return "Team";
     case "enterprise":


### PR DESCRIPTION
Reverts MCPJam/inspector#1996

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates billing plan enums and UI logic across checkout/deep-linking and plan-change flows; mistakes could break plan transitions or render incorrect CTAs/text for paid users. Changes are localized to client-side billing/plan presentation and associated tests.
> 
> **Overview**
> Reverts the prior *Starter → Solo* rename by removing the `solo` tier from client plan types/checkout tiers and updating plan-rank/CTA logic to treat only `starter` and `team` as self-serve paid plans.
> 
> Updates billing UI copy (upgrade/downgrade confirmations, scheduled change messaging, upsell text) to consistently display **Starter**, and adjusts deep-link validation, annual discount computation, and related unit tests to match the restored plan taxonomy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ea27623f8a6ea85d16144270d570319355b207c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->