### PR TITLE
Fix Ollama/Azure custom base URLs not sent in chat-v2 requests

### DIFF
--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -1356,6 +1356,8 @@ export function useChatSession({
               // omitting it client-side keeps the body honest about the
               // session kind.
               ...(hostedChatboxId ? {} : { directVisibility }),
+              ollamaBaseUrl: getOllamaBaseUrl(),
+              azureBaseUrl: getAzureBaseUrl(),
               // Pass projectId for BYOK direct-chat history persistence
               ...(hostedProjectId ? { projectId: hostedProjectId } : {}),
               // Convex server Ids parallel to `selectedServers`. Only sent
@@ -1405,6 +1407,8 @@ export function useChatSession({
     systemPrompt,
     selectedServers,
     directVisibility,
+    getOllamaBaseUrl,
+    getAzureBaseUrl,
     hostedProjectId,
     chatSessionId,
     hostedSelectedServerIds,


### PR DESCRIPTION
## Summary
- The chat-v2 transport body was missing `ollamaBaseUrl` and `azureBaseUrl`, so the server always fell back to the default Ollama URL (`http://127.0.0.1:11434/api`) regardless of what the user configured in Settings.
- Added both fields to the transport body in `useChatSession`, matching what `useChat` (v1) already does.

## Test plan
- Set a custom Ollama base URL (e.g. `http://localhost:11211/api`) in LLM Provider settings
- Select an Ollama model and send a chat message
- Verify the request hits the configured port instead of the default 11434