### PR TITLE
fix inspector orphan process cleanup

### DIFF
--- a/mcpjam-inspector/bin/start.js
+++ b/mcpjam-inspector/bin/start.js
@@ -137,44 +137,87 @@ function isPortAvailable(port) {
   });
 }
 
-function waitForServerReady(port, host, timeoutMs = 30000) {
+function waitForServerReady(port, host, timeoutMs = 30000, signal = null) {
   const intervalMs = 200;
   const startTime = Date.now();
 
   return new Promise((resolve) => {
+    let done = false;
+    let activeSocket = null;
+    let retryTimer = null;
+
+    function finish(ready) {
+      if (done) return;
+      done = true;
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+      }
+      if (activeSocket) {
+        activeSocket.destroy();
+      }
+      signal?.removeEventListener("abort", onAbort);
+      resolve(ready);
+    }
+
+    function onAbort() {
+      finish(false);
+    }
+
+    function retry() {
+      if (done) return;
+      retryTimer = setTimeout(() => {
+        retryTimer = null;
+        attempt();
+      }, intervalMs);
+    }
+
     function attempt() {
+      if (done) {
+        return;
+      }
+
       if (Date.now() - startTime >= timeoutMs) {
-        resolve(false);
+        finish(false);
         return;
       }
 
       const socket = createConnection({ port, host });
+      activeSocket = socket;
       let settled = false;
 
       function cleanup() {
         if (settled) return;
         settled = true;
+        if (activeSocket === socket) {
+          activeSocket = null;
+        }
         socket.removeAllListeners();
         socket.destroy();
       }
 
       socket.once("connect", () => {
         cleanup();
-        resolve(true);
+        finish(true);
       });
 
       socket.once("error", () => {
         cleanup();
-        setTimeout(attempt, intervalMs);
+        retry();
       });
 
       socket.setTimeout(1000);
       socket.once("timeout", () => {
         cleanup();
-        setTimeout(attempt, intervalMs);
+        retry();
       });
     }
 
+    if (signal?.aborted) {
+      finish(false);
+      return;
+    }
+
+    signal?.addEventListener("abort", onAbort, { once: true });
     attempt();
   });
 }
