### PR TITLE
Add normalizeWidgetCspMeta to @mcpjam/sdk

### DIFF
--- a/mcpjam-inspector/server/utils/widget-helpers.ts
+++ b/mcpjam-inspector/server/utils/widget-helpers.ts
@@ -6,49 +6,9 @@ export {
   WIDGET_BASE_CSS,
   buildRuntimeConfigScript,
   injectScripts,
+  normalizeWidgetCspMeta,
   buildCspHeader,
   buildCspMetaContent,
   buildChatGptRuntimeHead,
 } from "@mcpjam/sdk";
-import type { WidgetCspMeta } from "@mcpjam/sdk";
 export type { CspMode, WidgetCspMeta, CspConfig } from "@mcpjam/sdk";
-
-// Reads CSP from MCP Apps' standard `_meta.ui.csp` (camelCase) and falls
-// back to legacy `_meta["openai/widgetCSP"]` (snake_case). Output matches
-// the snake_case shape consumed by buildCspHeader.
-export function normalizeWidgetCspMeta(
-  resourceMeta: Record<string, unknown> | undefined,
-): WidgetCspMeta | undefined {
-  if (!resourceMeta) return undefined;
-
-  const ui = resourceMeta.ui as
-    | { csp?: Record<string, unknown> }
-    | undefined;
-  const standard = ui?.csp;
-  if (standard && typeof standard === "object") {
-    const connect = standard.connectDomains ?? standard.connect_domains;
-    const resource = standard.resourceDomains ?? standard.resource_domains;
-    const frame = standard.frameDomains ?? standard.frame_domains;
-    if (
-      Array.isArray(connect) ||
-      Array.isArray(resource) ||
-      Array.isArray(frame)
-    ) {
-      return {
-        connect_domains: Array.isArray(connect)
-          ? (connect as string[])
-          : undefined,
-        resource_domains: Array.isArray(resource)
-          ? (resource as string[])
-          : undefined,
-        frame_domains: Array.isArray(frame) ? (frame as string[]) : undefined,
-      };
-    }
-  }
-
-  const legacy = resourceMeta["openai/widgetCSP"];
-  if (legacy && typeof legacy === "object") {
-    return legacy as WidgetCspMeta;
-  }
-  return undefined;
-}

--- a/mcpjam-inspector/server/utils/widget-helpers.ts
+++ b/mcpjam-inspector/server/utils/widget-helpers.ts
@@ -6,9 +6,49 @@ export {
   WIDGET_BASE_CSS,
   buildRuntimeConfigScript,
   injectScripts,
-  normalizeWidgetCspMeta,
   buildCspHeader,
   buildCspMetaContent,
   buildChatGptRuntimeHead,
 } from "@mcpjam/sdk";
+import type { WidgetCspMeta } from "@mcpjam/sdk";
 export type { CspMode, WidgetCspMeta, CspConfig } from "@mcpjam/sdk";
