### PR TITLE
Synthesize Raw view payload for rehydrated chat sessions

### DIFF
--- a/mcpjam-inspector/client/src/components/evals/trace-raw-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-raw-view.tsx
@@ -1,11 +1,14 @@
 /**
  * Raw trace panel — single JsonEditor with bordered chrome around the tree.
- * When `requestPayloadHistory` is provided (live chat), Raw shows the resolved model request payload
- * (`system`, `tools`, `messages`) from the last `request_payload` event. `messages` are merged with
- * `trace.messages` from the live envelope when the snapshot is ahead of the last captured request.
- * If the chat shell passes this prop but `entries` is empty (e.g. a rehydrated stored session, which
- * never replays `request_payload`), we fall back to the `trace` blob so Raw matches Trace/Chat instead
- * of showing an endless spinner. Otherwise shows the stored trace blob (evals / offline).
+ * When `requestPayloadHistory` is provided (live chat or rehydrated session), Raw shows the resolved
+ * model request payload (`system`, `tools`, `messages`) from the last entry. For live chat that's the
+ * latest `request_payload` SSE event; for rehydrated sessions, `useChatSession` synthesizes a single
+ * entry from the current `systemPrompt`, currently-resolved tool schemas, and the converted thread —
+ * so tool schemas reflect what would be sent next, not a historical snapshot. `messages` are merged
+ * with `trace.messages` from the live envelope when that snapshot is ahead of the last captured
+ * request. If both `entries` and `traceTranscriptFromUi` are empty (e.g. no servers connected on
+ * rehydration), we fall back to the `trace` blob below. Otherwise shows the stored trace blob
+ * (evals / offline).
  */
 
 import { Copy, Loader2, ScanSearch } from "lucide-react";

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -57,6 +57,7 @@ import {
 } from "@/lib/ollama-utils";
 import { DEFAULT_SYSTEM_PROMPT } from "@/components/chat-v2/shared/chat-helpers";
 import { getToolsMetadata, ToolServerMap } from "@/lib/apis/mcp-tools-api";
