### PR TITLE
Guest sessions

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/useRegistryServers.guest-merge.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useRegistryServers.guest-merge.test.tsx
@@ -1,0 +1,93 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as registryHttp from "@/lib/apis/registry-http";
+import { useRegistryServers } from "../useRegistryServers";
+
+const { mockGetExistingGuestBearerToken, mockClearGuestSession } = vi.hoisted(
+  () => ({
+    mockGetExistingGuestBearerToken: vi.fn(),
+    mockClearGuestSession: vi.fn(),
+  }),
+);
+
+vi.mock("@/lib/apis/registry-http", () => ({
+  fetchRegistryCatalog: vi.fn().mockResolvedValue([]),
+  starRegistryCard: vi.fn(),
+  unstarRegistryCard: vi.fn(),
+  mergeGuestRegistryStars: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
+}));
+
+vi.mock("@/lib/guest-session", () => ({
+  getExistingGuestBearerToken: mockGetExistingGuestBearerToken,
+  clearGuestSession: mockClearGuestSession,
+}));
+
+vi.mock("@/lib/apis/web/context", () => ({
+  resetTokenCache: vi.fn(),
+}));
+
+vi.mock("@/lib/config", () => ({
+  HOSTED_MODE: true,
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: () => undefined,
+  useMutation: () => vi.fn(),
+}));
+
+describe("useRegistryServers (guest merge after sign-in)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("merges guest stars using lookup_only when an existing guest exists", async () => {
+    mockGetExistingGuestBearerToken.mockResolvedValue("guest-bearer-1");
+    vi.mocked(registryHttp.mergeGuestRegistryStars).mockResolvedValue(undefined);
+
+    renderHook(() =>
+      useRegistryServers({
+        projectId: "project-1",
+        isAuthenticated: true,
+        liveServers: {},
+        onConnect: vi.fn(),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetExistingGuestBearerToken).toHaveBeenCalledTimes(1);
+    });
+
+    await waitFor(() => {
+      expect(registryHttp.mergeGuestRegistryStars).toHaveBeenCalledWith(
+        "guest-bearer-1",
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockClearGuestSession).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not call merge when there is no existing guest", async () => {
+    mockGetExistingGuestBearerToken.mockResolvedValue(null);
+
+    renderHook(() =>
+      useRegistryServers({
+        projectId: "project-1",
+        isAuthenticated: true,
+        liveServers: {},
+        onConnect: vi.fn(),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockGetExistingGuestBearerToken).toHaveBeenCalledTimes(1);
+    });
+    expect(registryHttp.mergeGuestRegistryStars).not.toHaveBeenCalled();
+    expect(mockClearGuestSession).not.toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/useRegistryServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useRegistryServers.test.tsx
@@ -25,6 +25,15 @@ vi.mock("sonner", () => ({
   toast: { error: vi.fn() },
 }));
 
+vi.mock("@/lib/guest-session", () => ({
+  getExistingGuestBearerToken: vi.fn().mockResolvedValue(null),
+  clearGuestSession: vi.fn(),
+}));
+
+vi.mock("@/lib/apis/web/context", () => ({
+  resetTokenCache: vi.fn(),
+}));
+
 vi.mock("@/lib/config", () => ({
   HOSTED_MODE: false,
 }));

--- a/mcpjam-inspector/client/src/hooks/useRegistryServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useRegistryServers.ts
@@ -11,7 +11,10 @@ import {
 } from "@/lib/apis/registry-http";
 import { WebApiError } from "@/lib/apis/web/base";
 import { HOSTED_MODE } from "@/lib/config";
-import { peekStoredGuestToken, clearGuestSession } from "@/lib/guest-session";
+import {
+  clearGuestSession,
+  getExistingGuestBearerToken,
+} from "@/lib/guest-session";
 import { resetTokenCache } from "@/lib/apis/web/context";
 import { toast } from "sonner";
 
@@ -412,11 +415,14 @@ export function useRegistryServers({
   useEffect(() => {
     if (!enabled) return;
     if (!HOSTED_MODE || !isAuthenticated || DEV_MOCK_REGISTRY) return;
-    const guestToken = peekStoredGuestToken();
-    if (!guestToken || mergeRanRef.current) return;
+    if (mergeRanRef.current) return;
     mergeRanRef.current = true;
     void (async () => {
       try {
+        const guestToken = await getExistingGuestBearerToken();
+        if (!guestToken) {
+          return;
+        }
         await mergeGuestRegistryStars(guestToken);
         clearGuestSession();
         resetTokenCache();

--- a/mcpjam-inspector/client/src/hooks/useRegistryServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useRegistryServers.ts
@@ -384,9 +384,18 @@ export function useRegistryServers({
 
   const mergeRanRef = useRef(false);
   const mergeInFlightRef = useRef(false);
+  // Bumped after a transient merge failure to force the merge effect to
+  // re-run (refs alone don't participate in effect deps). Bounded so a
+  // persistent error doesn't loop forever.
+  const [mergeRetryNonce, setMergeRetryNonce] = useState(0);
+  const mergeAttemptCountRef = useRef(0);
+  const MAX_MERGE_ATTEMPTS = 3;
 
   useEffect(() => {
-    if (!isAuthenticated) mergeRanRef.current = false;
+    if (!isAuthenticated) {
+      mergeRanRef.current = false;
+      mergeAttemptCountRef.current = 0;
+    }
   }, [isAuthenticated]);
 
   const loadCatalog = useCallback(async () => {
@@ -417,21 +426,28 @@ export function useRegistryServers({
     if (!enabled) return;
     if (!HOSTED_MODE || !isAuthenticated || DEV_MOCK_REGISTRY) return;
     if (mergeRanRef.current || mergeInFlightRef.current) return;
+    if (mergeAttemptCountRef.current >= MAX_MERGE_ATTEMPTS) return;
     mergeInFlightRef.current = true;
+    mergeAttemptCountRef.current += 1;
+    let cancelled = false;
+    let retryTimeout: ReturnType<typeof setTimeout> | null = null;
     void (async () => {
       try {
         const guestToken = await getExistingGuestBearerToken();
-        // null here is a definitive "no guest exists" miss (HTTP 204/404
-        // from upstream); transient errors throw and are handled below so
-        // we don't permanently latch the merge as done after a network blip.
+        if (cancelled) return;
+        // null here is a definitive "no guest exists" miss (HTTP 204 from
+        // upstream); transient errors throw and are handled below so we
+        // don't permanently latch the merge as done after a network blip.
         if (!guestToken) {
           mergeRanRef.current = true;
           return;
         }
         await mergeGuestRegistryStars(guestToken);
+        if (cancelled) return;
         clearGuestSession();
         resetTokenCache();
         await loadCatalog();
+        if (cancelled) return;
         mergeRanRef.current = true;
       } catch (error) {
         const message =
@@ -439,11 +455,26 @@ export function useRegistryServers({
             ? error.message
             : "Could not merge guest stars";
         toast.error(message);
+        // Schedule a retry by bumping the nonce, which is in this effect's
+        // deps. Backoff grows with attempt count; capped by MAX_MERGE_ATTEMPTS.
+        if (
+          !cancelled &&
+          mergeAttemptCountRef.current < MAX_MERGE_ATTEMPTS
+        ) {
+          const delayMs = 1_000 * 2 ** (mergeAttemptCountRef.current - 1);
+          retryTimeout = setTimeout(() => {
+            if (!cancelled) setMergeRetryNonce((n) => n + 1);
+          }, delayMs);
+        }
       } finally {
         mergeInFlightRef.current = false;
       }
     })();
-  }, [enabled, isAuthenticated, loadCatalog]);
+    return () => {
+      cancelled = true;
+      if (retryTimeout !== null) clearTimeout(retryTimeout);
+    };
+  }, [enabled, isAuthenticated, loadCatalog, mergeRetryNonce]);
 
   const connections = useQuery(
     "registryServers:getProjectRegistryConnections" as any,

--- a/mcpjam-inspector/client/src/hooks/useRegistryServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useRegistryServers.ts
@@ -383,6 +383,7 @@ export function useRegistryServers({
   );
 
   const mergeRanRef = useRef(false);
+  const mergeInFlightRef = useRef(false);
 
   useEffect(() => {
     if (!isAuthenticated) mergeRanRef.current = false;
@@ -415,25 +416,31 @@ export function useRegistryServers({
   useEffect(() => {
     if (!enabled) return;
     if (!HOSTED_MODE || !isAuthenticated || DEV_MOCK_REGISTRY) return;
-    if (mergeRanRef.current) return;
-    mergeRanRef.current = true;
+    if (mergeRanRef.current || mergeInFlightRef.current) return;
+    mergeInFlightRef.current = true;
     void (async () => {
       try {
         const guestToken = await getExistingGuestBearerToken();
+        // null here is a definitive "no guest exists" miss (HTTP 204/404
+        // from upstream); transient errors throw and are handled below so
+        // we don't permanently latch the merge as done after a network blip.
         if (!guestToken) {
+          mergeRanRef.current = true;
           return;
         }
         await mergeGuestRegistryStars(guestToken);
         clearGuestSession();
         resetTokenCache();
         await loadCatalog();
+        mergeRanRef.current = true;
       } catch (error) {
-        mergeRanRef.current = false;
         const message =
           error instanceof WebApiError
             ? error.message
             : "Could not merge guest stars";
         toast.error(message);
+      } finally {
+        mergeInFlightRef.current = false;
       }
     })();
   }, [enabled, isAuthenticated, loadCatalog]);

--- a/mcpjam-inspector/client/src/lib/__tests__/guest-session.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/guest-session.test.ts
@@ -218,7 +218,7 @@ describe("guest-session module", () => {
       );
     });
 
-    it("deletes legacy token even when the migration fetch fails", async () => {
+    it("keeps legacy token when the migration fetch throws", async () => {
       vi.mocked(localStorage.getItem).mockReturnValue(
         JSON.stringify({
           guestId: "legacy",
@@ -229,6 +229,89 @@ describe("guest-session module", () => {
       vi.mocked(global.fetch).mockRejectedValue(new Error("offline"));
 
       await guestSession.getOrCreateGuestSession();
+      expect(localStorage.removeItem).not.toHaveBeenCalledWith(
+        LEGACY_STORAGE_KEY,
+      );
+    });
+
+    it("keeps legacy token when the migration fetch returns 503", async () => {
+      vi.mocked(localStorage.getItem).mockReturnValue(
+        JSON.stringify({
+          guestId: "legacy",
+          token: "legacy-token",
+          expiresAt: Date.now() - 1000,
+        }),
+      );
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: "Service Unavailable",
+      } as Response);
+
+      await guestSession.getOrCreateGuestSession();
+      expect(localStorage.removeItem).not.toHaveBeenCalledWith(
+        LEGACY_STORAGE_KEY,
+      );
+    });
+
+    it("keeps legacy token when the migration response body is malformed", async () => {
+      vi.mocked(localStorage.getItem).mockReturnValue(
+        JSON.stringify({
+          guestId: "legacy",
+          token: "legacy-token",
+          expiresAt: Date.now() - 1000,
+        }),
+      );
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ guestId: "legacy" }),
+      } as Response);
+
+      await guestSession.getOrCreateGuestSession();
+      expect(localStorage.removeItem).not.toHaveBeenCalledWith(
+        LEGACY_STORAGE_KEY,
+      );
+    });
+
+    it("retries legacy migration after a transient failure and deletes after success", async () => {
+      vi.mocked(localStorage.getItem).mockReturnValue(
+        JSON.stringify({
+          guestId: "legacy",
+          token: "legacy-token",
+          expiresAt: Date.now() - 1000,
+        }),
+      );
+      vi.mocked(global.fetch)
+        .mockRejectedValueOnce(new Error("offline"))
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              guestId: "legacy",
+              token: "fresh",
+              expiresAt: Date.now() + 60_000,
+            }),
+        } as Response);
+
+      const first = await guestSession.getOrCreateGuestSession();
+      expect(first).toBeNull();
+      expect(localStorage.removeItem).not.toHaveBeenCalledWith(
+        LEGACY_STORAGE_KEY,
+      );
+
+      const second = await guestSession.getOrCreateGuestSession();
+      expect(second?.token).toBe("fresh");
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      for (const call of vi.mocked(global.fetch).mock.calls) {
+        expect(call[1]?.body).toBe(
+          JSON.stringify({
+            mode: "lookup_or_create",
+            legacyToken: "legacy-token",
+          }),
+        );
+      }
       expect(localStorage.removeItem).toHaveBeenCalledWith(LEGACY_STORAGE_KEY);
     });
   });
@@ -356,6 +439,90 @@ describe("guest-session module", () => {
       expect(localStorage.removeItem).not.toHaveBeenCalledWith(
         LEGACY_STORAGE_KEY,
       );
+    });
+  });
+
+  describe("generation guard", () => {
+    it("does not resurrect cachedSession when a stale fetch resolves after clearGuestSession", async () => {
+      let resolveFetch: (value: Response) => void = () => {};
+      vi.mocked(global.fetch).mockImplementation(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+          }),
+      );
+
+      const pending = guestSession.getOrCreateGuestSession();
+      // Clear before the in-flight request resolves.
+      guestSession.clearGuestSession();
+      // Now resolve the original request with what would have been a valid
+      // session — the stale generation should prevent it from landing in
+      // the cache.
+      resolveFetch({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            guestId: "stale",
+            token: "stale-token",
+            expiresAt: Date.now() + 60_000,
+          }),
+      } as Response);
+      await pending;
+
+      // Subsequent lookup must not return the resurrected stale token.
+      vi.mocked(global.fetch).mockReset();
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        status: 204,
+        statusText: "No Content",
+      } as Response);
+      const token = await guestSession.getExistingGuestBearerToken();
+      expect(token).toBeNull();
+    });
+
+    it("does not resurrect cachedSession after forceRefreshGuestSession", async () => {
+      // Prime an in-flight lookup_or_create whose response is delayed.
+      let resolveStale: (value: Response) => void = () => {};
+      vi.mocked(global.fetch).mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveStale = resolve;
+          }),
+      );
+      const stalePending = guestSession.getOrCreateGuestSession();
+
+      // Refresh fires a new fetch that resolves immediately with a fresh
+      // token. The stale fetch is still pending.
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            guestId: "fresh",
+            token: "fresh-token",
+            expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+          }),
+      } as Response);
+      const refreshed = await guestSession.forceRefreshGuestSession();
+      expect(refreshed).toBe("fresh-token");
+
+      // Now resolve the stale request — its session must not overwrite
+      // the freshly refreshed cache.
+      resolveStale({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            guestId: "stale",
+            token: "stale-token",
+            expiresAt: Date.now() + 60_000,
+          }),
+      } as Response);
+      await stalePending;
+
+      const token = await guestSession.getGuestBearerToken();
+      expect(token).toBe("fresh-token");
     });
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/guest-session.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/guest-session.test.ts
@@ -1,12 +1,16 @@
 /**
  * Guest Session Client Module Tests
  *
- * Tests for the client-side guest session manager.
- * Covers localStorage persistence, token fetching, expiry handling,
- * request deduplication, and session cleanup.
+ * Cookie-backed guest sessions: the JWT lives only in module memory and
+ * the persistent identity is the HttpOnly cookie owned by the backend.
+ * Tests cover memory caching, credentials passthrough, lookup_only,
+ * legacy localStorage migration (one-time), force refresh, and
+ * deduplication.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const LEGACY_STORAGE_KEY = "mcpjam_guest_session_v1";
 
 describe("guest-session module", () => {
   let guestSession: typeof import("../guest-session");
@@ -14,14 +18,10 @@ describe("guest-session module", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.mocked(global.fetch).mockReset();
-
-    // Clear localStorage
     localStorage.clear();
     vi.mocked(localStorage.getItem).mockClear();
     vi.mocked(localStorage.setItem).mockClear();
     vi.mocked(localStorage.removeItem).mockClear();
-
-    // Import fresh module
     guestSession = await import("../guest-session");
   });
 
@@ -30,386 +30,332 @@ describe("guest-session module", () => {
   });
 
   describe("getOrCreateGuestSession", () => {
-    it("fetches a new session when localStorage is empty", async () => {
+    it("requests with credentials:include and lookup_or_create body", async () => {
       const mockSession = {
-        guestId: "test-guest-id",
-        token: "test-token",
+        guestId: "guest-1",
+        token: "token-1",
         expiresAt: Date.now() + 24 * 60 * 60 * 1000,
       };
 
       vi.mocked(global.fetch).mockResolvedValue({
         ok: true,
+        status: 200,
         json: () => Promise.resolve(mockSession),
       } as Response);
 
       const session = await guestSession.getOrCreateGuestSession();
-
       expect(session).toEqual(mockSession);
-      expect(global.fetch).toHaveBeenCalledWith("/api/web/guest-session", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-      });
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/web/guest-session",
+        expect.objectContaining({
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ mode: "lookup_or_create" }),
+        }),
+      );
     });
 
-    it("stores fetched session in localStorage", async () => {
-      const mockSession = {
-        guestId: "stored-guest-id",
-        token: "stored-token",
-        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
-      };
-
+    it("never persists session to localStorage", async () => {
       vi.mocked(global.fetch).mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(mockSession),
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            guestId: "g",
+            token: "t",
+            expiresAt: Date.now() + 60_000,
+          }),
       } as Response);
 
       await guestSession.getOrCreateGuestSession();
-
-      expect(localStorage.setItem).toHaveBeenCalledWith(
-        "mcpjam_guest_session_v1",
-        JSON.stringify(mockSession),
-      );
+      expect(localStorage.setItem).not.toHaveBeenCalled();
     });
 
-    it("returns cached session from localStorage when not expired", async () => {
-      const cachedSession = {
-        guestId: "cached-guest-id",
-        token: "cached-token",
-        expiresAt: Date.now() + 24 * 60 * 60 * 1000, // 24h from now
-      };
-
-      vi.mocked(localStorage.getItem).mockReturnValue(
-        JSON.stringify(cachedSession),
-      );
-
-      const session = await guestSession.getOrCreateGuestSession();
-
-      expect(session).toEqual(cachedSession);
-      expect(global.fetch).not.toHaveBeenCalled();
-    });
-
-    it("refreshes session when within 5-minute expiry buffer", async () => {
-      const almostExpired = {
-        guestId: "expiring-guest-id",
-        token: "expiring-token",
-        expiresAt: Date.now() + 4 * 60 * 1000, // Only 4 minutes left
-      };
-
-      vi.mocked(localStorage.getItem).mockReturnValue(
-        JSON.stringify(almostExpired),
-      );
-
-      const newSession = {
-        guestId: "new-guest-id",
-        token: "new-token",
-        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
-      };
-
+    it("returns the in-memory session on subsequent calls without re-fetching", async () => {
       vi.mocked(global.fetch).mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(newSession),
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            guestId: "g",
+            token: "memory-token",
+            expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+          }),
       } as Response);
 
-      const session = await guestSession.getOrCreateGuestSession();
-
-      expect(session).toEqual(newSession);
-      expect(global.fetch).toHaveBeenCalled();
+      const a = await guestSession.getOrCreateGuestSession();
+      const b = await guestSession.getOrCreateGuestSession();
+      expect(a).toEqual(b);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 
-    it("refreshes session when already expired", async () => {
-      const expired = {
-        guestId: "expired-guest-id",
-        token: "expired-token",
-        expiresAt: Date.now() - 1000, // Already expired
-      };
+    it("refetches when within 5-minute expiry buffer", async () => {
+      const frozen = 1_700_000_000_000;
+      vi.useFakeTimers({ now: frozen });
 
-      vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(expired));
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              guestId: "g1",
+              token: "almost-expired",
+              expiresAt: frozen + 4 * 60 * 1000,
+            }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              guestId: "g2",
+              token: "fresh",
+              expiresAt: frozen + 24 * 60 * 60 * 1000,
+            }),
+        } as Response);
 
-      const newSession = {
-        guestId: "fresh-guest-id",
-        token: "fresh-token",
-        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
-      };
+      await guestSession.getOrCreateGuestSession();
+      const second = await guestSession.getOrCreateGuestSession();
+      expect(second?.token).toBe("fresh");
+      expect(global.fetch).toHaveBeenCalledTimes(2);
 
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(newSession),
-      } as Response);
-
-      const session = await guestSession.getOrCreateGuestSession();
-
-      expect(session).toEqual(newSession);
+      vi.useRealTimers();
     });
 
-    it("returns null when fetch fails with non-ok response", async () => {
+    it("returns null on non-ok response", async () => {
       vi.mocked(global.fetch).mockResolvedValue({
         ok: false,
-        status: 429,
-        statusText: "Too Many Requests",
+        status: 503,
+        statusText: "Service Unavailable",
       } as Response);
 
       const session = await guestSession.getOrCreateGuestSession();
-
       expect(session).toBeNull();
     });
 
-    it("returns null when fetch throws network error", async () => {
-      vi.mocked(global.fetch).mockRejectedValue(new Error("Network error"));
-
+    it("returns null on network error", async () => {
+      vi.mocked(global.fetch).mockRejectedValue(new Error("network"));
       const session = await guestSession.getOrCreateGuestSession();
-
       expect(session).toBeNull();
     });
 
-    it("handles invalid JSON in localStorage gracefully", async () => {
-      vi.mocked(localStorage.getItem).mockReturnValue("not valid json{{{");
-
-      const newSession = {
-        guestId: "recovery-guest-id",
-        token: "recovery-token",
-        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
-      };
-
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(newSession),
-      } as Response);
-
-      const session = await guestSession.getOrCreateGuestSession();
-
-      expect(session).toEqual(newSession);
-      expect(global.fetch).toHaveBeenCalled();
-    });
-
-    it("deduplicates concurrent fetch requests", async () => {
+    it("deduplicates concurrent calls", async () => {
       vi.mocked(global.fetch).mockImplementation(
         () =>
           new Promise((resolve) => {
-            setTimeout(() => {
-              resolve({
-                ok: true,
-                json: () =>
-                  Promise.resolve({
-                    guestId: "dedup-guest",
-                    token: "dedup-token",
-                    expiresAt: Date.now() + 24 * 60 * 60 * 1000,
-                  }),
-              } as Response);
-            }, 10);
+            setTimeout(
+              () =>
+                resolve({
+                  ok: true,
+                  status: 200,
+                  json: () =>
+                    Promise.resolve({
+                      guestId: "dedup",
+                      token: "dedup-token",
+                      expiresAt: Date.now() + 60_000,
+                    }),
+                } as Response),
+              5,
+            );
           }),
       );
 
-      const results = await Promise.all([
+      const [a, b, c] = await Promise.all([
         guestSession.getOrCreateGuestSession(),
         guestSession.getOrCreateGuestSession(),
         guestSession.getOrCreateGuestSession(),
       ]);
-
-      // All should get the same result
-      expect(results[0]).toEqual(results[1]);
-      expect(results[1]).toEqual(results[2]);
-
-      // Only one fetch should have been made
+      expect(a).toEqual(b);
+      expect(b).toEqual(c);
       expect(global.fetch).toHaveBeenCalledTimes(1);
     });
+  });
 
-    it("allows retry after failed fetch", async () => {
-      // First call fails
-      vi.mocked(global.fetch).mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: "Internal Server Error",
-      } as Response);
+  describe("legacy migration", () => {
+    it("forwards legacyToken from localStorage exactly once and deletes it after fetch", async () => {
+      vi.mocked(localStorage.getItem).mockImplementation((key) =>
+        key === LEGACY_STORAGE_KEY
+          ? JSON.stringify({
+              guestId: "legacy-id",
+              token: "legacy-token",
+              expiresAt: Date.now() - 1000,
+            })
+          : null,
+      );
 
-      const result1 = await guestSession.getOrCreateGuestSession();
-      expect(result1).toBeNull();
-
-      // Second call succeeds
-      const newSession = {
-        guestId: "retry-guest",
-        token: "retry-token",
-        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
-      };
-      vi.mocked(global.fetch).mockResolvedValueOnce({
+      vi.mocked(global.fetch).mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(newSession),
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            guestId: "legacy-id",
+            token: "fresh",
+            expiresAt: Date.now() + 60_000,
+          }),
       } as Response);
 
-      const result2 = await guestSession.getOrCreateGuestSession();
-      expect(result2).toEqual(newSession);
+      const a = await guestSession.getOrCreateGuestSession();
+      expect(a?.token).toBe("fresh");
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/web/guest-session",
+        expect.objectContaining({
+          body: JSON.stringify({
+            mode: "lookup_or_create",
+            legacyToken: "legacy-token",
+          }),
+        }),
+      );
+      expect(localStorage.removeItem).toHaveBeenCalledWith(LEGACY_STORAGE_KEY);
+
+      // Force a refetch to ensure legacy token isn't sent twice.
+      vi.mocked(global.fetch).mockClear();
+      await guestSession.forceRefreshGuestSession();
+      const lastCall = vi.mocked(global.fetch).mock.calls.at(-1);
+      expect(lastCall?.[1]?.body).toBe(
+        JSON.stringify({ mode: "lookup_or_create" }),
+      );
     });
 
-    it("uses session with exactly 5 min + 1ms remaining (valid)", async () => {
-      const frozenNow = 1_700_000_000_000;
-      vi.useFakeTimers({ now: frozenNow });
+    it("deletes legacy token even when the migration fetch fails", async () => {
+      vi.mocked(localStorage.getItem).mockReturnValue(
+        JSON.stringify({
+          guestId: "legacy",
+          token: "legacy-token",
+          expiresAt: Date.now() - 1000,
+        }),
+      );
+      vi.mocked(global.fetch).mockRejectedValue(new Error("offline"));
 
-      const session = {
-        guestId: "edge-guest",
-        token: "edge-token",
-        expiresAt: frozenNow + 5 * 60 * 1000 + 1, // 5 min + 1ms past buffer threshold
-      };
-
-      vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(session));
-
-      const result = await guestSession.getOrCreateGuestSession();
-
-      expect(result).toEqual(session);
-      expect(global.fetch).not.toHaveBeenCalled();
-
-      vi.useRealTimers();
+      await guestSession.getOrCreateGuestSession();
+      expect(localStorage.removeItem).toHaveBeenCalledWith(LEGACY_STORAGE_KEY);
     });
   });
 
-  describe("getGuestBearerToken", () => {
-    it("returns just the token string from a valid session", async () => {
-      const mockSession = {
-        guestId: "token-guest",
-        token: "the-bearer-token",
-        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
-      };
-
+  describe("getExistingGuestBearerToken (lookup_only)", () => {
+    it("sends mode:lookup_only and returns null on 204", async () => {
       vi.mocked(global.fetch).mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(mockSession),
+        status: 204,
+        statusText: "No Content",
       } as Response);
 
-      const token = await guestSession.getGuestBearerToken();
-
-      expect(token).toBe("the-bearer-token");
-    });
-
-    it("returns null when session creation fails", async () => {
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: false,
-        status: 500,
-        statusText: "Error",
-      } as Response);
-
-      const token = await guestSession.getGuestBearerToken();
-
+      const token = await guestSession.getExistingGuestBearerToken();
       expect(token).toBeNull();
-    });
-
-    it("returns cached token from localStorage", async () => {
-      const session = {
-        guestId: "cached",
-        token: "cached-bearer",
-        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
-      };
-
-      vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(session));
-
-      const token = await guestSession.getGuestBearerToken();
-
-      expect(token).toBe("cached-bearer");
-      expect(global.fetch).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("clearGuestSession", () => {
-    it("removes session from localStorage", () => {
-      guestSession.clearGuestSession();
-
-      expect(localStorage.removeItem).toHaveBeenCalledWith(
-        "mcpjam_guest_session_v1",
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/web/guest-session",
+        expect.objectContaining({
+          credentials: "include",
+          body: JSON.stringify({ mode: "lookup_only" }),
+        }),
       );
     });
 
-    it("can be called safely when no session exists", () => {
-      expect(() => guestSession.clearGuestSession()).not.toThrow();
-      expect(localStorage.removeItem).toHaveBeenCalledWith(
-        "mcpjam_guest_session_v1",
-      );
-    });
-
-    it("after clearing, next getOrCreate fetches a new session", async () => {
-      // First, create a cached session
-      const session1 = {
-        guestId: "first",
-        token: "first-token",
-        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
-      };
-      vi.mocked(localStorage.getItem).mockReturnValue(JSON.stringify(session1));
-
-      const result1 = await guestSession.getGuestBearerToken();
-      expect(result1).toBe("first-token");
-      expect(global.fetch).not.toHaveBeenCalled();
-
-      // Clear the session
-      guestSession.clearGuestSession();
-
-      // Now localStorage should return null
-      vi.mocked(localStorage.getItem).mockReturnValue(null);
-
-      const session2 = {
-        guestId: "second",
-        token: "second-token",
-        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
-      };
+    it("returns existing cached token without re-fetching", async () => {
       vi.mocked(global.fetch).mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(session2),
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            guestId: "g",
+            token: "cached-token",
+            expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+          }),
       } as Response);
 
-      const result2 = await guestSession.getGuestBearerToken();
-      expect(result2).toBe("second-token");
-      expect(global.fetch).toHaveBeenCalled();
+      await guestSession.getOrCreateGuestSession();
+      vi.mocked(global.fetch).mockClear();
+
+      const token = await guestSession.getExistingGuestBearerToken();
+      expect(token).toBe("cached-token");
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 
   describe("forceRefreshGuestSession", () => {
-    it("clears localStorage and fetches a new token", async () => {
-      // Seed a cached session that looks valid by time
-      const staleSession = {
-        guestId: "stale",
-        token: "stale-token",
-        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
-      };
-      vi.mocked(localStorage.getItem).mockReturnValue(
-        JSON.stringify(staleSession),
+    it("clears in-memory cache and re-requests with credentials", async () => {
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              guestId: "g",
+              token: "stale",
+              expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+            }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              guestId: "g",
+              token: "fresh",
+              expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+            }),
+        } as Response);
+
+      await guestSession.getOrCreateGuestSession();
+      const refreshed = await guestSession.forceRefreshGuestSession();
+      expect(refreshed).toBe("fresh");
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        "/api/web/guest-session",
+        expect.objectContaining({ credentials: "include" }),
       );
-
-      // Verify the stale session would be returned normally
-      const before = await guestSession.getOrCreateGuestSession();
-      expect(before?.token).toBe("stale-token");
-      expect(global.fetch).not.toHaveBeenCalled();
-
-      // Now simulate localStorage returning null after clear
-      vi.mocked(localStorage.getItem).mockReturnValue(null);
-
-      const freshSession = {
-        guestId: "fresh",
-        token: "fresh-token",
-        expiresAt: Date.now() + 24 * 60 * 60 * 1000,
-      };
-      vi.mocked(global.fetch).mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(freshSession),
-      } as Response);
-
-      const result = await guestSession.forceRefreshGuestSession();
-
-      expect(localStorage.removeItem).toHaveBeenCalledWith(
-        "mcpjam_guest_session_v1",
-      );
-      expect(result).toBe("fresh-token");
-      expect(global.fetch).toHaveBeenCalledWith("/api/web/guest-session", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-      });
     });
 
-    it("returns null when server is unreachable", async () => {
-      vi.mocked(localStorage.getItem).mockReturnValue(null);
+    it("dedupes concurrent force-refresh calls", async () => {
+      vi.mocked(global.fetch).mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  ok: true,
+                  status: 200,
+                  json: () =>
+                    Promise.resolve({
+                      guestId: "g",
+                      token: "fresh",
+                      expiresAt: Date.now() + 60_000,
+                    }),
+                } as Response),
+              5,
+            ),
+          ),
+      );
+
+      const [a, b] = await Promise.all([
+        guestSession.forceRefreshGuestSession(),
+        guestSession.forceRefreshGuestSession(),
+      ]);
+      expect(a).toBe("fresh");
+      expect(b).toBe("fresh");
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("clearGuestSession", () => {
+    it("drops only the in-memory cache, no localStorage call needed", async () => {
       vi.mocked(global.fetch).mockResolvedValue({
-        ok: false,
-        status: 500,
-        statusText: "Internal Server Error",
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            guestId: "g",
+            token: "memory",
+            expiresAt: Date.now() + 60_000,
+          }),
       } as Response);
 
-      const result = await guestSession.forceRefreshGuestSession();
-
-      expect(result).toBeNull();
+      await guestSession.getOrCreateGuestSession();
+      guestSession.clearGuestSession();
+      expect(localStorage.removeItem).not.toHaveBeenCalledWith(
+        LEGACY_STORAGE_KEY,
+      );
     });
   });
 });

--- a/mcpjam-inspector/client/src/lib/guest-session.ts
+++ b/mcpjam-inspector/client/src/lib/guest-session.ts
@@ -8,8 +8,8 @@
  *
  * The legacy `mcpjam_guest_session_v1` localStorage entry is read once and
  * forwarded to the server as `legacyToken` so existing guests can be
- * migrated, and is deleted as soon as the server has had a chance to
- * accept it.
+ * migrated. It is deleted only after a definitive server response so
+ * transient failures do not strand old guests on a new identity.
  */
 
 const LEGACY_STORAGE_KEY = "mcpjam_guest_session_v1";
