### PR TITLE
Use actor key for PostHog identification instead of auth state

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -650,16 +650,19 @@ export default function App() {
 
   usePostHogIdentify();
 
+  const lastLaunchedActorRef = useRef<string | null>(null);
   useEffect(() => {
-    if (isAuthLoading) return;
+    if (!actorKey) return;
+    if (lastLaunchedActorRef.current === actorKey) return;
+    lastLaunchedActorRef.current = actorKey;
     posthog.capture("app_launched", {
       platform: detectPlatform(),
       environment: detectEnvironment(),
       user_agent: navigator.userAgent,
       version: __APP_VERSION__,
-      is_authenticated: isAuthenticated,
+      is_authenticated: Boolean(workOsUser),
     });
-  }, [isAuthLoading, isAuthenticated]);
+  }, [actorKey, workOsUser, posthog]);
 
   // Set the initial theme mode and preset on page load
   const initialThemeMode = getInitialThemeMode();

--- a/mcpjam-inspector/client/src/hooks/__tests__/usePostHogIdentify.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/usePostHogIdentify.test.ts
@@ -20,6 +20,7 @@ const mockState = vi.hoisted(() => ({
     isAuthenticated: false,
   },
   convexUser: null as { occupation?: string } | null,
+  actorKey: null as string | null,
   detectPlatform: vi.fn(() => "mac"),
 }));
 
@@ -40,6 +41,10 @@ vi.mock("@/lib/PosthogUtils", () => ({
   detectPlatform: mockState.detectPlatform,
 }));
 
