### PR TITLE
was sending stale projectId to db

### DIFF
--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -595,7 +595,7 @@ export function ServersTab({
     hostId: previewedHostId,
   });
   const { servers: viewProjectServersList } = useViewProjectServers({
-    projectId: activeProjectId || null,
+    projectId: sharedProjectIdForHostScope,
     isAuthenticated,
   });
   const previewedHostRequiredNames = useMemo(() => {

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
@@ -126,7 +126,7 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
   // No previewed host = no auto-connect. Optional servers stay
   // disconnected until the user manually toggles them in the Servers tab.
   const { servers: projectServersList } = useProjectServers({
-    projectId: props.activeProjectId ?? null,
+    projectId: props.sharedProjectId ?? null,
     isAuthenticated: isConvexAuthenticated,
   });
   const previewedHostRequiredNames = useMemo(() => {

--- a/mcpjam-inspector/client/src/hooks/__tests__/useProjects.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useProjects.test.ts
@@ -4,7 +4,9 @@ import {
   filterProjectsForOrganization,
   normalizeProjectMembersResult,
   type RemoteProject,
+  shouldQueryProjectId,
   useProjectQueries,
+  useProjectServers,
   type ProjectMember,
 } from "../useProjects";
 
@@ -81,6 +83,58 @@ describe("useProjectQueries", () => {
     expect(result.current.hasProjects).toBe(false);
     expect(result.current.hasAnyProjects).toBe(false);
     expect(mockUseQuery).toHaveBeenCalledWith("projects:getMyProjects", {});
+  });
+});
+
+describe("useProjectServers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseMutation.mockReturnValue(vi.fn());
+  });
+
+  it("skips the project servers query for the none sentinel", () => {
+    const { result } = renderHook(() =>
+      useProjectServers({
+        isAuthenticated: true,
+        projectId: "none",
+      }),
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.serversRecord).toEqual({});
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      "servers:getProjectServers",
+      "skip",
+    );
+  });
+
+  it("trims valid project ids before querying", () => {
+    mockUseQuery.mockReturnValue([]);
+
+    renderHook(() =>
+      useProjectServers({
+        isAuthenticated: true,
+        projectId: " project-id ",
+      }),
+    );
+
+    expect(mockUseQuery).toHaveBeenCalledWith("servers:getProjectServers", {
+      projectId: "project-id",
+    });
+  });
+});
+
+describe("shouldQueryProjectId", () => {
+  it("rejects empty and sentinel ids", () => {
+    expect(shouldQueryProjectId(null)).toBe(false);
+    expect(shouldQueryProjectId("")).toBe(false);
+    expect(shouldQueryProjectId(" none ")).toBe(false);
+    expect(shouldQueryProjectId("NULL")).toBe(false);
+    expect(shouldQueryProjectId("a3ae0f26-0747-4ef0-963f-2c93fbadbeef")).toBe(
+      false,
+    );
+    expect(shouldQueryProjectId("local_123")).toBe(false);
+    expect(shouldQueryProjectId("project_123")).toBe(false);
   });
 });
 

--- a/mcpjam-inspector/client/src/hooks/useProjects.ts
+++ b/mcpjam-inspector/client/src/hooks/useProjects.ts
@@ -78,6 +78,22 @@ interface ProjectMembersQueryResult {
   canManageMembers: boolean;
 }
 
+const INVALID_PROJECT_ID_SENTINELS = new Set(["none", "null", "undefined"]);
+const UUID_PROJECT_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const LOCAL_PROJECT_ID_PREFIXES = ["local_", "project_"];
+
+export function shouldQueryProjectId(projectId: string | null | undefined) {
+  const normalized = projectId?.trim();
+  if (!normalized) return false;
+  const lower = normalized.toLowerCase();
+  return Boolean(
+    !INVALID_PROJECT_ID_SENTINELS.has(lower) &&
+      !UUID_PROJECT_ID_PATTERN.test(normalized) &&
+      !LOCAL_PROJECT_ID_PREFIXES.some((prefix) => lower.startsWith(prefix)),
+  );
+}
+
 function isProjectMembersQueryResult(
   value: unknown
 ): value is ProjectMembersQueryResult {
@@ -259,12 +275,15 @@ export function useProjectServers({
   projectId: string | null;
   isAuthenticated: boolean;
 }) {
+  const shouldQuery = isAuthenticated && shouldQueryProjectId(projectId);
+  const queryProjectId = projectId?.trim() ?? "";
+
   const servers = useQuery(
     "servers:getProjectServers" as any,
-    isAuthenticated && projectId ? ({ projectId } as any) : "skip"
+    shouldQuery ? ({ projectId: queryProjectId } as any) : "skip"
   ) as RemoteServer[] | undefined;
 
-  const isLoading = isAuthenticated && projectId && servers === undefined;
+  const isLoading = shouldQuery && servers === undefined;
 
   // Convert array to record keyed by server name
   const serversRecord = useMemo(() => {

--- a/mcpjam-inspector/client/src/hooks/useViews.ts
+++ b/mcpjam-inspector/client/src/hooks/useViews.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useQuery, useMutation } from "convex/react";
-import type { RemoteServer } from "./useProjects";
+import { shouldQueryProjectId, type RemoteServer } from "./useProjects";
 
 // Type definitions matching backend
 export type ViewProtocol = "mcp-apps" | "openai-apps";
@@ -90,11 +90,12 @@ export function useViewQueries({
   isAuthenticated: boolean;
   projectId: string | null;
 }) {
-  const enableQuery = isAuthenticated && !!projectId;
+  const enableQuery = isAuthenticated && shouldQueryProjectId(projectId);
+  const queryProjectId = projectId?.trim() ?? "";
 
   const views = useQuery(
     "views:listAllByProject" as any,
-    enableQuery ? ({ projectId } as any) : "skip",
+    enableQuery ? ({ projectId: queryProjectId } as any) : "skip",
   ) as AnyView[] | undefined;
 
   const isLoading = enableQuery && views === undefined;
@@ -191,11 +192,12 @@ export function useProjectServers({
   isAuthenticated: boolean;
   projectId: string | null;
 }) {
-  const enableQuery = isAuthenticated && !!projectId;
+  const enableQuery = isAuthenticated && shouldQueryProjectId(projectId);
+  const queryProjectId = projectId?.trim() ?? "";
 
   const servers = useQuery(
     "servers:getProjectServers" as any,
-    enableQuery ? ({ projectId } as any) : "skip",
+    enableQuery ? ({ projectId: queryProjectId } as any) : "skip",
   ) as RemoteServer[] | undefined;
 
   const isLoading = enableQuery && servers === undefined;


### PR DESCRIPTION
Before, some Convex project queries could receive `activeProjectId` — the project the user is currently in on the frontend — instead of the Convex project ID. That caused Convex ID validation errors when `activeProjectId` was stale or frontend-only.

Now, server/view queries only run with the Convex project ID (`sharedProjectId`). If the frontend does not have `sharedProjectId` yet, it skips those queries instead of sending `activeProjectId`.