### PR TITLE
fix(apps): Permissive toolbar toggle bypasses host-config CSP hardening

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1417,13 +1417,20 @@ export function MCPAppsRenderer({
     // (restrictTo, cspDirectives) and skip CSP injection entirely. Strict
     // applies the host profile.
     //
-    // Gate on `isPlaygroundActive`: chatbox/minimal-mode surfaces also hardcode
-    // `cspMode = "permissive"` (line 405) as a UX-friendliness default for
-    // end-user demos, NOT as a user choice. The host's `restrictTo` /
-    // `cspDirectives` MUST still apply on those surfaces — otherwise a
-    // developer who configures `restrictTo: { connectDomains: ["https://api.acme"] }`
+    // Chatbox / minimal-mode surfaces also hardcode `cspMode = "permissive"`
+    // (line 405) as a UX-friendliness default for end-user demos, NOT as a
+    // user choice. The host's `restrictTo` / `cspDirectives` MUST still apply
+    // there — otherwise a developer who configures `restrictTo: { connectDomains: ["https://api.acme"] }`
     // on their chatbox host would have it honored on Connect → Chat but
     // silently dropped on the public chatbox runtime / Sessions transcript.
+    //
+    // We can't gate on `isPlaygroundActive` alone: the Playground store is
+    // localStorage and leaks across browsing contexts on the same origin
+    // (see line 396), so a chatbox preview iframe can read
+    // `isPlaygroundActive = true` from the parent inspector tab even though
+    // it's a chatbox surface. Require `!isChatboxSurface && !minimalMode` so
+    // the short-circuit is gated on the actual rendering surface, not just
+    // the (leakable) playground flag.
     //
     // No HOSTED_MODE carve-out: PR #2164 moves the sandbox proxy to a separate
     // origin so the iframe is no longer same-origin with mcpjam.com, and a
@@ -1431,7 +1438,12 @@ export function MCPAppsRenderer({
     // cookies.
     //
     // Permissions policy still resolves below — it's orthogonal to CSP.
-    if (cspMode === "permissive" && isPlaygroundActive) {
+    const userTogglePermissive =
+      cspMode === "permissive" &&
+      isPlaygroundActive &&
+      !isChatboxSurface &&
+      !minimalMode;
+    if (userTogglePermissive) {
       let resolvedPermissions: McpUiResourcePermissions | undefined;
       if (sandboxPermissionsPolicy) {
         const resourcePermsMap: Record<string, boolean> = {};
@@ -1599,6 +1611,8 @@ export function MCPAppsRenderer({
   }, [
     cspMode,
     isPlaygroundActive,
+    isChatboxSurface,
+    minimalMode,
     sandboxCspPolicy,
     sandboxPermissionsPolicy,
     widgetCsp,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1412,15 +1412,26 @@ export function MCPAppsRenderer({
             return true;
           }),
       );
-    // Permissive means permissive: ignore the saved profile's CSP hardening
-    // (restrictTo, cspDirectives) and skip CSP injection entirely. To get the
-    // host profile applied, the user picks Strict. No HOSTED_MODE carve-out:
-    // PR #2164 moves the sandbox proxy to a separate origin so the iframe is
-    // no longer same-origin with mcpjam.com, and a permissive CSP can't be
-    // used to fetch /api/* with the user's session cookies.
+    // Permissive means permissive — when the user explicitly toggles it in
+    // the playground toolbar — ignore the saved profile's CSP hardening
+    // (restrictTo, cspDirectives) and skip CSP injection entirely. Strict
+    // applies the host profile.
+    //
+    // Gate on `isPlaygroundActive`: chatbox/minimal-mode surfaces also hardcode
+    // `cspMode = "permissive"` (line 405) as a UX-friendliness default for
+    // end-user demos, NOT as a user choice. The host's `restrictTo` /
+    // `cspDirectives` MUST still apply on those surfaces — otherwise a
+    // developer who configures `restrictTo: { connectDomains: ["https://api.acme"] }`
+    // on their chatbox host would have it honored on Connect → Chat but
+    // silently dropped on the public chatbox runtime / Sessions transcript.
+    //
+    // No HOSTED_MODE carve-out: PR #2164 moves the sandbox proxy to a separate
+    // origin so the iframe is no longer same-origin with mcpjam.com, and a
+    // permissive CSP can't be used to fetch /api/* with the user's session
+    // cookies.
     //
     // Permissions policy still resolves below — it's orthogonal to CSP.
-    if (cspMode === "permissive") {
+    if (cspMode === "permissive" && isPlaygroundActive) {
       let resolvedPermissions: McpUiResourcePermissions | undefined;
       if (sandboxPermissionsPolicy) {
         const resourcePermsMap: Record<string, boolean> = {};
@@ -1587,6 +1598,7 @@ export function MCPAppsRenderer({
     };
   }, [
     cspMode,
+    isPlaygroundActive,
     sandboxCspPolicy,
     sandboxPermissionsPolicy,
     widgetCsp,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1412,29 +1412,15 @@ export function MCPAppsRenderer({
             return true;
           }),
       );
-    const hasExplicitCspHardening =
-      restrictToConfigured || cspDirectivesConfigured || HOSTED_MODE;
-
-    // Chatbox / Playground / minimal-mode surfaces opted into `permissive`
-    // CSP up at line 285. Permissive means "default to permissive when the
-    // host hasn't asked for tightening" — short-circuit the host CSP
-    // resolver only when the saved profile carries NO explicit hardening
-    // (restrictTo) and we're not in hosted mode. Otherwise fall through to
-    // the resolver so the documented guarantees still hold even when the
-    // surface is permissive-by-default:
-    //   * restrictTo intersects whatever the resource declares
-    //   * hosted clamp is non-bypassable (MCPJam-origin SDK-internal strip)
+    // Permissive means permissive: ignore the saved profile's CSP hardening
+    // (restrictTo, cspDirectives) and skip CSP injection entirely. To get the
+    // host profile applied, the user picks Strict. No HOSTED_MODE carve-out:
+    // PR #2164 moves the sandbox proxy to a separate origin so the iframe is
+    // no longer same-origin with mcpjam.com, and a permissive CSP can't be
+    // used to fetch /api/* with the user's session cookies.
     //
-    // Without this fall-through, a host could save `restrictTo:
-    // { connectDomains: ["https://api.acme"] }` on its chatbox host and
-    // the inspector would silently honor it on Connect → Chat but ignore
-    // it on the public chatbox URL — a policy bypass tied to surface
-    // type.
-    //
-    // Permissions policy still resolves below — it's orthogonal to CSP
-    // and the chatbox-surface decision is specifically about content
-    // loading, not device access.
-    if (cspMode === "permissive" && !hasExplicitCspHardening) {
+    // Permissions policy still resolves below — it's orthogonal to CSP.
+    if (cspMode === "permissive") {
       let resolvedPermissions: McpUiResourcePermissions | undefined;
       if (sandboxPermissionsPolicy) {
         const resourcePermsMap: Record<string, boolean> = {};


### PR DESCRIPTION
## Summary

- Picking **Permissive** in the playground toolbar was silently a no-op whenever the saved host profile had `restrictTo` or `cspDirectives` set. The renderer treated those as "explicit hardening" and fell through to the strict resolver anyway, overruling the label.
- Visible repro: with the ChatGPT host preset (which ships with `cspDirectives` baked in), Leaflet + external script fetches stayed blocked even after picking Permissive. MCPJam preset worked only because its profile has no overrides.
- New behavior matches the label: **Permissive = skip CSP injection.** **Strict = apply the host profile.**
- Drops the previous HOSTED_MODE carve-out — relies on the separate-origin sandbox proxy from #2164 so the inner iframe is no longer in mcpjam.com's cookie scope.

## Test plan
- [ ] Local dev: pick ChatGPT preset → Permissive → confirm widgets that fetch external CSS/JS (e.g. Leaflet from unpkg) render
- [ ] Local dev: pick ChatGPT preset → Strict → confirm host CSP hardening still applies (blocked fetches surface in the Sandbox debug panel)
- [ ] Local dev: pick MCPJam preset → both modes still render
- [ ] Hosted: depends on #2164 landing first; verify same behavior on mcpjam.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CSP enforcement is skipped/applied for sandboxed MCP Apps, which can affect network access and security boundaries across surfaces. The update is scoped but touches CSP-mode decision logic and hosted-mode assumptions, so regressions could change what resources widgets can load.
> 
> **Overview**
> Fixes the MCP Apps sandbox policy resolution so the **Playground toolbar’s `permissive` mode actually disables CSP injection**, even when the active host profile configures `restrictTo`/`cspDirectives`.
> 
> Keeps host CSP hardening enforced on **chatbox/minimal surfaces** that default to `permissive` for UX (i.e., only skip CSP when the user explicitly toggled permissive in the playground), and removes the prior `HOSTED_MODE` exception. Updates the `effectiveSandbox` memo dependencies accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93ad9ccc2c3f224ea6b19a26560329ad9c754b4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->