### PR TITLE
Codex/local org byok unification

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -87,7 +87,10 @@ import {
 import { useProjectServers } from "@/hooks/useViews";
 import { HOSTED_MODE } from "@/lib/config";
 import { buildOAuthTokensByServerId } from "@/lib/oauth/oauth-tokens";
-import type { OrgModelProvider } from "@/hooks/use-org-model-config";
+import {
+  canReadOrgModelConfig,
+  type OrgModelProvider,
+} from "@/hooks/use-org-model-config";
 import { useOpenOrgModels } from "@/hooks/use-open-org-models";
 import type { HostedOAuthRequiredDetails } from "@/lib/hosted-oauth-required";
 import type { EvalChatHandoff } from "@/lib/eval-chat-handoff";
@@ -292,9 +295,21 @@ export function ChatTabV2({
     activeProject?.sharedProjectId ??
     (activeProject?.organizationId ? appState.activeProjectId : null);
   const organizationId = activeProject?.organizationId ?? null;
+  const visibleOrganizations = useQuery(
+    "organizations:getMyOrganizations" as any,
+    isConvexAuthenticated ? ({} as any) : "skip",
+  ) as Array<{ _id: string; myRole?: string }> | undefined;
+  const visibleOrganization = visibleOrganizations?.find(
+    (organization) => organization._id === organizationId,
+  );
+  const canQueryOrgModelConfig = Boolean(
+    isConvexAuthenticated &&
+      organizationId &&
+      canReadOrgModelConfig(visibleOrganization?.myRole),
+  );
   const hostedOrgModelConfig = useQuery(
     "organizationModelProviders:getVisibleConfig" as any,
-    isConvexAuthenticated && organizationId
+    canQueryOrgModelConfig && organizationId
       ? ({ organizationId } as any)
       : "skip",
   ) as { providers: OrgModelProvider[] } | undefined;
@@ -321,16 +336,12 @@ export function ChatTabV2({
   const hostedChatboxToken = hostedContext?.chatboxToken;
   const hostedChatboxSurface = hostedContext?.chatboxSurface;
   const effectiveHostedProjectId =
-    hostedProjectIdOverride ?? hostedContext?.projectId ?? convexProjectId;
+    hostedContext?.projectId ?? convexProjectId;
   const effectiveHostedSelectedServerIds =
-    hostedSelectedServerIdsOverride ??
-    hostedContext?.selectedServerIds ??
-    hostedSelectedServerIds;
+    hostedContext?.selectedServerIds ?? hostedSelectedServerIds;
   const effectiveHostedOAuthTokens = hostedChatboxToken
     ? undefined
-    : (hostedOAuthTokensOverride ??
-      hostedContext?.oauthTokens ??
-      hostedOAuthTokens);
+    : (hostedContext?.oauthTokens ?? hostedOAuthTokens);
   const isHostedDirectGuest =
     HOSTED_MODE &&
     !isConvexAuthenticated &&
@@ -2257,6 +2268,7 @@ export function ChatTabV2({
                             temperature,
                             requireToolApproval,
                           }}
+                          hostedOrgModelConfig={hostedOrgModelConfig}
                           hostedContext={{
                             ...hostedContext,
                             projectId: effectiveHostedProjectId,

--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
@@ -7,6 +7,25 @@ const mockToastError = vi.hoisted(() => vi.fn());
 const mockGetChatHistoryDetail = vi.hoisted(() => vi.fn());
 const mockChatHistoryAction = vi.hoisted(() => vi.fn());
 const mockUseFeatureFlagEnabled = vi.hoisted(() => vi.fn(() => true));
+const mockVisibleOrganizationsRef = vi.hoisted(() => ({
+  current: [] as Array<{ _id: string; myRole?: string }>,
+}));
+const mockOrgModelConfigQuery = vi.hoisted(() => vi.fn());
+const mockAppStateRef = vi.hoisted(() => ({
+  current: {
+    servers: {
+      "server-1": {
+        connectionStatus: "connected",
+      },
+    },
+    projects: {
+      "project-1": {
+        sharedProjectId: "project-1",
+      },
+    },
+    activeProjectId: "project-1",
+  } as any,
+}));
 const mockReactiveHistoryState = vi.hoisted(() => ({
   session: undefined as any,
   widgetSnapshots: undefined as any,
@@ -66,6 +85,13 @@ vi.mock("convex/react", () => ({
     if (args === "skip") {
       return undefined;
     }
+    if (name === "organizations:getMyOrganizations") {
+      return mockVisibleOrganizationsRef.current;
+    }
+    if (name === "organizationModelProviders:getVisibleConfig") {
+      mockOrgModelConfigQuery(args);
+      return { providers: [] };
+    }
     if (name === "directChatHistory:getCurrentSession") {
       return mockReactiveHistoryState.session;
     }
@@ -124,19 +150,7 @@ vi.mock("@/lib/oauth/oauth-tokens", () => ({
 }));
 
 vi.mock("@/state/app-state-context", () => ({
-  useSharedAppState: () => ({
-    servers: {
-      "server-1": {
-        connectionStatus: "connected",
-      },
-    },
-    projects: {
-      "project-1": {
-        sharedProjectId: "project-1",
-      },
-    },
-    activeProjectId: "project-1",
-  }),
+  useSharedAppState: () => mockAppStateRef.current,
 }));
 
 vi.mock("@/components/ui/resizable", () => ({
@@ -421,6 +435,20 @@ describe("ChatTabV2 history sync", () => {
     );
     chatSessionOnResetRef.current = undefined;
     lastUseChatSessionOptionsRef.current = undefined;
+    mockVisibleOrganizationsRef.current = [];
+    mockAppStateRef.current = {
+      servers: {
+        "server-1": {
+          connectionStatus: "connected",
+        },
+      },
+      projects: {
+        "project-1": {
+          sharedProjectId: "project-1",
+        },
+      },
+      activeProjectId: "project-1",
+    };
     mockReactiveHistoryState.session = undefined;
     mockReactiveHistoryState.widgetSnapshots = undefined;
     Object.assign(mockUseChatSession, {
@@ -459,6 +487,50 @@ describe("ChatTabV2 history sync", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.useRealTimers();
+  });
+
+  it("queries org model config for organization guests", () => {
+    mockAppStateRef.current = {
+      ...mockAppStateRef.current,
+      projects: {
+        "project-1": {
+          _id: "project-1",
+          organizationId: "org-1",
+        },
+      },
+    };
+    mockVisibleOrganizationsRef.current = [{ _id: "org-1", myRole: "guest" }];
+
+    render(<ChatTabV2 {...defaultProps} />);
+
+    expect(mockOrgModelConfigQuery).toHaveBeenCalledWith({
+      organizationId: "org-1",
+    });
+    expect(lastUseChatSessionOptionsRef.current?.hostedOrgModelConfig).toEqual({
+      providers: [],
+    });
+  });
+
+  it("queries org model config for organization members", () => {
+    mockAppStateRef.current = {
+      ...mockAppStateRef.current,
+      projects: {
+        "project-1": {
+          _id: "project-1",
+          organizationId: "org-1",
+        },
+      },
+    };
+    mockVisibleOrganizationsRef.current = [{ _id: "org-1", myRole: "member" }];
+
+    render(<ChatTabV2 {...defaultProps} />);
+
+    expect(mockOrgModelConfigQuery).toHaveBeenCalledWith({
+      organizationId: "org-1",
+    });
+    expect(lastUseChatSessionOptionsRef.current?.hostedOrgModelConfig).toEqual({
+      providers: [],
+    });
   });
 
   it("suppresses hosted OAuth token fallback for chatbox contexts", () => {

--- a/mcpjam-inspector/client/src/components/__tests__/SettingsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/SettingsTab.test.tsx
@@ -71,7 +71,7 @@ describe("SettingsTab", () => {
     expect(
       screen.getByRole("switch", { name: "Toggle dark mode" }),
     ).toBeInTheDocument();
-    expect(screen.queryByText("LLM Providers")).not.toBeInTheDocument();
+    expect(screen.getByText("LLM Providers")).toBeInTheDocument();
   });
 
   it("updates theme when toggled", async () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/multi-model-chat-card.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/multi-model-chat-card.tsx
@@ -17,6 +17,7 @@ import {
   cloneUiMessages,
   formatErrorMessage,
 } from "@/components/chat-v2/shared/chat-helpers";
+import type { OrgVisibleConfig } from "@/components/chat-v2/shared/model-helpers";
 import { useChatSession } from "@/hooks/use-chat-session";
 import { getChatComposerInteractivity } from "@/hooks/use-chat-stop-controls";
 import type { ModelDefinition } from "@/shared/types";
@@ -47,6 +48,9 @@ interface MultiModelChatCardProps {
   placeholder: string;
   reasoningDisplayMode: ReasoningDisplayMode;
   executionConfig: ExecutionConfig;
+  /** Org-managed BYOK provider config — forwarded to useChatSession so each
+   * compare card sees the same models as the single-model picker. */
+  hostedOrgModelConfig?: OrgVisibleConfig;
   hostedContext?: HostedRuntimeContext;
   onSummaryChange: (summary: MultiModelCardSummary) => void;
   onHasMessagesChange?: (modelId: string, hasMessages: boolean) => void;
@@ -71,6 +75,7 @@ export function MultiModelChatCard({
   placeholder,
   reasoningDisplayMode,
   executionConfig,
+  hostedOrgModelConfig,
   hostedContext,
   onSummaryChange,
   onHasMessagesChange,
@@ -121,6 +126,7 @@ export function MultiModelChatCard({
     startChatWithMessages,
   } = useChatSession({
     selectedServers,
+    hostedOrgModelConfig,
     hostedContext,
     executionConfig: {
       ...executionConfig,

--- a/mcpjam-inspector/client/src/components/chat-v2/shared/model-helpers.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/shared/model-helpers.ts
@@ -146,11 +146,11 @@ export const getDefaultModel = (
     "anthropic/claude-haiku-4.5",
     "openai/gpt-5-mini",
     "meta-llama/llama-4-scout",
-    Model.CLAUDE_3_7_SONNET_LATEST, // anthropic
+    Model.CLAUDE_SONNET_4_6, // anthropic (was 3.7-sonnet, retired 2026-02-19)
     Model.GPT_4_1, // openai
     Model.GEMINI_2_5_PRO, // google
-    Model.DEEPSEEK_CHAT, // deepseek
-    Model.MISTRAL_LARGE_LATEST, // mistral
+    Model.DEEPSEEK_V4_FLASH, // deepseek (was deepseek-chat, deprecating)
+    Model.MISTRAL_LARGE_3, // mistral (was mistral-large-latest)
   ];
 
   for (const id of modelIdsByPriority) {

--- a/mcpjam-inspector/client/src/components/organization/OrganizationModelsSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationModelsSection.tsx
@@ -103,6 +103,33 @@ const PROVIDER_CATALOG: ProviderCatalogEntry[] = [
     logo: "/mistral_logo.png",
   },
   { key: "xai", name: "xAI", kind: "api-key-only", logo: "/xai_logo.png" },
+  // OpenAI-compatible providers — admin only supplies an API key, the
+  // baseURL is hardcoded server-side in convex/stream/buildOrgModel.ts and
+  // mirrored in mcpjam-inspector/server/utils/chat-helpers.ts.
+  {
+    key: "moonshotai",
+    name: "Moonshot (Kimi)",
+    kind: "api-key-only",
+    logo: "/moonshot_light.png",
+  },
+  {
+    key: "z-ai",
+    name: "Z.AI (GLM)",
+    kind: "api-key-only",
+    logo: "/z-ai.png",
+  },
+  {
+    key: "qwen",
+    name: "Qwen",
+    kind: "api-key-only",
+    logo: "/qwen_logo.png",
+  },
+  {
+    key: "minimax",
+    name: "MiniMax",
+    kind: "api-key-only",
+    logo: "/minimax_logo.svg",
+  },
   {
     key: "azure",
     name: "Azure OpenAI",

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -83,7 +83,8 @@ import { useSharedAppState } from "@/state/app-state-context";
 import { Settings2 } from "lucide-react";
 import { ToolRenderOverride } from "@/components/chat-v2/thread/tool-render-overrides";
 import type { LoadingIndicatorVariant } from "@/components/chat-v2/shared/loading-indicator-content";
-import { useConvexAuth } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
+import type { OrgModelProvider } from "@/hooks/use-org-model-config";
 import { useProjectServers } from "@/hooks/useViews";
 import { buildOAuthTokensByServerId } from "@/lib/oauth/oauth-tokens";
 import { useHostContextStore } from "@/stores/host-context-store";
@@ -354,6 +355,17 @@ export function PlaygroundMain({
   const convexProjectId =
     activeProject?.sharedProjectId ??
     (activeProject?.organizationId ? appState.activeProjectId : null);
+  const organizationId = activeProject?.organizationId ?? null;
+  // Fetch org-managed BYOK provider config so the playground model picker
+  // surfaces the same models as ChatTabV2. Without this, an org-invited
+  // user opening App Builder would only see MCPJam-provided models even
+  // though their org admin has configured Anthropic / OpenAI / etc.
+  const hostedOrgModelConfig = useQuery(
+    "organizationModelProviders:getVisibleConfig" as any,
+    isConvexAuthenticated && organizationId
+      ? ({ organizationId } as any)
+      : "skip",
+  ) as { providers: OrgModelProvider[] } | undefined;
   const { serversByName } = useProjectServers({
     isAuthenticated: isConvexAuthenticated,
     projectId: convexProjectId,
@@ -415,6 +427,7 @@ export function PlaygroundMain({
     addToolApprovalResponse,
   } = useChatSession({
     selectedServers,
+    hostedOrgModelConfig,
     hostedContext: {
       projectId: convexProjectId,
       selectedServerIds: hostedSelectedServerIds,
@@ -1663,6 +1676,7 @@ export function PlaygroundMain({
                         temperature,
                         requireToolApproval,
                       }}
+                      hostedOrgModelConfig={hostedOrgModelConfig}
                       hostedContext={{
                         projectId: convexProjectId,
                         selectedServerIds: hostedSelectedServerIds,

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -143,6 +143,9 @@ vi.mock("convex/react", () => ({
     isAuthenticated: false,
     isLoading: false,
   }),
+  // useQuery used to fetch organizationModelProviders:getVisibleConfig.
+  // Tests don't exercise org BYOK so returning undefined is fine.
+  useQuery: () => undefined,
 }));
 
 // Mock useViews (useProjectServers)

--- a/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
@@ -13,6 +13,7 @@ import {
   cloneUiMessages,
   formatErrorMessage,
 } from "@/components/chat-v2/shared/chat-helpers";
+import type { OrgVisibleConfig } from "@/components/chat-v2/shared/model-helpers";
 import type { ToolRenderOverride } from "@/components/chat-v2/thread/tool-render-overrides";
 import {
   type MultiModelCardSummary,
@@ -91,6 +92,9 @@ interface MultiModelPlaygroundCardProps {
   stopRequestId: number;
   reasoningDisplayMode?: ReasoningDisplayMode;
   executionConfig: ExecutionConfig;
+  /** Org-managed BYOK provider config — forwarded to useChatSession so each
+   * compare card sees the same models as ChatTabV2 / PlaygroundMain. */
+  hostedOrgModelConfig?: OrgVisibleConfig;
   hostedContext?: HostedRuntimeContext;
   displayMode: DisplayMode;
   onDisplayModeChange: (mode: DisplayMode) => void;
@@ -125,6 +129,7 @@ export function MultiModelPlaygroundCard({
   stopRequestId,
   reasoningDisplayMode = "inline",
   executionConfig,
+  hostedOrgModelConfig,
   hostedContext,
   displayMode,
   onDisplayModeChange,
@@ -191,6 +196,7 @@ export function MultiModelPlaygroundCard({
     startChatWithMessages,
   } = useChatSession({
     selectedServers,
+    hostedOrgModelConfig,
     hostedContext,
     executionConfig: {
       ...executionConfig,

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-app-ready.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-app-ready.test.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AppReadyProvider, useAppReady } from "@/hooks/use-app-ready";
+
+vi.mock("@/lib/config", () => ({
+  HOSTED_MODE: false,
+}));
+
+function renderAppReady(props: {
+  isLoadingAppState?: boolean;
+  isConvexAuthLoading?: boolean;
+  isConvexAuthenticated?: boolean;
+  effectiveActiveProjectId?: string;
+  isLoadingRemoteProjects?: boolean;
+}) {
+  return renderHook(() => useAppReady(), {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <AppReadyProvider
+        isLoadingAppState={props.isLoadingAppState ?? false}
+        isConvexAuthLoading={props.isConvexAuthLoading ?? false}
+        isConvexAuthenticated={props.isConvexAuthenticated ?? false}
+        effectiveActiveProjectId={props.effectiveActiveProjectId ?? "local"}
+        isLoadingRemoteProjects={props.isLoadingRemoteProjects ?? false}
+      >
+        {children}
+      </AppReadyProvider>
+    ),
+  });
+}
+
+describe("AppReadyProvider", () => {
+  it("keeps non-hosted local mode ready without Convex auth or remote projects", () => {
+    const { result } = renderAppReady({
+      isConvexAuthenticated: false,
+      effectiveActiveProjectId: "local-project",
+      isLoadingRemoteProjects: false,
+    });
+
+    expect(result.current).toEqual({
+      status: "ready",
+      projectId: "local-project",
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-available-eval-models.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-available-eval-models.test.tsx
@@ -6,22 +6,17 @@ const {
   mockBuildAvailableModelsFromOrgConfig,
   mockDetectOllamaModels,
   mockDetectOllamaToolCapableModels,
+  mockUseQuery,
 } = vi.hoisted(() => ({
   mockBuildAvailableModelsFromOrgConfig: vi.fn(),
   mockDetectOllamaModels: vi.fn(),
   mockDetectOllamaToolCapableModels: vi.fn(),
+  mockUseQuery: vi.fn(),
 }));
 
 vi.mock("convex/react", () => ({
   useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
-  useQuery: () => ({
-    providers: [
-      {
-        providerKey: "openai",
-        enabled: true,
-      },
-    ],
-  }),
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
 }));
 
 vi.mock("@/state/app-state-context", () => ({
@@ -56,6 +51,23 @@ vi.mock("@/components/chat-v2/shared/model-helpers", () => ({
 describe("useAvailableEvalModels", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseQuery.mockImplementation((name: string, args: unknown) => {
+      if (args === "skip") return undefined;
+      if (name === "organizations:getMyOrganizations") {
+        return [{ _id: "org-1", myRole: "member" }];
+      }
+      if (name === "organizationModelProviders:getVisibleConfig") {
+        return {
+          providers: [
+            {
+              providerKey: "openai",
+              enabled: true,
+            },
+          ],
+        };
+      }
+      return undefined;
+    });
     mockDetectOllamaModels.mockResolvedValue({
       isRunning: true,
       availableModels: ["llama3.2"],
@@ -96,6 +108,54 @@ describe("useAvailableEvalModels", () => {
     expect(mockDetectOllamaToolCapableModels).toHaveBeenCalledWith(
       "http://127.0.0.1:11434/api"
     );
+    expect(mockBuildAvailableModelsFromOrgConfig).toHaveBeenCalledWith({
+      providers: [
+        {
+          providerKey: "openai",
+          enabled: true,
+        },
+      ],
+    });
+  });
+
+  it("queries org model config for org guests", async () => {
+    mockUseQuery.mockImplementation((name: string, args: unknown) => {
+      if (args === "skip") return undefined;
+      if (name === "organizations:getMyOrganizations") {
+        return [{ _id: "org-1", myRole: "guest" }];
+      }
+      if (name === "organizationModelProviders:getVisibleConfig") {
+        return {
+          providers: [
+            {
+              providerKey: "openai",
+              enabled: true,
+            },
+          ],
+        };
+      }
+      return undefined;
+    });
+
+    const { result } = renderHook(() => useAvailableEvalModels());
+
+    await waitFor(() => {
+      expect(result.current.availableModels).toEqual([
+        {
+          id: "openai/gpt-5-mini",
+          name: "GPT-5 mini",
+          provider: "openai",
+        },
+        {
+          id: "llama3.2",
+          name: "llama3.2",
+          provider: "ollama",
+          disabled: false,
+          disabledReason: undefined,
+        },
+      ]);
+    });
+
     expect(mockBuildAvailableModelsFromOrgConfig).toHaveBeenCalledWith({
       providers: [
         {

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.fork.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.fork.test.tsx
@@ -49,7 +49,7 @@ vi.mock("@/lib/config", () => ({
 }));
 
 vi.mock("@/components/chat-v2/shared/model-helpers", () => ({
-  buildAvailableModels: vi.fn(() => [baseModel]),
+  buildAvailableModelsFromOrgConfig: vi.fn(() => [baseModel]),
   getDefaultModel: vi.fn(() => baseModel),
 }));
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
@@ -88,14 +88,6 @@ vi.mock("@/lib/config", () => ({
 }));
 
 vi.mock("@/components/chat-v2/shared/model-helpers", () => ({
-  buildAvailableModels: vi.fn(() => [
-    gatedAnthropicModel,
-    gatedGoogleModel,
-    gatedOpenAiModel,
-    allowedHostedModel,
-    allowedOpenAiModel,
-    guestModel,
-  ]),
   buildAvailableModelsFromOrgConfig: vi.fn((orgConfig) =>
     orgConfig
       ? [

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.live-trace.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.live-trace.test.tsx
@@ -54,10 +54,11 @@ function tracePart(data: unknown) {
 
 vi.mock("@/lib/config", () => ({
   HOSTED_MODE: false,
+  NON_PROD_LOCKDOWN: false,
 }));
 
 vi.mock("@/components/chat-v2/shared/model-helpers", () => ({
-  buildAvailableModels: vi.fn(() => [mcpJamModel]),
+  buildAvailableModelsFromOrgConfig: vi.fn(() => [mcpJamModel]),
   getDefaultModel: vi.fn(() => mcpJamModel),
 }));
 
@@ -109,6 +110,10 @@ vi.mock("@/lib/apis/mcp-tokenizer-api", () => ({
 vi.mock("@/lib/session-token", () => ({
   authFetch: vi.fn(),
   getAuthHeaders: vi.fn(() => ({})),
+}));
+
+vi.mock("@/lib/guest-session", () => ({
+  getGuestBearerToken: vi.fn(async () => null),
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-project-state.test.tsx
@@ -1023,6 +1023,40 @@ describe("useProjectState automatic project creation", () => {
     );
   });
 
+  it("filters stale local org projects that the signed-in actor cannot access", async () => {
+    projectQueryState.allProjects = [];
+    projectQueryState.projects = [];
+
+    const appState = createAppState({
+      "stale-org-project": createLocalProject("stale-org-project", {
+        organizationId: "org-stale",
+      }),
+      "local-live-org-project": createLocalProject("local-live-org-project", {
+        organizationId: "org-live",
+      }),
+    });
+
+    const { result } = renderUseProjectState({
+      appState,
+      activeOrganizationId: "org-live",
+      hasOrganizations: true,
+      isLoadingOrganizations: false,
+      validOrganizationIds: ["org-live"],
+    });
+
+    await waitFor(() => {
+      expect(result.current.effectiveProjects).not.toHaveProperty(
+        "stale-org-project",
+      );
+      expect(result.current.effectiveProjects).toHaveProperty(
+        "local-live-org-project",
+      );
+      expect(result.current.effectiveActiveProjectId).toBe(
+        "local-live-org-project",
+      );
+    });
+  });
+
   it("does not migrate local projects from another org into the current organization", async () => {
     projectQueryState.allProjects = [];
     projectQueryState.projects = [];

--- a/mcpjam-inspector/client/src/hooks/use-app-ready.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-ready.ts
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import type { AppReadyStatus } from "@/lib/app-ready";
+import { HOSTED_MODE } from "@/lib/config";
 
 /**
  * Single source of truth for "is this app ready to dispatch a request?".
@@ -95,6 +96,15 @@ export function AppReadyProvider({
     }
     if (isLoadingAppState) {
       return { status: "bootstrapping", reason: "loading-app-state" };
+    }
+    if (!HOSTED_MODE) {
+      return {
+        status: "ready",
+        projectId:
+          effectiveActiveProjectId && effectiveActiveProjectId !== "none"
+            ? effectiveActiveProjectId
+            : null,
+      };
     }
     if (isConvexAuthLoading || !isConvexAuthenticated) {
       return { status: "bootstrapping", reason: "resolving-auth" };

--- a/mcpjam-inspector/client/src/hooks/use-available-eval-models.ts
+++ b/mcpjam-inspector/client/src/hooks/use-available-eval-models.ts
@@ -11,16 +11,33 @@ import {
   buildAvailableModelsFromOrgConfig,
   type OrgVisibleConfig,
 } from "@/components/chat-v2/shared/model-helpers";
-import type { OrgModelProvider } from "@/hooks/use-org-model-config";
+import {
+  canReadOrgModelConfig,
+  type OrgModelProvider,
+} from "@/hooks/use-org-model-config";
 
 export function useAvailableEvalModels() {
   const { isAuthenticated } = useConvexAuth();
   const appState = useSharedAppState();
   const activeProject = appState.projects[appState.activeProjectId];
   const organizationId = activeProject?.organizationId ?? null;
+  const visibleOrganizations = useQuery(
+    "organizations:getMyOrganizations" as any,
+    isAuthenticated ? ({} as any) : "skip",
+  ) as Array<{ _id: string; myRole?: string }> | undefined;
+  const visibleOrganization = visibleOrganizations?.find(
+    (organization) => organization._id === organizationId,
+  );
+  const canQueryOrgModelConfig = Boolean(
+    isAuthenticated &&
+      organizationId &&
+      canReadOrgModelConfig(visibleOrganization?.myRole),
+  );
   const orgModelConfig = useQuery(
     "organizationModelProviders:getVisibleConfig" as any,
-    isAuthenticated && organizationId ? ({ organizationId } as any) : "skip",
+    canQueryOrgModelConfig && organizationId
+      ? ({ organizationId } as any)
+      : "skip",
   ) as { providers: OrgModelProvider[] } | undefined;
   const { getOllamaBaseUrl } = useOllamaConfig();
   const [ollamaModels, setOllamaModels] = useState<ModelDefinition[]>([]);

--- a/mcpjam-inspector/client/src/hooks/use-org-model-config.ts
+++ b/mcpjam-inspector/client/src/hooks/use-org-model-config.ts
@@ -29,6 +29,15 @@ export interface OrgModelConfigResult {
   error: string | null;
 }
 
+export function canReadOrgModelConfig(role: string | undefined): boolean {
+  return (
+    role === "owner" ||
+    role === "admin" ||
+    role === "member" ||
+    role === "guest"
+  );
+}
+
 export interface OrgModelUsageAggregate {
   key: string;
   requestCount: number;

--- a/mcpjam-inspector/client/src/hooks/use-project-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-project-state.ts
@@ -396,6 +396,11 @@ export function useProjectState({
     );
   }, [remoteProjects, resolvedActiveProjectIdForServers, activeProjectServersFlat]);
 
+  const validOrganizationIdSet = useMemo(
+    () => new Set(validOrganizationIds),
+    [validOrganizationIds],
+  );
+
   useEffect(() => {
     if (pendingClientConfigSyncRef.current.size === 0) {
       return;
@@ -417,16 +422,30 @@ export function useProjectState({
   }, [clearPendingClientConfigSync, convexProjects]);
 
   const scopedLocalProjects = useMemo((): Record<string, Project> => {
-    if (!shouldScopeLocalFallbackByOrganization) {
-      return appState.projects;
-    }
-
     return Object.fromEntries(
-      Object.entries(appState.projects).filter(
-        ([, project]) => project.organizationId === projectOrganizationId,
-      ),
+      Object.entries(appState.projects).filter(([, project]) => {
+        if (
+          isAuthenticated &&
+          project.organizationId &&
+          !validOrganizationIdSet.has(project.organizationId)
+        ) {
+          return false;
+        }
+
+        if (!shouldScopeLocalFallbackByOrganization) {
+          return true;
+        }
+
+        return project.organizationId === projectOrganizationId;
+      }),
     );
-  }, [appState.projects, shouldScopeLocalFallbackByOrganization, projectOrganizationId]);
+  }, [
+    appState.projects,
+    isAuthenticated,
+    projectOrganizationId,
+    shouldScopeLocalFallbackByOrganization,
+    validOrganizationIdSet,
+  ]);
 
   // Legacy fallback memo. Convex is the only source of truth post-unification;
   // `useLocalFallback` is permanently false. Kept as a stable empty/identity

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -546,9 +546,7 @@ describe("POST /api/mcp/chat-v2", () => {
       capturedOnError = undefined;
     });
 
-    async function getOnError(
-      _provider: string
-    ): Promise<(error: unknown) => string> {
+    async function getOnError(): Promise<(error: unknown) => string> {
       await postJson(app, "/api/mcp/chat-v2", {
         messages: [{ role: "user", content: "Hello" }],
         model: { id: "llama3.2", name: "Llama 3.2", provider: "ollama" },
@@ -559,8 +557,8 @@ describe("POST /api/mcp/chat-v2", () => {
       return capturedOnError!;
     }
 
-    it("returns normalized message for 401 APICallError from OpenAI", async () => {
-      const onError = await getOnError("openai");
+    it("normalizes OpenAI-shaped 401 APICallErrors for the active Ollama provider", async () => {
+      const onError = await getOnError();
       const error = new APICallError({
         message: "Incorrect API key provided: sk-proj-...",
         url: "https://api.openai.com/v1/chat/completions",
@@ -578,8 +576,8 @@ describe("POST /api/mcp/chat-v2", () => {
       expect(result.statusCode).toBe(401);
     });
 
-    it("returns normalized message for 401 APICallError from Anthropic", async () => {
-      const onError = await getOnError("anthropic");
+    it("normalizes Anthropic-shaped 401 APICallErrors for the active Ollama provider", async () => {
+      const onError = await getOnError();
       const error = new APICallError({
         message: "invalid x-api-key",
         url: "https://api.anthropic.com/v1/messages",
@@ -594,8 +592,8 @@ describe("POST /api/mcp/chat-v2", () => {
       );
     });
 
-    it("returns normalized message for 401 APICallError from DeepSeek", async () => {
-      const onError = await getOnError("deepseek");
+    it("normalizes DeepSeek-shaped 401 APICallErrors for the active Ollama provider", async () => {
+      const onError = await getOnError();
       const error = new APICallError({
         message: "Authentication Fails, Your api key: ****dfaf is invalid",
         url: "https://api.deepseek.com/v1/chat",
@@ -613,8 +611,8 @@ describe("POST /api/mcp/chat-v2", () => {
       expect(result.statusCode).toBe(401);
     });
 
-    it("detects auth error from xAI 400 via response body keywords", async () => {
-      const onError = await getOnError("xai");
+    it("detects xAI-shaped 400 auth errors via response body keywords", async () => {
+      const onError = await getOnError();
       const error = new APICallError({
         message: "Bad Request",
         url: "https://api.x.ai/v1/chat/completions",
@@ -631,8 +629,8 @@ describe("POST /api/mcp/chat-v2", () => {
       );
     });
 
-    it("detects auth error from Google 400 via response body keywords", async () => {
-      const onError = await getOnError("google");
+    it("detects Google-shaped 400 auth errors via response body keywords", async () => {
+      const onError = await getOnError();
       const error = new APICallError({
         message: "API key not valid. Please pass a valid API key.",
         url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash",
@@ -650,7 +648,7 @@ describe("POST /api/mcp/chat-v2", () => {
     });
 
     it("does not treat non-auth 400 errors as auth errors", async () => {
-      const onError = await getOnError("openai");
+      const onError = await getOnError();
       const error = new APICallError({
         message: "Bad Request: invalid model",
         url: "https://api.openai.com/v1/chat/completions",
@@ -665,7 +663,7 @@ describe("POST /api/mcp/chat-v2", () => {
     });
 
     it("does not leak raw response body for auth errors", async () => {
-      const onError = await getOnError("openai");
+      const onError = await getOnError();
       const error = new APICallError({
         message: "Incorrect API key provided",
         url: "https://api.openai.com/v1/chat/completions",
@@ -681,7 +679,7 @@ describe("POST /api/mcp/chat-v2", () => {
     });
 
     it("passes through non-auth APICallErrors with details", async () => {
-      const onError = await getOnError("openai");
+      const onError = await getOnError();
       const error = new APICallError({
         message: "Rate limit exceeded",
         url: "https://api.openai.com/v1/chat/completions",
@@ -699,7 +697,7 @@ describe("POST /api/mcp/chat-v2", () => {
     });
 
     it("passes through regular Error messages", async () => {
-      const onError = await getOnError("openai");
+      const onError = await getOnError();
       const error = new Error("Network connection failed");
 
       const result = onError(error);
@@ -707,13 +705,13 @@ describe("POST /api/mcp/chat-v2", () => {
     });
 
     it("converts non-Error values to string", async () => {
-      const onError = await getOnError("openai");
+      const onError = await getOnError();
       const result = onError("something broke");
       expect(result).toBe("something broke");
     });
 
     it("catches auth errors via duck-typing, not just APICallError instances", async () => {
-      const onError = await getOnError("openai");
+      const onError = await getOnError();
       const error = Object.assign(new Error("Unauthorized"), {
         statusCode: 401,
       });

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -623,6 +623,10 @@ export async function runEvalsWithManager(
     modelApiKeys: resolvedModelApiKeys ?? undefined,
     orgModelConfig: resolvedOrgModelConfig,
     orgRuntimeProjectId,
+    orgRuntimeAuth: {
+      chatboxToken,
+      serverIds: resolvedServerIds,
+    },
     convexClient,
     convexHttpUrl,
     convexAuthToken,
@@ -742,6 +746,10 @@ export async function runEvalTestCaseWithManager(
     modelApiKeys: resolvedModelApiKeys ?? undefined,
     orgModelConfig: resolvedOrgModelConfig,
     orgRuntimeProjectId: testCaseProjectId,
+    orgRuntimeAuth: {
+      chatboxToken,
+      serverIds: resolvedServerIds,
+    },
     convexClient,
     convexHttpUrl,
     convexAuthToken,
@@ -988,6 +996,10 @@ export async function streamEvalTestCaseWithManager(
           modelApiKeys: resolvedStreamModelApiKeys ?? undefined,
           orgModelConfig: resolvedStreamOrgModelConfig,
           orgRuntimeProjectId: streamTestCaseProjectId,
+          orgRuntimeAuth: {
+            chatboxToken,
+            serverIds: resolvedServerIds,
+          },
           convexHttpUrl,
           convexAuthToken,
           convexClient,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -187,10 +187,8 @@ chatV2.post("/", async (c) => {
 
         // Cloud-only providers (everything that isn't on the local-runtime
         // allowlist) skip the /stream/org/resolve round-trip entirely. The
-        // answer is always "cloud" for those, so calling resolve would just
-        // add latency and a new failure point on the cloud path — which
-        // regressed BYOK chat for cloud-only providers like OpenAI/Anthropic
-        // when resolve was made unconditional.
+        // answer is always "cloud" for those, so resolving would only add
+        // latency and another failure point on the cloud path.
         const runtime: OrgProviderRuntime = isLocalRuntimeEligible(providerKey)
           ? await resolveOrgProviderRuntime(
               hostedBody.projectId,

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -31,6 +31,7 @@ import {
   deriveOrgProviderKey,
   resolveOrgProviderRuntime,
   type OrgProviderRuntime,
+  type ResolveOrgModelConfigAuth,
   type ResolvedOrgModelConfig,
 } from "../utils/org-model-config";
 import {
@@ -127,11 +128,17 @@ export type RunEvalSuiteOptions = {
   convexHttpUrl: string;
   convexAuthToken: string;
   orgRuntimeProjectId?: string;
+  orgRuntimeAuth?: EvalOrgRuntimeAuth;
   mcpClientManager: MCPClientManager;
   recorder?: SuiteRunRecorder | null;
   testCaseId?: string; // For quick runs, associate iterations with a specific test case
   compareRunId?: string; // For quick compare runs, group related iterations in metadata
 };
+
+export type EvalOrgRuntimeAuth = Pick<
+  ResolveOrgModelConfigAuth,
+  "chatboxToken" | "serverIds"
+>;
 
 /** One executed iteration inside a suite/quick run (evaluation + optional persisted iteration id). */
 export type EvalIterationOutcome = {
@@ -1023,6 +1030,7 @@ type RunIterationBaseParams = {
   modelApiKeys?: Record<string, string>;
   orgModelConfig?: ResolvedOrgModelConfig;
   orgResolvedProvider?: OrgProviderResolvedConfig;
+  orgRuntimeAuth?: EvalOrgRuntimeAuth;
   convexClient: ConvexHttpClient;
   runId: string | null; // For cancellation checks
   abortSignal?: AbortSignal; // For aborting in-flight requests
@@ -1131,6 +1139,7 @@ function resolveEvalModelRuntime(args: {
 
 async function resolveEvalOrgRuntime(args: {
   orgRuntimeProjectId?: string;
+  orgRuntimeAuth?: EvalOrgRuntimeAuth;
   modelDefinition: ModelDefinition;
   modelId: string;
   convexAuthToken: string;
@@ -1147,7 +1156,10 @@ async function resolveEvalOrgRuntime(args: {
     args.orgRuntimeProjectId,
     providerKey.key,
     args.modelId,
-    { bearerToken: args.convexAuthToken },
+    {
+      bearerToken: args.convexAuthToken,
+      ...args.orgRuntimeAuth,
+    },
   );
 }
 
@@ -1612,6 +1624,7 @@ const runIterationViaBackend = async ({
   endpointPath = "/stream",
   providerKey,
   projectId,
+  orgRuntimeAuth,
   convexClient,
   runId,
   abortSignal,
@@ -1746,6 +1759,9 @@ const runIterationViaBackend = async ({
   const authHeader = convexAuthToken
     ? { Authorization: `Bearer ${convexAuthToken}` }
     : ({} as Record<string, string>);
+  const orgRuntimeServerIds = orgRuntimeAuth?.serverIds?.filter(
+    (serverId) => serverId.trim().length > 0,
+  );
 
   let accumulatedUsage: UsageTotals = {
     inputTokens: 0,
@@ -1790,6 +1806,14 @@ const runIterationViaBackend = async ({
             model: modelId,
             ...(providerKey ? { providerKey } : {}),
             ...(projectId ? { projectId } : {}),
+            ...(endpointPath === "/stream/org" && orgRuntimeAuth?.chatboxToken
+              ? { chatboxToken: orgRuntimeAuth.chatboxToken }
+              : {}),
+            ...(endpointPath === "/stream/org" &&
+            orgRuntimeServerIds &&
+            orgRuntimeServerIds.length > 0
+              ? { serverIds: orgRuntimeServerIds }
+              : {}),
             ...(systemPrompt ? { systemPrompt } : {}),
             ...(temperature == null ? {} : { temperature }),
             ...(toolChoice ? { toolChoice } : {}),
@@ -2146,6 +2170,7 @@ const runTestCase = async (params: {
   modelApiKeys?: Record<string, string>;
   orgModelConfig?: ResolvedOrgModelConfig;
   orgRuntimeProjectId?: string;
+  orgRuntimeAuth?: EvalOrgRuntimeAuth;
   convexHttpUrl: string;
   convexAuthToken: string;
   convexClient: ConvexHttpClient;
@@ -2163,6 +2188,7 @@ const runTestCase = async (params: {
     modelApiKeys,
     orgModelConfig,
     orgRuntimeProjectId,
+    orgRuntimeAuth,
     convexHttpUrl,
     convexAuthToken,
     convexClient,
@@ -2189,6 +2215,7 @@ const runTestCase = async (params: {
         modelDefinition,
         modelId: resolvedModelId,
         convexAuthToken,
+        orgRuntimeAuth,
         modelApiKeys,
       });
 
@@ -2217,6 +2244,7 @@ const runTestCase = async (params: {
           orgRuntime?.runtimeLocation === "cloud"
             ? orgRuntimeProjectId
             : undefined,
+        orgRuntimeAuth,
         convexClient,
         modelApiKeys,
         orgModelConfig,
@@ -2261,6 +2289,7 @@ export const runEvalSuiteWithAiSdk = async ({
   modelApiKeys,
   orgModelConfig,
   orgRuntimeProjectId,
+  orgRuntimeAuth,
   convexClient,
   convexHttpUrl,
   convexAuthToken,
@@ -2274,6 +2303,15 @@ export const runEvalSuiteWithAiSdk = async ({
     environment: config.environment,
     mcpClientManager,
   });
+  const shouldForwardOrgRuntimeAuth =
+    Boolean(orgRuntimeAuth) || serverIds.length > 0;
+  const effectiveOrgRuntimeAuth: EvalOrgRuntimeAuth | undefined =
+    shouldForwardOrgRuntimeAuth
+      ? {
+          ...orgRuntimeAuth,
+          serverIds: orgRuntimeAuth?.serverIds ?? serverIds,
+        }
+      : undefined;
 
   if (!tests.length) {
     throw new Error("No tests supplied for eval run");
@@ -2335,6 +2373,7 @@ export const runEvalSuiteWithAiSdk = async ({
         modelApiKeys,
         orgModelConfig,
         orgRuntimeProjectId,
+        orgRuntimeAuth: effectiveOrgRuntimeAuth,
         convexHttpUrl,
         convexAuthToken,
         convexClient,
@@ -3050,6 +3089,7 @@ const streamIterationViaBackend = async ({
   endpointPath = "/stream",
   providerKey,
   projectId,
+  orgRuntimeAuth,
   convexClient,
   runId,
   abortSignal,
@@ -3186,6 +3226,9 @@ const streamIterationViaBackend = async ({
   const authHeader = convexAuthToken
     ? { Authorization: `Bearer ${convexAuthToken}` }
     : ({} as Record<string, string>);
+  const orgRuntimeServerIds = orgRuntimeAuth?.serverIds?.filter(
+    (serverId) => serverId.trim().length > 0,
+  );
 
   let accumulatedUsage: UsageTotals = {
     inputTokens: 0,
@@ -3236,6 +3279,14 @@ const streamIterationViaBackend = async ({
             model: modelId,
             ...(providerKey ? { providerKey } : {}),
             ...(projectId ? { projectId } : {}),
+            ...(endpointPath === "/stream/org" && orgRuntimeAuth?.chatboxToken
+              ? { chatboxToken: orgRuntimeAuth.chatboxToken }
+              : {}),
+            ...(endpointPath === "/stream/org" &&
+            orgRuntimeServerIds &&
+            orgRuntimeServerIds.length > 0
+              ? { serverIds: orgRuntimeServerIds }
+              : {}),
             ...(systemPrompt ? { systemPrompt } : {}),
             ...(temperature == null ? {} : { temperature }),
             ...(toolChoice ? { toolChoice } : {}),
@@ -3812,6 +3863,7 @@ export const streamTestCase = async (params: {
   modelApiKeys?: Record<string, string>;
   orgModelConfig?: ResolvedOrgModelConfig;
   orgRuntimeProjectId?: string;
+  orgRuntimeAuth?: EvalOrgRuntimeAuth;
   convexHttpUrl: string;
   convexAuthToken: string;
   convexClient: ConvexHttpClient;
@@ -3830,6 +3882,7 @@ export const streamTestCase = async (params: {
     modelApiKeys,
     orgModelConfig,
     orgRuntimeProjectId,
+    orgRuntimeAuth,
     convexHttpUrl,
     convexAuthToken,
     convexClient,
@@ -3857,6 +3910,7 @@ export const streamTestCase = async (params: {
         modelDefinition,
         modelId: resolvedModelId,
         convexAuthToken,
+        orgRuntimeAuth,
         modelApiKeys,
       });
 
@@ -3885,6 +3939,7 @@ export const streamTestCase = async (params: {
           orgRuntime?.runtimeLocation === "cloud"
             ? orgRuntimeProjectId
             : undefined,
+        orgRuntimeAuth,
         convexClient,
         modelApiKeys,
         orgModelConfig,

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -29,6 +29,7 @@ import { injectOpenAICompat } from "../utils/widget-helpers.js";
 import {
   buildLlmRuntimeConfigFromOrgConfig,
   deriveOrgProviderKey,
+  isLocalRuntimeEligible,
   resolveOrgProviderRuntime,
   type OrgProviderRuntime,
   type ResolveOrgModelConfigAuth,
@@ -1151,6 +1152,12 @@ async function resolveEvalOrgRuntime(args: {
   const providerKey = deriveOrgProviderKey(args.modelDefinition);
   if (!providerKey.ok) {
     throw new Error(providerKey.error);
+  }
+  if (!isLocalRuntimeEligible(providerKey.key)) {
+    return {
+      runtimeLocation: "cloud",
+      providerKey: providerKey.key,
+    };
   }
   return resolveOrgProviderRuntime(
     args.orgRuntimeProjectId,

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -58,6 +58,8 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     vi.clearAllMocks();
     fetchMock.mockReset();
     vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("CONVEX_HTTP_URL", "https://example.convex.site");
+    vi.stubEnv("INSPECTOR_SERVICE_TOKEN", "service-token");
     convexClient.mutation.mockResolvedValue({ iterationId: "iter-1" });
     convexClient.query.mockResolvedValue({ status: "running" });
     convexClient.action.mockResolvedValue(undefined);
@@ -80,6 +82,7 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
   });
 
   async function runQuickTestCase(compareRunId?: string) {
@@ -171,6 +174,20 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       status: 200,
       statusText: "OK",
       body: stream,
+      text: vi.fn().mockResolvedValue(""),
+    };
+  }
+
+  function createOrgRuntimeResolveResponse() {
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: vi.fn().mockResolvedValue({
+        ok: true,
+        runtimeLocation: "cloud",
+        providerKey: "openai",
+      }),
       text: vi.fn().mockResolvedValue(""),
     };
   }
@@ -468,6 +485,68 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     expect(createLlmModelMock).not.toHaveBeenCalled();
   });
 
+  it("forwards guest org runtime auth to resolve and backend eval calls", async () => {
+    fetchMock
+      .mockResolvedValueOnce(createOrgRuntimeResolveResponse())
+      .mockResolvedValueOnce(createBackendSuccessResponse());
+
+    await expect(
+      runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: null,
+        config: {
+          tests: [
+            {
+              title: "Case",
+              query: "Hello",
+              runs: 1,
+              model: "gpt-4-turbo",
+              provider: "openai",
+              expectedToolCalls: [],
+              promptTurns: [
+                { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+              ],
+              testCaseId: "case-1",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        orgRuntimeProjectId: "project-2",
+        orgRuntimeAuth: {
+          chatboxToken: "chatbox-token-2",
+          serverIds: ["srv-1"],
+        },
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "guest-token-2",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-1",
+      }),
+    ).resolves.toBeDefined();
+
+    const resolveCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).endsWith("/stream/org/resolve"),
+    );
+    const resolveRequest = resolveCall?.[1] as { body?: string };
+    expect(JSON.parse(resolveRequest.body ?? "{}")).toMatchObject({
+      projectId: "project-2",
+      providerKey: "openai",
+      chatboxToken: "chatbox-token-2",
+      serverIds: ["srv-1"],
+    });
+
+    const streamCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).endsWith("/stream/org"),
+    );
+    const streamRequest = streamCall?.[1] as { body?: string };
+    expect(JSON.parse(streamRequest.body ?? "{}")).toMatchObject({
+      projectId: "project-2",
+      providerKey: "openai",
+      chatboxToken: "chatbox-token-2",
+      serverIds: ["srv-1"],
+    });
+  });
+
   it("streams bare MCPJam Anthropic test cases through the backend without a BYOK key", async () => {
     const emitted: Array<Record<string, unknown>> = [];
     fetchMock.mockResolvedValue(createBackendStreamResponse());
@@ -513,6 +592,75 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       "anthropic/claude-haiku-4.5",
     );
     expect(createLlmModelMock).not.toHaveBeenCalled();
+    expect(emitted).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "text_delta",
+          content: "Done",
+        }),
+      ]),
+    );
+  });
+
+  it("forwards guest org runtime auth to streaming eval calls", async () => {
+    const emitted: Array<Record<string, unknown>> = [];
+    fetchMock
+      .mockResolvedValueOnce(createOrgRuntimeResolveResponse())
+      .mockResolvedValueOnce(createBackendStreamResponse());
+
+    await expect(
+      streamTestCase({
+        test: {
+          title: "Case",
+          query: "Hello",
+          runs: 1,
+          model: "gpt-4-turbo",
+          provider: "openai",
+          expectedToolCalls: [],
+          promptTurns: [
+            { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+          ],
+          testCaseId: "case-1",
+        },
+        tools: {},
+        mcpClientManager: mcpClientManager as any,
+        recorder: null,
+        orgRuntimeProjectId: "project-1",
+        orgRuntimeAuth: {
+          chatboxToken: "chatbox-token",
+          serverIds: ["srv-1"],
+        },
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "guest-token",
+        testCaseId: "case-1",
+        suiteId: "suite-1",
+        runId: null,
+        emit: (event) => emitted.push(event as Record<string, unknown>),
+      }),
+    ).resolves.toBeDefined();
+
+    const resolveCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).endsWith("/stream/org/resolve"),
+    );
+    const resolveRequest = resolveCall?.[1] as { body?: string };
+    expect(JSON.parse(resolveRequest.body ?? "{}")).toMatchObject({
+      projectId: "project-1",
+      providerKey: "openai",
+      chatboxToken: "chatbox-token",
+      serverIds: ["srv-1"],
+    });
+
+    const streamCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).endsWith("/stream/org"),
+    );
+    const streamRequest = streamCall?.[1] as { body?: string };
+    expect(JSON.parse(streamRequest.body ?? "{}")).toMatchObject({
+      projectId: "project-1",
+      providerKey: "openai",
+      chatboxToken: "chatbox-token",
+      serverIds: ["srv-1"],
+    });
     expect(emitted).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -178,16 +178,18 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     };
   }
 
-  function createOrgRuntimeResolveResponse() {
+  function createOrgRuntimeResolveResponse(
+    payload: Record<string, unknown> = {
+      ok: true,
+      runtimeLocation: "cloud",
+      providerKey: "openai",
+    },
+  ) {
     return {
       ok: true,
       status: 200,
       statusText: "OK",
-      json: vi.fn().mockResolvedValue({
-        ok: true,
-        runtimeLocation: "cloud",
-        providerKey: "openai",
-      }),
+      json: vi.fn().mockResolvedValue(payload),
       text: vi.fn().mockResolvedValue(""),
     };
   }
@@ -485,10 +487,8 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     expect(createLlmModelMock).not.toHaveBeenCalled();
   });
 
-  it("forwards guest org runtime auth to resolve and backend eval calls", async () => {
-    fetchMock
-      .mockResolvedValueOnce(createOrgRuntimeResolveResponse())
-      .mockResolvedValueOnce(createBackendSuccessResponse());
+  it("forwards guest org runtime auth to cloud-only backend eval calls", async () => {
+    fetchMock.mockResolvedValueOnce(createBackendSuccessResponse());
 
     await expect(
       runEvalSuiteWithAiSdk({
@@ -524,16 +524,10 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       }),
     ).resolves.toBeDefined();
 
-    const resolveCall = fetchMock.mock.calls.find(([url]) =>
-      String(url).endsWith("/stream/org/resolve"),
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("/stream/org/resolve"),
+      expect.anything(),
     );
-    const resolveRequest = resolveCall?.[1] as { body?: string };
-    expect(JSON.parse(resolveRequest.body ?? "{}")).toMatchObject({
-      projectId: "project-2",
-      providerKey: "openai",
-      chatboxToken: "chatbox-token-2",
-      serverIds: ["srv-1"],
-    });
 
     const streamCall = fetchMock.mock.calls.find(([url]) =>
       String(url).endsWith("/stream/org"),
@@ -545,6 +539,72 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       chatboxToken: "chatbox-token-2",
       serverIds: ["srv-1"],
     });
+  });
+
+  it("forwards guest org runtime auth when resolving custom local eval providers", async () => {
+    fetchMock.mockResolvedValueOnce(
+      createOrgRuntimeResolveResponse({
+        ok: true,
+        runtimeLocation: "local",
+        provider: {
+          providerKey: "custom:acme",
+          apiKey: "custom-secret",
+          baseUrl: "https://models.example/v1",
+          protocol: "openai-compatible",
+          modelIds: ["llama-3"],
+        },
+      }),
+    );
+
+    await expect(
+      runEvalSuiteWithAiSdk({
+        suiteId: "suite-1",
+        runId: null,
+        config: {
+          tests: [
+            {
+              title: "Custom Case",
+              query: "Hello",
+              runs: 1,
+              model: "custom:acme:llama-3",
+              provider: "custom",
+              expectedToolCalls: [],
+              promptTurns: [
+                { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+              ],
+              testCaseId: "case-1",
+            },
+          ],
+          environment: { servers: ["srv-1"] },
+        },
+        orgRuntimeProjectId: "project-2",
+        orgRuntimeAuth: {
+          chatboxToken: "chatbox-token-2",
+          serverIds: ["srv-1"],
+        },
+        convexClient: convexClient as any,
+        convexHttpUrl: "https://example.convex.site",
+        convexAuthToken: "guest-token-2",
+        mcpClientManager: mcpClientManager as any,
+        testCaseId: "case-1",
+      }),
+    ).resolves.toBeDefined();
+
+    const resolveCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).endsWith("/stream/org/resolve"),
+    );
+    const resolveRequest = resolveCall?.[1] as { body?: string };
+    expect(JSON.parse(resolveRequest.body ?? "{}")).toMatchObject({
+      projectId: "project-2",
+      providerKey: "custom:acme",
+      chatboxToken: "chatbox-token-2",
+      serverIds: ["srv-1"],
+    });
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "https://example.convex.site/stream/org",
+      expect.anything(),
+    );
+    expect(generateTextMock).toHaveBeenCalled();
   });
 
   it("streams bare MCPJam Anthropic test cases through the backend without a BYOK key", async () => {
@@ -602,11 +662,9 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     );
   });
 
-  it("forwards guest org runtime auth to streaming eval calls", async () => {
+  it("forwards guest org runtime auth to cloud-only streaming eval calls", async () => {
     const emitted: Array<Record<string, unknown>> = [];
-    fetchMock
-      .mockResolvedValueOnce(createOrgRuntimeResolveResponse())
-      .mockResolvedValueOnce(createBackendStreamResponse());
+    fetchMock.mockResolvedValueOnce(createBackendStreamResponse());
 
     await expect(
       streamTestCase({
@@ -640,16 +698,10 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       }),
     ).resolves.toBeDefined();
 
-    const resolveCall = fetchMock.mock.calls.find(([url]) =>
-      String(url).endsWith("/stream/org/resolve"),
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("/stream/org/resolve"),
+      expect.anything(),
     );
-    const resolveRequest = resolveCall?.[1] as { body?: string };
-    expect(JSON.parse(resolveRequest.body ?? "{}")).toMatchObject({
-      projectId: "project-1",
-      providerKey: "openai",
-      chatboxToken: "chatbox-token",
-      serverIds: ["srv-1"],
-    });
 
     const streamCall = fetchMock.mock.calls.find(([url]) =>
       String(url).endsWith("/stream/org"),

--- a/mcpjam-inspector/server/services/evals/replay-suite-run.ts
+++ b/mcpjam-inspector/server/services/evals/replay-suite-run.ts
@@ -148,6 +148,10 @@ export async function executeSuiteReplayFromRun(
       config,
       modelApiKeys: resolvedModelApiKeys ?? undefined,
       orgModelConfig: resolvedOrgModelConfig,
+      orgRuntimeProjectId: replayProjectId,
+      orgRuntimeAuth: {
+        serverIds: replayServerIds,
+      },
       convexClient,
       convexHttpUrl,
       convexAuthToken,

--- a/mcpjam-inspector/server/utils/__tests__/org-model-config.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/org-model-config.test.ts
@@ -143,14 +143,14 @@ describe("isUnsafeHostedOutboundUrl", () => {
 });
 
 describe("isLocalRuntimeEligible", () => {
-  it("returns true for org-managed providers", () => {
+  it("only allows Ollama and custom providers to use local runtime", () => {
     expect(isLocalRuntimeEligible("ollama")).toBe(true);
-    expect(isLocalRuntimeEligible("openai")).toBe(true);
-    expect(isLocalRuntimeEligible("anthropic")).toBe(true);
-    expect(isLocalRuntimeEligible("azure")).toBe(true);
-    expect(isLocalRuntimeEligible("google")).toBe(true);
-    expect(isLocalRuntimeEligible("openrouter")).toBe(true);
     expect(isLocalRuntimeEligible("custom:my-llm")).toBe(true);
+    expect(isLocalRuntimeEligible("openai")).toBe(false);
+    expect(isLocalRuntimeEligible("anthropic")).toBe(false);
+    expect(isLocalRuntimeEligible("azure")).toBe(false);
+    expect(isLocalRuntimeEligible("google")).toBe(false);
+    expect(isLocalRuntimeEligible("openrouter")).toBe(false);
     expect(isLocalRuntimeEligible("")).toBe(false);
   });
 });

--- a/mcpjam-inspector/server/utils/chat-helpers.ts
+++ b/mcpjam-inspector/server/utils/chat-helpers.ts
@@ -69,6 +69,30 @@ export const createLlmModel = (
       })(modelDefinition.id);
     case "xai":
       return createXai({ apiKey })(modelDefinition.id);
+    // OpenAI-compatible providers with hardcoded baseURLs. Mirrors
+    // convex/stream/buildOrgModel.ts — keep the baseURLs in sync. Use
+    // createOpenAI({baseURL,apiKey}).chat() instead of pulling in
+    // @ai-sdk/openai-compatible (one fewer dep, same wire protocol).
+    case "moonshotai":
+      return createOpenAI({
+        apiKey,
+        baseURL: "https://api.moonshot.ai/v1",
+      }).chat(String(modelDefinition.id));
+    case "z-ai":
+      return createOpenAI({
+        apiKey,
+        baseURL: "https://api.z.ai/api/paas/v4",
+      }).chat(String(modelDefinition.id));
+    case "qwen":
+      return createOpenAI({
+        apiKey,
+        baseURL: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+      }).chat(String(modelDefinition.id));
+    case "minimax":
+      return createOpenAI({
+        apiKey,
+        baseURL: "https://api.minimax.io/v1",
+      }).chat(String(modelDefinition.id));
     case "azure": {
       const azureBaseUrl = baseUrls?.azure ?? "";
       // Extract resourceName from the Azure base URL so the SDK doesn't fall

--- a/mcpjam-inspector/server/utils/org-model-config.ts
+++ b/mcpjam-inspector/server/utils/org-model-config.ts
@@ -38,15 +38,20 @@ export type ResolveOrgModelConfigAuth = {
 // ---------------------------------------------------------------------------
 // Local-runtime eligibility
 //
-// Any org-managed provider can be configured with runtimeLocation: "local":
-// LiteLLM gateways, Bedrock with local AWS/IAM auth, VPN-only endpoints, and
-// custom private-network providers all need the inspector process to execute
-// the request. Ollama is the only local-only-by-default provider, but it is not
-// the only local-runtime provider.
+// Keep local runtime scoped to providers that naturally need the Inspector
+// process to make the request: Ollama and org custom providers. Built-in
+// providers like OpenAI/Anthropic/OpenRouter/Azure stay on the cloud BYOK path.
+// Keep this allowlist in sync with mcpjam-backend/convex/organizationModelProviders.ts.
 // ---------------------------------------------------------------------------
 
+const LOCAL_RUNTIME_PROVIDER_KEYS = new Set(["ollama"]);
+
 export function isLocalRuntimeEligible(providerKey: string): boolean {
-  return providerKey.trim().length > 0;
+  const normalized = providerKey.trim();
+  return (
+    LOCAL_RUNTIME_PROVIDER_KEYS.has(normalized) ||
+    normalized.startsWith("custom:")
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/mcpjam-inspector/server/utils/tokenizer-helpers.ts
+++ b/mcpjam-inspector/server/utils/tokenizer-helpers.ts
@@ -7,12 +7,25 @@ import { logger } from "./logger";
  * Values: Model IDs recognized by ai-tokenizer
  */
 const MODEL_ID_MAPPINGS: Record<string, string> = {
-  // Anthropic models
+  // Anthropic models — current-generation dateless IDs
+  "claude-opus-4-7": "anthropic/claude-opus-4.7",
+  "claude-sonnet-4-6": "anthropic/claude-sonnet-4.6",
+  "claude-opus-4-6": "anthropic/claude-opus-4.6",
+  // Anthropic models — dated/pinned IDs for legacy generations
+  "claude-haiku-4-5-20251001": "anthropic/claude-haiku-4.5",
+  "claude-opus-4-5-20251101": "anthropic/claude-opus-4.5",
+  "claude-sonnet-4-5-20250929": "anthropic/claude-sonnet-4.5",
+  "claude-opus-4-1-20250805": "anthropic/claude-opus-4.1",
+  "claude-opus-4-20250514": "anthropic/claude-opus-4",
+  "claude-sonnet-4-20250514": "anthropic/claude-sonnet-4",
+  // Anthropic — alias forms (still accepted by Anthropic until retirement)
   "claude-opus-4-1": "anthropic/claude-opus-4.1",
   "claude-opus-4-0": "anthropic/claude-opus-4",
   "claude-sonnet-4-5": "anthropic/claude-sonnet-4.5",
   "claude-sonnet-4-0": "anthropic/claude-sonnet-4",
   "claude-haiku-4-5": "anthropic/claude-haiku-4.5",
+  // Retired models (still mapped for token-counting on legacy persisted
+  // chats — Anthropic API itself returns 404 for these now).
   "claude-3-7-sonnet-latest": "anthropic/claude-3.7-sonnet",
   "claude-3-5-sonnet-latest": "anthropic/claude-3.5-sonnet",
   "claude-3-5-haiku-latest": "anthropic/claude-3.5-haiku",

--- a/mcpjam-inspector/shared/types.ts
+++ b/mcpjam-inspector/shared/types.ts
@@ -270,13 +270,21 @@ export interface ModelDefinition {
 }
 
 export enum Model {
-  CLAUDE_OPUS_4_1 = "claude-opus-4-1",
-  CLAUDE_OPUS_4_0 = "claude-opus-4-0",
-  CLAUDE_SONNET_4_5 = "claude-sonnet-4-5",
-  CLAUDE_SONNET_4_0 = "claude-sonnet-4-0",
-  CLAUDE_3_7_SONNET_LATEST = "claude-3-7-sonnet-latest",
-  CLAUDE_HAIKU_4_5 = "claude-haiku-4-5",
-  CLAUDE_3_5_HAIKU_LATEST = "claude-3-5-haiku-latest",
+  // Anthropic — current generation (4.6+) uses dateless pinned IDs
+  CLAUDE_OPUS_4_7 = "claude-opus-4-7",
+  CLAUDE_SONNET_4_6 = "claude-sonnet-4-6",
+  CLAUDE_OPUS_4_6 = "claude-opus-4-6",
+  CLAUDE_HAIKU_4_5 = "claude-haiku-4-5-20251001",
+  // Anthropic — legacy (pre-4.6) use dated IDs because aliases like
+  // claude-opus-4-0 can be yanked before retirement.
+  CLAUDE_OPUS_4_5 = "claude-opus-4-5-20251101",
+  CLAUDE_SONNET_4_5 = "claude-sonnet-4-5-20250929",
+  CLAUDE_OPUS_4_1 = "claude-opus-4-1-20250805",
+  // Removed: claude-opus-4-20250514 + claude-sonnet-4-20250514 (deprecated
+  // 2026-04-14, retiring 2026-06-15 — and many accounts have already lost
+  // access). Replacement: claude-opus-4-7 / claude-sonnet-4-6.
+  // Removed: claude-3-7-sonnet (retired 2026-02-19) and claude-3-5-haiku
+  // (retired 2026-02-19) — both alias forms 404 against Anthropic's API.
   GPT_4_1 = "gpt-4.1",
   GPT_4_1_MINI = "gpt-4.1-mini",
   GPT_4_1_NANO = "gpt-4.1-nano",
@@ -294,9 +302,14 @@ export enum Model {
   GPT_5_1_CODEX = "gpt-5.1-codex",
   GPT_5_1_CODEX_MINI = "gpt-5.1-codex-mini",
   GPT_3_5_TURBO = "gpt-3.5-turbo",
+  // DeepSeek — v4 family is current; v3 aliases are deprecating
+  DEEPSEEK_V4_PRO = "deepseek-v4-pro",
+  DEEPSEEK_V4_FLASH = "deepseek-v4-flash",
   DEEPSEEK_CHAT = "deepseek-chat",
   DEEPSEEK_REASONER = "deepseek-reasoner",
-  // Google Gemini models
+  // Google Gemini models — 3.x is current
+  GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview",
+  GEMINI_3_1_FLASH_LITE = "gemini-3.1-flash-lite",
   GEMINI_2_5_PRO = "gemini-2.5-pro",
   GEMINI_2_5_FLASH = "gemini-2.5-flash",
   GEMINI_2_5_FLASH_LITE = "gemini-2.5-flash-lite",
@@ -310,18 +323,55 @@ export enum Model {
   GEMMA_2_27B = "gemma-2-27b",
   CODE_GEMMA_2B = "codegemma-2b",
   CODE_GEMMA_7B = "codegemma-7b",
-  // Mistral models
+  // Mistral — current dated IDs (aliases like mistral-large-latest still work
+  // but the dated form is recommended)
+  MISTRAL_LARGE_3 = "mistral-large-3-25-12",
+  MISTRAL_MEDIUM_3_5 = "mistral-medium-3-5-26-04",
+  MISTRAL_MEDIUM_3_1 = "mistral-medium-3-1-25-08",
+  MISTRAL_SMALL_4 = "mistral-small-2603",
+  MAGISTRAL_MEDIUM_1_2 = "magistral-medium-1-2-25-09",
+  DEVSTRAL_2 = "devstral-2-25-12",
+  CODESTRAL_25_08 = "codestral-25-08",
+  MINISTRAL_3_14B = "ministral-3-14b-25-12",
+  MINISTRAL_3_8B = "ministral-3-8b-25-12",
+  MINISTRAL_3_3B = "ministral-3-3b-25-12",
+  // Mistral — legacy aliases kept for back-compat
   MISTRAL_LARGE_LATEST = "mistral-large-latest",
   MISTRAL_SMALL_LATEST = "mistral-small-latest",
   CODESTRAL_LATEST = "codestral-latest",
   MINISTRAL_8B_LATEST = "ministral-8b-latest",
   MINISTRAL_3B_LATEST = "ministral-3b-latest",
-  // xAI models
+  // xAI/Grok — 4.3 is current
+  GROK_4_3 = "grok-4.3",
+  GROK_4 = "grok-4",
+  GROK_4_FAST = "grok-4-fast",
+  GROK_4_1_FAST = "grok-4-1-fast",
+  GROK_CODE_FAST_1 = "grok-code-fast-1",
   GROK_3 = "grok-3",
   GROK_3_MINI = "grok-3-mini",
-  GROK_CODE_FAST_1 = "grok-code-fast-1",
   GROK_4_FAST_NON_REASONING = "grok-4-fast-non-reasoning",
   GROK_4_FAST_REASONING = "grok-4-fast-reasoning",
+  // Moonshot / Kimi — OpenAI-compatible API
+  KIMI_K2_6 = "kimi-k2.6",
+  KIMI_K2 = "kimi-k2",
+  MOONSHOT_V1 = "moonshot-v1",
+  // Z.AI / GLM — OpenAI-compatible API
+  GLM_4_6 = "glm-4.6",
+  GLM_4_5 = "glm-4.5",
+  GLM_4_PLUS = "glm-4-plus",
+  GLM_4_AIR = "glm-4-air",
+  // Qwen / DashScope — OpenAI-compatible API
+  QWEN_3_6_MAX_PREVIEW = "qwen3.6-max-preview",
+  QWEN_3_6_PLUS = "qwen3.6-plus",
+  QWEN_3_6_FLASH = "qwen3.6-flash",
+  QWEN_MAX = "qwen-max",
+  QWEN_PLUS = "qwen-plus",
+  QWEN_TURBO = "qwen-turbo",
+  // MiniMax — OpenAI-compatible API
+  MINIMAX_M2_7 = "MiniMax-M2.7",
+  MINIMAX_M2_5 = "MiniMax-M2.5",
+  MINIMAX_M2_1 = "MiniMax-M2.1",
+  MINIMAX_M2 = "MiniMax-M2",
 }
 
 const freeModel = (
@@ -337,15 +387,35 @@ const freeModel = (
 });
 
 export const SUPPORTED_MODELS: ModelDefinition[] = [
+  // Anthropic — current generation first
   {
-    id: Model.CLAUDE_OPUS_4_1,
-    name: "Claude Opus 4.1",
+    id: Model.CLAUDE_OPUS_4_7,
+    name: "Claude Opus 4.7",
+    provider: "anthropic",
+    contextLength: 1000000,
+  },
+  {
+    id: Model.CLAUDE_SONNET_4_6,
+    name: "Claude Sonnet 4.6",
+    provider: "anthropic",
+    contextLength: 1000000,
+  },
+  {
+    id: Model.CLAUDE_OPUS_4_6,
+    name: "Claude Opus 4.6",
+    provider: "anthropic",
+    contextLength: 1000000,
+  },
+  {
+    id: Model.CLAUDE_HAIKU_4_5,
+    name: "Claude Haiku 4.5",
     provider: "anthropic",
     contextLength: 200000,
   },
+  // Anthropic — legacy
   {
-    id: Model.CLAUDE_OPUS_4_0,
-    name: "Claude Opus 4",
+    id: Model.CLAUDE_OPUS_4_5,
+    name: "Claude Opus 4.5",
     provider: "anthropic",
     contextLength: 200000,
   },
@@ -356,29 +426,14 @@ export const SUPPORTED_MODELS: ModelDefinition[] = [
     contextLength: 200000,
   },
   {
-    id: Model.CLAUDE_SONNET_4_0,
-    name: "Claude Sonnet 4",
+    id: Model.CLAUDE_OPUS_4_1,
+    name: "Claude Opus 4.1",
     provider: "anthropic",
     contextLength: 200000,
   },
-  {
-    id: Model.CLAUDE_HAIKU_4_5,
-    name: "Claude Haiku 4.5",
-    provider: "anthropic",
-    contextLength: 200000,
-  },
-  {
-    id: Model.CLAUDE_3_7_SONNET_LATEST,
-    name: "Claude Sonnet 3.7",
-    provider: "anthropic",
-    contextLength: 200000,
-  },
-  {
-    id: Model.CLAUDE_3_5_HAIKU_LATEST,
-    name: "Claude Haiku 3.5",
-    provider: "anthropic",
-    contextLength: 200000,
-  },
+  // Claude Opus 4, Sonnet 4 (deprecated 2026-04-14, retiring 2026-06-15),
+  // Claude 3.7 Sonnet, 3.5 Haiku (retired 2026-02-19) entries all removed.
+  // Replacements: claude-opus-4-7 / claude-sonnet-4-6 / claude-haiku-4-5.
   {
     id: Model.GPT_5_1,
     name: "GPT-5.1",
@@ -464,19 +519,44 @@ export const SUPPORTED_MODELS: ModelDefinition[] = [
     provider: "openai",
     contextLength: 128000,
   },
+  // DeepSeek BYOK — v4 family is current
+  {
+    id: Model.DEEPSEEK_V4_PRO,
+    name: "DeepSeek V4 Pro",
+    provider: "deepseek",
+    contextLength: 128000,
+  },
+  {
+    id: Model.DEEPSEEK_V4_FLASH,
+    name: "DeepSeek V4 Flash",
+    provider: "deepseek",
+    contextLength: 128000,
+  },
   {
     id: Model.DEEPSEEK_CHAT,
-    name: "DeepSeek Chat",
+    name: "DeepSeek Chat (legacy)",
     provider: "deepseek",
     contextLength: 128000,
   },
   {
     id: Model.DEEPSEEK_REASONER,
-    name: "DeepSeek Reasoner",
+    name: "DeepSeek Reasoner (legacy)",
     provider: "deepseek",
     contextLength: 128000,
   },
-  // Google Gemini models (latest first)
+  // Google Gemini BYOK — 3.x is current
+  {
+    id: Model.GEMINI_3_1_PRO_PREVIEW,
+    name: "Gemini 3.1 Pro Preview",
+    provider: "google",
+    contextLength: 1048576,
+  },
+  {
+    id: Model.GEMINI_3_1_FLASH_LITE,
+    name: "Gemini 3.1 Flash Lite",
+    provider: "google",
+    contextLength: 1048576,
+  },
   {
     id: Model.GEMINI_2_5_PRO,
     name: "Gemini 2.5 Pro",
@@ -490,10 +570,214 @@ export const SUPPORTED_MODELS: ModelDefinition[] = [
     contextLength: 1000000,
   },
   {
+    id: Model.GEMINI_2_5_FLASH_LITE,
+    name: "Gemini 2.5 Flash Lite",
+    provider: "google",
+    contextLength: 1000000,
+  },
+  {
     id: Model.GEMINI_2_0_FLASH_EXP,
     name: "Gemini 2.0 Flash Experimental",
     provider: "google",
     contextLength: 1048576,
+  },
+  // Mistral BYOK
+  {
+    id: Model.MISTRAL_LARGE_3,
+    name: "Mistral Large 3",
+    provider: "mistral",
+    contextLength: 128000,
+  },
+  {
+    id: Model.MISTRAL_MEDIUM_3_5,
+    name: "Mistral Medium 3.5",
+    provider: "mistral",
+    contextLength: 128000,
+  },
+  {
+    id: Model.MISTRAL_MEDIUM_3_1,
+    name: "Mistral Medium 3.1",
+    provider: "mistral",
+    contextLength: 128000,
+  },
+  {
+    id: Model.MISTRAL_SMALL_4,
+    name: "Mistral Small 4",
+    provider: "mistral",
+    contextLength: 128000,
+  },
+  {
+    id: Model.MAGISTRAL_MEDIUM_1_2,
+    name: "Magistral Medium 1.2",
+    provider: "mistral",
+    contextLength: 128000,
+  },
+  {
+    id: Model.DEVSTRAL_2,
+    name: "Devstral 2",
+    provider: "mistral",
+    contextLength: 128000,
+  },
+  {
+    id: Model.CODESTRAL_25_08,
+    name: "Codestral",
+    provider: "mistral",
+    contextLength: 256000,
+  },
+  {
+    id: Model.MINISTRAL_3_14B,
+    name: "Ministral 3 14B",
+    provider: "mistral",
+    contextLength: 128000,
+  },
+  {
+    id: Model.MINISTRAL_3_8B,
+    name: "Ministral 3 8B",
+    provider: "mistral",
+    contextLength: 128000,
+  },
+  {
+    id: Model.MINISTRAL_3_3B,
+    name: "Ministral 3 3B",
+    provider: "mistral",
+    contextLength: 128000,
+  },
+  // xAI / Grok BYOK
+  {
+    id: Model.GROK_4_3,
+    name: "Grok 4.3",
+    provider: "xai",
+    contextLength: 256000,
+  },
+  {
+    id: Model.GROK_4,
+    name: "Grok 4",
+    provider: "xai",
+    contextLength: 256000,
+  },
+  {
+    id: Model.GROK_4_FAST,
+    name: "Grok 4 Fast",
+    provider: "xai",
+    contextLength: 2000000,
+  },
+  {
+    id: Model.GROK_4_1_FAST,
+    name: "Grok 4.1 Fast",
+    provider: "xai",
+    contextLength: 2000000,
+  },
+  {
+    id: Model.GROK_CODE_FAST_1,
+    name: "Grok Code Fast 1",
+    provider: "xai",
+    contextLength: 256000,
+  },
+  // Moonshot / Kimi BYOK
+  {
+    id: Model.KIMI_K2_6,
+    name: "Kimi K2.6",
+    provider: "moonshotai",
+    contextLength: 262144,
+  },
+  {
+    id: Model.KIMI_K2,
+    name: "Kimi K2",
+    provider: "moonshotai",
+    contextLength: 262144,
+  },
+  {
+    id: Model.MOONSHOT_V1,
+    name: "Moonshot v1",
+    provider: "moonshotai",
+    contextLength: 200000,
+  },
+  // Z.AI / GLM BYOK
+  {
+    id: Model.GLM_4_6,
+    name: "GLM 4.6",
+    provider: "z-ai",
+    contextLength: 200000,
+  },
+  {
+    id: Model.GLM_4_5,
+    name: "GLM 4.5",
+    provider: "z-ai",
+    contextLength: 200000,
+  },
+  {
+    id: Model.GLM_4_PLUS,
+    name: "GLM 4 Plus",
+    provider: "z-ai",
+    contextLength: 128000,
+  },
+  {
+    id: Model.GLM_4_AIR,
+    name: "GLM 4 Air",
+    provider: "z-ai",
+    contextLength: 128000,
+  },
+  // Qwen / DashScope BYOK
+  {
+    id: Model.QWEN_3_6_MAX_PREVIEW,
+    name: "Qwen 3.6 Max Preview",
+    provider: "qwen",
+    contextLength: 1000000,
+  },
+  {
+    id: Model.QWEN_3_6_PLUS,
+    name: "Qwen 3.6 Plus",
+    provider: "qwen",
+    contextLength: 1000000,
+  },
+  {
+    id: Model.QWEN_3_6_FLASH,
+    name: "Qwen 3.6 Flash",
+    provider: "qwen",
+    contextLength: 1000000,
+  },
+  {
+    id: Model.QWEN_MAX,
+    name: "Qwen Max",
+    provider: "qwen",
+    contextLength: 32000,
+  },
+  {
+    id: Model.QWEN_PLUS,
+    name: "Qwen Plus",
+    provider: "qwen",
+    contextLength: 32000,
+  },
+  {
+    id: Model.QWEN_TURBO,
+    name: "Qwen Turbo",
+    provider: "qwen",
+    contextLength: 1000000,
+  },
+  // MiniMax BYOK
+  {
+    id: Model.MINIMAX_M2_7,
+    name: "MiniMax M2.7",
+    provider: "minimax",
+    contextLength: 245760,
+  },
+  {
+    id: Model.MINIMAX_M2_5,
+    name: "MiniMax M2.5",
+    provider: "minimax",
+    contextLength: 245760,
+  },
+  {
+    id: Model.MINIMAX_M2_1,
+    name: "MiniMax M2.1",
+    provider: "minimax",
+    contextLength: 245760,
+  },
+  {
+    id: Model.MINIMAX_M2,
+    name: "MiniMax M2",
+    provider: "minimax",
+    contextLength: 245760,
   },
   {
     id: "openai/gpt-oss-120b",


### PR DESCRIPTION
- Org admins now add model API keys in MCPJam, and those keys are stored in the vault.

- OpenAI, Claude, OpenRouter, Azure, Google, etc now use the org’s vaulted key through MCPJam cloud runtime.

- Invited org/project users can use those org models without seeing or copying the raw API key.

- Ollama stays personal/local. It uses the Ollama running on your own machine.

- Custom providers stay local-runtime capable, so teams can still use private/local endpoints when needed.

- Chat and evals now follow the same BYOK rules.

- Fixed permission edge cases so invited users do not crash Chat when loading org models.

- Added tests and a changeset for the release.