### PR TITLE
Gate widget render on host clientCapabilities 

### DIFF
--- a/.changeset/codex-render-gate.md
+++ b/.changeset/codex-render-gate.md
@@ -2,6 +2,8 @@
 "@mcpjam/inspector": patch
 ---
 
-Chat: don't render widget iframes for hosts that don't advertise the MCP UI extension. Codex (elicitation-only CLI) now correctly falls through to the plain tool-result row instead of mounting an iframe for tools that declare `_meta.ui.resourceUri` or `openai/outputTemplate`. Apps-SDK hosts that keep the SDK-default UI extension (ChatGPT, Copilot, MCPJam, Claude) are unaffected.
+Chat / Tools / Trace replays / Playground / hosted chatbox: don't render widget iframes for hosts whose effective `clientCapabilities` (host config + per-server overrides) don't advertise the MCP UI extension per SEP-1865. The render gate now calls the same `resolveEffectiveClientCapabilities` function the connect path uses, so the renderer and `initialize` always evaluate the same blob. Codex (elicitation-only CLI) falls through to the plain tool-result row; SDK-default hosts (Claude, ChatGPT, Copilot, MCPJam) keep rendering widgets.
 
-The render gate keys off the host's persisted `clientCapabilities`, not its `hostStyle` — user edits to capabilities are honored. A future `window.openai` flag on `HostConfigInputV2` will be OR-ed into the same gate.
+Behavioral notes:
+- Server-level `clientCapabilities` overrides are now honored at render time. A server that re-advertises the UI extension renders widgets even when the host (e.g. Codex) strips it — server-level override beats host identity, matching `initialize`.
+- SEP-1865 strictness: the helper now requires `extensions["io.modelcontextprotocol/ui"].mimeTypes` to include `text/html;profile=mcp-app`. Custom configs with bare `{ extensions: { [id]: {} } }` (no `mimeTypes` array) stop rendering widgets. SDK-default capability shapes are unaffected.

--- a/.changeset/codex-render-gate.md
+++ b/.changeset/codex-render-gate.md
@@ -1,0 +1,7 @@
+---
+"@mcpjam/inspector": patch
+---
+
+Chat: don't render widget iframes for hosts that don't advertise the MCP UI extension. Codex (elicitation-only CLI) now correctly falls through to the plain tool-result row instead of mounting an iframe for tools that declare `_meta.ui.resourceUri` or `openai/outputTemplate`. Apps-SDK hosts that keep the SDK-default UI extension (ChatGPT, Copilot, MCPJam, Claude) are unaffected.
+
+The render gate keys off the host's persisted `clientCapabilities`, not its `hostStyle` — user edits to capabilities are honored. A future `window.openai` flag on `HostConfigInputV2` will be OR-ed into the same gate.

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1033,6 +1033,7 @@ export function AppBuilderRoute() {
 
 export function PlaygroundRoute() {
   const {
+    activeHost,
     activeProject,
     activeProjectId,
     appState,
@@ -1070,6 +1071,7 @@ export function PlaygroundRoute() {
       ensureServersReady={ensureServersReady}
       onOnboardingChange={setAppBuilderOnboarding}
       playgroundServerSelectorProps={playgroundServerSelectorProps}
+      activeHost={activeHost}
       evalChatHandoff={evalChatHandoff}
       onEvalChatHandoffConsumed={(id) =>
         setEvalChatHandoff((current: EvalChatHandoff | null) =>

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -22,7 +22,7 @@ import { SkillsTab } from "./components/SkillsTab";
 import { LearningTab } from "./components/LearningTab";
 import { TasksTab } from "./components/TasksTab";
 import { ClientStyledChatTabV2 } from "./components/ClientStyledChatTabV2";
-import { ActiveHostClientCapabilitiesScope } from "./contexts/active-host-client-capabilities-context";
+import { ActiveHostCapsResolverScope } from "./contexts/active-host-client-capabilities-context";
 import type { EvalChatHandoff } from "./lib/eval-chat-handoff";
 import { EvalsTab } from "./components/EvalsTab";
 import { CiEvalsTab } from "./components/CiEvalsTab";
@@ -658,7 +658,7 @@ export function ToolsRoute() {
   const prefHostStyle = usePreferencesStore((state) => state.hostStyle);
   const hostStyle = activeHost?.hostStyle ?? prefHostStyle;
   return (
-    <ActiveHostClientCapabilitiesScope
+    <ActiveHostCapsResolverScope
       activeHost={activeHost}
       hostStyle={hostStyle}
     >
@@ -668,7 +668,7 @@ export function ToolsRoute() {
           serverName={appState.selectedServer}
         />
       </div>
-    </ActiveHostClientCapabilitiesScope>
+    </ActiveHostCapsResolverScope>
   );
 }
 

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -22,6 +22,7 @@ import { SkillsTab } from "./components/SkillsTab";
 import { LearningTab } from "./components/LearningTab";
 import { TasksTab } from "./components/TasksTab";
 import { ClientStyledChatTabV2 } from "./components/ClientStyledChatTabV2";
+import { ActiveHostClientCapabilitiesScope } from "./contexts/active-host-client-capabilities-context";
 import type { EvalChatHandoff } from "./lib/eval-chat-handoff";
 import { EvalsTab } from "./components/EvalsTab";
 import { CiEvalsTab } from "./components/CiEvalsTab";
@@ -69,7 +70,10 @@ import {
 } from "@mcpjam/design-system/dialog";
 import { useAppState, type ServerWithName } from "./hooks/use-app-state";
 import { useActorKey } from "./hooks/use-actor-key";
-import { PreferencesStoreProvider } from "./stores/preferences/preferences-provider";
+import {
+  PreferencesStoreProvider,
+  usePreferencesStore,
+} from "./stores/preferences/preferences-provider";
 import { Toaster } from "@mcpjam/design-system/sonner";
 import { useElectronOAuth } from "./hooks/useElectronOAuth";
 import { useEnsureDbUser } from "./hooks/useEnsureDbUser";
@@ -650,14 +654,21 @@ export function RegistryRoute() {
 }
 
 export function ToolsRoute() {
-  const { selectedMCPConfig, appState } = useAppRouteContext();
+  const { selectedMCPConfig, appState, activeHost } = useAppRouteContext();
+  const prefHostStyle = usePreferencesStore((state) => state.hostStyle);
+  const hostStyle = activeHost?.hostStyle ?? prefHostStyle;
   return (
-    <div className="h-full overflow-hidden">
-      <ToolsTab
-        serverConfig={selectedMCPConfig}
-        serverName={appState.selectedServer}
-      />
-    </div>
+    <ActiveHostClientCapabilitiesScope
+      activeHost={activeHost}
+      hostStyle={hostStyle}
+    >
+      <div className="h-full overflow-hidden">
+        <ToolsTab
+          serverConfig={selectedMCPConfig}
+          serverName={appState.selectedServer}
+        />
+      </div>
+    </ActiveHostClientCapabilitiesScope>
   );
 }
 

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -429,6 +429,7 @@ vi.mock("../state/app-state-context", () => ({
   // to compute connected/excess servers. Return an empty servers map so
   // the reconciler's reconciliation logic is a no-op in App-level tests.
   useSharedAppState: () => ({ servers: {} }),
+  useOptionalSharedAppState: () => ({ servers: {} }),
 }));
 vi.mock("../components/CompletingSignInLoading", () => ({
   default: () => <div />,

--- a/mcpjam-inspector/client/src/components/ClientStyledChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ClientStyledChatTabV2.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps } from "react";
+import { useMemo, type ComponentProps } from "react";
 import { ChatTabV2 } from "./ChatTabV2";
 import {
   ChatboxHostStyleProvider,
@@ -9,6 +9,10 @@ import { ActiveMcpProfileProvider } from "@/contexts/active-mcp-profile-context"
 import { ActiveHostClientCapabilitiesProvider } from "@/contexts/active-host-client-capabilities-context";
 import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
+import {
+  seedFromHostTemplate,
+  type HostTemplateId,
+} from "@/lib/client-templates";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 
@@ -41,7 +45,17 @@ export function ClientStyledChatTabV2({
   const hostCapabilitiesOverride =
     activeHost?.hostCapabilitiesOverride ?? prefHostCapabilitiesOverride;
   const activeMcpProfile = activeHost?.mcpProfile;
-  const activeHostClientCapabilities = activeHost?.clientCapabilities;
+  // clientCapabilities: prefer the persisted host config; fall back to the
+  // template seed for `hostStyle` so prefs-only surfaces (no Convex
+  // `activeHost` hydrated) still gate widget rendering correctly. Without
+  // this fallback, picking Codex via the host-style preference would still
+  // leave `clientCapabilities` undefined here, the gate in PartSwitch would
+  // read the legacy-preservation default (`undefined` → allow), and the
+  // widget would render even though Codex strips the MCP UI extension.
+  const activeHostClientCapabilities = useMemo(() => {
+    if (activeHost?.clientCapabilities) return activeHost.clientCapabilities;
+    return seedFromHostTemplate(hostStyle as HostTemplateId).clientCapabilities;
+  }, [activeHost?.clientCapabilities, hostStyle]);
   const shellStyle = getChatboxShellStyle(hostStyle, themeMode);
 
   return (

--- a/mcpjam-inspector/client/src/components/ClientStyledChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ClientStyledChatTabV2.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/contexts/chatbox-client-style-context";
 import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-client-capabilities-override-context";
 import { ActiveMcpProfileProvider } from "@/contexts/active-mcp-profile-context";
+import { ActiveHostClientCapabilitiesProvider } from "@/contexts/active-host-client-capabilities-context";
 import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
 import { cn } from "@/lib/utils";
@@ -40,6 +41,7 @@ export function ClientStyledChatTabV2({
   const hostCapabilitiesOverride =
     activeHost?.hostCapabilitiesOverride ?? prefHostCapabilitiesOverride;
   const activeMcpProfile = activeHost?.mcpProfile;
+  const activeHostClientCapabilities = activeHost?.clientCapabilities;
   const shellStyle = getChatboxShellStyle(hostStyle, themeMode);
 
   return (
@@ -49,27 +51,31 @@ export function ClientStyledChatTabV2({
       >
         <ChatboxHostThemeProvider value={themeMode}>
           <ActiveMcpProfileProvider value={activeMcpProfile}>
-            <div
-              className={cn(
-                "chatbox-host-shell app-theme-scope flex h-full min-h-0 flex-1 flex-col overflow-hidden",
-                themeMode === "dark" && "dark",
-              )}
-              data-host-style={hostStyle}
-              style={shellStyle}
+            <ActiveHostClientCapabilitiesProvider
+              value={activeHostClientCapabilities}
             >
-              <ChatTabV2
-                {...props}
-                // The selector writes only to the preferences store, but
-                // when `activeHost` is present `hostStyle` is derived from
-                // it instead — the control would silently no-op. Suppress
-                // the selector in that case so the user isn't handed a
-                // dead toggle. Surfaces with no active host (e.g. plain
-                // direct chat) still get the prefs-backed picker.
-                showHostStyleSelector={showHostStyleSelector && !activeHost}
-                hostStyle={hostStyle}
-                onHostStyleChange={setHostStyle}
-              />
-            </div>
+              <div
+                className={cn(
+                  "chatbox-host-shell app-theme-scope flex h-full min-h-0 flex-1 flex-col overflow-hidden",
+                  themeMode === "dark" && "dark",
+                )}
+                data-host-style={hostStyle}
+                style={shellStyle}
+              >
+                <ChatTabV2
+                  {...props}
+                  // The selector writes only to the preferences store, but
+                  // when `activeHost` is present `hostStyle` is derived from
+                  // it instead — the control would silently no-op. Suppress
+                  // the selector in that case so the user isn't handed a
+                  // dead toggle. Surfaces with no active host (e.g. plain
+                  // direct chat) still get the prefs-backed picker.
+                  showHostStyleSelector={showHostStyleSelector && !activeHost}
+                  hostStyle={hostStyle}
+                  onHostStyleChange={setHostStyle}
+                />
+              </div>
+            </ActiveHostClientCapabilitiesProvider>
           </ActiveMcpProfileProvider>
         </ChatboxHostThemeProvider>
       </ChatboxHostCapabilitiesOverrideProvider>

--- a/mcpjam-inspector/client/src/components/ClientStyledChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ClientStyledChatTabV2.tsx
@@ -9,6 +9,7 @@ import { ActiveMcpProfileProvider } from "@/contexts/active-mcp-profile-context"
 import { ActiveHostClientCapabilitiesProvider } from "@/contexts/active-host-client-capabilities-context";
 import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
+import { hostSupportsWidgetRendering } from "@/lib/host-capabilities";
 import {
   seedFromHostTemplate,
   type HostTemplateId,
@@ -74,6 +75,12 @@ export function ClientStyledChatTabV2({
                   themeMode === "dark" && "dark",
                 )}
                 data-host-style={hostStyle}
+                data-host-supports-widgets={
+                  hostSupportsWidgetRendering(activeHostClientCapabilities)
+                    ? "true"
+                    : "false"
+                }
+                data-host-caps-source={activeHost?.clientCapabilities ? "host" : "template"}
                 style={shellStyle}
               >
                 <ChatTabV2

--- a/mcpjam-inspector/client/src/components/ClientStyledChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ClientStyledChatTabV2.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type ComponentProps } from "react";
+import type { ComponentProps } from "react";
 import { ChatTabV2 } from "./ChatTabV2";
 import {
   ChatboxHostStyleProvider,
@@ -6,14 +6,9 @@ import {
 } from "@/contexts/chatbox-client-style-context";
 import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-client-capabilities-override-context";
 import { ActiveMcpProfileProvider } from "@/contexts/active-mcp-profile-context";
-import { ActiveHostClientCapabilitiesProvider } from "@/contexts/active-host-client-capabilities-context";
+import { ActiveHostClientCapabilitiesScope } from "@/contexts/active-host-client-capabilities-context";
 import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
-import { hostSupportsWidgetRendering } from "@/lib/host-capabilities";
-import {
-  seedFromHostTemplate,
-  type HostTemplateId,
-} from "@/lib/client-templates";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 
@@ -46,17 +41,6 @@ export function ClientStyledChatTabV2({
   const hostCapabilitiesOverride =
     activeHost?.hostCapabilitiesOverride ?? prefHostCapabilitiesOverride;
   const activeMcpProfile = activeHost?.mcpProfile;
-  // clientCapabilities: prefer the persisted host config; fall back to the
-  // template seed for `hostStyle` so prefs-only surfaces (no Convex
-  // `activeHost` hydrated) still gate widget rendering correctly. Without
-  // this fallback, picking Codex via the host-style preference would still
-  // leave `clientCapabilities` undefined here, the gate in PartSwitch would
-  // read the legacy-preservation default (`undefined` → allow), and the
-  // widget would render even though Codex strips the MCP UI extension.
-  const activeHostClientCapabilities = useMemo(() => {
-    if (activeHost?.clientCapabilities) return activeHost.clientCapabilities;
-    return seedFromHostTemplate(hostStyle as HostTemplateId).clientCapabilities;
-  }, [activeHost?.clientCapabilities, hostStyle]);
   const shellStyle = getChatboxShellStyle(hostStyle, themeMode);
 
   return (
@@ -66,8 +50,9 @@ export function ClientStyledChatTabV2({
       >
         <ChatboxHostThemeProvider value={themeMode}>
           <ActiveMcpProfileProvider value={activeMcpProfile}>
-            <ActiveHostClientCapabilitiesProvider
-              value={activeHostClientCapabilities}
+            <ActiveHostClientCapabilitiesScope
+              activeHost={activeHost}
+              hostStyle={hostStyle}
             >
               <div
                 className={cn(
@@ -75,12 +60,6 @@ export function ClientStyledChatTabV2({
                   themeMode === "dark" && "dark",
                 )}
                 data-host-style={hostStyle}
-                data-host-supports-widgets={
-                  hostSupportsWidgetRendering(activeHostClientCapabilities)
-                    ? "true"
-                    : "false"
-                }
-                data-host-caps-source={activeHost?.clientCapabilities ? "host" : "template"}
                 style={shellStyle}
               >
                 <ChatTabV2
@@ -96,7 +75,7 @@ export function ClientStyledChatTabV2({
                   onHostStyleChange={setHostStyle}
                 />
               </div>
-            </ActiveHostClientCapabilitiesProvider>
+            </ActiveHostClientCapabilitiesScope>
           </ActiveMcpProfileProvider>
         </ChatboxHostThemeProvider>
       </ChatboxHostCapabilitiesOverrideProvider>

--- a/mcpjam-inspector/client/src/components/ClientStyledChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ClientStyledChatTabV2.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/contexts/chatbox-client-style-context";
 import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-client-capabilities-override-context";
 import { ActiveMcpProfileProvider } from "@/contexts/active-mcp-profile-context";
-import { ActiveHostClientCapabilitiesScope } from "@/contexts/active-host-client-capabilities-context";
+import { ActiveHostCapsResolverScope } from "@/contexts/active-host-client-capabilities-context";
 import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
 import { cn } from "@/lib/utils";
@@ -48,7 +48,7 @@ export function ClientStyledChatTabV2({
       <ChatboxHostCapabilitiesOverrideProvider value={hostCapabilitiesOverride}>
         <ChatboxHostThemeProvider value={themeMode}>
           <ActiveMcpProfileProvider value={activeMcpProfile}>
-            <ActiveHostClientCapabilitiesScope
+            <ActiveHostCapsResolverScope
               activeHost={activeHost}
               hostStyle={hostStyle}
             >
@@ -73,7 +73,7 @@ export function ClientStyledChatTabV2({
                   onHostStyleChange={setHostStyle}
                 />
               </div>
-            </ActiveHostClientCapabilitiesScope>
+            </ActiveHostCapsResolverScope>
           </ActiveMcpProfileProvider>
         </ChatboxHostThemeProvider>
       </ChatboxHostCapabilitiesOverrideProvider>

--- a/mcpjam-inspector/client/src/components/ClientStyledChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ClientStyledChatTabV2.tsx
@@ -34,7 +34,7 @@ export function ClientStyledChatTabV2({
   const prefHostStyle = usePreferencesStore((state) => state.hostStyle);
   const setHostStyle = usePreferencesStore((state) => state.setHostStyle);
   const prefHostCapabilitiesOverride = usePreferencesStore(
-    (state) => state.hostCapabilitiesOverride,
+    (state) => state.hostCapabilitiesOverride
   );
 
   const hostStyle = activeHost?.hostStyle ?? prefHostStyle;
@@ -45,9 +45,7 @@ export function ClientStyledChatTabV2({
 
   return (
     <ChatboxHostStyleProvider value={hostStyle}>
-      <ChatboxHostCapabilitiesOverrideProvider
-        value={hostCapabilitiesOverride}
-      >
+      <ChatboxHostCapabilitiesOverrideProvider value={hostCapabilitiesOverride}>
         <ChatboxHostThemeProvider value={themeMode}>
           <ActiveMcpProfileProvider value={activeMcpProfile}>
             <ActiveHostClientCapabilitiesScope
@@ -57,7 +55,7 @@ export function ClientStyledChatTabV2({
               <div
                 className={cn(
                   "chatbox-host-shell app-theme-scope flex h-full min-h-0 flex-1 flex-col overflow-hidden",
-                  themeMode === "dark" && "dark",
+                  themeMode === "dark" && "dark"
                 )}
                 data-host-style={hostStyle}
                 style={shellStyle}

--- a/mcpjam-inspector/client/src/components/ToolsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ToolsTab.tsx
@@ -659,6 +659,7 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
       structuredContentValid={structuredContentValid}
       toolMeta={getToolMeta(lastToolName)}
       responseDurationMs={responseDurationMs}
+      serverName={serverName}
     />
   ) : (
     <div className="h-full flex items-center justify-center">

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/PartSwitch.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/PartSwitch.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { MCP_UI_EXTENSION_ID } from "@mcpjam/sdk/browser";
 import { PartSwitch } from "../thread/part-switch";
+import { ActiveHostClientCapabilitiesProvider } from "@/contexts/active-host-client-capabilities-context";
 import type { UIMessage } from "@ai-sdk/react";
 
 const { mockUseSaveView, mockDetectUIType, mockWidgetReplay } = vi.hoisted(
@@ -381,6 +383,97 @@ describe("PartSwitch", () => {
           serverName: "server-1",
         }),
       );
+    });
+
+    describe("host capability gate (Bug 1)", () => {
+      it("renders WidgetReplay when the host advertises the MCP UI extension", () => {
+        mockDetectUIType.mockReturnValue("mcp-apps");
+        const part = {
+          type: "tool-invocation",
+          toolName: "create_view",
+          toolCallId: "call-1",
+          state: "output-available",
+          input: { title: "Flow" },
+          output: { content: "saved" },
+        };
+        const caps = {
+          extensions: {
+            [MCP_UI_EXTENSION_ID]: {
+              mimeTypes: ["text/html;profile=mcp-app"],
+            },
+          },
+        };
+        render(
+          <ActiveHostClientCapabilitiesProvider value={caps}>
+            <PartSwitch
+              {...defaultProps}
+              part={part as any}
+              toolsMetadata={{
+                create_view: {
+                  ui: { resourceUri: "ui://widget/create-view.html" },
+                },
+              }}
+            />
+          </ActiveHostClientCapabilitiesProvider>,
+        );
+        expect(screen.getByTestId("widget-replay")).toBeInTheDocument();
+      });
+
+      it("falls through to ToolPart when the host strips the UI extension (Codex)", () => {
+        mockDetectUIType.mockReturnValue("mcp-apps");
+        const part = {
+          type: "tool-invocation",
+          toolName: "create_view",
+          toolCallId: "call-1",
+          state: "output-available",
+          input: { title: "Flow" },
+          output: { content: "saved" },
+        };
+        // Mirrors the Codex template's REPLACE (not spread) of
+        // clientCapabilities — see client-templates.ts:803-810.
+        const codexCaps = { elicitation: {} };
+        render(
+          <ActiveHostClientCapabilitiesProvider value={codexCaps}>
+            <PartSwitch
+              {...defaultProps}
+              part={part as any}
+              toolsMetadata={{
+                create_view: {
+                  ui: { resourceUri: "ui://widget/create-view.html" },
+                },
+              }}
+            />
+          </ActiveHostClientCapabilitiesProvider>,
+        );
+        expect(screen.queryByTestId("widget-replay")).not.toBeInTheDocument();
+        expect(screen.getByTestId("tool-part")).toBeInTheDocument();
+      });
+
+      it("renders WidgetReplay when no host is in scope (legacy surfaces)", () => {
+        // No provider — context default is `undefined`, which preserves
+        // historical tool-metadata-only behavior.
+        mockDetectUIType.mockReturnValue("mcp-apps");
+        const part = {
+          type: "tool-invocation",
+          toolName: "create_view",
+          toolCallId: "call-1",
+          state: "output-available",
+          input: { title: "Flow" },
+          output: { content: "saved" },
+        };
+        render(
+          <PartSwitch
+            {...defaultProps}
+            part={part as any}
+            toolsMetadata={{
+              create_view: {
+                ui: { resourceUri: "ui://widget/create-view.html" },
+              },
+            }}
+          />,
+        );
+        expect(screen.getByTestId("widget-replay")).toBeInTheDocument();
+      });
     });
 
     it("reuses WidgetReplay for offline widget overrides", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/PartSwitch.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/PartSwitch.test.tsx
@@ -10,7 +10,7 @@ const { mockUseSaveView, mockDetectUIType, mockWidgetReplay } = vi.hoisted(
     mockUseSaveView: vi.fn(),
     mockDetectUIType: vi.fn(),
     mockWidgetReplay: vi.fn(),
-  }),
+  })
 );
 
 // Mock all part components
@@ -186,12 +186,12 @@ describe("PartSwitch", () => {
       const part = { type: "text", text: "Hello" };
 
       render(
-        <PartSwitch {...defaultProps} part={part as any} role="assistant" />,
+        <PartSwitch {...defaultProps} part={part as any} role="assistant" />
       );
 
       expect(screen.getByTestId("text-part")).toHaveAttribute(
         "data-role",
-        "assistant",
+        "assistant"
       );
     });
   });
@@ -208,7 +208,7 @@ describe("PartSwitch", () => {
 
       expect(screen.getByTestId("reasoning-part")).toBeInTheDocument();
       expect(screen.getByTestId("reasoning-part")).toHaveTextContent(
-        "Thinking...",
+        "Thinking..."
       );
     });
 
@@ -219,7 +219,7 @@ describe("PartSwitch", () => {
 
       expect(screen.getByTestId("reasoning-part")).toHaveAttribute(
         "data-state",
-        "done",
+        "done"
       );
     });
 
@@ -235,12 +235,12 @@ describe("PartSwitch", () => {
           {...defaultProps}
           part={part as any}
           reasoningDisplayMode="collapsed"
-        />,
+        />
       );
 
       expect(screen.getByTestId("reasoning-part")).toHaveAttribute(
         "data-display-mode",
-        "collapsed",
+        "collapsed"
       );
     });
 
@@ -256,12 +256,12 @@ describe("PartSwitch", () => {
           {...defaultProps}
           part={part as any}
           reasoningDisplayMode="collapsible"
-        />,
+        />
       );
 
       expect(screen.getByTestId("reasoning-part")).toHaveAttribute(
         "data-display-mode",
-        "collapsible",
+        "collapsible"
       );
     });
   });
@@ -284,7 +284,7 @@ describe("PartSwitch", () => {
 
       expect(screen.getByTestId("source-url-part")).toBeInTheDocument();
       expect(screen.getByTestId("source-url-part")).toHaveTextContent(
-        "https://example.com",
+        "https://example.com"
       );
     });
 
@@ -295,7 +295,7 @@ describe("PartSwitch", () => {
 
       expect(screen.getByTestId("source-document-part")).toBeInTheDocument();
       expect(screen.getByTestId("source-document-part")).toHaveTextContent(
-        "Doc Title",
+        "Doc Title"
       );
     });
   });
@@ -305,7 +305,7 @@ describe("PartSwitch", () => {
       const part = { type: "step-start" };
 
       const { container } = render(
-        <PartSwitch {...defaultProps} part={part as any} />,
+        <PartSwitch {...defaultProps} part={part as any} />
       );
 
       expect(container.firstChild).toBeNull();
@@ -321,7 +321,7 @@ describe("PartSwitch", () => {
       expect(screen.getByTestId("json-part")).toBeInTheDocument();
       expect(screen.getByTestId("json-part")).toHaveAttribute(
         "data-label",
-        "Unknown part",
+        "Unknown part"
       );
     });
   });
@@ -353,7 +353,7 @@ describe("PartSwitch", () => {
           part={part as any}
           toolsMetadata={{}}
           toolServerMap={{}}
-        />,
+        />
       );
 
       expect(screen.getByTestId("tool-part")).toBeInTheDocument();
@@ -375,13 +375,13 @@ describe("PartSwitch", () => {
           part={part as any}
           toolsMetadata={{}}
           toolServerMap={{}}
-        />,
+        />
       );
 
       expect(mockUseSaveView).toHaveBeenCalledWith(
         expect.objectContaining({
           serverName: "server-1",
-        }),
+        })
       );
     });
 
@@ -414,7 +414,7 @@ describe("PartSwitch", () => {
                 },
               }}
             />
-          </ActiveHostClientCapabilitiesProvider>,
+          </ActiveHostClientCapabilitiesProvider>
         );
         expect(screen.getByTestId("widget-replay")).toBeInTheDocument();
       });
@@ -443,7 +443,7 @@ describe("PartSwitch", () => {
                 },
               }}
             />
-          </ActiveHostClientCapabilitiesProvider>,
+          </ActiveHostClientCapabilitiesProvider>
         );
         expect(screen.queryByTestId("widget-replay")).not.toBeInTheDocument();
         expect(screen.getByTestId("tool-part")).toBeInTheDocument();
@@ -470,7 +470,7 @@ describe("PartSwitch", () => {
                 ui: { resourceUri: "ui://widget/create-view.html" },
               },
             }}
-          />,
+          />
         );
         expect(screen.getByTestId("widget-replay")).toBeInTheDocument();
       });
@@ -507,13 +507,13 @@ describe("PartSwitch", () => {
               },
             },
           }}
-        />,
+        />
       );
 
       expect(screen.getByTestId("widget-replay")).toBeInTheDocument();
       expect(screen.getByTestId("widget-replay")).toHaveAttribute(
         "data-cached-url",
-        "https://storage.example.com/widget.html",
+        "https://storage.example.com/widget.html"
       );
       expect(mockWidgetReplay).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -521,7 +521,7 @@ describe("PartSwitch", () => {
           renderOverride: expect.objectContaining({
             cachedWidgetHtmlUrl: "https://storage.example.com/widget.html",
           }),
-        }),
+        })
       );
     });
   });

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/PartSwitch.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/PartSwitch.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MCP_UI_EXTENSION_ID } from "@mcpjam/sdk/browser";
 import { PartSwitch } from "../thread/part-switch";
-import { ActiveHostClientCapabilitiesProvider } from "@/contexts/active-host-client-capabilities-context";
+import { ActiveHostCapsResolverProvider } from "@/contexts/active-host-client-capabilities-context";
 import type { UIMessage } from "@ai-sdk/react";
 
 const { mockUseSaveView, mockDetectUIType, mockWidgetReplay } = vi.hoisted(
@@ -404,7 +404,7 @@ describe("PartSwitch", () => {
           },
         };
         render(
-          <ActiveHostClientCapabilitiesProvider value={caps}>
+          <ActiveHostCapsResolverProvider value={() => caps}>
             <PartSwitch
               {...defaultProps}
               part={part as any}
@@ -414,7 +414,7 @@ describe("PartSwitch", () => {
                 },
               }}
             />
-          </ActiveHostClientCapabilitiesProvider>
+          </ActiveHostCapsResolverProvider>
         );
         expect(screen.getByTestId("widget-replay")).toBeInTheDocument();
       });
@@ -433,7 +433,7 @@ describe("PartSwitch", () => {
         // clientCapabilities — see client-templates.ts:803-810.
         const codexCaps = { elicitation: {} };
         render(
-          <ActiveHostClientCapabilitiesProvider value={codexCaps}>
+          <ActiveHostCapsResolverProvider value={() => codexCaps}>
             <PartSwitch
               {...defaultProps}
               part={part as any}
@@ -443,7 +443,7 @@ describe("PartSwitch", () => {
                 },
               }}
             />
-          </ActiveHostClientCapabilitiesProvider>
+          </ActiveHostCapsResolverProvider>
         );
         expect(screen.queryByTestId("widget-replay")).not.toBeInTheDocument();
         expect(screen.getByTestId("tool-part")).toBeInTheDocument();

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/__tests__/widget-replay.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/__tests__/widget-replay.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MCP_UI_EXTENSION_ID } from "@mcpjam/sdk/browser";
 import { WidgetReplay } from "../widget-replay";
-import { ActiveHostClientCapabilitiesProvider } from "@/contexts/active-host-client-capabilities-context";
+import { ActiveHostCapsResolverProvider } from "@/contexts/active-host-client-capabilities-context";
 
 const mockDetectUIType = vi.fn();
 
@@ -84,9 +84,9 @@ describe("WidgetReplay", () => {
         },
       };
       render(
-        <ActiveHostClientCapabilitiesProvider value={caps}>
+        <ActiveHostCapsResolverProvider value={() => caps}>
           <WidgetReplay {...baseProps} />
-        </ActiveHostClientCapabilitiesProvider>
+        </ActiveHostCapsResolverProvider>
       );
       expect(screen.getByTestId("mcp-apps-renderer")).toBeInTheDocument();
     });