+vi.mock("@/hooks/use-actor-key", () => ({
+  useActorKey: () => mockState.actorKey,
+}));
+
 describe("usePostHogIdentify", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -47,6 +52,7 @@ describe("usePostHogIdentify", () => {
     mockState.auth.user = null;
     mockState.convexAuth.isAuthenticated = false;
     mockState.convexUser = null;
+    mockState.actorKey = null;
     mockState.detectPlatform.mockReturnValue("mac");
   });
 
@@ -58,6 +64,7 @@ describe("usePostHogIdentify", () => {
       lastName: "Smith",
     };
     mockState.convexAuth.isAuthenticated = true;
+    mockState.actorKey = "user_123";
 
     renderHook(() => usePostHogIdentify());
 
@@ -73,18 +80,49 @@ describe("usePostHogIdentify", () => {
     expect(mockState.posthog.reset).not.toHaveBeenCalled();
   });
 
-  it("re-registers static telemetry properties after logout reset", () => {
+  it("identifies guests with their guestId and does not call reset", () => {
+    mockState.auth.user = null;
+    mockState.convexAuth.isAuthenticated = false;
+    mockState.actorKey = "guest_abc";
+
     renderHook(() => usePostHogIdentify());
 
-    expect(mockState.posthog.reset).toHaveBeenCalledTimes(1);
+    expect(mockState.posthog.identify).toHaveBeenCalledWith("guest_abc", {});
     expect(mockState.posthog.register).toHaveBeenCalledWith({
-      environment: import.meta.env.MODE,
-      platform: "mac",
-      version: "2.0.13-test",
+      user_id: "guest_abc",
     });
+    expect(mockState.posthog.reset).not.toHaveBeenCalled();
   });
 
-  it("resets and re-registers static telemetry properties when auth changes from logged in to logged out", () => {
+  it("does nothing while the actor key is still resolving", () => {
+    mockState.auth.user = null;
+    mockState.actorKey = null;
+
+    renderHook(() => usePostHogIdentify());
+
+    expect(mockState.posthog.identify).not.toHaveBeenCalled();
+    expect(mockState.posthog.register).not.toHaveBeenCalled();
+    expect(mockState.posthog.reset).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent across re-renders with the same guest actor key", () => {
+    mockState.auth.user = null;
+    mockState.actorKey = "guest_abc";
+
+    const { rerender } = renderHook(() => usePostHogIdentify());
+
+    expect(mockState.posthog.identify).toHaveBeenCalledTimes(1);
+    expect(mockState.posthog.register).toHaveBeenCalledTimes(1);
+
+    rerender();
+    rerender();
+
+    expect(mockState.posthog.identify).toHaveBeenCalledTimes(1);
+    expect(mockState.posthog.register).toHaveBeenCalledTimes(1);
+    expect(mockState.posthog.reset).not.toHaveBeenCalled();
+  });
+
+  it("resets and re-registers static telemetry properties when an authed user signs out into a guest session", () => {
     mockState.auth.user = {
       id: "user_123",
       email: "user@example.com",
@@ -92,6 +130,7 @@ describe("usePostHogIdentify", () => {
       lastName: "Smith",
     };
     mockState.convexAuth.isAuthenticated = true;
+    mockState.actorKey = "user_123";
 
     const { rerender } = renderHook(() => usePostHogIdentify());
 
@@ -106,6 +145,7 @@ describe("usePostHogIdentify", () => {
 
     mockState.auth.user = null;
     mockState.convexAuth.isAuthenticated = false;
+    mockState.actorKey = "guest_abc";
 
     rerender();
 
@@ -115,7 +155,44 @@ describe("usePostHogIdentify", () => {
       platform: "mac",
       version: "2.0.13-test",
     });
-    expect(mockState.posthog.identify).not.toHaveBeenCalled();
+    expect(mockState.posthog.identify).toHaveBeenCalledWith("guest_abc", {});
+    expect(mockState.posthog.register).toHaveBeenCalledWith({
+      user_id: "guest_abc",
+    });
+  });
+
+  it("aliases a guest into an authed user without calling reset on guest→authed promotion", () => {
+    mockState.auth.user = null;
+    mockState.convexAuth.isAuthenticated = false;
+    mockState.actorKey = "guest_abc";
+
+    const { rerender } = renderHook(() => usePostHogIdentify());
+
+    expect(mockState.posthog.identify).toHaveBeenCalledWith("guest_abc", {});
+
+    vi.clearAllMocks();
+
+    mockState.auth.user = {
+      id: "user_123",
+      email: "user@example.com",
+      firstName: "Taylor",
+      lastName: "Smith",
+    };
+    mockState.convexAuth.isAuthenticated = true;
+    mockState.actorKey = "user_123";
+
+    rerender();
+
+    expect(mockState.posthog.reset).not.toHaveBeenCalled();
+    expect(mockState.posthog.identify).toHaveBeenCalledWith("user_123", {
+      email: "user@example.com",
+      name: "Taylor Smith",
+      first_name: "Taylor",
+      last_name: "Smith",
+    });
+    expect(mockState.posthog.register).toHaveBeenCalledWith({
+      user_id: "user_123",
+    });
   });
 
   it("adds trimmed occupation when the Convex user has one", () => {
@@ -126,6 +203,7 @@ describe("usePostHogIdentify", () => {
       lastName: "Smith",
     };
     mockState.convexAuth.isAuthenticated = true;
+    mockState.actorKey = "user_123";
     mockState.convexUser = { occupation: "  Platform Engineer  " };
 
     renderHook(() => usePostHogIdentify());
@@ -147,6 +225,7 @@ describe("usePostHogIdentify", () => {
       lastName: "Smith",
     };
     mockState.convexAuth.isAuthenticated = true;
+    mockState.actorKey = "user_123";
     mockState.convexUser = { occupation: "   " };
 
     renderHook(() => usePostHogIdentify());

--- a/mcpjam-inspector/client/src/hooks/usePostHogIdentify.ts
+++ b/mcpjam-inspector/client/src/hooks/usePostHogIdentify.ts
@@ -1,12 +1,15 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { usePostHog } from "posthog-js/react";
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth, useQuery } from "convex/react";
 import { detectPlatform } from "@/lib/PosthogUtils";
+import { useActorKey } from "@/hooks/use-actor-key";
 
 /**
- * Automatically identify users in PostHog when they log in/out
- * and set super properties that are sent with every event.
+ * Identify the active actor in PostHog using the same id the backend uses:
+ * the WorkOS user id for signed-in users, the cookie-backed guestId for
+ * guests. Reset only on a true identity switch away from an authed user, so
+ * the same browser revisiting as a guest keeps a stable distinct_id.
  */
 export function usePostHogIdentify() {
   const posthog = usePostHog();
@@ -16,13 +19,31 @@ export function usePostHogIdentify() {
     "users:getCurrentUser" as any,
     isAuthenticated ? ({} as any) : "skip"
   );
+  const actorKey = useActorKey();
+  const previousActorRef = useRef<{ key: string; wasAuthed: boolean } | null>(
+    null
+  );
 
   useEffect(() => {
     if (!posthog) return;
+    if (!actorKey) return;
 
-    // User is authenticated - identify them
-    if (isAuthenticated && user) {
-      const personProperties: Record<string, string | null | undefined> = {
+    const previous = previousActorRef.current;
+    const isActorChange = !previous || previous.key !== actorKey;
+    const isAuthedActor = Boolean(user) && user?.id === actorKey;
+
+    if (isActorChange && previous?.wasAuthed) {
+      posthog.reset();
+      posthog.register({
+        environment: import.meta.env.MODE,
+        platform: detectPlatform(),
+        version: __APP_VERSION__,
+      });
+    }
+
+    let personProperties: Record<string, string | null | undefined> = {};
+    if (isAuthedActor && user) {
+      personProperties = {
         email: user.email,
         name:
           user.firstName && user.lastName
@@ -31,7 +52,6 @@ export function usePostHogIdentify() {
         first_name: user.firstName,
         last_name: user.lastName,
       };
-
       const trimmedOccupation =
         typeof convexUser?.occupation === "string"
           ? convexUser.occupation.trim()
@@ -39,22 +59,12 @@ export function usePostHogIdentify() {
       if (trimmedOccupation) {
         personProperties.occupation = trimmedOccupation;
       }
-
-      // Identify the user with their WorkOS ID
-      posthog.identify(user.id, personProperties);
-
-      posthog.register({
-        user_id: user.id,
-      });
-    } else {
-      // User logged out - reset PostHog
-      posthog.reset();
-      // Re-register static props after reset so anonymous events still have them
-      posthog.register({
-        environment: import.meta.env.MODE,
-        platform: detectPlatform(),
-        version: __APP_VERSION__,
-      });
     }
-  }, [posthog, isAuthenticated, user, convexUser]);
+
+    posthog.identify(actorKey, personProperties);
+    if (isActorChange) {
+      posthog.register({ user_id: actorKey });
+      previousActorRef.current = { key: actorKey, wasAuthed: isAuthedActor };
+    }
+  }, [posthog, actorKey, user, convexUser]);
 }


### PR DESCRIPTION
## Summary
Refactored PostHog identification to use a stable actor key (WorkOS user ID for authenticated users, guest ID for guests) instead of relying on authentication state. This ensures consistent user tracking across authentication transitions and prevents unnecessary resets when guests revisit.

## Key Changes
- **Introduced `useActorKey` hook**: Centralized source of truth for the current actor's identifier, replacing direct auth state checks
- **Removed PostHog reset on logout**: Only reset when transitioning away from an authenticated user (true identity switch), not when becoming a guest
- **Added idempotency tracking**: Uses `useRef` to track previous actor state and prevent duplicate PostHog calls on re-renders
- **Guest identification**: Guests are now properly identified with their guestId instead of being treated as anonymous
- **Guest→authed promotion**: When a guest signs up, they're identified with their new user ID without a reset, preserving analytics continuity
- **Updated app_launched event**: Now uses `actorKey` to determine when a new actor has launched the app, and uses `workOsUser` instead of `isAuthenticated` for the flag

## Implementation Details
- The `previousActorRef` tracks both the actor key and whether they were authenticated, enabling intelligent reset logic
- Person properties are only set for authenticated actors; guests get empty properties
- `user_id` is registered on every actor change to ensure PostHog has the correct identifier
- Tests comprehensively cover: authenticated users, guests, actor transitions, idempotency, and the guest→authed promotion flow

https://claude.ai/code/session_01PuDjab7fUNkn7cmqrtexqz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches analytics identity management (identify/reset/register) and changes when resets occur across auth/guest transitions, which can affect event attribution and user profiles if incorrect.
> 
> **Overview**
> Refactors PostHog identification to use a stable `actorKey` (WorkOS user id or guest id) rather than Convex auth state, and adds per-actor idempotency so `identify`/`register` only re-run on real actor changes.
> 
> Updates reset behavior to only `posthog.reset()` when switching away from an authenticated actor (while still re-registering static props), and updates the `app_launched` event to fire once per actor and to derive `is_authenticated` from `workOsUser` instead of `isAuthenticated`. Tests are expanded to cover guest identification, actor-key resolution, idempotency, and guest↔authed transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e966eab9fd99ddf4959e12ba07ebaa87cfd4af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->