### PR TITLE
[codex] fix playground auto-connect

### DIFF
--- a/mcpjam-inspector/client/src/components/ServersTab.tsx
+++ b/mcpjam-inspector/client/src/components/ServersTab.tsx
@@ -747,7 +747,7 @@ export function ServersTab({
       .filter((name): name is string => !!name);
   }, [previewedHost?.config?.serverIds, viewProjectServersList]);
   useAutoConnectProjectServers({
-    projectId: activeProjectId || null,
+    projectId: sharedProjectIdForHostScope ?? activeProjectId ?? null,
     hostScopeKey: previewedHostId,
     requiredServerNames: previewedHostRequiredNames,
   });

--- a/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
+++ b/mcpjam-inspector/client/src/components/playground/PlaygroundTab.tsx
@@ -137,7 +137,10 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
     isAuthenticated: isConvexAuthenticated,
     hostId: previewedHostId,
   });
-  const activeMcpProfile = previewedHost?.config.mcpProfile;
+  const effectiveHostConfig = previewedHostId
+    ? previewedHost?.config ?? null
+    : props.activeHost ?? null;
+  const activeMcpProfile = effectiveHostConfig?.mcpProfile;
 
   // Host-derived widget runtime values. The preferences store is the
   // editing surface for ad-hoc previews; once a host is selected its
@@ -150,23 +153,25 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
   const prefChatUiOverride = usePreferencesStore(
     (state) => state.chatUiOverride
   );
-  const hostStyle = previewedHost?.config.hostStyle ?? prefHostStyle;
+  const hostStyle = effectiveHostConfig?.hostStyle ?? prefHostStyle;
   const hostCapabilitiesOverride =
-    previewedHost?.config.hostCapabilitiesOverride ??
+    effectiveHostConfig?.hostCapabilitiesOverride ??
     prefHostCapabilitiesOverride;
   const chatUiOverride =
-    previewedHost?.config.chatUiOverride ?? prefChatUiOverride;
+    effectiveHostConfig?.chatUiOverride ?? prefChatUiOverride;
   const shellStyle = getChatboxShellStyle(hostStyle, themeMode);
 
-  // Auto-connect the previewed host's REQUIRED servers once per session.
-  // No previewed host = no auto-connect. Optional servers stay
-  // disconnected until the user manually toggles them in the Servers tab.
+  // Auto-connect the effective host's REQUIRED servers once per session.
+  // Preview mode wins; otherwise fall back to the project default host so
+  // the connect path matches the host config this surface renders with.
+  // Optional servers stay disconnected until the user manually toggles them
+  // in the Servers tab.
   const { servers: projectServersList } = useProjectServers({
     projectId: props.sharedProjectId ?? null,
     isAuthenticated: isConvexAuthenticated,
   });
