### PR TITLE
feat(playground): multi-host storage primitives + state hook (Phase 1)

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-persisted-host.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-persisted-host.test.tsx
@@ -1,0 +1,151 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { usePersistedHost } from "../use-persisted-host";
+import {
+  loadSelectedHostIds,
+  replaceLeadHostId,
+  saveSelectedHostIds,
+} from "@/lib/selected-host-storage";
+import {
+  loadPreviewedHostId,
+  savePreviewedHostId,
+} from "@/lib/previewed-client-storage";
+
+const PROJECT = "p1";
+
+describe("usePersistedHost", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("initializes from localStorage (lead + array + toggle)", () => {
+    saveSelectedHostIds(["a", "b"]);
+    savePreviewedHostId(PROJECT, "a");
+    localStorage.setItem("mcp-inspector-multi-host-enabled", "true");
+
+    const { result } = renderHook(() => usePersistedHost(PROJECT));
+    expect(result.current.selectedHostIds).toEqual(["a", "b"]);
+    expect(result.current.multiHostEnabled).toBe(true);
+  });
+
+  it("returns stored array unchanged when no lead is set", () => {
+    saveSelectedHostIds(["a", "b"]);
+
+    const { result } = renderHook(() => usePersistedHost(PROJECT));
+    expect(result.current.selectedHostIds).toEqual(["a", "b"]);
+  });
+
+  it("setSelectedHostIds updates React state and mirrors localStorage without dispatching", () => {
+    savePreviewedHostId(PROJECT, "a");
+    saveSelectedHostIds(["a"]);
+
+    const { result } = renderHook(() => usePersistedHost(PROJECT));
+
+    act(() => {
+      result.current.setSelectedHostIds(["a", "b"]);
+    });
+
+    expect(result.current.selectedHostIds).toEqual(["a", "b"]);
+    expect(loadSelectedHostIds()).toEqual(["a", "b"]);
+    expect(loadPreviewedHostId(PROJECT)).toBe("a");
+  });
+
+  it("propagates external `replaceLeadHostId` writes into the hook on the next event tick", () => {
+    saveSelectedHostIds(["a", "extra"]);
+    savePreviewedHostId(PROJECT, "a");
+
+    const { result } = renderHook(() => usePersistedHost(PROJECT));
+    expect(result.current.selectedHostIds).toEqual(["a", "extra"]);
+
+    act(() => {
+      replaceLeadHostId(PROJECT, "z");
+    });
+
+    // Lead is "z", column count preserved at 2, "extra" still secondary.
+    expect(result.current.selectedHostIds).toEqual(["z", "extra"]);
+  });
+
+  it("derives the lead from previewed host: external savePreviewedHostId surfaces as slot 0", () => {
+    saveSelectedHostIds(["a", "b", "c"]);
+    savePreviewedHostId(PROJECT, "a");
+
+    const { result } = renderHook(() => usePersistedHost(PROJECT));
+    expect(result.current.selectedHostIds[0]).toBe("a");
+
+    // Directly change the previewed host (no array rotation). The hook
+    // must surface "b" at slot 0 and filter it out of secondaries.
+    act(() => {
+      savePreviewedHostId(PROJECT, "b");
+    });
+
+    expect(result.current.selectedHostIds[0]).toBe("b");
+    // "b" is removed from secondaries (no duplication) and the
+    // remaining stored entries follow.
+    expect(result.current.selectedHostIds).toEqual(["b", "a", "c"]);
+  });
+
+  // Multi-select regression analog from the model hook. Starting from
+  // ["a"] with multi-host enabled, the picker calls replaceLeadHostId
+  // (re-affirms the existing lead at slot 0 — no array change) then
+  // setSelectedHostIds(["a", "b"]). Final state must be ["a", "b"].
+  it("adds a second host when picker re-affirms the lead then writes a longer array", () => {
+    saveSelectedHostIds(["a"]);
+    savePreviewedHostId(PROJECT, "a");
+
+    const { result } = renderHook(() => usePersistedHost(PROJECT));
+    act(() => {
+      result.current.setMultiHostEnabled(true);
+    });
+    expect(result.current.selectedHostIds).toEqual(["a"]);
+
+    act(() => {
+      // Step 1: re-affirm existing lead (the picker always sends the
+      // current lead at slot 0).
+      replaceLeadHostId(PROJECT, "a");
+      // Step 2: write the new compare array including the new host.
+      result.current.setSelectedHostIds(["a", "b"]);
+    });
+
+    expect(result.current.selectedHostIds).toEqual(["a", "b"]);
+    expect(loadSelectedHostIds()).toEqual(["a", "b"]);
+    expect(loadPreviewedHostId(PROJECT)).toBe("a");
+  });
+
+  it("preserves column count across a host switch via replaceLeadHostId", () => {
+    saveSelectedHostIds(["host-a", "extra"]);
+    savePreviewedHostId(PROJECT, "host-a");
+
+    const { result } = renderHook(() => usePersistedHost(PROJECT));
+    expect(result.current.selectedHostIds).toEqual(["host-a", "extra"]);
+
+    act(() => {
+      replaceLeadHostId(PROJECT, "host-b");
+    });
+
+    expect(result.current.selectedHostIds).toEqual(["host-b", "extra"]);
+    expect(loadSelectedHostIds()).toEqual(["host-b", "extra"]);
+    expect(loadPreviewedHostId(PROJECT)).toBe("host-b");
+  });
+
+  it("setMultiHostEnabled persists to localStorage", () => {
+    const { result } = renderHook(() => usePersistedHost(PROJECT));
+
+    act(() => {
+      result.current.setMultiHostEnabled(true);
+    });
+    expect(localStorage.getItem("mcp-inspector-multi-host-enabled")).toBe(
+      "true",
+    );
+
+    act(() => {
+      result.current.setMultiHostEnabled(false);
+    });
+    expect(localStorage.getItem("mcp-inspector-multi-host-enabled")).toBe(
+      "false",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-persisted-host.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-persisted-host.test.tsx
@@ -12,6 +12,9 @@ import {
 } from "@/lib/previewed-client-storage";
 
 const PROJECT = "p1";
+const PROJECT_B = "p2";
+const TOGGLE_KEY_P1 = `mcp-inspector-multi-host-enabled:${PROJECT}`;
+const TOGGLE_KEY_P2 = `mcp-inspector-multi-host-enabled:${PROJECT_B}`;
 
 describe("usePersistedHost", () => {
   beforeEach(() => {
@@ -23,9 +26,9 @@ describe("usePersistedHost", () => {
   });
 
   it("initializes from localStorage (lead + array + toggle)", () => {
-    saveSelectedHostIds(["a", "b"]);
+    saveSelectedHostIds(PROJECT, ["a", "b"]);
     savePreviewedHostId(PROJECT, "a");
-    localStorage.setItem("mcp-inspector-multi-host-enabled", "true");
+    localStorage.setItem(TOGGLE_KEY_P1, "true");
 
     const { result } = renderHook(() => usePersistedHost(PROJECT));
     expect(result.current.selectedHostIds).toEqual(["a", "b"]);
@@ -33,7 +36,7 @@ describe("usePersistedHost", () => {
   });
 
   it("returns stored array unchanged when no lead is set", () => {
-    saveSelectedHostIds(["a", "b"]);
+    saveSelectedHostIds(PROJECT, ["a", "b"]);
 
     const { result } = renderHook(() => usePersistedHost(PROJECT));
     expect(result.current.selectedHostIds).toEqual(["a", "b"]);
@@ -41,7 +44,7 @@ describe("usePersistedHost", () => {
 
   it("setSelectedHostIds updates React state and mirrors localStorage without dispatching", () => {
     savePreviewedHostId(PROJECT, "a");
-    saveSelectedHostIds(["a"]);
+    saveSelectedHostIds(PROJECT, ["a"]);
 
     const { result } = renderHook(() => usePersistedHost(PROJECT));
 
@@ -50,12 +53,12 @@ describe("usePersistedHost", () => {
     });
 
     expect(result.current.selectedHostIds).toEqual(["a", "b"]);
-    expect(loadSelectedHostIds()).toEqual(["a", "b"]);
+    expect(loadSelectedHostIds(PROJECT)).toEqual(["a", "b"]);
     expect(loadPreviewedHostId(PROJECT)).toBe("a");
   });
 
   it("propagates external `replaceLeadHostId` writes into the hook on the next event tick", () => {
-    saveSelectedHostIds(["a", "extra"]);
+    saveSelectedHostIds(PROJECT, ["a", "extra"]);
     savePreviewedHostId(PROJECT, "a");
 
     const { result } = renderHook(() => usePersistedHost(PROJECT));
@@ -70,7 +73,7 @@ describe("usePersistedHost", () => {
   });
 
   it("derives the lead from previewed host: external savePreviewedHostId surfaces as slot 0", () => {
-    saveSelectedHostIds(["a", "b", "c"]);
+    saveSelectedHostIds(PROJECT, ["a", "b", "c"]);
     savePreviewedHostId(PROJECT, "a");
 
     const { result } = renderHook(() => usePersistedHost(PROJECT));
@@ -83,9 +86,48 @@ describe("usePersistedHost", () => {
     });
 
     expect(result.current.selectedHostIds[0]).toBe("b");
-    // "b" is removed from secondaries (no duplication) and the
-    // remaining stored entries follow.
+    // "b" is rotated to slot 0; count (3) preserved.
     expect(result.current.selectedHostIds).toEqual(["b", "a", "c"]);
+  });
+
+  // Defensive derivation: external `savePreviewedHostId` writes (from
+  // the global host bar or project setup flows) bypass
+  // `replaceLeadHostId`. The hook must still preserve column count by
+  // REPLACING slot 0 when the new lead isn't in the stored array — not
+  // growing the array.
+  it("preserves count when an external savePreviewedHostId targets a host NOT in the array", () => {
+    saveSelectedHostIds(PROJECT, ["a", "b"]);
+    savePreviewedHostId(PROJECT, "a");
+
+    const { result } = renderHook(() => usePersistedHost(PROJECT));
+    expect(result.current.selectedHostIds).toEqual(["a", "b"]);
+
+    act(() => {
+      // Direct lead write (not via replaceLeadHostId): "c" isn't in
+      // stored. The hook must replace slot 0, not append.
+      savePreviewedHostId(PROJECT, "c");
+    });
+
+    expect(result.current.selectedHostIds).toEqual(["c", "b"]);
+    expect(result.current.selectedHostIds.length).toBe(2);
+  });
+
+  // Defensive derivation, rotate branch: external `savePreviewedHostId`
+  // targets a host already in the stored array at index k > 0. The hook
+  // must rotate it to slot 0 and preserve count.
+  it("preserves count and rotates when an external savePreviewedHostId targets a host already in the array", () => {
+    saveSelectedHostIds(PROJECT, ["a", "b", "c"]);
+    savePreviewedHostId(PROJECT, "a");
+
+    const { result } = renderHook(() => usePersistedHost(PROJECT));
+    expect(result.current.selectedHostIds).toEqual(["a", "b", "c"]);
+
+    act(() => {
+      savePreviewedHostId(PROJECT, "c");
+    });
+
+    expect(result.current.selectedHostIds).toEqual(["c", "a", "b"]);
+    expect(result.current.selectedHostIds.length).toBe(3);
   });
 
   // Multi-select regression analog from the model hook. Starting from
@@ -93,7 +135,7 @@ describe("usePersistedHost", () => {
   // (re-affirms the existing lead at slot 0 — no array change) then
   // setSelectedHostIds(["a", "b"]). Final state must be ["a", "b"].
   it("adds a second host when picker re-affirms the lead then writes a longer array", () => {
-    saveSelectedHostIds(["a"]);
+    saveSelectedHostIds(PROJECT, ["a"]);
     savePreviewedHostId(PROJECT, "a");
 
     const { result } = renderHook(() => usePersistedHost(PROJECT));
@@ -111,12 +153,12 @@ describe("usePersistedHost", () => {
     });
 
     expect(result.current.selectedHostIds).toEqual(["a", "b"]);
-    expect(loadSelectedHostIds()).toEqual(["a", "b"]);
+    expect(loadSelectedHostIds(PROJECT)).toEqual(["a", "b"]);
     expect(loadPreviewedHostId(PROJECT)).toBe("a");
   });
 
   it("preserves column count across a host switch via replaceLeadHostId", () => {
-    saveSelectedHostIds(["host-a", "extra"]);
+    saveSelectedHostIds(PROJECT, ["host-a", "extra"]);
     savePreviewedHostId(PROJECT, "host-a");
 
     const { result } = renderHook(() => usePersistedHost(PROJECT));
@@ -127,25 +169,77 @@ describe("usePersistedHost", () => {
     });
 
     expect(result.current.selectedHostIds).toEqual(["host-b", "extra"]);
-    expect(loadSelectedHostIds()).toEqual(["host-b", "extra"]);
+    expect(loadSelectedHostIds(PROJECT)).toEqual(["host-b", "extra"]);
     expect(loadPreviewedHostId(PROJECT)).toBe("host-b");
   });
 
-  it("setMultiHostEnabled persists to localStorage", () => {
+  it("setMultiHostEnabled persists to project-scoped localStorage key", () => {
     const { result } = renderHook(() => usePersistedHost(PROJECT));
 
     act(() => {
       result.current.setMultiHostEnabled(true);
     });
-    expect(localStorage.getItem("mcp-inspector-multi-host-enabled")).toBe(
-      "true",
-    );
+    expect(localStorage.getItem(TOGGLE_KEY_P1)).toBe("true");
 
     act(() => {
       result.current.setMultiHostEnabled(false);
     });
-    expect(localStorage.getItem("mcp-inspector-multi-host-enabled")).toBe(
-      "false",
+    expect(localStorage.getItem(TOGGLE_KEY_P1)).toBe("false");
+  });
+
+  // Project-scoping: hosts are project entities. The array must NOT
+  // leak from project A into project B.
+  it("does not surface project A's stored array under project B", () => {
+    saveSelectedHostIds(PROJECT, ["a", "b"]);
+    savePreviewedHostId(PROJECT, "a");
+
+    const { result } = renderHook(() => usePersistedHost(PROJECT_B));
+    expect(result.current.selectedHostIds).toEqual([]);
+  });
+
+  it("switching projectId surfaces the new project's persisted array", () => {
+    saveSelectedHostIds(PROJECT, ["a", "b"]);
+    saveSelectedHostIds(PROJECT_B, ["x", "y", "z"]);
+    savePreviewedHostId(PROJECT, "a");
+    savePreviewedHostId(PROJECT_B, "x");
+
+    const { result, rerender } = renderHook(
+      ({ pid }: { pid: string }) => usePersistedHost(pid),
+      { initialProps: { pid: PROJECT } },
     );
+    expect(result.current.selectedHostIds).toEqual(["a", "b"]);
+
+    rerender({ pid: PROJECT_B });
+    expect(result.current.selectedHostIds).toEqual(["x", "y", "z"]);
+
+    rerender({ pid: PROJECT });
+    expect(result.current.selectedHostIds).toEqual(["a", "b"]);
+  });
+
+  // Toggle is per-project too: turning it on for project A must not
+  // surface as enabled when project B mounts (and vice versa).
+  it("multi-host toggle is per-project (no leakage between projects)", () => {
+    localStorage.setItem(TOGGLE_KEY_P1, "true");
+    localStorage.setItem(TOGGLE_KEY_P2, "false");
+
+    const { result: resultA } = renderHook(() => usePersistedHost(PROJECT));
+    expect(resultA.current.multiHostEnabled).toBe(true);
+
+    const { result: resultB } = renderHook(() => usePersistedHost(PROJECT_B));
+    expect(resultB.current.multiHostEnabled).toBe(false);
+  });
+
+  it("switching projectId re-reads the toggle from the new project's key", () => {
+    localStorage.setItem(TOGGLE_KEY_P1, "true");
+    localStorage.setItem(TOGGLE_KEY_P2, "false");
+
+    const { result, rerender } = renderHook(
+      ({ pid }: { pid: string }) => usePersistedHost(pid),
+      { initialProps: { pid: PROJECT } },
+    );
+    expect(result.current.multiHostEnabled).toBe(true);
+
+    rerender({ pid: PROJECT_B });
+    expect(result.current.multiHostEnabled).toBe(false);
   });
 });

--- a/mcpjam-inspector/client/src/hooks/use-persisted-host.ts
+++ b/mcpjam-inspector/client/src/hooks/use-persisted-host.ts
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  loadSelectedHostIds,
+  saveSelectedHostIds,
+  subscribeSelectedHostIds,
+} from "@/lib/selected-host-storage";
+import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
+
+const MULTI_HOST_ENABLED_STORAGE_KEY = "mcp-inspector-multi-host-enabled";
+
+function normalizeSelectedHostIds(hostIds: string[]): string[] {
+  const uniqueHostIds: string[] = [];
+  const seen = new Set<string>();
+
+  for (const hostId of hostIds) {
+    if (typeof hostId !== "string") {
+      continue;
+    }
+
+    const trimmed = hostId.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+
+    seen.add(trimmed);
+    uniqueHostIds.push(trimmed);
+  }
+
+  return uniqueHostIds;
+}
+
+export interface UsePersistedHostReturn {
+  /**
+   * The compare-column line-up, always normalized so the lead host id
+   * (the per-project previewed host) sits at slot 0 followed by stored
+   * secondaries with the lead filtered out. If no lead is set, this is
+   * just the stored secondaries.
+   */
+  selectedHostIds: string[];
+  /**
+   * In-app setter. Updates React state and mirrors to localStorage via
+   * `saveSelectedHostIds`. Does NOT dispatch the array channel — the
+   * picker's promote-then-write-array sequence relies on this asymmetry
+   * to avoid feeding back into React state and clobbering the longer
+   * array. Outside-seam writes (`replaceLeadHostId`) DO dispatch.
+   */
+  setSelectedHostIds: (ids: string[]) => void;
+  multiHostEnabled: boolean;
+  setMultiHostEnabled: (enabled: boolean) => void;
+}
+
+/**
+ * Hook to persist the user's multi-host compare line-up + the
+ * "multiple hosts" toggle to localStorage. The lead host id is derived
+ * from `usePreviewedHostId(projectId)` (per-project source of truth in
+ * `lib/previewed-client-storage.ts`); this hook composes the two so the
+ * exposed `selectedHostIds` cannot drift from the previewed host.
+ *
+ * `setSelectedHostIds` is React-state-authoritative for in-app writes;
+ * `saveSelectedHostIds` only mirrors to localStorage without dispatching
+ * an event, so the picker's promote-then-write-array sequence cannot
+ * race with a listener that overwrites the new array. The host-switch
+ * outside seam (`replaceLeadHostId`) fires the
+ * `selected-host-ids-changed` channel so the array state still syncs
+ * when the active host changes — and `usePreviewedHostId`'s own channel
+ * handles lead changes.
+ *
+ * Not exported from a barrel — Phase 1 (this PR) only adds storage +
+ * hook. Consumers will wire up in Phase 4.
+ */
+export function usePersistedHost(
+  projectId: string | null,
+): UsePersistedHostReturn {
+  const [previewedHostId] = usePreviewedHostId(projectId);
+  const [storedHostIds, setStoredHostIdsState] = useState<string[]>([]);
+  const [multiHostEnabled, setMultiHostEnabledState] = useState(false);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // Load array + toggle from localStorage on mount; subscribe to
+  // outside-seam writes (host-snapshot apply, MultiHostPicker promote)
+  // so the picker stays in sync.
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      setIsInitialized(true);
+      return;
+    }
+    setStoredHostIdsState(loadSelectedHostIds());
+    try {
+      const storedMultiHostEnabled = localStorage.getItem(
+        MULTI_HOST_ENABLED_STORAGE_KEY,
+      );
+      if (storedMultiHostEnabled === "true") {
+        setMultiHostEnabledState(true);
+      }
+    } catch (error) {
+      console.warn("Failed to load selected hosts from localStorage:", error);
+    }
+    setIsInitialized(true);
+
+    // Array channel: fires only from `replaceLeadHostId` (outside-seam
+    // host-switch primitive) and cross-tab `storage` events on the
+    // array key. In-app `setSelectedHostIds` mirrors localStorage
+    // silently — that's the asymmetry that fixes the regression where
+    // in-app multi-select setters fed back into React state.
+    const unsubscribeIds = subscribeSelectedHostIds(() => {
+      setStoredHostIdsState(loadSelectedHostIds());
+    });
+    return () => {
+      unsubscribeIds();
+    };
+  }, []);
+
+  // Persist multi-host toggle + mirror the array to localStorage on
+  // every React state change. The array is React-state-authoritative for
+  // in-app writes; this effect is the single backstop that keeps
+  // localStorage in sync so setters never have to call
+  // `saveSelectedHostIds` themselves.
+  useEffect(() => {
+    if (!isInitialized || typeof window === "undefined") return;
+    try {
+      localStorage.setItem(
+        MULTI_HOST_ENABLED_STORAGE_KEY,
+        multiHostEnabled ? "true" : "false",
+      );
+    } catch (error) {
+      console.warn("Failed to save selected hosts to localStorage:", error);
+    }
+    // `saveSelectedHostIds` does NOT dispatch a same-tab event, so this
+    // won't feed back into React state.
+    saveSelectedHostIds(storedHostIds);
+  }, [isInitialized, multiHostEnabled, storedHostIds]);
+
+  // Derived: always normalize so the lead sits at slot 0 with the lead
+  // filtered out of secondaries. If lead is null, just expose the
+  // stored secondaries. This is the invariant that keeps the lead key
+  // and the array from drifting: callers see one consistent shape.
+  const selectedHostIds = useMemo(() => {
+    if (!previewedHostId) return storedHostIds;
+    const filtered = storedHostIds.filter((id) => id !== previewedHostId);
+    return [previewedHostId, ...filtered];
+  }, [previewedHostId, storedHostIds]);
+
+  const setSelectedHostIds = useCallback((hostIds: string[]) => {
+    const normalized = normalizeSelectedHostIds(hostIds);
+    // React state is the source of truth for the compare-column line-up
+    // during in-app writes; the array-mirror effect above persists it.
+    // The lead (previewed host) is owned by `usePreviewedHostId` /
+    // `savePreviewedHostId`; this setter intentionally does NOT touch
+    // the lead — promotion goes through `replaceLeadHostId`. Mutating
+    // the lead from here would be the same anti-pattern that grew the
+    // model array on every host switch.
+    setStoredHostIdsState(normalized);
+  }, []);
+
+  const setMultiHostEnabled = useCallback((enabled: boolean) => {
+    setMultiHostEnabledState(enabled);
+  }, []);
+
+  return {
+    selectedHostIds,
+    setSelectedHostIds,
+    multiHostEnabled,
+    setMultiHostEnabled,
+  };
+}

--- a/mcpjam-inspector/client/src/hooks/use-persisted-host.ts
+++ b/mcpjam-inspector/client/src/hooks/use-persisted-host.ts
@@ -6,7 +6,16 @@ import {
 } from "@/lib/selected-host-storage";
 import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
 
-const MULTI_HOST_ENABLED_STORAGE_KEY = "mcp-inspector-multi-host-enabled";
+// Project-scoped toggle key prefix. Deliberate divergence from the model
+// toggle (`mcp-inspector-multi-model-enabled` is global): models are
+// global resources; hosts are project entities; the toggle scopes
+// accordingly so opening a different project doesn't inherit the
+// previous project's compare-mode state.
+const MULTI_HOST_ENABLED_STORAGE_KEY_PREFIX = "mcp-inspector-multi-host-enabled";
+
+function multiHostEnabledKey(projectId: string): string {
+  return `${MULTI_HOST_ENABLED_STORAGE_KEY_PREFIX}:${projectId}`;
+}
 
 function normalizeSelectedHostIds(hostIds: string[]): string[] {
   const uniqueHostIds: string[] = [];
@@ -29,12 +38,57 @@ function normalizeSelectedHostIds(hostIds: string[]): string[] {
   return uniqueHostIds;
 }
 
+/**
+ * Defensive count-preserving derivation: mirrors the algorithm in
+ * `replaceLeadHostId` so external `savePreviewedHostId` writes (global
+ * host bar, project setup flows) that change the lead WITHOUT going
+ * through `replaceLeadHostId` can't break column-count preservation.
+ *
+ * Branches (must match `replaceLeadHostId` exactly):
+ *   - Stored empty + lead null → `[]`.
+ *   - Stored empty + lead set → `[lead]` (seed).
+ *   - Lead null + stored non-empty → stored as-is.
+ *   - Lead at slot 0 → no change.
+ *   - Lead at slot k > 0 → rotate to front (count preserved).
+ *   - Lead not in stored + stored non-empty → replace slot 0 (count
+ *     preserved). NEVER append.
+ */
+function deriveSelectedHostIds(
+  storedHostIds: string[],
+  previewedHostId: string | null,
+): string[] {
+  if (storedHostIds.length === 0) {
+    return previewedHostId ? [previewedHostId] : [];
+  }
+  if (!previewedHostId) {
+    return storedHostIds;
+  }
+  if (storedHostIds[0] === previewedHostId) {
+    return storedHostIds;
+  }
+  const idx = storedHostIds.indexOf(previewedHostId);
+  if (idx > 0) {
+    // Rotate the existing entry to slot 0; preserve count.
+    return [
+      previewedHostId,
+      ...storedHostIds.slice(0, idx),
+      ...storedHostIds.slice(idx + 1),
+    ];
+  }
+  // Lead is not in stored; replace slot 0 in-place. Do NOT append — that
+  // would grow the column count on every external `savePreviewedHostId`
+  // write that targets a host not already in the array.
+  return [previewedHostId, ...storedHostIds.slice(1)];
+}
+
 export interface UsePersistedHostReturn {
   /**
-   * The compare-column line-up, always normalized so the lead host id
-   * (the per-project previewed host) sits at slot 0 followed by stored
-   * secondaries with the lead filtered out. If no lead is set, this is
-   * just the stored secondaries.
+   * The compare-column line-up, always normalized with the lead host id
+   * (the per-project previewed host) at slot 0 and column count
+   * preserved. See `deriveSelectedHostIds` for the count-preserving
+   * branches — the hook re-applies the same algorithm at READ time so
+   * external `savePreviewedHostId` writes that bypass `replaceLeadHostId`
+   * can't grow the array.
    */
   selectedHostIds: string[];
   /**
@@ -54,7 +108,13 @@ export interface UsePersistedHostReturn {
  * "multiple hosts" toggle to localStorage. The lead host id is derived
  * from `usePreviewedHostId(projectId)` (per-project source of truth in
  * `lib/previewed-client-storage.ts`); this hook composes the two so the
- * exposed `selectedHostIds` cannot drift from the previewed host.
+ * exposed `selectedHostIds` cannot drift from the previewed host AND
+ * cannot grow when the lead changes through any seam.
+ *
+ * Project scoping: both the array and the toggle are project-scoped at
+ * the storage layer. Switching `projectId` re-reads from the new
+ * project's keys; project A's compare line-up will not surface in
+ * project B (and vice versa).
  *
  * `setSelectedHostIds` is React-state-authoritative for in-app writes;
  * `saveSelectedHostIds` only mirrors to localStorage without dispatching
@@ -63,7 +123,8 @@ export interface UsePersistedHostReturn {
  * outside seam (`replaceLeadHostId`) fires the
  * `selected-host-ids-changed` channel so the array state still syncs
  * when the active host changes — and `usePreviewedHostId`'s own channel
- * handles lead changes.
+ * handles lead changes (including direct `savePreviewedHostId` calls
+ * from other surfaces, which the derivation re-shapes count-preservingly).
  *
  * Not exported from a barrel — Phase 1 (this PR) only adds storage +
  * hook. Consumers will wire up in Phase 4.
@@ -76,21 +137,26 @@ export function usePersistedHost(
   const [multiHostEnabled, setMultiHostEnabledState] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
 
-  // Load array + toggle from localStorage on mount; subscribe to
-  // outside-seam writes (host-snapshot apply, MultiHostPicker promote)
-  // so the picker stays in sync.
+  // Load array + toggle from localStorage when projectId changes;
+  // subscribe to outside-seam writes (host-snapshot apply,
+  // MultiHostPicker promote) so the picker stays in sync. Re-running on
+  // `projectId` is what makes switching projects re-read from the new
+  // project's scoped keys — without it, project B would inherit the
+  // last-loaded array from project A.
   useEffect(() => {
     if (typeof window === "undefined") {
       setIsInitialized(true);
       return;
     }
-    setStoredHostIdsState(loadSelectedHostIds());
+    setStoredHostIdsState(loadSelectedHostIds(projectId));
     try {
-      const storedMultiHostEnabled = localStorage.getItem(
-        MULTI_HOST_ENABLED_STORAGE_KEY,
-      );
-      if (storedMultiHostEnabled === "true") {
-        setMultiHostEnabledState(true);
+      if (projectId) {
+        const storedMultiHostEnabled = localStorage.getItem(
+          multiHostEnabledKey(projectId),
+        );
+        setMultiHostEnabledState(storedMultiHostEnabled === "true");
+      } else {
+        setMultiHostEnabledState(false);
       }
     } catch (error) {
       console.warn("Failed to load selected hosts from localStorage:", error);
@@ -98,17 +164,17 @@ export function usePersistedHost(
     setIsInitialized(true);
 
     // Array channel: fires only from `replaceLeadHostId` (outside-seam
-    // host-switch primitive) and cross-tab `storage` events on the
-    // array key. In-app `setSelectedHostIds` mirrors localStorage
-    // silently — that's the asymmetry that fixes the regression where
-    // in-app multi-select setters fed back into React state.
+    // host-switch primitive) and cross-tab `storage` events on any
+    // project's array key. The subscriber re-reads with this hook's own
+    // projectId — cross-project events that don't apply to this hook
+    // simply re-read the same value.
     const unsubscribeIds = subscribeSelectedHostIds(() => {
-      setStoredHostIdsState(loadSelectedHostIds());
+      setStoredHostIdsState(loadSelectedHostIds(projectId));
     });
     return () => {
       unsubscribeIds();
     };
-  }, []);
+  }, [projectId]);
 
   // Persist multi-host toggle + mirror the array to localStorage on
   // every React state change. The array is React-state-authoritative for
@@ -117,9 +183,10 @@ export function usePersistedHost(
   // `saveSelectedHostIds` themselves.
   useEffect(() => {
     if (!isInitialized || typeof window === "undefined") return;
+    if (!projectId) return;
     try {
       localStorage.setItem(
-        MULTI_HOST_ENABLED_STORAGE_KEY,
+        multiHostEnabledKey(projectId),
         multiHostEnabled ? "true" : "false",
       );
     } catch (error) {
@@ -127,18 +194,18 @@ export function usePersistedHost(
     }
     // `saveSelectedHostIds` does NOT dispatch a same-tab event, so this
     // won't feed back into React state.
-    saveSelectedHostIds(storedHostIds);
-  }, [isInitialized, multiHostEnabled, storedHostIds]);
+    saveSelectedHostIds(projectId, storedHostIds);
+  }, [isInitialized, multiHostEnabled, storedHostIds, projectId]);
 
-  // Derived: always normalize so the lead sits at slot 0 with the lead
-  // filtered out of secondaries. If lead is null, just expose the
-  // stored secondaries. This is the invariant that keeps the lead key
-  // and the array from drifting: callers see one consistent shape.
-  const selectedHostIds = useMemo(() => {
-    if (!previewedHostId) return storedHostIds;
-    const filtered = storedHostIds.filter((id) => id !== previewedHostId);
-    return [previewedHostId, ...filtered];
-  }, [previewedHostId, storedHostIds]);
+  // Derived: defensively re-apply the count-preserving algorithm so an
+  // external `savePreviewedHostId` write (global host bar, project setup
+  // flows) that changes the lead WITHOUT rotating the array can't grow
+  // our column count. The hook tolerates such writes by re-shaping the
+  // line-up at READ time.
+  const selectedHostIds = useMemo(
+    () => deriveSelectedHostIds(storedHostIds, previewedHostId),
+    [previewedHostId, storedHostIds],
+  );
 
   const setSelectedHostIds = useCallback((hostIds: string[]) => {
     const normalized = normalizeSelectedHostIds(hostIds);

--- a/mcpjam-inspector/client/src/lib/__tests__/selected-host-storage.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/selected-host-storage.test.ts
@@ -10,8 +10,10 @@ import {
   savePreviewedHostId,
 } from "../previewed-client-storage";
 
-const ARRAY_KEY = "mcp-inspector-selected-hosts";
 const PROJECT = "p1";
+const PROJECT_B = "p2";
+const ARRAY_KEY_P1 = `mcp-inspector-selected-hosts:${PROJECT}`;
+const ARRAY_KEY_P2 = `mcp-inspector-selected-hosts:${PROJECT_B}`;
 
 describe("selected-host-storage", () => {
   beforeEach(() => {
@@ -24,19 +26,19 @@ describe("selected-host-storage", () => {
 
   describe("loadSelectedHostIds / saveSelectedHostIds", () => {
     it("returns [] when nothing is stored", () => {
-      expect(loadSelectedHostIds()).toEqual([]);
+      expect(loadSelectedHostIds(PROJECT)).toEqual([]);
     });
 
-    it("round-trips a normalized array", () => {
-      saveSelectedHostIds(["a", "b", "c"]);
-      expect(loadSelectedHostIds()).toEqual(["a", "b", "c"]);
-      expect(localStorage.getItem(ARRAY_KEY)).toBe(
+    it("round-trips a normalized array under the project-scoped key", () => {
+      saveSelectedHostIds(PROJECT, ["a", "b", "c"]);
+      expect(loadSelectedHostIds(PROJECT)).toEqual(["a", "b", "c"]);
+      expect(localStorage.getItem(ARRAY_KEY_P1)).toBe(
         JSON.stringify(["a", "b", "c"]),
       );
     });
 
     it("dedupes, trims, and drops non-strings on save", () => {
-      saveSelectedHostIds([
+      saveSelectedHostIds(PROJECT, [
         " a ",
         "a",
         "",
@@ -45,18 +47,46 @@ describe("selected-host-storage", () => {
         "b",
         "b",
       ]);
-      expect(loadSelectedHostIds()).toEqual(["a", "b"]);
+      expect(loadSelectedHostIds(PROJECT)).toEqual(["a", "b"]);
     });
 
     it("removes the key when saving an empty array", () => {
-      saveSelectedHostIds(["a"]);
-      saveSelectedHostIds([]);
-      expect(localStorage.getItem(ARRAY_KEY)).toBeNull();
+      saveSelectedHostIds(PROJECT, ["a"]);
+      saveSelectedHostIds(PROJECT, []);
+      expect(localStorage.getItem(ARRAY_KEY_P1)).toBeNull();
     });
 
     it("returns [] when the stored JSON is malformed", () => {
-      localStorage.setItem(ARRAY_KEY, "{not json");
-      expect(loadSelectedHostIds()).toEqual([]);
+      localStorage.setItem(ARRAY_KEY_P1, "{not json");
+      expect(loadSelectedHostIds(PROJECT)).toEqual([]);
+    });
+
+    it("isolates arrays across projects (no cross-project leakage)", () => {
+      saveSelectedHostIds(PROJECT, ["a", "b"]);
+      expect(loadSelectedHostIds(PROJECT_B)).toEqual([]);
+      saveSelectedHostIds(PROJECT_B, ["x", "y", "z"]);
+      expect(loadSelectedHostIds(PROJECT)).toEqual(["a", "b"]);
+      expect(loadSelectedHostIds(PROJECT_B)).toEqual(["x", "y", "z"]);
+      expect(localStorage.getItem(ARRAY_KEY_P1)).toBe(
+        JSON.stringify(["a", "b"]),
+      );
+      expect(localStorage.getItem(ARRAY_KEY_P2)).toBe(
+        JSON.stringify(["x", "y", "z"]),
+      );
+    });
+
+    // Null projectId is defensive — not reachable through PlaygroundTab
+    // (which always passes a non-null projectId). We still guard the
+    // storage seam.
+    it("loadSelectedHostIds(null) returns [] (defensive; not reachable in practice)", () => {
+      saveSelectedHostIds(PROJECT, ["a"]);
+      expect(loadSelectedHostIds(null)).toEqual([]);
+    });
+
+    it("saveSelectedHostIds(null, …) is a no-op (defensive; not reachable in practice)", () => {
+      saveSelectedHostIds(null, ["a", "b"]);
+      expect(loadSelectedHostIds(PROJECT)).toEqual([]);
+      expect(localStorage.getItem(ARRAY_KEY_P1)).toBeNull();
     });
   });
 
@@ -64,69 +94,77 @@ describe("selected-host-storage", () => {
     it("seeds the array with [newHostId] when it is currently empty", () => {
       replaceLeadHostId(PROJECT, "host-a");
       expect(loadPreviewedHostId(PROJECT)).toBe("host-a");
-      expect(loadSelectedHostIds()).toEqual(["host-a"]);
+      expect(loadSelectedHostIds(PROJECT)).toEqual(["host-a"]);
     });
 
     it("is a no-op on the array when newHostId already sits at index 0", () => {
-      saveSelectedHostIds(["a", "b", "c"]);
+      saveSelectedHostIds(PROJECT, ["a", "b", "c"]);
       replaceLeadHostId(PROJECT, "a");
       expect(loadPreviewedHostId(PROJECT)).toBe("a");
-      expect(loadSelectedHostIds()).toEqual(["a", "b", "c"]);
+      expect(loadSelectedHostIds(PROJECT)).toEqual(["a", "b", "c"]);
     });
 
     it("rotates an existing id at index k > 0 to the front, preserving count", () => {
-      saveSelectedHostIds(["a", "b", "c"]);
+      saveSelectedHostIds(PROJECT, ["a", "b", "c"]);
       replaceLeadHostId(PROJECT, "c");
       expect(loadPreviewedHostId(PROJECT)).toBe("c");
-      expect(loadSelectedHostIds()).toEqual(["c", "a", "b"]);
+      expect(loadSelectedHostIds(PROJECT)).toEqual(["c", "a", "b"]);
     });
 
     it("replaces the lead slot when newHostId is not in the array, preserving count", () => {
-      saveSelectedHostIds(["a", "b", "c"]);
+      saveSelectedHostIds(PROJECT, ["a", "b", "c"]);
       replaceLeadHostId(PROJECT, "z");
       expect(loadPreviewedHostId(PROJECT)).toBe("z");
-      expect(loadSelectedHostIds()).toEqual(["z", "b", "c"]);
+      expect(loadSelectedHostIds(PROJECT)).toEqual(["z", "b", "c"]);
     });
 
     it("clears the lead but leaves the array intact when called with null", () => {
-      saveSelectedHostIds(["a", "b", "c"]);
+      saveSelectedHostIds(PROJECT, ["a", "b", "c"]);
       savePreviewedHostId(PROJECT, "a");
       replaceLeadHostId(PROJECT, null);
       expect(loadPreviewedHostId(PROJECT)).toBeNull();
-      expect(loadSelectedHostIds()).toEqual(["a", "b", "c"]);
+      expect(loadSelectedHostIds(PROJECT)).toEqual(["a", "b", "c"]);
     });
 
     it("treats whitespace-only ids like null", () => {
-      saveSelectedHostIds(["a", "b"]);
+      saveSelectedHostIds(PROJECT, ["a", "b"]);
       savePreviewedHostId(PROJECT, "a");
       replaceLeadHostId(PROJECT, "   ");
       expect(loadPreviewedHostId(PROJECT)).toBeNull();
-      expect(loadSelectedHostIds()).toEqual(["a", "b"]);
+      expect(loadSelectedHostIds(PROJECT)).toEqual(["a", "b"]);
     });
 
     it("keeps lead and array aligned after a switch", () => {
-      saveSelectedHostIds(["a"]);
+      saveSelectedHostIds(PROJECT, ["a"]);
       savePreviewedHostId(PROJECT, "a");
 
       replaceLeadHostId(PROJECT, "b");
       // Lead in the per-project previewed-host storage is "b" and the
       // array starts with "b".
       expect(loadPreviewedHostId(PROJECT)).toBe("b");
-      const ids = loadSelectedHostIds();
+      const ids = loadSelectedHostIds(PROJECT);
       expect(ids[0]).toBe("b");
     });
 
     it("preserves multi-column count when switching hosts (regression for column-drift bug)", () => {
-      saveSelectedHostIds(["host-a", "extra"]);
+      saveSelectedHostIds(PROJECT, ["host-a", "extra"]);
       savePreviewedHostId(PROJECT, "host-a");
 
       replaceLeadHostId(PROJECT, "host-b");
 
-      const ids = loadSelectedHostIds();
+      const ids = loadSelectedHostIds(PROJECT);
       expect(ids.length).toBe(2);
       expect(ids[0]).toBe("host-b");
       expect(ids[1]).toBe("extra");
       expect(loadPreviewedHostId(PROJECT)).toBe("host-b");
+    });
+
+    it("scopes array writes to the given projectId", () => {
+      saveSelectedHostIds(PROJECT_B, ["other"]);
+      replaceLeadHostId(PROJECT, "host-a");
+      expect(loadSelectedHostIds(PROJECT)).toEqual(["host-a"]);
+      // Project B's array is untouched.
+      expect(loadSelectedHostIds(PROJECT_B)).toEqual(["other"]);
     });
   });
 
@@ -134,20 +172,20 @@ describe("selected-host-storage", () => {
     it("does NOT fire when only `saveSelectedHostIds` is called (in-app mirror path)", () => {
       const cb = vi.fn();
       const unsubscribe = subscribeSelectedHostIds(cb);
-      saveSelectedHostIds(["a", "b"]);
+      saveSelectedHostIds(PROJECT, ["a", "b"]);
       expect(cb).not.toHaveBeenCalled();
       unsubscribe();
     });
 
     it("fires once on `replaceLeadHostId` and the read after the event sees both keys updated", () => {
-      saveSelectedHostIds(["a", "b"]);
+      saveSelectedHostIds(PROJECT, ["a", "b"]);
       savePreviewedHostId(PROJECT, "a");
 
       let observedLead: string | null | undefined;
       let observedArray: string[] | undefined;
       const cb = vi.fn(() => {
         observedLead = loadPreviewedHostId(PROJECT);
-        observedArray = loadSelectedHostIds();
+        observedArray = loadSelectedHostIds(PROJECT);
       });
       const unsubscribe = subscribeSelectedHostIds(cb);
 
@@ -163,7 +201,7 @@ describe("selected-host-storage", () => {
     });
 
     it("does NOT fire when `replaceLeadHostId` leaves the array untouched (lead already at slot 0)", () => {
-      saveSelectedHostIds(["a", "b"]);
+      saveSelectedHostIds(PROJECT, ["a", "b"]);
       savePreviewedHostId(PROJECT, "a");
 
       const cb = vi.fn();
@@ -174,19 +212,38 @@ describe("selected-host-storage", () => {
       unsubscribe();
     });
 
-    it("fires on cross-tab `storage` events for the array key", () => {
+    it("fires on cross-tab `storage` events for any project-scoped array key (prefix match)", () => {
       const cb = vi.fn();
       const unsubscribe = subscribeSelectedHostIds(cb);
-      // Simulate a cross-tab storage event on the array key.
+      // Simulate a cross-tab storage event on a project-scoped array key.
       window.dispatchEvent(
-        new StorageEvent("storage", { key: ARRAY_KEY, newValue: "[]" }),
+        new StorageEvent("storage", { key: ARRAY_KEY_P1, newValue: "[]" }),
       );
       expect(cb).toHaveBeenCalledTimes(1);
+      // A different project's array key also wakes the listener; the
+      // subscriber re-reads with its own projectId.
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: ARRAY_KEY_P2, newValue: "[]" }),
+      );
+      expect(cb).toHaveBeenCalledTimes(2);
+      unsubscribe();
+    });
+
+    it("ignores cross-tab `storage` events on unrelated keys", () => {
+      const cb = vi.fn();
+      const unsubscribe = subscribeSelectedHostIds(cb);
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: "some-other-key",
+          newValue: "x",
+        }),
+      );
+      expect(cb).not.toHaveBeenCalled();
       unsubscribe();
     });
 
     it("stops firing after unsubscribe", () => {
-      saveSelectedHostIds(["a"]);
+      saveSelectedHostIds(PROJECT, ["a"]);
       const cb = vi.fn();
       const unsubscribe = subscribeSelectedHostIds(cb);
       unsubscribe();

--- a/mcpjam-inspector/client/src/lib/__tests__/selected-host-storage.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/selected-host-storage.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  loadSelectedHostIds,
+  replaceLeadHostId,
+  saveSelectedHostIds,
+  subscribeSelectedHostIds,
+} from "../selected-host-storage";
+import {
+  loadPreviewedHostId,
+  savePreviewedHostId,
+} from "../previewed-client-storage";
+
+const ARRAY_KEY = "mcp-inspector-selected-hosts";
+const PROJECT = "p1";
+
+describe("selected-host-storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe("loadSelectedHostIds / saveSelectedHostIds", () => {
+    it("returns [] when nothing is stored", () => {
+      expect(loadSelectedHostIds()).toEqual([]);
+    });
+
+    it("round-trips a normalized array", () => {
+      saveSelectedHostIds(["a", "b", "c"]);
+      expect(loadSelectedHostIds()).toEqual(["a", "b", "c"]);
+      expect(localStorage.getItem(ARRAY_KEY)).toBe(
+        JSON.stringify(["a", "b", "c"]),
+      );
+    });
+
+    it("dedupes, trims, and drops non-strings on save", () => {
+      saveSelectedHostIds([
+        " a ",
+        "a",
+        "",
+        // @ts-expect-error — exercising runtime normalization
+        null,
+        "b",
+        "b",
+      ]);
+      expect(loadSelectedHostIds()).toEqual(["a", "b"]);
+    });
+
+    it("removes the key when saving an empty array", () => {
+      saveSelectedHostIds(["a"]);
+      saveSelectedHostIds([]);
+      expect(localStorage.getItem(ARRAY_KEY)).toBeNull();
+    });
+
+    it("returns [] when the stored JSON is malformed", () => {
+      localStorage.setItem(ARRAY_KEY, "{not json");
+      expect(loadSelectedHostIds()).toEqual([]);
+    });
+  });
+
+  describe("replaceLeadHostId", () => {
+    it("seeds the array with [newHostId] when it is currently empty", () => {
+      replaceLeadHostId(PROJECT, "host-a");
+      expect(loadPreviewedHostId(PROJECT)).toBe("host-a");
+      expect(loadSelectedHostIds()).toEqual(["host-a"]);
+    });
+
+    it("is a no-op on the array when newHostId already sits at index 0", () => {
+      saveSelectedHostIds(["a", "b", "c"]);
+      replaceLeadHostId(PROJECT, "a");
+      expect(loadPreviewedHostId(PROJECT)).toBe("a");
+      expect(loadSelectedHostIds()).toEqual(["a", "b", "c"]);
+    });
+
+    it("rotates an existing id at index k > 0 to the front, preserving count", () => {
+      saveSelectedHostIds(["a", "b", "c"]);
+      replaceLeadHostId(PROJECT, "c");
+      expect(loadPreviewedHostId(PROJECT)).toBe("c");
+      expect(loadSelectedHostIds()).toEqual(["c", "a", "b"]);
+    });
+
+    it("replaces the lead slot when newHostId is not in the array, preserving count", () => {
+      saveSelectedHostIds(["a", "b", "c"]);
+      replaceLeadHostId(PROJECT, "z");
+      expect(loadPreviewedHostId(PROJECT)).toBe("z");
+      expect(loadSelectedHostIds()).toEqual(["z", "b", "c"]);
+    });
+
+    it("clears the lead but leaves the array intact when called with null", () => {
+      saveSelectedHostIds(["a", "b", "c"]);
+      savePreviewedHostId(PROJECT, "a");
+      replaceLeadHostId(PROJECT, null);
+      expect(loadPreviewedHostId(PROJECT)).toBeNull();
+      expect(loadSelectedHostIds()).toEqual(["a", "b", "c"]);
+    });
+
+    it("treats whitespace-only ids like null", () => {
+      saveSelectedHostIds(["a", "b"]);
+      savePreviewedHostId(PROJECT, "a");
+      replaceLeadHostId(PROJECT, "   ");
+      expect(loadPreviewedHostId(PROJECT)).toBeNull();
+      expect(loadSelectedHostIds()).toEqual(["a", "b"]);
+    });
+
+    it("keeps lead and array aligned after a switch", () => {
+      saveSelectedHostIds(["a"]);
+      savePreviewedHostId(PROJECT, "a");
+
+      replaceLeadHostId(PROJECT, "b");
+      // Lead in the per-project previewed-host storage is "b" and the
+      // array starts with "b".
+      expect(loadPreviewedHostId(PROJECT)).toBe("b");
+      const ids = loadSelectedHostIds();
+      expect(ids[0]).toBe("b");
+    });
+
+    it("preserves multi-column count when switching hosts (regression for column-drift bug)", () => {
+      saveSelectedHostIds(["host-a", "extra"]);
+      savePreviewedHostId(PROJECT, "host-a");
+
+      replaceLeadHostId(PROJECT, "host-b");
+
+      const ids = loadSelectedHostIds();
+      expect(ids.length).toBe(2);
+      expect(ids[0]).toBe("host-b");
+      expect(ids[1]).toBe("extra");
+      expect(loadPreviewedHostId(PROJECT)).toBe("host-b");
+    });
+  });
+
+  describe("subscribeSelectedHostIds", () => {
+    it("does NOT fire when only `saveSelectedHostIds` is called (in-app mirror path)", () => {
+      const cb = vi.fn();
+      const unsubscribe = subscribeSelectedHostIds(cb);
+      saveSelectedHostIds(["a", "b"]);
+      expect(cb).not.toHaveBeenCalled();
+      unsubscribe();
+    });
+
+    it("fires once on `replaceLeadHostId` and the read after the event sees both keys updated", () => {
+      saveSelectedHostIds(["a", "b"]);
+      savePreviewedHostId(PROJECT, "a");
+
+      let observedLead: string | null | undefined;
+      let observedArray: string[] | undefined;
+      const cb = vi.fn(() => {
+        observedLead = loadPreviewedHostId(PROJECT);
+        observedArray = loadSelectedHostIds();
+      });
+      const unsubscribe = subscribeSelectedHostIds(cb);
+
+      // "c" isn't in the array, so the lead slot is replaced; count
+      // (2) is preserved.
+      replaceLeadHostId(PROJECT, "c");
+
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(observedLead).toBe("c");
+      expect(observedArray).toEqual(["c", "b"]);
+
+      unsubscribe();
+    });
+
+    it("does NOT fire when `replaceLeadHostId` leaves the array untouched (lead already at slot 0)", () => {
+      saveSelectedHostIds(["a", "b"]);
+      savePreviewedHostId(PROJECT, "a");
+
+      const cb = vi.fn();
+      const unsubscribe = subscribeSelectedHostIds(cb);
+      // "a" is already at slot 0 — no array change, no array event.
+      replaceLeadHostId(PROJECT, "a");
+      expect(cb).not.toHaveBeenCalled();
+      unsubscribe();
+    });
+
+    it("fires on cross-tab `storage` events for the array key", () => {
+      const cb = vi.fn();
+      const unsubscribe = subscribeSelectedHostIds(cb);
+      // Simulate a cross-tab storage event on the array key.
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: ARRAY_KEY, newValue: "[]" }),
+      );
+      expect(cb).toHaveBeenCalledTimes(1);
+      unsubscribe();
+    });
+
+    it("stops firing after unsubscribe", () => {
+      saveSelectedHostIds(["a"]);
+      const cb = vi.fn();
+      const unsubscribe = subscribeSelectedHostIds(cb);
+      unsubscribe();
+      replaceLeadHostId(PROJECT, "b");
+      expect(cb).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/lib/selected-host-storage.ts
+++ b/mcpjam-inspector/client/src/lib/selected-host-storage.ts
@@ -1,9 +1,19 @@
 /**
  * Storage for the playground's persisted multi-host array — the compare-
- * column line-up of host ids the user wants to compare side-by-side. The
- * array lives in global localStorage under `mcp-inspector-selected-hosts`.
+ * column line-up of host ids the user wants to compare side-by-side.
  *
- * This file owns the array key and its same-tab channel
+ * Per-project scoping: hosts are project entities (a host belongs to a
+ * specific project), so the array lives under a project-scoped key
+ * `mcp-inspector-selected-hosts:{projectId}`. Switching projects must NOT
+ * inherit the previous project's compare-column line-up — opening project
+ * B should never surface project A's host ids. This is a deliberate
+ * divergence from `selected-model-storage.ts`: models are global
+ * resources (the same provider/model ids mean the same thing across
+ * projects), so the model array is keyed globally. Hosts are not — so
+ * this module project-scopes the array (and the hook project-scopes its
+ * sibling `mcp-inspector-multi-host-enabled` toggle for the same reason).
+ *
+ * This file owns the array key prefix and its same-tab channel
  * (`selected-host-ids-changed`). It does NOT own the lead host id: the
  * LEAD source-of-truth is the per-project "previewed host" managed by
  * `lib/previewed-client-storage.ts` (key: `mcp-previewed-host-id`,
@@ -13,10 +23,17 @@
  * operation, then dispatches the array channel once so subscribers see a
  * consistent snapshot.
  *
- * `usePersistedHost` (in `hooks/use-persisted-host.ts`) derives the lead
- * from `usePreviewedHostId(projectId)` and exposes
- * `selectedHostIds` always normalized as `[leadId, ...secondaries]`, so
- * the two cannot drift by construction.
+ * Defensive-derivation contract: `usePersistedHost` (in
+ * `hooks/use-persisted-host.ts`) does NOT trust that every lead change
+ * flows through `replaceLeadHostId`. Existing UI surfaces (global host
+ * bar, project setup flows) call `savePreviewedHostId` directly, which
+ * changes the lead without rotating the array. The hook therefore
+ * re-applies the same count-preserving algorithm at READ time: if the
+ * derived lead is not at slot 0 of the stored array, the hook rotates it
+ * to slot 0 (when present elsewhere) or replaces slot 0 (when absent),
+ * never growing the array. The invariant is enforced by both writers
+ * (`replaceLeadHostId`) and readers (`usePersistedHost`) so an external
+ * `savePreviewedHostId` write cannot break column-count preservation.
  *
  * Same dispatch asymmetry as `selected-model-storage.ts`:
  *   - `saveSelectedHostIds` does NOT dispatch a same-tab event. In-app
@@ -27,19 +44,31 @@
  *   - `replaceLeadHostId` DOES dispatch, because it's the outside-seam
  *     write — fired by host-snapshot apply or by the future
  *     `MultiHostPicker` promotion path. Subscribers re-read on the next
- *     event tick.
- *   - Cross-tab `storage` events on the array key are forwarded to
- *     subscribers for free.
+ *     event tick with their own `projectId` to resolve the scoped key.
+ *   - Cross-tab `storage` events on any project's array key are forwarded
+ *     to subscribers. The listener filters on key PREFIX
+ *     (`mcp-inspector-selected-hosts:`) since project-scoping makes the
+ *     exact key variable; subscribers re-read with their own projectId.
  *
  * Count-preservation invariant: column count is a workspace preference,
  * not a host property. Switching hosts must swap the lead in place, never
  * grow or shrink the array. `replaceLeadHostId` rotates an existing entry
- * to slot 0 or replaces slot 0 in-place; it never appends or pops.
+ * to slot 0 or replaces slot 0 in-place; it never appends or pops. The
+ * hook's defensive derivation re-applies the same algorithm at read time.
  */
 import { savePreviewedHostId } from "@/lib/previewed-client-storage";
 
-const MULTI_STORAGE_KEY = "mcp-inspector-selected-hosts";
+const MULTI_STORAGE_KEY_PREFIX = "mcp-inspector-selected-hosts";
 const ARRAY_EVENT_NAME = "selected-host-ids-changed";
+
+function arrayKey(projectId: string): string {
+  return `${MULTI_STORAGE_KEY_PREFIX}:${projectId}`;
+}
+
+function isArrayKey(key: string | null): boolean {
+  if (!key) return false;
+  return key.startsWith(`${MULTI_STORAGE_KEY_PREFIX}:`);
+}
 
 function normalizeSelectedHostIds(hostIds: unknown): string[] {
   if (!Array.isArray(hostIds)) return [];
@@ -63,9 +92,15 @@ function dispatchArrayChanged(): void {
   }
 }
 
-export function loadSelectedHostIds(): string[] {
+export function loadSelectedHostIds(projectId: string | null): string[] {
+  // Defend against null projectId: hosts are per-project, so without a
+  // project we have nothing meaningful to return. In practice
+  // `PlaygroundTab.tsx` only mounts the hook with a non-null projectId,
+  // so this branch is not reachable through the normal app shell — but
+  // we still guard the storage seam.
+  if (!projectId) return [];
   try {
-    const raw = localStorage.getItem(MULTI_STORAGE_KEY);
+    const raw = localStorage.getItem(arrayKey(projectId));
     if (typeof raw !== "string" || raw.length === 0) return [];
     const parsed = JSON.parse(raw);
     return normalizeSelectedHostIds(parsed);
@@ -74,13 +109,22 @@ export function loadSelectedHostIds(): string[] {
   }
 }
 
-export function saveSelectedHostIds(ids: string[]): void {
+export function saveSelectedHostIds(
+  projectId: string | null,
+  ids: string[],
+): void {
+  // No-op when projectId is null: see `loadSelectedHostIds`. Writing
+  // without a scope would either leak project A's ids into B's storage
+  // or overwrite an existing project's array — both worse than dropping
+  // the write.
+  if (!projectId) return;
   try {
     const normalized = normalizeSelectedHostIds(ids);
+    const key = arrayKey(projectId);
     if (normalized.length > 0) {
-      localStorage.setItem(MULTI_STORAGE_KEY, JSON.stringify(normalized));
+      localStorage.setItem(key, JSON.stringify(normalized));
     } else {
-      localStorage.removeItem(MULTI_STORAGE_KEY);
+      localStorage.removeItem(key);
     }
     // Intentionally do NOT dispatch the array channel here. In-app writes
     // flow from React setters that already updated React state directly
@@ -101,7 +145,7 @@ export function saveSelectedHostIds(ids: string[]): void {
  * previewed host key for the purpose of promotion (single-mode pickers
  * that simply change the previewed host without rotating the array
  * continue to use `savePreviewedHostId` directly — they don't need
- * rotation).
+ * rotation, and the hook's defensive derivation handles them).
  *
  * Semantics (mirroring `replaceLeadModelId`):
  *   - `newHostId` null/whitespace → clear the lead key, leave array
@@ -130,7 +174,7 @@ export function replaceLeadHostId(
     return;
   }
 
-  const current = loadSelectedHostIds();
+  const current = loadSelectedHostIds(projectId);
   let nextArray: string[] | null;
   if (current.length === 0) {
     nextArray = [next];
@@ -156,10 +200,11 @@ export function replaceLeadHostId(
   // the event observe a consistent snapshot.
   try {
     if (nextArray !== null) {
+      const key = arrayKey(projectId);
       if (nextArray.length > 0) {
-        localStorage.setItem(MULTI_STORAGE_KEY, JSON.stringify(nextArray));
+        localStorage.setItem(key, JSON.stringify(nextArray));
       } else {
-        localStorage.removeItem(MULTI_STORAGE_KEY);
+        localStorage.removeItem(key);
       }
     }
   } catch {
@@ -177,11 +222,19 @@ export function replaceLeadHostId(
 
 /**
  * Subscribe to outside-seam writes of the multi-host array (currently
- * only `replaceLeadHostId`) and cross-tab `storage` events on the array
- * key. React-side setters intentionally do NOT fire this channel — they
- * update React state directly and call `saveSelectedHostIds` only to
- * mirror localStorage, so subscribers here won't be flooded by every
- * in-app multi-host change.
+ * only `replaceLeadHostId`) and cross-tab `storage` events on any
+ * project-scoped array key. React-side setters intentionally do NOT fire
+ * this channel — they update React state directly and call
+ * `saveSelectedHostIds` only to mirror localStorage, so subscribers here
+ * won't be flooded by every in-app multi-host change.
+ *
+ * The channel is event-name-keyed (one channel for all projects);
+ * subscribers re-read with their own `projectId` to resolve the scoped
+ * key. The cross-tab `storage` filter matches the prefix
+ * `mcp-inspector-selected-hosts:` so writes to any project's key wake
+ * subscribers, who then re-read with their own projectId and ignore
+ * irrelevant changes (the re-read for the wrong project simply returns
+ * the same value).
  *
  * Lead-host changes flow through `subscribePreviewedHostId` (in
  * `previewed-client-storage.ts`); `usePersistedHost` derives the lead
@@ -191,7 +244,7 @@ export function replaceLeadHostId(
 export function subscribeSelectedHostIds(callback: () => void): () => void {
   const onCustom = () => callback();
   const onStorage = (event: StorageEvent) => {
-    if (event.key === MULTI_STORAGE_KEY) callback();
+    if (isArrayKey(event.key)) callback();
   };
   window.addEventListener(ARRAY_EVENT_NAME, onCustom);
   window.addEventListener("storage", onStorage);

--- a/mcpjam-inspector/client/src/lib/selected-host-storage.ts
+++ b/mcpjam-inspector/client/src/lib/selected-host-storage.ts
@@ -1,0 +1,202 @@
+/**
+ * Storage for the playground's persisted multi-host array — the compare-
+ * column line-up of host ids the user wants to compare side-by-side. The
+ * array lives in global localStorage under `mcp-inspector-selected-hosts`.
+ *
+ * This file owns the array key and its same-tab channel
+ * (`selected-host-ids-changed`). It does NOT own the lead host id: the
+ * LEAD source-of-truth is the per-project "previewed host" managed by
+ * `lib/previewed-client-storage.ts` (key: `mcp-previewed-host-id`,
+ * project-scoped). `replaceLeadHostId` is the single canonical primitive
+ * that promotes a host to the lead position — it writes both the lead key
+ * (via `savePreviewedHostId`) AND rotates the array in one atomic
+ * operation, then dispatches the array channel once so subscribers see a
+ * consistent snapshot.
+ *
+ * `usePersistedHost` (in `hooks/use-persisted-host.ts`) derives the lead
+ * from `usePreviewedHostId(projectId)` and exposes
+ * `selectedHostIds` always normalized as `[leadId, ...secondaries]`, so
+ * the two cannot drift by construction.
+ *
+ * Same dispatch asymmetry as `selected-model-storage.ts`:
+ *   - `saveSelectedHostIds` does NOT dispatch a same-tab event. In-app
+ *     React setters call it only to mirror localStorage, and a round-trip
+ *     through a same-tab event would race with pending setStates in the
+ *     same batch (see the multi-select regression that motivated the
+ *     selected-model fix in PR #2171).
+ *   - `replaceLeadHostId` DOES dispatch, because it's the outside-seam
+ *     write — fired by host-snapshot apply or by the future
+ *     `MultiHostPicker` promotion path. Subscribers re-read on the next
+ *     event tick.
+ *   - Cross-tab `storage` events on the array key are forwarded to
+ *     subscribers for free.
+ *
+ * Count-preservation invariant: column count is a workspace preference,
+ * not a host property. Switching hosts must swap the lead in place, never
+ * grow or shrink the array. `replaceLeadHostId` rotates an existing entry
+ * to slot 0 or replaces slot 0 in-place; it never appends or pops.
+ */
+import { savePreviewedHostId } from "@/lib/previewed-client-storage";
+
+const MULTI_STORAGE_KEY = "mcp-inspector-selected-hosts";
+const ARRAY_EVENT_NAME = "selected-host-ids-changed";
+
+function normalizeSelectedHostIds(hostIds: unknown): string[] {
+  if (!Array.isArray(hostIds)) return [];
+  const uniqueHostIds: string[] = [];
+  const seen = new Set<string>();
+  for (const hostId of hostIds) {
+    if (typeof hostId !== "string") continue;
+    const trimmed = hostId.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    uniqueHostIds.push(trimmed);
+  }
+  return uniqueHostIds;
+}
+
+function dispatchArrayChanged(): void {
+  try {
+    window.dispatchEvent(new CustomEvent(ARRAY_EVENT_NAME));
+  } catch {
+    // ignore
+  }
+}
+
+export function loadSelectedHostIds(): string[] {
+  try {
+    const raw = localStorage.getItem(MULTI_STORAGE_KEY);
+    if (typeof raw !== "string" || raw.length === 0) return [];
+    const parsed = JSON.parse(raw);
+    return normalizeSelectedHostIds(parsed);
+  } catch {
+    return [];
+  }
+}
+
+export function saveSelectedHostIds(ids: string[]): void {
+  try {
+    const normalized = normalizeSelectedHostIds(ids);
+    if (normalized.length > 0) {
+      localStorage.setItem(MULTI_STORAGE_KEY, JSON.stringify(normalized));
+    } else {
+      localStorage.removeItem(MULTI_STORAGE_KEY);
+    }
+    // Intentionally do NOT dispatch the array channel here. In-app writes
+    // flow from React setters that already updated React state directly
+    // — a round-trip through a same-tab event would re-set state to the
+    // value we just wrote and could race with pending setStates in the
+    // same batch. The host-switch outside seam uses `replaceLeadHostId`,
+    // which fires the channel itself.
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Promote a host to the lead slot. The single canonical primitive that
+ * updates both the per-project previewed host key AND the multi-host
+ * array in one atomic operation. `MultiHostPicker` and any future
+ * host-snapshot apply seam call only this; nothing else writes the
+ * previewed host key for the purpose of promotion (single-mode pickers
+ * that simply change the previewed host without rotating the array
+ * continue to use `savePreviewedHostId` directly — they don't need
+ * rotation).
+ *
+ * Semantics (mirroring `replaceLeadModelId`):
+ *   - `newHostId` null/whitespace → clear the lead key, leave array
+ *     alone.
+ *   - Array currently empty → seed with `[newHostId]`.
+ *   - `newHostId` already at slot 0 → no array change.
+ *   - `newHostId` at slot k > 0 → rotate to slot 0 (count preserved).
+ *   - `newHostId` not in array → replace slot 0 with `newHostId`
+ *     (count preserved).
+ *
+ * Both writes complete before any event is dispatched, so subscribers
+ * re-reading on the event observe a consistent snapshot.
+ */
+export function replaceLeadHostId(
+  projectId: string,
+  newHostId: string | null,
+): void {
+  const trimmed = newHostId?.trim() ?? null;
+  const next = trimmed && trimmed.length > 0 ? trimmed : null;
+
+  if (!next) {
+    // Clear the lead, leave the array alone. Matches `replaceLeadModelId(null)`
+    // semantics: clearing the lead is a "no preview" gesture, not a
+    // column-count change.
+    savePreviewedHostId(projectId, null);
+    return;
+  }
+
+  const current = loadSelectedHostIds();
+  let nextArray: string[] | null;
+  if (current.length === 0) {
+    nextArray = [next];
+  } else if (current[0] === next) {
+    nextArray = null; // no array change
+  } else {
+    const existingIdx = current.indexOf(next);
+    if (existingIdx > 0) {
+      // Rotate existing entry to the front, preserve count.
+      const rotated = current.slice();
+      rotated.splice(existingIdx, 1);
+      rotated.unshift(next);
+      nextArray = rotated;
+    } else {
+      // Replace the lead slot, preserve count.
+      nextArray = [next, ...current.slice(1)];
+    }
+  }
+
+  // Write the array directly (bypassing `saveSelectedHostIds`) so the
+  // single array event we dispatch below sees both the lead key and the
+  // array key already up to date. Subscribers that read both keys after
+  // the event observe a consistent snapshot.
+  try {
+    if (nextArray !== null) {
+      if (nextArray.length > 0) {
+        localStorage.setItem(MULTI_STORAGE_KEY, JSON.stringify(nextArray));
+      } else {
+        localStorage.removeItem(MULTI_STORAGE_KEY);
+      }
+    }
+  } catch {
+    // ignore
+  }
+  // Lead write goes through `savePreviewedHostId` so cross-surface
+  // subscribers (Connect's overlay, the existing previewed-host channel)
+  // get notified the same way they always have.
+  savePreviewedHostId(projectId, next);
+  // Fire the array channel once, AFTER both writes complete.
+  if (nextArray !== null) {
+    dispatchArrayChanged();
+  }
+}
+
+/**
+ * Subscribe to outside-seam writes of the multi-host array (currently
+ * only `replaceLeadHostId`) and cross-tab `storage` events on the array
+ * key. React-side setters intentionally do NOT fire this channel — they
+ * update React state directly and call `saveSelectedHostIds` only to
+ * mirror localStorage, so subscribers here won't be flooded by every
+ * in-app multi-host change.
+ *
+ * Lead-host changes flow through `subscribePreviewedHostId` (in
+ * `previewed-client-storage.ts`); `usePersistedHost` derives the lead
+ * from `usePreviewedHostId`, so subscribers don't need to listen to both
+ * channels here — the hook composes them.
+ */
+export function subscribeSelectedHostIds(callback: () => void): () => void {
+  const onCustom = () => callback();
+  const onStorage = (event: StorageEvent) => {
+    if (event.key === MULTI_STORAGE_KEY) callback();
+  };
+  window.addEventListener(ARRAY_EVENT_NAME, onCustom);
+  window.addEventListener("storage", onStorage);
+  return () => {
+    window.removeEventListener(ARRAY_EVENT_NAME, onCustom);
+    window.removeEventListener("storage", onStorage);
+  };
+}


### PR DESCRIPTION
## Summary

Phase 1 of the multi-host compare feature. Pure plumbing — adds the storage primitives + state hook that mirror the multi-model equivalents shipped in PR #2171. **No UI, no render path changes, no consumers wired up yet.** On its own this PR has no user-visible behavior; the hook is exported but not consumed.

This is the foundation for the polymorphic compare card (Phase 3) and the `MultiHostPicker` (Phase 2). The full multi-phase plan lives at `.claude/plans/create-a-plan-and-polymorphic-cray.md`.

## What's new

- **`client/src/lib/selected-host-storage.ts`** — owns the multi-host array key (`mcp-inspector-selected-hosts`) and its same-tab channel (`selected-host-ids-changed`). `replaceLeadHostId(projectId, hostId)` is the single canonical promotion primitive — writes the per-project previewed-host key via `savePreviewedHostId` AND rotates the array atomically with the same count-preserving algorithm as `replaceLeadModelId`. Lead source-of-truth stays in `previewed-client-storage.ts` (no new lead key).
- **`client/src/hooks/use-persisted-host.ts`** — derives the lead from `usePreviewedHostId(projectId)` and normalizes `selectedHostIds` so the lead always sits at slot 0. The array and the previewed-host key cannot drift by construction. Same dispatch asymmetry as `usePersistedModel`: in-app `setSelectedHostIds` mirrors localStorage silently; outside-seam `replaceLeadHostId` fires the channel.

Not exported from any barrel — Phase 4 wires consumers.

## Test plan

- [x] `selected-host-storage.test.ts` — 18 tests covering:
  - Round-trip `saveSelectedHostIds` / `loadSelectedHostIds` with dedupe + trim normalization
  - All four `replaceLeadHostId` branches (empty, already-at-slot-0, rotate-from-k>0, replace-slot-0)
  - `replaceLeadHostId(projectId, null)` clears the lead, leaves the array intact
  - Subscription fires once on `replaceLeadHostId` with a consistent snapshot (both keys updated)
  - `saveSelectedHostIds` does NOT fire the channel (in-app mirror path)
  - Cross-tab `storage` events on the array key trigger the subscription
  - Column-drift regression: host switch preserves multi-column count
- [x] `use-persisted-host.test.tsx` — 8 tests covering:
  - Initial state from localStorage (lead + array + toggle)
  - `setSelectedHostIds` updates state and mirrors localStorage
  - External `replaceLeadHostId` propagates into the hook on the next event tick
  - Derived-lead invariant: external `savePreviewedHostId` surfaces as `selectedHostIds[0]`, secondaries reorder
  - Multi-select regression analog: `replaceLeadHostId` then `setSelectedHostIds(["a", "b"])` yields `["a", "b"]`
  - Host-switch column-count preservation through the hook
  - `setMultiHostEnabled` persists
- [x] `npm run typecheck:client` — green
- [x] Full client vitest (`npx vitest run --project client`) — 3115 passed | 6 skipped, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: new, currently unconsumed storage/hook code with extensive unit coverage; main impact is confined to localStorage keys and same-tab/cross-tab event wiring.
> 
> **Overview**
> Introduces **project-scoped multi-host compare persistence** via new `selected-host-storage` primitives (`load/saveSelectedHostIds`, `replaceLeadHostId`, `subscribeSelectedHostIds`) that keep the lead host and stored array aligned while *preserving column count* (rotate-or-replace slot 0; never append) and emitting an explicit same-tab channel only for outside-seam promotions.
> 
> Adds `usePersistedHost(projectId)` to compose the stored array with the per-project previewed host, persist a per-project `multiHostEnabled` toggle, and defensively re-shape `selectedHostIds` when external `savePreviewedHostId` updates bypass promotion logic. Includes comprehensive unit tests covering normalization, project scoping, event behavior, and regression scenarios around column-count drift and multi-select sequencing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e48aa7d48d6affb635312860e87058a71aa0cadf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->