### PR TITLE
wrongly persisted servers through project switch

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -819,12 +819,14 @@ export default function App() {
   }, []);
   const handleSignOut = useCallback<SidebarSignOut>(
     async (options) => {
-      const connectedServerNames = Object.entries(appState.servers)
-        .filter(([, server]) => server.connectionStatus === "connected")
+      const serverNamesToDisconnect = Object.entries(appState.servers)
+        .filter(([, server]) => server.connectionStatus !== "disconnected")
         .map(([serverName]) => serverName);
 
       await Promise.allSettled(
-        connectedServerNames.map((serverName) => handleDisconnect(serverName))
+        serverNamesToDisconnect.map((serverName) =>
+          handleDisconnect(serverName)
+        )
       );
 
       if (options?.navigate === false) {

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -44,6 +44,7 @@ import { SupportTab } from "./components/SupportTab";
 import { RegistryTab } from "./components/RegistryTab";
 import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
 import { MCPSidebar } from "./components/mcp-sidebar";
+import type { SidebarSignOut } from "./components/sidebar/sidebar-user";
 import { SidebarInset, SidebarProvider } from "./components/ui/sidebar";
 import {
   Alert,
@@ -250,7 +251,7 @@ function sanitizeOAuthDebuggerText(value: string | null | undefined): string {
         const separator = typeof args[2] === "string" ? args[2] : undefined;
         return key && separator ? `${key}${separator}[redacted]` : "[redacted]";
       }),
-    value,
+    value
   );
 }
 
@@ -816,6 +817,25 @@ export default function App() {
     const server = runtimeServer ?? projectServer;
     return server ? { runtimeServer, projectServer, server } : null;
   }, []);
