### PR TITLE
fix(limit-modal): stop firing for guests on unrelated errors

### DIFF
--- a/mcpjam-inspector/client/src/lib/__tests__/mcpjam-limit.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/mcpjam-limit.test.ts
@@ -94,6 +94,42 @@ describe("isMCPJamModelLimitError", () => {
     ).toBe(true);
   });
 
+  it("detects rate-limit codes wrapped by formatStreamError's {message, details} envelope", () => {
+    // mcpjam-inspector/server/routes/mcp/chat-v2.ts:formatStreamError
+    // serializes non-auth API errors as `{message, details: <raw response
+    // body>}`. The real rate-limit code lives nested inside the
+    // stringified `details`, not at the top level of the message JSON.
+    expect(
+      isMCPJamModelLimitError({
+        message: JSON.stringify({
+          message: "AI_APICallError: rate limit hit",
+          details: JSON.stringify({
+            ok: false,
+            code: "user_rate_limit",
+            limitKind: "total",
+            error: "Daily MCPJam model limit reached. Use BYOK or try again tomorrow.",
+          }),
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("respects the concurrency carve-out in a formatStreamError envelope", () => {
+    expect(
+      isMCPJamModelLimitError({
+        message: JSON.stringify({
+          message: "AI_APICallError: rate limit hit",
+          details: JSON.stringify({
+            ok: false,
+            code: "user_rate_limit",
+            limitKind: "concurrency",
+            error: "Another credit-funded chat is still in flight.",
+          }),
+        }),
+      }),
+    ).toBe(false);
+  });
+
   it("ignores unrelated errors", () => {
     expect(
       isMCPJamModelLimitError({

--- a/mcpjam-inspector/client/src/lib/__tests__/mcpjam-limit.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/mcpjam-limit.test.ts
@@ -115,10 +115,14 @@ describe("isMCPJamModelLimitError", () => {
   });
 
   it("respects the concurrency carve-out in a formatStreamError envelope", () => {
+    // The serialized payload deliberately embeds the user-facing
+    // "MCPJam model limit" phrase alongside `limitKind: "concurrency"`
+    // so the trailing raw-message regex fallback can't sneak past the
+    // carve-out and open the modal for a transient throttle.
     expect(
       isMCPJamModelLimitError({
         message: JSON.stringify({
-          message: "AI_APICallError: rate limit hit",
+          message: "AI_APICallError: Daily MCPJam model limit reached",
           details: JSON.stringify({
             ok: false,
             code: "user_rate_limit",

--- a/mcpjam-inspector/client/src/lib/mcpjam-limit.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-limit.ts
@@ -68,6 +68,29 @@ const limitKindFromShape = (
   return value === "total" || value === "concurrency" ? value : undefined;
 };
 
+/** Expand `value` into the top-level JSON object(s) we're willing to
+ * inspect for a rate-limit signal. Recurses one extra level into a
+ * stringified `details` field so backend stream errors wrapped by
+ * `formatStreamError` as `{message, details: "<raw upstream JSON>"}`
+ * still surface the upstream `code`/`limitKind`. */
+const collectShapes = (
+  value: unknown,
+  shapes: Record<string, unknown>[],
+): void => {
+  let shape: Record<string, unknown> | null = null;
+  if (value && typeof value === "object") {
+    shape = value as Record<string, unknown>;
+  } else if (typeof value === "string" && value.length > 0) {
+    shape = extractEmbeddedJsonObject(value);
+  }
+  if (!shape) return;
+  shapes.push(shape);
+  if (typeof shape.details === "string") {
+    const inner = extractEmbeddedJsonObject(shape.details);
+    if (inner) shapes.push(inner);
+  }
+};
+
 export function isMCPJamModelLimitError(args: MCPJamLimitErrorInput): boolean {
   // Single source of truth for the concurrency carve-out: a transient
   // throttle resolves in seconds and is owned by the inline retry banner,
@@ -82,21 +105,17 @@ export function isMCPJamModelLimitError(args: MCPJamLimitErrorInput): boolean {
   //     the raw text when JSON.parse fails)
   //   - `message` as a JSON-prefixed string (AI SDK wraps SSE error chunks
   //     like `Backend stream error: 429 {"code":...}`)
+  //   - a stringified `shape.details` one level deeper — the inspector's
+  //     `formatStreamError` wraps non-auth backend errors as
+  //     `{message, details: "<raw response body>"}`, so the real rate-limit
+  //     code lives nested in `details`.
   // We deliberately avoid walking arbitrary nested keys or substring-matching
   // the bare `user_rate_limit` identifier — those caught unrelated error
   // payloads that happened to mention the identifier in passing and opened
   // the modal for guests on their first send.
   const shapes: Array<Record<string, unknown>> = [];
-  if (args.details && typeof args.details === "object") {
-    shapes.push(args.details as Record<string, unknown>);
-  } else if (typeof args.details === "string") {
-    const embedded = extractEmbeddedJsonObject(args.details);
-    if (embedded) shapes.push(embedded);
-  }
-  if (typeof args.message === "string" && args.message.length > 0) {
-    const embedded = extractEmbeddedJsonObject(args.message);
-    if (embedded) shapes.push(embedded);
-  }
+  collectShapes(args.details, shapes);
+  collectShapes(args.message, shapes);
 
   for (const shape of shapes) {
     // Honor a concurrency carve-out declared alongside the code so a

--- a/mcpjam-inspector/client/src/lib/mcpjam-limit.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-limit.ts
@@ -117,11 +117,17 @@ export function isMCPJamModelLimitError(args: MCPJamLimitErrorInput): boolean {
   collectShapes(args.details, shapes);
   collectShapes(args.message, shapes);
 
+  // First pass: a concurrency carve-out declared anywhere in the
+  // inspected shapes is global — the wrapper produced by
+  // `formatStreamError` and its parsed `details` describe the same
+  // error, so neither a sibling shape's `message` field nor the raw
+  // message regex below should re-open the modal for a transient
+  // throttle.
   for (const shape of shapes) {
-    // Honor a concurrency carve-out declared alongside the code so a
-    // throttle wrapped in a backend error string doesn't open the modal.
-    if (limitKindFromShape(shape) === "concurrency") continue;
+    if (limitKindFromShape(shape) === "concurrency") return false;
+  }
 
+  for (const shape of shapes) {
     const code = typeof shape.code === "string" ? shape.code : undefined;
     if (code && MCPJAM_LIMIT_CODES.has(code)) return true;
 

--- a/mcpjam-inspector/client/src/lib/mcpjam-limit.ts
+++ b/mcpjam-inspector/client/src/lib/mcpjam-limit.ts
@@ -7,8 +7,6 @@ const MCPJAM_LIMIT_CODES = new Set([
   MCPJAM_RATE_LIMIT_CODE,
   MCPJAM_USER_RATE_LIMIT_CODE,
 ]);
-const MCPJAM_RATE_LIMIT_CODE_PATTERN =
-  /\b(?:mcpjam_rate_limit|user_rate_limit)\b/;
 
 export type MCPJamLimitKind = "total" | "concurrency";
 
@@ -35,107 +33,40 @@ const tryParseJson = (value: string): unknown => {
   }
 };
 
-const collectJsonCandidates = (value: string): unknown[] => {
-  const candidates: unknown[] = [];
+/** Extract a JSON object embedded in a string. Backend errors come through
+ * the AI SDK transport wrapped like `Backend stream error: 429 {"code":...}`,
+ * so we accept either a full JSON string or one with a prefix. Returns null
+ * for anything that isn't a top-level JSON object — we deliberately don't
+ * dig further. */
+const extractEmbeddedJsonObject = (
+  value: string,
+): Record<string, unknown> | null => {
   const parsed = tryParseJson(value);
-  if (parsed !== null) {
-    candidates.push(parsed);
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    return parsed as Record<string, unknown>;
   }
 
   const jsonStart = value.indexOf("{");
   if (jsonStart > 0) {
     const parsedSuffix = tryParseJson(value.slice(jsonStart));
-    if (parsedSuffix !== null) {
-      candidates.push(parsedSuffix);
+    if (
+      parsedSuffix &&
+      typeof parsedSuffix === "object" &&
+      !Array.isArray(parsedSuffix)
+    ) {
+      return parsedSuffix as Record<string, unknown>;
     }
   }
 
-  return candidates;
+  return null;
 };
 
-const collectStringValues = (
-  value: unknown,
-  strings: string[] = [],
-  seen = new WeakSet<object>(),
-): string[] => {
-  if (typeof value === "string") {
-    strings.push(value);
-    return strings;
-  }
-
-  if (!value || typeof value !== "object") {
-    return strings;
-  }
-
-  if (seen.has(value)) {
-    return strings;
-  }
-  seen.add(value);
-
-  if (Array.isArray(value)) {
-    for (const item of value) {
-      collectStringValues(item, strings, seen);
-    }
-    return strings;
-  }
-
-  for (const item of Object.values(value)) {
-    collectStringValues(item, strings, seen);
-  }
-
-  return strings;
-};
-
-const findMCPJamRateLimitCode = (
-  value: unknown,
-  seen = new WeakSet<object>(),
-): string | undefined => {
-  if (!value || typeof value !== "object") return undefined;
-  if (seen.has(value)) return undefined;
-  seen.add(value);
-
-  if (
-    "code" in value &&
-    typeof (value as { code?: unknown }).code === "string" &&
-    MCPJAM_LIMIT_CODES.has((value as { code: string }).code)
-  ) {
-    return (value as { code: string }).code;
-  }
-
-  const values = Array.isArray(value) ? value : Object.values(value);
-  for (const item of values) {
-    const code = findMCPJamRateLimitCode(item, seen);
-    if (code) return code;
-  }
-
-  return undefined;
-};
-
-const findMCPJamLimitKind = (
-  value: unknown,
-  seen = new WeakSet<object>(),
+const limitKindFromShape = (
+  shape: Record<string, unknown>,
 ): MCPJamLimitKind | undefined => {
-  if (!value || typeof value !== "object") return undefined;
-  if (seen.has(value)) return undefined;
-  seen.add(value);
-
-  const limitKind = getStringProperty(value, "limitKind");
-  if (limitKind === "total" || limitKind === "concurrency") {
-    return limitKind;
-  }
-
-  const values = Array.isArray(value) ? value : Object.values(value);
-  for (const item of values) {
-    const nestedLimitKind = findMCPJamLimitKind(item, seen);
-    if (nestedLimitKind) return nestedLimitKind;
-  }
-
-  return undefined;
+  const value = shape.limitKind;
+  return value === "total" || value === "concurrency" ? value : undefined;
 };
-
-const isMCPJamLimitString = (value: string): boolean =>
-  MCPJAM_MODEL_LIMIT_PATTERN.test(value) ||
-  MCPJAM_RATE_LIMIT_CODE_PATTERN.test(value);
 
 export function isMCPJamModelLimitError(args: MCPJamLimitErrorInput): boolean {
   // Single source of truth for the concurrency carve-out: a transient
@@ -143,43 +74,54 @@ export function isMCPJamModelLimitError(args: MCPJamLimitErrorInput): boolean {
   // never the modal. Downstream consumers don't need to re-check.
   if (args.limitKind === "concurrency") return false;
 
-  if (args.code === MCPJAM_RATE_LIMIT_CODE) return true;
-  if (args.code === MCPJAM_USER_RATE_LIMIT_CODE) return true;
+  if (args.code && MCPJAM_LIMIT_CODES.has(args.code)) return true;
 
-  const valuesToInspect = [args.message, args.details];
-  for (const value of valuesToInspect) {
-    if (typeof value === "string") {
-      for (const parsed of collectJsonCandidates(value)) {
-        const code = findMCPJamRateLimitCode(parsed);
-        const limitKind = findMCPJamLimitKind(parsed);
-        const hasLimitString = collectStringValues(parsed).some((item) =>
-          isMCPJamLimitString(item),
-        );
-        if (
-          limitKind === "concurrency" &&
-          (code === MCPJAM_USER_RATE_LIMIT_CODE || hasLimitString)
-        ) {
-          return false;
-        }
-        if (code || hasLimitString) return true;
-      }
+  // Only inspect well-defined shapes the backend actually emits:
+  //   - `details` as an already-parsed object
+  //   - `details` as a raw JSON string (notifyMCPJamLimitErrorFromResponse keeps
+  //     the raw text when JSON.parse fails)
+  //   - `message` as a JSON-prefixed string (AI SDK wraps SSE error chunks
+  //     like `Backend stream error: 429 {"code":...}`)
+  // We deliberately avoid walking arbitrary nested keys or substring-matching
+  // the bare `user_rate_limit` identifier — those caught unrelated error
+  // payloads that happened to mention the identifier in passing and opened
+  // the modal for guests on their first send.
+  const shapes: Array<Record<string, unknown>> = [];
+  if (args.details && typeof args.details === "object") {
+    shapes.push(args.details as Record<string, unknown>);
+  } else if (typeof args.details === "string") {
+    const embedded = extractEmbeddedJsonObject(args.details);
+    if (embedded) shapes.push(embedded);
+  }
+  if (typeof args.message === "string" && args.message.length > 0) {
+    const embedded = extractEmbeddedJsonObject(args.message);
+    if (embedded) shapes.push(embedded);
+  }
 
-      if (isMCPJamLimitString(value)) return true;
-      continue;
+  for (const shape of shapes) {
+    // Honor a concurrency carve-out declared alongside the code so a
+    // throttle wrapped in a backend error string doesn't open the modal.
+    if (limitKindFromShape(shape) === "concurrency") continue;
+
+    const code = typeof shape.code === "string" ? shape.code : undefined;
+    if (code && MCPJAM_LIMIT_CODES.has(code)) return true;
+
+    const errorMessage =
+      typeof shape.error === "string"
+        ? shape.error
+        : typeof shape.message === "string"
+          ? shape.message
+          : undefined;
+    if (errorMessage && MCPJAM_MODEL_LIMIT_PATTERN.test(errorMessage)) {
+      return true;
     }
+  }
 
-    const code = findMCPJamRateLimitCode(value);
-    const limitKind = findMCPJamLimitKind(value);
-    const hasLimitString = collectStringValues(value).some((item) =>
-      isMCPJamLimitString(item),
-    );
-    if (
-      limitKind === "concurrency" &&
-      (code === MCPJAM_USER_RATE_LIMIT_CODE || hasLimitString)
-    ) {
-      return false;
-    }
-    if (code || hasLimitString) return true;
+  if (
+    typeof args.message === "string" &&
+    MCPJAM_MODEL_LIMIT_PATTERN.test(args.message)
+  ) {
+    return true;
   }
 
   return false;


### PR DESCRIPTION
## Summary

Guests were getting the "You've used today's free guest limit" modal **on their very first chat send**, even when they hadn't actually exhausted any quota.

## Root cause

`isMCPJamModelLimitError` in `mcpjam-inspector/client/src/lib/mcpjam-limit.ts` was over-greedy:

- `findMCPJamRateLimitCode` walked **every nested key** in the error payload looking for a `code` field set to `mcpjam_rate_limit` / `user_rate_limit`.
- `collectStringValues` flattened every string in the payload and tested `\b(?:mcpjam_rate_limit|user_rate_limit)\b` against each one.

That meant any error response whose body happened to mention those identifiers anywhere (enum literals echoed back in serialized error types, an upstream error chain that listed possible codes, etc.) was misclassified as a genuine rate-limit hit. Combined with `notifyMCPJamLimitError({ message: chatError.message })` running on every chat error in `use-chat-session.ts`, this surfaced the guest upsell modal on unrelated 4xx/5xx responses.

## Fix

Restrict detection to the explicit shapes the backend actually emits:

1. Caller-provided top-level `code` matching the rate-limit codes.
2. `details` as a parsed object with `{ code, limitKind?, error? }`.
3. `details` as a raw JSON string (kept by `notifyMCPJamLimitErrorFromResponse` when `JSON.parse` fails — the wrapper still works).
4. `message` as a wrapped `Backend stream error: 429 {"code":…}` string (the AI SDK transport's SSE error format).
5. The user-facing `"Daily MCPJam model limit reached…"` phrase, via the existing `/mcpjam[\w\s-]*model limit/i` regex.

Drops the recursive nested-key walker and the bare-identifier substring regex — both of which were the source of false positives.

## Test plan

The existing `mcpjam-limit.test.ts` suite covers each surviving detection path (canonical codes, prefixed backend strings, the concurrency carve-out, and structured-details model-limit text), and the change is strictly a tightening of the detector. Verified manually by tracing every case through the new logic.

- [ ] Hosted guest: open the chat, send any prompt → request goes through, modal stays closed (unless the backend actually returns a 429 with `code: "user_rate_limit"`).
- [ ] Real rate-limit hit (signed-in user past their daily cap): topup modal still opens.
- [ ] Run `npm test -- mcpjam-limit` once dependencies are installed.

https://claude.ai/code/session_01U8jB6iZ6Z7vSKS7zNbVcrM

---
_Generated by [Claude Code](https://claude.ai/code/session_01U8jB6iZ6Z7vSKS7zNbVcrM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors client-side rate-limit detection logic that controls when the limit modal opens; mistakes could suppress legitimate limit modals or reintroduce false positives, but scope is limited to error parsing/UI behavior.
> 
> **Overview**
> Tightens `isMCPJamModelLimitError` to stop opening the guest limit modal for unrelated errors by **removing deep recursive scanning and bare substring matching** and instead inspecting only known backend error shapes (top-level `code`, embedded JSON objects in `message`/`details`, and one extra level of stringified `details`).
> 
> Adds coverage for `formatStreamError`’s `{message, details}` envelope and ensures the `limitKind: "concurrency"` carve-out suppresses the modal even when wrapper messages contain "model limit" text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3788a11d5ef1f87eadcc0aee51df85a323f52d13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->