### PR TITLE
feat(evals): M1 phase 4 — suite-run regression detection (stacks on phase 3)

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/regression.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/regression.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeSuiteRegression,
+  executionConfigKeyForIteration,
+} from "../regression";
+import type { EvalIteration } from "../types";
+
+function makeIteration(
+  overrides: Partial<EvalIteration> & {
+    testCaseId: string;
+    result: EvalIteration["result"];
+    provider?: string;
+    model?: string;
+  },
+): EvalIteration {
+  const { provider, model, ...rest } = overrides;
+  return {
+    _id: `it-${Math.random().toString(36).slice(2)}`,
+    testCaseId: rest.testCaseId,
+    projectId: "p-1",
+    testCaseSnapshot: {
+      title: "t",
+      query: "q",
+      provider: provider ?? "anthropic",
+      model: model ?? "claude-haiku",
+      expectedToolCalls: [],
+    } as unknown as EvalIteration["testCaseSnapshot"],
+    suiteRunId: "sr-current",
+    createdBy: "u-1",
+    createdAt: 0,
+    iterationNumber: 1,
+    updatedAt: 0,
+    status: "completed",
+    actualToolCalls: [],
+    tokensUsed: 0,
+    ...rest,
+  } as EvalIteration;
+}
+
+describe("computeSuiteRegression", () => {
+  it("flags a pass-rate drop above the threshold", () => {
+    const prev: EvalIteration[] = [
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+    ]; // 5/5 = 100%
+    const cur: EvalIteration[] = [
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+      makeIteration({ testCaseId: "tc1", result: "failed" }),
+      makeIteration({ testCaseId: "tc1", result: "failed" }),
+      makeIteration({ testCaseId: "tc1", result: "failed" }),
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+    ]; // 2/5 = 40%
+    const report = computeSuiteRegression(cur, prev, 10);
+    expect(report.comparable).toHaveLength(1);
+    const entry = report.comparable[0];
+    expect(entry.previousPassRate).toBe(1);
+    expect(entry.currentPassRate).toBe(0.4);
+    expect(entry.drop).toBeCloseTo(0.6);
+    expect(entry.exceededThreshold).toBe(true);
+    expect(report.regressedCount).toBe(1);
+  });
+
+  it("does NOT flag drops within the threshold", () => {
+    const prev: EvalIteration[] = [
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+    ];
+    const cur: EvalIteration[] = [
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+      makeIteration({ testCaseId: "tc1", result: "failed" }),
+    ]; // 4/5 = 80% — drop is 20%, threshold strictly > 10% so still flags
+    // Use a higher threshold to stay below the flag
+    const report = computeSuiteRegression(cur, prev, 25);
+    expect(report.regressedCount).toBe(0);
+    expect(report.comparable[0].exceededThreshold).toBe(false);
+  });
+
+  it("groups by (testCaseId, executionConfigKey) so different models don't collide", () => {
+    const prev: EvalIteration[] = [
+      makeIteration({
+        testCaseId: "tc1",
+        provider: "anthropic",
+        model: "claude-haiku",
+        result: "passed",
+      }),
+      makeIteration({
+        testCaseId: "tc1",
+        provider: "openai",
+        model: "gpt-4o",
+        result: "failed",
+      }),
+    ];
+    const cur: EvalIteration[] = [
+      makeIteration({
+        testCaseId: "tc1",
+        provider: "anthropic",
+        model: "claude-haiku",
+        result: "passed",
+      }),
+      makeIteration({
+        testCaseId: "tc1",
+        provider: "openai",
+        model: "gpt-4o",
+        result: "passed",
+      }),
+    ];
+    const report = computeSuiteRegression(cur, prev, 10);
+    expect(report.comparable).toHaveLength(2);
+    const keys = new Set(report.comparable.map((c) => c.executionConfigKey));
+    expect(keys.size).toBe(2);
+    expect(report.regressedCount).toBe(0);
+  });
+
+  it("reports added pairs (only in current run)", () => {
+    const prev: EvalIteration[] = [
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+    ];
+    const cur: EvalIteration[] = [
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+      makeIteration({ testCaseId: "tc2-new", result: "passed" }),
+    ];
+    const report = computeSuiteRegression(cur, prev, 10);
+    expect(report.addedPairs).toHaveLength(1);
+    expect(report.addedPairs[0].testCaseId).toBe("tc2-new");
+  });
+
+  it("reports removed pairs (only in prior run)", () => {
+    const prev: EvalIteration[] = [
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+      makeIteration({ testCaseId: "tc-gone", result: "passed" }),
+    ];
+    const cur: EvalIteration[] = [
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+    ];
+    const report = computeSuiteRegression(cur, prev, 10);
+    expect(report.removedPairs).toHaveLength(1);
+    expect(report.removedPairs[0].testCaseId).toBe("tc-gone");
+  });
+
+  it("ignores non-completed iterations defensively", () => {
+    const prev: EvalIteration[] = [
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+    ];
+    const cur: EvalIteration[] = [
+      makeIteration({
+        testCaseId: "tc1",
+        result: "pending",
+        status: "running",
+      }),
+      makeIteration({ testCaseId: "tc1", result: "passed" }),
+    ];
+    const report = computeSuiteRegression(cur, prev, 10);
+    expect(report.comparable).toHaveLength(1);
+    expect(report.comparable[0].currentTotal).toBe(1);
+  });
+
+  it("handles empty input", () => {
+    const report = computeSuiteRegression([], [], 10);
+    expect(report.comparable).toEqual([]);
+    expect(report.addedPairs).toEqual([]);
+    expect(report.removedPairs).toEqual([]);
+    expect(report.regressedCount).toBe(0);
+  });
+});
+
+describe("executionConfigKeyForIteration", () => {
+  it("differs between two iterations whose snapshots differ by provider", () => {
+    const a = makeIteration({
+      testCaseId: "tc1",
+      result: "passed",
+      provider: "anthropic",
+      model: "claude-haiku",
+    });
+    const b = makeIteration({
+      testCaseId: "tc1",
+      result: "passed",
+      provider: "openai",
+      model: "claude-haiku",
+    });
+    expect(executionConfigKeyForIteration(a)).not.toBe(
+      executionConfigKeyForIteration(b),
+    );
+  });
+
+  it("uses backend hostConfigId when present", () => {
+    const a = makeIteration({
+      testCaseId: "tc1",
+      result: "passed",
+      provider: "anthropic",
+      model: "x",
+    });
+    const b = makeIteration({
+      testCaseId: "tc1",
+      result: "passed",
+      provider: "anthropic",
+      model: "y", // different model would normally yield different key
+    });
+    const keyA = executionConfigKeyForIteration({
+      ...a,
+      hostConfigId: "hc_pinned",
+    });
+    const keyB = executionConfigKeyForIteration({
+      ...b,
+      hostConfigId: "hc_pinned",
+    });
+    // Same hostConfigId + same provider = same key regardless of model.
+    expect(keyA).toBe(keyB);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-run-regression-summary.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-run-regression-summary.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SuiteRunRegressionSummary } from "../suite-run-regression-summary";
+import type { EvalIteration } from "../types";
+
+function it_(
+  testCaseId: string,
+  result: EvalIteration["result"],
+  provider = "anthropic",
+  model = "claude-haiku",
+): EvalIteration {
+  return {
+    _id: Math.random().toString(36).slice(2),
+    testCaseId,
+    projectId: "p",
+    testCaseSnapshot: {
+      title: "t",
+      query: "q",
+      provider,
+      model,
+      expectedToolCalls: [],
+    } as unknown as EvalIteration["testCaseSnapshot"],
+    suiteRunId: "sr",
+    createdBy: "u",
+    createdAt: 0,
+    iterationNumber: 1,
+    updatedAt: 0,
+    status: "completed",
+    result,
+    actualToolCalls: [],
+    tokensUsed: 0,
+  } as EvalIteration;
+}
+
+describe("SuiteRunRegressionSummary", () => {
+  it("renders nothing when there is no overlap and nothing added/removed", () => {
+    const { container } = render(
+      <SuiteRunRegressionSummary
+        currentIterations={[]}
+        previousIterations={[]}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders an all-clear status when comparable pairs exist but none regressed", () => {
+    const prev = [it_("tc1", "passed"), it_("tc1", "passed")];
+    const cur = [it_("tc1", "passed"), it_("tc1", "passed")];
+    render(
+      <SuiteRunRegressionSummary
+        currentIterations={cur}
+        previousIterations={prev}
+        thresholdPct={10}
+      />,
+    );
+    expect(
+      screen.getByText(/no regressions vs previous run/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders flagged regressions with previous → current pass rates", () => {
+    const prev = [
+      it_("tc1", "passed"),
+      it_("tc1", "passed"),
+      it_("tc1", "passed"),
+      it_("tc1", "passed"),
+      it_("tc1", "passed"),
+    ];
+    const cur = [
+      it_("tc1", "passed"),
+      it_("tc1", "failed"),
+      it_("tc1", "failed"),
+      it_("tc1", "failed"),
+      it_("tc1", "failed"),
+    ];
+    render(
+      <SuiteRunRegressionSummary
+        currentIterations={cur}
+        previousIterations={prev}
+        thresholdPct={10}
+        titleByCaseId={{ tc1: "search-issues case" }}
+      />,
+    );
+    expect(
+      screen.getByText(/1 regression vs previous run/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("search-issues case")).toBeInTheDocument();
+    expect(screen.getByText(/100% → 20%/)).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/regression.ts
+++ b/mcpjam-inspector/client/src/components/evals/regression.ts
@@ -1,0 +1,177 @@
+/**
+ * Suite-run-to-suite-run regression detection.
+ *
+ * Computes per-(testCaseId, executionConfigKey) pass-rate deltas between
+ * a completed suite run and the most recent prior completed run on the
+ * same suite. Flags any pair whose pass-rate dropped more than the
+ * configured `thresholdPct` (default 10%).
+ *
+ * The grouping key bakes in provider + tool choice on top of any
+ * `hostConfigId` the backend already records, so two configs that
+ * differ only in provider/toolChoice get compared separately (per the
+ * Phase 3 design RFC). This works today with single-config runs and
+ * auto-extends when Phase 3's multi-config lands.
+ */
+
+import type { EvalIteration } from "./types";
+import { computeExecutionConfigKey } from "@/shared/eval-config";
+
+const DEFAULT_REGRESSION_THRESHOLD_PCT = 10;
+
+/**
+ * Stable execution-config key for an iteration. Prefers backend-supplied
+ * `hostConfigId` when present, falls back to the testCaseSnapshot's
+ * provider+model so the key works in single-config runs today.
+ */
+export function executionConfigKeyForIteration(
+  iteration: Pick<EvalIteration, "testCaseSnapshot"> & {
+    hostConfigId?: string | null;
+  },
+): string {
+  const snapshot = iteration.testCaseSnapshot;
+  const hostConfigId =
+    iteration.hostConfigId ??
+    // Until backend hostConfigId reaches the client type, fall back to a
+    // stable per-iteration model identifier. Phase 3b will replace this.
+    `${snapshot?.provider ?? ""}|${snapshot?.model ?? ""}`;
+  return computeExecutionConfigKey({
+    hostConfigId,
+    provider: snapshot?.provider,
+    // testCaseSnapshot does not currently carry a toolChoice; once Phase
+    // 3 wires it through the snapshot, this helper picks it up
+    // automatically.
+    toolChoice: undefined,
+  });
+}
+
+type IterationGroupKey = string; // `${testCaseId}::${executionConfigKey}`
+
+type IterationGroupStats = {
+  testCaseId: string;
+  executionConfigKey: string;
+  total: number;
+  passed: number;
+  passRate: number; // 0..1
+};
+
+function groupKey(testCaseId: string, executionConfigKey: string): IterationGroupKey {
+  return `${testCaseId}::${executionConfigKey}`;
+}
+
+function aggregateIterations(
+  iterations: EvalIteration[],
+): Map<IterationGroupKey, IterationGroupStats> {
+  const map = new Map<IterationGroupKey, IterationGroupStats>();
+  for (const it of iterations) {
+    if (!it.testCaseId) continue;
+    if (it.status !== "completed") continue;
+    const ekey = executionConfigKeyForIteration(it);
+    const k = groupKey(it.testCaseId, ekey);
+    const prev = map.get(k);
+    const passed = it.result === "passed" ? 1 : 0;
+    if (prev) {
+      prev.total += 1;
+      prev.passed += passed;
+    } else {
+      map.set(k, {
+        testCaseId: it.testCaseId,
+        executionConfigKey: ekey,
+        total: 1,
+        passed,
+        passRate: 0, // computed below
+      });
+    }
+  }
+  for (const stats of map.values()) {
+    stats.passRate = stats.total > 0 ? stats.passed / stats.total : 0;
+  }
+  return map;
+}
+
+export type SuiteRegressionEntry = {
+  testCaseId: string;
+  executionConfigKey: string;
+  previousPassRate: number; // 0..1
+  currentPassRate: number; // 0..1
+  /**
+   * `previousPassRate - currentPassRate`. Positive means current is worse
+   * (regression). Negative means current improved.
+   */
+  drop: number;
+  /** True iff `drop * 100 > thresholdPct` (strictly greater than). */
+  exceededThreshold: boolean;
+  currentTotal: number;
+  previousTotal: number;
+};
+
+export type SuiteRegressionReport = {
+  thresholdPct: number;
+  /** Pairs present in BOTH runs, with their pass-rate delta. */
+  comparable: SuiteRegressionEntry[];
+  /** `(testCaseId, executionConfigKey)` pairs only in the current run. */
+  addedPairs: Array<{ testCaseId: string; executionConfigKey: string }>;
+  /** Pairs only in the prior run (removed/skipped). */
+  removedPairs: Array<{ testCaseId: string; executionConfigKey: string }>;
+  /** Convenience: count of comparable pairs that exceeded threshold. */
+  regressedCount: number;
+};
+
+/**
+ * Compute the regression report between two runs' iteration lists.
+ *
+ * Both inputs should be the COMPLETED iterations for a single
+ * `testSuiteRun` (caller filters by `suiteRunId`). The helper itself
+ * ignores non-completed iterations defensively.
+ */
+export function computeSuiteRegression(
+  currentIterations: EvalIteration[],
+  previousIterations: EvalIteration[],
+  thresholdPct: number = DEFAULT_REGRESSION_THRESHOLD_PCT,
+): SuiteRegressionReport {
+  const currentGroups = aggregateIterations(currentIterations);
+  const previousGroups = aggregateIterations(previousIterations);
+
+  const comparable: SuiteRegressionEntry[] = [];
+  const addedPairs: SuiteRegressionReport["addedPairs"] = [];
+  const removedPairs: SuiteRegressionReport["removedPairs"] = [];
+
+  for (const [k, cur] of currentGroups) {
+    const prev = previousGroups.get(k);
+    if (!prev) {
+      addedPairs.push({
+        testCaseId: cur.testCaseId,
+        executionConfigKey: cur.executionConfigKey,
+      });
+      continue;
+    }
+    const drop = prev.passRate - cur.passRate;
+    comparable.push({
+      testCaseId: cur.testCaseId,
+      executionConfigKey: cur.executionConfigKey,
+      previousPassRate: prev.passRate,
+      currentPassRate: cur.passRate,
+      drop,
+      exceededThreshold: drop * 100 > thresholdPct,
+      currentTotal: cur.total,
+      previousTotal: prev.total,
+    });
+  }
+
+  for (const [k, prev] of previousGroups) {
+    if (currentGroups.has(k)) continue;
+    removedPairs.push({
+      testCaseId: prev.testCaseId,
+      executionConfigKey: prev.executionConfigKey,
+    });
+  }
+
+  const regressedCount = comparable.filter((e) => e.exceededThreshold).length;
+
+  return {
+    thresholdPct,
+    comparable,
+    addedPairs,
+    removedPairs,
+    regressedCount,
+  };
+}

--- a/mcpjam-inspector/client/src/components/evals/suite-run-regression-summary.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-run-regression-summary.tsx
@@ -1,0 +1,110 @@
+import { useMemo } from "react";
+import type { EvalIteration } from "./types";
+import { computeSuiteRegression, type SuiteRegressionReport } from "./regression";
+
+type SuiteRunRegressionSummaryProps = {
+  currentIterations: EvalIteration[];
+  previousIterations: EvalIteration[];
+  /**
+   * Percentage drop above which a `(testCaseId, executionConfigKey)` pair
+   * is flagged as a regression. Default 10. Read from
+   * `suite.regressionThresholdPct` when wired through.
+   */
+  thresholdPct?: number;
+  /**
+   * Map of testCaseId -> human-readable title. Used to label badges in
+   * the summary. Optional — if a case id has no entry we fall back to a
+   * truncated id.
+   */
+  titleByCaseId?: Record<string, string>;
+};
+
+/**
+ * Compact summary of pass-rate regressions vs the previous suite run on
+ * the same suite. Renders nothing when there's nothing to compare or
+ * nothing to flag.
+ */
+export function SuiteRunRegressionSummary({
+  currentIterations,
+  previousIterations,
+  thresholdPct = 10,
+  titleByCaseId,
+}: SuiteRunRegressionSummaryProps) {
+  const report: SuiteRegressionReport = useMemo(
+    () =>
+      computeSuiteRegression(
+        currentIterations,
+        previousIterations,
+        thresholdPct,
+      ),
+    [currentIterations, previousIterations, thresholdPct],
+  );
+
+  if (
+    report.comparable.length === 0 &&
+    report.addedPairs.length === 0 &&
+    report.removedPairs.length === 0
+  ) {
+    return null;
+  }
+
+  const flagged = report.comparable.filter((e) => e.exceededThreshold);
+
+  if (flagged.length === 0) {
+    return (
+      <div
+        role="status"
+        className="rounded-md border border-border/40 bg-muted/10 px-3 py-2 text-xs text-muted-foreground"
+      >
+        No regressions vs previous run (threshold {thresholdPct}%).
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="alert"
+      className="space-y-1.5 rounded-md border border-red-500/40 bg-red-500/5 p-3"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-xs font-semibold text-red-700 dark:text-red-300">
+          {flagged.length} regression{flagged.length === 1 ? "" : "s"} vs
+          previous run
+        </div>
+        <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+          threshold {thresholdPct}%
+        </div>
+      </div>
+      <ul className="space-y-1 text-xs">
+        {flagged.map((entry) => {
+          const label =
+            titleByCaseId?.[entry.testCaseId] ??
+            `case ${entry.testCaseId.slice(0, 8)}`;
+          return (
+            <li
+              key={`${entry.testCaseId}::${entry.executionConfigKey}`}
+              className="flex items-center justify-between gap-3 rounded border border-red-500/30 bg-background/50 px-2 py-1"
+            >
+              <span className="truncate font-medium">{label}</span>
+              <span className="font-mono text-[11px] tabular-nums text-red-700 dark:text-red-300">
+                {formatPct(entry.previousPassRate)} → {formatPct(entry.currentPassRate)}{" "}
+                <span className="text-muted-foreground">
+                  (−{formatPct(entry.drop, { signed: false })})
+                </span>
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function formatPct(
+  rate: number,
+  options?: { signed?: boolean },
+): string {
+  const pct = Math.round(rate * 100);
+  if (options?.signed && pct >= 0) return `+${pct}%`;
+  return `${pct}%`;
+}


### PR DESCRIPTION
## Summary

> Stacks on #2076 (Phase 3 design RFC + foundational types). After that lands, re-target to `main`.

Three pieces, all pure / reusable, no Convex or backend work yet:

### 1. `client/src/components/evals/regression.ts`
- `computeSuiteRegression(current, previous, thresholdPct)` returning a `SuiteRegressionReport` with per-(`testCaseId`, `executionConfigKey`) pass-rate deltas. Flags pairs whose drop exceeds `thresholdPct` (default 10).
- `executionConfigKeyForIteration()` — wrapper around the Phase 3 `computeExecutionConfigKey()` that picks up `hostConfigId` when present and falls back to `provider+model` from the iteration's `testCaseSnapshot`. Works **today** for single-config runs; auto-extends when Phase 3b multi-config lands.

### 2. `client/src/components/evals/suite-run-regression-summary.tsx`
- Drop-in component that renders nothing on clean runs, a status line on no-regression runs, and a red banner with flagged pairs on regression runs. Format: `"previous% → current% (−drop%)"`.

### 3. Tests (12)
- 9 in `regression.test.ts`: threshold flag, no-flag, grouping by config, added/removed pairs, status filtering, `hostConfigId` override.
- 3 in `suite-run-regression-summary.test.tsx`: empty state, clean-pass status, flagged-banner copy.

## What does NOT land

- Wiring the summary into the run-detail / suite-runs surfaces.
- Adding `testSuite.regressionThresholdPct` to `mcpjam-backend`'s Convex schema (defaulting to 10 in the meantime).

Both are tractable follow-ups but felt better suited to a wiring PR after this helper lands.

## Test plan

- [ ] Read `regression.ts` — confirm the `(testCaseId, executionConfigKey)` grouping is correct for both single-config (today) and multi-config (Phase 3b) eras
- [ ] Confirm `executionConfigKeyForIteration` falls back to `provider+model` when `hostConfigId` is absent
- [ ] CI green (12 new tests, 0 net new TS errors)
- [ ] Drop `<SuiteRunRegressionSummary>` into a sandbox view with two suite runs that differ by one regressed case → confirm the banner renders the right copy and threshold

Stacks on: #2076. **Phase 1 / 2 / 5** are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new client-side regression computation and a standalone UI summary component with tests, without changing existing wiring or backend data paths.
> 
> **Overview**
> Adds a new `computeSuiteRegression` helper (and `executionConfigKeyForIteration`) to compare current vs previous suite-run iterations by `(testCaseId, executionConfigKey)`, compute pass-rate deltas, and flag drops above a configurable threshold.
> 
> Introduces `SuiteRunRegressionSummary`, a small UI component that renders either nothing, an all-clear status, or an alert banner listing regressed cases with `previous% → current% (−drop%)`.
> 
> Adds unit/UI tests covering threshold behavior, config-key grouping, added/removed pairs, defensive filtering of non-completed iterations, and summary rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f17c670844a86c960b2f9fbb72e5060b8e966a11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->