### PR TITLE
feat(billing): surface pending and failed credit top-ups

### DIFF
--- a/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from "@mcpjam/design-system/card";
 import { Progress } from "@mcpjam/design-system/progress";
 import { Skeleton } from "@mcpjam/design-system/skeleton";
 import { CreditTopupDialog } from "@/components/billing/CreditTopupDialog";
+import { PendingCreditTopupsBanner } from "@/components/billing/PendingCreditTopupsBanner";
 import { TopupActionButton } from "@/components/billing/TopupActionButton";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { useCreditBalance } from "@/hooks/useCreditBalance";
@@ -89,6 +90,10 @@ export function CreditBalanceCard({
             <TopupActionButton onClick={handleManualTopup} />
           </ErrorBoundary>
         </div>
+
+        <ErrorBoundary fallback={null}>
+          <PendingCreditTopupsBanner />
+        </ErrorBoundary>
 
         <UsageRow
           label="Daily limit"

--- a/mcpjam-inspector/client/src/components/billing/PendingCreditTopupsBanner.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PendingCreditTopupsBanner.tsx
@@ -1,0 +1,107 @@
+import { useMemo } from "react";
+import { Clock, CircleAlert } from "lucide-react";
+import { usePendingCreditTopups } from "@/hooks/usePendingCreditTopups";
+import type { PendingCreditTopup } from "@/hooks/usePendingCreditTopups";
+
+const formatUsd = (cents: number): string => {
+  const dollars = cents / 100;
+  return Number.isInteger(dollars) ? `$${dollars}` : `$${dollars.toFixed(2)}`;
+};
+
+/**
+ * Renders a small notice for any in-flight or recently-failed credit top-up.
+ *
+ * Backed by the server's `billing/pendingCreditTopups:listForCurrentUser`
+ * query: a row is written when Stripe Checkout completes with an *unpaid*
+ * payment_status (delayed payment methods like ACH/SEPA), flipped to
+ * `failed` if the payment is rejected, and deleted once credits actually
+ * land. Renders nothing for the common instant-card path because the
+ * webhook never writes a row in that case.
+ */
+export function PendingCreditTopupsBanner() {
+  const { pending, failed } = usePendingCreditTopups();
+
+  const pendingTotalCents = useMemo(
+    () => (pending ?? []).reduce((sum, t) => sum + t.amountCents, 0),
+    [pending],
+  );
+
+  if (!pending && !failed) return null;
+
+  const hasPending = (pending?.length ?? 0) > 0;
+  const hasFailed = (failed?.length ?? 0) > 0;
+  if (!hasPending && !hasFailed) return null;
+
+  return (
+    <div
+      className="flex flex-col gap-2"
+      data-testid="pending-credit-topups-banner"
+    >
+      {hasPending && (
+        <PendingNotice
+          totalAmountCents={pendingTotalCents}
+          count={pending?.length ?? 0}
+        />
+      )}
+      {hasFailed &&
+        (failed ?? []).map((topup) => (
+          <FailedNotice key={topup.id} topup={topup} />
+        ))}
+    </div>
+  );
+}
+
+interface PendingNoticeProps {
+  totalAmountCents: number;
+  count: number;
+}
+
+function PendingNotice({ totalAmountCents, count }: PendingNoticeProps) {
+  const amountLabel = formatUsd(totalAmountCents);
+  const headline =
+    count === 1
+      ? `Top-up of ${amountLabel} is pending`
+      : `${count} top-ups (${amountLabel} total) are pending`;
+  return (
+    <div
+      role="status"
+      data-testid="pending-credit-topups-pending"
+      className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100"
+    >
+      <Clock className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+      <div className="space-y-0.5">
+        <p className="font-medium">{headline}</p>
+        <p className="text-amber-800/80 dark:text-amber-200/80">
+          Bank transfers usually take 1–5 business days to clear. Credits land
+          automatically once your payment settles.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+interface FailedNoticeProps {
+  topup: PendingCreditTopup;
+}
+
+function FailedNotice({ topup }: FailedNoticeProps) {
+  return (
+    <div
+      role="alert"
+      data-testid="pending-credit-topups-failed"
+      data-session-id={topup.stripeSessionId}
+      className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive dark:border-destructive/60"
+    >
+      <CircleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+      <div className="space-y-0.5">
+        <p className="font-medium">
+          Top-up of {formatUsd(topup.amountCents)} could not be completed
+        </p>
+        <p className="text-destructive/80">
+          Your payment was declined or returned. No credits were granted —
+          please try again with a different payment method.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/PendingCreditTopupsBanner.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PendingCreditTopupsBanner.tsx
@@ -8,16 +8,7 @@ const formatUsd = (cents: number): string => {
   return Number.isInteger(dollars) ? `$${dollars}` : `$${dollars.toFixed(2)}`;
 };
 
-/**
- * Renders a small notice for any in-flight or recently-failed credit top-up.
- *
- * Backed by the server's `billing/pendingCreditTopups:listForCurrentUser`
- * query: a row is written when Stripe Checkout completes with an *unpaid*
- * payment_status (delayed payment methods like ACH/SEPA), flipped to
- * `failed` if the payment is rejected, and deleted once credits actually
- * land. Renders nothing for the common instant-card path because the
- * webhook never writes a row in that case.
- */
+/** Renders a small notice for any in-flight or recently-failed credit top-up. */
 export function PendingCreditTopupsBanner() {
   const { pending, failed } = usePendingCreditTopups();
 
@@ -89,7 +80,6 @@ function FailedNotice({ topup }: FailedNoticeProps) {
     <div
       role="alert"
       data-testid="pending-credit-topups-failed"
-      data-session-id={topup.stripeSessionId}
       className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive dark:border-destructive/60"
     >
       <CircleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
@@ -38,6 +38,12 @@ vi.mock("@/components/billing/TopupActionButton", () => ({
   ),
 }));
 
+// Banner has its own dedicated suite — stub here so we don't have to set up
+// the underlying Convex/auth hooks for every CreditBalanceCard test.
+vi.mock("@/components/billing/PendingCreditTopupsBanner", () => ({
+  PendingCreditTopupsBanner: () => null,
+}));
+
 describe("CreditBalanceCard", () => {
   beforeEach(() => {
     balanceState = {

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PendingCreditTopupsBanner.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PendingCreditTopupsBanner.test.tsx
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { PendingCreditTopupsBanner } from "../PendingCreditTopupsBanner";
+import type {
+  PendingCreditTopup,
+  UsePendingCreditTopupsResult,
+} from "@/hooks/usePendingCreditTopups";
+
+let hookState: UsePendingCreditTopupsResult = {
+  topups: undefined,
+  pending: undefined,
+  failed: undefined,
+  isLoading: true,
+  isAuthenticated: false,
+};
+
+vi.mock("@/hooks/usePendingCreditTopups", () => ({
+  usePendingCreditTopups: () => hookState,
+}));
+
+function makeTopup(
+  overrides: Partial<PendingCreditTopup> & { id: string },
+): PendingCreditTopup {
+  return {
+    id: overrides.id,
+    stripeSessionId: overrides.stripeSessionId ?? `cs_${overrides.id}`,
+    amountCents: overrides.amountCents ?? 1000,
+    status: overrides.status ?? "pending",
+    createdAt: overrides.createdAt ?? Date.now(),
+    updatedAt: overrides.updatedAt ?? Date.now(),
+  };
+}
+
+describe("PendingCreditTopupsBanner", () => {
+  beforeEach(() => {
+    hookState = {
+      topups: undefined,
+      pending: undefined,
+      failed: undefined,
+      isLoading: true,
+      isAuthenticated: false,
+    };
+  });
+
+  it("renders nothing while the query is loading (no flash of empty UI)", () => {
+    const { container } = render(<PendingCreditTopupsBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when there are no pending or failed top-ups", () => {
+    hookState = {
+      topups: [],
+      pending: [],
+      failed: [],
+      isLoading: false,
+      isAuthenticated: true,
+    };
+    const { container } = render(<PendingCreditTopupsBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a single pending notice with the dollar amount", () => {
+    const pending = [makeTopup({ id: "p1", amountCents: 1000 })];
+    hookState = {
+      topups: pending,
+      pending,
+      failed: [],
+      isLoading: false,
+      isAuthenticated: true,
+    };
+    render(<PendingCreditTopupsBanner />);
+
+    const notice = screen.getByTestId("pending-credit-topups-pending");
+    expect(notice).toHaveTextContent(/Top-up of \$10 is pending/);
+    expect(notice).toHaveTextContent(/1–5 business days/);
+  });
+
+  it("aggregates multiple pending top-ups into one notice with a total", () => {
+    const pending = [
+      makeTopup({ id: "p1", amountCents: 500 }),
+      makeTopup({ id: "p2", amountCents: 2500 }),
+    ];
+    hookState = {
+      topups: pending,
+      pending,
+      failed: [],
+      isLoading: false,
+      isAuthenticated: true,
+    };
+    render(<PendingCreditTopupsBanner />);
+
+    const notice = screen.getByTestId("pending-credit-topups-pending");
+    expect(notice).toHaveTextContent(/2 top-ups \(\$30 total\) are pending/);
+  });
+
+  it("renders a failed notice per failed top-up", () => {
+    const failed = [
+      makeTopup({ id: "f1", amountCents: 1000, status: "failed" }),
+      makeTopup({ id: "f2", amountCents: 2000, status: "failed" }),
+    ];
+    hookState = {
+      topups: failed,
+      pending: [],
+      failed,
+      isLoading: false,
+      isAuthenticated: true,
+    };
+    render(<PendingCreditTopupsBanner />);
+
+    const failedNotices = screen.getAllByTestId("pending-credit-topups-failed");
+    expect(failedNotices).toHaveLength(2);
+    expect(failedNotices[0]).toHaveTextContent(
+      /Top-up of \$10 could not be completed/,
+    );
+    expect(failedNotices[1]).toHaveTextContent(
+      /Top-up of \$20 could not be completed/,
+    );
+  });
+
+  it("renders both pending and failed notices when both exist", () => {
+    const pending = [makeTopup({ id: "p1", amountCents: 1000 })];
+    const failed = [
+      makeTopup({ id: "f1", amountCents: 500, status: "failed" }),
+    ];
+    hookState = {
+      topups: [...pending, ...failed],
+      pending,
+      failed,
+      isLoading: false,
+      isAuthenticated: true,
+    };
+    render(<PendingCreditTopupsBanner />);
+
+    expect(
+      screen.getByTestId("pending-credit-topups-pending"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("pending-credit-topups-failed"),
+    ).toBeInTheDocument();
+  });
+
+  it("never surfaces the take-rate-derived credited amount", () => {
+    // Regression guard mirroring the backend wire-rule: the banner reads
+    // only `amountCents`. Even if a future server change accidentally
+    // shipped `creditedCents` and the loose-shape normalizer kept it, it
+    // must never render here.
+    const pending = [makeTopup({ id: "p1", amountCents: 1000 })];
+    hookState = {
+      topups: pending,
+      pending,
+      failed: [],
+      isLoading: false,
+      isAuthenticated: true,
+    };
+    render(<PendingCreditTopupsBanner />);
+    const notice = screen.getByTestId("pending-credit-topups-pending");
+    // The only dollar value should be $10. No $9.45, $9.50, etc. that could
+    // hint at the post-take-rate credited amount.
+    const matches = notice.textContent?.match(/\$\d+(\.\d+)?/g) ?? [];
+    expect(matches).toEqual(["$10"]);
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/usePendingCreditTopups.ts
+++ b/mcpjam-inspector/client/src/hooks/usePendingCreditTopups.ts
@@ -1,0 +1,117 @@
+import { useAuth } from "@workos-inc/authkit-react";
+import { useConvexAuth, useQuery } from "convex/react";
+import { useMemo } from "react";
+
+export type PendingCreditTopupStatus = "pending" | "failed";
+
+export interface PendingCreditTopup {
+  id: string;
+  stripeSessionId: string;
+  amountCents: number;
+  status: PendingCreditTopupStatus;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface RawPendingTopup {
+  id?: unknown;
+  stripeSessionId?: unknown;
+  amountCents?: unknown;
+  status?: unknown;
+  createdAt?: unknown;
+  updatedAt?: unknown;
+}
+
+const isValidStatus = (value: unknown): value is PendingCreditTopupStatus =>
+  value === "pending" || value === "failed";
+
+const normalizePending = (
+  raw: unknown,
+): PendingCreditTopup[] | undefined => {
+  // Accept either a bare array or `{ items: [...] }`. Matches the loose-shape
+  // convention used by useCreditTopup / useCreditBalance so the backend can
+  // evolve without forcing a coordinated inspector PR.
+  let items: unknown = raw;
+  if (
+    raw &&
+    typeof raw === "object" &&
+    !Array.isArray(raw) &&
+    "items" in raw
+  ) {
+    items = (raw as { items?: unknown }).items;
+  }
+  if (!Array.isArray(items)) return undefined;
+
+  const out: PendingCreditTopup[] = [];
+  for (const item of items as RawPendingTopup[]) {
+    if (
+      typeof item?.id !== "string" ||
+      typeof item.stripeSessionId !== "string" ||
+      typeof item.amountCents !== "number" ||
+      !isValidStatus(item.status) ||
+      typeof item.createdAt !== "number" ||
+      typeof item.updatedAt !== "number"
+    ) {
+      continue;
+    }
+    out.push({
+      id: item.id,
+      stripeSessionId: item.stripeSessionId,
+      amountCents: item.amountCents,
+      status: item.status,
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+    });
+  }
+  return out;
+};
+
+export interface UsePendingCreditTopupsResult {
+  /** All pending + failed top-ups for the current user, newest first. */
+  topups: PendingCreditTopup[] | undefined;
+  /** Convenience subsets — undefined while loading, else possibly empty. */
+  pending: PendingCreditTopup[] | undefined;
+  failed: PendingCreditTopup[] | undefined;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+}
+
+export function usePendingCreditTopups(): UsePendingCreditTopupsResult {
+  const {
+    isAuthenticated: hasConvexIdentity,
+    isLoading: isConvexAuthLoading,
+  } = useConvexAuth();
+  const { user, isLoading: isWorkOsLoading } = useAuth();
+  const hasWorkOsUser = !!user;
+  const isAuthLoading = isConvexAuthLoading || isWorkOsLoading;
+  const shouldFetch =
+    !isAuthLoading && hasConvexIdentity && hasWorkOsUser;
+
+  const raw = useQuery(
+    "billing/pendingCreditTopups:listForCurrentUser" as any,
+    shouldFetch ? ({} as any) : "skip",
+  ) as unknown | undefined;
+
+  // Stable reference: Convex returns the same object when nothing has
+  // changed, so memoizing on `raw` keeps the normalized array stable too.
+  const topups = useMemo(() => normalizePending(raw), [raw]);
+
+  const pending = useMemo(
+    () => topups?.filter((t) => t.status === "pending"),
+    [topups],
+  );
+  const failed = useMemo(
+    () => topups?.filter((t) => t.status === "failed"),
+    [topups],
+  );
+
+  const isLoading = isAuthLoading || (shouldFetch && raw === undefined);
+
+  return {
+    topups,
+    pending,
+    failed,
+    isLoading,
+    isAuthenticated: hasConvexIdentity,
+  };
+}


### PR DESCRIPTION
## 🪜 TL;DR

Adds a small notice on the billing surface so users paying via a delayed payment method (ACH, SEPA, bank transfer) see *"your payment is pending"* — or *"your payment failed"* — instead of staring at the same balance for several business days while the bank settles.

## 🐛 Problem

When a user pays via a delayed method, credits don't appear immediately. Today the UI gives no signal at all in the meantime.

| State | What the user sees today |
|---|---|
| 🕒 Payment pending | nothing — looks broken |
| ❌ Payment failed | nothing — looks broken |
| ✅ Payment cleared | credits appear (good) |

## ✅ Solution

A small banner on the credit balance card driven by a new server-side state query.

| State | What the user sees |
|---|---|
| 🕒 Payment pending | 🟡 amber notice: *"Top-up of $X is pending — bank transfers usually take 1–5 business days to clear"* |
| ❌ Payment failed | 🔴 alert: *"Top-up of $X could not be completed — please try again with a different payment method"* |
| ✅ Cleared | banner disappears |

## 📝 Changes

- 🆕 `usePendingCreditTopups` hook — loose-shape normalizer matching the existing `useCreditTopup` / `useCreditBalance` pattern. Accepts bare-array or `{items: [...]}` envelopes, skips while auth bootstraps, and renders nothing if the query isn't available.
- 🆕 `PendingCreditTopupsBanner` — aggregated pending notice (single row with summed amount) + one alert per failed top-up.
- 🔌 Wired into `CreditBalanceCard` under an `ErrorBoundary` so a banner crash never takes down the balance card.
- 🧪 7 new banner tests + 1 mock added to the existing `CreditBalanceCard` suite.

## 🔁 Before / after

**Before** ❌

```
┌─────────────────────────────────────┐
│ Credit usage              [Top up]  │
│ Your model credits                  │
│                                     │
│ Daily limit         9% used · 11h   │
│ ▓░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░     │
└─────────────────────────────────────┘
```

(User just paid $30 via bank transfer minutes ago — no signal anywhere.)

**After** ✅

```
┌─────────────────────────────────────────────────────┐
│ Credit usage                            [Top up]    │
│ Your model credits                                  │
│                                                     │
│ 🕒 Top-up of $30 is pending                         │
│    Bank transfers usually take 1–5 business days    │
│    to clear. Credits land automatically once your   │
│    payment settles.                                 │
│                                                     │
│ Daily limit                       9% used · 11h     │
│ ▓░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░     │
└─────────────────────────────────────────────────────┘
```

## ⚠️ Risk register

| Concern | Answer |
|---|---|
| Banner crashes? | `ErrorBoundary` wrap → balance card still renders. |
| Flash of empty UI while loading? | Banner returns `null` until the query resolves. |
| Stale notice showing after credits land? | The notice disappears live via the Convex subscription as soon as the state changes. |
| User has many failed top-ups from a bad card? | Each renders its own alert. Not a problem at realistic volumes; revisit if it becomes one. |

## 🧪 Test plan

- [x] Targeted vitest: 7 new banner tests + 8 existing balance-card tests = 15 passing
- [x] `npm run typecheck:client` clean
- [ ] Manual: trigger a delayed-payment top-up → see pending banner appear → wait for clear / failure → see correct state
- [ ] Manual: instant card top-up → banner should never appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)