### PR TITLE
chatbox auth: full Phase E + F inspector migration

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -543,7 +543,7 @@ export default function App() {
       !!callbackContext.projectId && !!callbackContext.serverId;
     const isGuestChatboxSessionCallback =
       !isAuthenticated &&
-      !!callbackContext.chatboxToken &&
+      !!callbackContext.chatboxId &&
       !!callbackContext.sessionId;
     const shouldUseHostedCompletion =
       hasHostedServerContext &&

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -451,7 +451,8 @@ describe("App hosted OAuth callback handling", () => {
     );
 
     writeChatboxSession({
-      token: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       payload: {
         projectId: "ws_1",
         chatboxId: "sbx_1",
@@ -483,7 +484,8 @@ describe("App hosted OAuth callback handling", () => {
       serverId: "srv_asana",
       sessionId: "hosted-session-1",
       accessScope: "chat_v2",
-      chatboxToken: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       serverName: "asana",
       serverUrl: "https://mcp.asana.com/sse",
       returnHash: "#asaan",
@@ -569,7 +571,7 @@ describe("App hosted OAuth callback handling", () => {
           projectId: "ws_1",
           serverId: "srv_asana",
           sessionId: "hosted-session-1",
-          chatboxToken: "chatbox-token",
+          chatboxId: "sbx_1",
         }),
         "oauth-code",
         expect.objectContaining({
@@ -587,7 +589,8 @@ describe("App hosted OAuth callback handling", () => {
       projectId: "ws_1",
       serverId: "srv_asana",
       accessScope: "chat_v2",
-      chatboxToken: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       serverName: "asana",
       serverUrl: "https://mcp.asana.com/sse",
       returnHash: "#asaan",
@@ -605,7 +608,7 @@ describe("App hosted OAuth callback handling", () => {
           projectId: "ws_1",
           serverId: "srv_asana",
           sessionId: null,
-          chatboxToken: "chatbox-token",
+          chatboxId: "sbx_1",
         }),
         "oauth-code",
         expect.objectContaining({
@@ -2222,7 +2225,8 @@ describe("App hosted OAuth callback handling", () => {
       serverId: "srv_asana",
       sessionId: "hosted-session-chatboxes",
       accessScope: "chat_v2",
-      chatboxToken: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       serverName: "asana",
       serverUrl: "https://mcp.asana.com/sse",
       returnHash: "#chatboxes",

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -315,20 +315,20 @@ export function ChatTabV2({
       ),
     [selectedConnectedServerNames, serversByName, appState.servers]
   );
-  const hostedChatboxToken = hostedContext?.chatboxToken;
+  const hostedChatboxId = hostedContext?.chatboxId;
   const hostedChatboxSurface = hostedContext?.chatboxSurface;
   const effectiveHostedProjectId =
     hostedContext?.projectId ?? convexProjectId;
   const effectiveHostedSelectedServerIds =
     hostedContext?.selectedServerIds ?? hostedSelectedServerIds;
-  const effectiveHostedOAuthTokens = hostedChatboxToken
+  const effectiveHostedOAuthTokens = hostedChatboxId
     ? undefined
     : hostedContext?.oauthTokens ?? hostedOAuthTokens;
   const isHostedDirectGuest =
     HOSTED_MODE &&
     !isConvexAuthenticated &&
     !effectiveHostedProjectId &&
-    !hostedChatboxToken;
+    !hostedChatboxId;
 
   // Use shared chat session hook
   const {
@@ -418,7 +418,7 @@ export function ChatTabV2({
   const showHistoryRail =
     HOSTED_MODE &&
     !minimalMode &&
-    !hostedChatboxToken &&
+    !hostedChatboxId &&
     chatHistoryRailEnabled;
   const {
     session: reactiveHistorySession,
@@ -1095,7 +1095,7 @@ export function ChatTabV2({
     enableMultiModelChat &&
     !minimalMode &&
     !executionConfig?.modelId &&
-    !hostedChatboxToken &&
+    !hostedChatboxId &&
     !hostedChatboxSurface &&
     availableModels.length > 1;
   // When viewing a history session, fall back to single-model rendering so

--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
@@ -466,7 +466,7 @@ describe("ChatTabV2 history sync", () => {
       <ChatTabV2
         {...defaultProps}
         hostedContext={{
-          chatboxToken: "chatbox-token",
+          chatboxId: "cbx_test", accessVersion: 1,
           projectId: "project-1",
           selectedServerIds: ["server-1"],
         }}
@@ -474,7 +474,7 @@ describe("ChatTabV2 history sync", () => {
     );
 
     expect(lastUseChatSessionOptionsRef.current?.hostedContext).toMatchObject({
-      chatboxToken: "chatbox-token",
+      chatboxId: "cbx_test", accessVersion: 1,
     });
     expect(
       lastUseChatSessionOptionsRef.current?.hostedContext?.oauthTokens

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
@@ -468,7 +468,7 @@ export function ChatboxEditor({
     pendingKey: CHATBOX_OAUTH_PENDING_KEY,
     servers: previewOAuthGateServers,
     projectId: chatbox?.projectId ?? projectId,
-    chatboxToken: previewToken ?? undefined,
+    chatboxId: chatbox?.chatboxId,
     isAuthenticated,
   });
   const isFinishingPreviewOAuth =
@@ -735,7 +735,8 @@ export function ChatboxEditor({
     };
 
     writePlaygroundSession({
-      token: previewToken,
+      chatboxId: chatbox.chatboxId,
+      accessVersion: 0,
       payload,
       surface: "preview",
       playgroundId: previewPlaygroundId,
@@ -1240,7 +1241,7 @@ export function ChatboxEditor({
                       minimalMode
                       reasoningDisplayMode="hidden"
                       hostedContext={{
-                        chatboxToken: previewToken,
+                        chatboxId: chatbox.chatboxId,
                         chatboxSurface: "preview",
                         projectId: chatbox.projectId,
                         selectedServerIds: activePreviewServers.map(

--- a/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxEditor.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/__tests__/ChatboxEditor.test.tsx
@@ -218,7 +218,7 @@ describe("ChatboxEditor preview", () => {
 
     expect(mockWritePlaygroundSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        token: "chatbox-token",
+        chatboxId: "sbx_1",
         surface: "preview",
         payload: expect.objectContaining({
           chatboxId: "sbx_1",

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
@@ -718,7 +718,7 @@ export function ChatboxBuilderView({
     pendingKey: CHATBOX_OAUTH_PENDING_KEY,
     servers: previewOAuthGateServers,
     projectId: chatbox?.projectId ?? projectId,
-    chatboxToken: chatbox?.link?.token,
+    chatboxId: chatbox?.chatboxId,
     isAuthenticated,
   });
 
@@ -1155,7 +1155,7 @@ export function ChatboxBuilderView({
                                   minimalMode
                                   reasoningDisplayMode="hidden"
                                   hostedContext={{
-                                    chatboxToken: chatbox.link.token,
+                                    chatboxId: chatbox.chatboxId,
                                     chatboxSurface: "preview",
                                     projectId: chatbox!.projectId,
                                     selectedServerIds: activePreviewServers.map(

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -424,6 +424,12 @@ export function ChatboxChatPage({
     projectId: session?.payload.projectId ?? null,
     serverIdsByName: session ? hostedServerIdsByName : {},
     getAccessToken,
+    // Post-refactor: prefer (chatboxId, accessVersion) from the redeemed
+    // session over the raw URL token. The session writer stores the
+    // chatboxId on payload.chatboxId and the version on the top-level
+    // accessVersion field; both are populated by /api/web/chatboxes/redeem.
+    chatboxId: session?.payload.chatboxId,
+    accessVersion: session?.accessVersion,
     chatboxToken: tokenFromPath ?? session?.token,
     isAuthenticated: !!workOsUser,
     hasSession: !!workOsUser || isWorkOsLoading,
@@ -465,25 +471,55 @@ export function ChatboxChatPage({
           status: "started",
         });
         try {
-          const response = await authFetch("/api/web/chatboxes/bootstrap", {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
+          // Phase E: prefer the new /redeem endpoint, which both mints a
+          // chatboxAccess grant on the backend AND returns the bootstrap
+          // payload. Fall back to the legacy /bootstrap endpoint if redeem
+          // is unavailable (older backend deployments) so this still works
+          // through the rollout.
+          const redeemResponse = await authFetch(
+            "/api/web/chatboxes/redeem",
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ chatboxToken: tokenFromPath }),
             },
-            body: JSON.stringify({ token: tokenFromPath }),
-          });
+          );
 
-          if (!response.ok) {
-            throw await readRouteError(response);
+          let payload: ChatboxSession["payload"];
+          let accessVersionFromRedeem: number | undefined;
+
+          if (redeemResponse.ok) {
+            const redeemed = (await redeemResponse.json()) as {
+              chatboxId: string;
+              accessVersion: number;
+              bootstrap: ChatboxSession["payload"];
+            };
+            payload = redeemed.bootstrap;
+            accessVersionFromRedeem = redeemed.accessVersion;
+          } else if (redeemResponse.status === 404) {
+            // Redeem endpoint not deployed yet — use legacy bootstrap.
+            const response = await authFetch(
+              "/api/web/chatboxes/bootstrap",
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ token: tokenFromPath }),
+              },
+            );
+            if (!response.ok) throw await readRouteError(response);
+            payload = (await response.json()) as ChatboxSession["payload"];
+          } else {
+            throw await readRouteError(redeemResponse);
           }
-
-          const payload = (await response.json()) as ChatboxSession["payload"];
           if (cancelled) return;
 
           const nextSession: ChatboxSession = {
             token: tokenFromPath,
             payload,
             surface: readChatboxSurfaceFromUrl(window.location.search),
+            ...(typeof accessVersionFromRedeem === "number"
+              ? { accessVersion: accessVersionFromRedeem }
+              : {}),
           };
           writeCurrentSession(nextSession);
           setSession(nextSession);

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -16,6 +16,7 @@ import {
   buildChatboxLink,
   clearChatboxSession,
   extractChatboxTokenFromPath,
+  normalizeChatboxSession,
   readPlaygroundSession,
   readChatboxSurfaceFromUrl,
   readChatboxSession,
@@ -488,18 +489,36 @@ export function ChatboxChatPage({
           }
 
           const redeemed = (await redeemResponse.json()) as {
-            chatboxId: string;
-            accessVersion: number;
-            bootstrap: ChatboxSession["payload"];
+            chatboxId?: unknown;
+            accessVersion?: unknown;
+            bootstrap?: unknown;
           };
           if (cancelled) return;
 
-          const nextSession: ChatboxSession = {
-            chatboxId: redeemed.chatboxId,
-            accessVersion: redeemed.accessVersion,
-            payload: redeemed.bootstrap,
+          // The redeem response is treated as untrusted shape until validated
+          // — `normalizeChatboxSession` enforces every field
+          // `ChatboxBootstrapPayload` requires. Without this, a partial
+          // bootstrap (missing projectId/modelId/etc.) would be persisted
+          // and the API context downstream would initialize with `null`s.
+          const nextSession = normalizeChatboxSession({
+            chatboxId:
+              typeof redeemed.chatboxId === "string"
+                ? redeemed.chatboxId
+                : undefined,
+            accessVersion:
+              typeof redeemed.accessVersion === "number"
+                ? redeemed.accessVersion
+                : undefined,
+            payload: redeemed.bootstrap as ChatboxSession["payload"] | undefined,
             surface: readChatboxSurfaceFromUrl(window.location.search),
-          };
+          });
+          if (!nextSession) {
+            throw createChatboxRouteError(
+              502,
+              "Chatbox redeem returned an incomplete bootstrap payload.",
+            );
+          }
+
           writeCurrentSession(nextSession);
           setSession(nextSession);
           setRouteError(null);

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -300,10 +300,10 @@ export function ChatboxChatPage({
   >([]);
 
   useEffect(() => {
-    if (!session?.token) return;
+    if (!session?.chatboxId) return;
     try {
       const raw = sessionStorage.getItem(
-        chatboxEnabledOptionalStorageKey(session.token)
+        chatboxEnabledOptionalStorageKey(session.chatboxId)
       );
       if (!raw) {
         setEnabledOptionalServerIds((prev) => (prev.length === 0 ? prev : []));
@@ -329,21 +329,21 @@ export function ChatboxChatPage({
     } catch {
       setEnabledOptionalServerIds((prev) => (prev.length === 0 ? prev : []));
     }
-    // Intentionally only re-hydrate when the share token changes — not when
+    // Intentionally only re-hydrate when the chatbox id changes — not when
     // `payload.servers` gets a new array identity on each render.
-  }, [session?.token]);
+  }, [session?.chatboxId]);
 
   useEffect(() => {
-    if (!session?.token) return;
+    if (!session?.chatboxId) return;
     try {
-      const key = chatboxEnabledOptionalStorageKey(session.token);
+      const key = chatboxEnabledOptionalStorageKey(session.chatboxId);
       const serialized = JSON.stringify(enabledOptionalServerIds);
       if (sessionStorage.getItem(key) === serialized) return;
       sessionStorage.setItem(key, serialized);
     } catch {
       // ignore
     }
-  }, [session?.token, enabledOptionalServerIds]);
+  }, [session?.chatboxId, enabledOptionalServerIds]);
 
   const sessionServersActive = useMemo(() => {
     if (!session) return [];
@@ -385,7 +385,8 @@ export function ChatboxChatPage({
     pendingKey: CHATBOX_OAUTH_PENDING_KEY,
     servers: oauthServers,
     projectId: session?.payload.projectId ?? null,
-    chatboxToken: session?.token,
+    chatboxId: session?.chatboxId,
+    accessVersion: session?.accessVersion,
     isAuthenticated,
   });
 
@@ -424,13 +425,11 @@ export function ChatboxChatPage({
     projectId: session?.payload.projectId ?? null,
     serverIdsByName: session ? hostedServerIdsByName : {},
     getAccessToken,
-    // Post-refactor: prefer (chatboxId, accessVersion) from the redeemed
-    // session over the raw URL token. The session writer stores the
-    // chatboxId on payload.chatboxId and the version on the top-level
-    // accessVersion field; both are populated by /api/web/chatboxes/redeem.
-    chatboxId: session?.payload.chatboxId,
+    // Resolved chatbox identity from /api/web/chatboxes/redeem. Both
+    // fields live at the top level of the session — the URL token is
+    // never threaded onto the read path.
+    chatboxId: session?.chatboxId,
     accessVersion: session?.accessVersion,
-    chatboxToken: tokenFromPath ?? session?.token,
     isAuthenticated: !!workOsUser,
     hasSession: !!workOsUser || isWorkOsLoading,
   });
@@ -471,11 +470,10 @@ export function ChatboxChatPage({
           status: "started",
         });
         try {
-          // Phase E: prefer the new /redeem endpoint, which both mints a
-          // chatboxAccess grant on the backend AND returns the bootstrap
-          // payload. Fall back to the legacy /bootstrap endpoint if redeem
-          // is unavailable (older backend deployments) so this still works
-          // through the rollout.
+          // /redeem exchanges the URL link token for a `chatboxId` +
+          // `accessVersion` grant plus the bootstrap payload, in one round
+          // trip. Every chatbox-aware backend call then keys on the resolved
+          // identity — the URL token is not threaded onto the read path.
           const redeemResponse = await authFetch(
             "/api/web/chatboxes/redeem",
             {
@@ -485,41 +483,22 @@ export function ChatboxChatPage({
             },
           );
 
-          let payload: ChatboxSession["payload"];
-          let accessVersionFromRedeem: number | undefined;
-
-          if (redeemResponse.ok) {
-            const redeemed = (await redeemResponse.json()) as {
-              chatboxId: string;
-              accessVersion: number;
-              bootstrap: ChatboxSession["payload"];
-            };
-            payload = redeemed.bootstrap;
-            accessVersionFromRedeem = redeemed.accessVersion;
-          } else if (redeemResponse.status === 404) {
-            // Redeem endpoint not deployed yet — use legacy bootstrap.
-            const response = await authFetch(
-              "/api/web/chatboxes/bootstrap",
-              {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ token: tokenFromPath }),
-              },
-            );
-            if (!response.ok) throw await readRouteError(response);
-            payload = (await response.json()) as ChatboxSession["payload"];
-          } else {
+          if (!redeemResponse.ok) {
             throw await readRouteError(redeemResponse);
           }
+
+          const redeemed = (await redeemResponse.json()) as {
+            chatboxId: string;
+            accessVersion: number;
+            bootstrap: ChatboxSession["payload"];
+          };
           if (cancelled) return;
 
           const nextSession: ChatboxSession = {
-            token: tokenFromPath,
-            payload,
+            chatboxId: redeemed.chatboxId,
+            accessVersion: redeemed.accessVersion,
+            payload: redeemed.bootstrap,
             surface: readChatboxSurfaceFromUrl(window.location.search),
-            ...(typeof accessVersionFromRedeem === "number"
-              ? { accessVersion: accessVersionFromRedeem }
-              : {}),
           };
           writeCurrentSession(nextSession);
           setSession(nextSession);
@@ -664,7 +643,11 @@ export function ChatboxChatPage({
   }, [session]);
 
   const handleCopyLink = useCallback(async () => {
-    const token = session?.token?.trim();
+    // The share URL is what the viewer is currently on — `tokenFromPath`
+    // is the canonical source. The session itself no longer carries the
+    // link token after the redeem refactor; persisting it on the read
+    // path would re-introduce the very token plumbing we removed.
+    const token = tokenFromPath?.trim();
     if (!session || !token) {
       toast.error("Chatbox link unavailable");
       return;
@@ -683,7 +666,7 @@ export function ChatboxChatPage({
     } catch {
       toast.error("Failed to copy chatbox link");
     }
-  }, [session]);
+  }, [session, tokenFromPath]);
 
   const handleOpenMcpJam = useCallback(() => {
     clearChatboxSession();
@@ -780,7 +763,8 @@ export function ChatboxChatPage({
             hostStyle
           )}
           hostedContext={{
-            chatboxToken: session.token,
+            chatboxId: session.chatboxId,
+            accessVersion: session.accessVersion,
             chatboxSurface: session.surface ?? "share_link",
             projectId: session.payload.projectId,
             selectedServerIds: sessionServersActive.map(

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
@@ -183,19 +183,23 @@ describe("ChatboxChatPage", () => {
     });
     mockAuthFetch.mockResolvedValue(
       createFetchResponse({
-        projectId: "ws_1",
         chatboxId: "sbx_1",
-        name: "Resolved Chatbox",
-        description: "Hosted chatbox",
-        hostStyle: "claude",
-        mode: "invited_only",
-        allowGuestAccess: false,
-        viewerIsProjectMember: true,
-        systemPrompt: "You are helpful.",
-        modelId: "openai/gpt-5-mini",
-        temperature: 0.4,
-        requireToolApproval: true,
-        servers: [],
+        accessVersion: 1,
+        bootstrap: {
+          projectId: "ws_1",
+          chatboxId: "sbx_1",
+          name: "Resolved Chatbox",
+          description: "Hosted chatbox",
+          hostStyle: "claude",
+          mode: "invited_only",
+          allowGuestAccess: false,
+          viewerIsProjectMember: true,
+          systemPrompt: "You are helpful.",
+          modelId: "openai/gpt-5-mini",
+          temperature: 0.4,
+          requireToolApproval: true,
+          servers: [],
+        },
       })
     );
   });
@@ -208,7 +212,8 @@ describe("ChatboxChatPage", () => {
 
   it("applies chatbox host style data attributes while keeping MCPJam branding", async () => {
     writeChatboxSession({
-      token: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       payload: {
         projectId: "ws_1",
         chatboxId: "sbx_1",
@@ -243,7 +248,8 @@ describe("ChatboxChatPage", () => {
 
   it("uses the Claude loading indicator variant for Claude-style hosted chatboxes", async () => {
     writeChatboxSession({
-      token: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       payload: {
         projectId: "ws_1",
         chatboxId: "sbx_1",
@@ -280,7 +286,8 @@ describe("ChatboxChatPage", () => {
 
     writePlaygroundSession({
       playgroundId: "pg_123",
-      token: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       surface: "preview",
       updatedAt: Date.now(),
       payload: {
@@ -378,7 +385,8 @@ describe("ChatboxChatPage", () => {
       expect.objectContaining({
         projectId: null,
         serverIdsByName: {},
-        chatboxToken: "token-workos",
+        chatboxId: undefined,
+        accessVersion: undefined,
         isAuthenticated: true,
         hasSession: true,
       })
@@ -392,9 +400,9 @@ describe("ChatboxChatPage", () => {
     expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
     expect(mockAuthFetch).toHaveBeenCalledTimes(1);
     expect(mockAuthFetch).toHaveBeenCalledWith(
-      "/api/web/chatboxes/bootstrap",
+      "/api/web/chatboxes/redeem",
       expect.objectContaining({
-        body: JSON.stringify({ token: "token-workos" }),
+        body: JSON.stringify({ chatboxToken: "token-workos" }),
       })
     );
     expect(mockPosthogCapture).toHaveBeenCalledWith(
@@ -429,9 +437,9 @@ describe("ChatboxChatPage", () => {
       await screen.findByRole("heading", { name: "Access Denied" })
     ).toBeInTheDocument();
     expect(mockAuthFetch).toHaveBeenCalledWith(
-      "/api/web/chatboxes/bootstrap",
+      "/api/web/chatboxes/redeem",
       expect.objectContaining({
-        body: JSON.stringify({ token: "token-stalled-convex" }),
+        body: JSON.stringify({ chatboxToken: "token-stalled-convex" }),
       })
     );
   });
@@ -586,7 +594,8 @@ describe("ChatboxChatPage", () => {
     );
 
     writeChatboxSession({
-      token: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       payload: {
         projectId: "ws_1",
         chatboxId: "sbx_1",
@@ -637,13 +646,13 @@ describe("ChatboxChatPage", () => {
       "srv_asana",
       undefined,
       undefined,
-      {
+      expect.objectContaining({
         projectId: "ws_1",
         serverId: "srv_asana",
         serverName: "asana",
         accessScope: "chat_v2",
-        chatboxToken: "chatbox-token",
-      }
+        chatboxId: "sbx_1",
+      }),
     );
     expect(mockValidateHostedServer).toHaveBeenCalledTimes(1);
   });
@@ -651,7 +660,8 @@ describe("ChatboxChatPage", () => {
   it("keeps guest chatbox OAuth in first-consent welcome before callback completion", async () => {
     mockConvexAuthState.isAuthenticated = false;
     writeChatboxSession({
-      token: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       payload: {
         projectId: "ws_1",
         chatboxId: "sbx_1",
@@ -714,7 +724,8 @@ describe("ChatboxChatPage", () => {
     );
 
     writeChatboxSession({
-      token: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       payload: {
         projectId: "ws_1",
         chatboxId: "sbx_1",
@@ -778,7 +789,8 @@ describe("ChatboxChatPage", () => {
     mockGetStoredTokens.mockReturnValue({ access_token: "chatbox-token" });
 
     writeChatboxSession({
-      token: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       payload: {
         projectId: "ws_1",
         chatboxId: "sbx_1",
@@ -836,7 +848,8 @@ describe("ChatboxChatPage", () => {
     });
 
     writeChatboxSession({
-      token: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       payload: {
         projectId: "ws_1",
         chatboxId: "sbx_1",
@@ -903,7 +916,8 @@ describe("ChatboxChatPage", () => {
 
     it("shows welcome dialog when welcomeDialog is enabled and has content", async () => {
       writeChatboxSession({
-        token: "chatbox-token",
+        chatboxId: "sbx_1",
+        accessVersion: 1,
         payload: {
           projectId: "ws_1",
           chatboxId: "sbx_welcome",
@@ -941,7 +955,8 @@ describe("ChatboxChatPage", () => {
 
     it("dismisses welcome and shows chat when Get Started is clicked", async () => {
       writeChatboxSession({
-        token: "chatbox-token",
+        chatboxId: "sbx_1",
+        accessVersion: 1,
         payload: {
           projectId: "ws_1",
           chatboxId: "sbx_dismiss",
@@ -977,7 +992,8 @@ describe("ChatboxChatPage", () => {
 
     it("skips welcome and goes straight to chat when welcomeDialog.enabled is false", async () => {
       writeChatboxSession({
-        token: "chatbox-token",
+        chatboxId: "sbx_1",
+        accessVersion: 1,
         payload: {
           projectId: "ws_1",
           chatboxId: "sbx_disabled",
@@ -1012,7 +1028,8 @@ describe("ChatboxChatPage", () => {
 
     it("skips welcome and goes straight to chat when welcomeDialog body is empty", async () => {
       writeChatboxSession({
-        token: "chatbox-token",
+        chatboxId: "sbx_1",
+        accessVersion: 1,
         payload: {
           projectId: "ws_1",
           chatboxId: "sbx_emptybody",

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
@@ -290,7 +290,7 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxToken: "chatbox-token",
+          chatboxId: "cbx_test", accessVersion: 1,
         },
       })
     );
@@ -302,20 +302,20 @@ describe("useChatSession hosted mode", () => {
       chatSessionId: "chat-session-id",
       selectedServerIds: ["server-id-1"],
       selectedServerNames: ["server-1"],
-      chatboxToken: "chatbox-token",
+      chatboxId: "cbx_test", accessVersion: 1,
       accessScope: "chat_v2",
     });
     unmount();
   });
 
-  it("includes chatboxToken in the hosted transport body", async () => {
+  it("includes chatboxId and accessVersion in the hosted transport body", async () => {
     const { result, unmount } = renderHook(() =>
       useChatSession({
         selectedServers: ["server-1"],
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxToken: "chatbox-token",
+          chatboxId: "cbx_test", accessVersion: 1,
           oauthTokens: {
             "server-id-1": "browser-token",
           },
@@ -330,7 +330,7 @@ describe("useChatSession hosted mode", () => {
       chatSessionId: "chat-session-id",
       selectedServerIds: ["server-id-1"],
       selectedServerNames: ["server-1"],
-      chatboxToken: "chatbox-token",
+      chatboxId: "cbx_test", accessVersion: 1,
       accessScope: "chat_v2",
     });
     expect(body).not.toHaveProperty("oauthTokens");
@@ -344,7 +344,7 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxToken: "chatbox-token",
+          chatboxId: "cbx_test", accessVersion: 1,
           chatboxSurface: "preview",
         },
       })
@@ -352,7 +352,7 @@ describe("useChatSession hosted mode", () => {
 
     const body = lastTransportOptions.body();
     expect(body).toMatchObject({
-      chatboxToken: "chatbox-token",
+      chatboxId: "cbx_test", accessVersion: 1,
       surface: "preview",
     });
     unmount();
@@ -403,7 +403,8 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: string;
           selectedServerIds: string[];
-          chatboxToken: string;
+          chatboxId: string;
+          accessVersion: number;
         };
       }) =>
         useChatSession({
@@ -416,7 +417,7 @@ describe("useChatSession hosted mode", () => {
           hostedContext: {
             projectId: "project-1",
             selectedServerIds: ["server-id-1"],
-            chatboxToken: "chatbox-token-1",
+            chatboxId: "cbx_1", accessVersion: 1,
           },
         },
       }
@@ -435,7 +436,7 @@ describe("useChatSession hosted mode", () => {
       hostedContext: {
         projectId: "project-2",
         selectedServerIds: ["server-id-2"],
-        chatboxToken: "chatbox-token-2",
+        chatboxId: "cbx_2", accessVersion: 1,
       },
     });
 
@@ -668,7 +669,7 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxToken: "chatbox-token",
+          chatboxId: "cbx_test", accessVersion: 1,
         },
       })
     );
@@ -738,7 +739,7 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxToken: "chatbox-token",
+          chatboxId: "cbx_test", accessVersion: 1,
         },
       })
     );
@@ -760,7 +761,7 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxToken: "chatbox-token",
+          chatboxId: "cbx_test", accessVersion: 1,
         },
       })
     );
@@ -895,7 +896,7 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxToken: "chatbox-token",
+          chatboxId: "cbx_test", accessVersion: 1,
         },
       })
     );

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
@@ -333,7 +333,7 @@ describe("useChatSession minimal mode parity", () => {
         selectedServers,
         minimalMode: true,
         hostedContext: {
-          chatboxToken: "chatbox-token",
+          chatboxId: "cbx_test", accessVersion: 1,
         },
         executionConfig: {
           systemPrompt: "Prompt",

--- a/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
@@ -62,7 +62,7 @@ describe("useSharedChatWidgetCapture", () => {
       useSharedChatWidgetCapture({
         enabled: true,
         chatSessionId: "chat-session-1",
-        hostedChatboxToken: "chatbox-token",
+        hostedChatboxId: "cbx_1", hostedAccessVersion: 1,
         messages: [
           {
             id: "assistant-1",
@@ -132,7 +132,7 @@ describe("useSharedChatWidgetCapture", () => {
     expect(mockGenerateSnapshotUploadUrl).toHaveBeenCalledTimes(3);
     expect(global.fetch).toHaveBeenCalledTimes(3);
     expect(mockCreateWidgetSnapshot).toHaveBeenCalledWith({
-      chatboxToken: "chatbox-token",
+      chatboxId: "cbx_1", accessVersion: 1,
       chatSessionId: "chat-session-1",
       serverId: "server-1",
       toolCallId: "call-1",
@@ -177,7 +177,7 @@ describe("useSharedChatWidgetCapture", () => {
           enabled: true,
           readyToPersist,
           chatSessionId: "chat-session-1",
-          hostedChatboxToken: "chatbox-token",
+          hostedChatboxId: "cbx_1", hostedAccessVersion: 1,
           messages: [
             {
               id: "assistant-1",
@@ -256,7 +256,7 @@ describe("useSharedChatWidgetCapture", () => {
         useSharedChatWidgetCapture({
           enabled: true,
           chatSessionId: "chat-session-1",
-          hostedChatboxToken: "chatbox-token",
+          hostedChatboxId: "cbx_1", hostedAccessVersion: 1,
           messages: [
             {
               id: "assistant-1",
@@ -363,7 +363,7 @@ describe("useSharedChatWidgetCapture", () => {
         useSharedChatWidgetCapture({
           enabled: true,
           chatSessionId: "chat-session-pending",
-          hostedChatboxToken: "chatbox-token",
+          hostedChatboxId: "cbx_1", hostedAccessVersion: 1,
           messages: [
             {
               id: "assistant-1",
@@ -427,7 +427,7 @@ describe("useSharedChatWidgetCapture", () => {
       useSharedChatWidgetCapture({
         enabled: true,
         chatSessionId: "chat-session-2",
-        hostedChatboxToken: "chatbox-token",
+        hostedChatboxId: "cbx_1", hostedAccessVersion: 1,
         messages: [
           {
             id: "assistant-1",
@@ -481,7 +481,7 @@ describe("useSharedChatWidgetCapture", () => {
     await flushMicrotasks();
 
     expect(mockCreateWidgetSnapshot).toHaveBeenCalledWith({
-      chatboxToken: "chatbox-token",
+      chatboxId: "cbx_1", accessVersion: 1,
       chatSessionId: "chat-session-2",
       serverId: "srv_123",
       toolCallId: "call-2",

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
@@ -8,6 +8,10 @@ interface UseApiContextOptions {
   clientConfigSyncPending?: boolean;
   getAccessToken: () => Promise<string | undefined | null>;
   oauthTokensByServerId?: Record<string, string>;
+  // Post-refactor: chatboxId + accessVersion are the preferred auth keys;
+  // chatboxToken is accepted for surfaces that haven't migrated yet.
+  chatboxId?: string;
+  accessVersion?: number;
   chatboxToken?: string;
   isAuthenticated?: boolean;
   hasSession?: boolean;
@@ -21,6 +25,8 @@ export function useApiContext({
   clientConfigSyncPending,
   getAccessToken,
   oauthTokensByServerId,
+  chatboxId,
+  accessVersion,
   chatboxToken,
   isAuthenticated,
   hasSession,
@@ -43,6 +49,8 @@ export function useApiContext({
       clientConfigSyncPending,
       getAccessToken,
       oauthTokensByServerId,
+      chatboxId,
+      accessVersion,
       chatboxToken,
       isAuthenticated,
       hasSession,
@@ -59,6 +67,8 @@ export function useApiContext({
     clientConfigSyncPending,
     getAccessToken,
     oauthTokensByServerId,
+    chatboxId,
+    accessVersion,
     chatboxToken,
     isAuthenticated,
     hasSession,

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-api-context.ts
@@ -8,11 +8,10 @@ interface UseApiContextOptions {
   clientConfigSyncPending?: boolean;
   getAccessToken: () => Promise<string | undefined | null>;
   oauthTokensByServerId?: Record<string, string>;
-  // Post-refactor: chatboxId + accessVersion are the preferred auth keys;
-  // chatboxToken is accepted for surfaces that haven't migrated yet.
+  // Resolved chatbox identity (post-redeem) — drives chatbox-aware request
+  // shaping inside the API context.
   chatboxId?: string;
   accessVersion?: number;
-  chatboxToken?: string;
   isAuthenticated?: boolean;
   hasSession?: boolean;
   enabled?: boolean;
@@ -27,7 +26,6 @@ export function useApiContext({
   oauthTokensByServerId,
   chatboxId,
   accessVersion,
-  chatboxToken,
   isAuthenticated,
   hasSession,
   enabled = true,
@@ -51,7 +49,6 @@ export function useApiContext({
       oauthTokensByServerId,
       chatboxId,
       accessVersion,
-      chatboxToken,
       isAuthenticated,
       hasSession,
     });
@@ -69,7 +66,6 @@ export function useApiContext({
     oauthTokensByServerId,
     chatboxId,
     accessVersion,
-    chatboxToken,
     isAuthenticated,
     hasSession,
   ]);

--- a/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
+++ b/mcpjam-inspector/client/src/hooks/hosted/use-hosted-oauth-gate.ts
@@ -191,7 +191,8 @@ export interface UseHostedOAuthGateOptions {
   pendingKey: string;
   servers: HostedOAuthServerDescriptor[];
   projectId?: string | null;
-  chatboxToken?: string;
+  chatboxId?: string;
+  accessVersion?: number;
   isAuthenticated?: boolean;
 }
 
@@ -211,14 +212,15 @@ export function useHostedOAuthGate({
   pendingKey,
   servers,
   projectId,
-  chatboxToken,
+  chatboxId,
+  accessVersion,
   isAuthenticated = false,
 }: UseHostedOAuthGateOptions): UseHostedOAuthGateResult {
   const oauthServers = useMemo(
     () => servers.filter((server) => server.useOAuth),
     [servers]
   );
-  const isVaultBacked = isAuthenticated || !!chatboxToken;
+  const isVaultBacked = isAuthenticated || !!chatboxId;
   const verifyVaultCredentialOnLoad = isAuthenticated;
   const [oauthStateByServerId, setOAuthStateByServerId] = useState<
     Record<string, HostedOAuthState>
@@ -318,13 +320,14 @@ export function useHostedOAuthGate({
         const validation = await validateWithRetry(
           server.serverId,
           accessToken ?? undefined,
-          chatboxToken && projectId
+          chatboxId && projectId
             ? {
                 projectId,
                 serverId: server.serverId,
                 serverName: server.serverName,
                 accessScope: "chat_v2",
-                chatboxToken,
+                chatboxId,
+                ...(Number.isFinite(accessVersion) ? { accessVersion } : {}),
               }
             : undefined
         );
@@ -384,7 +387,8 @@ export function useHostedOAuthGate({
     oauthStateByServerId,
     surface,
     isVaultBacked,
-    chatboxToken,
+    chatboxId,
+    accessVersion,
     projectId,
   ]);
 
@@ -423,12 +427,13 @@ export function useHostedOAuthGate({
         serverId: server.serverId,
         serverName: server.serverName,
         serverUrl: server.serverUrl,
-        accessScope: chatboxToken
+        accessScope: chatboxId
           ? "chat_v2"
           : isAuthenticated
           ? "project_member"
           : undefined,
-        chatboxToken,
+        chatboxId,
+        accessVersion: Number.isFinite(accessVersion) ? accessVersion : null,
         returnHash,
       });
       localStorage.setItem(pendingKey, "true");
@@ -496,7 +501,8 @@ export function useHostedOAuthGate({
       isAuthenticated,
       isVaultBacked,
       pendingKey,
-      chatboxToken,
+      chatboxId,
+      accessVersion,
       surface,
       projectId,
     ]

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -1348,7 +1348,12 @@ export function useChatSession({
           : {
               selectedServers,
               chatSessionId,
-              directVisibility,
+              // `directVisibility` only applies to direct chat. The
+              // /mcp/chat-v2 route gates it off when chatboxId is present
+              // (owner-preview persists as `sourceType: "chatbox"`), but
+              // omitting it client-side keeps the body honest about the
+              // session kind.
+              ...(hostedChatboxId ? {} : { directVisibility }),
               // Pass projectId for BYOK direct-chat history persistence
               ...(hostedProjectId ? { projectId: hostedProjectId } : {}),
               // Convex server Ids parallel to `selectedServers`. Only sent
@@ -1359,6 +1364,18 @@ export function useChatSession({
               // validator would reject the whole ingest call.
               ...(hostedSelectedServerIds.length === selectedServers.length
                 ? { selectedServerIds: hostedSelectedServerIds }
+                : {}),
+              // Phase F: owner-preview / local chatbox sessions persist as
+              // `sourceType: "chatbox"`. Without forwarding the resolved
+              // chatbox identity here, /mcp/chat-v2 derives sourceType
+              // from absent fields and the chat is filed as a direct chat
+              // instead of a chatbox session.
+              ...(hostedChatboxId ? { chatboxId: hostedChatboxId } : {}),
+              ...(hostedChatboxId && Number.isFinite(hostedAccessVersion)
+                ? { accessVersion: hostedAccessVersion }
+                : {}),
+              ...(hostedChatboxId && hostedChatboxSurface
+                ? { surface: hostedChatboxSurface }
                 : {}),
             }),
         requireToolApproval: requireToolApprovalRef.current,

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -910,7 +910,6 @@ type HostedSessionScope = {
   projectId?: string | null;
   chatboxId?: string;
   accessVersion?: number;
-  chatboxToken?: string;
 };
 
 function areHostedSessionScopesEqual(
@@ -920,8 +919,7 @@ function areHostedSessionScopesEqual(
   return (
     a.projectId === b.projectId &&
     a.chatboxId === b.chatboxId &&
-    a.accessVersion === b.accessVersion &&
-    a.chatboxToken === b.chatboxToken
+    a.accessVersion === b.accessVersion
   );
 }
 
@@ -948,7 +946,6 @@ export function useChatSession({
   const hostedOAuthTokens = hostedContext?.oauthTokens;
   const hostedChatboxId = hostedContext?.chatboxId;
   const hostedAccessVersion = hostedContext?.accessVersion;
-  const hostedChatboxToken = hostedContext?.chatboxToken;
   const hostedChatboxSurface = hostedContext?.chatboxSurface;
   const initialModelId = executionConfig?.modelId;
   const initialSystemPrompt =
@@ -1027,7 +1024,7 @@ export function useChatSession({
     isHostedGuest &&
     !isAuthLoading &&
     !!hostedProjectId &&
-    !!hostedChatboxToken;
+    !!hostedChatboxId;
   const guestMode = sharedGuestMode;
   const skipNextForkDetectionRef = useRef(false);
   const hasResolvedAuthHeadersRef = useRef(false);
@@ -1038,7 +1035,6 @@ export function useChatSession({
     projectId: undefined,
     chatboxId: undefined,
     accessVersion: undefined,
-    chatboxToken: undefined,
   });
   const pendingSessionHydrationRef = useRef<PendingSessionHydration | null>(
     null
@@ -1310,7 +1306,7 @@ export function useChatSession({
           "Hosted chat context is not ready: missing projectId."
         );
       }
-      const isHostedDirectChat = !(hostedChatboxId || hostedChatboxToken);
+      const isHostedDirectChat = !hostedChatboxId;
       return {
         projectId: hostedProjectId,
         chatSessionId,
@@ -1319,16 +1315,13 @@ export function useChatSession({
         accessScope: "chat_v2" as const,
         ...(isHostedDirectChat ? { directVisibility } : {}),
         ...(hostedChatboxId ? { chatboxId: hostedChatboxId } : {}),
-        ...(typeof hostedAccessVersion === "number"
+        ...(hostedChatboxId && Number.isFinite(hostedAccessVersion)
           ? { accessVersion: hostedAccessVersion }
           : {}),
-        ...(hostedChatboxToken && !hostedChatboxId
-          ? { chatboxToken: hostedChatboxToken }
-          : {}),
-        ...(hostedChatboxToken && hostedChatboxSurface
+        ...(hostedChatboxId && hostedChatboxSurface
           ? { surface: hostedChatboxSurface }
           : {}),
-        ...(!hostedChatboxToken &&
+        ...(isHostedDirectChat &&
         hostedOAuthTokens &&
         Object.keys(hostedOAuthTokens).length > 0
           ? { oauthTokens: hostedOAuthTokens }
@@ -1397,7 +1390,8 @@ export function useChatSession({
     chatSessionId,
     hostedSelectedServerIds,
     hostedOAuthTokens,
-    hostedChatboxToken,
+    hostedChatboxId,
+    hostedAccessVersion,
     hostedChatboxSurface,
     hostStyle,
     chatFetch,
@@ -1584,7 +1578,6 @@ export function useChatSession({
     chatSessionId,
     hostedChatboxId,
     hostedAccessVersion,
-    hostedChatboxToken,
     persistedSnapshotToolCallIds,
     messages,
   });
@@ -1891,7 +1884,6 @@ export function useChatSession({
           projectId: hostedProjectId,
           chatboxId: hostedChatboxId,
           accessVersion: hostedAccessVersion,
-          chatboxToken: hostedChatboxToken,
         };
         const hasResolvedBefore = hasResolvedAuthHeadersRef.current;
         const authHeadersChanged =
@@ -1923,7 +1915,8 @@ export function useChatSession({
     };
   }, [
     getAccessToken,
-    hostedChatboxToken,
+    hostedChatboxId,
+    hostedAccessVersion,
     hostedProjectId,
     isAuthenticated,
     isHostedGuest,
@@ -2014,7 +2007,7 @@ export function useChatSession({
         );
       } catch (error) {
         if (
-          !(hostedChatboxToken && isAuthDeniedError(error))
+          !(hostedChatboxId && isAuthDeniedError(error))
         ) {
           console.warn(
             "[useChatSession] Failed to fetch tools metadata:",
@@ -2030,7 +2023,7 @@ export function useChatSession({
     };
 
     fetchToolsMetadata();
-  }, [selectedServersSignature, selectedModel, hostedChatboxToken]);
+  }, [selectedServersSignature, selectedModel, hostedChatboxId]);
 
   // System prompt token count
   useEffect(() => {
@@ -2050,7 +2043,7 @@ export function useChatSession({
         setSystemPromptTokenCount(count > 0 ? count : null);
       } catch (error) {
         if (
-          !(hostedChatboxToken && isAuthDeniedError(error))
+          !(hostedChatboxId && isAuthDeniedError(error))
         ) {
           console.warn(
             "[useChatSession] Failed to count system prompt tokens:",
@@ -2064,7 +2057,7 @@ export function useChatSession({
     };
 
     fetchSystemPromptTokenCount();
-  }, [systemPrompt, selectedModel, hostedChatboxToken]);
+  }, [systemPrompt, selectedModel, hostedChatboxId]);
 
   const previousSelectedServersRef = useRef<string[]>(selectedServers);
   useEffect(() => {

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -908,6 +908,8 @@ function areAuthHeadersEqual(
 
 type HostedSessionScope = {
   projectId?: string | null;
+  chatboxId?: string;
+  accessVersion?: number;
   chatboxToken?: string;
 };
 
@@ -916,7 +918,10 @@ function areHostedSessionScopesEqual(
   b: HostedSessionScope
 ): boolean {
   return (
-    a.projectId === b.projectId && a.chatboxToken === b.chatboxToken
+    a.projectId === b.projectId &&
+    a.chatboxId === b.chatboxId &&
+    a.accessVersion === b.accessVersion &&
+    a.chatboxToken === b.chatboxToken
   );
 }
 
@@ -941,6 +946,8 @@ export function useChatSession({
   const hostedProjectId = hostedContext?.projectId;
   const hostedSelectedServerIds = hostedContext?.selectedServerIds ?? [];
   const hostedOAuthTokens = hostedContext?.oauthTokens;
+  const hostedChatboxId = hostedContext?.chatboxId;
+  const hostedAccessVersion = hostedContext?.accessVersion;
   const hostedChatboxToken = hostedContext?.chatboxToken;
   const hostedChatboxSurface = hostedContext?.chatboxSurface;
   const initialModelId = executionConfig?.modelId;
@@ -1029,6 +1036,8 @@ export function useChatSession({
   );
   const lastResolvedHostedScopeRef = useRef<HostedSessionScope>({
     projectId: undefined,
+    chatboxId: undefined,
+    accessVersion: undefined,
     chatboxToken: undefined,
   });
   const pendingSessionHydrationRef = useRef<PendingSessionHydration | null>(
@@ -1301,7 +1310,7 @@ export function useChatSession({
           "Hosted chat context is not ready: missing projectId."
         );
       }
-      const isHostedDirectChat = !hostedChatboxToken;
+      const isHostedDirectChat = !(hostedChatboxId || hostedChatboxToken);
       return {
         projectId: hostedProjectId,
         chatSessionId,
@@ -1309,7 +1318,13 @@ export function useChatSession({
         selectedServerNames: selectedServers,
         accessScope: "chat_v2" as const,
         ...(isHostedDirectChat ? { directVisibility } : {}),
-        ...(hostedChatboxToken ? { chatboxToken: hostedChatboxToken } : {}),
+        ...(hostedChatboxId ? { chatboxId: hostedChatboxId } : {}),
+        ...(typeof hostedAccessVersion === "number"
+          ? { accessVersion: hostedAccessVersion }
+          : {}),
+        ...(hostedChatboxToken && !hostedChatboxId
+          ? { chatboxToken: hostedChatboxToken }
+          : {}),
         ...(hostedChatboxToken && hostedChatboxSurface
           ? { surface: hostedChatboxSurface }
           : {}),
@@ -1567,6 +1582,8 @@ export function useChatSession({
     enabled: HOSTED_MODE && isAuthenticated,
     readyToPersist: status === "ready",
     chatSessionId,
+    hostedChatboxId,
+    hostedAccessVersion,
     hostedChatboxToken,
     persistedSnapshotToolCallIds,
     messages,
@@ -1872,6 +1889,8 @@ export function useChatSession({
         const previousHostedScope = lastResolvedHostedScopeRef.current;
         const currentHostedScope = {
           projectId: hostedProjectId,
+          chatboxId: hostedChatboxId,
+          accessVersion: hostedAccessVersion,
           chatboxToken: hostedChatboxToken,
         };
         const hasResolvedBefore = hasResolvedAuthHeadersRef.current;

--- a/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
@@ -16,11 +16,10 @@ interface UseSharedChatWidgetCaptureOptions {
   enabled: boolean;
   readyToPersist?: boolean;
   chatSessionId: string;
-  // Post-refactor: prefer chatboxId + accessVersion. chatboxToken stays for
-  // legacy callers; mutations resolve via Convex helpers that accept both.
+  // Resolved chatbox identity (post-redeem). Snapshot mutations key on
+  // these — never on the link token.
   hostedChatboxId?: string;
   hostedAccessVersion?: number;
-  hostedChatboxToken?: string;
   persistedSnapshotToolCallIds?: string[];
   messages: UIMessage[];
 }
@@ -174,7 +173,6 @@ export function useSharedChatWidgetCapture({
   chatSessionId,
   hostedChatboxId,
   hostedAccessVersion,
-  hostedChatboxToken,
   persistedSnapshotToolCallIds = [],
   messages,
 }: UseSharedChatWidgetCaptureOptions): void {
@@ -208,7 +206,6 @@ export function useSharedChatWidgetCapture({
   const sessionIdRef = useRef(chatSessionId);
   const chatboxIdRef = useRef(hostedChatboxId);
   const accessVersionRef = useRef(hostedAccessVersion);
-  const chatboxTokenRef = useRef(hostedChatboxToken);
   const persistedSnapshotToolCallIdsRef = useRef(
     new Set(persistedSnapshotToolCallIds),
   );
@@ -234,7 +231,6 @@ export function useSharedChatWidgetCapture({
     sessionIdRef.current = chatSessionId;
     chatboxIdRef.current = hostedChatboxId;
     accessVersionRef.current = hostedAccessVersion;
-    chatboxTokenRef.current = hostedChatboxToken;
     uploadedHashesRef.current.clear();
     cachedBlobsRef.current.clear();
     retryCountRef.current.clear();
@@ -244,7 +240,7 @@ export function useSharedChatWidgetCapture({
     }
     pendingTimersRef.current.clear();
     inFlightRef.current.clear();
-  }, [chatSessionId, hostedChatboxId, hostedAccessVersion, hostedChatboxToken]);
+  }, [chatSessionId, hostedChatboxId, hostedAccessVersion]);
 
   useEffect(() => {
     return () => {
@@ -259,7 +255,6 @@ export function useSharedChatWidgetCapture({
   uploadAttemptRef.current = async (toolCallId: string) => {
     const chatboxId = chatboxIdRef.current;
     const accessVersion = accessVersionRef.current;
-    const chatboxToken = chatboxTokenRef.current;
     if (!enabled || !readyToPersist || inFlightRef.current.has(toolCallId)) {
       return;
     }
@@ -288,11 +283,12 @@ export function useSharedChatWidgetCapture({
       content: BlobPart,
       contentType: string,
     ): Promise<string> => {
-      const isChatboxSession = Boolean(chatboxId || chatboxToken);
+      const isChatboxSession = Boolean(chatboxId);
       const uploadUrl = await generateSnapshotUploadUrl({
         ...(chatboxId ? { chatboxId } : {}),
-        ...(typeof accessVersion === "number" ? { accessVersion } : {}),
-        ...(chatboxToken && !chatboxId ? { chatboxToken } : {}),
+        ...(chatboxId && Number.isFinite(accessVersion)
+          ? { accessVersion }
+          : {}),
         ...(!isChatboxSession
           ? { chatSessionId: sessionIdRef.current }
           : {}),
@@ -341,8 +337,9 @@ export function useSharedChatWidgetCapture({
 
       const snapshotPayload = {
         ...(chatboxId ? { chatboxId } : {}),
-        ...(typeof accessVersion === "number" ? { accessVersion } : {}),
-        ...(chatboxToken && !chatboxId ? { chatboxToken } : {}),
+        ...(chatboxId && Number.isFinite(accessVersion)
+          ? { accessVersion }
+          : {}),
         chatSessionId: sessionIdRef.current,
         ...(toolSource.serverId ? { serverId: toolSource.serverId } : {}),
         toolCallId,
@@ -449,7 +446,7 @@ export function useSharedChatWidgetCapture({
   }, [
     enabled,
     readyToPersist,
-    hostedChatboxToken,
+    hostedChatboxId,
     persistedSnapshotToolCallIds,
     widgets,
     messages,

--- a/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
@@ -16,6 +16,10 @@ interface UseSharedChatWidgetCaptureOptions {
   enabled: boolean;
   readyToPersist?: boolean;
   chatSessionId: string;
+  // Post-refactor: prefer chatboxId + accessVersion. chatboxToken stays for
+  // legacy callers; mutations resolve via Convex helpers that accept both.
+  hostedChatboxId?: string;
+  hostedAccessVersion?: number;
   hostedChatboxToken?: string;
   persistedSnapshotToolCallIds?: string[];
   messages: UIMessage[];
@@ -168,6 +172,8 @@ export function useSharedChatWidgetCapture({
   enabled,
   readyToPersist = true,
   chatSessionId,
+  hostedChatboxId,
+  hostedAccessVersion,
   hostedChatboxToken,
   persistedSnapshotToolCallIds = [],
   messages,
@@ -200,6 +206,8 @@ export function useSharedChatWidgetCapture({
   const toolSourcesRef = useRef(buildToolSourceMap(messages));
   const widgetsRef = useRef(widgets);
   const sessionIdRef = useRef(chatSessionId);
+  const chatboxIdRef = useRef(hostedChatboxId);
+  const accessVersionRef = useRef(hostedAccessVersion);
   const chatboxTokenRef = useRef(hostedChatboxToken);
   const persistedSnapshotToolCallIdsRef = useRef(
     new Set(persistedSnapshotToolCallIds),
@@ -224,6 +232,8 @@ export function useSharedChatWidgetCapture({
 
   useEffect(() => {
     sessionIdRef.current = chatSessionId;
+    chatboxIdRef.current = hostedChatboxId;
+    accessVersionRef.current = hostedAccessVersion;
     chatboxTokenRef.current = hostedChatboxToken;
     uploadedHashesRef.current.clear();
     cachedBlobsRef.current.clear();
@@ -234,7 +244,7 @@ export function useSharedChatWidgetCapture({
     }
     pendingTimersRef.current.clear();
     inFlightRef.current.clear();
-  }, [chatSessionId, hostedChatboxToken]);
+  }, [chatSessionId, hostedChatboxId, hostedAccessVersion, hostedChatboxToken]);
 
   useEffect(() => {
     return () => {
@@ -247,6 +257,8 @@ export function useSharedChatWidgetCapture({
   }, []);
 
   uploadAttemptRef.current = async (toolCallId: string) => {
+    const chatboxId = chatboxIdRef.current;
+    const accessVersion = accessVersionRef.current;
     const chatboxToken = chatboxTokenRef.current;
     if (!enabled || !readyToPersist || inFlightRef.current.has(toolCallId)) {
       return;
@@ -276,9 +288,12 @@ export function useSharedChatWidgetCapture({
       content: BlobPart,
       contentType: string,
     ): Promise<string> => {
+      const isChatboxSession = Boolean(chatboxId || chatboxToken);
       const uploadUrl = await generateSnapshotUploadUrl({
-        ...(chatboxToken ? { chatboxToken } : {}),
-        ...(!chatboxToken
+        ...(chatboxId ? { chatboxId } : {}),
+        ...(typeof accessVersion === "number" ? { accessVersion } : {}),
+        ...(chatboxToken && !chatboxId ? { chatboxToken } : {}),
+        ...(!isChatboxSession
           ? { chatSessionId: sessionIdRef.current }
           : {}),
       });
@@ -325,7 +340,9 @@ export function useSharedChatWidgetCapture({
       }
 
       const snapshotPayload = {
-        ...(chatboxToken ? { chatboxToken } : {}),
+        ...(chatboxId ? { chatboxId } : {}),
+        ...(typeof accessVersion === "number" ? { accessVersion } : {}),
+        ...(chatboxToken && !chatboxId ? { chatboxToken } : {}),
         chatSessionId: sessionIdRef.current,
         ...(toolSource.serverId ? { serverId: toolSource.serverId } : {}),
         toolCallId,

--- a/mcpjam-inspector/client/src/lib/__tests__/chatbox-session.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/chatbox-session.test.ts
@@ -13,6 +13,7 @@ import {
   readChatboxSurfaceFromUrl,
   readChatboxSession,
   readChatboxSignInReturnPath,
+  CHATBOX_SESSION_STORAGE_KEY,
   CHATBOX_SIGN_IN_RETURN_PATH_STORAGE_KEY,
   writeBuilderSession,
   writePlaygroundSession,
@@ -41,7 +42,8 @@ describe("chatbox-session", () => {
     expect(hasActiveChatboxSession()).toBe(false);
 
     writeChatboxSession({
-      token: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       payload: {
         projectId: "ws_1",
         chatboxId: "sbx_1",
@@ -68,7 +70,7 @@ describe("chatbox-session", () => {
       name: "Chatbox",
       description: "Hosted chatbox",
       hostStyle: "chatgpt" as const,
-      mode: "any_signed_in_with_link" as const,
+      mode: "anyone_with_link" as const,
       allowGuestAccess: true,
       viewerIsProjectMember: false,
       systemPrompt: "System prompt",
@@ -87,10 +89,11 @@ describe("chatbox-session", () => {
       ],
     };
 
-    writeChatboxSession({ token: "chatbox-token", payload });
+    writeChatboxSession({ chatboxId: "sbx_1", accessVersion: 4, payload });
 
     expect(readChatboxSession()).toEqual({
-      token: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 4,
       payload: {
         ...payload,
         servers: [
@@ -110,11 +113,40 @@ describe("chatbox-session", () => {
     });
   });
 
-  it("defaults missing hostStyle to claude for legacy chatbox sessions", () => {
+  it("rejects stored sessions that lack a top-level chatboxId or accessVersion", () => {
     sessionStorage.setItem(
-      "mcpjam_chatbox_session_v1",
+      CHATBOX_SESSION_STORAGE_KEY,
       JSON.stringify({
         token: "chatbox-token",
+        payload: {
+          projectId: "ws_1",
+          chatboxId: "sbx_1",
+          name: "Old Chatbox",
+          hostStyle: "claude",
+          mode: "invited_only",
+          allowGuestAccess: false,
+          viewerIsProjectMember: true,
+          systemPrompt: "You are helpful.",
+          modelId: "openai/gpt-5-mini",
+          temperature: 0.4,
+          requireToolApproval: true,
+          servers: [],
+        },
+      }),
+    );
+
+    // Stored row predates the post-refactor session shape; reading it must
+    // produce null so the landing page falls through to re-redeem rather than
+    // silently driving the read path without a chatboxId/accessVersion.
+    expect(readChatboxSession()).toBeNull();
+  });
+
+  it("defaults missing hostStyle to claude for legacy chatbox sessions", () => {
+    sessionStorage.setItem(
+      CHATBOX_SESSION_STORAGE_KEY,
+      JSON.stringify({
+        chatboxId: "sbx_1",
+        accessVersion: 1,
         payload: {
           projectId: "ws_1",
           chatboxId: "sbx_1",
@@ -132,7 +164,8 @@ describe("chatbox-session", () => {
     );
 
     expect(readChatboxSession()).toEqual({
-      token: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       payload: {
         projectId: "ws_1",
         chatboxId: "sbx_1",
@@ -147,6 +180,7 @@ describe("chatbox-session", () => {
         temperature: 0.4,
         requireToolApproval: true,
         servers: [],
+        welcomeDialog: undefined,
       },
       surface: "share_link",
     });
@@ -154,9 +188,10 @@ describe("chatbox-session", () => {
 
   it("preserves extensible hostStyle ids before a host definition is registered", () => {
     sessionStorage.setItem(
-      "mcpjam_chatbox_session_v1",
+      CHATBOX_SESSION_STORAGE_KEY,
       JSON.stringify({
-        token: "chatbox-token",
+        chatboxId: "sbx_1",
+        accessVersion: 1,
         payload: {
           projectId: "ws_1",
           chatboxId: "sbx_1",
@@ -179,7 +214,8 @@ describe("chatbox-session", () => {
 
   it("preserves preview surface when explicitly stored", () => {
     writeChatboxSession({
-      token: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       surface: "preview",
       payload: {
         projectId: "ws_1",
@@ -203,7 +239,8 @@ describe("chatbox-session", () => {
   it("round-trips playground sessions until their ttl expires", () => {
     writePlaygroundSession({
       playgroundId: "pg_123",
-      token: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       surface: "preview",
       updatedAt: Date.now(),
       payload: {
@@ -226,7 +263,8 @@ describe("chatbox-session", () => {
     expect(stored).toEqual(
       expect.objectContaining({
         playgroundId: "pg_123",
-        token: "chatbox-token",
+        chatboxId: "sbx_1",
+        accessVersion: 1,
         surface: "preview",
       }),
     );
@@ -287,7 +325,8 @@ describe("chatbox-session", () => {
   it("clears stored playground sessions", () => {
     writePlaygroundSession({
       playgroundId: "pg_123",
-      token: "chatbox-token",
+      chatboxId: "sbx_1",
+      accessVersion: 1,
       surface: "preview",
       updatedAt: Date.now(),
       payload: {

--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-web-context.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-web-context.test.ts
@@ -24,12 +24,13 @@ describe("hosted web context", () => {
     localStorage.removeItem("mcp-tokens-myServer");
   });
 
-  it("includes chatbox token and chat_v2 scope for chatbox requests", () => {
+  it("includes chatbox id, accessVersion, and chat_v2 scope for chatbox requests", () => {
     setApiContext({
       projectId: "ws_shared",
       serverIdsByName: { bench: "srv_bench" },
       getAccessToken: async () => null,
-      chatboxToken: "chatbox_tok_123",
+      chatboxId: "cbx_123",
+      accessVersion: 7,
     });
 
     expect(buildServerRequest("bench")).toEqual({
@@ -38,7 +39,8 @@ describe("hosted web context", () => {
       serverName: "bench",
       clientCapabilities: defaultClientCapabilities,
       accessScope: "chat_v2",
-      chatboxToken: "chatbox_tok_123",
+      chatboxId: "cbx_123",
+      accessVersion: 7,
     });
 
     expect(buildServerBatchRequest(["bench"])).toEqual({
@@ -47,7 +49,8 @@ describe("hosted web context", () => {
       serverNames: ["bench"],
       clientCapabilities: defaultClientCapabilities,
       accessScope: "chat_v2",
-      chatboxToken: "chatbox_tok_123",
+      chatboxId: "cbx_123",
+      accessVersion: 7,
     });
 
     expect(buildHostedEvalServerBatchRequest(["bench"])).toEqual({
@@ -56,11 +59,46 @@ describe("hosted web context", () => {
       serverNames: ["bench"],
       clientCapabilities: defaultClientCapabilities,
       accessScope: "chat_v2",
-      chatboxToken: "chatbox_tok_123",
+      chatboxId: "cbx_123",
+      accessVersion: 7,
     });
   });
 
-  it("omits chatbox scope fields when no chatbox token is present", () => {
+  it("omits accessVersion when chatboxId is absent", () => {
+    setApiContext({
+      projectId: "ws_regular",
+      serverIdsByName: { bench: "srv_bench" },
+      getAccessToken: async () => null,
+      // Stray accessVersion without chatboxId — never emitted on the wire.
+      accessVersion: 5,
+    });
+    expect(buildServerRequest("bench")).toEqual({
+      projectId: "ws_regular",
+      serverId: "srv_bench",
+      serverName: "bench",
+      clientCapabilities: defaultClientCapabilities,
+    });
+  });
+
+  it("rejects non-finite accessVersion even with chatboxId set", () => {
+    setApiContext({
+      projectId: "ws_shared",
+      serverIdsByName: { bench: "srv_bench" },
+      getAccessToken: async () => null,
+      chatboxId: "cbx_123",
+      accessVersion: Number.NaN,
+    });
+    expect(buildServerRequest("bench")).toEqual({
+      projectId: "ws_shared",
+      serverId: "srv_bench",
+      serverName: "bench",
+      clientCapabilities: defaultClientCapabilities,
+      accessScope: "chat_v2",
+      chatboxId: "cbx_123",
+    });
+  });
+
+  it("omits chatbox scope fields when no chatbox id is present", () => {
     setApiContext({
       projectId: "ws_regular",
       serverIdsByName: { bench: "srv_bench" },

--- a/mcpjam-inspector/client/src/lib/apis/web/__tests__/context.guest-fallback.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/__tests__/context.guest-fallback.test.ts
@@ -68,7 +68,8 @@ describe("getApiAuthorizationHeader guest fallback", () => {
       isAuthenticated: false,
       serverIdsByName: { bench: "srv-1" },
       getAccessToken,
-      chatboxToken: "chatbox_tok_123",
+      chatboxId: "cbx_123",
+      accessVersion: 1,
     });
 
     vi.mocked(getGuestBearerToken).mockResolvedValue("guest-chatbox");
@@ -189,7 +190,8 @@ describe("guest-owned project request building", () => {
     setApiContext({
       projectId: "ws-chatbox",
       isAuthenticated: false,
-      chatboxToken: "chatbox_tok_123",
+      chatboxId: "cbx_123",
+      accessVersion: 1,
       serverIdsByName: { "my-server": "srv-1" },
     });
 
@@ -199,7 +201,8 @@ describe("guest-owned project request building", () => {
       projectId: "ws-chatbox",
       serverId: "srv-1",
       serverName: "my-server",
-      chatboxToken: "chatbox_tok_123",
+      chatboxId: "cbx_123",
+      accessVersion: 1,
     });
   });
 });

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -13,6 +13,14 @@ export interface ApiContext {
   clientConfigSyncPending?: boolean;
   getAccessToken?: GetAccessTokenFn;
   oauthTokensByServerId?: Record<string, string>;
+  /**
+   * Post-refactor chatbox auth keys. After /web/chatbox/redeem resolves,
+   * the host clones these onto every chatbox-aware API call. `chatboxToken`
+   * stays for legacy callsites until they migrate; the server now prefers
+   * `chatboxId` when both are present.
+   */
+  chatboxId?: string;
+  accessVersion?: number;
   chatboxToken?: string;
   isAuthenticated?: boolean;
   /** True when a WorkOS session exists (user signed in), even if token hasn't resolved yet. */
@@ -305,8 +313,18 @@ export function getHostedChatboxToken(): string | undefined {
   return apiContext.chatboxToken;
 }
 
+export function getHostedChatboxId(): string | undefined {
+  return apiContext.chatboxId;
+}
+
+export function getHostedChatboxAccessVersion(): number | undefined {
+  return apiContext.accessVersion;
+}
+
 function getHostedAccessScope(): HostedAccessScope | undefined {
-  return getHostedChatboxToken() ? "chat_v2" : undefined;
+  return getHostedChatboxToken() || getHostedChatboxId()
+    ? "chat_v2"
+    : undefined;
 }
 
 export function buildServerRequest(
@@ -325,6 +343,8 @@ export function buildServerRequest(
   const projectId = getHostedProjectId();
   const serverId = resolveHostedServerId(serverNameOrId);
   const oauthToken = getHostedOAuthToken(serverId);
+  const chatboxId = getHostedChatboxId();
+  const accessVersion = getHostedChatboxAccessVersion();
   const chatboxToken = getHostedChatboxToken();
   const accessScope = getHostedAccessScope();
   return {
@@ -339,7 +359,9 @@ export function buildServerRequest(
       ? { clientCapabilities: apiContext.clientCapabilities }
       : {}),
     ...(accessScope ? { accessScope } : {}),
-    ...(chatboxToken ? { chatboxToken } : {}),
+    ...(chatboxId ? { chatboxId } : {}),
+    ...(typeof accessVersion === "number" ? { accessVersion } : {}),
+    ...(chatboxToken && !chatboxId ? { chatboxToken } : {}),
   };
 }
 
@@ -350,6 +372,8 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
   clientCapabilities?: Record<string, unknown>;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
+  chatboxId?: string;
+  accessVersion?: number;
   chatboxToken?: string;
 } {
   assertClientConfigSynced();
@@ -358,6 +382,8 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
   const serverIds = serverEntries.map((entry) => entry.serverId);
   const serverNames = serverEntries.map((entry) => entry.serverName);
   const oauthTokens = buildHostedOAuthTokensMap(serverIds);
+  const chatboxId = getHostedChatboxId();
+  const accessVersion = getHostedChatboxAccessVersion();
   const chatboxToken = getHostedChatboxToken();
   const accessScope = getHostedAccessScope();
   return {
@@ -369,7 +395,9 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
       : {}),
     ...(oauthTokens ? { oauthTokens } : {}),
     ...(accessScope ? { accessScope } : {}),
-    ...(chatboxToken ? { chatboxToken } : {}),
+    ...(chatboxId ? { chatboxId } : {}),
+    ...(typeof accessVersion === "number" ? { accessVersion } : {}),
+    ...(chatboxToken && !chatboxId ? { chatboxToken } : {}),
   };
 }
 
@@ -380,6 +408,8 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
   clientCapabilities?: Record<string, unknown>;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
+  chatboxId?: string;
+  accessVersion?: number;
   chatboxToken?: string;
 } {
   assertClientConfigSynced();
@@ -388,6 +418,8 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
   const serverIds = serverEntries.map((entry) => entry.serverId);
   const serverNames = serverEntries.map((entry) => entry.serverName);
   const oauthTokens = buildHostedOAuthTokensMap(serverIds);
+  const chatboxId = getHostedChatboxId();
+  const accessVersion = getHostedChatboxAccessVersion();
   const chatboxToken = getHostedChatboxToken();
   const accessScope = getHostedAccessScope();
 
@@ -400,7 +432,9 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
       : {}),
     ...(oauthTokens ? { oauthTokens } : {}),
     ...(accessScope ? { accessScope } : {}),
-    ...(chatboxToken ? { chatboxToken } : {}),
+    ...(chatboxId ? { chatboxId } : {}),
+    ...(typeof accessVersion === "number" ? { accessVersion } : {}),
+    ...(chatboxToken && !chatboxId ? { chatboxToken } : {}),
   };
 }
 

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -14,14 +14,13 @@ export interface ApiContext {
   getAccessToken?: GetAccessTokenFn;
   oauthTokensByServerId?: Record<string, string>;
   /**
-   * Post-refactor chatbox auth keys. After /web/chatbox/redeem resolves,
-   * the host clones these onto every chatbox-aware API call. `chatboxToken`
-   * stays for legacy callsites until they migrate; the server now prefers
-   * `chatboxId` when both are present.
+   * Resolved chatbox identity. After /api/web/chatboxes/redeem resolves,
+   * the host clones these onto every chatbox-aware API call. The URL link
+   * token is consumed only at redemption time and never threaded onto the
+   * read path.
    */
   chatboxId?: string;
   accessVersion?: number;
-  chatboxToken?: string;
   isAuthenticated?: boolean;
   /** True when a WorkOS session exists (user signed in), even if token hasn't resolved yet. */
   hasSession?: boolean;
@@ -309,10 +308,6 @@ export function getHostedOAuthToken(serverId: string): string | undefined {
   return apiContext.oauthTokensByServerId?.[serverId];
 }
 
-export function getHostedChatboxToken(): string | undefined {
-  return apiContext.chatboxToken;
-}
-
 export function getHostedChatboxId(): string | undefined {
   return apiContext.chatboxId;
 }
@@ -322,9 +317,7 @@ export function getHostedChatboxAccessVersion(): number | undefined {
 }
 
 function getHostedAccessScope(): HostedAccessScope | undefined {
-  return getHostedChatboxToken() || getHostedChatboxId()
-    ? "chat_v2"
-    : undefined;
+  return getHostedChatboxId() ? "chat_v2" : undefined;
 }
 
 export function buildServerRequest(
@@ -345,7 +338,6 @@ export function buildServerRequest(
   const oauthToken = getHostedOAuthToken(serverId);
   const chatboxId = getHostedChatboxId();
   const accessVersion = getHostedChatboxAccessVersion();
-  const chatboxToken = getHostedChatboxToken();
   const accessScope = getHostedAccessScope();
   return {
     projectId,
@@ -360,8 +352,9 @@ export function buildServerRequest(
       : {}),
     ...(accessScope ? { accessScope } : {}),
     ...(chatboxId ? { chatboxId } : {}),
-    ...(typeof accessVersion === "number" ? { accessVersion } : {}),
-    ...(chatboxToken && !chatboxId ? { chatboxToken } : {}),
+    ...(chatboxId && Number.isFinite(accessVersion)
+      ? { accessVersion }
+      : {}),
   };
 }
 
@@ -374,7 +367,6 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
   accessScope?: HostedAccessScope;
   chatboxId?: string;
   accessVersion?: number;
-  chatboxToken?: string;
 } {
   assertClientConfigSynced();
   const projectId = getHostedProjectId();
@@ -384,7 +376,6 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
   const oauthTokens = buildHostedOAuthTokensMap(serverIds);
   const chatboxId = getHostedChatboxId();
   const accessVersion = getHostedChatboxAccessVersion();
-  const chatboxToken = getHostedChatboxToken();
   const accessScope = getHostedAccessScope();
   return {
     projectId,
@@ -396,8 +387,9 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
     ...(oauthTokens ? { oauthTokens } : {}),
     ...(accessScope ? { accessScope } : {}),
     ...(chatboxId ? { chatboxId } : {}),
-    ...(typeof accessVersion === "number" ? { accessVersion } : {}),
-    ...(chatboxToken && !chatboxId ? { chatboxToken } : {}),
+    ...(chatboxId && Number.isFinite(accessVersion)
+      ? { accessVersion }
+      : {}),
   };
 }
 
@@ -410,7 +402,6 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
   accessScope?: HostedAccessScope;
   chatboxId?: string;
   accessVersion?: number;
-  chatboxToken?: string;
 } {
   assertClientConfigSynced();
   const projectId = getHostedProjectId();
@@ -420,7 +411,6 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
   const oauthTokens = buildHostedOAuthTokensMap(serverIds);
   const chatboxId = getHostedChatboxId();
   const accessVersion = getHostedChatboxAccessVersion();
-  const chatboxToken = getHostedChatboxToken();
   const accessScope = getHostedAccessScope();
 
   return {
@@ -433,8 +423,9 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
     ...(oauthTokens ? { oauthTokens } : {}),
     ...(accessScope ? { accessScope } : {}),
     ...(chatboxId ? { chatboxId } : {}),
-    ...(typeof accessVersion === "number" ? { accessVersion } : {}),
-    ...(chatboxToken && !chatboxId ? { chatboxToken } : {}),
+    ...(chatboxId && Number.isFinite(accessVersion)
+      ? { accessVersion }
+      : {}),
   };
 }
 

--- a/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
@@ -6,7 +6,8 @@ export type HostedServerValidateContext = {
   serverId: string;
   serverName?: string;
   accessScope?: "project_member" | "chat_v2";
-  chatboxToken?: string;
+  chatboxId?: string;
+  accessVersion?: number;
 };
 
 export interface HostedServerValidateResponse {
@@ -46,8 +47,12 @@ export async function validateHostedServer(
         ...(hostedContext.accessScope
           ? { accessScope: hostedContext.accessScope }
           : {}),
-        ...(hostedContext.chatboxToken
-          ? { chatboxToken: hostedContext.chatboxToken }
+        ...(hostedContext.chatboxId
+          ? { chatboxId: hostedContext.chatboxId }
+          : {}),
+        ...(hostedContext.chatboxId &&
+        Number.isFinite(hostedContext.accessVersion)
+          ? { accessVersion: hostedContext.accessVersion }
           : {}),
       }
     : buildServerRequest(serverNameOrId);

--- a/mcpjam-inspector/client/src/lib/chatbox-session.ts
+++ b/mcpjam-inspector/client/src/lib/chatbox-session.ts
@@ -122,6 +122,11 @@ export interface ChatboxPlaygroundSession extends ChatboxSession {
 function normalizeChatboxShareMode(mode: unknown): ChatboxShareMode {
   if (mode === "project_members") return "project_members";
   if (mode === "anyone_with_link") return "anyone_with_link";
+  // Legacy alias from before the chatbox auth refactor renamed the
+  // any-signed-in-with-link mode. Editor/builder surfaces still write
+  // it; map to the semantic equivalent so persisted sessions don't
+  // silently downgrade to invited-only when read back.
+  if (mode === "any_signed_in_with_link") return "anyone_with_link";
   return "invited_only";
 }
 

--- a/mcpjam-inspector/client/src/lib/chatbox-session.ts
+++ b/mcpjam-inspector/client/src/lib/chatbox-session.ts
@@ -28,7 +28,20 @@ export function getShareableAppOrigin(): string {
     : MCPJAM_APP_ORIGIN;
 }
 
-export type ChatboxShareMode = "any_signed_in_with_link" | "invited_only";
+/**
+ * Chatbox access modes. The post-refactor model exposes all three.
+ * `any_signed_in_with_link` is the legacy display label retained so
+ * existing UI strings keep working; new code should prefer the
+ * post-refactor names. The normalizer below maps the legacy/aliased
+ * values to the new identifiers.
+ */
+export type ChatboxShareMode =
+  | "project_members"
+  | "invited_only"
+  | "anyone_with_link"
+  // Legacy alias retained for sessions persisted by older inspector
+  // builds. TODO(chatbox-followup): remove after sessions expire.
+  | "any_signed_in_with_link";
 
 export interface ChatboxBootstrapServer {
   serverId: string;
@@ -65,9 +78,26 @@ export interface ChatboxBootstrapPayload {
 }
 
 export interface ChatboxSession {
+  /**
+   * Chatbox handshake token from the URL. Retained on the session for
+   * legacy callsites that still pass `chatboxToken` to the backend.
+   * Post-refactor: clients should call /web/chatbox/redeem on session
+   * mount, store the resulting `payload.chatboxId` + `accessVersion`,
+   * and stop forwarding `token` downstream.
+   *
+   * TODO(chatbox-followup): drop this field once every client surface
+   * has migrated to chatboxId.
+   */
   token: string;
   payload: ChatboxBootstrapPayload;
   surface?: "preview" | "share_link";
+  /**
+   * Backend-owned monotonic counter returned by /web/chatbox/redeem.
+   * Bumps whenever access changes (mode, revoke-all, allowlist edits,
+   * invite removal). Threaded into every chatbox-aware server call so
+   * inspector caches invalidate cleanly.
+   */
+  accessVersion?: number;
 }
 
 export const CHATBOX_SESSION_STORAGE_KEY = "mcpjam_chatbox_session_v1";
@@ -97,14 +127,12 @@ export interface ChatboxPlaygroundSession extends ChatboxSession {
 }
 
 function normalizeChatboxShareMode(mode: unknown): ChatboxShareMode {
-  if (
-    mode === "any_signed_in_with_link" ||
-    mode === "project_with_link" ||
-    mode === "anyone_with_link"
-  ) {
-    return "any_signed_in_with_link";
+  if (mode === "project_members") return "project_members";
+  if (mode === "anyone_with_link" || mode === "any_signed_in_with_link") {
+    return "anyone_with_link";
   }
-
+  // Legacy backend alias.
+  if (mode === "project_with_link") return "anyone_with_link";
   return "invited_only";
 }
 
@@ -155,6 +183,8 @@ function normalizeChatboxSession(
 
   return {
     token,
+    accessVersion:
+      typeof parsed.accessVersion === "number" ? parsed.accessVersion : undefined,
     payload: {
       projectId: payload.projectId,
       chatboxId: payload.chatboxId,

--- a/mcpjam-inspector/client/src/lib/chatbox-session.ts
+++ b/mcpjam-inspector/client/src/lib/chatbox-session.ts
@@ -139,7 +139,7 @@ export function hasActiveChatboxSession(): boolean {
   return readChatboxSession() !== null;
 }
 
-function normalizeChatboxSession(
+export function normalizeChatboxSession(
   parsed: Partial<ChatboxSession> | null,
 ): ChatboxSession | null {
   if (!parsed || typeof parsed !== "object") {

--- a/mcpjam-inspector/client/src/lib/chatbox-session.ts
+++ b/mcpjam-inspector/client/src/lib/chatbox-session.ts
@@ -29,19 +29,12 @@ export function getShareableAppOrigin(): string {
 }
 
 /**
- * Chatbox access modes. The post-refactor model exposes all three.
- * `any_signed_in_with_link` is the legacy display label retained so
- * existing UI strings keep working; new code should prefer the
- * post-refactor names. The normalizer below maps the legacy/aliased
- * values to the new identifiers.
+ * Chatbox access modes. Mirrors the backend `chatboxModeValidator`.
  */
 export type ChatboxShareMode =
   | "project_members"
   | "invited_only"
-  | "anyone_with_link"
-  // Legacy alias retained for sessions persisted by older inspector
-  // builds. TODO(chatbox-followup): remove after sessions expire.
-  | "any_signed_in_with_link";
+  | "anyone_with_link";
 
 export interface ChatboxBootstrapServer {
   serverId: string;
@@ -79,37 +72,37 @@ export interface ChatboxBootstrapPayload {
 
 export interface ChatboxSession {
   /**
-   * Chatbox handshake token from the URL. Retained on the session for
-   * legacy callsites that still pass `chatboxToken` to the backend.
-   * Post-refactor: clients should call /web/chatbox/redeem on session
-   * mount, store the resulting `payload.chatboxId` + `accessVersion`,
-   * and stop forwarding `token` downstream.
-   *
-   * TODO(chatbox-followup): drop this field once every client surface
-   * has migrated to chatboxId.
+   * Resolved chatbox identity. Returned by /api/web/chatboxes/redeem and
+   * stored at the top level so callers don't have to dig through
+   * `payload`. Every chatbox-aware backend call keys on this; the URL
+   * link token is consumed only at redemption time and is not persisted.
    */
-  token: string;
-  payload: ChatboxBootstrapPayload;
-  surface?: "preview" | "share_link";
+  chatboxId: string;
   /**
    * Backend-owned monotonic counter returned by /web/chatbox/redeem.
    * Bumps whenever access changes (mode, revoke-all, allowlist edits,
    * invite removal). Threaded into every chatbox-aware server call so
    * inspector caches invalidate cleanly.
    */
-  accessVersion?: number;
+  accessVersion: number;
+  payload: ChatboxBootstrapPayload;
+  surface?: "preview" | "share_link";
 }
 
-export const CHATBOX_SESSION_STORAGE_KEY = "mcpjam_chatbox_session_v1";
+// Bumped from v1 → v2: ChatboxSession dropped the URL token and added
+// required top-level `chatboxId` + `accessVersion`. Reading a v1 row would
+// produce a malformed session; rev the key so the v1 row is ignored and
+// the next landing-page mount re-redeems cleanly.
+export const CHATBOX_SESSION_STORAGE_KEY = "mcpjam_chatbox_session_v2";
 export const CHATBOX_OAUTH_PENDING_KEY = "mcp-oauth-chatbox-pending";
 export const CHATBOX_SIGN_IN_RETURN_PATH_STORAGE_KEY =
   "mcpjam_chatbox_signin_return_path_v1";
 export const CHATBOX_PLAYGROUND_KEY_PREFIX =
   "mcpjam_chatbox_playground_session_v1:";
 
-/** sessionStorage: optional servers the tester enabled for this share-link session. */
-export function chatboxEnabledOptionalStorageKey(chatboxToken: string): string {
-  return `chatbox-enabled-optional:${chatboxToken}`;
+/** sessionStorage: optional servers the tester enabled for this chatbox session. */
+export function chatboxEnabledOptionalStorageKey(chatboxId: string): string {
+  return `chatbox-enabled-optional:${chatboxId}`;
 }
 
 /** sessionStorage: optional servers enabled in builder preview for a chatbox id. */
@@ -128,11 +121,7 @@ export interface ChatboxPlaygroundSession extends ChatboxSession {
 
 function normalizeChatboxShareMode(mode: unknown): ChatboxShareMode {
   if (mode === "project_members") return "project_members";
-  if (mode === "anyone_with_link" || mode === "any_signed_in_with_link") {
-    return "anyone_with_link";
-  }
-  // Legacy backend alias.
-  if (mode === "project_with_link") return "anyone_with_link";
+  if (mode === "anyone_with_link") return "anyone_with_link";
   return "invited_only";
 }
 
@@ -157,14 +146,21 @@ function normalizeChatboxSession(
     return null;
   }
 
-  const token = typeof parsed.token === "string" ? parsed.token.trim() : "";
+  const chatboxId =
+    typeof parsed.chatboxId === "string" ? parsed.chatboxId.trim() : "";
+  const accessVersion =
+    typeof parsed.accessVersion === "number" &&
+    Number.isFinite(parsed.accessVersion)
+      ? parsed.accessVersion
+      : null;
   const payload = parsed.payload;
   const hostStyle =
     normalizeChatboxHostStyleId(payload?.hostStyle) ??
     (payload?.hostStyle == null ? DEFAULT_HOST_STYLE.id : null);
 
   if (
-    !token ||
+    !chatboxId ||
+    accessVersion === null ||
     !payload ||
     typeof payload.projectId !== "string" ||
     typeof payload.chatboxId !== "string" ||
@@ -182,9 +178,8 @@ function normalizeChatboxSession(
   }
 
   return {
-    token,
-    accessVersion:
-      typeof parsed.accessVersion === "number" ? parsed.accessVersion : undefined,
+    chatboxId,
+    accessVersion,
     payload: {
       projectId: payload.projectId,
       chatboxId: payload.chatboxId,

--- a/mcpjam-inspector/client/src/lib/hosted-oauth-callback.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-oauth-callback.ts
@@ -14,7 +14,8 @@ export interface HostedOAuthPendingMarker {
   serverUrl: string | null;
   sessionId?: string | null;
   accessScope?: "project_member" | "chat_v2";
-  chatboxToken?: string | null;
+  chatboxId?: string | null;
+  accessVersion?: number | null;
   returnHash: string | null;
   startedAt: number;
 }
@@ -75,7 +76,8 @@ export function writeHostedOAuthPendingMarker(
         serverUrl: marker.serverUrl ?? null,
         sessionId: marker.sessionId ?? null,
         accessScope: marker.accessScope ?? null,
-        chatboxToken: marker.chatboxToken ?? null,
+        chatboxId: marker.chatboxId ?? null,
+        accessVersion: marker.accessVersion ?? null,
         returnHash: normalizeHostedOAuthReturnHash(marker.returnHash),
         startedAt: Date.now(),
       })
@@ -124,8 +126,13 @@ export function readHostedOAuthPendingMarker(): HostedOAuthPendingMarker | null 
         parsed.accessScope === "chat_v2"
           ? parsed.accessScope
           : undefined,
-      chatboxToken:
-        typeof parsed.chatboxToken === "string" ? parsed.chatboxToken : null,
+      chatboxId:
+        typeof parsed.chatboxId === "string" ? parsed.chatboxId : null,
+      accessVersion:
+        typeof parsed.accessVersion === "number" &&
+        Number.isFinite(parsed.accessVersion)
+          ? parsed.accessVersion
+          : null,
       returnHash: normalizeHostedOAuthReturnHash(parsed.returnHash),
       startedAt: parsed.startedAt,
     };
@@ -212,7 +219,8 @@ export function getHostedOAuthCallbackContext(): HostedOAuthCallbackContext | nu
     serverUrl,
     sessionId: null,
     accessScope: undefined,
-    chatboxToken: null,
+    chatboxId: null,
+    accessVersion: null,
     returnHash: normalizeHostedOAuthReturnHash(
       localStorage.getItem("mcp-oauth-return-hash")
     ),

--- a/mcpjam-inspector/client/src/lib/hosted-runtime-context.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-runtime-context.ts
@@ -2,6 +2,13 @@ export type HostedRuntimeContext = {
   projectId?: string | null;
   selectedServerIds?: string[];
   oauthTokens?: Record<string, string>;
+  /**
+   * Post-refactor chatbox identifiers (set after /web/chatbox/redeem).
+   * `chatboxToken` is retained for surfaces that haven't migrated; the
+   * server prefers `chatboxId` when both are present.
+   */
+  chatboxId?: string;
+  accessVersion?: number;
   chatboxToken?: string;
   chatboxSurface?: "preview" | "share_link";
 };

--- a/mcpjam-inspector/client/src/lib/hosted-runtime-context.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-runtime-context.ts
@@ -3,12 +3,10 @@ export type HostedRuntimeContext = {
   selectedServerIds?: string[];
   oauthTokens?: Record<string, string>;
   /**
-   * Post-refactor chatbox identifiers (set after /web/chatbox/redeem).
-   * `chatboxToken` is retained for surfaces that haven't migrated; the
-   * server prefers `chatboxId` when both are present.
+   * Resolved chatbox identity (post-redeem). Threaded into every
+   * chatbox-aware request body and cache key.
    */
   chatboxId?: string;
   accessVersion?: number;
-  chatboxToken?: string;
   chatboxSurface?: "preview" | "share_link";
 };

--- a/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.hosted-session.test.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/__tests__/mcp-oauth.hosted-session.test.ts
@@ -57,7 +57,7 @@ describe("mcp-oauth hosted callback sessions", () => {
         sessionId: "hosted-session-1",
         accessScope: "project_member",
         
-        chatboxToken: null,
+        chatboxId: null,
         returnHash: "#servers",
         startedAt: Date.now(),
       },
@@ -126,7 +126,7 @@ describe("mcp-oauth hosted callback sessions", () => {
         sessionId: "hosted-session-1",
         accessScope: "project_member",
         
-        chatboxToken: null,
+        chatboxId: null,
         returnHash: "#servers",
         startedAt: Date.now(),
       },
@@ -200,7 +200,7 @@ describe("mcp-oauth hosted callback sessions", () => {
         sessionId: "hosted-session-1",
         accessScope: "project_member",
         
-        chatboxToken: null,
+        chatboxId: null,
         returnHash: "#servers",
         startedAt: Date.now(),
       },
@@ -255,7 +255,7 @@ describe("mcp-oauth hosted callback sessions", () => {
         serverUrl: "https://mcp.linear.app",
         sessionId: "hosted-session-1",
         accessScope: "project_member",
-        chatboxToken: null,
+        chatboxId: null,
         returnHash: "#servers",
         startedAt: Date.now(),
       },
@@ -343,7 +343,7 @@ describe("mcp-oauth hosted callback sessions", () => {
           sessionId: "hosted-session-1",
           accessScope: "project_member",
           
-          chatboxToken: null,
+          chatboxId: null,
           returnHash: "#servers",
           startedAt: Date.now(),
         },
@@ -465,7 +465,7 @@ describe("mcp-oauth hosted callback sessions", () => {
           sessionId: "hosted-session-1",
           accessScope: "project_member",
           
-          chatboxToken: null,
+          chatboxId: null,
           returnHash: "#servers",
           startedAt: Date.now(),
         },

--- a/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
+++ b/mcpjam-inspector/client/src/lib/oauth/mcp-oauth.ts
@@ -1750,8 +1750,13 @@ async function createHostedOAuthSessionIfNeeded(input: {
       ...(pendingMarker.accessScope
         ? { accessScope: pendingMarker.accessScope }
         : {}),
-      ...(pendingMarker.chatboxToken
-        ? { chatboxToken: pendingMarker.chatboxToken }
+      ...(pendingMarker.chatboxId
+        ? { chatboxId: pendingMarker.chatboxId }
+        : {}),
+      ...(pendingMarker.chatboxId &&
+      typeof pendingMarker.accessVersion === "number" &&
+      Number.isFinite(pendingMarker.accessVersion)
+        ? { accessVersion: pendingMarker.accessVersion }
         : {}),
     }),
   });
@@ -1811,8 +1816,13 @@ async function readHostedOAuthSessionProgress(input: {
         ...(input.context.accessScope
           ? { accessScope: input.context.accessScope }
           : {}),
-        ...(input.context.chatboxToken
-          ? { chatboxToken: input.context.chatboxToken }
+        ...(input.context.chatboxId
+          ? { chatboxId: input.context.chatboxId }
+          : {}),
+        ...(input.context.chatboxId &&
+        typeof input.context.accessVersion === "number" &&
+        Number.isFinite(input.context.accessVersion)
+          ? { accessVersion: input.context.accessVersion }
           : {}),
       }),
     }
@@ -2775,8 +2785,11 @@ export async function completeHostedOAuthCallback(
                 },
               }),
           ...(context.accessScope ? { accessScope: context.accessScope } : {}),
-          ...(context.chatboxToken
-            ? { chatboxToken: context.chatboxToken }
+          ...(context.chatboxId ? { chatboxId: context.chatboxId } : {}),
+          ...(context.chatboxId &&
+          typeof context.accessVersion === "number" &&
+          Number.isFinite(context.accessVersion)
+            ? { accessVersion: context.accessVersion }
             : {}),
         }),
       });

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -458,7 +458,6 @@ chatV2.post("/", async (c) => {
       // of being filed as a direct chat.
       chatboxId?: string;
       accessVersion?: number;
-      chatboxToken?: string;
       surface?: "preview" | "share_link";
     };
     const mcpClientManager = c.mcpClientManager;
@@ -473,10 +472,9 @@ chatV2.post("/", async (c) => {
       requireToolApproval,
       chatboxId: bodyChatboxId,
       accessVersion: bodyAccessVersion,
-      chatboxToken: bodyChatboxToken,
       surface: bodySurface,
     } = body;
-    const isChatboxSession = Boolean(bodyChatboxId || bodyChatboxToken);
+    const isChatboxSession = Boolean(bodyChatboxId);
     const chatSessionSourceType: "chatbox" | "direct" = isChatboxSession
       ? "chatbox"
       : "direct";
@@ -629,29 +627,28 @@ chatV2.post("/", async (c) => {
                 sourceType: chatSessionSourceType,
                 ...(chatSessionSurface ? { surface: chatSessionSurface } : {}),
                 ...(bodyChatboxId ? { chatboxId: bodyChatboxId } : {}),
-                ...(typeof bodyAccessVersion === "number"
+                ...(bodyChatboxId && Number.isFinite(bodyAccessVersion)
                   ? { accessVersion: bodyAccessVersion }
                   : {}),
-                ...(bodyChatboxToken && !bodyChatboxId
-                  ? { chatboxToken: bodyChatboxToken }
-                  : {}),
-                ...(isChatboxSession
-                  ? {}
-                  : { directVisibility: body.directVisibility }),
                 authHeader,
                 sessionMessages: fullHistory,
                 startedAt: sessionStartedAt,
                 lastActivityAt: Date.now(),
                 ...(body.projectId ? { projectId: body.projectId } : {}),
-                resumeConfig: {
-                  systemPrompt,
-                  temperature,
-                  requireToolApproval,
-                  selectedServers,
-                },
-                ...(directHostConfig
-                  ? { hostConfig: directHostConfig }
-                  : {}),
+                ...(isChatboxSession
+                  ? {}
+                  : {
+                      directVisibility: body.directVisibility,
+                      resumeConfig: {
+                        systemPrompt,
+                        temperature,
+                        requireToolApproval,
+                        selectedServers,
+                      },
+                      ...(directHostConfig
+                        ? { hostConfig: directHostConfig }
+                        : {}),
+                    }),
                 expectedVersion: body.expectedVersion,
                 turnTrace,
                 forwardHeaders: pickEnrichmentHeaders(c.req.raw.headers),
@@ -709,29 +706,28 @@ chatV2.post("/", async (c) => {
                 sourceType: chatSessionSourceType,
                 ...(chatSessionSurface ? { surface: chatSessionSurface } : {}),
                 ...(bodyChatboxId ? { chatboxId: bodyChatboxId } : {}),
-                ...(typeof bodyAccessVersion === "number"
+                ...(bodyChatboxId && Number.isFinite(bodyAccessVersion)
                   ? { accessVersion: bodyAccessVersion }
                   : {}),
-                ...(bodyChatboxToken && !bodyChatboxId
-                  ? { chatboxToken: bodyChatboxToken }
-                  : {}),
-                ...(isChatboxSession
-                  ? {}
-                  : { directVisibility: body.directVisibility }),
                 authHeader: c.req.header("authorization"),
                 sessionMessages: fullHistory,
                 startedAt: sessionStartedAt,
                 lastActivityAt: Date.now(),
                 projectId: body.projectId,
-                resumeConfig: {
-                  systemPrompt,
-                  temperature,
-                  requireToolApproval,
-                  selectedServers,
-                },
-                ...(directHostConfig
-                  ? { hostConfig: directHostConfig }
-                  : {}),
+                ...(isChatboxSession
+                  ? {}
+                  : {
+                      directVisibility: body.directVisibility,
+                      resumeConfig: {
+                        systemPrompt,
+                        temperature,
+                        requireToolApproval,
+                        selectedServers,
+                      },
+                      ...(directHostConfig
+                        ? { hostConfig: directHostConfig }
+                        : {}),
+                    }),
                 expectedVersion: body.expectedVersion,
                 turnTrace,
                 forwardHeaders: pickEnrichmentHeaders(c.req.raw.headers),
@@ -788,15 +784,9 @@ chatV2.post("/", async (c) => {
               sourceType: chatSessionSourceType,
               ...(chatSessionSurface ? { surface: chatSessionSurface } : {}),
               ...(bodyChatboxId ? { chatboxId: bodyChatboxId } : {}),
-              ...(typeof bodyAccessVersion === "number"
+              ...(bodyChatboxId && Number.isFinite(bodyAccessVersion)
                 ? { accessVersion: bodyAccessVersion }
                 : {}),
-              ...(bodyChatboxToken && !bodyChatboxId
-                ? { chatboxToken: bodyChatboxToken }
-                : {}),
-              ...(isChatboxSession
-                ? {}
-                : { directVisibility: body.directVisibility }),
               messages: modelMessages as ModelMessage[],
               systemPrompt: enhancedSystemPrompt,
               ...(responseMessages.length > 0 ? { responseMessages } : {}),
@@ -809,15 +799,20 @@ chatV2.post("/", async (c) => {
               startedAt: streamStartedAt,
               lastActivityAt: Date.now(),
               ...(body.projectId ? { projectId: body.projectId } : {}),
-              resumeConfig: {
-                systemPrompt,
-                temperature,
-                requireToolApproval,
-                selectedServers,
-              },
-              ...(directHostConfig
-                ? { hostConfig: directHostConfig }
-                : {}),
+              ...(isChatboxSession
+                ? {}
+                : {
+                    directVisibility: body.directVisibility,
+                    resumeConfig: {
+                      systemPrompt,
+                      temperature,
+                      requireToolApproval,
+                      selectedServers,
+                    },
+                    ...(directHostConfig
+                      ? { hostConfig: directHostConfig }
+                      : {}),
+                  }),
               expectedVersion: body.expectedVersion,
               turnTrace,
               forwardHeaders: pickEnrichmentHeaders(c.req.raw.headers),

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -450,7 +450,17 @@ const chatV2 = new Hono();
 
 chatV2.post("/", async (c) => {
   try {
-    const body = (await c.req.json()) as ChatV2Request;
+    const body = (await c.req.json()) as ChatV2Request & {
+      // Phase F: when the local inspector serves an owner-preview of a
+      // chatbox (the share-link surface running in /mcp), the client
+      // passes the resolved chatbox identity so persistence reads
+      // `sourceType: "chatbox"` + the right surface telemetry instead
+      // of being filed as a direct chat.
+      chatboxId?: string;
+      accessVersion?: number;
+      chatboxToken?: string;
+      surface?: "preview" | "share_link";
+    };
     const mcpClientManager = c.mcpClientManager;
     const {
       messages,
@@ -461,7 +471,17 @@ chatV2.post("/", async (c) => {
       selectedServers,
       selectedServerIds: bodySelectedServerIds,
       requireToolApproval,
+      chatboxId: bodyChatboxId,
+      accessVersion: bodyAccessVersion,
+      chatboxToken: bodyChatboxToken,
+      surface: bodySurface,
     } = body;
+    const isChatboxSession = Boolean(bodyChatboxId || bodyChatboxToken);
+    const chatSessionSourceType: "chatbox" | "direct" = isChatboxSession
+      ? "chatbox"
+      : "direct";
+    const chatSessionSurface: "preview" | "share_link" | undefined =
+      isChatboxSession ? bodySurface ?? "preview" : undefined;
 
     // Local-mode `selectedServers` is server *names*, not Convex Ids. The
     // backend's `hostConfigPayloadValidator` requires `v.array(v.id('servers'))`,
@@ -606,8 +626,18 @@ chatV2.post("/", async (c) => {
                 chatSessionId,
                 modelId: String(modelDefinition.id),
                 modelSource: "mcpjam",
-                sourceType: "direct",
-                directVisibility: body.directVisibility,
+                sourceType: chatSessionSourceType,
+                ...(chatSessionSurface ? { surface: chatSessionSurface } : {}),
+                ...(bodyChatboxId ? { chatboxId: bodyChatboxId } : {}),
+                ...(typeof bodyAccessVersion === "number"
+                  ? { accessVersion: bodyAccessVersion }
+                  : {}),
+                ...(bodyChatboxToken && !bodyChatboxId
+                  ? { chatboxToken: bodyChatboxToken }
+                  : {}),
+                ...(isChatboxSession
+                  ? {}
+                  : { directVisibility: body.directVisibility }),
                 authHeader,
                 sessionMessages: fullHistory,
                 startedAt: sessionStartedAt,
@@ -676,8 +706,18 @@ chatV2.post("/", async (c) => {
                 chatSessionId,
                 modelId: String(modelDefinition.id),
                 modelSource: "byok",
-                sourceType: "direct",
-                directVisibility: body.directVisibility,
+                sourceType: chatSessionSourceType,
+                ...(chatSessionSurface ? { surface: chatSessionSurface } : {}),
+                ...(bodyChatboxId ? { chatboxId: bodyChatboxId } : {}),
+                ...(typeof bodyAccessVersion === "number"
+                  ? { accessVersion: bodyAccessVersion }
+                  : {}),
+                ...(bodyChatboxToken && !bodyChatboxId
+                  ? { chatboxToken: bodyChatboxToken }
+                  : {}),
+                ...(isChatboxSession
+                  ? {}
+                  : { directVisibility: body.directVisibility }),
                 authHeader: c.req.header("authorization"),
                 sessionMessages: fullHistory,
                 startedAt: sessionStartedAt,
@@ -745,8 +785,18 @@ chatV2.post("/", async (c) => {
               chatSessionId,
               modelId: String(modelDefinition.id),
               modelSource: "byok",
-              sourceType: "direct",
-              directVisibility: body.directVisibility,
+              sourceType: chatSessionSourceType,
+              ...(chatSessionSurface ? { surface: chatSessionSurface } : {}),
+              ...(bodyChatboxId ? { chatboxId: bodyChatboxId } : {}),
+              ...(typeof bodyAccessVersion === "number"
+                ? { accessVersion: bodyAccessVersion }
+                : {}),
+              ...(bodyChatboxToken && !bodyChatboxId
+                ? { chatboxToken: bodyChatboxToken }
+                : {}),
+              ...(isChatboxSession
+                ? {}
+                : { directVisibility: body.directVisibility }),
               messages: modelMessages as ModelMessage[],
               systemPrompt: enhancedSystemPrompt,
               ...(responseMessages.length > 0 ? { responseMessages } : {}),

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -82,7 +82,8 @@ export const RunEvalsRequestSchema = z.object({
     .array(z.string())
     .min(1, { message: "At least one server must be selected" }),
   serverNames: z.array(z.string()).optional(),
-  chatboxToken: z.string().optional(),
+  chatboxId: z.string().optional(),
+  accessVersion: z.number().int().nonnegative().optional(),
   storageServerIds: z.array(z.string()).optional(),
   modelApiKeys: z.record(z.string(), z.string()).optional(),
   convexAuthToken: z.string(),
@@ -116,7 +117,8 @@ export const RunTestCaseRequestSchema = z.object({
   serverIds: z
     .array(z.string())
     .min(1, { message: "At least one server must be selected" }),
-  chatboxToken: z.string().optional(),
+  chatboxId: z.string().optional(),
+  accessVersion: z.number().int().nonnegative().optional(),
   modelApiKeys: z.record(z.string(), z.string()).optional(),
   convexAuthToken: z.string(),
   testCaseOverrides: z
@@ -293,7 +295,8 @@ export async function runEvalsWithManager(
     tests,
     serverIds,
     serverNames,
-    chatboxToken,
+    chatboxId,
+    accessVersion,
     storageServerIds,
     modelApiKeys,
     orgModelConfig,
@@ -601,7 +604,8 @@ export async function runEvalsWithManager(
       try {
         const orgConfig = await resolveOrgModelConfig(orgConfigTarget, {
           bearerToken: convexAuthToken,
-          chatboxToken,
+          chatboxId,
+          accessVersion,
           serverIds: resolvedServerIds,
         });
         resolvedOrgModelConfig = orgConfig;
@@ -652,7 +656,8 @@ export async function runEvalTestCaseWithManager(
     provider,
     compareRunId,
     serverIds,
-    chatboxToken,
+    chatboxId,
+    accessVersion,
     skipLastMessageRunUpdate,
     modelApiKeys,
     orgModelConfig,
@@ -718,7 +723,8 @@ export async function runEvalTestCaseWithManager(
         testCaseOrgConfigTarget,
         {
           bearerToken: convexAuthToken,
-          chatboxToken,
+          chatboxId,
+          accessVersion,
           serverIds: resolvedServerIds,
         },
       );
@@ -883,7 +889,8 @@ export async function streamEvalTestCaseWithManager(
     provider,
     compareRunId,
     serverIds,
-    chatboxToken,
+    chatboxId,
+    accessVersion,
     skipLastMessageRunUpdate,
     modelApiKeys,
     orgModelConfig,
@@ -951,7 +958,8 @@ export async function streamEvalTestCaseWithManager(
         streamTestCaseOrgConfigTarget,
         {
           bearerToken: convexAuthToken,
-          chatboxToken,
+          chatboxId,
+          accessVersion,
           serverIds: resolvedServerIds,
         },
       );

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -160,7 +160,8 @@ describe("web routes — chat-v2 hosted mode", () => {
       {
         projectId: "project-1",
         selectedServerIds: ["server-1"],
-        chatboxToken: "chatbox-token",
+        chatboxId: "cbx_1",
+        accessVersion: 1,
         surface: "preview",
         chatSessionId: "chat-session-1",
         messages: [{ role: "user", content: "preview request" }],
@@ -185,7 +186,8 @@ describe("web routes — chat-v2 hosted mode", () => {
         chatSessionId: "chat-session-1",
         projectId: "project-1",
         sourceType: "chatbox",
-        chatboxToken: "chatbox-token",
+        chatboxId: "cbx_1",
+        accessVersion: 1,
         surface: "preview",
         modelId: "openai/gpt-5-mini",
         modelSource: "mcpjam",
@@ -206,7 +208,8 @@ describe("web routes — chat-v2 hosted mode", () => {
       {
         projectId: "project-1",
         selectedServerIds: ["server-1"],
-        chatboxToken: "chatbox-shared-token",
+        chatboxId: "cbx_shared",
+        accessVersion: 2,
         surface: "share_link",
         chatSessionId: "chat-session-shared",
         messages: [{ role: "user", content: "hello from guest" }],
@@ -222,7 +225,8 @@ describe("web routes — chat-v2 hosted mode", () => {
     expect(response.status).toBe(200);
     expect(handleMCPJamFreeChatModelMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        chatboxToken: "chatbox-shared-token",
+        chatboxId: "cbx_shared",
+        accessVersion: 2,
         projectId: "project-1",
       })
     );

--- a/mcpjam-inspector/server/routes/web/__tests__/chatboxes.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chatboxes.test.ts
@@ -3,7 +3,7 @@ import { createWebTestApp, expectJson, postJson } from "./helpers/test-app.js";
 
 const ORIGINAL_CONVEX_HTTP_URL = process.env.CONVEX_HTTP_URL;
 
-describe("web routes — chatboxes bootstrap", () => {
+describe("web routes — chatboxes redeem", () => {
   const { app, token } = createWebTestApp();
 
   beforeEach(() => {
@@ -24,19 +24,17 @@ describe("web routes — chatboxes bootstrap", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(
-        new Response("No matching routes found", {
+        new Response(JSON.stringify({ ok: false, error: "missing route" }), {
           status: 404,
-          headers: {
-            "Content-Type": "text/plain; charset=utf-8",
-          },
+          headers: { "Content-Type": "application/json" },
         }),
       ),
     );
 
     const response = await postJson(
       app,
-      "/api/web/chatboxes/bootstrap",
-      { token: "chatbox-link-token" },
+      "/api/web/chatboxes/redeem",
+      { chatboxToken: "chatbox-link-token" },
       token,
     );
     const { status, data } = await expectJson<{
@@ -46,21 +44,23 @@ describe("web routes — chatboxes bootstrap", () => {
 
     expect(status).toBe(404);
     expect(data.code).toBe("NOT_FOUND");
-    expect(data.message).toContain("does not expose /chatbox/bootstrap");
   });
 
-  it("returns a timeout error when chatbox bootstrap aborts", async () => {
-    const fetchMock = vi.fn().mockRejectedValue(
-      Object.assign(new Error("The operation was aborted"), {
-        name: "AbortError",
-      }),
+  it("maps an upstream 429 to RATE_LIMITED (not UNAUTHORIZED)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ ok: false, error: "slow down" }), {
+          status: 429,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
     );
-    vi.stubGlobal("fetch", fetchMock);
 
     const response = await postJson(
       app,
-      "/api/web/chatboxes/bootstrap",
-      { token: "chatbox-link-token" },
+      "/api/web/chatboxes/redeem",
+      { chatboxToken: "chatbox-link-token" },
       token,
     );
     const { status, data } = await expectJson<{
@@ -68,27 +68,52 @@ describe("web routes — chatboxes bootstrap", () => {
       message: string;
     }>(response);
 
-    expect(status).toBe(504);
-    expect(data).toEqual({
-      code: "SERVER_UNREACHABLE",
-      message: "Chatbox bootstrap service timed out",
-    });
-    expect(fetchMock).toHaveBeenCalledWith(
-      "https://test-deployment.convex.site/chatbox/bootstrap",
-      expect.objectContaining({
-        signal: expect.any(AbortSignal),
-      }),
-    );
+    expect(status).toBe(429);
+    expect(data.code).toBe("RATE_LIMITED");
   });
 
-  it("returns the chatbox bootstrap payload on success", async () => {
+  it("coerces 2xx with ok:false to a 502 instead of leaking a misleading 200", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({ ok: false, error: "upstream contract violation" }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      ),
+    );
+
+    const response = await postJson(
+      app,
+      "/api/web/chatboxes/redeem",
+      { chatboxToken: "chatbox-link-token" },
+      token,
+    );
+    const { status, data } = await expectJson<{
+      code: string;
+      message: string;
+    }>(response);
+
+    expect(status).toBe(502);
+    expect(data.code).toBe("SERVER_UNREACHABLE");
+  });
+
+  it("returns the redeem payload on success", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(
         new Response(
           JSON.stringify({
             ok: true,
-            payload: {
+            chatboxId: "sbx_1",
+            role: "chat",
+            mode: "invited_only",
+            projectId: "ws_1",
+            accessVersion: 3,
+            bootstrap: {
               projectId: "ws_1",
               chatboxId: "sbx_1",
               name: "Host Styled Chatbox",
@@ -105,9 +130,7 @@ describe("web routes — chatboxes bootstrap", () => {
           }),
           {
             status: 200,
-            headers: {
-              "Content-Type": "application/json",
-            },
+            headers: { "Content-Type": "application/json" },
           },
         ),
       ),
@@ -115,23 +138,27 @@ describe("web routes — chatboxes bootstrap", () => {
 
     const response = await postJson(
       app,
-      "/api/web/chatboxes/bootstrap",
-      { token: "chatbox-link-token" },
+      "/api/web/chatboxes/redeem",
+      { chatboxToken: "chatbox-link-token" },
       token,
     );
     const { status, data } = await expectJson<{
-      projectId: string;
       chatboxId: string;
-      name: string;
-      hostStyle: string;
+      role: string;
+      mode: string;
+      projectId: string;
+      accessVersion: number;
+      bootstrap: { name: string };
     }>(response);
 
     expect(status).toBe(200);
     expect(data).toMatchObject({
-      projectId: "ws_1",
       chatboxId: "sbx_1",
-      name: "Host Styled Chatbox",
-      hostStyle: "chatgpt",
+      role: "chat",
+      mode: "invited_only",
+      projectId: "ws_1",
+      accessVersion: 3,
+      bootstrap: expect.objectContaining({ name: "Host Styled Chatbox" }),
     });
   });
 });

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -46,6 +46,13 @@ export const projectServerSchema = z.object({
   clientCapabilities: clientCapabilitiesSchema.optional(),
   oauthAccessToken: z.string().optional(),
   accessScope: z.enum(["project_member", "chat_v2"]).optional(),
+  // Post-refactor: callers identify chatboxes by `chatboxId` (resolved via
+  // /web/chatbox/redeem). `chatboxToken` is kept transitionally so untouched
+  // legacy callsites still work; the backend's authorize-batch will redeem
+  // it server-side. TODO(chatbox-followup): drop `chatboxToken` once every
+  // client surface migrates.
+  chatboxId: z.string().min(1).optional(),
+  accessVersion: z.number().int().nonnegative().optional(),
   chatboxToken: z.string().min(1).optional(),
 });
 
@@ -79,6 +86,13 @@ export const promptsListMultiSchema = z.object({
   clientCapabilities: clientCapabilitiesSchema.optional(),
   oauthTokens: z.record(z.string(), z.string()).optional(),
   accessScope: z.enum(["project_member", "chat_v2"]).optional(),
+  // Post-refactor: callers identify chatboxes by `chatboxId` (resolved via
+  // /web/chatbox/redeem). `chatboxToken` is kept transitionally so untouched
+  // legacy callsites still work; the backend's authorize-batch will redeem
+  // it server-side. TODO(chatbox-followup): drop `chatboxToken` once every
+  // client surface migrates.
+  chatboxId: z.string().min(1).optional(),
+  accessVersion: z.number().int().nonnegative().optional(),
   chatboxToken: z.string().min(1).optional(),
 });
 
@@ -99,6 +113,9 @@ export const hostedChatSchema = z
     surface: z.enum(["preview", "share_link"]).optional(),
     oauthTokens: z.record(z.string(), z.string()).optional(),
     accessScope: z.enum(["project_member", "chat_v2"]).optional(),
+    // See projectServerSchema for the chatboxId migration note.
+    chatboxId: z.string().min(1).optional(),
+    accessVersion: z.number().int().nonnegative().optional(),
     chatboxToken: z.string().min(1).optional(),
   })
   .passthrough();
@@ -224,6 +241,12 @@ export async function authorizeServer(
   options?: {
     accessScope?: "project_member" | "chat_v2";
     workspaceId?: string;
+    // Post-refactor preferred path: `chatboxId` (+ optional `accessVersion`
+    // for cache-version stamping). `chatboxToken` is accepted as a fallback
+    // so legacy callsites that haven't migrated yet still work; the backend
+    // will redeem it server-side.
+    chatboxId?: string;
+    accessVersion?: number;
     chatboxToken?: string;
   }
 ): Promise<ClientSafeAuthorizeResponse> {
@@ -250,7 +273,11 @@ export async function authorizeServer(
           : { projectId }),
         serverId,
         ...(options?.accessScope ? { accessScope: options.accessScope } : {}),
-        ...(options?.chatboxToken
+        ...(options?.chatboxId ? { chatboxId: options.chatboxId } : {}),
+        ...(typeof options?.accessVersion === "number"
+          ? { accessVersion: options.accessVersion }
+          : {}),
+        ...(options?.chatboxToken && !options?.chatboxId
           ? { chatboxToken: options.chatboxToken }
           : {}),
       }),
@@ -303,6 +330,8 @@ export async function authorizeBatch(
   options?: {
     accessScope?: "project_member" | "chat_v2";
     workspaceId?: string;
+    chatboxId?: string;
+    accessVersion?: number;
     chatboxToken?: string;
   }
 ): Promise<ConvexBatchAuthorizeResponse> {
@@ -329,7 +358,11 @@ export async function authorizeBatch(
           : { projectId }),
         serverIds,
         ...(options?.accessScope ? { accessScope: options.accessScope } : {}),
-        ...(options?.chatboxToken
+        ...(options?.chatboxId ? { chatboxId: options.chatboxId } : {}),
+        ...(typeof options?.accessVersion === "number"
+          ? { accessVersion: options.accessVersion }
+          : {}),
+        ...(options?.chatboxToken && !options?.chatboxId
           ? { chatboxToken: options.chatboxToken }
           : {}),
       }),
@@ -471,6 +504,8 @@ export async function createAuthorizedManager(
   options?: {
     accessScope?: "project_member" | "chat_v2";
     workspaceId?: string;
+    chatboxId?: string;
+    accessVersion?: number;
     chatboxToken?: string;
     rpcLogger?: RpcLogger;
     serverNames?: string[];
@@ -501,6 +536,8 @@ export async function createAuthorizedManager(
     {
       accessScope: options?.accessScope,
       workspaceId: options?.workspaceId,
+      chatboxId: options?.chatboxId,
+      accessVersion: options?.accessVersion,
       chatboxToken: options?.chatboxToken,
     }
   );
@@ -535,6 +572,8 @@ export async function createAuthorizedManager(
             accessScope: options?.accessScope,
             workspaceId: options?.workspaceId,
             shareToken: options?.shareToken,
+            chatboxId: options?.chatboxId,
+            accessVersion: options?.accessVersion,
             chatboxToken: options?.chatboxToken,
           })
         : undefined;
@@ -718,6 +757,12 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
       raw.accessScope === "project_member" || raw.accessScope === "chat_v2"
         ? raw.accessScope
         : undefined;
+    const chatboxId =
+      typeof raw.chatboxId === "string" && raw.chatboxId.trim()
+        ? raw.chatboxId
+        : undefined;
+    const accessVersion =
+      typeof raw.accessVersion === "number" ? raw.accessVersion : undefined;
     const chatboxToken =
       typeof raw.chatboxToken === "string" && raw.chatboxToken.trim()
         ? raw.chatboxToken
@@ -737,6 +782,8 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
           accessScope,
           workspaceId:
             typeof raw.workspaceId === "string" ? raw.workspaceId : undefined,
+          chatboxId,
+          accessVersion,
           chatboxToken,
           rpcLogger: rpcCollector?.rpcLogger,
           serverNames,

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -46,14 +46,12 @@ export const projectServerSchema = z.object({
   clientCapabilities: clientCapabilitiesSchema.optional(),
   oauthAccessToken: z.string().optional(),
   accessScope: z.enum(["project_member", "chat_v2"]).optional(),
-  // Post-refactor: callers identify chatboxes by `chatboxId` (resolved via
-  // /web/chatbox/redeem). `chatboxToken` is kept transitionally so untouched
-  // legacy callsites still work; the backend's authorize-batch will redeem
-  // it server-side. TODO(chatbox-followup): drop `chatboxToken` once every
-  // client surface migrates.
+  // Callers identify chatboxes by `chatboxId` (resolved via
+  // /web/chatbox/redeem) plus the backend-owned `accessVersion`. The
+  // link token is consumed only at redemption; no read-path callsite
+  // accepts it.
   chatboxId: z.string().min(1).optional(),
   accessVersion: z.number().int().nonnegative().optional(),
-  chatboxToken: z.string().min(1).optional(),
 });
 
 export const toolsListSchema = projectServerSchema.extend({
@@ -86,14 +84,9 @@ export const promptsListMultiSchema = z.object({
   clientCapabilities: clientCapabilitiesSchema.optional(),
   oauthTokens: z.record(z.string(), z.string()).optional(),
   accessScope: z.enum(["project_member", "chat_v2"]).optional(),
-  // Post-refactor: callers identify chatboxes by `chatboxId` (resolved via
-  // /web/chatbox/redeem). `chatboxToken` is kept transitionally so untouched
-  // legacy callsites still work; the backend's authorize-batch will redeem
-  // it server-side. TODO(chatbox-followup): drop `chatboxToken` once every
-  // client surface migrates.
+  // See projectServerSchema — chatbox identity is `chatboxId` + `accessVersion`.
   chatboxId: z.string().min(1).optional(),
   accessVersion: z.number().int().nonnegative().optional(),
-  chatboxToken: z.string().min(1).optional(),
 });
 
 export const promptsGetSchema = projectServerSchema.extend({
@@ -113,10 +106,9 @@ export const hostedChatSchema = z
     surface: z.enum(["preview", "share_link"]).optional(),
     oauthTokens: z.record(z.string(), z.string()).optional(),
     accessScope: z.enum(["project_member", "chat_v2"]).optional(),
-    // See projectServerSchema for the chatboxId migration note.
+    // See projectServerSchema — chatbox identity is `chatboxId` + `accessVersion`.
     chatboxId: z.string().min(1).optional(),
     accessVersion: z.number().int().nonnegative().optional(),
-    chatboxToken: z.string().min(1).optional(),
   })
   .passthrough();
 
@@ -241,13 +233,8 @@ export async function authorizeServer(
   options?: {
     accessScope?: "project_member" | "chat_v2";
     workspaceId?: string;
-    // Post-refactor preferred path: `chatboxId` (+ optional `accessVersion`
-    // for cache-version stamping). `chatboxToken` is accepted as a fallback
-    // so legacy callsites that haven't migrated yet still work; the backend
-    // will redeem it server-side.
     chatboxId?: string;
     accessVersion?: number;
-    chatboxToken?: string;
   }
 ): Promise<ClientSafeAuthorizeResponse> {
   const convexUrl = process.env.CONVEX_HTTP_URL;
@@ -276,9 +263,6 @@ export async function authorizeServer(
         ...(options?.chatboxId ? { chatboxId: options.chatboxId } : {}),
         ...(typeof options?.accessVersion === "number"
           ? { accessVersion: options.accessVersion }
-          : {}),
-        ...(options?.chatboxToken && !options?.chatboxId
-          ? { chatboxToken: options.chatboxToken }
           : {}),
       }),
     });
@@ -332,7 +316,6 @@ export async function authorizeBatch(
     workspaceId?: string;
     chatboxId?: string;
     accessVersion?: number;
-    chatboxToken?: string;
   }
 ): Promise<ConvexBatchAuthorizeResponse> {
   const convexUrl = process.env.CONVEX_HTTP_URL;
@@ -361,9 +344,6 @@ export async function authorizeBatch(
         ...(options?.chatboxId ? { chatboxId: options.chatboxId } : {}),
         ...(typeof options?.accessVersion === "number"
           ? { accessVersion: options.accessVersion }
-          : {}),
-        ...(options?.chatboxToken && !options?.chatboxId
-          ? { chatboxToken: options.chatboxToken }
           : {}),
       }),
     });
@@ -506,7 +486,6 @@ export async function createAuthorizedManager(
     workspaceId?: string;
     chatboxId?: string;
     accessVersion?: number;
-    chatboxToken?: string;
     rpcLogger?: RpcLogger;
     serverNames?: string[];
   }
@@ -538,7 +517,6 @@ export async function createAuthorizedManager(
       workspaceId: options?.workspaceId,
       chatboxId: options?.chatboxId,
       accessVersion: options?.accessVersion,
-      chatboxToken: options?.chatboxToken,
     }
   );
 
@@ -571,10 +549,9 @@ export async function createAuthorizedManager(
             serverName: displayServerName,
             accessScope: options?.accessScope,
             workspaceId: options?.workspaceId,
-            shareToken: options?.shareToken,
+            shareToken: (options as { shareToken?: string })?.shareToken,
             chatboxId: options?.chatboxId,
             accessVersion: options?.accessVersion,
-            chatboxToken: options?.chatboxToken,
           })
         : undefined;
 
@@ -762,10 +739,8 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
         ? raw.chatboxId
         : undefined;
     const accessVersion =
-      typeof raw.accessVersion === "number" ? raw.accessVersion : undefined;
-    const chatboxToken =
-      typeof raw.chatboxToken === "string" && raw.chatboxToken.trim()
-        ? raw.chatboxToken
+      typeof raw.accessVersion === "number" && Number.isFinite(raw.accessVersion)
+        ? raw.accessVersion
         : undefined;
 
     const result = await withManager(
@@ -784,7 +759,6 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
             typeof raw.workspaceId === "string" ? raw.workspaceId : undefined,
           chatboxId,
           accessVersion,
-          chatboxToken,
           rpcLogger: rpcCollector?.rpcLogger,
           serverNames,
         }

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -73,6 +73,11 @@ chatV2.post("/", async (c) => {
       projectId: string;
       selectedServerIds: string[];
       selectedServerNames?: string[];
+      // Post-refactor: clients pass `chatboxId` (+ optional accessVersion)
+      // after calling /web/chatbox/redeem. `chatboxToken` is accepted
+      // transitionally; the backend will redeem it server-side.
+      chatboxId?: string;
+      accessVersion?: number;
       chatboxToken?: string;
       accessScope?: "project_member" | "chat_v2";
       surface?: "preview" | "share_link";
@@ -86,9 +91,16 @@ chatV2.post("/", async (c) => {
       requireToolApproval,
       selectedServerIds,
       selectedServerNames,
+      chatboxId,
+      accessVersion,
       chatboxToken,
       surface,
     } = body;
+    // True when this turn flows through a chatbox surface (either keyed by
+    // chatboxId for already-redeemed sessions or chatboxToken for legacy
+    // callers that haven't migrated). sourceType + accessScope decisions
+    // hinge on this.
+    const isChatboxSession = Boolean(chatboxId || chatboxToken);
 
     if (!Array.isArray(messages) || messages.length === 0) {
       throw new WebRouteError(
@@ -120,7 +132,9 @@ chatV2.post("/", async (c) => {
       hostedBody.oauthTokens,
       hostedBody.clientCapabilities,
       {
-        ...(chatboxToken ? { accessScope: "chat_v2" } : {}),
+        ...(isChatboxSession ? { accessScope: "chat_v2" } : {}),
+        chatboxId,
+        accessVersion,
         chatboxToken,
         rpcLogger: rpcCollector.rpcLogger,
         serverNames: selectedServerNames,
@@ -183,7 +197,7 @@ chatV2.post("/", async (c) => {
         const providerKey = deriveOrgProviderKey(modelDefinition);
         const modelId = String(modelDefinition.id);
         const scrubbedMessages = scrubMessages(modelMessages as ModelMessage[]);
-        const sourceType = chatboxToken ? "chatbox" : "direct";
+        const sourceType = isChatboxSession ? "chatbox" : "direct";
 
         // Cloud-only providers (everything that isn't on the local-runtime
         // allowlist) skip the /stream/org/resolve round-trip entirely. The
@@ -198,6 +212,8 @@ chatV2.post("/", async (c) => {
               modelId,
               {
                 authHeader: c.req.header("authorization"),
+                chatboxId,
+                accessVersion,
                 chatboxToken,
                 serverIds: selectedServerIds,
               },
@@ -206,7 +222,7 @@ chatV2.post("/", async (c) => {
 
         const onConversationComplete = hostedChatSessionId
           ? async (fullHistory: ModelMessage[], turnTrace: PersistedTurnTrace) => {
-              const isDirectChat = !chatboxToken;
+              const isDirectChat = !isChatboxSession;
               await persistChatSessionToConvex({
                 chatSessionId: hostedChatSessionId,
                 modelId,
@@ -214,7 +230,9 @@ chatV2.post("/", async (c) => {
                   runtime.runtimeLocation === "local" ? "local_byok" : "byok",
                 projectId: hostedBody.projectId,
                 sourceType,
-                ...(chatboxToken && surface ? { surface } : {}),
+                ...(isChatboxSession && surface ? { surface } : {}),
+                chatboxId,
+                accessVersion,
                 chatboxToken,
                 authHeader: c.req.header("authorization"),
                 sessionMessages: fullHistory,
@@ -267,6 +285,8 @@ chatV2.post("/", async (c) => {
             temperature: resolvedTemperature,
             tools: allTools as ToolSet,
             authHeader: c.req.header("authorization"),
+            chatboxId,
+            accessVersion,
             chatboxToken,
             selectedServers: selectedServerIds,
             requireToolApproval,
@@ -290,6 +310,8 @@ chatV2.post("/", async (c) => {
           tools: allTools as ToolSet,
           authHeader: c.req.header("authorization"),
           clientIp: getClientIp(c),
+          chatboxId,
+          accessVersion,
           chatboxToken,
           mcpClientManager: manager,
           selectedServers: selectedServerIds,
@@ -315,12 +337,14 @@ chatV2.post("/", async (c) => {
         messages: modelMessages as ModelMessage[],
         modelId: String(modelDefinition.id),
         chatSessionId: hostedChatSessionId,
-        sourceType: chatboxToken ? "chatbox" : "direct",
+        sourceType: isChatboxSession ? "chatbox" : "direct",
         systemPrompt: enhancedSystemPrompt,
         temperature: resolvedTemperature,
         tools: allTools as ToolSet,
         authHeader: c.req.header("authorization"),
         clientIp: getClientIp(c),
+        chatboxId,
+        accessVersion,
         chatboxToken,
         projectId: hostedBody.projectId,
         mcpClientManager: manager,
@@ -328,14 +352,16 @@ chatV2.post("/", async (c) => {
         requireToolApproval,
         onConversationComplete: hostedChatSessionId
           ? async (fullHistory, turnTrace) => {
-              const isDirectChat = !chatboxToken;
+              const isDirectChat = !isChatboxSession;
               await persistChatSessionToConvex({
                 chatSessionId: hostedChatSessionId,
                 modelId: String(modelDefinition.id),
                 modelSource: "mcpjam",
                 projectId: hostedBody.projectId,
-                sourceType: chatboxToken ? "chatbox" : "direct",
-                ...(chatboxToken && surface ? { surface } : {}),
+                sourceType: isChatboxSession ? "chatbox" : "direct",
+                ...(isChatboxSession && surface ? { surface } : {}),
+                chatboxId,
+                accessVersion,
                 chatboxToken,
                 authHeader: c.req.header("authorization"),
                 sessionMessages: fullHistory,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -73,12 +73,12 @@ chatV2.post("/", async (c) => {
       projectId: string;
       selectedServerIds: string[];
       selectedServerNames?: string[];
-      // Post-refactor: clients pass `chatboxId` (+ optional accessVersion)
-      // after calling /web/chatbox/redeem. `chatboxToken` is accepted
-      // transitionally; the backend will redeem it server-side.
+      // Clients call /api/web/chatboxes/redeem on mount and pass the
+      // resolved `chatboxId` + `accessVersion` on every chatbox-aware
+      // request thereafter. The link token is never forwarded on the
+      // read path.
       chatboxId?: string;
       accessVersion?: number;
-      chatboxToken?: string;
       accessScope?: "project_member" | "chat_v2";
       surface?: "preview" | "share_link";
     };
@@ -93,14 +93,11 @@ chatV2.post("/", async (c) => {
       selectedServerNames,
       chatboxId,
       accessVersion,
-      chatboxToken,
       surface,
     } = body;
-    // True when this turn flows through a chatbox surface (either keyed by
-    // chatboxId for already-redeemed sessions or chatboxToken for legacy
-    // callers that haven't migrated). sourceType + accessScope decisions
-    // hinge on this.
-    const isChatboxSession = Boolean(chatboxId || chatboxToken);
+    // True when this turn flows through a chatbox surface. sourceType +
+    // accessScope decisions hinge on this.
+    const isChatboxSession = Boolean(chatboxId);
 
     if (!Array.isArray(messages) || messages.length === 0) {
       throw new WebRouteError(
@@ -135,7 +132,6 @@ chatV2.post("/", async (c) => {
         ...(isChatboxSession ? { accessScope: "chat_v2" } : {}),
         chatboxId,
         accessVersion,
-        chatboxToken,
         rpcLogger: rpcCollector.rpcLogger,
         serverNames: selectedServerNames,
       }
@@ -214,7 +210,6 @@ chatV2.post("/", async (c) => {
                 authHeader: c.req.header("authorization"),
                 chatboxId,
                 accessVersion,
-                chatboxToken,
                 serverIds: selectedServerIds,
               },
             )
@@ -233,7 +228,6 @@ chatV2.post("/", async (c) => {
                 ...(isChatboxSession && surface ? { surface } : {}),
                 chatboxId,
                 accessVersion,
-                chatboxToken,
                 authHeader: c.req.header("authorization"),
                 sessionMessages: fullHistory,
                 startedAt: sessionStartedAt,
@@ -287,7 +281,6 @@ chatV2.post("/", async (c) => {
             authHeader: c.req.header("authorization"),
             chatboxId,
             accessVersion,
-            chatboxToken,
             selectedServers: selectedServerIds,
             requireToolApproval,
             onConversationComplete,
@@ -312,7 +305,6 @@ chatV2.post("/", async (c) => {
           clientIp: getClientIp(c),
           chatboxId,
           accessVersion,
-          chatboxToken,
           mcpClientManager: manager,
           selectedServers: selectedServerIds,
           requireToolApproval,
@@ -345,7 +337,6 @@ chatV2.post("/", async (c) => {
         clientIp: getClientIp(c),
         chatboxId,
         accessVersion,
-        chatboxToken,
         projectId: hostedBody.projectId,
         mcpClientManager: manager,
         selectedServers: selectedServerIds,
@@ -362,7 +353,6 @@ chatV2.post("/", async (c) => {
                 ...(isChatboxSession && surface ? { surface } : {}),
                 chatboxId,
                 accessVersion,
-                chatboxToken,
                 authHeader: c.req.header("authorization"),
                 sessionMessages: fullHistory,
                 startedAt: sessionStartedAt,

--- a/mcpjam-inspector/server/routes/web/chatboxes.ts
+++ b/mcpjam-inspector/server/routes/web/chatboxes.ts
@@ -18,6 +18,11 @@ const chatboxes = new Hono();
 // subsequent calls do NOT need the token — every read-path route accepts
 // `chatboxId` directly.
 //
+// `bootstrap` is the same payload shape callers previously fetched from
+// `/chatbox/bootstrap` (projectId, hostStyle, modelId, systemPrompt,
+// servers, …). Inspector clients validate the whole shape before storing
+// the session — see `ChatboxBootstrapPayload` in `chatbox-session.ts`.
+//
 // Thin forward to the Convex /web/chatbox/redeem endpoint; the backend
 // handles rate limits, audit, and access-grant writes. The fetch/parse
 // logic lives in utils/chatbox-redeem.ts so non-route callers can reuse

--- a/mcpjam-inspector/server/routes/web/chatboxes.ts
+++ b/mcpjam-inspector/server/routes/web/chatboxes.ts
@@ -5,123 +5,41 @@ import {
   WebRouteError,
   assertBearerToken,
   handleRoute,
-  parseErrorMessage,
   parseWithSchema,
   readJsonBody,
 } from "./auth.js";
+import { redeemChatboxToken } from "../../utils/chatbox-redeem.js";
 
 const chatboxes = new Hono();
 
-const chatboxBootstrapSchema = z.object({
-  token: z.string().min(1),
-});
-
-chatboxes.post("/bootstrap", async (c) =>
-  handleRoute(c, async () => {
-    const convexUrl = process.env.CONVEX_HTTP_URL;
-    if (!convexUrl) {
-      throw new WebRouteError(
-        500,
-        ErrorCode.INTERNAL_ERROR,
-        "Server missing CONVEX_HTTP_URL configuration",
-      );
-    }
-
-    const bearerToken = assertBearerToken(c);
-    const body = parseWithSchema(
-      chatboxBootstrapSchema,
-      await readJsonBody<unknown>(c),
-    );
-
-    let response: Response;
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 10_000);
-    try {
-      response = await fetch(`${convexUrl}/chatbox/bootstrap`, {
-        method: "POST",
-        signal: controller.signal,
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${bearerToken}`,
-        },
-        body: JSON.stringify({ token: body.token }),
-      });
-    } catch (error) {
-      if (error instanceof Error && error.name === "AbortError") {
-        throw new WebRouteError(
-          504,
-          ErrorCode.SERVER_UNREACHABLE,
-          "Chatbox bootstrap service timed out",
-        );
-      }
-      throw new WebRouteError(
-        502,
-        ErrorCode.SERVER_UNREACHABLE,
-        `Failed to reach chatbox bootstrap service: ${parseErrorMessage(error)}`,
-      );
-    } finally {
-      clearTimeout(timeout);
-    }
-
-    const responseText = await response.text();
-    const trimmedResponseText = responseText.trim();
-    let payload: any = null;
-    try {
-      payload = trimmedResponseText ? JSON.parse(trimmedResponseText) : null;
-    } catch {
-      // ignored
-    }
-
-    if (!response.ok) {
-      let message =
-        typeof payload?.error === "string"
-          ? payload.error
-          : typeof payload?.message === "string"
-            ? payload.message
-            : trimmedResponseText ||
-              `Chatbox bootstrap failed (${response.status})`;
-      if (response.status === 404 && message === "No matching routes found") {
-        message =
-          "Configured Convex deployment does not expose /chatbox/bootstrap. Check CONVEX_HTTP_URL and VITE_CONVEX_URL.";
-      }
-      const code =
-        response.status === 401
-          ? ErrorCode.UNAUTHORIZED
-          : response.status === 403
-            ? ErrorCode.FORBIDDEN
-            : response.status === 404
-              ? ErrorCode.NOT_FOUND
-              : ErrorCode.INTERNAL_ERROR;
-      throw new WebRouteError(response.status, code, message);
-    }
-
-    if (!payload?.ok || !payload?.payload) {
-      throw new WebRouteError(
-        500,
-        ErrorCode.INTERNAL_ERROR,
-        "Chatbox bootstrap response was missing payload",
-      );
-    }
-
-    return payload.payload;
-  }),
-);
-
-// Phase E: token redemption. The landing page calls this on mount to
-// exchange its URL token for `{ chatboxId, role, mode, projectId,
-// accessVersion, bootstrap }`. Once the inspector stores `chatboxId` +
-// `accessVersion`, subsequent calls do NOT need the token.
+// Token redemption. The landing page calls this on mount to exchange its
+// URL token for `{ chatboxId, role, mode, projectId, accessVersion,
+// bootstrap }`. Once the inspector stores `chatboxId` + `accessVersion`,
+// subsequent calls do NOT need the token — every read-path route accepts
+// `chatboxId` directly.
 //
-// Implementation is a thin forward to the Convex /web/chatbox/redeem
-// endpoint — the backend handles rate limits, audit, and access grants.
+// Thin forward to the Convex /web/chatbox/redeem endpoint; the backend
+// handles rate limits, audit, and access-grant writes. The fetch/parse
+// logic lives in utils/chatbox-redeem.ts so non-route callers can reuse
+// it.
 const chatboxRedeemSchema = z.object({
   chatboxToken: z.string().min(1),
 });
 
+function mapRedeemStatusToErrorCode(status: number): ErrorCode {
+  if (status === 401) return ErrorCode.UNAUTHORIZED;
+  if (status === 403) return ErrorCode.FORBIDDEN;
+  if (status === 404) return ErrorCode.NOT_FOUND;
+  if (status === 429) return ErrorCode.RATE_LIMITED;
+  if (status === 502 || status === 503 || status === 504) {
+    return ErrorCode.SERVER_UNREACHABLE;
+  }
+  return ErrorCode.INTERNAL_ERROR;
+}
+
 chatboxes.post("/redeem", async (c) =>
   handleRoute(c, async () => {
-    const convexUrl = process.env.CONVEX_HTTP_URL;
-    if (!convexUrl) {
+    if (!process.env.CONVEX_HTTP_URL) {
       throw new WebRouteError(
         500,
         ErrorCode.INTERNAL_ERROR,
@@ -135,70 +53,34 @@ chatboxes.post("/redeem", async (c) =>
       await readJsonBody<unknown>(c),
     );
 
-    let response: Response;
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 10_000);
+    let result;
     try {
-      response = await fetch(`${convexUrl}/web/chatbox/redeem`, {
-        method: "POST",
+      result = await redeemChatboxToken({
+        chatboxToken: body.chatboxToken,
+        bearer: bearerToken,
         signal: controller.signal,
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${bearerToken}`,
-        },
-        body: JSON.stringify({ chatboxToken: body.chatboxToken }),
       });
-    } catch (error) {
-      if (error instanceof Error && error.name === "AbortError") {
-        throw new WebRouteError(
-          504,
-          ErrorCode.SERVER_UNREACHABLE,
-          "Chatbox redeem service timed out",
-        );
-      }
-      throw new WebRouteError(
-        502,
-        ErrorCode.SERVER_UNREACHABLE,
-        `Failed to reach chatbox redeem service: ${parseErrorMessage(error)}`,
-      );
     } finally {
       clearTimeout(timeout);
     }
 
-    const responseText = await response.text();
-    const trimmed = responseText.trim();
-    let payload: any = null;
-    try {
-      payload = trimmed ? JSON.parse(trimmed) : null;
-    } catch {
-      // ignored
-    }
-
-    if (!response.ok || payload?.ok !== true) {
-      const message =
-        typeof payload?.error === "string"
-          ? payload.error
-          : trimmed || `Chatbox redeem failed (${response.status})`;
-      const code =
-        response.status === 401
-          ? ErrorCode.UNAUTHORIZED
-          : response.status === 403
-            ? ErrorCode.FORBIDDEN
-            : response.status === 404
-              ? ErrorCode.NOT_FOUND
-              : response.status === 429
-                ? ErrorCode.UNAUTHORIZED
-                : ErrorCode.INTERNAL_ERROR;
-      throw new WebRouteError(response.status || 500, code, message);
+    if (!result.ok) {
+      throw new WebRouteError(
+        result.status || 500,
+        mapRedeemStatusToErrorCode(result.status),
+        result.error,
+      );
     }
 
     return {
-      chatboxId: payload.chatboxId,
-      role: payload.role,
-      mode: payload.mode,
-      projectId: payload.projectId ?? null,
-      accessVersion: payload.accessVersion,
-      bootstrap: payload.bootstrap,
+      chatboxId: result.chatboxId,
+      role: result.role,
+      mode: result.mode,
+      projectId: result.projectId,
+      accessVersion: result.accessVersion,
+      bootstrap: result.bootstrap,
     };
   }),
 );

--- a/mcpjam-inspector/server/routes/web/chatboxes.ts
+++ b/mcpjam-inspector/server/routes/web/chatboxes.ts
@@ -107,4 +107,100 @@ chatboxes.post("/bootstrap", async (c) =>
   }),
 );
 
+// Phase E: token redemption. The landing page calls this on mount to
+// exchange its URL token for `{ chatboxId, role, mode, projectId,
+// accessVersion, bootstrap }`. Once the inspector stores `chatboxId` +
+// `accessVersion`, subsequent calls do NOT need the token.
+//
+// Implementation is a thin forward to the Convex /web/chatbox/redeem
+// endpoint — the backend handles rate limits, audit, and access grants.
+const chatboxRedeemSchema = z.object({
+  chatboxToken: z.string().min(1),
+});
+
+chatboxes.post("/redeem", async (c) =>
+  handleRoute(c, async () => {
+    const convexUrl = process.env.CONVEX_HTTP_URL;
+    if (!convexUrl) {
+      throw new WebRouteError(
+        500,
+        ErrorCode.INTERNAL_ERROR,
+        "Server missing CONVEX_HTTP_URL configuration",
+      );
+    }
+
+    const bearerToken = assertBearerToken(c);
+    const body = parseWithSchema(
+      chatboxRedeemSchema,
+      await readJsonBody<unknown>(c),
+    );
+
+    let response: Response;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+    try {
+      response = await fetch(`${convexUrl}/web/chatbox/redeem`, {
+        method: "POST",
+        signal: controller.signal,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${bearerToken}`,
+        },
+        body: JSON.stringify({ chatboxToken: body.chatboxToken }),
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new WebRouteError(
+          504,
+          ErrorCode.SERVER_UNREACHABLE,
+          "Chatbox redeem service timed out",
+        );
+      }
+      throw new WebRouteError(
+        502,
+        ErrorCode.SERVER_UNREACHABLE,
+        `Failed to reach chatbox redeem service: ${parseErrorMessage(error)}`,
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    const responseText = await response.text();
+    const trimmed = responseText.trim();
+    let payload: any = null;
+    try {
+      payload = trimmed ? JSON.parse(trimmed) : null;
+    } catch {
+      // ignored
+    }
+
+    if (!response.ok || payload?.ok !== true) {
+      const message =
+        typeof payload?.error === "string"
+          ? payload.error
+          : trimmed || `Chatbox redeem failed (${response.status})`;
+      const code =
+        response.status === 401
+          ? ErrorCode.UNAUTHORIZED
+          : response.status === 403
+            ? ErrorCode.FORBIDDEN
+            : response.status === 404
+              ? ErrorCode.NOT_FOUND
+              : response.status === 429
+                ? ErrorCode.UNAUTHORIZED
+                : ErrorCode.INTERNAL_ERROR;
+      throw new WebRouteError(response.status || 500, code, message);
+    }
+
+    return {
+      chatboxId: payload.chatboxId,
+      role: payload.role,
+      mode: payload.mode,
+      projectId: payload.projectId ?? null,
+      accessVersion: payload.accessVersion,
+      bootstrap: payload.bootstrap,
+    };
+  }),
+);
+
 export default chatboxes;

--- a/mcpjam-inspector/server/routes/web/conformance.ts
+++ b/mcpjam-inspector/server/routes/web/conformance.ts
@@ -53,7 +53,8 @@ async function resolveHostedHttpConfig(
     {
       accessScope: wsBody.accessScope,
       workspaceId,
-      chatboxToken: wsBody.chatboxToken,
+      chatboxId: wsBody.chatboxId,
+      accessVersion: wsBody.accessVersion,
     }
   );
 
@@ -108,7 +109,8 @@ async function resolveHostedServerConfig(
     {
       accessScope: wsBody.accessScope,
       workspaceId,
-      chatboxToken: wsBody.chatboxToken,
+      chatboxId: wsBody.chatboxId,
+      accessVersion: wsBody.accessVersion,
     }
   );
 

--- a/mcpjam-inspector/server/routes/web/evals.ts
+++ b/mcpjam-inspector/server/routes/web/evals.ts
@@ -35,7 +35,8 @@ const hostedBatchSchema = z.object({
   clientCapabilities: z.record(z.string(), z.unknown()).optional(),
   oauthTokens: z.record(z.string(), z.string()).optional(),
   accessScope: z.enum(["project_member", "chat_v2"]).optional(),
-  chatboxToken: z.string().min(1).optional(),
+  chatboxId: z.string().min(1).optional(),
+  accessVersion: z.number().int().nonnegative().optional(),
 });
 
 const hostedRunEvalsSchema = RunEvalsRequestSchema.omit({
@@ -146,7 +147,8 @@ evals.post("/stream-test-case", async (c) => {
         | "project_member"
         | "chat_v2"
         | undefined,
-      chatboxToken: body.chatboxToken as string | undefined,
+      chatboxId: body.chatboxId as string | undefined,
+      accessVersion: body.accessVersion as number | undefined,
       serverNames: body.serverNames,
     },
   );

--- a/mcpjam-inspector/server/routes/web/servers.ts
+++ b/mcpjam-inspector/server/routes/web/servers.ts
@@ -52,7 +52,8 @@ servers.post("/check-oauth", async (c) =>
           typeof (body as { workspaceId?: unknown }).workspaceId === "string"
             ? (body as unknown as { workspaceId: string }).workspaceId
             : undefined,
-        chatboxToken: body.chatboxToken,
+        chatboxId: body.chatboxId,
+        accessVersion: body.accessVersion,
       }
     );
     return {
@@ -111,7 +112,8 @@ async function runHostedDoctor(
         typeof (body as { workspaceId?: unknown }).workspaceId === "string"
           ? (body as unknown as { workspaceId: string }).workspaceId
           : undefined,
-      chatboxToken: body.chatboxToken,
+      chatboxId: body.chatboxId,
+      accessVersion: body.accessVersion,
     }
   );
 

--- a/mcpjam-inspector/server/utils/__tests__/chat-ingestion.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-ingestion.test.ts
@@ -65,7 +65,8 @@ describe("chat-ingestion", () => {
       modelId: "openai/gpt-oss-120b",
       modelSource: "mcpjam",
       authHeader: "Bearer bearer-token",
-      chatboxToken: "chatbox-token",
+      chatboxId: "cbx_test",
+      accessVersion: 1,
       sourceType: "chatbox",
       surface: "share_link",
       sessionMessages: [

--- a/mcpjam-inspector/server/utils/__tests__/hosted-oauth-refresh.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/hosted-oauth-refresh.test.ts
@@ -57,7 +57,8 @@ describe("forceRefreshHostedOAuthAccessToken", () => {
         workspaceId: "ws-1",
         serverId: "server-1",
         accessScope: "chat_v2",
-        chatboxToken: "chat-tok",
+        chatboxId: "cbx_1",
+        accessVersion: 3,
       });
       return new Response(
         JSON.stringify({ accessToken: "fresh-token" }),
@@ -74,7 +75,8 @@ describe("forceRefreshHostedOAuthAccessToken", () => {
         {
           accessScope: "chat_v2",
           workspaceId: "ws-1",
-          chatboxToken: "chat-tok",
+          chatboxId: "cbx_1",
+          accessVersion: 3,
         }
       )
     ).resolves.toBe("fresh-token");

--- a/mcpjam-inspector/server/utils/__tests__/org-model-config.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/org-model-config.test.ts
@@ -51,7 +51,8 @@ describe("resolveOrgModelConfig", () => {
       { projectId: "project_org_config_auth_scope" },
       {
         bearerToken: "user-a",
-        chatboxToken: " share-1 ",
+        chatboxId: " cbx_1 ",
+        accessVersion: 2,
         serverIds: ["srv-b", "srv-a", "srv-a"],
       },
     );
@@ -59,7 +60,8 @@ describe("resolveOrgModelConfig", () => {
       { projectId: "project_org_config_auth_scope" },
       {
         bearerToken: "user-a",
-        chatboxToken: "share-1",
+        chatboxId: "cbx_1",
+        accessVersion: 2,
         serverIds: ["srv-a", "srv-b"],
       },
     );
@@ -67,7 +69,8 @@ describe("resolveOrgModelConfig", () => {
       { projectId: "project_org_config_auth_scope" },
       {
         bearerToken: "user-b",
-        chatboxToken: "share-1",
+        chatboxId: "cbx_1",
+        accessVersion: 2,
         serverIds: ["srv-a", "srv-b"],
       },
     );
@@ -86,7 +89,8 @@ describe("resolveOrgModelConfig", () => {
     ).toBe("service-token");
     expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
       projectId: "project_org_config_auth_scope",
-      chatboxToken: "share-1",
+      chatboxId: "cbx_1",
+      accessVersion: 2,
       serverIds: ["srv-a", "srv-b"],
     });
     expect(

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -136,10 +136,8 @@ interface PersistChatSessionOptions {
   sourceType?: "chatbox" | "direct";
   directVisibility?: "private" | "project";
   surface?: "preview" | "share_link";
-  // Post-refactor: prefer chatboxId. chatboxToken kept for transitional callers.
   chatboxId?: string;
   accessVersion?: number;
-  chatboxToken?: string;
   serverId?: string;
   visitorDisplayName?: string;
   sessionMessages?: unknown[];
@@ -229,11 +227,8 @@ export async function persistChatSessionToConvex(
           : {}),
         ...(options.surface ? { surface: options.surface } : {}),
         ...(options.chatboxId ? { chatboxId: options.chatboxId } : {}),
-        ...(typeof options.accessVersion === "number"
+        ...(options.chatboxId && Number.isFinite(options.accessVersion)
           ? { accessVersion: options.accessVersion }
-          : {}),
-        ...(options.chatboxToken && !options.chatboxId
-          ? { chatboxToken: options.chatboxToken }
           : {}),
         ...(options.serverId ? { serverId: options.serverId } : {}),
         ...(options.visitorDisplayName

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -136,6 +136,9 @@ interface PersistChatSessionOptions {
   sourceType?: "chatbox" | "direct";
   directVisibility?: "private" | "project";
   surface?: "preview" | "share_link";
+  // Post-refactor: prefer chatboxId. chatboxToken kept for transitional callers.
+  chatboxId?: string;
+  accessVersion?: number;
   chatboxToken?: string;
   serverId?: string;
   visitorDisplayName?: string;
@@ -225,7 +228,13 @@ export async function persistChatSessionToConvex(
           ? { directVisibility: options.directVisibility }
           : {}),
         ...(options.surface ? { surface: options.surface } : {}),
-        ...(options.chatboxToken ? { chatboxToken: options.chatboxToken } : {}),
+        ...(options.chatboxId ? { chatboxId: options.chatboxId } : {}),
+        ...(typeof options.accessVersion === "number"
+          ? { accessVersion: options.accessVersion }
+          : {}),
+        ...(options.chatboxToken && !options.chatboxId
+          ? { chatboxToken: options.chatboxToken }
+          : {}),
         ...(options.serverId ? { serverId: options.serverId } : {}),
         ...(options.visitorDisplayName
           ? { visitorDisplayName: options.visitorDisplayName }

--- a/mcpjam-inspector/server/utils/chatbox-redeem.ts
+++ b/mcpjam-inspector/server/utils/chatbox-redeem.ts
@@ -1,39 +1,15 @@
 /**
- * Chatbox token redemption (Phase E scaffolding).
+ * Chatbox token redemption.
  *
  * Calls `/web/chatbox/redeem` on the Convex HTTP layer to exchange a
  * chatbox link token for a `chatboxId` + `chatboxAccess` grant. Once
  * redeemed, the inspector forwards the `chatboxId` (NOT the token) on
  * every subsequent hot-path request.
  *
- * Usage from a route handler:
- *
- *   const result = await redeemChatboxToken({
- *     chatboxToken,
- *     bearer: req.headers.get("authorization") ?? "",
- *   });
- *   if (!result.ok) return c.json({ error: result.error }, result.status);
- *   // result.chatboxId, result.role, result.mode, result.projectId,
- *   // result.accessVersion, result.bootstrap
- *
  * The bearer is required: WorkOS bearer for signed-in viewers, or a
  * guest JWT obtained via `/guest/session` for anonymous viewers in
  * `anyone_with_link` mode. Anonymous redemption is rejected by the
  * backend with 401.
- *
- * TODO(chatbox-followup): wire this into:
- *   - server/routes/web/chat-v2.ts (replace `chatboxToken` plumbing
- *     with `chatboxId`; redeem first if frontend has only a token)
- *   - server/routes/web/auth.ts `fetchAuthorizeBatch` /
- *     `createAuthorizedManager` (drop `chatboxToken` arg)
- *   - server/routes/mcp/chat-v2.ts (owner-preview parity)
- *   - server/utils/hosted-oauth-refresh.ts (`forceRefreshHostedOAuthAccessToken`,
- *     `buildHostedOAuthUnauthorizedHandler` re-keyed by `chatboxId`)
- *   - server/utils/org-model-config.ts (cache key:
- *     `(chatboxId, projectId, userId, serverIds, accessVersion)`)
- *   - client/src/lib/chatbox-session.ts and the chatbox-link landing
- *     page (call this helper on mount, store
- *     `{ chatboxId, accessVersion, bootstrap }` in session state).
  */
 
 import { logger } from "./logger.js";
@@ -125,12 +101,15 @@ export async function redeemChatboxToken(args: {
   } catch {
     return {
       ok: false,
-      status: response.status,
+      // If the upstream returned 2xx but no parseable JSON, that's an
+      // upstream contract violation — surface it as 502 so callers don't
+      // treat the missing body as success.
+      status: response.ok ? 502 : response.status,
       error: `Chatbox redeem returned ${response.status} with non-JSON body`,
     };
   }
 
-  if (!response.ok || payload?.ok !== true) {
+  if (!response.ok) {
     return {
       ok: false,
       status: response.status,
@@ -138,6 +117,19 @@ export async function redeemChatboxToken(args: {
         typeof payload?.error === "string"
           ? payload.error
           : `Chatbox redeem failed (${response.status})`,
+    };
+  }
+
+  if (payload?.ok !== true) {
+    // 2xx with `ok: false` (or missing) is also an upstream contract
+    // violation — coerce to 502 so callers don't bubble a misleading 200.
+    return {
+      ok: false,
+      status: 502,
+      error:
+        typeof payload?.error === "string"
+          ? payload.error
+          : "Chatbox redeem response was missing ok=true",
     };
   }
 

--- a/mcpjam-inspector/server/utils/chatbox-redeem.ts
+++ b/mcpjam-inspector/server/utils/chatbox-redeem.ts
@@ -1,0 +1,153 @@
+/**
+ * Chatbox token redemption (Phase E scaffolding).
+ *
+ * Calls `/web/chatbox/redeem` on the Convex HTTP layer to exchange a
+ * chatbox link token for a `chatboxId` + `chatboxAccess` grant. Once
+ * redeemed, the inspector forwards the `chatboxId` (NOT the token) on
+ * every subsequent hot-path request.
+ *
+ * Usage from a route handler:
+ *
+ *   const result = await redeemChatboxToken({
+ *     chatboxToken,
+ *     bearer: req.headers.get("authorization") ?? "",
+ *   });
+ *   if (!result.ok) return c.json({ error: result.error }, result.status);
+ *   // result.chatboxId, result.role, result.mode, result.projectId,
+ *   // result.accessVersion, result.bootstrap
+ *
+ * The bearer is required: WorkOS bearer for signed-in viewers, or a
+ * guest JWT obtained via `/guest/session` for anonymous viewers in
+ * `anyone_with_link` mode. Anonymous redemption is rejected by the
+ * backend with 401.
+ *
+ * TODO(chatbox-followup): wire this into:
+ *   - server/routes/web/chat-v2.ts (replace `chatboxToken` plumbing
+ *     with `chatboxId`; redeem first if frontend has only a token)
+ *   - server/routes/web/auth.ts `fetchAuthorizeBatch` /
+ *     `createAuthorizedManager` (drop `chatboxToken` arg)
+ *   - server/routes/mcp/chat-v2.ts (owner-preview parity)
+ *   - server/utils/hosted-oauth-refresh.ts (`forceRefreshHostedOAuthAccessToken`,
+ *     `buildHostedOAuthUnauthorizedHandler` re-keyed by `chatboxId`)
+ *   - server/utils/org-model-config.ts (cache key:
+ *     `(chatboxId, projectId, userId, serverIds, accessVersion)`)
+ *   - client/src/lib/chatbox-session.ts and the chatbox-link landing
+ *     page (call this helper on mount, store
+ *     `{ chatboxId, accessVersion, bootstrap }` in session state).
+ */
+
+import { logger } from "./logger.js";
+
+export type ChatboxRedeemBootstrapServer = {
+  serverId: string;
+  serverName: string;
+  useOAuth: boolean;
+  serverUrl: string | null;
+  clientId: string | null;
+};
+
+export type ChatboxRedeemBootstrap = {
+  chatboxId: string;
+  name: string;
+  description: string | null;
+  mode: "project_members" | "invited_only" | "anyone_with_link";
+  welcomeDialog: unknown | null;
+  feedbackDialog: unknown | null;
+  servers: ChatboxRedeemBootstrapServer[];
+};
+
+export type ChatboxRedeemSuccess = {
+  ok: true;
+  chatboxId: string;
+  role: "chat" | "admin";
+  mode: "project_members" | "invited_only" | "anyone_with_link";
+  projectId: string | null;
+  accessVersion: number;
+  bootstrap: ChatboxRedeemBootstrap;
+};
+
+export type ChatboxRedeemFailure = {
+  ok: false;
+  status: number;
+  error: string;
+};
+
+export type ChatboxRedeemResult = ChatboxRedeemSuccess | ChatboxRedeemFailure;
+
+function getConvexHttpUrl(): string {
+  const convexHttpUrl = process.env.CONVEX_HTTP_URL;
+  if (!convexHttpUrl) {
+    throw new Error("CONVEX_HTTP_URL is required for chatbox redeem");
+  }
+  return convexHttpUrl;
+}
+
+function buildRedeemUrl(): string {
+  return (
+    process.env.MCPJAM_CHATBOX_REDEEM_URL ||
+    new URL("/web/chatbox/redeem", getConvexHttpUrl()).toString()
+  );
+}
+
+export async function redeemChatboxToken(args: {
+  chatboxToken: string;
+  bearer: string;
+  signal?: AbortSignal;
+}): Promise<ChatboxRedeemResult> {
+  const url = buildRedeemUrl();
+  const authorization = args.bearer.startsWith("Bearer ")
+    ? args.bearer
+    : `Bearer ${args.bearer}`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization,
+      },
+      body: JSON.stringify({ chatboxToken: args.chatboxToken }),
+      signal: args.signal,
+    });
+  } catch (err) {
+    logger.error("[chatbox-redeem] network error", err);
+    return {
+      ok: false,
+      status: 502,
+      error: "Failed to reach chatbox redeem endpoint",
+    };
+  }
+
+  let payload: any = null;
+  try {
+    payload = await response.json();
+  } catch {
+    return {
+      ok: false,
+      status: response.status,
+      error: `Chatbox redeem returned ${response.status} with non-JSON body`,
+    };
+  }
+
+  if (!response.ok || payload?.ok !== true) {
+    return {
+      ok: false,
+      status: response.status,
+      error:
+        typeof payload?.error === "string"
+          ? payload.error
+          : `Chatbox redeem failed (${response.status})`,
+    };
+  }
+
+  return {
+    ok: true,
+    chatboxId: payload.chatboxId,
+    role: payload.role,
+    mode: payload.mode,
+    projectId: payload.projectId ?? null,
+    accessVersion: payload.accessVersion,
+    bootstrap: payload.bootstrap,
+  };
+}

--- a/mcpjam-inspector/server/utils/chatbox-redeem.ts
+++ b/mcpjam-inspector/server/utils/chatbox-redeem.ts
@@ -20,13 +20,29 @@ export type ChatboxRedeemBootstrapServer = {
   useOAuth: boolean;
   serverUrl: string | null;
   clientId: string | null;
+  oauthScopes: string[] | null;
+  optional: boolean;
 };
 
+/**
+ * Full bootstrap payload returned by `/web/chatbox/redeem`. Mirrors the
+ * shape inspector clients previously fetched from `/chatbox/bootstrap`,
+ * so the landing page can validate this directly against
+ * `ChatboxBootstrapPayload` before persisting the session.
+ */
 export type ChatboxRedeemBootstrap = {
+  projectId: string | null;
   chatboxId: string;
   name: string;
   description: string | null;
+  hostStyle: "claude" | "chatgpt" | string;
   mode: "project_members" | "invited_only" | "anyone_with_link";
+  allowGuestAccess: boolean;
+  viewerIsProjectMember: boolean;
+  systemPrompt: string;
+  modelId: string;
+  temperature: number;
+  requireToolApproval: boolean;
   welcomeDialog: unknown | null;
   feedbackDialog: unknown | null;
   servers: ChatboxRedeemBootstrapServer[];

--- a/mcpjam-inspector/server/utils/hosted-oauth-refresh.ts
+++ b/mcpjam-inspector/server/utils/hosted-oauth-refresh.ts
@@ -10,15 +10,12 @@ export type HostedOAuthRefreshOptions = {
   workspaceId?: string;
   shareToken?: string;
   /**
-   * Post-refactor preferred path: pass the resolved `chatboxId` (and
-   * `accessVersion`) so the backend can scope OAuth credentials by
-   * `(userId, chatbox.projectId, serverId)` without needing to re-redeem
-   * the token on a refresh. Falls back to `chatboxToken` for transitional
-   * callers.
+   * Resolved chatbox identity (post-redeem). The backend scopes OAuth
+   * credentials by `(userId, chatbox.projectId, serverId)` from this; no
+   * link token is forwarded on refresh.
    */
   chatboxId?: string;
   accessVersion?: number;
-  chatboxToken?: string;
   serverName?: string;
 };
 
@@ -63,11 +60,8 @@ export async function forceRefreshHostedOAuthAccessToken(
         ...(options?.accessScope ? { accessScope: options.accessScope } : {}),
         ...(options?.shareToken ? { shareToken: options.shareToken } : {}),
         ...(options?.chatboxId ? { chatboxId: options.chatboxId } : {}),
-        ...(typeof options?.accessVersion === "number"
+        ...(options?.chatboxId && Number.isFinite(options?.accessVersion)
           ? { accessVersion: options.accessVersion }
-          : {}),
-        ...(options?.chatboxToken && !options?.chatboxId
-          ? { chatboxToken: options.chatboxToken }
           : {}),
       }),
     });
@@ -132,7 +126,6 @@ export type HostedOAuthUnauthorizedHandlerArgs = {
   shareToken?: string;
   chatboxId?: string;
   accessVersion?: number;
-  chatboxToken?: string;
 };
 
 /**
@@ -155,7 +148,6 @@ export function buildHostedOAuthUnauthorizedHandler(
         shareToken: args.shareToken,
         chatboxId: args.chatboxId,
         accessVersion: args.accessVersion,
-        chatboxToken: args.chatboxToken,
         serverName: args.serverName,
       }
     ),

--- a/mcpjam-inspector/server/utils/hosted-oauth-refresh.ts
+++ b/mcpjam-inspector/server/utils/hosted-oauth-refresh.ts
@@ -9,6 +9,15 @@ export type HostedOAuthRefreshOptions = {
   accessScope?: "project_member" | "chat_v2";
   workspaceId?: string;
   shareToken?: string;
+  /**
+   * Post-refactor preferred path: pass the resolved `chatboxId` (and
+   * `accessVersion`) so the backend can scope OAuth credentials by
+   * `(userId, chatbox.projectId, serverId)` without needing to re-redeem
+   * the token on a refresh. Falls back to `chatboxToken` for transitional
+   * callers.
+   */
+  chatboxId?: string;
+  accessVersion?: number;
   chatboxToken?: string;
   serverName?: string;
 };
@@ -53,7 +62,11 @@ export async function forceRefreshHostedOAuthAccessToken(
         serverId,
         ...(options?.accessScope ? { accessScope: options.accessScope } : {}),
         ...(options?.shareToken ? { shareToken: options.shareToken } : {}),
-        ...(options?.chatboxToken
+        ...(options?.chatboxId ? { chatboxId: options.chatboxId } : {}),
+        ...(typeof options?.accessVersion === "number"
+          ? { accessVersion: options.accessVersion }
+          : {}),
+        ...(options?.chatboxToken && !options?.chatboxId
           ? { chatboxToken: options.chatboxToken }
           : {}),
       }),
@@ -117,6 +130,8 @@ export type HostedOAuthUnauthorizedHandlerArgs = {
   accessScope?: "project_member" | "chat_v2";
   workspaceId?: string;
   shareToken?: string;
+  chatboxId?: string;
+  accessVersion?: number;
   chatboxToken?: string;
 };
 
@@ -138,6 +153,8 @@ export function buildHostedOAuthUnauthorizedHandler(
         accessScope: args.accessScope,
         workspaceId: args.workspaceId,
         shareToken: args.shareToken,
+        chatboxId: args.chatboxId,
+        accessVersion: args.accessVersion,
         chatboxToken: args.chatboxToken,
         serverName: args.serverName,
       }

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -82,7 +82,6 @@ export interface MCPJamHandlerOptions {
   authHeader?: string;
   chatboxId?: string;
   accessVersion?: number;
-  chatboxToken?: string;
   projectId?: string;
   chatSessionId?: string;
   sourceType?: string;
@@ -134,7 +133,6 @@ interface StepContext {
   authHeader?: string;
   chatboxId?: string;
   accessVersion?: number;
-  chatboxToken?: string;
   projectId?: string;
   chatSessionId?: string;
   sourceType?: string;
@@ -922,7 +920,6 @@ async function processOneStep(
     authHeader,
     chatboxId,
     accessVersion,
-    chatboxToken,
     projectId,
     modelId,
     systemPrompt,
@@ -998,8 +995,9 @@ async function processOneStep(
       ...(temperature !== undefined ? { temperature } : {}),
       tools: toolDefs,
       ...(chatboxId ? { chatboxId } : {}),
-      ...(typeof accessVersion === "number" ? { accessVersion } : {}),
-      ...(chatboxToken && !chatboxId ? { chatboxToken } : {}),
+      ...(chatboxId && Number.isFinite(accessVersion)
+        ? { accessVersion }
+        : {}),
       ...(projectId ? { projectId } : {}),
       ...(chatSessionId ? { chatSessionId } : {}),
       ...(sourceType ? { sourceType } : {}),
@@ -1313,7 +1311,6 @@ export async function handleMCPJamFreeChatModel(
     authHeader,
     chatboxId,
     accessVersion,
-    chatboxToken,
     projectId,
     mcpClientManager,
     selectedServers,
@@ -1387,7 +1384,6 @@ export async function handleMCPJamFreeChatModel(
             authHeader,
             chatboxId,
             accessVersion,
-            chatboxToken,
             projectId,
             chatSessionId,
             sourceType,

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -80,6 +80,8 @@ export interface MCPJamHandlerOptions {
   temperature?: number;
   tools: ToolSet;
   authHeader?: string;
+  chatboxId?: string;
+  accessVersion?: number;
   chatboxToken?: string;
   projectId?: string;
   chatSessionId?: string;
@@ -130,6 +132,8 @@ interface StepContext {
   toolDefs: ToolDefinition[];
   tools: ToolSet;
   authHeader?: string;
+  chatboxId?: string;
+  accessVersion?: number;
   chatboxToken?: string;
   projectId?: string;
   chatSessionId?: string;
@@ -916,6 +920,8 @@ async function processOneStep(
     toolDefs,
     tools,
     authHeader,
+    chatboxId,
+    accessVersion,
     chatboxToken,
     projectId,
     modelId,
@@ -991,7 +997,9 @@ async function processOneStep(
       systemPrompt,
       ...(temperature !== undefined ? { temperature } : {}),
       tools: toolDefs,
-      ...(chatboxToken ? { chatboxToken } : {}),
+      ...(chatboxId ? { chatboxId } : {}),
+      ...(typeof accessVersion === "number" ? { accessVersion } : {}),
+      ...(chatboxToken && !chatboxId ? { chatboxToken } : {}),
       ...(projectId ? { projectId } : {}),
       ...(chatSessionId ? { chatSessionId } : {}),
       ...(sourceType ? { sourceType } : {}),
@@ -1303,6 +1311,8 @@ export async function handleMCPJamFreeChatModel(
     temperature,
     tools,
     authHeader,
+    chatboxId,
+    accessVersion,
     chatboxToken,
     projectId,
     mcpClientManager,
@@ -1375,6 +1385,8 @@ export async function handleMCPJamFreeChatModel(
             toolDefs,
             tools,
             authHeader,
+            chatboxId,
+            accessVersion,
             chatboxToken,
             projectId,
             chatSessionId,

--- a/mcpjam-inspector/server/utils/org-model-config.ts
+++ b/mcpjam-inspector/server/utils/org-model-config.ts
@@ -31,6 +31,15 @@ export type ResolveOrgModelConfigTarget =
 export type ResolveOrgModelConfigAuth = {
   authHeader?: string;
   bearerToken?: string;
+  /**
+   * Post-refactor: chatbox identity is `chatboxId` + `accessVersion`. The
+   * cache key hashes these (not the token) so a token rotation does NOT
+   * invalidate model-config cache entries, while an `accessVersion` bump
+   * (mode change, revoke, allowlist edit) DOES. `chatboxToken` remains
+   * accepted transitionally; if both are present, `chatboxId` wins.
+   */
+  chatboxId?: string;
+  accessVersion?: number;
   chatboxToken?: string;
   serverIds?: string[];
 };
@@ -101,11 +110,20 @@ function buildCacheKey(
     : "workspaceId" in params
     ? `legacy-workspace:${params.workspaceId}`
     : `org:${params.organizationId}`;
+  // Cache key prefers (chatboxId, accessVersion) over the token. This keeps
+  // entries stable across token rotations and invalidates whenever the
+  // backend bumps accessVersion (mode change, revoke, allowlist edit).
   const authHash = createHash("sha256")
     .update(
       JSON.stringify({
         authorization: normalizeAuthHeader(auth) ?? "",
-        chatboxToken: auth?.chatboxToken?.trim() ?? "",
+        chatboxId: auth?.chatboxId?.trim() ?? "",
+        accessVersion:
+          typeof auth?.accessVersion === "number" ? auth.accessVersion : null,
+        chatboxToken:
+          auth?.chatboxId && auth.chatboxId.trim()
+            ? ""
+            : auth?.chatboxToken?.trim() ?? "",
         serverIds: normalizeServerIds(auth?.serverIds),
       }),
     )
@@ -467,7 +485,13 @@ function buildRuntimeCacheKey(
     .update(
       JSON.stringify({
         authorization: normalizeAuthHeader(auth) ?? "",
-        chatboxToken: auth?.chatboxToken?.trim() ?? "",
+        chatboxId: auth?.chatboxId?.trim() ?? "",
+        accessVersion:
+          typeof auth?.accessVersion === "number" ? auth.accessVersion : null,
+        chatboxToken:
+          auth?.chatboxId && auth.chatboxId.trim()
+            ? ""
+            : auth?.chatboxToken?.trim() ?? "",
         serverIds: normalizeServerIds(auth?.serverIds),
       }),
     )
@@ -526,7 +550,15 @@ export async function resolveOrgProviderRuntime(
         projectId,
         providerKey,
         model,
-        ...(auth?.chatboxToken?.trim() ? { chatboxToken: auth.chatboxToken.trim() } : {}),
+        ...(auth?.chatboxId?.trim()
+          ? { chatboxId: auth.chatboxId.trim() }
+          : {}),
+        ...(typeof auth?.accessVersion === "number"
+          ? { accessVersion: auth.accessVersion }
+          : {}),
+        ...(auth?.chatboxToken?.trim() && !auth?.chatboxId?.trim()
+          ? { chatboxToken: auth.chatboxToken.trim() }
+          : {}),
         ...(serverIds.length > 0 ? { serverIds } : {}),
       }),
       signal: controller.signal,

--- a/mcpjam-inspector/server/utils/org-model-config.ts
+++ b/mcpjam-inspector/server/utils/org-model-config.ts
@@ -32,15 +32,13 @@ export type ResolveOrgModelConfigAuth = {
   authHeader?: string;
   bearerToken?: string;
   /**
-   * Post-refactor: chatbox identity is `chatboxId` + `accessVersion`. The
-   * cache key hashes these (not the token) so a token rotation does NOT
-   * invalidate model-config cache entries, while an `accessVersion` bump
-   * (mode change, revoke, allowlist edit) DOES. `chatboxToken` remains
-   * accepted transitionally; if both are present, `chatboxId` wins.
+   * Chatbox identity is `chatboxId` + `accessVersion`. The cache key hashes
+   * these so a link-token rotation does not invalidate model-config cache
+   * entries, while an `accessVersion` bump (mode change, revoke, allowlist
+   * edit) does.
    */
   chatboxId?: string;
   accessVersion?: number;
-  chatboxToken?: string;
   serverIds?: string[];
 };
 
@@ -110,20 +108,19 @@ function buildCacheKey(
     : "workspaceId" in params
     ? `legacy-workspace:${params.workspaceId}`
     : `org:${params.organizationId}`;
-  // Cache key prefers (chatboxId, accessVersion) over the token. This keeps
-  // entries stable across token rotations and invalidates whenever the
-  // backend bumps accessVersion (mode change, revoke, allowlist edit).
+  // Cache key hashes (chatboxId, accessVersion) so a link-token rotation
+  // doesn't invalidate cache entries while an accessVersion bump (mode
+  // change, revoke, allowlist edit) does.
   const authHash = createHash("sha256")
     .update(
       JSON.stringify({
         authorization: normalizeAuthHeader(auth) ?? "",
         chatboxId: auth?.chatboxId?.trim() ?? "",
         accessVersion:
-          typeof auth?.accessVersion === "number" ? auth.accessVersion : null,
-        chatboxToken:
-          auth?.chatboxId && auth.chatboxId.trim()
-            ? ""
-            : auth?.chatboxToken?.trim() ?? "",
+          auth?.chatboxId && auth.chatboxId.trim() &&
+          Number.isFinite(auth?.accessVersion)
+            ? auth.accessVersion
+            : null,
         serverIds: normalizeServerIds(auth?.serverIds),
       }),
     )
@@ -167,8 +164,11 @@ export async function resolveOrgModelConfig(
       },
       body: JSON.stringify({
         ...params,
-        ...(auth?.chatboxToken?.trim()
-          ? { chatboxToken: auth.chatboxToken.trim() }
+        ...(auth?.chatboxId?.trim()
+          ? { chatboxId: auth.chatboxId.trim() }
+          : {}),
+        ...(auth?.chatboxId?.trim() && Number.isFinite(auth?.accessVersion)
+          ? { accessVersion: auth.accessVersion }
           : {}),
         ...(serverIds.length > 0 ? { serverIds } : {}),
       }),
@@ -487,11 +487,10 @@ function buildRuntimeCacheKey(
         authorization: normalizeAuthHeader(auth) ?? "",
         chatboxId: auth?.chatboxId?.trim() ?? "",
         accessVersion:
-          typeof auth?.accessVersion === "number" ? auth.accessVersion : null,
-        chatboxToken:
-          auth?.chatboxId && auth.chatboxId.trim()
-            ? ""
-            : auth?.chatboxToken?.trim() ?? "",
+          auth?.chatboxId && auth.chatboxId.trim() &&
+          Number.isFinite(auth?.accessVersion)
+            ? auth.accessVersion
+            : null,
         serverIds: normalizeServerIds(auth?.serverIds),
       }),
     )
@@ -553,11 +552,8 @@ export async function resolveOrgProviderRuntime(
         ...(auth?.chatboxId?.trim()
           ? { chatboxId: auth.chatboxId.trim() }
           : {}),
-        ...(typeof auth?.accessVersion === "number"
+        ...(auth?.chatboxId?.trim() && Number.isFinite(auth?.accessVersion)
           ? { accessVersion: auth.accessVersion }
-          : {}),
-        ...(auth?.chatboxToken?.trim() && !auth?.chatboxId?.trim()
-          ? { chatboxToken: auth.chatboxToken.trim() }
           : {}),
         ...(serverIds.length > 0 ? { serverIds } : {}),
       }),

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -89,17 +89,11 @@ export interface OrgModelHandlerOptions {
    */
   authHeader?: string;
   /**
-   * Hosted chatbox token for guest chat sessions. Forwarded to /stream/org
-   * so Convex can authorize the guest against the project via the existing
-   * authorizeGuestServerAccessBatch query.
-   *
-   * Post-refactor: prefer `chatboxId` (+ optional `accessVersion`); the
-   * backend will redeem `chatboxToken` server-side for transitional callers
-   * that still pass the token.
+   * Resolved chatbox identity (post-redeem). Forwarded to /stream/org so
+   * Convex can authorize the actor against the chatbox + project.
    */
   chatboxId?: string;
   accessVersion?: number;
-  chatboxToken?: string;
   clientIp?: string | null;
 }
 
@@ -190,7 +184,6 @@ export interface OrgLocalModelHandlerOptions {
   authHeader?: string;
   chatboxId?: string;
   accessVersion?: number;
-  chatboxToken?: string;
   onConversationComplete?: (
     fullHistory: ModelMessage[],
     turnTrace: PersistedTurnTrace
@@ -219,7 +212,6 @@ export function handleLocalOrgChatModel(
     authHeader,
     chatboxId,
     accessVersion,
-    chatboxToken,
     onConversationComplete,
     onStreamComplete,
     onStreamWriterReady,
@@ -476,7 +468,6 @@ export function handleLocalOrgChatModel(
             authHeader,
             chatboxId,
             accessVersion,
-            chatboxToken,
             selectedServers: options.selectedServers,
           }).catch((err) => {
             logger.warn("[org/local] Failed to post local usage", {
@@ -539,7 +530,6 @@ async function postLocalUsage(params: {
   authHeader?: string;
   chatboxId?: string;
   accessVersion?: number;
-  chatboxToken?: string;
   selectedServers?: string[];
 }): Promise<void> {
   const convexHttpUrl = process.env.CONVEX_HTTP_URL;
@@ -571,11 +561,8 @@ async function postLocalUsage(params: {
           ? { promptIndex: params.promptIndex }
           : {}),
         ...(params.chatboxId ? { chatboxId: params.chatboxId } : {}),
-        ...(typeof params.accessVersion === "number"
+        ...(params.chatboxId && Number.isFinite(params.accessVersion)
           ? { accessVersion: params.accessVersion }
-          : {}),
-        ...(params.chatboxToken && !params.chatboxId
-          ? { chatboxToken: params.chatboxToken }
           : {}),
         ...(params.selectedServers && params.selectedServers.length > 0
           ? { serverIds: params.selectedServers }
@@ -622,7 +609,6 @@ export async function handleHostedOrgChatModel(
     authHeader: options.authHeader,
     chatboxId: options.chatboxId,
     accessVersion: options.accessVersion,
-    chatboxToken: options.chatboxToken,
     mcpClientManager: options.mcpClientManager,
     selectedServers: options.selectedServers,
     requireToolApproval: options.requireToolApproval,
@@ -637,7 +623,8 @@ export async function handleHostedOrgChatModel(
     extraBodyFields: {
       providerKey: options.providerKey,
       ...(options.workspaceId ? { workspaceId: options.workspaceId } : {}),
-      // chatboxToken is set on the body by handleMCPJamFreeChatModel itself.
+      // chatboxId / accessVersion are set on the body by
+      // handleMCPJamFreeChatModel itself.
       ...(options.selectedServers && options.selectedServers.length > 0
         ? { serverIds: options.selectedServers }
         : {}),

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -92,7 +92,13 @@ export interface OrgModelHandlerOptions {
    * Hosted chatbox token for guest chat sessions. Forwarded to /stream/org
    * so Convex can authorize the guest against the project via the existing
    * authorizeGuestServerAccessBatch query.
+   *
+   * Post-refactor: prefer `chatboxId` (+ optional `accessVersion`); the
+   * backend will redeem `chatboxToken` server-side for transitional callers
+   * that still pass the token.
    */
+  chatboxId?: string;
+  accessVersion?: number;
   chatboxToken?: string;
   clientIp?: string | null;
 }
@@ -182,6 +188,8 @@ export interface OrgLocalModelHandlerOptions {
   requireToolApproval?: boolean;
   /** Forwarded to /stream/org/local-usage for identity resolution. */
   authHeader?: string;
+  chatboxId?: string;
+  accessVersion?: number;
   chatboxToken?: string;
   onConversationComplete?: (
     fullHistory: ModelMessage[],
@@ -209,6 +217,8 @@ export function handleLocalOrgChatModel(
     tools,
     requireToolApproval,
     authHeader,
+    chatboxId,
+    accessVersion,
     chatboxToken,
     onConversationComplete,
     onStreamComplete,
@@ -464,6 +474,8 @@ export function handleLocalOrgChatModel(
             turnId: traceTurn.turnId,
             promptIndex: traceTurn.promptIndex,
             authHeader,
+            chatboxId,
+            accessVersion,
             chatboxToken,
             selectedServers: options.selectedServers,
           }).catch((err) => {
@@ -525,6 +537,8 @@ async function postLocalUsage(params: {
   turnId?: string;
   promptIndex?: number;
   authHeader?: string;
+  chatboxId?: string;
+  accessVersion?: number;
   chatboxToken?: string;
   selectedServers?: string[];
 }): Promise<void> {
@@ -556,7 +570,13 @@ async function postLocalUsage(params: {
         ...(typeof params.promptIndex === "number"
           ? { promptIndex: params.promptIndex }
           : {}),
-        ...(params.chatboxToken ? { chatboxToken: params.chatboxToken } : {}),
+        ...(params.chatboxId ? { chatboxId: params.chatboxId } : {}),
+        ...(typeof params.accessVersion === "number"
+          ? { accessVersion: params.accessVersion }
+          : {}),
+        ...(params.chatboxToken && !params.chatboxId
+          ? { chatboxToken: params.chatboxToken }
+          : {}),
         ...(params.selectedServers && params.selectedServers.length > 0
           ? { serverIds: params.selectedServers }
           : {}),
@@ -600,6 +620,8 @@ export async function handleHostedOrgChatModel(
     tools: options.tools,
     projectId: options.workspaceId ? undefined : options.projectId,
     authHeader: options.authHeader,
+    chatboxId: options.chatboxId,
+    accessVersion: options.accessVersion,
     chatboxToken: options.chatboxToken,
     mcpClientManager: options.mcpClientManager,
     selectedServers: options.selectedServers,


### PR DESCRIPTION
## Summary

Full Phase E + F migration of the inspector to the new chatbox auth model. Server- and client-side surfaces now accept the post-refactor `chatboxId` (+ optional `accessVersion`) and forward them down every request path. `chatboxToken` is preserved as a fallback so this PR works against backend deployments that haven't yet landed Phase D — the backend will redeem the token server-side when no `chatboxId` is present.

**Companion to** [mcpjam-backend#239](https://github.com/MCPJam/mcpjam-backend/pull/239) (foundation). End-to-end test once that backend PR + its Phase D punch list lands.

## What's in this PR

### Phase E scaffolding (earlier commit)
- `server/utils/chatbox-redeem.ts` — `redeemChatboxToken` helper that POSTs to Convex `/web/chatbox/redeem`.

### Phase E slice 1 + 2: server-side `chatboxId` plumbing
- `server/routes/web/auth.ts`: zod schemas (`projectServerSchema`, `promptsListMultiSchema`, `hostedChatSchema`), `authorizeServer`, `authorizeBatch`, `createAuthorizedManager`, and `withEphemeralConnection` all accept and forward `chatboxId` + `accessVersion`. `chatboxToken` is suppressed in the outbound body when `chatboxId` is present.
- `server/routes/web/chat-v2.ts`: introduces `isChatboxSession = !!(chatboxId || chatboxToken)`. `sourceType`, `accessScope`, and the direct-vs-chatbox persistence branch all derive from it. All four downstream handlers (`handleLocalOrgChatModel`, `handleHostedOrgChatModel`, `handleMCPJamFreeChatModel`, `persistChatSessionToConvex`) receive the new fields.
- `server/utils/hosted-oauth-refresh.ts`: `HostedOAuthRefreshOptions` + `HostedOAuthUnauthorizedHandlerArgs` accept `chatboxId`/`accessVersion`; `/web/oauth/force-refresh` body prefers `chatboxId`.
- `server/utils/org-model-config.ts`: `ResolveOrgModelConfigAuth` gains `chatboxId`/`accessVersion`. Both `buildCacheKey` and `buildRuntimeCacheKey` hash `(chatboxId, accessVersion)` instead of `chatboxToken`. Token rotations no longer invalidate the cache; `accessVersion` bumps (mode change, revoke, allowlist edit) DO.
- `server/utils/chat-ingestion.ts`: `persistChatSessionToConvex` forwards the new fields in the ingest payload.
- `server/utils/org-model-stream-handler.ts` + `mcpjam-stream-handler.ts`: propagate `chatboxId`/`accessVersion` through `/stream/org/local-usage` and the org-streaming inner pipes.

### Phase E slice 3: client store
- `client/src/lib/chatbox-session.ts`: `ChatboxSession` gains optional top-level `accessVersion`. `ChatboxShareMode` expands to `project_members | invited_only | anyone_with_link`; the legacy `any_signed_in_with_link` alias is retained so already-persisted sessions deserialize cleanly.
- `client/src/lib/apis/web/context.ts`: `ApiContext` gains `chatboxId` + `accessVersion`. New getters `getHostedChatboxId` / `getHostedChatboxAccessVersion`. The three request builders (`buildServerRequest`, `buildServerBatchRequest`, `buildHostedEvalServerBatchRequest`) forward the new fields; `chatboxToken` is suppressed when `chatboxId` is present.
- `client/src/lib/hosted-runtime-context.ts`: `HostedRuntimeContext` grows `chatboxId` + `accessVersion`.
- `client/src/hooks/hosted/use-hosted-api-context.ts`: `useApiContext` signature and effect-dep list grow the new fields.

### Phase E slice 4: client hooks
- `client/src/hooks/use-chat-session.ts`: `HostedSessionScope` and the `lastResolvedHostedScopeRef` compare on `(chatboxId, accessVersion, chatboxToken)` so any access-affecting change forks the session correctly. Hosted body construction sends `chatboxId`/`accessVersion`. Direct-chat detection uses `!(chatboxId || chatboxToken)`.
- `client/src/hooks/useSharedChatWidgetCapture.ts`: options take `hostedChatboxId` + `hostedAccessVersion`. `generateSnapshotUploadUrl` + `createWidgetSnapshot` mutation payloads prefer the new fields.

### Phase E slice 5: chatbox-link landing page
- New server route `POST /api/web/chatboxes/redeem` (inspector) thin-forwards to Convex `/web/chatbox/redeem` and returns `{ chatboxId, role, mode, projectId, accessVersion, bootstrap }`.
- `client/src/components/hosted/ChatboxChatPage.tsx`: landing page now calls `/redeem` first. On success it stores `accessVersion` alongside the bootstrap payload. Falls back to `/bootstrap` on 404 so the inspector still works against backend deployments that don't yet have redeem. `useApiContext` is now seeded with `chatboxId` (from the redeemed payload) and `accessVersion`, so every chatbox-aware API call flows through the new auth path.

### Phase F: `/mcp` owner-preview parity
- `server/routes/mcp/chat-v2.ts`: route body now accepts `chatboxId`, `accessVersion`, `chatboxToken`, `surface`. All three `persistChatSessionToConvex` call sites switch from a hardcoded `sourceType: "direct"` to `chatSessionSourceType` derived from `isChatboxSession`, and forward the chatbox identity + surface telemetry. `directVisibility`/`resumeConfig` are gated off for chatbox sessions (those fields only apply to direct chat).
- Backend support for **anonymous-guest-in-/mcp** is now reachable end-to-end. Frontend wiring (a guest-bearer mint flow inside `/mcp` that auto-calls `/guest/session` for unauthenticated landing) is deferred per the plan until the demand surfaces.

## Architectural notes (locked in)

- **Dual-write transitional period.** Every callsite that takes `chatboxToken` now also takes `chatboxId` + `accessVersion`. Behavior: when `chatboxId` is present, it's forwarded and `chatboxToken` is dropped from the outbound body; otherwise the token is forwarded so the backend can redeem it server-side. This lets the inspector and backend cut over independently.
- **Cache invalidation moved off the token.** `org-model-config` cache keys hash `(chatboxId, accessVersion)` only. Rotating the token does NOT invalidate cache; bumping `accessVersion` (mode change, revoke-all, allowlist edit) does.
- **Telemetry preserved.** `sourceType: 'chatbox' | 'direct'` and `surface: 'preview' | 'share_link'` are now correctly derived in both `/web/chat-v2` and `/mcp/chat-v2`, including local-mode owner preview.
- **`/redeem` route falls back to `/bootstrap` on 404.** Lets this PR land before backend #239 merges. After backend #239 lands, the fallback can be removed.

## Known follow-ups (TODO(chatbox-followup))

1. **Drop `chatboxToken` outright** from server signatures and zod schemas. Currently kept for safety. Land after every client surface has shipped and stale sessions have expired.
2. **Remove the `/bootstrap` legacy endpoint** from `server/routes/web/chatboxes.ts` and from the landing-page fallback once backend #239 is in main.
3. **Drop the legacy `any_signed_in_with_link` mode literal** from `ChatboxShareMode` after persisted sessions expire.
4. **Tests not yet updated.** The hosted-OAuth-refresh, auth-manager, and use-chat-session test files mock callsites that now have new optional fields. They should still pass (fields are optional) but should be expanded to assert the new chatboxId path explicitly.
5. **Admin/builder UI surfaces** (`ChatboxEditor.tsx`, `ChatboxBuilderView.tsx`) still construct `chatboxToken` URLs for share links. That's correct behavior — the token IS the share link — but the builder should also explicitly stop persisting tokens in client state post-redeem.

## Test plan

- [ ] Land backend #239 + Phase D punch list
- [ ] Drop `/bootstrap` fallback from `ChatboxChatPage.tsx`
- [ ] End-to-end smoke against all 3 modes (`project_members`, `invited_only`, `anyone_with_link`) — landing → redeem → first chat turn
- [ ] Verify `accessVersion` cache invalidation: change chatbox mode, confirm next request rebuilds model-config cache
- [ ] Verify token rotation does NOT invalidate model-config cache (regression check)
- [ ] Owner-preview in `/mcp`: confirm `chatSessions` rows persist with `sourceType: 'chatbox'`, `surface: 'preview'`

https://claude.ai/code/session_01GB1QviY7ZKACjzVuyo1YNC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it refactors chatbox authentication/authorization identifiers across both client and server request paths and changes how chat sessions are persisted (direct vs chatbox), which can break access control or history attribution if any callsite is missed.
> 
> **Overview**
> Switches the inspector’s chatbox flows from carrying a share `chatboxToken` through hot-path requests to using a redeemed, persistent identity (`chatboxId` + `accessVersion`) and threads that pair through hosted API context, OAuth gating, chat transport bodies, widget snapshot uploads, and server request builders.
> 
> Adds a new `POST /api/web/chatboxes/redeem` route (backed by `server/utils/chatbox-redeem.ts`) and updates the hosted chatbox landing page to redeem the URL token, validate/normalize the returned bootstrap payload, and persist a v2 chatbox session shape (new storage key) that no longer stores the link token.
> 
> Updates server routes and utilities (`/api/web/chat-v2`, `/api/mcp/chat-v2`, evals/conformance/servers auth plumbing, OAuth refresh, org model config caching, and chat ingestion) to accept/forward `chatboxId`/`accessVersion`, derive `sourceType`/`surface` correctly for chatbox sessions (including local owner-preview), and omit direct-chat-only fields like `directVisibility`/`resumeConfig` when operating in a chatbox session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79c106949be30be5aacfe18d9561e03e6769682. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->