### PR TITLE
race on connecting project and onboarding

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2320,9 +2320,7 @@ export default function App() {
               isSignedInWithWorkOs={!!workOsUser}
               isWorkOsAuthLoading={isWorkOsLoading}
               isConvexAuthenticated={isAuthenticated}
-              isProjectProvisioned={
-                !isAuthenticated || Boolean(activeProject?.sharedProjectId)
-              }
+              isProjectProvisioned={Boolean(activeProject?.sharedProjectId)}
               hasSeenFirstRunOnboarding={remoteFirstRunOnboardingShown}
               isServerSyncing={isSelectedServerSyncing}
               onConnect={handleConnect}

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2320,6 +2320,9 @@ export default function App() {
               isSignedInWithWorkOs={!!workOsUser}
               isWorkOsAuthLoading={isWorkOsLoading}
               isConvexAuthenticated={isAuthenticated}
+              isProjectProvisioned={
+                !isAuthenticated || Boolean(activeProject?.sharedProjectId)
+              }
               hasSeenFirstRunOnboarding={remoteFirstRunOnboardingShown}
               isServerSyncing={isSelectedServerSyncing}
               onConnect={handleConnect}

--- a/mcpjam-inspector/client/src/components/ui-playground/AppBuilderTab.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/AppBuilderTab.tsx
@@ -80,6 +80,7 @@ interface AppBuilderTabProps {
   isSignedInWithWorkOs?: boolean;
   isWorkOsAuthLoading?: boolean;
   isConvexAuthenticated?: boolean;
+  isProjectProvisioned?: boolean;
   hasSeenFirstRunOnboarding?: boolean;
   /**
    * True while the currently selected server exists in runtime state but has
@@ -129,6 +130,7 @@ export function AppBuilderTab({
   isSignedInWithWorkOs = false,
   isWorkOsAuthLoading = false,
   isConvexAuthenticated = false,
+  isProjectProvisioned = true,
   hasSeenFirstRunOnboarding,
   isServerSyncing = false,
   onConnect,
@@ -152,6 +154,7 @@ export function AppBuilderTab({
     hasRemoteOnboardingState: hasSeenFirstRunOnboarding !== undefined,
     hasSeenOnboarding: hasSeenFirstRunOnboarding === true,
     canPersistRemoteOnboarding: isConvexAuthenticated,
+    isProjectProvisioned,
   });
 
   const firstRunComposerSeed =

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-onboarding.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-onboarding.test.tsx
@@ -88,6 +88,33 @@ describe("useOnboarding", () => {
     });
   });
 
+  it("waits for project provisioning before auto-connecting Excalidraw", async () => {
+    const onConnect = vi.fn();
+    const { rerender } = renderHook(
+      ({ isProjectProvisioned }: { isProjectProvisioned: boolean }) =>
+        useOnboarding({
+          servers: {},
+          onConnect,
+          isSignedInWithWorkOs: false,
+          isWorkOsAuthLoading: false,
+          isProjectProvisioned,
+        }),
+      {
+        initialProps: {
+          isProjectProvisioned: false,
+        },
+      }
+    );
+
+    expect(onConnect).not.toHaveBeenCalled();
+
+    rerender({ isProjectProvisioned: true });
+
+    await waitFor(() => {
+      expect(onConnect).toHaveBeenCalledWith(EXCALIDRAW_SERVER_CONFIG);
+    });
+  });
+
   it("does not show the onboarding overlay while auth is still settling", () => {
     const { result } = renderHook(() =>
       useOnboarding({

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.hosted-oauth.test.tsx
@@ -12,6 +12,7 @@ const {
   mockUseServerMutations,
   mockConvexQuery,
   testConnectionMock,
+  mockTryResolveProjectServer,
   readStoredOAuthConfigMock,
   toastSuccess,
 } = vi.hoisted(() => ({
@@ -26,6 +27,9 @@ const {
   })),
   mockConvexQuery: vi.fn(),
   testConnectionMock: vi.fn(),
+  mockTryResolveProjectServer: vi.fn<
+    (serverNameOrId: string) => { projectId: string; serverId: string } | null
+  >(() => ({ projectId: "ws_1", serverId: "srv_asana" })),
   readStoredOAuthConfigMock: vi.fn(),
   toastSuccess: vi.fn(),
 }));
@@ -64,7 +68,7 @@ vi.mock("@/lib/oauth/mcp-oauth", () => ({
 vi.mock("@/lib/apis/web/context", () => ({
   injectHostedServerMapping: vi.fn(),
   tryGetHostedServerDisplayName: vi.fn(),
-  tryResolveProjectServer: vi.fn(() => null),
+  tryResolveProjectServer: mockTryResolveProjectServer,
 }));
 
 vi.mock("@/lib/session-token", () => ({
@@ -109,6 +113,7 @@ function renderHostedServerState(
           ws_1: {
             id: "ws_1",
             name: "Project",
+            sharedProjectId: "ws_1",
             clientConfig: options?.projectClientConfig,
             servers: {
               asana: {
@@ -157,6 +162,7 @@ function renderHostedServerState(
         ws_1: {
           id: "ws_1",
           name: "Project",
+          sharedProjectId: "ws_1",
           clientConfig: options?.projectClientConfig,
           servers: {
             asana: {
@@ -210,6 +216,10 @@ describe("useServerState hosted OAuth callback guards", () => {
       success: true,
       initInfo: {},
     });
+    mockTryResolveProjectServer.mockReturnValue({
+      projectId: "ws_1",
+      serverId: "srv_asana",
+    });
     readStoredOAuthConfigMock.mockReturnValue({});
   });
 
@@ -236,7 +246,16 @@ describe("useServerState hosted OAuth callback guards", () => {
         isAuthLoading: false,
         isLoadingProjects: false,
         useLocalFallback: false,
-        effectiveProjects: {} as any,
+        effectiveProjects: {
+          ws_1: {
+            id: "ws_1",
+            name: "Project",
+            sharedProjectId: "ws_1",
+            servers: {},
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        } as any,
         effectiveActiveProjectId: "ws_1",
         activeProjectServersFlat: [],
         logger: {
@@ -290,7 +309,16 @@ describe("useServerState hosted OAuth callback guards", () => {
         isAuthLoading: false,
         isLoadingProjects: false,
         useLocalFallback: false,
-        effectiveProjects: {} as any,
+        effectiveProjects: {
+          ws_1: {
+            id: "ws_1",
+            name: "Project",
+            sharedProjectId: "ws_1",
+            servers: {},
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        } as any,
         effectiveActiveProjectId: "ws_1",
         activeProjectServersFlat: [],
         logger: {
@@ -417,7 +445,7 @@ describe("useServerState hosted OAuth callback guards", () => {
 
     await waitFor(() => {
       expect(mockReconnectServer).toHaveBeenCalledWith(
-        "asana",
+        "srv_asana",
         expect.objectContaining({
           type: "http",
           url: "https://mcp.asana.com/sse",
@@ -426,6 +454,10 @@ describe("useServerState hosted OAuth callback guards", () => {
               projectProfile: {},
             },
           }),
+        }),
+        expect.objectContaining({
+          projectId: "ws_1",
+          serverName: "asana",
         }),
       );
     });

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -2,7 +2,10 @@ import { act, renderHook, waitFor } from "@testing-library/react";
 import { flushSync } from "react-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppState, AppAction, ServerWithName } from "@/state/app-types";
-import { CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE } from "@/lib/client-config";
+import {
+  CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE,
+  PROJECT_NOT_PROVISIONED_ERROR_MESSAGE,
+} from "@/lib/client-config";
 import type { ProjectClientConfig } from "@/lib/client-config";
 import { useClientConfigStore } from "@/stores/client-config-store";
 import { useHostContextStore } from "@/stores/host-context-store";
@@ -18,6 +21,9 @@ const {
   clearOAuthDataMock,
   readStoredOAuthConfigMock,
   testConnectionMock,
+  reconnectServerMock,
+  getInitializationInfoMock,
+  tryResolveProjectServerMock,
   mockConvexQuery,
   mockCreateServer,
   mockUpdateServer,
@@ -31,6 +37,11 @@ const {
   clearOAuthDataMock: vi.fn(),
   readStoredOAuthConfigMock: vi.fn(),
   testConnectionMock: vi.fn(),
+  reconnectServerMock: vi.fn(),
+  getInitializationInfoMock: vi.fn(),
+  tryResolveProjectServerMock: vi.fn<
+    (serverNameOrId: string) => { projectId: string; serverId: string } | null
+  >(() => null),
   mockConvexQuery: vi.fn(),
   mockCreateServer: vi.fn(),
   mockUpdateServer: vi.fn(),
@@ -53,8 +64,8 @@ vi.mock("@/state/mcp-api", () => ({
   testConnection: testConnectionMock,
   deleteServer: vi.fn(),
   listServers: vi.fn(),
-  reconnectServer: vi.fn(),
-  getInitializationInfo: vi.fn(),
+  reconnectServer: reconnectServerMock,
+  getInitializationInfo: getInitializationInfoMock,
 }));
 
 vi.mock("@/state/oauth-orchestrator", () => ({
@@ -73,7 +84,7 @@ vi.mock("@/lib/oauth/mcp-oauth", () => ({
 vi.mock("@/lib/apis/web/context", () => ({
   injectHostedServerMapping: vi.fn(),
   tryGetHostedServerDisplayName: vi.fn(),
-  tryResolveProjectServer: vi.fn(() => null),
+  tryResolveProjectServer: tryResolveProjectServerMock,
 }));
 
 vi.mock("@/lib/session-token", () => ({
@@ -185,6 +196,18 @@ function renderUseServerState(
     })
   );
 }
+
+beforeEach(() => {
+  tryResolveProjectServerMock.mockReturnValue({
+    projectId: "project_default",
+    serverId: "srv_demo",
+  });
+  reconnectServerMock.mockReset();
+  getInitializationInfoMock.mockResolvedValue({
+    success: true,
+    initInfo: null,
+  });
+});
 
 describe("useServerState effective server projection", () => {
   beforeEach(() => {
@@ -322,6 +345,10 @@ describe("useServerState OAuth callback failures", () => {
     mockConvexQuery.mockResolvedValue(null);
     mockCreateServer.mockReset();
     mockUpdateServer.mockReset();
+    tryResolveProjectServerMock.mockReturnValue({
+      projectId: "project_default",
+      serverId: "srv_demo",
+    });
   });
 
   it("marks the pending server as failed when authorization is denied", async () => {
@@ -457,30 +484,31 @@ describe("useServerState OAuth callback failures", () => {
     renderUseServerState(dispatch, appState);
 
     await waitFor(() => {
-      expect(testConnectionMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: "https://example.com/mcp",
-          requestInit: expect.objectContaining({
-            headers: expect.objectContaining({
-              Authorization: "Bearer access-token",
-              "x-existing-header": "present",
-            }),
-          }),
-          timeout: 15000,
-          capabilities: {
-            roots: {
-              listChanged: true,
-            },
-          },
-          clientCapabilities: {
-            roots: {
-              listChanged: true,
-            },
-          },
-        }),
-        "demo-server"
-      );
+      expect(testConnectionMock).toHaveBeenCalled();
     });
+
+    expect(testConnectionMock.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({
+        url: "https://example.com/mcp",
+        requestInit: expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer access-token",
+            "x-existing-header": "present",
+          }),
+        }),
+        timeout: 15000,
+        capabilities: {
+          roots: {
+            listChanged: true,
+          },
+        },
+        clientCapabilities: {
+          roots: {
+            listChanged: true,
+          },
+        },
+      })
+    );
 
     const upsertAction = dispatch.mock.calls.find(
       ([action]) => action.type === "UPSERT_SERVER"
@@ -528,18 +556,19 @@ describe("useServerState OAuth callback failures", () => {
     renderUseServerState(dispatch, appState);
 
     await waitFor(() => {
-      expect(testConnectionMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          url: "https://example.com/mcp",
-          requestInit: expect.objectContaining({
-            headers: expect.objectContaining({
-              Authorization: "Bearer access-token",
-            }),
+      expect(testConnectionMock).toHaveBeenCalled();
+    });
+
+    expect(testConnectionMock.mock.calls.at(-1)?.[0]).toEqual(
+      expect.objectContaining({
+        url: "https://example.com/mcp",
+        requestInit: expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer access-token",
           }),
         }),
-        "demo-server"
-      );
-    });
+      })
+    );
 
     const connectConfig = testConnectionMock.mock.calls.at(-1)?.[0];
     expect(connectConfig).not.toHaveProperty("command");
@@ -567,6 +596,62 @@ describe("useServerState OAuth callback failures", () => {
     expect(
       dispatch.mock.calls.some(([action]) => action.type === "CONNECT_REQUEST")
     ).toBe(false);
+  });
+
+  it("blocks connect while the active project is still provisioning", async () => {
+    const dispatch = vi.fn();
+    const { result } = renderUseServerState(dispatch, createAppState(), {
+      isAuthenticated: true,
+      useLocalFallback: false,
+    });
+
+    await act(async () => {
+      await result.current.handleConnect({
+        name: "new-server",
+        type: "http",
+        url: "https://example.com/mcp",
+      });
+    });
+
+    expect(toastError).toHaveBeenCalledWith(
+      PROJECT_NOT_PROVISIONED_ERROR_MESSAGE
+    );
+    expect(testConnectionMock).not.toHaveBeenCalled();
+    expect(mockCreateServer).not.toHaveBeenCalled();
+    expect(
+      dispatch.mock.calls.some(([action]) => action.type === "CONNECT_REQUEST")
+    ).toBe(false);
+  });
+
+  it("uses the friendly provisioning message when the resolver mapping is missing", async () => {
+    tryResolveProjectServerMock.mockReturnValue(null);
+    const appState = createAppState();
+    appState.projects.default.sharedProjectId = "project_default";
+
+    const dispatch = vi.fn();
+    const { result } = renderUseServerState(dispatch, appState, {
+      isAuthenticated: true,
+      useLocalFallback: false,
+      effectiveProjects: appState.projects,
+    });
+
+    await act(async () => {
+      await result.current.handleConnect({
+        name: "new-server",
+        type: "http",
+        url: "https://example.com/mcp",
+      });
+    });
+
+    expect(testConnectionMock).not.toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "CONNECT_FAILURE",
+      name: "new-server",
+      error: PROJECT_NOT_PROVISIONED_ERROR_MESSAGE,
+    });
+    expect(toastError).toHaveBeenCalledWith(
+      PROJECT_NOT_PROVISIONED_ERROR_MESSAGE
+    );
   });
 
   it("applies project connection defaults on local reconnect", async () => {

--- a/mcpjam-inspector/client/src/hooks/use-onboarding.ts
+++ b/mcpjam-inspector/client/src/hooks/use-onboarding.ts
@@ -25,6 +25,7 @@ interface UseOnboardingOptions {
   hasRemoteOnboardingState?: boolean;
   hasSeenOnboarding?: boolean;
   canPersistRemoteOnboarding?: boolean;
+  isProjectProvisioned?: boolean;
 }
 
 interface UseOnboardingReturn {
@@ -100,6 +101,7 @@ export function useOnboarding({
   hasRemoteOnboardingState = false,
   hasSeenOnboarding = false,
   canPersistRemoteOnboarding = false,
+  isProjectProvisioned = true,
 }: UseOnboardingOptions): UseOnboardingReturn {
   const posthog = usePostHog();
   const markOnboardingAsShownMutation = useMutation(
@@ -195,6 +197,7 @@ export function useOnboarding({
   useEffect(() => {
     if (isWorkOsAuthLoading || isSignedInWithWorkOs) return;
     if (didAutoConnectRef.current) return;
+    if (!isProjectProvisioned) return;
 
     if (hasRemoteOnboardingState) {
       if (hasSeenOnboarding) return;
@@ -232,6 +235,7 @@ export function useOnboarding({
     servers,
     isWorkOsAuthLoading,
     isSignedInWithWorkOs,
+    isProjectProvisioned,
     hasRemoteOnboardingState,
     hasSeenOnboarding,
     onConnect,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -48,6 +48,7 @@ import { useUIPlaygroundStore } from "@/stores/ui-playground-store";
 import { useServerMutations, type RemoteServer } from "./useProjects";
 import {
   CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE,
+  PROJECT_NOT_PROVISIONED_ERROR_MESSAGE,
   getEffectiveProjectConnectionDefaults,
   mergeProjectConnectionHeaders,
   resolveEffectiveServerClientCapabilities,
@@ -720,6 +721,31 @@ export function useServerState({
     return true;
   }, [isClientConfigSyncPending]);
 
+  const isProjectProvisioned = useMemo(
+    () => Boolean(activeProject?.sharedProjectId),
+    [activeProject?.sharedProjectId]
+  );
+
+  const getProjectNotProvisionedError = useCallback(() => {
+    if (isProjectProvisioned) {
+      return null;
+    }
+    if (useLocalFallbackRef.current || !isAuthenticatedRef.current) {
+      return null;
+    }
+    return PROJECT_NOT_PROVISIONED_ERROR_MESSAGE;
+  }, [isProjectProvisioned]);
+
+  const notifyIfProjectNotProvisioned = useCallback(() => {
+    const errorMessage = getProjectNotProvisionedError();
+    if (!errorMessage) {
+      return false;
+    }
+
+    toast.error(errorMessage);
+    return true;
+  }, [getProjectNotProvisionedError]);
+
   // Extract runtime overlay applied by `withProjectConnectionDefaults` so the
   // resolver path can reproduce them server-side. Without this, the resolver
   // sees only the Convex-stored per-server config and loses project-level
@@ -769,7 +795,7 @@ export function useServerState({
           connectionDefaults: buildResolverConnectionDefaults(serverConfig),
         });
       }
-      return testConnection(serverConfig, serverName);
+      throw new Error(PROJECT_NOT_PROVISIONED_ERROR_MESSAGE);
     },
     [assertClientConfigSynced, buildResolverConnectionDefaults]
   );
@@ -785,7 +811,7 @@ export function useServerState({
           connectionDefaults: buildResolverConnectionDefaults(serverConfig),
         });
       }
-      return reconnectServer(serverName, serverConfig);
+      throw new Error(PROJECT_NOT_PROVISIONED_ERROR_MESSAGE);
     },
     [assertClientConfigSynced, buildResolverConnectionDefaults]
   );
@@ -1680,6 +1706,9 @@ export function useServerState({
       if (notifyIfClientConfigSyncPending()) {
         return;
       }
+      if (notifyIfProjectNotProvisioned()) {
+        return;
+      }
 
       const validationError = validateForm(formData);
       if (validationError) {
@@ -2003,7 +2032,11 @@ export function useServerState({
           serverName: formData.name,
           error: errorMessage,
         });
-        toast.error(`Network error: ${errorMessage}`);
+        toast.error(
+          errorMessage === PROJECT_NOT_PROVISIONED_ERROR_MESSAGE
+            ? errorMessage
+            : `Network error: ${errorMessage}`
+        );
       }
     },
     [
@@ -2013,6 +2046,7 @@ export function useServerState({
       appState.projects,
       appState.activeProjectId,
       notifyIfClientConfigSyncPending,
+      notifyIfProjectNotProvisioned,
       prepareHostedProjectOAuthRedirect,
       resolveOAuthInitiationInputs,
       syncServerToConvex,
@@ -2248,6 +2282,9 @@ export function useServerState({
       if (notifyIfClientConfigSyncPending()) {
         return;
       }
+      if (notifyIfProjectNotProvisioned()) {
+        return;
+      }
 
       const result = await applyTokensFromOAuthFlow(
         serverName,
@@ -2260,7 +2297,11 @@ export function useServerState({
         toast.error(`Connection failed: ${result.error}`);
       }
     },
-    [applyTokensFromOAuthFlow, notifyIfClientConfigSyncPending]
+    [
+      applyTokensFromOAuthFlow,
+      notifyIfClientConfigSyncPending,
+      notifyIfProjectNotProvisioned,
+    ]
   );
 
   const handleRefreshTokensFromOAuthFlow = useCallback(
@@ -2279,6 +2320,9 @@ export function useServerState({
       if (notifyIfClientConfigSyncPending()) {
         return;
       }
+      if (notifyIfProjectNotProvisioned()) {
+        return;
+      }
 
       const result = await applyTokensFromOAuthFlow(
         serverName,
@@ -2291,7 +2335,11 @@ export function useServerState({
         toast.error(`Token refresh failed: ${result.error}`);
       }
     },
-    [applyTokensFromOAuthFlow, notifyIfClientConfigSyncPending]
+    [
+      applyTokensFromOAuthFlow,
+      notifyIfClientConfigSyncPending,
+      notifyIfProjectNotProvisioned,
+    ]
   );
 
   const cliConfigProcessedRef = useRef<boolean>(false);
@@ -2546,6 +2594,15 @@ export function useServerState({
         return {
           status: "failed",
           error: errorMessage,
+        };
+      }
+
+      const projectNotProvisionedError = getProjectNotProvisionedError();
+      if (projectNotProvisionedError) {
+        reportError(projectNotProvisionedError);
+        return {
+          status: "failed",
+          error: projectNotProvisionedError,
         };
       }
 
@@ -3011,6 +3068,7 @@ export function useServerState({
       activeProjectServersFlat,
       isAuthenticated,
       isClientConfigSyncPending,
+      getProjectNotProvisionedError,
       storeInitInfo,
       logger,
       dispatch,
@@ -3311,6 +3369,9 @@ export function useServerState({
       if (notifyIfClientConfigSyncPending()) {
         return { ok: false, serverName: originalServerName };
       }
+      if (notifyIfProjectNotProvisioned()) {
+        return { ok: false, serverName: originalServerName };
+      }
 
       const shouldPreserveOAuth =
         hadOAuthTokens &&
@@ -3394,6 +3455,7 @@ export function useServerState({
       useLocalFallback,
       persistServerToLocalProject,
       notifyIfClientConfigSyncPending,
+      notifyIfProjectNotProvisioned,
       guardedTestConnection,
     ]
   );

--- a/mcpjam-inspector/client/src/lib/client-config.ts
+++ b/mcpjam-inspector/client/src/lib/client-config.ts
@@ -42,6 +42,9 @@ export type HostSafeAreaInsets = {
 export const CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE =
   "Project connection defaults are still syncing. Try again in a moment.";
 
+export const PROJECT_NOT_PROVISIONED_ERROR_MESSAGE =
+  "Your project isn't ready yet. Refresh the page in a moment, or sign in if you're signed out, then try connecting again.";
+
 export const DEFAULT_REQUEST_TIMEOUT_MS = 10000;
 
 export const DEFAULT_HOST_DEVICE_CAPABILITIES: HostDeviceCapabilities = {

--- a/mcpjam-inspector/client/src/lib/client-config.ts
+++ b/mcpjam-inspector/client/src/lib/client-config.ts
@@ -42,8 +42,7 @@ export type HostSafeAreaInsets = {
 export const CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE =
   "Project connection defaults are still syncing. Try again in a moment.";
 
-export const PROJECT_NOT_PROVISIONED_ERROR_MESSAGE =
-  "Your project isn't ready yet. Refresh the page in a moment, or sign in if you're signed out, then try connecting again.";
+export const PROJECT_NOT_PROVISIONED_ERROR_MESSAGE = "Finishing setup.";
 
 export const DEFAULT_REQUEST_TIMEOUT_MS = 10000;
 


### PR DESCRIPTION
- Fixes an ugly developer error toast that appeared when users connected MCP servers before their project finished loading
- The bug: onboarding tried to auto-connect Excalidraw before the project was ready in the backend
- Fix 1: onboarding now waits until the project is ready, then connects on its own
- Fix 2: if a user manually clicks Connect/Reconnect/etc. before the project is ready, they see a friendly `"Finishing setup."` toast
- Fix 3: there was old fallback code that triggered the ugly error directly — we rewired it so it now shows the friendly toast too, as a safety net