### PR TITLE
feat(evals): suite-level Default Execution Config editor

### DIFF
--- a/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/CiEvalsTab.tsx
@@ -282,6 +282,7 @@ export function CiEvalsTab({
     latestRunBySuiteId,
     evalsNavigationContext: "ci-evals",
     projectServers: ciProjectServers,
+    availableModels,
   });
 
   const suiteAggregate = useMemo(() => {

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -150,6 +150,7 @@ export function EvalsTab({
     latestRunBySuiteId,
     projectServers,
     isDirectGuest,
+    availableModels,
   });
   const {
     deletingSuiteId,

--- a/mcpjam-inspector/client/src/components/evals/eval-runner.tsx
+++ b/mcpjam-inspector/client/src/components/evals/eval-runner.tsx
@@ -52,6 +52,8 @@ interface EvalRunnerProps {
   inline?: boolean;
   onSuccess?: (suiteId?: string) => void;
   preselectedServer?: string;
+  /** Pre-populate model selection from suite.defaultConfig.modelId. User can still change it. */
+  defaultModelId?: string;
 }
 
 type StepKey = (typeof WIZARD_STEPS)[number]["key"];
@@ -151,6 +153,7 @@ export function EvalRunner({
   inline = false,
   onSuccess,
   preselectedServer,
+  defaultModelId,
 }: EvalRunnerProps) {
   const [open, setOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -260,6 +263,18 @@ export function EvalRunner({
       return;
     }
 
+    // Suite defaultConfig takes precedence over stored preferences when present
+    if (defaultModelId) {
+      const suiteDefault = availableModels.find(
+        (m) => String(m.id) === defaultModelId,
+      );
+      if (suiteDefault) {
+        setSelectedModels([suiteDefault]);
+        setHasRestoredPreferences(true);
+        return;
+      }
+    }
+
     if (savedPreferences?.modelIds && savedPreferences.modelIds.length > 0) {
       const matches = availableModels.filter((model) =>
         savedPreferences.modelIds.includes(model.id),
@@ -270,7 +285,7 @@ export function EvalRunner({
     }
 
     setHasRestoredPreferences(true);
-  }, [availableModels, savedPreferences, hasRestoredPreferences]);
+  }, [availableModels, savedPreferences, hasRestoredPreferences, defaultModelId]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;

--- a/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from "react";
+import { Loader2, Settings2 } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { Label } from "@mcpjam/design-system/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
+import { Slider } from "@mcpjam/design-system/slider";
+import { Textarea } from "@mcpjam/design-system/textarea";
+import type { EvalSuite } from "./types";
+import type { ModelDefinition } from "@/shared/types";
+
+type SuiteExecutionConfigEditorProps = {
+  suite: Pick<EvalSuite, "_id" | "defaultConfig">;
+  availableModels: ModelDefinition[];
+  onSave: (
+    defaultConfig: NonNullable<EvalSuite["defaultConfig"]>
+  ) => Promise<void>;
+};
+
+const DEFAULT_TEMPERATURE = 0.7;
+
+export function SuiteExecutionConfigEditor({
+  suite,
+  availableModels,
+  onSave,
+}: SuiteExecutionConfigEditorProps) {
+  const [modelId, setModelId] = useState(suite.defaultConfig?.modelId ?? "");
+  const [systemPrompt, setSystemPrompt] = useState(
+    suite.defaultConfig?.systemPrompt ?? ""
+  );
+  const [temperature, setTemperature] = useState(
+    suite.defaultConfig?.temperature ?? DEFAULT_TEMPERATURE
+  );
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setModelId(suite.defaultConfig?.modelId ?? "");
+    setSystemPrompt(suite.defaultConfig?.systemPrompt ?? "");
+    setTemperature(suite.defaultConfig?.temperature ?? DEFAULT_TEMPERATURE);
+  }, [suite.defaultConfig]);
+
+  const savedModelId = suite.defaultConfig?.modelId ?? "";
+  const savedSystemPrompt = suite.defaultConfig?.systemPrompt ?? "";
+  const savedTemperature =
+    suite.defaultConfig?.temperature ?? DEFAULT_TEMPERATURE;
+
+  const isDirty =
+    modelId !== savedModelId ||
+    systemPrompt !== savedSystemPrompt ||
+    temperature !== savedTemperature;
+
+  const handleReset = () => {
+    setModelId(savedModelId);
+    setSystemPrompt(savedSystemPrompt);
+    setTemperature(savedTemperature);
+  };
+
+  const handleSave = async () => {
+    if (!modelId) return;
+    setIsSaving(true);
+    try {
+      await onSave({ modelId, systemPrompt, temperature });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <section className="space-y-3">
+      <div>
+        <h2 className="text-base font-semibold text-foreground">
+          Default Execution Config
+        </h2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          The model and parameters all iterations in this suite inherit. Per-case{" "}
+          <code className="rounded bg-muted px-1 py-0.5 text-[10px]">
+            advancedConfig
+          </code>{" "}
+          overrides take precedence.
+        </p>
+      </div>
+
+      <div className="space-y-4 rounded-xl border bg-card/60 p-4">
+        {/* Model */}
+        <div>
+          <Label className="text-xs font-medium text-muted-foreground">
+            Model
+          </Label>
+          <Select value={modelId} onValueChange={setModelId}>
+            <SelectTrigger className="mt-1.5 border-0 bg-muted/50 transition-colors hover:bg-muted">
+              <SelectValue placeholder="Select a model" />
+            </SelectTrigger>
+            <SelectContent>
+              {availableModels.map((model) => (
+                <SelectItem key={String(model.id)} value={String(model.id)}>
+                  {model.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* System prompt */}
+        <div>
+          <Label className="text-xs font-medium text-muted-foreground">
+            System prompt
+          </Label>
+          <p className="mb-1.5 mt-0.5 text-[10px] text-muted-foreground">
+            Instructions given to the model at the start of each run.
+          </p>
+          <Textarea
+            value={systemPrompt}
+            onChange={(e) => setSystemPrompt(e.target.value)}
+            placeholder="You are a helpful assistant…"
+            className="min-h-[80px] resize-y border-0 bg-muted/50 text-sm"
+          />
+        </div>
+
+        {/* Temperature */}
+        <div>
+          <div className="flex items-center justify-between">
+            <Label className="text-xs font-medium text-muted-foreground">
+              Temperature
+            </Label>
+            <span className="text-xs text-muted-foreground">
+              {temperature.toFixed(2)}
+            </span>
+          </div>
+          <Slider
+            min={0}
+            max={2}
+            step={0.05}
+            value={[temperature]}
+            onValueChange={(values) =>
+              setTemperature(values[0] ?? DEFAULT_TEMPERATURE)
+            }
+            className="mt-3"
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <Settings2 className="h-3.5 w-3.5" />
+          <span>
+            {modelId
+              ? `Default: ${modelId}`
+              : "No default model configured"}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleReset}
+            disabled={!isDirty || isSaving}
+          >
+            Reset
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => void handleSave()}
+            disabled={!isDirty || isSaving || !modelId}
+          >
+            {isSaving ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : null}
+            Save config
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
@@ -32,6 +32,7 @@ export function SuiteExecutionConfigEditor({
   onClear,
 }: SuiteExecutionConfigEditorProps) {
   const [modelId, setModelId] = useState(suite.defaultConfig?.modelId ?? "");
+  const [provider, setProvider] = useState(suite.defaultConfig?.provider ?? "");
   const [systemPrompt, setSystemPrompt] = useState(
     suite.defaultConfig?.systemPrompt ?? ""
   );
@@ -43,22 +44,26 @@ export function SuiteExecutionConfigEditor({
 
   useEffect(() => {
     setModelId(suite.defaultConfig?.modelId ?? "");
+    setProvider(suite.defaultConfig?.provider ?? "");
     setSystemPrompt(suite.defaultConfig?.systemPrompt ?? "");
     setTemperature(suite.defaultConfig?.temperature ?? DEFAULT_TEMPERATURE);
   }, [suite.defaultConfig]);
 
   const savedModelId = suite.defaultConfig?.modelId ?? "";
+  const savedProvider = suite.defaultConfig?.provider ?? "";
   const savedSystemPrompt = suite.defaultConfig?.systemPrompt ?? "";
   const savedTemperature =
     suite.defaultConfig?.temperature ?? DEFAULT_TEMPERATURE;
 
   const isDirty =
     modelId !== savedModelId ||
+    provider !== savedProvider ||
     systemPrompt !== savedSystemPrompt ||
     temperature !== savedTemperature;
 
   const handleReset = () => {
     setModelId(savedModelId);
+    setProvider(savedProvider);
     setSystemPrompt(savedSystemPrompt);
     setTemperature(savedTemperature);
   };
@@ -67,7 +72,7 @@ export function SuiteExecutionConfigEditor({
     if (!modelId) return;
     setIsSaving(true);
     try {
-      await onSave({ modelId, systemPrompt, temperature });
+      await onSave({ modelId, provider: provider || undefined, systemPrompt, temperature });
     } finally {
       setIsSaving(false);
     }
@@ -104,7 +109,14 @@ export function SuiteExecutionConfigEditor({
           <Label className="text-xs font-medium text-muted-foreground">
             Model
           </Label>
-          <Select value={modelId} onValueChange={setModelId}>
+          <Select
+            value={modelId}
+            onValueChange={(id) => {
+              setModelId(id);
+              const def = availableModels.find((m) => String(m.id) === id);
+              setProvider(def?.provider ?? "");
+            }}
+          >
             <SelectTrigger className="mt-1.5 border-0 bg-muted/50 transition-colors hover:bg-muted">
               <SelectValue placeholder="Select a model" />
             </SelectTrigger>

--- a/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Loader2, Settings2 } from "lucide-react";
+import { Loader2, Settings2, Trash2 } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
 import { Label } from "@mcpjam/design-system/label";
 import {
@@ -20,6 +20,7 @@ type SuiteExecutionConfigEditorProps = {
   onSave: (
     defaultConfig: NonNullable<EvalSuite["defaultConfig"]>
   ) => Promise<void>;
+  onClear?: () => Promise<void>;
 };
 
 const DEFAULT_TEMPERATURE = 0.7;
@@ -28,6 +29,7 @@ export function SuiteExecutionConfigEditor({
   suite,
   availableModels,
   onSave,
+  onClear,
 }: SuiteExecutionConfigEditorProps) {
   const [modelId, setModelId] = useState(suite.defaultConfig?.modelId ?? "");
   const [systemPrompt, setSystemPrompt] = useState(
@@ -37,6 +39,7 @@ export function SuiteExecutionConfigEditor({
     suite.defaultConfig?.temperature ?? DEFAULT_TEMPERATURE
   );
   const [isSaving, setIsSaving] = useState(false);
+  const [isClearing, setIsClearing] = useState(false);
 
   useEffect(() => {
     setModelId(suite.defaultConfig?.modelId ?? "");
@@ -67,6 +70,16 @@ export function SuiteExecutionConfigEditor({
       await onSave({ modelId, systemPrompt, temperature });
     } finally {
       setIsSaving(false);
+    }
+  };
+
+  const handleClear = async () => {
+    if (!onClear) return;
+    setIsClearing(true);
+    try {
+      await onClear();
+    } finally {
+      setIsClearing(false);
     }
   };
 
@@ -154,12 +167,29 @@ export function SuiteExecutionConfigEditor({
           </span>
         </div>
         <div className="flex items-center gap-2">
+          {onClear && suite.defaultConfig ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => void handleClear()}
+              disabled={isClearing || isSaving}
+              className="text-destructive hover:text-destructive"
+            >
+              {isClearing ? (
+                <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Trash2 className="mr-1 h-3.5 w-3.5" />
+              )}
+              Remove
+            </Button>
+          ) : null}
           <Button
             type="button"
             variant="ghost"
             size="sm"
             onClick={handleReset}
-            disabled={!isDirty || isSaving}
+            disabled={!isDirty || isSaving || isClearing}
           >
             Reset
           </Button>
@@ -167,7 +197,7 @@ export function SuiteExecutionConfigEditor({
             type="button"
             size="sm"
             onClick={() => void handleSave()}
-            disabled={!isDirty || isSaving || !modelId}
+            disabled={!isDirty || isSaving || isClearing || !modelId}
           >
             {isSaving ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
@@ -42,12 +42,30 @@ export function SuiteExecutionConfigEditor({
   const [isSaving, setIsSaving] = useState(false);
   const [isClearing, setIsClearing] = useState(false);
 
+  // Depend on scalar values, not the object reference: a parent re-render
+  // that produces a fresh `suite.defaultConfig` with identical values would
+  // otherwise stomp in-progress edits.
   useEffect(() => {
     setModelId(suite.defaultConfig?.modelId ?? "");
     setProvider(suite.defaultConfig?.provider ?? "");
     setSystemPrompt(suite.defaultConfig?.systemPrompt ?? "");
     setTemperature(suite.defaultConfig?.temperature ?? DEFAULT_TEMPERATURE);
-  }, [suite.defaultConfig]);
+  }, [
+    suite.defaultConfig?.modelId,
+    suite.defaultConfig?.provider,
+    suite.defaultConfig?.systemPrompt,
+    suite.defaultConfig?.temperature,
+  ]);
+
+  // For suites saved before provider was tracked, fall back to the first
+  // matching model so the Select still renders the saved choice. Computed at
+  // render time so we don't have to add availableModels as an effect dep
+  // (which would risk stomping in-progress edits on parent re-renders).
+  const displayProvider =
+    provider ||
+    (modelId
+      ? availableModels.find((m) => String(m.id) === modelId)?.provider ?? ""
+      : "");
 
   const savedModelId = suite.defaultConfig?.modelId ?? "";
   const savedProvider = suite.defaultConfig?.provider ?? "";
@@ -72,7 +90,12 @@ export function SuiteExecutionConfigEditor({
     if (!modelId) return;
     setIsSaving(true);
     try {
-      await onSave({ modelId, provider: provider || undefined, systemPrompt, temperature });
+      await onSave({
+        modelId,
+        provider: provider || displayProvider || undefined,
+        systemPrompt,
+        temperature,
+      });
     } finally {
       setIsSaving(false);
     }
@@ -109,23 +132,31 @@ export function SuiteExecutionConfigEditor({
           <Label className="text-xs font-medium text-muted-foreground">
             Model
           </Label>
+          {/* Encode provider into the Select value so colliding model ids
+              across providers (e.g. native OpenAI gpt-4o vs OpenRouter
+              gpt-4o) are saved with the correct provider. */}
           <Select
-            value={modelId}
-            onValueChange={(id) => {
-              setModelId(id);
-              const def = availableModels.find((m) => String(m.id) === id);
-              setProvider(def?.provider ?? "");
+            value={modelId ? `${displayProvider}:${modelId}` : ""}
+            onValueChange={(value) => {
+              const sep = value.indexOf(":");
+              const nextProvider = sep >= 0 ? value.slice(0, sep) : "";
+              const nextId = sep >= 0 ? value.slice(sep + 1) : value;
+              setProvider(nextProvider);
+              setModelId(nextId);
             }}
           >
             <SelectTrigger className="mt-1.5 border-0 bg-muted/50 transition-colors hover:bg-muted">
               <SelectValue placeholder="Select a model" />
             </SelectTrigger>
             <SelectContent>
-              {availableModels.map((model) => (
-                <SelectItem key={String(model.id)} value={String(model.id)}>
-                  {model.name}
-                </SelectItem>
-              ))}
+              {availableModels.map((model) => {
+                const value = `${model.provider}:${String(model.id)}`;
+                return (
+                  <SelectItem key={value} value={value}>
+                    {model.name}
+                  </SelectItem>
+                );
+              })}
             </SelectContent>
           </Select>
         </div>

--- a/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
@@ -144,6 +144,7 @@ export function SuiteExecutionConfigEditor({
               setProvider(nextProvider);
               setModelId(nextId);
             }}
+            disabled={isSaving || isClearing}
           >
             <SelectTrigger className="mt-1.5 border-0 bg-muted/50 transition-colors hover:bg-muted">
               <SelectValue placeholder="Select a model" />
@@ -174,6 +175,7 @@ export function SuiteExecutionConfigEditor({
             onChange={(e) => setSystemPrompt(e.target.value)}
             placeholder="You are a helpful assistant…"
             className="min-h-[80px] resize-y border-0 bg-muted/50 text-sm"
+            disabled={isSaving || isClearing}
           />
         </div>
 
@@ -196,6 +198,7 @@ export function SuiteExecutionConfigEditor({
               setTemperature(values[0] ?? DEFAULT_TEMPERATURE)
             }
             className="mt-3"
+            disabled={isSaving || isClearing}
           />
         </div>
       </div>

--- a/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
@@ -44,13 +44,16 @@ export function SuiteExecutionConfigEditor({
 
   // Depend on scalar values, not the object reference: a parent re-render
   // that produces a fresh `suite.defaultConfig` with identical values would
-  // otherwise stomp in-progress edits.
+  // otherwise stomp in-progress edits. `suite._id` is also a dep so drafts
+  // can't leak across suites when the editor stays mounted (parent doesn't
+  // key it by suite id) and two suites happen to share the same scalars.
   useEffect(() => {
     setModelId(suite.defaultConfig?.modelId ?? "");
     setProvider(suite.defaultConfig?.provider ?? "");
     setSystemPrompt(suite.defaultConfig?.systemPrompt ?? "");
     setTemperature(suite.defaultConfig?.temperature ?? DEFAULT_TEMPERATURE);
   }, [
+    suite._id,
     suite.defaultConfig?.modelId,
     suite.defaultConfig?.provider,
     suite.defaultConfig?.systemPrompt,

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -878,6 +878,27 @@ export function SuiteIterationsView({
                   throw error;
                 }
               }}
+              onClear={async () => {
+                try {
+                  await updateSuite({
+                    suiteId: suite._id,
+                    defaultConfig: null,
+                  });
+                  toast.success("Suite execution config removed");
+                } catch (error) {
+                  toast.error(
+                    getBillingErrorMessage(
+                      error,
+                      "Failed to remove suite execution config",
+                    ),
+                  );
+                  console.error(
+                    "Failed to remove suite execution config:",
+                    error,
+                  );
+                  throw error;
+                }
+              }}
             />
 
             {/* Suite Description Section */}

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -18,6 +18,7 @@ import { TestCaseDetailView } from "./test-case-detail-view";
 import { SuiteDashboard } from "./suite-dashboard";
 import { EvalExportModal } from "./eval-export-modal";
 import { SuiteEnvironmentEditor } from "./suite-environment-editor";
+import { SuiteExecutionConfigEditor } from "./suite-execution-config-editor";
 import { useSuiteData, useRunDetailData } from "./use-suite-data";
 import type {
   EvalCase,
@@ -852,6 +853,32 @@ export function SuiteIterationsView({
                 }}
               />
             ) : null}
+
+            <SuiteExecutionConfigEditor
+              suite={suite}
+              availableModels={availableModels}
+              onSave={async (defaultConfig) => {
+                try {
+                  await updateSuite({
+                    suiteId: suite._id,
+                    defaultConfig,
+                  });
+                  toast.success("Suite execution config updated");
+                } catch (error) {
+                  toast.error(
+                    getBillingErrorMessage(
+                      error,
+                      "Failed to update suite execution config",
+                    ),
+                  );
+                  console.error(
+                    "Failed to update suite execution config:",
+                    error,
+                  );
+                  throw error;
+                }
+              }}
+            />
 
             {/* Suite Description Section */}
             <div className="space-y-3">

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -47,6 +47,7 @@ export type EvalSuite = {
   tags?: string[];
   defaultConfig?: {
     modelId: string;
+    provider?: string;
     systemPrompt: string;
     temperature: number;
   };

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -45,6 +45,11 @@ export type EvalSuite = {
   };
   _creationTime?: number; // Convex auto field
   tags?: string[];
+  defaultConfig?: {
+    modelId: string;
+    systemPrompt: string;
+    temperature: number;
+  };
 };
 
 export type EvalCase = {

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -285,9 +285,14 @@ export function useEvalHandlers({
         : {};
 
       // Resolve the fallback model definition for cases with no per-case models.
+      // Disambiguate by provider when stored, so OpenRouter gpt-4o doesn't
+      // resolve to the native OpenAI gpt-4o if their ids collide.
       const suiteDefaultModelDef = suite.defaultConfig?.modelId
         ? (availableModels ?? []).find(
-            (m) => String(m.id) === suite.defaultConfig!.modelId
+            (m) =>
+              String(m.id) === suite.defaultConfig!.modelId &&
+              (!suite.defaultConfig!.provider ||
+                m.provider === suite.defaultConfig!.provider)
           )
         : undefined;
 

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -25,6 +25,7 @@ import { getSuiteReplayEligibility } from "./replay-eligibility";
 import type { useEvalMutations } from "./use-eval-mutations";
 import { authFetch } from "@/lib/session-token";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
+import type { ModelDefinition } from "@/shared/types";
 import {
   buildEvalConvexAuthPayload,
   getEvalApiEndpoints,
@@ -169,6 +170,8 @@ interface UseEvalHandlersProps {
   projectServers?: RemoteServer[];
   /** When true, this uses the direct-guest eval playground flow. */
   isDirectGuest?: boolean;
+  /** Available models; used to resolve provider when falling back to suite.defaultConfig.modelId. */
+  availableModels?: ModelDefinition[];
 }
 
 /**
@@ -186,6 +189,7 @@ export function useEvalHandlers({
   evalsNavigationContext = "evals",
   projectServers,
   isDirectGuest = false,
+  availableModels,
 }: UseEvalHandlersProps) {
   const convex = useConvex();
   const { getAccessToken } = useAuth();
@@ -278,8 +282,16 @@ export function useEvalHandlers({
           }
         : {};
 
+      // Resolve the fallback model definition for cases with no per-case models.
+      const suiteDefaultModelDef = suite.defaultConfig?.modelId
+        ? (availableModels ?? []).find(
+            (m) => String(m.id) === suite.defaultConfig!.modelId
+          )
+        : undefined;
+
       for (const testCase of testCases) {
-        if (!testCase.models || testCase.models.length === 0) {
+        const hasModels = testCase.models && testCase.models.length > 0;
+        if (!hasModels && !suiteDefaultModelDef) {
           continue;
         }
 
@@ -288,7 +300,18 @@ export function useEvalHandlers({
             ? { ...suiteDefaultAdvancedConfig, ...testCase.advancedConfig }
             : testCase.advancedConfig;
 
-        for (const modelConfig of testCase.models) {
+        // Use per-case models when present; fall back to suite default model.
+        const modelConfigs: Array<{ model: string; provider: string }> =
+          hasModels
+            ? testCase.models
+            : [
+                {
+                  model: suiteDefaultModelDef!.id as string,
+                  provider: suiteDefaultModelDef!.provider,
+                },
+              ];
+
+        for (const modelConfig of modelConfigs) {
           tests.push({
             title: testCase.title,
             query: testCase.query,
@@ -338,7 +361,7 @@ export function useEvalHandlers({
         providersNeeded,
       };
     },
-    [getTestCasesForRerun, getToken, hasToken]
+    [getTestCasesForRerun, getToken, hasToken, availableModels]
   );
 
   const handleReplayRun = useCallback(

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -270,20 +270,6 @@ export function useEvalHandlers({
       const tests: any[] = [];
       const providersNeeded = new Set<string>();
 
-      // Build a baseline advancedConfig from suite.defaultConfig so the runner
-      // inherits system prompt and temperature even when testCase.advancedConfig
-      // is empty. Per-case advancedConfig fields take precedence.
-      const suiteDefaultAdvancedConfig = suite.defaultConfig
-        ? {
-            ...(suite.defaultConfig.systemPrompt
-              ? { system: suite.defaultConfig.systemPrompt }
-              : {}),
-            ...(typeof suite.defaultConfig.temperature === "number"
-              ? { temperature: suite.defaultConfig.temperature }
-              : {}),
-          }
-        : {};
-
       // Resolve the fallback model definition for cases with no per-case models.
       // Disambiguate by provider when stored, so OpenRouter gpt-4o doesn't
       // resolve to the native OpenAI gpt-4o if their ids collide.
@@ -295,17 +281,24 @@ export function useEvalHandlers({
                 m.provider === suite.defaultConfig!.provider)
           )
         : undefined;
+      // Distinguish "no default set" from "default set but unresolvable"
+      // (e.g. model removed, availableModels still loading) so we can show a
+      // more useful toast than "add models to your test cases".
+      const suiteDefaultUnresolved =
+        !!suite.defaultConfig?.modelId && !suiteDefaultModelDef;
+
+      // Note: suite.defaultConfig.systemPrompt / temperature are NOT merged
+      // into per-case advancedConfig here. The wire field flows through the
+      // server's testCase upsert path and would bake the suite default into
+      // every per-case advancedConfig, breaking later edits to the suite
+      // default. Runtime application of suite defaults happens server-side
+      // (Convex testSuiteRun hostConfigId snapshot).
 
       for (const testCase of testCases) {
         const hasModels = testCase.models && testCase.models.length > 0;
         if (!hasModels && !suiteDefaultModelDef) {
           continue;
         }
-
-        const mergedAdvancedConfig =
-          Object.keys(suiteDefaultAdvancedConfig).length > 0
-            ? { ...suiteDefaultAdvancedConfig, ...testCase.advancedConfig }
-            : testCase.advancedConfig;
 
         // Use per-case models when present; fall back to suite default model.
         const modelConfigs: Array<{ model: string; provider: string }> =
@@ -330,7 +323,7 @@ export function useEvalHandlers({
             scenario: testCase.scenario,
             expectedOutput: testCase.expectedOutput,
             promptTurns: testCase.promptTurns,
-            advancedConfig: mergedAdvancedConfig,
+            advancedConfig: testCase.advancedConfig,
             testCaseId: testCase._id,
           });
 
@@ -341,7 +334,16 @@ export function useEvalHandlers({
       }
 
       if (tests.length === 0) {
-        toast.error("No tests to run. Please add models to your test cases.");
+        if (suiteDefaultUnresolved) {
+          const label = suite.defaultConfig?.provider
+            ? `${suite.defaultConfig.modelId} (${suite.defaultConfig.provider})`
+            : suite.defaultConfig?.modelId;
+          toast.error(
+            `Suite default model ${label} is not available. Re-select it in the suite's default execution config, or add per-case models.`
+          );
+        } else {
+          toast.error("No tests to run. Please add models to your test cases.");
+        }
         return null;
       }
 

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -266,10 +266,27 @@ export function useEvalHandlers({
       const tests: any[] = [];
       const providersNeeded = new Set<string>();
 
+      // Build a baseline advancedConfig from suite.defaultConfig so the runner
+      // inherits system prompt and temperature even when testCase.advancedConfig
+      // is empty. Per-case advancedConfig fields take precedence.
+      const suiteDefaultAdvancedConfig = suite.defaultConfig
+        ? {
+            ...(suite.defaultConfig.systemPrompt
+              ? { system: suite.defaultConfig.systemPrompt }
+              : {}),
+            temperature: suite.defaultConfig.temperature,
+          }
+        : {};
+
       for (const testCase of testCases) {
         if (!testCase.models || testCase.models.length === 0) {
           continue;
         }
+
+        const mergedAdvancedConfig =
+          Object.keys(suiteDefaultAdvancedConfig).length > 0
+            ? { ...suiteDefaultAdvancedConfig, ...testCase.advancedConfig }
+            : testCase.advancedConfig;
 
         for (const modelConfig of testCase.models) {
           tests.push({
@@ -283,7 +300,7 @@ export function useEvalHandlers({
             scenario: testCase.scenario,
             expectedOutput: testCase.expectedOutput,
             promptTurns: testCase.promptTurns,
-            advancedConfig: testCase.advancedConfig,
+            advancedConfig: mergedAdvancedConfig,
             testCaseId: testCase._id,
           });
 

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -579,6 +579,10 @@ export function useEvalHandlers({
             minimumPassRate: minimumPassRate,
           },
           notes: criteriaNote,
+          // Cases are already persisted; tell the server to skip the
+          // per-case upsert so suite-default-derived wire fields don't
+          // get baked into per-case overrides.
+          suiteRerun: true,
         });
 
         // Track suite run started

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -278,7 +278,9 @@ export function useEvalHandlers({
             ...(suite.defaultConfig.systemPrompt
               ? { system: suite.defaultConfig.systemPrompt }
               : {}),
-            temperature: suite.defaultConfig.temperature,
+            ...(typeof suite.defaultConfig.temperature === "number"
+              ? { temperature: suite.defaultConfig.temperature }
+              : {}),
           }
         : {};
 

--- a/mcpjam-inspector/client/src/lib/apis/evals-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/evals-api.ts
@@ -61,6 +61,13 @@ type RunEvalsRequest = EvalRequestWithServers & {
   passCriteria?: {
     minimumPassRate: number;
   };
+  /**
+   * True for suite reruns of already-persisted cases. Tells the server to
+   * skip the per-case upsert path so suite-default-derived wire fields
+   * (substituted models, merged advancedConfig) don't get baked into
+   * per-case overrides.
+   */
+  suiteRerun?: boolean;
 };
 
 type RunTestCaseRequest = EvalRequestWithServers & {

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -93,6 +93,14 @@ export const RunEvalsRequestSchema = z.object({
       minimumPassRate: z.number(),
     })
     .optional(),
+  /**
+   * When true, the request is a rerun of an already-persisted suite — skip
+   * the per-test-case upsert. Without this, derived wire fields (suite
+   * default model substituted in for model-less cases, merged advancedConfig)
+   * get baked into per-case overrides on first rerun, breaking later edits
+   * to the suite default.
+   */
+  suiteRerun: z.boolean().optional(),
 });
 
 export type RunEvalsRequest = z.infer<typeof RunEvalsRequestSchema>;
@@ -295,6 +303,7 @@ export async function runEvalsWithManager(
     convexAuthToken,
     notes,
     passCriteria,
+    suiteRerun,
   } = request;
 
   if (!suiteId && (!suiteName || suiteName.trim().length === 0)) {
@@ -381,6 +390,14 @@ export async function runEvalsWithManager(
       environment: persistedEnvironment,
     });
 
+    // On a suite rerun, do NOT upsert per-case fields. The wire payload
+    // contains values derived from suite.defaultConfig (model substituted in
+    // for model-less cases, etc.); writing them back would bake the current
+    // suite default into per-case overrides and stop later default changes
+    // from propagating. Cases are already persisted; rerun just runs them.
+    if (suiteRerun) {
+      // skip upsert
+    } else {
     const existingTestCases = await convexClient.query(
       "testSuites:listTestCases" as any,
       { suiteId: resolvedSuiteId },
@@ -483,6 +500,7 @@ export async function runEvalsWithManager(
           ),
         });
       }
+    }
     }
   } else {
     const createdSuite = await convexClient.mutation(


### PR DESCRIPTION
## Summary

Adds a **Default Execution Config** card to the suite settings edit panel, letting users set a suite-wide default model, system prompt, and temperature. This config is stored on `testSuite.defaultConfig` (wired in the backend PR [mcpjam-backend#227](https://github.com/MCPJam/mcpjam-backend/pull/227)) and snapshotted into each run's `testSuiteRun.hostConfigId`.

- **`types.ts`**: adds `defaultConfig?: { modelId, systemPrompt, temperature }` to `EvalSuite`
- **`suite-execution-config-editor.tsx`** (new): settings card with model `<Select>`, system prompt `<Textarea>`, and temperature `<Slider>`; saves via `updateTestSuite`
- **`suite-iterations-view.tsx`**: mounts `SuiteExecutionConfigEditor` in edit mode, directly below the `SuiteEnvironmentEditor`
- **`eval-runner.tsx`**: optional `defaultModelId` prop pre-populates model selection from `suite.defaultConfig.modelId` (user can still change before running)

## Test plan

- [ ] Open a suite in edit mode — verify "Default Execution Config" card appears below "Servers"
- [ ] Set model + prompt + temperature and click "Save config" — verify toast success
- [ ] Re-open edit mode — verify saved values are restored
- [ ] Reset button reverts unsaved changes
- [ ] Suite with no `defaultConfig` shows empty state with "No default model configured"
- [ ] Verify `testSuite.defaultConfig` is persisted to the backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes eval run/rerun request semantics and server-side persistence behavior (skipping test-case upserts on reruns) while adding new suite-level configuration fields that affect model selection.
> 
> **Overview**
> Adds a **suite-level “Default Execution Config”** (model/provider, system prompt, temperature) stored on `EvalSuite.defaultConfig`, including a new `SuiteExecutionConfigEditor` mounted in suite edit mode and wiring `availableModels` through the tabs/handlers.
> 
> Updates execution flows to **use suite defaults as a fallback** when test cases have no per-case models, and to disambiguate provider/model id collisions; the eval runner can also preselect a model via `defaultModelId`.
> 
> Introduces a `suiteRerun` flag on `runEvals` requests and updates the server `RunEvalsRequest` handling to **skip per-test-case upserts on suite reruns**, preventing suite-default-derived fields from being baked into per-case overrides (with improved error messaging when the suite default model can’t be resolved).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eaec8120e801b32152667b02205cd3701a98815. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->