### PR TITLE
feat(evals): M1 phase 3 — multi-config design RFC + ClientConfigDto + executionConfigKey

### DIFF
--- a/mcpjam-inspector/docs/evals/m1-phase3-multi-config-design.md
+++ b/mcpjam-inspector/docs/evals/m1-phase3-multi-config-design.md
@@ -1,0 +1,145 @@
+# M1 Phase 3 — Multi-config eval runs (design RFC)
+
+Status: design — gating implementation per the M1 plan.
+
+## Why this is its own design pass
+
+Phase 3 is the architectural piece of M1. It touches run identity, iteration identity, the host-config materialization pipeline, the SSE event shape, and the run-detail UI all at once. The plan calls out that this is where bad assumptions get expensive, so the implementation is gated on agreement here. Phases 1, 2, 4, and 5 do not need this design.
+
+## What changes
+
+Today a suite run executes against one client config. Phase 3 lets a single run target up to **3** client configs concurrently, and surfaces the per-config results side by side. A "client config" maps to the same data model as the chatbox (model + provider + system prompt + temperature + tool choice + servers).
+
+## Decisions (locked)
+
+- **Cap:** up to 3 client configs per request, enforced both at Zod (`clientConfigs.length <= 3`) and post-parse via the cap formula already in `server/routes/shared/evals.ts` (`Math.max(clientConfigs.length, 1)`).
+- **Iteration identity:** reuse the existing `hostConfigId` on `testIteration` (already persisted and indexed per `mcpjam-backend/convex/schema.ts:614`). No new Convex field.
+- **Grouping disambiguator:** `HostConfigInputV2` does not include `provider` or `toolChoice` (`mcpjam-backend/convex/lib/hostConfigV2.ts:31`), so two configs that differ only in those fields could share a `hostConfigId`. To keep the cross-run comparison key correct, compute `executionConfigKey = hash(hostConfigId, provider, toolChoice)` at runtime in the runner/recorder and use it as the grouping key for Phase 4 regression detection.
+- **Run identity:** one `testSuiteRun` row with up to 3 config branches keyed by `(hostConfigId, executionConfigKey)`. Not 3 sibling runs. Preserves run numbering, `latestRun` semantics, and lets the UI group by `(testCaseId, executionConfigKey)` inside one run.
+- **Fail isolation:** `Promise.allSettled` per config — one config's MCP server crashing must not poison another's tool registry. Per-config errors land on the per-iteration record; the suite run itself still completes.
+- **SSE shape:** every event payload carries `hostConfigId`. The client-side `eval-stream-reducer.ts` buckets by `hostConfigId`.
+- **Transport DTO:** chat-box / project config is NOT lifted into `shared/`. A dedicated `ClientConfigDto` lives in `shared/eval-config.ts` (this PR). UI converts chatbox state → DTO at the boundary.
+- **Pinned baseline:** out of scope for M1. Comparison source is most-recent-prior only.
+
+## ClientConfigDto
+
+```ts
+type ClientConfigDto = {
+  id: string;             // stable, client-supplied; same id across reruns of the same picked config
+  model: string;          // e.g. "claude-3-7-sonnet"
+  provider: string;       // e.g. "anthropic"
+  systemPrompt?: string;
+  temperature?: number;
+  toolChoice?: ToolChoice;
+  serverRefs: ServerRef[]; // resolvable to MCP server identities; NOT raw chatbox state
+};
+```
+
+The shape mirrors the runtime resolved execution config — not the chatbox UI state. The chatbox picker UI emits this DTO via a thin adapter at the boundary; the backend never sees chatbox-only fields.
+
+## Worked example — 2 configs × 3 iterations × 2 cases
+
+A suite run with `clientConfigs.length = 2`, two test cases, each with `runs: 3`, produces **1** `testSuiteRun` row and **12** `testIteration` rows. The pseudo-shape, illustrative only:
+
+```
+testSuiteRun {
+  _id: "run_42",
+  suiteId: "ts_abc",
+  runNumber: 17,
+  status: "completed",
+  // existing fields...
+}
+
+testIteration[0] { suiteRunId: "run_42", testCaseId: "tc_A", iterationNumber: 1, hostConfigId: "hc_haiku_default", ... }
+testIteration[1] { suiteRunId: "run_42", testCaseId: "tc_A", iterationNumber: 2, hostConfigId: "hc_haiku_default", ... }
+testIteration[2] { suiteRunId: "run_42", testCaseId: "tc_A", iterationNumber: 3, hostConfigId: "hc_haiku_default", ... }
+testIteration[3] { suiteRunId: "run_42", testCaseId: "tc_A", iterationNumber: 1, hostConfigId: "hc_sonnet_default", ... }
+testIteration[4] { suiteRunId: "run_42", testCaseId: "tc_A", iterationNumber: 2, hostConfigId: "hc_sonnet_default", ... }
+testIteration[5] { suiteRunId: "run_42", testCaseId: "tc_A", iterationNumber: 3, hostConfigId: "hc_sonnet_default", ... }
+testIteration[6..11]  // same for tc_B
+```
+
+The run-detail UI queries iterations by `suiteRunId`, groups by `(testCaseId, executionConfigKey)`, and renders one column per config. Per-config p50/p95 reuse the helpers from Phase 1.
+
+`iterationNumber` is **per (testCase, config)**, not global within the run. So `(tc_A, hc_haiku_default, iter 1..3)` and `(tc_A, hc_sonnet_default, iter 1..3)` coexist with overlapping iteration numbers. This matches today's invariant for single-config runs (iteration number is per case).
+
+## Runner pseudocode
+
+```ts
+const configs = request.clientConfigs ?? [defaultConfigFromSuite(suite)];
+
+for (const test of tests) {
+  await Promise.allSettled(
+    configs.map(async (config) => {
+      for (let i = 0; i < test.runs; i++) {
+        const hostConfigId = await resolveHostConfig({ suite, test, config });
+        const executionConfigKey = hashExecutionConfig({
+          hostConfigId,
+          provider: config.provider,
+          toolChoice: config.toolChoice,
+        });
+        const iter = await precreateIteration({
+          suiteRunId,
+          testCaseId: test._id,
+          iterationNumber: i + 1,
+          hostConfigId,
+        });
+        try {
+          await runOneIteration(iter, config, hostConfigId);
+        } catch (err) {
+          await markIterationFailed(iter, err); // does NOT abort siblings
+        }
+        emitSseEvent({ type: "iteration:done", hostConfigId, ... });
+      }
+    }),
+  );
+}
+```
+
+Key invariants:
+1. `Promise.allSettled` at the config level. A thrown config does not block siblings.
+2. Inside each config, iterations run sequentially (matches today).
+3. Each iteration is recorded with the resolved `hostConfigId`. The runtime-only `executionConfigKey` is attached to SSE events for client-side grouping but does not need to be persisted (Phase 4 recomputes it at comparison time).
+
+## SSE event shape
+
+Today's events carry an iteration identity. Phase 3 adds `hostConfigId` to every event payload that already carries `iterationId` or `testCaseId`:
+
+```ts
+type EvalStreamEvent =
+  | { type: "iteration:started"; iterationId; testCaseId; hostConfigId }
+  | { type: "tool:called";       iterationId; testCaseId; hostConfigId; toolName; arguments }
+  | { type: "iteration:done";    iterationId; testCaseId; hostConfigId; result }
+  | ...
+```
+
+`eval-stream-reducer.ts` keys its per-iteration accumulators by `(iterationId)` already; for multi-config display we add a derived bucket keyed by `hostConfigId` so the UI can render N columns without re-querying.
+
+## Concurrency caps
+
+The Phase 2 ceiling already accounts for multi-config: `MAX_TOTAL_LLM_CALLS = 300`, with `totalCalls = sum(test.runs) * Math.max(clientConfigs.length, 1)`. No new cap logic required; the post-parse check in `runEvalsWithManager` already takes a `configCount` parameter and will pick it up once the request carries `clientConfigs[]`.
+
+## UI changes
+
+- Generalize `compare-run-chat-surface.tsx` (currently 2-up for runs) into N-up (1..3) keyed by `executionConfigKey`. Reuse `trace-viewer.tsx` per column.
+- Add a "Pick up to 3 client configs" affordance on the run surface that reuses the existing chatbox config picker components but emits `ClientConfigDto[]`.
+- Run-detail KPIs (Phase 1's p50/p95 helpers) compute per config.
+
+## Out of scope for Phase 3
+
+- Pinned baseline. Most-recent-prior only.
+- More than 3 configs.
+- Extending `HostConfigInputV2` to include `provider` / `toolChoice`. That's a backend schema change; defer past M1. Until it lands, `executionConfigKey` carries the disambiguator.
+- Cross-suite comparison.
+
+## Open questions before implementation
+
+1. Should `serverRefs` on `ClientConfigDto` be allowed to differ from the suite environment's `servers`? If yes, the runner must merge per-config server overrides into the host-config resolver. If no (default), all configs share the suite's `environment.servers` and `serverRefs` is purely informational.
+2. When a user picks 3 configs from chatboxes that already exist as named entities (e.g. "Sonnet w/ careful tool choice"), should we surface those names in the run-detail column headers? Likely yes — the DTO's `id` can carry an optional `label`.
+3. Hash function for `executionConfigKey` — SHA-256 over a canonicalized JSON shape, or a smaller FNV-1a / xxhash? Stable across server restarts is the only hard requirement. Defaulting to a tiny pure-JS FNV-1a in `shared/` to avoid a node-crypto dependency in the inspector client.
+
+## Sequencing after this RFC
+
+- **Phase 3b**: implement the runner fan-out, SSE multiplexing, N-up UI, and `ClientConfigDto[]` plumbing in `RunEvalsRequest` / `RunTestCaseRequest`. Land behind a feature flag if practical.
+- **Phase 4**: regression detection keyed by `(testCaseId, executionConfigKey)`. Schema-only change in `mcpjam-backend`: add `regressionThresholdPct?: number` to the `testSuite` table.
+- **Phase 5**: strip host chrome from test-case detail views.

--- a/mcpjam-inspector/shared/__tests__/eval-config.test.ts
+++ b/mcpjam-inspector/shared/__tests__/eval-config.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { computeExecutionConfigKey } from "../eval-config";
+import type { ClientConfigToolChoice } from "../eval-config";
+
+describe("computeExecutionConfigKey", () => {
+  it("is deterministic for the same input", () => {
+    const k1 = computeExecutionConfigKey({
+      hostConfigId: "hc_1",
+      provider: "anthropic",
+      toolChoice: "auto",
+    });
+    const k2 = computeExecutionConfigKey({
+      hostConfigId: "hc_1",
+      provider: "anthropic",
+      toolChoice: "auto",
+    });
+    expect(k1).toBe(k2);
+  });
+
+  it("differs when hostConfigId differs", () => {
+    expect(
+      computeExecutionConfigKey({
+        hostConfigId: "hc_1",
+        provider: "anthropic",
+        toolChoice: "auto",
+      }),
+    ).not.toBe(
+      computeExecutionConfigKey({
+        hostConfigId: "hc_2",
+        provider: "anthropic",
+        toolChoice: "auto",
+      }),
+    );
+  });
+
+  it("differs when provider differs even if hostConfigId matches (the disambiguation case)", () => {
+    expect(
+      computeExecutionConfigKey({
+        hostConfigId: "hc_shared",
+        provider: "anthropic",
+        toolChoice: "auto",
+      }),
+    ).not.toBe(
+      computeExecutionConfigKey({
+        hostConfigId: "hc_shared",
+        provider: "openai",
+        toolChoice: "auto",
+      }),
+    );
+  });
+
+  it("differs when toolChoice differs even if hostConfigId and provider match", () => {
+    const t1: ClientConfigToolChoice = "required";
+    const t2: ClientConfigToolChoice = { type: "tool", toolName: "search" };
+    expect(
+      computeExecutionConfigKey({
+        hostConfigId: "hc_shared",
+        provider: "anthropic",
+        toolChoice: t1,
+      }),
+    ).not.toBe(
+      computeExecutionConfigKey({
+        hostConfigId: "hc_shared",
+        provider: "anthropic",
+        toolChoice: t2,
+      }),
+    );
+  });
+
+  it("treats missing toolChoice as a stable empty value", () => {
+    expect(
+      computeExecutionConfigKey({
+        hostConfigId: "hc",
+        provider: "p",
+        toolChoice: undefined,
+      }),
+    ).toBe(
+      computeExecutionConfigKey({
+        hostConfigId: "hc",
+        provider: "p",
+        toolChoice: null,
+      }),
+    );
+  });
+
+  it("emits 8-character lowercase hex", () => {
+    const key = computeExecutionConfigKey({
+      hostConfigId: "hc",
+      provider: "p",
+      toolChoice: "auto",
+    });
+    expect(key).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it("treats string tool-choice and tool-call tool-choice as different keys", () => {
+    const k1 = computeExecutionConfigKey({
+      hostConfigId: "hc",
+      provider: "p",
+      toolChoice: "auto",
+    });
+    const k2 = computeExecutionConfigKey({
+      hostConfigId: "hc",
+      provider: "p",
+      toolChoice: { type: "tool", toolName: "auto" },
+    });
+    expect(k1).not.toBe(k2);
+  });
+});

--- a/mcpjam-inspector/shared/eval-config.ts
+++ b/mcpjam-inspector/shared/eval-config.ts
@@ -1,0 +1,102 @@
+/**
+ * Transport DTO + grouping-key helpers for multi-config eval runs.
+ *
+ * Phase 3 of the M1 plan lets a suite run target up to 3 client configs
+ * concurrently. This module defines the wire-level config shape (a small
+ * DTO derived from the existing chatbox/project config — chatbox UI
+ * state is NOT lifted into shared/) and the runtime grouping key used
+ * by the recorder and Phase 4 regression detection.
+ *
+ * Why a separate key from `hostConfigId`: `HostConfigInputV2` does NOT
+ * include `provider` or `toolChoice`, so two configs that differ only
+ * in those fields can share a `hostConfigId`. The grouping key bakes
+ * `provider` and `toolChoice` into a stable identifier per execution
+ * config snapshot.
+ */
+
+export type ServerRef = string;
+
+export type ClientConfigToolChoice =
+  | "auto"
+  | "none"
+  | "required"
+  | { type: "tool"; toolName: string };
+
+export type ClientConfigDto = {
+  /** Stable, client-supplied; same id across reruns of the same picked config. */
+  id: string;
+  /** Optional human label for column headers; not used for identity. */
+  label?: string;
+  model: string;
+  provider: string;
+  systemPrompt?: string;
+  temperature?: number;
+  toolChoice?: ClientConfigToolChoice;
+  /** Resolvable to MCP server identities; NOT raw chatbox state. */
+  serverRefs: ServerRef[];
+};
+
+/**
+ * Inputs used to derive `executionConfigKey`. Decoupled from
+ * `ClientConfigDto` so the runner can compute the key from whatever
+ * sources it has (the request DTO or a recorded iteration).
+ */
+export type ExecutionConfigKeyInput = {
+  hostConfigId: string | null | undefined;
+  provider: string | null | undefined;
+  toolChoice?: ClientConfigToolChoice | null;
+};
+
+/**
+ * Canonicalize a tool-choice value into a stable string. Order and
+ * key-order independence matter — different JSON serializations of the
+ * same logical tool choice must hash to the same key.
+ */
+function canonicalizeToolChoice(
+  toolChoice: ClientConfigToolChoice | null | undefined,
+): string {
+  if (toolChoice === undefined || toolChoice === null) return "";
+  if (typeof toolChoice === "string") return toolChoice;
+  if (toolChoice.type === "tool") {
+    return `tool:${toolChoice.toolName}`;
+  }
+  return "";
+}
+
+/**
+ * Stable, tiny, pure-JS hash. FNV-1a 32-bit. Chosen over crypto.subtle
+ * so this module stays browser- AND node-safe without async APIs.
+ * Collision risk for the input space (small enums + a tool name string)
+ * is acceptable for grouping purposes — when two execution configs ever
+ * collide the worst case is one extra column in the regression view.
+ */
+function fnv1a32(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i += 1) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  // Force unsigned and emit as 8-char hex.
+  return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+/**
+ * Compute the grouping key for an iteration's execution config.
+ *
+ * - Two iterations with the same `hostConfigId` + same `provider` + same
+ *   `toolChoice` produce the same key.
+ * - Two iterations with the same `hostConfigId` but different `provider`
+ *   or `toolChoice` produce different keys (this is the core reason the
+ *   key exists — `HostConfigInputV2` does not carry those fields).
+ * - Missing/null inputs hash to a deterministic value too, so partially
+ *   populated iterations still group consistently.
+ */
+export function computeExecutionConfigKey(
+  input: ExecutionConfigKeyInput,
+): string {
+  const hostConfigId = input.hostConfigId ?? "";
+  const provider = input.provider ?? "";
+  const toolChoice = canonicalizeToolChoice(input.toolChoice);
+  const composite = `${hostConfigId}|${provider}|${toolChoice}`;
+  return fnv1a32(composite);
+}


### PR DESCRIPTION
## Summary

Per the M1 plan, **Phase 3** (concurrent multi-config runs) is the architectural piece that touches run identity, iteration identity, the host-config resolver, SSE multiplexing, and the run-detail UI all at once. The plan explicitly gates implementation on a design pass — **this PR is that gate**.

### What lands

1. **`docs/evals/m1-phase3-multi-config-design.md`** — the RFC. Covers:
   - Cap (3 configs max)
   - Iteration identity (reuse `hostConfigId`, no new Convex field)
   - Grouping disambiguator (`executionConfigKey = hash(hostConfigId, provider, toolChoice)`) — needed because `HostConfigInputV2` does not include `provider`/`toolChoice`
   - Run identity (one `testSuiteRun` row with N config branches, not N sibling rows)
   - Fail isolation (`Promise.allSettled` per config)
   - SSE shape (`hostConfigId` on every event payload)
   - Transport DTO (`ClientConfigDto` — chat-box state stays out of `shared/`)
   - **A worked data-shape example**: 2 configs × 3 iterations × 2 cases → 1 `testSuiteRun` + 12 `testIteration` rows
   - Runner pseudocode + open questions

2. **`shared/eval-config.ts`** — `ClientConfigDto` and `computeExecutionConfigKey()`. Pure / browser-safe. The hash is FNV-1a 32-bit (small, sync, no node-crypto), with a documented collision tolerance.

3. **`shared/__tests__/eval-config.test.ts`** — 7 tests covering the key's invariants:
   - Deterministic for the same input
   - Disambiguates by provider when `hostConfigId` collides (the core reason the helper exists)
   - Disambiguates by toolChoice (string vs `{type:"tool", toolName:...}`)
   - Stable across null/undefined toolChoice
   - 8-char lowercase hex output

### What does NOT land (Phase 3b — immediate follow-up after this RFC review)

- Runner fan-out (`Promise.allSettled` across configs).
- SSE event multiplexing.
- `RunEvalsRequest.clientConfigs[]` / `RunTestCaseRequest.clientConfigs[]` plumbing.
- N-up UI in `compare-run-chat-surface.tsx`.
- Chatbox-config-picker adapter that emits `ClientConfigDto[]`.

## Why two PRs

The plan calls out that Phase 3 is "where bad assumptions get expensive". Landing the design + the foundational types first, with the runner fan-out as a separate review, lets reviewers settle the cross-cutting decisions (iteration identity, run identity, SSE shape) before any of those decisions are baked into a hard-to-revert runner refactor.

## Test plan

- [ ] Read `docs/evals/m1-phase3-multi-config-design.md` end-to-end
- [ ] Confirm the worked data-shape example matches how the run-detail UI should slice iterations
- [ ] Confirm the proposed `executionConfigKey` disambiguation works for the case where two chatboxes share a `hostConfigId` but differ in provider or toolChoice
- [ ] Resolve the three open questions at the bottom of the RFC
- [ ] CI green (7 new tests, 0 net new TS errors)

This PR is **independent** of Phase 1 / 2 / 5. **Phase 4 stacks on this** (uses `computeExecutionConfigKey`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a design RFC plus new shared DTO/types and a pure helper hash with unit tests, with no integration into runner/SSE/UI yet.
> 
> **Overview**
> Adds a Phase 3 design RFC for running eval suites against up to **3** client configs concurrently, specifying run/iteration identity, `hostConfigId`-tagged SSE events, and a new runtime `executionConfigKey` for disambiguating configs that share a `hostConfigId`.
> 
> Introduces `shared/eval-config.ts` with the `ClientConfigDto` transport shape and `computeExecutionConfigKey()` (FNV-1a hash over `hostConfigId|provider|toolChoice`), plus Vitest coverage validating determinism and disambiguation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 779b13426f48ec5fcfc0a28f5f18e550430d4329. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->