### PR TITLE
refactor(chatboxes): collapse welcome/feedback into chatUi.surfaces

### DIFF
--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
@@ -477,8 +477,8 @@ export function ChatboxEditor({
 
   const oauthPending = pendingOAuthServers.length > 0;
   const welcomeAvailable =
-    (chatbox?.welcomeDialog?.enabled ?? true) &&
-    !!chatbox?.welcomeDialog?.body?.trim();
+    (chatbox?.chatUi?.surfaces?.welcome?.enabled ?? true) &&
+    !!chatbox?.chatUi?.surfaces?.welcome?.body?.trim();
   const introGate = useChatboxHostIntroGate({
     chatboxId: chatbox?.chatboxId ?? "",
     servers: requiredPreviewServers,
@@ -628,14 +628,19 @@ export function ChatboxEditor({
       mode,
       selectedServerIds,
       optionalServerIds,
-      welcomeDialog: {
-        enabled: chatbox?.welcomeDialog?.enabled ?? true,
-        body: chatbox?.welcomeDialog?.body ?? "",
-      },
-      feedbackDialog: {
-        enabled: chatbox?.feedbackDialog?.enabled ?? true,
-        everyNToolCalls: chatbox?.feedbackDialog?.everyNToolCalls ?? 1,
-        promptHint: chatbox?.feedbackDialog?.promptHint ?? "",
+      chatUi: {
+        surfaces: {
+          welcome: {
+            enabled: chatbox?.chatUi?.surfaces?.welcome?.enabled ?? true,
+            body: chatbox?.chatUi?.surfaces?.welcome?.body ?? "",
+          },
+          feedback: {
+            enabled: chatbox?.chatUi?.surfaces?.feedback?.enabled ?? true,
+            everyNToolCalls:
+              chatbox?.chatUi?.surfaces?.feedback?.everyNToolCalls ?? 1,
+            promptHint: chatbox?.chatUi?.surfaces?.feedback?.promptHint ?? "",
+          },
+        },
       },
     };
     const hostConfigInput = draftToHostConfigInputV2(synthDraft, seedInput);
@@ -733,9 +738,10 @@ export function ChatboxEditor({
       temperature,
       requireToolApproval,
       servers: selectedPreviewServers,
-      welcomeDialog: chatbox.welcomeDialog ?? {
-        enabled: true,
-        body: "",
+      chatUi: chatbox.chatUi ?? {
+        surfaces: {
+          welcome: { enabled: true, body: "" },
+        },
       },
     };
 
@@ -1287,7 +1293,7 @@ export function ChatboxEditor({
                 <ChatboxHostOnboardingOverlays
                   showWelcome={introGate.showWelcome}
                   onGetStarted={introGate.dismissIntro}
-                  welcomeBody={chatbox.welcomeDialog?.body}
+                  welcomeBody={chatbox.chatUi?.surfaces?.welcome?.body}
                   showAuthPanel={introGate.showAuthPanel}
                   pendingOAuthServers={pendingOAuthServers}
                   authorizeServer={authorizeServer}

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
@@ -73,6 +73,7 @@ import { ChatboxCanvas } from "./ChatboxCanvas";
 import {
   DEFAULT_SYSTEM_PROMPT,
   draftToHostConfigInputV2,
+  toChatUiFromChatbox,
   toDraftConfig,
 } from "./drafts";
 import {
@@ -359,11 +360,15 @@ export function ChatboxBuilderView({
               servers: [],
               link: null,
               members: [],
-              welcomeDialog: { enabled: true, body: "" },
-              feedbackDialog: {
-                enabled: true,
-                everyNToolCalls: 1,
-                promptHint: "",
+              chatUi: {
+                surfaces: {
+                  welcome: { enabled: true, body: "" },
+                  feedback: {
+                    enabled: true,
+                    everyNToolCalls: 1,
+                    promptHint: "",
+                  },
+                },
               },
             } as ChatboxSettings)
         );
@@ -416,8 +421,7 @@ export function ChatboxBuilderView({
         requireToolApproval: draftChatboxConfig.requireToolApproval,
         mode: draftChatboxConfig.mode,
         allowGuestAccess: draftChatboxConfig.allowGuestAccess,
-        welcomeDialog: draftChatboxConfig.welcomeDialog,
-        feedbackDialog: draftChatboxConfig.feedbackDialog,
+        chatUi: draftChatboxConfig.chatUi,
         selectedServerIds: [...draftChatboxConfig.selectedServerIds].sort(),
         optionalServerIds: [...draftChatboxConfig.optionalServerIds].sort(),
       }),
@@ -524,7 +528,7 @@ export function ChatboxBuilderView({
       temperature: draftChatboxConfig.temperature,
       requireToolApproval: draftChatboxConfig.requireToolApproval,
       servers,
-      welcomeDialog: draftChatboxConfig.welcomeDialog,
+      chatUi: draftChatboxConfig.chatUi,
     };
 
     writePlaygroundSession({
@@ -579,20 +583,8 @@ export function ChatboxBuilderView({
       draftChatboxConfig.requireToolApproval !== chatbox.requireToolApproval ||
       draftChatboxConfig.mode !== chatbox.mode ||
       draftChatboxConfig.allowGuestAccess !== chatbox.allowGuestAccess ||
-      JSON.stringify(draftChatboxConfig.welcomeDialog) !==
-        JSON.stringify({
-          enabled: chatbox.welcomeDialog?.enabled ?? true,
-          body: chatbox.welcomeDialog?.body ?? "",
-        }) ||
-      JSON.stringify(draftChatboxConfig.feedbackDialog) !==
-        JSON.stringify({
-          enabled: chatbox.feedbackDialog?.enabled ?? true,
-          everyNToolCalls: Math.max(
-            1,
-            chatbox.feedbackDialog?.everyNToolCalls ?? 1
-          ),
-          promptHint: chatbox.feedbackDialog?.promptHint ?? "",
-        }) ||
+      JSON.stringify(draftChatboxConfig.chatUi) !==
+        JSON.stringify(toChatUiFromChatbox(chatbox)) ||
       JSON.stringify(currentIds) !== JSON.stringify(draftIds) ||
       JSON.stringify(optionalFromChatbox) !== JSON.stringify(draftOptionalIds)
     );
@@ -742,8 +734,8 @@ export function ChatboxBuilderView({
 
   const oauthPending = pendingOAuthServers.length > 0;
   const welcomeAvailable =
-    draftChatboxConfig.welcomeDialog.enabled &&
-    !!draftChatboxConfig.welcomeDialog.body?.trim();
+    draftChatboxConfig.chatUi.surfaces.welcome.enabled &&
+    !!draftChatboxConfig.chatUi.surfaces.welcome.body?.trim();
   const introGate = useChatboxHostIntroGate({
     chatboxId: introChatboxId,
     servers: requiredPreviewServers,
@@ -972,8 +964,7 @@ export function ChatboxBuilderView({
       const payload = {
         name: trimmedName,
         description: draftChatboxConfig.description.trim() || undefined,
-        welcomeDialog: draftChatboxConfig.welcomeDialog,
-        feedbackDialog: draftChatboxConfig.feedbackDialog,
+        chatUi: draftChatboxConfig.chatUi,
         hostConfig: hostConfigInput,
       };
 
@@ -1144,20 +1135,20 @@ export function ChatboxBuilderView({
       return {
         hostStyle: chatbox.hostStyle,
         serverCount: chatbox.servers.length,
-        welcomeOn: chatbox.welcomeDialog?.enabled ?? true,
-        feedbackOn: chatbox.feedbackDialog?.enabled ?? true,
+        welcomeOn: chatbox.chatUi?.surfaces?.welcome?.enabled ?? true,
+        feedbackOn: chatbox.chatUi?.surfaces?.feedback?.enabled ?? true,
         feedbackEvery: Math.max(
           1,
-          chatbox.feedbackDialog?.everyNToolCalls ?? 1
+          chatbox.chatUi?.surfaces?.feedback?.everyNToolCalls ?? 1
         ),
       };
     }
     return {
       hostStyle: draftChatboxConfig.hostStyle,
       serverCount: draftChatboxConfig.selectedServerIds.length,
-      welcomeOn: draftChatboxConfig.welcomeDialog.enabled,
-      feedbackOn: draftChatboxConfig.feedbackDialog.enabled,
-      feedbackEvery: draftChatboxConfig.feedbackDialog.everyNToolCalls,
+      welcomeOn: draftChatboxConfig.chatUi.surfaces.welcome.enabled,
+      feedbackOn: draftChatboxConfig.chatUi.surfaces.feedback.enabled,
+      feedbackEvery: draftChatboxConfig.chatUi.surfaces.feedback.everyNToolCalls,
     };
   }, [chatbox, isDirty, draftChatboxConfig]);
 
@@ -1361,7 +1352,7 @@ export function ChatboxBuilderView({
                                 showWelcome={introGate.showWelcome}
                                 onGetStarted={introGate.dismissIntro}
                                 welcomeBody={
-                                  draftChatboxConfig.welcomeDialog.body
+                                  draftChatboxConfig.chatUi.surfaces.welcome.body
                                 }
                                 showAuthPanel={introGate.showAuthPanel}
                                 pendingOAuthServers={pendingOAuthServers}

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxBuilderView.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxBuilderView.test.tsx
@@ -115,11 +115,15 @@ function createSavedChatbox(hostStyle: "claude" | "chatgpt"): ChatboxSettings {
       rotatedAt: 1,
     },
     members: [],
-    welcomeDialog: { enabled: true, body: "" },
-    feedbackDialog: {
-      enabled: true,
-      everyNToolCalls: 1,
-      promptHint: "",
+    chatUi: {
+      surfaces: {
+        welcome: { enabled: true, body: "" },
+        feedback: {
+          enabled: true,
+          everyNToolCalls: 1,
+          promptHint: "",
+        },
+      },
     },
   };
 }

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxCanvas.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/ChatboxCanvas.test.tsx
@@ -138,8 +138,12 @@ describe("ChatboxCanvas", () => {
         mode: "anyone_with_link",
         selectedServerIds: ["srv1"],
         optionalServerIds: [],
-        welcomeDialog: { enabled: true, body: "" },
-        feedbackDialog: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+        chatUi: {
+          surfaces: {
+            welcome: { enabled: true, body: "" },
+            feedback: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+          },
+        },
       },
       projectServers: [
         {
@@ -208,8 +212,12 @@ describe("ChatboxCanvas", () => {
         mode: "anyone_with_link",
         selectedServerIds: [],
         optionalServerIds: [],
-        welcomeDialog: { enabled: true, body: "" },
-        feedbackDialog: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+        chatUi: {
+          surfaces: {
+            welcome: { enabled: true, body: "" },
+            feedback: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+          },
+        },
       },
       projectServers: [
         {
@@ -294,8 +302,12 @@ describe("ChatboxCanvas", () => {
         mode: "anyone_with_link",
         selectedServerIds: ["a", "b"],
         optionalServerIds: [],
-        welcomeDialog: { enabled: true, body: "" },
-        feedbackDialog: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+        chatUi: {
+          surfaces: {
+            welcome: { enabled: true, body: "" },
+            feedback: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+          },
+        },
       },
       projectServers: [
         {
@@ -361,8 +373,12 @@ describe("ChatboxCanvas", () => {
       allowGuestAccess: false,
       mode: "anyone_with_link" as const,
       optionalServerIds: [] as string[],
-      welcomeDialog: { enabled: true, body: "" },
-      feedbackDialog: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+      chatUi: {
+        surfaces: {
+          welcome: { enabled: true, body: "" },
+          feedback: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+        },
+      },
     };
 
     const server = {
@@ -670,8 +686,12 @@ function minimalContext(
     mode: "anyone_with_link" as const,
     selectedServerIds: [] as string[],
     optionalServerIds: [] as string[],
-    welcomeDialog: { enabled: true, body: "" },
-    feedbackDialog: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+    chatUi: {
+      surfaces: {
+        welcome: { enabled: true, body: "" },
+        feedback: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+      },
+    },
     ...overrides,
   };
   return {

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/chatbox-canvas-viewport.test.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/chatbox-canvas-viewport.test.ts
@@ -24,8 +24,12 @@ function minimalContext(
     mode: "anyone_with_link" as const,
     selectedServerIds: [] as string[],
     optionalServerIds: [] as string[],
-    welcomeDialog: { enabled: true, body: "" },
-    feedbackDialog: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+    chatUi: {
+      surfaces: {
+        welcome: { enabled: true, body: "" },
+        feedback: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+      },
+    },
     ...overrides,
   };
   return {

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/chatboxCanvasBuilder.test.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/chatboxCanvasBuilder.test.ts
@@ -15,8 +15,12 @@ const baseDraft = (): ChatboxDraftConfig => ({
   mode: "anyone_with_link",
   selectedServerIds: ["srv-draft"],
   optionalServerIds: [],
-  welcomeDialog: { enabled: true, body: "" },
-  feedbackDialog: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+  chatUi: {
+    surfaces: {
+      welcome: { enabled: true, body: "" },
+      feedback: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+    },
+  },
 });
 
 const projectServers = [

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/drafts.test.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/drafts.test.ts
@@ -27,14 +27,14 @@ describe("migrateBuilderDraft", () => {
       temperature: 0.5,
       requireToolApproval: false,
       selectedServerIds: ["srv-1", "srv-2"],
-      // Missing: optionalServerIds, welcomeDialog, feedbackDialog, mode, etc.
+      // Missing: optionalServerIds, chatUi (welcome/feedback), mode, etc.
     };
     const migrated = migrateBuilderDraft(oldShape);
     expect(migrated).not.toBeNull();
     expect(migrated!.selectedServerIds).toEqual(["srv-1", "srv-2"]);
     expect(migrated!.optionalServerIds).toEqual([]);
-    expect(migrated!.welcomeDialog).toBeDefined();
-    expect(migrated!.feedbackDialog).toBeDefined();
+    expect(migrated!.chatUi.surfaces.welcome).toBeDefined();
+    expect(migrated!.chatUi.surfaces.feedback).toBeDefined();
     expect(migrated!.mode).toBeDefined();
     expect(migrated!.allowGuestAccess).toBeDefined();
     expect(migrated!.name).toBe("Pre-existing draft");
@@ -53,11 +53,15 @@ describe("migrateBuilderDraft", () => {
       mode: "invited_only" as const,
       selectedServerIds: ["a", "b"],
       optionalServerIds: ["b"],
-      welcomeDialog: { enabled: true, body: "hi" },
-      feedbackDialog: {
-        enabled: true,
-        everyNToolCalls: 2,
-        promptHint: "feedback?",
+      chatUi: {
+        surfaces: {
+          welcome: { enabled: true, body: "hi" },
+          feedback: {
+            enabled: true,
+            everyNToolCalls: 2,
+            promptHint: "feedback?",
+          },
+        },
       },
     };
     const migrated = migrateBuilderDraft(draft);
@@ -79,8 +83,12 @@ describe("draftToHostConfigInputV2", () => {
       mode: "invited_only" as const,
       selectedServerIds: ["srv-1"],
       optionalServerIds: ["srv-1"],
-      welcomeDialog: { enabled: true, body: "" },
-      feedbackDialog: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+      chatUi: {
+        surfaces: {
+          welcome: { enabled: true, body: "" },
+          feedback: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+        },
+      },
     };
     const input = draftToHostConfigInputV2(draft);
     expect(input.hostStyle).toBe("claude");
@@ -105,8 +113,12 @@ describe("draftToHostConfigInputV2", () => {
       mode: "invited_only" as const,
       selectedServerIds: [],
       optionalServerIds: [],
-      welcomeDialog: { enabled: true, body: "" },
-      feedbackDialog: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+      chatUi: {
+        surfaces: {
+          welcome: { enabled: true, body: "" },
+          feedback: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+        },
+      },
     };
     const input = draftToHostConfigInputV2(draft, {
       connectionDefaults: {

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/drafts.test.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/drafts.test.ts
@@ -40,6 +40,75 @@ describe("migrateBuilderDraft", () => {
     expect(migrated!.name).toBe("Pre-existing draft");
   });
 
+  it("rehydrates legacy top-level welcomeDialog/feedbackDialog into chatUi.surfaces", () => {
+    // sessionStorage drafts written before the chatUi envelope landed carry
+    // welcome/feedback at the top level. The migrator must fold them into
+    // the new shape so an in-flight builder draft doesn't lose its body or
+    // cadence the moment the new code ships.
+    const legacy = {
+      name: "Mid-edit draft",
+      hostStyle: "claude" as const,
+      systemPrompt: "Sys",
+      modelId: "openai/gpt-5-mini",
+      temperature: 0.5,
+      requireToolApproval: false,
+      selectedServerIds: ["srv-1"],
+      optionalServerIds: [],
+      mode: "anyone_with_link" as const,
+      allowGuestAccess: true,
+      welcomeDialog: { enabled: false, body: "Half-written welcome" },
+      feedbackDialog: {
+        enabled: true,
+        everyNToolCalls: 4,
+        promptHint: "Any blockers?",
+      },
+    };
+    const migrated = migrateBuilderDraft(legacy);
+    expect(migrated).not.toBeNull();
+    expect(migrated!.chatUi.surfaces.welcome).toEqual({
+      enabled: false,
+      body: "Half-written welcome",
+    });
+    expect(migrated!.chatUi.surfaces.feedback).toEqual({
+      enabled: true,
+      everyNToolCalls: 4,
+      promptHint: "Any blockers?",
+    });
+    // Orphan top-level keys must not ride along on the migrated draft.
+    expect(migrated as unknown as Record<string, unknown>).not.toHaveProperty(
+      "welcomeDialog",
+    );
+    expect(migrated as unknown as Record<string, unknown>).not.toHaveProperty(
+      "feedbackDialog",
+    );
+  });
+
+  it("prefers the new chatUi shape over legacy keys when both are present", () => {
+    const both = {
+      name: "Both shapes",
+      hostStyle: "claude" as const,
+      systemPrompt: "Sys",
+      modelId: "openai/gpt-5-mini",
+      temperature: 0.5,
+      requireToolApproval: false,
+      selectedServerIds: [],
+      optionalServerIds: [],
+      mode: "anyone_with_link" as const,
+      allowGuestAccess: true,
+      welcomeDialog: { enabled: false, body: "stale" },
+      chatUi: {
+        surfaces: {
+          welcome: { enabled: true, body: "fresh" },
+        },
+      },
+    };
+    const migrated = migrateBuilderDraft(both);
+    expect(migrated!.chatUi.surfaces.welcome).toEqual({
+      enabled: true,
+      body: "fresh",
+    });
+  });
+
   it("preserves complete drafts at the field level", () => {
     const draft = {
       name: "Complete",

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/setup-checklist-panel.test.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/__tests__/setup-checklist-panel.test.tsx
@@ -59,7 +59,16 @@ describe("SetupChecklistPanel", () => {
       <SetupChecklistPanel
         chatboxDraft={{
           ...baseDraft,
-          welcomeDialog: { ...baseDraft.welcomeDialog, enabled: false },
+          chatUi: {
+            ...baseDraft.chatUi,
+            surfaces: {
+              ...baseDraft.chatUi.surfaces,
+              welcome: {
+                ...baseDraft.chatUi.surfaces.welcome,
+                enabled: false,
+              },
+            },
+          },
         }}
         savedChatbox={null}
         projectServers={[]}

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
@@ -176,19 +176,47 @@ export function migrateBuilderDraft(
           | { welcome?: unknown; feedback?: unknown }
           | undefined)
       : undefined;
+  // Pre-chatUi drafts (sessionStorage written before the envelope landed)
+  // carry welcome/feedback at the top level. Fall back to them per-surface
+  // when the new shape doesn't supply that surface, so an in-flight builder
+  // draft doesn't lose its body/cadence the moment we ship.
+  const legacyWelcome =
+    rawSurfaces?.welcome === undefined
+      ? ((raw as { welcomeDialog?: unknown }).welcomeDialog as
+          | Partial<ChatboxDraftConfig["chatUi"]["surfaces"]["welcome"]>
+          | undefined)
+      : undefined;
+  const legacyFeedback =
+    rawSurfaces?.feedback === undefined
+      ? ((raw as { feedbackDialog?: unknown }).feedbackDialog as
+          | Partial<ChatboxDraftConfig["chatUi"]["surfaces"]["feedback"]>
+          | undefined)
+      : undefined;
+  // Strip the legacy top-level keys before the spread so the merged draft
+  // doesn't carry orphan `welcomeDialog` / `feedbackDialog` properties at
+  // runtime alongside the canonical `chatUi`.
+  const {
+    welcomeDialog: _legacyWelcomeDialog,
+    feedbackDialog: _legacyFeedbackDialog,
+    ...rawWithoutLegacyKeys
+  } = raw as Record<string, unknown>;
+  void _legacyWelcomeDialog;
+  void _legacyFeedbackDialog;
   const merged: ChatboxDraftConfig = {
     ...blank,
-    ...(raw as Partial<ChatboxDraftConfig>),
+    ...(rawWithoutLegacyKeys as Partial<ChatboxDraftConfig>),
     chatUi: {
       surfaces: {
         welcome: {
           ...blank.chatUi.surfaces.welcome,
+          ...(legacyWelcome ?? {}),
           ...((rawSurfaces?.welcome as
             | Partial<ChatboxDraftConfig["chatUi"]["surfaces"]["welcome"]>
             | undefined) ?? {}),
         },
         feedback: {
           ...blank.chatUi.surfaces.feedback,
+          ...(legacyFeedback ?? {}),
           ...((rawSurfaces?.feedback as
             | Partial<ChatboxDraftConfig["chatUi"]["surfaces"]["feedback"]>
             | undefined) ?? {}),
@@ -214,8 +242,6 @@ export function migrateBuilderDraft(
 }
 
 export function toDraftConfig(chatbox: ChatboxSettings): ChatboxDraftConfig {
-  const welcome = chatbox.chatUi?.surfaces?.welcome;
-  const feedback = chatbox.chatUi?.surfaces?.feedback;
   return {
     name: chatbox.name,
     description: chatbox.description ?? "",
@@ -230,25 +256,32 @@ export function toDraftConfig(chatbox: ChatboxSettings): ChatboxDraftConfig {
     optionalServerIds: chatbox.servers
       .filter((server) => server.optional)
       .map((server) => server.serverId),
-    chatUi: {
-      surfaces: {
-        welcome: {
-          enabled: welcome?.enabled ?? true,
-          body: welcome?.body ?? "",
-        },
-        feedback: {
-          enabled: feedback?.enabled ?? true,
-          everyNToolCalls: Math.max(1, feedback?.everyNToolCalls ?? 1),
-          promptHint: feedback?.promptHint ?? "",
-        },
-      },
-    },
+    chatUi: toChatUiFromChatbox(chatbox),
   };
 }
 
-/** Mirror of `toDraftConfig`'s chatUi unpacking — used by `isDirty` comparator. */
+/**
+ * Unpacks the chatbox's `chatUi` into the draft shape (defaulting both
+ * surfaces). Shared between `toDraftConfig` and the `isDirty` comparator
+ * in `ChatboxBuilderView` so both arrive at the same default-coalesced
+ * envelope without `isDirty` having to rebuild the entire draft.
+ */
 export function toChatUiFromChatbox(
   chatbox: ChatboxSettings,
 ): ChatboxDraftConfig["chatUi"] {
-  return toDraftConfig(chatbox).chatUi;
+  const welcome = chatbox.chatUi?.surfaces?.welcome;
+  const feedback = chatbox.chatUi?.surfaces?.feedback;
+  return {
+    surfaces: {
+      welcome: {
+        enabled: welcome?.enabled ?? true,
+        body: welcome?.body ?? "",
+      },
+      feedback: {
+        enabled: feedback?.enabled ?? true,
+        everyNToolCalls: Math.max(1, feedback?.everyNToolCalls ?? 1),
+        promptHint: feedback?.promptHint ?? "",
+      },
+    },
+  };
 }

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
@@ -64,12 +64,16 @@ export const CHATBOX_STARTERS: ChatboxStarterDefinition[] = [
       mode: "anyone_with_link",
       selectedServerIds: [],
       optionalServerIds: [],
-      welcomeDialog: { enabled: true, body: WELCOME_BODY_EXCALIDRAW_DEMO },
-      feedbackDialog: {
-        enabled: true,
-        everyNToolCalls: 3,
-        promptHint:
-          "Short feedback is enough: what worked, what felt confusing, or what you would change.",
+      chatUi: {
+        surfaces: {
+          welcome: { enabled: true, body: WELCOME_BODY_EXCALIDRAW_DEMO },
+          feedback: {
+            enabled: true,
+            everyNToolCalls: 3,
+            promptHint:
+              "Short feedback is enough: what worked, what felt confusing, or what you would change.",
+          },
+        },
       },
     }),
   },
@@ -91,8 +95,12 @@ export const CHATBOX_STARTERS: ChatboxStarterDefinition[] = [
       mode: "anyone_with_link",
       selectedServerIds: [],
       optionalServerIds: [],
-      welcomeDialog: { enabled: true, body: "" },
-      feedbackDialog: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+      chatUi: {
+        surfaces: {
+          welcome: { enabled: true, body: "" },
+          feedback: { enabled: true, everyNToolCalls: 1, promptHint: "" },
+        },
+      },
     }),
   },
 ];
@@ -161,18 +169,31 @@ export function migrateBuilderDraft(
 ): ChatboxDraftConfig | null {
   if (!raw || typeof raw !== "object") return null;
   const blank = CHATBOX_BLANK_STARTER.createDraft(getDefaultHostedModelId());
+  const rawChatUi = (raw as { chatUi?: unknown }).chatUi;
+  const rawSurfaces =
+    rawChatUi && typeof rawChatUi === "object"
+      ? ((rawChatUi as { surfaces?: unknown }).surfaces as
+          | { welcome?: unknown; feedback?: unknown }
+          | undefined)
+      : undefined;
   const merged: ChatboxDraftConfig = {
     ...blank,
     ...(raw as Partial<ChatboxDraftConfig>),
-    welcomeDialog: {
-      ...blank.welcomeDialog,
-      ...((raw as { welcomeDialog?: Partial<ChatboxDraftConfig["welcomeDialog"]> })
-        .welcomeDialog ?? {}),
-    },
-    feedbackDialog: {
-      ...blank.feedbackDialog,
-      ...((raw as { feedbackDialog?: Partial<ChatboxDraftConfig["feedbackDialog"]> })
-        .feedbackDialog ?? {}),
+    chatUi: {
+      surfaces: {
+        welcome: {
+          ...blank.chatUi.surfaces.welcome,
+          ...((rawSurfaces?.welcome as
+            | Partial<ChatboxDraftConfig["chatUi"]["surfaces"]["welcome"]>
+            | undefined) ?? {}),
+        },
+        feedback: {
+          ...blank.chatUi.surfaces.feedback,
+          ...((rawSurfaces?.feedback as
+            | Partial<ChatboxDraftConfig["chatUi"]["surfaces"]["feedback"]>
+            | undefined) ?? {}),
+        },
+      },
     },
     selectedServerIds: Array.isArray(
       (raw as { selectedServerIds?: unknown }).selectedServerIds,
@@ -193,6 +214,8 @@ export function migrateBuilderDraft(
 }
 
 export function toDraftConfig(chatbox: ChatboxSettings): ChatboxDraftConfig {
+  const welcome = chatbox.chatUi?.surfaces?.welcome;
+  const feedback = chatbox.chatUi?.surfaces?.feedback;
   return {
     name: chatbox.name,
     description: chatbox.description ?? "",
@@ -207,17 +230,25 @@ export function toDraftConfig(chatbox: ChatboxSettings): ChatboxDraftConfig {
     optionalServerIds: chatbox.servers
       .filter((server) => server.optional)
       .map((server) => server.serverId),
-    welcomeDialog: {
-      enabled: chatbox.welcomeDialog?.enabled ?? true,
-      body: chatbox.welcomeDialog?.body ?? "",
-    },
-    feedbackDialog: {
-      enabled: chatbox.feedbackDialog?.enabled ?? true,
-      everyNToolCalls: Math.max(
-        1,
-        chatbox.feedbackDialog?.everyNToolCalls ?? 1,
-      ),
-      promptHint: chatbox.feedbackDialog?.promptHint ?? "",
+    chatUi: {
+      surfaces: {
+        welcome: {
+          enabled: welcome?.enabled ?? true,
+          body: welcome?.body ?? "",
+        },
+        feedback: {
+          enabled: feedback?.enabled ?? true,
+          everyNToolCalls: Math.max(1, feedback?.everyNToolCalls ?? 1),
+          promptHint: feedback?.promptHint ?? "",
+        },
+      },
     },
   };
+}
+
+/** Mirror of `toDraftConfig`'s chatUi unpacking — used by `isDirty` comparator. */
+export function toChatUiFromChatbox(
+  chatbox: ChatboxSettings,
+): ChatboxDraftConfig["chatUi"] {
+  return toDraftConfig(chatbox).chatUi;
 }

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/setup-checklist-panel.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/setup-checklist-panel.tsx
@@ -338,15 +338,18 @@ export function computeSectionStatuses(
 
   const access: SectionStatusKind = draft.mode ? "complete" : "attention";
 
-  const welcome: SectionStatusKind = draft.welcomeDialog.enabled
+  const welcomeSurface = draft.chatUi.surfaces.welcome;
+  const feedbackSurface = draft.chatUi.surfaces.feedback;
+
+  const welcome: SectionStatusKind = welcomeSurface.enabled
     ? "default_on"
     : "optional";
 
   const feedbackInvalid =
-    draft.feedbackDialog.enabled && draft.feedbackDialog.everyNToolCalls < 1;
+    feedbackSurface.enabled && feedbackSurface.everyNToolCalls < 1;
   const feedback: SectionStatusKind = feedbackInvalid
     ? "attention"
-    : draft.feedbackDialog.enabled
+    : feedbackSurface.enabled
       ? "default_on"
       : "optional";
 
@@ -801,38 +804,50 @@ export function SetupChecklistPanel({
                       </p>
                     </div>
                     <Switch
-                      checked={chatboxDraft.welcomeDialog.enabled}
+                      checked={chatboxDraft.chatUi.surfaces.welcome.enabled}
                       onCheckedChange={(checked) =>
                         onDraftChange((draft) => ({
                           ...draft,
-                          welcomeDialog: {
-                            ...draft.welcomeDialog,
-                            enabled: checked,
+                          chatUi: {
+                            ...draft.chatUi,
+                            surfaces: {
+                              ...draft.chatUi.surfaces,
+                              welcome: {
+                                ...draft.chatUi.surfaces.welcome,
+                                enabled: checked,
+                              },
+                            },
                           },
                         }))
                       }
                     />
                   </div>
-                  {chatboxDraft.welcomeDialog.enabled ? (
+                  {chatboxDraft.chatUi.surfaces.welcome.enabled ? (
                     <div className="space-y-2">
                       <Label htmlFor="welcome-body">Welcome content</Label>
                       <Textarea
                         id="welcome-body"
                         rows={5}
-                        value={chatboxDraft.welcomeDialog.body}
+                        value={chatboxDraft.chatUi.surfaces.welcome.body}
                         onChange={(event) =>
                           onDraftChange((draft) => ({
                             ...draft,
-                            welcomeDialog: {
-                              ...draft.welcomeDialog,
-                              body: event.target.value,
+                            chatUi: {
+                              ...draft.chatUi,
+                              surfaces: {
+                                ...draft.chatUi.surfaces,
+                                welcome: {
+                                  ...draft.chatUi.surfaces.welcome,
+                                  body: event.target.value,
+                                },
+                              },
                             },
                           }))
                         }
                         placeholder="What your audience should know before they start…"
                       />
                       <p className="text-xs text-muted-foreground">
-                        {chatboxDraft.welcomeDialog.body.trim()
+                        {chatboxDraft.chatUi.surfaces.welcome.body.trim()
                           ? "Shown once, the first time someone opens your chatbox link."
                           : "Leave blank to skip — no welcome will be shown."}
                       </p>
@@ -868,19 +883,25 @@ export function SetupChecklistPanel({
                       </p>
                     </div>
                     <Switch
-                      checked={chatboxDraft.feedbackDialog.enabled}
+                      checked={chatboxDraft.chatUi.surfaces.feedback.enabled}
                       onCheckedChange={(checked) =>
                         onDraftChange((draft) => ({
                           ...draft,
-                          feedbackDialog: {
-                            ...draft.feedbackDialog,
-                            enabled: checked,
+                          chatUi: {
+                            ...draft.chatUi,
+                            surfaces: {
+                              ...draft.chatUi.surfaces,
+                              feedback: {
+                                ...draft.chatUi.surfaces.feedback,
+                                enabled: checked,
+                              },
+                            },
                           },
                         }))
                       }
                     />
                   </div>
-                  {chatboxDraft.feedbackDialog.enabled ? (
+                  {chatboxDraft.chatUi.surfaces.feedback.enabled ? (
                     <>
                       <div className="space-y-2">
                         <Label>Every N tool calls</Label>
@@ -893,16 +914,24 @@ export function SetupChecklistPanel({
                           type="number"
                           min={1}
                           step={1}
-                          value={chatboxDraft.feedbackDialog.everyNToolCalls}
+                          value={
+                            chatboxDraft.chatUi.surfaces.feedback.everyNToolCalls
+                          }
                           onChange={(event) => {
                             const n = Number.parseInt(event.target.value, 10);
                             onDraftChange((draft) => ({
                               ...draft,
-                              feedbackDialog: {
-                                ...draft.feedbackDialog,
-                                everyNToolCalls: Number.isFinite(n)
-                                  ? Math.max(1, n)
-                                  : 1,
+                              chatUi: {
+                                ...draft.chatUi,
+                                surfaces: {
+                                  ...draft.chatUi.surfaces,
+                                  feedback: {
+                                    ...draft.chatUi.surfaces.feedback,
+                                    everyNToolCalls: Number.isFinite(n)
+                                      ? Math.max(1, n)
+                                      : 1,
+                                  },
+                                },
                               },
                             }));
                           }}
@@ -913,13 +942,19 @@ export function SetupChecklistPanel({
                         <Textarea
                           id="feedback-hint"
                           rows={3}
-                          value={chatboxDraft.feedbackDialog.promptHint}
+                          value={chatboxDraft.chatUi.surfaces.feedback.promptHint}
                           onChange={(event) =>
                             onDraftChange((draft) => ({
                               ...draft,
-                              feedbackDialog: {
-                                ...draft.feedbackDialog,
-                                promptHint: event.target.value,
+                              chatUi: {
+                                ...draft.chatUi,
+                                surfaces: {
+                                  ...draft.chatUi.surfaces,
+                                  feedback: {
+                                    ...draft.chatUi.surfaces.feedback,
+                                    promptHint: event.target.value,
+                                  },
+                                },
                               },
                             }))
                           }

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/types.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/types.ts
@@ -27,6 +27,15 @@ export interface ChatboxFeedbackDialogDraft {
   promptHint: string;
 }
 
+export interface ChatUiSurfacesDraft {
+  welcome: ChatboxWelcomeDialogDraft;
+  feedback: ChatboxFeedbackDialogDraft;
+}
+
+export interface ChatUiDraft {
+  surfaces: ChatUiSurfacesDraft;
+}
+
 export interface ChatboxDraftConfig {
   name: string;
   description: string;
@@ -40,8 +49,7 @@ export interface ChatboxDraftConfig {
   selectedServerIds: string[];
   /** Subset of selectedServerIds that are optional (off by default for testers). */
   optionalServerIds: string[];
-  welcomeDialog: ChatboxWelcomeDialogDraft;
-  feedbackDialog: ChatboxFeedbackDialogDraft;
+  chatUi: ChatUiDraft;
 }
 
 export interface ChatboxBuilderContext {

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/useChatboxDemoSeed.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/useChatboxDemoSeed.ts
@@ -107,8 +107,7 @@ export function useChatboxDemoSeed({
           projectId,
           name: draft.name,
           description: draft.description.trim() || undefined,
-          welcomeDialog: draft.welcomeDialog,
-          feedbackDialog: draft.feedbackDialog,
+          chatUi: draft.chatUi,
           mode: draft.mode,
           serverSeed: { name: seed.name, url: seed.url },
           hostConfigSeed: {

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -791,8 +791,8 @@ export function ChatboxChatPage({
   const shellStyle = getChatboxShellStyle(hostStyle, themeMode);
   const oauthPending = pendingOAuthServers.length > 0;
   const welcomeAvailable =
-    (session?.payload.welcomeDialog?.enabled ?? true) &&
-    !!session?.payload.welcomeDialog?.body?.trim();
+    (session?.payload.chatUi?.surfaces?.welcome?.enabled ?? true) &&
+    !!session?.payload.chatUi?.surfaces?.welcome?.body?.trim();
   const introGate = useChatboxHostIntroGate({
     chatboxId: session?.payload.chatboxId ?? "",
     servers: sessionServersRequired,
@@ -888,7 +888,7 @@ export function ChatboxChatPage({
         <ChatboxHostOnboardingOverlays
           showWelcome={introGate.showWelcome}
           onGetStarted={introGate.dismissIntro}
-          welcomeBody={session.payload.welcomeDialog?.body}
+          welcomeBody={session.payload.chatUi?.surfaces?.welcome?.body}
           showAuthPanel={introGate.showAuthPanel}
           pendingOAuthServers={pendingOAuthServers}
           authorizeServer={authorizeServer}

--- a/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/__tests__/ChatboxChatPage.test.tsx
@@ -685,9 +685,13 @@ describe("ChatboxChatPage", () => {
             oauthScopes: null,
           },
         ],
-        welcomeDialog: {
-          enabled: true,
-          body: "Connect Asana before chatting.",
+        chatUi: {
+          surfaces: {
+            welcome: {
+              enabled: true,
+              body: "Connect Asana before chatting.",
+            },
+          },
         },
       },
     });
@@ -914,7 +918,7 @@ describe("ChatboxChatPage", () => {
       };
     }
 
-    it("shows welcome dialog when welcomeDialog is enabled and has content", async () => {
+    it("shows welcome dialog when chatUi welcome surface is enabled and has content", async () => {
       writeChatboxSession({
         chatboxId: "sbx_1",
         accessVersion: 1,
@@ -932,9 +936,13 @@ describe("ChatboxChatPage", () => {
           temperature: 0.7,
           requireToolApproval: false,
           servers: [nonOAuthServer()],
-          welcomeDialog: {
-            enabled: true,
-            body: "Welcome — thanks for trying this out.",
+          chatUi: {
+            surfaces: {
+              welcome: {
+                enabled: true,
+                body: "Welcome — thanks for trying this out.",
+              },
+            },
           },
         },
       });
@@ -971,9 +979,13 @@ describe("ChatboxChatPage", () => {
           temperature: 0.7,
           requireToolApproval: false,
           servers: [nonOAuthServer()],
-          welcomeDialog: {
-            enabled: true,
-            body: "Welcome — thanks for trying this out.",
+          chatUi: {
+            surfaces: {
+              welcome: {
+                enabled: true,
+                body: "Welcome — thanks for trying this out.",
+              },
+            },
           },
         },
       });
@@ -990,7 +1002,7 @@ describe("ChatboxChatPage", () => {
       expect(await screen.findByTestId("chatbox-chat-tab")).toBeInTheDocument();
     });
 
-    it("skips welcome and goes straight to chat when welcomeDialog.enabled is false", async () => {
+    it("skips welcome and goes straight to chat when chatUi welcome.enabled is false", async () => {
       writeChatboxSession({
         chatboxId: "sbx_1",
         accessVersion: 1,
@@ -1008,9 +1020,13 @@ describe("ChatboxChatPage", () => {
           temperature: 0.7,
           requireToolApproval: false,
           servers: [nonOAuthServer()],
-          welcomeDialog: {
-            enabled: false,
-            body: "This should not appear.",
+          chatUi: {
+            surfaces: {
+              welcome: {
+                enabled: false,
+                body: "This should not appear.",
+              },
+            },
           },
         },
       });
@@ -1026,7 +1042,7 @@ describe("ChatboxChatPage", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("skips welcome and goes straight to chat when welcomeDialog body is empty", async () => {
+    it("skips welcome and goes straight to chat when chatUi welcome body is empty", async () => {
       writeChatboxSession({
         chatboxId: "sbx_1",
         accessVersion: 1,
@@ -1044,9 +1060,13 @@ describe("ChatboxChatPage", () => {
           temperature: 0.7,
           requireToolApproval: false,
           servers: [nonOAuthServer()],
-          welcomeDialog: {
-            enabled: true,
-            body: "",
+          chatUi: {
+            surfaces: {
+              welcome: {
+                enabled: true,
+                body: "",
+              },
+            },
           },
         },
       });

--- a/mcpjam-inspector/client/src/hooks/useChatboxes.ts
+++ b/mcpjam-inspector/client/src/hooks/useChatboxes.ts
@@ -1,5 +1,16 @@
 import { useMutation, useQuery } from "convex/react";
 import type { ChatboxHostStyle } from "@/lib/chatbox-host-style";
+import type {
+  ChatUiSettings,
+  ChatboxFeedbackDialogSettings,
+  ChatboxWelcomeDialogSettings,
+} from "@/types/chatUi";
+
+export type {
+  ChatUiSettings,
+  ChatboxFeedbackDialogSettings,
+  ChatboxWelcomeDialogSettings,
+};
 
 export type ChatboxMode =
   | "anyone_with_link"
@@ -36,18 +47,6 @@ export interface ChatboxServerSettings {
   optional?: boolean;
 }
 
-export interface ChatboxWelcomeDialogSettings {
-  enabled: boolean;
-  body?: string;
-}
-
-export interface ChatboxFeedbackDialogSettings {
-  enabled: boolean;
-  /** Completed tool calls between feedback prompts in hosted sessions (not user message count). */
-  everyNToolCalls?: number;
-  promptHint?: string;
-}
-
 export interface ChatboxSettings {
   chatboxId: string;
   projectId: string;
@@ -60,10 +59,8 @@ export interface ChatboxSettings {
   requireToolApproval: boolean;
   allowGuestAccess: boolean;
   mode: ChatboxMode;
-  /** When present, drives welcome dialog in hosted chatbox (Convex may add fields incrementally). */
-  welcomeDialog?: ChatboxWelcomeDialogSettings | null;
-  /** When present, drives tester feedback cadence and copy. */
-  feedbackDialog?: ChatboxFeedbackDialogSettings | null;
+  /** Chat UI config envelope: welcome / feedback dialog surfaces (and future surfaces / branding). */
+  chatUi?: ChatUiSettings | null;
   servers: ChatboxServerSettings[];
   link: {
     token: string;

--- a/mcpjam-inspector/client/src/lib/__tests__/chatbox-session.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/chatbox-session.test.ts
@@ -107,7 +107,7 @@ describe("chatbox-session", () => {
             optional: false,
           },
         ],
-        welcomeDialog: undefined,
+        chatUi: undefined,
       },
       surface: "share_link",
     });
@@ -180,7 +180,7 @@ describe("chatbox-session", () => {
         temperature: 0.4,
         requireToolApproval: true,
         servers: [],
-        welcomeDialog: undefined,
+        chatUi: undefined,
       },
       surface: "share_link",
     });

--- a/mcpjam-inspector/client/src/lib/chatbox-session.ts
+++ b/mcpjam-inspector/client/src/lib/chatbox-session.ts
@@ -52,6 +52,12 @@ export interface ChatboxWelcomeDialogPayload {
   body?: string;
 }
 
+export interface ChatUiPayload {
+  surfaces?: {
+    welcome?: ChatboxWelcomeDialogPayload | null;
+  } | null;
+}
+
 export interface ChatboxBootstrapPayload {
   projectId: string;
   chatboxId: string;
@@ -67,7 +73,7 @@ export interface ChatboxBootstrapPayload {
   requireToolApproval: boolean;
   servers: ChatboxBootstrapServer[];
   /** When set by bootstrap or playground snapshot, drives hosted welcome copy. */
-  welcomeDialog?: ChatboxWelcomeDialogPayload | null;
+  chatUi?: ChatUiPayload | null;
 }
 
 export interface ChatboxSession {
@@ -117,6 +123,31 @@ const PLAYGROUND_TTL_MS = 24 * 60 * 60 * 1000;
 export interface ChatboxPlaygroundSession extends ChatboxSession {
   playgroundId: string;
   updatedAt: number;
+}
+
+// Defensive normalizer for the chatUi envelope in playground snapshots and
+// /web/chatbox/redeem responses. Returns `undefined` when no recognized
+// surface is present; the hosted runtime only consumes the `welcome`
+// surface today (feedback never reaches the bootstrap payload).
+function normalizeChatUiPayload(input: unknown): ChatUiPayload | undefined {
+  if (!input || typeof input !== "object") return undefined;
+  const surfaces = (input as { surfaces?: unknown }).surfaces;
+  if (!surfaces || typeof surfaces !== "object") return undefined;
+  const welcomeRaw = (surfaces as { welcome?: unknown }).welcome;
+  const welcome =
+    welcomeRaw &&
+    typeof welcomeRaw === "object" &&
+    typeof (welcomeRaw as { enabled?: unknown }).enabled === "boolean"
+      ? {
+          enabled: (welcomeRaw as { enabled: boolean }).enabled,
+          body:
+            typeof (welcomeRaw as { body?: unknown }).body === "string"
+              ? (welcomeRaw as { body: string }).body
+              : "",
+        }
+      : undefined;
+  if (!welcome) return undefined;
+  return { surfaces: { welcome } };
 }
 
 function normalizeChatboxShareMode(mode: unknown): ChatboxShareMode {
@@ -222,18 +253,7 @@ export function normalizeChatboxSession(
             : null,
           optional: Boolean(server.optional),
         })),
-      welcomeDialog:
-        payload.welcomeDialog &&
-        typeof payload.welcomeDialog === "object" &&
-        typeof payload.welcomeDialog.enabled === "boolean"
-          ? {
-              enabled: payload.welcomeDialog.enabled,
-              body:
-                typeof payload.welcomeDialog.body === "string"
-                  ? payload.welcomeDialog.body
-                  : "",
-            }
-          : undefined,
+      chatUi: normalizeChatUiPayload(payload.chatUi),
     },
     surface: parsed.surface === "preview" ? "preview" : "share_link",
   };

--- a/mcpjam-inspector/client/src/types/chatUi.ts
+++ b/mcpjam-inspector/client/src/types/chatUi.ts
@@ -1,0 +1,25 @@
+// Shared "Chat UI" types — single source of truth for the chatUi envelope
+// that wraps welcome/feedback dialogs (and future surfaces / branding).
+// Consumed by the chatbox builder, the hosted chat runtime, and the
+// playground bootstrap normalizer.
+
+export interface ChatboxWelcomeDialogSettings {
+  enabled: boolean;
+  body?: string;
+}
+
+export interface ChatboxFeedbackDialogSettings {
+  enabled: boolean;
+  /** Completed tool calls between feedback prompts in hosted sessions (not user message count). */
+  everyNToolCalls?: number;
+  promptHint?: string;
+}
+
+export interface ChatUiSurfaces {
+  welcome?: ChatboxWelcomeDialogSettings | null;
+  feedback?: ChatboxFeedbackDialogSettings | null;
+}
+
+export interface ChatUiSettings {
+  surfaces?: ChatUiSurfaces | null;
+}


### PR DESCRIPTION
## Summary

Replace the two ad-hoc top-level `welcomeDialog` / `feedbackDialog` fields on the chatbox config with a single typed `chatUi` envelope holding both dialogs under `chatUi.surfaces.{welcome, feedback}`. Mirrors the backend refactor in `mcpjam/mcpjam-backend#257`.

- New shared `client/src/types/chatUi.ts` module is the single source of truth for `ChatUiSettings` / surface shapes; hooks, builder drafts, hosted runtime, and playground bootstrap all import from it.
- Builder's chatUi unpacking happens once in `toDraftConfig` (sibling `toChatUiFromChatbox` helper used by `isDirty` comparator). Per-starter `createDraft` factories emit the nested shape.
- `migrateBuilderDraft` rebuilds `chatUi` from the blank starter when a sessionStorage draft predates this change — legacy top-level keys are ignored.
- Feedback surface remains absent from the playground bootstrap payload (builder-only); only `chatUi.surfaces.welcome` flows downstream, matching the prior asymmetry.

## Test plan
- [x] `pnpm vitest run` for all 8 affected `__tests__` files — 84 tests pass
- [ ] Manual: open builder for a fresh chatbox, edit welcome body + feedback cadence, save, reload — verify persistence
- [ ] Manual: open hosted link incognito; confirm welcome modal renders saved body on first visit
- [ ] Cross-check playground snapshot in DevTools localStorage shows `chatUi.surfaces.welcome.body` (no leftover top-level `welcomeDialog`)

https://claude.ai/code/session_01F8ghU3rgVHSTJSr9VJNPbT

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8ghU3rgVHSTJSr9VJNPbT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this changes the persisted/config schema shape for chatbox welcome/feedback settings and adds migration/normalization logic; mistakes could silently drop UI copy or affect preview/hosted onboarding behavior.
> 
> **Overview**
> Refactors chatbox UI configuration by replacing top-level `welcomeDialog`/`feedbackDialog` settings with a single `chatUi` envelope (`chatUi.surfaces.welcome` / `chatUi.surfaces.feedback`) across the editor, builder, hosted chat page, and preview/playground session payloads.
> 
> Adds a shared `types/chatUi.ts` as the source of truth for the new shapes, updates draft starters/comparators, and introduces draft/session migration + payload normalization to preserve legacy in-flight builder drafts and safely parse stored playground/redeem payloads (currently only the welcome surface is consumed in bootstrap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 420328e8e6dd521dbcda8adad0b90e059157317e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->