### PR TITLE
feat(mcp-apps): profile-driven hostCapabilities with user-saved overrides

### DIFF
--- a/mcpjam-inspector/client/src/components/HostStyledChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/HostStyledChatTabV2.tsx
@@ -4,6 +4,7 @@ import {
   ChatboxHostStyleProvider,
   ChatboxHostThemeProvider,
 } from "@/contexts/chatbox-host-style-context";
+import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-host-capabilities-override-context";
 import { getChatboxShellStyle } from "@/lib/chatbox-host-style";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
@@ -20,27 +21,34 @@ export function HostStyledChatTabV2({
   const themeMode = usePreferencesStore((state) => state.themeMode);
   const hostStyle = usePreferencesStore((state) => state.hostStyle);
   const setHostStyle = usePreferencesStore((state) => state.setHostStyle);
+  const hostCapabilitiesOverride = usePreferencesStore(
+    (state) => state.hostCapabilitiesOverride,
+  );
   const shellStyle = getChatboxShellStyle(hostStyle, themeMode);
 
   return (
     <ChatboxHostStyleProvider value={hostStyle}>
-      <ChatboxHostThemeProvider value={themeMode}>
-        <div
-          className={cn(
-            "chatbox-host-shell app-theme-scope flex h-full min-h-0 flex-1 flex-col overflow-hidden",
-            themeMode === "dark" && "dark",
-          )}
-          data-host-style={hostStyle}
-          style={shellStyle}
-        >
-          <ChatTabV2
-            {...props}
-            showHostStyleSelector={showHostStyleSelector}
-            hostStyle={hostStyle}
-            onHostStyleChange={setHostStyle}
-          />
-        </div>
-      </ChatboxHostThemeProvider>
+      <ChatboxHostCapabilitiesOverrideProvider
+        value={hostCapabilitiesOverride}
+      >
+        <ChatboxHostThemeProvider value={themeMode}>
+          <div
+            className={cn(
+              "chatbox-host-shell app-theme-scope flex h-full min-h-0 flex-1 flex-col overflow-hidden",
+              themeMode === "dark" && "dark",
+            )}
+            data-host-style={hostStyle}
+            style={shellStyle}
+          >
+            <ChatTabV2
+              {...props}
+              showHostStyleSelector={showHostStyleSelector}
+              hostStyle={hostStyle}
+              onHostStyleChange={setHostStyle}
+            />
+          </div>
+        </ChatboxHostThemeProvider>
+      </ChatboxHostCapabilitiesOverrideProvider>
     </ChatboxHostStyleProvider>
   );
 }

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -220,6 +220,7 @@ import {
   ChatboxHostStyleProvider,
   ChatboxHostThemeProvider,
 } from "@/contexts/chatbox-host-style-context";
+import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-host-capabilities-override-context";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 const baseProps = {
@@ -320,19 +321,79 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(sandboxedIframePropsRef.current?.permissions).toBeUndefined();
   });
 
