### PR TITLE
feat: forward hashed client IP to Convex for guest spend cap

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -14,6 +14,7 @@ import {
   isMCPJamProvidedModel,
 } from "@/shared/types";
 import type { ModelProvider } from "@/shared/types";
+import { getClientIp } from "../../utils/client-ip.js";
 import { getProductionGuestAuthHeader } from "../../utils/guest-auth.js";
 import { logger } from "../../utils/logger";
 import { handleMCPJamFreeChatModel } from "../../utils/mcpjam-stream-handler";
@@ -557,6 +558,7 @@ chatV2.post("/", async (c) => {
         temperature: resolvedTemperature,
         tools: allTools as ToolSet,
         authHeader,
+        clientIp: getClientIp(c),
         mcpClientManager,
         selectedServers,
         requireToolApproval,
@@ -623,6 +625,7 @@ chatV2.post("/", async (c) => {
         temperature: resolvedTemperature,
         tools: allTools as ToolSet,
         authHeader: c.req.header("authorization"),
+        clientIp: getClientIp(c),
         mcpClientManager,
         selectedServers,
         requireToolApproval,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -36,6 +36,7 @@ import {
   createHostedRpcLogCollector,
 } from "./hosted-rpc-logs.js";
 import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
+import { getClientIp } from "../../utils/client-ip.js";
 
 function deriveOrgProviderKey(modelDefinition: ModelDefinition): string {
   const result = deriveOrgProviderKeyResult(modelDefinition);
@@ -224,6 +225,7 @@ chatV2.post("/", async (c) => {
           temperature: resolvedTemperature,
           tools: allTools as ToolSet,
           authHeader: c.req.header("authorization"),
+          clientIp: getClientIp(c),
           mcpClientManager: manager,
           selectedServers,
           requireToolApproval,
@@ -398,6 +400,7 @@ chatV2.post("/", async (c) => {
           temperature: resolvedTemperature,
           tools: allTools as ToolSet,
           authHeader: c.req.header("authorization"),
+          clientIp: getClientIp(c),
           shareToken,
           chatboxToken,
           mcpClientManager: manager,
@@ -477,6 +480,7 @@ chatV2.post("/", async (c) => {
         temperature: resolvedTemperature,
         tools: allTools as ToolSet,
         authHeader: c.req.header("authorization"),
+        clientIp: getClientIp(c),
         chatboxToken,
         projectId: hostedBody.projectId,
         mcpClientManager: manager,

--- a/mcpjam-inspector/server/routes/web/guest-session.ts
+++ b/mcpjam-inspector/server/routes/web/guest-session.ts
@@ -10,6 +10,7 @@ import {
   type GuestSessionRequestBody,
 } from "../../utils/guest-session-source.js";
 import { getClientIp } from "../../utils/client-ip.js";
+import { hashGuestSpendIp } from "../../utils/guest-spend-ip.js";
 import { ErrorCode } from "./errors.js";
 
 const guestSession = new Hono();
@@ -148,10 +149,18 @@ guestSession.post("/", async (c) => {
     body = {};
   }
 
+  // Hash the client IP so Convex can record the IP-bucket key on the
+  // guest's session row. Lets the credit-balance display reflect the
+  // per-IP cap on the very first load after a cookie clear, before any
+  // /stream call has run.
+  const clientIp = getClientIp(c);
+  const ipHash = clientIp ? await hashGuestSpendIp(clientIp) : null;
+
   const context: GuestSessionFetchContext = {
     cookie: extractGuestSessionCookie(c.req.header("cookie")),
     userAgent: c.req.header("user-agent") ?? null,
     body,
+    ipHash,
   };
 
   const result = shouldFetchGuestSessionFromConvex()

--- a/mcpjam-inspector/server/routes/web/guest-session.ts
+++ b/mcpjam-inspector/server/routes/web/guest-session.ts
@@ -9,6 +9,7 @@ import {
   type GuestSessionFetchContext,
   type GuestSessionRequestBody,
 } from "../../utils/guest-session-source.js";
+import { getClientIp } from "../../utils/client-ip.js";
 import { ErrorCode } from "./errors.js";
 
 const guestSession = new Hono();
@@ -27,19 +28,6 @@ setInterval(() => {
     }
   }
 }, 5 * 60_000).unref();
-
-function getClientIp(c: any): string | null {
-  const forwardedFor = c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
-  if (forwardedFor) return forwardedFor;
-
-  const realIp = c.req.header("x-real-ip")?.trim();
-  if (realIp) return realIp;
-
-  const cfConnectingIp = c.req.header("cf-connecting-ip")?.trim();
-  if (cfConnectingIp) return cfConnectingIp;
-
-  return null;
-}
 
 const GUEST_SESSION_COOKIE_NAME = "__Host-mcpjam_guest_session";
 

--- a/mcpjam-inspector/server/utils/__tests__/client-ip.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/client-ip.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { getClientIp } from "../client-ip.js";
+import { canonicalizeClientIp } from "../guest-spend-ip.js";
+
+function makeCtx(headers: Record<string, string>) {
+  return {
+    req: {
+      header: (name: string) => headers[name.toLowerCase()],
+    },
+  } as any;
+}
+
+describe("getClientIp", () => {
+  it("prefers cf-connecting-ip over x-real-ip and x-forwarded-for", () => {
+    const ctx = makeCtx({
+      "cf-connecting-ip": "1.2.3.4",
+      "x-real-ip": "5.6.7.8",
+      "x-forwarded-for": "9.10.11.12, 13.14.15.16",
+    });
+    expect(getClientIp(ctx)).toBe("1.2.3.4");
+  });
+
+  it("falls back to x-real-ip when cf-connecting-ip is absent", () => {
+    const ctx = makeCtx({
+      "x-real-ip": "5.6.7.8",
+      "x-forwarded-for": "9.10.11.12",
+    });
+    expect(getClientIp(ctx)).toBe("5.6.7.8");
+  });
+
+  it("falls back to first x-forwarded-for entry when nothing else is set", () => {
+    const ctx = makeCtx({
+      "x-forwarded-for": "9.10.11.12, 13.14.15.16",
+    });
+    expect(getClientIp(ctx)).toBe("9.10.11.12");
+  });
+
+  it("returns null when no headers are present", () => {
+    expect(getClientIp(makeCtx({}))).toBe(null);
+  });
+
+  it("trims whitespace", () => {
+    const ctx = makeCtx({ "cf-connecting-ip": "  1.2.3.4  " });
+    expect(getClientIp(ctx)).toBe("1.2.3.4");
+  });
+});
+
+describe("canonicalizeClientIp", () => {
+  it("collapses ::ffff:1.2.3.4 to 1.2.3.4 (mapped-v4)", () => {
+    expect(canonicalizeClientIp("::ffff:1.2.3.4")).toBe("1.2.3.4");
+  });
+
+  it("preserves plain IPv4", () => {
+    expect(canonicalizeClientIp("203.0.113.10")).toBe("203.0.113.10");
+  });
+
+  it("strips brackets and lowercases plain IPv6", () => {
+    const out = canonicalizeClientIp("::1");
+    expect(out).toBe("::1");
+  });
+
+  it("lowercases mixed-case IPv6", () => {
+    const out = canonicalizeClientIp("2001:DB8::1");
+    expect(out?.toLowerCase()).toBe(out);
+    expect(out).toContain("2001:db8");
+  });
+
+  it("hashes the same client identically whether seen as IPv4 or IPv4-mapped IPv6", () => {
+    expect(canonicalizeClientIp("1.2.3.4")).toBe(
+      canonicalizeClientIp("::ffff:1.2.3.4")
+    );
+  });
+
+  it("returns null for non-IP strings", () => {
+    expect(canonicalizeClientIp("not-an-ip")).toBe(null);
+    expect(canonicalizeClientIp("")).toBe(null);
+  });
+
+  it("trims whitespace before canonicalization", () => {
+    expect(canonicalizeClientIp("  1.2.3.4  ")).toBe("1.2.3.4");
+  });
+});

--- a/mcpjam-inspector/server/utils/__tests__/guest-session-source.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/guest-session-source.test.ts
@@ -221,6 +221,56 @@ describe("guest-session-source", () => {
     );
   });
 
+  it("forwards x-mcpjam-guest-ip-hash to Convex when ipHash is provided", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          guestId: "g",
+          token: "t",
+          expiresAt: Date.now() + 60_000,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const { fetchConvexGuestSession } = await import(
+      "../guest-session-source.js"
+    );
+    await fetchConvexGuestSession({
+      cookie: null,
+      userAgent: null,
+      ipHash: "abc-hash",
+    });
+
+    const init = vi.mocked(global.fetch).mock.calls[0]![1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["x-mcpjam-guest-ip-hash"]).toBe("abc-hash");
+  });
+
+  it("sends _unknown sentinel when ipHash is null but the field is set", async () => {
+    vi.mocked(global.fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          guestId: "g",
+          token: "t",
+          expiresAt: Date.now() + 60_000,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const { fetchConvexGuestSession } = await import(
+      "../guest-session-source.js"
+    );
+    await fetchConvexGuestSession({
+      cookie: null,
+      userAgent: null,
+      ipHash: null,
+    });
+
+    const init = vi.mocked(global.fetch).mock.calls[0]![1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["x-mcpjam-guest-ip-hash"]).toBe("_unknown");
+  });
+
   it("waits for provisioning before fetching Convex JWKS", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
       new Response(JSON.stringify({ keys: [] }), {

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -929,6 +929,33 @@ describe("mcpjam-stream-handler", () => {
       delete process.env.GUEST_SESSION_HASH_PEPPER;
     });
 
+    it("does not let extraHeaders override the computed guest IP hash", async () => {
+      process.env.GUEST_SESSION_HASH_PEPPER = "test-pepper-for-ip-hash";
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "hi" }] as any,
+        modelId: "gpt-4.1-mini",
+        systemPrompt: "You are helpful",
+        tools: {},
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        clientIp: "203.0.113.10",
+        extraHeaders: {
+          "x-mcpjam-guest-ip-hash": "attacker-controlled",
+        },
+      });
+
+      await lastExecution;
+
+      const headers = (global.fetch as any).mock.calls[0]?.[1]
+        ?.headers as Record<string, string>;
+      expect(headers["x-mcpjam-guest-ip-hash"]).not.toBe("attacker-controlled");
+      expect(headers["x-mcpjam-guest-ip-hash"]).toMatch(/^[A-Za-z0-9_-]+$/);
+
+      delete process.env.GUEST_SESSION_HASH_PEPPER;
+    });
+
     it("hashes IPv4 and ::ffff:-mapped IPv6 of the same client identically", async () => {
       process.env.GUEST_SESSION_HASH_PEPPER = "test-pepper-for-ip-hash";
 

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -877,4 +877,98 @@ describe("mcpjam-stream-handler", () => {
       },
     });
   });
+
+  describe("guest IP-hash header", () => {
+    it("forwards a hashed IP for the per-IP daily spend cap when clientIp is provided", async () => {
+      process.env.GUEST_SESSION_HASH_PEPPER = "test-pepper-for-ip-hash";
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "hi" }] as any,
+        modelId: "gpt-4.1-mini",
+        systemPrompt: "You are helpful",
+        tools: {},
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        clientIp: "203.0.113.10",
+      });
+
+      await lastExecution;
+
+      const headers = (global.fetch as any).mock.calls[0]?.[1]
+        ?.headers as Record<string, string>;
+      const ipHash = headers["x-mcpjam-guest-ip-hash"];
+      expect(typeof ipHash).toBe("string");
+      expect(ipHash).not.toBe("_unknown");
+      // base64url, no padding
+      expect(ipHash).toMatch(/^[A-Za-z0-9_-]+$/);
+
+      delete process.env.GUEST_SESSION_HASH_PEPPER;
+    });
+
+    it("sends the _unknown sentinel when clientIp is null", async () => {
+      process.env.GUEST_SESSION_HASH_PEPPER = "test-pepper-for-ip-hash";
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "hi" }] as any,
+        modelId: "gpt-4.1-mini",
+        systemPrompt: "You are helpful",
+        tools: {},
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        clientIp: null,
+      });
+
+      await lastExecution;
+
+      const headers = (global.fetch as any).mock.calls[0]?.[1]
+        ?.headers as Record<string, string>;
+      expect(headers["x-mcpjam-guest-ip-hash"]).toBe("_unknown");
+
+      delete process.env.GUEST_SESSION_HASH_PEPPER;
+    });
+
+    it("hashes IPv4 and ::ffff:-mapped IPv6 of the same client identically", async () => {
+      process.env.GUEST_SESSION_HASH_PEPPER = "test-pepper-for-ip-hash";
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "hi" }] as any,
+        modelId: "gpt-4.1-mini",
+        systemPrompt: "You are helpful",
+        tools: {},
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        clientIp: "1.2.3.4",
+      });
+      await lastExecution;
+      const v4Hash = ((global.fetch as any).mock.calls[0]?.[1]?.headers ?? {})[
+        "x-mcpjam-guest-ip-hash"
+      ];
+
+      // Reset between calls
+      lastExecution = null;
+      writtenChunks = [];
+      (global.fetch as any).mockClear();
+
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "hi" }] as any,
+        modelId: "gpt-4.1-mini",
+        systemPrompt: "You are helpful",
+        tools: {},
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        clientIp: "::ffff:1.2.3.4",
+      });
+      await lastExecution;
+      const mappedHash = ((global.fetch as any).mock.calls[0]?.[1]?.headers ??
+        {})["x-mcpjam-guest-ip-hash"];
+
+      expect(mappedHash).toBe(v4Hash);
+
+      delete process.env.GUEST_SESSION_HASH_PEPPER;
+    });
+  });
 });