+import type { SerializedModelRequestTool } from "@/shared/model-request-payload";
 import { countTextTokens } from "@/lib/apis/mcp-tokenizer-api";
 import {
   authFetch,
@@ -1018,6 +1019,9 @@ export function useChatSession(
     Record<string, Record<string, unknown>>
   >({});
   const [toolServerMap, setToolServerMap] = useState<ToolServerMap>({});
+  const [serializedTools, setSerializedTools] = useState<
+    Record<string, SerializedModelRequestTool>
+  >({});
   const [persistedSnapshotToolCallIds, setPersistedSnapshotToolCallIds] =
     useState<string[]>([]);
   const [mcpToolsTokenCount, setMcpToolsTokenCount] = useState<Record<
@@ -1595,6 +1599,45 @@ export function useChatSession(
   const hasLiveTimelineContent =
     livePreviewSpanCount > 0 || (liveTraceEnvelope?.spans?.length ?? 0) > 0;
 
+  /**
+   * Live SSE produces a `request_payload` event per turn; rehydrated stored
+   * sessions never replay it, so the Raw view would have nothing to render.
+   * When there's no live history but we have a converted transcript, synthesize
+   * a single entry from current `systemPrompt` + currently-resolved tool
+   * schemas + the rehydrated thread. This intentionally reflects what would
+   * be sent if the user typed next — tool schemas may differ from when the
+   * session originally ran, since they're fetched from currently-connected
+   * servers.
+   */
+  const requestPayloadHistory = useMemo<
+    LiveChatTraceRequestPayloadEntry[]
+  >(() => {
+    const live = liveTraceState.requestPayloadHistory;
+    if (live.length > 0) {
+      return live;
+    }
+    if (!traceTranscriptFromUi || traceTranscriptFromUi.length === 0) {
+      return live;
+    }
+    return [
+      {
+        turnId: "rehydrated",
+        promptIndex: 0,
+        stepIndex: 0,
+        payload: {
+          system: systemPrompt ?? "",
+          tools: serializedTools,
+          messages: traceTranscriptFromUi,
+        },
+      },
+    ];
+  }, [
+    liveTraceState.requestPayloadHistory,
+    traceTranscriptFromUi,
+    systemPrompt,
+    serializedTools,
+  ]);
+
   // useLayoutEffect (not useEffect) so the trace state is swapped out
   // before the browser paints the new chatSessionId render, preventing a
   // flash of the previous session's live-trace envelope on session switch
@@ -2028,6 +2071,9 @@ export function useChatSession(
         setToolServerMap((previous) =>
           Object.keys(previous).length > 0 ? {} : previous
         );
+        setSerializedTools((previous) =>
+          Object.keys(previous).length > 0 ? {} : previous
+        );
         setMcpToolsTokenCount((previous) =>
           previous !== null ? null : previous
         );
@@ -2047,12 +2093,11 @@ export function useChatSession(
       setMcpToolsTokenCountLoading(!!modelIdForTokens);
 
       try {
-        const { metadata, toolServerMap, tokenCounts } = await getToolsMetadata(
-          selectedServers,
-          modelIdForTokens
-        );
+        const { metadata, toolServerMap, serializedTools, tokenCounts } =
+          await getToolsMetadata(selectedServers, modelIdForTokens);
         setToolsMetadata(metadata);
         setToolServerMap(toolServerMap);
+        setSerializedTools(serializedTools);
         setMcpToolsTokenCount(
           tokenCounts && Object.keys(tokenCounts).length > 0
             ? tokenCounts
@@ -2069,6 +2114,7 @@ export function useChatSession(
         }
         setToolsMetadata({});
         setToolServerMap({});
+        setSerializedTools({});
         setMcpToolsTokenCount(null);
       } finally {
         setMcpToolsTokenCountLoading(false);
@@ -2247,7 +2293,7 @@ export function useChatSession(
 
     // Live trace state
     liveTraceEnvelope,
-    requestPayloadHistory: liveTraceState.requestPayloadHistory,
+    requestPayloadHistory,
     hasTraceSnapshot,
     hasLiveTimelineContent,
     traceViewsSupported,

--- a/mcpjam-inspector/client/src/lib/apis/mcp-tools-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-tools-api.ts
@@ -5,6 +5,7 @@ import type {
   ListToolsResult,
 } from "@modelcontextprotocol/client";
 import type { MCPTask, TaskOptions } from "@mcpjam/sdk/browser";
+import type { SerializedModelRequestTool } from "@/shared/model-request-payload";
 import { authFetch } from "@/lib/session-token";
 import { executeHostedTool, listHostedTools } from "@/lib/apis/web/tools-api";
 import { isHostedMode, runByMode } from "@/lib/apis/mode-client";
@@ -185,6 +186,13 @@ export interface ToolsMetadataAggregate {
   /** Bare tool names that appear on more than one server. */
   collidingToolNames: string[];
   tokenCounts: Record<string, number> | null;
+  /**
+   * Tool schemas advertised to the model (name + description + inputSchema),
+   * keyed by bare tool name. Used by the Raw view when rendering rehydrated
+   * sessions that never replayed `request_payload`. Last-seen wins on name
+   * collisions, mirroring `toolServerMap`.
+   */
+  serializedTools: Record<string, SerializedModelRequestTool>;
 }
 
 export function getToolServerId(
@@ -208,6 +216,7 @@ export async function getToolsMetadata(
     scopedMetadata: {},
     collidingToolNames: [],
     tokenCounts: modelId ? {} : null,
+    serializedTools: {},
   };
   // Track which servers have seen each tool name so we can surface collisions
   // to callers (e.g. the Playground tools pane uses this to disambiguate via
@@ -227,6 +236,14 @@ export async function getToolsMetadata(
         const servers = seenOn.get(toolName) ?? new Set<string>();
         servers.add(serverId);
         seenOn.set(toolName, servers);
+      }
+
+      for (const tool of data.tools ?? []) {
+        aggregate.serializedTools[tool.name] = {
+          name: tool.name,
+          description: tool.description,
+          inputSchema: tool.inputSchema as Record<string, unknown> | undefined,
+        };
       }
 
       // Collect token counts if modelId was provided


### PR DESCRIPTION
## Summary
- Old sessions never replay the `request_payload` SSE event, so the Raw tab fell through to the bare trace blob (`traceVersion`/`spans`/empty `messages`) instead of the resolved `{system, tools, messages}` shape a fresh session shows.
- `useChatSession` now synthesizes a single-entry `requestPayloadHistory` for rehydrated sessions using the current `systemPrompt`, currently-resolved tool schemas, and the converted thread. Live SSE history still wins when present.
- Tool schemas reflect the *currently-connected* servers (not a historical snapshot) — matches what would actually be sent if the user typed next.
- `getToolsMetadata` is extended to also return `serializedTools` (name + description + inputSchema) by reusing the `tools` field already in each `listTools` response — no extra fetches.

## Test plan
- [x] `vitest run client/src/components/evals/__tests__/trace-raw-view.test.tsx` — 4/4
- [x] `vitest run client/src/hooks/__tests__/use-chat-session.fork.test.tsx use-chat-session.hosted.test.tsx` — 23/23
- [x] `vitest run client/src/lib/apis` — 55/55
- [x] `tsc -p client/tsconfig.typecheck.json --noEmit` — clean
- [ ] Manual: open an old chat session, switch to Raw — should show `{system, tools, messages}` instead of the trace blob
- [ ] Manual: open a session with no servers connected — should fall back to the trace blob (safety net)
- [ ] Manual: live chat — unchanged, latest `request_payload` still wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes how `useChatSession` derives and exposes `requestPayloadHistory` and extends the tools-metadata API shape, which could affect Raw/trace rendering and any consumers expecting the previous `getToolsMetadata` return.
> 
> **Overview**
> The Raw tab now shows a resolved model request payload for *rehydrated* chat sessions by synthesizing a single `requestPayloadHistory` entry from the current `systemPrompt`, currently-fetched tool schemas, and the converted thread when no live SSE `request_payload` events exist.
> 
> `getToolsMetadata` is extended to also return `serializedTools` (tool name/description/inputSchema) derived from each `listTools` response, and `useChatSession` stores/clears this alongside existing tool metadata and uses it when building the synthesized payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0575ac64a19faf0e301fa6dc7962802ac50375e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->