### PR TITLE
fix(servers): reset auto-connect attempts on project toggle

### DIFF
--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -72,7 +72,10 @@ import type {
   ProjectServerConfigDto,
   ProjectServerConfigInput,
 } from "@/lib/project-server-config";
-import { useAutoConnectProjectServers } from "@/hooks/useAutoConnectProjectServers";
+import {
+  resetAutoConnectAttempts,
+  useAutoConnectProjectServers,
+} from "@/hooks/useAutoConnectProjectServers";
 import { useHost } from "@/hooks/useClients";
 import { usePreviewedHostId } from "@/hooks/use-previewed-client-id";
 import { useProjectServers as useViewProjectServers } from "@/hooks/useViews";
@@ -656,6 +659,10 @@ export function ServersTab({
     async (next: boolean) => {
       if (!sharedProjectIdForHostScope) return;
       setIsTogglingAutoConnect(true);
+      // Treat an explicit project toggle like a fresh host transition so the
+      // current host re-runs reconciliation instead of reusing stale attempts.
+      resetAutoConnectAttempts(activeProjectId);
+      resetAutoConnectAttempts(sharedProjectIdForHostScope);
       try {
         if (next) {
           // Preserve overrides for servers that remain in the catalog —
@@ -691,6 +698,7 @@ export function ServersTab({
       }
     },
     [
+      activeProjectId,
       sharedProjectIdForHostScope,
       catalogServerIds,
       projectServerConfigDto,

--- a/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
@@ -200,6 +200,44 @@ describe("useAutoConnectProjectServers", () => {
     expect(ensureServersReady).toHaveBeenCalledTimes(1);
   });
 
+  it("re-attempts after the project auto-connect toggle resets attempts", async () => {
+    const ensureServersReady = vi.fn().mockResolvedValue({
+      readyServerNames: ["alpha"],
+      failedServerNames: [],
+      missingServerNames: [],
+      reauthServerNames: [],
+    });
+    const appState = makeAppState(["alpha"]);
+
+    const { rerender } = renderHook(
+      ({ requiredServerNames }: { requiredServerNames: string[] }) =>
+        useAutoConnectProjectServers({
+          projectId: "proj-toggle",
+          hostScopeKey: "host-a",
+          requiredServerNames,
+        }),
+      {
+        initialProps: { requiredServerNames: ["alpha"] },
+        wrapper: ({ children }) =>
+          wrapper({ children, ensureServersReady, appState }),
+      },
+    );
+
+    await flushMicrotasks();
+    expect(ensureServersReady).toHaveBeenCalledTimes(1);
+
+    rerender({ requiredServerNames: [] });
+    await flushMicrotasks();
+    expect(ensureServersReady).toHaveBeenCalledTimes(1);
+
+    resetAutoConnectAttempts("proj-toggle");
+    rerender({ requiredServerNames: ["alpha"] });
+    await flushMicrotasks();
+
+    expect(ensureServersReady).toHaveBeenCalledTimes(2);
+    expect(ensureServersReady).toHaveBeenLastCalledWith(["alpha"]);
+  });
+
   it("disconnects EVERY connected server on host switch (incl. ones the new host still requires)", async () => {
     const ensureServersReady = vi.fn().mockResolvedValue({
       readyServerNames: [],


### PR DESCRIPTION
## Summary
- Reset auto-connect attempts for both the active project and host scope when the user toggles project auto-connect, so the current host re-runs reconciliation instead of reusing stale attempt state.
- Add a regression test covering re-attempt after `resetAutoConnectAttempts`.

## Test plan
- [ ] `useAutoConnectProjectServers` unit tests pass
- [ ] Manually toggle project auto-connect off/on and confirm servers reconnect on the active host

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-connect reconciliation behavior by clearing in-memory attempt dedupe when the project-wide auto-connect toggle is flipped, which could cause additional reconnect attempts if mis-scoped. Impact is limited to client-side connection orchestration and is covered by a new unit test.
> 
> **Overview**
> When the user toggles the project-wide **Auto-connect** switch in `ServersTab`, the PR now calls `resetAutoConnectAttempts` for both the local `activeProjectId` and the Convex-synced `sharedProjectIdForHostScope`, forcing the current host to re-run auto-connect reconciliation instead of reusing prior attempt state.
> 
> Adds a regression unit test for `useAutoConnectProjectServers` verifying that after `resetAutoConnectAttempts(projectId)`, the hook will call `ensureServersReady` again for the same required server set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 111d7828d2a8b8a63eb3a9dce19c55c8a5460fdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->