### PR TITLE
Limits sidebar

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/MCPJamLimitDialog.test.tsx
@@ -76,7 +76,7 @@ describe("MCPJamLimitDialog", () => {
         name: /you've used today's free guest limit/i,
       }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/10×/i)).toBeInTheDocument();
+    expect(screen.getByText(/15×/i)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /^sign in$/i }),
     ).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
@@ -6,6 +6,7 @@ import { CreditTopupDialog } from "@/components/billing/CreditTopupDialog";
 import { TopupActionButton } from "@/components/billing/TopupActionButton";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { useCreditBalance } from "@/hooks/useCreditBalance";
+import { formatCreditResetText } from "@/lib/credit-usage";
 import type { CreditTopupSource } from "@/hooks/useCreditTopup";
 
 /** Pulls the limit-modal redirect flag out of the current hash and clears it
@@ -32,24 +33,6 @@ function consumeTopupFlagFromHash(): boolean {
   );
   return true;
 }
-
-const MS_PER_HOUR = 60 * 60 * 1000;
-const MS_PER_DAY = 24 * MS_PER_HOUR;
-
-const formatResetText = (resetAt: number): string => {
-  if (!resetAt || !Number.isFinite(resetAt)) return "resets daily";
-  const diffMs = resetAt - Date.now();
-  if (diffMs <= 0) return "resets shortly";
-  if (diffMs < MS_PER_HOUR) {
-    const minutes = Math.max(1, Math.round(diffMs / 60000));
-    return `resets in ${minutes}m`;
-  }
-  if (diffMs < MS_PER_DAY) {
-    const hours = Math.max(1, Math.round(diffMs / MS_PER_HOUR));
-    return `resets in ${hours}h`;
-  }
-  return "resets tomorrow";
-};
 
 interface CreditBalanceCardProps {
   /** Optional override for the chat session id used by the top-up flow. */
