### PR TITLE
Fix chatbox OAuth 403 by attaching WorkOS bearer in /oauth/callback

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -489,6 +489,16 @@ export default function App() {
 
   // Handle hosted OAuth callback: claim the callback before any hosted page renders.
   useEffect(() => {
+    // Wait for Convex/WorkOS auth to settle before deciding signed-in vs guest
+    // bearer. On post-redirect mount the first render sees
+    // isAuthenticated=false while isAuthLoading=true; routing a signed-in
+    // user's completion through the guest-bearer branch materializes a fresh
+    // anonymous user with no chatboxAccess row and 403s on
+    // /web/oauth/complete + /web/oauth/session/progress, then clears the
+    // pending marker so the post-settle re-run can't recover.
+    if (isAuthLoading) {
+      return;
+    }
     const callbackContext = getHostedOAuthCallbackContext();
     if (!callbackContext || callbackContext.surface === "project") {
       setHostedOAuthHandling(false);
@@ -564,6 +574,25 @@ export default function App() {
               };
             }
             authorizationHeader = `Bearer ${guestBearerToken}`;
+          } else if (workOsUser) {
+            // On chatbox routes, `useApiContext` is disabled (App.tsx
+            // `enabled: !isHostedChatRoute`), so the module-level apiContext
+            // is EMPTY_CONTEXT. authFetch's default header resolver then sees
+            // `!apiContext.isAuthenticated && !apiContext.hasSession`, decides
+            // the actor is a guest, and attaches a guest bearer — even though
+            // the user is WorkOS-signed-in. The backend then materializes a
+            // fresh anonymous user and 403s on chatboxAccess lookup. Explicitly
+            // attach the WorkOS bearer here so the chatbox-route gating of
+            // apiContext cannot demote a signed-in user to a guest.
+            try {
+              const accessToken = await getAccessToken();
+              if (accessToken) {
+                authorizationHeader = `Bearer ${accessToken}`;
+              }
+            } catch {
+              // Fall through to authFetch default. The callback will retry
+              // via the standard error UI if this token fetch fails.
+            }
           }
 
           return completeHostedOAuthCallback(callbackContext, code, {
@@ -605,7 +634,7 @@ export default function App() {
     return () => {
       cancelled = true;
     };
-  }, [isAuthenticated]);
+  }, [isAuthLoading, isAuthenticated, workOsUser, getAccessToken]);
 
   usePostHogIdentify();
 

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -683,6 +683,35 @@ describe("App hosted OAuth callback handling", () => {
     expect(mockHandleOAuthCallback).not.toHaveBeenCalled();
   });
 
+  it("attaches the WorkOS bearer when a signed-in user returns to a chatbox callback", async () => {
+    // Regression for the chatbox OAuth 403: on chatbox routes useApiContext is
+    // gated off, so authFetch's default header resolver demoted signed-in
+    // users to guest bearers. The fix explicitly fetches the WorkOS access
+    // token and passes it as authorizationHeader, bypassing apiContext.
+    mockConvexAuthState.isAuthenticated = true;
+    mockWorkOsAuthState.user = { id: "user-workos-1" };
+    mockWorkOsAuthState.getAccessToken = vi
+      .fn()
+      .mockResolvedValue("workos-token");
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockCompleteHostedOAuthCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          surface: "chatbox",
+          chatboxId: "sbx_1",
+        }),
+        "oauth-code",
+        expect.objectContaining({
+          authorizationHeader: "Bearer workos-token",
+          onTraceUpdate: expect.any(Function),
+        })
+      );
+    });
+    expect(mockGetGuestBearerToken).not.toHaveBeenCalled();
+  });
+
   it("does not keep the hosted loading screen for project OAuth callbacks", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();


### PR DESCRIPTION
## Summary
On chatbox routes (`isHostedChatRoute === true`), `useApiContext` is gated off (App.tsx `enabled: !isHostedChatRoute`), leaving the module-level `apiContext` as `EMPTY_CONTEXT`. When the OAuth callback handler invoked `authFetch` with no explicit `authorizationHeader`, `getApiAuthorizationHeader` saw `!apiContext.isAuthenticated && !apiContext.hasSession`, picked **guest** as the preferred bearer, and attached a guest JWT — even when `workOsUser` was set.

The backend `resolveHostedOAuthScope` then routed the request through the guest branch, materialized a fresh anonymous user via `upsertGuestUserFromIdentity`, and 403d the `chatboxAccess` lookup because the grant was minted under the WorkOS user, not the brand-new guest UUID subject.

### Fix
In the OAuth callback handler, when `workOsUser` is present and the callback is not a true guest-chatbox session, explicitly fetch the WorkOS access token via `getAccessToken()` and pass it as the `authorizationHeader`. This bypasses `apiContext` entirely so the chatbox-route gating cannot demote a signed-in user.

Also:
- Wait for `isAuthLoading === false` before deciding the bearer branch (prior change from the handoff doc — the post-redirect first render sees `isAuthLoading=true, isAuthenticated=false`, which would route a signed-in user through the guest branch and clear the pending OAuth marker before the post-settle re-run can recover).
- Add `workOsUser` + `getAccessToken` to the effect deps so the effect re-runs once WorkOS finishes loading.

### Repro (before this fix)
- WorkOS-signed-in gmail user accesses a chatbox via share link (`anyone_with_link`, `link_grant` chatboxAccess minted under their WorkOS userId).
- Linear server in the chatbox requires OAuth → user clicks "Authorize again" → Linear consent → redirect back to `/oauth/callback`.
- `/web/oauth/complete` and `/web/oauth/session/progress` return `403 "Guest chatbox access denied or revoked"`.

### Diagnosed via
Backend log (added temporarily during debugging) showed the request hit the guest branch with `issuer: https://api.mcpjam.com/guest, subject: 62d9baac-…`, while the frontend reported `hasWorkOsUser: true, isAuthenticated: true`. That divergence is only possible if the bearer attached client-side was the guest one — which traced back to the `apiContext` gating.

## Test plan
- [x] `npx vitest run src/__tests__/App.hosted-oauth.test.tsx` — 54/58 pass (the 4 failures are pre-existing billing-handoff tests unrelated to this PR; all OAuth-callback tests pass)
- [x] Manual: gmail user (WorkOS-signed-in) accesses chatbox link, completes Linear OAuth, returns to callback — no more 403, OAuth completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hosted OAuth callback authorization/header selection, which is authentication-adjacent and can impact sign-in/permission enforcement if incorrect. Scope is small and covered by a targeted regression test.
> 
> **Overview**
> Fixes a hosted chatbox OAuth callback regression where signed-in WorkOS users could be treated as guests and hit `403` during `/web/oauth/complete`.
> 
> `App.tsx` now waits for Convex auth to finish loading before choosing the guest vs authenticated completion path, and explicitly fetches/attaches a WorkOS `Bearer` token for non-guest chatbox callbacks so chatbox-route `useApiContext` gating can’t demote a signed-in user.
> 
> Adds a new unit test asserting the WorkOS bearer is passed to `completeHostedOAuthCallback` on chatbox callbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1919c05ac807d56812fe685957a6e7c07cd36d87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->