### PR TITLE
fix: handle guest credit balance queries

### DIFF
--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
@@ -11,13 +11,13 @@ let balanceState:
     }
   | undefined;
 let isLoadingState = false;
-let isAuthenticatedState = true;
+let hasWorkOsUserState = true;
 
 vi.mock("@/hooks/useCreditBalance", () => ({
   useCreditBalance: () => ({
     balance: balanceState,
     isLoading: isLoadingState,
-    isAuthenticated: isAuthenticatedState,
+    hasWorkOsUser: hasWorkOsUserState,
   }),
 }));
 
@@ -32,7 +32,7 @@ describe("SidebarCreditUsage", () => {
       freeDailyResetAt: Date.now() + 3 * 60 * 60 * 1000,
     };
     isLoadingState = false;
-    isAuthenticatedState = true;
+    hasWorkOsUserState = true;
   });
 
   afterEach(() => {
@@ -106,7 +106,7 @@ describe("SidebarCreditUsage", () => {
       freeDailyPercentUsed: 65,
       freeDailyResetAt: Date.now() + 2 * 60 * 60 * 1000,
     };
-    isAuthenticatedState = false;
+    hasWorkOsUserState = false;
 
     render(<SidebarCreditUsage includeGuests />);
 

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
@@ -15,7 +15,7 @@ export function SidebarCreditUsage({
   includeGuests = false,
   variant = "strip",
 }: SidebarCreditUsageProps = {}) {
-  const { balance, isLoading, isAuthenticated } = useCreditBalance({
+  const { balance, isLoading, hasWorkOsUser } = useCreditBalance({
     includeGuests,
   });
 
@@ -35,7 +35,7 @@ export function SidebarCreditUsage({
       : 0;
   const hasPaidHistory = balance?.hasPurchaseHistory === true;
   const showGuestUpgradeHint =
-    variant === "strip" && includeGuests && !isAuthenticated && !isLoading;
+    variant === "strip" && includeGuests && !hasWorkOsUser && !isLoading;
 
   return (
     <div

--- a/mcpjam-inspector/client/src/hooks/__tests__/useCreditBalance.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useCreditBalance.test.tsx
@@ -53,7 +53,8 @@ describe("useCreditBalance", () => {
     );
     expect(result.current.balance).toBeUndefined();
     expect(result.current.isLoading).toBe(false);
-    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.hasWorkOsUser).toBe(false);
   });
 
   it("fetches guest balances when includeGuests is enabled", () => {
@@ -71,7 +72,8 @@ describe("useCreditBalance", () => {
       freeDailyResetAt: 1_777_777_777_000,
     });
     expect(result.current.isLoading).toBe(false);
-    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.hasWorkOsUser).toBe(false);
   });
 
   it("fetches signed-in balances without includeGuests", () => {
@@ -83,5 +85,6 @@ describe("useCreditBalance", () => {
     expect(mocks.useQuery).toHaveBeenCalledWith("billing:getCreditBalance", {});
     expect(result.current.balance?.freeDailyPercentUsed).toBe(65);
     expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.hasWorkOsUser).toBe(true);
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/useCreditBalance.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useCreditBalance.test.tsx
@@ -1,0 +1,87 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCreditBalance } from "@/hooks/useCreditBalance";
+
+const mocks = vi.hoisted(() => ({
+  convexAuth: {
+    isAuthenticated: false,
+    isLoading: false,
+  },
+  workosAuth: {
+    user: null as { id: string } | null,
+    isLoading: false,
+  },
+  queryResult: undefined as unknown,
+  useQuery: vi.fn(),
+}));
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => mocks.convexAuth,
+  useQuery: (...args: unknown[]) => mocks.useQuery(...args),
+}));
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => mocks.workosAuth,
+}));
+
+describe("useCreditBalance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.convexAuth.isAuthenticated = false;
+    mocks.convexAuth.isLoading = false;
+    mocks.workosAuth.user = null;
+    mocks.workosAuth.isLoading = false;
+    mocks.queryResult = {
+      paidPercentRemaining: null,
+      hasPurchaseHistory: false,
+      freeDailyPercentUsed: 65,
+      freeDailyResetAt: 1_777_777_777_000,
+    };
+    mocks.useQuery.mockImplementation((_name: unknown, args: unknown) =>
+      args === "skip" ? undefined : mocks.queryResult
+    );
+  });
+
+  it("skips guest Convex identities unless guests are included", () => {
+    mocks.convexAuth.isAuthenticated = true;
+
+    const { result } = renderHook(() => useCreditBalance());
+
+    expect(mocks.useQuery).toHaveBeenCalledWith(
+      "billing:getCreditBalance",
+      "skip"
+    );
+    expect(result.current.balance).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it("fetches guest balances when includeGuests is enabled", () => {
+    mocks.convexAuth.isAuthenticated = true;
+
+    const { result } = renderHook(() =>
+      useCreditBalance({ includeGuests: true })
+    );
+
+    expect(mocks.useQuery).toHaveBeenCalledWith("billing:getCreditBalance", {});
+    expect(result.current.balance).toEqual({
+      paidPercentRemaining: null,
+      hasPurchaseHistory: false,
+      freeDailyPercentUsed: 65,
+      freeDailyResetAt: 1_777_777_777_000,
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it("fetches signed-in balances without includeGuests", () => {
+    mocks.convexAuth.isAuthenticated = true;
+    mocks.workosAuth.user = { id: "user_123" };
+
+    const { result } = renderHook(() => useCreditBalance());
+
+    expect(mocks.useQuery).toHaveBeenCalledWith("billing:getCreditBalance", {});
+    expect(result.current.balance?.freeDailyPercentUsed).toBe(65);
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
@@ -68,8 +68,7 @@ export function useCreditBalance({
   includeGuests = false,
 }: UseCreditBalanceOptions = {}) {
   const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
-  const shouldFetchBalance =
-    !isAuthLoading && (isAuthenticated || includeGuests);
+  const shouldFetchBalance = !isAuthLoading && isAuthenticated;
   const raw = useQuery(
     "billing:getCreditBalance" as any,
     shouldFetchBalance ? ({} as any) : "skip"

--- a/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
@@ -1,3 +1,4 @@
+import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth, useQuery } from "convex/react";
 import { useMemo } from "react";
 
@@ -67,8 +68,17 @@ interface UseCreditBalanceOptions {
 export function useCreditBalance({
   includeGuests = false,
 }: UseCreditBalanceOptions = {}) {
-  const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
-  const shouldFetchBalance = !isAuthLoading && isAuthenticated;
+  const {
+    isAuthenticated: hasConvexIdentity,
+    isLoading: isConvexAuthLoading,
+  } = useConvexAuth();
+  const { user, isLoading: isWorkOsLoading } = useAuth();
+  const isAuthenticated = !!user;
+  const isAuthLoading = isConvexAuthLoading || isWorkOsLoading;
+  const shouldFetchBalance =
+    !isAuthLoading &&
+    hasConvexIdentity &&
+    (isAuthenticated || includeGuests);
   const raw = useQuery(
     "billing:getCreditBalance" as any,
     shouldFetchBalance ? ({} as any) : "skip"

--- a/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditBalance.ts
@@ -73,12 +73,12 @@ export function useCreditBalance({
     isLoading: isConvexAuthLoading,
   } = useConvexAuth();
   const { user, isLoading: isWorkOsLoading } = useAuth();
-  const isAuthenticated = !!user;
+  const hasWorkOsUser = !!user;
   const isAuthLoading = isConvexAuthLoading || isWorkOsLoading;
   const shouldFetchBalance =
     !isAuthLoading &&
     hasConvexIdentity &&
-    (isAuthenticated || includeGuests);
+    (hasWorkOsUser || includeGuests);
   const raw = useQuery(
     "billing:getCreditBalance" as any,
     shouldFetchBalance ? ({} as any) : "skip"
@@ -91,5 +91,10 @@ export function useCreditBalance({
   // Treat the bootstrap window as loading so the card shows a skeleton
   // instead of flashing an empty zero state before the query resolves.
   const isLoading = isAuthLoading || (shouldFetchBalance && raw === undefined);
-  return { balance, isLoading, isAuthenticated };
+  return {
+    balance,
+    isLoading,
+    isAuthenticated: hasConvexIdentity,
+    hasWorkOsUser,
+  };
 }


### PR DESCRIPTION
billing:getCreditBalance requires authentication on the backend. With includeGuests=true, shouldFetchBalance was true as soon as auth stopped loading — even with no token (WorkOS fails + guest session unavailable). The server threw "Authentication required", useQuery re-threw during render, and with no error boundary around the sidebar the React tree unmounted → blank page on staging.

Gate the query solely on isAuthenticated (true for both WorkOS users and guests with valid JWTs, false only when there is no token at all).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes when `billing:getCreditBalance` is queried based on combined Convex + WorkOS auth state, which can affect whether credit usage renders or silently skips fetching in edge auth cases.
> 
> **Overview**
> Prevents `billing:getCreditBalance` from being queried unless Convex auth is ready *and* there is either a WorkOS user or `includeGuests` is enabled, avoiding unauthenticated renders that could crash the sidebar.
> 
> Updates `SidebarCreditUsage` to use a new `hasWorkOsUser` signal (instead of `isAuthenticated`) for showing the guest “sign in” upsell, and adds unit tests covering the new `useCreditBalance` gating behavior plus the sidebar hint behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63cc8ea9c0f3462d528a3a238fe03fc9df777f17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->