### PR TITLE
issues mixing dev and local redirects

### DIFF
--- a/mcpjam-inspector/server/routes/web/__tests__/guest-session.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/guest-session.test.ts
@@ -114,7 +114,10 @@ describe("POST /guest-session", () => {
     });
 
     it("returns a three-part JWT token (header.payload.signature)", async () => {
-      const res = await app.request("/guest-session", { method: "POST" });
+      const res = await app.request("/guest-session", {
+        method: "POST",
+        headers: { "x-forwarded-for": "203.0.113.11" },
+      });
       const data = await res.json();
 
       const parts = data.token.split(".");
@@ -128,6 +131,43 @@ describe("POST /guest-session", () => {
     expect(res.headers.get("set-cookie")).toContain(
       "__Host-mcpjam_guest_session=cookie-set-by-convex",
     );
+  });
+
+  it("also sets a local HTTP-compatible guest cookie", async () => {
+    const res = await app.request("/guest-session", { method: "POST" });
+    expect(res.status).toBe(200);
+
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(
+      "__Host-mcpjam_guest_session=cookie-set-by-convex",
+    );
+    expect(setCookie).toContain("mcpjam_guest_session=cookie-set-by-convex");
+    expect(setCookie).toContain(
+      "mcpjam_guest_session=cookie-set-by-convex; HttpOnly; SameSite=Lax",
+    );
+  });
+
+  it("sets the local HTTP-compatible guest cookie on 127.0.0.1", async () => {
+    const res = await app.request("http://127.0.0.1/guest-session", {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("mcpjam_guest_session=cookie-set-by-convex");
+  });
+
+  it("does not set the local HTTP-compatible guest cookie for HTTPS origins", async () => {
+    const res = await app.request("https://app.mcpjam.com/guest-session", {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(
+      "__Host-mcpjam_guest_session=cookie-set-by-convex",
+    );
+    expect(setCookie).not.toMatch(/(?:^|,\s*)mcpjam_guest_session=/);
   });
 
   it("forwards browser Cookie/User-Agent but not spoofable IP headers upstream", async () => {
@@ -151,6 +191,39 @@ describe("POST /guest-session", () => {
     expect(headers["User-Agent"]).toBe("BrowserAgent/1.0");
     expect(headers["X-Forwarded-For"]).toBeUndefined();
     expect(headers["X-Real-IP"]).toBeUndefined();
+  });
+
+  it("maps the local HTTP-compatible guest cookie back to the upstream cookie name", async () => {
+    await app.request("/guest-session", {
+      method: "POST",
+      headers: {
+        cookie: "mcpjam_guest_session=local-cookie-id",
+      },
+    });
+
+    const upstreamCall = vi.mocked(global.fetch).mock.calls[0]!;
+    const init = upstreamCall[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Cookie"]).toBe(
+      "__Host-mcpjam_guest_session=local-cookie-id",
+    );
+  });
+
+  it("prefers the local HTTP-compatible guest cookie when both cookie names are present", async () => {
+    await app.request("/guest-session", {
+      method: "POST",
+      headers: {
+        cookie:
+          "__Host-mcpjam_guest_session=stale-cookie-id; mcpjam_guest_session=fresh-cookie-id",
+      },
+    });
+
+    const upstreamCall = vi.mocked(global.fetch).mock.calls[0]!;
+    const init = upstreamCall[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Cookie"]).toBe(
+      "__Host-mcpjam_guest_session=fresh-cookie-id",
+    );
   });
 
   it("forwards only the guest-session cookie upstream, not other origin cookies", async () => {
@@ -238,6 +311,31 @@ describe("POST /guest-session", () => {
     expect(res.headers.get("set-cookie")).toContain("Max-Age=0");
     const data = await res.json();
     expect(data.code).toBe("FORBIDDEN");
+  });
+
+  it("clears both upstream and local guest cookies on local HTTP revoke", async () => {
+    const expiredCookie =
+      "__Host-mcpjam_guest_session=; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=0";
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ revoked: true }), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Set-Cookie": expiredCookie,
+        },
+      }),
+    ) as typeof fetch;
+
+    const res = await app.request("http://127.0.0.1/guest-session/revoke", {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(expiredCookie);
+    expect(setCookie).toContain(
+      "mcpjam_guest_session=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0",
+    );
   });
 
   it("returns 403 when non-prod lockdown is enabled", async () => {

--- a/mcpjam-inspector/server/routes/web/guest-session.ts
+++ b/mcpjam-inspector/server/routes/web/guest-session.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import {
   fetchConvexGuestPromotionProof,
   fetchConvexGuestSession,
@@ -31,21 +31,85 @@ setInterval(() => {
 }, 5 * 60_000).unref();
 
 const GUEST_SESSION_COOKIE_NAME = "__Host-mcpjam_guest_session";
+const LOCAL_GUEST_SESSION_COOKIE_NAME = "mcpjam_guest_session";
+const LOCAL_GUEST_SESSION_HOSTNAMES = new Set(["localhost", "127.0.0.1"]);
 
 // Forward only the guest-session cookie to the upstream guest service.
 // Passing the entire Cookie header would leak unrelated auth/CSRF cookies
 // from the Inspector origin to Convex / hosted MCPJam.
-function extractGuestSessionCookie(
-  cookieHeader: string | null | undefined
+function extractCookieValue(
+  cookieHeader: string | null | undefined,
+  cookieName: string
 ): string | null {
   if (!cookieHeader) return null;
-  const prefix = `${GUEST_SESSION_COOKIE_NAME}=`;
+  const prefix = `${cookieName}=`;
   for (const part of cookieHeader.split(/;\s*/)) {
     if (part.startsWith(prefix)) {
-      return part;
+      return part.slice(prefix.length);
     }
   }
   return null;
+}
+
+function extractGuestSessionCookie(
+  cookieHeader: string | null | undefined
+): string | null {
+  const localCookie = extractCookieValue(
+    cookieHeader,
+    LOCAL_GUEST_SESSION_COOKIE_NAME
+  );
+  if (localCookie) {
+    return `${GUEST_SESSION_COOKIE_NAME}=${localCookie}`;
+  }
+
+  const upstreamCookie = extractCookieValue(
+    cookieHeader,
+    GUEST_SESSION_COOKIE_NAME
+  );
+  return upstreamCookie
+    ? `${GUEST_SESSION_COOKIE_NAME}=${upstreamCookie}`
+    : null;
+}
+
+function isLocalHttpRequest(requestUrl: string): boolean {
+  try {
+    const url = new URL(requestUrl);
+    return (
+      url.protocol === "http:" &&
+      LOCAL_GUEST_SESSION_HOSTNAMES.has(url.hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function rewriteGuestSessionCookieForLocalHttp(cookie: string): string {
+  const parts = cookie
+    .split(";")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const [nameValue, ...attributes] = parts;
+  if (!nameValue?.startsWith(`${GUEST_SESSION_COOKIE_NAME}=`)) {
+    return cookie;
+  }
+
+  return [
+    nameValue.replace(
+      `${GUEST_SESSION_COOKIE_NAME}=`,
+      `${LOCAL_GUEST_SESSION_COOKIE_NAME}=`
+    ),
+    ...attributes.filter((attribute) => !/^secure$/i.test(attribute)),
+  ].join("; ");
+}
+
+function appendGuestSessionSetCookie(c: Context, cookie: string): void {
+  c.header("Set-Cookie", cookie, { append: true });
+  if (isLocalHttpRequest(c.req.url)) {
+    const localCookie = rewriteGuestSessionCookieForLocalHttp(cookie);
+    if (localCookie !== cookie) {
+      c.header("Set-Cookie", localCookie, { append: true });
+    }
+  }
 }
 
 function shouldFetchGuestSessionFromConvex(): boolean {
@@ -85,7 +149,8 @@ function parseRequestBody(raw: unknown): GuestSessionRequestBody {
  * forwards browser cookie/UA context to the upstream guest service so the
  * server can resolve a stable guest from the HttpOnly cookie. Spoofable
  * client IP headers are intentionally not forwarded. Set-Cookie
- * headers from upstream are passed through unchanged.
+ * headers from upstream are passed through unchanged, with an additional
+ * local HTTP-compatible cookie emitted for localhost/127.0.0.1 runtimes.
  *
  * Inspector rate-limits this endpoint locally and either:
  * - proxies to Convex in hosted web and local dev
@@ -168,7 +233,7 @@ guestSession.post("/", async (c) => {
     : await fetchRemoteGuestSession(context);
 
   for (const cookie of result.setCookies) {
-    c.header("Set-Cookie", cookie, { append: true });
+    appendGuestSessionSetCookie(c, cookie);
   }
 
   if (result.kind === "session") {
@@ -253,10 +318,10 @@ guestSession.post("/revoke", async (c) => {
   // load-bearing part of the contract.
   if (result.setCookies.length > 0) {
     for (const cookie of result.setCookies) {
-      c.header("Set-Cookie", cookie, { append: true });
+      appendGuestSessionSetCookie(c, cookie);
     }
   } else {
-    c.header("Set-Cookie", buildExpiredGuestSessionCookie(), { append: true });
+    appendGuestSessionSetCookie(c, buildExpiredGuestSessionCookie());
   }
 
   if (result.status >= 200 && result.status < 300) {
@@ -356,7 +421,7 @@ guestSession.post("/promotion-proof", async (c) => {
 
   if (result.kind === "revoked") {
     for (const cookie of result.setCookies) {
-      c.header("Set-Cookie", cookie, { append: true });
+      appendGuestSessionSetCookie(c, cookie);
     }
     return c.json(
       {


### PR DESCRIPTION
## Fixes local/npx guest OAuth by making the guest session persist reliably on local HTTP.

- Fixes guest OAuth in local dev and npx by keeping the same local guest session through the OAuth redirect.

Local dev uses localhost:5173.
npx uses 127.0.0.1:6274.

- The fix makes the guest-session route handle both local origins correctly, without changing hosted behavior.

- This prevents the OAuth callback from losing the local guest session and failing token import with Not a member of this project.

- Tests cover local dev, npx, hosted/HTTPS, and sign-out cleanup.





