### PR TITLE
fix(docs): use latest release URLs for desktop downloads (#1823)

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -11,7 +11,7 @@ MCPJam Inspector runs three ways: a hosted web app, a desktop app for Mac and Wi
     Open [app.mcpjam.com](https://app.mcpjam.com). HTTPS only. No install. Share servers with your team.
   </Card>
   <Card title="Desktop App" icon="monitor">
-    Download for [Mac](https://github.com/MCPJam/inspector/releases/download/v2.2.0/MCPJam.Inspector.dmg) or [Windows](https://github.com/MCPJam/inspector/releases/download/v2.2.0/MCPJam-Inspector-Setup.exe). HTTP/S and local STDIO.
+    Download for [Mac](https://github.com/MCPJam/inspector/releases/latest/download/MCPJam.Inspector.dmg) or [Windows](https://github.com/MCPJam/inspector/releases/latest/download/MCPJam-Inspector-Setup.exe). HTTP/S and local STDIO.
   </Card>
   <Card title="Terminal" icon="terminal">
     `npx @mcpjam/inspector@latest`. HTTP/S and local STDIO.
@@ -26,8 +26,8 @@ Go to [app.mcpjam.com](https://app.mcpjam.com) in your browser. No install requi
 
 Download the installer for your OS and run it:
 
-- [Mac](https://github.com/MCPJam/inspector/releases/download/v2.2.0/MCPJam.Inspector.dmg)
-- [Windows](https://github.com/MCPJam/inspector/releases/download/v2.2.0/MCPJam-Inspector-Setup.exe)
+- [Mac](https://github.com/MCPJam/inspector/releases/latest/download/MCPJam.Inspector.dmg)
+- [Windows](https://github.com/MCPJam/inspector/releases/latest/download/MCPJam-Inspector-Setup.exe)
 
 The desktop app supports HTTP/S and local STDIO servers, and does not require Node.js.
 


### PR DESCRIPTION
## Summary

- Replace hardcoded `v2.2.0` download URLs in `docs/installation.mdx` with `/releases/latest/download/` pattern
- Affects Mac (`.dmg`) and Windows (`.exe`) download links in both the card and the download section
- Matches the URL pattern already used in `README.md`

Fixes #1823

## Test plan

- Verified both `/releases/latest/download/MCPJam.Inspector.dmg` and `/releases/latest/download/MCPJam-Inspector-Setup.exe` return 302 redirects to current release assets (v2.4.9)
- No remaining hardcoded version strings in download URLs