### PR TITLE
fix(tokenizer): stop paging Sentry for client-side fetch failures

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/tokenizer.ts
+++ b/mcpjam-inspector/server/routes/mcp/tokenizer.ts
@@ -3,6 +3,8 @@ import "../../types/hono";
 import {
   mapModelIdToTokenizerBackend,
   estimateTokensFromChars,
+  isFetchConnectionFailure,
+  getFetchErrorCause,
 } from "../../utils/tokenizer-helpers";
 import { logger } from "../../utils/logger";
 
@@ -121,10 +123,20 @@ tokenizer.post("/count-tools", async (c) => {
             tokenCounts[serverId] = estimateTokensFromChars(toolsText);
           }
         } catch (error) {
-          logger.warn(`[tokenizer] Error counting tokens for server`, {
-            serverId,
-            error: error instanceof Error ? error.message : String(error),
-          });
+          // Connection-level failures reaching the Convex tokenizer come from
+          // the caller's network, not our backend — log locally and move on.
+          if (isFetchConnectionFailure(error)) {
+            logger.debug(
+              `[tokenizer] Backend unreachable for server, falling back to estimate`,
+              { serverId, cause: getFetchErrorCause(error) },
+            );
+          } else {
+            logger.warn(`[tokenizer] Error counting tokens for server`, {
+              serverId,
+              error: error instanceof Error ? error.message : String(error),
+              cause: getFetchErrorCause(error),
+            });
+          }
           // Fallback to character-based estimation on error
           try {
             const tools = await mcpClientManager.getToolsForAiSdk([serverId]);
@@ -247,9 +259,20 @@ tokenizer.post("/count-text", async (c) => {
           });
         }
       } catch (error) {
-        logger.warn(`[tokenizer] Error counting tokens for text`, {
-          error: error instanceof Error ? error.message : String(error),
-        });
+        // Connection-level failures (DNS, ECONNREFUSED, TLS) are user-network
+        // issues, not backend problems. Demote to debug so they don't page
+        // Sentry; backend HTTP/logical errors are already handled above as warnings.
+        if (isFetchConnectionFailure(error)) {
+          logger.debug(
+            `[tokenizer] Backend unreachable, falling back to estimate`,
+            { cause: getFetchErrorCause(error) },
+          );
+        } else {
+          logger.warn(`[tokenizer] Error counting tokens for text`, {
+            error: error instanceof Error ? error.message : String(error),
+            cause: getFetchErrorCause(error),
+          });
+        }
         // Fallback to character-based estimation on error
         return c.json({
           ok: true,

--- a/mcpjam-inspector/server/utils/__tests__/tokenizer-helpers.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/tokenizer-helpers.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   mapModelIdToTokenizerBackend,
   estimateTokensFromChars,
+  isFetchConnectionFailure,
+  getFetchErrorCause,
 } from "../tokenizer-helpers.js";
 
 describe("mapModelIdToTokenizerBackend", () => {
@@ -144,5 +146,57 @@ describe("estimateTokensFromChars", () => {
   it("handles long text", () => {
     const longText = "a".repeat(1000);
     expect(estimateTokensFromChars(longText)).toBe(250);
+  });
+});
+
+describe("isFetchConnectionFailure", () => {
+  it("returns true for a Node fetch-failed TypeError", () => {
+    const err = new TypeError("fetch failed");
+    expect(isFetchConnectionFailure(err)).toBe(true);
+  });
+
+  it("is case-insensitive on the message", () => {
+    const err = new TypeError("Fetch failed");
+    expect(isFetchConnectionFailure(err)).toBe(true);
+  });
+
+  it("returns false for unrelated TypeErrors", () => {
+    expect(isFetchConnectionFailure(new TypeError("oops"))).toBe(false);
+  });
+
+  it("returns false for plain Errors with the same message", () => {
+    // Only undici raises this as a TypeError; a normal Error of the same
+    // text is something else (e.g. user code) and should still warn.
+    expect(isFetchConnectionFailure(new Error("fetch failed"))).toBe(false);
+  });
+
+  it("returns false for non-Error values", () => {
+    expect(isFetchConnectionFailure("fetch failed")).toBe(false);
+    expect(isFetchConnectionFailure(undefined)).toBe(false);
+    expect(isFetchConnectionFailure(null)).toBe(false);
+  });
+});
+
+describe("getFetchErrorCause", () => {
+  it("extracts cause.code from a fetch-failed TypeError", () => {
+    const err = new TypeError("fetch failed");
+    (err as { cause?: unknown }).cause = { code: "ECONNREFUSED" };
+    expect(getFetchErrorCause(err)).toBe("ECONNREFUSED");
+  });
+
+  it("returns undefined when cause is missing", () => {
+    expect(getFetchErrorCause(new TypeError("fetch failed"))).toBeUndefined();
+  });
+
+  it("returns undefined when cause.code is not a string", () => {
+    const err = new TypeError("fetch failed");
+    (err as { cause?: unknown }).cause = { code: 42 };
+    expect(getFetchErrorCause(err)).toBeUndefined();
+  });
+
+  it("handles non-object errors gracefully", () => {
+    expect(getFetchErrorCause("nope")).toBeUndefined();
+    expect(getFetchErrorCause(null)).toBeUndefined();
+    expect(getFetchErrorCause(undefined)).toBeUndefined();
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/tokenizer-helpers.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/tokenizer-helpers.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   mapModelIdToTokenizerBackend,
   estimateTokensFromChars,
   isFetchConnectionFailure,
   getFetchErrorCause,
+  countToolsTokens,
 } from "../tokenizer-helpers.js";
 
 describe("mapModelIdToTokenizerBackend", () => {
@@ -198,5 +199,51 @@ describe("getFetchErrorCause", () => {
     expect(getFetchErrorCause("nope")).toBeUndefined();
     expect(getFetchErrorCause(null)).toBeUndefined();
     expect(getFetchErrorCause(undefined)).toBeUndefined();
+  });
+});
+
+describe("countToolsTokens fallback behavior", () => {
+  const originalFetch = global.fetch;
+  const originalUrl = process.env.CONVEX_HTTP_URL;
+
+  beforeEach(() => {
+    process.env.CONVEX_HTTP_URL = "http://nowhere.invalid";
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    if (originalUrl === undefined) {
+      delete process.env.CONVEX_HTTP_URL;
+    } else {
+      process.env.CONVEX_HTTP_URL = originalUrl;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("returns a char-based estimate (not 0) when fetch throws a connection error", async () => {
+    // Simulate the undici 'fetch failed' shape that fires on DNS/ECONNREFUSED/TLS.
+    global.fetch = vi.fn().mockImplementation(() => {
+      const err = new TypeError("fetch failed");
+      (err as { cause?: unknown }).cause = { code: "ECONNREFUSED" };
+      throw err;
+    });
+
+    const tools = [{ name: "search", description: "search the catalog" }];
+    const expected = estimateTokensFromChars(JSON.stringify(tools));
+
+    const result = await countToolsTokens(tools, "claude-opus-4-1");
+
+    expect(expected).toBeGreaterThan(0); // sanity
+    expect(result).toBe(expected);
+  });
+
+  it("returns 0 only when the input itself cannot be serialized", async () => {
+    // Circular reference -> JSON.stringify throws. The fetch never runs.
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    const result = await countToolsTokens([circular], "claude-opus-4-1");
+
+    expect(result).toBe(0);
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/tokenizer-helpers.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/tokenizer-helpers.test.ts
@@ -238,12 +238,17 @@ describe("countToolsTokens fallback behavior", () => {
   });
 
   it("returns 0 only when the input itself cannot be serialized", async () => {
-    // Circular reference -> JSON.stringify throws. The fetch never runs.
+    // Circular reference -> JSON.stringify throws inside the try block before
+    // fetch is reached. Spy on fetch to lock in that contract.
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy as unknown as typeof global.fetch;
+
     const circular: Record<string, unknown> = {};
     circular.self = circular;
 
     const result = await countToolsTokens([circular], "claude-opus-4-1");
 
     expect(result).toBe(0);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/server/utils/tokenizer-helpers.ts
+++ b/mcpjam-inspector/server/utils/tokenizer-helpers.ts
@@ -212,6 +212,13 @@ export async function countToolsTokens(
         cause: getFetchErrorCause(error),
       });
     }
-    return 0;
+    // Honor the "falling back to estimate" log above: compute a char-based
+    // estimate from the input. Only return 0 if even stringifying fails
+    // (e.g. circular references in `tools`).
+    try {
+      return estimateTokensFromChars(JSON.stringify(tools));
+    } catch {
+      return 0;
+    }
   }
 }

--- a/mcpjam-inspector/server/utils/tokenizer-helpers.ts
+++ b/mcpjam-inspector/server/utils/tokenizer-helpers.ts
@@ -142,6 +142,29 @@ export function estimateTokensFromChars(text: string): number {
 }
 
 /**
+ * Detect Node/undici connection-level fetch failures
+ * (`TypeError: fetch failed` with a populated `cause`).
+ *
+ * These happen on the *client's* network — DNS miss, connection refused, TLS
+ * failure, etc. — so logging them as warnings to Sentry conflates user-side
+ * connectivity with backend issues. Callers should route these to a debug
+ * log instead while still surfacing backend HTTP/logical errors as warnings.
+ */
+export function isFetchConnectionFailure(error: unknown): boolean {
+  return error instanceof TypeError && /fetch failed/i.test(error.message);
+}
+
+/**
+ * Pull the underlying network error code (e.g. `ECONNREFUSED`, `ENOTFOUND`)
+ * out of a `fetch failed` TypeError. `error.cause` is where undici stashes
+ * the real reason; `error.message` is the useless generic wrapper.
+ */
+export function getFetchErrorCause(error: unknown): string | undefined {
+  const cause = (error as { cause?: { code?: unknown } })?.cause?.code;
+  return typeof cause === "string" ? cause : undefined;
+}
+
+/**
  * Count tokens for tools, using backend tokenizer or char fallback.
  * Shared by mcp/tools and web routes.
  */
@@ -177,9 +200,18 @@ export async function countToolsTokens(
 
     return estimateTokensFromChars(toolsText);
   } catch (error) {
-    logger.warn(`${logPrefix} Error counting tokens`, {
-      error: error instanceof Error ? error.message : String(error),
-    });
+    // Connection-level failures (DNS, ECONNREFUSED, TLS) come from the
+    // caller's network, not our backend. Log locally but don't page Sentry.
+    if (isFetchConnectionFailure(error)) {
+      logger.debug(`${logPrefix} Backend unreachable, falling back to estimate`, {
+        cause: getFetchErrorCause(error),
+      });
+    } else {
+      logger.warn(`${logPrefix} Error counting tokens`, {
+        error: error instanceof Error ? error.message : String(error),
+        cause: getFetchErrorCause(error),
+      });
+    }
     return 0;
   }
 }


### PR DESCRIPTION
## TL;DR

The tokenizer's inline fallback path warns to Sentry on every fetch failure. Most of those failures are network-level errors on the caller's machine (DNS, connection refused, TLS), not signals our service is unhealthy. Demote that one case to `debug`; keep `warn` for actual backend errors.

## What changed

| Failure mode | Before | After |
|---|---|---|
| `fetch` throws (DNS / ECONNREFUSED / TLS) | `logger.warn` → Sentry | `logger.debug` → local + analytics |
| Upstream HTTP non-2xx | `logger.warn` → Sentry | unchanged |
| Upstream `{ok: false}` | `logger.warn` → Sentry | unchanged |
| Other thrown error | `logger.warn` → Sentry | `logger.warn`, now with `cause` |

Detection is tight: `error instanceof TypeError && /fetch failed/i.test(error.message)` — the exact undici signature. Both paths now also extract `error.cause.code` so warnings are actionable (`ECONNREFUSED` / `ENOTFOUND` / etc.) instead of just `"fetch failed"`.

## Test plan

- [x] 9 new unit tests for the bucketing helpers
- [x] Existing tokenizer-helpers tests still pass
- [x] Typecheck of edited files
- [ ] Manual: run inspector with an unreachable backend URL, confirm UI shows estimate and `--verbose` log shows the `cause` code
- [ ] Manual: confirm a deliberate backend 500 still warns to Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)