### PR TITLE
Address widget CSP review feedback

### DIFF
--- a/sdk/src/widget-helpers.ts
+++ b/sdk/src/widget-helpers.ts
@@ -129,7 +129,6 @@ export interface WidgetCspMeta {
   connect_domains?: string[];
   resource_domains?: string[];
   frame_domains?: string[];
-  redirect_domains?: string[];
 }
 
 export interface CspConfig {
@@ -160,21 +159,46 @@ function readStringArray(value: unknown): string[] | undefined {
   );
 }
 
-function pickStringArray(...values: unknown[]): string[] | undefined {
-  for (const value of values) {
-    const parsed = readStringArray(value);
-    if (parsed !== undefined) return parsed;
-  }
-  return undefined;
+function uniqueSources(values: string[]): string[] {
+  return Array.from(new Set(values));
 }
 
 function hasAnyWidgetCspField(value: WidgetCspMeta): boolean {
   return (
     Boolean(value.connect_domains?.length) ||
     Boolean(value.resource_domains?.length) ||
-    Boolean(value.frame_domains?.length) ||
-    Boolean(value.redirect_domains?.length)
+    Boolean(value.frame_domains?.length)
   );
+}
+
+function normalizeStandardWidgetCsp(
+  uiCsp: Record<string, unknown>,
+): WidgetCspMeta | undefined {
+  const normalized: WidgetCspMeta = {};
+  const connectDomains = readStringArray(uiCsp.connectDomains);
+  const resourceDomains = readStringArray(uiCsp.resourceDomains);
+  const frameDomains = readStringArray(uiCsp.frameDomains);
+
+  if (connectDomains) normalized.connect_domains = connectDomains;
+  if (resourceDomains) normalized.resource_domains = resourceDomains;
+  if (frameDomains) normalized.frame_domains = frameDomains;
+
+  return hasAnyWidgetCspField(normalized) ? normalized : undefined;
+}
+
+function normalizeLegacyWidgetCsp(
+  openaiCsp: Record<string, unknown>,
+): WidgetCspMeta | undefined {
+  const normalized: WidgetCspMeta = {};
+  const connectDomains = readStringArray(openaiCsp.connect_domains);
+  const resourceDomains = readStringArray(openaiCsp.resource_domains);
+  const frameDomains = readStringArray(openaiCsp.frame_domains);
+
+  if (connectDomains) normalized.connect_domains = connectDomains;
+  if (resourceDomains) normalized.resource_domains = resourceDomains;
+  if (frameDomains) normalized.frame_domains = frameDomains;
+
+  return hasAnyWidgetCspField(normalized) ? normalized : undefined;
 }
 
 export function normalizeWidgetCspMeta(
@@ -190,33 +214,15 @@ export function normalizeWidgetCspMeta(
     uiMeta?.csp && typeof uiMeta.csp === "object"
       ? (uiMeta.csp as Record<string, unknown>)
       : undefined;
+  if (uiCsp) return normalizeStandardWidgetCsp(uiCsp);
+
   const openaiCsp =
     resourceMeta["openai/widgetCSP"] &&
     typeof resourceMeta["openai/widgetCSP"] === "object"
       ? (resourceMeta["openai/widgetCSP"] as Record<string, unknown>)
       : undefined;
 
-  const normalized: WidgetCspMeta = {};
-  const connectDomains = pickStringArray(
-    uiCsp?.connectDomains,
-    openaiCsp?.connect_domains,
-  );
-  const resourceDomains = pickStringArray(
-    uiCsp?.resourceDomains,
-    openaiCsp?.resource_domains,
-  );
-  const frameDomains = pickStringArray(
-    uiCsp?.frameDomains,
-    openaiCsp?.frame_domains,
-  );
-  const redirectDomains = readStringArray(openaiCsp?.redirect_domains);
-
-  if (connectDomains) normalized.connect_domains = connectDomains;
-  if (resourceDomains) normalized.resource_domains = resourceDomains;
-  if (frameDomains) normalized.frame_domains = frameDomains;
-  if (redirectDomains) normalized.redirect_domains = redirectDomains;
-
-  return hasAnyWidgetCspField(normalized) ? normalized : undefined;
+  return openaiCsp ? normalizeLegacyWidgetCsp(openaiCsp) : undefined;
 }
 
 export function buildCspHeader(
@@ -229,25 +235,25 @@ export function buildCspHeader(
   let frameDomains: string[];
 
   if (mode === "widget-declared") {
-    connectDomains = [
+    connectDomains = uniqueSources([
       "'self'",
       ...(widgetCsp?.connect_domains || []),
       ...LOCALHOST_SOURCES,
       ...WS_SOURCES,
-    ];
-    resourceDomains = [
+    ]);
+    resourceDomains = uniqueSources([
       "'self'",
       "data:",
       "blob:",
       ...(widgetCsp?.resource_domains || []),
       ...LOCALHOST_SOURCES,
-    ];
+    ]);
     frameDomains =
       widgetCsp?.frame_domains && widgetCsp.frame_domains.length > 0
-        ? widgetCsp.frame_domains
+        ? uniqueSources(widgetCsp.frame_domains)
         : [];
   } else {
-    connectDomains = [
+    connectDomains = uniqueSources([
       "'self'",
       "https:",
       "http:",
@@ -255,28 +261,62 @@ export function buildCspHeader(
       "ws:",
       ...LOCALHOST_SOURCES,
       ...WS_SOURCES,
-    ];
-    resourceDomains = [
+    ]);
+    resourceDomains = uniqueSources([
       "'self'",
       "data:",
       "blob:",
       "https:",
       "http:",
       ...LOCALHOST_SOURCES,
-    ];
-    frameDomains = ["*", "data:", "blob:", "https:", "http:", "about:"];
+    ]);
+    frameDomains = uniqueSources([
+      "*",
+      "data:",
+      "blob:",
+      "https:",
+      "http:",
+      "about:",
+    ]);
   }
 
   const connectSrc = connectDomains.join(" ");
-  const resourceSrc = resourceDomains.join(" ");
-  const imgSrc =
+  const scriptSrc = uniqueSources([
+    "'self'",
+    "'unsafe-inline'",
+    "'unsafe-eval'",
+    ...resourceDomains,
+  ]).join(" ");
+  const styleSrc = uniqueSources([
+    "'self'",
+    "'unsafe-inline'",
+    ...resourceDomains,
+  ]).join(" ");
+  const fontSrc = uniqueSources(["'self'", "data:", ...resourceDomains]).join(
+    " ",
+  );
+  const imgSrc = uniqueSources(
     mode === "widget-declared"
-      ? `'self' data: blob: ${(widgetCsp?.resource_domains || []).join(" ")} ${LOCALHOST_SOURCES.join(" ")}`
-      : `'self' data: blob: https: http: ${LOCALHOST_SOURCES.join(" ")}`;
-  const mediaSrc =
+      ? [
+          "'self'",
+          "data:",
+          "blob:",
+          ...(widgetCsp?.resource_domains || []),
+          ...LOCALHOST_SOURCES,
+        ]
+      : ["'self'", "data:", "blob:", "https:", "http:", ...LOCALHOST_SOURCES],
+  ).join(" ");
+  const mediaSrc = uniqueSources(
     mode === "widget-declared"
-      ? `'self' data: blob: ${(widgetCsp?.resource_domains || []).join(" ")} ${LOCALHOST_SOURCES.join(" ")}`
-      : "'self' data: blob: https: http:";
+      ? [
+          "'self'",
+          "data:",
+          "blob:",
+          ...(widgetCsp?.resource_domains || []),
+          ...LOCALHOST_SOURCES,
+        ]
+      : ["'self'", "data:", "blob:", "https:", "http:"],
+  ).join(" ");
 
   const frameAncestors =
     options?.frameAncestors ??
@@ -289,13 +329,13 @@ export function buildCspHeader(
 
   const headerString = [
     "default-src 'self'",
-    `script-src 'self' 'unsafe-inline' 'unsafe-eval' ${resourceSrc}`,
+    `script-src ${scriptSrc}`,
     "worker-src 'self' blob:",
     "child-src 'self' blob:",
-    `style-src 'self' 'unsafe-inline' ${resourceSrc}`,
+    `style-src ${styleSrc}`,
     `img-src ${imgSrc}`,
     `media-src ${mediaSrc}`,
-    `font-src 'self' data: ${resourceSrc}`,
+    `font-src ${fontSrc}`,
     `connect-src ${connectSrc}`,
     frameSrc,
     frameAncestors,

--- a/sdk/tests/widget-helpers.test.ts
+++ b/sdk/tests/widget-helpers.test.ts
@@ -31,7 +31,7 @@ describe("buildCspHeader", () => {
     expect(headerString).toContain("media-src 'self' data: blob: https: http:");
     expect(headerString).toContain("connect-src 'self' https: http: wss: ws:");
     expect(headerString).toContain(
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' 'self' data: blob: https: http:",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: https: http:",
     );
   });
 });
@@ -58,7 +58,23 @@ describe("normalizeWidgetCspMeta", () => {
     );
   });
 
-  it("falls back to legacy openai/widgetCSP fields when standard fields are absent", () => {
+  it("falls back to legacy openai/widgetCSP fields when standard csp is absent", () => {
+    expect(
+      normalizeWidgetCspMeta({
+        "openai/widgetCSP": {
+          connect_domains: ["https://legacy-api.example.com"],
+          resource_domains: ["https://legacy-assets.example.com"],
+          frame_domains: ["https://legacy-frame.example.com"],
+        },
+      }),
+    ).toEqual({
+      connect_domains: ["https://legacy-api.example.com"],
+      resource_domains: ["https://legacy-assets.example.com"],
+      frame_domains: ["https://legacy-frame.example.com"],
+    });
+  });
+
+  it("uses standard ui.csp exclusively when stale legacy fields also exist", () => {
     expect(
       normalizeWidgetCspMeta({
         ui: {
@@ -68,17 +84,15 @@ describe("normalizeWidgetCspMeta", () => {
         },
         "openai/widgetCSP": {
           resource_domains: ["https://legacy-assets.example.com"],
-          redirect_domains: ["https://redirect.example.com"],
+          frame_domains: ["https://legacy-frame.example.com"],
         },
       }),
     ).toEqual({
       connect_domains: ["https://api.example.com"],
-      resource_domains: ["https://legacy-assets.example.com"],
-      redirect_domains: ["https://redirect.example.com"],
     });
   });
 
-  it("treats empty standard domain arrays as explicit declarations", () => {
+  it("returns undefined when explicit empty standard arrays block legacy fallback", () => {
     expect(
       normalizeWidgetCspMeta({
         ui: {


### PR DESCRIPTION
- Made _meta.ui.csp the source of truth when present, while preserving _meta["openai/widgetCSP"] as the fallback when ui.csp is absent.
- Removed unused redirect_domains parsing since nothing enforced it.
- Deduplicated CSP source values so generated CSP no longer repeats entries like 'self'.