### PR TITLE
Chatbox preview: auto-connect configured MCP servers before first turn

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2141,6 +2141,7 @@ export default function App() {
                 projectId={billingProjectId}
                 organizationId={activeProjectBillingOrganizationId}
                 isBillingContextPending={isBillingContextPending}
+                ensureServersReady={ensureServersReady}
               />
             ))}
           {activeTab === "resources" && (

--- a/mcpjam-inspector/client/src/components/ChatboxesTab.tsx
+++ b/mcpjam-inspector/client/src/components/ChatboxesTab.tsx
@@ -1,4 +1,5 @@
 import { Suspense, lazy, useEffect } from "react";
+import type { EnsureServersReadyResult } from "@/hooks/use-app-state";
 import { useOrganizationBilling } from "@/hooks/useOrganizationBilling";
 import {
   getBillingUpsellCtaLabel,
@@ -17,6 +18,15 @@ interface ChatboxesTabProps {
   projectId: string | null;
   organizationId: string | null;
   isBillingContextPending?: boolean;
+  /**
+   * Same reconnect helper that EvalsTab uses. Threaded into the builder so
+   * the Preview tab can auto-connect the chatbox's MCP servers before the
+   * first message — without this, the LLM gets zero tools (the inspector's
+   * mcpClientManager has nothing registered for the configured servers).
+   */
+  ensureServersReady?: (
+    serverNames: string[],
+  ) => Promise<EnsureServersReadyResult>;
 }
 
 function ChatboxesLoadingState({
@@ -47,6 +57,7 @@ export function ChatboxesTab({
   projectId,
   organizationId,
   isBillingContextPending = false,
+  ensureServersReady,
 }: ChatboxesTabProps) {
   const resolvedOrganizationId = isBillingContextPending
     ? null
@@ -124,6 +135,7 @@ export function ChatboxesTab({
           isCreateChatboxDisabled={chatboxCreationGate.isDenied}
           isCreateChatboxLoading={chatboxCreationGate.isLoading}
           createChatboxUpsell={createChatboxUpsell}
+          ensureServersReady={ensureServersReady}
         />
       </Suspense>
     </BillingGateSurface>

--- a/mcpjam-inspector/client/src/components/__tests__/ChatboxesTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatboxesTab.test.tsx
@@ -160,6 +160,8 @@ vi.mock("convex/react", () => ({
   useConvexAuth: () => ({
     isAuthenticated: true,
   }),
+  useMutation: () => vi.fn(),
+  useQuery: () => undefined,
 }));
 
 vi.mock("posthog-js/react", () => ({
@@ -203,6 +205,7 @@ vi.mock("@/hooks/useProjects", () => ({
   useProjectServers: () => ({
     servers: [],
   }),
+  useServerMutations: () => ({ createServer: vi.fn() }),
 }));
 
 vi.mock("../chatboxes/builder/ChatboxBuilderView", () => ({

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderExperience.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderExperience.tsx
@@ -25,6 +25,7 @@ import { ChatboxLauncher } from "./ChatboxLauncher";
 import { getDefaultHostedModelId, migrateBuilderDraft } from "./drafts";
 import type { ChatboxDraftConfig, ChatboxStarterDefinition } from "./types";
 import { useChatboxDemoSeed } from "./useChatboxDemoSeed";
+import type { EnsureServersReadyResult } from "@/hooks/use-app-state";
 
 interface ChatboxBuilderExperienceProps {
   projectId: string | null;
@@ -38,6 +39,9 @@ interface ChatboxBuilderExperienceProps {
     ctaLabel: string;
     onNavigateToBilling: () => void;
   } | null;
+  ensureServersReady?: (
+    serverNames: string[],
+  ) => Promise<EnsureServersReadyResult>;
 }
 
 export default function ChatboxBuilderExperience({
@@ -45,6 +49,7 @@ export default function ChatboxBuilderExperience({
   isCreateChatboxDisabled = false,
   isCreateChatboxLoading = false,
   createChatboxUpsell = null,
+  ensureServersReady,
 }: ChatboxBuilderExperienceProps) {
   const { isAuthenticated } = useConvexAuth();
   const { chatboxes, isLoading } = useChatboxList({
@@ -350,6 +355,7 @@ export default function ChatboxBuilderExperience({
           chatboxId={selectedChatboxId}
           draft={draft}
           initialViewMode={restoredViewMode}
+          ensureServersReady={ensureServersReady}
           onSavedDraft={handleSavedDraft}
           onBack={() => {
             clearBuilderSession();

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
@@ -771,12 +771,23 @@ export function ChatboxBuilderView({
     () => activePreviewServerNames.slice().sort().join("\0"),
     [activePreviewServerNames]
   );
+  // Seed in "connecting" when the Preview tab opens with servers and the
+  // helper plumbed: the reconnect effect below only fires after the first
+  // paint, so an initial `"idle"` would leave previewConnectComposerBlocked
+  // false for one frame, letting the composer briefly accept input before
+  // the local mcpClientManager has the servers registered.
   const [previewConnectStatus, setPreviewConnectStatus] = useState<{
     phase: "idle" | "connecting" | "ready" | "blocked";
     readyCount: number;
     totalCount: number;
     blockedReason?: string;
-  }>({ phase: "idle", readyCount: 0, totalCount: 0 });
+  }>(() => {
+    const total = activePreviewServerNames.length;
+    if (viewMode === "preview" && ensureServersReady && total > 0) {
+      return { phase: "connecting", readyCount: 0, totalCount: total };
+    }
+    return { phase: "idle", readyCount: 0, totalCount: 0 };
+  });
 
   useEffect(() => {
     // Only run while the Preview tab is active. Switching to setup/usage

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
@@ -763,8 +763,12 @@ export function ChatboxBuilderView({
     () => activePreviewServers.map((s) => s.serverName),
     [activePreviewServers]
   );
+  // Stable key for the reconnect effect. The `\0` delimiter prevents
+  // collisions between e.g. ["ab","c"] and ["a","bc"] (both join to "abc"
+  // without one), which would otherwise let a server-set swap skip the
+  // effect entirely. Matches the convention in use-playground-project-executions.
   const activePreviewServerNamesKey = useMemo(
-    () => activePreviewServerNames.slice().sort().join(""),
+    () => activePreviewServerNames.slice().sort().join("\0"),
     [activePreviewServerNames]
   );
   const [previewConnectStatus, setPreviewConnectStatus] = useState<{

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
@@ -46,7 +46,10 @@ import { getBillingErrorMessage } from "@/lib/billing-entitlements";
 import { getChatboxHostStyleShortLabel } from "@/lib/chatbox-host-style";
 import { ChatTabV2 } from "@/components/ChatTabV2";
 import { getLoadingIndicatorVariantForHostStyle } from "@/components/chat-v2/shared/loading-indicator-content";
-import type { ServerWithName } from "@/hooks/use-app-state";
+import type {
+  EnsureServersReadyResult,
+  ServerWithName,
+} from "@/hooks/use-app-state";
 import { useHostedOAuthGate } from "@/hooks/hosted/use-hosted-oauth-gate";
 import type { HostedOAuthRequiredDetails } from "@/lib/hosted-oauth-required";
 import { isHostedOAuthBusy } from "@/lib/hosted-oauth-resume";
@@ -97,6 +100,16 @@ interface ChatboxBuilderViewProps {
   chatboxId?: string | null;
   draft: ChatboxDraftConfig | null;
   initialViewMode?: "setup" | "preview" | "usage" | "insights";
+  /**
+   * Reconnect the chatbox's MCP servers on the local inspector before the
+   * first preview message. Reuses the eval-tab helper from
+   * `useAppState.ensureServersReady` — without it, `prepareChatV2` in
+   * `/api/mcp/chat-v2` filters out unconnected servers and the LLM responds
+   * with zero MCP tools (e.g. ASCII drawings instead of an Excalidraw call).
+   */
+  ensureServersReady?: (
+    serverNames: string[],
+  ) => Promise<EnsureServersReadyResult>;
   onBack: () => void;
   onSavedDraft: (chatbox: ChatboxSettings) => void;
 }
@@ -292,6 +305,7 @@ export function ChatboxBuilderView({
   chatboxId,
   draft,
   initialViewMode,
+  ensureServersReady,
   onBack,
   onSavedDraft,
 }: ChatboxBuilderViewProps) {
@@ -739,6 +753,131 @@ export function ChatboxBuilderView({
     welcomeAvailable,
   });
 
+  // Auto-connect the chatbox's MCP servers on the inspector's local
+  // mcpClientManager before the first preview turn. Without this,
+  // prepareChatV2 in /api/mcp/chat-v2 filters out servers that aren't
+  // registered → the LLM gets zero tools → "draw a dog" returns ASCII
+  // art instead of an Excalidraw tool call. Mirrors the evals flow at
+  // EvalsTab.tsx:445 + use-eval-handlers.ts:653.
+  const activePreviewServerNames = useMemo(
+    () => activePreviewServers.map((s) => s.serverName),
+    [activePreviewServers]
+  );
+  const activePreviewServerNamesKey = useMemo(
+    () => activePreviewServerNames.slice().sort().join(""),
+    [activePreviewServerNames]
+  );
+  const [previewConnectStatus, setPreviewConnectStatus] = useState<{
+    phase: "idle" | "connecting" | "ready" | "blocked";
+    readyCount: number;
+    totalCount: number;
+    blockedReason?: string;
+  }>({ phase: "idle", readyCount: 0, totalCount: 0 });
+
+  useEffect(() => {
+    // Only run while the Preview tab is active. Switching to setup/usage
+    // shouldn't kick off reconnects (and the composer is hidden anyway).
+    if (viewMode !== "preview") {
+      return;
+    }
+    if (!ensureServersReady) {
+      // No helper plumbed (e.g. in tests or non-app shells). Treat as ready;
+      // the composer's other gates still apply.
+      setPreviewConnectStatus({
+        phase: "idle",
+        readyCount: activePreviewServerNames.length,
+        totalCount: activePreviewServerNames.length,
+      });
+      return;
+    }
+    if (activePreviewServerNames.length === 0) {
+      setPreviewConnectStatus({ phase: "ready", readyCount: 0, totalCount: 0 });
+      return;
+    }
+
+    let cancelled = false;
+    setPreviewConnectStatus((prev) => ({
+      phase: "connecting",
+      readyCount: prev.phase === "ready" ? prev.readyCount : 0,
+      totalCount: activePreviewServerNames.length,
+    }));
+
+    void (async () => {
+      try {
+        const result = await ensureServersReady(activePreviewServerNames);
+        if (cancelled) return;
+        const total = activePreviewServerNames.length;
+        const ready = result.readyServerNames.length;
+        if (result.reauthServerNames.length > 0) {
+          setPreviewConnectStatus({
+            phase: "blocked",
+            readyCount: ready,
+            totalCount: total,
+            blockedReason: `Reconnect ${result.reauthServerNames.join(", ")} to send messages.`,
+          });
+          return;
+        }
+        if (result.missingServerNames.length > 0) {
+          setPreviewConnectStatus({
+            phase: "blocked",
+            readyCount: ready,
+            totalCount: total,
+            blockedReason: `Add ${result.missingServerNames.join(", ")} to the project to send messages.`,
+          });
+          return;
+        }
+        if (result.failedServerNames.length > 0) {
+          setPreviewConnectStatus({
+            phase: "blocked",
+            readyCount: ready,
+            totalCount: total,
+            blockedReason: `Couldn't connect ${result.failedServerNames.join(", ")}. Retry from the Servers tab.`,
+          });
+          return;
+        }
+        setPreviewConnectStatus({
+          phase: "ready",
+          readyCount: ready,
+          totalCount: total,
+        });
+      } catch (error) {
+        if (cancelled) return;
+        setPreviewConnectStatus({
+          phase: "blocked",
+          readyCount: 0,
+          totalCount: activePreviewServerNames.length,
+          blockedReason:
+            error instanceof Error
+              ? error.message
+              : "Couldn't connect chatbox servers. Try again.",
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // Stable string key avoids reruns on activePreviewServerNames identity
+    // churn (the memo above produces a fresh array per render). viewMode
+    // gates the effect to the active Preview tab.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewMode, activePreviewServerNamesKey, ensureServersReady]);
+
+  const previewConnectComposerBlocked =
+    previewConnectStatus.phase === "connecting" ||
+    previewConnectStatus.phase === "blocked";
+  const previewConnectComposerReason =
+    previewConnectStatus.phase === "connecting"
+      ? "Connecting servers…"
+      : previewConnectStatus.phase === "blocked"
+        ? previewConnectStatus.blockedReason
+        : undefined;
+  const composerBlocked =
+    introGate.composerBlocked || previewConnectComposerBlocked;
+  const composerBlockedReason = introGate.composerBlocked
+    ? "Get started or authorize to send messages…"
+    : previewConnectComposerReason;
+
   const handlePreviewOAuthRequired = useCallback(
     (details?: HostedOAuthRequiredDetails) => {
       markOAuthRequired(details);
@@ -1174,10 +1313,10 @@ export function ChatboxBuilderView({
                                     draftChatboxConfig.hostStyle
                                   )}
                                   onOAuthRequired={handlePreviewOAuthRequired}
-                                  chatboxComposerBlocked={
-                                    introGate.composerBlocked
+                                  chatboxComposerBlocked={composerBlocked}
+                                  chatboxComposerBlockedReason={
+                                    composerBlockedReason ?? ""
                                   }
-                                  chatboxComposerBlockedReason="Get started or authorize to send messages…"
                                   chatboxOptionalInventory={selectedPreviewServers
                                     .filter(
                                       (s) =>
@@ -1242,7 +1381,11 @@ export function ChatboxBuilderView({
                             </div>
                             <div className="flex justify-between gap-2">
                               <dt className="text-muted-foreground">Servers</dt>
-                              <dd>{previewRailConfig.serverCount} connected</dd>
+                              <dd>
+                                {previewConnectStatus.totalCount > 0
+                                  ? `${previewConnectStatus.readyCount}/${previewConnectStatus.totalCount} connected`
+                                  : `${previewRailConfig.serverCount} configured`}
+                              </dd>
                             </div>
                             <div className="flex justify-between gap-2">
                               <dt className="text-muted-foreground">

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxBuilderView.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxBuilderView.test.tsx
@@ -396,6 +396,34 @@ describe("ChatboxBuilderView", () => {
     return (call?.[0] ?? {}) as Record<string, unknown>;
   }
 
+  it("blocks the composer on the first preview render before ensureServersReady fires", () => {
+    // Regression: useState initializer must seed `connecting` so the
+    // composer doesn't accept input for one frame before the reconnect
+    // effect runs (`useEffect` runs after the first paint).
+    const chatbox = createSavedChatboxWithServer();
+    mockUseChatbox.mockReturnValue({ chatbox });
+    const ensureServersReady = vi
+      .fn()
+      .mockReturnValue(new Promise(() => {}));
+
+    render(
+      <ChatboxBuilderView
+        projectId="ws-1"
+        projectServers={[httpsServer]}
+        chatboxId={chatbox.chatboxId}
+        initialViewMode="preview"
+        ensureServersReady={ensureServersReady}
+        onBack={() => {}}
+        onSavedDraft={() => {}}
+      />,
+    );
+
+    const firstCall = mockChatTabV2.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(firstCall?.chatboxComposerBlocked).toBe(true);
+  });
+
   it("calls ensureServersReady with the configured server names on Preview open", async () => {
     const chatbox = createSavedChatboxWithServer();
     mockUseChatbox.mockReturnValue({ chatbox });

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxBuilderView.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxBuilderView.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import type { ChatboxSettings } from "@/hooks/useChatboxes";
 import { ChatboxBuilderView } from "../ChatboxBuilderView";
 import { CHATBOX_STARTERS, toDraftConfig } from "../drafts";
@@ -369,5 +369,121 @@ describe("ChatboxBuilderView", () => {
         loadingIndicatorVariant: "claude-mark",
       }),
     );
+  });
+
+  // Auto-connect: the builder Preview tab reuses the eval-style
+  // ensureServersReady so the local mcpClientManager actually has the
+  // chatbox's servers registered before the first message.
+  function createSavedChatboxWithServer(): ChatboxSettings {
+    const base = createSavedChatbox("claude");
+    return {
+      ...base,
+      servers: [
+        {
+          serverId: httpsServer._id,
+          serverName: httpsServer.name,
+          useOAuth: false,
+          serverUrl: httpsServer.url,
+          clientId: null,
+          oauthScopes: null,
+        },
+      ],
+    };
+  }
+
+  function lastChatTabProps(): Record<string, unknown> {
+    const call = mockChatTabV2.mock.calls.at(-1);
+    return (call?.[0] ?? {}) as Record<string, unknown>;
+  }
+
+  it("calls ensureServersReady with the configured server names on Preview open", async () => {
+    const chatbox = createSavedChatboxWithServer();
+    mockUseChatbox.mockReturnValue({ chatbox });
+    const ensureServersReady = vi.fn().mockResolvedValue({
+      readyServerNames: [httpsServer.name],
+      missingServerNames: [],
+      failedServerNames: [],
+      reauthServerNames: [],
+    });
+
+    render(
+      <ChatboxBuilderView
+        projectId="ws-1"
+        projectServers={[httpsServer]}
+        chatboxId={chatbox.chatboxId}
+        initialViewMode="preview"
+        ensureServersReady={ensureServersReady}
+        onBack={() => {}}
+        onSavedDraft={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(ensureServersReady).toHaveBeenCalledWith([httpsServer.name]);
+    });
+    // Eventually unblocks the composer once the helper resolves.
+    await waitFor(() => {
+      expect(lastChatTabProps().chatboxComposerBlocked).toBe(false);
+    });
+  });
+
+  it("keeps the composer blocked with a reauth reason when ensureServersReady reports reauth", async () => {
+    const chatbox = createSavedChatboxWithServer();
+    mockUseChatbox.mockReturnValue({ chatbox });
+    const ensureServersReady = vi.fn().mockResolvedValue({
+      readyServerNames: [],
+      missingServerNames: [],
+      failedServerNames: [],
+      reauthServerNames: [httpsServer.name],
+    });
+
+    render(
+      <ChatboxBuilderView
+        projectId="ws-1"
+        projectServers={[httpsServer]}
+        chatboxId={chatbox.chatboxId}
+        initialViewMode="preview"
+        ensureServersReady={ensureServersReady}
+        onBack={() => {}}
+        onSavedDraft={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(lastChatTabProps().chatboxComposerBlocked).toBe(true);
+    });
+    expect(lastChatTabProps().chatboxComposerBlockedReason).toContain(
+      "Reconnect",
+    );
+    expect(lastChatTabProps().chatboxComposerBlockedReason).toContain(
+      httpsServer.name,
+    );
+  });
+
+  it("does not invoke ensureServersReady while in setup mode", async () => {
+    const chatbox = createSavedChatboxWithServer();
+    mockUseChatbox.mockReturnValue({ chatbox });
+    const ensureServersReady = vi.fn().mockResolvedValue({
+      readyServerNames: [httpsServer.name],
+      missingServerNames: [],
+      failedServerNames: [],
+      reauthServerNames: [],
+    });
+
+    render(
+      <ChatboxBuilderView
+        projectId="ws-1"
+        projectServers={[httpsServer]}
+        chatboxId={chatbox.chatboxId}
+        initialViewMode="setup"
+        ensureServersReady={ensureServersReady}
+        onBack={() => {}}
+        onSavedDraft={() => {}}
+      />,
+    );
+
+    // Flush any pending microtasks before asserting absence.
+    await Promise.resolve();
+    expect(ensureServersReady).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Thread `useAppState.ensureServersReady` (the eval-tab helper at `client/src/hooks/use-server-state.ts:3042`) through `ChatboxesTab → ChatboxBuilderExperience → ChatboxBuilderView`.
- On Preview activation, call it with the chatbox's required + active-optional server names. Block the composer with "Connecting servers…" while pending; surface structured outcomes (`reauthServerNames` / `missingServerNames` / `failedServerNames`) via `chatboxComposerBlockedReason`.
- Replace the side rail's static `serverCount + " connected"` lie with truthful `ready/total connected` once the helper resolves.

## Problem
The Preview pane fabricates `connectionStatus: "connected"` for its `chatboxServerConfigs` purely to satisfy ChatTabV2's UI gating (see `ChatboxBuilderView.tsx:699-718`). Nothing actually registers the chatbox's MCP servers on the local `mcpClientManager`. Server-side, `prepareChatV2` filters out unregistered servers via `mcpClientManager.hasServer(id)` → the LLM gets zero MCP tools → "draw a dog" against the Excalidraw demo returns ASCII art instead of an Excalidraw tool call.

Evals solve the same problem the same way (`EvalsTab.tsx:445` + `use-eval-handlers.ts:653`). This PR just reuses that helper unchanged on the preview path.

## Test plan
- [x] `npx vitest run client/src/components/chatboxes/builder/__tests__/ChatboxBuilderView.test.tsx` — 14/14 (3 new + 11 pre-existing):
  - `ensureServersReady` is invoked with the configured server names when Preview opens
  - composer stays blocked with a "Reconnect…" reason when the helper reports `reauthServerNames`
  - effect is a no-op while in setup mode
- [ ] Manual end-to-end: open a fresh project with the Excalidraw server configured but NOT connected on the Servers tab. Open the chatbox builder Preview tab → expect the composer to briefly show "Connecting servers…", the rail to flip to "1/1 connected", and "draw a dog" to trigger a real Excalidraw tool call.
- [ ] Manual: disconnect the server mid-preview → composer should reblock until reconnected.
- [ ] Manual: OAuth-gated server (e.g. Linear) → composer should show the reauth prompt instead of attempting to chat.

## Companion PR
Backend resolver fix for the related `Chatbox access denied or revoked` /ingest-chat error: MCPJam/mcpjam-backend#247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds async server-reconnect gating to the chatbox preview composer and surfaces new blocked states/reasons, which could impact UX or leave preview stuck if edge cases aren’t handled. Uses an existing `ensureServersReady` helper, limiting scope but touching core preview flow.
> 
> **Overview**
> Chatbox builder Preview now **auto-connects the chatbox’s configured MCP servers before the first message** by threading `useAppState.ensureServersReady` from `App` → `ChatboxesTab` → `ChatboxBuilderExperience` → `ChatboxBuilderView`.
> 
> While reconnect is pending, the Preview composer is **blocked with “Connecting servers…”**, and structured outcomes (`reauth`/`missing`/`failed`) are surfaced as `chatboxComposerBlockedReason`; the preview side rail also switches from a static server count to **`ready/total connected`**. Tests were updated/added to mock Convex/hooks and verify the new Preview reconnect + blocking behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3035567b91c76146eff31d229d2de538eb6d9997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->