### PR TITLE
feat(inspector): hostConfig CSP for ChatGPT widgets + advertise=enforce for MCP Apps

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-app-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-app-renderer.tsx
@@ -40,6 +40,8 @@ import {
   type WidgetCspData,
 } from "./chatgpt-widget-loaders";
 import { useHostContextStore } from "@/stores/host-context-store";
+import { useActiveMcpProfile } from "@/contexts/active-mcp-profile-context";
+import type { HostConfigMcpProfileV1 } from "@/lib/host-config-v2";
 import {
   extractHostDeviceCapabilities,
   extractHostLocale,
@@ -47,6 +49,7 @@ import {
   extractHostTheme,
   extractHostTimeZone,
 } from "@/lib/client-config";
+import { stableStringifyJson } from "@/lib/client-config";
 
 type ToolState =
   | "input-streaming"
@@ -252,6 +255,8 @@ function useWidgetFetch(
   deviceType: string,
   capabilities: { hover: boolean; touch: boolean },
   safeAreaInsets: { top: number; bottom: number; left: number; right: number },
+  mcpProfile: HostConfigMcpProfileV1 | undefined,
+  mcpProfileKey: string,
   onCspConfigReceived?: (csp: WidgetCspData) => void,
   isOffline?: boolean,
   cachedWidgetHtmlUrl?: string,
@@ -339,6 +344,17 @@ function useWidgetFetch(
       setWidgetUrl(null);
     }
   }, [cspMode, prevCspMode, widgetUrl]);
+
+  // Reset widget URL when the active mcpProfile changes so a saved
+  // policy edit (deny rule, restrictTo intersection, etc.) takes effect
+  // without a manual refresh.
+  const prevMcpProfileKeyRef = useRef<string>(mcpProfileKey);
+  useEffect(() => {
+    if (prevMcpProfileKeyRef.current !== mcpProfileKey) {
+      prevMcpProfileKeyRef.current = mcpProfileKey;
+      if (widgetUrl) setWidgetUrl(null);
+    }
+  }, [mcpProfileKey, widgetUrl]);
 
   // Serialize data for stable comparison (avoids re-running effect on reference changes)
   const serializedData = useMemo(
@@ -471,6 +487,7 @@ function useWidgetFetch(
             locale,
             cspMode,
             deviceType,
+            mcpProfile,
           });
 
           if (hostedData.csp && onCspConfigReceivedRef.current) {
@@ -515,6 +532,7 @@ function useWidgetFetch(
           deviceType,
           capabilities,
           safeAreaInsets,
+          mcpProfile,
           onWidgetHtmlCaptured,
         });
         if (isCancelled) return;
@@ -573,6 +591,10 @@ function useWidgetFetch(
     deviceType,
     capabilities,
     safeAreaInsets,
+    // Track mcpProfile by stable key so a parent that hands us a freshly
+    // cloned envelope on each render doesn't trigger a refetch.
+    mcpProfileKey,
+    mcpProfile,
     isOffline,
     cachedWidgetHtmlUrl,
     onWidgetHtmlCaptured,
@@ -627,6 +649,16 @@ export function ChatGPTAppRenderer({
   const inlineWidthRef = useRef<number | undefined>(undefined);
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const draftHostContext = useHostContextStore((s) => s.draftHostContext);
+  // Active hostConfig.mcpProfile from the surrounding scope; drives the
+  // server-side CSP resolver via the widget-content routes. Stable JSON
+  // key is what the load effect tracks so identical envelopes with
+  // different object identity don't force a reload.
+  const activeMcpProfile = useActiveMcpProfile();
+  const mcpProfileKey = useMemo(
+    () =>
+      activeMcpProfile === undefined ? "" : stableStringifyJson(activeMcpProfile),
+    [activeMcpProfile],
+  );
   // Get locale and time zone from playground store, fallback to browser settings
   const playgroundLocale = useUIPlaygroundStore((s) => s.globals.locale);
   const playgroundTimeZone = useUIPlaygroundStore((s) => s.globals.timeZone);
@@ -776,14 +808,20 @@ export function ChatGPTAppRenderer({
   const setWidgetHtml = useWidgetDebugStore((s) => s.setWidgetHtml);
   const clearCspViolations = useWidgetDebugStore((s) => s.clearCspViolations);
 
-  // Clear CSP violations when CSP mode changes (stale data from previous mode)
+  // Clear CSP violations when CSP mode or the active mcpProfile changes
+  // (stale data from the previous policy).
   const prevCspModeRef = useRef(cspMode);
+  const prevProfileKeyDebugRef = useRef(mcpProfileKey);
   useEffect(() => {
-    if (prevCspModeRef.current !== cspMode) {
+    if (
+      prevCspModeRef.current !== cspMode ||
+      prevProfileKeyDebugRef.current !== mcpProfileKey
+    ) {
       clearCspViolations(resolvedToolCallId);
       prevCspModeRef.current = cspMode;
+      prevProfileKeyDebugRef.current = mcpProfileKey;
     }
-  }, [cspMode, resolvedToolCallId, clearCspViolations]);
+  }, [cspMode, mcpProfileKey, resolvedToolCallId, clearCspViolations]);
 
   // Mobile playground mode detection
   const isMobilePlaygroundMode = isPlaygroundActive && deviceType === "mobile";
@@ -841,6 +879,8 @@ export function ChatGPTAppRenderer({
     deviceType,
     capabilities,
     safeAreaInsets,
+    activeMcpProfile,
+    mcpProfileKey,
     handleCspConfigReceived,
     isOffline,
     cachedWidgetHtmlUrl,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-widget-loaders.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-widget-loaders.ts
@@ -1,6 +1,7 @@
 import { authFetch } from "@/lib/session-token";
 import { buildServerRequest } from "@/lib/apis/web/context";
 import type { CspMode } from "@/stores/ui-playground-store";
+import type { HostConfigMcpProfileV1 } from "@/lib/host-config-v2";
 
 export interface WidgetCspData {
   mode: CspMode;
@@ -27,6 +28,13 @@ interface BaseWidgetLoaderOptions {
   locale: string;
   cspMode: CspMode;
   deviceType: string;
+  /**
+   * Active hostConfig.mcpProfile from the surrounding scope (chatbox
+   * session, project default, eval suite). Forwarded to the widget
+   * routes so saved sandbox CSP overrides legacy `cspMode`.
+   * `undefined` preserves widget-derived behavior.
+   */
+  mcpProfile?: HostConfigMcpProfileV1;
 }
 
 interface LocalChatGptWidgetLoadOptions extends BaseWidgetLoaderOptions {
@@ -71,6 +79,11 @@ export async function loadHostedChatGptWidget(
         deviceType: options.deviceType,
         userLocation: null,
         cspMode: options.cspMode,
+        // Preserve `undefined` verbatim — JSON.stringify drops the key.
+        // Backend distinguishes `undefined` from `{ profileVersion: 1 }`.
+        ...(options.mcpProfile !== undefined
+          ? { mcpProfile: options.mcpProfile }
+          : {}),
       }),
     },
   );
@@ -123,6 +136,12 @@ export async function loadLocalChatGptWidget(
       cspMode: options.cspMode,
       capabilities: options.capabilities,
       safeAreaInsets: options.safeAreaInsets,
+      // Persist mcpProfile alongside the rest of the widget state so
+      // /widget-html/:toolId and /widget-content/:toolId resolve the
+      // same CSP policy.
+      ...(options.mcpProfile !== undefined
+        ? { mcpProfile: options.mcpProfile }
+        : {}),
     }),
   });
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -1283,6 +1283,133 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(screen.queryByText(baseProps.resourceUri)).toBeNull();
   });
 
