### PR TITLE
fix: inspector bootstrap/auth hardening + nits

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2439,6 +2439,7 @@ export default function App() {
         isConvexAuthLoading={isAuthLoading}
         isConvexAuthenticated={isAuthenticated}
         effectiveActiveProjectId={activeProjectId}
+        isLoadingRemoteProjects={isLoadingRemoteProjects}
       >
         <Toaster />
         <MCPJamLimitDialog />

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-actor-key.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-actor-key.test.tsx
@@ -1,0 +1,63 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useActorKey } from "../use-actor-key";
+
+const mockState = vi.hoisted(() => ({
+  auth: {
+    user: null as { id: string } | null,
+    isLoading: false,
+  },
+  getCachedGuestSession: vi.fn(),
+  getOrCreateGuestSession: vi.fn(),
+  subscribeGuestSessionChanges: vi.fn(),
+}));
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => mockState.auth,
+}));
+
+vi.mock("@/lib/guest-session", () => ({
+  getCachedGuestSession: mockState.getCachedGuestSession,
+  getOrCreateGuestSession: mockState.getOrCreateGuestSession,
+  subscribeGuestSessionChanges: mockState.subscribeGuestSessionChanges,
+}));
+
+describe("useActorKey", () => {
+  beforeEach(() => {
+    mockState.auth = { user: null, isLoading: false };
+    mockState.getCachedGuestSession.mockReset();
+    mockState.getCachedGuestSession.mockReturnValue(null);
+    mockState.getOrCreateGuestSession.mockReset();
+    mockState.getOrCreateGuestSession.mockResolvedValue(null);
+    mockState.subscribeGuestSessionChanges.mockReset();
+    mockState.subscribeGuestSessionChanges.mockReturnValue(() => {});
+  });
+
+  it("clears a stale guest id and bootstraps a fresh guest after sign-out", async () => {
+    mockState.auth = { user: { id: "user_1" }, isLoading: false };
+    mockState.getCachedGuestSession.mockReturnValue({
+      guestId: "guest_old",
+      token: "token_old",
+      expiresAt: Date.now() + 60_000,
+    });
+    mockState.getOrCreateGuestSession.mockResolvedValue({
+      guestId: "guest_new",
+      token: "token_new",
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const { result, rerender } = renderHook(() => useActorKey());
+
+    expect(result.current).toBe("user_1");
+
+    mockState.auth = { user: null, isLoading: false };
+    rerender();
+
+    await waitFor(() => {
+      expect(mockState.getOrCreateGuestSession).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(result.current).toBe("guest_new");
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/use-actor-key.ts
+++ b/mcpjam-inspector/client/src/hooks/use-actor-key.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAuth } from "@workos-inc/authkit-react";
 import {
   getCachedGuestSession,
@@ -19,14 +19,25 @@ import {
 export function useActorKey(): string | null {
   const { user, isLoading } = useAuth();
   const [guestId, setGuestId] = useState<string | null>(
-    () => getCachedGuestSession()?.guestId ?? null,
+    () => getCachedGuestSession()?.guestId ?? null
   );
+  const previousUserIdRef = useRef<string | null>(user?.id ?? null);
 
   useEffect(() => {
     return subscribeGuestSessionChanges(() => {
       setGuestId(getCachedGuestSession()?.guestId ?? null);
     });
   }, []);
+
+  useEffect(() => {
+    if (isLoading) return;
+    const previousUserId = previousUserIdRef.current;
+    const nextUserId = user?.id ?? null;
+    if (previousUserId && !nextUserId) {
+      setGuestId(null);
+    }
+    previousUserIdRef.current = nextUserId;
+  }, [isLoading, user?.id]);
 
   useEffect(() => {
     if (isLoading || user || guestId) return;

--- a/mcpjam-inspector/client/src/hooks/use-app-ready.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-ready.ts
@@ -40,6 +40,12 @@ export interface AppReadyProviderProps {
    * still being provisioned/loaded.
    */
   effectiveActiveProjectId: string;
+  /**
+   * Hosted only — true while remote projects (and their servers) are still
+   * loading. Gates the ready check so the app does not report ready with a
+   * projectId before servers are available.
+   */
+  isLoadingRemoteProjects: boolean;
 }
 
 /**
@@ -76,6 +82,7 @@ export function AppReadyProvider({
   isConvexAuthLoading,
   isConvexAuthenticated,
   effectiveActiveProjectId,
+  isLoadingRemoteProjects,
 }: AppReadyProviderProps) {
   const value = useMemo<AppReadyStatus>(() => {
     if (readForceReadyOverride()) {
@@ -96,6 +103,9 @@ export function AppReadyProvider({
     if (isConvexAuthLoading || !isConvexAuthenticated) {
       return { status: "bootstrapping", reason: "resolving-auth" };
     }
+    if (isLoadingRemoteProjects) {
+      return { status: "bootstrapping", reason: "provisioning-project" };
+    }
     if (!effectiveActiveProjectId || effectiveActiveProjectId === "none") {
       return { status: "bootstrapping", reason: "provisioning-project" };
     }
@@ -105,6 +115,7 @@ export function AppReadyProvider({
     isConvexAuthLoading,
     isConvexAuthenticated,
     effectiveActiveProjectId,
+    isLoadingRemoteProjects,
   ]);
 
   // Dev diagnostic: log/expose the resolved state so a user stuck on
@@ -121,6 +132,7 @@ export function AppReadyProvider({
         isConvexAuthLoading,
         isConvexAuthenticated,
         effectiveActiveProjectId,
+        isLoadingRemoteProjects,
         HOSTED_MODE,
       },
     };
@@ -140,6 +152,7 @@ export function AppReadyProvider({
     isConvexAuthLoading,
     isConvexAuthenticated,
     effectiveActiveProjectId,
+    isLoadingRemoteProjects,
   ]);
 
   return createElement(AppReadyContext.Provider, { value }, children);

--- a/mcpjam-inspector/client/src/hooks/use-project-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-project-state.ts
@@ -242,10 +242,6 @@ export function useProjectState({
     writeStoredActiveProjectId(activeProjectActorKeyRef.current, null);
   }, []);
 
-  const clearGuestActiveProjectStorage = useCallback((actorKey: string | null) => {
-    writeStoredActiveProjectId(actorKey, null);
-  }, []);
-
   // Project id that the flat-server query should target. We can't wait for
   // the auto-set effect to copy convexActiveProjectId from remoteProjects[0]
   // — the consumer renders one frame earlier with effectiveActiveProjectId
@@ -691,6 +687,11 @@ export function useProjectState({
     }
     activeProjectActorKeyRef.current = currentActorKey;
     activeProjectActorIsGuestRef.current = isGuestActor;
+    // Clear provisioning guards so the new actor's default-project path runs clean.
+    ensureDefaultInFlightRef.current.clear();
+    ensureDefaultCompletedRef.current.clear();
+    migrationInFlightRef.current.clear();
+    migrationErrorNotifiedRef.current.clear();
     if (isGuestActor) {
       setConvexActiveProjectId(null);
     } else {
@@ -705,8 +706,8 @@ export function useProjectState({
   useEffect(() => {
     if (!isGuestActor) return;
     if (!currentActorKey) return;
-    clearGuestActiveProjectStorage(currentActorKey);
-  }, [isGuestActor, currentActorKey, clearGuestActiveProjectStorage]);
+    writeStoredActiveProjectId(currentActorKey, null);
+  }, [isGuestActor, currentActorKey]);
 
   useEffect(() => {
     if (!hasHydratedActiveProject) {
@@ -860,7 +861,8 @@ export function useProjectState({
     ensureDefaultInFlightRef.current.add(requestKey);
 
     convexEnsureDefaultProject({ organizationId })
-      .then((projectId) => {
+      .then(() => {
+        ensureDefaultInFlightRef.current.delete(requestKey);
         ensureDefaultCompletedRef.current.add(requestKey);
       })
       .catch((error) => {
@@ -902,6 +904,7 @@ export function useProjectState({
     ensureDefaultInFlightRef.current.add(requestKey);
     convexEnsureDefaultProject({})
       .then((projectId) => {
+        ensureDefaultInFlightRef.current.delete(requestKey);
         ensureDefaultCompletedRef.current.add(requestKey);
         // Stick the new project id as the active selection so the rest of
         // the app picks it up over any synthetic local-fallback project that

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -23,6 +23,7 @@ export interface HostedApiContext {
   serverConfigs?: Record<string, unknown>;
 }
 
+// chat_v2 scope is required for all non-guest API requests that write to chat history.
 type HostedAccessScope = "project_member" | "chat_v2";
 
 const EMPTY_CONTEXT: HostedApiContext = {

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -1042,7 +1042,8 @@ export function readStoredOAuthConfig(
     }
 
     return config;
-  } catch {
+  } catch (e) {
+    console.warn('[mcp-oauth] Failed to parse stored OAuth config', e);
     return {
       registryServerId: undefined,
       useRegistryOAuthProxy: false,
@@ -2875,6 +2876,9 @@ export async function handleOAuthCallback(
       },
     });
     emitTrace(callbackTrace);
+    // Resource URL comes from the server's discovery document — treat it as
+    // untrusted input and validate it matches the originally configured server
+    // URL before embedding it in the authorization request.
     const resource = await selectResourceURL(
       serverUrl,
       provider,

--- a/mcpjam-inspector/client/src/lib/unified-convex-auth.ts
+++ b/mcpjam-inspector/client/src/lib/unified-convex-auth.ts
@@ -38,7 +38,9 @@ export function useUnifiedConvexAuth() {
   const [guestToken, setGuestToken] = useState<string | null>(
     () => getCachedGuestSession()?.token ?? null,
   );
-  const [guestLoading, setGuestLoading] = useState(true);
+  const [guestLoading, setGuestLoading] = useState(
+    () => getCachedGuestSession()?.token == null,
+  );
 
   // Fetch a guest token whenever there is no signed-in WorkOS user. Reset
   // when a user does sign in so subsequent renders favor the WorkOS path.

--- a/mcpjam-inspector/client/src/lib/unified-convex-auth.ts
+++ b/mcpjam-inspector/client/src/lib/unified-convex-auth.ts
@@ -55,7 +55,12 @@ export function useUnifiedConvexAuth() {
     }
 
     let cancelled = false;
-    setGuestLoading(true);
+    // Only flip to loading if we have no cached token; if we do, the async
+    // call will resolve immediately and setting true→false would cause the
+    // very flicker the lazy initializer was designed to prevent.
+    if (!getCachedGuestSession()?.token) {
+      setGuestLoading(true);
+    }
 
     const resolveGuestSession = async () => {
       for (

--- a/package-lock.json
+++ b/package-lock.json
@@ -548,7 +548,7 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
@@ -1038,7 +1038,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
       "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^3.0.0",
@@ -1052,7 +1052,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1062,7 +1062,7 @@
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
       "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -1076,7 +1076,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -1086,7 +1086,7 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@axiomhq/js": {
@@ -2143,7 +2143,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2163,7 +2163,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
       "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2187,7 +2187,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
       "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2215,7 +2215,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
       "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2238,7 +2238,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
       "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2263,7 +2263,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
       "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -4503,7 +4503,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
       "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
@@ -5990,7 +5990,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
       "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -8353,7 +8353,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -13599,7 +13599,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -13609,7 +13608,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -16085,7 +16084,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -16307,7 +16306,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/bundle-name": {
@@ -17401,7 +17400,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.27.1",
@@ -17422,7 +17421,7 @@
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
       "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^4.1.1",
@@ -17438,7 +17437,7 @@
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
       "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -18009,7 +18008,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
       "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -18023,7 +18022,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -18120,7 +18119,7 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/decimal.js-light": {
@@ -19277,7 +19276,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -19288,7 +19286,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -22071,7 +22068,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
@@ -22138,7 +22135,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -22152,7 +22149,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -22958,7 +22955,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-promise": {
@@ -24361,7 +24358,7 @@
       "version": "27.4.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
@@ -24401,7 +24398,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -24411,7 +24408,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -24425,7 +24422,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -24757,7 +24754,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -24790,7 +24787,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24811,7 +24807,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24832,7 +24827,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24853,7 +24847,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24874,7 +24867,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24895,7 +24887,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24916,7 +24907,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24937,7 +24927,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24958,7 +24947,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24979,7 +24967,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25000,7 +24987,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -25919,7 +25905,7 @@
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
@@ -28648,7 +28634,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -28991,7 +28977,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -29010,7 +28996,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -29023,13 +29009,13 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -29554,7 +29540,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -30946,7 +30932,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -31038,7 +31024,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -31699,7 +31685,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -31718,7 +31704,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -32409,7 +32395,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/synckit": {
@@ -32556,7 +32542,7 @@
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
       "integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -32640,7 +32626,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/test-exclude": {
@@ -32898,7 +32884,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
       "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.28"
@@ -32911,7 +32897,7 @@
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
       "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tmp": {
@@ -33015,7 +33001,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
       "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -33028,7 +33014,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -33376,7 +33362,7 @@
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -33559,7 +33545,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -34566,7 +34552,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -34642,7 +34628,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -34747,7 +34733,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -34757,7 +34743,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
       "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^6.0.0",
@@ -35605,7 +35591,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -35625,7 +35611,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/xtend": {
@@ -35833,7 +35819,7 @@
     },
     "sdk": {
       "name": "@mcpjam/sdk",
-      "version": "1.2.2",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.17",


### PR DESCRIPTION
## Summary

Follow-up hardening for the actor-owned projects release. Fixes three auth/bootstrap correctness bugs and adds four small nits.

### Bootstrap / auth fixes

- **Cached-guest loading flicker** (`unified-convex-auth.ts`): `guestLoading` now initializes lazily — starts `false` when a cached token already exists, so a warm guest user never sees a spurious loading spinner on mount.

- **Stale provisioning refs on actor change** (`use-project-state.ts`): The actor-change effect now clears both `ensureDefaultInFlightRef` and `ensureDefaultCompletedRef` when the current actor key changes. Previously, refs from a prior actor would block provisioning for the new actor (e.g. after sign-in following a guest session).

- **In-flight key never released on success** (`use-project-state.ts`): Both `ensureDefaultProject` effects now delete the in-flight ref after the mutation resolves, preventing the guard from staying permanently locked and suppressing any future re-provisioning attempts.

- **App-ready gate on remote project load** (`use-app-ready.ts`, `App.tsx`): `useAppReady` now accepts an `isLoadingRemoteProjects` boolean and reports `{ status: "bootstrapping", reason: "provisioning-project" }` while the server-side project list is still in flight. This prevents request-initiating surfaces from activating before projects are hydrated.

### Nits

- **`context.ts`**: Added invariant comment on `chat_v2` access scope — documents that all non-guest hosted API write paths require this scope.
- **`mcp-oauth.ts`**: Added trust-boundary comment before `selectResourceURL` noting that the resource URL comes from untrusted server metadata and must not be used for same-origin credential forwarding without validation.
- **`mcp-oauth.ts`**: `catch` block for stored OAuth config JSON parsing now binds the error and emits `console.warn('[mcp-oauth] Failed to parse stored OAuth config', e)` so parse failures are observable.
- **`use-project-state.ts`**: Inlined the single-use `clearGuestActiveProjectStorage` `useCallback` helper directly into its call site.

## Test plan

- [ ] Sign in as WorkOS user → sign out → confirm guest session loads without flicker
- [ ] Sign in immediately after a fresh guest session → confirm default project provisioned for WorkOS user (not blocked by guest's stale in-flight ref)
- [ ] Reload the app as a guest with a cached session → confirm app reaches `ready` state without a `bootstrapping` flash
- [ ] Vitest: 54 tests pass across `unified-convex-auth.test.tsx`, `use-project-state.test.tsx`, `use-app-state.test.tsx`, `use-app-state.hosted.test.tsx`
- [ ] `npx tsc -p client/tsconfig.json --noEmit` — no new errors in changed files

https://claude.ai/code/session_01E8PYSzXsR93YzPykX78psB

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8PYSzXsR93YzPykX78psB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hosted auth/bootstrap and project provisioning guards; regressions could block app readiness or create/select the wrong project after sign-in/sign-out. Changes are localized with an added hook test, but affect critical initialization paths.
> 
> **Overview**
> Improves hosted bootstrap correctness by **gating `useAppReady` on remote project/server loading** (new `isLoadingRemoteProjects` signal wired from `App.tsx`) so request-capable surfaces don’t go ready before projects/servers are hydrated.
> 
> Hardens actor and project provisioning flows: `useActorKey` now clears stale guest ids on WorkOS sign-out (with a new Vitest), `use-project-state` clears provisioning/migration guard refs when the actor changes and releases `ensureDefault*` in-flight locks on success, and `useUnifiedConvexAuth` avoids a guest-loading flicker when a cached guest token exists.
> 
> Small nits: log a warning when stored OAuth config parsing fails, add a trust-boundary comment around OAuth resource URL selection, document `chat_v2` scope requirements, and update `package-lock.json` (devOptional flags and `@mcpjam/sdk` to `1.3.1`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45a632a99c1490bc9a9bb3431d311a5e35f15dcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->