### PR TITLE
[Org Creation Limit] PR-I1: cap created organizations at 2

### DIFF
--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-context-switcher.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-context-switcher.test.tsx
@@ -197,6 +197,8 @@ describe("SidebarContextSwitcher", () => {
     mockUseOrganizationQueries.mockReturnValue({
       sortedOrganizations: orgs,
       isLoading: false,
+      createdCount: 0,
+      canCreateOrganization: true,
     });
   });
 
@@ -641,6 +643,33 @@ describe("SidebarContextSwitcher", () => {
     expect(lastCall.open).toBe(true);
   });
 
+  it("disables the 'New organization' button when the user has reached the creation limit", () => {
+    mockUseOrganizationQueries.mockReturnValue({
+      sortedOrganizations: orgs,
+      isLoading: false,
+      createdCount: 2,
+      canCreateOrganization: false,
+    });
+    render(
+      <SidebarContextSwitcher
+        activeProjectId="p1"
+        activeOrganizationId="org_a"
+        projects={projects}
+        onSwitchProject={vi.fn()}
+        onCreateProject={vi.fn(async () => "")}
+        onDeleteProject={vi.fn()}
+      />
+    );
+    openMainDropdown();
+    const button = screen.getByRole("button", { name: "New organization" });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    const lastCall = mockCreateOrgDialog.mock.calls.at(-1)?.[0] as
+      | { open: boolean }
+      | undefined;
+    expect(lastCall?.open ?? false).toBe(false);
+  });
+
   it("clicking the 'Add project' header button calls onCreateProject with a unique name", () => {
     const onCreateProject = vi.fn(async () => "");
     render(
@@ -684,6 +713,8 @@ describe("SidebarContextSwitcher", () => {
     mockUseOrganizationQueries.mockReturnValue({
       sortedOrganizations: [orgs[0]],
       isLoading: false,
+      createdCount: 0,
+      canCreateOrganization: true,
     });
     const { container } = render(
       <SidebarContextSwitcher
@@ -764,6 +795,8 @@ describe("SidebarContextSwitcher", () => {
     mockUseOrganizationQueries.mockReturnValue({
       sortedOrganizations: [orgs[0]],
       isLoading: false,
+      createdCount: 0,
+      canCreateOrganization: true,
     });
     render(
       <SidebarContextSwitcher

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-context-switcher.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-context-switcher.tsx
@@ -128,7 +128,8 @@ export function SidebarContextSwitcher({
 }: SidebarContextSwitcherProps) {
   const { isMobile } = useSidebar();
   const { isAuthenticated } = useConvexAuth();
-  const { sortedOrganizations } = useOrganizationQueries({ isAuthenticated });
+  const { sortedOrganizations, canCreateOrganization } =
+    useOrganizationQueries({ isAuthenticated });
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [chipPopoverOpen, setChipPopoverOpen] = useState(false);
@@ -269,19 +270,31 @@ export function SidebarContextSwitcher({
               <div className="relative px-1.5 pt-2 pb-1">
                 <div className="flex items-center justify-between px-2 pb-1.5">
                   <span className={SECTION_LABEL_CLASS}>Organization</span>
-                  <button
-                    type="button"
-                    aria-label="New organization"
-                    title="New organization"
-                    onClick={() => {
-                      setShowCreateOrgDialog(true);
-                      setChipPopoverOpen(false);
-                      setMenuOpen(false);
-                    }}
-                    className="p-0.5 rounded text-muted-foreground/70 hover:text-foreground hover:bg-muted transition-colors"
-                  >
-                    <Plus className="size-3.5" />
-                  </button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="inline-flex">
+                        <button
+                          type="button"
+                          aria-label="New organization"
+                          disabled={!canCreateOrganization}
+                          onClick={() => {
+                            if (!canCreateOrganization) return;
+                            setShowCreateOrgDialog(true);
+                            setChipPopoverOpen(false);
+                            setMenuOpen(false);
+                          }}
+                          className="p-0.5 rounded text-muted-foreground/70 hover:text-foreground hover:bg-muted transition-colors disabled:opacity-40 disabled:hover:bg-transparent disabled:hover:text-muted-foreground/70 disabled:cursor-not-allowed"
+                        >
+                          <Plus className="size-3.5" />
+                        </button>
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" sideOffset={6}>
+                      {canCreateOrganization
+                        ? "New organization"
+                        : "You can only create up to 2 organizations."}
+                    </TooltipContent>
+                  </Tooltip>
                 </div>
                 <div
                   className="flex items-center gap-1 rounded-lg hover:bg-accent transition-colors"

--- a/mcpjam-inspector/client/src/hooks/useOrganizations.ts
+++ b/mcpjam-inspector/client/src/hooks/useOrganizations.ts
@@ -13,7 +13,10 @@ export interface Organization {
   createdAt: number;
   updatedAt: number;
   myRole?: string;
+  isCreator?: boolean;
 }
+
+export const ORGANIZATION_CREATION_LIMIT = 2;
 
 export interface OrganizationMember {
   _id: string;
@@ -57,9 +60,24 @@ export function useOrganizationQueries({
     return [...organizations].sort((a, b) => b.updatedAt - a.updatedAt);
   }, [organizations]);
 
+  const createdCount = useMemo(
+    () =>
+      organizations
+        ? organizations.filter((org) => org.isCreator).length
+        : 0,
+    [organizations],
+  );
+
+  const canCreateOrganization =
+    !isAuthenticated ||
+    organizations === undefined ||
+    createdCount < ORGANIZATION_CREATION_LIMIT;
+
   return {
     sortedOrganizations,
     isLoading,
+    createdCount,
+    canCreateOrganization,
   };
 }
 


### PR DESCRIPTION
## Summary

- Disables the org switcher's "+" button with an explanatory tooltip once a user has already created two organizations.
- The cap applies to **organizations the user created** — being invited to additional orgs as a member is unaffected.
- Existing users who created more than two orgs are grandfathered; the limit only blocks new creation.
- Frontend disable is purely UX — server-side enforcement lives in the companion backend PR, so the limit can't be bypassed by calling the endpoint directly.

## Test plan

- [ ] As a user with 0 created orgs: "+" button is enabled, hover shows "New organization", create flow works.
- [ ] As a user with 1 created org: "+" still enabled, can create their 2nd.
- [ ] As a user with 2 created orgs: "+" is disabled with reduced opacity, hover shows "You can only create up to 2 organizations.", clicking does nothing.
- [ ] As a legacy user with >2 created orgs: "+" is disabled with the same tooltip; existing orgs all render and switch normally.
- [ ] Being invited to extra orgs as a member does not consume the creation quota.
- [ ] Stale/racing client (e.g. opened before backend rolled out): server rejects the mutation, dialog surfaces a toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)