### PR TITLE
serve hosted sandbox proxy from a distinct origin

### DIFF
--- a/mcpjam-inspector/HOSTED_DEPLOYMENT.md
+++ b/mcpjam-inspector/HOSTED_DEPLOYMENT.md
@@ -1,0 +1,59 @@
+# Hosted Deployment Notes
+
+Configuration notes for operators self-hosting MCPJam Inspector. Not relevant
+when running locally via `npx @mcpjam/inspector`.
+
+## Sandbox origin (required for production)
+
+The MCP Apps / ChatGPT Apps widget sandbox **must** be served from an origin
+distinct from the host app. Without origin separation, widget code running
+inside the sandbox iframe shares cookies and `localStorage` with the host app
+even though the iframe carries `sandbox="... allow-same-origin"`. CSP is not a
+substitute — origin separation is what enforces isolation.
+
+### Configuration
+
+Set at client build time:
+
+```bash
+VITE_MCPJAM_SANDBOX_ORIGIN=https://sandbox.example.com
+```
+
+`VITE_MCPJAM_SANDBOX_ORIGIN` must be:
+
+- A different registrable origin from the host app (e.g. host on
+  `app.example.com`, sandbox on `sandbox.example.com`), so the browser scopes
+  cookies and storage separately.
+- Reachable by browsers. The same MCPJam backend can serve both DNS names —
+  no separate deploy is required. The sandbox host only needs to answer the
+  two `GET` routes:
+  - `/api/web/apps/mcp-apps/sandbox-proxy`
+  - `/api/web/apps/chatgpt-apps/sandbox-proxy`
+
+### DNS / routing
+
+Point the sandbox hostname at the same backend that serves the host app.
+There is no shared state between the host app and the sandbox proxy — the
+proxy is a static bootstrap document that receives widget HTML via
+`postMessage`.
+
+### CSP
+
+The sandbox proxy already emits a `frame-ancestors` directive that includes
+every `https://` entry from `CORS_ORIGINS`. Make sure the host app origin
+(e.g. `https://app.example.com`) is in `CORS_ORIGINS` so the host page is
+allowed to frame the sandbox.
+
+### Fallback behavior
+
+If `VITE_MCPJAM_SANDBOX_ORIGIN` is unset in a hosted build, the iframe falls
+back to same-origin and the client logs a security warning to the browser
+console. The fallback exists only as a soft-fail for misconfigured deploys;
+production deployments must set the variable. The regression test at
+`client/src/components/ui/__tests__/sandboxed-iframe.hosted.test.tsx` pins
+this contract.
+
+### Local development
+
+Local development is unaffected. The dev client swaps between `localhost`
+and `127.0.0.1` to get origin separation without operator configuration.