-  const previewedHostRequiredNames = useMemo(() => {
-    const requiredIds = previewedHost?.config?.serverIds ?? [];
+  const effectiveHostRequiredNames = useMemo(() => {
+    const requiredIds = effectiveHostConfig?.serverIds ?? [];
     if (requiredIds.length === 0 || !projectServersList) return [];
     const byId = new Map(
       projectServersList.map((s) => [s._id, s.name] as const)
@@ -174,11 +179,11 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
     return requiredIds
       .map((id) => byId.get(id))
       .filter((name): name is string => !!name);
-  }, [previewedHost?.config?.serverIds, projectServersList]);
+  }, [effectiveHostConfig?.serverIds, projectServersList]);
   useAutoConnectProjectServers({
-    projectId: props.activeProjectId ?? null,
-    hostScopeKey: previewedHostId,
-    requiredServerNames: previewedHostRequiredNames,
+    projectId: props.sharedProjectId ?? props.activeProjectId ?? null,
+    hostScopeKey: previewedHostId ?? effectiveHostConfig?.id ?? null,
+    requiredServerNames: effectiveHostRequiredNames,
   });
 
   const appBuilderState = useAppBuilderState({
@@ -228,7 +233,7 @@ export function PlaygroundTab(props: PlaygroundTabProps) {
           // project whose default is Codex would render widgets in
           // Playground while connect knows the server was init'd as
           // Codex.
-          activeHost={previewedHost?.config ?? props.activeHost ?? null}
+          activeHost={effectiveHostConfig}
           hostStyle={hostStyle}
         >
           <ChatboxHostStyleProvider value={hostStyle}>

--- a/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useAutoConnectProjectServers.test.tsx
@@ -238,7 +238,7 @@ describe("useAutoConnectProjectServers", () => {
     expect(ensureServersReady).toHaveBeenLastCalledWith(["alpha"]);
   });
 
-  it("disconnects EVERY connected server on host switch (incl. ones the new host still requires)", async () => {
+  it("disconnects only connected servers required by the active host on host switch", async () => {
     const ensureServersReady = vi.fn().mockResolvedValue({
       readyServerNames: [],
       failedServerNames: [],
@@ -247,10 +247,9 @@ describe("useAutoConnectProjectServers", () => {
     });
     const runtimeDisconnectServer = vi.fn();
     // Three servers connected from a prior host; current host requires only
-    // "alpha". With the reconnect-on-host-switch policy, alpha gets torn
-    // down alongside beta/gamma; its reconnect fires on the next render
-    // once the DISCONNECT dispatch propagates and it re-enters the
-    // candidate set (see ensureServersReady call path in use-server-state).
+    // "alpha". Only alpha needs a recycle so it can reconnect with the
+    // active host's initialize payload. beta/gamma may have been connected
+    // manually or by project-level auto-connect and should remain up.
     const appState = {
       servers: {
         alpha: { name: "alpha", connectionStatus: "connected" },
@@ -282,13 +281,13 @@ describe("useAutoConnectProjectServers", () => {
     // state, so it's filtered out of the candidate set. In production the
     // next render (after DISCONNECT lands) would pick it up.
     expect(ensureServersReady).not.toHaveBeenCalled();
-    // Disconnect side: every connected server comes down, alpha included.
-    expect(runtimeDisconnectServer).toHaveBeenCalledTimes(3);
+    // Disconnect side: only the host-required connected server comes down.
+    expect(runtimeDisconnectServer).toHaveBeenCalledTimes(1);
     const disconnected = runtimeDisconnectServer.mock.calls.map((c) => c[0]);
-    expect(disconnected.sort()).toEqual(["alpha", "beta", "gamma"]);
+    expect(disconnected).toEqual(["alpha"]);
   });
 
-  it("disconnects ALL connected servers when the active host requires none (e.g. MCPJam default)", async () => {
+  it("keeps connected servers up when the active host requires none", async () => {
     const ensureServersReady = vi.fn();
     const runtimeDisconnectServer = vi.fn();
     const appState = {
@@ -318,9 +317,7 @@ describe("useAutoConnectProjectServers", () => {
 
     await flushMicrotasks();
     expect(ensureServersReady).not.toHaveBeenCalled();
-    expect(runtimeDisconnectServer).toHaveBeenCalledTimes(2);
-    const disconnected = runtimeDisconnectServer.mock.calls.map((c) => c[0]);
-    expect(disconnected.sort()).toEqual(["alpha", "beta"]);
+    expect(runtimeDisconnectServer).not.toHaveBeenCalled();
   });
 
   it("syncs setSelectedServerNames to the host's required set on each new scope", async () => {
@@ -364,10 +361,11 @@ describe("useAutoConnectProjectServers", () => {
     await flushMicrotasks();
     expect(setSelectedServerNames).toHaveBeenLastCalledWith(["alpha", "beta"]);
 
-    // Switch to a host with empty required set → playground selection clears.
+    // Empty required set is no-op; surfaces with no explicit host selection
+    // must not clear the project/default host's selected servers.
     rerender({ hostScopeKey: "host-mcpjam", requiredServerNames: [] });
     await flushMicrotasks();
-    expect(setSelectedServerNames).toHaveBeenLastCalledWith([]);
+    expect(setSelectedServerNames).toHaveBeenCalledTimes(1);
   });
 
   it("re-attempts on every host transition, including returning to a previously-visited host", async () => {
@@ -453,8 +451,8 @@ describe("useAutoConnectProjectServers", () => {
     );
 
     await flushMicrotasks();
-    // First pass: every connected server is torn down (including the
-    // required `learn`, which will reconnect once its DISCONNECT lands).
+    // First pass: the host-required connected server is torn down so it
+    // can reconnect once its DISCONNECT lands.
     expect(runtimeDisconnectServer).toHaveBeenCalledTimes(1);
     expect(runtimeDisconnectServer).toHaveBeenCalledWith("learn");
 

--- a/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
+++ b/mcpjam-inspector/client/src/hooks/useAutoConnectProjectServers.ts
@@ -130,34 +130,47 @@ export function useAutoConnectProjectServers({
   } = useServerActions();
   const lastResultRef = useRef<EnsureServersReadyResult | null>(null);
 
-  // Names currently in a "connected" runtime state — on a host switch we
-  // tear down EVERY connected server (not just the ones the new host
-  // doesn't require) so each transition forces a fresh reconnect. Servers
-  // the new host still requires fall through to the connect-required pass
-  // below once their dispatched DISCONNECT lands and they re-enter the
-  // candidate set on the next render. Skipped when no project is active or
-  // when auto-connect is toggled off (the toggle gates both directions —
-  // it's "auto-reconcile to host", not just "auto-connect").
-  const connectedNamesToDisconnectKey = useMemo(() => {
-    if (!enabled || !projectId) return null;
+  const scopeKey = hostScopeKey ?? "-";
+  // Stable key for "what the active host wants selected". Drives the
+  // playground/chat multi-select sync below, independent of connect /
+  // disconnect dedupe.
+  const requiredNamesKey = useMemo(
+    () => requiredServerNames.slice().sort().join("\0"),
+    [requiredServerNames],
+  );
+  const requiredNames = useMemo(
+    () => (requiredNamesKey ? requiredNamesKey.split("\0") : []),
+    [requiredNamesKey],
+  );
+
+  // Names in the active host's required set that are currently connected.
+  // On a host switch, only those servers need to be recycled so they can
+  // reconnect with the new host's initialize payload. Servers outside the
+  // required set may have been connected manually or by the project-level
+  // auto-connect switch; entering a host with no required servers must not
+  // tear them down.
+  const requiredConnectedNamesToDisconnectKey = useMemo(() => {
+    if (!enabled || !projectId || requiredNames.length === 0) return null;
     const connected: string[] = [];
-    for (const [name, server] of Object.entries(sharedAppState.servers)) {
-      if (server?.connectionStatus !== "connected") continue;
+    for (const name of requiredNames) {
+      if (sharedAppState.servers[name]?.connectionStatus !== "connected") {
+        continue;
+      }
       connected.push(name);
     }
     if (connected.length === 0) return null;
-    return connected.slice().sort().join("\0");
-  }, [enabled, projectId, sharedAppState.servers]);
+    return connected.join("\0");
+  }, [enabled, projectId, requiredNames, sharedAppState.servers]);
 
   // Build the candidate name list. Skip servers that are already connected,
   // currently connecting, or in an OAuth flow — connecting/oauth-flow would
   // be interrupted; connected has nothing to do.
   const candidateNamesKey = useMemo(() => {
-    if (!enabled || !projectId || requiredServerNames.length === 0) {
+    if (!enabled || !projectId || requiredNames.length === 0) {
       return null;
     }
     const candidates: string[] = [];
-    for (const name of requiredServerNames) {
+    for (const name of requiredNames) {
       const status = sharedAppState.servers[name]?.connectionStatus;
       if (
         status === "connected" ||
@@ -171,34 +184,20 @@ export function useAutoConnectProjectServers({
     if (candidates.length === 0) return null;
     // Stable key: sorted and joined with NUL — same shape ChatboxBuilderView
     // uses (line 754) so reordering doesn't trigger a fresh batch.
-    return candidates.slice().sort().join("\0");
-  }, [enabled, projectId, requiredServerNames, sharedAppState.servers]);
-
-  const scopeKey = hostScopeKey ?? "-";
-  // Stable key for "what the active host wants selected". Drives the
-  // playground/chat multi-select sync below, independent of connect /
-  // disconnect dedupe — so switching from one zero-required host to
-  // another still clears the previous selection.
-  const requiredNamesKey = useMemo(
-    () => requiredServerNames.slice().sort().join("\0"),
-    [requiredServerNames],
-  );
+    return candidates.join("\0");
+  }, [enabled, projectId, requiredNames, sharedAppState.servers]);
 
   // Sync the playground/chat multi-select to the host's required set
-  // whenever the (project, hostScope, required-names) tuple changes.
+  // whenever the (project, hostScope, required-names) tuple changes. Empty
+  // required sets are a no-op: surfaces with no explicit host selection
+  // should not wipe the active project/default host's server selection.
   // React's dep comparison deduplicates re-renders that don't actually
   // change the tuple, so this fires once per host switch (and once per
   // edit to the host's required set after save).
   useEffect(() => {
-    if (!enabled || !projectId) return;
-    setSelectedServerNames(requiredNamesKey ? requiredNamesKey.split("\0") : []);
-  }, [
-    enabled,
-    projectId,
-    scopeKey,
-    requiredNamesKey,
-    setSelectedServerNames,
-  ]);
+    if (!enabled || !projectId || requiredNames.length === 0) return;
+    setSelectedServerNames(requiredNames);
+  }, [enabled, projectId, scopeKey, requiredNames, setSelectedServerNames]);
 
   // Detect a scope transition (user switched the previewed host) and
   // clear the prior attempt log so revisiting a previously-tried host
@@ -208,40 +207,46 @@ export function useAutoConnectProjectServers({
   // try again. Sitting on the same host doesn't trigger this — only the
   // actual scope change does.
   useEffect(() => {
-    if (!projectId) return;
+    if (!projectId || requiredNames.length === 0) return;
     if (lastSeenScopeByProject.get(projectId) !== scopeKey) {
       attemptedByProject.delete(projectId);
       lastSeenScopeByProject.set(projectId, scopeKey);
     }
-  }, [projectId, scopeKey]);
+  }, [projectId, scopeKey, requiredNames.length]);
 
-  // Disconnect-all-connected: fires at most once per (project, scopeKey).
-  // This is the host-switch tear-down pass — it snapshots every currently
-  // connected server on first entry to the scope and disconnects it,
-  // including ones the new host still requires. The required ones then
-  // re-enter the candidate set on the next render and reconnect fresh
-  // (each host switch = full reconnect cycle). Later changes to the
-  // connected set within the SAME scope (e.g. the user manually
+  // Disconnect-required-connected: fires at most once per (project,
+  // scopeKey). This is the host-switch recycle pass — it snapshots the
+  // active host's required servers that are already connected on first
+  // entry to the scope and disconnects only those. They then re-enter the
+  // candidate set on the next render and reconnect fresh. Later changes
+  // to the connected set within the SAME scope (e.g. the user manually
   // connecting an additional server from the Servers tab) must not re-
   // fire this path, otherwise we'd tear down servers the user just
   // intentionally connected. The dedupe key is scope-only and we mark
   // attempted unconditionally on first run, so subsequent renders bail
-  // even if `connectedNamesToDisconnectKey` becomes non-null afterwards.
+  // even if `requiredConnectedNamesToDisconnectKey` becomes non-null
+  // afterwards.
   useEffect(() => {
-    if (!enabled || !projectId) return;
+    if (!enabled || !projectId || requiredNames.length === 0) return;
     if (isAttempted(projectId, scopeKey, "disconnect")) return;
     markAttempted(projectId, scopeKey, "disconnect");
-    if (!connectedNamesToDisconnectKey) return;
-    for (const name of connectedNamesToDisconnectKey.split("\0")) {
+    if (!requiredConnectedNamesToDisconnectKey) return;
+    for (const name of requiredConnectedNamesToDisconnectKey.split("\0")) {
       runtimeDisconnectServer(name);
     }
-    // `connectedNamesToDisconnectKey` is intentionally excluded from the
-    // dep array: this effect must fire only on scope transitions, not when
-    // the user's actions change the set of connected servers within the
-    // same scope. Reading the latest value via closure is fine because the
-    // dedupe gate stops re-runs.
+    // `requiredConnectedNamesToDisconnectKey` is intentionally excluded from
+    // the dep array: this effect must fire only on scope transitions, not
+    // when the user's actions change the set of connected servers within
+    // the same scope. Reading the latest value via closure is fine because
+    // the dedupe gate stops re-runs.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, projectId, scopeKey, runtimeDisconnectServer]);
+  }, [
+    enabled,
+    projectId,
+    scopeKey,
+    requiredNames.length,
+    runtimeDisconnectServer,
+  ]);
 
   // Connect-required: fires when the candidate set (required-but-not-yet-
   // connected) changes. Dedupe is per-server-within-scope, not per


### PR DESCRIPTION
## Summary
- make Playground auto-connect use the same effective/default host config that the UI renders
- keep auto-connect reconciliation from disconnecting servers outside the active host's required set, including empty required sets
- align Servers tab auto-connect project scope with the shared project id used by host preview reconciliation

## Validation
- npm exec -- vitest run src/hooks/__tests__/useAutoConnectProjectServers.test.tsx --config vitest.config.ts
- npm exec -- vitest run src/components/__tests__/ServersTab.test.tsx --config vitest.config.ts
- npm exec -- vitest run src/components/ui-playground/__tests__/PlaygroundMain.test.tsx --config vitest.config.ts
- npm --prefix mcpjam-inspector run typecheck:client

Related to MCPJam/inspector#2208.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-connect reconciliation/disconnect behavior across Playground and ServersTab, which can affect server connection lifecycle and user-selected connections. Risk is moderate due to behavioral changes in connection management, but scoped to client-side reconciliation and covered by updated tests.
> 
> **Overview**
> Playground auto-connect now derives required servers from the same *effective host config* the UI renders with (previewed host when selected, otherwise the project default `activeHost`), and uses the shared project id where available for consistent scoping.
> 
> `useAutoConnectProjectServers` no longer disconnects every connected server on host changes; it only recycles servers that are both **required by the active host** and currently connected, and treats *empty required sets* as a no-op (no disconnects and no selection clearing). Tests were updated to reflect the new disconnect/selection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f62788fb8d12ce2e60ee8f2ec0de7aa14aed10e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->