### PR TITLE
Electron Squirrel + Update detector

### DIFF
--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -568,6 +568,11 @@ export function MCPSidebar({
     updateStatus.kind === "pending" || updateStatus.kind === "downloaded";
   const updateInstalling =
     updateStatus.kind === "pending" && updateStatus.installRequested;
+  const handleUpdateClick = () => {
+    if (!updateInstalling) {
+      restartAndInstall();
+    }
+  };
   const [showInviteDialog, setShowInviteDialog] = useState(false);
   const learnMore = useLearnMore();
   const { state, isMobile } = useSidebar();
@@ -637,7 +642,7 @@ export function MCPSidebar({
   return (
     <>
       <Sidebar collapsible="icon" {...props}>
-        <SidebarHeader>
+        <SidebarHeader className="gap-1 px-2 pt-1.5 pb-2">
           <div
             className={cn(
               "no-drag",
@@ -648,7 +653,7 @@ export function MCPSidebar({
               <button
                 type="button"
                 onClick={() => handleNavClick("#servers")}
-                className="flex w-full cursor-pointer items-center justify-center px-4 py-4 transition-opacity hover:opacity-80"
+                className="flex w-full cursor-pointer items-center justify-center px-4 py-3 transition-opacity hover:opacity-80"
               >
                 <img
                   src={
@@ -666,7 +671,7 @@ export function MCPSidebar({
                   type="button"
                   onClick={() => handleNavClick("#servers")}
                   className={cn(
-                    "relative z-0 flex w-full cursor-pointer items-center justify-center py-3 transition-opacity duration-200",
+                    "relative z-0 flex w-full cursor-pointer items-center justify-center py-2 transition-opacity duration-200",
                     /* Reserve space for the collapse control so the logo stays visually centered and
                        clicks on the logo never compete with the invisible hit target. */
                     "px-2 pr-10 hover:opacity-80",
@@ -704,15 +709,18 @@ export function MCPSidebar({
             )}
           </div>
           {showUpdateButton && (
-            <div className="px-2 pb-2">
+            <div className="px-3">
               <Button
                 size="sm"
-                onClick={restartAndInstall}
-                disabled={updateInstalling}
-                className="w-full bg-primary hover:bg-primary/90 text-primary-foreground h-7 text-xs font-medium rounded-md gap-1.5"
+                onClick={handleUpdateClick}
+                aria-disabled={updateInstalling}
+                className={cn(
+                  "h-5 w-full gap-1 rounded-full bg-primary px-2 text-[11px] font-medium text-primary-foreground hover:bg-primary/90",
+                  updateInstalling && "pointer-events-none hover:bg-primary",
+                )}
               >
                 {updateInstalling && (
-                  <Loader2 className="size-3 animate-spin" aria-hidden />
+                  <Loader2 className="size-2.5 animate-spin" aria-hidden />
                 )}
                 {updateInstalling ? "Updating…" : "Update"}
               </Button>

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -562,7 +562,11 @@ export function MCPSidebar({
   const { user } = useAuth();
   const learningEnabled = !!learningFlagEnabled && isAuthenticated;
   const themeMode = usePreferencesStore((s) => s.themeMode);
-  const { updateReady, restartAndInstall } = useUpdateNotification();
+  const { status: updateStatus, restartAndInstall } = useUpdateNotification();
+  const showUpdateButton =
+    updateStatus.kind === "pending" || updateStatus.kind === "downloaded";
+  const updateInstalling =
+    updateStatus.kind === "pending" && updateStatus.installRequested;
   const [showInviteDialog, setShowInviteDialog] = useState(false);
   const learnMore = useLearnMore();
   const { state, isMobile } = useSidebar();
@@ -698,14 +702,15 @@ export function MCPSidebar({
               />
             )}
           </div>
-          {updateReady && (
+          {showUpdateButton && (
             <div className="px-2 pb-2">
               <Button
                 size="sm"
                 onClick={restartAndInstall}
+                disabled={updateInstalling}
                 className="w-full bg-primary hover:bg-primary/90 text-primary-foreground h-7 text-xs font-medium rounded-md"
               >
-                Update & Restart
+                {updateInstalling ? "Updating…" : "Update"}
               </Button>
             </div>
           )}

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   Puzzle,
   UserPlus,
   ShieldCheck,
+  Loader2,
 } from "lucide-react";
 import { usePostHog, useFeatureFlagEnabled } from "posthog-js/react";
 import { standardEventProps } from "@/lib/PosthogUtils";
@@ -708,8 +709,11 @@ export function MCPSidebar({
                 size="sm"
                 onClick={restartAndInstall}
                 disabled={updateInstalling}
-                className="w-full bg-primary hover:bg-primary/90 text-primary-foreground h-7 text-xs font-medium rounded-md"
+                className="w-full bg-primary hover:bg-primary/90 text-primary-foreground h-7 text-xs font-medium rounded-md gap-1.5"
               >
+                {updateInstalling && (
+                  <Loader2 className="size-3 animate-spin" aria-hidden />
+                )}
                 {updateInstalling ? "Updating…" : "Update"}
               </Button>
             </div>

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -708,24 +708,6 @@ export function MCPSidebar({
               />
             )}
           </div>
-          {showUpdateButton && (
-            <div className="px-3">
-              <Button
-                size="sm"
-                onClick={handleUpdateClick}
-                aria-disabled={updateInstalling}
-                className={cn(
-                  "h-5 w-full gap-1 rounded-full bg-primary px-2 text-[11px] font-medium text-primary-foreground hover:bg-primary/90",
-                  updateInstalling && "pointer-events-none hover:bg-primary",
-                )}
-              >
-                {updateInstalling && (
-                  <Loader2 className="size-2.5 animate-spin" aria-hidden />
-                )}
-                {updateInstalling ? "Updating…" : "Update"}
-              </Button>
-            </div>
-          )}
           <SidebarContextSwitcher
             activeProjectId={activeProjectId}
             projects={projects}
@@ -743,6 +725,24 @@ export function MCPSidebar({
             onSwitchOrganization={onSwitchOrganization}
             onSwitchActiveOrganization={onSwitchActiveOrganization}
           />
+          {showUpdateButton && (
+            <div className="px-3 pt-2">
+              <Button
+                size="sm"
+                onClick={handleUpdateClick}
+                aria-disabled={updateInstalling}
+                className={cn(
+                  "h-5 w-full gap-1 rounded-full bg-primary px-2 text-[11px] font-medium text-primary-foreground hover:bg-primary/90",
+                  updateInstalling && "pointer-events-none hover:bg-primary",
+                )}
+              >
+                {updateInstalling && (
+                  <Loader2 className="size-2.5 animate-spin" aria-hidden />
+                )}
+                {updateInstalling ? "Updating…" : "Update"}
+              </Button>
+            </div>
+          )}
         </SidebarHeader>
         <SidebarContent>
           {visibleNavigationSections.map((section, sectionIndex) => {

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-invite-cta.test.tsx
@@ -31,8 +31,9 @@ vi.mock("@/stores/preferences/preferences-provider", () => ({
 
 vi.mock("@/hooks/useUpdateNotification", () => ({
   useUpdateNotification: () => ({
-    updateReady: false,
+    status: { kind: "idle" },
     restartAndInstall: vi.fn(),
+    simulateUpdate: vi.fn(),
   }),
 }));
 

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-context-switcher.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-context-switcher.tsx
@@ -227,7 +227,7 @@ export function SidebarContextSwitcher({
           ? `Switch context: ${activeOrg.name} / ${projectName}`
           : `Switch project: ${projectName}`
       }
-      className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+      className="h-10 p-1.5 data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
     >
       <ProjectIconBadge
         icon={activeProject?.icon}

--- a/mcpjam-inspector/client/src/hooks/__tests__/useUpdateNotification.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useUpdateNotification.test.ts
@@ -1,29 +1,30 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderHook, act } from "@testing-library/react";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import { useUpdateNotification } from "../useUpdateNotification";
+import type { UpdateStatus } from "@/types/electron";
 
-const STORAGE_KEY = "mcpjam-pending-update";
-
-// Helper to set up window.electronAPI mock
-function setupElectronMock() {
-  const mockOnUpdateReady = vi.fn();
-  const mockRemoveUpdateReadyListener = vi.fn();
+function setupElectronMock(initial: UpdateStatus = { kind: "idle" }) {
+  const mockOnUpdateStatus = vi.fn();
+  const mockRemoveUpdateStatusListener = vi.fn();
+  const mockGetUpdateStatus = vi.fn().mockResolvedValue(initial);
   const mockRestartAndInstall = vi.fn();
   const mockSimulateUpdate = vi.fn();
 
   window.isElectron = true;
   window.electronAPI = {
     update: {
-      onUpdateReady: mockOnUpdateReady,
-      removeUpdateReadyListener: mockRemoveUpdateReadyListener,
+      onUpdateStatus: mockOnUpdateStatus,
+      removeUpdateStatusListener: mockRemoveUpdateStatusListener,
+      getUpdateStatus: mockGetUpdateStatus,
       restartAndInstall: mockRestartAndInstall,
       simulateUpdate: mockSimulateUpdate,
     },
   } as any;
 
   return {
-    mockOnUpdateReady,
-    mockRemoveUpdateReadyListener,
+    mockOnUpdateStatus,
+    mockRemoveUpdateStatusListener,
+    mockGetUpdateStatus,
     mockRestartAndInstall,
     mockSimulateUpdate,
   };
@@ -36,81 +37,101 @@ function clearElectronMock() {
 
 describe("useUpdateNotification", () => {
   beforeEach(() => {
-    localStorage.clear();
     clearElectronMock();
   });
 
   describe("initial state", () => {
-    it("returns null when no update is stored", () => {
+    it("returns idle when not running in Electron", () => {
       const { result } = renderHook(() => useUpdateNotification());
-      expect(result.current.updateReady).toBeNull();
+      expect(result.current.status).toEqual({ kind: "idle" });
     });
 
-    it("restores update info from localStorage", () => {
-      const stored = { version: "2.0.0", releaseNotes: "New stuff" };
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+    it("hydrates initial status from main via getUpdateStatus", async () => {
+      const initial: UpdateStatus = {
+        kind: "downloaded",
+        version: "3.0.0",
+        releaseNotes: "Big release",
+      };
+      setupElectronMock(initial);
 
       const { result } = renderHook(() => useUpdateNotification());
-      expect(result.current.updateReady).toEqual(stored);
-    });
 
-    it("returns null when localStorage has invalid JSON", () => {
-      localStorage.setItem(STORAGE_KEY, "not-json{{{");
-
-      const { result } = renderHook(() => useUpdateNotification());
-      expect(result.current.updateReady).toBeNull();
+      await waitFor(() => {
+        expect(result.current.status).toEqual(initial);
+      });
     });
   });
 
-  describe("Electron update listener", () => {
-    it("registers onUpdateReady listener in Electron", () => {
-      const { mockOnUpdateReady } = setupElectronMock();
+  describe("Electron status listener", () => {
+    it("registers onUpdateStatus listener in Electron", () => {
+      const { mockOnUpdateStatus } = setupElectronMock();
 
       renderHook(() => useUpdateNotification());
-      expect(mockOnUpdateReady).toHaveBeenCalledWith(expect.any(Function));
+      expect(mockOnUpdateStatus).toHaveBeenCalledWith(expect.any(Function));
     });
 
     it("does not register listener when not in Electron", () => {
-      // window.isElectron is undefined
       const { result } = renderHook(() => useUpdateNotification());
-      expect(result.current.updateReady).toBeNull();
+      expect(result.current.status).toEqual({ kind: "idle" });
     });
 
-    it("sets updateReady and persists to localStorage when update arrives", () => {
-      const { mockOnUpdateReady } = setupElectronMock();
+    it("transitions through pending → downloaded as main broadcasts", () => {
+      const { mockOnUpdateStatus } = setupElectronMock();
 
       const { result } = renderHook(() => useUpdateNotification());
-
-      // Grab the callback that was passed to onUpdateReady
-      const callback = mockOnUpdateReady.mock.calls[0][0];
-      const updateInfo = { version: "3.0.0", releaseNotes: "Big release" };
+      const callback = mockOnUpdateStatus.mock.calls[0][0];
 
       act(() => {
-        callback(updateInfo);
+        callback({ kind: "pending", installRequested: false });
+      });
+      expect(result.current.status).toEqual({
+        kind: "pending",
+        installRequested: false,
       });
 
-      expect(result.current.updateReady).toEqual(updateInfo);
-      expect(localStorage.getItem(STORAGE_KEY)).toBe(
-        JSON.stringify(updateInfo),
-      );
+      act(() => {
+        callback({
+          kind: "downloaded",
+          version: "3.0.0",
+          releaseNotes: "Big release",
+        });
+      });
+      expect(result.current.status).toEqual({
+        kind: "downloaded",
+        version: "3.0.0",
+        releaseNotes: "Big release",
+      });
+    });
+
+    it("reflects installRequested flag from pending status", () => {
+      const { mockOnUpdateStatus } = setupElectronMock();
+
+      const { result } = renderHook(() => useUpdateNotification());
+      const callback = mockOnUpdateStatus.mock.calls[0][0];
+
+      act(() => {
+        callback({ kind: "pending", installRequested: true });
+      });
+
+      expect(result.current.status).toEqual({
+        kind: "pending",
+        installRequested: true,
+      });
     });
 
     it("removes listener on unmount", () => {
-      const { mockRemoveUpdateReadyListener } = setupElectronMock();
+      const { mockRemoveUpdateStatusListener } = setupElectronMock();
 
       const { unmount } = renderHook(() => useUpdateNotification());
       unmount();
 
-      expect(mockRemoveUpdateReadyListener).toHaveBeenCalled();
+      expect(mockRemoveUpdateStatusListener).toHaveBeenCalled();
     });
   });
 
   describe("restartAndInstall", () => {
-    it("clears localStorage and calls Electron API", () => {
+    it("forwards to the Electron API", () => {
       const { mockRestartAndInstall } = setupElectronMock();
-
-      // Simulate a stored update
-      localStorage.setItem(STORAGE_KEY, JSON.stringify({ version: "2.0.0" }));
 
       const { result } = renderHook(() => useUpdateNotification());
 
@@ -118,14 +139,12 @@ describe("useUpdateNotification", () => {
         result.current.restartAndInstall();
       });
 
-      expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
       expect(mockRestartAndInstall).toHaveBeenCalled();
     });
 
     it("does nothing when not in Electron", () => {
       const { result } = renderHook(() => useUpdateNotification());
 
-      // Should not throw
       act(() => {
         result.current.restartAndInstall();
       });
@@ -133,7 +152,7 @@ describe("useUpdateNotification", () => {
   });
 
   describe("simulateUpdate", () => {
-    it("calls Electron simulate API", () => {
+    it("calls the Electron simulate API", () => {
       const { mockSimulateUpdate } = setupElectronMock();
 
       const { result } = renderHook(() => useUpdateNotification());

--- a/mcpjam-inspector/client/src/hooks/__tests__/useUpdateNotification.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useUpdateNotification.test.ts
@@ -127,6 +127,36 @@ describe("useUpdateNotification", () => {
       });
     });
 
+    it("does not let a slower initial snapshot overwrite a live status event", async () => {
+      const { mockGetUpdateStatus, mockOnUpdateStatus } = setupElectronMock();
+      let resolveInitialStatus!: (status: UpdateStatus) => void;
+      mockGetUpdateStatus.mockReturnValueOnce(
+        new Promise<UpdateStatus>((resolve) => {
+          resolveInitialStatus = resolve;
+        }),
+      );
+
+      const { result } = renderHook(() => useUpdateNotification());
+      const callback = mockOnUpdateStatus.mock.calls[0][0];
+
+      act(() => {
+        callback({ kind: "pending", installRequested: false });
+      });
+      expect(result.current.status).toEqual({
+        kind: "pending",
+        installRequested: false,
+      });
+
+      await act(async () => {
+        resolveInitialStatus({ kind: "idle" });
+      });
+
+      expect(result.current.status).toEqual({
+        kind: "pending",
+        installRequested: false,
+      });
+    });
+
     it("reflects installRequested flag from pending status", () => {
       const { mockOnUpdateStatus } = setupElectronMock();
 

--- a/mcpjam-inspector/client/src/hooks/__tests__/useUpdateNotification.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useUpdateNotification.test.ts
@@ -3,30 +3,52 @@ import { renderHook, act, waitFor } from "@testing-library/react";
 import { useUpdateNotification } from "../useUpdateNotification";
 import type { UpdateStatus } from "@/types/electron";
 
+const { mockToastError } = vi.hoisted(() => ({
+  mockToastError: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: mockToastError,
+  },
+}));
+
 function setupElectronMock(initial: UpdateStatus = { kind: "idle" }) {
   const mockOnUpdateStatus = vi.fn();
   const mockRemoveUpdateStatusListener = vi.fn();
+  const mockOnUpdateError = vi.fn();
+  const mockRemoveUpdateErrorListener = vi.fn();
   const mockGetUpdateStatus = vi.fn().mockResolvedValue(initial);
   const mockRestartAndInstall = vi.fn();
   const mockSimulateUpdate = vi.fn();
+  const mockSimulateUpdateDownloaded = vi.fn();
+  const mockSimulateUpdateError = vi.fn();
 
   window.isElectron = true;
   window.electronAPI = {
     update: {
       onUpdateStatus: mockOnUpdateStatus,
       removeUpdateStatusListener: mockRemoveUpdateStatusListener,
+      onUpdateError: mockOnUpdateError,
+      removeUpdateErrorListener: mockRemoveUpdateErrorListener,
       getUpdateStatus: mockGetUpdateStatus,
       restartAndInstall: mockRestartAndInstall,
       simulateUpdate: mockSimulateUpdate,
+      simulateUpdateDownloaded: mockSimulateUpdateDownloaded,
+      simulateUpdateError: mockSimulateUpdateError,
     },
   } as any;
 
   return {
     mockOnUpdateStatus,
     mockRemoveUpdateStatusListener,
+    mockOnUpdateError,
+    mockRemoveUpdateErrorListener,
     mockGetUpdateStatus,
     mockRestartAndInstall,
     mockSimulateUpdate,
+    mockSimulateUpdateDownloaded,
+    mockSimulateUpdateError,
   };
 }
 
@@ -38,6 +60,7 @@ function clearElectronMock() {
 describe("useUpdateNotification", () => {
   beforeEach(() => {
     clearElectronMock();
+    mockToastError.mockClear();
   });
 
   describe("initial state", () => {
@@ -64,10 +87,11 @@ describe("useUpdateNotification", () => {
 
   describe("Electron status listener", () => {
     it("registers onUpdateStatus listener in Electron", () => {
-      const { mockOnUpdateStatus } = setupElectronMock();
+      const { mockOnUpdateStatus, mockOnUpdateError } = setupElectronMock();
 
       renderHook(() => useUpdateNotification());
       expect(mockOnUpdateStatus).toHaveBeenCalledWith(expect.any(Function));
+      expect(mockOnUpdateError).toHaveBeenCalledWith(expect.any(Function));
     });
 
     it("does not register listener when not in Electron", () => {
@@ -119,13 +143,32 @@ describe("useUpdateNotification", () => {
       });
     });
 
+    it("shows a generic toast when main reports an update error", () => {
+      const { mockOnUpdateError } = setupElectronMock();
+
+      renderHook(() => useUpdateNotification());
+      const callback = mockOnUpdateError.mock.calls[0][0];
+
+      act(() => {
+        callback();
+      });
+
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Update failed. Try again later.",
+      );
+    });
+
     it("removes listener on unmount", () => {
-      const { mockRemoveUpdateStatusListener } = setupElectronMock();
+      const {
+        mockRemoveUpdateStatusListener,
+        mockRemoveUpdateErrorListener,
+      } = setupElectronMock();
 
       const { unmount } = renderHook(() => useUpdateNotification());
       unmount();
 
       expect(mockRemoveUpdateStatusListener).toHaveBeenCalled();
+      expect(mockRemoveUpdateErrorListener).toHaveBeenCalled();
     });
   });
 
@@ -153,15 +196,23 @@ describe("useUpdateNotification", () => {
 
   describe("simulateUpdate", () => {
     it("calls the Electron simulate API", () => {
-      const { mockSimulateUpdate } = setupElectronMock();
+      const {
+        mockSimulateUpdate,
+        mockSimulateUpdateDownloaded,
+        mockSimulateUpdateError,
+      } = setupElectronMock();
 
       const { result } = renderHook(() => useUpdateNotification());
 
       act(() => {
         result.current.simulateUpdate();
+        result.current.simulateUpdateDownloaded();
+        result.current.simulateUpdateError();
       });
 
       expect(mockSimulateUpdate).toHaveBeenCalled();
+      expect(mockSimulateUpdateDownloaded).toHaveBeenCalled();
+      expect(mockSimulateUpdateError).toHaveBeenCalled();
     });
   });
 });

--- a/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
+++ b/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
@@ -1,62 +1,38 @@
 import { useEffect, useState, useCallback } from "react";
-
-interface UpdateInfo {
-  version: string;
-  releaseNotes?: string;
-}
-
-const STORAGE_KEY = "mcpjam-pending-update";
+import type { UpdateStatus } from "@/types/electron";
 
 export function useUpdateNotification() {
-  const [updateReady, setUpdateReady] = useState<UpdateInfo | null>(() => {
-    // Check localStorage on initial load
-    if (typeof window !== "undefined") {
-      const saved = localStorage.getItem(STORAGE_KEY);
-      if (saved) {
-        try {
-          return JSON.parse(saved);
-        } catch {
-          return null;
-        }
-      }
-    }
-    return null;
-  });
+  const [status, setStatus] = useState<UpdateStatus>({ kind: "idle" });
 
   useEffect(() => {
-    // Only set up if running in Electron
     if (!window.isElectron || !window.electronAPI?.update) {
       return;
     }
+    const api = window.electronAPI.update;
 
-    const handleUpdateReady = (info: UpdateInfo) => {
-      console.log("Update ready:", info);
-      setUpdateReady(info);
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(info));
-    };
+    let cancelled = false;
+    api.getUpdateStatus().then((initial) => {
+      if (!cancelled) setStatus(initial);
+    });
 
-    window.electronAPI.update.onUpdateReady(handleUpdateReady);
+    api.onUpdateStatus((next) => setStatus(next));
 
     return () => {
-      window.electronAPI?.update?.removeUpdateReadyListener();
+      cancelled = true;
+      window.electronAPI?.update?.removeUpdateStatusListener();
     };
   }, []);
 
   const restartAndInstall = useCallback(() => {
-    if (window.electronAPI?.update) {
-      localStorage.removeItem(STORAGE_KEY);
-      window.electronAPI.update.restartAndInstall();
-    }
+    window.electronAPI?.update?.restartAndInstall();
   }, []);
 
   const simulateUpdate = useCallback(() => {
-    if (window.electronAPI?.update) {
-      window.electronAPI.update.simulateUpdate?.();
-    }
+    window.electronAPI?.update?.simulateUpdate?.();
   }, []);
 
   return {
-    updateReady,
+    status,
     restartAndInstall,
     simulateUpdate,
   };

--- a/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
+++ b/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
@@ -26,9 +26,13 @@ export function useUpdateNotification() {
     // Initial snapshot — apply only if a live event hasn't already overtaken it.
     // Avoids a startup race where an older idle snapshot overwrites a live
     // pending/downloaded event and hides the button until the next broadcast.
-    api.getUpdateStatus().then((initial) => {
-      if (!cancelled && !liveEventReceived) setStatus(initial);
-    });
+    api.getUpdateStatus()
+      .then((initial) => {
+        if (!cancelled && !liveEventReceived) setStatus(initial);
+      })
+      .catch((error) => {
+        console.warn("Failed to get update status", error);
+      });
 
     return () => {
       cancelled = true;

--- a/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
+++ b/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
@@ -12,13 +12,22 @@ export function useUpdateNotification() {
     const api = window.electronAPI.update;
 
     let cancelled = false;
-    api.getUpdateStatus().then((initial) => {
-      if (!cancelled) setStatus(initial);
+    // Subscribe first so we don't miss broadcasts that arrive between the
+    // getUpdateStatus() call and its resolution.
+    let liveEventReceived = false;
+    api.onUpdateStatus((next) => {
+      liveEventReceived = true;
+      setStatus(next);
     });
-
-    api.onUpdateStatus((next) => setStatus(next));
     api.onUpdateError(() => {
       toast.error("Update failed. Try again later.");
+    });
+
+    // Initial snapshot — apply only if a live event hasn't already overtaken it.
+    // Avoids a startup race where an older idle snapshot overwrites a live
+    // pending/downloaded event and hides the button until the next broadcast.
+    api.getUpdateStatus().then((initial) => {
+      if (!cancelled && !liveEventReceived) setStatus(initial);
     });
 
     return () => {

--- a/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
+++ b/mcpjam-inspector/client/src/hooks/useUpdateNotification.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
+import { toast } from "sonner";
 import type { UpdateStatus } from "@/types/electron";
 
 export function useUpdateNotification() {
@@ -16,10 +17,14 @@ export function useUpdateNotification() {
     });
 
     api.onUpdateStatus((next) => setStatus(next));
+    api.onUpdateError(() => {
+      toast.error("Update failed. Try again later.");
+    });
 
     return () => {
       cancelled = true;
       window.electronAPI?.update?.removeUpdateStatusListener();
+      window.electronAPI?.update?.removeUpdateErrorListener();
     };
   }, []);
 
@@ -31,9 +36,19 @@ export function useUpdateNotification() {
     window.electronAPI?.update?.simulateUpdate?.();
   }, []);
 
+  const simulateUpdateDownloaded = useCallback(() => {
+    window.electronAPI?.update?.simulateUpdateDownloaded?.();
+  }, []);
+
+  const simulateUpdateError = useCallback(() => {
+    window.electronAPI?.update?.simulateUpdateError?.();
+  }, []);
+
   return {
     status,
     restartAndInstall,
     simulateUpdate,
+    simulateUpdateDownloaded,
+    simulateUpdateError,
   };
 }

--- a/mcpjam-inspector/client/src/types/electron.d.ts
+++ b/mcpjam-inspector/client/src/types/electron.d.ts
@@ -43,9 +43,13 @@ export interface ElectronAPI {
   update: {
     onUpdateStatus: (callback: (status: UpdateStatus) => void) => void;
     removeUpdateStatusListener: () => void;
+    onUpdateError: (callback: () => void) => void;
+    removeUpdateErrorListener: () => void;
     getUpdateStatus: () => Promise<UpdateStatus>;
     restartAndInstall: () => void;
     simulateUpdate?: () => void;
+    simulateUpdateDownloaded?: () => void;
+    simulateUpdateError?: () => void;
   };
 }
 

--- a/mcpjam-inspector/client/src/types/electron.d.ts
+++ b/mcpjam-inspector/client/src/types/electron.d.ts
@@ -1,7 +1,7 @@
-export interface UpdateInfo {
-  version: string;
-  releaseNotes?: string;
-}
+export type UpdateStatus =
+  | { kind: "idle" }
+  | { kind: "pending"; version?: string; installRequested: boolean }
+  | { kind: "downloaded"; version: string; releaseNotes?: string };
 
 export interface ElectronAPI {
   // App metadata
@@ -41,8 +41,9 @@ export interface ElectronAPI {
 
   // Update operations
   update: {
-    onUpdateReady: (callback: (info: UpdateInfo) => void) => void;
-    removeUpdateReadyListener: () => void;
+    onUpdateStatus: (callback: (status: UpdateStatus) => void) => void;
+    removeUpdateStatusListener: () => void;
+    getUpdateStatus: () => Promise<UpdateStatus>;
     restartAndInstall: () => void;
     simulateUpdate?: () => void;
   };

--- a/mcpjam-inspector/server/__tests__/update-listeners.test.ts
+++ b/mcpjam-inspector/server/__tests__/update-listeners.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  appState,
+  autoUpdaterHandlers,
+  checkForUpdatesMock,
+  getAllWindowsMock,
+  ipcHandleMock,
+  ipcOnMock,
+  ipcHandlers,
+  ipcListeners,
+  logErrorMock,
+  logInfoMock,
+  logWarnMock,
+  quitAndInstallMock,
+  windows,
+} = vi.hoisted(() => {
+  const appState = { isPackaged: true };
+  const autoUpdaterHandlers = new Map<
+    string,
+    Array<(...args: any[]) => void>
+  >();
+  const ipcHandlers = new Map<string, (...args: any[]) => any>();
+  const ipcListeners = new Map<string, (...args: any[]) => void>();
+  const windows: any[] = [];
+
+  return {
+    appState,
+    autoUpdaterHandlers,
+    checkForUpdatesMock: vi.fn(),
+    getAllWindowsMock: vi.fn(() => windows),
+    ipcHandleMock: vi.fn(
+      (channel: string, handler: (...args: any[]) => any) => {
+        ipcHandlers.set(channel, handler);
+      }
+    ),
+    ipcOnMock: vi.fn((channel: string, handler: (...args: any[]) => void) => {
+      ipcListeners.set(channel, handler);
+    }),
+    ipcHandlers,
+    ipcListeners,
+    logErrorMock: vi.fn(),
+    logInfoMock: vi.fn(),
+    logWarnMock: vi.fn(),
+    quitAndInstallMock: vi.fn(),
+    windows,
+  };
+});
+
+vi.mock("electron", () => ({
+  app: appState,
+  autoUpdater: {
+    checkForUpdates: checkForUpdatesMock,
+    on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+      const handlers = autoUpdaterHandlers.get(event) ?? [];
+      handlers.push(handler);
+      autoUpdaterHandlers.set(event, handlers);
+    }),
+    quitAndInstall: quitAndInstallMock,
+  },
+  BrowserWindow: {
+    getAllWindows: getAllWindowsMock,
+  },
+  ipcMain: {
+    handle: ipcHandleMock,
+    on: ipcOnMock,
+  },
+}));
+
+vi.mock("electron-log", () => ({
+  default: {
+    error: logErrorMock,
+    info: logInfoMock,
+    warn: logWarnMock,
+  },
+}));
+
+function createWindow(id = 1) {
+  return {
+    isDestroyed: vi.fn(() => false),
+    webContents: {
+      id,
+      isLoading: vi.fn(() => false),
+      once: vi.fn(),
+      send: vi.fn(),
+    },
+  };
+}
+
+function emitAutoUpdaterEvent(event: string, ...args: any[]) {
+  for (const handler of autoUpdaterHandlers.get(event) ?? []) {
+    handler(...args);
+  }
+}
+
+async function loadUpdateListeners() {
+  vi.resetModules();
+  const mod = await import("../../src/ipc/update/update-listeners.js");
+  mod.setupAutoUpdaterEvents();
+  return mod;
+}
+
+describe("update-listeners", () => {
+  beforeEach(() => {
+    appState.isPackaged = true;
+    autoUpdaterHandlers.clear();
+    ipcHandlers.clear();
+    ipcListeners.clear();
+    windows.splice(0, windows.length);
+  });
+
+  it("keeps the update button visible when update-not-available follows an available update", async () => {
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+
+    emitAutoUpdaterEvent("update-available");
+    emitAutoUpdaterEvent("update-not-available");
+
+    expect(window.webContents.send).toHaveBeenLastCalledWith("update-status", {
+      kind: "pending",
+      installRequested: false,
+    });
+    expect(
+      ipcHandlers.get("app:get-update-status")?.({ sender: { id: 1 } })
+    ).toEqual({ kind: "pending", installRequested: false });
+  });
+
+  it("queues install when the user clicks Update while the download is still pending", async () => {
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    emitAutoUpdaterEvent("update-available");
+
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+
+    expect(checkForUpdatesMock).not.toHaveBeenCalled();
+    expect(window.webContents.send).toHaveBeenLastCalledWith("update-status", {
+      kind: "pending",
+      installRequested: true,
+    });
+
+    emitAutoUpdaterEvent("update-downloaded", {}, "", "2.4.11");
+
+    expect(quitAndInstallMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets the user retry from a pending state after a prior updater error", async () => {
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    emitAutoUpdaterEvent("update-available");
+    emitAutoUpdaterEvent("error", new Error("download failed"));
+
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+
+    expect(checkForUpdatesMock).toHaveBeenCalledTimes(1);
+    expect(window.webContents.send).toHaveBeenLastCalledWith("update-status", {
+      kind: "pending",
+      installRequested: true,
+    });
+  });
+
+  it("keeps the button visible and notifies after a user-requested install fails", async () => {
+    const window = createWindow();
+    windows.push(window);
+    const { registerUpdateListeners } = await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    emitAutoUpdaterEvent("update-available");
+    ipcListeners.get("app:restart-for-update")?.({ sender: { id: 1 } });
+
+    emitAutoUpdaterEvent("error", new Error("download failed"));
+
+    expect(window.webContents.send).toHaveBeenCalledWith("update-status", {
+      kind: "pending",
+      installRequested: false,
+    });
+    expect(window.webContents.send).toHaveBeenCalledWith("update-error");
+  });
+});

--- a/mcpjam-inspector/server/__tests__/update-listeners.test.ts
+++ b/mcpjam-inspector/server/__tests__/update-listeners.test.ts
@@ -184,4 +184,18 @@ describe("update-listeners", () => {
     });
     expect(window.webContents.send).toHaveBeenCalledWith("update-error");
   });
+
+  it("does not try to install simulated downloaded updates on quit in dev", async () => {
+    appState.isPackaged = false;
+    const window = createWindow();
+    windows.push(window);
+    const { installUpdateOnQuit, registerUpdateListeners } =
+      await loadUpdateListeners();
+
+    registerUpdateListeners(window as any);
+    ipcListeners.get("app:simulate-update-downloaded")?.({ sender: { id: 1 } });
+
+    expect(installUpdateOnQuit()).toBe(false);
+    expect(quitAndInstallMock).not.toHaveBeenCalled();
+  });
 });

--- a/mcpjam-inspector/src/ipc/update/update-listeners.ts
+++ b/mcpjam-inspector/src/ipc/update/update-listeners.ts
@@ -8,6 +8,7 @@ export type UpdateStatus =
 
 let currentStatus: UpdateStatus = { kind: "idle" };
 let isQuittingForUpdate = false;
+let isCheckingOrDownloading = false;
 let trustedWindow: BrowserWindow | null = null;
 let updateListenersRegistered = false;
 
@@ -61,10 +62,12 @@ function setStatus(next: UpdateStatus): void {
 
 export function setupAutoUpdaterEvents(): void {
   autoUpdater.on("checking-for-update", () => {
+    isCheckingOrDownloading = true;
     log.info("Checking for updates...");
   });
 
   autoUpdater.on("update-available", () => {
+    isCheckingOrDownloading = true;
     log.info("Update available, downloading...");
     const installRequested =
       currentStatus.kind === "pending" ? currentStatus.installRequested : false;
@@ -72,21 +75,43 @@ export function setupAutoUpdaterEvents(): void {
   });
 
   autoUpdater.on("update-not-available", () => {
+    isCheckingOrDownloading = false;
     log.info("No updates available");
-    setStatus({ kind: "idle" });
+    if (currentStatus.kind === "idle") {
+      setStatus({ kind: "idle" });
+      return;
+    }
+    if (currentStatus.kind === "pending" && currentStatus.installRequested) {
+      setStatus({ ...currentStatus, installRequested: false });
+    }
+    log.info(
+      `Keeping visible update status after update-not-available: ${currentStatus.kind}`,
+    );
   });
 
   autoUpdater.on("error", (error) => {
+    isCheckingOrDownloading = false;
     log.error("Auto-updater error:", error);
     const shouldNotifyUser =
-      currentStatus.kind === "pending" && currentStatus.installRequested;
-    setStatus({ kind: "idle" });
+      (currentStatus.kind === "pending" && currentStatus.installRequested) ||
+      isQuittingForUpdate;
+
+    if (currentStatus.kind === "pending") {
+      setStatus({ ...currentStatus, installRequested: false });
+    } else if (currentStatus.kind === "downloaded") {
+      setStatus(currentStatus);
+    } else {
+      setStatus({ kind: "idle" });
+    }
+    isQuittingForUpdate = false;
+
     if (shouldNotifyUser) {
       broadcastUpdateError();
     }
   });
 
   autoUpdater.on("update-downloaded", (_event, releaseNotes, releaseName) => {
+    isCheckingOrDownloading = false;
     log.info(`Update downloaded: ${releaseName}`);
     const installRequested =
       currentStatus.kind === "pending" ? currentStatus.installRequested : false;
@@ -135,6 +160,17 @@ export function registerUpdateListeners(mainWindow: BrowserWindow): void {
     } else if (currentStatus.kind === "pending") {
       log.info("Update still downloading — queuing install for completion");
       setStatus({ ...currentStatus, installRequested: true });
+      if (!isCheckingOrDownloading) {
+        try {
+          isCheckingOrDownloading = true;
+          autoUpdater.checkForUpdates();
+        } catch (error) {
+          isCheckingOrDownloading = false;
+          log.error("Failed to retry update check:", error);
+          setStatus({ ...currentStatus, installRequested: false });
+          broadcastUpdateError();
+        }
+      }
     } else {
       log.info("Restart requested but no update is staged");
     }
@@ -182,7 +218,13 @@ export function registerUpdateListeners(mainWindow: BrowserWindow): void {
       log.error("Auto-updater error:", new Error("Simulated update failure"));
       const shouldNotifyUser =
         currentStatus.kind === "pending" && currentStatus.installRequested;
-      setStatus({ kind: "idle" });
+      if (currentStatus.kind === "pending") {
+        setStatus({ ...currentStatus, installRequested: false });
+      } else if (currentStatus.kind === "downloaded") {
+        setStatus(currentStatus);
+      } else {
+        setStatus({ kind: "idle" });
+      }
       if (shouldNotifyUser) {
         broadcastUpdateError();
       }
@@ -204,6 +246,7 @@ export function installUpdateOnQuit(): boolean {
 export function __resetUpdateStateForTests(): void {
   currentStatus = { kind: "idle" };
   isQuittingForUpdate = false;
+  isCheckingOrDownloading = false;
   trustedWindow = null;
   updateListenersRegistered = false;
 }

--- a/mcpjam-inspector/src/ipc/update/update-listeners.ts
+++ b/mcpjam-inspector/src/ipc/update/update-listeners.ts
@@ -1,73 +1,209 @@
-import { ipcMain, BrowserWindow, autoUpdater } from "electron";
+import { ipcMain, BrowserWindow, autoUpdater, app } from "electron";
 import log from "electron-log";
 
-const isDev = process.env.NODE_ENV === "development";
+export type UpdateStatus =
+  | { kind: "idle" }
+  | { kind: "pending"; version?: string; installRequested: boolean }
+  | { kind: "downloaded"; version: string; releaseNotes?: string };
 
-function sendToRenderer(
-  mainWindow: BrowserWindow,
-  channel: string,
-  payload: unknown,
-): void {
-  if (mainWindow.isDestroyed()) return;
-  const wc = mainWindow.webContents;
-  if (wc.isDestroyed()) return;
-  wc.send(channel, payload);
+let currentStatus: UpdateStatus = { kind: "idle" };
+let isQuittingForUpdate = false;
+let trustedWindow: BrowserWindow | null = null;
+let updateListenersRegistered = false;
+
+function isTrustedSender(senderId: number): boolean {
+  return (
+    trustedWindow !== null &&
+    !trustedWindow.isDestroyed() &&
+    senderId === trustedWindow.webContents.id
+  );
 }
 
-export function registerUpdateListeners(mainWindow: BrowserWindow): void {
-  // Handle restart request from renderer
-  ipcMain.on("app:restart-for-update", (event) => {
-    if (event.sender.id !== mainWindow.webContents.id) {
-      log.warn(
-        `Ignoring restart-for-update from untrusted sender (id: ${event.sender.id})`,
-      );
-      return;
-    }
-    log.info("Restarting app to install update...");
-    autoUpdater.quitAndInstall();
-  });
+export function setTrustedUpdateWindow(window: BrowserWindow): void {
+  trustedWindow = window;
 
-  // Dev only: simulate update for testing UI
-  if (isDev) {
-    ipcMain.on("app:simulate-update", (event) => {
-      if (event.sender.id !== mainWindow.webContents.id) {
-        log.warn(
-          `Ignoring simulate-update from untrusted sender (id: ${event.sender.id})`,
-        );
-        return;
+  if (currentStatus.kind === "idle") {
+    return;
+  }
+
+  if (window.webContents.isLoading()) {
+    window.webContents.once("did-finish-load", () => {
+      if (!window.isDestroyed()) {
+        window.webContents.send("update-status", currentStatus);
       }
-      log.info("Simulating update available (dev mode)");
-      sendToRenderer(mainWindow, "update-ready", {
-        version: "99.0.0",
-        releaseNotes: "Simulated update for testing",
-      });
     });
+    return;
+  }
+
+  window.webContents.send("update-status", currentStatus);
+}
+
+function broadcast(): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send("update-status", currentStatus);
+    }
   }
 }
 
-export function setupAutoUpdaterEvents(mainWindow: BrowserWindow): void {
-  // Listen for update-downloaded event from autoUpdater
-  autoUpdater.on("update-downloaded", (event, releaseNotes, releaseName) => {
-    log.info(`Update downloaded: ${releaseName}`);
-    sendToRenderer(mainWindow, "update-ready", {
-      version: releaseName || "new version",
-      releaseNotes: releaseNotes || "",
-    });
-  });
+function broadcastUpdateError(): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (!win.isDestroyed()) {
+      win.webContents.send("update-error");
+    }
+  }
+}
 
+function setStatus(next: UpdateStatus): void {
+  currentStatus = next;
+  broadcast();
+}
+
+export function setupAutoUpdaterEvents(): void {
   autoUpdater.on("checking-for-update", () => {
     log.info("Checking for updates...");
   });
 
   autoUpdater.on("update-available", () => {
     log.info("Update available, downloading...");
+    const installRequested =
+      currentStatus.kind === "pending" ? currentStatus.installRequested : false;
+    setStatus({ kind: "pending", installRequested });
   });
 
   autoUpdater.on("update-not-available", () => {
     log.info("No updates available");
+    setStatus({ kind: "idle" });
   });
 
   autoUpdater.on("error", (error) => {
     log.error("Auto-updater error:", error);
+    const shouldNotifyUser =
+      currentStatus.kind === "pending" && currentStatus.installRequested;
+    setStatus({ kind: "idle" });
+    if (shouldNotifyUser) {
+      broadcastUpdateError();
+    }
   });
+
+  autoUpdater.on("update-downloaded", (_event, releaseNotes, releaseName) => {
+    log.info(`Update downloaded: ${releaseName}`);
+    const installRequested =
+      currentStatus.kind === "pending" ? currentStatus.installRequested : false;
+    setStatus({
+      kind: "downloaded",
+      version: releaseName || "new version",
+      releaseNotes: releaseNotes || "",
+    });
+    if (installRequested && !isQuittingForUpdate) {
+      log.info("User had requested install — restarting now");
+      isQuittingForUpdate = true;
+      autoUpdater.quitAndInstall();
+    }
+  });
+}
+
+export function registerUpdateListeners(mainWindow: BrowserWindow): void {
+  setTrustedUpdateWindow(mainWindow);
+
+  if (updateListenersRegistered) {
+    return;
+  }
+  updateListenersRegistered = true;
+
+  ipcMain.handle("app:get-update-status", (event) => {
+    if (!isTrustedSender(event.sender.id)) {
+      log.warn(
+        `Ignoring get-update-status from untrusted sender (id: ${event.sender.id})`,
+      );
+      return { kind: "idle" } satisfies UpdateStatus;
+    }
+    return currentStatus;
+  });
+
+  ipcMain.on("app:restart-for-update", (event) => {
+    if (!isTrustedSender(event.sender.id)) {
+      log.warn(
+        `Ignoring restart-for-update from untrusted sender (id: ${event.sender.id})`,
+      );
+      return;
+    }
+    if (currentStatus.kind === "downloaded") {
+      log.info("Restarting app to install update...");
+      isQuittingForUpdate = true;
+      autoUpdater.quitAndInstall();
+    } else if (currentStatus.kind === "pending") {
+      log.info("Update still downloading — queuing install for completion");
+      setStatus({ ...currentStatus, installRequested: true });
+    } else {
+      log.info("Restart requested but no update is staged");
+    }
+  });
+
+  if (!app.isPackaged) {
+    ipcMain.on("app:simulate-update", (event) => {
+      if (!isTrustedSender(event.sender.id)) {
+        log.warn(
+          `Ignoring simulate-update from untrusted sender (id: ${event.sender.id})`,
+        );
+        return;
+      }
+      log.info("Simulating update available (dev mode)");
+      setStatus({ kind: "pending", installRequested: false });
+    });
+
+    ipcMain.on("app:simulate-update-downloaded", (event) => {
+      if (!isTrustedSender(event.sender.id)) {
+        log.warn(
+          `Ignoring simulate-update-downloaded from untrusted sender (id: ${event.sender.id})`,
+        );
+        return;
+      }
+      log.info("Simulating update downloaded (dev mode)");
+      const installRequested =
+        currentStatus.kind === "pending" && currentStatus.installRequested;
+      setStatus({
+        kind: "downloaded",
+        version: "99.0.0",
+        releaseNotes: "Simulated update for testing",
+      });
+      if (installRequested) {
+        log.info("User had requested install — would restart now (dev mode)");
+      }
+    });
+
+    ipcMain.on("app:simulate-update-error", (event) => {
+      if (!isTrustedSender(event.sender.id)) {
+        log.warn(
+          `Ignoring simulate-update-error from untrusted sender (id: ${event.sender.id})`,
+        );
+        return;
+      }
+      log.error("Auto-updater error:", new Error("Simulated update failure"));
+      const shouldNotifyUser =
+        currentStatus.kind === "pending" && currentStatus.installRequested;
+      setStatus({ kind: "idle" });
+      if (shouldNotifyUser) {
+        broadcastUpdateError();
+      }
+    });
+  }
+}
+
+export function installUpdateOnQuit(): boolean {
+  if (currentStatus.kind === "downloaded" && !isQuittingForUpdate) {
+    log.info("Staged update found at quit — installing before exit");
+    isQuittingForUpdate = true;
+    autoUpdater.quitAndInstall();
+    return true;
+  }
+  return false;
+}
+
+// Test-only reset
+export function __resetUpdateStateForTests(): void {
+  currentStatus = { kind: "idle" };
+  isQuittingForUpdate = false;
+  trustedWindow = null;
+  updateListenersRegistered = false;
 }

--- a/mcpjam-inspector/src/ipc/update/update-listeners.ts
+++ b/mcpjam-inspector/src/ipc/update/update-listeners.ts
@@ -233,6 +233,9 @@ export function registerUpdateListeners(mainWindow: BrowserWindow): void {
 }
 
 export function installUpdateOnQuit(): boolean {
+  if (!app.isPackaged) {
+    return false;
+  }
   if (currentStatus.kind === "downloaded" && !isQuittingForUpdate) {
     log.info("Staged update found at quit — installing before exit");
     isQuittingForUpdate = true;

--- a/mcpjam-inspector/src/main.ts
+++ b/mcpjam-inspector/src/main.ts
@@ -15,7 +15,11 @@ import { createHonoApp } from "../server/app.js";
 import log from "electron-log";
 import { updateElectronApp } from "update-electron-app";
 import { registerListeners } from "./ipc/listeners-register.js";
-import { setupAutoUpdaterEvents } from "./ipc/update/update-listeners.js";
+import {
+  installUpdateOnQuit,
+  setTrustedUpdateWindow,
+  setupAutoUpdaterEvents,
+} from "./ipc/update/update-listeners.js";
 import {
   buildProtocolOAuthCallbackUrl,
   buildRendererCallbackUrl,
@@ -26,6 +30,10 @@ import {
 // Configure logging
 log.transports.file.level = "info";
 log.transports.console.level = "debug";
+
+// Wire autoUpdater event handlers BEFORE update-electron-app starts polling,
+// otherwise an early `update-available` event could fire before our listener exists.
+setupAutoUpdaterEvents();
 
 // Enable auto-updater (with custom notification handling)
 updateElectronApp({
@@ -402,6 +410,7 @@ async function handleOAuthCallbackUrl(url: string): Promise<void> {
     if (!mainWindow) {
       if (rendererCallbackUrl) {
         mainWindow = createMainWindow(baseUrl);
+        setTrustedUpdateWindow(mainWindow);
         mainWindow.loadURL(rendererCallbackUrl.toString());
       } else {
         const debugCallbackUrl = new URL("/oauth/callback/debug", baseUrl);
@@ -410,6 +419,7 @@ async function handleOAuthCallbackUrl(url: string): Promise<void> {
           debugCallbackUrl.searchParams.append(key, value);
         }
         mainWindow = createMainWindow(baseUrl);
+        setTrustedUpdateWindow(mainWindow);
         mainWindow.loadURL(debugCallbackUrl.toString());
       }
     } else if (rendererCallbackUrl) {
@@ -531,9 +541,6 @@ app.whenReady().then(async () => {
     // Register IPC listeners
     registerListeners(mainWindow, () => mainWindow);
 
-    // Setup auto-updater events to notify renderer when update is ready
-    setupAutoUpdaterEvents(mainWindow);
-
     appBootstrapped = true;
 
     if (pendingProtocolUrl) {
@@ -574,11 +581,13 @@ app.on("activate", async () => {
   if (BrowserWindow.getAllWindows().length === 0) {
     if (serverPort > 0) {
       mainWindow = createMainWindow(getServerUrl());
+      setTrustedUpdateWindow(mainWindow);
     } else {
       // Restart server if needed
       try {
         serverPort = await startHonoServer();
         mainWindow = createMainWindow(getServerUrl());
+        setTrustedUpdateWindow(mainWindow);
       } catch (error) {
         log.error("Failed to restart server:", error);
       }
@@ -630,7 +639,15 @@ app.on("web-contents-created", (_, contents) => {
 });
 
 // Handle app shutdown
-app.on("before-quit", () => {
+app.on("before-quit", (event) => {
+  // Safety net: if a new build has been downloaded but the user never clicked the
+  // button, install it during quit so the next launch is on the new version.
+  // quitAndInstall() re-fires before-quit; the helper guards with isQuittingForUpdate
+  // so the second pass falls through and we still close the server.
+  if (installUpdateOnQuit()) {
+    event.preventDefault();
+    return;
+  }
   if (server) {
     server.close?.();
   }

--- a/mcpjam-inspector/src/preload.ts
+++ b/mcpjam-inspector/src/preload.ts
@@ -1,10 +1,10 @@
 import { contextBridge, ipcRenderer } from "electron";
 
-// Update info type
-interface UpdateInfo {
-  version: string;
-  releaseNotes?: string;
-}
+// Mirror of the main-process UpdateStatus union (kept inline to avoid a shared module).
+type UpdateStatus =
+  | { kind: "idle" }
+  | { kind: "pending"; version?: string; installRequested: boolean }
+  | { kind: "downloaded"; version: string; releaseNotes?: string };
 
 // Define the API interface
 interface ElectronAPI {
@@ -45,8 +45,9 @@ interface ElectronAPI {
 
   // Update operations
   update: {
-    onUpdateReady: (callback: (info: UpdateInfo) => void) => void;
-    removeUpdateReadyListener: () => void;
+    onUpdateStatus: (callback: (status: UpdateStatus) => void) => void;
+    removeUpdateStatusListener: () => void;
+    getUpdateStatus: () => Promise<UpdateStatus>;
     restartAndInstall: () => void;
     simulateUpdate?: () => void; // Dev only - for testing
   };
@@ -89,12 +90,15 @@ const electronAPI: ElectronAPI = {
   },
 
   update: {
-    onUpdateReady: (callback: (info: UpdateInfo) => void) => {
-      ipcRenderer.on("update-ready", (_, info: UpdateInfo) => callback(info));
+    onUpdateStatus: (callback: (status: UpdateStatus) => void) => {
+      ipcRenderer.on("update-status", (_, status: UpdateStatus) =>
+        callback(status),
+      );
     },
-    removeUpdateReadyListener: () => {
-      ipcRenderer.removeAllListeners("update-ready");
+    removeUpdateStatusListener: () => {
+      ipcRenderer.removeAllListeners("update-status");
     },
+    getUpdateStatus: () => ipcRenderer.invoke("app:get-update-status"),
     restartAndInstall: () => {
       ipcRenderer.send("app:restart-for-update");
     },

--- a/mcpjam-inspector/src/preload.ts
+++ b/mcpjam-inspector/src/preload.ts
@@ -47,9 +47,13 @@ interface ElectronAPI {
   update: {
     onUpdateStatus: (callback: (status: UpdateStatus) => void) => void;
     removeUpdateStatusListener: () => void;
+    onUpdateError: (callback: () => void) => void;
+    removeUpdateErrorListener: () => void;
     getUpdateStatus: () => Promise<UpdateStatus>;
     restartAndInstall: () => void;
     simulateUpdate?: () => void; // Dev only - for testing
+    simulateUpdateDownloaded?: () => void; // Dev only - for testing
+    simulateUpdateError?: () => void; // Dev only - for testing
   };
 }
 
@@ -98,6 +102,12 @@ const electronAPI: ElectronAPI = {
     removeUpdateStatusListener: () => {
       ipcRenderer.removeAllListeners("update-status");
     },
+    onUpdateError: (callback: () => void) => {
+      ipcRenderer.on("update-error", () => callback());
+    },
+    removeUpdateErrorListener: () => {
+      ipcRenderer.removeAllListeners("update-error");
+    },
     getUpdateStatus: () => ipcRenderer.invoke("app:get-update-status"),
     restartAndInstall: () => {
       ipcRenderer.send("app:restart-for-update");
@@ -106,6 +116,12 @@ const electronAPI: ElectronAPI = {
       ? {
           simulateUpdate: () => {
             ipcRenderer.send("app:simulate-update");
+          },
+          simulateUpdateDownloaded: () => {
+            ipcRenderer.send("app:simulate-update-downloaded");
+          },
+          simulateUpdateError: () => {
+            ipcRenderer.send("app:simulate-update-error");
           },
         }
       : {}),

--- a/mcpjam-inspector/vite.renderer.config.mts
+++ b/mcpjam-inspector/vite.renderer.config.mts
@@ -31,7 +31,9 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       fs: {
-        allow: [resolve(__dirname, "./client"), resolve(__dirname, "./shared")],
+        // Allow serving the whole package: index.html lives at client/, and the
+        // @/shared alias points at ../shared. A single root entry covers both.
+        allow: [__dirname],
       },
       proxy: {
         "/api": {

--- a/mcpjam-inspector/vite.renderer.config.mts
+++ b/mcpjam-inspector/vite.renderer.config.mts
@@ -31,9 +31,7 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       fs: {
-        // Allow serving the whole package: index.html lives at client/, and the
-        // @/shared alias points at ../shared. A single root entry covers both.
-        allow: [__dirname],
+        allow: [resolve(__dirname, "./client"), resolve(__dirname, "./shared")],
       },
       proxy: {
         "/api": {


### PR DESCRIPTION

- Improves the Electron desktop update flow in two ways:
- **First:** the Update button now appears as soon as Electron finds an available update.
  - Before, the button only appeared after the update finished downloading.
  - This matters because update downloads/checks can fail or get weird, so users might never know an update was available.
  - Since Electron starts downloading updates automatically, the button can appear while the download is still in progress.
  - If the user clicks it early, we show `Updating…` with a spinner and restart as soon as the download finishes.
- **Second:** if an update has already downloaded and the user quits MCPJam, Electron/Squirrel applies the update during quit so the next launch opens the new version.
- Added tests for the button staying visible through updater edge cases.

## Tested

- Targeted updater/sidebar tests pass.
- Full inspector build passes.