### PR TITLE
fix(apps): stabilize widget iframe across first render and history reloads

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-app-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-app-renderer.tsx
@@ -47,6 +47,7 @@ import {
   extractHostTheme,
   extractHostTimeZone,
 } from "@/lib/client-config";
+import { useWidgetSurface } from "@/contexts/widget-surface-context";
 
 type ToolState =
   | "input-streaming"
@@ -745,11 +746,17 @@ export function ChatGPTAppRenderer({
   const playgroundSafeAreaInsets = useUIPlaygroundStore(
     (s) => s.safeAreaInsets,
   );
-  const cspMode = isPlaygroundActive
-    ? playgroundCspMode
-    : minimalMode
-      ? "permissive"
-      : "widget-declared";
+  // Surface-derived cspMode: read from WidgetSurfaceContext, NOT
+  // `isPlaygroundActive`. See mcp-apps-renderer.tsx for the rationale —
+  // the store flag is set in a passive `useEffect` and flips on commit
+  // #2, which used to remount the iframe and drop View state.
+  const widgetSurface = useWidgetSurface();
+  const cspMode =
+    widgetSurface === "playground"
+      ? playgroundCspMode
+      : minimalMode
+        ? "permissive"
+        : "widget-declared";
   // Use playground settings when active, otherwise compute from window
   const deviceType = isPlaygroundActive
     ? playgroundDeviceType

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -75,6 +75,7 @@ const {
     setWidgetHtml: vi.fn(),
     setSandboxApplied: vi.fn(),
     appendLifecycle: vi.fn(),
+    recordMount: vi.fn(),
   };
 
   return {
@@ -203,6 +204,7 @@ vi.mock("@/stores/widget-debug-store", () => ({
       setWidgetHtml: stableStoreFns.setWidgetHtml,
       setSandboxApplied: stableStoreFns.setSandboxApplied,
       appendLifecycle: stableStoreFns.appendLifecycle,
+      recordMount: stableStoreFns.recordMount,
     }),
 }));
 
@@ -241,6 +243,7 @@ import {
   ChatboxHostThemeProvider,
 } from "@/contexts/chatbox-client-style-context";
 import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-client-capabilities-override-context";
+import { WidgetSurfaceProvider } from "@/contexts/widget-surface-context";
 import type { McpUiHostCapabilities } from "@modelcontextprotocol/ext-apps/app-bridge";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
@@ -1002,6 +1005,62 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(vi.mocked(global.fetch)).toHaveBeenCalledWith("blob:cached");
     // Cached path forces permissive rendering.
     expect(sandboxedIframePropsRef.current?.permissive).toBe(true);
+  });
+
+  it("first-render cspMode derives from WidgetSurfaceProvider, not isPlaygroundActive", async () => {
+    // Regression for the "draw a cat, then it vanishes" iframe re-mount
+    // bug. Previously `cspMode` came from `isPlaygroundActive`, which was
+    // set in a passive useEffect by PlaygroundMain. First render saw
+    // `false` → cspMode = "widget-declared" → live fetch with that
+    // mode; the effect then committed → flag flipped → cspMode flipped
+    // → fetch-source key changed → iframe remounted and lost View state.
+    //
+    // The fix routes cspMode through WidgetSurfaceContext, which
+    // propagates synchronously on the first render. This test pins
+    // that contract so a future refactor reintroducing a global-flag
+    // dependency on cspMode would flip the assertion.
+    Object.assign(mockPlaygroundStoreState, {
+      isPlaygroundActive: false,
+      mcpAppsCspMode: "permissive",
+    });
+
+    render(
+      <WidgetSurfaceProvider value="playground">
+        <MCPAppsRenderer {...baseProps} />
+      </WidgetSurfaceProvider>,
+    );
+
+    await vi.waitFor(() => {
+      expect(vi.mocked(authFetch)).toHaveBeenCalled();
+    });
+
+    // First live fetch must already carry the playground cspMode —
+    // proves no race, no second fetch with the corrected mode.
+    expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(1);
+    const firstCall = vi.mocked(authFetch).mock.calls[0];
+    const body = JSON.parse(firstCall[1]!.body as string);
+    expect(body.cspMode).toBe("permissive");
+  });
+
+  it("first-render cspMode falls back to 'widget-declared' outside the playground surface", async () => {
+    // Symmetric guard: without the WidgetSurfaceProvider, the renderer
+    // is on the chat surface and must use the strict default —
+    // regardless of any leaked store flag value.
+    Object.assign(mockPlaygroundStoreState, {
+      isPlaygroundActive: true,
+      mcpAppsCspMode: "permissive",
+    });
+
+    render(<MCPAppsRenderer {...baseProps} />);
+
+    await vi.waitFor(() => {
+      expect(vi.mocked(authFetch)).toHaveBeenCalled();
+    });
+
+    expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(1);
+    const firstCall = vi.mocked(authFetch).mock.calls[0];
+    const body = JSON.parse(firstCall[1]!.body as string);
+    expect(body.cspMode).toBe("widget-declared");
   });
 
   it("drops stale live-fetch results when the source key has moved on (renderer reuse)", async () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -33,6 +33,7 @@ import { authFetch } from "@/lib/session-token";
 import { HOSTED_MODE } from "@/lib/config";
 import { useActiveMcpProfile } from "@/contexts/active-mcp-profile-context";
 import { useIsChatboxSurface } from "@/contexts/chatbox-surface-context";
+import { useWidgetSurface } from "@/contexts/widget-surface-context";
 import {
   resolveSandboxCsp,
   resolveSandboxPermissions,
@@ -303,6 +304,30 @@ function mapLogToLifecycle(
   return { kind, status, message, timestamp: Date.now() };
 }
 
+/**
+ * Segments of the fetch-source key, in the same order as the renderer
+ * builds it below. Used to describe re-mount reasons for the Sandbox
+ * debug panel — e.g. "cachedWidgetHtmlUrl, liveFetchPreferred" when a
+ * Convex history snapshot lands.
+ */
+const FETCH_SOURCE_KEY_SEGMENTS = [
+  "toolCallId",
+  "resourceUri",
+  "cachedWidgetHtmlUrl",
+  "cspMode",
+  "liveFetchPreferred",
+] as const;
+
+function describeFetchSourceKeyDiff(prev: string, next: string): string {
+  const prevSegs = prev.split("|");
+  const nextSegs = next.split("|");
+  const changes: string[] = [];
+  for (let i = 0; i < FETCH_SOURCE_KEY_SEGMENTS.length; i += 1) {
+    if (prevSegs[i] !== nextSegs[i]) changes.push(FETCH_SOURCE_KEY_SEGMENTS[i]);
+  }
+  return changes.length === 0 ? "remount" : changes.join(", ");
+}
+
 export function MCPAppsRenderer({
   serverId,
   toolCallId,
@@ -402,10 +427,22 @@ export function MCPAppsRenderer({
   // under strict CSP — surprising and inconsistent with the published
   // chatbox runtime when opened in a top-level window.
   const isChatboxSurface = useIsChatboxSurface();
+  // Surface-derived cspMode: read from the WidgetSurfaceContext set by
+  // PlaygroundMain, NOT from `isPlaygroundActive` in the store. The
+  // store flag was set in a passive `useEffect`, so descendants
+  // observed `false` on the first render and resolved cspMode to
+  // "widget-declared"; the effect then flipped it to true, cspMode
+  // flipped to playgroundCspMode, the fetch-source key changed, and
+  // the iframe was torn down and rebuilt — losing View state. Context
+  // propagates synchronously on first render, so cspMode is stable
+  // from mount #1. Other readers of `isPlaygroundActive` below keep
+  // the store source — those don't gate the iframe-creation-time
+  // policy, so the same race is benign for them.
+  const widgetSurface = useWidgetSurface();
   const cspMode: CspMode =
     isChatboxSurface || minimalMode
       ? "permissive"
-      : isPlaygroundActive
+      : widgetSurface === "playground"
         ? playgroundCspMode
         : "widget-declared";
 
@@ -675,6 +712,18 @@ export function MCPAppsRenderer({
   // its own key; the helpers below drop any state writes that don't still
   // match the latest key.
   const latestFetchSourceKeyRef = useRef<string>("");
+  /**
+   * Previous fetch-source key, kept for the debug-panel mount log. We
+   * can't reuse `latestFetchSourceKeyRef` because it's bumped before the
+   * fetch starts; this one only advances after the mount has been
+   * recorded so the diff is always prev→current.
+   */
+  const prevLoggedFetchSourceKeyRef = useRef<string | null>(null);
+  // Bound before the fetch effect below references it in its deps array —
+  // the other widget-debug-store bindings live further down because they
+  // only fire from async callbacks, but `recordMountStore` is called
+  // synchronously inside the effect body, so it has to be in scope here.
+  const recordMountStore = useWidgetDebugStore((s) => s.recordMount);
 
   const {
     canRenderStreamingInput,
@@ -724,6 +773,18 @@ export function MCPAppsRenderer({
       liveFetchPreferred ? "live-pref" : "",
     ].join("|");
     latestFetchSourceKeyRef.current = fetchSourceKey;
+    // Mount log for the Sandbox debug panel. Record one entry per real
+    // key change (not per effect re-run) so devs can spot self-induced
+    // reloads — e.g. a Convex history snapshot landing and flipping
+    // `cachedWidgetHtmlUrl`/`liveFetchPreferred` mid-session, which
+    // remounts the iframe and visually wipes the previous render.
+    if (prevLoggedFetchSourceKeyRef.current !== fetchSourceKey) {
+      const prev = prevLoggedFetchSourceKeyRef.current;
+      const reason =
+        prev === null ? "initial" : describeFetchSourceKeyDiff(prev, fetchSourceKey);
+      prevLoggedFetchSourceKeyRef.current = fetchSourceKey;
+      recordMountStore(toolCallId, reason);
+    }
     const isStillCurrent = () =>
       latestFetchSourceKeyRef.current === fetchSourceKey;
 
@@ -956,6 +1017,7 @@ export function MCPAppsRenderer({
     liveFetchPreferred,
     initialPrefersBorder,
     cachedReplayInjectOpenAiCompat,
+    recordMountStore,
   ]);
 
   // UI logging

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/message-view.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/message-view.tsx
@@ -22,6 +22,7 @@ import { getAssistantAvatarDescriptor } from "@/components/chat-v2/shared/assist
 import { CopilotMessageHeader } from "./copilot-message-header";
 
 type ClaudeFooterMode = "none" | "animated" | "static";
+type MessagePart = UIMessage["parts"][number];
 
 interface MessageViewProps {
   message: UIMessage;
@@ -69,6 +70,24 @@ function shouldRerenderMessage(prevMessage: UIMessage, nextMessage: UIMessage) {
       prevMessage.role === nextMessage.role &&
       prevMessage.parts === nextMessage.parts)
   );
+}
+
+function getPartKey(part: MessagePart, stepIndex: number, partIndex: number) {
+  const candidate = part as {
+    type?: string;
+    toolCallId?: unknown;
+    id?: unknown;
+  };
+  if (
+    typeof candidate.toolCallId === "string" &&
+    candidate.toolCallId.length > 0
+  ) {
+    return `tool-${candidate.toolCallId}`;
+  }
+  if (typeof candidate.id === "string" && candidate.id.length > 0) {
+    return `${candidate.type ?? "part"}-${candidate.id}`;
+  }
+  return `${stepIndex}-${partIndex}`;
 }
 
 function areMessageViewPropsEqual(
@@ -275,7 +294,7 @@ function MessageViewImpl({
             <div key={sIdx} className="space-y-3">
               {stepParts.map((part, pIdx) => (
                 <PartSwitch
-                  key={`${sIdx}-${pIdx}`}
+                  key={getPartKey(part, sIdx, pIdx)}
                   part={part}
                   role={role}
                   onSendFollowUp={onSendFollowUp}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
@@ -740,6 +740,7 @@ export function ToolPart({
                           ...widgetDebugInfo.csp,
                           applied: widgetDebugInfo.applied,
                           lifecycle: widgetDebugInfo.lifecycle,
+                          mounts: widgetDebugInfo.mounts,
                           hostInfo: widgetDebugInfo.hostInfo ?? null,
                         }
                       : undefined

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/sandbox-debug-panel.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/sandbox-debug-panel.tsx
@@ -46,6 +46,7 @@ import type { CspMode } from "@/stores/ui-playground-store";
 import type {
   CspViolation,
   WidgetLifecycleEvent,
+  WidgetMount,
   WidgetSandboxApplied,
 } from "@/stores/widget-debug-store";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
@@ -78,6 +79,7 @@ interface SandboxDebugPanelProps {
     } | null;
     applied?: WidgetSandboxApplied;
     lifecycle?: WidgetLifecycleEvent[];
+    mounts?: WidgetMount[];
     hostInfo?: { name: string; version: string } | null;
   };
   protocol?: "openai-apps" | "mcp-apps";
@@ -415,6 +417,7 @@ export function SandboxDebugPanel({
   const resolvedThemeMode = chatboxHostTheme ?? themeMode;
   const violations = sandboxInfo?.violations ?? [];
   const lifecycle = sandboxInfo?.lifecycle ?? [];
+  const mounts = sandboxInfo?.mounts ?? [];
   const applied = sandboxInfo?.applied;
   const hasViolations = violations.length > 0;
   const [copied, setCopied] = useState(false);
@@ -487,6 +490,45 @@ export function SandboxDebugPanel({
     <div className="space-y-4 text-xs">
       {/* Lifecycle progress track */}
       <LifecycleStrip events={lifecycle} />
+
+      {/* Mount log — hidden in the healthy case (exactly one mount).
+          When the iframe re-mounted, list each entry with the segments of
+          the fetch-source key that changed, so devs can spot self-induced
+          reloads (e.g. a history snapshot landing flipping
+          `cachedWidgetHtmlUrl` / `liveFetchPreferred`). */}
+      {mounts.length > 1 && (
+        <details className="group" open>
+          <summary className="flex items-center gap-1.5 cursor-pointer list-none text-amber-600 dark:text-amber-400">
+            <ChevronRight className="h-3.5 w-3.5 transition-transform group-open:rotate-90" />
+            <span className="font-medium">Mounts</span>
+            <Badge
+              variant="outline"
+              className="text-[9px] px-1 py-0 h-4 ml-0.5"
+              title="Iframe was torn down and rebuilt"
+            >
+              {mounts.length}
+            </Badge>
+          </summary>
+          <div className="mt-2 pl-5 space-y-1">
+            {mounts.map((m) => (
+              <div
+                key={m.index}
+                className="flex items-baseline gap-2 text-[10px]"
+              >
+                <span className="text-muted-foreground tabular-nums w-4 shrink-0">
+                  #{m.index}
+                </span>
+                <span className="font-mono text-foreground truncate">
+                  {m.reason}
+                </span>
+                <span className="ml-auto text-muted-foreground/60 tabular-nums shrink-0">
+                  {new Date(m.at).toLocaleTimeString()}
+                </span>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
 
       {/* Suggested Fix */}
       {hasViolations && suggestedFixes.length > 0 && (

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -148,10 +148,35 @@ import { usePlaygroundChatHistoryBridgeStore } from "@/components/playground/pla
 import { useFeatureFlagEnabled } from "posthog-js/react";
 import { WebApiError } from "@/lib/apis/web/base";
 import { useDirectChatSessionSubscription } from "@/hooks/use-direct-chat-session-subscription";
+import { WidgetSurfaceProvider } from "@/contexts/widget-surface-context";
 
 // On post-stream reconcile, the Convex-side detail row may not yet reflect the
 // version bump from the turn that just finished. Retry a couple of times.
 const RESUMED_THREAD_REFRESH_RETRIES = 2;
+
+function buildHistoryContentSignature(
+  session: ChatHistoryDetailSession,
+  widgetSnapshots?: ChatHistoryWidgetSnapshot[],
+) {
+  const snapshotSignature = (widgetSnapshots ?? [])
+    .map((snapshot) =>
+      [
+        snapshot._id,
+        snapshot.toolCallId,
+        snapshot.resourceUri ?? "",
+        snapshot.widgetHtmlUrl ?? "",
+        snapshot.toolOutputUrl ?? "",
+      ].join(":"),
+    )
+    .sort()
+    .join("|");
+  return [
+    session._id,
+    session.chatSessionId,
+    session.messagesBlobUrl ?? "",
+    snapshotSignature,
+  ].join("::");
+}
 
 /** Custom device config - dimensions come from store */
 const CUSTOM_DEVICE_BASE = {
@@ -315,6 +340,7 @@ export function PlaygroundMain({
   const historySelectionRequestIdRef = useRef(0);
   const activeHistorySessionIdRef = useRef<string | null>(null);
   const reactiveHistoryLoadRequestIdRef = useRef(0);
+  const appliedHistoryContentSignatureRef = useRef<string | null>(null);
   const resumedThreadSendBaselineRef = useRef<{
     sessionId: string;
     version: number;
@@ -323,6 +349,9 @@ export function PlaygroundMain({
   useEffect(() => {
     activeHistorySessionIdRef.current = activeHistorySessionId;
     reactiveHistoryLoadRequestIdRef.current += 1;
+    if (!activeHistorySessionId) {
+      appliedHistoryContentSignatureRef.current = null;
+    }
   }, [activeHistorySessionId]);
 
   const [mcpPromptResults, setMcpPromptResults] = useState<MCPPromptResult[]>(
@@ -1139,6 +1168,8 @@ export function PlaygroundMain({
       }
       setActiveHistorySessionId(detail._id);
       setPendingDirectVisibility(detail.directVisibility);
+      appliedHistoryContentSignatureRef.current =
+        buildHistoryContentSignature(detail, widgetSnapshots);
       syncResumedVersion(detail.version);
       void markHistorySessionRead(detail._id);
     },
@@ -1188,6 +1219,10 @@ export function PlaygroundMain({
       return;
     }
 
+    if (loadingHistorySessionId === activeHistorySessionId) {
+      return;
+    }
+
     if (reactiveHistorySession === undefined) {
       return;
     }
@@ -1207,6 +1242,16 @@ export function PlaygroundMain({
       resumedVersion !== null &&
       reactiveHistorySession.version <= resumedVersion
     ) {
+      return;
+    }
+
+    const contentSignature = buildHistoryContentSignature(
+      reactiveHistorySession,
+      reactiveHistoryWidgetSnapshots,
+    );
+    if (appliedHistoryContentSignatureRef.current === contentSignature) {
+      setPendingDirectVisibility(reactiveHistorySession.directVisibility);
+      syncResumedVersion(reactiveHistorySession.version);
       return;
     }
 
@@ -1235,6 +1280,7 @@ export function PlaygroundMain({
     activeHistorySessionId,
     detachHistorySession,
     isStreaming,
+    loadingHistorySessionId,
     loadHistorySession,
     reactiveHistorySession,
     reactiveHistoryWidgetSnapshots,
@@ -2481,7 +2527,16 @@ export function PlaygroundMain({
 
   // Device frame container - display mode is passed to widgets via Thread
   return (
-    <>
+    // Surface signal for `MCPAppsRenderer` / `chatgpt-app-renderer`: the
+    // `cspMode` they compute on first render must already see
+    // "playground" before any descendant subscribes. The legacy
+    // `isPlaygroundActive` store flag was set in a passive `useEffect`,
+    // which committed on render #2 and flipped `cspMode` mid-session —
+    // tearing down the iframe and dropping View state (the
+    // "draw a cat, then it vanishes" bug). Context propagates
+    // synchronously on the first render, so the fetch-source key is
+    // stable from mount #1.
+    <WidgetSurfaceProvider value="playground">
     <div
       className={cn(
         "relative h-full flex flex-col overflow-hidden",
@@ -2878,6 +2933,6 @@ export function PlaygroundMain({
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
-    </>
+    </WidgetSurfaceProvider>
   );
 }

--- a/mcpjam-inspector/client/src/contexts/widget-surface-context.ts
+++ b/mcpjam-inspector/client/src/contexts/widget-surface-context.ts
@@ -1,0 +1,25 @@
+import { createContext, useContext } from "react";
+
+/**
+ * Identifies which inspector surface is rendering the current widget
+ * subtree. Used by the MCP-Apps / ChatGPT-Apps renderers to resolve
+ * `cspMode` synchronously on the first render — replacing a prior
+ * global-store flag (`isPlaygroundActive`) that was set in a passive
+ * `useEffect` and caused the iframe's fetch-source key to flip on
+ * commit #2, tearing down a healthy iframe and dropping View state
+ * (the "draw a cat, then it vanishes" bug).
+ *
+ * `"chat"` is the default. Surfaces that aren't Playground (Connect →
+ * Chat, eval suite editors, replay) inherit it and keep the existing
+ * strict `"widget-declared"` CSP behavior, unchanged. Chatbox surface
+ * is a separate dimension and stays on `useIsChatboxSurface()`.
+ */
+export type WidgetSurface = "playground" | "chat";
+
+const WidgetSurfaceContext = createContext<WidgetSurface>("chat");
+
+export const WidgetSurfaceProvider = WidgetSurfaceContext.Provider;
+
+export function useWidgetSurface(): WidgetSurface {
+  return useContext(WidgetSurfaceContext);
+}

--- a/mcpjam-inspector/client/src/lib/__tests__/transcript-to-ui-messages.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/transcript-to-ui-messages.test.ts
@@ -266,6 +266,30 @@ describe("transcriptToUIMessages", () => {
     expect(typeof messages[0].id).toBe("string");
   });
 
+  it("uses stable fallback IDs across repeated hydration", () => {
+    const transcript = [
+      { role: "user", content: "draw a dog" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolName: "create_view",
+            args: { prompt: "draw a dog" },
+          },
+        ],
+      },
+    ];
+
+    const first = transcriptToUIMessages(transcript);
+    const second = transcriptToUIMessages(transcript);
+
+    expect(first.map((message) => message.id)).toEqual(
+      second.map((message) => message.id),
+    );
+    expect(first[1].parts[0]).toMatchObject(second[1].parts[0]);
+  });
+
   it("preserves existing IDs", () => {
     const transcript = [{ id: "msg-123", role: "user", content: "Hi" }];
     const messages = transcriptToUIMessages(transcript);

--- a/mcpjam-inspector/client/src/lib/transcript-to-ui-messages.ts
+++ b/mcpjam-inspector/client/src/lib/transcript-to-ui-messages.ts
@@ -1,5 +1,4 @@
 import { type UIMessage } from "@ai-sdk/react";
-import { generateId } from "ai";
 
 /**
  * Convert a persisted transcript blob (array of message objects from the
@@ -23,6 +22,53 @@ interface TranscriptMessage {
   role?: string;
   content?: string | TranscriptPart[];
   [key: string]: unknown;
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value) ?? String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`;
+  }
+  const obj = value as Record<string, unknown>;
+  return `{${Object.keys(obj)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(obj[key])}`)
+    .join(",")}}`;
+}
+
+function stableHash(value: unknown): string {
+  const input = stableStringify(value);
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function getStableMessageId(msg: TranscriptMessage, index: number): string {
+  if (typeof msg.id === "string" && msg.id.length > 0) {
+    return msg.id;
+  }
+  return `transcript-${index}-${msg.role ?? "unknown"}-${stableHash(
+    msg.content,
+  )}`;
+}
+
+function getStableToolCallId(
+  part: TranscriptPart,
+  messageIndex: number,
+  partIndex: number,
+): string {
+  const explicitId = readToolCallId(part);
+  if (explicitId) return explicitId;
+
+  return `transcript-tool-${messageIndex}-${partIndex}-${stableHash({
+    args: part.args ?? part.input,
+    toolName: part.toolName,
+  })}`;
 }
 
 function readToolCallId(part: TranscriptPart): string | undefined {
@@ -133,7 +179,10 @@ function extractTextContent(content: unknown): string {
     .join("\n");
 }
 
-function convertParts(content: unknown): UIMessage["parts"] {
+function convertParts(
+  content: unknown,
+  messageIndex: number,
+): UIMessage["parts"] {
   if (typeof content === "string") {
     return [{ type: "text", text: content }];
   }
@@ -143,7 +192,7 @@ function convertParts(content: unknown): UIMessage["parts"] {
   }
 
   const parts: UIMessage["parts"] = [];
-  for (const part of content) {
+  for (const [partIndex, part] of content.entries()) {
     if (typeof part === "string") {
       parts.push({ type: "text", text: part });
       continue;
@@ -161,7 +210,7 @@ function convertParts(content: unknown): UIMessage["parts"] {
       // widget metadata like `_meta.ui.resourceUri` and `_serverId`.
       parts.push({
         type: "dynamic-tool",
-        toolCallId: part.toolCallId ?? part.id ?? generateId(),
+        toolCallId: getStableToolCallId(part, messageIndex, partIndex),
         toolName: part.toolName ?? "unknown",
         state: "output-available" as const,
         input: part.args ?? part.input ?? {},
@@ -189,7 +238,7 @@ export function transcriptToUIMessages(transcript: unknown[]): UIMessage[] {
 
   const mergedTranscript = mergeTranscriptToolResults(transcript);
   const messages: UIMessage[] = [];
-  for (const raw of mergedTranscript) {
+  for (const [index, raw] of mergedTranscript.entries()) {
     const msg = raw as TranscriptMessage;
     if (!msg || typeof msg !== "object") continue;
 
@@ -205,9 +254,9 @@ export function transcriptToUIMessages(transcript: unknown[]): UIMessage[] {
           : ("assistant" as const);
 
     messages.push({
-      id: msg.id ?? generateId(),
+      id: getStableMessageId(msg, index),
       role: uiRole,
-      parts: convertParts(msg.content),
+      parts: convertParts(msg.content, index),
     } as UIMessage);
   }
 

--- a/mcpjam-inspector/client/src/stores/widget-debug-store.ts
+++ b/mcpjam-inspector/client/src/stores/widget-debug-store.ts
@@ -93,6 +93,24 @@ export interface WidgetSandboxApplied {
 }
 
 /**
+ * One iframe-load attempt for a widget. The renderer records a mount
+ * each time its fetch-source key flips (toolCallId, resourceUri,
+ * cachedWidgetHtmlUrl, cspMode, liveFetchPreferred) — i.e. every time
+ * the iframe is torn down and re-mounted with new HTML. `reason`
+ * names the segments that changed so devs can spot self-induced
+ * reloads ("rendered then disappeared" usually = an unexpected
+ * second mount triggered by a snapshot landing or a prop flip).
+ */
+export interface WidgetMount {
+  /** 1-based index. */
+  index: number;
+  /** Human reason this mount fired. "initial" for the first one. */
+  reason: string;
+  /** Mount start timestamp. */
+  at: number;
+}
+
+/**
  * One lifecycle event from the widget's load/connect sequence. Recorded
  * by `mcp-apps-renderer` from the same `logWidgetDebug` callsites that
  * already feed the traffic log, so this never invents events — it just
@@ -212,6 +230,12 @@ export interface WidgetDebugInfo {
    * to a single entry whose timestamp/message reflect the latest.
    */
   lifecycle: WidgetLifecycleEvent[];
+  /**
+   * Iframe re-mount log. Each entry = one new fetch-source key. A
+   * healthy widget has exactly one entry; more than one signals the
+   * iframe was torn down and rebuilt mid-session.
+   */
+  mounts: WidgetMount[];
   /** Model context set by the widget (SEP-1865 ui/update-model-context) */
   modelContext?: {
     content?: unknown[];
@@ -313,6 +337,13 @@ interface WidgetDebugStore {
     toolCallId: string,
     event: WidgetLifecycleEvent,
   ) => void;
+
+  /**
+   * Append one mount entry. Create-if-missing for the same reason as
+   * `appendLifecycle` — the renderer's first mount is recorded before
+   * `setWidgetDebugInfo`'s init effect settles.
+   */
+  recordMount: (toolCallId: string, reason: string) => void;
 }
 
 export const useWidgetDebugStore = create<WidgetDebugStore>((set, get) => ({
@@ -346,6 +377,7 @@ export const useWidgetDebugStore = create<WidgetDebugStore>((set, get) => ({
         hostProfileId: existing?.hostProfileId,
         hostInfo: existing?.hostInfo,
         lifecycle: existing?.lifecycle ?? [],
+        mounts: existing?.mounts ?? [],
         widgetHtml: existing?.widgetHtml, // Preserve cached HTML for save view feature
         // Preserve the cached compat-runtime flag across debug-info
         // merges so the save path keeps seeing the value the renderer
@@ -504,6 +536,7 @@ export const useWidgetDebugStore = create<WidgetDebugStore>((set, get) => ({
         hostProfileId: existing?.hostProfileId,
         hostInfo: existing?.hostInfo,
         lifecycle: existing?.lifecycle ?? [],
+        mounts: existing?.mounts ?? [],
         modelContext: existing?.modelContext,
         widgetHtml: html,
         injectedOpenAiCompat:
@@ -535,6 +568,7 @@ export const useWidgetDebugStore = create<WidgetDebugStore>((set, get) => ({
         hostProfileId: hostProfileId ?? existing?.hostProfileId,
         hostInfo: hostInfo !== undefined ? hostInfo : existing?.hostInfo,
         lifecycle: existing?.lifecycle ?? [],
+        mounts: existing?.mounts ?? [],
         modelContext: existing?.modelContext,
         widgetHtml: existing?.widgetHtml,
         updatedAt: Date.now(),
@@ -573,6 +607,37 @@ export const useWidgetDebugStore = create<WidgetDebugStore>((set, get) => ({
         hostProfileId: existing?.hostProfileId,
         hostInfo: existing?.hostInfo,
         lifecycle: nextLifecycle,
+        mounts: existing?.mounts ?? [],
+        modelContext: existing?.modelContext,
+        widgetHtml: existing?.widgetHtml,
+        updatedAt: Date.now(),
+      });
+      return { widgets };
+    });
+  },
+
+  recordMount: (toolCallId, reason) => {
+    set((state) => {
+      const widgets = new Map(state.widgets);
+      const existing = widgets.get(toolCallId);
+      const existingMounts = existing?.mounts ?? [];
+      const nextMounts: WidgetMount[] = [
+        ...existingMounts,
+        { index: existingMounts.length + 1, reason, at: Date.now() },
+      ];
+      widgets.set(toolCallId, {
+        toolCallId,
+        toolName: existing?.toolName ?? "unknown",
+        protocol: existing?.protocol ?? "mcp-apps",
+        widgetState: existing?.widgetState ?? null,
+        globals: existing?.globals ?? { theme: "dark", displayMode: "inline" },
+        prefersBorder: existing?.prefersBorder,
+        csp: existing?.csp,
+        applied: existing?.applied,
+        hostProfileId: existing?.hostProfileId,
+        hostInfo: existing?.hostInfo,
+        lifecycle: existing?.lifecycle ?? [],
+        mounts: nextMounts,
         modelContext: existing?.modelContext,
         widgetHtml: existing?.widgetHtml,
         updatedAt: Date.now(),


### PR DESCRIPTION
## Summary

Fixes the *"draw a cat, then it vanishes"* widget iframe re-mount bug. The widget renders correctly, then its iframe is torn down and rebuilt mid-session, wiping View state. Four coordinated causes, all in the iframe's fetch-source key path:

- **cspMode race.** `cspMode` was derived from `isPlaygroundActive` in the playground store, which is set in a passive `useEffect`. First render saw `false` → `cspMode = "widget-declared"` → live fetch with that mode; the effect then committed → flag flipped → `cspMode` flipped → fetch-source key changed → iframe remounted. Fix: a new `WidgetSurfaceContext` (`"chat"` default, `"playground"` provided by `PlaygroundMain`) propagates synchronously on the first render. Both `MCPAppsRenderer` and `ChatGPTAppRenderer` now read `cspMode` from context.
- **Unstable React keys in `MessageView`.** Parts were keyed by `${stepIdx}-${partIdx}`, which churned when message structure shifted. Now keyed by `toolCallId` / `id` when available, falling back to the index pair.
- **Random ids in transcript hydration.** `transcript-to-ui-messages` minted ids via `generateId()` on every call, so reloaded sessions produced new `toolCallId`s → new renderer keys → forced remounts. Derive stable ids from a content hash (FNV-1a over canonicalized JSON).
- **Reactive history re-apply.** `PlaygroundMain` re-applied a Convex history session even when content was unchanged. Track an applied-content signature (session + blob url + snapshot ids/uris) and skip the reload when it matches; also bail out while the same session is mid-load.

### Observability
Adds a mount log to the widget debug store. `MCPAppsRenderer` records one entry per real fetch-source key change with the segments that flipped (e.g. `cachedWidgetHtmlUrl, liveFetchPreferred`). The Sandbox debug panel surfaces it only when `mounts.length > 1` — healthy widgets stay clean; future re-mount regressions become visible.

## Test plan

- [x] Unit: first-render `cspMode` derives from `WidgetSurfaceProvider`, not `isPlaygroundActive` — only one live fetch, already carrying playground cspMode.
- [x] Unit: outside the playground surface, `cspMode` falls back to `"widget-declared"` even when the store flag leaks `true`.
- [x] Unit: `transcriptToUIMessages` produces identical ids across repeated hydration of the same transcript.
- [ ] Manual: `/create_view` widget in Playground — draw, confirm no remount in the Sandbox debug panel.
- [ ] Manual: reload a history session containing a widget; iframe should not remount on reactive snapshot landing.
- [ ] Manual: same widget in Connect → Chat surface; cspMode stays `widget-declared`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches widget rendering CSP selection, transcript hydration IDs, and reactive history application logic; regressions could cause widget iframes to remount, load with the wrong CSP mode, or fail to restore history correctly.
> 
> **Overview**
> Fixes unexpected widget iframe re-mounts by making `cspMode` resolve *synchronously on first render* via a new `WidgetSurfaceContext` (provided by `PlaygroundMain`) instead of the delayed `isPlaygroundActive` store flag, and wiring both `MCPAppsRenderer` and `ChatGPTAppRenderer` to use it.
> 
> Stabilizes React identity across reloads by generating deterministic message/tool-call IDs in `transcriptToUIMessages` (content-hash based) and using stable `MessageView` part keys (preferring `toolCallId`/`id`). Also reduces unnecessary Playground history re-application by tracking an applied content signature and skipping no-op reloads.
> 
> Adds observability for future regressions by recording iframe mount reasons in `widget-debug-store` and surfacing them in the Sandbox debug panel; includes new unit tests pinning the first-render `cspMode` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cacd53881a20bb4f8e36ba3cc8e419700eeb5fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->