### PR TITLE
read global theme on host creation + icons

### DIFF
--- a/mcpjam-inspector/client/src/components/clients/ClientOverlayBar.tsx
+++ b/mcpjam-inspector/client/src/components/clients/ClientOverlayBar.tsx
@@ -16,7 +16,16 @@ import { cn } from "@/lib/utils";
 import { useHostList, useHostMutations } from "@/hooks/useClients";
 import { emptyHostConfigInputV2 } from "@/lib/client-config-v2";
 import { standardEventProps } from "@/lib/PosthogUtils";
+import {
+  HOST_TEMPLATES,
+  seedFromHostTemplate,
+  type HostTemplateId,
+} from "@/lib/client-templates";
+import { useProjectServers } from "@/hooks/useViews";
+import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { CreateClientDialog } from "./CreateClientDialog";
+
+const QUICK_ADD_TEMPLATES: HostTemplateId[] = ["claude", "chatgpt", "copilot"];
 
 const MCPJAM_HOST_NAME = "MCPJam";
 const LAST_HOST_DELETE_REASON =
@@ -41,7 +50,10 @@ export function ClientOverlayBar({
   const { isAuthenticated } = useConvexAuth();
   const { hosts, isLoading } = useHostList({ isAuthenticated, projectId });
   const { createHost, deleteHost } = useHostMutations();
+  const { servers } = useProjectServers({ isAuthenticated, projectId });
+  const themeMode = usePreferencesStore((s) => s.themeMode);
   const [showCreate, setShowCreate] = useState(false);
+  const [quickAddingId, setQuickAddingId] = useState<HostTemplateId | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
 
@@ -184,6 +196,33 @@ export function ClientOverlayBar({
     }
   };
 
+  const handleQuickAdd = async (templateId: HostTemplateId) => {
+    const template = HOST_TEMPLATES.find((t) => t.id === templateId);
+    if (!template) return;
+    setQuickAddingId(templateId);
+    try {
+      const seed = seedFromHostTemplate(templateId, { theme: themeMode });
+      const projectServerIds = servers?.map((s) => s._id) ?? [];
+      const { hostId } = await createHost({
+        projectId,
+        name: template.label,
+        input: { ...seed, serverIds: projectServerIds },
+      });
+      toast.success(`Client "${template.label}" created`);
+      posthog.capture("connect_host_overlay_quick_added", {
+        template_id: templateId,
+        host_id: hostId,
+      });
+      setMenuOpen(false);
+      onChangePreviewedHostId(hostId);
+      onCanvasReplaceHost?.(hostId);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to create client");
+    } finally {
+      setQuickAddingId(null);
+    }
+  };
+
   const canCycle = sortedHosts.length > 1;
   const canDelete = sortedHosts.length > 1;
   const arrowDisabled = isLoading || !canCycle;
@@ -285,9 +324,49 @@ export function ClientOverlayBar({
               <DropdownMenuItem
                 data-testid="host-overlay-save-as-new"
                 onSelect={() => setShowCreate(true)}
+                className="group pr-1.5"
               >
                 <Plus className="size-3.5" />
-                Add client
+                <span className="flex-1">Add client</span>
+                <span
+                  className="ml-2 flex shrink-0 items-center gap-0.5"
+                  onPointerDown={(e) => e.stopPropagation()}
+                >
+                  {QUICK_ADD_TEMPLATES.map((id) => {
+                    const template = HOST_TEMPLATES.find((t) => t.id === id);
+                    if (!template) return null;
+                    const isAdding = quickAddingId === id;
+                    return (
+                      <button
+                        key={id}
+                        type="button"
+                        aria-label={`Add ${template.label} client`}
+                        title={`Add ${template.label}`}
+                        disabled={quickAddingId !== null}
+                        data-testid={`host-overlay-quick-add-${id}`}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          void handleQuickAdd(id);
+                        }}
+                        className={cn(
+                          "inline-flex size-6 items-center justify-center rounded-sm transition-colors",
+                          "hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50",
+                        )}
+                      >
+                        {isAdding ? (
+                          <span className="size-3 animate-pulse rounded-full bg-muted-foreground/40" />
+                        ) : (
+                          <img
+                            src={template.logoSrc}
+                            alt=""
+                            className="size-4 object-contain"
+                          />
+                        )}
+                      </button>
+                    );
+                  })}
+                </span>
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/mcpjam-inspector/client/src/components/clients/ClientOverlayBar.tsx
+++ b/mcpjam-inspector/client/src/components/clients/ClientOverlayBar.tsx
@@ -196,7 +196,19 @@ export function ClientOverlayBar({
     }
   };
 
+  // Mirrors the gate in CreateClientDialog.handleCreate. `useProjectServers`
+  // returns `undefined` while loading vs `[]` for a truly empty project;
+  // collapsing both into `[]` would silently seed the new host with zero
+  // attachments and there's no UI affordance to fix it after the fact (the
+  // host never self-corrects). The auth gate matches `useProjectServers`'s
+  // own skip rule: unauthenticated users never fire the query.
+  const isServersLoading = isAuthenticated && servers === undefined;
+
   const handleQuickAdd = async (templateId: HostTemplateId) => {
+    if (isServersLoading) {
+      toast.error("Still loading project servers. Try again in a moment.");
+      return;
+    }
     const template = HOST_TEMPLATES.find((t) => t.id === templateId);
     if (!template) return;
     setQuickAddingId(templateId);
@@ -342,7 +354,7 @@ export function ClientOverlayBar({
                         type="button"
                         aria-label={`Add ${template.label} client`}
                         title={`Add ${template.label}`}
-                        disabled={quickAddingId !== null}
+                        disabled={quickAddingId !== null || isServersLoading}
                         data-testid={`host-overlay-quick-add-${id}`}
                         onClick={(e) => {
                           e.preventDefault();

--- a/mcpjam-inspector/client/src/components/clients/CreateClientDialog.tsx
+++ b/mcpjam-inspector/client/src/components/clients/CreateClientDialog.tsx
@@ -22,6 +22,7 @@ import {
   seedFromHostTemplate,
   type HostTemplateId,
 } from "@/lib/client-templates";
+import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { cn } from "@/lib/utils";
 
 interface CreateHostDialogProps {
@@ -41,6 +42,7 @@ export function CreateClientDialog({
   const { createHost } = useHostMutations();
   const { isAuthenticated } = useConvexAuth();
   const { servers } = useProjectServers({ isAuthenticated, projectId });
+  const themeMode = usePreferencesStore((s) => s.themeMode);
   const [name, setName] = useState("");
   const [selectedTemplateId, setSelectedTemplateId] = useState<HostTemplateId>(
     DEFAULT_HOST_TEMPLATE_ID,
@@ -81,8 +83,13 @@ export function CreateClientDialog({
     try {
       // Pre-attach every existing project server as required so the new
       // host's Servers tab opens with checkboxes filled in instead of
-      // every server reading "optional / uses defaults".
-      const seed = seedFromHostTemplate(selectedTemplateId);
+      // every server reading "optional / uses defaults". Thread MCPJam's
+      // current global theme into the seed so the new host opens
+      // matching the inspector chrome instead of always defaulting to
+      // dark — the user can still flip it later from the host editor.
+      const seed = seedFromHostTemplate(selectedTemplateId, {
+        theme: themeMode,
+      });
       // `isServersLoading` already guards the authenticated-loading case;
       // for unauthenticated callers the query is skipped so `servers` is
       // undefined and we seed with no attachments.

--- a/mcpjam-inspector/client/src/components/clients/__tests__/ClientOverlayBar.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/__tests__/ClientOverlayBar.test.tsx
@@ -23,6 +23,15 @@ vi.mock("@/hooks/useClients", () => ({
   }),
 }));
 
+vi.mock("@/hooks/useViews", () => ({
+  useProjectServers: () => ({ servers: [] }),
+}));
+
+vi.mock("@/stores/preferences/preferences-provider", () => ({
+  usePreferencesStore: (selector: (state: { themeMode: "light" | "dark" }) => unknown) =>
+    selector({ themeMode: "light" }),
+}));
+
 vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({ capture: vi.fn() }),
 }));

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
@@ -94,8 +94,11 @@ export const HostMatrixCard = memo(function HostMatrixCard({
           className="hp-identity"
         >
           {(() => {
-            const clientInfoName = clientInfoLeaf?.value?.split(" ")[0];
-            const clientLogo = getClientLogo(clientInfoName, hostName);
+            // Pass the full value — `getClientLogo` already lowercases
+            // and substring-matches against the combined haystack, so any
+            // pre-tokenization here just hides keywords that don't sit at
+            // index 0 (e.g. "mcp-client-claude" → no logo with split[0]).
+            const clientLogo = getClientLogo(clientInfoLeaf?.value, hostName);
             return (
               <span
                 className={cn("hp-glyph", clientLogo && "hp-glyph--logo")}

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
@@ -1,5 +1,11 @@
 import { memo, type CSSProperties, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import claudeLogo from "/claude_logo.png";
+import openaiLogo from "/openai_logo.png";
+import cursorLogo from "/cursor_logo.png";
+import codexLogo from "/codex-logo.svg";
+import copilotLogo from "/copilot_logo.png";
+import mcpjamLogo from "/mcp_jam_2row.png";
 import {
   AGENT_IDENTITY_NODE_ID,
   APPS_HUB_NODE_ID,
@@ -15,6 +21,21 @@ import {
   type ProtocolLeafNodeData,
   type SandboxConfigNodeData,
 } from "../types";
+
+function getClientLogo(
+  clientInfoName: string | undefined,
+  hostName: string | undefined,
+): string | null {
+  const haystack = `${clientInfoName ?? ""} ${hostName ?? ""}`.toLowerCase();
+  if (haystack.includes("mcpjam") || haystack.includes("mcp-jam")) return mcpjamLogo;
+  if (haystack.includes("claude")) return claudeLogo;
+  if (haystack.includes("cursor")) return cursorLogo;
+  if (haystack.includes("codex")) return codexLogo;
+  if (haystack.includes("copilot")) return copilotLogo;
+  if (haystack.includes("openai") || haystack.includes("chatgpt") || haystack.includes("gpt"))
+    return openaiLogo;
+  return null;
+}
 
 /* ============================================================
    Host card. The card IS the architecture diagram — Host frame
@@ -72,10 +93,26 @@ export const HostMatrixCard = memo(function HostMatrixCard({
           onSelectNode={onSelectNode}
           className="hp-identity"
         >
-          <span className="hp-glyph" aria-hidden>
-            {(agent?.modelProvider?.charAt(0) ?? "?").toUpperCase()}
-            <span className="hp-glyph-state" aria-hidden />
-          </span>
+          {(() => {
+            const clientInfoName = clientInfoLeaf?.value?.split(" ")[0];
+            const clientLogo = getClientLogo(clientInfoName, hostName);
+            return (
+              <span
+                className={cn("hp-glyph", clientLogo && "hp-glyph--logo")}
+                aria-hidden
+              >
+                {clientLogo ? (
+                  <img
+                    src={clientLogo}
+                    alt=""
+                    className="hp-glyph-img"
+                  />
+                ) : (
+                  (agent?.modelProvider?.charAt(0) ?? "?").toUpperCase()
+                )}
+              </span>
+            );
+          })()}
           <span className="hp-identity-meta">
             <span className="hp-host-name" title={hostName}>
               {hostName}
@@ -530,8 +567,8 @@ const PAPER_STYLES = `
 .host-paper-card .hp-glyph {
   position: relative;
   width: 44px; height: 44px;
-  background: var(--hp-paper-surface);
-  border: 1px solid var(--hp-host-ring);
+  background: transparent;
+  border: none;
   border-radius: 11px;
   display: grid; place-items: center;
   font-weight: 600;
@@ -539,6 +576,12 @@ const PAPER_STYLES = `
   color: var(--hp-ink);
   letter-spacing: -0.02em;
   flex: none;
+}
+.host-paper-card .hp-glyph-img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: 8px;
 }
 .host-paper-card .hp-glyph-state {
   position: absolute;

--- a/mcpjam-inspector/client/src/components/shared/ClientContextHeader.tsx
+++ b/mcpjam-inspector/client/src/components/shared/ClientContextHeader.tsx
@@ -460,12 +460,19 @@ export function ClientContextHeader({
                   size="icon"
                   onClick={() => {
                     // Helper writes the pill id first (via setHostStyle),
-                    // then fans out to the chip stores.
-                    applyHostDefaultsToPlayground(host.id, {
-                      setHostStyle,
-                      setHostCapabilitiesOverride,
-                      setChatUiOverride,
-                    });
+                    // then fans out to the chip stores. Pass MCPJam's
+                    // current global theme so the seeded host matches
+                    // the inspector chrome instead of always opening
+                    // dark (the template default).
+                    applyHostDefaultsToPlayground(
+                      host.id,
+                      {
+                        setHostStyle,
+                        setHostCapabilitiesOverride,
+                        setChatUiOverride,
+                      },
+                      { theme: themeMode },
+                    );
                   }}
                   className="h-6 w-6"
                 >

--- a/mcpjam-inspector/client/src/lib/client-templates.ts
+++ b/mcpjam-inspector/client/src/lib/client-templates.ts
@@ -2,6 +2,7 @@ import {
   emptyHostConfigInputV2,
   type HostConfigInputV2,
 } from "@/lib/client-config-v2";
+import type { HostThemeMode } from "@/lib/client-styles";
 import {
   MCPJAM_FONT_CSS,
   MCPJAM_PLATFORM,
@@ -212,12 +213,32 @@ export type HostTemplateId =
   | "codex"
   | "copilot";
 
+export interface SeedHostTemplateOptions {
+  /**
+   * Theme stamped into `hostContext.theme` (and for the MCPJam template,
+   * threaded into `getMcpJamStyleVariables`) at creation time. Callers at
+   * the host-creation seam pass MCPJam's current global `themeMode` so a
+   * newly-created host opens matching the rest of the app instead of
+   * defaulting to dark. Omitting it preserves the legacy "always dark"
+   * behavior for callers that snapshot template defaults onto already-
+   * existing surfaces (see `applyHostStyleToHostConfigInput`,
+   * `applyHostDefaultsToPlayground`) where flipping to MCPJam's theme on
+   * every brand-pill click would be a surprise.
+   *
+   * Codex ignores this — its template doesn't set `hostContext` at all
+   * (no rendering surface, so no theme to honor).
+   */
+  theme?: HostThemeMode;
+}
+
+const DEFAULT_SEED_THEME: HostThemeMode = "dark";
+
 export interface HostTemplate {
   id: HostTemplateId;
   label: string;
   description: string;
   logoSrc: string;
-  seed: () => HostConfigInputV2;
+  seed: (opts?: SeedHostTemplateOptions) => HostConfigInputV2;
 }
 
 export const HOST_TEMPLATES: readonly HostTemplate[] = [
@@ -229,19 +250,21 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
     // Explicit `hostStyle: "mcpjam"` so the template doesn't silently
     // inherit the registry default — keeps MCPJam hosts visually distinct
     // from Claude even if the default ever drifts.
-    seed: () => {
+    seed: (opts) => {
       const base = emptyHostConfigInputV2({ hostStyle: "mcpjam" });
+      const theme = opts?.theme ?? DEFAULT_SEED_THEME;
       // Per-resource hostContext for MCPJam's own house chrome. Style
       // variables come straight from the design-system tokens that
       // `client/src/index.css` imports via `@mcpjam/design-system`, so
       // a widget rendered in an MCPJam-styled host sees the same
-      // surfaces/text/border tokens as the inspector itself. Theme is
-      // resolved to "dark" here because the template hardcodes `theme:
-      // "dark"` below; switching theme requires re-seeding.
+      // surfaces/text/border tokens as the inspector itself. The theme
+      // value below also threads into `getMcpJamStyleVariables(theme)` —
+      // MCPJam's variables are JS-resolved (not CSS `light-dark()`), so
+      // both need to flip together.
       // MCPJAM_FONT_CSS is empty (system font stack, no @font-face), so
       // `styles.css` is omitted entirely.
       base.hostContext = {
-        theme: "dark",
+        theme,
         displayMode: "inline",
         availableDisplayModes: ["inline", "fullscreen"],
         containerDimensions: { width: 720, maxHeight: 5000 },
@@ -252,7 +275,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         deviceCapabilities: { touch: false, hover: true },
         safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
         styles: {
-          variables: getMcpJamStyleVariables("dark"),
+          variables: getMcpJamStyleVariables(theme),
           ...(MCPJAM_FONT_CSS ? { css: { fonts: MCPJAM_FONT_CSS } } : {}),
         },
       };
@@ -278,7 +301,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
     label: "Claude",
     description: "Anthropic-style host. Tool approval on.",
     logoSrc: claudeLogo,
-    seed: () => {
+    seed: (opts) => {
       const base = emptyHostConfigInputV2({
         hostStyle: "claude",
         // Canonical id (anthropic/<slug>) so the chat-composer model
@@ -290,6 +313,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         temperature: 1.0,
         requireToolApproval: true,
       });
+      const theme = opts?.theme ?? DEFAULT_SEED_THEME;
       // clientCapabilities: Real claude.ai publishes only the SDK-default
       // MCP UI extension (no `experimental` flag). emptyHostConfigInputV2
       // already seeds that, so no override needed here — distinct from
@@ -322,7 +346,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
       // width; widgets render at whatever the iframe is, the value
       // communicates Claude's layout policy.
       base.hostContext = {
-        theme: "dark",
+        theme,
         displayMode: "inline",
         availableDisplayModes: ["inline", "fullscreen"],
         containerDimensions: { width: 720, maxHeight: 5000 },
@@ -335,7 +359,9 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
         // SEP-1865 hostContext.styles. Anthropic Sans @font-face URLs
         // require `assets.claude.ai` in apps.sandbox.csp.resourceDomains
-        // (set below).
+        // (set below). Variables use CSS `light-dark()` so they pick the
+        // right side based on the iframe's `color-scheme` — no JS-side
+        // theme threading required here.
         styles: {
           variables: CLAUDE_HOST_STYLE_VARIABLES,
           css: { fonts: CLAUDE_FONTS_CSS },
@@ -382,7 +408,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
     label: "ChatGPT",
     description: "OpenAI-style host with ChatGPT protocol.",
     logoSrc: openaiLogo,
-    seed: () => {
+    seed: (opts) => {
       const base = emptyHostConfigInputV2({
         hostStyle: "chatgpt",
         // Canonical id (openai/<slug>) so the chat-composer model picker
@@ -394,6 +420,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         temperature: 0.7,
         requireToolApproval: false,
       });
+      const theme = opts?.theme ?? DEFAULT_SEED_THEME;
       // Real ChatGPT advertises an `experimental.openai/visibility` flag on top
       // of the SDK-default MCP UI extension. Keep the default extension block
       // (mime types) intact; only add the openai-specific experimental key.
@@ -423,7 +450,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
       // viewport-minus-padding); rounded to the md breakpoint (768) so the
       // template communicates intent rather than freezing a snapshot.
       base.hostContext = {
-        theme: "dark",
+        theme,
         displayMode: "inline",
         availableDisplayModes: ["inline", "fullscreen", "pip"],
         containerDimensions: { height: 400, maxWidth: 768 },
@@ -481,7 +508,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
     label: "Cursor",
     description: "Cursor IDE chat panel. MCP UI extension on, no message/updateModelContext.",
     logoSrc: cursorLogo,
-    seed: () => {
+    seed: (opts) => {
       const base = emptyHostConfigInputV2({
         hostStyle: "cursor",
         // Canonical id (anthropic/<slug>) so the chat-composer model
@@ -494,6 +521,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         temperature: 0.7,
         requireToolApproval: false,
       });
+      const theme = opts?.theme ?? DEFAULT_SEED_THEME;
       // clientCapabilities: matches what real Cursor publishes during MCP
       // `initialize` — declares MCP UI support plus its own elicitation
       // and roots flags. We keep the SDK-default UI extension entry
@@ -521,7 +549,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
       // `availableDisplayModes` is a single-element list because Cursor
       // currently only renders inline (no fullscreen / pip).
       base.hostContext = {
-        theme: "dark",
+        theme,
         displayMode: "inline",
         availableDisplayModes: ["inline"],
         containerDimensions: { width: 748, maxHeight: 800 },
@@ -624,7 +652,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
     label: "Copilot",
     description: "Microsoft 365 Copilot host. OpenAI-shaped Apps SDK.",
     logoSrc: copilotLogo,
-    seed: () => {
+    seed: (opts) => {
       const base = emptyHostConfigInputV2({
         hostStyle: "copilot",
         // Real Microsoft 365 Copilot routes through OpenAI's chat-class
@@ -637,6 +665,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         temperature: 0.7,
         requireToolApproval: false,
       });
+      const theme = opts?.theme ?? DEFAULT_SEED_THEME;
       // Copilot's MCP client identity is not publicly documented; declare
       // an experimental `microsoft/copilot` flag so any app that branches
       // on it can detect the host. Keep the SDK-default UI extension entry
@@ -663,7 +692,7 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
       // policy, modest fixed height); `availableDisplayModes` drops
       // `pip` because Copilot's surface doesn't currently expose it.
       base.hostContext = {
-        theme: "dark",
+        theme,
         displayMode: "inline",
         availableDisplayModes: ["inline", "fullscreen"],
         containerDimensions: { height: 400, maxWidth: 768 },
@@ -722,8 +751,11 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
 
 export const DEFAULT_HOST_TEMPLATE_ID: HostTemplateId = "mcpjam";
 
-export function seedFromHostTemplate(id: HostTemplateId): HostConfigInputV2 {
+export function seedFromHostTemplate(
+  id: HostTemplateId,
+  opts?: SeedHostTemplateOptions,
+): HostConfigInputV2 {
   const template =
     HOST_TEMPLATES.find((t) => t.id === id) ?? HOST_TEMPLATES[0];
-  return template.seed();
+  return template.seed(opts);
 }

--- a/mcpjam-inspector/client/src/lib/playground/apply-client-defaults.ts
+++ b/mcpjam-inspector/client/src/lib/playground/apply-client-defaults.ts
@@ -7,7 +7,7 @@ import {
   seedFromHostTemplate,
   type HostTemplateId,
 } from "@/lib/client-templates";
-import type { ChatUiOverride } from "@/lib/client-styles";
+import type { ChatUiOverride, HostThemeMode } from "@/lib/client-styles";
 import { saveSelectedModelId } from "@/lib/selected-model-storage";
 import {
   getCanonicalModelId,
@@ -175,11 +175,18 @@ export function applyHostConfigToPlayground(
 export function applyHostDefaultsToPlayground(
   hostStyle: ChatboxHostStyle,
   setters: ApplyHostPlaygroundSetters,
+  opts?: { theme?: HostThemeMode },
 ): void {
   // `seedFromHostTemplate` is typed as `HostTemplateId` but the runtime
   // falls through to MCPJam on unknown ids. The cast keeps the call site
   // tolerant of arbitrary BYO host-style ids.
-  const cfg = seedFromHostTemplate(hostStyle as HostTemplateId);
+  //
+  // Thread the caller's theme so the brand-pill click in the chat header
+  // seeds the new host with MCPJam's current global theme instead of the
+  // template's hardcoded "dark" fallback. Without this, picking Copilot/
+  // ChatGPT/etc. from the pill row always flipped the chat surface to
+  // dark even when MCPJam itself was in light mode.
+  const cfg = seedFromHostTemplate(hostStyle as HostTemplateId, opts);
   // Override the template's `hostStyle` with the user's actual pick — for
   // BYO ids the template falls back to MCPJam, but the brand pill that
   // was clicked is the right identity to advertise.


### PR DESCRIPTION
 Problem
  - Every host template (Claude, ChatGPT, Cursor,
   Copilot, MCPJam) was hardcoded to theme: 
  "dark".
  - Result: creating a new host or clicking a
  host pill in the chat always opened in dark
  mode, even when MCPJam was in light mode.

  Fix
  - Host templates now accept a theme argument
  instead of hardcoding "dark".
  - When you create a host (Connections tab), it
  grabs MCPJam's current theme and bakes it into
  the new host's config (persistent).
  - When you click a host pill in the chat
  header, the same theme is applied for that
  session (ephemeral — doesn't save).
  - Codex left alone — it has no theme (CLI).

  Notes
  - Existing hosts unchanged — theme is captured
  at creation time, like a photo. Editing later
  still works via the host editor.
  - Default arg stays "dark" for backwards
  compat, so any other code path that doesn't
  pass a theme behaves exactly as before.
  - Widgets receive the correct hostContext.theme
   value via ui/initialize — colors stay
  consistent with what they're told.

 