### PR TITLE
fix: stop chat-tab connection storm from prompts popover refetch loop

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/prompts/__tests__/mcp-prompts-popover.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/prompts/__tests__/mcp-prompts-popover.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { PromptsPopover } from "../mcp-prompts-popover";
+
+const listPromptsForServersMock = vi.fn();
+const listSkillsMock = vi.fn();
+
+vi.mock("@/lib/apis/mcp-prompts-api", () => ({
+  listPromptsForServers: (...args: unknown[]) =>
+    listPromptsForServersMock(...args),
+  getPrompt: vi.fn(),
+}));
+
+vi.mock("@/lib/apis/mcp-skills-api", () => ({
+  listSkills: (...args: unknown[]) => listSkillsMock(...args),
+}));
+
+// Skills section pulls in upload/connect components that are noisy in jsdom
+// and aren't relevant to this loop test.
+vi.mock("../../skills/skills-popover-section", () => ({
+  SkillsPopoverSection: () => null,
+}));
+vi.mock("../../skills/skill-upload-dialog", () => ({
+  SkillUploadDialog: () => null,
+}));
+
+const baseProps = {
+  anchor: { x: 0, y: 0 },
+  onPromptSelected: vi.fn(),
+  actionTrigger: null,
+  setActionTrigger: vi.fn(),
+  value: "",
+  caretIndex: 0,
+};
+
+describe("PromptsPopover", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listPromptsForServersMock.mockResolvedValue({ prompts: {} });
+    listSkillsMock.mockResolvedValue([]);
+  });
+
+  it("does not refetch prompts when the parent re-renders with a new array reference but identical contents", async () => {
+    const { rerender } = render(
+      <PromptsPopover {...baseProps} selectedServers={["excalidraw"]} />,
+    );
+
+    await waitFor(() =>
+      expect(listPromptsForServersMock).toHaveBeenCalledTimes(1),
+    );
+
+    // Simulate the parent re-rendering with a fresh array of identical content
+    // (the original symptom: an unmemoized upstream filter producing a new
+    // array each render).
+    for (let i = 0; i < 5; i++) {
+      rerender(
+        <PromptsPopover {...baseProps} selectedServers={["excalidraw"]} />,
+      );
+    }
+
+    // Give any spurious effects a tick to fire.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(listPromptsForServersMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refetches when the selected server list actually changes", async () => {
+    const { rerender } = render(
+      <PromptsPopover {...baseProps} selectedServers={["excalidraw"]} />,
+    );
+
+    await waitFor(() =>
+      expect(listPromptsForServersMock).toHaveBeenCalledTimes(1),
+    );
+
+    rerender(
+      <PromptsPopover
+        {...baseProps}
+        selectedServers={["excalidraw", "other"]}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(listPromptsForServersMock).toHaveBeenCalledTimes(2),
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/chat-v2/chat-input/prompts/mcp-prompts-popover.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/chat-input/prompts/mcp-prompts-popover.tsx
@@ -88,18 +88,23 @@ export function PromptsPopover({
   const [isSkillUploadDialogOpen, setIsSkillUploadDialogOpen] = useState(false);
   const skillsEnabled = Boolean(onSkillSelected);
 
+  // Depend on a stable signature so reference-only changes from the parent
+  // don't refire this fetch (each fetch spins up a per-request MCPClientManager
+  // on the hosted backend → fresh handshake).
+  const selectedServersSignature = (selectedServers ?? []).join("\u0000");
   useEffect(() => {
     // In shared/minimal mode, skip prompts fetch (project-member-only endpoint)
     if (minimalMode) return;
 
-    // Fetch prompts for selected servers
+    const servers = selectedServersSignature
+      ? selectedServersSignature.split("\u0000")
+      : [];
+    if (servers.length === 0) return;
+
     let active = true;
     (async () => {
       try {
-        if (!selectedServers || selectedServers.length === 0) {
-          return;
-        }
-        const { prompts } = await listPromptsForServers(selectedServers);
+        const { prompts } = await listPromptsForServers(servers);
         const promptListItems: PromptListItem[] = [];
         for (const serverId of Object.keys(prompts)) {
           const serverPrompts = prompts[serverId];
@@ -122,7 +127,7 @@ export function PromptsPopover({
     return () => {
       active = false;
     };
-  }, [selectedServers, minimalMode]);
+  }, [selectedServersSignature, minimalMode]);
 
   // Fetch skills count for navigation (only when skills UI is enabled)
   useEffect(() => {

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -628,6 +628,18 @@ export function useServerState({
   const effectiveServers = useMemo(() => {
     return activeProject?.servers || {};
   }, [activeProject]);
+
+  const connectedOrConnectingServerConfigs = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(effectiveServers).filter(
+          ([, server]) =>
+            server.connectionStatus === "connected" ||
+            server.connectionStatus === "connecting"
+        )
+      ),
+    [effectiveServers]
+  );
   const latestEffectiveServersRef = useRef(effectiveServers);
 
   useEffect(() => {
@@ -3390,13 +3402,7 @@ export function useServerState({
     activeProject,
     effectiveServers,
     projectServers: effectiveServers,
-    connectedOrConnectingServerConfigs: Object.fromEntries(
-      Object.entries(effectiveServers).filter(
-        ([, server]) =>
-          server.connectionStatus === "connected" ||
-          server.connectionStatus === "connecting"
-      )
-    ),
+    connectedOrConnectingServerConfigs,
     selectedServerEntry: effectiveServers[appState.selectedServer],
     selectedMCPConfig: effectiveServers[appState.selectedServer]?.config,
     selectedMCPConfigs: appState.selectedMultipleServers


### PR DESCRIPTION
## Summary

Fixes a feedback loop where opening the **Chat** tab in `dev:hosted` (and prod) triggers a continuous flood of MCP `initialize` / `notifications/initialized` / `logging/setLevel` traffic in the inspector log panel — log count climbs from 0 to 400+ within a minute while the page sits idle. Reproducible in multiple browsers; does not happen on the Connect tab or App Builder.

The driver is the prompts popover refetching `/api/web/prompts/list-multi` on every render of `ChatTabV2`. Each call builds a per-request `MCPClientManager` on the hosted backend, connects to every selected server, lists prompts, and disconnects — so each spurious refetch is one full handshake per server.

## Root cause

Three latent ingredients combine into the loop. They've been co-resident since 2025-11-30; something in the recent render-cadence changes (likely PR #2032 / #2028 / `348f5c4a4`) pushed parent re-renders frequent enough to expose it.

1. `mcp-prompts-popover.tsx` keys its fetch effect on `[selectedServers, minimalMode]` — array-reference dep, refires on any new array ref even with identical contents.
2. `useServerState` returned `connectedOrConnectingServerConfigs` as an inline `Object.fromEntries(Object.entries(...).filter(...))` in its return object — fresh object reference every render.
3. `ChatTabV2`'s `selectedConnectedServerNames` `useMemo` depends on (2) and feeds (1) — so an unstable upstream propagates straight into the popover's effect dep.

## Fix

Two small changes:

- **`client/src/hooks/use-server-state.ts`** — memoize `connectedOrConnectingServerConfigs` on `[effectiveServers]`. Source-of-truth fix: stops downstream memos in `ChatTabV2` (and any other consumer) from invalidating on every render.
- **`client/src/components/chat-v2/chat-input/prompts/mcp-prompts-popover.tsx`** — derive a stable joined signature (NUL-separated, matching the existing pattern in `use-chat-session.ts:1037`) and key the fetch effect on that instead of the array reference. Defense in depth: the popover stays robust even if some other parent up the tree hands down a fresh array.

User confirmed during diagnosis that both edits together stop the symptom — log count plateaus on idle Chat tab, and the dev server stops printing `POST /api/web/prompts/list-multi` on a loop.

## What this PR does NOT change

- `server/routes/web/auth.ts` per-request `MCPClientManager` pattern. Architecturally chatty (every web call does a full connect/disconnect) but intentional for hosted-mode auth scoping. Worth a separate conversation about pooling.
- `sdk/src/mcp-client-manager/MCPClientManager.ts:1168` auto `setLoggingLevel(serverId, "debug")` after every connect. Real concern (sends `logging/setLevel` to servers that don't advertise the capability, hardcodes `"debug"`, doubles the log noise per handshake), but separable SDK-side decision.
- Other unmemoized return-object fields in `useServerState` (`selectedMCPConfigs`, `selectedMCPConfigsMap`, etc.). Same anti-pattern but not implicated in this storm.

## Test plan

- [x] `npx vitest run mcp-prompts use-server-state ChatInput` — 74 tests pass
- [x] `npx tsc --noEmit` — no new type errors in modified files (pre-existing errors on `main` unaffected)
- [ ] Reviewer: open Chat tab in `dev:hosted`, verify log count plateaus on idle and `POST /api/web/prompts/list-multi` does not repeat
- [ ] Reviewer: send a chat message and verify normal chat traffic still flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily stabilizes React memo/effect dependencies to avoid redundant network calls; behavior should only change in when prompt lists refetch, with small chance of missing a refetch if server ordering/signature handling is incorrect.
> 
> **Overview**
> Stops the chat prompts popover from repeatedly refetching the prompts list during parent re-renders by keying the fetch effect off a stable `selectedServers` signature (instead of the array reference) and early-returning when no servers are selected.
> 
> Also memoizes `connectedOrConnectingServerConfigs` in `useServerState` so consumers (e.g. `ChatTabV2`) don’t receive a new object each render, reducing downstream recomputation and preventing feedback-loop network traffic.
> 
> Adds a focused `PromptsPopover` test to assert no refetch on identical server lists across rerenders and that refetch still occurs when the selected servers actually change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34b065e08c660babc0765aa320b3d01eda939a16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->