### PR TITLE
fix(inspector): clear billing-specific tsc errors

### DIFF
--- a/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
+++ b/mcpjam-inspector/client/src/components/OrganizationsTab.tsx
@@ -1030,9 +1030,6 @@ function OrganizationPage({
               isStartingPlanChange={isStartingPlanChange}
               pendingPlanChangeTarget={pendingPlanChangeTarget}
               isOpeningPortal={isOpeningPortal}
-              activeMemberCount={
-                membersLoading ? undefined : activeMembers.length
-              }
               onDowngradePlan={handleDowngradePlan}
               onStartPlanChange={handlePlanChange}
               onStartAutoPlanChange={handleAutoPlanChange}

--- a/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
@@ -467,7 +467,6 @@ interface OrganizationBillingSectionProps {
   isStartingPlanChange: boolean;
   pendingPlanChangeTarget: "team" | null;
   isOpeningPortal: boolean;
-  activeMemberCount: number | undefined;
   onDowngradePlan: (
     plan: OrganizationPlan,
     billingInterval: BillingInterval,
@@ -493,7 +492,6 @@ export function OrganizationBillingSection({
   isStartingPlanChange,
   pendingPlanChangeTarget,
   isOpeningPortal,
-  activeMemberCount,
   onDowngradePlan,
   onStartPlanChange,
   onStartAutoPlanChange,
@@ -850,7 +848,6 @@ export function OrganizationBillingSection({
                           billingConfigured,
                           canManageBilling,
                           isBillingActionPending,
-                          activeMemberCount,
                           onDowngradePlan: (
                             targetPlan,
                             targetBillingInterval,

--- a/mcpjam-inspector/client/src/lib/billing-deep-link.ts
+++ b/mcpjam-inspector/client/src/lib/billing-deep-link.ts
@@ -148,10 +148,10 @@ export function readPersistedCheckoutIntent(): CheckoutIntent | null {
     }
     const plan = (parsed as { plan: unknown }).plan;
     const interval = (parsed as { interval: unknown }).interval;
-    if (!isValidPlan(typeof plan === "string" ? plan : null)) {
+    if (typeof plan !== "string" || !isValidPlan(plan)) {
       return null;
     }
-    if (!isValidInterval(typeof interval === "string" ? interval : null)) {
+    if (typeof interval !== "string" || !isValidInterval(interval)) {
       return null;
     }
     return { plan, interval };

--- a/mcpjam-inspector/client/src/lib/billing-entitlements.ts
+++ b/mcpjam-inspector/client/src/lib/billing-entitlements.ts
@@ -11,7 +11,7 @@ import type {
   PremiumnessState,
 } from "@/hooks/useOrganizationBilling";
 export function getDisplayPriceCentsForPlan(
-  plan: OrganizationPlan,
+  _plan: OrganizationPlan,
   interval: BillingInterval,
   catalogEntry: PlanCatalogEntry,
 ): number | null {


### PR DESCRIPTION
## Summary
Clears four pre-existing `tsc --noEmit` errors in inspector billing code. Targeted tests still pass (51 billing tests).

- Removed dead `activeMemberCount` prop from `OrganizationBillingSection` (leftover after Solo plan removal)
- Fixed type narrowing in `billing-deep-link.ts` so guards apply to the returned values
- Renamed unused `plan` → `_plan` in `getDisplayPriceCentsForPlan`

## Test plan
- [x] `npm run test -- client/src/lib/__tests__/billing-deep-link.test.ts client/src/lib/__tests__/billing-entitlements.test.ts` — 36 passed
- [x] `npm run test -- client/src/components/organization/__tests__ client/src/components/__tests__/OrganizationsTab.billing.test.tsx` — 51 passed
- [x] `npx tsc --noEmit -p client/tsconfig.json` — billing errors gone (unrelated pre-existing drift remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)