### PR TITLE
fix: gate apps conformance to HTTP-only transport

### DIFF
--- a/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
+++ b/mcpjam-inspector/client/src/components/conformance/ConformancePanel.tsx
@@ -592,9 +592,7 @@ function ConformanceContent({ server }: { server: ServerWithName }) {
     const promises: Promise<void>[] = [];
     if (httpServerNow) {
       promises.push(runProtocol(runToken, currentServer.name));
-    }
-    promises.push(runApps(runToken, currentServer.name));
-    if (httpServerNow) {
+      promises.push(runApps(runToken, currentServer.name));
       promises.push(runOAuth(runToken, currentServer));
     }
 

--- a/mcpjam-inspector/server/routes/mcp/conformance.ts
+++ b/mcpjam-inspector/server/routes/mcp/conformance.ts
@@ -132,6 +132,8 @@ conformance.post("/apps", async (c) => {
       return c.json({ success: false, ...resolved }, 400);
     }
 
+    assertHttpSupported("apps", resolved.config);
+
     // MCPClientManager stores `url` as a URL object; the SDK expects a string.
     const serverConfig = { ...resolved.config } as MCPServerConfig;
     if ("url" in serverConfig && serverConfig.url) {

--- a/sdk/src/mcp-conformance/transport-support.ts
+++ b/sdk/src/mcp-conformance/transport-support.ts
@@ -55,7 +55,9 @@ export function canRunConformance(
         ? { supported: true }
         : { supported: false, reason: HTTP_ONLY_REASON };
     case "apps":
-      return { supported: true };
+      return isHttpServerConfig(config)
+        ? { supported: true }
+        : { supported: false, reason: HTTP_ONLY_REASON };
     default: {
       const exhaustive: never = suite;
       return {


### PR DESCRIPTION
MCP Apps are HTTP-only (browser loads UI resources from a URL), so the apps conformance suite should require HTTP transport the same way protocol and OAuth suites do.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens transport validation for Apps conformance in the SDK, UI, and server route, which may change behavior for existing stdio-configured servers and surface new errors if unsupported-transport exceptions aren’t handled consistently.
> 
> **Overview**
> Apps conformance is now treated as **HTTP-only**: the SDK’s `canRunConformance` rejects non-HTTP configs for the `apps` suite, aligning it with `protocol`/`oauth`.
> 
> The inspector UI’s “Run available checks” flow now only launches Apps checks when the selected server is HTTP, and the server-side `/conformance/apps` route adds an `assertHttpSupported("apps", ...)` guard before running the suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8b1eb685476902bbf763a6af79edd42a02f77df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->