### PR TITLE
chore: release rollup (inspector patch + sdk minor)

### DIFF
--- a/.changeset/release-rollup-2026-05-12.md
+++ b/.changeset/release-rollup-2026-05-12.md
@@ -1,0 +1,22 @@
+---
+"@mcpjam/inspector": patch
+"@mcpjam/sdk": minor
+---
+
+Inspector + SDK rollup since the last release.
+
+**@mcpjam/sdk (new matchers + eval reporting types)**
+
+- Add `matchers` exports for the new SDK matchers used by evals (M1 phase 1).
+- Add layered match options and run-level validator override types (M1 evals).
+
+**@mcpjam/inspector**
+
+- Hot fix: resolves "unknown IP" guest-session bug.
+- Evals: layered match options + run-level validator overrides.
+- Evals M1: SDK matchers + diff rendering + p50/p95 percentiles.
+- Evals M1 phase 2: N-iterations picker and save-from-chat into tests.
+- MCP apps: profile-driven `hostCapabilities` with user-saved overrides; advertise MCP app message capabilities.
+- Electron: redirect OAuth flows to the system browser; include `@ngrok/ngrok` in the packaged app so tunnels work; guard `autoUpdater` renderer messaging against destroyed windows.
+- Billing: compare-plans table now reads "Unlimited" for servers-per-project on free; cleaner member/invite copy on the billing UI.
+- TypeScript hygiene: cleared all production `tsc` errors, enforce typecheck in CI, and added a `typecheck:client` script.


### PR DESCRIPTION
## Summary

Rollup changeset for the unreleased commits since the last `chore(release)` (c368abae6), ahead of the next deploy.

- `@mcpjam/inspector`: **patch** (2.4.9 → 2.4.10)
- `@mcpjam/sdk`: **minor** (1.3.2 → 1.4.0) — new public matchers + eval reporting types

Covers PRs: #2100, #2092, #2090, #1870, #2075, #2087, #2088, #2086, #2083, #2084, #2082, #2074, #2069, #2037.

## Test plan
- [x] `npm run release:status` reports `@mcpjam/inspector` patch + `@mcpjam/sdk` minor, no other public packages affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)