### PR TITLE
billing: remove topup processing-fee disclaimer

### DIFF
--- a/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
@@ -115,12 +115,6 @@ export function CreditTopupDialog({
               })}
             </div>
           )}
-          {selectedPreset && (
-            <p className="text-xs text-muted-foreground">
-              A portion of your payment covers payment processing and platform
-              fees; the rest is added to your account balance.
-            </p>
-          )}
         </div>
         <DialogFooter>
           <Button

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
@@ -57,7 +57,7 @@ describe("CreditTopupDialog", () => {
     expect(screen.getByRole("radio", { name: "$20" })).toBeInTheDocument();
   });
 
-  it("auto-selects the first preset and shows the fee copy without dollar amounts", () => {
+  it("auto-selects the first preset without surfacing fee or credited dollar amounts", () => {
     render(
       <CreditTopupDialog
         open
@@ -72,11 +72,13 @@ describe("CreditTopupDialog", () => {
       "aria-checked",
       "true",
     );
+    // The processing-fee disclaimer was removed so users can't back-compute
+    // the take rate.
     expect(
-      screen.getByText(
+      screen.queryByText(
         /A portion of your payment covers payment processing and platform fees/,
       ),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
     // Guard against regressions that surface a "credited" / "you'll receive
     // $X.XX" dollar value (which would leak the take rate).
     expect(screen.queryByText(/You'll receive \$/)).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Removes the "A portion of your payment covers payment processing and platform fees…" copy from the credit topup dialog so users can't back-compute the take rate.
- Flips the test assertion from "disclaimer is shown" to "disclaimer is absent" as a regression guard.

Pairs with the backend rate bump in [mcpjam-backend#203](https://github.com/MCPJam/mcpjam-backend/pull/203). Fixes the UI half of the [Asana bug](https://app.asana.com/1/743928175952196/project/1214370586897409/task/1214458310737926).

## Test plan
- [x] \`npx vitest run client/src/components/billing/__tests__/CreditTopupDialog.test.tsx\` (7/7 passing)
- [ ] Open the topup dialog in the inspector and confirm only the preset buttons + Cancel/Continue render — no disclaimer paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)