### PR TITLE
refactor(playground): polymorphic compare card + provider lift (Phase 3)

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/model-compare-card-header.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/model-compare-card-header.tsx
@@ -39,6 +39,8 @@ function formatCardDuration(durationMs: number | null): string {
 export function ModelCompareCardHeader({
   model,
   modelLabel: modelLabelProp,
+  compareLabel,
+  compareSubLabel,
   summary,
   allSummaries,
   mode,
@@ -58,6 +60,18 @@ export function ModelCompareCardHeader({
   model?: ModelDefinition;
   /** Override for the displayed model name; takes precedence over `model.name`. */
   modelLabel?: string;
+  /**
+   * Polymorphic compare-card title (Phase 3 of the multi-host plan).
+   * Takes precedence over both `modelLabel` and `model?.name`. In model
+   * mode the caller passes `model.name`; in host mode it passes the host
+   * name.
+   */
+  compareLabel?: string;
+  /**
+   * Secondary line under the title (host mode shows the resolved model
+   * name here; model mode leaves it empty).
+   */
+  compareSubLabel?: string;
   summary: MultiModelCardSummary | null;
   allSummaries: MultiModelCardSummary[];
   mode: TraceViewMode;
@@ -85,7 +99,7 @@ export function ModelCompareCardHeader({
     return null;
   }
 
-  const displayName = modelLabelProp ?? model?.name ?? "";
+  const displayName = compareLabel ?? modelLabelProp ?? model?.name ?? "";
 
   const isNonComparableSummary =
     summary?.status === "error" || summary?.status === "cancelled";
@@ -183,24 +197,31 @@ export function ModelCompareCardHeader({
           )}
         >
           <div className="flex items-start justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-1.5">
-              <div className="truncate text-sm font-semibold leading-tight">
-                {displayName}
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <div className="flex min-w-0 items-center gap-1.5">
+                <div className="truncate text-sm font-semibold leading-tight">
+                  {displayName}
+                </div>
+                {!compactCompareHeader && result === "passed" ? (
+                  <span
+                    className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-emerald-500/15 text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-300"
+                    aria-label="Passed"
+                  >
+                    Passed
+                  </span>
+                ) : !compactCompareHeader && result === "failed" ? (
+                  <span
+                    className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-rose-500/15 text-rose-700 dark:bg-rose-400/20 dark:text-rose-300"
+                    aria-label="Failed"
+                  >
+                    Failed
+                  </span>
+                ) : null}
               </div>
-              {!compactCompareHeader && result === "passed" ? (
-                <span
-                  className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-emerald-500/15 text-emerald-700 dark:bg-emerald-400/20 dark:text-emerald-300"
-                  aria-label="Passed"
-                >
-                  Passed
-                </span>
-              ) : !compactCompareHeader && result === "failed" ? (
-                <span
-                  className="inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider bg-rose-500/15 text-rose-700 dark:bg-rose-400/20 dark:text-rose-300"
-                  aria-label="Failed"
-                >
-                  Failed
-                </span>
+              {compareSubLabel ? (
+                <div className="truncate text-[11px] leading-tight text-muted-foreground">
+                  {compareSubLabel}
+                </div>
               ) : null}
             </div>
             {!compactCompareHeader && result == null ? (

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -358,23 +358,27 @@ export function PlaygroundMain({
   const [stopBroadcastRequestId, setStopBroadcastRequestId] = useState(0);
   const [multiModelSessionGeneration, setMultiModelSessionGeneration] =
     useState(0);
-  const [multiModelSummaries, setMultiModelSummaries] = useState<
+  // Phase 3 (multi-host plan): per-column state is keyed by `compareId` — a
+  // mode-neutral column identifier. In model mode `compareId === String(model.id)`
+  // (unchanged from today); in host mode (Phase 4) it'll be the hostId, so two
+  // columns running the same default model can't collide.
+  const [compareSummaries, setCompareSummaries] = useState<
     Record<string, MultiModelCardSummary>
   >({});
-  const [multiModelHasMessages, setMultiModelHasMessages] = useState<
+  const [compareHasMessages, setCompareHasMessages] = useState<
     Record<string, boolean>
   >({});
   const [multiCompareEnterVersion, setMultiCompareEnterVersion] = useState(0);
   const [multiCompareEnterMessages, setMultiCompareEnterMessages] = useState<
     UIMessage[]
   >([]);
-  const [multiAddColumnSeeds, setMultiAddColumnSeeds] = useState<
+  const [compareAddColumnSeeds, setCompareAddColumnSeeds] = useState<
     Record<string, { version: number; messages: UIMessage[] }>
   >({});
-  const multiTranscriptsRef = useRef<Record<string, UIMessage[]>>({});
+  const compareTranscriptsRef = useRef<Record<string, UIMessage[]>>({});
   const prevCompareModeRef = useRef(false);
-  const lastMultiLeadIdRef = useRef<string | null>(null);
-  const prevCompareModelIdsRef = useRef<Set<string>>(new Set());
+  const lastCompareLeadIdRef = useRef<string | null>(null);
+  const prevCompareIdsRef = useRef<Set<string>>(new Set());
   const multiAddColumnSeqRef = useRef(0);
   // Device config from store (managed by ClientContextHeader)
   const storeDeviceType = useUIPlaygroundStore((s) => s.deviceType);
@@ -725,13 +729,13 @@ export function PlaygroundMain({
 
   useEffect(() => {
     if (isMultiModelMode && resolvedSelectedModels[0]) {
-      lastMultiLeadIdRef.current = String(resolvedSelectedModels[0].id);
+      lastCompareLeadIdRef.current = String(resolvedSelectedModels[0].id);
     }
   }, [isMultiModelMode, resolvedSelectedModels]);
 
   const handleMultiModelTranscriptSync = useCallback(
-    (modelId: string, transcript: UIMessage[]) => {
-      multiTranscriptsRef.current[modelId] = cloneUiMessages(transcript);
+    (compareId: string, transcript: UIMessage[]) => {
+      compareTranscriptsRef.current[compareId] = cloneUiMessages(transcript);
     },
     []
   );
@@ -740,18 +744,18 @@ export function PlaygroundMain({
     setBroadcastRequest(null);
     setDeterministicExecutionRequest(null);
     setStopBroadcastRequestId(0);
-    setMultiModelSummaries({});
-    setMultiModelHasMessages({});
-    setMultiAddColumnSeeds({});
-    prevCompareModelIdsRef.current = new Set();
+    setCompareSummaries({});
+    setCompareHasMessages({});
+    setCompareAddColumnSeeds({});
+    prevCompareIdsRef.current = new Set();
   }, []);
 
   useLayoutEffect(() => {
     const prev = prevCompareModeRef.current;
     if (prev && !isMultiModelMode) {
-      const leadId = lastMultiLeadIdRef.current;
+      const leadId = lastCompareLeadIdRef.current;
       if (leadId) {
-        const transcript = multiTranscriptsRef.current[leadId];
+        const transcript = compareTranscriptsRef.current[leadId];
         const hasConversation =
           transcript?.some(
             (m) => m.role === "user" || m.role === "assistant"
@@ -776,20 +780,20 @@ export function PlaygroundMain({
 
   useEffect(() => {
     if (!isMultiModelMode) {
-      prevCompareModelIdsRef.current = new Set();
+      prevCompareIdsRef.current = new Set();
       return;
     }
     const current = new Set(resolvedSelectedModels.map((m) => String(m.id)));
-    const prev = prevCompareModelIdsRef.current;
+    const prev = prevCompareIdsRef.current;
     const added = [...current].filter((id) => !prev.has(id));
     const leadId = resolvedSelectedModels[0]
       ? String(resolvedSelectedModels[0].id)
       : null;
     if (prev.size > 0 && added.length > 0 && leadId) {
-      const src = multiTranscriptsRef.current[leadId] ?? [];
+      const src = compareTranscriptsRef.current[leadId] ?? [];
       multiAddColumnSeqRef.current += 1;
       const v = multiAddColumnSeqRef.current;
-      setMultiAddColumnSeeds((s) => {
+      setCompareAddColumnSeeds((s) => {
         const next = { ...s };
         for (const id of added) {
           next[id] = { version: v, messages: cloneUiMessages(src) };
@@ -797,11 +801,11 @@ export function PlaygroundMain({
         return next;
       });
     }
-    prevCompareModelIdsRef.current = current;
+    prevCompareIdsRef.current = current;
   }, [isMultiModelMode, resolvedSelectedModels]);
 
   const effectiveHasMessages = isMultiModelLayoutMode
-    ? Object.values(multiModelHasMessages).some(Boolean)
+    ? Object.values(compareHasMessages).some(Boolean)
     : !isThreadEmpty;
   const preludeTraceEnvelope = useMemo(
     () => buildPreludeTraceEnvelope(preludeTraceExecutions),
@@ -829,7 +833,7 @@ export function PlaygroundMain({
   const { isStreamingActive, stopActiveChat } = useChatStopControls({
     isMultiModelMode,
     isStreaming,
-    multiModelSummaries,
+    multiModelSummaries: compareSummaries,
     setStopBroadcastRequestId,
     stop,
   });
@@ -1625,17 +1629,17 @@ export function PlaygroundMain({
       resolvedSelectedModels.map((model) => String(model.id))
     );
 
-    setMultiModelSummaries((previous) =>
+    setCompareSummaries((previous) =>
       Object.fromEntries(
-        Object.entries(previous).filter(([modelId]) =>
-          activeModelIds.has(modelId)
+        Object.entries(previous).filter(([compareId]) =>
+          activeModelIds.has(compareId)
         )
       )
     );
-    setMultiModelHasMessages((previous) =>
+    setCompareHasMessages((previous) =>
       Object.fromEntries(
-        Object.entries(previous).filter(([modelId]) =>
-          activeModelIds.has(modelId)
+        Object.entries(previous).filter(([compareId]) =>
+          activeModelIds.has(compareId)
         )
       )
     );
@@ -1916,8 +1920,10 @@ export function PlaygroundMain({
 
   const handleMultiModelSummaryChange = useCallback(
     (summary: MultiModelCardSummary) => {
-      setMultiModelSummaries((previous) => ({
+      setCompareSummaries((previous) => ({
         ...previous,
+        // `summary.modelId` is the legacy field name; in multi-host mode
+        // (Phase 4) it carries the host's `compareId` — see the card.
         [summary.modelId]: summary,
       }));
     },
@@ -1925,10 +1931,10 @@ export function PlaygroundMain({
   );
 
   const handleMultiModelHasMessagesChange = useCallback(
-    (modelId: string, hasMessages: boolean) => {
-      setMultiModelHasMessages((previous) => ({
+    (compareId: string, hasMessages: boolean) => {
+      setCompareHasMessages((previous) => ({
         ...previous,
-        [modelId]: hasMessages,
+        [compareId]: hasMessages,
       }));
     },
     []
@@ -2640,51 +2646,65 @@ export function PlaygroundMain({
                       "grid-cols-1 xl:grid-cols-3"
                   )}
                 >
-                  {resolvedSelectedModels.map((model) => (
-                    <MultiModelPlaygroundCard
-                      key={`${multiModelSessionGeneration}:${String(model.id)}`}
-                      model={model}
-                      comparisonSummaries={Object.values(multiModelSummaries)}
-                      selectedServers={selectedServers}
-                      broadcastRequest={broadcastRequest}
-                      deterministicExecutionRequest={
-                        deterministicExecutionRequest
-                      }
-                      stopRequestId={stopBroadcastRequestId}
-                      executionConfig={{
-                        systemPrompt,
-                        temperature,
-                        requireToolApproval,
-                      }}
-                      hostedContext={{
-                        projectId: convexProjectId,
-                        selectedServerIds: hostedSelectedServerIds,
-                        oauthTokens: hostedOAuthTokens,
-                      }}
-                      displayMode={displayMode}
-                      onDisplayModeChange={handleDisplayModeChange}
-                      hostStyle={hostStyle}
-                      effectiveThreadTheme={effectiveThreadTheme}
-                      deviceType={storeDeviceType}
-                      selectedProtocol={selectedProtocol}
-                      hideSaveViewButton={hideSaveViewButton}
-                      onWidgetStateChange={onWidgetStateChange}
-                      toolRenderOverrides={externalToolRenderOverrides}
-                      isExecuting={isExecuting}
-                      executingToolName={executingToolName}
-                      invokingMessage={invokingMessage}
-                      onSummaryChange={handleMultiModelSummaryChange}
-                      onHasMessagesChange={handleMultiModelHasMessagesChange}
-                      showComparisonChrome={resolvedSelectedModels.length > 1}
-                      suppressThreadEmptyHint={false}
-                      compareEnterVersion={multiCompareEnterVersion}
-                      compareEnterMessages={multiCompareEnterMessages}
-                      addColumnSeed={
-                        multiAddColumnSeeds[String(model.id)] ?? null
-                      }
-                      onTranscriptSync={handleMultiModelTranscriptSync}
-                    />
-                  ))}
+                  {resolvedSelectedModels.map((model) => {
+                    const compareId = String(model.id);
+                    return (
+                      <MultiModelPlaygroundCard
+                        // Phase 3 (multi-host plan): include `compareKind` in
+                        // the key so model-mode and (future) host-mode keys
+                        // never collide during mode-swap transitions.
+                        key={`${multiModelSessionGeneration}:model:${compareId}`}
+                        compareId={compareId}
+                        compareLabel={model.name}
+                        compareKind="model"
+                        model={model}
+                        comparisonSummaries={Object.values(compareSummaries)}
+                        selectedServers={selectedServers}
+                        broadcastRequest={broadcastRequest}
+                        deterministicExecutionRequest={
+                          deterministicExecutionRequest
+                        }
+                        stopRequestId={stopBroadcastRequestId}
+                        executionConfig={{
+                          systemPrompt,
+                          temperature,
+                          requireToolApproval,
+                        }}
+                        hostedContext={{
+                          projectId: convexProjectId,
+                          selectedServerIds: hostedSelectedServerIds,
+                          oauthTokens: hostedOAuthTokens,
+                        }}
+                        displayMode={displayMode}
+                        onDisplayModeChange={handleDisplayModeChange}
+                        hostStyle={hostStyle}
+                        effectiveThreadTheme={effectiveThreadTheme}
+                        deviceType={storeDeviceType}
+                        selectedProtocol={selectedProtocol}
+                        hideSaveViewButton={hideSaveViewButton}
+                        onWidgetStateChange={onWidgetStateChange}
+                        toolRenderOverrides={externalToolRenderOverrides}
+                        isExecuting={isExecuting}
+                        executingToolName={executingToolName}
+                        invokingMessage={invokingMessage}
+                        onSummaryChange={handleMultiModelSummaryChange}
+                        onHasMessagesChange={handleMultiModelHasMessagesChange}
+                        showComparisonChrome={resolvedSelectedModels.length > 1}
+                        suppressThreadEmptyHint={false}
+                        compareEnterVersion={multiCompareEnterVersion}
+                        compareEnterMessages={multiCompareEnterMessages}
+                        addColumnSeed={
+                          compareAddColumnSeeds[compareId] ?? null
+                        }
+                        onTranscriptSync={handleMultiModelTranscriptSync}
+                        // Phase 3: model-mode does NOT pass per-card host
+                        // snapshot props. The card falls back to tab-root
+                        // provider values via `useContext`, so the rendered
+                        // tree is behavior-identical to today. Phase 4 host
+                        // mode passes explicit per-column values here.
+                      />
+                    );
+                  })}
                 </div>
               </div>
 

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.provider-shadow.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.provider-shadow.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Phase 3 contract test: when the card receives explicit per-card
+ * host-snapshot props, its inner subtree's `useContext()` reads must
+ * return the prop value (not the tab-root context value).
+ *
+ * This is the contract Phase 4 (multi-host render path) depends on —
+ * without provider shadowing inside the card, two host columns would
+ * read the same global host-snapshot from the tab root.
+ *
+ * Uses REAL context modules (no vi.mock) so the contract is exercised
+ * end-to-end. We stub `useChatSession` and a few heavy children that
+ * the card pulls in only because they share the file.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MultiModelPlaygroundCard } from "../multi-model-playground-card";
+import {
+  ChatboxHostCapabilitiesOverrideProvider,
+  useChatboxHostCapabilitiesOverride,
+} from "@/contexts/chatbox-client-capabilities-override-context";
+
+// Stub use-stick-to-bottom so we don't need DOM measurement.
+vi.mock("use-stick-to-bottom", () => {
+  const StickToBottomComponent = ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <div data-testid="stick-to-bottom">{children}</div>;
+  StickToBottomComponent.Content = ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <div>{children}</div>;
+  return {
+    StickToBottom: StickToBottomComponent,
+    useStickToBottomContext: () => ({ isAtBottom: true, scrollToBottom: vi.fn() }),
+  };
+});
+
+const mockUseChatSession = {
+  messages: [],
+  setMessages: vi.fn(),
+  sendMessage: vi.fn(),
+  stop: vi.fn(),
+  status: "ready",
+  error: undefined,
+  chatSessionId: "chat-session-1",
+  toolsMetadata: {},
+  toolServerMap: {},
+  liveTraceEnvelope: null,
+  requestPayloadHistory: [],
+  hasTraceSnapshot: false,
+  hasLiveTimelineContent: false,
+  traceViewsSupported: true,
+  isStreaming: false,
+  addToolApprovalResponse: vi.fn(),
+  systemPrompt: "",
+  startChatWithMessages: vi.fn(),
+};
+
+vi.mock("@/hooks/use-chat-session", () => ({
+  useChatSession: () => mockUseChatSession,
+}));
+
+// The Thread component captures the inner `useChatboxHostCapabilitiesOverride`
+// value and renders it as JSON so the test can assert on the shadowed value.
+vi.mock("@/components/chat-v2/thread", () => ({
+  Thread: () => {
+    const inner = useChatboxHostCapabilitiesOverride();
+    return (
+      <div data-testid="thread-host-caps-override">{JSON.stringify(inner)}</div>
+    );
+  },
+}));
+
+vi.mock("@/components/evals/trace-viewer", () => ({
+  TraceViewer: () => <div data-testid="trace-viewer" />,
+}));
+
+vi.mock("@/components/chat-v2/error", () => ({
+  ErrorBox: () => <div data-testid="error-box" />,
+}));
+
+vi.mock("@/components/chat-v2/shared/chat-helpers", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/components/chat-v2/shared/chat-helpers")
+    >();
+  return {
+    ...actual,
+    formatErrorMessage: () => null,
+  };
+});
+
+vi.mock("@/components/chat-v2/model-compare-card-header", () => ({
+  ModelCompareCardHeader: () => <div data-testid="compare-card-header" />,
+}));
+
+const model = {
+  id: "openai/gpt-5-mini",
+  name: "GPT-5 Mini",
+  provider: "openai" as const,
+};
+
+describe("MultiModelPlaygroundCard provider shadowing", () => {
+  it("inner Thread sees the per-card hostCapabilitiesOverride prop, not the outer tab-root context", () => {
+    // Set up a Thread that has at least one assistant message so the chat
+    // branch renders (rather than the empty-thread placeholder, which
+    // wouldn't expose the Thread component's context read).
+    mockUseChatSession.messages = [
+      { id: "m-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      { id: "m-2", role: "assistant", parts: [{ type: "text", text: "hi" }] },
+    ] as (typeof mockUseChatSession)["messages"];
+
+    const tabRootValue = { foo: "tab-root" };
+    const perCardValue = { foo: "per-card" };
+
+    render(
+      <ChatboxHostCapabilitiesOverrideProvider value={tabRootValue}>
+        <MultiModelPlaygroundCard
+          compareId={String(model.id)}
+          compareLabel={model.name}
+          compareKind="model"
+          model={model}
+          comparisonSummaries={[]}
+          selectedServers={[]}
+          broadcastRequest={null}
+          deterministicExecutionRequest={null}
+          stopRequestId={0}
+          executionConfig={{
+            systemPrompt: "",
+            temperature: 0.7,
+            requireToolApproval: false,
+          }}
+          displayMode="inline"
+          onDisplayModeChange={vi.fn()}
+          hostStyle="chatgpt"
+          effectiveThreadTheme="light"
+          deviceType="desktop"
+          selectedProtocol={null}
+          onSummaryChange={vi.fn()}
+          hostCapabilitiesOverride={perCardValue}
+          hostCapabilitiesOverrideSet
+        />
+      </ChatboxHostCapabilitiesOverrideProvider>,
+    );
+
+    const rendered = screen.getByTestId("thread-host-caps-override");
+    expect(rendered.textContent).toBe(JSON.stringify(perCardValue));
+  });
+
+  it("without the prop, inner Thread falls back to the tab-root context value", () => {
+    mockUseChatSession.messages = [
+      { id: "m-1", role: "user", parts: [{ type: "text", text: "hi" }] },
+      { id: "m-2", role: "assistant", parts: [{ type: "text", text: "hi" }] },
+    ] as (typeof mockUseChatSession)["messages"];
+
+    const tabRootValue = { foo: "tab-root" };
+
+    render(
+      <ChatboxHostCapabilitiesOverrideProvider value={tabRootValue}>
+        <MultiModelPlaygroundCard
+          compareId={String(model.id)}
+          compareLabel={model.name}
+          compareKind="model"
+          model={model}
+          comparisonSummaries={[]}
+          selectedServers={[]}
+          broadcastRequest={null}
+          deterministicExecutionRequest={null}
+          stopRequestId={0}
+          executionConfig={{
+            systemPrompt: "",
+            temperature: 0.7,
+            requireToolApproval: false,
+          }}
+          displayMode="inline"
+          onDisplayModeChange={vi.fn()}
+          hostStyle="chatgpt"
+          effectiveThreadTheme="light"
+          deviceType="desktop"
+          selectedProtocol={null}
+          onSummaryChange={vi.fn()}
+          // No hostCapabilitiesOverride prop — should fall back to outer.
+        />
+      </ChatboxHostCapabilitiesOverrideProvider>,
+    );
+
+    const rendered = screen.getByTestId("thread-host-caps-override");
+    expect(rendered.textContent).toBe(JSON.stringify(tabRootValue));
+  });
+});

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.test.tsx
@@ -102,6 +102,12 @@ vi.mock("@/contexts/chatbox-client-style-context", () => ({
   ChatboxHostThemeProvider: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
+  ChatboxChatUiOverrideProvider: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <>{children}</>,
+  useChatboxChatUiOverride: () => undefined,
 }));
 
 vi.mock("@/contexts/chatbox-client-capabilities-override-context", () => ({
@@ -110,7 +116,22 @@ vi.mock("@/contexts/chatbox-client-capabilities-override-context", () => ({
   }: {
     children: React.ReactNode;
   }) => <>{children}</>,
-  useChatboxHostCapabilitiesOverride: () => null,
+  useChatboxHostCapabilitiesOverride: () => undefined,
+}));
+
+vi.mock("@/contexts/active-mcp-profile-context", () => ({
+  ActiveMcpProfileProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  useActiveMcpProfile: () => undefined,
+}));
+
+vi.mock("@/contexts/active-host-client-capabilities-context", () => ({
+  ActiveHostCapsResolverScope: ({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) => <>{children}</>,
 }));
 
 vi.mock("@/stores/preferences/preferences-provider", () => ({
@@ -136,6 +157,9 @@ function Harness() {
         {Object.keys(messageFlags).length}
       </div>
       <MultiModelPlaygroundCard
+        compareId={String(model.id)}
+        compareLabel={model.name}
+        compareKind="model"
         model={model}
         comparisonSummaries={Object.values(summaries)}
         selectedServers={[]}
@@ -184,6 +208,9 @@ describe("MultiModelPlaygroundCard", () => {
   it("omits compare header chrome when showComparisonChrome is false (matches chat tab single-column compare)", () => {
     render(
       <MultiModelPlaygroundCard
+        compareId={String(model.id)}
+        compareLabel={model.name}
+        compareKind="model"
         model={model}
         comparisonSummaries={[]}
         selectedServers={[]}
@@ -208,6 +235,9 @@ describe("MultiModelPlaygroundCard", () => {
   it("hides shared-message empty hint when suppressThreadEmptyHint is true", () => {
     render(
       <MultiModelPlaygroundCard
+        compareId={String(model.id)}
+        compareLabel={model.name}
+        compareKind="model"
         model={model}
         comparisonSummaries={[]}
         selectedServers={[]}
@@ -234,6 +264,9 @@ describe("MultiModelPlaygroundCard", () => {
   it("calls stop when stopRequestId changes", async () => {
     const { rerender } = render(
       <MultiModelPlaygroundCard
+        compareId={String(model.id)}
+        compareLabel={model.name}
+        compareKind="model"
         model={model}
         comparisonSummaries={[]}
         selectedServers={[]}
@@ -253,6 +286,9 @@ describe("MultiModelPlaygroundCard", () => {
 
     rerender(
       <MultiModelPlaygroundCard
+        compareId={String(model.id)}
+        compareLabel={model.name}
+        compareKind="model"
         model={model}
         comparisonSummaries={[]}
         selectedServers={[]}
@@ -284,6 +320,9 @@ describe("MultiModelPlaygroundCard", () => {
     it("card root has no forced min-height so it can shrink inside a short grid row", () => {
       render(
         <MultiModelPlaygroundCard
+          compareId={String(model.id)}
+          compareLabel={model.name}
+          compareKind="model"
           model={model}
           comparisonSummaries={[]}
           selectedServers={[]}
@@ -318,6 +357,9 @@ describe("MultiModelPlaygroundCard", () => {
 
       const { container } = render(
         <MultiModelPlaygroundCard
+          compareId={String(model.id)}
+          compareLabel={model.name}
+          compareKind="model"
           model={model}
           comparisonSummaries={[]}
           selectedServers={[]}
@@ -352,6 +394,9 @@ describe("MultiModelPlaygroundCard", () => {
 
       const { container } = render(
         <MultiModelPlaygroundCard
+          compareId={String(model.id)}
+          compareLabel={model.name}
+          compareKind="model"
           model={model}
           comparisonSummaries={[]}
           selectedServers={[]}

--- a/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { Braces, Loader2 } from "lucide-react";
 import { StickToBottom } from "use-stick-to-bottom";
 import { ScrollToBottomButton } from "@/components/chat-v2/shared/scroll-to-bottom-button";
@@ -30,11 +37,25 @@ import {
   type PreludeTraceExecution,
 } from "@/components/ui-playground/live-trace-prelude";
 import {
+  ChatboxChatUiOverrideProvider,
   ChatboxHostStyleProvider,
   ChatboxHostThemeProvider,
+  useChatboxChatUiOverride,
 } from "@/contexts/chatbox-client-style-context";
-import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-client-capabilities-override-context";
-import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
+import {
+  ChatboxHostCapabilitiesOverrideProvider,
+  useChatboxHostCapabilitiesOverride,
+} from "@/contexts/chatbox-client-capabilities-override-context";
+import {
+  ActiveMcpProfileProvider,
+  useActiveMcpProfile,
+} from "@/contexts/active-mcp-profile-context";
+import { ActiveHostCapsResolverScope } from "@/contexts/active-host-client-capabilities-context";
+import type { ChatUiOverride } from "@/lib/client-styles";
+import type {
+  HostConfigDtoV2,
+  HostConfigMcpProfileV1,
+} from "@/lib/client-config-v2";
 import type { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import {
   getChatboxChatBackground,
@@ -86,6 +107,22 @@ function InvokingIndicator({
 }
 
 interface MultiModelPlaygroundCardProps {
+  /**
+   * Polymorphic column identity (Phase 3 of the multi-host plan). In model
+   * mode `compareId === String(model.id)`; in host mode it's the host id.
+   * The card uses `compareId` to key transcripts/summaries/`hasMessages`
+   * callbacks so two columns running the same default model can't collide.
+   */
+  compareId: string;
+  /** Visible title rendered in the card header. */
+  compareLabel: string;
+  compareKind: "model" | "host";
+  /**
+   * Secondary line under the title. In model mode this is undefined; in
+   * host mode it's the resolved model name (so users see which model the
+   * host is running).
+   */
+  compareSubLabel?: string;
   model: ModelDefinition;
   comparisonSummaries: MultiModelCardSummary[];
   selectedServers: string[];
@@ -108,7 +145,7 @@ interface MultiModelPlaygroundCardProps {
   executingToolName?: string | null;
   invokingMessage?: string | null;
   onSummaryChange: (summary: MultiModelCardSummary) => void;
-  onHasMessagesChange?: (modelId: string, hasMessages: boolean) => void;
+  onHasMessagesChange?: (compareId: string, hasMessages: boolean) => void;
   /** When false, hides per-card model title and Latency/Tokens/Tools (single selected model in compare mode). */
   showComparisonChrome?: boolean;
   /** Hide in-card “send a shared message” empty hint when the parent shows the shared starter strip + footer composer. */
@@ -116,10 +153,43 @@ interface MultiModelPlaygroundCardProps {
   compareEnterVersion?: number;
   compareEnterMessages?: UIMessage[];
   addColumnSeed?: { version: number; messages: UIMessage[] } | null;
-  onTranscriptSync?: (modelId: string, messages: UIMessage[]) => void;
+  onTranscriptSync?: (compareId: string, messages: UIMessage[]) => void;
+  /**
+   * Optional per-card host-snapshot props (Phase 3 plumbing for Phase 4
+   * multi-host render path). When undefined, the card falls back to the
+   * tab-root provider value via `useContext` so model-mode callers don't
+   * need to thread these. When defined, the card's inner provider shadows
+   * the tab-root one so per-column overrides apply to trace + raw views
+   * (not just chat — this is the whole point of the Phase 3 lift).
+   *
+   * NOTE: `hostCapabilitiesOverride` and `chatUiOverride` have `undefined`
+   * as a meaningful runtime value ("no override; preset wins"). We use a
+   * separate `*Set` discriminator below to distinguish "no prop passed"
+   * (fall back to context) from "prop passed as undefined" (shadow with
+   * undefined). Model-mode callers don't pass either flag.
+   */
+  hostCapabilitiesOverride?: Record<string, unknown> | undefined;
+  /** When true, treat `hostCapabilitiesOverride` as an explicit prop even if undefined (shadow context). */
+  hostCapabilitiesOverrideSet?: boolean;
+  chatUiOverride?: ChatUiOverride | undefined;
+  /** When true, treat `chatUiOverride` as an explicit prop even if undefined (shadow context). */
+  chatUiOverrideSet?: boolean;
+  mcpProfile?: HostConfigMcpProfileV1 | undefined;
+  /** When true, treat `mcpProfile` as an explicit prop even if undefined (shadow context). */
+  mcpProfileSet?: boolean;
+  /**
+   * Optional host config used to build a per-card
+   * `ActiveHostCapsResolverScope`. When undefined, the tab-root scope's
+   * resolver is inherited (no per-card shadow).
+   */
+  activeHost?: HostConfigDtoV2 | null;
 }
 
 export function MultiModelPlaygroundCard({
+  compareId,
+  compareLabel,
+  compareKind: _compareKind,
+  compareSubLabel,
   model,
   comparisonSummaries,
   selectedServers,
@@ -149,10 +219,33 @@ export function MultiModelPlaygroundCard({
   compareEnterMessages = [],
   addColumnSeed = null,
   onTranscriptSync,
+  hostCapabilitiesOverride: hostCapabilitiesOverrideProp,
+  hostCapabilitiesOverrideSet = false,
+  chatUiOverride: chatUiOverrideProp,
+  chatUiOverrideSet = false,
+  mcpProfile: mcpProfileProp,
+  mcpProfileSet = false,
+  activeHost,
 }: MultiModelPlaygroundCardProps) {
-  const hostCapabilitiesOverride = usePreferencesStore(
-    (s) => s.hostCapabilitiesOverride,
-  );
+  // Resolve effective per-card values from props with fall-back to the
+  // tab-root provider context. Model-mode callers (today) don't pass any
+  // of these; the card inherits the tab-root values via `useContext` so
+  // the rendered tree is behavior-identical to pre-refactor. Phase 4
+  // host-render path passes explicit per-column values to take advantage
+  // of the provider shadowing.
+  const tabRootHostCapabilitiesOverride =
+    useChatboxHostCapabilitiesOverride();
+  const tabRootChatUiOverride = useChatboxChatUiOverride();
+  const tabRootMcpProfile = useActiveMcpProfile();
+  const effectiveHostCapabilitiesOverride = hostCapabilitiesOverrideSet
+    ? hostCapabilitiesOverrideProp
+    : tabRootHostCapabilitiesOverride;
+  const effectiveChatUiOverride = chatUiOverrideSet
+    ? chatUiOverrideProp
+    : tabRootChatUiOverride;
+  const effectiveMcpProfile = mcpProfileSet
+    ? mcpProfileProp
+    : tabRootMcpProfile;
   const [modelContextQueue, setModelContextQueue] = useState<
     {
       toolCallId: string;
@@ -218,8 +311,8 @@ export function MultiModelPlaygroundCard({
     });
 
   useEffect(() => {
-    onTranscriptSync?.(String(model.id), messages);
-  }, [messages, model.id, onTranscriptSync]);
+    onTranscriptSync?.(compareId, messages);
+  }, [messages, compareId, onTranscriptSync]);
 
   useEffect(() => {
     if (
@@ -286,7 +379,11 @@ export function MultiModelPlaygroundCard({
   const latestTurn = effectiveLiveTraceEnvelope?.turns?.at(-1);
   const summary = useMemo<MultiModelCardSummary>(
     () => ({
-      modelId: String(model.id),
+      // `MultiModelCardSummary.modelId` is the legacy field name; in
+      // multi-host mode it holds the host's `compareId`. Renaming the
+      // field would ripple to ChatTabV2 + evals — keep the field name,
+      // change what we put in it.
+      modelId: compareId,
       durationMs: latestTurn?.durationMs ?? null,
       tokens: latestTurn?.usage?.totalTokens ?? 0,
       toolCount: latestTurn?.actualToolCalls?.length ?? 0,
@@ -299,7 +396,7 @@ export function MultiModelPlaygroundCard({
             : "ready",
       hasMessages: !isThreadEmpty,
     }),
-    [error, isExecuting, isStreaming, isThreadEmpty, latestTurn, model.id],
+    [compareId, error, isExecuting, isStreaming, isThreadEmpty, latestTurn],
   );
   const errorMessage = formatErrorMessage(error);
   const mergedToolRenderOverrides = useMemo(
@@ -334,8 +431,8 @@ export function MultiModelPlaygroundCard({
   }, [summary]);
 
   useEffect(() => {
-    onHasMessagesChangeRef.current?.(String(model.id), !isThreadEmpty);
-  }, [isThreadEmpty, model.id]);
+    onHasMessagesChangeRef.current?.(compareId, !isThreadEmpty);
+  }, [isThreadEmpty, compareId]);
 
   useEffect(() => {
     if (!traceViewsSupported) {
@@ -547,13 +644,27 @@ export function MultiModelPlaygroundCard({
     [],
   );
 
-  return (
+  // Provider stack wraps the WHOLE card body — header + trace branch +
+  // chat branch — so per-card host overrides (Phase 4) flow into all
+  // three. Pre-refactor only the chat branch had this stack.
+  //
+  // Two of the providers (`ActiveMcpProfileProvider`,
+  // `ActiveHostCapsResolverScope`) are conditional: they shadow the
+  // tab-root only when the caller explicitly passes the prop. This
+  // matters because (a) model-mode wants the tab-root values to flow
+  // through unchanged, and (b) the contexts' default values aren't
+  // meaningful sentinels (their `undefined` defaults represent real
+  // states, not "no scope"). The "*Set" discriminator booleans handle
+  // the value-providers analogously.
+  const cardBody = (
     <div
       data-testid="multi-model-playground-card-root"
       className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl border border-border/60 bg-card/40"
     >
       <ModelCompareCardHeader
         model={model}
+        compareLabel={compareLabel}
+        compareSubLabel={compareSubLabel}
         summary={summary}
         allSummaries={comparisonSummaries}
         mode={activeTraceViewMode}
@@ -616,7 +727,7 @@ export function MultiModelPlaygroundCard({
                 />
               ) : showLiveTracePending ? (
                 <LiveTraceTimelineEmptyState
-                  testId={`playground-live-trace-pending-${String(model.id)}`}
+                  testId={`playground-live-trace-pending-${compareId}`}
                 />
               ) : (
                 <TraceViewer
@@ -646,78 +757,108 @@ export function MultiModelPlaygroundCard({
             </div>
           </div>
         ) : (
-          <ChatboxHostStyleProvider value={hostStyle}>
-            <ChatboxHostCapabilitiesOverrideProvider
-              value={hostCapabilitiesOverride}
-            >
-            <ChatboxHostThemeProvider value={effectiveThreadTheme}>
-              <div
-                className={cn(
-                  "chatbox-host-shell app-theme-scope relative m-3 flex min-h-0 flex-1 flex-col overflow-hidden rounded-[1.25rem] border border-border/50",
-                  shellHeightClass,
-                  effectiveThreadTheme === "dark" && "dark",
-                )}
-                data-host-style={hostStyle}
-                data-thread-theme={effectiveThreadTheme}
-                style={{
-                  backgroundColor: hostBackgroundColor,
-                }}
+          <div
+            className={cn(
+              "chatbox-host-shell app-theme-scope relative m-3 flex min-h-0 flex-1 flex-col overflow-hidden rounded-[1.25rem] border border-border/50",
+              shellHeightClass,
+              effectiveThreadTheme === "dark" && "dark",
+            )}
+            data-host-style={hostStyle}
+            data-thread-theme={effectiveThreadTheme}
+            style={{
+              backgroundColor: hostBackgroundColor,
+            }}
+          >
+            {isThreadEmpty ? (
+              suppressThreadEmptyHint ? (
+                <div className="min-h-[8rem] flex-1" aria-hidden />
+              ) : (
+                <div className="flex flex-1 items-center justify-center px-6 py-8 text-center text-sm text-muted-foreground">
+                  Send a shared message to start this model’s thread.
+                </div>
+              )
+            ) : (
+              <StickToBottom
+                className="relative flex flex-1 flex-col min-h-0"
+                resize="smooth"
+                initial="smooth"
               >
-                {isThreadEmpty ? (
-                  suppressThreadEmptyHint ? (
-                    <div className="min-h-[8rem] flex-1" aria-hidden />
-                  ) : (
-                    <div className="flex flex-1 items-center justify-center px-6 py-8 text-center text-sm text-muted-foreground">
-                      Send a shared message to start this model’s thread.
-                    </div>
-                  )
-                ) : (
-                  <StickToBottom
-                    className="relative flex flex-1 flex-col min-h-0"
-                    resize="smooth"
-                    initial="smooth"
-                  >
-                    <div className="relative flex-1 min-h-0">
-                      <StickToBottom.Content className="flex flex-col min-h-0">
-                        <Thread
-                          messages={messages}
-                          sendFollowUpMessage={handleSendFollowUp}
-                          model={model}
-                          isLoading={isStreaming}
-                          toolsMetadata={toolsMetadata}
-                          toolServerMap={toolServerMap}
-                          onWidgetStateChange={onWidgetStateChange}
-                          onModelContextUpdate={handleModelContextUpdate}
-                          displayMode={displayMode}
-                          onDisplayModeChange={onDisplayModeChange}
-                          onFullscreenChange={setIsWidgetFullscreen}
-                          selectedProtocolOverrideIfBothExists={
-                            selectedProtocol ?? undefined
-                          }
-                          onToolApprovalResponse={addToolApprovalResponse}
-                          toolRenderOverrides={mergedToolRenderOverrides}
-                          showSaveViewButton={!hideSaveViewButton}
-                          fullscreenChatSendBlocked={fullscreenChatSendBlocked}
-                          onFullscreenChatStop={stop}
-                          reasoningDisplayMode={reasoningDisplayMode}
-                        />
-                        {isExecuting && executingToolName ? (
-                          <InvokingIndicator
-                            toolName={executingToolName}
-                            customMessage={invokingMessage}
-                          />
-                        ) : null}
-                      </StickToBottom.Content>
-                      <ScrollToBottomButton />
-                    </div>
-                  </StickToBottom>
-                )}
-              </div>
-            </ChatboxHostThemeProvider>
-            </ChatboxHostCapabilitiesOverrideProvider>
-          </ChatboxHostStyleProvider>
+                <div className="relative flex-1 min-h-0">
+                  <StickToBottom.Content className="flex flex-col min-h-0">
+                    <Thread
+                      messages={messages}
+                      sendFollowUpMessage={handleSendFollowUp}
+                      model={model}
+                      isLoading={isStreaming}
+                      toolsMetadata={toolsMetadata}
+                      toolServerMap={toolServerMap}
+                      onWidgetStateChange={onWidgetStateChange}
+                      onModelContextUpdate={handleModelContextUpdate}
+                      displayMode={displayMode}
+                      onDisplayModeChange={onDisplayModeChange}
+                      onFullscreenChange={setIsWidgetFullscreen}
+                      selectedProtocolOverrideIfBothExists={
+                        selectedProtocol ?? undefined
+                      }
+                      onToolApprovalResponse={addToolApprovalResponse}
+                      toolRenderOverrides={mergedToolRenderOverrides}
+                      showSaveViewButton={!hideSaveViewButton}
+                      fullscreenChatSendBlocked={fullscreenChatSendBlocked}
+                      onFullscreenChatStop={stop}
+                      reasoningDisplayMode={reasoningDisplayMode}
+                    />
+                    {isExecuting && executingToolName ? (
+                      <InvokingIndicator
+                        toolName={executingToolName}
+                        customMessage={invokingMessage}
+                      />
+                    ) : null}
+                  </StickToBottom.Content>
+                  <ScrollToBottomButton />
+                </div>
+              </StickToBottom>
+            )}
+          </div>
         )}
       </div>
     </div>
   );
+
+  // Always-on value providers — wrap the whole card body. The values
+  // are the resolved `effective*` (prop with fall-back to tab-root
+  // context), so model-mode is byte-equivalent to today (tab-root flows
+  // through), host-mode shadows.
+  let wrapped: ReactNode = (
+    <ChatboxHostStyleProvider value={hostStyle}>
+      <ChatboxHostCapabilitiesOverrideProvider
+        value={effectiveHostCapabilitiesOverride}
+      >
+        <ChatboxChatUiOverrideProvider value={effectiveChatUiOverride}>
+          <ChatboxHostThemeProvider value={effectiveThreadTheme}>
+            {cardBody}
+          </ChatboxHostThemeProvider>
+        </ChatboxChatUiOverrideProvider>
+      </ChatboxHostCapabilitiesOverrideProvider>
+    </ChatboxHostStyleProvider>
+  );
+
+  // Optional shadow providers — only wrap when the caller explicitly
+  // passed the corresponding prop. Without the prop, the tab-root
+  // scope's value flows through, preserving today's behavior.
+  if (mcpProfileSet) {
+    wrapped = (
+      <ActiveMcpProfileProvider value={effectiveMcpProfile}>
+        {wrapped}
+      </ActiveMcpProfileProvider>
+    );
+  }
+  if (activeHost !== undefined) {
+    wrapped = (
+      <ActiveHostCapsResolverScope activeHost={activeHost} hostStyle={hostStyle}>
+        {wrapped}
+      </ActiveHostCapsResolverScope>
+    );
+  }
+
+  return wrapped;
 }


### PR DESCRIPTION
## Summary

Phase 3 of the multi-host compare feature (plan: `create-a-plan-and-polymorphic-cray.md`). This is a structural refactor in preparation for Phase 4's multi-host render path. **No user-visible behavior change** — but qualifying that: it IS a structural prop / provider boundary shift, not a pure rename. Reviewers should evaluate it as a refactor whose acceptance bar is "model-mode is behavior-equivalent to today."

Two changes land together:

### 1. Polymorphic compare card identity
- `MultiModelPlaygroundCard` takes new props `compareId`, `compareLabel`, `compareKind`, `compareSubLabel`. Internal per-card state keys (transcript sync, hasMessages callback, summary.modelId field) now use `compareId` instead of `String(model.id)`. In today's model-mode caller `compareId === String(model.id)`, so the keying is byte-equivalent.
- `ModelCompareCardHeader` takes `compareLabel` and `compareSubLabel`. `compareLabel` takes precedence over the legacy `modelLabel` / `model?.name`. `compareSubLabel` renders a secondary muted line — undefined in model mode (renders nothing), the resolved model name in host mode (Phase 4).
- `PlaygroundMain` per-column state refs renamed to mode-neutral identifiers (`compareSummaries`, `compareHasMessages`, `compareTranscriptsRef`, `compareAddColumnSeeds`, `prevCompareIdsRef`, `lastCompareLeadIdRef`). The KEYS in these maps stay strings — column ids regardless of mode.
- Grid card `key` becomes `${gen}:${kind}:${id}` (was `${gen}:${id}`) so model-mode and host-mode keys won't collide during Phase 6 mode-swap transitions.

### 2. Provider lift — whole card body, not just chat branch
Before: the card wrapped only the chat branch with `ChatboxHostStyleProvider` + `ChatboxHostCapabilitiesOverrideProvider` + `ChatboxHostThemeProvider`. The trace branch lived OUTSIDE that stack, reading from the tab-root. That meant Phase 4 per-column host overrides could not apply to trace/raw views.

After: providers wrap the entire card body (header + trace branch + chat branch). The card also accepts optional new host-snapshot props — `hostCapabilitiesOverride`, `chatUiOverride`, `mcpProfile`, `activeHost`. When passed, the card's inner provider shadows the tab-root one for that subtree. When NOT passed (today's model-mode caller in PlaygroundMain), the card falls back to the tab-root provider via `useContext`, so the rendered tree is behavior-equivalent.

`ChatboxChatUiOverrideProvider`, `ActiveMcpProfileProvider`, and `ActiveHostCapsResolverScope` continue to live at the tab root (`PlaygroundTab.tsx`). The card's per-card layer shadows them only when an explicit prop is passed — see `feedback_inner_scope_shadows_outer.md`; the shadow here is intentional and controlled by passing-only-when-explicit.

### Notes for reviewers
- The card no longer reads `hostCapabilitiesOverride` from the preferences store directly. It consumes the tab-root context instead. The tab root already reads from prefs and provides it, so the resolved value is identical in model mode.
- `hostCapabilitiesOverride` and `chatUiOverride` have `undefined` as a meaningful runtime value ("no override; preset wins"). To distinguish "no prop" from "prop = undefined", the card takes `hostCapabilitiesOverrideSet` / `chatUiOverrideSet` / `mcpProfileSet` discriminator booleans. Model-mode never passes either.
- No new exports were needed from the context modules — the contexts already expose their `useXxx` hook helpers, which is all the card needed for fallback reads.

## Test plan

- [x] `npm run typecheck:client` — clean (production code; tests excluded per project config).
- [x] Full client `vitest run` — 3174 passed, 6 skipped (no regressions vs main).
- [x] Updated `multi-model-playground-card.test.tsx` for the new required props (compareId / compareLabel / compareKind) and added mocks for new context modules.
- [x] New `multi-model-playground-card.provider-shadow.test.tsx` — exercises the Phase 4 contract end-to-end with REAL contexts (no `vi.mock` of the context modules under test): when the card receives an explicit `hostCapabilitiesOverride` prop, the inner `Thread` subtree's `useChatboxHostCapabilitiesOverride()` returns the prop value; without the prop it falls back to the tab-root context.
- [ ] Manual smoke on `pnpm dev`: NOT performed by the agent (no interactive UI access). Reviewer should exercise single-host + single-model, multi-model with 2 models, trace view in each card, raw view, and confirm visual parity with main. The structural changes are exhaustively unit-tested but visual confirmation is the final acceptance gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors multi-model compare card identity/state keying and lifts provider boundaries across the whole card; while intended to be behavior-neutral in model mode, subtle context/provider and keying changes could affect rendering, trace/raw views, or per-column state sync.
> 
> **Overview**
> Prepares the playground’s multi-column compare UI for upcoming multi-host support by making each column **mode-neutral**: `MultiModelPlaygroundCard` now takes `compareId`/`compareLabel`/`compareKind`/`compareSubLabel`, and per-column transcripts, summaries, and “has messages” state in `PlaygroundMain` are keyed by `compareId` (with card React keys updated to include the compare kind).
> 
> Lifts the host-related provider stack to wrap the **entire** compare card (header + trace/raw + chat), and adds optional per-card “host snapshot” override props (`hostCapabilitiesOverride`, `chatUiOverride`, `mcpProfile`, `activeHost`) with explicit “*Set” flags to control when the card shadows tab-root contexts.
> 
> Updates `ModelCompareCardHeader` to support polymorphic titles via `compareLabel` and an optional secondary `compareSubLabel`, and adds tests including a new contract test ensuring per-card provider shadowing overrides tab-root context values when supplied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 146e9847917f0ae72f25ed18e8177bba59b3957d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->