-  it("advertises model context and message host capabilities", async () => {
+  it("advertises hostCapabilities from the active host style preset (claude)", async () => {
+    render(
+      <ChatboxHostStyleProvider value="claude">
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostStyleProvider>,
+    );
+
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+
+    // Should advertise Claude's preset, not the old empty literal.
+    expect(appBridgeArgsRef.current?.hostCapabilities).toEqual(
+      expect.objectContaining(CLAUDE_HOST_STYLE.hostCapabilities),
+    );
+  });
+
+  it("falls back to the spec-default 'no claims' blob when no style is resolvable", async () => {
+    // No ChatboxHostStyleProvider, isPlaygroundActive is false in this test
+    // setup, so effectiveHostStyle is null. The resolver MUST NOT silently
+    // impersonate Claude here — it returns the spec-default {}.
     render(<MCPAppsRenderer {...baseProps} />);
 
     await vi.waitFor(() => {
       expect(mockBridge.connect).toHaveBeenCalled();
     });
 
-    expect(appBridgeArgsRef.current?.hostCapabilities).toEqual(
-      expect.objectContaining({
-        updateModelContext: {},
-        message: {},
-      }),
+    const { sandbox: _sandbox, ...vendorOnly } =
+      appBridgeArgsRef.current?.hostCapabilities ?? {};
+    expect(vendorOnly).toEqual({});
+  });
+
+  it("flips advertised hostCapabilities when host style switches to chatgpt", async () => {
+    render(
+      <ChatboxHostStyleProvider value="chatgpt">
+        <ChatboxHostThemeProvider value="dark">
+          <MCPAppsRenderer {...baseProps} />
+        </ChatboxHostThemeProvider>
+      </ChatboxHostStyleProvider>,
     );
+
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+
+    expect(appBridgeArgsRef.current?.hostCapabilities).toEqual(
+      expect.objectContaining(CHATGPT_HOST_STYLE.hostCapabilities),
+    );
+    // Sanity: profiles differ — switching is observable.
+    expect(appBridgeArgsRef.current?.hostCapabilities).not.toEqual(
+      expect.objectContaining(CLAUDE_HOST_STYLE.hostCapabilities),
+    );
+  });
+
+  it("user override wins over the host style preset", async () => {
+    const override = {
+      openLinks: {},
+      // Intentionally omits serverTools / serverResources / message etc.
+      // so the resolved blob is observably distinct from both presets.
+    };
+    render(
+      <ChatboxHostCapabilitiesOverrideProvider value={override}>
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostCapabilitiesOverrideProvider>,
+    );
+
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+
+    const { sandbox: _sandbox, ...vendorOnly } =
+      appBridgeArgsRef.current?.hostCapabilities ?? {};
+    expect(vendorOnly).toEqual(override);
   });
 
   it("uses chatbox host style for SEP-1865 host context outside the playground", async () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -67,6 +67,7 @@ import {
   useChatboxHostStyle,
   useChatboxHostTheme,
 } from "@/contexts/chatbox-host-style-context";
+import { useChatboxHostCapabilitiesOverride } from "@/contexts/chatbox-host-capabilities-override-context";
 import { useHostContextStore } from "@/stores/host-context-store";
 import {
   clampDisplayModeToAvailableModes,
@@ -74,6 +75,7 @@ import {
   extractHostDisplayModes,
   extractHostTheme,
 } from "@/lib/client-config";
+import { resolveEffectiveHostCapabilities } from "@/lib/host-config-v2";
 
 // Injected by Vite at build time from package.json
 declare const __APP_VERSION__: string;
@@ -213,6 +215,7 @@ export function MCPAppsRenderer({
   const sharedHostStyle = usePreferencesStore((s) => s.hostStyle);
   const chatboxHostStyle = useChatboxHostStyle();
   const chatboxHostTheme = useChatboxHostTheme();
+  const hostCapabilitiesOverride = useChatboxHostCapabilitiesOverride();
   const draftHostContext = useHostContextStore((s) => s.draftHostContext);
   const baseHostContext = useMemo(
     () =>
@@ -788,6 +791,19 @@ export function MCPAppsRenderer({
     ? sharedHostStyle
     : chatboxHostStyle;
   const hostStyleDefinition = getHostStyleOrDefault(effectiveHostStyle);
+  // Single source of truth for what `hostCapabilities` this view will
+  // advertise. The bridge-creation effect (`new AppBridge(...)`) spreads this
+  // value into the handshake; `registerBridgeHandlers` closes over it so the
+  // future enforcement PR can read the same blob without duplicating the
+  // resolution logic (which would risk advertise/enforce drift).
+  const effectiveHostCapabilities = useMemo(
+    () =>
+      resolveEffectiveHostCapabilities({
+        hostStyle: effectiveHostStyle,
+        hostCapabilitiesOverride,
+      }),
+    [effectiveHostStyle, hostCapabilitiesOverride],
+  );
   themeModeRef.current = resolvedTheme;
   const styleVariables = useMemo(
     () => hostStyleDefinition.resolveStyleVariables(resolvedTheme),
@@ -921,6 +937,24 @@ export function MCPAppsRenderer({
     onAppSupportedDisplayModesChange,
   ]);
 
+  // ENFORCEMENT LANDING PAD (deferred):
+  // `effectiveHostCapabilities` (above) is the contract advertised in
+  // ui/initialize. The handlers bound below SHOULD eventually gate their work
+  // on it so that "advertise" and "enforce" stay in lockstep, otherwise the
+  // handshake lies (advertised "unsupported" + behavior "supported") — which
+  // is worse than no mock at all for conformance testing. Mapping for the
+  // follow-up PR:
+  //   • bridge.onopenlink            ← effectiveHostCapabilities.openLinks
+  //   • bridge.onmessage             ← effectiveHostCapabilities.message
+  //   • bridge.onupdatemodelcontext  ← effectiveHostCapabilities.updateModelContext
+  //   • bridge.oncalltool            ← effectiveHostCapabilities.serverTools
+  //   • bridge.onreadresource /
+  //     onlistresources /
+  //     onlistresourcetemplates      ← effectiveHostCapabilities.serverResources
+  //   • bridge.onloggingmessage      ← effectiveHostCapabilities.logging
+  //   • (downloadFile handler)       ← effectiveHostCapabilities.downloadFile
+  // When enforcement lands, add `effectiveHostCapabilities` to this
+  // useCallback's dep array.
   const registerBridgeHandlers = useCallback(
     (bridge: AppBridge) => {
       bridge.oninitialized = () => {
@@ -1164,16 +1198,16 @@ export function MCPAppsRenderer({
       toolState: toolState ?? null,
     });
 
+    // `effectiveHostCapabilities` is computed at component scope so
+    // `registerBridgeHandlers` can read the same value when enforcement
+    // gates land (see comment near its definition). Runtime `sandbox` stays
+    // widget-derived per SEP-1865 — CSP/permissions are approved per UI
+    // resource, not a vendor trait.
     const bridge = new AppBridge(
       null,
       { name: "mcpjam-inspector", version: __APP_VERSION__ },
       {
-        openLinks: {},
-        serverTools: {},
-        serverResources: {},
-        logging: {},
-        updateModelContext: {},
-        message: {},
+        ...effectiveHostCapabilities,
         sandbox: {
           // In permissive mode: omit CSP (undefined) to indicate no restrictions
           // In widget-declared mode: pass the widget's declared CSP
@@ -1268,6 +1302,10 @@ export function MCPAppsRenderer({
     widgetPermissions,
     widgetPermissive,
     logWidgetDebug,
+    // Bridge must rebuild when the advertised host capabilities change
+    // (host style switch or override edit) so the new handshake reflects
+    // the new contract.
+    effectiveHostCapabilities,
   ]);
 
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/ChatboxEditor.tsx
@@ -63,6 +63,7 @@ import {
 } from "@mcpjam/design-system/popover";
 import { getLoadingIndicatorVariantForHostStyle } from "@/components/chat-v2/shared/loading-indicator-content";
 import { ChatboxHostStyleProvider } from "@/contexts/chatbox-host-style-context";
+import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-host-capabilities-override-context";
 import { ChatboxHostOnboardingOverlays } from "@/components/hosted/ChatboxHostOnboardingOverlays";
 import { useChatboxHostIntroGate } from "@/components/hosted/useChatboxHostIntroGate";
 import type { ServerWithName } from "@/hooks/use-app-state";
@@ -1239,6 +1240,9 @@ export function ChatboxEditor({
             ) : (
               <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
                 <ChatboxHostStyleProvider value={hostStyle}>
+                  <ChatboxHostCapabilitiesOverrideProvider
+                    value={chatboxHostConfig?.hostCapabilitiesOverride}
+                  >
                   <div
                     className="flex min-h-0 flex-1 overflow-hidden"
                     data-host-style={hostStyle}
@@ -1289,6 +1293,7 @@ export function ChatboxEditor({
                       }}
                     />
                   </div>
+                  </ChatboxHostCapabilitiesOverrideProvider>
                 </ChatboxHostStyleProvider>
                 <ChatboxHostOnboardingOverlays
                   showWelcome={introGate.showWelcome}

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/ChatboxBuilderView.tsx
@@ -67,6 +67,7 @@ import {
   type ChatboxBootstrapServer,
 } from "@/lib/chatbox-session";
 import { ChatboxHostStyleProvider } from "@/contexts/chatbox-host-style-context";
+import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-host-capabilities-override-context";
 import type { ServerFormData } from "@/shared/types";
 import { buildChatboxCanvas } from "./chatboxCanvasBuilder";
 import { ChatboxCanvas } from "./ChatboxCanvas";
@@ -1294,6 +1295,9 @@ export function ChatboxBuilderView({
                               <ChatboxHostStyleProvider
                                 value={draftChatboxConfig.hostStyle}
                               >
+                              <ChatboxHostCapabilitiesOverrideProvider
+                                value={chatboxHostConfig?.hostCapabilitiesOverride}
+                              >
                                 <ChatTabV2
                                   key={chatKey}
                                   connectedOrConnectingServerConfigs={
@@ -1347,6 +1351,7 @@ export function ChatboxBuilderView({
                                     );
                                   }}
                                 />
+                              </ChatboxHostCapabilitiesOverrideProvider>
                               </ChatboxHostStyleProvider>
                               <ChatboxHostOnboardingOverlays
                                 showWelcome={introGate.showWelcome}

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
@@ -136,7 +136,10 @@ export function draftToHostConfigInputV2(
   draft: ChatboxDraftConfig,
   projectDefault?: Pick<
     HostConfigInputV2,
-    "connectionDefaults" | "clientCapabilities" | "hostContext"
+    | "connectionDefaults"
+    | "clientCapabilities"
+    | "hostContext"
+    | "hostCapabilitiesOverride"
   > | null,
 ): HostConfigInputV2 {
   const seed = emptyHostConfigInputV2({
@@ -150,6 +153,10 @@ export function draftToHostConfigInputV2(
     connectionDefaults: projectDefault?.connectionDefaults,
     clientCapabilities: projectDefault?.clientCapabilities,
     hostContext: projectDefault?.hostContext,
+    // Inherit the project default's MCP Apps capability override so
+    // new/edited chatboxes match what the project-default editor saved.
+    // Undefined here keeps "use the active host style preset" intact.
+    hostCapabilitiesOverride: projectDefault?.hostCapabilitiesOverride,
   });
   return seed;
 }

--- a/mcpjam-inspector/client/src/components/host-config/HostCapabilitiesOverrideDialog.tsx
+++ b/mcpjam-inspector/client/src/components/host-config/HostCapabilitiesOverrideDialog.tsx
@@ -1,0 +1,163 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { Textarea } from "@mcpjam/design-system/textarea";
+import { Label } from "@mcpjam/design-system/label";
+import type { ChatboxHostStyle } from "@/lib/chatbox-host-style";
+import { getHostCapabilitiesForStyle } from "@/lib/host-styles";
+
+/**
+ * Direct-Chat editor for the MCP Apps `hostCapabilities` override
+ * (advertised in ui/initialize). Mirrors the JSON section in
+ * `HostConfigEditor`, surfaced as a standalone dialog because Direct Chat
+ * doesn't own a v2 HostConfig row — its override lives in the
+ * preferences-store and persists to localStorage.
+ *
+ * The dialog stages edits locally so the user can preview/abandon without
+ * touching the persisted override until they click Save.
+ */
+export interface HostCapabilitiesOverrideDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  hostStyle: ChatboxHostStyle;
+  /** Current saved override; undefined means "using host style preset". */
+  override: Record<string, unknown> | undefined;
+  /** Called on Save with the parsed override or undefined to reset to preset. */
+  onSave: (next: Record<string, unknown> | undefined) => void;
+}
+
+export function HostCapabilitiesOverrideDialog({
+  open,
+  onOpenChange,
+  hostStyle,
+  override,
+  onSave,
+}: HostCapabilitiesOverrideDialogProps) {
+  const profilePreset = useMemo(
+    () => getHostCapabilitiesForStyle(hostStyle),
+    [hostStyle],
+  );
+  const profilePresetJson = useMemo(
+    () => JSON.stringify(profilePreset, null, 2),
+    [profilePreset],
+  );
+
+  const initialText = useMemo(() => {
+    if (override === undefined) return profilePresetJson;
+    return JSON.stringify(override, null, 2);
+  }, [override, profilePresetJson]);
+
+  const [text, setText] = useState(initialText);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-sync local text every time the dialog opens (or the upstream
+  // override/style changes while open). Without this, reopening after a
+  // cancel would still show stale edits.
+  useEffect(() => {
+    if (open) {
+      setText(initialText);
+      setError(null);
+    }
+  }, [open, initialText]);
+
+  const onTextChange = useCallback((value: string) => {
+    setText(value);
+    try {
+      const parsed = JSON.parse(value || "{}");
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        setError("Value must be a JSON object");
+        return;
+      }
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Invalid JSON");
+    }
+  }, []);
+
+  const isOverriding = override !== undefined;
+
+  const handleSave = useCallback(() => {
+    try {
+      const parsed = JSON.parse(text || "{}") as Record<string, unknown>;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        setError("Value must be a JSON object");
+        return;
+      }
+      onSave(parsed);
+      onOpenChange(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Invalid JSON");
+    }
+  }, [text, onSave, onOpenChange]);
+
+  const handleResetToPreset = useCallback(() => {
+    onSave(undefined);
+    onOpenChange(false);
+  }, [onSave, onOpenChange]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-2xl"
+        aria-describedby={undefined}
+      >
+        <DialogHeader>
+          <DialogTitle>Host capabilities override</DialogTitle>
+        </DialogHeader>
+
+        <div className="grid gap-2 py-2">
+          <div className="flex items-center justify-between gap-2">
+            <Label htmlFor="host-capabilities-override-textarea">
+              JSON
+            </Label>
+            {isOverriding ? (
+              <span className="text-xs text-muted-foreground">
+                Custom override active
+              </span>
+            ) : null}
+          </div>
+          <Textarea
+            id="host-capabilities-override-textarea"
+            className="font-mono text-xs"
+            rows={14}
+            value={text}
+            onChange={(e) => onTextChange(e.target.value)}
+            placeholder={profilePresetJson}
+            spellCheck={false}
+          />
+          {error && (
+            <p className="text-xs text-destructive">{error}</p>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={handleResetToPreset}
+            disabled={!isOverriding}
+          >
+            Clear override
+          </Button>
+          <div className="flex-1" />
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSave} disabled={error != null}>
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
@@ -40,12 +40,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@mcpjam/design-system/select";
+import { Button } from "@mcpjam/design-system/button";
 import {
   type HostConfigInputV2,
   type HostStyleId,
   DEFAULT_TEMPERATURE_V2,
 } from "@/lib/host-config-v2";
-import { listHostStyles } from "@/lib/host-styles";
+import {
+  getHostCapabilitiesForStyle,
+  listHostStyles,
+} from "@/lib/host-styles";
 
 export type HostConfigEditorOwner =
   | "project-default"
@@ -95,7 +99,14 @@ export function HostConfigEditor({
   const [headersError, setHeadersError] = useState<string | null>(null);
   const [capsError, setCapsError] = useState<string | null>(null);
   const [hostCtxError, setHostCtxError] = useState<string | null>(null);
-  const hasError = headersError != null || capsError != null || hostCtxError != null;
+  const [hostCapsOverrideError, setHostCapsOverrideError] = useState<
+    string | null
+  >(null);
+  const hasError =
+    headersError != null ||
+    capsError != null ||
+    hostCtxError != null ||
+    hostCapsOverrideError != null;
   useEffect(() => {
     onValidityChange?.(hasError);
   }, [hasError, onValidityChange]);
@@ -323,7 +334,86 @@ export function HostConfigEditor({
             />
           </div>
         ) : null}
+
+        {owner !== "connection-only" ? (
+          <HostCapabilitiesOverrideSection
+            hostStyle={value.hostStyle}
+            override={value.hostCapabilitiesOverride}
+            onChange={(hostCapabilitiesOverride) =>
+              update({ hostCapabilitiesOverride })
+            }
+            onErrorChange={setHostCapsOverrideError}
+          />
+        ) : null}
       </section>
+    </div>
+  );
+}
+
+/**
+ * Editor for the optional MCP Apps `hostCapabilities` override (advertised in
+ * `ui/initialize`). When the override is undefined, the renderer falls back
+ * to the active host style's preset; this section shows that preset as the
+ * placeholder so users can see what they'd be overriding. Resetting writes
+ * `undefined`, which snaps back to the preset.
+ *
+ * CONFORMANCE GAP: this configures the *advertised* blob. Behavior gating
+ * inside request handlers is a separate, deferred step (see
+ * registerBridgeHandlers in mcp-apps-renderer.tsx).
+ */
+function HostCapabilitiesOverrideSection({
+  hostStyle,
+  override,
+  onChange,
+  onErrorChange,
+}: {
+  hostStyle: HostStyleId;
+  override: Record<string, unknown> | undefined;
+  onChange: (next: Record<string, unknown> | undefined) => void;
+  onErrorChange: (error: string | null) => void;
+}) {
+  const profilePreset = useMemo(
+    () => getHostCapabilitiesForStyle(hostStyle),
+    [hostStyle],
+  );
+  const profilePresetJson = useMemo(
+    () => JSON.stringify(profilePreset, null, 2),
+    [profilePreset],
+  );
+  const isOverriding = override !== undefined;
+  // When the user hasn't set an override, seed the editor with the profile
+  // preset (writeable copy) so they have a visible starting point for edits.
+  const editorValue = isOverriding ? override : (profilePreset as Record<string, unknown>);
+
+  return (
+    <div className="grid gap-2">
+      <div className="flex items-center justify-between gap-2">
+        <Label>Host capabilities override (JSON)</Label>
+        {isOverriding ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={() => onChange(undefined)}
+          >
+            Reset to {hostStyle} preset
+          </Button>
+        ) : (
+          <span className="text-xs text-muted-foreground">
+            Using {hostStyle} preset
+          </span>
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Advertised in <code>ui/initialize</code>. Leave at the preset to match
+        the vendor; override to mock specific capability combinations.
+      </p>
+      <JsonRecordEditor
+        value={editorValue}
+        onChange={(next) => onChange(next)}
+        onErrorChange={onErrorChange}
+        placeholder={profilePresetJson}
+      />
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/host-config/__tests__/HostCapabilitiesOverrideDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/host-config/__tests__/HostCapabilitiesOverrideDialog.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { HostCapabilitiesOverrideDialog } from "../HostCapabilitiesOverrideDialog";
+
+describe("HostCapabilitiesOverrideDialog", () => {
+  it("renders the title without the header description paragraph", () => {
+    const onSave = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <HostCapabilitiesOverrideDialog
+        open
+        onOpenChange={onOpenChange}
+        hostStyle="claude"
+        override={undefined}
+        onSave={onSave}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Host capabilities override" }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByText(/Advertised in ui\/initialize/i),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText(/Empty JSON object/),
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.queryByText(/Using claude preset/),
+    ).not.toBeInTheDocument();
+
+    const clearOverride = screen.getByRole("button", { name: "Clear override" });
+    expect(clearOverride).toBeDisabled();
+  });
+
+  it("shows override status and enables Clear override when an override is saved", () => {
+    render(
+      <HostCapabilitiesOverrideDialog
+        open
+        onOpenChange={vi.fn()}
+        hostStyle="claude"
+        override={{ serverTools: { listChanged: false } }}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Custom override active"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Clear override" })).toBeEnabled();
+  });
+
+  it("shows a validation error when JSON is invalid", () => {
+    const onSave = vi.fn();
+    const onOpenChange = vi.fn();
+
+    render(
+      <HostCapabilitiesOverrideDialog
+        open
+        onOpenChange={onOpenChange}
+        hostStyle="claude"
+        override={undefined}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "not-json" },
+    });
+
+    expect(
+      screen.getByText(/not valid JSON/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -31,6 +31,7 @@ import { bootstrapServerToHostedOAuthDescriptor } from "@/components/chatboxes/b
 import { isHostedOAuthBusy } from "@/lib/hosted-oauth-resume";
 import type { HostedOAuthRequiredDetails } from "@/lib/hosted-oauth-required";
 import { ChatboxHostStyleProvider } from "@/contexts/chatbox-host-style-context";
+import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-host-capabilities-override-context";
 import { ChatboxHostOnboardingOverlays } from "@/components/hosted/ChatboxHostOnboardingOverlays";
 import { useChatboxHostIntroGate } from "@/components/hosted/useChatboxHostIntroGate";
 import { getChatboxShellStyle } from "@/lib/chatbox-host-style";
@@ -905,6 +906,9 @@ export function ChatboxChatPage({
 
   return (
     <ChatboxHostStyleProvider value={hostStyle}>
+      <ChatboxHostCapabilitiesOverrideProvider
+        value={session?.payload.hostCapabilitiesOverride}
+      >
       <div
         className="chatbox-host-shell flex h-svh min-h-0 flex-col overflow-hidden"
         data-host-style={hostStyle}
@@ -946,6 +950,7 @@ export function ChatboxChatPage({
 
         {renderContent()}
       </div>
+      </ChatboxHostCapabilitiesOverrideProvider>
     </ChatboxHostStyleProvider>
   );
 }

--- a/mcpjam-inspector/client/src/components/shared/HostContextHeader.tsx
+++ b/mcpjam-inspector/client/src/components/shared/HostContextHeader.tsx
@@ -16,11 +16,12 @@ import {
 } from "react";
 import {
   Clock,
+  Cpu,
   Globe,
   Hand,
   Moon,
   MousePointer2,
-  Palette,
+  Paintbrush,
   Settings2,
   Shield,
   Sun,
@@ -407,7 +408,7 @@ export function HostContextHeader({
               data-testid="host-capabilities-trigger"
               onClick={() => setHostCapsDialogOpen(true)}
             >
-              <Settings2 className="h-3.5 w-3.5" />
+              <Cpu className="h-3.5 w-3.5" />
               <span className="whitespace-nowrap @max-[700px]/playground-header:sr-only">
                 Host Capabilities
               </span>
@@ -430,7 +431,7 @@ export function HostContextHeader({
           <TooltipTrigger asChild>
             <div className="flex shrink-0 items-center gap-0.5 rounded-md border bg-background p-0.5 shadow-xs">
               <div className="flex h-6 w-6 items-center justify-center @max-[820px]/playground-header:hidden">
-                <Palette className="h-3.5 w-3.5 text-muted-foreground" />
+                <Paintbrush className="h-3.5 w-3.5 text-muted-foreground" />
               </div>
               {listHostStyles().map((host) => (
                 <Button

--- a/mcpjam-inspector/client/src/components/shared/HostContextHeader.tsx
+++ b/mcpjam-inspector/client/src/components/shared/HostContextHeader.tsx
@@ -52,6 +52,7 @@ import { useUIPlaygroundStore } from "@/stores/ui-playground-store";
 import { useWidgetDebugStore } from "@/stores/widget-debug-store";
 import { SafeAreaEditor } from "@/components/ui-playground/SafeAreaEditor";
 import { HostContextDialog } from "@/components/shared/HostContextDialog";
+import { HostCapabilitiesOverrideDialog } from "@/components/host-config/HostCapabilitiesOverrideDialog";
 import {
   PRESET_DEVICE_CONFIGS,
   TIMEZONE_OPTIONS,
@@ -92,6 +93,7 @@ export function HostContextHeader({
   const [cspPopoverOpen, setCspPopoverOpen] = useState(false);
   const [timezonePopoverOpen, setTimezonePopoverOpen] = useState(false);
   const [hostContextDialogOpen, setHostContextDialogOpen] = useState(false);
+  const [hostCapsDialogOpen, setHostCapsDialogOpen] = useState(false);
 
   const widthInputId = useId();
   const heightInputId = useId();
@@ -118,6 +120,12 @@ export function HostContextHeader({
   const themeMode = usePreferencesStore((state) => state.themeMode);
   const hostStyle = usePreferencesStore((state) => state.hostStyle);
   const setHostStyle = usePreferencesStore((state) => state.setHostStyle);
+  const hostCapabilitiesOverride = usePreferencesStore(
+    (state) => state.hostCapabilitiesOverride,
+  );
+  const setHostCapabilitiesOverride = usePreferencesStore(
+    (state) => state.setHostCapabilitiesOverride,
+  );
 
   const usesMcpAppsCsp =
     protocol === UIType.MCP_APPS ||
@@ -392,6 +400,34 @@ export function HostContextHeader({
 
         <Tooltip>
           <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 shrink-0 gap-1.5 border bg-background px-2 text-xs shadow-xs"
+              data-testid="host-capabilities-trigger"
+              onClick={() => setHostCapsDialogOpen(true)}
+            >
+              <Settings2 className="h-3.5 w-3.5" />
+              <span className="whitespace-nowrap @max-[700px]/playground-header:sr-only">
+                Host Capabilities
+              </span>
+              {hostCapabilitiesOverride !== undefined ? (
+                <span className="whitespace-nowrap text-[10px] text-amber-600 @max-[700px]/playground-header:sr-only dark:text-amber-400">
+                  Override
+                </span>
+              ) : null}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p className="font-medium">Host Capabilities</p>
+            <p className="text-xs text-muted-foreground">
+              Override the `hostCapabilities` advertised in ui/initialize
+            </p>
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
             <div className="flex shrink-0 items-center gap-0.5 rounded-md border bg-background p-0.5 shadow-xs">
               <div className="flex h-6 w-6 items-center justify-center @max-[820px]/playground-header:hidden">
                 <Palette className="h-3.5 w-3.5 text-muted-foreground" />
@@ -445,6 +481,14 @@ export function HostContextHeader({
         open={hostContextDialogOpen}
         onOpenChange={setHostContextDialogOpen}
         onSaveHostContext={onSaveHostContext}
+      />
+
+      <HostCapabilitiesOverrideDialog
+        open={hostCapsDialogOpen}
+        onOpenChange={setHostCapsDialogOpen}
+        hostStyle={hostStyle}
+        override={hostCapabilitiesOverride}
+        onSave={setHostCapabilitiesOverride}
       />
     </div>
   );

--- a/mcpjam-inspector/client/src/components/shared/HostContextHeader.tsx
+++ b/mcpjam-inspector/client/src/components/shared/HostContextHeader.tsx
@@ -71,6 +71,13 @@ const CUSTOM_DEVICE_BASE = {
   label: "Custom",
 };
 
+/** Muted toolbar hints (`design-system/tooltip`): popover chrome, avoids primary “CTA” orange. */
+const PLAYGROUND_HEADER_TOOLTIP = {
+  variant: "muted" as const,
+  sideOffset: 6,
+  collisionPadding: 12,
+};
+
 export interface HostContextHeaderProps {
   activeProjectId: string | null;
   onSaveHostContext?: (
@@ -209,7 +216,7 @@ export function HostContextHeader({
                 </Button>
               </PopoverTrigger>
             </TooltipTrigger>
-            <TooltipContent>
+            <TooltipContent {...PLAYGROUND_HEADER_TOOLTIP}>
               <p className="font-medium">Device</p>
             </TooltipContent>
           </Tooltip>
@@ -242,7 +249,7 @@ export function HostContextHeader({
                 </Button>
               </PopoverTrigger>
             </TooltipTrigger>
-            <TooltipContent>
+            <TooltipContent {...PLAYGROUND_HEADER_TOOLTIP}>
               <p className="font-medium">Locale</p>
             </TooltipContent>
           </Tooltip>
@@ -272,7 +279,7 @@ export function HostContextHeader({
                 </Button>
               </PopoverTrigger>
             </TooltipTrigger>
-            <TooltipContent>
+            <TooltipContent {...PLAYGROUND_HEADER_TOOLTIP}>
               <p className="font-medium">Timezone</p>
             </TooltipContent>
           </Tooltip>
@@ -307,7 +314,7 @@ export function HostContextHeader({
                 </Button>
               </PopoverTrigger>
             </TooltipTrigger>
-            <TooltipContent>
+            <TooltipContent {...PLAYGROUND_HEADER_TOOLTIP}>
               <p className="font-medium">CSP</p>
             </TooltipContent>
           </Tooltip>
@@ -332,9 +339,9 @@ export function HostContextHeader({
                 <MousePointer2 className="h-3.5 w-3.5" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>
+            <TooltipContent {...PLAYGROUND_HEADER_TOOLTIP}>
               <p className="font-medium">Hover</p>
-              <p className="text-xs font-light text-primary-foreground/90">
+              <p className="text-xs font-light text-muted-foreground">
                 {capabilities.hover ? "Enabled" : "Disabled"}
               </p>
             </TooltipContent>
@@ -351,9 +358,9 @@ export function HostContextHeader({
                 <Hand className="h-3.5 w-3.5" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent>
+            <TooltipContent {...PLAYGROUND_HEADER_TOOLTIP}>
               <p className="font-medium">Touch</p>
-              <p className="text-xs font-light text-primary-foreground/90">
+              <p className="text-xs font-light text-muted-foreground">
                 {capabilities.touch ? "Enabled" : "Disabled"}
               </p>
             </TooltipContent>
@@ -366,7 +373,7 @@ export function HostContextHeader({
               <SafeAreaEditor />
             </div>
           </TooltipTrigger>
-          <TooltipContent>
+          <TooltipContent {...PLAYGROUND_HEADER_TOOLTIP}>
             <p className="font-medium">Safe Area</p>
           </TooltipContent>
         </Tooltip>
@@ -391,7 +398,7 @@ export function HostContextHeader({
               ) : null}
             </Button>
           </TooltipTrigger>
-          <TooltipContent>
+          <TooltipContent {...PLAYGROUND_HEADER_TOOLTIP} className="max-w-sm">
             <p className="font-medium">Host Context</p>
             <p className="text-xs text-muted-foreground">
               Edit raw `hostContext` JSON
@@ -419,7 +426,7 @@ export function HostContextHeader({
               ) : null}
             </Button>
           </TooltipTrigger>
-          <TooltipContent>
+          <TooltipContent {...PLAYGROUND_HEADER_TOOLTIP} className="max-w-sm">
             <p className="font-medium">Host Capabilities</p>
             <p className="text-xs text-muted-foreground">
               Override the `hostCapabilities` advertised in ui/initialize
@@ -450,7 +457,9 @@ export function HostContextHeader({
               ))}
             </div>
           </TooltipTrigger>
-          <TooltipContent>Host Styles</TooltipContent>
+          <TooltipContent {...PLAYGROUND_HEADER_TOOLTIP}>
+            <p className="font-medium">Host Styles</p>
+          </TooltipContent>
         </Tooltip>
 
         {showThemeToggle ? (
@@ -470,8 +479,10 @@ export function HostContextHeader({
                 )}
               </Button>
             </TooltipTrigger>
-            <TooltipContent>
-              {effectiveThemeMode === "dark" ? "Light mode" : "Dark mode"}
+            <TooltipContent {...PLAYGROUND_HEADER_TOOLTIP}>
+              <p className="font-medium">
+                {effectiveThemeMode === "dark" ? "Light mode" : "Dark mode"}
+              </p>
             </TooltipContent>
           </Tooltip>
         ) : null}

--- a/mcpjam-inspector/client/src/components/shared/__tests__/HostContextHeader.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/__tests__/HostContextHeader.test.tsx
@@ -11,8 +11,10 @@ const {
   mockPreferencesState: {
     themeMode: "light",
     hostStyle: "claude",
+    hostCapabilitiesOverride: undefined,
     setThemeMode: vi.fn(),
     setHostStyle: vi.fn(),
+    setHostCapabilitiesOverride: vi.fn(),
   },
   mockUIPlaygroundStore: {
     deviceType: "desktop",
@@ -92,6 +94,11 @@ vi.mock("@/components/ui-playground/SafeAreaEditor", () => ({
 vi.mock("@/components/shared/HostContextDialog", () => ({
   HostContextDialog: ({ open }: { open: boolean }) =>
     open ? <div data-testid="host-context-dialog" /> : null,
+}));
+
+vi.mock("@/components/host-config/HostCapabilitiesOverrideDialog", () => ({
+  HostCapabilitiesOverrideDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="host-capabilities-dialog" /> : null,
 }));
 
 vi.mock("@/components/shared/host-context-constants", () => ({

--- a/mcpjam-inspector/client/src/components/shared/__tests__/HostContextHeader.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/__tests__/HostContextHeader.test.tsx
@@ -53,10 +53,11 @@ vi.mock("lucide-react", () => ({
   Globe: () => <span data-testid="icon-globe" />,
   Clock: () => <span data-testid="icon-clock" />,
   Shield: () => <span data-testid="icon-shield" />,
+  Cpu: () => <span data-testid="icon-cpu" />,
   Settings2: () => <span data-testid="icon-settings" />,
   MousePointer2: () => <span data-testid="icon-mouse" />,
   Hand: () => <span data-testid="icon-hand" />,
-  Palette: () => <span data-testid="icon-palette" />,
+  Paintbrush: () => <span data-testid="icon-paintbrush" />,
 }));
 
 vi.mock("@mcpjam/design-system/button", () => ({

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -1748,6 +1748,9 @@ export function PlaygroundMain({
           <>
             {showLiveTraceDiagnostics && (
               <ChatboxHostStyleProvider value={hostStyle}>
+                <ChatboxHostCapabilitiesOverrideProvider
+                  value={hostCapabilitiesOverride}
+                >
                 <ChatboxHostThemeProvider value={effectiveThreadTheme}>
                   <div
                     className={cn(
@@ -1808,6 +1811,7 @@ export function PlaygroundMain({
                     </div>
                   </div>
                 </ChatboxHostThemeProvider>
+                </ChatboxHostCapabilitiesOverrideProvider>
               </ChatboxHostStyleProvider>
             )}
 
@@ -1817,6 +1821,9 @@ export function PlaygroundMain({
               style={showLiveTraceDiagnostics ? { display: "none" } : undefined}
             >
               <ChatboxHostStyleProvider value={hostStyle}>
+                <ChatboxHostCapabilitiesOverrideProvider
+                  value={hostCapabilitiesOverride}
+                >
                 <ChatboxHostThemeProvider value={effectiveThreadTheme}>
                   <div
                     className={cn(
@@ -1846,6 +1853,7 @@ export function PlaygroundMain({
                     </div>
                   </div>
                 </ChatboxHostThemeProvider>
+                </ChatboxHostCapabilitiesOverrideProvider>
               </ChatboxHostStyleProvider>
             </div>
           </>

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -99,6 +99,7 @@ import {
   ChatboxHostStyleProvider,
   ChatboxHostThemeProvider,
 } from "@/contexts/chatbox-host-style-context";
+import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-host-capabilities-override-context";
 import { useComposerOnboarding } from "@/hooks/use-composer-onboarding";
 import { useDebouncedXRayPayload } from "@/hooks/use-debounced-x-ray-payload";
 import { useModelSelectorLayoutLock } from "@/hooks/use-model-selector-layout-lock";
@@ -446,6 +447,9 @@ export function PlaygroundMain({
   // Host chat background: actual chat area colors from each host's UI
   // (separate from the 76 MCP spec widget design tokens)
   const hostStyle = usePreferencesStore((s) => s.hostStyle);
+  const hostCapabilitiesOverride = usePreferencesStore(
+    (s) => s.hostCapabilitiesOverride
+  );
   const globalThemeMode = usePreferencesStore(
     (s) => s.themeMode
   ) as ThreadThemeMode;

--- a/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
@@ -33,6 +33,8 @@ import {
   ChatboxHostStyleProvider,
   ChatboxHostThemeProvider,
 } from "@/contexts/chatbox-host-style-context";
+import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-host-capabilities-override-context";
+import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import type { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import {
   getChatboxChatBackground,
@@ -147,6 +149,9 @@ export function MultiModelPlaygroundCard({
   addColumnSeed = null,
   onTranscriptSync,
 }: MultiModelPlaygroundCardProps) {
+  const hostCapabilitiesOverride = usePreferencesStore(
+    (s) => s.hostCapabilitiesOverride,
+  );
   const [modelContextQueue, setModelContextQueue] = useState<
     {
       toolCallId: string;
@@ -643,6 +648,9 @@ export function MultiModelPlaygroundCard({
           </div>
         ) : (
           <ChatboxHostStyleProvider value={hostStyle}>
+            <ChatboxHostCapabilitiesOverrideProvider
+              value={hostCapabilitiesOverride}
+            >
             <ChatboxHostThemeProvider value={effectiveThreadTheme}>
               <div
                 className={cn(
@@ -707,6 +715,7 @@ export function MultiModelPlaygroundCard({
                 )}
               </div>
             </ChatboxHostThemeProvider>
+            </ChatboxHostCapabilitiesOverrideProvider>
           </ChatboxHostStyleProvider>
         )}
       </div>

--- a/mcpjam-inspector/client/src/contexts/chatbox-host-capabilities-override-context.ts
+++ b/mcpjam-inspector/client/src/contexts/chatbox-host-capabilities-override-context.ts
@@ -1,0 +1,29 @@
+import { createContext, useContext } from "react";
+
+/**
+ * Per-scope user override for the MCP Apps `hostCapabilities` blob advertised
+ * in the `ui/initialize` response.
+ *
+ * Mirrors the shape of {@link chatbox-host-style-context}: a single Provider
+ * sets the value for whatever scope owns the host config (chatbox, eval suite,
+ * direct chat). The renderer reads via {@link useChatboxHostCapabilitiesOverride}
+ * and falls back to the active host style's preset when this returns
+ * `undefined`.
+ *
+ * Storing the override here — rather than in the host-context store — keeps
+ * the two concerns separate: `hostContext` is per-resource environment data
+ * passed into ui/initialize; `hostCapabilitiesOverride` is a vendor-trait
+ * customization of the static contract the host advertises.
+ */
+const ChatboxHostCapabilitiesOverrideContext = createContext<
+  Record<string, unknown> | undefined
+>(undefined);
+
+export const ChatboxHostCapabilitiesOverrideProvider =
+  ChatboxHostCapabilitiesOverrideContext.Provider;
+
+export function useChatboxHostCapabilitiesOverride():
+  | Record<string, unknown>
+  | undefined {
+  return useContext(ChatboxHostCapabilitiesOverrideContext);
+}

--- a/mcpjam-inspector/client/src/lib/__tests__/host-config-v2.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/host-config-v2.test.ts
@@ -3,6 +3,7 @@ import {
   emptyHostConfigInputV2,
   hostConfigDtoToInput,
   hostConfigInputsEqual,
+  resolveEffectiveHostCapabilities,
   type HostConfigDtoV2,
   type HostConfigInputV2,
 } from "../host-config-v2";
@@ -269,5 +270,43 @@ describe("hostConfigDtoToInput", () => {
     };
     const input = hostConfigDtoToInput(dto);
     expect(input.hostCapabilitiesOverride).toBeUndefined();
+  });
+});
+
+describe("resolveEffectiveHostCapabilities", () => {
+  it("strips sandbox from the override before returning", () => {
+    // SEP-1865: sandbox is approved per UI resource at runtime, not a
+    // vendor trait. If a user pastes sandbox into the JSON editor, it
+    // MUST NOT leak into the advertised hostCapabilities blob.
+    const resolved = resolveEffectiveHostCapabilities({
+      hostStyle: "claude",
+      hostCapabilitiesOverride: {
+        serverTools: { listChanged: true },
+        sandbox: { permissions: { camera: {} } },
+      },
+    });
+    expect(resolved).not.toHaveProperty("sandbox");
+    // Sibling fields survive — sandbox stripping must be surgical.
+    expect(resolved).toEqual({ serverTools: { listChanged: true } });
+  });
+
+  it("returns an empty {} override as 'advertise nothing' (not preset)", () => {
+    // The override is explicitly the empty object — must hash distinctly
+    // from undefined (which would fall through to the host style preset).
+    const resolved = resolveEffectiveHostCapabilities({
+      hostStyle: "claude",
+      hostCapabilitiesOverride: {},
+    });
+    expect(resolved).toEqual({});
+  });
+
+  it("falls back to the host style preset when no override is set", () => {
+    const resolved = resolveEffectiveHostCapabilities({
+      hostStyle: "claude",
+      hostCapabilitiesOverride: undefined,
+    });
+    // Claude preset advertises message; sentinel that we picked the
+    // preset rather than the spec-default {}.
+    expect(resolved).toHaveProperty("message");
   });
 });

--- a/mcpjam-inspector/client/src/lib/__tests__/host-config-v2.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/host-config-v2.test.ts
@@ -88,6 +88,31 @@ describe("hostConfigInputsEqual", () => {
     });
     expect(hostConfigInputsEqual(a, b)).toBe(false);
   });
+
+  it("treats two undefined hostCapabilitiesOverrides as equal", () => {
+    expect(
+      hostConfigInputsEqual(
+        makeInput({ hostCapabilitiesOverride: undefined }),
+        makeInput({ hostCapabilitiesOverride: undefined }),
+      ),
+    ).toBe(true);
+  });
+
+  it("distinguishes undefined from an empty {} override", () => {
+    const a = makeInput({ hostCapabilitiesOverride: undefined });
+    const b = makeInput({ hostCapabilitiesOverride: {} });
+    expect(hostConfigInputsEqual(a, b)).toBe(false);
+  });
+
+  it("detects nested value changes in hostCapabilitiesOverride", () => {
+    const a = makeInput({
+      hostCapabilitiesOverride: { openLinks: {} } as Record<string, unknown>,
+    });
+    const b = makeInput({
+      hostCapabilitiesOverride: {} as Record<string, unknown>,
+    });
+    expect(hostConfigInputsEqual(a, b)).toBe(false);
+  });
 });
 
 describe("emptyHostConfigInputV2", () => {
@@ -197,5 +222,52 @@ describe("hostConfigDtoToInput", () => {
         >
       ),
     ).toEqual({ value: 1 });
+  });
+
+  it("deep-clones hostCapabilitiesOverride when present", () => {
+    const dto: HostConfigDtoV2 = {
+      id: "host-3",
+      schemaVersion: 2,
+      hostStyle: "claude",
+      modelId: "x",
+      systemPrompt: "",
+      temperature: 0.7,
+      requireToolApproval: false,
+      serverIds: [],
+      optionalServerIds: [],
+      connectionDefaults: { headers: {}, requestTimeout: 10000 },
+      clientCapabilities: {},
+      hostContext: {},
+      hostCapabilitiesOverride: {
+        serverTools: { listChanged: true },
+      } as Record<string, unknown>,
+    };
+    const input = hostConfigDtoToInput(dto);
+    (input.hostCapabilitiesOverride!.serverTools as Record<string, unknown>)
+      .listChanged = false;
+
+    expect(
+      (dto.hostCapabilitiesOverride!.serverTools as Record<string, unknown>)
+        .listChanged,
+    ).toBe(true);
+  });
+
+  it("leaves hostCapabilitiesOverride undefined when the dto omits it", () => {
+    const dto: HostConfigDtoV2 = {
+      id: "host-4",
+      schemaVersion: 2,
+      hostStyle: "claude",
+      modelId: "x",
+      systemPrompt: "",
+      temperature: 0.7,
+      requireToolApproval: false,
+      serverIds: [],
+      optionalServerIds: [],
+      connectionDefaults: { headers: {}, requestTimeout: 10000 },
+      clientCapabilities: {},
+      hostContext: {},
+    };
+    const input = hostConfigDtoToInput(dto);
+    expect(input.hostCapabilitiesOverride).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/lib/chatbox-session.ts
+++ b/mcpjam-inspector/client/src/lib/chatbox-session.ts
@@ -74,6 +74,12 @@ export interface ChatboxBootstrapPayload {
   servers: ChatboxBootstrapServer[];
   /** When set by bootstrap or playground snapshot, drives hosted welcome copy. */
   chatUi?: ChatUiPayload | null;
+  /**
+   * User override for the MCP Apps `hostCapabilities` blob (see
+   * HostConfigInputV2.hostCapabilitiesOverride). When undefined the hosted
+   * runtime falls back to the active `hostStyle`'s preset.
+   */
+  hostCapabilitiesOverride?: Record<string, unknown>;
 }
 
 export interface ChatboxSession {
@@ -155,6 +161,15 @@ function normalizeChatUiPayload(input: unknown): ChatUiPayload | undefined {
       : undefined;
   if (!welcome) return undefined;
   return { surfaces: { welcome } };
+}
+
+function normalizeHostCapabilitiesOverride(
+  input: unknown,
+): Record<string, unknown> | undefined {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return undefined;
+  }
+  return input as Record<string, unknown>;
 }
 
 function normalizeChatboxShareMode(mode: unknown): ChatboxShareMode {
@@ -261,6 +276,10 @@ export function normalizeChatboxSession(
           optional: Boolean(server.optional),
         })),
       chatUi: normalizeChatUiPayload(payload.chatUi),
+      hostCapabilitiesOverride: normalizeHostCapabilitiesOverride(
+        (payload as { hostCapabilitiesOverride?: unknown })
+          .hostCapabilitiesOverride,
+      ),
     },
     surface: parsed.surface === "preview" ? "preview" : "share_link",
     shareToken:

--- a/mcpjam-inspector/client/src/lib/host-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-v2.ts
@@ -11,11 +11,13 @@
  * place; the shape below is stable.
  */
 
+import type { McpUiHostCapabilities } from "@modelcontextprotocol/ext-apps/app-bridge";
 import type { ChatboxHostStyle } from "@/lib/chatbox-host-style";
 import {
   DEFAULT_REQUEST_TIMEOUT_MS,
   stableStringifyJson,
 } from "@/lib/client-config";
+import { getHostCapabilitiesForStyle } from "@/lib/host-styles";
 import { getDefaultClientCapabilities } from "@mcpjam/sdk/browser";
 
 export type HostStyleId = ChatboxHostStyle;
@@ -40,6 +42,14 @@ export type HostConfigInputV2 = {
   connectionDefaults: HostConfigConnectionDefaults;
   clientCapabilities: Record<string, unknown>;
   hostContext: Record<string, unknown>;
+  /**
+   * User override for the MCP Apps `hostCapabilities` blob advertised in the
+   * `ui/initialize` response. When undefined, the renderer falls back to the
+   * preset declared by the active `hostStyle`. Tracked as an **override** so
+   * source is unambiguous: switching host styles must not drag a stale base
+   * value along, and "Reset to profile" is a one-line undefined write.
+   */
+  hostCapabilitiesOverride?: Record<string, unknown>;
 };
 
 /**
@@ -59,6 +69,8 @@ export type HostConfigDtoV2 = {
   connectionDefaults: HostConfigConnectionDefaults;
   clientCapabilities: Record<string, unknown>;
   hostContext: Record<string, unknown>;
+  /** Optional user override (see HostConfigInputV2.hostCapabilitiesOverride). */
+  hostCapabilitiesOverride?: Record<string, unknown>;
 };
 
 export const DEFAULT_HOST_STYLE_V2: HostStyleId = "claude";
@@ -107,6 +119,9 @@ export function emptyHostConfigInputV2(
     hostContext: partial.hostContext
       ? deepCloneJsonRecord(partial.hostContext)
       : {},
+    hostCapabilitiesOverride: partial.hostCapabilitiesOverride
+      ? deepCloneJsonRecord(partial.hostCapabilitiesOverride)
+      : undefined,
   };
 }
 
@@ -133,7 +148,42 @@ export function hostConfigDtoToInput(
     },
     clientCapabilities: deepCloneJsonRecord(dto.clientCapabilities),
     hostContext: deepCloneJsonRecord(dto.hostContext),
+    hostCapabilitiesOverride: dto.hostCapabilitiesOverride
+      ? deepCloneJsonRecord(dto.hostCapabilitiesOverride)
+      : undefined,
   };
+}
+
+/**
+ * Resolve the `hostCapabilities` blob the MCP Apps iframe handshake should
+ * advertise for a given host config. Precedence:
+ *   1. User-saved `hostCapabilitiesOverride` (verbatim, when present)
+ *   2. The active host style's preset
+ *   3. Spec-default "no claims" baseline (handled inside
+ *      {@link getHostCapabilitiesForStyle})
+ *
+ * **Sandbox is intentionally NOT resolved here.** Per SEP-1865, sandbox
+ * CSP/permissions are approved per-UI-resource at runtime and merged into
+ * the final blob by the renderer. Profile presets and user overrides cover
+ * vendor-trait fields only.
+ *
+ * **Conformance gap (advertise vs. enforce):** This returns the value the
+ * handshake will advertise. Until enforcement gates land in the renderer's
+ * request handlers, behavior may still service methods this blob omits.
+ * Use this value as the single source of truth when enforcement ships so
+ * advertise and enforce stay in lockstep.
+ */
+export function resolveEffectiveHostCapabilities(args: {
+  hostStyle: HostStyleId | null | undefined;
+  hostCapabilitiesOverride?: Record<string, unknown>;
+}): Omit<McpUiHostCapabilities, "sandbox"> {
+  if (args.hostCapabilitiesOverride) {
+    return args.hostCapabilitiesOverride as Omit<
+      McpUiHostCapabilities,
+      "sandbox"
+    >;
+  }
+  return getHostCapabilitiesForStyle(args.hostStyle);
 }
 
 function deepCloneJsonRecord(
@@ -185,7 +235,21 @@ export function hostConfigInputsEqual(
     return false;
   if (!jsonRecordEq(a.clientCapabilities, b.clientCapabilities)) return false;
   if (!jsonRecordEq(a.hostContext, b.hostContext)) return false;
+  if (!optionalJsonRecordEq(a.hostCapabilitiesOverride, b.hostCapabilitiesOverride))
+    return false;
   return true;
+}
+
+function optionalJsonRecordEq(
+  a: Record<string, unknown> | undefined,
+  b: Record<string, unknown> | undefined,
+): boolean {
+  // Treat `undefined` (use profile preset) and `{}` (explicit empty override)
+  // as distinct values — flipping between them changes the resolved blob and
+  // must register as dirty.
+  if (a === undefined && b === undefined) return true;
+  if (a === undefined || b === undefined) return false;
+  return jsonRecordEq(a, b);
 }
 
 function stringArrayEq(a: string[], b: string[]): boolean {

--- a/mcpjam-inspector/client/src/lib/host-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-v2.ts
@@ -177,11 +177,19 @@ export function resolveEffectiveHostCapabilities(args: {
   hostStyle: HostStyleId | null | undefined;
   hostCapabilitiesOverride?: Record<string, unknown>;
 }): Omit<McpUiHostCapabilities, "sandbox"> {
-  if (args.hostCapabilitiesOverride) {
-    return args.hostCapabilitiesOverride as Omit<
-      McpUiHostCapabilities,
-      "sandbox"
-    >;
+  // `!== undefined` (not truthy-check): `{}` is a meaningful override
+  // ("advertise nothing") and must take the strip-then-return path, not
+  // silently fall through to the preset.
+  if (args.hostCapabilitiesOverride !== undefined) {
+    // Strip `sandbox` defensively: the JSON editor doesn't prevent users
+    // from typing it in, and leaking a static sandbox blob into the
+    // advertised handshake would violate the per-resource sandbox rule
+    // (SEP-1865 — sandbox is approved per UI resource at runtime, not as
+    // a vendor trait). Matches the return-type contract.
+    const { sandbox: _sandbox, ...rest } = args.hostCapabilitiesOverride as {
+      sandbox?: unknown;
+    } & Record<string, unknown>;
+    return rest as Omit<McpUiHostCapabilities, "sandbox">;
   }
   return getHostCapabilitiesForStyle(args.hostStyle);
 }

--- a/mcpjam-inspector/client/src/lib/host-styles/__tests__/registry.test.ts
+++ b/mcpjam-inspector/client/src/lib/host-styles/__tests__/registry.test.ts
@@ -3,7 +3,9 @@ import {
   CHATGPT_HOST_STYLE,
   CLAUDE_HOST_STYLE,
   DEFAULT_HOST_STYLE,
+  SPEC_DEFAULT_HOST_CAPABILITIES,
   findHostStyle,
+  getHostCapabilitiesForStyle,
   getHostStyleOrDefault,
   isKnownHostStyleId,
   listHostStyles,
@@ -56,6 +58,7 @@ describe("host-styles registry", () => {
       protocolOverride: CLAUDE_HOST_STYLE.protocolOverride,
       platform: "web",
       fontCss: "",
+      hostCapabilities: {},
       resolveStyleVariables: CLAUDE_HOST_STYLE.resolveStyleVariables,
       resolveChatBackground: () => "rgba(0, 0, 0, 1)",
     };
@@ -65,6 +68,38 @@ describe("host-styles registry", () => {
     expect(findHostStyle("test-host-registry")).toBe(fakeStyle);
     expect(isKnownHostStyleId("test-host-registry")).toBe(true);
     expect(listHostStyles()).toContain(fakeStyle);
+  });
+
+  it("returns the host style's hostCapabilities preset by id", () => {
+    expect(getHostCapabilitiesForStyle("claude")).toBe(
+      CLAUDE_HOST_STYLE.hostCapabilities,
+    );
+    expect(getHostCapabilitiesForStyle("chatgpt")).toBe(
+      CHATGPT_HOST_STYLE.hostCapabilities,
+    );
+  });
+
+  it("falls back to the spec-default capabilities for unknown ids (NOT claude)", () => {
+    // Critical: we don't want unknown ids to silently impersonate Claude's
+    // capability blob. The honest fallback is "no claims."
+    expect(getHostCapabilitiesForStyle("does-not-exist")).toBe(
+      SPEC_DEFAULT_HOST_CAPABILITIES,
+    );
+    expect(getHostCapabilitiesForStyle(null)).toBe(
+      SPEC_DEFAULT_HOST_CAPABILITIES,
+    );
+    expect(getHostCapabilitiesForStyle(undefined)).toBe(
+      SPEC_DEFAULT_HOST_CAPABILITIES,
+    );
+  });
+
+  it("differentiates claude and chatgpt capability presets", () => {
+    // Two profiles MUST differ in at least one observable key — otherwise
+    // host-style switching is cosmetic only and provides no signal to
+    // widget authors testing cross-client.
+    expect(CLAUDE_HOST_STYLE.hostCapabilities).not.toEqual(
+      CHATGPT_HOST_STYLE.hostCapabilities,
+    );
   });
 
   it("rejects duplicate host style ids", async () => {

--- a/mcpjam-inspector/client/src/lib/host-styles/built-ins.ts
+++ b/mcpjam-inspector/client/src/lib/host-styles/built-ins.ts
@@ -15,6 +15,11 @@ import {
 } from "@/config/claude-desktop-host-context";
 import type { HostStyleDefinition } from "./types";
 
+// NOTE: capability presets are best-effort mocks of what each vendor publicly
+// supports today. Treat them as starting points — verify against vendor docs
+// when behavior matters, and refine as the inspector's enforcement layer
+// (Step 4) lands. Sandbox is omitted intentionally; it's resource-derived at
+// runtime (see HostStyleDefinition.hostCapabilities).
 export const CLAUDE_HOST_STYLE: HostStyleDefinition = {
   id: "claude",
   label: "Claude",
@@ -25,6 +30,14 @@ export const CLAUDE_HOST_STYLE: HostStyleDefinition = {
   protocolOverride: UIType.MCP_APPS,
   platform: CLAUDE_DESKTOP_PLATFORM,
   fontCss: CLAUDE_DESKTOP_FONT_CSS,
+  hostCapabilities: {
+    openLinks: {},
+    serverTools: { listChanged: true },
+    serverResources: { listChanged: true },
+    logging: {},
+    updateModelContext: { text: {} },
+    message: { text: {} },
+  },
   resolveStyleVariables: getClaudeDesktopStyleVariables,
   resolveChatBackground: (theme) => CLAUDE_DESKTOP_CHAT_BACKGROUND[theme],
 };
@@ -39,6 +52,16 @@ export const CHATGPT_HOST_STYLE: HostStyleDefinition = {
   protocolOverride: UIType.OPENAI_SDK,
   platform: CHATGPT_PLATFORM,
   fontCss: CHATGPT_FONT_CSS,
+  hostCapabilities: {
+    openLinks: {},
+    serverTools: { listChanged: true },
+    // Differs from Claude: ChatGPT's Apps SDK historically focuses on tool
+    // calls rather than proxying server resources/logging. Adjust once
+    // verified against the current OpenAI Apps SDK documentation.
+    updateModelContext: { text: {} },
+    message: { text: {} },
+    downloadFile: {},
+  },
   resolveStyleVariables: getChatGPTStyleVariables,
   resolveChatBackground: (theme) => CHATGPT_CHAT_BACKGROUND[theme],
 };

--- a/mcpjam-inspector/client/src/lib/host-styles/built-ins.ts
+++ b/mcpjam-inspector/client/src/lib/host-styles/built-ins.ts
@@ -30,10 +30,15 @@ export const CLAUDE_HOST_STYLE: HostStyleDefinition = {
   protocolOverride: UIType.MCP_APPS,
   platform: CLAUDE_DESKTOP_PLATFORM,
   fontCss: CLAUDE_DESKTOP_FONT_CSS,
+  // Only claim capabilities the renderer actually implements. listChanged
+  // notifications are not forwarded into the iframe yet, so omit them here
+  // — apps that gate on `listChanged: true` would otherwise hit dead paths.
+  // Re-add per field when the renderer wires the corresponding notification
+  // (see the enforcement landing pad in mcp-apps-renderer.tsx).
   hostCapabilities: {
     openLinks: {},
-    serverTools: { listChanged: true },
-    serverResources: { listChanged: true },
+    serverTools: {},
+    serverResources: {},
     logging: {},
     updateModelContext: { text: {} },
     message: { text: {} },
@@ -52,15 +57,18 @@ export const CHATGPT_HOST_STYLE: HostStyleDefinition = {
   protocolOverride: UIType.OPENAI_SDK,
   platform: CHATGPT_PLATFORM,
   fontCss: CHATGPT_FONT_CSS,
+  // Only claim capabilities the renderer actually implements (see comment
+  // on CLAUDE_HOST_STYLE.hostCapabilities). `downloadFile` is a renderer
+  // TODO and `listChanged` notifications aren't forwarded yet — both are
+  // omitted to keep advertise and behavior in sync.
   hostCapabilities: {
     openLinks: {},
-    serverTools: { listChanged: true },
+    serverTools: {},
     // Differs from Claude: ChatGPT's Apps SDK historically focuses on tool
     // calls rather than proxying server resources/logging. Adjust once
     // verified against the current OpenAI Apps SDK documentation.
     updateModelContext: { text: {} },
     message: { text: {} },
-    downloadFile: {},
   },
   resolveStyleVariables: getChatGPTStyleVariables,
   resolveChatBackground: (theme) => CHATGPT_CHAT_BACKGROUND[theme],

--- a/mcpjam-inspector/client/src/lib/host-styles/index.ts
+++ b/mcpjam-inspector/client/src/lib/host-styles/index.ts
@@ -11,7 +11,9 @@ export {
 } from "./built-ins";
 export {
   DEFAULT_HOST_STYLE,
+  SPEC_DEFAULT_HOST_CAPABILITIES,
   findHostStyle,
+  getHostCapabilitiesForStyle,
   getHostStyleOrDefault,
   isKnownHostStyleId,
   listHostStyles,

--- a/mcpjam-inspector/client/src/lib/host-styles/registry.ts
+++ b/mcpjam-inspector/client/src/lib/host-styles/registry.ts
@@ -1,5 +1,19 @@
+import type { McpUiHostCapabilities } from "@modelcontextprotocol/ext-apps/app-bridge";
 import { BUILT_IN_HOST_STYLES, CLAUDE_HOST_STYLE } from "./built-ins";
 import type { HostStyleDefinition, HostStyleId } from "./types";
+
+/**
+ * Last-resort fallback used when no host style resolves (e.g., the caller
+ * passed an unknown id and we don't want to silently inherit Claude's
+ * capability blob). Mirrors the "advertise nothing" position from the SEP —
+ * widgets that gate on optional fields will treat them as unsupported.
+ *
+ * `sandbox` is intentionally omitted; it's per-resource runtime data.
+ */
+export const SPEC_DEFAULT_HOST_CAPABILITIES: Omit<
+  McpUiHostCapabilities,
+  "sandbox"
+> = {};
 
 const registry = new Map<HostStyleId, HostStyleDefinition>();
 
@@ -44,6 +58,20 @@ export function getHostStyleOrDefault(
   id: HostStyleId | null | undefined,
 ): HostStyleDefinition {
   return findHostStyle(id) ?? DEFAULT_HOST_STYLE;
+}
+
+/**
+ * Resolve the `hostCapabilities` blob this host style advertises.
+ *
+ * Unlike {@link getHostStyleOrDefault} this does NOT silently fall back to
+ * Claude's preset — an unknown/absent id returns
+ * {@link SPEC_DEFAULT_HOST_CAPABILITIES} so the resolved blob reflects an
+ * honest "no claims" baseline rather than impersonating Claude.
+ */
+export function getHostCapabilitiesForStyle(
+  id: HostStyleId | null | undefined,
+): Omit<McpUiHostCapabilities, "sandbox"> {
+  return findHostStyle(id)?.hostCapabilities ?? SPEC_DEFAULT_HOST_CAPABILITIES;
 }
 
 export function isKnownHostStyleId(id: unknown): id is HostStyleId {

--- a/mcpjam-inspector/client/src/lib/host-styles/types.ts
+++ b/mcpjam-inspector/client/src/lib/host-styles/types.ts
@@ -1,4 +1,7 @@
-import type { McpUiStyles } from "@modelcontextprotocol/ext-apps/app-bridge";
+import type {
+  McpUiHostCapabilities,
+  McpUiStyles,
+} from "@modelcontextprotocol/ext-apps/app-bridge";
 import type { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 
 export type HostStyleId = string;
@@ -40,6 +43,19 @@ export interface HostStyleDefinition {
   platform: "web" | "desktop" | "mobile";
   /** Inline @font-face CSS injected into MCP App iframes. */
   fontCss: string;
+  /**
+   * MCP Apps `hostCapabilities` blob advertised in the `ui/initialize`
+   * response for this host. Excludes `sandbox` — sandbox CSP/permissions are
+   * approved per UI resource (widget-declared) at runtime, not as a static
+   * vendor trait, per SEP-1865.
+   *
+   * NOTE: Advertising a capability is a runtime contract. Until enforcement
+   * gates land in `registerBridgeHandlers`, behavior may still service methods
+   * that the handshake says are unsupported. Profiles should reflect what the
+   * vendor *actually* supports so widget authors testing against the mock are
+   * not misled when enforcement catches up.
+   */
+  hostCapabilities: Omit<McpUiHostCapabilities, "sandbox">;
   resolveStyleVariables: (theme: HostThemeMode) => McpUiStyles;
   resolveChatBackground: (theme: HostThemeMode) => string;
 }

--- a/mcpjam-inspector/client/src/stores/preferences/__tests__/preferences-store.test.ts
+++ b/mcpjam-inspector/client/src/stores/preferences/__tests__/preferences-store.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   createPreferencesStore,
+  HOST_CAPABILITIES_OVERRIDE_KEY,
   HOST_STYLE_KEY,
   THEME_MODE_KEY,
   THEME_PRESET_KEY,
@@ -60,5 +61,87 @@ describe("preferences-store", () => {
 
     expect(localStorage.getItem(THEME_MODE_KEY)).toBe("dark");
     expect(localStorage.getItem(THEME_PRESET_KEY)).toBe("soft-pop");
+  });
+
+  it("defaults hostCapabilitiesOverride to undefined (use host style preset)", () => {
+    const store = createPreferencesStore({
+      themeMode: "light",
+      themePreset: "default",
+    });
+    expect(store.getState().hostCapabilitiesOverride).toBeUndefined();
+  });
+
+  it("persists hostCapabilitiesOverride to localStorage as JSON", () => {
+    const store = createPreferencesStore({
+      themeMode: "light",
+      themePreset: "default",
+    });
+
+    store.getState().setHostCapabilitiesOverride({ openLinks: {} });
+
+    expect(store.getState().hostCapabilitiesOverride).toEqual({
+      openLinks: {},
+    });
+    expect(
+      JSON.parse(localStorage.getItem(HOST_CAPABILITIES_OVERRIDE_KEY) ?? "{}"),
+    ).toEqual({ openLinks: {} });
+  });
+
+  it("hydrates hostCapabilitiesOverride from localStorage on init", () => {
+    localStorage.setItem(
+      HOST_CAPABILITIES_OVERRIDE_KEY,
+      JSON.stringify({ logging: {} }),
+    );
+    const store = createPreferencesStore({
+      themeMode: "light",
+      themePreset: "default",
+    });
+    expect(store.getState().hostCapabilitiesOverride).toEqual({
+      logging: {},
+    });
+  });
+
+  it("clearing hostCapabilitiesOverride to undefined removes the localStorage entry", () => {
+    // Initial state: an override is persisted. The "Reset to preset" action
+    // sets the field to undefined; the localStorage entry must be removed
+    // (not left as "null") so the next reload also returns undefined and
+    // the user lands back on the host style preset.
+    localStorage.setItem(
+      HOST_CAPABILITIES_OVERRIDE_KEY,
+      JSON.stringify({ openLinks: {} }),
+    );
+    const store = createPreferencesStore({
+      themeMode: "light",
+      themePreset: "default",
+    });
+    expect(store.getState().hostCapabilitiesOverride).toEqual({
+      openLinks: {},
+    });
+
+    store.getState().setHostCapabilitiesOverride(undefined);
+
+    expect(store.getState().hostCapabilitiesOverride).toBeUndefined();
+    expect(localStorage.getItem(HOST_CAPABILITIES_OVERRIDE_KEY)).toBeNull();
+  });
+
+  it("distinguishes saved empty {} override from undefined (preset)", () => {
+    const store = createPreferencesStore({
+      themeMode: "light",
+      themePreset: "default",
+    });
+
+    // {} means "advertise nothing" — must NOT collapse to undefined.
+    store.getState().setHostCapabilitiesOverride({});
+    expect(store.getState().hostCapabilitiesOverride).toEqual({});
+    expect(localStorage.getItem(HOST_CAPABILITIES_OVERRIDE_KEY)).toBe("{}");
+  });
+
+  it("silently ignores a corrupt persisted override (falls back to preset)", () => {
+    localStorage.setItem(HOST_CAPABILITIES_OVERRIDE_KEY, "{not-valid-json");
+    const store = createPreferencesStore({
+      themeMode: "light",
+      themePreset: "default",
+    });
+    expect(store.getState().hostCapabilitiesOverride).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/client/src/stores/preferences/preferences-store.ts
+++ b/mcpjam-inspector/client/src/stores/preferences/preferences-store.ts
@@ -11,14 +11,30 @@ export type PreferencesState = {
   themeMode: ThemeMode;
   themePreset: ThemePreset;
   hostStyle: ChatboxHostStyle;
+  /**
+   * Direct-Chat scoped MCP Apps `hostCapabilities` override. Undefined means
+   * "use the active host style's preset" (advertised in ui/initialize).
+   *
+   * Direct Chat is the working bench where users iterate on capability
+   * mocks while testing widgets; this field is the "save the bench" target
+   * so a tweaked configuration survives reloads. Chatbox / eval-suite /
+   * project-default flows persist their own overrides through the v2
+   * HostConfig row instead.
+   */
+  hostCapabilitiesOverride: Record<string, unknown> | undefined;
   setThemeMode: (mode: ThemeMode) => void;
   setThemePreset: (preset: ThemePreset) => void;
   setHostStyle: (hostStyle: ChatboxHostStyle) => void;
+  setHostCapabilitiesOverride: (
+    next: Record<string, unknown> | undefined,
+  ) => void;
 };
 
 export const THEME_MODE_KEY = "themeMode";
 export const THEME_PRESET_KEY = "themePreset";
 export const HOST_STYLE_KEY = "mcpjam-ui-playground-host-style";
+export const HOST_CAPABILITIES_OVERRIDE_KEY =
+  "mcpjam-ui-playground-host-capabilities-override";
 
 function getStoredHostStyle(): ChatboxHostStyle {
   if (typeof window === "undefined") return DEFAULT_HOST_STYLE.id;
@@ -36,11 +52,52 @@ function getStoredHostStyle(): ChatboxHostStyle {
   return DEFAULT_HOST_STYLE.id;
 }
 
+function getStoredHostCapabilitiesOverride():
+  | Record<string, unknown>
+  | undefined {
+  if (typeof window === "undefined") return undefined;
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(HOST_CAPABILITIES_OVERRIDE_KEY);
+  } catch (error) {
+    console.warn(
+      "Failed to read persisted host capabilities override:",
+      error,
+    );
+    return undefined;
+  }
+  if (!raw) return undefined;
+  // Stored as JSON. Anything malformed is treated as "no override" rather
+  // than throwing — we don't want a corrupt localStorage entry to brick
+  // the chat tab. A failed parse silently falls back to the preset.
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed)
+    ) {
+      return parsed as Record<string, unknown>;
+    }
+    return undefined;
+  } catch (error) {
+    console.warn(
+      "Failed to parse persisted host capabilities override:",
+      error,
+    );
+    return undefined;
+  }
+}
+
 export const createPreferencesStore = (init?: Partial<PreferencesState>) =>
   createStore<PreferencesState>()((set) => ({
     themeMode: init?.themeMode ?? "light",
     themePreset: init?.themePreset ?? "default",
     hostStyle: init?.hostStyle ?? getStoredHostStyle(),
+    hostCapabilitiesOverride:
+      init?.hostCapabilitiesOverride !== undefined
+        ? init.hostCapabilitiesOverride
+        : getStoredHostCapabilitiesOverride(),
     setThemeMode: (mode) => {
       try {
         localStorage.setItem(THEME_MODE_KEY, mode);
@@ -64,5 +121,28 @@ export const createPreferencesStore = (init?: Partial<PreferencesState>) =>
         console.warn("Failed to persist host style:", error);
       }
       set({ hostStyle });
+    },
+    setHostCapabilitiesOverride: (next) => {
+      try {
+        if (next === undefined) {
+          // Treat undefined as "reset to host style preset". Remove the
+          // localStorage entry so a future getStoredHostCapabilitiesOverride
+          // returns undefined too — keeping an empty {} stored would be
+          // semantically different ("advertise nothing") and trap the user
+          // on the next reload.
+          localStorage.removeItem(HOST_CAPABILITIES_OVERRIDE_KEY);
+        } else {
+          localStorage.setItem(
+            HOST_CAPABILITIES_OVERRIDE_KEY,
+            JSON.stringify(next),
+          );
+        }
+      } catch (error) {
+        console.warn(
+          "Failed to persist host capabilities override:",
+          error,
+        );
+      }
+      set({ hostCapabilitiesOverride: next });
     },
   }));


### PR DESCRIPTION
## Summary

The MCP Apps iframe handshake currently advertises a single hardcoded `hostCapabilities` literal — every widget sees the same `{}` blob regardless of which host style is active. This PR replaces that literal with a value resolved at runtime: **per-host-style preset + optional user override**.

The result:

- Widgets that gate on `hostCapabilities.*` actually exercise different branches under "Claude" vs "ChatGPT" host styles (instead of seeing identical empty objects).
- Users can save a custom override per chatbox / project / eval suite (persisted on the v2 host config row) or for Direct Chat (persisted in localStorage via preferences-store).
- Two editor surfaces:
  - `HostConfigEditor` — JSON section next to `clientCapabilities` / `hostContext`, surfaced from Project Settings / Chatbox Editor / Eval Suite Settings.
  - `HostContextHeader` — "Host Capabilities" trigger button right next to "Host Context" in the App Builder playground header. Opens a dialog wired to the preferences-store.

Per **SEP-1865**, hostCapabilities is the contract returned in ui/initialize. The sandbox sub-field stays widget-derived (CSP/permissions are approved per UI resource, not vendor traits).

## Security

- **Advertise = enforce, partially.** Today this PR only updates what the handshake advertises. The handlers in registerBridgeHandlers (mcp-apps-renderer.tsx:927) still service every method regardless of the advertised blob. That's a conformance gap: a "ChatGPT" mock that omits serverResources will still actually service resources/read proxied from a view. Widget authors testing cross-client need to know this. The PR explicitly scaffolds the landing pad — effectiveHostCapabilities is hoisted to component scope and a per-handler mapping comment lives next to registerBridgeHandlers, so the enforcement follow-up is per-handler if-adds, not a refactor.
- No new permissions, secrets, or network surfaces. JSON editor parses with JSON.parse and rejects arrays / non-object values before save. localStorage entries are scoped to mcpjam-ui-playground-host-capabilities-override; corrupt entries are silently ignored (fall back to preset).
- undefined vs {} is preserved end-to-end so "use host style preset" and "advertise nothing" remain distinct states. Pairs with the backend canonicalize tests guarding the same distinction in hash dedupe.

## What ships

- **Profiles** (lib/host-styles/built-ins.ts): concrete hostCapabilities blobs for Claude and ChatGPT — intentionally distinct so widgets see real differences. Best-effort against public vendor behavior; flagged in comments as "verify against vendor docs."
- **Resolver** (lib/host-config-v2.ts): resolveEffectiveHostCapabilities returns override → profile preset → SPEC_DEFAULT_HOST_CAPABILITIES ({}).
- **Renderer wiring** (components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx): the inline literal at ~line 1170 is gone. Bridge effect deps include effectiveHostCapabilities so style/override changes rebuild the bridge cleanly.
- **Persistence paths**:
  - Chatbox / Builder / Eval suite: through the existing v2 host config row (new optional hostCapabilitiesOverride field).
  - Direct Chat: through preferences-store + new HOST_CAPABILITIES_OVERRIDE_KEY localStorage entry.
- **Editor surfaces**: HostConfigEditor JSON section + Direct Chat HostCapabilitiesOverrideDialog.

## What's deferred

- **Enforcement gates** in registerBridgeHandlers (per-handler reject when capability absent). Scaffolded with the mapping comment; not gated yet.
- **Vendor preset accuracy**: Claude/ChatGPT presets are educated guesses pending verification against current vendor docs.
- **Eval suite preview wiring**: the eval test-template-editor doesn't load a v2 DTO at its provider site, so it currently uses the host-style preset at runtime (saves still round-trip through the editor).

## Test plan

- [x] host-config-v2.test.ts — 16 cases (5 new) cover undefined-vs-{} equality, deep-clone round-trip
- [x] host-styles/__tests__/registry.test.ts — 10 cases (3 new) cover getHostCapabilitiesForStyle and "two profiles must differ"
- [x] mcp-apps-renderer.test.tsx — 32 cases (3 new) cover style switching flips the blob, user override wins, fallback to spec default
- [x] preferences-store.test.ts — 10 cases (6 new) cover persistence, undefined-vs-{}, corrupt entry fallback
- [x] HostCapabilitiesOverrideDialog.test.tsx — 3 new cases cover header, override status, JSON validation
- [x] HostContextHeader.test.tsx — 4 existing cases still pass with the new trigger button
- [x] Full inspector test sweep: 780 passing

## Pairs with

mcpjam-backend feat/host-capabilities-override — schema field, validator, canonicalize. Backend optional field is backwards-compatible; this PR is safe to ship first but won't fully exercise persistence until the backend lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the MCP Apps `ui/initialize` handshake contract by making advertised `hostCapabilities` dynamic (style presets + overrides) and persisted across multiple surfaces; incorrect presets/override handling could break widget compatibility or test expectations.
> 
> **Overview**
> The MCP Apps renderer now **advertises `hostCapabilities` dynamically**: it resolves a per-`hostStyle` preset (Claude vs ChatGPT) and applies an optional user override, instead of sending a single hardcoded literal.
> 
> This introduces a new `ChatboxHostCapabilitiesOverride` context and threads it through Direct Chat, playground, hosted chatbox sessions, and chatbox preview/builder flows; the bridge is rebuilt when capabilities change so the handshake stays in sync.
> 
> Host config v2 gains an optional `hostCapabilitiesOverride` field plus a resolver (`resolveEffectiveHostCapabilities`) that preserves the semantic difference between `undefined` (use preset) vs `{}` (advertise nothing) and strips `sandbox` from overrides; host styles now define explicit capability presets with a spec-default fallback for unknown styles.
> 
> Adds UI to edit overrides: a new JSON section in `HostConfigEditor` and a standalone `HostCapabilitiesOverrideDialog` launched from the playground header, with Direct Chat persistence via localStorage-backed preferences. Tests are updated/added to cover capability resolution, persistence, and handshake behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20b028a17eaf30a49cdc2ad7d21f4f565032442a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->