### PR TITLE
Hide multi-model + multi-host compare in shared sessions

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -1161,12 +1161,16 @@ export function ChatTabV2({
     selectedModel,
     selectedModelIds,
   ]);
+  // Shared (project-visible) sessions are collaborative artifacts; the
+  // multi-model toggle would mutate session state for every collaborator,
+  // so it's hidden in that scope. Single-model selection stays available.
   const canEnableMultiModel =
     enableMultiModelChat &&
     !minimalMode &&
     !executionConfig?.modelId &&
     !hostedChatboxId &&
     !hostedChatboxSurface &&
+    pendingDirectVisibility !== "project" &&
     availableModels.length > 1;
   // When viewing a history session, fall back to single-model rendering so
   // the ChatTabV2 messages (which hold the hydrated transcript) are displayed.

--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
@@ -233,13 +233,16 @@ vi.mock("@/components/chat-v2/chat-input", () => ({
   ChatInput: ({
     value,
     onChange,
+    enableMultiModel,
   }: {
     value: string;
     onChange: (value: string) => void;
+    enableMultiModel?: boolean;
   }) => (
     <input
       aria-label="Chat input"
       data-testid="chat-input"
+      data-enable-multi-model={enableMultiModel ? "true" : "false"}
       value={value}
       onChange={(event) => onChange(event.target.value)}
     />
@@ -761,6 +764,64 @@ describe("ChatTabV2 history sync", () => {
       "project"
     );
     expect(mockGetChatHistoryDetail).not.toHaveBeenCalled();
+  });
+
+  it("hides the multi-model toggle when the active thread is shared", async () => {
+    mockUseChatSession.availableModels = [
+      { id: "openai/gpt-5-mini", name: "GPT-5 Mini", provider: "openai" },
+      {
+        id: "anthropic/claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        provider: "anthropic",
+      },
+    ];
+    const privateDetailResponse = {
+      ok: true,
+      session: {
+        ...mockHistorySession,
+        directVisibility: "private" as const,
+        messagesBlobUrl: "https://storage.test/blob",
+        resumeConfig: { selectedServers: ["server-1"] },
+      },
+      widgetSnapshots: [],
+    };
+    const sharedDetailResponse = {
+      ...privateDetailResponse,
+      session: {
+        ...privateDetailResponse.session,
+        directVisibility: "project" as const,
+        version: 5,
+      },
+    };
+    mockGetChatHistoryDetail
+      .mockResolvedValueOnce(privateDetailResponse)
+      .mockResolvedValueOnce(sharedDetailResponse);
+
+    render(<ChatTabV2 {...defaultProps} enableMultiModelChat={true} />);
+
+    expect(screen.getByTestId("chat-input")).toHaveAttribute(
+      "data-enable-multi-model",
+      "true",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Show sessions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select thread" }));
+    await flushMicrotasks();
+
+    expect(screen.getByTestId("chat-input")).toHaveAttribute(
+      "data-enable-multi-model",
+      "true",
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Share active thread" }),
+    );
+    await flushMicrotasks();
+
+    expect(screen.getByTestId("chat-input")).toHaveAttribute(
+      "data-enable-multi-model",
+      "false",
+    );
   });
 
   it("keeps direct visibility in sync when the active thread is shared", async () => {

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -1179,6 +1179,17 @@ export function PlaygroundMain({
       isPreparingServerForSend,
   });
 
+  // Mirror of the `canEnableMultiModel` cleanup below: when the multi-host
+  // gate flips false (host count drops, or the session becomes shared) and
+  // the persisted `multiHostEnabled` is still true, reset it. Without this,
+  // a user who had compare on in a private session would silently re-enter
+  // compare the next time `canEnableMultiHost` flips back to true.
+  useEffect(() => {
+    if (!canEnableMultiHost && multiHostEnabled) {
+      setMultiHostEnabled(false);
+    }
+  }, [canEnableMultiHost, multiHostEnabled, setMultiHostEnabled]);
+
   useEffect(() => {
     if (!canEnableMultiModel && multiModelEnabled) {
       setMultiModelEnabled(false);

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -383,6 +383,11 @@ export function PlaygroundMain({
   const [pendingDirectVisibility, setPendingDirectVisibility] = useState<
     "private" | "project"
   >("private");
+  // Shared (project-visible) sessions are collaborative artifacts. Treat
+  // multi-model and multi-host compare as experiment-mode controls that
+  // would mutate the shared session state for every collaborator, and
+  // hide them. The single-model + single-host path stays usable.
+  const isSharedSession = pendingDirectVisibility === "project";
   // ChatTabV2 holds this at 0 today; bumping after each completed turn is a
   // follow-up. The rail re-fetches on initial mount + whenever signal changes.
   const historyRefreshSignal = 0;
@@ -813,7 +818,7 @@ export function PlaygroundMain({
     return selectedModel ? [selectedModel] : [];
   }, [multiModelAvailableModels, selectedModel, selectedModelIds]);
   const canEnableMultiModel =
-    enableMultiModelChat && availableModels.length > 1;
+    enableMultiModelChat && availableModels.length > 1 && !isSharedSession;
 
   // Phase 4 (multi-host plan): read multi-host state in parallel to
   // multi-model. Lead host is derived inside `usePersistedHost` from the
@@ -853,7 +858,7 @@ export function PlaygroundMain({
         .filter((host): host is HostDetail => host !== null),
     [hostSlots, selectedHostIds.length],
   );
-  const canEnableMultiHost = hostList.length > 1;
+  const canEnableMultiHost = hostList.length > 1 && !isSharedSession;
 
   // Lead identity check — we cannot compact away the lead slot. If
   // `selectedHostIds[0]` is still loading from Convex, the resolved
@@ -3029,14 +3034,16 @@ export function PlaygroundMain({
             // change the playground render path (that lands in Phase 4).
             // The global `GlobalClientBar` remains the host pill for other
             // tabs; both surfaces stay in sync via shared `usePreviewedHostId`.
-            <PlaygroundHostPicker
-              projectId={multiHostProjectId}
-              selectedHostIds={selectedHostIds}
-              multiHostEnabled={multiHostEnabled}
-              onSelectedHostIdsChange={setSelectedHostIds}
-              onMultiHostEnabledChange={handleMultiHostEnabledChange}
-              onPromoteLead={handlePromoteLead}
-            />
+            isSharedSession ? null : (
+              <PlaygroundHostPicker
+                projectId={multiHostProjectId}
+                selectedHostIds={selectedHostIds}
+                multiHostEnabled={multiHostEnabled}
+                onSelectedHostIdsChange={setSelectedHostIds}
+                onMultiHostEnabledChange={handleMultiHostEnabledChange}
+                onPromoteLead={handlePromoteLead}
+              />
+            )
           }
           trailing={
             effectiveHasMessages ? (

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -681,6 +681,79 @@ describe("PlaygroundMain", () => {
       expect(mockUseChatSession.resetChat).toHaveBeenCalled();
     });
 
+    it("hides the multi-host compare picker after the active session is shared", async () => {
+      const privateSessionLocal = {
+        _id: "history-share-gate-1",
+        chatSessionId: "chat-session-share-gate-1",
+        firstMessagePreview: "Hello",
+        status: "active" as const,
+        directVisibility: "private" as const,
+        messageCount: 2,
+        version: 4,
+        startedAt: 1,
+        lastActivityAt: 1,
+        isPinned: false,
+        manualUnread: false,
+        isUnread: false,
+        messagesBlobUrl: "https://storage.test/blob",
+        resumeConfig: { selectedServers: ["test-server"] },
+      };
+      const sharedSessionLocal = {
+        ...privateSessionLocal,
+        directVisibility: "project" as const,
+        version: 5,
+      };
+      mockGetChatHistoryDetail
+        .mockResolvedValueOnce({
+          ok: true,
+          session: privateSessionLocal,
+          widgetSnapshots: [],
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          session: sharedSessionLocal,
+          widgetSnapshots: [],
+        });
+
+      render(<PlaygroundMain {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(usePlaygroundChatHistoryBridgeStore.getState().bridge).not.toBe(
+          null,
+        );
+      });
+
+      // Private sessions show the host picker by default.
+      expect(
+        screen.getByTestId("playground-host-picker-stub"),
+      ).toBeInTheDocument();
+
+      await act(async () => {
+        const bridge = usePlaygroundChatHistoryBridgeStore.getState().bridge;
+        await Promise.resolve(bridge?.onSelectThread(privateSessionLocal));
+      });
+      await waitFor(() => {
+        expect(capturedChatSessionOptions.directVisibility).toBe("private");
+      });
+
+      await act(async () => {
+        const bridge = usePlaygroundChatHistoryBridgeStore.getState().bridge;
+        await Promise.resolve(
+          bridge?.onSessionAction?.({
+            action: "share",
+            session: privateSessionLocal,
+          }),
+        );
+      });
+
+      await waitFor(() => {
+        expect(capturedChatSessionOptions.directVisibility).toBe("project");
+      });
+      expect(
+        screen.queryByTestId("playground-host-picker-stub"),
+      ).toBeNull();
+    });
+
     it("keeps active playground thread visibility in sync after sharing", async () => {
       const privateSession = {
         _id: "history-1",


### PR DESCRIPTION
## Summary
- Shared (project-visible) sessions are collaborative — flipping "Multiple models" or entering multi-host compare from one viewer would mutate experiment state for every collaborator. Hide both affordances when `pendingDirectVisibility === "project"`.
- Single-model selection + single-host playground stay fully usable; only the compare/experiment toggles disappear.
- Applied to both surfaces that already track `pendingDirectVisibility`: `PlaygroundMain` (gates `canEnableMultiModel`, `canEnableMultiHost`, and stops rendering `PlaygroundHostPicker` in the center header) and `ChatTabV2` (gates `canEnableMultiModel`).

## Why not also add a "Fork to private" button?
Considered, but there's no backend session-duplicate endpoint to lean on yet — adding fork is a separate feature. This PR ships the smallest defensible change: hide the experiment toggles. If/when fork lands, the same `isSharedSession` flag is the right gate to add it next to.

## Test plan
- [x] `npm run typecheck:client` passes
- [x] `vitest run client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx` (57/57)
- [x] `vitest run client/src/components/__tests__/ChatTabV2.history-sync.test.tsx` (14/14)
- [x] Two new tests assert the gates flip on transition: PlaygroundMain hides `PlaygroundHostPicker` and ChatTabV2 flips `enableMultiModel` to `false` once a session is shared.
- [ ] Manual: open a private session, confirm Compare + Multiple-models work. Share the session via the rail action, confirm both controls disappear. Reload — still hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI gating change that only affects whether compare toggles render/auto-reset based on `directVisibility`; main risk is unexpected state resets when a session transitions to shared.
> 
> **Overview**
> Prevents collaborative (project-visible) threads from exposing experiment/compare controls that would mutate shared session state for all collaborators.
> 
> `ChatTabV2` now disables the multi-model toggle when `pendingDirectVisibility === "project"`, and `PlaygroundMain` similarly gates multi-model and multi-host compare, hides the `PlaygroundHostPicker`, and resets `multiHostEnabled` when the gate turns off. Adds targeted tests to verify the toggles/picker disappear when a private session is shared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b6850c172e4eb012b59e4460fca5c0ad5e305f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->