### PR TITLE
feat(playground): PostHog instrumentation for launch

### DIFF
--- a/mcpjam-inspector/client/src/components/clients/MultiHostPicker.tsx
+++ b/mcpjam-inspector/client/src/components/clients/MultiHostPicker.tsx
@@ -231,17 +231,22 @@ export function MultiHostPicker({
     // the only selected client (the lead) is a no-op.
     if (nextSelectedHostIds.length === 0) return;
 
-    const nextEnabled = nextSelectedHostIds.length > 1;
+    const prevCount = effectiveSelectedHostIds.length;
+    const nextCount = nextSelectedHostIds.length;
+    const nextEnabled = nextCount > 1;
     captureCompare(
       isSelected
         ? "playground_compare_host_removed"
         : "playground_compare_host_added",
       {
-        selected_count: nextSelectedHostIds.length,
+        selected_count: nextCount,
         compare_active: nextEnabled,
-        entered_compare:
-          !isSelected && !multiHostEnabled && nextEnabled,
-        exited_compare: isSelected && multiHostEnabled && !nextEnabled,
+        // Derive transitions from the host count crossing 1 ↔ 2 rather than
+        // the persisted `multiHostEnabled` flag, which can drift from the
+        // count (e.g. if the wrapper toggles the flag without changing the
+        // selection). Bugbot 2026-05-20.
+        entered_compare: !isSelected && prevCount <= 1 && nextEnabled,
+        exited_compare: isSelected && prevCount > 1 && !nextEnabled,
       },
     );
 

--- a/mcpjam-inspector/client/src/components/clients/MultiHostPicker.tsx
+++ b/mcpjam-inspector/client/src/components/clients/MultiHostPicker.tsx
@@ -1,5 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Check, Columns2, X } from "lucide-react";
+import { usePostHog } from "posthog-js/react";
+import { standardEventProps } from "@/lib/PosthogUtils";
 import { Button } from "@mcpjam/design-system/button";
 import {
   Popover,
@@ -206,6 +208,17 @@ export function MultiHostPicker({
   // client enters compare; removing back to one client exits.
   // `multiHostEnabled` is derived from `nextIds.length > 1` instead
   // of being driven by a separate toggle.
+  const posthog = usePostHog();
+  const captureCompare = useCallback(
+    (event: string, props?: Record<string, unknown>) => {
+      posthog?.capture(event, {
+        ...standardEventProps("playground_multi_host_picker"),
+        ...props,
+      });
+    },
+    [posthog],
+  );
+
   const handleHostRowToggle = (hostId: string) => {
     requestPopoverStayOpen();
 
@@ -218,9 +231,23 @@ export function MultiHostPicker({
     // the only selected client (the lead) is a no-op.
     if (nextSelectedHostIds.length === 0) return;
 
+    const nextEnabled = nextSelectedHostIds.length > 1;
+    captureCompare(
+      isSelected
+        ? "playground_compare_host_removed"
+        : "playground_compare_host_added",
+      {
+        selected_count: nextSelectedHostIds.length,
+        compare_active: nextEnabled,
+        entered_compare:
+          !isSelected && !multiHostEnabled && nextEnabled,
+        exited_compare: isSelected && multiHostEnabled && !nextEnabled,
+      },
+    );
+
     requestSelectionChange({
       type: "multi",
-      enabled: nextSelectedHostIds.length > 1,
+      enabled: nextEnabled,
       selectedHostIds: nextSelectedHostIds,
     });
   };
@@ -228,6 +255,9 @@ export function MultiHostPicker({
   const handlePromoteLeadFromChip = (hostId: string) => {
     if (!multiHostEnabled || hostId === leadHostId) return;
     requestPopoverStayOpen();
+    captureCompare("playground_compare_lead_promoted", {
+      selected_count: effectiveSelectedHostIds.length,
+    });
     onPromoteLead(hostId);
   };
 

--- a/mcpjam-inspector/client/src/components/logger-view.tsx
+++ b/mcpjam-inspector/client/src/components/logger-view.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useRef, useState, useMemo } from "react";
+import { useCallback, useEffect, useRef, useState, useMemo } from "react";
+import { usePostHog } from "posthog-js/react";
+import { standardEventProps } from "@/lib/PosthogUtils";
 import {
   ChevronRight,
   AlertCircle,
@@ -359,7 +361,34 @@ export function LoggerView({
     });
   };
 
+  const posthog = usePostHog();
+  const captureLogger = useCallback(
+    (event: string, props?: Record<string, unknown>) => {
+      posthog?.capture(event, {
+        ...standardEventProps("logger_view"),
+        ...props,
+      });
+    },
+    [posthog],
+  );
+
+  // Fire `logger_search_used` once per non-empty search session — i.e. the
+  // first character typed after an empty query — so we measure usage of the
+  // feature without flooding PostHog with one event per keystroke.
+  const searchUsedFiredRef = useRef(false);
+  useEffect(() => {
+    if (searchQuery.trim() === "") {
+      searchUsedFiredRef.current = false;
+      return;
+    }
+    if (!searchUsedFiredRef.current) {
+      searchUsedFiredRef.current = true;
+      captureLogger("logger_search_used");
+    }
+  }, [searchQuery, captureLogger]);
+
   const clearMessages = () => {
+    captureLogger("logger_cleared", { item_count: totalItemCount });
     clearLogs();
     setExpanded(new Set());
   };
@@ -376,6 +405,7 @@ export function LoggerView({
     }));
 
   const copyLogs = async () => {
+    captureLogger("logger_copy_clicked", { item_count: filteredItemCount });
     try {
       await navigator.clipboard.writeText(
         JSON.stringify(serializeLogs(), null, 2),
@@ -387,6 +417,9 @@ export function LoggerView({
   };
 
   const downloadLogs = () => {
+    captureLogger("logger_download_clicked", {
+      item_count: filteredItemCount,
+    });
     const json = JSON.stringify(serializeLogs(), null, 2);
     const blob = new Blob([json], { type: "application/json" });
     const url = URL.createObjectURL(blob);
@@ -500,9 +533,16 @@ export function LoggerView({
                 <DropdownMenuContent align="end">
                   <DropdownMenuRadioGroup
                     value={sourceFilter}
-                    onValueChange={(value) =>
-                      setSourceFilter(value as "all" | TrafficSource)
-                    }
+                    onValueChange={(value) => {
+                      const next = value as "all" | TrafficSource;
+                      if (next !== sourceFilter) {
+                        captureLogger("logger_source_filter_changed", {
+                          from: sourceFilter,
+                          to: next,
+                        });
+                      }
+                      setSourceFilter(next);
+                    }}
                   >
                     <DropdownMenuRadioItem value="all" className="text-xs">
                       All
@@ -561,6 +601,9 @@ export function LoggerView({
                                 value={serverLogLevels[server.id] || "debug"}
                                 onValueChange={(val) => {
                                   const level = val as LoggingLevel;
+                                  captureLogger("logger_log_level_changed", {
+                                    to: level,
+                                  });
                                   setServerLogLevels((prev) => ({
                                     ...prev,
                                     [server.id]: level,
@@ -645,7 +688,10 @@ export function LoggerView({
           <Button
             variant="ghost"
             size="icon"
-            onClick={onClose}
+            onClick={() => {
+              captureLogger("logger_collapsed");
+              onClose();
+            }}
             className="h-7 w-7 flex-shrink-0"
             title="Hide JSON-RPC panel"
           >

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundLeftRail.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundLeftRail.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Hammer, History } from "lucide-react";
-import { useFeatureFlagEnabled } from "posthog-js/react";
+import { useFeatureFlagEnabled, usePostHog } from "posthog-js/react";
+import { standardEventProps } from "@/lib/PosthogUtils";
 import { ChatHistoryRail } from "@/components/chat-v2/history/ChatHistoryRail";
 import { useAppBuilderStateContext } from "@/components/ui-playground/hooks/use-app-builder-state";
 import { PlaygroundLeft } from "@/components/ui-playground/PlaygroundLeft";
@@ -27,6 +28,20 @@ export function PlaygroundLeftRail() {
     }
   }, [sessionsTabEnabled, activeTab]);
 
+  const posthog = usePostHog();
+  const handleTabClick = useCallback(
+    (next: LeftRailTab) => {
+      if (next === activeTab) return;
+      posthog?.capture("playground_left_rail_tab_changed", {
+        ...standardEventProps("playground_left_rail"),
+        from: activeTab,
+        to: next,
+      });
+      setActiveTab(next);
+    },
+    [activeTab, posthog],
+  );
+
   return (
     <div className="flex h-full min-h-0 flex-col bg-background">
       <div className="flex shrink-0 items-center gap-0.5 border-b border-border px-2 py-1">
@@ -34,14 +49,14 @@ export function PlaygroundLeftRail() {
           icon={Hammer}
           label="Tools"
           isActive={activeTab === "tools"}
-          onClick={() => setActiveTab("tools")}
+          onClick={() => handleTabClick("tools")}
         />
         {sessionsTabEnabled ? (
           <TabButton
             icon={History}
             label="Sessions"
             isActive={activeTab === "sessions"}
-            onClick={() => setActiveTab("sessions")}
+            onClick={() => handleTabClick("sessions")}
           />
         ) : null}
       </div>

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
@@ -1,5 +1,7 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useConvexAuth } from "convex/react";
+import { usePostHog } from "posthog-js/react";
+import { standardEventProps } from "@/lib/PosthogUtils";
 import {
   AppBuilderStateProvider,
   useAppBuilderState,
@@ -97,6 +99,19 @@ interface PlaygroundTabProps {
  */
 export function PlaygroundTab(props: PlaygroundTabProps) {
   const themeMode = usePreferencesStore((state) => state.themeMode);
+
+  const posthog = usePostHog();
+  useEffect(() => {
+    posthog?.capture("playground_tab_viewed", {
+      ...standardEventProps("playground_tab"),
+      has_active_project: !!props.activeProjectId,
+      has_shared_project: !!props.sharedProjectId,
+      is_signed_in: !!props.isSignedInWithWorkOs,
+    });
+    // Fire once per mount; deps intentionally limited to posthog so the
+    // event isn't refired when project ids hydrate after auth.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [posthog]);
 
   // Resolve the previewed host once at the tab root so the host-config-
   // derived providers (Active MCP Profile, hostStyle, capabilities override,

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
@@ -101,17 +101,28 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
   const themeMode = usePreferencesStore((state) => state.themeMode);
 
   const posthog = usePostHog();
+  const hasCapturedViewRef = useRef(false);
   useEffect(() => {
-    posthog?.capture("playground_tab_viewed", {
+    // Wait until auth is settled so the boolean flags reflect the user's
+    // real state, not a pre-hydration false. After that, fire exactly once
+    // per mount.
+    if (hasCapturedViewRef.current) return;
+    if (!posthog) return;
+    if (props.isWorkOsAuthLoading) return;
+    hasCapturedViewRef.current = true;
+    posthog.capture("playground_tab_viewed", {
       ...standardEventProps("playground_tab"),
       has_active_project: !!props.activeProjectId,
       has_shared_project: !!props.sharedProjectId,
       is_signed_in: !!props.isSignedInWithWorkOs,
     });
-    // Fire once per mount; deps intentionally limited to posthog so the
-    // event isn't refired when project ids hydrate after auth.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [posthog]);
+  }, [
+    posthog,
+    props.activeProjectId,
+    props.sharedProjectId,
+    props.isSignedInWithWorkOs,
+    props.isWorkOsAuthLoading,
+  ]);
 
   // Resolve the previewed host once at the tab root so the host-config-
   // derived providers (Active MCP Profile, hostStyle, capabilities override,

--- a/mcpjam-inspector/client/src/components/ui-playground/TabHeader.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/TabHeader.tsx
@@ -15,6 +15,8 @@ import {
   MoreHorizontal,
   Check,
 } from "lucide-react";
+import { usePostHog } from "posthog-js/react";
+import { standardEventProps } from "@/lib/PosthogUtils";
 import { Button } from "@mcpjam/design-system/button";
 import {
   DropdownMenu,
@@ -72,9 +74,34 @@ export function TabHeader({
   const wideActionsClass =
     "hidden items-center gap-0.5 @min-[320px]/tab-header:flex";
 
+  const posthog = usePostHog();
+
   const handleRefreshTools = () => {
+    posthog?.capture("playground_tools_refresh_clicked", {
+      ...standardEventProps("playground_tab_header"),
+      tool_count: toolCount,
+    });
     onTabChange("tools");
     onRefresh();
+  };
+
+  const handleRunClick = () => {
+    posthog?.capture("playground_tool_run_clicked", {
+      ...standardEventProps("playground_tab_header"),
+      tool_count: toolCount,
+    });
+    onExecute();
+  };
+
+  const handleTabClick = (tab: "tools" | "saved") => {
+    if (tab !== activeTab) {
+      posthog?.capture("playground_tools_pane_tab_changed", {
+        ...standardEventProps("playground_tab_header"),
+        from: activeTab,
+        to: tab,
+      });
+    }
+    onTabChange(tab);
   };
 
   return (
@@ -98,7 +125,7 @@ export function TabHeader({
             <button
               type="button"
               role="tab"
-              onClick={() => onTabChange("tools")}
+              onClick={() => handleTabClick("tools")}
               className={tabButtonClass(activeTab === "tools")}
             >
               Tools
@@ -109,7 +136,7 @@ export function TabHeader({
             <button
               type="button"
               role="tab"
-              onClick={() => onTabChange("saved")}
+              onClick={() => handleTabClick("saved")}
               className={tabButtonClass(activeTab === "saved")}
             >
               Saved
@@ -127,7 +154,7 @@ export function TabHeader({
               type="button"
               role="tab"
               aria-selected={activeTab === "tools"}
-              onClick={() => onTabChange("tools")}
+              onClick={() => handleTabClick("tools")}
               className={tabButtonClass(activeTab === "tools")}
             >
               Tools
@@ -154,7 +181,7 @@ export function TabHeader({
               <DropdownMenuContent align="start" className="w-56">
                 <DropdownMenuItem
                   className="text-xs"
-                  onSelect={() => onTabChange("saved")}
+                  onSelect={() => handleTabClick("saved")}
                 >
                   <span className="flex w-4 shrink-0 justify-center">
                     {activeTab === "saved" ? (
@@ -216,7 +243,7 @@ export function TabHeader({
             </Button>
           </div>
           <Button
-            onClick={onExecute}
+            onClick={handleRunClick}
             disabled={isExecuting || !canExecute}
             size="sm"
             className="h-8 shrink-0 px-2 text-xs sm:px-3"


### PR DESCRIPTION
## Summary
- Adds 14 PostHog events covering previously-untracked Playground surfaces: tab entry, left rail tab toggle (Tools/Sessions), multi-host Compare picker, tools-pane Run/Refresh, and the logger panel (search/filter/log level/copy/download/clear/collapse).
- Host context toolbar was already instrumented via `ClientContextHeader` (`host_toolbar_*`); tool execution and chat send continue to fire existing `app_builder_*` events.
- Logger search fires once per non-empty search session (guarded by a ref) to avoid one event per keystroke.

## Events added
- `playground_tab_viewed` — `PlaygroundTab` mount
- `playground_left_rail_tab_changed` — Tools ↔ Sessions
- `playground_compare_host_added` / `_removed` / `_lead_promoted` — `MultiHostPicker` (with `entered_compare` / `exited_compare` flags)
- `playground_tools_pane_tab_changed`, `playground_tool_run_clicked`, `playground_tools_refresh_clicked` — `TabHeader`
- `logger_search_used`, `logger_source_filter_changed`, `logger_log_level_changed`, `logger_copy_clicked`, `logger_download_clicked`, `logger_cleared`, `logger_collapsed` — `logger-view`

## Dashboard
[Playground Launch (2026-05-20)](https://us.posthog.com/project/212744/dashboard/1609263) — 10 tiles wired to these events plus existing `app_builder_send_message` and `trace_view_mode_changed`.

## Test plan
- [ ] Open Playground → confirm `playground_tab_viewed` in PostHog live events
- [ ] Toggle Tools/Sessions → `playground_left_rail_tab_changed` with `from`/`to`
- [ ] Add a second host via Compare → `playground_compare_host_added` with `entered_compare: true`; remove → `_removed`; click non-lead chip → `_lead_promoted`
- [ ] Click Refresh / Run in tools pane → `playground_tools_refresh_clicked` / `playground_tool_run_clicked`
- [ ] In logger: type in search (one event), change source filter, change log level, copy, download, clear, collapse
- [ ] Confirm dashboard tiles begin populating

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to client-side analytics (`posthog.capture`) on existing UI interactions, with minimal impact on control flow beyond adding event calls and a small search-session guard ref.
> 
> **Overview**
> Adds PostHog instrumentation across Playground and Logger surfaces using `standardEventProps`, including events for Playground tab view, left-rail tab switches, multi-host Compare add/remove/promote actions (with derived enter/exit compare flags), tools-pane tab changes plus Run/Refresh clicks, and logger actions (search-used once per non-empty session, source filter changes, log level changes, copy/download/clear, and panel collapse).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9365facaa2ab0f3fc896f542ca3422700dfee48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->