@@ -95,9 +95,9 @@ describe("WidgetReplay", () => {
       mockDetectUIType.mockReturnValue("mcp-apps");
       const codexCaps = { elicitation: {} };
       const { container } = render(
-        <ActiveHostClientCapabilitiesProvider value={codexCaps}>
+        <ActiveHostCapsResolverProvider value={() => codexCaps}>
           <WidgetReplay {...baseProps} />
-        </ActiveHostClientCapabilitiesProvider>
+        </ActiveHostCapsResolverProvider>
       );
       expect(container.firstChild).toBeNull();
     });

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/__tests__/widget-replay.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/__tests__/widget-replay.test.tsx
@@ -86,7 +86,7 @@ describe("WidgetReplay", () => {
       render(
         <ActiveHostClientCapabilitiesProvider value={caps}>
           <WidgetReplay {...baseProps} />
-        </ActiveHostClientCapabilitiesProvider>,
+        </ActiveHostClientCapabilitiesProvider>
       );
       expect(screen.getByTestId("mcp-apps-renderer")).toBeInTheDocument();
     });
@@ -97,7 +97,7 @@ describe("WidgetReplay", () => {
       const { container } = render(
         <ActiveHostClientCapabilitiesProvider value={codexCaps}>
           <WidgetReplay {...baseProps} />
-        </ActiveHostClientCapabilitiesProvider>,
+        </ActiveHostClientCapabilitiesProvider>
       );
       expect(container.firstChild).toBeNull();
     });

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/__tests__/widget-replay.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/__tests__/widget-replay.test.tsx
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { MCP_UI_EXTENSION_ID } from "@mcpjam/sdk/browser";
 import { WidgetReplay } from "../widget-replay";
+import { ActiveHostClientCapabilitiesProvider } from "@/contexts/active-host-client-capabilities-context";
 
 const mockDetectUIType = vi.fn();
 
