### PR TITLE
Snappy Servers→Host transition + host routes + clean canvas edges

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -498,8 +498,18 @@ export function ServersRoute() {
     convexProjectId,
     hostsHubFlagEnabled,
     isAuthenticated,
-    setHostsTabSelectedHostId,
   } = useAppRouteContext();
+  const navigate = useAppNavigate();
+
+  // From /servers, "select a host" means navigate to /hosts/:id. State sync
+  // happens in HostsRoute via the URL → hostsTabSelectedHostId effect, so
+  // here we only need to drive the URL.
+  const handleSelectHost = useCallback(
+    (next: string | null) => {
+      navigate(next ? buildHostsPath(next) : routePaths.servers);
+    },
+    [navigate],
+  );
 
   if (!hostsHubFlagEnabled || !isAuthenticated) {
     return <ServersTabBody />;
@@ -510,7 +520,7 @@ export function ServersRoute() {
       projectId={convexProjectId}
       isAuthenticated={isAuthenticated}
       selectedHostId={null}
-      onSelectHost={setHostsTabSelectedHostId}
+      onSelectHost={handleSelectHost}
       serversTabElement={<ServersTabBody />}
     />
   );

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -181,6 +181,7 @@ import { disconnectAllRuntimeServers } from "./state/mcp-api";
 import { getEffectiveProjectClientCapabilities } from "./lib/client-config";
 import { getDefaultClientCapabilities } from "@mcpjam/sdk/browser";
 import {
+  buildHostsPath,
   buildOrganizationPath,
   buildEvalsPath,
   getInvalidOrganizationRouteNavigationTarget,
@@ -191,6 +192,7 @@ import {
   routePaths,
   type OrganizationRouteSection,
   useActiveTab,
+  useAppNavigate,
   useCurrentOrgRoute,
 } from "./lib/app-navigation";
 import {
@@ -198,6 +200,7 @@ import {
   Outlet,
   UNSAFE_LocationContext,
   useOutletContext,
+  useParams,
 } from "react-router";
 import { useProjectClientConfigSyncPending } from "./hooks/use-project-client-config-sync-pending";
 import { ingestOAuthTraceLogs } from "./stores/traffic-log-store";
@@ -570,6 +573,31 @@ export function HostsRoute() {
     setHostsTabSelectedHostId,
   } = useAppRouteContext();
   const [previewedHostId] = usePreviewedHostId(convexProjectId);
+  const params = useParams<{ hostId?: string }>();
+  const navigate = useAppNavigate();
+  const urlHostId = useMemo(() => {
+    if (!params.hostId) return null;
+    try {
+      return decodeURIComponent(params.hostId);
+    } catch {
+      return params.hostId;
+    }
+  }, [params.hostId]);
+
+  // URL is the source of truth for the open host canvas. Sync into shared
+  // state so `GlobalHostBar`, `onCanvasReplaceHost`, and other surfaces that
+  // still read `hostsTabSelectedHostId` stay aligned.
+  useEffect(() => {
+    if (hostsTabSelectedHostId === urlHostId) return;
+    setHostsTabSelectedHostId(urlHostId);
+  }, [urlHostId, hostsTabSelectedHostId, setHostsTabSelectedHostId]);
+
+  const handleSelectHost = useCallback(
+    (next: string | null) => {
+      navigate(next ? buildHostsPath(next) : routePaths.hosts);
+    },
+    [navigate],
+  );
 
   if (!hostsHubFlagEnabled || !isAuthenticated) {
     return <ServersTabBody />;
@@ -579,8 +607,8 @@ export function HostsRoute() {
     <HostsTab
       projectId={convexProjectId}
       isAuthenticated={isAuthenticated}
-      selectedHostId={hostsTabSelectedHostId ?? previewedHostId}
-      onSelectHost={setHostsTabSelectedHostId}
+      selectedHostId={urlHostId ?? previewedHostId}
+      onSelectHost={handleSelectHost}
       serversTabElement={<ServersTabBody />}
     />
   );
@@ -2796,14 +2824,17 @@ export default function App() {
           projectId: convexProjectId,
           onEditHost: (hostId: string) => {
             setHostsTabSelectedHostId(hostId);
-            handleNavigate("hosts");
+            navigateApp(buildHostsPath(hostId));
           },
           // Only present while the host canvas is open — re-targets it on
           // dropdown change so the diagram tracks the selected host instead
           // of stuck on whatever was first opened via Edit.
           onCanvasReplaceHost:
             activeTab === "hosts" && hostsTabSelectedHostId
-              ? (hostId: string) => setHostsTabSelectedHostId(hostId)
+              ? (hostId: string) => {
+                  setHostsTabSelectedHostId(hostId);
+                  navigateApp(buildHostsPath(hostId), { replace: true });
+                }
               : undefined,
         }
       : undefined;

--- a/mcpjam-inspector/client/src/components/HostsTab.tsx
+++ b/mcpjam-inspector/client/src/components/HostsTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useNavigate } from "react-router";
 import { HostBuilderView } from "./hosts/HostBuilderView";
@@ -6,6 +6,7 @@ import { HostsConnectAddServerSlotContext } from "./hosts/HostsConnectAddServerS
 import { ViewModeSelector } from "./shared/view-mode-selector";
 import { usePreviewedHostId } from "@/hooks/use-previewed-host-id";
 import { useHost, useHostList } from "@/hooks/useHosts";
+import { buildHostsPath, routePaths } from "@/lib/app-navigation";
 import { getChatboxShellStyle } from "@/lib/chatbox-host-style";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 
@@ -64,7 +65,14 @@ export function HostsTab({
     [previewedHostStyle, themeMode],
   );
 
+  // Reset host selection only when the project actually changes mid-session,
+  // not on first mount — otherwise a deep-link like `/hosts/:hostId` gets
+  // wiped right after the page loads.
+  const prevProjectIdRef = useRef(projectId);
   useEffect(() => {
+    const prev = prevProjectIdRef.current;
+    prevProjectIdRef.current = projectId;
+    if (prev === projectId) return;
     if (selectedHostId) onSelectHost(null);
     // selectedHostId/onSelectHost intentionally omitted: this effect resets
     // host context when the active project changes, not when the selection
@@ -147,9 +155,9 @@ export function HostsTab({
                       onChange={(next) => {
                         if (next === "host" && previewedHostId) {
                           onSelectHost(previewedHostId);
-                          navigate("/hosts");
+                          navigate(buildHostsPath(previewedHostId));
                         } else if (next === "servers") {
-                          navigate("/servers");
+                          navigate(routePaths.servers);
                         }
                       }}
                       options={[

--- a/mcpjam-inspector/client/src/components/HostsTab.tsx
+++ b/mcpjam-inspector/client/src/components/HostsTab.tsx
@@ -8,7 +8,7 @@ import { SNAPPY_RAIL } from "./hosts/transition-tokens";
 import { ViewModeSelector } from "./shared/view-mode-selector";
 import { usePreviewedHostId } from "@/hooks/use-previewed-host-id";
 import { useHost, useHostList } from "@/hooks/useHosts";
-import { buildHostsPath, routePaths } from "@/lib/app-navigation";
+import { routePaths } from "@/lib/app-navigation";
 import { getChatboxShellStyle } from "@/lib/chatbox-host-style";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 
@@ -66,11 +66,18 @@ export function HostsTab({
   // Reset host selection only when the project actually changes mid-session,
   // not on first mount — otherwise a deep-link like `/hosts/:hostId` gets
   // wiped right after the page loads.
+  //
+  // useRef(projectId) captures the value at first render; if auth hasn't
+  // resolved yet that's `null`, so the very next render (auth resolves →
+  // projectId becomes a real id) would otherwise look like a project
+  // switch and clear the deep-linked selection. Treat any transition
+  // involving a null side as initial hydration, not a real switch.
   const prevProjectIdRef = useRef(projectId);
   useEffect(() => {
     const prev = prevProjectIdRef.current;
     prevProjectIdRef.current = projectId;
     if (prev === projectId) return;
+    if (prev == null || projectId == null) return;
     if (selectedHostId) onSelectHost(null);
     // selectedHostId/onSelectHost intentionally omitted: this effect resets
     // host context when the active project changes, not when the selection
@@ -123,7 +130,6 @@ export function HostsTab({
             <HostBuilderView
               hostId={selectedHostId}
               projectId={projectId}
-              onBack={() => onSelectHost(null)}
             />
           </motion.div>
         ) : (
@@ -155,9 +161,12 @@ export function HostsTab({
                       value="servers"
                       ariaLabel="Connect view"
                       onChange={(next) => {
+                        // `onSelectHost` is wired to `handleSelectHost` in
+                        // HostsRoute, which itself calls `navigate(buildHostsPath(...))`
+                        // — calling `navigate` here too pushes a duplicate
+                        // history entry, breaking the browser Back button.
                         if (next === "host" && previewedHostId) {
                           onSelectHost(previewedHostId);
-                          navigate(buildHostsPath(previewedHostId));
                         } else if (next === "servers") {
                           navigate(routePaths.servers);
                         }

--- a/mcpjam-inspector/client/src/components/HostsTab.tsx
+++ b/mcpjam-inspector/client/src/components/HostsTab.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, LayoutGroup, motion } from "framer-motion";
 import { useNavigate } from "react-router";
 import { HostBuilderView } from "./hosts/HostBuilderView";
 import { HostsConnectAddServerSlotContext } from "./hosts/HostsConnectAddServerSlotContext";
+import { HostsConnectViewPhaseContext } from "./hosts/HostsConnectViewPhaseContext";
+import { SNAPPY_RAIL } from "./hosts/transition-tokens";
 import { ViewModeSelector } from "./shared/view-mode-selector";
 import { usePreviewedHostId } from "@/hooks/use-previewed-host-id";
 import { useHost, useHostList } from "@/hooks/useHosts";
@@ -20,15 +22,11 @@ interface HostsTabProps {
 
 /**
  * Camera-style transition between the browsing state (server list) and the
- * host architecture canvas. Servers shrink toward where the canvas's "Servers
- * hub" will sit (≈70% down, horizontally centered) so the swap reads as a
- * zoom-out reveal of the bigger machine. Canvas exits by pushing past the
- * camera (scale > 1) to feel like the camera is moving back in.
+ * host architecture canvas. Server cards morph 1:1 into the canvas's pills
+ * via shared `layoutId` (see transition-tokens.ts) while the logs rail slides
+ * out and the host chrome staggers in — so the wrapper itself only needs a
+ * gentle opacity/y fade to soften the cut.
  */
-const TRANSITION = {
-  duration: 0.7,
-  ease: [0.32, 0.72, 0, 1] as [number, number, number, number],
-};
 
 export function HostsTab({
   projectId,
@@ -106,17 +104,21 @@ export function HostsTab({
   // fallback the user expects on `#connect`/`#servers`.
   if (!projectId) return <>{serversTabElement}</>;
 
+  const viewPhase = selectedHostId ? "host" : "servers";
+
   return (
+    <HostsConnectViewPhaseContext.Provider value={viewPhase}>
+    <LayoutGroup id="connect-servers-host">
     <div className="relative h-full min-h-0 overflow-hidden">
       <AnimatePresence initial={false} mode="sync">
         {selectedHostId ? (
           <motion.div
             key="host-canvas"
-            initial={{ opacity: 0, scale: 1.06 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 1.18 }}
-            transition={TRANSITION}
-            className="absolute inset-0 [transform-origin:50%_42%]"
+            initial={{ opacity: 0, y: 18, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 18, scale: 0.97 }}
+            transition={SNAPPY_RAIL}
+            className="absolute inset-0 [transform-origin:50%_30%]"
           >
             <HostBuilderView
               hostId={selectedHostId}
@@ -127,13 +129,13 @@ export function HostsTab({
         ) : (
           <motion.div
             key="host-browse"
-            initial={{ opacity: 0, scale: 1.04 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.42 }}
-            transition={TRANSITION}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 8 }}
+            transition={SNAPPY_RAIL}
             data-host-style={previewedHostStyle ?? undefined}
             style={browseShellStyle}
-            className="absolute inset-0 flex min-h-0 flex-col bg-background text-foreground [transform-origin:50%_70%]"
+            className="absolute inset-0 flex min-h-0 flex-col bg-background text-foreground"
           >
             <HostsConnectAddServerSlotContext.Provider value={addServerSlotEl}>
               <div
@@ -178,5 +180,7 @@ export function HostsTab({
         )}
       </AnimatePresence>
     </div>
+    </LayoutGroup>
+    </HostsConnectViewPhaseContext.Provider>
   );
 }

--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
+import { AnimatePresence, motion } from "framer-motion";
 import { Card } from "@mcpjam/design-system/card";
 import { Button } from "@mcpjam/design-system/button";
 import {
@@ -104,6 +105,12 @@ import {
 } from "@/lib/server-detail-modal-resume";
 import { cn } from "@/lib/utils";
 import { HostsConnectAddServerSlotContext } from "./hosts/HostsConnectAddServerSlotContext";
+import { useHostsConnectViewPhase } from "./hosts/HostsConnectViewPhaseContext";
+import {
+  SERVER_CARD_LAYOUT_ID,
+  SNAPPY_CAMERA,
+  SNAPPY_RAIL,
+} from "./hosts/transition-tokens";
 import { compareQuickConnectCatalogCards } from "@/lib/quick-connect-catalog-sort";
 import { toast } from "sonner";
 
@@ -452,6 +459,7 @@ function SortableServerCard({
 }) {
   const { listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id, disabled: dndDisabled });
+  const viewPhase = useHostsConnectViewPhase();
   const dragListeners =
     listeners == null
       ? {}
@@ -464,18 +472,49 @@ function SortableServerCard({
     opacity: isDragging ? 0 : 1,
   };
 
+  // When the server has a Convex id, share layout with the ReactFlow pill of
+  // the same server in the Host canvas so the Servers→Host swap morphs cards
+  // into pills 1:1 instead of crossfading. Without an id (server not yet
+  // persisted) we fall back to a plain div so the rest of the grid still
+  // renders.
+  const cardContent = (
+    <ServerConnectionCard
+      server={server}
+      needsReconnect={needsReconnect}
+      onDisconnect={onDisconnect}
+      onReconnect={onReconnect}
+      onRemove={onRemove}
+      hostedServerId={hostedServerId}
+      onOpenDetailModal={onOpenDetailModal}
+      projectId={projectId}
+    />
+  );
+
   return (
     <div ref={setNodeRef} style={style} {...dragListeners}>
-      <ServerConnectionCard
-        server={server}
-        needsReconnect={needsReconnect}
-        onDisconnect={onDisconnect}
-        onReconnect={onReconnect}
-        onRemove={onRemove}
-        hostedServerId={hostedServerId}
-        onOpenDetailModal={onOpenDetailModal}
-        projectId={projectId}
-      />
+      {hostedServerId ? (
+        // Outer box owns the size+position morph (layout); inner wrapper
+        // fades the heavy ServerConnectionCard UI out *before* the size
+        // morph reveals it warping. Mirrors the demo's CSS approach where
+        // toggle/menu/copy collapse to opacity 0 during the camera move.
+        <motion.div
+          layoutId={SERVER_CARD_LAYOUT_ID(hostedServerId)}
+          layout
+          transition={SNAPPY_CAMERA}
+          className="h-full overflow-hidden rounded-xl"
+        >
+          <motion.div
+            initial={false}
+            animate={{ opacity: viewPhase === "servers" ? 1 : 0 }}
+            transition={{ duration: 0.32, ease: [0.22, 1, 0.36, 1] }}
+            className="h-full"
+          >
+            {cardContent}
+          </motion.div>
+        </motion.div>
+      ) : (
+        cardContent
+      )}
     </div>
   );
 }
@@ -531,6 +570,7 @@ export function ServersTab({
 }: ServersTabProps) {
   const posthog = usePostHog();
   const hostsConnectAddServerSlot = useContext(HostsConnectAddServerSlotContext);
+  const viewPhase = useHostsConnectViewPhase();
   const { isAuthenticated } = useConvexAuth();
 
   // Auto-connect the previewed host's REQUIRED servers once per host scope.
@@ -1463,14 +1503,25 @@ export function ServersTab({
             collapsedSize={0}
             onCollapse={toggleJsonRpcPanel}
           >
-            <div className="h-full flex flex-col bg-background border-l border-border">
-              <LoggerView
-                key={connectedCount}
-                serverIds={loggerServerIds}
-                sinceTimestamp={loggerSinceTimestamp}
-                onClose={toggleJsonRpcPanel}
-              />
-            </div>
+            <AnimatePresence initial={false}>
+              {viewPhase === "servers" ? (
+                <motion.div
+                  key="logs-rail"
+                  initial={{ x: "100%", opacity: 0 }}
+                  animate={{ x: 0, opacity: 1 }}
+                  exit={{ x: "100%", opacity: 0 }}
+                  transition={SNAPPY_RAIL}
+                  className="h-full flex flex-col bg-background border-l border-border"
+                >
+                  <LoggerView
+                    key={connectedCount}
+                    serverIds={loggerServerIds}
+                    sinceTimestamp={loggerSinceTimestamp}
+                    onClose={toggleJsonRpcPanel}
+                  />
+                </motion.div>
+              ) : null}
+            </AnimatePresence>
           </ResizablePanel>
         </>
       ) : (

--- a/mcpjam-inspector/client/src/components/__tests__/HostsTab.header-chrome.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/HostsTab.header-chrome.test.tsx
@@ -51,6 +51,9 @@ vi.mock("framer-motion", () => {
     AnimatePresence: ({ children }: { children: React.ReactNode }) => (
       <>{children}</>
     ),
+    LayoutGroup: ({ children }: { children: React.ReactNode }) => (
+      <>{children}</>
+    ),
   };
 });
 

--- a/mcpjam-inspector/client/src/components/hosts/HostBuilderView.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostBuilderView.tsx
@@ -3,7 +3,6 @@ import { HostBuilderViewRedesigned } from "./redesigned/HostBuilderViewRedesigne
 interface HostBuilderViewProps {
   hostId: string;
   projectId: string;
-  onBack: () => void;
 }
 
 export function HostBuilderView(props: HostBuilderViewProps) {

--- a/mcpjam-inspector/client/src/components/hosts/HostsConnectViewPhaseContext.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/HostsConnectViewPhaseContext.tsx
@@ -1,0 +1,17 @@
+import { createContext, useContext } from "react";
+import type { ViewPhase } from "./transition-tokens";
+
+/**
+ * Connect-tab transition phase. Lets ServersTab (which is passed into HostsTab
+ * as a ReactNode) opt into a slide-out animation on the logs rail when the
+ * user toggles to the Host view, without ServersTab needing to know about
+ * the parent's animation orchestration.
+ *
+ * Defaults to "servers" so standalone callers (e.g. HostFocusDialog) render
+ * the static layout unchanged.
+ */
+export const HostsConnectViewPhaseContext = createContext<ViewPhase>("servers");
+
+export function useHostsConnectViewPhase(): ViewPhase {
+  return useContext(HostsConnectViewPhaseContext);
+}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/HostBuilderViewRedesigned.tsx
@@ -44,7 +44,6 @@ import {
 interface HostBuilderViewRedesignedProps {
   hostId: string;
   projectId: string;
-  onBack: () => void;
 }
 
 const CLOSED_FOCUS: HostFocusState = {
@@ -56,7 +55,6 @@ const CLOSED_FOCUS: HostFocusState = {
 export function HostBuilderViewRedesigned({
   hostId,
   projectId,
-  onBack,
 }: HostBuilderViewRedesignedProps) {
   const navigate = useNavigate();
   const { isAuthenticated } = useConvexAuth();
@@ -381,7 +379,10 @@ export function HostBuilderViewRedesigned({
               ariaLabel="Connect view"
               onChange={(next) => {
                 if (next === "servers") {
-                  onBack();
+                  // Skip `onBack()` (which would push `/hosts` first via
+                  // the parent's handleSelectHost) and just navigate.
+                  // The URL→state sync in HostsRoute will clear the
+                  // selected host when /servers takes over.
                   navigate("/servers");
                 }
               }}

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/RedesignedHostCanvas.tsx
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/RedesignedHostCanvas.tsx
@@ -1,12 +1,21 @@
-import { createContext, memo, useContext, useMemo, type CSSProperties } from "react";
 import {
+  createContext,
+  memo,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+} from "react";
+import { motion } from "framer-motion";
+import {
+  BaseEdge,
   Background,
   BackgroundVariant,
   Controls,
   Handle,
   Position,
   ReactFlow,
-  SmoothStepEdge,
   type EdgeProps,
   type Node,
   type NodeProps,
@@ -21,6 +30,11 @@ import {
   type ServerCardNodeData,
   type ServersHubNodeData,
 } from "../types";
+import {
+  SERVER_CARD_LAYOUT_ID,
+  SNAPPY_CAMERA,
+  SNAPPY_HOST_REVEAL,
+} from "../../transition-tokens";
 import { HostMatrixCard } from "./HostCapabilityMatrix";
 
 const decorativeHandleClass = "!opacity-0 !w-2 !h-2";
@@ -47,8 +61,17 @@ const HostMatrixNodeRenderer = memo(
   (props: NodeProps<Node<HostMatrixNodeData, "redesignHostMatrix">>) => {
     const { data } = props;
     const ctx = useContext(HostMatrixContext);
+    // Reveal the host card with a brief scale/fade after the page-level
+    // crossfade begins. Without this the Cursor card reads as "already
+    // there" on click — the demo's host group has the same beat.
     return (
-      <div className="w-full">
+      <motion.div
+        className="w-full"
+        initial={{ opacity: 0, scale: 0.9, y: 40 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        transition={SNAPPY_HOST_REVEAL}
+        style={{ transformOrigin: "50% 0%" }}
+      >
         <HostMatrixCard
           hostName={data.hostName}
           agent={data.agent}
@@ -67,7 +90,7 @@ const HostMatrixNodeRenderer = memo(
           id="bottom"
           className={decorativeHandleClass}
         />
-      </div>
+      </motion.div>
     );
   },
 );
@@ -83,7 +106,10 @@ const ServersHubNodeRenderer = memo(
   (props: NodeProps<Node<ServersHubNodeData, "redesignServersHub">>) => {
     const { data, selected } = props;
     return (
-      <div
+      <motion.div
+        initial={{ opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ ...SNAPPY_HOST_REVEAL, delay: 0.32 }}
         className={cn(
           "flex items-center gap-2 rounded-[10px] border border-border/70 bg-card/95 px-3 py-2 shadow-sm transition-all hover:shadow-md",
           selected && "ring-2 ring-primary/40",
@@ -110,7 +136,7 @@ const ServersHubNodeRenderer = memo(
           id="bottom"
           className={decorativeHandleClass}
         />
-      </div>
+      </motion.div>
     );
   },
 );
@@ -156,47 +182,69 @@ const ServerCardNodeRenderer = memo(
   (props: NodeProps<Node<ServerCardNodeData, "redesignServerCard">>) => {
     const { data, selected } = props;
     const { dotClass, statusLabel } = getServerStatusDot(data);
+    // Share layout with the same server's grid card on the Connect "Servers"
+    // view — Framer Motion FLIPs between the two rendered rects when the user
+    // toggles tabs so each card morphs 1:1 into its pill slot. Full `layout`
+    // animates both position and size; the inner motion.div fades the pill
+    // content in *after* the box has finished shrinking, which avoids the
+    // visible warp that scaling text/icons would cause mid-morph. Mirrors the
+    // demo's pattern where inner controls slide to opacity 0 first, the box
+    // morphs, then the pill content settles in.
     return (
-      <div
+      <motion.div
+        layoutId={SERVER_CARD_LAYOUT_ID(data.serverId)}
+        layout
+        transition={SNAPPY_CAMERA}
         className={cn(
-          "flex h-full w-full flex-col gap-1 rounded-[8px] border border-border/70 bg-card/95 px-3 py-2 shadow-sm transition-all hover:shadow-md",
+          "h-full w-full overflow-hidden rounded-[8px] border border-border/70 bg-card/95 shadow-sm transition-shadow hover:shadow-md",
           selected && "ring-2 ring-primary/40",
         )}
       >
-        <div className="flex items-center gap-1.5">
-          <span
-            className={cn("size-1.5 rounded-full", dotClass)}
-            aria-label={statusLabel}
-            title={statusLabel}
-          />
-          <span
-            className="flex-1 truncate text-[12.5px] font-semibold"
-            title={data.name}
-          >
-            {data.name}
-          </span>
-          <span className="text-[10px] uppercase tracking-[0.04em] text-muted-foreground/80">
-            {data.isOptional ? "optional" : "required"}
-          </span>
-        </div>
-        <span
-          className="truncate font-mono text-[10.5px] text-muted-foreground"
-          title={data.url ?? "Project server"}
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{
+            duration: 0.34,
+            delay: 0.55,
+            ease: [0.22, 1, 0.36, 1],
+          }}
+          className="flex h-full w-full flex-col gap-1 px-3 py-2"
         >
-          {data.url ?? "Project server"}
-        </span>
-        {data.hasOverride ? (
-          <span className="mt-auto text-[10px] text-amber-700 dark:text-amber-300">
-            overrides set
+          <div className="flex items-center gap-1.5">
+            <span
+              className={cn("size-1.5 rounded-full", dotClass)}
+              aria-label={statusLabel}
+              title={statusLabel}
+            />
+            <span
+              className="flex-1 truncate text-[12.5px] font-semibold"
+              title={data.name}
+            >
+              {data.name}
+            </span>
+            <span className="text-[10px] uppercase tracking-[0.04em] text-muted-foreground/80">
+              {data.isOptional ? "optional" : "required"}
+            </span>
+          </div>
+          <span
+            className="truncate font-mono text-[10.5px] text-muted-foreground"
+            title={data.url ?? "Project server"}
+          >
+            {data.url ?? "Project server"}
           </span>
-        ) : null}
+          {data.hasOverride ? (
+            <span className="mt-auto text-[10px] text-amber-700 dark:text-amber-300">
+              overrides set
+            </span>
+          ) : null}
+        </motion.div>
         <Handle
           type="target"
           position={Position.Top}
           id="top"
           className={decorativeHandleClass}
         />
-      </div>
+      </motion.div>
     );
   },
 );
@@ -220,13 +268,83 @@ const nodeTypes = {
   redesignAddServer: AddServerPillRenderer,
 };
 
-function HostSmoothEdge(props: EdgeProps) {
-  const pathOptions = useMemo(() => ({ borderRadius: 14 }), []);
-  return <SmoothStepEdge {...props} pathOptions={pathOptions} />;
+/**
+ * Both host-canvas edges (matrix→hub trunk and hub→card branches) read
+ * their endpoints from `edge.data.fixed{Source,Target}{X,Y}` instead of
+ * from ReactFlow's measured handle positions.
+ *
+ * Why: framer-motion's `layout` + `layoutId` morph on the canvas server
+ * pills (and the matrix card's initial scale/y transform) modify the
+ * elements' CSS transforms. ReactFlow measures handle positions via
+ * `getBoundingClientRect`, which includes those transforms — so the
+ * measured target X/Y can be hundreds of px away from where the node
+ * actually lives in flow coordinates. That made one branch flap up to
+ * the top-right of the canvas (the "giant dashed rectangle" artifact).
+ *
+ * The canvasBuilder already has authoritative flow coordinates for every
+ * node, so just pass them straight through and bypass the measurement.
+ */
+interface FixedEdgeData {
+  fixedSourceX: number;
+  fixedSourceY: number;
+  fixedTargetX: number;
+  fixedTargetY: number;
 }
 
+const TRUNK_CORNER = 14;
+const BRANCH_CORNER = 8;
+
+function buildOrthogonalTreePath(
+  sourceX: number,
+  sourceY: number,
+  targetX: number,
+  targetY: number,
+  cornerRadius: number,
+): string {
+  const midY = (sourceY + targetY) / 2;
+  const goingRight = targetX >= sourceX;
+  const dirX = goingRight ? 1 : -1;
+  const r = Math.min(
+    cornerRadius,
+    Math.abs(targetX - sourceX) / 2,
+    Math.abs(midY - sourceY),
+    Math.abs(targetY - midY),
+  );
+  if (r <= 0.5) {
+    // Source and target vertically aligned — single straight line.
+    return `M ${sourceX} ${sourceY} L ${targetX} ${targetY}`;
+  }
+  return [
+    `M ${sourceX} ${sourceY}`,
+    `L ${sourceX} ${midY - r}`,
+    `Q ${sourceX} ${midY} ${sourceX + r * dirX} ${midY}`,
+    `L ${targetX - r * dirX} ${midY}`,
+    `Q ${targetX} ${midY} ${targetX} ${midY + r}`,
+    `L ${targetX} ${targetY}`,
+  ].join(" ");
+}
+
+function makeFixedEdge(cornerRadius: number) {
+  return function FixedEdge({ id, data, style, markerEnd }: EdgeProps) {
+    const d = data as FixedEdgeData | undefined;
+    if (!d) return null;
+    const path = buildOrthogonalTreePath(
+      d.fixedSourceX,
+      d.fixedSourceY,
+      d.fixedTargetX,
+      d.fixedTargetY,
+      cornerRadius,
+    );
+    return <BaseEdge id={id} path={path} style={style} markerEnd={markerEnd} />;
+  };
+}
+
+const HostTrunkEdge = makeFixedEdge(TRUNK_CORNER);
+const HostBranchEdge = makeFixedEdge(BRANCH_CORNER);
+
 const edgeTypes = {
-  default: HostSmoothEdge,
+  hostTrunk: HostTrunkEdge,
+  hostBranch: HostBranchEdge,
 };
 
 interface RedesignedHostCanvasProps {
@@ -311,12 +429,46 @@ export function RedesignedHostCanvas({
     [selectedNodeId, onSelectNode, readOnly, onRequestEdit],
   );
 
+  // Hold the canvas edges invisible until the server pills have landed at
+  // their layoutId destinations AND their inner content has faded in —
+  // otherwise the lines render at full opacity while the cards are still
+  // morphing in from the Servers grid, which reads as "lines drawn first,
+  // then servers". Timing covers SNAPPY_CAMERA (1150ms) + inner-fade tail.
+  const [edgesReady, setEdgesReady] = useState(false);
+  useEffect(() => {
+    const t = window.setTimeout(() => setEdgesReady(true), 1450);
+    return () => window.clearTimeout(t);
+  }, []);
+
+  // ReactFlow renders nodes at their absolute canvas coordinates first, then
+  // applies `fitView` on the next frame, which causes a one-frame "off-center"
+  // flash where edges trail off to wherever the nodes are pre-fit. Hide the
+  // viewport until onInit fires and fitView has settled, then fade in.
+  const [viewportReady, setViewportReady] = useState(false);
+
   return (
     <div
       className="host-redesign-canvas relative h-full w-full overflow-hidden rounded-[28px] border border-border/70 bg-background"
       style={shellStyle}
+      data-edges-ready={edgesReady ? "true" : "false"}
+      data-viewport-ready={viewportReady ? "true" : "false"}
     >
       <HostMatrixContext.Provider value={matrixCtx}>
+        {/* Inline opacity gate: keeps ReactFlow's pre-fitView paint (nodes
+            at raw canvas coords, edges trailing off-screen) invisible until
+            fitView has applied. Inline style always wins over the cascade,
+            unlike the `data-viewport-ready` CSS attribute selector which was
+            getting shadowed by xyflow's own stylesheet in some load orders. */}
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            opacity: viewportReady ? 1 : 0,
+            transition: viewportReady
+              ? "opacity 220ms cubic-bezier(0.22, 1, 0.36, 1)"
+              : "none",
+          }}
+        >
         <ReactFlow
           nodes={nodes}
           edges={filteredEdges}
@@ -332,7 +484,15 @@ export function RedesignedHostCanvas({
           nodesConnectable={false}
           elementsSelectable={!readOnly}
           fitView
-          fitViewOptions={{ padding: 0.18 }}
+          fitViewOptions={{ padding: 0.18, duration: 0 }}
+          onInit={(instance) => {
+            // Force a deterministic fit + defer the visibility flip a couple
+            // frames so node-measurement and fitView have definitely
+            // applied. `requestAnimationFrame` alone fires before
+            // ReactFlow's measurement pass on the first render.
+            instance.fitView({ padding: 0.18, duration: 0 });
+            window.setTimeout(() => setViewportReady(true), 60);
+          }}
           onNodeClick={(_, node) => {
             if (readOnly) {
               onRequestEdit?.();
@@ -359,6 +519,7 @@ export function RedesignedHostCanvas({
             className="!rounded-xl !border !border-border/70 !bg-card/95"
           />
         </ReactFlow>
+        </div>
       </HostMatrixContext.Provider>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/canvasBuilder.ts
+++ b/mcpjam-inspector/client/src/components/hosts/redesigned/canvas/canvasBuilder.ts
@@ -549,7 +549,15 @@ export function buildRedesignedHostCanvas(
     id: "host-matrix-to-hub",
     source: HOST_MATRIX_NODE_ID,
     target: SERVERS_HUB_NODE_ID,
-    type: "default",
+    type: "hostTrunk",
+    data: {
+      // matrix is positioned at (0, 0); its bottom-center sits at
+      // (MATRIX_W / 2, matrixH). Hub top-center is the target.
+      fixedSourceX: MATRIX_W / 2,
+      fixedSourceY: matrixH,
+      fixedTargetX: serversHubX + serversHubW / 2,
+      fixedTargetY: serversHubY,
+    },
     style: { stroke: "oklch(0.68 0.11 40 / 0.55)", strokeWidth: 1.5 },
   });
 
@@ -605,11 +613,23 @@ export function buildRedesignedHostCanvas(
       draggable: false,
     });
 
+    // Bake the source/target endpoints into edge.data so the custom
+    // HostBranchEdge can ignore ReactFlow's measured handle positions —
+    // which framer-motion's `layout`/`layoutId` transform on the canvas
+    // pills pollutes via getBoundingClientRect, making one branch flap
+    // up to the top of the canvas.
+    const cardX = cardsStartX + i * (SERVER_CARD_W + SERVER_CARD_GAP_X);
     edges.push({
       id: `hub-to-server-${serverId}`,
       source: SERVERS_HUB_NODE_ID,
       target: `server-card:${serverId}`,
-      type: "default",
+      type: "hostBranch",
+      data: {
+        fixedSourceX: serversHubX + serversHubW / 2,
+        fixedSourceY: serversHubY + SERVERS_HUB_H,
+        fixedTargetX: cardX + SERVER_CARD_W / 2,
+        fixedTargetY: serverRowY,
+      },
       style: {
         stroke: insecure
           ? "oklch(0.65 0.18 60)"

--- a/mcpjam-inspector/client/src/components/hosts/transition-tokens.ts
+++ b/mcpjam-inspector/client/src/components/hosts/transition-tokens.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared timing/easing for the Connect-tab "Snappy Canyon" transition between
+ * the Servers grid and the Host canvas. Mirrors the prototype at
+ * /tmp/host-transition-demo.html — bezier `[0.32, 0.72, 0, 1]` is the
+ * camera-ease (zoom-out), and the durations match the demo's --t-* tokens.
+ */
+
+export const SNAPPY_CAMERA = {
+  duration: 1.15,
+  ease: [0.32, 0.72, 0, 1] as [number, number, number, number],
+};
+
+export const SNAPPY_FADE = {
+  duration: 0.5,
+  ease: [0.22, 1, 0.36, 1] as [number, number, number, number],
+};
+
+export const SNAPPY_RAIL = {
+  duration: 0.9,
+  ease: [0.32, 0.72, 0, 1] as [number, number, number, number],
+};
+
+/**
+ * Host canvas inner-content entrance. Slight delay so the camera fade
+ * "opens" first, then the host card scales into view — gives the click a
+ * second beat instead of cutting straight to the final state.
+ */
+export const SNAPPY_HOST_REVEAL = {
+  duration: 0.7,
+  delay: 0.18,
+  ease: [0.22, 1, 0.36, 1] as [number, number, number, number],
+};
+
+export const SNAPPY_STAGGER = {
+  staggerChildren: 0.08,
+  delayChildren: 0.28,
+};
+
+export type ViewPhase = "servers" | "host";
+
+export const SERVER_CARD_LAYOUT_ID = (serverId: string) =>
+  `connect-server:${serverId}`;

--- a/mcpjam-inspector/client/src/components/hosts/transition-tokens.ts
+++ b/mcpjam-inspector/client/src/components/hosts/transition-tokens.ts
@@ -10,11 +10,6 @@ export const SNAPPY_CAMERA = {
   ease: [0.32, 0.72, 0, 1] as [number, number, number, number],
 };
 
-export const SNAPPY_FADE = {
-  duration: 0.5,
-  ease: [0.22, 1, 0.36, 1] as [number, number, number, number],
-};
-
 export const SNAPPY_RAIL = {
   duration: 0.9,
   ease: [0.32, 0.72, 0, 1] as [number, number, number, number],
@@ -29,11 +24,6 @@ export const SNAPPY_HOST_REVEAL = {
   duration: 0.7,
   delay: 0.18,
   ease: [0.22, 1, 0.36, 1] as [number, number, number, number],
-};
-
-export const SNAPPY_STAGGER = {
-  staggerChildren: 0.08,
-  delayChildren: 0.28,
 };
 
 export type ViewPhase = "servers" | "host";

--- a/mcpjam-inspector/client/src/index.css
+++ b/mcpjam-inspector/client/src/index.css
@@ -747,6 +747,15 @@
   transition: opacity 220ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+/* Reduced-motion: the canvas still needs the visibility gate (otherwise the
+   pre-fitView flash is worse), but instant rather than animated. */
+@media (prefers-reduced-motion: reduce) {
+  .host-redesign-canvas[data-edges-ready="true"] .react-flow__edges,
+  .host-redesign-canvas[data-viewport-ready="true"] .react-flow__viewport {
+    transition: none;
+  }
+}
+
 /* Font code variable for theme */
 @theme inline {
   --font-code: var(--font-code);

--- a/mcpjam-inspector/client/src/index.css
+++ b/mcpjam-inspector/client/src/index.css
@@ -723,6 +723,30 @@
   }
 }
 
+/* Hold the host canvas's connecting edges invisible until the server pills
+   have landed via Framer Motion's layoutId morph (~SNAPPY_CAMERA + buffer).
+   Otherwise the lines render immediately while cards are still translating,
+   which reads as "edges drawn before servers arrive". */
+.host-redesign-canvas[data-edges-ready="false"] .react-flow__edges {
+  opacity: 0;
+}
+.host-redesign-canvas[data-edges-ready="true"] .react-flow__edges {
+  opacity: 1;
+  transition: opacity 360ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Hide ReactFlow's viewport (node + edge layers) until fitView has settled —
+   prevents the one-frame "off-center" flash where nodes render at their raw
+   canvas coords before the viewport pans into place. The nodes pane and the
+   edges pane both sit inside .react-flow__viewport. */
+.host-redesign-canvas[data-viewport-ready="false"] .react-flow__viewport {
+  opacity: 0;
+}
+.host-redesign-canvas[data-viewport-ready="true"] .react-flow__viewport {
+  opacity: 1;
+  transition: opacity 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
 /* Font code variable for theme */
 @theme inline {
   --font-code: var(--font-code);

--- a/mcpjam-inspector/client/src/lib/host-templates.ts
+++ b/mcpjam-inspector/client/src/lib/host-templates.ts
@@ -11,6 +11,7 @@ import mcpjamLogo from "/mcp_jam.svg";
 import claudeLogo from "/claude_logo.png";
 import openaiLogo from "/openai_logo.png";
 import cursorLogo from "/cursor_logo.png";
+import codexLogo from "/codex-logo.svg";
 
 declare const __APP_VERSION__: string;
 
@@ -202,7 +203,12 @@ const CLAUDE_FONTS_CSS = `
 }
 `;
 
-export type HostTemplateId = "mcpjam" | "claude" | "chatgpt" | "cursor";
+export type HostTemplateId =
+  | "mcpjam"
+  | "claude"
+  | "chatgpt"
+  | "cursor"
+  | "codex";
 
 export interface HostTemplate {
   id: HostTemplateId;
@@ -551,6 +557,61 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
               mode: "custom",
               allow: { clipboardWrite: true },
             },
+          },
+        },
+      };
+      return base;
+    },
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    description:
+      "OpenAI Codex CLI. Elicitation-only client, no widget rendering.",
+    logoSrc: codexLogo,
+    seed: () => {
+      const base = emptyHostConfigInputV2({
+        // No "codex" entry in the host-style registry yet — fall back to
+        // chatgpt visuals (closest OpenAI-flavored chrome) so chat UI
+        // resolves to something coherent. Bump to a dedicated "codex"
+        // hostStyle if/when one lands in host-styles/built-ins.ts.
+        hostStyle: "chatgpt",
+        // Canonical id (openai/<slug>) so the chat-composer model picker
+        // resolves it. gpt-5-nano is in MCPJAM_GUEST_ALLOWED_MODEL_IDS, so
+        // guests get it without an OpenAI key; users can swap to a
+        // codex-specific model after creation.
+        modelId: "openai/gpt-5-nano",
+        temperature: 0.7,
+        requireToolApproval: false,
+      });
+      // Codex CLI probe advertises only elicitation. It does NOT advertise
+      // the MCP UI extension (no widget rendering), so we replace the SDK
+      // default clientCapabilities entirely rather than spreading on top —
+      // a spread would leak `extensions["io.modelcontextprotocol/ui"]`
+      // back in and misrepresent Codex as a UI-capable client.
+      base.clientCapabilities = {
+        elicitation: {},
+      };
+      // Codex is a CLI: it doesn't render MCP Apps views, so no
+      // hostContext (styles/displayMode/containerDimensions are
+      // meaningless without a renderer). Leaving `hostContext` as the
+      // empty object from emptyHostConfigInputV2.
+      //
+      // Same reasoning for hostCapabilitiesOverride: there's no
+      // ui/initialize negotiation, so we don't override what the preset
+      // advertises. The preset's chatgpt advertise is irrelevant in
+      // practice because no widget will ever read it from Codex.
+      base.mcpProfile = {
+        profileVersion: 1,
+        initialize: {
+          supportedProtocolVersions: ["2025-06-18"],
+          // Verbatim from a real Codex CLI probe. `title` lands in the
+          // pass-through `Record<string, unknown>` per host-config-v2
+          // (backend soft-validates name/version only).
+          clientInfo: {
+            name: "codex-mcp-client",
+            title: "Codex",
+            version: "0.131.0-alpha.9",
           },
         },
       };

--- a/mcpjam-inspector/client/src/router.tsx
+++ b/mcpjam-inspector/client/src/router.tsx
@@ -50,6 +50,7 @@ export function createAppRouter(): AppRouter {
         { index: true, element: <ServersRoute /> },
         { path: "servers", element: <ServersRoute /> },
         { path: "hosts", element: <HostsRoute /> },
+        { path: "hosts/:hostId", element: <HostsRoute /> },
         { path: "registry", element: <RegistryRoute /> },
         { path: "tools", element: <ToolsRoute /> },
         { path: "resources", element: <ResourcesRoute /> },


### PR DESCRIPTION
## Summary
- New camera-style transition between the Servers grid and the Host canvas: server cards morph 1:1 into ReactFlow pills via shared `layoutId`, logs rail slides out, host chrome staggers in.
- Adds per-host `/hosts/:id` routes (App + router).
- Replaces the host canvas's smoothstep auto-routing with deterministic tree edges. `canvasBuilder` now bakes the source/target flow coordinates into `edge.data.fixed*`, and the custom `HostTrunkEdge`/`HostBranchEdge` draw an explicit `M → L → Q → L → Q → L` path from those endpoints. This sidesteps a bug where framer-motion's `layout`/`layoutId` transforms polluted ReactFlow's `getBoundingClientRect`-based handle measurement, sending one hub→card branch hundreds of px off and drawing a giant dashed rectangle across the canvas.
- All three branches now share a single bus line at `(sourceY + targetY) / 2` with a clamped corner radius, so the fan reads as a clean tree.

## Test plan
- [ ] Servers tab → click a host → smooth morph + clean tree edges (no off-canvas dashed rectangle)
- [ ] Navigate to `/hosts/:id` directly → host canvas renders, edges correct
- [ ] Resize the canvas / open & close focus panel → edges stay aligned with hub bottom and card tops
- [ ] Toggle servers ↔ host repeatedly → no ghost cards or stray paths
- [ ] Reduced-motion → no animation regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to new URL-driven host selection, navigation behavior changes (history/replace), and custom ReactFlow edge rendering/animation timing that could regress routing, back-button behavior, or canvas visuals.
> 
> **Overview**
> **Connect tab now deep-links hosts and uses URL-driven selection.** Adds a new `hosts/:hostId` route and updates Servers/Hosts navigation so selecting a host drives the URL (and HostsRoute syncs URL → shared `hostsTabSelectedHostId`), including `GlobalHostBar` using `buildHostsPath()` with `replace` on canvas retarget.
> 
> **Servers→Host transition is upgraded to a shared-layout “camera” morph.** Introduces shared Framer Motion `layoutId`s between server grid cards and host-canvas pills, a `HostsConnectViewPhaseContext` to coordinate phase-aware animations (e.g., sliding out the logs rail), and centralized transition tokens.
> 
> **Host canvas edge rendering is made deterministic to avoid transform-measurement glitches.** Replaces SmoothStep routing with custom fixed-endpoint trunk/branch edges (endpoints baked into `edge.data` by `canvasBuilder`), and gates canvas viewport/edge visibility until `fitView` and morph animations settle (JS + new CSS selectors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 169b8ccaa2c62b851bcb9a5da4bb7182da6ec7c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->