### PR TITLE
feat(playground): MultiHostPicker UI (Phase 2)

### DIFF
--- a/mcpjam-inspector/client/src/components/clients/MultiHostPicker.tsx
+++ b/mcpjam-inspector/client/src/components/clients/MultiHostPicker.tsx
@@ -1,0 +1,445 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, Server, X } from "lucide-react";
+import { Button } from "@mcpjam/design-system/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@mcpjam/design-system/popover";
+import { Switch } from "@mcpjam/design-system/switch";
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@mcpjam/design-system/command";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+import { cn } from "@/lib/utils";
+import type { HostListItem } from "@/hooks/useClients";
+
+/**
+ * MultiHostPicker — playground host pill that supports comparing up to N
+ * hosts side-by-side. Structurally mirrors `chat-v2/chat-input/model-selector.tsx`:
+ *
+ *   - Trigger button shows the lead host name; when multi-host is enabled
+ *     with more than one host selected, appends "+N".
+ *   - Popover contains: search input, "Multiple hosts" switch row, chip
+ *     strip (lead + secondaries; clicking a secondary promotes it to lead),
+ *     and a flat host list. Each row gets a checkbox when multi-host is
+ *     enabled.
+ *
+ * This component is intentionally dumb about WHERE the data comes from. The
+ * wrapper (`PlaygroundHostPicker`) calls all hooks (`useHostList`,
+ * `usePersistedHost`, `usePreviewedHostId`) and threads the values in. The
+ * only promotion primitive the picker uses is `onPromoteLead`, which the
+ * wrapper implements as `replaceLeadHostId(projectId, hostId)` per the
+ * canonical-write contract from Phase 1 (`selected-host-storage.ts`).
+ *
+ * Phase 2 scope (this PR): UI + state writes only. Toggling "Multiple hosts"
+ * on persists `multiHostEnabled` + `selectedHostIds` to localStorage but
+ * does NOT change the playground render path; that lands in Phase 4.
+ */
+
+export interface MultiHostPickerProps {
+  projectId: string | null;
+  hosts: HostListItem[];
+  /** Lead host id (from `usePreviewedHostId`). */
+  currentHostId: string | null;
+  /** Persisted compare-column line-up (from `usePersistedHost`). */
+  selectedHostIds: string[];
+  multiHostEnabled: boolean;
+  onMultiHostEnabledChange: (enabled: boolean) => void;
+  onSelectedHostIdsChange: (ids: string[]) => void;
+  /**
+   * Wraps `replaceLeadHostId(projectId, hostId)`. The ONLY promotion path
+   * the picker may use; do NOT pass a `setPreviewedHostId` directly.
+   */
+  onPromoteLead: (hostId: string) => void;
+  disabled?: boolean;
+  isLoading?: boolean;
+  maxSelectedHosts?: number;
+}
+
+type PendingHostSelectionChange =
+  | { type: "single"; nextHostId: string }
+  | { type: "multi"; enabled: boolean; selectedHostIds: string[] };
+
+function sameHostIdOrder(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) return false;
+  return left.every((id, index) => id === right[index]);
+}
+
+function compactHostLabel(name: string): string {
+  if (!name) return "Host";
+  return name;
+}
+
+export function MultiHostPicker({
+  projectId: _projectId,
+  hosts,
+  currentHostId,
+  selectedHostIds,
+  multiHostEnabled,
+  onMultiHostEnabledChange,
+  onSelectedHostIdsChange,
+  onPromoteLead,
+  disabled,
+  isLoading,
+  maxSelectedHosts = 3,
+}: MultiHostPickerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const keepPopoverOpenRef = useRef(false);
+  const keepPopoverOpenTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (
+        typeof window !== "undefined" &&
+        keepPopoverOpenTimeoutRef.current !== null
+      ) {
+        window.clearTimeout(keepPopoverOpenTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  // Same pattern as model-selector.tsx:143-159. Clicks in the switch row /
+  // chip strip flip this ref on; the next `onOpenChange(false)` is then
+  // suppressed. The 0-timeout clears the ref on the next tick so subsequent
+  // outside clicks close the popover normally.
+  const requestPopoverStayOpen = () => {
+    keepPopoverOpenRef.current = true;
+    setIsOpen(true);
+
+    if (typeof window === "undefined") return;
+
+    if (keepPopoverOpenTimeoutRef.current !== null) {
+      window.clearTimeout(keepPopoverOpenTimeoutRef.current);
+    }
+
+    keepPopoverOpenTimeoutRef.current = window.setTimeout(() => {
+      keepPopoverOpenRef.current = false;
+      keepPopoverOpenTimeoutRef.current = null;
+    }, 0);
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && keepPopoverOpenRef.current) return;
+
+    if (
+      typeof window !== "undefined" &&
+      keepPopoverOpenTimeoutRef.current !== null
+    ) {
+      window.clearTimeout(keepPopoverOpenTimeoutRef.current);
+      keepPopoverOpenTimeoutRef.current = null;
+    }
+    keepPopoverOpenRef.current = false;
+    setIsOpen(nextOpen);
+  };
+
+  // Effective selected ids: when the multi-host array is empty (e.g. before
+  // the user has ever toggled multi-host on) we use the lead as the single
+  // implicit selection. Mirrors `selectedModelsData` in model-selector.tsx:187-190.
+  const effectiveSelectedHostIds = useMemo(() => {
+    if (selectedHostIds.length > 0) return selectedHostIds;
+    return currentHostId ? [currentHostId] : [];
+  }, [selectedHostIds, currentHostId]);
+
+  const selectedIds = useMemo(
+    () => new Set(effectiveSelectedHostIds),
+    [effectiveSelectedHostIds],
+  );
+
+  const hostsById = useMemo(() => {
+    const map = new Map<string, HostListItem>();
+    for (const host of hosts) map.set(host.hostId, host);
+    return map;
+  }, [hosts]);
+
+  const leadHostId = effectiveSelectedHostIds[0] ?? currentHostId ?? null;
+  const leadHost = leadHostId ? (hostsById.get(leadHostId) ?? null) : null;
+  const leadHostName = leadHost?.name ?? "Select host";
+
+  const triggerLabel =
+    multiHostEnabled && effectiveSelectedHostIds.length > 1
+      ? `${compactHostLabel(leadHostName)} +${effectiveSelectedHostIds.length - 1}`
+      : compactHostLabel(leadHostName);
+
+  // Toggle is only usable when there are at least 2 hosts to compare;
+  // otherwise display a tooltip explaining the requirement. Matches the
+  // plan's "single-host project guard" decision (table row 7).
+  const canUseMultiHost = hosts.length > 1;
+  const selectedLimitReached =
+    multiHostEnabled && effectiveSelectedHostIds.length >= maxSelectedHosts;
+
+  const requestSelectionChange = (nextChange: PendingHostSelectionChange) => {
+    const isSingleNoOp =
+      nextChange.type === "single" &&
+      nextChange.nextHostId === (currentHostId ?? "");
+    const isMultiNoOp =
+      nextChange.type === "multi" &&
+      nextChange.enabled === multiHostEnabled &&
+      sameHostIdOrder(
+        nextChange.selectedHostIds,
+        effectiveSelectedHostIds,
+      );
+
+    if (isSingleNoOp) {
+      setIsOpen(false);
+      return;
+    }
+    if (isMultiNoOp) return;
+
+    if (nextChange.type === "single") {
+      onPromoteLead(nextChange.nextHostId);
+      setIsOpen(false);
+    } else {
+      onSelectedHostIdsChange(nextChange.selectedHostIds);
+      onMultiHostEnabledChange(nextChange.enabled);
+    }
+  };
+
+  const handleToggleMultiHost = (enabled: boolean) => {
+    if (!canUseMultiHost) return;
+
+    requestPopoverStayOpen();
+
+    if (enabled) {
+      // Seed the array with the current lead so multi-host opens with the
+      // lead already selected; the user adds others incrementally.
+      requestSelectionChange({
+        type: "multi",
+        enabled: true,
+        selectedHostIds:
+          effectiveSelectedHostIds.length > 0
+            ? effectiveSelectedHostIds
+            : leadHostId
+              ? [leadHostId]
+              : [],
+      });
+      return;
+    }
+
+    requestSelectionChange({
+      type: "multi",
+      enabled: false,
+      selectedHostIds: leadHostId ? [leadHostId] : [],
+    });
+  };
+
+  const handleMultiHostSelect = (hostId: string) => {
+    requestPopoverStayOpen();
+
+    const isSelected = selectedIds.has(hostId);
+    const nextSelectedHostIds = isSelected
+      ? effectiveSelectedHostIds.filter((id) => id !== hostId)
+      : [...effectiveSelectedHostIds, hostId];
+
+    // Mirror model-selector.tsx:338-340: never allow the array to collapse
+    // to empty — at least the lead has to stay.
+    if (nextSelectedHostIds.length === 0) return;
+
+    requestSelectionChange({
+      type: "multi",
+      enabled: true,
+      selectedHostIds: nextSelectedHostIds,
+    });
+  };
+
+  const handlePromoteLeadFromChip = (hostId: string) => {
+    if (!multiHostEnabled || hostId === leadHostId) return;
+    requestPopoverStayOpen();
+    onPromoteLead(hostId);
+  };
+
+  return (
+    <Popover open={isOpen} onOpenChange={handleOpenChange}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={disabled || isLoading}
+              className="h-8 max-w-[200px] rounded-full px-2 text-xs transition-colors hover:bg-muted/80"
+              data-testid="multi-host-picker-trigger"
+            >
+              <Server className="h-3.5 w-3.5 shrink-0" />
+              <span className="truncate text-[10px] font-medium">
+                {triggerLabel}
+              </span>
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="top">{triggerLabel}</TooltipContent>
+      </Tooltip>
+
+      <PopoverContent align="start" className="w-[280px] p-0" sideOffset={8}>
+        <Command shouldFilter={true}>
+          <CommandInput placeholder="Search hosts" />
+
+          <div className="flex cursor-default items-center justify-between gap-2 border-b px-2.5 py-2">
+            <span className="text-xs text-muted-foreground">
+              Multiple hosts
+            </span>
+            {canUseMultiHost ? (
+              <Switch
+                checked={multiHostEnabled}
+                onCheckedChange={handleToggleMultiHost}
+                aria-label="Use multiple hosts"
+                disabled={disabled || isLoading}
+                data-testid="multi-host-toggle"
+              />
+            ) : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <Switch
+                      checked={false}
+                      onCheckedChange={() => {}}
+                      aria-label="Use multiple hosts"
+                      disabled
+                      data-testid="multi-host-toggle"
+                    />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="left">
+                  Add a second host to compare
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+
+          {multiHostEnabled ? (
+            <div
+              className="flex flex-wrap gap-1 border-b px-2.5 py-1.5"
+              title="First chip is the lead host. Click a chip to promote it."
+              data-testid="multi-host-chip-strip"
+            >
+              {effectiveSelectedHostIds.map((hostId, index) => {
+                const host = hostsById.get(hostId);
+                const isLead = index === 0;
+                const name = host?.name ?? hostId;
+                return (
+                  <button
+                    key={hostId}
+                    type="button"
+                    data-testid={`multi-host-chip-${hostId}`}
+                    className={cn(
+                      "inline-flex max-w-full items-center gap-1 rounded-md border px-1.5 py-0.5 text-[11px] transition-colors",
+                      isLead
+                        ? "border-primary/25 bg-primary/5 text-foreground"
+                        : "border-border/50 bg-muted/30 text-muted-foreground hover:text-foreground",
+                    )}
+                    onClick={() => handlePromoteLeadFromChip(hostId)}
+                  >
+                    <Server className="size-3" />
+                    <span className="truncate">{compactHostLabel(name)}</span>
+                    {effectiveSelectedHostIds.length > 1 ? (
+                      <span
+                        role="button"
+                        tabIndex={-1}
+                        aria-label={`Remove ${name}`}
+                        data-testid={`multi-host-chip-remove-${hostId}`}
+                        className="inline-flex size-3.5 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          handleMultiHostSelect(hostId);
+                        }}
+                      >
+                        <X className="h-2.5 w-2.5" />
+                      </span>
+                    ) : null}
+                  </button>
+                );
+              })}
+              {selectedLimitReached ? (
+                <span className="w-full text-[10px] text-muted-foreground">
+                  Max {maxSelectedHosts}. Remove one to add another.
+                </span>
+              ) : null}
+            </div>
+          ) : null}
+
+          <CommandList className="max-h-[min(320px,45vh)]">
+            <CommandEmpty>No matching hosts.</CommandEmpty>
+
+            {hosts.map((host) => {
+              const isSelected = selectedIds.has(host.hostId);
+              const isLimitedOut =
+                multiHostEnabled && !isSelected && selectedLimitReached;
+              const isDisabled = isLimitedOut;
+              const disabledReason = isLimitedOut
+                ? `You can compare up to ${maxSelectedHosts} hosts at once`
+                : undefined;
+
+              const row = (
+                <CommandItem
+                  key={host.hostId}
+                  value={`${host.name} ${host.hostId}`}
+                  onSelect={() => {
+                    if (multiHostEnabled) {
+                      handleMultiHostSelect(host.hostId);
+                    } else {
+                      requestSelectionChange({
+                        type: "single",
+                        nextHostId: host.hostId,
+                      });
+                    }
+                  }}
+                  disabled={isDisabled}
+                  className="cursor-pointer rounded-sm px-2 py-1 data-[disabled=true]:cursor-not-allowed"
+                  data-testid={`multi-host-row-${host.hostId}`}
+                >
+                  <Server className="size-3.5 shrink-0" />
+                  <span className="min-w-0 flex-1 truncate text-sm">
+                    {compactHostLabel(host.name)}
+                  </span>
+                  {multiHostEnabled ? (
+                    <div
+                      className={cn(
+                        "ml-auto flex size-4 shrink-0 items-center justify-center rounded-[5px] border transition-[background-color,border-color,box-shadow] duration-200 ease-[cubic-bezier(0.33,1,0.68,1)]",
+                        isSelected
+                          ? "border-primary bg-primary shadow-sm"
+                          : "border-border/60 bg-transparent hover:border-border",
+                      )}
+                      aria-hidden
+                      data-testid={`multi-host-checkbox-${host.hostId}`}
+                      data-checked={isSelected ? "true" : "false"}
+                    >
+                      {isSelected ? (
+                        <Check
+                          strokeWidth={3}
+                          className="size-2.5 animate-in zoom-in-95 fade-in duration-200 fill-none text-primary-foreground"
+                        />
+                      ) : null}
+                    </div>
+                  ) : host.hostId === currentHostId ? (
+                    <div className="ml-auto size-1.5 shrink-0 rounded-full bg-primary" />
+                  ) : null}
+                </CommandItem>
+              );
+
+              return disabledReason ? (
+                <Tooltip key={host.hostId}>
+                  <TooltipTrigger asChild>
+                    <div className="rounded-sm transition-colors hover:bg-accent/60">
+                      {row}
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="right">{disabledReason}</TooltipContent>
+                </Tooltip>
+              ) : (
+                row
+              );
+            })}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/mcpjam-inspector/client/src/components/clients/__tests__/MultiHostPicker.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/__tests__/MultiHostPicker.test.tsx
@@ -1,0 +1,267 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MultiHostPicker } from "@/components/clients/MultiHostPicker";
+import type { HostListItem } from "@/hooks/useClients";
+
+const hostA: HostListItem = {
+  hostId: "host-a",
+  name: "MCPJam",
+  hostConfigId: "cfg-a",
+  modelId: "m-a",
+  serverCount: 0,
+  createdAt: 1,
+  updatedAt: 1,
+};
+
+const hostB: HostListItem = {
+  hostId: "host-b",
+  name: "Claude",
+  hostConfigId: "cfg-b",
+  modelId: "m-b",
+  serverCount: 0,
+  createdAt: 2,
+  updatedAt: 2,
+};
+
+const hostC: HostListItem = {
+  hostId: "host-c",
+  name: "Codex",
+  hostConfigId: "cfg-c",
+  modelId: "m-c",
+  serverCount: 0,
+  createdAt: 3,
+  updatedAt: 3,
+};
+
+const hostD: HostListItem = {
+  hostId: "host-d",
+  name: "ChatGPT",
+  hostConfigId: "cfg-d",
+  modelId: "m-d",
+  serverCount: 0,
+  createdAt: 4,
+  updatedAt: 4,
+};
+
+interface RenderOptions {
+  hosts: HostListItem[];
+  currentHostId: string | null;
+  selectedHostIds?: string[];
+  multiHostEnabled?: boolean;
+  onMultiHostEnabledChange?: ReturnType<typeof vi.fn>;
+  onSelectedHostIdsChange?: ReturnType<typeof vi.fn>;
+  onPromoteLead?: ReturnType<typeof vi.fn>;
+  maxSelectedHosts?: number;
+}
+
+function renderPicker(opts: RenderOptions) {
+  const onPromoteLead = opts.onPromoteLead ?? vi.fn();
+  const onMultiHostEnabledChange = opts.onMultiHostEnabledChange ?? vi.fn();
+  const onSelectedHostIdsChange = opts.onSelectedHostIdsChange ?? vi.fn();
+  const utils = render(
+    <MultiHostPicker
+      projectId="proj-1"
+      hosts={opts.hosts}
+      currentHostId={opts.currentHostId}
+      selectedHostIds={opts.selectedHostIds ?? []}
+      multiHostEnabled={opts.multiHostEnabled ?? false}
+      onMultiHostEnabledChange={onMultiHostEnabledChange}
+      onSelectedHostIdsChange={onSelectedHostIdsChange}
+      onPromoteLead={onPromoteLead}
+      maxSelectedHosts={opts.maxSelectedHosts}
+    />,
+  );
+  return { ...utils, onPromoteLead, onMultiHostEnabledChange, onSelectedHostIdsChange };
+}
+
+describe("MultiHostPicker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the lead host name in the trigger", () => {
+    renderPicker({ hosts: [hostA], currentHostId: "host-a" });
+    expect(screen.getByTestId("multi-host-picker-trigger")).toHaveTextContent(
+      "MCPJam",
+    );
+  });
+
+  it("disables the Multiple hosts switch with a tooltip when only one host exists", async () => {
+    const user = userEvent.setup();
+    renderPicker({ hosts: [hostA], currentHostId: "host-a" });
+
+    await user.click(screen.getByTestId("multi-host-picker-trigger"));
+
+    const toggle = await screen.findByTestId("multi-host-toggle");
+    expect(toggle).toBeDisabled();
+  });
+
+  it("calls onPromoteLead when picking another host in single-mode", async () => {
+    const user = userEvent.setup();
+    const { onPromoteLead } = renderPicker({
+      hosts: [hostA, hostB],
+      currentHostId: "host-a",
+    });
+
+    await user.click(screen.getByTestId("multi-host-picker-trigger"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("multi-host-row-host-b")).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByTestId("multi-host-row-host-b"));
+
+    expect(onPromoteLead).toHaveBeenCalledWith("host-b");
+  });
+
+  it("toggles Multiple hosts on, shows chip strip with current lead, and renders checkboxes", async () => {
+    const user = userEvent.setup();
+    const onMultiHostEnabledChange = vi.fn();
+    const onSelectedHostIdsChange = vi.fn();
+    renderPicker({
+      hosts: [hostA, hostB],
+      currentHostId: "host-a",
+      onMultiHostEnabledChange,
+      onSelectedHostIdsChange,
+    });
+
+    await user.click(screen.getByTestId("multi-host-picker-trigger"));
+
+    const toggle = await screen.findByTestId("multi-host-toggle");
+    expect(toggle).not.toBeDisabled();
+
+    await user.click(toggle);
+
+    expect(onMultiHostEnabledChange).toHaveBeenCalledWith(true);
+    expect(onSelectedHostIdsChange).toHaveBeenCalledWith(["host-a"]);
+  });
+
+  it("with multi-host enabled, shows the chip strip including the lead and renders checkbox affordances", async () => {
+    const user = userEvent.setup();
+    renderPicker({
+      hosts: [hostA, hostB],
+      currentHostId: "host-a",
+      selectedHostIds: ["host-a"],
+      multiHostEnabled: true,
+    });
+
+    await user.click(screen.getByTestId("multi-host-picker-trigger"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("multi-host-chip-strip")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("multi-host-chip-host-a")).toHaveTextContent(
+      "MCPJam",
+    );
+    expect(
+      screen.getByTestId("multi-host-checkbox-host-a"),
+    ).toHaveAttribute("data-checked", "true");
+    expect(
+      screen.getByTestId("multi-host-checkbox-host-b"),
+    ).toHaveAttribute("data-checked", "false");
+  });
+
+  it("selecting a second host in multi-mode appends it to selectedHostIds", async () => {
+    const user = userEvent.setup();
+    const onSelectedHostIdsChange = vi.fn();
+    renderPicker({
+      hosts: [hostA, hostB],
+      currentHostId: "host-a",
+      selectedHostIds: ["host-a"],
+      multiHostEnabled: true,
+      onSelectedHostIdsChange,
+    });
+
+    await user.click(screen.getByTestId("multi-host-picker-trigger"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("multi-host-row-host-b")).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByTestId("multi-host-row-host-b"));
+
+    expect(onSelectedHostIdsChange).toHaveBeenCalledWith(["host-a", "host-b"]);
+  });
+
+  it("blocks deselecting the last selected host (length never reaches zero)", async () => {
+    const user = userEvent.setup();
+    const onSelectedHostIdsChange = vi.fn();
+    renderPicker({
+      hosts: [hostA, hostB],
+      currentHostId: "host-a",
+      selectedHostIds: ["host-a"],
+      multiHostEnabled: true,
+      onSelectedHostIdsChange,
+    });
+
+    await user.click(screen.getByTestId("multi-host-picker-trigger"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("multi-host-row-host-a")).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByTestId("multi-host-row-host-a"));
+
+    expect(onSelectedHostIdsChange).not.toHaveBeenCalled();
+  });
+
+  it("clicking a non-lead chip promotes that host to lead", async () => {
+    const user = userEvent.setup();
+    const onPromoteLead = vi.fn();
+    renderPicker({
+      hosts: [hostA, hostB],
+      currentHostId: "host-a",
+      selectedHostIds: ["host-a", "host-b"],
+      multiHostEnabled: true,
+      onPromoteLead,
+    });
+
+    await user.click(screen.getByTestId("multi-host-picker-trigger"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("multi-host-chip-host-b")).toBeInTheDocument(),
+    );
+
+    await user.click(screen.getByTestId("multi-host-chip-host-b"));
+
+    expect(onPromoteLead).toHaveBeenCalledWith("host-b");
+  });
+
+  it("disables unselected rows when selection has hit the max-selected limit", async () => {
+    const user = userEvent.setup();
+    renderPicker({
+      hosts: [hostA, hostB, hostC, hostD],
+      currentHostId: "host-a",
+      selectedHostIds: ["host-a", "host-b", "host-c"],
+      multiHostEnabled: true,
+      maxSelectedHosts: 3,
+    });
+
+    await user.click(screen.getByTestId("multi-host-picker-trigger"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("multi-host-row-host-d")).toBeInTheDocument(),
+    );
+
+    const rowD = screen.getByTestId("multi-host-row-host-d");
+    expect(rowD).toHaveAttribute("data-disabled", "true");
+
+    // Already-selected rows stay enabled so the user can deselect them.
+    const rowA = screen.getByTestId("multi-host-row-host-a");
+    expect(rowA).not.toHaveAttribute("data-disabled", "true");
+  });
+
+  it("shows +N in the trigger when multi-host has more than one selected", () => {
+    renderPicker({
+      hosts: [hostA, hostB, hostC],
+      currentHostId: "host-a",
+      selectedHostIds: ["host-a", "host-b", "host-c"],
+      multiHostEnabled: true,
+    });
+
+    expect(screen.getByTestId("multi-host-picker-trigger")).toHaveTextContent(
+      "MCPJam +2",
+    );
+  });
+});

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundCenterHeaderBar.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundCenterHeaderBar.tsx
@@ -26,6 +26,13 @@ interface Props {
   protocol: UIType | null;
   isMultiModelLayoutMode: boolean;
   trailing?: ReactNode;
+  /**
+   * Optional leading control rendered at the start of the chrome row,
+   * ahead of the `ClientContextHeader` chips. Used by the playground to
+   * surface the multi-host picker (Phase 2). Kept generic so future
+   * leading controls (e.g. saved-view picker) can slot in here too.
+   */
+  leading?: ReactNode;
 }
 
 export function PlaygroundCenterHeaderBar({
@@ -37,11 +44,13 @@ export function PlaygroundCenterHeaderBar({
   protocol,
   isMultiModelLayoutMode,
   trailing,
+  leading,
 }: Props) {
   const chromeRowClass = cn(
     "relative flex min-w-0 items-center justify-center gap-2 text-xs text-muted-foreground",
     showTraceTabs ? "border-b border-border/60 px-3 py-1.5" : "h-11 px-3",
     trailing && "pe-11",
+    leading && "ps-11",
   );
 
   return (
@@ -53,6 +62,11 @@ export function PlaygroundCenterHeaderBar({
       data-testid="playground-main-header"
     >
       <div className={chromeRowClass}>
+        {leading ? (
+          <div className="pointer-events-none absolute inset-y-0 start-3 z-10 flex items-center">
+            <div className="pointer-events-auto">{leading}</div>
+          </div>
+        ) : null}
         <div className="flex min-w-0 w-full justify-center overflow-x-auto overflow-y-hidden [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           <ClientContextHeader
             activeProjectId={activeProjectId}

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundHostPicker.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundHostPicker.tsx
@@ -1,0 +1,71 @@
+import { useCallback } from "react";
+import { useConvexAuth } from "convex/react";
+import { useHostList } from "@/hooks/useClients";
+import { usePersistedHost } from "@/hooks/use-persisted-host";
+import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
+import { replaceLeadHostId } from "@/lib/selected-host-storage";
+import { MultiHostPicker } from "@/components/clients/MultiHostPicker";
+
+interface PlaygroundHostPickerProps {
+  projectId: string | null;
+  disabled?: boolean;
+}
+
+/**
+ * Playground-specific wrapper around `MultiHostPicker`. Calls the
+ * data/storage hooks (`useHostList`, `usePersistedHost`,
+ * `usePreviewedHostId`) and threads values into the dumb picker. The only
+ * promotion primitive used is `replaceLeadHostId` (canonical per Phase 1's
+ * `selected-host-storage.ts` contract — never `setPreviewedHostId`
+ * directly).
+ *
+ * Phase 2 scope: this picker persists `multiHostEnabled` + `selectedHostIds`
+ * to localStorage but does NOT yet change the playground render path.
+ * Phase 4 wires `selectedHostIds` into the multi-host grid. Until then,
+ * toggling "Multiple hosts" on persists state but the playground stays
+ * single-host.
+ */
+export function PlaygroundHostPicker({
+  projectId,
+  disabled,
+}: PlaygroundHostPickerProps) {
+  const { isAuthenticated } = useConvexAuth();
+  const { hosts, isLoading } = useHostList({
+    isAuthenticated,
+    projectId,
+  });
+  const [previewedHostId] = usePreviewedHostId(projectId);
+  const {
+    selectedHostIds,
+    setSelectedHostIds,
+    multiHostEnabled,
+    setMultiHostEnabled,
+  } = usePersistedHost(projectId);
+
+  const handlePromoteLead = useCallback(
+    (hostId: string) => {
+      if (!projectId) return;
+      // Canonical single primitive: writes the per-project previewed host
+      // key AND rotates the multi-host array in one atomic operation. See
+      // `selected-host-storage.ts` and the plan's lead-host promotion path
+      // decision.
+      replaceLeadHostId(projectId, hostId);
+    },
+    [projectId],
+  );
+
+  return (
+    <MultiHostPicker
+      projectId={projectId}
+      hosts={hosts}
+      currentHostId={previewedHostId}
+      selectedHostIds={selectedHostIds}
+      multiHostEnabled={multiHostEnabled}
+      onMultiHostEnabledChange={setMultiHostEnabled}
+      onSelectedHostIdsChange={setSelectedHostIds}
+      onPromoteLead={handlePromoteLead}
+      disabled={disabled || !projectId}
+      isLoading={isLoading}
+    />
+  );
+}

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -116,6 +116,7 @@ import {
 } from "@/hooks/use-chat-stop-controls";
 import { HandDrawnSendHint } from "./HandDrawnSendHint";
 import { PlaygroundCenterHeaderBar } from "@/components/playground/PlaygroundCenterHeaderBar";
+import { PlaygroundHostPicker } from "@/components/playground/PlaygroundHostPicker";
 import { SingleModelTraceDiagnosticsBody } from "@/components/evals/single-model-trace-diagnostics-body";
 import type { PlaygroundServerSelectorProps } from "@/components/ActiveServerSelector";
 import {
@@ -2443,6 +2444,14 @@ export function PlaygroundMain({
           onSaveHostContext={onSaveHostContext}
           protocol={selectedProtocol}
           isMultiModelLayoutMode={isMultiModelLayoutMode}
+          leading={
+            // Phase 2: playground-scoped multi-host picker. Persists the
+            // multi-host array + toggle to localStorage but does NOT yet
+            // change the playground render path (that lands in Phase 4).
+            // The global `GlobalClientBar` remains the host pill for other
+            // tabs; both surfaces stay in sync via shared `usePreviewedHostId`.
+            <PlaygroundHostPicker projectId={activeProjectId} />
+          }
           trailing={
             effectiveHasMessages ? (
               <Tooltip>

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -57,6 +57,10 @@ vi.mock("lucide-react", () => ({
   ArrowLeft: () => <span data-testid="icon-arrow-left" />,
   Code2: () => <span data-testid="icon-code2" />,
   MessageSquare: () => <span data-testid="icon-message-square" />,
+  // Icons used by MultiHostPicker (rendered via PlaygroundHostPicker in the
+  // header `leading` slot)
+  Server: () => <span data-testid="icon-server" />,
+  X: () => <span data-testid="icon-x" />,
 }));
 
 // Mock UI components
@@ -484,6 +488,14 @@ vi.mock("@/components/shared/ClientContextHeader", () => ({
     tablet: { width: 768, height: 1024, label: "Tablet", icon: () => null },
     desktop: { width: 1280, height: 800, label: "Desktop", icon: () => null },
   },
+}));
+
+// Stub the playground host picker — its data hooks (Convex auth, host list,
+// previewed-host storage) are out of scope for these PlaygroundMain tests.
+vi.mock("@/components/playground/PlaygroundHostPicker", () => ({
+  PlaygroundHostPicker: () => (
+    <div data-testid="playground-host-picker-stub" />
+  ),
 }));
 
 // Mock traffic log store


### PR DESCRIPTION
## Summary

Phase 2 of the multi-host compare feature: ships the `MultiHostPicker`
UI. Plan: `/Users/marcelojimenezrocabado/.claude/plans/create-a-plan-and-polymorphic-cray.md`
(Phase 1 storage primitives merged in #2178).

- New `MultiHostPicker` (`client/src/components/clients/MultiHostPicker.tsx`)
  structurally clones `chat-v2/chat-input/model-selector.tsx`: trigger
  with lead host name + `+N` chip when multi-host is on; popover with
  search, "Multiple hosts" switch row, lead-chip strip (clickable to
  promote), flat host list with checkbox affordances and a max-selected
  guard.
- New `PlaygroundHostPicker` wrapper
  (`client/src/components/playground/PlaygroundHostPicker.tsx`) calls
  the data hooks (`useHostList`, `usePersistedHost`,
  `usePreviewedHostId`) and routes promotion through `replaceLeadHostId`
  — the single canonical primitive from Phase 1. No
  `setPreviewedHostId` calls from the picker.
- `PlaygroundCenterHeaderBar` gets a new optional `leading` slot;
  `PlaygroundMain` mounts `PlaygroundHostPicker` there.

## v1-staging note (important)

**This PR persists `selectedHostIds` + `multiHostEnabled` but does not
change what renders in the grid.** Phase 4 is the one that wires the
array into the multi-host render path. Until then, toggling "Multiple
hosts" on persists state but the playground stays single-host. This is
intentional and the picker still drives single-mode lead changes
correctly through `replaceLeadHostId`.

## Host pill location decision

The plan suggested the host pill lives in `PlaygroundCenterHeaderBar`,
but it does not — the existing host pill is the global `GlobalClientBar`
/ `ClientOverlayBar` in the app's top bar, used by every tab
(playground, clients, servers, chat-v2, etc.). To keep the blast radius
of this PR to the playground only, the new picker is added as new UI in
the playground header's `leading` slot. The global host bar is left
intact for other tabs. Both surfaces share `usePreviewedHostId` so
selecting a host in either reflects in the other.

The global host pill stays as the single-select surface for non-
playground tabs in this PR. A follow-up can decide whether to migrate
it to `MultiHostPicker` or keep `ClientOverlayBar` for tabs that don't
need compare mode.

## Test plan

- [x] `npm run typecheck:client` — clean
- [x] `vitest run` on `src/components/clients/__tests__/MultiHostPicker.test.tsx` — 10/10 green
- [x] Full client `vitest run` — 336 files, 3155 passing (the 7 failing
      server-side test files are pre-existing, unrelated to this PR —
      missing `SandboxProxyHtml.bundled` server build artifact)
- [x] Existing `PlaygroundMain.test.tsx` still passes (stubbed the new
      host-picker child since its hooks are out of scope there)
- [x] Existing `PlaygroundCenterHeaderBar.test.tsx` still passes
- [ ] Manual smoke: open playground, toggle "Multiple hosts" on, pick
      a second host, verify chip strip + trigger label show `+1`.
      Confirm toggling does NOT affect the playground render (Phase 4
      pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new selection UI that writes multi-host state to localStorage and changes the Playground header layout; risk is mainly UI/state-sync regressions (popover behavior, lead promotion, selection limits), not backend/security.
> 
> **Overview**
> Adds a new `MultiHostPicker` control for selecting a **lead host** and optionally enabling a **multi-host compare lineup** (with search, chips, checkmarks, max-selection guard, and lead promotion), persisting changes via callbacks.
> 
> Wires this into Playground via a new `PlaygroundHostPicker` wrapper that connects `useHostList`/`usePersistedHost`/`usePreviewedHostId` and promotes hosts through `replaceLeadHostId`, and updates `PlaygroundCenterHeaderBar` to support a `leading` slot used by `PlaygroundMain`.
> 
> Adds focused unit tests for `MultiHostPicker`, and stubs `PlaygroundHostPicker` in `PlaygroundMain` tests to keep existing coverage stable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fd015097ab4b39128a35a02ec3af2002e9e22bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->