### PR TITLE
feat(inspector): named hosts UI — Hosts tab, HostPicker, consumer seeding

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -43,6 +43,9 @@ import { BillingUpsellGate } from "./components/billing/BillingUpsellGate";
 import { OrganizationsTab } from "./components/OrganizationsTab";
 import { SupportTab } from "./components/SupportTab";
 import { RegistryTab } from "./components/RegistryTab";
+import { HostsTab } from "./components/HostsTab";
+import { HostPicker } from "./components/hosts/HostPicker";
+import { useHost } from "./hooks/useHosts";
 import OAuthDebugCallback from "./components/oauth/OAuthDebugCallback";
 import OAuthDesktopReturnNotice from "./components/oauth/OAuthDesktopReturnNotice";
 import { MCPSidebar } from "./components/mcp-sidebar";
@@ -369,6 +372,7 @@ function AppChromeHeader({ hidden, ...props }: AppChromeHeaderProps) {
 
 export default function App() {
   const [activeTab, setActiveTab] = useState("servers");
+  const [chatTabHostId, setChatTabHostId] = useState<string | null>(null);
   const [evalChatHandoff, setEvalChatHandoff] =
     useState<EvalChatHandoff | null>(null);
   const [activeOrganizationSection, setActiveOrganizationSection] =
@@ -396,6 +400,7 @@ export default function App() {
   const learningEnabled = useFeatureFlagEnabled("mcpjam-learning");
   const registryEnabled = useFeatureFlagEnabled("registry-enabled");
   const conformanceEnabled = useFeatureFlagEnabled("mcpjam-conformance");
+  const hostsEnabled = useFeatureFlagEnabled("hosts-enabled");
   const playgroundEnabled = useFeatureFlagEnabled("playground-enabled");
   const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-runs");
   const xaaEnabled = useFeatureFlagEnabled("xaa");
@@ -971,6 +976,10 @@ export default function App() {
     activeProject?.clientConfig
   ) as Record<string, unknown>;
   const convexProjectId = activeProject?.sharedProjectId ?? null;
+  const { host: chatTabHost } = useHost({
+    isAuthenticated: isAuthenticated && hostsEnabled === true,
+    hostId: chatTabHostId,
+  });
   const routeScopedOrganizationId = hasRouteOrganization
     ? currentHashRoute.organizationId ?? null
     : null;
@@ -1586,6 +1595,8 @@ export default function App() {
         )} plan. Upgrade the organization to continue.`
       );
       applyNavigation("servers", { updateHash: true });
+    } else if (activeTab === "hosts" && (hostsEnabled !== true || !isAuthenticated)) {
+      applyNavigation("servers", { updateHash: true });
     } else if (activeTab === "registry" && registryEnabled !== true) {
       applyNavigation("servers", { updateHash: true });
     } else if (
@@ -1602,6 +1613,7 @@ export default function App() {
     }
   }, [
     conformanceEnabled,
+    hostsEnabled,
     registryEnabled,
     learningEnabled,
     evaluateRunsFlagsLoaded,
@@ -2049,6 +2061,12 @@ export default function App() {
               onSaveClientConfig={handleUpdateClientConfig}
             />
           )}
+          {activeTab === "hosts" && hostsEnabled === true && isAuthenticated && (
+            <HostsTab
+              projectId={convexProjectId}
+              isAuthenticated={isAuthenticated}
+            />
+          )}
           {activeTab === "registry" && registryEnabled === true && (
             <RegistryTab
               projectId={convexProjectId}
@@ -2300,31 +2318,57 @@ export default function App() {
             </ErrorBoundary>
           )}
           {activeTab === "chat-v2" && (
-            <HostStyledChatTabV2
-              connectedOrConnectingServerConfigs={
-                connectedOrConnectingServerConfigs
-              }
-              selectedServerNames={appState.selectedMultipleServers}
-              allServerConfigs={projectServers}
-              onServerToggle={toggleServerSelection}
-              onReconnectServer={handleReconnect}
-              onAddServer={handleConnect}
-              onSelectedServerNamesChange={setSelectedMCPConfigs}
-              enableMultiModelChat
-              showHostStyleSelector
-              // Active project default `mcpProfile`. Mounting the provider
-              // here is the in-inspector counterpart to ChatboxChatPage's
-              // hosted mount — without it, MCPAppsRenderer reads
-              // `undefined` from useActiveMcpProfile() and skips the
-              // sandbox-policy resolver entirely.
-              activeMcpProfile={activeMcpProfile}
-              evalChatHandoff={evalChatHandoff}
-              onEvalChatHandoffConsumed={(id) =>
-                setEvalChatHandoff((current) =>
-                  current?.id === id ? null : current
-                )
-              }
-            />
+            <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
+              {hostsEnabled === true && isAuthenticated && convexProjectId && (
+                <div className="flex shrink-0 items-center gap-2 border-b px-4 py-2">
+                  <span className="text-xs text-muted-foreground">Host:</span>
+                  <div className="w-48">
+                    <HostPicker
+                      projectId={convexProjectId}
+                      value={chatTabHostId}
+                      onChange={setChatTabHostId}
+                      placeholder="Project default"
+                      noneLabel="Project default"
+                    />
+                  </div>
+                </div>
+              )}
+              <HostStyledChatTabV2
+                connectedOrConnectingServerConfigs={
+                  connectedOrConnectingServerConfigs
+                }
+                selectedServerNames={appState.selectedMultipleServers}
+                allServerConfigs={projectServers}
+                onServerToggle={toggleServerSelection}
+                onReconnectServer={handleReconnect}
+                onAddServer={handleConnect}
+                onSelectedServerNamesChange={setSelectedMCPConfigs}
+                enableMultiModelChat
+                showHostStyleSelector
+                executionConfig={
+                  chatTabHost
+                    ? {
+                        modelId: chatTabHost.config.modelId,
+                        systemPrompt: chatTabHost.config.systemPrompt,
+                        temperature: chatTabHost.config.temperature,
+                        requireToolApproval: chatTabHost.config.requireToolApproval,
+                      }
+                    : undefined
+                }
+                // Active project default `mcpProfile`. Mounting the provider
+                // here is the in-inspector counterpart to ChatboxChatPage's
+                // hosted mount — without it, MCPAppsRenderer reads
+                // `undefined` from useActiveMcpProfile() and skips the
+                // sandbox-policy resolver entirely.
+                activeMcpProfile={chatTabHost?.config.mcpProfile ?? activeMcpProfile}
+                evalChatHandoff={evalChatHandoff}
+                onEvalChatHandoffConsumed={(id) =>
+                  setEvalChatHandoff((current) =>
+                    current?.id === id ? null : current
+                  )
+                }
+              />
+            </div>
           )}
           {activeTab === "tracing" && <TracingTab />}
           {activeTab === "app-builder" && (

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -416,6 +416,10 @@ export default function App() {
   } = useAuth();
   const { isAuthenticated, isLoading: isAuthLoading } = useConvexAuth();
   const actorKey = useActorKey();
+  const { host: chatTabHost } = useHost({
+    isAuthenticated: isAuthenticated && hostsEnabled === true,
+    hostId: chatTabHostId,
+  });
   const currentUser = useQuery(
     "users:getCurrentUser" as any,
     isAuthenticated ? ({} as any) : "skip"
@@ -802,6 +806,7 @@ export default function App() {
     routeOrganizationId: hasRouteOrganization
       ? currentHashRoute.organizationId
       : undefined,
+    activeHostConfig: chatTabHost?.config,
   });
   useInspectorCommandBus();
   // One-time migration from legacy localStorage state to Convex. No-op in
@@ -979,10 +984,20 @@ export default function App() {
     activeProject?.clientConfig
   ) as Record<string, unknown>;
   const convexProjectId = activeProject?.sharedProjectId ?? null;
-  const { host: chatTabHost } = useHost({
-    isAuthenticated: isAuthenticated && hostsEnabled === true,
-    hostId: chatTabHostId,
-  });
+  // chatTabHostId/hostsTabSelectedHostId are project-scoped — drop them when
+  // the active project, auth, or feature flag changes so host-derived config
+  // can't bleed across projects (e.g. switching to project B while a project-A
+  // host is still selected in the Chat tab picker).
+  useEffect(() => {
+    if (!hostsEnabled || !isAuthenticated || !convexProjectId) {
+      setChatTabHostId(null);
+      setHostsTabSelectedHostId(null);
+    }
+  }, [hostsEnabled, isAuthenticated, convexProjectId]);
+  useEffect(() => {
+    setChatTabHostId(null);
+    setHostsTabSelectedHostId(null);
+  }, [convexProjectId]);
   const routeScopedOrganizationId = hasRouteOrganization
     ? currentHashRoute.organizationId ?? null
     : null;

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -373,6 +373,9 @@ function AppChromeHeader({ hidden, ...props }: AppChromeHeaderProps) {
 export default function App() {
   const [activeTab, setActiveTab] = useState("servers");
   const [chatTabHostId, setChatTabHostId] = useState<string | null>(null);
+  const [hostsTabSelectedHostId, setHostsTabSelectedHostId] = useState<
+    string | null
+  >(null);
   const [evalChatHandoff, setEvalChatHandoff] =
     useState<EvalChatHandoff | null>(null);
   const [activeOrganizationSection, setActiveOrganizationSection] =
@@ -2036,37 +2039,46 @@ export default function App() {
             </div>
           ) : null}
           {/* Content Areas */}
-          {activeTab === "servers" && (
-            <ServersTab
-              projectServers={projectServers}
-              onConnect={handleConnect}
-              onDisconnect={handleDisconnect}
-              onReconnect={handleReconnect}
-              onUpdate={handleUpdate}
-              onRemove={handleRemoveServer}
-              projects={projects}
-              activeProjectId={activeProjectId}
-              organizationId={activeProjectBillingOrganizationId}
-              pendingDashboardOAuth={pendingDashboardOAuth}
-              isBillingContextPending={isBillingContextPending}
-              isLoadingProjects={isLoadingRemoteProjects}
-              onProjectShared={handleProjectShared}
-              onLeaveProject={() => handleLeaveProject(activeProjectId)}
-              isRegistryEnabled={registryEnabled === true}
-              onNavigateToRegistry={
-                registryEnabled === true
-                  ? () => handleNavigate("registry")
-                  : undefined
-              }
-              onSaveClientConfig={handleUpdateClientConfig}
-            />
-          )}
-          {activeTab === "hosts" && hostsEnabled === true && isAuthenticated && (
-            <HostsTab
-              projectId={convexProjectId}
-              isAuthenticated={isAuthenticated}
-            />
-          )}
+          {(activeTab === "servers" ||
+            (activeTab === "hosts" &&
+              hostsEnabled === true &&
+              isAuthenticated)) && (() => {
+            const serversTabElement = (
+              <ServersTab
+                projectServers={projectServers}
+                onConnect={handleConnect}
+                onDisconnect={handleDisconnect}
+                onReconnect={handleReconnect}
+                onUpdate={handleUpdate}
+                onRemove={handleRemoveServer}
+                projects={projects}
+                activeProjectId={activeProjectId}
+                organizationId={activeProjectBillingOrganizationId}
+                pendingDashboardOAuth={pendingDashboardOAuth}
+                isBillingContextPending={isBillingContextPending}
+                isLoadingProjects={isLoadingRemoteProjects}
+                onProjectShared={handleProjectShared}
+                onLeaveProject={() => handleLeaveProject(activeProjectId)}
+                isRegistryEnabled={registryEnabled === true}
+                onNavigateToRegistry={
+                  registryEnabled === true
+                    ? () => handleNavigate("registry")
+                    : undefined
+                }
+                onSaveClientConfig={handleUpdateClientConfig}
+              />
+            );
+            if (activeTab === "servers") return serversTabElement;
+            return (
+              <HostsTab
+                projectId={convexProjectId}
+                isAuthenticated={isAuthenticated}
+                selectedHostId={hostsTabSelectedHostId}
+                onSelectHost={setHostsTabSelectedHostId}
+                serversTabElement={serversTabElement}
+              />
+            );
+          })()}
           {activeTab === "registry" && registryEnabled === true && (
             <RegistryTab
               projectId={convexProjectId}

--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -27,7 +27,8 @@ import {
   PlaygroundSuitesExecutionsTabs,
   type PlaygroundProjectBrowse,
 } from "./evals/playground-suites-executions-tabs";
-import { CreateSuiteDialog } from "./evals/create-suite-dialog";
+import { CreateSuiteDialog, type CreateSuitePayload } from "./evals/create-suite-dialog";
+import { useFeatureFlagEnabled } from "posthog-js/react";
 import { SuiteExecutionsOverview } from "./evals/suite-executions-overview";
 import { usePlaygroundProjectExecutions } from "./evals/use-playground-project-executions";
 import type { EvalIteration } from "./evals/types";
@@ -61,6 +62,7 @@ export function EvalsTab({
   const { isAuthenticated, isLoading } = useConvexAuth();
   const convex = useConvex();
   const { user, getAccessToken } = useAuth();
+  const hostsEnabled = useFeatureFlagEnabled("hosts-enabled") === true && isAuthenticated;
   const route = useEvalsRoute();
   const [projectBrowse, setProjectBrowse] =
     useState<PlaygroundProjectBrowse>("suites");
@@ -359,11 +361,7 @@ export function EvalsTab({
   );
 
   const handleCreateSuite = useCallback(
-    async (payload: {
-      name: string;
-      description?: string;
-      selectedServers: string[];
-    }) => {
+    async (payload: CreateSuitePayload) => {
       if (!projectId) {
         return;
       }
@@ -376,6 +374,8 @@ export function EvalsTab({
           environment: {
             servers: payload.selectedServers,
           },
+          ...(payload.namedHostId ? { namedHostId: payload.namedHostId } : {}),
+          ...(payload.hostConfigInput ? { hostConfigInput: payload.hostConfigInput } : {}),
         });
 
         if (!createdSuite?._id) {
@@ -821,6 +821,8 @@ export function EvalsTab({
           projectServers={projectServers}
           connectedServerNames={connectedServerNames}
           onSubmit={handleCreateSuite}
+          hostsEnabled={hostsEnabled}
+          projectId={projectId}
         />
 
         <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">

--- a/mcpjam-inspector/client/src/components/HostsTab.tsx
+++ b/mcpjam-inspector/client/src/components/HostsTab.tsx
@@ -54,6 +54,11 @@ export function HostsTab({
 
   useEffect(() => {
     setPreviewedHostId(projectId ? loadPreviewedHostId(projectId) : null);
+    if (selectedHostId) onSelectHost(null);
+    // selectedHostId/onSelectHost intentionally omitted: this effect resets
+    // host context when the active project changes, not when the selection
+    // changes within the same project.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [projectId]);
 
   const handleChangePreviewedHostId = useCallback(

--- a/mcpjam-inspector/client/src/components/HostsTab.tsx
+++ b/mcpjam-inspector/client/src/components/HostsTab.tsx
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import { HostIndexPage } from "./hosts/HostIndexPage";
+import { HostBuilderView } from "./hosts/HostBuilderView";
+
+interface HostsTabProps {
+  projectId: string | null;
+  isAuthenticated: boolean;
+}
+
+export function HostsTab({ projectId, isAuthenticated }: HostsTabProps) {
+  const [selectedHostId, setSelectedHostId] = useState<string | null>(null);
+
+  if (!projectId) return null;
+
+  if (selectedHostId) {
+    return (
+      <HostBuilderView
+        hostId={selectedHostId}
+        projectId={projectId}
+        onBack={() => setSelectedHostId(null)}
+      />
+    );
+  }
+
+  return (
+    <HostIndexPage
+      projectId={projectId}
+      isAuthenticated={isAuthenticated}
+      onSelectHost={setSelectedHostId}
+    />
+  );
+}

--- a/mcpjam-inspector/client/src/components/HostsTab.tsx
+++ b/mcpjam-inspector/client/src/components/HostsTab.tsx
@@ -1,14 +1,68 @@
-import { useState } from "react";
-import { HostIndexPage } from "./hosts/HostIndexPage";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { HostBuilderView } from "./hosts/HostBuilderView";
+import { HostOverlayBar } from "./hosts/HostOverlayBar";
+
+const PREVIEWED_HOST_STORAGE_KEY = "mcp-previewed-host-id";
+
+function loadPreviewedHostId(projectId: string): string | null {
+  try {
+    const raw = localStorage.getItem(PREVIEWED_HOST_STORAGE_KEY);
+    if (!raw) return null;
+    const all = JSON.parse(raw) as Record<string, string | null>;
+    const value = all[projectId];
+    return typeof value === "string" && value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+function savePreviewedHostId(
+  projectId: string,
+  hostId: string | null,
+): void {
+  try {
+    const raw = localStorage.getItem(PREVIEWED_HOST_STORAGE_KEY);
+    const all = raw ? JSON.parse(raw) : {};
+    if (hostId) {
+      all[projectId] = hostId;
+    } else {
+      delete all[projectId];
+    }
+    localStorage.setItem(PREVIEWED_HOST_STORAGE_KEY, JSON.stringify(all));
+  } catch {
+    // ignore
+  }
+}
 
 interface HostsTabProps {
   projectId: string | null;
   isAuthenticated: boolean;
+  selectedHostId: string | null;
+  onSelectHost: (hostId: string | null) => void;
+  serversTabElement: ReactNode;
 }
 
-export function HostsTab({ projectId, isAuthenticated }: HostsTabProps) {
-  const [selectedHostId, setSelectedHostId] = useState<string | null>(null);
+export function HostsTab({
+  projectId,
+  selectedHostId,
+  onSelectHost,
+  serversTabElement,
+}: HostsTabProps) {
+  const [previewedHostId, setPreviewedHostId] = useState<string | null>(() =>
+    projectId ? loadPreviewedHostId(projectId) : null,
+  );
+
+  useEffect(() => {
+    setPreviewedHostId(projectId ? loadPreviewedHostId(projectId) : null);
+  }, [projectId]);
+
+  const handleChangePreviewedHostId = useCallback(
+    (hostId: string | null) => {
+      setPreviewedHostId(hostId);
+      if (projectId) savePreviewedHostId(projectId, hostId);
+    },
+    [projectId],
+  );
 
   if (!projectId) return null;
 
@@ -17,16 +71,22 @@ export function HostsTab({ projectId, isAuthenticated }: HostsTabProps) {
       <HostBuilderView
         hostId={selectedHostId}
         projectId={projectId}
-        onBack={() => setSelectedHostId(null)}
+        onBack={() => onSelectHost(null)}
       />
     );
   }
 
   return (
-    <HostIndexPage
-      projectId={projectId}
-      isAuthenticated={isAuthenticated}
-      onSelectHost={setSelectedHostId}
-    />
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="shrink-0 px-8 pt-6 pb-3">
+        <HostOverlayBar
+          projectId={projectId}
+          previewedHostId={previewedHostId}
+          onChangePreviewedHostId={handleChangePreviewedHostId}
+          onEditHost={(hostId) => onSelectHost(hostId)}
+        />
+      </div>
+      <div className="min-h-0 flex-1">{serversTabElement}</div>
+    </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-modal.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-modal.tsx
@@ -21,6 +21,8 @@ import type { CallToolResult } from "@modelcontextprotocol/client";
 import type { CspMode } from "@/stores/ui-playground-store";
 import { LoggingTransport } from "./mcp-apps-logging-transport";
 import { fetchMcpAppsWidgetContent } from "./fetch-widget-content";
+import { useActiveMcpProfile } from "@/contexts/active-mcp-profile-context";
+import { resolveHostInfo } from "@/lib/host-config-v2";
 
 // Injected by Vite at build time from package.json
 declare const __APP_VERSION__: string;
@@ -80,6 +82,9 @@ export function McpAppsModal({
   const [modalHtml, setModalHtml] = useState<string | null>(null);
   const modalSandboxRef = useRef<SandboxedIframeHandle>(null);
   const modalBridgeRef = useRef<AppBridge | null>(null);
+  // Same scope as the inline renderer — `ActiveMcpProfileProvider` wraps
+  // both. Used to resolve `hostInfo` for the modal's AppBridge handshake.
+  const activeMcpProfile = useActiveMcpProfile();
   const modalColorScheme =
     hostContextRef.current?.theme === "light" ||
     hostContextRef.current?.theme === "dark"
@@ -140,9 +145,16 @@ export function McpAppsModal({
     const iframe = modalSandboxRef.current?.getIframeElement();
     if (!iframe?.contentWindow) return;
 
+    // Match the inline renderer: ChatGPT-like templates override this
+    // via mcpProfile.apps.uiInitialize.hostInfo. Backend soft-validates
+    // name+version when set, so the cast below is safe.
+    const resolvedHostInfo = (resolveHostInfo(activeMcpProfile) ?? {
+      name: "mcpjam-inspector",
+      version: __APP_VERSION__,
+    }) as { name: string; version: string };
     const bridge = new AppBridge(
       null,
-      { name: "mcpjam-inspector", version: __APP_VERSION__ },
+      resolvedHostInfo,
       {
         openLinks: {},
         serverTools: {},
@@ -247,6 +259,7 @@ export function McpAppsModal({
     hostContextRef,
     toolInputRef,
     toolOutputRef,
+    activeMcpProfile,
   ]);
 
   const handleModalMessage = (event: MessageEvent) => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -80,7 +80,10 @@ import {
   extractHostDisplayModes,
   extractHostTheme,
 } from "@/lib/client-config";
-import { resolveEffectiveHostCapabilities } from "@/lib/host-config-v2";
+import {
+  resolveEffectiveHostCapabilities,
+  resolveHostInfo,
+} from "@/lib/host-config-v2";
 
 // Injected by Vite at build time from package.json
 declare const __APP_VERSION__: string;
@@ -1407,9 +1410,17 @@ export function MCPAppsRenderer({
     // inline used to be the canonical correctness bug: the bridge got the
     // resolved policy while the iframe still got the raw resource
     // declaration, so the browser-enforced CSP didn't honor the host clamp.
+    // Host identity advertised in ui/initialize. Templates that emulate
+    // another host (e.g. ChatGPT) override this via
+    // `mcpProfile.apps.uiInitialize.hostInfo`; backend soft-validates
+    // name+version when set so the cast below is safe.
+    const resolvedHostInfo = (resolveHostInfo(activeMcpProfile) ?? {
+      name: "mcpjam-inspector",
+      version: __APP_VERSION__,
+    }) as { name: string; version: string };
     const bridge = new AppBridge(
       null,
-      { name: "mcpjam-inspector", version: __APP_VERSION__ },
+      resolvedHostInfo,
       {
         ...effectiveHostCapabilities,
         sandbox: {
@@ -1502,14 +1513,17 @@ export function MCPAppsRenderer({
     // Bridge must rebuild when the resolved sandbox policy changes — a host
     // toggling deny rules at runtime needs the new handshake. The memo
     // identity captures `widgetCsp`/`widgetPermissions`/`widgetPermissive`
-    // and the active mcpProfile transitively, so they don't need their own
-    // entries here.
+    // and the sandbox slice of mcpProfile transitively.
     effectiveSandbox,
     logWidgetDebug,
     // Bridge must rebuild when the advertised host capabilities change
     // (host style switch or override edit) so the new handshake reflects
     // the new contract.
     effectiveHostCapabilities,
+    // Bridge must rebuild when the host identity advertised in
+    // ui/initialize changes — switching to a template that overrides
+    // hostInfo (e.g. ChatGPT) is observable to the View.
+    activeMcpProfile,
   ]);
 
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/chatboxes/CreateChatboxDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/CreateChatboxDialog.tsx
@@ -69,6 +69,9 @@ export function CreateChatboxDialog({
   const [requireToolApproval, setRequireToolApproval] = useState(false);
   const [allowGuestAccess, setAllowGuestAccess] = useState(false);
   const [selectedServerIds, setSelectedServerIds] = useState<string[]>([]);
+  const [hostSeededOptionalIds, setHostSeededOptionalIds] = useState<string[]>(
+    [],
+  );
   const [isSaving, setIsSaving] = useState(false);
   const [selectedHostId, setSelectedHostId] = useState<string | null>(null);
   const { host: selectedHost } = useHost({
@@ -108,18 +111,33 @@ export function CreateChatboxDialog({
     setSelectedServerIds(
       chatbox?.servers.map((server) => server.serverId) ?? [],
     );
+    setHostSeededOptionalIds([]);
   }, [hostedModels, isOpen, chatbox]);
 
-  // Seed form from selected host
+  // Seed form from selected host. Chatboxes only support HTTP servers, so
+  // filter the host's server list to ids that exist as HTTP project servers.
+  // De-dupe across serverIds/optionalServerIds (optionalServerIds is a subset
+  // of serverIds per the host config model). Re-runs only when the selected
+  // host identity changes — depending on the full host object would
+  // overwrite user edits on background data refreshes.
   useEffect(() => {
     if (!selectedHost) return;
     const config = selectedHost.config;
+    const allowedHttpIds = new Set(availableServers.map((s) => s._id));
+    const seededIds = Array.from(
+      new Set([...config.serverIds, ...config.optionalServerIds]),
+    ).filter((id) => allowedHttpIds.has(id));
+    const seededOptional = config.optionalServerIds.filter((id) =>
+      allowedHttpIds.has(id),
+    );
     setModelId(config.modelId);
     setSystemPrompt(config.systemPrompt);
     setTemperature(config.temperature);
     setRequireToolApproval(config.requireToolApproval);
-    setSelectedServerIds([...config.serverIds, ...config.optionalServerIds]);
-  }, [selectedHost]);
+    setSelectedServerIds(seededIds);
+    setHostSeededOptionalIds(seededOptional);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedHost?.hostId]);
 
   const handleToggleServer = (serverId: string, checked: boolean) => {
     setSelectedServerIds((current) => {
@@ -150,7 +168,7 @@ export function CreateChatboxDialog({
                 s.optional === true && selectedServerIds.includes(s.serverId),
             )
             .map((s) => s.serverId)
-        : [];
+        : hostSeededOptionalIds.filter((id) => selectedServerIds.includes(id));
 
       const payload = {
         name: trimmedName,
@@ -166,11 +184,9 @@ export function CreateChatboxDialog({
       };
 
       const hostSnapshot =
-        !chatbox && selectedHost
+        !chatbox && selectedHost && selectedHostId
           ? {
-              namedHostId: selectedHost.config
-                ? selectedHostId
-                : undefined,
+              namedHostId: selectedHostId,
               hostConfigInput: hostConfigDtoToInput(selectedHost.config),
             }
           : {};

--- a/mcpjam-inspector/client/src/components/chatboxes/CreateChatboxDialog.tsx
+++ b/mcpjam-inspector/client/src/components/chatboxes/CreateChatboxDialog.tsx
@@ -27,6 +27,10 @@ import { Switch } from "@mcpjam/design-system/switch";
 import { Checkbox } from "@mcpjam/design-system/checkbox";
 import { Label } from "@mcpjam/design-system/label";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
+import { useHost } from "@/hooks/useHosts";
+import { useConvexAuth } from "convex/react";
+import { HostPicker } from "@/components/hosts/HostPicker";
+import { hostConfigDtoToInput } from "@/lib/host-config-v2";
 
 interface ProjectServerOption {
   _id: string;
@@ -41,6 +45,7 @@ interface CreateChatboxDialogProps {
   projectServers: ProjectServerOption[];
   chatbox?: ChatboxSettings | null;
   onSaved?: (chatbox: ChatboxSettings) => void;
+  hostsEnabled?: boolean;
 }
 
 const DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant.";
@@ -52,7 +57,9 @@ export function CreateChatboxDialog({
   projectServers,
   chatbox,
   onSaved,
+  hostsEnabled = false,
 }: CreateChatboxDialogProps) {
+  const { isAuthenticated } = useConvexAuth();
   const { createChatbox, updateChatbox } = useChatboxMutations();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -63,6 +70,11 @@ export function CreateChatboxDialog({
   const [allowGuestAccess, setAllowGuestAccess] = useState(false);
   const [selectedServerIds, setSelectedServerIds] = useState<string[]>([]);
   const [isSaving, setIsSaving] = useState(false);
+  const [selectedHostId, setSelectedHostId] = useState<string | null>(null);
+  const { host: selectedHost } = useHost({
+    isAuthenticated: isAuthenticated && hostsEnabled,
+    hostId: selectedHostId,
+  });
 
   const availableServers = useMemo(
     () => projectServers.filter((server) => server.transportType === "http"),
@@ -81,6 +93,7 @@ export function CreateChatboxDialog({
       return;
     }
 
+    setSelectedHostId(null);
     setName(chatbox?.name ?? "");
     setDescription(chatbox?.description ?? "");
     setSystemPrompt(chatbox?.systemPrompt ?? DEFAULT_SYSTEM_PROMPT);
@@ -96,6 +109,17 @@ export function CreateChatboxDialog({
       chatbox?.servers.map((server) => server.serverId) ?? [],
     );
   }, [hostedModels, isOpen, chatbox]);
+
+  // Seed form from selected host
+  useEffect(() => {
+    if (!selectedHost) return;
+    const config = selectedHost.config;
+    setModelId(config.modelId);
+    setSystemPrompt(config.systemPrompt);
+    setTemperature(config.temperature);
+    setRequireToolApproval(config.requireToolApproval);
+    setSelectedServerIds([...config.serverIds, ...config.optionalServerIds]);
+  }, [selectedHost]);
 
   const handleToggleServer = (serverId: string, checked: boolean) => {
     setSelectedServerIds((current) => {
@@ -141,6 +165,16 @@ export function CreateChatboxDialog({
         optionalServerIds,
       };
 
+      const hostSnapshot =
+        !chatbox && selectedHost
+          ? {
+              namedHostId: selectedHost.config
+                ? selectedHostId
+                : undefined,
+              hostConfigInput: hostConfigDtoToInput(selectedHost.config),
+            }
+          : {};
+
       const next = (
         chatbox
           ? await updateChatbox({
@@ -150,6 +184,7 @@ export function CreateChatboxDialog({
           : await createChatbox({
               projectId,
               ...payload,
+              ...hostSnapshot,
             })
       ) as ChatboxSettings;
 
@@ -177,6 +212,26 @@ export function CreateChatboxDialog({
         </DialogHeader>
 
         <div className="space-y-5">
+          {hostsEnabled && !chatbox && (
+            <div className="grid gap-2">
+              <Label>Seed from host (optional)</Label>
+              <HostPicker
+                projectId={projectId}
+                value={selectedHostId}
+                onChange={setSelectedHostId}
+                placeholder="Choose a host to pre-fill settings"
+                includeNone={false}
+                noneLabel="No host"
+              />
+              {selectedHostId && (
+                <p className="text-xs text-muted-foreground">
+                  Model, prompt, and servers pre-filled from host. You can
+                  still adjust them below.
+                </p>
+              )}
+            </div>
+          )}
+
           <div className="grid gap-2">
             <Label htmlFor="chatbox-name">Name</Label>
             <Input

--- a/mcpjam-inspector/client/src/components/evals/create-suite-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/evals/create-suite-dialog.tsx
@@ -64,17 +64,25 @@ export function CreateSuiteDialog({
     }
   }, [open]);
 
-  // Seed server selection from selected host
+  // Seed server selection from selected host. Includes optional servers too
+  // (optionalServerIds is a subset of serverIds per the host config model;
+  // we de-dupe defensively in case the host pre-dates that invariant).
+  // Re-runs only when the host selection changes — depending on
+  // projectServers would clobber user edits on background refreshes.
   useEffect(() => {
     if (!selectedHost) return;
-    const serverNames = selectedHost.config.serverIds
-      .map((id) => {
-        const found = projectServers.find((s) => s._id === id);
-        return found?.name ?? null;
-      })
+    const ids = Array.from(
+      new Set([
+        ...selectedHost.config.serverIds,
+        ...selectedHost.config.optionalServerIds,
+      ]),
+    );
+    const serverNames = ids
+      .map((id) => projectServers.find((s) => s._id === id)?.name ?? null)
       .filter((n): n is string => n !== null);
     setSelectedServers(serverNames);
-  }, [selectedHost, projectServers]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedHost?.hostId]);
 
   const options = useMemo(
     () =>

--- a/mcpjam-inspector/client/src/components/evals/create-suite-dialog.tsx
+++ b/mcpjam-inspector/client/src/components/evals/create-suite-dialog.tsx
@@ -5,22 +5,33 @@ import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import { Textarea } from "@mcpjam/design-system/textarea";
 import { Checkbox } from "@mcpjam/design-system/checkbox";
+import { Label } from "@mcpjam/design-system/label";
 import {
   buildSuiteEnvironmentOptions,
   normalizeServerNames,
   type ProjectServerRecord,
 } from "./suite-environment-utils";
+import { useHost } from "@/hooks/useHosts";
+import { useConvexAuth } from "convex/react";
+import { HostPicker } from "@/components/hosts/HostPicker";
+import { hostConfigDtoToInput } from "@/lib/host-config-v2";
+
+export type CreateSuitePayload = {
+  name: string;
+  description?: string;
+  selectedServers: string[];
+  namedHostId?: string;
+  hostConfigInput?: ReturnType<typeof hostConfigDtoToInput>;
+};
 
 type CreateSuiteDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   projectServers: ProjectServerRecord[];
   connectedServerNames: ReadonlySet<string>;
-  onSubmit: (payload: {
-    name: string;
-    description?: string;
-    selectedServers: string[];
-  }) => Promise<void>;
+  onSubmit: (payload: CreateSuitePayload) => Promise<void>;
+  hostsEnabled?: boolean;
+  projectId?: string | null;
 };
 
 export function CreateSuiteDialog({
@@ -29,11 +40,19 @@ export function CreateSuiteDialog({
   projectServers,
   connectedServerNames,
   onSubmit,
+  hostsEnabled = false,
+  projectId = null,
 }: CreateSuiteDialogProps) {
+  const { isAuthenticated } = useConvexAuth();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [selectedServers, setSelectedServers] = useState<string[]>([]);
   const [isSaving, setIsSaving] = useState(false);
+  const [selectedHostId, setSelectedHostId] = useState<string | null>(null);
+  const { host: selectedHost } = useHost({
+    isAuthenticated: isAuthenticated && hostsEnabled,
+    hostId: selectedHostId,
+  });
 
   useEffect(() => {
     if (!open) {
@@ -41,8 +60,21 @@ export function CreateSuiteDialog({
       setDescription("");
       setSelectedServers([]);
       setIsSaving(false);
+      setSelectedHostId(null);
     }
   }, [open]);
+
+  // Seed server selection from selected host
+  useEffect(() => {
+    if (!selectedHost) return;
+    const serverNames = selectedHost.config.serverIds
+      .map((id) => {
+        const found = projectServers.find((s) => s._id === id);
+        return found?.name ?? null;
+      })
+      .filter((n): n is string => n !== null);
+    setSelectedServers(serverNames);
+  }, [selectedHost, projectServers]);
 
   const options = useMemo(
     () =>
@@ -76,6 +108,12 @@ export function CreateSuiteDialog({
         name: name.trim(),
         description: description.trim() || undefined,
         selectedServers: normalizeServerNames(selectedServers),
+        ...(selectedHost && selectedHostId
+          ? {
+              namedHostId: selectedHostId,
+              hostConfigInput: hostConfigDtoToInput(selectedHost.config),
+            }
+          : {}),
       });
     } catch {
       // onSubmit surfaces its own error toast; keep the dialog open so the
@@ -97,6 +135,26 @@ export function CreateSuiteDialog({
         </DialogHeader>
 
         <div className="space-y-5">
+          {hostsEnabled && projectId && (
+            <div className="grid gap-2">
+              <Label>Seed from host (optional)</Label>
+              <HostPicker
+                projectId={projectId}
+                value={selectedHostId}
+                onChange={setSelectedHostId}
+                placeholder="Choose a host to pre-fill servers"
+                includeNone={false}
+                noneLabel="No host"
+              />
+              {selectedHostId && (
+                <p className="text-xs text-muted-foreground">
+                  Server selection pre-filled from host. You can still adjust it
+                  below.
+                </p>
+              )}
+            </div>
+          )}
+
           <div className="grid gap-2">
             <label className="text-sm font-medium text-foreground">
               Suite name

--- a/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/host-config/HostConfigEditor.tsx
@@ -56,7 +56,8 @@ export type HostConfigEditorOwner =
   | "project-default"
   | "chatbox"
   | "eval-suite"
-  | "connection-only";
+  | "connection-only"
+  | "host";
 
 export interface HostConfigEditorProps {
   value: HostConfigInputV2;
@@ -136,8 +137,10 @@ export function HostConfigEditor({
   // editor surface for owner="eval-suite" therefore hides the server
   // picker entirely (and ignores `availableServers`) so users can't
   // type changes the backend would reject.
+  // For owner="host", server selection is managed via the canvas in
+  // HostBuilderView — hiding it here prevents double-entry confusion.
   const showServersSection =
-    owner !== "connection-only" && owner !== "eval-suite";
+    owner !== "connection-only" && owner !== "eval-suite" && owner !== "host";
 
   const hostStyleOptions = useMemo(() => listHostStyles(), []);
 

--- a/mcpjam-inspector/client/src/components/hosts/CreateHostDialog.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/CreateHostDialog.tsx
@@ -12,7 +12,13 @@ import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import { Label } from "@mcpjam/design-system/label";
 import { useHostMutations } from "@/hooks/useHosts";
-import { emptyHostConfigInputV2 } from "@/lib/host-config-v2";
+import {
+  DEFAULT_HOST_TEMPLATE_ID,
+  HOST_TEMPLATES,
+  seedFromHostTemplate,
+  type HostTemplateId,
+} from "@/lib/host-templates";
+import { cn } from "@/lib/utils";
 
 interface CreateHostDialogProps {
   isOpen: boolean;
@@ -29,10 +35,14 @@ export function CreateHostDialog({
 }: CreateHostDialogProps) {
   const { createHost } = useHostMutations();
   const [name, setName] = useState("");
+  const [selectedTemplateId, setSelectedTemplateId] = useState<HostTemplateId>(
+    DEFAULT_HOST_TEMPLATE_ID,
+  );
   const [isSaving, setIsSaving] = useState(false);
 
   const handleClose = () => {
     setName("");
+    setSelectedTemplateId(DEFAULT_HOST_TEMPLATE_ID);
     onClose();
   };
 
@@ -44,7 +54,7 @@ export function CreateHostDialog({
       const { hostId } = await createHost({
         projectId,
         name: trimmed,
-        input: emptyHostConfigInputV2(),
+        input: seedFromHostTemplate(selectedTemplateId),
       });
       toast.success(`Host "${trimmed}" created`);
       handleClose();
@@ -58,20 +68,58 @@ export function CreateHostDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>New Host</DialogTitle>
         </DialogHeader>
-        <div className="flex flex-col gap-3 py-2">
-          <Label htmlFor="host-name">Name</Label>
-          <Input
-            id="host-name"
-            placeholder="My Host"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && handleCreate()}
-            autoFocus
-          />
+        <div className="flex flex-col gap-4 py-2">
+          <div className="flex flex-col gap-2">
+            <Label>Start from</Label>
+            <div className="grid grid-cols-3 gap-2">
+              {HOST_TEMPLATES.map((template) => {
+                const isSelected = template.id === selectedTemplateId;
+                return (
+                  <button
+                    key={template.id}
+                    type="button"
+                    onClick={() => setSelectedTemplateId(template.id)}
+                    className={cn(
+                      "flex flex-col items-start gap-2 rounded-md border p-3 text-left transition-colors",
+                      isSelected
+                        ? "border-primary ring-2 ring-primary/30 bg-accent"
+                        : "border-border hover:bg-accent/50",
+                    )}
+                    aria-pressed={isSelected}
+                  >
+                    <img
+                      src={template.logoSrc}
+                      alt=""
+                      className="h-6 w-6 object-contain"
+                    />
+                    <div className="flex flex-col gap-0.5">
+                      <span className="text-sm font-medium leading-none">
+                        {template.label}
+                      </span>
+                      <span className="text-xs text-muted-foreground leading-snug">
+                        {template.description}
+                      </span>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="host-name">Name</Label>
+            <Input
+              id="host-name"
+              placeholder="My Host"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+              autoFocus
+            />
+          </div>
         </div>
         <DialogFooter>
           <Button variant="outline" onClick={handleClose} disabled={isSaving}>

--- a/mcpjam-inspector/client/src/components/hosts/CreateHostDialog.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/CreateHostDialog.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@mcpjam/design-system/dialog";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import { Label } from "@mcpjam/design-system/label";
+import { useHostMutations } from "@/hooks/useHosts";
+import { emptyHostConfigInputV2 } from "@/lib/host-config-v2";
+
+interface CreateHostDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  projectId: string;
+  onCreated: (hostId: string) => void;
+}
+
+export function CreateHostDialog({
+  isOpen,
+  onClose,
+  projectId,
+  onCreated,
+}: CreateHostDialogProps) {
+  const { createHost } = useHostMutations();
+  const [name, setName] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleClose = () => {
+    setName("");
+    onClose();
+  };
+
+  const handleCreate = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setIsSaving(true);
+    try {
+      const { hostId } = await createHost({
+        projectId,
+        name: trimmed,
+        input: emptyHostConfigInputV2(),
+      });
+      toast.success(`Host "${trimmed}" created`);
+      handleClose();
+      onCreated(hostId);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to create host");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>New Host</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col gap-3 py-2">
+          <Label htmlFor="host-name">Name</Label>
+          <Input
+            id="host-name"
+            placeholder="My Host"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+            autoFocus
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose} disabled={isSaving}>
+            Cancel
+          </Button>
+          <Button onClick={handleCreate} disabled={!name.trim() || isSaving}>
+            {isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Create
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/HostBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostBuilderView.tsx
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ArrowLeft, Loader2, Save, Server } from "lucide-react";
+import { toast } from "sonner";
+import { useConvexAuth } from "convex/react";
+import { Button } from "@mcpjam/design-system/button";
+import { Input } from "@mcpjam/design-system/input";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import { HostConfigEditor } from "@/components/host-config/HostConfigEditor";
+import { useHost, useHostMutations } from "@/hooks/useHosts";
+import { useProjectServers } from "@/hooks/useProjects";
+import {
+  hostConfigDtoToInput,
+  hostConfigInputsEqual,
+  serverConnectionOverridesEqual,
+  type HostConfigInputV2,
+} from "@/lib/host-config-v2";
+import { Skeleton } from "@mcpjam/design-system/skeleton";
+import { AddServerModal } from "@/components/connection/AddServerModal";
+import { useServerMutations } from "@/hooks/useProjects";
+import type { ServerFormData } from "@/shared/types";
+import { getBillingErrorMessage } from "@/lib/billing-entitlements";
+import { ServerConnectionOverrideSection } from "./ServerConnectionOverrideSection";
+
+interface HostBuilderViewProps {
+  hostId: string;
+  projectId: string;
+  onBack: () => void;
+}
+
+export function HostBuilderView({ hostId, projectId, onBack }: HostBuilderViewProps) {
+  const { isAuthenticated } = useConvexAuth();
+  const { host, isLoading: hostLoading } = useHost({ isAuthenticated, hostId });
+  const { servers } = useProjectServers({ projectId, isAuthenticated });
+  const { updateHost } = useHostMutations();
+  const { createServer } = useServerMutations();
+
+  const [draftName, setDraftName] = useState("");
+  const [draftConfig, setDraftConfig] = useState<HostConfigInputV2 | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [hasError, setHasError] = useState(false);
+  const [showAddServer, setShowAddServer] = useState(false);
+
+  useEffect(() => {
+    if (!host) return;
+    setDraftName(host.name);
+    setDraftConfig(hostConfigDtoToInput(host.config));
+  }, [host]);
+
+  const savedConfig = useMemo(
+    () => (host ? hostConfigDtoToInput(host.config) : null),
+    [host],
+  );
+
+  const isDirty = useMemo(() => {
+    if (!host || !draftConfig || !savedConfig) return false;
+    return (
+      draftName !== host.name ||
+      !hostConfigInputsEqual(draftConfig, savedConfig) ||
+      !serverConnectionOverridesEqual(
+        draftConfig.serverConnectionOverrides,
+        savedConfig.serverConnectionOverrides,
+      )
+    );
+  }, [host, draftName, draftConfig, savedConfig]);
+
+  const handleSave = useCallback(async () => {
+    if (!draftConfig) return;
+    setIsSaving(true);
+    try {
+      await updateHost({ hostId, name: draftName, input: draftConfig });
+      toast.success("Host saved");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to save host");
+    } finally {
+      setIsSaving(false);
+    }
+  }, [hostId, draftName, draftConfig, updateHost]);
+
+  const handleAddServer = useCallback(
+    async (formData: ServerFormData) => {
+      try {
+        const serverId = (await createServer({
+          projectId,
+          name: formData.name,
+          enabled: true,
+          transportType: formData.type === "stdio" ? "stdio" : "http",
+          url: formData.url,
+          headers: formData.headers,
+          timeout: formData.requestTimeout,
+          useOAuth: formData.useOAuth,
+          oauthScopes: formData.oauthScopes,
+          clientId: formData.clientId,
+        })) as string;
+        // auto-select newly added server
+        setDraftConfig((prev) =>
+          prev
+            ? { ...prev, serverIds: [...(prev.serverIds ?? []), serverId] }
+            : prev,
+        );
+        toast.success(`Server "${formData.name}" added`);
+      } catch (err) {
+        toast.error(getBillingErrorMessage(err, "Failed to add server"));
+      }
+    },
+    [createServer, projectId],
+  );
+
+  if (hostLoading || !draftConfig) {
+    return (
+      <div className="flex flex-col gap-4 p-6">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  const availableServers =
+    servers?.map((s) => ({ id: s._id, name: s.name })) ?? [];
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="flex shrink-0 items-center gap-3 border-b px-4 py-3">
+        <Button variant="ghost" size="icon" onClick={onBack} className="h-8 w-8">
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <Input
+          className="h-8 max-w-xs border-transparent bg-transparent text-base font-semibold shadow-none focus-visible:border-input focus-visible:bg-background"
+          value={draftName}
+          onChange={(e) => setDraftName(e.target.value)}
+          placeholder="Host name"
+        />
+        <div className="flex-1" />
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={!isDirty || isSaving || hasError}
+        >
+          {isSaving ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Save className="mr-2 h-4 w-4" />
+          )}
+          Save
+        </Button>
+      </div>
+
+      {/* Body */}
+      <ResizablePanelGroup direction="horizontal" className="flex-1 overflow-hidden">
+        {/* Left: server list + overrides */}
+        <ResizablePanel defaultSize={50} minSize={30}>
+          <div className="flex h-full flex-col overflow-y-auto p-4 gap-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-sm font-semibold">Servers</h2>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => setShowAddServer(true)}
+              >
+                <Server className="mr-2 h-4 w-4" />
+                Add Server
+              </Button>
+            </div>
+            <ServerConnectionOverrideSection
+              serverIds={draftConfig.serverIds ?? []}
+              optionalServerIds={draftConfig.optionalServerIds ?? []}
+              projectServers={availableServers}
+              overrides={draftConfig.serverConnectionOverrides ?? {}}
+              onChange={(overrides) =>
+                setDraftConfig((prev) =>
+                  prev ? { ...prev, serverConnectionOverrides: overrides } : prev,
+                )
+              }
+              onServerSelectionChange={(serverIds, optionalServerIds) =>
+                setDraftConfig((prev) =>
+                  prev ? { ...prev, serverIds, optionalServerIds } : prev,
+                )
+              }
+            />
+          </div>
+        </ResizablePanel>
+
+        <ResizableHandle withHandle />
+
+        {/* Right: config editor */}
+        <ResizablePanel defaultSize={50} minSize={30}>
+          <div className="h-full overflow-y-auto p-4">
+            <HostConfigEditor
+              value={draftConfig}
+              onChange={(next) => setDraftConfig(next)}
+              owner="host"
+              availableServers={availableServers}
+              onValidityChange={setHasError}
+            />
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+
+      {showAddServer && (
+        <AddServerModal
+          isOpen={showAddServer}
+          onClose={() => setShowAddServer(false)}
+          onSubmit={handleAddServer}
+        />
+      )}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/HostBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostBuilderView.tsx
@@ -55,14 +55,14 @@ function HostBuilderChrome({
   const saveDisabled = !canSave;
   const saveLabel = isDirty ? "Save changes" : "Save";
   return (
-    <div className="shrink-0 border-b border-border/70 px-6 py-3">
-      <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] md:items-center md:gap-x-4 md:gap-y-0">
-        <div className="order-1 flex min-w-0 items-center gap-3">
+    <div className="shrink-0 border-b border-border/40 px-8 py-2.5">
+      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+        <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
           <Button
             type="button"
             variant="ghost"
             size="icon"
-            className="size-8 shrink-0 rounded-xl"
+            className="size-8 shrink-0 text-muted-foreground hover:text-foreground"
             onClick={onBack}
             aria-label="Return to hosts"
             title="Return to hosts"
@@ -70,26 +70,29 @@ function HostBuilderChrome({
             <ArrowLeft className="size-4" aria-hidden />
           </Button>
           <Input
-            className="h-9 max-w-md border-transparent bg-transparent text-xl font-semibold shadow-none focus-visible:border-input focus-visible:bg-background"
+            className="h-8 min-w-0 max-w-md flex-1 border-0 bg-transparent px-1 text-base font-semibold tracking-tight shadow-none placeholder:text-muted-foreground focus-visible:border-transparent focus-visible:bg-muted/40 focus-visible:ring-2 focus-visible:ring-ring/45 md:text-base"
             value={draftName}
             onChange={(event) => onDraftNameChange(event.target.value)}
             placeholder="Host name"
           />
         </div>
 
-        <div className="hidden md:block" />
-
-        <div className="order-2 flex flex-wrap items-center justify-end gap-2 md:order-3">
+        <div className="flex shrink-0 items-center gap-2">
           <Button
+            size="sm"
             onClick={onSave}
             disabled={saveDisabled}
-            variant={!isDirty ? "ghost" : "default"}
-            className="rounded-xl"
+            variant={isDirty ? "default" : "ghost"}
+            className={
+              isDirty
+                ? undefined
+                : "text-muted-foreground hover:text-foreground disabled:opacity-40"
+            }
           >
             {isSaving ? (
-              <Loader2 className="mr-1.5 size-4 animate-spin" />
+              <Loader2 className="size-4 animate-spin" />
             ) : (
-              <Save className="mr-1.5 size-4" />
+              <Save className="size-4" />
             )}
             {saveLabel}
           </Button>

--- a/mcpjam-inspector/client/src/components/hosts/HostBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostBuilderView.tsx
@@ -1,29 +1,33 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { ArrowLeft, Loader2, Save, Server } from "lucide-react";
+import { ArrowLeft, Loader2, Save } from "lucide-react";
 import { toast } from "sonner";
 import { useConvexAuth } from "convex/react";
+import { ReactFlowProvider } from "@xyflow/react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
+import { Skeleton } from "@mcpjam/design-system/skeleton";
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
-import { HostConfigEditor } from "@/components/host-config/HostConfigEditor";
 import { useHost, useHostMutations } from "@/hooks/useHosts";
-import { useProjectServers } from "@/hooks/useProjects";
+import { useProjectServers, useServerMutations } from "@/hooks/useProjects";
 import {
   hostConfigDtoToInput,
   hostConfigInputsEqual,
   serverConnectionOverridesEqual,
   type HostConfigInputV2,
 } from "@/lib/host-config-v2";
-import { Skeleton } from "@mcpjam/design-system/skeleton";
 import { AddServerModal } from "@/components/connection/AddServerModal";
-import { useServerMutations } from "@/hooks/useProjects";
 import type { ServerFormData } from "@/shared/types";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
-import { ServerConnectionOverrideSection } from "./ServerConnectionOverrideSection";
+import { buildHostCanvas } from "./hostCanvasBuilder";
+import { HostCanvas } from "./HostCanvas";
+import {
+  HostSetupChecklistPanel,
+} from "./HostSetupChecklistPanel";
+import type { HostSetupSectionId } from "./host-builder-types";
 
 interface HostBuilderViewProps {
   hostId: string;
@@ -31,7 +35,75 @@ interface HostBuilderViewProps {
   onBack: () => void;
 }
 
-export function HostBuilderView({ hostId, projectId, onBack }: HostBuilderViewProps) {
+function HostBuilderChrome({
+  draftName,
+  onDraftNameChange,
+  isDirty,
+  isSaving,
+  canSave,
+  onBack,
+  onSave,
+}: {
+  draftName: string;
+  onDraftNameChange: (value: string) => void;
+  isDirty: boolean;
+  isSaving: boolean;
+  canSave: boolean;
+  onBack: () => void;
+  onSave: () => void;
+}) {
+  const saveDisabled = !canSave;
+  const saveLabel = isDirty ? "Save changes" : "Save";
+  return (
+    <div className="shrink-0 border-b border-border/70 px-6 py-3">
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] md:items-center md:gap-x-4 md:gap-y-0">
+        <div className="order-1 flex min-w-0 items-center gap-3">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="size-8 shrink-0 rounded-xl"
+            onClick={onBack}
+            aria-label="Return to hosts"
+            title="Return to hosts"
+          >
+            <ArrowLeft className="size-4" aria-hidden />
+          </Button>
+          <Input
+            className="h-9 max-w-md border-transparent bg-transparent text-xl font-semibold shadow-none focus-visible:border-input focus-visible:bg-background"
+            value={draftName}
+            onChange={(event) => onDraftNameChange(event.target.value)}
+            placeholder="Host name"
+          />
+        </div>
+
+        <div className="hidden md:block" />
+
+        <div className="order-2 flex flex-wrap items-center justify-end gap-2 md:order-3">
+          <Button
+            onClick={onSave}
+            disabled={saveDisabled}
+            variant={!isDirty ? "ghost" : "default"}
+            className="rounded-xl"
+          >
+            {isSaving ? (
+              <Loader2 className="mr-1.5 size-4 animate-spin" />
+            ) : (
+              <Save className="mr-1.5 size-4" />
+            )}
+            {saveLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function HostBuilderView({
+  hostId,
+  projectId,
+  onBack,
+}: HostBuilderViewProps) {
   const { isAuthenticated } = useConvexAuth();
   const { host, isLoading: hostLoading } = useHost({ isAuthenticated, hostId });
   const { servers } = useProjectServers({ projectId, isAuthenticated });
@@ -39,11 +111,17 @@ export function HostBuilderView({ hostId, projectId, onBack }: HostBuilderViewPr
   const { createServer } = useServerMutations();
 
   const [draftName, setDraftName] = useState("");
-  const [draftConfig, setDraftConfig] = useState<HostConfigInputV2 | null>(null);
+  const [draftConfig, setDraftConfig] = useState<HostConfigInputV2 | null>(
+    null,
+  );
   const [isSaving, setIsSaving] = useState(false);
   const [hasError, setHasError] = useState(false);
   const [showAddServer, setShowAddServer] = useState(false);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>("host");
+  const [focusedSetupSection, setFocusedSetupSection] =
+    useState<HostSetupSectionId | null>(null);
 
+  // Seed draft state from the loaded host.
   useEffect(() => {
     if (!host) return;
     setDraftName(host.name);
@@ -66,6 +144,60 @@ export function HostBuilderView({ hostId, projectId, onBack }: HostBuilderViewPr
       )
     );
   }, [host, draftName, draftConfig, savedConfig]);
+
+  const availableServers = useMemo(
+    () => servers?.map((s) => ({ id: s._id, name: s.name })) ?? [],
+    [servers],
+  );
+
+  const availableServersForCanvas = useMemo(
+    () =>
+      servers?.map((s) => ({
+        id: s._id,
+        name: s.name,
+        url: s.url ?? undefined,
+      })) ?? [],
+    [servers],
+  );
+
+  const viewModel = useMemo(
+    () =>
+      buildHostCanvas({
+        hostName: draftName,
+        draft:
+          draftConfig ??
+          ({
+            hostStyle: "claude",
+            modelId: "",
+            systemPrompt: "",
+            temperature: 0.7,
+            requireToolApproval: false,
+            serverIds: [],
+            optionalServerIds: [],
+            connectionDefaults: { headers: {}, requestTimeout: 30000 },
+            clientCapabilities: {},
+            hostContext: {},
+          } as HostConfigInputV2),
+        projectServers: availableServersForCanvas,
+      }),
+    [draftName, draftConfig, availableServersForCanvas],
+  );
+
+  const handleSelectNode = useCallback((nodeId: string) => {
+    if (nodeId === "host") {
+      setSelectedNodeId("host");
+      setFocusedSetupSection("basics");
+      return;
+    }
+    if (nodeId.startsWith("server:")) {
+      setSelectedNodeId(nodeId);
+      setFocusedSetupSection("servers");
+      return;
+    }
+    if (nodeId === "add-server") {
+      setShowAddServer(true);
+    }
+  }, []);
 
   const handleSave = useCallback(async () => {
     if (!draftConfig) return;
@@ -95,12 +227,13 @@ export function HostBuilderView({ hostId, projectId, onBack }: HostBuilderViewPr
           oauthScopes: formData.oauthScopes,
           clientId: formData.clientId,
         })) as string;
-        // auto-select newly added server
         setDraftConfig((prev) =>
           prev
             ? { ...prev, serverIds: [...(prev.serverIds ?? []), serverId] }
             : prev,
         );
+        setSelectedNodeId(`server:${serverId}`);
+        setFocusedSetupSection("servers");
         toast.success(`Server "${formData.name}" added`);
       } catch (err) {
         toast.error(getBillingErrorMessage(err, "Failed to add server"));
@@ -119,87 +252,54 @@ export function HostBuilderView({ hostId, projectId, onBack }: HostBuilderViewPr
     );
   }
 
-  const availableServers =
-    servers?.map((s) => ({ id: s._id, name: s.name })) ?? [];
+  const canSave = isDirty && !isSaving && !hasError;
 
   return (
-    <div className="flex h-full flex-col">
-      {/* Header */}
-      <div className="flex shrink-0 items-center gap-3 border-b px-4 py-3">
-        <Button variant="ghost" size="icon" onClick={onBack} className="h-8 w-8">
-          <ArrowLeft className="h-4 w-4" />
-        </Button>
-        <Input
-          className="h-8 max-w-xs border-transparent bg-transparent text-base font-semibold shadow-none focus-visible:border-input focus-visible:bg-background"
-          value={draftName}
-          onChange={(e) => setDraftName(e.target.value)}
-          placeholder="Host name"
-        />
-        <div className="flex-1" />
-        <Button
-          size="sm"
-          onClick={handleSave}
-          disabled={!isDirty || isSaving || hasError}
-        >
-          {isSaving ? (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-          ) : (
-            <Save className="mr-2 h-4 w-4" />
-          )}
-          Save
-        </Button>
-      </div>
+    <div className="flex h-full min-h-0 flex-col">
+      <HostBuilderChrome
+        draftName={draftName}
+        onDraftNameChange={setDraftName}
+        isDirty={isDirty}
+        isSaving={isSaving}
+        canSave={canSave}
+        onBack={onBack}
+        onSave={() => void handleSave()}
+      />
 
-      {/* Body */}
-      <ResizablePanelGroup direction="horizontal" className="flex-1 overflow-hidden">
-        {/* Left: server list + overrides */}
-        <ResizablePanel defaultSize={50} minSize={30}>
-          <div className="flex h-full flex-col overflow-y-auto p-4 gap-4">
-            <div className="flex items-center justify-between">
-              <h2 className="text-sm font-semibold">Servers</h2>
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => setShowAddServer(true)}
-              >
-                <Server className="mr-2 h-4 w-4" />
-                Add Server
-              </Button>
+      <div className="relative min-h-0 flex-1 p-4">
+        <ResizablePanelGroup direction="horizontal" className="h-full">
+          <ResizablePanel defaultSize={50} minSize={30}>
+            <div className="h-full min-h-0 pr-2">
+              <ReactFlowProvider>
+                <HostCanvas
+                  viewModel={viewModel}
+                  selectedNodeId={selectedNodeId}
+                  onSelectNode={handleSelectNode}
+                  onClearSelection={() => setSelectedNodeId(null)}
+                  onAddServer={() => setShowAddServer(true)}
+                />
+              </ReactFlowProvider>
             </div>
-            <ServerConnectionOverrideSection
-              serverIds={draftConfig.serverIds ?? []}
-              optionalServerIds={draftConfig.optionalServerIds ?? []}
-              projectServers={availableServers}
-              overrides={draftConfig.serverConnectionOverrides ?? {}}
-              onChange={(overrides) =>
-                setDraftConfig((prev) =>
-                  prev ? { ...prev, serverConnectionOverrides: overrides } : prev,
-                )
-              }
-              onServerSelectionChange={(serverIds, optionalServerIds) =>
-                setDraftConfig((prev) =>
-                  prev ? { ...prev, serverIds, optionalServerIds } : prev,
-                )
-              }
-            />
-          </div>
-        </ResizablePanel>
+          </ResizablePanel>
 
-        <ResizableHandle withHandle />
+          <ResizableHandle withHandle />
 
-        {/* Right: config editor */}
-        <ResizablePanel defaultSize={50} minSize={30}>
-          <div className="h-full overflow-y-auto p-4">
-            <HostConfigEditor
-              value={draftConfig}
-              onChange={(next) => setDraftConfig(next)}
-              owner="host"
-              availableServers={availableServers}
-              onValidityChange={setHasError}
-            />
-          </div>
-        </ResizablePanel>
-      </ResizablePanelGroup>
+          <ResizablePanel defaultSize={50} minSize={30}>
+            <div className="flex h-full min-h-0 flex-col border-l border-border/70">
+              <HostSetupChecklistPanel
+                draft={draftConfig}
+                onDraftChange={(updater) =>
+                  setDraftConfig((prev) => (prev ? updater(prev) : prev))
+                }
+                availableServers={availableServers}
+                focusedSection={focusedSetupSection}
+                onValidityChange={setHasError}
+                onOpenAddServer={() => setShowAddServer(true)}
+              />
+            </div>
+          </ResizablePanel>
+        </ResizablePanelGroup>
+      </div>
 
       {showAddServer && (
         <AddServerModal

--- a/mcpjam-inspector/client/src/components/hosts/HostCanvas.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostCanvas.tsx
@@ -1,0 +1,262 @@
+import { memo, useMemo } from "react";
+import {
+  Background,
+  BackgroundVariant,
+  Controls,
+  Handle,
+  Position,
+  ReactFlow,
+  SmoothStepEdge,
+  type EdgeProps,
+  type Node,
+  type NodeProps,
+} from "@xyflow/react";
+import { Plus, Server } from "lucide-react";
+import "@xyflow/react/dist/style.css";
+import { Badge } from "@mcpjam/design-system/badge";
+import { getChatboxHostLogo } from "@/lib/chatbox-host-style";
+import { cn } from "@/lib/utils";
+import type {
+  HostBuilderAddServerNodeData,
+  HostBuilderNodeData,
+  HostBuilderViewModel,
+} from "./host-builder-types";
+
+const CHIP_STYLES = {
+  neutral: "border-border/70 bg-muted/40 text-muted-foreground",
+  success: "border-emerald-600/30 bg-emerald-500/10 text-emerald-700",
+  warning: "border-amber-500/30 bg-amber-500/10 text-amber-700",
+  info: "border-sky-500/30 bg-sky-500/10 text-sky-700",
+} as const;
+
+function stateRing(state: HostBuilderNodeData["state"]) {
+  switch (state) {
+    case "attention":
+      return "ring-amber-400/40";
+    case "ready":
+      return "ring-primary/40";
+    case "draft":
+      return "ring-border/40";
+  }
+}
+
+const handleClass = "!opacity-0 !w-2 !h-2";
+
+const HostNodeRenderer = memo(
+  (props: NodeProps<Node<HostBuilderNodeData, "hostNode">>) => {
+    const { data, selected } = props;
+    const isHostCard = data.kind === "host";
+    const hostStyle = data.hostStyle ?? "claude";
+    const hostLogoSrc = isHostCard ? getChatboxHostLogo(hostStyle) : null;
+
+    return (
+      <div
+        className={cn(
+          "host-builder-card relative w-[280px] overflow-visible rounded-xl border border-border/60 px-3.5 py-3 text-card-foreground transition-all",
+          isHostCard
+            ? "bg-gradient-to-b from-muted/80 to-muted/40 shadow-sm"
+            : "bg-card/90",
+          selected && "ring-2 shadow-xl",
+          stateRing(data.state),
+        )}
+      >
+        {!isHostCard ? (
+          <Handle
+            type="target"
+            position={Position.Top}
+            id="top"
+            className={handleClass}
+          />
+        ) : null}
+
+        {isHostCard ? (
+          <div className="flex gap-3">
+            <div className="flex size-11 shrink-0 items-center justify-center rounded-2xl border border-border/50 bg-background/80 shadow-inner">
+              <img
+                src={hostLogoSrc ?? undefined}
+                alt=""
+                className="size-7 object-contain"
+              />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p
+                className="truncate text-sm font-semibold leading-tight"
+                title={data.subtitle ?? data.title}
+              >
+                {data.subtitle ?? data.title}
+              </p>
+              {data.detailLine ? (
+                <p
+                  className="mt-1.5 text-[11px] text-muted-foreground/90"
+                  title={data.detailLine}
+                >
+                  {data.detailLine}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-muted/40">
+                <Server className="size-3.5" />
+              </div>
+              <div className="min-w-0">
+                <p
+                  className="truncate text-sm font-semibold"
+                  title={data.title}
+                >
+                  {data.title}
+                </p>
+                {data.subtitle ? (
+                  <p
+                    className="mt-1 line-clamp-2 text-xs text-muted-foreground"
+                    title={data.subtitle}
+                  >
+                    {data.subtitle}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {!isHostCard && data.chips.length > 0 ? (
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            {data.chips.map((item) => (
+              <Badge
+                key={`${data.kind}:${item.label}`}
+                variant="outline"
+                className={cn(
+                  "rounded-full text-[10px]",
+                  CHIP_STYLES[item.tone ?? "neutral"],
+                )}
+              >
+                {item.label}
+              </Badge>
+            ))}
+          </div>
+        ) : null}
+
+        {isHostCard ? (
+          <Handle
+            type="source"
+            position={Position.Bottom}
+            id="bottom"
+            className={handleClass}
+          />
+        ) : null}
+      </div>
+    );
+  },
+);
+HostNodeRenderer.displayName = "HostNodeRenderer";
+
+const plusHandleButtonClass =
+  "nodrag nopan pointer-events-auto flex size-9 items-center justify-center rounded-full border border-border/60 bg-card text-muted-foreground shadow-sm transition-colors hover:bg-primary hover:text-primary-foreground hover:border-primary";
+
+const HostAddServerNodeRenderer = memo(
+  (
+    props: NodeProps<
+      Node<HostBuilderAddServerNodeData, "hostAddServerNode">
+    >,
+  ) => {
+    const label = props.data.label || "Add server";
+    return (
+      <div className="flex w-10 items-center justify-center">
+        <button
+          type="button"
+          aria-label={label}
+          className={plusHandleButtonClass}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          <Plus className="size-4" />
+        </button>
+      </div>
+    );
+  },
+);
+HostAddServerNodeRenderer.displayName = "HostAddServerNodeRenderer";
+
+const nodeTypes = {
+  hostNode: HostNodeRenderer,
+  hostAddServerNode: HostAddServerNodeRenderer,
+};
+
+function HostSmoothEdge(props: EdgeProps) {
+  return (
+    <SmoothStepEdge
+      {...props}
+      pathOptions={useMemo(() => ({ borderRadius: 14 }), [])}
+    />
+  );
+}
+
+const edgeTypes = {
+  default: HostSmoothEdge,
+};
+
+interface HostCanvasProps {
+  viewModel: HostBuilderViewModel;
+  selectedNodeId: string | null;
+  onSelectNode: (nodeId: string) => void;
+  onClearSelection: () => void;
+  onAddServer: () => void;
+}
+
+export function HostCanvas({
+  viewModel,
+  selectedNodeId,
+  onSelectNode,
+  onClearSelection,
+  onAddServer,
+}: HostCanvasProps) {
+  const nodes = viewModel.nodes.map((node) =>
+    node.type === "hostNode"
+      ? { ...node, selected: node.id === selectedNodeId }
+      : node,
+  );
+
+  return (
+    <div className="host-builder-grid relative h-full w-full rounded-[28px] border border-border/70 bg-background">
+      <ReactFlow
+        nodes={nodes}
+        edges={viewModel.edges}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        minZoom={0.55}
+        maxZoom={1.35}
+        proOptions={{ hideAttribution: true }}
+        panOnDrag
+        panOnScroll
+        zoomOnScroll
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable
+        fitView
+        fitViewOptions={{ padding: 0.2 }}
+        onNodeClick={(_, node) => {
+          if (node.id === "add-server") {
+            onAddServer();
+            return;
+          }
+          onSelectNode(node.id);
+        }}
+        onPaneClick={onClearSelection}
+      >
+        <Background
+          id="host-builder-dots"
+          variant={BackgroundVariant.Dots}
+          gap={30}
+          size={0.9}
+          color="oklch(0.55 0.02 250 / 0.22)"
+          patternClassName="opacity-[0.4]"
+        />
+        <Controls
+          showInteractive={false}
+          className="!rounded-xl !border !border-border/70 !bg-card/95"
+        />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/HostCard.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostCard.tsx
@@ -1,0 +1,87 @@
+import { MoreVertical, Pencil, Copy, Trash2 } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { CardInteractive } from "@mcpjam/design-system/card";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@mcpjam/design-system/dropdown-menu";
+import type { HostListItem } from "@/hooks/useHosts";
+
+interface HostCardProps {
+  host: HostListItem;
+  onEdit: () => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+  isDuplicating?: boolean;
+  isDeleting?: boolean;
+}
+
+export function HostCard({
+  host,
+  onEdit,
+  onDuplicate,
+  onDelete,
+  isDuplicating = false,
+  isDeleting = false,
+}: HostCardProps) {
+  const serverLabel =
+    host.serverCount === 1
+      ? "1 server"
+      : `${host.serverCount} servers`;
+
+  return (
+    <CardInteractive className="flex flex-col gap-4" onClick={onEdit}>
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="min-w-0 flex-1 truncate text-lg font-bold tracking-tight">
+          {host.name}
+        </h3>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <MoreVertical className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onEdit(); }}>
+              <Pencil className="mr-2 h-4 w-4" />
+              Edit
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={(e) => { e.stopPropagation(); onDuplicate(); }}
+              disabled={isDuplicating}
+            >
+              <Copy className="mr-2 h-4 w-4" />
+              Duplicate
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={(e) => { e.stopPropagation(); onDelete(); }}
+              disabled={isDeleting}
+              className="text-destructive"
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <p className="truncate text-sm text-muted-foreground">
+        {host.modelId} · {serverLabel}
+      </p>
+
+      <p className="text-xs text-muted-foreground">
+        Updated {formatDistanceToNow(host.updatedAt, { addSuffix: true })}
+      </p>
+    </CardInteractive>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/HostIndexPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostIndexPage.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import { Plus, Loader2, Server } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "@mcpjam/design-system/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { useHostList, useHostMutations, type HostListItem } from "@/hooks/useHosts";
+import { HostCard } from "./HostCard";
+import { CreateHostDialog } from "./CreateHostDialog";
+
+interface HostIndexPageProps {
+  projectId: string;
+  isAuthenticated: boolean;
+  onSelectHost: (hostId: string) => void;
+}
+
+export function HostIndexPage({
+  projectId,
+  isAuthenticated,
+  onSelectHost,
+}: HostIndexPageProps) {
+  const { hosts, isLoading } = useHostList({ isAuthenticated, projectId });
+  const { deleteHost, duplicateHost } = useHostMutations();
+  const [showCreate, setShowCreate] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [duplicatingId, setDuplicatingId] = useState<string | null>(null);
+
+  const handleDelete = async (host: HostListItem) => {
+    setDeletingId(host.hostId);
+    try {
+      await deleteHost({ hostId: host.hostId });
+      toast.success(`Host "${host.name}" deleted`);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Failed to delete host";
+      if (msg.includes("consumer")) {
+        toast.error(
+          `${msg} — use force delete or remove dependent chatboxes/evals first`,
+        );
+      } else {
+        toast.error(msg);
+      }
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  const handleDuplicate = async (host: HostListItem) => {
+    setDuplicatingId(host.hostId);
+    try {
+      const { hostId } = await duplicateHost({ hostId: host.hostId });
+      toast.success(`Host duplicated`);
+      onSelectHost(hostId);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to duplicate host");
+    } finally {
+      setDuplicatingId(null);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Hosts</h1>
+          <p className="text-sm text-muted-foreground">
+            Named configurations combining a model, system prompt, and server
+            selection.
+          </p>
+        </div>
+        <Button onClick={() => setShowCreate(true)}>
+          <Plus className="mr-2 h-4 w-4" />
+          New Host
+        </Button>
+      </div>
+
+      {hosts.length === 0 ? (
+        <EmptyState
+          icon={Server}
+          title="No hosts yet"
+          description="Create a named host to reuse across Chat, Chatboxes, and Evals."
+        >
+          <Button onClick={() => setShowCreate(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            New Host
+          </Button>
+        </EmptyState>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {hosts.map((host) => (
+            <HostCard
+              key={host.hostId}
+              host={host}
+              onEdit={() => onSelectHost(host.hostId)}
+              onDuplicate={() => handleDuplicate(host)}
+              onDelete={() => handleDelete(host)}
+              isDuplicating={duplicatingId === host.hostId}
+              isDeleting={deletingId === host.hostId}
+            />
+          ))}
+        </div>
+      )}
+
+      <CreateHostDialog
+        isOpen={showCreate}
+        onClose={() => setShowCreate(false)}
+        projectId={projectId}
+        onCreated={(hostId) => onSelectHost(hostId)}
+      />
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/HostOverlayBar.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostOverlayBar.tsx
@@ -1,0 +1,196 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Pencil, Plus } from "lucide-react";
+import { usePostHog } from "posthog-js/react";
+import { useConvexAuth } from "convex/react";
+import { Button } from "@mcpjam/design-system/button";
+import { Separator } from "@mcpjam/design-system/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
+import { cn } from "@/lib/utils";
+import { useHostList, useHostMutations } from "@/hooks/useHosts";
+import { emptyHostConfigInputV2 } from "@/lib/host-config-v2";
+import { CreateHostDialog } from "./CreateHostDialog";
+
+const MCPJAM_HOST_NAME = "MCPJam";
+
+interface HostOverlayBarProps {
+  projectId: string;
+  previewedHostId: string | null;
+  onChangePreviewedHostId: (hostId: string | null) => void;
+  onEditHost: (hostId: string) => void;
+}
+
+export function HostOverlayBar({
+  projectId,
+  previewedHostId,
+  onChangePreviewedHostId,
+  onEditHost,
+}: HostOverlayBarProps) {
+  const posthog = usePostHog();
+  const { isAuthenticated } = useConvexAuth();
+  const { hosts, isLoading } = useHostList({ isAuthenticated, projectId });
+  const { createHost } = useHostMutations();
+  const [showCreate, setShowCreate] = useState(false);
+
+  const mcpjamHost = useMemo(
+    () => hosts.find((h) => h.name === MCPJAM_HOST_NAME) ?? null,
+    [hosts],
+  );
+
+  // Lazily seed a "MCPJam" host with SDK defaults the first time a project
+  // opens Connect without one. Idempotent: only fires when the list has loaded
+  // and no MCPJam exists yet.
+  const seededRef = useRef(false);
+  useEffect(() => {
+    if (
+      !isAuthenticated ||
+      isLoading ||
+      mcpjamHost != null ||
+      seededRef.current
+    ) {
+      return;
+    }
+    seededRef.current = true;
+    createHost({
+      projectId,
+      name: MCPJAM_HOST_NAME,
+      input: emptyHostConfigInputV2(),
+    }).catch(() => {
+      seededRef.current = false;
+    });
+  }, [isAuthenticated, isLoading, mcpjamHost, projectId, createHost]);
+
+  const validPreviewedHostId =
+    previewedHostId && hosts.some((h) => h.hostId === previewedHostId)
+      ? previewedHostId
+      : null;
+  const effectiveHostId = validPreviewedHostId ?? mcpjamHost?.hostId ?? null;
+
+  // Normalize parent state when the persisted previewedHostId is missing or
+  // stale (deleted host, fresh project). Fires once after MCPJam appears.
+  useEffect(() => {
+    if (isLoading) return;
+    if (effectiveHostId == null) return;
+    if (previewedHostId === effectiveHostId) return;
+    onChangePreviewedHostId(effectiveHostId);
+  }, [
+    isLoading,
+    effectiveHostId,
+    previewedHostId,
+    onChangePreviewedHostId,
+  ]);
+
+  const sortedHosts = useMemo(() => {
+    return [...hosts].sort((a, b) => {
+      if (a.name === MCPJAM_HOST_NAME) return -1;
+      if (b.name === MCPJAM_HOST_NAME) return 1;
+      return a.name.localeCompare(b.name);
+    });
+  }, [hosts]);
+
+  const hasFiredOpened = useRef(false);
+  useEffect(() => {
+    if (hasFiredOpened.current) return;
+    hasFiredOpened.current = true;
+    posthog.capture("connect_host_overlay_opened", {
+      host_count: hosts.length,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [posthog]);
+
+  const handleChange = (next: string) => {
+    if (next === effectiveHostId) return;
+    posthog.capture("connect_host_overlay_swapped", {
+      from: effectiveHostId ?? "__unknown__",
+      to: next,
+      host_count: hosts.length,
+    });
+    onChangePreviewedHostId(next);
+  };
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-x-4 gap-y-2"
+      data-testid="host-overlay-bar"
+    >
+      <div className="min-w-[10rem] max-w-[18rem]">
+        <Select
+          value={effectiveHostId ?? ""}
+          onValueChange={handleChange}
+          disabled={isLoading || sortedHosts.length === 0}
+        >
+          <SelectTrigger
+            aria-label="Host used for preview"
+            size="sm"
+            className={cn(
+              "h-8 w-full justify-between gap-2 border-0 bg-transparent px-2.5 shadow-none",
+              "text-sm font-medium text-foreground",
+              "hover:bg-muted/60 data-[state=open]:bg-muted/60",
+              "focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-ring/45",
+              "[&_svg:not([class*='text-'])]:opacity-55",
+            )}
+          >
+            <SelectValue
+              placeholder={isLoading ? "Loading..." : "Select host"}
+            />
+          </SelectTrigger>
+          <SelectContent>
+            {sortedHosts.map((host) => (
+              <SelectItem key={host.hostId} value={host.hostId}>
+                {host.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Separator
+        orientation="vertical"
+        className="hidden h-4 shrink-0 bg-border/70 sm:block"
+      />
+
+      <div className="flex flex-wrap items-center gap-0.5">
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-muted-foreground hover:text-foreground"
+          onClick={() => {
+            if (effectiveHostId) onEditHost(effectiveHostId);
+          }}
+          disabled={!effectiveHostId}
+          data-testid="host-overlay-edit"
+        >
+          <Pencil className="size-3.5" />
+          Edit
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          className="text-muted-foreground hover:text-foreground"
+          onClick={() => setShowCreate(true)}
+          data-testid="host-overlay-save-as-new"
+        >
+          <Plus className="size-3.5" />
+          Save as new host…
+        </Button>
+      </div>
+      <CreateHostDialog
+        isOpen={showCreate}
+        onClose={() => setShowCreate(false)}
+        projectId={projectId}
+        onCreated={(hostId) => {
+          posthog.capture("connect_host_overlay_saved_as_new", {
+            host_id: hostId,
+          });
+          onChangePreviewedHostId(hostId);
+          onEditHost(hostId);
+        }}
+      />
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/HostPicker.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostPicker.tsx
@@ -30,9 +30,12 @@ export function HostPicker({
   const { isAuthenticated } = useConvexAuth();
   const { hosts, isLoading } = useHostList({ isAuthenticated, projectId });
 
+  const selectValue =
+    value !== null ? value : includeNone ? "__none__" : undefined;
+
   return (
     <Select
-      value={value ?? "__none__"}
+      value={selectValue}
       onValueChange={(v) => onChange(v === "__none__" ? null : v)}
       disabled={disabled || isLoading}
     >

--- a/mcpjam-inspector/client/src/components/hosts/HostPicker.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostPicker.tsx
@@ -1,0 +1,54 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@mcpjam/design-system/select";
+import { useHostList } from "@/hooks/useHosts";
+import { useConvexAuth } from "convex/react";
+
+interface HostPickerProps {
+  projectId: string | null;
+  value: string | null;
+  onChange: (hostId: string | null) => void;
+  placeholder?: string;
+  includeNone?: boolean;
+  noneLabel?: string;
+  disabled?: boolean;
+}
+
+export function HostPicker({
+  projectId,
+  value,
+  onChange,
+  placeholder = "Select a host",
+  includeNone = true,
+  noneLabel = "Project default",
+  disabled = false,
+}: HostPickerProps) {
+  const { isAuthenticated } = useConvexAuth();
+  const { hosts, isLoading } = useHostList({ isAuthenticated, projectId });
+
+  return (
+    <Select
+      value={value ?? "__none__"}
+      onValueChange={(v) => onChange(v === "__none__" ? null : v)}
+      disabled={disabled || isLoading}
+    >
+      <SelectTrigger>
+        <SelectValue placeholder={isLoading ? "Loading..." : placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {includeNone && (
+          <SelectItem value="__none__">{noneLabel}</SelectItem>
+        )}
+        {hosts.map((host) => (
+          <SelectItem key={host.hostId} value={host.hostId}>
+            {host.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/HostSetupChecklistPanel.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostSetupChecklistPanel.tsx
@@ -1,0 +1,250 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, ChevronDown, Plus } from "lucide-react";
+import { Badge } from "@mcpjam/design-system/badge";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@mcpjam/design-system/collapsible";
+import { ScrollArea } from "@mcpjam/design-system/scroll-area";
+import { HostConfigEditor } from "@/components/host-config/HostConfigEditor";
+import { cn } from "@/lib/utils";
+import type { HostConfigInputV2 } from "@/lib/host-config-v2";
+import { ServerConnectionOverrideSection } from "./ServerConnectionOverrideSection";
+import type {
+  HostSectionStatusKind,
+  HostSetupSectionId,
+} from "./host-builder-types";
+
+const sectionStatusMetaClassName =
+  "inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground";
+
+function SectionStatusBadge({ kind }: { kind: HostSectionStatusKind }) {
+  switch (kind) {
+    case "complete":
+      return (
+        <span className={sectionStatusMetaClassName}>
+          <Check className="size-3.5 shrink-0" strokeWidth={2.25} aria-hidden />
+          Done
+        </span>
+      );
+    case "attention":
+      return (
+        <Badge
+          variant="outline"
+          className="border-amber-500/50 bg-amber-500/10 text-amber-800 dark:text-amber-300"
+        >
+          Attention
+        </Badge>
+      );
+    case "optional":
+      return <span className={sectionStatusMetaClassName}>Optional</span>;
+    default:
+      return null;
+  }
+}
+
+function SetupSectionStepIndex({ step }: { step: number }) {
+  return (
+    <span
+      className={cn(
+        "flex size-7 shrink-0 items-center justify-center rounded-full border border-border/70 bg-muted/40 text-xs font-semibold tabular-nums text-muted-foreground transition-colors",
+      )}
+    >
+      {step}
+    </span>
+  );
+}
+
+const setupSectionCollapsibleTriggerClass =
+  "group flex w-full items-center justify-between gap-2 rounded-xl border border-border/60 bg-muted/20 px-3 py-3 text-left hover:bg-muted/35";
+
+function SetupSectionCollapsibleTrigger({
+  step,
+  title,
+  statusKind,
+}: {
+  step: number;
+  title: string;
+  statusKind: HostSectionStatusKind;
+}) {
+  return (
+    <CollapsibleTrigger className={setupSectionCollapsibleTriggerClass}>
+      <div className="flex min-w-0 items-center gap-2.5">
+        <SetupSectionStepIndex step={step} />
+        <span className="text-sm font-semibold">{title}</span>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <SectionStatusBadge kind={statusKind} />
+        <ChevronDown
+          className="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-180"
+          aria-hidden
+        />
+      </div>
+    </CollapsibleTrigger>
+  );
+}
+
+export function computeHostSectionStatuses(
+  draft: HostConfigInputV2,
+): Record<HostSetupSectionId, HostSectionStatusKind> {
+  const basics: HostSectionStatusKind =
+    draft.modelId.trim() !== "" ? "complete" : "attention";
+  const totalServers = draft.serverIds.length + draft.optionalServerIds.length;
+  const servers: HostSectionStatusKind =
+    totalServers > 0 ? "complete" : "optional";
+  return { basics, servers };
+}
+
+export interface HostSetupChecklistPanelProps {
+  draft: HostConfigInputV2;
+  onDraftChange: (
+    updater: (draft: HostConfigInputV2) => HostConfigInputV2,
+  ) => void;
+  availableServers: ReadonlyArray<{ id: string; name: string }>;
+  focusedSection: HostSetupSectionId | null;
+  onValidityChange: (hasError: boolean) => void;
+  onOpenAddServer: () => void;
+}
+
+export function HostSetupChecklistPanel({
+  draft,
+  onDraftChange,
+  availableServers,
+  focusedSection,
+  onValidityChange,
+  onOpenAddServer,
+}: HostSetupChecklistPanelProps) {
+  const statuses = useMemo(() => computeHostSectionStatuses(draft), [draft]);
+
+  const sectionRefs = useRef<
+    Partial<Record<HostSetupSectionId, HTMLDivElement | null>>
+  >({});
+
+  const [openMap, setOpenMap] = useState<
+    Partial<Record<HostSetupSectionId, boolean>>
+  >({});
+  const didAutoExpandRef = useRef(false);
+
+  // First-mount: auto-expand the first attention section. Mirrors the
+  // chatbox setup-checklist behaviour at setup-checklist-panel.tsx:411-426.
+  useEffect(() => {
+    if (didAutoExpandRef.current) return;
+    const order: HostSetupSectionId[] = ["basics", "servers"];
+    const firstIncomplete = order.find((id) => statuses[id] === "attention");
+    if (firstIncomplete) {
+      setOpenMap((prev) => ({ ...prev, [firstIncomplete]: true }));
+    } else {
+      // No attention sections — still expand basics so the user lands on
+      // something rather than a wall of collapsed pills.
+      setOpenMap((prev) =>
+        prev.basics === undefined ? { ...prev, basics: true } : prev,
+      );
+    }
+    didAutoExpandRef.current = true;
+  }, [statuses]);
+
+  // When the canvas requests focus, open that section and scroll it into view.
+  useEffect(() => {
+    if (!focusedSection) return;
+    setOpenMap((prev) => ({ ...prev, [focusedSection]: true }));
+    const el = sectionRefs.current[focusedSection];
+    el?.scrollIntoView({ behavior: "smooth", block: "nearest" });
+  }, [focusedSection]);
+
+  const setSectionOpen = (id: HostSetupSectionId, open: boolean) => {
+    setOpenMap((prev) => ({ ...prev, [id]: open }));
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="space-y-2 p-4 pb-12">
+          {/* 1. Basics */}
+          <div
+            ref={(el) => {
+              sectionRefs.current.basics = el;
+            }}
+          >
+            <Collapsible
+              open={openMap.basics ?? false}
+              onOpenChange={(o) => setSectionOpen("basics", o)}
+            >
+              <SetupSectionCollapsibleTrigger
+                step={1}
+                title="Basics"
+                statusKind={statuses.basics}
+              />
+              <CollapsibleContent className="pt-3 pb-1">
+                <div className="rounded-xl border border-border/50 bg-card/40 p-4">
+                  <HostConfigEditor
+                    value={draft}
+                    onChange={(next) => onDraftChange(() => next)}
+                    owner="host"
+                    availableServers={availableServers}
+                    onValidityChange={onValidityChange}
+                  />
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          </div>
+
+          {/* 2. Servers */}
+          <div
+            ref={(el) => {
+              sectionRefs.current.servers = el;
+            }}
+          >
+            <Collapsible
+              open={openMap.servers ?? false}
+              onOpenChange={(o) => setSectionOpen("servers", o)}
+            >
+              <SetupSectionCollapsibleTrigger
+                step={2}
+                title="Servers"
+                statusKind={statuses.servers}
+              />
+              <CollapsibleContent className="pt-3 pb-1">
+                <div className="space-y-3 rounded-xl border border-border/50 bg-card/40 p-4">
+                  <div className="flex items-center justify-between gap-2">
+                    <h3 className="text-sm font-semibold">MCP servers</h3>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="gap-1.5"
+                      onClick={onOpenAddServer}
+                    >
+                      <Plus className="size-4" />
+                      Add server
+                    </Button>
+                  </div>
+                  <ServerConnectionOverrideSection
+                    serverIds={draft.serverIds}
+                    optionalServerIds={draft.optionalServerIds}
+                    projectServers={[...availableServers]}
+                    overrides={draft.serverConnectionOverrides ?? {}}
+                    onChange={(overrides) =>
+                      onDraftChange((prev) => ({
+                        ...prev,
+                        serverConnectionOverrides: overrides,
+                      }))
+                    }
+                    onServerSelectionChange={(serverIds, optionalServerIds) =>
+                      onDraftChange((prev) => ({
+                        ...prev,
+                        serverIds,
+                        optionalServerIds,
+                      }))
+                    }
+                  />
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          </div>
+        </div>
+      </ScrollArea>
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/ServerConnectionOverrideSection.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/ServerConnectionOverrideSection.tsx
@@ -1,0 +1,232 @@
+import { useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { Label } from "@mcpjam/design-system/label";
+import { Input } from "@mcpjam/design-system/input";
+import { Switch } from "@mcpjam/design-system/switch";
+import { Checkbox } from "@mcpjam/design-system/checkbox";
+import { Button } from "@mcpjam/design-system/button";
+import { cn } from "@/lib/utils";
+
+interface ServerEntry {
+  id: string;
+  name: string;
+}
+
+interface Override {
+  headersOverride?: Record<string, string>;
+  requestTimeoutOverride?: number;
+}
+
+interface ServerConnectionOverrideSectionProps {
+  serverIds: string[];
+  optionalServerIds: string[];
+  projectServers: ServerEntry[];
+  overrides: Record<string, Override>;
+  onChange: (overrides: Record<string, Override>) => void;
+  onServerSelectionChange: (serverIds: string[], optionalServerIds: string[]) => void;
+}
+
+function HeadersEditor({
+  headers,
+  onChange,
+}: {
+  headers: Record<string, string>;
+  onChange: (h: Record<string, string>) => void;
+}) {
+  const [rawJson, setRawJson] = useState(() => JSON.stringify(headers, null, 2));
+  const [parseError, setParseError] = useState<string | null>(null);
+
+  const handleChange = (value: string) => {
+    setRawJson(value);
+    try {
+      const parsed = JSON.parse(value);
+      if (typeof parsed !== "object" || Array.isArray(parsed)) {
+        setParseError("Must be a JSON object");
+        return;
+      }
+      setParseError(null);
+      onChange(parsed as Record<string, string>);
+    } catch {
+      setParseError("Invalid JSON");
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Label className="text-xs">Headers override (JSON)</Label>
+      <textarea
+        className={cn(
+          "min-h-[80px] w-full rounded-md border bg-background px-3 py-2 font-mono text-xs",
+          parseError ? "border-destructive" : "border-input",
+        )}
+        value={rawJson}
+        onChange={(e) => handleChange(e.target.value)}
+        spellCheck={false}
+      />
+      {parseError && (
+        <p className="text-xs text-destructive">{parseError}</p>
+      )}
+    </div>
+  );
+}
+
+function ServerOverrideRow({
+  server,
+  isRequired,
+  isOptional,
+  override,
+  onRequiredChange,
+  onOptionalChange,
+  onOverrideChange,
+}: {
+  server: ServerEntry;
+  isRequired: boolean;
+  isOptional: boolean;
+  override: Override | undefined;
+  onRequiredChange: (checked: boolean) => void;
+  onOptionalChange: (checked: boolean) => void;
+  onOverrideChange: (override: Override | undefined) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const hasOverride = override !== undefined;
+
+  return (
+    <div className="rounded-md border bg-card">
+      <div className="flex items-center gap-3 px-3 py-2">
+        <Checkbox
+          id={`req-${server.id}`}
+          checked={isRequired}
+          onCheckedChange={(checked) => onRequiredChange(!!checked)}
+        />
+        <Label htmlFor={`req-${server.id}`} className="flex-1 cursor-pointer text-sm font-medium">
+          {server.name}
+        </Label>
+        <Checkbox
+          id={`opt-${server.id}`}
+          checked={isOptional}
+          onCheckedChange={(checked) => onOptionalChange(!!checked)}
+          title="Optional"
+        />
+        <Label htmlFor={`opt-${server.id}`} className="cursor-pointer text-xs text-muted-foreground">
+          Optional
+        </Label>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6"
+          onClick={() => setExpanded((v) => !v)}
+          title="Per-server overrides"
+        >
+          {expanded ? (
+            <ChevronDown className="h-3 w-3" />
+          ) : (
+            <ChevronRight className="h-3 w-3" />
+          )}
+        </Button>
+      </div>
+
+      {expanded && (
+        <div className="border-t px-3 py-3 flex flex-col gap-3">
+          <div className="flex items-center gap-2">
+            <Switch
+              id={`override-${server.id}`}
+              checked={hasOverride}
+              onCheckedChange={(checked) =>
+                onOverrideChange(checked ? {} : undefined)
+              }
+            />
+            <Label htmlFor={`override-${server.id}`} className="text-xs">
+              {hasOverride ? "Override active" : "Using host defaults"}
+            </Label>
+          </div>
+          {hasOverride && (
+            <>
+              <HeadersEditor
+                headers={override?.headersOverride ?? {}}
+                onChange={(h) =>
+                  onOverrideChange({ ...override, headersOverride: h })
+                }
+              />
+              <div className="flex flex-col gap-1">
+                <Label className="text-xs">Timeout override (ms)</Label>
+                <Input
+                  type="number"
+                  placeholder="Using host default"
+                  value={override?.requestTimeoutOverride ?? ""}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    onOverrideChange({
+                      ...override,
+                      requestTimeoutOverride: val ? Number(val) : undefined,
+                    });
+                  }}
+                  className="h-8 text-xs"
+                />
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ServerConnectionOverrideSection({
+  serverIds,
+  optionalServerIds,
+  projectServers,
+  overrides,
+  onChange,
+  onServerSelectionChange,
+}: ServerConnectionOverrideSectionProps) {
+  if (projectServers.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No servers in this project yet. Add a server to configure it.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {projectServers.map((server) => (
+        <ServerOverrideRow
+          key={server.id}
+          server={server}
+          isRequired={serverIds.includes(server.id)}
+          isOptional={optionalServerIds.includes(server.id)}
+          override={overrides[server.id]}
+          onRequiredChange={(checked) => {
+            const newRequired = checked
+              ? [...serverIds, server.id]
+              : serverIds.filter((id) => id !== server.id);
+            // can't be both required and optional
+            const newOptional = checked
+              ? optionalServerIds.filter((id) => id !== server.id)
+              : optionalServerIds;
+            onServerSelectionChange(newRequired, newOptional);
+          }}
+          onOptionalChange={(checked) => {
+            const newOptional = checked
+              ? [...optionalServerIds, server.id]
+              : optionalServerIds.filter((id) => id !== server.id);
+            // can't be both required and optional
+            const newRequired = checked
+              ? serverIds.filter((id) => id !== server.id)
+              : serverIds;
+            onServerSelectionChange(newRequired, newOptional);
+          }}
+          onOverrideChange={(override) => {
+            const next = { ...overrides };
+            if (override === undefined) {
+              delete next[server.id];
+            } else {
+              next[server.id] = override;
+            }
+            onChange(next);
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/hosts/ServerConnectionOverrideSection.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/ServerConnectionOverrideSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { Label } from "@mcpjam/design-system/label";
 import { Input } from "@mcpjam/design-system/input";
@@ -35,6 +35,21 @@ function HeadersEditor({
 }) {
   const [rawJson, setRawJson] = useState(() => JSON.stringify(headers, null, 2));
   const [parseError, setParseError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const serialized = JSON.stringify(headers, null, 2);
+    setRawJson((prev) => {
+      try {
+        const parsed = JSON.parse(prev);
+        return JSON.stringify(parsed) === JSON.stringify(headers)
+          ? prev
+          : serialized;
+      } catch {
+        return serialized;
+      }
+    });
+    setParseError(null);
+  }, [headers]);
 
   const handleChange = (value: string) => {
     setRawJson(value);
@@ -193,28 +208,40 @@ export function ServerConnectionOverrideSection({
         <ServerOverrideRow
           key={server.id}
           server={server}
-          isRequired={serverIds.includes(server.id)}
+          isRequired={
+            serverIds.includes(server.id) &&
+            !optionalServerIds.includes(server.id)
+          }
           isOptional={optionalServerIds.includes(server.id)}
           override={overrides[server.id]}
           onRequiredChange={(checked) => {
+            // Selecting "required" picks the server (adds to serverIds) and
+            // clears any optional flag; unselecting removes it from both.
             const newRequired = checked
-              ? [...serverIds, server.id]
+              ? Array.from(new Set([...serverIds, server.id]))
               : serverIds.filter((id) => id !== server.id);
-            // can't be both required and optional
-            const newOptional = checked
-              ? optionalServerIds.filter((id) => id !== server.id)
-              : optionalServerIds;
+            const newOptional = optionalServerIds.filter(
+              (id) => id !== server.id,
+            );
             onServerSelectionChange(newRequired, newOptional);
           }}
           onOptionalChange={(checked) => {
-            const newOptional = checked
-              ? [...optionalServerIds, server.id]
-              : optionalServerIds.filter((id) => id !== server.id);
-            // can't be both required and optional
-            const newRequired = checked
-              ? serverIds.filter((id) => id !== server.id)
-              : serverIds;
-            onServerSelectionChange(newRequired, newOptional);
+            // optionalServerIds is a subset of serverIds — marking a server
+            // optional keeps it selected, it just becomes non-required.
+            if (checked) {
+              const newRequired = Array.from(
+                new Set([...serverIds, server.id]),
+              );
+              const newOptional = Array.from(
+                new Set([...optionalServerIds, server.id]),
+              );
+              onServerSelectionChange(newRequired, newOptional);
+            } else {
+              const newOptional = optionalServerIds.filter(
+                (id) => id !== server.id,
+              );
+              onServerSelectionChange(serverIds, newOptional);
+            }
           }}
           onOverrideChange={(override) => {
             const next = { ...overrides };

--- a/mcpjam-inspector/client/src/components/hosts/host-builder-types.ts
+++ b/mcpjam-inspector/client/src/components/hosts/host-builder-types.ts
@@ -1,0 +1,51 @@
+import type { Edge, Node } from "@xyflow/react";
+import type { HostConfigInputV2, HostStyleId } from "@/lib/host-config-v2";
+
+export type HostBuilderNodeKind = "host" | "server";
+
+export type HostBuilderNodeState = "ready" | "attention" | "draft";
+
+export type HostSetupSectionId = "basics" | "servers";
+
+export type HostSectionStatusKind = "complete" | "attention" | "optional";
+
+export interface HostBuilderChip {
+  label: string;
+  tone?: "neutral" | "success" | "warning" | "info";
+}
+
+export interface HostBuilderNodeData extends Record<string, unknown> {
+  kind: HostBuilderNodeKind;
+  title: string;
+  subtitle?: string;
+  /** Extra line under subtitle (e.g. model name on the host card). */
+  detailLine?: string;
+  chips: HostBuilderChip[];
+  state: HostBuilderNodeState;
+  serverId?: string;
+  /** Host card only: drives the host-style logo on the canvas. */
+  hostStyle?: HostStyleId;
+}
+
+export interface HostBuilderAddServerNodeData extends Record<string, unknown> {
+  label: string;
+}
+
+export interface HostBuilderContext {
+  hostName: string;
+  draft: HostConfigInputV2;
+  projectServers: Array<{ id: string; name: string; url?: string }>;
+}
+
+export type HostFlowNode =
+  | Node<HostBuilderNodeData, "hostNode">
+  | Node<HostBuilderAddServerNodeData, "hostAddServerNode">;
+
+export interface HostBuilderViewModel {
+  title: string;
+  nodes: HostFlowNode[];
+  edges: Edge[];
+}
+
+export const HOST_BUILDER_HOST_NODE_ID = "host";
+export const HOST_BUILDER_ADD_SERVER_NODE_ID = "add-server";

--- a/mcpjam-inspector/client/src/components/hosts/hostCanvasBuilder.ts
+++ b/mcpjam-inspector/client/src/components/hosts/hostCanvasBuilder.ts
@@ -1,0 +1,160 @@
+import type { Edge, Node } from "@xyflow/react";
+import { getModelById } from "@/shared/types";
+import {
+  HOST_BUILDER_ADD_SERVER_NODE_ID,
+  HOST_BUILDER_HOST_NODE_ID,
+  type HostBuilderAddServerNodeData,
+  type HostBuilderChip,
+  type HostBuilderContext,
+  type HostBuilderNodeData,
+  type HostBuilderViewModel,
+  type HostFlowNode,
+} from "./host-builder-types";
+
+/**
+ * Layout constants. Host card at the top, an add-server pseudo-node in
+ * the middle, then a vertical stack of server cards below. Spacing is
+ * tighter than the chatbox builder because hosts don't render a tools
+ * collapsible on each server card.
+ */
+const HOST_NODE_Y = 0;
+const ADD_SERVER_NODE_Y = 180;
+const FIRST_SERVER_Y = 300;
+const SERVER_ROW_GAP = 120;
+const NODE_X = 0;
+
+const NODE_WIDTH = 280;
+const ADD_SERVER_OFFSET_X = (NODE_WIDTH - 40) / 2;
+
+function hostChip(
+  label: string,
+  tone: HostBuilderChip["tone"] = "neutral",
+): HostBuilderChip {
+  return { label, tone };
+}
+
+function createHostNode(
+  data: HostBuilderNodeData,
+): Node<HostBuilderNodeData, "hostNode"> {
+  return {
+    id: HOST_BUILDER_HOST_NODE_ID,
+    type: "hostNode",
+    position: { x: NODE_X, y: HOST_NODE_Y },
+    data,
+    draggable: false,
+  };
+}
+
+function createServerNode(
+  serverId: string,
+  index: number,
+  data: HostBuilderNodeData,
+): Node<HostBuilderNodeData, "hostNode"> {
+  return {
+    id: `server:${serverId}`,
+    type: "hostNode",
+    position: { x: NODE_X, y: FIRST_SERVER_Y + index * SERVER_ROW_GAP },
+    data,
+    draggable: false,
+  };
+}
+
+function createAddServerNode(): Node<
+  HostBuilderAddServerNodeData,
+  "hostAddServerNode"
+> {
+  return {
+    id: HOST_BUILDER_ADD_SERVER_NODE_ID,
+    type: "hostAddServerNode",
+    position: { x: NODE_X + ADD_SERVER_OFFSET_X, y: ADD_SERVER_NODE_Y },
+    data: { label: "Add server" },
+    draggable: false,
+    selectable: false,
+  };
+}
+
+function resolveHostData(context: HostBuilderContext): HostBuilderNodeData {
+  const { draft, hostName } = context;
+  const modelName = draft.modelId
+    ? (getModelById(draft.modelId)?.name ?? draft.modelId)
+    : "No model selected";
+  return {
+    kind: "host",
+    title: "Host",
+    subtitle: hostName.trim() || "Untitled host",
+    detailLine: `Model · ${modelName}`,
+    hostStyle: draft.hostStyle,
+    chips: [],
+    state: "ready",
+  };
+}
+
+function resolveServerData(
+  serverId: string,
+  context: HostBuilderContext,
+): HostBuilderNodeData {
+  const server =
+    context.projectServers.find((item) => item.id === serverId) ?? null;
+  const url = server?.url;
+  const insecure = typeof url === "string" && url.startsWith("http://");
+  const isOptional = context.draft.optionalServerIds.includes(serverId);
+
+  const chips: HostBuilderChip[] = [];
+  if (isOptional) chips.push(hostChip("Optional", "info"));
+  if (insecure) chips.push(hostChip("Insecure", "warning"));
+
+  return {
+    kind: "server",
+    title: server?.name ?? "Server",
+    subtitle: url ?? "Project server",
+    chips,
+    state: insecure ? "attention" : "ready",
+    serverId,
+  };
+}
+
+export function buildHostCanvas(
+  context: HostBuilderContext,
+): HostBuilderViewModel {
+  const { draft } = context;
+
+  // Union required + optional, preserving required order then appending
+  // optional ids that aren't already in serverIds.
+  const seen = new Set<string>();
+  const orderedServerIds: string[] = [];
+  for (const id of draft.serverIds) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    orderedServerIds.push(id);
+  }
+  for (const id of draft.optionalServerIds) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    orderedServerIds.push(id);
+  }
+
+  const nodes: HostFlowNode[] = [
+    createHostNode(resolveHostData(context)),
+    createAddServerNode(),
+  ];
+
+  orderedServerIds.forEach((serverId, index) => {
+    nodes.push(createServerNode(serverId, index, resolveServerData(serverId, context)));
+  });
+
+  const edges: Edge[] = orderedServerIds.map((serverId) => ({
+    id: `host-server-${serverId}`,
+    source: HOST_BUILDER_HOST_NODE_ID,
+    target: `server:${serverId}`,
+    type: "default",
+    style: { stroke: "oklch(0.68 0.11 40 / 0.5)", strokeWidth: 1.5 },
+    sourceHandle: "bottom",
+    targetHandle: "top",
+  }));
+
+  return {
+    title: context.hostName.trim() || "Untitled host",
+    nodes,
+    edges,
+  };
+}

--- a/mcpjam-inspector/client/src/components/hosts/types.ts
+++ b/mcpjam-inspector/client/src/components/hosts/types.ts
@@ -1,0 +1,6 @@
+import type { HostConfigInputV2 } from "@/lib/host-config-v2";
+
+export interface HostDraftConfig {
+  name: string;
+  hostConfigInput: HostConfigInputV2;
+}

--- a/mcpjam-inspector/client/src/components/hosts/types.ts
+++ b/mcpjam-inspector/client/src/components/hosts/types.ts
@@ -1,6 +1,0 @@
-import type { HostConfigInputV2 } from "@/lib/host-config-v2";
-
-export interface HostDraftConfig {
-  name: string;
-  hostConfigInput: HostConfigInputV2;
-}

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -164,6 +164,12 @@ const navigationSections: NavSection[] = [
     id: "connection",
     items: [
       {
+        title: "Hosts",
+        url: "#hosts",
+        icon: MCPIcon,
+        featureFlag: "hosts-enabled",
+      },
+      {
         title: "Servers",
         url: "#servers",
         icon: MCPIcon,
@@ -550,6 +556,7 @@ export function MCPSidebar({
   const xaaEnabled = useFeatureFlagEnabled("xaa");
   const learnMoreEnabled = useFeatureFlagEnabled("learn-more-enabled");
   const conformanceEnabled = useFeatureFlagEnabled("mcpjam-conformance");
+  const hostsEnabled = useFeatureFlagEnabled("hosts-enabled");
   const { isAuthenticated } = useConvexAuth();
   const { user } = useAuth();
   const learningEnabled = !!learningFlagEnabled && isAuthenticated;
@@ -603,6 +610,7 @@ export function MCPSidebar({
       "sandboxes-enabled": !!sandboxesEnabled && isAuthenticated,
       "registry-enabled": registryEnabled === true,
       "mcpjam-conformance": conformanceEnabled === true,
+      "hosts-enabled": hostsEnabled === true && isAuthenticated,
       xaa: xaaEnabled === true,
     }),
     [
@@ -610,6 +618,7 @@ export function MCPSidebar({
       sandboxesEnabled,
       registryEnabled,
       conformanceEnabled,
+      hostsEnabled,
       xaaEnabled,
       isAuthenticated,
     ],

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -164,7 +164,7 @@ const navigationSections: NavSection[] = [
     id: "connection",
     items: [
       {
-        title: "Hosts",
+        title: "Connect",
         url: "#hosts",
         icon: MCPIcon,
         featureFlag: "hosts-enabled",

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -165,6 +165,7 @@ export function useAppState({
   hasOrganizations,
   isLoadingOrganizations,
   validOrganizations,
+  activeHostConfig,
 }: {
   currentUserId: string | null;
   /**
@@ -178,6 +179,13 @@ export function useAppState({
   hasOrganizations: boolean;
   isLoadingOrganizations: boolean;
   validOrganizations: Array<{ _id: string; myRole?: string }>;
+  /**
+   * When a named host is active in the Chat tab (or host preview), its
+   * connectionDefaults + per-server overrides drive reconnects via
+   * useServerState. App.tsx resolves this from the chat-tab HostPicker
+   * selection; useAppState forwards it untouched.
+   */
+  activeHostConfig?: HostConfigDtoV2;
 }) {
   const logger = useLogger("Connections");
   const [appState, dispatch] = useReducer(appReducer, initialAppState);
@@ -488,7 +496,9 @@ export function useAppState({
     effectiveProjects: projectState.effectiveProjects,
     effectiveActiveProjectId: projectState.effectiveActiveProjectId,
     activeProjectServersFlat: projectState.activeProjectServersFlat,
-    activeMcpProfile: activeProjectDefaultHostConfig?.mcpProfile,
+    activeMcpProfile:
+      activeHostConfig?.mcpProfile ?? activeProjectDefaultHostConfig?.mcpProfile,
+    activeHostConfig,
     logger,
   });
 

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -56,6 +56,8 @@ import {
 } from "@/lib/client-config";
 import { EXCALIDRAW_SERVER_NAME } from "@/lib/excalidraw-quick-connect";
 import { readOnboardingState } from "@/lib/onboarding-state";
+import type { HostConfigDtoV2 } from "@/lib/host-config-v2";
+import { resolveServerConnectionSettings } from "@/lib/host-connection-resolve";
 
 /** Skip noisy connect toast while first-run App Builder onboarding is in progress. */
 function shouldSuppressExcalidrawConnectToastForOnboarding(
@@ -483,6 +485,13 @@ interface UseServerStateParams {
    * clientInfo / supportedProtocolVersions accordingly.
    */
   activeMcpProfile?: import("@/lib/host-config-v2").HostConfigMcpProfileV1;
+  /**
+   * When a named host is active (e.g. selected in ChatTabV2 or HostBuilderView
+   * preview), its connectionDefaults replace the project-level connection
+   * defaults in `withProjectConnectionDefaults`. Per-server overrides are
+   * applied when the call site also supplies the `serverId`.
+   */
+  activeHostConfig?: HostConfigDtoV2;
   logger: LoggerLike;
 }
 
@@ -542,6 +551,7 @@ export function useServerState({
   effectiveActiveProjectId,
   activeProjectServersFlat,
   activeMcpProfile,
+  activeHostConfig,
   logger,
 }: UseServerStateParams) {
   const convex = useConvex();
@@ -727,7 +737,7 @@ export function useServerState({
   );
 
   const withProjectConnectionDefaults = useCallback(
-    (serverConfig: MCPServerConfig): MCPServerConfig => {
+    (serverConfig: MCPServerConfig, serverId?: string): MCPServerConfig => {
       const effectiveClientCapabilities =
         resolveEffectiveServerClientCapabilities({
           serverConfig,
@@ -736,10 +746,33 @@ export function useServerState({
 
       let nextRequestInit = serverConfig.requestInit;
       if ("url" in serverConfig) {
-        const mergedHeaders = mergeProjectConnectionHeaders(
-          projectConnectionDefaults.headers,
-          extractRequestHeaders(serverConfig.requestInit)
-        );
+        let mergedHeaders: Record<string, string>;
+        let effectiveTimeout: number;
+
+        if (activeHostConfig) {
+          // Use host-level connection defaults + optional per-server override
+          const serverBase = {
+            headers: extractRequestHeaders(serverConfig.requestInit),
+            timeout: serverConfig.timeout,
+          };
+          const perServerOverride = serverId
+            ? activeHostConfig.serverConnectionOverrides?.[serverId]
+            : undefined;
+          const resolved = resolveServerConnectionSettings(
+            serverBase,
+            activeHostConfig.connectionDefaults,
+            perServerOverride,
+          );
+          mergedHeaders = resolved.headers;
+          effectiveTimeout = resolved.timeout;
+        } else {
+          mergedHeaders = mergeProjectConnectionHeaders(
+            projectConnectionDefaults.headers,
+            extractRequestHeaders(serverConfig.requestInit)
+          );
+          effectiveTimeout =
+            serverConfig.timeout ?? projectConnectionDefaults.requestTimeout;
+        }
 
         if (Object.keys(mergedHeaders).length > 0) {
           nextRequestInit = {
@@ -747,20 +780,26 @@ export function useServerState({
             headers: mergedHeaders,
           };
         }
+
+        return {
+          ...serverConfig,
+          ...(nextRequestInit ? { requestInit: nextRequestInit } : {}),
+          timeout: effectiveTimeout,
+          capabilities: effectiveClientCapabilities,
+          clientCapabilities: effectiveClientCapabilities,
+        } as MCPServerConfig;
       }
 
       return {
         ...serverConfig,
-        ...("url" in serverConfig && nextRequestInit
-          ? { requestInit: nextRequestInit }
-          : {}),
-        timeout:
-          serverConfig.timeout ?? projectConnectionDefaults.requestTimeout,
+        timeout: activeHostConfig
+          ? activeHostConfig.connectionDefaults.requestTimeout
+          : serverConfig.timeout ?? projectConnectionDefaults.requestTimeout,
         capabilities: effectiveClientCapabilities,
         clientCapabilities: effectiveClientCapabilities,
       } as MCPServerConfig;
     },
-    [activeProject?.clientConfig, projectConnectionDefaults]
+    [activeProject?.clientConfig, projectConnectionDefaults, activeHostConfig]
   );
 
   const mergeWithProjectHeaders = useCallback(
@@ -917,11 +956,15 @@ export function useServerState({
       assertClientConfigSynced();
       const resolved = tryResolveProjectServer(serverName);
       if (resolved) {
-        return reconnectServer(resolved.serverId, serverConfig, {
+        const configWithDefaults = withProjectConnectionDefaults(
+          serverConfig,
+          resolved.serverId,
+        );
+        return reconnectServer(resolved.serverId, configWithDefaults, {
           projectId: resolved.projectId,
           serverName,
           connectionDefaults: buildResolverConnectionDefaults(
-            serverConfig,
+            configWithDefaults,
             activeMcpProfile,
           ),
         });
@@ -932,6 +975,7 @@ export function useServerState({
       assertClientConfigSynced,
       buildResolverConnectionDefaults,
       activeMcpProfile,
+      withProjectConnectionDefaults,
     ]
   );
 

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -793,7 +793,9 @@ export function useServerState({
       return {
         ...serverConfig,
         timeout: activeHostConfig
-          ? activeHostConfig.connectionDefaults.requestTimeout
+          ? activeHostConfig.connectionDefaults.requestTimeout ??
+            serverConfig.timeout ??
+            projectConnectionDefaults.requestTimeout
           : serverConfig.timeout ?? projectConnectionDefaults.requestTimeout,
         capabilities: effectiveClientCapabilities,
         clientCapabilities: effectiveClientCapabilities,

--- a/mcpjam-inspector/client/src/hooks/useHosts.ts
+++ b/mcpjam-inspector/client/src/hooks/useHosts.ts
@@ -1,0 +1,88 @@
+import { useMutation, useQuery } from "convex/react";
+import type { HostConfigDtoV2, HostConfigInputV2 } from "@/lib/host-config-v2";
+
+export interface HostListItem {
+  hostId: string;
+  name: string;
+  hostConfigId: string;
+  modelId: string;
+  serverCount: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface HostDetail {
+  hostId: string;
+  name: string;
+  config: HostConfigDtoV2;
+}
+
+export function useHostList({
+  isAuthenticated,
+  projectId,
+}: {
+  isAuthenticated: boolean;
+  projectId: string | null;
+}): {
+  hosts: HostListItem[];
+  isLoading: boolean;
+} {
+  const result = useQuery(
+    "hosts:listHosts" as any,
+    isAuthenticated && projectId
+      ? ({ projectId } as any)
+      : "skip",
+  ) as HostListItem[] | null | undefined;
+
+  return {
+    hosts: result ?? [],
+    isLoading: result === undefined,
+  };
+}
+
+export function useHost({
+  isAuthenticated,
+  hostId,
+}: {
+  isAuthenticated: boolean;
+  hostId: string | null;
+}): {
+  host: HostDetail | null;
+  isLoading: boolean;
+} {
+  const result = useQuery(
+    "hosts:getHost" as any,
+    isAuthenticated && hostId ? ({ hostId } as any) : "skip",
+  ) as HostDetail | null | undefined;
+
+  return {
+    host: result ?? null,
+    isLoading: result === undefined,
+  };
+}
+
+export function useHostMutations() {
+  const createHost = useMutation("hosts:createHost" as any) as unknown as (args: {
+    projectId: string;
+    name: string;
+    input: HostConfigInputV2;
+  }) => Promise<{ hostId: string; hostConfigId: string }>;
+
+  const updateHost = useMutation("hosts:updateHost" as any) as unknown as (args: {
+    hostId: string;
+    name?: string;
+    input?: HostConfigInputV2;
+  }) => Promise<{ hostId: string; hostConfigId: string }>;
+
+  const deleteHost = useMutation("hosts:deleteHost" as any) as unknown as (args: {
+    hostId: string;
+    force?: boolean;
+  }) => Promise<void>;
+
+  const duplicateHost = useMutation("hosts:duplicateHost" as any) as unknown as (args: {
+    hostId: string;
+    name?: string;
+  }) => Promise<{ hostId: string; hostConfigId: string }>;
+
+  return { createHost, updateHost, deleteHost, duplicateHost };
+}

--- a/mcpjam-inspector/client/src/lib/host-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-v2.ts
@@ -90,6 +90,24 @@ export type HostConfigMcpProfileV1 = {
         extensions?: Record<string, unknown>;
       };
     };
+    /**
+     * Overrides for the MCP Apps `ui/initialize` response advertised to
+     * the View iframe (SEP-1865). Sibling to `apps.sandbox` because the
+     * `ui/initialize` envelope is the MCP Apps extension's negotiation
+     * step — distinct from the base-protocol `initialize` whose overrides
+     * live under `mcpProfile.initialize`.
+     */
+    uiInitialize?: {
+      /**
+       * The exact `hostInfo` the inspector should report in the
+       * `ui/initialize` result. Backend soft-validates `name` and
+       * `version` (non-empty strings, required when `hostInfo` is set)
+       * and passes everything else through verbatim so future spec
+       * additions (e.g. `title`) land here without a schema migration.
+       * Mirror of `initialize.clientInfo`.
+       */
+      hostInfo?: Record<string, unknown>;
+    };
   };
   extensions?: Record<string, unknown>;
 };
@@ -338,6 +356,21 @@ export function resolveSupportedProtocolVersions(
   profile: HostConfigMcpProfileV1 | undefined,
 ): string[] | undefined {
   return profile?.initialize?.supportedProtocolVersions;
+}
+
+/**
+ * Resolve the `hostInfo` advertised in the MCP Apps `ui/initialize`
+ * response. `undefined` means "use the renderer's built-in default
+ * (mcpjam-inspector + __APP_VERSION__)" — preserves the historic value
+ * for hosts that haven't opted into the override.
+ *
+ * Sibling of {@link resolveClientInfo}: same shape, different protocol
+ * layer (base-protocol `initialize` vs. MCP Apps `ui/initialize`).
+ */
+export function resolveHostInfo(
+  profile: HostConfigMcpProfileV1 | undefined,
+): Record<string, unknown> | undefined {
+  return profile?.apps?.uiInitialize?.hostInfo;
 }
 
 /**

--- a/mcpjam-inspector/client/src/lib/host-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-v2.ts
@@ -243,6 +243,21 @@ export function emptyHostConfigInputV2(
     mcpProfile: partial.mcpProfile
       ? cloneMcpProfile(partial.mcpProfile)
       : undefined,
+    serverConnectionOverrides: partial.serverConnectionOverrides
+      ? Object.fromEntries(
+          Object.entries(partial.serverConnectionOverrides).map(([k, v]) => [
+            k,
+            {
+              ...(v.headersOverride !== undefined
+                ? { headersOverride: { ...v.headersOverride } }
+                : {}),
+              ...(v.requestTimeoutOverride !== undefined
+                ? { requestTimeoutOverride: v.requestTimeoutOverride }
+                : {}),
+            },
+          ]),
+        )
+      : undefined,
   };
 }
 
@@ -436,6 +451,13 @@ export function hostConfigInputsEqual(
   if (!optionalJsonRecordEq(a.hostCapabilitiesOverride, b.hostCapabilitiesOverride))
     return false;
   if (!optionalMcpProfileEq(a.mcpProfile, b.mcpProfile)) return false;
+  if (
+    !serverConnectionOverridesEqual(
+      a.serverConnectionOverrides,
+      b.serverConnectionOverrides,
+    )
+  )
+    return false;
   return true;
 }
 

--- a/mcpjam-inspector/client/src/lib/host-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/host-config-v2.ts
@@ -125,6 +125,16 @@ export type HostConfigInputV2 = {
    * the two states distinctly.
    */
   mcpProfile?: HostConfigMcpProfileV1;
+  /**
+   * Per-server connection overrides scoped to this host config. Keys are
+   * server IDs. When present for a server, these win over host-wide
+   * connectionDefaults for that specific server. Included in the canonical
+   * hash so hosts that differ only in overrides get distinct rows.
+   */
+  serverConnectionOverrides?: Record<string, {
+    headersOverride?: Record<string, string>;
+    requestTimeoutOverride?: number;
+  }>;
 };
 
 /**
@@ -152,6 +162,11 @@ export type HostConfigDtoV2 = {
    * default empty envelope.
    */
   mcpProfile?: HostConfigMcpProfileV1;
+  /** Per-server connection overrides hydrated from hostConfigServerRefs. */
+  serverConnectionOverrides?: Record<string, {
+    headersOverride?: Record<string, string>;
+    requestTimeoutOverride?: number;
+  }>;
 };
 
 export const DEFAULT_HOST_STYLE_V2: HostStyleId = "claude";
@@ -240,6 +255,21 @@ export function hostConfigDtoToInput(
       ? deepCloneJsonRecord(dto.hostCapabilitiesOverride)
       : undefined,
     mcpProfile: dto.mcpProfile ? cloneMcpProfile(dto.mcpProfile) : undefined,
+    serverConnectionOverrides: dto.serverConnectionOverrides
+      ? Object.fromEntries(
+          Object.entries(dto.serverConnectionOverrides).map(([k, v]) => [
+            k,
+            {
+              ...(v.headersOverride !== undefined
+                ? { headersOverride: { ...v.headersOverride } }
+                : {}),
+              ...(v.requestTimeoutOverride !== undefined
+                ? { requestTimeoutOverride: v.requestTimeoutOverride }
+                : {}),
+            },
+          ])
+        )
+      : undefined,
   };
 }
 
@@ -374,6 +404,38 @@ export function hostConfigInputsEqual(
     return false;
   if (!optionalMcpProfileEq(a.mcpProfile, b.mcpProfile)) return false;
   return true;
+}
+
+/**
+ * Deep equality for serverConnectionOverrides maps. Normalizes empty/undefined
+ * entries so `undefined`, `{}`, and an entry with all undefined fields all
+ * compare equal (no override).
+ */
+export function serverConnectionOverridesEqual(
+  a: HostConfigInputV2["serverConnectionOverrides"],
+  b: HostConfigInputV2["serverConnectionOverrides"],
+): boolean {
+  const normalize = (
+    overrides: HostConfigInputV2["serverConnectionOverrides"],
+  ): Record<string, { headersOverride?: Record<string, string>; requestTimeoutOverride?: number }> => {
+    if (!overrides) return {};
+    const result: Record<string, { headersOverride?: Record<string, string>; requestTimeoutOverride?: number }> = {};
+    for (const [key, entry] of Object.entries(overrides)) {
+      if (!entry) continue;
+      const hasHeaders =
+        entry.headersOverride !== undefined &&
+        Object.keys(entry.headersOverride).length > 0;
+      const hasTimeout = entry.requestTimeoutOverride !== undefined;
+      if (hasHeaders || hasTimeout) {
+        result[key] = {
+          ...(hasHeaders ? { headersOverride: entry.headersOverride } : {}),
+          ...(hasTimeout ? { requestTimeoutOverride: entry.requestTimeoutOverride } : {}),
+        };
+      }
+    }
+    return result;
+  };
+  return stableStringifyJson(normalize(a)) === stableStringifyJson(normalize(b));
 }
 
 function optionalMcpProfileEq(

--- a/mcpjam-inspector/client/src/lib/host-connection-resolve.ts
+++ b/mcpjam-inspector/client/src/lib/host-connection-resolve.ts
@@ -25,6 +25,9 @@ export function resolveServerConnectionSettings(
       ...hostDefaults.headers,
       ...override?.headersOverride,
     },
-    timeout: override?.requestTimeoutOverride ?? hostDefaults.requestTimeout,
+    timeout:
+      override?.requestTimeoutOverride ??
+      hostDefaults.requestTimeout ??
+      serverBase.timeout,
   };
 }

--- a/mcpjam-inspector/client/src/lib/host-connection-resolve.ts
+++ b/mcpjam-inspector/client/src/lib/host-connection-resolve.ts
@@ -1,0 +1,30 @@
+import type { HostConfigConnectionDefaults } from "./host-config-v2";
+
+/**
+ * Resolve the effective connection settings for a single server within a host.
+ *
+ * Merge order (lowest → highest priority):
+ *   1. serverBase   — the server row's own headers/timeout
+ *   2. hostDefaults — host-wide connectionDefaults
+ *   3. override     — per-host-server override from hostConfigServerRefs
+ *
+ * The `requestTimeoutOverride` wire name maps to the `timeout` field used by
+ * MCPServerConfig.
+ */
+export function resolveServerConnectionSettings(
+  serverBase: { headers?: Record<string, string>; timeout?: number },
+  hostDefaults: HostConfigConnectionDefaults,
+  override?: {
+    headersOverride?: Record<string, string>;
+    requestTimeoutOverride?: number;
+  },
+): { headers: Record<string, string>; timeout: number } {
+  return {
+    headers: {
+      ...serverBase.headers,
+      ...hostDefaults.headers,
+      ...override?.headersOverride,
+    },
+    timeout: override?.requestTimeoutOverride ?? hostDefaults.requestTimeout,
+  };
+}

--- a/mcpjam-inspector/client/src/lib/host-templates.ts
+++ b/mcpjam-inspector/client/src/lib/host-templates.ts
@@ -1,0 +1,414 @@
+import {
+  emptyHostConfigInputV2,
+  type HostConfigInputV2,
+} from "@/lib/host-config-v2";
+import mcpjamLogo from "/mcp_jam.svg";
+import claudeLogo from "/claude_logo.png";
+import openaiLogo from "/openai_logo.png";
+
+// Verbatim from a real claude.ai ui/initialize response. Kept out of the
+// template entry for readability. Updating these keeps the Claude template
+// in lockstep with what real claude.ai publishes to MCP App views.
+const CLAUDE_HOST_STYLE_VARIABLES: Record<string, string> = {
+  "--color-background-primary":
+    "light-dark(rgba(255, 255, 255, 1), rgba(48, 48, 46, 1))",
+  "--color-background-secondary":
+    "light-dark(rgba(245, 244, 237, 1), rgba(38, 38, 36, 1))",
+  "--color-background-tertiary":
+    "light-dark(rgba(250, 249, 245, 1), rgba(20, 20, 19, 1))",
+  "--color-background-inverse":
+    "light-dark(rgba(20, 20, 19, 1), rgba(250, 249, 245, 1))",
+  "--color-background-ghost":
+    "light-dark(rgba(255, 255, 255, 0), rgba(48, 48, 46, 0))",
+  "--color-background-info":
+    "light-dark(rgba(214, 228, 246, 1), rgba(37, 62, 95, 1))",
+  "--color-background-danger":
+    "light-dark(rgba(247, 236, 236, 1), rgba(96, 42, 40, 1))",
+  "--color-background-success":
+    "light-dark(rgba(233, 241, 220, 1), rgba(27, 70, 20, 1))",
+  "--color-background-warning":
+    "light-dark(rgba(246, 238, 223, 1), rgba(72, 58, 15, 1))",
+  "--color-background-disabled":
+    "light-dark(rgba(255, 255, 255, 0.5), rgba(48, 48, 46, 0.5))",
+  "--color-text-primary":
+    "light-dark(rgba(20, 20, 19, 1), rgba(250, 249, 245, 1))",
+  "--color-text-secondary":
+    "light-dark(rgba(61, 61, 58, 1), rgba(194, 192, 182, 1))",
+  "--color-text-tertiary":
+    "light-dark(rgba(115, 114, 108, 1), rgba(156, 154, 146, 1))",
+  "--color-text-inverse":
+    "light-dark(rgba(255, 255, 255, 1), rgba(20, 20, 19, 1))",
+  "--color-text-ghost":
+    "light-dark(rgba(115, 114, 108, 0.5), rgba(156, 154, 146, 0.5))",
+  "--color-text-info":
+    "light-dark(rgba(50, 102, 173, 1), rgba(128, 170, 221, 1))",
+  "--color-text-danger":
+    "light-dark(rgba(127, 44, 40, 1), rgba(238, 136, 132, 1))",
+  "--color-text-success":
+    "light-dark(rgba(38, 91, 25, 1), rgba(122, 185, 72, 1))",
+  "--color-text-warning":
+    "light-dark(rgba(90, 72, 21, 1), rgba(209, 160, 65, 1))",
+  "--color-text-disabled":
+    "light-dark(rgba(20, 20, 19, 0.5), rgba(250, 249, 245, 0.5))",
+  "--color-border-primary":
+    "light-dark(rgba(31, 30, 29, 0.4), rgba(222, 220, 209, 0.4))",
+  "--color-border-secondary":
+    "light-dark(rgba(31, 30, 29, 0.3), rgba(222, 220, 209, 0.3))",
+  "--color-border-tertiary":
+    "light-dark(rgba(31, 30, 29, 0.15), rgba(222, 220, 209, 0.15))",
+  "--color-border-inverse":
+    "light-dark(rgba(255, 255, 255, 0.3), rgba(20, 20, 19, 0.15))",
+  "--color-border-ghost":
+    "light-dark(rgba(31, 30, 29, 0), rgba(222, 220, 209, 0))",
+  "--color-border-info":
+    "light-dark(rgba(70, 130, 213, 1), rgba(70, 130, 213, 1))",
+  "--color-border-danger":
+    "light-dark(rgba(167, 61, 57, 1), rgba(205, 92, 88, 1))",
+  "--color-border-success":
+    "light-dark(rgba(67, 116, 38, 1), rgba(89, 145, 48, 1))",
+  "--color-border-warning":
+    "light-dark(rgba(128, 92, 31, 1), rgba(168, 120, 41, 1))",
+  "--color-border-disabled":
+    "light-dark(rgba(31, 30, 29, 0.1), rgba(222, 220, 209, 0.1))",
+  "--color-ring-primary":
+    "light-dark(rgba(20, 20, 19, 0.7), rgba(250, 249, 245, 0.7))",
+  "--color-ring-secondary":
+    "light-dark(rgba(61, 61, 58, 0.7), rgba(194, 192, 182, 0.7))",
+  "--color-ring-inverse":
+    "light-dark(rgba(255, 255, 255, 0.7), rgba(20, 20, 19, 0.7))",
+  "--color-ring-info":
+    "light-dark(rgba(50, 102, 173, 0.5), rgba(128, 170, 221, 0.5))",
+  "--color-ring-danger":
+    "light-dark(rgba(167, 61, 57, 0.5), rgba(205, 92, 88, 0.5))",
+  "--color-ring-success":
+    "light-dark(rgba(67, 116, 38, 0.5), rgba(89, 145, 48, 0.5))",
+  "--color-ring-warning":
+    "light-dark(rgba(128, 92, 31, 0.5), rgba(168, 120, 41, 0.5))",
+  "--font-sans": "Anthropic Sans, sans-serif",
+  "--font-mono": "ui-monospace, monospace",
+  "--font-weight-normal": "400",
+  "--font-weight-medium": "500",
+  "--font-weight-semibold": "600",
+  "--font-weight-bold": "700",
+  "--font-text-xs-size": "12px",
+  "--font-text-sm-size": "14px",
+  "--font-text-md-size": "16px",
+  "--font-text-lg-size": "20px",
+  "--font-heading-xs-size": "12px",
+  "--font-heading-sm-size": "14px",
+  "--font-heading-md-size": "16px",
+  "--font-heading-lg-size": "20px",
+  "--font-heading-xl-size": "24px",
+  "--font-heading-2xl-size": "28px",
+  "--font-heading-3xl-size": "36px",
+  "--font-text-xs-line-height": "1.4",
+  "--font-text-sm-line-height": "1.4",
+  "--font-text-md-line-height": "1.4",
+  "--font-text-lg-line-height": "1.25",
+  "--font-heading-xs-line-height": "1.4",
+  "--font-heading-sm-line-height": "1.4",
+  "--font-heading-md-line-height": "1.4",
+  "--font-heading-lg-line-height": "1.25",
+  "--font-heading-xl-line-height": "1.25",
+  "--font-heading-2xl-line-height": "1.1",
+  "--font-heading-3xl-line-height": "1",
+  "--border-radius-xs": "4px",
+  "--border-radius-sm": "6px",
+  "--border-radius-md": "8px",
+  "--border-radius-lg": "10px",
+  "--border-radius-xl": "12px",
+  "--border-radius-full": "9999px",
+  "--border-width-regular": "0.5px",
+  "--shadow-hairline": "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
+  "--shadow-sm":
+    "0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1)",
+  "--shadow-md":
+    "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)",
+  "--shadow-lg":
+    "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1)",
+};
+
+// @font-face block claude.ai injects via hostContext.styles.css.fonts. URL
+// hosts must be allowed in apps.sandbox.csp.resourceDomains (assets.claude.ai)
+// for these to actually load inside the View iframe.
+const CLAUDE_FONTS_CSS = `
+@font-face {
+  font-family: "Anthropic Sans";
+  src: url("https://assets.claude.ai/Fonts/AnthropicSans-Text-Regular-Static.otf") format("opentype");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Anthropic Sans";
+  src: url("https://assets.claude.ai/Fonts/AnthropicSans-Text-RegularItalic-Static.otf") format("opentype");
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Anthropic Sans";
+  src: url("https://assets.claude.ai/Fonts/AnthropicSans-Text-Medium-Static.otf") format("opentype");
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Anthropic Sans";
+  src: url("https://assets.claude.ai/Fonts/AnthropicSans-Text-MediumItalic-Static.otf") format("opentype");
+  font-weight: 500;
+  font-style: italic;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Anthropic Sans";
+  src: url("https://assets.claude.ai/Fonts/AnthropicSans-Text-Semibold-Static.otf") format("opentype");
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Anthropic Sans";
+  src: url("https://assets.claude.ai/Fonts/AnthropicSans-Text-SemiboldItalic-Static.otf") format("opentype");
+  font-weight: 600;
+  font-style: italic;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Anthropic Sans";
+  src: url("https://assets.claude.ai/Fonts/AnthropicSans-Text-Bold-Static.otf") format("opentype");
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: "Anthropic Sans";
+  src: url("https://assets.claude.ai/Fonts/AnthropicSans-Text-BoldItalic-Static.otf") format("opentype");
+  font-weight: 700;
+  font-style: italic;
+  font-display: swap;
+}
+`;
+
+export type HostTemplateId = "mcpjam" | "claude" | "chatgpt";
+
+export interface HostTemplate {
+  id: HostTemplateId;
+  label: string;
+  description: string;
+  logoSrc: string;
+  seed: () => HostConfigInputV2;
+}
+
+export const HOST_TEMPLATES: readonly HostTemplate[] = [
+  {
+    id: "mcpjam",
+    label: "MCPJam",
+    description: "SDK defaults. Pick a model later.",
+    logoSrc: mcpjamLogo,
+    seed: () => emptyHostConfigInputV2(),
+  },
+  {
+    id: "claude",
+    label: "Claude",
+    description: "Anthropic-style host. Tool approval on.",
+    logoSrc: claudeLogo,
+    seed: () => {
+      const base = emptyHostConfigInputV2({
+        hostStyle: "claude",
+        modelId: "claude-sonnet-4-5",
+        temperature: 1.0,
+        requireToolApproval: true,
+      });
+      // clientCapabilities: Real claude.ai publishes only the SDK-default
+      // MCP UI extension (no `experimental` flag). emptyHostConfigInputV2
+      // already seeds that, so no override needed here — distinct from
+      // the ChatGPT template, which adds `experimental.openai/visibility`.
+      //
+      // Override the preset advertise to match what real claude.ai
+      // publishes in ui/initialize. `sandbox` is intentionally omitted —
+      // the canonicalizer strips it from the override (sandbox is per-
+      // resource at runtime per SEP-1865; see mcpProfile.apps.sandbox).
+      // listChanged is advertised here even though the inspector's
+      // renderer doesn't currently forward those notifications (see
+      // host-styles/built-ins.ts:33–37) — kept faithful to real Claude
+      // so apps that gate on it can detect the host. Resolving the
+      // renderer gap is a separate enforcement-side fix.
+      base.hostCapabilitiesOverride = {
+        openLinks: {},
+        downloadFile: {},
+        serverTools: { listChanged: true },
+        serverResources: { listChanged: true },
+        logging: {},
+        updateModelContext: { text: {}, image: {} },
+        message: { text: {} },
+      };
+      // Per-resource environment context claude.ai exposes to MCP apps.
+      // Skips `toolInfo` (per-invocation) and `containerDimensions`
+      // (claude.ai pins width: 720 / maxHeight: 5000, but pinning here
+      // would lie to apps about the inspector's actual viewport width).
+      base.hostContext = {
+        theme: "dark",
+        displayMode: "inline",
+        availableDisplayModes: ["inline", "fullscreen"],
+        locale: "en-US",
+        timeZone: "America/Los_Angeles",
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
+        platform: "web",
+        deviceCapabilities: { touch: false, hover: true },
+        safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+        // SEP-1865 hostContext.styles. Anthropic Sans @font-face URLs
+        // require `assets.claude.ai` in apps.sandbox.csp.resourceDomains
+        // (set below).
+        styles: {
+          variables: CLAUDE_HOST_STYLE_VARIABLES,
+          css: { fonts: CLAUDE_FONTS_CSS },
+        },
+      };
+      base.mcpProfile = {
+        profileVersion: 1,
+        initialize: {
+          // Base MCP protocol: clientInfo sent to MCP servers during
+          // `initialize`. Matches what real claude.ai publishes.
+          clientInfo: { name: "claude-ai", version: "0.1.0" },
+        },
+        apps: {
+          // MCP Apps extension: hostInfo sent to the View iframe in
+          // `ui/initialize`. Apps that branch on `hostInfo.name === "Claude"`
+          // need this to take that path.
+          uiInitialize: {
+            hostInfo: { name: "Claude", version: "1.0.0" },
+          },
+          sandbox: {
+            csp: {
+              mode: "declared",
+              restrictTo: {
+                connectDomains: [
+                  "https://api.openai.com",
+                  "https://api.anthropic.com",
+                  "https://cdn.jsdelivr.net",
+                ],
+                // claude.ai *advertises* only cdn.jsdelivr.net in
+                // hostCapabilities.sandbox.csp.resourceDomains but the
+                // *enforced* sandbox URL adds assets.claude.ai so the
+                // Anthropic Sans @font-face URLs above can load. We
+                // honor the enforced set; otherwise fonts 404 inside the
+                // sandbox.
+                resourceDomains: [
+                  "https://cdn.jsdelivr.net",
+                  "https://assets.claude.ai",
+                ],
+              },
+            },
+            permissions: {
+              mode: "custom",
+              allow: { clipboardWrite: true },
+            },
+          },
+        },
+      };
+      return base;
+    },
+  },
+  {
+    id: "chatgpt",
+    label: "ChatGPT",
+    description: "OpenAI-style host with ChatGPT protocol.",
+    logoSrc: openaiLogo,
+    seed: () => {
+      const base = emptyHostConfigInputV2({
+        hostStyle: "chatgpt",
+        modelId: "gpt-5",
+        temperature: 0.7,
+        requireToolApproval: false,
+      });
+      // Real ChatGPT advertises an `experimental.openai/visibility` flag on top
+      // of the SDK-default MCP UI extension. Keep the default extension block
+      // (mime types) intact; only add the openai-specific experimental key.
+      base.clientCapabilities = {
+        ...base.clientCapabilities,
+        experimental: {
+          "openai/visibility": { enabled: true },
+        },
+      };
+      // Override the preset advertise to match what real ChatGPT publishes in
+      // ui/initialize. `sandbox` is intentionally omitted — host-config-v2's
+      // canonicalizer strips it from the override anyway (sandbox is per-
+      // resource at runtime per SEP-1865; see mcpProfile.apps.sandbox below).
+      base.hostCapabilitiesOverride = {
+        openLinks: {},
+        serverTools: {},
+        serverResources: {},
+        logging: {},
+        message: {},
+        updateModelContext: {},
+      };
+      // Per-resource environment context ChatGPT exposes to MCP apps. Skips
+      // `toolInfo` (per-invocation) and `containerDimensions` (measured at
+      // resource mount); both are filled at runtime, not config time.
+      base.hostContext = {
+        theme: "dark",
+        displayMode: "inline",
+        availableDisplayModes: ["inline", "fullscreen", "pip"],
+        locale: "en-US",
+        timeZone: "America/Los_Angeles",
+        userAgent: "chatgpt",
+        platform: "desktop",
+        deviceCapabilities: {
+          touch: false,
+          hover: true,
+        },
+        safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      };
+      // Host-level MCP profile: identify as openai-mcp during MCP
+      // initialize, and lock the iframe CSP down to the same connect/resource
+      // domain set real ChatGPT publishes. `mode: "declared"` keeps each
+      // resource's own CSP authoritative; `restrictTo` intersects on top so
+      // an MCP app can never reach a domain ChatGPT itself wouldn't allow.
+      base.mcpProfile = {
+        profileVersion: 1,
+        initialize: {
+          // Base MCP protocol: clientInfo sent to MCP servers during
+          // `initialize`. Matches what real ChatGPT publishes.
+          clientInfo: { name: "openai-mcp", version: "1.0.0" },
+        },
+        apps: {
+          // MCP Apps extension: hostInfo sent to the View iframe in
+          // `ui/initialize`. Different protocol layer from clientInfo
+          // above — apps that branch on `hostInfo.name === "chatgpt"`
+          // (e.g. OpenAI Apps SDK widgets) need this to take that path.
+          uiInitialize: {
+            hostInfo: { name: "chatgpt", version: "0.0.1" },
+          },
+          sandbox: {
+            csp: {
+              mode: "declared",
+              restrictTo: {
+                connectDomains: [
+                  "https://api.openai.com",
+                  "https://api.anthropic.com",
+                  "https://cdn.jsdelivr.net",
+                ],
+                resourceDomains: ["https://cdn.jsdelivr.net"],
+              },
+            },
+            permissions: {
+              mode: "custom",
+              allow: { microphone: true },
+            },
+          },
+        },
+      };
+      return base;
+    },
+  },
+];
+
+export const DEFAULT_HOST_TEMPLATE_ID: HostTemplateId = "mcpjam";
+
+export function seedFromHostTemplate(id: HostTemplateId): HostConfigInputV2 {
+  const template =
+    HOST_TEMPLATES.find((t) => t.id === id) ?? HOST_TEMPLATES[0];
+  return template.seed();
+}

--- a/mcpjam-inspector/client/src/lib/host-templates.ts
+++ b/mcpjam-inspector/client/src/lib/host-templates.ts
@@ -244,13 +244,18 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         message: { text: {} },
       };
       // Per-resource environment context claude.ai exposes to MCP apps.
-      // Skips `toolInfo` (per-invocation) and `containerDimensions`
-      // (claude.ai pins width: 720 / maxHeight: 5000, but pinning here
-      // would lie to apps about the inspector's actual viewport width).
+      // Skips `toolInfo` (per-invocation, fills at runtime).
+      // `containerDimensions` is verbatim from claude.ai — clean policy
+      // values (720px wide chat column, 5000px height cap). Per SEP-1865,
+      // Views interpret `width: 720` as "fill your container with width:
+      // 100vw" intent, not a literal claim about the inspector's iframe
+      // width; widgets render at whatever the iframe is, the value
+      // communicates Claude's layout policy.
       base.hostContext = {
         theme: "dark",
         displayMode: "inline",
         availableDisplayModes: ["inline", "fullscreen"],
+        containerDimensions: { width: 720, maxHeight: 5000 },
         locale: "en-US",
         timeZone: "America/Los_Angeles",
         userAgent:
@@ -345,12 +350,17 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         updateModelContext: {},
       };
       // Per-resource environment context ChatGPT exposes to MCP apps. Skips
-      // `toolInfo` (per-invocation) and `containerDimensions` (measured at
-      // resource mount); both are filled at runtime, not config time.
+      // `toolInfo` (per-invocation, fills at runtime). `containerDimensions`
+      // is included as host policy per SEP-1865 — Views interpret it as
+      // "fill your container" intent, not a literal viewport claim. Real
+      // ChatGPT publishes `maxWidth: 767.984375` (runtime-measured
+      // viewport-minus-padding); rounded to the md breakpoint (768) so the
+      // template communicates intent rather than freezing a snapshot.
       base.hostContext = {
         theme: "dark",
         displayMode: "inline",
         availableDisplayModes: ["inline", "fullscreen", "pip"],
+        containerDimensions: { height: 400, maxWidth: 768 },
         locale: "en-US",
         timeZone: "America/Los_Angeles",
         userAgent: "chatgpt",

--- a/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
+++ b/mcpjam-inspector/client/src/lib/hosted-tab-policy.ts
@@ -3,6 +3,7 @@ const HASH_TAB_ALIASES = {
 } as const;
 
 export const HOSTED_SIDEBAR_ALLOWED_TABS = [
+  "hosts",
   "servers",
   "registry",
   "chat-v2",


### PR DESCRIPTION
## Summary

- **Hosts tab** — replaces Servers tab (gated behind `hosts-enabled` PostHog flag); index grid of `HostCard`s + `HostBuilderView` 2-panel editor with inline name edit, Save, and dirty detection across name / config / per-server overrides
- **Per-server override UI** — `ServerConnectionOverrideSection` lets users toggle per-server headers and timeout on top of host-wide `connectionDefaults`
- **Runtime plumbing** — `use-server-state.ts` accepts optional `activeHostConfig`; `withProjectConnectionDefaults` uses host `connectionDefaults` + per-server overrides (via `resolveServerConnectionSettings`) when a host is active; reconnect path threads `serverId` for override lookup
- **HostPicker** — reusable `Select` dropdown of project hosts with "Project default" (null) option; wired into:
  - `CreateChatboxDialog` — seeds model / system prompt / servers; submits `namedHostId` + `hostConfigInput`
  - `CreateSuiteDialog` (evals) — seeds server selection; submits `namedHostId` + `hostConfigInput`
  - Chat tab (App.tsx) — compact picker bar above chat; selected host's executionConfig (model / prompt / temperature / tool approval) flows into `HostStyledChatTabV2`

## New files
`client/src/lib/host-connection-resolve.ts` · `client/src/hooks/useHosts.ts` · `client/src/components/HostsTab.tsx` · `client/src/components/hosts/{types,CreateHostDialog,HostCard,HostIndexPage,HostBuilderView,ServerConnectionOverrideSection,HostPicker}.tsx`

## Test plan

- [ ] Enable `hosts-enabled` PostHog flag → "Hosts" appears in sidebar, `#servers` redirect works when flag is off
- [ ] Create a host → lands in `HostBuilderView`; edit name + config → Save button activates; save persists
- [ ] Change only a per-server override → Save button activates (dirty detection covers overrides)
- [ ] Duplicate host → opens builder for the copy
- [ ] Delete host with no consumers → gone; delete host with consumers → error toast (no force option in UI)
- [ ] `CreateChatboxDialog` with flag on: pick a host → model / system prompt / servers pre-fill; create → chatbox carries `namedHostId`
- [ ] `CreateSuiteDialog` with flag on: pick a host → server checkboxes pre-fill; create → suite carries `namedHostId`
- [ ] Chat tab with flag on: pick a host in picker bar → model and system prompt update in chat session; clear → project defaults restore

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new, feature-flagged host configuration surface that affects how chat execution and server connection defaults/overrides are resolved; mis-selection or incorrect merge behavior could change runtime connectivity across projects.
> 
> **Overview**
> Adds a new `hosts-enabled`-gated **Hosts** experience: sidebar navigation + `HostsTab` with a host index, create/duplicate/delete actions, and a two-panel `HostBuilderView` (canvas + checklist editor) including per-server connection overrides.
> 
> Wires a reusable `HostPicker` into Chat (per-project host selection affecting `executionConfig` and `activeMcpProfile`), `CreateChatboxDialog`, and eval suite creation to optionally seed settings from a named host and persist `namedHostId`/`hostConfigInput` with newly created resources.
> 
> Extends runtime plumbing so `useAppState`/`use-server-state` accept `activeHostConfig` and, when present, resolve connection defaults and per-server overrides (headers/timeout) via new `resolveServerConnectionSettings`; also adds `mcpProfile.apps.uiInitialize.hostInfo` support so MCP Apps `ui/initialize` host identity can be overridden (inline + modal renderer).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8f48d786dd034ad99b31f0ef50313442d3281f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->