### PR TITLE
chore: release rollup (inspector patch + sdk minor)

### DIFF
--- a/.changeset/release-rollup-2026-05-14.md
+++ b/.changeset/release-rollup-2026-05-14.md
@@ -1,0 +1,20 @@
+---
+"@mcpjam/inspector": patch
+"@mcpjam/sdk": minor
+---
+
+Inspector + SDK rollup since the last release.
+
+**@mcpjam/sdk**
+
+- Consume `hostConfig.mcpProfile` end-to-end: profile-aware connection in `MCPClientManager`, new sandbox-policy types, and supporting browser/index exports (#2103).
+
+**@mcpjam/inspector**
+
+- Named hosts UI: new Hosts tab, HostPicker, host builder, and consumer seeding (#2112).
+- Host config: consume `hostConfig.mcpProfile` end-to-end across chatbox, hosted chat, and server connection paths (#2103).
+- Billing: surface pending and failed credit top-ups in the credit balance card (#2111).
+- Electron OAuth: redirect-mixing fix between dev and local (#2116), plus an Electron fallback path for the OAuth modal/sidebar/auth flow (#2096).
+- Tokenizer: stop paging Sentry for client-side fetch failures (#2109).
+- Docs: desktop download links now point at the latest release URLs (#2093).
+- Misc sidebar nit.


### PR DESCRIPTION
## Summary

Rollup changeset for the unreleased commits since the last `chore(release)` (022ab27ef), ahead of the next deploy.

- `@mcpjam/inspector`: **patch** (2.4.10 → 2.4.11)
- `@mcpjam/sdk`: **minor** (1.4.0 → 1.5.0) — new mcpProfile-aware client manager + sandbox-policy exports

Covers PRs: #2116, #2096, #2112, #2093, #2111, #2109, #2103 (and one direct sidebar nit).

## Test plan
- [x] `npm run release:status` reports `@mcpjam/inspector` patch + `@mcpjam/sdk` minor, no other public packages affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)