### PR TITLE
fix(playground): align MultiHostPicker chrome with sibling pills

### DIFF
--- a/mcpjam-inspector/client/src/components/clients/MultiHostPicker.tsx
+++ b/mcpjam-inspector/client/src/components/clients/MultiHostPicker.tsx
@@ -271,11 +271,11 @@ export function MultiHostPicker({
               variant="ghost"
               size="sm"
               disabled={disabled || isLoading}
-              className="h-8 max-w-[200px] rounded-full px-2 text-xs transition-colors hover:bg-muted/80"
+              className="h-7 max-w-[200px] shrink-0 gap-1.5 border bg-background px-2 text-xs shadow-xs"
               data-testid="multi-host-picker-trigger"
             >
               <Server className="h-3.5 w-3.5 shrink-0" />
-              <span className="truncate text-[10px] font-medium">
+              <span className="truncate whitespace-nowrap @max-[820px]/playground-header:sr-only">
                 {triggerLabel}
               </span>
             </Button>

--- a/mcpjam-inspector/client/src/components/clients/MultiHostPicker.tsx
+++ b/mcpjam-inspector/client/src/components/clients/MultiHostPicker.tsx
@@ -79,6 +79,12 @@ function compactHostLabel(name: string): string {
   return name;
 }
 
+const PLAYGROUND_HEADER_TOOLTIP = {
+  variant: "muted" as const,
+  sideOffset: 6,
+  collisionPadding: 12,
+};
+
 export function MultiHostPicker({
   projectId: _projectId,
   hosts,
@@ -275,7 +281,20 @@ export function MultiHostPicker({
             </Button>
           </PopoverTrigger>
         </TooltipTrigger>
-        <TooltipContent side="top">{triggerLabel}</TooltipContent>
+        <TooltipContent {...PLAYGROUND_HEADER_TOOLTIP}>
+          <p className="font-medium">
+            {multiHostEnabled && effectiveSelectedHostIds.length > 1
+              ? "Hosts"
+              : "Host"}
+          </p>
+          {multiHostEnabled && effectiveSelectedHostIds.length > 1 ? (
+            <p className="text-xs font-light text-muted-foreground">
+              {effectiveSelectedHostIds
+                .map((id) => hostsById.get(id)?.name ?? id)
+                .join(", ")}
+            </p>
+          ) : null}
+        </TooltipContent>
       </Tooltip>
 
       <PopoverContent align="start" className="w-[280px] p-0" sideOffset={8}>


### PR DESCRIPTION
## Summary
At a reduced viewport, the host pill looked visually inconsistent with the sibling toolbar pills (Device / Locale / Timezone / CSP) and never collapsed to icon-only, so it hogged horizontal space and stood out as the loud item.

Two-commit fix on `mcpjam-inspector/client/src/components/clients/MultiHostPicker.tsx`:

1. **Chrome alignment** — drop `h-8 rounded-full` filled style for siblings' shared `h-7 rounded-md gap-1.5 border bg-background px-2 text-xs shadow-xs`. Drop the inner `text-[10px] font-medium` label for `text-xs whitespace-nowrap` and collapse the label to `sr-only` below the `@[820px]/playground-header` container breakpoint, mirroring Locale / Timezone.
2. **Tooltip semantics** — the old tooltip just echoed the trigger label (`ChatGPT +1` on a `ChatGPT +1` button). Replace with the sibling `PLAYGROUND_HEADER_TOOLTIP` muted style and a semantic header (`Host` / `Hosts`); when multi-host is enabled, append a secondary line that expands the `+N` abbreviation to the comma-separated host-name list so users can decode it without opening the popover (and so the label still has meaning once it collapses to icon-only).

## Test plan
- [ ] At wide viewports the host pill matches Device / Locale / Timezone / CSP in shape, height, border, and shadow.
- [ ] Below ~820px container width, only the server icon shows (label `sr-only`); siblings already collapse around the same band.
- [ ] Hover with one host → tooltip shows `Host` only.
- [ ] Hover with multi-host on and 2+ selected → tooltip shows `Hosts` plus the comma-separated full names (lead first).
- [ ] `npm run typecheck:client` passes (verified locally).
- [ ] `MultiHostPicker.test.tsx` (10 tests) passes (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)