### PR TITLE
hot fix: resolves unkonwn ip

### DIFF
--- a/mcpjam-inspector/server/routes/web/guest-session.ts
+++ b/mcpjam-inspector/server/routes/web/guest-session.ts
@@ -36,7 +36,7 @@ const GUEST_SESSION_COOKIE_NAME = "__Host-mcpjam_guest_session";
 // Passing the entire Cookie header would leak unrelated auth/CSRF cookies
 // from the Inspector origin to Convex / hosted MCPJam.
 function extractGuestSessionCookie(
-  cookieHeader: string | null | undefined,
+  cookieHeader: string | null | undefined
 ): string | null {
   if (!cookieHeader) return null;
   const prefix = `${GUEST_SESSION_COOKIE_NAME}=`;
@@ -100,7 +100,7 @@ guestSession.post("/", async (c) => {
         code: ErrorCode.FORBIDDEN,
         message: "Guest access is disabled in this environment.",
       },
-      403,
+      403
     );
   }
 
@@ -112,7 +112,7 @@ guestSession.post("/", async (c) => {
         message:
           "Unable to determine client IP for guest session rate limiting.",
       },
-      429,
+      429
     );
   }
   const rateLimitKey = ip ?? "local-dev";
@@ -128,7 +128,7 @@ guestSession.post("/", async (c) => {
             code: ErrorCode.RATE_LIMITED,
             message: "Too many guest session requests. Try again later.",
           },
-          429,
+          429
         );
       }
       entry.count++;
@@ -160,7 +160,7 @@ guestSession.post("/", async (c) => {
     cookie: extractGuestSessionCookie(c.req.header("cookie")),
     userAgent: c.req.header("user-agent") ?? null,
     body,
-    ipHash,
+    ...(ipHash ? { ipHash } : {}),
   };
 
   const result = shouldFetchGuestSessionFromConvex()
@@ -185,17 +185,16 @@ guestSession.post("/", async (c) => {
         code: ErrorCode.FORBIDDEN,
         message: "Guest session revoked.",
       },
-      403,
+      403
     );
   }
 
   return c.json(
     {
       code: ErrorCode.INTERNAL_ERROR,
-      message:
-        "Unable to obtain a guest session right now. Please try again.",
+      message: "Unable to obtain a guest session right now. Please try again.",
     },
-    503,
+    503
   );
 });
 
@@ -234,7 +233,7 @@ guestSession.post("/revoke", async (c) => {
         code: ErrorCode.FORBIDDEN,
         message: "Guest access is disabled in this environment.",
       },
-      403,
+      403
     );
   }
 
@@ -275,7 +274,7 @@ guestSession.post("/revoke", async (c) => {
       code: ErrorCode.INTERNAL_ERROR,
       message: "Unable to revoke guest session right now.",
     },
-    503,
+    503
   );
 });
 
@@ -299,7 +298,7 @@ guestSession.post("/promotion-proof", async (c) => {
         code: ErrorCode.FORBIDDEN,
         message: "Guest access is disabled in this environment.",
       },
-      403,
+      403
     );
   }
 
@@ -311,7 +310,7 @@ guestSession.post("/promotion-proof", async (c) => {
         message:
           "Unable to determine client IP for guest session rate limiting.",
       },
-      429,
+      429
     );
   }
   const rateLimitKey = ip ?? "local-dev";
@@ -326,7 +325,7 @@ guestSession.post("/promotion-proof", async (c) => {
             code: ErrorCode.RATE_LIMITED,
             message: "Too many guest session requests. Try again later.",
           },
-          429,
+          429
         );
       }
       entry.count++;
@@ -364,7 +363,7 @@ guestSession.post("/promotion-proof", async (c) => {
         code: ErrorCode.FORBIDDEN,
         message: "Guest session revoked.",
       },
-      403,
+      403
     );
   }
 
@@ -374,7 +373,7 @@ guestSession.post("/promotion-proof", async (c) => {
       message:
         "Unable to obtain a guest promotion proof right now. Please try again.",
     },
-    503,
+    503
   );
 });
 

