### PR TITLE
Model real-host iframe attributes via 3 new sandbox config fields

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-modal.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-modal.tsx
@@ -37,6 +37,9 @@ export interface McpAppsModalProps {
   widgetCsp: McpUiResourceCsp | undefined;
   widgetPermissions: McpUiResourcePermissions | undefined;
   widgetPermissive: boolean;
+  widgetSandboxAttrs: string[] | undefined;
+  widgetAllowFeatures: Record<string, string> | undefined;
+  widgetCspDirectives: Record<string, string[]> | undefined;
   hostContextRef: React.RefObject<McpUiHostContext | null>;
   serverId: string;
   resourceUri: string;
@@ -67,6 +70,9 @@ export function McpAppsModal({
   widgetCsp,
   widgetPermissions,
   widgetPermissive,
+  widgetSandboxAttrs,
+  widgetAllowFeatures,
+  widgetCspDirectives,
   hostContextRef,
   serverId,
   resourceUri,
@@ -287,6 +293,9 @@ export function McpAppsModal({
               csp={widgetCsp}
               permissions={widgetPermissions}
               permissive={widgetPermissive}
+              sandboxAttrs={widgetSandboxAttrs}
+              allowFeatures={widgetAllowFeatures}
+              cspDirectives={widgetCspDirectives}
               colorScheme={modalColorScheme}
               onMessage={handleModalMessage}
               title={`MCP App Modal: ${title}`}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -983,11 +983,24 @@ export function MCPAppsRenderer({
   const sandboxCspPolicy = activeMcpProfile?.apps?.sandbox?.csp;
   const sandboxPermissionsPolicy =
     activeMcpProfile?.apps?.sandbox?.permissions;
+  // Inspector-only emission knobs sourced directly from the profile. They
+  // bypass the SEP-1865 resolver because they model browser-emission state
+  // that has no spec slot (raw `sandbox=`/`allow=` tokens, CSP source
+  // expressions). Passed through unchanged to <SandboxedIframe>.
+  const sandboxAttrsPolicy =
+    activeMcpProfile?.apps?.sandbox?.sandboxAttrs;
+  const allowFeaturesPolicy =
+    activeMcpProfile?.apps?.sandbox?.allowFeatures;
+  const cspDirectivesPolicy =
+    activeMcpProfile?.apps?.sandbox?.csp?.cspDirectives;
   const effectiveSandbox = useMemo<{
     csp: McpUiResourceCsp | undefined;
     permissions: McpUiResourcePermissions | undefined;
     permissive: boolean;
     hostPolicyApplied: boolean;
+    sandboxAttrs: string[] | undefined;
+    allowFeatures: Record<string, string> | undefined;
+    cspDirectives: Record<string, string[]> | undefined;
   }>(() => {
     // Detect whether the host explicitly configured CSP hardening signals.
     // Hoisted above the permissive short-circuit so the permissive branch
@@ -1048,6 +1061,9 @@ export function MCPAppsRenderer({
         permissions: resolvedPermissions ?? widgetPermissions,
         permissive: true,
         hostPolicyApplied: !!resolvedPermissions,
+        sandboxAttrs: sandboxAttrsPolicy,
+        allowFeatures: allowFeaturesPolicy,
+        cspDirectives: cspDirectivesPolicy,
       };
     }
 
@@ -1178,6 +1194,9 @@ export function MCPAppsRenderer({
           ? false
           : widgetPermissive,
       hostPolicyApplied,
+      sandboxAttrs: sandboxAttrsPolicy,
+      allowFeatures: allowFeaturesPolicy,
+      cspDirectives: cspDirectivesPolicy,
     };
   }, [
     cspMode,
@@ -1186,6 +1205,9 @@ export function MCPAppsRenderer({
     widgetCsp,
     widgetPermissions,
     widgetPermissive,
+    sandboxAttrsPolicy,
+    allowFeaturesPolicy,
+    cspDirectivesPolicy,
   ]);
 
   useEffect(() => {
@@ -1920,6 +1942,9 @@ export function MCPAppsRenderer({
       csp={effectiveSandbox.csp}
       permissions={effectiveSandbox.permissions}
       permissive={effectiveSandbox.permissive}
+      sandboxAttrs={effectiveSandbox.sandboxAttrs}
+      allowFeatures={effectiveSandbox.allowFeatures}
+      cspDirectives={effectiveSandbox.cspDirectives}
       colorScheme={resolvedTheme}
       onProxyReady={() => {
         setSandboxProxyReady(true);
@@ -2020,6 +2045,9 @@ export function MCPAppsRenderer({
         widgetCsp={effectiveSandbox.csp}
         widgetPermissions={effectiveSandbox.permissions}
         widgetPermissive={effectiveSandbox.permissive}
+        widgetSandboxAttrs={effectiveSandbox.sandboxAttrs}
+        widgetAllowFeatures={effectiveSandbox.allowFeatures}
+        widgetCspDirectives={effectiveSandbox.cspDirectives}
         hostContextRef={hostContextRef}
         serverId={serverId}
         resourceUri={resourceUri}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -993,6 +993,37 @@ export function MCPAppsRenderer({
     activeMcpProfile?.apps?.sandbox?.allowFeatures;
   const cspDirectivesPolicy =
     activeMcpProfile?.apps?.sandbox?.csp?.cspDirectives;
+  // Hosted-mode clamp for cspDirectives. The resolver's
+  // `hostedClampExtraDeny` strips MCPJam app/API origins from the
+  // widget-declared CSP (`restrictTo` + resource declaration), but
+  // cspDirectives is inspector-only — it bypasses the resolver and the
+  // proxy merges its tokens AFTER the resolver output, so without a
+  // mirrored clamp here a hosted profile with e.g.
+  // `cspDirectives: { "connect-src": ["https://app.mcpjam.com"] }`
+  // re-adds the same-origin access the clamp is meant to make
+  // non-bypassable. Strip any host-bearing token that resolves to the
+  // mcpjam.com namespace; CSP keyword tokens (`'unsafe-eval'`, hashes,
+  // nonces — quoted with `'…'`) and scheme-only tokens (`data:`, `blob:`)
+  // pass through unchanged.
+  const cspDirectivesEffective = useMemo(() => {
+    if (!cspDirectivesPolicy) return cspDirectivesPolicy;
+    if (!HOSTED_MODE) return cspDirectivesPolicy;
+    const isMcpjamOrigin = (token: string) => {
+      if (token.startsWith("'")) return false; // CSP keyword
+      if (/^[a-z]+:$/.test(token)) return false; // scheme-only (data:, blob:)
+      // Match `mcpjam.com` as a host component: with optional subdomain,
+      // optional scheme prefix, optional port/path. Covers the same
+      // surface as MCPJAM_HOSTED_CLAMP_ORIGINS (`https://*.mcpjam.com`
+      // and `https://mcpjam.com`).
+      return /(?:^|[/.@])mcpjam\.com(?:[:/]|$)/i.test(token);
+    };
+    const out: Record<string, string[]> = {};
+    for (const [k, tokens] of Object.entries(cspDirectivesPolicy)) {
+      const clamped = tokens.filter((t) => !isMcpjamOrigin(t));
+      if (clamped.length > 0) out[k] = clamped;
+    }
+    return Object.keys(out).length > 0 ? out : undefined;
+  }, [cspDirectivesPolicy]);
   const effectiveSandbox = useMemo<{
     csp: McpUiResourceCsp | undefined;
     permissions: McpUiResourcePermissions | undefined;
@@ -1074,7 +1105,7 @@ export function MCPAppsRenderer({
         hostPolicyApplied: !!resolvedPermissions,
         sandboxAttrs: sandboxAttrsPolicy,
         allowFeatures: allowFeaturesPolicy,
-        cspDirectives: cspDirectivesPolicy,
+        cspDirectives: cspDirectivesEffective,
       };
     }
 
@@ -1208,7 +1239,7 @@ export function MCPAppsRenderer({
       hostPolicyApplied,
       sandboxAttrs: sandboxAttrsPolicy,
       allowFeatures: allowFeaturesPolicy,
-      cspDirectives: cspDirectivesPolicy,
+      cspDirectives: cspDirectivesEffective,
     };
   }, [
     cspMode,
@@ -1219,7 +1250,7 @@ export function MCPAppsRenderer({
     widgetPermissive,
     sandboxAttrsPolicy,
     allowFeaturesPolicy,
-    cspDirectivesPolicy,
+    cspDirectivesEffective,
   ]);
 
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1083,9 +1083,28 @@ export function MCPAppsRenderer({
     // without treating cspDirectives as hardening the configured
     // directives get silently dropped on the chatbox/preview surfaces
     // where host profiles are most meant to apply.
+    //
+    // Only count entries that contribute at least one token that would
+    // survive the proxy's mergeDirective filter (trim, plus `;,\n\r"<>`
+    // rejection — kept in lockstep with the predicate in
+    // sandbox-proxy.html). An entry like `{ "frame-src": [] }` or
+    // `{ "frame-src": [" "] }` is a semantic no-op and must not flip
+    // a permissive surface into the resolver path (which would then
+    // enforce the widget-declared CSP even though the named directive
+    // contributes nothing).
     const cspDirectivesConfigured =
       sandboxCspPolicy?.cspDirectives !== undefined &&
-      Object.keys(sandboxCspPolicy.cspDirectives).length > 0;
+      Object.values(sandboxCspPolicy.cspDirectives).some(
+        (tokens) =>
+          Array.isArray(tokens) &&
+          tokens.some((t) => {
+            if (typeof t !== "string") return false;
+            const trimmed = t.trim();
+            if (trimmed.length === 0) return false;
+            if (/[;,\n\r"<>]/.test(trimmed)) return false;
+            return true;
+          }),
+      );
     const hasExplicitCspHardening =
       restrictToConfigured || cspDirectivesConfigured || HOSTED_MODE;
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1030,7 +1030,17 @@ export function MCPAppsRenderer({
     };
     const out: Record<string, string[]> = {};
     for (const [k, tokens] of Object.entries(cspDirectivesPolicy)) {
-      const clamped = tokens.filter((t) => !isClampBypass(t));
+      // Trim BEFORE the bypass check: an imported/saved profile can
+      // carry " https:" or " https://app.mcpjam.com" with leading
+      // whitespace, and the proxy's mergeDirective trims tokens before
+      // emitting them — so the untrimmed string sneaks past
+      // isClampBypass while the trimmed version still lands in the
+      // output CSP, reintroducing the access the clamp is supposed to
+      // remove. Normalize here so the filter and the proxy see the same
+      // token shape.
+      const clamped = tokens
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0 && !isClampBypass(t));
       if (clamped.length > 0) out[k] = clamped;
     }
     return Object.keys(out).length > 0 ? out : undefined;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1013,7 +1013,18 @@ export function MCPAppsRenderer({
       Object.values(sandboxCspPolicy.restrictTo).some(
         (list) => Array.isArray(list) && list.length > 0,
       );
-    const hasExplicitCspHardening = restrictToConfigured || HOSTED_MODE;
+    // cspDirectives is an inspector-only emission knob, but a populated
+    // value is still an explicit "I want this CSP shape" signal. The
+    // permissive shortcut below bypasses the proxy's `buildCSP(csp,
+    // cspDirectives)` path (it builds its own fixed permissive CSP), so
+    // without treating cspDirectives as hardening the configured
+    // directives get silently dropped on the chatbox/preview surfaces
+    // where host profiles are most meant to apply.
+    const cspDirectivesConfigured =
+      sandboxCspPolicy?.cspDirectives !== undefined &&
+      Object.keys(sandboxCspPolicy.cspDirectives).length > 0;
+    const hasExplicitCspHardening =
+      restrictToConfigured || cspDirectivesConfigured || HOSTED_MODE;
 
     // Chatbox / Playground / minimal-mode surfaces opted into `permissive`
     // CSP up at line 285. Permissive means "default to permissive when the
@@ -1086,6 +1097,7 @@ export function MCPAppsRenderer({
     const isPureRelaxedCsp =
       sandboxCspPolicy?.mode === "relaxed" &&
       !restrictToConfigured &&
+      !cspDirectivesConfigured &&
       !HOSTED_MODE;
 
     let resolvedCsp: McpUiResourceCsp | undefined;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1002,24 +1002,35 @@ export function MCPAppsRenderer({
   // `cspDirectives: { "connect-src": ["https://app.mcpjam.com"] }`
   // re-adds the same-origin access the clamp is meant to make
   // non-bypassable. Strip any host-bearing token that resolves to the
-  // mcpjam.com namespace; CSP keyword tokens (`'unsafe-eval'`, hashes,
-  // nonces — quoted with `'…'`) and scheme-only tokens (`data:`, `blob:`)
-  // pass through unchanged.
+  // mcpjam.com namespace AND scheme-wide tokens that would otherwise
+  // cover MCPJam endpoints (`*`, `https:`, `http:`, `wss:`, `ws:`); CSP
+  // keyword tokens (`'unsafe-eval'`, hashes, nonces — quoted with `'…'`)
+  // and safe scheme-only tokens (`data:`, `blob:`, `about:`,
+  // `filesystem:`, `mediastream:`) pass through unchanged.
   const cspDirectivesEffective = useMemo(() => {
     if (!cspDirectivesPolicy) return cspDirectivesPolicy;
     if (!HOSTED_MODE) return cspDirectivesPolicy;
-    const isMcpjamOrigin = (token: string) => {
+    const isClampBypass = (token: string) => {
       if (token.startsWith("'")) return false; // CSP keyword
-      if (/^[a-z]+:$/.test(token)) return false; // scheme-only (data:, blob:)
-      // Match `mcpjam.com` as a host component: with optional subdomain,
-      // optional scheme prefix, optional port/path. Covers the same
-      // surface as MCPJAM_HOSTED_CLAMP_ORIGINS (`https://*.mcpjam.com`
+      // Scheme-wide tokens that cover MCPJam-namespace origins. The
+      // clamp's purpose is to keep MCPJam app/API endpoints unreachable
+      // from the iframe; `https:` (and friends) covers them just as
+      // effectively as naming `https://app.mcpjam.com` directly.
+      // Templates that need broad access should list specific origins
+      // (e.g. Claude lists `https://esm.sh`, `https://assets.claude.ai`).
+      if (token === "*") return true;
+      if (/^(https?|wss?):$/i.test(token)) return true;
+      // Other scheme-only tokens (data:, blob:, about:, filesystem:,
+      // mediastream:) don't reach MCPJam origins — let through.
+      if (/^[a-z]+:$/.test(token)) return false;
+      // Host-bearing token: match mcpjam.com as a host component,
+      // covering MCPJAM_HOSTED_CLAMP_ORIGINS (`https://*.mcpjam.com`
       // and `https://mcpjam.com`).
       return /(?:^|[/.@])mcpjam\.com(?:[:/]|$)/i.test(token);
     };
     const out: Record<string, string[]> = {};
     for (const [k, tokens] of Object.entries(cspDirectivesPolicy)) {
-      const clamped = tokens.filter((t) => !isMcpjamOrigin(t));
+      const clamped = tokens.filter((t) => !isClampBypass(t));
       if (clamped.length > 0) out[k] = clamped;
     }
     return Object.keys(out).length > 0 ? out : undefined;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1011,7 +1011,18 @@ export function MCPAppsRenderer({
     if (!cspDirectivesPolicy) return cspDirectivesPolicy;
     if (!HOSTED_MODE) return cspDirectivesPolicy;
     const isClampBypass = (token: string) => {
-      if (token.startsWith("'")) return false; // CSP keyword
+      // `'self'` is a clamp bypass in hosted mode. The proxy is served
+      // from the MCPJam origin and the inner srcdoc iframe carries
+      // `allow-same-origin` (so its document origin = parent's =
+      // MCPJam). `'self'` in the inner doc's CSP therefore resolves
+      // to the MCPJam app origin, which lets an untrusted widget
+      // fetch authenticated MCPJam endpoints — exactly what the clamp
+      // is meant to make unreachable. Templates that need actual
+      // same-origin access in production hosts (e.g. real Claude
+      // where `'self'` resolves to claude.ai) should list the host
+      // explicitly so the modeling is faithful in hosted mode too.
+      if (token === "'self'") return true;
+      if (token.startsWith("'")) return false; // other CSP keywords
       // Scheme-wide tokens that cover MCPJam-namespace origins. The
       // clamp's purpose is to keep MCPJam app/API endpoints unreachable
       // from the iframe; `https:` (and friends) covers them just as

--- a/mcpjam-inspector/client/src/components/client-config/ClientConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/client-config/ClientConfigEditor.tsx
@@ -941,16 +941,41 @@ function McpProfileCspDirectivesEditor({
   value: Record<string, string[]> | undefined;
   onChange: (next: Record<string, string[]> | undefined) => void;
 }) {
-  // Always work with a sorted-key array for stable rendering across keystrokes.
-  const rows = useMemo<Array<{ name: string; tokens: string }>>(() => {
-    if (!value) return [];
-    return Object.keys(value)
-      .sort()
-      .map((k) => ({
-        name: k,
-        tokens: (value[k] ?? []).join(", "),
-      }));
-  }, [value]);
+  const fromValue = useCallback(
+    (v: Record<string, string[]> | undefined) => {
+      if (!v) return [] as Array<{ name: string; tokens: string }>;
+      return Object.keys(v)
+        .sort()
+        .map((k) => ({ name: k, tokens: (v[k] ?? []).join(", ") }));
+    },
+    [],
+  );
+
+  // Local draft state including in-progress blank rows the user has
+  // added but not yet filled in. `commit` filters blanks out before
+  // calling onChange, so without a local buffer a freshly-added blank
+  // would round-trip back through `value` as nothing and disappear.
+  const [draftRows, setDraftRows] = useState<
+    Array<{ name: string; tokens: string }>
+  >(() => fromValue(value));
+
+  // Reconcile with external `value` changes (e.g. switching host
+  // configs from the parent). Tracks the last canonical key we synced
+  // to so our own commits don't trigger a re-seed that wipes blanks.
+  const valueKey = useMemo(() => JSON.stringify(value ?? null), [value]);
+  const lastSyncedKeyRef = useRef(valueKey);
+  useEffect(() => {
+    if (lastSyncedKeyRef.current === valueKey) return;
+    lastSyncedKeyRef.current = valueKey;
+    setDraftRows((prev) => {
+      const fromVal = fromValue(value);
+      // Preserve any blank/in-progress rows the user is still editing.
+      const blanks = prev.filter(
+        (r) => r.name.trim() === "" || r.tokens.trim() === "",
+      );
+      return [...fromVal, ...blanks];
+    });
+  }, [valueKey, value, fromValue]);
 
   const commit = useCallback(
     (next: Array<{ name: string; tokens: string }>) => {
@@ -965,7 +990,9 @@ function McpProfileCspDirectivesEditor({
         if (tokens.length === 0) continue;
         out[name] = tokens;
       }
-      onChange(Object.keys(out).length > 0 ? out : undefined);
+      const built = Object.keys(out).length > 0 ? out : undefined;
+      lastSyncedKeyRef.current = JSON.stringify(built ?? null);
+      onChange(built);
     },
     [onChange],
   );
@@ -974,17 +1001,25 @@ function McpProfileCspDirectivesEditor({
     idx: number,
     patch: Partial<{ name: string; tokens: string }>,
   ) => {
-    const next = rows.map((r, i) => (i === idx ? { ...r, ...patch } : r));
+    const next = draftRows.map((r, i) => (i === idx ? { ...r, ...patch } : r));
+    setDraftRows(next);
     commit(next);
   };
 
   const removeRow = (idx: number) => {
-    commit(rows.filter((_, i) => i !== idx));
+    const next = draftRows.filter((_, i) => i !== idx);
+    setDraftRows(next);
+    commit(next);
   };
 
   const addRow = () => {
-    commit([...rows, { name: "", tokens: "" }]);
+    // Blank rows live only in local draft state until the user types
+    // both a name and at least one token — `commit` filters blanks out,
+    // so committing here would no-op and the row would never appear.
+    setDraftRows((prev) => [...prev, { name: "", tokens: "" }]);
   };
+
+  const rows = draftRows;
 
   return (
     <div className="grid gap-2">
@@ -1197,12 +1232,44 @@ function McpProfileAllowFeaturesEditor({
     [],
   );
 
-  const rows = useMemo<Array<{ key: string; allowlist: string }>>(() => {
-    if (!value) return [];
-    return Object.keys(value)
-      .sort()
-      .map((k) => ({ key: k, allowlist: value[k] ?? "" }));
-  }, [value]);
+  const fromValue = useCallback(
+    (v: Record<string, string> | undefined) => {
+      if (!v) return [] as Array<{ key: string; allowlist: string }>;
+      return Object.keys(v)
+        .sort()
+        .map((k) => ({ key: k, allowlist: v[k] ?? "" }));
+    },
+    [],
+  );
+
+  // Local draft state including in-progress blanks. `commit` filters
+  // blank/spec-feature rows out before calling onChange, so without a
+  // local buffer a freshly-added blank row would round-trip back through
+  // `value` as nothing and disappear before the user can type anything.
+  const [draftRows, setDraftRows] = useState<
+    Array<{ key: string; allowlist: string }>
+  >(() => fromValue(value));
+
+  const valueKey = useMemo(() => JSON.stringify(value ?? null), [value]);
+  const lastSyncedKeyRef = useRef(valueKey);
+  useEffect(() => {
+    if (lastSyncedKeyRef.current === valueKey) return;
+    lastSyncedKeyRef.current = valueKey;
+    setDraftRows((prev) => {
+      const fromVal = fromValue(value);
+      // Preserve any rows the user is mid-edit (blank keys, blank
+      // allowlists, or spec-feature keys that haven't been corrected
+      // yet — the latter would otherwise vanish as soon as they were
+      // typed, losing the inline warning's teaching moment).
+      const inProgress = prev.filter(
+        (r) =>
+          r.key.trim() === "" ||
+          r.allowlist.trim() === "" ||
+          specFeatures.has(r.key.trim()),
+      );
+      return [...fromVal, ...inProgress];
+    });
+  }, [valueKey, value, fromValue, specFeatures]);
 
   const commit = useCallback(
     (next: Array<{ key: string; allowlist: string }>) => {
@@ -1217,7 +1284,9 @@ function McpProfileAllowFeaturesEditor({
         if (allowlist === "") continue;
         out[key] = allowlist;
       }
-      onChange(Object.keys(out).length > 0 ? out : undefined);
+      const built = Object.keys(out).length > 0 ? out : undefined;
+      lastSyncedKeyRef.current = JSON.stringify(built ?? null);
+      onChange(built);
     },
     [onChange, specFeatures],
   );
@@ -1226,17 +1295,25 @@ function McpProfileAllowFeaturesEditor({
     idx: number,
     patch: Partial<{ key: string; allowlist: string }>,
   ) => {
-    const next = rows.map((r, i) => (i === idx ? { ...r, ...patch } : r));
+    const next = draftRows.map((r, i) => (i === idx ? { ...r, ...patch } : r));
+    setDraftRows(next);
     commit(next);
   };
 
   const removeRow = (idx: number) => {
-    commit(rows.filter((_, i) => i !== idx));
+    const next = draftRows.filter((_, i) => i !== idx);
+    setDraftRows(next);
+    commit(next);
   };
 
   const addRow = () => {
-    commit([...rows, { key: "", allowlist: "*" }]);
+    // Blank rows live only in local draft state until the user types
+    // both a feature name and an allowlist — `commit` would filter them
+    // out, so committing here would no-op and the row would never appear.
+    setDraftRows((prev) => [...prev, { key: "", allowlist: "*" }]);
   };
+
+  const rows = draftRows;
 
   return (
     <div className="grid gap-2">

--- a/mcpjam-inspector/client/src/components/client-config/ClientConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/client-config/ClientConfigEditor.tsx
@@ -46,6 +46,7 @@ import {
   type HostConfigMcpProfileV1,
   type HostStyleId,
   DEFAULT_TEMPERATURE_V2,
+  SEP_1865_PERMISSION_FEATURES,
 } from "@/lib/client-config-v2";
 import {
   getHostCapabilitiesForStyle,
@@ -784,7 +785,9 @@ function McpProfileSandboxEditor({
       };
       const hasSandboxFields =
         nextSandbox.csp !== undefined ||
-        nextSandbox.permissions !== undefined;
+        nextSandbox.permissions !== undefined ||
+        nextSandbox.sandboxAttrs !== undefined ||
+        nextSandbox.allowFeatures !== undefined;
       // Preserve sibling apps fields (e.g. uiInitialize.hostInfo set by the
       // redesigned Apps Extension tab) — don't rewrite `apps` to only sandbox.
       const nextApps = { ...(base.apps ?? {}) };
@@ -849,6 +852,13 @@ function McpProfileSandboxEditor({
         }
       />
 
+      <McpProfileCspDirectivesEditor
+        value={csp?.cspDirectives}
+        onChange={(cspDirectives) =>
+          updateSandbox({ csp: { ...(csp ?? {}), cspDirectives } })
+        }
+      />
+
       <Separator />
 
       <div className="grid gap-2">
@@ -898,6 +908,392 @@ function McpProfileSandboxEditor({
           })
         }
       />
+
+      <Separator />
+
+      <McpProfileSandboxAttrsEditor
+        value={profile?.apps?.sandbox?.sandboxAttrs}
+        onChange={(sandboxAttrs) => updateSandbox({ sandboxAttrs })}
+      />
+
+      <McpProfileAllowFeaturesEditor
+        value={profile?.apps?.sandbox?.allowFeatures}
+        onChange={(allowFeatures) => updateSandbox({ allowFeatures })}
+      />
+    </div>
+  );
+}
+
+/**
+ * `cspDirectives` editor — inspector-only per-directive source-expression
+ * overrides emitted in the inner doc's `<meta http-equiv="Content-Security-
+ * Policy">`. Each row is a directive name + comma-separated tokens.
+ *
+ * Not part of SEP-1865 metadata; models what real hosts emit at the browser
+ * layer (e.g. `'unsafe-eval'`, `'wasm-unsafe-eval'`, `'strict-dynamic'`,
+ * nonces, hashes). Stored verbatim so future tokens land here without
+ * schema churn.
+ */
+function McpProfileCspDirectivesEditor({
+  value,
+  onChange,
+}: {
+  value: Record<string, string[]> | undefined;
+  onChange: (next: Record<string, string[]> | undefined) => void;
+}) {
+  // Always work with a sorted-key array for stable rendering across keystrokes.
+  const rows = useMemo<Array<{ name: string; tokens: string }>>(() => {
+    if (!value) return [];
+    return Object.keys(value)
+      .sort()
+      .map((k) => ({
+        name: k,
+        tokens: (value[k] ?? []).join(", "),
+      }));
+  }, [value]);
+
+  const commit = useCallback(
+    (next: Array<{ name: string; tokens: string }>) => {
+      const out: Record<string, string[]> = {};
+      for (const row of next) {
+        const name = row.name.trim();
+        if (name === "") continue;
+        const tokens = row.tokens
+          .split(",")
+          .map((t) => t.trim())
+          .filter((t) => t.length > 0);
+        if (tokens.length === 0) continue;
+        out[name] = tokens;
+      }
+      onChange(Object.keys(out).length > 0 ? out : undefined);
+    },
+    [onChange],
+  );
+
+  const updateRow = (
+    idx: number,
+    patch: Partial<{ name: string; tokens: string }>,
+  ) => {
+    const next = rows.map((r, i) => (i === idx ? { ...r, ...patch } : r));
+    commit(next);
+  };
+
+  const removeRow = (idx: number) => {
+    commit(rows.filter((_, i) => i !== idx));
+  };
+
+  const addRow = () => {
+    commit([...rows, { name: "", tokens: "" }]);
+  };
+
+  return (
+    <div className="grid gap-2">
+      <Label className="text-xs">cspDirectives (inspector-only)</Label>
+      <p className="text-xs text-muted-foreground">
+        Adds source expressions (e.g. <code>'unsafe-eval'</code>) to the inner
+        doc CSP. Not in SEP-1865 metadata; models what real hosts emit at the
+        browser layer. Comma-separate tokens; values stored verbatim so
+        nonces/hashes/<code>'strict-dynamic'</code> round-trip.
+      </p>
+      {rows.length === 0 ? (
+        <p className="text-xs italic text-muted-foreground">
+          No directive overrides.
+        </p>
+      ) : (
+        <div className="grid gap-1">
+          {rows.map((row, idx) => (
+            <div key={idx} className="grid grid-cols-[1fr_2fr_auto] gap-2">
+              <Input
+                value={row.name}
+                placeholder="script-src"
+                onChange={(e) => updateRow(idx, { name: e.target.value })}
+                list="csp-directive-name-suggestions"
+              />
+              <Input
+                value={row.tokens}
+                placeholder="'unsafe-eval', 'wasm-unsafe-eval'"
+                onChange={(e) => updateRow(idx, { tokens: e.target.value })}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => removeRow(idx)}
+              >
+                Remove
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+      <datalist id="csp-directive-name-suggestions">
+        <option value="script-src" />
+        <option value="style-src" />
+        <option value="img-src" />
+        <option value="connect-src" />
+        <option value="frame-src" />
+        <option value="media-src" />
+        <option value="font-src" />
+        <option value="base-uri" />
+        <option value="default-src" />
+      </datalist>
+      <Button type="button" variant="outline" size="sm" onClick={addRow}>
+        + add directive
+      </Button>
+    </div>
+  );
+}
+
+/**
+ * `sandboxAttrs` editor — inspector-only extra outer/inner iframe `sandbox=`
+ * tokens unioned with the mandatory `allow-scripts allow-same-origin`.
+ * Each known token is a toggle; a free-text input accepts unknown tokens
+ * for forward-compat.
+ */
+const KNOWN_SANDBOX_TOKENS = [
+  "allow-scripts",
+  "allow-same-origin",
+  "allow-forms",
+  "allow-popups",
+  "allow-popups-to-escape-sandbox",
+  "allow-modals",
+  "allow-downloads",
+  "allow-presentation",
+  "allow-pointer-lock",
+  "allow-top-navigation",
+  "allow-top-navigation-by-user-activation",
+  "allow-orientation-lock",
+] as const;
+const MANDATORY_SANDBOX_TOKENS = new Set<string>([
+  "allow-scripts",
+  "allow-same-origin",
+]);
+
+function McpProfileSandboxAttrsEditor({
+  value,
+  onChange,
+}: {
+  value: string[] | undefined;
+  onChange: (next: string[] | undefined) => void;
+}) {
+  const [customDraft, setCustomDraft] = useState("");
+  const active = useMemo(() => new Set(value ?? []), [value]);
+
+  const commit = (next: Set<string>) => {
+    const arr = Array.from(next)
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0 && !MANDATORY_SANDBOX_TOKENS.has(t));
+    arr.sort();
+    onChange(arr.length > 0 ? arr : undefined);
+  };
+
+  const toggle = (token: string) => {
+    if (MANDATORY_SANDBOX_TOKENS.has(token)) return;
+    const next = new Set(active);
+    if (next.has(token)) next.delete(token);
+    else next.add(token);
+    commit(next);
+  };
+
+  const addCustom = () => {
+    const t = customDraft.trim();
+    if (t.length === 0) return;
+    if (MANDATORY_SANDBOX_TOKENS.has(t)) {
+      setCustomDraft("");
+      return;
+    }
+    const next = new Set(active);
+    next.add(t);
+    commit(next);
+    setCustomDraft("");
+  };
+
+  // Anything in value that isn't in the known list — surface as a chip too
+  // so the user can see it and remove it.
+  const unknownTokens = Array.from(active).filter(
+    (t) => !KNOWN_SANDBOX_TOKENS.includes(t as (typeof KNOWN_SANDBOX_TOKENS)[number]),
+  );
+
+  return (
+    <div className="grid gap-2">
+      <Label className="text-xs">sandboxAttrs (inspector-only)</Label>
+      <p className="text-xs text-muted-foreground">
+        Extra <code>sandbox=</code> tokens beyond <code>allow-scripts</code> /
+        <code>allow-same-origin</code> which the spec mandates.
+      </p>
+      <div className="flex flex-wrap gap-1">
+        {KNOWN_SANDBOX_TOKENS.map((token) => {
+          const isMandatory = MANDATORY_SANDBOX_TOKENS.has(token);
+          const isActive = isMandatory || active.has(token);
+          return (
+            <button
+              key={token}
+              type="button"
+              onClick={() => toggle(token)}
+              disabled={isMandatory}
+              className={`rounded-md border px-2 py-0.5 text-xs ${
+                isActive
+                  ? "border-primary bg-primary/10 text-foreground"
+                  : "border-border/40 text-muted-foreground hover:bg-muted/40"
+              } ${isMandatory ? "cursor-not-allowed opacity-70" : "cursor-pointer"}`}
+              title={isMandatory ? "Spec-mandated (always on)" : token}
+            >
+              {token}
+              {isMandatory ? " (locked)" : ""}
+            </button>
+          );
+        })}
+        {unknownTokens.map((token) => (
+          <button
+            key={token}
+            type="button"
+            onClick={() => toggle(token)}
+            className="rounded-md border border-primary bg-primary/10 px-2 py-0.5 text-xs"
+            title={token}
+          >
+            {token} ×
+          </button>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <Input
+          value={customDraft}
+          placeholder="custom token"
+          onChange={(e) => setCustomDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              addCustom();
+            }
+          }}
+        />
+        <Button type="button" variant="outline" size="sm" onClick={addCustom}>
+          Add
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * `allowFeatures` editor — inspector-only extra Permissions Policy entries
+ * appended to outer/inner iframe `allow=`. Keys are RAW kebab Permissions
+ * Policy tokens; values are allowlist strings.
+ *
+ * The 4 spec features (camera / microphone / geolocation / clipboard-write)
+ * live in the Permissions section above and cannot be added here — entering
+ * them shows an inline warning and the canonicalizer drops them on save as
+ * a defense-in-depth safeguard.
+ */
+function McpProfileAllowFeaturesEditor({
+  value,
+  onChange,
+}: {
+  value: Record<string, string> | undefined;
+  onChange: (next: Record<string, string> | undefined) => void;
+}) {
+  const specFeatures = useMemo(
+    () => new Set<string>(SEP_1865_PERMISSION_FEATURES),
+    [],
+  );
+
+  const rows = useMemo<Array<{ key: string; allowlist: string }>>(() => {
+    if (!value) return [];
+    return Object.keys(value)
+      .sort()
+      .map((k) => ({ key: k, allowlist: value[k] ?? "" }));
+  }, [value]);
+
+  const commit = useCallback(
+    (next: Array<{ key: string; allowlist: string }>) => {
+      const out: Record<string, string> = {};
+      for (const row of next) {
+        const key = row.key.trim();
+        if (key === "") continue;
+        // Defense in depth — the canonicalizer drops these too, but we
+        // refuse to commit them locally so the warning has teeth.
+        if (specFeatures.has(key)) continue;
+        const allowlist = row.allowlist.trim();
+        if (allowlist === "") continue;
+        out[key] = allowlist;
+      }
+      onChange(Object.keys(out).length > 0 ? out : undefined);
+    },
+    [onChange, specFeatures],
+  );
+
+  const updateRow = (
+    idx: number,
+    patch: Partial<{ key: string; allowlist: string }>,
+  ) => {
+    const next = rows.map((r, i) => (i === idx ? { ...r, ...patch } : r));
+    commit(next);
+  };
+
+  const removeRow = (idx: number) => {
+    commit(rows.filter((_, i) => i !== idx));
+  };
+
+  const addRow = () => {
+    commit([...rows, { key: "", allowlist: "*" }]);
+  };
+
+  return (
+    <div className="grid gap-2">
+      <Label className="text-xs">allowFeatures (inspector-only)</Label>
+      <p className="text-xs text-muted-foreground">
+        Non-spec Permissions Policy features (e.g. <code>fullscreen</code>,
+        <code>web-share</code>). The 4 spec features (<code>camera</code>,
+        <code>microphone</code>, <code>geolocation</code>,
+        <code>clipboard-write</code>) live in Permissions above and cannot
+        be added here.
+      </p>
+      {rows.length === 0 ? (
+        <p className="text-xs italic text-muted-foreground">
+          No extra features.
+        </p>
+      ) : (
+        <div className="grid gap-1">
+          {rows.map((row, idx) => {
+            const isSpec = specFeatures.has(row.key.trim());
+            return (
+              <div key={idx} className="grid gap-1">
+                <div className="grid grid-cols-[1fr_1fr_auto] gap-2">
+                  <Input
+                    value={row.key}
+                    placeholder="fullscreen"
+                    onChange={(e) => updateRow(idx, { key: e.target.value })}
+                  />
+                  <Input
+                    value={row.allowlist}
+                    placeholder="*"
+                    onChange={(e) =>
+                      updateRow(idx, { allowlist: e.target.value })
+                    }
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => removeRow(idx)}
+                  >
+                    Remove
+                  </Button>
+                </div>
+                {isSpec ? (
+                  <p className="text-xs text-destructive">
+                    Use Permissions above for spec features — this row will be
+                    dropped on save.
+                  </p>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      )}
+      <Button type="button" variant="outline" size="sm" onClick={addRow}>
+        + add feature
+      </Button>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/client-config/ClientConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/client-config/ClientConfigEditor.tsx
@@ -1112,6 +1112,13 @@ function McpProfileSandboxAttrsEditor({
   onChange: (next: string[] | undefined) => void;
 }) {
   const [customDraft, setCustomDraft] = useState("");
+  // `value === undefined` (no profile opinion) vs `value === []` (explicit
+  // "spec-minimum only") are SEMANTICALLY DIFFERENT at the runtime layer:
+  // the renderer treats undefined as "fall back to the legacy permissive
+  // baseline" and any array (including empty) as "the profile is
+  // authoritative — use spec-mandated tokens plus exactly these." The
+  // toggle below is the user-facing affordance for that opt-in.
+  const isEnabled = Array.isArray(value);
   const active = useMemo(() => new Set(value ?? []), [value]);
 
   const commit = (next: Set<string>) => {
@@ -1119,10 +1126,27 @@ function McpProfileSandboxAttrsEditor({
       .map((t) => t.trim())
       .filter((t) => t.length > 0 && !MANDATORY_SANDBOX_TOKENS.has(t));
     arr.sort();
-    onChange(arr.length > 0 ? arr : undefined);
+    // Don't collapse empty → undefined. Once the user has opted in, an
+    // empty array IS the stricter "spec-minimum only" host model and
+    // must round-trip as `[]`.
+    onChange(arr);
+  };
+
+  const setEnabled = (enabled: boolean) => {
+    if (enabled === isEnabled) return;
+    if (enabled) {
+      // Opt in. Seed with any tokens that were already on `value` (would
+      // only happen if value was [...] before, but isEnabled would be true
+      // already — keeping the branch defensive).
+      onChange(Array.from(active).sort());
+    } else {
+      // Opt out → revert to legacy permissive default.
+      onChange(undefined);
+    }
   };
 
   const toggle = (token: string) => {
+    if (!isEnabled) return;
     if (MANDATORY_SANDBOX_TOKENS.has(token)) return;
     const next = new Set(active);
     if (next.has(token)) next.delete(token);
@@ -1131,6 +1155,7 @@ function McpProfileSandboxAttrsEditor({
   };
 
   const addCustom = () => {
+    if (!isEnabled) return;
     const t = customDraft.trim();
     if (t.length === 0) return;
     if (MANDATORY_SANDBOX_TOKENS.has(t)) {
@@ -1151,21 +1176,36 @@ function McpProfileSandboxAttrsEditor({
 
   return (
     <div className="grid gap-2">
-      <Label className="text-xs">sandboxAttrs (inspector-only)</Label>
+      <div className="flex items-center justify-between">
+        <Label className="text-xs">sandboxAttrs (inspector-only)</Label>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">
+            Model host sandbox tokens
+          </span>
+          <Switch
+            checked={isEnabled}
+            onCheckedChange={setEnabled}
+            aria-label="Model host sandbox tokens"
+          />
+        </div>
+      </div>
       <p className="text-xs text-muted-foreground">
-        Extra <code>sandbox=</code> tokens beyond <code>allow-scripts</code> /
-        <code>allow-same-origin</code> which the spec mandates.
+        {isEnabled
+          ? "Profile is authoritative: the iframe gets allow-scripts / allow-same-origin (spec-mandated) plus exactly the tokens checked below. Leave everything off to model a host that emits the spec minimum only."
+          : "Using the inspector's legacy permissive sandbox default. Toggle on to model the real host's emitted sandbox= tokens — empty = spec minimum only."}
       </p>
-      <div className="flex flex-wrap gap-1">
+      <div
+        className={`flex flex-wrap gap-1 ${isEnabled ? "" : "opacity-50 pointer-events-none"}`}
+      >
         {KNOWN_SANDBOX_TOKENS.map((token) => {
           const isMandatory = MANDATORY_SANDBOX_TOKENS.has(token);
-          const isActive = isMandatory || active.has(token);
+          const isActive = isEnabled && (isMandatory || active.has(token));
           return (
             <button
               key={token}
               type="button"
               onClick={() => toggle(token)}
-              disabled={isMandatory}
+              disabled={isMandatory || !isEnabled}
               className={`rounded-md border px-2 py-0.5 text-xs ${
                 isActive
                   ? "border-primary bg-primary/10 text-foreground"
@@ -1190,10 +1230,13 @@ function McpProfileSandboxAttrsEditor({
           </button>
         ))}
       </div>
-      <div className="flex gap-2">
+      <div
+        className={`flex gap-2 ${isEnabled ? "" : "opacity-50 pointer-events-none"}`}
+      >
         <Input
           value={customDraft}
           placeholder="custom token"
+          disabled={!isEnabled}
           onChange={(e) => setCustomDraft(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter") {
@@ -1202,7 +1245,13 @@ function McpProfileSandboxAttrsEditor({
             }
           }}
         />
-        <Button type="button" variant="outline" size="sm" onClick={addCustom}>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!isEnabled}
+          onClick={addCustom}
+        >
           Add
         </Button>
       </div>

--- a/mcpjam-inspector/client/src/components/client-config/ClientConfigEditor.tsx
+++ b/mcpjam-inspector/client/src/components/client-config/ClientConfigEditor.tsx
@@ -1320,6 +1320,15 @@ function McpProfileAllowFeaturesEditor({
     });
   }, [valueKey, value, fromValue, specFeatures]);
 
+  // Same `undefined` vs `{}` semantic as sandboxAttrs above: the
+  // renderer treats `allowFeatures === undefined` as the legacy fallback
+  // (re-adds `local-network-access *` / `midi *`); any Record value
+  // (including the empty {}) is the authoritative profile model and
+  // drops those legacy defaults. The toggle below is the explicit opt-in
+  // — without it, removing the last row collapsed `{}` to `undefined`
+  // and silently flipped a stricter-host profile back to permissive.
+  const isEnabled = value !== undefined;
+
   const commit = useCallback(
     (next: Array<{ key: string; allowlist: string }>) => {
       const out: Record<string, string> = {};
@@ -1333,29 +1342,44 @@ function McpProfileAllowFeaturesEditor({
         if (allowlist === "") continue;
         out[key] = allowlist;
       }
-      const built = Object.keys(out).length > 0 ? out : undefined;
-      lastSyncedKeyRef.current = JSON.stringify(built ?? null);
-      onChange(built);
+      // Don't collapse empty → undefined. Once the user has opted in,
+      // an empty record IS the stricter "spec-features-only" host model
+      // and must round-trip as `{}`.
+      lastSyncedKeyRef.current = JSON.stringify(out);
+      onChange(out);
     },
     [onChange, specFeatures],
   );
+
+  const setEnabled = (enabled: boolean) => {
+    if (enabled === isEnabled) return;
+    if (enabled) {
+      onChange({});
+    } else {
+      // Opt out → revert to legacy permissive default.
+      onChange(undefined);
+    }
+  };
 
   const updateRow = (
     idx: number,
     patch: Partial<{ key: string; allowlist: string }>,
   ) => {
+    if (!isEnabled) return;
     const next = draftRows.map((r, i) => (i === idx ? { ...r, ...patch } : r));
     setDraftRows(next);
     commit(next);
   };
 
   const removeRow = (idx: number) => {
+    if (!isEnabled) return;
     const next = draftRows.filter((_, i) => i !== idx);
     setDraftRows(next);
     commit(next);
   };
 
   const addRow = () => {
+    if (!isEnabled) return;
     // Blank rows live only in local draft state until the user types
     // both a feature name and an allowlist — `commit` would filter them
     // out, so committing here would no-op and the row would never appear.
@@ -1366,60 +1390,81 @@ function McpProfileAllowFeaturesEditor({
 
   return (
     <div className="grid gap-2">
-      <Label className="text-xs">allowFeatures (inspector-only)</Label>
-      <p className="text-xs text-muted-foreground">
-        Non-spec Permissions Policy features (e.g. <code>fullscreen</code>,
-        <code>web-share</code>). The 4 spec features (<code>camera</code>,
-        <code>microphone</code>, <code>geolocation</code>,
-        <code>clipboard-write</code>) live in Permissions above and cannot
-        be added here.
-      </p>
-      {rows.length === 0 ? (
-        <p className="text-xs italic text-muted-foreground">
-          No extra features.
-        </p>
-      ) : (
-        <div className="grid gap-1">
-          {rows.map((row, idx) => {
-            const isSpec = specFeatures.has(row.key.trim());
-            return (
-              <div key={idx} className="grid gap-1">
-                <div className="grid grid-cols-[1fr_1fr_auto] gap-2">
-                  <Input
-                    value={row.key}
-                    placeholder="fullscreen"
-                    onChange={(e) => updateRow(idx, { key: e.target.value })}
-                  />
-                  <Input
-                    value={row.allowlist}
-                    placeholder="*"
-                    onChange={(e) =>
-                      updateRow(idx, { allowlist: e.target.value })
-                    }
-                  />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => removeRow(idx)}
-                  >
-                    Remove
-                  </Button>
-                </div>
-                {isSpec ? (
-                  <p className="text-xs text-destructive">
-                    Use Permissions above for spec features — this row will be
-                    dropped on save.
-                  </p>
-                ) : null}
-              </div>
-            );
-          })}
+      <div className="flex items-center justify-between">
+        <Label className="text-xs">allowFeatures (inspector-only)</Label>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">
+            Model host allow features
+          </span>
+          <Switch
+            checked={isEnabled}
+            onCheckedChange={setEnabled}
+            aria-label="Model host allow features"
+          />
         </div>
-      )}
-      <Button type="button" variant="outline" size="sm" onClick={addRow}>
-        + add feature
-      </Button>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {isEnabled
+          ? "Profile is authoritative: the outer iframe's allow= is the 4 spec permissions (above) plus exactly the features listed below. Leave empty to model a host that grants only the spec features."
+          : "Using the inspector's legacy outer-iframe allow= default (adds local-network-access / midi on top of spec permissions). Toggle on to model the real host's emitted allow= — empty = spec permissions only."}
+      </p>
+      <div className={isEnabled ? "" : "opacity-50 pointer-events-none"}>
+        {rows.length === 0 ? (
+          <p className="text-xs italic text-muted-foreground">
+            No extra features.
+          </p>
+        ) : (
+          <div className="grid gap-1">
+            {rows.map((row, idx) => {
+              const isSpec = specFeatures.has(row.key.trim());
+              return (
+                <div key={idx} className="grid gap-1">
+                  <div className="grid grid-cols-[1fr_1fr_auto] gap-2">
+                    <Input
+                      value={row.key}
+                      placeholder="fullscreen"
+                      disabled={!isEnabled}
+                      onChange={(e) => updateRow(idx, { key: e.target.value })}
+                    />
+                    <Input
+                      value={row.allowlist}
+                      placeholder="*"
+                      disabled={!isEnabled}
+                      onChange={(e) =>
+                        updateRow(idx, { allowlist: e.target.value })
+                      }
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      disabled={!isEnabled}
+                      onClick={() => removeRow(idx)}
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                  {isSpec ? (
+                    <p className="text-xs text-destructive">
+                      Use Permissions above for spec features — this row will be
+                      dropped on save.
+                    </p>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        )}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!isEnabled}
+          onClick={addRow}
+        >
+          + add feature
+        </Button>
+      </div>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
@@ -395,61 +395,55 @@ function SandboxConfigCell({
 }) {
   const displayValue =
     row.summary && row.summary !== "—" ? row.summary : semanticAbsence(row.subKey);
+  // Per-directive token chips intentionally NOT rendered inline. For rows
+  // like cspDirectives with 10+ directives × multiple tokens each, an
+  // always-expanded chip list overwhelms the matrix and pushes downstream
+  // sections (View iframe, Servers) off-screen. The row's summary
+  // ("10 directives · 25 tokens") conveys cardinality at a glance; the
+  // structured editor in ClientConfigEditor.tsx is where the per-directive
+  // detail belongs. We surface the breakdown as a `title=` tooltip on the
+  // qualifier so power users can hover without losing the layout.
   const directives = row.directives ?? [];
+  const directivesTooltip =
+    directives.length > 0
+      ? directives
+          .map((d) => `${d.label}: ${d.domains.join(" ")}`)
+          .join("\n")
+      : undefined;
   return (
-    <div
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
       className={cn(
-        "hp-sb-cell",
-        directives.length > 0 && "hp-sb-cell--with-directives",
+        "hp-sb-row",
+        selected && "hp-sb-row--selected",
+        row.severity === "danger" && "hp-sb-row--danger",
+        row.severity === "warn" && "hp-sb-row--warn",
+        row.isChanged && "host-matrix-changed",
       )}
     >
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onClick();
-        }}
+      <span className="hp-sb-key">{row.label}</span>
+      <span
         className={cn(
-          "hp-sb-row",
-          selected && "hp-sb-row--selected",
-          row.severity === "danger" && "hp-sb-row--danger",
-          row.severity === "warn" && "hp-sb-row--warn",
-          row.isChanged && "host-matrix-changed",
+          "hp-sb-value",
+          row.summary === "—" && "hp-sb-value--italic",
         )}
+        title={directivesTooltip ?? row.summary}
       >
-        <span className="hp-sb-key">{row.label}</span>
+        {displayValue}
+      </span>
+      {row.qualifier ? (
         <span
-          className={cn(
-            "hp-sb-value",
-            row.summary === "—" && "hp-sb-value--italic",
-          )}
-          title={row.summary}
+          className="hp-sb-qual"
+          title={directivesTooltip ?? row.qualifier}
         >
-          {displayValue}
+          {row.qualifier}
         </span>
-        {row.qualifier ? (
-          <span className="hp-sb-qual" title={row.qualifier}>
-            {row.qualifier}
-          </span>
-        ) : null}
-      </button>
-      {directives.length > 0 ? (
-        <ul className="hp-sb-directives" aria-label={`${row.label} directives`}>
-          {directives.map((d) => (
-            <li key={d.key} className="hp-sb-directive">
-              <span className="hp-sb-directive-label">{d.label}</span>
-              <span className="hp-sb-directive-domains">
-                {d.domains.map((domain) => (
-                  <span key={domain} className="hp-sb-directive-domain">
-                    {domain}
-                  </span>
-                ))}
-              </span>
-            </li>
-          ))}
-        </ul>
       ) : null}
-    </div>
+    </button>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
@@ -399,7 +399,7 @@ function SandboxConfigCell({
   // like cspDirectives with 10+ directives × multiple tokens each, an
   // always-expanded chip list overwhelms the matrix and pushes downstream
   // sections (View iframe, Servers) off-screen. The row's summary
-  // ("10 directives · 25 tokens") conveys cardinality at a glance; the
+  // ("10 directives · 25 source expressions") conveys cardinality at a glance; the
   // structured editor in ClientConfigEditor.tsx is where the per-directive
   // detail belongs. We surface the breakdown as a `title=` tooltip on the
   // qualifier so power users can hover without losing the layout.
@@ -426,23 +426,25 @@ function SandboxConfigCell({
       )}
     >
       <span className="hp-sb-key">{row.label}</span>
-      <span
-        className={cn(
-          "hp-sb-value",
-          row.summary === "—" && "hp-sb-value--italic",
-        )}
-        title={directivesTooltip ?? row.summary}
-      >
-        {displayValue}
-      </span>
-      {row.qualifier ? (
+      <span className="hp-sb-value-line">
         <span
-          className="hp-sb-qual"
-          title={directivesTooltip ?? row.qualifier}
+          className={cn(
+            "hp-sb-value",
+            row.summary === "—" && "hp-sb-value--italic",
+          )}
+          title={directivesTooltip ?? row.summary}
         >
-          {row.qualifier}
+          {displayValue}
         </span>
-      ) : null}
+        {row.qualifier ? (
+          <span
+            className="hp-sb-qual"
+            title={directivesTooltip ?? row.qualifier}
+          >
+            {row.qualifier}
+          </span>
+        ) : null}
+      </span>
     </button>
   );
 }
@@ -740,11 +742,10 @@ const PAPER_STYLES = `
   gap: 6px 18px;
 }
 .host-paper-card .hp-sb-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
-  gap: 8px;
-  align-items: baseline;
-  padding: 5px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 6px 8px;
   border-radius: 8px;
   border: 0;
   background: transparent;
@@ -754,6 +755,7 @@ const PAPER_STYLES = `
   color: var(--hp-sandbox-ink);
   border-bottom: 1px dashed var(--hp-sandbox-hairline);
   transition: background 120ms ease;
+  min-width: 0;
 }
 .host-paper-card .hp-sb-row:hover { background: var(--hp-sandbox-row-hover); }
 .host-paper-card .hp-sb-row--selected { background: var(--hp-sandbox-row-selected); }
@@ -774,12 +776,22 @@ const PAPER_STYLES = `
   font-family: ui-monospace, "JetBrains Mono", monospace;
   font-size: 11.5px;
 }
+.host-paper-card .hp-sb-value-line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 8px;
+  min-width: 0;
+}
 .host-paper-card .hp-sb-value {
-  text-align: right;
+  text-align: left;
   font-family: ui-monospace, "JetBrains Mono", monospace;
   font-size: 11.5px;
   color: var(--hp-sandbox-ink);
   font-weight: 500;
+  min-width: 0;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 .host-paper-card .hp-sb-value--italic {
   font-style: italic;
@@ -789,14 +801,11 @@ const PAPER_STYLES = `
   font-size: 12.5px;
 }
 .host-paper-card .hp-sb-qual {
-  text-align: right;
+  text-align: left;
   font-family: ui-monospace, "JetBrains Mono", monospace;
   font-size: 10.5px;
   color: var(--hp-sandbox-sub);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 120px;
+  flex: 0 0 auto;
 }
 
 /* === View nested-nested frame === */

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
@@ -458,9 +458,10 @@ function SandboxConfigCell({
  * reader sees "default" / "none granted" instead of an em-dash that
  * could be confused with "unknown".
  *
- * Note: `restrictTo` is not listed here — canvasBuilder skips the row
- * entirely when restrictTo is empty (the safe default), so this helper
- * is only called for `mode` and `permissions`.
+ * Note: `restrictTo` / `cspDirectives` / `sandboxAttrs` / `allowFeatures`
+ * are not listed here — canvasBuilder skips those rows entirely when at
+ * the safe default, so this helper is only called for `mode` and
+ * `permissions`.
  */
 function semanticAbsence(key: SandboxConfigNodeData["subKey"]): string {
   switch (key) {
@@ -471,8 +472,11 @@ function semanticAbsence(key: SandboxConfigNodeData["subKey"]): string {
     case "mode":
       return "default";
     case "restrictTo":
-      // Unreachable — canvasBuilder drops the row when restrictTo is
-      // empty. Kept for type exhaustiveness.
+    case "cspDirectives":
+    case "sandboxAttrs":
+    case "allowFeatures":
+      // Unreachable — canvasBuilder drops these rows when they're at the
+      // safe default. Kept for type exhaustiveness.
       return "";
   }
 }

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/__tests__/canvasBuilder.test.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/__tests__/canvasBuilder.test.ts
@@ -156,12 +156,12 @@ describe("buildRedesignedHostCanvas", () => {
 });
 
 describe("buildRedesignedHostCanvas — sandbox config rows", () => {
-  it("emits only the permissions row when mode is 'declared' and restrictTo is empty — the universal safe default doesn't generate noise rows", () => {
-    // Both mode='declared' and empty restrictTo are the spec-aligned
-    // defaults (trust the view's CSP, narrow nothing). Surfacing them
-    // as rows would just confirm "safe default in effect" on every
-    // host. permissions stays because it's always informative (lists
-    // granted spec keys, "—" when nothing's granted).
+  it("emits only the permissions row when every other slice is at the safe default — no noise rows", () => {
+    // mode='declared', empty restrictTo / cspDirectives / sandboxAttrs /
+    // allowFeatures are all spec-aligned safe defaults. Surfacing them as
+    // rows would just confirm "safe default in effect" on every host.
+    // permissions stays because it's always informative (lists granted spec
+    // keys, "—" when nothing's granted).
     const data = matrixData(buildVm());
     expect(data.sandbox.map((s) => s.subKey)).toEqual(["permissions"]);
   });
@@ -322,6 +322,90 @@ describe("buildRedesignedHostCanvas — sandbox config rows", () => {
     );
     expect(row?.summary).toBe("—");
     expect(row?.qualifier).toBeNull();
+  });
+
+  it("omits the new inspector-only rows entirely when at the safe default", () => {
+    // cspDirectives / sandboxAttrs / allowFeatures all follow the same
+    // "skip at default" pattern as mode / restrictTo — surfacing them as
+    // "—" rows would just confirm "safe default in effect" on every host.
+    const data = matrixData(buildVm());
+    for (const key of ["cspDirectives", "sandboxAttrs", "allowFeatures"]) {
+      const row = data.sandbox.find((s) => s.subKey === key);
+      expect(row).toBeUndefined();
+    }
+  });
+
+  it("tints cspDirectives as DANGER when any value contains 'unsafe-eval'", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.mcpProfile = {
+      profileVersion: 1,
+      apps: {
+        sandbox: {
+          csp: {
+            cspDirectives: {
+              "script-src": ["'unsafe-eval'", "'wasm-unsafe-eval'"],
+            },
+          },
+        },
+      },
+    };
+    const row = matrixData(buildVm({ draft })).sandbox.find(
+      (s) => s.subKey === "cspDirectives",
+    );
+    expect(row?.severity).toBe("danger");
+    expect(row?.summary).toBe("1 directive");
+  });
+
+  it("keeps cspDirectives NEUTRAL when only safe tokens are present", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.mcpProfile = {
+      profileVersion: 1,
+      apps: {
+        sandbox: {
+          csp: {
+            cspDirectives: {
+              "img-src": ["blob:", "data:"],
+              "connect-src": ["https://api.example.com"],
+            },
+          },
+        },
+      },
+    };
+    const row = matrixData(buildVm({ draft })).sandbox.find(
+      (s) => s.subKey === "cspDirectives",
+    );
+    expect(row?.severity).toBe("neutral");
+    expect(row?.summary).toBe("2 directives");
+  });
+
+  it("summarizes sandboxAttrs as a neutral list", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.mcpProfile = {
+      profileVersion: 1,
+      apps: {
+        sandbox: { sandboxAttrs: ["allow-forms", "allow-modals"] },
+      },
+    };
+    const row = matrixData(buildVm({ draft })).sandbox.find(
+      (s) => s.subKey === "sandboxAttrs",
+    );
+    expect(row?.severity).toBe("neutral");
+    expect(row?.summary).toBe("allow-forms, allow-modals");
+  });
+
+  it("summarizes allowFeatures as a neutral key:value list", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.mcpProfile = {
+      profileVersion: 1,
+      apps: {
+        sandbox: { allowFeatures: { fullscreen: "*" } },
+      },
+    };
+    const row = matrixData(buildVm({ draft })).sandbox.find(
+      (s) => s.subKey === "allowFeatures",
+    );
+    expect(row?.severity).toBe("neutral");
+    expect(row?.summary).toBe("fullscreen: *");
   });
 
   it("flags a sandbox row as changed when the previous host had different config", () => {

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/__tests__/canvasBuilder.test.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/__tests__/canvasBuilder.test.ts
@@ -451,7 +451,12 @@ describe("buildRedesignedHostCanvas — sandbox config rows", () => {
     expect(row?.summary).toBe("allow-forms, allow-modals");
   });
 
-  it("summarizes allowFeatures as a neutral key:value list", () => {
+  it("summarizes allowFeatures as a neutral key:value list on its own row", () => {
+    // `Permissions` (spec) and `Permissions Policy` (vendor extras) are
+    // separate rows because the spec only blesses the 4 features under
+    // `permissions.allow`; everything else is host-specific and may not
+    // survive a host swap. The split mirrors that boundary so readers can
+    // tell spec-portable from vendor-extra at a glance.
     const draft = emptyHostConfigInputV2();
     draft.mcpProfile = {
       profileVersion: 1,
@@ -462,6 +467,7 @@ describe("buildRedesignedHostCanvas — sandbox config rows", () => {
     const row = matrixData(buildVm({ draft })).sandbox.find(
       (s) => s.subKey === "allowFeatures",
     );
+    expect(row?.label).toBe("Permissions Policy");
     expect(row?.severity).toBe("neutral");
     expect(row?.summary).toBe("fullscreen: *");
   });

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/__tests__/canvasBuilder.test.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/__tests__/canvasBuilder.test.ts
@@ -378,6 +378,64 @@ describe("buildRedesignedHostCanvas — sandbox config rows", () => {
     expect(row?.summary).toBe("2 directives");
   });
 
+  // Regression: `'unsafe-inline'` is part of the SEP-1865 restrictive
+  // baseline for script-src/style-src — every host has it. Treating it
+  // as a danger trigger would light up every populated cspDirectives
+  // row unavoidably. Only the tokens that re-enable script-execution
+  // loosening BEYOND the baseline (`'unsafe-eval'`,
+  // `'wasm-unsafe-eval'`, `'strict-dynamic'`) qualify as danger.
+  it("does NOT tint cspDirectives danger when only 'unsafe-inline' is present (baseline, not a deviation)", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.mcpProfile = {
+      profileVersion: 1,
+      apps: {
+        sandbox: {
+          csp: {
+            cspDirectives: {
+              "script-src": ["'unsafe-inline'"],
+              "style-src": ["'unsafe-inline'"],
+            },
+          },
+        },
+      },
+    };
+    const row = matrixData(buildVm({ draft })).sandbox.find(
+      (s) => s.subKey === "cspDirectives",
+    );
+    expect(row?.severity).toBe("neutral");
+  });
+
+  it("surfaces per-directive expansion on cspDirectives for matrix sub-rows", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.mcpProfile = {
+      profileVersion: 1,
+      apps: {
+        sandbox: {
+          csp: {
+            cspDirectives: {
+              "script-src": ["'unsafe-eval'", "'wasm-unsafe-eval'"],
+              "img-src": ["data:", "blob:"],
+            },
+          },
+        },
+      },
+    };
+    const row = matrixData(buildVm({ draft })).sandbox.find(
+      (s) => s.subKey === "cspDirectives",
+    );
+    // Reuses the existing `directives` field on SandboxConfigNodeData so the
+    // renderer's per-directive expansion (used for restrictTo today) works
+    // unchanged. Sorted by directive name for stable diffs across edits.
+    expect(row?.directives).toEqual([
+      { key: "img-src", label: "img-src", domains: ["data:", "blob:"] },
+      {
+        key: "script-src",
+        label: "script-src",
+        domains: ["'unsafe-eval'", "'wasm-unsafe-eval'"],
+      },
+    ]);
+  });
+
   it("summarizes sandboxAttrs as a neutral list", () => {
     const draft = emptyHostConfigInputV2();
     draft.mcpProfile = {

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
@@ -335,14 +335,99 @@ function buildSandboxConfig(
     severity: "neutral",
   };
 
-  // Stable order: mode, restrictTo, permissions. mode and restrictTo
-  // are conditional (skipped when at the safe default); permissions is
-  // always emitted so the row count reflects whatever currently
-  // deviates plus the always-on permissions baseline.
+  // cspDirectives — inspector-only per-directive source-expression overrides
+  // (e.g. `script-src` adds `'unsafe-eval'`). Sits next to restrictTo because
+  // both live under `csp` in the schema. Skipped when undefined/empty so the
+  // matrix stays quiet at the safe default — matches the mode/restrictTo
+  // pattern. When populated, tints `danger` if any token re-enables real
+  // script-execution loosening; else neutral.
+  const cspDirectives = csp?.cspDirectives;
+  const cspDirectivesKeys = cspDirectives ? Object.keys(cspDirectives) : [];
+  let cspDirectivesValueCount = 0;
+  let hasDangerousToken = false;
+  if (cspDirectives) {
+    for (const k of cspDirectivesKeys) {
+      const tokens = cspDirectives[k] ?? [];
+      cspDirectivesValueCount += tokens.length;
+      for (const t of tokens) {
+        if (
+          t === "'unsafe-eval'" ||
+          t === "'unsafe-inline'" ||
+          t === "'wasm-unsafe-eval'" ||
+          t === "'strict-dynamic'"
+        ) {
+          hasDangerousToken = true;
+        }
+      }
+    }
+  }
+  const cspDirectivesDescriptor: SandboxConfigDescriptor | null =
+    cspDirectivesKeys.length === 0
+      ? null
+      : {
+          subKey: "cspDirectives",
+          label: "cspDirectives",
+          summary: `${cspDirectivesKeys.length} ${
+            cspDirectivesKeys.length === 1 ? "directive" : "directives"
+          }`,
+          qualifier: `${cspDirectivesValueCount} ${
+            cspDirectivesValueCount === 1 ? "token" : "tokens"
+          }`,
+          severity: hasDangerousToken ? "danger" : "neutral",
+        };
+
+  // sandboxAttrs — extra outer/inner iframe `sandbox=` tokens beyond the
+  // spec mandatory `allow-scripts allow-same-origin`. Skipped at the safe
+  // default; neutral severity when populated (additive tokens are explicit
+  // user grants, not silent narrowing).
+  const sandboxAttrs = sandbox?.sandboxAttrs ?? [];
+  const sandboxAttrsDescriptor: SandboxConfigDescriptor | null =
+    sandboxAttrs.length === 0
+      ? null
+      : {
+          subKey: "sandboxAttrs",
+          label: "sandboxAttrs",
+          summary: sandboxAttrs.slice(0, 2).join(", "),
+          qualifier:
+            sandboxAttrs.length > 2 ? `+${sandboxAttrs.length - 2} more` : null,
+          severity: "neutral",
+        };
+
+  // allowFeatures — extra Permissions Policy entries beyond the 4 spec
+  // permissions. Skipped at the safe default; neutral severity when
+  // populated (explicit user grant).
+  const allowFeatures = sandbox?.allowFeatures ?? {};
+  const allowFeaturesKeys = Object.keys(allowFeatures);
+  allowFeaturesKeys.sort();
+  const allowFeaturesDescriptor: SandboxConfigDescriptor | null =
+    allowFeaturesKeys.length === 0
+      ? null
+      : {
+          subKey: "allowFeatures",
+          label: "allowFeatures",
+          summary: allowFeaturesKeys
+            .slice(0, 2)
+            .map((k) => `${k}: ${allowFeatures[k]}`)
+            .join(", "),
+          qualifier:
+            allowFeaturesKeys.length > 2
+              ? `+${allowFeaturesKeys.length - 2} more`
+              : null,
+          severity: "neutral",
+        };
+
+  // Stable row order: CSP family first (mode, restrictTo, cspDirectives),
+  // then permissions, then the iframe-attribute knobs at the bottom. Every
+  // row except permissions is conditional — skipped when at the safe
+  // default — so the row count reflects whatever currently deviates plus
+  // the always-on permissions baseline.
   const out: SandboxConfigDescriptor[] = [];
   if (modeDescriptor !== null) out.push(modeDescriptor);
   if (restrictDescriptor !== null) out.push(restrictDescriptor);
+  if (cspDirectivesDescriptor !== null) out.push(cspDirectivesDescriptor);
   out.push(permsDescriptor);
+  if (sandboxAttrsDescriptor !== null) out.push(sandboxAttrsDescriptor);
+  if (allowFeaturesDescriptor !== null) out.push(allowFeaturesDescriptor);
   return out;
 }
 

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
@@ -285,7 +285,7 @@ function buildSandboxConfig(
       ? null
       : {
           subKey: "mode",
-          label: "mode",
+          label: "CSP mode",
           summary: mode,
           qualifier: null,
           // "relaxed" opens the iframe up; "host-default" silently
@@ -306,20 +306,17 @@ function buildSandboxConfig(
       ? null
       : {
           subKey: "restrictTo",
-          label: "restrictTo",
+          label: "Allowed CSP domains",
           summary: `${restrict.total} domains`,
           qualifier: restrict.breakdown,
           severity: "danger",
           directives: describeCspDirectives(csp?.restrictTo),
         };
 
-  // Permissions: list explicitly granted spec keys (camera / microphone /
-  // geolocation / clipboardWrite per SEP-1865 §UIResourceMeta.permissions).
-  // SEP-1865 is allowlist-only — absence means "not granted." Only the
-  // granted list goes on the row; the inspector-internal `mode`
-  // (resource-declared / deny-all / custom) is a knob name, not spec
-  // terminology, so it stays out of the at-a-glance summary. Users who
-  // need the mode click through to the Apps Extension tab.
+  // Permissions: the 4 SEP-1865-blessed features under
+  // `permissions.allow` (camera / microphone / geolocation / clipboardWrite).
+  // Granted Y/N per the spec — no allowlist control surfaced; the host
+  // decides. Always emitted as the baseline row; "—" when none granted.
   const granted: string[] = [];
   if (perms?.allow) {
     for (const [name, on] of Object.entries(perms.allow)) {
@@ -329,7 +326,7 @@ function buildSandboxConfig(
   granted.sort();
   const permsDescriptor: SandboxConfigDescriptor = {
     subKey: "permissions",
-    label: "permissions",
+    label: "Permissions",
     summary: granted.length === 0 ? "—" : granted.join(", "),
     qualifier: null,
     severity: "neutral",
@@ -385,12 +382,12 @@ function buildSandboxConfig(
       ? null
       : {
           subKey: "cspDirectives",
-          label: "cspDirectives",
+          label: "CSP directive overrides",
           summary: `${cspDirectivesKeys.length} ${
             cspDirectivesKeys.length === 1 ? "directive" : "directives"
           }`,
-          qualifier: `${cspDirectivesValueCount} ${
-            cspDirectivesValueCount === 1 ? "token" : "tokens"
+          qualifier: `${cspDirectivesValueCount} source ${
+            cspDirectivesValueCount === 1 ? "expression" : "expressions"
           }`,
           severity: hasDangerousToken ? "danger" : "neutral",
           directives:
@@ -407,16 +404,18 @@ function buildSandboxConfig(
       ? null
       : {
           subKey: "sandboxAttrs",
-          label: "sandboxAttrs",
+          label: "Sandbox attributes",
           summary: sandboxAttrs.slice(0, 2).join(", "),
           qualifier:
             sandboxAttrs.length > 2 ? `+${sandboxAttrs.length - 2} more` : null,
           severity: "neutral",
         };
 
-  // allowFeatures — extra Permissions Policy entries beyond the 4 spec
-  // permissions. Skipped at the safe default; neutral severity when
-  // populated (explicit user grant).
+  // Permissions Policy: vendor extras from `allowFeatures` beyond the 4
+  // spec features. Carries a per-feature Permissions Policy allowlist
+  // value (e.g. `*`, `'self'`). Distinct row from `Permissions` because
+  // the spec only blesses the 4; everything else is host-specific and
+  // may not survive a host swap. Skipped at the safe default.
   const allowFeatures = sandbox?.allowFeatures ?? {};
   const allowFeaturesKeys = Object.keys(allowFeatures);
   allowFeaturesKeys.sort();
@@ -425,7 +424,7 @@ function buildSandboxConfig(
       ? null
       : {
           subKey: "allowFeatures",
-          label: "allowFeatures",
+          label: "Permissions Policy",
           summary: allowFeaturesKeys
             .slice(0, 2)
             .map((k) => `${k}: ${allowFeatures[k]}`)
@@ -438,10 +437,10 @@ function buildSandboxConfig(
         };
 
   // Stable row order: CSP family first (mode, restrictTo, cspDirectives),
-  // then permissions, then the iframe-attribute knobs at the bottom. Every
-  // row except permissions is conditional — skipped when at the safe
-  // default — so the row count reflects whatever currently deviates plus
-  // the always-on permissions baseline.
+  // then Permissions (spec), then the iframe sandbox-attribute knob, then
+  // Permissions Policy (vendor extras). Every row except Permissions is
+  // conditional — skipped when at the safe default — so the row count
+  // reflects whatever currently deviates plus the spec-permissions baseline.
   const out: SandboxConfigDescriptor[] = [];
   if (modeDescriptor !== null) out.push(modeDescriptor);
   if (restrictDescriptor !== null) out.push(restrictDescriptor);

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
@@ -350,9 +350,14 @@ function buildSandboxConfig(
       const tokens = cspDirectives[k] ?? [];
       cspDirectivesValueCount += tokens.length;
       for (const t of tokens) {
+        // `'unsafe-inline'` is INTENTIONALLY NOT a danger trigger — it's
+        // part of the SEP-1865 restrictive baseline for `script-src` /
+        // `style-src` (the proxy always includes it). Flagging it would
+        // light up every host's matrix unavoidably. The triggers below
+        // are the ones that re-enable real script-execution loosening
+        // beyond the spec default.
         if (
           t === "'unsafe-eval'" ||
-          t === "'unsafe-inline'" ||
           t === "'wasm-unsafe-eval'" ||
           t === "'strict-dynamic'"
         ) {
@@ -361,6 +366,20 @@ function buildSandboxConfig(
       }
     }
   }
+  // Build the per-directive expansion list. Reuses CspDirectiveDetail
+  // (same `{ key, label, domains }` shape as restrictTo's expansion);
+  // the `domains` field semantically carries source-expression tokens
+  // and/or origins. Sorted by directive name for stability across edits.
+  const cspDirectivesDetails: CspDirectiveDetail[] =
+    cspDirectives !== undefined
+      ? [...cspDirectivesKeys].sort().flatMap((k) => {
+          const tokens = cspDirectives[k] ?? [];
+          return tokens.length > 0
+            ? [{ key: k, label: k, domains: [...tokens] }]
+            : [];
+        })
+      : [];
+
   const cspDirectivesDescriptor: SandboxConfigDescriptor | null =
     cspDirectivesKeys.length === 0
       ? null
@@ -374,6 +393,8 @@ function buildSandboxConfig(
             cspDirectivesValueCount === 1 ? "token" : "tokens"
           }`,
           severity: hasDangerousToken ? "danger" : "neutral",
+          directives:
+            cspDirectivesDetails.length > 0 ? cspDirectivesDetails : undefined,
         };
 
   // sandboxAttrs — extra outer/inner iframe `sandbox=` tokens beyond the

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -18,27 +18,44 @@ interface AppsExtensionTabProps {
 }
 
 /**
- * User-facing JSON document. Shape matches SEP-1865 verbatim so an MCP App
- * developer can read it against the spec without translating inspector-
- * specific concepts. Key points:
+ * User-facing JSON document. The `sandbox` block configures the proxy
+ * iframe the inspector renders MCP App views in — one place to edit
+ * everything the inspector enforces at the iframe boundary, matching the
+ * "Sandbox proxy iframe" card in the matrix.
  *
- *  - `hostCapabilities` is the EFFECTIVE merged value (preset for the
- *    active hostStyle, overlaid with the user's `hostCapabilitiesOverride`
- *    when defined). On parse-back we diff against the preset to decide
- *    whether an override needs to be stored, so editing back to the
- *    preset's exact shape cleanly reverts to "no override" — the backend
- *    hashes that distinctly from an explicit `{}`.
+ * Spec-portable fields (will be advertised as `HostCapabilities.sandbox`
+ * to real MCP App views) keep their SEP-1865 names and positions verbatim:
  *
- *  - `hostCapabilities.sandbox` is the SPEC SHAPE — four allowlist arrays
- *    under `csp` (connectDomains, resourceDomains, frameDomains,
- *    baseUriDomains) and presence-flag objects under `permissions`
- *    (camera, microphone, geolocation, clipboardWrite). The inspector
- *    stores this as `mcpProfile.apps.sandbox.csp.restrictTo` /
- *    `permissions.allow`; we hoist it into spec position on serialize and
- *    lift it back on parse. Inspector-only knobs (`mode`, `extensions`)
- *    are intentionally not surfaced in this JSON — they aren't in the
- *    SEP and would confuse a developer reading the doc against the spec.
- *    They're preserved across edits.
+ *   sandbox.csp.connectDomains   ⟷ SEP-1865 HostCapabilities.sandbox.csp.connectDomains
+ *   sandbox.csp.resourceDomains  ⟷ SEP-1865 HostCapabilities.sandbox.csp.resourceDomains
+ *   sandbox.csp.frameDomains     ⟷ SEP-1865 HostCapabilities.sandbox.csp.frameDomains
+ *   sandbox.csp.baseUriDomains   ⟷ SEP-1865 HostCapabilities.sandbox.csp.baseUriDomains
+ *   sandbox.permissions          ⟷ SEP-1865 HostCapabilities.sandbox.permissions
+ *
+ * Inspector-only knobs (NOT in SEP-1865 — won't survive a host swap) are
+ * named after the HTML mechanism they drive on the proxy iframe:
+ *
+ *   sandbox.csp.directiveOverrides   per-directive CSP source-expression
+ *                                    overrides on the proxy iframe CSP
+ *   sandbox.iframeSandboxAttrs       extra tokens for the iframe `sandbox=`
+ *                                    attribute beyond the spec-required
+ *                                    `allow-scripts allow-same-origin`
+ *   sandbox.permissionsPolicy        Permissions Policy entries on the
+ *                                    iframe `allow=` attribute beyond the
+ *                                    4 SEP-blessed features
+ *
+ * Inspector-internal resolver fields (`mode`, `extensions`) stay out of
+ * the JSON entirely — they're owned by the structured editor and preserved
+ * across JSON edits.
+ *
+ * `hostCapabilities` is the EFFECTIVE merged value (preset + override).
+ * On parse-back we diff against the preset to decide whether to store an
+ * override, so editing back to the preset's exact shape cleanly reverts to
+ * "no override" — the backend hashes that distinctly from an explicit `{}`.
+ *
+ * Permissions use the spec presence-flag shape (`{ clipboardWrite: {} }`
+ * means granted; absence means not granted). Stored internally as a
+ * boolean map; converted at the JSON boundary.
  */
 type SpecSandboxCsp = {
   connectDomains?: string[];
@@ -59,15 +76,39 @@ type SpecSandboxPermissions = {
   geolocation?: Record<string, never>;
   clipboardWrite?: Record<string, never>;
 } & Record<string, unknown>;
-type SpecHostCapabilitiesSandbox = {
-  csp?: SpecSandboxCsp;
+
+type SandboxDocCsp = SpecSandboxCsp & {
+  /**
+   * Inspector-only: per-directive source-expression overrides on the
+   * proxy iframe CSP (e.g. `script-src: ["'unsafe-eval'"]`). NOT in
+   * SEP-1865. Sits under `csp` because that's the directive family it
+   * affects, but a real MCP App host won't see this.
+   */
+  directiveOverrides?: Record<string, string[]>;
+};
+
+type SandboxDoc = {
+  csp?: SandboxDocCsp;
   permissions?: SpecSandboxPermissions;
+  /**
+   * Inspector-only: extra tokens for the proxy iframe's HTML `sandbox=`
+   * attribute, on top of the spec-required `allow-scripts allow-same-origin`.
+   * NOT in SEP-1865.
+   */
+  iframeSandboxAttrs?: string[];
+  /**
+   * Inspector-only: Permissions Policy entries written to the proxy
+   * iframe's HTML `allow=` attribute, beyond the 4 SEP-blessed features in
+   * `permissions`. NOT in SEP-1865. May not survive a host swap.
+   */
+  permissionsPolicy?: Record<string, string>;
 };
 
 type AppsDoc = {
   extensions?: Record<string, unknown>;
   hostCapabilities?: Record<string, unknown>;
   hostContext: Record<string, unknown>;
+  sandbox?: SandboxDoc;
   uiInitialize?: {
     hostInfo?: Record<string, unknown>;
   };
@@ -78,32 +119,40 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 }
 
 /**
- * Build the spec-shaped `HostCapabilities.sandbox` from our internal
- * storage. We persist a richer policy (mode/restrictTo); the spec
- * only knows about the four domain allowlists and the four permission
- * presence-flags. `restrictTo` IS the spec's allowlist semantically —
- * "host MAY further restrict but MUST NOT allow undeclared domains" —
- * so we hoist it directly into spec position.
+ * Build the JSON `sandbox` block from internal policy storage. The four
+ * CSP allowlists are hoisted out of internal `csp.restrictTo` into spec
+ * position directly under `csp.{connectDomains, ...}` so a reader can map
+ * them straight to SEP-1865; inspector-only knobs are nested with names
+ * that telegraph their non-spec status.
  */
-function specSandboxFromPolicy(
+function sandboxFromPolicy(
   policy: NonNullable<HostConfigMcpProfileV1["apps"]>["sandbox"] | undefined,
-): SpecHostCapabilitiesSandbox | undefined {
+): SandboxDoc | undefined {
   if (!policy) return undefined;
-  const out: SpecHostCapabilitiesSandbox = {};
+  const out: SandboxDoc = {};
 
+  const cspBlock: SandboxDocCsp = {};
+  // Hoist restrictTo's allowlists into spec position. Semantically these
+  // ARE the spec's `HostCapabilities.sandbox.csp.{connectDomains, ...}` —
+  // "host MAY further restrict but MUST NOT allow undeclared domains."
   const restrict = policy.csp?.restrictTo;
   if (restrict) {
-    const csp: SpecSandboxCsp = {};
     if (restrict.connectDomains && restrict.connectDomains.length > 0)
-      csp.connectDomains = [...restrict.connectDomains];
+      cspBlock.connectDomains = [...restrict.connectDomains];
     if (restrict.resourceDomains && restrict.resourceDomains.length > 0)
-      csp.resourceDomains = [...restrict.resourceDomains];
+      cspBlock.resourceDomains = [...restrict.resourceDomains];
     if (restrict.frameDomains && restrict.frameDomains.length > 0)
-      csp.frameDomains = [...restrict.frameDomains];
+      cspBlock.frameDomains = [...restrict.frameDomains];
     if (restrict.baseUriDomains && restrict.baseUriDomains.length > 0)
-      csp.baseUriDomains = [...restrict.baseUriDomains];
-    if (Object.keys(csp).length > 0) out.csp = csp;
+      cspBlock.baseUriDomains = [...restrict.baseUriDomains];
   }
+  const directiveOverrides = policy.csp?.cspDirectives;
+  if (directiveOverrides && Object.keys(directiveOverrides).length > 0) {
+    const cd: Record<string, string[]> = {};
+    for (const [k, v] of Object.entries(directiveOverrides)) cd[k] = [...v];
+    cspBlock.directiveOverrides = cd;
+  }
+  if (Object.keys(cspBlock).length > 0) out.csp = cspBlock;
 
   const allow = policy.permissions?.allow;
   if (allow) {
@@ -120,6 +169,13 @@ function specSandboxFromPolicy(
     if (Object.keys(perms).length > 0) out.permissions = perms;
   }
 
+  if (policy.sandboxAttrs && policy.sandboxAttrs.length > 0) {
+    out.iframeSandboxAttrs = [...policy.sandboxAttrs];
+  }
+  if (policy.allowFeatures && Object.keys(policy.allowFeatures).length > 0) {
+    out.permissionsPolicy = { ...policy.allowFeatures };
+  }
+
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
@@ -130,50 +186,54 @@ type SandboxPolicyCsp = NonNullable<SandboxPolicy["csp"]>;
 type SandboxPolicyPerms = NonNullable<SandboxPolicy["permissions"]>;
 
 /**
- * Inverse of `specSandboxFromPolicy`. Reads the spec-shaped
- * `hostCapabilities.sandbox` block coming out of the JSON editor and
- * folds it into the inspector's richer policy shape, preserving prev's
- * inspector-only knobs (`mode`, `extensions`).
+ * Inverse of `sandboxFromPolicy`. Reads the unified `sandbox` block from
+ * the JSON editor and folds it into the inspector's richer policy shape,
+ * preserving prev's inspector-internal knobs (`mode`, `extensions`) which
+ * aren't surfaced in the JSON.
+ *
+ * `incomingPresent: false` means the `sandbox` key wasn't in the JSON at
+ * all → don't touch the stored policy. A present (even empty) block means
+ * the user is asserting intent; we replace each surfaced field with the
+ * parsed value (or clear it when absent under the present block).
  */
-function liftSpecSandboxIntoPolicy(args: {
+function liftSandboxIntoPolicy(args: {
   incomingPresent: boolean;
-  incoming: SpecHostCapabilitiesSandbox | undefined;
+  incoming: SandboxDoc | undefined;
   prev: SandboxPolicy | undefined;
 }): SandboxPolicy | undefined {
   const { incomingPresent, incoming, prev } = args;
 
-  // No sandbox key in the JSON at all → don't touch policy. The user
-  // either hasn't expanded the section or it's a no-op save.
   if (!incomingPresent) return prev;
 
   const prevCsp = prev?.csp;
   const prevPerms = prev?.permissions;
+  const incomingCspBlock = incoming?.csp;
 
-  // CSP: replace restrictTo wholesale with the parsed spec arrays.
-  // Preserve mode / extensions from prev.
+  // CSP: the four spec allowlists live directly under `csp` (spec
+  // position); `directiveOverrides` is the inspector-only sibling. Replace
+  // each with the parsed value when its key is present; when the parent
+  // `csp` block is absent, all clear. Preserve internal mode / extensions
+  // from prev — those aren't in the JSON.
   const newRestrict: SpecSandboxCsp = {};
-  const incomingCsp = incoming?.csp;
-  if (incomingCsp?.connectDomains && incomingCsp.connectDomains.length > 0) {
-    newRestrict.connectDomains = [...incomingCsp.connectDomains];
+  if (incomingCspBlock?.connectDomains && incomingCspBlock.connectDomains.length > 0) {
+    newRestrict.connectDomains = [...incomingCspBlock.connectDomains];
   }
-  if (incomingCsp?.resourceDomains && incomingCsp.resourceDomains.length > 0) {
-    newRestrict.resourceDomains = [...incomingCsp.resourceDomains];
+  if (incomingCspBlock?.resourceDomains && incomingCspBlock.resourceDomains.length > 0) {
+    newRestrict.resourceDomains = [...incomingCspBlock.resourceDomains];
   }
-  if (incomingCsp?.frameDomains && incomingCsp.frameDomains.length > 0) {
-    newRestrict.frameDomains = [...incomingCsp.frameDomains];
+  if (incomingCspBlock?.frameDomains && incomingCspBlock.frameDomains.length > 0) {
+    newRestrict.frameDomains = [...incomingCspBlock.frameDomains];
   }
-  if (incomingCsp?.baseUriDomains && incomingCsp.baseUriDomains.length > 0) {
-    newRestrict.baseUriDomains = [...incomingCsp.baseUriDomains];
+  if (incomingCspBlock?.baseUriDomains && incomingCspBlock.baseUriDomains.length > 0) {
+    newRestrict.baseUriDomains = [...incomingCspBlock.baseUriDomains];
   }
 
   const nextCsp: SandboxPolicyCsp = {};
   if (prevCsp?.mode !== undefined) nextCsp.mode = prevCsp.mode;
   if (prevCsp?.extensions !== undefined) nextCsp.extensions = prevCsp.extensions;
-  // cspDirectives is an inspector-only emission knob — not in the spec JSON
-  // shape. Preserve verbatim across a JSON edit; the user manages it from
-  // the structured editor in `ClientConfigEditor`, not by typing it here.
-  if (prevCsp?.cspDirectives !== undefined)
-    nextCsp.cspDirectives = prevCsp.cspDirectives;
+  if (incomingCspBlock?.directiveOverrides !== undefined) {
+    nextCsp.cspDirectives = incomingCspBlock.directiveOverrides;
+  }
   if (Object.keys(newRestrict).length > 0) nextCsp.restrictTo = newRestrict;
   const cspNonEmpty = Object.keys(nextCsp).length > 0;
 
@@ -200,26 +260,24 @@ function liftSpecSandboxIntoPolicy(args: {
   if (Object.keys(newAllow).length > 0) nextPerms.allow = newAllow;
   const permsNonEmpty = Object.keys(nextPerms).length > 0;
 
-  // sandboxAttrs and allowFeatures are inspector-only emission knobs —
-  // never surfaced in the spec JSON view. Preserve verbatim across a JSON
-  // edit; the user manages them from the structured editor in
-  // `ClientConfigEditor`, not by typing them here.
-  const prevSandboxAttrs = prev?.sandboxAttrs;
-  const prevAllowFeatures = prev?.allowFeatures;
+  // iframeSandboxAttrs / permissionsPolicy: parsed value wins when the
+  // block is present (absent under a present block = user cleared it).
+  const nextSandboxAttrs = incoming?.iframeSandboxAttrs;
+  const nextAllowFeatures = incoming?.permissionsPolicy;
 
   if (
     !cspNonEmpty &&
     !permsNonEmpty &&
-    prevSandboxAttrs === undefined &&
-    prevAllowFeatures === undefined
+    nextSandboxAttrs === undefined &&
+    nextAllowFeatures === undefined
   ) {
     return undefined;
   }
   const next: SandboxPolicy = {};
   if (cspNonEmpty) next.csp = nextCsp;
   if (permsNonEmpty) next.permissions = nextPerms;
-  if (prevSandboxAttrs !== undefined) next.sandboxAttrs = prevSandboxAttrs;
-  if (prevAllowFeatures !== undefined) next.allowFeatures = prevAllowFeatures;
+  if (nextSandboxAttrs !== undefined) next.sandboxAttrs = nextSandboxAttrs;
+  if (nextAllowFeatures !== undefined) next.allowFeatures = nextAllowFeatures;
   return next;
 }
 
@@ -236,26 +294,27 @@ function appsToJson(draft: HostConfigInputV2): AppsDoc {
   }
 
   // hostCapabilities — show the EFFECTIVE merged value (preset + override)
-  // so the JSON matches what the host actually advertises. resolveEffective
-  // strips `sandbox` defensively because we own sandbox separately; we then
-  // hoist the spec-shaped sandbox view into the same object below.
+  // so the JSON matches what the host actually advertises. Sandbox lives
+  // in its own top-level block below; resolveEffective strips it from this
+  // object defensively so the two views don't desync.
   const effectiveCaps = resolveEffectiveHostCapabilities({
     hostStyle: draft.hostStyle,
     hostCapabilitiesOverride: draft.hostCapabilitiesOverride,
   }) as Record<string, unknown>;
 
-  // Nest sandbox inside hostCapabilities per SEP-1865, using the spec
-  // shape (allowlist arrays + permission presence-flags). Our richer
-  // policy fields (mode/extensions) are intentionally NOT surfaced
-  // here — they're inspector knobs, not in the SEP, so a developer
-  // reading this JSON against the spec sees only spec primitives.
-  const specSandbox = specSandboxFromPolicy(draft.mcpProfile?.apps?.sandbox);
-  if (specSandbox) {
-    effectiveCaps.sandbox = specSandbox;
-  }
-
   if (Object.keys(effectiveCaps).length > 0) {
     doc.hostCapabilities = effectiveCaps;
+  }
+
+  // sandbox — proxy iframe configuration. Maps to `mcpProfile.apps.sandbox`
+  // in storage and the "Sandbox proxy iframe" card in the matrix. Spec
+  // fields use SEP-1865 names/positions verbatim (csp.{connectDomains,...},
+  // permissions); inspector-only knobs are named after the HTML mechanism
+  // they drive (csp.directiveOverrides, iframeSandboxAttrs,
+  // permissionsPolicy) and clearly do not survive a host swap.
+  const sandboxDoc = sandboxFromPolicy(draft.mcpProfile?.apps?.sandbox);
+  if (sandboxDoc) {
+    doc.sandbox = sandboxDoc;
   }
 
   // mcpProfile.apps.uiInitialize.hostInfo
@@ -291,24 +350,17 @@ export function applyJsonToDraft(
   //   - equal to preset → undefined override (clean revert)
   //   - different from preset → override = parsed value (incl. `{}` for
   //     "advertise nothing")
-  // `sandbox` is peeled off here and routed to mcpProfile.apps.sandbox
-  // storage below; the override-diff compares only the static cap fields
-  // so adding/changing sandbox doesn't spuriously create a host-caps
-  // override.
+  // Sandbox is its own top-level block now; if a `sandbox` key sneaks into
+  // hostCapabilities (paste from an older export, hand-edit), strip it so
+  // it doesn't pollute the override diff.
   const presetEffective = resolveEffectiveHostCapabilities({
     hostStyle: prev.hostStyle,
     hostCapabilitiesOverride: undefined,
   }) as Record<string, unknown>;
   let nextOverride: Record<string, unknown> | undefined = undefined;
-  let incomingHostCapsSandbox: SpecHostCapabilitiesSandbox | undefined;
-  let hostCapsSandboxPresent = false;
   if ("hostCapabilities" in parsed) {
     if (isPlainObject(parsed.hostCapabilities)) {
-      const { sandbox, ...incoming } = parsed.hostCapabilities;
-      hostCapsSandboxPresent = "sandbox" in parsed.hostCapabilities;
-      if (isPlainObject(sandbox)) {
-        incomingHostCapsSandbox = sandbox as SpecHostCapabilitiesSandbox;
-      }
+      const { sandbox: _ignored, ...incoming } = parsed.hostCapabilities;
       if (stableStringifyJson(incoming) === stableStringifyJson(presetEffective)) {
         nextOverride = undefined;
       } else {
@@ -331,7 +383,7 @@ export function applyJsonToDraft(
   // splice back the user's existing `initialize` (edited in ProtocolTab)
   // so cross-tab edits don't trample each other. `apps.uiInitialize`
   // round-trips through this tab's JSON doc; `apps.sandbox` is lifted
-  // from `hostCapabilities.sandbox` (spec-shape) back into the inspector's
+  // from the unified top-level `sandbox` block back into the inspector's
   // richer policy shape, preserving prev's mode/extensions.
   const prevProfile = prev.mcpProfile;
   const prevSandbox = prevProfile?.apps?.sandbox;
@@ -344,15 +396,77 @@ export function applyJsonToDraft(
       ? incomingUiInit.hostInfo
       : undefined;
 
-  // Lift spec-shaped hostCapabilities.sandbox back into policy storage.
-  // - hostCaps had no `sandbox` key → use prev sandbox verbatim (no edit)
-  // - hostCaps had `sandbox` (even empty) → user is asserting intent, so
-  //   overwrite restrictTo / permissions.allow with the parsed spec
-  //   values; preserve mode / extensions from prev because those
-  //   are inspector-only and the JSON view never exposed them.
-  const nextSandbox = liftSpecSandboxIntoPolicy({
-    incomingPresent: hostCapsSandboxPresent,
-    incoming: incomingHostCapsSandbox,
+  // Parse the `sandbox` block. Values are validated shape-wise here; the
+  // canonicalizer enforces deeper constraints (no `;` or `,` in CSP
+  // directive override values, spec-feature filtering, etc.) at storage
+  // time. The four spec allowlists are read from spec position directly
+  // under `csp`; inspector-only knobs use the new names.
+  let incomingSandbox: SandboxDoc | undefined;
+  let sandboxPresent = false;
+  if ("sandbox" in parsed) {
+    sandboxPresent = true;
+    const sandboxBlock = parsed.sandbox;
+    if (isPlainObject(sandboxBlock)) {
+      const parsedSandbox: SandboxDoc = {};
+      if (isPlainObject(sandboxBlock.csp)) {
+        const c = sandboxBlock.csp;
+        const cspOut: SandboxDocCsp = {};
+        if (Array.isArray(c.connectDomains))
+          cspOut.connectDomains = c.connectDomains.filter(
+            (t): t is string => typeof t === "string",
+          );
+        if (Array.isArray(c.resourceDomains))
+          cspOut.resourceDomains = c.resourceDomains.filter(
+            (t): t is string => typeof t === "string",
+          );
+        if (Array.isArray(c.frameDomains))
+          cspOut.frameDomains = c.frameDomains.filter(
+            (t): t is string => typeof t === "string",
+          );
+        if (Array.isArray(c.baseUriDomains))
+          cspOut.baseUriDomains = c.baseUriDomains.filter(
+            (t): t is string => typeof t === "string",
+          );
+        if (isPlainObject(c.directiveOverrides)) {
+          const cd: Record<string, string[]> = {};
+          for (const [k, v] of Object.entries(c.directiveOverrides)) {
+            if (Array.isArray(v)) {
+              cd[k] = v.filter((t): t is string => typeof t === "string");
+            }
+          }
+          cspOut.directiveOverrides = cd;
+        }
+        // Always assign the csp block when present in JSON — empty
+        // signals "user asserted intent to clear", which liftSandboxIntoPolicy
+        // honors by dropping restrictTo / directiveOverrides while
+        // preserving inspector-internal mode / extensions.
+        parsedSandbox.csp = cspOut;
+      }
+      if (isPlainObject(sandboxBlock.permissions)) {
+        parsedSandbox.permissions = sandboxBlock.permissions as SpecSandboxPermissions;
+      }
+      if (Array.isArray(sandboxBlock.iframeSandboxAttrs)) {
+        parsedSandbox.iframeSandboxAttrs = sandboxBlock.iframeSandboxAttrs.filter(
+          (t): t is string => typeof t === "string",
+        );
+      }
+      if (isPlainObject(sandboxBlock.permissionsPolicy)) {
+        const pp: Record<string, string> = {};
+        for (const [k, v] of Object.entries(sandboxBlock.permissionsPolicy)) {
+          if (typeof v === "string") pp[k] = v;
+        }
+        parsedSandbox.permissionsPolicy = pp;
+      }
+      incomingSandbox = parsedSandbox;
+    }
+  }
+
+  // Lift the parsed `sandbox` block back into policy storage. Inspector-
+  // internal fields not surfaced in the JSON (mode, extensions) are
+  // preserved from prev across edits regardless.
+  const nextSandbox = liftSandboxIntoPolicy({
+    incomingPresent: sandboxPresent,
+    incoming: incomingSandbox,
     prev: prevSandbox,
   });
 

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -169,6 +169,11 @@ function liftSpecSandboxIntoPolicy(args: {
   const nextCsp: SandboxPolicyCsp = {};
   if (prevCsp?.mode !== undefined) nextCsp.mode = prevCsp.mode;
   if (prevCsp?.extensions !== undefined) nextCsp.extensions = prevCsp.extensions;
+  // cspDirectives is an inspector-only emission knob — not in the spec JSON
+  // shape. Preserve verbatim across a JSON edit; the user manages it from
+  // the structured editor in `ClientConfigEditor`, not by typing it here.
+  if (prevCsp?.cspDirectives !== undefined)
+    nextCsp.cspDirectives = prevCsp.cspDirectives;
   if (Object.keys(newRestrict).length > 0) nextCsp.restrictTo = newRestrict;
   const cspNonEmpty = Object.keys(nextCsp).length > 0;
 
@@ -195,10 +200,26 @@ function liftSpecSandboxIntoPolicy(args: {
   if (Object.keys(newAllow).length > 0) nextPerms.allow = newAllow;
   const permsNonEmpty = Object.keys(nextPerms).length > 0;
 
-  if (!cspNonEmpty && !permsNonEmpty) return undefined;
+  // sandboxAttrs and allowFeatures are inspector-only emission knobs —
+  // never surfaced in the spec JSON view. Preserve verbatim across a JSON
+  // edit; the user manages them from the structured editor in
+  // `ClientConfigEditor`, not by typing them here.
+  const prevSandboxAttrs = prev?.sandboxAttrs;
+  const prevAllowFeatures = prev?.allowFeatures;
+
+  if (
+    !cspNonEmpty &&
+    !permsNonEmpty &&
+    prevSandboxAttrs === undefined &&
+    prevAllowFeatures === undefined
+  ) {
+    return undefined;
+  }
   const next: SandboxPolicy = {};
   if (cspNonEmpty) next.csp = nextCsp;
   if (permsNonEmpty) next.permissions = nextPerms;
+  if (prevSandboxAttrs !== undefined) next.sandboxAttrs = prevSandboxAttrs;
+  if (prevAllowFeatures !== undefined) next.allowFeatures = prevAllowFeatures;
   return next;
 }
 

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -169,10 +169,15 @@ function sandboxFromPolicy(
     if (Object.keys(perms).length > 0) out.permissions = perms;
   }
 
-  if (policy.sandboxAttrs && policy.sandboxAttrs.length > 0) {
+  // Inspector-only knobs round-trip with their full undefined-vs-empty
+  // semantics so the JSON faithfully represents what's in storage.
+  // `[]` / `{}` are the user's explicit "model the strict host" intent;
+  // dropping them on serialize would silently flip the JSON back to the
+  // legacy permissive default on a copy/paste import.
+  if (policy.sandboxAttrs !== undefined) {
     out.iframeSandboxAttrs = [...policy.sandboxAttrs];
   }
-  if (policy.allowFeatures && Object.keys(policy.allowFeatures).length > 0) {
+  if (policy.allowFeatures !== undefined) {
     out.permissionsPolicy = { ...policy.allowFeatures };
   }
 

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
@@ -319,6 +319,28 @@ describe("AppsExtensionTab — sandbox JSON round-trip", () => {
     });
   });
 
+  it("round-trips EMPTY iframeSandboxAttrs/permissionsPolicy as the explicit strict-host model", () => {
+    // Regression: serializing `sandboxAttrs: []` / `allowFeatures: {}`
+    // used to be dropped from the JSON (only emitted when non-empty),
+    // so a copy/paste import would lose the explicit "spec minimum"
+    // model — the runtime treats the absent fields as the legacy
+    // permissive default and silently re-grants
+    // `local-network-access` / `midi` / popups / forms. Both directions
+    // must preserve the empty container.
+    const next = applyJsonToDraft(
+      {
+        hostContext: {},
+        sandbox: {
+          iframeSandboxAttrs: [],
+          permissionsPolicy: {},
+        },
+      },
+      emptyHostConfigInputV2(),
+    );
+    expect(next?.mcpProfile?.apps?.sandbox?.sandboxAttrs).toEqual([]);
+    expect(next?.mcpProfile?.apps?.sandbox?.allowFeatures).toEqual({});
+  });
+
   it("preserves all sandbox state when JSON has no sandbox key at all", () => {
     // No-op save with rich internal state — everything (including
     // inspector-only knobs) survives because incomingPresent is false.

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
@@ -12,9 +12,6 @@ import {
 
 describe("focusTabForNodeId — sandbox routing", () => {
   it("routes the sandbox hub id to the Apps Extension tab", () => {
-    // Sandbox lives at mcpProfile.apps.sandbox; the matrix surfaces it as
-    // its own section for visibility, but clicking opens the Apps
-    // Extension tab so users edit the spec-shaped JSON.
     expect(focusTabForNodeId(SANDBOX_HUB_NODE_ID)).toEqual({
       tab: "apps",
       selectedServerId: null,
@@ -42,24 +39,22 @@ describe("focusTabForNodeId — sandbox routing", () => {
   });
 });
 
-describe("AppsExtensionTab — spec-shaped sandbox round-trip", () => {
-  it("writes spec-shaped hostCapabilities.sandbox.csp into storage as restrictTo", () => {
-    // The user typed spec-shaped JSON: domain arrays under csp,
-    // presence-flags under permissions. Internally we store this as
-    // `restrictTo` + `allow` because we layer an inspector-only `mode`
-    // knob on top — but that's not in the spec JSON. SEP-1865 is
-    // allowlist-only; there's no deny concept.
+describe("AppsExtensionTab — sandbox JSON round-trip", () => {
+  it("reads the four spec CSP allowlists from spec position into restrictTo storage", () => {
+    // The user types SEP-1865 shape: the four allowlists live directly
+    // under `sandbox.csp` (no `restrictTo` wrapper) so they map to
+    // `HostCapabilities.sandbox.csp.{connectDomains, ...}` 1:1.
+    // Internally we still store as `csp.restrictTo` because the inspector
+    // layers a `mode` knob on top.
     const next = applyJsonToDraft(
       {
         hostContext: {},
-        hostCapabilities: {
-          sandbox: {
-            csp: {
-              connectDomains: ["https://api.openai.com"],
-              resourceDomains: ["https://cdn.jsdelivr.net"],
-            },
-            permissions: { clipboardWrite: {}, microphone: {} },
+        sandbox: {
+          csp: {
+            connectDomains: ["https://api.openai.com"],
+            resourceDomains: ["https://cdn.jsdelivr.net"],
           },
+          permissions: { clipboardWrite: {}, microphone: {} },
         },
       },
       emptyHostConfigInputV2(),
@@ -76,9 +71,8 @@ describe("AppsExtensionTab — spec-shaped sandbox round-trip", () => {
 
   it("preserves inspector-only mode on edit (not surfaced in JSON, can't be wiped from it)", () => {
     // Regression: `mode` is an inspector knob (not in SEP-1865). The JSON
-    // view shows only spec primitives. If editing the JSON dropped `mode`,
-    // a user who set `mode: "relaxed"` from elsewhere would silently lose
-    // it the next time they saved this tab.
+    // surfaces enforcement, not internal resolver state. Editing JSON
+    // must not nuke `mode`.
     const prev = emptyHostConfigInputV2();
     prev.mcpProfile = {
       profileVersion: 1,
@@ -92,15 +86,11 @@ describe("AppsExtensionTab — spec-shaped sandbox round-trip", () => {
         },
       },
     };
-    // User edits hostCapabilities.sandbox in JSON, swapping the allowed
-    // connect domain. Nothing about mode in the JSON.
     const next = applyJsonToDraft(
       {
         hostContext: {},
-        hostCapabilities: {
-          sandbox: {
-            csp: { connectDomains: ["https://api.anthropic.com"] },
-          },
+        sandbox: {
+          csp: { connectDomains: ["https://api.anthropic.com"] },
         },
       },
       prev,
@@ -112,7 +102,7 @@ describe("AppsExtensionTab — spec-shaped sandbox round-trip", () => {
     expect(next?.mcpProfile?.apps?.sandbox?.permissions?.mode).toBe("custom");
   });
 
-  it("treats absent hostCapabilities.sandbox as 'no change' (preserves prev sandbox verbatim)", () => {
+  it("treats absent sandbox key as 'no change' (preserves prev sandbox verbatim)", () => {
     // A no-op apps-tab save (user opened the tab, didn't touch sandbox,
     // pressed save) parses JSON without a sandbox key. Sandbox must
     // round-trip untouched.
@@ -135,10 +125,10 @@ describe("AppsExtensionTab — spec-shaped sandbox round-trip", () => {
     );
   });
 
-  it("treats empty hostCapabilities.sandbox as 'clear restrictTo + allow' but keeps mode", () => {
-    // The user explicitly emptied the spec-shape (e.g. they cleared the
-    // arrays from the JSON). That should drop restrictTo/allow but keep
-    // `mode` so the user doesn't lose the inspector-side state.
+  it("treats empty sandbox block as 'clear surfaced fields' but keeps mode", () => {
+    // The user explicitly emptied the sandbox block. That should drop
+    // restrictTo/allow/directiveOverrides/sandboxAttrs/permissionsPolicy
+    // but keep `mode` so the user doesn't lose inspector-internal state.
     const prev = emptyHostConfigInputV2();
     prev.mcpProfile = {
       profileVersion: 1,
@@ -158,7 +148,7 @@ describe("AppsExtensionTab — spec-shaped sandbox round-trip", () => {
     const next = applyJsonToDraft(
       {
         hostContext: {},
-        hostCapabilities: { sandbox: {} },
+        sandbox: {},
       },
       prev,
     );
@@ -174,11 +164,9 @@ describe("AppsExtensionTab — spec-shaped sandbox round-trip", () => {
     const next = applyJsonToDraft(
       {
         hostContext: {},
-        hostCapabilities: {
-          sandbox: {
-            permissions: { clipboardWrite: {} },
-            // microphone absent → not granted
-          },
+        sandbox: {
+          permissions: { clipboardWrite: {} },
+          // microphone absent → not granted
         },
       },
       emptyHostConfigInputV2(),
@@ -198,9 +186,7 @@ describe("AppsExtensionTab — spec-shaped sandbox round-trip", () => {
     const next = applyJsonToDraft(
       {
         hostContext: {},
-        hostCapabilities: {
-          sandbox: { csp: { connectDomains: ["https://api.openai.com"] } },
-        },
+        sandbox: { csp: { connectDomains: ["https://api.openai.com"] } },
       },
       prev,
     );
@@ -210,11 +196,34 @@ describe("AppsExtensionTab — spec-shaped sandbox round-trip", () => {
     });
   });
 
-  it("does NOT create a hostCapabilitiesOverride when JSON matches preset + adds sandbox", () => {
-    // The override-diff compares static caps only. Adding sandbox to the
-    // JSON while leaving the rest of hostCapabilities equal to the
-    // preset must not create a spurious override — sandbox is policy
-    // (stored separately at mcpProfile.apps.sandbox), not a vendor cap.
+  it("does NOT create a hostCapabilitiesOverride when sandbox is edited and hostCapabilities matches preset", () => {
+    // Sandbox lives in its own top-level block; the override-diff
+    // compares only static cap fields. Editing sandbox while leaving
+    // hostCapabilities equal to the preset must not create a spurious
+    // override.
+    const prev = emptyHostConfigInputV2();
+    const preset = resolveEffectiveHostCapabilities({
+      hostStyle: prev.hostStyle,
+      hostCapabilitiesOverride: undefined,
+    }) as Record<string, unknown>;
+    const next = applyJsonToDraft(
+      {
+        hostContext: {},
+        hostCapabilities: preset,
+        sandbox: { csp: { connectDomains: ["https://api.openai.com"] } },
+      },
+      prev,
+    );
+    expect(next?.hostCapabilitiesOverride).toBeUndefined();
+    expect(
+      next?.mcpProfile?.apps?.sandbox?.csp?.restrictTo?.connectDomains,
+    ).toEqual(["https://api.openai.com"]);
+  });
+
+  it("strips a legacy `sandbox` key from hostCapabilities so it doesn't pollute the override diff", () => {
+    // Older exports / hand-edits may still nest sandbox under
+    // hostCapabilities. We ignore it there (it lives at top level now)
+    // and must not let it flip the diff into 'override present'.
     const prev = emptyHostConfigInputV2();
     const preset = resolveEffectiveHostCapabilities({
       hostStyle: prev.hostStyle,
@@ -225,56 +234,82 @@ describe("AppsExtensionTab — spec-shaped sandbox round-trip", () => {
         hostContext: {},
         hostCapabilities: {
           ...preset,
-          sandbox: { csp: { connectDomains: ["https://api.openai.com"] } },
+          sandbox: { csp: { connectDomains: ["https://leaked.example"] } },
         },
       },
       prev,
     );
     expect(next?.hostCapabilitiesOverride).toBeUndefined();
-    // sandbox still landed in policy storage
-    expect(
-      next?.mcpProfile?.apps?.sandbox?.csp?.restrictTo?.connectDomains,
-    ).toEqual(["https://api.openai.com"]);
   });
 
-  it("preserves inspector-only sandboxAttrs/allowFeatures/cspDirectives across a JSON edit", () => {
-    // These three knobs live in the structured editor (not the spec JSON
-    // view), but they must survive a JSON-side edit of the spec sandbox
-    // shape — same preservation contract as mode/extensions.
+  it("round-trips csp.directiveOverrides through the renamed JSON shape", () => {
+    // Inspector-only per-directive source-expression overrides on the
+    // proxy iframe CSP. Surfaced under `csp.directiveOverrides`; stored
+    // as `csp.cspDirectives` because that's the internal field name.
+    const next = applyJsonToDraft(
+      {
+        hostContext: {},
+        sandbox: {
+          csp: {
+            directiveOverrides: {
+              "script-src": ["'unsafe-eval'", "'wasm-unsafe-eval'"],
+            },
+          },
+        },
+      },
+      emptyHostConfigInputV2(),
+    );
+    expect(next?.mcpProfile?.apps?.sandbox?.csp?.cspDirectives).toEqual({
+      "script-src": ["'unsafe-eval'", "'wasm-unsafe-eval'"],
+    });
+  });
+
+  it("clears csp.directiveOverrides when the csp block is present but the field is absent", () => {
+    // Regression: with the unified-block "present-block-asserts-intent"
+    // semantics, removing `directiveOverrides` from a still-present `csp`
+    // block must clear it. Round-trip stability — if we silently
+    // preserved prev's value, the next save would resurrect the field
+    // the user deleted.
     const prev = emptyHostConfigInputV2();
     prev.mcpProfile = {
       profileVersion: 1,
       apps: {
         sandbox: {
           csp: {
-            cspDirectives: {
-              "script-src": ["'unsafe-eval'", "'wasm-unsafe-eval'"],
-            },
+            cspDirectives: { "script-src": ["'unsafe-eval'"] },
           },
-          sandboxAttrs: ["allow-forms", "allow-modals"],
-          allowFeatures: { fullscreen: "*" },
         },
       },
     };
     const next = applyJsonToDraft(
       {
         hostContext: {},
-        hostCapabilities: {
-          sandbox: {
-            csp: { connectDomains: ["https://api.openai.com"] },
-          },
+        sandbox: {
+          csp: { connectDomains: ["https://api.openai.com"] },
         },
       },
       prev,
     );
-    // The user typed a new spec-shape restrictTo on the CSP side.
+    expect(next?.mcpProfile?.apps?.sandbox?.csp?.cspDirectives).toBeUndefined();
     expect(
       next?.mcpProfile?.apps?.sandbox?.csp?.restrictTo?.connectDomains,
     ).toEqual(["https://api.openai.com"]);
-    // Inspector-only knobs survived verbatim.
-    expect(next?.mcpProfile?.apps?.sandbox?.csp?.cspDirectives).toEqual({
-      "script-src": ["'unsafe-eval'", "'wasm-unsafe-eval'"],
-    });
+  });
+
+  it("round-trips iframeSandboxAttrs and permissionsPolicy through their renamed JSON keys", () => {
+    // These two are inspector-only HTML iframe attribute knobs. Both
+    // editable from the JSON now; both store under their legacy field
+    // names internally.
+    const next = applyJsonToDraft(
+      {
+        hostContext: {},
+        sandbox: {
+          iframeSandboxAttrs: ["allow-forms", "allow-modals"],
+          permissionsPolicy: { fullscreen: "*" },
+        },
+      },
+      emptyHostConfigInputV2(),
+    );
     expect(next?.mcpProfile?.apps?.sandbox?.sandboxAttrs).toEqual([
       "allow-forms",
       "allow-modals",
@@ -284,23 +319,26 @@ describe("AppsExtensionTab — spec-shaped sandbox round-trip", () => {
     });
   });
 
-  it("preserves inspector-only knobs when JSON has no sandbox key at all", () => {
+  it("preserves all sandbox state when JSON has no sandbox key at all", () => {
+    // No-op save with rich internal state — everything (including
+    // inspector-only knobs) survives because incomingPresent is false.
     const prev = emptyHostConfigInputV2();
     prev.mcpProfile = {
       profileVersion: 1,
       apps: {
         sandbox: {
+          csp: {
+            cspDirectives: { "script-src": ["'unsafe-eval'"] },
+            restrictTo: { connectDomains: ["https://api.openai.com"] },
+          },
           sandboxAttrs: ["allow-forms"],
           allowFeatures: { fullscreen: "*" },
         },
       },
     };
     const next = applyJsonToDraft({ hostContext: {} }, prev);
-    expect(next?.mcpProfile?.apps?.sandbox?.sandboxAttrs).toEqual([
-      "allow-forms",
-    ]);
-    expect(next?.mcpProfile?.apps?.sandbox?.allowFeatures).toEqual({
-      fullscreen: "*",
-    });
+    expect(next?.mcpProfile?.apps?.sandbox).toEqual(
+      prev.mcpProfile.apps!.sandbox,
+    );
   });
 });

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
@@ -22,7 +22,14 @@ describe("focusTabForNodeId — sandbox routing", () => {
   });
 
   it("routes every sandbox leaf node id to the Apps Extension tab", () => {
-    for (const sub of ["mode", "restrictTo", "permissions"] as const) {
+    for (const sub of [
+      "mode",
+      "restrictTo",
+      "cspDirectives",
+      "permissions",
+      "sandboxAttrs",
+      "allowFeatures",
+    ] as const) {
       expect(focusTabForNodeId(sandboxConfigLeafNodeId(sub))).toEqual({
         tab: "apps",
         selectedServerId: null,
@@ -228,5 +235,72 @@ describe("AppsExtensionTab — spec-shaped sandbox round-trip", () => {
     expect(
       next?.mcpProfile?.apps?.sandbox?.csp?.restrictTo?.connectDomains,
     ).toEqual(["https://api.openai.com"]);
+  });
+
+  it("preserves inspector-only sandboxAttrs/allowFeatures/cspDirectives across a JSON edit", () => {
+    // These three knobs live in the structured editor (not the spec JSON
+    // view), but they must survive a JSON-side edit of the spec sandbox
+    // shape — same preservation contract as mode/extensions.
+    const prev = emptyHostConfigInputV2();
+    prev.mcpProfile = {
+      profileVersion: 1,
+      apps: {
+        sandbox: {
+          csp: {
+            cspDirectives: {
+              "script-src": ["'unsafe-eval'", "'wasm-unsafe-eval'"],
+            },
+          },
+          sandboxAttrs: ["allow-forms", "allow-modals"],
+          allowFeatures: { fullscreen: "*" },
+        },
+      },
+    };
+    const next = applyJsonToDraft(
+      {
+        hostContext: {},
+        hostCapabilities: {
+          sandbox: {
+            csp: { connectDomains: ["https://api.openai.com"] },
+          },
+        },
+      },
+      prev,
+    );
+    // The user typed a new spec-shape restrictTo on the CSP side.
+    expect(
+      next?.mcpProfile?.apps?.sandbox?.csp?.restrictTo?.connectDomains,
+    ).toEqual(["https://api.openai.com"]);
+    // Inspector-only knobs survived verbatim.
+    expect(next?.mcpProfile?.apps?.sandbox?.csp?.cspDirectives).toEqual({
+      "script-src": ["'unsafe-eval'", "'wasm-unsafe-eval'"],
+    });
+    expect(next?.mcpProfile?.apps?.sandbox?.sandboxAttrs).toEqual([
+      "allow-forms",
+      "allow-modals",
+    ]);
+    expect(next?.mcpProfile?.apps?.sandbox?.allowFeatures).toEqual({
+      fullscreen: "*",
+    });
+  });
+
+  it("preserves inspector-only knobs when JSON has no sandbox key at all", () => {
+    const prev = emptyHostConfigInputV2();
+    prev.mcpProfile = {
+      profileVersion: 1,
+      apps: {
+        sandbox: {
+          sandboxAttrs: ["allow-forms"],
+          allowFeatures: { fullscreen: "*" },
+        },
+      },
+    };
+    const next = applyJsonToDraft({ hostContext: {} }, prev);
+    expect(next?.mcpProfile?.apps?.sandbox?.sandboxAttrs).toEqual([
+      "allow-forms",
+    ]);
+    expect(next?.mcpProfile?.apps?.sandbox?.allowFeatures).toEqual({
+      fullscreen: "*",
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/clients/redesigned/types.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/types.ts
@@ -154,17 +154,27 @@ export type SandboxConfigSubKey =
   | "allowFeatures";
 
 /**
- * CSP directive arrays surfaced under the `restrictTo` row when populated.
- * Each entry is one of the four SEP-1865 allowlist directive families.
- * Empty arrays / undefined values are NOT rendered — the matrix only shows
- * directives the host actually narrowed.
+ * CSP directive arrays surfaced under the `restrictTo` and `cspDirectives`
+ * rows when populated. Two consumers, same shape:
+ *
+ * - `restrictTo` uses it for the four SEP-1865 allowlist directive families
+ *   (`connectDomains` / `resourceDomains` / `frameDomains` / `baseUriDomains`).
+ *   `domains` carries domain origins.
+ * - `cspDirectives` uses it for arbitrary CSP directive names (`script-src`,
+ *   `style-src`, …). `domains` carries source-expression tokens AND/OR
+ *   public-domain origins — the field name is historical; semantically
+ *   it's a flat token list.
+ *
+ * `key` is a free-form string so both consumers can share the type. Empty
+ * arrays / undefined values are NOT rendered — the matrix only shows
+ * directives the host actually populated.
  */
 export interface CspDirectiveDetail {
-  /** Directive family name (e.g. "connectDomains"). */
-  key: "connectDomains" | "resourceDomains" | "frameDomains" | "baseUriDomains";
-  /** Short display label ("connect", "resource", "frame", "baseUri"). */
+  /** Directive family or name (e.g. "connectDomains", "script-src"). */
+  key: string;
+  /** Short display label. */
   label: string;
-  /** Domain entries declared under this directive. */
+  /** Token entries declared under this directive (domains and/or source expressions). */
   domains: string[];
 }
 

--- a/mcpjam-inspector/client/src/components/clients/redesigned/types.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/types.ts
@@ -128,20 +128,30 @@ export interface AppsCapLeafNodeData extends Record<string, unknown> {
 }
 
 /**
- * One row per sandbox config slice (CSP mode, restrictTo, permissions).
- * The sandbox section in the matrix is fixed-shape (always 3 rows) so
- * users can read "this is the default" at a glance — same "absence is
- * informative" principle the Apps caps section uses for off capabilities.
+ * One row per sandbox config slice. The CSP-family rows (mode, restrictTo,
+ * cspDirectives) plus permissions form the SEP-1865 surface; sandboxAttrs
+ * and allowFeatures are inspector-only emission knobs that model what real
+ * hosts emit at the browser layer.
+ *
  * Severity drives the row tint:
- *   - `neutral`: default / empty, no surprise
+ *   - `neutral`: default / empty / additive user grant, no surprise
  *   - `warn`: deviates from default but doesn't silently narrow (e.g.
  *     `mode: "relaxed"`)
- *   - `danger`: silently NARROWS what widgets can do (e.g. `restrictTo`
- *     populated — the intersection trap that broke Excalidraw)
+ *   - `danger`: silently NARROWS what widgets can do, OR re-enables real
+ *     script-execution loosening (e.g. `restrictTo` populated — the
+ *     intersection trap that broke Excalidraw; `cspDirectives` carrying
+ *     `'unsafe-eval'` / `'wasm-unsafe-eval'` / `'unsafe-inline'` /
+ *     `'strict-dynamic'`)
  *
  * SEP-1865 is allowlist-only — there's no deny concept at any layer.
  */
-export type SandboxConfigSubKey = "mode" | "restrictTo" | "permissions";
+export type SandboxConfigSubKey =
+  | "mode"
+  | "restrictTo"
+  | "cspDirectives"
+  | "permissions"
+  | "sandboxAttrs"
+  | "allowFeatures";
 
 /**
  * CSP directive arrays surfaced under the `restrictTo` row when populated.

--- a/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
@@ -150,4 +150,51 @@ describe("SandboxedIframe — outer allow attribute (allowFeatures injection gua
     );
     expect(getOuterIframeAllow(container)).toContain("fullscreen *");
   });
+
+  // Mirror of the sandboxAttrs authoritative-profile contract: when a
+  // profile uses allowFeatures to model a real host's `allow=` shape, the
+  // renderer's legacy `local-network-access *` / `midi *` defaults are
+  // dropped so MCPJam matches the real host's grant set. Spec-permission
+  // entries from `permissions` are orthogonal and still flow through.
+
+  it("preserves legacy local-network-access + midi defaults when allowFeatures is undefined", () => {
+    const { container } = render(
+      <SandboxedIframe html={null} onMessage={() => {}} />,
+    );
+    const allow = getOuterIframeAllow(container);
+    expect(allow).toContain("local-network-access *");
+    expect(allow).toContain("midi *");
+  });
+
+  it("drops legacy local-network-access + midi defaults when allowFeatures is provided (even {})", () => {
+    // The profile is authoritative: a host that doesn't list
+    // local-network-access / midi shouldn't have them silently granted by
+    // the inspector.
+    const { container } = render(
+      <SandboxedIframe
+        html={null}
+        allowFeatures={{}}
+        onMessage={() => {}}
+      />,
+    );
+    const allow = getOuterIframeAllow(container);
+    expect(allow).not.toContain("local-network-access");
+    expect(allow).not.toContain("midi");
+  });
+
+  it("still emits spec-permission grants from `permissions` even when allowFeatures is authoritative", () => {
+    // SEP-1865 spec permissions and allowFeatures are orthogonal —
+    // `allowFeatures: {}` shouldn't suppress a `permissions.camera` grant.
+    const { container } = render(
+      <SandboxedIframe
+        html={null}
+        permissions={{ camera: {} }}
+        allowFeatures={{}}
+        onMessage={() => {}}
+      />,
+    );
+    const allow = getOuterIframeAllow(container);
+    expect(allow).toContain("camera *");
+    expect(allow).not.toContain("local-network-access");
+  });
 });

--- a/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
@@ -101,6 +101,26 @@ describe("SandboxedIframe — outer sandbox attribute", () => {
       "allow-scripts",
     ]);
   });
+
+  it("rejects sandboxAttrs entries with internal whitespace (silent-widen guard)", () => {
+    // Regression: `"allow-forms allow-popups-to-escape-sandbox"` as a
+    // single Set entry would otherwise emit two real sandbox flags via
+    // join(" "), silently widening the iframe grants beyond what the
+    // editor/matrix display.
+    const { container } = render(
+      <SandboxedIframe
+        html={null}
+        sandboxAttrs={["allow-forms allow-popups-to-escape-sandbox"]}
+        onMessage={() => {}}
+      />,
+    );
+    const tokens = getOuterIframeSandbox(container);
+    // The whitespace-bearing entry is dropped entirely. Mandatory
+    // tokens remain; the smuggled flags do NOT.
+    expect(tokens).toEqual(["allow-same-origin", "allow-scripts"]);
+    expect(tokens).not.toContain("allow-forms");
+    expect(tokens).not.toContain("allow-popups-to-escape-sandbox");
+  });
 });
 
 describe("SandboxedIframe — outer allow attribute (allowFeatures injection guard)", () => {

--- a/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
@@ -102,3 +102,52 @@ describe("SandboxedIframe — outer sandbox attribute", () => {
     ]);
   });
 });
+
+describe("SandboxedIframe — outer allow attribute (allowFeatures injection guard)", () => {
+  function getOuterIframeAllow(container: HTMLElement): string {
+    const iframe = container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    return iframe!.getAttribute("allow") ?? "";
+  }
+
+  it("drops allowFeatures entries with ';' in the value — directive-injection guard", () => {
+    // A crafted profile that put `fullscreen: "*; camera *"` would
+    // otherwise smuggle `camera *` past the spec-feature key filter
+    // (since `;` is the Permissions Policy separator). Defense in depth
+    // for the canonicalizer's reject-at-write-time check.
+    const { container } = render(
+      <SandboxedIframe
+        html={null}
+        allowFeatures={{ fullscreen: "*; camera *" }}
+        onMessage={() => {}}
+      />,
+    );
+    const allow = getOuterIframeAllow(container);
+    expect(allow).not.toContain("camera");
+    expect(allow).not.toContain("fullscreen");
+  });
+
+  it("drops allowFeatures entries with ',' in the value", () => {
+    const { container } = render(
+      <SandboxedIframe
+        html={null}
+        allowFeatures={{ fullscreen: "*, camera *" }}
+        onMessage={() => {}}
+      />,
+    );
+    const allow = getOuterIframeAllow(container);
+    expect(allow).not.toContain("camera");
+    expect(allow).not.toContain("fullscreen");
+  });
+
+  it("keeps clean allowFeatures entries through", () => {
+    const { container } = render(
+      <SandboxedIframe
+        html={null}
+        allowFeatures={{ fullscreen: "*" }}
+        onMessage={() => {}}
+      />,
+    );
+    expect(getOuterIframeAllow(container)).toContain("fullscreen *");
+  });
+});

--- a/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
@@ -102,6 +102,40 @@ describe("SandboxedIframe — outer sandbox attribute", () => {
     ]);
   });
 
+  it("remounts the outer iframe when sandboxAttrs changes (so new sandbox flags take effect)", () => {
+    // Browsers apply iframe `sandbox=` only on navigation; mutating
+    // the attribute on a mounted iframe does not retroactively change
+    // its grants. If we didn't remount, editing a profile from
+    // permissive tokens to `[]` would leave the running widget with
+    // popups/forms/etc. enabled even though the matrix shows the
+    // stricter model. Asserts the iframe DOM identity changes when
+    // outerSandboxAttribute does.
+    const { container, rerender } = render(
+      <SandboxedIframe
+        html={null}
+        sandboxAttrs={["allow-forms", "allow-popups"]}
+        onMessage={() => {}}
+      />,
+    );
+    const firstIframe = container.querySelector("iframe");
+    expect(firstIframe).not.toBeNull();
+    rerender(
+      <SandboxedIframe
+        html={null}
+        sandboxAttrs={[]}
+        onMessage={() => {}}
+      />,
+    );
+    const secondIframe = container.querySelector("iframe");
+    expect(secondIframe).not.toBeNull();
+    expect(secondIframe).not.toBe(firstIframe);
+    // The remounted iframe carries the strict spec-minimum sandbox.
+    expect(getOuterIframeSandbox(container)).toEqual([
+      "allow-same-origin",
+      "allow-scripts",
+    ]);
+  });
+
   it("rejects sandboxAttrs entries with internal whitespace (silent-widen guard)", () => {
     // Regression: `"allow-forms allow-popups-to-escape-sandbox"` as a
     // single Set entry would otherwise emit two real sandbox flags via
@@ -169,6 +203,23 @@ describe("SandboxedIframe — outer allow attribute (allowFeatures injection gua
       />,
     );
     expect(getOuterIframeAllow(container)).toContain("fullscreen *");
+  });
+
+  it("drops allowFeatures keys with whitespace (spec-feature-bypass guard)", () => {
+    // Regression: a key like `"camera *"` doesn't match the spec-feature
+    // filter (exact-equals `"camera"`), so without a whitespace check it
+    // would flow through as `camera * *`, which the browser parses as a
+    // camera grant — bypassing `permissions.allow` as the single source
+    // of truth for the 4 spec permissions.
+    const { container } = render(
+      <SandboxedIframe
+        html={null}
+        allowFeatures={{ "camera *": "*" }}
+        onMessage={() => {}}
+      />,
+    );
+    const allow = getOuterIframeAllow(container);
+    expect(allow).not.toContain("camera");
   });
 
   // Mirror of the sandboxAttrs authoritative-profile contract: when a

--- a/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Pins the `sandboxAttrs` semantic switch on the outer iframe `sandbox=`:
+ *
+ *   - `sandboxAttrs: undefined` (no profile opinion) → preserve the
+ *     caller-supplied permissive baseline so legacy callers behave
+ *     unchanged.
+ *   - `sandboxAttrs: []` (profile explicitly modeling a strict host) →
+ *     emit only the spec-mandated `allow-scripts allow-same-origin`.
+ *   - `sandboxAttrs: ["allow-forms"]` → spec-mandated minimum PLUS that
+ *     token, NOT unioned with the legacy baseline.
+ *
+ * Locks the contract so a future refactor of `sandboxed-iframe.tsx` or
+ * `mcp-apps-renderer.tsx` can't silently re-grant tokens like
+ * `allow-popups-to-escape-sandbox` on profiles that explicitly model a
+ * stricter real host.
+ */
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { SandboxedIframe } from "@/components/ui/sandboxed-iframe";
+
+function getOuterIframeSandbox(container: HTMLElement): string[] {
+  const iframe = container.querySelector("iframe");
+  expect(iframe).not.toBeNull();
+  return (iframe!.getAttribute("sandbox") ?? "")
+    .split(/\s+/)
+    .filter((t) => t.length > 0)
+    .sort();
+}
+
+describe("SandboxedIframe — outer sandbox attribute", () => {
+  it("preserves the caller's permissive baseline when sandboxAttrs is undefined", () => {
+    // No profile opinion → legacy callers (which pass a wide permissive
+    // baseline) keep their pre-feature behavior. Spec-mandated tokens are
+    // still always present as a defense-in-depth guarantee.
+    const { container } = render(
+      <SandboxedIframe
+        html={null}
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+        onMessage={() => {}}
+      />,
+    );
+    const tokens = getOuterIframeSandbox(container);
+    expect(tokens).toEqual([
+      "allow-forms",
+      "allow-popups",
+      "allow-popups-to-escape-sandbox",
+      "allow-same-origin",
+      "allow-scripts",
+    ]);
+  });
+
+  it("collapses to the spec-mandated minimum when sandboxAttrs: []", () => {
+    // Explicit `[]` = "profile models a host that emits the spec minimum
+    // only." The caller's wide `sandbox` prop is ignored in favor of the
+    // profile, so tokens like `allow-popups-to-escape-sandbox` must NOT
+    // appear.
+    const { container } = render(
+      <SandboxedIframe
+        html={null}
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+        sandboxAttrs={[]}
+        onMessage={() => {}}
+      />,
+    );
+    const tokens = getOuterIframeSandbox(container);
+    expect(tokens).toEqual(["allow-same-origin", "allow-scripts"]);
+  });
+
+  it("emits spec-mandated minimum + profile tokens when sandboxAttrs is non-empty", () => {
+    // A Claude-modeled profile carries `allow-forms`; the renderer's
+    // legacy permissive baseline must NOT subsume it into a wider grant.
+    const { container } = render(
+      <SandboxedIframe
+        html={null}
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+        sandboxAttrs={["allow-forms"]}
+        onMessage={() => {}}
+      />,
+    );
+    const tokens = getOuterIframeSandbox(container);
+    expect(tokens).toEqual([
+      "allow-forms",
+      "allow-same-origin",
+      "allow-scripts",
+    ]);
+  });
+
+  it("dedupes when sandboxAttrs repeats the spec-mandated tokens", () => {
+    // Mandatory tokens are unioned regardless of input order or duplicates.
+    const { container } = render(
+      <SandboxedIframe
+        html={null}
+        sandboxAttrs={["allow-scripts", "allow-forms", "allow-scripts"]}
+        onMessage={() => {}}
+      />,
+    );
+    const tokens = getOuterIframeSandbox(container);
+    expect(tokens).toEqual([
+      "allow-forms",
+      "allow-same-origin",
+      "allow-scripts",
+    ]);
+  });
+});

--- a/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
@@ -227,9 +227,16 @@ export const SandboxedIframe = forwardRef<
       for (const k of Object.keys(allowFeatures).sort()) {
         if (specFeatures.has(k)) continue;
         const allowlist = allowFeatures[k];
-        if (typeof allowlist === "string" && allowlist.length > 0) {
-          allowList.push(`${k} ${allowlist}`);
-        }
+        if (typeof allowlist !== "string" || allowlist.length === 0) continue;
+        // Reject `;` and `,` in keys and values. The Permissions Policy
+        // iframe `allow=` attribute uses `;` to separate features; allowing
+        // either character through here turns the per-feature filter into
+        // a directive-injection bypass (e.g. `fullscreen: "*; camera *"`
+        // would smuggle a `camera *` grant past the spec-feature check
+        // above). `,` is the corresponding separator in HTTP-header
+        // Permissions-Policy syntax and is rejected for symmetry.
+        if (/[;,]/.test(k) || /[;,]/.test(allowlist)) continue;
+        allowList.push(`${k} ${allowlist}`);
       }
     }
     return allowList.join("; ");

--- a/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
@@ -251,6 +251,16 @@ export const SandboxedIframe = forwardRef<
         // above). `,` is the corresponding separator in HTTP-header
         // Permissions-Policy syntax and is rejected for symmetry.
         if (/[;,]/.test(k) || /[;,]/.test(allowlist)) continue;
+        // Reject whitespace in the KEY too. A key like `"camera *"`
+        // doesn't equal the spec key `"camera"`, so the spec-feature
+        // filter above lets it through; the join produces
+        // `camera * *`, which the browser parses as a `camera` grant
+        // — bypassing `permissions.allow` as the single source of
+        // truth for the 4 spec permissions. (Values legitimately
+        // contain whitespace for multi-token allowlists like
+        // `"'self' https://example.com"`, so the whitespace rule
+        // applies only to keys.)
+        if (/\s/.test(k)) continue;
         allowList.push(`${k} ${allowlist}`);
       }
     }
@@ -375,8 +385,26 @@ export const SandboxedIframe = forwardRef<
 
   const iframeStyle = colorScheme ? { ...style, colorScheme } : style;
 
+  // Browsers apply iframe `sandbox=` only on navigation, not when the
+  // attribute mutates on an already-loaded frame. If the user edits a
+  // profile from permissive tokens to `[]` while the widget is mounted,
+  // React updates the attribute but the live iframe keeps the OLD
+  // grants until something forces a navigation — so the matrix/editor
+  // can show stricter modeling while the running widget still has
+  // popups/forms/etc. enabled. Key the outer iframe on
+  // outerSandboxAttribute so React unmounts + remounts (= fresh
+  // navigation) whenever the effective sandbox flags change. Resetting
+  // proxyReady below ensures the resource-ready effect re-fires after
+  // the new proxy load completes (otherwise proxyReady would stay
+  // `true` from the prior iframe and the widget wouldn't get re-sent
+  // to the new proxy).
+  useEffect(() => {
+    setProxyReady(false);
+  }, [outerSandboxAttribute]);
+
   return (
     <iframe
+      key={outerSandboxAttribute}
       ref={outerRef}
       src={sandboxProxyUrl}
       sandbox={outerSandboxAttribute}

--- a/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
@@ -42,6 +42,28 @@ interface SandboxedIframeProps {
   csp?: McpUiResourceCsp;
   /** Permissions metadata from resource _meta.ui.permissions (SEP-1865) */
   permissions?: McpUiResourcePermissions;
+  /**
+   * Inspector-only: extra `sandbox=` tokens unioned with the spec-mandated
+   * `allow-scripts allow-same-origin` on both outer and inner iframes.
+   * Models tokens real hosts emit (e.g. `allow-forms`) that aren't part of
+   * SEP-1865 metadata.
+   */
+  sandboxAttrs?: string[];
+  /**
+   * Inspector-only: extra Permissions Policy entries appended to outer/inner
+   * iframe `allow=`. Keys are kebab Permissions Policy tokens
+   * (`fullscreen`, `web-share`); the 4 spec features
+   * (camera/microphone/geolocation/clipboard-write) live in `permissions`
+   * and are NOT permitted here.
+   */
+  allowFeatures?: Record<string, string>;
+  /**
+   * Inspector-only: per-directive CSP source-expression overrides merged
+   * into the inner doc's `<meta http-equiv="Content-Security-Policy">`.
+   * Keys are CSP directive names (`script-src`, …); values are token arrays
+   * (`["'unsafe-eval'", "'wasm-unsafe-eval'"]`).
+   */
+  cspDirectives?: Record<string, string[]>;
   /** Skip CSP injection entirely (for permissive/testing mode) */
   permissive?: boolean;
   /** Callback when sandbox proxy is ready */
@@ -75,6 +97,9 @@ export const SandboxedIframe = forwardRef<
     sandbox = "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox",
     csp,
     permissions,
+    sandboxAttrs,
+    allowFeatures,
+    cspDirectives,
     permissive,
     onProxyReady,
     onMessage,
@@ -182,15 +207,58 @@ export const SandboxedIframe = forwardRef<
     return () => window.removeEventListener("message", handleMessage);
   }, [handleMessage]);
 
-  // Build allow attribute for outer iframe based on requested permissions
+  // Build allow attribute for outer iframe based on requested permissions.
+  // SEP-1865 spec-permission features come from `permissions`; extra
+  // Permissions Policy entries from the inspector-only `allowFeatures` knob
+  // are appended after them. Per Permissions Policy spec, `;` separates
+  // features.
   const outerAllowAttribute = useMemo(() => {
     const allowList = ["local-network-access *", "midi *"];
     if (permissions?.camera) allowList.push("camera *");
     if (permissions?.microphone) allowList.push("microphone *");
     if (permissions?.geolocation) allowList.push("geolocation *");
     if (permissions?.clipboardWrite) allowList.push("clipboard-write *");
+    if (allowFeatures) {
+      for (const k of Object.keys(allowFeatures).sort()) {
+        // Defense-in-depth: skip the 4 spec features here too in case the
+        // canonicalizer was bypassed.
+        if (
+          k === "camera" ||
+          k === "microphone" ||
+          k === "geolocation" ||
+          k === "clipboard-write"
+        ) {
+          continue;
+        }
+        const allowlist = allowFeatures[k];
+        if (typeof allowlist === "string" && allowlist.length > 0) {
+          allowList.push(`${k} ${allowlist}`);
+        }
+      }
+    }
     return allowList.join("; ");
-  }, [permissions]);
+  }, [permissions, allowFeatures]);
+
+  // Outer iframe `sandbox=` value: union of the spec-mandated/default
+  // tokens (from the `sandbox` prop) with the inspector-only `sandboxAttrs`
+  // extras. Dedupe + sort for stable DOM output.
+  const outerSandboxAttribute = useMemo(() => {
+    const tokens = new Set<string>();
+    for (const t of sandbox.split(/\s+/)) {
+      if (t.length > 0) tokens.add(t);
+    }
+    // `allow-scripts` and `allow-same-origin` are mandatory regardless of
+    // what the caller passed.
+    tokens.add("allow-scripts");
+    tokens.add("allow-same-origin");
+    if (sandboxAttrs) {
+      for (const t of sandboxAttrs) {
+        const trimmed = t.trim();
+        if (trimmed.length > 0) tokens.add(trimmed);
+      }
+    }
+    return Array.from(tokens).sort().join(" ");
+  }, [sandbox, sandboxAttrs]);
 
   // Send HTML, CSP, and permissions to sandbox when ready (SEP-1865)
   useEffect(() => {
@@ -200,7 +268,17 @@ export const SandboxedIframe = forwardRef<
       {
         jsonrpc: "2.0",
         method: "ui/notifications/sandbox-resource-ready",
-        params: { html, sandbox, csp, permissions, permissive, colorScheme },
+        params: {
+          html,
+          sandbox,
+          csp,
+          permissions,
+          sandboxAttrs,
+          allowFeatures,
+          cspDirectives,
+          permissive,
+          colorScheme,
+        },
       },
       sandboxProxyOrigin,
     );
@@ -210,8 +288,12 @@ export const SandboxedIframe = forwardRef<
     sandbox,
     csp,
     permissions,
+    sandboxAttrs,
+    allowFeatures,
+    cspDirectives,
     permissive,
     sandboxProxyOrigin,
+    colorScheme,
   ]);
 
   // Keep iframe color-scheme in sync without reloading the widget document.
@@ -234,7 +316,7 @@ export const SandboxedIframe = forwardRef<
     <iframe
       ref={outerRef}
       src={sandboxProxyUrl}
-      sandbox={sandbox}
+      sandbox={outerSandboxAttribute}
       allow={outerAllowAttribute}
       title={title}
       className={className}

--- a/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
@@ -239,23 +239,38 @@ export const SandboxedIframe = forwardRef<
     return allowList.join("; ");
   }, [permissions, allowFeatures]);
 
-  // Outer iframe `sandbox=` value: union of the spec-mandated/default
-  // tokens (from the `sandbox` prop) with the inspector-only `sandboxAttrs`
-  // extras. Dedupe + sort for stable DOM output.
+  // Outer iframe `sandbox=` value.
+  //
+  // When `sandboxAttrs` is provided (even as `[]`), the profile is the
+  // authoritative source: the iframe gets `allow-scripts allow-same-origin`
+  // plus exactly what the profile lists. This is what makes "model the
+  // real host's emitted tokens" actually work — e.g. a Claude-modeled
+  // profile with `sandboxAttrs: ["allow-forms"]` gets exactly those three
+  // tokens, not those PLUS the renderer's legacy permissive default.
+  //
+  // When `sandboxAttrs` is undefined (no profile opinion), fall back to
+  // the caller's `sandbox` prop so existing call sites — which pass a
+  // wider permissive baseline — behave unchanged.
+  //
+  // `undefined` vs `[]` matters here: `[]` is the explicit "spec-minimum
+  // only" intent, mirroring the canonicalizer's preservation contract.
   const outerSandboxAttribute = useMemo(() => {
     const tokens = new Set<string>();
-    for (const t of sandbox.split(/\s+/)) {
-      if (t.length > 0) tokens.add(t);
-    }
-    // `allow-scripts` and `allow-same-origin` are mandatory regardless of
-    // what the caller passed.
-    tokens.add("allow-scripts");
-    tokens.add("allow-same-origin");
-    if (sandboxAttrs) {
+    if (sandboxAttrs !== undefined) {
+      tokens.add("allow-scripts");
+      tokens.add("allow-same-origin");
       for (const t of sandboxAttrs) {
         const trimmed = t.trim();
         if (trimmed.length > 0) tokens.add(trimmed);
       }
+    } else {
+      for (const t of sandbox.split(/\s+/)) {
+        if (t.length > 0) tokens.add(t);
+      }
+      // Defense in depth: spec-mandated tokens are always present even
+      // if a caller passes a malformed `sandbox` prop.
+      tokens.add("allow-scripts");
+      tokens.add("allow-same-origin");
     }
     return Array.from(tokens).sort().join(" ");
   }, [sandbox, sandboxAttrs]);

--- a/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
@@ -282,6 +282,13 @@ export const SandboxedIframe = forwardRef<
       },
       sandboxProxyOrigin,
     );
+    // `colorScheme` is intentionally OMITTED from this dep list: the proxy
+    // handles `sandbox-resource-ready` by rebuilding the CSP and assigning
+    // `inner.srcdoc`, which reloads the widget and drops any in-iframe state.
+    // Theme changes flow through the dedicated
+    // `sandbox-color-scheme-changed` effect below, which updates the inner
+    // document's color-scheme without a reload. Re-including colorScheme
+    // here would silently full-reload the widget on every theme flip.
   }, [
     proxyReady,
     html,
@@ -293,7 +300,6 @@ export const SandboxedIframe = forwardRef<
     cspDirectives,
     permissive,
     sandboxProxyOrigin,
-    colorScheme,
   ]);
 
   // Keep iframe color-scheme in sync without reloading the widget document.

--- a/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
@@ -279,7 +279,17 @@ export const SandboxedIframe = forwardRef<
       tokens.add("allow-same-origin");
       for (const t of sandboxAttrs) {
         const trimmed = t.trim();
-        if (trimmed.length > 0) tokens.add(trimmed);
+        if (trimmed.length === 0) continue;
+        // Reject tokens with internal whitespace. A profile (or custom-
+        // token input) that smuggles `"allow-forms allow-popups-to-
+        // escape-sandbox"` would otherwise land in the Set as one entry
+        // but the join(" ") below would emit it as two real sandbox
+        // flags — silently widening the iframe grant beyond what the
+        // editor/matrix display. Reject is safer than split: the entry
+        // visibly does nothing (user notices) instead of taking effect
+        // invisibly.
+        if (/\s/.test(trimmed)) continue;
+        tokens.add(trimmed);
       }
     } else {
       for (const t of sandbox.split(/\s+/)) {

--- a/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
@@ -321,13 +321,22 @@ export const SandboxedIframe = forwardRef<
       },
       sandboxProxyOrigin,
     );
-    // `colorScheme` is intentionally OMITTED from this dep list: the proxy
-    // handles `sandbox-resource-ready` by rebuilding the CSP and assigning
-    // `inner.srcdoc`, which reloads the widget and drops any in-iframe state.
-    // Theme changes flow through the dedicated
-    // `sandbox-color-scheme-changed` effect below, which updates the inner
-    // document's color-scheme without a reload. Re-including colorScheme
-    // here would silently full-reload the widget on every theme flip.
+    // `colorScheme` and `allowFeatures` are intentionally OMITTED from
+    // this dep list. The proxy handles `sandbox-resource-ready` by
+    // rebuilding the CSP and assigning `inner.srcdoc`, which reloads the
+    // widget and drops any in-iframe state — so we MUST NOT re-fire this
+    // effect for props that don't actually affect the inner iframe.
+    //
+    //   - `colorScheme`: flows through the dedicated
+    //     `sandbox-color-scheme-changed` effect below, which updates the
+    //     inner document's color-scheme without a reload.
+    //   - `allowFeatures`: applies only to the OUTER iframe's `allow=`
+    //     attribute (computed in `outerAllowAttribute` above and applied
+    //     declaratively via JSX, so React reconciliation handles the
+    //     update without a reload). It's not forwarded in the params
+    //     payload at all (see the comment above the field). Re-including
+    //     it here would silently full-reload the widget every time a
+    //     user toggles an entry in the AppExtensionTab editor.
   }, [
     proxyReady,
     html,
@@ -335,7 +344,6 @@ export const SandboxedIframe = forwardRef<
     csp,
     permissions,
     sandboxAttrs,
-    allowFeatures,
     cspDirectives,
     permissive,
     sandboxProxyOrigin,

--- a/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
@@ -27,6 +27,7 @@ import type {
   McpUiResourceCsp,
   McpUiResourcePermissions,
 } from "@modelcontextprotocol/ext-apps/app-bridge";
+import { SEP_1865_PERMISSION_FEATURES } from "@/lib/client-config-v2";
 
 export interface SandboxedIframeHandle {
   postMessage: (data: unknown) => void;
@@ -219,17 +220,12 @@ export const SandboxedIframe = forwardRef<
     if (permissions?.geolocation) allowList.push("geolocation *");
     if (permissions?.clipboardWrite) allowList.push("clipboard-write *");
     if (allowFeatures) {
+      // Defense-in-depth: skip spec features in case the canonicalizer
+      // was bypassed. `permissions.allow.{camera,...}` is the single
+      // source of truth — see SEP_1865_PERMISSION_FEATURES.
+      const specFeatures = new Set<string>(SEP_1865_PERMISSION_FEATURES);
       for (const k of Object.keys(allowFeatures).sort()) {
-        // Defense-in-depth: skip the 4 spec features here too in case the
-        // canonicalizer was bypassed.
-        if (
-          k === "camera" ||
-          k === "microphone" ||
-          k === "geolocation" ||
-          k === "clipboard-write"
-        ) {
-          continue;
-        }
+        if (specFeatures.has(k)) continue;
         const allowlist = allowFeatures[k];
         if (typeof allowlist === "string" && allowlist.length > 0) {
           allowList.push(`${k} ${allowlist}`);

--- a/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
@@ -209,12 +209,27 @@ export const SandboxedIframe = forwardRef<
   }, [handleMessage]);
 
   // Build allow attribute for outer iframe based on requested permissions.
-  // SEP-1865 spec-permission features come from `permissions`; extra
-  // Permissions Policy entries from the inspector-only `allowFeatures` knob
-  // are appended after them. Per Permissions Policy spec, `;` separates
-  // features.
+  //
+  // Same authoritative-profile semantic as `sandboxAttrs` above: when
+  // `allowFeatures` is provided (even as `{}`), the profile is the
+  // source of truth for non-spec Permissions Policy features, and the
+  // renderer's legacy defaults (`local-network-access *`, `midi *`) are
+  // dropped. A profile that doesn't list those features models a real
+  // host that doesn't emit them — and the iframe must match, or
+  // experiments using Web MIDI / Local Network Access would pass in
+  // MCPJam while the real host blocks them.
+  //
+  // The 4 SEP-1865 spec permissions (camera/microphone/geolocation/
+  // clipboard-write) ALWAYS flow through from `permissions` regardless
+  // of `allowFeatures` — they're orthogonal user-facing knobs. Only the
+  // inspector-only legacy defaults are conditional.
+  //
+  // Per Permissions Policy spec, `;` separates features.
   const outerAllowAttribute = useMemo(() => {
-    const allowList = ["local-network-access *", "midi *"];
+    const allowFeaturesIsAuthoritative = allowFeatures !== undefined;
+    const allowList = allowFeaturesIsAuthoritative
+      ? []
+      : ["local-network-access *", "midi *"];
     if (permissions?.camera) allowList.push("camera *");
     if (permissions?.microphone) allowList.push("microphone *");
     if (permissions?.geolocation) allowList.push("geolocation *");

--- a/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
@@ -292,7 +292,13 @@ export const SandboxedIframe = forwardRef<
           csp,
           permissions,
           sandboxAttrs,
-          allowFeatures,
+          // `allowFeatures` is intentionally NOT forwarded to the proxy:
+          // it applies to the OUTER iframe only. The inner iframe gets the
+          // 4 spec permissions (via `permissions`) and nothing else, matching
+          // real claude.ai's outer-grants-fullscreen / inner-trims-to-spec
+          // pattern. Centralizing the outer/inner split here means the proxy
+          // can't accidentally widen the inner grant by reading a stale
+          // field.
           cspDirectives,
           permissive,
           colorScheme,

--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -23,6 +23,26 @@ import { getDefaultClientCapabilities } from "@mcpjam/sdk/browser";
 
 export type HostStyleId = ChatboxHostStyle;
 
+/**
+ * Permissions Policy feature tokens corresponding to the four SEP-1865
+ * spec permissions. KEBAB-CASE browser tokens (as they appear in iframe
+ * `allow=` attributes), NOT the camelCase keys used in
+ * `mcpProfile.permissions.allow`. The backend canonicalizer drops any
+ * key in this list from `allowFeatures` — `permissions.allow` is the
+ * single source of truth. Mirror of the same constant in
+ * `convex/lib/hostConfigV2.ts`.
+ *
+ * Naming gap (intentional): `permissions.allow.clipboardWrite` (camel,
+ * spec field name) ↔ `allowFeatures["clipboard-write"]` (kebab,
+ * Permissions Policy token). Do NOT normalize casing on either side.
+ */
+export const SEP_1865_PERMISSION_FEATURES = [
+  "camera",
+  "microphone",
+  "geolocation",
+  "clipboard-write",
+] as const;
+
 export type HostConfigConnectionDefaults = {
   headers: Record<string, string>;
   requestTimeout: number;
@@ -81,6 +101,17 @@ export type HostConfigMcpProfileV1 = {
         mode?: "host-default" | "declared" | "relaxed";
         /** Intersection — never adds undeclared domains (SEP-1865). */
         restrictTo?: CspDomainSet;
+        /**
+         * Per-directive CSP source-expression overrides emitted in the inner
+         * doc's `<meta http-equiv="Content-Security-Policy">`. Keys are CSP
+         * directive names (`script-src`, `style-src`, …); values are
+         * source-expression token arrays (`["'unsafe-eval'", "'wasm-unsafe-eval'"]`).
+         * Stored verbatim — no enum — so future tokens (nonces, hashes,
+         * `'strict-dynamic'`) land here without schema churn.
+         * Inspector-only emission knob: NOT advertised in SEP-1865 metadata;
+         * models what real hosts emit at the browser layer.
+         */
+        cspDirectives?: Record<string, string[]>;
         extensions?: Record<string, unknown>;
       };
       permissions?: {
@@ -88,6 +119,21 @@ export type HostConfigMcpProfileV1 = {
         allow?: Record<string, boolean>;
         extensions?: Record<string, unknown>;
       };
+      /**
+       * Extra outer/inner iframe `sandbox=` tokens unioned with the mandatory
+       * `allow-scripts allow-same-origin`. Inspector-only emission knob.
+       */
+      sandboxAttrs?: string[];
+      /**
+       * Extra Permissions Policy entries appended to the outer/inner iframe
+       * `allow=` attribute. Keys are RAW kebab-case Permissions Policy tokens
+       * (`clipboard-write`, not `clipboardWrite`); values are allowlist
+       * strings (`*`, `'self'`, an origin). The 4 spec features
+       * (camera/microphone/geolocation/clipboard-write) are silently dropped
+       * by the canonicalizer — `permissions.allow` is the single source of
+       * truth for them. Inspector-only.
+       */
+      allowFeatures?: Record<string, string>;
     };
     /**
      * Overrides for the MCP Apps `ui/initialize` response advertised to

--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -125,12 +125,16 @@ export type HostConfigMcpProfileV1 = {
        */
       sandboxAttrs?: string[];
       /**
-       * Extra Permissions Policy entries appended to the outer/inner iframe
-       * `allow=` attribute. Keys are RAW kebab-case Permissions Policy tokens
-       * (`clipboard-write`, not `clipboardWrite`); values are allowlist
-       * strings (`*`, `'self'`, an origin). The 4 spec features
-       * (camera/microphone/geolocation/clipboard-write) are silently dropped
-       * by the canonicalizer — `permissions.allow` is the single source of
+       * Extra Permissions Policy entries appended to the OUTER iframe's
+       * `allow=` attribute ONLY. The inner iframe gets only the 4 spec
+       * permissions (from `permissions.allow`), matching real claude.ai's
+       * pattern where the outer grants `fullscreen *; clipboard-write *`
+       * but the inner trims to `clipboard-write *`. Keys are RAW
+       * kebab-case Permissions Policy tokens (`clipboard-write`, not
+       * `clipboardWrite`); values are allowlist strings (`*`, `'self'`,
+       * an origin). The 4 spec features (camera / microphone /
+       * geolocation / clipboard-write) are silently dropped by the
+       * canonicalizer — `permissions.allow` is the single source of
        * truth for them. Inspector-only.
        */
       allowFeatures?: Record<string, string>;

--- a/mcpjam-inspector/client/src/lib/client-templates.ts
+++ b/mcpjam-inspector/client/src/lib/client-templates.ts
@@ -459,11 +459,81 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
               // to model the production allowlist can add it explicitly
               // in the editor; absence here means "trust the view".
               mode: "declared",
+              // cspDirectives — verbatim from a live claude.ai inner-iframe
+              // response CSP header (captured 2026-05-18 via DevTools →
+              // Network → Response Headers). These layer on top of
+              // SEP-1865's restrictive baseline via the union merge in
+              // buildCSP (sandbox-proxy.html). Tokens already in the
+              // baseline (`'unsafe-inline'` for script-src/style-src,
+              // `data:`/`blob:` for img/font/media) are omitted to keep
+              // the data set minimal — the merge dedupes regardless.
+              //
+              // 'unsafe-eval' enables `eval()` / `new Function()` — real
+              // Claude allows this; widgets relying on runtime-compiled
+              // templating (Handlebars, Vue full build, etc.) work here
+              // but break in hosts that don't grant it.
+              //
+              // `esm.sh` + `assets.claude.ai` are public CDNs Claude
+              // adds at the proxy layer (NOT in advertised metadata).
+              // Including them here is safe under the union merge rule
+              // (PR 2142) — they can only grant capabilities, never
+              // narrow what a widget declared.
+              cspDirectives: {
+                "script-src": [
+                  "'self'",
+                  "'unsafe-eval'",
+                  "https://esm.sh",
+                  "https://assets.claude.ai",
+                ],
+                "style-src": [
+                  "'self'",
+                  "https://esm.sh",
+                  "https://assets.claude.ai",
+                ],
+                "img-src": [
+                  "'self'",
+                  "https://esm.sh",
+                  "https://assets.claude.ai",
+                ],
+                "connect-src": ["'self'", "https://esm.sh"],
+                "font-src": [
+                  "'self'",
+                  "https://esm.sh",
+                  "https://assets.claude.ai",
+                ],
+                "media-src": [
+                  "'self'",
+                  "https://esm.sh",
+                  "https://assets.claude.ai",
+                ],
+                "worker-src": [
+                  "'self'",
+                  "blob:",
+                  "https://esm.sh",
+                  "https://assets.claude.ai",
+                ],
+                "frame-src": ["'self'"],
+                "base-uri": ["'self'"],
+                "form-action": ["'self'"],
+              },
             },
             permissions: {
               mode: "custom",
               allow: { clipboardWrite: true },
             },
+            // sandboxAttrs — from live capture of real claude.ai's outer
+            // and inner iframes (both carry `allow-scripts allow-same-origin
+            // allow-forms`). The first two are spec-mandated; `allow-forms`
+            // is the host's addition so `<form>` POSTs work inside widgets.
+            sandboxAttrs: ["allow-forms"],
+            // allowFeatures — non-spec Permissions Policy entries on the
+            // OUTER iframe. Claude's outer grants `fullscreen *; clipboard-
+            // write *`; clipboard-write is the spec permission (lives in
+            // `permissions.allow` above), fullscreen is the non-spec extra
+            // captured here. The inner iframe trims fullscreen out (see
+            // sandbox-proxy.html: inner gets spec-4 only), matching real
+            // claude.ai's outer-grants / inner-trims pattern.
+            allowFeatures: { fullscreen: "*" },
           },
         },
       };

--- a/mcpjam-inspector/client/src/lib/client-templates.ts
+++ b/mcpjam-inspector/client/src/lib/client-templates.ts
@@ -630,11 +630,61 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
               // (intersection trap) and silently breaks widgets reaching
               // any other origin. The view's declaration is authoritative.
               mode: "declared",
+              // cspDirectives — verbatim from a live chatgpt response
+              // Content-Security-Policy header (captured 2026-05-18 via
+              // DevTools → Network → oaiusercontent.com response).
+              //
+              // Real ChatGPT's outer-doc CSP is strikingly minimal: only
+              // `frame-ancestors`, `frame-src`, and the CSP `sandbox`
+              // directive are emitted. There is NO `script-src`,
+              // `style-src`, `connect-src` etc. — script and style
+              // execution is effectively unconstrained at the host layer.
+              // `frame-ancestors` is dropped (controls who can embed the
+              // doc — irrelevant for widget runtime); the CSP `sandbox`
+              // directive duplicates `sandboxAttrs` below and is modeled
+              // there. That leaves just `frame-src` as the meaningful
+              // host-emitted constraint on widget behavior.
+              cspDirectives: {
+                "frame-src": ["'self'", "https:", "data:", "blob:"],
+              },
             },
             permissions: {
               mode: "custom",
-              allow: { microphone: true },
+              // Per ui/initialize hostCapabilities only `microphone` is
+              // advertised. Per the outer iframe `allow=` attribute,
+              // `clipboard-write` is ALSO emitted at runtime even though
+              // it's not in the advertised metadata. Include both so a
+              // widget testing in MCPJam-as-ChatGPT actually gets what
+              // the production iframe grants.
+              allow: { microphone: true, clipboardWrite: true },
             },
+            // sandboxAttrs — captured 2026-05-18 from the outer and
+            // inner iframe `sandbox=` attributes. There's an asymmetry:
+            //   outer: allow-scripts allow-same-origin allow-forms
+            //   inner: allow-scripts allow-same-origin allow-popups
+            //          allow-popups-to-escape-sandbox allow-forms
+            // Schema applies one set to both layers; use the broader
+            // inner set since that's what determines widget runtime
+            // behavior. Outer will over-grant allow-popups in MCPJam vs
+            // real ChatGPT; the modal-popup widget surface is rare
+            // enough that this divergence is acceptable.
+            sandboxAttrs: [
+              "allow-forms",
+              "allow-popups",
+              "allow-popups-to-escape-sandbox",
+            ],
+            // allowFeatures — non-spec Permissions Policy extras on the
+            // outer iframe. Real ChatGPT emits
+            // `clipboard-write *; local-network-access *; microphone *;
+            // midi *`:
+            //   - clipboard-write + microphone → spec features, modeled
+            //     in `permissions.allow` above.
+            //   - local-network-access + midi → ALREADY in MCPJam's
+            //     renderer baseline (sandboxed-iframe.tsx's
+            //     `outerAllowAttribute` memo), auto-granted to every
+            //     host.
+            // So ChatGPT contributes no host-specific allowFeatures
+            // extras — the runtime grant matches real ChatGPT for free.
           },
         },
       };

--- a/mcpjam-inspector/client/src/lib/playground/__tests__/apply-client-defaults.test.ts
+++ b/mcpjam-inspector/client/src/lib/playground/__tests__/apply-client-defaults.test.ts
@@ -129,7 +129,7 @@ describe("applyHostDefaultsToPlayground", () => {
     expect(setHostCapabilitiesOverride.mock.calls[0]?.[0]).toBeDefined();
   });
 
-  it("snapshots MCPJam fallback: setDeviceType('desktop'), permissive CSP, override cleared, model id NOT touched", () => {
+  it("snapshots MCPJam fallback: setDeviceType('desktop'), widget-declared CSP, override set, model id NOT touched", () => {
     applyHostDefaultsToPlayground("mcpjam", setters);
 
     expect(setHostStyle).toHaveBeenCalledWith("mcpjam");
@@ -141,13 +141,16 @@ describe("applyHostDefaultsToPlayground", () => {
     expect(setCustomViewportSpy).not.toHaveBeenCalled();
     expect(setDeviceTypeSpy).toHaveBeenCalledWith("desktop");
 
-    expect(setCspModeSpy).toHaveBeenCalledWith("permissive");
-    expect(setMcpAppsCspModeSpy).toHaveBeenCalledWith("permissive");
+    // MCPJam template advertises apps.sandbox.csp.mode "declared" so the
+    // Permissive chip resolves to widget-declared, same as Claude/ChatGPT.
+    expect(setCspModeSpy).toHaveBeenCalledWith("widget-declared");
+    expect(setMcpAppsCspModeSpy).toHaveBeenCalledWith("widget-declared");
 
-    // MCPJam template doesn't set hostCapabilitiesOverride → undefined,
-    // which clears the override (host-style preset takes over).
+    // MCPJam template now ships its own hostCapabilitiesOverride
+    // (openLinks, updateModelContext, etc.) — the override is set, not
+    // cleared, so widgets see MCPJam's advertised host surface.
     expect(setHostCapabilitiesOverride).toHaveBeenCalledTimes(1);
-    expect(setHostCapabilitiesOverride.mock.calls[0]?.[0]).toBeUndefined();
+    expect(setHostCapabilitiesOverride.mock.calls[0]?.[0]).toBeDefined();
   });
 
   it("preserves the picked hostStyle for an unknown BYO host id even though template falls back to MCPJam", () => {
@@ -161,8 +164,11 @@ describe("applyHostDefaultsToPlayground", () => {
     // is preserved.
     expect(saveSelectedModelIdSpy).not.toHaveBeenCalled();
     expect(setDeviceTypeSpy).toHaveBeenCalledWith("desktop");
-    expect(setCspModeSpy).toHaveBeenCalledWith("permissive");
-    expect(setHostCapabilitiesOverride.mock.calls[0]?.[0]).toBeUndefined();
+    // MCPJam fallback now stamps apps.sandbox.csp.mode "declared" and a
+    // hostCapabilitiesOverride, so the BYO unknown id inherits both like
+    // other branded templates.
+    expect(setCspModeSpy).toHaveBeenCalledWith("widget-declared");
+    expect(setHostCapabilitiesOverride.mock.calls[0]?.[0]).toBeDefined();
   });
 
   describe("applyHostConfigToPlayground (used by named-host picker sync)", () => {

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Sandbox Proxy buildCSP merge-rule tests.
+ *
+ * `buildCSP` lives inline in `sandbox-proxy.html` (it runs in the proxy
+ * iframe, not Node). To unit-test the merge rule (domain-derived tokens
+ * unioned with `cspDirectives` overrides, with `'none'` dropped when any
+ * other token is present), we read the HTML, extract the function source,
+ * and evaluate it in a sandbox via the `Function` constructor.
+ *
+ * Keeps the function physically in the HTML (where it ships to the
+ * browser) while still letting us assert on the merge contract.
+ */
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const html = fs.readFileSync(
+  path.resolve(
+    __dirname,
+    "..",
+    "routes",
+    "apps",
+    "mcp-apps",
+    "sandbox-proxy.html",
+  ),
+  "utf8",
+);
+
+// Extract sanitizeDomain + buildCSP source from the inline <script>.
+function extract(name: string): string {
+  const re = new RegExp(
+    `function\\s+${name}\\s*\\([^)]*\\)\\s*\\{([\\s\\S]*?)\\n\\s{6}\\}`,
+  );
+  const m = html.match(re);
+  if (!m) throw new Error(`Could not extract function ${name}`);
+  return m[0];
+}
+
+const sanitize = extract("sanitizeDomain");
+const build = extract("buildCSP");
+
+// eslint-disable-next-line @typescript-eslint/no-implied-eval
+const buildCSP = new Function(
+  "csp",
+  "cspDirectives",
+  `${sanitize}\n${build}\nreturn buildCSP(csp, cspDirectives);`,
+) as (
+  csp: unknown,
+  cspDirectives?: Record<string, string[]>,
+) => string;
+
+describe("sandbox-proxy buildCSP merge rule", () => {
+  it("emits 'none' when no domains and no cspDirectives for an empty directive", () => {
+    const out = buildCSP({ frameDomains: [] }, undefined);
+    expect(out).toContain("frame-src 'none'");
+  });
+
+  it("drops 'none' when cspDirectives adds real tokens to an otherwise-empty directive", () => {
+    const out = buildCSP(
+      { frameDomains: [] },
+      { "frame-src": ["https://embed.example.com"] },
+    );
+    expect(out).toContain("frame-src https://embed.example.com");
+    expect(out).not.toContain("frame-src 'none'");
+  });
+
+  it("deduplicates when cspDirectives overlaps with domain-derived tokens", () => {
+    const out = buildCSP(
+      { connectDomains: ["https://api.example.com"] },
+      { "connect-src": ["https://api.example.com", "https://api2.example.com"] },
+    );
+    const connectLine = out
+      .split(";")
+      .map((s) => s.trim())
+      .find((s) => s.startsWith("connect-src "));
+    expect(connectLine).toBeDefined();
+    const tokens = connectLine!.slice("connect-src ".length).split(/\s+/);
+    expect(tokens.filter((t) => t === "https://api.example.com")).toHaveLength(
+      1,
+    );
+    expect(tokens).toContain("https://api2.example.com");
+  });
+
+  it("merges cspDirectives into script-src on top of 'unsafe-inline'", () => {
+    const out = buildCSP(
+      { resourceDomains: [] },
+      { "script-src": ["'unsafe-eval'", "'wasm-unsafe-eval'"] },
+    );
+    const scriptLine = out
+      .split(";")
+      .map((s) => s.trim())
+      .find((s) => s.startsWith("script-src "));
+    expect(scriptLine).toContain("'unsafe-inline'");
+    expect(scriptLine).toContain("'unsafe-eval'");
+    expect(scriptLine).toContain("'wasm-unsafe-eval'");
+  });
+
+  it("appends unknown cspDirectives keys verbatim", () => {
+    const out = buildCSP({}, { "form-action": ["'self'"] });
+    expect(out).toContain("form-action 'self'");
+  });
+
+  it("the no-csp branch still respects cspDirectives merge", () => {
+    const out = buildCSP(undefined, {
+      "script-src": ["'unsafe-eval'"],
+    });
+    const scriptLine = out
+      .split(";")
+      .map((s) => s.trim())
+      .find((s) => s.startsWith("script-src "));
+    expect(scriptLine).toContain("'unsafe-inline'");
+    expect(scriptLine).toContain("'unsafe-eval'");
+  });
+});

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
@@ -161,6 +161,19 @@ describe("sandbox-proxy buildCSP merge rule", () => {
     expect(frameSrc).not.toMatch(/(?:^|\s)blob:(?:\s|$)/);
   });
 
+  it("treats cspDirectives with only empty-array entries as no-override (keeps restrictive defaults)", () => {
+    // Regression: `cspDirectives: { "frame-src": [] }` is semantically
+    // a no-op (no source expressions for that directive). Without a
+    // non-empty check, it used to flip the no-csp branch's baseline
+    // from restrictive secure-default to broad permissive (`https:` /
+    // `wss:` on connect-src etc.), silently widening the iframe's
+    // network surface for widgets without their own _meta.ui.csp.
+    const out = buildCSP(undefined, { "frame-src": [] });
+    expect(out).toContain("connect-src 'none'");
+    expect(out).toContain("frame-src 'none'");
+    expect(out).toContain("default-src 'none'");
+  });
+
   it("appends unknown cspDirectives keys in the no-csp branch too", () => {
     // Regression: the !csp branch previously early-returned after merging
     // only the 10 known directives, dropping unknown keys (e.g. `form-action`,

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
@@ -29,13 +29,22 @@ const html = fs.readFileSync(
 );
 
 // Extract sanitizeDomain + buildCSP source from the inline <script>.
+// Locates the function signature with a forgiving regex, then walks the
+// body counting `{` / `}` so reformatting (whitespace, brace indentation)
+// in `sandbox-proxy.html` doesn't break the test.
 function extract(name: string): string {
-  const re = new RegExp(
-    `function\\s+${name}\\s*\\([^)]*\\)\\s*\\{([\\s\\S]*?)\\n\\s{6}\\}`,
-  );
-  const m = html.match(re);
+  const sig = new RegExp(`function\\s+${name}\\s*\\([^)]*\\)\\s*\\{`);
+  const m = sig.exec(html);
   if (!m) throw new Error(`Could not extract function ${name}`);
-  return m[0];
+  let i = m.index + m[0].length;
+  let depth = 1;
+  while (i < html.length && depth > 0) {
+    const ch = html[i++];
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+  }
+  if (depth !== 0) throw new Error(`Unbalanced braces in ${name}`);
+  return html.slice(m.index, i);
 }
 
 const sanitize = extract("sanitizeDomain");

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
@@ -154,6 +154,35 @@ describe("sandbox-proxy buildCSP merge rule", () => {
     expect(connectLine).not.toContain("'self'");
   });
 
+  it("uses permissive baselines (not restrictive) on no-csp + cspDirectives — ChatGPT-style profile", () => {
+    // Regression for: a profile like ChatGPT that lists only `frame-src`
+    // in cspDirectives (because the real host's emitted CSP only
+    // constrains frame-src) used to force restrictive defaults on every
+    // other directive — so a widget without its own _meta.ui.csp got
+    // `connect-src 'none'` / restrictive `script-src` and silently
+    // failed even though the modeled host wouldn't block it.
+    const out = buildCSP(undefined, {
+      "frame-src": ["'self'", "https:", "data:", "blob:"],
+    });
+    const lines = out.split(";").map((s) => s.trim());
+    const get = (name: string) => lines.find((l) => l.startsWith(name + " "));
+
+    // Directives NOT in cspDirectives should be permissive (specifically
+    // include 'unsafe-inline' / 'https:' / 'data:' / 'blob:' so widget
+    // code can execute and fetch normally).
+    expect(get("script-src")).toContain("'unsafe-inline'");
+    expect(get("script-src")).toContain("https:");
+    expect(get("connect-src")).toContain("https:");
+    expect(get("connect-src")).not.toContain("'none'");
+
+    // frame-src IS in cspDirectives — gets the listed tokens (and no `*`
+    // wildcard in the baseline that would dilute them back to permissive).
+    const frameSrc = get("frame-src");
+    expect(frameSrc).toContain("'self'");
+    expect(frameSrc).toContain("https:");
+    expect(frameSrc).not.toContain("*");
+  });
+
   it("drops cspDirectives keys containing CSP separators or whitespace", () => {
     // The key is concatenated into the output via `name + " " + tokens`,
     // so a crafted name like `"worker-src *; script-src"` would smuggle

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
@@ -183,6 +183,19 @@ describe("sandbox-proxy buildCSP merge rule", () => {
     expect(out).toContain("frame-src 'none'");
   });
 
+  it("treats cspDirectives with HTML-attribute-breakout tokens as no-override", () => {
+    // mergeDirective rejects `"`, `<`, `>` (they'd break out of the
+    // injectCSP meta-tag content attribute). hasCspOverrides must
+    // mirror that filter — otherwise an entry like `["https:\"><script>"]`
+    // flips the baseline to permissive for every other directive while
+    // contributing zero tokens to the named one.
+    const out = buildCSP(undefined, {
+      "frame-src": ['https:"><script>'],
+    });
+    expect(out).toContain("connect-src 'none'");
+    expect(out).toContain("frame-src 'none'");
+  });
+
   it("treats cspDirectives with only empty-array entries as no-override (keeps restrictive defaults)", () => {
     // Regression: `cspDirectives: { "frame-src": [] }` is semantically
     // a no-op (no source expressions for that directive). Without a

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
@@ -111,7 +111,16 @@ describe("sandbox-proxy buildCSP merge rule", () => {
     expect(out).toContain("form-action 'self'");
   });
 
-  it("the no-csp branch still respects cspDirectives merge", () => {
+  it("no-csp + cspDirectives REPLACES the baseline for overridden directives", () => {
+    // When cspDirectives names a directive, the profile is authoritative
+    // — the permissive baseline is dropped so a restrictive entry isn't
+    // diluted (e.g. `frame-src "https://widgets.example.com"` must not
+    // be widened to `frame-src https: data: blob: https://widgets...`).
+    //
+    // Template authors who want 'unsafe-inline' alongside 'unsafe-eval'
+    // for script-src must list both explicitly; the inspector won't
+    // silently add baseline tokens that would lie about the modeled
+    // host's CSP shape.
     const out = buildCSP(undefined, {
       "script-src": ["'unsafe-eval'"],
     });
@@ -119,8 +128,37 @@ describe("sandbox-proxy buildCSP merge rule", () => {
       .split(";")
       .map((s) => s.trim())
       .find((s) => s.startsWith("script-src "));
-    expect(scriptLine).toContain("'unsafe-inline'");
-    expect(scriptLine).toContain("'unsafe-eval'");
+    expect(scriptLine).toBe("script-src 'unsafe-eval'");
+  });
+
+  it("no-csp + cspDirectives keeps permissive defaults on UNOVERRIDDEN directives", () => {
+    // The ChatGPT case: profile only restricts frame-src. Other
+    // directives stay permissive (with 'unsafe-inline' / https: / etc.)
+    // so widgets without their own CSP keep working.
+    const out = buildCSP(undefined, {
+      "frame-src": ["'self'", "https://embed.example.com"],
+    });
+    const lines = out.split(";").map((s) => s.trim());
+    const get = (name: string) => lines.find((l) => l.startsWith(name + " "));
+
+    // script-src wasn't overridden → permissive baseline applies.
+    expect(get("script-src")).toContain("'unsafe-inline'");
+    expect(get("script-src")).toContain("https:");
+    // connect-src wasn't overridden → permissive baseline applies.
+    expect(get("connect-src")).toContain("https:");
+
+    // frame-src IS in cspDirectives → REPLACE, no permissive dilution.
+    // The strict `toBe` pins the full directive shape; the regex
+    // assertions below additionally guard against the scheme-only
+    // `https:` (or `data:` / `blob:`) tokens bleeding in from the
+    // permissive baseline as separate tokens, which is what we're
+    // specifically defending against (`https://embed...` contains the
+    // substring "https:" but is a host-bearing token, not scheme-wide).
+    const frameSrc = get("frame-src");
+    expect(frameSrc).toBe("frame-src 'self' https://embed.example.com");
+    expect(frameSrc).not.toMatch(/(?:^|\s)https:(?:\s|$)/);
+    expect(frameSrc).not.toMatch(/(?:^|\s)data:(?:\s|$)/);
+    expect(frameSrc).not.toMatch(/(?:^|\s)blob:(?:\s|$)/);
   });
 
   it("appends unknown cspDirectives keys in the no-csp branch too", () => {

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
@@ -161,6 +161,28 @@ describe("sandbox-proxy buildCSP merge rule", () => {
     expect(frameSrc).not.toMatch(/(?:^|\s)blob:(?:\s|$)/);
   });
 
+  it("treats cspDirectives with only whitespace-string entries as no-override", () => {
+    // Regression: `{ "frame-src": [" "] }` and similar entries trim
+    // away to nothing in mergeDirective, so they contribute nothing to
+    // frame-src — but `hasCspOverrides` used to count them as
+    // "configured" and flip every other directive's baseline from
+    // restrictive secure-default to broad permissive.
+    const out = buildCSP(undefined, { "frame-src": [" "] });
+    expect(out).toContain("connect-src 'none'");
+    expect(out).toContain("frame-src 'none'");
+  });
+
+  it("treats cspDirectives with only injection-rejected entries as no-override", () => {
+    // Same idea for tokens rejected by the `;,\n\r` injection guard —
+    // mergeDirective drops them, so they contribute nothing and must
+    // not flip the baseline.
+    const out = buildCSP(undefined, {
+      "frame-src": ["bad;injection"],
+    });
+    expect(out).toContain("connect-src 'none'");
+    expect(out).toContain("frame-src 'none'");
+  });
+
   it("treats cspDirectives with only empty-array entries as no-override (keeps restrictive defaults)", () => {
     // Regression: `cspDirectives: { "frame-src": [] }` is semantically
     // a no-op (no source expressions for that directive). Without a

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
@@ -135,4 +135,33 @@ describe("sandbox-proxy buildCSP merge rule", () => {
     expect(out).toContain("form-action 'self'");
     expect(out).toContain("worker-src blob:");
   });
+
+  it("drops cspDirectives value tokens containing ';' — injection guard", () => {
+    // Defense in depth: the backend canonicalizer rejects this at write
+    // time, but if it ever drifts the proxy must not blindly concatenate
+    // a token like `"'self'; script-src *"` into the CSP — that would
+    // break out of the intended directive and smuggle a wildcard.
+    const out = buildCSP({}, {
+      "connect-src": ["'self'; script-src *"],
+    });
+    // The injected directive must not appear in the output.
+    expect(out).not.toContain("script-src *");
+    // The hostile token must not be emitted under connect-src either.
+    const connectLine = out
+      .split(";")
+      .map((s) => s.trim())
+      .find((s) => s.startsWith("connect-src "));
+    expect(connectLine).not.toContain("'self'");
+  });
+
+  it("drops cspDirectives keys containing CSP separators or whitespace", () => {
+    // The key is concatenated into the output via `name + " " + tokens`,
+    // so a crafted name like `"worker-src *; script-src"` would smuggle
+    // a second directive even if every value token is clean.
+    const out = buildCSP({}, {
+      "worker-src *; script-src": ["'unsafe-eval'"],
+    });
+    expect(out).not.toContain("script-src 'unsafe-eval'");
+    expect(out).not.toContain("worker-src *");
+  });
 });

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
@@ -221,6 +221,50 @@ describe("sandbox-proxy buildCSP merge rule", () => {
     expect(frameSrc).not.toContain("*");
   });
 
+  it("drops cspDirectives value tokens containing HTML-attribute breakouts — meta-tag injection guard", () => {
+    // The merged CSP string is injected as the value of
+    // `<meta http-equiv="Content-Security-Policy" content="...">` without
+    // HTML-escaping. A token containing `"`, `<`, or `>` would close the
+    // content attribute or open a tag in the srcdoc before the intended
+    // CSP is established. CSP source expressions never legitimately
+    // contain these characters, so reject them outright.
+    const out = buildCSP(
+      {},
+      {
+        "connect-src": [
+          "'self\"><script>alert(1)</script>",
+          "https://evil<>.example",
+        ],
+      },
+    );
+    expect(out).not.toContain("<script>");
+    expect(out).not.toContain('">');
+    expect(out).not.toContain("<");
+    expect(out).not.toContain(">");
+    expect(out).not.toContain('"');
+    const connectLine = out
+      .split(";")
+      .map((s) => s.trim())
+      .find((s) => s.startsWith("connect-src "));
+    // Both hostile tokens dropped → directive falls back to 'none'.
+    expect(connectLine).toBe("connect-src 'none'");
+  });
+
+  it("drops cspDirectives keys containing HTML-attribute breakouts", () => {
+    // Same risk as the value path: the key flows into the unescaped
+    // content="..." of the injected <meta> tag via `name + " " + tokens`.
+    const out = buildCSP(
+      {},
+      {
+        'x"><script>alert(1)</script><x ': ["'self'"],
+      },
+    );
+    expect(out).not.toContain("<script>");
+    expect(out).not.toContain('"');
+    expect(out).not.toContain("<");
+    expect(out).not.toContain(">");
+  });
+
   it("drops cspDirectives keys containing CSP separators or whitespace", () => {
     // The key is concatenated into the output via `name + " " + tokens`,
     // so a crafted name like `"worker-src *; script-src"` would smuggle

--- a/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
+++ b/mcpjam-inspector/server/__tests__/sandbox-proxy-buildCSP.test.ts
@@ -113,4 +113,17 @@ describe("sandbox-proxy buildCSP merge rule", () => {
     expect(scriptLine).toContain("'unsafe-inline'");
     expect(scriptLine).toContain("'unsafe-eval'");
   });
+
+  it("appends unknown cspDirectives keys in the no-csp branch too", () => {
+    // Regression: the !csp branch previously early-returned after merging
+    // only the 10 known directives, dropping unknown keys (e.g. `form-action`,
+    // `worker-src`) — breaking the round-trip guarantee whenever no CSP
+    // metadata was declared.
+    const out = buildCSP(undefined, {
+      "form-action": ["'self'"],
+      "worker-src": ["blob:"],
+    });
+    expect(out).toContain("form-action 'self'");
+    expect(out).toContain("worker-src blob:");
+  });
 });

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -183,7 +183,12 @@
             if (typeof t !== "string") return false;
             const trimmed = t.trim();
             if (trimmed.length === 0) return false;
-            if (/[;,\n\r]/.test(trimmed)) return false;
+            // Keep this in lockstep with mergeDirective's filter above.
+            // Any character class it rejects must be rejected here too,
+            // or the predicate flips hasCspOverrides for an entry that
+            // ultimately contributes zero tokens — widening every
+            // unrelated directive's baseline for nothing.
+            if (/[;,\n\r"<>]/.test(trimmed)) return false;
             return true;
           };
           const hasCspOverrides =

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -150,54 +150,66 @@
         if (!csp) {
           // Two baselines for the no-csp branch:
           //   - When cspDirectives is set, the profile is modeling a host
-          //     whose emitted CSP is unconstrained EXCEPT for the directives
-          //     it explicitly lists. Use SPECIFIC permissive baselines
-          //     (no `*` wildcard — so cspDirectives entries that name
-          //     specific origins, e.g. ChatGPT's `frame-src 'self' https:
-          //     data: blob:`, actually constrain via the union merge rather
-          //     than being diluted back to permissive by a `*` in the base).
-          //     Widgets without their own `_meta.ui.csp` still need
-          //     `'unsafe-inline'`, `data:`, `https:`, etc. to function.
-          //   - Otherwise (pure no-csp, no overrides), restrictive defaults
-          //     for SEP-1865 secure-default behavior.
+          //     whose emitted CSP is unconstrained EXCEPT for the
+          //     directives it explicitly lists. For directives IN
+          //     cspDirectives, the profile is authoritative (REPLACE the
+          //     baseline — otherwise a permissive base like `https:` would
+          //     dilute a restrictive entry like
+          //     `frame-src "https://widgets.example.com"` back to "any
+          //     HTTPS frame"). For directives NOT in cspDirectives, use
+          //     specific permissive baselines (no `*`) so widgets without
+          //     their own `_meta.ui.csp` can still execute inline scripts,
+          //     load images, fetch over HTTPS, etc.
+          //   - Otherwise (pure no-csp, no overrides), restrictive
+          //     defaults for SEP-1865 secure-default behavior.
           const hasCspOverrides =
             cspDirectives &&
             typeof cspDirectives === "object" &&
             Object.keys(cspDirectives).length > 0;
           if (hasCspOverrides) {
+            // Helper: if cspDirectives names this directive, emit ONLY
+            // the profile's tokens (REPLACE). Otherwise emit the
+            // permissive default tokens (browser-default-like for an
+            // unconstrained host).
+            const emitOverridable = (name, permissiveBase) => {
+              const hasOverride =
+                Array.isArray(cspDirectives[name]) &&
+                cspDirectives[name].length > 0;
+              return mergeDirective(name, hasOverride ? [] : permissiveBase);
+            };
             directives = [
-              mergeDirective("default-src", [
+              emitOverridable("default-src", [
                 "'unsafe-inline'",
                 "'unsafe-eval'",
                 "data:",
                 "blob:",
                 "https:",
               ]),
-              mergeDirective("script-src", [
+              emitOverridable("script-src", [
                 "'unsafe-inline'",
                 "'unsafe-eval'",
                 "data:",
                 "blob:",
                 "https:",
               ]),
-              mergeDirective("style-src", [
+              emitOverridable("style-src", [
                 "'unsafe-inline'",
                 "data:",
                 "blob:",
                 "https:",
               ]),
-              mergeDirective("img-src", ["data:", "blob:", "https:"]),
-              mergeDirective("font-src", ["data:", "blob:", "https:"]),
-              mergeDirective("media-src", ["data:", "blob:", "https:"]),
-              mergeDirective("connect-src", [
+              emitOverridable("img-src", ["data:", "blob:", "https:"]),
+              emitOverridable("font-src", ["data:", "blob:", "https:"]),
+              emitOverridable("media-src", ["data:", "blob:", "https:"]),
+              emitOverridable("connect-src", [
                 "data:",
                 "blob:",
                 "https:",
                 "wss:",
               ]),
-              mergeDirective("frame-src", ["data:", "blob:", "https:"]),
-              mergeDirective("object-src", ["'none'"]),
-              mergeDirective("base-uri", ["'self'"]),
+              emitOverridable("frame-src", ["data:", "blob:", "https:"]),
+              emitOverridable("object-src", ["'none'"]),
+              emitOverridable("base-uri", ["'self'"]),
             ];
           } else {
             directives = [

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -148,18 +148,71 @@
         // So we use 'unsafe-inline' for scripts/styles since all widget code is inline
         let directives;
         if (!csp) {
-          directives = [
-            mergeDirective("default-src", ["'none'"]),
-            mergeDirective("script-src", ["'unsafe-inline'"]),
-            mergeDirective("style-src", ["'unsafe-inline'"]),
-            mergeDirective("img-src", ["data:"]),
-            mergeDirective("font-src", ["data:"]),
-            mergeDirective("media-src", ["data:"]),
-            mergeDirective("connect-src", ["'none'"]),
-            mergeDirective("frame-src", ["'none'"]),
-            mergeDirective("object-src", ["'none'"]),
-            mergeDirective("base-uri", ["'none'"]),
-          ];
+          // Two baselines for the no-csp branch:
+          //   - When cspDirectives is set, the profile is modeling a host
+          //     whose emitted CSP is unconstrained EXCEPT for the directives
+          //     it explicitly lists. Use SPECIFIC permissive baselines
+          //     (no `*` wildcard — so cspDirectives entries that name
+          //     specific origins, e.g. ChatGPT's `frame-src 'self' https:
+          //     data: blob:`, actually constrain via the union merge rather
+          //     than being diluted back to permissive by a `*` in the base).
+          //     Widgets without their own `_meta.ui.csp` still need
+          //     `'unsafe-inline'`, `data:`, `https:`, etc. to function.
+          //   - Otherwise (pure no-csp, no overrides), restrictive defaults
+          //     for SEP-1865 secure-default behavior.
+          const hasCspOverrides =
+            cspDirectives &&
+            typeof cspDirectives === "object" &&
+            Object.keys(cspDirectives).length > 0;
+          if (hasCspOverrides) {
+            directives = [
+              mergeDirective("default-src", [
+                "'unsafe-inline'",
+                "'unsafe-eval'",
+                "data:",
+                "blob:",
+                "https:",
+              ]),
+              mergeDirective("script-src", [
+                "'unsafe-inline'",
+                "'unsafe-eval'",
+                "data:",
+                "blob:",
+                "https:",
+              ]),
+              mergeDirective("style-src", [
+                "'unsafe-inline'",
+                "data:",
+                "blob:",
+                "https:",
+              ]),
+              mergeDirective("img-src", ["data:", "blob:", "https:"]),
+              mergeDirective("font-src", ["data:", "blob:", "https:"]),
+              mergeDirective("media-src", ["data:", "blob:", "https:"]),
+              mergeDirective("connect-src", [
+                "data:",
+                "blob:",
+                "https:",
+                "wss:",
+              ]),
+              mergeDirective("frame-src", ["data:", "blob:", "https:"]),
+              mergeDirective("object-src", ["'none'"]),
+              mergeDirective("base-uri", ["'self'"]),
+            ];
+          } else {
+            directives = [
+              mergeDirective("default-src", ["'none'"]),
+              mergeDirective("script-src", ["'unsafe-inline'"]),
+              mergeDirective("style-src", ["'unsafe-inline'"]),
+              mergeDirective("img-src", ["data:"]),
+              mergeDirective("font-src", ["data:"]),
+              mergeDirective("media-src", ["data:"]),
+              mergeDirective("connect-src", ["'none'"]),
+              mergeDirective("frame-src", ["'none'"]),
+              mergeDirective("object-src", ["'none'"]),
+              mergeDirective("base-uri", ["'none'"]),
+            ];
+          }
         } else {
           // Build CSP from declared domains (SEP-1865)
           // Per spec: "Host MAY further restrict but MUST NOT allow undeclared domains"

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -440,10 +440,18 @@ document.addEventListener('securitypolicyviolation', function(e) {
               sandboxTokens.add("allow-scripts");
               sandboxTokens.add("allow-same-origin");
               for (const t of sandboxAttrs) {
-                if (typeof t === "string") {
-                  const trimmed = t.trim();
-                  if (trimmed.length > 0) sandboxTokens.add(trimmed);
-                }
+                if (typeof t !== "string") continue;
+                const trimmed = t.trim();
+                if (trimmed.length === 0) continue;
+                // Reject tokens with internal whitespace — see the
+                // matching renderer-side guard in sandboxed-iframe.tsx.
+                // Without this, a profile entry like
+                // `"allow-forms allow-popups-to-escape-sandbox"` would
+                // round-trip as one Set member but the eventual
+                // join(" ") would emit it as two real sandbox flags,
+                // silently widening the inner iframe's grants.
+                if (/\s/.test(trimmed)) continue;
+                sandboxTokens.add(trimmed);
               }
             } else {
               const baseSandbox =

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -122,8 +122,19 @@
             if (typeof t === "string" && t.length > 0) merged.add(t);
           }
           for (const t of extras) {
-            if (typeof t === "string" && t.trim().length > 0)
-              merged.add(t.trim());
+            if (typeof t !== "string") continue;
+            const trimmed = t.trim();
+            if (trimmed.length === 0) continue;
+            // Reject CSP directive separators (`;`) and structural chars
+            // (`,`, newlines, quote-wrapping whitespace) in extras. The
+            // backend canonicalizer is the primary defense, but a crafted
+            // cspDirectives value like `"'self'; script-src *"` would
+            // otherwise break out of the intended directive and inject
+            // an attacker-controlled one when joined with " " below.
+            // Same defense-in-depth as the allowFeatures filter applied
+            // in sandboxed-iframe.tsx.
+            if (/[;,\n\r]/.test(trimmed)) continue;
+            merged.add(trimmed);
           }
           if (merged.size > 1 && merged.has("'none'")) {
             merged.delete("'none'");
@@ -220,6 +231,11 @@
           ]);
           for (const k of Object.keys(cspDirectives).sort()) {
             if (known.has(k)) continue;
+            // Reject CSP separators in the directive NAME too — `k` is
+            // concatenated into the output via `name + " " + tokens`, so
+            // a crafted key like `worker-src *; script-src` would inject
+            // a second directive even if every value token is clean.
+            if (/[;,\n\r\s]/.test(k)) continue;
             const tokens = cspDirectives[k];
             if (!Array.isArray(tokens) || tokens.length === 0) continue;
             directives.push(mergeDirective(k, []));

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -135,8 +135,9 @@
         // Per SEP-1865: If no CSP declared, use restrictive defaults
         // Note: 'self' doesn't work in srcdoc iframes (refers to about:srcdoc)
         // So we use 'unsafe-inline' for scripts/styles since all widget code is inline
+        let directives;
         if (!csp) {
-          return [
+          directives = [
             mergeDirective("default-src", ["'none'"]),
             mergeDirective("script-src", ["'unsafe-inline'"]),
             mergeDirective("style-src", ["'unsafe-inline'"]),
@@ -147,59 +148,63 @@
             mergeDirective("frame-src", ["'none'"]),
             mergeDirective("object-src", ["'none'"]),
             mergeDirective("base-uri", ["'none'"]),
-          ].join("; ");
+          ];
+        } else {
+          // Build CSP from declared domains (SEP-1865)
+          // Per spec: "Host MAY further restrict but MUST NOT allow undeclared domains"
+          const connectDomains = (csp.connectDomains || [])
+            .map(sanitizeDomain)
+            .filter(Boolean);
+          const resourceDomains = (csp.resourceDomains || [])
+            .map(sanitizeDomain)
+            .filter(Boolean);
+          const frameDomains = (csp.frameDomains || [])
+            .map(sanitizeDomain)
+            .filter(Boolean);
+          const baseUriDomains = (csp.baseUriDomains || [])
+            .map(sanitizeDomain)
+            .filter(Boolean);
+
+          // connect-src: Only allow declared domains, or 'none' if empty
+          const connectTokens =
+            connectDomains.length > 0 ? connectDomains.slice() : ["'none'"];
+
+          // Resource sources: data: and blob: are always allowed for inline content
+          // Only add declared resourceDomains - no forced CDNs per SEP-1865
+          const resourceTokens =
+            resourceDomains.length > 0
+              ? ["data:", "blob:", ...resourceDomains]
+              : ["data:", "blob:"];
+
+          // frame-src: Only allow declared frame domains, or 'none' if empty
+          const frameTokens =
+            frameDomains.length > 0 ? frameDomains.slice() : ["'none'"];
+
+          // base-uri: Only allow declared base URI domains, or 'none' if empty
+          const baseUriTokens =
+            baseUriDomains.length > 0 ? baseUriDomains.slice() : ["'none'"];
+
+          directives = [
+            mergeDirective("default-src", ["'none'"]),
+            mergeDirective("script-src", ["'unsafe-inline'", ...resourceTokens]),
+            mergeDirective("style-src", ["'unsafe-inline'", ...resourceTokens]),
+            mergeDirective("img-src", resourceTokens),
+            mergeDirective("font-src", resourceTokens),
+            mergeDirective("media-src", resourceTokens),
+            mergeDirective("connect-src", connectTokens),
+            mergeDirective("frame-src", frameTokens),
+            mergeDirective("object-src", ["'none'"]),
+            mergeDirective("base-uri", baseUriTokens),
+          ];
         }
-
-        // Build CSP from declared domains (SEP-1865)
-        // Per spec: "Host MAY further restrict but MUST NOT allow undeclared domains"
-        const connectDomains = (csp.connectDomains || [])
-          .map(sanitizeDomain)
-          .filter(Boolean);
-        const resourceDomains = (csp.resourceDomains || [])
-          .map(sanitizeDomain)
-          .filter(Boolean);
-        const frameDomains = (csp.frameDomains || [])
-          .map(sanitizeDomain)
-          .filter(Boolean);
-        const baseUriDomains = (csp.baseUriDomains || [])
-          .map(sanitizeDomain)
-          .filter(Boolean);
-
-        // connect-src: Only allow declared domains, or 'none' if empty
-        const connectTokens =
-          connectDomains.length > 0 ? connectDomains.slice() : ["'none'"];
-
-        // Resource sources: data: and blob: are always allowed for inline content
-        // Only add declared resourceDomains - no forced CDNs per SEP-1865
-        const resourceTokens =
-          resourceDomains.length > 0
-            ? ["data:", "blob:", ...resourceDomains]
-            : ["data:", "blob:"];
-
-        // frame-src: Only allow declared frame domains, or 'none' if empty
-        const frameTokens =
-          frameDomains.length > 0 ? frameDomains.slice() : ["'none'"];
-
-        // base-uri: Only allow declared base URI domains, or 'none' if empty
-        const baseUriTokens =
-          baseUriDomains.length > 0 ? baseUriDomains.slice() : ["'none'"];
-
-        const directives = [
-          mergeDirective("default-src", ["'none'"]),
-          mergeDirective("script-src", ["'unsafe-inline'", ...resourceTokens]),
-          mergeDirective("style-src", ["'unsafe-inline'", ...resourceTokens]),
-          mergeDirective("img-src", resourceTokens),
-          mergeDirective("font-src", resourceTokens),
-          mergeDirective("media-src", resourceTokens),
-          mergeDirective("connect-src", connectTokens),
-          mergeDirective("frame-src", frameTokens),
-          mergeDirective("object-src", ["'none'"]),
-          mergeDirective("base-uri", baseUriTokens),
-        ];
 
         // If cspDirectives names a directive we didn't emit above (e.g.
         // `form-action`, `worker-src`), append it verbatim so inspector
         // probes that capture additional directives round-trip end-to-end.
+        // Runs in both the !csp and truthy-csp branches: a host that
+        // declares no CSP metadata but supplies inspector-only directive
+        // overrides (the documented `form-action` round-trip case) still
+        // gets them appended.
         if (cspDirectives && typeof cspDirectives === "object") {
           const known = new Set([
             "default-src",

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -91,25 +91,62 @@
 
       /**
        * Build CSP string from metadata (SEP-1865)
+       *
+       * CSP merge rule per directive:
+       *   tokens = unique(domain-derived tokens ++ cspDirectives[directive])
+       *   if tokens contains anything other than 'none', drop 'none'
+       *   emit `<directive> ${tokens.join(" ")}` (or `<directive> 'none'` if
+       *   tokens === ['none'])
+       *
+       * Rationale: `'none' 'self'` is invalid CSP. The domain-derived branch
+       * emits 'none' for empty allowlists (frameDomains: [] → frame-src 'none'),
+       * and cspDirectives can add real tokens on top. Union-and-drop-'none' is
+       * the only sound merge.
+       *
        * @param {Object} csp - CSP metadata with connectDomains, resourceDomains, frameDomains, and baseUriDomains
+       * @param {Object} cspDirectives - Per-directive source-expression overrides
+       *   (inspector-only). Keys are CSP directive names (`script-src`, …);
+       *   values are token arrays.
        * @returns {string} CSP policy string
        */
-      function buildCSP(csp) {
+      function buildCSP(csp, cspDirectives) {
+        // Merge a single directive's domain-derived tokens with any extra
+        // tokens supplied by cspDirectives. See merge rule above the function.
+        function mergeDirective(name, baseTokens) {
+          const extras =
+            cspDirectives && Array.isArray(cspDirectives[name])
+              ? cspDirectives[name]
+              : [];
+          const merged = new Set();
+          for (const t of baseTokens) {
+            if (typeof t === "string" && t.length > 0) merged.add(t);
+          }
+          for (const t of extras) {
+            if (typeof t === "string" && t.trim().length > 0)
+              merged.add(t.trim());
+          }
+          if (merged.size > 1 && merged.has("'none'")) {
+            merged.delete("'none'");
+          }
+          if (merged.size === 0) return name + " 'none'";
+          return name + " " + Array.from(merged).join(" ");
+        }
+
         // Per SEP-1865: If no CSP declared, use restrictive defaults
         // Note: 'self' doesn't work in srcdoc iframes (refers to about:srcdoc)
         // So we use 'unsafe-inline' for scripts/styles since all widget code is inline
         if (!csp) {
           return [
-            "default-src 'none'",
-            "script-src 'unsafe-inline'",
-            "style-src 'unsafe-inline'",
-            "img-src data:",
-            "font-src data:",
-            "media-src data:",
-            "connect-src 'none'",
-            "frame-src 'none'",
-            "object-src 'none'",
-            "base-uri 'none'",
+            mergeDirective("default-src", ["'none'"]),
+            mergeDirective("script-src", ["'unsafe-inline'"]),
+            mergeDirective("style-src", ["'unsafe-inline'"]),
+            mergeDirective("img-src", ["data:"]),
+            mergeDirective("font-src", ["data:"]),
+            mergeDirective("media-src", ["data:"]),
+            mergeDirective("connect-src", ["'none'"]),
+            mergeDirective("frame-src", ["'none'"]),
+            mergeDirective("object-src", ["'none'"]),
+            mergeDirective("base-uri", ["'none'"]),
           ].join("; ");
         }
 
@@ -129,59 +166,64 @@
           .filter(Boolean);
 
         // connect-src: Only allow declared domains, or 'none' if empty
-        const connectSrc =
-          connectDomains.length > 0 ? connectDomains.join(" ") : "'none'";
+        const connectTokens =
+          connectDomains.length > 0 ? connectDomains.slice() : ["'none'"];
 
         // Resource sources: data: and blob: are always allowed for inline content
         // Only add declared resourceDomains - no forced CDNs per SEP-1865
-        const resourceSrc =
+        const resourceTokens =
           resourceDomains.length > 0
-            ? ["data:", "blob:", ...resourceDomains].join(" ")
-            : "data: blob:";
+            ? ["data:", "blob:", ...resourceDomains]
+            : ["data:", "blob:"];
 
         // frame-src: Only allow declared frame domains, or 'none' if empty
-        const frameSrc =
-          frameDomains.length > 0 ? frameDomains.join(" ") : "'none'";
+        const frameTokens =
+          frameDomains.length > 0 ? frameDomains.slice() : ["'none'"];
 
         // base-uri: Only allow declared base URI domains, or 'none' if empty
-        const baseUri =
-          baseUriDomains.length > 0 ? baseUriDomains.join(" ") : "'none'";
+        const baseUriTokens =
+          baseUriDomains.length > 0 ? baseUriDomains.slice() : ["'none'"];
 
-        console.log("[buildCSP] Processing domains:", {
-          frameDomains,
-          frameSrc,
-          baseUriDomains,
-          baseUri,
-        });
+        const directives = [
+          mergeDirective("default-src", ["'none'"]),
+          mergeDirective("script-src", ["'unsafe-inline'", ...resourceTokens]),
+          mergeDirective("style-src", ["'unsafe-inline'", ...resourceTokens]),
+          mergeDirective("img-src", resourceTokens),
+          mergeDirective("font-src", resourceTokens),
+          mergeDirective("media-src", resourceTokens),
+          mergeDirective("connect-src", connectTokens),
+          mergeDirective("frame-src", frameTokens),
+          mergeDirective("object-src", ["'none'"]),
+          mergeDirective("base-uri", baseUriTokens),
+        ];
 
-        console.log(
-          "[buildCSP] Built CSP string:",
-          [
-            "default-src 'none'",
-            "script-src 'unsafe-inline' " + resourceSrc,
-            "style-src 'unsafe-inline' " + resourceSrc,
-            "img-src " + resourceSrc,
-            "font-src " + resourceSrc,
-            "media-src " + resourceSrc,
-            "connect-src " + connectSrc,
-            "frame-src " + frameSrc,
-            "object-src 'none'",
-            "base-uri " + baseUri,
-          ].join("; "),
-        );
+        // If cspDirectives names a directive we didn't emit above (e.g.
+        // `form-action`, `worker-src`), append it verbatim so inspector
+        // probes that capture additional directives round-trip end-to-end.
+        if (cspDirectives && typeof cspDirectives === "object") {
+          const known = new Set([
+            "default-src",
+            "script-src",
+            "style-src",
+            "img-src",
+            "font-src",
+            "media-src",
+            "connect-src",
+            "frame-src",
+            "object-src",
+            "base-uri",
+          ]);
+          for (const k of Object.keys(cspDirectives).sort()) {
+            if (known.has(k)) continue;
+            const tokens = cspDirectives[k];
+            if (!Array.isArray(tokens) || tokens.length === 0) continue;
+            directives.push(mergeDirective(k, []));
+          }
+        }
 
-        return [
-          "default-src 'none'",
-          "script-src 'unsafe-inline' " + resourceSrc,
-          "style-src 'unsafe-inline' " + resourceSrc,
-          "img-src " + resourceSrc,
-          "font-src " + resourceSrc,
-          "media-src " + resourceSrc,
-          "connect-src " + connectSrc,
-          "frame-src " + frameSrc,
-          "object-src 'none'",
-          "base-uri " + baseUri,
-        ].join("; ");
+        const cspString = directives.join("; ");
+        console.log("[buildCSP] Built CSP string:", cspString);
+        return cspString;
       }
 
       /**
@@ -282,18 +324,70 @@ document.addEventListener('securitypolicyviolation', function(e) {
             event.data.method === "ui/notifications/sandbox-resource-ready"
           ) {
             // Load HTML into inner iframe with CSP enforcement
-            const { html, sandbox, csp, permissions, permissive, colorScheme } =
-              event.data.params || {};
+            const {
+              html,
+              sandbox,
+              csp,
+              permissions,
+              sandboxAttrs,
+              allowFeatures,
+              cspDirectives,
+              permissive,
+              colorScheme,
+            } = event.data.params || {};
             inner.style.colorScheme = applyColorScheme(colorScheme);
 
-            if (typeof sandbox === "string") {
-              inner.setAttribute("sandbox", sandbox);
+            // Inner iframe `sandbox=` is the union of the spec-mandated
+            // `allow-scripts allow-same-origin allow-forms` baseline (or the
+            // explicit `sandbox` string from the host) with the inspector-only
+            // `sandboxAttrs` extras. Dedupe + sort for stable DOM output.
+            const sandboxTokens = new Set();
+            const baseSandbox =
+              typeof sandbox === "string" && sandbox.length > 0
+                ? sandbox
+                : "allow-scripts allow-same-origin allow-forms";
+            for (const t of baseSandbox.split(/\s+/)) {
+              if (t.length > 0) sandboxTokens.add(t);
             }
+            // Mandatory tokens regardless of caller input.
+            sandboxTokens.add("allow-scripts");
+            sandboxTokens.add("allow-same-origin");
+            if (Array.isArray(sandboxAttrs)) {
+              for (const t of sandboxAttrs) {
+                if (typeof t === "string") {
+                  const trimmed = t.trim();
+                  if (trimmed.length > 0) sandboxTokens.add(trimmed);
+                }
+              }
+            }
+            inner.setAttribute(
+              "sandbox",
+              Array.from(sandboxTokens).sort().join(" "),
+            );
 
-            // Set Permission Policy allow attribute based on requested permissions (SEP-1865)
-            const allowAttribute = buildAllowAttribute(permissions);
-            if (allowAttribute) {
-              inner.setAttribute("allow", allowAttribute);
+            // Set Permission Policy allow attribute based on requested
+            // permissions (SEP-1865) plus any inspector-only `allowFeatures`
+            // extras (kebab Permissions Policy tokens, e.g. `fullscreen`).
+            const allowParts = [];
+            const baseAllow = buildAllowAttribute(permissions);
+            if (baseAllow) allowParts.push(baseAllow);
+            if (allowFeatures && typeof allowFeatures === "object") {
+              const specFeatures = new Set([
+                "camera",
+                "microphone",
+                "geolocation",
+                "clipboard-write",
+              ]);
+              for (const k of Object.keys(allowFeatures).sort()) {
+                if (specFeatures.has(k)) continue;
+                const v = allowFeatures[k];
+                if (typeof v === "string" && v.length > 0) {
+                  allowParts.push(k + " " + v);
+                }
+              }
+            }
+            if (allowParts.length > 0) {
+              inner.setAttribute("allow", allowParts.join("; "));
             }
 
             if (typeof html === "string") {
@@ -316,8 +410,10 @@ document.addEventListener('securitypolicyviolation', function(e) {
                 const processedHtml = injectCSP(html, permissiveCsp);
                 inner.srcdoc = processedHtml;
               } else {
-                // Build CSP and inject into HTML (SEP-1865)
-                const cspValue = buildCSP(csp);
+                // Build CSP and inject into HTML (SEP-1865). cspDirectives
+                // is the inspector-only per-directive source-expression
+                // override map (e.g. `script-src` adds `'unsafe-eval'`).
+                const cspValue = buildCSP(csp, cspDirectives);
                 const processedHtml = injectCSP(html, cspValue);
                 inner.srcdoc = processedHtml;
               }

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -397,9 +397,17 @@ document.addEventListener('securitypolicyviolation', function(e) {
               for (const k of Object.keys(allowFeatures).sort()) {
                 if (specFeatures.has(k)) continue;
                 const v = allowFeatures[k];
-                if (typeof v === "string" && v.length > 0) {
-                  allowParts.push(k + " " + v);
-                }
+                if (typeof v !== "string" || v.length === 0) continue;
+                // Reject `;` (and `,` for symmetry) in keys and values.
+                // `;` is the Permissions Policy iframe `allow=` separator,
+                // so unescaped `;` in a value turns the per-feature filter
+                // above into a directive-injection bypass (e.g.
+                // `fullscreen: "*; camera *"`). Without this check, a
+                // crafted profile could grant spec features (camera, etc.)
+                // through allowFeatures even though permissions.allow is
+                // documented as the single source of truth.
+                if (/[;,]/.test(k) || /[;,]/.test(v)) continue;
+                allowParts.push(k + " " + v);
               }
             }
             if (allowParts.length > 0) {

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -226,9 +226,7 @@
           }
         }
 
-        const cspString = directives.join("; ");
-        console.log("[buildCSP] Built CSP string:", cspString);
-        return cspString;
+        return directives.join("; ");
       }
 
       /**
@@ -383,6 +381,13 @@ document.addEventListener('securitypolicyviolation', function(e) {
             const baseAllow = buildAllowAttribute(permissions);
             if (baseAllow) allowParts.push(baseAllow);
             if (allowFeatures && typeof allowFeatures === "object") {
+              // Keep this list in sync with SEP_1865_PERMISSION_FEATURES
+              // in `convex/lib/hostConfigV2.ts` (canonical) and
+              // `client/src/lib/client-config-v2.ts` (mirror). This file
+              // is plain HTML/JS served to the proxy iframe and can't
+              // import the constant; the canonicalizer drops these keys
+              // server-side, the renderer drops them again client-side,
+              // and this is the last line of defense.
               const specFeatures = new Set([
                 "camera",
                 "microphone",

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -342,28 +342,34 @@ document.addEventListener('securitypolicyviolation', function(e) {
             } = event.data.params || {};
             inner.style.colorScheme = applyColorScheme(colorScheme);
 
-            // Inner iframe `sandbox=` is the union of the spec-mandated
-            // `allow-scripts allow-same-origin allow-forms` baseline (or the
-            // explicit `sandbox` string from the host) with the inspector-only
-            // `sandboxAttrs` extras. Dedupe + sort for stable DOM output.
+            // Inner iframe `sandbox=` value.
+            //
+            // When `sandboxAttrs` is provided (even an empty array), the
+            // profile is authoritative: only spec-mandated tokens plus what
+            // the profile lists. Otherwise (no profile opinion) fall back to
+            // the caller's `sandbox` string so existing widget renders that
+            // depend on the legacy permissive baseline keep working.
             const sandboxTokens = new Set();
-            const baseSandbox =
-              typeof sandbox === "string" && sandbox.length > 0
-                ? sandbox
-                : "allow-scripts allow-same-origin allow-forms";
-            for (const t of baseSandbox.split(/\s+/)) {
-              if (t.length > 0) sandboxTokens.add(t);
-            }
-            // Mandatory tokens regardless of caller input.
-            sandboxTokens.add("allow-scripts");
-            sandboxTokens.add("allow-same-origin");
             if (Array.isArray(sandboxAttrs)) {
+              sandboxTokens.add("allow-scripts");
+              sandboxTokens.add("allow-same-origin");
               for (const t of sandboxAttrs) {
                 if (typeof t === "string") {
                   const trimmed = t.trim();
                   if (trimmed.length > 0) sandboxTokens.add(trimmed);
                 }
               }
+            } else {
+              const baseSandbox =
+                typeof sandbox === "string" && sandbox.length > 0
+                  ? sandbox
+                  : "allow-scripts allow-same-origin allow-forms";
+              for (const t of baseSandbox.split(/\s+/)) {
+                if (t.length > 0) sandboxTokens.add(t);
+              }
+              // Defense in depth: spec-mandated tokens are always present.
+              sandboxTokens.add("allow-scripts");
+              sandboxTokens.add("allow-same-origin");
             }
             inner.setAttribute(
               "sandbox",

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -171,10 +171,21 @@
           //     load images, fetch over HTTPS, etc.
           //   - Otherwise (pure no-csp, no overrides), restrictive
           //     defaults for SEP-1865 secure-default behavior.
+          // A directive entry with an empty array (`{ "frame-src": [] }`)
+          // models "no source expressions for this directive" — semantically
+          // a no-op, not a hardening signal. Counting it as `hasCspOverrides`
+          // would flip every other directive's baseline from the secure
+          // default to the permissive baseline (broad `https:` / `wss:`)
+          // just because an empty key exists. Require at least one
+          // non-empty array entry.
           const hasCspOverrides =
             cspDirectives &&
             typeof cspDirectives === "object" &&
-            Object.keys(cspDirectives).length > 0;
+            Object.keys(cspDirectives).some(
+              (k) =>
+                Array.isArray(cspDirectives[k]) &&
+                cspDirectives[k].length > 0,
+            );
           if (hasCspOverrides) {
             // Helper: if cspDirectives names this directive, emit ONLY
             // the profile's tokens (REPLACE). Otherwise emit the

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -133,7 +133,16 @@
             // an attacker-controlled one when joined with " " below.
             // Same defense-in-depth as the allowFeatures filter applied
             // in sandboxed-iframe.tsx.
-            if (/[;,\n\r]/.test(trimmed)) continue;
+            //
+            // Also reject HTML-attribute breakouts (`"`, `<`, `>`). The
+            // merged CSP string is concatenated into
+            // `<meta http-equiv="Content-Security-Policy" content="...">`
+            // by injectCSP without escaping, so a token like
+            // `'self"><script>...` would close the content attribute and
+            // inject markup into the srcdoc before the intended CSP is
+            // established. CSP source expressions never legitimately
+            // contain these characters.
+            if (/[;,\n\r"<>]/.test(trimmed)) continue;
             merged.add(trimmed);
           }
           if (merged.size > 1 && merged.has("'none'")) {
@@ -300,7 +309,12 @@
             // concatenated into the output via `name + " " + tokens`, so
             // a crafted key like `worker-src *; script-src` would inject
             // a second directive even if every value token is clean.
-            if (/[;,\n\r\s]/.test(k)) continue;
+            // Also reject HTML-attribute breakouts (`"`, `<`, `>`) for
+            // the same reason as in mergeDirective: the directive name
+            // flows into the unescaped `content="..."` attribute of the
+            // injected <meta> tag, and a crafted key like `x"><script>`
+            // would otherwise close the attribute and inject markup.
+            if (/[;,\n\r\s"<>]/.test(k)) continue;
             const tokens = cspDirectives[k];
             if (!Array.isArray(tokens) || tokens.length === 0) continue;
             directives.push(mergeDirective(k, []));

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -326,14 +326,21 @@ document.addEventListener('securitypolicyviolation', function(e) {
             event.data &&
             event.data.method === "ui/notifications/sandbox-resource-ready"
           ) {
-            // Load HTML into inner iframe with CSP enforcement
+            // Load HTML into inner iframe with CSP enforcement.
+            //
+            // `allowFeatures` is intentionally NOT received here — by design
+            // it applies to the OUTER iframe's `allow=` attribute only. The
+            // outer/inner split (outer grants extras like `fullscreen`; inner
+            // grants only the 4 spec permissions) is enforced upstream in
+            // `sandboxed-iframe.tsx`'s postMessage payload. If `allowFeatures`
+            // shows up in the message here, it's a contract bug, not data we
+            // should consume.
             const {
               html,
               sandbox,
               csp,
               permissions,
               sandboxAttrs,
-              allowFeatures,
               cspDirectives,
               permissive,
               colorScheme,
@@ -374,44 +381,18 @@ document.addEventListener('securitypolicyviolation', function(e) {
               Array.from(sandboxTokens).sort().join(" "),
             );
 
-            // Set Permission Policy allow attribute based on requested
-            // permissions (SEP-1865) plus any inspector-only `allowFeatures`
-            // extras (kebab Permissions Policy tokens, e.g. `fullscreen`).
-            const allowParts = [];
+            // Set Permission Policy `allow=` attribute for the inner iframe
+            // from the requested spec-4 permissions only (SEP-1865:
+            // camera / microphone / geolocation / clipboard-write).
+            //
+            // Non-spec features like `fullscreen` belong on the OUTER
+            // iframe (handled in `sandboxed-iframe.tsx`'s
+            // `outerAllowAttribute`), not here. Modeling real claude.ai's
+            // pattern: outer grants extras for the wrapper, inner trims to
+            // spec so the widget only experiences what's documented.
             const baseAllow = buildAllowAttribute(permissions);
-            if (baseAllow) allowParts.push(baseAllow);
-            if (allowFeatures && typeof allowFeatures === "object") {
-              // Keep this list in sync with SEP_1865_PERMISSION_FEATURES
-              // in `convex/lib/hostConfigV2.ts` (canonical) and
-              // `client/src/lib/client-config-v2.ts` (mirror). This file
-              // is plain HTML/JS served to the proxy iframe and can't
-              // import the constant; the canonicalizer drops these keys
-              // server-side, the renderer drops them again client-side,
-              // and this is the last line of defense.
-              const specFeatures = new Set([
-                "camera",
-                "microphone",
-                "geolocation",
-                "clipboard-write",
-              ]);
-              for (const k of Object.keys(allowFeatures).sort()) {
-                if (specFeatures.has(k)) continue;
-                const v = allowFeatures[k];
-                if (typeof v !== "string" || v.length === 0) continue;
-                // Reject `;` (and `,` for symmetry) in keys and values.
-                // `;` is the Permissions Policy iframe `allow=` separator,
-                // so unescaped `;` in a value turns the per-feature filter
-                // above into a directive-injection bypass (e.g.
-                // `fullscreen: "*; camera *"`). Without this check, a
-                // crafted profile could grant spec features (camera, etc.)
-                // through allowFeatures even though permissions.allow is
-                // documented as the single source of truth.
-                if (/[;,]/.test(k) || /[;,]/.test(v)) continue;
-                allowParts.push(k + " " + v);
-              }
-            }
-            if (allowParts.length > 0) {
-              inner.setAttribute("allow", allowParts.join("; "));
+            if (baseAllow) {
+              inner.setAttribute("allow", baseAllow);
             }
 
             if (typeof html === "string") {

--- a/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
+++ b/mcpjam-inspector/server/routes/apps/mcp-apps/sandbox-proxy.html
@@ -171,20 +171,28 @@
           //     load images, fetch over HTTPS, etc.
           //   - Otherwise (pure no-csp, no overrides), restrictive
           //     defaults for SEP-1865 secure-default behavior.
-          // A directive entry with an empty array (`{ "frame-src": [] }`)
-          // models "no source expressions for this directive" — semantically
-          // a no-op, not a hardening signal. Counting it as `hasCspOverrides`
-          // would flip every other directive's baseline from the secure
-          // default to the permissive baseline (broad `https:` / `wss:`)
-          // just because an empty key exists. Require at least one
-          // non-empty array entry.
+          // A cspDirectives entry only counts as "configured" if it
+          // contributes at least one token that would survive
+          // mergeDirective's trim/filter pass — otherwise the no-op
+          // entry (empty array, whitespace-only string, or a token
+          // rejected by the `;,\n\r` injection guard) flips every
+          // OTHER directive's baseline from secure-default to broad
+          // permissive while the named directive contributes nothing.
+          // Mirrors the filter applied below at the actual emit site.
+          const cspDirectiveTokenSurvives = (t) => {
+            if (typeof t !== "string") return false;
+            const trimmed = t.trim();
+            if (trimmed.length === 0) return false;
+            if (/[;,\n\r]/.test(trimmed)) return false;
+            return true;
+          };
           const hasCspOverrides =
             cspDirectives &&
             typeof cspDirectives === "object" &&
-            Object.keys(cspDirectives).some(
-              (k) =>
-                Array.isArray(cspDirectives[k]) &&
-                cspDirectives[k].length > 0,
+            Object.values(cspDirectives).some(
+              (tokens) =>
+                Array.isArray(tokens) &&
+                tokens.some(cspDirectiveTokenSurvives),
             );
           if (hasCspOverrides) {
             // Helper: if cspDirectives names this directive, emit ONLY


### PR DESCRIPTION
## Summary

Adds three optional fields under `mcpProfile.apps.sandbox` so each host template can carry the exact outer-iframe `sandbox=` / `allow=` tokens and inner-doc CSP source expressions its host actually emits at the browser layer. SEP-1865 only models the metadata (CSP allowlists + 4 spec permissions); live captures of real `ui/initialize` responses and the actual outer-iframe element from production hosts show divergence we couldn't previously express:

- Outer iframe `sandbox=` attribute (e.g. Claude ships `allow-scripts allow-same-origin allow-forms`).
- Outer iframe `allow=` Permissions Policy (e.g. Claude grants `fullscreen *` — not in SEP-1865's 4-permission schema).
- Inner-document CSP source expressions (`'unsafe-eval'`, `'unsafe-inline'`, `'wasm-unsafe-eval'`, `'strict-dynamic'`, nonces, hashes — allowlist-only metadata can't hold them).

This change lands the schema + runtime wiring + matrix surfacing + editors. **No host template values are populated** — those come in follow-up commits driven by host-probe captures.

## What changed

### New fields (all optional, under `mcpProfile.apps.sandbox`)

- **`sandboxAttrs: string[]`** — extra `sandbox=` tokens unioned with the mandatory `allow-scripts allow-same-origin` on both outer + inner iframes. Set semantics: trim + dedupe + sort on canonicalize.
- **`allowFeatures: Record<string, string>`** — extra Permissions Policy entries appended to `allow=`. Keys are **raw kebab Permissions Policy tokens** (`clipboard-write`, not `clipboardWrite`). The 4 spec features stay in `permissions.allow` as camelCase; the canonicalizer silently drops any of them from `allowFeatures` (single source of truth). New `SEP_1865_PERMISSION_FEATURES` constant exported from both the backend and inspector mirror.
- **`csp.cspDirectives: Record<string, string[]>`** — per-directive source-expression overrides emitted in the inner doc's `<meta http-equiv="Content-Security-Policy">`. Keys are CSP directive names; values are token arrays. Stored **verbatim** — no enum — so future tokens land here without schema churn.

### CSP merge rule (resolves the `'none' 'self'` hard blocker)

`buildCSP(csp, cspDirectives)` in `sandbox-proxy.html` now merges per-directive:
- `tokens = unique(domain-derived ++ cspDirectives[directive])`
- if `tokens` contains anything other than `'none'`, drop `'none'`
- emit `<directive> ${tokens.join(' ')}` (or `<directive> 'none'` if `tokens === ['none']`)

Rationale: `'none' 'self'` is invalid CSP. The domain-derived branch emits `'none'` for empty allowlists (`frameDomains: [] → frame-src 'none'`), and `cspDirectives` can add real tokens on top. Union-and-drop-`'none'` is the only sound merge. Unknown directives (e.g. `form-action`, `worker-src`) are appended verbatim so probe captures of additional directives round-trip end-to-end.

### Editors (inspector-only, in `ClientConfigEditor`)

- `McpProfileCspDirectivesEditor` — per-directive textarea grid with directive-name suggestions.
- `McpProfileSandboxAttrsEditor` — chip multi-select; `allow-scripts` / `allow-same-origin` are shown locked-on; free-text input for unknown tokens.
- `McpProfileAllowFeaturesEditor` — key/value list; spec-feature keys typed here show an inline warning and are dropped on save (defense in depth — the canonicalizer drops them too).

All three editors include help-text caveats that they are inspector-only emission knobs (not advertised in `ui/initialize`, not in SEP-1865 metadata).

### Matrix

`SandboxConfigSubKey` gains `cspDirectives | sandboxAttrs | allowFeatures`. Each new row follows the post-#2142 "skip at safe default" convention — surfaces only when populated. `cspDirectives` tints `danger` when any value contains `'unsafe-eval'` / `'unsafe-inline'` / `'wasm-unsafe-eval'` / `'strict-dynamic'`; otherwise neutral. `sandboxAttrs` and `allowFeatures` are always neutral (additive grants, not silent narrowing).

### JSON round-trip

The spec-shaped JSON view in `AppsExtensionTab` deliberately **hides** these fields (they're inspector-only). `liftSpecSandboxIntoPolicy` preserves all three from `prev` across a JSON edit — matching the existing `mode` / `extensions` preservation contract.

## Reviewer notes

- This change **requires the matching backend schema extension** (`mcpjam-backend/convex/lib/hostConfigV2.ts`: new canonicalizer helpers + `SEP_1865_PERMISSION_FEATURES` export). That lives in a separate diff against `mcpjam-backend`. Without it, writes will fail soft-validation. Don't merge this alone.
- The AppBridge `ui/initialize` handshake intentionally does NOT advertise these fields. They model browser-emission behavior, not SEP-1865 metadata.
- Rebased on top of #2142 — adopted its "skip at safe default" pattern for the new rows, dropped my own conditional logic from the canvasBuilder.

## Test plan

- [x] Backend canonicalize tests pass (39/39)
- [x] Inspector typecheck clean (`npm run typecheck:client`)
- [x] Affected suites pass (557/557): `canvasBuilder`, `AppsExtensionTab.sandbox`, new `sandbox-proxy-buildCSP`, `mcp-apps-renderer`, redesigned-clients, client-config
- [ ] Manual smoke: edit MCPJam-host config → set `csp.cspDirectives = { "script-src": ["'unsafe-eval'"] }` → render a UI Resource → inspect the inner iframe's CSP meta (should contain `'unsafe-eval'` alongside `'unsafe-inline'`, no duplicates)
- [ ] Manual smoke: `allowFeatures = { fullscreen: "*" }` → outer iframe's `allow=` contains `fullscreen *`
- [ ] Manual smoke: `allowFeatures = { camera: "*" }` → silently dropped (not on iframe); `permissions.allow.camera` is the only path
- [ ] Probe round-trip: run host-probe widget; confirm `frame.sandboxAttr` / `frame.allowAttr` / `policies.metaCsp` → schema → matrix display works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox/CSP/permissions enforcement paths for untrusted MCP App iframes and changes how CSP/Permissions Policy tokens are merged and emitted, so misconfiguration could unintentionally widen or break widget capabilities (mitigated by new injection guards and tests).
> 
> **Overview**
> Adds three new optional MCP Apps sandbox config fields—`csp.cspDirectives`, `sandboxAttrs`, and `allowFeatures`—to model real hosts’ emitted CSP source-expressions, iframe `sandbox=` tokens, and outer-iframe `allow=` (Permissions Policy) beyond SEP-1865 metadata.
> 
> Wires these fields through the renderer and modal into `SandboxedIframe`, updates `SandboxedIframe` to treat provided values as *authoritative* (including `undefined` vs empty container semantics), remounts the outer iframe when sandbox flags change, and adds guards to prevent token/directive injection or spec-permission bypass.
> 
> Updates `sandbox-proxy.html` to merge `cspDirectives` into generated CSP per-directive (dropping `'none'` when overridden), support unknown directives, and enforce additional filtering; adds ClientConfigEditor UIs, matrix/canvas surfacing + ordering/severity for the new rows, updates AppsExtensionTab JSON round-trip to a new top-level `sandbox` block, extends host templates with captured host-like defaults, and adds targeted unit tests for the new CSP merge and iframe attribute semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eae8d253e2b3edf1c9a7ad1f56db1b2b95616bf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->