### PR TITLE
Ip stuff

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/local-secret-store.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/local-secret-store.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import { getOrCreateLocalSecret } from "../local-secret-store.js";
+
+const ORIGINAL_ENV = { ...process.env };
+
+const spec = {
+  fileName: "test-secret.txt",
+  envVar: "TEST_LOCAL_SECRET",
+  productionErrorMessage: "TEST_LOCAL_SECRET is required",
+  label: "test local secret",
+};
+
+let tempDir: string;
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  tempDir = mkdtempSync(path.join(os.tmpdir(), "mcpjam-local-secret-test-"));
+  process.env.GUEST_JWT_KEY_DIR = tempDir;
+  delete process.env.TEST_LOCAL_SECRET;
+  delete process.env.VITE_MCPJAM_HOSTED_MODE;
+  delete process.env.DOCKER_CONTAINER;
+  delete process.env.RAILWAY_ENVIRONMENT;
+  delete process.env.RAILWAY_SERVICE_ID;
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("getOrCreateLocalSecret", () => {
+  it("uses the env var when present", () => {
+    process.env.NODE_ENV = "production";
+    process.env.VITE_MCPJAM_HOSTED_MODE = "true";
+    process.env.TEST_LOCAL_SECRET = "from-env";
+
+    expect(getOrCreateLocalSecret(spec)).toBe("from-env");
+  });
+
+  it("allows local production runtimes to use the persisted local secret", () => {
+    process.env.NODE_ENV = "production";
+
+    const value = getOrCreateLocalSecret(spec);
+    const filePath = path.join(tempDir, spec.fileName);
+
+    expect(value).toHaveLength(64);
+    expect(existsSync(filePath)).toBe(true);
+    expect(readFileSync(filePath, "utf-8").trim()).toBe(value);
+    expect(getOrCreateLocalSecret(spec)).toBe(value);
+  });
+
+  it("still rejects hosted production without an env var", () => {
+    process.env.NODE_ENV = "production";
+    process.env.DOCKER_CONTAINER = "true";
+
+    expect(() => getOrCreateLocalSecret(spec)).toThrow(
+      "TEST_LOCAL_SECRET is required"
+    );
+    expect(existsSync(path.join(tempDir, spec.fileName))).toBe(false);
+  });
+
+  it("keeps test runtime strict unless an env var is present", () => {
+    process.env.NODE_ENV = "test";
+
+    expect(() => getOrCreateLocalSecret(spec)).toThrow(
+      "TEST_LOCAL_SECRET is required"
+    );
+  });
+});

--- a/mcpjam-inspector/server/utils/local-secret-store.ts
+++ b/mcpjam-inspector/server/utils/local-secret-store.ts
@@ -53,24 +53,44 @@ function loadPersistedLocalSecret(spec: LocalSecretSpec): string | null {
     return value.length > 0 ? value : null;
   } catch (error) {
     logger.warn(
-      `[guest-auth] Failed to load local ${spec.label} (${error instanceof Error ? error.message : String(error)})`,
+      `[guest-auth] Failed to load local ${spec.label} (${
+        error instanceof Error ? error.message : String(error)
+      })`
     );
     return null;
   }
 }
 
+function isHostedRuntime(): boolean {
+  return (
+    process.env.VITE_MCPJAM_HOSTED_MODE === "true" ||
+    process.env.DOCKER_CONTAINER === "true" ||
+    Boolean(process.env.RAILWAY_ENVIRONMENT || process.env.RAILWAY_SERVICE_ID)
+  );
+}
+
+function canUseLocalSecretFile(): boolean {
+  if (process.env.NODE_ENV === "test") {
+    return false;
+  }
+  if (process.env.NODE_ENV === "development") {
+    return true;
+  }
+  return !isHostedRuntime();
+}
+
 /**
  * Resolve a server-side secret with this precedence:
  *   1. Trimmed value of `spec.envVar` if set.
- *   2. Only when `NODE_ENV === "development"`: load the persisted file at
- *      `~/.mcpjam/<fileName>`, or generate, persist, and return a fresh
- *      32-byte hex value.
- *   3. Otherwise (production, test, staging, preview, ci, unset, …):
+ *   2. In local runtimes: load the persisted file at `~/.mcpjam/<fileName>`,
+ *      or generate, persist, and return a fresh 32-byte hex value.
+ *   3. Otherwise (test, hosted Docker/Railway production, staging, preview):
  *      throw `spec.productionErrorMessage`.
  *
- * The allowlist is deliberate: a containerized staging deployment with an
- * ephemeral filesystem would otherwise generate a fresh random secret on
- * every restart, silently invalidating every existing guest-session hash.
+ * Hosted runtimes must fail loudly when a required secret is missing. Local
+ * production runtimes (`npx @mcpjam/inspector`, packaged desktop) still need a
+ * stable local secret because the launcher starts the server with
+ * `NODE_ENV=production`.
  */
 export function getOrCreateLocalSecret(spec: LocalSecretSpec): string {
   const envValue = process.env[spec.envVar]?.trim();
@@ -78,7 +98,7 @@ export function getOrCreateLocalSecret(spec: LocalSecretSpec): string {
     return envValue;
   }
 
-  if (process.env.NODE_ENV !== "development") {
+  if (!canUseLocalSecretFile()) {
     throw new Error(spec.productionErrorMessage);
   }
 


### PR DESCRIPTION
## Summary

- Fix guest IP/rate-limit support for local `npx` runs
- Let local production mode create stable guest secrets on disk
- Keep hosted prod strict: Railway/Docker still must use real env vars
- Add tests for local vs hosted secret behavior

## Why

- Guest rate limits need a stable IP hash pepper
- Guest proxying needs a stable shared secret
- `npx` can run with `NODE_ENV=production`
- Before this, local `npx` could fail because it expected hosted env secrets

## Tests

- Added local-secret-store tests for env, local fallback, hosted rejection, and test-mode rejection