--- a/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.hosted.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Pins the hosted-mode sandbox-origin contract on SandboxedIframe (the
+ * load-bearing renderer post-consolidation — both MCP-Apps and ChatGPT-Apps
+ * widgets flow through it via the window.openai compat shim).
+ *
+ *   - When `SANDBOX_ORIGIN` is configured, the iframe MUST point at that
+ *     distinct origin, NOT at `window.location.origin`. This is the
+ *     isolation property — without it the sandbox shares cookies and
+ *     storage with the host app despite `allow-same-origin`.
+ *   - When `SANDBOX_ORIGIN` is unset, hosted mode falls back to same-origin
+ *     and MUST log a clear security warning. The fallback exists only as
+ *     a soft-fail for misconfigured deploys; the warning is the signal that
+ *     prevents silent regression.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+const ORIGINAL_LOCATION = window.location;
+
+function setLocation(origin: string): void {
+  const url = new URL(origin);
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      ...ORIGINAL_LOCATION,
+      hostname: url.hostname,
+      port: url.port,
+      protocol: url.protocol,
+      origin: url.origin,
+      href: `${url.origin}/`,
+    },
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: ORIGINAL_LOCATION,
+  });
+  vi.resetModules();
+  vi.restoreAllMocks();
+  vi.doUnmock("@/lib/config");
+});
+
+describe("SandboxedIframe — hosted-mode sandbox origin", () => {
+  beforeEach(() => {
+    setLocation("https://app.mcpjam.test");
+  });
+
+  it("uses the configured SANDBOX_ORIGIN, not window.location.origin", async () => {
+    vi.doMock("@/lib/config", () => ({
+      HOSTED_MODE: true,
+      SANDBOX_ORIGIN: "https://sandbox.mcpjam.test",
+      SANITIZE_OAUTH_TRACES: true,
+      NON_PROD_LOCKDOWN: false,
+      EMPLOYEE_EMAIL_DOMAINS: [],
+      isAllowedEmployeeEmail: () => false,
+    }));
+    const { SandboxedIframe } = await import(
+      "@/components/ui/sandboxed-iframe"
+    );
+
+    const { container } = render(
+      <SandboxedIframe html={null} onMessage={() => {}} />,
+    );
+    const iframe = container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    const src = iframe!.getAttribute("src")!;
+    const srcUrl = new URL(src);
+    expect(srcUrl.origin).toBe("https://sandbox.mcpjam.test");
+    expect(srcUrl.origin).not.toBe(window.location.origin);
+    expect(srcUrl.pathname).toBe("/api/web/apps/mcp-apps/sandbox-proxy");
+  });
+
+  it("falls back to same-origin and logs a security warning when SANDBOX_ORIGIN is unset", async () => {
+    vi.doMock("@/lib/config", () => ({
+      HOSTED_MODE: true,
+      SANDBOX_ORIGIN: null,
+      SANITIZE_OAUTH_TRACES: true,
+      NON_PROD_LOCKDOWN: false,
+      EMPLOYEE_EMAIL_DOMAINS: [],
+      isAllowedEmployeeEmail: () => false,
+    }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { SandboxedIframe } = await import(
+      "@/components/ui/sandboxed-iframe"
+    );
+
+    const { container } = render(
+      <SandboxedIframe html={null} onMessage={() => {}} />,
+    );
+    const iframe = container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    const srcOrigin = new URL(iframe!.getAttribute("src")!).origin;
+    expect(srcOrigin).toBe(window.location.origin);
+    expect(warn).toHaveBeenCalled();
+    const warnings = warn.mock.calls.map((args) => args.join(" "));
+    expect(
+      warnings.some((line) => line.includes("VITE_MCPJAM_SANDBOX_ORIGIN")),
+    ).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/components/ui/chatgpt-sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/chatgpt-sandboxed-iframe.tsx
@@ -7,7 +7,7 @@ import {
   forwardRef,
   useMemo,
 } from "react";
-import { HOSTED_MODE } from "@/lib/config";
+import { HOSTED_MODE, SANDBOX_ORIGIN } from "@/lib/config";
 
 export interface ChatGPTSandboxedIframeHandle {
   postMessage: (data: unknown) => void;
@@ -71,37 +71,51 @@ export const ChatGPTSandboxedIframe = forwardRef<
   const [proxyReady, setProxyReady] = useState(false);
   const urlSentRef = useRef(false);
 
-  // Build cross-origin sandbox proxy URL (localhost ↔ 127.0.0.1 swap)
+  // Build cross-origin sandbox proxy URL.
+  //
+  // Hosted: prefer operator-configured SANDBOX_ORIGIN
+  // (`VITE_MCPJAM_SANDBOX_ORIGIN`) so the sandbox lives on a distinct
+  // origin. Same-origin fallback is a soft-fail with a loud warning.
+  //
+  // Local: localhost ↔ 127.0.0.1 swap.
   const [sandboxProxyUrl, sandboxOrigin] = useMemo(() => {
-    const currentHost = window.location.hostname;
-    const currentPort = window.location.port;
-    const protocol = window.location.protocol;
-
-    // Hosted mode keeps same-origin to support blob/data widget URLs.
-    // Local mode keeps localhost <-> 127.0.0.1 swapping for stronger isolation.
-    let sandboxHost: string;
-    if (HOSTED_MODE) {
-      sandboxHost = currentHost;
-    } else if (currentHost === "localhost") {
-      sandboxHost = "127.0.0.1";
-    } else if (currentHost === "127.0.0.1") {
-      sandboxHost = "localhost";
-    } else {
-      // In production or other environments, fall back to same-origin
-      // Could be enhanced with a dedicated sandbox subdomain
-      console.warn(
-        "[ChatGPTSandboxedIframe] Cross-origin isolation not available, using same-origin",
-      );
-      sandboxHost = currentHost;
-    }
-
-    const portSuffix = currentPort ? `:${currentPort}` : "";
     const version = import.meta.env.PROD
       ? import.meta.env.VITE_BUILD_HASH || "v1"
       : Date.now();
     const proxyPath = HOSTED_MODE
       ? "/api/web/apps/chatgpt-apps/sandbox-proxy"
       : "/api/apps/chatgpt-apps/sandbox-proxy";
+
+    if (HOSTED_MODE && SANDBOX_ORIGIN) {
+      const url = `${SANDBOX_ORIGIN}${proxyPath}?v=${version}`;
+      return [url, SANDBOX_ORIGIN];
+    }
+
+    const currentHost = window.location.hostname;
+    const currentPort = window.location.port;
+    const protocol = window.location.protocol;
+
+    let sandboxHost: string;
+    if (currentHost === "localhost") {
+      sandboxHost = "127.0.0.1";
+    } else if (currentHost === "127.0.0.1") {
+      sandboxHost = "localhost";
+    } else {
+      if (HOSTED_MODE) {
+        console.warn(
+          "[ChatGPTSandboxedIframe] VITE_MCPJAM_SANDBOX_ORIGIN is not configured;" +
+            " sandbox iframe is falling back to same-origin." +
+            " This is a security regression — configure a distinct origin and redeploy.",
+        );
+      } else {
+        console.warn(
+          "[ChatGPTSandboxedIframe] Cross-origin isolation not available, using same-origin",
+        );
+      }
+      sandboxHost = currentHost;
+    }
+
+    const portSuffix = currentPort ? `:${currentPort}` : "";
     const url = `${protocol}//${sandboxHost}${portSuffix}${proxyPath}?v=${version}`;
     const origin = `${protocol}//${sandboxHost}${portSuffix}`;
 

--- a/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
@@ -13,7 +13,7 @@
  * and potentially future OpenAI SDK consolidation.
  */
 
-import { HOSTED_MODE } from "@/lib/config";
+import { HOSTED_MODE, SANDBOX_ORIGIN } from "@/lib/config";
 import {
   useRef,
   useState,
@@ -114,8 +114,27 @@ export const SandboxedIframe = forwardRef<
   const outerRef = useRef<HTMLIFrameElement>(null);
   const [proxyReady, setProxyReady] = useState(false);
 
-  // SEP-1865: Host and Sandbox MUST have different origins
+  // SEP-1865: Host and Sandbox MUST have different origins.
+  //
+  // Hosted: prefer the operator-configured SANDBOX_ORIGIN
+  // (`VITE_MCPJAM_SANDBOX_ORIGIN`). It MUST be a distinct origin from the
+  // host app so the sandboxed iframe cannot reach host cookies or storage
+  // even when its sandbox carries `allow-same-origin`.
+  //
+  // Local: keep the localhost ↔ 127.0.0.1 swap so dev gets the same
+  // origin-separation property without operator config.
+  //
+  // Same-origin fallback exists only as a soft-fail for misconfigured
+  // hosted deploys; it emits a loud security warning.
   const [sandboxProxyUrl] = useState(() => {
+    const proxyPath = HOSTED_MODE
+      ? "/api/web/apps/mcp-apps/sandbox-proxy"
+      : "/api/apps/mcp-apps/sandbox-proxy";
+
+    if (HOSTED_MODE && SANDBOX_ORIGIN) {
+      return `${SANDBOX_ORIGIN}${proxyPath}?v=${Date.now()}`;
+    }
+
     const currentHost = window.location.hostname;
     const currentPort = window.location.port;
     const protocol = window.location.protocol;
@@ -126,20 +145,25 @@ export const SandboxedIframe = forwardRef<
     } else if (currentHost === "127.0.0.1") {
       sandboxHost = "localhost";
     } else {
-      // In production/hosted environments, fall back to same-origin
-      // Note: SEP-1865 recommends different origins, but same-origin works with sandbox attribute
-      console.warn(
-        "[SandboxedIframe] Cross-origin isolation not available for hostname:",
-        currentHost,
-        "- falling back to same-origin sandbox",
-      );
+      if (HOSTED_MODE) {
+        console.warn(
+          "[SandboxedIframe] VITE_MCPJAM_SANDBOX_ORIGIN is not configured;" +
+            " sandbox iframe is falling back to same-origin." +
+            " This is a security regression — the sandbox shares cookies and" +
+            " storage with the host app. Configure a distinct origin" +
+            " (e.g. https://sandbox.mcpjam.com) and redeploy.",
+        );
+      } else {
+        console.warn(
+          "[SandboxedIframe] Cross-origin isolation not available for hostname:",
+          currentHost,
+          "- falling back to same-origin sandbox",
+        );
+      }
       sandboxHost = currentHost;
     }
 
     const portSuffix = currentPort ? `:${currentPort}` : "";
-    const proxyPath = HOSTED_MODE
-      ? "/api/web/apps/mcp-apps/sandbox-proxy"
-      : "/api/apps/mcp-apps/sandbox-proxy";
     return `${protocol}//${sandboxHost}${portSuffix}${proxyPath}?v=${Date.now()}`;
   });
 

--- a/mcpjam-inspector/client/src/lib/config.ts
+++ b/mcpjam-inspector/client/src/lib/config.ts
@@ -22,6 +22,35 @@ export const HOSTED_MODE = import.meta.env.VITE_MCPJAM_HOSTED_MODE === "true";
  */
 export const SANITIZE_OAUTH_TRACES = HOSTED_MODE;
 
+/**
+ * Origin to serve the MCP Apps / ChatGPT Apps sandbox proxy from in hosted
+ * mode. Must be a distinct origin from the host app (different eTLD+1 or at
+ * minimum a different registrable subdomain that does not share cookies),
+ * e.g. `https://sandbox.mcpjam.com`.
+ *
+ * Set via `VITE_MCPJAM_SANDBOX_ORIGIN` at build time. The configured origin
+ * must serve the same sandbox-proxy routes the host app serves at
+ * `/api/web/apps/{mcp-apps,chatgpt-apps}/sandbox-proxy`, and its
+ * `frame-ancestors` CSP must include the host app origin (the existing
+ * `buildFrameAncestors()` includes every `https://` origin from
+ * `CORS_ORIGINS`, so adding the app origin to `CORS_ORIGINS` is enough).
+ *
+ * When unset in hosted mode, the iframe falls back to same-origin and a
+ * console warning is emitted — this is a security regression, not the
+ * intended deploy.
+ */
+export const SANDBOX_ORIGIN: string | null = (() => {
+  const raw = import.meta.env.VITE_MCPJAM_SANDBOX_ORIGIN;
+  if (typeof raw !== "string" || raw.length === 0) return null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+})();
+
 export const NON_PROD_LOCKDOWN =
   import.meta.env.VITE_MCPJAM_NONPROD_LOCKDOWN === "true";
 

--- a/mcpjam-inspector/client/src/vite-env.d.ts
+++ b/mcpjam-inspector/client/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_MCPJAM_HOSTED_MODE?: string;
   readonly VITE_MCPJAM_NONPROD_LOCKDOWN?: string;
   readonly VITE_MCPJAM_EMPLOYEE_EMAIL_DOMAINS?: string;
+  readonly VITE_MCPJAM_SANDBOX_ORIGIN?: string;
   readonly VITE_WORKOS_DEV_MODE?: string;
   // more env variables...
 }


### PR DESCRIPTION
## Summary

- The hosted MCP Apps / ChatGPT Apps sandbox iframe was silently falling back to same-origin in production. Same-origin + `allow-same-origin` means a widget can read host cookies and `localStorage` — CSP is not a substitute for origin separation.
- Adds `VITE_MCPJAM_SANDBOX_ORIGIN` (build-time client env var) and routes both sandbox iframes through it in hosted mode. Local dev is unchanged (the existing `localhost` ↔ `127.0.0.1` swap already gets origin separation without operator config).
- If hosted mode runs without the env var, the iframe still loads (soft-fail) but emits a loud `console.warn` so the misconfiguration is visible rather than silent.

## Why

The previous `[SandboxedIframe] falling back to same-origin` warning fired in production with no fix path. This is the first item on the broader Apps SDK + MCP Apps plan because it's the only item that affects the trust model for every widget that renders.

## Deployment requirements

Operators self-hosting MCPJam need to:

1. Pick a sandbox origin distinct from the host app — e.g. host on `app.example.com`, sandbox on `sandbox.example.com`.
2. Point the sandbox DNS at the same backend (it just needs to answer `/api/web/apps/{mcp-apps,chatgpt-apps}/sandbox-proxy`).
3. Set `VITE_MCPJAM_SANDBOX_ORIGIN=https://sandbox.example.com` at client build time.
4. Make sure the host app origin is in `CORS_ORIGINS` so the proxy's `frame-ancestors` allows the host page to frame it.

See [`mcpjam-inspector/HOSTED_DEPLOYMENT.md`](./mcpjam-inspector/HOSTED_DEPLOYMENT.md) for the full operator note.

## What reviewers should look at

- [`client/src/lib/config.ts`](mcpjam-inspector/client/src/lib/config.ts) — `SANDBOX_ORIGIN` rejects non-http(s) and malformed URLs before exporting.
- [`client/src/components/ui/sandboxed-iframe.tsx`](mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx) and [`chatgpt-sandboxed-iframe.tsx`](mcpjam-inspector/client/src/components/ui/chatgpt-sandboxed-iframe.tsx) — hosted mode now prefers `SANDBOX_ORIGIN`; the same-origin branch is the soft-fail path with a security warning.
- New regression test [`client/src/components/ui/__tests__/sandboxed-iframe.hosted.test.tsx`](mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.hosted.test.tsx) pins (a) iframe `src` is the configured origin, NOT `window.location.origin`, and (b) the unset-env case emits the security warning.

## Test plan

- [x] `npx vitest run src/components/ui/__tests__/sandboxed-iframe.hosted.test.tsx` — 2/2 pass.
- [x] `npx vitest run src/components/ui/__tests__/sandboxed-iframe.test.tsx` — 20/20 still pass (no regression in the existing iframe contract tests).
- [x] `npm run typecheck:client` — clean.
- [ ] Manual: hosted deploy with `VITE_MCPJAM_SANDBOX_ORIGIN` set — confirm widget iframe `src` is on the sandbox origin in DevTools and that postMessage flows still work end-to-end.
- [ ] Manual: hosted deploy without the env var — confirm the security warning appears in the browser console.

## Follow-ups (not in this PR)

Per the planning doc, the next PR is the SDK compat correctness pass (forward `_meta` on `callTool`, make `requestDisplayMode` resolve with the host-accepted mode, add `selectFiles`, remove the deprecated `selectedProtocolOverrideIfBothExists` dead path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how hosted widget sandbox iframes choose their `src` origin, which is security-sensitive and could break hosted deployments if `VITE_MCPJAM_SANDBOX_ORIGIN` is misconfigured. The fallback remains same-origin but now intentionally emits loud warnings and is covered by a regression test.
> 
> **Overview**
> In hosted mode, the MCP Apps and ChatGPT Apps sandbox iframes now **prefer a configurable, distinct origin** via new build-time env var `VITE_MCPJAM_SANDBOX_ORIGIN` (exported as `SANDBOX_ORIGIN`), instead of silently using `window.location.origin`.
> 
> If the variable is unset in hosted builds, the components still load but now **emit a loud security warning** and fall back to same-origin; local dev behavior (localhost/127.0.0.1 swap) remains unchanged. This adds a regression test pinning the hosted contract and new operator docs in `HOSTED_DEPLOYMENT.md`, plus the env typing in `vite-env.d.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e953a78281c9dd0c3d139c3248925ecb5162258e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->