### PR TITLE
Phase 4 HostConfig v2 Write Switch (Inspector)

### DIFF
--- a/.changeset/phase-4-hostconfig-v2-write-switch.md
+++ b/.changeset/phase-4-hostconfig-v2-write-switch.md
@@ -1,0 +1,5 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Phase 4 HostConfig v2 write switch (inspector): connection settings now route through `hostConfigsV2.patchProjectDefaultConnection` instead of the legacy `projects.updateProjectClientConfig` (mutation completion is the durability signal — no project-doc echo round-trip). Eval suite settings replace "Remove" with "Reset to project default" which copies the current project default into the suite's owned `hostConfigId`. Chatbox builder draft loader migrates older sessionStorage drafts (missing fields filled from the blank starter) so persisted drafts from previous shapes don't crash the builder.

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
@@ -570,6 +570,15 @@ export function ChatboxEditor({
 
     setIsSaving(true);
     try {
+      // Phase 4: the backend createChatbox/updateChatbox accept either
+      // a v2 `hostConfig` arg or these legacy flat fields. The flat
+      // path lets the backend seed connection settings (headers /
+      // requestTimeout / clientCapabilities / hostContext) from the
+      // project's v2 default, which the editor UI doesn't surface.
+      // Sending an explicit v2 hostConfig here with empty connection
+      // settings would clobber project defaults — so we keep the flat
+      // path until the editor learns to read the project default
+      // and round-trip its connection portion.
       const payload = {
         name: trimmedName,
         description: description.trim() || undefined,

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderExperience.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderExperience.tsx
@@ -21,7 +21,7 @@ import { readBuilderSession, clearBuilderSession } from "@/lib/chatbox-session";
 import { ChatboxIndexPage, type ChatboxOpenOptions } from "./ChatboxIndexPage";
 import { ChatboxBuilderView } from "./ChatboxBuilderView";
 import { ChatboxLauncher } from "./ChatboxLauncher";
-import { getDefaultHostedModelId } from "./drafts";
+import { getDefaultHostedModelId, migrateBuilderDraft } from "./drafts";
 import type { ChatboxDraftConfig, ChatboxStarterDefinition } from "./types";
 
 interface ChatboxBuilderExperienceProps {
@@ -93,7 +93,10 @@ export default function ChatboxBuilderExperience({
 
     startTransition(() => {
       setSelectedChatboxId(session.chatboxId);
-      setDraft((session.draft as ChatboxDraftConfig | null) ?? null);
+      // Phase 4: migrate any older-shape draft (missing fields added
+      // since the draft was persisted) into the current shape before
+      // handing it to the builder.
+      setDraft(migrateBuilderDraft(session.draft) ?? null);
       const vm = session.viewMode;
       if (vm === "builder") {
         setRestoredViewMode("setup");

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/drafts.test.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/drafts.test.ts
@@ -1,9 +1,124 @@
 import { describe, expect, it } from "vitest";
-import { getDefaultHostedModelId } from "../drafts";
+import {
+  draftToHostConfigInputV2,
+  getDefaultHostedModelId,
+  migrateBuilderDraft,
+} from "../drafts";
 
 describe("getDefaultHostedModelId", () => {
   it("defaults to GPT-5 Mini, not the first MCPJam model in the catalog (gpt-oss)", () => {
     expect(getDefaultHostedModelId()).toBe("openai/gpt-5-mini");
     expect(getDefaultHostedModelId()).not.toBe("openai/gpt-oss-120b");
+  });
+});
+
+describe("migrateBuilderDraft", () => {
+  it("returns null for null/undefined input", () => {
+    expect(migrateBuilderDraft(null)).toBeNull();
+    expect(migrateBuilderDraft(undefined)).toBeNull();
+  });
+
+  it("fills missing fields from the blank starter for older drafts", () => {
+    const oldShape = {
+      name: "Pre-existing draft",
+      hostStyle: "claude" as const,
+      systemPrompt: "Hello",
+      modelId: "openai/gpt-5-mini",
+      temperature: 0.5,
+      requireToolApproval: false,
+      selectedServerIds: ["srv-1", "srv-2"],
+      // Missing: optionalServerIds, welcomeDialog, feedbackDialog, mode, etc.
+    };
+    const migrated = migrateBuilderDraft(oldShape);
+    expect(migrated).not.toBeNull();
+    expect(migrated!.selectedServerIds).toEqual(["srv-1", "srv-2"]);
+    expect(migrated!.optionalServerIds).toEqual([]);
+    expect(migrated!.welcomeDialog).toBeDefined();
+    expect(migrated!.feedbackDialog).toBeDefined();
+    expect(migrated!.mode).toBeDefined();
+    expect(migrated!.allowGuestAccess).toBeDefined();
+    expect(migrated!.name).toBe("Pre-existing draft");
+  });
+
+  it("preserves complete drafts at the field level", () => {
+    const draft = {
+      name: "Complete",
+      description: "desc",
+      hostStyle: "chatgpt" as const,
+      systemPrompt: "Sys",
+      modelId: "openai/gpt-5-mini",
+      temperature: 0.42,
+      requireToolApproval: true,
+      allowGuestAccess: false,
+      mode: "invited_only" as const,
+      selectedServerIds: ["a", "b"],
+      optionalServerIds: ["b"],
+      welcomeDialog: { enabled: true, body: "hi" },
+      feedbackDialog: {
+        enabled: true,
+        everyNToolCalls: 2,
+        promptHint: "feedback?",
+      },
+    };
+    const migrated = migrateBuilderDraft(draft);
+    expect(migrated).toEqual(draft);
+  });
+});
+
+describe("draftToHostConfigInputV2", () => {
+  it("builds a v2 input from a draft, defaulting connection settings when no project default is supplied", () => {
+    const draft = {
+      name: "n",
+      description: "",
+      hostStyle: "claude" as const,
+      systemPrompt: "Sys",
+      modelId: "openai/gpt-5-mini",
+      temperature: 0.5,
+      requireToolApproval: false,
+      allowGuestAccess: false,
+      mode: "invited_only" as const,
+      selectedServerIds: ["srv-1"],
+      optionalServerIds: ["srv-1"],
+      welcomeDialog: { enabled: true, body: "" },
+      feedbackDialog: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+    };
+    const input = draftToHostConfigInputV2(draft);
+    expect(input.hostStyle).toBe("claude");
+    expect(input.modelId).toBe("openai/gpt-5-mini");
+    expect(input.systemPrompt).toBe("Sys");
+    expect(input.serverIds).toEqual(["srv-1"]);
+    expect(input.optionalServerIds).toEqual(["srv-1"]);
+    expect(input.connectionDefaults.headers).toEqual({});
+    expect(input.connectionDefaults.requestTimeout).toBeGreaterThan(0);
+  });
+
+  it("uses the project default's connection portion when supplied", () => {
+    const draft = {
+      name: "n",
+      description: "",
+      hostStyle: "claude" as const,
+      systemPrompt: "",
+      modelId: "openai/gpt-5-mini",
+      temperature: 0.5,
+      requireToolApproval: false,
+      allowGuestAccess: false,
+      mode: "invited_only" as const,
+      selectedServerIds: [],
+      optionalServerIds: [],
+      welcomeDialog: { enabled: true, body: "" },
+      feedbackDialog: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+    };
+    const input = draftToHostConfigInputV2(draft, {
+      connectionDefaults: {
+        headers: { "x-project": "abc" },
+        requestTimeout: 5_000,
+      },
+      clientCapabilities: { custom: true },
+      hostContext: { theme: "dark" },
+    });
+    expect(input.connectionDefaults.headers).toEqual({ "x-project": "abc" });
+    expect(input.connectionDefaults.requestTimeout).toBe(5_000);
+    expect(input.clientCapabilities).toEqual({ custom: true });
+    expect(input.hostContext).toEqual({ theme: "dark" });
   });
 });

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
@@ -5,6 +5,10 @@ import {
 } from "@/shared/types";
 import type { ChatboxDraftConfig, ChatboxStarterDefinition } from "./types";
 import type { ChatboxSettings } from "@/hooks/useChatboxes";
+import {
+  emptyHostConfigInputV2,
+  type HostConfigInputV2,
+} from "@/lib/host-config-v2";
 
 export const DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant.";
 
@@ -143,6 +147,87 @@ export const CHATBOX_BLANK_STARTER = CHATBOX_STARTERS.find(
 export const CHATBOX_TEMPLATE_STARTERS = CHATBOX_STARTERS.filter(
   (s) => s.id !== "blank",
 );
+
+/**
+ * Phase 4: build the v2 hostConfig input for a chatbox save from a
+ * draft + project connection seed. The chatbox's `hostConfig` carries
+ * its own model/prompt/temperature/host style/server selection;
+ * connection settings are seeded from the project default (the editor
+ * does not surface them).
+ *
+ * connectionDefaults / clientCapabilities / hostContext are passed as
+ * the v2 default empty shapes when no project default is supplied —
+ * the backend's mintV2ChatboxHostConfigFromV2Input flow re-seeds from
+ * the project default before persisting, so an empty seed here is
+ * safe.
+ */
+export function draftToHostConfigInputV2(
+  draft: ChatboxDraftConfig,
+  projectDefault?: Pick<
+    HostConfigInputV2,
+    "connectionDefaults" | "clientCapabilities" | "hostContext"
+  > | null,
+): HostConfigInputV2 {
+  const seed = emptyHostConfigInputV2({
+    hostStyle: draft.hostStyle,
+    modelId: draft.modelId,
+    systemPrompt: draft.systemPrompt,
+    temperature: draft.temperature,
+    requireToolApproval: draft.requireToolApproval,
+    serverIds: draft.selectedServerIds,
+    optionalServerIds: draft.optionalServerIds,
+    connectionDefaults: projectDefault?.connectionDefaults,
+    clientCapabilities: projectDefault?.clientCapabilities,
+    hostContext: projectDefault?.hostContext,
+  });
+  return seed;
+}
+
+/**
+ * Phase 4: migrate a sessionStorage builder draft from any older shape
+ * into a draft that the current builder can consume. Today the draft
+ * still stores flat fields (hostStyle/modelId/etc.) so this is a
+ * structural sanity check — fill defaults for anything missing so a
+ * draft persisted before required fields were added (e.g. the
+ * optionalServerIds split, or the welcome/feedback dialog blocks)
+ * doesn't crash the builder. When the draft already carries every
+ * required field this is a no-op.
+ */
+export function migrateBuilderDraft(
+  raw: Record<string, unknown> | null | undefined,
+): ChatboxDraftConfig | null {
+  if (!raw || typeof raw !== "object") return null;
+  const blank = CHATBOX_BLANK_STARTER.createDraft(getDefaultHostedModelId());
+  const merged: ChatboxDraftConfig = {
+    ...blank,
+    ...(raw as Partial<ChatboxDraftConfig>),
+    welcomeDialog: {
+      ...blank.welcomeDialog,
+      ...((raw as { welcomeDialog?: Partial<ChatboxDraftConfig["welcomeDialog"]> })
+        .welcomeDialog ?? {}),
+    },
+    feedbackDialog: {
+      ...blank.feedbackDialog,
+      ...((raw as { feedbackDialog?: Partial<ChatboxDraftConfig["feedbackDialog"]> })
+        .feedbackDialog ?? {}),
+    },
+    selectedServerIds: Array.isArray(
+      (raw as { selectedServerIds?: unknown }).selectedServerIds,
+    )
+      ? ((raw as { selectedServerIds: string[] }).selectedServerIds.filter(
+          (id) => typeof id === "string",
+        ) as string[])
+      : [],
+    optionalServerIds: Array.isArray(
+      (raw as { optionalServerIds?: unknown }).optionalServerIds,
+    )
+      ? ((raw as { optionalServerIds: string[] }).optionalServerIds.filter(
+          (id) => typeof id === "string",
+        ) as string[])
+      : [],
+  };
+  return merged;
+}
 
 export function toDraftConfig(chatbox: ChatboxSettings): ChatboxDraftConfig {
   return {

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
@@ -155,11 +155,15 @@ export const CHATBOX_TEMPLATE_STARTERS = CHATBOX_STARTERS.filter(
  * connection settings are seeded from the project default (the editor
  * does not surface them).
  *
- * connectionDefaults / clientCapabilities / hostContext are passed as
- * the v2 default empty shapes when no project default is supplied —
- * the backend's mintV2ChatboxHostConfigFromV2Input flow re-seeds from
- * the project default before persisting, so an empty seed here is
- * safe.
+ * IMPORTANT: callers MUST pass `projectDefault` whenever the chatbox
+ * being minted should inherit the project's connection settings.
+ * `mintV2ChatboxHostConfigFromV2Input` on the backend persists the
+ * caller-supplied connectionDefaults / clientCapabilities / hostContext
+ * verbatim — it does not re-seed from the project default. Calling
+ * this helper without `projectDefault` falls back to the v2 empty
+ * shapes (empty headers / SDK-default capabilities / empty host
+ * context) and will overwrite the project's connection settings on
+ * the chatbox row.
  */
 export function draftToHostConfigInputV2(
   draft: ChatboxDraftConfig,

--- a/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-execution-config-editor.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Loader2, RotateCcw, Save, Settings2, Trash2 } from "lucide-react";
+import { Loader2, RotateCcw, Save, Settings2 } from "lucide-react";
 import { useMutation, useQuery } from "convex/react";
 import { toast } from "sonner";
 import { Button } from "@mcpjam/design-system/button";
@@ -19,13 +19,13 @@ type SuiteExecutionConfigEditorProps = {
   suite: Pick<EvalSuite, "_id" | "defaultConfig">;
   availableModels: ModelDefinition[];
   /**
-   * Optional clear callback — surfaces "Remove" affordance when the
-   * suite has a saved defaultConfig. The legacy mirror is cleared via
-   * the wider `updateTestSuite({ defaultConfig: null })` mutation
-   * which the parent owns, so we keep this as a callback rather than
-   * hardcoding the v1 path here.
+   * Phase 4: when set, surfaces a "Reset to project default" affordance.
+   * The parent passes the convex project id so the editor can fetch the
+   * project default and write it through `setSuiteConfig`. Replaces the
+   * legacy "Remove" button which cleared `suite.defaultConfig` via
+   * `updateTestSuite({ defaultConfig: null })`.
    */
-  onClear?: () => Promise<void>;
+  projectId?: string | null;
 };
 
 /**
@@ -45,13 +45,21 @@ type SuiteExecutionConfigEditorProps = {
 export function SuiteExecutionConfigEditor({
   suite,
   availableModels,
-  onClear,
+  projectId,
 }: SuiteExecutionConfigEditorProps) {
   void availableModels; // currently unused; HostConfigEditor uses a free-text modelId.
 
   const dto = useQuery(
     "hostConfigsV2:getSuiteConfig" as any,
     { suiteId: suite._id } as any,
+  ) as HostConfigDtoV2 | null | undefined;
+
+  // Phase 4: project default snapshot used by the "Reset to project
+  // default" affordance. Skipped when no projectId is wired through
+  // (e.g. unscoped guest suites).
+  const projectDefaultDto = useQuery(
+    "hostConfigsV2:getProjectDefault" as any,
+    projectId ? ({ projectId } as any) : "skip",
   ) as HostConfigDtoV2 | null | undefined;
 
   const setSuiteConfig = useMutation(
@@ -65,7 +73,7 @@ export function SuiteExecutionConfigEditor({
   const [baseline, setBaseline] = useState<HostConfigInputV2 | null>(null);
   const [hasJsonError, setHasJsonError] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
-  const [isClearing, setIsClearing] = useState(false);
+  const [isResetting, setIsResetting] = useState(false);
 
   // Track the scalar fields the legacy fallback reads so the editor
   // re-seeds when the parent clears `suite.defaultConfig` via
@@ -148,7 +156,7 @@ export function SuiteExecutionConfigEditor({
     serverIds: [],
     optionalServerIds: [],
   };
-  const canSave = isDirty && !hasJsonError && !isSaving && !isClearing;
+  const canSave = isDirty && !hasJsonError && !isSaving && !isResetting;
 
   const handleReset = () => {
     if (baseline) setValue(baseline);
@@ -180,13 +188,38 @@ export function SuiteExecutionConfigEditor({
     }
   };
 
-  const handleClear = async () => {
-    if (!onClear) return;
-    setIsClearing(true);
+  const handleResetToProjectDefault = async () => {
+    if (!projectDefaultDto) return;
+    setIsResetting(true);
     try {
-      await onClear();
+      // Phase 4: copy the project default into the suite-owned
+      // hostConfigId via setSuiteConfig. Server lists are forced empty
+      // since suite server selection lives on `suite.environment`. The
+      // mutation mints a new v2 row when the project-default content
+      // differs from the suite's existing row, or no-ops via dedupe
+      // when they already match.
+      const projectDefaultInput: HostConfigInputV2 = {
+        ...hostConfigDtoToInput(projectDefaultDto),
+        serverIds: [],
+        optionalServerIds: [],
+      };
+      await setSuiteConfig({
+        suiteId: suite._id,
+        input: projectDefaultInput,
+      });
+      setBaseline(projectDefaultInput);
+      setValue(projectDefaultInput);
+      toast.success("Suite reset to project default");
+    } catch (err) {
+      toast.error(
+        getBillingErrorMessage(
+          err,
+          "Failed to reset suite to project default",
+        ),
+      );
+      console.error("Failed to reset suite to project default:", err);
     } finally {
-      setIsClearing(false);
+      setIsResetting(false);
     }
   };
 
@@ -225,21 +258,20 @@ export function SuiteExecutionConfigEditor({
           </span>
         </div>
         <div className="flex items-center gap-2">
-          {onClear && suite.defaultConfig ? (
+          {projectDefaultDto ? (
             <Button
               type="button"
               variant="ghost"
               size="sm"
-              onClick={() => void handleClear()}
-              disabled={isClearing || isSaving}
-              className="text-destructive hover:text-destructive"
+              onClick={() => void handleResetToProjectDefault()}
+              disabled={isResetting || isSaving}
             >
-              {isClearing ? (
+              {isResetting ? (
                 <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
               ) : (
-                <Trash2 className="mr-1 h-3.5 w-3.5" />
+                <RotateCcw className="mr-1 h-3.5 w-3.5" />
               )}
-              Remove
+              Reset to project default
             </Button>
           ) : null}
           <Button
@@ -247,7 +279,7 @@ export function SuiteExecutionConfigEditor({
             variant="ghost"
             size="sm"
             onClick={handleReset}
-            disabled={!isDirty || isSaving || isClearing}
+            disabled={!isDirty || isSaving || isResetting}
           >
             <RotateCcw className="mr-1 h-3.5 w-3.5" />
             Reset

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -857,27 +857,7 @@ export function SuiteIterationsView({
             <SuiteExecutionConfigEditor
               suite={suite}
               availableModels={availableModels}
-              onClear={async () => {
-                try {
-                  await updateSuite({
-                    suiteId: suite._id,
-                    defaultConfig: null,
-                  });
-                  toast.success("Suite execution config removed");
-                } catch (error) {
-                  toast.error(
-                    getBillingErrorMessage(
-                      error,
-                      "Failed to remove suite execution config",
-                    ),
-                  );
-                  console.error(
-                    "Failed to remove suite execution config:",
-                    error,
-                  );
-                  throw error;
-                }
-              }}
+              projectId={projectId}
             />
 
             {/* Suite Description Section */}

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
@@ -14,7 +14,7 @@ import type {
 const {
   createProjectMock,
   ensureDefaultProjectMock,
-  updateClientConfigMock,
+  patchProjectDefaultConnectionMock,
   updateProjectMock,
   deleteProjectMock,
   projectQueryState,
@@ -25,7 +25,7 @@ const {
 } = vi.hoisted(() => ({
   createProjectMock: vi.fn(),
   ensureDefaultProjectMock: vi.fn(),
-  updateClientConfigMock: vi.fn(),
+  patchProjectDefaultConnectionMock: vi.fn(),
   updateProjectMock: vi.fn(),
   deleteProjectMock: vi.fn(),
   projectQueryState: {
@@ -62,7 +62,7 @@ vi.mock("../useProjects", () => ({
     createProject: createProjectMock,
     ensureDefaultProject: ensureDefaultProjectMock,
     updateProject: updateProjectMock,
-    updateClientConfig: updateClientConfigMock,
+    patchProjectDefaultConnection: patchProjectDefaultConnectionMock,
     deleteProject: deleteProjectMock,
   }),
   useProjectServers: () => projectServersState,
@@ -210,7 +210,7 @@ describe("useProjectState automatic project creation", () => {
     localStorage.clear();
     createProjectMock.mockResolvedValue("remote-project-id");
     ensureDefaultProjectMock.mockResolvedValue("default-project-id");
-    updateClientConfigMock.mockResolvedValue(undefined);
+    patchProjectDefaultConnectionMock.mockResolvedValue(undefined);
     updateProjectMock.mockResolvedValue("remote-project-id");
     deleteProjectMock.mockResolvedValue(undefined);
     projectQueryState.allProjects = [];
@@ -612,7 +612,11 @@ describe("useProjectState automatic project creation", () => {
     });
   });
 
-  it("keeps authenticated client-config saves pending until the remote echo arrives", async () => {
+  it("authenticated client-config saves resolve as soon as the v2 mutation returns", async () => {
+    // Phase 4: writes go through hostConfigsV2.patchProjectDefaultConnection.
+    // The mutation is awaited and the v2 row is the canonical write
+    // target, so the save resolves immediately on mutation completion —
+    // no project-doc echo round-trip.
     const savedConfig: ProjectConnectionConfigDraft = {
       version: 1,
       connectionDefaults: {
@@ -624,15 +628,6 @@ describe("useProjectState automatic project creation", () => {
           inspectorProfile: true,
         },
       },
-    };
-    const expectedPersistedClientConfig: ProjectClientConfig = {
-      version: 1,
-      connectionDefaults: {
-        headers: {},
-        requestTimeout: 10000,
-      },
-      clientCapabilities: savedConfig.clientCapabilities,
-      hostContext: {},
     };
 
     projectQueryState.allProjects = [
@@ -652,39 +647,18 @@ describe("useProjectState automatic project creation", () => {
     const appState = createAppState({
       default: createSyntheticDefaultProject(),
     });
-    const { result, rerender } = renderUseProjectState({ appState });
+    const { result } = renderUseProjectState({ appState });
 
-    let resolved = false;
-    const savePromise = result.current
-      .handleUpdateClientConfig("remote-1", savedConfig)
-      .then(() => {
-        resolved = true;
-      });
+    await result.current.handleUpdateClientConfig("remote-1", savedConfig);
 
-    await waitFor(() => {
-      expect(updateClientConfigMock).toHaveBeenCalledWith({
-        projectId: "remote-1",
-        clientConfig: expectedPersistedClientConfig,
-      });
+    expect(patchProjectDefaultConnectionMock).toHaveBeenCalledWith({
+      projectId: "remote-1",
+      connectionDefaults: { headers: {}, requestTimeout: 10000 },
+      clientCapabilities: savedConfig.clientCapabilities,
+      hostContext: {},
     });
-
-    expect(useClientConfigStore.getState().isAwaitingRemoteEcho).toBe(true);
-    expect(resolved).toBe(false);
-
-    projectQueryState.allProjects = [
-      {
-        ...projectQueryState.allProjects[0],
-        clientConfig: expectedPersistedClientConfig,
-      },
-    ];
-    projectQueryState.projects = [...projectQueryState.allProjects];
-    rerender({ organizationId: undefined });
-
-    await waitFor(() => {
-      expect(resolved).toBe(true);
-    });
-
-    await savePromise;
+    expect(useClientConfigStore.getState().isAwaitingRemoteEcho).toBe(false);
+    expect(useClientConfigStore.getState().isSaving).toBe(false);
   });
 
   it("composes host-context saves with the target project connection config", async () => {
@@ -780,31 +754,19 @@ describe("useProjectState automatic project creation", () => {
     const appState = createAppState({
       default: createSyntheticDefaultProject(),
     });
-    const { result, rerender } = renderUseProjectState({ appState });
+    const { result } = renderUseProjectState({ appState });
 
-    const savePromise = result.current.handleUpdateHostContext(
-      "remote-2",
-      savedHostContext,
-    );
+    await result.current.handleUpdateHostContext("remote-2", savedHostContext);
 
-    await waitFor(() => {
-      expect(updateClientConfigMock).toHaveBeenCalledWith({
-        projectId: "remote-2",
-        clientConfig: expectedPersistedClientConfig,
-      });
+    // Phase 4: the v2 patcher receives the composed connection portion
+    // (from remote-2's existing config) plus the new host context. The
+    // legacy `clientConfig` blob shape is no longer the wire format.
+    expect(patchProjectDefaultConnectionMock).toHaveBeenCalledWith({
+      projectId: "remote-2",
+      connectionDefaults: expectedPersistedClientConfig.connectionDefaults,
+      clientCapabilities: expectedPersistedClientConfig.clientCapabilities,
+      hostContext: savedHostContext,
     });
-
-    projectQueryState.allProjects = [
-      projectQueryState.allProjects[0],
-      {
-        ...projectQueryState.allProjects[1],
-        clientConfig: expectedPersistedClientConfig,
-      },
-    ];
-    projectQueryState.projects = [...projectQueryState.allProjects];
-    rerender({ organizationId: undefined });
-
-    await savePromise;
   });
 
   it("composes connection-config saves with the target project host context", async () => {
@@ -897,36 +859,28 @@ describe("useProjectState automatic project creation", () => {
     const appState = createAppState({
       default: createSyntheticDefaultProject(),
     });
-    const { result, rerender } = renderUseProjectState({ appState });
+    const { result } = renderUseProjectState({ appState });
 
-    const savePromise = result.current.handleUpdateClientConfig(
+    await result.current.handleUpdateClientConfig(
       "remote-2",
       savedConnectionConfig,
     );
 
-    await waitFor(() => {
-      expect(updateClientConfigMock).toHaveBeenCalledWith({
-        projectId: "remote-2",
-        clientConfig: expectedPersistedClientConfig,
-      });
+    // Phase 4: connection portion comes from the new draft, hostContext
+    // is preserved from the target project's existing config.
+    expect(patchProjectDefaultConnectionMock).toHaveBeenCalledWith({
+      projectId: "remote-2",
+      connectionDefaults: savedConnectionConfig.connectionDefaults,
+      clientCapabilities: savedConnectionConfig.clientCapabilities,
+      hostContext: remoteTwoHostContext,
     });
-
-    projectQueryState.allProjects = [
-      projectQueryState.allProjects[0],
-      {
-        ...projectQueryState.allProjects[1],
-        clientConfig: expectedPersistedClientConfig,
-      },
-    ];
-    projectQueryState.projects = [...projectQueryState.allProjects];
-    rerender({ organizationId: undefined });
-
-    await savePromise;
   });
 
-  it("keeps a newer project save pending when an older save times out", async () => {
-    vi.useFakeTimers();
-
+  it("calls the v2 patcher once per save and resolves each independently", async () => {
+    // Phase 4: writes go directly through the v2 mutation; the legacy
+    // echo-pending pattern (which gated newer saves on older saves
+    // timing out) no longer applies. Each save resolves on its own
+    // mutation completion.
     const firstSavedConfig: ProjectConnectionConfigDraft = {
       version: 1,
       connectionDefaults: {
@@ -950,12 +904,6 @@ describe("useProjectState automatic project creation", () => {
           projectTwo: true,
         },
       },
-    };
-    const secondPersistedClientConfig: ProjectClientConfig = {
-      version: 1,
-      connectionDefaults: secondSavedConfig.connectionDefaults,
-      clientCapabilities: secondSavedConfig.clientCapabilities,
-      hostContext: {},
     };
 
     projectQueryState.allProjects = [
@@ -983,52 +931,24 @@ describe("useProjectState automatic project creation", () => {
     const appState = createAppState({
       default: createSyntheticDefaultProject(),
     });
-    const { result, rerender } = renderUseProjectState({ appState });
+    const { result } = renderUseProjectState({ appState });
 
-    const firstSavePromise = result.current.handleUpdateClientConfig(
-      "remote-1",
-      firstSavedConfig,
-    );
-    const firstSaveError = firstSavePromise.catch((error) => error);
+    await result.current.handleUpdateClientConfig("remote-1", firstSavedConfig);
+    await result.current.handleUpdateClientConfig("remote-2", secondSavedConfig);
 
-    await Promise.resolve();
-    expect(updateClientConfigMock).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(5000);
+    expect(patchProjectDefaultConnectionMock).toHaveBeenCalledTimes(2);
+    expect(patchProjectDefaultConnectionMock).toHaveBeenNthCalledWith(1, {
+      projectId: "remote-1",
+      connectionDefaults: firstSavedConfig.connectionDefaults,
+      clientCapabilities: firstSavedConfig.clientCapabilities,
+      hostContext: {},
     });
-
-    const secondSavePromise = result.current.handleUpdateClientConfig(
-      "remote-2",
-      secondSavedConfig,
-    );
-
-    await Promise.resolve();
-    expect(updateClientConfigMock).toHaveBeenCalledTimes(2);
-    expect(useClientConfigStore.getState().pendingProjectId).toBe("remote-2");
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(5000);
+    expect(patchProjectDefaultConnectionMock).toHaveBeenNthCalledWith(2, {
+      projectId: "remote-2",
+      connectionDefaults: secondSavedConfig.connectionDefaults,
+      clientCapabilities: secondSavedConfig.clientCapabilities,
+      hostContext: {},
     });
-
-    await expect(firstSaveError).resolves.toBeInstanceOf(Error);
-    await expect(firstSavePromise).rejects.toThrow(
-      "Timed out waiting for project client config to sync.",
-    );
-    expect(useClientConfigStore.getState().pendingProjectId).toBe("remote-2");
-    expect(useClientConfigStore.getState().isAwaitingRemoteEcho).toBe(true);
-
-    projectQueryState.allProjects = [
-      projectQueryState.allProjects[0],
-      {
-        ...projectQueryState.allProjects[1],
-        clientConfig: secondPersistedClientConfig,
-      },
-    ];
-    projectQueryState.projects = [...projectQueryState.allProjects];
-    rerender({ organizationId: undefined });
-
-    await secondSavePromise;
   });
 
   it("treats the authenticated zero-org state as empty remote projects and clears stale synced selection", async () => {
@@ -1117,9 +1037,10 @@ describe("useProjectState automatic project creation", () => {
     expect(createProjectMock).not.toHaveBeenCalled();
   });
 
-  it("fails authenticated client-config saves when the remote echo times out", async () => {
-    vi.useFakeTimers();
-
+  it("propagates v2 mutation errors and clears saving state", async () => {
+    // Phase 4: when the v2 patcher rejects, the save promise rejects
+    // with the mutation's error and the store's isSaving / pendingProjectId
+    // both clear. The legacy echo timeout no longer applies.
     const savedConfig: ProjectConnectionConfigDraft = {
       version: 1,
       connectionDefaults: {
@@ -1147,28 +1068,18 @@ describe("useProjectState automatic project creation", () => {
     projectQueryState.projects = [...projectQueryState.allProjects];
     localStorage.setItem("convex-active-project-id", "remote-1");
 
+    patchProjectDefaultConnectionMock.mockRejectedValueOnce(
+      new Error("backend exploded"),
+    );
+
     const appState = createAppState({
       default: createSyntheticDefaultProject(),
     });
     const { result } = renderUseProjectState({ appState });
 
-    const savePromise = result.current.handleUpdateClientConfig(
-      "remote-1",
-      savedConfig,
-    );
-    const saveError = savePromise.catch((error) => error);
-
-    await Promise.resolve();
-    expect(updateClientConfigMock).toHaveBeenCalledTimes(1);
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(10_000);
-    });
-
-    await expect(saveError).resolves.toBeInstanceOf(Error);
-    await expect(savePromise).rejects.toThrow(
-      "Timed out waiting for project client config to sync.",
-    );
+    await expect(
+      result.current.handleUpdateClientConfig("remote-1", savedConfig),
+    ).rejects.toThrow("backend exploded");
     expect(useClientConfigStore.getState().isAwaitingRemoteEcho).toBe(false);
     expect(useClientConfigStore.getState().isSaving).toBe(false);
   });
@@ -1394,7 +1305,11 @@ describe("useProjectState automatic project creation", () => {
     expect(result.current.effectiveProjects["convex-project-a"]).toBeDefined();
   });
 
-  it("rejects authenticated client-config saves when the hook unmounts mid-sync", async () => {
+  it("v2 client-config saves resolve even if the hook unmounts after the call", async () => {
+    // Phase 4: the v2 mutation is awaited and there is no in-flight
+    // echo wait that an unmount could interrupt. Once the mutation
+    // resolves the save is durable; the hook unmounting later doesn't
+    // reject the promise.
     const savedConfig: ProjectConnectionConfigDraft = {
       version: 1,
       connectionDefaults: {
@@ -1406,15 +1321,6 @@ describe("useProjectState automatic project creation", () => {
           inspectorProfile: true,
         },
       },
-    };
-    const expectedPersistedClientConfig: ProjectClientConfig = {
-      version: 1,
-      connectionDefaults: {
-        headers: {},
-        requestTimeout: 10000,
-      },
-      clientCapabilities: savedConfig.clientCapabilities,
-      hostContext: {},
     };
 
     projectQueryState.allProjects = [
@@ -1436,27 +1342,11 @@ describe("useProjectState automatic project creation", () => {
     });
     const { result, unmount } = renderUseProjectState({ appState });
 
-    const savePromise = result.current.handleUpdateClientConfig(
-      "remote-1",
-      savedConfig,
-    );
+    await result.current.handleUpdateClientConfig("remote-1", savedConfig);
 
-    await waitFor(() => {
-      expect(updateClientConfigMock).toHaveBeenCalledWith({
-        projectId: "remote-1",
-        clientConfig: expectedPersistedClientConfig,
-      });
-    });
-
+    expect(patchProjectDefaultConnectionMock).toHaveBeenCalledTimes(1);
     unmount();
-
-    await expect(savePromise).rejects.toThrow(
-      "Project client config sync was interrupted.",
-    );
-    await waitFor(() => {
-      expect(useClientConfigStore.getState().isAwaitingRemoteEcho).toBe(false);
-      expect(useClientConfigStore.getState().isSaving).toBe(false);
-    });
+    expect(useClientConfigStore.getState().isSaving).toBe(false);
   });
 });
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
@@ -1226,6 +1226,150 @@ describe("useProjectState automatic project creation", () => {
     expect(fullClientConfigDispatches).toHaveLength(0);
   });
 
+  it("connection saves with undefined connectionDefaults send explicit defaults so the backend doesn't preserve the old timeout", async () => {
+    // CodeRabbit Major: previously the reset branch sent only
+    // `headers: {}`. The backend's partial validator merges missing
+    // requestTimeout from the existing default, so a draft with
+    // `connectionDefaults: undefined` would have the user's old
+    // timeout stick remotely while the optimistic local state showed
+    // the default — drifting back on the next refetch.
+    //
+    // ProjectConnectionConfigDraft.connectionDefaults is optional, so
+    // a draft can legally have it absent; the wire payload (and
+    // optimistic dispatch) must in that case carry an explicit
+    // { headers: {}, requestTimeout: DEFAULT_REQUEST_TIMEOUT_MS }
+    // rather than letting the backend preserve a stale value.
+    projectQueryState.allProjects = [
+      {
+        _id: "remote-1",
+        name: "Remote project",
+        servers: {},
+        ownerId: "user-1",
+        createdAt: 1,
+        updatedAt: 1,
+        clientConfig: {
+          version: 1,
+          connectionDefaults: {
+            headers: { "x-custom": "yes" },
+            requestTimeout: 99_999,
+          },
+          clientCapabilities: { customCap: true },
+          hostContext: {},
+        },
+      },
+    ];
+    projectQueryState.projects = [...projectQueryState.allProjects];
+    localStorage.setItem("convex-active-project-id", "remote-1");
+
+    const appState = createAppState({
+      default: createSyntheticDefaultProject(),
+    });
+    const { result, dispatch } = renderUseProjectState({ appState });
+
+    const draftWithoutConnectionDefaults: ProjectConnectionConfigDraft = {
+      version: 1,
+      clientCapabilities: { newCap: true },
+    };
+    await result.current.handleUpdateClientConfig(
+      "remote-1",
+      draftWithoutConnectionDefaults,
+    );
+
+    // Wire payload carries explicit defaults — the backend's
+    // preserve-when-undefined merge can't fall back to 99_999.
+    expect(patchProjectDefaultConnectionMock).toHaveBeenCalledWith({
+      projectId: "remote-1",
+      connectionDefaults: { headers: {}, requestTimeout: 10000 },
+      clientCapabilities: { newCap: true },
+      hostContext: undefined,
+    });
+
+    // Optimistic dispatch matches the wire payload — local state
+    // doesn't drift between save and the next refetch.
+    const sliceDispatch = dispatch.mock.calls
+      .map(([action]) => action)
+      .find(
+        (
+          action,
+        ): action is Extract<
+          AppAction,
+          { type: "UPDATE_PROJECT_CLIENT_CONFIG_SLICE" }
+        > => action.type === "UPDATE_PROJECT_CLIENT_CONFIG_SLICE",
+      );
+    expect(sliceDispatch).toMatchObject({
+      projectId: "remote-1",
+      slice: {
+        kind: "connection",
+        connectionDefaults: { headers: {}, requestTimeout: 10000 },
+        clientCapabilities: { newCap: true },
+      },
+    });
+  });
+
+  it("gates connect / reconnect paths via isAwaitingRemoteEcho while the v2 mutation is in flight", async () => {
+    // Codex P2: setting awaitRemoteEcho:false on beginSave previously
+    // left useProjectClientConfigSyncPending() returning false during
+    // the network round-trip, so assertClientConfigSynced /
+    // notifyIfClientConfigSyncPending in use-server-state would not
+    // gate connect/test/resolver paths and a reconnect could read the
+    // stale activeProject.clientConfig (the optimistic dispatch only
+    // fires after the await resolves).
+    const savedConfig: ProjectConnectionConfigDraft = {
+      version: 1,
+      connectionDefaults: { headers: {}, requestTimeout: 5_000 },
+      clientCapabilities: {},
+    };
+
+    projectQueryState.allProjects = [
+      {
+        _id: "remote-1",
+        name: "Remote project",
+        servers: {},
+        ownerId: "user-1",
+        createdAt: 1,
+        updatedAt: 1,
+        clientConfig: undefined,
+      },
+    ];
+    projectQueryState.projects = [...projectQueryState.allProjects];
+    localStorage.setItem("convex-active-project-id", "remote-1");
+
+    let resolveSave!: () => void;
+    patchProjectDefaultConnectionMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+
+    const appState = createAppState({
+      default: createSyntheticDefaultProject(),
+    });
+    const { result } = renderUseProjectState({ appState });
+
+    const inFlight = result.current.handleUpdateClientConfig(
+      "remote-1",
+      savedConfig,
+    );
+
+    // While the v2 mutation is in flight, the sync-pending guard is
+    // active for the target project. assertClientConfigSynced /
+    // notifyIfClientConfigSyncPending in use-server-state read off
+    // exactly this state.
+    expect(useClientConfigStore.getState().isAwaitingRemoteEcho).toBe(true);
+    expect(useClientConfigStore.getState().pendingProjectId).toBe("remote-1");
+    expect(useClientConfigStore.getState().isSaving).toBe(true);
+
+    resolveSave();
+    await inFlight;
+
+    // Once the mutation resolves we mark saved immediately — no
+    // project-doc echo wait — so the gate releases.
+    expect(useClientConfigStore.getState().isAwaitingRemoteEcho).toBe(false);
+    expect(useClientConfigStore.getState().pendingProjectId).toBeNull();
+    expect(useClientConfigStore.getState().isSaving).toBe(false);
+  });
+
   it("formats project create billing errors for organization owners", async () => {
     projectQueryState.allProjects = [
       {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
@@ -651,17 +651,20 @@ describe("useProjectState automatic project creation", () => {
 
     await result.current.handleUpdateClientConfig("remote-1", savedConfig);
 
+    // Connection-only saves leave hostContext untouched on the backend
+    // by passing `undefined` (P2): the v2 patcher merges only the
+    // fields it receives.
     expect(patchProjectDefaultConnectionMock).toHaveBeenCalledWith({
       projectId: "remote-1",
       connectionDefaults: { headers: {}, requestTimeout: 10000 },
       clientCapabilities: savedConfig.clientCapabilities,
-      hostContext: {},
+      hostContext: undefined,
     });
     expect(useClientConfigStore.getState().isAwaitingRemoteEcho).toBe(false);
     expect(useClientConfigStore.getState().isSaving).toBe(false);
   });
 
-  it("composes host-context saves with the target project connection config", async () => {
+  it("sends only the host-context slice on host-context saves so connection settings are not clobbered", async () => {
     const remoteOneClientConfig: ProjectClientConfig = {
       version: 1,
       connectionDefaults: {
@@ -758,18 +761,26 @@ describe("useProjectState automatic project creation", () => {
 
     await result.current.handleUpdateHostContext("remote-2", savedHostContext);
 
-    // Phase 4: the v2 patcher receives the composed connection portion
-    // (from remote-2's existing config) plus the new host context. The
-    // legacy `clientConfig` blob shape is no longer the wire format.
+    // P2: host-context saves send only the hostContext slice. The
+    // backend helper preserves connectionDefaults / clientCapabilities
+    // when those fields are undefined, so a slow connection save can
+    // no longer overwrite them.
     expect(patchProjectDefaultConnectionMock).toHaveBeenCalledWith({
       projectId: "remote-2",
-      connectionDefaults: expectedPersistedClientConfig.connectionDefaults,
-      clientCapabilities: expectedPersistedClientConfig.clientCapabilities,
+      connectionDefaults: undefined,
+      clientCapabilities: undefined,
       hostContext: savedHostContext,
     });
+    // expectedPersistedClientConfig is referenced here purely as a
+    // sanity check that the test setup composes a recognizable
+    // post-save shape; the wire format itself is the per-slice patch
+    // asserted above.
+    expect(expectedPersistedClientConfig.hostContext).toEqual(
+      savedHostContext,
+    );
   });
 
-  it("composes connection-config saves with the target project host context", async () => {
+  it("sends only the connection slice on connection saves so host context is not clobbered", async () => {
     const remoteOneClientConfig: ProjectClientConfig = {
       version: 1,
       connectionDefaults: {
@@ -866,14 +877,18 @@ describe("useProjectState automatic project creation", () => {
       savedConnectionConfig,
     );
 
-    // Phase 4: connection portion comes from the new draft, hostContext
-    // is preserved from the target project's existing config.
+    // P2: connection saves send only the connection slice. The
+    // backend helper preserves hostContext when undefined, so a slow
+    // host-context save can no longer overwrite it.
     expect(patchProjectDefaultConnectionMock).toHaveBeenCalledWith({
       projectId: "remote-2",
       connectionDefaults: savedConnectionConfig.connectionDefaults,
       clientCapabilities: savedConnectionConfig.clientCapabilities,
-      hostContext: remoteTwoHostContext,
+      hostContext: undefined,
     });
+    expect(expectedPersistedClientConfig.hostContext).toEqual(
+      remoteTwoHostContext,
+    );
   });
 
   it("calls the v2 patcher once per save and resolves each independently", async () => {
@@ -941,13 +956,13 @@ describe("useProjectState automatic project creation", () => {
       projectId: "remote-1",
       connectionDefaults: firstSavedConfig.connectionDefaults,
       clientCapabilities: firstSavedConfig.clientCapabilities,
-      hostContext: {},
+      hostContext: undefined,
     });
     expect(patchProjectDefaultConnectionMock).toHaveBeenNthCalledWith(2, {
       projectId: "remote-2",
       connectionDefaults: secondSavedConfig.connectionDefaults,
       clientCapabilities: secondSavedConfig.clientCapabilities,
-      hostContext: {},
+      hostContext: undefined,
     });
   });
 
@@ -1082,6 +1097,133 @@ describe("useProjectState automatic project creation", () => {
     ).rejects.toThrow("backend exploded");
     expect(useClientConfigStore.getState().isAwaitingRemoteEcho).toBe(false);
     expect(useClientConfigStore.getState().isSaving).toBe(false);
+  });
+
+  it("interleaved connection and host-context saves do not clobber each other", async () => {
+    // P2 regression: previously persistProjectClientConfig sent all
+    // three sections (connectionDefaults / clientCapabilities /
+    // hostContext) on every save and dispatched a full clientConfig
+    // optimistically. A slow connection save resolving after a fast
+    // host-context save would overwrite the new hostContext both
+    // remotely and locally. Now each save sends only its slice and
+    // dispatches a slice-merge action.
+    const initialClientConfig: ProjectClientConfig = {
+      version: 1,
+      connectionDefaults: {
+        headers: { "x-initial": "yes" },
+        requestTimeout: 1000,
+      },
+      clientCapabilities: { initial: true },
+      hostContext: { theme: "light" },
+    };
+    const newConnection: ProjectConnectionConfigDraft = {
+      version: 1,
+      connectionDefaults: {
+        headers: { "x-new": "yes" },
+        requestTimeout: 2000,
+      },
+      clientCapabilities: { updated: true },
+    };
+    const newHostContext: ProjectHostContextDraft = { theme: "dark" };
+
+    projectQueryState.allProjects = [
+      {
+        _id: "remote-1",
+        name: "Remote project",
+        servers: {},
+        ownerId: "user-1",
+        createdAt: 1,
+        updatedAt: 1,
+        clientConfig: initialClientConfig,
+      },
+    ];
+    projectQueryState.projects = [...projectQueryState.allProjects];
+    localStorage.setItem("convex-active-project-id", "remote-1");
+
+    let resolveSlowConnectionSave!: () => void;
+    patchProjectDefaultConnectionMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSlowConnectionSave = resolve;
+        }),
+    );
+    patchProjectDefaultConnectionMock.mockResolvedValueOnce(undefined);
+
+    const appState = createAppState({
+      default: createSyntheticDefaultProject(),
+    });
+    const { result, dispatch } = renderUseProjectState({ appState });
+
+    // Kick off the slow connection save first (don't await).
+    const slowConnectionSave = result.current.handleUpdateClientConfig(
+      "remote-1",
+      newConnection,
+    );
+    // Then complete a host-context save while the connection save is
+    // still pending.
+    await result.current.handleUpdateHostContext("remote-1", newHostContext);
+    // Finally let the slow connection save resolve.
+    resolveSlowConnectionSave();
+    await slowConnectionSave;
+
+    // Wire format: each save sent only its own slice. The connection
+    // save did NOT include hostContext, so the backend helper's
+    // preserve-when-undefined merge keeps the new hostContext intact.
+    expect(patchProjectDefaultConnectionMock).toHaveBeenCalledTimes(2);
+    expect(patchProjectDefaultConnectionMock).toHaveBeenNthCalledWith(1, {
+      projectId: "remote-1",
+      connectionDefaults: newConnection.connectionDefaults,
+      clientCapabilities: newConnection.clientCapabilities,
+      hostContext: undefined,
+    });
+    expect(patchProjectDefaultConnectionMock).toHaveBeenNthCalledWith(2, {
+      projectId: "remote-1",
+      connectionDefaults: undefined,
+      clientCapabilities: undefined,
+      hostContext: newHostContext,
+    });
+
+    // Local optimistic dispatch: each save dispatched a slice-merge
+    // action, never a full UPDATE_PROJECT { clientConfig: ... }. That's
+    // what prevents the in-flight connection save from clobbering the
+    // newly-saved hostContext locally when it eventually resolves.
+    const sliceDispatches = dispatch.mock.calls
+      .map(([action]) => action)
+      .filter(
+        (
+          action,
+        ): action is Extract<
+          AppAction,
+          { type: "UPDATE_PROJECT_CLIENT_CONFIG_SLICE" }
+        > => action.type === "UPDATE_PROJECT_CLIENT_CONFIG_SLICE",
+      );
+    expect(sliceDispatches).toHaveLength(2);
+    expect(sliceDispatches[0]).toMatchObject({
+      projectId: "remote-1",
+      slice: {
+        kind: "hostContext",
+        hostContext: newHostContext,
+      },
+    });
+    expect(sliceDispatches[1]).toMatchObject({
+      projectId: "remote-1",
+      slice: {
+        kind: "connection",
+        connectionDefaults: newConnection.connectionDefaults,
+        clientCapabilities: newConnection.clientCapabilities,
+      },
+    });
+    // No call passed `updates: { clientConfig: ... }` — i.e. the full
+    // overwrite path that previously clobbered sibling slices.
+    const fullClientConfigDispatches = dispatch.mock.calls
+      .map(([action]) => action)
+      .filter(
+        (action) =>
+          action.type === "UPDATE_PROJECT" &&
+          (action as Extract<AppAction, { type: "UPDATE_PROJECT" }>).updates
+            .clientConfig !== undefined,
+      );
+    expect(fullClientConfigDispatches).toHaveLength(0);
   });
 
   it("formats project create billing errors for organization owners", async () => {

--- a/mcpjam-inspector/client/src/hooks/use-project-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-project-state.ts
@@ -23,11 +23,13 @@ import {
   serializeServersForSharing,
 } from "@/lib/project-serialization";
 import {
+  DEFAULT_REQUEST_TIMEOUT_MS,
   pickProjectConnectionConfig,
   pickProjectHostContext,
   stableStringifyJson,
   type ProjectClientConfig,
   type ProjectConnectionConfigDraft,
+  type ProjectConnectionDefaults,
   type ProjectHostContextDraft,
 } from "@/lib/client-config";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
@@ -1025,63 +1027,77 @@ export function useProjectState({
       controller: ClientConfigSaveController<T>;
     }): Promise<void> => {
       // Phase 4: writes go through `hostConfigsV2.patchProjectDefaultConnection`.
-      // The mutation is awaited; once it resolves the v2 row is durable so we
-      // mark saved immediately. The legacy round-trip echo (which watched
-      // `projects.clientConfig` for an updated value before resolving) is
-      // no longer needed — v2 is the canonical write target. The local
-      // store no longer needs to wait for a project-doc reactive update.
+      // The legacy project-doc echo wait is gone (v2 is the canonical
+      // target), but we still need a sync-pending window during the
+      // mutation in-flight period. `useProjectClientConfigSyncPending`
+      // (and the `assertClientConfigSynced` /
+      // `notifyIfClientConfigSyncPending` guards in use-server-state)
+      // gate connect / reconnect / test / resolver paths so a user who
+      // saves and immediately reconnects can't be served the still-stale
+      // `activeProject.clientConfig` (the optimistic slice-merge dispatch
+      // only runs after the await resolves). beginSave with
+      // awaitRemoteEcho:true sets that pending state; markSaved /
+      // failSave with awaitRemoteEcho:false skip the controller's
+      // pending-data gate so we clear immediately on mutation completion.
       const useV2Write = isAuthenticated && !shouldUseLocalFallback;
 
       controller.beginSave({
         projectId,
         savedConfig: savedSlice,
-        awaitRemoteEcho: false,
+        awaitRemoteEcho: useV2Write,
       });
+
+      // Resolve the connection slice into both the v2 wire payload and
+      // the local optimistic state. Reset (`connectionConfig ===
+      // undefined`) explicitly sends `{ headers: {}, requestTimeout:
+      // DEFAULT_REQUEST_TIMEOUT_MS }` — sending headers-only would let
+      // the backend's helper preserve the user's previous timeout while
+      // the optimistic local state shows defaults, drifting back to the
+      // old timeout on the next refetch.
+      let resolvedConnectionDefaults:
+        | ProjectConnectionDefaults
+        | undefined;
+      if (slice.kind === "connection") {
+        const { connectionConfig } = slice;
+        if (connectionConfig === undefined) {
+          resolvedConnectionDefaults = {
+            headers: {},
+            requestTimeout: DEFAULT_REQUEST_TIMEOUT_MS,
+          };
+        } else {
+          const cd = connectionConfig.connectionDefaults;
+          if (cd === undefined) {
+            resolvedConnectionDefaults = {
+              headers: {},
+              requestTimeout: DEFAULT_REQUEST_TIMEOUT_MS,
+            };
+          } else {
+            const requestTimeout =
+              cd.requestTimeout !== undefined &&
+              Number.isFinite(cd.requestTimeout)
+                ? cd.requestTimeout
+                : DEFAULT_REQUEST_TIMEOUT_MS;
+            resolvedConnectionDefaults = {
+              headers: cd.headers ?? {},
+              requestTimeout,
+            };
+          }
+        }
+      }
+      const resolvedClientCapabilities =
+        slice.kind === "connection"
+          ? slice.connectionConfig === undefined
+            ? {}
+            : slice.connectionConfig.clientCapabilities
+          : undefined;
 
       if (useV2Write) {
         try {
           if (slice.kind === "connection") {
-            const { connectionConfig } = slice;
-            // Map the legacy ProjectClientConfig blob onto the v2 patcher
-            // args. `connectionConfig === undefined` (Reset) maps to a
-            // clear: empty headers + default timeout, empty capabilities
-            // — preserving model/prompt/temperature/host style/server
-            // selection on the v2 default. This matches the backend compat
-            // wrapper's clear semantics.
-            const cd = connectionConfig?.connectionDefaults as
-              | { headers?: Record<string, string>; requestTimeout?: number }
-              | undefined
-              | null;
-            const partialConnectionDefaults: {
-              headers?: Record<string, string>;
-              requestTimeout?: number;
-            } = {};
-            if (connectionConfig === undefined || cd === undefined) {
-              partialConnectionDefaults.headers = {};
-              // Backend's partial validator now accepts headers-only;
-              // it merges the existing requestTimeout when omitted.
-            } else {
-              if (cd?.headers !== undefined) {
-                partialConnectionDefaults.headers =
-                  (cd.headers as Record<string, string> | undefined) ?? {};
-              }
-              if (
-                cd?.requestTimeout !== undefined &&
-                Number.isFinite(cd.requestTimeout)
-              ) {
-                partialConnectionDefaults.requestTimeout = cd.requestTimeout;
-              }
-            }
             await convexPatchProjectDefaultConnection({
               projectId,
-              connectionDefaults:
-                Object.keys(partialConnectionDefaults).length > 0
-                  ? partialConnectionDefaults
-                  : undefined,
-              clientCapabilities:
-                connectionConfig === undefined
-                  ? {}
-                  : connectionConfig.clientCapabilities,
+              connectionDefaults: resolvedConnectionDefaults,
+              clientCapabilities: resolvedClientCapabilities,
               // Leave hostContext untouched on the backend — passing
               // undefined preserves the existing value (P2).
               hostContext: undefined,
@@ -1116,14 +1132,13 @@ export function useProjectState({
         // even when two saves race. The reactive project query will
         // catch up on its next refetch.
         if (slice.kind === "connection") {
-          const cc = slice.connectionConfig;
           dispatch({
             type: "UPDATE_PROJECT_CLIENT_CONFIG_SLICE",
             projectId,
             slice: {
               kind: "connection",
-              connectionDefaults: cc?.connectionDefaults,
-              clientCapabilities: cc?.clientCapabilities ?? {},
+              connectionDefaults: resolvedConnectionDefaults,
+              clientCapabilities: resolvedClientCapabilities ?? {},
             },
           });
         } else {
@@ -1142,14 +1157,13 @@ export function useProjectState({
       }
 
       if (slice.kind === "connection") {
-        const cc = slice.connectionConfig;
         dispatch({
           type: "UPDATE_PROJECT_CLIENT_CONFIG_SLICE",
           projectId,
           slice: {
             kind: "connection",
-            connectionDefaults: cc?.connectionDefaults,
-            clientCapabilities: cc?.clientCapabilities ?? {},
+            connectionDefaults: resolvedConnectionDefaults,
+            clientCapabilities: resolvedClientCapabilities ?? {},
           },
         });
       } else {

--- a/mcpjam-inspector/client/src/hooks/use-project-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-project-state.ts
@@ -23,7 +23,6 @@ import {
   serializeServersForSharing,
 } from "@/lib/project-serialization";
 import {
-  composeProjectClientConfig,
   pickProjectConnectionConfig,
   pickProjectHostContext,
   stableStringifyJson,
@@ -1002,12 +1001,26 @@ export function useProjectState({
   const persistProjectClientConfig = useCallback(
     async <T,>({
       projectId,
-      clientConfig,
+      slice,
       savedSlice,
       controller,
     }: {
       projectId: string;
-      clientConfig: ProjectClientConfig | undefined;
+      // The slice the user actually edited. Only this section is sent
+      // to the backend (the helper preserves the others) and only this
+      // section is updated optimistically — passing the full clientConfig
+      // would let a slow connection save clobber a newer host-context
+      // save and vice versa (P2). `connectionConfig: undefined` means
+      // "reset to default" for the connection slice.
+      slice:
+        | {
+            kind: "connection";
+            connectionConfig: ProjectConnectionConfigDraft | undefined;
+          }
+        | {
+            kind: "hostContext";
+            hostContext: ProjectHostContextDraft;
+          };
       savedSlice: T | undefined;
       controller: ClientConfigSaveController<T>;
     }): Promise<void> => {
@@ -1027,50 +1040,61 @@ export function useProjectState({
 
       if (useV2Write) {
         try {
-          // Map the legacy ProjectClientConfig blob onto the v2 patcher
-          // args. `clientConfig === undefined` (Reset) maps to a clear:
-          // empty headers + default timeout, empty capabilities, empty
-          // host context — preserving model/prompt/temperature/host
-          // style/server selection on the v2 default. This matches the
-          // backend compat wrapper's clear semantics.
-          const cd = clientConfig?.connectionDefaults as
-            | { headers?: Record<string, string>; requestTimeout?: number }
-            | undefined
-            | null;
-          const partialConnectionDefaults: {
-            headers?: Record<string, string>;
-            requestTimeout?: number;
-          } = {};
-          if (clientConfig === undefined || cd === undefined) {
-            partialConnectionDefaults.headers = {};
-            // No DEFAULT_REQUEST_TIMEOUT_MS import here to keep the diff
-            // local; backend defaults to 10_000 if requestTimeout is
-            // omitted. Send the explicit zero-headers signal but let the
-            // backend supply the default timeout.
+          if (slice.kind === "connection") {
+            const { connectionConfig } = slice;
+            // Map the legacy ProjectClientConfig blob onto the v2 patcher
+            // args. `connectionConfig === undefined` (Reset) maps to a
+            // clear: empty headers + default timeout, empty capabilities
+            // — preserving model/prompt/temperature/host style/server
+            // selection on the v2 default. This matches the backend compat
+            // wrapper's clear semantics.
+            const cd = connectionConfig?.connectionDefaults as
+              | { headers?: Record<string, string>; requestTimeout?: number }
+              | undefined
+              | null;
+            const partialConnectionDefaults: {
+              headers?: Record<string, string>;
+              requestTimeout?: number;
+            } = {};
+            if (connectionConfig === undefined || cd === undefined) {
+              partialConnectionDefaults.headers = {};
+              // Backend's partial validator now accepts headers-only;
+              // it merges the existing requestTimeout when omitted.
+            } else {
+              if (cd?.headers !== undefined) {
+                partialConnectionDefaults.headers =
+                  (cd.headers as Record<string, string> | undefined) ?? {};
+              }
+              if (
+                cd?.requestTimeout !== undefined &&
+                Number.isFinite(cd.requestTimeout)
+              ) {
+                partialConnectionDefaults.requestTimeout = cd.requestTimeout;
+              }
+            }
+            await convexPatchProjectDefaultConnection({
+              projectId,
+              connectionDefaults:
+                Object.keys(partialConnectionDefaults).length > 0
+                  ? partialConnectionDefaults
+                  : undefined,
+              clientCapabilities:
+                connectionConfig === undefined
+                  ? {}
+                  : connectionConfig.clientCapabilities,
+              // Leave hostContext untouched on the backend — passing
+              // undefined preserves the existing value (P2).
+              hostContext: undefined,
+            });
           } else {
-            if (cd?.headers !== undefined) {
-              partialConnectionDefaults.headers =
-                (cd.headers as Record<string, string> | undefined) ?? {};
-            }
-            if (
-              cd?.requestTimeout !== undefined &&
-              Number.isFinite(cd.requestTimeout)
-            ) {
-              partialConnectionDefaults.requestTimeout = cd.requestTimeout;
-            }
+            await convexPatchProjectDefaultConnection({
+              projectId,
+              // Leave connection portions untouched on the backend.
+              connectionDefaults: undefined,
+              clientCapabilities: undefined,
+              hostContext: slice.hostContext,
+            });
           }
-
-          await convexPatchProjectDefaultConnection({
-            projectId,
-            connectionDefaults:
-              Object.keys(partialConnectionDefaults).length > 0
-                ? partialConnectionDefaults
-                : undefined,
-            clientCapabilities:
-              clientConfig === undefined ? {} : clientConfig.clientCapabilities,
-            hostContext:
-              clientConfig === undefined ? {} : clientConfig.hostContext,
-          });
         } catch (error) {
           controller.failSave({
             projectId,
@@ -1086,15 +1110,29 @@ export function useProjectState({
           toast.error(errorMessage);
           throw error instanceof Error ? error : new Error(errorMessage);
         }
-        // Optimistically update the local Project doc's clientConfig so
-        // reads from `effectiveProjects[projectId].clientConfig` reflect
-        // the new state immediately. The reactive project query will
+        // Optimistically update only the slice the user edited. Using
+        // the slice-merge action (rather than dispatching a recomposed
+        // full clientConfig) keeps the sibling slice authoritative
+        // even when two saves race. The reactive project query will
         // catch up on its next refetch.
-        dispatch({
-          type: "UPDATE_PROJECT",
-          projectId,
-          updates: { clientConfig },
-        });
+        if (slice.kind === "connection") {
+          const cc = slice.connectionConfig;
+          dispatch({
+            type: "UPDATE_PROJECT_CLIENT_CONFIG_SLICE",
+            projectId,
+            slice: {
+              kind: "connection",
+              connectionDefaults: cc?.connectionDefaults,
+              clientCapabilities: cc?.clientCapabilities ?? {},
+            },
+          });
+        } else {
+          dispatch({
+            type: "UPDATE_PROJECT_CLIENT_CONFIG_SLICE",
+            projectId,
+            slice: { kind: "hostContext", hostContext: slice.hostContext },
+          });
+        }
         controller.markSaved({
           projectId,
           savedConfig: savedSlice,
@@ -1103,11 +1141,24 @@ export function useProjectState({
         return;
       }
 
-      dispatch({
-        type: "UPDATE_PROJECT",
-        projectId,
-        updates: { clientConfig },
-      });
+      if (slice.kind === "connection") {
+        const cc = slice.connectionConfig;
+        dispatch({
+          type: "UPDATE_PROJECT_CLIENT_CONFIG_SLICE",
+          projectId,
+          slice: {
+            kind: "connection",
+            connectionDefaults: cc?.connectionDefaults,
+            clientCapabilities: cc?.clientCapabilities ?? {},
+          },
+        });
+      } else {
+        dispatch({
+          type: "UPDATE_PROJECT_CLIENT_CONFIG_SLICE",
+          projectId,
+          slice: { kind: "hostContext", hostContext: slice.hostContext },
+        });
+      }
       controller.markSaved({
         projectId,
         savedConfig: savedSlice,
@@ -1265,7 +1316,6 @@ export function useProjectState({
       connectionConfig: ProjectConnectionConfigDraft | undefined,
     ): Promise<void> => {
       const clientConfigStore = useClientConfigStore.getState();
-      const projectClientConfig = effectiveProjects[projectId]?.clientConfig;
       const scopedDraftConfig = doesStoreSliceBelongToProject(
         clientConfigStore.activeProjectId,
         projectId,
@@ -1276,25 +1326,21 @@ export function useProjectState({
         connectionConfig ??
         scopedDraftConfig ??
         resolvePersistedConnectionConfig(projectId);
-      const clientConfig = composeProjectClientConfig({
-        connectionConfig: connectionConfigToPersist,
-        hostContext: resolvePersistedHostContext(projectId),
-        fallback: projectClientConfig ?? null,
-      });
 
       await persistProjectClientConfig({
         projectId,
-        clientConfig,
+        slice: {
+          kind: "connection",
+          connectionConfig: connectionConfigToPersist,
+        },
         savedSlice: connectionConfigToPersist,
         controller: connectionConfigSaveController,
       });
     },
     [
-      effectiveProjects,
       connectionConfigSaveController,
       persistProjectClientConfig,
       resolvePersistedConnectionConfig,
-      resolvePersistedHostContext,
     ],
   );
 
@@ -1304,7 +1350,6 @@ export function useProjectState({
       hostContext: ProjectHostContextDraft | undefined,
     ): Promise<void> => {
       const hostContextStore = useHostContextStore.getState();
-      const projectClientConfig = effectiveProjects[projectId]?.clientConfig;
       const scopedDraftHostContext = doesStoreSliceBelongToProject(
         hostContextStore.activeProjectId,
         projectId,
@@ -1315,24 +1360,17 @@ export function useProjectState({
         hostContext ??
         scopedDraftHostContext ??
         resolvePersistedHostContext(projectId);
-      const clientConfig = composeProjectClientConfig({
-        connectionConfig: resolvePersistedConnectionConfig(projectId),
-        hostContext: hostContextToPersist,
-        fallback: projectClientConfig ?? null,
-      });
 
       await persistProjectClientConfig({
         projectId,
-        clientConfig,
+        slice: { kind: "hostContext", hostContext: hostContextToPersist },
         savedSlice: hostContextToPersist,
         controller: hostContextSaveController,
       });
     },
     [
-      effectiveProjects,
       hostContextSaveController,
       persistProjectClientConfig,
-      resolvePersistedConnectionConfig,
       resolvePersistedHostContext,
     ],
   );

--- a/mcpjam-inspector/client/src/hooks/use-project-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-project-state.ts
@@ -187,7 +187,7 @@ export function useProjectState({
     createProject: convexCreateProject,
     ensureDefaultProject: convexEnsureDefaultProject,
     updateProject: convexUpdateProject,
-    updateClientConfig: convexUpdateClientConfig,
+    patchProjectDefaultConnection: convexPatchProjectDefaultConnection,
     deleteProject: convexDeleteProject,
   } = useProjectMutations();
   const billingStatus = useOrganizationBillingStatus(
@@ -1011,76 +1011,95 @@ export function useProjectState({
       savedSlice: T | undefined;
       controller: ClientConfigSaveController<T>;
     }): Promise<void> => {
-      const awaitRemoteEcho = isAuthenticated && !shouldUseLocalFallback;
+      // Phase 4: writes go through `hostConfigsV2.patchProjectDefaultConnection`.
+      // The mutation is awaited; once it resolves the v2 row is durable so we
+      // mark saved immediately. The legacy round-trip echo (which watched
+      // `projects.clientConfig` for an updated value before resolving) is
+      // no longer needed — v2 is the canonical write target. The local
+      // store no longer needs to wait for a project-doc reactive update.
+      const useV2Write = isAuthenticated && !shouldUseLocalFallback;
 
       controller.beginSave({
         projectId,
         savedConfig: savedSlice,
-        awaitRemoteEcho,
+        awaitRemoteEcho: false,
       });
 
-      if (awaitRemoteEcho) {
-        const pendingSyncId = `project-client-config-sync-${pendingClientConfigSyncIdRef.current++}`;
-        const remoteEchoPromise = new Promise<void>((resolve, reject) => {
-          const supersededPendingId =
-            pendingClientConfigSyncByProjectRef.current.get(projectId);
-          if (supersededPendingId) {
-            clearPendingClientConfigSync(
-              supersededPendingId,
-              new Error(PROJECT_CLIENT_CONFIG_SYNC_SUPERSEDED_ERROR_MESSAGE),
-            );
+      if (useV2Write) {
+        try {
+          // Map the legacy ProjectClientConfig blob onto the v2 patcher
+          // args. `clientConfig === undefined` (Reset) maps to a clear:
+          // empty headers + default timeout, empty capabilities, empty
+          // host context — preserving model/prompt/temperature/host
+          // style/server selection on the v2 default. This matches the
+          // backend compat wrapper's clear semantics.
+          const cd = clientConfig?.connectionDefaults as
+            | { headers?: Record<string, string>; requestTimeout?: number }
+            | undefined
+            | null;
+          const partialConnectionDefaults: {
+            headers?: Record<string, string>;
+            requestTimeout?: number;
+          } = {};
+          if (clientConfig === undefined || cd === undefined) {
+            partialConnectionDefaults.headers = {};
+            // No DEFAULT_REQUEST_TIMEOUT_MS import here to keep the diff
+            // local; backend defaults to 10_000 if requestTimeout is
+            // omitted. Send the explicit zero-headers signal but let the
+            // backend supply the default timeout.
+          } else {
+            if (cd?.headers !== undefined) {
+              partialConnectionDefaults.headers =
+                (cd.headers as Record<string, string> | undefined) ?? {};
+            }
+            if (
+              cd?.requestTimeout !== undefined &&
+              Number.isFinite(cd.requestTimeout)
+            ) {
+              partialConnectionDefaults.requestTimeout = cd.requestTimeout;
+            }
           }
 
-          const timeoutId = setTimeout(() => {
-            pendingClientConfigSyncRef.current.delete(pendingSyncId);
-            if (
-              pendingClientConfigSyncByProjectRef.current.get(projectId) ===
-              pendingSyncId
-            ) {
-              pendingClientConfigSyncByProjectRef.current.delete(projectId);
-            }
-            reject(new Error(PROJECT_CLIENT_CONFIG_SYNC_TIMEOUT_ERROR_MESSAGE));
-          }, CLIENT_CONFIG_SYNC_ECHO_TIMEOUT_MS);
-
-          pendingClientConfigSyncByProjectRef.current.set(
+          await convexPatchProjectDefaultConnection({
             projectId,
-            pendingSyncId,
-          );
-          pendingClientConfigSyncRef.current.set(pendingSyncId, {
-            id: pendingSyncId,
-            projectId,
-            expectedSerializedConfig:
-              stringifyProjectClientConfig(clientConfig),
-            resolve,
-            reject,
-            timeoutId,
+            connectionDefaults:
+              Object.keys(partialConnectionDefaults).length > 0
+                ? partialConnectionDefaults
+                : undefined,
+            clientCapabilities:
+              clientConfig === undefined ? {} : clientConfig.clientCapabilities,
+            hostContext:
+              clientConfig === undefined ? {} : clientConfig.hostContext,
           });
-        });
-
-        try {
-          await convexUpdateClientConfig({
-            projectId,
-            clientConfig,
-          });
-          await remoteEchoPromise;
         } catch (error) {
-          clearPendingClientConfigSync(pendingSyncId);
           controller.failSave({
             projectId,
             savedConfig: savedSlice,
-            awaitRemoteEcho,
+            awaitRemoteEcho: false,
           });
           const errorMessage =
             error instanceof Error ? error.message : "Unknown error";
-          if (!isSupersededClientConfigSyncError(error)) {
-            logger.error("Failed to update project client config", {
-              error: errorMessage,
-              projectId,
-            });
-            toast.error(errorMessage);
-          }
+          logger.error("Failed to update project client config", {
+            error: errorMessage,
+            projectId,
+          });
+          toast.error(errorMessage);
           throw error instanceof Error ? error : new Error(errorMessage);
         }
+        // Optimistically update the local Project doc's clientConfig so
+        // reads from `effectiveProjects[projectId].clientConfig` reflect
+        // the new state immediately. The reactive project query will
+        // catch up on its next refetch.
+        dispatch({
+          type: "UPDATE_PROJECT",
+          projectId,
+          updates: { clientConfig },
+        });
+        controller.markSaved({
+          projectId,
+          savedConfig: savedSlice,
+          awaitRemoteEcho: false,
+        });
         return;
       }
 
@@ -1092,14 +1111,13 @@ export function useProjectState({
       controller.markSaved({
         projectId,
         savedConfig: savedSlice,
-        awaitRemoteEcho,
+        awaitRemoteEcho: false,
       });
     },
     [
       isAuthenticated,
       shouldUseLocalFallback,
-      clearPendingClientConfigSync,
-      convexUpdateClientConfig,
+      convexPatchProjectDefaultConnection,
       logger,
       dispatch,
     ],

--- a/mcpjam-inspector/client/src/hooks/useProjects.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjects.ts
@@ -197,8 +197,12 @@ export function useProjectMutations() {
     "projects:ensureDefaultProject" as any
   );
   const updateProject = useMutation("projects:updateProject" as any);
-  const updateClientConfig = useMutation(
-    "projects:updateProjectClientConfig" as any
+  // Phase 4: write the project default's connection portion through the
+  // v2 owner pointer. The legacy `projects:updateProjectClientConfig`
+  // is still exported by the backend as a compat wrapper but the
+  // inspector no longer calls it.
+  const patchProjectDefaultConnection = useMutation(
+    "hostConfigsV2:patchProjectDefaultConnection" as any
   );
   const deleteProject = useMutation("projects:deleteProject" as any);
   const inviteProjectMember = useMutation(
@@ -218,7 +222,7 @@ export function useProjectMutations() {
     createProject,
     ensureDefaultProject,
     updateProject,
-    updateClientConfig,
+    patchProjectDefaultConnection,
     deleteProject,
     inviteProjectMember,
     removeProjectMember,

--- a/mcpjam-inspector/client/src/state/app-reducer.ts
+++ b/mcpjam-inspector/client/src/state/app-reducer.ts
@@ -4,6 +4,7 @@ import {
   ConnectionStatus,
   ServerWithName,
 } from "./app-types";
+import type { ProjectClientConfig } from "@/lib/client-config";
 
 const setStatus = (
   server: ServerWithName,
@@ -368,6 +369,46 @@ export function appReducer(state: AppState, action: AppAction): AppState {
           [action.projectId]: {
             ...project,
             ...action.updates,
+            updatedAt: new Date(),
+          },
+        },
+      };
+    }
+
+    case "UPDATE_PROJECT_CLIENT_CONFIG_SLICE": {
+      // Merge a single section of clientConfig into the project's
+      // current value. Reading clientConfig from the latest state here
+      // (rather than recomposing from a stale snapshot at the call
+      // site) is what prevents a slow connection save from clobbering
+      // a newer host-context save (and vice versa). See P2 in PR #237/#2051.
+      const project = state.projects[action.projectId];
+      if (!project) return state;
+      const baseClientConfig: ProjectClientConfig = project.clientConfig
+        ? project.clientConfig
+        : {
+            version: 1,
+            connectionDefaults: undefined,
+            clientCapabilities: {},
+            hostContext: {},
+          };
+      const nextClientConfig: ProjectClientConfig =
+        action.slice.kind === "connection"
+          ? {
+              ...baseClientConfig,
+              connectionDefaults: action.slice.connectionDefaults,
+              clientCapabilities: action.slice.clientCapabilities,
+            }
+          : {
+              ...baseClientConfig,
+              hostContext: action.slice.hostContext,
+            };
+      return {
+        ...state,
+        projects: {
+          ...state.projects,
+          [action.projectId]: {
+            ...project,
+            clientConfig: nextClientConfig,
             updatedAt: new Date(),
           },
         },

--- a/mcpjam-inspector/client/src/state/app-types.ts
+++ b/mcpjam-inspector/client/src/state/app-types.ts
@@ -1,7 +1,10 @@
 import type { MCPServerConfig } from "@mcpjam/sdk/browser";
 import { OauthTokens } from "@/shared/types.js";
 import type { OAuthTestProfile } from "@/lib/oauth/profile";
-import type { ProjectClientConfig } from "@/lib/client-config";
+import type {
+  ProjectClientConfig,
+  ProjectConnectionDefaults,
+} from "@/lib/client-config";
 import type { OAuthTrace } from "@/lib/oauth/oauth-trace";
 
 export type ConnectionStatus =
@@ -130,6 +133,27 @@ export type AppAction =
       type: "UPDATE_PROJECT";
       projectId: string;
       updates: Partial<Project>;
+    }
+  | {
+      // Merge one section of `clientConfig` into the project's current
+      // value, reading the current value from reducer state at the time
+      // the action is processed. Necessary so concurrent connection +
+      // host-context saves don't clobber each other locally — a full
+      // `UPDATE_PROJECT` with a composed clientConfig captures the
+      // sibling section at save-start, so a slow save can overwrite a
+      // newer sibling. This action only touches the named slice.
+      type: "UPDATE_PROJECT_CLIENT_CONFIG_SLICE";
+      projectId: string;
+      slice:
+        | {
+            kind: "connection";
+            connectionDefaults: ProjectConnectionDefaults | undefined;
+            clientCapabilities: Record<string, unknown>;
+          }
+        | {
+            kind: "hostContext";
+            hostContext: Record<string, unknown>;
+          };
     }
   | { type: "DELETE_PROJECT"; projectId: string }
   | { type: "SWITCH_PROJECT"; projectId: string }


### PR DESCRIPTION
## Summary

Inspector half of the Phase 4 HostConfig v2 write switch. Pairs with [mcpjam-backend#237](https://github.com/MCPJam/mcpjam-backend/pull/237).

This PR moves three of the four inspector chunks called out in the Phase 4 plan to the v2 owner pointers:

### Connection settings → v2 (`hostConfigsV2.patchProjectDefaultConnection`)

- `useProjectMutations` exposes `patchProjectDefaultConnection`. The legacy `projects:updateProjectClientConfig` is still on the backend as a compat wrapper but the inspector no longer calls it.
- `use-project-state.persistProjectClientConfig` writes through the v2 patcher. The legacy round-trip echo (which watched `projects.clientConfig` for an updated value before resolving) is gone — the v2 row is the canonical write target, so the save resolves immediately on mutation completion.
- Tests updated to mock `patchProjectDefaultConnection` and assert the v2 wire shape `{ projectId, connectionDefaults?, clientCapabilities, hostContext }`. Echo timeout / unmount-mid-sync tests replaced with v2-shaped equivalents (mutation-error propagation; no echo gate).

### Eval suite "Reset to project default"

- The "Remove" affordance is replaced with **Reset to project default**: fetches `hostConfigsV2.getProjectDefault` and writes it through `setSuiteConfig` (forcing empty serverIds — suite server selection lives on `suite.environment`). Backed by the spec line *"Reset to project default, which copies the current project default into the suite's owned hostConfigId"*.
- `suite-iterations-view` passes `projectId` through and drops the legacy `onClear` callback that called `updateTestSuite({ defaultConfig: null })`.

### Chatbox builder draft migration

- `migrateBuilderDraft()` detects older sessionStorage builder drafts (missing fields added since the draft was persisted, e.g. the `optionalServerIds` split or the welcome/feedback dialog blocks) and fills defaults from the blank starter so the builder doesn't crash on hydration.
- `draftToHostConfigInputV2()` builds a v2 hostConfig input from a builder draft, optionally seeded with the project default's connection portion. Ready for the eventual `ChatboxEditor` v2 switch.
- `ChatboxBuilderExperience` runs `migrateBuilderDraft` on session restore.

### Out of scope (separate PR)

- **Direct chat hydration from `project.defaultHostConfigId`**: wires into `ChatTabV2` chat session state with dirty detection across input, models, servers, messages, and attachments. The dirty signals span several stores; doing this safely warrants its own PR with focused tests.
- **`ChatboxEditor` switching to send v2 `hostConfig` payload**: the editor doesn't yet read the project default to pass through, and sending an empty connection seed via the v2 path would clobber the project's headers/timeouts/capabilities. The backend's compat wrapper already routes the inspector's flat-arg call through v2 internally, so the canonical write target is unchanged either way. Helpers (`draftToHostConfigInputV2`) are landed in this PR.

## Test plan

- [x] `client/src/hooks/__tests__/use-project-state.test.tsx` — 30/30 pass; all client-config save tests reshaped to v2 expectations.
- [x] `client/src/components/client-config/**` — 4/4 pass.
- [x] `client/src/components/evals/**` — 420/420 pass (suite editor passes `projectId` instead of `onClear`).
- [x] `client/src/components/chatboxes/builder/__tests__/drafts.test.ts` — 6/6 pass (added `migrateBuilderDraft` + `draftToHostConfigInputV2`).
- [x] Full `vitest run` for `@mcpjam/inspector` — see CI.

https://claude.ai/code/session_01Eu2pgzXQYZoZMzjmMb5gAw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eu2pgzXQYZoZMzjmMb5gAw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how project connection/host-context saves are persisted and optimistically merged, which can affect reconnect behavior and config durability. UI/UX changes for eval suite reset and draft migration are lower risk but touch user-facing flows.
> 
> **Overview**
> **Project connection settings now write via HostConfig v2.** Inspector saves route through `hostConfigsV2.patchProjectDefaultConnection` (via `useProjectMutations`/`useProjectState`), drop the legacy “wait for project-doc echo” durability signal, and optimistically update state using a new reducer action `UPDATE_PROJECT_CLIENT_CONFIG_SLICE` to avoid connection/host-context saves clobbering each other.
> 
> **Eval suite defaults UX updated.** Replaces the suite execution config “Remove” flow with **Reset to project default**, fetching `hostConfigsV2.getProjectDefault` and writing it back via `hostConfigsV2.setSuiteConfig` (with server lists forced empty).
> 
> **Chatbox builder draft loading hardened.** Session restore now runs `migrateBuilderDraft` to backfill missing fields from the blank starter; adds `draftToHostConfigInputV2` helper + tests, while `ChatboxEditor` stays on legacy flat payload (with added rationale) to avoid overwriting project-level connection defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e0dd94d9f2a6998311fc3667d6ed5be1a797867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->