### PR TITLE
Wire chatbox saves through v2 hostConfig path

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
@@ -600,12 +600,17 @@ export function ChatboxEditor({
     // verbatim. Block save until a seed has resolved so we don't ship
     // empty connectionDefaults / clientCapabilities / hostContext and
     // clobber the existing values. For edit-mode chatboxes prefer the
-    // chatbox's own config; fall back to the project default for
-    // legacy rows that resolve null. For create mode, use the project
-    // default directly.
-    const seedDto = isCreateMode
-      ? projectDefaultHostConfig
-      : (chatboxHostConfig ?? projectDefaultHostConfig);
+    // chatbox's own config; only fall back to the project default
+    // when the chatbox config has *resolved* null (legacy rows) — not
+    // while it's still undefined (loading), which would let the
+    // project default overwrite an existing chatbox's own connection
+    // fields if the project query resolves first. For create mode,
+    // use the project default directly.
+    const chatboxSeed =
+      chatboxHostConfig === null
+        ? projectDefaultHostConfig
+        : chatboxHostConfig;
+    const seedDto = isCreateMode ? projectDefaultHostConfig : chatboxSeed;
     if (seedDto === undefined) {
       toast.error("Loading chatbox config — try again in a moment");
       return;

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useConvexAuth } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import {
   ArrowLeft,
   Check,
@@ -87,6 +87,12 @@ import {
   bootstrapServerToHostedOAuthDescriptor,
   countRequiredServers,
 } from "./builder/chatbox-server-optional";
+import { draftToHostConfigInputV2 } from "./builder/drafts";
+import type { ChatboxDraftConfig } from "./builder/types";
+import {
+  hostConfigDtoToInput,
+  type HostConfigDtoV2,
+} from "@/lib/host-config-v2";
 
 interface ProjectServerOption {
   _id: string;
@@ -144,6 +150,27 @@ export function ChatboxEditor({
     useChatboxMutations();
   const { createServer } = useServerMutations();
   const isCreateMode = !chatbox;
+
+  // Round-trip the chatbox's own hostConfig (edit mode) so the v2 save
+  // path preserves the connection portion (connectionDefaults /
+  // clientCapabilities / hostContext) the editor UI doesn't surface.
+  // mintV2ChatboxHostConfigFromV2Input persists those fields verbatim,
+  // so we MUST feed them or they get clobbered.
+  const chatboxHostConfig = useQuery(
+    "hostConfigsV2:getChatboxConfig" as any,
+    isAuthenticated && chatbox?.chatboxId
+      ? ({ chatboxId: chatbox.chatboxId } as any)
+      : "skip"
+  ) as HostConfigDtoV2 | null | undefined;
+
+  // Create-mode seed: the project default supplies the connection
+  // portion for new chatboxes.
+  const projectDefaultHostConfig = useQuery(
+    "hostConfigsV2:getProjectDefault" as any,
+    isAuthenticated && isCreateMode && projectId
+      ? ({ projectId } as any)
+      : "skip"
+  ) as HostConfigDtoV2 | null | undefined;
   const isMobile = useIsMobile();
 
   const hostedModels = useMemo(
@@ -568,28 +595,47 @@ export function ChatboxEditor({
       return;
     }
 
+    // The backend's v2 hostConfig path persists connection fields
+    // verbatim. Block save until the seed query has resolved so we
+    // don't ship empty connectionDefaults / clientCapabilities /
+    // hostContext and clobber the existing values.
+    const seedDto = isCreateMode ? projectDefaultHostConfig : chatboxHostConfig;
+    if (seedDto === undefined) {
+      toast.error("Loading chatbox config — try again in a moment");
+      return;
+    }
+    const seedInput = seedDto ? hostConfigDtoToInput(seedDto) : null;
+    const synthDraft: ChatboxDraftConfig = {
+      name: trimmedName,
+      description: description.trim(),
+      hostStyle,
+      systemPrompt: systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+      modelId,
+      temperature,
+      requireToolApproval,
+      allowGuestAccess,
+      mode,
+      selectedServerIds,
+      optionalServerIds,
+      welcomeDialog: {
+        enabled: chatbox?.welcomeDialog?.enabled ?? true,
+        body: chatbox?.welcomeDialog?.body ?? "",
+      },
+      feedbackDialog: {
+        enabled: chatbox?.feedbackDialog?.enabled ?? true,
+        everyNToolCalls: chatbox?.feedbackDialog?.everyNToolCalls ?? 1,
+        promptHint: chatbox?.feedbackDialog?.promptHint ?? "",
+      },
+    };
+    const hostConfigInput = draftToHostConfigInputV2(synthDraft, seedInput);
+
     setIsSaving(true);
     try {
-      // Phase 4: the backend createChatbox/updateChatbox accept either
-      // a v2 `hostConfig` arg or these legacy flat fields. The flat
-      // path lets the backend seed connection settings (headers /
-      // requestTimeout / clientCapabilities / hostContext) from the
-      // project's v2 default, which the editor UI doesn't surface.
-      // Sending an explicit v2 hostConfig here with empty connection
-      // settings would clobber project defaults — so we keep the flat
-      // path until the editor learns to read the project default
-      // and round-trip its connection portion.
       const payload = {
         name: trimmedName,
         description: description.trim() || undefined,
-        hostStyle,
-        systemPrompt: systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
-        modelId,
-        temperature,
-        requireToolApproval,
         allowGuestAccess,
-        serverIds: selectedServerIds,
-        optionalServerIds,
+        hostConfig: hostConfigInput,
       };
 
       let result;

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
@@ -163,13 +163,14 @@ export function ChatboxEditor({
       : "skip"
   ) as HostConfigDtoV2 | null | undefined;
 
-  // Create-mode seed: the project default supplies the connection
-  // portion for new chatboxes.
+  // Project default seeds the connection portion for new chatboxes
+  // and is the fallback for legacy edit-mode rows that resolve null
+  // from getChatboxConfig — without it, draftToHostConfigInputV2 would
+  // fall back to v2 empty shape and silently drop the project's
+  // configured headers / capabilities / hostContext on next save.
   const projectDefaultHostConfig = useQuery(
     "hostConfigsV2:getProjectDefault" as any,
-    isAuthenticated && isCreateMode && projectId
-      ? ({ projectId } as any)
-      : "skip"
+    isAuthenticated && projectId ? ({ projectId } as any) : "skip"
   ) as HostConfigDtoV2 | null | undefined;
   const isMobile = useIsMobile();
 
@@ -596,10 +597,15 @@ export function ChatboxEditor({
     }
 
     // The backend's v2 hostConfig path persists connection fields
-    // verbatim. Block save until the seed query has resolved so we
-    // don't ship empty connectionDefaults / clientCapabilities /
-    // hostContext and clobber the existing values.
-    const seedDto = isCreateMode ? projectDefaultHostConfig : chatboxHostConfig;
+    // verbatim. Block save until a seed has resolved so we don't ship
+    // empty connectionDefaults / clientCapabilities / hostContext and
+    // clobber the existing values. For edit-mode chatboxes prefer the
+    // chatbox's own config; fall back to the project default for
+    // legacy rows that resolve null. For create mode, use the project
+    // default directly.
+    const seedDto = isCreateMode
+      ? projectDefaultHostConfig
+      : (chatboxHostConfig ?? projectDefaultHostConfig);
     if (seedDto === undefined) {
       toast.error("Loading chatbox config — try again in a moment");
       return;

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxEditor.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxEditor.test.tsx
@@ -40,6 +40,7 @@ vi.mock("sonner", () => ({
 
 vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isAuthenticated: true }),
+  useQuery: () => null,
 }));
 
 vi.mock("@/hooks/useChatboxes", () => ({

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
@@ -16,7 +16,7 @@ import {
   Save,
 } from "lucide-react";
 import { ReactFlowProvider } from "@xyflow/react";
-import { useConvexAuth } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
 import { Button } from "@mcpjam/design-system/button";
 import { Card } from "@mcpjam/design-system/card";
 import {
@@ -67,7 +67,15 @@ import { ChatboxHostStyleProvider } from "@/contexts/chatbox-host-style-context"
 import type { ServerFormData } from "@/shared/types";
 import { buildChatboxCanvas } from "./chatboxCanvasBuilder";
 import { ChatboxCanvas } from "./ChatboxCanvas";
-import { DEFAULT_SYSTEM_PROMPT, toDraftConfig } from "./drafts";
+import {
+  DEFAULT_SYSTEM_PROMPT,
+  draftToHostConfigInputV2,
+  toDraftConfig,
+} from "./drafts";
+import {
+  hostConfigDtoToInput,
+  type HostConfigDtoV2,
+} from "@/lib/host-config-v2";
 import {
   computeSectionStatuses,
   SetupChecklistPanel,
@@ -296,6 +304,25 @@ export function ChatboxBuilderView({
   const { createChatbox, updateChatbox, setChatboxMode, upsertChatboxMember } =
     useChatboxMutations();
   const { createServer } = useServerMutations();
+
+  // Round-trip the chatbox's own hostConfig (edit mode). The save path
+  // sends a complete HostConfigInputV2 to the backend; the backend's
+  // mintV2ChatboxHostConfigFromV2Input persists the connection portion
+  // (connectionDefaults / clientCapabilities / hostContext) verbatim,
+  // so we MUST feed it the existing values or they'll be clobbered.
+  const chatboxHostConfig = useQuery(
+    "hostConfigsV2:getChatboxConfig" as any,
+    isAuthenticated && chatboxId ? ({ chatboxId } as any) : "skip"
+  ) as HostConfigDtoV2 | null | undefined;
+
+  // Seed for create mode: the project default supplies the connection
+  // portion the chatbox builder UI doesn't expose.
+  const projectDefaultHostConfig = useQuery(
+    "hostConfigsV2:getProjectDefault" as any,
+    isAuthenticated && !chatboxId && projectId
+      ? ({ projectId } as any)
+      : "skip"
+  ) as HostConfigDtoV2 | null | undefined;
 
   const [draftChatboxConfig, setDraftChatboxConfig] =
     useState<ChatboxDraftConfig>(() => {
@@ -745,22 +772,35 @@ export function ChatboxBuilderView({
       return false;
     }
 
+    // The backend's v2 hostConfig path persists connection fields
+    // verbatim. Block save until the seed query has resolved so we
+    // don't ship empty connectionDefaults / clientCapabilities /
+    // hostContext and clobber the existing values.
+    const seedDto = chatboxId ? chatboxHostConfig : projectDefaultHostConfig;
+    if (seedDto === undefined) {
+      toast.error("Loading chatbox config — try again in a moment");
+      return false;
+    }
+    const seedInput = seedDto ? hostConfigDtoToInput(seedDto) : null;
+    const draftWithTrimmedSystemPrompt: ChatboxDraftConfig = {
+      ...draftChatboxConfig,
+      systemPrompt:
+        draftChatboxConfig.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
+    };
+    const hostConfigInput = draftToHostConfigInputV2(
+      draftWithTrimmedSystemPrompt,
+      seedInput
+    );
+
     setIsSaving(true);
     try {
       const payload = {
         name: trimmedName,
         description: draftChatboxConfig.description.trim() || undefined,
-        hostStyle: draftChatboxConfig.hostStyle,
-        systemPrompt:
-          draftChatboxConfig.systemPrompt.trim() || DEFAULT_SYSTEM_PROMPT,
-        modelId: draftChatboxConfig.modelId,
-        temperature: draftChatboxConfig.temperature,
-        requireToolApproval: draftChatboxConfig.requireToolApproval,
-        serverIds: draftChatboxConfig.selectedServerIds,
-        optionalServerIds: draftChatboxConfig.optionalServerIds,
         allowGuestAccess: draftChatboxConfig.allowGuestAccess,
         welcomeDialog: draftChatboxConfig.welcomeDialog,
         feedbackDialog: draftChatboxConfig.feedbackDialog,
+        hostConfig: hostConfigInput,
       };
 
       if (!chatbox) {
@@ -797,6 +837,9 @@ export function ChatboxBuilderView({
     draftChatboxConfig,
     onSavedDraft,
     chatbox,
+    chatboxId,
+    chatboxHostConfig,
+    projectDefaultHostConfig,
     setChatboxMode,
     updateChatbox,
     projectId,

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
@@ -787,12 +787,17 @@ export function ChatboxBuilderView({
     // verbatim. Block save until a seed has resolved so we don't ship
     // empty connectionDefaults / clientCapabilities / hostContext and
     // clobber the existing values. For edit-mode chatboxes prefer the
-    // chatbox's own config; fall back to the project default for
-    // legacy rows that resolve null. For create mode, use the project
-    // default directly.
-    const seedDto = chatboxId
-      ? (chatboxHostConfig ?? projectDefaultHostConfig)
-      : projectDefaultHostConfig;
+    // chatbox's own config; only fall back to the project default
+    // when the chatbox config has *resolved* null (legacy rows) — not
+    // while it's still undefined (loading), which would let the
+    // project default overwrite an existing chatbox's own connection
+    // fields if the project query resolves first. For create mode,
+    // use the project default directly.
+    const chatboxSeed =
+      chatboxHostConfig === null
+        ? projectDefaultHostConfig
+        : chatboxHostConfig;
+    const seedDto = chatboxId ? chatboxSeed : projectDefaultHostConfig;
     if (seedDto === undefined) {
       toast.error("Loading chatbox config — try again in a moment");
       return false;

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
@@ -772,6 +772,16 @@ export function ChatboxBuilderView({
       return false;
     }
 
+    // On an edit route chatboxId is set before useChatbox() resolves;
+    // branching the create-vs-update decision below on `chatbox` (the
+    // reactive load) would let an early click fall into createChatbox
+    // and duplicate the row. Block save until the chatbox record is
+    // available, then key the branch off chatboxId.
+    if (chatboxId && !chatbox) {
+      toast.error("Loading chatbox — try again in a moment");
+      return false;
+    }
+
     // The backend's v2 hostConfig path persists connection fields
     // verbatim. Block save until the seed query has resolved so we
     // don't ship empty connectionDefaults / clientCapabilities /
@@ -803,7 +813,7 @@ export function ChatboxBuilderView({
         hostConfig: hostConfigInput,
       };
 
-      if (!chatbox) {
+      if (!chatboxId) {
         let created = (await createChatbox({
           projectId,
           ...payload,
@@ -821,7 +831,7 @@ export function ChatboxBuilderView({
       }
 
       await updateChatbox({
-        chatboxId: chatbox.chatboxId,
+        chatboxId,
         ...payload,
       });
       toast.success("Chatbox updated");

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
@@ -315,13 +315,14 @@ export function ChatboxBuilderView({
     isAuthenticated && chatboxId ? ({ chatboxId } as any) : "skip"
   ) as HostConfigDtoV2 | null | undefined;
 
-  // Seed for create mode: the project default supplies the connection
-  // portion the chatbox builder UI doesn't expose.
+  // Project default seeds the connection portion for new chatboxes and
+  // is also the fallback for legacy edit-mode rows that resolve null
+  // from getChatboxConfig — without it, draftToHostConfigInputV2 would
+  // fall back to v2 empty shape and silently drop the project's
+  // configured headers / capabilities / hostContext on next save.
   const projectDefaultHostConfig = useQuery(
     "hostConfigsV2:getProjectDefault" as any,
-    isAuthenticated && !chatboxId && projectId
-      ? ({ projectId } as any)
-      : "skip"
+    isAuthenticated && projectId ? ({ projectId } as any) : "skip"
   ) as HostConfigDtoV2 | null | undefined;
 
   const [draftChatboxConfig, setDraftChatboxConfig] =
@@ -783,10 +784,15 @@ export function ChatboxBuilderView({
     }
 
     // The backend's v2 hostConfig path persists connection fields
-    // verbatim. Block save until the seed query has resolved so we
-    // don't ship empty connectionDefaults / clientCapabilities /
-    // hostContext and clobber the existing values.
-    const seedDto = chatboxId ? chatboxHostConfig : projectDefaultHostConfig;
+    // verbatim. Block save until a seed has resolved so we don't ship
+    // empty connectionDefaults / clientCapabilities / hostContext and
+    // clobber the existing values. For edit-mode chatboxes prefer the
+    // chatbox's own config; fall back to the project default for
+    // legacy rows that resolve null. For create mode, use the project
+    // default directly.
+    const seedDto = chatboxId
+      ? (chatboxHostConfig ?? projectDefaultHostConfig)
+      : projectDefaultHostConfig;
     if (seedDto === undefined) {
       toast.error("Loading chatbox config — try again in a moment");
       return false;

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxBuilderView.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxBuilderView.test.tsx
@@ -15,6 +15,7 @@ vi.mock("sonner", () => ({
 
 vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isAuthenticated: true }),
+  useQuery: () => null,
 }));
 
 vi.mock("@/hooks/useChatboxes", () => ({


### PR DESCRIPTION
The chatbox builder and legacy editor now assemble a complete HostConfigInputV2 on the frontend and send it via the v2 `hostConfig` arg, instead of relying on the backend's flat-fields fallback to silently seed connection settings from the project default.

- Edit mode: round-trip the chatbox's own connectionDefaults / clientCapabilities / hostContext (via hostConfigsV2:getChatboxConfig) so subsequent saves don't re-seed from a possibly-stale project default.
- Create mode: seed those three fields from hostConfigsV2:getProjectDefault.
- Save is gated on the seed query resolving so empty connection fields can't clobber the existing values via mintV2ChatboxHostConfigFromV2Input's verbatim-persist behavior.
- Reuses the existing draftToHostConfigInputV2 helper. Backend unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes chatbox create/update payloads to always send a full `hostConfig` v2 object, which can affect persisted configuration if the seeding/round-tripping logic is wrong or queries race. Added save gating reduces overwrite risk but failures could block saves until config queries resolve.
> 
> **Overview**
> **Chatbox saves are now routed through the v2 `hostConfig` path** in both the legacy `ChatboxEditor` and the new `ChatboxBuilderView`, replacing the previous flat-field save payload.
> 
> On save, the UI now fetches and uses a *connection seed* (prefer the chatbox’s own v2 config; fall back to the project default only when the chatbox config resolves `null`) and blocks saving while that seed is still loading to avoid clobbering connection-related fields the UI doesn’t edit.
> 
> The builder additionally prevents accidental duplicate creation by blocking saves on edit routes until the chatbox record has loaded and branching create-vs-update off `chatboxId`. Tests were updated to mock `useQuery` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ba35e687ae932123ff13dcbfcbb232df22649b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->