### PR TITLE
fix(electron): guard autoUpdater renderer messaging against destroyed window

### DIFF
--- a/mcpjam-inspector/src/ipc/update/update-listeners.ts
+++ b/mcpjam-inspector/src/ipc/update/update-listeners.ts
@@ -3,6 +3,17 @@ import log from "electron-log";
 
 const isDev = process.env.NODE_ENV === "development";
 
+function sendToRenderer(
+  mainWindow: BrowserWindow,
+  channel: string,
+  payload: unknown,
+): void {
+  if (mainWindow.isDestroyed()) return;
+  const wc = mainWindow.webContents;
+  if (wc.isDestroyed()) return;
+  wc.send(channel, payload);
+}
+
 export function registerUpdateListeners(mainWindow: BrowserWindow): void {
   // Handle restart request from renderer
   ipcMain.on("app:restart-for-update", (event) => {
@@ -26,12 +37,10 @@ export function registerUpdateListeners(mainWindow: BrowserWindow): void {
         return;
       }
       log.info("Simulating update available (dev mode)");
-      if (mainWindow && mainWindow.webContents) {
-        mainWindow.webContents.send("update-ready", {
-          version: "99.0.0",
-          releaseNotes: "Simulated update for testing",
-        });
-      }
+      sendToRenderer(mainWindow, "update-ready", {
+        version: "99.0.0",
+        releaseNotes: "Simulated update for testing",
+      });
     });
   }
 }
@@ -40,14 +49,10 @@ export function setupAutoUpdaterEvents(mainWindow: BrowserWindow): void {
   // Listen for update-downloaded event from autoUpdater
   autoUpdater.on("update-downloaded", (event, releaseNotes, releaseName) => {
     log.info(`Update downloaded: ${releaseName}`);
-
-    // Notify renderer that update is ready
-    if (mainWindow && mainWindow.webContents) {
-      mainWindow.webContents.send("update-ready", {
-        version: releaseName || "new version",
-        releaseNotes: releaseNotes || "",
-      });
-    }
+    sendToRenderer(mainWindow, "update-ready", {
+      version: releaseName || "new version",
+      releaseNotes: releaseNotes || "",
+    });
   });
 
   autoUpdater.on("checking-for-update", () => {


### PR DESCRIPTION
## TL;DR

Electron auto-updater can finish downloading **after** the user closes the window. Our handler then tries to `webContents.send(...)` on a destroyed window and throws `TypeError: Object has been destroyed`. This PR adds a destroyed-state guard so the message is silently dropped instead.

- One file changed
- Same fix applied to the dev `simulate-update` path (same bug pattern)
- Crash has been firing in production for months; counted in the four-digit range in error tracking

---

## The bug, in plain terms

| What we assumed | What actually happens |
| --- | --- |
| If `mainWindow` is set, the window is alive. | The JS reference stays set forever. After the window closes, the underlying native object is destroyed but `mainWindow` and `mainWindow.webContents` are still truthy. |
| `if (mainWindow && mainWindow.webContents) { send(...) }` is a safe guard. | It isn't. Calling `.send(...)` on a destroyed `webContents` throws. |

The correct check in Electron is **`.isDestroyed()`** — the only API that actually tells you the native object is gone.

---

## Sequence that triggers the crash

```mermaid
sequenceDiagram
    autonumber
    participant U as User
    participant W as Main Window
    participant AU as Electron autoUpdater
    participant H as Our update-downloaded handler

    U->>W: opens app
    AU->>AU: checking-for-update
    AU->>AU: update-available, download starts
    U->>W: closes window
    W-->>W: destroyed
    Note over W: mainWindow ref still truthy<br/>but native object is gone
    AU->>H: update-downloaded (~30-60s later)
    H->>W: webContents.send("update-ready", ...)
    W-->>H: TypeError: Object has been destroyed 💥
```

---

## Real telemetry confirms the race

From one captured occurrence — note the **37-second gap** between window close and the download finishing:

| Time offset | Event |
| --- | --- |
| `t = 0s` | App launches |
| `t = +1s` | autoUpdater starts checking |
| `t = +11s` | `update-available` → download begins |
| `t = +24s` | **User closes the window** |
| `t = +24s` | renderer destroyed, `window-all-closed` |
| `t = +61s` | `update-downloaded` fires |
| `t = +61s` | 💥 `TypeError: Object has been destroyed` |

The handler ran 37 seconds after the window was already dead.

---

## Why it only fails sometimes

- Most users keep the window open until the download finishes → handler runs against a live window → no crash.
- A minority close the window mid-download (or quit & relaunch quickly) → race wins → crash.
- On macOS this is especially easy because closing the window doesn't quit the app — the auto-updater keeps running with no UI to deliver the result to.

---

## The fix

Centralize the destroyed-state check in one helper and route both call sites through it.

**Before**

```ts
if (mainWindow && mainWindow.webContents) {
  mainWindow.webContents.send("update-ready", { ... });
}
```

**After**

```ts
function sendToRenderer(mainWindow, channel, payload) {
  if (mainWindow.isDestroyed()) return;
  const wc = mainWindow.webContents;
  if (wc.isDestroyed()) return;
  wc.send(channel, payload);
}

sendToRenderer(mainWindow, "update-ready", { ... });
```

Applied to:
- The real `autoUpdater.on("update-downloaded", ...)` handler
- The dev-mode `app:simulate-update` IPC handler (same buggy pattern, would have caused identical crashes in dev once anyone reproduced the close-mid-update flow)

---

## Will this break X? — Risk register

| Concern | Answer |
| --- | --- |
| Could we silently swallow the "update ready" toast for users who legitimately need it? | No. If the window is destroyed there's no renderer to receive the toast anyway. The update is already downloaded and will install on next launch via `update-electron-app`'s normal lifecycle. |
| Does the fix change update install timing? | No. `quitAndInstall` is still triggered from the renderer via the `app:restart-for-update` IPC and is untouched. |
| Could `.isDestroyed()` itself throw? | No. It's the Electron-blessed way to check lifecycle and is safe on a destroyed object — it's literally designed for this. |
| Does this hide a different bug we should fix instead? | No. The crash is genuinely "renderer is gone, nothing to deliver to." Dropping the message is the correct behavior. The renderer side already re-checks for updates on next launch. |
| What about Windows / Linux users? | Same fix applies — the bug is in the JS handler, not platform-specific. macOS is just where it shows up most because the app stays alive after window close. |

---

## Test plan

- [ ] Manual: open Inspector, close the window before any auto-update finishes, leave the app running on macOS, confirm no crash in main process logs.
- [ ] Manual (dev): `app:simulate-update` IPC after closing the window — confirm no crash, log line is silent drop.
- [ ] Monitor error tracking after release — occurrence count for this issue should drop to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)