### PR TITLE
project-scoped server config: DTO mirror (P1)

### DIFF
--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -164,6 +164,15 @@ export type HostConfigMcpProfileV1 = {
 /**
  * Mutable input shape. All fields are required at write time so the editor
  * can't accidentally erase a section.
+ *
+ * Note: the backend validator (`hostConfigInputV2Validator` in
+ * `mcpjam-backend/convex/lib/hostConfigV2.ts`) has been relaxed to make
+ * `serverIds`, `optionalServerIds`, and `serverConnectionOverrides`
+ * optional as part of the project-scoped server config rollout (Option A:
+ * optional + canonicalize → [] before hashing). The inspector type is
+ * intentionally kept strict during P1/P2/P3 so the editor draft can't
+ * silently drop a section; P4 will loosen this as the iterative-host
+ * write path stops sending server fields.
  */
 export type HostConfigInputV2 = {
   hostStyle: HostStyleId;

--- a/mcpjam-inspector/client/src/lib/project-server-config.ts
+++ b/mcpjam-inspector/client/src/lib/project-server-config.ts
@@ -1,0 +1,53 @@
+/**
+ * Frontend types for project-scoped server configuration.
+ *
+ * Mirrors `mcpjam-backend/convex/lib/projectServerConfig.ts` (kept in
+ * sync by hand, same as `client-config-v2.ts` mirrors `hostConfigV2.ts`).
+ *
+ * Phase 1 (additive): the types exist so the inspector can typecheck
+ * future call sites. P4 will swap auto-connect + the lifted Servers
+ * section to read this DTO.
+ *
+ * Storage on the backend:
+ *   - membership: `projects.serverIds` (optional array; normalized to []
+ *     at read time)
+ *   - per-server header / timeout overrides: `projectServerRefs` table
+ *     keyed by (projectId, serverId)
+ *
+ * Chatbox/eval forks do NOT read this — they keep using the per-host
+ * `serverIds` / `serverConnectionOverrides` snapshotted into their
+ * pinned hostConfig at creation time. See the
+ * "Project-scoped server connections" memory entry for the full
+ * iterative-vs-fork split.
+ */
+
+/** Per-server connection override entry. Same shape as
+ * `HostConfigInputV2.serverConnectionOverrides[serverId]` so a chatbox
+ * fork can snapshot the project's overrides into its hostConfig without
+ * re-shaping. */
+export type ProjectServerOverrideEntry = {
+  headersOverride?: Record<string, string>;
+  requestTimeoutOverride?: number;
+};
+
+/** Write payload for `ensureProjectServerConfig`. `overrides` is keyed
+ * by serverId; entries for ids not in `serverIds` are rejected by the
+ * backend. */
+export type ProjectServerConfigInput = {
+  serverIds: string[];
+  overrides: Record<string, ProjectServerOverrideEntry>;
+};
+
+/** Read shape returned by `getProjectServerConfig`. Identical to the
+ * input plus the projectId stamped on so callers can key caches by
+ * project without an extra round trip. */
+export type ProjectServerConfigDto = ProjectServerConfigInput & {
+  projectId: string;
+};
+
+/** Empty / "no servers configured yet" default. Use as the seed value
+ * for new project drafts before any save has happened. */
+export const emptyProjectServerConfigInput = (): ProjectServerConfigInput => ({
+  serverIds: [],
+  overrides: {},
+});


### PR DESCRIPTION
## Summary

Frontend half of the P1 additive slice for project-scoped server config. Companion to [MCPJam/mcpjam-backend#306](https://github.com/MCPJam/mcpjam-backend/pull/306) which adds `projects.serverIds` + `projectServerRefs` + the `ensureProjectServerConfig` mutation.

- New `client/src/lib/project-server-config.ts` mirrors the backend DTO (`ProjectServerConfigInput` / `ProjectServerConfigDto` / `emptyProjectServerConfigInput`). Kept in sync by hand, same convention as `client-config-v2.ts` ↔ `convex/lib/hostConfigV2.ts`.
- `HostConfigInputV2` in `client-config-v2.ts` kept strict for now — loosening `serverIds` / `optionalServerIds` to optional in the inspector type would cascade TS errors across the editor (ClientConfigEditor, ClientFocusPanel, canvas builders, useJsonDraftBuffer, etc.). The backend validator already accepts the optional shape; P4 will loosen the inspector type as the iterative-host write path stops sending server fields.

No read sites switched, no UI changes. The Project Settings → Servers section and the Servers-tab removal land in P4.

## Test plan

- [x] `npm run typecheck:client` — clean
- [x] `npm test` — 4174 passed / 6 skipped across 420 test files
- [ ] Backend PR merges first (no consumers yet in this PR, so order is flexible; backend ships independently)

## Notes

- Paired with backend PR https://github.com/MCPJam/mcpjam-backend/pull/306.
- Next phases (P2 migration, P3 chatbox/eval pin architecture, P4 read-swap + UI) are independently shippable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, type-only changes with no new runtime logic or call sites. Main risk is minor type drift versus the backend DTO if the hand-synced shapes diverge.
> 
> **Overview**
> Introduces a new `project-server-config.ts` module that mirrors the backend project-scoped server configuration DTOs (`ProjectServerConfigInput`/`ProjectServerConfigDto`) and provides an `emptyProjectServerConfigInput` seed value.
> 
> Updates `HostConfigInputV2` documentation to note that the backend now accepts optional server fields during the rollout, while intentionally keeping the inspector input type strict for now (no behavior changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41ddc596a823dfcc9d3d7c789684957c0a8aade0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->