+  const handleSignOut = useCallback<SidebarSignOut>(
+    async (options) => {
+      const connectedServerNames = Object.entries(appState.servers)
+        .filter(([, server]) => server.connectionStatus === "connected")
+        .map(([serverName]) => serverName);
+
+      await Promise.allSettled(
+        connectedServerNames.map((serverName) => handleDisconnect(serverName))
+      );
+
+      if (options?.navigate === false) {
+        await signOut(options);
+        return;
+      }
+
+      signOut(options);
+    },
+    [appState.servers, handleDisconnect, signOut]
+  );
   useEffect(() => {
     return subscribeToOAuthDebuggerRequests(({ serverName }) => {
       const matchedServerName = Object.entries(
@@ -1288,6 +1308,21 @@ export default function App() {
       setSelectedMultipleServersToAllServers,
     ]
   );
+  const previousActiveProjectIdRef = useRef(activeProjectId);
+
+  useEffect(() => {
+    const previousActiveProjectId = previousActiveProjectIdRef.current;
+    previousActiveProjectIdRef.current = activeProjectId;
+
+    if (
+      previousActiveProjectId === activeProjectId ||
+      previousActiveProjectId === "none"
+    ) {
+      return;
+    }
+
+    applyNavigation("servers", { updateHash: true });
+  }, [activeProjectId, applyNavigation]);
 
   useLayoutEffect(() => {
     if (HOSTED_MODE) {
@@ -1666,8 +1701,8 @@ export default function App() {
           section === "billing"
             ? `organizations/${organizationId}/billing`
             : section === "models"
-              ? `organizations/${organizationId}/models`
-              : `organizations/${organizationId}`,
+            ? `organizations/${organizationId}/models`
+            : `organizations/${organizationId}`,
           { updateHash: true }
         );
         return;
@@ -2002,6 +2037,7 @@ export default function App() {
         activeOrganizationName={activeOrganizationName}
         onSwitchOrganization={handleSidebarSwitchOrganization}
         onSwitchActiveOrganization={handleSwitchActiveOrganization}
+        onSignOut={handleSignOut}
         onProjectShared={handleProjectShared}
         billingUiEnabled={billingUiEnabled}
         billingGateDenied={sidebarGateDenied}
@@ -2237,7 +2273,7 @@ export default function App() {
                     ?.writeText(details)
                     .then(() => toast.success("Copied OAuth debugger error"))
                     .catch(() =>
-                      toast.error("Could not copy OAuth debugger error"),
+                      toast.error("Could not copy OAuth debugger error")
                     );
                 };
 
@@ -2272,7 +2308,7 @@ export default function App() {
                   message: sanitizedError.message,
                   stack: sanitizedError.stack,
                   componentStack: sanitizeOAuthDebuggerText(
-                    errorInfo.componentStack,
+                    errorInfo.componentStack
                   ),
                 });
               }}
@@ -2355,11 +2391,11 @@ export default function App() {
             />
           )}
           {activeTab === "settings" && (
-              <SettingsTab
-                activeOrganizationId={activeOrganizationId}
-                onNavigate={handleNavigate}
-              />
-            )}
+            <SettingsTab
+              activeOrganizationId={activeOrganizationId}
+              onNavigate={handleNavigate}
+            />
+          )}
           {activeTab === "support" && <SupportTab />}
           {activeTab === "profile" && <ProfileTab />}
           {activeTab === "organizations" && (
@@ -2474,7 +2510,7 @@ export default function App() {
               signIn();
             }}
             onSignOut={() => {
-              void signOut();
+              void handleSignOut();
             }}
           >
             {isSharedChatRoute ? (

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -1583,6 +1583,58 @@ describe("App hosted OAuth callback handling", () => {
     expect(window.location.hash).toBe("#tools");
   });
 
+  it("disconnects in-flight servers before signing out from the sidebar", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    window.history.replaceState({}, "", "/#servers");
+
+    const signOut = vi.fn();
+    const handleDisconnect = vi.fn().mockResolvedValue(undefined);
+    mockUseAuth.mockReturnValue({
+      ...mockWorkOsAuthState,
+      signOut,
+    });
+    mockUseAppState.mockReturnValue({
+      ...createAppStateMock(),
+      appState: {
+        servers: {
+          connected: { connectionStatus: "connected" },
+          connecting: { connectionStatus: "connecting" },
+          oauth: { connectionStatus: "oauth-flow" },
+          disconnected: { connectionStatus: "disconnected" },
+        },
+        selectedServer: "none",
+        selectedMultipleServers: [],
+      },
+      handleDisconnect,
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockMCPSidebar).toHaveBeenCalled();
+    });
+
+    const lastCall =
+      mockMCPSidebar.mock.calls[mockMCPSidebar.mock.calls.length - 1];
+    const sidebarProps = lastCall?.[0] as unknown as {
+      onSignOut?: (options?: { returnTo?: string }) => Promise<void>;
+    };
+
+    await act(async () => {
+      await sidebarProps.onSignOut?.({ returnTo: "https://example.test" });
+    });
+
+    expect(handleDisconnect).toHaveBeenCalledWith("connected");
+    expect(handleDisconnect).toHaveBeenCalledWith("connecting");
+    expect(handleDisconnect).toHaveBeenCalledWith("oauth");
+    expect(handleDisconnect).not.toHaveBeenCalledWith("disconnected");
+    expect(signOut).toHaveBeenCalledWith({ returnTo: "https://example.test" });
+    expect(signOut.mock.invocationCallOrder[0]).toBeGreaterThan(
+      Math.max(...handleDisconnect.mock.invocationCallOrder.slice(0, 3))
+    );
+  });
+
   it("disables sidebar project creation when the routed org is free and at cap", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -522,7 +522,7 @@ describe("App hosted OAuth callback handling", () => {
     window.history.replaceState({}, "", "/#oauth-flow");
     mockOAuthFlowTabState.shouldThrow = true;
     mockOAuthFlowTabState.error = new Error(
-      "token exchange failed client_secret=super-secret Bearer access-token",
+      "token exchange failed client_secret=super-secret Bearer access-token"
     );
     const writeText = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal("navigator", {
@@ -532,22 +532,24 @@ describe("App hosted OAuth callback handling", () => {
 
     render(<App />);
 
-    expect(await screen.findByText("OAuth Debugger crashed")).toBeInTheDocument();
+    expect(
+      await screen.findByText("OAuth Debugger crashed")
+    ).toBeInTheDocument();
     expect(mockPosthogCapture).toHaveBeenCalledWith(
       "oauth_debugger_error_boundary",
       expect.objectContaining({
         message: expect.stringContaining("[redacted]"),
-      }),
+      })
     );
-    expect(
-      JSON.stringify(mockPosthogCapture.mock.calls),
-    ).not.toContain("super-secret");
+    expect(JSON.stringify(mockPosthogCapture.mock.calls)).not.toContain(
+      "super-secret"
+    );
 
     fireEvent.click(screen.getByRole("button", { name: /copy details/i }));
 
     await waitFor(() => {
       expect(writeText).toHaveBeenCalledWith(
-        expect.not.stringContaining("super-secret"),
+        expect.not.stringContaining("super-secret")
       );
     });
     expect(writeText.mock.calls[0]?.[0]).toContain("[redacted]");
@@ -1274,6 +1276,313 @@ describe("App hosted OAuth callback handling", () => {
     });
   });
 
+  it("redirects to servers when switching active organization changes the project", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    window.history.replaceState({}, "", "/#tools");
+
+    const setActiveOrganizationIdSpy = vi.fn();
+    mockUseAppState.mockImplementation(() => {
+      const [activeOrganizationId, setActiveOrganizationId] = useState<
+        string | undefined
+      >("org-a");
+      const [activeProjectId, setActiveProjectId] = useState("project-a");
+
+      return {
+        ...createAppStateMock(),
+        activeProjectId,
+        activeOrganizationId,
+        setActiveOrganizationId: (organizationId: string | undefined) => {
+          setActiveOrganizationIdSpy(organizationId);
+          setActiveOrganizationId(organizationId);
+          setActiveProjectId("project-b");
+        },
+      };
+    });
+    mockUseQuery.mockImplementation((name: string) => {
+      if (name === "organizations:getMyOrganizations") {
+        return [
+          {
+            _id: "org-a",
+            name: "Org A",
+            updatedAt: 1,
+            createdAt: 1,
+            createdBy: "user-1",
+            myRole: "owner",
+          },
+          {
+            _id: "org-b",
+            name: "Org B",
+            updatedAt: 2,
+            createdAt: 2,
+            createdBy: "user-1",
+            myRole: "owner",
+          },
+        ];
+      }
+
+      return undefined;
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockMCPSidebar).toHaveBeenCalled();
+    });
+
+    const getLastSidebarProps = () => {
+      const lastCall =
+        mockMCPSidebar.mock.calls[mockMCPSidebar.mock.calls.length - 1];
+      return lastCall?.[0] as unknown as {
+        activeOrganizationId?: string;
+        onSwitchActiveOrganization?: (organizationId: string) => void;
+      };
+    };
+
+    act(() => {
+      getLastSidebarProps().onSwitchActiveOrganization?.("org-b");
+    });
+
+    await waitFor(() => {
+      expect(setActiveOrganizationIdSpy).toHaveBeenCalledWith("org-b");
+      expect(getLastSidebarProps().activeOrganizationId).toBe("org-b");
+      expect(window.location.hash).toBe("#servers");
+    });
+  });
+
+  it("stays on servers when an organization-driven project change already starts there", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    window.history.replaceState({}, "", "/#servers");
+
+    const setActiveOrganizationIdSpy = vi.fn();
+    mockUseAppState.mockImplementation(() => {
+      const [activeOrganizationId, setActiveOrganizationId] = useState<
+        string | undefined
+      >("org-a");
+      const [activeProjectId, setActiveProjectId] = useState("project-a");
+
+      return {
+        ...createAppStateMock(),
+        activeProjectId,
+        activeOrganizationId,
+        setActiveOrganizationId: (organizationId: string | undefined) => {
+          setActiveOrganizationIdSpy(organizationId);
+          setActiveOrganizationId(organizationId);
+          setActiveProjectId("project-b");
+        },
+      };
+    });
+    mockUseQuery.mockImplementation((name: string) => {
+      if (name === "organizations:getMyOrganizations") {
+        return [
+          {
+            _id: "org-a",
+            name: "Org A",
+            updatedAt: 1,
+            createdAt: 1,
+            createdBy: "user-1",
+            myRole: "owner",
+          },
+          {
+            _id: "org-b",
+            name: "Org B",
+            updatedAt: 2,
+            createdAt: 2,
+            createdBy: "user-1",
+            myRole: "owner",
+          },
+        ];
+      }
+
+      return undefined;
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockMCPSidebar).toHaveBeenCalled();
+    });
+
+    const getLastSidebarProps = () => {
+      const lastCall =
+        mockMCPSidebar.mock.calls[mockMCPSidebar.mock.calls.length - 1];
+      return lastCall?.[0] as unknown as {
+        activeOrganizationId?: string;
+        onSwitchActiveOrganization?: (organizationId: string) => void;
+      };
+    };
+
+    act(() => {
+      getLastSidebarProps().onSwitchActiveOrganization?.("org-b");
+    });
+
+    await waitFor(() => {
+      expect(setActiveOrganizationIdSpy).toHaveBeenCalledWith("org-b");
+      expect(getLastSidebarProps().activeOrganizationId).toBe("org-b");
+      expect(window.location.hash).toBe("#servers");
+    });
+  });
+
+  it("redirects to servers after an explicit project switch", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    window.history.replaceState({}, "", "/#settings");
+
+    const handleSwitchProjectMock = vi.fn();
+    mockUseAppState.mockImplementation(() => {
+      const [activeProjectId, setActiveProjectId] = useState("project-a");
+
+      return {
+        ...createAppStateMock(),
+        activeProjectId,
+        handleSwitchProject: (projectId: string) => {
+          handleSwitchProjectMock(projectId);
+          setActiveProjectId(projectId);
+        },
+      };
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockMCPSidebar).toHaveBeenCalled();
+    });
+
+    const lastCall =
+      mockMCPSidebar.mock.calls[mockMCPSidebar.mock.calls.length - 1];
+    const sidebarProps = lastCall?.[0] as unknown as {
+      onSwitchProject?: (projectId: string) => void;
+    };
+
+    act(() => {
+      sidebarProps.onSwitchProject?.("project-b");
+    });
+
+    await waitFor(() => {
+      expect(handleSwitchProjectMock).toHaveBeenCalledWith("project-b");
+      expect(window.location.hash).toBe("#servers");
+    });
+  });
+
+  it("keeps the current tab when the initial empty project selection resolves", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    window.history.replaceState({}, "", "/#tools");
+
+    let resolveProject: ((projectId: string) => void) | undefined;
+    mockUseAppState.mockImplementation(() => {
+      const [activeProjectId, setActiveProjectId] = useState("none");
+      resolveProject = setActiveProjectId;
+
+      return {
+        ...createAppStateMock(),
+        activeProjectId,
+      };
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockMCPSidebar).toHaveBeenCalled();
+    });
+
+    act(() => {
+      resolveProject?.("project-a");
+    });
+
+    await waitFor(() => {
+      const lastCall =
+        mockMCPSidebar.mock.calls[mockMCPSidebar.mock.calls.length - 1];
+      expect(
+        (lastCall?.[0] as unknown as { activeProjectId?: string })
+          .activeProjectId
+      ).toBe("project-a");
+    });
+    expect(window.location.hash).toBe("#tools");
+  });
+
+  it("redirects to servers after deleting the active project", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    window.history.replaceState({}, "", "/#tools");
+
+    const handleDeleteProjectMock = vi.fn();
+    mockUseAppState.mockImplementation(() => {
+      const [activeProjectId, setActiveProjectId] = useState("project-active");
+
+      return {
+        ...createAppStateMock(),
+        activeProjectId,
+        handleDeleteProject: async (projectId: string) => {
+          handleDeleteProjectMock(projectId);
+          setActiveProjectId("project-fallback");
+          return true;
+        },
+      };
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockMCPSidebar).toHaveBeenCalled();
+    });
+
+    const lastCall =
+      mockMCPSidebar.mock.calls[mockMCPSidebar.mock.calls.length - 1];
+    const sidebarProps = lastCall?.[0] as unknown as {
+      onDeleteProject?: (projectId: string) => Promise<boolean>;
+    };
+
+    await act(async () => {
+      await sidebarProps.onDeleteProject?.("project-active");
+    });
+
+    await waitFor(() => {
+      expect(handleDeleteProjectMock).toHaveBeenCalledWith("project-active");
+      expect(window.location.hash).toBe("#servers");
+    });
+  });
+
+  it("keeps the current tab after deleting a non-active project", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    window.history.replaceState({}, "", "/#tools");
+
+    const handleDeleteProjectMock = vi.fn();
+    mockUseAppState.mockImplementation(() => {
+      const [activeProjectId] = useState("project-active");
+
+      return {
+        ...createAppStateMock(),
+        activeProjectId,
+        handleDeleteProject: async (projectId: string) => {
+          handleDeleteProjectMock(projectId);
+          return true;
+        },
+      };
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockMCPSidebar).toHaveBeenCalled();
+    });
+
+    const lastCall =
+      mockMCPSidebar.mock.calls[mockMCPSidebar.mock.calls.length - 1];
+    const sidebarProps = lastCall?.[0] as unknown as {
+      onDeleteProject?: (projectId: string) => Promise<boolean>;
+    };
+
+    await act(async () => {
+      await sidebarProps.onDeleteProject?.("project-other");
+    });
+
+    expect(handleDeleteProjectMock).toHaveBeenCalledWith("project-other");
+    expect(window.location.hash).toBe("#tools");
+  });
+
   it("disables sidebar project creation when the routed org is free and at cap", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
@@ -1381,11 +1690,7 @@ describe("App hosted OAuth callback handling", () => {
   it("shows billing handoff loading and triggers sign-in for guest billing entry", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
-    window.history.replaceState(
-      {},
-      "",
-      "/billing?plan=solo&interval=annual"
-    );
+    window.history.replaceState({}, "", "/billing?plan=solo&interval=annual");
 
     const signIn = vi.fn();
     mockUseAuth.mockReturnValue({
@@ -1553,11 +1858,7 @@ describe("App hosted OAuth callback handling", () => {
   it("keeps billing resume behind the checkout spinner for signed-in users", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
-    window.history.replaceState(
-      {},
-      "",
-      "/billing?plan=solo&interval=annual"
-    );
+    window.history.replaceState({}, "", "/billing?plan=solo&interval=annual");
 
     mockUseFeatureFlagEnabled.mockImplementation(
       (flag: string) => flag === "billing-entitlements-ui"
@@ -1615,11 +1916,7 @@ describe("App hosted OAuth callback handling", () => {
   it("drops the billing overlay when checkout intent is consumed", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
-    window.history.replaceState(
-      {},
-      "",
-      "/billing?plan=solo&interval=annual"
-    );
+    window.history.replaceState({}, "", "/billing?plan=solo&interval=annual");
 
     mockUseFeatureFlagEnabled.mockImplementation(
       (flag: string) => flag === "billing-entitlements-ui"
@@ -1671,11 +1968,7 @@ describe("App hosted OAuth callback handling", () => {
   it("drops the billing overlay when checkout navigation starts", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
-    window.history.replaceState(
-      {},
-      "",
-      "/billing?plan=solo&interval=annual"
-    );
+    window.history.replaceState({}, "", "/billing?plan=solo&interval=annual");
 
     mockUseFeatureFlagEnabled.mockImplementation(
       (flag: string) => flag === "billing-entitlements-ui"
@@ -1730,11 +2023,7 @@ describe("App hosted OAuth callback handling", () => {
   it("clears billing handoff state when no organization is available", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();
-    window.history.replaceState(
-      {},
-      "",
-      "/billing?plan=solo&interval=annual"
-    );
+    window.history.replaceState({}, "", "/billing?plan=solo&interval=annual");
 
     mockUseFeatureFlagEnabled.mockImplementation(
       (flag: string) => flag === "billing-entitlements-ui"

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -46,12 +46,14 @@ import { useConvexAuth } from "convex/react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { MCPIcon } from "@/components/ui/mcp-icon";
-import { SidebarUser } from "@/components/sidebar/sidebar-user";
+import {
+  SidebarUser,
+  type SidebarSignOut,
+} from "@/components/sidebar/sidebar-user";
 import { SidebarContextSwitcher } from "@/components/sidebar/sidebar-context-switcher";
 import { SidebarCreditUsage } from "@/components/sidebar/sidebar-credit-usage";
 import { ShareProjectDialog } from "@/components/project/ShareProjectDialog";
 import { useUpdateNotification } from "@/hooks/useUpdateNotification";
-import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
 import {
   Tooltip,
@@ -101,7 +103,7 @@ interface NavSection {
  */
 export function filterByFeatureFlags(
   sections: NavSection[],
-  flags: Record<string, boolean>,
+  flags: Record<string, boolean>
 ): NavSection[] {
   return sections
     .map((section) => ({
@@ -129,7 +131,7 @@ export function applyBillingGateNavState(
     /** When true, feature is denied by premiumness (locked). */
     gateDenied: Partial<Record<BillingFeatureName, boolean>>;
     enforcementActive: boolean;
-  },
+  }
 ): NavSection[] {
   const { billingUiEnabled, gateDenied, enforcementActive } = options;
   if (!billingUiEnabled || !enforcementActive) {
@@ -290,14 +292,14 @@ const navigationSections: NavSection[] = [
 ];
 
 export function getHostedNavigationSections(
-  sections: NavSection[],
+  sections: NavSection[]
 ): NavSection[] {
   return sections
     .map((section) => ({
       ...section,
       items: section.items.flatMap((item) => {
         const normalizedTab = normalizeHostedHashTab(
-          item.url.startsWith("#") ? item.url.slice(1) : item.url,
+          item.url.startsWith("#") ? item.url.slice(1) : item.url
         );
 
         if (isHostedSidebarTabAllowed(normalizedTab)) {
@@ -338,13 +340,11 @@ interface MCPSidebarProps extends React.ComponentProps<typeof Sidebar> {
   activeOrganizationName?: string;
   onSwitchOrganization?: (
     organizationId: string,
-    section?: OrganizationRouteSection,
+    section?: OrganizationRouteSection
   ) => void;
   onSwitchActiveOrganization?: (organizationId: string) => void;
-  onProjectShared?: (
-    sharedProjectId: string,
-    sourceProjectId?: string,
-  ) => void;
+  onSignOut?: SidebarSignOut;
+  onProjectShared?: (sharedProjectId: string, sourceProjectId?: string) => void;
   billingGateDenied?: Partial<Record<BillingFeatureName, boolean>>;
   billingGateEnforcementActive?: boolean;
   billingUiEnabled?: boolean;
@@ -431,8 +431,8 @@ export function SidebarEvalsNavGroup({
         disabled || isPlaygroundLocked
           ? "cursor-not-allowed text-muted-foreground opacity-50 hover:bg-transparent hover:text-muted-foreground active:bg-transparent active:text-muted-foreground"
           : isEvalsFamily
-            ? "[&[data-active=true]]:bg-accent cursor-pointer"
-            : "cursor-pointer"
+          ? "[&[data-active=true]]:bg-accent cursor-pointer"
+          : "cursor-pointer"
       }
     >
       <Icon className="h-4 w-4" />
@@ -486,7 +486,7 @@ export function SidebarEvalsNavGroup({
                         "cursor-not-allowed text-muted-foreground opacity-50 hover:bg-transparent hover:text-muted-foreground active:bg-transparent active:text-muted-foreground",
                       isItemPlaygroundLocked &&
                         "aria-disabled:pointer-events-auto",
-                      disabled && "pointer-events-none",
+                      disabled && "pointer-events-none"
                     )}
                   >
                     <ItemIcon className="h-4 w-4" />
@@ -530,6 +530,7 @@ export function MCPSidebar({
   activeOrganizationName,
   onSwitchOrganization,
   onSwitchActiveOrganization,
+  onSignOut,
   onProjectShared,
   billingGateDenied = {},
   billingGateEnforcementActive = false,
@@ -563,9 +564,8 @@ export function MCPSidebar({
 
     return Object.fromEntries(
       Object.entries(projects).filter(
-        ([, project]) =>
-          project.organizationId === activeProject.organizationId,
-      ),
+        ([, project]) => project.organizationId === activeProject.organizationId
+      )
     );
   }, [activeProject?.organizationId, projects]);
   const shouldShowInviteCta = isAuthenticated && !!user && !!activeProject;
@@ -597,11 +597,11 @@ export function MCPSidebar({
       conformanceEnabled,
       xaaEnabled,
       isAuthenticated,
-    ],
+    ]
   );
   const visibleNavigationSections = filterByFeatureFlags(
     HOSTED_MODE ? hostedNavigationSections : navigationSections,
-    featureFlags,
+    featureFlags
   );
 
   return (
@@ -611,7 +611,7 @@ export function MCPSidebar({
           <div
             className={cn(
               "no-drag",
-              state === "collapsed" && !isMobile && "flex justify-center px-0",
+              state === "collapsed" && !isMobile && "flex justify-center px-0"
             )}
           >
             {isMobile ? (
@@ -639,7 +639,7 @@ export function MCPSidebar({
                     "relative z-0 flex w-full cursor-pointer items-center justify-center py-3 transition-opacity duration-200",
                     /* Reserve space for the collapse control so the logo stays visually centered and
                        clicks on the logo never compete with the invisible hit target. */
-                    "px-2 pr-10 hover:opacity-80",
+                    "px-2 pr-10 hover:opacity-80"
                   )}
                 >
                   <img
@@ -661,7 +661,7 @@ export function MCPSidebar({
                     "pointer-events-auto opacity-0 transition-opacity duration-200",
                     /* Named group avoids ambiguous group-hover when SidebarProvider also uses group/sidebar-wrapper */
                     "group-hover/sidebar-rail:opacity-100 focus-visible:opacity-100",
-                    "[@media(hover:none)]:opacity-100",
+                    "[@media(hover:none)]:opacity-100"
                   )}
                   aria-label="Collapse sidebar"
                 />
@@ -758,10 +758,8 @@ export function MCPSidebar({
               </SidebarMenuItem>
             </SidebarMenu>
           ) : null}
-          {!user ? (
-            <SidebarCreditUsage className="px-1" includeGuests />
-          ) : null}
-          <SidebarUser />
+          {!user ? <SidebarCreditUsage className="px-1" includeGuests /> : null}
+          <SidebarUser onSignOut={onSignOut} />
         </SidebarFooter>
       </Sidebar>
       {shouldShowInviteCta && user && activeProject ? (

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
@@ -8,7 +8,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@mcpjam/design-system/dropdown-menu";
-import { Avatar, AvatarFallback, AvatarImage } from "@mcpjam/design-system/avatar";
+import {
+  Avatar,
+  AvatarFallback,
+  AvatarImage,
+} from "@mcpjam/design-system/avatar";
 import {
   SidebarMenu,
   SidebarMenuButton,
@@ -29,7 +33,25 @@ import { useProfilePicture } from "@/hooks/useProfilePicture";
 import { HOSTED_MODE } from "@/lib/config";
 import { SidebarCreditUsage } from "@/components/sidebar/sidebar-credit-usage";
 
-export function SidebarUser() {
+export type SidebarSignOutOptions =
+  | {
+      returnTo?: string;
+      navigate?: true;
+    }
+  | {
+      returnTo?: string;
+      navigate: false;
+    };
+
+export type SidebarSignOut = (
+  options?: SidebarSignOutOptions
+) => void | Promise<void>;
+
+interface SidebarUserProps {
+  onSignOut?: SidebarSignOut;
+}
+
+export function SidebarUser({ onSignOut }: SidebarUserProps = {}) {
   const { isLoading, isAuthenticated: _isAuthenticated } = useConvexAuth();
   const { user, signIn, signOut } = useAuth();
   const { profilePictureUrl } = useProfilePicture();
@@ -49,6 +71,10 @@ export function SidebarUser() {
       isElectron && import.meta.env.DEV
         ? "http://localhost:8080/callback"
         : window.location.origin;
+    if (onSignOut) {
+      void onSignOut({ returnTo });
+      return;
+    }
     signOut({ returnTo });
   };
 
@@ -139,9 +165,7 @@ export function SidebarUser() {
                   </AvatarFallback>
                 </Avatar>
                 <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-semibold">
-                    {displayName}
-                  </span>
+                  <span className="truncate font-semibold">{displayName}</span>
                   <span className="truncate text-xs text-muted-foreground">
                     {email}
                   </span>

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.test.tsx
@@ -101,7 +101,7 @@ function createServer(
     | "connecting"
     | "oauth-flow"
     | "disconnected"
-    | "failed" = "connected",
+    | "failed" = "connected"
 ) {
   return {
     name,
@@ -146,11 +146,43 @@ function createLoadedAppState(selectedServerState?: {
     servers: {
       [selectedServerState.name]: createServer(
         selectedServerState.name,
-        selectedServerState.connectionStatus,
+        selectedServerState.connectionStatus
       ),
     },
     selectedServer: selectedServerState.name,
   };
+}
+
+function createProject(
+  id: string,
+  options: {
+    organizationId?: string;
+    servers?: Record<string, ReturnType<typeof createServer>>;
+    isDefault?: boolean;
+  } = {}
+) {
+  return {
+    ...initialAppState.projects.default,
+    id,
+    name: id,
+    organizationId: options.organizationId,
+    servers: options.servers ?? {},
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    isDefault: options.isDefault ?? false,
+  };
+}
+
+function renderDefaultUseAppState() {
+  return renderHook(() =>
+    useAppState({
+      currentUserId: "user-1",
+      routeOrganizationId: undefined,
+      hasOrganizations: false,
+      isLoadingOrganizations: false,
+      validOrganizations: [],
+    })
+  );
 }
 
 describe("useAppState active organization recovery", () => {
@@ -184,7 +216,7 @@ describe("useAppState active organization recovery", () => {
           { _id: "org-member", myRole: "member" },
           { _id: "org-owned", myRole: "owner" },
         ],
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -195,10 +227,10 @@ describe("useAppState active organization recovery", () => {
       expect.objectContaining({
         activeOrganizationId: "org-owned",
         validOrganizationIds: ["org-member", "org-owned"],
-      }),
+      })
     );
     expect(localStorage.getItem("active-organization-id:user-1")).toBe(
-      "org-owned",
+      "org-owned"
     );
   });
 
@@ -215,14 +247,14 @@ describe("useAppState active organization recovery", () => {
           { _id: "org-owned", myRole: "owner" },
           { _id: "org-stored", myRole: "member" },
         ],
-      }),
+      })
     );
 
     expect(useProjectStateMock).toHaveBeenCalled();
     expect(useProjectStateMock.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         activeOrganizationId: undefined,
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -243,7 +275,7 @@ describe("useAppState active organization recovery", () => {
           { _id: "org-a", myRole: "owner" },
           { _id: "org-b", myRole: "member" },
         ],
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -263,7 +295,7 @@ describe("useAppState active organization recovery", () => {
         hasOrganizations: false,
         isLoadingOrganizations: false,
         validOrganizations: [],
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -274,7 +306,7 @@ describe("useAppState active organization recovery", () => {
       expect.objectContaining({
         activeOrganizationId: undefined,
         validOrganizationIds: [],
-      }),
+      })
     );
     expect(localStorage.getItem("active-organization-id:user-1")).toBeNull();
   });
@@ -284,7 +316,7 @@ describe("useAppState active organization recovery", () => {
       buildDisconnectedRuntimeServers({
         champions: createServer("champions"),
         linear: createServer("linear", "disconnected"),
-      }),
+      })
     ).toEqual({
       champions: expect.objectContaining({
         name: "champions",
@@ -297,12 +329,114 @@ describe("useAppState active organization recovery", () => {
     });
   });
 
+  it("disconnects previous runtime servers when the active project changes", async () => {
+    const zombieServer = createServer("zombie-server", "connected");
+    const nextServer = createServer("next-server", "disconnected");
+    const projectA = createProject("p1", {
+      organizationId: "org-a",
+      servers: { "zombie-server": zombieServer },
+      isDefault: true,
+    });
+    const projectB = createProject("p2", {
+      organizationId: "org-b",
+      servers: { "next-server": nextServer },
+    });
+
+    loadAppStateMock.mockReturnValue({
+      ...initialAppState,
+      projects: { p1: projectA, p2: projectB },
+      activeProjectId: "p1",
+      servers: { "zombie-server": zombieServer },
+      selectedServer: "zombie-server",
+    });
+    Object.assign(projectStateValue, {
+      effectiveProjects: { p1: projectA, p2: projectB },
+      effectiveActiveProjectId: "p1",
+      useLocalFallback: true,
+    });
+
+    const { result } = renderDefaultUseAppState();
+
+    expect(serverStateValue.handleDisconnect).not.toHaveBeenCalled();
+
+    act(() => {
+      Object.assign(projectStateValue, {
+        effectiveProjects: { p2: projectB },
+        effectiveActiveProjectId: "p2",
+      });
+      result.current.clearLocalFallbackProjectSelection("org-a", "org-b");
+    });
+
+    await waitFor(() => {
+      expect(serverStateValue.handleDisconnect).toHaveBeenCalledWith(
+        "zombie-server"
+      );
+    });
+  });
+
+  it("does not disconnect servers when the active project id is unchanged", () => {
+    const connectedServer = createServer("steady-server", "connected");
+    const project = createProject("p1", {
+      servers: { "steady-server": connectedServer },
+      isDefault: true,
+    });
+
+    loadAppStateMock.mockReturnValue({
+      ...initialAppState,
+      projects: { p1: project },
+      activeProjectId: "p1",
+      servers: { "steady-server": connectedServer },
+      selectedServer: "steady-server",
+    });
+    Object.assign(projectStateValue, {
+      effectiveProjects: { p1: project },
+      effectiveActiveProjectId: "p1",
+      useLocalFallback: true,
+    });
+
+    const { rerender } = renderDefaultUseAppState();
+    rerender();
+
+    expect(serverStateValue.handleDisconnect).not.toHaveBeenCalled();
+  });
+
+  it("does not disconnect when the initial empty project selection resolves", () => {
+    const connectedServer = createServer("loading-server", "connected");
+    const project = createProject("p1", {
+      servers: { "loading-server": connectedServer },
+      isDefault: true,
+    });
+
+    loadAppStateMock.mockReturnValue({
+      ...initialAppState,
+      projects: { p1: project },
+      activeProjectId: "p1",
+      servers: { "loading-server": connectedServer },
+      selectedServer: "loading-server",
+    });
+    Object.assign(projectStateValue, {
+      effectiveProjects: {},
+      effectiveActiveProjectId: "none",
+      useLocalFallback: true,
+    });
+
+    const { rerender } = renderDefaultUseAppState();
+
+    Object.assign(projectStateValue, {
+      effectiveProjects: { p1: project },
+      effectiveActiveProjectId: "p1",
+    });
+    rerender();
+
+    expect(serverStateValue.handleDisconnect).not.toHaveBeenCalled();
+  });
+
   it("keeps the syncing flag on while a runtime-only selected server is still awaiting cloud echo", async () => {
     loadAppStateMock.mockReturnValue(
       createLoadedAppState({
         name: "pending-server",
         connectionStatus: "connected",
-      }),
+      })
     );
     Object.assign(projectStateValue, {
       effectiveProjects: {
@@ -329,7 +463,7 @@ describe("useAppState active organization recovery", () => {
         hasOrganizations: false,
         isLoadingOrganizations: false,
         validOrganizations: [],
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -384,7 +518,7 @@ describe("useAppState active organization recovery", () => {
         hasOrganizations: false,
         isLoadingOrganizations: false,
         validOrganizations: [],
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -399,7 +533,7 @@ describe("useAppState active organization recovery", () => {
         createLoadedAppState({
           name: "demo-server",
           connectionStatus: "disconnected",
-        }),
+        })
       );
       localStorage.setItem(
         "mcp-hosted-oauth-pending",
@@ -409,7 +543,7 @@ describe("useAppState active organization recovery", () => {
           serverUrl: "https://example.com/mcp",
           returnHash: "#demo",
           startedAt: Date.now(),
-        }),
+        })
       );
       localStorage.setItem("mcp-oauth-pending", "demo-server");
       window.history.replaceState({}, "", "/oauth/callback?code=test-code");
@@ -421,18 +555,16 @@ describe("useAppState active organization recovery", () => {
           hasOrganizations: false,
           isLoadingOrganizations: false,
           validOrganizations: [],
-        }),
+        })
       );
 
       await waitFor(() => {
-        const lastProjectArgs =
-          useProjectStateMock.mock.calls.at(-1)?.[0];
+        const lastProjectArgs = useProjectStateMock.mock.calls.at(-1)?.[0];
         expect(
-          lastProjectArgs?.appState.servers["demo-server"]
-            ?.connectionStatus,
+          lastProjectArgs?.appState.servers["demo-server"]?.connectionStatus
         ).toBe("disconnected");
       });
-    },
+    }
   );
 
   it("tracks missing dashboard OAuth callbacks without seeding a temporary server", async () => {
@@ -449,7 +581,10 @@ describe("useAppState active organization recovery", () => {
       servers: {},
     });
     localStorage.setItem("mcp-oauth-pending", "demo-server");
-    localStorage.setItem("mcp-serverUrl-demo-server", "https://example.com/mcp");
+    localStorage.setItem(
+      "mcp-serverUrl-demo-server",
+      "https://example.com/mcp"
+    );
     window.history.replaceState({}, "", "/oauth/callback?code=test-code");
 
     const { result } = renderHook(() =>
@@ -459,7 +594,7 @@ describe("useAppState active organization recovery", () => {
         hasOrganizations: false,
         isLoadingOrganizations: false,
         validOrganizations: [],
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -467,7 +602,7 @@ describe("useAppState active organization recovery", () => {
         expect.objectContaining({
           serverName: "demo-server",
           serverUrl: "https://example.com/mcp",
-        }),
+        })
       );
     });
 
@@ -494,7 +629,7 @@ describe("useAppState active organization recovery", () => {
       localStorage.setItem("mcp-oauth-pending", "demo-server");
       localStorage.setItem(
         "mcp-serverUrl-demo-server",
-        "https://example.com/mcp",
+        "https://example.com/mcp"
       );
       window.history.replaceState({}, "", "/oauth/callback?code=test-code");
 
@@ -505,14 +640,14 @@ describe("useAppState active organization recovery", () => {
           hasOrganizations: false,
           isLoadingOrganizations: false,
           validOrganizations: [],
-        }),
+        })
       );
 
       expect(result.current.pendingDashboardOAuth).toEqual(
         expect.objectContaining({
           serverName: "demo-server",
           serverUrl: "https://example.com/mcp",
-        }),
+        })
       );
 
       act(() => {
@@ -524,5 +659,4 @@ describe("useAppState active organization recovery", () => {
       vi.useRealTimers();
     }
   });
-
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.test.tsx
@@ -331,10 +331,21 @@ describe("useAppState active organization recovery", () => {
 
   it("disconnects previous runtime servers when the active project changes", async () => {
     const zombieServer = createServer("zombie-server", "connected");
+    const connectingServer = createServer("connecting-server", "connecting");
+    const oauthServer = createServer("oauth-server", "oauth-flow");
+    const disconnectedServer = createServer(
+      "disconnected-server",
+      "disconnected"
+    );
     const nextServer = createServer("next-server", "disconnected");
     const projectA = createProject("p1", {
       organizationId: "org-a",
-      servers: { "zombie-server": zombieServer },
+      servers: {
+        "zombie-server": zombieServer,
+        "connecting-server": connectingServer,
+        "oauth-server": oauthServer,
+        "disconnected-server": disconnectedServer,
+      },
       isDefault: true,
     });
     const projectB = createProject("p2", {
@@ -346,7 +357,12 @@ describe("useAppState active organization recovery", () => {
       ...initialAppState,
       projects: { p1: projectA, p2: projectB },
       activeProjectId: "p1",
-      servers: { "zombie-server": zombieServer },
+      servers: {
+        "zombie-server": zombieServer,
+        "connecting-server": connectingServer,
+        "oauth-server": oauthServer,
+        "disconnected-server": disconnectedServer,
+      },
       selectedServer: "zombie-server",
     });
     Object.assign(projectStateValue, {
@@ -371,7 +387,16 @@ describe("useAppState active organization recovery", () => {
       expect(serverStateValue.handleDisconnect).toHaveBeenCalledWith(
         "zombie-server"
       );
+      expect(serverStateValue.handleDisconnect).toHaveBeenCalledWith(
+        "connecting-server"
+      );
+      expect(serverStateValue.handleDisconnect).toHaveBeenCalledWith(
+        "oauth-server"
+      );
     });
+    expect(serverStateValue.handleDisconnect).not.toHaveBeenCalledWith(
+      "disconnected-server"
+    );
   });
 
   it("does not disconnect servers when the active project id is unchanged", () => {

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -495,6 +495,38 @@ export function useAppState({
   } = projectState;
   const { handleDisconnect } = serverState;
 
+  const previousActiveProjectIdRef = useRef(effectiveActiveProjectId);
+  const previousServersRef = useRef(appState.servers);
+
+  useEffect(() => {
+    const previousActiveProjectId = previousActiveProjectIdRef.current;
+    previousActiveProjectIdRef.current = effectiveActiveProjectId;
+
+    if (
+      previousActiveProjectId === effectiveActiveProjectId ||
+      previousActiveProjectId === "none"
+    ) {
+      return;
+    }
+
+    for (const [serverName, server] of Object.entries(
+      previousServersRef.current
+    )) {
+      if (server.connectionStatus === "connected") {
+        logger.info("Disconnecting server on project change", {
+          serverName,
+          from: previousActiveProjectId,
+          to: effectiveActiveProjectId,
+        });
+        void handleDisconnect(serverName);
+      }
+    }
+  }, [effectiveActiveProjectId, handleDisconnect, logger]);
+
+  useEffect(() => {
+    previousServersRef.current = appState.servers;
+  }, [appState.servers]);
+
   const handleSwitchProject = useCallback(
     async (projectId: string) => {
       const newProject = effectiveProjects[projectId];

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -512,7 +512,7 @@ export function useAppState({
     for (const [serverName, server] of Object.entries(
       previousServersRef.current
     )) {
-      if (server.connectionStatus === "connected") {
+      if (server.connectionStatus !== "disconnected") {
         logger.info("Disconnecting server on project change", {
           serverName,
           from: previousActiveProjectId,
@@ -543,7 +543,7 @@ export function useAppState({
       const currentServers = Object.keys(appState.servers);
       for (const serverName of currentServers) {
         const server = appState.servers[serverName];
-        if (server.connectionStatus === "connected") {
+        if (server.connectionStatus !== "disconnected") {
           logger.info("Disconnecting server before project switch", {
             serverName,
           });
@@ -594,7 +594,10 @@ export function useAppState({
       const projectServers = Object.keys(project.servers || {});
       for (const serverName of projectServers) {
         const runtimeServer = appState.servers[serverName];
-        if (runtimeServer?.connectionStatus === "connected") {
+        if (
+          runtimeServer &&
+          runtimeServer.connectionStatus !== "disconnected"
+        ) {
           await handleDisconnect(serverName);
         }
       }


### PR DESCRIPTION
## What this PR does
- Fixes zombie connections — switching orgs, deleting projects, or signing out used to leave MCP server connections alive in the background. Now they're cleanly closed.
- Sign-out actually disconnects first — before, the page would redirect away before the "close this connection" message had time to leave the browser, so the server never knew. Now we wait for it to send.
- Both sign-out buttons fixed — sidebar dropdown and hosted shell logout share one handler.
- Lands on Servers tab after switching — no more being stranded on App Builder/Chat with a connection that no longer exists.