### PR TITLE
harden soundcheck

### DIFF
--- a/soundcheck/src/app/callback/route.ts
+++ b/soundcheck/src/app/callback/route.ts
@@ -2,4 +2,17 @@
 // returns the user to `/` afterward.
 import { handleAuth } from "@workos-inc/authkit-nextjs";
 
-export const GET = handleAuth();
+function getCallbackBaseUrl(): string {
+  const redirectUri = process.env.NEXT_PUBLIC_WORKOS_REDIRECT_URI;
+  if (!redirectUri) {
+    throw new Error("NEXT_PUBLIC_WORKOS_REDIRECT_URI must be set");
+  }
+
+  return new URL(redirectUri).origin;
+}
+
+export const GET = handleAuth({
+  // Railway can expose the internal bind address to Next during callbacks.
+  // Force AuthKit's final post-login redirect back to the public app origin.
+  baseURL: getCallbackBaseUrl()
+});


### PR DESCRIPTION
- Problem: Soundcheck hosted login was starting correctly, but after WorkOS sign-in it redirected users to `https://0.0.0.0:8080/`.
- Why that broke: `0.0.0.0:8080` is Railway's internal server address, not the public Soundcheck URL, so Chrome blocked it.
- Root cause: AuthKit's callback handler was using the request URL from Railway/Next to decide where to redirect after login.
- Fix: In `soundcheck/src/app/callback/route.ts`, pass AuthKit an explicit public `baseURL`.
- How it works now: The callback derives the public origin from `NEXT_PUBLIC_WORKOS_REDIRECT_URI`, so hosted redirects back to `https://soundcheck.mcpjam.com/`.
- Scope: Soundcheck-only change, one file: `soundcheck/src/app/callback/route.ts`.
- Verification: `npm run typecheck -w @mcpjam/soundcheck` passes