### PR TITLE
patches csp in gpt client

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-app-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-app-renderer.tsx
@@ -395,13 +395,14 @@ function useWidgetFetch(
     // Check if widgetUrl is current (matches expected URL based on mode)
     // In cached mode: widgetUrl should equal cachedWidgetHtmlUrl
     // In live mode: widgetUrl is a widget-content endpoint URL
+    const expectedLocalWidgetUrl = `/api/apps/chatgpt-apps/widget-content/${resolvedToolCallId}?csp_mode=${encodeURIComponent(cspMode)}`;
     const isWidgetUrlCurrent =
       widgetUrl &&
       ((canUseCachedHtml && widgetUrl === cachedWidgetHtmlUrl) ||
         (!canUseCachedHtml &&
           (HOSTED_MODE
             ? widgetUrl.startsWith("blob:")
-            : widgetUrl.includes("/api/apps/chatgpt-apps/widget-content/"))));
+            : widgetUrl === expectedLocalWidgetUrl)));
 
     if (
       toolState !== "output-available" ||

--- a/mcpjam-inspector/client/src/components/shared/ClientContextHeader.tsx
+++ b/mcpjam-inspector/client/src/components/shared/ClientContextHeader.tsx
@@ -157,7 +157,24 @@ export function ClientContextHeader({
     protocol === UIType.MCP_APPS ||
     protocol === UIType.OPENAI_SDK_AND_MCP_APPS;
   const activeCspMode = usesMcpAppsCsp ? mcpAppsCspMode : cspMode;
-  const setActiveCspMode = usesMcpAppsCsp ? setMcpAppsCspMode : setCspMode;
+  const setActiveCspMode = useCallback(
+    (next: typeof activeCspMode) => {
+      setCspMode(next);
+      setMcpAppsCspMode(next);
+    },
+    [setCspMode, setMcpAppsCspMode],
+  );
+
+  useEffect(() => {
+    if (cspMode !== activeCspMode) setCspMode(activeCspMode);
+    if (mcpAppsCspMode !== activeCspMode) setMcpAppsCspMode(activeCspMode);
+  }, [
+    activeCspMode,
+    cspMode,
+    mcpAppsCspMode,
+    setCspMode,
+    setMcpAppsCspMode,
+  ]);
 
   const violationCount = useWidgetDebugStore((state) =>
     Array.from(state.widgets.values()).reduce(

--- a/mcpjam-inspector/client/src/components/shared/__tests__/ClientContextHeader.test.tsx
+++ b/mcpjam-inspector/client/src/components/shared/__tests__/ClientContextHeader.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { ClientContextHeader } from "../ClientContextHeader";
+import { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 
 const {
   mockPreferencesState,
@@ -210,6 +211,8 @@ describe("ClientContextHeader", () => {
     vi.clearAllMocks();
     mockPreferencesState.themeMode = "light";
     mockPreferencesState.hostStyle = "claude";
+    mockUIPlaygroundStore.cspMode = "widget-declared";
+    mockUIPlaygroundStore.mcpAppsCspMode = "widget-declared";
     mockHostContextState.draftHostContext = {
       locale: "en-US",
       timeZone: "UTC",
@@ -222,6 +225,25 @@ describe("ClientContextHeader", () => {
       },
     };
     mockHostContextState.isDirty = false;
+  });
+
+  it("keeps the ChatGPT and MCP Apps CSP stores synchronized from the active chip", async () => {
+    mockUIPlaygroundStore.cspMode = "widget-declared";
+    mockUIPlaygroundStore.mcpAppsCspMode = "permissive";
+
+    render(
+      <ClientContextHeader
+        activeProjectId="project-1"
+        protocol={UIType.MCP_APPS}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockUIPlaygroundStore.setCspMode).toHaveBeenCalledWith(
+        "permissive",
+      );
+    });
+    expect(mockUIPlaygroundStore.setMcpAppsCspMode).not.toHaveBeenCalled();
   });
 
   it("writes theme changes through hostContext instead of global preferences", () => {

--- a/mcpjam-inspector/client/src/components/shared/client-context-constants.ts
+++ b/mcpjam-inspector/client/src/components/shared/client-context-constants.ts
@@ -85,7 +85,7 @@ export const CSP_MODE_OPTIONS: {
   {
     mode: "permissive",
     label: "Permissive",
-    description: "Allows all HTTPS resources",
+    description: "Allows all HTTP(S) resources",
   },
   {
     mode: "widget-declared",

--- a/mcpjam-inspector/server/routes/apps/chatgpt-apps/index.ts
+++ b/mcpjam-inspector/server/routes/apps/chatgpt-apps/index.ts
@@ -6,8 +6,8 @@ import {
   buildChatGptRuntimeHead,
   injectScripts,
   buildCspHeader,
+  normalizeWidgetCspMeta,
   type CspMode,
-  type WidgetCspMeta,
 } from "../../../utils/widget-helpers";
 
 const chatgpt = new Hono();
@@ -254,13 +254,13 @@ chatgpt.get("/widget-html/:toolId", async (c) => {
     const { html: htmlContent, firstContent } = extractHtmlContent(content);
     if (!htmlContent) return c.json({ error: "No HTML content found" }, 404);
 
-    // Extract openai/widgetCSP from resource metadata
+    // ChatGPT now supports the standard MCP Apps `_meta.ui.csp` field.
+    // Normalize it into the legacy snake_case shape expected by this
+    // compatibility route, falling back to `openai/widgetCSP` for older apps.
     const resourceMeta = firstContent?._meta as
       | Record<string, unknown>
       | undefined;
-    const widgetCspRaw = resourceMeta?.["openai/widgetCSP"] as
-      | WidgetCspMeta
-      | undefined;
+    const widgetCspRaw = normalizeWidgetCspMeta(resourceMeta);
 
     // Build CSP configuration based on mode
     const cspConfig = buildCspHeader(cspMode ?? "permissive", widgetCspRaw);
@@ -308,6 +308,8 @@ chatgpt.get("/widget-html/:toolId", async (c) => {
         | undefined,
       prefersBorder:
         (resourceMeta?.["openai/widgetPrefersBorder"] as boolean | undefined) ??
+        ((resourceMeta?.ui as { prefersBorder?: boolean } | undefined)
+          ?.prefersBorder as boolean | undefined) ??
         true,
       closeWidget:
         (resourceMeta?.["openai/closeWidget"] as boolean | undefined) ?? false,
@@ -416,13 +418,13 @@ chatgpt.get("/widget-content/:toolId", async (c) => {
         404,
       );
 
-    // Extract openai/widgetCSP from resource metadata
+    // ChatGPT now supports the standard MCP Apps `_meta.ui.csp` field.
+    // Normalize it into the legacy snake_case shape expected by this
+    // compatibility route, falling back to `openai/widgetCSP` for older apps.
     const resourceMeta = firstContent?._meta as
       | Record<string, unknown>
       | undefined;
-    const widgetCspRaw = resourceMeta?.["openai/widgetCSP"] as
-      | WidgetCspMeta
-      | undefined;
+    const widgetCspRaw = normalizeWidgetCspMeta(resourceMeta);
 
     // Build CSP based on effective mode
     const cspConfig = buildCspHeader(effectiveCspMode, widgetCspRaw);

--- a/mcpjam-inspector/server/routes/apps/chatgpt-apps/index.ts
+++ b/mcpjam-inspector/server/routes/apps/chatgpt-apps/index.ts
@@ -307,9 +307,9 @@ chatgpt.get("/widget-html/:toolId", async (c) => {
         | string
         | undefined,
       prefersBorder:
-        (resourceMeta?.["openai/widgetPrefersBorder"] as boolean | undefined) ??
         ((resourceMeta?.ui as { prefersBorder?: boolean } | undefined)
           ?.prefersBorder as boolean | undefined) ??
+        (resourceMeta?.["openai/widgetPrefersBorder"] as boolean | undefined) ??
         true,
       closeWidget:
         (resourceMeta?.["openai/closeWidget"] as boolean | undefined) ?? false,

--- a/mcpjam-inspector/server/routes/web/apps.ts
+++ b/mcpjam-inspector/server/routes/web/apps.ts
@@ -284,11 +284,11 @@ apps.post("/chatgpt-apps/widget-content", async (c) =>
           | string
           | undefined,
         prefersBorder:
+          ((resourceMeta?.ui as { prefersBorder?: boolean } | undefined)
+            ?.prefersBorder as boolean | undefined) ??
           (resourceMeta?.["openai/widgetPrefersBorder"] as
             | boolean
             | undefined) ??
-          ((resourceMeta?.ui as { prefersBorder?: boolean } | undefined)
-            ?.prefersBorder as boolean | undefined) ??
           true,
         closeWidget:
           (resourceMeta?.["openai/closeWidget"] as boolean | undefined) ??

--- a/mcpjam-inspector/server/routes/web/apps.ts
+++ b/mcpjam-inspector/server/routes/web/apps.ts
@@ -16,8 +16,8 @@ import {
   buildCspHeader,
   buildCspMetaContent,
   buildChatGptRuntimeHead,
+  normalizeWidgetCspMeta,
   type CspMode,
-  type WidgetCspMeta,
 } from "../../utils/widget-helpers.js";
 import {
   projectServerSchema,
@@ -229,9 +229,7 @@ apps.post("/chatgpt-apps/widget-content", async (c) =>
       const resourceMeta = firstContent?._meta as
         | Record<string, unknown>
         | undefined;
-      const widgetCspRaw = resourceMeta?.["openai/widgetCSP"] as
-        | WidgetCspMeta
-        | undefined;
+      const widgetCspRaw = normalizeWidgetCspMeta(resourceMeta);
       const effectiveCspMode = body.cspMode ?? "permissive";
       const cspConfig = buildCspHeader(effectiveCspMode, widgetCspRaw, {
         frameAncestors: buildFrameAncestors(),
@@ -288,7 +286,10 @@ apps.post("/chatgpt-apps/widget-content", async (c) =>
         prefersBorder:
           (resourceMeta?.["openai/widgetPrefersBorder"] as
             | boolean
-            | undefined) ?? true,
+            | undefined) ??
+          ((resourceMeta?.ui as { prefersBorder?: boolean } | undefined)
+            ?.prefersBorder as boolean | undefined) ??
+          true,
         closeWidget:
           (resourceMeta?.["openai/closeWidget"] as boolean | undefined) ??
           false,

--- a/mcpjam-inspector/server/utils/widget-helpers.ts
+++ b/mcpjam-inspector/server/utils/widget-helpers.ts
@@ -6,6 +6,7 @@ export {
   WIDGET_BASE_CSS,
   buildRuntimeConfigScript,
   injectScripts,
+  normalizeWidgetCspMeta,
   buildCspHeader,
   buildCspMetaContent,
   buildChatGptRuntimeHead,


### PR DESCRIPTION
- Fixed ChatGPT-mode widgets loading with Strict CSP even when the toolbar showed Permissive.
- Made the CSP toggle update the actual ChatGPT widget policy.
- Made switching CSP mode reload the widget with the new setting.
- Made ChatGPT Permissive mode allow normal external assets.
- Made ChatGPT mode read widget CSP domains from both new and old metadata formats.
- Added tests for these cases.