### PR TITLE
Guard stale playground history loads

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -773,9 +773,11 @@ describe("MCPAppsRenderer tool input streaming", () => {
     const { rerender } = render(renderInline());
 
     await screen.findByTestId("sandboxed-iframe");
+    await vi.waitFor(() => {
+      expect(sandboxedIframeMountsRef.current).toBe(1);
+    });
     const initialIframeElement = sandboxedIframeElementRef.current;
     expect(initialIframeElement).not.toBeNull();
-    expect(sandboxedIframeMountsRef.current).toBe(1);
 
     rerender(
       <MCPAppsRenderer

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -324,6 +324,12 @@ export function PlaygroundMain({
     reactiveHistoryLoadRequestIdRef.current += 1;
   }, [activeHistorySessionId]);
 
+  /** Invalidate reactive history loads immediately (refs otherwise lag behind state until useEffect). */
+  const invalidatePendingReactiveHistoryLoad = useCallback(() => {
+    activeHistorySessionIdRef.current = null;
+    reactiveHistoryLoadRequestIdRef.current += 1;
+  }, []);
+
   const [mcpPromptResults, setMcpPromptResults] = useState<MCPPromptResult[]>(
     []
   );
@@ -1025,9 +1031,10 @@ export function PlaygroundMain({
 
   const cancelPendingHistorySelection = useCallback(() => {
     historySelectionRequestIdRef.current += 1;
+    invalidatePendingReactiveHistoryLoad();
     setLoadingHistorySessionId(null);
     setActiveHistorySessionId(null);
-  }, []);
+  }, [invalidatePendingReactiveHistoryLoad]);
 
   const markHistorySessionRead = useCallback(async (sessionId: string) => {
     try {


### PR DESCRIPTION
Before:

Click Chat A
Chat A starts loading
Quickly click Chat B
Chat B should win
But Chat A could finish late and accidentally replace Chat B
Now:

Click Chat A
Quickly click Chat B
The app immediately marks Chat A’s load as old/invalid
If Chat A finishes late, it gets ignored