+
+// Reads CSP from MCP Apps' standard `_meta.ui.csp` (camelCase) and falls
+// back to legacy `_meta["openai/widgetCSP"]` (snake_case). Output matches
+// the snake_case shape consumed by buildCspHeader.
+export function normalizeWidgetCspMeta(
+  resourceMeta: Record<string, unknown> | undefined,
+): WidgetCspMeta | undefined {
+  if (!resourceMeta) return undefined;
+
+  const ui = resourceMeta.ui as
+    | { csp?: Record<string, unknown> }
+    | undefined;
+  const standard = ui?.csp;
+  if (standard && typeof standard === "object") {
+    const connect = standard.connectDomains ?? standard.connect_domains;
+    const resource = standard.resourceDomains ?? standard.resource_domains;
+    const frame = standard.frameDomains ?? standard.frame_domains;
+    if (
+      Array.isArray(connect) ||
+      Array.isArray(resource) ||
+      Array.isArray(frame)
+    ) {
+      return {
+        connect_domains: Array.isArray(connect)
+          ? (connect as string[])
+          : undefined,
+        resource_domains: Array.isArray(resource)
+          ? (resource as string[])
+          : undefined,
+        frame_domains: Array.isArray(frame) ? (frame as string[]) : undefined,
+      };
+    }
+  }
+
+  const legacy = resourceMeta["openai/widgetCSP"];
+  if (legacy && typeof legacy === "object") {
+    return legacy as WidgetCspMeta;
+  }
+  return undefined;
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -367,6 +367,7 @@ export {
   WIDGET_BASE_CSS,
   buildRuntimeConfigScript,
   injectScripts,
+  normalizeWidgetCspMeta,
   buildCspHeader,
   buildCspMetaContent,
   buildChatGptRuntimeHead,

--- a/sdk/src/widget-helpers.ts
+++ b/sdk/src/widget-helpers.ts
@@ -131,6 +131,46 @@ export interface WidgetCspMeta {
   frame_domains?: string[];
 }
 
+// Reads CSP from MCP Apps' standard `_meta.ui.csp` (camelCase) and falls
+// back to legacy `_meta["openai/widgetCSP"]` (snake_case). Output matches
+// the snake_case shape consumed by buildCspHeader.
+export function normalizeWidgetCspMeta(
+  resourceMeta: Record<string, unknown> | undefined,
+): WidgetCspMeta | undefined {
+  if (!resourceMeta) return undefined;
+
+  const ui = resourceMeta.ui as
+    | { csp?: Record<string, unknown> }
+    | undefined;
+  const standard = ui?.csp;
+  if (standard && typeof standard === "object") {
+    const connect = standard.connectDomains ?? standard.connect_domains;
+    const resource = standard.resourceDomains ?? standard.resource_domains;
+    const frame = standard.frameDomains ?? standard.frame_domains;
+    if (
+      Array.isArray(connect) ||
+      Array.isArray(resource) ||
+      Array.isArray(frame)
+    ) {
+      return {
+        connect_domains: Array.isArray(connect)
+          ? (connect as string[])
+          : undefined,
+        resource_domains: Array.isArray(resource)
+          ? (resource as string[])
+          : undefined,
+        frame_domains: Array.isArray(frame) ? (frame as string[]) : undefined,
+      };
+    }
+  }
+
+  const legacy = resourceMeta["openai/widgetCSP"];
+  if (legacy && typeof legacy === "object") {
+    return legacy as WidgetCspMeta;
+  }
+  return undefined;
+}
+
 export interface CspConfig {
   mode: CspMode;
   connectDomains: string[];


### PR DESCRIPTION
## Summary
- Adds `normalizeWidgetCspMeta` to `@mcpjam/sdk` and re-exports it from `sdk/src/index.ts`.
- Follow-up to #2147, which imported `normalizeWidgetCspMeta` from `@mcpjam/sdk` in the inspector but never landed the function in the SDK. The published `@mcpjam/sdk@1.6.0` does not export it, so the inspector server crashes at startup with `SyntaxError: The requested module '@mcpjam/sdk' does not provide an export named 'normalizeWidgetCspMeta'`, which in turn causes every `/api/web/*` request (including OAuth) to fail with `ECONNREFUSED` against the vite proxy.

## Behavior
`normalizeWidgetCspMeta(resourceMeta)` reads CSP from MCP Apps' standard `_meta.ui.csp` (camelCase: `connectDomains` / `resourceDomains` / `frameDomains`) and falls back to legacy `_meta["openai/widgetCSP"]` (snake_case). It returns the snake_case `WidgetCspMeta` shape already consumed by `buildCspHeader`, so the chatgpt-apps routes that #2147 already updated pick it up with no further changes.

## Test plan
- [ ] `npm run build -w @mcpjam/sdk` succeeds; `normalizeWidgetCspMeta` appears in `sdk/dist/index.js` and `sdk/dist/index.d.ts`.
- [ ] Inspector dev server boots without the `does not provide an export named 'normalizeWidgetCspMeta'` SyntaxError.
- [ ] `/api/web/*` requests respond (no more `ECONNREFUSED` against the vite proxy); OAuth flow completes end-to-end.
- [ ] ChatGPT widget HTML still receives the correct CSP for both new (`_meta.ui.csp`) and legacy (`_meta["openai/widgetCSP"]`) apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new helper + export without changing existing CSP generation logic; behavior only affects callers that opt into the new normalization function.
> 
> **Overview**
> Adds `normalizeWidgetCspMeta(resourceMeta)` to `widget-helpers.ts` to normalize widget CSP declarations from standard `_meta.ui.csp` (camelCase) with fallback to legacy `_meta["openai/widgetCSP"]` (snake_case), returning the `WidgetCspMeta` shape expected by existing CSP builders.
> 
> Re-exports `normalizeWidgetCspMeta` from `sdk/src/index.ts` so downstream consumers can import it from `@mcpjam/sdk`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3a9084f08a207118adcadb8dede7301602c5f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->