--- a/mcpjam-inspector/server/utils/__tests__/guest-session-source.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/guest-session-source.test.ts
@@ -34,7 +34,7 @@ describe("guest-session-source", () => {
     delete process.env.MCPJAM_GUEST_JWKS_URL;
     mockProvisionGuestAuthConfigToConvex.mockResolvedValue(undefined);
     mockGetGuestSessionSharedSecret.mockReturnValue(
-      "test-guest-session-secret",
+      "test-guest-session-secret"
     );
     global.fetch = vi.fn();
   });
@@ -69,8 +69,8 @@ describe("guest-session-source", () => {
         {
           status: 200,
           headers: { "Content-Type": "application/json" },
-        },
-      ),
+        }
+      )
     );
 
     const { fetchRemoteGuestSession } = await import(
@@ -87,7 +87,7 @@ describe("guest-session-source", () => {
       expect.objectContaining({
         method: "POST",
         signal: expect.anything(),
-      }),
+      })
     );
   });
 
@@ -102,8 +102,8 @@ describe("guest-session-source", () => {
         {
           status: 200,
           headers: { "Content-Type": "application/json" },
-        },
-      ),
+        }
+      )
     );
 
     const { fetchConvexGuestSession } = await import(
@@ -120,13 +120,13 @@ describe("guest-session-source", () => {
       expect.objectContaining({
         method: "POST",
         signal: expect.anything(),
-      }),
+      })
     );
   });
 
   it("returns kind:miss for upstream 204 (lookup_only)", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
-      new Response(null, { status: 204 }),
+      new Response(null, { status: 204 })
     );
     const { fetchConvexGuestSession } = await import(
       "../guest-session-source.js"
@@ -139,7 +139,7 @@ describe("guest-session-source", () => {
 
   it("returns kind:miss for upstream 404 in lookup_only mode", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
-      new Response(null, { status: 404 }),
+      new Response(null, { status: 404 })
     );
     const { fetchConvexGuestSession } = await import(
       "../guest-session-source.js"
@@ -152,7 +152,7 @@ describe("guest-session-source", () => {
 
   it("returns kind:error for upstream 404 in lookup_or_create mode (not silent miss)", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
-      new Response(null, { status: 404 }),
+      new Response(null, { status: 404 })
     );
     const { fetchConvexGuestSession } = await import(
       "../guest-session-source.js"
@@ -179,15 +179,17 @@ describe("guest-session-source", () => {
             "Content-Type": "application/json",
             "Set-Cookie": "__Host-mcpjam_guest_session=opaque; Path=/",
           },
-        },
-      ),
+        }
+      )
     );
     const { fetchConvexGuestSession } = await import(
       "../guest-session-source.js"
     );
     const result = await fetchConvexGuestSession();
     expect(result.setCookies.length).toBeGreaterThan(0);
-    expect(result.setCookies[0]).toContain("__Host-mcpjam_guest_session=opaque");
+    expect(result.setCookies[0]).toContain(
+      "__Host-mcpjam_guest_session=opaque"
+    );
   });
 
   it("forwards browser cookie/UA and omits spoofable IP headers upstream", async () => {
@@ -198,8 +200,8 @@ describe("guest-session-source", () => {
           token: "t",
           expiresAt: Date.now() + 60_000,
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
     );
     const { fetchConvexGuestSession } = await import(
       "../guest-session-source.js"
@@ -217,7 +219,7 @@ describe("guest-session-source", () => {
     expect(headers["X-Forwarded-For"]).toBeUndefined();
     expect(headers["X-Real-IP"]).toBeUndefined();
     expect(init.body).toBe(
-      JSON.stringify({ mode: "lookup_or_create", legacyToken: "legacy" }),
+      JSON.stringify({ mode: "lookup_or_create", legacyToken: "legacy" })
     );
   });
 
@@ -229,8 +231,8 @@ describe("guest-session-source", () => {
           token: "t",
           expiresAt: Date.now() + 60_000,
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
     );
     const { fetchConvexGuestSession } = await import(
       "../guest-session-source.js"
@@ -246,7 +248,7 @@ describe("guest-session-source", () => {
     expect(headers["x-mcpjam-guest-ip-hash"]).toBe("abc-hash");
   });
 
-  it("sends _unknown sentinel when ipHash is null but the field is set", async () => {
+  it("omits x-mcpjam-guest-ip-hash when ipHash is null", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -254,8 +256,8 @@ describe("guest-session-source", () => {
           token: "t",
           expiresAt: Date.now() + 60_000,
         }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      )
     );
     const { fetchConvexGuestSession } = await import(
       "../guest-session-source.js"
@@ -268,7 +270,7 @@ describe("guest-session-source", () => {
 
     const init = vi.mocked(global.fetch).mock.calls[0]![1] as RequestInit;
     const headers = init.headers as Record<string, string>;
-    expect(headers["x-mcpjam-guest-ip-hash"]).toBe("_unknown");
+    expect(headers["x-mcpjam-guest-ip-hash"]).toBeUndefined();
   });
 
   it("waits for provisioning before fetching Convex JWKS", async () => {
@@ -276,7 +278,7 @@ describe("guest-session-source", () => {
       new Response(JSON.stringify({ keys: [] }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
-      }),
+      })
     );
 
     const { fetchRemoteGuestJwks } = await import("../guest-session-source.js");
@@ -290,7 +292,7 @@ describe("guest-session-source", () => {
         method: "GET",
         headers: { Accept: "application/json" },
         signal: expect.anything(),
-      }),
+      })
     );
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -47,7 +47,7 @@ vi.mock("ai", async () => {
     createUIMessageStreamResponse: vi.fn().mockReturnValue(
       new Response("{}", {
         headers: { "Content-Type": "text/event-stream" },
-      }),
+      })
     ),
   };
 });
@@ -58,8 +58,9 @@ vi.mock("@/shared/http-tool-calls", () => ({
 }));
 
 vi.mock("../chat-helpers", async () => {
-  const actual =
-    await vi.importActual<typeof import("../chat-helpers")>("../chat-helpers");
+  const actual = await vi.importActual<typeof import("../chat-helpers")>(
+    "../chat-helpers"
+  );
   return {
     ...actual,
     scrubMcpAppsToolResultsForBackend: vi.fn((messages) => messages),
@@ -94,7 +95,7 @@ describe("mcpjam-stream-handler", () => {
           finishReason: "stop",
           totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
         },
-      ]),
+      ])
     );
   });
 
@@ -143,7 +144,7 @@ describe("mcpjam-stream-handler", () => {
     await lastExecution;
 
     const fetchBody = JSON.parse(
-      ((global.fetch as any).mock.calls[0]?.[1]?.body as string) ?? "{}",
+      ((global.fetch as any).mock.calls[0]?.[1]?.body as string) ?? "{}"
     );
     const scrubbedMessages = JSON.parse(fetchBody.messages);
 
@@ -169,7 +170,7 @@ describe("mcpjam-stream-handler", () => {
         endedAt: expect.any(Number),
         spans: expect.any(Array),
         modelId: expect.any(String),
-      }),
+      })
     );
   });
 
