### PR TITLE
Remove playground empty-state subtitle

### DIFF
--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -2317,21 +2317,6 @@ export function PlaygroundMain({
                         >
                           This is your playground for MCP.
                         </h3>
-                        <p
-                          className={cn(
-                            "text-base leading-7",
-                            hostStyleFamily === "chatgpt"
-                              ? effectiveThreadTheme === "dark"
-                                ? "text-neutral-400"
-                                : "text-neutral-600"
-                              : effectiveThreadTheme === "dark"
-                              ? "text-[#F1F0ED]/80"
-                              : "text-[rgba(61,57,41,0.72)]"
-                          )}
-                        >
-                          Test prompts, inspect tools, and debug AI-powered
-                          apps. Type a message here, or run a tool on the left.
-                        </p>
                       </div>
                     </div>
                     {errorMessage && (

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -799,11 +799,6 @@ describe("PlaygroundMain", () => {
           name: /This is your playground for MCP./i,
         }),
       ).toBeInTheDocument();
-      expect(
-        screen.getByText(
-          /Test prompts, inspect tools, and debug AI-powered apps/i,
-        ),
-      ).toBeInTheDocument();
     });
 
     it("shows sign up prompt when authentication required", () => {


### PR DESCRIPTION
## Summary
- Drops the "Test prompts, inspect tools, and debug AI-powered apps. Type a message here, or run a tool on the left." subtitle under the playground empty-state heading
- Updates the matching assertion in `PlaygroundMain.test.tsx`

## Test plan
- [ ] Open the playground with an empty thread and confirm only the "This is your playground for MCP." heading is shown
- [ ] `pnpm test PlaygroundMain` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only copy removal with a matching test update; no behavioral, data, or auth logic changes.
> 
> **Overview**
> Simplifies the UI Playground empty state by removing the secondary instructional subtitle beneath `This is your playground for MCP.`
> 
> Updates `PlaygroundMain.test.tsx` to stop asserting on the removed copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40dfa80397ce572c550e131d38359a817372434c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->