### PR TITLE
test(inspector): mock new lucide icons + standardEventProps in PlaygroundMain test

### DIFF
--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -887,12 +887,19 @@ describe("PlaygroundMain", () => {
         <PlaygroundMain {...defaultProps} enableTraceViews={true} />,
       );
 
-      expect(screen.getByTestId("trace-view-tabs")).toBeInTheDocument();
+      // #2121: trace tabs now live inline in PlaygroundCenterHeaderBar.
+      // The host pill (only rendered when showTraceTabs is true) is a stable
+      // proxy for "trace mode tabs are visible".
+      expect(
+        screen.getByTestId("playground-header-host-tab"),
+      ).toBeInTheDocument();
 
       mockUseChatSession.traceViewsSupported = false;
       rerender(<PlaygroundMain {...defaultProps} enableTraceViews={true} />);
 
-      expect(screen.queryByTestId("trace-view-tabs")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("playground-header-host-tab"),
+      ).not.toBeInTheDocument();
     });
 
     it("shows trace mode tabs on an empty thread when trace views are supported", () => {
@@ -901,7 +908,9 @@ describe("PlaygroundMain", () => {
 
       render(<PlaygroundMain {...defaultProps} enableTraceViews={true} />);
 
-      expect(screen.getByTestId("trace-view-tabs")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("playground-header-host-tab"),
+      ).toBeInTheDocument();
     });
 
     it("renders the shared trace header tabs", () => {
@@ -910,10 +919,14 @@ describe("PlaygroundMain", () => {
 
       render(<PlaygroundMain {...defaultProps} enableTraceViews={true} />);
 
+      // #2121 collapsed the legacy ChatTraceViewModeHeaderBar +
+      // TraceViewModeTabs into the single PlaygroundCenterHeaderBar strip.
       expect(
-        screen.getByTestId("chat-trace-view-mode-header-bar"),
+        screen.getByTestId("playground-main-header"),
       ).toBeInTheDocument();
-      expect(screen.getByTestId("trace-view-tabs")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("playground-header-host-tab"),
+      ).toBeInTheDocument();
     });
 
     it("shows the sample raw JSON empty state on an empty thread when Raw is selected", () => {
@@ -1127,7 +1140,9 @@ describe("PlaygroundMain", () => {
       expect(grid.className.includes("hidden")).toBe(false);
       expect(grid).toHaveClass("xl:grid-cols-3");
       expect(grid).not.toHaveClass("2xl:grid-cols-3");
-      expect(screen.getByTestId("trace-view-tabs")).toBeInTheDocument();
+      expect(
+        screen.getByTestId("playground-header-host-tab"),
+      ).toBeInTheDocument();
       expect(screen.getAllByTestId("chat-input")).not.toHaveLength(0);
       expect(
         screen.queryByText(

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -53,6 +53,10 @@ vi.mock("lucide-react", () => ({
   Maximize2: () => <span data-testid="icon-maximize" />,
   Minimize2: () => <span data-testid="icon-minimize" />,
   ChevronRight: () => <span data-testid="icon-chevron-right" />,
+  // Icons used by PlaygroundCenterHeaderBar
+  ArrowLeft: () => <span data-testid="icon-arrow-left" />,
+  Code2: () => <span data-testid="icon-code2" />,
+  MessageSquare: () => <span data-testid="icon-message-square" />,
 }));
 
 // Mock UI components
@@ -127,6 +131,7 @@ vi.mock("posthog-js/react", () => ({
 vi.mock("@/lib/PosthogUtils", () => ({
   detectEnvironment: vi.fn().mockReturnValue("test"),
   detectPlatform: vi.fn().mockReturnValue("web"),
+  standardEventProps: vi.fn().mockReturnValue({}),
 }));
 
 // Mock authkit


### PR DESCRIPTION
## Summary

After #2121, `PlaygroundMain.test.tsx` had 10 failures from two sources:

1. **Missing mock entries.** `PlaygroundCenterHeaderBar` imports `ArrowLeft`, `Code2`, `MessageSquare` from `lucide-react`, and `standardEventProps` from `PosthogUtils`. The existing test mocks omitted them, so 10 tests crashed before any assertion ran.

2. **Stale assertions.** 4 tests queried for legacy testids (`trace-view-tabs`, `chat-trace-view-mode-header-bar`) that lived in the old two-strip layout #2121 replaced.

This PR fixes both:

- Adds `ArrowLeft`, `Code2`, `MessageSquare` to the `lucide-react` mock
- Adds `standardEventProps` to the `@/lib/PosthogUtils` mock
- Updates 4 tests to query the new `PlaygroundCenterHeaderBar` testids:
  - `playground-header-host-tab` — only rendered when `showTraceTabs` is true, so it's a stable proxy for "trace mode tabs are visible"
  - `playground-main-header` — outer container of the new single-strip header

## Result

Full `PlaygroundMain.test.tsx` suite now passes (55/55). Full inspector test suite passes (3904 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)