@@ -714,10 +757,21 @@ async function main() {
   Object.assign(process.env, envVars);
 
   // Port configuration (fixed default to 6274)
-  const requestedPort = 6274;
+  const requestedPortValue = envVars.PORT || "6274";
+  const requestedPort = Number(requestedPortValue);
   let PORT;
 
   try {
+    if (
+      !/^\d+$/.test(requestedPortValue) ||
+      !Number.isInteger(requestedPort) ||
+      requestedPort < 1 ||
+      requestedPort > 65535
+    ) {
+      logError(`Invalid port: ${requestedPortValue}`);
+      throw new Error(`Invalid port: ${requestedPortValue}`);
+    }
+
     // Check if user explicitly set a port via --port flag
     const hasExplicitPort = envVars.PORT !== undefined;
 
@@ -745,6 +799,7 @@ async function main() {
 
     // Update environment variables with the final port
     envVars.PORT = PORT;
+    envVars.SERVER_PORT = PORT;
     // Default: localhost in development, 127.0.0.1 in production
     const defaultHost =
       process.env.ENVIRONMENT === "dev" ? "localhost" : "127.0.0.1";
@@ -757,10 +812,26 @@ async function main() {
   }
 
   const abort = new AbortController();
+  const initialParentPid = process.ppid;
+  let parentWatcher = null;
+  const orphanCheckDisabled =
+    process.env.MCPJAM_INSPECTOR_DISABLE_ORPHAN_CHECK === "1";
 
   let cancelled = false;
-  process.on("SIGINT", () => {
+  function stopParentWatcher() {
+    if (parentWatcher) {
+      clearInterval(parentWatcher);
+      parentWatcher = null;
+    }
+  }
+
+  function requestShutdown() {
+    if (cancelled) {
+      return;
+    }
+
     cancelled = true;
+    stopParentWatcher();
     abort.abort();
     logDivider();
     logWarning("Shutdown signal received...");
@@ -768,7 +839,20 @@ async function main() {
     logInfo("Cleaning up resources...");
     logSuccess("Server stopped gracefully");
     logDivider();
-  });
+  }
+
+  for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+    process.on(signal, requestShutdown);
+  }
+
+  if (!orphanCheckDisabled && initialParentPid > 1) {
+    parentWatcher = setInterval(() => {
+      if (process.ppid !== initialParentPid) {
+        requestShutdown();
+      }
+    }, 1000);
+    parentWatcher.unref?.();
+  }
 
   try {
     const distServerPath = resolve(projectRoot, "dist", "server", "index.js");
@@ -802,10 +886,15 @@ async function main() {
       await delay(500);
     }
 
+    if (cancelled) {
+      return 0;
+    }
+
     // Spawn the server process but don't wait for it to exit
     const serverProcess = spawn("node", [distServerPath], {
       env: {
         ...process.env,
+        MCPJAM_INSPECTOR_PARENT_PID: process.pid.toString(),
         NODE_ENV: "production",
         PORT: PORT,
         ...(verboseLogs && { VERBOSE_LOGS: "true" }),
@@ -813,6 +902,26 @@ async function main() {
       cwd: projectRoot,
       stdio: "inherit",
     });
+
+    let serverProcessClosed = false;
+    const serverExit = new Promise((resolve, reject) => {
+      serverProcess.on("close", (code) => {
+        serverProcessClosed = true;
+        if (code === 0 || cancelled) {
+          resolve(code);
+        } else {
+          reject(new Error(`Server process exited with code ${code}`));
+        }
+      });
+    });
+
+    function killServerProcess() {
+      if (!serverProcessClosed && !serverProcess.killed) {
+        serverProcess.kill("SIGTERM");
+      }
+    }
+
+    process.once("exit", killServerProcess);
 
     // Handle server process errors
     serverProcess.on("error", (error) => {
@@ -823,9 +932,7 @@ async function main() {
     });
 
     // Handle abort signal
-    abort.signal.addEventListener("abort", () => {
-      serverProcess.kill("SIGTERM");
-    });
+    abort.signal.addEventListener("abort", killServerProcess, { once: true });
 
     if (!cancelled) {
       // Default: localhost in development, 127.0.0.1 in production
@@ -835,9 +942,14 @@ async function main() {
       const apiBaseUrl = process.env.BASE_URL || `http://${host}:${PORT}`;
 
       // Wait until the server is actually accepting connections
-      const ready = await waitForServerReady(parseInt(PORT, 10), host, 30000);
+      const ready = await waitForServerReady(
+        parseInt(PORT, 10),
+        host,
+        30000,
+        abort.signal,
+      );
 
-      if (!ready) {
+      if (!ready && !cancelled) {
         logWarning(
           `Server did not become ready within 30s. Please visit ${apiBaseUrl} manually.`,
         );
@@ -861,15 +973,7 @@ async function main() {
     }
 
     // Wait for the server process to exit
-    await new Promise((resolve, reject) => {
-      serverProcess.on("close", (code) => {
-        if (code === 0 || cancelled) {
-          resolve(code);
-        } else {
-          reject(new Error(`Server process exited with code ${code}`));
-        }
-      });
-    });
+    await serverExit;
   } catch (e) {
     if (!cancelled || process.env.DEBUG) {
       logDivider();
@@ -878,6 +982,8 @@ async function main() {
       logDivider();
       throw e;
     }
+  } finally {
+    stopParentWatcher();
   }
 
   return 0;

--- a/mcpjam-inspector/bin/start.js
+++ b/mcpjam-inspector/bin/start.js
@@ -543,10 +543,7 @@ async function main() {
       continue;
     }
 
-    if (
-      parsingFlags &&
-      (arg === "--no-open" || arg === "--no-browser")
-    ) {
+    if (parsingFlags && (arg === "--no-open" || arg === "--no-browser")) {
       openBrowser = false;
       continue;
     }
@@ -632,7 +629,9 @@ async function main() {
         if (mcpServerName) {
           if (!configData.mcpServers[mcpServerName]) {
             logError(
-              `Server '${mcpServerName}' not found in config file. Available servers: ${Object.keys(configData.mcpServers).join(", ")}`,
+              `Server '${mcpServerName}' not found in config file. Available servers: ${Object.keys(
+                configData.mcpServers,
+              ).join(", ")}`,
             );
             process.exit(1);
           }
@@ -705,7 +704,9 @@ async function main() {
     // Handle single MCP server command if provided (legacy mode)
     logStep(
       "MCP Server",
-      `Configuring auto-connection to: ${mcpServerCommand} ${mcpServerArgs.join(" ")}`,
+      `Configuring auto-connection to: ${mcpServerCommand} ${mcpServerArgs.join(
+        " ",
+      )}`,
     );
 
     // Pass MCP server config via environment variables
@@ -837,8 +838,6 @@ async function main() {
     logWarning("Shutdown signal received...");
     logProgress("Stopping MCP Inspector server");
     logInfo("Cleaning up resources...");
-    logSuccess("Server stopped gracefully");
-    logDivider();
   }
 
   for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) {
@@ -904,20 +903,49 @@ async function main() {
     });
 
     let serverProcessClosed = false;
+    let forceKillTimer = null;
+
+    function clearForceKillTimer() {
+      if (forceKillTimer) {
+        clearTimeout(forceKillTimer);
+        forceKillTimer = null;
+      }
+    }
+
     const serverExit = new Promise((resolve, reject) => {
-      serverProcess.on("close", (code) => {
+      serverProcess.on("close", (code, signal) => {
         serverProcessClosed = true;
+        clearForceKillTimer();
         if (code === 0 || cancelled) {
-          resolve(code);
+          resolve({ code, signal });
         } else {
-          reject(new Error(`Server process exited with code ${code}`));
+          reject(
+            new Error(
+              signal
+                ? `Server process exited from signal ${signal}`
+                : `Server process exited with code ${code}`,
+            ),
+          );
         }
       });
     });
 
     function killServerProcess() {
-      if (!serverProcessClosed && !serverProcess.killed) {
-        serverProcess.kill("SIGTERM");
+      if (serverProcessClosed) {
+        return;
+      }
+
+      serverProcess.kill("SIGTERM");
+      if (!forceKillTimer) {
+        forceKillTimer = setTimeout(() => {
+          if (!serverProcessClosed) {
+            logWarning(
+              "Server did not exit after SIGTERM; forcing shutdown...",
+            );
+            serverProcess.kill("SIGKILL");
+          }
+        }, 5000);
+        forceKillTimer.unref?.();
       }
     }
 
@@ -973,7 +1001,15 @@ async function main() {
     }
 
     // Wait for the server process to exit
-    await serverExit;
+    const result = await serverExit;
+    if (cancelled) {
+      if (result.signal === "SIGKILL") {
+        logWarning("Server process was force-killed after shutdown timeout");
+      } else {
+        logSuccess("Server stopped gracefully");
+      }
+      logDivider();
+    }
   } catch (e) {
     if (!cancelled || process.env.DEBUG) {
       logDivider();

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -512,13 +512,44 @@ const server = serve({
   hostname,
 });
 
+const expectedParentPid = Number.parseInt(
+  process.env.MCPJAM_INSPECTOR_PARENT_PID ?? "",
+  10,
+);
+let orphanCheckInterval: ReturnType<typeof setInterval> | undefined;
+let shuttingDown = false;
+
 // Handle graceful shutdown
 async function shutdown() {
+  if (shuttingDown) {
+    return;
+  }
+
+  shuttingDown = true;
+  if (orphanCheckInterval) {
+    clearInterval(orphanCheckInterval);
+    orphanCheckInterval = undefined;
+  }
+
   console.log("\n🛑 Shutting down gracefully...");
   await tunnelManager.closeAll();
   server.close();
   await appLogger.flush();
   process.exit(0);
+}
+
+if (
+  Number.isFinite(expectedParentPid) &&
+  expectedParentPid > 1 &&
+  process.env.MCPJAM_INSPECTOR_DISABLE_ORPHAN_CHECK !== "1" &&
+  !process.versions.electron
+) {
+  orphanCheckInterval = setInterval(() => {
+    if (process.ppid !== expectedParentPid) {
+      void shutdown();
+    }
+  }, 1000);
+  orphanCheckInterval.unref();
 }
 
 process.on("SIGINT", shutdown);

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -518,6 +518,7 @@ const expectedParentPid = Number.parseInt(
 );
 let orphanCheckInterval: ReturnType<typeof setInterval> | undefined;
 let shuttingDown = false;
+const shutdownForceExitMs = 5000;
 
 // Handle graceful shutdown
 async function shutdown() {
@@ -531,11 +532,24 @@ async function shutdown() {
     orphanCheckInterval = undefined;
   }
 
+  const forceExitTimer = setTimeout(() => {
+    console.error("Shutdown timed out; forcing process exit.");
+    process.exit(1);
+  }, shutdownForceExitMs);
+  forceExitTimer.unref();
+
   console.log("\n🛑 Shutting down gracefully...");
-  await tunnelManager.closeAll();
-  server.close();
-  await appLogger.flush();
-  process.exit(0);
+  try {
+    await tunnelManager.closeAll();
+    server.close();
+    await appLogger.flush();
+    clearTimeout(forceExitTimer);
+    process.exit(0);
+  } catch (error) {
+    clearTimeout(forceExitTimer);
+    console.error("Error during shutdown:", error);
+    process.exit(1);
+  }
 }
 
 if (

--- a/mcpjam-inspector/server/index.ts
+++ b/mcpjam-inspector/server/index.ts
@@ -519,6 +519,20 @@ const expectedParentPid = Number.parseInt(
 let orphanCheckInterval: ReturnType<typeof setInterval> | undefined;
 let shuttingDown = false;
 const shutdownForceExitMs = 5000;
+const logFlushExitMs = 1000;
+
+function exitAfterLogFlush(code: number) {
+  const exitFallbackTimer = setTimeout(
+    () => process.exit(code),
+    logFlushExitMs,
+  );
+  exitFallbackTimer.unref();
+
+  void appLogger.flush().finally(() => {
+    clearTimeout(exitFallbackTimer);
+    process.exit(code);
+  });
+}
 
 // Handle graceful shutdown
 async function shutdown() {
@@ -533,12 +547,15 @@ async function shutdown() {
   }
 
   const forceExitTimer = setTimeout(() => {
-    console.error("Shutdown timed out; forcing process exit.");
-    process.exit(1);
+    appLogger.error(
+      "Shutdown timed out; forcing process exit.",
+      new Error("Shutdown timed out; forcing process exit."),
+    );
+    exitAfterLogFlush(1);
   }, shutdownForceExitMs);
   forceExitTimer.unref();
 
-  console.log("\n🛑 Shutting down gracefully...");
+  appLogger.info("Shutting down gracefully...");
   try {
     await tunnelManager.closeAll();
     server.close();
@@ -547,8 +564,8 @@ async function shutdown() {
     process.exit(0);
   } catch (error) {
     clearTimeout(forceExitTimer);
-    console.error("Error during shutdown:", error);
-    process.exit(1);
+    appLogger.error("Error during shutdown", error);
+    exitAfterLogFlush(1);
   }
 }
 


### PR DESCRIPTION
## Summary

This makes the inspector clean itself up when the process that launched it goes away.

The launcher now handles normal shutdown signals and watches for parent process exit. The server also watches for the launcher disappearing, so it can still shut down even if the launcher is force-killed.

## Why

Killing `npx` / `npm exec` could leave the inspector server running in the background, keeping the dashboard alive and the port busy.

## Tested

- Launcher exits cleanly on SIGTERM
- Server exits after launcher SIGKILL
- Server exits after wrapper / parent process is killed
- Invalid port values are rejected