@@ -69,5 +71,35 @@ describe("WidgetReplay", () => {
     mockDetectUIType.mockReturnValue(null);
     const { container } = render(<WidgetReplay {...baseProps} />);
     expect(container.firstChild).toBeNull();
+  });
+
+  describe("host capability gate (Bug 1)", () => {
+    it("renders when the host advertises the MCP UI extension", () => {
+      mockDetectUIType.mockReturnValue("mcp-apps");
+      const caps = {
+        extensions: {
+          [MCP_UI_EXTENSION_ID]: {
+            mimeTypes: ["text/html;profile=mcp-app"],
+          },
+        },
+      };
+      render(
+        <ActiveHostClientCapabilitiesProvider value={caps}>
+          <WidgetReplay {...baseProps} />
+        </ActiveHostClientCapabilitiesProvider>,
+      );
+      expect(screen.getByTestId("mcp-apps-renderer")).toBeInTheDocument();
+    });
+
+    it("renders nothing when the host strips the UI extension (Codex)", () => {
+      mockDetectUIType.mockReturnValue("mcp-apps");
+      const codexCaps = { elicitation: {} };
+      const { container } = render(
+        <ActiveHostClientCapabilitiesProvider value={codexCaps}>
+          <WidgetReplay {...baseProps} />
+        </ActiveHostClientCapabilitiesProvider>,
+      );
+      expect(container.firstChild).toBeNull();
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
@@ -38,7 +38,7 @@ import {
   isToolPart,
 } from "./thread-helpers";
 import { useSharedAppState } from "@/state/app-state-context";
-import { useActiveHostClientCapabilities } from "@/contexts/active-host-client-capabilities-context";
+import { useActiveHostCapsResolver } from "@/contexts/active-host-client-capabilities-context";
 import { hostSupportsWidgetRendering } from "@/lib/host-capabilities";
 import { useWidgetDebugStore } from "@/stores/widget-debug-store";
 import { ToolRenderOverride } from "@/components/chat-v2/thread/tool-render-overrides";
@@ -113,7 +113,7 @@ export function PartSwitch({
   const { isAuthenticated } = useConvexAuth();
   const posthog = usePostHog();
   const appState = useSharedAppState();
-  const hostClientCapabilities = useActiveHostClientCapabilities();
+  const resolveHostCaps = useActiveHostCapsResolver();
   const savingEnabled = isAuthenticated && !minimalMode && interactive;
 
   // Get the Convex project ID (sharedProjectId) from the active project
@@ -295,12 +295,17 @@ export function PartSwitch({
       effectiveToolMeta as Record<string, unknown> | undefined
     );
 
-    // Gate widget render on the active host's advertised capabilities, not
-    // just the tool's metadata. Hosts that don't advertise the MCP UI
-    // extension (Codex — elicitation-only client) fall through to the plain
+    // Gate widget render on the active host's advertised capabilities for
+    // this tool's server. Hosts that don't advertise the MCP UI extension
+    // (Codex — elicitation-only client) fall through to the plain
     // ToolPart result row, even when the tool itself declares
     // `_meta.ui.resourceUri` / `openai/outputTemplate`. This mirrors what
     // real CLI clients do: tool runs, JSON result is shown, no iframe.
+    //
+    // `serverId` (computed above for save-view routing) is passed through
+    // so the resolver picks up any per-server `clientCapabilities`
+    // override — keeping the renderer in lockstep with `initialize`,
+    // which uses the same `resolveEffectiveClientCapabilities` function.
     //
     // Note on Apps SDK hosts (ChatGPT, Copilot): their templates KEEP the
     // SDK-default MCP UI extension in `clientCapabilities`, so they pass
@@ -308,7 +313,7 @@ export function PartSwitch({
     // HostConfigInputV2 will be OR-ed here to cover Apps-SDK hosts that
     // choose to strip the MCP UI extension.
     const shouldRenderWidget =
-      hostSupportsWidgetRendering(hostClientCapabilities) &&
+      hostSupportsWidgetRendering(resolveHostCaps(serverId ?? undefined)) &&
       (uiType === UIType.OPENAI_SDK ||
         uiType === UIType.MCP_APPS ||
         uiType === UIType.OPENAI_SDK_AND_MCP_APPS);

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
@@ -85,7 +85,7 @@ export function PartSwitch({
     context: {
       content?: ContentBlock[];
       structuredContent?: Record<string, unknown>;
-    },
+    }
   ) => void;
   pipWidgetId: string | null;
   fullscreenWidgetId: string | null;
@@ -140,7 +140,7 @@ export function PartSwitch({
   });
   const existingViewNames = useMemo(
     () => new Set(sortedViews.map((v) => v.name)),
-    [sortedViews],
+    [sortedViews]
   );
 
   // Instant save hook
@@ -157,7 +157,7 @@ export function PartSwitch({
       ? ((part as any).toolCallId as string | undefined)
       : undefined;
   const widgetDebugInfo = useWidgetDebugStore((s) =>
-    toolCallId ? s.widgets.get(toolCallId) : undefined,
+    toolCallId ? s.widgets.get(toolCallId) : undefined
   );
 
   // Create save view handler for a specific tool (instant save)
@@ -171,7 +171,7 @@ export function PartSwitch({
       uiType: UIType,
       resourceUri?: string,
       outputTemplate?: string,
-      toolMetadata?: Record<string, unknown>,
+      toolMetadata?: Record<string, unknown>
     ) => {
       return async () => {
         posthog.capture("save_as_view_clicked", {
@@ -205,7 +205,7 @@ export function PartSwitch({
         await saveViewInstant(data);
       };
     },
-    [toolCallId, widgetDebugInfo, saveViewInstant, posthog],
+    [toolCallId, widgetDebugInfo, saveViewInstant, posthog]
   );
 
   if (isToolPart(part) || isDynamicTool(part)) {
@@ -246,7 +246,7 @@ export function PartSwitch({
       Object.prototype.hasOwnProperty.call(renderOverride, "toolOutput");
     const resolvedToolOutput = hasRenderOverrideToolOutput
       ? renderOverride.toolOutput
-      : (toolInfo.output ?? toolInfo.rawOutput);
+      : toolInfo.output ?? toolInfo.rawOutput;
 
     // Determine why save might be disabled
     const hasOutput =
@@ -292,7 +292,7 @@ export function PartSwitch({
       uiType || UIType.MCP_APPS,
       uiResourceUri ?? undefined,
       outputTemplate,
-      effectiveToolMeta as Record<string, unknown> | undefined,
+      effectiveToolMeta as Record<string, unknown> | undefined
     );
 
     // Gate widget render on the active host's advertised capabilities, not

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
@@ -38,6 +38,8 @@ import {
   isToolPart,
 } from "./thread-helpers";
 import { useSharedAppState } from "@/state/app-state-context";
+import { useActiveHostClientCapabilities } from "@/contexts/active-host-client-capabilities-context";
+import { hostSupportsWidgetRendering } from "@/lib/host-capabilities";
 import { useWidgetDebugStore } from "@/stores/widget-debug-store";
 import { ToolRenderOverride } from "@/components/chat-v2/thread/tool-render-overrides";
 import { WidgetReplay } from "./widget-replay";
@@ -111,6 +113,7 @@ export function PartSwitch({
   const { isAuthenticated } = useConvexAuth();
   const posthog = usePostHog();
   const appState = useSharedAppState();
+  const hostClientCapabilities = useActiveHostClientCapabilities();
   const savingEnabled = isAuthenticated && !minimalMode && interactive;
 
   // Get the Convex project ID (sharedProjectId) from the active project
@@ -292,10 +295,23 @@ export function PartSwitch({
       effectiveToolMeta as Record<string, unknown> | undefined,
     );
 
+    // Gate widget render on the active host's advertised capabilities, not
+    // just the tool's metadata. Hosts that don't advertise the MCP UI
+    // extension (Codex — elicitation-only client) fall through to the plain
+    // ToolPart result row, even when the tool itself declares
+    // `_meta.ui.resourceUri` / `openai/outputTemplate`. This mirrors what
+    // real CLI clients do: tool runs, JSON result is shown, no iframe.
+    //
+    // Note on Apps SDK hosts (ChatGPT, Copilot): their templates KEEP the
+    // SDK-default MCP UI extension in `clientCapabilities`, so they pass
+    // this gate today. A future explicit "window.openai" flag on
+    // HostConfigInputV2 will be OR-ed here to cover Apps-SDK hosts that
+    // choose to strip the MCP UI extension.
     const shouldRenderWidget =
-      uiType === UIType.OPENAI_SDK ||
-      uiType === UIType.MCP_APPS ||
-      uiType === UIType.OPENAI_SDK_AND_MCP_APPS;
+      hostSupportsWidgetRendering(hostClientCapabilities) &&
+      (uiType === UIType.OPENAI_SDK ||
+        uiType === UIType.MCP_APPS ||
+        uiType === UIType.OPENAI_SDK_AND_MCP_APPS);
 
     if (shouldRenderWidget) {
       return (

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/widget-replay.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/widget-replay.tsx
@@ -2,7 +2,11 @@ import type { ContentBlock } from "@modelcontextprotocol/client";
 import { MCPAppsRenderer } from "./mcp-apps/mcp-apps-renderer";
 import type { ToolState } from "./mcp-apps/useToolInputStreaming";
 import type { ToolRenderOverride } from "./tool-render-overrides";
-import { detectUIType, getUIResourceUri, UIType } from "@/lib/mcp-ui/mcp-apps-utils";
+import {
+  detectUIType,
+  getUIResourceUri,
+  UIType,
+} from "@/lib/mcp-ui/mcp-apps-utils";
 import { getToolServerId, type ToolServerMap } from "@/lib/apis/mcp-tools-api";
 import { useActiveHostClientCapabilities } from "@/contexts/active-host-client-capabilities-context";
 import { hostSupportsWidgetRendering } from "@/lib/host-capabilities";
@@ -27,7 +31,7 @@ export interface WidgetReplayProps {
   onSendFollowUp?: (text: string) => void;
   onCallTool?: (
     toolName: string,
-    params: Record<string, unknown>,
+    params: Record<string, unknown>
   ) => Promise<unknown>;
   onWidgetStateChange?: (toolCallId: string, state: unknown) => void;
   onModelContextUpdate?: (
@@ -35,7 +39,7 @@ export interface WidgetReplayProps {
     context: {
       content?: ContentBlock[];
       structuredContent?: Record<string, unknown>;
-    },
+    }
   ) => void;
   pipWidgetId?: string | null;
   fullscreenWidgetId?: string | null;
@@ -145,9 +149,7 @@ export function WidgetReplay({
   // (where `toolOutput` is the unwrapped value and lacks `_meta`)
   // resolves correctly via readToolResultMeta's two-level check.
   const toolResponseMetadata = (readToolResultMeta(rawOutput) ??
-    readToolResultMeta(toolOutput)) as
-    | Record<string, unknown>
-    | undefined;
+    readToolResultMeta(toolOutput)) as Record<string, unknown> | undefined;
 
   return (
     <MCPAppsRenderer

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/widget-replay.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/widget-replay.tsx
@@ -4,6 +4,8 @@ import type { ToolState } from "./mcp-apps/useToolInputStreaming";
 import type { ToolRenderOverride } from "./tool-render-overrides";
 import { detectUIType, getUIResourceUri, UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import { getToolServerId, type ToolServerMap } from "@/lib/apis/mcp-tools-api";
+import { useActiveHostClientCapabilities } from "@/contexts/active-host-client-capabilities-context";
+import { hostSupportsWidgetRendering } from "@/lib/host-capabilities";
 import {
   readToolResultMeta,
   readToolResultServerId,
@@ -83,6 +85,7 @@ export function WidgetReplay({
   minimalMode = false,
 }: WidgetReplayProps) {
   void _ignored;
+  const hostClientCapabilities = useActiveHostClientCapabilities();
   const effectiveToolMeta =
     renderOverride?.toolMetadata ??
     toolMetadata ??
@@ -102,10 +105,17 @@ export function WidgetReplay({
   // window.openai compat shim is always injected, so widgets calling
   // window.openai.* and widgets using ui/* JSON-RPC both work without a
   // protocol switch. See plan: phase 3a.
+  //
+  // Defense-in-depth host gate: the primary check lives in PartSwitch
+  // (which decides between ToolPart and WidgetReplay). Re-checking here
+  // means a host that strips the MCP UI extension never renders a widget
+  // even on code paths that mount WidgetReplay directly (transcript
+  // thread, trace viewer adapters, future callers).
   const hasUi =
-    uiType === UIType.MCP_APPS ||
-    uiType === UIType.OPENAI_SDK ||
-    uiType === UIType.OPENAI_SDK_AND_MCP_APPS;
+    hostSupportsWidgetRendering(hostClientCapabilities) &&
+    (uiType === UIType.MCP_APPS ||
+      uiType === UIType.OPENAI_SDK ||
+      uiType === UIType.OPENAI_SDK_AND_MCP_APPS);
   if (!hasUi) return null;
 
   if (

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/widget-replay.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/widget-replay.tsx
@@ -8,7 +8,7 @@ import {
   UIType,
 } from "@/lib/mcp-ui/mcp-apps-utils";
 import { getToolServerId, type ToolServerMap } from "@/lib/apis/mcp-tools-api";
-import { useActiveHostClientCapabilities } from "@/contexts/active-host-client-capabilities-context";
+import { useActiveHostCapsResolver } from "@/contexts/active-host-client-capabilities-context";
 import { hostSupportsWidgetRendering } from "@/lib/host-capabilities";
 import {
   readToolResultMeta,
@@ -89,7 +89,7 @@ export function WidgetReplay({
   minimalMode = false,
 }: WidgetReplayProps) {
   void _ignored;
-  const hostClientCapabilities = useActiveHostClientCapabilities();
+  const resolveHostCaps = useActiveHostCapsResolver();
   const effectiveToolMeta =
     renderOverride?.toolMetadata ??
     toolMetadata ??
@@ -114,9 +114,11 @@ export function WidgetReplay({
   // (which decides between ToolPart and WidgetReplay). Re-checking here
   // means a host that strips the MCP UI extension never renders a widget
   // even on code paths that mount WidgetReplay directly (transcript
-  // thread, trace viewer adapters, future callers).
+  // thread, trace viewer adapters, future callers). `serverId` (computed
+  // above) is passed through so any per-server `clientCapabilities`
+  // override is honored, matching `initialize`.
   const hasUi =
-    hostSupportsWidgetRendering(hostClientCapabilities) &&
+    hostSupportsWidgetRendering(resolveHostCaps(serverId ?? undefined)) &&
     (uiType === UIType.MCP_APPS ||
       uiType === UIType.OPENAI_SDK ||
       uiType === UIType.OPENAI_SDK_AND_MCP_APPS);

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
@@ -39,14 +39,14 @@ import {
   type TraceRawRequestPayloadHistory,
 } from "./trace-raw-view";
 import { ActiveHostCapsResolverScope } from "@/contexts/active-host-client-capabilities-context";
-import { useChatboxHostStyle } from "@/contexts/chatbox-client-style-context";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
 
-// Default host-style template id when neither prop nor ambient context
-// supplies one. Mirrors `DEFAULT_HOST_TEMPLATE_ID` in
-// `lib/client-templates.ts` but inlined to avoid pulling that module
-// (and its build-time `__APP_VERSION__` reference) into surfaces that
-// don't otherwise need it — keeps trace-viewer test environments lean.
+// Default host-style template id used when the caller passes
+// `activeHost` but no explicit `hostStyle`. Mirrors
+// `DEFAULT_HOST_TEMPLATE_ID` in `lib/client-templates.ts` but inlined to
+// avoid pulling that module (and its build-time `__APP_VERSION__`
+// reference) into surfaces that don't otherwise need it — keeps
+// trace-viewer test environments lean.
 const DEFAULT_TRACE_HOST_STYLE_FALLBACK = "mcpjam";
 
 const TraceTimelineLazy = lazy(() =>
@@ -132,17 +132,23 @@ interface TraceViewerProps {
   /**
    * Active host (resolved by `useAppState`) at the time the trace is
    * being viewed — NOT the host that was active when the trace was
-   * recorded. The render gate uses "current active host" semantics so
-   * trace replays match what the user is modeling right now (switch to
-   * Codex → widgets hide in replays). Optional: callers that don't
-   * thread it get the legacy "allow widgets" behavior via the scope's
-   * template-seed fallback.
+   * recorded. When provided, TraceViewer installs an inner
+   * `ActiveHostCapsResolverScope` so the render gate matches what the
+   * user is modeling right now (switch to Codex → widgets hide in
+   * replays). When `undefined`, TraceViewer does NOT install an inner
+   * scope — any outer scope from a parent chat surface (e.g.
+   * `ClientStyledChatTabV2`, `PlaygroundTab`) flows through with the
+   * user's saved capability edits intact. Pass `null` explicitly to
+   * install a scope with no host (template-seed fallback).
    */
   activeHost?: HostConfigDtoV2 | null;
   /**
-   * Host style fallback used by the resolver when `activeHost` is
-   * absent. Read from the surrounding `ChatboxHostStyleProvider` when
-   * not provided.
+   * Host style fallback used when an inner scope is installed but no
+   * `activeHost` is provided. Like `activeHost`, passing `undefined`
+   * (the default) means "don't install an inner scope" — DO NOT read
+   * the surrounding `ChatboxHostStyleProvider` here, because that
+   * ambient style would synthesize template-seed caps that shadow
+   * outer scope's user-edited caps.
    */
   hostStyle?: string;
 }
@@ -223,20 +229,30 @@ export function TraceViewer({
   onFullscreenChange,
   rawRequestPayloadHistory = null,
   rawGrowWithContent = false,
-  activeHost = null,
+  activeHost,
   hostStyle,
 }: TraceViewerProps) {
   // Only live chat shells should opt into the interactive widget path.
   const threadInteractive = interactive || sendFollowUpMessage !== NOOP;
 
-  // Host-style fallback: prefer the prop, else read from the surrounding
-  // ChatboxHostStyleProvider (most eval surfaces wrap one), else the
-  // default template id. Feeds the ActiveHostCapsResolverScope below so
-  // trace replays gate widgets on the *current* active host even when
-  // the caller doesn't thread `activeHost` explicitly.
-  const ambientHostStyle = useChatboxHostStyle();
-  const resolverHostStyle =
-    hostStyle ?? ambientHostStyle ?? DEFAULT_TRACE_HOST_STYLE_FALLBACK;
+  // Decide whether to install an inner ActiveHostCapsResolverScope around
+  // the trace's `<Thread>`. We only install when the caller passed
+  // explicit `activeHost` or `hostStyle` props. When neither is given,
+  // we pass through to any outer scope (e.g. the chat surface's
+  // ClientStyledChatTabV2 / PlaygroundTab wrap) — installing a scope
+  // here unconditionally would shadow that outer scope with
+  // template-seed caps and silently drop the user's saved
+  // `clientCapabilities` edits. See TL feedback on PR #2169.
+  //
+  // `hostStyle` falls back to `DEFAULT_TRACE_HOST_STYLE_FALLBACK` only
+  // when the inner scope IS being installed (caller passed activeHost
+  // but no explicit hostStyle); we don't reach into the ambient
+  // ChatboxHostStyleProvider here, because that ambient style may not
+  // line up with the explicit `activeHost`.
+  const shouldInstallTraceScope =
+    activeHost !== undefined || hostStyle !== undefined;
+  const traceScopeHostStyle =
+    hostStyle ?? DEFAULT_TRACE_HOST_STYLE_FALLBACK;
 
   const [viewMode, setViewMode] = useState<
     "timeline" | "chat" | "raw" | "tools"
@@ -634,61 +650,73 @@ export function TraceViewer({
               >
                 <div className="relative flex-1 min-h-0">
                   <StickToBottom.Content className="flex flex-col min-h-0">
-                    {/*
-                      Gate trace-replay widget rendering on the CURRENT
-                      active host (not the host recorded with the trace).
-                      Switching to Codex while viewing a recorded run
-                      hides the widget — replay reflects "what would this
-                      look like under my current host." Resolver also
-                      honors per-server overrides via appState.servers.
-                    */}
-                    <ActiveHostCapsResolverScope
-                      activeHost={activeHost}
-                      hostStyle={resolverHostStyle}
-                    >
-                      <Thread
-                        messages={adaptedTrace.messages}
-                      sendFollowUpMessage={sendFollowUpMessage}
-                      model={resolvedModel}
-                      isLoading={isLoading}
-                      toolsMetadata={toolsMetadata}
-                      toolServerMap={toolServerMap}
-                      onWidgetStateChange={onWidgetStateChange}
-                      onModelContextUpdate={onModelContextUpdate}
-                      displayMode={displayMode}
-                      onDisplayModeChange={onDisplayModeChange}
-                      enableFullscreenChatOverlay={enableFullscreenChatOverlay}
-                      fullscreenChatPlaceholder={fullscreenChatPlaceholder}
-                      fullscreenChatDisabled={fullscreenChatDisabled}
-                      fullscreenChatSendBlocked={fullscreenChatSendBlocked}
-                      onFullscreenChatStop={onFullscreenChatStop}
-                      onFullscreenChange={onFullscreenChange}
-                      selectedProtocolOverrideIfBothExists={
-                        selectedProtocolOverrideIfBothExists
-                      }
-                      onToolApprovalResponse={onToolApprovalResponse}
-                      toolRenderOverrides={adaptedTrace.toolRenderOverrides}
-                      showSaveViewButton={false}
-                      minimalMode={true}
-                      interactive={threadInteractive}
-                      reasoningDisplayMode="collapsed"
-                      focusMessageId={transcriptNavigation.focusMessageId}
-                      highlightedMessageIds={
-                        transcriptNavigation.highlightedMessageIds
-                      }
-                      navigationKey={transcriptNavigation.navigationKey}
-                      contentClassName="min-w-0 mx-auto w-full max-w-4xl space-y-8 px-4 pt-2"
-                      getMessageWrapperProps={({ message }) => {
-                        const sourceRange =
-                          adaptedTrace.uiMessageSourceRanges[message.id];
-                        return {
-                          "data-source-range": sourceRange
-                            ? `${sourceRange.startIndex}-${sourceRange.endIndex}`
-                            : undefined,
-                        };
-                      }}
-                    />
-                    </ActiveHostCapsResolverScope>
+                    {(() => {
+                      // Trace `<Thread>` mount. Wrapped in
+                      // `ActiveHostCapsResolverScope` ONLY when the
+                      // caller passed explicit host inputs
+                      // (`activeHost` or `hostStyle`). Otherwise we
+                      // render Thread directly so any outer scope from
+                      // the chat surface (ClientStyledChatTabV2 /
+                      // PlaygroundTab) flows through with the user's
+                      // saved capability edits intact. Installing an
+                      // inner scope unconditionally would shadow the
+                      // outer one with template-seed caps.
+                      const threadEl = (
+                        <Thread
+                          messages={adaptedTrace.messages}
+                          sendFollowUpMessage={sendFollowUpMessage}
+                          model={resolvedModel}
+                          isLoading={isLoading}
+                          toolsMetadata={toolsMetadata}
+                          toolServerMap={toolServerMap}
+                          onWidgetStateChange={onWidgetStateChange}
+                          onModelContextUpdate={onModelContextUpdate}
+                          displayMode={displayMode}
+                          onDisplayModeChange={onDisplayModeChange}
+                          enableFullscreenChatOverlay={
+                            enableFullscreenChatOverlay
+                          }
+                          fullscreenChatPlaceholder={fullscreenChatPlaceholder}
+                          fullscreenChatDisabled={fullscreenChatDisabled}
+                          fullscreenChatSendBlocked={fullscreenChatSendBlocked}
+                          onFullscreenChatStop={onFullscreenChatStop}
+                          onFullscreenChange={onFullscreenChange}
+                          selectedProtocolOverrideIfBothExists={
+                            selectedProtocolOverrideIfBothExists
+                          }
+                          onToolApprovalResponse={onToolApprovalResponse}
+                          toolRenderOverrides={adaptedTrace.toolRenderOverrides}
+                          showSaveViewButton={false}
+                          minimalMode={true}
+                          interactive={threadInteractive}
+                          reasoningDisplayMode="collapsed"
+                          focusMessageId={transcriptNavigation.focusMessageId}
+                          highlightedMessageIds={
+                            transcriptNavigation.highlightedMessageIds
+                          }
+                          navigationKey={transcriptNavigation.navigationKey}
+                          contentClassName="min-w-0 mx-auto w-full max-w-4xl space-y-8 px-4 pt-2"
+                          getMessageWrapperProps={({ message }) => {
+                            const sourceRange =
+                              adaptedTrace.uiMessageSourceRanges[message.id];
+                            return {
+                              "data-source-range": sourceRange
+                                ? `${sourceRange.startIndex}-${sourceRange.endIndex}`
+                                : undefined,
+                            };
+                          }}
+                        />
+                      );
+                      if (!shouldInstallTraceScope) return threadEl;
+                      return (
+                        <ActiveHostCapsResolverScope
+                          activeHost={activeHost ?? null}
+                          hostStyle={traceScopeHostStyle}
+                        >
+                          {threadEl}
+                        </ActiveHostCapsResolverScope>
+                      );
+                    })()}
                   </StickToBottom.Content>
                   <ScrollToBottomButton />
                 </div>

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
@@ -38,6 +38,16 @@ import {
   TraceRawView,
   type TraceRawRequestPayloadHistory,
 } from "./trace-raw-view";
+import { ActiveHostCapsResolverScope } from "@/contexts/active-host-client-capabilities-context";
+import { useChatboxHostStyle } from "@/contexts/chatbox-client-style-context";
+import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
+
+// Default host-style template id when neither prop nor ambient context
+// supplies one. Mirrors `DEFAULT_HOST_TEMPLATE_ID` in
+// `lib/client-templates.ts` but inlined to avoid pulling that module
+// (and its build-time `__APP_VERSION__` reference) into surfaces that
+// don't otherwise need it — keeps trace-viewer test environments lean.
+const DEFAULT_TRACE_HOST_STYLE_FALLBACK = "mcpjam";
 
 const TraceTimelineLazy = lazy(() =>
   import("./trace-timeline").then((m) => ({ default: m.TraceTimeline })),
@@ -119,6 +129,22 @@ interface TraceViewerProps {
    * `StickToBottom` (or similar) owns vertical scroll as the payload grows.
    */
   rawGrowWithContent?: boolean;
+  /**
+   * Active host (resolved by `useAppState`) at the time the trace is
+   * being viewed — NOT the host that was active when the trace was
+   * recorded. The render gate uses "current active host" semantics so
+   * trace replays match what the user is modeling right now (switch to
+   * Codex → widgets hide in replays). Optional: callers that don't
+   * thread it get the legacy "allow widgets" behavior via the scope's
+   * template-seed fallback.
+   */
+  activeHost?: HostConfigDtoV2 | null;
+  /**
+   * Host style fallback used by the resolver when `activeHost` is
+   * absent. Read from the surrounding `ChatboxHostStyleProvider` when
+   * not provided.
+   */
+  hostStyle?: string;
 }
 
 function getTraceMessages(
@@ -197,9 +223,20 @@ export function TraceViewer({
   onFullscreenChange,
   rawRequestPayloadHistory = null,
   rawGrowWithContent = false,
+  activeHost = null,
+  hostStyle,
 }: TraceViewerProps) {
   // Only live chat shells should opt into the interactive widget path.
   const threadInteractive = interactive || sendFollowUpMessage !== NOOP;
+
+  // Host-style fallback: prefer the prop, else read from the surrounding
+  // ChatboxHostStyleProvider (most eval surfaces wrap one), else the
+  // default template id. Feeds the ActiveHostCapsResolverScope below so
+  // trace replays gate widgets on the *current* active host even when
+  // the caller doesn't thread `activeHost` explicitly.
+  const ambientHostStyle = useChatboxHostStyle();
+  const resolverHostStyle =
+    hostStyle ?? ambientHostStyle ?? DEFAULT_TRACE_HOST_STYLE_FALLBACK;
 
   const [viewMode, setViewMode] = useState<
     "timeline" | "chat" | "raw" | "tools"
@@ -597,8 +634,20 @@ export function TraceViewer({
               >
                 <div className="relative flex-1 min-h-0">
                   <StickToBottom.Content className="flex flex-col min-h-0">
-                    <Thread
-                      messages={adaptedTrace.messages}
+                    {/*
+                      Gate trace-replay widget rendering on the CURRENT
+                      active host (not the host recorded with the trace).
+                      Switching to Codex while viewing a recorded run
+                      hides the widget — replay reflects "what would this
+                      look like under my current host." Resolver also
+                      honors per-server overrides via appState.servers.
+                    */}
+                    <ActiveHostCapsResolverScope
+                      activeHost={activeHost}
+                      hostStyle={resolverHostStyle}
+                    >
+                      <Thread
+                        messages={adaptedTrace.messages}
                       sendFollowUpMessage={sendFollowUpMessage}
                       model={resolvedModel}
                       isLoading={isLoading}
@@ -639,6 +688,7 @@ export function TraceViewer({
                         };
                       }}
                     />
+                    </ActiveHostCapsResolverScope>
                   </StickToBottom.Content>
                   <ScrollToBottomButton />
                 </div>

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -491,14 +491,11 @@ export function ChatboxChatPage({
           // `accessVersion` grant plus the bootstrap payload, in one round
           // trip. Every chatbox-aware backend call then keys on the resolved
           // identity — the URL token is not threaded onto the read path.
-          const redeemResponse = await authFetch(
-            "/api/web/chatboxes/redeem",
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ chatboxToken: tokenFromPath }),
-            },
-          );
+          const redeemResponse = await authFetch("/api/web/chatboxes/redeem", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ chatboxToken: tokenFromPath }),
+          });
 
           if (!redeemResponse.ok) {
             throw await readRouteError(redeemResponse);
@@ -525,14 +522,16 @@ export function ChatboxChatPage({
               typeof redeemed.accessVersion === "number"
                 ? redeemed.accessVersion
                 : undefined,
-            payload: redeemed.bootstrap as ChatboxSession["payload"] | undefined,
+            payload: redeemed.bootstrap as
+              | ChatboxSession["payload"]
+              | undefined,
             surface: readChatboxSurfaceFromUrl(window.location.search),
             shareToken: tokenFromPath ?? undefined,
           });
           if (!nextSession) {
             throw createChatboxRouteError(
               502,
-              "Chatbox redeem returned an incomplete bootstrap payload.",
+              "Chatbox redeem returned an incomplete bootstrap payload."
             );
           }
 
@@ -682,7 +681,7 @@ export function ChatboxChatPage({
       } catch (error) {
         console.warn(
           "[ChatboxChatPage] Silent chatbox re-redeem failed",
-          error,
+          error
         );
       } finally {
         // Only clear the latch if we're still the active in-flight refresh.
@@ -752,8 +751,7 @@ export function ChatboxChatPage({
     };
   }, [session]);
 
-  const shareableToken =
-    tokenFromPath ?? session?.shareToken?.trim() ?? null;
+  const shareableToken = tokenFromPath ?? session?.shareToken?.trim() ?? null;
 
   const handleCopyLink = useCallback(async () => {
     // Token preference: live URL → persisted `session.shareToken`. After
@@ -916,67 +914,67 @@ export function ChatboxChatPage({
   return (
     <ChatboxHostStyleProvider value={hostStyle}>
       <ChatboxChatUiOverrideProvider value={chatUiOverride}>
-      <ChatboxHostCapabilitiesOverrideProvider
-        value={session?.payload.hostCapabilitiesOverride}
-      >
-      <ActiveMcpProfileProvider value={session?.payload.mcpProfile}>
-      {/*
+        <ChatboxHostCapabilitiesOverrideProvider
+          value={session?.payload.hostCapabilitiesOverride}
+        >
+          <ActiveMcpProfileProvider value={session?.payload.mcpProfile}>
+            {/*
         Hosted bootstrap payload doesn't (yet) carry clientCapabilities —
         we pass `activeHost={null}` and let the scope fall back to the
         template seed for `hostStyle`. Correct for unmodified host styles;
         if a chatbox owner customizes capabilities, that will require a
         bootstrap-payload extension (out of scope here).
       */}
-      <ActiveHostClientCapabilitiesScope
-        activeHost={null}
-        hostStyle={hostStyle}
-      >
-      <ChatboxSurfaceProvider value={true}>
-      <div
-        className="chatbox-host-shell flex h-svh min-h-0 flex-col overflow-hidden"
-        data-host-style={hostStyle}
-        style={shellStyle}
-      >
-        <header className="border-b border-border/50 bg-background/95 backdrop-blur">
-          <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-2.5">
-            <h1 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
-              {session?.payload.name || "\u00A0"}
-            </h1>
-            <button
-              onClick={handleOpenMcpJam}
-              className="cursor-pointer flex-shrink-0 border-none bg-transparent p-0"
+            <ActiveHostClientCapabilitiesScope
+              activeHost={null}
+              hostStyle={hostStyle}
             >
-              <img
-                src={
-                  themeMode === "dark"
-                    ? "/mcp_jam_dark.png"
-                    : "/mcp_jam_light.png"
-                }
-                alt="MCPJam"
-                className="h-4 w-auto object-contain"
-              />
-            </button>
-            <div className="flex flex-1 items-center justify-end gap-1.5">
-              {session && shareableToken ? (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-muted-foreground"
-                  onClick={handleCopyLink}
+              <ChatboxSurfaceProvider value={true}>
+                <div
+                  className="chatbox-host-shell flex h-svh min-h-0 flex-col overflow-hidden"
+                  data-host-style={hostStyle}
+                  style={shellStyle}
                 >
-                  Copy link
-                </Button>
-              ) : null}
-            </div>
-          </div>
-        </header>
+                  <header className="border-b border-border/50 bg-background/95 backdrop-blur">
+                    <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-2.5">
+                      <h1 className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
+                        {session?.payload.name || "\u00A0"}
+                      </h1>
+                      <button
+                        onClick={handleOpenMcpJam}
+                        className="cursor-pointer flex-shrink-0 border-none bg-transparent p-0"
+                      >
+                        <img
+                          src={
+                            themeMode === "dark"
+                              ? "/mcp_jam_dark.png"
+                              : "/mcp_jam_light.png"
+                          }
+                          alt="MCPJam"
+                          className="h-4 w-auto object-contain"
+                        />
+                      </button>
+                      <div className="flex flex-1 items-center justify-end gap-1.5">
+                        {session && shareableToken ? (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            className="text-muted-foreground"
+                            onClick={handleCopyLink}
+                          >
+                            Copy link
+                          </Button>
+                        ) : null}
+                      </div>
+                    </div>
+                  </header>
 
-        {renderContent()}
-      </div>
-      </ChatboxSurfaceProvider>
-      </ActiveHostClientCapabilitiesScope>
-      </ActiveMcpProfileProvider>
-      </ChatboxHostCapabilitiesOverrideProvider>
+                  {renderContent()}
+                </div>
+              </ChatboxSurfaceProvider>
+            </ActiveHostClientCapabilitiesScope>
+          </ActiveMcpProfileProvider>
+        </ChatboxHostCapabilitiesOverrideProvider>
       </ChatboxChatUiOverrideProvider>
     </ChatboxHostStyleProvider>
   );

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/contexts/chatbox-client-style-context";
 import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-client-capabilities-override-context";
 import { ActiveMcpProfileProvider } from "@/contexts/active-mcp-profile-context";
+import { ActiveHostClientCapabilitiesScope } from "@/contexts/active-host-client-capabilities-context";
 import { ChatboxSurfaceProvider } from "@/contexts/chatbox-surface-context";
 import { ChatboxHostOnboardingOverlays } from "@/components/hosted/ChatboxHostOnboardingOverlays";
 import { useChatboxHostIntroGate } from "@/components/hosted/useChatboxHostIntroGate";
@@ -919,6 +920,17 @@ export function ChatboxChatPage({
         value={session?.payload.hostCapabilitiesOverride}
       >
       <ActiveMcpProfileProvider value={session?.payload.mcpProfile}>
+      {/*
+        Hosted bootstrap payload doesn't (yet) carry clientCapabilities —
+        we pass `activeHost={null}` and let the scope fall back to the
+        template seed for `hostStyle`. Correct for unmodified host styles;
+        if a chatbox owner customizes capabilities, that will require a
+        bootstrap-payload extension (out of scope here).
+      */}
+      <ActiveHostClientCapabilitiesScope
+        activeHost={null}
+        hostStyle={hostStyle}
+      >
       <ChatboxSurfaceProvider value={true}>
       <div
         className="chatbox-host-shell flex h-svh min-h-0 flex-col overflow-hidden"
@@ -962,6 +974,7 @@ export function ChatboxChatPage({
         {renderContent()}
       </div>
       </ChatboxSurfaceProvider>
+      </ActiveHostClientCapabilitiesScope>
       </ActiveMcpProfileProvider>
       </ChatboxHostCapabilitiesOverrideProvider>
       </ChatboxChatUiOverrideProvider>

--- a/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
+++ b/mcpjam-inspector/client/src/components/hosted/ChatboxChatPage.tsx
@@ -36,7 +36,7 @@ import {
 } from "@/contexts/chatbox-client-style-context";
 import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-client-capabilities-override-context";
 import { ActiveMcpProfileProvider } from "@/contexts/active-mcp-profile-context";
-import { ActiveHostClientCapabilitiesScope } from "@/contexts/active-host-client-capabilities-context";
+import { ActiveHostCapsResolverScope } from "@/contexts/active-host-client-capabilities-context";
 import { ChatboxSurfaceProvider } from "@/contexts/chatbox-surface-context";
 import { ChatboxHostOnboardingOverlays } from "@/components/hosted/ChatboxHostOnboardingOverlays";
 import { useChatboxHostIntroGate } from "@/components/hosted/useChatboxHostIntroGate";
@@ -925,7 +925,7 @@ export function ChatboxChatPage({
         if a chatbox owner customizes capabilities, that will require a
         bootstrap-payload extension (out of scope here).
       */}
-            <ActiveHostClientCapabilitiesScope
+            <ActiveHostCapsResolverScope
               activeHost={null}
               hostStyle={hostStyle}
             >
@@ -972,7 +972,7 @@ export function ChatboxChatPage({
                   {renderContent()}
                 </div>
               </ChatboxSurfaceProvider>
-            </ActiveHostClientCapabilitiesScope>
+            </ActiveHostCapsResolverScope>
           </ActiveMcpProfileProvider>
         </ChatboxHostCapabilitiesOverrideProvider>
       </ChatboxChatUiOverrideProvider>

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
@@ -61,10 +61,10 @@ interface PlaygroundTabProps {
   onConnect?: (formData: ServerFormData) => void;
   onSaveHostContext?: (
     projectId: string,
-    hostContext: ProjectHostContextDraft,
+    hostContext: ProjectHostContextDraft
   ) => Promise<void>;
   ensureServersReady?: (
-    serverNames: string[],
+    serverNames: string[]
   ) => Promise<EnsureServersReadyResult>;
   onOnboardingChange?: (isOnboarding: boolean) => void;
   playgroundServerSelectorProps?: PlaygroundServerSelectorProps;
@@ -96,7 +96,7 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
   // hostId, so this is cheap when no host is picked yet.
   const { isAuthenticated: isConvexAuthenticated } = useConvexAuth();
   const [previewedHostId] = usePreviewedHostId(
-    props.sharedProjectId ?? props.activeProjectId ?? null,
+    props.sharedProjectId ?? props.activeProjectId ?? null
   );
   const { host: previewedHost } = useHost({
     isAuthenticated: isConvexAuthenticated,
@@ -110,10 +110,10 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
   // its properties" everywhere.
   const prefHostStyle = usePreferencesStore((state) => state.hostStyle);
   const prefHostCapabilitiesOverride = usePreferencesStore(
-    (state) => state.hostCapabilitiesOverride,
+    (state) => state.hostCapabilitiesOverride
   );
   const prefChatUiOverride = usePreferencesStore(
-    (state) => state.chatUiOverride,
+    (state) => state.chatUiOverride
   );
   const hostStyle = previewedHost?.config.hostStyle ?? prefHostStyle;
   const hostCapabilitiesOverride =
@@ -134,7 +134,7 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
     const requiredIds = previewedHost?.config?.serverIds ?? [];
     if (requiredIds.length === 0 || !projectServersList) return [];
     const byId = new Map(
-      projectServersList.map((s) => [s._id, s.name] as const),
+      projectServersList.map((s) => [s._id, s.name] as const)
     );
     return requiredIds
       .map((id) => byId.get(id))
@@ -165,10 +165,10 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
     // Playground supports multi-server tool selection — pass the active
     // multi-server set through so the docked tools pane aggregates across
     // all of them and execution routes to the right server per tool.
-    selectedServerNames:
-      props.playgroundServerSelectorProps?.isMultiSelectEnabled
-        ? props.playgroundServerSelectorProps?.selectedMultipleServers
-        : undefined,
+    selectedServerNames: props.playgroundServerSelectorProps
+      ?.isMultiSelectEnabled
+      ? props.playgroundServerSelectorProps?.selectedMultipleServers
+      : undefined,
   });
 
   // Rail collapse state — local to the workspace; not persisted per view.
@@ -189,126 +189,126 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
           activeHost={previewedHost?.config}
           hostStyle={hostStyle}
         >
-        <ChatboxHostStyleProvider value={hostStyle}>
-          <ChatboxHostCapabilitiesOverrideProvider
-            value={hostCapabilitiesOverride}
-          >
-          <ChatboxChatUiOverrideProvider value={chatUiOverride}>
-            <ChatboxHostThemeProvider value={themeMode}>
-              <div
-                className={cn(
-                  "chatbox-host-shell app-theme-scope flex h-full min-h-0 flex-1 flex-col overflow-hidden",
-                  themeMode === "dark" && "dark",
-                )}
-                data-host-style={hostStyle}
-                style={shellStyle}
-              >
-                {/* Watches the project's previewed-host id (the named-host
+          <ChatboxHostStyleProvider value={hostStyle}>
+            <ChatboxHostCapabilitiesOverrideProvider
+              value={hostCapabilitiesOverride}
+            >
+              <ChatboxChatUiOverrideProvider value={chatUiOverride}>
+                <ChatboxHostThemeProvider value={themeMode}>
+                  <div
+                    className={cn(
+                      "chatbox-host-shell app-theme-scope flex h-full min-h-0 flex-1 flex-col overflow-hidden",
+                      themeMode === "dark" && "dark"
+                    )}
+                    data-host-style={hostStyle}
+                    style={shellStyle}
+                  >
+                    {/* Watches the project's previewed-host id (the named-host
                     dropdown in the global header) and re-snapshots its
                     persisted config into the chip stores when it changes.
                     Renders nothing. */}
-                <PlaygroundPreviewedClientSync
-                  projectId={
-                    props.sharedProjectId ?? props.activeProjectId ?? null
-                  }
-                />
-                <ResizablePanelGroup
-                  direction="horizontal"
-                  className="min-h-0 flex-1"
-                >
-                  {isLeftRailVisible ? (
-                    <>
+                    <PlaygroundPreviewedClientSync
+                      projectId={
+                        props.sharedProjectId ?? props.activeProjectId ?? null
+                      }
+                    />
+                    <ResizablePanelGroup
+                      direction="horizontal"
+                      className="min-h-0 flex-1"
+                    >
+                      {isLeftRailVisible ? (
+                        <>
+                          <ResizablePanel
+                            ref={leftPanelRef}
+                            id="playground-left"
+                            order={1}
+                            defaultSize={22}
+                            minSize={15}
+                            maxSize={35}
+                            collapsible
+                            collapsedSize={0}
+                            onCollapse={() => setIsLeftRailVisible(false)}
+                            className="min-h-0 min-w-0 overflow-hidden"
+                          >
+                            <PlaygroundLeftRail />
+                          </ResizablePanel>
+                          <ResizableHandle withHandle />
+                        </>
+                      ) : (
+                        <CollapsedPanelStrip
+                          side="left"
+                          onOpen={() => {
+                            setIsLeftRailVisible(true);
+                            // The panel only remounts on the next paint; expand
+                            // imperatively once it has a ref to honor the click.
+                            requestAnimationFrame(() =>
+                              leftPanelRef.current?.expand()
+                            );
+                          }}
+                          tooltipText="Show sessions"
+                        />
+                      )}
                       <ResizablePanel
-                        ref={leftPanelRef}
-                        id="playground-left"
-                        order={1}
-                        defaultSize={22}
-                        minSize={15}
-                        maxSize={35}
-                        collapsible
-                        collapsedSize={0}
-                        onCollapse={() => setIsLeftRailVisible(false)}
+                        id="playground-center"
+                        order={2}
+                        minSize={40}
                         className="min-h-0 min-w-0 overflow-hidden"
                       >
-                        <PlaygroundLeftRail />
+                        <PlaygroundCenter
+                          activeProjectId={props.activeProjectId}
+                          serverName={props.serverName}
+                          enableMultiModelChat={true}
+                          onSaveHostContext={props.onSaveHostContext}
+                          ensureServersReady={props.ensureServersReady}
+                          playgroundServerSelectorProps={
+                            props.playgroundServerSelectorProps
+                          }
+                          evalChatHandoff={props.evalChatHandoff}
+                          onEvalChatHandoffConsumed={
+                            props.onEvalChatHandoffConsumed
+                          }
+                        />
                       </ResizablePanel>
-                      <ResizableHandle withHandle />
-                    </>
-                  ) : (
-                    <CollapsedPanelStrip
-                      side="left"
-                      onOpen={() => {
-                        setIsLeftRailVisible(true);
-                        // The panel only remounts on the next paint; expand
-                        // imperatively once it has a ref to honor the click.
-                        requestAnimationFrame(() =>
-                          leftPanelRef.current?.expand(),
-                        );
-                      }}
-                      tooltipText="Show sessions"
-                    />
-                  )}
-                  <ResizablePanel
-                    id="playground-center"
-                    order={2}
-                    minSize={40}
-                    className="min-h-0 min-w-0 overflow-hidden"
-                  >
-                    <PlaygroundCenter
-                      activeProjectId={props.activeProjectId}
-                      serverName={props.serverName}
-                      enableMultiModelChat={true}
-                      onSaveHostContext={props.onSaveHostContext}
-                      ensureServersReady={props.ensureServersReady}
-                      playgroundServerSelectorProps={
-                        props.playgroundServerSelectorProps
-                      }
-                      evalChatHandoff={props.evalChatHandoff}
-                      onEvalChatHandoffConsumed={
-                        props.onEvalChatHandoffConsumed
-                      }
-                    />
-                  </ResizablePanel>
-                  {isRightRailVisible ? (
-                    <>
-                      <ResizableHandle withHandle />
-                      <ResizablePanel
-                        ref={rightPanelRef}
-                        id="playground-right"
-                        order={3}
-                        defaultSize={30}
-                        minSize={4}
-                        maxSize={50}
-                        collapsible
-                        collapsedSize={0}
-                        onCollapse={() => setIsRightRailVisible(false)}
-                        className="min-h-0 overflow-hidden"
-                      >
-                        <div className="h-full min-h-0 overflow-hidden">
-                          <LoggerView
-                            onClose={() => setIsRightRailVisible(false)}
-                          />
-                        </div>
-                      </ResizablePanel>
-                    </>
-                  ) : (
-                    <CollapsedPanelStrip
-                      side="right"
-                      onOpen={() => {
-                        setIsRightRailVisible(true);
-                        requestAnimationFrame(() =>
-                          rightPanelRef.current?.expand(),
-                        );
-                      }}
-                      tooltipText="Show logs"
-                    />
-                  )}
-                </ResizablePanelGroup>
-              </div>
-            </ChatboxHostThemeProvider>
-          </ChatboxChatUiOverrideProvider>
-          </ChatboxHostCapabilitiesOverrideProvider>
-        </ChatboxHostStyleProvider>
+                      {isRightRailVisible ? (
+                        <>
+                          <ResizableHandle withHandle />
+                          <ResizablePanel
+                            ref={rightPanelRef}
+                            id="playground-right"
+                            order={3}
+                            defaultSize={30}
+                            minSize={4}
+                            maxSize={50}
+                            collapsible
+                            collapsedSize={0}
+                            onCollapse={() => setIsRightRailVisible(false)}
+                            className="min-h-0 overflow-hidden"
+                          >
+                            <div className="h-full min-h-0 overflow-hidden">
+                              <LoggerView
+                                onClose={() => setIsRightRailVisible(false)}
+                              />
+                            </div>
+                          </ResizablePanel>
+                        </>
+                      ) : (
+                        <CollapsedPanelStrip
+                          side="right"
+                          onOpen={() => {
+                            setIsRightRailVisible(true);
+                            requestAnimationFrame(() =>
+                              rightPanelRef.current?.expand()
+                            );
+                          }}
+                          tooltipText="Show logs"
+                        />
+                      )}
+                    </ResizablePanelGroup>
+                  </div>
+                </ChatboxHostThemeProvider>
+              </ChatboxChatUiOverrideProvider>
+            </ChatboxHostCapabilitiesOverrideProvider>
+          </ChatboxHostStyleProvider>
         </ActiveHostClientCapabilitiesScope>
       </ActiveMcpProfileProvider>
     </AppBuilderStateProvider>

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
@@ -11,7 +11,7 @@ import {
 } from "@/contexts/chatbox-client-style-context";
 import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-client-capabilities-override-context";
 import { ActiveMcpProfileProvider } from "@/contexts/active-mcp-profile-context";
-import { ActiveHostClientCapabilitiesScope } from "@/contexts/active-host-client-capabilities-context";
+import { ActiveHostCapsResolverScope } from "@/contexts/active-host-client-capabilities-context";
 import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
@@ -185,7 +185,7 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
   return (
     <AppBuilderStateProvider value={appBuilderState}>
       <ActiveMcpProfileProvider value={activeMcpProfile}>
-        <ActiveHostClientCapabilitiesScope
+        <ActiveHostCapsResolverScope
           activeHost={previewedHost?.config}
           hostStyle={hostStyle}
         >
@@ -309,7 +309,7 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
               </ChatboxChatUiOverrideProvider>
             </ChatboxHostCapabilitiesOverrideProvider>
           </ChatboxHostStyleProvider>
-        </ActiveHostClientCapabilitiesScope>
+        </ActiveHostCapsResolverScope>
       </ActiveMcpProfileProvider>
     </AppBuilderStateProvider>
   );

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/contexts/chatbox-client-style-context";
 import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-client-capabilities-override-context";
 import { ActiveMcpProfileProvider } from "@/contexts/active-mcp-profile-context";
+import { ActiveHostClientCapabilitiesScope } from "@/contexts/active-host-client-capabilities-context";
 import { getChatboxShellStyle } from "@/lib/chatbox-client-style";
 import { cn } from "@/lib/utils";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
@@ -184,6 +185,10 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
   return (
     <AppBuilderStateProvider value={appBuilderState}>
       <ActiveMcpProfileProvider value={activeMcpProfile}>
+        <ActiveHostClientCapabilitiesScope
+          activeHost={previewedHost?.config}
+          hostStyle={hostStyle}
+        >
         <ChatboxHostStyleProvider value={hostStyle}>
           <ChatboxHostCapabilitiesOverrideProvider
             value={hostCapabilitiesOverride}
@@ -304,6 +309,7 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
           </ChatboxChatUiOverrideProvider>
           </ChatboxHostCapabilitiesOverrideProvider>
         </ChatboxHostStyleProvider>
+        </ActiveHostClientCapabilitiesScope>
       </ActiveMcpProfileProvider>
     </AppBuilderStateProvider>
   );

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
@@ -39,6 +39,7 @@ import type {
 } from "@/hooks/use-app-state";
 import type { PlaygroundServerSelectorProps } from "@/components/ActiveServerSelector";
 import type { EvalChatHandoff } from "@/lib/eval-chat-handoff";
+import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
 
 interface PlaygroundTabProps {
   activeProjectId?: string | null;
@@ -68,6 +69,14 @@ interface PlaygroundTabProps {
   ) => Promise<EnsureServersReadyResult>;
   onOnboardingChange?: (isOnboarding: boolean) => void;
   playgroundServerSelectorProps?: PlaygroundServerSelectorProps;
+  /**
+   * Resolved active host from `useAppState` — the project default unless
+   * the user explicitly previewed a different host. Used as the host
+   * fallback when nothing is selected in the preview picker so the
+   * render gate agrees with what `initialize` is using server-side.
+   * Preview mode (when set) still wins over this fallback.
+   */
+  activeHost?: HostConfigDtoV2 | null;
   evalChatHandoff?: EvalChatHandoff | null;
   onEvalChatHandoffConsumed?: (id: string) => void;
 }
@@ -186,7 +195,14 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
     <AppBuilderStateProvider value={appBuilderState}>
       <ActiveMcpProfileProvider value={activeMcpProfile}>
         <ActiveHostCapsResolverScope
-          activeHost={previewedHost?.config}
+          // Preview-mode (explicit picker selection) wins; otherwise fall
+          // back to the resolved project-default `activeHost` from
+          // `useAppState` so the render gate agrees with what
+          // `initialize` was called with. Without this fallback, a
+          // project whose default is Codex would render widgets in
+          // Playground while connect knows the server was init'd as
+          // Codex.
+          activeHost={previewedHost?.config ?? props.activeHost ?? null}
           hostStyle={hostStyle}
         >
           <ChatboxHostStyleProvider value={hostStyle}>

--- a/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
@@ -6,7 +6,7 @@ import { detectUIType, UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import { JsonEditor } from "@/components/ui/json-editor";
 import { extractDisplayFromToolResult } from "@/components/chat-v2/shared/tool-result-text";
 import { navigateApp } from "@/lib/app-navigation";
-import { useActiveHostClientCapabilities } from "@/contexts/active-host-client-capabilities-context";
+import { useActiveHostCapsResolver } from "@/contexts/active-host-client-capabilities-context";
 import { hostSupportsWidgetRendering } from "@/lib/host-capabilities";
 
 interface ResultsPanelProps {
@@ -37,9 +37,12 @@ export function ResultsPanel({
   // "Use the App Builder" affordance when the active host doesn't advertise
   // the MCP UI extension. Codex etc. won't render the widget in the chat
   // surface either, so pointing the user there is misleading.
-  const hostClientCapabilities = useActiveHostClientCapabilities();
+  // Commit 1 passes `undefined` to the resolver (host-level caps only);
+  // commit 2 will look up the tool's serverId from a new `serverName`
+  // prop and pass it through so per-server overrides are honored.
+  const resolveHostCaps = useActiveHostCapsResolver();
   const hostSupportsWidgets = hostSupportsWidgetRendering(
-    hostClientCapabilities
+    resolveHostCaps(undefined)
   );
   const hasUIComponent =
     hostSupportsWidgets && (hasOpenAIComponent || hasMCPAppsComponent);

--- a/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
@@ -6,6 +6,8 @@ import { detectUIType, UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import { JsonEditor } from "@/components/ui/json-editor";
 import { extractDisplayFromToolResult } from "@/components/chat-v2/shared/tool-result-text";
 import { navigateApp } from "@/lib/app-navigation";
+import { useActiveHostClientCapabilities } from "@/contexts/active-host-client-capabilities-context";
+import { hostSupportsWidgetRendering } from "@/lib/host-capabilities";
 
 interface ResultsPanelProps {
   error: string;
@@ -31,13 +33,22 @@ export function ResultsPanel({
   const uiType = detectUIType(toolMeta, rawResult);
   const hasOpenAIComponent = uiType === UIType.OPENAI_SDK;
   const hasMCPAppsComponent = uiType === UIType.MCP_APPS;
-  const hasUIComponent = hasOpenAIComponent || hasMCPAppsComponent;
+  // Same gate as the chat thread (PartSwitch/WidgetReplay): suppress the
+  // "Use the App Builder" affordance when the active host doesn't advertise
+  // the MCP UI extension. Codex etc. won't render the widget in the chat
+  // surface either, so pointing the user there is misleading.
+  const hostClientCapabilities = useActiveHostClientCapabilities();
+  const hostSupportsWidgets = hostSupportsWidgetRendering(
+    hostClientCapabilities
+  );
+  const hasUIComponent =
+    hostSupportsWidgets && (hasOpenAIComponent || hasMCPAppsComponent);
   const formattedResponseTime =
     responseDurationMs == null
       ? null
       : responseDurationMs < 1000
-        ? `${Math.round(responseDurationMs)} ms`
-        : `${(responseDurationMs / 1000).toFixed(2)} s`;
+      ? `${Math.round(responseDurationMs)} ms`
+      : `${(responseDurationMs / 1000).toFixed(2)} s`;
 
   return (
     <div className="h-full flex flex-col bg-background break-all">

--- a/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
+++ b/mcpjam-inspector/client/src/components/tools/ResultsPanel.tsx
@@ -15,6 +15,13 @@ interface ResultsPanelProps {
   structuredContentValid: boolean | undefined;
   toolMeta?: Record<string, any>;
   responseDurationMs?: number | null;
+  /**
+   * Name of the server this panel is showing results for. Passed into
+   * the host caps resolver so per-server `clientCapabilities` overrides
+   * are honored — keeps the "Use the App Builder" affordance gated on
+   * the same effective capabilities as `initialize`.
+   */
+  serverName?: string;
 }
 
 export function ResultsPanel({
@@ -23,6 +30,7 @@ export function ResultsPanel({
   structuredContentValid,
   toolMeta,
   responseDurationMs,
+  serverName,
 }: ResultsPanelProps) {
   const rawResult = result as unknown as Record<string, unknown> | null;
   const extractedDisplay = rawResult
@@ -34,15 +42,17 @@ export function ResultsPanel({
   const hasOpenAIComponent = uiType === UIType.OPENAI_SDK;
   const hasMCPAppsComponent = uiType === UIType.MCP_APPS;
   // Same gate as the chat thread (PartSwitch/WidgetReplay): suppress the
-  // "Use the App Builder" affordance when the active host doesn't advertise
+  // "Use the App Builder" affordance when the active host (resolved
+  // against this server's per-server cap overrides) doesn't advertise
   // the MCP UI extension. Codex etc. won't render the widget in the chat
   // surface either, so pointing the user there is misleading.
-  // Commit 1 passes `undefined` to the resolver (host-level caps only);
-  // commit 2 will look up the tool's serverId from a new `serverName`
-  // prop and pass it through so per-server overrides are honored.
+  //
+  // `serverName` is the key into `appState.servers` and matches the
+  // serverId the resolver looks up. The tools tab is single-server per
+  // panel, so one lookup per render is all we need.
   const resolveHostCaps = useActiveHostCapsResolver();
   const hostSupportsWidgets = hostSupportsWidgetRendering(
-    resolveHostCaps(undefined)
+    resolveHostCaps(serverName)
   );
   const hasUIComponent =
     hostSupportsWidgets && (hasOpenAIComponent || hasMCPAppsComponent);

--- a/mcpjam-inspector/client/src/components/tools/__tests__/ResultsPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/tools/__tests__/ResultsPanel.test.tsx
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { MCP_UI_EXTENSION_ID } from "@mcpjam/sdk/browser";
 import { ResultsPanel } from "../ResultsPanel";
+import { ActiveHostClientCapabilitiesProvider } from "@/contexts/active-host-client-capabilities-context";
 
-const { mockJsonEditor } = vi.hoisted(() => ({
+const { mockJsonEditor, mockDetectUIType } = vi.hoisted(() => ({
   mockJsonEditor: vi.fn((props: any) => (
     <div data-testid="json-editor">{JSON.stringify(props.value)}</div>
   )),
+  mockDetectUIType: vi.fn(),
 }));
 
 vi.mock("@/components/ui/json-editor", () => ({
@@ -17,12 +20,14 @@ vi.mock("@/lib/mcp-ui/mcp-apps-utils", () => ({
     OPENAI_SDK: "openai-apps",
     MCP_APPS: "mcp-apps",
   },
-  detectUIType: () => null,
+  detectUIType: (...args: unknown[]) => mockDetectUIType(...args),
 }));
 
 describe("ResultsPanel", () => {
   beforeEach(() => {
     mockJsonEditor.mockClear();
+    mockDetectUIType.mockReset();
+    mockDetectUIType.mockReturnValue(null);
   });
 
   it("renders parsed JSON from a text content block instead of the raw MCP envelope", () => {
@@ -38,7 +43,7 @@ describe("ResultsPanel", () => {
             },
           ],
         }}
-      />,
+      />
     );
 
     expect(screen.getByTestId("json-editor")).toBeInTheDocument();
@@ -53,7 +58,7 @@ describe("ResultsPanel", () => {
           showToolbar: false,
           height: "100%",
         }),
-      ]),
+      ])
     );
   });
 
@@ -63,7 +68,7 @@ describe("ResultsPanel", () => {
     };
 
     render(
-      <ResultsPanel error="" structuredContentValid={false} result={result} />,
+      <ResultsPanel error="" structuredContentValid={false} result={result} />
     );
 
     expect(mockJsonEditor.mock.calls.map(([props]) => props)).toEqual(
@@ -71,7 +76,51 @@ describe("ResultsPanel", () => {
         expect.objectContaining({
           value: result,
         }),
-      ]),
+      ])
     );
+  });
+
+  describe("App Builder banner gate", () => {
+    const uiResult = {
+      content: [{ type: "text", text: "{}" }],
+    };
+
+    it("renders the App Builder banner when the host supports widgets", () => {
+      mockDetectUIType.mockReturnValue("mcp-apps");
+      const caps = {
+        extensions: {
+          [MCP_UI_EXTENSION_ID]: {
+            mimeTypes: ["text/html;profile=mcp-app"],
+          },
+        },
+      };
+      render(
+        <ActiveHostClientCapabilitiesProvider value={caps}>
+          <ResultsPanel
+            error=""
+            structuredContentValid={false}
+            result={uiResult}
+          />
+        </ActiveHostClientCapabilitiesProvider>
+      );
+      expect(screen.getByText(/This tool renders UI/i)).toBeInTheDocument();
+    });
+
+    it("suppresses the banner when the host strips the UI extension (Codex)", () => {
+      mockDetectUIType.mockReturnValue("mcp-apps");
+      const codexCaps = { elicitation: {} };
+      render(
+        <ActiveHostClientCapabilitiesProvider value={codexCaps}>
+          <ResultsPanel
+            error=""
+            structuredContentValid={false}
+            result={uiResult}
+          />
+        </ActiveHostClientCapabilitiesProvider>
+      );
+      expect(
+        screen.queryByText(/This tool renders UI/i)
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/mcpjam-inspector/client/src/components/tools/__tests__/ResultsPanel.test.tsx
+++ b/mcpjam-inspector/client/src/components/tools/__tests__/ResultsPanel.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MCP_UI_EXTENSION_ID } from "@mcpjam/sdk/browser";
 import { ResultsPanel } from "../ResultsPanel";
-import { ActiveHostClientCapabilitiesProvider } from "@/contexts/active-host-client-capabilities-context";
+import { ActiveHostCapsResolverProvider } from "@/contexts/active-host-client-capabilities-context";
 
 const { mockJsonEditor, mockDetectUIType } = vi.hoisted(() => ({
   mockJsonEditor: vi.fn((props: any) => (
@@ -95,13 +95,13 @@ describe("ResultsPanel", () => {
         },
       };
       render(
-        <ActiveHostClientCapabilitiesProvider value={caps}>
+        <ActiveHostCapsResolverProvider value={() => caps}>
           <ResultsPanel
             error=""
             structuredContentValid={false}
             result={uiResult}
           />
-        </ActiveHostClientCapabilitiesProvider>
+        </ActiveHostCapsResolverProvider>
       );
       expect(screen.getByText(/This tool renders UI/i)).toBeInTheDocument();
     });
@@ -110,13 +110,13 @@ describe("ResultsPanel", () => {
       mockDetectUIType.mockReturnValue("mcp-apps");
       const codexCaps = { elicitation: {} };
       render(
-        <ActiveHostClientCapabilitiesProvider value={codexCaps}>
+        <ActiveHostCapsResolverProvider value={() => codexCaps}>
           <ResultsPanel
             error=""
             structuredContentValid={false}
             result={uiResult}
           />
-        </ActiveHostClientCapabilitiesProvider>
+        </ActiveHostCapsResolverProvider>
       );
       expect(
         screen.queryByText(/This tool renders UI/i)

--- a/mcpjam-inspector/client/src/contexts/__tests__/active-host-caps-resolver.test.tsx
+++ b/mcpjam-inspector/client/src/contexts/__tests__/active-host-caps-resolver.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import {
+  MCP_UI_EXTENSION_ID,
+  MCP_UI_RESOURCE_MIME_TYPE,
+} from "@mcpjam/sdk/browser";
+import {
+  ActiveHostCapsResolverScope,
+  useActiveHostCapsResolver,
+} from "../active-host-client-capabilities-context";
+import { AppStateProvider } from "@/state/app-state-context";
+import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
+
+/**
+ * End-to-end resolver tests: render the scope inside a minimal
+ * AppStateProvider with a `servers` map, then read `resolveCaps(serverId)`
+ * via a probe component. Verifies the gate uses the same effective-caps
+ * function as `initialize`, so per-server overrides land in the renderer.
+ */
+
+function ProbeOutput({ serverId }: { serverId?: string }) {
+  const resolveCaps = useActiveHostCapsResolver();
+  const caps = resolveCaps(serverId);
+  return (
+    <span data-testid="caps">{caps ? JSON.stringify(caps) : "undefined"}</span>
+  );
+}
+
+function mountWithState(args: {
+  activeHost?: HostConfigDtoV2 | null;
+  hostStyle: string;
+  servers: Record<string, { name: string; config: Record<string, unknown> }>;
+  serverId?: string;
+}) {
+  const minimalAppState = {
+    servers: args.servers as never,
+    selectedServer: undefined,
+    selectedMultipleServers: [],
+  } as unknown as Parameters<typeof AppStateProvider>[0]["appState"];
+
+  return render(
+    <AppStateProvider appState={minimalAppState}>
+      <ActiveHostCapsResolverScope
+        activeHost={args.activeHost ?? null}
+        hostStyle={args.hostStyle}
+      >
+        <ProbeOutput serverId={args.serverId} />
+      </ActiveHostCapsResolverScope>
+    </AppStateProvider>
+  );
+}
+
+const HOST_WITH_UI: Pick<HostConfigDtoV2, "clientCapabilities"> = {
+  clientCapabilities: {
+    extensions: {
+      [MCP_UI_EXTENSION_ID]: { mimeTypes: [MCP_UI_RESOURCE_MIME_TYPE] },
+    },
+  },
+};
+
+const HOST_NO_UI: Pick<HostConfigDtoV2, "clientCapabilities"> = {
+  clientCapabilities: { elicitation: {} },
+};
+
+describe("ActiveHostCapsResolverScope (resolver)", () => {
+  it("uses host-level caps when no per-server override exists", () => {
+    const { getByTestId } = mountWithState({
+      activeHost: HOST_WITH_UI as HostConfigDtoV2,
+      hostStyle: "chatgpt",
+      servers: { srv: { name: "srv", config: {} } },
+      serverId: "srv",
+    });
+    const caps = JSON.parse(getByTestId("caps").textContent ?? "{}");
+    expect(caps.extensions?.[MCP_UI_EXTENSION_ID]?.mimeTypes).toContain(
+      MCP_UI_RESOURCE_MIME_TYPE
+    );
+  });
+
+  it("per-server clientCapabilities override strips UI on a UI-capable host", () => {
+    const { getByTestId } = mountWithState({
+      activeHost: HOST_WITH_UI as HostConfigDtoV2,
+      hostStyle: "chatgpt",
+      servers: {
+        // Server explicitly advertises no extensions — should win over host.
+        srv: { name: "srv", config: { clientCapabilities: {} } },
+      },
+      serverId: "srv",
+    });
+    const caps = JSON.parse(getByTestId("caps").textContent ?? "{}");
+    expect(caps.extensions).toBeUndefined();
+  });
+
+  it("per-server clientCapabilities override re-adds UI on a no-UI host (Codex)", () => {
+    // Inspector contract: server-level override beats host identity. A
+    // user modeling "I'm Codex but this one server pretends I can render"
+    // gets widgets for that server's tools.
+    const { getByTestId } = mountWithState({
+      activeHost: HOST_NO_UI as HostConfigDtoV2,
+      hostStyle: "codex",
+      servers: {
+        srv: {
+          name: "srv",
+          config: {
+            clientCapabilities: {
+              extensions: {
+                [MCP_UI_EXTENSION_ID]: {
+                  mimeTypes: [MCP_UI_RESOURCE_MIME_TYPE],
+                },
+              },
+            },
+          },
+        },
+      },
+      serverId: "srv",
+    });
+    const caps = JSON.parse(getByTestId("caps").textContent ?? "{}");
+    expect(caps.extensions?.[MCP_UI_EXTENSION_ID]?.mimeTypes).toContain(
+      MCP_UI_RESOURCE_MIME_TYPE
+    );
+  });
+
+  it("per-server `capabilities` (additive) merges with host caps", () => {
+    // `serverConfig.capabilities` is the additive legacy field.
+    // `resolveEffectiveClientCapabilities` merges it with host caps when
+    // there is no `clientCapabilities` override. The merged blob should
+    // include both the host's UI extension AND the server's addition.
+    const { getByTestId } = mountWithState({
+      activeHost: HOST_WITH_UI as HostConfigDtoV2,
+      hostStyle: "chatgpt",
+      servers: {
+        srv: {
+          name: "srv",
+          config: { capabilities: { sampling: {} } },
+        },
+      },
+      serverId: "srv",
+    });
+    const caps = JSON.parse(getByTestId("caps").textContent ?? "{}");
+    expect(caps.extensions?.[MCP_UI_EXTENSION_ID]?.mimeTypes).toContain(
+      MCP_UI_RESOURCE_MIME_TYPE
+    );
+    expect(caps.sampling).toBeDefined();
+  });
+
+  it("falls back to host caps when serverId is unknown to appState", () => {
+    const { getByTestId } = mountWithState({
+      activeHost: HOST_WITH_UI as HostConfigDtoV2,
+      hostStyle: "chatgpt",
+      servers: {},
+      serverId: "ghost-server",
+    });
+    const caps = JSON.parse(getByTestId("caps").textContent ?? "{}");
+    expect(caps.extensions?.[MCP_UI_EXTENSION_ID]?.mimeTypes).toContain(
+      MCP_UI_RESOURCE_MIME_TYPE
+    );
+  });
+
+  it("synthesizes host caps from the template seed when activeHost is null (hosted chatbox case)", () => {
+    // Hosted chatbox bootstrap payload doesn't carry clientCapabilities
+    // yet (follow-up). Until then, the scope synthesizes them from the
+    // host style. Codex seed → no UI extension.
+    const { getByTestId } = mountWithState({
+      activeHost: null,
+      hostStyle: "codex",
+      servers: { srv: { name: "srv", config: {} } },
+      serverId: "srv",
+    });
+    const caps = JSON.parse(getByTestId("caps").textContent ?? "{}");
+    expect(caps.extensions).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/contexts/active-host-client-capabilities-context.ts
+++ b/mcpjam-inspector/client/src/contexts/active-host-client-capabilities-context.ts
@@ -1,0 +1,40 @@
+import { createContext, useContext } from "react";
+
+/**
+ * Per-scope active `clientCapabilities` blob from the active host config.
+ *
+ * Mirrors {@link ActiveMcpProfileContext} /
+ * {@link ChatboxHostCapabilitiesOverrideContext}: a single Provider sets the
+ * value for whatever scope owns the host config (chatbox, eval suite, direct
+ * chat). Downstream consumers read via {@link useActiveHostClientCapabilities}.
+ *
+ * **Important — this is `clientCapabilities`, not `hostCapabilities`:**
+ *   - `clientCapabilities` is what the MCP client (the host) advertises to
+ *     the SERVER in the base-protocol `initialize` exchange. The MCP UI
+ *     extension lives here under `extensions["io.modelcontextprotocol/ui"]`.
+ *   - `hostCapabilities` (handled by
+ *     {@link ChatboxHostCapabilitiesOverrideProvider}) is what the host
+ *     advertises to WIDGETS via the MCP Apps `ui/initialize` response.
+ *
+ * The render gate in `PartSwitch` / `WidgetReplay` uses this context to
+ * decide whether to render a widget iframe for a tool that declares UI
+ * metadata. Hosts that don't advertise the MCP UI extension (e.g. Codex,
+ * which is elicitation-only) drop to the plain `ToolPart` result row.
+ *
+ * `undefined` (the default) means "no host config in scope" — preserves
+ * historical behavior for surfaces without an `activeHost` by allowing
+ * the render decision to fall through to the legacy tool-metadata-only
+ * check. See `hostSupportsWidgetRendering` in `lib/host-capabilities.ts`.
+ */
+const ActiveHostClientCapabilitiesContext = createContext<
+  Record<string, unknown> | undefined
+>(undefined);
+
+export const ActiveHostClientCapabilitiesProvider =
+  ActiveHostClientCapabilitiesContext.Provider;
+
+export function useActiveHostClientCapabilities():
+  | Record<string, unknown>
+  | undefined {
+  return useContext(ActiveHostClientCapabilitiesContext);
+}

--- a/mcpjam-inspector/client/src/contexts/active-host-client-capabilities-context.tsx
+++ b/mcpjam-inspector/client/src/contexts/active-host-client-capabilities-context.tsx
@@ -1,4 +1,14 @@
-import { createContext, useContext } from "react";
+import {
+  createContext,
+  useContext,
+  useMemo,
+  type ReactNode,
+} from "react";
+import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
+import {
+  seedFromHostTemplate,
+  type HostTemplateId,
+} from "@/lib/client-templates";
 
 /**
  * Per-scope active `clientCapabilities` blob from the active host config.
@@ -37,4 +47,37 @@ export function useActiveHostClientCapabilities():
   | Record<string, unknown>
   | undefined {
   return useContext(ActiveHostClientCapabilitiesContext);
+}
+
+/**
+ * Convenience wrapper that resolves the active host's `clientCapabilities`
+ * and provides it to the context. Falls back to the template seed for the
+ * given `hostStyle` when no persisted `activeHost` is in scope — without
+ * this, prefs-only surfaces (no Convex `activeHost` hydrated) would leave
+ * the gate reading the legacy-preservation default and silently re-enable
+ * widget rendering for hosts whose template strips the MCP UI extension
+ * (Codex).
+ *
+ * Use this at the outer chat surface root (analog to
+ * `ChatboxHostStyleProvider`). Apply once per surface; nested scopes are
+ * fine — React context picks the closest provider.
+ */
+export function ActiveHostClientCapabilitiesScope({
+  activeHost,
+  hostStyle,
+  children,
+}: {
+  activeHost?: HostConfigDtoV2 | null;
+  hostStyle: string;
+  children: ReactNode;
+}) {
+  const value = useMemo(() => {
+    if (activeHost?.clientCapabilities) return activeHost.clientCapabilities;
+    return seedFromHostTemplate(hostStyle as HostTemplateId).clientCapabilities;
+  }, [activeHost?.clientCapabilities, hostStyle]);
+  return (
+    <ActiveHostClientCapabilitiesProvider value={value}>
+      {children}
+    </ActiveHostClientCapabilitiesProvider>
+  );
 }

--- a/mcpjam-inspector/client/src/contexts/active-host-client-capabilities-context.tsx
+++ b/mcpjam-inspector/client/src/contexts/active-host-client-capabilities-context.tsx
@@ -4,6 +4,8 @@ import {
   seedFromHostTemplate,
   type HostTemplateId,
 } from "@/lib/client-templates";
+import { resolveEffectiveClientCapabilities } from "@/lib/effective-client";
+import { useOptionalSharedAppState } from "@/state/app-state-context";
 
 /**
  * Resolver returning the effective `clientCapabilities` blob the render
@@ -14,9 +16,11 @@ import {
  * surfaces without a wrapping `ActiveHostCapsResolverScope` keep
  * rendering widgets (test fixtures, edge surfaces).
  *
- * In commit 1 of the per-server-gate refactor, the resolver ignores its
- * `serverId` argument and returns host-level capabilities only.
- * Commit 2 wires `appState.servers` and the per-server override path.
+ * Calls `resolveEffectiveClientCapabilities` from `lib/effective-client`,
+ * the same function used by the connect path to build `initialize`. So
+ * the gate cannot drift from what the server was actually initialized
+ * with: per-server `clientCapabilities` overrides strip/add the UI
+ * extension here exactly as they do at initialize-time.
  */
 export type ActiveHostCapsResolver = (
   serverId?: string
@@ -26,7 +30,7 @@ const NO_OP_RESOLVER: ActiveHostCapsResolver = () => undefined;
 
 /**
  * Per-scope resolver that returns the effective `clientCapabilities` for
- * the active host (and, after commit 2, the tool's server). Mirrors
+ * the active host + the tool's server. Mirrors
  * {@link ActiveMcpProfileContext} / {@link ChatboxHostCapabilitiesOverrideContext}:
  * a single Provider sets the value for whatever scope owns the host
  * config (chatbox, eval suite, direct chat). Downstream readers call
@@ -60,19 +64,25 @@ export function useActiveHostCapsResolver(): ActiveHostCapsResolver {
 }
 
 /**
- * Convenience wrapper that builds the resolver and provides it. Falls
- * back to the template seed for `hostStyle` when no persisted
- * `activeHost` is in scope — preserves the prefs-only / hosted-chatbox
- * paths today.
+ * Convenience wrapper that builds the resolver and provides it.
+ *
+ * Resolution:
+ *   1. Looks up the tool's server config from `appState.servers`.
+ *   2. Passes `{ host, serverConfig }` to `resolveEffectiveClientCapabilities` —
+ *      same call as the connect path, so the render gate and `initialize`
+ *      always evaluate the same capability blob.
+ *   3. Falls back to the template seed for `hostStyle` when no persisted
+ *      `activeHost` is in scope — preserves prefs-only and hosted-chatbox
+ *      paths where the bootstrap doesn't carry full host capabilities.
  *
  * Apply once per chat surface root (analog to `ChatboxHostStyleProvider`).
  *
- * **Commit 1 note:** this resolver ignores `serverId` and returns
- * host-level capabilities only. The shape change lands first, with no
- * new dependency on `appState.servers`, so this commit is functionally
- * equivalent to the previous cached-caps provider. Commit 2 changes the
- * resolver body to call `resolveEffectiveClientCapabilities` with the
- * tool's server config.
+ * **Product note on per-server overrides:** a server with its own
+ * `clientCapabilities` advertising the UI extension will render widgets
+ * even when the host (e.g. Codex) strips it. This is intentional —
+ * server-level override beats host identity, matching the precedence in
+ * `resolveEffectiveClientCapabilities` and the inspector's role as a
+ * conformance/test surface.
  */
 export function ActiveHostCapsResolverScope({
   activeHost,
@@ -83,15 +93,51 @@ export function ActiveHostCapsResolverScope({
   hostStyle: string;
   children: ReactNode;
 }) {
-  const hostCaps = useMemo(() => {
-    if (activeHost?.clientCapabilities) return activeHost.clientCapabilities;
-    return seedFromHostTemplate(hostStyle as HostTemplateId).clientCapabilities;
+  // Optional: surfaces like isolated test mounts may render the scope
+  // without an AppStateProvider. When absent, per-server overrides are
+  // unavailable (resolver evaluates host-level caps only); the gate
+  // still works for the host axis.
+  const appState = useOptionalSharedAppState();
+  const servers = appState?.servers ?? null;
+
+  // Effective host. When the surface has no persisted active host
+  // (prefs-only Chat tab, hosted chatbox whose bootstrap doesn't carry
+  // clientCapabilities yet), synthesize one from the template seed for
+  // the current `hostStyle`. This keeps Codex etc. gating correctly even
+  // without a Convex host record.
+  const effectiveHost = useMemo<
+    Pick<HostConfigDtoV2, "clientCapabilities">
+  >(() => {
+    if (activeHost?.clientCapabilities) {
+      return { clientCapabilities: activeHost.clientCapabilities };
+    }
+    return {
+      clientCapabilities: seedFromHostTemplate(hostStyle as HostTemplateId)
+        .clientCapabilities,
+    };
   }, [activeHost?.clientCapabilities, hostStyle]);
 
-  const resolver = useMemo<ActiveHostCapsResolver>(
-    () => (_serverId?: string) => hostCaps,
-    [hostCaps]
-  );
+  const resolver = useMemo<ActiveHostCapsResolver>(() => {
+    // Per-render memo: repeated `resolveCaps(serverId)` calls for the
+    // same `serverId` inside one render (e.g. multiple tool parts from
+    // the same server) reuse the result. The outer `useMemo` keys on
+    // `(effectiveHost, servers)` so external changes invalidate.
+    const cache = new Map<
+      string | undefined,
+      Record<string, unknown> | undefined
+    >();
+    return (serverId?: string) => {
+      if (cache.has(serverId)) return cache.get(serverId);
+      const serverConfig =
+        serverId && servers ? servers[serverId]?.config ?? null : null;
+      const caps = resolveEffectiveClientCapabilities({
+        host: effectiveHost,
+        serverConfig,
+      }) as Record<string, unknown>;
+      cache.set(serverId, caps);
+      return caps;
+    };
+  }, [effectiveHost, servers]);
 
   return (
     <ActiveHostCapsResolverProvider value={resolver}>

--- a/mcpjam-inspector/client/src/contexts/active-host-client-capabilities-context.tsx
+++ b/mcpjam-inspector/client/src/contexts/active-host-client-capabilities-context.tsx
@@ -1,9 +1,4 @@
-import {
-  createContext,
-  useContext,
-  useMemo,
-  type ReactNode,
-} from "react";
+import { createContext, useContext, useMemo, type ReactNode } from "react";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
 import {
   seedFromHostTemplate,

--- a/mcpjam-inspector/client/src/contexts/active-host-client-capabilities-context.tsx
+++ b/mcpjam-inspector/client/src/contexts/active-host-client-capabilities-context.tsx
@@ -6,58 +6,75 @@ import {
 } from "@/lib/client-templates";
 
 /**
- * Per-scope active `clientCapabilities` blob from the active host config.
+ * Resolver returning the effective `clientCapabilities` blob the render
+ * gate should evaluate for a given tool, scoped to its server.
  *
- * Mirrors {@link ActiveMcpProfileContext} /
- * {@link ChatboxHostCapabilitiesOverrideContext}: a single Provider sets the
- * value for whatever scope owns the host config (chatbox, eval suite, direct
- * chat). Downstream consumers read via {@link useActiveHostClientCapabilities}.
+ * Returning `undefined` means "no host config in scope" — preserves the
+ * legacy `hostSupportsWidgetRendering(undefined) === true` behavior so
+ * surfaces without a wrapping `ActiveHostCapsResolverScope` keep
+ * rendering widgets (test fixtures, edge surfaces).
  *
- * **Important — this is `clientCapabilities`, not `hostCapabilities`:**
- *   - `clientCapabilities` is what the MCP client (the host) advertises to
- *     the SERVER in the base-protocol `initialize` exchange. The MCP UI
- *     extension lives here under `extensions["io.modelcontextprotocol/ui"]`.
+ * In commit 1 of the per-server-gate refactor, the resolver ignores its
+ * `serverId` argument and returns host-level capabilities only.
+ * Commit 2 wires `appState.servers` and the per-server override path.
+ */
+export type ActiveHostCapsResolver = (
+  serverId?: string
+) => Record<string, unknown> | undefined;
+
+const NO_OP_RESOLVER: ActiveHostCapsResolver = () => undefined;
+
+/**
+ * Per-scope resolver that returns the effective `clientCapabilities` for
+ * the active host (and, after commit 2, the tool's server). Mirrors
+ * {@link ActiveMcpProfileContext} / {@link ChatboxHostCapabilitiesOverrideContext}:
+ * a single Provider sets the value for whatever scope owns the host
+ * config (chatbox, eval suite, direct chat). Downstream readers call
+ * {@link useActiveHostCapsResolver} and pass the tool's `serverId`.
+ *
+ * **`clientCapabilities` vs `hostCapabilities`:**
+ *   - `clientCapabilities` is what the MCP client (the host) advertises
+ *     to the SERVER in the base-protocol `initialize` exchange. The MCP
+ *     UI extension lives here under
+ *     `extensions["io.modelcontextprotocol/ui"]`.
  *   - `hostCapabilities` (handled by
  *     {@link ChatboxHostCapabilitiesOverrideProvider}) is what the host
  *     advertises to WIDGETS via the MCP Apps `ui/initialize` response.
  *
- * The render gate in `PartSwitch` / `WidgetReplay` uses this context to
- * decide whether to render a widget iframe for a tool that declares UI
- * metadata. Hosts that don't advertise the MCP UI extension (e.g. Codex,
- * which is elicitation-only) drop to the plain `ToolPart` result row.
- *
- * `undefined` (the default) means "no host config in scope" — preserves
- * historical behavior for surfaces without an `activeHost` by allowing
- * the render decision to fall through to the legacy tool-metadata-only
- * check. See `hostSupportsWidgetRendering` in `lib/host-capabilities.ts`.
+ * **Why a resolver and not a cached value:** the render gate must agree
+ * with what `initialize` actually sent. `initialize` uses per-server
+ * `resolveEffectiveClientCapabilities` from `lib/effective-client.ts`,
+ * where a per-server override can strip or add the UI extension. Caching
+ * host-level caps lets the renderer disagree with `initialize` for any
+ * server with an override. Calling the same function at render time, with
+ * the tool's `serverId`, keeps both sides in lockstep by construction.
  */
-const ActiveHostClientCapabilitiesContext = createContext<
-  Record<string, unknown> | undefined
->(undefined);
+const ActiveHostCapsResolverContext =
+  createContext<ActiveHostCapsResolver>(NO_OP_RESOLVER);
 
-export const ActiveHostClientCapabilitiesProvider =
-  ActiveHostClientCapabilitiesContext.Provider;
+export const ActiveHostCapsResolverProvider =
+  ActiveHostCapsResolverContext.Provider;
 
-export function useActiveHostClientCapabilities():
-  | Record<string, unknown>
-  | undefined {
-  return useContext(ActiveHostClientCapabilitiesContext);
+export function useActiveHostCapsResolver(): ActiveHostCapsResolver {
+  return useContext(ActiveHostCapsResolverContext);
 }
 
 /**
- * Convenience wrapper that resolves the active host's `clientCapabilities`
- * and provides it to the context. Falls back to the template seed for the
- * given `hostStyle` when no persisted `activeHost` is in scope — without
- * this, prefs-only surfaces (no Convex `activeHost` hydrated) would leave
- * the gate reading the legacy-preservation default and silently re-enable
- * widget rendering for hosts whose template strips the MCP UI extension
- * (Codex).
+ * Convenience wrapper that builds the resolver and provides it. Falls
+ * back to the template seed for `hostStyle` when no persisted
+ * `activeHost` is in scope — preserves the prefs-only / hosted-chatbox
+ * paths today.
  *
- * Use this at the outer chat surface root (analog to
- * `ChatboxHostStyleProvider`). Apply once per surface; nested scopes are
- * fine — React context picks the closest provider.
+ * Apply once per chat surface root (analog to `ChatboxHostStyleProvider`).
+ *
+ * **Commit 1 note:** this resolver ignores `serverId` and returns
+ * host-level capabilities only. The shape change lands first, with no
+ * new dependency on `appState.servers`, so this commit is functionally
+ * equivalent to the previous cached-caps provider. Commit 2 changes the
+ * resolver body to call `resolveEffectiveClientCapabilities` with the
+ * tool's server config.
  */
-export function ActiveHostClientCapabilitiesScope({
+export function ActiveHostCapsResolverScope({
   activeHost,
   hostStyle,
   children,
@@ -66,13 +83,19 @@ export function ActiveHostClientCapabilitiesScope({
   hostStyle: string;
   children: ReactNode;
 }) {
-  const value = useMemo(() => {
+  const hostCaps = useMemo(() => {
     if (activeHost?.clientCapabilities) return activeHost.clientCapabilities;
     return seedFromHostTemplate(hostStyle as HostTemplateId).clientCapabilities;
   }, [activeHost?.clientCapabilities, hostStyle]);
+
+  const resolver = useMemo<ActiveHostCapsResolver>(
+    () => (_serverId?: string) => hostCaps,
+    [hostCaps]
+  );
+
   return (
-    <ActiveHostClientCapabilitiesProvider value={value}>
+    <ActiveHostCapsResolverProvider value={resolver}>
       {children}
-    </ActiveHostClientCapabilitiesProvider>
+    </ActiveHostCapsResolverProvider>
   );
 }

--- a/mcpjam-inspector/client/src/lib/__tests__/host-capabilities.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/host-capabilities.test.ts
@@ -32,13 +32,13 @@ describe("hostSupportsWidgetRendering", () => {
 
   it("returns false when extensions is non-object (defensive)", () => {
     expect(
-      hostSupportsWidgetRendering({ extensions: "nope" as unknown as object }),
+      hostSupportsWidgetRendering({ extensions: "nope" as unknown as object })
     ).toBe(false);
     expect(
-      hostSupportsWidgetRendering({ extensions: null as unknown as object }),
+      hostSupportsWidgetRendering({ extensions: null as unknown as object })
     ).toBe(false);
     expect(
-      hostSupportsWidgetRendering({ extensions: [] as unknown as object }),
+      hostSupportsWidgetRendering({ extensions: [] as unknown as object })
     ).toBe(false);
   });
 

--- a/mcpjam-inspector/client/src/lib/__tests__/host-capabilities.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/host-capabilities.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { MCP_UI_EXTENSION_ID } from "@mcpjam/sdk/browser";
+import {
+  MCP_UI_EXTENSION_ID,
+  MCP_UI_RESOURCE_MIME_TYPE,
+} from "@mcpjam/sdk/browser";
 import { hostSupportsWidgetRendering } from "../host-capabilities";
 
 describe("hostSupportsWidgetRendering", () => {
@@ -42,11 +45,43 @@ describe("hostSupportsWidgetRendering", () => {
     ).toBe(false);
   });
 
-  it("returns true even when the extension entry is an empty object", () => {
-    // Presence of the key is the contract; value is opaque here. SDK
-    // ships `{ mimeTypes: [...] }` but profiles MAY emit a bare `{}`.
+  it("returns false when the extension entry has no mimeTypes (SEP-1865 strictness)", () => {
+    // Behavioral change: per SEP-1865, the extension MUST advertise
+    // `mimeTypes` including `text/html;profile=mcp-app`. Hand-crafted
+    // minimal blobs like `{ extensions: { [id]: {} } }` no longer count.
+    // The SDK default ships the correct shape, so default-using hosts
+    // (Claude/ChatGPT/MCPJam/Copilot templates) are unaffected.
     const caps = { extensions: { [MCP_UI_EXTENSION_ID]: {} } };
+    expect(hostSupportsWidgetRendering(caps)).toBe(false);
+  });
+
+  it("returns false when mimeTypes is present but doesn't include the spec mime", () => {
+    const caps = {
+      extensions: {
+        [MCP_UI_EXTENSION_ID]: { mimeTypes: ["application/json"] },
+      },
+    };
+    expect(hostSupportsWidgetRendering(caps)).toBe(false);
+  });
+
+  it("returns true when mimeTypes contains the spec mime alongside others", () => {
+    const caps = {
+      extensions: {
+        [MCP_UI_EXTENSION_ID]: {
+          mimeTypes: ["application/json", MCP_UI_RESOURCE_MIME_TYPE],
+        },
+      },
+    };
     expect(hostSupportsWidgetRendering(caps)).toBe(true);
+  });
+
+  it("returns false when mimeTypes is a non-array", () => {
+    const caps = {
+      extensions: {
+        [MCP_UI_EXTENSION_ID]: { mimeTypes: MCP_UI_RESOURCE_MIME_TYPE },
+      },
+    };
+    expect(hostSupportsWidgetRendering(caps)).toBe(false);
   });
 
   it("ignores unrelated extensions", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/host-capabilities.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/host-capabilities.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { MCP_UI_EXTENSION_ID } from "@mcpjam/sdk/browser";
+import { hostSupportsWidgetRendering } from "../host-capabilities";
+
+describe("hostSupportsWidgetRendering", () => {
+  it("returns true when the MCP UI extension is advertised", () => {
+    const caps = {
+      extensions: {
+        [MCP_UI_EXTENSION_ID]: { mimeTypes: ["text/html;profile=mcp-app"] },
+      },
+    };
+    expect(hostSupportsWidgetRendering(caps)).toBe(true);
+  });
+
+  it("returns true when the host config is absent (undefined)", () => {
+    // Default for legacy surfaces / tests without an activeHost in scope —
+    // preserve historical behavior (gate falls back to tool-metadata only).
+    expect(hostSupportsWidgetRendering(undefined)).toBe(true);
+  });
+
+  it("returns false when extensions is missing", () => {
+    expect(hostSupportsWidgetRendering({ elicitation: {} })).toBe(false);
+  });
+
+  it("returns false when the UI extension is explicitly stripped (Codex)", () => {
+    // Mirrors the Codex template in client-templates.ts:803-810, which
+    // REPLACES clientCapabilities (no spread) so the SDK-default UI
+    // extension is gone.
+    const codex = { elicitation: {} };
+    expect(hostSupportsWidgetRendering(codex)).toBe(false);
+  });
+
+  it("returns false when extensions is non-object (defensive)", () => {
+    expect(
+      hostSupportsWidgetRendering({ extensions: "nope" as unknown as object }),
+    ).toBe(false);
+    expect(
+      hostSupportsWidgetRendering({ extensions: null as unknown as object }),
+    ).toBe(false);
+    expect(
+      hostSupportsWidgetRendering({ extensions: [] as unknown as object }),
+    ).toBe(false);
+  });
+
+  it("returns true even when the extension entry is an empty object", () => {
+    // Presence of the key is the contract; value is opaque here. SDK
+    // ships `{ mimeTypes: [...] }` but profiles MAY emit a bare `{}`.
+    const caps = { extensions: { [MCP_UI_EXTENSION_ID]: {} } };
+    expect(hostSupportsWidgetRendering(caps)).toBe(true);
+  });
+
+  it("ignores unrelated extensions", () => {
+    const caps = {
+      extensions: { "vendor/some-other-ext": { enabled: true } },
+    };
+    expect(hostSupportsWidgetRendering(caps)).toBe(false);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/host-capabilities.ts
+++ b/mcpjam-inspector/client/src/lib/host-capabilities.ts
@@ -32,7 +32,7 @@ import { MCP_UI_EXTENSION_ID } from "@mcpjam/sdk/browser";
  * a host at all.
  */
 export function hostSupportsWidgetRendering(
-  clientCapabilities: Record<string, unknown> | undefined,
+  clientCapabilities: Record<string, unknown> | undefined
 ): boolean {
   if (clientCapabilities === undefined) return true;
   const extensions = clientCapabilities.extensions;

--- a/mcpjam-inspector/client/src/lib/host-capabilities.ts
+++ b/mcpjam-inspector/client/src/lib/host-capabilities.ts
@@ -1,0 +1,45 @@
+import { MCP_UI_EXTENSION_ID } from "@mcpjam/sdk/browser";
+
+/**
+ * Decide whether the active host can render widget iframes for UI-bearing
+ * tools.
+ *
+ * Today's signal: the host's `clientCapabilities` blob advertises the MCP
+ * UI extension (`extensions["io.modelcontextprotocol/ui"]`). Hosts that
+ * keep the SDK-default extension (Claude, ChatGPT, MCPJam, …) render
+ * widgets; hosts that explicitly strip it (Codex — elicitation-only CLI)
+ * fall through to the plain tool-result row.
+ *
+ * **Why `clientCapabilities` and not `hostStyle`:** users edit
+ * `clientCapabilities` directly in the host editor. A user who wants to
+ * model "ChatGPT but without UI support" must be able to remove the
+ * extension and have the render gate honor that. Inferring from
+ * `hostStyle` would silently override their edit.
+ *
+ * **Transitional gap:** the OpenAI Apps SDK (`window.openai`) is a
+ * separate rendering protocol not yet represented by a capability flag.
+ * In practice every Apps-SDK host we ship today (ChatGPT, Copilot)
+ * KEEPS the MCP UI extension in their template, so the extension check
+ * covers them. Codex strips the extension and is correctly excluded.
+ * A future explicit "window.openai" flag on `HostConfigInputV2` will
+ * subsume this branch — see the TODO at the OR site in the caller.
+ *
+ * **`undefined` semantics:** when called with `undefined` (no active host
+ * in scope), returns `true`. Surfaces without `activeHost` plumbing
+ * (legacy chat tabs, tests) preserve their historical "tool metadata is
+ * the only gate" behavior. The intent is to RESTRICT capable hosts'
+ * rendering when they opt out, not to break surfaces that don't model
+ * a host at all.
+ */
+export function hostSupportsWidgetRendering(
+  clientCapabilities: Record<string, unknown> | undefined,
+): boolean {
+  if (clientCapabilities === undefined) return true;
+  const extensions = clientCapabilities.extensions;
+  if (!isRecord(extensions)) return false;
+  return MCP_UI_EXTENSION_ID in extensions;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}

--- a/mcpjam-inspector/client/src/lib/host-capabilities.ts
+++ b/mcpjam-inspector/client/src/lib/host-capabilities.ts
@@ -1,14 +1,26 @@
-import { MCP_UI_EXTENSION_ID } from "@mcpjam/sdk/browser";
+import {
+  MCP_UI_EXTENSION_ID,
+  MCP_UI_RESOURCE_MIME_TYPE,
+} from "@mcpjam/sdk/browser";
 
 /**
  * Decide whether the active host can render widget iframes for UI-bearing
  * tools.
  *
- * Today's signal: the host's `clientCapabilities` blob advertises the MCP
- * UI extension (`extensions["io.modelcontextprotocol/ui"]`). Hosts that
- * keep the SDK-default extension (Claude, ChatGPT, MCPJam, …) render
- * widgets; hosts that explicitly strip it (Codex — elicitation-only CLI)
- * fall through to the plain tool-result row.
+ * Today's signal: SEP-1865-conformant advertisement of the MCP UI
+ * extension. Specifically, `clientCapabilities.extensions[MCP_UI_EXTENSION_ID]`
+ * must be an object whose `mimeTypes` array includes
+ * `"text/html;profile=mcp-app"`. The SDK default
+ * (`getDefaultClientCapabilities`) ships exactly this shape, so hosts
+ * that retain the SDK-default extension (Claude, ChatGPT, MCPJam, …)
+ * render widgets. Hosts that explicitly strip it (Codex —
+ * elicitation-only CLI) fall through to the plain tool-result row.
+ *
+ * **Behavioral change since PR #2169 commit 1:** previously the helper
+ * accepted bare `{ extensions: { [MCP_UI_EXTENSION_ID]: {} } }` (no
+ * `mimeTypes` array). After this commit such configs no longer render
+ * widgets — the spec requires the mimeTypes advertisement. Hand-crafted
+ * minimal capability blobs may need to add `mimeTypes: ["text/html;profile=mcp-app"]`.
  *
  * **Why `clientCapabilities` and not `hostStyle`:** users edit
  * `clientCapabilities` directly in the host editor. A user who wants to
@@ -37,7 +49,11 @@ export function hostSupportsWidgetRendering(
   if (clientCapabilities === undefined) return true;
   const extensions = clientCapabilities.extensions;
   if (!isRecord(extensions)) return false;
-  return MCP_UI_EXTENSION_ID in extensions;
+  const uiExt = extensions[MCP_UI_EXTENSION_ID];
+  if (!isRecord(uiExt)) return false;
+  const mimeTypes = uiExt.mimeTypes;
+  if (!Array.isArray(mimeTypes)) return false;
+  return mimeTypes.includes(MCP_UI_RESOURCE_MIME_TYPE);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/mcpjam-inspector/client/src/state/app-state-context.tsx
+++ b/mcpjam-inspector/client/src/state/app-state-context.tsx
@@ -24,3 +24,14 @@ export function useSharedAppState(): AppState {
   }
   return ctx;
 }
+
+/**
+ * Non-throwing variant for surfaces that may legitimately render outside
+ * an `AppStateProvider` (test fixtures, isolated previews, transient
+ * bootstrap). Returns `null` instead of throwing — callers MUST handle
+ * the absence themselves. Use sparingly; prefer
+ * {@link useSharedAppState} when the provider is guaranteed.
+ */
+export function useOptionalSharedAppState(): AppState | null {
+  return useContext(AppStateContext);
+}

--- a/mcpjam-inspector/client/vitest.config.ts
+++ b/mcpjam-inspector/client/vitest.config.ts
@@ -22,6 +22,11 @@ const mcpSdkSharedAuthEntry = path.resolve(
 export default defineConfig({
   define: {
     __MCPJAM_SDK_VERSION__: JSON.stringify("test"),
+    // Mirrors the Vite build-time constant injected into `client-templates`
+    // and `mcp-apps-renderer`. Tests that exercise the host-style seed
+    // (e.g. via the render-gate scope wrapper) need this defined or the
+    // codex/mcpjam templates throw a `ReferenceError`.
+    __APP_VERSION__: JSON.stringify("test"),
   },
   plugins: [
     {


### PR DESCRIPTION
## Summary

Tie the widget-render gate to the **same** `resolveEffectiveClientCapabilities` function the connect path uses for `initialize`. Host-level + per-server overrides now affect the renderer exactly as they affect `initialize`, so the two cannot drift. Closes the four TL findings on the previous revision of this PR (#2169 review).

## What changed (per-commit)

1. **Reshape context: value → resolver** (`2ce6e889c`).
   The `ActiveHostClientCapabilities*` exports become `ActiveHostCapsResolver*`. The context now holds a `(serverId?: string) => caps` resolver. Behavior unchanged in this commit (the resolver still returns host-level caps only).
2. **Per-server gate + SEP-1865 tightening** (`a6646732f`). The TL-blocking fix.
   The resolver reads `appState.servers[serverId]?.config` (via new non-throwing `useOptionalSharedAppState`) and feeds `{ host, serverConfig }` into `resolveEffectiveClientCapabilities`. The helper now requires `extensions[MCP_UI_EXTENSION_ID].mimeTypes` to include `text/html;profile=mcp-app`.
3. **Playground + trace replays + rebase** (`e7b8d1eab`).
   `PlaygroundRoute` threads `activeHost` to `PlaygroundTab`; precedence is `previewedHost ?? activeHost`. `TraceViewer` self-wraps its `<Thread>` mount in `ActiveHostCapsResolverScope` (current-active-host semantics, not recorded-host). Adds `__APP_VERSION__` to `vitest.config.ts`. Updates the changeset.

## Two behavioral decisions worth flagging

1. **Per-server cap overrides can re-enable widgets on a no-UI host.** A server explicitly advertising the UI extension renders widgets even under Codex — server-level override beats host identity, matching the precedence in `resolveEffectiveClientCapabilities` and what the inspector already does at `initialize`. Appropriate for a conformance/test surface.
2. **SEP-1865 tightening is a breaking change for hand-crafted configs.** `{ extensions: { [id]: {} } }` (no `mimeTypes`) used to render widgets; now it doesn't. The SDK default ships `mimeTypes: ["text/html;profile=mcp-app"]`, so default-using hosts (Claude / ChatGPT / Copilot / MCPJam / Cursor) are unaffected.

## Verified

| Surface | Host | Server caps | Expected | Result |
|---|---|---|---|---|
| Chat (chat-v2 / playground routing) | Codex | default | No widget | ✅ |
| Chat | ChatGPT | default | Widget renders | ✅ |
| Chat | ChatGPT | server strips UI | No widget for that server | ✅ (covered by resolver tests) |
| Chat | Codex | server adds UI | Widget renders for that server | ✅ (covered by resolver tests) |
| Tools tab | Codex | default | "Use App Builder" banner absent | ✅ |
| Tools tab | ChatGPT | default | Banner present | ✅ |
| TraceViewer | Switch to Codex while viewing recorded trace | n/a | Widget hides in replay | ✅ (scope wraps Thread; gates on current host) |
| Hosted chatbox link | Codex-styled chatbox | n/a | No widget (template-seed fallback) | ✅ |
| Hosted chatbox link | ChatGPT-styled chatbox | n/a | Widget renders | ✅ |
| Custom config `{ extensions: { [id]: {} } }` | any | default | No widget (SEP-1865 strictness) | ✅ |

## Test plan

- [x] `client/src/lib/__tests__/host-capabilities.test.ts` — 10 cases (4 new for mimeTypes contract)
- [x] `client/src/contexts/__tests__/active-host-caps-resolver.test.tsx` — 6 new resolver scenarios (host-only, server strips UI, server adds UI on Codex, additive `capabilities` merge, unknown serverId, null-host template-seed synthesis)
- [x] `PartSwitch.test.tsx`, `widget-replay.test.tsx`, `ResultsPanel.test.tsx`, `ClientStyledChatTabV2.test.tsx` updated for resolver shape
- [x] `App.hosted-oauth.test.tsx` mock includes new `useOptionalSharedAppState`
- [x] **3089 client tests** pass (full sweep)
- [x] Client typecheck clean
- [x] Branch rebased on `origin/main` (absorbs PRs #2166–#2172 including Bug 2's live-fetch-on-revisit fix)

## Files changed

| Area | File |
|---|---|
| Resolver context | `client/src/contexts/active-host-client-capabilities-context.tsx` |
| New non-throwing hook | `client/src/state/app-state-context.tsx` |
| Helper | `client/src/lib/host-capabilities.ts` |
| Render gate | `client/src/components/chat-v2/thread/part-switch.tsx`, `widget-replay.tsx` |
| Tools banner gate | `client/src/components/tools/ResultsPanel.tsx`, `client/src/components/ToolsTab.tsx` |
| Surface scope wraps | `ClientStyledChatTabV2.tsx`, `playground/PlaygroundTab.tsx`, `hosted/ChatboxChatPage.tsx`, `App.tsx` (ToolsRoute + PlaygroundRoute) |
| Trace gate | `client/src/components/evals/trace-viewer.tsx` |
| Test config | `client/vitest.config.ts` (`__APP_VERSION__` define) |
| Changeset | `.changeset/codex-render-gate.md` |

## Follow-ups (out of scope, file at merge)

- **Hosted bootstrap payload extension** — extend `ChatboxBootstrapPayload` and the Convex redeem mutation to carry `clientCapabilities` (top-level + per-server) so chatbox owners' custom capability edits flow to the published runtime. Until then, hosted gates against the template seed for the chatbox's host style.
- **Drop the `seedFromHostTemplate` fallback in `ChatboxChatPage`** once the bootstrap-payload extension ships and all minted links carry the new fields.
- **Plumb `activeHost` into eval routes** (`CiEvalsTab`, `iteration-details`, `compare-run-chat-surface`, etc.) so trace replays can honor user-edited host capabilities instead of falling back to the template seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core widget-rendering decision across chat/tools/trace/playground based on resolved `clientCapabilities`, which could unexpectedly hide UI for hosts with custom/incorrect capability blobs or server overrides.
> 
> **Overview**
> **Widget rendering is now gated by effective host `clientCapabilities` instead of tool metadata alone.** A new `ActiveHostCapsResolverScope` provides a per-server resolver (using `resolveEffectiveClientCapabilities`) and chat render paths (`PartSwitch`, `WidgetReplay`) now require the MCP UI extension to be advertised before mounting widgets.
> 
> This gate is applied across more surfaces (Tools route/banner, Playground, hosted chatbox, and TraceViewer replays) so switching to a host like Codex suppresses widgets consistently, while per-server `clientCapabilities` overrides can explicitly re-enable/disable widgets at render time.
> 
> Adds a stricter SEP-1865 check via `hostSupportsWidgetRendering` (requires `extensions["io.modelcontextprotocol/ui"].mimeTypes` to include `text/html;profile=mcp-app`), plus supporting test updates/new tests and a non-throwing `useOptionalSharedAppState` hook; Vitest now defines `__APP_VERSION__` for template seeding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3da85195d7769cf81e05ecb282111a9de06ff15a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->