@@ -217,7 +218,7 @@ describe("mcpjam-stream-handler", () => {
     await lastExecution;
 
     const fetchBody = JSON.parse(
-      ((global.fetch as any).mock.calls[0]?.[1]?.body as string) ?? "{}",
+      ((global.fetch as any).mock.calls[0]?.[1]?.body as string) ?? "{}"
     );
     const scrubbedMessages = JSON.parse(fetchBody.messages);
 
@@ -324,7 +325,7 @@ describe("mcpjam-stream-handler", () => {
     expect(onConversationComplete).toHaveBeenCalledTimes(1);
     expect(onStreamComplete).toHaveBeenCalledTimes(1);
     expect(onStreamComplete.mock.invocationCallOrder[0]).toBeGreaterThan(
-      onConversationComplete.mock.invocationCallOrder[0],
+      onConversationComplete.mock.invocationCallOrder[0]
     );
   });
 
@@ -380,7 +381,7 @@ describe("mcpjam-stream-handler", () => {
     await lastExecution;
 
     const fetchBody = JSON.parse(
-      ((global.fetch as any).mock.calls[0]?.[1]?.body as string) ?? "{}",
+      ((global.fetch as any).mock.calls[0]?.[1]?.body as string) ?? "{}"
     );
     const scrubbedMessages = JSON.parse(fetchBody.messages);
 
@@ -438,7 +439,7 @@ describe("mcpjam-stream-handler", () => {
           finishReason: "stop",
           totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
         },
-      ]),
+      ])
     );
 
     await handleMCPJamFreeChatModel({
@@ -500,7 +501,7 @@ describe("mcpjam-stream-handler", () => {
           finishReason: "stop",
           totalUsage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
         },
-      ]),
+      ])
     );
 
     await handleMCPJamFreeChatModel({
@@ -565,7 +566,7 @@ describe("mcpjam-stream-handler", () => {
           promptIndex: 0,
           stepIndex: 0,
         }),
-      ]),
+      ])
     );
     expect(traceEvents[4]).toMatchObject({
       type: "turn_finish",
@@ -602,7 +603,7 @@ describe("mcpjam-stream-handler", () => {
             totalTokens: 15,
           },
         },
-      ]),
+      ])
     );
 
     await handleMCPJamFreeChatModel({
@@ -629,7 +630,7 @@ describe("mcpjam-stream-handler", () => {
     });
 
     const llmSpan = snapshot.snapshot.spans.find(
-      (s: any) => s.category === "llm",
+      (s: any) => s.category === "llm"
     );
     expect(llmSpan).toBeDefined();
     expect(llmSpan.inputTokens).toBe(10);
@@ -650,7 +651,7 @@ describe("mcpjam-stream-handler", () => {
       () =>
         new Promise<Response>((resolve) => {
           resolveFetch = resolve;
-        }),
+        })
     );
 
     const collector = createHostedRpcLogCollector({
@@ -705,13 +706,13 @@ describe("mcpjam-stream-handler", () => {
           finishReason: "stop",
           totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
         },
-      ]),
+      ])
     );
 
     await lastExecution;
 
     const rpcChunks = writtenChunks.filter(
-      (chunk) => chunk?.type === "data-rpc-log",
+      (chunk) => chunk?.type === "data-rpc-log"
     );
     expect(rpcChunks).toEqual(
       expect.arrayContaining([
@@ -727,7 +728,7 @@ describe("mcpjam-stream-handler", () => {
             direction: "receive",
           }),
         }),
-      ]),
+      ])
     );
   });
 
