### PR TITLE
local was sending guest token in request for sessions

### DIFF
--- a/mcpjam-inspector/client/src/lib/apis/web/__tests__/chat-history-api.nonhosted.test.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/__tests__/chat-history-api.nonhosted.test.ts
@@ -1,18 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockAuthFetch = vi.hoisted(() => vi.fn());
-const mockGetGuestBearerToken = vi.hoisted(() => vi.fn());
-
-vi.mock("@/lib/config", () => ({
-  HOSTED_MODE: false,
-}));
 
 vi.mock("@/lib/session-token", () => ({
   authFetch: (...args: unknown[]) => mockAuthFetch(...args),
-}));
-
-vi.mock("@/lib/guest-session", () => ({
-  getGuestBearerToken: (...args: unknown[]) => mockGetGuestBearerToken(...args),
 }));
 
 import {
@@ -25,11 +16,9 @@ import {
 describe("chat history API in non-hosted mode", () => {
   beforeEach(() => {
     mockAuthFetch.mockReset();
-    mockGetGuestBearerToken.mockReset();
-    mockGetGuestBearerToken.mockResolvedValue("guest-token");
   });
 
-  it("attaches the guest bearer when listing history", async () => {
+  it("lets authFetch choose the bearer when listing history", async () => {
     mockAuthFetch.mockResolvedValue(
       new Response(JSON.stringify({ ok: true, personal: [], project: [] }), {
         status: 200,
@@ -39,20 +28,17 @@ describe("chat history API in non-hosted mode", () => {
 
     await listChatHistory({ status: "active", projectId: "ws-1" });
 
-    expect(mockGetGuestBearerToken).toHaveBeenCalledTimes(1);
     expect(mockAuthFetch).toHaveBeenCalledWith(
       "/api/web/chat-history/list?projectId=ws-1&status=active",
       expect.objectContaining({
         method: "GET",
-        headers: expect.any(Headers),
       }),
     );
 
-    const headers = mockAuthFetch.mock.calls[0]?.[1]?.headers as Headers;
-    expect(headers.get("Authorization")).toBe("Bearer guest-token");
+    expect(mockAuthFetch.mock.calls[0]?.[1]?.headers).toBeUndefined();
   });
 
-  it("attaches the guest bearer when posting an action", async () => {
+  it("does not preempt authFetch's bearer when posting an action", async () => {
     mockAuthFetch.mockResolvedValue(
       new Response(JSON.stringify({ ok: true }), {
         status: 200,
@@ -62,7 +48,6 @@ describe("chat history API in non-hosted mode", () => {
 
     await chatHistoryAction("mark-read", "session-1");
 
-    expect(mockGetGuestBearerToken).toHaveBeenCalledTimes(1);
     expect(mockAuthFetch).toHaveBeenCalledWith(
       "/api/web/chat-history/action",
       expect.objectContaining({
@@ -72,7 +57,7 @@ describe("chat history API in non-hosted mode", () => {
     );
 
     const headers = mockAuthFetch.mock.calls[0]?.[1]?.headers as Headers;
-    expect(headers.get("Authorization")).toBe("Bearer guest-token");
+    expect(headers.get("Authorization")).toBeNull();
     expect(headers.get("Content-Type")).toBe("application/json");
   });
 
@@ -89,12 +74,11 @@ describe("chat history API in non-hosted mode", () => {
       { headers: { Authorization: "Bearer explicit-token" } },
     );
 
-    expect(mockGetGuestBearerToken).not.toHaveBeenCalled();
     const headers = mockAuthFetch.mock.calls[0]?.[1]?.headers as Headers;
     expect(headers.get("Authorization")).toBe("Bearer explicit-token");
   });
 
-  it("attaches the guest bearer when generating a widget snapshot upload URL", async () => {
+  it("does not preempt authFetch's bearer when generating a widget snapshot upload URL", async () => {
     mockAuthFetch.mockResolvedValue(
       new Response(
         JSON.stringify({ ok: true, uploadUrl: "https://upload.test" }),
@@ -108,11 +92,11 @@ describe("chat history API in non-hosted mode", () => {
     await generateWidgetSnapshotUploadUrl({ chatSessionId: "chat-session-1" });
 
     const headers = mockAuthFetch.mock.calls[0]?.[1]?.headers as Headers;
-    expect(headers.get("Authorization")).toBe("Bearer guest-token");
+    expect(headers.get("Authorization")).toBeNull();
     expect(headers.get("Content-Type")).toBe("application/json");
   });
 
-  it("attaches the guest bearer when creating a widget snapshot", async () => {
+  it("does not preempt authFetch's bearer when creating a widget snapshot", async () => {
     mockAuthFetch.mockResolvedValue(
       new Response(JSON.stringify({ ok: true, snapshotId: "snapshot-1" }), {
         status: 200,
@@ -129,7 +113,7 @@ describe("chat history API in non-hosted mode", () => {
     });
 
     const headers = mockAuthFetch.mock.calls[0]?.[1]?.headers as Headers;
-    expect(headers.get("Authorization")).toBe("Bearer guest-token");
+    expect(headers.get("Authorization")).toBeNull();
     expect(headers.get("Content-Type")).toBe("application/json");
   });
 });

--- a/mcpjam-inspector/client/src/lib/apis/web/chat-history-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/chat-history-api.ts
@@ -1,6 +1,4 @@
 import { authFetch } from "@/lib/session-token";
-import { HOSTED_MODE } from "@/lib/config";
-import { getGuestBearerToken } from "@/lib/guest-session";
 import { WebApiError } from "./base";
 
 export interface ChatHistorySession {
@@ -119,18 +117,10 @@ interface ChatHistoryRequestOptions {
   headers?: HeadersInit;
 }
 
-async function buildChatHistoryHeaders(
+function buildChatHistoryHeaders(
   initHeaders?: HeadersInit,
-): Promise<HeadersInit | undefined> {
+): HeadersInit | undefined {
   const headers = new Headers(initHeaders);
-
-  if (!HOSTED_MODE && !headers.has("Authorization")) {
-    const guestToken = await getGuestBearerToken();
-    if (guestToken) {
-      headers.set("Authorization", `Bearer ${guestToken}`);
-    }
-  }
-
   return Array.from(headers.keys()).length > 0 ? headers : undefined;
 }
 
@@ -140,7 +130,7 @@ async function webGet<T>(
 ): Promise<T> {
   const response = await authFetch(path, {
     method: "GET",
-    headers: await buildChatHistoryHeaders(options?.headers),
+    headers: buildChatHistoryHeaders(options?.headers),
   });
 
   let body: any = null;
@@ -171,7 +161,7 @@ async function webPost<TRequest, TResponse>(
 ): Promise<TResponse> {
   const initHeaders = new Headers(options?.headers);
   initHeaders.set("Content-Type", "application/json");
-  const headers = new Headers(await buildChatHistoryHeaders(initHeaders));
+  const headers = new Headers(buildChatHistoryHeaders(initHeaders));
   const response = await authFetch(path, {
     method: "POST",
     headers,


### PR DESCRIPTION
Summary

Fix local chat history auth.

Local chat history was always adding a guest auth token before calling the backend. That could make Convex reject the request locally with:

No auth provider found matching the given token

Now chat history lets the normal auth code choose the right token, same as the rest of the app.

Testing

npm run test -- client/src/lib/__tests__/session-token.hosted-retry.test.ts client/src/lib/apis/web/__tests__/context.guest-fallback.test.ts client/src/lib/apis/web/__tests__/chat-history-api.nonhosted.test.ts
npm run typecheck:client