### PR TITLE
[codex] Gate MCP primitive loading on connection status

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -644,7 +644,8 @@ export function RegistryRoute() {
 }
 
 export function ToolsRoute() {
-  const { selectedMCPConfig, appState, activeHost } = useAppRouteContext();
+  const { selectedMCPConfig, selectedServerEntry, appState, activeHost } =
+    useAppRouteContext();
   const prefHostStyle = usePreferencesStore((state) => state.hostStyle);
   const hostStyle = activeHost?.hostStyle ?? prefHostStyle;
   return (
@@ -656,6 +657,9 @@ export function ToolsRoute() {
         <ToolsTab
           serverConfig={selectedMCPConfig}
           serverName={appState.selectedServer}
+          serverConnectionStatus={
+            selectedServerEntry?.connectionStatus ?? "disconnected"
+          }
         />
       </div>
     </ActiveHostCapsResolverScope>
@@ -766,24 +770,32 @@ export function ChatboxesRoute() {
 }
 
 export function ResourcesRoute() {
-  const { selectedMCPConfig, appState } = useAppRouteContext();
+  const { selectedMCPConfig, selectedServerEntry, appState } =
+    useAppRouteContext();
   return (
     <div className="h-full overflow-hidden">
       <ResourcesTab
         serverConfig={selectedMCPConfig}
         serverName={appState.selectedServer}
+        serverConnectionStatus={
+          selectedServerEntry?.connectionStatus ?? "disconnected"
+        }
       />
     </div>
   );
 }
 
 export function PromptsRoute() {
-  const { selectedMCPConfig, appState } = useAppRouteContext();
+  const { selectedMCPConfig, selectedServerEntry, appState } =
+    useAppRouteContext();
   return (
     <div className="h-full overflow-hidden">
       <PromptsTab
         serverConfig={selectedMCPConfig}
         serverName={appState.selectedServer}
+        serverConnectionStatus={
+          selectedServerEntry?.connectionStatus ?? "disconnected"
+        }
       />
     </div>
   );

--- a/mcpjam-inspector/client/src/components/PromptsTab.tsx
+++ b/mcpjam-inspector/client/src/components/PromptsTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "@mcpjam/design-system/button";
 import { Input } from "@mcpjam/design-system/input";
 import { Textarea } from "@mcpjam/design-system/textarea";
@@ -28,10 +28,12 @@ import {
   listPrompts as listPromptsApi,
 } from "@/lib/apis/mcp-prompts-api";
 import { SelectedToolHeader } from "./ui-playground/SelectedToolHeader";
+import type { ConnectionStatus } from "@/state/app-types";
 
 interface PromptsTabProps {
   serverConfig?: MCPServerConfig;
   serverName?: string;
+  serverConnectionStatus?: ConnectionStatus;
 }
 
 type PromptArgument = NonNullable<MCPPrompt["arguments"]>[number];
@@ -47,7 +49,11 @@ interface FormField {
   maximum?: number;
 }
 
-export function PromptsTab({ serverConfig, serverName }: PromptsTabProps) {
+export function PromptsTab({
+  serverConfig,
+  serverName,
+  serverConnectionStatus,
+}: PromptsTabProps) {
   const [prompts, setPrompts] = useState<MCPPrompt[]>([]);
   const [selectedPrompt, setSelectedPrompt] = useState<string>("");
   const [formFields, setFormFields] = useState<FormField[]>([]);
@@ -56,17 +62,43 @@ export function PromptsTab({ serverConfig, serverName }: PromptsTabProps) {
   const [fetchingPrompts, setFetchingPrompts] = useState(false);
   const [error, setError] = useState<string>("");
   const [isSidebarVisible, setIsSidebarVisible] = useState(true);
+  const promptsFetchVersionRef = useRef(0);
+  const promptGetVersionRef = useRef(0);
+  const isServerConnected =
+    serverConnectionStatus === undefined ||
+    serverConnectionStatus === "connected";
 
   const selectedPromptData = useMemo(() => {
     return prompts.find((prompt) => prompt.name === selectedPrompt) ?? null;
   }, [prompts, selectedPrompt]);
   const promptDisplay = extractDisplayFromValue(promptContent);
 
-  useEffect(() => {
-    if (serverConfig && serverName) {
-      fetchPrompts();
+  const resetLoadedPromptState = (
+    invalidateRequests = true,
+    stopLoading = true,
+  ) => {
+    if (invalidateRequests) {
+      promptsFetchVersionRef.current += 1;
+      promptGetVersionRef.current += 1;
     }
-  }, [serverConfig, serverName]);
+    if (stopLoading) {
+      setLoading(false);
+      setFetchingPrompts(false);
+    }
+    setPrompts([]);
+    setSelectedPrompt("");
+    setFormFields([]);
+    setPromptContent(null);
+    setError("");
+  };
+
+  useEffect(() => {
+    if (!serverConfig || !serverName || !isServerConnected) {
+      resetLoadedPromptState();
+      return;
+    }
+    fetchPrompts();
+  }, [serverConfig, serverName, isServerConnected]);
 
   useEffect(() => {
     if (selectedPromptData?.arguments) {
@@ -78,12 +110,18 @@ export function PromptsTab({ serverConfig, serverName }: PromptsTabProps) {
 
   const fetchPrompts = async () => {
     if (!serverName) return;
+    if (!isServerConnected) {
+      resetLoadedPromptState();
+      return;
+    }
 
     setFetchingPrompts(true);
     setError("");
+    const fetchVersion = ++promptsFetchVersionRef.current;
 
     try {
       const serverPrompts = await listPromptsApi(serverName);
+      if (fetchVersion !== promptsFetchVersionRef.current) return;
       setPrompts(serverPrompts);
 
       // Clear selection if the selected prompt no longer exists
@@ -95,11 +133,14 @@ export function PromptsTab({ serverConfig, serverName }: PromptsTabProps) {
         setPromptContent(null);
       }
     } catch (err) {
+      if (fetchVersion !== promptsFetchVersionRef.current) return;
       const message =
         err instanceof Error ? err.message : `Could not fetch prompts: ${err}`;
       setError(message);
     } finally {
-      setFetchingPrompts(false);
+      if (fetchVersion === promptsFetchVersionRef.current) {
+        setFetchingPrompts(false);
+      }
     }
   };
 
@@ -162,9 +203,14 @@ export function PromptsTab({ serverConfig, serverName }: PromptsTabProps) {
     async (promptName?: string, params?: Record<string, string>) => {
       const targetPrompt = promptName ?? selectedPrompt;
       if (!targetPrompt || !serverName) return;
+      if (!isServerConnected) {
+        setError("Connect this server before running prompts.");
+        return;
+      }
 
       setLoading(true);
       setError("");
+      const getVersion = ++promptGetVersionRef.current;
 
       try {
         const resolvedParams = params ?? buildParameters();
@@ -173,23 +219,27 @@ export function PromptsTab({ serverConfig, serverName }: PromptsTabProps) {
           targetPrompt,
           resolvedParams,
         );
+        if (getVersion !== promptGetVersionRef.current) return;
         setPromptContent(data.content);
       } catch (err) {
+        if (getVersion !== promptGetVersionRef.current) return;
         const message =
           err instanceof Error ? err.message : `Error getting prompt: ${err}`;
         setError(message);
       } finally {
-        setLoading(false);
+        if (getVersion === promptGetVersionRef.current) {
+          setLoading(false);
+        }
       }
     },
-    [selectedPrompt, serverName, buildParameters],
+    [selectedPrompt, serverName, isServerConnected, buildParameters],
   );
 
   const promptNames = prompts.map((prompt) => prompt.name);
 
   // Handle Enter key in input fields
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && !loading) {
+    if (e.key === "Enter" && isServerConnected && !loading) {
       e.preventDefault();
       getPrompt();
     }
@@ -198,7 +248,13 @@ export function PromptsTab({ serverConfig, serverName }: PromptsTabProps) {
   // Handle Enter key to get prompt globally
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Enter" && !e.shiftKey && selectedPrompt && !loading) {
+      if (
+        e.key === "Enter" &&
+        !e.shiftKey &&
+        selectedPrompt &&
+        isServerConnected &&
+        !loading
+      ) {
         const target = e.target as HTMLElement;
         const tagName = target.tagName;
         const isEditable = target.isContentEditable;
@@ -214,7 +270,7 @@ export function PromptsTab({ serverConfig, serverName }: PromptsTabProps) {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectedPrompt, loading, getPrompt]);
+  }, [selectedPrompt, isServerConnected, loading, getPrompt]);
 
   if (!serverConfig || !serverName) {
     return (
@@ -247,7 +303,7 @@ export function PromptsTab({ serverConfig, serverName }: PromptsTabProps) {
               onClick={fetchPrompts}
               variant="ghost"
               size="sm"
-              disabled={fetchingPrompts}
+              disabled={fetchingPrompts || !isServerConnected}
               className="h-7 w-7 p-0"
               title="Refresh prompts"
             >
@@ -269,7 +325,7 @@ export function PromptsTab({ serverConfig, serverName }: PromptsTabProps) {
           {/* Run button */}
           <Button
             onClick={() => getPrompt()}
-            disabled={loading || !selectedPrompt}
+            disabled={loading || !selectedPrompt || !isServerConnected}
             size="sm"
             className="h-8 px-3 text-xs ml-auto"
           >
@@ -426,7 +482,9 @@ export function PromptsTab({ serverConfig, serverName }: PromptsTabProps) {
               ) : promptNames.length === 0 ? (
                 <div className="text-center py-8">
                   <p className="text-sm text-muted-foreground">
-                    No prompts available
+                    {isServerConnected
+                      ? "No prompts available"
+                      : "Connect this server to load prompts."}
                   </p>
                 </div>
               ) : (

--- a/mcpjam-inspector/client/src/components/ResourcesTab.tsx
+++ b/mcpjam-inspector/client/src/components/ResourcesTab.tsx
@@ -30,10 +30,12 @@ import {
 import { listResourceTemplates } from "@/lib/apis/mcp-resource-templates-api";
 import { parseTemplate } from "url-template";
 import { HOSTED_MODE } from "@/lib/config";
+import type { ConnectionStatus } from "@/state/app-types";
 
 interface ResourcesTabProps {
   serverConfig?: MCPServerConfig;
   serverName?: string;
+  serverConnectionStatus?: ConnectionStatus;
 }
 
 // RFC 6570 compliant URI template parameter extraction
@@ -89,7 +91,11 @@ function renderResourceTextContent(
   );
 }
 
-export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
+export function ResourcesTab({
+  serverConfig,
+  serverName,
+  serverConnectionStatus,
+}: ResourcesTabProps) {
   const [activeTab, setActiveTab] = useState<"resources" | "templates">(
     "resources",
   );
@@ -120,6 +126,13 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
   // Panel state
   const [isSidebarVisible, setIsSidebarVisible] = useState(true);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const resourcesFetchVersionRef = useRef(0);
+  const resourceReadVersionRef = useRef(0);
+  const templatesFetchVersionRef = useRef(0);
+  const templateReadVersionRef = useRef(0);
+  const isServerConnected =
+    serverConnectionStatus === undefined ||
+    serverConnectionStatus === "connected";
 
   const selectedTemplateData = useMemo(() => {
     return templates.find((t) => t.uriTemplate === selectedTemplate) ?? null;
@@ -138,15 +151,46 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
     return [];
   }, [selectedTemplateData?.uriTemplate, templateOverrides]);
 
+  const resetLoadedResourceState = (
+    invalidateRequests = true,
+    stopLoading = true,
+  ) => {
+    if (invalidateRequests) {
+      resourcesFetchVersionRef.current += 1;
+      resourceReadVersionRef.current += 1;
+      templatesFetchVersionRef.current += 1;
+      templateReadVersionRef.current += 1;
+    }
+    if (stopLoading) {
+      setLoading(false);
+      setFetchingResources(false);
+      setLoadingMore(false);
+      setTemplateLoading(false);
+      setFetchingTemplates(false);
+    }
+    setResources([]);
+    setSelectedResource("");
+    setResourceContent(null);
+    setError("");
+    setNextCursor(undefined);
+    setTemplates([]);
+    setSelectedTemplate("");
+    setTemplateContent(null);
+    setTemplateError("");
+    setTemplateOverrides({});
+  };
+
   // Fetch resources and templates on mount
   useEffect(() => {
-    if (serverConfig && serverName) {
-      fetchResources();
-      if (!HOSTED_MODE) {
-        fetchTemplates();
-      }
+    if (!serverConfig || !serverName || !isServerConnected) {
+      resetLoadedResourceState();
+      return;
     }
-  }, [serverConfig, serverName]);
+    fetchResources();
+    if (!HOSTED_MODE) {
+      fetchTemplates();
+    }
+  }, [serverConfig, serverName, isServerConnected]);
 
   useEffect(() => {
     if (HOSTED_MODE && activeTab === "templates") {
@@ -156,6 +200,10 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
 
   const fetchResources = async (cursor?: string, append = false) => {
     if (!serverName) return;
+    if (!isServerConnected) {
+      resetLoadedResourceState();
+      return;
+    }
 
     if (append) {
       setLoadingMore(true);
@@ -167,9 +215,11 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
       setResourceContent(null);
       setNextCursor(undefined);
     }
+    const fetchVersion = ++resourcesFetchVersionRef.current;
 
     try {
       const result = await listResources(serverName, cursor);
+      if (fetchVersion !== resourcesFetchVersionRef.current) return;
       const serverResources: MCPResource[] = Array.isArray(result.resources)
         ? result.resources
         : [];
@@ -189,15 +239,22 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
       }
       setNextCursor(result.nextCursor);
     } catch (err) {
+      if (fetchVersion !== resourcesFetchVersionRef.current) return;
       setError(`Network error fetching resources: ${err}`);
     } finally {
-      setFetchingResources(false);
-      setLoadingMore(false);
+      if (fetchVersion === resourcesFetchVersionRef.current) {
+        setFetchingResources(false);
+        setLoadingMore(false);
+      }
     }
   };
 
   const fetchTemplates = async () => {
     if (!serverName) return;
+    if (!isServerConnected) {
+      resetLoadedResourceState();
+      return;
+    }
 
     setFetchingTemplates(true);
     setTemplateError("");
@@ -205,14 +262,19 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
     setSelectedTemplate("");
     setTemplateOverrides({});
     setTemplateContent(null);
+    const fetchVersion = ++templatesFetchVersionRef.current;
 
     try {
       const serverTemplates = await listResourceTemplates(serverName);
+      if (fetchVersion !== templatesFetchVersionRef.current) return;
       setTemplates(serverTemplates);
     } catch (err) {
+      if (fetchVersion !== templatesFetchVersionRef.current) return;
       setTemplateError(`Could not fetch resource templates: ${err}`);
     } finally {
-      setFetchingTemplates(false);
+      if (fetchVersion === templatesFetchVersionRef.current) {
+        setFetchingTemplates(false);
+      }
     }
   };
 
@@ -247,16 +309,25 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
   // Read resource
   const readResource = async (uri: string) => {
     if (!serverName) return;
+    if (!isServerConnected) {
+      setError("Connect this server before reading resources.");
+      return;
+    }
     setLoading(true);
     setError("");
+    const readVersion = ++resourceReadVersionRef.current;
 
     try {
       const data = await readResourceApi(serverName, uri);
+      if (readVersion !== resourceReadVersionRef.current) return;
       setResourceContent(data?.content ?? null);
     } catch (err) {
+      if (readVersion !== resourceReadVersionRef.current) return;
       setError(`Error reading resource: ${err}`);
     } finally {
-      setLoading(false);
+      if (readVersion === resourceReadVersionRef.current) {
+        setLoading(false);
+      }
     }
   };
 
@@ -284,26 +355,35 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
   // Read template resource
   const readTemplateResource = useCallback(async () => {
     if (!selectedTemplate || !serverName) return;
+    if (!isServerConnected) {
+      setTemplateError("Connect this server before reading resources.");
+      return;
+    }
 
     setTemplateLoading(true);
     setTemplateError("");
+    const readVersion = ++templateReadVersionRef.current;
 
     try {
       const uri = getResolvedUri();
       const data = await readResourceApi(serverName, uri);
+      if (readVersion !== templateReadVersionRef.current) return;
       setTemplateContent(data?.content ?? null);
     } catch (err) {
+      if (readVersion !== templateReadVersionRef.current) return;
       setTemplateError(`Error reading resource: ${err}`);
     } finally {
-      setTemplateLoading(false);
+      if (readVersion === templateReadVersionRef.current) {
+        setTemplateLoading(false);
+      }
     }
-  }, [selectedTemplate, serverName, getResolvedUri]);
+  }, [selectedTemplate, serverName, isServerConnected, getResolvedUri]);
 
   // Handle Enter key in template input fields
   const handleTemplateInputKeyDown = (
     e: React.KeyboardEvent<HTMLInputElement>,
   ) => {
-    if (e.key === "Enter" && !templateLoading) {
+    if (e.key === "Enter" && isServerConnected && !templateLoading) {
       e.preventDefault();
       readTemplateResource();
     }
@@ -322,12 +402,18 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
         return;
       }
 
-      if (activeTab === "resources" && selectedResource && !loading) {
+      if (
+        activeTab === "resources" &&
+        selectedResource &&
+        isServerConnected &&
+        !loading
+      ) {
         e.preventDefault();
         readResource(selectedResource);
       } else if (
         activeTab === "templates" &&
         selectedTemplate &&
+        isServerConnected &&
         !templateLoading
       ) {
         e.preventDefault();
@@ -339,6 +425,7 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [
     selectedResource,
+    isServerConnected,
     loading,
     activeTab,
     selectedTemplate,
@@ -408,7 +495,7 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
               }}
               variant="ghost"
               size="sm"
-              disabled={isFetching}
+              disabled={isFetching || !isServerConnected}
               className="h-7 w-7 p-0"
               title={
                 activeTab === "resources"
@@ -434,7 +521,9 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
           {activeTab === "templates" && (
             <Button
               onClick={readTemplateResource}
-              disabled={templateLoading || !selectedTemplate}
+              disabled={
+                templateLoading || !selectedTemplate || !isServerConnected
+              }
               size="sm"
               className="h-8 px-3 text-xs"
             >
@@ -552,7 +641,9 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
                 ) : resources.length === 0 ? (
                   <div className="text-center py-8">
                     <p className="text-sm text-muted-foreground">
-                      No resources available
+                      {isServerConnected
+                        ? "No resources available"
+                        : "Connect this server to load resources."}
                     </p>
                   </div>
                 ) : (
@@ -612,7 +703,9 @@ export function ResourcesTab({ serverConfig, serverName }: ResourcesTabProps) {
               ) : templates.length === 0 ? (
                 <div className="text-center py-8">
                   <p className="text-sm text-muted-foreground">
-                    No resource templates available
+                    {isServerConnected
+                      ? "No resource templates available"
+                      : "Connect this server to load resource templates."}
                   </p>
                 </div>
               ) : (

--- a/mcpjam-inspector/client/src/components/ToolsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ToolsTab.tsx
@@ -44,6 +44,7 @@ import { validateToolOutput } from "@/lib/schema-utils";
 import type { MCPServerConfig } from "@mcpjam/sdk/browser";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { usePostHog } from "posthog-js/react";
+import type { ConnectionStatus } from "@/state/app-types";
 
 type ToolMap = Record<string, Tool>;
 type FormField = ToolFormField;
@@ -89,9 +90,14 @@ function normalizeElicitationContent(
 interface ToolsTabProps {
   serverConfig?: MCPServerConfig;
   serverName?: string;
+  serverConnectionStatus?: ConnectionStatus;
 }
 
-export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
+export function ToolsTab({
+  serverConfig,
+  serverName,
+  serverConnectionStatus,
+}: ToolsTabProps) {
   const logger = useLogger("ToolsTab");
   const posthog = usePostHog();
   const [tools, setTools] = useState<ToolMap>({});
@@ -132,7 +138,12 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
   const [taskTtl, setTaskTtl] = useState<number>(0);
   // Infinite scroll state
   const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const toolFetchVersionRef = useRef(0);
+  const taskCapabilitiesFetchVersionRef = useRef(0);
   const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const isServerConnected =
+    serverConnectionStatus === undefined ||
+    serverConnectionStatus === "connected";
   const serverKey = useMemo(() => {
     if (!serverConfig) return "none";
     try {
@@ -183,22 +194,46 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
   const serverSupportsTaskToolCalls =
     taskCapabilities?.supportsToolCalls ?? false;
 
-  useEffect(() => {
-    if (!serverConfig || !serverName) {
-      setTools({});
-      setSelectedTool("");
-      setFormFields([]);
-      setResult(null);
-      setStructuredContentValid(undefined);
-      setError("");
-      setResponseDurationMs(null);
-      setActiveElicitation(null);
+  const resetLoadedToolState = ({
+    invalidateRequests = true,
+    stopLoading = true,
+    clearTaskCapabilities = true,
+  }: {
+    invalidateRequests?: boolean;
+    stopLoading?: boolean;
+    clearTaskCapabilities?: boolean;
+  } = {}) => {
+    if (invalidateRequests) {
+      toolFetchVersionRef.current += 1;
+      taskCapabilitiesFetchVersionRef.current += 1;
+    }
+    if (stopLoading) {
+      setFetchingTools(false);
+      setLoadingExecuteTool(false);
+      setElicitationLoading(false);
+    }
+    setTools({});
+    setSelectedTool("");
+    setFormFields([]);
+    setResult(null);
+    setStructuredContentValid(undefined);
+    setError("");
+    setResponseDurationMs(null);
+    setActiveElicitation(null);
+    if (clearTaskCapabilities) {
       setTaskCapabilities(null);
+    }
+    setCursor(undefined);
+  };
+
+  useEffect(() => {
+    if (!serverConfig || !serverName || !isServerConnected) {
+      resetLoadedToolState();
       return;
     }
     void fetchTools(true);
     void fetchTaskCapabilities();
-  }, [serverConfig, serverName]);
+  }, [serverConfig, serverName, isServerConnected]);
 
   const toolNames = Object.keys(tools);
   const filteredToolNames = searchQuery.trim()
@@ -235,8 +270,11 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
   // Fetch task capabilities for the server
   const fetchTaskCapabilities = async () => {
     if (!serverName) return;
+    if (!isServerConnected) return;
+    const fetchVersion = ++taskCapabilitiesFetchVersionRef.current;
     try {
       const capabilities = await getTaskCapabilities(serverName);
+      if (fetchVersion !== taskCapabilitiesFetchVersionRef.current) return;
       setTaskCapabilities(capabilities);
       logger.info("Task capabilities fetched", {
         serverId: serverName,
@@ -245,6 +283,7 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
         supportsCancel: capabilities.supportsCancel,
       });
     } catch (err) {
+      if (fetchVersion !== taskCapabilitiesFetchVersionRef.current) return;
       // Server may not support tasks - this is fine, just log it
       logger.debug("Could not fetch task capabilities", {
         error: err instanceof Error ? err.message : "Unknown error",
@@ -279,18 +318,21 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
       logger.warn("Cannot fetch tools: no serverId available");
       return;
     }
+    if (!isServerConnected) {
+      resetLoadedToolState();
+      return;
+    }
 
     setError("");
     setFetchingTools(true);
     if (reset) {
-      setSelectedTool("");
-      setFormFields([]);
-      setResult(null);
-      setStructuredContentValid(undefined);
-      setResponseDurationMs(null);
-      setTools({});
-      setCursor(undefined);
+      resetLoadedToolState({
+        invalidateRequests: false,
+        stopLoading: false,
+        clearTaskCapabilities: false,
+      });
     }
+    const fetchVersion = ++toolFetchVersionRef.current;
 
     try {
       // Call to get all of the tools for server
@@ -298,6 +340,7 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
         serverId: serverName,
         cursor: reset ? undefined : cursor,
       });
+      if (fetchVersion !== toolFetchVersionRef.current) return;
       const toolArray = data.tools ?? [];
       const dictionary = Object.fromEntries(
         toolArray.map((tool: Tool) => [tool.name, tool]),
@@ -309,11 +352,14 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
         toolCount: toolArray.length,
       });
     } catch (err) {
+      if (fetchVersion !== toolFetchVersionRef.current) return;
       const message = err instanceof Error ? err.message : "Unknown error";
       logger.error("Failed to fetch tools", { error: message });
       setError(message);
     } finally {
-      setFetchingTools(false);
+      if (fetchVersion === toolFetchVersionRef.current) {
+        setFetchingTools(false);
+      }
     }
   };
 
@@ -432,6 +478,14 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
       logger.warn("Cannot execute tool: no serverId available");
       return;
     }
+    if (!isServerConnected) {
+      logger.warn("Cannot execute tool: server is not connected", {
+        serverId: serverName,
+        connectionStatus: serverConnectionStatus,
+      });
+      setError("Connect this server before running tools.");
+      return;
+    }
 
     setLoadingExecuteTool(true);
     setError("");
@@ -482,6 +536,7 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
         e.key === "Enter" &&
         !e.shiftKey &&
         selectedTool &&
+        isServerConnected &&
         !loadingExecuteTool
       ) {
         // Don't trigger if user is typing in an input, textarea, or contenteditable
@@ -500,7 +555,7 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectedTool, loadingExecuteTool]);
+  }, [selectedTool, isServerConnected, loadingExecuteTool]);
 
   const handleElicitationResponse = async (
     action: "accept" | "decline" | "cancel",
@@ -625,6 +680,7 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
       sentinelRef={sentinelRef}
       loadingMore={fetchingTools}
       cursor={cursor ?? ""}
+      serverConnected={isServerConnected}
       formFields={formFields}
       onFieldChange={updateFieldValue}
       onToggleField={updateFieldIsSet}

--- a/mcpjam-inspector/client/src/components/ToolsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ToolsTab.tsx
@@ -44,6 +44,7 @@ import { validateToolOutput } from "@/lib/schema-utils";
 import type { MCPServerConfig } from "@mcpjam/sdk/browser";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
 import { usePostHog } from "posthog-js/react";
+import type { ConnectionStatus } from "@/state/app-types";
 
 type ToolMap = Record<string, Tool>;
 type FormField = ToolFormField;
@@ -89,9 +90,14 @@ function normalizeElicitationContent(
 interface ToolsTabProps {
   serverConfig?: MCPServerConfig;
   serverName?: string;
+  serverConnectionStatus?: ConnectionStatus;
 }
 
-export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
+export function ToolsTab({
+  serverConfig,
+  serverName,
+  serverConnectionStatus,
+}: ToolsTabProps) {
   const logger = useLogger("ToolsTab");
   const posthog = usePostHog();
   const [tools, setTools] = useState<ToolMap>({});
@@ -132,7 +138,12 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
   const [taskTtl, setTaskTtl] = useState<number>(0);
   // Infinite scroll state
   const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const toolFetchVersionRef = useRef(0);
+  const taskCapabilitiesFetchVersionRef = useRef(0);
   const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const isServerConnected =
+    serverConnectionStatus === undefined ||
+    serverConnectionStatus === "connected";
   const serverKey = useMemo(() => {
     if (!serverConfig) return "none";
     try {
@@ -183,22 +194,39 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
   const serverSupportsTaskToolCalls =
     taskCapabilities?.supportsToolCalls ?? false;
 
+  const resetLoadedToolState = (
+    invalidateRequests = true,
+    stopLoading = true,
+  ) => {
+    if (invalidateRequests) {
+      toolFetchVersionRef.current += 1;
+      taskCapabilitiesFetchVersionRef.current += 1;
+    }
+    if (stopLoading) {
+      setFetchingTools(false);
+      setLoadingExecuteTool(false);
+      setElicitationLoading(false);
+    }
+    setTools({});
+    setSelectedTool("");
+    setFormFields([]);
+    setResult(null);
+    setStructuredContentValid(undefined);
+    setError("");
+    setResponseDurationMs(null);
+    setActiveElicitation(null);
+    setTaskCapabilities(null);
+    setCursor(undefined);
+  };
+
   useEffect(() => {
-    if (!serverConfig || !serverName) {
-      setTools({});
-      setSelectedTool("");
-      setFormFields([]);
-      setResult(null);
-      setStructuredContentValid(undefined);
-      setError("");
-      setResponseDurationMs(null);
-      setActiveElicitation(null);
-      setTaskCapabilities(null);
+    if (!serverConfig || !serverName || !isServerConnected) {
+      resetLoadedToolState();
       return;
     }
     void fetchTools(true);
     void fetchTaskCapabilities();
-  }, [serverConfig, serverName]);
+  }, [serverConfig, serverName, isServerConnected]);
 
   const toolNames = Object.keys(tools);
   const filteredToolNames = searchQuery.trim()
@@ -235,8 +263,11 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
   // Fetch task capabilities for the server
   const fetchTaskCapabilities = async () => {
     if (!serverName) return;
+    if (!isServerConnected) return;
+    const fetchVersion = ++taskCapabilitiesFetchVersionRef.current;
     try {
       const capabilities = await getTaskCapabilities(serverName);
+      if (fetchVersion !== taskCapabilitiesFetchVersionRef.current) return;
       setTaskCapabilities(capabilities);
       logger.info("Task capabilities fetched", {
         serverId: serverName,
@@ -245,6 +276,7 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
         supportsCancel: capabilities.supportsCancel,
       });
     } catch (err) {
+      if (fetchVersion !== taskCapabilitiesFetchVersionRef.current) return;
       // Server may not support tasks - this is fine, just log it
       logger.debug("Could not fetch task capabilities", {
         error: err instanceof Error ? err.message : "Unknown error",
@@ -279,18 +311,17 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
       logger.warn("Cannot fetch tools: no serverId available");
       return;
     }
+    if (!isServerConnected) {
+      resetLoadedToolState();
+      return;
+    }
 
     setError("");
     setFetchingTools(true);
     if (reset) {
-      setSelectedTool("");
-      setFormFields([]);
-      setResult(null);
-      setStructuredContentValid(undefined);
-      setResponseDurationMs(null);
-      setTools({});
-      setCursor(undefined);
+      resetLoadedToolState(false, false);
     }
+    const fetchVersion = ++toolFetchVersionRef.current;
 
     try {
       // Call to get all of the tools for server
@@ -298,6 +329,7 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
         serverId: serverName,
         cursor: reset ? undefined : cursor,
       });
+      if (fetchVersion !== toolFetchVersionRef.current) return;
       const toolArray = data.tools ?? [];
       const dictionary = Object.fromEntries(
         toolArray.map((tool: Tool) => [tool.name, tool]),
@@ -309,11 +341,14 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
         toolCount: toolArray.length,
       });
     } catch (err) {
+      if (fetchVersion !== toolFetchVersionRef.current) return;
       const message = err instanceof Error ? err.message : "Unknown error";
       logger.error("Failed to fetch tools", { error: message });
       setError(message);
     } finally {
-      setFetchingTools(false);
+      if (fetchVersion === toolFetchVersionRef.current) {
+        setFetchingTools(false);
+      }
     }
   };
 
@@ -432,6 +467,14 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
       logger.warn("Cannot execute tool: no serverId available");
       return;
     }
+    if (!isServerConnected) {
+      logger.warn("Cannot execute tool: server is not connected", {
+        serverId: serverName,
+        connectionStatus: serverConnectionStatus,
+      });
+      setError("Connect this server before running tools.");
+      return;
+    }
 
     setLoadingExecuteTool(true);
     setError("");
@@ -482,6 +525,7 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
         e.key === "Enter" &&
         !e.shiftKey &&
         selectedTool &&
+        isServerConnected &&
         !loadingExecuteTool
       ) {
         // Don't trigger if user is typing in an input, textarea, or contenteditable
@@ -500,7 +544,7 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [selectedTool, loadingExecuteTool]);
+  }, [selectedTool, isServerConnected, loadingExecuteTool]);
 
   const handleElicitationResponse = async (
     action: "accept" | "decline" | "cancel",
@@ -625,6 +669,7 @@ export function ToolsTab({ serverConfig, serverName }: ToolsTabProps) {
       sentinelRef={sentinelRef}
       loadingMore={fetchingTools}
       cursor={cursor ?? ""}
+      serverConnected={isServerConnected}
       formFields={formFields}
       onFieldChange={updateFieldValue}
       onToggleField={updateFieldIsSet}

--- a/mcpjam-inspector/client/src/components/__tests__/PromptsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/PromptsTab.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import { PromptsTab } from "../PromptsTab";
 import type { MCPServerConfig } from "@mcpjam/sdk/browser";
 
@@ -94,6 +100,99 @@ describe("PromptsTab", () => {
       await waitFor(() => {
         expect(mockListPrompts).toHaveBeenCalledWith("test-server");
       });
+    });
+
+    it("does not fetch prompts when the server is disconnected", () => {
+      const serverConfig = createServerConfig();
+
+      render(
+        <PromptsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="disconnected"
+        />,
+      );
+
+      expect(mockListPrompts).not.toHaveBeenCalled();
+      expect(
+        screen.getByText("Connect this server to load prompts."),
+      ).toBeInTheDocument();
+    });
+
+    it("clears loaded prompts when the selected server disconnects", async () => {
+      const serverConfig = createServerConfig();
+
+      mockListPrompts.mockResolvedValue([
+        { name: "greeting", description: "A greeting prompt" },
+      ]);
+
+      const { rerender } = render(
+        <PromptsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="connected"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("greeting")).toBeInTheDocument();
+      });
+      expect(mockListPrompts).toHaveBeenCalledTimes(1);
+
+      rerender(
+        <PromptsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="disconnected"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText("greeting")).not.toBeInTheDocument();
+      });
+      expect(
+        screen.getByText("Connect this server to load prompts."),
+      ).toBeInTheDocument();
+      expect(mockListPrompts).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores a stale prompts response after the selected server disconnects", async () => {
+      const serverConfig = createServerConfig();
+      let resolvePrompts!: (value: Array<Record<string, unknown>>) => void;
+      mockListPrompts.mockReturnValue(
+        new Promise((resolve) => {
+          resolvePrompts = resolve;
+        }),
+      );
+
+      const { rerender } = render(
+        <PromptsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="connected"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(mockListPrompts).toHaveBeenCalledTimes(1);
+      });
+
+      rerender(
+        <PromptsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="disconnected"
+        />,
+      );
+
+      await act(async () => {
+        resolvePrompts([{ name: "late-prompt" }]);
+      });
+
+      expect(screen.queryByText("late-prompt")).not.toBeInTheDocument();
+      expect(
+        screen.getByText("Connect this server to load prompts."),
+      ).toBeInTheDocument();
     });
 
     it("displays prompts after fetching", async () => {

--- a/mcpjam-inspector/client/src/components/__tests__/ResourcesTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ResourcesTab.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import { ResourcesTab } from "../ResourcesTab";
 import type { MCPServerConfig } from "@mcpjam/sdk/browser";
 
@@ -99,6 +105,103 @@ describe("ResourcesTab", () => {
           undefined,
         );
       });
+    });
+
+    it("does not fetch resources when the server is disconnected", () => {
+      const serverConfig = createServerConfig();
+
+      render(
+        <ResourcesTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="disconnected"
+        />,
+      );
+
+      expect(mockListResources).not.toHaveBeenCalled();
+      expect(
+        screen.getByText("Connect this server to load resources."),
+      ).toBeInTheDocument();
+    });
+
+    it("clears loaded resources when the selected server disconnects", async () => {
+      const serverConfig = createServerConfig();
+
+      mockListResources.mockResolvedValue({
+        resources: [{ name: "test.txt", uri: "file:///test.txt" }],
+      });
+
+      const { rerender } = render(
+        <ResourcesTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="connected"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("test.txt")).toBeInTheDocument();
+      });
+      expect(mockListResources).toHaveBeenCalledTimes(1);
+
+      rerender(
+        <ResourcesTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="disconnected"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText("test.txt")).not.toBeInTheDocument();
+      });
+      expect(
+        screen.getByText("Connect this server to load resources."),
+      ).toBeInTheDocument();
+      expect(mockListResources).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores a stale resources response after the selected server disconnects", async () => {
+      const serverConfig = createServerConfig();
+      let resolveResources!: (value: {
+        resources: Array<Record<string, unknown>>;
+      }) => void;
+      mockListResources.mockReturnValue(
+        new Promise((resolve) => {
+          resolveResources = resolve;
+        }),
+      );
+
+      const { rerender } = render(
+        <ResourcesTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="connected"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(mockListResources).toHaveBeenCalledTimes(1);
+      });
+
+      rerender(
+        <ResourcesTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="disconnected"
+        />,
+      );
+
+      await act(async () => {
+        resolveResources({
+          resources: [{ name: "late.txt", uri: "file:///late.txt" }],
+        });
+      });
+
+      expect(screen.queryByText("late.txt")).not.toBeInTheDocument();
+      expect(
+        screen.getByText("Connect this server to load resources."),
+      ).toBeInTheDocument();
     });
 
     it("displays resources after fetching", async () => {

--- a/mcpjam-inspector/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ToolsTab.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import { ToolsTab } from "../ToolsTab";
 import type { MCPServerConfig } from "@mcpjam/sdk/browser";
 
@@ -135,6 +141,157 @@ describe("ToolsTab", () => {
           cursor: undefined,
         });
       });
+    });
+
+    it("does not fetch tools or task capabilities when the server is disconnected", () => {
+      const serverConfig = createServerConfig();
+
+      render(
+        <ToolsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="disconnected"
+        />,
+      );
+
+      expect(mockListTools).not.toHaveBeenCalled();
+      expect(mockGetTaskCapabilities).not.toHaveBeenCalled();
+      expect(
+        screen.getByText("Connect this server to load tools."),
+      ).toBeInTheDocument();
+    });
+
+    it("clears loaded tools when the selected server disconnects", async () => {
+      const serverConfig = createServerConfig();
+
+      mockListTools.mockResolvedValue({
+        tools: [{ name: "test-tool", inputSchema: { type: "object" } }],
+      });
+
+      const { rerender } = render(
+        <ToolsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="connected"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("test-tool")).toBeInTheDocument();
+      });
+      expect(mockListTools).toHaveBeenCalledTimes(1);
+
+      rerender(
+        <ToolsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="disconnected"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText("test-tool")).not.toBeInTheDocument();
+      });
+      expect(
+        screen.getByText("Connect this server to load tools."),
+      ).toBeInTheDocument();
+      expect(mockListTools).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores a stale tools response after the selected server disconnects", async () => {
+      const serverConfig = createServerConfig();
+      let resolveTools!: (value: {
+        tools: Array<Record<string, unknown>>;
+      }) => void;
+      mockListTools.mockReturnValue(
+        new Promise((resolve) => {
+          resolveTools = resolve;
+        }),
+      );
+
+      const { rerender } = render(
+        <ToolsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="connected"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(mockListTools).toHaveBeenCalledTimes(1);
+      });
+
+      rerender(
+        <ToolsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="disconnected"
+        />,
+      );
+
+      await act(async () => {
+        resolveTools({
+          tools: [{ name: "late-tool", inputSchema: { type: "object" } }],
+        });
+      });
+
+      expect(screen.queryByText("late-tool")).not.toBeInTheDocument();
+      expect(
+        screen.getByText("Connect this server to load tools."),
+      ).toBeInTheDocument();
+    });
+
+    it("preserves task capabilities when refreshing tools", async () => {
+      const serverConfig = createServerConfig();
+
+      mockGetTaskCapabilities.mockResolvedValue({
+        supportsToolCalls: true,
+        supportsList: false,
+        supportsCancel: false,
+      });
+      mockListTools.mockResolvedValue({
+        tools: [
+          {
+            name: "task-tool",
+            inputSchema: { type: "object" },
+            execution: { taskSupport: "optional" },
+          },
+        ],
+      });
+
+      render(
+        <ToolsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="connected"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("task-tool")).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(mockGetTaskCapabilities).toHaveBeenCalledWith("test-server");
+      });
+
+      fireEvent.click(screen.getByText("task-tool"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Execute as task")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByTitle("Refresh tools"));
+
+      await waitFor(() => {
+        expect(mockListTools).toHaveBeenCalledTimes(2);
+      });
+
+      fireEvent.click(screen.getByText("task-tool"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Execute as task")).toBeInTheDocument();
+      });
+      expect(mockGetTaskCapabilities).toHaveBeenCalledTimes(1);
     });
 
     it("displays tools after fetching", async () => {

--- a/mcpjam-inspector/client/src/components/__tests__/ToolsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ToolsTab.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  act,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import { ToolsTab } from "../ToolsTab";
 import type { MCPServerConfig } from "@mcpjam/sdk/browser";
 
@@ -135,6 +141,104 @@ describe("ToolsTab", () => {
           cursor: undefined,
         });
       });
+    });
+
+    it("does not fetch tools or task capabilities when the server is disconnected", () => {
+      const serverConfig = createServerConfig();
+
+      render(
+        <ToolsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="disconnected"
+        />,
+      );
+
+      expect(mockListTools).not.toHaveBeenCalled();
+      expect(mockGetTaskCapabilities).not.toHaveBeenCalled();
+      expect(
+        screen.getByText("Connect this server to load tools."),
+      ).toBeInTheDocument();
+    });
+
+    it("clears loaded tools when the selected server disconnects", async () => {
+      const serverConfig = createServerConfig();
+
+      mockListTools.mockResolvedValue({
+        tools: [{ name: "test-tool", inputSchema: { type: "object" } }],
+      });
+
+      const { rerender } = render(
+        <ToolsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="connected"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("test-tool")).toBeInTheDocument();
+      });
+      expect(mockListTools).toHaveBeenCalledTimes(1);
+
+      rerender(
+        <ToolsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="disconnected"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByText("test-tool")).not.toBeInTheDocument();
+      });
+      expect(
+        screen.getByText("Connect this server to load tools."),
+      ).toBeInTheDocument();
+      expect(mockListTools).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores a stale tools response after the selected server disconnects", async () => {
+      const serverConfig = createServerConfig();
+      let resolveTools!: (value: {
+        tools: Array<Record<string, unknown>>;
+      }) => void;
+      mockListTools.mockReturnValue(
+        new Promise((resolve) => {
+          resolveTools = resolve;
+        }),
+      );
+
+      const { rerender } = render(
+        <ToolsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="connected"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(mockListTools).toHaveBeenCalledTimes(1);
+      });
+
+      rerender(
+        <ToolsTab
+          serverConfig={serverConfig}
+          serverName="test-server"
+          serverConnectionStatus="disconnected"
+        />,
+      );
+
+      await act(async () => {
+        resolveTools({
+          tools: [{ name: "late-tool", inputSchema: { type: "object" } }],
+        });
+      });
+
+      expect(screen.queryByText("late-tool")).not.toBeInTheDocument();
+      expect(
+        screen.getByText("Connect this server to load tools."),
+      ).toBeInTheDocument();
     });
 
     it("displays tools after fetching", async () => {

--- a/mcpjam-inspector/client/src/components/tools/ToolsSidebar.tsx
+++ b/mcpjam-inspector/client/src/components/tools/ToolsSidebar.tsx
@@ -43,6 +43,7 @@ interface ToolsSidebarProps {
   sentinelRef: RefObject<HTMLDivElement | null>;
   loadingMore: boolean;
   cursor: string;
+  serverConnected?: boolean;
   // Parameters form props (for full-page replacement pattern)
   formFields?: FormField[];
   onFieldChange?: (name: string, value: unknown) => void;
@@ -83,6 +84,7 @@ export function ToolsSidebar({
   sentinelRef,
   loadingMore,
   cursor,
+  serverConnected = true,
   // Parameters form props
   formFields,
   onFieldChange,
@@ -108,7 +110,7 @@ export function ToolsSidebar({
   useEffect(() => {
     setOpenSections(hasParameters ? ["parameters"] : ["description"]);
   }, [selectedToolName, hasParameters]);
-  const canExecute = !!selectedToolName && !!onExecute;
+  const canExecute = serverConnected && !!selectedToolName && !!onExecute;
   const canSave = !!selectedToolName && !!onSave;
 
   const handleExecute = () => {
@@ -194,7 +196,7 @@ export function ToolsSidebar({
               onClick={handleRefresh}
               variant="ghost"
               size="sm"
-              disabled={fetchingTools}
+              disabled={fetchingTools || !serverConnected}
               className="h-7 w-7 p-0"
               title="Refresh tools"
             >
@@ -406,7 +408,9 @@ export function ToolsSidebar({
                     <div className="text-center py-8">
                       <p className="text-sm text-muted-foreground">
                         {tools && toolNames.length === 0
-                          ? "No tools were found. Try refreshing. Make sure you selected the correct server and the server is running."
+                          ? serverConnected
+                            ? "No tools were found. Try refreshing. Make sure you selected the correct server and the server is running."
+                            : "Connect this server to load tools."
                           : "No tools match your search."}
                       </p>
                     </div>


### PR DESCRIPTION
## Summary
- Pass the visible selected-server connection status into Tools, Resources, and Prompts.
- Clear and skip primitive discovery when the selected server is not connected.
- Block tool execution, resource reads, and prompt runs when the UI state is disconnected.
- Ignore late hosted responses after a server disconnects so stale Tools/Resources/Prompts cannot repopulate.
- Add regression coverage for disconnected state, clearing stale primitives, and late hosted responses.

## Root Cause
Hosted primitive APIs can create ephemeral backend connections for list/read/get operations. The primitive tabs were calling those APIs whenever a selected server config existed, even if app state showed the selected server as disconnected. That made disconnected servers expose tools, resources, or prompts in the UI.

## Fix Strategy
Use app state as the source of truth, matching the Playground behavior: no visible `connectionStatus === connected`, no primitive discovery or invocation. Hosted ephemeral connections remain an implementation detail behind API calls, but the user-facing primitive surfaces now respect visible connection state.

## Validation
- npm run test -- --run client/src/components/__tests__/ToolsTab.test.tsx
- npm run test -- --run client/src/components/__tests__/ResourcesTab.test.tsx
- npm run test -- --run client/src/components/__tests__/PromptsTab.test.tsx
- npm run test -- --run client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
- npm run test -- --run client/src/components/__tests__/ServersTab.test.tsx
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes core inspector tab data-loading/execution flow and adds request-invalidation logic that could inadvertently suppress updates or leave tabs in a cleared state if connection status handling is incorrect.
> 
> **Overview**
> **Gate MCP primitive discovery and invocation on visible connection status.** `ToolsTab`, `ResourcesTab`, and `PromptsTab` now receive `serverConnectionStatus` from `App.tsx`, skip list/read/get calls when disconnected, and proactively clear loaded tab state when the selected server disconnects.
> 
> Adds stale-response protection via per-request version refs so late API responses can’t repopulate cleared tools/resources/prompts after a disconnect, and updates UI controls/messages (refresh/run/enter-to-run) to be disabled and prompt reconnection when not connected. Test suites for all three tabs add coverage for disconnected gating, clearing on disconnect, and ignoring late responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b533148b27d60f1cd262d31c952e5c0c5a60acb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->