+  it("refuses every gated handler when advertised capabilities is empty {}", async () => {
+    render(
+      <ChatboxHostCapabilitiesOverrideProvider value={{}}>
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostCapabilitiesOverrideProvider>,
+    );
+
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+
+    // tools/call → unsupported + sendToolCancelled fired
+    await expect(
+      mockBridge.oncalltool?.(
+        { name: "tool", arguments: {} } as any,
+        {} as any,
+      ),
+    ).rejects.toThrow(/serverTools/);
+    expect(mockBridge.sendToolCancelled).toHaveBeenCalled();
+
+    // ui/open-link
+    await expect(
+      mockBridge.onopenlink?.({ url: "https://example.com" } as any),
+    ).rejects.toThrow(/openLinks/);
+
+    // ui/message
+    await expect(
+      mockBridge.onmessage?.({
+        content: [{ type: "text", text: "hi" }],
+      } as any),
+    ).rejects.toThrow(/message/);
+
+    // ui/update-model-context
+    await expect(
+      mockBridge.onupdatemodelcontext?.({} as any),
+    ).rejects.toThrow(/updateModelContext/);
+
+    // resources/read + list + templates
+    await expect(
+      mockBridge.onreadresource?.({ uri: "ui://foo" } as any),
+    ).rejects.toThrow(/serverResources/);
+    await expect(
+      mockBridge.onlistresources?.({} as any),
+    ).rejects.toThrow(/serverResources/);
+    await expect(
+      mockBridge.onlistresourcetemplates?.({} as any),
+    ).rejects.toThrow(/serverResources/);
+
+    // logging — silently dropped, never surfaced as supported
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    act(() => {
+      mockBridge.onloggingmessage?.({
+        level: "info",
+        data: { message: "hi" },
+        logger: "widget",
+      });
+    });
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalled();
+    debugSpy.mockRestore();
+    infoSpy.mockRestore();
+  });
+
+  it("allows only the single advertised capability", async () => {
+    render(
+      <ChatboxHostCapabilitiesOverrideProvider value={{ openLinks: {} }}>
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostCapabilitiesOverrideProvider>,
+    );
+
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+
+    // openLinks is allowed — opens window
+    const openSpy = vi
+      .spyOn(window, "open")
+      .mockImplementation(() => null);
+    await expect(
+      mockBridge.onopenlink?.({ url: "https://example.com" } as any),
+    ).resolves.toEqual({});
+    expect(openSpy).toHaveBeenCalled();
+    openSpy.mockRestore();
+
+    // Everything else is still gated
+    await expect(
+      mockBridge.onmessage?.({
+        content: [{ type: "text", text: "hi" }],
+      } as any),
+    ).rejects.toThrow(/message/);
+  });
+
+  it("rebuilds the bridge when hostCapabilitiesOverride flips", async () => {
+    const { rerender } = render(
+      <ChatboxHostCapabilitiesOverrideProvider value={{ openLinks: {} }}>
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostCapabilitiesOverrideProvider>,
+    );
+
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+    const firstCalls = mockAppBridgeCtor.mock.calls.length;
+
+    rerender(
+      <ChatboxHostCapabilitiesOverrideProvider value={{ message: { text: {} } }}>
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostCapabilitiesOverrideProvider>,
+    );
+
+    await vi.waitFor(() => {
+      expect(mockAppBridgeCtor.mock.calls.length).toBeGreaterThan(firstCalls);
+    });
+
+    // After rebuild the new bridge gates on the new contract: openLinks
+    // is gone, message is allowed.
+    await expect(
+      mockBridge.onopenlink?.({ url: "https://example.com" } as any),
+    ).rejects.toThrow(/openLinks/);
+    await expect(
+      mockBridge.onmessage?.({
+        content: [{ type: "text", text: "hi" }],
+      } as any),
+    ).resolves.toEqual({});
+  });
+
   it("suppresses bridge diagnostic logs in minimal mode", async () => {
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1137,13 +1137,12 @@ export function MCPAppsRenderer({
     onAppSupportedDisplayModesChange,
   ]);
 
-  // ENFORCEMENT LANDING PAD (deferred):
-  // `effectiveHostCapabilities` (above) is the contract advertised in
-  // ui/initialize. The handlers bound below SHOULD eventually gate their work
-  // on it so that "advertise" and "enforce" stay in lockstep, otherwise the
-  // handshake lies (advertised "unsupported" + behavior "supported") — which
-  // is worse than no mock at all for conformance testing. Mapping for the
-  // follow-up PR:
+  // Advertise == enforce. Each handler below short-circuits with an
+  // "unsupported capability" error when the corresponding key is absent
+  // from `effectiveHostCapabilities`. Without this, the ui/initialize
+  // handshake would lie ("advertised unsupported, behaved supported")
+  // which is worse than no mock at all for conformance testing.
+  //
   //   • bridge.onopenlink            ← effectiveHostCapabilities.openLinks
   //   • bridge.onmessage             ← effectiveHostCapabilities.message
   //   • bridge.onupdatemodelcontext  ← effectiveHostCapabilities.updateModelContext
@@ -1152,11 +1151,17 @@ export function MCPAppsRenderer({
   //     onlistresources /
   //     onlistresourcetemplates      ← effectiveHostCapabilities.serverResources
   //   • bridge.onloggingmessage      ← effectiveHostCapabilities.logging
-  //   • (downloadFile handler)       ← effectiveHostCapabilities.downloadFile
-  // When enforcement lands, add `effectiveHostCapabilities` to this
-  // useCallback's dep array.
+  //
+  // `downloadFile` stays unconditional in this pass — none of the
+  // built-in presets advertise it today, so gating it here would only
+  // break code paths that already work without a capability claim.
+  const advertisedHostCapabilities = effectiveHostCapabilities;
   const registerBridgeHandlers = useCallback(
     (bridge: AppBridge) => {
+      const unsupportedCapabilityError = (capability: string) =>
+        new Error(
+          `Host has not advertised the "${capability}" capability; request refused.`,
+        );
       bridge.oninitialized = () => {
         const wasReady = isReadyRef.current;
         setIsReady(true);
@@ -1180,6 +1185,9 @@ export function MCPAppsRenderer({
       };
 
       bridge.onmessage = async ({ content }) => {
+        if (!advertisedHostCapabilities.message) {
+          throw unsupportedCapabilityError("message");
+        }
         const textContent = content.find((item) => item.type === "text")?.text;
         if (textContent) {
           onSendFollowUpRef.current?.(textContent);
@@ -1188,6 +1196,9 @@ export function MCPAppsRenderer({
       };
 
       bridge.onopenlink = async ({ url }) => {
+        if (!advertisedHostCapabilities.openLinks) {
+          throw unsupportedCapabilityError("openLinks");
+        }
         if (url) {
           window.open(url, "_blank", "noopener,noreferrer");
         }
@@ -1195,6 +1206,11 @@ export function MCPAppsRenderer({
       };
 
       bridge.oncalltool = async ({ name, arguments: args }, _extra) => {
+        if (!advertisedHostCapabilities.serverTools) {
+          const error = unsupportedCapabilityError("serverTools");
+          bridge.sendToolCancelled({ reason: error.message });
+          throw error;
+        }
         // Check if tool is model-only (not callable by apps) per SEP-1865
         const calledToolMeta = toolsMetadataRef.current?.[name];
         if (isVisibleToModelOnly(calledToolMeta)) {
@@ -1227,11 +1243,17 @@ export function MCPAppsRenderer({
       };
 
       bridge.onreadresource = async ({ uri }) => {
+        if (!advertisedHostCapabilities.serverResources) {
+          throw unsupportedCapabilityError("serverResources");
+        }
         const result = await readResource(serverIdRef.current, uri);
         return result.content;
       };
 
       bridge.onlistresources = async (params) => {
+        if (!advertisedHostCapabilities.serverResources) {
+          throw unsupportedCapabilityError("serverResources");
+        }
         return listResources(
           serverIdRef.current,
           (params as { cursor?: string } | undefined)?.cursor,
@@ -1239,6 +1261,9 @@ export function MCPAppsRenderer({
       };
 
       bridge.onlistresourcetemplates = async (_params) => {
+        if (!advertisedHostCapabilities.serverResources) {
+          throw unsupportedCapabilityError("serverResources");
+        }
         if (HOSTED_MODE) {
           throw new Error(
             "Resource templates are not supported in hosted mode",
@@ -1267,6 +1292,19 @@ export function MCPAppsRenderer({
       };
 
       bridge.onloggingmessage = ({ level, data, logger }) => {
+        // When `logging` is not advertised, drop the notification locally —
+        // SEP-1865 logging is a one-way notification (no JSON-RPC error
+        // surface). Surface the drop in the console once so it's
+        // diagnosable without falsely advertising support to the widget.
+        if (!advertisedHostCapabilities.logging) {
+          if (!minimalMode) {
+            console.debug(
+              "[MCP Apps] Dropping logging notification — `logging` capability not advertised",
+              { level, logger },
+            );
+          }
+          return;
+        }
         if (minimalMode) return;
         const prefix = logger ? `[${logger}]` : "[MCP Apps]";
         const message = `${prefix} ${level.toUpperCase()}:`;
@@ -1352,6 +1390,9 @@ export function MCPAppsRenderer({
       };
 
       bridge.onupdatemodelcontext = async ({ content, structuredContent }) => {
+        if (!advertisedHostCapabilities.updateModelContext) {
+          throw unsupportedCapabilityError("updateModelContext");
+        }
         // Store in debug store for UI display
         setWidgetModelContext(toolCallId, {
           content,
@@ -1367,7 +1408,19 @@ export function MCPAppsRenderer({
         return {};
       };
     },
-    [setIsReady, toolCallId, setWidgetModelContext, logWidgetDebug],
+    // `advertisedHostCapabilities` reflects the resolved
+    // `effectiveHostCapabilities`; rebuilding the bridge when it changes is
+    // already handled by the dep entry on the outer effect. Keeping the
+    // dependency here is what makes "swap hostCapabilitiesOverride at
+    // runtime → new handlers gate on the new contract" actually fire.
+    [
+      setIsReady,
+      toolCallId,
+      setWidgetModelContext,
+      logWidgetDebug,
+      advertisedHostCapabilities,
+      minimalMode,
+    ],
   );
 
   useEffect(() => {

--- a/mcpjam-inspector/server/routes/apps/chatgpt-apps/index.ts
+++ b/mcpjam-inspector/server/routes/apps/chatgpt-apps/index.ts
@@ -5,10 +5,11 @@ import { CHATGPT_APPS_SANDBOX_PROXY_HTML } from "../SandboxProxyHtml.bundled";
 import {
   buildChatGptRuntimeHead,
   injectScripts,
-  buildCspHeader,
   type CspMode,
   type WidgetCspMeta,
 } from "../../../utils/widget-helpers";
+import { resolveWidgetCspPolicy } from "../../../utils/widget-csp-policy";
+import type { SandboxCspPolicy } from "@mcpjam/sdk";
 
 const chatgpt = new Hono();
 
@@ -34,6 +35,24 @@ interface SafeAreaInsets {
   right: number;
 }
 
+/**
+ * Host-config `mcpProfile` envelope as stored alongside the widget data.
+ * Kept structurally compatible with `HostConfigMcpProfileV1` on the
+ * client; only `apps.sandbox.csp` is consumed below, the rest passes
+ * through verbatim so future fields don't require a server migration.
+ */
+interface StoredMcpProfile {
+  profileVersion: 1;
+  apps?: {
+    sandbox?: {
+      csp?: SandboxCspPolicy;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
 interface WidgetData {
   serverId: string;
   uri: string;
@@ -50,6 +69,12 @@ interface WidgetData {
   cspMode?: CspMode; // CSP enforcement mode
   capabilities?: DeviceCapabilities; // Device capabilities (hover, touch)
   safeAreaInsets?: SafeAreaInsets; // Safe area insets for device notches, etc.
+  /**
+   * Persisted `hostConfig.mcpProfile` envelope. Stored at `/widget/store`
+   * time so `/widget-html/:toolId` and `/widget-content/:toolId` resolve
+   * the same CSP policy.
+   */
+  mcpProfile?: StoredMcpProfile;
   timestamp: number;
 }
 
@@ -166,9 +191,31 @@ chatgpt.post("/widget/store", async (c) => {
       cspMode,
       capabilities,
       safeAreaInsets,
+      mcpProfile,
     } = await c.req.json();
     if (!serverId || !uri || !toolId || !toolName)
       return c.json({ success: false, error: "Missing required fields" }, 400);
+
+    // Preserve `undefined` exactly — do NOT synthesize an empty
+    // `{ profileVersion: 1 }`. The renderer key relies on the distinction.
+    let storedProfile: StoredMcpProfile | undefined;
+    if (mcpProfile !== undefined) {
+      if (
+        mcpProfile === null ||
+        typeof mcpProfile !== "object" ||
+        Array.isArray(mcpProfile) ||
+        (mcpProfile as { profileVersion?: unknown }).profileVersion !== 1
+      ) {
+        return c.json(
+          {
+            success: false,
+            error: "Invalid mcpProfile: profileVersion must be 1",
+          },
+          400,
+        );
+      }
+      storedProfile = mcpProfile as StoredMcpProfile;
+    }
 
     widgetDataStore.set(toolId, {
       serverId,
@@ -191,6 +238,7 @@ chatgpt.post("/widget/store", async (c) => {
         left: 0,
         right: 0,
       }, // Safe area insets
+      mcpProfile: storedProfile,
       timestamp: Date.now(),
     });
     return c.json({ success: true });
@@ -241,6 +289,7 @@ chatgpt.get("/widget-html/:toolId", async (c) => {
       cspMode,
       capabilities,
       safeAreaInsets,
+      mcpProfile,
     } = widgetData;
     const mcpClientManager = c.mcpClientManager;
     const availableServers = mcpClientManager
@@ -262,8 +311,13 @@ chatgpt.get("/widget-html/:toolId", async (c) => {
       | WidgetCspMeta
       | undefined;
 
-    // Build CSP configuration based on mode
-    const cspConfig = buildCspHeader(cspMode ?? "permissive", widgetCspRaw);
+    // Build CSP configuration based on mode + saved host-config profile.
+    const cspConfig = resolveWidgetCspPolicy({
+      cspMode: cspMode ?? "permissive",
+      widgetCsp: widgetCspRaw,
+      sandboxCspPolicy: mcpProfile?.apps?.sandbox?.csp,
+      hostedMode: false,
+    });
 
     const runtimeConfig: RuntimeConfig = {
       toolId,
@@ -387,6 +441,7 @@ chatgpt.get("/widget-content/:toolId", async (c) => {
       cspMode: storedCspMode,
       capabilities,
       safeAreaInsets,
+      mcpProfile,
     } = widgetData;
 
     // Use query param override if provided, otherwise use stored mode
@@ -424,8 +479,13 @@ chatgpt.get("/widget-content/:toolId", async (c) => {
       | WidgetCspMeta
       | undefined;
 
-    // Build CSP based on effective mode
-    const cspConfig = buildCspHeader(effectiveCspMode, widgetCspRaw);
+    // Build CSP based on effective mode + saved host-config profile.
+    const cspConfig = resolveWidgetCspPolicy({
+      cspMode: effectiveCspMode,
+      widgetCsp: widgetCspRaw,
+      sandboxCspPolicy: mcpProfile?.apps?.sandbox?.csp,
+      hostedMode: false,
+    });
 
     const runtimeConfig: RuntimeConfig = {
       toolId,

--- a/mcpjam-inspector/server/routes/web/apps.ts
+++ b/mcpjam-inspector/server/routes/web/apps.ts
@@ -13,12 +13,12 @@ import {
 import {
   injectOpenAICompat,
   injectScripts,
-  buildCspHeader,
   buildCspMetaContent,
   buildChatGptRuntimeHead,
-  type CspMode,
   type WidgetCspMeta,
 } from "../../utils/widget-helpers.js";
+import { resolveWidgetCspPolicy } from "../../utils/widget-csp-policy.js";
+import { mcpProfileSchema } from "./mcp-profile-schema.js";
 import {
   projectServerSchema,
   withEphemeralConnection,
@@ -86,6 +86,10 @@ const chatgptAppsWidgetContentSchema = projectServerSchema.extend({
   cspMode: z.enum(["permissive", "widget-declared"]).optional(),
   locale: z.string().optional(),
   deviceType: z.enum(["mobile", "tablet", "desktop"]).optional(),
+  // Optional host-config sandbox CSP envelope. Forwarded verbatim through
+  // the schema so route-level validation rejects malformed payloads
+  // without us having to mirror the entire profile shape server-side.
+  mcpProfile: mcpProfileSchema.optional(),
 });
 
 // ── Sandbox Proxy Routes ─────────────────────────────────────────────
@@ -233,7 +237,14 @@ apps.post("/chatgpt-apps/widget-content", async (c) =>
         | WidgetCspMeta
         | undefined;
       const effectiveCspMode = body.cspMode ?? "permissive";
-      const cspConfig = buildCspHeader(effectiveCspMode, widgetCspRaw, {
+      // `mcpProfile.apps.sandbox.csp` wins over `cspMode` when present;
+      // when absent the adapter delegates to the legacy buildCspHeader so
+      // the response shape (and behavior) is unchanged.
+      const cspConfig = resolveWidgetCspPolicy({
+        cspMode: effectiveCspMode,
+        widgetCsp: widgetCspRaw,
+        sandboxCspPolicy: body.mcpProfile?.apps?.sandbox?.csp,
+        hostedMode: true,
         frameAncestors: buildFrameAncestors(),
       });
 

--- a/mcpjam-inspector/server/routes/web/mcp-profile-schema.ts
+++ b/mcpjam-inspector/server/routes/web/mcp-profile-schema.ts
@@ -1,0 +1,57 @@
+/**
+ * Zod schema for the optional `mcpProfile` payload field on internal
+ * widget routes. Validates `profileVersion: 1` strictly and treats
+ * everything else as pass-through (so future top-level fields don't
+ * require a schema migration).
+ *
+ * Only `apps.sandbox.csp` is parsed in depth — the legacy CSP path is
+ * the only consumer in this PR. `apps.sandbox.permissions`,
+ * `initialize`, and `extensions` are accepted verbatim.
+ */
+import { z } from "zod";
+
+const cspDomainSetSchema = z
+  .object({
+    connectDomains: z.array(z.string()).optional(),
+    resourceDomains: z.array(z.string()).optional(),
+    frameDomains: z.array(z.string()).optional(),
+    baseUriDomains: z.array(z.string()).optional(),
+  })
+  .strict();
+
+const sandboxCspSchema = z
+  .object({
+    mode: z.enum(["host-default", "declared", "relaxed"]).optional(),
+    restrictTo: cspDomainSetSchema.optional(),
+    deny: cspDomainSetSchema.optional(),
+    extensions: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+export const mcpProfileSchema = z
+  .object({
+    profileVersion: z.literal(1),
+    initialize: z
+      .object({
+        supportedProtocolVersions: z.array(z.string()).optional(),
+        clientInfo: z.record(z.string(), z.unknown()).optional(),
+      })
+      .passthrough()
+      .optional(),
+    apps: z
+      .object({
+        sandbox: z
+          .object({
+            csp: sandboxCspSchema.optional(),
+            permissions: z.record(z.string(), z.unknown()).optional(),
+          })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
+    extensions: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
+export type McpProfilePayload = z.infer<typeof mcpProfileSchema>;

--- a/mcpjam-inspector/server/utils/__tests__/widget-csp-policy.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/widget-csp-policy.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { resolveWidgetCspPolicy } from "../widget-csp-policy.js";
+
+describe("resolveWidgetCspPolicy", () => {
+  it("preserves legacy buildCspHeader output when mcpProfile is undefined", () => {
+    const result = resolveWidgetCspPolicy({
+      cspMode: "permissive",
+      widgetCsp: null,
+      sandboxCspPolicy: undefined,
+      hostedMode: false,
+    });
+    // Permissive mode emits the broad allowlist.
+    expect(result.connectDomains).toContain("https:");
+    expect(result.headerString).toContain("connect-src");
+    expect(result.headerString).toContain("frame-ancestors");
+  });
+
+  it("preserves widget-declared output when mcpProfile is undefined", () => {
+    const result = resolveWidgetCspPolicy({
+      cspMode: "widget-declared",
+      widgetCsp: {
+        connect_domains: ["https://api.example.com"],
+        resource_domains: ["https://cdn.example.com"],
+        frame_domains: [],
+      },
+      sandboxCspPolicy: undefined,
+      hostedMode: false,
+    });
+    expect(result.connectDomains).toContain("https://api.example.com");
+    expect(result.resourceDomains).toContain("https://cdn.example.com");
+  });
+
+  it("removes a widget-declared domain via deny.connectDomains", () => {
+    const result = resolveWidgetCspPolicy({
+      cspMode: "widget-declared",
+      widgetCsp: {
+        connect_domains: ["https://api.example.com", "https://evil.com"],
+      },
+      sandboxCspPolicy: {
+        mode: "declared",
+        deny: { connectDomains: ["https://evil.com"] },
+      },
+      hostedMode: false,
+    });
+    expect(result.connectDomains).toContain("https://api.example.com");
+    expect(result.connectDomains).not.toContain("https://evil.com");
+  });
+
+  it("intersects with restrictTo without adding undeclared domains", () => {
+    const result = resolveWidgetCspPolicy({
+      cspMode: "widget-declared",
+      widgetCsp: {
+        connect_domains: ["https://a.example.com", "https://b.example.com"],
+      },
+      sandboxCspPolicy: {
+        mode: "declared",
+        // restrictTo lists a domain the widget never declared — must NOT
+        // appear in the resolved set (intersection, never union).
+        restrictTo: {
+          connectDomains: ["https://a.example.com", "https://undeclared.com"],
+        },
+      },
+      hostedMode: false,
+    });
+    expect(result.connectDomains).toContain("https://a.example.com");
+    expect(result.connectDomains).not.toContain("https://b.example.com");
+    expect(result.connectDomains).not.toContain("https://undeclared.com");
+  });
+
+  it("strips localhost and private-network origins in hosted mode", () => {
+    const result = resolveWidgetCspPolicy({
+      cspMode: "widget-declared",
+      widgetCsp: {
+        connect_domains: [
+          "https://api.example.com",
+          "http://localhost:3000",
+          "http://10.0.0.5",
+        ],
+      },
+      // Trigger the policy path with `mode: "declared"` (no restrictTo/deny).
+      sandboxCspPolicy: { mode: "declared" },
+      hostedMode: true,
+    });
+    expect(result.connectDomains).toContain("https://api.example.com");
+    expect(result.connectDomains).not.toContain("http://localhost:3000");
+    expect(result.connectDomains).not.toContain("http://10.0.0.5");
+  });
+
+  it("strips MCPJam own-origin in hosted mode regardless of widget declaration", () => {
+    const result = resolveWidgetCspPolicy({
+      cspMode: "widget-declared",
+      widgetCsp: {
+        connect_domains: [
+          "https://api.example.com",
+          "https://app.mcpjam.com",
+          "https://mcpjam.com",
+        ],
+      },
+      sandboxCspPolicy: { mode: "declared" },
+      hostedMode: true,
+    });
+    expect(result.connectDomains).not.toContain("https://app.mcpjam.com");
+    expect(result.connectDomains).not.toContain("https://mcpjam.com");
+    expect(result.connectDomains).toContain("https://api.example.com");
+  });
+
+  it("saved mcpProfile overrides the legacy cspMode behavior", () => {
+    // Legacy `permissive` would have produced `https:` etc. With a host
+    // policy applied the resolved domain set should be the widget-declared
+    // intersection, not the legacy permissive set.
+    const result = resolveWidgetCspPolicy({
+      cspMode: "permissive",
+      widgetCsp: {
+        connect_domains: ["https://api.example.com"],
+      },
+      sandboxCspPolicy: { mode: "declared" },
+      hostedMode: false,
+    });
+    expect(result.connectDomains).not.toContain("https:");
+    expect(result.connectDomains).toContain("https://api.example.com");
+  });
+});

--- a/mcpjam-inspector/server/utils/widget-csp-policy.ts
+++ b/mcpjam-inspector/server/utils/widget-csp-policy.ts
@@ -1,0 +1,185 @@
+/**
+ * Server-side CSP adapter for ChatGPT Apps widget routes.
+ *
+ * Combines the legacy `cspMode` / `openai/widgetCSP` inputs with the
+ * host-config `mcpProfile.apps.sandbox.csp` slice. When no host policy is
+ * declared the function falls back to `buildCspHeader` exactly as today —
+ * preserving widget-derived behavior for users who haven't opted in.
+ *
+ * When a host policy IS declared, the widget-declared CSP is routed through
+ * the shared `resolveSandboxCsp` resolver (mode → restrictTo intersect →
+ * deny subtract → hosted clamp), and the resolved domain sets are assembled
+ * directly into a CSP header — we do NOT re-route through `buildCspHeader`
+ * because that helper unconditionally folds in localhost/wildcard sources
+ * that the resolver stripped on purpose (specifically the hosted clamp).
+ *
+ * Mirrors the MCP-Apps renderer's behavior in
+ * `client/.../mcp-apps-renderer.tsx` so advertise and enforce stay in
+ * lockstep across protocols.
+ */
+import {
+  resolveSandboxCsp,
+  type SandboxCspPolicy,
+} from "@mcpjam/sdk";
+import {
+  buildCspHeader,
+  type CspMode,
+  type CspConfig,
+  type WidgetCspMeta,
+} from "./widget-helpers.js";
+
+const DEFAULT_FRAME_ANCESTORS =
+  "frame-ancestors 'self' http://localhost:* http://127.0.0.1:* https://localhost:* https://127.0.0.1:*";
+
+/**
+ * Origins the hosted-mode sandbox clamp must strip from any widget-
+ * declared CSP. Same list the MCP Apps renderer passes into
+ * `resolveSandboxCsp` — keep in sync.
+ */
+const MCPJAM_HOSTED_CLAMP_ORIGINS: ReadonlyArray<string> = [
+  "https://*.mcpjam.com",
+  "https://mcpjam.com",
+];
+
+export interface ResolveWidgetCspArgs {
+  /** Legacy `cspMode` value from the request body. */
+  cspMode: CspMode;
+  /** Widget-declared CSP from `openai/widgetCSP` resource metadata. */
+  widgetCsp?: WidgetCspMeta | null;
+  /** Host-config sandbox CSP slice from `mcpProfile.apps.sandbox.csp`. */
+  sandboxCspPolicy?: SandboxCspPolicy;
+  /** Whether the inspector is running in hosted mode. */
+  hostedMode: boolean;
+  /**
+   * frame-ancestors directive to append. Defaults to the localhost set used
+   * by the legacy `buildCspHeader`.
+   */
+  frameAncestors?: string;
+  /**
+   * Additional origins to strip in hosted mode. Defaults to the MCPJam
+   * own-origin list above; tests may pass `[]` to isolate the clamp.
+   */
+  hostedClampExtraOrigins?: ReadonlyArray<string>;
+}
+
+/**
+ * Resolve the effective CSP for a ChatGPT Apps widget request.
+ *
+ * @returns A `CspConfig` shaped exactly like `buildCspHeader` so existing
+ * route response shapes (`csp.connectDomains`, `csp.headerString`, etc.)
+ * stay unchanged.
+ */
+export function resolveWidgetCspPolicy(
+  args: ResolveWidgetCspArgs,
+): CspConfig {
+  const frameAncestors = args.frameAncestors ?? DEFAULT_FRAME_ANCESTORS;
+  const policyApplies = isPolicyConfigured(args.sandboxCspPolicy);
+
+  // No host policy → preserve historical behavior bit-for-bit. Hosted-mode
+  // hard clamp is implicitly skipped here because today's hosted ChatGPT
+  // flows opt into a host policy via mcpProfile; nothing in the legacy
+  // path expected a same-origin strip.
+  if (!policyApplies) {
+    return buildCspHeader(args.cspMode, args.widgetCsp, { frameAncestors });
+  }
+
+  const widgetMeta = args.widgetCsp ?? {};
+  const resolved = resolveSandboxCsp({
+    resourceCsp: {
+      connectDomains: widgetMeta.connect_domains,
+      resourceDomains: widgetMeta.resource_domains,
+      frameDomains: widgetMeta.frame_domains,
+    },
+    policy: args.sandboxCspPolicy,
+    // "host-default" baseline falls back to the widget declaration so a
+    // user who picks `mode: "host-default"` without a custom baseline gets
+    // the resource's own declaration as the starting set — matches the
+    // renderer's treatment.
+    hostDefaultBaseline: {
+      connectDomains: widgetMeta.connect_domains,
+      resourceDomains: widgetMeta.resource_domains,
+      frameDomains: widgetMeta.frame_domains,
+    },
+    hostedMode: args.hostedMode,
+    hostedClampExtraDeny: args.hostedMode
+      ? buildHostedClampDeny(
+          args.hostedClampExtraOrigins ?? MCPJAM_HOSTED_CLAMP_ORIGINS,
+        )
+      : undefined,
+  });
+
+  const connectDomains = ["'self'", ...resolved.connectDomains];
+  const resourceDomains = [
+    "'self'",
+    "data:",
+    "blob:",
+    ...resolved.resourceDomains,
+  ];
+  const frameDomains = resolved.frameDomains;
+
+  const connectSrc = connectDomains.join(" ");
+  const resourceSrc = resourceDomains.join(" ");
+  const imgSrc = `'self' data: blob: ${resolved.resourceDomains.join(" ")}`.trim();
+  const mediaSrc = imgSrc;
+  const frameSrc =
+    frameDomains.length > 0
+      ? `frame-src ${frameDomains.join(" ")}`
+      : "frame-src 'none'";
+
+  const headerString = [
+    "default-src 'self'",
+    `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${resourceSrc}`,
+    "worker-src 'self' blob:",
+    "child-src 'self' blob:",
+    `style-src 'self' 'unsafe-inline' ${resourceSrc}`,
+    `img-src ${imgSrc}`,
+    `media-src ${mediaSrc}`,
+    `font-src 'self' data: ${resourceSrc}`,
+    `connect-src ${connectSrc}`,
+    frameSrc,
+    frameAncestors,
+  ].join("; ");
+
+  return {
+    // Surfaces the original mode so callers that branch on it stay
+    // unchanged. The resolver's effectiveMode lives in resolved.trace if
+    // ever needed for debug.
+    mode: args.cspMode,
+    connectDomains,
+    resourceDomains,
+    frameDomains,
+    headerString,
+  };
+}
+
+function isPolicyConfigured(policy: SandboxCspPolicy | undefined): boolean {
+  if (!policy) return false;
+  if (policy.mode !== undefined) return true;
+  if (
+    policy.restrictTo &&
+    Object.values(policy.restrictTo).some(
+      (list) => Array.isArray(list) && list.length > 0,
+    )
+  ) {
+    return true;
+  }
+  if (
+    policy.deny &&
+    Object.values(policy.deny).some(
+      (list) => Array.isArray(list) && list.length > 0,
+    )
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function buildHostedClampDeny(origins: ReadonlyArray<string>) {
+  const list = [...origins];
+  return {
+    connectDomains: list,
+    resourceDomains: list,
+    frameDomains: list,
+    baseUriDomains: list,
+  };
+}


### PR DESCRIPTION
## Summary

Implements the HostConfig CSP + capability enforcement plan in two slices:

1. **ChatGPT Apps CSP from `hostConfig.mcpProfile`** — saved sandbox CSP applies to ChatGPT-style widgets in both hosted and local flows. `mcpProfile.apps.sandbox.csp` wins over legacy `cspMode`; `cspMode` remains the fallback when no host policy is set.
2. **Advertise-equals-enforce for MCP Apps** — bridge handlers refuse requests for capabilities the host didn't advertise in `ui/initialize` (tool calls also send `tool-cancelled`).

## Changes

### Server CSP adapter
- New `server/utils/widget-csp-policy.ts`: routes legacy `cspMode` / `openai/widgetCSP` through `resolveSandboxCsp` when a host policy is configured; falls back to `buildCspHeader` otherwise. In hosted mode, passes a non-overridable extra-deny for `https://*.mcpjam.com` and `https://mcpjam.com`.
- The resolver output is assembled directly into a CSP header — not re-routed through `buildCspHeader` — so localhost/wildcard sources stripped by the hosted clamp don't get re-added.

### Routes
- Hosted `/api/web/apps/chatgpt-apps/widget-content`: optional `mcpProfile` accepted via a permissive zod schema (validates `profileVersion: 1`, passes other fields through).
- Local `/widget/store` persists `mcpProfile`; `/widget-html/:toolId` and `/widget-content/:toolId` read it back so they resolve the same CSP policy. Malformed `profileVersion` returns 400.

### Client
- ChatGPT widget loaders forward `mcpProfile` to both hosted + local routes; `undefined` is preserved exactly (no `{ profileVersion: 1 }` synthesis).
- `ChatGPTAppRenderer` reads `useActiveMcpProfile()`, computes a stable profile key, includes it in the widget-load effect deps and CSP-debug reset, and regenerates blob URLs / local widget URLs on profile change.

### MCP Apps capability enforcement
- `mcp-apps-renderer.tsx` gates `ui/open-link`, `ui/message`, `ui/update-model-context`, `tools/call`, resource read/list/templates, and logging on the corresponding `effectiveHostCapabilities` fields. Missing capability → clear unsupported-capability error; tool calls also emit `tool-cancelled`. Logging is dropped locally without surfacing as supported.

### Tests
- `server/utils/__tests__/widget-csp-policy.test.ts` (7 tests): `undefined` profile preserves legacy output; `deny` removes domains; `restrictTo` intersects; hosted mode strips localhost/private/MCPJam origins; saved profile overrides legacy mode.
- `client/.../mcp-apps-renderer.test.tsx` (+3 tests): advertised `{}` denies every gated handler (tools/call also sends tool-cancelled, logging is dropped silently); single-capability override allows only that handler; flipping `hostCapabilitiesOverride` rebuilds the bridge with the new contract.

## Test plan

- [x] `npm run test -w @mcpjam/inspector -- server/utils/__tests__/widget-csp-policy.test.ts` — 7/7 pass
- [x] `npm run test -w @mcpjam/inspector -- client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx` — 35/35 pass
- [x] `npm run test -w @mcpjam/inspector -- client/src/components/chat-v2/thread/__tests__/chatgpt-app-renderer.test.tsx` — 2/2 pass
- [x] `npm run typecheck:client -w @mcpjam/inspector` — clean
- [x] `npm run build:server -w @mcpjam/inspector` — clean
- [x] Related server route + host-config tests — 149/149 pass

https://claude.ai/code/session_01NxnPLJWN5AfDwnR3MXz6FH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxnPLJWN5AfDwnR3MXz6FH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CSP resolution and enforcement for widget sandboxes (including hosted-mode clamping) and starts rejecting MCP app requests based on advertised capabilities, which could break existing widgets or tests if expectations differ.
> 
> **Overview**
> ChatGPT widget loading now forwards an optional `mcpProfile` envelope through both hosted and local flows, persists it with stored widget state, and triggers widget reload/debug resets when the active profile changes via a stable JSON key.
> 
> Server-side widget routes switch CSP generation to a new `resolveWidgetCspPolicy` adapter that preserves legacy `cspMode` behavior when no profile policy is present, but otherwise applies `mcpProfile.apps.sandbox.csp` (including hosted-mode clamps) while keeping the response shape compatible; hosted routes validate `mcpProfile` via a new permissive Zod schema.
> 
> MCP Apps bridge handlers now *advertise == enforce*: `openLinks`, `message`, `updateModelContext`, `serverTools` (also emits `tool-cancelled`), `serverResources`, and `logging` are refused/dropped when not advertised, with new unit tests covering the gating and bridge rebuild behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68d39ac6cc120e9ec96bff7f14b10775848610cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->