--- a/mcpjam-inspector/server/utils/client-ip.ts
+++ b/mcpjam-inspector/server/utils/client-ip.ts
@@ -1,0 +1,21 @@
+import type { Context } from "hono";
+
+// Extract the originating client IP from forwarded-for headers. Order matters:
+// - cf-connecting-ip is set by Cloudflare and not spoofable by the client.
+// - x-real-ip is set by trusted reverse proxies (Railway, nginx).
+// - x-forwarded-for is the legacy fallback; the first entry is the client when
+//   the chain is fully trusted, but is mutable by the client when there's no
+//   trusted proxy in front. Listed last so a real cf-connecting-ip / x-real-ip
+//   wins on the hosted edge.
+export function getClientIp(c: Context): string | null {
+  const cfConnectingIp = c.req.header("cf-connecting-ip")?.trim();
+  if (cfConnectingIp) return cfConnectingIp;
+
+  const realIp = c.req.header("x-real-ip")?.trim();
+  if (realIp) return realIp;
+
+  const forwardedFor = c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
+  if (forwardedFor) return forwardedFor;
+
+  return null;
+}

--- a/mcpjam-inspector/server/utils/guest-session-source.ts
+++ b/mcpjam-inspector/server/utils/guest-session-source.ts
@@ -18,6 +18,10 @@ export type GuestSessionFetchContext = {
   cookie?: string | null;
   userAgent?: string | null;
   body?: GuestSessionRequestBody | null;
+  // Hashed client IP so the upstream can record the IP-bucket key on the
+  // guest's session row at resolve time. Letting the display path read it
+  // from the row before any /stream call has run.
+  ipHash?: string | null;
 };
 
 export type GuestSessionRequestBody = {
@@ -93,6 +97,9 @@ function buildForwardedHeaders(
   }
   if (context?.userAgent) {
     headers["User-Agent"] = context.userAgent;
+  }
+  if (context?.ipHash !== undefined) {
+    headers["x-mcpjam-guest-ip-hash"] = context.ipHash ?? "_unknown";
   }
   return headers;
 }

