### PR TITLE
requests 429

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/client-ip.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/client-ip.test.ts
@@ -35,13 +35,48 @@ describe("getClientIp", () => {
     expect(getClientIp(ctx)).toBe("9.10.11.12");
   });
 
-  it("returns null when no headers are present", () => {
+  it("returns null when no headers are present and no socket info is available (test-mock context)", () => {
     expect(getClientIp(makeCtx({}))).toBe(null);
   });
 
   it("trims whitespace", () => {
     const ctx = makeCtx({ "cf-connecting-ip": "  1.2.3.4  " });
     expect(getClientIp(ctx)).toBe("1.2.3.4");
+  });
+
+  it("falls back to the socket peer address when no proxy headers are present (npx-style direct hit)", () => {
+    // Shape that @hono/node-server's getConnInfo reads: c.env.incoming.socket.
+    // Covers the `npx @mcpjam/inspector` case where the browser hits the
+    // server directly with no proxy injecting forwarded-for headers.
+    const ctx = {
+      req: { header: (_name: string) => undefined },
+      env: {
+        incoming: {
+          socket: { remoteAddress: "::1", remotePort: 12345, remoteFamily: "IPv6" },
+        },
+      },
+    } as any;
+    expect(getClientIp(ctx)).toBe("::1");
+  });
+
+  it("prefers proxy headers over the socket peer address when both are present", () => {
+    // Hosted prod must keep using the proxy-supplied client IP even when the
+    // adapter-level socket info is available — otherwise rate limiting would
+    // bucket every request on the proxy's loopback address.
+    const ctx = {
+      req: {
+        header: (name: string) =>
+          ({ "cf-connecting-ip": "203.0.113.10" } as Record<string, string>)[
+            name.toLowerCase()
+          ],
+      },
+      env: {
+        incoming: {
+          socket: { remoteAddress: "::1", remotePort: 12345, remoteFamily: "IPv6" },
+        },
+      },
+    } as any;
+    expect(getClientIp(ctx)).toBe("203.0.113.10");
   });
 });
 

--- a/mcpjam-inspector/server/utils/client-ip.ts
+++ b/mcpjam-inspector/server/utils/client-ip.ts
@@ -1,12 +1,19 @@
 import type { Context } from "hono";
+import { getConnInfo } from "@hono/node-server/conninfo";
 
-// Extract the originating client IP from forwarded-for headers. Order matters:
+// Extract the originating client IP. Order matters:
 // - cf-connecting-ip is set by Cloudflare and not spoofable by the client.
 // - x-real-ip is set by trusted reverse proxies (Railway, nginx).
 // - x-forwarded-for is the legacy fallback; the first entry is the client when
 //   the chain is fully trusted, but is mutable by the client when there's no
 //   trusted proxy in front. Listed last so a real cf-connecting-ip / x-real-ip
 //   wins on the hosted edge.
+// - As a last resort (no headers at all), read the TCP connection's peer
+//   address. This covers direct-hit runtimes like `npx @mcpjam/inspector`
+//   where no upstream proxy injects forwarded-for headers and the request
+//   comes straight from the local browser. Hosted deployments behind a real
+//   reverse proxy never reach this fallback — one of the header checks above
+//   always returns first.
 export function getClientIp(c: Context): string | null {
   const cfConnectingIp = c.req.header("cf-connecting-ip")?.trim();
   if (cfConnectingIp) return cfConnectingIp;
@@ -16,6 +23,17 @@ export function getClientIp(c: Context): string | null {
 
   const forwardedFor = c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
   if (forwardedFor) return forwardedFor;
+
+  // Node-adapter socket fallback. Wrapped in try/catch because hand-rolled
+  // test mocks don't expose the `c.env.incoming.socket` shape `getConnInfo`
+  // reads from — falling through to `null` preserves the existing contract
+  // for those callers.
+  try {
+    const address = getConnInfo(c).remote.address?.trim();
+    if (address) return address;
+  } catch {
+    // Not running under @hono/node-server (e.g., unit-test mock context).
+  }
 
   return null;
 }


### PR DESCRIPTION
- Fixes a bug where npx @mcpjam/inspector users couldn't connect to any MCP server as a guest — every request was rejected with a 429 error
- Root cause: the server demanded an IP address for rate limiting, but there was no proxy in front to provide one, so it just rejected everyone
- Fix: if no IP header is present, fall back to using the actual TCP connection address (::1 / 127.0.0.1 locally) instead of giving up
- Real production (behind Cloudflare/Railway) is unaffected — those proxies always set the IP header, so the fallback never runs
