### PR TITLE
trial countdown

### DIFF
--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -49,6 +49,7 @@ import { MCPIcon } from "@/components/ui/mcp-icon";
 import { SidebarUser } from "@/components/sidebar/sidebar-user";
 import { SidebarContextSwitcher } from "@/components/sidebar/sidebar-context-switcher";
 import { SidebarCreditUsage } from "@/components/sidebar/sidebar-credit-usage";
+import { SidebarTrialCountdown } from "@/components/sidebar/sidebar-trial-countdown";
 import { ShareProjectDialog } from "@/components/project/ShareProjectDialog";
 import { useUpdateNotification } from "@/hooks/useUpdateNotification";
 import { Badge } from "@mcpjam/design-system/badge";
@@ -69,7 +70,10 @@ import { withTestingSurface } from "@/lib/testing-surface";
 import { HOSTED_LOCAL_ONLY_TOOLTIP } from "@/lib/hosted-ui";
 import { useLearnMore } from "@/hooks/use-learn-more";
 import { LearnMoreExpandedPanel } from "@/components/learn-more/LearnMoreExpandedPanel";
-import type { BillingFeatureName } from "@/hooks/useOrganizationBilling";
+import {
+  useOrganizationBillingStatus,
+  type BillingFeatureName,
+} from "@/hooks/useOrganizationBilling";
 import type { Project } from "@/state/app-types";
 import type { OrganizationRouteSection } from "@/lib/hosted-navigation";
 
@@ -569,6 +573,18 @@ export function MCPSidebar({
     );
   }, [activeProject?.organizationId, projects]);
   const shouldShowInviteCta = isAuthenticated && !!user && !!activeProject;
+  const trialBilling = useOrganizationBillingStatus(
+    activeProject?.organizationId ?? null,
+    { enabled: billingUiEnabled && !!activeProject?.organizationId },
+  );
+  const trialActive =
+    billingUiEnabled &&
+    trialBilling?.trialStatus === "active" &&
+    !!trialBilling.trialEndsAt;
+  const handleTrialUpgradeClick = () => {
+    if (!activeProject?.organizationId) return;
+    window.location.hash = `#organizations/${activeProject.organizationId}/billing`;
+  };
 
   const handleNavClick = (url: string) => {
     if (onNavigate && url.startsWith("#")) {
@@ -757,6 +773,14 @@ export function MCPSidebar({
                 </SidebarMenuButton>
               </SidebarMenuItem>
             </SidebarMenu>
+          ) : null}
+          {shouldShowInviteCta && trialActive && trialBilling?.trialEndsAt ? (
+            <SidebarTrialCountdown
+              trialEndsAt={trialBilling.trialEndsAt}
+              trialStartedAt={trialBilling.trialStartedAt}
+              onUpgradeClick={handleTrialUpgradeClick}
+              className="mt-1"
+            />
           ) : null}
           {!user ? (
             <SidebarCreditUsage className="px-1" includeGuests />

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
@@ -10,6 +10,7 @@ const mockFeatureFlags: Record<string, boolean | undefined> = {};
 
 vi.mock("convex/react", () => ({
   useConvexAuth: (...args: unknown[]) => mockUseConvexAuth(...args),
+  useQuery: () => undefined,
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-trial-countdown.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-trial-countdown.test.tsx
@@ -1,0 +1,36 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SidebarTrialCountdown } from "@/components/sidebar/sidebar-trial-countdown";
+
+describe("SidebarTrialCountdown", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("tightens to one-second ticks after crossing into the final hour", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T12:00:00.000Z"));
+
+    const start = Date.now();
+    render(
+      <SidebarTrialCountdown
+        trialStartedAt={start - 6 * 24 * 60 * 60 * 1000}
+        trialEndsAt={start + 60 * 60 * 1000 + 1_000}
+      />,
+    );
+
+    expect(screen.getByText("1h 0m 1s")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(screen.getByText("59m 1s")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+
+    expect(screen.getByText("59m 0s")).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-trial-countdown.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-trial-countdown.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface SidebarTrialCountdownProps {
+  trialEndsAt: number;
+  trialStartedAt: number | null;
+  onUpgradeClick?: () => void;
+  className?: string;
+}
+
+export function SidebarTrialCountdown({
+  trialEndsAt,
+  trialStartedAt,
+  onUpgradeClick,
+  className,
+}: SidebarTrialCountdownProps) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const remaining = trialEndsAt - now;
+    if (remaining <= 0) return;
+
+    const delay = remaining < 60 * 60 * 1000 ? 1_000 : 60_000;
+    const id = window.setTimeout(() => setNow(Date.now()), delay);
+    return () => window.clearTimeout(id);
+  }, [now, trialEndsAt]);
+
+  const remainingMs = Math.max(0, trialEndsAt - now);
+  const totalMs =
+    trialStartedAt && trialEndsAt > trialStartedAt
+      ? trialEndsAt - trialStartedAt
+      : remainingMs || 1;
+  const elapsedPct = Math.min(
+    100,
+    Math.max(0, ((totalMs - remainingMs) / totalMs) * 100),
+  );
+
+  const Wrapper: "button" | "div" = onUpgradeClick ? "button" : "div";
+
+  return (
+    <div
+      data-testid="sidebar-trial-countdown"
+      aria-label="Trial countdown"
+      className={cn("group-data-[collapsible=icon]:hidden", className)}
+    >
+      <Wrapper
+        {...(onUpgradeClick
+          ? {
+              type: "button" as const,
+              onClick: onUpgradeClick,
+              "aria-label": "Trial — upgrade",
+            }
+          : {})}
+        className={cn(
+          "flex w-full flex-col gap-1 rounded-md px-2 py-1 text-left",
+          onUpgradeClick &&
+            "transition-colors hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        )}
+      >
+        <div className="flex items-baseline justify-between gap-2 leading-none">
+          <span className="text-[11px] text-foreground">Trial</span>
+          <span className="shrink-0 text-[11px] text-foreground">
+            {formatRemaining(remainingMs)}
+          </span>
+        </div>
+        <div className="relative h-[3px] w-full overflow-hidden rounded-full bg-primary/15">
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-primary/80 to-primary transition-[width] duration-500"
+            style={{ width: `${elapsedPct}%` }}
+          />
+        </div>
+      </Wrapper>
+    </div>
+  );
+}
+
+function formatRemaining(ms: number): string {
+  if (ms <= 0) return "expired";
+  const totalSec = Math.floor(ms / 1000);
+  const days = Math.floor(totalSec / 86_400);
+  const hours = Math.floor((totalSec % 86_400) / 3_600);
+  const minutes = Math.floor((totalSec % 3_600) / 60);
+  const seconds = totalSec % 60;
+
+  if (days >= 1) return `${days}d ${hours}h ${minutes}m`;
+  if (hours >= 1) return `${hours}h ${minutes}m ${seconds}s`;
+  if (minutes >= 1) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}


### PR DESCRIPTION
## Sidebar trial countdown

- Adds a compact trial countdown row to the sidebar footer, driven off trialEndsAt (label + remaining days/hours/minutes)
- Live-ticks (every minute, every second in the final hour); whole row is clickable and routes to the billing page
- Only renders when trialStatus === "active" and the billingUiEnabled flag is on

<img width="181" height="136" alt="image" src="https://github.com/user-attachments/assets/c1edf1bd-002f-4068-9011-39a92e9db621" />