@@ -28,10 +28,14 @@ let inFlightRequest: Promise<GuestSession | null> | null = null;
 let inFlightLookupOnly: Promise<GuestSession | null> | null = null;
 let forceRefreshInFlight: Promise<GuestSession | null> | null = null;
 let legacyMigrationConsumed = false;
+// Bumped whenever the cache is invalidated externally (clearGuestSession,
+// forceRefreshGuestSession). Captured before each fetch so a late response
+// from a request that was started before the bump cannot resurrect a stale
+// token by overwriting cachedSession.
+let sessionGeneration = 0;
 
 function consumeLegacyToken(): string | null {
   if (legacyMigrationConsumed) return null;
-  legacyMigrationConsumed = true;
   try {
     const raw = localStorage.getItem(LEGACY_STORAGE_KEY);
     if (!raw) return null;
@@ -50,8 +54,22 @@ function deleteLegacyToken(): void {
   } catch {
     // ignore
   }
+  legacyMigrationConsumed = true;
 }
 
+class GuestSessionRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GuestSessionRequestError";
+  }
+}
+
+/**
+ * Returns the parsed session on success, `null` on a definitive "no guest"
+ * miss (HTTP 204/404), and throws `GuestSessionRequestError` on transient
+ * failures (network error, non-ok response, malformed body) so callers can
+ * distinguish "no guest exists" from "couldn't reach the server."
+ */
 async function requestGuestSession(
   mode: GuestSessionMode,
   legacyToken: string | null,
@@ -68,38 +86,42 @@ async function requestGuestSession(
       body: JSON.stringify(body),
     });
   } catch (error) {
-    console.error("Failed to create guest session:", error);
+    throw new GuestSessionRequestError(
+      error instanceof Error ? error.message : "network error",
+    );
+  }
+
+  if (response.status === 204 || response.status === 404) {
     if (legacyToken) deleteLegacyToken();
     return null;
   }
 
