### PR TITLE
fix: actually disable PostHog capture in dev mode

### DIFF
--- a/mcpjam-inspector/client/src/lib/PosthogUtils.ts
+++ b/mcpjam-inspector/client/src/lib/PosthogUtils.ts
@@ -30,8 +30,11 @@ export const getPostHogOptions = () =>
         api_host: VITE_PUBLIC_POSTHOG_HOST,
         capture_pageview: false,
         person_profiles: "always" as const,
-        // Disable event capture but keep /decide enabled for feature flag evaluation
-        opt_out_capturing: true,
+        // Disable event capture but keep /decide enabled for feature flag evaluation.
+        // Must be `opt_out_capturing_by_default` — `opt_out_capturing` is a method,
+        // not a config field, so passing it here was silently ignored and dev
+        // events flowed into prod PostHog from 2026-03-12 until this fix.
+        opt_out_capturing_by_default: true,
       }
     : options;
 

--- a/mcpjam-inspector/client/src/lib/__tests__/posthog-utils.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/posthog-utils.test.ts
@@ -1,9 +1,14 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { options } from "../PosthogUtils";
 
 describe("PosthogUtils", () => {
   beforeEach(() => {
     vi.stubGlobal("__APP_VERSION__", "2.0.13-test");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
   });
 
   it("registers static telemetry properties on PostHog load", () => {
@@ -18,5 +23,28 @@ describe("PosthogUtils", () => {
       platform: expect.any(String),
       version: "2.0.13-test",
     });
+  });
+
+  it("opts capture out by default when VITE_DISABLE_POSTHOG_LOCAL is set", async () => {
+    vi.stubEnv("VITE_DISABLE_POSTHOG_LOCAL", "true");
+    vi.resetModules();
+    const { getPostHogOptions } = await import("../PosthogUtils");
+
+    const opts = getPostHogOptions() as Record<string, unknown>;
+
+    expect(opts.opt_out_capturing_by_default).toBe(true);
+    // Guard against re-introducing the typo: `opt_out_capturing` is a method
+    // on PostHog instances, not a valid init config field.
+    expect(opts).not.toHaveProperty("opt_out_capturing");
+  });
+
+  it("does not opt out when the disable flag is unset", async () => {
+    vi.stubEnv("VITE_DISABLE_POSTHOG_LOCAL", "false");
+    vi.resetModules();
+    const { getPostHogOptions } = await import("../PosthogUtils");
+
+    const opts = getPostHogOptions() as Record<string, unknown>;
+
+    expect(opts.opt_out_capturing_by_default).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

`opt_out_capturing: true` was passed as a PostHog init config field — but that's the name of a runtime method, not a config key. The valid field is `opt_out_capturing_by_default`. Since 2026-03-12 (commit bd5d23e7a "fix ff llogic"), PostHog initialized with the real prod key + host and silently dropped the typo'd field, so every dev's `vite dev` session has been firing events into the prod project.

This fix restores the original intent: when `VITE_DISABLE_POSTHOG_LOCAL=true`, capture is opted out at init while `/decide` stays enabled for feature flag evaluation.

## Why this surfaced now

The PostHog "Unique DAU (App Launched)" insight (`Ds5kf7I8`) showed a 3× spike on the `authenticated` series this week. Investigation traced it to local dev traffic on `localhost:5173` and `127.0.0.1:6274` flowing into the prod project. The `authenticated` series filters on `is_authenticated = true`, which guests now satisfy after #2003 ("Guest sessions"); combined with the broken opt-out, every dev guest reload landed in the cohort.

The chart's host filter is also being tightened separately so future regressions of this kind don't silently inflate the numbers.

## Test plan

- [x] `npx vitest run client/src/lib/__tests__/posthog-utils.test.ts` — 3 tests pass.
- [ ] After merge, expect a step-down in PostHog DAU numbers as local dev stops being counted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small config key fix plus unit tests; behavior change is limited to local/dev telemetry capture when `VITE_DISABLE_POSTHOG_LOCAL=true`.
> 
> **Overview**
> Fixes local/dev PostHog initialization by replacing the incorrect `opt_out_capturing` init field with the valid `opt_out_capturing_by_default`, ensuring dev sessions don’t emit events while `/decide` remains usable for feature flags.
> 
> Adds Vitest coverage to assert opt-out behavior when `VITE_DISABLE_POSTHOG_LOCAL` is set/unset, plus cleanup to reset env/module state and a guard to prevent reintroducing the invalid config key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e22d72e2be76e6cde3e30cd75a344a9c492aaa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->