### PR TITLE
fix(clients): stack hosts header chrome on mobile

### DIFF
--- a/mcpjam-inspector/client/src/components/ClientsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ClientsTab.tsx
@@ -145,18 +145,12 @@ export function ClientsTab({
           >
             <ClientsConnectAddServerSlotContext.Provider value={addServerSlotEl}>
               <div
-                className="relative shrink-0 border-b border-border/40 px-8 py-2.5"
+                className="relative shrink-0 border-b border-border/40 px-4 py-2.5 md:px-8"
                 data-testid="hosts-tab-header-chrome"
               >
-                <div className="flex min-w-0 items-center justify-end gap-3">
-                  <div
-                    ref={setAddServerSlotEl}
-                    className="flex shrink-0 items-center gap-4"
-                    data-testid="hosts-tab-add-server-slot"
-                  />
-                </div>
-                <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-                  <div className="pointer-events-auto">
+                <div className="flex flex-col items-stretch gap-2 md:grid md:grid-cols-[1fr_auto_1fr] md:items-center md:gap-3">
+                  <div className="hidden md:block" aria-hidden="true" />
+                  <div className="flex min-w-0 justify-center">
                     <ViewModeSelector
                       value="servers"
                       ariaLabel="Connect view"
@@ -181,6 +175,11 @@ export function ClientsTab({
                       ]}
                     />
                   </div>
+                  <div
+                    ref={setAddServerSlotEl}
+                    className="flex min-w-0 flex-wrap items-center justify-center gap-3 md:justify-end"
+                    data-testid="hosts-tab-add-server-slot"
+                  />
                 </div>
               </div>
               <div


### PR DESCRIPTION
## Summary
- Replace the absolute-centered `ViewModeSelector` overlaid on top of the right-aligned action slot in `ClientsTab` with a single 3-column grid (`[1fr_auto_1fr]`) on md+ that stacks vertically below md.
- On mobile, the Servers/Client tabs now sit on their own row above the Auto-connect toggle + Add Server controls instead of overlapping them; outer padding drops to `px-4` for a bit more breathing room.
- Desktop layout is visually unchanged (tabs centered, controls right-aligned).

## Test plan
- [ ] Load `/servers` on a phone-width viewport — tabs and controls render on separate rows, no overlap.
- [ ] At md+ width, tabs are centered and Auto-connect + Add Server stay right-aligned.
- [ ] Switching between Servers and Client tabs still navigates correctly (no duplicate history entries).
- [ ] Add Server button still opens the add-server flow; Auto-connect toggle still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a layout-only change in `ClientsTab` to prevent mobile header overlap, with no data/auth logic changes.
> 
> **Overview**
> Adjusts the `ClientsTab` servers view header layout to avoid mobile overlap by replacing the absolute-centered `ViewModeSelector` overlay with a responsive stacked layout (vertical on small screens, `md` 3-column grid with centered tabs and right-aligned controls).
> 
> Also reduces small-screen horizontal padding (`px-8` → `px-4 md:px-8`) and updates the action-slot container to wrap/center on mobile while preserving the desktop alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59c11527f4b5ebfc8b522e37ad576c0872abf584. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->