### PR TITLE
Codex/cli config active project

### DIFF
--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -147,6 +147,11 @@ npm start -- --config path/to/config.json --server myserver
   arguments to the underlying script.
 </Info>
 
+Every server in the config is saved to your active project and persists across
+refreshes. `--server` only chooses which one auto-connects on launch — the rest
+are saved but left idle. If you aren't signed in yet, you'll be sent to sign in
+first and returned here automatically once you're done.
+
 Example configuration file structure:
 
 ```json

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -147,14 +147,13 @@ npm start -- --config path/to/config.json --server myserver
   arguments to the underlying script.
 </Info>
 
-Every server in the config is saved to your active project and persists across
-refreshes. `--server` only chooses which one auto-connects on launch — the rest
-are saved but left idle. If you aren't signed in yet, you'll be sent to sign in
-first and returned here automatically once you're done.
+All servers in the config get added to your project. By default they all
+connect on launch; pass `--server <name>` to only connect that one. If
+you're not signed in, we'll send you to sign in and bring you right back.
 
 Example configuration file structure:
 
-```json
+```json config.json
 {
   "mcpServers": {
     "everything": {

--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -168,6 +168,10 @@ import {
   writeChatboxSignInReturnPath,
 } from "./lib/chatbox-session";
 import {
+  clearCliSignInReturnPath,
+  readCliSignInReturnPath,
+} from "./lib/cli-signin-return-path";
+import {
   sanitizeHostedOAuthErrorMessage,
   clearHostedOAuthResumeMarker,
   writeHostedOAuthResumeMarker,
@@ -1516,12 +1520,14 @@ export default function App() {
       const billingReturnPath = persistedCheckoutIntent
         ? readBillingSignInReturnPath()
         : null;
+      const cliReturnPath = readCliSignInReturnPath();
       clearChatboxSignInReturnPath();
       clearBillingSignInReturnPath();
+      clearCliSignInReturnPath();
       window.history.replaceState(
         {},
         "",
-        chatboxReturnPath ?? billingReturnPath ?? "/"
+        chatboxReturnPath ?? billingReturnPath ?? cliReturnPath ?? "/"
       );
       setCallbackCompleted(true);
       setCallbackRecoveryExpired(false);
@@ -1609,6 +1615,9 @@ export default function App() {
     validOrganizations: effectiveOrganizations,
     routeOrganizationId: hasRouteOrganization ? routeOrganizationId : undefined,
     hostsHubFlagEnabled,
+    requestSignIn: () => {
+      void signIn();
+    },
   });
   // Keep this explicit sign-out cleanup even though useAppState also cleans up
   // on auth-scope changes: WorkOS navigation can redirect before that effect

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.test.tsx
@@ -14,6 +14,8 @@ import {
 import type { ProjectClientConfig } from "@/lib/client-config";
 import { useClientConfigStore } from "@/stores/client-config-store";
 import { useHostContextStore } from "@/stores/client-context-store";
+import { authFetch } from "@/lib/session-token";
+import { readCliSignInReturnPath } from "@/lib/cli-signin-return-path";
 
 const {
   toastError,
@@ -117,6 +119,8 @@ vi.mock("@/stores/ui-playground-store", () => ({
   useUIPlaygroundStore: {
     getState: vi.fn(() => ({
       setSelectedToolResult: vi.fn(),
+      setCspMode: vi.fn(),
+      setMcpAppsCspMode: vi.fn(),
     })),
   },
 }));
@@ -184,6 +188,27 @@ function createAppState(options?: {
   };
 }
 
+function createCloudCliAppState(): AppState {
+  return {
+    projects: {
+      proj_cloud: {
+        id: "proj_cloud",
+        name: "Cloud project",
+        servers: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        sharedProjectId: "proj_cloud",
+        organizationId: "org_1",
+      },
+    },
+    activeProjectId: "proj_cloud",
+    servers: {},
+    selectedServer: "",
+    selectedMultipleServers: [],
+    isMultiSelectMode: false,
+  };
+}
+
 function renderUseServerState(
   dispatch: (action: AppAction) => void,
   appState = createAppState(),
@@ -197,6 +222,7 @@ function renderUseServerState(
     activeProjectServersFlat?: any;
     activeMcpProfile?: any;
     activeHostConfig?: any;
+    requestSignIn?: () => void | Promise<void>;
   }
 ) {
   mockUseDbUserReady.mockReturnValue(
@@ -219,6 +245,7 @@ function renderUseServerState(
       activeProjectServersFlat: options?.activeProjectServersFlat,
       activeMcpProfile: options?.activeMcpProfile,
       activeHostConfig: options?.activeHostConfig,
+      requestSignIn: options?.requestSignIn,
       logger: {
         info: vi.fn(),
         warn: vi.fn(),
@@ -237,6 +264,15 @@ async function flushAsyncWork(iterations = 5): Promise<void> {
 
 beforeEach(() => {
   mockUseDbUserReady.mockReturnValue(true);
+  vi.mocked(authFetch).mockReset();
+  vi.mocked(authFetch).mockResolvedValue({
+    json: async () => ({}),
+  } as Response);
+  sessionStorage.clear();
+  readStoredOAuthConfigMock.mockReturnValue({
+    registryServerId: undefined,
+    useRegistryOAuthProxy: false,
+  });
   tryResolveProjectServerMock.mockReturnValue({
     projectId: "project_default",
     serverId: "srv_demo",
@@ -245,6 +281,217 @@ beforeEach(() => {
   getInitializationInfoMock.mockResolvedValue({
     success: true,
     initInfo: null,
+  });
+});
+
+describe("useServerState CLI config import", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    window.history.replaceState({}, "", "/");
+    mockCreateServerIfMissing.mockReset();
+    mockUpdateServer.mockReset();
+    mockConvexQuery.mockResolvedValue([]);
+    testConnectionMock.mockResolvedValue({ success: true, initInfo: null });
+    getInitializationInfoMock.mockResolvedValue({
+      success: true,
+      initInfo: null,
+    });
+    vi.mocked(authFetch).mockReset();
+    vi.mocked(authFetch).mockResolvedValue({
+      json: async () => ({}),
+    } as Response);
+  });
+
+  it("does not ask for sign-in when there is no CLI server payload", async () => {
+    vi.mocked(authFetch).mockResolvedValueOnce({
+      json: async () => ({ config: { servers: [] } }),
+    } as Response);
+    const requestSignIn = vi.fn();
+
+    renderUseServerState(vi.fn(), createCloudCliAppState(), {
+      isAuthenticated: true,
+      hasSignedInUser: false,
+      useLocalFallback: false,
+      effectiveProjects: createCloudCliAppState().projects,
+      effectiveActiveProjectId: "proj_cloud",
+      activeProjectServersFlat: [],
+      requestSignIn,
+    });
+
+    await waitFor(() => {
+      expect(authFetch).toHaveBeenCalledWith("/api/mcp-cli-config");
+    });
+
+    expect(requestSignIn).not.toHaveBeenCalled();
+    expect(mockCreateServerIfMissing).not.toHaveBeenCalled();
+  });
+
+  it("requests WorkOS sign-in for guest auth and waits to inject until a signed-in project is available", async () => {
+    vi.mocked(authFetch).mockResolvedValueOnce({
+      json: async () => ({
+        config: {
+          servers: [
+            {
+              name: "cli-stdio",
+              type: "stdio",
+              command: "node",
+              args: ["server.js"],
+              env: { API_TOKEN: "token" },
+            },
+          ],
+        },
+      }),
+    } as Response);
+    mockCreateServerIfMissing.mockResolvedValue("srv_cli");
+    const appState = createCloudCliAppState();
+    const dispatch = vi.fn();
+    const requestSignIn = vi.fn();
+    window.history.replaceState({}, "", "/tools?view=cli");
+
+    const { rerender } = renderHook(
+      (props: { hasSignedInUser: boolean }) =>
+        useServerState({
+          appState,
+          dispatch,
+          isLoading: false,
+          isAuthenticated: true,
+          hasSignedInUser: props.hasSignedInUser,
+          isAuthLoading: false,
+          isLoadingProjects: false,
+          useLocalFallback: false,
+          effectiveProjects: appState.projects,
+          effectiveActiveProjectId: "proj_cloud",
+          activeProjectServersFlat: [],
+          requestSignIn,
+          logger: {
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+            debug: vi.fn(),
+          },
+        }),
+      { initialProps: { hasSignedInUser: false } }
+    );
+
+    await waitFor(() => {
+      expect(requestSignIn).toHaveBeenCalledTimes(1);
+    });
+    expect(readCliSignInReturnPath()).toBe("/tools?view=cli");
+    expect(mockCreateServerIfMissing).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "UPSERT_SERVER" })
+    );
+
+    rerender({ hasSignedInUser: true });
+
+    await waitFor(() => {
+      expect(mockCreateServerIfMissing).toHaveBeenCalledTimes(1);
+    });
+    expect(mockCreateServerIfMissing).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "proj_cloud",
+        name: "cli-stdio",
+        enabled: true,
+        transportType: "stdio",
+        command: "node",
+        args: ["server.js"],
+        env: { API_TOKEN: "token" },
+      })
+    );
+  });
+
+  it("persists all CLI config servers and only connects the selected auto-connect server", async () => {
+    vi.mocked(authFetch).mockResolvedValueOnce({
+      json: async () => ({
+        config: {
+          autoConnectServer: "cli-http",
+          servers: [
+            {
+              name: "cli-stdio",
+              type: "stdio",
+              command: "node",
+              args: ["server.js"],
+              env: { API_TOKEN: "token" },
+            },
+            {
+              name: "cli-http",
+              type: "http",
+              url: "https://example.com/mcp",
+              headers: { Authorization: "Bearer secret" },
+            },
+          ],
+        },
+      }),
+    } as Response);
+    mockCreateServerIfMissing.mockImplementation(async (payload: any) => {
+      return `srv_${payload.name}`;
+    });
+    const appState = createCloudCliAppState();
+    const dispatch = vi.fn();
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    };
+
+    renderHook(() =>
+      useServerState({
+        appState,
+        dispatch,
+        isLoading: false,
+        isAuthenticated: true,
+        hasSignedInUser: true,
+        isAuthLoading: false,
+        isLoadingProjects: false,
+        useLocalFallback: false,
+        effectiveProjects: appState.projects,
+        effectiveActiveProjectId: "proj_cloud",
+        activeProjectServersFlat: [],
+        logger,
+      })
+    );
+
+    await waitFor(() => {
+      expect(authFetch).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(mockCreateServerIfMissing).toHaveBeenCalledTimes(2);
+    });
+
+    const payloads = mockCreateServerIfMissing.mock.calls.map(
+      ([payload]) => payload
+    );
+    expect(payloads).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          projectId: "proj_cloud",
+          name: "cli-stdio",
+          enabled: false,
+          transportType: "stdio",
+          command: "node",
+          args: ["server.js"],
+          env: { API_TOKEN: "token" },
+        }),
+        expect.objectContaining({
+          projectId: "proj_cloud",
+          name: "cli-http",
+          enabled: true,
+          transportType: "http",
+          url: "https://example.com/mcp",
+          headers: { Authorization: "Bearer secret" },
+        }),
+      ])
+    );
+    expect(testConnectionMock).toHaveBeenCalledTimes(1);
+    expect(testConnectionMock.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        url: "https://example.com/mcp",
+      })
+    );
   });
 });
 

--- a/mcpjam-inspector/client/src/hooks/use-app-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-app-state.ts
@@ -180,6 +180,7 @@ export function useAppState({
   isLoadingOrganizations,
   validOrganizations,
   hostsHubFlagEnabled,
+  requestSignIn,
 }: {
   currentUserId: string | null;
   /**
@@ -199,6 +200,7 @@ export function useAppState({
    * via its shadow `projects.clientConfig`).
    */
   hostsHubFlagEnabled: boolean;
+  requestSignIn?: () => void | Promise<void>;
 }) {
   const logger = useLogger("Connections");
   const [appState, dispatch] = useReducer(appReducer, initialAppState);
@@ -527,6 +529,7 @@ export function useAppState({
     activeProjectServersFlat: projectState.activeProjectServersFlat,
     activeMcpProfile: activeHost?.mcpProfile,
     activeHostConfig: activeHost,
+    requestSignIn,
     logger,
   });
 

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -54,6 +54,7 @@ import {
 import { useProjectClientConfigSyncPending } from "./use-project-client-config-sync-pending";
 import { useUIPlaygroundStore } from "@/stores/ui-playground-store";
 import { useServerMutations, type RemoteServer } from "./useProjects";
+import { writeCliSignInReturnPath } from "@/lib/cli-signin-return-path";
 import {
   CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE,
   PROJECT_NOT_PROVISIONED_ERROR_MESSAGE,
@@ -508,6 +509,7 @@ interface UseServerStateParams {
    * applied when the call site also supplies the `serverId`.
    */
   activeHostConfig?: HostConfigDtoV2;
+  requestSignIn?: () => void | Promise<void>;
   logger: LoggerLike;
 }
 
@@ -568,6 +570,7 @@ export function useServerState({
   activeProjectServersFlat,
   activeMcpProfile,
   activeHostConfig,
+  requestSignIn,
   logger,
 }: UseServerStateParams) {
   const isUserReady = useDbUserReady();
@@ -1165,6 +1168,7 @@ export function useServerState({
         transportType,
         command: config?.command,
         args: config?.args,
+        env: config?.env,
         url,
         headers,
         timeout: config?.timeout,
@@ -2515,7 +2519,7 @@ export function useServerState({
   const saveServerConfigWithoutConnecting = useCallback(
     async (
       formData: ServerFormData,
-      options?: { oauthProfile?: OAuthTestProfile }
+      options?: { oauthProfile?: OAuthTestProfile; suppressToast?: boolean }
     ) => {
       const validationError = validateForm(formData);
       if (validationError) {
@@ -2601,7 +2605,9 @@ export function useServerState({
       logger.info("Saved server configuration without connecting", {
         serverName,
       });
-      toast.success(`Saved configuration for ${serverName}`);
+      if (!options?.suppressToast) {
+        toast.success(`Saved configuration for ${serverName}`);
+      }
     },
     [
       appState.activeProjectId,
@@ -2797,123 +2803,201 @@ export function useServerState({
   );
 
   const cliConfigProcessedRef = useRef<boolean>(false);
+  const cliConfigFetchStartedRef = useRef<boolean>(false);
+  const cliConfigSignInRequestedRef = useRef<boolean>(false);
+  const pendingCliConfigRef = useRef<any | null>(null);
 
   useEffect(() => {
     if (HOSTED_MODE) {
       return;
     }
-
-    if (!isLoading && !cliConfigProcessedRef.current) {
-      cliConfigProcessedRef.current = true;
-      authFetch("/api/mcp-cli-config")
-        .then((response) => response.json())
-        .then((data) => {
-          const cliConfig = data.config;
-          if (cliConfig) {
-            if (
-              cliConfig.initialTab &&
-              (!window.location.pathname || window.location.pathname === "/")
-            ) {
-              const tab = cliConfig.initialTab.replace(/^[#/]+/, "");
-              if (tab) {
-                navigateApp(`/${tab}`, { replace: true });
-              }
-            }
-
-            if (
-              cliConfig.cspMode === "permissive" ||
-              cliConfig.cspMode === "widget-declared"
-            ) {
-              const store = useUIPlaygroundStore.getState();
-              store.setCspMode(cliConfig.cspMode);
-              store.setMcpAppsCspMode(cliConfig.cspMode);
-            }
-
-            if (cliConfig.servers && Array.isArray(cliConfig.servers)) {
-              const autoConnectServer = cliConfig.autoConnectServer;
-
-              logger.info(
-                "Processing CLI-provided MCP servers (from config file)",
-                {
-                  serverCount: cliConfig.servers.length,
-                  autoConnectServer: autoConnectServer || "all",
-                  cliConfig: cliConfig,
-                }
-              );
-
-              cliConfig.servers.forEach((server: any) => {
-                const serverName = server.name || "CLI Server";
-                const urlParams = new URLSearchParams(window.location.search);
-                const oauthCallbackInProgress = urlParams.has("code");
-                const formData: ServerFormData = {
-                  name: serverName,
-                  type: (server.type === "sse"
-                    ? "http"
-                    : server.type || "stdio") as "stdio" | "http",
-                  command: server.command,
-                  args: server.args || [],
-                  url: server.url,
-                  env: server.env || {},
-                  headers: server.headers,
-                  useOAuth: server.useOAuth ?? false,
-                };
-
-                const mcpConfig = toMCPConfig(formData);
-                dispatch({
-                  type: "UPSERT_SERVER",
-                  name: formData.name,
-                  server: {
-                    name: formData.name,
-                    config: mcpConfig,
-                    lastConnectionTime: new Date(),
-                    connectionStatus: "disconnected" as const,
-                    retryCount: 0,
-                    enabled: false,
-                  },
-                });
-
-                if (oauthCallbackInProgress && server.useOAuth) {
-                  logger.info("Skipping auto-connect for OAuth server", {
-                    serverName: server.name,
-                    reason: "OAuth callback in progress",
-                  });
-                } else if (
-                  !autoConnectServer ||
-                  server.name === autoConnectServer
-                ) {
-                  logger.info("Auto-connecting to server", {
-                    serverName: server.name,
-                  });
-                  handleConnect(formData);
-                } else {
-                  logger.info("Skipping auto-connect for server", {
-                    serverName: server.name,
-                    reason: "filtered out",
-                  });
-                }
-              });
-              return;
-            }
-            if (cliConfig.command) {
-              logger.info("Auto-connecting to CLI-provided MCP server", {
-                cliConfig,
-              });
-              const formData: ServerFormData = {
-                name: cliConfig.name || "CLI Server",
-                type: "stdio" as const,
-                command: cliConfig.command,
-                args: cliConfig.args || [],
-                env: cliConfig.env || {},
-              };
-              handleConnect(formData);
-            }
-          }
-        })
-        .catch((error) => {
-          logger.debug("Could not fetch CLI config from API", { error });
-        });
+    if (cliConfigProcessedRef.current) {
+      return;
     }
-  }, [isLoading, handleConnect, logger, dispatch]);
+    if (isLoading || isAuthLoading) {
+      return;
+    }
+
+    const oauthCallbackInProgress = new URLSearchParams(
+      window.location.search
+    ).has("code");
+
+    const applyCliUiConfig = (cliConfig: any) => {
+      if (
+        cliConfig.initialTab &&
+        (!window.location.pathname || window.location.pathname === "/")
+      ) {
+        const tab = cliConfig.initialTab.replace(/^[#/]+/, "");
+        if (tab) {
+          navigateApp(`/${tab}`, { replace: true });
+        }
+      }
+
+      if (
+        cliConfig.cspMode === "permissive" ||
+        cliConfig.cspMode === "widget-declared"
+      ) {
+        const store = useUIPlaygroundStore.getState();
+        store.setCspMode(cliConfig.cspMode);
+        store.setMcpAppsCspMode(cliConfig.cspMode);
+      }
+    };
+
+    const hasServerPayload = (cliConfig: any): boolean =>
+      Boolean(
+        (Array.isArray(cliConfig.servers) && cliConfig.servers.length > 0) ||
+          cliConfig.command
+      );
+
+    const formDataFromCliServer = (
+      server: any,
+      fallbackName = "CLI Server"
+    ): ServerFormData => ({
+      name: server.name || fallbackName,
+      type: (server.type === "sse"
+        ? "http"
+        : server.type || "stdio") as "stdio" | "http",
+      command: server.command,
+      args: server.args || [],
+      url: server.url,
+      env: server.env || {},
+      headers: server.headers,
+      useOAuth: server.useOAuth ?? false,
+    });
+
+    const requestCliSignIn = () => {
+      if (cliConfigSignInRequestedRef.current) {
+        return;
+      }
+      cliConfigSignInRequestedRef.current = true;
+      writeCliSignInReturnPath(
+        `${window.location.pathname || routePaths.root}${window.location.search || ""}`
+      );
+      void requestSignIn?.();
+    };
+
+    const processCliConfig = async (cliConfig: any) => {
+      applyCliUiConfig(cliConfig);
+
+      if (!hasServerPayload(cliConfig)) {
+        cliConfigProcessedRef.current = true;
+        return;
+      }
+
+      if (!hasSignedInUser) {
+        if (oauthCallbackInProgress) {
+          logger.info("Skipping CLI sign-in redirect during OAuth callback");
+          return;
+        }
+        requestCliSignIn();
+        return;
+      }
+
+      const hasActiveConvexProject = Boolean(
+        activeProject?.sharedProjectId &&
+          effectiveActiveProjectId &&
+          effectiveActiveProjectId !== "none" &&
+          !useLocalFallback
+      );
+      if (isLoadingProjects || !hasActiveConvexProject) {
+        return;
+      }
+
+      cliConfigProcessedRef.current = true;
+
+      if (Array.isArray(cliConfig.servers) && cliConfig.servers.length > 0) {
+        const autoConnectServer = cliConfig.autoConnectServer;
+
+        logger.info("Processing CLI-provided MCP servers (from config file)", {
+          serverCount: cliConfig.servers.length,
+          autoConnectServer: autoConnectServer || "all",
+          cliConfig,
+        });
+
+        for (const server of cliConfig.servers) {
+          const serverName = server.name || "CLI Server";
+          const formData = formDataFromCliServer(server, serverName);
+
+          if (oauthCallbackInProgress && server.useOAuth) {
+            logger.info("Skipping auto-connect for OAuth server", {
+              serverName,
+              reason: "OAuth callback in progress",
+            });
+            await saveServerConfigWithoutConnecting(formData, {
+              suppressToast: true,
+            });
+          } else if (!autoConnectServer || server.name === autoConnectServer) {
+            logger.info("Auto-connecting to server", {
+              serverName,
+            });
+            await handleConnect(formData);
+          } else {
+            logger.info("Saving CLI server without auto-connect", {
+              serverName,
+              reason: "filtered out",
+            });
+            await saveServerConfigWithoutConnecting(formData, {
+              suppressToast: true,
+            });
+          }
+        }
+        return;
+      }
+
+      if (cliConfig.command) {
+        logger.info("Auto-connecting to CLI-provided MCP server", {
+          cliConfig,
+        });
+        const formData = formDataFromCliServer(
+          {
+            ...cliConfig,
+            type: "stdio",
+          },
+          cliConfig.name || "CLI Server"
+        );
+        await handleConnect(formData);
+      }
+    };
+
+    const pendingCliConfig = pendingCliConfigRef.current;
+    if (pendingCliConfig) {
+      void processCliConfig(pendingCliConfig);
+      return;
+    }
+
+    if (cliConfigFetchStartedRef.current) {
+      return;
+    }
+
+    cliConfigFetchStartedRef.current = true;
+    authFetch("/api/mcp-cli-config")
+      .then((response) => response.json())
+      .then((data) => {
+        const cliConfig = data.config ?? null;
+        pendingCliConfigRef.current = cliConfig;
+        if (!cliConfig) {
+          cliConfigProcessedRef.current = true;
+          return;
+        }
+        void processCliConfig(cliConfig);
+      })
+      .catch((error) => {
+        logger.debug("Could not fetch CLI config from API", { error });
+        cliConfigProcessedRef.current = true;
+      });
+  }, [
+    isLoading,
+    isAuthLoading,
+    isLoadingProjects,
+    hasSignedInUser,
+    useLocalFallback,
+    effectiveActiveProjectId,
+    activeProject?.sharedProjectId,
+    requestSignIn,
+    handleConnect,
+    saveServerConfigWithoutConnecting,
+    logger,
+  ]);
 
   const getValidAccessToken = useCallback(
     async (serverName: string): Promise<string | null> => {

--- a/mcpjam-inspector/client/src/lib/__tests__/cli-signin-return-path.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/cli-signin-return-path.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearCliSignInReturnPath,
+  readCliSignInReturnPath,
+  writeCliSignInReturnPath,
+} from "../cli-signin-return-path";
+
+describe("cli-signin-return-path", () => {
+  afterEach(() => {
+    clearCliSignInReturnPath();
+  });
+
+  it("round-trips an app route", () => {
+    writeCliSignInReturnPath("/tools?server=demo");
+
+    expect(readCliSignInReturnPath()).toBe("/tools?server=demo");
+  });
+
+  it("falls back to root for empty or unknown routes", () => {
+    writeCliSignInReturnPath("/not-an-app-route");
+
+    expect(readCliSignInReturnPath()).toBe("/");
+
+    clearCliSignInReturnPath();
+    writeCliSignInReturnPath("");
+
+    expect(readCliSignInReturnPath()).toBe("/");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/cli-signin-return-path.ts
+++ b/mcpjam-inspector/client/src/lib/cli-signin-return-path.ts
@@ -1,0 +1,54 @@
+import { normalizeReturnTargetPath, routePaths } from "./app-navigation";
+
+const CLI_SIGN_IN_RETURN_PATH_STORAGE_KEY =
+  "mcpjam_cli_signin_return_path_v1";
+
+function normalizeCliReturnPath(path: string | null | undefined): string {
+  const trimmed = path?.trim() ?? "";
+  if (!trimmed || trimmed === routePaths.root || trimmed.startsWith("/?")) {
+    return routePaths.root;
+  }
+  return normalizeReturnTargetPath(trimmed, routePaths.root);
+}
+
+export function writeCliSignInReturnPath(path: string | null | undefined): void {
+  if (typeof sessionStorage === "undefined") {
+    return;
+  }
+
+  const normalizedPath = normalizeCliReturnPath(path);
+  try {
+    sessionStorage.setItem(
+      CLI_SIGN_IN_RETURN_PATH_STORAGE_KEY,
+      normalizedPath
+    );
+  } catch {
+    // Ignore storage failures.
+  }
+}
+
+export function readCliSignInReturnPath(): string | null {
+  if (typeof sessionStorage === "undefined") {
+    return null;
+  }
+
+  try {
+    const raw = sessionStorage.getItem(CLI_SIGN_IN_RETURN_PATH_STORAGE_KEY);
+    if (!raw) return null;
+    return normalizeCliReturnPath(raw);
+  } catch {
+    return null;
+  }
+}
+
+export function clearCliSignInReturnPath(): void {
+  if (typeof sessionStorage === "undefined") {
+    return;
+  }
+
+  try {
+    sessionStorage.removeItem(CLI_SIGN_IN_RETURN_PATH_STORAGE_KEY);
+  } catch {
+    // Ignore storage failures.
+  }
+}


### PR DESCRIPTION
- Fixes CLI-added MCP servers from `--config` / `--server`.
- If you are not signed in yet, the app sends you to sign in first.
- After sign-in, the app returns to the same page and imports the server.
- Imported servers now save into the active Convex project, so refreshes keep them.
- `--server` only controls which server auto-connects; all config servers still get saved.
- Uses the existing project/server credential behavior. No new token policy.
- Adds tests for signed-out import, signed-in import, and empty CLI config.