### PR TITLE
copilot wasn't working on web

### DIFF
--- a/mcpjam-inspector/client/src/index.css
+++ b/mcpjam-inspector/client/src/index.css
@@ -486,7 +486,16 @@
   height: 14px;
   margin: -7px 0 0 -7px;
   border-radius: 9999px;
-  animation: 3600ms cubic-bezier(0.8, 0, 0.2, 1) infinite;
+  /* Longhand form on purpose: esbuild's CSS minifier collapses the
+     `animation` shorthand to `animation: none` when `animation-name` is
+     omitted (the modifier classes below supply the name via cascade).
+     That collapse strips duration/timing/iteration too, killing the
+     dot-color-cycling animation in production. Same family of staging-
+     only minifier hazard as the Claude strip-keyframe collapse fixed in
+     #1727 / c45b3d590. */
+  animation-duration: 3600ms;
+  animation-timing-function: cubic-bezier(0.8, 0, 0.2, 1);
+  animation-iteration-count: infinite;
   will-change: transform, opacity;
 }
 


### PR DESCRIPTION
Copilot's color-cycling dot was frozen in staging. The CSS minifier was deleting the animation timing because of how we wrote one line. Switched it to a form the minifier leaves alone. Same kind of staging-only bug as the Claude mascot fix, different cause.