### PR TITLE
fix: advertise MCP app message capabilities

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -320,6 +320,21 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(sandboxedIframePropsRef.current?.permissions).toBeUndefined();
   });
 
+  it("advertises model context and message host capabilities", async () => {
+    render(<MCPAppsRenderer {...baseProps} />);
+
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+
+    expect(appBridgeArgsRef.current?.hostCapabilities).toEqual(
+      expect.objectContaining({
+        updateModelContext: {},
+        message: {},
+      }),
+    );
+  });
+
   it("uses chatbox host style for SEP-1865 host context outside the playground", async () => {
     render(
       <ChatboxHostStyleProvider value="chatgpt">

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-modal.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-modal.tsx
@@ -148,6 +148,8 @@ export function McpAppsModal({
         serverTools: {},
         serverResources: {},
         logging: {},
+        updateModelContext: {},
+        message: {},
         sandbox: {
           csp: widgetPermissive ? undefined : widgetCsp,
           permissions: widgetPermissions,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1172,6 +1172,8 @@ export function MCPAppsRenderer({
         serverTools: {},
         serverResources: {},
         logging: {},
+        updateModelContext: {},
+        message: {},
         sandbox: {
           // In permissive mode: omit CSP (undefined) to indicate no restrictions
           // In widget-declared mode: pass the widget's declared CSP


### PR DESCRIPTION
## What changed
- Advertise the `message` and `updateModelContext` host capabilities when initializing MCP Apps bridges.
- Apply the same capabilities to both inline widgets and modal widgets.
- Add renderer regression coverage for the advertised capabilities.

Fixes #2031

## Testing
- `npm run test -w @mcpjam/inspector -- client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx`
