### PR TITLE
[codex] fix UI stream finish chunks

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/ClientsTab.header-chrome.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ClientsTab.header-chrome.test.tsx
@@ -71,11 +71,13 @@ describe("ClientsTab", () => {
 
     const chrome = screen.getByTestId("hosts-tab-header-chrome");
     expect(chrome).toHaveClass(
+      "relative",
       "shrink-0",
       "border-b",
       "border-border/40",
-      "px-8",
+      "px-4",
       "py-2.5",
+      "md:px-8",
     );
   });
 });

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -602,6 +602,11 @@ describe("mcpjam-stream-handler", () => {
             outputTokens: 5,
             totalTokens: 15,
           },
+          totalUsage: {
+            inputTokens: 999,
+            outputTokens: 999,
+            totalTokens: 1998,
+          },
         },
       ])
     );
@@ -643,6 +648,18 @@ describe("mcpjam-stream-handler", () => {
       outputTokens: 5,
       totalTokens: 15,
     });
+
+    const finishChunk = writtenChunks.find((chunk) => chunk?.type === "finish");
+    expect(finishChunk).toMatchObject({
+      type: "finish",
+      finishReason: "stop",
+      messageMetadata: {
+        inputTokens: 10,
+        outputTokens: 5,
+        totalTokens: 15,
+      },
+    });
+    expect(finishChunk).not.toHaveProperty("totalUsage");
   });
 
   it("flushes buffered hosted rpc logs first and streams live hosted rpc logs as data parts", async () => {

--- a/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts
@@ -662,6 +662,99 @@ describe("mcpjam-stream-handler", () => {
     expect(finishChunk).not.toHaveProperty("totalUsage");
   });
 
+  it("aggregates usage across steps when emitting the final UI finish chunk", async () => {
+    const stepOne = [
+      {
+        type: "tool-input-available",
+        toolCallId: "call-1",
+        toolName: "read_docs",
+        input: { topic: "latency" },
+      },
+      {
+        type: "finish",
+        finishReason: "stop",
+        messageMetadata: { inputTokens: 3, outputTokens: 4, totalTokens: 7 },
+      },
+    ];
+    const stepTwo = [
+      { type: "text-start", id: "text-1" },
+      { type: "text-delta", id: "text-1", delta: "ok" },
+      { type: "text-end", id: "text-1" },
+      {
+        type: "finish",
+        finishReason: "stop",
+        messageMetadata: {
+          inputTokens: 10,
+          outputTokens: 5,
+          totalTokens: 15,
+        },
+      },
+    ];
+    let call = 0;
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const events = call === 0 ? stepOne : stepTwo;
+      call += 1;
+      return createSseResponse(events);
+    });
+    vi.mocked(hasUnresolvedToolCalls).mockImplementation(
+      (messages) =>
+        messages.some(
+          (message: any) =>
+            message?.role === "assistant" &&
+            Array.isArray(message.content) &&
+            message.content.some((part: any) => part.type === "tool-call")
+        ) && !messages.some((message: any) => message?.role === "tool")
+    );
+    vi.mocked(executeToolCallsFromMessages).mockImplementation(
+      async (messages: any[]) => {
+        const toolResultMessage = {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-1",
+              toolName: "read_docs",
+              output: { type: "json", value: { ok: true } },
+              result: { ok: true },
+              serverId: "docs-server",
+            },
+          ],
+        };
+        messages.splice(2, 0, toolResultMessage);
+        return [toolResultMessage] as any;
+      }
+    );
+
+    await handleMCPJamFreeChatModel({
+      messages: [{ role: "user", content: "Fetch the docs" }] as any,
+      modelId: "openai/gpt-5-mini",
+      systemPrompt: "You are helpful",
+      tools: {
+        read_docs: { _serverId: "docs-server" },
+      } as any,
+      mcpClientManager: {
+        getAllToolsMetadata: vi.fn().mockReturnValue({ read_docs: {} }),
+      } as any,
+    });
+
+    await lastExecution;
+
+    const finishChunks = writtenChunks.filter(
+      (chunk) => chunk?.type === "finish"
+    );
+    expect(finishChunks).toHaveLength(1);
+    expect(finishChunks[0]).toMatchObject({
+      type: "finish",
+      finishReason: "stop",
+      messageMetadata: {
+        inputTokens: 13,
+        outputTokens: 9,
+        totalTokens: 22,
+      },
+    });
+    expect(finishChunks[0]).not.toHaveProperty("totalUsage");
+  });
+
   it("flushes buffered hosted rpc logs first and streams live hosted rpc logs as data parts", async () => {
     let resolveFetch: ((response: Response) => void) | undefined;
     global.fetch = vi.fn().mockImplementation(

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -330,21 +330,19 @@ function readUsageFromFinishChunk(
 
 function createClientFinishChunk(
   finishChunk: UIMessageChunk | null,
+  traceTurn: LiveTraceTurnContext | null,
   fallbackReason: "length" | "stop"
 ): UIMessageChunk {
   type FinishUIMessageChunk = Extract<UIMessageChunk, { type: "finish" }>;
-  const source = finishChunk as
-    | (Partial<FinishUIMessageChunk> & {
-        totalUsage?: {
-          inputTokens?: number;
-          outputTokens?: number;
-          totalTokens?: number;
-        };
-      })
-    | null;
-  const usage = finishChunk
-    ? readUsageFromFinishChunk(finishChunk)
-    : { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  const source = finishChunk as Partial<FinishUIMessageChunk> | null;
+  // Prefer the turn-level aggregate so multi-step (tool-call) turns report the
+  // sum across all LLM calls, not just the final step.
+  const aggregateUsage = traceTurn?.turnUsage;
+  const usage =
+    aggregateUsage ??
+    (finishChunk
+      ? readUsageFromFinishChunk(finishChunk)
+      : { inputTokens: 0, outputTokens: 0, totalTokens: 0 });
   const metadata = source?.messageMetadata;
   const messageMetadata =
     metadata &&
@@ -1211,7 +1209,7 @@ async function processOneStep(
       );
       emitTraceSnapshot(writer, messageHistory, tools, traceTurn);
       if (finishChunk) {
-        writer.write(createClientFinishChunk(finishChunk, "stop"));
+        writer.write(createClientFinishChunk(finishChunk, traceTurn, "stop"));
       }
       return { shouldContinue: false, didEmitFinish: !!finishChunk };
     }
@@ -1382,7 +1380,7 @@ async function processOneStep(
   // No more tool calls - emit finish and stop
   const didEmitFinish = !!finishChunk;
   if (finishChunk) {
-    writer.write(createClientFinishChunk(finishChunk, "stop"));
+    writer.write(createClientFinishChunk(finishChunk, traceTurn, "stop"));
   }
 
   // We're done with this conversation turn
@@ -1513,6 +1511,7 @@ export async function handleMCPJamFreeChatModel(
           writer.write(
             createClientFinishChunk(
               null,
+              traceTurn,
               steps >= MAX_STEPS ? "length" : "stop"
             )
           );

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -309,7 +309,7 @@ function readUsageFromFinishChunk(
       totalTokens?: number;
     };
   };
-  const usage = chunk.totalUsage ?? chunk.messageMetadata;
+  const usage = chunk.messageMetadata ?? chunk.totalUsage;
   if (!usage) {
     return undefined;
   }
@@ -326,6 +326,39 @@ function readUsageFromFinishChunk(
   }
 
   return Object.keys(next).length > 0 ? next : undefined;
+}
+
+function createClientFinishChunk(
+  finishChunk: UIMessageChunk | null,
+  fallbackReason: "length" | "stop"
+): UIMessageChunk {
+  type FinishUIMessageChunk = Extract<UIMessageChunk, { type: "finish" }>;
+  const source = finishChunk as
+    | (Partial<FinishUIMessageChunk> & {
+        totalUsage?: {
+          inputTokens?: number;
+          outputTokens?: number;
+          totalTokens?: number;
+        };
+      })
+    | null;
+  const usage = finishChunk
+    ? readUsageFromFinishChunk(finishChunk)
+    : { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  const metadata = source?.messageMetadata;
+  const messageMetadata =
+    metadata &&
+    typeof metadata === "object" &&
+    !Array.isArray(metadata) &&
+    usage
+      ? { ...metadata, ...usage }
+      : metadata ?? usage;
+
+  return {
+    type: "finish",
+    finishReason: source?.finishReason ?? fallbackReason,
+    ...(messageMetadata != null ? { messageMetadata } : {}),
+  } as UIMessageChunk;
 }
 
 function setStepSpanMessageRanges(
@@ -1178,7 +1211,7 @@ async function processOneStep(
       );
       emitTraceSnapshot(writer, messageHistory, tools, traceTurn);
       if (finishChunk) {
-        writer.write(finishChunk);
+        writer.write(createClientFinishChunk(finishChunk, "stop"));
       }
       return { shouldContinue: false, didEmitFinish: !!finishChunk };
     }
@@ -1349,7 +1382,7 @@ async function processOneStep(
   // No more tool calls - emit finish and stop
   const didEmitFinish = !!finishChunk;
   if (finishChunk) {
-    writer.write(finishChunk);
+    writer.write(createClientFinishChunk(finishChunk, "stop"));
   }
 
   // We're done with this conversation turn
@@ -1477,11 +1510,12 @@ export async function handleMCPJamFreeChatModel(
 
         // Safety: ensure we always emit a finish event
         if (!finishEmitted) {
-          writer.write({
-            type: "finish",
-            finishReason: steps >= MAX_STEPS ? "length" : "stop",
-            totalUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-          } as unknown as UIMessageChunk);
+          writer.write(
+            createClientFinishChunk(
+              null,
+              steps >= MAX_STEPS ? "length" : "stop"
+            )
+          );
           finishEmitted = true;
         }
 


### PR DESCRIPTION
## Summary

Fixes invalid AI SDK UI stream `finish` chunks emitted by the MCPJam model stream forwarder.

The browser-side AI SDK transport validates UI message chunks with a strict schema. The inspector was forwarding or synthesizing `finish` chunks with a top-level `totalUsage` field, which is present on core `streamText` finish parts but is not valid on UI message stream chunks. This caused the client to render a validation error instead of completing the assistant response.

## Changes

- Convert upstream `finish.totalUsage` into `finish.messageMetadata` before writing the chunk to the client.
- Preserve `messageMetadata` as the canonical UI-stream location for usage metadata.
- Update the stream-handler regression test to cover an upstream chunk that includes both `messageMetadata` and legacy `totalUsage`, and assert that the emitted client chunk omits top-level `totalUsage`.

## Validation

- `npm --prefix mcpjam-inspector run test -- server/utils/__tests__/mcpjam-stream-handler.test.ts`
- `npm --prefix sdk run build`
- `npm --prefix mcpjam-inspector run build:server`
- `npx --prefix mcpjam-inspector prettier --check mcpjam-inspector/server/utils/mcpjam-stream-handler.ts mcpjam-inspector/server/utils/__tests__/mcpjam-stream-handler.test.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the server-side streaming protocol for `finish` chunks (usage fields and emission timing), which could affect client completion/rendering if mismatched, though covered by updated regression tests.
> 
> **Overview**
> Fixes the MCPJam stream forwarder to emit **AI SDK schema-compliant** UI `finish` chunks by converting any upstream `totalUsage` into `messageMetadata` and never sending top-level `totalUsage` to the browser.
> 
> Adds `createClientFinishChunk` so the final emitted `finish` uses the **turn-level aggregated usage** (summing multi-step/tool-call turns) with a safe fallback when a finish chunk wasn’t received. Updates stream-handler tests to cover mixed `messageMetadata`+`totalUsage`, verify `totalUsage` is stripped, and validate usage aggregation across steps.
> 
> Also updates the `ClientsTab` chrome spacing test to match new responsive padding classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abdd5681447d9207f00b2d4ec19a7a4e63edef9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->