-  if (legacyToken) deleteLegacyToken();
-
-  if (response.status === 204 || response.status === 404) {
-    return null;
-  }
-
   if (!response.ok) {
-    console.error(
-      "Failed to create guest session:",
-      response.status,
-      response.statusText,
+    throw new GuestSessionRequestError(
+      `guest-session request failed: ${response.status} ${response.statusText}`,
     );
-    return null;
   }
 
+  let session: GuestSession;
   try {
-    const session = (await response.json()) as GuestSession;
-    if (
-      typeof session?.token !== "string" ||
-      typeof session?.expiresAt !== "number"
-    ) {
-      return null;
-    }
-    return session;
-  } catch {
-    return null;
+    session = (await response.json()) as GuestSession;
+  } catch (error) {
+    throw new GuestSessionRequestError(
+      `guest-session response was not valid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
+
+  if (
+    typeof session?.token !== "string" ||
+    typeof session?.expiresAt !== "number"
+  ) {
+    throw new GuestSessionRequestError(
+      "guest-session response missing token or expiresAt",
+    );
+  }
+
+  if (legacyToken) deleteLegacyToken();
+  return session;
 }
 
 /**
@@ -117,19 +139,32 @@ export async function getOrCreateGuestSession(): Promise<GuestSession | null> {
   }
 
   const legacyToken = consumeLegacyToken();
+  const generation = sessionGeneration;
+  // Initialized to a placeholder so TS sees a definite assignment; the
+  // real value is assigned synchronously below before the IIFE's finally
+  // (which references currentInFlight via closure) can run.
+  let currentInFlight: Promise<GuestSession | null> = Promise.resolve(null);
 
-  inFlightRequest = (async () => {
+  currentInFlight = (async () => {
     try {
       const session = await requestGuestSession(
         "lookup_or_create",
         legacyToken,
       );
-      if (session) cachedSession = session;
+      if (session && generation === sessionGeneration) {
+        cachedSession = session;
+      }
       return session;
+    } catch (error) {
+      console.error("Failed to create guest session:", error);
+      return null;
     } finally {
-      inFlightRequest = null;
+      if (inFlightRequest === currentInFlight) {
+        inFlightRequest = null;
+      }
     }
   })();
+  inFlightRequest = currentInFlight;
 
   return inFlightRequest;
 }
@@ -146,6 +181,10 @@ export async function getGuestBearerToken(): Promise<string | null> {
  * Look up an existing guest bearer token without creating a new guest.
  * Used by post-login flows (e.g. registry-star merge) so signing in does
  * not accidentally mint a brand-new guest just to merge nothing.
+ *
+ * Returns `null` only when the server confirms there is no existing guest
+ * (HTTP 204/404). Throws `GuestSessionRequestError` on transient failures
+ * so callers can retry rather than treating a network blip as "no guest."
  */
 export async function getExistingGuestBearerToken(): Promise<string | null> {
   if (cachedSession && cachedSession.expiresAt - EXPIRY_BUFFER_MS > Date.now()) {
@@ -158,16 +197,23 @@ export async function getExistingGuestBearerToken(): Promise<string | null> {
   }
 
   const legacyToken = consumeLegacyToken();
+  const generation = sessionGeneration;
+  let currentLookup: Promise<GuestSession | null> = Promise.resolve(null);
 
-  inFlightLookupOnly = (async () => {
+  currentLookup = (async () => {
     try {
       const session = await requestGuestSession("lookup_only", legacyToken);
-      if (session) cachedSession = session;
+      if (session && generation === sessionGeneration) {
+        cachedSession = session;
+      }
       return session;
     } finally {
-      inFlightLookupOnly = null;
+      if (inFlightLookupOnly === currentLookup) {
+        inFlightLookupOnly = null;
+      }
     }
   })();
+  inFlightLookupOnly = currentLookup;
 
   const session = await inFlightLookupOnly;
   return session?.token ?? null;
@@ -177,9 +223,17 @@ export async function getExistingGuestBearerToken(): Promise<string | null> {
  * Drop the in-memory guest session cache. The HttpOnly cookie remains set
  * on the browser, so the next call to `getOrCreateGuestSession` continues
  * to resolve the same guest identity.
+ *
+ * Bumps the session generation so any in-flight request that was started
+ * before the clear cannot resurrect a stale token by writing into
+ * `cachedSession` after it resolves.
  */
 export function clearGuestSession(): void {
+  sessionGeneration += 1;
   cachedSession = null;
+  inFlightRequest = null;
+  inFlightLookupOnly = null;
+  forceRefreshInFlight = null;
 }
 
 /**
@@ -193,17 +247,27 @@ export async function forceRefreshGuestSession(): Promise<string | null> {
     return session?.token ?? null;
   }
 
+  sessionGeneration += 1;
+  const generation = sessionGeneration;
   cachedSession = null;
   inFlightRequest = null;
+  inFlightLookupOnly = null;
 
   forceRefreshInFlight = (async () => {
-    const legacyToken = consumeLegacyToken();
-    const session = await requestGuestSession(
-      "lookup_or_create",
-      legacyToken,
-    );
-    if (session) cachedSession = session;
-    return session;
+    try {
+      const legacyToken = consumeLegacyToken();
+      const session = await requestGuestSession(
+        "lookup_or_create",
+        legacyToken,
+      );
+      if (session && generation === sessionGeneration) {
+        cachedSession = session;
+      }
+      return session;
+    } catch (error) {
+      console.error("Failed to refresh guest session:", error);
+      return null;
+    }
   })();
 
   try {

--- a/mcpjam-inspector/client/src/lib/guest-session.ts
+++ b/mcpjam-inspector/client/src/lib/guest-session.ts
@@ -91,7 +91,11 @@ async function requestGuestSession(
     );
   }
 
-  if (response.status === 204 || response.status === 404) {
+  // 204 is the server's explicit "no guest exists" signal — definitive miss.
+  // 404 is ambiguous (route missing/misrouted in a deployment) and may be
+  // transient, so treat it as an error rather than discarding the legacy
+  // migration token.
+  if (response.status === 204) {
     if (legacyToken) deleteLegacyToken();
     return null;
   }

--- a/mcpjam-inspector/client/src/lib/guest-session.ts
+++ b/mcpjam-inspector/client/src/lib/guest-session.ts
@@ -1,12 +1,21 @@
 /**
  * Guest Session Manager
  *
- * Manages guest bearer tokens for unauthenticated visitors in hosted mode.
- * Tokens are stored in localStorage and automatically refreshed when expired.
+ * Manages short-lived guest bearer tokens for unauthenticated visitors. The
+ * persistent guest identity now lives in an HttpOnly cookie set by the
+ * backend; this module keeps the bearer token in module memory only and
+ * fetches a fresh one whenever needed.
+ *
+ * The legacy `mcpjam_guest_session_v1` localStorage entry is read once and
+ * forwarded to the server as `legacyToken` so existing guests can be
+ * migrated, and is deleted as soon as the server has had a chance to
+ * accept it.
  */
 
-const STORAGE_KEY = "mcpjam_guest_session_v1";
-const EXPIRY_BUFFER_MS = 5 * 60 * 1000; // Refresh 5 minutes before expiry
+const LEGACY_STORAGE_KEY = "mcpjam_guest_session_v1";
+const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
+type GuestSessionMode = "lookup_or_create" | "lookup_only";
 
 interface GuestSession {
   guestId: string;
@@ -14,68 +23,109 @@ interface GuestSession {
   expiresAt: number;
 }
 
+let cachedSession: GuestSession | null = null;
 let inFlightRequest: Promise<GuestSession | null> | null = null;
+let inFlightLookupOnly: Promise<GuestSession | null> | null = null;
 let forceRefreshInFlight: Promise<GuestSession | null> | null = null;
-let sessionGeneration = 0;
+let legacyMigrationConsumed = false;
 
-function readFromStorage(): GuestSession | null {
+function consumeLegacyToken(): string | null {
+  if (legacyMigrationConsumed) return null;
+  legacyMigrationConsumed = true;
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = localStorage.getItem(LEGACY_STORAGE_KEY);
     if (!raw) return null;
-    return JSON.parse(raw) as GuestSession;
+    const parsed = JSON.parse(raw) as { token?: unknown };
+    return typeof parsed.token === "string" && parsed.token.length > 0
+      ? parsed.token
+      : null;
   } catch {
     return null;
   }
 }
 
-function writeToStorage(session: GuestSession): void {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+function deleteLegacyToken(): void {
+  try {
+    localStorage.removeItem(LEGACY_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+async function requestGuestSession(
+  mode: GuestSessionMode,
+  legacyToken: string | null,
+): Promise<GuestSession | null> {
+  const body: Record<string, unknown> = { mode };
+  if (legacyToken) body.legacyToken = legacyToken;
+
+  let response: Response;
+  try {
+    response = await fetch("/api/web/guest-session", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (error) {
+    console.error("Failed to create guest session:", error);
+    if (legacyToken) deleteLegacyToken();
+    return null;
+  }
+
+  if (legacyToken) deleteLegacyToken();
+
+  if (response.status === 204 || response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    console.error(
+      "Failed to create guest session:",
+      response.status,
+      response.statusText,
+    );
+    return null;
+  }
+
+  try {
+    const session = (await response.json()) as GuestSession;
+    if (
+      typeof session?.token !== "string" ||
+      typeof session?.expiresAt !== "number"
+    ) {
+      return null;
+    }
+    return session;
+  } catch {
+    return null;
+  }
 }
 
 /**
- * Get or create a guest session. If a valid session exists in localStorage,
- * it is reused. Otherwise, a new one is fetched from the server.
- *
- * Uses raw fetch (not authFetch) to avoid circular dependency.
+ * Get or create a guest session. Returns a cached session if one is in
+ * memory and not within the expiry buffer; otherwise issues a single
+ * `lookup_or_create` request and dedupes concurrent callers.
  */
 export async function getOrCreateGuestSession(): Promise<GuestSession | null> {
-  // Check localStorage first
-  const existing = readFromStorage();
-  if (existing && existing.expiresAt - EXPIRY_BUFFER_MS > Date.now()) {
-    return existing;
+  if (cachedSession && cachedSession.expiresAt - EXPIRY_BUFFER_MS > Date.now()) {
+    return cachedSession;
   }
 
-  // Deduplicate concurrent requests
   if (inFlightRequest) {
     return inFlightRequest;
   }
 
-  const generation = sessionGeneration;
+  const legacyToken = consumeLegacyToken();
+
   inFlightRequest = (async () => {
     try {
-      const response = await fetch("/api/web/guest-session", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-      });
-
-      if (!response.ok) {
-        console.error(
-          "Failed to create guest session:",
-          response.status,
-          response.statusText,
-        );
-        return null;
-      }
-
-      const session: GuestSession = await response.json();
-      // Only write if no force-refresh has invalidated this generation
-      if (sessionGeneration === generation) {
-        writeToStorage(session);
-      }
+      const session = await requestGuestSession(
+        "lookup_or_create",
+        legacyToken,
+      );
+      if (session) cachedSession = session;
       return session;
-    } catch (error) {
-      console.error("Failed to create guest session:", error);
-      return null;
     } finally {
       inFlightRequest = null;
     }
@@ -93,44 +143,69 @@ export async function getGuestBearerToken(): Promise<string | null> {
 }
 
 /**
- * Returns the currently persisted guest token without triggering a network
- * request. Used by retry logic to detect whether a failing hosted request
- * was sent with the guest bearer even if hosted context classification is stale.
+ * Look up an existing guest bearer token without creating a new guest.
+ * Used by post-login flows (e.g. registry-star merge) so signing in does
+ * not accidentally mint a brand-new guest just to merge nothing.
  */
-export function peekStoredGuestToken(): string | null {
-  return readFromStorage()?.token ?? null;
+export async function getExistingGuestBearerToken(): Promise<string | null> {
+  if (cachedSession && cachedSession.expiresAt - EXPIRY_BUFFER_MS > Date.now()) {
+    return cachedSession.token;
+  }
+
+  if (inFlightLookupOnly) {
+    const session = await inFlightLookupOnly;
+    return session?.token ?? null;
+  }
+
+  const legacyToken = consumeLegacyToken();
+
+  inFlightLookupOnly = (async () => {
+    try {
+      const session = await requestGuestSession("lookup_only", legacyToken);
+      if (session) cachedSession = session;
+      return session;
+    } finally {
+      inFlightLookupOnly = null;
+    }
+  })();
+
+  const session = await inFlightLookupOnly;
+  return session?.token ?? null;
 }
 
 /**
- * Clear the guest session from localStorage.
- * Call this when the user logs in with WorkOS.
+ * Drop the in-memory guest session cache. The HttpOnly cookie remains set
+ * on the browser, so the next call to `getOrCreateGuestSession` continues
+ * to resolve the same guest identity.
  */
 export function clearGuestSession(): void {
-  localStorage.removeItem(STORAGE_KEY);
+  cachedSession = null;
 }
 
 /**
- * Force-refresh the guest session by clearing the cached token
- * and fetching a new one from the server. Used when the server
- * rejects a token that hasn't expired client-side (e.g., after
- * a server restart with new signing keys).
- *
- * Deduplicates concurrent force-refresh calls (e.g., when multiple
- * parallel requests all get 401 and each triggers a retry).
+ * Force-refresh the guest bearer token. Drops the in-memory cache and
+ * fetches a new JWT bound to the cookie-backed guest. Deduplicates
+ * concurrent force-refresh calls.
  */
 export async function forceRefreshGuestSession(): Promise<string | null> {
-  // If a force-refresh is already in flight, piggyback on it
-  // instead of clearing its state and starting yet another request.
   if (forceRefreshInFlight) {
     const session = await forceRefreshInFlight;
     return session?.token ?? null;
   }
 
-  clearGuestSession();
-  sessionGeneration++;
+  cachedSession = null;
   inFlightRequest = null;
 
-  forceRefreshInFlight = getOrCreateGuestSession();
+  forceRefreshInFlight = (async () => {
+    const legacyToken = consumeLegacyToken();
+    const session = await requestGuestSession(
+      "lookup_or_create",
+      legacyToken,
+    );
+    if (session) cachedSession = session;
+    return session;
+  })();
+
   try {
     const session = await forceRefreshInFlight;
     return session?.token ?? null;

--- a/mcpjam-inspector/package.json
+++ b/mcpjam-inspector/package.json
@@ -53,7 +53,7 @@
     "dev:hosted": "cross-env VITE_MCPJAM_HOSTED_MODE=true WEB_ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173 npm run dev",
     "sdk:build": "npm --prefix ../sdk run build",
     "dev:convex": "convex dev",
-    "dev:server": "cross-env ENVIRONMENT=dev tsx watch --tsconfig server/tsconfig.json --include 'evals-cli/src/**/*.ts' --exclude 'evals-cli/dist/**' --exclude 'evals-cli/node_modules/**' server/index.ts",
+    "dev:server": "cross-env ENVIRONMENT=dev NODE_ENV=development tsx watch --tsconfig server/tsconfig.json --include 'evals-cli/src/**/*.ts' --exclude 'evals-cli/dist/**' --exclude 'evals-cli/node_modules/**' server/index.ts",
     "dev:client": "vite --config client/vite.config.ts",
     "dev:client:clean": "rm -rf node_modules/.vite && FORCE_OPTIMIZE=true vite --config client/vite.config.ts",
     "build": "npm run clean && npm run build:sdk && npm run bundle:sandbox-proxies && npm run build:lib && npm run build:client && npm run build:server",

--- a/mcpjam-inspector/server/routes/web/__tests__/guest-session.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/guest-session.test.ts
@@ -124,7 +124,7 @@ describe("POST /guest-session", () => {
     );
   });
 
-  it("forwards browser Cookie/User-Agent/X-Forwarded-For/X-Real-IP to upstream", async () => {
+  it("forwards browser Cookie/User-Agent but not spoofable IP headers upstream", async () => {
     await app.request("/guest-session", {
       method: "POST",
       headers: {
@@ -143,8 +143,8 @@ describe("POST /guest-session", () => {
     const headers = init.headers as Record<string, string>;
     expect(headers["Cookie"]).toBe("__Host-mcpjam_guest_session=raw-cookie-id");
     expect(headers["User-Agent"]).toBe("BrowserAgent/1.0");
-    expect(headers["X-Forwarded-For"]).toBe("203.0.113.7");
-    expect(headers["X-Real-IP"]).toBe("203.0.113.7");
+    expect(headers["X-Forwarded-For"]).toBeUndefined();
+    expect(headers["X-Real-IP"]).toBeUndefined();
   });
 
   it("forwards only the guest-session cookie upstream, not other origin cookies", async () => {

--- a/mcpjam-inspector/server/routes/web/__tests__/guest-session.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/guest-session.test.ts
@@ -10,6 +10,9 @@ const ORIGINAL_HOSTED_MODE = process.env.VITE_MCPJAM_HOSTED_MODE;
 const ORIGINAL_NON_PROD_LOCKDOWN = process.env.MCPJAM_NONPROD_LOCKDOWN;
 const ORIGINAL_FETCH = global.fetch;
 
+const SAMPLE_COOKIE =
+  "__Host-mcpjam_guest_session=cookie-set-by-convex; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=31536000";
+
 function createTestApp(): Hono {
   const app = new Hono();
   app.route("/guest-session", guestSession);
@@ -40,7 +43,10 @@ describe("POST /guest-session", () => {
         }),
         {
           status: 200,
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            "Set-Cookie": SAMPLE_COOKIE,
+          },
         },
       );
     }) as typeof fetch;
@@ -108,25 +114,90 @@ describe("POST /guest-session", () => {
       const parts = data.token.split(".");
       expect(parts.length).toBe(3);
     });
+  });
 
-    it("returns expiresAt in the future", async () => {
-      const before = Date.now();
-      const res = await app.request("/guest-session", { method: "POST" });
-      const data = await res.json();
+  it("forwards Set-Cookie from Convex to the browser", async () => {
+    const res = await app.request("/guest-session", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("set-cookie")).toContain(
+      "__Host-mcpjam_guest_session=cookie-set-by-convex",
+    );
+  });
 
-      expect(data.expiresAt).toBeGreaterThan(before);
+  it("forwards browser Cookie/User-Agent/X-Forwarded-For/X-Real-IP to upstream", async () => {
+    await app.request("/guest-session", {
+      method: "POST",
+      headers: {
+        cookie: "__Host-mcpjam_guest_session=raw-cookie-id",
+        "user-agent": "BrowserAgent/1.0",
+        "x-forwarded-for": "203.0.113.7",
+        "x-real-ip": "203.0.113.7",
+      },
     });
 
-    it("returns different tokens on successive requests", async () => {
-      const res1 = await app.request("/guest-session", { method: "POST" });
-      const res2 = await app.request("/guest-session", { method: "POST" });
+    const upstreamCall = vi.mocked(global.fetch).mock.calls[0]!;
+    expect(upstreamCall[0]).toBe(
+      "https://test-deployment.convex.site/guest/session",
+    );
+    const init = upstreamCall[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Cookie"]).toBe("__Host-mcpjam_guest_session=raw-cookie-id");
+    expect(headers["User-Agent"]).toBe("BrowserAgent/1.0");
+    expect(headers["X-Forwarded-For"]).toBe("203.0.113.7");
+    expect(headers["X-Real-IP"]).toBe("203.0.113.7");
+  });
 
-      const data1 = await res1.json();
-      const data2 = await res2.json();
-
-      expect(data1.guestId).not.toBe(data2.guestId);
-      expect(data1.token).not.toBe(data2.token);
+  it("forwards mode and legacyToken from request body to upstream", async () => {
+    await app.request("/guest-session", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        mode: "lookup_only",
+        legacyToken: "old-jwt",
+      }),
     });
+
+    const upstreamCall = vi.mocked(global.fetch).mock.calls[0]!;
+    const init = upstreamCall[1] as RequestInit;
+    expect(init.body).toBe(
+      JSON.stringify({ mode: "lookup_only", legacyToken: "old-jwt" }),
+    );
+  });
+
+  it("returns 204 when upstream lookup_only finds no session", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 })) as typeof fetch;
+
+    const res = await app.request("/guest-session", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ mode: "lookup_only" }),
+    });
+    expect(res.status).toBe(204);
+  });
+
+  it("returns 403 with passthrough Set-Cookie when upstream revokes", async () => {
+    const expiredCookie =
+      "__Host-mcpjam_guest_session=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0";
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ code: "FORBIDDEN", message: "Guest session revoked" }),
+        {
+          status: 403,
+          headers: {
+            "Content-Type": "application/json",
+            "Set-Cookie": expiredCookie,
+          },
+        },
+      ),
+    ) as typeof fetch;
+
+    const res = await app.request("/guest-session", { method: "POST" });
+    expect(res.status).toBe(403);
+    expect(res.headers.get("set-cookie")).toContain("Max-Age=0");
+    const data = await res.json();
+    expect(data.code).toBe("FORBIDDEN");
   });
 
   it("returns 403 when non-prod lockdown is enabled", async () => {
@@ -189,51 +260,9 @@ describe("POST /guest-session", () => {
         "https://app.mcpjam.com/api/web/guest-session",
         expect.objectContaining({
           method: "POST",
-          headers: {
+          headers: expect.objectContaining({
             "Content-Type": "application/json",
-          },
-          signal: expect.anything(),
-        }),
-      );
-    });
-
-    it("proxies the Convex guest session in hosted production", async () => {
-      process.env.NODE_ENV = "production";
-      process.env.VITE_MCPJAM_HOSTED_MODE = "true";
-      process.env.CONVEX_HTTP_URL = "https://test-deployment.convex.site";
-      process.env.MCPJAM_GUEST_SESSION_SHARED_SECRET =
-        "test-guest-session-secret";
-      global.fetch = vi.fn().mockResolvedValue(
-        new Response(
-          JSON.stringify({
-            guestId: "guest-remote",
-            token: "remote-token",
-            expiresAt: 123456789,
           }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-      ) as typeof fetch;
-
-      const res = await app.request("/guest-session", { method: "POST" });
-      const data = await res.json();
-
-      expect(res.status).toBe(200);
-      expect(data).toEqual({
-        guestId: "guest-remote",
-        token: "remote-token",
-        expiresAt: 123456789,
-      });
-      expect(global.fetch).toHaveBeenCalledWith(
-        "https://test-deployment.convex.site/guest/session",
-        expect.objectContaining({
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "x-mcpjam-guest-session-secret": "test-guest-session-secret",
-          },
           signal: expect.anything(),
         }),
       );
@@ -266,7 +295,6 @@ describe("POST /guest-session", () => {
     });
 
     it("returns 429 after 10 requests from the same IP", async () => {
-      // Exhaust the rate limit
       for (let i = 0; i < 10; i++) {
         await app.request("/guest-session", {
           method: "POST",
@@ -274,7 +302,6 @@ describe("POST /guest-session", () => {
         });
       }
 
-      // 11th request should be rate-limited
       const res = await app.request("/guest-session", {
         method: "POST",
         headers: { "x-forwarded-for": "10.0.0.2" },
@@ -283,11 +310,9 @@ describe("POST /guest-session", () => {
       expect(res.status).toBe(429);
       const data = await res.json();
       expect(data.code).toBe("RATE_LIMITED");
-      expect(data.message).toBeDefined();
     });
 
     it("rate limits are per-IP", async () => {
-      // Exhaust limit for IP1
       for (let i = 0; i < 10; i++) {
         await app.request("/guest-session", {
           method: "POST",
@@ -295,7 +320,6 @@ describe("POST /guest-session", () => {
         });
       }
 
-      // IP2 should still be allowed
       const res = await app.request("/guest-session", {
         method: "POST",
         headers: { "x-forwarded-for": "10.0.0.4" },
@@ -304,7 +328,6 @@ describe("POST /guest-session", () => {
     });
 
     it("uses first IP from x-forwarded-for when multiple present", async () => {
-      // Exhaust limit for the first IP in the chain
       for (let i = 0; i < 10; i++) {
         await app.request("/guest-session", {
           method: "POST",
@@ -312,14 +335,12 @@ describe("POST /guest-session", () => {
         });
       }
 
-      // Same first IP should be rate-limited
       const res = await app.request("/guest-session", {
         method: "POST",
         headers: { "x-forwarded-for": "10.0.0.5" },
       });
       expect(res.status).toBe(429);
 
-      // Different first IP should be allowed
       const res2 = await app.request("/guest-session", {
         method: "POST",
         headers: { "x-forwarded-for": "10.0.0.6" },
@@ -328,7 +349,6 @@ describe("POST /guest-session", () => {
     });
 
     it("falls back to x-real-ip when x-forwarded-for is absent", async () => {
-      // Exhaust limit using x-real-ip
       for (let i = 0; i < 10; i++) {
         await app.request("/guest-session", {
           method: "POST",

--- a/mcpjam-inspector/server/routes/web/__tests__/guest-session.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/guest-session.test.ts
@@ -147,6 +147,40 @@ describe("POST /guest-session", () => {
     expect(headers["X-Real-IP"]).toBe("203.0.113.7");
   });
 
+  it("forwards only the guest-session cookie upstream, not other origin cookies", async () => {
+    await app.request("/guest-session", {
+      method: "POST",
+      headers: {
+        "x-forwarded-for": "10.0.99.1",
+        cookie:
+          "session=secret-app-session; csrf=abc123; __Host-mcpjam_guest_session=raw-cookie-id; other=keep",
+      },
+    });
+
+    const upstreamCall = vi.mocked(global.fetch).mock.calls[0]!;
+    const init = upstreamCall[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Cookie"]).toBe("__Host-mcpjam_guest_session=raw-cookie-id");
+    expect(headers["Cookie"]).not.toContain("session=secret-app-session");
+    expect(headers["Cookie"]).not.toContain("csrf=abc123");
+    expect(headers["Cookie"]).not.toContain("other=keep");
+  });
+
+  it("omits Cookie header upstream when guest-session cookie is absent", async () => {
+    await app.request("/guest-session", {
+      method: "POST",
+      headers: {
+        "x-forwarded-for": "10.0.99.2",
+        cookie: "session=secret-app-session; csrf=abc123",
+      },
+    });
+
+    const upstreamCall = vi.mocked(global.fetch).mock.calls[0]!;
+    const init = upstreamCall[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Cookie"]).toBeUndefined();
+  });
+
   it("forwards mode and legacyToken from request body to upstream", async () => {
     await app.request("/guest-session", {
       method: "POST",

--- a/mcpjam-inspector/server/routes/web/guest-session.ts
+++ b/mcpjam-inspector/server/routes/web/guest-session.ts
@@ -75,8 +75,9 @@ function parseRequestBody(raw: unknown): GuestSessionRequestBody {
  * POST /api/web/guest-session
  *
  * Returns a guest bearer token for unauthenticated visitors. Inspector
- * forwards browser cookie/UA/IP context to the upstream guest service so the
- * server can resolve a stable guest from the HttpOnly cookie. Set-Cookie
+ * forwards browser cookie/UA context to the upstream guest service so the
+ * server can resolve a stable guest from the HttpOnly cookie. Spoofable
+ * client IP headers are intentionally not forwarded. Set-Cookie
  * headers from upstream are passed through unchanged.
  *
  * Inspector rate-limits this endpoint locally and either:
@@ -133,8 +134,6 @@ guestSession.post("/", async (c) => {
   const context: GuestSessionFetchContext = {
     cookie: extractGuestSessionCookie(c.req.header("cookie")),
     userAgent: c.req.header("user-agent") ?? null,
-    forwardedFor: c.req.header("x-forwarded-for") ?? null,
-    realIp: c.req.header("x-real-ip") ?? null,
     body,
   };
 

--- a/mcpjam-inspector/server/routes/web/guest-session.ts
+++ b/mcpjam-inspector/server/routes/web/guest-session.ts
@@ -2,6 +2,8 @@ import { Hono } from "hono";
 import {
   fetchConvexGuestSession,
   fetchRemoteGuestSession,
+  type GuestSessionFetchContext,
+  type GuestSessionRequestBody,
 } from "../../utils/guest-session-source.js";
 import { ErrorCode } from "./errors.js";
 
@@ -38,13 +40,31 @@ function shouldFetchGuestSessionFromConvex(): boolean {
   return process.env.NODE_ENV !== "production";
 }
 
+function parseRequestBody(raw: unknown): GuestSessionRequestBody {
+  if (!raw || typeof raw !== "object") return {};
+  const body = raw as Record<string, unknown>;
+  const out: GuestSessionRequestBody = {};
+  if (body.mode === "lookup_only" || body.mode === "lookup_or_create") {
+    out.mode = body.mode;
+  }
+  if (typeof body.legacyToken === "string" && body.legacyToken.length > 0) {
+    out.legacyToken = body.legacyToken;
+  }
+  return out;
+}
+
 /**
  * POST /api/web/guest-session
  *
- * Returns a guest bearer token for unauthenticated visitors.
- * Inspector rate-limits this endpoint locally, then either:
+ * Returns a guest bearer token for unauthenticated visitors. Inspector
+ * forwards browser cookie/UA/IP context to the upstream guest service so the
+ * server can resolve a stable guest from the HttpOnly cookie. Set-Cookie
+ * headers from upstream are passed through unchanged.
+ *
+ * Inspector rate-limits this endpoint locally and either:
  * - proxies to Convex in hosted web and local dev
  * - relays through hosted Inspector in local production runtimes
+ *
  * Rate limited to 10 requests per minute per IP.
  */
 guestSession.post("/", async (c) => {
@@ -84,21 +104,56 @@ guestSession.post("/", async (c) => {
     ipWindows.set(ip, { count: 1, windowStart: now });
   }
 
-  const session = shouldFetchGuestSessionFromConvex()
-    ? await fetchConvexGuestSession()
-    : await fetchRemoteGuestSession();
-  if (!session) {
+  let body: GuestSessionRequestBody = {};
+  try {
+    const raw = await c.req.json();
+    body = parseRequestBody(raw);
+  } catch {
+    body = {};
+  }
+
+  const context: GuestSessionFetchContext = {
+    cookie: c.req.header("cookie") ?? null,
+    userAgent: c.req.header("user-agent") ?? null,
+    forwardedFor: c.req.header("x-forwarded-for") ?? null,
+    realIp: c.req.header("x-real-ip") ?? null,
+    body,
+  };
+
+  const result = shouldFetchGuestSessionFromConvex()
+    ? await fetchConvexGuestSession(context)
+    : await fetchRemoteGuestSession(context);
+
+  for (const cookie of result.setCookies) {
+    c.header("Set-Cookie", cookie, { append: true });
+  }
+
+  if (result.kind === "session") {
+    return c.json(result.session);
+  }
+
+  if (result.kind === "miss") {
+    return c.body(null, 204);
+  }
+
+  if (result.status === 403) {
     return c.json(
       {
-        code: ErrorCode.INTERNAL_ERROR,
-        message:
-          "Unable to obtain a guest session right now. Please try again.",
+        code: ErrorCode.FORBIDDEN,
+        message: result.message ?? "Guest session revoked.",
       },
-      503,
+      403,
     );
   }
 
-  return c.json(session);
+  return c.json(
+    {
+      code: ErrorCode.INTERNAL_ERROR,
+      message:
+        "Unable to obtain a guest session right now. Please try again.",
+    },
+    503,
+  );
 });
 
 export default guestSession;

--- a/mcpjam-inspector/server/routes/web/guest-session.ts
+++ b/mcpjam-inspector/server/routes/web/guest-session.ts
@@ -158,7 +158,7 @@ guestSession.post("/", async (c) => {
     return c.json(
       {
         code: ErrorCode.FORBIDDEN,
-        message: result.message ?? "Guest session revoked.",
+        message: "Guest session revoked.",
       },
       403,
     );

--- a/mcpjam-inspector/server/routes/web/guest-session.ts
+++ b/mcpjam-inspector/server/routes/web/guest-session.ts
@@ -58,6 +58,11 @@ function shouldFetchGuestSessionFromConvex(): boolean {
   return process.env.NODE_ENV !== "production";
 }
 
+// Bound the size of the legacy migration token we will forward upstream.
+// Real guest JWTs are well under this limit; anything larger is either
+// malformed or an attempt to inflate the upstream request body.
+const MAX_LEGACY_TOKEN_LENGTH = 4096;
+
 function parseRequestBody(raw: unknown): GuestSessionRequestBody {
   if (!raw || typeof raw !== "object") return {};
   const body = raw as Record<string, unknown>;
@@ -65,7 +70,11 @@ function parseRequestBody(raw: unknown): GuestSessionRequestBody {
   if (body.mode === "lookup_only" || body.mode === "lookup_or_create") {
     out.mode = body.mode;
   }
-  if (typeof body.legacyToken === "string" && body.legacyToken.length > 0) {
+  if (
+    typeof body.legacyToken === "string" &&
+    body.legacyToken.length > 0 &&
+    body.legacyToken.length <= MAX_LEGACY_TOKEN_LENGTH
+  ) {
     out.legacyToken = body.legacyToken;
   }
   return out;

--- a/mcpjam-inspector/server/routes/web/guest-session.ts
+++ b/mcpjam-inspector/server/routes/web/guest-session.ts
@@ -32,6 +32,24 @@ function getClientIp(c: any): string {
   );
 }
 
+const GUEST_SESSION_COOKIE_NAME = "__Host-mcpjam_guest_session";
+
+// Forward only the guest-session cookie to the upstream guest service.
+// Passing the entire Cookie header would leak unrelated auth/CSRF cookies
+// from the Inspector origin to Convex / hosted MCPJam.
+function extractGuestSessionCookie(
+  cookieHeader: string | null | undefined,
+): string | null {
+  if (!cookieHeader) return null;
+  const prefix = `${GUEST_SESSION_COOKIE_NAME}=`;
+  for (const part of cookieHeader.split(/;\s*/)) {
+    if (part.startsWith(prefix)) {
+      return part;
+    }
+  }
+  return null;
+}
+
 function shouldFetchGuestSessionFromConvex(): boolean {
   if (process.env.VITE_MCPJAM_HOSTED_MODE === "true") {
     return true;
@@ -113,7 +131,7 @@ guestSession.post("/", async (c) => {
   }
 
   const context: GuestSessionFetchContext = {
-    cookie: c.req.header("cookie") ?? null,
+    cookie: extractGuestSessionCookie(c.req.header("cookie")),
     userAgent: c.req.header("user-agent") ?? null,
     forwardedFor: c.req.header("x-forwarded-for") ?? null,
     realIp: c.req.header("x-real-ip") ?? null,

--- a/mcpjam-inspector/server/utils/__tests__/guest-session-source.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/guest-session-source.test.ts
@@ -58,7 +58,7 @@ describe("guest-session-source", () => {
     global.fetch = originalFetch;
   });
 
-  it("fetches hosted guest sessions without the shared secret", async () => {
+  it("fetches hosted guest sessions and returns parsed session", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -73,19 +73,19 @@ describe("guest-session-source", () => {
       ),
     );
 
-    const { fetchRemoteGuestSession } =
-      await import("../guest-session-source.js");
-    const session = await fetchRemoteGuestSession();
+    const { fetchRemoteGuestSession } = await import(
+      "../guest-session-source.js"
+    );
+    const result = await fetchRemoteGuestSession();
 
-    expect(session?.token).toBe("remote-token");
+    expect(result.kind).toBe("session");
+    if (result.kind !== "session") return;
+    expect(result.session.token).toBe("remote-token");
     expect(mockProvisionGuestAuthConfigToConvex).not.toHaveBeenCalled();
     expect(global.fetch).toHaveBeenCalledWith(
       "https://app.mcpjam.com/api/web/guest-session",
       expect.objectContaining({
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
         signal: expect.anything(),
       }),
     );
@@ -106,22 +106,92 @@ describe("guest-session-source", () => {
       ),
     );
 
-    const { fetchConvexGuestSession } =
-      await import("../guest-session-source.js");
-    const session = await fetchConvexGuestSession();
+    const { fetchConvexGuestSession } = await import(
+      "../guest-session-source.js"
+    );
+    const result = await fetchConvexGuestSession();
 
-    expect(session?.token).toBe("convex-token");
+    expect(result.kind).toBe("session");
+    if (result.kind !== "session") return;
+    expect(result.session.token).toBe("convex-token");
     expect(mockProvisionGuestAuthConfigToConvex).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledWith(
       "https://test-deployment.convex.site/guest/session",
       expect.objectContaining({
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-mcpjam-guest-session-secret": "test-guest-session-secret",
-        },
         signal: expect.anything(),
       }),
+    );
+  });
+
+  it("returns kind:miss for upstream 204 (lookup_only)", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
+    const { fetchConvexGuestSession } = await import(
+      "../guest-session-source.js"
+    );
+    const result = await fetchConvexGuestSession({
+      body: { mode: "lookup_only" },
+    });
+    expect(result.kind).toBe("miss");
+  });
+
+  it("captures upstream Set-Cookie headers and forwards them in the result", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          guestId: "g",
+          token: "t",
+          expiresAt: Date.now() + 60_000,
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            "Set-Cookie": "__Host-mcpjam_guest_session=opaque; Path=/",
+          },
+        },
+      ),
+    );
+    const { fetchConvexGuestSession } = await import(
+      "../guest-session-source.js"
+    );
+    const result = await fetchConvexGuestSession();
+    expect(result.setCookies.length).toBeGreaterThan(0);
+    expect(result.setCookies[0]).toContain("__Host-mcpjam_guest_session=opaque");
+  });
+
+  it("forwards browser cookie/UA/IP headers to upstream when context provided", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          guestId: "g",
+          token: "t",
+          expiresAt: Date.now() + 60_000,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const { fetchConvexGuestSession } = await import(
+      "../guest-session-source.js"
+    );
+    await fetchConvexGuestSession({
+      cookie: "__Host-mcpjam_guest_session=raw",
+      userAgent: "UA/1.0",
+      forwardedFor: "1.2.3.4",
+      realIp: "1.2.3.4",
+      body: { mode: "lookup_or_create", legacyToken: "legacy" },
+    });
+
+    const init = vi.mocked(global.fetch).mock.calls[0]![1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Cookie"]).toBe("__Host-mcpjam_guest_session=raw");
+    expect(headers["User-Agent"]).toBe("UA/1.0");
+    expect(headers["X-Forwarded-For"]).toBe("1.2.3.4");
+    expect(headers["X-Real-IP"]).toBe("1.2.3.4");
+    expect(init.body).toBe(
+      JSON.stringify({ mode: "lookup_or_create", legacyToken: "legacy" }),
     );
   });
 

--- a/mcpjam-inspector/server/utils/__tests__/guest-session-source.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/guest-session-source.test.ts
@@ -190,7 +190,7 @@ describe("guest-session-source", () => {
     expect(result.setCookies[0]).toContain("__Host-mcpjam_guest_session=opaque");
   });
 
-  it("forwards browser cookie/UA/IP headers to upstream when context provided", async () => {
+  it("forwards browser cookie/UA and omits spoofable IP headers upstream", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -207,8 +207,6 @@ describe("guest-session-source", () => {
     await fetchConvexGuestSession({
       cookie: "__Host-mcpjam_guest_session=raw",
       userAgent: "UA/1.0",
-      forwardedFor: "1.2.3.4",
-      realIp: "1.2.3.4",
       body: { mode: "lookup_or_create", legacyToken: "legacy" },
     });
 
@@ -216,8 +214,8 @@ describe("guest-session-source", () => {
     const headers = init.headers as Record<string, string>;
     expect(headers["Cookie"]).toBe("__Host-mcpjam_guest_session=raw");
     expect(headers["User-Agent"]).toBe("UA/1.0");
-    expect(headers["X-Forwarded-For"]).toBe("1.2.3.4");
-    expect(headers["X-Real-IP"]).toBe("1.2.3.4");
+    expect(headers["X-Forwarded-For"]).toBeUndefined();
+    expect(headers["X-Real-IP"]).toBeUndefined();
     expect(init.body).toBe(
       JSON.stringify({ mode: "lookup_or_create", legacyToken: "legacy" }),
     );

--- a/mcpjam-inspector/server/utils/__tests__/guest-session-source.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/guest-session-source.test.ts
@@ -137,6 +137,34 @@ describe("guest-session-source", () => {
     expect(result.kind).toBe("miss");
   });
 
+  it("returns kind:miss for upstream 404 in lookup_only mode", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(null, { status: 404 }),
+    );
+    const { fetchConvexGuestSession } = await import(
+      "../guest-session-source.js"
+    );
+    const result = await fetchConvexGuestSession({
+      body: { mode: "lookup_only" },
+    });
+    expect(result.kind).toBe("miss");
+  });
+
+  it("returns kind:error for upstream 404 in lookup_or_create mode (not silent miss)", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(null, { status: 404 }),
+    );
+    const { fetchConvexGuestSession } = await import(
+      "../guest-session-source.js"
+    );
+    const result = await fetchConvexGuestSession({
+      body: { mode: "lookup_or_create" },
+    });
+    expect(result.kind).toBe("error");
+    if (result.kind !== "error") return;
+    expect(result.status).toBe(404);
+  });
+
   it("captures upstream Set-Cookie headers and forwards them in the result", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
       new Response(

--- a/mcpjam-inspector/server/utils/convex-guest-auth-sync.ts
+++ b/mcpjam-inspector/server/utils/convex-guest-auth-sync.ts
@@ -4,6 +4,7 @@ import {
   initGuestTokenSecret,
 } from "../services/guest-token.js";
 import { getGuestSessionSharedSecret } from "./guest-session-secret.js";
+import { getGuestSessionHashPepper } from "./guest-session-pepper.js";
 import { logger } from "./logger.js";
 
 let provisioningPromise: Promise<void> | null = null;
@@ -109,6 +110,11 @@ export async function provisionGuestAuthConfigToConvex(): Promise<void> {
         convexEnv,
         "GUEST_SESSION_SHARED_SECRET",
         getGuestSessionSharedSecret(),
+      );
+      await setConvexEnv(
+        convexEnv,
+        "GUEST_SESSION_HASH_PEPPER",
+        getGuestSessionHashPepper(),
       );
 
       logger.info(

--- a/mcpjam-inspector/server/utils/guest-session-pepper.ts
+++ b/mcpjam-inspector/server/utils/guest-session-pepper.ts
@@ -1,0 +1,74 @@
+import { randomBytes } from "crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "fs";
+import os from "os";
+import path from "path";
+import { logger } from "./logger.js";
+
+function getLocalPepperDir(): string {
+  return process.env.GUEST_JWT_KEY_DIR || path.join(os.homedir(), ".mcpjam");
+}
+
+function getLocalPepperPath(): string {
+  return path.join(getLocalPepperDir(), "guest-session-hash-pepper.txt");
+}
+
+function createAndPersistLocalPepper(): string {
+  const pepperPath = getLocalPepperPath();
+  const dir = path.dirname(pepperPath);
+  const pepper = randomBytes(32).toString("hex");
+
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(pepperPath, pepper, "utf-8");
+
+  try {
+    chmodSync(pepperPath, 0o600);
+  } catch {
+    // Best effort. Some platforms/filesystems do not support chmod semantics.
+  }
+
+  logger.info(
+    `[guest-auth] Created local guest session hash pepper at ${pepperPath}`,
+  );
+  return pepper;
+}
+
+function loadPersistedLocalPepper(): string | null {
+  const pepperPath = getLocalPepperPath();
+  if (!existsSync(pepperPath)) {
+    return null;
+  }
+
+  try {
+    const pepper = readFileSync(pepperPath, "utf-8").trim();
+    return pepper.length > 0 ? pepper : null;
+  } catch (error) {
+    logger.warn(
+      `[guest-auth] Failed to load local guest session hash pepper (${error instanceof Error ? error.message : String(error)})`,
+    );
+    return null;
+  }
+}
+
+export function getGuestSessionHashPepper(): string {
+  const envPepper = process.env.GUEST_SESSION_HASH_PEPPER?.trim();
+  if (envPepper) {
+    return envPepper;
+  }
+
+  if (
+    process.env.NODE_ENV === "production" ||
+    process.env.NODE_ENV === "test"
+  ) {
+    throw new Error(
+      "GUEST_SESSION_HASH_PEPPER is required for guest session hashing",
+    );
+  }
+
+  return loadPersistedLocalPepper() || createAndPersistLocalPepper();
+}

--- a/mcpjam-inspector/server/utils/guest-session-pepper.ts
+++ b/mcpjam-inspector/server/utils/guest-session-pepper.ts
@@ -1,74 +1,11 @@
-import { randomBytes } from "crypto";
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  writeFileSync,
-} from "fs";
-import os from "os";
-import path from "path";
-import { logger } from "./logger.js";
-
-function getLocalPepperDir(): string {
-  return process.env.GUEST_JWT_KEY_DIR || path.join(os.homedir(), ".mcpjam");
-}
-
-function getLocalPepperPath(): string {
-  return path.join(getLocalPepperDir(), "guest-session-hash-pepper.txt");
-}
-
-function createAndPersistLocalPepper(): string {
-  const pepperPath = getLocalPepperPath();
-  const dir = path.dirname(pepperPath);
-  const pepper = randomBytes(32).toString("hex");
-
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(pepperPath, pepper, "utf-8");
-
-  try {
-    chmodSync(pepperPath, 0o600);
-  } catch {
-    // Best effort. Some platforms/filesystems do not support chmod semantics.
-  }
-
-  logger.info(
-    `[guest-auth] Created local guest session hash pepper at ${pepperPath}`,
-  );
-  return pepper;
-}
-
-function loadPersistedLocalPepper(): string | null {
-  const pepperPath = getLocalPepperPath();
-  if (!existsSync(pepperPath)) {
-    return null;
-  }
-
-  try {
-    const pepper = readFileSync(pepperPath, "utf-8").trim();
-    return pepper.length > 0 ? pepper : null;
-  } catch (error) {
-    logger.warn(
-      `[guest-auth] Failed to load local guest session hash pepper (${error instanceof Error ? error.message : String(error)})`,
-    );
-    return null;
-  }
-}
+import { getOrCreateLocalSecret } from "./local-secret-store.js";
 
 export function getGuestSessionHashPepper(): string {
-  const envPepper = process.env.GUEST_SESSION_HASH_PEPPER?.trim();
-  if (envPepper) {
-    return envPepper;
-  }
-
-  if (
-    process.env.NODE_ENV === "production" ||
-    process.env.NODE_ENV === "test"
-  ) {
-    throw new Error(
+  return getOrCreateLocalSecret({
+    fileName: "guest-session-hash-pepper.txt",
+    envVar: "GUEST_SESSION_HASH_PEPPER",
+    productionErrorMessage:
       "GUEST_SESSION_HASH_PEPPER is required for guest session hashing",
-    );
-  }
-
-  return loadPersistedLocalPepper() || createAndPersistLocalPepper();
+    label: "guest session hash pepper",
+  });
 }

--- a/mcpjam-inspector/server/utils/guest-session-secret.ts
+++ b/mcpjam-inspector/server/utils/guest-session-secret.ts
@@ -1,79 +1,13 @@
-import { randomBytes } from "crypto";
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  writeFileSync,
-} from "fs";
-import os from "os";
-import path from "path";
-import { logger } from "./logger.js";
+import { getOrCreateLocalSecret } from "./local-secret-store.js";
 
 export const GUEST_SESSION_SECRET_HEADER = "x-mcpjam-guest-session-secret";
 
-function getLocalGuestSecretDir(): string {
-  return process.env.GUEST_JWT_KEY_DIR || path.join(os.homedir(), ".mcpjam");
-}
-
-function getLocalGuestSessionSecretPath(): string {
-  return path.join(getLocalGuestSecretDir(), "guest-session-shared-secret.txt");
-}
-
-function createAndPersistLocalGuestSessionSecret(): string {
-  const secretPath = getLocalGuestSessionSecretPath();
-  const dir = path.dirname(secretPath);
-  const secret = randomBytes(32).toString("hex");
-
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(secretPath, secret, "utf-8");
-
-  try {
-    chmodSync(secretPath, 0o600);
-  } catch {
-    // Best effort. Some platforms/filesystems do not support chmod semantics.
-  }
-
-  logger.info(
-    `[guest-auth] Created local guest session shared secret at ${secretPath}`,
-  );
-  return secret;
-}
-
-function loadPersistedLocalGuestSessionSecret(): string | null {
-  const secretPath = getLocalGuestSessionSecretPath();
-  if (!existsSync(secretPath)) {
-    return null;
-  }
-
-  try {
-    const secret = readFileSync(secretPath, "utf-8").trim();
-    return secret.length > 0 ? secret : null;
-  } catch (error) {
-    logger.warn(
-      `[guest-auth] Failed to load local guest session shared secret (${error instanceof Error ? error.message : String(error)})`,
-    );
-    return null;
-  }
-}
-
 export function getGuestSessionSharedSecret(): string {
-  const envSecret = process.env.MCPJAM_GUEST_SESSION_SHARED_SECRET?.trim();
-  if (envSecret) {
-    return envSecret;
-  }
-
-  if (
-    process.env.NODE_ENV === "production" ||
-    process.env.NODE_ENV === "test"
-  ) {
-    throw new Error(
+  return getOrCreateLocalSecret({
+    fileName: "guest-session-shared-secret.txt",
+    envVar: "MCPJAM_GUEST_SESSION_SHARED_SECRET",
+    productionErrorMessage:
       "MCPJAM_GUEST_SESSION_SHARED_SECRET is required for guest session proxying",
-    );
-  }
-
-  return (
-    loadPersistedLocalGuestSessionSecret() ||
-    createAndPersistLocalGuestSessionSecret()
-  );
+    label: "guest session shared secret",
+  });
 }

--- a/mcpjam-inspector/server/utils/guest-session-source.ts
+++ b/mcpjam-inspector/server/utils/guest-session-source.ts
@@ -136,12 +136,21 @@ async function performGuestSessionFetch(
   url: string,
   init: RequestInit,
   source: "Convex" | "MCPJam",
+  mode: "lookup_or_create" | "lookup_only" | undefined,
 ): Promise<GuestSessionFetchResult> {
   try {
     const response = await fetch(url, init);
     const setCookies = readSetCookies(response.headers);
 
-    if (response.status === 204 || response.status === 404) {
+    // 204 is the upstream's explicit "no guest exists" signal and is always
+    // a miss. 404 is ambiguous: in lookup_only it's a reasonable miss, but
+    // in lookup_or_create (the default) it almost certainly means the
+    // upstream endpoint is missing/misconfigured and should surface as an
+    // error rather than silently disabling guest auth.
+    if (response.status === 204) {
+      return { kind: "miss", setCookies };
+    }
+    if (response.status === 404 && mode === "lookup_only") {
       return { kind: "miss", setCookies };
     }
 
@@ -188,6 +197,7 @@ export async function fetchRemoteGuestSession(
       signal: AbortSignal.timeout(10_000),
     },
     "MCPJam",
+    context?.body?.mode,
   );
 }
 
@@ -215,6 +225,7 @@ export async function fetchConvexGuestSession(
       signal: AbortSignal.timeout(10_000),
     },
     "Convex",
+    context?.body?.mode,
   );
 }
 

--- a/mcpjam-inspector/server/utils/guest-session-source.ts
+++ b/mcpjam-inspector/server/utils/guest-session-source.ts
@@ -17,8 +17,6 @@ export type RemoteGuestSession = {
 export type GuestSessionFetchContext = {
   cookie?: string | null;
   userAgent?: string | null;
-  forwardedFor?: string | null;
-  realIp?: string | null;
   body?: GuestSessionRequestBody | null;
 };
 
@@ -95,12 +93,6 @@ function buildForwardedHeaders(
   }
   if (context?.userAgent) {
     headers["User-Agent"] = context.userAgent;
-  }
-  if (context?.forwardedFor) {
-    headers["X-Forwarded-For"] = context.forwardedFor;
-  }
-  if (context?.realIp) {
-    headers["X-Real-IP"] = context.realIp;
   }
   return headers;
 }
@@ -230,7 +222,7 @@ export async function fetchConvexGuestSession(
 
 /**
  * Server-only fetch helper used by inspector services that need a guest
- * bearer token without browser context (no cookie, no UA, no IP). Returns
+ * bearer token without browser context (no cookie, no UA). Returns
  * just the session JSON or null. Always uses lookup_or_create.
  */
 export async function fetchGuestSessionForServerSideAuth(): Promise<RemoteGuestSession | null> {

--- a/mcpjam-inspector/server/utils/guest-session-source.ts
+++ b/mcpjam-inspector/server/utils/guest-session-source.ts
@@ -40,7 +40,6 @@ export type GuestSessionFetchResult =
   | {
       kind: "error";
       status: number;
-      message?: string;
       setCookies: string[];
     };
 

--- a/mcpjam-inspector/server/utils/guest-session-source.ts
+++ b/mcpjam-inspector/server/utils/guest-session-source.ts
@@ -14,6 +14,36 @@ export type RemoteGuestSession = {
   expiresAt: number;
 };
 
+export type GuestSessionFetchContext = {
+  cookie?: string | null;
+  userAgent?: string | null;
+  forwardedFor?: string | null;
+  realIp?: string | null;
+  body?: GuestSessionRequestBody | null;
+};
+
+export type GuestSessionRequestBody = {
+  mode?: "lookup_or_create" | "lookup_only";
+  legacyToken?: string;
+};
+
+export type GuestSessionFetchResult =
+  | {
+      kind: "session";
+      session: RemoteGuestSession;
+      setCookies: string[];
+    }
+  | {
+      kind: "miss";
+      setCookies: string[];
+    }
+  | {
+      kind: "error";
+      status: number;
+      message?: string;
+      setCookies: string[];
+    };
+
 function getConvexHttpUrl(): string {
   const convexHttpUrl = process.env.CONVEX_HTTP_URL;
   if (!convexHttpUrl) {
@@ -42,110 +72,167 @@ export function getRemoteGuestJwksUrl(): string {
   );
 }
 
-export async function fetchRemoteGuestSession(): Promise<RemoteGuestSession | null> {
+function readSetCookies(headers: Headers): string[] {
+  const fnHeaders = headers as Headers & {
+    getSetCookie?: () => string[];
+  };
+  if (typeof fnHeaders.getSetCookie === "function") {
+    return fnHeaders.getSetCookie();
+  }
+  const single = headers.get("set-cookie");
+  return single ? [single] : [];
+}
+
+function buildForwardedHeaders(
+  context: GuestSessionFetchContext | undefined,
+  extra: Record<string, string>,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...extra,
+  };
+  if (context?.cookie) {
+    headers["Cookie"] = context.cookie;
+  }
+  if (context?.userAgent) {
+    headers["User-Agent"] = context.userAgent;
+  }
+  if (context?.forwardedFor) {
+    headers["X-Forwarded-For"] = context.forwardedFor;
+  }
+  if (context?.realIp) {
+    headers["X-Real-IP"] = context.realIp;
+  }
+  return headers;
+}
+
+function buildRequestBody(
+  context: GuestSessionFetchContext | undefined,
+): string {
+  const body: GuestSessionRequestBody = {};
+  if (context?.body?.mode) body.mode = context.body.mode;
+  if (context?.body?.legacyToken) body.legacyToken = context.body.legacyToken;
+  return JSON.stringify(body);
+}
+
+function parseSessionPayload(raw: unknown): RemoteGuestSession | null {
+  if (!raw || typeof raw !== "object") return null;
+  const session = raw as Record<string, unknown>;
+  if (
+    typeof session.token !== "string" ||
+    typeof session.expiresAt !== "number"
+  ) {
+    return null;
+  }
+  return {
+    guestId:
+      typeof session.guestId === "string" ? session.guestId : undefined,
+    token: session.token,
+    expiresAt: session.expiresAt,
+  };
+}
+
+async function performGuestSessionFetch(
+  url: string,
+  init: RequestInit,
+  source: "Convex" | "MCPJam",
+): Promise<GuestSessionFetchResult> {
   try {
-    const response = await fetch(getRemoteGuestSessionUrl(), {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      signal: AbortSignal.timeout(10_000),
-    });
+    const response = await fetch(url, init);
+    const setCookies = readSetCookies(response.headers);
+
+    if (response.status === 204 || response.status === 404) {
+      return { kind: "miss", setCookies };
+    }
 
     if (!response.ok) {
       logger.warn(
-        `[guest-auth] Failed to fetch MCPJam guest session: ${response.status} ${response.statusText}`,
+        `[guest-auth] Failed to fetch ${source} guest session: ${response.status} ${response.statusText}`,
       );
-      return null;
+      return { kind: "error", status: response.status, setCookies };
     }
 
-    const session = (await response.json()) as {
-      guestId?: unknown;
-      token?: unknown;
-      expiresAt?: unknown;
-    };
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      return { kind: "error", status: 503, setCookies };
+    }
 
-    if (
-      typeof session.token !== "string" ||
-      typeof session.expiresAt !== "number"
-    ) {
+    const session = parseSessionPayload(body);
+    if (!session) {
       logger.warn(
-        "[guest-auth] MCPJam guest session response was missing token or expiresAt",
+        `[guest-auth] ${source} guest session response was missing token or expiresAt`,
       );
-      return null;
+      return { kind: "error", status: 503, setCookies };
     }
 
-    logger.info("[guest-auth] Fetched guest token from MCPJam guest session");
-    return {
-      guestId:
-        typeof session.guestId === "string" ? session.guestId : undefined,
-      token: session.token,
-      expiresAt: session.expiresAt,
-    };
+    logger.info(`[guest-auth] Fetched guest token from ${source} guest session`);
+    return { kind: "session", session, setCookies };
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
-    logger.warn(`[guest-auth] Failed to fetch MCPJam guest session: ${errMsg}`);
-    return null;
+    logger.warn(`[guest-auth] Failed to fetch ${source} guest session: ${errMsg}`);
+    return { kind: "error", status: 503, setCookies: [] };
   }
 }
 
-export async function fetchConvexGuestSession(): Promise<RemoteGuestSession | null> {
+export async function fetchRemoteGuestSession(
+  context?: GuestSessionFetchContext,
+): Promise<GuestSessionFetchResult> {
+  return performGuestSessionFetch(
+    getRemoteGuestSessionUrl(),
+    {
+      method: "POST",
+      headers: buildForwardedHeaders(context, {}),
+      body: buildRequestBody(context),
+      signal: AbortSignal.timeout(10_000),
+    },
+    "MCPJam",
+  );
+}
+
+export async function fetchConvexGuestSession(
+  context?: GuestSessionFetchContext,
+): Promise<GuestSessionFetchResult> {
   try {
     await provisionGuestAuthConfigToConvex();
-
-    const response = await fetch(getConvexGuestSessionUrl(), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        [GUEST_SESSION_SECRET_HEADER]: getGuestSessionSharedSecret(),
-      },
-      signal: AbortSignal.timeout(10_000),
-    });
-
-    if (!response.ok) {
-      logger.warn(
-        `[guest-auth] Failed to fetch Convex guest session: ${response.status} ${response.statusText}`,
-      );
-      return null;
-    }
-
-    const session = (await response.json()) as {
-      guestId?: unknown;
-      token?: unknown;
-      expiresAt?: unknown;
-    };
-
-    if (
-      typeof session.token !== "string" ||
-      typeof session.expiresAt !== "number"
-    ) {
-      logger.warn(
-        "[guest-auth] Convex guest session response was missing token or expiresAt",
-      );
-      return null;
-    }
-
-    logger.info("[guest-auth] Fetched guest token from Convex guest session");
-    return {
-      guestId:
-        typeof session.guestId === "string" ? session.guestId : undefined,
-      token: session.token,
-      expiresAt: session.expiresAt,
-    };
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
-    logger.warn(`[guest-auth] Failed to fetch Convex guest session: ${errMsg}`);
-    return null;
+    logger.warn(
+      `[guest-auth] Failed to provision Convex guest auth env: ${errMsg}`,
+    );
+    return { kind: "error", status: 503, setCookies: [] };
   }
+
+  return performGuestSessionFetch(
+    getConvexGuestSessionUrl(),
+    {
+      method: "POST",
+      headers: buildForwardedHeaders(context, {
+        [GUEST_SESSION_SECRET_HEADER]: getGuestSessionSharedSecret(),
+      }),
+      body: buildRequestBody(context),
+      signal: AbortSignal.timeout(10_000),
+    },
+    "Convex",
+  );
 }
 
+/**
+ * Server-only fetch helper used by inspector services that need a guest
+ * bearer token without browser context (no cookie, no UA, no IP). Returns
+ * just the session JSON or null. Always uses lookup_or_create.
+ */
 export async function fetchGuestSessionForServerSideAuth(): Promise<RemoteGuestSession | null> {
-  if (
+  const useRemote =
     process.env.MCPJAM_GUEST_SESSION_URL ||
-    process.env.NODE_ENV === "production"
-  ) {
-    return fetchRemoteGuestSession();
-  }
+    process.env.NODE_ENV === "production";
 
-  return fetchConvexGuestSession();
+  const result = useRemote
+    ? await fetchRemoteGuestSession()
+    : await fetchConvexGuestSession();
+
+  return result.kind === "session" ? result.session : null;
 }
 
 export async function fetchRemoteGuestJwks(): Promise<Response | null> {

--- a/mcpjam-inspector/server/utils/local-secret-store.ts
+++ b/mcpjam-inspector/server/utils/local-secret-store.ts
@@ -1,0 +1,83 @@
+import { randomBytes } from "crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "fs";
+import os from "os";
+import path from "path";
+import { logger } from "./logger.js";
+
+export interface LocalSecretSpec {
+  /** Filename inside the local secrets directory. */
+  fileName: string;
+  /** Environment variable that, when set, takes precedence over the local file. */
+  envVar: string;
+  /** Error thrown in production/test when the env var is missing. */
+  productionErrorMessage: string;
+  /** Human-readable label used in log messages (e.g. "guest session shared secret"). */
+  label: string;
+}
+
+function getLocalSecretDir(): string {
+  return process.env.GUEST_JWT_KEY_DIR || path.join(os.homedir(), ".mcpjam");
+}
+
+function persistLocalSecret(spec: LocalSecretSpec): string {
+  const filePath = path.join(getLocalSecretDir(), spec.fileName);
+  const value = randomBytes(32).toString("hex");
+
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, value, "utf-8");
+
+  try {
+    chmodSync(filePath, 0o600);
+  } catch {
+    // Best effort. Some platforms/filesystems do not support chmod semantics.
+  }
+
+  logger.info(`[guest-auth] Created local ${spec.label} at ${filePath}`);
+  return value;
+}
+
+function loadPersistedLocalSecret(spec: LocalSecretSpec): string | null {
+  const filePath = path.join(getLocalSecretDir(), spec.fileName);
+  if (!existsSync(filePath)) {
+    return null;
+  }
+
+  try {
+    const value = readFileSync(filePath, "utf-8").trim();
+    return value.length > 0 ? value : null;
+  } catch (error) {
+    logger.warn(
+      `[guest-auth] Failed to load local ${spec.label} (${error instanceof Error ? error.message : String(error)})`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Resolve a server-side secret with this precedence:
+ *   1. Trimmed value of `spec.envVar` if set.
+ *   2. In production/test: throw `spec.productionErrorMessage`.
+ *   3. In dev: load the persisted file at `~/.mcpjam/<fileName>`, or
+ *      generate, persist, and return a fresh 32-byte hex value.
+ */
+export function getOrCreateLocalSecret(spec: LocalSecretSpec): string {
+  const envValue = process.env[spec.envVar]?.trim();
+  if (envValue) {
+    return envValue;
+  }
+
+  if (
+    process.env.NODE_ENV === "production" ||
+    process.env.NODE_ENV === "test"
+  ) {
+    throw new Error(spec.productionErrorMessage);
+  }
+
+  return loadPersistedLocalSecret(spec) || persistLocalSecret(spec);
+}

--- a/mcpjam-inspector/server/utils/local-secret-store.ts
+++ b/mcpjam-inspector/server/utils/local-secret-store.ts
@@ -62,9 +62,15 @@ function loadPersistedLocalSecret(spec: LocalSecretSpec): string | null {
 /**
  * Resolve a server-side secret with this precedence:
  *   1. Trimmed value of `spec.envVar` if set.
- *   2. In production/test: throw `spec.productionErrorMessage`.
- *   3. In dev: load the persisted file at `~/.mcpjam/<fileName>`, or
- *      generate, persist, and return a fresh 32-byte hex value.
+ *   2. Only when `NODE_ENV === "development"`: load the persisted file at
+ *      `~/.mcpjam/<fileName>`, or generate, persist, and return a fresh
+ *      32-byte hex value.
+ *   3. Otherwise (production, test, staging, preview, ci, unset, …):
+ *      throw `spec.productionErrorMessage`.
+ *
+ * The allowlist is deliberate: a containerized staging deployment with an
+ * ephemeral filesystem would otherwise generate a fresh random secret on
+ * every restart, silently invalidating every existing guest-session hash.
  */
 export function getOrCreateLocalSecret(spec: LocalSecretSpec): string {
   const envValue = process.env[spec.envVar]?.trim();
@@ -72,10 +78,7 @@ export function getOrCreateLocalSecret(spec: LocalSecretSpec): string {
     return envValue;
   }
 
-  if (
-    process.env.NODE_ENV === "production" ||
-    process.env.NODE_ENV === "test"
-  ) {
+  if (process.env.NODE_ENV !== "development") {
     throw new Error(spec.productionErrorMessage);
   }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches guest-session issuance/proxying and client token caching/merge flows, which impacts authentication-adjacent behavior and could affect user state if cookie/204/403 handling is wrong. Changes are well-tested but span both client and server request semantics.
> 
> **Overview**
> Shifts guest sessions from `localStorage`-persisted JWTs to **cookie-backed identity**: the browser keeps the guest id in an HttpOnly cookie while the client caches short-lived bearer tokens only in memory, adds `credentials: "include"`, and implements one-time legacy `localStorage` token migration via `legacyToken`.
> 
> Adds a `lookup_only` mode end-to-end (client `getExistingGuestBearerToken`, server request parsing, upstream forwarding) and updates `useRegistryServers` to merge guest stars post-login using lookup-only plus bounded retries/backoff instead of reading a stored token.
> 
> Hardens the `/api/web/guest-session` proxy: forwards only the `__Host-mcpjam_guest_session` cookie + `User-Agent` upstream, passes through upstream `Set-Cookie`, treats upstream 204 as a miss, and surfaces revocation as 403. Refactors local secret handling into reusable `getOrCreateLocalSecret` and provisions a new `GUEST_SESSION_HASH_PEPPER` secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43ab67b491463fff781e8d403d25526d0e161b6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->