--- a/mcpjam-inspector/server/utils/guest-spend-ip.ts
+++ b/mcpjam-inspector/server/utils/guest-spend-ip.ts
@@ -7,8 +7,19 @@ const SCOPE = "guest-spend-ip";
 let cachedKeyPepper: string | null = null;
 let cachedKeyPromise: Promise<webcrypto.CryptoKey> | null = null;
 
-async function getHmacKey(): Promise<webcrypto.CryptoKey> {
-  const pepper = getGuestSessionHashPepper();
+async function getHmacKey(): Promise<webcrypto.CryptoKey | null> {
+  // The pepper helper throws in non-dev environments when the env var is
+  // unset (test, prod-without-config, ephemeral staging). Treat that as
+  // "no pepper" and return null so callers can degrade to the `_unknown`
+  // sentinel — same end state as a request with no resolvable IP. We
+  // never want a missing pepper to bubble up as a 500 from the chat /
+  // guest-session routes.
+  let pepper: string;
+  try {
+    pepper = getGuestSessionHashPepper();
+  } catch {
+    return null;
+  }
   if (cachedKeyPepper === pepper && cachedKeyPromise) {
     return cachedKeyPromise;
   }
@@ -78,11 +89,14 @@ export function canonicalizeClientIp(rawIp: string): string | null {
 
 // HMAC the canonicalized IP with the guest-session pepper under a dedicated
 // scope. Same scope/pepper used by the cookie hash path, but separate scope
-// prefix so the two hashes can't be cross-substituted.
+// prefix so the two hashes can't be cross-substituted. Returns null when
+// the IP can't be canonicalized OR the pepper is unavailable; caller falls
+// back to the `_unknown` sentinel.
 export async function hashGuestSpendIp(rawIp: string): Promise<string | null> {
   const canonical = canonicalizeClientIp(rawIp);
   if (!canonical) return null;
   const key = await getHmacKey();
+  if (!key) return null;
   const sig = await crypto.subtle.sign(
     "HMAC",
     key,

--- a/mcpjam-inspector/server/utils/guest-spend-ip.ts
+++ b/mcpjam-inspector/server/utils/guest-spend-ip.ts
@@ -1,0 +1,92 @@
+import { isIP, isIPv4, isIPv6 } from "node:net";
+import type { webcrypto } from "node:crypto";
+import { getGuestSessionHashPepper } from "./guest-session-pepper.js";
+
+const SCOPE = "guest-spend-ip";
+
+let cachedKeyPepper: string | null = null;
+let cachedKeyPromise: Promise<webcrypto.CryptoKey> | null = null;
+
+async function getHmacKey(): Promise<webcrypto.CryptoKey> {
+  const pepper = getGuestSessionHashPepper();
+  if (cachedKeyPepper === pepper && cachedKeyPromise) {
+    return cachedKeyPromise;
+  }
+  cachedKeyPepper = pepper;
+  cachedKeyPromise = crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(pepper),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  return cachedKeyPromise;
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+}
+
+const IPV4_MAPPED_RE = /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/i;
+
+// Canonicalize a raw client IP into the form we hash. Same client must always
+// hash to the same key, so:
+//   - IPv4-mapped IPv6 (::ffff:1.2.3.4) collapses to its dotted-quad form. We
+//     can't rely on `new URL(...).hostname` here because Node normalizes the
+//     mapped form to compressed `[::ffff:102:304]`, which would key a v4
+//     client differently depending on whether the proxy hands us the v4 or
+//     the v6 representation.
+//   - Other IPv6 addresses are normalized via URL parsing (which lowercases
+//     and applies RFC 5952 compression). The bracketed form Node returns is
+//     stripped.
+//   - IPv4 passes through unchanged.
+//   - Anything else returns null so the caller can fall back to a sentinel.
+export function canonicalizeClientIp(rawIp: string): string | null {
+  const trimmed = rawIp.trim();
+  if (!trimmed) return null;
+
+  const mapped = trimmed.match(IPV4_MAPPED_RE);
+  if (mapped && isIPv4(mapped[1])) {
+    return mapped[1];
+  }
+
+  if (isIPv4(trimmed)) {
+    return trimmed;
+  }
+
+  if (isIPv6(trimmed)) {
+    try {
+      const normalized = new URL(`http://[${trimmed}]`).hostname.toLowerCase();
+      // Node returns IPv6 hostnames bracketed (e.g. "[::1]"); strip them.
+      return normalized.startsWith("[") && normalized.endsWith("]")
+        ? normalized.slice(1, -1)
+        : normalized;
+    } catch {
+      return null;
+    }
+  }
+
+  return isIP(trimmed) ? trimmed.toLowerCase() : null;
+}
+
+// HMAC the canonicalized IP with the guest-session pepper under a dedicated
+// scope. Same scope/pepper used by the cookie hash path, but separate scope
+// prefix so the two hashes can't be cross-substituted.
+export async function hashGuestSpendIp(rawIp: string): Promise<string | null> {
+  const canonical = canonicalizeClientIp(rawIp);
+  if (!canonical) return null;
+  const key = await getHmacKey();
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(`${SCOPE}:${canonical}`),
+  );
+  return bytesToBase64Url(new Uint8Array(sig));
+}

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -978,8 +978,8 @@ async function processOneStep(
     headers: {
       "content-type": "application/json",
       ...(authHeader ? { authorization: authHeader } : {}),
-      [GUEST_IP_HASH_HEADER]: ipHash ?? GUEST_IP_UNKNOWN_SENTINEL,
       ...(extraHeaders ?? {}),
+      [GUEST_IP_HASH_HEADER]: ipHash ?? GUEST_IP_UNKNOWN_SENTINEL,
     },
     body: JSON.stringify({
       mode: "stream",

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -66,8 +66,11 @@ import {
   writeTraceEvent,
 } from "./live-chat-trace-stream";
 import { buildResolvedModelRequestPayload } from "./model-request-payload";
+import { hashGuestSpendIp } from "./guest-spend-ip.js";
 
 const MAX_STEPS = 20;
+const GUEST_IP_HASH_HEADER = "x-mcpjam-guest-ip-hash";
+const GUEST_IP_UNKNOWN_SENTINEL = "_unknown";
 const streamChunkSchema = zodSchema(z.unknown());
 
 export interface MCPJamHandlerOptions {
@@ -109,6 +112,14 @@ export interface MCPJamHandlerOptions {
    * BYOK chat to send the providerKey alongside the model id.
    */
   extraBodyFields?: Record<string, unknown>;
+  /**
+   * Originating client IP from the inbound request. Hashed and forwarded as
+   * `x-mcpjam-guest-ip-hash` so Convex can apply the per-IP daily spend cap
+   * for guests in addition to the per-cookie cap. Null when no IP is
+   * available (dev / missing forwarded-for) — caller header is sent as the
+   * `_unknown` sentinel so all keyless callers share one bucket.
+   */
+  clientIp?: string | null;
 }
 
 interface StepContext {
@@ -135,6 +146,7 @@ interface StepContext {
   endpointPath: string;
   extraHeaders?: Record<string, string>;
   extraBodyFields?: Record<string, unknown>;
+  clientIp?: string | null;
 }
 
 type PersistedAssistantPart = TextPart | ToolCallPart | ReasoningUIPart;
@@ -954,12 +966,19 @@ async function processOneStep(
     extraBodyFields,
     chatSessionId,
     sourceType,
+    clientIp,
   } = ctx;
+  // Hash the originating IP for the per-IP daily spend cap. Hashing here
+  // (server-side) keeps the raw IP off the wire to Convex. Always send a
+  // value — `_unknown` funnels keyless callers into one shared bucket
+  // rather than letting them bypass by stripping the header.
+  const ipHash = clientIp ? await hashGuestSpendIp(clientIp) : null;
   const res = await fetch(`${process.env.CONVEX_HTTP_URL}${endpointPath}`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
       ...(authHeader ? { authorization: authHeader } : {}),
+      [GUEST_IP_HASH_HEADER]: ipHash ?? GUEST_IP_UNKNOWN_SENTINEL,
       ...(extraHeaders ?? {}),
     },
     body: JSON.stringify({
@@ -1297,6 +1316,7 @@ export async function handleMCPJamFreeChatModel(
     extraBodyFields,
     chatSessionId,
     sourceType,
+    clientIp,
   } = options;
   const resolvedEndpointPath = endpointPath ?? "/stream";
 
@@ -1371,6 +1391,7 @@ export async function handleMCPJamFreeChatModel(
             endpointPath: resolvedEndpointPath,
             extraHeaders,
             extraBodyFields,
+            clientIp,
           });
 
           steps++;

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -50,6 +50,7 @@ export interface OrgModelHandlerOptions {
    */
   shareToken?: string;
   chatboxToken?: string;
+  clientIp?: string | null;
 }
 
 export async function handleHostedOrgChatModel(
@@ -80,6 +81,7 @@ export async function handleHostedOrgChatModel(
     onConversationComplete: options.onConversationComplete,
     onStreamComplete: options.onStreamComplete,
     onStreamWriterReady: options.onStreamWriterReady,
+    clientIp: options.clientIp,
     endpointPath: "/stream/org",
     extraHeaders: {
       "X-Inspector-Service-Token": inspectorServiceToken,


### PR DESCRIPTION
## Summary

Pairs with [mcpjam-backend#211](https://github.com/MCPJam/mcpjam-backend/pull/211)'s per-IP daily spend cap. Inspector hashes the originating client IP server-side using `GUEST_SESSION_HASH_PEPPER` (under a dedicated `"guest-spend-ip"` scope) and sends it as `x-mcpjam-guest-ip-hash` on every `/stream` POST so Convex can apply the per-IP bucket in addition to the per-cookie bucket.

## Changes

- **`server/utils/client-ip.ts`** (new) — shared `getClientIp` with the correct preference order: `cf-connecting-ip` > `x-real-ip` > first `x-forwarded-for`. Old `guest-session.ts` had XFF first, which is wrong behind Cloudflare.
- **`server/utils/guest-spend-ip.ts`** (new) — `hashGuestSpendIp` (HMAC-SHA256, base64url) + IP canonicalization. IPv4-mapped IPv6 (`::ffff:1.2.3.4`) collapses to dotted-quad via explicit regex; a v4 client hashes identically whether seen as v4 or mapped-v6. Other IPv6 normalized via URL parse + bracket strip + lowercase.
- **`chat-v2.ts`** — computes `clientIp` at all three handler call sites (direct, hosted org BYOK, hosted MCPJam free).
- **`mcpjam-stream-handler.ts`** — `clientIp` option plumbed through `processOneStep`. Always sends the header (uses `_unknown` sentinel when IP is unresolvable in dev) so omission can't be used to bypass.
- **`org-model-stream-handler.ts`** — passes `clientIp` through for parity (org BYOK doesn't consume the MCPJam free bucket, but consistency keeps the path simple).

## Test plan

- [x] 12 new `client-ip` cases — header order + IPv6 canonicalization, including v4 ≡ mapped-v6 hash equality
- [x] 3 new `mcpjam-stream-handler` cases — header presence with real IP, `_unknown` sentinel for null, hash equality across v4/mapped-v6
- [x] Full inspector suite (`pnpm vitest run`) — 3565 tests pass
- [x] `tsc --noEmit` on `server/tsconfig.json` — clean (the errors that exist are pre-existing in unrelated files)

## Deploy order

Either order is safe — both ends are backwards-compatible:
- Convex without the header read = inspector header is harmlessly ignored.
- Inspector without the header send = Convex maps to `_unknown`, all keyless callers share one bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request metadata sent to Convex (`x-mcpjam-guest-ip-hash`) and adds new hashing/canonicalization logic that affects guest spend/rate-limit bucketing across chat and session endpoints.
> 
> **Overview**
> Adds per-request forwarding of a **server-side HMAC’d client IP** to Convex via `x-mcpjam-guest-ip-hash` to support per-IP guest spend caps.
> 
> Introduces shared `getClientIp` (Cloudflare/real-ip/XFF preference), a new `guest-spend-ip` hashing helper (canonicalizes IPv4/IPv6 and returns `_unknown` when unavailable/pepper missing), and plumbs `clientIp` through `chat-v2` routes into `handleMCPJamFreeChatModel`/`handleHostedOrgChatModel`. `guest-session` now also computes and forwards the IP hash during session resolution so Convex can persist the IP bucket before the first `/stream` call.
> 
> Expands tests to cover header precedence, IP canonicalization, and that the computed hash is always sent (cannot be overridden by `extraHeaders`) with a stable hash for IPv4 vs IPv4-mapped IPv6.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4cd1533f9ac1b26e80cf3245b0e9ad8da7a3075. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->