### PR TITLE
chore: add inspector rollup changeset pre-soundcheck-deploy

### DIFF
--- a/.changeset/inspector-rollup-pre-soundcheck-deploy.md
+++ b/.changeset/inspector-rollup-pre-soundcheck-deploy.md
@@ -1,0 +1,10 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Inspector rollup since the last release:
+
+- Chatbox OAuth: attach the WorkOS bearer token on `/oauth/callback` to fix the 403 some users hit when finishing the chatbox auth flow.
+- Sidebar credit usage: clicking the progress bar now sends the user to billing.
+- Compare-plans table: removed the team seat-minimum label and finished the Projects row in the plan comparison.
+- Chatbox builder: removed the unused `allowGuestAccess` toggle.


### PR DESCRIPTION
## Summary

Rollup changeset for the unreleased commits since `chore(release)` ef1b09a82, ahead of the Soundcheck deploy. Patch bumps `@mcpjam/inspector` (2.4.7 → 2.4.8).

Covers:
- Chatbox OAuth 403 fix (attach WorkOS bearer in `/oauth/callback`) — #2067
- Sidebar credit-usage progress bar redirects to billing on click — #2057
- Compare-plans table: drop team seat-minimum label + finish Projects row — #2065
- Remove unused `allowGuestAccess` from ChatboxBuilderView (2533d737c)

## Test plan
- [x] `npm run release:status` shows `@mcpjam/inspector` patch bump, no other public packages affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)