### PR TITLE
Redesign client canvas as a single host matrix with diagram color tokens

### DIFF
--- a/design-system/src/index.css
+++ b/design-system/src/index.css
@@ -288,6 +288,12 @@
   --info-foreground: oklch(1 0 0);
   --pending: oklch(0.769 0.188 85.3);
   --pending-foreground: oklch(0.239 0.06 60);
+  --diagram-server: oklch(0.62 0.1 155);
+  --diagram-server-foreground: oklch(0.99 0.01 155);
+  --diagram-sandbox: oklch(0.65 0.12 75);
+  --diagram-sandbox-foreground: oklch(0.99 0.01 75);
+  --diagram-view: oklch(0.6 0.1 290);
+  --diagram-view-foreground: oklch(0.99 0.01 290);
   --trace-waterfall-bar-prompt: oklch(0.885 0.082 292);
   --trace-waterfall-bar-llm: oklch(0.885 0.076 255);
   --trace-waterfall-bar-tool: oklch(0.905 0.105 96);
@@ -351,6 +357,12 @@
   --info-foreground: oklch(1 0 0);
   --pending: oklch(0.75 0.183 55);
   --pending-foreground: oklch(0.95 0.06 70);
+  --diagram-server: oklch(0.8 0.1 155);
+  --diagram-server-foreground: oklch(0.2 0.04 155);
+  --diagram-sandbox: oklch(0.82 0.11 75);
+  --diagram-sandbox-foreground: oklch(0.2 0.04 75);
+  --diagram-view: oklch(0.8 0.09 290);
+  --diagram-view-foreground: oklch(0.2 0.04 290);
   --trace-waterfall-bar-prompt: oklch(0.79 0.11 292 / 0.58);
   --trace-waterfall-bar-llm: oklch(0.79 0.1 255 / 0.58);
   --trace-waterfall-bar-tool: oklch(0.83 0.12 88 / 0.58);
@@ -392,6 +404,12 @@
   --color-info-foreground: var(--info-foreground);
   --color-pending: var(--pending);
   --color-pending-foreground: var(--pending-foreground);
+  --color-diagram-server: var(--diagram-server);
+  --color-diagram-server-foreground: var(--diagram-server-foreground);
+  --color-diagram-sandbox: var(--diagram-sandbox);
+  --color-diagram-sandbox-foreground: var(--diagram-sandbox-foreground);
+  --color-diagram-view: var(--diagram-view);
+  --color-diagram-view-foreground: var(--diagram-view-foreground);
   --color-overlay: var(--overlay);
   --color-chart-1: var(--chart-1);
   --color-chart-2: var(--chart-2);

--- a/design-system/src/tokens.css
+++ b/design-system/src/tokens.css
@@ -41,6 +41,15 @@
   --info-foreground: oklch(1 0 0);
   --pending: oklch(0.769 0.188 85.3);
   --pending-foreground: oklch(0.239 0.06 60);
+  /* Diagram accent tokens — pastel hues for the client-diagram layers
+     (servers hub, sandbox proxy iframe, view iframe). Role-based, not
+     reused outside the architecture diagram. */
+  --diagram-server: oklch(0.62 0.1 155);
+  --diagram-server-foreground: oklch(0.99 0.01 155);
+  --diagram-sandbox: oklch(0.65 0.12 75);
+  --diagram-sandbox-foreground: oklch(0.99 0.01 75);
+  --diagram-view: oklch(0.6 0.1 290);
+  --diagram-view-foreground: oklch(0.99 0.01 290);
   /* Overlay color */
   --overlay: oklch(0 0 0 / 0.5);
   --font-sans:
@@ -122,6 +131,14 @@
   --info-foreground: oklch(1 0 0);
   --pending: oklch(0.75 0.183 55);
   --pending-foreground: oklch(0.95 0.06 70);
+  /* Diagram accent tokens — pastel hues for the client-diagram layers.
+     Higher lightness in dark mode so tints read against the dark canvas. */
+  --diagram-server: oklch(0.8 0.1 155);
+  --diagram-server-foreground: oklch(0.2 0.04 155);
+  --diagram-sandbox: oklch(0.82 0.11 75);
+  --diagram-sandbox-foreground: oklch(0.2 0.04 75);
+  --diagram-view: oklch(0.8 0.09 290);
+  --diagram-view-foreground: oklch(0.2 0.04 290);
   /* Overlay color */
   --overlay: oklch(0 0 0 / 0.5);
   --font-sans:

--- a/design-system/src/tokens.ts
+++ b/design-system/src/tokens.ts
@@ -41,6 +41,15 @@ export const tokensCss: string = `@theme {
   --info-foreground: oklch(1 0 0);
   --pending: oklch(0.769 0.188 85.3);
   --pending-foreground: oklch(0.239 0.06 60);
+  /* Diagram accent tokens — pastel hues for the client-diagram layers
+     (servers hub, sandbox proxy iframe, view iframe). Role-based, not
+     reused outside the architecture diagram. */
+  --diagram-server: oklch(0.62 0.1 155);
+  --diagram-server-foreground: oklch(0.99 0.01 155);
+  --diagram-sandbox: oklch(0.65 0.12 75);
+  --diagram-sandbox-foreground: oklch(0.99 0.01 75);
+  --diagram-view: oklch(0.6 0.1 290);
+  --diagram-view-foreground: oklch(0.99 0.01 290);
   /* Overlay color */
   --overlay: oklch(0 0 0 / 0.5);
   --font-sans:
@@ -122,6 +131,14 @@ export const tokensCss: string = `@theme {
   --info-foreground: oklch(1 0 0);
   --pending: oklch(0.75 0.183 55);
   --pending-foreground: oklch(0.95 0.06 70);
+  /* Diagram accent tokens — pastel hues for the client-diagram layers.
+     Higher lightness in dark mode so tints read against the dark canvas. */
+  --diagram-server: oklch(0.8 0.1 155);
+  --diagram-server-foreground: oklch(0.2 0.04 155);
+  --diagram-sandbox: oklch(0.82 0.11 75);
+  --diagram-sandbox-foreground: oklch(0.2 0.04 75);
+  --diagram-view: oklch(0.8 0.09 290);
+  --diagram-view-foreground: oklch(0.2 0.04 290);
   /* Overlay color */
   --overlay: oklch(0 0 0 / 0.5);
   --font-sans:

--- a/mcpjam-inspector/client/src/components/ClientsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ClientsTab.tsx
@@ -9,7 +9,10 @@ import { ViewModeSelector } from "./shared/view-mode-selector";
 import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
 import { useHost, useHostList } from "@/hooks/useClients";
 import { routePaths } from "@/lib/app-navigation";
-import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
+import {
+  getChatboxShellStyle,
+  getHostChromeAccentVariables,
+} from "@/lib/chatbox-client-style";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 
 interface HostsTabProps {
@@ -44,23 +47,35 @@ export function ClientsTab({
   const [addServerSlotEl, setAddServerSlotEl] = useState<HTMLDivElement | null>(
     null,
   );
-  // Match the Host canvas's brand-tinted backdrop on the Servers view: read
-  // the previewed host's style and cascade brand `--background`, `--primary`,
-  // `--card`, etc. into the subtree so the Servers chrome inherits the host's
-  // accent (orange for Claude, blue for ChatGPT, …) without per-component
-  // theming code. Mirrors `ClientBuilderViewRedesigned.canvasShellStyle`.
+  // Brand shell variables apply to the server list body so cards match the
+  // emulated host canvas; the tab chrome uses the app background (same as
+  // the global Header) plus `getHostChromeAccentVariables` for primary accents.
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const { host: previewedHost } = useHost({
     isAuthenticated,
     hostId: previewedHostId,
   });
   const previewedHostStyle = previewedHost?.config?.hostStyle ?? null;
+  const previewedChatUiOverride = previewedHost?.config?.chatUiOverride;
   const browseShellStyle = useMemo(
     () =>
       previewedHostStyle
-        ? getChatboxShellStyle(previewedHostStyle, themeMode)
+        ? getChatboxShellStyle(
+            previewedHostStyle,
+            themeMode,
+            previewedChatUiOverride,
+          )
         : undefined,
-    [previewedHostStyle, themeMode],
+    [previewedHostStyle, previewedChatUiOverride, themeMode],
+  );
+  const chromeAccentStyle = useMemo(
+    () =>
+      getHostChromeAccentVariables(
+        previewedHostStyle,
+        themeMode,
+        previewedChatUiOverride,
+      ),
+    [previewedHostStyle, previewedChatUiOverride, themeMode],
   );
 
   // Reset host selection only when the project actually changes mid-session,
@@ -139,13 +154,12 @@ export function ClientsTab({
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 8 }}
             transition={SNAPPY_RAIL}
-            data-host-style={previewedHostStyle ?? undefined}
-            style={browseShellStyle}
             className="absolute inset-0 flex min-h-0 flex-col bg-background text-foreground"
           >
             <ClientsConnectAddServerSlotContext.Provider value={addServerSlotEl}>
               <div
                 className="relative shrink-0 border-b border-border/40 px-8 py-2.5"
+                style={chromeAccentStyle}
                 data-testid="hosts-tab-header-chrome"
               >
                 <div className="flex min-w-0 items-center justify-end gap-3">
@@ -183,7 +197,13 @@ export function ClientsTab({
                   </div>
                 </div>
               </div>
-              <div className="min-h-0 flex-1">{serversTabElement}</div>
+              <div
+                className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background text-foreground"
+                style={browseShellStyle}
+                data-host-style={previewedHostStyle ?? undefined}
+              >
+                <div className="min-h-0 flex-1">{serversTabElement}</div>
+              </div>
             </ClientsConnectAddServerSlotContext.Provider>
           </motion.div>
         )}

--- a/mcpjam-inspector/client/src/components/clients/redesigned/ClientBuilderViewRedesigned.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/ClientBuilderViewRedesigned.tsx
@@ -26,7 +26,10 @@ import {
   serverConnectionOverridesEqual,
   type HostConfigInputV2,
 } from "@/lib/client-config-v2";
-import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
+import {
+  getChatboxShellStyle,
+  getHostChromeAccentVariables,
+} from "@/lib/chatbox-client-style";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { RedesignedClientCanvas } from "./canvas/RedesignedClientCanvas";
 import { buildRedesignedHostCanvas } from "./canvas/canvasBuilder";
@@ -210,9 +213,8 @@ export function ClientBuilderViewRedesigned({
   );
 
   const themeMode = usePreferencesStore((s) => s.themeMode);
-  // Full brand shell — sets `--background`, `--foreground`, `--card`,
-  // `--border`, etc. for the canvas subtree so sub-cards repaint to the
-  // host's brand instead of the app theme.
+  // Brand shell on the canvas subtree only (not the top tab chrome) so the
+  // tab row matches the global Header background; see getHostChromeAccentVariables.
   const canvasShellStyle = useMemo(
     () =>
       draftConfig?.hostStyle
@@ -222,6 +224,15 @@ export function ClientBuilderViewRedesigned({
             draftConfig.chatUiOverride,
           )
         : undefined,
+    [draftConfig?.hostStyle, draftConfig?.chatUiOverride, themeMode],
+  );
+  const chromeAccentStyle = useMemo(
+    () =>
+      getHostChromeAccentVariables(
+        draftConfig?.hostStyle ?? null,
+        themeMode,
+        draftConfig?.chatUiOverride,
+      ),
     [draftConfig?.hostStyle, draftConfig?.chatUiOverride, themeMode],
   );
 
@@ -349,9 +360,12 @@ export function ClientBuilderViewRedesigned({
   const canSave = isDirty && !isSaving && !hasBlockingErrors(attention);
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      {/* Chrome */}
-      <div className="relative shrink-0 border-b border-border/40 px-8 py-2.5">
+    <div className="flex h-full min-h-0 flex-col bg-background text-foreground">
+      {/* Chrome — app background matches global Header; primary accents stay host-branded */}
+      <div
+        className="relative shrink-0 border-b border-border/40 px-8 py-2.5"
+        style={chromeAccentStyle}
+      >
         <div className="flex min-w-0 items-center justify-end gap-2 sm:gap-3">
           <Button
             size="sm"
@@ -395,6 +409,10 @@ export function ClientBuilderViewRedesigned({
         </div>
       </div>
 
+      <div
+        className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background text-foreground"
+        style={canvasShellStyle}
+      >
       {/* Canvas + side focus panel (mirrors the ChatboxBuilderView layout:
           left = canvas, right = setup/focus rail). Resizable so the user
           can grow the editor without losing the canvas context. */}
@@ -463,6 +481,7 @@ export function ClientBuilderViewRedesigned({
           onSubmit={handleAddServer}
         />
       )}
+      </div>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
@@ -17,17 +17,12 @@ import {
 } from "../types";
 
 /* ============================================================
-   Host card — paper aesthetic. The card IS the architecture
-   diagram. Host frame wraps Sandbox frame wraps View frame;
-   capability data lives inside the layer it belongs to.
-
-   - Host outer (gray paper): identity, agent settings, client
-     capabilities, extensions footer
-   - Sandbox middle (amber/cream): mode/restrictTo/deny/permissions
-   - View inner (lavender): Apps Extension capabilities + hostContext
-
-   Every sub-region click still dispatches the same node id as the
-   previous matrix card, so the focus panel routing is unchanged.
+   Host card. The card IS the architecture diagram — Host frame
+   wraps Sandbox frame wraps View frame; capability data lives
+   inside the layer it belongs to. Depth comes from tonal
+   variation of the app's design-system tokens (card → muted →
+   card), so the card reads as the same product as the Servers
+   tab. Sub-region clicks dispatch the same node ids as before.
    ============================================================ */
 export interface HostMatrixCardProps {
   hostName: string;
@@ -451,80 +446,54 @@ function extractFieldCount(value: string | undefined): number {
 
 /* ---------------- inline styles ---------------- */
 /**
- * Paper palette declared via scoped CSS custom properties. The light/paper
- * values are the default; `.dark .host-paper-card` overrides them with a
- * dark-tinted equivalent that keeps the per-frame hue cues (amber sandbox,
- * lavender view) so the architecture metaphor survives the theme flip.
+ * Frame palette is sourced from the app's design-system tokens
+ * (--card, --muted, --border, --foreground, --muted-foreground,
+ * --success, --warning, --destructive). Light/dark switches via
+ * those tokens at :root / .dark, so the card matches the rest of
+ * the product without a separate dark block here.
+ *
+ * Depth between the three nested frames comes from tonal
+ * variation alone: Host = card, Sandbox = muted wash, View =
+ * card again (inset back to the surface tone). The result is a
+ * clear "paper inside grey inside paper" hierarchy without any
+ * bespoke hue.
  */
 const PAPER_STYLES = `
 .host-paper-card {
-  /* Light / paper palette (default) */
-  --hp-page: oklch(0.985 0.005 80);
-  --hp-ink: oklch(0.22 0.01 250);
-  --hp-muted: oklch(0.50 0.01 250);
-  --hp-muted-dim: oklch(0.64 0.008 250);
-  --hp-hairline: oklch(0.82 0.005 250 / 0.55);
-  --hp-paper-surface: white;
-  --hp-region-hover: oklch(1 0 0 / 0.4);
-  --hp-region-selected: oklch(1 0 0 / 0.6);
-  --hp-ctx-hover: oklch(1 0 0 / 0.5);
+  --hp-ink: var(--foreground);
+  --hp-muted: var(--muted-foreground);
+  --hp-muted-dim: color-mix(in oklch, var(--muted-foreground) 65%, transparent);
+  --hp-hairline: var(--border);
+  --hp-paper-surface: var(--popover);
+  --hp-region-hover: color-mix(in oklch, var(--foreground) 4%, transparent);
+  --hp-region-selected: color-mix(in oklch, var(--foreground) 7%, transparent);
+  --hp-ctx-hover: color-mix(in oklch, var(--foreground) 5%, transparent);
 
-  --hp-host-bg: oklch(0.965 0.005 80);
-  --hp-host-ring: oklch(0.86 0.008 80);
+  --hp-host-bg: var(--popover);
+  --hp-host-ring: var(--border);
 
-  --hp-sandbox-bg: oklch(0.965 0.03 75);
-  --hp-sandbox-ring: oklch(0.87 0.06 70);
-  --hp-sandbox-ink: oklch(0.40 0.10 60);
-  --hp-sandbox-sub: oklch(0.55 0.10 65);
-  --hp-sandbox-hairline: oklch(0.87 0.04 70 / 0.4);
-  --hp-sandbox-row-hover: oklch(1 0 0 / 0.35);
-  --hp-sandbox-row-selected: oklch(1 0 0 / 0.55);
+  --hp-sandbox-bg: var(--muted);
+  --hp-sandbox-ring: var(--border);
+  --hp-sandbox-ink: var(--foreground);
+  --hp-sandbox-sub: var(--muted-foreground);
+  --hp-sandbox-hairline: var(--border);
+  --hp-sandbox-row-hover: color-mix(in oklch, var(--foreground) 4%, transparent);
+  --hp-sandbox-row-selected: color-mix(in oklch, var(--foreground) 7%, transparent);
 
-  --hp-view-bg: oklch(0.96 0.025 285);
-  --hp-view-ring: oklch(0.86 0.07 285);
-  --hp-view-ink: oklch(0.34 0.16 285);
-  --hp-view-sub: oklch(0.50 0.12 285);
-  --hp-view-cap-selected-bg: oklch(0.90 0.06 285);
+  --hp-view-bg: var(--popover);
+  --hp-view-ring: var(--border);
+  --hp-view-ink: var(--foreground);
+  --hp-view-sub: var(--muted-foreground);
+  --hp-view-cap-selected-bg: color-mix(in oklch, var(--foreground) 7%, transparent);
 
-  --hp-emerald: oklch(0.62 0.15 145);
-  --hp-amber: oklch(0.72 0.16 70);
-  --hp-danger: oklch(0.65 0.21 25);
+  --hp-emerald: var(--success);
+  --hp-amber: var(--warning);
+  --hp-danger: var(--destructive);
 
-  font-family: ui-sans-serif, system-ui, -apple-system, "Inter", sans-serif;
   color: var(--hp-ink);
   font-size: 14px;
   line-height: 1.5;
   text-align: left;
-}
-
-/* Dark theme: keep hue cues, swap lightness. Each frame is now a dim
-   tinted wash rather than a saturated paper fill. */
-.dark .host-paper-card {
-  --hp-ink: oklch(0.95 0.005 250);
-  --hp-muted: oklch(0.65 0.01 250);
-  --hp-muted-dim: oklch(0.50 0.008 250);
-  --hp-hairline: oklch(0.40 0.01 250 / 0.5);
-  --hp-paper-surface: oklch(0.27 0.008 250);
-  --hp-region-hover: oklch(1 0 0 / 0.04);
-  --hp-region-selected: oklch(1 0 0 / 0.07);
-  --hp-ctx-hover: oklch(1 0 0 / 0.05);
-
-  --hp-host-bg: oklch(0.215 0.006 250);
-  --hp-host-ring: oklch(0.32 0.008 250);
-
-  --hp-sandbox-bg: oklch(0.255 0.035 70);
-  --hp-sandbox-ring: oklch(0.38 0.06 70);
-  --hp-sandbox-ink: oklch(0.86 0.10 70);
-  --hp-sandbox-sub: oklch(0.72 0.08 65);
-  --hp-sandbox-hairline: oklch(0.40 0.04 70 / 0.5);
-  --hp-sandbox-row-hover: oklch(1 0 0 / 0.04);
-  --hp-sandbox-row-selected: oklch(1 0 0 / 0.07);
-
-  --hp-view-bg: oklch(0.245 0.045 285);
-  --hp-view-ring: oklch(0.40 0.08 285);
-  --hp-view-ink: oklch(0.87 0.10 285);
-  --hp-view-sub: oklch(0.72 0.10 285);
-  --hp-view-cap-selected-bg: oklch(0.36 0.10 285);
 }
 .host-paper-card .hp-mono {
   font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
@@ -699,7 +668,7 @@ const PAPER_STYLES = `
   border-style: dashed;
   font-weight: 400;
   text-decoration: line-through;
-  text-decoration-color: oklch(0.64 0.008 250 / 0.5);
+  text-decoration-color: color-mix(in oklch, var(--muted-foreground) 60%, transparent);
   text-decoration-thickness: 0.5px;
 }
 .host-paper-card .hp-cap-dot {
@@ -802,13 +771,17 @@ const PAPER_STYLES = `
 .host-paper-card .hp-sb-row:hover { background: var(--hp-sandbox-row-hover); }
 .host-paper-card .hp-sb-row--selected { background: var(--hp-sandbox-row-selected); }
 .host-paper-card .hp-sb-row--warn {
-  background: oklch(0.78 0.16 75 / 0.10);
+  background: color-mix(in oklch, var(--warning) 12%, transparent);
 }
-.host-paper-card .hp-sb-row--warn:hover { background: oklch(0.78 0.16 75 / 0.16); }
+.host-paper-card .hp-sb-row--warn:hover {
+  background: color-mix(in oklch, var(--warning) 18%, transparent);
+}
 .host-paper-card .hp-sb-row--danger {
-  background: oklch(0.65 0.21 25 / 0.10);
+  background: color-mix(in oklch, var(--destructive) 12%, transparent);
 }
-.host-paper-card .hp-sb-row--danger:hover { background: oklch(0.65 0.21 25 / 0.16); }
+.host-paper-card .hp-sb-row--danger:hover {
+  background: color-mix(in oklch, var(--destructive) 18%, transparent);
+}
 .host-paper-card .hp-sb-key {
   color: var(--hp-sandbox-sub);
   font-family: ui-monospace, "JetBrains Mono", monospace;
@@ -887,7 +860,7 @@ const PAPER_STYLES = `
   border-style: dashed;
   font-weight: 400;
   text-decoration: line-through;
-  text-decoration-color: oklch(0.50 0.12 285 / 0.55);
+  text-decoration-color: color-mix(in oklch, var(--muted-foreground) 60%, transparent);
   text-decoration-thickness: 0.5px;
 }
 .host-paper-card .hp-view-cap--selected {
@@ -955,16 +928,16 @@ const PAPER_STYLES = `
   background: var(--hp-region-selected) !important;
 }
 
-/* === Diff flash (preserved from prior card, retuned to paper) === */
+/* === Diff flash === */
 @keyframes hostMatrixDiffFlashPaper {
-  0% { background-color: oklch(0.83 0.17 75 / 0.32); }
+  0% { background-color: color-mix(in oklch, var(--warning) 32%, transparent); }
   100% { background-color: transparent; }
 }
 .host-paper-card .host-matrix-changed {
   animation: hostMatrixDiffFlashPaper 1.8s ease-out;
 }
 .host-paper-card .host-matrix-newly {
-  box-shadow: inset 2px 0 0 oklch(0.78 0.16 70);
+  box-shadow: inset 2px 0 0 var(--warning);
   animation: hostMatrixDiffFlashPaper 1.8s ease-out;
 }
 `;

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
@@ -472,21 +472,23 @@ const PAPER_STYLES = `
   --hp-host-bg: var(--popover);
   --hp-host-ring: var(--border);
 
-  --hp-sandbox-bg: var(--muted);
-  --hp-sandbox-ring: var(--border);
+  --hp-sandbox-bg: color-mix(in oklch, var(--diagram-sandbox) 8%, var(--popover));
+  --hp-sandbox-ring: color-mix(in oklch, var(--diagram-sandbox) 35%, var(--border));
   --hp-sandbox-ink: var(--foreground);
+  --hp-sandbox-accent: var(--diagram-sandbox);
   --hp-sandbox-sub: var(--muted-foreground);
-  --hp-sandbox-hairline: var(--border);
-  --hp-sandbox-row-hover: color-mix(in oklch, var(--foreground) 4%, transparent);
-  --hp-sandbox-row-selected: color-mix(in oklch, var(--foreground) 7%, transparent);
+  --hp-sandbox-hairline: color-mix(in oklch, var(--diagram-sandbox) 20%, var(--border));
+  --hp-sandbox-row-hover: color-mix(in oklch, var(--diagram-sandbox) 6%, transparent);
+  --hp-sandbox-row-selected: color-mix(in oklch, var(--diagram-sandbox) 12%, transparent);
 
-  --hp-view-bg: var(--popover);
-  --hp-view-ring: var(--border);
+  --hp-view-bg: color-mix(in oklch, var(--diagram-view) 10%, var(--popover));
+  --hp-view-ring: color-mix(in oklch, var(--diagram-view) 40%, var(--border));
   --hp-view-ink: var(--foreground);
+  --hp-view-accent: var(--diagram-view);
   --hp-view-sub: var(--muted-foreground);
-  --hp-view-cap-selected-bg: color-mix(in oklch, var(--foreground) 7%, transparent);
+  --hp-view-cap-selected-bg: color-mix(in oklch, var(--diagram-view) 14%, transparent);
 
-  --hp-emerald: var(--success);
+  --hp-emerald: var(--diagram-server);
   --hp-amber: var(--warning);
   --hp-danger: var(--destructive);
 
@@ -721,7 +723,7 @@ const PAPER_STYLES = `
 .host-paper-card .hp-sandbox-title {
   font-size: 15px;
   font-weight: 600;
-  color: var(--hp-sandbox-ink);
+  color: var(--hp-sandbox-accent);
   letter-spacing: -0.01em;
   display: inline-flex;
   align-items: center;
@@ -826,7 +828,7 @@ const PAPER_STYLES = `
 .host-paper-card .hp-view-title {
   font-size: 14px;
   font-weight: 600;
-  color: var(--hp-view-ink);
+  color: var(--hp-view-accent);
   letter-spacing: -0.01em;
 }
 .host-paper-card .hp-view-sub {

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
@@ -17,10 +17,17 @@ import {
 } from "../types";
 
 /* ============================================================
-   Pure presentational card. Receives pre-computed data from the
-   canvas builder; renders the matrix layout used inside the
-   ReactFlow host node. No outer shell, no servers strip — those
-   are the parent canvas's concern.
+   Host card — paper aesthetic. The card IS the architecture
+   diagram. Host frame wraps Sandbox frame wraps View frame;
+   capability data lives inside the layer it belongs to.
+
+   - Host outer (gray paper): identity, agent settings, client
+     capabilities, extensions footer
+   - Sandbox middle (amber/cream): mode/restrictTo/deny/permissions
+   - View inner (lavender): Apps Extension capabilities + hostContext
+
+   Every sub-region click still dispatches the same node id as the
+   previous matrix card, so the focus panel routing is unchanged.
    ============================================================ */
 export interface HostMatrixCardProps {
   hostName: string;
@@ -28,28 +35,14 @@ export interface HostMatrixCardProps {
   protocolBand: ProtocolLeafNodeData[];
   clientCaps: ClientCapRow[];
   appsCaps: AppsCapLeafNodeData[];
-  /**
-   * Sandbox config rows (CSP mode, restrictTo, deny, permissions).
-   * Surfaced as a sibling section to Apps Extension so the policies that
-   * silently affect widget behavior (the `restrictTo` intersection trap,
-   * mode = "relaxed" opening things up) are visible from the host card
-   * instead of buried in raw JSON. Same `appsExtensionAdvertised` gate
-   * as Apps caps — sandbox is part of SEP-1865 and meaningless without
-   * the UI extension.
-   */
   sandbox: SandboxConfigNodeData[];
-  /**
-   * When false, the entire Apps extension section (banner, rows, and
-   * footer "apps" count) is hidden — host-side Apps caps are inert
-   * unless the client advertises `io.modelcontextprotocol/ui`.
-   */
   appsExtensionAdvertised: boolean;
   hostContext: ProtocolLeafNodeData | null;
   selectedNodeId: string | null;
   onSelectNode: (nodeId: string) => void;
 }
 
-export const ClientMatrixCard = memo(function ClientMatrixCard({
+export const HostMatrixCard = memo(function HostMatrixCard({
   hostName,
   agent,
   protocolBand,
@@ -64,236 +57,254 @@ export const ClientMatrixCard = memo(function ClientMatrixCard({
   const clientOn = clientCaps.filter((c) => c.on).length;
   const appsOn = appsCaps.filter((c) => c.on).length;
 
+  const timeoutLeaf = protocolBand.find((l) => l.leafKey === "timeout");
+  const clientInfoLeaf = protocolBand.find((l) => l.leafKey === "clientInfo");
+  const protocolVersionLeaf = protocolBand.find(
+    (l) => l.leafKey === "protocolVersion",
+  );
+  const extensionsLeaf = protocolBand.find((l) => l.leafKey === "capabilities");
+
   return (
-    <article className="host-matrix-card w-full overflow-hidden rounded-2xl border border-border/70 bg-card/95 shadow-sm">
-      <style>{MATRIX_STYLES}</style>
+    <article className="host-paper-card w-full">
+      <style>{PAPER_STYLES}</style>
 
-      {/* Identity strip — clickable opens General tab */}
-      <Region
-        id={HOST_GROUP_NODE_ID}
-        selectedNodeId={selectedNodeId}
-        onSelectNode={onSelectNode}
-        className="flex w-full items-center gap-3 border-b border-border/60 px-4 py-3"
-      >
-        <ProviderGlyph provider={agent?.modelProvider ?? null} />
-        <div className="flex min-w-0 flex-col">
-          <span
-            className="truncate text-[13.5px] font-semibold leading-tight"
-            title={hostName}
-          >
-            {hostName}
-          </span>
-          <span
-            className="truncate font-mono text-[10.5px] text-muted-foreground"
-            title={agent?.modelLabel ?? ""}
-          >
-            {agent?.modelLabel ?? "No model selected"}
-          </span>
-        </div>
-      </Region>
-
-      {/* Agent stats */}
-      <Region
-        id={AGENT_IDENTITY_NODE_ID}
-        selectedNodeId={selectedNodeId}
-        onSelectNode={onSelectNode}
-        className="grid w-full grid-cols-4 gap-px border-b border-border/60 bg-border/60"
-      >
-        <Stat
-          label="temp"
-          value={agent?.temperature.toFixed(2) ?? "—"}
-          changed={agent?.changedFields.includes("temperature")}
-        />
-        <Stat
-          label="style"
-          value={agent?.hostStyleLabel ?? "—"}
-          changed={agent?.changedFields.includes("hostStyle")}
-        />
-        <Stat
-          label="approve"
-          value={agent ? (agent.toolApproval ? "on" : "off") : "—"}
-          changed={agent?.changedFields.includes("toolApproval")}
-        />
-        <Stat
-          label="prompt"
-          value={agent ? (agent.systemPromptEmpty ? "∅" : "set") : "—"}
-          empty={agent?.systemPromptEmpty}
-          changed={agent?.changedFields.includes("systemPrompt")}
-        />
-      </Region>
-
-      {/* Protocol band */}
-      <Region
-        id={PROTOCOL_HUB_NODE_ID}
-        selectedNodeId={selectedNodeId}
-        onSelectNode={onSelectNode}
-        className="grid w-full gap-px border-b border-border/60 bg-border/60"
-        style={{
-          gridTemplateColumns: `repeat(${Math.max(protocolBand.length, 1)}, minmax(0, 1fr))`,
-        }}
-      >
-        {protocolBand.length === 0 ? (
-          <ProtocolCell label="protocol" value="SDK defaults" />
-        ) : (
-          protocolBand.map((leaf) => (
-            <ProtocolCell
-              key={leaf.leafKey}
-              label={leaf.label}
-              value={leaf.value}
-              changed={leaf.isChanged}
-            />
-          ))
-        )}
-      </Region>
-
-      {/* Client capabilities sub-matrix */}
-      <SectionBanner
-        label="Client capabilities"
-        meta={
-          <>
-            <b className="font-medium text-foreground/85">{clientOn}/5</b>
-            {"  ·  base protocol"}
-          </>
-        }
-        onClick={() => onSelectNode(PROTOCOL_HUB_NODE_ID)}
-      />
-      <MatrixHead cols={["", "capability", "sub-capabilities"]} merged />
-      {clientCaps.map((row) => (
-        <MatrixRow
-          key={row.key}
-          kind="mcp"
-          on={row.on}
-          changed={row.isChanged && !row.isNewlyOn}
-          newly={row.isNewlyOn}
-          selected={false}
-          onClick={() => onSelectNode(PROTOCOL_HUB_NODE_ID)}
+      {/* ===== Host outer frame ===== */}
+      <div className="hp-host">
+        {/* Identity strip — HOST_GROUP_NODE_ID */}
+        <ClickableRegion
+          id={HOST_GROUP_NODE_ID}
+          selectedNodeId={selectedNodeId}
+          onSelectNode={onSelectNode}
+          className="hp-identity"
         >
-          <span
-            className={cn(
-              "font-mono text-[11px]",
-              row.on
-                ? "text-foreground/95"
-                : "text-muted-foreground line-through decoration-muted-foreground/60",
-            )}
-          >
-            {row.key}
+          <span className="hp-glyph" aria-hidden>
+            {(agent?.modelProvider?.charAt(0) ?? "?").toUpperCase()}
+            <span className="hp-glyph-state" aria-hidden />
           </span>
-          <span className="flex justify-end gap-1 overflow-hidden whitespace-nowrap font-mono text-[10px] text-muted-foreground">
-            {row.subs.length === 0 ? (
-              <span className="text-muted-foreground/60">—</span>
-            ) : (
-              row.subs.map((s) => <SubTag key={s}>{s}</SubTag>)
-            )}
+          <span className="hp-identity-meta">
+            <span className="hp-host-name" title={hostName}>
+              {hostName}
+            </span>
+            <span className="hp-host-sub" title={agent?.modelLabel ?? ""}>
+              {agent?.modelLabel ?? "No model selected"}
+              {clientInfoLeaf ? (
+                <>
+                  <span className="hp-dot-sep" aria-hidden>
+                    ·
+                  </span>
+                  <span className="hp-mono">{clientInfoLeaf.value}</span>
+                </>
+              ) : null}
+            </span>
           </span>
-        </MatrixRow>
-      ))}
+        </ClickableRegion>
 
-      {/* Apps extension sub-matrix — hidden when the client doesn't
-          advertise `io.modelcontextprotocol/ui`. Host-side Apps caps
-          (openLinks / serverTools / message / etc.) are meaningless
-          for a client that can't render iframes (e.g. codex-mcp-client). */}
-      {appsExtensionAdvertised ? (
-        <>
-          <SectionBanner
-            label="Apps extension"
-            meta={
-              <>
-                <b className="font-medium text-foreground/85">{appsOn}/6</b>
-                {"  ·  io.modelcontextprotocol/ui"}
-              </>
-            }
-            onClick={() => onSelectNode(APPS_HUB_NODE_ID)}
+        {/* Agent stats — AGENT_IDENTITY_NODE_ID */}
+        <ClickableRegion
+          id={AGENT_IDENTITY_NODE_ID}
+          selectedNodeId={selectedNodeId}
+          onSelectNode={onSelectNode}
+          className="hp-agents"
+        >
+          <PaperStat
+            label="Temp"
+            value={agent?.temperature.toFixed(2) ?? "—"}
+            changed={agent?.changedFields.includes("temperature")}
+            mono
           />
-          <MatrixHead cols={["", "capability", "scope", "content"]} />
-          {appsCaps.map((row) => (
-            <MatrixRow
-              key={row.capKey}
-              kind="apps"
-              on={row.on}
-              changed={row.isChanged && !row.isNewlyOn}
-              newly={row.isNewlyOn}
-              selected={selectedNodeId === appsCapLeafNodeId(row.capKey)}
-              onClick={() => onSelectNode(appsCapLeafNodeId(row.capKey))}
-            >
-              <span
-                className={cn(
-                  "font-mono text-[11px]",
-                  row.on
-                    ? "text-foreground/95"
-                    : "text-muted-foreground line-through decoration-muted-foreground/60",
-                )}
-              >
-                {row.label}
-              </span>
-              <span className="text-right font-mono text-[10px] text-muted-foreground">
-                {row.on ? "view" : "—"}
-              </span>
-              <span className="text-right font-mono text-[10px] text-muted-foreground">
-                {row.on ? row.qualifier ?? "—" : "—"}
-              </span>
-            </MatrixRow>
-          ))}
-
-          {/* Sandbox sub-matrix — surfaces the CSP/permissions policy that
-              decides whether widget declarations are honored, narrowed, or
-              overridden. Gated on the same UI-extension flag because
-              sandbox is part of SEP-1865 and inert without it. */}
-          <SectionBanner
-            label="Sandbox"
-            meta={
-              <>
-                <b className="font-medium text-foreground/85">
-                  {sandbox.filter((r) => r.severity !== "neutral").length}
-                </b>
-                {"  ·  csp + permissions"}
-              </>
-            }
-            onClick={() => onSelectNode(SANDBOX_HUB_NODE_ID)}
+          <PaperStat
+            label="Style"
+            value={agent?.hostStyleLabel ?? "—"}
+            changed={agent?.changedFields.includes("hostStyle")}
           />
-          <MatrixHead cols={["", "config", "value", "detail"]} />
-          {sandbox.map((row) => (
-            <SandboxRow
-              key={row.subKey}
-              row={row}
-              selected={selectedNodeId === sandboxConfigLeafNodeId(row.subKey)}
-              onClick={() => onSelectNode(sandboxConfigLeafNodeId(row.subKey))}
+          <PaperStat
+            label="Approve"
+            value={agent ? (agent.toolApproval ? "on" : "off") : "—"}
+            changed={agent?.changedFields.includes("toolApproval")}
+            muted={agent ? !agent.toolApproval : false}
+          />
+          <PaperStat
+            label="Prompt"
+            value={agent ? (agent.systemPromptEmpty ? "∅ empty" : "set") : "—"}
+            changed={agent?.changedFields.includes("systemPrompt")}
+            muted={agent?.systemPromptEmpty}
+          />
+          {timeoutLeaf ? (
+            <PaperStat
+              label="Timeout"
+              value={timeoutLeaf.value}
+              changed={timeoutLeaf.isChanged}
+              mono
             />
-          ))}
-        </>
-      ) : null}
+          ) : (
+            <PaperStat label="Protocol" value={protocolVersionLeaf?.value ?? "—"} mono />
+          )}
+        </ClickableRegion>
 
-      {/* Footer */}
-      <div className="flex items-center justify-between border-t border-border/60 bg-foreground/[0.015] px-3.5 py-2 font-mono text-[10px] text-muted-foreground">
-        <span>
-          <b className="font-medium text-foreground/85">{clientOn}/5</b> client
-          {appsExtensionAdvertised ? (
-            <>
-              {" · "}
-              <b className="font-medium text-foreground/85">{appsOn}/6</b> apps
-            </>
-          ) : null}
-        </span>
-        {/* hostContext is part of SEP-1865 (the Apps extension); skip it
-            entirely when the client doesn't advertise the UI extension. */}
-        {appsExtensionAdvertised ? (
+        {/* Client capabilities — chip row at the Host layer */}
+        <div className="hp-section">
           <button
             type="button"
+            className="hp-section-head"
             onClick={(e) => {
               e.stopPropagation();
-              onSelectNode(protocolLeafNodeId("hostContext"));
+              onSelectNode(PROTOCOL_HUB_NODE_ID);
             }}
-            className={cn(
-              "rounded px-1.5 py-0.5 hover:bg-foreground/[0.04]",
-              hostContext?.isChanged && "text-[oklch(0.83_0.17_75)]",
-            )}
           >
-            hostContext ·{" "}
-            <b className="font-medium text-foreground/85">
-              {extractFieldCount(hostContext?.value)}
-            </b>{" "}
-            fields
+            <span className="hp-section-title">Client capabilities</span>
+            <span className="hp-section-count">
+              <b>{clientOn}</b> of 5 advertised
+              <span className="hp-section-meta"> · base protocol</span>
+            </span>
           </button>
+          <div className="hp-caps">
+            {clientCaps.map((row) => (
+              <button
+                key={row.key}
+                type="button"
+                className={cn(
+                  "hp-cap",
+                  !row.on && "hp-cap--off",
+                  row.isChanged && !row.isNewlyOn && "host-matrix-changed",
+                  row.isNewlyOn && "host-matrix-newly",
+                )}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSelectNode(PROTOCOL_HUB_NODE_ID);
+                }}
+              >
+                <span className="hp-cap-dot" aria-hidden />
+                <span className="hp-cap-name">{row.key}</span>
+                {row.subs.length > 0 ? (
+                  <span className="hp-cap-tag">{row.subs.join(" · ")}</span>
+                ) : null}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* ===== Sandbox nested frame ===== */}
+        {appsExtensionAdvertised ? (
+          <div className="hp-sandbox">
+            <button
+              type="button"
+              className="hp-frame-head"
+              onClick={(e) => {
+                e.stopPropagation();
+                onSelectNode(SANDBOX_HUB_NODE_ID);
+              }}
+            >
+              <span className="hp-sandbox-title">
+                Sandbox proxy iframe
+                <span className="hp-policy-tag">host policy</span>
+              </span>
+              <span className="hp-sandbox-sub">
+                Different origin · enforces CSP for nested Views
+              </span>
+            </button>
+
+            <div className="hp-sb-grid">
+              {sandbox.map((row) => (
+                <SandboxConfigCell
+                  key={row.subKey}
+                  row={row}
+                  selected={
+                    selectedNodeId === sandboxConfigLeafNodeId(row.subKey)
+                  }
+                  onClick={() =>
+                    onSelectNode(sandboxConfigLeafNodeId(row.subKey))
+                  }
+                />
+              ))}
+            </div>
+
+            {/* ===== View nested-nested frame ===== */}
+            <div className="hp-view">
+              <button
+                type="button"
+                className="hp-frame-head"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSelectNode(APPS_HUB_NODE_ID);
+                }}
+              >
+                <span className="hp-view-title">View iframe</span>
+                <span className="hp-view-sub">
+                  Apps extension · io.modelcontextprotocol/ui ·{" "}
+                  <b>{appsOn}</b> of 6 advertised
+                </span>
+              </button>
+              <div className="hp-view-caps">
+                {appsCaps.map((row) => {
+                  const isSelected =
+                    selectedNodeId === appsCapLeafNodeId(row.capKey);
+                  return (
+                    <button
+                      key={row.capKey}
+                      type="button"
+                      className={cn(
+                        "hp-view-cap",
+                        !row.on && "hp-view-cap--off",
+                        isSelected && "hp-view-cap--selected",
+                        row.isChanged && !row.isNewlyOn && "host-matrix-changed",
+                        row.isNewlyOn && "host-matrix-newly",
+                      )}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onSelectNode(appsCapLeafNodeId(row.capKey));
+                      }}
+                    >
+                      <span className="hp-view-cap-name">{row.label}</span>
+                      {row.on ? (
+                        <span className="hp-view-cap-tag">
+                          view
+                          {row.qualifier ? ` · ${row.qualifier}` : ""}
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
         ) : null}
+
+        {/* ===== Host footer ===== */}
+        <div className="hp-footer">
+          <span className="hp-footer-ext">
+            Extensions ·{" "}
+            <span className="hp-mono">
+              {extensionsLeaf?.value ?? "io.modelcontextprotocol/ui"}
+            </span>
+          </span>
+          {appsExtensionAdvertised ? (
+            <button
+              type="button"
+              className={cn(
+                "hp-ctx-btn",
+                hostContext?.isChanged && "host-matrix-changed",
+              )}
+              onClick={(e) => {
+                e.stopPropagation();
+                onSelectNode(protocolLeafNodeId("hostContext"));
+              }}
+            >
+              hostContext · <b>{extractFieldCount(hostContext?.value)}</b>{" "}
+              fields
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden
+              >
+                <path d="M9 18l6-6-6-6" />
+              </svg>
+            </button>
+          ) : null}
+        </div>
       </div>
     </article>
   );
@@ -301,41 +312,7 @@ export const ClientMatrixCard = memo(function ClientMatrixCard({
 
 /* ---------------- subcomponents ---------------- */
 
-function ProviderGlyph({ provider }: { provider: string | null }) {
-  const letter = provider ? provider.charAt(0).toUpperCase() : "?";
-  return (
-    <span
-      aria-hidden
-      className="inline-flex size-7 items-center justify-center rounded-md bg-foreground/90 text-[11px] font-semibold uppercase text-background"
-    >
-      {letter}
-    </span>
-  );
-}
-
-function Status({ on }: { on: boolean }) {
-  return (
-    <span
-      aria-hidden
-      className={cn(
-        "size-2 rounded-full",
-        on ? "bg-emerald-400" : "bg-muted-foreground/35",
-      )}
-      style={
-        on
-          ? { boxShadow: "0 0 6px color-mix(in oklch, currentColor 55%, transparent)" }
-          : undefined
-      }
-    />
-  );
-}
-
-/**
- * A clickable region that participates in the canvas's selection
- * model. Stops propagation so the outer ReactFlow node's onClick
- * doesn't also fire — sub-region selection wins over whole-node.
- */
-function Region({
+function ClickableRegion({
   id,
   selectedNodeId,
   onSelectNode,
@@ -359,9 +336,8 @@ function Region({
       }}
       style={style}
       className={cn(
-        "text-left hover:bg-foreground/[0.025]",
-        selectedNodeId === id && "bg-foreground/[0.04]",
         className,
+        selectedNodeId === id && "hp-region--selected",
       )}
     >
       {children}
@@ -369,187 +345,42 @@ function Region({
   );
 }
 
-function Stat({
+function PaperStat({
   label,
   value,
-  empty,
+  mono,
+  muted,
   changed,
 }: {
   label: string;
   value: string;
-  empty?: boolean;
+  mono?: boolean;
+  muted?: boolean;
   changed?: boolean;
 }) {
   return (
-    <div
-      className={cn(
-        "flex flex-col gap-0.5 bg-card/95 px-3 py-2",
-        changed && "host-matrix-changed",
-      )}
-    >
-      <span className="font-mono text-[8.5px] uppercase tracking-[0.16em] text-muted-foreground/85">
-        {label}
-      </span>
+    <div className={cn("hp-stat", changed && "host-matrix-changed")}>
+      <span className="hp-stat-label">{label}</span>
       <span
         className={cn(
-          "truncate font-mono text-[11px]",
-          empty ? "text-amber-500" : "text-foreground/95",
-          changed && "text-[oklch(0.83_0.17_75)]",
+          "hp-stat-value",
+          mono && "hp-mono",
+          muted && "hp-stat-value--muted",
         )}
         title={value}
       >
         {value}
       </span>
     </div>
-  );
-}
-
-function ProtocolCell({
-  label,
-  value,
-  changed,
-}: {
-  label: string;
-  value: string;
-  changed?: boolean;
-}) {
-  return (
-    <div
-      className={cn(
-        "relative flex flex-col gap-0.5 bg-card/95 px-3 py-2",
-        changed && "host-matrix-changed",
-      )}
-    >
-      <span className="font-mono text-[8.5px] uppercase tracking-[0.16em] text-muted-foreground/85">
-        {label}
-      </span>
-      <span
-        className={cn(
-          "truncate font-mono text-[11px]",
-          changed ? "text-[oklch(0.83_0.17_75)]" : "text-foreground/95",
-        )}
-        title={value}
-      >
-        {value}
-      </span>
-    </div>
-  );
-}
-
-function SectionBanner({
-  label,
-  meta,
-  onClick,
-}: {
-  label: string;
-  meta: ReactNode;
-  onClick?: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={(e) => {
-        e.stopPropagation();
-        onClick?.();
-      }}
-      className="flex w-full items-baseline justify-between border-t border-border/60 px-3.5 pb-1.5 pt-3 text-left first:border-t-0 hover:bg-foreground/[0.025]"
-    >
-      <span className="font-mono text-[9.5px] font-semibold uppercase tracking-[0.22em] text-foreground/85">
-        {label}
-      </span>
-      <span className="font-mono text-[9.5px] text-muted-foreground">
-        {meta}
-      </span>
-    </button>
-  );
-}
-
-function MatrixHead({
-  cols,
-  merged,
-}: {
-  cols: string[];
-  merged?: boolean;
-}) {
-  return (
-    <div
-      className="grid items-center gap-x-2.5 border-b border-dashed border-border/60 px-3.5 py-1.5"
-      style={{
-        gridTemplateColumns: merged
-          ? "16px minmax(0, 1fr) auto"
-          : "16px minmax(0, 1fr) 56px 70px",
-      }}
-    >
-      {cols.map((c, i) => (
-        <span
-          key={i}
-          className={cn(
-            "font-mono text-[8.5px] uppercase tracking-[0.18em] text-muted-foreground/80",
-            i >= 2 && "text-right",
-          )}
-        >
-          {c}
-        </span>
-      ))}
-    </div>
-  );
-}
-
-function MatrixRow({
-  kind,
-  on,
-  changed,
-  newly,
-  selected,
-  onClick,
-  children,
-}: {
-  kind: "mcp" | "apps";
-  on: boolean;
-  /** Background flash when the row's on/off or sub-tags differ from prev host. */
-  changed?: boolean;
-  /** Stronger highlight: row flipped from off → on on the last host switch. */
-  newly?: boolean;
-  selected: boolean;
-  onClick: () => void;
-  children: ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={(e) => {
-        e.stopPropagation();
-        onClick();
-      }}
-      className={cn(
-        "relative grid w-full items-center gap-x-2.5 border-b border-dashed border-border/40 px-3.5 py-1.5 text-left last:border-b-0 hover:bg-foreground/[0.025]",
-        !on && "opacity-65",
-        selected && "bg-foreground/[0.04]",
-        changed && !newly && "host-matrix-changed",
-        newly && "host-matrix-newly",
-      )}
-      style={{
-        gridTemplateColumns:
-          kind === "mcp"
-            ? "16px minmax(0, 1fr) auto"
-            : "16px minmax(0, 1fr) 56px 70px",
-      }}
-    >
-      <span className="flex w-4 items-center justify-center">
-        <Status on={on} />
-      </span>
-      {children}
-    </button>
   );
 }
 
 /**
- * Sandbox config row. Uses a separate component (not MatrixRow) because
- * the severity tint replaces the on/off opacity dimming — sandbox rows
- * are *always* relevant; the variable is "does this row indicate a
- * silent narrowing of widget behavior?", not "is this capability on?".
+ * One sandbox config row. Severity drives a left-edge dot color but the
+ * row sits inside the amber Sandbox frame, so danger/warn render as
+ * subtler in-frame tints than they did on the old dark card.
  */
-function SandboxRow({
+function SandboxConfigCell({
   row,
   selected,
   onClick,
@@ -558,6 +389,8 @@ function SandboxRow({
   selected: boolean;
   onClick: () => void;
 }) {
+  const displayValue =
+    row.summary && row.summary !== "—" ? row.summary : semanticAbsence(row.subKey);
   return (
     <button
       type="button"
@@ -566,71 +399,48 @@ function SandboxRow({
         onClick();
       }}
       className={cn(
-        "relative grid w-full items-center gap-x-2.5 border-b border-dashed border-border/40 px-3.5 py-1.5 text-left last:border-b-0 hover:bg-foreground/[0.025]",
-        selected && "bg-foreground/[0.04]",
-        row.severity === "danger" && "host-matrix-sandbox-danger",
-        row.severity === "warn" && "host-matrix-sandbox-warn",
+        "hp-sb-row",
+        selected && "hp-sb-row--selected",
+        row.severity === "danger" && "hp-sb-row--danger",
+        row.severity === "warn" && "hp-sb-row--warn",
         row.isChanged && "host-matrix-changed",
       )}
-      style={{ gridTemplateColumns: "16px minmax(0, 1fr) 56px 90px" }}
     >
-      <span className="flex w-4 items-center justify-center">
-        <SandboxSeverityDot severity={row.severity} />
-      </span>
-      <span className="font-mono text-[11px] text-foreground/95">
-        {row.label}
-      </span>
+      <span className="hp-sb-key">{row.label}</span>
       <span
         className={cn(
-          "text-right font-mono text-[10px]",
-          row.severity === "danger" && "text-[oklch(0.65_0.21_25)]",
-          row.severity === "warn" && "text-[oklch(0.78_0.16_75)]",
-          row.severity === "neutral" && "text-muted-foreground",
+          "hp-sb-value",
+          row.summary === "—" && "hp-sb-value--italic",
         )}
         title={row.summary}
       >
-        {row.summary}
+        {displayValue}
       </span>
-      <span
-        className="truncate text-right font-mono text-[10px] text-muted-foreground"
-        title={row.qualifier ?? ""}
-      >
-        {row.qualifier ?? "—"}
-      </span>
+      {row.qualifier ? (
+        <span className="hp-sb-qual" title={row.qualifier}>
+          {row.qualifier}
+        </span>
+      ) : null}
     </button>
   );
 }
 
-function SandboxSeverityDot({
-  severity,
-}: {
-  severity: "neutral" | "warn" | "danger";
-}) {
-  const color =
-    severity === "danger"
-      ? "bg-[oklch(0.65_0.21_25)]"
-      : severity === "warn"
-        ? "bg-[oklch(0.78_0.16_75)]"
-        : "bg-muted-foreground/35";
-  return (
-    <span
-      aria-hidden
-      className={cn("size-2 rounded-full", color)}
-      style={
-        severity !== "neutral"
-          ? { boxShadow: "0 0 6px color-mix(in oklch, currentColor 55%, transparent)" }
-          : undefined
-      }
-    />
-  );
-}
-
-function SubTag({ children }: { children: ReactNode }) {
-  return (
-    <span className="rounded-[3px] border border-border/60 bg-foreground/[0.03] px-1.5 py-px font-mono text-[9.5px] text-muted-foreground">
-      {children}
-    </span>
-  );
+/**
+ * Map an absent sandbox slice ("—" summary) to a semantic word, so the
+ * reader sees "any" / "none" / "default" instead of an em-dash that
+ * could be confused with "unknown".
+ */
+function semanticAbsence(key: SandboxConfigNodeData["subKey"]): string {
+  switch (key) {
+    case "restrictTo":
+      return "any origin";
+    case "deny":
+      return "none";
+    case "permissions":
+      return "default";
+    case "mode":
+      return "default";
+  }
 }
 
 function extractFieldCount(value: string | undefined): number {
@@ -640,32 +450,521 @@ function extractFieldCount(value: string | undefined): number {
 }
 
 /* ---------------- inline styles ---------------- */
-const MATRIX_STYLES = `
-@keyframes hostMatrixDiffFlash {
+/**
+ * Paper palette declared via scoped CSS custom properties. The light/paper
+ * values are the default; `.dark .host-paper-card` overrides them with a
+ * dark-tinted equivalent that keeps the per-frame hue cues (amber sandbox,
+ * lavender view) so the architecture metaphor survives the theme flip.
+ */
+const PAPER_STYLES = `
+.host-paper-card {
+  /* Light / paper palette (default) */
+  --hp-page: oklch(0.985 0.005 80);
+  --hp-ink: oklch(0.22 0.01 250);
+  --hp-muted: oklch(0.50 0.01 250);
+  --hp-muted-dim: oklch(0.64 0.008 250);
+  --hp-hairline: oklch(0.82 0.005 250 / 0.55);
+  --hp-paper-surface: white;
+  --hp-region-hover: oklch(1 0 0 / 0.4);
+  --hp-region-selected: oklch(1 0 0 / 0.6);
+  --hp-ctx-hover: oklch(1 0 0 / 0.5);
+
+  --hp-host-bg: oklch(0.965 0.005 80);
+  --hp-host-ring: oklch(0.86 0.008 80);
+
+  --hp-sandbox-bg: oklch(0.965 0.03 75);
+  --hp-sandbox-ring: oklch(0.87 0.06 70);
+  --hp-sandbox-ink: oklch(0.40 0.10 60);
+  --hp-sandbox-sub: oklch(0.55 0.10 65);
+  --hp-sandbox-hairline: oklch(0.87 0.04 70 / 0.4);
+  --hp-sandbox-row-hover: oklch(1 0 0 / 0.35);
+  --hp-sandbox-row-selected: oklch(1 0 0 / 0.55);
+
+  --hp-view-bg: oklch(0.96 0.025 285);
+  --hp-view-ring: oklch(0.86 0.07 285);
+  --hp-view-ink: oklch(0.34 0.16 285);
+  --hp-view-sub: oklch(0.50 0.12 285);
+  --hp-view-cap-selected-bg: oklch(0.90 0.06 285);
+
+  --hp-emerald: oklch(0.62 0.15 145);
+  --hp-amber: oklch(0.72 0.16 70);
+  --hp-danger: oklch(0.65 0.21 25);
+
+  font-family: ui-sans-serif, system-ui, -apple-system, "Inter", sans-serif;
+  color: var(--hp-ink);
+  font-size: 14px;
+  line-height: 1.5;
+  text-align: left;
+}
+
+/* Dark theme: keep hue cues, swap lightness. Each frame is now a dim
+   tinted wash rather than a saturated paper fill. */
+.dark .host-paper-card {
+  --hp-ink: oklch(0.95 0.005 250);
+  --hp-muted: oklch(0.65 0.01 250);
+  --hp-muted-dim: oklch(0.50 0.008 250);
+  --hp-hairline: oklch(0.40 0.01 250 / 0.5);
+  --hp-paper-surface: oklch(0.27 0.008 250);
+  --hp-region-hover: oklch(1 0 0 / 0.04);
+  --hp-region-selected: oklch(1 0 0 / 0.07);
+  --hp-ctx-hover: oklch(1 0 0 / 0.05);
+
+  --hp-host-bg: oklch(0.215 0.006 250);
+  --hp-host-ring: oklch(0.32 0.008 250);
+
+  --hp-sandbox-bg: oklch(0.255 0.035 70);
+  --hp-sandbox-ring: oklch(0.38 0.06 70);
+  --hp-sandbox-ink: oklch(0.86 0.10 70);
+  --hp-sandbox-sub: oklch(0.72 0.08 65);
+  --hp-sandbox-hairline: oklch(0.40 0.04 70 / 0.5);
+  --hp-sandbox-row-hover: oklch(1 0 0 / 0.04);
+  --hp-sandbox-row-selected: oklch(1 0 0 / 0.07);
+
+  --hp-view-bg: oklch(0.245 0.045 285);
+  --hp-view-ring: oklch(0.40 0.08 285);
+  --hp-view-ink: oklch(0.87 0.10 285);
+  --hp-view-sub: oklch(0.72 0.10 285);
+  --hp-view-cap-selected-bg: oklch(0.36 0.10 285);
+}
+.host-paper-card .hp-mono {
+  font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
+  font-size: 0.92em;
+}
+
+/* === Host outer frame === */
+.host-paper-card .hp-host {
+  background: var(--hp-host-bg);
+  border: 1px solid var(--hp-host-ring);
+  border-radius: 18px;
+  padding: 26px 26px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+/* === Identity strip === */
+.host-paper-card .hp-identity {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  border-radius: 10px;
+}
+.host-paper-card .hp-identity:hover { background: var(--hp-region-hover); }
+.host-paper-card .hp-glyph {
+  position: relative;
+  width: 44px; height: 44px;
+  background: var(--hp-paper-surface);
+  border: 1px solid var(--hp-host-ring);
+  border-radius: 11px;
+  display: grid; place-items: center;
+  font-weight: 600;
+  font-size: 18px;
+  color: var(--hp-ink);
+  letter-spacing: -0.02em;
+  flex: none;
+}
+.host-paper-card .hp-glyph-state {
+  position: absolute;
+  top: -3px; right: -3px;
+  width: 10px; height: 10px;
+  border-radius: 999px;
+  background: var(--hp-emerald);
+  border: 2px solid var(--hp-host-bg);
+}
+.host-paper-card .hp-identity-meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  line-height: 1.3;
+}
+.host-paper-card .hp-host-name {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--hp-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.host-paper-card .hp-host-sub {
+  font-size: 12.5px;
+  color: var(--hp-muted);
+  margin-top: 1px;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.host-paper-card .hp-dot-sep { color: var(--hp-muted-dim); }
+
+/* === Agent stats === */
+.host-paper-card .hp-agents {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  padding: 0 0 22px 0;
+  border: 0;
+  border-bottom: 1px dashed var(--hp-hairline);
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+}
+.host-paper-card .hp-agents:hover { background: var(--hp-region-hover); }
+.host-paper-card .hp-stat {
+  padding: 0 16px;
+  border-right: 1px dashed var(--hp-hairline);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.host-paper-card .hp-stat:first-child { padding-left: 0; }
+.host-paper-card .hp-stat:last-child { border-right: 0; padding-right: 0; }
+.host-paper-card .hp-stat-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--hp-muted-dim);
+  font-weight: 500;
+}
+.host-paper-card .hp-stat-value {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--hp-ink);
+  letter-spacing: -0.005em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.host-paper-card .hp-stat-value--muted { color: var(--hp-muted); }
+
+/* === Section (Client capabilities) === */
+.host-paper-card .hp-section { display: flex; flex-direction: column; gap: 12px; }
+.host-paper-card .hp-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  color: inherit;
+}
+.host-paper-card .hp-section-title {
+  font-size: 14.5px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--hp-ink);
+}
+.host-paper-card .hp-section-count {
+  font-size: 12.5px;
+  color: var(--hp-muted);
+  font-variant-numeric: tabular-nums;
+}
+.host-paper-card .hp-section-count b { color: var(--hp-ink); font-weight: 600; }
+.host-paper-card .hp-section-meta { color: var(--hp-muted-dim); }
+
+/* === Capability chip row === */
+.host-paper-card .hp-caps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.host-paper-card .hp-cap {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 11px 6px;
+  border-radius: 999px;
+  font-size: 12.5px;
+  font-weight: 500;
+  background: var(--hp-paper-surface);
+  border: 1px solid var(--hp-host-ring);
+  color: var(--hp-ink);
+  cursor: pointer;
+  transition: transform 120ms ease, background 120ms ease;
+}
+.host-paper-card .hp-cap:hover { transform: translateY(-1px); }
+.host-paper-card .hp-cap--off {
+  color: var(--hp-muted-dim);
+  background: transparent;
+  border-style: dashed;
+  font-weight: 400;
+  text-decoration: line-through;
+  text-decoration-color: oklch(0.64 0.008 250 / 0.5);
+  text-decoration-thickness: 0.5px;
+}
+.host-paper-card .hp-cap-dot {
+  width: 6px; height: 6px;
+  border-radius: 999px;
+  background: var(--hp-emerald);
+  flex: none;
+}
+.host-paper-card .hp-cap--off .hp-cap-dot {
+  background: transparent;
+  border: 1px solid var(--hp-muted-dim);
+}
+.host-paper-card .hp-cap-name {
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 12px;
+}
+.host-paper-card .hp-cap-tag {
+  font-size: 10.5px;
+  color: var(--hp-muted);
+  padding-left: 6px;
+  margin-left: 1px;
+  border-left: 1px solid var(--hp-hairline);
+  font-weight: 400;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+}
+
+/* === Sandbox nested frame === */
+.host-paper-card .hp-sandbox {
+  background: var(--hp-sandbox-bg);
+  border: 1px solid var(--hp-sandbox-ring);
+  border-radius: 14px;
+  padding: 20px 20px 22px;
+  color: var(--hp-sandbox-ink);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.host-paper-card .hp-frame-head {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  color: inherit;
+}
+.host-paper-card .hp-sandbox-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--hp-sandbox-ink);
+  letter-spacing: -0.01em;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+/* Small tag next to the Sandbox title that signals the rows below
+   (mode / restrictTo / deny / permissions) are MCPJam's policy
+   abstractions, not raw spec terms. Quiet enough to skim past once
+   you know what it means, loud enough to keep readers honest. */
+.host-paper-card .hp-policy-tag {
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 2px 6px 3px;
+  border-radius: 4px;
+  border: 1px solid var(--hp-sandbox-ring);
+  color: var(--hp-sandbox-sub);
+  background: var(--hp-paper-surface);
+}
+.host-paper-card .hp-sandbox-sub {
+  font-size: 12.5px;
+  color: var(--hp-sandbox-sub);
+}
+
+.host-paper-card .hp-sb-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px 18px;
+}
+.host-paper-card .hp-sb-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 8px;
+  align-items: baseline;
+  padding: 5px 8px;
+  border-radius: 8px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  font-size: 12.5px;
+  color: var(--hp-sandbox-ink);
+  border-bottom: 1px dashed var(--hp-sandbox-hairline);
+  transition: background 120ms ease;
+}
+.host-paper-card .hp-sb-row:hover { background: var(--hp-sandbox-row-hover); }
+.host-paper-card .hp-sb-row--selected { background: var(--hp-sandbox-row-selected); }
+.host-paper-card .hp-sb-row--warn {
+  background: oklch(0.78 0.16 75 / 0.10);
+}
+.host-paper-card .hp-sb-row--warn:hover { background: oklch(0.78 0.16 75 / 0.16); }
+.host-paper-card .hp-sb-row--danger {
+  background: oklch(0.65 0.21 25 / 0.10);
+}
+.host-paper-card .hp-sb-row--danger:hover { background: oklch(0.65 0.21 25 / 0.16); }
+.host-paper-card .hp-sb-key {
+  color: var(--hp-sandbox-sub);
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 11.5px;
+}
+.host-paper-card .hp-sb-value {
+  text-align: right;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 11.5px;
+  color: var(--hp-sandbox-ink);
+  font-weight: 500;
+}
+.host-paper-card .hp-sb-value--italic {
+  font-style: italic;
+  font-weight: 400;
+  color: var(--hp-sandbox-sub);
+  font-family: inherit;
+  font-size: 12.5px;
+}
+.host-paper-card .hp-sb-qual {
+  text-align: right;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 10.5px;
+  color: var(--hp-sandbox-sub);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 120px;
+}
+
+/* === View nested-nested frame === */
+.host-paper-card .hp-view {
+  background: var(--hp-view-bg);
+  border: 1px solid var(--hp-view-ring);
+  border-radius: 12px;
+  padding: 16px 18px 18px;
+  color: var(--hp-view-ink);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.host-paper-card .hp-view-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--hp-view-ink);
+  letter-spacing: -0.01em;
+}
+.host-paper-card .hp-view-sub {
+  font-size: 12px;
+  color: var(--hp-view-sub);
+}
+.host-paper-card .hp-view-sub b { color: var(--hp-view-ink); font-weight: 600; }
+.host-paper-card .hp-view-caps {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+.host-paper-card .hp-view-cap {
+  display: inline-flex;
+  align-items: baseline;
+  background: var(--hp-paper-surface);
+  border: 1px solid var(--hp-view-ring);
+  color: var(--hp-view-ink);
+  border-radius: 999px;
+  padding: 4px 11px 5px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform 120ms ease;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+}
+.host-paper-card .hp-view-cap:hover { transform: translateY(-1px); }
+.host-paper-card .hp-view-cap--off {
+  background: transparent;
+  color: var(--hp-view-sub);
+  border-style: dashed;
+  font-weight: 400;
+  text-decoration: line-through;
+  text-decoration-color: oklch(0.50 0.12 285 / 0.55);
+  text-decoration-thickness: 0.5px;
+}
+.host-paper-card .hp-view-cap--selected {
+  background: var(--hp-view-cap-selected-bg);
+  border-color: var(--hp-view-ink);
+}
+.host-paper-card .hp-view-cap-name {
+  font-weight: 500;
+}
+.host-paper-card .hp-view-cap-tag {
+  font-size: 10px;
+  color: var(--hp-view-sub);
+  margin-left: 6px;
+  padding-left: 6px;
+  border-left: 1px solid var(--hp-view-ring);
+  font-weight: 400;
+  font-family: inherit;
+}
+
+/* === Host footer === */
+.host-paper-card .hp-footer {
+  margin-top: 4px;
+  padding-top: 16px;
+  border-top: 1px dashed var(--hp-hairline);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--hp-muted);
+  font-size: 12px;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.host-paper-card .hp-footer-ext {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+}
+.host-paper-card .hp-footer-ext .hp-mono {
+  color: var(--hp-ink);
+  font-size: 11.5px;
+}
+.host-paper-card .hp-ctx-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: 0;
+  padding: 4px 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--hp-muted);
+  font: inherit;
+  font-weight: 500;
+  font-size: 12px;
+}
+.host-paper-card .hp-ctx-btn:hover {
+  color: var(--hp-ink);
+  background: var(--hp-ctx-hover);
+}
+.host-paper-card .hp-ctx-btn b { color: var(--hp-ink); font-weight: 600; }
+.host-paper-card .hp-ctx-btn svg { width: 11px; height: 11px; }
+
+/* === Region selection wash === */
+.host-paper-card .hp-region--selected {
+  background: var(--hp-region-selected) !important;
+}
+
+/* === Diff flash (preserved from prior card, retuned to paper) === */
+@keyframes hostMatrixDiffFlashPaper {
   0% { background-color: oklch(0.83 0.17 75 / 0.32); }
   100% { background-color: transparent; }
 }
-.host-matrix-changed {
-  animation: hostMatrixDiffFlash 1.8s ease-out;
+.host-paper-card .host-matrix-changed {
+  animation: hostMatrixDiffFlashPaper 1.8s ease-out;
 }
-.host-matrix-newly {
-  box-shadow: inset 2px 0 0 oklch(0.83 0.17 75);
-  animation: hostMatrixDiffFlash 1.8s ease-out;
-}
-/* Sandbox row severity tints. Distinct from host-matrix-changed (which
-   animates a one-shot flash on host switch) — these are persistent
-   background tints so users can spot a populated restrictTo / deny at a
-   glance even on cold load. */
-.host-matrix-sandbox-danger {
-  background-color: oklch(0.65 0.21 25 / 0.08);
-}
-.host-matrix-sandbox-danger:hover {
-  background-color: oklch(0.65 0.21 25 / 0.12);
-}
-.host-matrix-sandbox-warn {
-  background-color: oklch(0.78 0.16 75 / 0.07);
-}
-.host-matrix-sandbox-warn:hover {
-  background-color: oklch(0.78 0.16 75 / 0.11);
+.host-paper-card .host-matrix-newly {
+  box-shadow: inset 2px 0 0 oklch(0.78 0.16 70);
+  animation: hostMatrixDiffFlashPaper 1.8s ease-out;
 }
 `;

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/RedesignedClientCanvas.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/RedesignedClientCanvas.tsx
@@ -35,9 +35,46 @@ import {
   SNAPPY_CAMERA,
   SNAPPY_HOST_REVEAL,
 } from "../../transition-tokens";
-import { ClientMatrixCard } from "./ClientCapabilityMatrix";
+import { HostMatrixCard } from "./ClientCapabilityMatrix";
 
 const decorativeHandleClass = "!opacity-0 !w-2 !h-2";
+
+/**
+ * Canvas chrome palette. Declared as CSS custom properties on the canvas
+ * root so server hub / cards / pill / controls / dots all read the same
+ * tokens. Dark mode swaps lightness while keeping the mint hue for the
+ * MCP-server frame — same principle as the inner Host/Sandbox/View card.
+ */
+const CANVAS_STYLES = `
+.host-redesign-canvas {
+  --rd-canvas-bg: oklch(0.985 0.005 80);
+  --rd-canvas-ring: oklch(0.86 0.008 80);
+  --rd-dot: oklch(0.70 0.04 80 / 0.55);
+
+  --rd-server-bg: oklch(0.95 0.035 165);
+  --rd-server-ring: oklch(0.84 0.08 165);
+  --rd-server-ink: oklch(0.36 0.12 165);
+  --rd-server-sub: oklch(0.50 0.10 165);
+  --rd-server-surface: white;
+
+  --rd-controls-bg: white;
+  --rd-override: oklch(0.55 0.14 70);
+}
+.dark .host-redesign-canvas {
+  --rd-canvas-bg: oklch(0.18 0.005 250);
+  --rd-canvas-ring: oklch(0.32 0.008 250);
+  --rd-dot: oklch(0.55 0.02 250 / 0.40);
+
+  --rd-server-bg: oklch(0.245 0.04 165);
+  --rd-server-ring: oklch(0.40 0.08 165);
+  --rd-server-ink: oklch(0.86 0.10 165);
+  --rd-server-sub: oklch(0.70 0.08 165);
+  --rd-server-surface: oklch(0.27 0.008 250);
+
+  --rd-controls-bg: oklch(0.27 0.008 250);
+  --rd-override: oklch(0.80 0.12 70);
+}
+`;
 
 /* ============================================================
    Sub-region click dispatch. The matrix is a single ReactFlow
@@ -72,7 +109,7 @@ const HostMatrixNodeRenderer = memo(
         transition={SNAPPY_HOST_REVEAL}
         style={{ transformOrigin: "50% 0%" }}
       >
-        <ClientMatrixCard
+        <HostMatrixCard
           hostName={data.hostName}
           agent={data.agent}
           protocolBand={data.protocolBand}
@@ -111,17 +148,36 @@ const ServersHubNodeRenderer = memo(
         animate={{ opacity: 1, y: 0 }}
         transition={{ ...SNAPPY_HOST_REVEAL, delay: 0.32 }}
         className={cn(
-          "flex items-center gap-2 rounded-[10px] border border-border/70 bg-card/95 px-3 py-2 shadow-sm transition-all hover:shadow-md",
-          selected && "ring-2 ring-primary/40",
+          "flex items-center gap-2 rounded-[12px] border px-3 py-2 shadow-sm transition-all hover:shadow-md",
+          selected && "ring-2",
         )}
+        style={{
+          background: "var(--rd-server-bg)",
+          borderColor: "var(--rd-server-ring)",
+          color: "var(--rd-server-ink)",
+        }}
       >
-        <div className="flex size-7 items-center justify-center rounded-md bg-muted/60 text-muted-foreground">
+        <div
+          className="flex size-7 items-center justify-center rounded-md"
+          style={{
+            background: "var(--rd-server-surface)",
+            color: "var(--rd-server-sub)",
+          }}
+        >
           <Server className="size-3.5" />
         </div>
-        <div className="flex min-w-0 flex-col">
-          <span className="text-[13px] font-semibold">Servers</span>
-          <span className="text-[10.5px] text-muted-foreground">
-            {data.totalCount} attached
+        <div className="flex min-w-0 flex-col leading-tight">
+          <span
+            className="text-[13px] font-semibold"
+            style={{ color: "var(--rd-server-ink)" }}
+          >
+            MCP servers
+          </span>
+          <span
+            className="text-[10.5px]"
+            style={{ color: "var(--rd-server-sub)" }}
+          >
+            {data.totalCount} attached · provide UI + tools
           </span>
         </div>
         <Handle
@@ -196,9 +252,13 @@ const ServerCardNodeRenderer = memo(
         layout
         transition={SNAPPY_CAMERA}
         className={cn(
-          "h-full w-full overflow-hidden rounded-[8px] border border-border/70 bg-card/95 shadow-sm transition-shadow hover:shadow-md",
-          selected && "ring-2 ring-primary/40",
+          "h-full w-full overflow-hidden rounded-[10px] border shadow-sm transition-shadow hover:shadow-md",
+          selected && "ring-2",
         )}
+        style={{
+          background: "var(--rd-server-surface)",
+          borderColor: "var(--rd-server-ring)",
+        }}
       >
         <motion.div
           initial={{ opacity: 0 }}
@@ -219,21 +279,32 @@ const ServerCardNodeRenderer = memo(
             <span
               className="flex-1 truncate text-[12.5px] font-semibold"
               title={data.name}
+              style={{
+                color: "var(--rd-server-ink)",
+                letterSpacing: "-0.005em",
+              }}
             >
               {data.name}
             </span>
-            <span className="text-[10px] uppercase tracking-[0.04em] text-muted-foreground/80">
+            <span
+              className="text-[10px] uppercase tracking-[0.08em]"
+              style={{ color: "var(--rd-server-sub)" }}
+            >
               {data.isOptional ? "optional" : "required"}
             </span>
           </div>
           <span
-            className="truncate font-mono text-[10.5px] text-muted-foreground"
+            className="truncate font-mono text-[10.5px]"
             title={data.url ?? "Project server"}
+            style={{ color: "var(--rd-server-sub)" }}
           >
             {data.url ?? "Project server"}
           </span>
           {data.hasOverride ? (
-            <span className="mt-auto text-[10px] text-amber-700 dark:text-amber-300">
+            <span
+              className="mt-auto text-[10px]"
+              style={{ color: "var(--rd-override)" }}
+            >
               overrides set
             </span>
           ) : null}
@@ -253,7 +324,14 @@ ServerCardNodeRenderer.displayName = "ServerCardNodeRenderer";
 const AddServerPillRenderer = memo(
   (_props: NodeProps<Node<AddServerPillNodeData, "redesignAddServer">>) => {
     return (
-      <div className="flex size-9 items-center justify-center rounded-full border border-dashed border-border/70 bg-card/95 text-muted-foreground shadow-sm">
+      <div
+        className="flex size-9 items-center justify-center rounded-full border border-dashed shadow-sm transition-colors"
+        style={{
+          background: "var(--rd-server-surface)",
+          borderColor: "var(--rd-server-ring)",
+          color: "var(--rd-server-sub)",
+        }}
+      >
         <Plus className="size-4" />
       </div>
     );
@@ -347,7 +425,7 @@ const edgeTypes = {
   hostBranch: HostBranchEdge,
 };
 
-interface RedesignedClientCanvasProps {
+interface RedesignedHostCanvasProps {
   viewModel: HostRedesignViewModel;
   selectedNodeId: string | null;
   onSelectNode: (nodeId: string) => void;
@@ -383,7 +461,7 @@ export function RedesignedClientCanvas({
   shellStyle,
   readOnly = false,
   onRequestEdit,
-}: RedesignedClientCanvasProps) {
+}: RedesignedHostCanvasProps) {
   const filteredNodes = useMemo(
     () =>
       readOnly
@@ -448,11 +526,16 @@ export function RedesignedClientCanvas({
 
   return (
     <div
-      className="host-redesign-canvas relative h-full w-full overflow-hidden rounded-[28px] border border-border/70 bg-background"
-      style={shellStyle}
+      className="host-redesign-canvas relative h-full w-full overflow-hidden rounded-[28px] border"
+      style={{
+        background: "var(--rd-canvas-bg)",
+        borderColor: "var(--rd-canvas-ring)",
+        ...shellStyle,
+      }}
       data-edges-ready={edgesReady ? "true" : "false"}
       data-viewport-ready={viewportReady ? "true" : "false"}
     >
+      <style>{CANVAS_STYLES}</style>
       <HostMatrixContext.Provider value={matrixCtx}>
         {/* Inline opacity gate: keeps ReactFlow's pre-fitView paint (nodes
             at raw canvas coords, edges trailing off-screen) invisible until
@@ -511,12 +594,16 @@ export function RedesignedClientCanvas({
             variant={BackgroundVariant.Dots}
             gap={16}
             size={0.9}
-            color="oklch(0.55 0.02 250 / 0.22)"
+            color="var(--rd-dot)"
             patternClassName="opacity-[0.45]"
           />
           <Controls
             showInteractive={false}
-            className="!rounded-xl !border !border-border/70 !bg-card/95"
+            className="!rounded-xl !border"
+            style={{
+              background: "var(--rd-controls-bg)",
+              borderColor: "var(--rd-canvas-ring)",
+            }}
           />
         </ReactFlow>
         </div>

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/RedesignedClientCanvas.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/RedesignedClientCanvas.tsx
@@ -111,15 +111,17 @@ const ServersHubNodeRenderer = memo(
         animate={{ opacity: 1, y: 0 }}
         transition={{ ...SNAPPY_HOST_REVEAL, delay: 0.32 }}
         className={cn(
-          "flex items-center gap-2 rounded-[10px] border border-border/70 bg-card/95 px-3 py-2 shadow-sm transition-all hover:shadow-md",
-          selected && "ring-2 ring-primary/40",
+          "flex items-center gap-2 rounded-[10px] border border-diagram-server/40 bg-diagram-server/10 px-3 py-2 shadow-sm transition-all hover:shadow-md",
+          selected && "ring-2 ring-diagram-server/50",
         )}
       >
-        <div className="flex size-7 items-center justify-center rounded-md bg-muted/60 text-muted-foreground">
+        <div className="flex size-7 items-center justify-center rounded-md bg-diagram-server/20 text-diagram-server">
           <Server className="size-3.5" />
         </div>
         <div className="flex min-w-0 flex-col">
-          <span className="text-[13px] font-semibold">Servers</span>
+          <span className="text-[13px] font-semibold text-diagram-server">
+            Servers
+          </span>
           <span className="text-[10.5px] text-muted-foreground">
             {data.totalCount} attached
           </span>
@@ -339,7 +341,40 @@ function makeFixedEdge(cornerRadius: number) {
   };
 }
 
-const HostTrunkEdge = makeFixedEdge(TRUNK_CORNER);
+/**
+ * Trunk edge uses ReactFlow's measured source/target positions instead of
+ * the canvasBuilder's fixed coords, so the line tracks the matrix card's
+ * actual rendered bottom rather than the `matrixH` estimate (which the
+ * card content doesn't reliably hit, leaving a visible gap + the apparent
+ * offset that motivated this edge type).
+ *
+ * Why this is safe (unlike the branch edges): neither the matrix card nor
+ * the servers hub uses framer-motion `layout`/`layoutId`. They only run a
+ * one-time mount reveal that settles to an identity transform, so
+ * `getBoundingClientRect` — and therefore ReactFlow's measured handle
+ * positions — is correct in steady state. The branch edges still need
+ * fixed coords because the server cards' `layoutId` morph persistently
+ * pollutes their measured rects on every tab switch.
+ */
+function HostTrunkEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  style,
+  markerEnd,
+}: EdgeProps) {
+  const path = buildOrthogonalTreePath(
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    TRUNK_CORNER,
+  );
+  return <BaseEdge id={id} path={path} style={style} markerEnd={markerEnd} />;
+}
+
 const HostBranchEdge = makeFixedEdge(BRANCH_CORNER);
 
 const edgeTypes = {

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/RedesignedClientCanvas.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/RedesignedClientCanvas.tsx
@@ -39,43 +39,6 @@ import { HostMatrixCard } from "./ClientCapabilityMatrix";
 
 const decorativeHandleClass = "!opacity-0 !w-2 !h-2";
 
-/**
- * Canvas chrome palette. Declared as CSS custom properties on the canvas
- * root so server hub / cards / pill / controls / dots all read the same
- * tokens. Dark mode swaps lightness while keeping the mint hue for the
- * MCP-server frame — same principle as the inner Host/Sandbox/View card.
- */
-const CANVAS_STYLES = `
-.host-redesign-canvas {
-  --rd-canvas-bg: oklch(0.985 0.005 80);
-  --rd-canvas-ring: oklch(0.86 0.008 80);
-  --rd-dot: oklch(0.70 0.04 80 / 0.55);
-
-  --rd-server-bg: oklch(0.95 0.035 165);
-  --rd-server-ring: oklch(0.84 0.08 165);
-  --rd-server-ink: oklch(0.36 0.12 165);
-  --rd-server-sub: oklch(0.50 0.10 165);
-  --rd-server-surface: white;
-
-  --rd-controls-bg: white;
-  --rd-override: oklch(0.55 0.14 70);
-}
-.dark .host-redesign-canvas {
-  --rd-canvas-bg: oklch(0.18 0.005 250);
-  --rd-canvas-ring: oklch(0.32 0.008 250);
-  --rd-dot: oklch(0.55 0.02 250 / 0.40);
-
-  --rd-server-bg: oklch(0.245 0.04 165);
-  --rd-server-ring: oklch(0.40 0.08 165);
-  --rd-server-ink: oklch(0.86 0.10 165);
-  --rd-server-sub: oklch(0.70 0.08 165);
-  --rd-server-surface: oklch(0.27 0.008 250);
-
-  --rd-controls-bg: oklch(0.27 0.008 250);
-  --rd-override: oklch(0.80 0.12 70);
-}
-`;
-
 /* ============================================================
    Sub-region click dispatch. The matrix is a single ReactFlow
    node, but its inner buttons (Agent stats, Protocol band, Apps
@@ -148,36 +111,17 @@ const ServersHubNodeRenderer = memo(
         animate={{ opacity: 1, y: 0 }}
         transition={{ ...SNAPPY_HOST_REVEAL, delay: 0.32 }}
         className={cn(
-          "flex items-center gap-2 rounded-[12px] border px-3 py-2 shadow-sm transition-all hover:shadow-md",
-          selected && "ring-2",
+          "flex items-center gap-2 rounded-[10px] border border-border/70 bg-card/95 px-3 py-2 shadow-sm transition-all hover:shadow-md",
+          selected && "ring-2 ring-primary/40",
         )}
-        style={{
-          background: "var(--rd-server-bg)",
-          borderColor: "var(--rd-server-ring)",
-          color: "var(--rd-server-ink)",
-        }}
       >
-        <div
-          className="flex size-7 items-center justify-center rounded-md"
-          style={{
-            background: "var(--rd-server-surface)",
-            color: "var(--rd-server-sub)",
-          }}
-        >
+        <div className="flex size-7 items-center justify-center rounded-md bg-muted/60 text-muted-foreground">
           <Server className="size-3.5" />
         </div>
-        <div className="flex min-w-0 flex-col leading-tight">
-          <span
-            className="text-[13px] font-semibold"
-            style={{ color: "var(--rd-server-ink)" }}
-          >
-            MCP servers
-          </span>
-          <span
-            className="text-[10.5px]"
-            style={{ color: "var(--rd-server-sub)" }}
-          >
-            {data.totalCount} attached · provide UI + tools
+        <div className="flex min-w-0 flex-col">
+          <span className="text-[13px] font-semibold">Servers</span>
+          <span className="text-[10.5px] text-muted-foreground">
+            {data.totalCount} attached
           </span>
         </div>
         <Handle
@@ -252,13 +196,9 @@ const ServerCardNodeRenderer = memo(
         layout
         transition={SNAPPY_CAMERA}
         className={cn(
-          "h-full w-full overflow-hidden rounded-[10px] border shadow-sm transition-shadow hover:shadow-md",
-          selected && "ring-2",
+          "h-full w-full overflow-hidden rounded-[8px] border border-border/70 bg-card/95 shadow-sm transition-shadow hover:shadow-md",
+          selected && "ring-2 ring-primary/40",
         )}
-        style={{
-          background: "var(--rd-server-surface)",
-          borderColor: "var(--rd-server-ring)",
-        }}
       >
         <motion.div
           initial={{ opacity: 0 }}
@@ -279,32 +219,21 @@ const ServerCardNodeRenderer = memo(
             <span
               className="flex-1 truncate text-[12.5px] font-semibold"
               title={data.name}
-              style={{
-                color: "var(--rd-server-ink)",
-                letterSpacing: "-0.005em",
-              }}
             >
               {data.name}
             </span>
-            <span
-              className="text-[10px] uppercase tracking-[0.08em]"
-              style={{ color: "var(--rd-server-sub)" }}
-            >
+            <span className="text-[10px] uppercase tracking-[0.04em] text-muted-foreground/80">
               {data.isOptional ? "optional" : "required"}
             </span>
           </div>
           <span
-            className="truncate font-mono text-[10.5px]"
+            className="truncate font-mono text-[10.5px] text-muted-foreground"
             title={data.url ?? "Project server"}
-            style={{ color: "var(--rd-server-sub)" }}
           >
             {data.url ?? "Project server"}
           </span>
           {data.hasOverride ? (
-            <span
-              className="mt-auto text-[10px]"
-              style={{ color: "var(--rd-override)" }}
-            >
+            <span className="mt-auto text-[10px] text-amber-700 dark:text-amber-300">
               overrides set
             </span>
           ) : null}
@@ -324,14 +253,7 @@ ServerCardNodeRenderer.displayName = "ServerCardNodeRenderer";
 const AddServerPillRenderer = memo(
   (_props: NodeProps<Node<AddServerPillNodeData, "redesignAddServer">>) => {
     return (
-      <div
-        className="flex size-9 items-center justify-center rounded-full border border-dashed shadow-sm transition-colors"
-        style={{
-          background: "var(--rd-server-surface)",
-          borderColor: "var(--rd-server-ring)",
-          color: "var(--rd-server-sub)",
-        }}
-      >
+      <div className="flex size-9 items-center justify-center rounded-full border border-dashed border-border/70 bg-card/95 text-muted-foreground shadow-sm">
         <Plus className="size-4" />
       </div>
     );
@@ -526,16 +448,11 @@ export function RedesignedClientCanvas({
 
   return (
     <div
-      className="host-redesign-canvas relative h-full w-full overflow-hidden rounded-[28px] border"
-      style={{
-        background: "var(--rd-canvas-bg)",
-        borderColor: "var(--rd-canvas-ring)",
-        ...shellStyle,
-      }}
+      className="host-redesign-canvas relative h-full w-full overflow-hidden rounded-[28px] border border-border/70 bg-background"
+      style={shellStyle}
       data-edges-ready={edgesReady ? "true" : "false"}
       data-viewport-ready={viewportReady ? "true" : "false"}
     >
-      <style>{CANVAS_STYLES}</style>
       <HostMatrixContext.Provider value={matrixCtx}>
         {/* Inline opacity gate: keeps ReactFlow's pre-fitView paint (nodes
             at raw canvas coords, edges trailing off-screen) invisible until
@@ -594,16 +511,12 @@ export function RedesignedClientCanvas({
             variant={BackgroundVariant.Dots}
             gap={16}
             size={0.9}
-            color="var(--rd-dot)"
+            color="oklch(0.55 0.02 250 / 0.22)"
             patternClassName="opacity-[0.45]"
           />
           <Controls
             showInteractive={false}
-            className="!rounded-xl !border"
-            style={{
-              background: "var(--rd-controls-bg)",
-              borderColor: "var(--rd-canvas-ring)",
-            }}
+            className="!rounded-xl !border !border-border/70 !bg-card/95"
           />
         </ReactFlow>
         </div>

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/__tests__/RedesignedClientCanvas.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/__tests__/RedesignedClientCanvas.test.tsx
@@ -55,7 +55,9 @@ describe("RedesignedClientCanvas", () => {
     expect(node).not.toBeNull();
     const scope = within(node as HTMLElement);
     expect(scope.getByText("Client capabilities")).toBeInTheDocument();
-    expect(scope.getByText("Apps extension")).toBeInTheDocument();
+    // The paper redesign nests Apps Extension caps under a "View iframe"
+    // frame whose subtitle still names the extension. Match by substring.
+    expect(scope.getByText(/Apps extension/)).toBeInTheDocument();
     expect(scope.getByText("roots")).toBeInTheDocument();
     expect(scope.getByText("openLinks")).toBeInTheDocument();
   });
@@ -69,8 +71,12 @@ describe("RedesignedClientCanvas", () => {
       `.react-flow__node[data-id="${HOST_MATRIX_NODE_ID}"]`,
     ) as HTMLElement | null;
     expect(node).not.toBeNull();
+    // Off caps in the View frame carry the `hp-view-cap--off` class which
+    // applies a dashed border + strike-through via CSS. Asserting the
+    // semantic class beats asserting a Tailwind utility name that the
+    // redesign no longer uses.
     expect(
-      (node as HTMLElement).querySelector(".line-through"),
+      (node as HTMLElement).querySelector(".hp-view-cap--off"),
     ).not.toBeNull();
   });
 });

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
@@ -34,22 +34,23 @@ import { fieldsWithIssues } from "../focus/useClientDraftValidation";
    ============================================================ */
 const MATRIX_W = 580;
 // Matrix renders auto-height; these constants only feed the servers hub
-// y-position downstream. Two heights so the servers hub doesn't float in
-// a dead zone when the Apps Extension section is hidden (Codex et al).
-//   - BASE: identity + stats + protocol + client-caps sub-matrix + footer
-//   - APPS_SECTION: banner + head + 6 cap rows
-const MATRIX_H_BASE = 400;
-const MATRIX_H_APPS_SECTION = 240;
-// Sandbox section: banner + head + 4 fixed rows (mode/restrictTo/deny/permissions)
-const MATRIX_H_SANDBOX_SECTION = 160;
-const SERVERS_HUB_GAP = 64;
+// y-position downstream. Three heights so the servers hub doesn't float in
+// a dead zone when the Apps Extension section is hidden (Codex et al) and
+// so the dimensions still match the paper-aesthetic card's nested frames.
+//   - BASE: outer host padding + identity + stats + client-caps + footer
+//   - APPS_SECTION: inner View frame (lavender) with chip rows
+//   - SANDBOX_SECTION: Sandbox frame (amber) shell + sb-grid rows
+const MATRIX_H_BASE = 380;
+const MATRIX_H_APPS_SECTION = 230;
+const MATRIX_H_SANDBOX_SECTION = 180;
+const SERVERS_HUB_GAP = 40;
 const SERVERS_HUB_W_BASE = 220;
 const SERVERS_HUB_W_PER_SERVER = 38;
 const SERVERS_HUB_H = 48;
 const SERVER_CARD_W = 220;
 const SERVER_CARD_H = 88;
 const SERVER_CARD_GAP_X = 16;
-const SERVERS_ROW_GAP = 56;
+const SERVERS_ROW_GAP = 40;
 
 /* ============================================================
    Stable cap orders. Keeping order stable lets row diffs morph
@@ -558,7 +559,7 @@ export function buildRedesignedHostCanvas(
       fixedTargetX: serversHubX + serversHubW / 2,
       fixedTargetY: serversHubY,
     },
-    style: { stroke: "oklch(0.68 0.11 40 / 0.55)", strokeWidth: 1.5 },
+    style: { stroke: "oklch(0.55 0.01 250 / 0.5)", strokeWidth: 1.5 },
   });
 
   // 3) Server cards — required first, then optional. Insecure http
@@ -633,7 +634,7 @@ export function buildRedesignedHostCanvas(
       style: {
         stroke: insecure
           ? "oklch(0.65 0.18 60)"
-          : "oklch(0.68 0.11 40 / 0.55)",
+          : "oklch(0.55 0.01 250 / 0.5)",
         strokeWidth: 1.5,
         strokeDasharray: isOptional ? "4 4" : undefined,
       },

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
@@ -550,15 +550,9 @@ export function buildRedesignedHostCanvas(
     id: "host-matrix-to-hub",
     source: HOST_MATRIX_NODE_ID,
     target: SERVERS_HUB_NODE_ID,
+    sourceHandle: "bottom",
+    targetHandle: "top",
     type: "hostTrunk",
-    data: {
-      // matrix is positioned at (0, 0); its bottom-center sits at
-      // (MATRIX_W / 2, matrixH). Hub top-center is the target.
-      fixedSourceX: MATRIX_W / 2,
-      fixedSourceY: matrixH,
-      fixedTargetX: serversHubX + serversHubW / 2,
-      fixedTargetY: serversHubY,
-    },
     style: { stroke: "oklch(0.68 0.11 40 / 0.55)", strokeWidth: 1.5 },
   });
 

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
@@ -559,7 +559,7 @@ export function buildRedesignedHostCanvas(
       fixedTargetX: serversHubX + serversHubW / 2,
       fixedTargetY: serversHubY,
     },
-    style: { stroke: "oklch(0.55 0.01 250 / 0.5)", strokeWidth: 1.5 },
+    style: { stroke: "oklch(0.68 0.11 40 / 0.55)", strokeWidth: 1.5 },
   });
 
   // 3) Server cards — required first, then optional. Insecure http
@@ -634,7 +634,7 @@ export function buildRedesignedHostCanvas(
       style: {
         stroke: insecure
           ? "oklch(0.65 0.18 60)"
-          : "oklch(0.55 0.01 250 / 0.5)",
+          : "oklch(0.68 0.11 40 / 0.55)",
         strokeWidth: 1.5,
         strokeDasharray: isOptional ? "4 4" : undefined,
       },

--- a/mcpjam-inspector/client/src/lib/chatbox-client-style.ts
+++ b/mcpjam-inspector/client/src/lib/chatbox-client-style.ts
@@ -168,3 +168,21 @@ export function getChatboxShellStyle(
 
   return shellStyle;
 }
+
+/**
+ * Applies only the host's primary pair so tab underlines and primary buttons
+ * match the emulated client, without swapping `--background` away from the
+ * app shell — keeps Connect headers visually aligned with {@link Header}.
+ */
+export function getHostChromeAccentVariables(
+  hostStyle: ChatboxHostStyle | null | undefined,
+  themeMode: HostThemeMode,
+  chatUiOverride?: ChatUiOverride,
+): CSSProperties | undefined {
+  if (!hostStyle) return undefined;
+  const shell = getChatboxShellStyle(hostStyle, themeMode, chatUiOverride);
+  return {
+    "--primary": shell["--primary"] as string,
+    "--primary-foreground": shell["--primary-foreground"] as string,
+  };
+}

--- a/mcpjam-inspector/client/src/lib/chatbox-client-style.ts
+++ b/mcpjam-inspector/client/src/lib/chatbox-client-style.ts
@@ -178,11 +178,15 @@ export function getHostChromeAccentVariables(
   hostStyle: ChatboxHostStyle | null | undefined,
   themeMode: HostThemeMode,
   chatUiOverride?: ChatUiOverride,
-): CSSProperties | undefined {
+): ChatboxShellStyle | undefined {
   if (!hostStyle) return undefined;
-  const shell = getChatboxShellStyle(hostStyle, themeMode, chatUiOverride);
+  const shell = getChatboxShellStyle(
+    hostStyle,
+    themeMode,
+    chatUiOverride,
+  ) as ChatboxShellStyle;
   return {
-    "--primary": shell["--primary"] as string,
-    "--primary-foreground": shell["--primary-foreground"] as string,
+    "--primary": shell["--primary"],
+    "--primary-foreground": shell["--primary-foreground"],
   };
 }


### PR DESCRIPTION
## Summary
- Rebuild the redesigned client canvas around a single `HostMatrixCard` ReactFlow node (Agent stats, Protocol band, Apps banner, capability rows) whose sub-regions dispatch their own ids to `onSelectNode` via context, so the focus panel routes correctly without making selection a renderer prop.
- Add pastel `--diagram-server` / `--diagram-sandbox` / `--diagram-view` tokens (light + dark) in `design-system/tokens.css`, `index.css`, and `tokens.ts`; servers hub and related diagram chrome now read from these role-based tokens instead of ad-hoc colors.
- Harden edge rendering: branch edges read fixed coords from `canvasBuilder` (framer-motion `layoutId` morphs pollute ReactFlow's `getBoundingClientRect`-based handle measurements), trunk edge keeps measured coords (no `layout` on those nodes), and edges + viewport are gated behind `edgesReady` / `viewportReady` so the first paint doesn't show off-center nodes with trailing lines.

## Test plan
- [ ] Open a host in the redesigned client canvas; verify the matrix card mounts with the reveal animation and all sub-regions (Agent, Protocol band, Apps, cap rows) dispatch the right focus-panel tab on click.
- [ ] Toggle between Servers tab and the canvas; confirm server pills morph 1:1 via `layoutId` with no edge flap to the top-right of the canvas.
- [ ] Switch between light and dark mode; servers hub, sandbox accent, and view accent read as distinct pastel hues with legible foreground in both themes.
- [ ] Embed the canvas in the chatbox builder with `readOnly` + `onRequestEdit`; verify the add-server pill is gone, clicks anywhere route to `onRequestEdit`, and selection state never paints.
- [ ] Reload the page; viewport stays hidden until `fitView` settles (no one-frame off-center flash) and edges fade in after server pills land.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a sizable ReactFlow canvas/UI refactor (new host matrix layout, edge routing, and theme-variable scoping) that could regress selection, layout, or theming behavior across light/dark modes.
> 
> **Overview**
> **Redesigns the redesigned client canvas host node into a single “paper” `HostMatrixCard`** that visually nests *Host → Sandbox → View* frames, while preserving focus-panel routing by dispatching sub-region selection ids from inside the card.
> 
> **Adds new role-based diagram accent tokens** (`--diagram-server`, `--diagram-sandbox`, `--diagram-view` + foregrounds) in the design system (light/dark) and wires them into Tailwind color aliases; the servers hub styling now uses these tokens.
> 
> **Adjusts Connect/Host theming scoping** so host-brand variables apply to the canvas/body only, while header/tab chrome stays on the app background but uses a new `getHostChromeAccentVariables()` helper to keep `--primary` accents host-branded.
> 
> **Improves canvas geometry/stability** by updating layout constants, switching the host→hub trunk edge to measured handle coordinates (while keeping branch edges fixed), and updating tests to match the new markup/classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb1010bbf72d7612669700e5b27f44321e7825b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->