### PR TITLE
fix(oauth): silently refresh OAuth servers after local-mode page reload

### DIFF
--- a/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.test.ts
+++ b/mcpjam-inspector/client/src/state/__tests__/oauth-orchestrator.test.ts
@@ -226,6 +226,69 @@ describe("ensureAuthorizedForReconnect", () => {
     );
   });
 
+  it("uses stored localStorage tokens to refresh silently when server.oauthTokens is undefined (post-reload local mode)", async () => {
+    // After a page reload in local (non-hosted) mode, `server.oauthTokens`
+    // is undefined because nothing hydrates the reducer state from
+    // localStorage at startup. The auto-reconnect path must still find the
+    // persisted refresh token via `getStoredTokens` and run a silent
+    // refresh — otherwise OAuth servers land in `reauth_required` even
+    // though valid tokens sit on disk.
+    getStoredTokensMock.mockReturnValue({
+      access_token: "stored-access",
+      refresh_token: "stored-refresh",
+    });
+    refreshOAuthTokensMock.mockResolvedValue({
+      success: true,
+      serverConfig: {
+        type: "http",
+        url: "https://mcp.asana.com/sse",
+      },
+      oauthTrace: { steps: [] },
+    });
+
+    const result = await ensureAuthorizedForReconnect(
+      createServer({ oauthTokens: undefined }),
+      { allowInteractiveOAuthFlow: false },
+    );
+
+    expect(refreshOAuthTokensMock).toHaveBeenCalledWith(
+      "asana",
+      expect.any(Object),
+    );
+    expect(initiateOAuthMock).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({
+        kind: "ready",
+        serverConfig: expect.objectContaining({
+          url: "https://mcp.asana.com/sse",
+        }),
+        tokens: expect.objectContaining({
+          access_token: "stored-access",
+        }),
+      }),
+    );
+  });
+
+  it("skips refresh and returns reauth_required when no in-memory or stored tokens exist", async () => {
+    // Mirror of the case above: OAuth-enabled server with neither
+    // reducer-state tokens nor localStorage-persisted tokens. The new
+    // `hasRefreshCandidate` gate must not fire a refresh (no token to
+    // refresh against) — and with interactive OAuth disabled, the result
+    // is reauth_required.
+    getStoredTokensMock.mockReturnValue(undefined);
+
+    const result = await ensureAuthorizedForReconnect(
+      createServer({ oauthTokens: undefined }),
+      { allowInteractiveOAuthFlow: false },
+    );
+
+    expect(refreshOAuthTokensMock).not.toHaveBeenCalled();
+    expect(initiateOAuthMock).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({ kind: "reauth_required" }),
+    );
+  });
+
   it("does not launch OAuth for a server explicitly saved without OAuth", async () => {
     const server = createServer({
       useOAuth: false,

--- a/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
+++ b/mcpjam-inspector/client/src/state/oauth-orchestrator.ts
@@ -194,10 +194,17 @@ export async function ensureAuthorizedForReconnect(
     return { kind: "ready", serverConfig: server.config, tokens: undefined };
   }
 
-  // If OAuth was configured, try to refresh or re-initiate
+  // If OAuth was configured, try to refresh or re-initiate. Local mode does
+  // not hydrate `server.oauthTokens` from localStorage at startup, so a
+  // page-reload + auto-reconnect arrives here with `oauthTokens: undefined`
+  // even when a refresh_token sits in localStorage. Probe getStoredTokens
+  // too so the silent refresh runs; refreshOAuthTokens self-reads from
+  // localStorage anyway and returns success: false cleanly if nothing is
+  // persisted.
   let refreshTrace: OAuthTrace | undefined;
-  if (server.oauthTokens) {
-    // Try refresh first
+  const hasRefreshCandidate =
+    server.oauthTokens || getStoredTokens(server.name);
+  if (hasRefreshCandidate) {
     const refreshed = await refreshOAuthTokens(server.name, {
       onTraceUpdate: options?.onTraceUpdate,
     });


### PR DESCRIPTION
## Summary
- In local (non-hosted) mode, OAuth servers (`stag`, `bart`, etc.) failed to auto-reconnect after a page reload, showing red "Failed (0)" even when valid tokens existed in `localStorage`. Hosted mode worked fine.
- Root cause: `ensureAuthorizedForReconnect` gated its silent-refresh attempt on `server.oauthTokens`, but local mode never hydrates that field from `localStorage` at startup (only `CONNECT_SUCCESS` populates it during a session). With `allowInteractiveOAuthFlow: false` set by `ensureServersReady` for auto-connect, the function returned `reauth_required` → dispatched as `CONNECT_FAILURE`.
- Fix: probe `getStoredTokens(server.name)` alongside `server.oauthTokens` to gate the refresh. `refreshOAuthTokens` already self-reads everything from `localStorage` and returns cleanly when nothing is persisted, so OAuth-enabled servers that never completed auth still skip refresh.
- Hosted mode is unaffected — it takes the `HOSTED_MODE && isAuthenticated && useOAuth` fast path in `use-server-state.ts` before reaching the orchestrator.

## Test plan
- [x] `npx vitest run client/src/state/__tests__/oauth-orchestrator.test.ts` — 8/8 pass (6 existing + 2 new regression tests).
- [ ] Manual: `npm run dev` (local mode) → connect an OAuth server (e.g. `stag`, `bart`) → reload page → server reconnects silently without OAuth prompt.
- [ ] Manual: `npm run dev` → OAuth server with no prior auth → still surfaces the reconnect prompt as expected (no silent-refresh false positive).
- [ ] Manual: `npm run dev:hosted` → confirm no regression (still uses backend-stored creds via the line 3154 fast path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to the reconnect gate for OAuth refresh plus targeted tests; potential impact is limited to when refresh is attempted (now also when tokens exist only in localStorage).
> 
> **Overview**
> Fixes local-mode auto-reconnect for OAuth servers after a page reload by allowing `ensureAuthorizedForReconnect` to attempt a silent `refreshOAuthTokens` when `server.oauthTokens` is missing but `getStoredTokens(server.name)` exists.
> 
> Adds regression coverage for (1) successful silent refresh using stored tokens and (2) correctly skipping refresh and returning `reauth_required` when neither in-memory nor stored tokens are available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97f1239d7362a7c5b1343331b42ed4361ca2d1ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->