### PR TITLE
PR-I2: Sentry alert when a project create silently drops servers

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
@@ -2401,4 +2401,58 @@ describe("useProjectState cold-share data-loss guard (PR-I2)", () => {
     expect(options.extra.bulkServerCount).toBeNull();
     expect(options.extra.embeddedServerCount).toBe(1);
   });
+
+  it("captures the migrate call site when local-project migration serializes to empty", async () => {
+    // Local-only project with servers, ready to be migrated to Convex.
+    // The migration effect auto-fires on mount when an authenticated user
+    // has a matching organization and a local project that needs sharing.
+    projectQueryState.allProjects = [];
+    projectQueryState.projects = [];
+
+    const appState = createAppState({
+      default: createSyntheticDefaultProject(),
+      "local-1": createLocalProject("local-1", {
+        name: "Local with servers",
+        organizationId: "org-migrate",
+        servers: {
+          demo: {
+            name: "demo",
+            config: { url: "https://example.com/mcp" } as any,
+            lastConnectionTime: new Date("2026-01-01T00:00:00.000Z"),
+            connectionStatus: "disconnected",
+            retryCount: 0,
+          },
+        },
+      }),
+    });
+
+    // Force the serializer to drop every server. This is the only realistic
+    // way to trip the assertion on the migrate path — a real bug in the
+    // serialize step (or a future regression that nukes the map) would
+    // look exactly like this from the caller's perspective.
+    serializeServersForSharingMock.mockImplementationOnce(() => ({}));
+
+    renderUseProjectState({
+      appState,
+      activeOrganizationId: "org-migrate",
+      hasOrganizations: true,
+      isLoadingOrganizations: false,
+      validOrganizationIds: ["org-migrate"],
+    });
+
+    await waitFor(() => {
+      expect(sentryCaptureMessageMock).toHaveBeenCalled();
+    });
+
+    const migrateCall = sentryCaptureMessageMock.mock.calls.find(
+      (c: any[]) => c[1]?.extra?.callSite === "migrate",
+    );
+    expect(migrateCall, "expected a migrate-callSite Sentry message").toBeDefined();
+    expect(migrateCall![1].extra.serializedServerCount).toBe(0);
+    // local-only project ids never appear in the bulk-query map, so
+    // bulkServerCount is null for the migrate path by construction.
+    expect(migrateCall![1].extra.bulkServerCount).toBeNull();
+    expect(migrateCall![1].extra.embeddedServerCount).toBe(1);
+    expect(migrateCall![1].extra.sourceProjectId).toBe("local-1");
+  });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
@@ -21,6 +21,7 @@ const {
   projectServersState,
   projectsBulkServersState,
   emitEmbeddedBlobReadMock,
+  sentryCaptureMessageMock,
   organizationBillingStatusState,
   useOrganizationBillingStatusMock,
   serializeServersForSharingMock,
@@ -44,6 +45,7 @@ const {
     isLoading: false as boolean,
   },
   emitEmbeddedBlobReadMock: vi.fn(),
+  sentryCaptureMessageMock: vi.fn(),
   organizationBillingStatusState: {
     value: undefined as
       | {
@@ -53,6 +55,10 @@ const {
   },
   useOrganizationBillingStatusMock: vi.fn(),
   serializeServersForSharingMock: vi.fn((servers) => servers),
+}));
+
+vi.mock("@sentry/react", () => ({
+  captureMessage: sentryCaptureMessageMock,
 }));
 
 vi.mock("sonner", () => ({
@@ -2172,5 +2178,227 @@ describe("useProjectState bulk-server query (PR-I1)", () => {
     await waitFor(() => {
       expect(result.current.isLoadingBulkServers).toBe(true);
     });
+  });
+});
+
+describe("useProjectState cold-share data-loss guard (PR-I2)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    projectQueryState.allProjects = [];
+    projectQueryState.projects = [];
+    projectQueryState.isLoading = false;
+    projectServersState.servers = undefined;
+    projectServersState.isLoading = false;
+    projectsBulkServersState.serversByProject = {};
+    projectsBulkServersState.isLoading = false;
+    sentryCaptureMessageMock.mockReset();
+    createProjectMock.mockResolvedValue("new-remote-id");
+    organizationBillingStatusState.value = { canManageBilling: true };
+    useOrganizationBillingStatusMock.mockImplementation(
+      () => organizationBillingStatusState.value,
+    );
+  });
+
+  it("captures a Sentry message when handleDuplicateProject sends empty servers but the bulk query has servers for the source", async () => {
+    // The first remote project is treated as the active project by the hook
+    // when no explicit selection exists; its servers route through the flat
+    // single-project query rather than through the bulk query. The spacer
+    // claims that slot so `remote-1` exercises the bulk-query path under
+    // test.
+    projectQueryState.allProjects = [
+      {
+        _id: "active-spacer",
+        name: "Active",
+        servers: {},
+        ownerId: "u1",
+        organizationId: "org-route",
+        createdAt: 0,
+        updatedAt: 0,
+      },
+      {
+        _id: "remote-1",
+        name: "Source Project",
+        servers: {}, // empty embedded blob — pre-PR-I1 the picker had a stale read
+        ownerId: "u1",
+        organizationId: "org-route",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    projectQueryState.projects = projectQueryState.allProjects;
+    // The bulk query KNOWS the source has servers — but the user clicked
+    // duplicate before the bulk hydration propagated into the project
+    // state. Without the guard, this would silently create an empty
+    // duplicate.
+    projectsBulkServersState.serversByProject = {
+      "remote-1": [{ name: "s1" } as any, { name: "s2" } as any],
+    };
+
+    const appState = createAppState({
+      default: createSyntheticDefaultProject(),
+    });
+    const { result } = renderUseProjectState({
+      appState,
+      activeOrganizationId: "org-route",
+      hasOrganizations: true,
+      isLoadingOrganizations: false,
+      validOrganizationIds: ["org-route"],
+    });
+
+    // Simulate the cold-duplicate race: when handleDuplicateProject reads
+    // sourceProject.servers, the bulk-fed version hasn't been threaded into
+    // effectiveProjects yet (this mirrors a window of a few render frames
+    // in production). The serializer mock is identity, so an empty source
+    // map → empty serialized payload.
+    serializeServersForSharingMock.mockImplementationOnce(() => ({}));
+
+    await act(async () => {
+      await result.current.handleDuplicateProject("remote-1", "Copy");
+    });
+
+    expect(sentryCaptureMessageMock).toHaveBeenCalledTimes(1);
+    const [message, options] = sentryCaptureMessageMock.mock.calls[0];
+    expect(message).toMatch(/Cold-share data-loss invariant tripped/);
+    expect(options.level).toBe("error");
+    expect(options.extra.callSite).toBe("duplicate");
+    expect(options.extra.sourceProjectId).toBe("remote-1");
+    expect(options.extra.serializedServerCount).toBe(0);
+    expect(options.extra.bulkServerCount).toBe(2);
+  });
+
+  it("does not fire when the serialized payload is non-empty", async () => {
+    // Two projects: an active one (its servers come from the flat query, not
+    // the bulk query) and a non-active duplicate target (the one we
+    // exercise). Without the spacer the picker treats the first remote
+    // project as active and routes its server count through the empty flat
+    // query instead of through the bulk-query path we want to test.
+    projectQueryState.allProjects = [
+      {
+        _id: "active-spacer",
+        name: "Active",
+        servers: {},
+        ownerId: "u1",
+        organizationId: "org-route",
+        createdAt: 0,
+        updatedAt: 0,
+      },
+      {
+        _id: "remote-2",
+        name: "Source Project",
+        servers: { good: { name: "good" } },
+        ownerId: "u1",
+        organizationId: "org-route",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    projectQueryState.projects = projectQueryState.allProjects;
+    projectsBulkServersState.serversByProject = {
+      "remote-2": [{ name: "good" } as any],
+    };
+
+    const appState = createAppState({
+      default: createSyntheticDefaultProject(),
+    });
+    const { result } = renderUseProjectState({
+      appState,
+      activeOrganizationId: "org-route",
+      hasOrganizations: true,
+      isLoadingOrganizations: false,
+      validOrganizationIds: ["org-route"],
+    });
+
+    await act(async () => {
+      await result.current.handleDuplicateProject("remote-2", "Copy");
+    });
+
+    expect(sentryCaptureMessageMock).not.toHaveBeenCalled();
+    expect(createProjectMock).toHaveBeenCalled();
+  });
+
+  it("does not fire when the source project legitimately has no servers", async () => {
+    projectQueryState.allProjects = [
+      {
+        _id: "active-spacer",
+        name: "Active",
+        servers: {},
+        ownerId: "u1",
+        organizationId: "org-route",
+        createdAt: 0,
+        updatedAt: 0,
+      },
+      {
+        _id: "remote-3",
+        name: "Empty Project",
+        servers: {},
+        ownerId: "u1",
+        organizationId: "org-route",
+        createdAt: 1,
+        updatedAt: 1,
+      },
+    ];
+    projectQueryState.projects = projectQueryState.allProjects;
+    // Bulk query confirmed the source is genuinely empty.
+    projectsBulkServersState.serversByProject = {
+      "remote-3": [],
+    };
+
+    const appState = createAppState({
+      default: createSyntheticDefaultProject(),
+    });
+    const { result } = renderUseProjectState({
+      appState,
+      activeOrganizationId: "org-route",
+      hasOrganizations: true,
+      isLoadingOrganizations: false,
+      validOrganizationIds: ["org-route"],
+    });
+
+    serializeServersForSharingMock.mockImplementationOnce(() => ({}));
+
+    await act(async () => {
+      await result.current.handleDuplicateProject("remote-3", "Copy");
+    });
+
+    expect(sentryCaptureMessageMock).not.toHaveBeenCalled();
+    expect(createProjectMock).toHaveBeenCalled();
+  });
+
+  it("captures the import call site with a null bulkServerCount", async () => {
+    projectQueryState.allProjects = [];
+    projectQueryState.projects = [];
+
+    const appState = createAppState({
+      default: createSyntheticDefaultProject(),
+    });
+    const { result } = renderUseProjectState({
+      appState,
+      activeOrganizationId: "org-route",
+      hasOrganizations: true,
+      isLoadingOrganizations: false,
+      validOrganizationIds: ["org-route"],
+    });
+
+    serializeServersForSharingMock.mockImplementationOnce(() => ({}));
+
+    await act(async () => {
+      await result.current.handleImportProject({
+        id: "import-1",
+        name: "Imported",
+        // The user pasted a file that claims the project has servers, but
+        // the post-serialize shape came out empty. This is the only
+        // realistic way the assertion fires on the import path.
+        servers: { ghost: { name: "ghost" } as any },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as any);
+    });
+
+    expect(sentryCaptureMessageMock).toHaveBeenCalledTimes(1);
+    const [, options] = sentryCaptureMessageMock.mock.calls[0];
+    expect(options.extra.callSite).toBe("import");
+    expect(options.extra.bulkServerCount).toBeNull();
+    expect(options.extra.embeddedServerCount).toBe(1);
   });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
@@ -1916,7 +1916,7 @@ describe("useProjectState convexProjects merge under loading", () => {
   });
 });
 
-describe("useProjectState bulk-server query (PR-I1)", () => {
+describe("useProjectState bulk-server query", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
@@ -2181,7 +2181,7 @@ describe("useProjectState bulk-server query (PR-I1)", () => {
   });
 });
 
-describe("useProjectState cold-share data-loss guard (PR-I2)", () => {
+describe("useProjectState cold-share data-loss guard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
@@ -2219,7 +2219,7 @@ describe("useProjectState cold-share data-loss guard (PR-I2)", () => {
       {
         _id: "remote-1",
         name: "Source Project",
-        servers: {}, // empty embedded blob — pre-PR-I1 the picker had a stale read
+        servers: {}, // empty in-record copy — before the bulk-query swap the picker had a stale read
         ownerId: "u1",
         organizationId: "org-route",
         createdAt: 1,

--- a/mcpjam-inspector/client/src/hooks/use-project-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-project-state.ts
@@ -20,6 +20,43 @@ import {
   useProjectsBulkServers,
 } from "./useProjects";
 import { useEmbeddedBlobReadTelemetry } from "./useClientTelemetry";
+import * as Sentry from "@sentry/react";
+
+// PR-I2: defensive assertion for the cold-share / cold-duplicate data-loss
+// vector. PR-I1 made non-active project servers source from a bulk query
+// (stale-while-revalidate). If a `createProject(... servers: {} ...)` call
+// fires for a project whose source DID have servers in the bulk-query map,
+// we have a race-condition data loss. Today the path is not reachable from
+// production UI (the duplicate handler is wired but no rendered component
+// calls it; the share dialog only runs createProject for local-only
+// projects whose servers come from Redux, not the bulk query) — but this
+// guard makes any future regression visible in Sentry on the first
+// occurrence rather than silently corrupting user data.
+function assertNotColdSharingEmptyServers(args: {
+  callSite: "duplicate" | "migrate" | "import";
+  sourceProjectId: string;
+  serializedServerCount: number;
+  bulkServerCount: number | null;
+  embeddedServerCount: number;
+}): void {
+  if (args.serializedServerCount > 0) return;
+  if ((args.bulkServerCount ?? 0) === 0 && args.embeddedServerCount === 0) {
+    return;
+  }
+  Sentry.captureMessage(
+    "Cold-share data-loss invariant tripped: createProject called with empty servers but source has servers",
+    {
+      level: "error",
+      extra: {
+        callSite: args.callSite,
+        sourceProjectId: args.sourceProjectId,
+        serializedServerCount: args.serializedServerCount,
+        bulkServerCount: args.bulkServerCount,
+        embeddedServerCount: args.embeddedServerCount,
+      },
+    },
+  );
+}
 import {
   deserializeServersFromConvex,
   serializeServersForSharing,
@@ -798,6 +835,14 @@ export function useProjectState({
 
       try {
         const serializedServers = serializeServersForSharing(project.servers);
+        const bulkForSource = bulkServersByProject[project.id];
+        assertNotColdSharingEmptyServers({
+          callSite: "migrate",
+          sourceProjectId: project.id,
+          serializedServerCount: Object.keys(serializedServers).length,
+          bulkServerCount: bulkForSource ? bulkForSource.length : null,
+          embeddedServerCount: Object.keys(project.servers ?? {}).length,
+        });
         const projectId = await convexCreateProject({
           name: project.name,
           description: project.description,
@@ -1540,6 +1585,14 @@ export function useProjectState({
           const serializedServers = serializeServersForSharing(
             sourceProject.servers,
           );
+          const bulkForSource = bulkServersByProject[sourceProject.id];
+          assertNotColdSharingEmptyServers({
+            callSite: "duplicate",
+            sourceProjectId: sourceProject.id,
+            serializedServerCount: Object.keys(serializedServers).length,
+            bulkServerCount: bulkForSource ? bulkForSource.length : null,
+            embeddedServerCount: Object.keys(sourceProject.servers ?? {}).length,
+          });
           await convexCreateProject({
             name: newName,
             description: sourceProject.description,
@@ -1682,6 +1735,15 @@ export function useProjectState({
           const serializedServers = serializeServersForSharing(
             projectData.servers || {},
           );
+          assertNotColdSharingEmptyServers({
+            callSite: "import",
+            sourceProjectId: projectData.id ?? "<unknown-import>",
+            serializedServerCount: Object.keys(serializedServers).length,
+            // Import-from-JSON has no bulk-query source — the user pasted
+            // the payload. We only have the embedded count to compare.
+            bulkServerCount: null,
+            embeddedServerCount: Object.keys(projectData.servers ?? {}).length,
+          });
           await convexCreateProject({
             name: projectData.name,
             description: projectData.description,

--- a/mcpjam-inspector/client/src/hooks/use-project-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-project-state.ts
@@ -893,6 +893,7 @@ export function useProjectState({
     hasResolvedProjectOrganizationSelection,
     canManageBillingForProjectActions,
     shouldTreatRemoteProjectsAsEmpty,
+    bulkServersByProject,
   ]);
 
   useEffect(() => {
@@ -1645,6 +1646,7 @@ export function useProjectState({
       projectOrganizationId,
       hasResolvedProjectOrganizationSelection,
       canManageBillingForProjectActions,
+      bulkServersByProject,
     ],
   );
 

--- a/mcpjam-inspector/client/src/hooks/use-project-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-project-state.ts
@@ -22,16 +22,16 @@ import {
 import { useEmbeddedBlobReadTelemetry } from "./useClientTelemetry";
 import * as Sentry from "@sentry/react";
 
-// PR-I2: defensive assertion for the cold-share / cold-duplicate data-loss
-// vector. PR-I1 made non-active project servers source from a bulk query
-// (stale-while-revalidate). If a `createProject(... servers: {} ...)` call
-// fires for a project whose source DID have servers in the bulk-query map,
-// we have a race-condition data loss. Today the path is not reachable from
-// production UI (the duplicate handler is wired but no rendered component
-// calls it; the share dialog only runs createProject for local-only
-// projects whose servers come from Redux, not the bulk query) — but this
-// guard makes any future regression visible in Sentry on the first
-// occurrence rather than silently corrupting user data.
+// Defensive invariant: the serialized servers payload sent to `createProject`
+// must not be empty when the source project actually has servers. Emits a
+// Sentry message rather than throwing so the user-facing "create" path still
+// succeeds — we want to learn about the bug from the first occurrence, not
+// from a confused user a week later.
+//
+// `bulkServerCount` and `embeddedServerCount` together pinpoint the cause:
+// `bulkServerCount > 0` means the project had servers in the loaded list
+// when the call was made (likely a serialization regression); a non-zero
+// `embeddedServerCount` means the in-record copy still has servers.
 function assertNotColdSharingEmptyServers(args: {
   callSite: "duplicate" | "migrate" | "import";
   sourceProjectId: string;
@@ -223,11 +223,10 @@ export function useProjectState({
     isAuthenticated,
     organizationId: projectOrganizationId,
   });
-  // PR-I1: bulk-fetch servers for every visible project in one query so the
-  // picker can stop relying on the embedded `servers` blob shipped on each
-  // `RemoteProject`. The active project still reads the flat
-  // single-project query (`useProjectServers` below); the bulk query covers
-  // every other project the picker renders.
+  // Bulk-fetch servers for every visible project in one query so the picker
+  // can render server counts without N round trips. The active project still
+  // reads via the flat single-project query (see `useProjectServers` below);
+  // the bulk query covers every other project the picker renders.
   const bulkServerProjectIds = useMemo(
     () => (remoteProjects ?? []).map((p) => p._id),
     [remoteProjects],
@@ -410,10 +409,11 @@ export function useProjectState({
       (remoteProjects === undefined || isLoadingServers)) ||
     (isAuthLoading && !!convexActiveProjectId);
 
-  // Project ids whose server count was sourced from the embedded blob on this
-  // render. Telemetry is emitted in a separate effect (below) so we don't
-  // perform side effects during the render path. PR-B2 watches the resulting
-  // Axiom counter and gates the embedded-blob removal on it being zero.
+  // Project ids whose server count was sourced from the in-record copy on
+  // this render. Telemetry is emitted in a separate effect (below) so we
+  // don't perform side effects during the render path. The resulting counter
+  // is what we watch to verify that no consumer still depends on the
+  // in-record copy before retiring it.
   const embeddedBlobReadEventsThisRender = useMemo<
     Array<{ projectId: string; serverCount: number }>
   >(() => {
@@ -456,9 +456,9 @@ export function useProjectState({
             );
           }
         } else {
-          // PR-I1: bulk query is the primary source. Stale-while-revalidate:
-          // render rw.servers (the embedded blob) until the bulk query
-          // resolves, then replace it with bulk data. Without the fallback
+          // Bulk query is the primary source. Stale-while-revalidate:
+          // render `rw.servers` (the in-record copy) until the bulk query
+          // resolves, then swap to the fresh result. Without the fallback
           // the picker would briefly flash "0 server(s)" on every fresh load.
           const bulk = bulkServersByProject[rw._id];
           if (bulk !== undefined) {
@@ -1802,11 +1802,11 @@ export function useProjectState({
     remoteProjects,
     isLoadingProjects,
     activeProjectServersFlat,
-    // PR-I1: true while the bulk server query is in flight for the picker's
-    // non-active projects. Consumers (e.g. ProjectManagementDialog) gate the
-    // "{n} server(s)" label on this so it never flashes "0 server(s)" before
-    // the bulk query resolves. The active project ignores this flag — its
-    // count comes from the existing flat query.
+    // True while the bulk server query is in flight for the picker's
+    // non-active projects. Consumers (e.g. ProjectManagementDialog) gate
+    // the "{n} server(s)" label on this so it never flashes "0 server(s)"
+    // before the bulk query resolves. The active project ignores this flag
+    // — its count comes from the existing flat single-project query.
     isLoadingBulkServers,
     bulkServersByProject,
     // Always false — kept on the return shape so existing consumers

--- a/mcpjam-inspector/client/src/hooks/useClientTelemetry.ts
+++ b/mcpjam-inspector/client/src/hooks/useClientTelemetry.ts
@@ -7,16 +7,11 @@ interface EmbeddedBlobReadEvent {
 }
 
 /**
- * Fire-and-forget telemetry emit for the vestigial embedded `servers` blob on
- * `RemoteProject`. Each `projectId` is reported at most once per browser
- * session, so the volume is bounded by the user's distinct non-active project
- * count. Failures are swallowed — a busted telemetry pipe must never affect
- * the picker.
- *
- * The backend's `telemetry.recordClientEvent` mutation logs a
- * `[mcpjam_client_telemetry]` line that the Axiom "Project Picker Latency"
- * dashboard counts; PR-B2 gates the embedded-blob removal on this count being
- * zero for seven consecutive days.
+ * Fire-and-forget telemetry emit for reads of the in-record `servers` map on
+ * a `RemoteProject`. Each `projectId` is reported at most once per browser
+ * session, so the volume is bounded by the user's distinct non-active
+ * project count. Failures are swallowed — a busted telemetry pipe must
+ * never affect the picker.
  */
 export function useEmbeddedBlobReadTelemetry() {
   const recordClientEvent = useMutation(


### PR DESCRIPTION
## TL;DR

Defensive Sentry alert if a code path ever calls "create project" with an empty servers list when the source project actually has servers. No user-facing behavior change — the create still runs. We just learn about it on the first occurrence instead of from a confused user a week later.

## The problem

The previous PR (#2058) made non-active project server lists load asynchronously. There's now a narrow window where a project's loaded server list hasn't propagated into local state yet.

If any code path creates a new project from a not-yet-loaded source project's data during that window, the new project lands with **zero servers**. The user gets no error. The toast says "duplicated successfully." They only notice when they open the duplicate and find it empty — silent data loss.

This affects three call sites in the project hook:

```mermaid
flowchart TB
    A["duplicate project"]:::client --> X
    B["migrate / share local project to shared"]:::client --> X
    C["import project from JSON"]:::client --> X
    X["serialize source.servers<br/>then create project"]:::client
    X --> Y{"serialized payload empty?"}:::client
    Y -->|"no"| Z["create succeeds<br/>(happy path)"]:::client
    Y -->|"yes"| W{"source actually had servers?"}:::client
    W -->|"no"| Z
    W -->|"yes"| ALERT["Sentry.captureMessage<br/>(level: error)"]:::external
    ALERT --> Z

    classDef client fill:#bfdbfe,stroke:#1e3a8a,color:#0b1f44
    classDef external fill:#fecaca,stroke:#991b1b,color:#450a0a
```

The Sentry alert fires only at the bottom branch — the actual data-loss case. Both-empty (legitimate "create an empty project") and serialized-non-empty (happy path) stay silent.

## Why a Sentry alert and not a hydration `await`

The naïve fix is to wait for hydration before allowing create. We deliberately chose not to:

1. **The duplicate handler isn't reached from any rendered UI today** — the dialog that exposes it is unreferenced. The bug is theoretical until that changes.
2. **The share dialog only creates projects from local-only data**, which doesn't depend on the asynchronously-loaded list at all.
3. The real risk is a *future* PR wiring one of these handlers into a code path that does depend on the async list. We want to find out immediately, not three months later from a user.

A Sentry alert costs zero behavior change and gives us a deterministic signal on the first occurrence — strictly better than the original plan's "watch a conversion ratio drop over time" approach.

## What the Sentry alert looks like

```jsonc
{
  "message": "Cold-share data-loss invariant tripped: createProject called with empty servers but source has servers",
  "level": "error",
  "extra": {
    "callSite": "duplicate",
    "sourceProjectId": "j7abc...",
    "serializedServerCount": 0,
    "bulkServerCount": 3,         // source has 3 servers per the loaded list
    "embeddedServerCount": 0      // and 0 in the inline copy
  }
}
```

`bulkServerCount: 3` is what makes this actionable — we can immediately see the source had servers and the create would have shipped empty.

## Will this break X?

| Risk | Answer |
|---|---|
| User-facing behavior | None. The create still proceeds. We capture a Sentry message; the toast still says "success." |
| False positives | None expected. Helper only fires when serialized is empty AND (loaded list OR inline copy) has servers. Both-empty is silent. |
| Performance | Three `Object.keys().length` calls per create. Negligible. |
| Sentry quota | Bounded by how often the bug triggers, which should be zero. |
| Stale-closure neutering the guard | Fixed in commit `b9a85a114` — the two callbacks/effects that read `bulkServersByProject` now declare it as a dep, so the captured map stays in sync with the bulk-query result. (Caught by CodeRabbit on the first pass.) |
| Existing tests | All 2,757 client tests pass. |

## Tests

**5 new, all passing. Full client suite: 2,757 / 2,757.**

One test per call site (3) plus two negative-path tests on the duplicate site:

- Duplicate path — captures Sentry message with the expected `extra` shape (callSite, sourceProjectId, all three counts).
- Duplicate path — does NOT fire when the serialized payload is non-empty (happy path).
- Duplicate path — does NOT fire when the source project legitimately has no servers.
- Import path — captures with `bulkServerCount: null` (import has no async source — the user pasted the payload).
- Migrate path — captures when local-only project migration to shared serializes to empty. Local-only ids never appear in the bulk map by construction, so `bulkServerCount === null`. Mirrors the duplicate-path test shape.

## Review iteration

- Rebased onto `main` after #2058 squash-merged. Zero conflicts — the squashed commit on main is semantically identical to the locally-stacked picker-swap commits.
- CodeRabbit flagged a stale-closure bug in `handleDuplicateProject`'s dep array and a coverage gap on the migrate call site. Both addressed in commit `b9a85a114`. The dep-array fix also extends to a sibling `useEffect` that had the same shape — see the commit body.
- Commit `49e5efa8f` strips internal plan jargon (`PR-Ix` / `PR-Bx` / backend tool names) from code comments and test describe blocks. Tests unchanged in behavior; 48/48 pass on the touched files.


