### PR TITLE
fix(inspector): disconnect servers on sign-out and snap to Servers tab on project change

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -836,6 +836,31 @@ export default function App() {
     const server = runtimeServer ?? projectServer;
     return server ? { runtimeServer, projectServer, server } : null;
   }, []);
+  const handleSignOut = useCallback(
+    async (options?: { returnTo?: string; navigate?: boolean }) => {
+      // Local mode talks to the inspector backend via DELETE /api/mcp/servers/:id;
+      // without disconnecting first, that request races the page redirect and the
+      // backend is left holding a zombie connection. Hosted mode's deleteServer is
+      // a no-op, so this loop is harmless there.
+      const serverNamesToDisconnect = Object.entries(appState.servers)
+        .filter(([, server]) => server.connectionStatus !== "disconnected")
+        .map(([serverName]) => serverName);
+      await Promise.allSettled(
+        serverNamesToDisconnect.map((serverName) =>
+          handleDisconnect(serverName)
+        )
+      );
+      // WorkOS's signOut has two overloads keyed on `navigate`: `navigate: false`
+      // returns a promise (used by the Electron flow so we can manually assign
+      // window.location after), anything else navigates synchronously.
+      if (options?.navigate === false) {
+        await signOut({ returnTo: options.returnTo, navigate: false });
+        return;
+      }
+      signOut({ returnTo: options?.returnTo });
+    },
+    [appState.servers, handleDisconnect, signOut]
+  );
   useEffect(() => {
     return subscribeToOAuthDebuggerRequests(({ serverName }) => {
       const matchedServerName = Object.entries(
@@ -1459,6 +1484,23 @@ export default function App() {
     workOsUser,
   ]);
 
+  // When the active project changes (org switch, project delete, manual switch),
+  // snap to Servers — staying on App Builder/Chat would leave the user pointed
+  // at a project that no longer exists. Skip the initial "none" → real-id
+  // transition so deep-links into other tabs aren't yanked away on first load.
+  const previousActiveProjectIdRef = useRef(activeProjectId);
+  useEffect(() => {
+    const previousActiveProjectId = previousActiveProjectIdRef.current;
+    previousActiveProjectIdRef.current = activeProjectId;
+    if (
+      previousActiveProjectId === activeProjectId ||
+      previousActiveProjectId === "none"
+    ) {
+      return;
+    }
+    applyNavigation("servers", { updateHash: true });
+  }, [activeProjectId, applyNavigation]);
+
   const consumeCheckoutIntent = useCallback(() => {
     clearPersistedCheckoutIntent();
     clearBillingSignInReturnPath();
@@ -2046,6 +2088,7 @@ export default function App() {
         activeOrganizationName={activeOrganizationName}
         onSwitchOrganization={handleSidebarSwitchOrganization}
         onSwitchActiveOrganization={handleSwitchActiveOrganization}
+        onSignOut={handleSignOut}
         onProjectShared={handleProjectShared}
         billingUiEnabled={billingUiEnabled}
         billingGateDenied={sidebarGateDenied}
@@ -2599,7 +2642,7 @@ export default function App() {
               signIn();
             }}
             onSignOut={() => {
-              void signOut();
+              void handleSignOut();
             }}
           >
             {isChatboxChatRoute ? (

--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -361,6 +361,10 @@ interface MCPSidebarProps extends React.ComponentProps<typeof Sidebar> {
     section?: OrganizationRouteSection,
   ) => void;
   onSwitchActiveOrganization?: (organizationId: string) => void;
+  onSignOut?: (options?: {
+    returnTo?: string;
+    navigate?: boolean;
+  }) => void | Promise<void>;
   onProjectShared?: (
     sharedProjectId: string,
     sourceProjectId?: string,
@@ -550,6 +554,7 @@ export function MCPSidebar({
   activeOrganizationName,
   onSwitchOrganization,
   onSwitchActiveOrganization,
+  onSignOut,
   onProjectShared,
   billingGateDenied = {},
   billingGateEnforcementActive = false,
@@ -823,7 +828,10 @@ export function MCPSidebar({
           {!user ? (
             <SidebarCreditUsage className="px-1" includeGuests />
           ) : null}
-          <SidebarUser activeOrganizationId={activeOrganizationId} />
+          <SidebarUser
+            activeOrganizationId={activeOrganizationId}
+            onSignOut={onSignOut}
+          />
         </SidebarFooter>
       </Sidebar>
       {shouldShowInviteCta && user && activeProject ? (

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-user.tsx
@@ -33,9 +33,16 @@ import { SidebarCreditUsage } from "@/components/sidebar/sidebar-credit-usage";
 
 interface SidebarUserProps {
   activeOrganizationId?: string;
+  onSignOut?: (options?: {
+    returnTo?: string;
+    navigate?: boolean;
+  }) => void | Promise<void>;
 }
 
-export function SidebarUser({ activeOrganizationId }: SidebarUserProps = {}) {
+export function SidebarUser({
+  activeOrganizationId,
+  onSignOut,
+}: SidebarUserProps = {}) {
   const { isLoading, isAuthenticated: _isAuthenticated } = useConvexAuth();
   const { user, signIn, signOut } = useAuth();
   const { profilePictureUrl } = useProfilePicture();
@@ -61,16 +68,17 @@ export function SidebarUser({ activeOrganizationId }: SidebarUserProps = {}) {
 
   const handleSignOut = () => {
     const returnTo = window.location.origin;
+    const performSignOut = onSignOut ?? signOut;
     if (window.isElectron) {
-      void Promise.resolve(signOut({ returnTo, navigate: false })).finally(
-        () => {
-          window.location.assign(returnTo);
-        }
-      );
+      void Promise.resolve(
+        performSignOut({ returnTo, navigate: false })
+      ).finally(() => {
+        window.location.assign(returnTo);
+      });
       return;
     }
 
-    signOut({ returnTo });
+    void performSignOut({ returnTo });
   };
 
   const avatarUrl = profilePictureUrl;


### PR DESCRIPTION
Local sign-out closes server connections before redirecting (no more zombies).
Project switch drops you on the Servers tab instead of leaving you stranded on Chat/App Builder.
Both sign-out buttons (sidebar + hosted shell) now share one handler instead of two near-duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)