### PR TITLE
fix(evals): pass custom provider configs through eval pipeline

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/eval-runner.tsx
+++ b/mcpjam-inspector/client/src/components/evals/eval-runner.tsx
@@ -16,6 +16,7 @@ import {
   useAiProviderKeys,
   type ProviderTokens,
 } from "@/hooks/use-ai-provider-keys";
+import { useCustomProviders } from "@/hooks/use-custom-providers";
 import { cn } from "@/lib/utils";
 import { ModelDefinition, isMCPJamProvidedModel } from "@/shared/types";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
@@ -102,7 +103,7 @@ const validateExpectedToolCalls = (toolCalls: ExpectedToolCall[]): boolean => {
 };
 
 function getFirstPromptTurn(
-  promptTurns: PromptTurn[] | undefined,
+  promptTurns: PromptTurn[] | undefined
 ): PromptTurn | undefined {
   return Array.isArray(promptTurns) && promptTurns.length > 0
     ? promptTurns[0]
@@ -110,7 +111,7 @@ function getFirstPromptTurn(
 }
 
 function promptTurnsRepresentNegativeCase(
-  promptTurns: PromptTurn[] | undefined,
+  promptTurns: PromptTurn[] | undefined
 ): boolean {
   return (
     Array.isArray(promptTurns) &&
@@ -121,7 +122,7 @@ function promptTurnsRepresentNegativeCase(
 
 function mapGeneratedTemplate(
   test: GeneratedEvalTestCase,
-  index: number,
+  index: number
 ): TestTemplate {
   const promptTurns =
     Array.isArray(test.promptTurns) && test.promptTurns.length > 0
@@ -136,8 +137,8 @@ function mapGeneratedTemplate(
     expectedToolCalls: firstTurn?.expectedToolCalls
       ? firstTurn.expectedToolCalls
       : Array.isArray(test.expectedToolCalls)
-        ? test.expectedToolCalls
-        : [],
+      ? test.expectedToolCalls
+      : [],
     isNegativeTest:
       test.isNegativeTest === true ||
       promptTurnsRepresentNegativeCase(promptTurns),
@@ -172,6 +173,7 @@ export function EvalRunner({
   const { getAccessToken } = useAuth();
   const appState = useSharedAppState();
   const { getToken, hasToken } = useAiProviderKeys();
+  const { customProviders, getCustomProviderByName } = useCustomProviders();
 
   // Initialize with preselected server if provided
   const [selectedServers, setSelectedServers] = useState<string[]>(() => {
@@ -187,7 +189,7 @@ export function EvalRunner({
   const [modelTab, setModelTab] = useState<"mcpjam" | "yours">("mcpjam");
   // Auto-name suite after server if preselected
   const [suiteName, setSuiteName] = useState(
-    hasPreselectedServer ? preselectedServer : "",
+    hasPreselectedServer ? preselectedServer : ""
   );
   const [suiteDescription, setSuiteDescription] = useState("");
   const [showNameError, setShowNameError] = useState(false);
@@ -196,20 +198,20 @@ export function EvalRunner({
 
   // Pass/fail criteria state
   const [minimumPassRate, setMinimumPassRate] = useState<number>(
-    DEFAULTS.MIN_PASS_RATE,
+    DEFAULTS.MIN_PASS_RATE
   );
 
   const connectedServers = useMemo(
     () =>
       Object.entries(appState.servers).filter(
-        ([, server]) => server.connectionStatus === "connected",
+        ([, server]) => server.connectionStatus === "connected"
       ),
-    [appState.servers],
+    [appState.servers]
   );
 
   const connectedServerNames = useMemo(
     () => new Set(connectedServers.map(([name]) => name)),
-    [connectedServers],
+    [connectedServers]
   );
 
   useEffect(() => {
@@ -247,7 +249,7 @@ export function EvalRunner({
 
     if (savedPreferences.servers?.length) {
       const filtered = savedPreferences.servers.filter((server) =>
-        connectedServerNames.has(server),
+        connectedServerNames.has(server)
       );
       if (filtered.length) {
         setSelectedServers(filtered);
@@ -266,7 +268,7 @@ export function EvalRunner({
     // Suite defaultConfig takes precedence over stored preferences when present
     if (defaultModelId) {
       const suiteDefault = availableModels.find(
-        (m) => String(m.id) === defaultModelId,
+        (m) => String(m.id) === defaultModelId
       );
       if (suiteDefault) {
         setSelectedModels([suiteDefault]);
@@ -277,7 +279,7 @@ export function EvalRunner({
 
     if (savedPreferences?.modelIds && savedPreferences.modelIds.length > 0) {
       const matches = availableModels.filter((model) =>
-        savedPreferences.modelIds.includes(model.id),
+        savedPreferences.modelIds.includes(model.id)
       );
       if (matches.length > 0) {
         setSelectedModels(matches);
@@ -285,7 +287,12 @@ export function EvalRunner({
     }
 
     setHasRestoredPreferences(true);
-  }, [availableModels, savedPreferences, hasRestoredPreferences, defaultModelId]);
+  }, [
+    availableModels,
+    savedPreferences,
+    hasRestoredPreferences,
+    defaultModelId,
+  ]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -299,7 +306,7 @@ export function EvalRunner({
       };
       localStorage.setItem(
         STORAGE_KEYS.EVAL_RUNNER_PREFERENCES,
-        JSON.stringify(payload),
+        JSON.stringify(payload)
       );
     } catch (error) {
       console.warn("Failed to persist eval runner preferences", error);
@@ -338,14 +345,19 @@ export function EvalRunner({
 
   const validTestTemplates = useMemo(
     () => testTemplates.filter((template) => template.query.trim().length > 0),
-    [testTemplates],
+    [testTemplates]
   );
 
   const stepCompletion = useMemo(() => {
     // Check that all selected models have credentials
     const allModelsHaveCredentials = selectedModels.every((model) => {
       const isJam = isMCPJamProvidedModel(model.id);
-      return isJam || hasToken(model.provider as keyof ProviderTokens);
+      if (isJam) return true;
+      if (model.provider === "custom" && model.customProviderName) {
+        const cp = getCustomProviderByName(model.customProviderName);
+        return Boolean(cp?.apiKey);
+      }
+      return hasToken(model.provider as keyof ProviderTokens);
     });
 
     // Check if all valid test templates are properly configured
@@ -368,7 +380,13 @@ export function EvalRunner({
       model: selectedModels.length > 0 && allModelsHaveCredentials,
       tests: validTestTemplates.length > 0 && allTestsAreValid,
     };
-  }, [selectedServers, selectedModels, validTestTemplates, hasToken]);
+  }, [
+    selectedServers,
+    selectedModels,
+    validTestTemplates,
+    hasToken,
+    getCustomProviderByName,
+  ]);
 
   const highestAvailableStep = useMemo(() => {
     if (!stepCompletion.servers) return 0;
@@ -427,7 +445,7 @@ export function EvalRunner({
   const handleUpdateTestTemplate = <K extends keyof TestTemplate>(
     index: number,
     field: K,
-    value: TestTemplate[K],
+    value: TestTemplate[K]
   ) => {
     setTestTemplates((prev) => {
       const next = [...prev];
@@ -503,13 +521,13 @@ export function EvalRunner({
         setTestTemplates(generatedTemplates);
         setCurrentStep(2);
         toast.success(
-          `Generated ${generatedTemplates.length} test template(s).`,
+          `Generated ${generatedTemplates.length} test template(s).`
         );
       }
     } catch (error) {
       console.error("Failed to generate tests:", error);
       toast.error(
-        getBillingErrorMessage(error, "Failed to generate test cases"),
+        getBillingErrorMessage(error, "Failed to generate test cases")
       );
     } finally {
       setIsGenerating(false);
@@ -555,13 +573,13 @@ export function EvalRunner({
         setTestTemplates((prev) => [...prev, ...generatedNegativeTemplates]);
         setCurrentStep(2);
         toast.success(
-          `Generated ${generatedNegativeTemplates.length} negative test template(s).`,
+          `Generated ${generatedNegativeTemplates.length} negative test template(s).`
         );
       }
     } catch (error) {
       console.error("Failed to generate negative tests:", error);
       toast.error(
-        getBillingErrorMessage(error, "Failed to generate negative test cases"),
+        getBillingErrorMessage(error, "Failed to generate negative test cases")
       );
     } finally {
       setIsGeneratingNegativeTests(false);
@@ -599,17 +617,32 @@ export function EvalRunner({
 
     // Collect API keys for all selected models
     const modelApiKeys: Record<string, string> = {};
+    const usesCustomProviders = selectedModels.some(
+      (m) => m.provider === "custom"
+    );
     for (const model of selectedModels) {
       if (!isMCPJamProvidedModel(model.id)) {
-        const key = getToken(model.provider as keyof ProviderTokens);
-        if (!key) {
-          toast.error(
-            `Please configure your ${model.provider} API key in Settings`,
-          );
-          setCurrentStep(1);
-          return;
+        if (model.provider === "custom" && model.customProviderName) {
+          const cp = getCustomProviderByName(model.customProviderName);
+          if (!cp?.apiKey) {
+            toast.error(
+              `Please configure an API key for custom provider "${model.customProviderName}" in Settings`
+            );
+            setCurrentStep(1);
+            return;
+          }
+          // Custom provider keys are sent via the customProviders config
+        } else {
+          const key = getToken(model.provider as keyof ProviderTokens);
+          if (!key) {
+            toast.error(
+              `Please configure your ${model.provider} API key in Settings`
+            );
+            setCurrentStep(1);
+            return;
+          }
+          modelApiKeys[model.provider] = key;
         }
-        modelApiKeys[model.provider] = key;
       }
     }
 
@@ -672,6 +705,15 @@ export function EvalRunner({
         tests: expandedTests,
         serverIds: selectedServers,
         modelApiKeys,
+        customProviders: usesCustomProviders
+          ? customProviders.map((cp) => ({
+              name: cp.name,
+              protocol: cp.protocol,
+              baseUrl: cp.baseUrl,
+              modelIds: cp.modelIds,
+              ...(cp.apiKey ? { apiKey: cp.apiKey } : {}),
+            }))
+          : undefined,
         convexAuthToken: accessToken,
         passCriteria: {
           minimumPassRate: minimumPassRate,
@@ -782,7 +824,7 @@ export function EvalRunner({
               disabled={!isSelectable}
               className={cn(
                 "flex flex-col items-center gap-2 transition",
-                !isSelectable && "cursor-not-allowed opacity-60",
+                !isSelectable && "cursor-not-allowed opacity-60"
               )}
             >
               <span
@@ -795,7 +837,7 @@ export function EvalRunner({
                     "border-primary bg-primary/10 text-primary",
                   !isActive &&
                     !isCompleted &&
-                    "border-border text-muted-foreground",
+                    "border-border text-muted-foreground"
                 )}
               >
                 {index + 1}
@@ -803,7 +845,7 @@ export function EvalRunner({
               <span
                 className={cn(
                   "text-xs leading-tight",
-                  isActive ? "text-foreground" : "text-muted-foreground",
+                  isActive ? "text-foreground" : "text-muted-foreground"
                 )}
               >
                 {step.title}
@@ -836,12 +878,12 @@ export function EvalRunner({
       const hasInvalidPositiveTests = validTestTemplates.some(
         (template) =>
           !template.isNegativeTest &&
-          !validateExpectedToolCalls(template.expectedToolCalls),
+          !validateExpectedToolCalls(template.expectedToolCalls)
       );
       const hasInvalidNegativeTests = validTestTemplates.some(
         (template) =>
           template.isNegativeTest &&
-          (!template.scenario?.trim() || !template.query.trim()),
+          (!template.scenario?.trim() || !template.query.trim())
       );
 
       if (hasInvalidPositiveTests) {
@@ -881,7 +923,7 @@ export function EvalRunner({
     <div
       className={cn(
         "mx-auto flex w-full flex-col gap-8 pb-10 pt-4",
-        inline ? "max-w-none px-4 sm:px-6 md:px-12 lg:px-32" : "max-w-3xl px-4",
+        inline ? "max-w-none px-4 sm:px-6 md:px-12 lg:px-32" : "max-w-3xl px-4"
       )}
     >
       <div className="flex flex-wrap items-center gap-4">
@@ -935,7 +977,7 @@ export function EvalRunner({
                           platform: detectPlatform(),
                           environment: detectEnvironment(),
                           step: currentStep,
-                        },
+                        }
                       );
                       void handleSubmit();
                     }
@@ -946,7 +988,7 @@ export function EvalRunner({
                   }
                   className={cn(
                     "justify-center gap-2",
-                    !nextDisabled && "shadow-sm",
+                    !nextDisabled && "shadow-sm"
                   )}
                 >
                   {currentStep === WIZARD_STEPS.length - 1 ? "Start" : "Next"}

--- a/mcpjam-inspector/client/src/lib/apis/evals-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/evals-api.ts
@@ -56,6 +56,13 @@ type RunEvalsRequest = EvalRequestWithServers & {
   tests: Array<Record<string, unknown>>;
   storageServerIds?: string[];
   modelApiKeys?: Record<string, string>;
+  customProviders?: Array<{
+    name: string;
+    protocol: string;
+    baseUrl: string;
+    modelIds: string[];
+    apiKey?: string;
+  }>;
   convexAuthToken?: string | null;
   notes?: string;
   passCriteria?: {
@@ -149,9 +156,9 @@ export function buildEvalConvexAuthPayload(convexAuthToken: string) {
 }
 
 function mergeHostedServerBatch<
-  T extends EvalRequestWithServers & { convexAuthToken?: string | null },
+  T extends EvalRequestWithServers & { convexAuthToken?: string | null }
 >(
-  request: T,
+  request: T
 ): Omit<T, "serverIds" | "convexAuthToken"> &
   ReturnType<typeof buildServerBatchRequest> {
   const hostedBatch = buildServerBatchRequest(request.serverIds);
@@ -169,7 +176,7 @@ function mergeHostedServerBatch<
 
 async function postEvalRequest<TResponse>(
   path: string,
-  payload: JsonRecord,
+  payload: JsonRecord
 ): Promise<TResponse> {
   const response = await authFetch(path, {
     method: "POST",
@@ -197,8 +204,8 @@ async function postEvalRequest<TResponse>(
       typeof errorBody?.message === "string"
         ? errorBody.message
         : typeof errorBody?.error === "string"
-          ? errorBody.error
-          : `Request failed (${response.status})`;
+        ? errorBody.error
+        : `Request failed (${response.status})`;
     const limitKind = (errorBody as { limitKind?: unknown } | null | undefined)
       ?.limitKind;
     notifyMCPJamLimitError({
@@ -217,7 +224,7 @@ async function postEvalRequest<TResponse>(
 }
 
 export async function listEvalTools(
-  request: EvalRequestWithServers,
+  request: EvalRequestWithServers
 ): Promise<ToolListResponse> {
   if (request.serverIds.length === 0) {
     return { tools: [] };
@@ -236,7 +243,7 @@ export async function listEvalTools(
             ...tool,
             serverId: serverNameOrId,
           }));
-        }),
+        })
       );
 
       return {
@@ -260,52 +267,52 @@ export async function runEvals(request: RunEvalsRequest): Promise<any> {
 }
 
 export async function runEvalTestCase(
-  request: RunTestCaseRequest,
+  request: RunTestCaseRequest
 ): Promise<any> {
   return runByMode({
     local: () =>
       postEvalRequest(
         EVALS_API_ENDPOINTS.local.runTestCase,
-        request as JsonRecord,
+        request as JsonRecord
       ),
     hosted: () =>
       postEvalRequest(
         EVALS_API_ENDPOINTS.hosted.runTestCase,
-        mergeHostedServerBatch(request) as JsonRecord,
+        mergeHostedServerBatch(request) as JsonRecord
       ),
   });
 }
 
 export async function generateEvalTests(
-  request: GenerateTestsRequest,
+  request: GenerateTestsRequest
 ): Promise<GenerateEvalTestsResponse> {
   return runByMode({
     local: () =>
       postEvalRequest(
         EVALS_API_ENDPOINTS.local.generateTests,
-        request as JsonRecord,
+        request as JsonRecord
       ),
     hosted: () =>
       postEvalRequest(
         EVALS_API_ENDPOINTS.hosted.generateTests,
-        mergeHostedServerBatch(request) as JsonRecord,
+        mergeHostedServerBatch(request) as JsonRecord
       ),
   });
 }
 
 export async function generateNegativeEvalTests(
-  request: GenerateTestsRequest,
+  request: GenerateTestsRequest
 ): Promise<GenerateEvalTestsResponse> {
   return runByMode({
     local: () =>
       postEvalRequest(
         EVALS_API_ENDPOINTS.local.generateNegativeTests,
-        request as JsonRecord,
+        request as JsonRecord
       ),
     hosted: () =>
       postEvalRequest(
         EVALS_API_ENDPOINTS.hosted.generateNegativeTests,
-        mergeHostedServerBatch(request) as JsonRecord,
+        mergeHostedServerBatch(request) as JsonRecord
       ),
   });
 }
@@ -327,7 +334,7 @@ export type StartTraceRepairParams =
     };
 
 export async function startTraceRepair(
-  params: StartTraceRepairParams,
+  params: StartTraceRepairParams
 ): Promise<{ success: boolean; jobId: string; existing?: boolean }> {
   return runByMode({
     local: () =>
@@ -359,14 +366,14 @@ export async function stopTraceRepair(jobId: string): Promise<void> {
 export async function streamEvalTestCase(
   request: RunTestCaseRequest,
   onEvent: (event: EvalStreamEvent) => void,
-  signal?: AbortSignal,
+  signal?: AbortSignal
 ): Promise<void> {
   const endpoint = isHostedMode()
     ? EVALS_API_ENDPOINTS.hosted.streamTestCase
     : EVALS_API_ENDPOINTS.local.streamTestCase;
 
   const payload = isHostedMode()
-    ? mergeHostedServerBatch(request) as JsonRecord
+    ? (mergeHostedServerBatch(request) as JsonRecord)
     : (request as JsonRecord);
 
   const response = await authFetch(endpoint, {

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -41,7 +41,7 @@ const promptTurnSchema = z.object({
     z.object({
       toolName: z.string(),
       arguments: z.record(z.string(), z.any()),
-    }),
+    })
   ),
   expectedOutput: z.string().optional(),
 });
@@ -62,7 +62,7 @@ export const RunEvalsRequestSchema = z.object({
         z.object({
           toolName: z.string(),
           arguments: z.record(z.string(), z.any()),
-        }),
+        })
       ),
       isNegativeTest: z.boolean().optional(),
       scenario: z.string().optional(),
@@ -76,7 +76,7 @@ export const RunEvalsRequestSchema = z.object({
         })
         .passthrough()
         .optional(),
-    }),
+    })
   ),
   serverIds: z
     .array(z.string())
@@ -86,6 +86,17 @@ export const RunEvalsRequestSchema = z.object({
   accessVersion: z.number().int().nonnegative().optional(),
   storageServerIds: z.array(z.string()).optional(),
   modelApiKeys: z.record(z.string(), z.string()).optional(),
+  customProviders: z
+    .array(
+      z.object({
+        name: z.string(),
+        protocol: z.string(),
+        baseUrl: z.string(),
+        modelIds: z.array(z.string()),
+        apiKey: z.string().optional(),
+      })
+    )
+    .optional(),
   convexAuthToken: z.string(),
   notes: z.string().optional(),
   passCriteria: z
@@ -157,7 +168,7 @@ export const MAX_TOTAL_LLM_CALLS = 300;
 
 export function assertSuiteRunWithinCap(
   request: RunEvalsRequest,
-  configCount = 1,
+  configCount = 1
 ) {
   const override = request.iterationOverride;
   // Each iteration issues one model call per prompt turn; counting only `runs`
@@ -173,7 +184,7 @@ export function assertSuiteRunWithinCap(
       400,
       ErrorCode.VALIDATION_ERROR,
       `Suite run would issue ${totalCalls} LLM calls, above the cap of ${MAX_TOTAL_LLM_CALLS}. Reduce iterations or test count.`,
-      { totalCalls, cap: MAX_TOTAL_LLM_CALLS },
+      { totalCalls, cap: MAX_TOTAL_LLM_CALLS }
     );
   }
 }
@@ -188,7 +199,7 @@ export function assertSuiteRunWithinCap(
 export function assertTestCaseRunWithinCap(
   request: RunTestCaseRequest,
   configCount = 1,
-  resolved?: { promptTurnsLength?: number },
+  resolved?: { promptTurnsLength?: number }
 ) {
   const iterations = request.testCaseOverrides?.runs ?? 1;
   const overrideTurns = request.testCaseOverrides?.promptTurns?.length;
@@ -200,7 +211,7 @@ export function assertTestCaseRunWithinCap(
       400,
       ErrorCode.VALIDATION_ERROR,
       `Test case run would issue ${totalCalls} LLM calls, above the cap of ${MAX_TOTAL_LLM_CALLS}.`,
-      { totalCalls, cap: MAX_TOTAL_LLM_CALLS },
+      { totalCalls, cap: MAX_TOTAL_LLM_CALLS }
     );
   }
 }
@@ -244,7 +255,7 @@ function createConvexClients(convexAuthToken: string) {
 
 export function resolveServerIdsOrThrow(
   requestedIds: string[],
-  clientManager: MCPClientManager,
+  clientManager: MCPClientManager
 ): string[] {
   const available = clientManager.listServers();
   const resolved: string[] = [];
@@ -258,7 +269,7 @@ export function resolveServerIdsOrThrow(
       throw new WebRouteError(
         404,
         ErrorCode.NOT_FOUND,
-        `Server '${requestedId}' not found`,
+        `Server '${requestedId}' not found`
       );
     }
 
@@ -287,7 +298,7 @@ function normalizeForComparison(obj: any): any {
 export function filterAndRemapReplayConfigs(
   replayConfigs: MCPServerReplayConfig[],
   resolvedServerIds: string[],
-  persistedServerIds: string[],
+  persistedServerIds: string[]
 ): MCPServerReplayConfig[] {
   const persistedIdByResolvedId = new Map<string, string>();
 
@@ -344,7 +355,7 @@ function buildPersistedSuiteEnvironment(args: {
 
 export async function runEvalsWithManager(
   clientManager: MCPClientManager,
-  request: RunEvalsWithManagerRequest,
+  request: RunEvalsWithManagerRequest
 ) {
   const {
     suiteId,
@@ -358,6 +369,7 @@ export async function runEvalsWithManager(
     accessVersion,
     storageServerIds,
     modelApiKeys,
+    customProviders,
     orgModelConfig,
     convexAuthToken,
     notes,
@@ -370,14 +382,14 @@ export async function runEvalsWithManager(
     throw new WebRouteError(
       400,
       ErrorCode.VALIDATION_ERROR,
-      "Provide suiteId or suiteName",
+      "Provide suiteId or suiteName"
     );
   }
   if (!suiteId && !projectId) {
     throw new WebRouteError(
       400,
       ErrorCode.VALIDATION_ERROR,
-      "projectId is required when creating a new eval suite",
+      "projectId is required when creating a new eval suite"
     );
   }
 
@@ -400,7 +412,7 @@ export async function runEvalsWithManager(
       resolvedServerIds,
       {
         logPrefix: "evals",
-      },
+      }
     );
 
   let resolvedSuiteId = suiteId ?? null;
@@ -460,109 +472,109 @@ export async function runEvalsWithManager(
     if (suiteRerun) {
       // skip upsert
     } else {
-    const existingTestCases = await convexClient.query(
-      "testSuites:listTestCases" as any,
-      { suiteId: resolvedSuiteId },
-    );
-
-    for (const [, testCaseData] of testCaseMap.entries()) {
-      const existingTestCase = existingTestCases?.find(
-        (tc: any) =>
-          tc.title === testCaseData.title && tc.query === testCaseData.query,
+      const existingTestCases = await convexClient.query(
+        "testSuites:listTestCases" as any,
+        { suiteId: resolvedSuiteId }
       );
 
-      if (existingTestCase) {
-        const normalize = (val: any) =>
-          val === undefined || val === null ? null : val;
+      for (const [, testCaseData] of testCaseMap.entries()) {
+        const existingTestCase = existingTestCases?.find(
+          (tc: any) =>
+            tc.title === testCaseData.title && tc.query === testCaseData.query
+        );
 
-        const modelsChanged =
-          JSON.stringify(
-            normalizeForComparison(existingTestCase.models || []),
-          ) !==
-          JSON.stringify(normalizeForComparison(testCaseData.models || []));
-        const runsChanged =
-          normalize(existingTestCase.runs) !== normalize(testCaseData.runs);
-        const expectedToolCallsChanged =
-          JSON.stringify(
-            normalizeForComparison(existingTestCase.expectedToolCalls || []),
-          ) !==
-          JSON.stringify(
-            normalizeForComparison(testCaseData.expectedToolCalls || []),
-          );
-        const isNegativeTestChanged =
-          normalize(existingTestCase.isNegativeTest) !==
-          normalize(testCaseData.isNegativeTest);
-        const scenarioChanged =
-          normalize(existingTestCase.scenario) !==
-          normalize(testCaseData.scenario);
-        const expectedOutputChanged =
-          normalize(existingTestCase.expectedOutput) !==
-          normalize(testCaseData.expectedOutput);
-        const promptTurnsChanged =
-          JSON.stringify(
-            normalizeForComparison(existingTestCase.promptTurns || []),
-          ) !==
-          JSON.stringify(
-            normalizeForComparison(testCaseData.promptTurns || []),
-          );
-        const judgeRequirementChanged =
-          normalize(existingTestCase.judgeRequirement) !==
-          normalize(testCaseData.judgeRequirement);
-        const advancedConfigChanged =
-          JSON.stringify(
-            normalizeForComparison(existingTestCase.advancedConfig),
-          ) !==
-          JSON.stringify(normalizeForComparison(testCaseData.advancedConfig));
+        if (existingTestCase) {
+          const normalize = (val: any) =>
+            val === undefined || val === null ? null : val;
 
-        const hasChanges =
-          modelsChanged ||
-          runsChanged ||
-          expectedToolCallsChanged ||
-          isNegativeTestChanged ||
-          scenarioChanged ||
-          expectedOutputChanged ||
-          promptTurnsChanged ||
-          judgeRequirementChanged ||
-          advancedConfigChanged;
+          const modelsChanged =
+            JSON.stringify(
+              normalizeForComparison(existingTestCase.models || [])
+            ) !==
+            JSON.stringify(normalizeForComparison(testCaseData.models || []));
+          const runsChanged =
+            normalize(existingTestCase.runs) !== normalize(testCaseData.runs);
+          const expectedToolCallsChanged =
+            JSON.stringify(
+              normalizeForComparison(existingTestCase.expectedToolCalls || [])
+            ) !==
+            JSON.stringify(
+              normalizeForComparison(testCaseData.expectedToolCalls || [])
+            );
+          const isNegativeTestChanged =
+            normalize(existingTestCase.isNegativeTest) !==
+            normalize(testCaseData.isNegativeTest);
+          const scenarioChanged =
+            normalize(existingTestCase.scenario) !==
+            normalize(testCaseData.scenario);
+          const expectedOutputChanged =
+            normalize(existingTestCase.expectedOutput) !==
+            normalize(testCaseData.expectedOutput);
+          const promptTurnsChanged =
+            JSON.stringify(
+              normalizeForComparison(existingTestCase.promptTurns || [])
+            ) !==
+            JSON.stringify(
+              normalizeForComparison(testCaseData.promptTurns || [])
+            );
+          const judgeRequirementChanged =
+            normalize(existingTestCase.judgeRequirement) !==
+            normalize(testCaseData.judgeRequirement);
+          const advancedConfigChanged =
+            JSON.stringify(
+              normalizeForComparison(existingTestCase.advancedConfig)
+            ) !==
+            JSON.stringify(normalizeForComparison(testCaseData.advancedConfig));
 
-        if (hasChanges) {
-          await convexClient.mutation("testSuites:updateTestCase" as any, {
-            testCaseId: existingTestCase._id,
+          const hasChanges =
+            modelsChanged ||
+            runsChanged ||
+            expectedToolCallsChanged ||
+            isNegativeTestChanged ||
+            scenarioChanged ||
+            expectedOutputChanged ||
+            promptTurnsChanged ||
+            judgeRequirementChanged ||
+            advancedConfigChanged;
+
+          if (hasChanges) {
+            await convexClient.mutation("testSuites:updateTestCase" as any, {
+              testCaseId: existingTestCase._id,
+              models: testCaseData.models,
+              runs: testCaseData.runs,
+              expectedToolCalls: sanitizeForConvexTransport(
+                testCaseData.expectedToolCalls
+              ),
+              isNegativeTest: testCaseData.isNegativeTest,
+              scenario: testCaseData.scenario,
+              expectedOutput: testCaseData.expectedOutput,
+              promptTurns: sanitizeForConvexTransport(testCaseData.promptTurns),
+              advancedConfig: sanitizeForConvexTransport(
+                testCaseData.advancedConfig
+              ),
+            });
+          }
+        } else {
+          await convexClient.mutation("testSuites:createTestCase" as any, {
+            suiteId: resolvedSuiteId,
+            title: testCaseData.title,
+            query: testCaseData.query,
             models: testCaseData.models,
             runs: testCaseData.runs,
             expectedToolCalls: sanitizeForConvexTransport(
-              testCaseData.expectedToolCalls,
+              testCaseData.expectedToolCalls
             ),
             isNegativeTest: testCaseData.isNegativeTest,
             scenario: testCaseData.scenario,
             expectedOutput: testCaseData.expectedOutput,
             promptTurns: sanitizeForConvexTransport(testCaseData.promptTurns),
+            judgeRequirement: testCaseData.judgeRequirement,
             advancedConfig: sanitizeForConvexTransport(
-              testCaseData.advancedConfig,
+              testCaseData.advancedConfig
             ),
           });
         }
-      } else {
-        await convexClient.mutation("testSuites:createTestCase" as any, {
-          suiteId: resolvedSuiteId,
-          title: testCaseData.title,
-          query: testCaseData.query,
-          models: testCaseData.models,
-          runs: testCaseData.runs,
-          expectedToolCalls: sanitizeForConvexTransport(
-            testCaseData.expectedToolCalls,
-          ),
-          isNegativeTest: testCaseData.isNegativeTest,
-          scenario: testCaseData.scenario,
-          expectedOutput: testCaseData.expectedOutput,
-          promptTurns: sanitizeForConvexTransport(testCaseData.promptTurns),
-          judgeRequirement: testCaseData.judgeRequirement,
-          advancedConfig: sanitizeForConvexTransport(
-            testCaseData.advancedConfig,
-          ),
-        });
       }
-    }
     }
   } else {
     const createdSuite = await convexClient.mutation(
@@ -573,7 +585,7 @@ export async function runEvalsWithManager(
         description: suiteDescription,
         environment: persistedEnvironment,
         defaultPassCriteria: passCriteria,
-      },
+      }
     );
 
     if (!createdSuite?._id) {
@@ -590,7 +602,7 @@ export async function runEvalsWithManager(
         models: testCaseData.models,
         runs: testCaseData.runs,
         expectedToolCalls: sanitizeForConvexTransport(
-          testCaseData.expectedToolCalls,
+          testCaseData.expectedToolCalls
         ),
         isNegativeTest: testCaseData.isNegativeTest,
         scenario: testCaseData.scenario,
@@ -616,7 +628,7 @@ export async function runEvalsWithManager(
   const replayConfigsToStore = filterAndRemapReplayConfigs(
     clientManager.getServerReplayConfigs(),
     resolvedServerIds,
-    persistedServerRefs,
+    persistedServerRefs
   );
   if (replayConfigsToStore.length > 0) {
     try {
@@ -633,8 +645,7 @@ export async function runEvalsWithManager(
   // Treat an empty client-provided map as "no keys" so org fallback still runs.
   // For reruns, projectId may not be in the request — derive it from the
   // suite record so org BYOK keeps working.
-  const hasClientKeys =
-    !!modelApiKeys && Object.keys(modelApiKeys).length > 0;
+  const hasClientKeys = !!modelApiKeys && Object.keys(modelApiKeys).length > 0;
   const resolvedModelApiKeys = hasClientKeys ? modelApiKeys : undefined;
   let resolvedOrgModelConfig = orgModelConfig;
   if (!resolvedModelApiKeys && !resolvedOrgModelConfig) {
@@ -644,7 +655,7 @@ export async function runEvalsWithManager(
       try {
         const suite = await convexClient.query(
           "testSuites:getTestSuite" as any,
-          { suiteId: resolvedSuiteId },
+          { suiteId: resolvedSuiteId }
         );
         if (suite?.projectId) {
           projectIdForOrgConfig = String(suite.projectId);
@@ -687,6 +698,7 @@ export async function runEvalsWithManager(
     runId,
     config,
     modelApiKeys: resolvedModelApiKeys ?? undefined,
+    customProviders,
     orgModelConfig: resolvedOrgModelConfig,
     convexClient,
     convexHttpUrl,
@@ -711,7 +723,7 @@ export type RunEvalTestCaseWithManagerOptions = {
 export async function runEvalTestCaseWithManager(
   clientManager: MCPClientManager,
   request: RunTestCaseWithManagerRequest,
-  options?: RunEvalTestCaseWithManagerOptions,
+  options?: RunEvalTestCaseWithManagerOptions
 ) {
   const {
     testCaseId,
@@ -793,7 +805,7 @@ export async function runEvalTestCaseWithManager(
           chatboxId,
           accessVersion,
           serverIds: resolvedServerIds,
-        },
+        }
       );
     } catch (error) {
       logger.warn("[evals] Failed to resolve org model config for test case", {
@@ -828,13 +840,13 @@ export async function runEvalTestCaseWithManager(
   if (expectedIterationId) {
     latestIteration = await convexClient.query(
       "testSuites:getTestIteration" as any,
-      { iterationId: expectedIterationId },
+      { iterationId: expectedIterationId }
     );
   }
   if (!latestIteration) {
     const recentIterations = await convexClient.query(
       "testSuites:listTestIterations" as any,
-      { testCaseId },
+      { testCaseId }
     );
     latestIteration = recentIterations?.[0] || null;
   }
@@ -859,18 +871,18 @@ export async function runEvalTestCaseWithManager(
 
 export async function generateEvalTestsWithManager(
   clientManager: MCPClientManager,
-  request: GenerateTestsRequest,
+  request: GenerateTestsRequest
 ) {
   const resolvedServerIds = resolveServerIdsOrThrow(
     request.serverIds,
-    clientManager,
+    clientManager
   );
   const { toolSnapshot } = await captureToolSnapshotForEvalAuthoring(
     clientManager,
     resolvedServerIds,
     {
       logPrefix: "evals.generate-tests",
-    },
+    }
   );
   const filteredTools = flattenServerToolSnapshotTools(toolSnapshot);
 
@@ -878,7 +890,7 @@ export async function generateEvalTestsWithManager(
     throw new WebRouteError(
       400,
       ErrorCode.VALIDATION_ERROR,
-      "No tools found for selected servers",
+      "No tools found for selected servers"
     );
   }
 
@@ -890,7 +902,7 @@ export async function generateEvalTestsWithManager(
   const tests = await generateTestCases(
     toolSnapshot,
     convexHttpUrl,
-    request.convexAuthToken,
+    request.convexAuthToken
   );
 
   return {
@@ -901,18 +913,18 @@ export async function generateEvalTestsWithManager(
 
 export async function generateNegativeEvalTestsWithManager(
   clientManager: MCPClientManager,
-  request: GenerateNegativeTestsRequest,
+  request: GenerateNegativeTestsRequest
 ) {
   const resolvedServerIds = resolveServerIdsOrThrow(
     request.serverIds,
-    clientManager,
+    clientManager
   );
   const { toolSnapshot } = await captureToolSnapshotForEvalAuthoring(
     clientManager,
     resolvedServerIds,
     {
       logPrefix: "evals.generate-negative-tests",
-    },
+    }
   );
   const filteredTools = flattenServerToolSnapshotTools(toolSnapshot);
 
@@ -920,7 +932,7 @@ export async function generateNegativeEvalTestsWithManager(
     throw new WebRouteError(
       400,
       ErrorCode.VALIDATION_ERROR,
-      "No tools found for selected servers",
+      "No tools found for selected servers"
     );
   }
 
@@ -932,7 +944,7 @@ export async function generateNegativeEvalTestsWithManager(
   const tests = await generateNegativeTestCases(
     toolSnapshot,
     convexHttpUrl,
-    request.convexAuthToken,
+    request.convexAuthToken
   );
 
   return {
@@ -948,7 +960,7 @@ export async function streamEvalTestCaseWithManager(
   options?: {
     skipLastMessageRunUpdate?: boolean;
     onStreamComplete?: () => void;
-  },
+  }
 ): Promise<ReadableStream<Uint8Array>> {
   const {
     testCaseId,
@@ -1032,7 +1044,7 @@ export async function streamEvalTestCaseWithManager(
           chatboxId,
           accessVersion,
           serverIds: resolvedServerIds,
-        },
+        }
       );
     } catch (error) {
       logger.warn(
@@ -1040,13 +1052,13 @@ export async function streamEvalTestCaseWithManager(
         {
           testCaseId,
           error: error instanceof Error ? error.message : String(error),
-        },
+        }
       );
     }
   }
 
   const tools = (await clientManager.getToolsForAiSdk(
-    resolvedServerIds,
+    resolvedServerIds
   )) as Record<string, any>;
   const encoder = new TextEncoder();
 
@@ -1085,13 +1097,13 @@ export async function streamEvalTestCaseWithManager(
         if (expectedIterationId) {
           latestIteration = await convexClient.query(
             "testSuites:getTestIteration" as any,
-            { iterationId: expectedIterationId },
+            { iterationId: expectedIterationId }
           );
         }
         if (!latestIteration) {
           const recentIterations = await convexClient.query(
             "testSuites:listTestIterations" as any,
-            { testCaseId },
+            { testCaseId }
           );
           latestIteration = recentIterations?.[0] || null;
         }
@@ -1114,7 +1126,7 @@ export async function streamEvalTestCaseWithManager(
             type: "complete",
             iterationId: expectedIterationId,
             iteration: latestIteration,
-          }),
+          })
         );
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -1126,7 +1138,7 @@ export async function streamEvalTestCaseWithManager(
               error instanceof WebRouteError && error.details
                 ? JSON.stringify(error.details)
                 : undefined,
-          }),
+          })
         );
       } finally {
         try {

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -114,6 +114,8 @@ export type RunEvalSuiteOptions = {
     };
   };
   modelApiKeys?: Record<string, string>;
+  /** Custom provider configs for local mode (non-org). */
+  customProviders?: CustomProviderConfig[];
   orgModelConfig?: ResolvedOrgModelConfig;
   convexClient: ConvexHttpClient;
   convexHttpUrl: string;
@@ -222,16 +224,24 @@ function normalizeWidgetCsp(value: unknown): Record<string, unknown> | null {
 
   const normalized: Record<string, unknown> = {};
   const connectDomains = Array.isArray(value.connectDomains)
-    ? value.connectDomains.filter((entry): entry is string => typeof entry === "string")
+    ? value.connectDomains.filter(
+        (entry): entry is string => typeof entry === "string"
+      )
     : undefined;
   const resourceDomains = Array.isArray(value.resourceDomains)
-    ? value.resourceDomains.filter((entry): entry is string => typeof entry === "string")
+    ? value.resourceDomains.filter(
+        (entry): entry is string => typeof entry === "string"
+      )
     : undefined;
   const frameDomains = Array.isArray(value.frameDomains)
-    ? value.frameDomains.filter((entry): entry is string => typeof entry === "string")
+    ? value.frameDomains.filter(
+        (entry): entry is string => typeof entry === "string"
+      )
     : undefined;
   const baseUriDomains = Array.isArray(value.baseUriDomains)
-    ? value.baseUriDomains.filter((entry): entry is string => typeof entry === "string")
+    ? value.baseUriDomains.filter(
+        (entry): entry is string => typeof entry === "string"
+      )
     : undefined;
 
   if (connectDomains && connectDomains.length > 0) {
@@ -251,12 +261,14 @@ function normalizeWidgetCsp(value: unknown): Record<string, unknown> | null {
 }
 
 function normalizeWidgetPermissions(
-  value: unknown,
+  value: unknown
 ): Record<string, unknown> | null {
   return isRecord(value) ? value : null;
 }
 
-function collectToolSnapshotSources(messages: ModelMessage[]): ToolSnapshotSource[] {
+function collectToolSnapshotSources(
+  messages: ModelMessage[]
+): ToolSnapshotSource[] {
   const toolInputsByCallId = new Map<
     string,
     { toolName: string; toolInput: Record<string, unknown> }
@@ -283,7 +295,7 @@ function collectToolSnapshotSources(messages: ModelMessage[]): ToolSnapshotSourc
       toolInputsByCallId.set(toolCallId, {
         toolName,
         toolInput: normalizeToolInput(
-          part.input ?? part.parameters ?? part.args ?? {},
+          part.input ?? part.parameters ?? part.args ?? {}
         ),
       });
     }
@@ -305,7 +317,7 @@ function collectToolSnapshotSources(messages: ModelMessage[]): ToolSnapshotSourc
       toolInputsByCallId.set(toolCallId, {
         toolName,
         toolInput: normalizeToolInput(
-          call.args ?? call.input ?? call.parameters ?? {},
+          call.args ?? call.input ?? call.parameters ?? {}
         ),
       });
     }
@@ -333,7 +345,8 @@ function collectToolSnapshotSources(messages: ModelMessage[]): ToolSnapshotSourc
 
       const toolOutput = unwrapToolResultPayload(part);
       const serverId =
-        readRecordString(part, "serverId") ?? readServerIdFromToolOutput(toolOutput);
+        readRecordString(part, "serverId") ??
+        readServerIdFromToolOutput(toolOutput);
       const sourceFromCall = toolInputsByCallId.get(toolCallId);
       const toolName =
         readRecordString(part, "toolName") ??
@@ -360,11 +373,11 @@ function collectToolSnapshotSources(messages: ModelMessage[]): ToolSnapshotSourc
 
 async function uploadEvalWidgetHtmlBlob(
   convexClient: ConvexHttpClient,
-  html: string,
+  html: string
 ): Promise<string | undefined> {
   const uploadUrl = await convexClient.mutation(
     "chatSessions:generateSnapshotUploadUrl" as any,
-    {},
+    {}
   );
 
   if (typeof uploadUrl !== "string" || uploadUrl.length === 0) {
@@ -380,9 +393,9 @@ async function uploadEvalWidgetHtmlBlob(
     throw new Error(`Failed to upload widget HTML (${response.status})`);
   }
 
-  const body = (await response.json().catch(() => null)) as
-    | { storageId?: string }
-    | null;
+  const body = (await response.json().catch(() => null)) as {
+    storageId?: string;
+  } | null;
   return typeof body?.storageId === "string" ? body.storageId : undefined;
 }
 
@@ -399,10 +412,9 @@ async function captureEvalTraceWidgetSnapshots(params: {
   const snapshots = await Promise.all(
     sources.map(async (source) => {
       try {
-        const toolMetadata =
-          params.mcpClientManager.getAllToolsMetadata(source.serverId)?.[
-            source.toolName
-          ];
+        const toolMetadata = params.mcpClientManager.getAllToolsMetadata(
+          source.serverId
+        )?.[source.toolName];
         if (!isRecord(toolMetadata) || !isMcpAppTool(toolMetadata)) {
           return null;
         }
@@ -430,7 +442,7 @@ async function captureEvalTraceWidgetSnapshots(params: {
         try {
           const resourceResult = await params.mcpClientManager.readResource(
             source.serverId,
-            { uri: resourceUri },
+            { uri: resourceUri }
           );
           const contents = Array.isArray((resourceResult as any)?.contents)
             ? ((resourceResult as any).contents as unknown[])
@@ -446,7 +458,7 @@ async function captureEvalTraceWidgetSnapshots(params: {
               : undefined;
           snapshot.widgetCsp = normalizeWidgetCsp(uiMeta?.csp);
           snapshot.widgetPermissions = normalizeWidgetPermissions(
-            uiMeta?.permissions,
+            uiMeta?.permissions
           );
           snapshot.prefersBorder =
             typeof uiMeta?.prefersBorder === "boolean"
@@ -466,7 +478,7 @@ async function captureEvalTraceWidgetSnapshots(params: {
           });
           const widgetHtmlBlobId = await uploadEvalWidgetHtmlBlob(
             params.convexClient,
-            widgetHtml,
+            widgetHtml
           );
           if (widgetHtmlBlobId) {
             snapshot.widgetHtmlBlobId = widgetHtmlBlobId;
@@ -493,11 +505,11 @@ async function captureEvalTraceWidgetSnapshots(params: {
         });
         return null;
       }
-    }),
+    })
   );
 
   const filtered = snapshots.filter(
-    (snapshot): snapshot is EvalTraceWidgetSnapshot => snapshot !== null,
+    (snapshot): snapshot is EvalTraceWidgetSnapshot => snapshot !== null
   );
   return filtered.length > 0 ? filtered : undefined;
 }
@@ -518,7 +530,7 @@ function resolveConfiguredServerIds(args: {
 
   const availableServerIdsSet = new Set(availableServerIds);
   const availableServerIdByLowercase = new Map(
-    availableServerIds.map((serverId) => [serverId.toLowerCase(), serverId]),
+    availableServerIds.map((serverId) => [serverId.toLowerCase(), serverId])
   );
   const projectServerIdByName = new Map<string, string>();
   const serverNameByProjectServerId = new Map<string, string>();
@@ -551,36 +563,37 @@ function resolveConfiguredServerIds(args: {
       continue;
     }
 
-    const normalizedServerId =
-      availableServerIdsSet.has(trimmedServerRef)
-        ? trimmedServerRef
-        : availableServerIdByLowercase.get(trimmedServerRef.toLowerCase()) ??
-          (() => {
-            const projectServerId = projectServerIdByName.get(
-              trimmedServerRef.toLowerCase(),
+    const normalizedServerId = availableServerIdsSet.has(trimmedServerRef)
+      ? trimmedServerRef
+      : availableServerIdByLowercase.get(trimmedServerRef.toLowerCase()) ??
+        (() => {
+          const projectServerId = projectServerIdByName.get(
+            trimmedServerRef.toLowerCase()
+          );
+          if (projectServerId) {
+            return (
+              (availableServerIdsSet.has(projectServerId)
+                ? projectServerId
+                : undefined) ??
+              availableServerIdByLowercase.get(projectServerId.toLowerCase())
             );
-            if (projectServerId) {
-              return (
-                (availableServerIdsSet.has(projectServerId)
-                  ? projectServerId
-                  : undefined) ??
-                availableServerIdByLowercase.get(projectServerId.toLowerCase())
-              );
-            }
+          }
 
-            const serverName = serverNameByProjectServerId.get(
-              trimmedServerRef.toLowerCase(),
+          const serverName = serverNameByProjectServerId.get(
+            trimmedServerRef.toLowerCase()
+          );
+          if (serverName) {
+            return (
+              (availableServerIdsSet.has(serverName)
+                ? serverName
+                : undefined) ??
+              availableServerIdByLowercase.get(serverName.toLowerCase())
             );
-            if (serverName) {
-              return (
-                (availableServerIdsSet.has(serverName) ? serverName : undefined) ??
-                availableServerIdByLowercase.get(serverName.toLowerCase())
-              );
-            }
+          }
 
-            return undefined;
-          })() ??
-          trimmedServerRef;
+          return undefined;
+        })() ??
+        trimmedServerRef;
 
     if (seen.has(normalizedServerId)) {
       continue;
@@ -613,7 +626,7 @@ function resolveEvalTestCase(test: EvalTestCase): ResolvedEvalTestCase {
 }
 
 function buildPromptTraceSummaries(
-  evaluation: MultiTurnEvaluationResult,
+  evaluation: MultiTurnEvaluationResult
 ): PromptTraceSummary[] {
   return evaluation.promptSummaries.map((summary) => ({
     promptIndex: summary.promptIndex,
@@ -642,7 +655,7 @@ function buildPromptTraceSummaries(
         mismatchedArguments: Array.from(mismatchedArguments).filter(
           (key) =>
             JSON.stringify(mismatch.expectedArgs?.[key]) !==
-            JSON.stringify(mismatch.actualArgs?.[key]),
+            JSON.stringify(mismatch.actualArgs?.[key])
         ),
       };
     }),
@@ -681,7 +694,7 @@ function extractToolCallsFromConversation(params: {
               (toolCall) =>
                 toolCall.toolName === name &&
                 JSON.stringify(toolCall.arguments) ===
-                  JSON.stringify(argumentsValue),
+                  JSON.stringify(argumentsValue)
             );
             if (!alreadyAdded) {
               toolsCalled.push({
@@ -703,7 +716,7 @@ function extractToolCallsFromConversation(params: {
             (toolCall) =>
               toolCall.toolName === toolName &&
               JSON.stringify(toolCall.arguments) ===
-                JSON.stringify(argumentsValue),
+                JSON.stringify(argumentsValue)
           );
           if (!alreadyAdded) {
             toolsCalled.push({
@@ -725,7 +738,7 @@ function toolCallIdentity(toolCall: ToolCall): string {
 
 function mergeToolCalls(
   existingToolCalls: ToolCall[],
-  incomingToolCalls: ToolCall[],
+  incomingToolCalls: ToolCall[]
 ): ToolCall[] {
   const seen = new Set(existingToolCalls.map(toolCallIdentity));
   const merged = [...existingToolCalls];
@@ -759,14 +772,14 @@ function appendPartialToolCallsToPrompt(params: {
   }
 
   const existingToolCalls = Array.isArray(
-    params.toolsCalledByPrompt[params.promptIndex],
+    params.toolsCalledByPrompt[params.promptIndex]
   )
     ? params.toolsCalledByPrompt[params.promptIndex]!
     : [];
 
   params.toolsCalledByPrompt[params.promptIndex] = mergeToolCalls(
     existingToolCalls,
-    partialToolCalls,
+    partialToolCalls
   );
 }
 
@@ -784,7 +797,7 @@ function toStreamToolCalls(toolCalls: ToolCall[]): EvalStreamToolCall[] {
  * Wire format: `data: <JSON>\n\n` per event, terminated by `data: [DONE]\n\n`.
  */
 async function* parseBackendUIMessageSSE(
-  body: ReadableStream<Uint8Array>,
+  body: ReadableStream<Uint8Array>
 ): AsyncGenerator<{ type: string; [key: string]: unknown }> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
@@ -858,7 +871,7 @@ function buildTraceSnapshotEvent(params: {
     snapshotKind: params.snapshotKind,
     trace: sanitizeForConvexTransport(trace),
     actualToolCalls: sanitizeForConvexTransport(
-      toStreamToolCalls(params.actualToolCalls),
+      toStreamToolCalls(params.actualToolCalls)
     ),
     usage: {
       inputTokens: params.usage.inputTokens ?? 0,
@@ -886,7 +899,7 @@ async function createIterationDirectly(
     };
     iterationNumber: number;
     startedAt: number;
-  },
+  }
 ): Promise<string | undefined> {
   try {
     const result = await convexClient.mutation(
@@ -896,7 +909,7 @@ async function createIterationDirectly(
         testCaseSnapshot: sanitizeForConvexTransport(params.testCaseSnapshot),
         iterationNumber: params.iterationNumber,
         startedAt: params.startedAt,
-      },
+      }
     );
 
     return result?.iterationId as string | undefined;
@@ -924,7 +937,7 @@ async function finishIterationDirectly(
     errorDetails?: string;
     resultSource?: "reported" | "derived";
     metadata?: Record<string, string | number | boolean>;
-  },
+  }
 ): Promise<void> {
   if (!params.iterationId) return;
 
@@ -932,12 +945,12 @@ async function finishIterationDirectly(
   try {
     const iteration = await convexClient.query(
       "testSuites:getTestIteration" as any,
-      { iterationId: params.iterationId },
+      { iterationId: params.iterationId }
     );
     if (iteration?.status === "cancelled") {
       logger.debug(
         "[evals] Skipping update for cancelled iteration:",
-        params.iterationId,
+        params.iterationId
       );
       return;
     }
@@ -965,9 +978,7 @@ async function finishIterationDirectly(
         : {}),
       ...(params.widgetSnapshots?.length
         ? {
-            widgetSnapshots: sanitizeForConvexTransport(
-              params.widgetSnapshots,
-            ),
+            widgetSnapshots: sanitizeForConvexTransport(params.widgetSnapshots),
           }
         : {}),
       error: params.error,
@@ -989,7 +1000,7 @@ async function finishIterationDirectly(
 
     logger.error(
       "[evals] Failed to finish iteration:",
-      new Error(errorMessage),
+      new Error(errorMessage)
     );
   }
 }
@@ -1003,6 +1014,7 @@ type RunIterationBaseParams = {
   testCaseId?: string;
   suiteId?: string;
   modelApiKeys?: Record<string, string>;
+  customProviders?: CustomProviderConfig[];
   orgModelConfig?: ResolvedOrgModelConfig;
   convexClient: ConvexHttpClient;
   runId: string | null; // For cancellation checks
@@ -1056,7 +1068,7 @@ const buildModelDefinition = (test: EvalTestCase): ModelDefinition => {
 
 function lookupProviderApiKey(
   modelApiKeys: Record<string, string> | undefined,
-  provider: string,
+  provider: string
 ): string | undefined {
   return modelApiKeys?.[provider] ?? modelApiKeys?.[provider.toLowerCase()];
 }
@@ -1069,6 +1081,8 @@ function resolveEvalModelRuntime(args: {
   test: EvalTestCase;
   modelDefinition: ModelDefinition;
   modelApiKeys?: Record<string, string>;
+  /** Custom provider configs passed from the client (local mode). */
+  requestCustomProviders?: CustomProviderConfig[];
   orgModelConfig?: ResolvedOrgModelConfig;
 }): {
   apiKey: string;
@@ -1086,17 +1100,22 @@ function resolveEvalModelRuntime(args: {
   const provider = args.modelDefinition.provider;
   if (!apiKey && provider !== "ollama" && provider !== "custom") {
     throw new Error(
-      `Missing API key for provider ${args.test.provider} (test: ${args.test.title})`,
+      `Missing API key for provider ${args.test.provider} (test: ${args.test.title})`
     );
   }
+
+  // Prefer org-provided custom providers, fall back to request-level ones
+  const resolvedCustomProviders = orgRuntime?.customProviders?.length
+    ? orgRuntime.customProviders
+    : args.requestCustomProviders;
 
   return {
     apiKey,
     ...(orgRuntime?.baseUrls && hasBaseUrls(orgRuntime.baseUrls)
       ? { baseUrls: orgRuntime.baseUrls }
       : {}),
-    ...(orgRuntime?.customProviders.length
-      ? { customProviders: orgRuntime.customProviders }
+    ...(resolvedCustomProviders?.length
+      ? { customProviders: resolvedCustomProviders }
       : {}),
   };
 }
@@ -1111,6 +1130,7 @@ const runIterationWithAiSdk = async ({
   suiteId,
   modelDefinition,
   modelApiKeys,
+  customProviders: requestCustomProviders,
   orgModelConfig,
   convexClient,
   runId,
@@ -1125,14 +1145,14 @@ const runIterationWithAiSdk = async ({
     try {
       const currentRun = await convexClient.query(
         "testSuites:getTestSuiteRun" as any,
-        { runId },
+        { runId }
       );
       if (currentRun?.status === "cancelled") {
         return {
           evaluation: evaluateMultiTurnResults(
             resolvedTest.promptTurns,
             [],
-            test.isNegativeTest,
+            test.isNegativeTest
           ),
           iterationId: undefined,
         };
@@ -1149,7 +1169,7 @@ const runIterationWithAiSdk = async ({
           evaluation: evaluateMultiTurnResults(
             resolvedTest.promptTurns,
             [],
-            test.isNegativeTest,
+            test.isNegativeTest
           ),
           iterationId: undefined,
         };
@@ -1178,6 +1198,7 @@ const runIterationWithAiSdk = async ({
     test,
     modelDefinition,
     modelApiKeys,
+    requestCustomProviders,
     orgModelConfig,
   });
 
@@ -1210,8 +1231,8 @@ const runIterationWithAiSdk = async ({
   const iterationId = precreatedIterationId
     ? precreatedIterationId
     : recorder
-      ? await recorder.startIteration(iterationParams)
-      : await createIterationDirectly(convexClient, iterationParams);
+    ? await recorder.startIteration(iterationParams)
+    : await createIterationDirectly(convexClient, iterationParams);
 
   const baseMessages: ModelMessage[] = [];
   if (system) {
@@ -1237,7 +1258,7 @@ const runIterationWithAiSdk = async ({
       modelDefinition,
       modelRuntime.apiKey,
       modelRuntime.baseUrls,
-      modelRuntime.customProviders,
+      modelRuntime.customProviders
     );
 
     if (
@@ -1246,7 +1267,7 @@ const runIterationWithAiSdk = async ({
       !Object.hasOwn(tools, toolChoice.toolName)
     ) {
       throw new Error(
-        `Configured tool choice '${toolChoice.toolName}' is not available for this eval run.`,
+        `Configured tool choice '${toolChoice.toolName}' is not available for this eval run.`
       );
     }
 
@@ -1263,7 +1284,7 @@ const runIterationWithAiSdk = async ({
       const tracedTools = wrapToolSetForEvalTrace(
         tools,
         activeTraceCtx,
-        promptIndex,
+        promptIndex
       );
 
       const result = await generateText({
@@ -1313,7 +1334,7 @@ const runIterationWithAiSdk = async ({
               : undefined;
           appendDedupedModelMessages(
             activePartialResponseMessages,
-            responseMessages as ModelMessage[],
+            responseMessages as ModelMessage[]
           );
           const appendedMessageCount =
             activePartialResponseMessages.length -
@@ -1350,7 +1371,7 @@ const runIterationWithAiSdk = async ({
           activeTraceCtx.recordedSpans,
           activePromptInputMessages.length,
           result.steps,
-          promptIndex,
+          promptIndex
         );
       }
 
@@ -1383,7 +1404,7 @@ const runIterationWithAiSdk = async ({
     const evaluation = evaluateMultiTurnResults(
       promptTurns,
       toolsCalledByPrompt,
-      test.isNegativeTest,
+      test.isNegativeTest
     );
     const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
 
@@ -1454,7 +1475,7 @@ const runIterationWithAiSdk = async ({
         evaluation: evaluateMultiTurnResults(
           promptTurns,
           toolsCalledByPrompt,
-          test.isNegativeTest,
+          test.isNegativeTest
         ),
         iterationId: undefined,
       };
@@ -1503,7 +1524,7 @@ const runIterationWithAiSdk = async ({
     const evaluation = evaluateMultiTurnResults(
       promptTurns,
       toolsCalledByPrompt,
-      test.isNegativeTest,
+      test.isNegativeTest
     );
     const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
     const widgetSnapshots = await captureEvalTraceWidgetSnapshots({
@@ -1571,14 +1592,14 @@ const runIterationViaBackend = async ({
     try {
       const currentRun = await convexClient.query(
         "testSuites:getTestSuiteRun" as any,
-        { runId },
+        { runId }
       );
       if (currentRun?.status === "cancelled") {
         return {
           evaluation: evaluateMultiTurnResults(
             resolvedTest.promptTurns,
             [],
-            test.isNegativeTest,
+            test.isNegativeTest
           ),
           iterationId: undefined,
         };
@@ -1595,7 +1616,7 @@ const runIterationViaBackend = async ({
           evaluation: evaluateMultiTurnResults(
             resolvedTest.promptTurns,
             [],
-            test.isNegativeTest,
+            test.isNegativeTest
           ),
           iterationId: undefined,
         };
@@ -1652,8 +1673,8 @@ const runIterationViaBackend = async ({
   const iterationId = precreatedIterationId
     ? precreatedIterationId
     : recorder
-      ? await recorder.startIteration(iterationParams)
-      : await createIterationDirectly(convexClient, iterationParams);
+    ? await recorder.startIteration(iterationParams)
+    : await createIterationDirectly(convexClient, iterationParams);
 
   const toolDefs = Object.entries(tools).map(([name, tool]) => {
     const schema = (tool as any)?.inputSchema;
@@ -1746,7 +1767,7 @@ const runIterationViaBackend = async ({
           iterationErrorDetails = errorText;
           logger.error(
             "[evals] backend stream error",
-            new Error(res.statusText),
+            new Error(res.statusText)
           );
           const failAbs = Date.now();
           pushBackendStepLlmFailureSpans(
@@ -1756,7 +1777,7 @@ const runIterationViaBackend = async ({
             stepIndex,
             stepStartAbs,
             llmStartAbs,
-            failAbs,
+            failAbs
           );
           break;
         }
@@ -1768,7 +1789,7 @@ const runIterationViaBackend = async ({
           iterationErrorDetails = JSON.stringify(json, null, 2);
           logger.error(
             "[evals] invalid backend response payload",
-            new Error("Invalid backend response payload"),
+            new Error("Invalid backend response payload")
           );
           const failAbs = Date.now();
           pushBackendStepLlmFailureSpans(
@@ -1781,7 +1802,7 @@ const runIterationViaBackend = async ({
             failAbs,
             {
               modelId,
-            },
+            }
           );
           break;
         }
@@ -1809,7 +1830,9 @@ const runIterationViaBackend = async ({
                   });
                 }
                 if (!item.toolCallId) {
-                  item.toolCallId = `tc_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+                  item.toolCallId = `tc_${Date.now()}_${Math.random()
+                    .toString(36)
+                    .slice(2, 8)}`;
                 }
                 if (item.input == null) {
                   item.input = item.parameters ?? item.args ?? {};
@@ -1833,7 +1856,7 @@ const runIterationViaBackend = async ({
               messageHistory as any,
               {
                 tools: tracedBackendTools as any,
-              },
+              }
             );
             const toolsEndAbs = Date.now();
             const toolMessageIndexByCallId = new Map<string, number>();
@@ -1861,7 +1884,7 @@ const runIterationViaBackend = async ({
                 continue;
               }
               const toolMessageIndex = toolMessageIndexByCallId.get(
-                span.toolCallId,
+                span.toolCallId
               );
               if (typeof toolMessageIndex === "number") {
                 span.messageStartIndex = toolMessageIndex;
@@ -1895,7 +1918,7 @@ const runIterationViaBackend = async ({
                     : undefined,
                 messageEndIndex: stepMessageEndIndex,
                 status: "ok",
-              },
+              }
             );
           } catch (toolErr) {
             const failAbs = Date.now();
@@ -1923,7 +1946,7 @@ const runIterationViaBackend = async ({
                     : undefined,
                 messageEndIndex: stepMessageEndIndex,
                 pushAggregateSpan: false,
-              },
+              }
             );
             iterationError =
               toolErr instanceof Error ? toolErr.message : String(toolErr);
@@ -1952,7 +1975,7 @@ const runIterationViaBackend = async ({
                 stepMessageEndIndex != null ? stepMessageStartIndex : undefined,
               messageEndIndex: stepMessageEndIndex,
               status: "ok",
-            },
+            }
           );
         }
 
@@ -1969,7 +1992,7 @@ const runIterationViaBackend = async ({
             evaluation: evaluateMultiTurnResults(
               promptTurns,
               toolsCalledByPrompt,
-              test.isNegativeTest,
+              test.isNegativeTest
             ),
             iterationId: undefined,
           };
@@ -2004,7 +2027,7 @@ const runIterationViaBackend = async ({
           failAbs,
           {
             modelId,
-          },
+          }
         );
         break;
       }
@@ -2018,7 +2041,7 @@ const runIterationViaBackend = async ({
   const evaluation = evaluateMultiTurnResults(
     promptTurns,
     toolsCalledByPrompt,
-    test.isNegativeTest,
+    test.isNegativeTest
   );
   const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
 
@@ -2085,6 +2108,7 @@ const runTestCase = async (params: {
   mcpClientManager: MCPClientManager;
   recorder: SuiteRunRecorder | null;
   modelApiKeys?: Record<string, string>;
+  customProviders?: CustomProviderConfig[];
   orgModelConfig?: ResolvedOrgModelConfig;
   convexHttpUrl: string;
   convexAuthToken: string;
@@ -2101,6 +2125,7 @@ const runTestCase = async (params: {
     mcpClientManager,
     recorder,
     modelApiKeys,
+    customProviders: requestCustomProviders,
     orgModelConfig,
     convexHttpUrl,
     convexAuthToken,
@@ -2115,11 +2140,11 @@ const runTestCase = async (params: {
   const modelDefinition = buildModelDefinition(test);
   const resolvedModelId = getCanonicalModelId(
     String(modelDefinition.id),
-    modelDefinition.provider,
+    modelDefinition.provider
   );
   const isJamModel = isMCPJamProvidedModel(
     resolvedModelId,
-    modelDefinition.provider,
+    modelDefinition.provider
   );
 
   const outcomes: EvalIterationOutcome[] = [];
@@ -2152,10 +2177,7 @@ const runTestCase = async (params: {
           iterationNumber: runIndex + 1,
           startedAt: precreatedAt,
         };
-        const id = await createIterationDirectly(
-          convexClient,
-          iterationParams,
-        );
+        const id = await createIterationDirectly(convexClient, iterationParams);
         precreatedIterationIds.push(id);
       } catch (error) {
         logger.warn(
@@ -2163,7 +2185,7 @@ const runTestCase = async (params: {
           {
             runIndex,
             error: error instanceof Error ? error.message : String(error),
-          },
+          }
         );
         precreatedIterationIds.push(undefined);
       }
@@ -2208,6 +2230,7 @@ const runTestCase = async (params: {
       suiteId,
       modelDefinition,
       modelApiKeys,
+      customProviders: requestCustomProviders,
       orgModelConfig,
       convexClient,
       runId,
@@ -2226,6 +2249,7 @@ export const runEvalSuiteWithAiSdk = async ({
   runId,
   config,
   modelApiKeys,
+  customProviders,
   orgModelConfig,
   convexClient,
   convexHttpUrl,
@@ -2249,12 +2273,12 @@ export const runEvalSuiteWithAiSdk = async ({
   const recorder =
     runId === null
       ? null
-      : (providedRecorder ??
+      : providedRecorder ??
         createSuiteRunRecorder({
           convexClient,
           suiteId,
           runId,
-        }));
+        });
 
   const tools = (await mcpClientManager.getToolsForAiSdk(serverIds)) as ToolSet;
 
@@ -2274,7 +2298,7 @@ export const runEvalSuiteWithAiSdk = async ({
         "testSuites:getTestSuiteRun" as any,
         {
           runId,
-        },
+        }
       );
 
       if (currentRun?.status === "cancelled") {
@@ -2299,6 +2323,7 @@ export const runEvalSuiteWithAiSdk = async ({
         mcpClientManager,
         recorder,
         modelApiKeys,
+        customProviders,
         orgModelConfig,
         convexHttpUrl,
         convexAuthToken,
@@ -2308,7 +2333,7 @@ export const runEvalSuiteWithAiSdk = async ({
         suiteId,
         runId,
         abortSignal: abortController.signal,
-      }),
+      })
     );
 
     // Create a cancellation checker that polls every 2s
@@ -2322,7 +2347,7 @@ export const runEvalSuiteWithAiSdk = async ({
         try {
           const currentRun = await convexClient.query(
             "testSuites:getTestSuiteRun" as any,
-            { runId },
+            { runId }
           );
           if (currentRun?.status === "cancelled") {
             // Abort all in-flight LLM requests
@@ -2362,7 +2387,7 @@ export const runEvalSuiteWithAiSdk = async ({
     } catch (error) {
       if (error instanceof Error && error.message === "RUN_CANCELLED") {
         logger.debug(
-          "[evals] Run was cancelled, all in-flight requests aborted",
+          "[evals] Run was cancelled, all in-flight requests aborted"
         );
 
         // Finalize the run as cancelled
@@ -2459,6 +2484,7 @@ const streamIterationWithAiSdk = async ({
   suiteId,
   modelDefinition,
   modelApiKeys,
+  customProviders: requestCustomProviders,
   orgModelConfig,
   convexClient,
   runId,
@@ -2476,14 +2502,14 @@ const streamIterationWithAiSdk = async ({
     try {
       const currentRun = await convexClient.query(
         "testSuites:getTestSuiteRun" as any,
-        { runId },
+        { runId }
       );
       if (currentRun?.status === "cancelled") {
         return {
           evaluation: evaluateMultiTurnResults(
             resolvedTest.promptTurns,
             [],
-            test.isNegativeTest,
+            test.isNegativeTest
           ),
           iterationId: undefined,
         };
@@ -2499,7 +2525,7 @@ const streamIterationWithAiSdk = async ({
           evaluation: evaluateMultiTurnResults(
             resolvedTest.promptTurns,
             [],
-            test.isNegativeTest,
+            test.isNegativeTest
           ),
           iterationId: undefined,
         };
@@ -2528,6 +2554,7 @@ const streamIterationWithAiSdk = async ({
     test,
     modelDefinition,
     modelApiKeys,
+    requestCustomProviders,
     orgModelConfig,
   });
 
@@ -2560,8 +2587,8 @@ const streamIterationWithAiSdk = async ({
   const iterationId = precreatedIterationId
     ? precreatedIterationId
     : recorder
-      ? await recorder.startIteration(iterationParams)
-      : await createIterationDirectly(convexClient, iterationParams);
+    ? await recorder.startIteration(iterationParams)
+    : await createIterationDirectly(convexClient, iterationParams);
 
   const baseMessages: ModelMessage[] = [];
   if (system) {
@@ -2587,7 +2614,7 @@ const streamIterationWithAiSdk = async ({
       modelDefinition,
       modelRuntime.apiKey,
       modelRuntime.baseUrls,
-      modelRuntime.customProviders,
+      modelRuntime.customProviders
     );
 
     if (
@@ -2596,7 +2623,7 @@ const streamIterationWithAiSdk = async ({
       !Object.hasOwn(tools, toolChoice.toolName)
     ) {
       throw new Error(
-        `Configured tool choice '${toolChoice.toolName}' is not available for this eval run.`,
+        `Configured tool choice '${toolChoice.toolName}' is not available for this eval run.`
       );
     }
 
@@ -2613,7 +2640,7 @@ const streamIterationWithAiSdk = async ({
       const tracedTools = wrapToolSetForEvalTrace(
         tools,
         activeTraceCtx,
-        promptIndex,
+        promptIndex
       );
 
       emit({
@@ -2672,7 +2699,7 @@ const streamIterationWithAiSdk = async ({
               : undefined;
           appendDedupedModelMessages(
             activePartialResponseMessages,
-            responseMessages as ModelMessage[],
+            responseMessages as ModelMessage[]
           );
           const appendedMessageCount =
             activePartialResponseMessages.length -
@@ -2705,7 +2732,7 @@ const streamIterationWithAiSdk = async ({
                 messages: snapshotMessages,
               }),
               usage: accumulatedUsage,
-            }),
+            })
           );
         },
         onFinish: async () => {
@@ -2772,7 +2799,7 @@ const streamIterationWithAiSdk = async ({
           activeTraceCtx.recordedSpans,
           activePromptInputMessages.length,
           steps,
-          promptIndex,
+          promptIndex
         );
       }
 
@@ -2798,7 +2825,7 @@ const streamIterationWithAiSdk = async ({
             messages: conversationMessages,
           }),
           usage: accumulatedUsage,
-        }),
+        })
       );
 
       activeTraceCtx = null;
@@ -2812,7 +2839,7 @@ const streamIterationWithAiSdk = async ({
     const evaluation = evaluateMultiTurnResults(
       promptTurns,
       toolsCalledByPrompt,
-      test.isNegativeTest,
+      test.isNegativeTest
     );
     const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
 
@@ -2881,7 +2908,7 @@ const streamIterationWithAiSdk = async ({
         evaluation: evaluateMultiTurnResults(
           promptTurns,
           toolsCalledByPrompt,
-          test.isNegativeTest,
+          test.isNegativeTest
         ),
         iterationId: undefined,
       };
@@ -2930,7 +2957,7 @@ const streamIterationWithAiSdk = async ({
     const evaluation = evaluateMultiTurnResults(
       promptTurns,
       toolsCalledByPrompt,
-      test.isNegativeTest,
+      test.isNegativeTest
     );
     const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
     const widgetSnapshots = await captureEvalTraceWidgetSnapshots({
@@ -2957,7 +2984,7 @@ const streamIterationWithAiSdk = async ({
           totalTokens: accumulatedUsage.totalTokens,
         },
         prompts: promptTraceSummaries,
-      }),
+      })
     );
     emit({
       type: "error",
@@ -3027,14 +3054,14 @@ const streamIterationViaBackend = async ({
     try {
       const currentRun = await convexClient.query(
         "testSuites:getTestSuiteRun" as any,
-        { runId },
+        { runId }
       );
       if (currentRun?.status === "cancelled") {
         return {
           evaluation: evaluateMultiTurnResults(
             resolvedTest.promptTurns,
             [],
-            test.isNegativeTest,
+            test.isNegativeTest
           ),
           iterationId: undefined,
         };
@@ -3050,7 +3077,7 @@ const streamIterationViaBackend = async ({
           evaluation: evaluateMultiTurnResults(
             resolvedTest.promptTurns,
             [],
-            test.isNegativeTest,
+            test.isNegativeTest
           ),
           iterationId: undefined,
         };
@@ -3107,8 +3134,8 @@ const streamIterationViaBackend = async ({
   const iterationId = precreatedIterationId
     ? precreatedIterationId
     : recorder
-      ? await recorder.startIteration(iterationParams)
-      : await createIterationDirectly(convexClient, iterationParams);
+    ? await recorder.startIteration(iterationParams)
+    : await createIterationDirectly(convexClient, iterationParams);
 
   const toolDefs = Object.entries(tools).map(([name, tool]) => {
     const schema = (tool as any)?.inputSchema;
@@ -3207,7 +3234,7 @@ const streamIterationViaBackend = async ({
           iterationErrorDetails = errorText;
           logger.error(
             "[evals] backend stream error",
-            new Error(res.statusText),
+            new Error(res.statusText)
           );
           const failAbs = Date.now();
           pushBackendStepLlmFailureSpans(
@@ -3217,7 +3244,7 @@ const streamIterationViaBackend = async ({
             stepIndex,
             stepStartAbs,
             llmStartAbs,
-            failAbs,
+            failAbs
           );
           emit(
             buildTraceSnapshotEvent({
@@ -3230,7 +3257,7 @@ const streamIterationViaBackend = async ({
                 messages: messageHistory,
               }),
               usage: accumulatedUsage,
-            }),
+            })
           );
           emit({
             type: "error",
@@ -3251,7 +3278,7 @@ const streamIterationViaBackend = async ({
             stepStartAbs,
             llmStartAbs,
             failAbs,
-            { modelId },
+            { modelId }
           );
           emit(
             buildTraceSnapshotEvent({
@@ -3264,7 +3291,7 @@ const streamIterationViaBackend = async ({
                 messages: messageHistory,
               }),
               usage: accumulatedUsage,
-            }),
+            })
           );
           emit({
             type: "error",
@@ -3348,7 +3375,7 @@ const streamIterationViaBackend = async ({
             stepStartAbs,
             llmStartAbs,
             failAbs,
-            { modelId },
+            { modelId }
           );
           emit(
             buildTraceSnapshotEvent({
@@ -3361,7 +3388,7 @@ const streamIterationViaBackend = async ({
                 messages: messageHistory,
               }),
               usage: accumulatedUsage,
-            }),
+            })
           );
           emit({
             type: "error",
@@ -3375,14 +3402,11 @@ const streamIterationViaBackend = async ({
 
         // Update accumulated usage from stream metadata
         accumulatedUsage.inputTokens =
-          (accumulatedUsage.inputTokens || 0) +
-          (stepUsage.inputTokens || 0);
+          (accumulatedUsage.inputTokens || 0) + (stepUsage.inputTokens || 0);
         accumulatedUsage.outputTokens =
-          (accumulatedUsage.outputTokens || 0) +
-          (stepUsage.outputTokens || 0);
+          (accumulatedUsage.outputTokens || 0) + (stepUsage.outputTokens || 0);
         accumulatedUsage.totalTokens =
-          (accumulatedUsage.totalTokens || 0) +
-          (stepUsage.totalTokens || 0);
+          (accumulatedUsage.totalTokens || 0) + (stepUsage.totalTokens || 0);
 
         // Reconstruct assistant message from stream chunks
         const assistantContent: unknown[] = [];
@@ -3421,7 +3445,7 @@ const streamIterationViaBackend = async ({
               messageHistory as any,
               {
                 tools: tracedBackendTools as any,
-              },
+              }
             );
             const toolsEndAbs = Date.now();
 
@@ -3472,7 +3496,7 @@ const streamIterationViaBackend = async ({
                 continue;
               }
               const toolMessageIndex = toolMessageIndexByCallId.get(
-                span.toolCallId,
+                span.toolCallId
               );
               if (typeof toolMessageIndex === "number") {
                 span.messageStartIndex = toolMessageIndex;
@@ -3506,7 +3530,7 @@ const streamIterationViaBackend = async ({
                     : undefined,
                 messageEndIndex: stepMessageEndIndex,
                 status: "ok",
-              },
+              }
             );
           } catch (toolErr) {
             const failAbs = Date.now();
@@ -3534,7 +3558,7 @@ const streamIterationViaBackend = async ({
                     : undefined,
                 messageEndIndex: stepMessageEndIndex,
                 pushAggregateSpan: false,
-              },
+              }
             );
             iterationError =
               toolErr instanceof Error ? toolErr.message : String(toolErr);
@@ -3550,7 +3574,7 @@ const streamIterationViaBackend = async ({
                   messages: messageHistory,
                 }),
                 usage: accumulatedUsage,
-              }),
+              })
             );
             emit({
               type: "error",
@@ -3581,7 +3605,7 @@ const streamIterationViaBackend = async ({
                 stepMessageEndIndex != null ? stepMessageStartIndex : undefined,
               messageEndIndex: stepMessageEndIndex,
               status: "ok",
-            },
+            }
           );
         }
 
@@ -3606,7 +3630,7 @@ const streamIterationViaBackend = async ({
               messages: messageHistory,
             }),
             usage: accumulatedUsage,
-          }),
+          })
         );
 
         if (stepFinishReason && stepFinishReason !== "tool-calls") {
@@ -3615,13 +3639,13 @@ const streamIterationViaBackend = async ({
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {
           logger.debug(
-            "[evals] backend streaming iteration aborted due to cancellation",
+            "[evals] backend streaming iteration aborted due to cancellation"
           );
           return {
             evaluation: evaluateMultiTurnResults(
               promptTurns,
               toolsCalledByPrompt,
-              test.isNegativeTest,
+              test.isNegativeTest
             ),
             iterationId: undefined,
           };
@@ -3656,7 +3680,7 @@ const streamIterationViaBackend = async ({
           failAbs,
           {
             modelId,
-          },
+          }
         );
         emit(
           buildTraceSnapshotEvent({
@@ -3669,7 +3693,7 @@ const streamIterationViaBackend = async ({
               messages: messageHistory,
             }),
             usage: accumulatedUsage,
-          }),
+          })
         );
         emit({
           type: "error",
@@ -3694,7 +3718,7 @@ const streamIterationViaBackend = async ({
           messages: messageHistory,
         }),
         usage: accumulatedUsage,
-      }),
+      })
     );
     emit({ type: "turn_finish", turnIndex: promptIndex });
   }
@@ -3702,7 +3726,7 @@ const streamIterationViaBackend = async ({
   const evaluation = evaluateMultiTurnResults(
     promptTurns,
     toolsCalledByPrompt,
-    test.isNegativeTest,
+    test.isNegativeTest
   );
   const promptTraceSummaries = buildPromptTraceSummaries(evaluation);
 
@@ -3769,6 +3793,7 @@ export const streamTestCase = async (params: {
   mcpClientManager: MCPClientManager;
   recorder: SuiteRunRecorder | null;
   modelApiKeys?: Record<string, string>;
+  customProviders?: CustomProviderConfig[];
   orgModelConfig?: ResolvedOrgModelConfig;
   convexHttpUrl: string;
   convexAuthToken: string;
@@ -3786,6 +3811,7 @@ export const streamTestCase = async (params: {
     mcpClientManager,
     recorder,
     modelApiKeys,
+    customProviders: requestCustomProviders,
     orgModelConfig,
     convexHttpUrl,
     convexAuthToken,
@@ -3801,11 +3827,11 @@ export const streamTestCase = async (params: {
   const modelDefinition = buildModelDefinition(test);
   const resolvedModelId = getCanonicalModelId(
     String(modelDefinition.id),
-    modelDefinition.provider,
+    modelDefinition.provider
   );
   const isJamModel = isMCPJamProvidedModel(
     resolvedModelId,
-    modelDefinition.provider,
+    modelDefinition.provider
   );
 
   const outcomes: EvalIterationOutcome[] = [];
@@ -3841,10 +3867,7 @@ export const streamTestCase = async (params: {
           iterationNumber: runIndex + 1,
           startedAt: precreatedAt,
         };
-        const id = await createIterationDirectly(
-          convexClient,
-          iterationParams,
-        );
+        const id = await createIterationDirectly(convexClient, iterationParams);
         precreatedIterationIds.push(id);
       } catch (error) {
         logger.warn(
@@ -3852,7 +3875,7 @@ export const streamTestCase = async (params: {
           {
             runIndex,
             error: error instanceof Error ? error.message : String(error),
-          },
+          }
         );
         precreatedIterationIds.push(undefined);
       }
@@ -3898,6 +3921,7 @@ export const streamTestCase = async (params: {
       suiteId,
       modelDefinition,
       modelApiKeys,
+      customProviders: requestCustomProviders,
       orgModelConfig,
       convexClient,
       runId,

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -9,11 +9,11 @@ const createLlmModelMock = vi.hoisted(() =>
       _modelDefinition?: unknown,
       _apiKey?: unknown,
       _baseUrls?: unknown,
-      _customProviders?: unknown,
+      _customProviders?: unknown
     ) => ({
       id: "mock-model",
-    }),
-  ),
+    })
+  )
 );
 
 vi.mock("ai", () => ({
@@ -23,8 +23,9 @@ vi.mock("ai", () => ({
 }));
 
 vi.mock("@mcpjam/sdk", async () => {
-  const actual =
-    await vi.importActual<typeof import("@mcpjam/sdk")>("@mcpjam/sdk");
+  const actual = await vi.importActual<typeof import("@mcpjam/sdk")>(
+    "@mcpjam/sdk"
+  );
   return {
     ...actual,
     finalizePassedForEval: ({ matchPassed }: { matchPassed: boolean }) =>
@@ -37,7 +38,7 @@ vi.mock("../../../utils/chat-helpers", () => ({
     modelDefinition: unknown,
     apiKey: unknown,
     baseUrls?: unknown,
-    customProviders?: unknown,
+    customProviders?: unknown
   ) => createLlmModelMock(modelDefinition, apiKey, baseUrls, customProviders),
 }));
 
@@ -232,7 +233,9 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
             model: "gpt-5-mini",
             provider: "openai",
             expectedToolCalls: [],
-            promptTurns: [{ id: "turn-1", prompt: "Hello", expectedToolCalls: [] }],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
             testCaseId: "case-1",
           },
         ],
@@ -272,7 +275,9 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
             model: "gpt-5-mini",
             provider: "openai",
             expectedToolCalls: [],
-            promptTurns: [{ id: "turn-1", prompt: "Hello", expectedToolCalls: [] }],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
             testCaseId: "case-1",
           },
         ],
@@ -294,7 +299,9 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       testCaseId: "case-1",
     });
 
-    expect(mcpClientManager.getToolsForAiSdk).toHaveBeenCalledWith(["server-1"]);
+    expect(mcpClientManager.getToolsForAiSdk).toHaveBeenCalledWith([
+      "server-1",
+    ]);
   });
 
   it("maps current fullStream chunks into eval stream events", async () => {
@@ -416,7 +423,7 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
           type: "step_finish",
           usage: { inputTokens: 2, outputTokens: 3 },
         }),
-      ]),
+      ])
     );
   });
 
@@ -450,20 +457,20 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
         convexAuthToken: "token",
         mcpClientManager: mcpClientManager as any,
         testCaseId: "case-1",
-      }),
+      })
     ).resolves.toBeDefined();
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://example.convex.site/stream",
       expect.objectContaining({
         method: "POST",
-      }),
+      })
     );
     const compareRequest = fetchMock.mock.calls[0]?.[1] as {
       body?: string;
     };
     expect(JSON.parse(compareRequest.body ?? "{}").model).toBe(
-      "anthropic/claude-haiku-4.5",
+      "anthropic/claude-haiku-4.5"
     );
     expect(createLlmModelMock).not.toHaveBeenCalled();
   });
@@ -497,20 +504,20 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
         suiteId: "suite-1",
         runId: null,
         emit: (event) => emitted.push(event as Record<string, unknown>),
-      }),
+      })
     ).resolves.toBeDefined();
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://example.convex.site/stream",
       expect.objectContaining({
         method: "POST",
-      }),
+      })
     );
     const streamRequest = fetchMock.mock.calls[0]?.[1] as {
       body?: string;
     };
     expect(JSON.parse(streamRequest.body ?? "{}").model).toBe(
-      "anthropic/claude-haiku-4.5",
+      "anthropic/claude-haiku-4.5"
     );
     expect(createLlmModelMock).not.toHaveBeenCalled();
     expect(emitted).toEqual(
@@ -519,7 +526,7 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
           type: "text_delta",
           content: "Done",
         }),
-      ]),
+      ])
     );
   });
 
@@ -576,7 +583,7 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
           baseUrl: "https://models.example/v1",
           modelIds: ["llama-3"],
         },
-      ],
+      ]
     );
   });
 
@@ -624,7 +631,7 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       }),
       "az-secret",
       { azure: "https://resource.openai.azure.com/openai" },
-      undefined,
+      undefined
     );
   });
 
@@ -671,7 +678,58 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
       }),
       "",
       { ollama: "http://ollama.internal:11434" },
+      undefined
+    );
+  });
+
+  it("passes request-level customProviders to createLlmModel for custom provider models", async () => {
+    const customProviderConfigs = [
+      {
+        name: "my-proxy",
+        protocol: "openai-compatible",
+        baseUrl: "https://my-proxy-url.com",
+        modelIds: ["gpt-5.2"],
+        apiKey: "custom-key-123",
+      },
+    ];
+
+    await runEvalSuiteWithAiSdk({
+      suiteId: "suite-1",
+      runId: null,
+      config: {
+        tests: [
+          {
+            title: "Custom provider test",
+            query: "Hello",
+            runs: 1,
+            model: "custom:my-proxy:gpt-5.2",
+            provider: "custom",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-1",
+          },
+        ],
+        environment: { servers: ["srv-1"] },
+      },
+      customProviders: customProviderConfigs,
+      convexClient: convexClient as any,
+      convexHttpUrl: "https://example.convex.site",
+      convexAuthToken: "token",
+      mcpClientManager: mcpClientManager as any,
+      testCaseId: "case-1",
+    });
+
+    expect(createLlmModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "custom:my-proxy:gpt-5.2",
+        provider: "custom",
+        customProviderName: "my-proxy",
+      }),
+      "",
       undefined,
+      customProviderConfigs
     );
   });
 });


### PR DESCRIPTION
## Summary

- Custom providers configured in Settings were available for Chat but not for Evals. The eval runner only checked `useAiProviderKeys` (which has no "custom" slot), so custom models always failed the credential gate. The server-side pipeline only received `customProviders` from org runtime configs, leaving local-mode custom providers unsupported.
- Client: recognize custom provider credentials in step completion check, collect and send `customProviders` config in eval run request
- Server: accept `customProviders` in `RunEvalsRequestSchema`, thread through `runEvalSuiteWithAiSdk` -> `runTestCase` -> `resolveEvalModelRuntime` -> `createLlmModel`
- Also clears all production tsc errors and enforces typecheck in CI

Fixes #1515

## Test plan

- [ ] Configure a custom provider in Settings, verify it appears in the Evals model dropdown
- [ ] Run an eval suite against a custom model and confirm it completes without credential errors
- [ ] Verify `npm run typecheck` passes with zero errors