### PR TITLE
fix(billing): compare table reads "Unlimited" for servers-per-project on free

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/ChatboxesTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatboxesTab.test.tsx
@@ -60,7 +60,7 @@ function createPlanCatalog() {
         limits: {
           maxMembers: 1,
           maxProjects: 1,
-          maxServersPerProject: 3,
+          maxServersPerProject: null,
           maxChatboxesPerProject: 0,
           maxEvalRunsPerMonth: 5,
         },
@@ -86,7 +86,7 @@ function createPlanCatalog() {
         limits: {
           maxMembers: 3,
           maxProjects: 2,
-          maxServersPerProject: 10,
+          maxServersPerProject: null,
           maxChatboxesPerProject: 1,
           maxEvalRunsPerMonth: 500,
         },

--- a/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
+++ b/mcpjam-inspector/client/src/components/organization/__tests__/compare-plan-marketing.test.ts
@@ -80,4 +80,25 @@ describe("COMPARE_PLAN_MARKETING_SECTIONS", () => {
       emphasize: true,
     });
   });
+
+  it("advertises unlimited servers per project across every tier (matches backend entitlement)", () => {
+    const orgProjects = COMPARE_PLAN_MARKETING_SECTIONS.find(
+      (s) => s.title === "Organization & projects",
+    );
+    const serversRow = orgProjects?.rows.find(
+      (r) => r.label === "Servers per project",
+    );
+
+    expect(serversRow?.free).toEqual({ kind: "text", text: "Unlimited" });
+    expect(serversRow?.team).toEqual({
+      kind: "text",
+      text: "Unlimited",
+      emphasize: true,
+    });
+    expect(serversRow?.enterprise).toEqual({
+      kind: "text",
+      text: "Unlimited",
+      emphasize: true,
+    });
+  });
 });

--- a/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
+++ b/mcpjam-inspector/client/src/components/organization/compare-plan-marketing.ts
@@ -54,7 +54,7 @@ export const COMPARE_PLAN_MARKETING_SECTIONS: ComparePlanSection[] = [
       },
       {
         label: "Servers per project",
-        free: t("3"),
+        free: t("Unlimited"),
         team: t("Unlimited", true),
         enterprise: t("Unlimited", true),
       },


### PR DESCRIPTION
## TL;DR

The "Servers per project" row in the in-app compare table previously showed `"3 / Unlimited / Unlimited"`. Updates the free cell to `"Unlimited"` so the table is consistent with the product's actual positioning: unlimited servers on every tier. One line of source, plus a test update.

## Before / after

```mermaid
flowchart LR
    classDef bad fill:#ffcdd2,stroke:#c62828,color:#000
    classDef good fill:#c8e6c9,stroke:#2e7d32,color:#000

    A["Before<br/>'3 / Unlimited / Unlimited'"]:::bad
    B["After<br/>'Unlimited / Unlimited / Unlimited'"]:::good

    A --> B
```

## What changed

| File | Change |
|---|---|
| `client/src/components/organization/compare-plan-marketing.ts` | "Servers per project" free cell: `t("3")` → `t("Unlimited")` |
| `client/src/components/organization/__tests__/compare-plan-marketing.test.ts` | Row-value assertion updated; expects `"Unlimited"` across all three tiers |
| `client/src/components/__tests__/ChatboxesTab.test.tsx` | Fixture cleanup: stale plan-catalog values updated to match unlimited |

## Test plan

- [x] `vitest run` on touched test files — 71/71 pass (5 files exercised end-to-end)
- [x] `tsc --noEmit` — no new errors
- [ ] Manual: open the plan-compare modal — "Servers per project" row shows "Unlimited" across all three columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)