### PR TITLE
Local chat

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/__tests__/helpers/mock-mcp-client-manager.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/helpers/mock-mcp-client-manager.ts
@@ -19,7 +19,7 @@ const defaultMocks = {
   disconnectServer: vi.fn().mockResolvedValue(undefined),
   removeServer: vi.fn(),
   getClient: vi.fn().mockReturnValue({}),
-  hasServer: vi.fn().mockReturnValue(false),
+  hasServer: vi.fn().mockReturnValue(true),
   listServers: vi.fn().mockReturnValue([]),
   getServerSummaries: vi.fn().mockReturnValue([]),
   getConnectionStatus: vi.fn().mockReturnValue("connected"),

--- a/mcpjam-inspector/server/routes/mcp/__tests__/helpers/mock-mcp-client-manager.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/helpers/mock-mcp-client-manager.ts
@@ -10,43 +10,51 @@ export type MockMCPClientManager = ReturnType<
 >;
 
 /**
- * Default mock implementations for MCPClientManager methods.
- * Each method returns a sensible default that can be overridden.
+ * Default implementations for MCPClientManager methods.
+ *
+ * Defined as plain functions (not vi.fn() instances) so the factory can
+ * install them via vi.fn(impl) on each call. mockReturnValue/mockResolvedValue
+ * do NOT register an implementation visible to getMockImplementation(), so
+ * copying defaults that way silently drops every default to undefined.
  */
-const defaultMocks = {
+const defaultImplementations = {
   // Connection management
-  connectToServer: vi.fn().mockResolvedValue(undefined),
-  disconnectServer: vi.fn().mockResolvedValue(undefined),
-  removeServer: vi.fn(),
-  getClient: vi.fn().mockReturnValue({}),
-  hasServer: vi.fn().mockReturnValue(true),
-  listServers: vi.fn().mockReturnValue([]),
-  getServerSummaries: vi.fn().mockReturnValue([]),
-  getConnectionStatus: vi.fn().mockReturnValue("connected"),
-  getInitializationInfo: vi.fn().mockReturnValue(null),
+  connectToServer: async () => undefined,
+  disconnectServer: async () => undefined,
+  removeServer: () => undefined,
+  getClient: () => ({}),
+  hasServer: () => true,
+  listServers: () => [],
+  getServerSummaries: () => [],
+  getConnectionStatus: () => "connected",
+  getInitializationInfo: () => null,
 
   // Tools
-  listTools: vi.fn().mockResolvedValue({ tools: [] }),
-  getToolsForAiSdk: vi.fn().mockResolvedValue({}),
-  executeTool: vi.fn().mockResolvedValue({
+  listTools: async () => ({ tools: [] }),
+  getToolsForAiSdk: async () => ({}),
+  executeTool: async () => ({
     content: [{ type: "text", text: "Tool executed successfully" }],
   }),
-  getAllToolsMetadata: vi.fn().mockReturnValue({}),
-  setElicitationHandler: vi.fn(),
-  clearElicitationHandler: vi.fn(),
+  getAllToolsMetadata: () => ({}),
+  setElicitationHandler: () => undefined,
+  clearElicitationHandler: () => undefined,
 
   // Resources
-  listResources: vi.fn().mockResolvedValue({
+  listResources: async () => ({
     resources: [],
     nextCursor: undefined,
   }),
-  readResource: vi.fn().mockResolvedValue({
+  readResource: async () => ({
     contents: [],
   }),
 
   // Prompts
-  listPrompts: vi.fn().mockResolvedValue({ prompts: [] }),
-  getPrompt: vi.fn().mockResolvedValue({ messages: [] }),
+  listPrompts: async () => ({ prompts: [] }),
+  getPrompt: async () => ({ messages: [] }),
+} satisfies Record<string, (...args: any[]) => any>;
+
+type DefaultMocks = {
+  [K in keyof typeof defaultImplementations]: MockFn;
 };
 
 /**
@@ -71,30 +79,20 @@ const defaultMocks = {
  * manager.listTools.mockResolvedValue({ tools: [{ name: "custom" }] });
  */
 export function createMockMcpClientManager(
-  overrides: Partial<Record<keyof typeof defaultMocks, MockFn>> = {},
-) {
+  overrides: Partial<Record<keyof typeof defaultImplementations, MockFn>> = {},
+): DefaultMocks {
   const freshMocks = Object.fromEntries(
-    (Object.keys(defaultMocks) as Array<keyof typeof defaultMocks>).map(
-      (key) => {
-        const mockFn = defaultMocks[key];
-        const implementation = mockFn.getMockImplementation();
-        const freshMock = vi.fn();
-        if (implementation) {
-          freshMock.mockImplementation(implementation as any);
-        }
-        return [
-          key,
-          // Create a fresh mock for each call to avoid state pollution.
-          freshMock,
-        ];
-      },
-    ),
-  ) as typeof defaultMocks;
+    (
+      Object.keys(defaultImplementations) as Array<
+        keyof typeof defaultImplementations
+      >
+    ).map((key) => [key, vi.fn(defaultImplementations[key] as any)]),
+  ) as DefaultMocks;
 
   return {
     ...freshMocks,
     ...overrides,
-  } as typeof defaultMocks;
+  };
 }
 
 /**

--- a/mcpjam-inspector/server/routes/mcp/tools.ts
+++ b/mcpjam-inspector/server/routes/mcp/tools.ts
@@ -149,6 +149,14 @@ tools.post("/list", async (c) => {
       }
     }
 
+    // If the (normalized) id still isn't a live, registered server, return an
+    // empty result instead of letting the SDK throw "Unknown MCP server" /
+    // "is not connected". Stale chatbox serverIds shouldn't 500 the metadata
+    // fetch — the chatbox preview just shows zero tools for that server.
+    if (!availableServers.includes(normalizedServerId)) {
+      return c.json({ tools: [], toolsMetadata: {}, tokenCount: undefined });
+    }
+
     return c.json(
       await listToolsShared(c.mcpClientManager, {
         serverId: normalizedServerId,

--- a/mcpjam-inspector/server/routes/mcp/tools.ts
+++ b/mcpjam-inspector/server/routes/mcp/tools.ts
@@ -134,14 +134,14 @@ tools.post("/list", async (c) => {
       return c.json({ error: "serverId is required" }, 400);
     }
 
-    // Normalize serverId - try to find a case-insensitive match if exact match fails
+    // Normalize serverId - try to find a case-insensitive match if exact match
+    // fails. Match against all registered servers (not just live-clients) so
+    // a server that's still mid-connect can still be resolved.
     let normalizedServerId = serverId;
-    const availableServers = c.mcpClientManager
-      .listServers()
-      .filter((id: string) => Boolean(c.mcpClientManager.getClient(id)));
+    const registeredServers = c.mcpClientManager.listServers();
 
-    if (!availableServers.includes(serverId)) {
-      const match = availableServers.find(
+    if (!registeredServers.includes(serverId)) {
+      const match = registeredServers.find(
         (name: string) => name.toLowerCase() === serverId.toLowerCase(),
       );
       if (match) {
@@ -149,11 +149,11 @@ tools.post("/list", async (c) => {
       }
     }
 
-    // If the (normalized) id still isn't a live, registered server, return an
-    // empty result instead of letting the SDK throw "Unknown MCP server" /
-    // "is not connected". Stale chatbox serverIds shouldn't 500 the metadata
-    // fetch — the chatbox preview just shows zero tools for that server.
-    if (!availableServers.includes(normalizedServerId)) {
+    // Only bail out for truly unknown ids (e.g. stale chatbox refs) so we
+    // don't 500 the metadata fetch. Registered-but-still-connecting ids fall
+    // through to the SDK path, which awaits the in-flight connectPromise and
+    // returns the real tools.
+    if (!registeredServers.includes(normalizedServerId)) {
       return c.json({ tools: [], toolsMetadata: {}, tokenCount: undefined });
     }
 

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -21,6 +21,7 @@ function mockManager(tools: Record<string, unknown>) {
     getToolsForAiSdk: vi.fn().mockResolvedValue(tools),
     getAllToolsMetadata: vi.fn().mockReturnValue({}),
     listServers: vi.fn().mockReturnValue([]),
+    hasServer: vi.fn().mockReturnValue(true),
   } as any;
 }
 
@@ -122,5 +123,22 @@ describe("prepareChatV2", () => {
         ],
       },
     ]);
+  });
+
+  it("filters selectedServers down to ids the manager has registered", async () => {
+    const manager = mockManager({});
+    manager.hasServer = vi.fn((id: string) => id === "live-server");
+
+    await prepareChatV2({
+      mcpClientManager: manager,
+      selectedServers: ["live-server", "stale-server"],
+      modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
+      systemPrompt: "Base prompt.",
+    });
+
+    expect(manager.getToolsForAiSdk).toHaveBeenCalledWith(
+      ["live-server"],
+      undefined,
+    );
   });
 });

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -67,9 +67,16 @@ export async function prepareChatV2(
     customProviders,
   } = options;
 
+  // Drop ids the manager hasn't registered (server disabled/disconnected, or
+  // a stale id baked into a chatbox config). Passing them through reaches
+  // ensureConnected and throws "Unknown MCP server", 500-ing the whole chat.
+  const knownSelectedServers = selectedServers?.filter((id) =>
+    mcpClientManager.hasServer(id),
+  );
+
   // 1. Get MCP + skill tools
   const mcpTools = await mcpClientManager.getToolsForAiSdk(
-    selectedServers,
+    knownSelectedServers,
     requireToolApproval ? { needsApproval: requireToolApproval } : undefined,
   );
   const { tools: skillTools, systemPromptSection: skillsPromptSection } =
@@ -120,10 +127,10 @@ export async function prepareChatV2(
       scrubMcpAppsToolResultsForBackend(
         scrubUnavailableToolHistoryForBackend(msgs, availableToolNames),
         mcpClientManager,
-        selectedServers,
+        knownSelectedServers,
       ),
       mcpClientManager,
-      selectedServers,
+      knownSelectedServers,
     );
 
   return {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes request handling for MCP tool listing and chat orchestration to tolerate unknown/stale server IDs, which could alter runtime behavior and potentially hide misconfigurations. Scope is limited but touches core chat/tool discovery paths.
> 
> **Overview**
> Prevents chat-v2 preparation from 500ing when `selectedServers` contains stale/disabled IDs by filtering through `mcpClientManager.hasServer()` and using the filtered list for tool discovery and message scrubbing.
> 
> Updates `POST /mcp/tools/list` to normalize `serverId` against *all registered servers* (not just connected clients) and to return an empty tools payload for truly unknown IDs instead of erroring.
> 
> Fixes the `createMockMcpClientManager` test helper to build fresh `vi.fn(impl)` mocks from plain default implementations (avoiding lost defaults), and adds a regression test asserting stale server IDs are filtered out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4eed9844ed2eab5a81e649c4240b15b4e079fe34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->