### PR TITLE
PR-I1: Switch project picker to one bulk server lookup (stale-while-revalidate)

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
@@ -2067,7 +2067,21 @@ describe("useProjectState bulk-server query (PR-I1)", () => {
   });
 
   it("does not emit telemetry once the bulk query has resolved for a project", async () => {
+    // The telemetry path skips the active project unconditionally, so a
+    // single-project setup would pass even if the bulk-resolved short-circuit
+    // were removed. The `active-spacer` project owns the active slot so `p1`
+    // is forced through the non-active path and the bulk-resolved check is
+    // what we're actually exercising.
     projectQueryState.allProjects = [
+      {
+        _id: "active-spacer",
+        name: "Active",
+        servers: {},
+        ownerId: "u1",
+        organizationId: "org-a",
+        createdAt: 0,
+        updatedAt: 0,
+      },
       {
         _id: "p1",
         name: "P1",

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
@@ -19,6 +19,8 @@ const {
   deleteProjectMock,
   projectQueryState,
   projectServersState,
+  projectsBulkServersState,
+  emitEmbeddedBlobReadMock,
   organizationBillingStatusState,
   useOrganizationBillingStatusMock,
   serializeServersForSharingMock,
@@ -37,6 +39,11 @@ const {
     servers: undefined as any,
     isLoading: false as boolean,
   },
+  projectsBulkServersState: {
+    serversByProject: {} as Record<string, any[]>,
+    isLoading: false as boolean,
+  },
+  emitEmbeddedBlobReadMock: vi.fn(),
   organizationBillingStatusState: {
     value: undefined as
       | {
@@ -66,6 +73,11 @@ vi.mock("../useProjects", () => ({
     deleteProject: deleteProjectMock,
   }),
   useProjectServers: () => projectServersState,
+  useProjectsBulkServers: () => projectsBulkServersState,
+}));
+
+vi.mock("../useClientTelemetry", () => ({
+  useEmbeddedBlobReadTelemetry: () => emitEmbeddedBlobReadMock,
 }));
 
 vi.mock("../useOrganizationBilling", () => ({
@@ -74,7 +86,14 @@ vi.mock("../useOrganizationBilling", () => ({
 }));
 
 vi.mock("@/lib/project-serialization", () => ({
-  deserializeServersFromConvex: vi.fn((servers) => servers ?? {}),
+  deserializeServersFromConvex: vi.fn((servers) => {
+    if (Array.isArray(servers)) {
+      return Object.fromEntries(
+        (servers as Array<{ name: string }>).map((s) => [s.name, s]),
+      );
+    }
+    return servers ?? {};
+  }),
   serializeServersForSharing: serializeServersForSharingMock,
 }));
 
@@ -1888,5 +1907,256 @@ describe("useProjectState convexProjects merge under loading", () => {
     expect(
       result.current.effectiveProjects["guest-project"]?.servers,
     ).toEqual({});
+  });
+});
+
+describe("useProjectState bulk-server query (PR-I1)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    projectQueryState.allProjects = [];
+    projectQueryState.projects = [];
+    projectQueryState.isLoading = false;
+    projectServersState.servers = undefined;
+    projectServersState.isLoading = false;
+    projectsBulkServersState.serversByProject = {};
+    projectsBulkServersState.isLoading = false;
+    emitEmbeddedBlobReadMock.mockReset();
+    organizationBillingStatusState.value = undefined;
+    useOrganizationBillingStatusMock.mockImplementation(
+      () => organizationBillingStatusState.value,
+    );
+  });
+
+  it("prefers the bulk-query result over the embedded servers blob", async () => {
+    projectQueryState.allProjects = [
+      {
+        _id: "active",
+        name: "Active",
+        servers: { stale: { name: "stale" } },
+        ownerId: "u1",
+        organizationId: "org-a",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      {
+        _id: "non-active",
+        name: "Non-Active",
+        // The embedded blob has a stale entry that the bulk result should
+        // override.
+        servers: { stale: { name: "stale" } },
+        ownerId: "u1",
+        organizationId: "org-a",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    projectQueryState.projects = projectQueryState.allProjects;
+    projectsBulkServersState.serversByProject = {
+      "non-active": [{ name: "fresh-from-bulk" } as any],
+    };
+    projectsBulkServersState.isLoading = false;
+
+    const appState = createAppState({});
+    const { result } = renderUseProjectState({ appState });
+
+    await waitFor(() => {
+      expect(result.current.effectiveProjects["non-active"]).toBeDefined();
+    });
+
+    const nonActiveServers =
+      result.current.effectiveProjects["non-active"].servers;
+    expect(Object.keys(nonActiveServers)).toEqual(["fresh-from-bulk"]);
+    expect(nonActiveServers).not.toHaveProperty("stale");
+  });
+
+  it("stale-while-revalidate: falls through to the embedded blob until the bulk query resolves", async () => {
+    projectQueryState.allProjects = [
+      {
+        _id: "active",
+        name: "Active",
+        servers: {},
+        ownerId: "u1",
+        organizationId: "org-a",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      {
+        _id: "non-active",
+        name: "Non-Active",
+        servers: { embedded: { name: "embedded" } },
+        ownerId: "u1",
+        organizationId: "org-a",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    projectQueryState.projects = projectQueryState.allProjects;
+    // Bulk query has not resolved yet.
+    projectsBulkServersState.serversByProject = {};
+    projectsBulkServersState.isLoading = true;
+
+    const appState = createAppState({});
+    const { result } = renderUseProjectState({ appState });
+
+    await waitFor(() => {
+      expect(result.current.effectiveProjects["non-active"]).toBeDefined();
+    });
+
+    // The non-active project renders the embedded blob immediately so the
+    // picker never flashes "0 server(s)" before bulk hydration.
+    expect(
+      Object.keys(result.current.effectiveProjects["non-active"].servers),
+    ).toEqual(["embedded"]);
+  });
+
+  it("emits embedded-blob-read telemetry when the SWR fallback is used", async () => {
+    projectQueryState.allProjects = [
+      {
+        _id: "active",
+        name: "Active",
+        servers: {},
+        ownerId: "u1",
+        organizationId: "org-a",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      {
+        _id: "fallback-1",
+        name: "Fallback 1",
+        servers: { a: { name: "a" }, b: { name: "b" } },
+        ownerId: "u1",
+        organizationId: "org-a",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      {
+        _id: "fallback-2",
+        name: "Fallback 2",
+        servers: { c: { name: "c" } },
+        ownerId: "u1",
+        organizationId: "org-a",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    projectQueryState.projects = projectQueryState.allProjects;
+    projectsBulkServersState.serversByProject = {};
+    projectsBulkServersState.isLoading = true;
+
+    const appState = createAppState({});
+    renderUseProjectState({ appState });
+
+    await waitFor(() => {
+      expect(emitEmbeddedBlobReadMock).toHaveBeenCalled();
+    });
+
+    const ids = emitEmbeddedBlobReadMock.mock.calls.map(
+      (c: any[]) => c[0].projectId,
+    );
+    expect(ids).toContain("fallback-1");
+    expect(ids).toContain("fallback-2");
+    // Active project must not emit — its servers don't come from the
+    // embedded blob, they come from the flat single-project query.
+    expect(ids).not.toContain("active");
+
+    const fallback1Call = emitEmbeddedBlobReadMock.mock.calls.find(
+      (c: any[]) => c[0].projectId === "fallback-1",
+    );
+    expect(fallback1Call?.[0].serverCount).toBe(2);
+  });
+
+  it("does not emit telemetry once the bulk query has resolved for a project", async () => {
+    projectQueryState.allProjects = [
+      {
+        _id: "p1",
+        name: "P1",
+        servers: { embedded: { name: "embedded" } },
+        ownerId: "u1",
+        organizationId: "org-a",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    projectQueryState.projects = projectQueryState.allProjects;
+    projectsBulkServersState.serversByProject = {
+      p1: [{ name: "bulk" } as any],
+    };
+    projectsBulkServersState.isLoading = false;
+
+    const appState = createAppState({
+      p1: {
+        id: "p1",
+        name: "P1",
+        servers: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+    renderUseProjectState({ appState });
+
+    await waitFor(() => {
+      expect(emitEmbeddedBlobReadMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not emit telemetry for the active project even when its embedded blob is non-empty", async () => {
+    projectQueryState.allProjects = [
+      {
+        _id: "active",
+        name: "Active",
+        // Active project's embedded blob is vestigial — its servers come from
+        // the flat single-project query, so even when this map is non-empty
+        // we must not count it as a read.
+        servers: { vestigial: { name: "vestigial" } },
+        ownerId: "u1",
+        organizationId: "org-a",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    projectQueryState.projects = projectQueryState.allProjects;
+    projectServersState.servers = []; // flat query resolved with no servers
+    projectsBulkServersState.serversByProject = {};
+    projectsBulkServersState.isLoading = false;
+
+    const appState = createAppState({
+      active: {
+        id: "active",
+        name: "Active",
+        servers: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+    renderUseProjectState({ appState });
+
+    await waitFor(() => {
+      expect(emitEmbeddedBlobReadMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("exposes bulk-loading state through the hook return", async () => {
+    projectQueryState.allProjects = [
+      {
+        _id: "p1",
+        name: "P1",
+        servers: {},
+        ownerId: "u1",
+        organizationId: "org-a",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    projectQueryState.projects = projectQueryState.allProjects;
+    projectsBulkServersState.serversByProject = {};
+    projectsBulkServersState.isLoading = true;
+
+    const appState = createAppState({});
+    const { result } = renderUseProjectState({ appState });
+
+    await waitFor(() => {
+      expect(result.current.isLoadingBulkServers).toBe(true);
+    });
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/useClientTelemetry.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useClientTelemetry.test.tsx
@@ -1,0 +1,83 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { recordClientEventMock } = vi.hoisted(() => ({
+  recordClientEventMock: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("convex/react", () => ({
+  useMutation: () => recordClientEventMock,
+}));
+
+import { useEmbeddedBlobReadTelemetry } from "../useClientTelemetry";
+
+describe("useEmbeddedBlobReadTelemetry", () => {
+  beforeEach(() => {
+    recordClientEventMock.mockReset();
+    recordClientEventMock.mockResolvedValue(null);
+  });
+
+  it("fires recordClientEvent with the embedded_servers_blob_read event", () => {
+    const { result } = renderHook(() => useEmbeddedBlobReadTelemetry());
+
+    act(() => {
+      result.current({ projectId: "proj_a", serverCount: 3 });
+    });
+
+    expect(recordClientEventMock).toHaveBeenCalledTimes(1);
+    const args = recordClientEventMock.mock.calls[0][0];
+    expect(args.event).toBe("embedded_servers_blob_read");
+    expect(args.properties.project_id).toBe("proj_a");
+    expect(args.properties.server_count).toBe(3);
+    expect(args.properties.location).toBe("project_picker");
+  });
+
+  it("dedupes repeated emits for the same project across re-renders", () => {
+    const { result, rerender } = renderHook(() =>
+      useEmbeddedBlobReadTelemetry(),
+    );
+
+    act(() => {
+      result.current({ projectId: "proj_a", serverCount: 1 });
+      result.current({ projectId: "proj_a", serverCount: 2 });
+      result.current({ projectId: "proj_a", serverCount: 5 });
+    });
+    rerender();
+    act(() => {
+      result.current({ projectId: "proj_a", serverCount: 7 });
+    });
+
+    expect(recordClientEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires separately for distinct projects", () => {
+    const { result } = renderHook(() => useEmbeddedBlobReadTelemetry());
+
+    act(() => {
+      result.current({ projectId: "proj_a", serverCount: 1 });
+      result.current({ projectId: "proj_b", serverCount: 2 });
+      result.current({ projectId: "proj_a", serverCount: 99 });
+    });
+
+    expect(recordClientEventMock).toHaveBeenCalledTimes(2);
+    const ids = recordClientEventMock.mock.calls.map(
+      (c) => c[0].properties.project_id,
+    );
+    expect(ids).toEqual(["proj_a", "proj_b"]);
+  });
+
+  it("swallows mutation rejections so the picker is unaffected", async () => {
+    recordClientEventMock.mockReset();
+    recordClientEventMock.mockRejectedValue(new Error("backend down"));
+
+    const { result } = renderHook(() => useEmbeddedBlobReadTelemetry());
+
+    // Must not throw synchronously.
+    act(() => {
+      result.current({ projectId: "proj_a", serverCount: 1 });
+    });
+    // And must not produce an unhandled rejection that fails the test.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(recordClientEventMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/use-project-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-project-state.ts
@@ -17,7 +17,9 @@ import {
   useProjectMutations,
   useProjectQueries,
   useProjectServers,
+  useProjectsBulkServers,
 } from "./useProjects";
+import { useEmbeddedBlobReadTelemetry } from "./useClientTelemetry";
 import {
   deserializeServersFromConvex,
   serializeServersForSharing,
@@ -184,6 +186,23 @@ export function useProjectState({
     isAuthenticated,
     organizationId: projectOrganizationId,
   });
+  // PR-I1: bulk-fetch servers for every visible project in one query so the
+  // picker can stop relying on the embedded `servers` blob shipped on each
+  // `RemoteProject`. The active project still reads the flat
+  // single-project query (`useProjectServers` below); the bulk query covers
+  // every other project the picker renders.
+  const bulkServerProjectIds = useMemo(
+    () => (remoteProjects ?? []).map((p) => p._id),
+    [remoteProjects],
+  );
+  const {
+    serversByProject: bulkServersByProject,
+    isLoading: isLoadingBulkServers,
+  } = useProjectsBulkServers({
+    projectIds: bulkServerProjectIds,
+    isAuthenticated,
+  });
+  const emitEmbeddedBlobRead = useEmbeddedBlobReadTelemetry();
   const {
     createProject: convexCreateProject,
     ensureDefaultProject: convexEnsureDefaultProject,
@@ -354,6 +373,34 @@ export function useProjectState({
       (remoteProjects === undefined || isLoadingServers)) ||
     (isAuthLoading && !!convexActiveProjectId);
 
+  // Project ids whose server count was sourced from the embedded blob on this
+  // render. Telemetry is emitted in a separate effect (below) so we don't
+  // perform side effects during the render path. PR-B2 watches the resulting
+  // Axiom counter and gates the embedded-blob removal on it being zero.
+  const embeddedBlobReadEventsThisRender = useMemo<
+    Array<{ projectId: string; serverCount: number }>
+  >(() => {
+    if (!remoteProjects) return [];
+    const events: Array<{ projectId: string; serverCount: number }> = [];
+    for (const rw of remoteProjects) {
+      if (rw._id === resolvedActiveProjectIdForServers) continue;
+      if (bulkServersByProject[rw._id] !== undefined) continue;
+      if (rw.servers && Object.keys(rw.servers).length > 0) {
+        events.push({
+          projectId: rw._id,
+          serverCount: Object.keys(rw.servers).length,
+        });
+      }
+    }
+    return events;
+  }, [remoteProjects, resolvedActiveProjectIdForServers, bulkServersByProject]);
+
+  useEffect(() => {
+    for (const event of embeddedBlobReadEventsThisRender) {
+      emitEmbeddedBlobRead(event);
+    }
+  }, [embeddedBlobReadEventsThisRender, emitEmbeddedBlobRead]);
+
   const convexProjects = useMemo((): Record<string, Project> => {
     if (!remoteProjects) return {};
     return Object.fromEntries(
@@ -371,8 +418,17 @@ export function useProjectState({
               activeProjectServersFlat,
             );
           }
-        } else if (rw.servers) {
-          deserializedServers = deserializeServersFromConvex(rw.servers);
+        } else {
+          // PR-I1: bulk query is the primary source. Stale-while-revalidate:
+          // render rw.servers (the embedded blob) until the bulk query
+          // resolves, then replace it with bulk data. Without the fallback
+          // the picker would briefly flash "0 server(s)" on every fresh load.
+          const bulk = bulkServersByProject[rw._id];
+          if (bulk !== undefined) {
+            deserializedServers = deserializeServersFromConvex(bulk);
+          } else if (rw.servers) {
+            deserializedServers = deserializeServersFromConvex(rw.servers);
+          }
         }
 
         return [
@@ -394,7 +450,12 @@ export function useProjectState({
         ];
       }),
     );
-  }, [remoteProjects, resolvedActiveProjectIdForServers, activeProjectServersFlat]);
+  }, [
+    remoteProjects,
+    resolvedActiveProjectIdForServers,
+    activeProjectServersFlat,
+    bulkServersByProject,
+  ]);
 
   useEffect(() => {
     if (pendingClientConfigSyncRef.current.size === 0) {
@@ -1677,6 +1738,13 @@ export function useProjectState({
     remoteProjects,
     isLoadingProjects,
     activeProjectServersFlat,
+    // PR-I1: true while the bulk server query is in flight for the picker's
+    // non-active projects. Consumers (e.g. ProjectManagementDialog) gate the
+    // "{n} server(s)" label on this so it never flashes "0 server(s)" before
+    // the bulk query resolves. The active project ignores this flag — its
+    // count comes from the existing flat query.
+    isLoadingBulkServers,
+    bulkServersByProject,
     // Always false — kept on the return shape so existing consumers
     // (tests, App.tsx) don't break in this PR. Convex-unreachable now
     // surfaces through the existing loading-skeleton path; no separate

--- a/mcpjam-inspector/client/src/hooks/useClientTelemetry.ts
+++ b/mcpjam-inspector/client/src/hooks/useClientTelemetry.ts
@@ -1,0 +1,44 @@
+import { useCallback, useRef } from "react";
+import { useMutation } from "convex/react";
+
+interface EmbeddedBlobReadEvent {
+  projectId: string;
+  serverCount: number;
+}
+
+/**
+ * Fire-and-forget telemetry emit for the vestigial embedded `servers` blob on
+ * `RemoteProject`. Each `projectId` is reported at most once per browser
+ * session, so the volume is bounded by the user's distinct non-active project
+ * count. Failures are swallowed — a busted telemetry pipe must never affect
+ * the picker.
+ *
+ * The backend's `telemetry.recordClientEvent` mutation logs a
+ * `[mcpjam_client_telemetry]` line that the Axiom "Project Picker Latency"
+ * dashboard counts; PR-B2 gates the embedded-blob removal on this count being
+ * zero for seven consecutive days.
+ */
+export function useEmbeddedBlobReadTelemetry() {
+  const recordClientEvent = useMutation(
+    "telemetry:recordClientEvent" as any
+  );
+  const seenRef = useRef<Set<string>>(new Set());
+
+  return useCallback(
+    (event: EmbeddedBlobReadEvent) => {
+      if (seenRef.current.has(event.projectId)) return;
+      seenRef.current.add(event.projectId);
+      void recordClientEvent({
+        event: "embedded_servers_blob_read",
+        properties: {
+          project_id: event.projectId,
+          server_count: event.serverCount,
+          location: "project_picker",
+        },
+      } as any).catch(() => {
+        // Fire-and-forget: telemetry failure must never affect the picker.
+      });
+    },
+    [recordClientEvent]
+  );
+}

--- a/mcpjam-inspector/client/src/hooks/useProjects.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjects.ts
@@ -279,3 +279,45 @@ export function useProjectServers({
     hasServers: (servers?.length ?? 0) > 0,
   };
 }
+
+// Bulk-fetch servers for many projects in one call. Replaces the embedded
+// servers blob the project picker used to read off each `RemoteProject`.
+// The backend cap is 500 ids; we dedupe + slice here so the picker can pass
+// a raw project list without worrying about either constraint.
+export function useProjectsBulkServers({
+  projectIds,
+  isAuthenticated,
+}: {
+  projectIds: string[];
+  isAuthenticated: boolean;
+}) {
+  // Stable identity for the query args. Using a joined key in the dependency
+  // list avoids re-running the memo when the input array reference flips but
+  // the contents are the same.
+  const stableKey = projectIds.join("|");
+  const stableProjectIds = useMemo(() => {
+    if (projectIds.length === 0) return [] as string[];
+    return Array.from(new Set(projectIds)).slice(0, 500);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stableKey]);
+
+  const data = useQuery(
+    "servers:listForProjects" as any,
+    isAuthenticated && stableProjectIds.length > 0
+      ? ({ projectIds: stableProjectIds } as any)
+      : "skip"
+  ) as Record<string, RemoteServer[]> | undefined;
+
+  const isLoading =
+    isAuthenticated && stableProjectIds.length > 0 && data === undefined;
+
+  const serversByProject = useMemo<Record<string, RemoteServer[]>>(
+    () => data ?? {},
+    [data]
+  );
+
+  return {
+    serversByProject,
+    isLoading,
+  };
+}


### PR DESCRIPTION
## TL;DR

The project picker reads each project's server count from a redundant copy of the server list attached to the project record itself. That copy is being retired soon, so the picker needs to switch to a fresh lookup. Naïvely switching would flash "0 server(s)" on every cold load while the lookup is in flight — this PR avoids that with a stale-while-revalidate fallback.

Zero user-facing change. Open the inspector with 3+ projects and the picker behaves exactly the same; it just sources the counts differently after the first ~100ms.

## The problem

Today the picker reads each project's server count from an inline copy of the server list stored on every project record:

```mermaid
sequenceDiagram
    participant U as User
    participant I as Inspector

    rect rgb(254, 226, 226)
        Note over U,I: BEFORE — read the inline copy
        U->>I: open picker
        I->>I: read inline server list off each project record
        I->>U: counts render
    end

    rect rgb(187, 247, 208)
        Note over U,I: AFTER — bulk lookup with SWR fallback
        U->>I: open picker
        I->>U: counts render immediately from the inline copy (SWR)
        I-->>I: bulk server lookup in flight
        I->>U: counts re-render from fresh lookup
    end
```

That inline copy is going away in a near-future change. If we just swap the picker to the new lookup, every cold load flashes "0 server(s)" for ~100ms until the lookup resolves. That's the user-visible bug we want to avoid.

## Solution

Three small pieces:

1. **`useProjectsBulkServers`** — a new hook that fires one bulk server lookup for every visible project id at once. Returns `{ serversByProject, isLoading }`.
2. **`use-project-state.ts`** — the picker memo now prefers the bulk lookup result. If the lookup hasn't resolved yet, it falls through to the inline copy ("stale-while-revalidate" — render what we have, refresh in the background). The active project keeps using its existing single-project flat query.
3. **`useEmbeddedBlobReadTelemetry`** — a fire-and-forget counter that fires once per project per browser session when the SWR fallback path is taken. Deduped via a `Set` ref so re-opens of the picker don't multiply the count. The next change watches this counter — once it's zero for a week, the inline copy can be safely retired.

## Before / after

| | Before | After this PR |
|---|---|---|
| Picker server-count source | Inline copy on each project record | Bulk lookup; inline copy as SWR fallback |
| First paint | Inline copy | Inline copy (same) |
| Steady state | Inline copy | Fresh bulk-lookup result |
| Flash "0 server(s)" risk | No | No (SWR fallback covers the in-flight window) |
| Network calls on picker open | None new | 1 bulk lookup |

## Worked example: signed-in user with a project they haven't opened yet

User has a project they haven't activated this session. Today the picker shows the count from the inline copy. After this PR:

1. **Frame 1.** Inline copy renders the count (e.g., "3 servers"). The telemetry counter fires once: "I read the inline copy for project X."
2. **Frame ~5 (~100ms later).** Bulk lookup resolves. Counts re-render from the fresh data. No further telemetry for that project this session.

No visual flicker, no "0 server(s)" flash.

## Will this break X?

| Risk | Answer |
|---|---|
| Active project's server list | Unchanged. Still uses the existing single-project flat query. |
| Picker flashing "0 server(s)" | No. SWR fallback covers the in-flight window. |
| Picker showing stale data | The inline copy is replaced by the fresh lookup the moment it resolves. Window is ~100ms. |
| Telemetry blocking the picker | No. Fire-and-forget, errors swallowed, deduped per session per project. |
| Existing tests | All 2,727 pass. |
| Memory leak from telemetry ref | No. `Set` ref lives with the hook, cleared on unmount. |
| Cost of bulk lookup | One round trip per picker open, regardless of project count. Strictly fewer round trips than today's per-project pattern. |

## Tests

**10 new, all passing. Full client suite: 2,727 / 2,727.**

- `use-project-state.test.tsx` — new `bulk-server query (PR-I1)` block (6):
  - bulk-lookup result is preferred over the inline copy
  - SWR fallback while loading
  - telemetry fires when the fallback path is taken (correct project id and server count)
  - telemetry does not fire once the bulk lookup has resolved
  - telemetry does not fire for the active project (its servers come from a different path)
  - bulk-loading state is exposed on the hook return for future UI use
- `useClientTelemetry.test.tsx` — new file (4): fires once per project, dedupes across re-renders, fires separately for distinct projects, swallows mutation rejections so a busted telemetry pipe can't break the picker.
