### PR TITLE
feat(evals): layered match options + run-level validator overrides

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/__tests__/pass-criteria-match-options.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/pass-criteria-match-options.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { computeIterationPassed } from "../pass-criteria";
+import type { EvalIteration } from "../types";
+
+const tc = (toolName: string, args: Record<string, unknown> = {}) => ({
+  toolName,
+  arguments: args,
+});
+
+function makeIteration(
+  overrides: Partial<EvalIteration> & {
+    expected?: ReturnType<typeof tc>[];
+    actual?: ReturnType<typeof tc>[];
+    matchOptions?: EvalIteration["testCaseSnapshot"] extends infer S
+      ? S extends { matchOptions?: infer M }
+        ? M
+        : never
+      : never;
+    isNegativeTest?: boolean;
+  } = {},
+): EvalIteration {
+  const {
+    expected = [],
+    actual = [],
+    matchOptions,
+    isNegativeTest,
+    ...rest
+  } = overrides;
+  return {
+    _id: "iter-1",
+    createdBy: "user-1",
+    createdAt: 0,
+    iterationNumber: 1,
+    updatedAt: 0,
+    status: "completed",
+    result: "pending",
+    actualToolCalls: actual,
+    tokensUsed: 0,
+    testCaseSnapshot: {
+      title: "case",
+      query: "q",
+      provider: "openai",
+      model: "gpt-4o",
+      expectedToolCalls: expected,
+      isNegativeTest,
+      matchOptions,
+    },
+    ...rest,
+  };
+}
+
+describe("computeIterationPassed honors snapshot matchOptions", () => {
+  it("defaults preserve legacy behavior when matchOptions is absent", () => {
+    // Order-agnostic, extras allowed, partial args
+    const iter = makeIteration({
+      expected: [tc("a"), tc("b")],
+      actual: [tc("b"), tc("a"), tc("c")],
+    });
+    expect(computeIterationPassed(iter)).toBe(true);
+  });
+
+  it("strict order fails when actual is out of order", () => {
+    const iter = makeIteration({
+      expected: [tc("a"), tc("b")],
+      actual: [tc("b"), tc("a")],
+      matchOptions: { toolCallOrder: "strict" },
+    });
+    expect(computeIterationPassed(iter)).toBe(false);
+  });
+
+  it("strict order passes when actual order matches expected", () => {
+    const iter = makeIteration({
+      expected: [tc("a"), tc("b")],
+      actual: [tc("a"), tc("b")],
+      matchOptions: { toolCallOrder: "strict" },
+    });
+    expect(computeIterationPassed(iter)).toBe(true);
+  });
+
+  it("allowExtraToolCalls=false fails when extras are present", () => {
+    const iter = makeIteration({
+      expected: [tc("a")],
+      actual: [tc("a"), tc("b")],
+      matchOptions: { allowExtraToolCalls: false },
+    });
+    expect(computeIterationPassed(iter)).toBe(false);
+  });
+
+  it("allowExtraToolCalls=true (default) passes despite extras", () => {
+    const iter = makeIteration({
+      expected: [tc("a")],
+      actual: [tc("a"), tc("b")],
+      matchOptions: { allowExtraToolCalls: true },
+    });
+    expect(computeIterationPassed(iter)).toBe(true);
+  });
+
+  it("argumentMatching=exact fails when actual carries extra keys", () => {
+    const iter = makeIteration({
+      expected: [tc("save", { id: 1 })],
+      actual: [tc("save", { id: 1, extra: "x" })],
+      matchOptions: { argumentMatching: "exact" },
+    });
+    expect(computeIterationPassed(iter)).toBe(false);
+  });
+
+  it("argumentMatching=ignore passes regardless of arg values", () => {
+    const iter = makeIteration({
+      expected: [tc("save", { id: 1 })],
+      actual: [tc("save", { id: 999 })],
+      matchOptions: { argumentMatching: "ignore" },
+    });
+    expect(computeIterationPassed(iter)).toBe(true);
+  });
+
+  it("argumentMatching=partial (default) tolerates extra actual keys", () => {
+    const iter = makeIteration({
+      expected: [tc("save", { id: 1 })],
+      actual: [tc("save", { id: 1, extra: "x" })],
+    });
+    expect(computeIterationPassed(iter)).toBe(true);
+  });
+
+  it("strict + forbid extras + exact args combine correctly", () => {
+    const matchOptions = {
+      toolCallOrder: "strict" as const,
+      allowExtraToolCalls: false,
+      argumentMatching: "exact" as const,
+    };
+    const passing = makeIteration({
+      expected: [tc("a", { x: 1 }), tc("b")],
+      actual: [tc("a", { x: 1 }), tc("b")],
+      matchOptions,
+    });
+    expect(computeIterationPassed(passing)).toBe(true);
+
+    const failingOnExtra = makeIteration({
+      expected: [tc("a", { x: 1 })],
+      actual: [tc("a", { x: 1 }), tc("b")],
+      matchOptions,
+    });
+    expect(computeIterationPassed(failingOnExtra)).toBe(false);
+  });
+
+  it("negative tests still pass when no tools called, regardless of options", () => {
+    const iter = makeIteration({
+      expected: [],
+      actual: [],
+      isNegativeTest: true,
+      matchOptions: { toolCallOrder: "strict", allowExtraToolCalls: false },
+    });
+    expect(computeIterationPassed(iter)).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-header.test.tsx
@@ -302,7 +302,38 @@ describe("SuiteHeader", () => {
     });
     expect(runAll).toBeEnabled();
     await user.click(runAll);
-    expect(onRerun).toHaveBeenCalledWith(baseSuite);
+    expect(onRerun).toHaveBeenCalledWith(baseSuite, {});
+  });
+
+  it("forwards iterationOverride on Run all even without a match-options override", async () => {
+    const user = userEvent.setup();
+    const onRerun = vi.fn();
+
+    renderWithProviders(
+      <SuiteHeader
+        {...baseProps}
+        viewMode="overview"
+        selectedRunDetails={null}
+        onRerun={onRerun}
+        runsViewMode="runs"
+        hideRunActions
+        unifiedSuiteDashboard
+        onCreateTestCase={vi.fn()}
+        onGenerateTestCases={vi.fn()}
+        canGenerateTestCases
+        testCases={[
+          { _id: "c1", models: [{ provider: "openai", model: "gpt-4" }] } as any,
+        ]}
+        connectedServerNames={new Set(["asana"])}
+        iterationOverride={3}
+      />,
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /Run all cases in this suite/i }),
+    );
+
+    expect(onRerun).toHaveBeenCalledWith(baseSuite, { iterationOverride: 3 });
   });
 
   it("shows the suite model bar on overview when test cases exist", () => {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/use-eval-handlers.test.ts
@@ -251,6 +251,57 @@ describe("useEvalHandlers", () => {
       expect(requestBody.iterationOverride).toBe(4);
     });
 
+    it("forwards matchOptionsOverride and iterationOverride together to runEvals", async () => {
+      const { result } = renderHook(() => useEvalHandlers(defaultProps));
+
+      await act(async () => {
+        await result.current.handleRerun(
+          {
+            _id: "suite-overrides",
+            name: "Suite",
+            environment: { servers: ["server-1"] },
+          } as any,
+          {
+            iterationOverride: 4,
+            matchOptionsOverride: { argumentMatching: "exact" },
+          },
+        );
+      });
+
+      const requestBody = JSON.parse(mockAuthFetch.mock.calls[0][1].body);
+      expect(requestBody.iterationOverride).toBe(4);
+      expect(requestBody.matchOptionsOverride).toEqual({
+        argumentMatching: "exact",
+      });
+    });
+
+    it("forwards matchOptionsOverride without iterationOverride", async () => {
+      const { result } = renderHook(() => useEvalHandlers(defaultProps));
+
+      await act(async () => {
+        await result.current.handleRerun(
+          {
+            _id: "suite-match-only",
+            name: "Suite",
+            environment: { servers: ["server-1"] },
+          } as any,
+          {
+            matchOptionsOverride: {
+              argumentMatching: "exact",
+              allowExtraToolCalls: false,
+            },
+          },
+        );
+      });
+
+      const requestBody = JSON.parse(mockAuthFetch.mock.calls[0][1].body);
+      expect(requestBody.matchOptionsOverride).toEqual({
+        argumentMatching: "exact",
+        allowExtraToolCalls: false,
+      });
+      expect(requestBody.iterationOverride).toBeUndefined();
+    });
+
     it("includes promptTurns and expectedOutput when rerunning saved cases", async () => {
       mockConvexQuery.mockResolvedValueOnce([
         {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/validators-section.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/validators-section.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test";
+import { MATCH_OPTIONS_DEFAULTS } from "@/shared/eval-matching";
+import { ValidatorsSection } from "../validators-section";
+
+describe("ValidatorsSection", () => {
+  it("renders concrete resolved values when nothing is overridden", () => {
+    renderWithProviders(
+      <ValidatorsSection
+        title="Validators"
+        description="Suite defaults apply unless overridden."
+        value={undefined}
+        inheritedFrom={MATCH_OPTIONS_DEFAULTS}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Suite defaults apply/)).toBeInTheDocument();
+    expect(screen.getByText("Any order")).toBeInTheDocument();
+    expect(screen.getByText("Allow extras")).toBeInTheDocument();
+    expect(screen.getByText("Partial")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /reset/i })).not.toBeInTheDocument();
+  });
+
+  it("hides description in compact density and only shows Reset when overridden", () => {
+    const { rerender } = renderWithProviders(
+      <ValidatorsSection
+        title="This run"
+        description="Should not render in compact layout."
+        value={undefined}
+        inheritedFrom={MATCH_OPTIONS_DEFAULTS}
+        density="compact"
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/Should not render/)).not.toBeInTheDocument();
+    expect(screen.getByText("This run")).toBeInTheDocument();
+    expect(screen.getByText("Extra tool calls")).toBeInTheDocument();
+    expect(screen.getByText("Args")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /reset/i })).not.toBeInTheDocument();
+
+    rerender(
+      <ValidatorsSection
+        title="This run"
+        value={{ toolCallOrder: "strict" }}
+        inheritedFrom={MATCH_OPTIONS_DEFAULTS}
+        density="compact"
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /reset/i })).toBeInTheDocument();
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/pass-criteria.ts
+++ b/mcpjam-inspector/client/src/components/evals/pass-criteria.ts
@@ -1,4 +1,4 @@
-import { matchToolCalls } from "@/shared/eval-matching";
+import { evaluateToolCalls } from "@/shared/eval-matching";
 import { EvalIteration, EvalSuiteRun } from "./types";
 
 export type PassCriteriaType =
@@ -101,11 +101,17 @@ export function computeIterationPassed(
   const actual = iteration.actualToolCalls || [];
   const expected = iteration.testCaseSnapshot?.expectedToolCalls || [];
   const isNegativeTest = iteration.testCaseSnapshot?.isNegativeTest;
+  const snapshotMatchOptions = iteration.testCaseSnapshot?.matchOptions;
 
-  // Use shared matching logic
-  const matchResult = matchToolCalls(expected, actual, isNegativeTest);
+  // Use shared matching logic; honor per-iteration snapshot options when
+  // present. Missing field on old iterations → defaults preserve prior
+  // inspector behavior (order-agnostic, extras allowed, partial args).
+  const matchResult = evaluateToolCalls(expected, actual, {
+    ...snapshotMatchOptions,
+    isNegativeTest,
+  });
 
-  // For negative tests, the shared function handles everything
+  // For negative tests, the matcher handles everything
   if (isNegativeTest) {
     return matchResult.passed;
   }
@@ -115,7 +121,8 @@ export function computeIterationPassed(
     return true;
   }
 
-  // Apply tolerances from criteria
+  // Apply tolerances from criteria (aggregate-suite leniency, not
+  // per-call match semantics).
   const effectiveMissing = criteria?.allowUnexpectedTools
     ? []
     : matchResult.missing;
@@ -123,7 +130,19 @@ export function computeIterationPassed(
     ? []
     : matchResult.argumentMismatches;
 
-  return effectiveMissing.length === 0 && effectiveMismatches.length === 0;
+  if (effectiveMissing.length > 0 || effectiveMismatches.length > 0) {
+    return false;
+  }
+
+  // Snapshot may also fail on out-of-order or extras (when strict).
+  // Mirror the matcher's `passed` for those cases.
+  if (matchResult.outOfOrder.length > 0) {
+    return false;
+  }
+  if (snapshotMatchOptions?.allowExtraToolCalls === false && matchResult.extra.length > 0) {
+    return false;
+  }
+  return true;
 }
 
 /**

--- a/mcpjam-inspector/client/src/components/evals/pass-criteria.ts
+++ b/mcpjam-inspector/client/src/components/evals/pass-criteria.ts
@@ -116,9 +116,11 @@ export function computeIterationPassed(
     return matchResult.passed;
   }
 
-  // For positive tests with no expected calls but tools were called = pass
+  // For positive tests with no expected calls but tools were called: pass
+  // unless extras are disallowed at this snapshot, in which case those
+  // calls are unexpected extras and must fail.
   if (expected.length === 0 && actual.length > 0) {
-    return true;
+    return snapshotMatchOptions?.allowExtraToolCalls !== false;
   }
 
   // Apply tolerances from criteria (aggregate-suite leniency, not

--- a/mcpjam-inspector/client/src/components/evals/run-validators-popover.tsx
+++ b/mcpjam-inspector/client/src/components/evals/run-validators-popover.tsx
@@ -1,0 +1,81 @@
+import { SlidersHorizontal } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import { Badge } from "@mcpjam/design-system/badge";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@mcpjam/design-system/popover";
+import type { EvalMatchOptions } from "@/shared/eval-matching";
+import { MATCH_OPTIONS_DEFAULTS } from "@/shared/eval-matching";
+import { ValidatorsSection } from "./validators-section";
+
+interface RunValidatorsPopoverProps {
+  /**
+   * Fully-resolved options that already apply to this run (suite default
+   * merged with case override). The popover layers `runOverride` on top.
+   */
+  persistedEffective?: Required<EvalMatchOptions>;
+  runOverride: EvalMatchOptions | undefined;
+  onChange: (next: EvalMatchOptions | undefined) => void;
+  disabled?: boolean;
+  /** Render variant: full button (default) or icon-only. */
+  variant?: "button" | "icon";
+}
+
+export function RunValidatorsPopover({
+  persistedEffective,
+  runOverride,
+  onChange,
+  disabled,
+  variant = "button",
+}: RunValidatorsPopoverProps) {
+  const persisted = persistedEffective ?? MATCH_OPTIONS_DEFAULTS;
+  const hasOverride = !!runOverride && Object.keys(runOverride).length > 0;
+
+  const trigger =
+    variant === "icon" ? (
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        disabled={disabled}
+        title="Validator settings"
+        aria-label="Validator settings"
+        className="h-8 w-8 p-0"
+      >
+        <SlidersHorizontal className="h-4 w-4" />
+      </Button>
+    ) : (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={disabled}
+        className="h-8 gap-2"
+      >
+        <SlidersHorizontal className="h-4 w-4" />
+        <span>Validators</span>
+        {hasOverride ? (
+          <Badge variant="secondary" className="ml-1 text-[10px] px-1.5 py-0">
+            override
+          </Badge>
+        ) : null}
+      </Button>
+    );
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent className="w-[20rem] p-3" align="end">
+        <ValidatorsSection
+          title="This run"
+          density="compact"
+          value={runOverride}
+          inheritedFrom={persisted}
+          onChange={onChange}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/single-test-case-runner.ts
+++ b/mcpjam-inspector/client/src/components/evals/single-test-case-runner.ts
@@ -2,6 +2,7 @@ import { HOSTED_MODE } from "@/lib/config";
 import type { ModelDefinition } from "@/shared/types";
 import type { EvalCase, EvalSuite } from "./types";
 import type { PromptTurn } from "@/shared/prompt-turns";
+import type { EvalMatchOptions } from "@/shared/eval-matching";
 
 type TestCaseRunOverrides = Partial<
   Pick<
@@ -12,6 +13,7 @@ type TestCaseRunOverrides = Partial<
     | "runs"
     | "expectedOutput"
     | "advancedConfig"
+    | "matchOptions"
   >
 >;
 type TestCaseRunOverridesWithTurns = TestCaseRunOverrides & {
@@ -25,6 +27,8 @@ interface PrepareSingleTestCaseRunParams {
   getAccessToken: () => Promise<string | null>;
   selectedModel?: string | null;
   testCaseOverrides?: TestCaseRunOverridesWithTurns;
+  /** One-off run override; does not persist on the case. */
+  matchOptionsOverride?: EvalMatchOptions;
 }
 
 export interface TestCaseModelOption {
@@ -152,6 +156,7 @@ export async function prepareSingleTestCaseRun({
   getAccessToken,
   selectedModel,
   testCaseOverrides,
+  matchOptionsOverride,
 }: PrepareSingleTestCaseRunParams) {
   const modelValue =
     selectedModel ?? getDefaultTestCaseModelValue(testCase) ?? null;
@@ -179,6 +184,7 @@ export async function prepareSingleTestCaseRun({
       serverIds: suite.environment?.servers || [],
       convexAuthToken,
       testCaseOverrides,
+      matchOptionsOverride,
     },
   };
 }

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -420,6 +420,7 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                 aria-label="Iterations per test case for the next run"
                 disabled={isRunAllDisabled}
               >
+                <option value="">Auto</option>
                 {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
                   <option key={n} value={n}>
                     {n}

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -63,7 +63,10 @@ interface SuiteHeaderProps {
   isEditMode: boolean;
   onRerun: (
     suite: EvalSuite,
-    opts?: { matchOptionsOverride?: EvalMatchOptions },
+    opts?: {
+      matchOptionsOverride?: EvalMatchOptions;
+      iterationOverride?: number;
+    },
   ) => void;
   onReplayRun?: (suite: EvalSuite, run: EvalSuiteRun) => void;
   onCancelRun: (runId: string) => void;
@@ -453,13 +456,14 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                     suite_id: suite._id,
                     iteration_override: iterationOverride ?? null,
                   });
-                  if (runMatchOptionsOverride) {
-                    onRerun(suite, {
-                      matchOptionsOverride: runMatchOptionsOverride,
-                    });
-                  } else {
-                    onRerun(suite);
-                  }
+                  onRerun(suite, {
+                    ...(runMatchOptionsOverride
+                      ? { matchOptionsOverride: runMatchOptionsOverride }
+                      : {}),
+                    ...(iterationOverride !== undefined
+                      ? { iterationOverride }
+                      : {}),
+                  });
                 }}
               >
                 {isRerunning ? (
@@ -693,11 +697,17 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                       onClick={() =>
                         replayableLatestRun
                           ? onReplayRun?.(suite, replayableLatestRun)
-                          : runMatchOptionsOverride
-                            ? onRerun(suite, {
-                                matchOptionsOverride: runMatchOptionsOverride,
-                              })
-                            : onRerun(suite)
+                          : onRerun(suite, {
+                              ...(runMatchOptionsOverride
+                                ? {
+                                    matchOptionsOverride:
+                                      runMatchOptionsOverride,
+                                  }
+                                : {}),
+                              ...(iterationOverride !== undefined
+                                ? { iterationOverride }
+                                : {}),
+                            })
                       }
                       disabled={
                         replayableLatestRun

--- a/mcpjam-inspector/client/src/components/evals/suite-header.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-header.tsx
@@ -38,6 +38,8 @@ import { toast } from "sonner";
 import { isMCPJamProvidedModel } from "@/shared/types";
 import { CiMetadataDisplay } from "./ci-metadata-display";
 import { PassCriteriaBadge } from "./pass-criteria-badge";
+import { RunValidatorsPopover } from "./run-validators-popover";
+import { resolveMatchOptions, type EvalMatchOptions } from "@/shared/eval-matching";
 import { RunHeaderCompactStats } from "./run-header-compact-stats";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
 import { getSuiteReplayEligibility } from "./replay-eligibility";
@@ -59,7 +61,10 @@ interface SuiteHeaderProps {
   viewMode: "overview" | "run-detail" | "test-detail" | "test-edit";
   selectedRunDetails: EvalSuiteRun | null;
   isEditMode: boolean;
-  onRerun: (suite: EvalSuite) => void;
+  onRerun: (
+    suite: EvalSuite,
+    opts?: { matchOptionsOverride?: EvalMatchOptions },
+  ) => void;
   onReplayRun?: (suite: EvalSuite, run: EvalSuiteRun) => void;
   onCancelRun: (runId: string) => void;
   onViewModeChange: (mode: "overview") => void;
@@ -157,6 +162,9 @@ export function SuiteHeader(props: SuiteHeaderProps) {
 
   const [isEditingName, setIsEditingName] = useState(false);
   const [editedName, setEditedName] = useState(suite.name);
+  const [runMatchOptionsOverride, setRunMatchOptionsOverride] = useState<
+    EvalMatchOptions | undefined
+  >(undefined);
   const updateSuite = useMutation("testSuites:updateTestSuite" as any);
 
   const latestRunForMetadata = useMemo(() => {
@@ -409,7 +417,6 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                 aria-label="Iterations per test case for the next run"
                 disabled={isRunAllDisabled}
               >
-                <option value="">Auto</option>
                 {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
                   <option key={n} value={n}>
                     {n}
@@ -421,6 +428,15 @@ export function SuiteHeader(props: SuiteHeaderProps) {
           const runAllButton = (
             <div className="flex items-center gap-2">
               {iterationPicker}
+              <RunValidatorsPopover
+                persistedEffective={resolveMatchOptions(
+                  suite.defaultMatchOptions,
+                )}
+                runOverride={runMatchOptionsOverride}
+                onChange={setRunMatchOptionsOverride}
+                variant="icon"
+                disabled={isRerunning}
+              />
               <Button
                 type="button"
                 variant="default"
@@ -437,7 +453,13 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                     suite_id: suite._id,
                     iteration_override: iterationOverride ?? null,
                   });
-                  onRerun(suite);
+                  if (runMatchOptionsOverride) {
+                    onRerun(suite, {
+                      matchOptionsOverride: runMatchOptionsOverride,
+                    });
+                  } else {
+                    onRerun(suite);
+                  }
                 }}
               >
                 {isRerunning ? (
@@ -671,7 +693,11 @@ export function SuiteHeader(props: SuiteHeaderProps) {
                       onClick={() =>
                         replayableLatestRun
                           ? onReplayRun?.(suite, replayableLatestRun)
-                          : onRerun(suite)
+                          : runMatchOptionsOverride
+                            ? onRerun(suite, {
+                                matchOptionsOverride: runMatchOptionsOverride,
+                              })
+                            : onRerun(suite)
                       }
                       disabled={
                         replayableLatestRun

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -229,12 +229,23 @@ export function SuiteIterationsView({
   >(undefined);
 
   const onRerunWithOverride = useCallback(
-    (s: EvalSuite) =>
-      (onRerun as (suite: EvalSuite, opts?: { iterationOverride?: number }) => void)(
-        s,
-        { iterationOverride },
-      ),
-    [onRerun, iterationOverride],
+    (
+      s: EvalSuite,
+      opts?: {
+        matchOptionsOverride?: EvalMatchOptions;
+        iterationOverride?: number;
+      },
+    ) =>
+      (
+        onRerun as (
+          suite: EvalSuite,
+          opts?: {
+            matchOptionsOverride?: EvalMatchOptions;
+            iterationOverride?: number;
+          },
+        ) => void
+      )(s, opts),
+    [onRerun],
   );
 
   const onRunTestCaseWithOverride = useMemo<

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -222,13 +222,14 @@ export function SuiteIterationsView({
   >("model");
   /**
    * Transient per-run iteration count (1-10) applied to Run-all-cases and
-   * per-case quick runs triggered from this suite view. Defaults to 1 so the
-   * UI is self-explanatory; never written back to the persisted
-   * `EvalCase.runs`. Server enforces an absolute cap above 10.
+   * per-case quick runs triggered from this suite view. Defaults to
+   * `undefined` (Auto) so the per-case persisted `EvalCase.runs` is honored
+   * until the user picks an explicit value. Never written back to
+   * persistence. Server enforces an absolute cap above 10.
    */
   const [iterationOverride, setIterationOverride] = useState<
     number | undefined
-  >(1);
+  >(undefined);
 
   const onRerunWithOverride = useCallback(
     (s: EvalSuite) =>

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -13,6 +13,9 @@ import {
 import { SuiteTestsConfig } from "./suite-tests-config";
 import { TestTemplateEditor } from "./test-template-editor";
 import { PassCriteriaSelector } from "./pass-criteria-selector";
+import { ValidatorsSection } from "./validators-section";
+import type { EvalMatchOptions } from "@/shared/eval-matching";
+import { MATCH_OPTIONS_DEFAULTS } from "@/shared/eval-matching";
 import { TestCasesOverview } from "./test-cases-overview";
 import { TestCaseDetailView } from "./test-case-detail-view";
 import { SuiteDashboard } from "./suite-dashboard";
@@ -218,19 +221,14 @@ export function SuiteIterationsView({
     "model" | "test" | "result"
   >("model");
   /**
-   * Transient per-run iteration override (1-10) applied to Run-all-cases and
-   * per-case quick runs triggered from this suite view. `undefined` means
-   * "Auto":
-   *   - Suite reruns: each test uses its persisted `EvalCase.runs`.
-   *   - Per-case quick runs: a single iteration (the route defaults
-   *     `runs` to 1 when no override is sent — persisted `runs` is not
-   *     consulted here).
-   * Never written back to the persisted default; server enforces an
-   * absolute cap above 10.
+   * Transient per-run iteration count (1-10) applied to Run-all-cases and
+   * per-case quick runs triggered from this suite view. Defaults to 1 so the
+   * UI is self-explanatory; never written back to the persisted
+   * `EvalCase.runs`. Server enforces an absolute cap above 10.
    */
   const [iterationOverride, setIterationOverride] = useState<
     number | undefined
-  >(undefined);
+  >(1);
 
   const onRerunWithOverride = useCallback(
     (s: EvalSuite) =>
@@ -974,6 +972,30 @@ export function SuiteIterationsView({
                     setDefaultMinimumPassRate(
                       suite.defaultPassCriteria?.minimumPassRate ?? 100
                     );
+                  }
+                }}
+              />
+            </div>
+
+            {/* Default Validators Section */}
+            <div className="space-y-3">
+              <ValidatorsSection
+                title="Default validators"
+                description="Applied to every run unless a test case or 'this run' popover changes them."
+                value={suite.defaultMatchOptions}
+                inheritedFrom={MATCH_OPTIONS_DEFAULTS}
+                onChange={async (next: EvalMatchOptions | undefined) => {
+                  try {
+                    await updateSuite({
+                      suiteId: suite._id,
+                      defaultMatchOptions: next ?? null,
+                    });
+                    toast.success("Default validators updated");
+                  } catch (error) {
+                    toast.error(
+                      getBillingErrorMessage(error, "Failed to update suite")
+                    );
+                    console.error("Failed to update default validators:", error);
                   }
                 }}
               />

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -56,8 +56,14 @@ import {
   type PromptTurn,
 } from "@/shared/prompt-turns";
 import { normalizeToolChoice } from "@/shared/tool-choice";
+import {
+  resolveMatchOptions,
+  type EvalMatchOptions,
+} from "@/shared/eval-matching";
 import { cn } from "@/lib/utils";
 import { computeIterationResult } from "./pass-criteria";
+import { ValidatorsSection } from "./validators-section";
+import { RunValidatorsPopover } from "./run-validators-popover";
 import {
   ChatboxHostStyleProvider,
   ChatboxHostThemeProvider,
@@ -114,6 +120,7 @@ interface TestTemplate {
   scenario?: string;
   promptTurns: PromptTurn[];
   advancedConfig?: Record<string, unknown>;
+  matchOptions?: EvalMatchOptions;
 }
 
 interface TestTemplateEditorProps {
@@ -331,6 +338,9 @@ export function TestTemplateEditor({
   const hostStyle = usePreferencesStore((state) => state.hostStyle);
   const setHostStyle = usePreferencesStore((state) => state.setHostStyle);
   const [editForm, setEditForm] = useState<TestTemplate | null>(null);
+  const [runMatchOptionsOverride, setRunMatchOptionsOverride] = useState<
+    EvalMatchOptions | undefined
+  >(undefined);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editorMode, setEditorMode] = useState<EditorMode>(
     openCompareFromRoute ? "run" : "config"
@@ -469,6 +479,7 @@ export function TestTemplateEditor({
       scenario: currentTestCase.scenario ?? "",
       promptTurns,
       advancedConfig: normalizeAdvancedConfig(currentTestCase.advancedConfig),
+      matchOptions: currentTestCase.matchOptions,
     });
     setExpandedPromptTurnIds(promptTurns.map((turn) => turn.id));
     // Seed the transient picker from the persisted runs so a user who saved
@@ -583,12 +594,20 @@ export function TestTemplateEditor({
     const serverNegativeFlagMismatch =
       (currentTestCase.isNegativeTest ?? false) !== effectiveNegativeOnServer;
 
+    const normalizedMatchOptions = JSON.stringify(
+      normalizeForComparison(editForm.matchOptions ?? null)
+    );
+    const normalizedCurrentMatchOptions = JSON.stringify(
+      normalizeForComparison(currentTestCase.matchOptions ?? null)
+    );
+
     return (
       editForm.title !== currentTestCase.title ||
       editForm.runs !== currentTestCase.runs ||
       normalizedScenario !== normalizedCurrentScenario ||
       normalizedPromptTurns !== normalizedCurrentPromptTurns ||
       normalizedAdvancedConfig !== normalizedCurrentAdvancedConfig ||
+      normalizedMatchOptions !== normalizedCurrentMatchOptions ||
       serverNegativeFlagMismatch
     );
   }, [editForm, currentAdvancedConfig, currentPromptTurns, currentTestCase]);
@@ -753,6 +772,7 @@ export function TestTemplateEditor({
       promptTurns: normalizedPromptTurns,
       isNegativeTest,
       advancedConfig: normalizeAdvancedConfig(form.advancedConfig),
+      matchOptions: form.matchOptions,
     };
   };
 
@@ -1240,7 +1260,9 @@ export function TestTemplateEditor({
             expectedOutput: savePayload.expectedOutput,
             promptTurns: savePayload.promptTurns,
             advancedConfig,
+            matchOptions: savePayload.matchOptions,
           },
+          matchOptionsOverride: runMatchOptionsOverride,
         });
 
         return {
@@ -1906,6 +1928,16 @@ export function TestTemplateEditor({
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span className="inline-flex items-center gap-2">
+                        <RunValidatorsPopover
+                          persistedEffective={resolveMatchOptions(
+                            suite?.defaultMatchOptions,
+                            editForm?.matchOptions ?? currentTestCase?.matchOptions,
+                          )}
+                          runOverride={runMatchOptionsOverride}
+                          onChange={setRunMatchOptionsOverride}
+                          variant="icon"
+                          disabled={isRunningCompare}
+                        />
                         <Button
                           type="button"
                           size="sm"
@@ -1947,6 +1979,16 @@ export function TestTemplateEditor({
                   </Tooltip>
                 ) : (
                   <span className="inline-flex items-center gap-2">
+                    <RunValidatorsPopover
+                      persistedEffective={resolveMatchOptions(
+                        suite?.defaultMatchOptions,
+                        editForm?.matchOptions ?? currentTestCase?.matchOptions,
+                      )}
+                      runOverride={runMatchOptionsOverride}
+                      onChange={setRunMatchOptionsOverride}
+                      variant="icon"
+                      disabled={isRunningCompare}
+                    />
                     <Button
                       type="button"
                       size="sm"
@@ -2075,6 +2117,24 @@ export function TestTemplateEditor({
                 />
               ) : null}
             </div>
+
+            {editForm ? (
+              <div className="space-y-3 rounded-lg border bg-muted/20 p-4">
+                <ValidatorsSection
+                  title="Validators"
+                  description="Validator settings for this case. Reset to follow the suite default."
+                  value={editForm.matchOptions}
+                  inheritedFrom={resolveMatchOptions(
+                    suite?.defaultMatchOptions,
+                  )}
+                  onChange={(next) =>
+                    setEditForm((current) =>
+                      current ? { ...current, matchOptions: next } : current
+                    )
+                  }
+                />
+              </div>
+            ) : null}
 
             {currentTestCase.lastMessageRun ? (
               <div className="flex items-center justify-end">

--- a/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
+++ b/mcpjam-inspector/client/src/components/evals/test-template-editor.tsx
@@ -805,9 +805,13 @@ export function TestTemplateEditor({
     }
 
     try {
+      const savePayload = buildSavePayload(editForm);
       await updateTestCaseMutation({
         testCaseId: currentTestCase._id,
-        ...buildSavePayload(editForm),
+        ...savePayload,
+        // Pass `null` (not undefined) so the mutation knows to clear a
+        // previously-persisted case-level override when the user resets it.
+        matchOptions: savePayload.matchOptions ?? null,
       });
       toast.success("Changes saved");
     } catch (error) {
@@ -855,7 +859,14 @@ export function TestTemplateEditor({
 
     await updateTestCaseMutation({
       testCaseId: currentTestCase._id,
-      ...(hasUnsavedChanges ? savePayload : {}),
+      ...(hasUnsavedChanges
+        ? {
+            ...savePayload,
+            // null (not undefined) signals "clear" — required to wipe a
+            // previously-persisted case-level matchOptions override.
+            matchOptions: savePayload.matchOptions ?? null,
+          }
+        : {}),
       ...(modelsUnchanged ? {} : { models: nextModels }),
     });
   };

--- a/mcpjam-inspector/client/src/components/evals/types.ts
+++ b/mcpjam-inspector/client/src/components/evals/types.ts
@@ -1,6 +1,7 @@
 import type { PromptTurn, PromptTurnToolCall } from "@/shared/prompt-turns";
 import type { EvalTraceBlobV1 } from "@/shared/eval-trace";
 import type { EvalStreamToolCall } from "@/shared/eval-stream-events";
+import type { EvalMatchOptions } from "@/shared/eval-matching";
 import type { TraceEnvelope, TraceMessage } from "./trace-viewer-adapter";
 
 export type EvalSuiteConfigTest = {
@@ -18,6 +19,8 @@ export type EvalSuiteConfigTest = {
   expectedOutput?: string; // The output or experience expected from the MCP server
   promptTurns?: PromptTurn[];
   advancedConfig?: Record<string, unknown>;
+  /** Effective validator options for this entry, resolved at run-start. */
+  matchOptions?: EvalMatchOptions;
   testCaseId?: string;
 };
 
@@ -43,6 +46,8 @@ export type EvalSuite = {
   defaultPassCriteria?: {
     minimumPassRate: number;
   };
+  /** Suite-level default validator options (used unless a case overrides). */
+  defaultMatchOptions?: EvalMatchOptions;
   _creationTime?: number; // Convex auto field
   tags?: string[];
   defaultConfig?: {
@@ -75,6 +80,8 @@ export type EvalCase = {
   expectedOutput?: string; // The output or experience expected from the MCP server
   promptTurns?: PromptTurn[];
   advancedConfig?: Record<string, unknown>;
+  /** Case-level validator override; merged on top of suite defaults. */
+  matchOptions?: EvalMatchOptions;
   lastMessageRun?: string | null;
   _creationTime?: number; // Convex auto field
 };
@@ -99,6 +106,8 @@ export type EvalIteration = {
     expectedOutput?: string; // The output or experience expected from the MCP server
     promptTurns?: PromptTurn[];
     advancedConfig?: Record<string, unknown>;
+    /** Effective validator options used for this iteration's pass/fail. */
+    matchOptions?: EvalMatchOptions;
   };
   suiteRunId?: string;
   configRevision?: string;
@@ -210,6 +219,8 @@ export type EvalSuiteRun = {
   passCriteria?: {
     minimumPassRate: number;
   };
+  /** One-off validator override applied to all iterations in this run. */
+  matchOptionsOverride?: EvalMatchOptions;
   result?: "pending" | "passed" | "failed" | "cancelled";
   source?: "ui" | "sdk";
   replayedFromRunId?: string;

--- a/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
+++ b/mcpjam-inspector/client/src/components/evals/use-eval-handlers.ts
@@ -319,6 +319,7 @@ export function useEvalHandlers({
             expectedOutput: testCase.expectedOutput,
             promptTurns: testCase.promptTurns,
             advancedConfig: testCase.advancedConfig,
+            matchOptions: testCase.matchOptions,
             testCaseId: testCase._id,
           });
 
@@ -473,6 +474,11 @@ export function useEvalHandlers({
          * Capped server-side at 10 per test.
          */
         iterationOverride?: number;
+        /**
+         * One-off match-options override for this run only. Applied to every
+         * test in the run. Does NOT mutate persisted suite/case records.
+         */
+        matchOptionsOverride?: import("@/shared/eval-matching").EvalMatchOptions;
       },
     ) => {
       if (rerunningSuiteId) return;
@@ -563,6 +569,7 @@ export function useEvalHandlers({
             expectedOutput: test.expectedOutput,
             promptTurns: test.promptTurns,
             advancedConfig: test.advancedConfig,
+            matchOptions: (test as { matchOptions?: unknown }).matchOptions,
           })),
           serverIds: executionContext.suiteServers,
           modelApiKeys:
@@ -579,6 +586,7 @@ export function useEvalHandlers({
           // get baked into per-case overrides.
           suiteRerun: true,
           iterationOverride: options?.iterationOverride,
+          matchOptionsOverride: options?.matchOptionsOverride,
         });
 
         // Track suite run started

--- a/mcpjam-inspector/client/src/components/evals/validators-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/validators-section.tsx
@@ -1,0 +1,196 @@
+import { Button } from "@mcpjam/design-system/button";
+import { Label } from "@mcpjam/design-system/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
+import type { EvalMatchOptions } from "@/shared/eval-matching";
+import { MATCH_OPTIONS_DEFAULTS } from "@/shared/eval-matching";
+
+const ORDER_OPTIONS: Array<{
+  value: Exclude<EvalMatchOptions["toolCallOrder"], undefined>;
+  label: string;
+}> = [
+  { value: "ignore", label: "Any" },
+  { value: "strict", label: "Strict" },
+];
+
+const EXTRAS_OPTIONS: Array<{ value: "true" | "false"; label: string }> = [
+  { value: "true", label: "Allowed" },
+  { value: "false", label: "Forbidden" },
+];
+
+const ARGS_OPTIONS: Array<{
+  value: Exclude<EvalMatchOptions["argumentMatching"], undefined>;
+  label: string;
+}> = [
+  { value: "partial", label: "Partial" },
+  { value: "exact", label: "Exact" },
+  { value: "ignore", label: "Ignore" },
+];
+
+interface ValidatorsSectionProps {
+  /**
+   * What this layer has pinned. `undefined` field = follows the layer above.
+   * Direct edits are stored here; the dropdowns themselves always show the
+   * resolved (effective) value, so the user never sees an "inherit" sentinel.
+   */
+  value: EvalMatchOptions | undefined;
+  /**
+   * What the next layer up resolves to. Used to (a) show concrete values in
+   * the dropdowns when this layer hasn't pinned a field, and (b) detect when
+   * a user picked the same value as the inherited one (we treat that as a
+   * no-op and keep the field unpinned).
+   */
+  inheritedFrom?: Required<EvalMatchOptions>;
+  onChange: (next: EvalMatchOptions | undefined) => void;
+  title?: string;
+  description?: string;
+  density?: "default" | "compact";
+}
+
+function pruneUndefined(
+  options: EvalMatchOptions,
+): EvalMatchOptions | undefined {
+  const entries = Object.entries(options).filter(([, v]) => v !== undefined);
+  return entries.length === 0
+    ? undefined
+    : (Object.fromEntries(entries) as EvalMatchOptions);
+}
+
+const LABELS_COMPACT = {
+  toolOrder: "Tool order",
+  extras: "Extra tool calls",
+  args: "Args",
+} as const;
+
+export function ValidatorsSection({
+  value,
+  inheritedFrom,
+  onChange,
+  title = "Validators",
+  description,
+  density = "default",
+}: ValidatorsSectionProps) {
+  const inherited = inheritedFrom ?? MATCH_OPTIONS_DEFAULTS;
+  const isCompact = density === "compact";
+  const orderLabel = isCompact ? LABELS_COMPACT.toolOrder : "Tool call order";
+  const extrasLabel = isCompact ? LABELS_COMPACT.extras : "Extra tool calls";
+  const argsLabel = isCompact ? LABELS_COMPACT.args : "Arguments";
+
+  const setField = <K extends keyof EvalMatchOptions>(
+    field: K,
+    next: EvalMatchOptions[K],
+  ) => {
+    const merged: EvalMatchOptions = { ...value };
+    // If user picked the value already inherited from above, treat as unpin —
+    // keeps state minimal and the "Reset" affordance honest.
+    merged[field] = next === inherited[field] ? undefined : next;
+    onChange(pruneUndefined(merged));
+  };
+
+  const orderValue: "ignore" | "strict" =
+    value?.toolCallOrder ?? inherited.toolCallOrder;
+  const extrasValue: "true" | "false" = (
+    value?.allowExtraToolCalls ?? inherited.allowExtraToolCalls
+  )
+    ? "true"
+    : "false";
+  const argsValue = value?.argumentMatching ?? inherited.argumentMatching;
+
+  const hasAnyOverride =
+    !!value &&
+    (value.toolCallOrder !== undefined ||
+      value.allowExtraToolCalls !== undefined ||
+      value.argumentMatching !== undefined);
+
+  const renderRow = (
+    label: string,
+    selectId: string,
+    selectedValue: string,
+    onValueChange: (v: string) => void,
+    options: Array<{ value: string; label: string }>,
+  ) => (
+    <div className="flex items-center justify-between gap-3">
+      <Label htmlFor={selectId} className="text-sm">
+        {label}
+      </Label>
+      <Select value={selectedValue} onValueChange={onValueChange}>
+        <SelectTrigger
+          id={selectId}
+          className={
+            isCompact
+              ? "h-8 w-[10rem] max-w-full shrink-0 text-sm"
+              : "h-8 w-40 text-sm"
+          }
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+
+  return (
+    <div className={isCompact ? "space-y-2" : "space-y-3"}>
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <h4 className="text-sm font-medium">{title}</h4>
+          {description && !isCompact ? (
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {description}
+            </p>
+          ) : null}
+        </div>
+        {hasAnyOverride ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 -mr-1 px-2 text-xs text-muted-foreground"
+            onClick={() => onChange(undefined)}
+            title="Discard overrides at this layer"
+          >
+            Reset
+          </Button>
+        ) : null}
+      </div>
+      <div className={isCompact ? "space-y-1.5" : "space-y-2"}>
+        {renderRow(
+          orderLabel,
+          "validators-order",
+          orderValue,
+          (v) => setField("toolCallOrder", v as "ignore" | "strict"),
+          ORDER_OPTIONS as Array<{ value: string; label: string }>,
+        )}
+        {renderRow(
+          extrasLabel,
+          "validators-extras",
+          extrasValue,
+          (v) => setField("allowExtraToolCalls", v === "true"),
+          EXTRAS_OPTIONS as Array<{ value: string; label: string }>,
+        )}
+        {renderRow(
+          argsLabel,
+          "validators-args",
+          argsValue,
+          (v) =>
+            setField(
+              "argumentMatching",
+              v as "partial" | "exact" | "ignore",
+            ),
+          ARGS_OPTIONS as Array<{ value: string; label: string }>,
+        )}
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/validators-section.tsx
+++ b/mcpjam-inspector/client/src/components/evals/validators-section.tsx
@@ -14,12 +14,12 @@ const ORDER_OPTIONS: Array<{
   value: Exclude<EvalMatchOptions["toolCallOrder"], undefined>;
   label: string;
 }> = [
-  { value: "ignore", label: "Any" },
+  { value: "ignore", label: "Any order" },
   { value: "strict", label: "Strict" },
 ];
 
 const EXTRAS_OPTIONS: Array<{ value: "true" | "false"; label: string }> = [
-  { value: "true", label: "Allowed" },
+  { value: "true", label: "Allow extras" },
   { value: "false", label: "Forbidden" },
 ];
 

--- a/mcpjam-inspector/client/src/lib/apis/evals-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/evals-api.ts
@@ -10,6 +10,7 @@ import { authFetch } from "@/lib/session-token";
 import { notifyMCPJamLimitError } from "@/lib/mcpjam-limit";
 import type { EvalStreamEvent } from "@/shared/eval-stream-events";
 import type { PromptTurn } from "@/shared/prompt-turns";
+import type { EvalMatchOptions } from "@/shared/eval-matching";
 
 export const EVALS_API_ENDPOINTS = {
   local: {
@@ -74,6 +75,12 @@ type RunEvalsRequest = EvalRequestWithServers & {
    * default is not mutated.
    */
   iterationOverride?: number;
+  /**
+   * One-off match-option override applied to every iteration of this run
+   * (layered on top of suite default + case override). Does not mutate
+   * persisted suite/case records.
+   */
+  matchOptionsOverride?: EvalMatchOptions;
 };
 
 type RunTestCaseRequest = EvalRequestWithServers & {
@@ -100,7 +107,10 @@ type RunTestCaseRequest = EvalRequestWithServers & {
       expectedOutput?: string;
     }>;
     advancedConfig?: Record<string, unknown>;
+    matchOptions?: EvalMatchOptions;
   };
+  /** One-off run override; does not persist on the case. */
+  matchOptionsOverride?: EvalMatchOptions;
 };
 
 type GenerateTestsRequest = EvalRequestWithServers & {

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -25,6 +25,11 @@ import {
 import { flattenServerToolSnapshotTools } from "../../utils/export-helpers.js";
 import { sanitizeForConvexTransport } from "../../services/evals/convex-sanitize.js";
 import { type PromptTurn } from "@/shared/prompt-turns";
+import {
+  matchOptionsSchema,
+  resolveMatchOptions,
+  type MatchOptionsDTO,
+} from "@/shared/eval-matching";
 
 const toolChoiceSchema = z.union([
   z.enum(["auto", "none", "required"]),
@@ -76,6 +81,7 @@ export const RunEvalsRequestSchema = z.object({
         })
         .passthrough()
         .optional(),
+      matchOptions: matchOptionsSchema.optional(),
     }),
   ),
   serverIds: z
@@ -108,6 +114,12 @@ export const RunEvalsRequestSchema = z.object({
    * MAX_TOTAL_LLM_CALLS.
    */
   iterationOverride: z.number().int().min(1).max(10).optional(),
+  /**
+   * One-off match-option override for this run only. Resolved on top of
+   * suite defaults + case overrides into each iteration's snapshot;
+   * does NOT mutate persisted suite/case records.
+   */
+  matchOptionsOverride: matchOptionsSchema.optional(),
 });
 
 export type RunEvalsRequest = z.infer<typeof RunEvalsRequestSchema>;
@@ -144,8 +156,14 @@ export const RunTestCaseRequestSchema = z.object({
         })
         .passthrough()
         .optional(),
+      matchOptions: matchOptionsSchema.optional(),
     })
     .optional(),
+  /**
+   * One-off match-option override for this single-case run only. Does
+   * NOT mutate the persisted case's `matchOptions`.
+   */
+  matchOptionsOverride: matchOptionsSchema.optional(),
 });
 
 export type RunTestCaseRequest = z.infer<typeof RunTestCaseRequestSchema>;
@@ -224,6 +242,28 @@ export const GenerateNegativeTestsRequestSchema = z.object({
 export type GenerateNegativeTestsRequest = z.infer<
   typeof GenerateNegativeTestsRequestSchema
 >;
+
+/**
+ * Best-effort fetch of a suite's `defaultMatchOptions` so single-case
+ * runs resolve the same suite → case → override precedence chain that
+ * `precreateIterationsForRun` applies for suite-level runs.
+ * Returns undefined on any error; defaults still apply downstream.
+ */
+async function loadSuiteDefaultMatchOptions(
+  convexClient: ConvexHttpClient,
+  suiteId?: string,
+): Promise<MatchOptionsDTO | undefined> {
+  if (!suiteId) return undefined;
+  try {
+    const suite = await convexClient.query("testSuites:getTestSuite" as any, {
+      suiteId,
+    });
+    return (suite?.defaultMatchOptions as MatchOptionsDTO | undefined) ??
+      undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 function createConvexClients(convexAuthToken: string) {
   const convexUrl = process.env.CONVEX_URL;
@@ -364,6 +404,7 @@ export async function runEvalsWithManager(
     passCriteria,
     suiteRerun,
     iterationOverride,
+    matchOptionsOverride,
   } = request;
 
   if (!suiteId && (!suiteName || suiteName.trim().length === 0)) {
@@ -419,6 +460,7 @@ export async function runEvalsWithManager(
       promptTurns?: PromptTurn[];
       judgeRequirement?: string;
       advancedConfig?: any;
+      matchOptions?: import("@/shared/eval-matching").MatchOptionsDTO;
     }
   >();
 
@@ -436,6 +478,7 @@ export async function runEvalsWithManager(
         expectedOutput: test.expectedOutput,
         promptTurns: test.promptTurns,
         advancedConfig: test.advancedConfig,
+        matchOptions: test.matchOptions,
       });
     }
     testCaseMap.get(key)!.models.push({
@@ -513,6 +556,11 @@ export async function runEvalsWithManager(
             normalizeForComparison(existingTestCase.advancedConfig),
           ) !==
           JSON.stringify(normalizeForComparison(testCaseData.advancedConfig));
+        const matchOptionsChanged =
+          JSON.stringify(
+            normalizeForComparison(existingTestCase.matchOptions),
+          ) !==
+          JSON.stringify(normalizeForComparison(testCaseData.matchOptions));
 
         const hasChanges =
           modelsChanged ||
@@ -523,7 +571,8 @@ export async function runEvalsWithManager(
           expectedOutputChanged ||
           promptTurnsChanged ||
           judgeRequirementChanged ||
-          advancedConfigChanged;
+          advancedConfigChanged ||
+          matchOptionsChanged;
 
         if (hasChanges) {
           await convexClient.mutation("testSuites:updateTestCase" as any, {
@@ -540,6 +589,7 @@ export async function runEvalsWithManager(
             advancedConfig: sanitizeForConvexTransport(
               testCaseData.advancedConfig,
             ),
+            matchOptions: testCaseData.matchOptions,
           });
         }
       } else {
@@ -560,6 +610,7 @@ export async function runEvalsWithManager(
           advancedConfig: sanitizeForConvexTransport(
             testCaseData.advancedConfig,
           ),
+          matchOptions: testCaseData.matchOptions,
         });
       }
     }
@@ -598,6 +649,7 @@ export async function runEvalsWithManager(
         promptTurns: sanitizeForConvexTransport(testCaseData.promptTurns),
         judgeRequirement: testCaseData.judgeRequirement,
         advancedConfig: sanitizeForConvexTransport(testCaseData.advancedConfig),
+        matchOptions: testCaseData.matchOptions,
       });
     }
   }
@@ -611,6 +663,7 @@ export async function runEvalsWithManager(
     toolSnapshot,
     toolSnapshotDebug,
     iterationOverride,
+    matchOptionsOverride,
   });
 
   const replayConfigsToStore = filterAndRemapReplayConfigs(
@@ -726,6 +779,7 @@ export async function runEvalTestCaseWithManager(
     orgModelConfig,
     convexAuthToken,
     testCaseOverrides,
+    matchOptionsOverride,
   } = request;
 
   const resolvedServerIds = resolveServerIdsOrThrow(serverIds, clientManager);
@@ -743,6 +797,10 @@ export async function runEvalTestCaseWithManager(
     promptTurnsLength: testCase.promptTurns?.length,
   });
 
+  const suiteDefaultMatchOptions = await loadSuiteDefaultMatchOptions(
+    convexClient,
+    testCase.evalTestSuiteId,
+  );
   const test = {
     title: testCase.title,
     query: testCaseOverrides?.query ?? testCase.query,
@@ -760,6 +818,13 @@ export async function runEvalTestCaseWithManager(
       testCase.promptTurns,
     advancedConfig:
       testCaseOverrides?.advancedConfig ?? testCase.advancedConfig,
+    matchOptions: resolveMatchOptions(
+      suiteDefaultMatchOptions,
+      (testCaseOverrides?.matchOptions ?? testCase.matchOptions) as
+        | MatchOptionsDTO
+        | undefined,
+      matchOptionsOverride,
+    ),
     testCaseId: testCase._id,
   };
 
@@ -963,6 +1028,7 @@ export async function streamEvalTestCaseWithManager(
     orgModelConfig,
     convexAuthToken,
     testCaseOverrides,
+    matchOptionsOverride,
   } = request;
 
   const resolvedServerIds = resolveServerIdsOrThrow(serverIds, clientManager);
@@ -980,6 +1046,10 @@ export async function streamEvalTestCaseWithManager(
     promptTurnsLength: testCase.promptTurns?.length,
   });
 
+  const suiteDefaultMatchOptions = await loadSuiteDefaultMatchOptions(
+    convexClient,
+    testCase.evalTestSuiteId,
+  );
   const test = {
     title: testCase.title,
     query: testCaseOverrides?.query ?? testCase.query,
@@ -997,6 +1067,13 @@ export async function streamEvalTestCaseWithManager(
       testCase.promptTurns,
     advancedConfig:
       testCaseOverrides?.advancedConfig ?? testCase.advancedConfig,
+    matchOptions: resolveMatchOptions(
+      suiteDefaultMatchOptions,
+      (testCaseOverrides?.matchOptions ?? testCase.matchOptions) as
+        | MatchOptionsDTO
+        | undefined,
+      matchOptionsOverride,
+    ),
     testCaseId: testCase._id,
   };
 

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -97,6 +97,12 @@ export type EvalTestCase = {
     temperature?: number;
     toolChoice?: EvalToolChoice | string;
   } & Record<string, unknown>;
+  /**
+   * Effective per-iteration match options. Suite-level runs receive this
+   * pre-resolved from Convex `precreateIterationsForRun`; single-case
+   * runs resolve it in the route handler.
+   */
+  matchOptions?: import("@/shared/eval-matching").MatchOptionsDTO;
   testCaseId?: string;
 };
 
@@ -883,6 +889,7 @@ async function createIterationDirectly(
       expectedOutput?: string;
       promptTurns?: PromptTurn[];
       advancedConfig?: Record<string, unknown>;
+      matchOptions?: import("@/shared/eval-matching").MatchOptionsDTO;
     };
     iterationNumber: number;
     startedAt: number;
@@ -1133,6 +1140,7 @@ const runIterationWithAiSdk = async ({
             resolvedTest.promptTurns,
             [],
             test.isNegativeTest,
+            test.matchOptions,
           ),
           iterationId: undefined,
         };
@@ -1150,6 +1158,7 @@ const runIterationWithAiSdk = async ({
             resolvedTest.promptTurns,
             [],
             test.isNegativeTest,
+            test.matchOptions,
           ),
           iterationId: undefined,
         };
@@ -1202,6 +1211,7 @@ const runIterationWithAiSdk = async ({
       expectedOutput,
       promptTurns,
       advancedConfig,
+      matchOptions: test.matchOptions,
     },
     iterationNumber: runIndex + 1,
     startedAt: runStartedAt,
@@ -1384,6 +1394,7 @@ const runIterationWithAiSdk = async ({
       promptTurns,
       toolsCalledByPrompt,
       test.isNegativeTest,
+      test.matchOptions,
     );
     const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
 
@@ -1455,6 +1466,7 @@ const runIterationWithAiSdk = async ({
           promptTurns,
           toolsCalledByPrompt,
           test.isNegativeTest,
+          test.matchOptions,
         ),
         iterationId: undefined,
       };
@@ -1504,6 +1516,7 @@ const runIterationWithAiSdk = async ({
       promptTurns,
       toolsCalledByPrompt,
       test.isNegativeTest,
+      test.matchOptions,
     );
     const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
     const widgetSnapshots = await captureEvalTraceWidgetSnapshots({
@@ -1579,6 +1592,7 @@ const runIterationViaBackend = async ({
             resolvedTest.promptTurns,
             [],
             test.isNegativeTest,
+            test.matchOptions,
           ),
           iterationId: undefined,
         };
@@ -1596,6 +1610,7 @@ const runIterationViaBackend = async ({
             resolvedTest.promptTurns,
             [],
             test.isNegativeTest,
+            test.matchOptions,
           ),
           iterationId: undefined,
         };
@@ -1644,6 +1659,7 @@ const runIterationViaBackend = async ({
       expectedOutput,
       promptTurns,
       advancedConfig,
+      matchOptions: test.matchOptions,
     },
     iterationNumber: runIndex + 1,
     startedAt: runStartedAt,
@@ -1970,6 +1986,7 @@ const runIterationViaBackend = async ({
               promptTurns,
               toolsCalledByPrompt,
               test.isNegativeTest,
+              test.matchOptions,
             ),
             iterationId: undefined,
           };
@@ -2019,6 +2036,7 @@ const runIterationViaBackend = async ({
     promptTurns,
     toolsCalledByPrompt,
     test.isNegativeTest,
+    test.matchOptions,
   );
   const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
 
@@ -2148,6 +2166,7 @@ const runTestCase = async (params: {
             expectedOutput: resolvedTestForPrecreate.expectedOutput,
             promptTurns: resolvedTestForPrecreate.promptTurns,
             advancedConfig: resolvedTestForPrecreate.advancedConfig,
+            matchOptions: test.matchOptions,
           },
           iterationNumber: runIndex + 1,
           startedAt: precreatedAt,
@@ -2484,6 +2503,7 @@ const streamIterationWithAiSdk = async ({
             resolvedTest.promptTurns,
             [],
             test.isNegativeTest,
+            test.matchOptions,
           ),
           iterationId: undefined,
         };
@@ -2500,6 +2520,7 @@ const streamIterationWithAiSdk = async ({
             resolvedTest.promptTurns,
             [],
             test.isNegativeTest,
+            test.matchOptions,
           ),
           iterationId: undefined,
         };
@@ -2552,6 +2573,7 @@ const streamIterationWithAiSdk = async ({
       expectedOutput,
       promptTurns,
       advancedConfig,
+      matchOptions: test.matchOptions,
     },
     iterationNumber: runIndex + 1,
     startedAt: runStartedAt,
@@ -2813,6 +2835,7 @@ const streamIterationWithAiSdk = async ({
       promptTurns,
       toolsCalledByPrompt,
       test.isNegativeTest,
+      test.matchOptions,
     );
     const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
 
@@ -2882,6 +2905,7 @@ const streamIterationWithAiSdk = async ({
           promptTurns,
           toolsCalledByPrompt,
           test.isNegativeTest,
+          test.matchOptions,
         ),
         iterationId: undefined,
       };
@@ -2931,6 +2955,7 @@ const streamIterationWithAiSdk = async ({
       promptTurns,
       toolsCalledByPrompt,
       test.isNegativeTest,
+      test.matchOptions,
     );
     const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
     const widgetSnapshots = await captureEvalTraceWidgetSnapshots({
@@ -3035,6 +3060,7 @@ const streamIterationViaBackend = async ({
             resolvedTest.promptTurns,
             [],
             test.isNegativeTest,
+            test.matchOptions,
           ),
           iterationId: undefined,
         };
@@ -3051,6 +3077,7 @@ const streamIterationViaBackend = async ({
             resolvedTest.promptTurns,
             [],
             test.isNegativeTest,
+            test.matchOptions,
           ),
           iterationId: undefined,
         };
@@ -3099,6 +3126,7 @@ const streamIterationViaBackend = async ({
       expectedOutput,
       promptTurns,
       advancedConfig,
+      matchOptions: test.matchOptions,
     },
     iterationNumber: runIndex + 1,
     startedAt: runStartedAt,
@@ -3622,6 +3650,7 @@ const streamIterationViaBackend = async ({
               promptTurns,
               toolsCalledByPrompt,
               test.isNegativeTest,
+              test.matchOptions,
             ),
             iterationId: undefined,
           };
@@ -3703,6 +3732,7 @@ const streamIterationViaBackend = async ({
     promptTurns,
     toolsCalledByPrompt,
     test.isNegativeTest,
+    test.matchOptions,
   );
   const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
 
@@ -3837,6 +3867,7 @@ export const streamTestCase = async (params: {
             expectedOutput: resolvedTestForPrecreate.expectedOutput,
             promptTurns: resolvedTestForPrecreate.promptTurns,
             advancedConfig: resolvedTestForPrecreate.advancedConfig,
+            matchOptions: test.matchOptions,
           },
           iterationNumber: runIndex + 1,
           startedAt: precreatedAt,

--- a/mcpjam-inspector/server/services/evals/recorder.ts
+++ b/mcpjam-inspector/server/services/evals/recorder.ts
@@ -298,6 +298,7 @@ export const startSuiteRunWithRecorder = async ({
   toolSnapshot,
   toolSnapshotDebug,
   iterationOverride,
+  matchOptionsOverride,
 }: {
   convexClient: ConvexHttpClient;
   suiteId: string;
@@ -323,6 +324,12 @@ export const startSuiteRunWithRecorder = async ({
    * `testCase.runs` is untouched.
    */
   iterationOverride?: number;
+  /**
+   * One-off match-option override for this run only. Convex
+   * `precreateIterationsForRun` resolves it on top of suite default +
+   * case override into each iteration's `testCaseSnapshot.matchOptions`.
+   */
+  matchOptionsOverride?: import("@/shared/eval-matching").MatchOptionsDTO;
 }) => {
   const response = await convexClient.mutation(
     "testSuites:startTestSuiteRun" as any,
@@ -336,6 +343,7 @@ export const startSuiteRunWithRecorder = async ({
       toolSnapshot: sanitizeForConvexTransport(toolSnapshot),
       toolSnapshotDebug: sanitizeForConvexTransport(toolSnapshotDebug),
       iterationOverride,
+      matchOptionsOverride,
     },
   );
 
@@ -372,6 +380,7 @@ export const startSuiteRunWithRecorder = async ({
           expectedOutput: tc.expectedOutput,
           promptTurns: tc.promptTurns,
           advancedConfig: tc.advancedConfig,
+          matchOptions: tc.matchOptions,
           testCaseId: tc._id,
         }));
       }
@@ -389,6 +398,7 @@ export const startSuiteRunWithRecorder = async ({
             expectedOutput: tc.expectedOutput,
             promptTurns: tc.promptTurns,
             advancedConfig: tc.advancedConfig,
+            matchOptions: tc.matchOptions,
             testCaseId: tc.testCaseId ?? tc._id,
           },
         ];

--- a/mcpjam-inspector/server/services/evals/types.ts
+++ b/mcpjam-inspector/server/services/evals/types.ts
@@ -102,16 +102,38 @@ export const evaluateMultiTurnResults = (
       }
 
       if (turn.expectedToolCalls.length === 0) {
+        // When the turn has no expected calls, only short-circuit if extras
+        // are allowed. With allowExtraToolCalls=false, any actual call on this
+        // turn is an unexpected extra that must fail evaluation.
+        if (matchOptions?.allowExtraToolCalls !== false) {
+          return {
+            promptIndex,
+            prompt: turn.prompt,
+            expectedToolCalls: turn.expectedToolCalls,
+            actualToolCalls,
+            expectedOutput: turn.expectedOutput,
+            missing: [],
+            unexpected: [],
+            argumentMismatches: [],
+            passed: true,
+          };
+        }
+        const evaluation = evaluateResults(
+          [],
+          actualToolCalls,
+          undefined,
+          matchOptions,
+        );
         return {
           promptIndex,
           prompt: turn.prompt,
           expectedToolCalls: turn.expectedToolCalls,
           actualToolCalls,
           expectedOutput: turn.expectedOutput,
-          missing: [],
-          unexpected: [],
-          argumentMismatches: [],
-          passed: true,
+          missing: evaluation.missing,
+          unexpected: evaluation.unexpected,
+          argumentMismatches: evaluation.argumentMismatches,
+          passed: evaluation.passed,
         };
       }
 
@@ -137,14 +159,18 @@ export const evaluateMultiTurnResults = (
 
   const assertedSummaries = isNegativeTest
     ? promptSummaries
-    : promptSummaries.filter((summary) => summary.expectedToolCalls.length > 0);
+    : promptSummaries.filter(
+        // Include turns that either declared expectations OR failed at
+        // evaluation time (e.g. strict-extras turn with 0 expected calls but
+        // actual calls present). The latter would otherwise be silently
+        // dropped from the aggregate pass/fail roll-up.
+        (summary) => summary.expectedToolCalls.length > 0 || !summary.passed,
+      );
   const failedSummaries = assertedSummaries.filter(
     (summary) => !summary.passed,
   );
-  const firstFailedTurn = promptSummaries.find((summary) =>
-    isNegativeTest
-      ? !summary.passed
-      : summary.expectedToolCalls.length > 0 && !summary.passed,
+  const firstFailedTurn = promptSummaries.find(
+    (summary) => !summary.passed,
   );
 
   return {

--- a/mcpjam-inspector/server/services/evals/types.ts
+++ b/mcpjam-inspector/server/services/evals/types.ts
@@ -102,10 +102,16 @@ export const evaluateMultiTurnResults = (
       }
 
       if (turn.expectedToolCalls.length === 0) {
-        // When the turn has no expected calls, only short-circuit if extras
-        // are allowed. With allowExtraToolCalls=false, any actual call on this
-        // turn is an unexpected extra that must fail evaluation.
-        if (matchOptions?.allowExtraToolCalls !== false) {
+        // A turn with no expectations should normally pass. The one exception
+        // is strict extras (`allowExtraToolCalls === false`) when the model
+        // *did* make calls on this turn — those calls are unexpected extras
+        // and must fail. We can't route through `evaluateResults` for the
+        // empty-actual case because the SDK matcher fails positive
+        // both-empty by design.
+        if (
+          matchOptions?.allowExtraToolCalls === false &&
+          actualToolCalls.length > 0
+        ) {
           return {
             promptIndex,
             prompt: turn.prompt,
@@ -113,27 +119,21 @@ export const evaluateMultiTurnResults = (
             actualToolCalls,
             expectedOutput: turn.expectedOutput,
             missing: [],
-            unexpected: [],
+            unexpected: actualToolCalls,
             argumentMismatches: [],
-            passed: true,
+            passed: false,
           };
         }
-        const evaluation = evaluateResults(
-          [],
-          actualToolCalls,
-          undefined,
-          matchOptions,
-        );
         return {
           promptIndex,
           prompt: turn.prompt,
           expectedToolCalls: turn.expectedToolCalls,
           actualToolCalls,
           expectedOutput: turn.expectedOutput,
-          missing: evaluation.missing,
-          unexpected: evaluation.unexpected,
-          argumentMismatches: evaluation.argumentMismatches,
-          passed: evaluation.passed,
+          missing: [],
+          unexpected: [],
+          argumentMismatches: [],
+          passed: true,
         };
       }
 

--- a/mcpjam-inspector/server/services/evals/types.ts
+++ b/mcpjam-inspector/server/services/evals/types.ts
@@ -1,5 +1,6 @@
 import {
-  matchToolCalls,
+  evaluateToolCalls,
+  type EvalMatchOptions,
   type ToolCall,
   type ArgumentMismatch,
 } from "@/shared/eval-matching";
@@ -45,25 +46,25 @@ export const evaluateResults = (
   expectedToolCalls: ToolCall[],
   toolsCalled: ToolCall[],
   isNegativeTest?: boolean,
+  matchOptions?: EvalMatchOptions,
 ): EvaluationResult => {
   const normalizedExpected = Array.isArray(expectedToolCalls)
     ? expectedToolCalls
     : [];
   const normalizedCalled = Array.isArray(toolsCalled) ? toolsCalled : [];
 
-  const matchResult = matchToolCalls(
-    normalizedExpected,
-    normalizedCalled,
+  const result = evaluateToolCalls(normalizedExpected, normalizedCalled, {
+    ...matchOptions,
     isNegativeTest,
-  );
+  });
 
   return {
     expectedToolCalls: normalizedExpected,
     toolsCalled: normalizedCalled,
-    missing: matchResult.missing,
-    unexpected: matchResult.unexpected,
-    argumentMismatches: matchResult.argumentMismatches,
-    passed: matchResult.passed,
+    missing: result.missing,
+    unexpected: result.extra,
+    argumentMismatches: result.argumentMismatches,
+    passed: result.passed,
   };
 };
 
@@ -71,6 +72,7 @@ export const evaluateMultiTurnResults = (
   promptTurns: PromptTurn[],
   toolsCalledByPrompt: ToolCall[][],
   isNegativeTest?: boolean,
+  matchOptions?: EvalMatchOptions,
 ): MultiTurnEvaluationResult => {
   const normalizedTurns = Array.isArray(promptTurns) ? promptTurns : [];
   const promptSummaries: PromptTurnEvaluation[] = normalizedTurns.map(
@@ -80,7 +82,12 @@ export const evaluateMultiTurnResults = (
         : [];
 
       if (isNegativeTest) {
-        const evaluation = evaluateResults([], actualToolCalls, true);
+        const evaluation = evaluateResults(
+          [],
+          actualToolCalls,
+          true,
+          matchOptions,
+        );
         return {
           promptIndex,
           prompt: turn.prompt,
@@ -111,6 +118,8 @@ export const evaluateMultiTurnResults = (
       const evaluation = evaluateResults(
         turn.expectedToolCalls,
         actualToolCalls,
+        undefined,
+        matchOptions,
       );
       return {
         promptIndex,

--- a/mcpjam-inspector/shared/eval-matching.ts
+++ b/mcpjam-inspector/shared/eval-matching.ts
@@ -14,8 +14,11 @@
  *     `"string"` matches any string)
  */
 
+import { z } from "zod";
 import {
   evaluateToolCalls,
+  MATCH_OPTIONS_DEFAULTS,
+  resolveMatchOptions,
   type EvalArgumentMismatch,
   type EvalMatchOptions,
   type EvalOutOfOrderToolCall,
@@ -26,6 +29,25 @@ import {
 export type ToolCall = EvalToolCall;
 export type ArgumentMismatch = EvalArgumentMismatch;
 export type OutOfOrderToolCall = EvalOutOfOrderToolCall;
+
+/**
+ * Zod schema mirroring `EvalMatchOptions` for transport boundaries
+ * (HTTP request bodies, Convex args). Keep field names + value enums in
+ * lockstep with `@mcpjam/sdk/matchers`.
+ */
+export const matchOptionsSchema = z
+  .object({
+    toolCallOrder: z.enum(["ignore", "strict"]).optional(),
+    allowExtraToolCalls: z.boolean().optional(),
+    argumentMatching: z.enum(["exact", "partial", "ignore"]).optional(),
+  })
+  .strict();
+
+/**
+ * Transport DTO — narrow Pick from the SDK type so server/client wire
+ * payloads import a stable name from this boundary module.
+ */
+export type MatchOptionsDTO = z.infer<typeof matchOptionsSchema>;
 
 /**
  * Inspector-shaped result that the existing tests + UI consume.
@@ -43,7 +65,7 @@ export type ToolCallMatchResult = {
 };
 
 export type { EvalMatchOptions, EvalToolCallMatchResult };
-export { evaluateToolCalls };
+export { evaluateToolCalls, MATCH_OPTIONS_DEFAULTS, resolveMatchOptions };
 
 /**
  * Compatibility alias for the inspector's historical matcher.

--- a/sdk/src/eval-reporting-types.ts
+++ b/sdk/src/eval-reporting-types.ts
@@ -1,4 +1,5 @@
 import type { MCPClientManager } from "./mcp-client-manager/MCPClientManager.js";
+import type { EvalMatchOptions } from "./matchers.js";
 
 export type EvalExpectedToolCall = {
   toolName: string;
@@ -96,6 +97,12 @@ export type EvalResultInput = {
   isNegativeTest?: boolean;
   advancedConfig?: Record<string, unknown>;
   widgetSnapshots?: EvalWidgetSnapshotInput[];
+  /**
+   * Per-result match options. When present, the inspector snapshots
+   * these onto the appended iteration's `testCaseSnapshot.matchOptions`
+   * so historical pass/fail computation honors them.
+   */
+  matchOptions?: EvalMatchOptions;
 };
 
 export type MCPServerReplayConfig = {

--- a/sdk/src/matchers.ts
+++ b/sdk/src/matchers.ts
@@ -67,6 +67,41 @@ export type EvalToolCallMatchResult = {
   passed: boolean;
 };
 
+/**
+ * Canonical defaults for {@link EvalMatchOptions}. Exported so the
+ * inspector server, client, and tests share a single source of truth
+ * with `evaluateToolCalls` instead of redefining the same literals.
+ */
+export const MATCH_OPTIONS_DEFAULTS: Required<EvalMatchOptions> = {
+  toolCallOrder: "ignore",
+  allowExtraToolCalls: true,
+  argumentMatching: "partial",
+};
+
+/**
+ * Merge match options from suite → case → run-override layers on top of
+ * defaults. `undefined` fields inherit from the next layer; explicit
+ * values win at their layer. Returns a fully-populated options object
+ * suitable to snapshot or pass directly to `evaluateToolCalls`.
+ */
+export function resolveMatchOptions(
+  suite?: EvalMatchOptions,
+  testCase?: EvalMatchOptions,
+  runOverride?: EvalMatchOptions,
+): Required<EvalMatchOptions> {
+  const merged: Required<EvalMatchOptions> = { ...MATCH_OPTIONS_DEFAULTS };
+  for (const layer of [suite, testCase, runOverride]) {
+    if (!layer) continue;
+    if (layer.toolCallOrder !== undefined)
+      merged.toolCallOrder = layer.toolCallOrder;
+    if (layer.allowExtraToolCalls !== undefined)
+      merged.allowExtraToolCalls = layer.allowExtraToolCalls;
+    if (layer.argumentMatching !== undefined)
+      merged.argumentMatching = layer.argumentMatching;
+  }
+  return merged;
+}
+
 type ArgumentPlaceholder =
   | "any"
   | "string"
@@ -191,9 +226,12 @@ export function evaluateToolCalls(
   const normalizedExpected = Array.isArray(expected) ? expected : [];
   const normalizedActual = Array.isArray(actual) ? actual : [];
 
-  const toolCallOrder = options?.toolCallOrder ?? "ignore";
-  const allowExtraToolCalls = options?.allowExtraToolCalls ?? true;
-  const argumentMatching = options?.argumentMatching ?? "partial";
+  const toolCallOrder =
+    options?.toolCallOrder ?? MATCH_OPTIONS_DEFAULTS.toolCallOrder;
+  const allowExtraToolCalls =
+    options?.allowExtraToolCalls ?? MATCH_OPTIONS_DEFAULTS.allowExtraToolCalls;
+  const argumentMatching =
+    options?.argumentMatching ?? MATCH_OPTIONS_DEFAULTS.argumentMatching;
 
   if (options?.isNegativeTest) {
     return {

--- a/sdk/tests/matchers.test.ts
+++ b/sdk/tests/matchers.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { evaluateToolCalls } from "../src/matchers.js";
+import {
+  evaluateToolCalls,
+  MATCH_OPTIONS_DEFAULTS,
+  resolveMatchOptions,
+} from "../src/matchers.js";
 import type { EvalToolCall } from "../src/matchers.js";
 
 const tc = (toolName: string, args: Record<string, unknown> = {}): EvalToolCall => ({
@@ -223,5 +227,63 @@ describe("evaluateToolCalls — negative tests", () => {
     });
     expect(result.passed).toBe(false);
     expect(result.extra.map((c) => c.toolName)).toEqual(["a"]);
+  });
+});
+
+describe("MATCH_OPTIONS_DEFAULTS", () => {
+  it("matches the inline defaults documented for evaluateToolCalls", () => {
+    expect(MATCH_OPTIONS_DEFAULTS).toEqual({
+      toolCallOrder: "ignore",
+      allowExtraToolCalls: true,
+      argumentMatching: "partial",
+    });
+  });
+});
+
+describe("resolveMatchOptions precedence", () => {
+  it("returns defaults when every layer is undefined", () => {
+    expect(resolveMatchOptions()).toEqual(MATCH_OPTIONS_DEFAULTS);
+  });
+
+  it("suite < case < run override", () => {
+    const merged = resolveMatchOptions(
+      { toolCallOrder: "strict" },
+      { argumentMatching: "exact" },
+      { allowExtraToolCalls: false },
+    );
+    expect(merged).toEqual({
+      toolCallOrder: "strict",
+      argumentMatching: "exact",
+      allowExtraToolCalls: false,
+    });
+  });
+
+  it("run override wins over case override on overlapping fields", () => {
+    const merged = resolveMatchOptions(
+      undefined,
+      { toolCallOrder: "ignore", argumentMatching: "exact" },
+      { toolCallOrder: "strict" },
+    );
+    expect(merged.toolCallOrder).toBe("strict");
+    expect(merged.argumentMatching).toBe("exact");
+  });
+
+  it("case override wins over suite default on overlapping fields", () => {
+    const merged = resolveMatchOptions(
+      { allowExtraToolCalls: true },
+      { allowExtraToolCalls: false },
+      undefined,
+    );
+    expect(merged.allowExtraToolCalls).toBe(false);
+  });
+
+  it("treats explicit undefined fields as inherit (does not clobber lower layers)", () => {
+    const merged = resolveMatchOptions(
+      { toolCallOrder: "strict" },
+      { toolCallOrder: undefined, argumentMatching: "exact" },
+      undefined,
+    );
+    expect(merged.toolCallOrder).toBe("strict");
+    expect(merged.argumentMatching).toBe("exact");
   });
 });


### PR DESCRIPTION
## Summary
- Adds layered eval match options: **suite default → case override → run override**, resolved into a single `Required<EvalMatchOptions>` at evaluation time.
- New SDK exports `MATCH_OPTIONS_DEFAULTS` + `resolveMatchOptions` so the inspector server, client, and tests share one source of truth (no change to existing `evaluateToolCalls` signature).
- New zod `matchOptionsSchema` + `MatchOptionsDTO` at the shared transport boundary; inspector server threads options through recorder/runner/routes.
- New `ValidatorsSection` + `RunValidatorsPopover` UI: validators icon on the suite header lets the user override `Tool order`, `Extra tool calls`, and `Args` for the next run without persisting.

## Companion
Backend schema/resolution changes ride in a separate PR against `MCPJam/mcpjam-backend` (new `defaultMatchOptions` on suites, `matchOptions` on cases, `matchOptionsOverride` on runs).

## Test plan
- [ ] `bun test` for SDK matchers (new defaults + resolver paths)
- [ ] Vitest suite for `pass-criteria-match-options` and `validators-section`
- [ ] Manual: open suite header → Validators popover → flip each dropdown → confirm "Run all" sends override and badge appears; "Reset" clears the override
- [ ] Manual: case-level override still takes effect when run override is unset
- [ ] Manual: pre-existing suites without `defaultMatchOptions` still resolve to defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates eval pass/fail semantics and threads new match-option fields through client, server routes, and SDK matcher exports; mistakes could change historical results or run behavior, but changes are scoped to eval tooling.
> 
> **Overview**
> Adds **layered tool-call validator options** (suite default → case override → one-off run override) and snapshots the resolved `matchOptions` onto iterations so pass/fail computation honors the settings.
> 
> Introduces new UI controls (`ValidatorsSection` + `RunValidatorsPopover`) to edit suite defaults and apply a transient override for the next run, and updates run triggers (`SuiteHeader`, single-case runner, `useEvalHandlers`) to forward `matchOptionsOverride` alongside `iterationOverride`.
> 
> Extends the SDK/shared boundary with `MATCH_OPTIONS_DEFAULTS`, `resolveMatchOptions`, and a transport `matchOptionsSchema`/`MatchOptionsDTO`, then propagates these fields through server eval request schemas and runner/recorder types; updates pass-criteria evaluation to use `evaluateToolCalls` and enforce strict ordering/extras rules when configured, with new tests covering these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2ba6f3c252bbd1533be48d9dee6307d2e9f6b8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->