### PR TITLE
Prefer live widget fetch over cached HTML on session revisit

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -847,6 +847,170 @@ describe("MCPAppsRenderer tool input streaming", () => {
     });
   });
 
+  it("prefers the live fetch over cached HTML when liveFetchPreferred is set", async () => {
+    render(
+      <MCPAppsRenderer
+        {...baseProps}
+        cachedWidgetHtmlUrl="blob:cached"
+        liveFetchPreferred
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(sandboxedIframePropsRef.current?.html).toBe(
+        "<html><body>live-widget</body></html>",
+      );
+    });
+
+    // authFetch is the live-fetch lever; the cached fetch goes through global.fetch.
+    // Successful live → cached blob URL must not be fetched.
+    expect(vi.mocked(authFetch)).toHaveBeenCalled();
+    expect(vi.mocked(global.fetch)).not.toHaveBeenCalledWith("blob:cached");
+    expect(sandboxedIframePropsRef.current?.permissive).toBe(false);
+  });
+
+  it("falls back to cached HTML when the live fetch throws (e.g. server disconnected)", async () => {
+    vi.mocked(authFetch).mockRejectedValueOnce(
+      new Error('Hosted server not found for "server-1"'),
+    );
+
+    render(
+      <MCPAppsRenderer
+        {...baseProps}
+        cachedWidgetHtmlUrl="blob:cached"
+        liveFetchPreferred
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(sandboxedIframePropsRef.current?.html).toBe(
+        "<html><body>widget</body></html>",
+      );
+    });
+
+    // Live attempted, threw, then cached blob fetched.
+    expect(vi.mocked(authFetch)).toHaveBeenCalled();
+    expect(vi.mocked(global.fetch)).toHaveBeenCalledWith("blob:cached");
+    // Cached path forces permissive rendering.
+    expect(sandboxedIframePropsRef.current?.permissive).toBe(true);
+  });
+
+  it("drops stale live-fetch results when the source key has moved on (renderer reuse)", async () => {
+    // Hold the first live fetch open with a controllable promise so we can
+    // simulate the source key changing (e.g. session swap, cspMode toggle,
+    // different toolCallId) before it resolves.
+    let resolveStale!: (response: Response) => void;
+    const staleResponse = new Promise<Response>((r) => {
+      resolveStale = r;
+    });
+    vi.mocked(authFetch).mockImplementationOnce(() => staleResponse);
+
+    const { rerender } = render(
+      <MCPAppsRenderer
+        {...baseProps}
+        toolCallId="call-stale"
+        cachedWidgetHtmlUrl="blob:cached"
+        liveFetchPreferred
+      />,
+    );
+
+    // Wait for the stale fetch to start.
+    await vi.waitFor(() => {
+      expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(1);
+    });
+
+    // Re-render with a new toolCallId. This rotates the source-identity key.
+    // A second live fetch is queued for the new key; we let it resolve
+    // normally with the default authFetch mock.
+    rerender(
+      <MCPAppsRenderer
+        {...baseProps}
+        toolCallId="call-fresh"
+        cachedWidgetHtmlUrl="blob:cached"
+        liveFetchPreferred
+      />,
+    );
+
+    // Wait for the fresh fetch to complete and paint the sandbox.
+    await vi.waitFor(() => {
+      expect(sandboxedIframePropsRef.current?.html).toBe(
+        "<html><body>live-widget</body></html>",
+      );
+    });
+
+    // Now resolve the *stale* fetch with a different payload. The renderer
+    // must drop it — the iframe must keep showing the fresh HTML.
+    await act(async () => {
+      resolveStale({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            html: "<html><body>STALE-CONTENT</body></html>",
+            csp: null,
+            permissions: null,
+            permissive: true,
+            mimeTypeValid: true,
+            prefersBorder: true,
+          }),
+        status: 200,
+        headers: new Headers(),
+      } as Response);
+      // Flush microtasks so any guarded setState would have committed.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(sandboxedIframePropsRef.current?.html).toBe(
+      "<html><body>live-widget</body></html>",
+    );
+    expect(sandboxedIframePropsRef.current?.html).not.toContain(
+      "STALE-CONTENT",
+    );
+  });
+
+  it("does not fall back to cached HTML when the live fetch returns an invalid mimetype", async () => {
+    // Server reachable but template misconfigured — invalid mimetype is a
+    // content error, not a transport error. The renderer must surface it
+    // and not silently mask it with stale cached HTML.
+    vi.mocked(authFetch).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          html: "<html><body>live-widget</body></html>",
+          csp: null,
+          permissions: null,
+          permissive: false,
+          mimeTypeValid: false,
+          mimeTypeWarning:
+            'Resource served as "text/html" but SEP-1865 requires "text/html;profile=mcp-app"',
+          prefersBorder: true,
+        }),
+      status: 200,
+      headers: new Headers(),
+    } as Response);
+
+    render(
+      <MCPAppsRenderer
+        {...baseProps}
+        cachedWidgetHtmlUrl="blob:cached"
+        liveFetchPreferred
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByText(/SEP-1865 requires/i),
+      ).toBeInTheDocument();
+    });
+
+    // Cached blob must NOT be fetched on invalid mimetype.
+    expect(vi.mocked(global.fetch)).not.toHaveBeenCalledWith("blob:cached");
+    // No widget HTML should have made it to the sandbox — the renderer is
+    // showing the error UI in place of the iframe, so `html` is either null
+    // (iframe still mounted but unset) or the iframe is not mounted at all.
+    expect(sandboxedIframePropsRef.current?.html ?? null).toBeNull();
+  });
+
   it("waits for the bridge transport before loading widget HTML into the sandbox", async () => {
     let resolveConnect: (() => void) | undefined;
     mockBridge.connect.mockImplementation(

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -560,6 +560,14 @@ export function MCPAppsRenderer({
   toolOutputRef.current = toolOutput;
   const themeModeRef = useRef(themeMode);
 
+  // Source-identity guard for the async fetch effect. The renderer can be
+  // reused across session swaps and prop changes, so an older fetch can
+  // resolve after `{ toolCallId, resourceUri, cachedWidgetHtmlUrl, cspMode,
+  // liveFetchPreferred }` has moved on. Each effect run sets this ref to
+  // its own key; the helpers below drop any state writes that don't still
+  // match the latest key.
+  const latestFetchSourceKeyRef = useRef<string>("");
+
   const {
     canRenderStreamingInput,
     signalStreamingRender,
@@ -588,6 +596,20 @@ export function MCPAppsRenderer({
     // Re-fetch if CSP mode changed (widget needs to reload with new CSP policy)
     if (widgetHtml && loadedCspMode === cspMode) return;
 
+    // Source-identity key for this run. Any in-flight fetch whose key no
+    // longer matches `latestFetchSourceKeyRef.current` when it resolves is
+    // stale and MUST NOT mutate state.
+    const fetchSourceKey = [
+      toolCallId,
+      resourceUri ?? "",
+      cachedWidgetHtmlUrl ?? "",
+      cspMode,
+      liveFetchPreferred ? "live-pref" : "",
+    ].join("|");
+    latestFetchSourceKeyRef.current = fetchSourceKey;
+    const isStillCurrent = () =>
+      latestFetchSourceKeyRef.current === fetchSourceKey;
+
     // Throws on failure. Caller is responsible for surfacing the error.
     const loadFromCachedUrl = async (cachedUrl: string) => {
       const cachedResponse = await fetch(cachedUrl);
@@ -597,6 +619,7 @@ export function MCPAppsRenderer({
         );
       }
       const html = await cachedResponse.text();
+      if (!isStillCurrent()) return;
       // Reset readiness so the previous bridge's transport doesn't
       // get reused with the new HTML before its connect resolves.
       setBridgeTransportReady(false);
@@ -648,6 +671,11 @@ export function MCPAppsRenderer({
         theme: themeModeRef.current,
         cspMode,
       });
+
+      // Stale fetch: source key moved on (e.g. session swap, CSP toggle,
+      // tool call change) while this request was in flight. Drop the
+      // result so it can't overwrite the newer commit's state.
+      if (!isStillCurrent()) return true;
 
       if (!valid) {
         const errorMessage =
@@ -762,6 +790,7 @@ export function MCPAppsRenderer({
 
         await loadFromLiveFetch();
       } catch (err) {
+        if (!isStillCurrent()) return;
         const errorMessage =
           err instanceof Error ? err.message : "Failed to prepare widget";
         setLoadError(errorMessage);

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -205,6 +205,14 @@ interface MCPAppsRendererProps {
   isOffline?: boolean;
   /** URL to cached widget HTML for offline rendering */
   cachedWidgetHtmlUrl?: string;
+  /**
+   * If true, attempt the live MCP Apps fetch first and only fall back to
+   * `cachedWidgetHtmlUrl` if the live fetch fails (e.g. the server is no
+   * longer connected). Used by in-flow session revisit; persisted offline
+   * replay (Views tab, eval traces) leaves this unset so the cached path
+   * stays primary.
+   */
+  liveFetchPreferred?: boolean;
   /** Persisted CSP metadata for cached/offline replay */
   widgetCsp?: McpUiResourceCsp | null;
   /** Persisted permissions metadata for cached/offline replay */
@@ -252,6 +260,7 @@ export function MCPAppsRenderer({
   onAppSupportedDisplayModesChange,
   isOffline,
   cachedWidgetHtmlUrl,
+  liveFetchPreferred,
   widgetCsp: initialWidgetCsp,
   widgetPermissions: initialWidgetPermissions,
   widgetPermissive: initialWidgetPermissive,
@@ -579,41 +588,163 @@ export function MCPAppsRenderer({
     // Re-fetch if CSP mode changed (widget needs to reload with new CSP policy)
     if (widgetHtml && loadedCspMode === cspMode) return;
 
+    // Throws on failure. Caller is responsible for surfacing the error.
+    const loadFromCachedUrl = async (cachedUrl: string) => {
+      const cachedResponse = await fetch(cachedUrl);
+      if (!cachedResponse.ok) {
+        throw new Error(
+          `Failed to fetch cached widget HTML: ${cachedResponse.statusText}`,
+        );
+      }
+      const html = await cachedResponse.text();
+      // Reset readiness so the previous bridge's transport doesn't
+      // get reused with the new HTML before its connect resolves.
+      setBridgeTransportReady(false);
+      setWidgetHtml(html);
+      setWidgetCsp(undefined);
+      setWidgetPermissions(undefined);
+      setWidgetPermissive(true);
+      setPrefersBorder(initialPrefersBorder ?? true);
+      setLoadedCspMode(cspMode);
+      setWidgetHtmlStore(toolCallId, html);
+      logWidgetDebug("host-to-ui", "debug/widget-content-ready", {
+        cached: true,
+        cspMode,
+        htmlLength: html.length,
+        permissive: true,
+      });
+    };
+
+    // Throws on failure. Returns true on success, false if the server
+    // returned an invalid mimetype (which is a content error — caller
+    // should surface it and NOT fall back to a cached blob).
+    const loadFromLiveFetch = async (): Promise<boolean> => {
+      const {
+        html,
+        csp,
+        permissions,
+        permissive,
+        mimeTypeWarning: warning,
+        mimeTypeValid: valid,
+        prefersBorder,
+      } = await fetchMcpAppsWidgetContent({
+        serverId,
+        resourceUri,
+        toolInput: toolInputRef.current,
+        toolOutput: toolOutputRef.current,
+        // Surface `_meta` from the tool response so the compat runtime
+        // can expose it as `window.openai.toolResponseMetadata`. Prefer
+        // the explicit `toolResponseMetadata` prop (which the caller
+        // computes from rawOutput where the `{ value, _meta }` wrapper
+        // is still intact); fall back to deriving from the resolved
+        // output for callers that don't pass it.
+        toolResponseMetadata:
+          toolResponseMetadata ??
+          readToolResultMeta(toolOutputRef.current) ??
+          null,
+        initialWidgetState,
+        toolId: toolCallId,
+        toolName,
+        theme: themeModeRef.current,
+        cspMode,
+      });
+
+      if (!valid) {
+        const errorMessage =
+          warning ||
+          `Invalid mimetype - SEP-1865 requires "text/html;profile=mcp-app"`;
+        setLoadError(errorMessage);
+        logWidgetDebug(
+          "host-to-ui",
+          "debug/widget-content-invalid-mimetype",
+          { cspMode, error: errorMessage },
+        );
+        return false;
+      }
+
+      // Reset readiness so the previous bridge's transport doesn't get
+      // reused with the new HTML before its connect resolves.
+      setBridgeTransportReady(false);
+      setWidgetHtml(html);
+      setWidgetCsp(csp);
+      setWidgetPermissions(permissions);
+      setWidgetPermissive(permissive ?? false);
+      setPrefersBorder(prefersBorder ?? true);
+      setLoadedCspMode(cspMode);
+
+      // Store widget HTML in debug store for save view feature
+      setWidgetHtmlStore(toolCallId, html);
+
+      // Update the widget debug store with CSP and permissions info
+      if (csp || permissions || !permissive) {
+        setWidgetCspStore(toolCallId, {
+          mode: permissive ? "permissive" : "widget-declared",
+          connectDomains: csp?.connectDomains || [],
+          resourceDomains: csp?.resourceDomains || [],
+          frameDomains: csp?.frameDomains || [],
+          baseUriDomains: csp?.baseUriDomains || [],
+          permissions: permissions,
+          widgetDeclared: csp
+            ? {
+                connectDomains: csp.connectDomains,
+                resourceDomains: csp.resourceDomains,
+                frameDomains: csp.frameDomains,
+                baseUriDomains: csp.baseUriDomains,
+              }
+            : null,
+        });
+      }
+      logWidgetDebug("host-to-ui", "debug/widget-content-ready", {
+        cached: false,
+        cspMode,
+        hasCsp: !!csp,
+        hasPermissions: !!permissions,
+        htmlLength: html.length,
+        permissive: permissive ?? false,
+        prefersBorder: prefersBorder ?? true,
+      });
+      return true;
+    };
+
     const fetchWidgetHtml = async () => {
       try {
         logWidgetDebug("host-to-ui", "debug/widget-content-requested", {
           cachedWidgetHtmlUrl: cachedWidgetHtmlUrl ?? null,
           cspMode,
           isOffline: !!isOffline,
+          liveFetchPreferred: !!liveFetchPreferred,
           resourceUri,
           toolState: toolState ?? null,
         });
-        // Use cached widget HTML whenever available (faster and works offline)
-        // This is for the Views tab offline rendering
-        if (cachedWidgetHtmlUrl) {
-          const cachedResponse = await fetch(cachedWidgetHtmlUrl);
-          if (!cachedResponse.ok) {
-            throw new Error(
-              `Failed to fetch cached widget HTML: ${cachedResponse.statusText}`,
+
+        // In-flow session revisit: try the live MCP Apps fetch first so the
+        // widget re-renders against the active host's current CSP / bridge
+        // state. If the server is no longer connected (or live fetch fails
+        // for any reason), fall back to the cached snapshot HTML.
+        if (liveFetchPreferred && cachedWidgetHtmlUrl) {
+          try {
+            await loadFromLiveFetch();
+            return;
+          } catch (liveErr) {
+            logWidgetDebug(
+              "host-to-ui",
+              "debug/widget-content-live-fallback",
+              {
+                error:
+                  liveErr instanceof Error
+                    ? liveErr.message
+                    : String(liveErr),
+              },
             );
+            await loadFromCachedUrl(cachedWidgetHtmlUrl);
+            return;
           }
-          const html = await cachedResponse.text();
-          // Reset readiness so the previous bridge's transport doesn't
-          // get reused with the new HTML before its connect resolves.
-          setBridgeTransportReady(false);
-          setWidgetHtml(html);
-          setWidgetCsp(undefined);
-          setWidgetPermissions(undefined);
-          setWidgetPermissive(true);
-          setPrefersBorder(initialPrefersBorder ?? true);
-          setLoadedCspMode(cspMode);
-          setWidgetHtmlStore(toolCallId, html);
-          logWidgetDebug("host-to-ui", "debug/widget-content-ready", {
-            cached: true,
-            cspMode,
-            htmlLength: html.length,
-            permissive: true,
-          });
+        }
+
+        // Persisted offline replay (Views tab, eval traces, openai-apps
+        // revisit): cached HTML is the only source.
+        if (cachedWidgetHtmlUrl) {
+          await loadFromCachedUrl(cachedWidgetHtmlUrl);
           return;
         }
 
@@ -629,89 +760,7 @@ export function MCPAppsRenderer({
           return;
         }
 
-        const {
-          html,
-          csp,
-          permissions,
-          permissive,
-          mimeTypeWarning: warning,
-          mimeTypeValid: valid,
-          prefersBorder,
-        } = await fetchMcpAppsWidgetContent({
-          serverId,
-          resourceUri,
-          toolInput: toolInputRef.current,
-          toolOutput: toolOutputRef.current,
-          // Surface `_meta` from the tool response so the compat runtime
-          // can expose it as `window.openai.toolResponseMetadata`. Prefer
-          // the explicit `toolResponseMetadata` prop (which the caller
-          // computes from rawOutput where the `{ value, _meta }` wrapper
-          // is still intact); fall back to deriving from the resolved
-          // output for callers that don't pass it.
-          toolResponseMetadata:
-            toolResponseMetadata ??
-            readToolResultMeta(toolOutputRef.current) ??
-            null,
-          initialWidgetState,
-          toolId: toolCallId,
-          toolName,
-          theme: themeModeRef.current,
-          cspMode,
-        });
-
-        if (!valid) {
-          const errorMessage =
-            warning ||
-            `Invalid mimetype - SEP-1865 requires "text/html;profile=mcp-app"`;
-          setLoadError(errorMessage);
-          logWidgetDebug("host-to-ui", "debug/widget-content-invalid-mimetype", {
-            cspMode,
-            error: errorMessage,
-          });
-          return;
-        }
-
-        // Reset readiness so the previous bridge's transport doesn't get
-        // reused with the new HTML before its connect resolves.
-        setBridgeTransportReady(false);
-        setWidgetHtml(html);
-        setWidgetCsp(csp);
-        setWidgetPermissions(permissions);
-        setWidgetPermissive(permissive ?? false);
-        setPrefersBorder(prefersBorder ?? true);
-        setLoadedCspMode(cspMode);
-
-        // Store widget HTML in debug store for save view feature
-        setWidgetHtmlStore(toolCallId, html);
-
-        // Update the widget debug store with CSP and permissions info
-        if (csp || permissions || !permissive) {
-          setWidgetCspStore(toolCallId, {
-            mode: permissive ? "permissive" : "widget-declared",
-            connectDomains: csp?.connectDomains || [],
-            resourceDomains: csp?.resourceDomains || [],
-            frameDomains: csp?.frameDomains || [],
-            baseUriDomains: csp?.baseUriDomains || [],
-            permissions: permissions,
-            widgetDeclared: csp
-              ? {
-                  connectDomains: csp.connectDomains,
-                  resourceDomains: csp.resourceDomains,
-                  frameDomains: csp.frameDomains,
-                  baseUriDomains: csp.baseUriDomains,
-                }
-              : null,
-          });
-        }
-        logWidgetDebug("host-to-ui", "debug/widget-content-ready", {
-          cached: false,
-          cspMode,
-          hasCsp: !!csp,
-          hasPermissions: !!permissions,
-          htmlLength: html.length,
-          permissive: permissive ?? false,
-          prefersBorder: prefersBorder ?? true,
-        });
+        await loadFromLiveFetch();
       } catch (err) {
         const errorMessage =
           err instanceof Error ? err.message : "Failed to prepare widget";
@@ -736,6 +785,7 @@ export function MCPAppsRenderer({
     cspMode,
     isOffline,
     cachedWidgetHtmlUrl,
+    liveFetchPreferred,
     initialPrefersBorder,
   ]);
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/persisted-execution-replay.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/persisted-execution-replay.ts
@@ -16,6 +16,8 @@ export interface PersistedExecutionReplayInput {
   serverId: string;
   isOffline: boolean;
   cachedWidgetHtmlUrl?: string;
+  /** See ToolRenderOverride.liveFetchPreferred. */
+  liveFetchPreferred?: boolean;
   resourceUri?: string;
   initialWidgetState?: unknown;
   widgetCsp?: McpUiResourceCsp | null;
@@ -50,6 +52,7 @@ export function buildPersistedExecutionReplay(
       serverId: input.serverId,
       isOffline: input.isOffline,
       cachedWidgetHtmlUrl: input.cachedWidgetHtmlUrl,
+      liveFetchPreferred: input.liveFetchPreferred,
       toolOutput: input.toolOutput,
       initialWidgetState:
         input.protocol === "openai-apps" ? input.initialWidgetState : undefined,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/tool-render-overrides.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/tool-render-overrides.ts
@@ -7,6 +7,18 @@ export interface ToolRenderOverride {
   serverId?: string;
   isOffline?: boolean;
   cachedWidgetHtmlUrl?: string;
+  /**
+   * Try the live MCP Apps fetch path before falling back to
+   * `cachedWidgetHtmlUrl`. Used by in-flow session revisit so the widget
+   * re-renders against the active host's current CSP / bridge state when the
+   * server is still reachable, while still surviving server disconnect by
+   * falling back to the cached snapshot HTML.
+   *
+   * When unset (the default), the cached path is taken whenever
+   * `cachedWidgetHtmlUrl` is present — matching the original offline-replay
+   * semantics used by the Views tab and persisted eval traces.
+   */
+  liveFetchPreferred?: boolean;
   toolOutput?: unknown;
   initialWidgetState?: unknown;
   resourceUri?: string;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/widget-replay.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/widget-replay.tsx
@@ -167,6 +167,7 @@ export function WidgetReplay({
       onAppSupportedDisplayModesChange={onAppSupportedDisplayModesChange}
       isOffline={renderOverride?.isOffline}
       cachedWidgetHtmlUrl={renderOverride?.cachedWidgetHtmlUrl}
+      liveFetchPreferred={renderOverride?.liveFetchPreferred}
       widgetCsp={renderOverride?.widgetCsp}
       widgetPermissions={renderOverride?.widgetPermissions}
       widgetPermissive={renderOverride?.widgetPermissive}

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer-adapter.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer-adapter.test.ts
@@ -729,7 +729,7 @@ describe("adaptTraceToUiMessages", () => {
   });
 
   describe("buildToolRenderOverridesFromSnapshots / preferLiveWhenPossible", () => {
-    it("strips cached widget URL for mcp-apps snapshots with a resourceUri", () => {
+    it("sets liveFetchPreferred for mcp-apps snapshots with a resourceUri but keeps the cached URL as fallback", () => {
       const overrides = buildToolRenderOverridesFromSnapshots(
         [
           makeWidgetSnapshot({
@@ -744,12 +744,15 @@ describe("adaptTraceToUiMessages", () => {
 
       const override = overrides["call-mcp-live"];
       expect(override).toBeDefined();
-      expect(override.cachedWidgetHtmlUrl).toBeUndefined();
-      expect(override.isOffline).toBe(false);
+      expect(override.liveFetchPreferred).toBe(true);
+      expect(override.cachedWidgetHtmlUrl).toBe(
+        "https://storage.example.com/mcp-widget.html",
+      );
+      expect(override.isOffline).toBe(true);
       expect(override.resourceUri).toBe("ui://widget/create-view.html");
     });
 
-    it("keeps cached widget URL for mcp-apps snapshots without a resourceUri", () => {
+    it("leaves liveFetchPreferred unset for mcp-apps snapshots without a resourceUri", () => {
       const overrides = buildToolRenderOverridesFromSnapshots(
         [
           makeWidgetSnapshot({
@@ -763,13 +766,14 @@ describe("adaptTraceToUiMessages", () => {
       );
 
       const override = overrides["call-mcp-no-uri"];
+      expect(override.liveFetchPreferred).toBe(false);
       expect(override.cachedWidgetHtmlUrl).toBe(
         "https://storage.example.com/no-uri.html",
       );
       expect(override.isOffline).toBe(true);
     });
 
-    it("keeps cached widget URL for openai-apps snapshots even with preferLiveWhenPossible", () => {
+    it("leaves liveFetchPreferred unset for openai-apps snapshots", () => {
       const overrides = buildToolRenderOverridesFromSnapshots(
         [
           makeWidgetSnapshot({
@@ -784,13 +788,14 @@ describe("adaptTraceToUiMessages", () => {
       );
 
       const override = overrides["call-openai"];
+      expect(override.liveFetchPreferred).toBe(false);
       expect(override.cachedWidgetHtmlUrl).toBe(
         "https://storage.example.com/openai-widget.html",
       );
       expect(override.isOffline).toBe(true);
     });
 
-    it("defaults to keeping the cached widget URL (back-compat with persisted offline replay)", () => {
+    it("defaults to liveFetchPreferred=false when the option is not set", () => {
       const overrides = buildToolRenderOverridesFromSnapshots([
         makeWidgetSnapshot({
           toolCallId: "call-default",
@@ -799,13 +804,14 @@ describe("adaptTraceToUiMessages", () => {
       ]);
 
       const override = overrides["call-default"];
+      expect(override.liveFetchPreferred).toBe(false);
       expect(override.cachedWidgetHtmlUrl).toBe(
         "https://storage.example.com/default.html",
       );
       expect(override.isOffline).toBe(true);
     });
 
-    it("leaves isOffline false when there was no cached widget URL to strip", () => {
+    it("sets liveFetchPreferred without a cached fallback when the snapshot has no widget HTML", () => {
       const overrides = buildToolRenderOverridesFromSnapshots(
         [
           makeWidgetSnapshot({
@@ -819,6 +825,7 @@ describe("adaptTraceToUiMessages", () => {
       );
 
       const override = overrides["call-no-url"];
+      expect(override.liveFetchPreferred).toBe(true);
       expect(override.cachedWidgetHtmlUrl).toBeUndefined();
       expect(override.isOffline).toBe(false);
     });

--- a/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer-adapter.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/trace-viewer-adapter.test.ts
@@ -728,6 +728,102 @@ describe("adaptTraceToUiMessages", () => {
     expect(overrides["call-1"].toolOutput).toBeUndefined();
   });
 
+  describe("buildToolRenderOverridesFromSnapshots / preferLiveWhenPossible", () => {
+    it("strips cached widget URL for mcp-apps snapshots with a resourceUri", () => {
+      const overrides = buildToolRenderOverridesFromSnapshots(
+        [
+          makeWidgetSnapshot({
+            toolCallId: "call-mcp-live",
+            protocol: "mcp-apps",
+            resourceUri: "ui://widget/create-view.html",
+            widgetHtmlUrl: "https://storage.example.com/mcp-widget.html",
+          }),
+        ],
+        { preferLiveWhenPossible: true },
+      );
+
+      const override = overrides["call-mcp-live"];
+      expect(override).toBeDefined();
+      expect(override.cachedWidgetHtmlUrl).toBeUndefined();
+      expect(override.isOffline).toBe(false);
+      expect(override.resourceUri).toBe("ui://widget/create-view.html");
+    });
+
+    it("keeps cached widget URL for mcp-apps snapshots without a resourceUri", () => {
+      const overrides = buildToolRenderOverridesFromSnapshots(
+        [
+          makeWidgetSnapshot({
+            toolCallId: "call-mcp-no-uri",
+            protocol: "mcp-apps",
+            resourceUri: undefined,
+            widgetHtmlUrl: "https://storage.example.com/no-uri.html",
+          }),
+        ],
+        { preferLiveWhenPossible: true },
+      );
+
+      const override = overrides["call-mcp-no-uri"];
+      expect(override.cachedWidgetHtmlUrl).toBe(
+        "https://storage.example.com/no-uri.html",
+      );
+      expect(override.isOffline).toBe(true);
+    });
+
+    it("keeps cached widget URL for openai-apps snapshots even with preferLiveWhenPossible", () => {
+      const overrides = buildToolRenderOverridesFromSnapshots(
+        [
+          makeWidgetSnapshot({
+            toolCallId: "call-openai",
+            protocol: "openai-apps",
+            resourceUri: undefined,
+            toolMetadata: { "openai/outputTemplate": "__cached__" },
+            widgetHtmlUrl: "https://storage.example.com/openai-widget.html",
+          }),
+        ],
+        { preferLiveWhenPossible: true },
+      );
+
+      const override = overrides["call-openai"];
+      expect(override.cachedWidgetHtmlUrl).toBe(
+        "https://storage.example.com/openai-widget.html",
+      );
+      expect(override.isOffline).toBe(true);
+    });
+
+    it("defaults to keeping the cached widget URL (back-compat with persisted offline replay)", () => {
+      const overrides = buildToolRenderOverridesFromSnapshots([
+        makeWidgetSnapshot({
+          toolCallId: "call-default",
+          widgetHtmlUrl: "https://storage.example.com/default.html",
+        }),
+      ]);
+
+      const override = overrides["call-default"];
+      expect(override.cachedWidgetHtmlUrl).toBe(
+        "https://storage.example.com/default.html",
+      );
+      expect(override.isOffline).toBe(true);
+    });
+
+    it("leaves isOffline false when there was no cached widget URL to strip", () => {
+      const overrides = buildToolRenderOverridesFromSnapshots(
+        [
+          makeWidgetSnapshot({
+            toolCallId: "call-no-url",
+            protocol: "mcp-apps",
+            resourceUri: "ui://widget/create-view.html",
+            widgetHtmlUrl: undefined,
+          }),
+        ],
+        { preferLiveWhenPossible: true },
+      );
+
+      const override = overrides["call-no-url"];
+      expect(override.cachedWidgetHtmlUrl).toBeUndefined();
+      expect(override.isOffline).toBe(false);
+    });
+  });
+
   it("treats nested result.isError tool-results as output errors", () => {
     const trace: TraceEnvelope = {
       messages: [

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer-adapter.ts
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer-adapter.ts
@@ -120,12 +120,13 @@ export function snapshotsToTraceWidgetSnapshots(
  * but don't need the full adaptTraceToUiMessages pipeline.
  *
  * When `preferLiveWhenPossible` is set, snapshots that have enough information
- * to live-fetch (mcp-apps with a real `resourceUri`) drop the cached widget
- * URL so the renderer goes through the live MCP Apps fetch path against the
- * active host's current CSP / bridge state. OpenAI Apps snapshots (whose
- * `toolMetadata["openai/outputTemplate"]` is `"__cached__"`) and mcp-apps
- * snapshots missing `resourceUri` keep the cached URL because there is no
- * source to live-fetch from.
+ * to live-fetch (mcp-apps with a real `resourceUri`) get `liveFetchPreferred:
+ * true` so the renderer attempts the live MCP Apps path first and only falls
+ * back to the cached snapshot HTML if live fetch fails (e.g., the server is
+ * no longer connected). The cached URL is preserved as the fallback. OpenAI
+ * Apps snapshots (whose `toolMetadata["openai/outputTemplate"]` is
+ * `"__cached__"`) and mcp-apps snapshots missing `resourceUri` cannot
+ * live-fetch, so they stay on the cached path unconditionally.
  */
 export function buildToolRenderOverridesFromSnapshots(
   snapshots: TraceWidgetSnapshot[],
@@ -136,9 +137,7 @@ export function buildToolRenderOverridesFromSnapshots(
   for (const snap of snapshots) {
     const canLiveFetch =
       preferLive && snap.protocol === "mcp-apps" && !!snap.resourceUri;
-    const cachedWidgetHtmlUrl = canLiveFetch
-      ? undefined
-      : (snap.widgetHtmlUrl ?? undefined);
+    const cachedWidgetHtmlUrl = snap.widgetHtmlUrl ?? undefined;
     const replay = buildPersistedExecutionReplay({
       protocol: snap.protocol,
       toolCallId: snap.toolCallId,
@@ -148,6 +147,7 @@ export function buildToolRenderOverridesFromSnapshots(
       serverId: snap.serverId,
       isOffline: !!cachedWidgetHtmlUrl,
       cachedWidgetHtmlUrl,
+      liveFetchPreferred: canLiveFetch,
       resourceUri: snap.resourceUri,
       toolMetadata: snap.toolMetadata,
       widgetCsp: snap.widgetCsp as any,

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer-adapter.ts
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer-adapter.ts
@@ -118,12 +118,27 @@ export function snapshotsToTraceWidgetSnapshots(
  * Build toolRenderOverrides directly from TraceWidgetSnapshot[].
  * Used when loading a persisted session where we have snapshots
  * but don't need the full adaptTraceToUiMessages pipeline.
+ *
+ * When `preferLiveWhenPossible` is set, snapshots that have enough information
+ * to live-fetch (mcp-apps with a real `resourceUri`) drop the cached widget
+ * URL so the renderer goes through the live MCP Apps fetch path against the
+ * active host's current CSP / bridge state. OpenAI Apps snapshots (whose
+ * `toolMetadata["openai/outputTemplate"]` is `"__cached__"`) and mcp-apps
+ * snapshots missing `resourceUri` keep the cached URL because there is no
+ * source to live-fetch from.
  */
 export function buildToolRenderOverridesFromSnapshots(
   snapshots: TraceWidgetSnapshot[],
+  options: { preferLiveWhenPossible?: boolean } = {},
 ): Record<string, ToolRenderOverride> {
+  const preferLive = options.preferLiveWhenPossible ?? false;
   const overrides: Record<string, ToolRenderOverride> = {};
   for (const snap of snapshots) {
+    const canLiveFetch =
+      preferLive && snap.protocol === "mcp-apps" && !!snap.resourceUri;
+    const cachedWidgetHtmlUrl = canLiveFetch
+      ? undefined
+      : (snap.widgetHtmlUrl ?? undefined);
     const replay = buildPersistedExecutionReplay({
       protocol: snap.protocol,
       toolCallId: snap.toolCallId,
@@ -131,8 +146,8 @@ export function buildToolRenderOverridesFromSnapshots(
       toolOutput: snap.toolOutput,
       toolState: "output-available",
       serverId: snap.serverId,
-      isOffline: !!snap.widgetHtmlUrl,
-      cachedWidgetHtmlUrl: snap.widgetHtmlUrl ?? undefined,
+      isOffline: !!cachedWidgetHtmlUrl,
+      cachedWidgetHtmlUrl,
       resourceUri: snap.resourceUri,
       toolMetadata: snap.toolMetadata,
       widgetCsp: snap.widgetCsp as any,

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
@@ -889,6 +889,70 @@ describe("useChatSession hosted mode", () => {
     unmount();
   });
 
+  it("strips cachedWidgetHtmlUrl for mcp-apps revisits but keeps it for openai-apps", async () => {
+    const { result, unmount } = renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1"],
+        hostedContext: {
+          projectId: "project-1",
+          selectedServerIds: ["server-id-1"],
+        },
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSessionBootstrapComplete).toBe(true);
+    });
+
+    await result.current.loadChatSession({
+      chatSessionId: "history-session-revisit",
+      messagesBlobUrl: null,
+      version: 5,
+      widgetSnapshots: [
+        {
+          toolCallId: "tool-call-mcp",
+          toolName: "create_view",
+          serverId: "server-id-1",
+          uiType: "mcp-apps",
+          resourceUri: "ui://excalidraw/mcp-app.html",
+          widgetCsp: null,
+          widgetPermissions: null,
+          widgetPermissive: false,
+          prefersBorder: false,
+          widgetHtmlUrl: "https://storage.example.com/mcp-widget.html",
+        },
+        {
+          toolCallId: "tool-call-openai",
+          toolName: "show_pizzeria",
+          serverId: "server-id-1",
+          uiType: "openai-apps",
+          widgetCsp: null,
+          widgetPermissions: null,
+          widgetPermissive: false,
+          prefersBorder: false,
+          widgetHtmlUrl: "https://storage.example.com/openai-widget.html",
+        },
+      ],
+    });
+
+    await waitFor(() => {
+      const mcp =
+        result.current.restoredToolRenderOverrides["tool-call-mcp"];
+      const openai =
+        result.current.restoredToolRenderOverrides["tool-call-openai"];
+      expect(mcp).toBeDefined();
+      expect(openai).toBeDefined();
+      expect(mcp?.cachedWidgetHtmlUrl).toBeUndefined();
+      expect(mcp?.isOffline).toBe(false);
+      expect(openai?.cachedWidgetHtmlUrl).toBe(
+        "https://storage.example.com/openai-widget.html"
+      );
+      expect(openai?.isOffline).toBe(true);
+    });
+
+    unmount();
+  });
+
   it("keeps even gated hosted models available for authenticated viewers", async () => {
     const { result, unmount } = renderHook(() =>
       useChatSession({

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
@@ -889,7 +889,7 @@ describe("useChatSession hosted mode", () => {
     unmount();
   });
 
-  it("strips cachedWidgetHtmlUrl for mcp-apps revisits but keeps it for openai-apps", async () => {
+  it("sets liveFetchPreferred for mcp-apps revisits but leaves openai-apps on the cached path", async () => {
     const { result, unmount } = renderHook(() =>
       useChatSession({
         selectedServers: ["server-1"],
@@ -942,8 +942,16 @@ describe("useChatSession hosted mode", () => {
         result.current.restoredToolRenderOverrides["tool-call-openai"];
       expect(mcp).toBeDefined();
       expect(openai).toBeDefined();
-      expect(mcp?.cachedWidgetHtmlUrl).toBeUndefined();
-      expect(mcp?.isOffline).toBe(false);
+      // MCP Apps revisit: live-first with cached fallback. Cached URL is
+      // preserved so the renderer can fall back if the server is no longer
+      // connected.
+      expect(mcp?.liveFetchPreferred).toBe(true);
+      expect(mcp?.cachedWidgetHtmlUrl).toBe(
+        "https://storage.example.com/mcp-widget.html"
+      );
+      // OpenAI Apps revisit: cached path only (cannot live-fetch
+      // `outputTemplate = "__cached__"`).
+      expect(openai?.liveFetchPreferred).toBe(false);
       expect(openai?.cachedWidgetHtmlUrl).toBe(
         "https://storage.example.com/openai-widget.html"
       );

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -1835,7 +1835,13 @@ export function useChatSession(
         const traceSnapshots = snapshotsToTraceWidgetSnapshots(
           hydratedWidgetSnapshots
         );
-        overrides = buildToolRenderOverridesFromSnapshots(traceSnapshots);
+        // In-flow session revisit: prefer the live MCP Apps fetch over the
+        // cached snapshot HTML so the widget re-renders against the active
+        // host's current CSP / bridge state. The cached path is kept for
+        // OpenAI Apps and degenerate mcp-apps snapshots that can't live-fetch.
+        overrides = buildToolRenderOverridesFromSnapshots(traceSnapshots, {
+          preferLiveWhenPossible: true,
+        });
       }
 
       const hydratedTurnTraces = await resolveHydratedTurnTraces(


### PR DESCRIPTION
## Summary

Fixes Bug 2 from `HANDOFF-widget-render-bugs.md`: revisiting a previous chat session leaves the MCP Apps widget blank, with the CSP-violation counter jumping from ~2 to ~12. Switching host "fixes" it because re-keying the session clears the cached override.

**Root cause:** every revisit went straight into the offline cached-replay branch. That branch was designed for explicit offline scenarios (Views tab, shared traces, server unreachable). Reusing it for in-flow revisit raced against the `SandboxedIframe` proxy under Strict CSP whenever the renderer was reused across session swaps.

**Fix:** live-first with cached fallback, gated by a new `liveFetchPreferred` flag.

1. `ToolRenderOverride` gains `liveFetchPreferred?: boolean`. The cached URL is **preserved** on the override regardless — it's the fallback, not the primary.
2. `buildToolRenderOverridesFromSnapshots` sets `liveFetchPreferred: true` for snapshots that can actually live-fetch (`protocol === "mcp-apps" && resourceUri`). OpenAI Apps and degenerate mcp-apps snapshots stay on the cached path because `toolMetadata["openai/outputTemplate"] = "__cached__"` cannot be live-fetched.
3. `loadChatSession` opts in via `preferLiveWhenPossible: true`. The eval trace viewer's separate `createReplayOverride` path is unaffected.
4. `MCPAppsRenderer` honors the flag: tries `fetchMcpAppsWidgetContent` first; on **transport error** falls back to the cached snapshot HTML. **Invalid mimetype** is treated as a content error — surfaced, not masked.
5. **Source-identity guard.** Renderer reuse across session swaps means an in-flight fetch can resolve after `{ toolCallId, resourceUri, cachedWidgetHtmlUrl, cspMode, liveFetchPreferred }` has rotated. Each effect run captures its own key; stale resolutions are dropped before any state mutation.

### Behavior matrix

| Scenario | Path |
|---|---|
| MCP Apps revisit, server connected | Live fetch (fixes original blank-on-revisit bug) |
| MCP Apps revisit, server disconnected | Live throws → cached fallback (handles "you switched servers") |
| MCP Apps live returns invalid mimetype | Error surfaced — no silent cached fallback |
| OpenAI Apps revisit | Cached (unchanged — `outputTemplate = "__cached__"` can't live-fetch) |
| Views tab / persisted eval traces | Cached (unchanged — separate code path, flag unset) |
| Concurrent stale fetch resolves after source key changes | Dropped (source-identity guard) |

## Test plan

- [x] `npx vitest run client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx` — 45 passing, including four new renderer-level tests:
  - `liveFetchPreferred + cached → live first`
  - `live throw → cached fallback`
  - `invalid mimetype → error, NO silent cached fallback`
  - `stale live result → dropped after source key rotates`
- [x] `npx vitest run client/src/components/evals/__tests__/trace-viewer-adapter.test.ts` — 27 passing, including a new matrix for `buildToolRenderOverridesFromSnapshots` with/without `preferLiveWhenPossible` across mcp-apps and openai-apps shapes.
- [x] `npx vitest run client/src/hooks/__tests__/use-chat-session.hosted.test.tsx` — 16 passing, including a new integration assertion that `loadChatSession` sets `liveFetchPreferred` for mcp-apps but leaves openai-apps on the cached path.
- [x] `npm run typecheck:client`.
- [ ] **Manual:** ChatGPT host + Strict CSP. Run `create_view`. Click away to another session, click back → widget renders, CSP-violation badge stays ~2.
- [ ] **Manual (disconnected-server fallback):** Run `create_view` on server A. Disconnect A, connect B. Revisit → live attempts and fails, cached fallback renders. In host-to-ui logs: `debug/widget-content-live-fallback` then `debug/widget-content-ready { cached: true }`.
- [ ] **Manual (negative — cached paths must still work):** Open a saved view in the Views tab; open a persisted eval trace; revisit an OpenAI Apps tool call. All render from cache unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)