### PR TITLE
fix(chatbox): re-redeem snapshot capture on chatbox_access_stale

### DIFF
--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -620,12 +620,23 @@ export function ChatboxChatPage({
   // consumer. Errors are swallowed — the original error UI is owned by the
   // primary bootstrap effect above, and a refresh failure should leave the
   // already-mounted chat alone rather than tearing the UI down.
-  const refreshInFlightRef = useRef(false);
+  //
+  // The in-flight latch is keyed by *token*, not a plain boolean. A
+  // navigation that swaps `tokenFromPath` from A to B while A's redeem is
+  // still pending must not block B from starting its own refresh — A's
+  // response would be discarded by the token-staleness guards below
+  // anyway, so leaving B with no refresh in flight would strand the
+  // capture hook's queued stale snapshot until an unrelated stale event
+  // or page reload happens to retrigger the callback.
+  const refreshInFlightTokenRef = useRef<string | null>(null);
   const requestRefreshAccessVersion = useCallback(() => {
-    if (refreshInFlightRef.current) return;
     const token = tokenFromPath;
     if (!token) return;
-    refreshInFlightRef.current = true;
+    // Same-token re-entry → drop. Different-token re-entry → allow; the
+    // older fetch will land in storage but its `setSession` is gated by
+    // `tokenFromPathRef`.
+    if (refreshInFlightTokenRef.current === token) return;
+    refreshInFlightTokenRef.current = token;
     void (async () => {
       try {
         const redeemResponse = await authFetch("/api/web/chatboxes/redeem", {
@@ -665,7 +676,12 @@ export function ChatboxChatPage({
           error,
         );
       } finally {
-        refreshInFlightRef.current = false;
+        // Only clear the latch if we're still the active in-flight refresh.
+        // A newer token's refresh may have already overwritten it; don't
+        // stomp on that one.
+        if (refreshInFlightTokenRef.current === token) {
+          refreshInFlightTokenRef.current = null;
+        }
       }
     })();
   }, [tokenFromPath, writeCurrentSession]);

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -604,6 +604,58 @@ export function ChatboxChatPage({
     writeCurrentSession,
   ]);
 
+  // Silent re-redeem path. The capture hook (or any chatbox-aware caller)
+  // calls this when the backend reports `chatbox_access_stale`. It re-runs
+  // /web/chatbox/redeem against the URL token and updates `session` in
+  // place, which propagates a fresh `accessVersion` to every downstream
+  // consumer. Errors are swallowed — the original error UI is owned by the
+  // primary bootstrap effect above, and a refresh failure should leave the
+  // already-mounted chat alone rather than tearing the UI down.
+  const refreshInFlightRef = useRef(false);
+  const requestRefreshAccessVersion = useCallback(() => {
+    if (refreshInFlightRef.current) return;
+    const token = tokenFromPath;
+    if (!token) return;
+    refreshInFlightRef.current = true;
+    void (async () => {
+      try {
+        const redeemResponse = await authFetch("/api/web/chatboxes/redeem", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ chatboxToken: token }),
+        });
+        if (!redeemResponse.ok) return;
+        const redeemed = (await redeemResponse.json()) as {
+          chatboxId?: unknown;
+          accessVersion?: unknown;
+          bootstrap?: unknown;
+        };
+        const nextSession = normalizeChatboxSession({
+          chatboxId:
+            typeof redeemed.chatboxId === "string"
+              ? redeemed.chatboxId
+              : undefined,
+          accessVersion:
+            typeof redeemed.accessVersion === "number"
+              ? redeemed.accessVersion
+              : undefined,
+          payload: redeemed.bootstrap as ChatboxSession["payload"] | undefined,
+          surface: readChatboxSurfaceFromUrl(window.location.search),
+        });
+        if (!nextSession) return;
+        writeCurrentSession(nextSession);
+        setSession(nextSession);
+      } catch (error) {
+        console.warn(
+          "[ChatboxChatPage] Silent chatbox re-redeem failed",
+          error,
+        );
+      } finally {
+        refreshInFlightRef.current = false;
+      }
+    })();
+  }, [tokenFromPath, writeCurrentSession]);
+
   const displayError = useMemo(
     () => getChatboxDisplayError(routeError),
     [routeError]
@@ -789,6 +841,7 @@ export function ChatboxChatPage({
             selectedServerIds: sessionServersActive.map(
               (server) => server.serverId
             ),
+            requestRefreshAccessVersion,
           }}
           executionConfig={{
             modelId: session.payload.modelId,

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -281,6 +281,15 @@ export function ChatboxChatPage({
   const [routeError, setRouteError] = useState<ChatboxRouteError | null>(null);
   const interactiveSignInEventKeyRef = useRef<string | null>(null);
   const tokenFromPath = useMemo(() => pathToken?.trim() || null, [pathToken]);
+  // Mirror `tokenFromPath` into a ref so async work (the silent re-redeem
+  // below) can detect a mid-flight navigation: when the user switches
+  // chatbox tokens before the in-flight `/api/web/chatboxes/redeem`
+  // response arrives, the resolved-but-stale session must not overwrite
+  // the new token's active session.
+  const tokenFromPathRef = useRef(tokenFromPath);
+  useEffect(() => {
+    tokenFromPathRef.current = tokenFromPath;
+  }, [tokenFromPath]);
   const isAuthSettling =
     Boolean(tokenFromPath) &&
     !playgroundParams &&
@@ -625,11 +634,13 @@ export function ChatboxChatPage({
           body: JSON.stringify({ chatboxToken: token }),
         });
         if (!redeemResponse.ok) return;
+        if (tokenFromPathRef.current !== token) return;
         const redeemed = (await redeemResponse.json()) as {
           chatboxId?: unknown;
           accessVersion?: unknown;
           bootstrap?: unknown;
         };
+        if (tokenFromPathRef.current !== token) return;
         const nextSession = normalizeChatboxSession({
           chatboxId:
             typeof redeemed.chatboxId === "string"
@@ -643,6 +654,9 @@ export function ChatboxChatPage({
           surface: readChatboxSurfaceFromUrl(window.location.search),
         });
         if (!nextSession) return;
+        // Final guard before mutating shared session state: a navigation
+        // between the JSON parse and now would still race.
+        if (tokenFromPathRef.current !== token) return;
         writeCurrentSession(nextSession);
         setSession(nextSession);
       } catch (error) {

--- a/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
@@ -596,6 +596,227 @@ describe("useSharedChatWidgetCapture", () => {
     unmount();
   });
 
+  it("retries stale snapshots even after the first refresh callback fails to advance accessVersion", async () => {
+    // P2 from review: if the parent's /redeem fetch fails, hostedAccessVersion
+    // never bumps, so the reset effect never runs. The hook must still fire
+    // onStaleHostedAccess on subsequent stale errors instead of latching
+    // permanently.
+    const onStaleHostedAccess = vi.fn();
+    class StaleError extends Error {
+      data: { code: string; currentAccessVersion: number };
+      constructor() {
+        super("Chatbox access version is stale; client must re-redeem.");
+        this.data = { code: "chatbox_access_stale", currentAccessVersion: 7 };
+      }
+    }
+    mockGenerateSnapshotUploadUrl.mockReset();
+    mockGenerateSnapshotUploadUrl.mockRejectedValue(new StaleError());
+
+    const { unmount } = renderHook(() =>
+      useSharedChatWidgetCapture({
+        enabled: true,
+        chatSessionId: "chat-session-refresh-fail",
+        hostedChatboxId: "cbx_1",
+        hostedAccessVersion: 1,
+        onStaleHostedAccess,
+        messages: [
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-search",
+                toolCallId: "call-a",
+                input: { q: "a" },
+                output: { result: "a", _serverId: "server-1" },
+              },
+              {
+                type: "tool-search",
+                toolCallId: "call-b",
+                input: { q: "b" },
+                output: { result: "b", _serverId: "server-1" },
+              },
+            ],
+          } as any,
+        ],
+      }),
+    );
+
+    act(() => {
+      useWidgetDebugStore.setState({
+        widgets: new Map([
+          [
+            "call-a",
+            {
+              toolCallId: "call-a",
+              toolName: "search",
+              protocol: "mcp-apps",
+              widgetState: null,
+              globals: { theme: "dark", displayMode: "inline" },
+              widgetHtml: "<div>A</div>",
+              updatedAt: Date.now(),
+            },
+          ],
+        ]),
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    await flushMicrotasks();
+    expect(onStaleHostedAccess).toHaveBeenCalledTimes(1);
+
+    // Parent's /redeem call failed silently — hostedAccessVersion did not
+    // advance. A second widget showing up later must still trigger another
+    // refresh, not get blocked by a stuck latch.
+    act(() => {
+      useWidgetDebugStore.setState({
+        widgets: new Map([
+          [
+            "call-b",
+            {
+              toolCallId: "call-b",
+              toolName: "search",
+              protocol: "mcp-apps",
+              widgetState: null,
+              globals: { theme: "dark", displayMode: "inline" },
+              widgetHtml: "<div>B</div>",
+              updatedAt: Date.now(),
+            },
+          ],
+        ]),
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    await flushMicrotasks();
+    expect(onStaleHostedAccess.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    unmount();
+  });
+
+  it("does not write to the new scope when chatSessionId changes mid-upload", async () => {
+    // CodeRabbit Major: an in-flight uploadAttemptRef started for chat A
+    // must not call createWidgetSnapshot against chat B's refs after a
+    // chatSessionId change.
+    let resolveCreateWidgetSnapshot: ((value: unknown) => void) | null = null;
+    mockCreateWidgetSnapshot.mockReset();
+    mockCreateWidgetSnapshot.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCreateWidgetSnapshot = resolve;
+        }),
+    );
+
+    const { rerender, unmount } = renderHook(
+      ({ chatSessionId }: { chatSessionId: string }) =>
+        useSharedChatWidgetCapture({
+          enabled: true,
+          chatSessionId,
+          hostedChatboxId: "cbx_1",
+          hostedAccessVersion: 1,
+          messages: [
+            {
+              id: "assistant-1",
+              role: "assistant",
+              parts: [
+                {
+                  type: "tool-search",
+                  toolCallId: "call-race",
+                  input: { q: "race" },
+                  output: { result: "ok", _serverId: "server-1" },
+                },
+              ],
+            } as any,
+          ],
+        }),
+      { initialProps: { chatSessionId: "chat-A" } },
+    );
+
+    act(() => {
+      useWidgetDebugStore.setState({
+        widgets: new Map([
+          [
+            "call-race",
+            {
+              toolCallId: "call-race",
+              toolName: "search",
+              protocol: "mcp-apps",
+              widgetState: null,
+              globals: { theme: "dark", displayMode: "inline" },
+              widgetHtml: "<div>Race</div>",
+              updatedAt: Date.now(),
+            },
+          ],
+        ]),
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    await flushMicrotasks();
+
+    // createWidgetSnapshot is awaiting; identity now changes.
+    expect(mockCreateWidgetSnapshot).toHaveBeenCalledTimes(1);
+    rerender({ chatSessionId: "chat-B" });
+    await flushMicrotasks();
+
+    // Resolve the pending mutation as if it succeeded for chat A.
+    act(() => {
+      resolveCreateWidgetSnapshot?.("snapshot-A");
+    });
+    await flushMicrotasks();
+
+    // The hook must not have written into chat B's bookkeeping refs. The
+    // observable signal: re-supplying the same widget after the rerender
+    // should NOT be treated as a duplicate. Bump the widget so the capture
+    // loop kicks again under chat-B.
+    act(() => {
+      useWidgetDebugStore.setState({
+        widgets: new Map([
+          [
+            "call-race",
+            {
+              toolCallId: "call-race",
+              toolName: "search",
+              protocol: "mcp-apps",
+              widgetState: null,
+              globals: { theme: "dark", displayMode: "inline" },
+              widgetHtml: "<div>Race v2</div>",
+              updatedAt: Date.now() + 1,
+            },
+          ],
+        ]),
+      });
+    });
+
+    // Swap the createWidgetSnapshot mock to resolve immediately for the
+    // chat-B attempt.
+    mockCreateWidgetSnapshot.mockImplementation(async () => "snapshot-B");
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    await flushMicrotasks();
+
+    // A second createWidgetSnapshot call should have happened under chat-B
+    // — proving the leaked chat-A success did not poison the
+    // uploadedHashes / cachedBlobs maps.
+    expect(mockCreateWidgetSnapshot).toHaveBeenCalledTimes(2);
+    expect(mockCreateWidgetSnapshot.mock.calls[1][0].chatSessionId).toBe(
+      "chat-B",
+    );
+
+    unmount();
+  });
+
   it("replays stale-failed snapshots when a fresh accessVersion arrives", async () => {
     const onStaleHostedAccess = vi.fn();
     class StaleError extends Error {

--- a/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
@@ -510,6 +510,92 @@ describe("useSharedChatWidgetCapture", () => {
     unmount();
   });
 
+  it("requests a hosted-access refresh on chatbox_access_stale and skips the local retry", async () => {
+    const onStaleHostedAccess = vi.fn();
+    class StaleError extends Error {
+      data: { code: string; currentAccessVersion: number };
+      constructor() {
+        super("Chatbox access version is stale; client must re-redeem.");
+        this.data = { code: "chatbox_access_stale", currentAccessVersion: 7 };
+      }
+    }
+    mockGenerateSnapshotUploadUrl.mockReset();
+    mockGenerateSnapshotUploadUrl.mockRejectedValue(new StaleError());
+
+    const { unmount } = renderHook(() =>
+      useSharedChatWidgetCapture({
+        enabled: true,
+        chatSessionId: "chat-session-stale",
+        hostedChatboxId: "cbx_1",
+        hostedAccessVersion: 1,
+        onStaleHostedAccess,
+        messages: [
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-search",
+                toolCallId: "call-stale",
+                input: { q: "hello" },
+                output: { result: "world", _serverId: "server-1" },
+              },
+            ],
+          } as any,
+        ],
+      }),
+    );
+
+    act(() => {
+      useWidgetDebugStore.setState({
+        widgets: new Map([
+          [
+            "call-stale",
+            {
+              toolCallId: "call-stale",
+              toolName: "search",
+              protocol: "mcp-apps",
+              widgetState: null,
+              globals: { theme: "dark", displayMode: "inline" },
+              widgetHtml: "<div>Widget</div>",
+              updatedAt: Date.now(),
+            },
+          ],
+        ]),
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    await flushMicrotasks();
+
+    // One initial upload flight (three concurrent uploadBlob calls, one
+    // per blob) — Promise.all rejects on the first stale error and
+    // suppresses the local retry path.
+    const generateCallsAfterFlight =
+      mockGenerateSnapshotUploadUrl.mock.calls.length;
+    expect(generateCallsAfterFlight).toBeGreaterThanOrEqual(1);
+    expect(onStaleHostedAccess).toHaveBeenCalledTimes(1);
+    expect(mockCreateWidgetSnapshot).not.toHaveBeenCalled();
+
+    // No local exponential retry should be scheduled for a stale-access
+    // error — recovery is driven by the parent's re-redeem.
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    await flushMicrotasks();
+
+    expect(mockGenerateSnapshotUploadUrl.mock.calls.length).toBe(
+      generateCallsAfterFlight,
+    );
+    expect(onStaleHostedAccess).toHaveBeenCalledTimes(1);
+
+    unmount();
+  });
+
   it("skips widget capture for tool calls that already have persisted snapshots", async () => {
     const { unmount } = renderHook(() =>
       useSharedChatWidgetCapture({

--- a/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
@@ -596,6 +596,104 @@ describe("useSharedChatWidgetCapture", () => {
     unmount();
   });
 
+  it("replays stale-failed snapshots when a fresh accessVersion arrives", async () => {
+    const onStaleHostedAccess = vi.fn();
+    class StaleError extends Error {
+      data: { code: string; currentAccessVersion: number };
+      constructor() {
+        super("Chatbox access version is stale; client must re-redeem.");
+        this.data = { code: "chatbox_access_stale", currentAccessVersion: 7 };
+      }
+    }
+
+    let uploadCounter = 0;
+    mockGenerateSnapshotUploadUrl.mockReset();
+    mockGenerateSnapshotUploadUrl.mockImplementation(async () => {
+      uploadCounter += 1;
+      throw new StaleError();
+    });
+
+    const { rerender, unmount } = renderHook(
+      ({ hostedAccessVersion }: { hostedAccessVersion: number }) =>
+        useSharedChatWidgetCapture({
+          enabled: true,
+          chatSessionId: "chat-session-replay",
+          hostedChatboxId: "cbx_1",
+          hostedAccessVersion,
+          onStaleHostedAccess,
+          messages: [
+            {
+              id: "assistant-1",
+              role: "assistant",
+              parts: [
+                {
+                  type: "tool-search",
+                  toolCallId: "call-replay",
+                  input: { q: "hello" },
+                  output: { result: "world", _serverId: "server-1" },
+                },
+              ],
+            } as any,
+          ],
+        }),
+      { initialProps: { hostedAccessVersion: 1 } },
+    );
+
+    act(() => {
+      useWidgetDebugStore.setState({
+        widgets: new Map([
+          [
+            "call-replay",
+            {
+              toolCallId: "call-replay",
+              toolName: "search",
+              protocol: "mcp-apps",
+              widgetState: null,
+              globals: { theme: "dark", displayMode: "inline" },
+              widgetHtml: "<div>Widget</div>",
+              updatedAt: Date.now(),
+            },
+          ],
+        ]),
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    await flushMicrotasks();
+    const generateCallsAfterFirstFlight =
+      mockGenerateSnapshotUploadUrl.mock.calls.length;
+    expect(generateCallsAfterFirstFlight).toBeGreaterThanOrEqual(1);
+    expect(onStaleHostedAccess).toHaveBeenCalledTimes(1);
+    expect(mockCreateWidgetSnapshot).not.toHaveBeenCalled();
+
+    // Parent's silent re-redeem hands back a fresh accessVersion. Swap the
+    // mock to resolve so the replay actually succeeds end-to-end.
+    mockGenerateSnapshotUploadUrl.mockImplementation(async () => {
+      uploadCounter += 1;
+      return `https://upload.example.com/${uploadCounter}`;
+    });
+
+    rerender({ hostedAccessVersion: 2 });
+
+    await flushMicrotasks();
+
+    expect(mockGenerateSnapshotUploadUrl.mock.calls.length).toBeGreaterThan(
+      generateCallsAfterFirstFlight,
+    );
+    expect(mockCreateWidgetSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockCreateWidgetSnapshot.mock.calls[0][0]).toMatchObject({
+      chatboxId: "cbx_1",
+      accessVersion: 2,
+      chatSessionId: "chat-session-replay",
+      toolCallId: "call-replay",
+    });
+
+    unmount();
+  });
+
   it("skips widget capture for tool calls that already have persisted snapshots", async () => {
     const { unmount } = renderHook(() =>
       useSharedChatWidgetCapture({

--- a/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
@@ -573,15 +573,18 @@ describe("useSharedChatWidgetCapture", () => {
 
     // One initial upload flight (three concurrent uploadBlob calls, one
     // per blob) — Promise.all rejects on the first stale error and
-    // suppresses the local retry path.
+    // suppresses the local snapshot-retry path.
     const generateCallsAfterFlight =
       mockGenerateSnapshotUploadUrl.mock.calls.length;
     expect(generateCallsAfterFlight).toBeGreaterThanOrEqual(1);
-    expect(onStaleHostedAccess).toHaveBeenCalledTimes(1);
+    expect(onStaleHostedAccess).toHaveBeenCalled();
     expect(mockCreateWidgetSnapshot).not.toHaveBeenCalled();
 
-    // No local exponential retry should be scheduled for a stale-access
-    // error — recovery is driven by the parent's re-redeem.
+    // No local *snapshot* retry should be scheduled — the
+    // `generateSnapshotUploadUrl` call count must stay flat even as the
+    // refresh-backoff timer fires repeatedly. (The refresh callback
+    // itself is allowed to be re-invoked on a bounded backoff; that
+    // behaviour is covered by a dedicated test.)
     act(() => {
       vi.advanceTimersByTime(60_000);
     });
@@ -591,7 +594,6 @@ describe("useSharedChatWidgetCapture", () => {
     expect(mockGenerateSnapshotUploadUrl.mock.calls.length).toBe(
       generateCallsAfterFlight,
     );
-    expect(onStaleHostedAccess).toHaveBeenCalledTimes(1);
 
     unmount();
   });
@@ -696,6 +698,90 @@ describe("useSharedChatWidgetCapture", () => {
 
     await flushMicrotasks();
     expect(onStaleHostedAccess.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    unmount();
+  });
+
+  it("re-fires the refresh callback on a backoff while the queue is non-empty", async () => {
+    // Codex P2: if the parent's redeem fails (accessVersion never bumps),
+    // the queued stale snapshot must not be stranded — the hook should
+    // retry the refresh on a bounded backoff so the parent gets another
+    // chance.
+    const onStaleHostedAccess = vi.fn();
+    class StaleError extends Error {
+      data: { code: string; currentAccessVersion: number };
+      constructor() {
+        super("Chatbox access version is stale; client must re-redeem.");
+        this.data = { code: "chatbox_access_stale", currentAccessVersion: 7 };
+      }
+    }
+    mockGenerateSnapshotUploadUrl.mockReset();
+    mockGenerateSnapshotUploadUrl.mockRejectedValue(new StaleError());
+
+    const { unmount } = renderHook(() =>
+      useSharedChatWidgetCapture({
+        enabled: true,
+        chatSessionId: "chat-session-backoff",
+        hostedChatboxId: "cbx_1",
+        hostedAccessVersion: 1,
+        onStaleHostedAccess,
+        messages: [
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-search",
+                toolCallId: "call-backoff",
+                input: { q: "hello" },
+                output: { result: "world", _serverId: "server-1" },
+              },
+            ],
+          } as any,
+        ],
+      }),
+    );
+
+    act(() => {
+      useWidgetDebugStore.setState({
+        widgets: new Map([
+          [
+            "call-backoff",
+            {
+              toolCallId: "call-backoff",
+              toolName: "search",
+              protocol: "mcp-apps",
+              widgetState: null,
+              globals: { theme: "dark", displayMode: "inline" },
+              widgetHtml: "<div>Widget</div>",
+              updatedAt: Date.now(),
+            },
+          ],
+        ]),
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    await flushMicrotasks();
+    expect(onStaleHostedAccess).toHaveBeenCalledTimes(1);
+
+    // Parent's redeem failed: accessVersion never advanced. The backoff
+    // timer should re-fire the callback after ~1s.
+    act(() => {
+      vi.advanceTimersByTime(1100);
+    });
+    await flushMicrotasks();
+    expect(onStaleHostedAccess.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+    // And again after ~2s more (next backoff tick).
+    act(() => {
+      vi.advanceTimersByTime(2100);
+    });
+    await flushMicrotasks();
+    expect(onStaleHostedAccess.mock.calls.length).toBeGreaterThanOrEqual(3);
 
     unmount();
   });

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -909,18 +909,20 @@ function areAuthHeadersEqual(
 type HostedSessionScope = {
   projectId?: string | null;
   chatboxId?: string;
-  accessVersion?: number;
 };
 
+// `accessVersion` is intentionally NOT part of the scope. The chat-reset
+// path uses this comparison to decide when to blow away `chatSessionId` /
+// `messages`, which is only appropriate when *identity* changes (different
+// project, different chatbox). A pure `accessVersion` bump — e.g. from the
+// silent re-redeem triggered by `chatbox_access_stale` — keeps the same
+// chatbox and the same conversation; tearing the chat down on those bumps
+// would defeat the purpose of the recovery path.
 function areHostedSessionScopesEqual(
   a: HostedSessionScope,
   b: HostedSessionScope
 ): boolean {
-  return (
-    a.projectId === b.projectId &&
-    a.chatboxId === b.chatboxId &&
-    a.accessVersion === b.accessVersion
-  );
+  return a.projectId === b.projectId && a.chatboxId === b.chatboxId;
 }
 
 function isAuthDeniedError(error: unknown): boolean {
@@ -1035,7 +1037,6 @@ export function useChatSession({
   const lastResolvedHostedScopeRef = useRef<HostedSessionScope>({
     projectId: undefined,
     chatboxId: undefined,
-    accessVersion: undefined,
   });
   const pendingSessionHydrationRef = useRef<PendingSessionHydration | null>(
     null
@@ -1902,7 +1903,6 @@ export function useChatSession({
         const currentHostedScope = {
           projectId: hostedProjectId,
           chatboxId: hostedChatboxId,
-          accessVersion: hostedAccessVersion,
         };
         const hasResolvedBefore = hasResolvedAuthHeadersRef.current;
         const authHeadersChanged =

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -1932,10 +1932,18 @@ export function useChatSession({
     return () => {
       active = false;
     };
+    // `hostedAccessVersion` is intentionally excluded. The effect resets
+    // `isSessionBootstrapComplete` to `false` synchronously on every run;
+    // including a value that bumps on every silent re-redeem (the
+    // `chatbox_access_stale` recovery path) would flip the flag false →
+    // true on each refresh, briefly unmounting downstream consumers gated
+    // on it (ChatTabV2). Auth-header resolution doesn't depend on the
+    // version, and the scope-equality check inside the effect no longer
+    // reads it either, so the effect body is exhaustive-deps-clean
+    // without it.
   }, [
     getAccessToken,
     hostedChatboxId,
-    hostedAccessVersion,
     hostedProjectId,
     isAuthenticated,
     isHostedGuest,

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -947,6 +947,7 @@ export function useChatSession({
   const hostedChatboxId = hostedContext?.chatboxId;
   const hostedAccessVersion = hostedContext?.accessVersion;
   const hostedChatboxSurface = hostedContext?.chatboxSurface;
+  const requestRefreshAccessVersion = hostedContext?.requestRefreshAccessVersion;
   const initialModelId = executionConfig?.modelId;
   const initialSystemPrompt =
     executionConfig?.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
@@ -1597,6 +1598,7 @@ export function useChatSession({
     hostedAccessVersion,
     persistedSnapshotToolCallIds,
     messages,
+    onStaleHostedAccess: requestRefreshAccessVersion,
   });
 
   const setMessages = useCallback<

--- a/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
@@ -31,6 +31,11 @@ interface UseSharedChatWidgetCaptureOptions {
 
 const MAX_PENDING_SESSION_RETRIES = 5;
 const SNAPSHOT_CAPTURE_DELAY_MS = 500;
+// Bounded backoff for re-asking the parent to redeem when the previous
+// redeem appears to have failed (queue still non-empty, accessVersion
+// hasn't advanced). 1s, 2s, 4s, 8s, 16s — capped at 30s.
+const MAX_STALE_REFRESH_ATTEMPTS = 5;
+const STALE_REFRESH_BACKOFF_CEILING_MS = 30_000;
 
 interface ToolSnapshotSource {
   toolName: string;
@@ -236,6 +241,14 @@ export function useSharedChatWidgetCapture({
   // until an unrelated widget/message change happens to retrigger the
   // debounced sweep.
   const pendingStaleRetryRef = useRef(new Set<string>());
+  // Bounded backoff state for re-asking the parent to redeem. Tracks how
+  // many times the timer has refired (without an accessVersion bump in
+  // between) and the currently-scheduled timer. Reset to zero whenever
+  // accessVersion actually advances or the chat identity changes.
+  const staleRefreshAttemptsRef = useRef(0);
+  const staleRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
   const prevScopeRef = useRef({
     chatSessionId,
     hostedChatboxId,
@@ -254,6 +267,50 @@ export function useSharedChatWidgetCapture({
   useEffect(() => {
     onStaleHostedAccessRef.current = onStaleHostedAccess;
   }, [onStaleHostedAccess]);
+
+  // Re-fire the parent's refresh callback on a backoff while the queue is
+  // non-empty and accessVersion hasn't advanced. The parent's redeem can
+  // fail silently (network / 5xx / 4xx); without this, a single failed
+  // redeem strands the queued snapshot until an unrelated stale event or
+  // a page reload happens to retrigger the callback path.
+  const schedulePendingStaleRefresh = () => {
+    if (staleRefreshTimerRef.current) {
+      clearTimeout(staleRefreshTimerRef.current);
+      staleRefreshTimerRef.current = null;
+    }
+    if (pendingStaleRetryRef.current.size === 0) return;
+    const attempts = staleRefreshAttemptsRef.current;
+    if (attempts >= MAX_STALE_REFRESH_ATTEMPTS) {
+      console.warn(
+        "[useSharedChatWidgetCapture] Giving up on stale-access refresh after",
+        attempts,
+        "attempts; queued toolCallIds:",
+        Array.from(pendingStaleRetryRef.current),
+      );
+      return;
+    }
+    const delayMs = Math.min(
+      1000 * Math.pow(2, attempts),
+      STALE_REFRESH_BACKOFF_CEILING_MS,
+    );
+    staleRefreshTimerRef.current = setTimeout(() => {
+      staleRefreshTimerRef.current = null;
+      if (pendingStaleRetryRef.current.size === 0) return;
+      staleRefreshAttemptsRef.current += 1;
+      onStaleHostedAccessRef.current?.();
+      // Re-arm for the next backoff tick. If accessVersion bumps before
+      // the next fire, the reset effect cancels this timer and resets
+      // attempts to zero.
+      schedulePendingStaleRefresh();
+    }, delayMs);
+  };
+  const clearPendingStaleRefresh = () => {
+    if (staleRefreshTimerRef.current) {
+      clearTimeout(staleRefreshTimerRef.current);
+      staleRefreshTimerRef.current = null;
+    }
+    staleRefreshAttemptsRef.current = 0;
+  };
 
   useEffect(() => {
     toolSourcesRef.current = buildToolSourceMap(messages);
@@ -290,6 +347,7 @@ export function useSharedChatWidgetCapture({
       cachedBlobsRef.current.clear();
       retryCountRef.current.clear();
       pendingStaleRetryRef.current.clear();
+      clearPendingStaleRefresh();
       for (const timer of pendingTimersRef.current.values()) {
         clearTimeout(timer);
       }
@@ -300,7 +358,9 @@ export function useSharedChatWidgetCapture({
       // silent re-redeem has handed us a fresh version. Replay the
       // toolCallIds whose previous attempt died on `chatbox_access_stale`
       // so the capture loop self-heals without waiting for an unrelated
-      // widget/message change.
+      // widget/message change. Cancel the bounded-backoff timer too —
+      // we made progress, no further auto-refreshes needed.
+      clearPendingStaleRefresh();
       const replay = Array.from(pendingStaleRetryRef.current);
       pendingStaleRetryRef.current.clear();
       for (const toolCallId of replay) {
@@ -318,6 +378,10 @@ export function useSharedChatWidgetCapture({
       }
       pendingTimersRef.current.clear();
       inFlightRef.current.clear();
+      if (staleRefreshTimerRef.current) {
+        clearTimeout(staleRefreshTimerRef.current);
+        staleRefreshTimerRef.current = null;
+      }
     };
   }, []);
 
@@ -486,6 +550,12 @@ export function useSharedChatWidgetCapture({
         }
         pendingStaleRetryRef.current.add(toolCallId);
         onStaleHostedAccessRef.current?.();
+        // Arm/refresh the bounded-backoff timer. If the parent's redeem
+        // succeeds, `hostedAccessVersion` will bump, the reset effect
+        // drains the queue and cancels this timer. If the redeem fails,
+        // the timer re-fires `onStaleHostedAccess` on a growing backoff
+        // so the queued snapshot isn't stranded.
+        schedulePendingStaleRefresh();
       } else if (shouldRetryPendingSnapshot(undefined, error)) {
         const retries = retryCountRef.current.get(toolCallId) ?? 0;
         if (retries >= MAX_PENDING_SESSION_RETRIES) {

--- a/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
@@ -229,7 +229,6 @@ export function useSharedChatWidgetCapture({
     new Set(persistedSnapshotToolCallIds),
   );
   const onStaleHostedAccessRef = useRef(onStaleHostedAccess);
-  const staleRefreshRequestedRef = useRef(false);
   // ToolCallIds whose upload was abandoned mid-flight because the backend
   // reported `chatbox_access_stale`. Replayed once the next
   // `hostedAccessVersion` arrives — without this, the parent's re-redeem
@@ -241,6 +240,13 @@ export function useSharedChatWidgetCapture({
     chatSessionId,
     hostedChatboxId,
   });
+  // Identity generation. Bumped whenever `chatSessionId` or
+  // `hostedChatboxId` changes. Each `uploadAttemptRef` invocation captures
+  // its generation at start and bails before any state-mutating
+  // continuation if the scope has moved — without this, an in-flight
+  // upload for chat A can land its `createWidgetSnapshot` call in chat B
+  // (refs are read lazily through the async function's awaits).
+  const scopeGenerationRef = useRef(0);
   const uploadAttemptRef = useRef<(toolCallId: string) => Promise<void>>(
     async () => {},
   );
@@ -272,14 +278,14 @@ export function useSharedChatWidgetCapture({
     sessionIdRef.current = chatSessionId;
     chatboxIdRef.current = hostedChatboxId;
     accessVersionRef.current = hostedAccessVersion;
-    // Re-arm the stale-access debounce so a subsequent divergence can
-    // trigger another re-redeem.
-    staleRefreshRequestedRef.current = false;
 
     if (identityChanged) {
       // Different chat or different chatbox → previous per-toolCallId state
       // is no longer relevant. Drop everything, including the stale-retry
-      // queue (those toolCallIds belong to the old scope).
+      // queue (those toolCallIds belong to the old scope). Bump the scope
+      // generation so any in-flight upload bails at its next continuation
+      // point rather than writing into the new scope.
+      scopeGenerationRef.current += 1;
       uploadedHashesRef.current.clear();
       cachedBlobsRef.current.clear();
       retryCountRef.current.clear();
@@ -318,6 +324,13 @@ export function useSharedChatWidgetCapture({
   uploadAttemptRef.current = async (toolCallId: string) => {
     const chatboxId = chatboxIdRef.current;
     const accessVersion = accessVersionRef.current;
+    // Generation snapshot. Re-read against `scopeGenerationRef.current`
+    // after every await to detect identity changes (chatSessionId /
+    // chatboxId) and bail before mutating per-scope refs or calling
+    // `createWidgetSnapshot` for the wrong chat.
+    const attemptGeneration = scopeGenerationRef.current;
+    const scopeStillValid = () =>
+      scopeGenerationRef.current === attemptGeneration;
     if (!enabled || !readyToPersist || inFlightRef.current.has(toolCallId)) {
       return;
     }
@@ -389,6 +402,13 @@ export function useSharedChatWidgetCapture({
               "application/json",
             ),
           ]);
+        if (!scopeStillValid()) {
+          // Scope moved while uploads were in flight. The blobs are
+          // orphaned in storage, but writing the cache entry under the
+          // new scope's refs would cause the next attempt to skip the
+          // re-upload pass and reference stale storage IDs.
+          return;
+        }
         cached = {
           htmlHash,
           widgetHtmlBlobId,
@@ -397,6 +417,8 @@ export function useSharedChatWidgetCapture({
         };
         cachedBlobsRef.current.set(toolCallId, cached);
       }
+
+      if (!scopeStillValid()) return;
 
       const snapshotPayload = {
         ...(chatboxId ? { chatboxId } : {}),
@@ -420,6 +442,15 @@ export function useSharedChatWidgetCapture({
       };
       const snapshotResult = await createWidgetSnapshot(snapshotPayload);
 
+      if (!scopeStillValid()) {
+        // Scope changed across the mutation await. The snapshot row was
+        // written for the previous chat — that's fine; the previous chat
+        // is what it belongs to. But don't touch the new scope's
+        // bookkeeping refs (uploadedHashesRef etc.), since the reset
+        // effect just cleared them on our behalf.
+        return;
+      }
+
       if (shouldRetryPendingSnapshot(snapshotResult, null)) {
         throw new Error("Session not found for chat session");
       }
@@ -428,12 +459,24 @@ export function useSharedChatWidgetCapture({
       cachedBlobsRef.current.delete(toolCallId);
       retryCountRef.current.delete(toolCallId);
     } catch (error) {
+      if (!scopeStillValid()) {
+        // Same as above — anything we do here would mutate refs that
+        // belong to a different scope now.
+        return;
+      }
       if (isStaleHostedAccessError(error)) {
         // Drop cached blobs uploaded under the stale accessVersion, queue
         // this toolCallId for replay once the fresh accessVersion arrives,
         // and ask the owner to re-redeem. The reset effect drains the
         // queue so recovery doesn't depend on an unrelated widget/message
         // change re-triggering the debounced sweep.
+        //
+        // No hook-side latch: the parent's `requestRefreshAccessVersion`
+        // gates re-entrancy with its own in-flight ref (cleared in
+        // `finally`), so concurrent stale errors coalesce there. Latching
+        // here would survive a failed `/api/web/chatboxes/redeem`
+        // response (no accessVersion bump → no reset → latch stuck true)
+        // and silently disable every future recovery attempt.
         cachedBlobsRef.current.delete(toolCallId);
         retryCountRef.current.delete(toolCallId);
         const existingTimer = pendingTimersRef.current.get(toolCallId);
@@ -442,10 +485,7 @@ export function useSharedChatWidgetCapture({
           pendingTimersRef.current.delete(toolCallId);
         }
         pendingStaleRetryRef.current.add(toolCallId);
-        if (!staleRefreshRequestedRef.current) {
-          staleRefreshRequestedRef.current = true;
-          onStaleHostedAccessRef.current?.();
-        }
+        onStaleHostedAccessRef.current?.();
       } else if (shouldRetryPendingSnapshot(undefined, error)) {
         const retries = retryCountRef.current.get(toolCallId) ?? 0;
         if (retries >= MAX_PENDING_SESSION_RETRIES) {

--- a/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
@@ -22,6 +22,11 @@ interface UseSharedChatWidgetCaptureOptions {
   hostedAccessVersion?: number;
   persistedSnapshotToolCallIds?: string[];
   messages: UIMessage[];
+  // Called when the backend reports `chatbox_access_stale` — the owner
+  // (typically ChatboxChatPage via use-chat-session) should re-run the
+  // /web/chatbox/redeem fetch so a fresh `hostedAccessVersion` flows back
+  // into this hook and the capture loop re-fires.
+  onStaleHostedAccess?: () => void;
 }
 
 const MAX_PENDING_SESSION_RETRIES = 5;
@@ -167,6 +172,19 @@ function shouldRetryPendingSnapshot(result: unknown, error: unknown): boolean {
   return message.includes("Session not found");
 }
 
+// Convex `ConvexError` payloads land on `err.data`. The backend throws
+// `{ code: 'chatbox_access_stale', currentAccessVersion }` when the client's
+// cached accessVersion no longer matches the chatbox doc — recovery is to
+// re-redeem, not to back off and retry locally.
+function isStaleHostedAccessError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const data = (error as { data?: unknown }).data;
+  if (!data || typeof data !== "object") return false;
+  return (
+    (data as { code?: unknown }).code === "chatbox_access_stale"
+  );
+}
+
 export function useSharedChatWidgetCapture({
   enabled,
   readyToPersist = true,
@@ -175,6 +193,7 @@ export function useSharedChatWidgetCapture({
   hostedAccessVersion,
   persistedSnapshotToolCallIds = [],
   messages,
+  onStaleHostedAccess,
 }: UseSharedChatWidgetCaptureOptions): void {
   const widgets = useWidgetDebugStore((state) => state.widgets);
   const generateSnapshotUploadUrl = useMutation(
@@ -209,9 +228,15 @@ export function useSharedChatWidgetCapture({
   const persistedSnapshotToolCallIdsRef = useRef(
     new Set(persistedSnapshotToolCallIds),
   );
+  const onStaleHostedAccessRef = useRef(onStaleHostedAccess);
+  const staleRefreshRequestedRef = useRef(false);
   const uploadAttemptRef = useRef<(toolCallId: string) => Promise<void>>(
     async () => {},
   );
+
+  useEffect(() => {
+    onStaleHostedAccessRef.current = onStaleHostedAccess;
+  }, [onStaleHostedAccess]);
 
   useEffect(() => {
     toolSourcesRef.current = buildToolSourceMap(messages);
@@ -234,6 +259,10 @@ export function useSharedChatWidgetCapture({
     uploadedHashesRef.current.clear();
     cachedBlobsRef.current.clear();
     retryCountRef.current.clear();
+    // A successful identity refresh (new accessVersion) re-arms the
+    // stale-access debounce so the next divergence can trigger another
+    // re-redeem.
+    staleRefreshRequestedRef.current = false;
 
     for (const timer of pendingTimersRef.current.values()) {
       clearTimeout(timer);
@@ -365,7 +394,23 @@ export function useSharedChatWidgetCapture({
       cachedBlobsRef.current.delete(toolCallId);
       retryCountRef.current.delete(toolCallId);
     } catch (error) {
-      if (shouldRetryPendingSnapshot(undefined, error)) {
+      if (isStaleHostedAccessError(error)) {
+        // Drop cached blobs uploaded under the stale accessVersion and
+        // ask the owner to re-redeem. The hook will reset (and rearm the
+        // debounce) when the fresh accessVersion flows back through props,
+        // and the capture loop fires again automatically.
+        cachedBlobsRef.current.delete(toolCallId);
+        retryCountRef.current.delete(toolCallId);
+        const existingTimer = pendingTimersRef.current.get(toolCallId);
+        if (existingTimer) {
+          clearTimeout(existingTimer);
+          pendingTimersRef.current.delete(toolCallId);
+        }
+        if (!staleRefreshRequestedRef.current) {
+          staleRefreshRequestedRef.current = true;
+          onStaleHostedAccessRef.current?.();
+        }
+      } else if (shouldRetryPendingSnapshot(undefined, error)) {
         const retries = retryCountRef.current.get(toolCallId) ?? 0;
         if (retries >= MAX_PENDING_SESSION_RETRIES) {
           console.warn(

--- a/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
@@ -230,6 +230,17 @@ export function useSharedChatWidgetCapture({
   );
   const onStaleHostedAccessRef = useRef(onStaleHostedAccess);
   const staleRefreshRequestedRef = useRef(false);
+  // ToolCallIds whose upload was abandoned mid-flight because the backend
+  // reported `chatbox_access_stale`. Replayed once the next
+  // `hostedAccessVersion` arrives — without this, the parent's re-redeem
+  // silently changes a ref value and nothing re-fires the capture loop
+  // until an unrelated widget/message change happens to retrigger the
+  // debounced sweep.
+  const pendingStaleRetryRef = useRef(new Set<string>());
+  const prevScopeRef = useRef({
+    chatSessionId,
+    hostedChatboxId,
+  });
   const uploadAttemptRef = useRef<(toolCallId: string) => Promise<void>>(
     async () => {},
   );
@@ -253,22 +264,45 @@ export function useSharedChatWidgetCapture({
   }, [persistedSnapshotToolCallIds]);
 
   useEffect(() => {
+    const prev = prevScopeRef.current;
+    const identityChanged =
+      prev.chatSessionId !== chatSessionId ||
+      prev.hostedChatboxId !== hostedChatboxId;
+
     sessionIdRef.current = chatSessionId;
     chatboxIdRef.current = hostedChatboxId;
     accessVersionRef.current = hostedAccessVersion;
-    uploadedHashesRef.current.clear();
-    cachedBlobsRef.current.clear();
-    retryCountRef.current.clear();
-    // A successful identity refresh (new accessVersion) re-arms the
-    // stale-access debounce so the next divergence can trigger another
-    // re-redeem.
+    // Re-arm the stale-access debounce so a subsequent divergence can
+    // trigger another re-redeem.
     staleRefreshRequestedRef.current = false;
 
-    for (const timer of pendingTimersRef.current.values()) {
-      clearTimeout(timer);
+    if (identityChanged) {
+      // Different chat or different chatbox → previous per-toolCallId state
+      // is no longer relevant. Drop everything, including the stale-retry
+      // queue (those toolCallIds belong to the old scope).
+      uploadedHashesRef.current.clear();
+      cachedBlobsRef.current.clear();
+      retryCountRef.current.clear();
+      pendingStaleRetryRef.current.clear();
+      for (const timer of pendingTimersRef.current.values()) {
+        clearTimeout(timer);
+      }
+      pendingTimersRef.current.clear();
+      inFlightRef.current.clear();
+    } else if (pendingStaleRetryRef.current.size > 0) {
+      // accessVersion bumped on the same chatbox/session — the parent's
+      // silent re-redeem has handed us a fresh version. Replay the
+      // toolCallIds whose previous attempt died on `chatbox_access_stale`
+      // so the capture loop self-heals without waiting for an unrelated
+      // widget/message change.
+      const replay = Array.from(pendingStaleRetryRef.current);
+      pendingStaleRetryRef.current.clear();
+      for (const toolCallId of replay) {
+        void uploadAttemptRef.current(toolCallId);
+      }
     }
-    pendingTimersRef.current.clear();
-    inFlightRef.current.clear();
+
+    prevScopeRef.current = { chatSessionId, hostedChatboxId };
   }, [chatSessionId, hostedChatboxId, hostedAccessVersion]);
 
   useEffect(() => {
@@ -395,10 +429,11 @@ export function useSharedChatWidgetCapture({
       retryCountRef.current.delete(toolCallId);
     } catch (error) {
       if (isStaleHostedAccessError(error)) {
-        // Drop cached blobs uploaded under the stale accessVersion and
-        // ask the owner to re-redeem. The hook will reset (and rearm the
-        // debounce) when the fresh accessVersion flows back through props,
-        // and the capture loop fires again automatically.
+        // Drop cached blobs uploaded under the stale accessVersion, queue
+        // this toolCallId for replay once the fresh accessVersion arrives,
+        // and ask the owner to re-redeem. The reset effect drains the
+        // queue so recovery doesn't depend on an unrelated widget/message
+        // change re-triggering the debounced sweep.
         cachedBlobsRef.current.delete(toolCallId);
         retryCountRef.current.delete(toolCallId);
         const existingTimer = pendingTimersRef.current.get(toolCallId);
@@ -406,6 +441,7 @@ export function useSharedChatWidgetCapture({
           clearTimeout(existingTimer);
           pendingTimersRef.current.delete(toolCallId);
         }
+        pendingStaleRetryRef.current.add(toolCallId);
         if (!staleRefreshRequestedRef.current) {
           staleRefreshRequestedRef.current = true;
           onStaleHostedAccessRef.current?.();

--- a/mcpjam-inspector/client/src/lib/hosted-runtime-context.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-runtime-context.ts
@@ -9,4 +9,11 @@ export type HostedRuntimeContext = {
   chatboxId?: string;
   accessVersion?: number;
   chatboxSurface?: "preview" | "share_link";
+  /**
+   * Silent re-redeem trigger. Called when a chatbox-aware Convex mutation
+   * reports `chatbox_access_stale` — the owner re-runs
+   * /web/chatbox/redeem and updates `accessVersion` in place so dependent
+   * flows can retry without a page reload.
+   */
+  requestRefreshAccessVersion?: () => void;
 };


### PR DESCRIPTION
## Summary

- **Bug:** Chatbox-mode widget snapshots never reach `sharedChatWidgetSnapshots`, so the Sessions tab shows the transcript but an empty widget block (repro: open a hosted chatbox, run a widget-rendering tool like `list_users`, open Sessions). Root cause is a contract mismatch — `useSharedChatWidgetCapture` (Phase E/F migration, #2056) sends `accessVersion` on every `chatSessions:generateSnapshotUploadUrl` / `createWidgetSnapshot` call, but the backend validators don't list the field; Convex strict validation rejects with `ArgumentValidationError: Object contains extra field 'accessVersion'`.
- **Fix split across two PRs:**
  - **Backend** (MCPJam/mcpjam-backend#256, *land first*): teach both validators about `accessVersion: v.optional(v.number())`, validate via `requireHostedChatAccess(expectedAccessVersion)`, and throw `ConvexError({ code: 'chatbox_access_stale', currentAccessVersion })` on mismatch.
  - **This PR (inspector):** the recovery half — detect the new error code, drop cached blob refs for the failing `toolCallId`, fire a debounced `onStaleHostedAccess` callback, and skip local exponential backoff. `ChatboxChatPage.requestRefreshAccessVersion` silently re-runs `/api/web/chatboxes/redeem` and updates the in-place session, propagating a fresh `accessVersion` to every downstream consumer (capture hook, OAuth gate, API context). No bootstrapping-loader flip; chat UI doesn't tear down on revoke/regrant.

## Why a structured ConvexError, not message-matching

The existing retry helper `shouldRetryPendingSnapshot` regex-matches `"Session not found"` to recognise the only other retryable error. Adding another string match would be brittle. The backend uses `ConvexError` so this hook branches on `err.data.code === 'chatbox_access_stale'` instead.

## What gets retried, by whom

- **Snapshot's exponential backoff** continues to handle the "session not found" race (chat ingestion hasn't materialised the session yet).
- **Stale-access** is not retried locally — recovery is driven by the parent re-redeem. The hook clears cached blob refs, fires `onStaleHostedAccess` once (debounced via `staleRefreshRequestedRef`), and waits. When `hostedAccessVersion` flows back into props, the existing dep-array effect resets state and the capture loop re-fires automatically with the fresh version.

## Files changed

- `client/src/lib/hosted-runtime-context.ts` — new optional `requestRefreshAccessVersion: () => void`.
- `client/src/components/hosted/ChatboxChatPage.tsx` — silent re-redeem callback, in-flight gated, threaded into `hostedContext`.
- `client/src/hooks/use-chat-session.ts` — forward as `onStaleHostedAccess` to the capture hook.
- `client/src/hooks/useSharedChatWidgetCapture.ts` — stale-access detector + callback prop + debounce ref.
- `client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx` — new case covering the stale path.

## Test plan

- [x] `npx vitest run client/src/hooks/__tests__ client/src/components/hosted/__tests__` → **322 passed, 6 skipped** (including the new stale-access case + the existing 20 ChatboxChatPage cases unaffected)
- [x] Existing capture-hook cases (upload happy path, ready-to-persist gating, blob cache reuse on retry, pending-session retry, persisted-snapshot skip) continue to pass
- [ ] After backend PR deploys: open a hosted chatbox, run `list_users` (or any widget-rendering tool), open Sessions tab → confirm widget renders and no `ArgumentValidationError` in console
- [ ] Stale-access E2E: revoke the test user's chatbox access in another tab (bumps `accessVersion`), trigger a fresh widget snapshot from the original tab → expect a single `chatbox_access_stale` throw, an automatic re-redeem, and a successful retry on the new accessVersion (`sharedChatWidgetSnapshots` row written exactly once for that toolCallId)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes hosted chatbox session refresh and snapshot-upload retry behavior with new async guards/timers, which could affect capture reliability and introduce race conditions if incorrect.
> 
> **Overview**
> Adds a *stale-access recovery path* for hosted chatbox widget snapshot capture: when Convex mutations fail with `chatbox_access_stale`, the capture hook now requests a parent refresh instead of locally retrying, queues the affected `toolCallId`s, and replays them once a new `accessVersion` arrives (with bounded refresh backoff if the parent redeem fails).
> 
> Implements a silent `/api/web/chatboxes/redeem` re-run in `ChatboxChatPage` (token-keyed in-flight gating plus navigation staleness guards) and threads this callback through `HostedRuntimeContext` and `use-chat-session` to `useSharedChatWidgetCapture`. Also adjusts hosted session reset logic to ignore `accessVersion` bumps so re-redeems don’t tear down the active chat, and adds extensive tests covering stale handling, replay, backoff, and mid-upload scope changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cba6b87c759893516de1ec6104d033811ffdc92d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->