@@ -112,7 +95,7 @@ export function CreditBalanceCard({
           rightText={
             isLoading || !balance
               ? null
-              : `${Math.round(balance.freeDailyPercentUsed)}% used · ${formatResetText(balance.freeDailyResetAt)}`
+              : `${Math.round(balance.freeDailyPercentUsed)}% used · ${formatCreditResetText(balance.freeDailyResetAt)}`
           }
           fillPercent={
             isLoading || !balance ? 0 : balance.freeDailyPercentUsed

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -48,6 +48,7 @@ import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { MCPIcon } from "@/components/ui/mcp-icon";
 import { SidebarUser } from "@/components/sidebar/sidebar-user";
 import { SidebarContextSwitcher } from "@/components/sidebar/sidebar-context-switcher";
+import { SidebarCreditUsage } from "@/components/sidebar/sidebar-credit-usage";
 import { ShareProjectDialog } from "@/components/project/ShareProjectDialog";
 import { useUpdateNotification } from "@/hooks/useUpdateNotification";
 import { Badge } from "@mcpjam/design-system/badge";
@@ -757,6 +758,7 @@ export function MCPSidebar({
               </SidebarMenuItem>
             </SidebarMenu>
           ) : null}
+          <SidebarCreditUsage />
           <SidebarUser />
         </SidebarFooter>
       </Sidebar>

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -758,7 +758,9 @@ export function MCPSidebar({
               </SidebarMenuItem>
             </SidebarMenu>
           ) : null}
-          <SidebarCreditUsage />
+          {!user ? (
+            <SidebarCreditUsage className="px-1" includeGuests />
+          ) : null}
           <SidebarUser />
         </SidebarFooter>
       </Sidebar>

--- a/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/mcpjam-limit-dialog.tsx
@@ -92,7 +92,7 @@ export function MCPJamLimitDialog() {
               <DialogTitle>You've used today's free guest limit</DialogTitle>
               <DialogDescription>
                 Sign in to get{" "}
-                <strong className="text-foreground font-medium">10×</strong>{" "}
+                <strong className="text-foreground font-medium">15×</strong>{" "}
                 daily usage.
               </DialogDescription>
             </DialogHeader>

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
@@ -11,11 +11,13 @@ let balanceState:
     }
   | undefined;
 let isLoadingState = false;
+let isAuthenticatedState = true;
 
 vi.mock("@/hooks/useCreditBalance", () => ({
   useCreditBalance: () => ({
     balance: balanceState,
     isLoading: isLoadingState,
+    isAuthenticated: isAuthenticatedState,
   }),
 }));
 
@@ -30,6 +32,7 @@ describe("SidebarCreditUsage", () => {
       freeDailyResetAt: Date.now() + 3 * 60 * 60 * 1000,
     };
     isLoadingState = false;
+    isAuthenticatedState = true;
   });
 
   afterEach(() => {
@@ -42,11 +45,14 @@ describe("SidebarCreditUsage", () => {
     const dailyRow = screen.getByTestId("sidebar-usage-daily");
     expect(screen.getByLabelText("Credit usage")).toBeInTheDocument();
     expect(dailyRow).toHaveTextContent("Daily limit");
-    expect(dailyRow).toHaveTextContent("12% used");
+    expect(dailyRow).toHaveTextContent("12%");
     expect(dailyRow).toHaveTextContent("resets in 3h");
+    expect(
+      screen.queryByText(/15× daily usage/i)
+    ).not.toBeInTheDocument();
   });
 
-  it("renders paid credits when the user has topped up before", () => {
+  it("keeps the sidebar strip focused on daily limits for paid users", () => {
     balanceState = {
       paidPercentRemaining: 25,
       hasPurchaseHistory: true,
@@ -56,16 +62,31 @@ describe("SidebarCreditUsage", () => {
 
     render(<SidebarCreditUsage />);
 
+    expect(screen.queryByTestId("sidebar-usage-paid")).not.toBeInTheDocument();
+    expect(screen.getByTestId("sidebar-usage-daily")).toHaveTextContent("40%");
+  });
+
+  it("shows paid credits in the full account-menu variant", () => {
+    balanceState = {
+      paidPercentRemaining: 25,
+      hasPurchaseHistory: true,
+      freeDailyPercentUsed: 40,
+      freeDailyResetAt: Date.now() + 60 * 60 * 1000,
+    };
+
+    render(<SidebarCreditUsage variant="full" />);
+
+    expect(screen.getByText("Credit usage")).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar-usage-daily")).toHaveTextContent(
+      "40% used"
+    );
     const paidRow = screen.getByTestId("sidebar-usage-paid");
     expect(paidRow).toHaveTextContent("Paid credits");
     expect(paidRow).toHaveTextContent("75% used");
     expect(paidRow.textContent ?? "").not.toMatch(/\$/);
-  });
-
-  it("hides paid credits for users without purchase history", () => {
-    render(<SidebarCreditUsage />);
-
-    expect(screen.queryByTestId("sidebar-usage-paid")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/15× daily usage/i)
+    ).not.toBeInTheDocument();
   });
 
   it("does not render when there is no balance to show", () => {
@@ -73,7 +94,29 @@ describe("SidebarCreditUsage", () => {
 
     render(<SidebarCreditUsage />);
 
-    expect(screen.queryByTestId("sidebar-credit-usage")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("sidebar-credit-usage")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders guest balance data with a sign-in upgrade hint", () => {
+    balanceState = {
+      paidPercentRemaining: null,
+      hasPurchaseHistory: false,
+      freeDailyPercentUsed: 65,
+      freeDailyResetAt: Date.now() + 2 * 60 * 60 * 1000,
+    };
+    isAuthenticatedState = false;
+
+    render(<SidebarCreditUsage includeGuests />);
+
+    const dailyRow = screen.getByTestId("sidebar-usage-daily");
+    expect(screen.getByTestId("sidebar-credit-usage")).toBeInTheDocument();
+    expect(dailyRow).toHaveTextContent("Sign in for 15× daily usage");
+    expect(dailyRow).toHaveTextContent("Daily limit");
+    expect(dailyRow).toHaveTextContent("65%");
+    expect(dailyRow).toHaveTextContent("resets in 2h");
+    expect(screen.queryByTestId("sidebar-usage-paid")).not.toBeInTheDocument();
   });
 
   it("shows a loading shell while credit balance is loading", () => {
@@ -84,9 +127,7 @@ describe("SidebarCreditUsage", () => {
 
     expect(screen.getByTestId("sidebar-credit-usage")).toBeInTheDocument();
     expect(screen.getByTestId("sidebar-usage-daily")).toHaveTextContent(
-      "Daily limit",
+      "Daily limit"
     );
-    expect(screen.queryByTestId("sidebar-usage-paid")).not.toBeInTheDocument();
   });
 });
-

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SidebarCreditUsage } from "@/components/sidebar/sidebar-credit-usage";
+
+let balanceState:
+  | {
+      paidPercentRemaining: number | null;
+      hasPurchaseHistory: boolean;
+      freeDailyPercentUsed: number;
+      freeDailyResetAt: number;
+    }
+  | undefined;
+let isLoadingState = false;
+
+vi.mock("@/hooks/useCreditBalance", () => ({
+  useCreditBalance: () => ({
+    balance: balanceState,
+    isLoading: isLoadingState,
+  }),
+}));
+
+describe("SidebarCreditUsage", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-03T12:00:00Z"));
+    balanceState = {
+      paidPercentRemaining: null,
+      hasPurchaseHistory: false,
+      freeDailyPercentUsed: 12,
+      freeDailyResetAt: Date.now() + 3 * 60 * 60 * 1000,
+    };
+    isLoadingState = false;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the daily limit bar with reset timing", () => {
+    render(<SidebarCreditUsage />);
+
+    const dailyRow = screen.getByTestId("sidebar-usage-daily");
+    expect(screen.getByLabelText("Credit usage")).toBeInTheDocument();
+    expect(dailyRow).toHaveTextContent("Daily limit");
+    expect(dailyRow).toHaveTextContent("12% used");
+    expect(dailyRow).toHaveTextContent("resets in 3h");
+  });
+
+  it("renders paid credits when the user has topped up before", () => {
+    balanceState = {
+      paidPercentRemaining: 25,
+      hasPurchaseHistory: true,
+      freeDailyPercentUsed: 40,
+      freeDailyResetAt: Date.now() + 60 * 60 * 1000,
+    };
+
+    render(<SidebarCreditUsage />);
+
+    const paidRow = screen.getByTestId("sidebar-usage-paid");
+    expect(paidRow).toHaveTextContent("Paid credits");
+    expect(paidRow).toHaveTextContent("75% used");
+    expect(paidRow.textContent ?? "").not.toMatch(/\$/);
+  });
+
+  it("hides paid credits for users without purchase history", () => {
+    render(<SidebarCreditUsage />);
+
+    expect(screen.queryByTestId("sidebar-usage-paid")).not.toBeInTheDocument();
+  });
+
+  it("does not render when there is no balance to show", () => {
+    balanceState = undefined;
+
+    render(<SidebarCreditUsage />);
+
+    expect(screen.queryByTestId("sidebar-credit-usage")).not.toBeInTheDocument();
+  });
+
+  it("shows a loading shell while credit balance is loading", () => {
+    balanceState = undefined;
+    isLoadingState = true;
+
+    render(<SidebarCreditUsage />);
+
+    expect(screen.getByTestId("sidebar-credit-usage")).toBeInTheDocument();
+    expect(screen.getByTestId("sidebar-usage-daily")).toHaveTextContent(
+      "Daily limit",
+    );
+    expect(screen.queryByTestId("sidebar-usage-paid")).not.toBeInTheDocument();
+  });
+});
+

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
@@ -60,6 +60,10 @@ vi.mock("@/components/sidebar/sidebar-context-switcher", () => ({
   SidebarContextSwitcher: () => <div data-testid="context-switcher" />,
 }));
 
+vi.mock("@/components/sidebar/sidebar-credit-usage", () => ({
+  SidebarCreditUsage: () => <div data-testid="sidebar-credit-usage" />,
+}));
+
 vi.mock("@/components/project/ShareProjectDialog", () => ({
   ShareProjectDialog: (props: unknown) => mockShareProjectDialog(props),
 }));
@@ -208,6 +212,25 @@ describe("sidebar invite CTA", () => {
     expect(screen.getByText("Invite team members")).toHaveClass(
       "group-data-[collapsible=icon]:hidden",
     );
+  });
+
+  it("places credit usage between the invite CTA and the profile menu", () => {
+    renderSidebar();
+
+    const inviteButton = screen.getByRole("button", {
+      name: "Invite team members",
+    });
+    const creditUsage = screen.getByTestId("sidebar-credit-usage");
+    const sidebarUser = screen.getByTestId("sidebar-user");
+
+    expect(
+      inviteButton.compareDocumentPosition(creditUsage) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      creditUsage.compareDocumentPosition(sidebarUser) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 
   it("opens the share dialog for the active project", () => {

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
@@ -61,7 +61,19 @@ vi.mock("@/components/sidebar/sidebar-context-switcher", () => ({
 }));
 
 vi.mock("@/components/sidebar/sidebar-credit-usage", () => ({
-  SidebarCreditUsage: () => <div data-testid="sidebar-credit-usage" />,
+  SidebarCreditUsage: ({
+    className,
+    includeGuests,
+  }: {
+    className?: string;
+    includeGuests?: boolean;
+  }) => (
+    <div
+      data-testid="sidebar-credit-usage"
+      data-include-guests={String(includeGuests)}
+      className={className}
+    />
+  ),
 }));
 
 vi.mock("@/components/project/ShareProjectDialog", () => ({
@@ -214,19 +226,37 @@ describe("sidebar invite CTA", () => {
     );
   });
 
-  it("places credit usage between the invite CTA and the profile menu", () => {
+  it("keeps signed-in footer focused on invite CTA and the profile menu", () => {
     renderSidebar();
 
     const inviteButton = screen.getByRole("button", {
       name: "Invite team members",
     });
+    const sidebarUser = screen.getByTestId("sidebar-user");
+
+    expect(screen.queryByTestId("sidebar-credit-usage")).not.toBeInTheDocument();
+    expect(
+      inviteButton.compareDocumentPosition(sidebarUser) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("pins credit usage above the account button for guests", () => {
+    mockUseConvexAuth.mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+    mockUseAuth.mockReturnValue({
+      user: null,
+    });
+
+    renderSidebar();
+
     const creditUsage = screen.getByTestId("sidebar-credit-usage");
     const sidebarUser = screen.getByTestId("sidebar-user");
 
-    expect(
-      inviteButton.compareDocumentPosition(creditUsage) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
+    expect(creditUsage).toHaveAttribute("data-include-guests", "true");
+    expect(creditUsage).toHaveClass("px-1");
     expect(
       creditUsage.compareDocumentPosition(sidebarUser) &
         Node.DOCUMENT_POSITION_FOLLOWING,

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-user.test.tsx
@@ -1,10 +1,25 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
 
-const signInMock = vi.fn();
+const authState = vi.hoisted(() => ({
+  signInMock: vi.fn(),
+  signOutMock: vi.fn(),
+  user: null as
+    | null
+    | {
+        email: string;
+        firstName?: string;
+        lastName?: string;
+      },
+}));
 
 vi.mock("@workos-inc/authkit-react", () => ({
-  useAuth: () => ({ user: null, signIn: signInMock, signOut: vi.fn() }),
+  useAuth: () => ({
+    user: authState.user,
+    signIn: authState.signInMock,
+    signOut: authState.signOutMock,
+  }),
 }));
 
 vi.mock("convex/react", () => ({
@@ -18,6 +33,48 @@ vi.mock("@/lib/config", () => ({
 
 vi.mock("@/hooks/useProfilePicture", () => ({
   useProfilePicture: () => ({ profilePictureUrl: null }),
+}));
+
+vi.mock("@/components/sidebar/sidebar-credit-usage", () => ({
+  SidebarCreditUsage: ({
+    className,
+    variant,
+  }: {
+    className?: string;
+    variant?: string;
+  }) => (
+    <div
+      data-testid="sidebar-credit-usage"
+      data-variant={variant}
+      className={className}
+    />
+  ),
+}));
+
+vi.mock("@mcpjam/design-system/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div data-testid="account-menu">{children}</div>
+  ),
+  DropdownMenuLabel: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuItem: ({
+    children,
+    variant: _variant,
+    ...props
+  }: {
+    children: ReactNode;
+    variant?: string;
+  } & ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
 }));
 
 vi.mock("@/components/ui/sidebar", () => ({
@@ -34,6 +91,12 @@ vi.mock("@/components/ui/sidebar", () => ({
 import { SidebarUser } from "../sidebar-user";
 
 describe("SidebarUser", () => {
+  beforeEach(() => {
+    authState.user = null;
+    authState.signInMock.mockClear();
+    authState.signOutMock.mockClear();
+  });
+
   it("renders sign-in button when unauthenticated in hosted mode", () => {
     render(<SidebarUser />);
     expect(screen.getByText("Sign in")).toBeDefined();
@@ -47,6 +110,21 @@ describe("SidebarUser", () => {
   it("calls signIn when button is clicked", () => {
     render(<SidebarUser />);
     fireEvent.click(screen.getByText("Sign in"));
-    expect(signInMock).toHaveBeenCalled();
+    expect(authState.signInMock).toHaveBeenCalled();
+  });
+
+  it("renders credit usage inside the signed-in account dropdown", () => {
+    authState.user = {
+      email: "owner@example.com",
+      firstName: "Owner",
+      lastName: "Example",
+    };
+
+    render(<SidebarUser />);
+
+    const creditUsage = screen.getByTestId("sidebar-credit-usage");
+    expect(screen.getByTestId("account-menu")).toContainElement(creditUsage);
+    expect(creditUsage).toHaveAttribute("data-variant", "full");
+    expect(creditUsage).toHaveClass("px-1", "pb-1");
   });
 });

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
@@ -1,0 +1,97 @@
+import { Progress } from "@mcpjam/design-system/progress";
+import { Skeleton } from "@mcpjam/design-system/skeleton";
+import { useCreditBalance } from "@/hooks/useCreditBalance";
+import { formatCreditResetText } from "@/lib/credit-usage";
+
+export function SidebarCreditUsage() {
+  const { balance, isLoading } = useCreditBalance();
+
+  if (!isLoading && !balance) {
+    return null;
+  }
+
+  const dailyPercentUsed = balance ? Math.round(balance.freeDailyPercentUsed) : 0;
+  const paidPercentUsed =
+    balance?.paidPercentRemaining != null
+      ? Math.round(100 - balance.paidPercentRemaining)
+      : 0;
+  const hasPaidHistory = balance?.hasPurchaseHistory === true;
+
+  return (
+    <div
+      data-testid="sidebar-credit-usage"
+      aria-label="Credit usage"
+      className="group-data-[collapsible=icon]:hidden"
+    >
+      <div className="rounded-md border border-sidebar-border/60 bg-sidebar-accent/25 px-2.5 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+        <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-sidebar-foreground/55">
+          Credit usage
+        </p>
+        <div className="flex flex-col gap-2.5">
+          <SidebarUsageRow
+            label="Daily limit"
+            percentText={`${dailyPercentUsed}% used`}
+            helperText={
+              balance ? formatCreditResetText(balance.freeDailyResetAt) : null
+            }
+            fillPercent={balance ? balance.freeDailyPercentUsed : 0}
+            isLoading={isLoading}
+            testId="sidebar-usage-daily"
+          />
+          {!isLoading && hasPaidHistory && balance ? (
+            <SidebarUsageRow
+              label="Paid credits"
+              percentText={`${paidPercentUsed}% used`}
+              helperText={null}
+              fillPercent={paidPercentUsed}
+              isLoading={false}
+              testId="sidebar-usage-paid"
+            />
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface SidebarUsageRowProps {
+  label: string;
+  percentText: string;
+  helperText: string | null;
+  fillPercent: number;
+  isLoading: boolean;
+  testId: string;
+}
+
+function SidebarUsageRow({
+  label,
+  percentText,
+  helperText,
+  fillPercent,
+  isLoading,
+  testId,
+}: SidebarUsageRowProps) {
+  return (
+    <div className="flex flex-col gap-1.5" data-testid={testId}>
+      <div className="flex items-center justify-between gap-2 text-[11px] leading-none">
+        <span className="min-w-0 truncate font-medium text-sidebar-foreground">
+          {label}
+        </span>
+        <span className="shrink-0 text-sidebar-foreground/60">
+          {isLoading ? <Skeleton className="h-3 w-12" /> : percentText}
+        </span>
+      </div>
+      {isLoading ? (
+        <Skeleton className="h-1.5 w-full rounded-full" />
+      ) : (
+        <Progress className="h-1.5 bg-primary/15" value={fillPercent} />
+      )}
+      {helperText && !isLoading ? (
+        <span className="truncate text-[10px] leading-none text-sidebar-foreground/45">
+          {helperText}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
@@ -2,43 +2,73 @@ import { Progress } from "@mcpjam/design-system/progress";
 import { Skeleton } from "@mcpjam/design-system/skeleton";
 import { useCreditBalance } from "@/hooks/useCreditBalance";
 import { formatCreditResetText } from "@/lib/credit-usage";
+import { cn } from "@/lib/utils";
 
-export function SidebarCreditUsage() {
-  const { balance, isLoading } = useCreditBalance();
+interface SidebarCreditUsageProps {
+  className?: string;
+  includeGuests?: boolean;
+  variant?: "strip" | "full";
+}
+
+export function SidebarCreditUsage({
+  className,
+  includeGuests = false,
+  variant = "strip",
+}: SidebarCreditUsageProps = {}) {
+  const { balance, isLoading, isAuthenticated } = useCreditBalance({
+    includeGuests,
+  });
 
   if (!isLoading && !balance) {
     return null;
   }
 
-  const dailyPercentUsed = balance ? Math.round(balance.freeDailyPercentUsed) : 0;
+  const dailyPercentUsed = balance
+    ? Math.round(balance.freeDailyPercentUsed)
+    : 0;
+  const resetText = balance
+    ? formatCreditResetText(balance.freeDailyResetAt)
+    : null;
   const paidPercentUsed =
     balance?.paidPercentRemaining != null
       ? Math.round(100 - balance.paidPercentRemaining)
       : 0;
   const hasPaidHistory = balance?.hasPurchaseHistory === true;
+  const showGuestUpgradeHint =
+    variant === "strip" && includeGuests && !isAuthenticated && !isLoading;
 
   return (
     <div
       data-testid="sidebar-credit-usage"
       aria-label="Credit usage"
-      className="group-data-[collapsible=icon]:hidden"
+      className={cn("group-data-[collapsible=icon]:hidden", className)}
     >
-      <div className="rounded-md border border-sidebar-border/60 bg-sidebar-accent/25 px-2.5 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-        <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-sidebar-foreground/55">
-          Credit usage
-        </p>
-        <div className="flex flex-col gap-2.5">
+      <div className={cn("px-2 py-1.5", variant === "full" && "px-2.5 py-2")}>
+        {variant === "full" ? (
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+            Credit usage
+          </p>
+        ) : null}
+        <div
+          className={cn(
+            "flex flex-col",
+            variant === "full" ? "gap-2.5" : "gap-0"
+          )}
+        >
           <SidebarUsageRow
             label="Daily limit"
-            percentText={`${dailyPercentUsed}% used`}
-            helperText={
-              balance ? formatCreditResetText(balance.freeDailyResetAt) : null
+            percentText={`${dailyPercentUsed}%${
+              variant === "full" ? " used" : ""
+            }`}
+            eyebrowText={
+              showGuestUpgradeHint ? "Sign in for 15× daily usage" : null
             }
+            helperText={resetText}
             fillPercent={balance ? balance.freeDailyPercentUsed : 0}
             isLoading={isLoading}
             testId="sidebar-usage-daily"
           />
-          {!isLoading && hasPaidHistory && balance ? (
+          {variant === "full" && !isLoading && hasPaidHistory && balance ? (
             <SidebarUsageRow
               label="Paid credits"
               percentText={`${paidPercentUsed}% used`}
@@ -57,6 +87,7 @@ export function SidebarCreditUsage() {
 interface SidebarUsageRowProps {
   label: string;
   percentText: string;
+  eyebrowText?: string | null;
   helperText: string | null;
   fillPercent: number;
   isLoading: boolean;
@@ -66,6 +97,7 @@ interface SidebarUsageRowProps {
 function SidebarUsageRow({
   label,
   percentText,
+  eyebrowText,
   helperText,
   fillPercent,
   isLoading,
@@ -73,11 +105,16 @@ function SidebarUsageRow({
 }: SidebarUsageRowProps) {
   return (
     <div className="flex flex-col gap-1.5" data-testid={testId}>
+      {eyebrowText && !isLoading ? (
+        <span className="truncate text-[10px] leading-none text-muted-foreground">
+          {eyebrowText}
+        </span>
+      ) : null}
       <div className="flex items-center justify-between gap-2 text-[11px] leading-none">
-        <span className="min-w-0 truncate font-medium text-sidebar-foreground">
+        <span className="min-w-0 truncate font-medium text-foreground">
           {label}
         </span>
-        <span className="shrink-0 text-sidebar-foreground/60">
+        <span className="shrink-0 text-muted-foreground">
           {isLoading ? <Skeleton className="h-3 w-12" /> : percentText}
         </span>
       </div>
@@ -87,11 +124,10 @@ function SidebarUsageRow({
         <Progress className="h-1.5 bg-primary/15" value={fillPercent} />
       )}
       {helperText && !isLoading ? (
-        <span className="truncate text-[10px] leading-none text-sidebar-foreground/45">
+        <span className="truncate text-[10px] leading-none text-muted-foreground">
           {helperText}
         </span>
       ) : null}
     </div>
   );
 }
-

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
@@ -27,6 +27,7 @@ import {
 } from "lucide-react";
 import { useProfilePicture } from "@/hooks/useProfilePicture";
 import { HOSTED_MODE } from "@/lib/config";
+import { SidebarCreditUsage } from "@/components/sidebar/sidebar-credit-usage";
 
 export function SidebarUser() {
   const { isLoading, isAuthenticated: _isAuthenticated } = useConvexAuth();
@@ -120,7 +121,7 @@ export function SidebarUser() {
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent
-            className="w-[--radix-dropdown-menu-trigger-width] min-w-56 rounded-lg"
+            className="w-[--radix-dropdown-menu-trigger-width] min-w-72 rounded-lg"
             side={isMobile ? "bottom" : "right"}
             align="end"
             sideOffset={4}
@@ -147,6 +148,7 @@ export function SidebarUser() {
                 </div>
               </div>
             </DropdownMenuLabel>
+            <SidebarCreditUsage className="px-1 pb-1" variant="full" />
             <DropdownMenuSeparator />
             <DropdownMenuItem
               onClick={() => (window.location.hash = "profile")}

--- a/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
@@ -1,5 +1,6 @@
 import { useConvexAuth, useQuery } from "convex/react";
 import { useMemo } from "react";
+import { HOSTED_MODE } from "@/lib/config";
 
 export interface CreditBalanceState {
   /**
@@ -60,11 +61,19 @@ const normalizeBalance = (raw: unknown): CreditBalanceState | undefined => {
   };
 };
 
-export function useCreditBalance() {
+interface UseCreditBalanceOptions {
+  includeGuests?: boolean;
+}
+
+export function useCreditBalance({
+  includeGuests = false,
+}: UseCreditBalanceOptions = {}) {
   const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
+  const shouldFetchBalance =
+    !isAuthLoading && (isAuthenticated || includeGuests || HOSTED_MODE);
   const raw = useQuery(
     "billing:getCreditBalance" as any,
-    isAuthenticated ? ({} as any) : "skip",
+    shouldFetchBalance ? ({} as any) : "skip"
   ) as unknown | undefined;
   // Memoize on the raw query reference. Convex returns a stable reference
   // when the underlying data is unchanged, so the normalized object stays
@@ -73,7 +82,6 @@ export function useCreditBalance() {
   const balance = useMemo(() => normalizeBalance(raw), [raw]);
   // Treat the bootstrap window as loading so the card shows a skeleton
   // instead of flashing an empty zero state before the query resolves.
-  const isLoading =
-    isAuthLoading || (isAuthenticated && raw === undefined);
-  return { balance, isLoading };
+  const isLoading = isAuthLoading || (shouldFetchBalance && raw === undefined);
+  return { balance, isLoading, isAuthenticated };
 }

--- a/mcpjam-inspector/client/src/lib/credit-usage.ts
+++ b/mcpjam-inspector/client/src/lib/credit-usage.ts
@@ -1,0 +1,18 @@
+const MS_PER_HOUR = 60 * 60 * 1000;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+
+export const formatCreditResetText = (resetAt: number): string => {
+  if (!resetAt || !Number.isFinite(resetAt)) return "resets daily";
+  const diffMs = resetAt - Date.now();
+  if (diffMs <= 0) return "resets shortly";
+  if (diffMs < MS_PER_HOUR) {
+    const minutes = Math.max(1, Math.round(diffMs / 60000));
+    return `resets in ${minutes}m`;
+  }
+  if (diffMs < MS_PER_DAY) {
+    const hours = Math.max(1, Math.round(diffMs / MS_PER_HOUR));
+    return `resets in ${hours}h`;
+  }
+  return "resets tomorrow";
+};
+

--- a/mcpjam-inspector/client/src/lib/credit-usage.ts
+++ b/mcpjam-inspector/client/src/lib/credit-usage.ts
@@ -15,4 +15,3 @@ export const formatCreditResetText = (resetAt: number): string => {
   }
   return "resets tomorrow";
 };
-


### PR DESCRIPTION
## What changed
- Added the existing billing-page usage logic to the sidebar.
- Guests now see their real daily usage bar in the sidebar.
- Guests see a sign-in message for more usage.
- Signed-in users can see daily usage and top-up credit usage from the account menu.
- getCreditBalance now supports both guests and signed-in users.
## Checks
- Backend credit tests pass.
- Sidebar and billing UI tests pass.