### PR TITLE
Require auth on widget upload + restore debug-store widget state

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -774,6 +774,7 @@ export function MCPAppsRenderer({
   // Widget debug store
   const setWidgetDebugInfo = useWidgetDebugStore((s) => s.setWidgetDebugInfo);
   const setWidgetGlobals = useWidgetDebugStore((s) => s.setWidgetGlobals);
+  const setWidgetStateStore = useWidgetDebugStore((s) => s.setWidgetState);
   const setWidgetCspStore = useWidgetDebugStore((s) => s.setWidgetCsp);
   const addCspViolation = useWidgetDebugStore((s) => s.addCspViolation);
   const clearCspViolations = useWidgetDebugStore((s) => s.clearCspViolations);
@@ -823,7 +824,12 @@ export function MCPAppsRenderer({
     setWidgetDebugInfo(toolCallId, {
       toolName,
       protocol: "mcp-apps",
-      widgetState: null, // MCP Apps don't have widget state in the same way
+      // Seed from persisted state when a saved view / fork supplied one,
+      // so the Debug "Widget State" tab shows the restored value on
+      // first render instead of `null`. Apps SDK widgets that call
+      // window.openai.setWidgetState() later will overwrite this via
+      // setWidgetStateStore in the openai:setWidgetState handler below.
+      widgetState: initialWidgetState ?? null,
       prefersBorder,
       globals: {
         theme: resolvedTheme,
@@ -845,6 +851,7 @@ export function MCPAppsRenderer({
     deviceCapabilities,
     safeAreaInsets,
     prefersBorder,
+    initialWidgetState,
   ]);
 
   // Update globals in debug store when they change
@@ -1870,13 +1877,19 @@ export function MCPAppsRenderer({
     }
 
     // Apps SDK widget-state persistence (forwarded from the compat
-    // runtime in the inner iframe). Pass through to the host so saved
-    // views / replay / fork can restore it; matches the contract the
-    // legacy ChatGPTAppRenderer fulfilled.
+    // runtime in the inner iframe). Two destinations:
+    //   1) onWidgetStateChange — propagates upward for saved-view /
+    //      replay / fork persistence (matches the legacy
+    //      ChatGPTAppRenderer contract).
+    //   2) setWidgetStateStore — keeps the Debug "Widget State" panel
+    //      live; without it, Apps SDK setWidgetState updates silently
+    //      bypass the diagnostics surface that reads from
+    //      widgetDebugInfo.widgetState.
     if (data.type === "openai:setWidgetState") {
-      if (onWidgetStateChange && typeof toolCallId === "string") {
+      if (onWidgetStateChange) {
         onWidgetStateChange(toolCallId, data.state);
       }
+      setWidgetStateStore(toolCallId, data.state);
       return;
     }
 

--- a/mcpjam-inspector/server/middleware/__tests__/session-auth.test.ts
+++ b/mcpjam-inspector/server/middleware/__tests__/session-auth.test.ts
@@ -44,6 +44,12 @@ function createTestApp(): Hono {
   app.get("/api/apps/mcp-apps/sandbox-proxy/content", (c) =>
     c.text("sandbox content"),
   );
+  // Widget file routes — DOWNLOAD is iframe-accessible (unauthenticated),
+  // UPLOAD is host-only (must require auth — see session-auth.ts).
+  app.get("/api/apps/files/file/file_abc", (c) => c.body("image-bytes"));
+  app.post("/api/apps/files/upload-file", (c) =>
+    c.json({ fileId: "file_abc" }),
+  );
 
   // Non-API routes (HTML pages, etc.)
   app.get("/", (c) => c.html("<html>Home</html>"));
@@ -227,6 +233,38 @@ describe("sessionAuthMiddleware", () => {
     it("allows /api/apps/mcp-apps/sandbox-proxy without token", async () => {
       const res = await app.request("/api/apps/mcp-apps/sandbox-proxy/content");
 
+      expect(res.status).toBe(200);
+    });
+
+    it("allows GET /api/apps/files/file/:fileId without token (iframe download)", async () => {
+      // The widget iframe fetches the download URL directly (img src, fetch,
+      // etc.) and can't carry session headers; download must stay public.
+      const res = await app.request("/api/apps/files/file/file_abc");
+      expect(res.status).toBe(200);
+    });
+
+    it("requires auth on POST /api/apps/files/upload-file (host-only)", async () => {
+      // Upload is called from the host page via authFetch, which CAN
+      // attach the session token. Allowing it through unauthenticated
+      // would let any caller fill the in-memory fileStore (20MB/req) by
+      // hitting this route directly. Pin the auth requirement.
+      const res = await app.request("/api/apps/files/upload-file", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ data: "dummy", mimeType: "image/png" }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("accepts upload-file POST when a valid session token is attached", async () => {
+      const res = await app.request("/api/apps/files/upload-file", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-MCP-Session-Auth": `Bearer ${validToken}`,
+        },
+        body: JSON.stringify({ data: "dummy", mimeType: "image/png" }),
+      });
       expect(res.status).toBe(200);
     });
   });

--- a/mcpjam-inspector/server/middleware/session-auth.ts
+++ b/mcpjam-inspector/server/middleware/session-auth.ts
@@ -41,7 +41,17 @@ const UNPROTECTED_PREFIXES = [
   "/assets/", // Static assets (JS, CSS, images) - no sensitive data
   "/api/apps/mcp-apps/", // MCP Apps widgets - loaded in sandboxed iframes, can't send headers
   "/api/apps/chatgpt-apps/", // ChatGPT widgets - loaded in sandboxed iframes, can't send headers
-  "/api/apps/files/", // Widget file upload/download - loaded from sandboxed iframes, can't send headers
+  // Widget file DOWNLOAD only. The download URL is fetched directly from
+  // inside the sandboxed iframe (img/script/fetch) and can't carry auth
+  // headers, so it must be public. Upload is intentionally NOT in this
+  // prefix: `POST /api/apps/files/upload-file` is always invoked from the
+  // host page (via `authFetch` in widget-file-messages.ts), so it CAN
+  // and DOES carry the session token. Keeping upload behind auth blocks
+  // unauthenticated callers from filling the in-memory fileStore with up
+  // to 20 MB blobs per request. (Same shape applies to the legacy
+  // `/api/apps/chatgpt-apps/upload-file` alias; the broader chatgpt-apps
+  // prefix is scheduled for deletion in the follow-up consolidation PR.)
+  "/api/apps/files/file/",
   "/api/mcp/adapter-http/", // HTTP adapter for tunneled MCP clients - auth via URL secrecy
   "/api/mcp/manager-http/", // HTTP manager for tunneled MCP clients - auth via URL secrecy
   "/api/mcp/xaa/.well-known/", // Public XAA issuer discovery + JWKS for external authorization servers


### PR DESCRIPTION
Follow-up to #2157 addressing two review findings on the consolidated widget path.

## [P2] `POST /api/apps/files/upload-file` was outside session auth

The previous fix added the entire `/api/apps/files/` namespace to `UNPROTECTED_PREFIXES` so the iframe download could fetch directly. That accidentally exempted the upload endpoint too — but upload is invoked from the host page via `authFetch`, so it CAN carry the session token. As written, unauthenticated callers could fill the in-memory `fileStore` with up to 20 MB per request.

**Fix**: tighten the prefix to `/api/apps/files/file/` (download only). Upload falls through to `sessionAuthMiddleware`, which the host's `authFetch` already satisfies via the `X-MCP-Session-Auth` header (line 207 in `session-token.ts`).

Three regression tests added in `session-auth.test.ts`:
- Download stays public (200 without token).
- Upload returns 401 without a token.
- Upload accepts a valid Bearer token (200).

The legacy `/api/apps/chatgpt-apps/upload-file` alias has the same shape, but its broader prefix is scheduled for deletion in the chatgpt-apps removal PR. Inline comment documents that.

## [P3] `openai:setWidgetState` no longer updated the widget debug store

The consolidated handler only called `onWidgetStateChange`, but the Debug "Widget State" tab reads from `widgetDebugInfo.widgetState`. The legacy `ChatGPTAppRenderer` also updated the store; without that, Apps SDK state changes silently disappeared from the diagnostics UI.

Two changes in `mcp-apps-renderer.tsx`:
- Initial `setWidgetDebugInfo()` now seeds `widgetState` from `initialWidgetState` (instead of always `null`) so saved-view / fork replays show the restored state immediately on first render.
- The `openai:setWidgetState` handler now also calls `useWidgetDebugStore.setWidgetState(toolCallId, data.state)` alongside the existing `onWidgetStateChange` propagation. Matches what the legacy renderer did.

## Verification

- `tsc --noEmit` clean on both client and server (no new errors).
- 33 session-auth tests pass (3 new + 30 pre-existing).
- 17 compat-runtime + 4 widget-replay + 5 widget-file + 2 sandbox-proxy-bundle-fresh tests still pass.

## Test plan

- [ ] Load an Apps SDK widget and confirm `window.openai.setWidgetState(...)` updates the Debug "Widget State" tab in real time.
- [ ] Load a saved view of an Apps SDK widget that had persisted state; confirm the Debug tab shows the restored value immediately (not `null` until the widget re-emits state).
- [ ] Confirm widget upload still works end-to-end (drag-drop a PNG, watch host → `/api/apps/files/upload-file` succeed with bearer header).
- [ ] Confirm `curl -X POST http://localhost:5173/api/apps/files/upload-file` returns 401 (no token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens authentication around widget file uploads, which is security-sensitive and could affect existing upload flows if any callers relied on unauthenticated access; adds regression tests to reduce risk.
> 
> **Overview**
> **Secures widget file uploads** by narrowing `session-auth`’s unauthenticated file-route allowlist from the entire `/api/apps/files/` namespace to download-only `GET /api/apps/files/file/…`, so `POST /api/apps/files/upload-file` now requires a valid session token.
> 
> **Restores widget-state diagnostics** in `MCPAppsRenderer` by seeding the debug store’s `widgetState` from `initialWidgetState` and updating the debug store on `openai:setWidgetState` events (while still propagating via `onWidgetStateChange`).
> 
> Adds middleware tests asserting public download, unauthorized upload without a token, and successful upload with a valid `X-MCP-Session-Auth` bearer token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e0ea526f18d6dfb34f1e8dda15c45c9470b0e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->