### PR TITLE
feat(evals): M1 phase 5 — strip host chrome from test-case run view

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/test-template-editor-open-compare-route.test.tsx
@@ -966,7 +966,7 @@ describe("TestTemplateEditor run view from route", () => {
     ).not.toBeNull();
   });
 
-  it("updates the pre-run host-style control and carries it across compare columns", async () => {
+  it("updates the pre-run host-style control without leaking it into compare columns (M1 phase 5)", async () => {
     const user = userEvent.setup();
 
     streamEvalTestCaseMock.mockImplementation(
@@ -1027,11 +1027,12 @@ describe("TestTemplateEditor run view from route", () => {
       expect(streamEvalTestCaseMock).toHaveBeenCalledTimes(2);
     });
 
-    await waitFor(() => {
-      expect(
-        view.container.querySelectorAll('[data-host-style="chatgpt"]'),
-      ).toHaveLength(2);
-    });
+    // Phase 5: the pre-run host-style preference no longer dictates
+    // the test-case run-view chrome. Compare columns must NOT carry
+    // [data-host-style], even though the global preference did change.
+    expect(
+      view.container.querySelectorAll("[data-host-style]"),
+    ).toHaveLength(0);
   });
 
   it("defaults to Results tab when expected tool calls are on a non-first prompt turn (multi-turn case)", async () => {
@@ -1122,7 +1123,7 @@ describe("TestTemplateEditor run view from route", () => {
     });
   });
 
-  it("removes the pre-run host-style selector and only applies the host shell on Chat", async () => {
+  it("removes the pre-run host-style selector once a run starts and does not apply a host shell on any tab (M1 phase 5)", async () => {
     const user = userEvent.setup();
     const caseWithExpectedToolCalls = {
       ...caseDoc,
@@ -1202,18 +1203,18 @@ describe("TestTemplateEditor run view from route", () => {
 
     const card = getCompareCard("GPT-4");
 
-    // Default tab is Results when the case has expected tools, so the chat host shell
-    // should only appear after switching back to Chat.
+    // Phase 5: no host shell on any tab — host styling belongs to the
+    // client config (Phase 3), not to the test-case view.
     expect(card.querySelector("[data-host-style]")).toBeNull();
 
     await user.click(within(card).getByRole("button", { name: /^Chat$/i }));
-    expect(card.querySelector('[data-host-style="claude"]')).not.toBeNull();
+    expect(card.querySelector("[data-host-style]")).toBeNull();
 
     await user.click(within(card).getByRole("button", { name: /^Trace$/i }));
     expect(card.querySelector("[data-host-style]")).toBeNull();
 
     await user.click(within(card).getByRole("button", { name: /^Chat$/i }));
-    expect(card.querySelector('[data-host-style="claude"]')).not.toBeNull();
+    expect(card.querySelector("[data-host-style]")).toBeNull();
 
     await user.click(within(card).getByRole("button", { name: /^Raw$/i }));
     expect(card.querySelector("[data-host-style]")).toBeNull();

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -70,10 +70,6 @@ import { normalizeToolChoice } from "@/shared/tool-choice";
 import { cn } from "@/lib/utils";
 import { computeIterationResult } from "./pass-criteria";
 import {
-  ChatboxHostStyleProvider,
-  ChatboxHostThemeProvider,
-} from "@/contexts/chatbox-host-style-context";
-import {
   buildHistoricalCompareRunRecords,
   buildComparePreviewTrace,
   buildCompareRunRecord,
@@ -114,7 +110,6 @@ import {
   adaptTraceToUiMessages,
   type TraceEnvelope,
 } from "./trace-viewer-adapter";
-import { getChatboxShellStyle } from "@/lib/chatbox-host-style";
 import { HostStylePillSelector } from "@/components/shared/HostStylePillSelector";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 
@@ -2503,8 +2498,6 @@ function RunColumn({
   onTabChange: (tab: RunColumnTab) => void;
   onRetry: () => void;
 }) {
-  const themeMode = usePreferencesStore((state) => state.themeMode);
-  const hostStyle = usePreferencesStore((state) => state.hostStyle);
   const { toolsMetadata, toolServerMap, connectedServerIds } =
     useEvalTraceToolContext({
       serverNames,
@@ -2622,9 +2615,6 @@ function RunColumn({
     record.iteration == null &&
     record.streamingTrace == null &&
     hasStreamingTrace;
-  const shouldRenderChatShell = effectiveActiveTab === "chat";
-  const shellStyle = getChatboxShellStyle(hostStyle, themeMode);
-
   const displayTokens =
     record.streamingMetrics?.tokensUsed ?? record.metrics.tokensUsed;
   const toolCount =
@@ -2874,26 +2864,16 @@ function RunColumn({
       />
 
       <div className="flex min-w-0 max-lg:min-h-[min(52vh,26rem)] flex-1 flex-col overflow-hidden p-3 lg:min-h-0">
-        {shouldRenderChatShell ? (
-          <ChatboxHostStyleProvider value={hostStyle}>
-            <ChatboxHostThemeProvider value={themeMode}>
-              <div
-                className={cn(
-                  "chatbox-host-shell app-theme-scope flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-xl border border-border/50",
-                  themeMode === "dark" && "dark",
-                )}
-                data-host-style={hostStyle}
-                style={shellStyle}
-              >
-                <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden p-3">
-                  {renderedRunContent}
-                </div>
-              </div>
-            </ChatboxHostThemeProvider>
-          </ChatboxHostStyleProvider>
-        ) : (
-          renderedRunContent
-        )}
+        {/*
+         * Phase 5 of the M1 plan: the test-case run view no longer wraps
+         * its chat tab in a chatbox-host-shell driven by the global
+         * `usePreferencesStore.hostStyle`. Host styling belongs to a
+         * client config (Phase 3 ClientConfigDto), not to the test case
+         * itself. The chat tab now renders as a plain panel; Phase 3b
+         * can opt this surface back into a per-config shell once
+         * multi-config runs land.
+         */}
+        {renderedRunContent}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

The M1 plan calls out that **host styling belongs to a client config, not to the test case itself**. Today the per-test-case compare run view's Chat tab wraps its content in a `ChatboxHostStyleProvider` / `ChatboxHostThemeProvider` / `chatbox-host-shell` driven by the global `usePreferencesStore.hostStyle` — i.e. a single global preference dictates the chrome on every test-case view, regardless of which client config is actually under test.

Phase 5 removes that wrapper. The Chat tab now renders as a plain panel. Phase 3b can opt this surface back into a per-config shell once multi-config runs (`ClientConfigDto`-driven) land.

### Files

- `test-template-editor.tsx`: drop the `shouldRenderChatShell` branch and its `ChatboxHostStyleProvider` / `ChatboxHostThemeProvider` wrap. Remove the now-unused imports and the shell-style locals.
- `test-template-editor-open-compare-route.test.tsx`: update the two host-style assertions to reflect the new behavior — the pre-run selector still mutates the global preference (it has other consumers), but the compare columns no longer carry `data-host-style`.

### What does NOT change

- The pre-run host-style **selector** itself (`HostStylePillSelector` row in the test-template editor) stays. It's still useful for setting the global preference that drives the chatbox view elsewhere; it just no longer leaks into the compare run cards.

## Test plan

- [ ] CI green (existing tests updated to reflect new behavior; 0 net new TS errors)
- [ ] Open the test-case compare view with a global hostStyle preference set to "claude". Run a compare. Inspect the rendered compare card → confirm NO `data-host-style="claude"` anywhere on Chat, Trace, Raw, or Results tabs.
- [ ] Confirm the pre-run host-style picker still updates the global preference (other consumers like the standalone chatbox view should still respond).

This PR is **independent** of Phase 1 / 2 / 3 / 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that removes host-style theming wrappers/attributes from the eval compare run cards; main risk is unintended visual regressions in the run view.
> 
> **Overview**
> **Removes host-style chrome from the test-case compare run view.** The run column no longer wraps the Chat tab in `ChatboxHostStyleProvider`/`ChatboxHostThemeProvider` or applies the `chatbox-host-shell` with `data-host-style`; the tab now renders as a plain panel.
> 
> **Updates route-open compare tests** to assert that changing the pre-run host-style preference still updates the selector but does *not* add any `[data-host-style]` attributes to compare columns (and no host shell appears on any tab).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da4ead2ef3cfcd8a1bb27a0159bb2c4e31df1298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->