@@ -745,7 +746,7 @@ describe("mcpjam-stream-handler", () => {
           finishReason: "stop",
           totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
         },
-      ]),
+      ])
     );
     vi.mocked(hasUnresolvedToolCalls).mockImplementation(
       (messages) =>
@@ -753,8 +754,8 @@ describe("mcpjam-stream-handler", () => {
           (message: any) =>
             message?.role === "assistant" &&
             Array.isArray(message.content) &&
-            message.content.some((part: any) => part.type === "tool-call"),
-        ) && !messages.some((message: any) => message?.role === "tool"),
+            message.content.some((part: any) => part.type === "tool-call")
+        ) && !messages.some((message: any) => message?.role === "tool")
     );
     vi.mocked(executeToolCallsFromMessages).mockImplementation(
       async (messages: any[]) => {
@@ -776,7 +777,7 @@ describe("mcpjam-stream-handler", () => {
         };
         messages.splice(2, 0, toolResultMessage);
         return [toolResultMessage] as any;
-      },
+      }
     );
 
     await handleMCPJamFreeChatModel({
@@ -801,7 +802,7 @@ describe("mcpjam-stream-handler", () => {
       .filter((chunk) => chunk?.type === "data-trace-event")
       .map((chunk) => chunk.data);
     const requestPayloadEvents = traceEvents.filter(
-      (event) => event.type === "request_payload",
+      (event) => event.type === "request_payload"
     );
 
     expect(traceEvents.map((event) => event.type)).toEqual(
@@ -812,7 +813,7 @@ describe("mcpjam-stream-handler", () => {
         "tool_result",
         "trace_snapshot",
         "turn_finish",
-      ]),
+      ])
     );
     expect(traceEvents).toEqual(
       expect.arrayContaining([
@@ -837,7 +838,7 @@ describe("mcpjam-stream-handler", () => {
             }),
           }),
         }),
-      ]),
+      ])
     );
     expect(requestPayloadEvents).toHaveLength(2);
     expect(requestPayloadEvents.map((event) => event.stepIndex)).toEqual([
@@ -906,7 +907,7 @@ describe("mcpjam-stream-handler", () => {
       delete process.env.GUEST_SESSION_HASH_PEPPER;
     });
 
-    it("sends the _unknown sentinel when clientIp is null", async () => {
+    it("omits the guest IP hash header when clientIp is null", async () => {
       process.env.GUEST_SESSION_HASH_PEPPER = "test-pepper-for-ip-hash";
 
       await handleMCPJamFreeChatModel({
@@ -924,7 +925,7 @@ describe("mcpjam-stream-handler", () => {
 
       const headers = (global.fetch as any).mock.calls[0]?.[1]
         ?.headers as Record<string, string>;
-      expect(headers["x-mcpjam-guest-ip-hash"]).toBe("_unknown");
+      expect(headers["x-mcpjam-guest-ip-hash"]).toBeUndefined();
 
       delete process.env.GUEST_SESSION_HASH_PEPPER;
     });
@@ -954,6 +955,30 @@ describe("mcpjam-stream-handler", () => {
       expect(headers["x-mcpjam-guest-ip-hash"]).toMatch(/^[A-Za-z0-9_-]+$/);
 
       delete process.env.GUEST_SESSION_HASH_PEPPER;
+    });
+
+    it("drops caller-provided guest IP hash when clientIp is null", async () => {
+      await handleMCPJamFreeChatModel({
+        messages: [{ role: "user", content: "hi" }] as any,
+        modelId: "gpt-4.1-mini",
+        systemPrompt: "You are helpful",
+        tools: {},
+        mcpClientManager: {
+          getAllToolsMetadata: vi.fn().mockReturnValue({}),
+        } as any,
+        clientIp: null,
+        extraHeaders: {
+          "x-mcpjam-guest-ip-hash": "attacker-controlled",
+          "X-MCPJam-Guest-IP-Hash": "attacker-controlled-case",
+        },
+      });
+
+      await lastExecution;
+
+      const headers = (global.fetch as any).mock.calls[0]?.[1]
+        ?.headers as Record<string, string>;
+      expect(headers["x-mcpjam-guest-ip-hash"]).toBeUndefined();
+      expect(headers["X-MCPJam-Guest-IP-Hash"]).toBeUndefined();
     });
 
     it("hashes IPv4 and ::ffff:-mapped IPv6 of the same client identically", async () => {

--- a/mcpjam-inspector/server/utils/guest-session-source.ts
+++ b/mcpjam-inspector/server/utils/guest-session-source.ts
@@ -20,7 +20,9 @@ export type GuestSessionFetchContext = {
   body?: GuestSessionRequestBody | null;
   // Hashed client IP so the upstream can record the IP-bucket key on the
   // guest's session row at resolve time. Letting the display path read it
-  // from the row before any /stream call has run.
+  // from the row before any /stream call has run. Omitted when unavailable so
+  // Convex falls back to cookie-only guest limits instead of a shared unknown
+  // IP bucket.
   ipHash?: string | null;
 };
 
@@ -86,7 +88,7 @@ function readSetCookies(headers: Headers): string[] {
 
 function buildForwardedHeaders(
   context: GuestSessionFetchContext | undefined,
-  extra: Record<string, string>,
+  extra: Record<string, string>
 ): Record<string, string> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
@@ -98,14 +100,14 @@ function buildForwardedHeaders(
   if (context?.userAgent) {
     headers["User-Agent"] = context.userAgent;
   }
-  if (context?.ipHash !== undefined) {
-    headers["x-mcpjam-guest-ip-hash"] = context.ipHash ?? "_unknown";
+  if (context?.ipHash) {
+    headers["x-mcpjam-guest-ip-hash"] = context.ipHash;
   }
   return headers;
 }
 
 function buildRequestBody(
-  context: GuestSessionFetchContext | undefined,
+  context: GuestSessionFetchContext | undefined
 ): string {
   const body: GuestSessionRequestBody = {};
   if (context?.body?.mode) body.mode = context.body.mode;
@@ -123,8 +125,7 @@ function parseSessionPayload(raw: unknown): RemoteGuestSession | null {
     return null;
   }
   return {
-    guestId:
-      typeof session.guestId === "string" ? session.guestId : undefined,
+    guestId: typeof session.guestId === "string" ? session.guestId : undefined,
     token: session.token,
     expiresAt: session.expiresAt,
   };
@@ -134,7 +135,7 @@ async function performGuestSessionFetch(
   url: string,
   init: RequestInit,
   source: "Convex" | "MCPJam",
-  mode: "lookup_or_create" | "lookup_only" | undefined,
+  mode: "lookup_or_create" | "lookup_only" | undefined
 ): Promise<GuestSessionFetchResult> {
   try {
     const response = await fetch(url, init);
@@ -154,7 +155,7 @@ async function performGuestSessionFetch(
 
     if (!response.ok) {
       logger.warn(
-        `[guest-auth] Failed to fetch ${source} guest session: ${response.status} ${response.statusText}`,
+        `[guest-auth] Failed to fetch ${source} guest session: ${response.status} ${response.statusText}`
       );
       return { kind: "error", status: response.status, setCookies };
     }
@@ -169,22 +170,26 @@ async function performGuestSessionFetch(
     const session = parseSessionPayload(body);
     if (!session) {
       logger.warn(
-        `[guest-auth] ${source} guest session response was missing token or expiresAt`,
+        `[guest-auth] ${source} guest session response was missing token or expiresAt`
       );
       return { kind: "error", status: 503, setCookies };
     }
 
-    logger.info(`[guest-auth] Fetched guest token from ${source} guest session`);
+    logger.info(
+      `[guest-auth] Fetched guest token from ${source} guest session`
+    );
     return { kind: "session", session, setCookies };
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
-    logger.warn(`[guest-auth] Failed to fetch ${source} guest session: ${errMsg}`);
+    logger.warn(
+      `[guest-auth] Failed to fetch ${source} guest session: ${errMsg}`
+    );
     return { kind: "error", status: 503, setCookies: [] };
   }
 }
 
 export async function fetchRemoteGuestSession(
-  context?: GuestSessionFetchContext,
+  context?: GuestSessionFetchContext
 ): Promise<GuestSessionFetchResult> {
   return performGuestSessionFetch(
     getRemoteGuestSessionUrl(),
@@ -195,19 +200,19 @@ export async function fetchRemoteGuestSession(
       signal: AbortSignal.timeout(10_000),
     },
     "MCPJam",
-    context?.body?.mode,
+    context?.body?.mode
   );
 }
 
 export async function fetchConvexGuestSession(
-  context?: GuestSessionFetchContext,
+  context?: GuestSessionFetchContext
 ): Promise<GuestSessionFetchResult> {
   try {
     await provisionGuestAuthConfigToConvex();
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
     logger.warn(
-      `[guest-auth] Failed to provision Convex guest auth env: ${errMsg}`,
+      `[guest-auth] Failed to provision Convex guest auth env: ${errMsg}`
     );
     return { kind: "error", status: 503, setCookies: [] };
   }
@@ -223,7 +228,7 @@ export async function fetchConvexGuestSession(
       signal: AbortSignal.timeout(10_000),
     },
     "Convex",
-    context?.body?.mode,
+    context?.body?.mode
   );
 }
 
@@ -282,7 +287,7 @@ export type GuestSessionRevokeResult = {
 async function performGuestSessionRevoke(
   url: string,
   init: RequestInit,
-  source: "Convex" | "MCPJam",
+  source: "Convex" | "MCPJam"
 ): Promise<GuestSessionRevokeResult> {
   try {
     const response = await fetch(url, init);
@@ -298,28 +303,28 @@ async function performGuestSessionRevoke(
     }
     if (!response.ok) {
       logger.warn(
-        `[guest-auth] ${source} guest session revoke returned ${response.status} ${response.statusText}`,
+        `[guest-auth] ${source} guest session revoke returned ${response.status} ${response.statusText}`
       );
     }
     return { status: response.status, setCookies, body };
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
     logger.warn(
-      `[guest-auth] Failed to revoke guest session via ${source}: ${errMsg}`,
+      `[guest-auth] Failed to revoke guest session via ${source}: ${errMsg}`
     );
     return { status: 503, setCookies: [], body: null };
   }
 }
 
 export async function fetchConvexGuestSessionRevoke(
-  context?: GuestSessionFetchContext,
+  context?: GuestSessionFetchContext
 ): Promise<GuestSessionRevokeResult> {
   try {
     await provisionGuestAuthConfigToConvex();
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
     logger.warn(
-      `[guest-auth] Failed to provision Convex guest auth env: ${errMsg}`,
+      `[guest-auth] Failed to provision Convex guest auth env: ${errMsg}`
     );
     return { status: 503, setCookies: [], body: null };
   }
@@ -333,12 +338,12 @@ export async function fetchConvexGuestSessionRevoke(
       }),
       signal: AbortSignal.timeout(10_000),
     },
-    "Convex",
+    "Convex"
   );
 }
 
 export async function fetchRemoteGuestSessionRevoke(
-  context?: GuestSessionFetchContext,
+  context?: GuestSessionFetchContext
 ): Promise<GuestSessionRevokeResult> {
   return performGuestSessionRevoke(
     getRemoteGuestSessionRevokeUrl(),
@@ -347,7 +352,7 @@ export async function fetchRemoteGuestSessionRevoke(
       headers: buildForwardedHeaders(context, {}),
       signal: AbortSignal.timeout(10_000),
     },
-    "MCPJam",
+    "MCPJam"
   );
 }
 
@@ -363,7 +368,7 @@ export type GuestPromotionProofResult =
 async function performGuestPromotionProofFetch(
   url: string,
   init: RequestInit,
-  source: "Convex" | "MCPJam",
+  source: "Convex" | "MCPJam"
 ): Promise<GuestPromotionProofResult> {
   try {
     const response = await fetch(url, init);
@@ -383,13 +388,13 @@ async function performGuestPromotionProofFetch(
         // fall through
       }
       logger.warn(
-        `[guest-auth] ${source} guest promotion proof returned 403 ${response.statusText}`,
+        `[guest-auth] ${source} guest promotion proof returned 403 ${response.statusText}`
       );
       return { kind: "error", status: 403 };
     }
     if (!response.ok) {
       logger.warn(
-        `[guest-auth] ${source} guest promotion proof returned ${response.status} ${response.statusText}`,
+        `[guest-auth] ${source} guest promotion proof returned ${response.status} ${response.statusText}`
       );
       return { kind: "error", status: response.status };
     }
@@ -408,17 +413,20 @@ async function performGuestPromotionProofFetch(
       typeof (body as Record<string, unknown>).expiresAt !== "number"
     ) {
       logger.warn(
-        `[guest-auth] ${source} guest promotion proof response was missing token or expiresAt`,
+        `[guest-auth] ${source} guest promotion proof response was missing token or expiresAt`
       );
       return { kind: "error", status: 503 };
     }
 
-    const proof = body as { guestId?: string; token: string; expiresAt: number };
+    const proof = body as {
+      guestId?: string;
+      token: string;
+      expiresAt: number;
+    };
     return {
       kind: "proof",
       proof: {
-        guestId:
-          typeof proof.guestId === "string" ? proof.guestId : undefined,
+        guestId: typeof proof.guestId === "string" ? proof.guestId : undefined,
         token: proof.token,
         expiresAt: proof.expiresAt,
       },
@@ -426,21 +434,21 @@ async function performGuestPromotionProofFetch(
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
     logger.warn(
-      `[guest-auth] Failed to fetch ${source} guest promotion proof: ${errMsg}`,
+      `[guest-auth] Failed to fetch ${source} guest promotion proof: ${errMsg}`
     );
     return { kind: "error", status: 503 };
   }
 }
 
 export async function fetchConvexGuestPromotionProof(
-  context?: GuestSessionFetchContext,
+  context?: GuestSessionFetchContext
 ): Promise<GuestPromotionProofResult> {
   try {
     await provisionGuestAuthConfigToConvex();
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : String(error);
     logger.warn(
-      `[guest-auth] Failed to provision Convex guest auth env: ${errMsg}`,
+      `[guest-auth] Failed to provision Convex guest auth env: ${errMsg}`
     );
     return { kind: "error", status: 503 };
   }
@@ -454,12 +462,12 @@ export async function fetchConvexGuestPromotionProof(
       }),
       signal: AbortSignal.timeout(10_000),
     },
-    "Convex",
+    "Convex"
   );
 }
 
 export async function fetchRemoteGuestPromotionProof(
-  context?: GuestSessionFetchContext,
+  context?: GuestSessionFetchContext
 ): Promise<GuestPromotionProofResult> {
   return performGuestPromotionProofFetch(
     getRemoteGuestPromotionProofUrl(),
@@ -468,7 +476,7 @@ export async function fetchRemoteGuestPromotionProof(
       headers: buildForwardedHeaders(context, {}),
       signal: AbortSignal.timeout(10_000),
     },
-    "MCPJam",
+    "MCPJam"
   );
 }
 

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -70,7 +70,6 @@ import { hashGuestSpendIp } from "./guest-spend-ip.js";
 
 const MAX_STEPS = 20;
 const GUEST_IP_HASH_HEADER = "x-mcpjam-guest-ip-hash";
-const GUEST_IP_UNKNOWN_SENTINEL = "_unknown";
 const streamChunkSchema = zodSchema(z.unknown());
 
 export interface MCPJamHandlerOptions {
@@ -117,8 +116,8 @@ export interface MCPJamHandlerOptions {
    * Originating client IP from the inbound request. Hashed and forwarded as
    * `x-mcpjam-guest-ip-hash` so Convex can apply the per-IP daily spend cap
    * for guests in addition to the per-cookie cap. Null when no IP is
-   * available (dev / missing forwarded-for) — caller header is sent as the
-   * `_unknown` sentinel so all keyless callers share one bucket.
+   * available (dev / missing forwarded-for), in which case the header is
+   * omitted and Convex falls back to the per-cookie guest cap.
    */
   clientIp?: string | null;
 }
@@ -972,18 +971,26 @@ async function processOneStep(
     clientIp,
   } = ctx;
   // Hash the originating IP for the per-IP daily spend cap. Hashing here
-  // (server-side) keeps the raw IP off the wire to Convex. Always send a
-  // value — `_unknown` funnels keyless callers into one shared bucket
-  // rather than letting them bypass by stripping the header.
+  // (server-side) keeps the raw IP off the wire to Convex. If no hash can be
+  // produced, omit the header so Convex uses its cookie-only guest fallback
+  // instead of pooling unrelated guests in a shared unknown-IP bucket.
   const ipHash = clientIp ? await hashGuestSpendIp(clientIp) : null;
+  const convexHeaders: Record<string, string> = {
+    "content-type": "application/json",
+    ...(authHeader ? { authorization: authHeader } : {}),
+    ...(extraHeaders ?? {}),
+  };
+  for (const header of Object.keys(convexHeaders)) {
+    if (header.toLowerCase() === GUEST_IP_HASH_HEADER) {
+      delete convexHeaders[header];
+    }
+  }
+  if (ipHash) {
+    convexHeaders[GUEST_IP_HASH_HEADER] = ipHash;
+  }
   const res = await fetch(`${process.env.CONVEX_HTTP_URL}${endpointPath}`, {
     method: "POST",
-    headers: {
-      "content-type": "application/json",
-      ...(authHeader ? { authorization: authHeader } : {}),
-      ...(extraHeaders ?? {}),
-      [GUEST_IP_HASH_HEADER]: ipHash ?? GUEST_IP_UNKNOWN_SENTINEL,
-    },
+    headers: convexHeaders,
     body: JSON.stringify({
       mode: "stream",
       // Persist only once at the end of the full agentic loop via
@@ -995,9 +1002,7 @@ async function processOneStep(
       ...(temperature !== undefined ? { temperature } : {}),
       tools: toolDefs,
       ...(chatboxId ? { chatboxId } : {}),
-      ...(chatboxId && Number.isFinite(accessVersion)
-        ? { accessVersion }
-        : {}),
+      ...(chatboxId && Number.isFinite(accessVersion) ? { accessVersion } : {}),
       ...(projectId ? { projectId } : {}),
       ...(chatSessionId ? { chatSessionId } : {}),
       ...(sourceType ? { sourceType } : {}),


### PR DESCRIPTION
## Summary
This hotfix stops Inspector from sending x-mcpjam-guest-ip-hash: _unknown when it cannot produce a real guest IP hash.

Instead, Inspector now omits the guest IP hash header when hashing fails or no client IP is available. The backend already treats a missing IP hash as legacy cookie-only guest limiting, so anonymous guests no longer get pooled into the shared guest-ip:_unknown bucket.

Also strips caller-provided x-mcpjam-guest-ip-hash from forwarded headers so the backend only receives a hash computed by Inspector, or no header at all.

## Testing

npm run test -w @mcpjam/inspector -- server/utils/__tests__/mcpjam-stream-handler.test.ts server/utils/__tests__/guest-session-source.test.ts server/routes/web/__tests__/guest-session.test.ts
Manual QA

Incognito guest can send a free-model message without immediately hitting the stale _unknown bucket.
Convex logs should no longer show ipKey: "guest-ip:_unknown" for new requests.




