### PR TITLE
[Solo Plan Member Limit] PR-I1: disable Solo upgrade for multi-member orgs

### DIFF
--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -1156,6 +1156,7 @@ function OrganizationPage({
               isStartingPlanChange={isStartingPlanChange}
               pendingPlanChangeTarget={pendingPlanChangeTarget}
               isOpeningPortal={isOpeningPortal}
+              activeMemberCount={activeMembers.length}
               onDowngradePlan={handleDowngradePlan}
               onStartPlanChange={handlePlanChange}
               onStartAutoPlanChange={handleAutoPlanChange}

--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -1156,7 +1156,9 @@ function OrganizationPage({
               isStartingPlanChange={isStartingPlanChange}
               pendingPlanChangeTarget={pendingPlanChangeTarget}
               isOpeningPortal={isOpeningPortal}
-              activeMemberCount={activeMembers.length}
+              activeMemberCount={
+                membersLoading ? undefined : activeMembers.length
+              }
               onDowngradePlan={handleDowngradePlan}
               onStartPlanChange={handlePlanChange}
               onStartAutoPlanChange={handleAutoPlanChange}

--- a/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
@@ -60,6 +60,9 @@ function getPlanRank(plan: OrganizationPlan): number {
   return PLAN_ORDER.indexOf(plan);
 }
 
+const SOLO_PLAN_MEMBER_LIMIT_TOOLTIP =
+  "Solo plan is only available to organizations with 1 member.";
+
 function getPlanColumnCta(params: {
   plan: OrganizationPlan;
   currentPlan: OrganizationPlan;
@@ -67,6 +70,7 @@ function getPlanColumnCta(params: {
   billingConfigured: boolean;
   canManageBilling: boolean;
   isBillingActionPending: boolean;
+  activeMemberCount: number;
   onDowngradePlan: (
     plan: OrganizationPlan,
     billingInterval: BillingInterval,
@@ -81,6 +85,7 @@ function getPlanColumnCta(params: {
   disabled: boolean;
   variant: "default" | "outline" | "secondary";
   onClick?: () => void;
+  tooltip?: string;
 } {
   const {
     plan,
@@ -89,6 +94,7 @@ function getPlanColumnCta(params: {
     billingConfigured,
     canManageBilling,
     isBillingActionPending,
+    activeMemberCount,
     onDowngradePlan,
     onStartPlanChange,
     billingInterval,
@@ -98,6 +104,8 @@ function getPlanColumnCta(params: {
   const isHigherTier = getPlanRank(plan) > getPlanRank(currentPlan);
   const isDowngrade = getPlanRank(plan) < getPlanRank(currentPlan);
   const isEnterprisePlan = plan === "enterprise";
+  const soloBlockedByMemberCount =
+    plan === "solo" && activeMemberCount > 1;
 
   if (isCurrentPlan) {
     return { label: "Current plan", disabled: true, variant: "outline" };
@@ -116,6 +124,14 @@ function getPlanColumnCta(params: {
   }
 
   if (isDowngrade) {
+    if (soloBlockedByMemberCount) {
+      return {
+        label: "Downgrade",
+        disabled: true,
+        variant: "outline",
+        tooltip: SOLO_PLAN_MEMBER_LIMIT_TOOLTIP,
+      };
+    }
     return {
       label: "Downgrade",
       disabled:
@@ -128,6 +144,14 @@ function getPlanColumnCta(params: {
   if (isHigherTier && entry.isSelfServe) {
     if (plan !== "solo" && plan !== "team") {
       return { label: "Unavailable", disabled: true, variant: "outline" };
+    }
+    if (soloBlockedByMemberCount) {
+      return {
+        label: "Upgrade",
+        disabled: true,
+        variant: "outline",
+        tooltip: SOLO_PLAN_MEMBER_LIMIT_TOOLTIP,
+      };
     }
     return {
       label: "Upgrade",
@@ -457,6 +481,7 @@ interface OrganizationBillingSectionProps {
   isStartingPlanChange: boolean;
   pendingPlanChangeTarget: "solo" | "team" | null;
   isOpeningPortal: boolean;
+  activeMemberCount: number;
   onDowngradePlan: (
     plan: OrganizationPlan,
     billingInterval: BillingInterval,
@@ -482,6 +507,7 @@ export function OrganizationBillingSection({
   isStartingPlanChange,
   pendingPlanChangeTarget,
   isOpeningPortal,
+  activeMemberCount,
   onDowngradePlan,
   onStartPlanChange,
   onStartAutoPlanChange,
@@ -837,6 +863,7 @@ export function OrganizationBillingSection({
                           billingConfigured,
                           canManageBilling,
                           isBillingActionPending,
+                          activeMemberCount,
                           onDowngradePlan: (
                             targetPlan,
                             targetBillingInterval,
@@ -888,22 +915,53 @@ export function OrganizationBillingSection({
                                   ) : null}
                                 </div>
                               </div>
-                              <Button
-                                className="w-full shrink-0 rounded-lg"
-                                size="sm"
-                                variant={cta.variant}
-                                disabled={cta.disabled}
-                                onClick={cta.onClick}
-                              >
-                                {showCtaSpinner ? (
-                                  <>
-                                    <Loader2 className="size-4 animate-spin" />
-                                    Loading...
-                                  </>
-                                ) : (
-                                  cta.label
-                                )}
-                              </Button>
+                              {cta.tooltip ? (
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <span className="w-full shrink-0">
+                                      <Button
+                                        className="w-full rounded-lg"
+                                        size="sm"
+                                        variant={cta.variant}
+                                        disabled={cta.disabled}
+                                        onClick={cta.onClick}
+                                      >
+                                        {showCtaSpinner ? (
+                                          <>
+                                            <Loader2 className="size-4 animate-spin" />
+                                            Loading...
+                                          </>
+                                        ) : (
+                                          cta.label
+                                        )}
+                                      </Button>
+                                    </span>
+                                  </TooltipTrigger>
+                                  <TooltipContent
+                                    side="top"
+                                    className="max-w-[14rem] text-center"
+                                  >
+                                    {cta.tooltip}
+                                  </TooltipContent>
+                                </Tooltip>
+                              ) : (
+                                <Button
+                                  className="w-full shrink-0 rounded-lg"
+                                  size="sm"
+                                  variant={cta.variant}
+                                  disabled={cta.disabled}
+                                  onClick={cta.onClick}
+                                >
+                                  {showCtaSpinner ? (
+                                    <>
+                                      <Loader2 className="size-4 animate-spin" />
+                                      Loading...
+                                    </>
+                                  ) : (
+                                    cta.label
+                                  )}
+                                </Button>
+                              )}
                             </div>
                           </TableHead>
                         );

--- a/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
@@ -70,7 +70,7 @@ function getPlanColumnCta(params: {
   billingConfigured: boolean;
   canManageBilling: boolean;
   isBillingActionPending: boolean;
-  activeMemberCount: number;
+  activeMemberCount: number | undefined;
   onDowngradePlan: (
     plan: OrganizationPlan,
     billingInterval: BillingInterval,
@@ -104,8 +104,12 @@ function getPlanColumnCta(params: {
   const isHigherTier = getPlanRank(plan) > getPlanRank(currentPlan);
   const isDowngrade = getPlanRank(plan) < getPlanRank(currentPlan);
   const isEnterprisePlan = plan === "enterprise";
+  // While member count is still loading, conservatively block Solo for non-current
+  // plans so a multi-member org can't briefly see an enabled Solo CTA before the
+  // count resolves.
   const soloBlockedByMemberCount =
-    plan === "solo" && activeMemberCount > 1;
+    plan === "solo" &&
+    (activeMemberCount === undefined || activeMemberCount > 1);
 
   if (isCurrentPlan) {
     return { label: "Current plan", disabled: true, variant: "outline" };
@@ -481,7 +485,7 @@ interface OrganizationBillingSectionProps {
   isStartingPlanChange: boolean;
   pendingPlanChangeTarget: "solo" | "team" | null;
   isOpeningPortal: boolean;
-  activeMemberCount: number;
+  activeMemberCount: number | undefined;
   onDowngradePlan: (
     plan: OrganizationPlan,
     billingInterval: BillingInterval,


### PR DESCRIPTION
## Summary

- Solo plan is intended for single-member organizations. Today, multi-member orgs can still click *Upgrade* on the Solo column of the billing matrix, which produces a confusing failure later in checkout.
- This PR greys out the Solo column's CTA (both **Upgrade** and **Downgrade** paths) on the org billing page when the org has more than one active member, and shows a tooltip on hover: *"Solo plan is only available to organizations with 1 member."*
- Existing solo subscribers are unaffected — the **Current plan** label short-circuits the new disable logic before it runs.

## Test plan

- [ ] Org with 1 active member: Solo column shows enabled **Upgrade** button (existing behavior).
- [ ] Org with 2+ active members on Free: Solo column shows greyed **Upgrade** button; tooltip on hover reads *"Solo plan is only available to organizations with 1 member."*
- [ ] Org with 2+ active members on Team: Solo column shows greyed **Downgrade** button + same tooltip.
- [ ] Org currently on Solo (regardless of member count): Solo column shows **Current plan** label as before; no tooltip.
- [ ] Enterprise *Talk to sales* and Free *Current plan* / *Downgrade* CTAs still render normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)