### PR TITLE
docs: clarify member/invite copy on billing UI

### DIFF
--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -1089,6 +1089,15 @@ function OrganizationPage({
                       </Button>
                     </div>
 
+                    {billingStatus?.plan &&
+                    planCatalog?.plans[billingStatus.plan]?.billingModel ===
+                      "per_seat" ? (
+                      <p className="text-xs text-muted-foreground">
+                        Pending invites are free. You'll be billed for this
+                        seat once the invite is accepted.
+                      </p>
+                    ) : null}
+
                     {memberInviteGate.isDenied ? (
                       <Alert
                         className="border-primary/20 bg-primary/[0.04]"

--- a/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
@@ -315,7 +315,7 @@ const COMPARE_PLAN_ROW_LABEL_TOOLTIPS: Record<
   "Seat limit": {
     ariaLabel: "About seat limits",
     content:
-      "Seats don't need to be filled by a member. To add a new member, you'll need to have one empty seat.",
+      "You're charged only for active members. Pending invites are free until accepted.",
     contentClassName: "max-w-[18rem]",
   },
   "SSO / SAML": {


### PR DESCRIPTION
## Summary

- Reword the "Seat limit" tooltip on the plan comparison so the wording matches actual behavior.
- Add a small helper line under the member invite input on per-seat plans.

## Test plan

- [ ] Open plan comparison, hover the "Seat limit" info icon — tooltip reads cleanly.
- [ ] On a per-seat plan, open the members panel — helper text appears under the invite input.
- [ ] On Free / Enterprise, helper text does not appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)