### PR TITLE
Phase 3: HostConfig v2 read switch (inspector)

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -387,6 +387,14 @@ export function ChatTabV2({
       oauthTokens: effectiveHostedOAuthTokens,
     },
     executionConfig,
+    // Phase 3: forward the resolved chat-tab host style so direct
+    // chat traces persist with `claude`/`chatgpt` rather than
+    // defaulting to `'claude'` regardless of user choice. Backend
+    // ingestion ignores it for chatbox flows (those resolve from the
+    // chatbox row), so it's safe to forward unconditionally.
+    hostStyle: hostStyle === "claude" || hostStyle === "chatgpt"
+      ? hostStyle
+      : undefined,
     minimalMode,
     onReset: (reason?: ChatSessionResetReason) => {
       if (reason === "auth-bootstrap" || reason === "hydrate") {

--- a/mcpjam-inspector/client/src/components/ProjectSettingsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ProjectSettingsTab.tsx
@@ -6,6 +6,7 @@ import { ProjectSlackIntegrationSection } from "./setting/ProjectSlackIntegratio
 import { ProjectMembersFacepile } from "./project/ProjectMembersFacepile";
 import { ProjectShareButton } from "./project/ProjectShareButton";
 import { ProjectIconPicker } from "./project/ProjectEmojiPicker";
+import { ProjectDefaultHostConfigSection } from "./host-config/ProjectDefaultHostConfigSection";
 
 import { Button } from "@mcpjam/design-system/button";
 import {
@@ -166,6 +167,17 @@ export function ProjectSettingsTab({
             canManageIntegration={canManageMembers}
           />
         </div>
+
+        {/* Default Host Config — seed for new chatboxes, eval suites,
+            and direct chat tabs. Editing it does not change existing
+            chatboxes or suites. */}
+        {isAuthenticated && convexProjectId ? (
+          <ProjectDefaultHostConfigSection
+            convexProjectId={convexProjectId}
+            projectServers={projectServers}
+            canManage={canManageProjectSettings}
+          />
+        ) : null}
 
         {/* Danger Zone */}
         <div className="space-y-2">

--- a/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Loader2, RotateCcw, Save, Settings2, Trash2 } from "lucide-react";
 import { useMutation, useQuery } from "convex/react";
 import { toast } from "sonner";
@@ -76,8 +76,16 @@ export function SuiteExecutionConfigEditor({
   const legacyModelId = suite.defaultConfig?.modelId;
   const legacySystemPrompt = suite.defaultConfig?.systemPrompt;
   const legacyTemperature = suite.defaultConfig?.temperature;
+  // Track the previous suite id so a suite switch ALWAYS resets
+  // state — including unsaved edits. Without this, the dirty-check
+  // below sees the OLD suite's baseline (stale closure: baseline is
+  // intentionally excluded from deps) and decides "user has unsaved
+  // edits, preserve them", leaking suite A's edits into suite B.
+  const prevSuiteIdRef = useRef<typeof suite._id | null>(null);
   useEffect(() => {
     if (dto === undefined) return; // still loading
+    const isSuiteSwitch = prevSuiteIdRef.current !== suite._id;
+    prevSuiteIdRef.current = suite._id;
     const next = dto
       ? hostConfigDtoToInput(dto)
       : emptyHostConfigInputV2({
@@ -91,15 +99,21 @@ export function SuiteExecutionConfigEditor({
         });
     setBaseline(next);
     setValue((current) => {
+      // Suite switch: hard reset — never preserve previous suite's
+      // edits. The dirty check below would compare suite A's edits
+      // against suite A's stale baseline (closure capture) and
+      // wrongly preserve them under suite B.
+      if (isSuiteSwitch) return next;
       if (current && baseline && !hostConfigInputsEqual(current, baseline)) {
-        return current; // preserve unsaved edits
+        return current; // preserve unsaved edits within the same suite
       }
       return next;
     });
     // baseline is intentionally excluded — including it would re-run
     // every save (we setBaseline above), causing an instant value
     // overwrite on save success. The dep set covers every external
-    // input the seed depends on.
+    // input the seed depends on, and the prevSuiteIdRef guards the
+    // cross-suite stale-closure case.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dto, suite._id, legacyModelId, legacySystemPrompt, legacyTemperature]);
 

--- a/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Loader2, RotateCcw, Save, Settings2, Trash2 } from "lucide-react";
 import { useMutation, useQuery } from "convex/react";
+import { toast } from "sonner";
 import { Button } from "@mcpjam/design-system/button";
 import { HostConfigEditor } from "@/components/host-config/HostConfigEditor";
 import {
@@ -10,6 +11,7 @@ import {
   type HostConfigDtoV2,
   type HostConfigInputV2,
 } from "@/lib/host-config-v2";
+import { getBillingErrorMessage } from "@/lib/billing-entitlements";
 import type { EvalSuite } from "./types";
 import type { ModelDefinition } from "@/shared/types";
 
@@ -65,6 +67,15 @@ export function SuiteExecutionConfigEditor({
   const [isSaving, setIsSaving] = useState(false);
   const [isClearing, setIsClearing] = useState(false);
 
+  // Track the scalar fields the legacy fallback reads so the editor
+  // re-seeds when the parent clears `suite.defaultConfig` via
+  // `onClear` without replacing the suite (suite._id is stable, but
+  // `defaultConfig` flips from object to undefined). Without these
+  // deps, the editor keeps showing the cleared values until the user
+  // navigates away and back.
+  const legacyModelId = suite.defaultConfig?.modelId;
+  const legacySystemPrompt = suite.defaultConfig?.systemPrompt;
+  const legacyTemperature = suite.defaultConfig?.temperature;
   useEffect(() => {
     if (dto === undefined) return; // still loading
     const next = dto
@@ -74,9 +85,9 @@ export function SuiteExecutionConfigEditor({
           // temperature} when the v2 row hasn't been written yet — so a
           // first-time save through HostConfigEditor doesn't blow away
           // a legacy-only suite config.
-          modelId: suite.defaultConfig?.modelId,
-          systemPrompt: suite.defaultConfig?.systemPrompt,
-          temperature: suite.defaultConfig?.temperature,
+          modelId: legacyModelId,
+          systemPrompt: legacySystemPrompt,
+          temperature: legacyTemperature,
         });
     setBaseline(next);
     setValue((current) => {
@@ -85,8 +96,12 @@ export function SuiteExecutionConfigEditor({
       }
       return next;
     });
+    // baseline is intentionally excluded — including it would re-run
+    // every save (we setBaseline above), causing an instant value
+    // overwrite on save success. The dep set covers every external
+    // input the seed depends on.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dto, suite._id]);
+  }, [dto, suite._id, legacyModelId, legacySystemPrompt, legacyTemperature]);
 
   const isDirty = useMemo(
     () =>
@@ -132,8 +147,20 @@ export function SuiteExecutionConfigEditor({
       await setSuiteConfig({ suiteId: suite._id, input: stripped });
       setBaseline(stripped);
       setValue(stripped);
+      toast.success("Suite execution config updated");
     } catch (err) {
-      throw err;
+      // Surface the failure to the user; do NOT rethrow. The button's
+      // onClick wraps this in `() => void handleSave()`, so a thrown
+      // error becomes an unhandled promise rejection with no UI
+      // feedback. Mirrors the parent-provided onSave handler the
+      // pre-Phase-3 component used.
+      toast.error(
+        getBillingErrorMessage(
+          err,
+          "Failed to update suite execution config",
+        ),
+      );
+      console.error("Failed to update suite execution config:", err);
     } finally {
       setIsSaving(false);
     }

--- a/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
@@ -1,104 +1,139 @@
-import { useEffect, useState } from "react";
-import { Loader2, Settings2, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Loader2, RotateCcw, Save, Settings2, Trash2 } from "lucide-react";
+import { useMutation, useQuery } from "convex/react";
 import { Button } from "@mcpjam/design-system/button";
-import { Label } from "@mcpjam/design-system/label";
+import { HostConfigEditor } from "@/components/host-config/HostConfigEditor";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@mcpjam/design-system/select";
-import { Slider } from "@mcpjam/design-system/slider";
-import { Textarea } from "@mcpjam/design-system/textarea";
+  emptyHostConfigInputV2,
+  hostConfigDtoToInput,
+  hostConfigInputsEqual,
+  type HostConfigDtoV2,
+  type HostConfigInputV2,
+} from "@/lib/host-config-v2";
 import type { EvalSuite } from "./types";
 import type { ModelDefinition } from "@/shared/types";
 
 type SuiteExecutionConfigEditorProps = {
   suite: Pick<EvalSuite, "_id" | "defaultConfig">;
   availableModels: ModelDefinition[];
-  onSave: (
-    defaultConfig: NonNullable<EvalSuite["defaultConfig"]>
-  ) => Promise<void>;
+  /**
+   * Optional clear callback — surfaces "Remove" affordance when the
+   * suite has a saved defaultConfig. The legacy mirror is cleared via
+   * the wider `updateTestSuite({ defaultConfig: null })` mutation
+   * which the parent owns, so we keep this as a callback rather than
+   * hardcoding the v1 path here.
+   */
   onClear?: () => Promise<void>;
 };
 
-const DEFAULT_TEMPERATURE = 0.7;
-
+/**
+ * Eval suite execution config editor.
+ *
+ * Phase 3 read switch: the editor now reads + writes through the v2
+ * `hostConfigsV2.{getSuiteConfig,setSuiteConfig}` API. Server selection
+ * is hidden (servers come from `suite.environment`; the backend rejects
+ * non-empty serverIds), but model / system prompt / temperature /
+ * tool-approval / connection-defaults / capabilities / hostContext are
+ * all editable through the shared HostConfigEditor.
+ *
+ * `setSuiteConfig` mirrors `{ modelId, systemPrompt, temperature }`
+ * back to `suite.defaultConfig` for legacy readers (run snapshot,
+ * inspector eval UI display labels) until Phase 5 drops the column.
+ */
 export function SuiteExecutionConfigEditor({
   suite,
   availableModels,
-  onSave,
   onClear,
 }: SuiteExecutionConfigEditorProps) {
-  const [modelId, setModelId] = useState(suite.defaultConfig?.modelId ?? "");
-  const [provider, setProvider] = useState(suite.defaultConfig?.provider ?? "");
-  const [systemPrompt, setSystemPrompt] = useState(
-    suite.defaultConfig?.systemPrompt ?? ""
-  );
-  const [temperature, setTemperature] = useState(
-    suite.defaultConfig?.temperature ?? DEFAULT_TEMPERATURE
-  );
+  void availableModels; // currently unused; HostConfigEditor uses a free-text modelId.
+
+  const dto = useQuery(
+    "hostConfigsV2:getSuiteConfig" as any,
+    { suiteId: suite._id } as any,
+  ) as HostConfigDtoV2 | null | undefined;
+
+  const setSuiteConfig = useMutation(
+    "hostConfigsV2:setSuiteConfig" as any,
+  ) as unknown as (args: {
+    suiteId: string;
+    input: HostConfigInputV2;
+  }) => Promise<string>;
+
+  const [value, setValue] = useState<HostConfigInputV2 | null>(null);
+  const [baseline, setBaseline] = useState<HostConfigInputV2 | null>(null);
+  const [hasJsonError, setHasJsonError] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isClearing, setIsClearing] = useState(false);
 
-  // Depend on scalar values, not the object reference: a parent re-render
-  // that produces a fresh `suite.defaultConfig` with identical values would
-  // otherwise stomp in-progress edits. `suite._id` is also a dep so drafts
-  // can't leak across suites when the editor stays mounted (parent doesn't
-  // key it by suite id) and two suites happen to share the same scalars.
   useEffect(() => {
-    setModelId(suite.defaultConfig?.modelId ?? "");
-    setProvider(suite.defaultConfig?.provider ?? "");
-    setSystemPrompt(suite.defaultConfig?.systemPrompt ?? "");
-    setTemperature(suite.defaultConfig?.temperature ?? DEFAULT_TEMPERATURE);
-  }, [
-    suite._id,
-    suite.defaultConfig?.modelId,
-    suite.defaultConfig?.provider,
-    suite.defaultConfig?.systemPrompt,
-    suite.defaultConfig?.temperature,
-  ]);
+    if (dto === undefined) return; // still loading
+    const next = dto
+      ? hostConfigDtoToInput(dto)
+      : emptyHostConfigInputV2({
+          // Seed empty editor with suite.defaultConfig.{modelId,systemPrompt,
+          // temperature} when the v2 row hasn't been written yet — so a
+          // first-time save through HostConfigEditor doesn't blow away
+          // a legacy-only suite config.
+          modelId: suite.defaultConfig?.modelId,
+          systemPrompt: suite.defaultConfig?.systemPrompt,
+          temperature: suite.defaultConfig?.temperature,
+        });
+    setBaseline(next);
+    setValue((current) => {
+      if (current && baseline && !hostConfigInputsEqual(current, baseline)) {
+        return current; // preserve unsaved edits
+      }
+      return next;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dto, suite._id]);
 
-  // For suites saved before provider was tracked, fall back to the first
-  // matching model so the Select still renders the saved choice. Computed at
-  // render time so we don't have to add availableModels as an effect dep
-  // (which would risk stomping in-progress edits on parent re-renders).
-  const displayProvider =
-    provider ||
-    (modelId
-      ? availableModels.find((m) => String(m.id) === modelId)?.provider ?? ""
-      : "");
+  const isDirty = useMemo(
+    () =>
+      value && baseline ? !hostConfigInputsEqual(value, baseline) : !!value,
+    [value, baseline],
+  );
 
-  const savedModelId = suite.defaultConfig?.modelId ?? "";
-  const savedProvider = suite.defaultConfig?.provider ?? "";
-  const savedSystemPrompt = suite.defaultConfig?.systemPrompt ?? "";
-  const savedTemperature =
-    suite.defaultConfig?.temperature ?? DEFAULT_TEMPERATURE;
+  if (!value) {
+    return (
+      <section className="space-y-3">
+        <div>
+          <h2 className="text-base font-semibold text-foreground">
+            Default Execution Config
+          </h2>
+        </div>
+        <div className="flex items-center gap-2 rounded-xl border bg-card/60 p-4 text-xs text-muted-foreground">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          Loading suite config…
+        </div>
+      </section>
+    );
+  }
 
-  const isDirty =
-    modelId !== savedModelId ||
-    provider !== savedProvider ||
-    systemPrompt !== savedSystemPrompt ||
-    temperature !== savedTemperature;
+  // setSuiteConfig refuses non-empty serverIds; if a stale v2 row
+  // somehow carried any, force them empty before saving so the
+  // backend's validator doesn't reject the otherwise-valid edit.
+  // Server selection lives on `suite.environment`.
+  const stripped: HostConfigInputV2 = {
+    ...value,
+    serverIds: [],
+    optionalServerIds: [],
+  };
+  const canSave = isDirty && !hasJsonError && !isSaving && !isClearing;
 
   const handleReset = () => {
-    setModelId(savedModelId);
-    setProvider(savedProvider);
-    setSystemPrompt(savedSystemPrompt);
-    setTemperature(savedTemperature);
+    if (baseline) setValue(baseline);
   };
 
   const handleSave = async () => {
-    if (!modelId) return;
+    if (!canSave) return;
     setIsSaving(true);
     try {
-      await onSave({
-        modelId,
-        provider: provider || displayProvider || undefined,
-        systemPrompt,
-        temperature,
-      });
+      await setSuiteConfig({ suiteId: suite._id, input: stripped });
+      setBaseline(stripped);
+      setValue(stripped);
+    } catch (err) {
+      throw err;
     } finally {
       setIsSaving(false);
     }
@@ -125,93 +160,26 @@ export function SuiteExecutionConfigEditor({
           <code className="rounded bg-muted px-1 py-0.5 text-[10px]">
             advancedConfig
           </code>{" "}
-          overrides take precedence.
+          overrides take precedence. Server selection lives in the suite
+          environment, not here.
         </p>
       </div>
 
-      <div className="space-y-4 rounded-xl border bg-card/60 p-4">
-        {/* Model */}
-        <div>
-          <Label className="text-xs font-medium text-muted-foreground">
-            Model
-          </Label>
-          {/* Encode provider into the Select value so colliding model ids
-              across providers (e.g. native OpenAI gpt-4o vs OpenRouter
-              gpt-4o) are saved with the correct provider. */}
-          <Select
-            value={modelId ? `${displayProvider}:${modelId}` : ""}
-            onValueChange={(value) => {
-              const sep = value.indexOf(":");
-              const nextProvider = sep >= 0 ? value.slice(0, sep) : "";
-              const nextId = sep >= 0 ? value.slice(sep + 1) : value;
-              setProvider(nextProvider);
-              setModelId(nextId);
-            }}
-            disabled={isSaving || isClearing}
-          >
-            <SelectTrigger className="mt-1.5 border-0 bg-muted/50 transition-colors hover:bg-muted">
-              <SelectValue placeholder="Select a model" />
-            </SelectTrigger>
-            <SelectContent>
-              {availableModels.map((model) => {
-                const value = `${model.provider}:${String(model.id)}`;
-                return (
-                  <SelectItem key={value} value={value}>
-                    {model.name}
-                  </SelectItem>
-                );
-              })}
-            </SelectContent>
-          </Select>
-        </div>
-
-        {/* System prompt */}
-        <div>
-          <Label className="text-xs font-medium text-muted-foreground">
-            System prompt
-          </Label>
-          <p className="mb-1.5 mt-0.5 text-[10px] text-muted-foreground">
-            Instructions given to the model at the start of each run.
-          </p>
-          <Textarea
-            value={systemPrompt}
-            onChange={(e) => setSystemPrompt(e.target.value)}
-            placeholder="You are a helpful assistant…"
-            className="min-h-[80px] resize-y border-0 bg-muted/50 text-sm"
-            disabled={isSaving || isClearing}
-          />
-        </div>
-
-        {/* Temperature */}
-        <div>
-          <div className="flex items-center justify-between">
-            <Label className="text-xs font-medium text-muted-foreground">
-              Temperature
-            </Label>
-            <span className="text-xs text-muted-foreground">
-              {temperature.toFixed(2)}
-            </span>
-          </div>
-          <Slider
-            min={0}
-            max={2}
-            step={0.05}
-            value={[temperature]}
-            onValueChange={(values) =>
-              setTemperature(values[0] ?? DEFAULT_TEMPERATURE)
-            }
-            className="mt-3"
-            disabled={isSaving || isClearing}
-          />
-        </div>
+      <div className="rounded-xl border bg-card/60 p-4">
+        <HostConfigEditor
+          value={value}
+          onChange={setValue}
+          owner="eval-suite"
+          onValidityChange={setHasJsonError}
+        />
       </div>
 
       <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
         <div className="flex items-center gap-2">
           <Settings2 className="h-3.5 w-3.5" />
           <span>
-            {modelId
-              ? `Default: ${modelId}`
+            {value.modelId
+              ? `Default: ${value.modelId}`
               : "No default model configured"}
           </span>
         </div>
@@ -240,17 +208,20 @@ export function SuiteExecutionConfigEditor({
             onClick={handleReset}
             disabled={!isDirty || isSaving || isClearing}
           >
+            <RotateCcw className="mr-1 h-3.5 w-3.5" />
             Reset
           </Button>
           <Button
             type="button"
             size="sm"
             onClick={() => void handleSave()}
-            disabled={!isDirty || isSaving || isClearing || !modelId}
+            disabled={!canSave}
           >
             {isSaving ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : null}
+            ) : (
+              <Save className="mr-2 h-4 w-4" />
+            )}
             Save config
           </Button>
         </div>

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -857,27 +857,6 @@ export function SuiteIterationsView({
             <SuiteExecutionConfigEditor
               suite={suite}
               availableModels={availableModels}
-              onSave={async (defaultConfig) => {
-                try {
-                  await updateSuite({
-                    suiteId: suite._id,
-                    defaultConfig,
-                  });
-                  toast.success("Suite execution config updated");
-                } catch (error) {
-                  toast.error(
-                    getBillingErrorMessage(
-                      error,
-                      "Failed to update suite execution config",
-                    ),
-                  );
-                  console.error(
-                    "Failed to update suite execution config:",
-                    error,
-                  );
-                  throw error;
-                }
-              }}
               onClear={async () => {
                 try {
                   await updateSuite({

--- a/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
@@ -118,7 +118,14 @@ export function HostConfigEditor({
   );
 
   const showExecutionSection = owner !== "connection-only";
-  const showServersSection = owner !== "connection-only";
+  // Eval suites own server selection through `suite.environment` —
+  // `setSuiteConfig` rejects non-empty serverIds, and the iteration
+  // materializer pulls server ids from the suite environment. The
+  // editor surface for owner="eval-suite" therefore hides the server
+  // picker entirely (and ignores `availableServers`) so users can't
+  // type changes the backend would reject.
+  const showServersSection =
+    owner !== "connection-only" && owner !== "eval-suite";
 
   const hostStyleOptions = useMemo(() => listHostStyles(), []);
 

--- a/mcpjam-inspector/client/src/components/host-config/ProjectDefaultHostConfigSection.tsx
+++ b/mcpjam-inspector/client/src/components/host-config/ProjectDefaultHostConfigSection.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { Loader2, RotateCcw, Save } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@mcpjam/design-system/button";
+import { HostConfigEditor } from "./HostConfigEditor";
+import {
+  emptyHostConfigInputV2,
+  hostConfigDtoToInput,
+  hostConfigInputsEqual,
+  type HostConfigDtoV2,
+  type HostConfigInputV2,
+} from "@/lib/host-config-v2";
+import type { ServerWithName } from "@/hooks/use-app-state";
+
+interface ProjectDefaultHostConfigSectionProps {
+  /** Convex project id (the v2 owner). May be null for guest/local projects. */
+  convexProjectId: string | null;
+  /**
+   * Map of server id → server entity for this project. Forwarded to the
+   * editor's `availableServers` prop so users can include project servers
+   * in the seed config. Keys are server ids; values carry the display name.
+   */
+  projectServers: Record<string, ServerWithName>;
+  /**
+   * When false, the editor renders read-only. Project Settings already
+   * gates editing on `canManageMembers`; we mirror that here.
+   */
+  canManage: boolean;
+}
+
+/**
+ * Project default HostConfig editor.
+ *
+ * The project default is a creation-time **seed** for new chatboxes,
+ * eval suites, and direct chat tabs. Editing it does NOT propagate to
+ * existing chatboxes or eval suites — they own their own hostConfig
+ * rows. The Connection Settings tab edits a connection-only subset of
+ * this same row through the legacy `updateProjectClientConfig`
+ * compatibility wrapper.
+ */
+export function ProjectDefaultHostConfigSection({
+  convexProjectId,
+  projectServers,
+  canManage,
+}: ProjectDefaultHostConfigSectionProps) {
+  const dto = useQuery(
+    "hostConfigsV2:getProjectDefault" as any,
+    convexProjectId ? ({ projectId: convexProjectId } as any) : "skip",
+  ) as HostConfigDtoV2 | null | undefined;
+
+  const setProjectDefault = useMutation(
+    "hostConfigsV2:setProjectDefault" as any,
+  ) as unknown as (args: {
+    projectId: string;
+    input: HostConfigInputV2;
+  }) => Promise<string>;
+
+  // Live editor state. `baseline` tracks what we last loaded/saved so we
+  // can compute dirty state and reset cleanly. The dto round-trip runs
+  // through `hostConfigDtoToInput` which deep-clones JSON record fields
+  // — see comments in lib/host-config-v2.ts.
+  const [value, setValue] = useState<HostConfigInputV2 | null>(null);
+  const [baseline, setBaseline] = useState<HostConfigInputV2 | null>(null);
+  const [hasJsonError, setHasJsonError] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Hydrate when the dto loads or changes server-side. Don't stomp
+  // in-progress edits: only sync `value` when there's no dirty state
+  // (mirrors the suite editor's effect dep pattern).
+  useEffect(() => {
+    if (dto === undefined) return; // still loading
+    const next = dto ? hostConfigDtoToInput(dto) : emptyHostConfigInputV2();
+    setBaseline(next);
+    setValue((current) => {
+      if (current && baseline && !hostConfigInputsEqual(current, baseline)) {
+        // User has unsaved edits; leave them alone. Reactive query
+        // refresh will retry next time the user resets or saves.
+        return current;
+      }
+      return next;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dto]);
+
+  const availableServers = useMemo(
+    () =>
+      Object.entries(projectServers).map(([id, srv]) => ({
+        id,
+        name: srv.name ?? id,
+      })),
+    [projectServers],
+  );
+
+  if (!convexProjectId) {
+    return null;
+  }
+
+  if (value === null) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        Loading default config…
+      </div>
+    );
+  }
+
+  const isDirty = baseline ? !hostConfigInputsEqual(value, baseline) : true;
+  const canSave = canManage && isDirty && !hasJsonError && !isSaving;
+
+  const handleReset = () => {
+    if (baseline) setValue(baseline);
+  };
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setIsSaving(true);
+    try {
+      await setProjectDefault({ projectId: convexProjectId, input: value });
+      setBaseline(value);
+      toast.success("Project default config saved");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to save project default",
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <section className="space-y-3">
+      <div>
+        <h2 className="text-sm font-medium text-muted-foreground">
+          Default Host Config
+        </h2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Seed for new chatboxes, eval suites, and direct chat tabs. Editing
+          this does not change existing chatboxes or suites.
+        </p>
+      </div>
+
+      <div className="rounded-xl border bg-card/60 p-4">
+        <HostConfigEditor
+          value={value}
+          onChange={canManage ? setValue : () => {}}
+          owner="project-default"
+          availableServers={availableServers}
+          onValidityChange={setHasJsonError}
+        />
+      </div>
+
+      <div className="flex flex-wrap items-center justify-end gap-2 rounded-lg bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleReset}
+          disabled={!isDirty || isSaving}
+        >
+          <RotateCcw className="mr-1 h-3.5 w-3.5" />
+          Reset
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => void handleSave()}
+          disabled={!canSave}
+        >
+          {isSaving ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Save className="mr-2 h-4 w-4" />
+          )}
+          Save default
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -110,6 +110,14 @@ export interface UseChatSessionOptions {
   minimalMode?: boolean;
   /** Execution configuration (model, system prompt, temperature, tool approval) */
   executionConfig?: ExecutionConfig;
+  /**
+   * Phase 3: real host style for direct chat traces. Forwarded into
+   * the request body so the backend persists the v2 hostConfig with
+   * the user's actual host style (`claude` / `chatgpt`) rather than
+   * defaulting to `'claude'`. Omitted for chatbox flows — the
+   * backend resolves chatbox host style from the chatbox row.
+   */
+  hostStyle?: "claude" | "chatgpt";
   /** Callback when chat is reset */
   onReset?: (reason?: ChatSessionResetReason) => void;
 }
@@ -927,6 +935,7 @@ export function useChatSession({
   hostedContext,
   minimalMode: _minimalMode = false,
   executionConfig,
+  hostStyle,
   onReset,
 }: UseChatSessionOptions): UseChatSessionReturn {
   const hostedProjectId = hostedContext?.projectId;
@@ -1345,6 +1354,11 @@ export function useChatSession({
                 : {}),
             }),
         requireToolApproval: requireToolApprovalRef.current,
+        // Phase 3: forward the chat tab's resolved host style so
+        // direct chat traces persist with a real `claude`/`chatgpt`
+        // hostStyle (no more legacy `'direct'`). Omitted body falls
+        // back to the backend default of `'claude'`.
+        ...(hostStyle ? { hostStyle } : {}),
         ...(!HOSTED_MODE && customProviders.length > 0
           ? { customProviders }
           : {}),
@@ -1370,6 +1384,7 @@ export function useChatSession({
     hostedOAuthTokens,
     hostedChatboxToken,
     hostedChatboxSurface,
+    hostStyle,
     chatFetch,
     // requireToolApproval read from ref at request time
   ]);

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -805,8 +805,10 @@ describe("POST /api/mcp/chat-v2", () => {
         expect(body.sessionMessages).toEqual([
           { role: "user", content: "Hello" },
         ]);
+        // Phase 3: hostStyle defaults to 'claude' when the client
+        // doesn't supply one (no more legacy 'direct' on the wire).
         expect(body.hostConfig).toEqual({
-          hostStyle: "direct",
+          hostStyle: "claude",
           systemPrompt: "you are a helpful assistant",
           modelId: "google/gemini-2.5-flash",
           temperature: 0.4,

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -541,6 +541,11 @@ chatV2.post("/", async (c) => {
     const directHostConfig = hostConfigServerIds
       ? buildDirectHostConfig({
           modelId: String(modelDefinition.id),
+          // Phase 3: forward the chat tab's resolved host style so the
+          // backend writes a v2 hostConfig with a real (non-`'direct'`)
+          // hostStyle. Defaults to `'claude'` when omitted by the
+          // caller — see DirectChatHostStyle docs.
+          hostStyle: body.hostStyle,
           systemPrompt,
           requestedTemperature: temperature,
           resolvedTemperature,

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -299,7 +299,9 @@ describe("web routes — chat-v2 hosted mode", () => {
           selectedServers: ["Asana"],
         }),
         hostConfig: expect.objectContaining({
-          hostStyle: "direct",
+          // Phase 3: hostStyle defaults to 'claude' when omitted —
+          // no more legacy 'direct' on the wire.
+          hostStyle: "claude",
           modelId: "openai/gpt-5-mini",
           selectedServerIds: ["server-1"],
           // resolvedTemperature from prepareChatV2Mock default (0.7)

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -357,6 +357,13 @@ chatV2.post("/", async (c) => {
                       },
                       hostConfig: buildDirectHostConfig({
                         modelId: String(modelDefinition.id),
+                        // Phase 3: forward the chat tab's resolved
+                        // host style (parity with the org-BYOK and
+                        // mcp/chat-v2 call sites). Without this, the
+                        // MCPJam-free path always persisted as
+                        // 'claude' regardless of the user's actual
+                        // hostStyle.
+                        hostStyle: body.hostStyle,
                         systemPrompt,
                         requestedTemperature: temperature,
                         resolvedTemperature,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -235,6 +235,11 @@ chatV2.post("/", async (c) => {
                       },
                       hostConfig: buildDirectHostConfig({
                         modelId,
+                        // Phase 3: real host style flows from the
+                        // chat tab; old inspector builds omit it and
+                        // the backend defaults to 'claude' (no more
+                        // legacy 'direct' hostStyle in new traces).
+                        hostStyle: body.hostStyle,
                         systemPrompt,
                         requestedTemperature: temperature,
                         resolvedTemperature,

--- a/mcpjam-inspector/server/utils/__tests__/chat-ingestion.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-ingestion.test.ts
@@ -467,7 +467,12 @@ describe("buildDirectHostConfig", () => {
     expect(undef.requireToolApproval).toBe(false);
   });
 
-  it("emits hostStyle 'direct' and the provided modelId", () => {
+  it("defaults hostStyle to 'claude' when omitted (Phase 3 read switch)", () => {
+    // Phase 3: legacy `'direct'` is no longer the default. Callers
+    // that used to omit hostStyle now get 'claude' so new direct chat
+    // traces produce v2 hostConfigs with a real host style. Backend
+    // accepts the legacy literal `'direct'` for one deploy and
+    // normalizes with a `legacy_direct_style` warn.
     const config = buildDirectHostConfig({
       modelId: "anthropic/claude-haiku-4.5",
       systemPrompt: "p",
@@ -477,12 +482,24 @@ describe("buildDirectHostConfig", () => {
     });
 
     expect(config).toEqual({
-      hostStyle: "direct",
+      hostStyle: "claude",
       systemPrompt: "p",
       modelId: "anthropic/claude-haiku-4.5",
       temperature: 0.2,
       requireToolApproval: true,
       selectedServerIds: ["x", "y"],
     });
+  });
+
+  it("forwards an explicit hostStyle (e.g. 'chatgpt') from the chat tab", () => {
+    const config = buildDirectHostConfig({
+      modelId: "openai/gpt-5-mini",
+      hostStyle: "chatgpt",
+      systemPrompt: "",
+      resolvedTemperature: 0.7,
+      selectedServerIds: [],
+      requireToolApproval: false,
+    });
+    expect(config.hostStyle).toBe("chatgpt");
   });
 });

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -46,9 +46,17 @@ interface ResumeConfig {
  * can dedupe per-turn config into `hostConfigs`. Mirrors the `HostConfigPayload`
  * shape accepted by the Convex `/ingest-chat` route. Only emitted for direct
  * chats (serverShare and chatbox flows skip it).
+ *
+ * Phase 3 read switch: `hostStyle` carries the real host style
+ * (`claude` / `chatgpt`). The legacy literal `"direct"` is kept in
+ * the union for one deploy so an old backend (still expecting
+ * `'direct'`) keeps working until its roll lands; the new backend
+ * accepts both and normalizes legacy `'direct'` to the project
+ * default's real style with a `legacy_direct_style` warn.
  */
+export type DirectChatHostStyle = "claude" | "chatgpt" | "direct";
 export interface DirectHostConfig {
-  hostStyle: "direct";
+  hostStyle: DirectChatHostStyle;
   systemPrompt: string;
   modelId: string;
   temperature: number;
@@ -63,9 +71,15 @@ export interface DirectHostConfig {
  * `isHostConfigPayload` guard requires — without this, paths like GPT-5 (where
  * `resolvedTemperature` is undefined) would fail the guard and skip with
  * `missing_field`.
+ *
+ * `hostStyle` defaults to `"claude"` when the caller doesn't supply one.
+ * Old call sites that used to hardcode `"direct"` should pass the
+ * resolved chat-tab host style instead — see ChatTabV2's hydration
+ * from project default for the source of truth.
  */
 export function buildDirectHostConfig(input: {
   modelId: string;
+  hostStyle?: DirectChatHostStyle;
   systemPrompt?: string;
   requestedTemperature?: number;
   resolvedTemperature?: number;
@@ -74,6 +88,7 @@ export function buildDirectHostConfig(input: {
 }): DirectHostConfig {
   const {
     modelId,
+    hostStyle,
     systemPrompt,
     requestedTemperature,
     resolvedTemperature,
@@ -81,7 +96,7 @@ export function buildDirectHostConfig(input: {
     selectedServerIds,
   } = input;
   return {
-    hostStyle: "direct",
+    hostStyle: hostStyle ?? "claude",
     systemPrompt: systemPrompt ?? "",
     modelId,
     temperature:

--- a/mcpjam-inspector/shared/chat-v2.ts
+++ b/mcpjam-inspector/shared/chat-v2.ts
@@ -37,6 +37,16 @@ export interface ChatV2Request {
   selectedServerIds?: string[];
   requireToolApproval?: boolean;
   /**
+   * Phase 3 read switch: real host style for direct chat traces. When
+   * unset, the backend's chatIngestion path defaults to `'claude'` —
+   * so existing call sites that don't yet thread this through still
+   * produce a v2 hostConfig with a real (non-`'direct'`) hostStyle.
+   * Old inspector builds will keep emitting nothing or `'direct'`;
+   * the backend accepts both and normalizes with a
+   * `legacy_direct_style` warn.
+   */
+  hostStyle?: "claude" | "chatgpt";
+  /**
    * Project ID for direct-chat history persistence and, when set, the server
    * resolves model-provider config from the org backing this project.
    */


### PR DESCRIPTION
## Summary

Phase 3 of the HostConfig v2 rollout (inspector side). Pairs with backend PR https://github.com/MCPJam/mcpjam-backend/pull/236.

**UI**

- New **Project Settings → Default Host Config** section (\`ProjectDefaultHostConfigSection.tsx\`) using the shared \`HostConfigEditor\`. Reads \`api.hostConfigsV2.getProjectDefault\`, saves via \`setProjectDefault\`. Copy makes clear that this seeds new chatboxes / eval suites / direct chat tabs and does NOT propagate to existing children.
- **Eval Suite editor** (\`suite-execution-config-editor.tsx\`) rewritten to use \`HostConfigEditor\` with \`owner="eval-suite"\` + \`getSuiteConfig\` / \`setSuiteConfig\`. Server picker hidden (servers come from \`suite.environment\`); \`requireToolApproval\` now editable since the backend guard was removed in the same milestone.
- \`HostConfigEditor\`: \`owner="eval-suite"\` hides the server picker entirely.

**Direct chat wire**

- \`DirectHostConfig.hostStyle\` now \`'claude' | 'chatgpt' | 'direct'\` (last for one deploy of skew tolerance). \`buildDirectHostConfig\` defaults to \`'claude'\` when omitted — all new direct chat traces produce v2 hostConfigs with a real (non-\`'direct'\`) style.
- \`ChatV2Request\` gains optional \`hostStyle\` field; chat-v2 routes forward \`body.hostStyle\` through to \`buildDirectHostConfig\`.

**Deferrals (cosmetic, not blocking the read switch)**

- Full HostConfigEditor swap-in inside \`ChatboxEditor\` — existing flat-field UI already shows v2-resolved values (backend §2 makes \`buildChatboxSettingsResponse\` read v2) and \`updateChatbox\` mirrors writes to v2, so the chatbox flow is already Phase-3-correct at the data layer.
- Direct chat tab hydration from project default on tab open — the wire change above is what enables the no-more-\`'direct'\` invariant; seeding tab state is UX polish.

## Test plan

- [x] All 1066 server tests pass (\`npx vitest run server\`).
- [x] All 2721 client tests pass (\`npx vitest run client\`).
- [x] Updated \`chat-ingestion.test.ts\`, \`chat-v2.test.ts\`, \`chat-v2.hosted.test.ts\` to assert the default-to-\`'claude'\` behavior.
- [ ] Manual smoke: open Project Settings → Default Host Config → save → confirm Connection Settings tab still shows the same headers/timeout/capabilities/hostContext.
- [ ] Manual smoke: edit suite default through the new editor → toggle \`requireToolApproval\` on → start a single-model run → confirm \`testSuiteRun.hostConfigId\` is a v2 row with the flag set.
- [ ] Manual smoke: open a fresh direct chat tab → send a message → confirm the persisted \`hostConfigs\` row has \`schemaVersion === 2\` and \`hostStyle ∈ {'claude','chatgpt'}\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how eval suite configs and direct-chat trace `hostConfig.hostStyle` are read/written and persisted, which could affect stored trace metadata and suite execution defaults if the new v2 wiring or dirty-state logic is incorrect.
> 
> **Overview**
> Enables **Phase 3 HostConfig v2 read/write** in the inspector by adding a Project Settings editor for the project’s *default* host config (seed for new chatboxes/suites/direct chats) and migrating the eval suite “Default Execution Config” UI to use the shared `HostConfigEditor` backed by `hostConfigsV2.{getSuiteConfig,setSuiteConfig}`.
> 
> Updates direct-chat ingestion to carry a real `hostStyle` (`claude`/`chatgpt`) instead of the legacy `'direct'` marker: `ChatTabV2`/`useChatSession` now optionally forward `hostStyle`, server routes pass it into `buildDirectHostConfig`, and `buildDirectHostConfig` defaults to `'claude'` when omitted; related tests are updated accordingly. Additionally, `HostConfigEditor` hides server selection for `owner="eval-suite"` (suite servers remain owned by `suite.environment`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68e5bcfc2aba9191485ed1940041eec79cf8c70e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->