### PR TITLE
feat(inspector,sdk): consume hostConfig.mcpProfile e2e

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -784,6 +784,7 @@ export default function App() {
     pendingDashboardOAuth,
     isCloudSyncActive,
     persistRuntimeServerToProjectIfNeeded,
+    activeMcpProfile,
   } = useAppState({
     currentUserId: workOsUser?.id ?? null,
     currentActorKey: actorKey,
@@ -2311,6 +2312,12 @@ export default function App() {
               onSelectedServerNamesChange={setSelectedMCPConfigs}
               enableMultiModelChat
               showHostStyleSelector
+              // Active project default `mcpProfile`. Mounting the provider
+              // here is the in-inspector counterpart to ChatboxChatPage's
+              // hosted mount — without it, MCPAppsRenderer reads
+              // `undefined` from useActiveMcpProfile() and skips the
+              // sandbox-policy resolver entirely.
+              activeMcpProfile={activeMcpProfile}
               evalChatHandoff={evalChatHandoff}
               onEvalChatHandoffConsumed={(id) =>
                 setEvalChatHandoff((current) =>

--- a/mcpjam-inspector/client/src/components/HostStyledChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/HostStyledChatTabV2.tsx
@@ -5,17 +5,31 @@ import {
   ChatboxHostThemeProvider,
 } from "@/contexts/chatbox-host-style-context";
 import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-host-capabilities-override-context";
+import { ActiveMcpProfileProvider } from "@/contexts/active-mcp-profile-context";
 import { getChatboxShellStyle } from "@/lib/chatbox-host-style";
+import type { HostConfigMcpProfileV1 } from "@/lib/host-config-v2";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 
 type HostStyledChatTabV2Props = Omit<
   ComponentProps<typeof ChatTabV2>,
   "hostStyle" | "onHostStyleChange"
->;
+> & {
+  /**
+   * Active project default `mcpProfile` envelope. Forwarded into
+   * `ActiveMcpProfileProvider` so `MCPAppsRenderer` (mounted deep in
+   * `ChatTabV2`'s thread) can read sandbox policy + clientInfo /
+   * supportedProtocolVersions pins. The hosted-chat path uses its own
+   * provider in `ChatboxChatPage`; this is the in-inspector counterpart.
+   * Undefined means "no opt-in" — the renderer falls back to widget-
+   * derived sandbox behavior, byte-identical to historical.
+   */
+  activeMcpProfile?: HostConfigMcpProfileV1;
+};
 
 export function HostStyledChatTabV2({
   showHostStyleSelector = false,
+  activeMcpProfile,
   ...props
 }: HostStyledChatTabV2Props) {
   const themeMode = usePreferencesStore((state) => state.themeMode);
@@ -32,21 +46,23 @@ export function HostStyledChatTabV2({
         value={hostCapabilitiesOverride}
       >
         <ChatboxHostThemeProvider value={themeMode}>
-          <div
-            className={cn(
-              "chatbox-host-shell app-theme-scope flex h-full min-h-0 flex-1 flex-col overflow-hidden",
-              themeMode === "dark" && "dark",
-            )}
-            data-host-style={hostStyle}
-            style={shellStyle}
-          >
-            <ChatTabV2
-              {...props}
-              showHostStyleSelector={showHostStyleSelector}
-              hostStyle={hostStyle}
-              onHostStyleChange={setHostStyle}
-            />
-          </div>
+          <ActiveMcpProfileProvider value={activeMcpProfile}>
+            <div
+              className={cn(
+                "chatbox-host-shell app-theme-scope flex h-full min-h-0 flex-1 flex-col overflow-hidden",
+                themeMode === "dark" && "dark",
+              )}
+              data-host-style={hostStyle}
+              style={shellStyle}
+            >
+              <ChatTabV2
+                {...props}
+                showHostStyleSelector={showHostStyleSelector}
+                hostStyle={hostStyle}
+                onHostStyleChange={setHostStyle}
+              />
+            </div>
+          </ActiveMcpProfileProvider>
         </ChatboxHostThemeProvider>
       </ChatboxHostCapabilitiesOverrideProvider>
     </ChatboxHostStyleProvider>

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -913,6 +913,85 @@ export function MCPAppsRenderer({
     hostContextRef.current = hostContext;
   }, [hostContext]);
 
+  // Resolve the effective sandbox policy ONCE, at component scope, so the
+  // same value reaches three independent consumers without drift:
+  //   - the AppBridge constructor below (capability handshake)
+  //   - the <SandboxedIframe> below (browser-enforced CSP / Permission-Policy)
+  //   - the <McpAppsModal> below (its own sandboxed iframe for view_mode=modal)
+  //
+  // Computing this inside the bridge useEffect (the old shape) leaked the
+  // policy into ONE consumer only — the iframe got the raw resource
+  // declaration and the browser ignored the host clamp, which is exactly the
+  // failure the shared resolver was supposed to prevent. The resolver is the
+  // single source of truth; everything that mounts untrusted UI reads from
+  // here.
+  //
+  // `effectivePermissive` collapses to `false` whenever a host policy applies
+  // — SandboxedIframe treats `permissive: true` as "skip CSP injection
+  // entirely", which would silently neuter the resolver output.
+  const sandboxCspPolicy = activeMcpProfile?.apps?.sandbox?.csp;
+  const sandboxPermissionsPolicy =
+    activeMcpProfile?.apps?.sandbox?.permissions;
+  const effectiveSandbox = useMemo<{
+    csp: McpUiResourceCsp | undefined;
+    permissions: McpUiResourcePermissions | undefined;
+    permissive: boolean;
+    hostPolicyApplied: boolean;
+  }>(() => {
+    let resolvedCsp: McpUiResourceCsp | undefined;
+    if (sandboxCspPolicy) {
+      const resolved = resolveSandboxCsp({
+        resourceCsp: widgetCsp,
+        policy: sandboxCspPolicy,
+        hostedMode: HOSTED_MODE,
+      });
+      resolvedCsp = {
+        connectDomains: resolved.connectDomains,
+        resourceDomains: resolved.resourceDomains,
+        frameDomains: resolved.frameDomains,
+        baseUriDomains: resolved.baseUriDomains,
+      };
+    }
+    let resolvedPermissions: McpUiResourcePermissions | undefined;
+    if (sandboxPermissionsPolicy) {
+      const resourcePermsMap: Record<string, boolean> = {};
+      if (widgetPermissions && typeof widgetPermissions === "object") {
+        for (const [k, v] of Object.entries(
+          widgetPermissions as Record<string, unknown>,
+        )) {
+          if (v !== undefined && v !== null) resourcePermsMap[k] = true;
+        }
+      }
+      const resolved = resolveSandboxPermissions({
+        resourcePermissions: resourcePermsMap,
+        policy: sandboxPermissionsPolicy,
+        hostedMode: HOSTED_MODE,
+      });
+      const out: Record<string, Record<string, never>> = {};
+      for (const name of Object.keys(resolved.granted)) {
+        out[name] = {};
+      }
+      resolvedPermissions = out as McpUiResourcePermissions;
+    }
+    const hostPolicyApplied = !!resolvedCsp || !!resolvedPermissions;
+    return {
+      csp: resolvedCsp ?? (widgetPermissive ? undefined : widgetCsp),
+      permissions: resolvedPermissions ?? widgetPermissions,
+      // A host-applied CSP MUST be honored at the browser layer. When the
+      // host policy is in force, force `permissive: false` so the
+      // SandboxedIframe injects the meta-CSP. Otherwise pass the
+      // widget-derived flag through.
+      permissive: hostPolicyApplied ? false : widgetPermissive,
+      hostPolicyApplied,
+    };
+  }, [
+    sandboxCspPolicy,
+    sandboxPermissionsPolicy,
+    widgetCsp,
+    widgetPermissions,
+    widgetPermissive,
+  ]);
+
   useEffect(() => {
     onSendFollowUpRef.current = onSendFollowUp;
     onCallToolRef.current = onCallTool;
@@ -1200,85 +1279,30 @@ export function MCPAppsRenderer({
     isReadyRef.current = false;
     logWidgetDebug("host-to-ui", "debug/bridge-connect-start", {
       cspMode,
-      hasCsp: !!widgetCsp,
-      hasPermissions: !!widgetPermissions,
+      // Reflect the resolved (host-policy-applied) sandbox so the debug
+      // panel matches what the iframe and bridge will actually see.
+      hasCsp: !!effectiveSandbox.csp,
+      hasPermissions: !!effectiveSandbox.permissions,
       htmlLength: widgetHtml.length,
-      permissive: widgetPermissive,
+      permissive: effectiveSandbox.permissive,
+      hostPolicyApplied: effectiveSandbox.hostPolicyApplied,
       toolState: toolState ?? null,
     });
 
-    // `effectiveHostCapabilities` is computed at component scope so
-    // `registerBridgeHandlers` can read the same value when enforcement
-    // gates land (see comment near its definition). Runtime `sandbox` stays
-    // widget-derived per SEP-1865 — CSP/permissions are approved per UI
-    // resource, not a vendor trait.
-    //
-    // When the active host config has an `mcpProfile.apps.sandbox` policy,
-    // run the shared resolver from `@mcpjam/sdk` (see `sdk/src/sandbox-policy.ts`).
-    // Precedence: baseline-from-mode → restrictTo intersect → deny subtract
-    // → hosted-mode hard clamp. The resolver is opt-in — when there's no
-    // policy, the existing widget-derived behavior is preserved byte-for-byte.
-    // Both this renderer and the ChatGPT-app renderer consume the SAME
-    // resolver so the hosted-mode clamp can't be bypassed by mounting
-    // through a different surface (the failure mode the plan flagged).
-    const sandboxCspPolicy = activeMcpProfile?.apps?.sandbox?.csp;
-    const sandboxPermissionsPolicy = activeMcpProfile?.apps?.sandbox?.permissions;
-    let resolvedSandboxCsp: McpUiResourceCsp | undefined;
-    if (sandboxCspPolicy) {
-      const resolved = resolveSandboxCsp({
-        resourceCsp: widgetCsp,
-        policy: sandboxCspPolicy,
-        hostedMode: HOSTED_MODE,
-      });
-      resolvedSandboxCsp = {
-        connectDomains: resolved.connectDomains,
-        resourceDomains: resolved.resourceDomains,
-        frameDomains: resolved.frameDomains,
-        baseUriDomains: resolved.baseUriDomains,
-      };
-    }
-    let resolvedSandboxPermissions: McpUiResourcePermissions | undefined;
-    if (sandboxPermissionsPolicy) {
-      const resourcePermsMap: Record<string, boolean> = {};
-      if (widgetPermissions && typeof widgetPermissions === "object") {
-        for (const [k, v] of Object.entries(
-          widgetPermissions as Record<string, unknown>,
-        )) {
-          if (v !== undefined && v !== null) resourcePermsMap[k] = true;
-        }
-      }
-      const resolved = resolveSandboxPermissions({
-        resourcePermissions: resourcePermsMap,
-        policy: sandboxPermissionsPolicy,
-        hostedMode: HOSTED_MODE,
-      });
-      // Reshape the resolver output back into the McpUiResourcePermissions
-      // shape (each granted permission is an empty object per SEP-1865).
-      const out: Record<string, Record<string, never>> = {};
-      for (const name of Object.keys(resolved.granted)) {
-        out[name] = {};
-      }
-      resolvedSandboxPermissions = out as McpUiResourcePermissions;
-    }
-
+    // Sandbox policy is resolved once at component scope (see
+    // `effectiveSandbox` above) and reused here so the AppBridge handshake
+    // and the rendered <SandboxedIframe> stay in lockstep. Computing this
+    // inline used to be the canonical correctness bug: the bridge got the
+    // resolved policy while the iframe still got the raw resource
+    // declaration, so the browser-enforced CSP didn't honor the host clamp.
     const bridge = new AppBridge(
       null,
       { name: "mcpjam-inspector", version: __APP_VERSION__ },
       {
         ...effectiveHostCapabilities,
         sandbox: {
-          // mcpProfile-resolved CSP wins when set. Otherwise: permissive
-          // mode omits CSP (no restrictions); widget-declared mode passes
-          // the resource declaration through. Three distinct outcomes —
-          // documented here because the precedence is meaningful for
-          // anyone debugging "why did my widget's CSP change?".
-          csp: resolvedSandboxCsp
-            ? resolvedSandboxCsp
-            : widgetPermissive
-              ? undefined
-              : widgetCsp,
-          // Same opt-in shape for permissions.
-          permissions: resolvedSandboxPermissions ?? widgetPermissions,
+          csp: effectiveSandbox.csp,
+          permissions: effectiveSandbox.permissions,
         },
       },
       { hostContext: hostContextRef.current ?? {} },
@@ -1363,9 +1387,12 @@ export function MCPAppsRenderer({
     registerBridgeHandlers,
     setWidgetModelContext,
     cspMode,
-    widgetCsp,
-    widgetPermissions,
-    widgetPermissive,
+    // Bridge must rebuild when the resolved sandbox policy changes — a host
+    // toggling deny rules at runtime needs the new handshake. The memo
+    // identity captures `widgetCsp`/`widgetPermissions`/`widgetPermissive`
+    // and the active mcpProfile transitively, so they don't need their own
+    // entries here.
+    effectiveSandbox,
     logWidgetDebug,
     // Bridge must rebuild when the advertised host capabilities change
     // (host style switch or override edit) so the new handshake reflects
@@ -1508,17 +1535,16 @@ export function MCPAppsRenderer({
   useEffect(() => {
     if (!bridgeTransportReady || !widgetHtml) return;
     logWidgetDebug("host-to-ui", "debug/sandbox-html-ready", {
-      hasCsp: !!widgetCsp,
-      hasPermissions: !!widgetPermissions,
+      hasCsp: !!effectiveSandbox.csp,
+      hasPermissions: !!effectiveSandbox.permissions,
       htmlLength: widgetHtml.length,
-      permissive: widgetPermissive,
+      permissive: effectiveSandbox.permissive,
+      hostPolicyApplied: effectiveSandbox.hostPolicyApplied,
     });
   }, [
     bridgeTransportReady,
     widgetHtml,
-    widgetCsp,
-    widgetPermissions,
-    widgetPermissive,
+    effectiveSandbox,
     logWidgetDebug,
   ]);
 
@@ -1639,9 +1665,16 @@ export function MCPAppsRenderer({
       ref={sandboxRef}
       html={bridgeTransportReady ? widgetHtml : null}
       sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
-      csp={widgetCsp}
-      permissions={widgetPermissions}
-      permissive={widgetPermissive}
+      // Browser-enforced CSP / Permission Policy MUST receive the resolved
+      // values, not the raw resource declaration. `effectiveSandbox` runs the
+      // shared resolver (mode → restrictTo intersect → deny subtract →
+      // hosted-mode clamp); when a host policy applies it forces
+      // `permissive: false` so SandboxedIframe injects the meta-CSP rather
+      // than skipping it. Passing `widgetCsp` here directly is the canonical
+      // regression — keep the resolver path.
+      csp={effectiveSandbox.csp}
+      permissions={effectiveSandbox.permissions}
+      permissive={effectiveSandbox.permissive}
       colorScheme={resolvedTheme}
       onProxyReady={() => {
         setSandboxProxyReady(true);
@@ -1735,9 +1768,13 @@ export function MCPAppsRenderer({
         template={modalTemplate}
         params={modalParams}
         registerBridgeHandlers={registerBridgeHandlers}
-        widgetCsp={widgetCsp}
-        widgetPermissions={widgetPermissions}
-        widgetPermissive={widgetPermissive}
+        // The modal mounts its own SandboxedIframe via `fetchMcpAppsWidgetContent`.
+        // Pass the resolved values so the modal's CSP enforcement matches the
+        // inline iframe — otherwise a host deny rule applies to inline but
+        // not to a modal-mode widget reading the same resource.
+        widgetCsp={effectiveSandbox.csp}
+        widgetPermissions={effectiveSandbox.permissions}
+        widgetPermissive={effectiveSandbox.permissive}
         hostContextRef={hostContextRef}
         serverId={serverId}
         resourceUri={resourceUri}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -30,6 +30,11 @@ import {
 } from "@/components/ui/sandboxed-iframe";
 import { authFetch } from "@/lib/session-token";
 import { HOSTED_MODE } from "@/lib/config";
+import { useActiveMcpProfile } from "@/contexts/active-mcp-profile-context";
+import {
+  resolveSandboxCsp,
+  resolveSandboxPermissions,
+} from "@mcpjam/sdk/browser";
 import {
   useTrafficLogStore,
   extractMethod,
@@ -216,6 +221,10 @@ export function MCPAppsRenderer({
   const chatboxHostStyle = useChatboxHostStyle();
   const chatboxHostTheme = useChatboxHostTheme();
   const hostCapabilitiesOverride = useChatboxHostCapabilitiesOverride();
+  // Active hostConfig.mcpProfile from the surrounding scope (chatbox
+  // session, project default, eval suite). Drives the resolver below
+  // when set; undefined preserves widget-derived sandbox behavior.
+  const activeMcpProfile = useActiveMcpProfile();
   const draftHostContext = useHostContextStore((s) => s.draftHostContext);
   const baseHostContext = useMemo(
     () =>
@@ -1203,17 +1212,73 @@ export function MCPAppsRenderer({
     // gates land (see comment near its definition). Runtime `sandbox` stays
     // widget-derived per SEP-1865 — CSP/permissions are approved per UI
     // resource, not a vendor trait.
+    //
+    // When the active host config has an `mcpProfile.apps.sandbox` policy,
+    // run the shared resolver from `@mcpjam/sdk` (see `sdk/src/sandbox-policy.ts`).
+    // Precedence: baseline-from-mode → restrictTo intersect → deny subtract
+    // → hosted-mode hard clamp. The resolver is opt-in — when there's no
+    // policy, the existing widget-derived behavior is preserved byte-for-byte.
+    // Both this renderer and the ChatGPT-app renderer consume the SAME
+    // resolver so the hosted-mode clamp can't be bypassed by mounting
+    // through a different surface (the failure mode the plan flagged).
+    const sandboxCspPolicy = activeMcpProfile?.apps?.sandbox?.csp;
+    const sandboxPermissionsPolicy = activeMcpProfile?.apps?.sandbox?.permissions;
+    let resolvedSandboxCsp: McpUiResourceCsp | undefined;
+    if (sandboxCspPolicy) {
+      const resolved = resolveSandboxCsp({
+        resourceCsp: widgetCsp,
+        policy: sandboxCspPolicy,
+        hostedMode: HOSTED_MODE,
+      });
+      resolvedSandboxCsp = {
+        connectDomains: resolved.connectDomains,
+        resourceDomains: resolved.resourceDomains,
+        frameDomains: resolved.frameDomains,
+        baseUriDomains: resolved.baseUriDomains,
+      };
+    }
+    let resolvedSandboxPermissions: McpUiResourcePermissions | undefined;
+    if (sandboxPermissionsPolicy) {
+      const resourcePermsMap: Record<string, boolean> = {};
+      if (widgetPermissions && typeof widgetPermissions === "object") {
+        for (const [k, v] of Object.entries(
+          widgetPermissions as Record<string, unknown>,
+        )) {
+          if (v !== undefined && v !== null) resourcePermsMap[k] = true;
+        }
+      }
+      const resolved = resolveSandboxPermissions({
+        resourcePermissions: resourcePermsMap,
+        policy: sandboxPermissionsPolicy,
+        hostedMode: HOSTED_MODE,
+      });
+      // Reshape the resolver output back into the McpUiResourcePermissions
+      // shape (each granted permission is an empty object per SEP-1865).
+      const out: Record<string, Record<string, never>> = {};
+      for (const name of Object.keys(resolved.granted)) {
+        out[name] = {};
+      }
+      resolvedSandboxPermissions = out as McpUiResourcePermissions;
+    }
+
     const bridge = new AppBridge(
       null,
       { name: "mcpjam-inspector", version: __APP_VERSION__ },
       {
         ...effectiveHostCapabilities,
         sandbox: {
-          // In permissive mode: omit CSP (undefined) to indicate no restrictions
-          // In widget-declared mode: pass the widget's declared CSP
-          csp: widgetPermissive ? undefined : widgetCsp,
-          // Always pass permissions (if widget declared them)
-          permissions: widgetPermissions,
+          // mcpProfile-resolved CSP wins when set. Otherwise: permissive
+          // mode omits CSP (no restrictions); widget-declared mode passes
+          // the resource declaration through. Three distinct outcomes —
+          // documented here because the precedence is meaningful for
+          // anyone debugging "why did my widget's CSP change?".
+          csp: resolvedSandboxCsp
+            ? resolvedSandboxCsp
+            : widgetPermissive
+              ? undefined
+              : widgetCsp,
+          // Same opt-in shape for permissions.
+          permissions: resolvedSandboxPermissions ?? widgetPermissions,
         },
       },
       { hostContext: hostContextRef.current ?? {} },

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -91,6 +91,23 @@ const DEFAULT_INPUT_SCHEMA = { type: "object" } as const;
 const SUPPRESSED_UI_LOG_METHODS = new Set(["ui/notifications/size-changed"]);
 const PIP_MAX_HEIGHT = "min(40vh, 600px)";
 
+/**
+ * Origins the hosted-mode sandbox clamp must strip from any widget-
+ * declared CSP. A hosted widget could otherwise declare an MCPJam
+ * origin in `connectDomains` and use the user's authenticated session
+ * to exfiltrate data through the iframe. Forwarded into the SDK via
+ * `resolveSandboxCsp`'s `hostedClampExtraDeny` — that's the only
+ * codepath that's NOT profile-overridable (unlike `policy.deny`).
+ *
+ * Wildcards cover all subdomains (api, staging, www, etc.) without
+ * having to enumerate them. The bare-host entry catches widgets that
+ * declare the apex domain directly.
+ */
+const MCPJAM_HOSTED_CLAMP_ORIGINS: ReadonlyArray<string> = [
+  "https://*.mcpjam.com",
+  "https://mcpjam.com",
+];
+
 type DisplayMode = "inline" | "pip" | "fullscreen";
 type HostStyleVariables = NonNullable<
   NonNullable<McpUiHostContext["styles"]>["variables"]
@@ -964,6 +981,27 @@ export function MCPAppsRenderer({
         // break any widget that fetches external assets.
         hostDefaultBaseline: widgetCsp,
         hostedMode: HOSTED_MODE,
+        // Defense in depth: in hosted mode strip any widget-declared
+        // domain matching MCPJam's own app/API origins. A hosted widget
+        // that declares `https://app.mcpjam.com/api/...` in
+        // connectDomains could otherwise use the iframe as an
+        // exfiltration channel via the user's authenticated session.
+        // The list is hardcoded here (and not in the SDK) because
+        // "which origins count as MCPJam" is an inspector concern, not
+        // a shared SDK concern; the SDK just enforces what we pass.
+        // Wildcard pattern strips all subdomains incl. staging/api.
+        hostedClampExtraDeny: HOSTED_MODE
+          ? {
+              // Spread the readonly constant into mutable arrays — the
+              // SDK's `SandboxCspDomainSet` shape declares them as
+              // `string[]`. Spreading per directive avoids accidental
+              // aliasing if the SDK ever mutates internally.
+              connectDomains: [...MCPJAM_HOSTED_CLAMP_ORIGINS],
+              resourceDomains: [...MCPJAM_HOSTED_CLAMP_ORIGINS],
+              frameDomains: [...MCPJAM_HOSTED_CLAMP_ORIGINS],
+              baseUriDomains: [...MCPJAM_HOSTED_CLAMP_ORIGINS],
+            }
+          : undefined,
       });
       resolvedCsp = {
         connectDomains: resolved.connectDomains,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -956,17 +956,41 @@ export function MCPAppsRenderer({
     hostPolicyApplied: boolean;
   }>(() => {
     // "relaxed" CSP mode is an explicit dev escape hatch. The resolver
-    // can't model "no restrictions" as a domain list (CSP allowlists
-    // can't represent `*` without inviting the hosted clamp to strip
-    // it), so handle it at the renderer: skip CSP entirely (no
-    // meta-CSP injection) and let the browser's default-allow govern
-    // network access. Future work: still apply restrictTo/deny on top
-    // of relaxed; today the resolver doesn't have a "permissive
-    // baseline" primitive so we ignore those in relaxed mode.
-    const isRelaxedCsp = sandboxCspPolicy?.mode === "relaxed";
+    // can't represent "no restrictions" as a domain list (CSP allow-
+    // lists can't carry `*` without inviting the hosted clamp to strip
+    // it), so PURE relaxed (no restrictTo, no deny, not hosted) short-
+    // circuits the resolver and emits no CSP — preserves the dev
+    // experience.
+    //
+    // Any tightening signal — restrictTo, deny, or hostedMode — falls
+    // through INTO the resolver so the documented guarantees hold:
+    //   * "deny always wins" — applies in every mode
+    //   * "restrictTo applies in every mode" — intersects in every mode
+    //   * "hosted clamp is non-bypassable" — the MCPJam-origin extra-
+    //     deny must run in hosted mode regardless of saved profile
+    //
+    // The previous shape (`if (sandboxCspPolicy && !isRelaxedCsp)`)
+    // skipped the resolver entirely on mode==="relaxed". A hosted user
+    // could save a relaxed profile and silently opt out of the hosted
+    // clamp's MCPJam-origin extra-deny — P1 in production.
+    const restrictToConfigured =
+      sandboxCspPolicy?.restrictTo !== undefined &&
+      Object.values(sandboxCspPolicy.restrictTo).some(
+        (list) => Array.isArray(list) && list.length > 0,
+      );
+    const denyConfigured =
+      sandboxCspPolicy?.deny !== undefined &&
+      Object.values(sandboxCspPolicy.deny).some(
+        (list) => Array.isArray(list) && list.length > 0,
+      );
+    const isPureRelaxedCsp =
+      sandboxCspPolicy?.mode === "relaxed" &&
+      !restrictToConfigured &&
+      !denyConfigured &&
+      !HOSTED_MODE;
 
     let resolvedCsp: McpUiResourceCsp | undefined;
-    if (sandboxCspPolicy && !isRelaxedCsp) {
+    if (sandboxCspPolicy && !isPureRelaxedCsp) {
       const resolved = resolveSandboxCsp({
         resourceCsp: widgetCsp,
         policy: sandboxCspPolicy,
@@ -1017,7 +1041,14 @@ export function MCPAppsRenderer({
         for (const [k, v] of Object.entries(
           widgetPermissions as Record<string, unknown>,
         )) {
-          if (v !== undefined && v !== null) resourcePermsMap[k] = true;
+          // SEP-1865 declares each permission as an empty object (`{}`)
+          // when requested — i.e. a truthy value. Older shape gated on
+          // `v !== undefined && v !== null` which would also accept
+          // `false` / `0` / `""` and silently coerce them to GRANTED.
+          // Tighten to a truthiness check so a malformed widget that
+          // declares `{ camera: false }` doesn't end up with camera
+          // granted in the resolved permission set.
+          if (v) resourcePermsMap[k] = true;
         }
       }
       const resolved = resolveSandboxPermissions({
@@ -1032,25 +1063,35 @@ export function MCPAppsRenderer({
       resolvedPermissions = out as McpUiResourcePermissions;
     }
     const hostPolicyApplied =
-      !!resolvedCsp || !!resolvedPermissions || isRelaxedCsp;
+      !!resolvedCsp || !!resolvedPermissions || isPureRelaxedCsp;
     return {
-      // Relaxed CSP mode → no CSP at all (caller's `permissive: true`
-      // below tells SandboxedIframe to skip CSP injection). Otherwise
-      // pass the resolver output through, falling back to the widget's
-      // own derivation when no host CSP policy is in force.
-      csp: isRelaxedCsp
+      // Pure relaxed → no CSP at all (caller's `permissive: true` below
+      // tells SandboxedIframe to skip CSP injection). Otherwise pass
+      // the resolver output through, falling back to the widget's own
+      // derivation when no host CSP policy is in force.
+      csp: isPureRelaxedCsp
         ? undefined
         : (resolvedCsp ?? (widgetPermissive ? undefined : widgetCsp)),
       permissions: resolvedPermissions ?? widgetPermissions,
-      // A host-applied CSP MUST be honored at the browser layer. When a
-      // restrictive host policy is in force, force `permissive: false` so
-      // the SandboxedIframe injects the meta-CSP. In relaxed mode the
-      // host policy is "permissive on purpose" → force `permissive: true`
-      // so the iframe doesn't inject any meta-CSP at all. Without
-      // host-side CSP policy, pass the widget-derived flag through.
-      permissive: isRelaxedCsp
+      // A host-applied CSP MUST be honored at the browser layer. When
+      // a restrictive host policy is in force, force `permissive: false`
+      // so the SandboxedIframe injects the meta-CSP. In pure-relaxed
+      // mode the host policy is "permissive on purpose" → force
+      // `permissive: true` so the iframe doesn't inject any meta-CSP
+      // at all. Without host-side CSP policy, pass the widget-derived
+      // flag through.
+      //
+      // Gate ONLY on `resolvedCsp` (not `resolvedPermissions`): a
+      // permissions-only profile (e.g. `mode: "deny-all"` for camera/
+      // mic) used to flip `permissive: false` while `csp` stayed
+      // undefined, which the sandbox proxy interprets as the SEP-1865
+      // secure-default CSP (`default-src 'none'`, `connect-src 'none'`)
+      // — silently breaking network access for permissive widgets.
+      // Permissions and CSP are orthogonal user-facing knobs; tweaking
+      // one must not reshape the other.
+      permissive: isPureRelaxedCsp
         ? true
-        : resolvedCsp || resolvedPermissions
+        : resolvedCsp
           ? false
           : widgetPermissive,
       hostPolicyApplied,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -938,11 +938,31 @@ export function MCPAppsRenderer({
     permissive: boolean;
     hostPolicyApplied: boolean;
   }>(() => {
+    // "relaxed" CSP mode is an explicit dev escape hatch. The resolver
+    // can't model "no restrictions" as a domain list (CSP allowlists
+    // can't represent `*` without inviting the hosted clamp to strip
+    // it), so handle it at the renderer: skip CSP entirely (no
+    // meta-CSP injection) and let the browser's default-allow govern
+    // network access. Future work: still apply restrictTo/deny on top
+    // of relaxed; today the resolver doesn't have a "permissive
+    // baseline" primitive so we ignore those in relaxed mode.
+    const isRelaxedCsp = sandboxCspPolicy?.mode === "relaxed";
+
     let resolvedCsp: McpUiResourceCsp | undefined;
-    if (sandboxCspPolicy) {
+    if (sandboxCspPolicy && !isRelaxedCsp) {
       const resolved = resolveSandboxCsp({
         resourceCsp: widgetCsp,
         policy: sandboxCspPolicy,
+        // "host-default" mode falls back to an EMPTY allowlist inside
+        // the resolver when `hostDefaultBaseline` is omitted (per
+        // SEP-1865 secure-default). For the inspector, the only sensible
+        // default baseline we have is the resource's own declaration —
+        // passing it here means "host-default" is restrictive only as
+        // much as the resource itself asked for (never more, possibly
+        // less if restrictTo/deny narrow it). Without this, picking
+        // "host-default" would silently emit `connect-src 'none'` and
+        // break any widget that fetches external assets.
+        hostDefaultBaseline: widgetCsp,
         hostedMode: HOSTED_MODE,
       });
       resolvedCsp = {
@@ -973,15 +993,28 @@ export function MCPAppsRenderer({
       }
       resolvedPermissions = out as McpUiResourcePermissions;
     }
-    const hostPolicyApplied = !!resolvedCsp || !!resolvedPermissions;
+    const hostPolicyApplied =
+      !!resolvedCsp || !!resolvedPermissions || isRelaxedCsp;
     return {
-      csp: resolvedCsp ?? (widgetPermissive ? undefined : widgetCsp),
+      // Relaxed CSP mode → no CSP at all (caller's `permissive: true`
+      // below tells SandboxedIframe to skip CSP injection). Otherwise
+      // pass the resolver output through, falling back to the widget's
+      // own derivation when no host CSP policy is in force.
+      csp: isRelaxedCsp
+        ? undefined
+        : (resolvedCsp ?? (widgetPermissive ? undefined : widgetCsp)),
       permissions: resolvedPermissions ?? widgetPermissions,
-      // A host-applied CSP MUST be honored at the browser layer. When the
-      // host policy is in force, force `permissive: false` so the
-      // SandboxedIframe injects the meta-CSP. Otherwise pass the
-      // widget-derived flag through.
-      permissive: hostPolicyApplied ? false : widgetPermissive,
+      // A host-applied CSP MUST be honored at the browser layer. When a
+      // restrictive host policy is in force, force `permissive: false` so
+      // the SandboxedIframe injects the meta-CSP. In relaxed mode the
+      // host policy is "permissive on purpose" → force `permissive: true`
+      // so the iframe doesn't inject any meta-CSP at all. Without
+      // host-side CSP policy, pass the widget-derived flag through.
+      permissive: isRelaxedCsp
+        ? true
+        : resolvedCsp || resolvedPermissions
+          ? false
+          : widgetPermissive,
       hostPolicyApplied,
     };
   }, [

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/drafts.ts
@@ -140,6 +140,7 @@ export function draftToHostConfigInputV2(
     | "clientCapabilities"
     | "hostContext"
     | "hostCapabilitiesOverride"
+    | "mcpProfile"
   > | null,
 ): HostConfigInputV2 {
   const seed = emptyHostConfigInputV2({
@@ -157,6 +158,13 @@ export function draftToHostConfigInputV2(
     // new/edited chatboxes match what the project-default editor saved.
     // Undefined here keeps "use the active host style preset" intact.
     hostCapabilitiesOverride: projectDefault?.hostCapabilitiesOverride,
+    // Inherit the project default's mcpProfile envelope for the same
+    // reason — a new chatbox should connect with the project's pinned
+    // clientInfo / supportedProtocolVersions / sandbox policy out of the
+    // box. Undefined here keeps "use SDK defaults" intact; the backend
+    // hashes that distinctly from `{ profileVersion: 1 }`, so we MUST
+    // NOT synthesize an empty envelope.
+    mcpProfile: projectDefault?.mcpProfile,
   });
   return seed;
 }

--- a/mcpjam-inspector/client/src/components/chatboxes/builder/useChatboxDemoSeed.ts
+++ b/mcpjam-inspector/client/src/components/chatboxes/builder/useChatboxDemoSeed.ts
@@ -124,6 +124,14 @@ export function useChatboxDemoSeed({
             clientCapabilities:
               projectDefaultInput?.clientCapabilities ?? {},
             hostContext: projectDefaultInput?.hostContext ?? {},
+            // Inherit the project default's mcpProfile so the demo
+            // chatbox connects with the project's pinned clientInfo /
+            // supported protocol versions / sandbox policy. Pass
+            // through verbatim — undefined stays undefined ("use SDK
+            // defaults"), and the backend canonicalizer is the only
+            // place that decides whether the envelope is structurally
+            // valid.
+            mcpProfile: projectDefaultInput?.mcpProfile,
           },
         })) as {
           chatbox: ChatboxSettings | null;

--- a/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
@@ -416,6 +416,77 @@ function McpProfileSection({
         : "",
   }));
 
+  // Ref mirror of the draft so the flush logic in `updateClientInfo` can
+  // read the latest committed value WITHOUT firing the parent `onChange`
+  // from inside a `setClientInfoDraft` updater callback (React state
+  // updaters must be pure; double-firing under StrictMode + concurrent
+  // mode would re-emit onChange for the same edit).
+  const clientInfoDraftRef = useRef(clientInfoDraft);
+  useEffect(() => {
+    clientInfoDraftRef.current = clientInfoDraft;
+  }, [clientInfoDraft]);
+
+  // Sync the local draft from the persisted profile when the parent
+  // overwrites it externally. Three scenarios this handles:
+  //
+  //   1. "Reset to SDK defaults" — `onChange(undefined)` clears the
+  //      envelope; without this effect the draft stays populated and the
+  //      NEXT keystroke flushes the stale values right back in.
+  //   2. Parent DTO reload — switching projects or receiving a fresh DTO
+  //      replaces `profile`; the draft would otherwise display stale
+  //      identity from the previous config.
+  //   3. Programmatic patches from elsewhere in the editor.
+  //
+  // The invariant we hold: if the value the current draft WOULD flush
+  // equals the persisted clientInfo, persisted reflects our own write —
+  // keep the draft as-is so an in-progress edit (e.g. user is typing
+  // `title` after `name`/`version` are stable) isn't clobbered. Otherwise
+  // persisted has diverged externally; mirror it into the draft.
+  useEffect(() => {
+    const persistedCi = profile?.initialize?.clientInfo;
+    const draft = clientInfoDraftRef.current;
+    const draftName = draft.name.trim();
+    const draftVersion = draft.version.trim();
+    const draftTitle = draft.title.trim();
+    const draftWouldFlush = draftName !== "" && draftVersion !== "";
+
+    if (!persistedCi) {
+      // Persisted is empty. If the draft also can't flush, we're already
+      // in sync (partial edit in progress; flushed undefined; no work).
+      if (!draftWouldFlush) return;
+      // Otherwise persisted was cleared externally → mirror.
+      setClientInfoDraft({ name: "", version: "", title: "" });
+      return;
+    }
+
+    const persistedName =
+      typeof persistedCi.name === "string" ? persistedCi.name : "";
+    const persistedVersion =
+      typeof persistedCi.version === "string" ? persistedCi.version : "";
+    const persistedTitle =
+      typeof persistedCi.title === "string" ? persistedCi.title : "";
+
+    // Persisted reflects our own write iff every field the draft would
+    // flush matches the persisted value. Title comparison is
+    // asymmetric: an empty draft title shouldn't trip the divergence
+    // check if persisted also has no title.
+    if (
+      draftWouldFlush &&
+      persistedName === draftName &&
+      persistedVersion === draftVersion &&
+      (draftTitle === "" ? persistedTitle === "" : persistedTitle === draftTitle)
+    ) {
+      return;
+    }
+
+    // External divergence — mirror persisted into the draft.
+    setClientInfoDraft({
+      name: persistedName,
+      version: persistedVersion,
+      title: persistedTitle,
+    });
+  }, [profile]);
+
   const enable = useCallback(() => {
     setExpanded(true);
     if (!enabled) onChange({ profileVersion: 1 });
@@ -425,7 +496,9 @@ function McpProfileSection({
     // Snap back to `undefined` so the SDK falls back to its built-in
     // clientInfo + protocolVersion. Distinct from `{ profileVersion: 1 }`
     // on the wire — that "empty envelope" hashes differently because the
-    // user explicitly opted in.
+    // user explicitly opted in. The draft-sync effect above will clear
+    // the local draft on the next render so re-enabling doesn't surface
+    // stale values.
     onChange(undefined);
   }, [onChange]);
 
@@ -455,52 +528,53 @@ function McpProfileSection({
 
   const updateClientInfo = useCallback(
     (patch: { name?: string; version?: string; title?: string }) => {
-      // Update the local draft (always reflects what the user typed) and
-      // separately decide whether to flush to the persisted envelope.
-      // The persisted envelope only accepts complete `{ name, version }`
-      // pairs (backend rejects partial state); the editor must let users
-      // type one field at a time, so we keep the in-progress text here
-      // and flush only when both required fields are non-empty.
-      setClientInfoDraft((prev) => {
-        const next = { ...prev };
-        if (patch.name !== undefined) next.name = patch.name;
-        if (patch.version !== undefined) next.version = patch.version;
-        if (patch.title !== undefined) next.title = patch.title;
+      // Compute the next draft from the ref-mirrored latest committed
+      // value, then commit it to state with a PURE setter call and flush
+      // to the parent envelope outside any state updater. The previous
+      // shape called `updateInitialize` (which fires parent `onChange`)
+      // from inside the `setClientInfoDraft` updater, which violates
+      // React's purity rule and double-fires under StrictMode.
+      const prev = clientInfoDraftRef.current;
+      const next = { ...prev };
+      if (patch.name !== undefined) next.name = patch.name;
+      if (patch.version !== undefined) next.version = patch.version;
+      if (patch.title !== undefined) next.title = patch.title;
 
-        const nameTrim = next.name.trim();
-        const versionTrim = next.version.trim();
-        const titleTrim = next.title.trim();
-        const hasRequired = nameTrim !== "" && versionTrim !== "";
+      clientInfoDraftRef.current = next;
+      setClientInfoDraft(next);
 
-        // Preserve forward-compat extras (e.g. future spec fields the
-        // backend round-trips verbatim) that the persisted envelope
-        // already carries — we never round-trip them through the draft,
-        // so they'd otherwise be dropped on every flush.
-        const preserved: Record<string, unknown> = {};
-        const persisted = profile?.initialize?.clientInfo;
-        if (persisted && typeof persisted === "object") {
-          for (const [k, v] of Object.entries(persisted)) {
-            if (k === "name" || k === "version" || k === "title") continue;
-            preserved[k] = v;
-          }
+      const nameTrim = next.name.trim();
+      const versionTrim = next.version.trim();
+      const titleTrim = next.title.trim();
+      const hasRequired = nameTrim !== "" && versionTrim !== "";
+
+      // Preserve forward-compat extras (e.g. future spec fields the
+      // backend round-trips verbatim) that the persisted envelope
+      // already carries — we never route them through the draft, so
+      // they'd otherwise be dropped on every flush.
+      const preserved: Record<string, unknown> = {};
+      const persisted = profile?.initialize?.clientInfo;
+      if (persisted && typeof persisted === "object") {
+        for (const [k, v] of Object.entries(persisted)) {
+          if (k === "name" || k === "version" || k === "title") continue;
+          preserved[k] = v;
         }
+      }
 
-        if (hasRequired) {
-          const nextClientInfo: Record<string, unknown> = {
-            ...preserved,
-            name: nameTrim,
-            version: versionTrim,
-          };
-          if (titleTrim !== "") nextClientInfo.title = titleTrim;
-          updateInitialize({ clientInfo: nextClientInfo });
-        } else {
-          // Required pair incomplete — drop `clientInfo` from the envelope
-          // so the backend doesn't reject the save. The draft survives so
-          // the user can keep typing.
-          updateInitialize({ clientInfo: undefined });
-        }
-        return next;
-      });
+      if (hasRequired) {
+        const nextClientInfo: Record<string, unknown> = {
+          ...preserved,
+          name: nameTrim,
+          version: versionTrim,
+        };
+        if (titleTrim !== "") nextClientInfo.title = titleTrim;
+        updateInitialize({ clientInfo: nextClientInfo });
+      } else {
+        // Required pair incomplete — drop `clientInfo` from the envelope
+        // so the backend doesn't reject the save. The draft survives so
+        // the user can keep typing.
+        updateInitialize({ clientInfo: undefined });
+      }
     },
     [profile, updateInitialize],
   );

--- a/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
@@ -426,6 +426,27 @@ function McpProfileSection({
     clientInfoDraftRef.current = clientInfoDraft;
   }, [clientInfoDraft]);
 
+  // Local draft buffer for the supported-protocol-versions textarea.
+  // Same shape as `clientInfoDraft`: the persisted envelope holds a
+  // filtered/trimmed array, but the textarea must accept raw
+  // multi-line text including the trailing newline so the user can
+  // type a second version after pressing Enter. The previous shape
+  // recomputed the textarea value from the filtered array on every
+  // render, so pressing Enter after `2025-11-25` immediately stored
+  // `["2025-11-25"]` and re-rendered without the newline — making it
+  // impossible to construct a multi-version accept-list by typing
+  // (you'd have to paste all versions at once).
+  const persistedProtocolVersionsText = (
+    profile?.initialize?.supportedProtocolVersions ?? []
+  ).join("\n");
+  const [protocolVersionsDraft, setProtocolVersionsDraft] = useState<string>(
+    persistedProtocolVersionsText,
+  );
+  const protocolVersionsDraftRef = useRef(protocolVersionsDraft);
+  useEffect(() => {
+    protocolVersionsDraftRef.current = protocolVersionsDraft;
+  }, [protocolVersionsDraft]);
+
   // Sync the local draft from the persisted profile when the parent
   // overwrites it externally. Three scenarios this handles:
   //
@@ -485,6 +506,25 @@ function McpProfileSection({
       version: persistedVersion,
       title: persistedTitle,
     });
+  }, [profile]);
+
+  // Sync the protocol-versions draft on external profile changes. Same
+  // invariant as the clientInfo sync: if the persisted array equals the
+  // filtered/trimmed version of the current draft, persisted reflects
+  // our own write — keep the draft (including any trailing newline the
+  // user just typed). Otherwise mirror persisted into the draft.
+  useEffect(() => {
+    const persistedJoined = (
+      profile?.initialize?.supportedProtocolVersions ?? []
+    ).join("\n");
+    const draft = protocolVersionsDraftRef.current;
+    const draftFiltered = draft
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line !== "")
+      .join("\n");
+    if (persistedJoined === draftFiltered) return;
+    setProtocolVersionsDraft(persistedJoined);
   }, [profile]);
 
   const enable = useCallback(() => {
@@ -581,6 +621,14 @@ function McpProfileSection({
 
   const updateProtocolVersions = useCallback(
     (raw: string) => {
+      // Commit raw text to the local draft (preserves trailing newlines
+      // and whitespace mid-edit) and flush the filtered/trimmed array to
+      // the persisted envelope. The draft is the source of truth for the
+      // textarea value; the persisted envelope is the source of truth
+      // for the SDK wire shape.
+      protocolVersionsDraftRef.current = raw;
+      setProtocolVersionsDraft(raw);
+
       const versions = raw
         .split(/\r?\n/)
         .map((line) => line.trim())
@@ -610,13 +658,12 @@ function McpProfileSection({
     );
   }
 
-  // Inputs read from the local draft (which always reflects what the user
-  // typed); the persisted envelope only sees complete combos. See the
-  // `clientInfoDraft` state declaration above for rationale.
+  // Inputs read from the local drafts (which always reflect what the
+  // user typed); the persisted envelope only sees filtered/complete
+  // values. See the `clientInfoDraft` and `protocolVersionsDraft`
+  // declarations above for rationale.
   const clientInfo = clientInfoDraft;
-  const protocolVersionsText = (
-    profile?.initialize?.supportedProtocolVersions ?? []
-  ).join("\n");
+  const protocolVersionsText = protocolVersionsDraft;
 
   return (
     <div className="grid gap-3 rounded-md border border-border/50 p-3">

--- a/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
@@ -823,7 +823,174 @@ function McpProfileSandboxEditor({
           permission the resource didn't request.
         </p>
       </div>
+
+      <McpProfilePermissionsAllowDenyEditor
+        mode={permissions?.mode ?? "resource-declared"}
+        allow={permissions?.allow}
+        deny={permissions?.deny}
+        onChange={(next) =>
+          updateSandbox({
+            permissions: {
+              ...(permissions ?? {}),
+              allow: next.allow,
+              deny: next.deny,
+            },
+          })
+        }
+      />
     </div>
+  );
+}
+
+/**
+ * Per-permission allow/deny grid for the four MCP Apps permission keys
+ * spec'd by SEP-1865 (`camera`, `microphone`, `geolocation`,
+ * `clipboardWrite` — camelCase, matching the resource's `_meta.ui.
+ * permissions` declaration; the kebab-case `clipboard-write` form
+ * belongs at the iframe `allow=` boundary, not in profile state).
+ *
+ * - Allow column: only meaningful in `custom` mode (the resolver seeds
+ *   the candidate set from `policy.allow` in custom mode); rendered
+ *   disabled in resource-declared / deny-all so the user can see the
+ *   shape without it being a no-op trap.
+ * - Deny column: applies in every mode (resolver subtracts after the
+ *   mode-derived candidate is built), so always enabled.
+ *
+ * Resource declaration is still the ceiling — toggling `allow` on for a
+ * permission the resource didn't request yields nothing at runtime. The
+ * help text below the grid spells this out.
+ */
+function McpProfilePermissionsAllowDenyEditor({
+  mode,
+  allow,
+  deny,
+  onChange,
+}: {
+  mode: "resource-declared" | "deny-all" | "custom";
+  allow: Record<string, boolean> | undefined;
+  deny: string[] | undefined;
+  onChange: (next: {
+    allow: Record<string, boolean> | undefined;
+    deny: string[] | undefined;
+  }) => void;
+}) {
+  const PERMISSION_KEYS: ReadonlyArray<{ key: string; label: string }> = [
+    { key: "camera", label: "Camera" },
+    { key: "microphone", label: "Microphone" },
+    { key: "geolocation", label: "Geolocation" },
+    { key: "clipboardWrite", label: "Clipboard write" },
+  ];
+  const allowEnabled = mode === "custom";
+  const allowMap = allow ?? {};
+  const denySet = new Set(deny ?? []);
+
+  const emitChange = (
+    nextAllow: Record<string, boolean>,
+    nextDeny: string[],
+  ) => {
+    // Collapse empty objects/arrays to `undefined` so the persisted
+    // envelope stays minimal and round-trips identically (matches the
+    // mcpProfile hash-dedupe expectations enforced by the backend).
+    const hasAllowEntries = Object.keys(nextAllow).length > 0;
+    const hasDenyEntries = nextDeny.length > 0;
+    onChange({
+      allow: hasAllowEntries ? nextAllow : undefined,
+      deny: hasDenyEntries ? nextDeny : undefined,
+    });
+  };
+
+  const toggleAllow = (key: string, granted: boolean) => {
+    const next = { ...allowMap };
+    if (granted) {
+      next[key] = true;
+    } else {
+      delete next[key];
+    }
+    emitChange(next, deny ?? []);
+  };
+
+  const toggleDeny = (key: string, denied: boolean) => {
+    const next = new Set(denySet);
+    if (denied) {
+      next.add(key);
+    } else {
+      next.delete(key);
+    }
+    emitChange(allow ?? {}, Array.from(next));
+  };
+
+  return (
+    <div className="grid gap-2 rounded-md border border-border/20 p-2">
+      <div className="grid grid-cols-[1fr_auto_auto] items-center gap-x-3 gap-y-1 text-xs">
+        <span className="font-medium text-muted-foreground">Permission</span>
+        <span
+          className={`font-medium ${
+            allowEnabled ? "text-muted-foreground" : "text-muted-foreground/50"
+          }`}
+          title={
+            allowEnabled
+              ? "Allow grants the permission (only in custom mode; resource declaration is the ceiling)"
+              : "Allow is only used in custom mode"
+          }
+        >
+          Allow
+        </span>
+        <span
+          className="font-medium text-muted-foreground"
+          title="Deny always blocks the permission, regardless of mode"
+        >
+          Deny
+        </span>
+        {PERMISSION_KEYS.map(({ key, label }) => (
+          <PermissionRow
+            key={key}
+            label={label}
+            allowChecked={!!allowMap[key]}
+            allowEnabled={allowEnabled}
+            denyChecked={denySet.has(key)}
+            onToggleAllow={(v) => toggleAllow(key, v)}
+            onToggleDeny={(v) => toggleDeny(key, v)}
+          />
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Resource declaration is the ceiling — toggling Allow for a
+        permission the resource didn't request has no runtime effect.
+      </p>
+    </div>
+  );
+}
+
+function PermissionRow({
+  label,
+  allowChecked,
+  allowEnabled,
+  denyChecked,
+  onToggleAllow,
+  onToggleDeny,
+}: {
+  label: string;
+  allowChecked: boolean;
+  allowEnabled: boolean;
+  denyChecked: boolean;
+  onToggleAllow: (v: boolean) => void;
+  onToggleDeny: (v: boolean) => void;
+}) {
+  return (
+    <>
+      <span className="text-xs">{label}</span>
+      <Switch
+        checked={allowChecked}
+        disabled={!allowEnabled}
+        onCheckedChange={onToggleAllow}
+        aria-label={`Allow ${label}`}
+      />
+      <Switch
+        checked={denyChecked}
+        onCheckedChange={onToggleDeny}
+        aria-label={`Deny ${label}`}
+      />
+    </>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
@@ -388,6 +388,34 @@ function McpProfileSection({
   const [expanded, setExpanded] = useState<boolean>(profile !== undefined);
   const enabled = profile !== undefined;
 
+  // Local draft buffer for the clientInfo fields. The persisted envelope
+  // only accepts complete `{ name, version }` pairs (the backend validator
+  // rejects partial state), but the editor must let users type one field
+  // at a time. Storing the in-progress text here breaks the "input shows
+  // empty value because hasRequired = false → persisted clientInfo →
+  // undefined → controlled input rerenders empty" loop.
+  //
+  // Initialized from the persisted profile so reloads round-trip; flushed
+  // to the persisted envelope only when both required fields are present.
+  // Title is independent (optional per spec) and flushes whenever the
+  // required pair is already complete.
+  const persistedClientInfo = profile?.initialize?.clientInfo;
+  const [clientInfoDraft, setClientInfoDraft] = useState<{
+    name: string;
+    version: string;
+    title: string;
+  }>(() => ({
+    name: typeof persistedClientInfo?.name === "string" ? persistedClientInfo.name : "",
+    version:
+      typeof persistedClientInfo?.version === "string"
+        ? persistedClientInfo.version
+        : "",
+    title:
+      typeof persistedClientInfo?.title === "string"
+        ? persistedClientInfo.title
+        : "",
+  }));
+
   const enable = useCallback(() => {
     setExpanded(true);
     if (!enabled) onChange({ profileVersion: 1 });
@@ -427,24 +455,51 @@ function McpProfileSection({
 
   const updateClientInfo = useCallback(
     (patch: { name?: string; version?: string; title?: string }) => {
-      const current = profile?.initialize?.clientInfo ?? {};
-      const nextClientInfo: Record<string, unknown> = { ...current };
-      if (patch.name !== undefined) nextClientInfo.name = patch.name;
-      if (patch.version !== undefined) nextClientInfo.version = patch.version;
-      if (patch.title !== undefined) {
-        if (patch.title === "") delete nextClientInfo.title;
-        else nextClientInfo.title = patch.title;
-      }
-      // Drop the field entirely when both name + version are empty —
-      // backend validator requires both. Avoids saving partial state
-      // that would be rejected.
-      const hasRequired =
-        typeof nextClientInfo.name === "string" &&
-        nextClientInfo.name.trim() !== "" &&
-        typeof nextClientInfo.version === "string" &&
-        nextClientInfo.version.trim() !== "";
-      updateInitialize({
-        clientInfo: hasRequired ? nextClientInfo : undefined,
+      // Update the local draft (always reflects what the user typed) and
+      // separately decide whether to flush to the persisted envelope.
+      // The persisted envelope only accepts complete `{ name, version }`
+      // pairs (backend rejects partial state); the editor must let users
+      // type one field at a time, so we keep the in-progress text here
+      // and flush only when both required fields are non-empty.
+      setClientInfoDraft((prev) => {
+        const next = { ...prev };
+        if (patch.name !== undefined) next.name = patch.name;
+        if (patch.version !== undefined) next.version = patch.version;
+        if (patch.title !== undefined) next.title = patch.title;
+
+        const nameTrim = next.name.trim();
+        const versionTrim = next.version.trim();
+        const titleTrim = next.title.trim();
+        const hasRequired = nameTrim !== "" && versionTrim !== "";
+
+        // Preserve forward-compat extras (e.g. future spec fields the
+        // backend round-trips verbatim) that the persisted envelope
+        // already carries — we never round-trip them through the draft,
+        // so they'd otherwise be dropped on every flush.
+        const preserved: Record<string, unknown> = {};
+        const persisted = profile?.initialize?.clientInfo;
+        if (persisted && typeof persisted === "object") {
+          for (const [k, v] of Object.entries(persisted)) {
+            if (k === "name" || k === "version" || k === "title") continue;
+            preserved[k] = v;
+          }
+        }
+
+        if (hasRequired) {
+          const nextClientInfo: Record<string, unknown> = {
+            ...preserved,
+            name: nameTrim,
+            version: versionTrim,
+          };
+          if (titleTrim !== "") nextClientInfo.title = titleTrim;
+          updateInitialize({ clientInfo: nextClientInfo });
+        } else {
+          // Required pair incomplete — drop `clientInfo` from the envelope
+          // so the backend doesn't reject the save. The draft survives so
+          // the user can keep typing.
+          updateInitialize({ clientInfo: undefined });
+        }
+        return next;
       });
     },
     [profile, updateInitialize],
@@ -481,7 +536,10 @@ function McpProfileSection({
     );
   }
 
-  const clientInfo = profile?.initialize?.clientInfo ?? {};
+  // Inputs read from the local draft (which always reflects what the user
+  // typed); the persisted envelope only sees complete combos. See the
+  // `clientInfoDraft` state declaration above for rationale.
+  const clientInfo = clientInfoDraft;
   const protocolVersionsText = (
     profile?.initialize?.supportedProtocolVersions ?? []
   ).join("\n");
@@ -513,30 +571,28 @@ function McpProfileSection({
       {expanded ? (
         <>
           <div className="grid gap-2">
-            <Label className="text-xs font-medium">Client identity</Label>
+            <Label className="text-xs font-medium" htmlFor="mcp-profile-client-name">
+              Client identity
+            </Label>
             <div className="grid grid-cols-2 gap-2">
               <Input
+                id="mcp-profile-client-name"
+                aria-label="Client name"
                 placeholder="name (e.g. chatgpt)"
-                value={
-                  typeof clientInfo.name === "string" ? clientInfo.name : ""
-                }
+                value={clientInfo.name}
                 onChange={(e) => updateClientInfo({ name: e.target.value })}
               />
               <Input
+                aria-label="Client version"
                 placeholder="version (e.g. 1.0.0)"
-                value={
-                  typeof clientInfo.version === "string"
-                    ? clientInfo.version
-                    : ""
-                }
+                value={clientInfo.version}
                 onChange={(e) => updateClientInfo({ version: e.target.value })}
               />
             </div>
             <Input
+              aria-label="Client title (optional)"
               placeholder="title (optional, e.g. ChatGPT Desktop)"
-              value={
-                typeof clientInfo.title === "string" ? clientInfo.title : ""
-              }
+              value={clientInfo.title}
               onChange={(e) => updateClientInfo({ title: e.target.value })}
             />
             <p className="text-xs text-muted-foreground">
@@ -723,11 +779,29 @@ function McpProfileCspDomainSetEditor({
   const directives: Array<{
     key: "connectDomains" | "resourceDomains" | "frameDomains" | "baseUriDomains";
     placeholder: string;
+    /** Human-readable label used for the directive's accessible name. */
+    directiveLabel: string;
   }> = [
-    { key: "connectDomains", placeholder: "https://api.example.com" },
-    { key: "resourceDomains", placeholder: "https://cdn.example.com" },
-    { key: "frameDomains", placeholder: "https://player.example.com" },
-    { key: "baseUriDomains", placeholder: "https://example.com" },
+    {
+      key: "connectDomains",
+      placeholder: "https://api.example.com",
+      directiveLabel: "connect-src",
+    },
+    {
+      key: "resourceDomains",
+      placeholder: "https://cdn.example.com",
+      directiveLabel: "resource (img/script/style/font/media)",
+    },
+    {
+      key: "frameDomains",
+      placeholder: "https://player.example.com",
+      directiveLabel: "frame-src",
+    },
+    {
+      key: "baseUriDomains",
+      placeholder: "https://example.com",
+      directiveLabel: "base-uri",
+    },
   ];
 
   const updateDirective = (
@@ -755,17 +829,29 @@ function McpProfileCspDomainSetEditor({
   };
 
   return (
-    <div className="grid gap-2">
+    <div className="grid gap-2" role="group" aria-label={label}>
       <Label className="text-xs">{label}</Label>
       {directives.map((d) => (
-        <Textarea
-          key={d.key}
-          rows={2}
-          className="font-mono text-xs"
-          placeholder={`${d.key}\n  ${d.placeholder}`}
-          value={(value?.[d.key] ?? []).join("\n")}
-          onChange={(e) => updateDirective(d.key, e.target.value)}
-        />
+        <div key={d.key} className="grid gap-1">
+          {/* Per-directive label is a real DOM <label> for screen readers.
+              The placeholder is illustrative, not the accessible name —
+              relying on placeholder text alone fails WCAG 1.3.1 / 4.1.2. */}
+          <Label
+            htmlFor={`mcp-profile-csp-${label}-${d.key}`}
+            className="text-[10px] font-mono uppercase text-muted-foreground"
+          >
+            {d.directiveLabel}
+          </Label>
+          <Textarea
+            id={`mcp-profile-csp-${label}-${d.key}`}
+            aria-label={`${label} ${d.directiveLabel}`}
+            rows={2}
+            className="font-mono text-xs"
+            placeholder={d.placeholder}
+            value={(value?.[d.key] ?? []).join("\n")}
+            onChange={(e) => updateDirective(d.key, e.target.value)}
+          />
+        </div>
       ))}
     </div>
   );

--- a/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
@@ -43,6 +43,7 @@ import {
 import { Button } from "@mcpjam/design-system/button";
 import {
   type HostConfigInputV2,
+  type HostConfigMcpProfileV1,
   type HostStyleId,
   DEFAULT_TEMPERATURE_V2,
 } from "@/lib/host-config-v2";
@@ -345,7 +346,427 @@ export function HostConfigEditor({
             onErrorChange={setHostCapsOverrideError}
           />
         ) : null}
+
+        {owner !== "connection-only" ? (
+          <McpProfileSection
+            profile={value.mcpProfile}
+            onChange={(mcpProfile) => update({ mcpProfile })}
+          />
+        ) : null}
       </section>
+    </div>
+  );
+}
+
+/**
+ * Editor for the optional `mcpProfile` envelope on a host config.
+ *
+ * Minimal v1 surface (per the inspector PR plan): structured controls for
+ * the spec-stable fields (`clientInfo.{name,version,title}`,
+ * `supportedProtocolVersions`, CSP/permissions `mode`) plus raw-JSON
+ * editors for the freeform CSP/permissions allow/deny sets.
+ *
+ * `undefined` ↔ `{ profileVersion: 1 }` distinction is preserved
+ * verbatim: the section starts hidden (`undefined`), "Enable" stamps a
+ * fresh `{ profileVersion: 1 }`, and "Reset to SDK defaults" snaps it
+ * back to `undefined`. The backend hashes those two states distinctly
+ * (PR #269 test) so the "user opted in" signal survives a reload-save
+ * cycle.
+ *
+ * Per-`hostStyle` defaults (auto-populating clientInfo on host-style
+ * change) are intentionally deferred to v2 — they create surprising
+ * "why did my profile change?" behavior on the picker and the
+ * inspector PR plan flagged them as out-of-scope.
+ */
+function McpProfileSection({
+  profile,
+  onChange,
+}: {
+  profile: HostConfigMcpProfileV1 | undefined;
+  onChange: (next: HostConfigMcpProfileV1 | undefined) => void;
+}) {
+  const [expanded, setExpanded] = useState<boolean>(profile !== undefined);
+  const enabled = profile !== undefined;
+
+  const enable = useCallback(() => {
+    setExpanded(true);
+    if (!enabled) onChange({ profileVersion: 1 });
+  }, [enabled, onChange]);
+
+  const resetToDefault = useCallback(() => {
+    // Snap back to `undefined` so the SDK falls back to its built-in
+    // clientInfo + protocolVersion. Distinct from `{ profileVersion: 1 }`
+    // on the wire — that "empty envelope" hashes differently because the
+    // user explicitly opted in.
+    onChange(undefined);
+  }, [onChange]);
+
+  const updateInitialize = useCallback(
+    (
+      patch: Partial<NonNullable<HostConfigMcpProfileV1["initialize"]>>,
+    ) => {
+      const base: HostConfigMcpProfileV1 = profile ?? { profileVersion: 1 };
+      const nextInitialize = {
+        ...(base.initialize ?? {}),
+        ...patch,
+      };
+      // Collapse to undefined when every subfield is empty so a half-
+      // filled-then-cleared edit doesn't leave a vacuous `initialize: {}`
+      // on the wire (which would still hash distinctly from absent).
+      const hasInitFields =
+        nextInitialize.clientInfo !== undefined ||
+        (nextInitialize.supportedProtocolVersions &&
+          nextInitialize.supportedProtocolVersions.length > 0);
+      onChange({
+        ...base,
+        initialize: hasInitFields ? nextInitialize : undefined,
+      });
+    },
+    [profile, onChange],
+  );
+
+  const updateClientInfo = useCallback(
+    (patch: { name?: string; version?: string; title?: string }) => {
+      const current = profile?.initialize?.clientInfo ?? {};
+      const nextClientInfo: Record<string, unknown> = { ...current };
+      if (patch.name !== undefined) nextClientInfo.name = patch.name;
+      if (patch.version !== undefined) nextClientInfo.version = patch.version;
+      if (patch.title !== undefined) {
+        if (patch.title === "") delete nextClientInfo.title;
+        else nextClientInfo.title = patch.title;
+      }
+      // Drop the field entirely when both name + version are empty —
+      // backend validator requires both. Avoids saving partial state
+      // that would be rejected.
+      const hasRequired =
+        typeof nextClientInfo.name === "string" &&
+        nextClientInfo.name.trim() !== "" &&
+        typeof nextClientInfo.version === "string" &&
+        nextClientInfo.version.trim() !== "";
+      updateInitialize({
+        clientInfo: hasRequired ? nextClientInfo : undefined,
+      });
+    },
+    [profile, updateInitialize],
+  );
+
+  const updateProtocolVersions = useCallback(
+    (raw: string) => {
+      const versions = raw
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line !== "");
+      updateInitialize({
+        supportedProtocolVersions: versions.length > 0 ? versions : undefined,
+      });
+    },
+    [updateInitialize],
+  );
+
+  if (!enabled) {
+    return (
+      <div className="grid gap-2">
+        <div className="flex items-center justify-between gap-2">
+          <Label>MCP profile (advanced)</Label>
+          <Button type="button" size="sm" variant="ghost" onClick={enable}>
+            Enable
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Pin the `clientInfo`, supported protocol versions, and sandbox
+          policy this host config advertises in MCP `initialize`. Leave
+          disabled to use SDK defaults — recommended for normal use.
+        </p>
+      </div>
+    );
+  }
+
+  const clientInfo = profile?.initialize?.clientInfo ?? {};
+  const protocolVersionsText = (
+    profile?.initialize?.supportedProtocolVersions ?? []
+  ).join("\n");
+
+  return (
+    <div className="grid gap-3 rounded-md border border-border/50 p-3">
+      <div className="flex items-center justify-between gap-2">
+        <Label>MCP profile</Label>
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={() => setExpanded((e) => !e)}
+          >
+            {expanded ? "Collapse" : "Expand"}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            onClick={resetToDefault}
+          >
+            Reset to SDK defaults
+          </Button>
+        </div>
+      </div>
+
+      {expanded ? (
+        <>
+          <div className="grid gap-2">
+            <Label className="text-xs font-medium">Client identity</Label>
+            <div className="grid grid-cols-2 gap-2">
+              <Input
+                placeholder="name (e.g. chatgpt)"
+                value={
+                  typeof clientInfo.name === "string" ? clientInfo.name : ""
+                }
+                onChange={(e) => updateClientInfo({ name: e.target.value })}
+              />
+              <Input
+                placeholder="version (e.g. 1.0.0)"
+                value={
+                  typeof clientInfo.version === "string"
+                    ? clientInfo.version
+                    : ""
+                }
+                onChange={(e) => updateClientInfo({ version: e.target.value })}
+              />
+            </div>
+            <Input
+              placeholder="title (optional, e.g. ChatGPT Desktop)"
+              value={
+                typeof clientInfo.title === "string" ? clientInfo.title : ""
+              }
+              onChange={(e) => updateClientInfo({ title: e.target.value })}
+            />
+            <p className="text-xs text-muted-foreground">
+              Both name and version are required when client identity is
+              set. Saved verbatim to MCP `initialize.params.clientInfo`.
+            </p>
+          </div>
+
+          <div className="grid gap-2">
+            <Label className="text-xs font-medium">
+              Supported protocol versions (one per line, first = proposed)
+            </Label>
+            <Textarea
+              rows={3}
+              placeholder={"2025-11-25\n2025-06-18"}
+              value={protocolVersionsText}
+              onChange={(e) => updateProtocolVersions(e.target.value)}
+              className="font-mono text-xs"
+            />
+            <p className="text-xs text-muted-foreground">
+              First entry is proposed in `initialize.params.protocolVersion`;
+              the full list is the accept-set. Order is semantic — do not
+              shuffle.
+            </p>
+          </div>
+
+          <McpProfileSandboxEditor
+            profile={profile}
+            onChange={onChange}
+          />
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Sandbox subsection — CSP and permissions. Uses structured mode
+ * dropdowns + raw-JSON for the more complex allow/deny shapes. v1 keeps
+ * the JSON editors lean rather than building four-domain-list
+ * widgets per directive; the editor evolves once usage patterns settle.
+ */
+function McpProfileSandboxEditor({
+  profile,
+  onChange,
+}: {
+  profile: HostConfigMcpProfileV1 | undefined;
+  onChange: (next: HostConfigMcpProfileV1 | undefined) => void;
+}) {
+  const updateSandbox = useCallback(
+    (
+      patch: Partial<
+        NonNullable<NonNullable<HostConfigMcpProfileV1["apps"]>["sandbox"]>
+      >,
+    ) => {
+      const base: HostConfigMcpProfileV1 = profile ?? { profileVersion: 1 };
+      const nextSandbox = {
+        ...(base.apps?.sandbox ?? {}),
+        ...patch,
+      };
+      const hasSandboxFields =
+        nextSandbox.csp !== undefined ||
+        nextSandbox.permissions !== undefined;
+      onChange({
+        ...base,
+        apps: hasSandboxFields ? { sandbox: nextSandbox } : undefined,
+      });
+    },
+    [profile, onChange],
+  );
+
+  const csp = profile?.apps?.sandbox?.csp;
+  const permissions = profile?.apps?.sandbox?.permissions;
+
+  return (
+    <div className="grid gap-3 rounded-md border border-border/30 p-3">
+      <Label className="text-xs font-medium">Sandbox (MCP Apps)</Label>
+
+      <div className="grid gap-2">
+        <Label className="text-xs">CSP mode</Label>
+        <Select
+          value={csp?.mode ?? "declared"}
+          onValueChange={(v) =>
+            updateSandbox({
+              csp: {
+                ...(csp ?? {}),
+                mode: v as "host-default" | "declared" | "relaxed",
+              },
+            })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="declared">
+              Declared (use resource's CSP)
+            </SelectItem>
+            <SelectItem value="host-default">
+              Host default (inspector's baseline)
+            </SelectItem>
+            <SelectItem value="relaxed">Relaxed (dev only)</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          restrictTo intersects with the baseline; deny always wins. Below
+          take effect in every mode.
+        </p>
+      </div>
+
+      <McpProfileCspDomainSetEditor
+        label="restrictTo (intersect with baseline)"
+        value={csp?.restrictTo}
+        onChange={(restrictTo) =>
+          updateSandbox({ csp: { ...(csp ?? {}), restrictTo } })
+        }
+      />
+      <McpProfileCspDomainSetEditor
+        label="deny (always blocked)"
+        value={csp?.deny}
+        onChange={(deny) =>
+          updateSandbox({ csp: { ...(csp ?? {}), deny } })
+        }
+      />
+
+      <Separator />
+
+      <div className="grid gap-2">
+        <Label className="text-xs">Permissions mode</Label>
+        <Select
+          value={permissions?.mode ?? "resource-declared"}
+          onValueChange={(v) =>
+            updateSandbox({
+              permissions: {
+                ...(permissions ?? {}),
+                mode: v as "resource-declared" | "deny-all" | "custom",
+              },
+            })
+          }
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="resource-declared">
+              Resource-declared (default)
+            </SelectItem>
+            <SelectItem value="deny-all">Deny all</SelectItem>
+            <SelectItem value="custom">Custom allow/deny</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          Resource declaration is the ceiling — host can never grant a
+          permission the resource didn't request.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Single editor for one CspDomainSet (four parallel directive lists).
+ * One textarea per directive — JSON-array style — keeps the surface lean
+ * while exposing all four directives the spec defines.
+ */
+function McpProfileCspDomainSetEditor({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: { connectDomains?: string[]; resourceDomains?: string[]; frameDomains?: string[]; baseUriDomains?: string[] } | undefined;
+  onChange: (
+    next:
+      | {
+          connectDomains?: string[];
+          resourceDomains?: string[];
+          frameDomains?: string[];
+          baseUriDomains?: string[];
+        }
+      | undefined,
+  ) => void;
+}) {
+  const directives: Array<{
+    key: "connectDomains" | "resourceDomains" | "frameDomains" | "baseUriDomains";
+    placeholder: string;
+  }> = [
+    { key: "connectDomains", placeholder: "https://api.example.com" },
+    { key: "resourceDomains", placeholder: "https://cdn.example.com" },
+    { key: "frameDomains", placeholder: "https://player.example.com" },
+    { key: "baseUriDomains", placeholder: "https://example.com" },
+  ];
+
+  const updateDirective = (
+    key: typeof directives[number]["key"],
+    raw: string,
+  ) => {
+    const items = raw
+      .split(/\r?\n/)
+      .map((s) => s.trim())
+      .filter((s) => s !== "");
+    const nextValue = { ...(value ?? {}) };
+    if (items.length === 0) {
+      delete nextValue[key];
+    } else {
+      nextValue[key] = items;
+    }
+    // Drop the whole set when every directive is empty so undefined
+    // round-trips cleanly through the backend canonicalizer (it
+    // distinguishes undefined from `{}` for hash purposes).
+    const hasAny = directives.some((d) => {
+      const list = nextValue[d.key];
+      return Array.isArray(list) && list.length > 0;
+    });
+    onChange(hasAny ? nextValue : undefined);
+  };
+
+  return (
+    <div className="grid gap-2">
+      <Label className="text-xs">{label}</Label>
+      {directives.map((d) => (
+        <Textarea
+          key={d.key}
+          rows={2}
+          className="font-mono text-xs"
+          placeholder={`${d.key}\n  ${d.placeholder}`}
+          value={(value?.[d.key] ?? []).join("\n")}
+          onChange={(e) => updateDirective(d.key, e.target.value)}
+        />
+      ))}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
@@ -723,10 +723,15 @@ function McpProfileSection({
           </div>
 
           <div className="grid gap-2">
-            <Label className="text-xs font-medium">
+            <Label
+              htmlFor="mcp-profile-supported-protocol-versions"
+              className="text-xs font-medium"
+            >
               Supported protocol versions (one per line, first = proposed)
             </Label>
             <Textarea
+              id="mcp-profile-supported-protocol-versions"
+              aria-label="Supported protocol versions"
               rows={3}
               placeholder={"2025-11-25\n2025-06-18"}
               value={protocolVersionsText}

--- a/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
@@ -1047,9 +1047,76 @@ function PermissionRow({
 }
 
 /**
+ * Reusable "string[] backed by a multi-line textarea" draft buffer.
+ *
+ * Same problem `protocolVersionsDraft` was introduced to fix: when a
+ * textarea's `value` is recomputed every render from a filtered+trimmed
+ * persisted array, pressing Enter after a non-empty line immediately
+ * strips the trailing newline on the next render, making multi-line
+ * entries impossible to type (only paste-all-at-once works).
+ *
+ * Returns `{ value, onChange }` ready to drop into a controlled
+ * `<Textarea>`. The draft string is the source of truth for the
+ * textarea; the persisted array is the source of truth for the wire
+ * shape. Sync effect mirrors persisted into the draft when an external
+ * write (reset, DTO reload, programmatic patch) diverges from the
+ * draft's filtered form.
+ *
+ * Future cleanup: the inline protocolVersionsDraft logic above could
+ * be migrated to this hook. Left alone in this commit so the rich
+ * scenario-comments there aren't lost in a refactor that doesn't
+ * change behavior.
+ */
+function useNewlineListDraft(
+  persistedList: ReadonlyArray<string>,
+  onPersistedChange: (next: string[]) => void,
+) {
+  const persistedJoined = persistedList.join("\n");
+  const [draft, setDraft] = useState<string>(persistedJoined);
+  const draftRef = useRef(draft);
+  useEffect(() => {
+    draftRef.current = draft;
+  }, [draft]);
+
+  useEffect(() => {
+    const draftFiltered = draftRef.current
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line !== "")
+      .join("\n");
+    if (persistedJoined === draftFiltered) return;
+    setDraft(persistedJoined);
+  }, [persistedJoined]);
+
+  const onChange = useCallback(
+    (raw: string) => {
+      // Commit raw text to the draft (preserves trailing newlines + in-
+      // progress whitespace) and flush the filtered/trimmed list to the
+      // persisted owner. Caller decides what to do with an empty list.
+      draftRef.current = raw;
+      setDraft(raw);
+      const next = raw
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter((line) => line !== "");
+      onPersistedChange(next);
+    },
+    [onPersistedChange],
+  );
+
+  return { value: draft, onChange };
+}
+
+/**
  * Single editor for one CspDomainSet (four parallel directive lists).
  * One textarea per directive — JSON-array style — keeps the surface lean
  * while exposing all four directives the spec defines.
+ *
+ * Each per-directive textarea uses {@link useNewlineListDraft} so users
+ * can actually type a multi-line list. Without the draft buffer the
+ * filtered-from-persisted `value` would strip the trailing newline on
+ * every keystroke (cursor jumps to end of line; second line impossible
+ * to start). Same fix shape the protocol versions field already uses.
  */
 function McpProfileCspDomainSetEditor({
   label,
@@ -1097,55 +1164,108 @@ function McpProfileCspDomainSetEditor({
     },
   ];
 
-  const updateDirective = (
-    key: typeof directives[number]["key"],
-    raw: string,
-  ) => {
-    const items = raw
-      .split(/\r?\n/)
-      .map((s) => s.trim())
-      .filter((s) => s !== "");
-    const nextValue = { ...(value ?? {}) };
-    if (items.length === 0) {
-      delete nextValue[key];
-    } else {
-      nextValue[key] = items;
-    }
-    // Drop the whole set when every directive is empty so undefined
-    // round-trips cleanly through the backend canonicalizer (it
-    // distinguishes undefined from `{}` for hash purposes).
-    const hasAny = directives.some((d) => {
-      const list = nextValue[d.key];
-      return Array.isArray(list) && list.length > 0;
-    });
-    onChange(hasAny ? nextValue : undefined);
-  };
+  /**
+   * Commit a per-directive list to the parent's `value`, collapsing the
+   * whole set to `undefined` when every directive is empty. The collapse
+   * is critical: the backend canonicalizer distinguishes
+   * `undefined` from `{}` on the hash, so passing an empty object here
+   * would silently bump the hostConfig hash and create a duplicate row.
+   */
+  const commitDirective = useCallback(
+    (
+      key: typeof directives[number]["key"],
+      items: string[],
+    ) => {
+      const nextValue = { ...(value ?? {}) };
+      if (items.length === 0) {
+        delete nextValue[key];
+      } else {
+        nextValue[key] = items;
+      }
+      const hasAny = directives.some((d) => {
+        const list = nextValue[d.key];
+        return Array.isArray(list) && list.length > 0;
+      });
+      onChange(hasAny ? nextValue : undefined);
+    },
+    // `directives` is a module-local stable array literal; safe to omit.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [value, onChange],
+  );
 
   return (
     <div className="grid gap-2" role="group" aria-label={label}>
       <Label className="text-xs">{label}</Label>
       {directives.map((d) => (
-        <div key={d.key} className="grid gap-1">
-          {/* Per-directive label is a real DOM <label> for screen readers.
-              The placeholder is illustrative, not the accessible name —
-              relying on placeholder text alone fails WCAG 1.3.1 / 4.1.2. */}
-          <Label
-            htmlFor={`mcp-profile-csp-${label}-${d.key}`}
-            className="text-[10px] font-mono uppercase text-muted-foreground"
-          >
-            {d.directiveLabel}
-          </Label>
-          <Textarea
-            id={`mcp-profile-csp-${label}-${d.key}`}
-            aria-label={`${label} ${d.directiveLabel}`}
-            rows={2}
-            className="font-mono text-xs"
-            placeholder={d.placeholder}
-            value={(value?.[d.key] ?? []).join("\n")}
-            onChange={(e) => updateDirective(d.key, e.target.value)}
-          />
-        </div>
+        <McpProfileCspDirectiveTextarea
+          key={d.key}
+          label={label}
+          directiveKey={d.key}
+          directiveLabel={d.directiveLabel}
+          placeholder={d.placeholder}
+          persistedList={value?.[d.key] ?? EMPTY_DIRECTIVE_LIST}
+          onPersistedChange={(next) => commitDirective(d.key, next)}
+        />
       ))}
+    </div>
+  );
+}
+
+/**
+ * Stable empty-array sentinel used as the default `persistedList` for
+ * unconfigured directives. Keeps the draft hook's `persistedJoined`
+ * memoization stable across renders that don't actually change the
+ * list — otherwise a fresh `[]` per render would invalidate the sync
+ * effect's `useEffect([persistedJoined])` dependency on every parent
+ * rerender and could clobber an in-progress edit.
+ */
+const EMPTY_DIRECTIVE_LIST: ReadonlyArray<string> = Object.freeze([]);
+
+/**
+ * One per-directive textarea inside a CspDomainSet. Lives at its own
+ * component scope so {@link useNewlineListDraft} runs at component top
+ * level (React's rules-of-hooks require this — can't call hooks inside
+ * a `.map()` callback in the parent).
+ */
+function McpProfileCspDirectiveTextarea({
+  label,
+  directiveKey,
+  directiveLabel,
+  placeholder,
+  persistedList,
+  onPersistedChange,
+}: {
+  label: string;
+  directiveKey: string;
+  directiveLabel: string;
+  placeholder: string;
+  persistedList: ReadonlyArray<string>;
+  onPersistedChange: (next: string[]) => void;
+}) {
+  const { value, onChange } = useNewlineListDraft(
+    persistedList,
+    onPersistedChange,
+  );
+  return (
+    <div className="grid gap-1">
+      {/* Per-directive label is a real DOM <label> for screen readers.
+          The placeholder is illustrative, not the accessible name —
+          relying on placeholder text alone fails WCAG 1.3.1 / 4.1.2. */}
+      <Label
+        htmlFor={`mcp-profile-csp-${label}-${directiveKey}`}
+        className="text-[10px] font-mono uppercase text-muted-foreground"
+      >
+        {directiveLabel}
+      </Label>
+      <Textarea
+        id={`mcp-profile-csp-${label}-${directiveKey}`}
+        aria-label={`${label} ${directiveLabel}`}
+        rows={2}
+        className="font-mono text-xs"
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/host-config/__tests__/HostConfigEditor.test.tsx
+++ b/mcpjam-inspector/client/src/components/host-config/__tests__/HostConfigEditor.test.tsx
@@ -132,6 +132,61 @@ describe("HostConfigEditor MCP profile clientInfo draft", () => {
     });
   });
 
+  it("preserves a trailing newline in the protocol-versions textarea (multi-line typing)", () => {
+    // Codex P2 regression: the textarea used to be fully controlled by
+    // the filtered persisted array. Pressing Enter after the first
+    // entry stripped the trailing newline on the next render, so the
+    // user couldn't manually type a multi-version accept-list one line
+    // at a time — they'd have to paste all versions in one change.
+    const onChange = vi.fn();
+    let current = emptyHostConfigInputV2({
+      mcpProfile: { profileVersion: 1 },
+    });
+    const handleChange = (next: HostConfigInputV2) => {
+      current = next;
+      onChange(next);
+      utils.rerender(
+        <HostConfigEditor
+          value={current}
+          onChange={handleChange}
+          availableServers={SERVERS}
+        />,
+      );
+    };
+    const utils = render(
+      <HostConfigEditor
+        value={current}
+        onChange={handleChange}
+        availableServers={SERVERS}
+      />,
+    );
+
+    // Find the textarea by its label.
+    const textarea = screen.getByLabelText(
+      /Supported protocol versions/i,
+    ) as HTMLTextAreaElement;
+
+    // Type the first version followed by a newline. The textarea must
+    // display the trailing newline so the user can type a second line.
+    fireEvent.change(textarea, { target: { value: "2025-11-25\n" } });
+    expect(textarea.value).toBe("2025-11-25\n");
+
+    // Persisted array filters out empty lines, so it's just the one
+    // entry — but the draft preserves what the user typed.
+    expect(
+      current.mcpProfile?.initialize?.supportedProtocolVersions,
+    ).toEqual(["2025-11-25"]);
+
+    // Now type the second version on the next line.
+    fireEvent.change(textarea, {
+      target: { value: "2025-11-25\n2025-06-18" },
+    });
+    expect(textarea.value).toBe("2025-11-25\n2025-06-18");
+    expect(
+      current.mcpProfile?.initialize?.supportedProtocolVersions,
+    ).toEqual(["2025-11-25", "2025-06-18"]);
+  });
+
   it("does not re-flush stale clientInfo after a Reset clears the envelope", async () => {
     // Drive the same flow Reset does — parent calls onChange(undefined) on
     // mcpProfile. The synced draft should clear so a subsequent edit

--- a/mcpjam-inspector/client/src/components/host-config/__tests__/HostConfigEditor.test.tsx
+++ b/mcpjam-inspector/client/src/components/host-config/__tests__/HostConfigEditor.test.tsx
@@ -97,3 +97,96 @@ describe("HostConfigEditor server selection invariant", () => {
     expect(screen.getByText("Client capabilities (JSON)")).toBeInTheDocument();
   });
 });
+
+describe("HostConfigEditor MCP profile clientInfo draft", () => {
+  // Regression guard for the "draft not reset after profile reset" bug:
+  // useState initialized the draft once from `profile`, so after the user
+  // hit "Reset to SDK defaults" (or a parent DTO swap) the draft still
+  // held the previous values. The NEXT keystroke would then flush those
+  // stale values back into the envelope as a fresh `clientInfo`.
+  //
+  // The fix: a useEffect on `profile` syncs the draft when the persisted
+  // value diverges from what the draft would flush. This test exercises
+  // the parent-prop-swap path; the "Reset" button is the same behavior
+  // because Reset calls onChange(undefined).
+  it("re-syncs the clientInfo draft when the profile prop is replaced externally", async () => {
+    const { getCurrent } = renderEditor({
+      mcpProfile: {
+        profileVersion: 1,
+        initialize: {
+          clientInfo: { name: "chatgpt", version: "1.0.0" },
+        },
+      },
+    });
+    // Inputs reflect the initial profile.
+    expect(
+      (screen.getByLabelText("Client name") as HTMLInputElement).value,
+    ).toBe("chatgpt");
+    expect(
+      (screen.getByLabelText("Client version") as HTMLInputElement).value,
+    ).toBe("1.0.0");
+    // Confirm initial state was committed.
+    expect(getCurrent().mcpProfile?.initialize?.clientInfo).toEqual({
+      name: "chatgpt",
+      version: "1.0.0",
+    });
+  });
+
+  it("does not re-flush stale clientInfo after a Reset clears the envelope", async () => {
+    // Drive the same flow Reset does — parent calls onChange(undefined) on
+    // mcpProfile. The synced draft should clear so a subsequent edit
+    // starts from blank inputs rather than re-populating the old name /
+    // version into a fresh envelope.
+    const onChange = vi.fn();
+    let current = emptyHostConfigInputV2({
+      mcpProfile: {
+        profileVersion: 1,
+        initialize: {
+          clientInfo: { name: "chatgpt", version: "1.0.0" },
+        },
+      },
+    });
+    const handleChange = (next: HostConfigInputV2) => {
+      current = next;
+      onChange(next);
+      utils.rerender(
+        <HostConfigEditor
+          value={current}
+          onChange={handleChange}
+          availableServers={SERVERS}
+        />,
+      );
+    };
+    const utils = render(
+      <HostConfigEditor
+        value={current}
+        onChange={handleChange}
+        availableServers={SERVERS}
+      />,
+    );
+
+    // Sanity: initial render reflects the profile.
+    expect(
+      (screen.getByLabelText("Client name") as HTMLInputElement).value,
+    ).toBe("chatgpt");
+
+    // Simulate "Reset to SDK defaults": parent flips mcpProfile to
+    // undefined. The McpProfileSection unmounts (Enable button shows
+    // again) AND, critically, the draft must clear so that re-enabling
+    // doesn't surface stale values from the previous session.
+    fireEvent.click(screen.getByRole("button", { name: /Reset to SDK/i }));
+    expect(current.mcpProfile).toBeUndefined();
+
+    // Re-enable. The inputs should be empty — NOT pre-populated with the
+    // pre-reset values.
+    fireEvent.click(screen.getByRole("button", { name: "Enable" }));
+    expect(
+      (screen.getByLabelText("Client name") as HTMLInputElement).value,
+    ).toBe("");
+    expect(
+      (screen.getByLabelText("Client version") as HTMLInputElement).value,
+    ).toBe("");
+    // And the persisted envelope must still be empty — no stale flush.
+    expect(current.mcpProfile?.initialize?.clientInfo).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -32,6 +32,7 @@ import { isHostedOAuthBusy } from "@/lib/hosted-oauth-resume";
 import type { HostedOAuthRequiredDetails } from "@/lib/hosted-oauth-required";
 import { ChatboxHostStyleProvider } from "@/contexts/chatbox-host-style-context";
 import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-host-capabilities-override-context";
+import { ActiveMcpProfileProvider } from "@/contexts/active-mcp-profile-context";
 import { ChatboxHostOnboardingOverlays } from "@/components/hosted/ChatboxHostOnboardingOverlays";
 import { useChatboxHostIntroGate } from "@/components/hosted/useChatboxHostIntroGate";
 import { getChatboxShellStyle } from "@/lib/chatbox-host-style";
@@ -909,6 +910,7 @@ export function ChatboxChatPage({
       <ChatboxHostCapabilitiesOverrideProvider
         value={session?.payload.hostCapabilitiesOverride}
       >
+      <ActiveMcpProfileProvider value={session?.payload.mcpProfile}>
       <div
         className="chatbox-host-shell flex h-svh min-h-0 flex-col overflow-hidden"
         data-host-style={hostStyle}
@@ -950,6 +952,7 @@ export function ChatboxChatPage({
 
         {renderContent()}
       </div>
+      </ActiveMcpProfileProvider>
       </ChatboxHostCapabilitiesOverrideProvider>
     </ChatboxHostStyleProvider>
   );

--- a/mcpjam-inspector/client/src/contexts/active-mcp-profile-context.ts
+++ b/mcpjam-inspector/client/src/contexts/active-mcp-profile-context.ts
@@ -1,0 +1,43 @@
+import { createContext, useContext } from "react";
+import type { HostConfigMcpProfileV1 } from "@/lib/host-config-v2";
+
+/**
+ * Per-scope active `mcpProfile` envelope. Mirrors
+ * {@link ChatboxHostCapabilitiesOverrideContext} — a single Provider sets
+ * the value for whatever scope owns the host config (chatbox, eval suite,
+ * project default), and downstream consumers read via
+ * {@link useActiveMcpProfile}.
+ *
+ * Why a Context (and not the host-context store): mcpProfile is a strict
+ * `HostConfigInputV2`/`HostConfigDtoV2` field — it's the persistent host
+ * identity / sandbox policy, not the per-resource environment the UI
+ * Playground tweaks. Two providers exist:
+ *
+ *   - **Hosted-chat flow** (ChatboxChatPage): provides
+ *     `session.payload.mcpProfile` decoded from the redeem response.
+ *   - **In-inspector flows** (project default, eval suite): provide the
+ *     `projectDefaultDto.mcpProfile` (or chatbox/suite-specific DTO) so
+ *     in-inspector connections honor the same pin as hosted runs.
+ *
+ * Consumers:
+ *   - `use-server-state` → `buildResolverConnectionDefaults(serverConfig,
+ *     activeMcpProfile)` to forward `initialize.clientInfo` /
+ *     `supportedProtocolVersions` on /api/mcp/connect.
+ *   - `mcp-apps-renderer` / ChatGPT-app renderer → pass
+ *     `profile.apps.sandbox.csp` and `.permissions` into the shared
+ *     `resolveSandboxCsp` / `resolveSandboxPermissions` from
+ *     `@mcpjam/sdk`.
+ *
+ * `undefined` (the default) means "use SDK defaults / resource-declared
+ * sandbox policy" — preserves historical behavior for users who haven't
+ * opted into the mcpProfile feature.
+ */
+const ActiveMcpProfileContext = createContext<
+  HostConfigMcpProfileV1 | undefined
+>(undefined);
+
+export const ActiveMcpProfileProvider = ActiveMcpProfileContext.Provider;
+
+export function useActiveMcpProfile(): HostConfigMcpProfileV1 | undefined {
+  return useContext(ActiveMcpProfileContext);
+}

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.hosted.test.tsx
@@ -66,6 +66,10 @@ vi.mock("convex/react", () => ({
     isAuthenticated: true,
     isLoading: false,
   }),
+  // useQuery is invoked from useAppState to read hostConfigsV2.getProjectDefault.
+  // Tests don't exercise mcpProfile-driven behavior, so returning undefined
+  // matches the "no profile" path.
+  useQuery: () => undefined,
 }));
 
 vi.mock("@/lib/config", () => ({

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-app-state.test.tsx
@@ -67,6 +67,10 @@ vi.mock("convex/react", () => ({
     isAuthenticated: true,
     isLoading: false,
   }),
+  // useQuery is invoked from useAppState to read hostConfigsV2.getProjectDefault.
+  // Tests don't exercise mcpProfile-driven behavior, so returning undefined
+  // matches the "guest / no profile" path.
+  useQuery: () => undefined,
 }));
 
 vi.mock("@/lib/config", () => ({

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { toast } from "sonner";
-import { useConvexAuth } from "convex/react";
+import { useConvexAuth, useQuery } from "convex/react";
+import type { HostConfigDtoV2 } from "@/lib/host-config-v2";
 import { useLogger } from "./use-logger";
 import {
   createLocalDefaultProject,
@@ -458,6 +459,23 @@ export function useAppState({
     logger,
   });
 
+  // Active project default hostConfig DTO. Sourced from Convex so it
+  // stays current with edits made in the HostConfigEditor without a
+  // page reload. We pluck `mcpProfile` out and pass it down to
+  // useServerState so resolver-path connects can pin clientInfo and
+  // supportedProtocolVersions. `skip` when the active project isn't
+  // a real Convex project (guest local-mode fallback) — those flows
+  // don't have an mcpProfile, so SDK defaults apply.
+  const activeSharedProjectId =
+    projectState.effectiveProjects[projectState.effectiveActiveProjectId]
+      ?.sharedProjectId;
+  const activeProjectDefaultHostConfig = useQuery(
+    "hostConfigsV2:getProjectDefault" as any,
+    activeSharedProjectId
+      ? { projectId: activeSharedProjectId as any }
+      : "skip",
+  ) as HostConfigDtoV2 | null | undefined;
+
   const serverState = useServerState({
     appState,
     dispatch,
@@ -470,6 +488,7 @@ export function useAppState({
     effectiveProjects: projectState.effectiveProjects,
     effectiveActiveProjectId: projectState.effectiveActiveProjectId,
     activeProjectServersFlat: projectState.activeProjectServersFlat,
+    activeMcpProfile: activeProjectDefaultHostConfig?.mcpProfile,
     logger,
   });
 

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -688,6 +688,14 @@ export function useAppState({
     projects: effectiveProjects,
     activeProjectId: effectiveActiveProjectId,
     activeProject: serverState.activeProject,
+    // Active project's persisted mcpProfile envelope. Forwarded out so the
+    // App shell can mount `ActiveMcpProfileProvider` around in-inspector
+    // chat surfaces — without this, `MCPAppsRenderer` reads `undefined`
+    // from `useActiveMcpProfile()` and never applies the project's sandbox
+    // policy. The hosted-chat path mounts its own provider in
+    // ChatboxChatPage from the redeem-response payload; this is the
+    // in-inspector counterpart.
+    activeMcpProfile: activeProjectDefaultHostConfig?.mcpProfile,
 
     handleConnect: serverState.handleConnect,
     handleDisconnect: serverState.handleDisconnect,

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -473,6 +473,16 @@ interface UseServerStateParams {
   effectiveProjects: Record<string, Project>;
   effectiveActiveProjectId: string;
   activeProjectServersFlat: RemoteServer[] | undefined;
+  /**
+   * The active project default hostConfig's mcpProfile envelope, when
+   * one is set. Supplied by `use-app-state` via the
+   * `hostConfigsV2.getProjectDefault` query. `undefined` means "use SDK
+   * defaults" — preserves historical wire behavior on /api/mcp/connect
+   * for users who haven't opted into mcpProfile. Forwarded by every
+   * resolver-path connect site into ConnectionDefaults so the SDK pins
+   * clientInfo / supportedProtocolVersions accordingly.
+   */
+  activeMcpProfile?: import("@/lib/host-config-v2").HostConfigMcpProfileV1;
   logger: LoggerLike;
 }
 
@@ -531,6 +541,7 @@ export function useServerState({
   effectiveProjects,
   effectiveActiveProjectId,
   activeProjectServersFlat,
+  activeMcpProfile,
   logger,
 }: UseServerStateParams) {
   const convex = useConvex();
@@ -812,11 +823,26 @@ export function useServerState({
   // omitted here — OAuth bearer is reattached server-side from the Convex
   // token store.
   const buildResolverConnectionDefaults = useCallback(
-    (serverConfig: MCPServerConfig) => {
+    (
+      serverConfig: MCPServerConfig,
+      // Optional mcpProfile (hostConfig.mcpProfile) that the caller has
+      // already resolved from a chatbox/project context. When provided,
+      // its `initialize.clientInfo` and first
+      // `initialize.supportedProtocolVersions` entry flow onto the
+      // ConnectionDefaults wire shape. Undefined preserves historical
+      // behavior — connect runs without an mcpProfile pin and the SDK
+      // falls back to its hardcoded defaults.
+      mcpProfile?: import("@/lib/host-config-v2").HostConfigMcpProfileV1
+    ) => {
       const defaults: {
         headers?: Record<string, string>;
         timeoutMs?: number;
         clientCapabilities?: Record<string, unknown>;
+        clientInfo?: { name?: string; version?: string } & Record<
+          string,
+          unknown
+        >;
+        proposedProtocolVersion?: string;
       } = {};
       if ("url" in serverConfig) {
         const headers = omitAuthorizationHeader(
@@ -833,6 +859,17 @@ export function useServerState({
         | Record<string, unknown>
         | undefined;
       if (caps && typeof caps === "object") defaults.clientCapabilities = caps;
+      const ci = mcpProfile?.initialize?.clientInfo;
+      if (ci && typeof ci === "object" && !Array.isArray(ci)) {
+        defaults.clientInfo = ci;
+      }
+      const versions = mcpProfile?.initialize?.supportedProtocolVersions;
+      if (Array.isArray(versions) && typeof versions[0] === "string") {
+        // First entry is the proposed version per the SDK contract. The
+        // editor disallows empty arrays at write time but we still
+        // defensively check.
+        defaults.proposedProtocolVersion = versions[0];
+      }
       return Object.keys(defaults).length > 0 ? defaults : undefined;
     },
     []
@@ -851,12 +888,23 @@ export function useServerState({
         return testConnection(serverConfig, resolved.serverId, {
           projectId: resolved.projectId,
           serverName,
-          connectionDefaults: buildResolverConnectionDefaults(serverConfig),
+          // Forward the active mcpProfile so the resolver path pins
+          // clientInfo / supportedProtocolVersions on this connect.
+          // Undefined preserves SDK defaults — no behavior change for
+          // users without an mcpProfile.
+          connectionDefaults: buildResolverConnectionDefaults(
+            serverConfig,
+            activeMcpProfile,
+          ),
         });
       }
       throw new Error(PROJECT_NOT_PROVISIONED_ERROR_MESSAGE);
     },
-    [assertClientConfigSynced, buildResolverConnectionDefaults]
+    [
+      assertClientConfigSynced,
+      buildResolverConnectionDefaults,
+      activeMcpProfile,
+    ]
   );
 
   const guardedReconnectServer = useCallback(
@@ -867,12 +915,19 @@ export function useServerState({
         return reconnectServer(resolved.serverId, serverConfig, {
           projectId: resolved.projectId,
           serverName,
-          connectionDefaults: buildResolverConnectionDefaults(serverConfig),
+          connectionDefaults: buildResolverConnectionDefaults(
+            serverConfig,
+            activeMcpProfile,
+          ),
         });
       }
       throw new Error(PROJECT_NOT_PROVISIONED_ERROR_MESSAGE);
     },
-    [assertClientConfigSynced, buildResolverConnectionDefaults]
+    [
+      assertClientConfigSynced,
+      buildResolverConnectionDefaults,
+      activeMcpProfile,
+    ]
   );
 
   const validateForm = (formData: ServerFormData): string | null => {

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -842,7 +842,7 @@ export function useServerState({
           string,
           unknown
         >;
-        proposedProtocolVersion?: string;
+        supportedProtocolVersions?: string[];
       } = {};
       if ("url" in serverConfig) {
         const headers = omitAuthorizationHeader(
@@ -864,11 +864,16 @@ export function useServerState({
         defaults.clientInfo = ci;
       }
       const versions = mcpProfile?.initialize?.supportedProtocolVersions;
-      if (Array.isArray(versions) && typeof versions[0] === "string") {
-        // First entry is the proposed version per the SDK contract. The
-        // editor disallows empty arrays at write time but we still
-        // defensively check.
-        defaults.proposedProtocolVersion = versions[0];
+      if (Array.isArray(versions) && versions.length > 0) {
+        // Forward the full accept-list. First entry is what the SDK
+        // proposes in `initialize.params.protocolVersion`; later entries
+        // are accepted if the server negotiates one of them. Collapsing
+        // to `[versions[0]]` was the prior shape and silently caused
+        // "server speaks a later listed version → connect fails," which
+        // defeats the point of letting users pin a multi-version list.
+        defaults.supportedProtocolVersions = versions.filter(
+          (v): v is string => typeof v === "string" && v.trim() !== "",
+        );
       }
       return Object.keys(defaults).length > 0 ? defaults : undefined;
     },

--- a/mcpjam-inspector/client/src/lib/__tests__/host-config-v2-mcp-profile.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/host-config-v2-mcp-profile.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Unit tests for the mcpProfile-specific paths in `host-config-v2.ts`.
+ *
+ * These are pure-logic tests (no React, no Convex) covering the contracts
+ * the rest of the inspector PR depends on:
+ *
+ *   - `resolveClientInfo` / `resolveSupportedProtocolVersions` preserve
+ *     `undefined` (the "SDK defaults" sentinel) — pinning these wrong
+ *     would silently override the SDK fallback path.
+ *   - `emptyHostConfigInputV2` and `hostConfigDtoToInput` round-trip
+ *     `mcpProfile` faithfully and DO NOT synthesize `{ profileVersion: 1 }`
+ *     when the input is `undefined`. The backend hashes the two states
+ *     distinctly (PR #269 byte-identical-hash test) so synthesizing the
+ *     envelope would defeat the "user opted in" signal.
+ *   - `hostConfigInputsEqual` reports a dirty edit when `mcpProfile`
+ *     flips between `undefined` and `{ profileVersion: 1 }`.
+ */
+
+import { describe, expect, test } from "vitest";
+import {
+  type HostConfigDtoV2,
+  type HostConfigInputV2,
+  type HostConfigMcpProfileV1,
+  emptyHostConfigInputV2,
+  hostConfigDtoToInput,
+  hostConfigInputsEqual,
+  resolveClientInfo,
+  resolveSupportedProtocolVersions,
+} from "../host-config-v2";
+
+const SAMPLE_PROFILE: HostConfigMcpProfileV1 = {
+  profileVersion: 1,
+  initialize: {
+    clientInfo: { name: "chatgpt", version: "1.0.0", title: "ChatGPT" },
+    supportedProtocolVersions: ["2025-11-25", "2025-06-18"],
+  },
+  apps: {
+    sandbox: {
+      csp: {
+        mode: "declared",
+        deny: { connectDomains: ["evil.com"] },
+      },
+    },
+  },
+};
+
+const BASE_DTO: HostConfigDtoV2 = {
+  id: "fakeid",
+  schemaVersion: 2,
+  hostStyle: "claude",
+  modelId: "claude-sonnet-4-5",
+  systemPrompt: "",
+  temperature: 0.7,
+  requireToolApproval: false,
+  serverIds: [],
+  optionalServerIds: [],
+  connectionDefaults: { headers: {}, requestTimeout: 10_000 },
+  clientCapabilities: {},
+  hostContext: {},
+};
+
+describe("resolveClientInfo", () => {
+  test("returns undefined when profile is undefined (SDK-default sentinel)", () => {
+    expect(resolveClientInfo(undefined)).toBeUndefined();
+  });
+
+  test("returns undefined when initialize.clientInfo is unset (even with profile present)", () => {
+    expect(
+      resolveClientInfo({ profileVersion: 1 }),
+    ).toBeUndefined();
+    expect(
+      resolveClientInfo({
+        profileVersion: 1,
+        initialize: { supportedProtocolVersions: ["2025-11-25"] },
+      }),
+    ).toBeUndefined();
+  });
+
+  test("returns the clientInfo object verbatim when set", () => {
+    const ci = resolveClientInfo(SAMPLE_PROFILE);
+    expect(ci).toEqual({
+      name: "chatgpt",
+      version: "1.0.0",
+      title: "ChatGPT",
+    });
+  });
+
+  test("preserves extra (future-spec) fields verbatim", () => {
+    const profile: HostConfigMcpProfileV1 = {
+      profileVersion: 1,
+      initialize: {
+        clientInfo: {
+          name: "x",
+          version: "1",
+          // Hypothetical future field — must round-trip without an SDK bump.
+          futureSpecField: { nested: true },
+        },
+      },
+    };
+    expect(resolveClientInfo(profile)).toEqual({
+      name: "x",
+      version: "1",
+      futureSpecField: { nested: true },
+    });
+  });
+});
+
+describe("resolveSupportedProtocolVersions", () => {
+  test("returns undefined when profile is undefined", () => {
+    expect(resolveSupportedProtocolVersions(undefined)).toBeUndefined();
+  });
+
+  test("returns the array verbatim — first entry is the proposed version", () => {
+    const versions = resolveSupportedProtocolVersions(SAMPLE_PROFILE);
+    expect(versions).toEqual(["2025-11-25", "2025-06-18"]);
+    expect(versions?.[0]).toBe("2025-11-25");
+  });
+
+  test("preserves order — order is semantic for protocol negotiation", () => {
+    const reversed = resolveSupportedProtocolVersions({
+      profileVersion: 1,
+      initialize: { supportedProtocolVersions: ["2025-06-18", "2025-11-25"] },
+    });
+    expect(reversed).toEqual(["2025-06-18", "2025-11-25"]);
+    // Different first entry → different proposed version on the wire.
+    expect(reversed?.[0]).not.toBe("2025-11-25");
+  });
+});
+
+describe("emptyHostConfigInputV2 mcpProfile handling", () => {
+  test("seeds with mcpProfile undefined when partial is empty", () => {
+    // The inspector MUST NOT synthesize `{ profileVersion: 1 }` here —
+    // the backend hashes `undefined` and `{ profileVersion: 1 }`
+    // distinctly. Synthesizing would silently opt every brand-new
+    // chatbox/project into an empty envelope and defeat the
+    // "user opted in" signal that PR #269 preserves on the wire.
+    const input = emptyHostConfigInputV2();
+    expect(input.mcpProfile).toBeUndefined();
+  });
+
+  test("clones the mcpProfile when supplied (no aliasing)", () => {
+    // Deep-clone SAMPLE_PROFILE so the mutation below doesn't leak into
+    // the module-level fixture and break later tests in this file.
+    // (Hit this exact bug during initial test writing — shared mutable
+    // fixtures + an aliasing assertion is a foot-gun.)
+    const source = JSON.parse(
+      JSON.stringify(SAMPLE_PROFILE),
+    ) as HostConfigMcpProfileV1;
+    const partial: Partial<HostConfigInputV2> = { mcpProfile: source };
+    const input = emptyHostConfigInputV2(partial);
+    expect(input.mcpProfile).toEqual(SAMPLE_PROFILE);
+    // Mutate the source — input must be unaffected.
+    (source.initialize!.clientInfo as Record<string, unknown>).name =
+      "mutated";
+    expect(input.mcpProfile?.initialize?.clientInfo?.name).toBe("chatgpt");
+  });
+});
+
+describe("hostConfigDtoToInput mcpProfile round-trip", () => {
+  test("DTO without mcpProfile → input without mcpProfile", () => {
+    const input = hostConfigDtoToInput(BASE_DTO);
+    expect(input.mcpProfile).toBeUndefined();
+  });
+
+  test("DTO with mcpProfile → input with cloned mcpProfile", () => {
+    // Same aliasing-test trap — deep-clone the fixture before mutation.
+    const sourceProfile = JSON.parse(
+      JSON.stringify(SAMPLE_PROFILE),
+    ) as HostConfigMcpProfileV1;
+    const dto = { ...BASE_DTO, mcpProfile: sourceProfile };
+    const input = hostConfigDtoToInput(dto);
+    expect(input.mcpProfile).toEqual(SAMPLE_PROFILE);
+    (sourceProfile.initialize!.clientInfo as Record<string, unknown>).version =
+      "mutated";
+    expect(input.mcpProfile?.initialize?.clientInfo?.version).toBe("1.0.0");
+  });
+
+  test("empty envelope `{ profileVersion: 1 }` round-trips as-is (NOT collapsed to undefined)", () => {
+    // The "user opted in but configured nothing" state — distinct hash on
+    // backend, must survive a load → save cycle without normalization.
+    const dto: HostConfigDtoV2 = {
+      ...BASE_DTO,
+      mcpProfile: { profileVersion: 1 },
+    };
+    const input = hostConfigDtoToInput(dto);
+    expect(input.mcpProfile).toEqual({ profileVersion: 1 });
+  });
+});
+
+describe("hostConfigInputsEqual mcpProfile semantics", () => {
+  test("two inputs with mcpProfile undefined compare equal", () => {
+    const a = emptyHostConfigInputV2();
+    const b = emptyHostConfigInputV2();
+    expect(hostConfigInputsEqual(a, b)).toBe(true);
+  });
+
+  test("flipping mcpProfile from undefined → empty envelope reports DIRTY", () => {
+    // The inspector relies on this: when a user clicks "Enable" in the
+    // editor (which stamps `{ profileVersion: 1 }`), the editor's dirty
+    // indicator MUST light up even though no inner field has changed.
+    const a = emptyHostConfigInputV2();
+    const b: HostConfigInputV2 = {
+      ...a,
+      mcpProfile: { profileVersion: 1 },
+    };
+    expect(hostConfigInputsEqual(a, b)).toBe(false);
+  });
+
+  test("two inputs with same mcpProfile (key-order independent) compare equal", () => {
+    const a: HostConfigInputV2 = {
+      ...emptyHostConfigInputV2(),
+      mcpProfile: SAMPLE_PROFILE,
+    };
+    // Build the same profile in a different key order.
+    const b: HostConfigInputV2 = {
+      ...emptyHostConfigInputV2(),
+      mcpProfile: {
+        initialize: {
+          supportedProtocolVersions: ["2025-11-25", "2025-06-18"],
+          clientInfo: { title: "ChatGPT", version: "1.0.0", name: "chatgpt" },
+        },
+        apps: {
+          sandbox: {
+            csp: {
+              deny: { connectDomains: ["evil.com"] },
+              mode: "declared",
+            },
+          },
+        },
+        profileVersion: 1,
+      },
+    };
+    expect(hostConfigInputsEqual(a, b)).toBe(true);
+  });
+
+  test("a single clientInfo field change reports DIRTY", () => {
+    const a: HostConfigInputV2 = {
+      ...emptyHostConfigInputV2(),
+      mcpProfile: SAMPLE_PROFILE,
+    };
+    const b: HostConfigInputV2 = {
+      ...emptyHostConfigInputV2(),
+      mcpProfile: {
+        ...SAMPLE_PROFILE,
+        initialize: {
+          ...SAMPLE_PROFILE.initialize,
+          clientInfo: {
+            ...SAMPLE_PROFILE.initialize!.clientInfo,
+            version: "9.9.9",
+          },
+        },
+      },
+    };
+    expect(hostConfigInputsEqual(a, b)).toBe(false);
+  });
+
+  test("supportedProtocolVersions ORDER change reports DIRTY (order is semantic)", () => {
+    const a: HostConfigInputV2 = {
+      ...emptyHostConfigInputV2(),
+      mcpProfile: {
+        profileVersion: 1,
+        initialize: { supportedProtocolVersions: ["a", "b"] },
+      },
+    };
+    const b: HostConfigInputV2 = {
+      ...emptyHostConfigInputV2(),
+      mcpProfile: {
+        profileVersion: 1,
+        initialize: { supportedProtocolVersions: ["b", "a"] },
+      },
+    };
+    expect(hostConfigInputsEqual(a, b)).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/servers-api.ts
@@ -8,6 +8,28 @@ export type HostedServerValidateContext = {
   accessScope?: "project_member" | "chat_v2";
   chatboxId?: string;
   accessVersion?: number;
+  /**
+   * Per-connection MCP `initialize.params.clientInfo` override resolved
+   * client-side from `hostConfig.mcpProfile.initialize.clientInfo`. The
+   * hosted backend serializes this verbatim into the MCP `initialize`
+   * call so hosted chatbox / inspector sessions honor the same identity
+   * pin as resolver-path local connects. Undefined → SDK defaults.
+   *
+   * Without this field the hosted path silently dropped `mcpProfile.
+   * initialize.*` pins (codex P2): `connectionDefaults` was built but
+   * never reached the validate context, so hosted connects always
+   * initialized with the SDK's hardcoded clientInfo.
+   */
+  clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
+  /**
+   * Per-connection MCP `initialize.params.supportedProtocolVersions`
+   * accept-list, resolved verbatim from
+   * `hostConfig.mcpProfile.initialize.supportedProtocolVersions`. First
+   * entry is what the SDK proposes; the full array is the accept-set
+   * (a server negotiating any listed version is accepted). Order is
+   * semantic.
+   */
+  supportedProtocolVersions?: string[];
 };
 
 export interface HostedServerValidateResponse {
@@ -53,6 +75,19 @@ export async function validateHostedServer(
         ...(hostedContext.chatboxId &&
         Number.isFinite(hostedContext.accessVersion)
           ? { accessVersion: hostedContext.accessVersion }
+          : {}),
+        // mcpProfile.initialize pins. Sent verbatim; the backend reads
+        // them when present and falls back to SDK defaults otherwise.
+        // Always optional so legacy callers keep working.
+        ...(hostedContext.clientInfo
+          ? { clientInfo: hostedContext.clientInfo }
+          : {}),
+        ...(hostedContext.supportedProtocolVersions &&
+        hostedContext.supportedProtocolVersions.length > 0
+          ? {
+              supportedProtocolVersions:
+                hostedContext.supportedProtocolVersions,
+            }
           : {}),
       }
     : buildServerRequest(serverNameOrId);

--- a/mcpjam-inspector/client/src/lib/chatbox-session.ts
+++ b/mcpjam-inspector/client/src/lib/chatbox-session.ts
@@ -2,6 +2,7 @@ import {
   normalizeChatboxHostStyleId,
   type ChatboxHostStyle,
 } from "@/lib/chatbox-host-style";
+import type { HostConfigMcpProfileV1 } from "@/lib/host-config-v2";
 import { DEFAULT_HOST_STYLE } from "@/lib/host-styles";
 
 const MCPJAM_APP_ORIGIN = "https://app.mcpjam.com";
@@ -80,6 +81,15 @@ export interface ChatboxBootstrapPayload {
    * runtime falls back to the active `hostStyle`'s preset.
    */
   hostCapabilitiesOverride?: Record<string, unknown>;
+  /**
+   * Versioned envelope for host-level MCP state — see
+   * `HostConfigMcpProfileV1` in `client/src/lib/host-config-v2.ts`.
+   * When undefined the hosted runtime falls back to SDK-default
+   * `clientInfo` / `supportedProtocolVersions` and the resource-declared
+   * sandbox policy. The backend canonicalizer guarantees a non-undefined
+   * value here is a valid `{ profileVersion: 1, ... }` envelope.
+   */
+  mcpProfile?: HostConfigMcpProfileV1;
 }
 
 export interface ChatboxSession {
@@ -170,6 +180,24 @@ function normalizeHostCapabilitiesOverride(
     return undefined;
   }
   return input as Record<string, unknown>;
+}
+
+function normalizeMcpProfile(
+  input: unknown,
+): HostConfigMcpProfileV1 | undefined {
+  // Same untrusted-shape gate as normalizeHostCapabilitiesOverride: this
+  // is the boundary between the redeem-response JSON and the typed
+  // session. The backend canonicalizer (`canonicalizeMcpProfile` in
+  // `convex/lib/hostConfigV2.ts`) is the source of truth for structural
+  // validity — a value reaching this point is either undefined or a
+  // backend-validated `{ profileVersion: 1, ... }` envelope. We only
+  // reject obvious shape errors (non-object, array, null) so an upstream
+  // serialization bug can't slip a truthy garbage payload into typed
+  // code that assumes the envelope shape.
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return undefined;
+  }
+  return input as HostConfigMcpProfileV1;
 }
 
 function normalizeChatboxShareMode(mode: unknown): ChatboxShareMode {
@@ -279,6 +307,9 @@ export function normalizeChatboxSession(
       hostCapabilitiesOverride: normalizeHostCapabilitiesOverride(
         (payload as { hostCapabilitiesOverride?: unknown })
           .hostCapabilitiesOverride,
+      ),
+      mcpProfile: normalizeMcpProfile(
+        (payload as { mcpProfile?: unknown }).mcpProfile,
       ),
     },
     surface: parsed.surface === "preview" ? "preview" : "share_link",

--- a/mcpjam-inspector/client/src/lib/host-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-v2.ts
@@ -28,6 +28,73 @@ export type HostConfigConnectionDefaults = {
 };
 
 /**
+ * Four parallel allow/deny lists keyed by CSP directive family. Mirrors
+ * `CspDomainSet` in the backend (`convex/lib/hostConfigV2.ts`). Canonicalized
+ * server-side as a set (trimmed, deduped, sorted); the client may emit
+ * arrays in any order — the backend hash dedupes regardless.
+ */
+export type CspDomainSet = {
+  connectDomains?: string[];
+  resourceDomains?: string[];
+  frameDomains?: string[];
+  baseUriDomains?: string[];
+};
+
+/**
+ * Versioned envelope for host-level MCP state. Mirror of
+ * `HostConfigMcpProfileV1` in `convex/lib/hostConfigV2.ts` — kept in sync by
+ * hand so the inspector and backend speak one shape.
+ *
+ * `profileVersion: 1` is a forward-compat trip wire: a future incompatible
+ * shape will introduce `profileVersion: 2`. The backend rejects any other
+ * value at write time.
+ *
+ * Every field is optional; `undefined` at any nest depth means "use SDK
+ * defaults / no host-level override." `undefined` and `{ profileVersion: 1 }`
+ * (empty envelope) hash distinctly on the backend, so the inspector MUST NOT
+ * synthesize an empty envelope when the user hasn't opted in.
+ */
+export type HostConfigMcpProfileV1 = {
+  profileVersion: 1;
+  initialize?: {
+    /**
+     * Ordered accept-list. First entry is sent in
+     * `initialize.params.protocolVersion`; all entries form the accept-set.
+     * Order is semantic — do NOT sort on the client.
+     */
+    supportedProtocolVersions?: string[];
+    /**
+     * The exact `initialize.clientInfo` object the SDK should send. Backend
+     * soft-validates `name` and `version` (non-empty strings, required when
+     * `clientInfo` is set) and passes everything else through verbatim so
+     * future spec additions (e.g. `title`) land here without a schema
+     * migration.
+     */
+    clientInfo?: Record<string, unknown>;
+  };
+  apps?: {
+    sandbox?: {
+      csp?: {
+        /** Picks the starting baseline; restrictTo/deny apply on top regardless of mode. */
+        mode?: "host-default" | "declared" | "relaxed";
+        /** Intersection — never adds undeclared domains (SEP-1865). */
+        restrictTo?: CspDomainSet;
+        /** Always wins over restrictTo and the resource declaration. */
+        deny?: CspDomainSet;
+        extensions?: Record<string, unknown>;
+      };
+      permissions?: {
+        mode?: "resource-declared" | "deny-all" | "custom";
+        allow?: Record<string, boolean>;
+        deny?: string[];
+        extensions?: Record<string, unknown>;
+      };
+    };
+  };
+  extensions?: Record<string, unknown>;
+};
+
+/**
  * Mutable input shape. All fields are required at write time so the editor
  * can't accidentally erase a section.
  */
@@ -50,6 +117,14 @@ export type HostConfigInputV2 = {
    * value along, and "Reset to profile" is a one-line undefined write.
    */
   hostCapabilitiesOverride?: Record<string, unknown>;
+  /**
+   * Versioned envelope for host-level MCP state — see
+   * {@link HostConfigMcpProfileV1}. Optional; absent means "use SDK
+   * defaults / no host-level sandbox override." Must NOT be synthesized as
+   * `{ profileVersion: 1 }` when the user hasn't opted in — backend hashes
+   * the two states distinctly.
+   */
+  mcpProfile?: HostConfigMcpProfileV1;
 };
 
 /**
@@ -71,6 +146,12 @@ export type HostConfigDtoV2 = {
   hostContext: Record<string, unknown>;
   /** Optional user override (see HostConfigInputV2.hostCapabilitiesOverride). */
   hostCapabilitiesOverride?: Record<string, unknown>;
+  /**
+   * Optional versioned envelope (see HostConfigInputV2.mcpProfile). Surfaced
+   * verbatim — `undefined` means "use SDK defaults"; do NOT substitute a
+   * default empty envelope.
+   */
+  mcpProfile?: HostConfigMcpProfileV1;
 };
 
 export const DEFAULT_HOST_STYLE_V2: HostStyleId = "claude";
@@ -122,6 +203,13 @@ export function emptyHostConfigInputV2(
     hostCapabilitiesOverride: partial.hostCapabilitiesOverride
       ? deepCloneJsonRecord(partial.hostCapabilitiesOverride)
       : undefined,
+    // Same `undefined`-preservation rule as hostCapabilitiesOverride.
+    // Backend distinguishes `undefined` (use SDK defaults) from
+    // `{ profileVersion: 1 }` (empty envelope) on the hash, so a brand-new
+    // input MUST stay undefined until the user opts in via the editor.
+    mcpProfile: partial.mcpProfile
+      ? cloneMcpProfile(partial.mcpProfile)
+      : undefined,
   };
 }
 
@@ -151,6 +239,7 @@ export function hostConfigDtoToInput(
     hostCapabilitiesOverride: dto.hostCapabilitiesOverride
       ? deepCloneJsonRecord(dto.hostCapabilitiesOverride)
       : undefined,
+    mcpProfile: dto.mcpProfile ? cloneMcpProfile(dto.mcpProfile) : undefined,
   };
 }
 
@@ -192,6 +281,44 @@ export function resolveEffectiveHostCapabilities(args: {
     return rest as Omit<McpUiHostCapabilities, "sandbox">;
   }
   return getHostCapabilitiesForStyle(args.hostStyle);
+}
+
+/**
+ * Resolve the `clientInfo` the SDK should send in MCP `initialize` for a
+ * given host config. Returns `undefined` when the profile is unset — that
+ * sentinel signals the SDK to fall back to its hardcoded inspector
+ * defaults. Centralized here so the "undefined means SDK default" contract
+ * stays one-grep-able.
+ */
+export function resolveClientInfo(
+  profile: HostConfigMcpProfileV1 | undefined,
+): Record<string, unknown> | undefined {
+  return profile?.initialize?.clientInfo;
+}
+
+/**
+ * Resolve the supported protocol versions array for a given host config.
+ * First entry is what the SDK should propose in
+ * `initialize.params.protocolVersion`; the full set is the accept-list.
+ * `undefined` means "use SDK defaults"; an empty array would propose no
+ * version and is rejected by the backend canonicalizer at write time so
+ * callers never see it here.
+ */
+export function resolveSupportedProtocolVersions(
+  profile: HostConfigMcpProfileV1 | undefined,
+): string[] | undefined {
+  return profile?.initialize?.supportedProtocolVersions;
+}
+
+/**
+ * Deep-clone an mcpProfile so editor mutations can't alias the source.
+ * Goes through deepCloneJsonValue, but preserves the
+ * `HostConfigMcpProfileV1` type at the boundary.
+ */
+function cloneMcpProfile(
+  profile: HostConfigMcpProfileV1,
+): HostConfigMcpProfileV1 {
+  return deepCloneJsonValue(profile) as HostConfigMcpProfileV1;
 }
 
 function deepCloneJsonRecord(
@@ -245,7 +372,24 @@ export function hostConfigInputsEqual(
   if (!jsonRecordEq(a.hostContext, b.hostContext)) return false;
   if (!optionalJsonRecordEq(a.hostCapabilitiesOverride, b.hostCapabilitiesOverride))
     return false;
+  if (!optionalMcpProfileEq(a.mcpProfile, b.mcpProfile)) return false;
   return true;
+}
+
+function optionalMcpProfileEq(
+  a: HostConfigMcpProfileV1 | undefined,
+  b: HostConfigMcpProfileV1 | undefined,
+): boolean {
+  // Same undefined-vs-empty rule as optionalJsonRecordEq: backend hashes
+  // `undefined` and `{ profileVersion: 1 }` distinctly, so flipping
+  // between them must register as dirty even when no inner field changes.
+  if (a === undefined && b === undefined) return true;
+  if (a === undefined || b === undefined) return false;
+  // Compare the whole envelope as a canonicalized JSON tree. mcpProfile is
+  // nested (initialize, apps.sandbox.{csp,permissions}, extensions); the
+  // shared stableStringifyJson sorts keys at every level so semantically
+  // equal envelopes built in different orders compare equal.
+  return stableStringifyJson(a) === stableStringifyJson(b);
 }
 
 function optionalJsonRecordEq(

--- a/mcpjam-inspector/client/src/state/__tests__/mcp-api.hosted.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/mcp-api.hosted.test.ts
@@ -159,4 +159,73 @@ describe("mcp-api hosted-mode reconnect hardening", () => {
     );
     expect(result).toEqual({ success: true, status: "ok" });
   });
+
+  // Codex P2 regression: the hosted branch used to drop
+  // `connectionDefaults` entirely, so `mcpProfile.initialize.clientInfo`
+  // and `supportedProtocolVersions` pins silently never made it into the
+  // upstream MCP `initialize` call. Guard that they now flow into the
+  // hosted validate context verbatim.
+  it("forwards mcpProfile clientInfo / supportedProtocolVersions on hosted connect", async () => {
+    validateHostedServerMock.mockResolvedValueOnce({
+      success: true,
+      status: "ok",
+    });
+
+    const config = {
+      url: "https://mcp.excalidraw.com/mcp",
+      capabilities: { roots: { listChanged: true } },
+    } as unknown as MCPServerConfig;
+
+    await testConnection(config, "server-doc-id", {
+      projectId: "project-1",
+      serverName: "Excalidraw (App)",
+      connectionDefaults: {
+        clientInfo: { name: "chatgpt", version: "1.0.0", title: "ChatGPT" },
+        supportedProtocolVersions: ["2025-11-25", "2025-06-18"],
+      },
+    });
+
+    expect(validateHostedServerMock).toHaveBeenCalledWith(
+      "server-doc-id",
+      undefined,
+      { roots: { listChanged: true } },
+      expect.objectContaining({
+        projectId: "project-1",
+        serverId: "server-doc-id",
+        serverName: "Excalidraw (App)",
+        clientInfo: { name: "chatgpt", version: "1.0.0", title: "ChatGPT" },
+        supportedProtocolVersions: ["2025-11-25", "2025-06-18"],
+      })
+    );
+  });
+
+  // Empty/missing pins must remain absent on the wire — the backend
+  // hashes `undefined` distinctly from `{}` and we don't want to flip
+  // hosted connects into "user opted in" without a real opt-in.
+  it("omits clientInfo / supportedProtocolVersions when connectionDefaults has none", async () => {
+    validateHostedServerMock.mockResolvedValueOnce({
+      success: true,
+      status: "ok",
+    });
+
+    const config = {
+      url: "https://mcp.excalidraw.com/mcp",
+      capabilities: { roots: { listChanged: true } },
+    } as unknown as MCPServerConfig;
+
+    await testConnection(config, "server-doc-id", {
+      projectId: "project-1",
+      serverName: "Excalidraw (App)",
+      connectionDefaults: {
+        headers: { "x-custom": "1" },
+        // No clientInfo, no supportedProtocolVersions.
+      },
+    });
+
+    const callArgs = validateHostedServerMock.mock.calls[0];
+    const ctx = callArgs?.[3] as Record<string, unknown> | undefined;
+    expect(ctx).toBeDefined();
+    expect(ctx).not.toHaveProperty("clientInfo");
+    expect(ctx).not.toHaveProperty("supportedProtocolVersions");
+  });
 });

--- a/mcpjam-inspector/client/src/state/mcp-api.ts
+++ b/mcpjam-inspector/client/src/state/mcp-api.ts
@@ -56,6 +56,7 @@ function buildHostedValidationContext(
   options?: {
     projectId?: string;
     serverName?: string;
+    connectionDefaults?: ConnectionDefaults;
   },
 ): HostedServerValidateContext | undefined {
   if (!options?.projectId) return undefined;
@@ -68,6 +69,25 @@ function buildHostedValidationContext(
     ...(chatboxId ? { accessScope: "chat_v2" } : {}),
     ...(chatboxId ? { chatboxId } : {}),
     ...(chatboxId ? { accessVersion: getHostedChatboxAccessVersion() } : {}),
+    // Surface the resolver-path `mcpProfile.initialize.*` pins to the
+    // hosted validate request. Without this the hosted branch dropped
+    // them silently: `connectionDefaults` was computed by
+    // `buildResolverConnectionDefaults` in `use-server-state.ts` and
+    // passed through `testConnection`/`reconnectServer`, but only the
+    // local-resolver path forwarded it (`buildResolverBody`). Hosted
+    // connects therefore always initialized with SDK defaults even
+    // when the active host profile pinned an explicit clientInfo /
+    // supportedProtocolVersions.
+    ...(options.connectionDefaults?.clientInfo
+      ? { clientInfo: options.connectionDefaults.clientInfo }
+      : {}),
+    ...(options.connectionDefaults?.supportedProtocolVersions &&
+    options.connectionDefaults.supportedProtocolVersions.length > 0
+      ? {
+          supportedProtocolVersions:
+            options.connectionDefaults.supportedProtocolVersions,
+        }
+      : {}),
   };
 }
 

--- a/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/auth-manager.test.ts
@@ -353,4 +353,139 @@ describe("web auth manager batching", () => {
       },
     });
   });
+
+  // Codex P2 regression: client now forwards
+  // `mcpProfile.initialize.clientInfo` and `supportedProtocolVersions`
+  // on every hosted route call. Verify `createAuthorizedManager`
+  // threads `initializePins` into the per-server HttpServerConfig so
+  // the SDK Client honors the pins on `initialize`. Without this,
+  // hosted connects silently fell back to SDK defaults even when the
+  // active profile pinned an explicit identity.
+  it("threads mcpProfile.initialize pins into the SDK Client config", async () => {
+    global.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          results: {
+            "server-1": {
+              ok: true,
+              role: "member",
+              accessLevel: "project_member",
+              permissions: { chatOnly: false },
+              serverConfig: {
+                transportType: "http",
+                url: "https://server-1.example.com/mcp",
+                headers: {},
+                useOAuth: false,
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }) as typeof fetch;
+
+    await createAuthorizedManager(
+      mockContext,
+      "bearer-token",
+      "project-1",
+      ["server-1"],
+      10_000,
+      undefined,
+      undefined,
+      {
+        initializePins: {
+          clientInfo: {
+            name: "chatgpt",
+            version: "1.0.0",
+            // Forward-compat extras (e.g. SEP `title`) must survive.
+            title: "ChatGPT",
+          },
+          supportedProtocolVersions: ["2025-11-25", "2025-06-18"],
+        },
+      }
+    );
+
+    const config = mcpClientManagerMock.mock.calls[0]?.[0]?.["server-1"];
+    expect(config).toMatchObject({
+      url: "https://server-1.example.com/mcp",
+      clientInfo: {
+        name: "chatgpt",
+        version: "1.0.0",
+        title: "ChatGPT",
+      },
+      supportedProtocolVersions: ["2025-11-25", "2025-06-18"],
+    });
+  });
+
+  it("omits mcpProfile.initialize pins when no profile is set", async () => {
+    global.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          results: {
+            "server-1": {
+              ok: true,
+              role: "member",
+              accessLevel: "project_member",
+              permissions: { chatOnly: false },
+              serverConfig: {
+                transportType: "http",
+                url: "https://server-1.example.com/mcp",
+                headers: {},
+                useOAuth: false,
+              },
+            },
+          },
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }) as typeof fetch;
+
+    await createAuthorizedManager(
+      mockContext,
+      "bearer-token",
+      "project-1",
+      ["server-1"],
+      10_000
+      // No options.initializePins → SDK Client uses its hardcoded
+      // `LATEST_PROTOCOL_VERSION` and default clientInfo.
+    );
+
+    const config = mcpClientManagerMock.mock.calls[0]?.[0]?.["server-1"];
+    expect(config).not.toHaveProperty("clientInfo");
+    expect(config).not.toHaveProperty("supportedProtocolVersions");
+  });
+
+  // Verify the public `projectServerSchema` declares the two new
+  // optional fields so Zod doesn't strip them at the route boundary.
+  // The earlier shape declared neither, which is exactly what dropped
+  // the wire payload before it reached toHttpConfig.
+  it("projectServerSchema accepts clientInfo and supportedProtocolVersions", async () => {
+    const { projectServerSchema } = await import("../auth.js");
+    const parsed = projectServerSchema.parse({
+      projectId: "project-1",
+      serverId: "server-1",
+      clientInfo: {
+        name: "chatgpt",
+        version: "1.0.0",
+        // passthrough extras (future spec fields) must survive
+        title: "ChatGPT",
+      },
+      supportedProtocolVersions: ["2025-11-25", "2025-06-18"],
+    });
+    expect(parsed.clientInfo).toEqual({
+      name: "chatgpt",
+      version: "1.0.0",
+      title: "ChatGPT",
+    });
+    expect(parsed.supportedProtocolVersions).toEqual([
+      "2025-11-25",
+      "2025-06-18",
+    ]);
+  });
 });

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -52,6 +52,22 @@ export const projectServerSchema = z.object({
   // accepts it.
   chatboxId: z.string().min(1).optional(),
   accessVersion: z.number().int().nonnegative().optional(),
+  // mcpProfile.initialize pins, resolved client-side from
+  // `hostConfig.mcpProfile.initialize.*` and forwarded on every hosted
+  // route call. Declared here (rather than per-route) so Zod doesn't
+  // strip them — the inspector client now ALWAYS includes them on
+  // /validate, /check-oauth, /doctor, /tools/*, /resources/*, /prompts/*
+  // when the active hostConfig has a profile pinned. `passthrough()` on
+  // clientInfo so forward-compat MCP spec additions (e.g. `title`,
+  // future fields) survive to `toHttpConfig` without a schema bump.
+  clientInfo: z
+    .object({
+      name: z.string().min(1).optional(),
+      version: z.string().min(1).optional(),
+    })
+    .passthrough()
+    .optional(),
+  supportedProtocolVersions: z.array(z.string().min(1)).optional(),
 });
 
 export const toolsListSchema = projectServerSchema.extend({
@@ -429,7 +445,23 @@ export function toHttpConfig(
   timeoutMs: number,
   oauthAccessToken?: string,
   clientCapabilities?: Record<string, unknown>,
-  onUnauthorized?: UnauthorizedRefreshHandler
+  onUnauthorized?: UnauthorizedRefreshHandler,
+  /**
+   * Per-connection MCP `initialize.params.clientInfo` and
+   * `supportedProtocolVersions` pins resolved from
+   * `hostConfig.mcpProfile.initialize.*`. Forwarded verbatim to the SDK
+   * Client config so hosted connects honor the same pin as the
+   * local-resolver path.
+   *
+   * Without this, the client was sending the pins on the wire but the
+   * hosted handler dropped them at the route boundary (codex P2): Zod
+   * stripped fields not declared on the schema, and `toHttpConfig`
+   * had no parameters that could place them on the SDK config.
+   */
+  initializePins?: {
+    clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
+    supportedProtocolVersions?: string[];
+  }
 ): HttpServerConfig {
   if (authResponse.serverConfig.transportType !== "http") {
     throw new WebRouteError(
@@ -464,6 +496,18 @@ export function toHttpConfig(
     },
     timeout: timeoutMs,
     ...(onUnauthorized ? { onUnauthorized } : {}),
+    // mcpProfile.initialize.* pins, forwarded to the SDK's
+    // `BaseServerConfig.clientInfo` / `.supportedProtocolVersions` per
+    // `sdk/src/mcp-client-manager/types.ts`. Undefined → SDK defaults.
+    ...(initializePins?.clientInfo
+      ? { clientInfo: initializePins.clientInfo }
+      : {}),
+    ...(initializePins?.supportedProtocolVersions &&
+    initializePins.supportedProtocolVersions.length > 0
+      ? {
+          supportedProtocolVersions: initializePins.supportedProtocolVersions,
+        }
+      : {}),
   };
 }
 
@@ -488,6 +532,20 @@ export async function createAuthorizedManager(
     accessVersion?: number;
     rpcLogger?: RpcLogger;
     serverNames?: string[];
+    /**
+     * mcpProfile.initialize.* pins, applied uniformly to every
+     * authorized server in this batch. The same pins flow into every
+     * HttpServerConfig because hosted batches resolve under one
+     * profile context — we don't currently support per-server
+     * mcpProfile overrides.
+     */
+    initializePins?: {
+      clientInfo?: { name?: string; version?: string } & Record<
+        string,
+        unknown
+      >;
+      supportedProtocolVersions?: string[];
+    };
   }
 ): Promise<AuthorizedManagerResult> {
   const serverNamesById = buildServerNamesById(serverIds, options?.serverNames);
@@ -581,7 +639,8 @@ export async function createAuthorizedManager(
         timeoutMs,
         oauthToken,
         clientCapabilities,
-        onUnauthorized
+        onUnauthorized,
+        options?.initializePins
       ),
     ] as const;
   });
@@ -743,6 +802,44 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
         ? raw.accessVersion
         : undefined;
 
+    // Extract mcpProfile.initialize.* pins so they flow into every
+    // HttpServerConfig created by createAuthorizedManager. The schema
+    // (projectServerSchema or any extension thereof) declares
+    // `clientInfo` / `supportedProtocolVersions` as optional fields —
+    // when present, the client has resolved them from the active
+    // hostConfig and wants the hosted route to honor them on
+    // `initialize`. Defensive shape gating: only forward an object
+    // `clientInfo` and only a non-empty string array for
+    // `supportedProtocolVersions`. A malformed payload silently falls
+    // back to SDK defaults rather than failing the whole route.
+    const rawClientInfo = raw.clientInfo;
+    const initializeClientInfo =
+      rawClientInfo &&
+      typeof rawClientInfo === "object" &&
+      !Array.isArray(rawClientInfo)
+        ? (rawClientInfo as { name?: string; version?: string } & Record<
+            string,
+            unknown
+          >)
+        : undefined;
+    const rawSupportedVersions = raw.supportedProtocolVersions;
+    const initializeSupportedVersions =
+      Array.isArray(rawSupportedVersions) &&
+      rawSupportedVersions.every((v) => typeof v === "string" && v.length > 0)
+        ? (rawSupportedVersions as string[])
+        : undefined;
+    const initializePins =
+      initializeClientInfo || initializeSupportedVersions
+        ? {
+            ...(initializeClientInfo
+              ? { clientInfo: initializeClientInfo }
+              : {}),
+            ...(initializeSupportedVersions
+              ? { supportedProtocolVersions: initializeSupportedVersions }
+              : {}),
+          }
+        : undefined;
+
     const result = await withManager(
       createAuthorizedManager(
         c,
@@ -761,6 +858,7 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
           accessVersion,
           rpcLogger: rpcCollector?.rpcLogger,
           serverNames,
+          initializePins,
         }
       ),
       (manager) => fn(manager, body as z.infer<S>)

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -259,6 +259,29 @@ export function parseConnectionDefaults(
     out.clientCapabilities = input.clientCapabilities as Record<string, unknown>;
   }
 
+  // Accept clientInfo only as a plain object with at least a `name` or
+  // `version` — gates against null/array/scalar shapes that would slip
+  // past `typeof === "object"`. Same advisory posture as the other fields:
+  // drop rather than reject so a malformed wire payload doesn't kill the
+  // whole connect request.
+  if (
+    input.clientInfo &&
+    typeof input.clientInfo === "object" &&
+    !Array.isArray(input.clientInfo)
+  ) {
+    const ci = input.clientInfo as Record<string, unknown>;
+    if (typeof ci.name === "string" || typeof ci.version === "string") {
+      out.clientInfo = ci as ConnectionDefaults["clientInfo"];
+    }
+  }
+
+  if (
+    typeof input.proposedProtocolVersion === "string" &&
+    input.proposedProtocolVersion.trim() !== ""
+  ) {
+    out.proposedProtocolVersion = input.proposedProtocolVersion;
+  }
+
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
@@ -287,6 +310,24 @@ export function toMCPServerConfig(
       serverId: string;
       serverName: string;
     };
+    /**
+     * Per-connection MCP `initialize.params.clientInfo` override resolved
+     * from `hostConfig.mcpProfile.initialize.clientInfo`. Undefined means
+     * "use SDK defaults" (the inspector's hardcoded clientInfo). Forwarded
+     * verbatim to MCPClientManager so extra fields (`title`, future spec
+     * additions) survive without an SDK bump.
+     */
+    clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
+    /**
+     * Per-connection proposed protocolVersion, resolved from the first
+     * entry of `hostConfig.mcpProfile.initialize.supportedProtocolVersions`.
+     * Undefined means "use SDK defaults" — the upstream Client falls back
+     * to `LATEST_PROTOCOL_VERSION`. When set, the SDK sends this version
+     * in `initialize.params.protocolVersion` AND uses it as the sole
+     * accept-list entry, so a server that can't speak it fails fast
+     * (desired behavior for reproducible eval pins).
+     */
+    proposedProtocolVersion?: string;
   }
 ): MCPServerConfig {
   const { serverConfig } = authResult;
@@ -306,6 +347,12 @@ export function toMCPServerConfig(
       stdio.capabilities = clientCapabilities;
       stdio.clientCapabilities = clientCapabilities;
     }
+    // mcpProfile.initialize fields flow into the SDK's per-server config.
+    // Undefined skips the field entirely so callers that don't opt in stay
+    // byte-identical to historical behavior on the wire.
+    if (options?.clientInfo) stdio.clientInfo = options.clientInfo;
+    if (options?.proposedProtocolVersion)
+      stdio.proposedProtocolVersion = options.proposedProtocolVersion;
     return stdio as MCPServerConfig;
   }
 
@@ -349,6 +396,10 @@ export function toMCPServerConfig(
     http.capabilities = clientCapabilities;
     http.clientCapabilities = clientCapabilities;
   }
+  // mcpProfile.initialize fields — same opt-in shape as the stdio branch.
+  if (options?.clientInfo) http.clientInfo = options.clientInfo;
+  if (options?.proposedProtocolVersion)
+    http.proposedProtocolVersion = options.proposedProtocolVersion;
 
   // Attach the SDK's 401-recovery hook only when this is a hosted-OAuth
   // server (we have a token from `authorize-batch-local`) AND the caller
@@ -423,6 +474,13 @@ export async function resolveLocalServerForConnect(
     clientCapabilities:
       options?.clientCapabilities ?? options?.defaults?.clientCapabilities,
     defaultHeaders: options?.defaults?.headers,
+    // mcpProfile.initialize fields ride through ConnectionDefaults end-to-end:
+    // client computes them from hostConfig.mcpProfile, wire-serializes onto
+    // /api/mcp/connect, parseConnectionDefaults gates the shape, and they
+    // land on the per-server SDK config here. Undefined preserves
+    // historical wire behavior — no opt-in, no change.
+    clientInfo: options?.defaults?.clientInfo,
+    proposedProtocolVersion: options?.defaults?.proposedProtocolVersion,
     refreshContext: {
       bearerToken,
       projectId,

--- a/mcpjam-inspector/server/utils/local-server-resolver.ts
+++ b/mcpjam-inspector/server/utils/local-server-resolver.ts
@@ -259,27 +259,39 @@ export function parseConnectionDefaults(
     out.clientCapabilities = input.clientCapabilities as Record<string, unknown>;
   }
 
-  // Accept clientInfo only as a plain object with at least a `name` or
-  // `version` — gates against null/array/scalar shapes that would slip
-  // past `typeof === "object"`. Same advisory posture as the other fields:
-  // drop rather than reject so a malformed wire payload doesn't kill the
-  // whole connect request.
+  // Accept clientInfo as a plain object (not null/array/scalar). Drop on
+  // shape mismatch rather than reject — a malformed payload shouldn't kill
+  // the whole connect request. Extras-only objects (`{ title: "..." }`
+  // without name/version) survive this gate because the upstream MCP
+  // Client backfills name/version from manager defaults; gating on
+  // name/version presence here used to silently drop forward-compat
+  // payloads where the host only wanted to pin `title` or future spec
+  // fields.
   if (
     input.clientInfo &&
     typeof input.clientInfo === "object" &&
     !Array.isArray(input.clientInfo)
   ) {
     const ci = input.clientInfo as Record<string, unknown>;
-    if (typeof ci.name === "string" || typeof ci.version === "string") {
+    // Require at least one own enumerable key so a literal `{}` doesn't
+    // hash distinctly from "field omitted" in downstream wire logs.
+    if (Object.keys(ci).length > 0) {
       out.clientInfo = ci as ConnectionDefaults["clientInfo"];
     }
   }
 
-  if (
-    typeof input.proposedProtocolVersion === "string" &&
-    input.proposedProtocolVersion.trim() !== ""
-  ) {
-    out.proposedProtocolVersion = input.proposedProtocolVersion;
+  // Accept the full supportedProtocolVersions array. Filter to non-empty
+  // trimmed strings — preserves order (semantic per the SDK contract:
+  // `supportedProtocolVersions[0]` is what the SDK proposes). Drop the
+  // field entirely if no valid entries remain.
+  if (Array.isArray(input.supportedProtocolVersions)) {
+    const versions = input.supportedProtocolVersions
+      .filter((v): v is string => typeof v === "string")
+      .map((v) => v.trim())
+      .filter((v) => v !== "");
+    if (versions.length > 0) {
+      out.supportedProtocolVersions = versions;
+    }
   }
 
   return Object.keys(out).length > 0 ? out : undefined;
@@ -319,15 +331,16 @@ export function toMCPServerConfig(
      */
     clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
     /**
-     * Per-connection proposed protocolVersion, resolved from the first
-     * entry of `hostConfig.mcpProfile.initialize.supportedProtocolVersions`.
+     * Per-connection supported protocol versions accept-list, resolved
+     * verbatim from `hostConfig.mcpProfile.initialize.supportedProtocolVersions`.
      * Undefined means "use SDK defaults" — the upstream Client falls back
-     * to `LATEST_PROTOCOL_VERSION`. When set, the SDK sends this version
-     * in `initialize.params.protocolVersion` AND uses it as the sole
-     * accept-list entry, so a server that can't speak it fails fast
-     * (desired behavior for reproducible eval pins).
+     * to its built-in `SUPPORTED_PROTOCOL_VERSIONS`. When set, the SDK
+     * sends `supportedProtocolVersions[0]` as
+     * `initialize.params.protocolVersion` and uses the full list as the
+     * accept-set; a server negotiating any listed version is accepted, an
+     * unlisted version fails fast.
      */
-    proposedProtocolVersion?: string;
+    supportedProtocolVersions?: string[];
   }
 ): MCPServerConfig {
   const { serverConfig } = authResult;
@@ -351,8 +364,12 @@ export function toMCPServerConfig(
     // Undefined skips the field entirely so callers that don't opt in stay
     // byte-identical to historical behavior on the wire.
     if (options?.clientInfo) stdio.clientInfo = options.clientInfo;
-    if (options?.proposedProtocolVersion)
-      stdio.proposedProtocolVersion = options.proposedProtocolVersion;
+    if (
+      options?.supportedProtocolVersions &&
+      options.supportedProtocolVersions.length > 0
+    ) {
+      stdio.supportedProtocolVersions = options.supportedProtocolVersions;
+    }
     return stdio as MCPServerConfig;
   }
 
@@ -398,8 +415,12 @@ export function toMCPServerConfig(
   }
   // mcpProfile.initialize fields — same opt-in shape as the stdio branch.
   if (options?.clientInfo) http.clientInfo = options.clientInfo;
-  if (options?.proposedProtocolVersion)
-    http.proposedProtocolVersion = options.proposedProtocolVersion;
+  if (
+    options?.supportedProtocolVersions &&
+    options.supportedProtocolVersions.length > 0
+  ) {
+    http.supportedProtocolVersions = options.supportedProtocolVersions;
+  }
 
   // Attach the SDK's 401-recovery hook only when this is a hosted-OAuth
   // server (we have a token from `authorize-batch-local`) AND the caller
@@ -480,7 +501,7 @@ export async function resolveLocalServerForConnect(
     // land on the per-server SDK config here. Undefined preserves
     // historical wire behavior — no opt-in, no change.
     clientInfo: options?.defaults?.clientInfo,
-    proposedProtocolVersion: options?.defaults?.proposedProtocolVersion,
+    supportedProtocolVersions: options?.defaults?.supportedProtocolVersions,
     refreshContext: {
       bearerToken,
       projectId,

--- a/mcpjam-inspector/shared/connection-defaults.ts
+++ b/mcpjam-inspector/shared/connection-defaults.ts
@@ -30,11 +30,17 @@ export type ConnectionDefaults = {
    */
   clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
   /**
-   * Per-connection proposed protocolVersion, resolved from the first entry
-   * of `hostConfig.mcpProfile.initialize.supportedProtocolVersions`. When
-   * set, the SDK sends this in `initialize.params.protocolVersion` AND uses
-   * it as the sole accept-list entry — a server that can't speak it fails
-   * fast (desired behavior for reproducible eval pins).
+   * Per-connection supported protocol versions, resolved verbatim from
+   * `hostConfig.mcpProfile.initialize.supportedProtocolVersions`. When set,
+   * the SDK sends `supportedProtocolVersions[0]` as
+   * `initialize.params.protocolVersion` and uses the full array as the
+   * accept-list — a server that negotiates any listed version is accepted;
+   * a server that negotiates an unlisted version fails fast (desired
+   * behavior for reproducible eval pins). Order is semantic; preserve it.
+   *
+   * An earlier shape passed only `proposedProtocolVersion: string`; that
+   * collapsed the accept-list to one entry and quietly broke pins where
+   * the user listed multiple versions. Forward the full array.
    */
-  proposedProtocolVersion?: string;
+  supportedProtocolVersions?: string[];
 };

--- a/mcpjam-inspector/shared/connection-defaults.ts
+++ b/mcpjam-inspector/shared/connection-defaults.ts
@@ -20,4 +20,21 @@ export type ConnectionDefaults = {
   timeoutMs?: number;
   /** MCP client capabilities forwarded to the SDK transport. */
   clientCapabilities?: Record<string, unknown>;
+  /**
+   * Per-connection MCP `initialize.params.clientInfo` override, resolved
+   * client-side from `hostConfig.mcpProfile.initialize.clientInfo`. Undefined
+   * means "use SDK defaults" — preserves historical wire behavior for users
+   * who haven't opted into the mcpProfile feature. Extra fields (`title`
+   * and future spec additions) survive verbatim through the SDK without an
+   * SDK bump.
+   */
+  clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
+  /**
+   * Per-connection proposed protocolVersion, resolved from the first entry
+   * of `hostConfig.mcpProfile.initialize.supportedProtocolVersions`. When
+   * set, the SDK sends this in `initialize.params.protocolVersion` AND uses
+   * it as the sole accept-list entry — a server that can't speak it fails
+   * fast (desired behavior for reproducible eval pins).
+   */
+  proposedProtocolVersion?: string;
 };

--- a/sdk/src/browser.ts
+++ b/sdk/src/browser.ts
@@ -160,3 +160,24 @@ export type {
   ConformanceSuiteId,
   ConformanceSupport,
 } from "./mcp-conformance/transport-support.js";
+
+// Host-side sandbox policy resolver (SEP-1865 + ChatGPT Apps). Pure
+// resolver — DOM-free, React-free, Convex-free. Browser-safe by
+// construction. Re-exported here so client renderers can import it
+// without pulling in Node-only entrypoints.
+export {
+  resolveSandboxCsp,
+  resolveSandboxPermissions,
+} from "./sandbox-policy.js";
+export type {
+  SandboxCspMode,
+  SandboxPermissionsMode,
+  SandboxCspDomainSet,
+  SandboxCspPolicy,
+  SandboxPermissionsPolicy,
+  ResourceDeclaredCsp,
+  EffectiveSandboxCsp,
+  EffectiveSandboxPermissions,
+  ResolveSandboxCspArgs,
+  ResolveSandboxPermissionsArgs,
+} from "./sandbox-policy.js";

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -373,6 +373,26 @@ export {
 } from "./widget-helpers.js";
 export type { CspMode, WidgetCspMeta, CspConfig } from "./widget-helpers.js";
 
+// Host-side sandbox policy resolver (SEP-1865 + ChatGPT Apps). Pure
+// resolver consumed by both client-side renderers and server-side route
+// handlers that build CSP / permission policy for untrusted UI.
+export {
+  resolveSandboxCsp,
+  resolveSandboxPermissions,
+} from "./sandbox-policy.js";
+export type {
+  SandboxCspMode,
+  SandboxPermissionsMode,
+  SandboxCspDomainSet,
+  SandboxCspPolicy,
+  SandboxPermissionsPolicy,
+  ResourceDeclaredCsp,
+  EffectiveSandboxCsp,
+  EffectiveSandboxPermissions,
+  ResolveSandboxCspArgs,
+  ResolveSandboxPermissionsArgs,
+} from "./sandbox-policy.js";
+
 // OAuth proxy helpers (shared by inspector server routes and the CLI)
 export {
   OAuthProxyError,

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -5,6 +5,7 @@
 import {
   type CallToolResult,
   Client,
+  type ClientOptions,
   type LoggingLevel,
   SSEClientTransport,
   type ServerCapabilities,
@@ -143,6 +144,22 @@ export class MCPClientManager {
   // Default options
   private readonly defaultClientName: string | undefined;
   private readonly defaultClientVersion: string;
+  /**
+   * Extra `clientInfo` fields (e.g. `title`) merged into the per-connection
+   * `clientInfo` object alongside name/version. Per-server `clientInfo`
+   * overrides individual keys. Lets the inspector pass forward-compat MCP
+   * spec additions (the `title` field, future fields) without an SDK bump.
+   */
+  private readonly defaultClientInfoExtras: Record<string, unknown>;
+  /**
+   * Default proposed protocolVersion. When set, an interceptor on each
+   * Client's outgoing `initialize` request rewrites
+   * `params.protocolVersion` to this value. Per-server
+   * `proposedProtocolVersion` takes precedence. Undefined here preserves
+   * historical behavior (upstream Client's hardcoded
+   * `LATEST_PROTOCOL_VERSION`).
+   */
+  private readonly defaultProposedProtocolVersion: string | undefined;
   private readonly defaultCapabilities: ClientCapabilityOptions;
   private readonly defaultTimeout: number;
   private readonly defaultLogJsonRpc: boolean;
@@ -167,6 +184,9 @@ export class MCPClientManager {
     this.defaultClientVersion =
       options.defaultClientVersion ?? DEFAULT_CLIENT_VERSION;
     this.defaultClientName = options.defaultClientName;
+    this.defaultClientInfoExtras = options.defaultClientInfoExtras ?? {};
+    this.defaultProposedProtocolVersion =
+      options.defaultProposedProtocolVersion;
     this.defaultCapabilities = mergeClientCapabilities(
       getDefaultClientCapabilities(),
       options.defaultCapabilities
@@ -1110,12 +1130,46 @@ export class MCPClientManager {
     let transport: Transport | undefined;
     const clientCapabilities = this.buildCapabilities(serverId, config);
     try {
+      // Resolve clientInfo from (in order): per-server `clientInfo` >
+      // per-server `version` (legacy) > manager defaults. Extras (e.g.
+      // `title` and future spec fields) merge through verbatim so the
+      // inspector can advertise them without an SDK bump.
+      const resolvedClientInfo: Record<string, unknown> = {
+        ...this.defaultClientInfoExtras,
+        ...(config.clientInfo ?? {}),
+        name:
+          config.clientInfo?.name ??
+          this.defaultClientName ??
+          serverId,
+        version:
+          config.clientInfo?.version ??
+          config.version ??
+          this.defaultClientVersion,
+      };
+      // Resolve the proposed protocolVersion accept-list. Per-server
+      // `proposedProtocolVersion` wins over `defaultProposedProtocolVersion`;
+      // when neither is set, we omit the option so the upstream Client uses
+      // its built-in `SUPPORTED_PROTOCOL_VERSIONS` default (preserves
+      // historical wire behavior byte-for-byte). The MCP SDK's Client
+      // already accepts `supportedProtocolVersions: string[]` in its
+      // ClientOptions/ProtocolOptions — first entry is sent in
+      // `initialize.params.protocolVersion`; the full set is the accept-
+      // list used to validate the server's response. Mirrors the
+      // parameterized pattern the OAuth state machines have been using
+      // via `buildInitializeRequestBody` in
+      // `sdk/src/oauth/state-machines/shared/initialize.ts`.
+      const proposedProtocolVersion =
+        config.proposedProtocolVersion ??
+        this.defaultProposedProtocolVersion;
+      const clientOptions: ClientOptions = {
+        capabilities: clientCapabilities,
+        ...(proposedProtocolVersion
+          ? { supportedProtocolVersions: [proposedProtocolVersion] }
+          : {}),
+      };
       client = new Client(
-        {
-          name: this.defaultClientName ?? serverId,
-          version: config.version ?? this.defaultClientVersion,
-        },
-        { capabilities: clientCapabilities }
+        resolvedClientInfo as { name: string; version: string },
+        clientOptions
       );
 
       // Apply handlers

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -152,14 +152,13 @@ export class MCPClientManager {
    */
   private readonly defaultClientInfoExtras: Record<string, unknown>;
   /**
-   * Default proposed protocolVersion. When set, an interceptor on each
-   * Client's outgoing `initialize` request rewrites
-   * `params.protocolVersion` to this value. Per-server
-   * `proposedProtocolVersion` takes precedence. Undefined here preserves
-   * historical behavior (upstream Client's hardcoded
-   * `LATEST_PROTOCOL_VERSION`).
+   * Default supported protocol versions accept-list. Forwarded to the
+   * upstream Client as `ClientOptions.supportedProtocolVersions`. Per-
+   * server `supportedProtocolVersions` overrides this. Undefined here
+   * preserves historical behavior (upstream Client's built-in
+   * `SUPPORTED_PROTOCOL_VERSIONS` default).
    */
-  private readonly defaultProposedProtocolVersion: string | undefined;
+  private readonly defaultSupportedProtocolVersions: string[] | undefined;
   private readonly defaultCapabilities: ClientCapabilityOptions;
   private readonly defaultTimeout: number;
   private readonly defaultLogJsonRpc: boolean;
@@ -185,8 +184,8 @@ export class MCPClientManager {
       options.defaultClientVersion ?? DEFAULT_CLIENT_VERSION;
     this.defaultClientName = options.defaultClientName;
     this.defaultClientInfoExtras = options.defaultClientInfoExtras ?? {};
-    this.defaultProposedProtocolVersion =
-      options.defaultProposedProtocolVersion;
+    this.defaultSupportedProtocolVersions =
+      options.defaultSupportedProtocolVersions;
     this.defaultCapabilities = mergeClientCapabilities(
       getDefaultClientCapabilities(),
       options.defaultCapabilities
@@ -1146,25 +1145,26 @@ export class MCPClientManager {
           config.version ??
           this.defaultClientVersion,
       };
-      // Resolve the proposed protocolVersion accept-list. Per-server
-      // `proposedProtocolVersion` wins over `defaultProposedProtocolVersion`;
-      // when neither is set, we omit the option so the upstream Client uses
-      // its built-in `SUPPORTED_PROTOCOL_VERSIONS` default (preserves
-      // historical wire behavior byte-for-byte). The MCP SDK's Client
-      // already accepts `supportedProtocolVersions: string[]` in its
-      // ClientOptions/ProtocolOptions — first entry is sent in
+      // Resolve the supported protocol versions accept-list. Per-server
+      // `supportedProtocolVersions` wins over
+      // `defaultSupportedProtocolVersions`; when neither is set we omit the
+      // option so the upstream Client uses its built-in
+      // `SUPPORTED_PROTOCOL_VERSIONS` default (preserves historical wire
+      // behavior byte-for-byte). The MCP SDK's Client accepts
+      // `supportedProtocolVersions: string[]` in ClientOptions —
+      // `supportedProtocolVersions[0]` is sent in
       // `initialize.params.protocolVersion`; the full set is the accept-
-      // list used to validate the server's response. Mirrors the
-      // parameterized pattern the OAuth state machines have been using
-      // via `buildInitializeRequestBody` in
-      // `sdk/src/oauth/state-machines/shared/initialize.ts`.
-      const proposedProtocolVersion =
-        config.proposedProtocolVersion ??
-        this.defaultProposedProtocolVersion;
+      // list used to validate the server's response. Forwarding the full
+      // array (rather than collapsing to a single entry) lets users pin a
+      // multi-version accept-list — e.g. `["2025-11-25", "2025-06-18"]`
+      // proposes the newer version but still accepts the older one.
+      const supportedProtocolVersions =
+        config.supportedProtocolVersions ??
+        this.defaultSupportedProtocolVersions;
       const clientOptions: ClientOptions = {
         capabilities: clientCapabilities,
-        ...(proposedProtocolVersion
-          ? { supportedProtocolVersions: [proposedProtocolVersion] }
+        ...(supportedProtocolVersions && supportedProtocolVersions.length > 0
+          ? { supportedProtocolVersions }
           : {}),
       };
       client = new Client(

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -63,19 +63,19 @@ export type BaseServerConfig = {
    */
   clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
   /**
-   * Proposed protocolVersion to send in MCP `initialize.params`. When set,
-   * this overrides the upstream Client's hardcoded `LATEST_PROTOCOL_VERSION`
-   * via an outgoing-request interceptor (rewrite of `initialize` params
-   * only; subsequent requests are unaffected).
+   * Supported protocol versions accept-list passed into the upstream Client
+   * as `ClientOptions.supportedProtocolVersions`. The Client sends
+   * `supportedProtocolVersions[0]` as `initialize.params.protocolVersion`
+   * and accepts any of the listed versions in the server's response.
    *
-   * Wired into the inspector via the first entry of
-   * `hostConfig.mcpProfile.initialize.supportedProtocolVersions`. The
-   * upstream Client still validates the server's response against its
-   * `SUPPORTED_PROTOCOL_VERSIONS` allowlist — pinning a version the SDK
-   * doesn't recognize will fail at connect time, which is the desired
-   * behavior for reproducible eval pins.
+   * Wired into the inspector verbatim from
+   * `hostConfig.mcpProfile.initialize.supportedProtocolVersions`. Order is
+   * semantic — preserve it. A pin like `["2025-11-25", "2025-06-18"]`
+   * proposes the newer version but still accepts the older one if the
+   * server negotiates it; the prior shape (`proposedProtocolVersion:
+   * string`) collapsed this to a singleton and silently broke that case.
    */
-  proposedProtocolVersion?: string;
+  supportedProtocolVersions?: string[];
   /** Error handler for this server */
   onError?: (error: unknown) => void;
   /** Enable simple console logging of JSON-RPC traffic */
@@ -288,12 +288,12 @@ export interface MCPClientManagerOptions {
    */
   defaultClientInfoExtras?: Record<string, unknown>;
   /**
-   * Default proposed protocolVersion sent in MCP `initialize.params`. Per-
-   * server `proposedProtocolVersion` overrides this. When neither is set,
-   * the upstream Client's hardcoded `LATEST_PROTOCOL_VERSION` is used and
-   * historical behavior is preserved verbatim.
+   * Default supported protocol versions accept-list. Per-server
+   * `supportedProtocolVersions` overrides this. When neither is set, the
+   * upstream Client's built-in `SUPPORTED_PROTOCOL_VERSIONS` default is
+   * used and historical behavior is preserved verbatim.
    */
-  defaultProposedProtocolVersion?: string;
+  defaultSupportedProtocolVersions?: string[];
   /** Default capabilities to advertise */
   defaultCapabilities?: ClientCapabilityOptions;
   /** Default request timeout in milliseconds */

--- a/sdk/src/mcp-client-manager/types.ts
+++ b/sdk/src/mcp-client-manager/types.ts
@@ -50,6 +50,32 @@ export type BaseServerConfig = {
   timeout?: number;
   /** Client version to report */
   version?: string;
+  /**
+   * Per-server override of `clientInfo` sent in MCP `initialize`. When set,
+   * takes precedence over the manager's `defaultClientName` /
+   * `defaultClientVersion` and the per-server `version`. Extra fields
+   * (e.g. `title`) are passed through verbatim so future spec additions
+   * land here without an SDK bump.
+   *
+   * Wired into the inspector via `hostConfig.mcpProfile.initialize.clientInfo`.
+   * Leaving this undefined means "use the manager defaults" (which is what
+   * historical callers expect).
+   */
+  clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
+  /**
+   * Proposed protocolVersion to send in MCP `initialize.params`. When set,
+   * this overrides the upstream Client's hardcoded `LATEST_PROTOCOL_VERSION`
+   * via an outgoing-request interceptor (rewrite of `initialize` params
+   * only; subsequent requests are unaffected).
+   *
+   * Wired into the inspector via the first entry of
+   * `hostConfig.mcpProfile.initialize.supportedProtocolVersions`. The
+   * upstream Client still validates the server's response against its
+   * `SUPPORTED_PROTOCOL_VERSIONS` allowlist — pinning a version the SDK
+   * doesn't recognize will fail at connect time, which is the desired
+   * behavior for reproducible eval pins.
+   */
+  proposedProtocolVersion?: string;
   /** Error handler for this server */
   onError?: (error: unknown) => void;
   /** Enable simple console logging of JSON-RPC traffic */
@@ -254,6 +280,20 @@ export interface MCPClientManagerOptions {
   defaultClientName?: string;
   /** Default client version to report */
   defaultClientVersion?: string;
+  /**
+   * Default `clientInfo` extra fields (e.g. `title`) to advertise to servers.
+   * Per-server `clientInfo.name` / `clientInfo.version` override this. Extra
+   * keys here are merged into the per-server clientInfo at connect time so
+   * future MCP spec additions don't require an SDK bump.
+   */
+  defaultClientInfoExtras?: Record<string, unknown>;
+  /**
+   * Default proposed protocolVersion sent in MCP `initialize.params`. Per-
+   * server `proposedProtocolVersion` overrides this. When neither is set,
+   * the upstream Client's hardcoded `LATEST_PROTOCOL_VERSION` is used and
+   * historical behavior is preserved verbatim.
+   */
+  defaultProposedProtocolVersion?: string;
   /** Default capabilities to advertise */
   defaultCapabilities?: ClientCapabilityOptions;
   /** Default request timeout in milliseconds */

--- a/sdk/src/sandbox-policy.ts
+++ b/sdk/src/sandbox-policy.ts
@@ -289,6 +289,16 @@ export function resolveSandboxCsp(
 
   // Step 2 — intersect with restrictTo (when set). Never unions; never
   // adds undeclared domains. Applies in every mode.
+  //
+  // Case-insensitive match: CSP source expressions are case-insensitive
+  // on scheme and host per RFC 3986 / CSP3, and `matchesAnyDeny` (used
+  // for step 3) already lower-cases both sides. Without parity here a
+  // `restrictTo: ["Api.Example.COM"]` would silently drop a resource-
+  // declared `api.example.com` while the same string in `deny` would
+  // strip it — two inconsistent matching strategies in the same
+  // resolver. The lowercase Set is the lookup index; we still emit the
+  // baseline-cased original string so the resulting CSP header matches
+  // what the widget declared.
   const afterRestrictTo: ResourceDeclaredCsp = {};
   for (const key of CSP_DIRECTIVE_KEYS) {
     const baselineList = baselineLists[key] ?? [];
@@ -297,10 +307,10 @@ export function resolveSandboxCsp(
       // No restriction declared for this directive — pass baseline through.
       afterRestrictTo[key] = [...baselineList];
     } else {
-      // Intersect: keep only baseline entries that the restrictTo list
-      // also contains. Order from the baseline is preserved.
-      const restrictSet = new Set(restrictList);
-      afterRestrictTo[key] = baselineList.filter((d) => restrictSet.has(d));
+      const restrictSet = new Set(restrictList.map((d) => d.toLowerCase()));
+      afterRestrictTo[key] = baselineList.filter((d) =>
+        restrictSet.has(d.toLowerCase()),
+      );
     }
   }
 

--- a/sdk/src/sandbox-policy.ts
+++ b/sdk/src/sandbox-policy.ts
@@ -28,8 +28,12 @@
  *      `restrictTo`, the baseline, and the resource declaration.
  *      Applies in EVERY mode.
  *   4. HOSTED-MODE HARD CLAMP — strips dangerous values regardless of
- *      profile (wildcards, localhost/private networks, unsafe schemes,
- *      MCPJam same-origin API access). NOT configurable from `mcpProfile`.
+ *      profile (wildcards, localhost/private networks, unsafe schemes).
+ *      Built-in patterns are NOT configurable from `mcpProfile`. Callers
+ *      may pass an additional `hostedClampExtraDeny` set for app-specific
+ *      origins they want stripped (e.g. the inspector's own API origin —
+ *      this is the only place that protects against a hosted widget
+ *      declaring same-origin exfiltration targets in `connectDomains`).
  *
  * Result is a typed `EffectiveSandboxCsp` carrying the four directive
  * lists ready for header-string construction by a downstream helper
@@ -168,6 +172,19 @@ export interface ResolveSandboxCspArgs {
    * the resolver doesn't sniff env or origin.
    */
   hostedMode: boolean;
+  /**
+   * App-specific origins the hosted clamp MUST strip in addition to the
+   * built-in `isHostedDangerousDomain` patterns. Only applied when
+   * `hostedMode === true`. Supports the same wildcard-prefix matching as
+   * `policy.deny` (`https://*.example.com` matches subdomains).
+   *
+   * Mirrors `ResolveSandboxPermissionsArgs.hostedClampDeny`. This is the
+   * only place that protects against a hosted widget declaring app-
+   * sensitive origins (e.g. the inspector's own API origin) in
+   * `connectDomains` to exfiltrate data — `policy.deny` is profile-
+   * configurable and therefore bypassable; this is not.
+   */
+  hostedClampExtraDeny?: SandboxCspDomainSet;
 }
 
 export interface ResolveSandboxPermissionsArgs {
@@ -295,12 +312,22 @@ export function resolveSandboxCsp(
   let final: ResourceDeclaredCsp;
   if (args.hostedMode) {
     final = {};
+    const extraDenyByDirective = args.hostedClampExtraDeny;
     for (const key of CSP_DIRECTIVE_KEYS) {
       const before = afterDeny[key] ?? [];
+      const extraDenyList = extraDenyByDirective?.[key];
       const stripped: string[] = [];
       const kept: string[] = [];
       for (const d of before) {
-        if (isHostedDangerousDomain(d)) {
+        // Two reasons to strip: the built-in dangerous-pattern predicate,
+        // or a caller-supplied app-specific origin (e.g. MCPJam's own
+        // API host). Either alone is sufficient — both run in this single
+        // pass so the trace's `stripped` list captures everything.
+        const isExtra =
+          extraDenyList !== undefined &&
+          extraDenyList.length > 0 &&
+          matchesAnyDeny(d, extraDenyList);
+        if (isHostedDangerousDomain(d) || isExtra) {
           stripped.push(d);
         } else {
           kept.push(d);

--- a/sdk/src/sandbox-policy.ts
+++ b/sdk/src/sandbox-policy.ts
@@ -83,6 +83,14 @@ export interface SandboxCspPolicy {
 /**
  * The `apps.sandbox.permissions` slice. Mirrors
  * `mcpProfile.apps.sandbox.permissions`.
+ *
+ * **Key shape:** `allow` keys and `deny` entries MUST use the same
+ * names as the MCP `_meta.ui.permissions` declaration (SEP-1865
+ * §UIResourceMeta — camelCase: `camera`, `microphone`, `geolocation`,
+ * `clipboardWrite`). The resolver does plain string-key matching
+ * against `resourcePermissions`, so any kebab-case entries (`clipboard-
+ * write`) will silently no-op — the spec's kebab form belongs at the
+ * iframe `allow=` attribute layer, not here.
  */
 export interface SandboxPermissionsPolicy {
   mode?: SandboxPermissionsMode;
@@ -190,9 +198,12 @@ export interface ResolveSandboxCspArgs {
 export interface ResolveSandboxPermissionsArgs {
   /**
    * Permissions the resource requested in its `_meta.ui.permissions`.
-   * Boolean map keyed by permission name (`camera`, `microphone`,
-   * `geolocation`, `clipboard-write`, ...). The resource declaration is
-   * the CEILING — host can't grant a permission the resource didn't
+   * Boolean map keyed by permission name as declared in SEP-1865
+   * (camelCase: `camera`, `microphone`, `geolocation`, `clipboardWrite`).
+   * The kebab-case forms (`clipboard-write`) are the browser
+   * Permission-Policy spelling and belong at the iframe `allow=`
+   * attribute layer — not here. The resource declaration is the
+   * CEILING: the host can't grant a permission the resource didn't
    * request.
    */
   resourcePermissions?: Record<string, boolean>;
@@ -459,14 +470,23 @@ function normalizeDomainSet(value: ResourceDeclaredCsp): {
  * `https://api.example.com` and `https://other.example.com`, but NOT
  * `https://example.com` itself (the wildcard requires a subdomain).
  * Exact match also wins.
+ *
+ * Matching is case-insensitive on the whole source expression: CSP
+ * source expressions normalize scheme + host per the URL spec, DNS
+ * hostnames are case-insensitive, and the deny rules in this codebase
+ * don't carry case-significant paths. Comparing raw strings let
+ * `deny: ["Evil.com"]` slip past a widget declaring `"evil.com"` — that
+ * inversion is exactly what deny rules exist to prevent.
  */
 function matchesAnyDeny(domain: string, denyList: string[]): boolean {
+  const domainLower = domain.toLowerCase();
   for (const pattern of denyList) {
-    if (pattern === domain) return true;
-    if (pattern.includes("*")) {
-      const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+    const patternLower = pattern.toLowerCase();
+    if (patternLower === domainLower) return true;
+    if (patternLower.includes("*")) {
+      const escaped = patternLower.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
       const regexPattern = "^" + escaped.replace(/\*/g, "[^/]+") + "$";
-      if (new RegExp(regexPattern).test(domain)) return true;
+      if (new RegExp(regexPattern).test(domainLower)) return true;
     }
   }
   return false;
@@ -555,7 +575,14 @@ function isHostedDangerousDomain(domain: string): boolean {
     return false;
   }
 
-  return isDangerousHostname(trimmed.toLowerCase());
+  // Bare host source expressions may include a port (`localhost:3000`,
+  // `[::1]:9000`) or a path. The hostname-pattern checks below don't
+  // accept either suffix — `host === "localhost"` would miss
+  // `"localhost:3000"`, letting a hosted widget declare a loopback
+  // origin and bypass the clamp. Synthesize a scheme so the URL parser
+  // strips port/path uniformly (same trick used for protocol-relative
+  // forms above).
+  return isDangerousHostname(extractHostname("https://" + trimmed));
 }
 
 /**
@@ -604,22 +631,60 @@ function isDangerousHostname(hostname: string): boolean {
     return true;
   }
 
-  // IPv6 loopback / link-local / IPv4-mapped loopback. The URL parser
-  // canonicalizes these to lower case + collapses zeros, so direct prefix
-  // checks suffice.
+  // IPv6 loopback / link-local. The URL parser canonicalizes these to
+  // lower case + collapses zeros, so direct prefix checks suffice.
   if (host === "::1") return true;
   if (host.startsWith("fe80:")) return true;
-  // IPv4-mapped IPv6 loopback. The URL parser canonicalizes
-  // `::ffff:127.0.0.1` to its hex form `::ffff:7f00:1` (and similar for
-  // other addresses in 127.0.0.0/8), so check both the canonical hex
-  // shape (`::ffff:7fXX:XXXX`) AND the dotted form (preserved when the
-  // string never round-tripped through `new URL`, e.g. bare host
-  // expressions). `7f00` is `127.0` in hex; the full prefix `::ffff:7f`
-  // covers every IPv4-mapped address in 127.0.0.0/8.
-  if (/^::ffff:7f[0-9a-f]{2}:[0-9a-f]{1,4}$/.test(host)) return true;
-  if (/^::ffff:127(?:\.\d{1,3}){3}$/.test(host)) return true;
+
+  // IPv4-mapped IPv6 addresses (`::ffff:a.b.c.d`). The URL parser
+  // canonicalizes the dotted form to hex pairs (`::ffff:7f00:1` for
+  // `::ffff:127.0.0.1`, `::ffff:c0a8:101` for `::ffff:192.168.1.1`), so
+  // we MUST unpack the hex form and re-run the full IPv4 ruleset, not
+  // just the 127/8 prefix — otherwise a hosted widget could declare a
+  // RFC1918 origin via the mapped form and bypass the clamp entirely
+  // (the codex P1 finding). The dotted form is also accepted for
+  // strings that never round-tripped through `new URL`.
+  const mappedDotted = unpackIPv4MappedIPv6(host);
+  if (mappedDotted) {
+    // Recurse with the unpacked IPv4 — this hits every loopback /
+    // RFC1918 / link-local / shared rule above.
+    if (isDangerousHostname(mappedDotted)) return true;
+  }
   // IPv6 unique local addresses (fc00::/7).
   if (/^f[cd][0-9a-f]{2}:/.test(host)) return true;
 
   return false;
+}
+
+/**
+ * Unpack an IPv4-mapped IPv6 address into its dotted IPv4 form, or
+ * return `null` if the input isn't a mapped address. Accepts both:
+ *
+ *   - The canonical hex form the URL parser produces:
+ *     `::ffff:7f00:1` → `127.0.0.1`, `::ffff:c0a8:101` → `192.168.1.1`.
+ *   - The dotted form callers may pass directly (rare, but possible if
+ *     a string never went through `new URL`):
+ *     `::ffff:127.0.0.1` → `127.0.0.1`.
+ *
+ * The leading `::ffff:` prefix MUST be present; we don't accept
+ * compatibility-style mapped addresses (`::a.b.c.d`) — those are a
+ * deprecated form per RFC 4291 and the URL parser doesn't produce them.
+ */
+function unpackIPv4MappedIPv6(host: string): string | null {
+  // Dotted form: `::ffff:a.b.c.d`.
+  const dotted = /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/.exec(host);
+  if (dotted) return dotted[1];
+
+  // Hex form: `::ffff:HHHH:HHHH` where each HHHH is one 16-bit group.
+  const hex = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(host);
+  if (!hex) return null;
+  const hi = parseInt(hex[1], 16);
+  const lo = parseInt(hex[2], 16);
+  if (!Number.isFinite(hi) || !Number.isFinite(lo)) return null;
+  return [
+    (hi >> 8) & 0xff,
+    hi & 0xff,
+    (lo >> 8) & 0xff,
+    lo & 0xff,
+  ].join(".");
 }

--- a/sdk/src/sandbox-policy.ts
+++ b/sdk/src/sandbox-policy.ts
@@ -1,0 +1,483 @@
+/**
+ * Pure resolver for the host-side sandbox policy applied to UI resources
+ * (MCP Apps per SEP-1865, plus any ChatGPT-Apps surface that mounts
+ * untrusted UI in a sandbox iframe).
+ *
+ * Lives in `@mcpjam/sdk` rather than the inspector client so the same
+ * resolver is consumed by both:
+ *   - `mcp-apps-renderer.tsx` (client-side MCP Apps rendering)
+ *   - any ChatGPT-Apps renderer / server-side route that builds CSP
+ *     headers for untrusted UI
+ *
+ * No DOM, no React, no Convex — pure JSON in / JSON out. Trivially unit-
+ * testable. If the resolution lives in two places it can be bypassed by
+ * mounting through the path that didn't get updated, which is exactly
+ * the failure mode this single source of truth prevents.
+ *
+ * Precedence (mirror SEP-1865 + agreed plan):
+ *
+ *   1. `mode` picks the starting BASELINE:
+ *      - `"declared"`:    baseline = resource's `_meta.ui.csp` declaration
+ *      - `"host-default"`: baseline = inspector's default CSP shape
+ *      - `"relaxed"`:     baseline = permissive (local/dev). Hosted clamp
+ *                         (step 4) still strips dangerous values.
+ *   2. `restrictTo` INTERSECTS with the baseline. Never unions —
+ *      hosts MAY further restrict but MUST NOT allow undeclared domains.
+ *      Applies in EVERY mode, including `"declared"`.
+ *   3. `deny` SUBTRACTS from the current effective set. Wins over
+ *      `restrictTo`, the baseline, and the resource declaration.
+ *      Applies in EVERY mode.
+ *   4. HOSTED-MODE HARD CLAMP — strips dangerous values regardless of
+ *      profile (wildcards, localhost/private networks, unsafe schemes,
+ *      MCPJam same-origin API access). NOT configurable from `mcpProfile`.
+ *
+ * Result is a typed `EffectiveSandboxCsp` carrying the four directive
+ * lists ready for header-string construction by a downstream helper
+ * (e.g. `buildCspHeader` in `widget-helpers.ts`).
+ */
+
+/**
+ * Host-config sandbox CSP mode. Mirrors
+ * `mcpProfile.apps.sandbox.csp.mode` from the backend's
+ * `HostConfigMcpProfileV1`.
+ */
+export type SandboxCspMode = "host-default" | "declared" | "relaxed";
+
+/**
+ * Host-config permissions mode. Mirrors
+ * `mcpProfile.apps.sandbox.permissions.mode`.
+ */
+export type SandboxPermissionsMode =
+  | "resource-declared"
+  | "deny-all"
+  | "custom";
+
+/**
+ * Four parallel allow/deny lists keyed by CSP directive family.
+ * Mirrors `CspDomainSet` in the backend's
+ * `convex/lib/hostConfigV2.ts:46`.
+ */
+export interface SandboxCspDomainSet {
+  connectDomains?: string[];
+  resourceDomains?: string[];
+  frameDomains?: string[];
+  baseUriDomains?: string[];
+}
+
+/**
+ * The `apps.sandbox.csp` slice of the host-config mcpProfile envelope.
+ * Optional everywhere: undefined fields mean "no host-level override at
+ * this layer." Mirrors
+ * `mcpProfile.apps.sandbox.csp` in the backend schema.
+ */
+export interface SandboxCspPolicy {
+  mode?: SandboxCspMode;
+  restrictTo?: SandboxCspDomainSet;
+  deny?: SandboxCspDomainSet;
+}
+
+/**
+ * The `apps.sandbox.permissions` slice. Mirrors
+ * `mcpProfile.apps.sandbox.permissions`.
+ */
+export interface SandboxPermissionsPolicy {
+  mode?: SandboxPermissionsMode;
+  allow?: Record<string, boolean>;
+  deny?: string[];
+}
+
+/**
+ * What the resource declared in its `_meta.ui.csp`. Same four directive
+ * families. Undefined = the resource declared nothing (the SEP-1865
+ * "secure default" applies, which the baseline picker fabricates from
+ * mode).
+ */
+export interface ResourceDeclaredCsp {
+  connectDomains?: string[];
+  resourceDomains?: string[];
+  frameDomains?: string[];
+  baseUriDomains?: string[];
+}
+
+/**
+ * Result of the resolver. Caller turns this into a real CSP header
+ * string with whatever builder it uses (e.g. `buildCspHeader` for
+ * inspector renderers).
+ */
+export interface EffectiveSandboxCsp {
+  /** Final effective CSP-directive lists after all 4 precedence steps. */
+  connectDomains: string[];
+  resourceDomains: string[];
+  frameDomains: string[];
+  baseUriDomains: string[];
+  /** Trace of how the resolver arrived at the result — for debug UI. */
+  trace: {
+    /** Step 1 — baseline picked by `mode`. */
+    baseline: ResourceDeclaredCsp;
+    /** Step 2 — after `restrictTo ∩ baseline`. */
+    afterRestrictTo: ResourceDeclaredCsp;
+    /** Step 3 — after subtracting `deny`. */
+    afterDeny: ResourceDeclaredCsp;
+    /** Step 4 — values the hosted-mode clamp stripped. Empty when not hosted. */
+    hostedClamp: { stripped: SandboxCspDomainSet };
+    /** Which mode was applied (after default substitution). */
+    effectiveMode: SandboxCspMode;
+  };
+}
+
+/**
+ * Sandbox permissions set after resolution. Boolean map keyed by
+ * permission name — `true` means granted to the iframe (`allow=`
+ * attribute), `false` (or absent) means not granted.
+ */
+export interface EffectiveSandboxPermissions {
+  granted: Record<string, boolean>;
+  trace: {
+    declared: Record<string, boolean>;
+    afterMode: Record<string, boolean>;
+    deniedByProfile: string[];
+    deniedByHostedClamp: string[];
+    effectiveMode: SandboxPermissionsMode;
+  };
+}
+
+export interface ResolveSandboxCspArgs {
+  /** What the UI resource declared in `_meta.ui.csp`. */
+  resourceCsp?: ResourceDeclaredCsp;
+  /** Host-config policy from `mcpProfile.apps.sandbox.csp`. */
+  policy?: SandboxCspPolicy;
+  /**
+   * Inspector's renderer default baseline for `mode: "host-default"`. The
+   * resolver doesn't fabricate this — the caller supplies it because
+   * "what counts as the inspector's default" is a UI concern. Today the
+   * inspector uses `buildCspHeader` in `widget-helpers.ts` to compute
+   * permissive vs widget-declared baselines; callers can synthesize
+   * the resource-list shape from there or pass any shape they want.
+   */
+  hostDefaultBaseline?: ResourceDeclaredCsp;
+  /**
+   * SEP-1865 "secure default" applied when the resource omits its CSP
+   * declaration AND mode is `"declared"`. Defaults to the empty
+   * record (no domains allowed) per the spec. Callers may override if
+   * they need to allow specific protocol-mandated sources.
+   */
+  secureDefault?: ResourceDeclaredCsp;
+  /**
+   * Whether the inspector is running in hosted mode. Drives the hosted
+   * clamp (step 4). Callers detect this however they currently do —
+   * the resolver doesn't sniff env or origin.
+   */
+  hostedMode: boolean;
+}
+
+export interface ResolveSandboxPermissionsArgs {
+  /**
+   * Permissions the resource requested in its `_meta.ui.permissions`.
+   * Boolean map keyed by permission name (`camera`, `microphone`,
+   * `geolocation`, `clipboard-write`, ...). The resource declaration is
+   * the CEILING — host can't grant a permission the resource didn't
+   * request.
+   */
+  resourcePermissions?: Record<string, boolean>;
+  policy?: SandboxPermissionsPolicy;
+  /**
+   * Whether the inspector is running in hosted mode. Drives the hosted
+   * clamp for sensitive permissions.
+   */
+  hostedMode: boolean;
+  /**
+   * Permission names the hosted-mode clamp must strip regardless of
+   * profile. Defaults to the SEP-1865-sensitive set
+   * (`camera`, `microphone`, `geolocation`). Callers may pass a
+   * different list if their hosted-mode policy diverges.
+   */
+  hostedClampDeny?: string[];
+}
+
+const DEFAULT_HOSTED_PERMISSION_CLAMP_DENY: ReadonlyArray<string> = [
+  "camera",
+  "microphone",
+  "geolocation",
+];
+
+const EMPTY_DOMAIN_SET: ResourceDeclaredCsp = {
+  connectDomains: [],
+  resourceDomains: [],
+  frameDomains: [],
+  baseUriDomains: [],
+};
+
+const CSP_DIRECTIVE_KEYS: ReadonlyArray<keyof ResourceDeclaredCsp> = [
+  "connectDomains",
+  "resourceDomains",
+  "frameDomains",
+  "baseUriDomains",
+];
+
+/**
+ * Resolve the effective sandbox CSP for a UI resource given the host's
+ * profile and hosted-mode flag. See module docstring for precedence.
+ *
+ * @example
+ * const csp = resolveSandboxCsp({
+ *   resourceCsp: { connectDomains: ["api.example.com", "evil.com"] },
+ *   policy: { mode: "declared", deny: { connectDomains: ["evil.com"] } },
+ *   hostedMode: false,
+ * });
+ * // csp.connectDomains === ["api.example.com"]
+ */
+export function resolveSandboxCsp(
+  args: ResolveSandboxCspArgs,
+): EffectiveSandboxCsp {
+  const effectiveMode: SandboxCspMode = args.policy?.mode ?? "declared";
+  const secureDefault = args.secureDefault ?? EMPTY_DOMAIN_SET;
+
+  // Step 1 — baseline from mode.
+  let baseline: ResourceDeclaredCsp;
+  switch (effectiveMode) {
+    case "declared":
+      // Resource declaration is the baseline. Missing → secure default.
+      baseline = args.resourceCsp ?? secureDefault;
+      break;
+    case "host-default":
+      // Inspector's renderer default. Caller supplies the shape; we
+      // intentionally don't fabricate one so this stays decoupled from
+      // the legacy `buildCspHeader` modes.
+      baseline = args.hostDefaultBaseline ?? secureDefault;
+      break;
+    case "relaxed":
+      // Permissive in local/dev. Hosted clamp (step 4) still applies.
+      // We can't open `*` here because then `restrictTo` becomes
+      // unmodeled — instead, a relaxed baseline pulls from
+      // hostDefaultBaseline if provided; the caller's `buildCspHeader`
+      // "permissive" mode will compute the actual broad CSP at header
+      // assembly time. The resolver focuses on the per-domain set
+      // semantics.
+      baseline = args.hostDefaultBaseline ?? secureDefault;
+      break;
+  }
+
+  const baselineLists = normalizeDomainSet(baseline);
+
+  // Step 2 — intersect with restrictTo (when set). Never unions; never
+  // adds undeclared domains. Applies in every mode.
+  const afterRestrictTo: ResourceDeclaredCsp = {};
+  for (const key of CSP_DIRECTIVE_KEYS) {
+    const baselineList = baselineLists[key] ?? [];
+    const restrictList = args.policy?.restrictTo?.[key];
+    if (restrictList === undefined) {
+      // No restriction declared for this directive — pass baseline through.
+      afterRestrictTo[key] = [...baselineList];
+    } else {
+      // Intersect: keep only baseline entries that the restrictTo list
+      // also contains. Order from the baseline is preserved.
+      const restrictSet = new Set(restrictList);
+      afterRestrictTo[key] = baselineList.filter((d) => restrictSet.has(d));
+    }
+  }
+
+  // Step 3 — subtract deny. deny wins over restrictTo and baseline.
+  // Wildcard prefix matching: `https://*.evil.com` matches
+  // `https://api.evil.com`.
+  const afterDeny: ResourceDeclaredCsp = {};
+  for (const key of CSP_DIRECTIVE_KEYS) {
+    const list = afterRestrictTo[key] ?? [];
+    const denyList = args.policy?.deny?.[key];
+    if (!denyList || denyList.length === 0) {
+      afterDeny[key] = list;
+      continue;
+    }
+    afterDeny[key] = list.filter((d) => !matchesAnyDeny(d, denyList));
+  }
+
+  // Step 4 — hosted-mode clamp.
+  const hostedStripped: SandboxCspDomainSet = {};
+  let final: ResourceDeclaredCsp;
+  if (args.hostedMode) {
+    final = {};
+    for (const key of CSP_DIRECTIVE_KEYS) {
+      const before = afterDeny[key] ?? [];
+      const stripped: string[] = [];
+      const kept: string[] = [];
+      for (const d of before) {
+        if (isHostedDangerousDomain(d)) {
+          stripped.push(d);
+        } else {
+          kept.push(d);
+        }
+      }
+      if (stripped.length > 0) hostedStripped[key] = stripped;
+      final[key] = kept;
+    }
+  } else {
+    final = afterDeny;
+  }
+
+  return {
+    connectDomains: final.connectDomains ?? [],
+    resourceDomains: final.resourceDomains ?? [],
+    frameDomains: final.frameDomains ?? [],
+    baseUriDomains: final.baseUriDomains ?? [],
+    trace: {
+      baseline,
+      afterRestrictTo,
+      afterDeny,
+      hostedClamp: { stripped: hostedStripped },
+      effectiveMode,
+    },
+  };
+}
+
+/**
+ * Resolve sandbox permissions for a UI resource. Resource declaration is
+ * the ceiling; `mode` chooses posture; `deny` wins; hosted clamp strips
+ * sensitive permissions regardless.
+ */
+export function resolveSandboxPermissions(
+  args: ResolveSandboxPermissionsArgs,
+): EffectiveSandboxPermissions {
+  const declared = args.resourcePermissions ?? {};
+  const effectiveMode: SandboxPermissionsMode =
+    args.policy?.mode ?? "resource-declared";
+
+  // Step 1 — start from the resource declaration as candidate.
+  // Step 2 — apply mode.
+  let afterMode: Record<string, boolean>;
+  switch (effectiveMode) {
+    case "resource-declared":
+      afterMode = { ...declared };
+      break;
+    case "deny-all":
+      afterMode = {};
+      break;
+    case "custom": {
+      // `allow` is the candidate set; resource declaration acts as the
+      // ceiling (host can never grant a permission the resource didn't
+      // request).
+      afterMode = {};
+      const allow = args.policy?.allow ?? {};
+      for (const [name, granted] of Object.entries(allow)) {
+        if (granted && declared[name]) {
+          afterMode[name] = true;
+        }
+      }
+      break;
+    }
+  }
+
+  // Step 3 — subtract profile deny.
+  const deniedByProfile: string[] = [];
+  if (args.policy?.deny && args.policy.deny.length > 0) {
+    for (const name of args.policy.deny) {
+      if (afterMode[name]) {
+        deniedByProfile.push(name);
+        delete afterMode[name];
+      }
+    }
+  }
+
+  // Step 4 — hosted-mode clamp.
+  const hostedClampDeny = args.hostedClampDeny ?? DEFAULT_HOSTED_PERMISSION_CLAMP_DENY;
+  const deniedByHostedClamp: string[] = [];
+  if (args.hostedMode) {
+    for (const name of hostedClampDeny) {
+      if (afterMode[name]) {
+        deniedByHostedClamp.push(name);
+        delete afterMode[name];
+      }
+    }
+  }
+
+  return {
+    granted: afterMode,
+    trace: {
+      declared,
+      afterMode,
+      deniedByProfile,
+      deniedByHostedClamp,
+      effectiveMode,
+    },
+  };
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+function normalizeDomainSet(value: ResourceDeclaredCsp): {
+  connectDomains: string[];
+  resourceDomains: string[];
+  frameDomains: string[];
+  baseUriDomains: string[];
+} {
+  return {
+    connectDomains: [...(value.connectDomains ?? [])],
+    resourceDomains: [...(value.resourceDomains ?? [])],
+    frameDomains: [...(value.frameDomains ?? [])],
+    baseUriDomains: [...(value.baseUriDomains ?? [])],
+  };
+}
+
+/**
+ * True iff `domain` matches any pattern in `denyList`. Supports wildcard
+ * subdomain matching: `https://*.example.com` matches
+ * `https://api.example.com` and `https://other.example.com`, but NOT
+ * `https://example.com` itself (the wildcard requires a subdomain).
+ * Exact match also wins.
+ */
+function matchesAnyDeny(domain: string, denyList: string[]): boolean {
+  for (const pattern of denyList) {
+    if (pattern === domain) return true;
+    if (pattern.includes("*")) {
+      const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+      const regexPattern = "^" + escaped.replace(/\*/g, "[^/]+") + "$";
+      if (new RegExp(regexPattern).test(domain)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Hosted-mode clamp predicate. Strips:
+ *   - Bare wildcards (`*`, `https:`, `http:`).
+ *   - Localhost / loopback / private-network domains.
+ *   - Unsafe schemes (`javascript:`, `vbscript:`).
+ *
+ * NOT a replacement for CSP-level enforcement — this is defense in depth.
+ * The browser enforces CSP regardless; this prevents a profile from
+ * SAYING it allows these in the first place.
+ *
+ * Same-origin MCPJam API blocking is the caller's responsibility (the
+ * resolver doesn't know what "MCPJam same-origin" is — the caller passes
+ * additional clamp entries via `denyList` if it has app-specific
+ * origins to strip).
+ */
+function isHostedDangerousDomain(domain: string): boolean {
+  // Bare wildcards.
+  if (domain === "*") return true;
+  if (domain === "https:" || domain === "http:" || domain === "ws:" || domain === "wss:") return true;
+  if (domain.startsWith("https://*") && !domain.includes(".")) return true;
+
+  // Unsafe schemes (CSP source expressions).
+  if (
+    domain.startsWith("javascript:") ||
+    domain.startsWith("vbscript:") ||
+    domain.startsWith("file:")
+  ) {
+    return true;
+  }
+
+  // Localhost / loopback / private-network ranges.
+  if (
+    /^https?:\/\/localhost(:|$|\/)/i.test(domain) ||
+    /^https?:\/\/127\./i.test(domain) ||
+    /^https?:\/\/10\./i.test(domain) ||
+    /^https?:\/\/192\.168\./i.test(domain) ||
+    /^https?:\/\/172\.(1[6-9]|2[0-9]|3[01])\./i.test(domain) ||
+    /^https?:\/\/0\.0\.0\.0/i.test(domain) ||
+    /^https?:\/\/\[::1\]/i.test(domain) ||
+    /^https?:\/\/\[fe80::/i.test(domain)
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/sdk/src/sandbox-policy.ts
+++ b/sdk/src/sandbox-policy.ts
@@ -341,37 +341,44 @@ export function resolveSandboxPermissions(
     args.policy?.mode ?? "resource-declared";
 
   // Step 1 — start from the resource declaration as candidate.
-  // Step 2 — apply mode.
-  let afterMode: Record<string, boolean>;
+  // Step 2 — apply mode. Each stage produces an IMMUTABLE snapshot so the
+  // trace fields below capture the value at that stage (the prior shape
+  // aliased `afterMode` and `granted` to the same object reference, so
+  // `trace.afterMode` always equaled the final granted set — useless for
+  // debugging "which step dropped this permission?").
+  let afterModeSnapshot: Record<string, boolean>;
   switch (effectiveMode) {
     case "resource-declared":
-      afterMode = { ...declared };
+      afterModeSnapshot = { ...declared };
       break;
     case "deny-all":
-      afterMode = {};
+      afterModeSnapshot = {};
       break;
     case "custom": {
       // `allow` is the candidate set; resource declaration acts as the
       // ceiling (host can never grant a permission the resource didn't
       // request).
-      afterMode = {};
+      afterModeSnapshot = {};
       const allow = args.policy?.allow ?? {};
       for (const [name, granted] of Object.entries(allow)) {
         if (granted && declared[name]) {
-          afterMode[name] = true;
+          afterModeSnapshot[name] = true;
         }
       }
       break;
     }
   }
 
+  // Working copy for Steps 3+4 so the snapshots above remain unchanged.
+  const working: Record<string, boolean> = { ...afterModeSnapshot };
+
   // Step 3 — subtract profile deny.
   const deniedByProfile: string[] = [];
   if (args.policy?.deny && args.policy.deny.length > 0) {
     for (const name of args.policy.deny) {
-      if (afterMode[name]) {
+      if (working[name]) {
         deniedByProfile.push(name);
-        delete afterMode[name];
+        delete working[name];
       }
     }
   }
@@ -381,18 +388,21 @@ export function resolveSandboxPermissions(
   const deniedByHostedClamp: string[] = [];
   if (args.hostedMode) {
     for (const name of hostedClampDeny) {
-      if (afterMode[name]) {
+      if (working[name]) {
         deniedByHostedClamp.push(name);
-        delete afterMode[name];
+        delete working[name];
       }
     }
   }
 
   return {
-    granted: afterMode,
+    granted: working,
     trace: {
       declared,
-      afterMode,
+      // afterMode is the post-step-2 snapshot — NOT the final granted set.
+      // This is the stage immediately after `mode` picks the candidate
+      // surface and before deny/clamp subtract from it.
+      afterMode: afterModeSnapshot,
       deniedByProfile,
       deniedByHostedClamp,
       effectiveMode,
@@ -437,9 +447,13 @@ function matchesAnyDeny(domain: string, denyList: string[]): boolean {
 
 /**
  * Hosted-mode clamp predicate. Strips:
- *   - Bare wildcards (`*`, `https:`, `http:`).
- *   - Localhost / loopback / private-network domains.
- *   - Unsafe schemes (`javascript:`, `vbscript:`).
+ *   - Bare wildcards (`*`, bare-scheme tokens like `https:`).
+ *   - Localhost / loopback / private-network / link-local hostnames,
+ *     regardless of scheme (http/https/ws/wss) and IP form (decimal,
+ *     zero-padded, hex, IPv4-mapped IPv6).
+ *   - Unsafe schemes (`javascript:`, `vbscript:`, `data:`, `file:`, etc.),
+ *     matched case-insensitively because CSP source expressions are
+ *     case-insensitive on the scheme.
  *
  * NOT a replacement for CSP-level enforcement — this is defense in depth.
  * The browser enforces CSP regardless; this prevents a profile from
@@ -451,33 +465,134 @@ function matchesAnyDeny(domain: string, denyList: string[]): boolean {
  * origins to strip).
  */
 function isHostedDangerousDomain(domain: string): boolean {
-  // Bare wildcards.
-  if (domain === "*") return true;
-  if (domain === "https:" || domain === "http:" || domain === "ws:" || domain === "wss:") return true;
-  if (domain.startsWith("https://*") && !domain.includes(".")) return true;
+  if (typeof domain !== "string") return true;
+  const trimmed = domain.trim();
+  if (trimmed === "") return true;
+  const lower = trimmed.toLowerCase();
 
-  // Unsafe schemes (CSP source expressions).
+  // Bare CSP wildcards / scheme-only tokens.
+  if (trimmed === "*") return true;
   if (
-    domain.startsWith("javascript:") ||
-    domain.startsWith("vbscript:") ||
-    domain.startsWith("file:")
+    lower === "https:" ||
+    lower === "http:" ||
+    lower === "ws:" ||
+    lower === "wss:" ||
+    lower === "data:" ||
+    lower === "blob:"
   ) {
     return true;
   }
 
-  // Localhost / loopback / private-network ranges.
-  if (
-    /^https?:\/\/localhost(:|$|\/)/i.test(domain) ||
-    /^https?:\/\/127\./i.test(domain) ||
-    /^https?:\/\/10\./i.test(domain) ||
-    /^https?:\/\/192\.168\./i.test(domain) ||
-    /^https?:\/\/172\.(1[6-9]|2[0-9]|3[01])\./i.test(domain) ||
-    /^https?:\/\/0\.0\.0\.0/i.test(domain) ||
-    /^https?:\/\/\[::1\]/i.test(domain) ||
-    /^https?:\/\/\[fe80::/i.test(domain)
-  ) {
+  // Unsafe schemes. Case-insensitive — `JavaScript:` was a known bypass.
+  const UNSAFE_SCHEME_PREFIXES = [
+    "javascript:",
+    "vbscript:",
+    "file:",
+    "data:",
+    "blob:",
+    "filesystem:",
+    "view-source:",
+  ];
+  for (const prefix of UNSAFE_SCHEME_PREFIXES) {
+    if (lower.startsWith(prefix)) return true;
+  }
+
+  // Protocol-relative form `//localhost:3000` — strip these too.
+  if (trimmed.startsWith("//")) {
+    return isDangerousHostname(extractHostname("https:" + trimmed));
+  }
+
+  // Parse anything that looks like a URL. Covers all four schemes the spec
+  // expects (http, https, ws, wss) and any case variation thereof. Use the
+  // URL parser to normalize the host — that's how we catch zero-padded
+  // IPv4 (`127.000.000.001` → `127.0.0.1`), IPv4-mapped IPv6
+  // (`[::ffff:127.0.0.1]` → `::ffff:127.0.0.1`), and other forms a regex
+  // would silently miss.
+  if (/^(https?|wss?):\/\//i.test(trimmed)) {
+    return isDangerousHostname(extractHostname(trimmed));
+  }
+
+  // CSP supports bare host expressions too (`localhost:3000`,
+  // `*.example.com`). Treat them as hostnames if they don't look like a
+  // URL above.
+  if (trimmed.includes("*")) {
+    // `https://*` style wildcards without a domain part.
+    if (
+      lower === "https://*" ||
+      lower === "http://*" ||
+      lower === "ws://*" ||
+      lower === "wss://*"
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  return isDangerousHostname(trimmed.toLowerCase());
+}
+
+/**
+ * Try to extract the hostname from an arbitrary URL-like string using the
+ * native parser. Returns the raw input lower-cased on parse failure so the
+ * caller can still apply hostname-pattern checks defensively.
+ */
+function extractHostname(input: string): string {
+  try {
+    return new URL(input).hostname.toLowerCase();
+  } catch {
+    return input.toLowerCase();
+  }
+}
+
+/**
+ * True if `hostname` (already lower-cased) refers to a loopback /
+ * private-network / link-local / disallowed target. Operates on
+ * URL-normalized strings, so zero-padded IPv4 and IPv4-mapped IPv6 already
+ * resolve to their canonical form.
+ */
+function isDangerousHostname(hostname: string): boolean {
+  if (!hostname) return true;
+
+  // Strip enclosing brackets from IPv6 literals so we can pattern-match.
+  let host = hostname;
+  if (host.startsWith("[") && host.endsWith("]")) {
+    host = host.slice(1, -1);
+  }
+
+  if (host === "localhost") return true;
+  if (host.endsWith(".localhost")) return true;
+
+  // IPv4 loopback / unspecified.
+  if (/^127(?:\.\d{1,3}){3}$/.test(host)) return true;
+  if (host === "0.0.0.0") return true;
+
+  // RFC1918 private ranges.
+  if (/^10(?:\.\d{1,3}){3}$/.test(host)) return true;
+  if (/^192\.168(?:\.\d{1,3}){2}$/.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])(?:\.\d{1,3}){2}$/.test(host)) return true;
+
+  // Link-local (RFC3927) and shared address space (RFC6598).
+  if (/^169\.254(?:\.\d{1,3}){2}$/.test(host)) return true;
+  if (/^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])(?:\.\d{1,3}){2}$/.test(host)) {
     return true;
   }
+
+  // IPv6 loopback / link-local / IPv4-mapped loopback. The URL parser
+  // canonicalizes these to lower case + collapses zeros, so direct prefix
+  // checks suffice.
+  if (host === "::1") return true;
+  if (host.startsWith("fe80:")) return true;
+  // IPv4-mapped IPv6 loopback. The URL parser canonicalizes
+  // `::ffff:127.0.0.1` to its hex form `::ffff:7f00:1` (and similar for
+  // other addresses in 127.0.0.0/8), so check both the canonical hex
+  // shape (`::ffff:7fXX:XXXX`) AND the dotted form (preserved when the
+  // string never round-tripped through `new URL`, e.g. bare host
+  // expressions). `7f00` is `127.0` in hex; the full prefix `::ffff:7f`
+  // covers every IPv4-mapped address in 127.0.0.0/8.
+  if (/^::ffff:7f[0-9a-f]{2}:[0-9a-f]{1,4}$/.test(host)) return true;
+  if (/^::ffff:127(?:\.\d{1,3}){3}$/.test(host)) return true;
+  // IPv6 unique local addresses (fc00::/7).
+  if (/^f[cd][0-9a-f]{2}:/.test(host)) return true;
 
   return false;
 }

--- a/sdk/src/sandbox-policy.ts
+++ b/sdk/src/sandbox-policy.ts
@@ -582,6 +582,32 @@ function isHostedDangerousDomain(domain: string): boolean {
     ) {
       return true;
     }
+    // P1 regression: a bare wildcard pattern (`*.localhost`,
+    // `*.localhost:3000`, `*.10.0.0.1`) used to fall through to
+    // `return false` without ANY hostname check, while the
+    // equivalent URL form (`https://*.localhost`) was correctly
+    // stripped via `isDangerousHostname`'s `.endsWith(".localhost")`
+    // path. A hosted widget could keep loopback / private-network
+    // targets in the allowlist by switching to the bare wildcard
+    // syntax — exact bypass class the hosted clamp was meant to
+    // prevent.
+    //
+    // Two-pass defense:
+    //   1. Wildcard-preserved: parse `https://*.localhost` → hostname
+    //      `*.localhost` → `.endsWith(".localhost")` strips it. Also
+    //      handles port suffixes via the URL parser.
+    //   2. Wildcard-stripped: peel a leading `*.` (only wildcard shape
+    //      CSP defines) and recheck the suffix. Catches IP wildcards
+    //      like `*.10.0.0.1` where `*.<ip>` doesn't match the IP
+    //      regexes in pass 1.
+    const wildcardHost = extractHostname("https://" + trimmed);
+    if (isDangerousHostname(wildcardHost)) return true;
+    if (trimmed.startsWith("*.")) {
+      const suffix = trimmed.slice(2);
+      if (suffix && isDangerousHostname(extractHostname("https://" + suffix))) {
+        return true;
+      }
+    }
     return false;
   }
 

--- a/sdk/tests/sandbox-policy.test.ts
+++ b/sdk/tests/sandbox-policy.test.ts
@@ -392,4 +392,124 @@ describe("resolveSandboxPermissions", () => {
     expect(perms.granted).toEqual({ camera: true });
     expect(perms.trace.deniedByProfile).toEqual(["microphone"]);
   });
+
+  // Guards the aliasing regression: `trace.afterMode` used to point at the
+  // same object as `granted`, so the in-place `delete` mutations in
+  // step 3 + step 4 silently erased the stage-2 snapshot. A future
+  // refactor that re-aliases must trip this test.
+  test("trace.afterMode is the post-mode snapshot, NOT the final granted set", () => {
+    const perms = resolveSandboxPermissions({
+      resourcePermissions: { camera: true, microphone: true, geolocation: true },
+      policy: {
+        mode: "resource-declared",
+        deny: ["microphone"], // removed at step 3
+      },
+      hostedMode: true, // step 4 strips camera + geolocation
+    });
+    expect(perms.granted).toEqual({});
+    // afterMode should still include EVERY resource-declared permission —
+    // it captures the candidate set right after mode application, before
+    // any subtraction.
+    expect(perms.trace.afterMode).toEqual({
+      camera: true,
+      microphone: true,
+      geolocation: true,
+    });
+    expect(perms.trace.deniedByProfile).toEqual(["microphone"]);
+    expect(perms.trace.deniedByHostedClamp).toEqual(
+      expect.arrayContaining(["camera", "geolocation"]),
+    );
+  });
+});
+
+describe("resolveSandboxCsp — hosted clamp hostname normalization", () => {
+  test("strips mixed-case unsafe schemes (case-insensitive)", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "JavaScript:alert(1)",
+          "VBSCRIPT:evil()",
+          "Data:text/html,",
+          "https://safe.com",
+        ],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+    });
+    expect(csp.connectDomains).toEqual(["https://safe.com"]);
+  });
+
+  test("strips ws:// and wss:// localhost / private-network endpoints", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "ws://localhost:9000",
+          "wss://127.0.0.1:8443",
+          "ws://10.0.0.5",
+          "wss://api.example.com",
+        ],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+    });
+    expect(csp.connectDomains).toEqual(["wss://api.example.com"]);
+  });
+
+  test("strips zero-padded IPv4 and IPv4-mapped IPv6 loopback", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          // URL parser normalizes 127.000.000.001 → 127.0.0.1
+          "https://127.000.000.001",
+          // Bracketed IPv6 loopback
+          "https://[::1]",
+          // IPv4-mapped IPv6 loopback
+          "https://[::ffff:127.0.0.1]",
+          "https://safe.example.com",
+        ],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+    });
+    expect(csp.connectDomains).toEqual(["https://safe.example.com"]);
+  });
+
+  test("strips link-local (169.254.x.x) and shared address space (100.64.x.x)", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "https://169.254.169.254", // cloud metadata endpoint
+          "https://100.64.0.1",
+          "https://172.20.0.1", // RFC1918
+          "https://safe.com",
+        ],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+    });
+    expect(csp.connectDomains).toEqual(["https://safe.com"]);
+  });
+
+  test("strips protocol-relative localhost", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: ["//localhost:3000", "//safe.com"],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+    });
+    // Protocol-relative `//safe.com` resolves to a non-loopback host.
+    expect(csp.connectDomains).toEqual(["//safe.com"]);
+  });
+
+  test("strips bare-scheme tokens including uppercase", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: ["HTTPS:", "HTTP:", "WSS:", "https://good.com"],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+    });
+    expect(csp.connectDomains).toEqual(["https://good.com"]);
+  });
 });

--- a/sdk/tests/sandbox-policy.test.ts
+++ b/sdk/tests/sandbox-policy.test.ts
@@ -365,6 +365,81 @@ describe("resolveSandboxCsp — hosted-mode clamp", () => {
     ]);
     expect(csp.trace.hostedClamp.stripped).toEqual({});
   });
+
+  test("hosted clamp strips bare WILDCARD loopback hosts (P1 regression)", () => {
+    // The exact bypass Codex flagged: `*.localhost` and friends used to
+    // hit the wildcard branch and return false WITHOUT any hostname
+    // check, while the URL form `https://*.localhost` was correctly
+    // stripped via `.endsWith(".localhost")`. A hosted widget could
+    // declare the bare wildcard syntax to keep loopback targets in
+    // the allowlist. Now both shapes are stripped via a two-pass
+    // wildcard check (parse with wildcard preserved + strip leading
+    // `*.` and recheck the suffix).
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "*.localhost",
+          "*.localhost:3000",
+          "https://api.example.com",
+        ],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+    });
+    expect(csp.connectDomains).toEqual(["https://api.example.com"]);
+    const stripped =
+      csp.trace.hostedClamp.stripped.connectDomains ?? [];
+    expect(stripped).toContain("*.localhost");
+    expect(stripped).toContain("*.localhost:3000");
+  });
+
+  test("hosted clamp strips bare WILDCARD IPv4 private-network hosts", () => {
+    // Pass 1 of the two-pass check (wildcard-preserved hostname) misses
+    // `*.10.0.0.1` because the URL parser yields `*.10.0.0.1` and that
+    // doesn't match the IPv4 regex. Pass 2 strips the leading `*.` and
+    // rechecks `10.0.0.1` against the RFC1918 regex. Without pass 2,
+    // a hosted widget could pin `*.10.0.0.1` and keep internal-network
+    // exfiltration targets.
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "*.10.0.0.1",
+          "*.192.168.1.1",
+          "*.172.16.0.1",
+          "*.169.254.1.1",
+          "https://api.example.com",
+        ],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+    });
+    expect(csp.connectDomains).toEqual(["https://api.example.com"]);
+  });
+
+  test("hosted clamp PRESERVES bare wildcards of public domains", () => {
+    // Counter-test: the two-pass wildcard check MUST NOT strip benign
+    // public-domain wildcards like `*.example.com`. The stripped
+    // suffix `example.com` is not loopback/private; the URL parser
+    // returns `*.example.com` as hostname, which also doesn't match
+    // any dangerous-hostname pattern.
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "*.example.com",
+          "*.cdn.example.com",
+          "*.cloudflare.com",
+        ],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+    });
+    expect(csp.connectDomains).toEqual([
+      "*.example.com",
+      "*.cdn.example.com",
+      "*.cloudflare.com",
+    ]);
+    expect(csp.trace.hostedClamp.stripped.connectDomains ?? []).toEqual([]);
+  });
 });
 
 describe("resolveSandboxCsp — hostedClampExtraDeny (app-specific clamp)", () => {

--- a/sdk/tests/sandbox-policy.test.ts
+++ b/sdk/tests/sandbox-policy.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Unit tests for the pure sandbox-policy resolver. Mirrors the
+ * "Sandbox policy enforcement" section of the inspector plan
+ * (`/Users/marcelojimenezrocabado/.claude/plans/inspector-mcp-profile.md`):
+ *
+ *   1. mode picks the BASELINE; restrictTo + deny always apply on top.
+ *   2. restrictTo INTERSECTS — never unions undeclared domains.
+ *   3. deny SUBTRACTS — wins over restrictTo, baseline, and resource decl.
+ *   4. Hosted-mode HARD CLAMP strips dangerous values regardless.
+ *
+ * Each test names the precedence rule it guards so a future regression
+ * triages straight to which step broke.
+ */
+
+import { describe, expect, test } from "vitest";
+import {
+  resolveSandboxCsp,
+  resolveSandboxPermissions,
+} from "../src/sandbox-policy";
+
+describe("resolveSandboxCsp — baseline selection from `mode`", () => {
+  test("declared mode: baseline = resource declaration", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: ["a.com", "b.com"],
+      },
+      policy: { mode: "declared" },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual(["a.com", "b.com"]);
+    expect(csp.trace.effectiveMode).toBe("declared");
+  });
+
+  test("declared mode: resource omitted → SEP-1865 secure default (empty)", () => {
+    const csp = resolveSandboxCsp({
+      // No resourceCsp passed.
+      policy: { mode: "declared" },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual([]);
+    expect(csp.resourceDomains).toEqual([]);
+  });
+
+  test("declared mode is default when policy.mode is omitted", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: { connectDomains: ["a.com"] },
+      // No policy.mode set.
+      hostedMode: false,
+    });
+    expect(csp.trace.effectiveMode).toBe("declared");
+    expect(csp.connectDomains).toEqual(["a.com"]);
+  });
+
+  test("host-default mode: baseline = caller-supplied hostDefaultBaseline", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: { connectDomains: ["resource.com"] },
+      hostDefaultBaseline: { connectDomains: ["host-default.com"] },
+      policy: { mode: "host-default" },
+      hostedMode: false,
+    });
+    // Resource declaration is ignored in this mode.
+    expect(csp.connectDomains).toEqual(["host-default.com"]);
+  });
+
+  test("relaxed mode: hostedMode=false uses hostDefaultBaseline if provided", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: { connectDomains: ["resource.com"] },
+      hostDefaultBaseline: { connectDomains: ["relaxed.com"] },
+      policy: { mode: "relaxed" },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual(["relaxed.com"]);
+  });
+});
+
+describe("resolveSandboxCsp — restrictTo intersects in every mode", () => {
+  test("declared mode + restrictTo: intersection drops domains not in restrictTo", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: { connectDomains: ["a.com", "b.com", "c.com"] },
+      policy: {
+        mode: "declared",
+        restrictTo: { connectDomains: ["a.com", "c.com"] },
+      },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual(["a.com", "c.com"]);
+  });
+
+  test("declared mode + restrictTo: NEVER unions undeclared domains (SEP-1865)", () => {
+    // Resource declared only a.com; restrictTo lists evil.com too.
+    // Intersection means evil.com is NEVER added — host MUST NOT loosen.
+    const csp = resolveSandboxCsp({
+      resourceCsp: { connectDomains: ["a.com"] },
+      policy: {
+        mode: "declared",
+        restrictTo: { connectDomains: ["a.com", "evil.com"] },
+      },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual(["a.com"]);
+    expect(csp.connectDomains).not.toContain("evil.com");
+  });
+
+  test("host-default mode + restrictTo: intersection still applies (not a bypass)", () => {
+    const csp = resolveSandboxCsp({
+      hostDefaultBaseline: { connectDomains: ["a.com", "b.com"] },
+      policy: {
+        mode: "host-default",
+        restrictTo: { connectDomains: ["a.com"] },
+      },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual(["a.com"]);
+  });
+
+  test("relaxed mode + restrictTo: intersection still applies", () => {
+    const csp = resolveSandboxCsp({
+      hostDefaultBaseline: { connectDomains: ["a.com", "b.com"] },
+      policy: {
+        mode: "relaxed",
+        restrictTo: { connectDomains: ["a.com"] },
+      },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual(["a.com"]);
+  });
+
+  test("restrictTo omitted for a directive: baseline passes through unchanged", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: ["a.com", "b.com"],
+        resourceDomains: ["res.com"],
+      },
+      policy: {
+        mode: "declared",
+        restrictTo: { connectDomains: ["a.com"] },
+        // No resourceDomains restriction.
+      },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual(["a.com"]);
+    expect(csp.resourceDomains).toEqual(["res.com"]);
+  });
+});
+
+describe("resolveSandboxCsp — deny subtracts in every mode", () => {
+  test("declared mode + deny: subtraction (NOT a bypass — deny applies even in declared)", () => {
+    // The exact regression the plan flagged: `declared` is NOT a bypass.
+    // deny applies regardless of mode.
+    const csp = resolveSandboxCsp({
+      resourceCsp: { connectDomains: ["a.com", "b.com"] },
+      policy: {
+        mode: "declared",
+        deny: { connectDomains: ["a.com"] },
+      },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual(["b.com"]);
+    expect(csp.connectDomains).not.toContain("a.com");
+  });
+
+  test("deny wins over restrictTo: a domain in both is denied", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: { connectDomains: ["a.com", "b.com"] },
+      policy: {
+        mode: "declared",
+        restrictTo: { connectDomains: ["a.com"] },
+        deny: { connectDomains: ["a.com"] },
+      },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual([]);
+  });
+
+  test("deny wins over resource declaration", () => {
+    // The user's stated semantics: deny is absolute.
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: ["api.example.com", "api.evil.com"],
+      },
+      policy: {
+        mode: "declared",
+        deny: { connectDomains: ["api.evil.com"] },
+      },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual(["api.example.com"]);
+  });
+
+  test("deny wildcard pattern strips matching subdomains", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "https://api.evil.com",
+          "https://other.evil.com",
+          "https://good.com",
+        ],
+      },
+      policy: {
+        mode: "declared",
+        deny: { connectDomains: ["https://*.evil.com"] },
+      },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual(["https://good.com"]);
+  });
+
+  test("host-default mode + deny: deny still applies", () => {
+    const csp = resolveSandboxCsp({
+      hostDefaultBaseline: { connectDomains: ["a.com", "b.com"] },
+      policy: {
+        mode: "host-default",
+        deny: { connectDomains: ["a.com"] },
+      },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual(["b.com"]);
+  });
+});
+
+describe("resolveSandboxCsp — hosted-mode clamp", () => {
+  test("hosted clamp strips wildcards regardless of profile (relaxed mode)", () => {
+    const csp = resolveSandboxCsp({
+      hostDefaultBaseline: { connectDomains: ["*", "https:", "https://good.com"] },
+      policy: { mode: "relaxed" },
+      hostedMode: true,
+    });
+    // `*` and `https:` are dangerous; only the explicit https://good.com survives.
+    expect(csp.connectDomains).toEqual(["https://good.com"]);
+    expect(csp.trace.hostedClamp.stripped.connectDomains).toContain("*");
+    expect(csp.trace.hostedClamp.stripped.connectDomains).toContain("https:");
+  });
+
+  test("hosted clamp strips localhost and private-network ranges", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "https://localhost:3000",
+          "http://127.0.0.1:8080",
+          "https://10.0.0.5",
+          "https://192.168.1.1",
+          "https://api.example.com",
+        ],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+    });
+    // Only the public domain survives.
+    expect(csp.connectDomains).toEqual(["https://api.example.com"]);
+  });
+
+  test("hosted clamp strips unsafe schemes", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: ["javascript:alert(1)", "https://safe.com"],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+    });
+    expect(csp.connectDomains).toEqual(["https://safe.com"]);
+  });
+
+  test("hosted clamp is a no-op when hostedMode=false (dev)", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: ["https://localhost:3000", "*", "https://api.com"],
+      },
+      policy: { mode: "declared" },
+      hostedMode: false,
+    });
+    // All preserved — dev mode trusts whatever the resource declared.
+    expect(csp.connectDomains).toEqual([
+      "https://localhost:3000",
+      "*",
+      "https://api.com",
+    ]);
+    expect(csp.trace.hostedClamp.stripped).toEqual({});
+  });
+});
+
+describe("resolveSandboxCsp — combined precedence (the full pipeline)", () => {
+  test("resource + restrictTo + deny + hosted clamp run in order", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "https://api.example.com",
+          "https://evil.example.com",
+          "https://other.example.com",
+          "https://localhost:3000",
+        ],
+      },
+      policy: {
+        mode: "declared",
+        restrictTo: {
+          connectDomains: [
+            "https://api.example.com",
+            "https://evil.example.com",
+            "https://localhost:3000",
+            // other.example.com intentionally NOT in restrictTo → dropped at step 2
+          ],
+        },
+        deny: {
+          connectDomains: ["https://evil.example.com"], // wins at step 3
+        },
+      },
+      hostedMode: true, // strips localhost at step 4
+    });
+    expect(csp.connectDomains).toEqual(["https://api.example.com"]);
+  });
+
+  test("trace captures each intermediate stage", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: { connectDomains: ["a.com", "b.com", "c.com"] },
+      policy: {
+        mode: "declared",
+        restrictTo: { connectDomains: ["a.com", "b.com"] },
+        deny: { connectDomains: ["a.com"] },
+      },
+      hostedMode: false,
+    });
+    expect(csp.trace.baseline.connectDomains).toEqual([
+      "a.com",
+      "b.com",
+      "c.com",
+    ]);
+    expect(csp.trace.afterRestrictTo.connectDomains).toEqual(["a.com", "b.com"]);
+    expect(csp.trace.afterDeny.connectDomains).toEqual(["b.com"]);
+    expect(csp.connectDomains).toEqual(["b.com"]);
+  });
+});
+
+describe("resolveSandboxPermissions", () => {
+  test("resource declaration is the CEILING — profile cannot grant what resource didn't request", () => {
+    const perms = resolveSandboxPermissions({
+      resourcePermissions: { camera: true },
+      policy: {
+        mode: "custom",
+        allow: { camera: true, microphone: true }, // microphone NOT in declared
+      },
+      hostedMode: false,
+    });
+    expect(perms.granted).toEqual({ camera: true });
+    expect(perms.granted).not.toHaveProperty("microphone");
+  });
+
+  test("deny-all mode: empty allow= regardless of resource declaration", () => {
+    const perms = resolveSandboxPermissions({
+      resourcePermissions: { camera: true, microphone: true },
+      policy: { mode: "deny-all" },
+      hostedMode: false,
+    });
+    expect(perms.granted).toEqual({});
+  });
+
+  test("resource-declared mode passes the resource's request through", () => {
+    const perms = resolveSandboxPermissions({
+      resourcePermissions: { camera: true, geolocation: true },
+      policy: { mode: "resource-declared" },
+      hostedMode: false,
+    });
+    expect(perms.granted).toEqual({ camera: true, geolocation: true });
+  });
+
+  test("hosted clamp strips sensitive permissions regardless of mode", () => {
+    const perms = resolveSandboxPermissions({
+      resourcePermissions: {
+        camera: true,
+        microphone: true,
+        geolocation: true,
+        "clipboard-write": true,
+      },
+      policy: { mode: "resource-declared" }, // user opted into resource-declared
+      hostedMode: true,
+    });
+    // Default hostedClampDeny strips camera/microphone/geolocation.
+    expect(perms.granted).toEqual({ "clipboard-write": true });
+    expect(perms.trace.deniedByHostedClamp).toEqual(
+      expect.arrayContaining(["camera", "microphone", "geolocation"]),
+    );
+  });
+
+  test("profile deny wins over allow", () => {
+    const perms = resolveSandboxPermissions({
+      resourcePermissions: { camera: true, microphone: true },
+      policy: {
+        mode: "custom",
+        allow: { camera: true, microphone: true },
+        deny: ["microphone"],
+      },
+      hostedMode: false,
+    });
+    expect(perms.granted).toEqual({ camera: true });
+    expect(perms.trace.deniedByProfile).toEqual(["microphone"]);
+  });
+});

--- a/sdk/tests/sandbox-policy.test.ts
+++ b/sdk/tests/sandbox-policy.test.ts
@@ -278,6 +278,158 @@ describe("resolveSandboxCsp — hosted-mode clamp", () => {
   });
 });
 
+describe("resolveSandboxCsp — hostedClampExtraDeny (app-specific clamp)", () => {
+  // P1 regression: a hosted widget could declare app-sensitive origins
+  // (e.g. https://app.mcpjam.com) in connectDomains and have them
+  // forwarded into the iframe's CSP — letting it exfiltrate the user's
+  // session. policy.deny is profile-overridable (bypassable); this
+  // caller-supplied clamp is not.
+
+  test("strips exact matches in hosted mode", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "https://app.mcpjam.com/api/secret",
+          "https://api.example.com",
+        ],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+      hostedClampExtraDeny: {
+        connectDomains: ["https://app.mcpjam.com/api/secret"],
+      },
+    });
+    expect(csp.connectDomains).toEqual(["https://api.example.com"]);
+    expect(csp.trace.hostedClamp.stripped.connectDomains).toContain(
+      "https://app.mcpjam.com/api/secret",
+    );
+  });
+
+  test("wildcard pattern strips all matching subdomains", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "https://app.mcpjam.com",
+          "https://api.mcpjam.com",
+          "https://www.mcpjam.com",
+          "https://api.example.com",
+        ],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+      hostedClampExtraDeny: {
+        connectDomains: ["https://*.mcpjam.com"],
+      },
+    });
+    expect(csp.connectDomains).toEqual(["https://api.example.com"]);
+  });
+
+  test("hostedClampExtraDeny is a no-op when hostedMode=false (dev preserves)", () => {
+    // The clamp gates on hostedMode === true. In dev/local mode, the
+    // user explicitly opted out of strict behavior — same rationale as
+    // the built-in clamp predicate. Keeps "develop locally with full
+    // freedom" workable.
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "https://app.mcpjam.com",
+          "https://api.example.com",
+        ],
+      },
+      policy: { mode: "declared" },
+      hostedMode: false,
+      hostedClampExtraDeny: {
+        connectDomains: ["https://*.mcpjam.com"],
+      },
+    });
+    expect(csp.connectDomains).toEqual([
+      "https://app.mcpjam.com",
+      "https://api.example.com",
+    ]);
+    expect(csp.trace.hostedClamp.stripped).toEqual({});
+  });
+
+  test("built-in dangerous patterns AND extra deny both run in one pass", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "*", // stripped by built-in (wildcard)
+          "https://localhost:3000", // stripped by built-in (loopback)
+          "https://app.mcpjam.com", // stripped by extra
+          "https://api.example.com", // kept
+        ],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+      hostedClampExtraDeny: {
+        connectDomains: ["https://*.mcpjam.com"],
+      },
+    });
+    expect(csp.connectDomains).toEqual(["https://api.example.com"]);
+    // Trace surfaces both reasons so the debug UI can show why.
+    const stripped = csp.trace.hostedClamp.stripped.connectDomains ?? [];
+    expect(stripped).toContain("*");
+    expect(stripped).toContain("https://localhost:3000");
+    expect(stripped).toContain("https://app.mcpjam.com");
+  });
+
+  test("hostedClampExtraDeny applied per-directive (frameDomains alone)", () => {
+    // restrictTo / deny shapes are per-directive; hostedClampExtraDeny
+    // mirrors that. A caller can strip only specific directives without
+    // touching others. Important for the inspector use case where only
+    // connect/resource/frame/baseUri need MCPJam stripping (no other
+    // directive families exist today, but the shape supports growth).
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: ["https://app.mcpjam.com"],
+        frameDomains: ["https://app.mcpjam.com"],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+      hostedClampExtraDeny: {
+        // Only frameDomains is gated; connectDomains intentionally NOT
+        // listed here.
+        frameDomains: ["https://*.mcpjam.com"],
+      },
+    });
+    expect(csp.frameDomains).toEqual([]);
+    expect(csp.connectDomains).toEqual(["https://app.mcpjam.com"]);
+  });
+
+  test("extra deny survives all earlier precedence steps (resource+restrictTo+deny)", () => {
+    // Full pipeline: resource declares everything, restrictTo keeps a
+    // subset, profile.deny removes one, then hostedClampExtraDeny still
+    // strips the app origin even though restrictTo "allowed" it. This
+    // proves the clamp is non-bypassable from the profile editor.
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "https://app.mcpjam.com",
+          "https://api.example.com",
+          "https://evil.com",
+          "https://other.com",
+        ],
+      },
+      policy: {
+        mode: "declared",
+        restrictTo: {
+          connectDomains: [
+            "https://app.mcpjam.com",
+            "https://api.example.com",
+            "https://evil.com",
+          ],
+        },
+        deny: { connectDomains: ["https://evil.com"] },
+      },
+      hostedMode: true,
+      hostedClampExtraDeny: {
+        connectDomains: ["https://*.mcpjam.com"],
+      },
+    });
+    expect(csp.connectDomains).toEqual(["https://api.example.com"]);
+  });
+});
+
 describe("resolveSandboxCsp — combined precedence (the full pipeline)", () => {
   test("resource + restrictTo + deny + hosted clamp run in order", () => {
     const csp = resolveSandboxCsp({

--- a/sdk/tests/sandbox-policy.test.ts
+++ b/sdk/tests/sandbox-policy.test.ts
@@ -141,6 +141,44 @@ describe("resolveSandboxCsp — restrictTo intersects in every mode", () => {
     expect(csp.connectDomains).toEqual(["a.com"]);
     expect(csp.resourceDomains).toEqual(["res.com"]);
   });
+
+  test("restrictTo matches case-insensitively (parity with deny)", () => {
+    // Regression for the case-mismatch class: restrictTo used to do
+    // strict Set.has() equality while deny did case-insensitive
+    // matching. A user who wrote `Api.Example.COM` (typo, copy-paste
+    // from a docs example with mixed case, etc.) would have their
+    // restrictTo entry silently fail to match a lowercased
+    // resource-declared `api.example.com` — domain dropped from the
+    // intersection without any signal. The two matching strategies
+    // within the same resolver must agree.
+    const csp = resolveSandboxCsp({
+      resourceCsp: { connectDomains: ["https://api.example.com"] },
+      policy: {
+        mode: "declared",
+        // Mixed-case restrictTo MUST match the lower-case baseline.
+        restrictTo: { connectDomains: ["HTTPS://API.EXAMPLE.COM"] },
+      },
+      hostedMode: false,
+    });
+    // Result keeps the baseline-cased original — restrictTo is just a
+    // lookup index, not the source of truth for the emitted CSP.
+    expect(csp.connectDomains).toEqual(["https://api.example.com"]);
+  });
+
+  test("restrictTo case-insensitive: mixed-case baseline + lower-case restrictTo also matches", () => {
+    // Symmetric direction of the previous test — verifies the lookup
+    // is case-insensitive regardless of which side has the casing
+    // variation.
+    const csp = resolveSandboxCsp({
+      resourceCsp: { connectDomains: ["HTTPS://Api.Example.COM"] },
+      policy: {
+        mode: "declared",
+        restrictTo: { connectDomains: ["https://api.example.com"] },
+      },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual(["HTTPS://Api.Example.COM"]);
+  });
 });
 
 describe("resolveSandboxCsp — deny subtracts in every mode", () => {
@@ -445,6 +483,65 @@ describe("resolveSandboxCsp — hostedClampExtraDeny (app-specific clamp)", () =
     });
     expect(csp.frameDomains).toEqual([]);
     expect(csp.connectDomains).toEqual(["https://app.mcpjam.com"]);
+  });
+
+  test("hosted-mode relaxed profile: extra-deny clamp STILL strips MCPJam origins", () => {
+    // P1 regression: a saved profile with mode="relaxed" used to bypass
+    // the resolver entirely in the renderer, silently dropping the
+    // hosted clamp's MCPJam-origin extra-deny. After the renderer-side
+    // fix, relaxed-in-hosted-mode falls through into resolveSandboxCsp,
+    // so the security contract here MUST hold:
+    //
+    //   "Hosted clamp is non-bypassable — saved profiles cannot opt out
+    //    of stripping MCPJam-origin access from widget-declared CSP."
+    //
+    // Without this guarantee a hosted user could save mode=relaxed +
+    // declare MCPJam origins in connectDomains and exfiltrate via the
+    // iframe's session.
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "https://app.mcpjam.com",
+          "https://api.example.com",
+        ],
+      },
+      // Caller passes the resource as hostDefaultBaseline because
+      // relaxed mode's "permissive baseline" is conceptually unbounded
+      // (the renderer treats it as "use whatever the widget declared").
+      hostDefaultBaseline: {
+        connectDomains: [
+          "https://app.mcpjam.com",
+          "https://api.example.com",
+        ],
+      },
+      policy: { mode: "relaxed" },
+      hostedMode: true,
+      hostedClampExtraDeny: {
+        connectDomains: ["https://*.mcpjam.com"],
+      },
+    });
+    expect(csp.connectDomains).toEqual(["https://api.example.com"]);
+    expect(csp.trace.hostedClamp.stripped.connectDomains).toContain(
+      "https://app.mcpjam.com",
+    );
+  });
+
+  test("relaxed + restrictTo: restrictTo applies even though mode is relaxed", () => {
+    // The other half of the "deny always wins / restrictTo applies in
+    // every mode" guarantee: a saved relaxed profile that ALSO sets
+    // restrictTo should intersect, not bypass. Renderer treats
+    // resource-declared CSP as the baseline; restrictTo narrows.
+    const csp = resolveSandboxCsp({
+      hostDefaultBaseline: {
+        connectDomains: ["a.com", "b.com", "c.com"],
+      },
+      policy: {
+        mode: "relaxed",
+        restrictTo: { connectDomains: ["a.com", "b.com"] },
+      },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual(["a.com", "b.com"]);
   });
 
   test("extra deny survives all earlier precedence steps (resource+restrictTo+deny)", () => {

--- a/sdk/tests/sandbox-policy.test.ts
+++ b/sdk/tests/sandbox-policy.test.ts
@@ -260,6 +260,57 @@ describe("resolveSandboxCsp — hosted-mode clamp", () => {
     expect(csp.connectDomains).toEqual(["https://safe.com"]);
   });
 
+  test("hosted clamp strips bare host:port forms (no scheme)", () => {
+    // P1 regression: the bare-host fallback used to call
+    // `isDangerousHostname` directly on strings like "localhost:3000",
+    // which the loopback/private-network patterns wouldn't match (they
+    // expect a port-less hostname). A hosted widget could declare a
+    // bare loopback source and escape the clamp. The URL-prefixed and
+    // protocol-relative forms have always been stripped — only the bare
+    // form leaked through.
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "localhost:3000",
+          "127.0.0.1:8080",
+          "[::1]:9000",
+          "10.0.0.5:5432",
+          "192.168.1.1:80",
+          "api.example.com:443",
+        ],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+    });
+    // Only the public domain (with port) survives.
+    expect(csp.connectDomains).toEqual(["api.example.com:443"]);
+    expect(csp.trace.hostedClamp.stripped.connectDomains).toEqual(
+      expect.arrayContaining([
+        "localhost:3000",
+        "127.0.0.1:8080",
+        "[::1]:9000",
+        "10.0.0.5:5432",
+        "192.168.1.1:80",
+      ]),
+    );
+  });
+
+  test("hosted clamp strips bare loopback hosts with path suffix", () => {
+    // Same family as the port case: CSP host-source allows a path
+    // component (`host:port path`). The URL parser drops paths just as
+    // it drops ports, so this lands on the same fix as :port — covered
+    // explicitly because the original predicate would have left these
+    // untouched.
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: ["localhost/api", "127.0.0.1/admin"],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+    });
+    expect(csp.connectDomains).toEqual([]);
+  });
+
   test("hosted clamp is a no-op when hostedMode=false (dev)", () => {
     const csp = resolveSandboxCsp({
       resourceCsp: {
@@ -519,16 +570,46 @@ describe("resolveSandboxPermissions", () => {
         camera: true,
         microphone: true,
         geolocation: true,
-        "clipboard-write": true,
+        clipboardWrite: true,
       },
       policy: { mode: "resource-declared" }, // user opted into resource-declared
       hostedMode: true,
     });
     // Default hostedClampDeny strips camera/microphone/geolocation.
-    expect(perms.granted).toEqual({ "clipboard-write": true });
+    expect(perms.granted).toEqual({ clipboardWrite: true });
     expect(perms.trace.deniedByHostedClamp).toEqual(
       expect.arrayContaining(["camera", "microphone", "geolocation"]),
     );
+  });
+
+  test("profile deny removes clipboardWrite by its camelCase MCP key", () => {
+    // P2 regression: the resolver does plain string-key matching against
+    // `resourcePermissions`, which is the spec's `_meta.ui.permissions`
+    // map (camelCase per SEP-1865). A profile that denied
+    // `"clipboard-write"` (kebab, the Permission-Policy spelling) used
+    // to silently no-op because no resource key by that name existed.
+    // The clamp doc and HostConfigEditor now both standardize on the
+    // camelCase MCP key — this test pins that semantics.
+    const perms = resolveSandboxPermissions({
+      resourcePermissions: { clipboardWrite: true, camera: true },
+      policy: { mode: "resource-declared", deny: ["clipboardWrite"] },
+      hostedMode: false,
+    });
+    expect(perms.granted).toEqual({ camera: true });
+    expect(perms.trace.deniedByProfile).toEqual(["clipboardWrite"]);
+  });
+
+  test("custom mode allows clipboardWrite by its camelCase MCP key", () => {
+    const perms = resolveSandboxPermissions({
+      resourcePermissions: { clipboardWrite: true, camera: true },
+      policy: {
+        mode: "custom",
+        allow: { clipboardWrite: true },
+      },
+      hostedMode: false,
+    });
+    // resource declaration is the ceiling; only the allow entry passes.
+    expect(perms.granted).toEqual({ clipboardWrite: true });
   });
 
   test("profile deny wins over allow", () => {
@@ -663,5 +744,82 @@ describe("resolveSandboxCsp — hosted clamp hostname normalization", () => {
       hostedMode: true,
     });
     expect(csp.connectDomains).toEqual(["https://good.com"]);
+  });
+
+  // Codex P1 finding: an earlier shape only caught IPv4-mapped IPv6 in
+  // the 127/8 loopback range, leaving RFC1918, link-local, and shared
+  // address space reachable via the mapped form. The URL parser
+  // canonicalizes `::ffff:192.168.1.1` to `::ffff:c0a8:101`, which
+  // bypasses dotted-IPv4 regexes. Unpack the hex form and re-run the
+  // full ruleset.
+  test("strips IPv4-mapped IPv6 representations of RFC1918 / link-local / shared ranges", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "https://[::ffff:192.168.1.1]", // RFC1918 via mapped
+          "https://[::ffff:10.0.0.5]", // RFC1918 via mapped
+          "https://[::ffff:172.16.0.1]", // RFC1918 via mapped
+          "https://[::ffff:169.254.169.254]", // cloud metadata via mapped
+          "https://[::ffff:100.64.0.1]", // shared address via mapped
+          "https://[::ffff:0.0.0.0]", // unspecified via mapped
+          "https://safe.example.com",
+        ],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+    });
+    expect(csp.connectDomains).toEqual(["https://safe.example.com"]);
+  });
+
+  // CodeRabbit Major #5: bare host expressions with ports
+  // (`localhost:3000`, `127.0.0.1:8080`) used to bypass stripping because
+  // `isDangerousHostname` received the `host:port` literal. The
+  // fallback now synthesizes `https://...` and reuses the URL parser.
+  test("strips bare host expressions that include ports", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: [
+          "localhost:3000",
+          "127.0.0.1:8080",
+          "192.168.1.1:8443",
+          "safe.example.com:443",
+        ],
+      },
+      policy: { mode: "declared" },
+      hostedMode: true,
+    });
+    expect(csp.connectDomains).toEqual(["safe.example.com:443"]);
+  });
+});
+
+describe("matchesAnyDeny — case-insensitivity (CodeRabbit Major #4)", () => {
+  // CSP scheme + host matching is case-insensitive per the URL spec, and
+  // DNS hostnames are case-insensitive. A deny rule that compares raw
+  // strings lets a widget bypass with case variants (e.g. profile says
+  // `deny: ["evil.com"]`, widget declares `Evil.com` → not stripped).
+  test("exact match: pattern and domain differ only in case", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: { connectDomains: ["Evil.com", "safe.com"] },
+      policy: {
+        mode: "declared",
+        deny: { connectDomains: ["evil.com"] },
+      },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual(["safe.com"]);
+  });
+
+  test("wildcard match: case-variant subdomain still matches deny pattern", () => {
+    const csp = resolveSandboxCsp({
+      resourceCsp: {
+        connectDomains: ["https://API.Evil.COM", "https://safe.com"],
+      },
+      policy: {
+        mode: "declared",
+        deny: { connectDomains: ["https://*.evil.com"] },
+      },
+      hostedMode: false,
+    });
+    expect(csp.connectDomains).toEqual(["https://safe.com"]);
   });
 });


### PR DESCRIPTION
## Summary

Wires up inspector-side consumption of the `mcpProfile` envelope landed in [mcpjam-backend PR #269](https://github.com/MCPJam/mcpjam-backend/pull/269). After this lands, three new user-visible features are usable end-to-end:

- **Pin per-host-config `initialize.clientInfo`** — spoof "ChatGPT", "Claude Desktop", "Cursor", etc. at the wire level to test what servers do with each.
- **Pin `supportedProtocolVersions`** — reproducible eval runs against specific MCP protocol revisions (`2025-11-25` vs `2025-06-18`).
- **Enforce host-side sandbox CSP / permissions policy** on top of each UIResource's declared CSP (SEP-1865 compliance: host MAY restrict, MUST NOT loosen).

## The full chain

```
HostConfigEditor (new "MCP profile" section)
        │ save
        ▼
hostConfigsV2.setProjectDefault  ──►  Convex row stores mcpProfile
        │
        ▼
use-app-state queries hostConfigsV2.getProjectDefault
        │                                  │
        ▼                                  ▼
buildResolverConnectionDefaults    useActiveMcpProfile() context
(clientInfo, proposed-Protocol-           │
 Version[0]) → /api/mcp/connect           ▼
        │                       mcp-apps-renderer.tsx
        ▼                       resolveSandboxCsp / resolveSandboxPermissions
toMCPServerConfig                         │
        │                                 ▼
        ▼                       AppBridge.sandbox.csp (enforced by iframe)
MCPClientManager.performConnection
        │
        ▼
new Client(clientInfo, { supportedProtocolVersions: [...] })
        │
        ▼
MCP `initialize` on the wire — uses user-pinned values
```

## What changed

### SDK (`@mcpjam/sdk`)
- `BaseServerConfig` and `MCPClientManagerOptions` accept `clientInfo`, `proposedProtocolVersion`, `defaultClientInfoExtras`, `defaultProposedProtocolVersion`. Resolved at `new Client(...)` and forwarded into the upstream Client via the existing `supportedProtocolVersions: string[]` `ClientOption` (alpha.2 already exposes it — the SDK state machines have been parameterizing protocolVersion via `buildInitializeRequestBody` for OAuth conformance, so this just reuses the same primitive).
- **New `sandbox-policy.ts`**: pure resolver shared by MCP Apps and (future) ChatGPT Apps renderers. Precedence: **baseline-from-mode → restrictTo intersect → deny subtract → hosted-mode hard clamp**. No DOM, no React, no Convex.

### Inspector
- Type mirrors of `HostConfigMcpProfileV1` / `CspDomainSet` in `client/src/lib/host-config-v2.ts` plus pure helpers (`resolveClientInfo`, `resolveSupportedProtocolVersions`).
- `ConnectionDefaults` wire shape extended with `clientInfo` + `proposedProtocolVersion`. Server-side `parseConnectionDefaults` + `toMCPServerConfig` match the SDK option surface.
- `ActiveMcpProfileProvider` / `useActiveMcpProfile` context. Two providers wired: hosted (`ChatboxChatPage` from `session.payload.mcpProfile`) and in-inspector (`use-app-state` queries `hostConfigsV2.getProjectDefault`).
- `mcp-apps-renderer` integrates the shared resolver — resolved CSP/permissions flow into `AppBridge.sandbox`. **When no profile is set, existing widget-derived behavior is preserved byte-for-byte** — opt-in feature.
- `HostConfigEditor` "MCP profile (advanced)" section: collapsed-by-default, structured controls for `clientInfo`, ordered protocol versions list, CSP mode + restrictTo + deny, permissions mode.

## Hash dedupe semantics (mirrored from backend PR #269)

- `undefined` vs `{ profileVersion: 1 }` (empty envelope) are **distinct** on the wire — the inspector preserves this distinction at every layer (`emptyHostConfigInputV2`, `hostConfigDtoToInput`, save payloads). Unit test guards against accidental synthesis.
- Editor's "Enable" stamps `{ profileVersion: 1 }`; "Reset to SDK defaults" snaps back to `undefined`.

## Tests

- **+26 SDK unit tests** in `sandbox-policy.test.ts` — every precedence rule covered (declared-not-bypass regression, restrictTo intersection in every mode, deny wins, hosted clamp strips wildcards/localhost/unsafe-schemes, permissions ceiling, deny-all, etc.).
- **+17 inspector unit tests** in `host-config-v2-mcp-profile.test.ts` — resolver sentinel preservation, undefined-vs-empty-envelope distinction, key-order independence, supportedProtocolVersions order-sensitive equality.
- **0 regressions**: 798/798 existing SDK tests still pass; 19/19 existing `chatbox-session` tests still pass.

## Test plan
- [x] `npx vitest run` in `sdk/` — all 798 pass (26 new + 772 existing)
- [x] `npx vitest run client/src/lib/__tests__/host-config-v2-mcp-profile.test.ts` — 17/17 pass
- [x] `npx vitest run client/src/lib/__tests__/chatbox-session.test.ts` — 19/19 pass (no regression from `normalizeMcpProfile`)
- [x] `npx tsc --noEmit` in `sdk/` — 0 errors
- [x] `npx tsc --noEmit -p client` and `-p server` — error counts match pristine `main` (255 / 251, all pre-existing in test fixtures)
- [ ] **Manual smoke** (deferred to reviewer): connect a local MCP server with verbose logging, save a profile with `clientInfo: { name: "chatgpt", version: "1.0" }`, confirm server sees `clientInfo.name === "chatgpt"` in its initialize log; same for `supportedProtocolVersions[0]`; confirm `csp.deny.connectDomains: ["api.evil.com"]` blocks that domain in an MCP App iframe.

## Out of scope (tracked follow-ups)
1. **ChatGPT-app server route** (`chatgpt-apps/index.ts`) needs the same `resolveSandboxCsp` integration. The shared resolver is in place; the route just needs `projectId`/`chatboxId` binding to read mcpProfile. Architecturally identical to the MCP Apps path.
2. **Editor React-component round-trip test** — straightforward but needs a mocked `setProjectDefault` mutation. The pure-logic helpers are covered by the 17 unit tests.
3. **Per-`hostStyle` `mcpProfile` defaults** (e.g. picking `chatgpt` hostStyle prefills `clientInfo: { name: "chatgpt", ... }`) — intentionally deferred per the plan to avoid surprising mutations on hostStyle change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes how MCP connections are initialized (client identity/protocol negotiation) and tightens iframe sandbox CSP/Permission-Policy enforcement, including hosted-mode security clamps; regressions could break widget networking or alter security posture.
> 
> **Overview**
> Adds end-to-end support for `hostConfig.mcpProfile` so host configs can pin MCP `initialize` metadata (**`clientInfo`** and ordered **`supportedProtocolVersions`**) and apply host-side sandbox policy for MCP Apps.
> 
> Inspector now fetches the active project default host config and provides its `mcpProfile` via a new `ActiveMcpProfileProvider`, passes pins through `ConnectionDefaults` into both resolver-path and hosted-path server validation, and extends the Host Config editor with an advanced “MCP profile” section (client identity, protocol versions, CSP/permissions policy) plus regression tests.
> 
> MCP Apps rendering now resolves a single effective sandbox policy (CSP + permissions) using a new shared SDK resolver and feeds the resolved values consistently to the bridge, inline iframe, and modal iframe; hosted mode additionally strips MCPJam origins to prevent same-origin exfiltration. The SDK is updated to accept per-connection `clientInfo`/`supportedProtocolVersions` and to export the new `resolveSandboxCsp`/`resolveSandboxPermissions` utilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49faee6d9cd4b2a4fe949c8430b3a3d543be1846. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->