### PR TITLE
Unify app view saves on mcpAppViews + fix ui:// fallback

### DIFF
--- a/mcpjam-inspector/client/src/hooks/useSaveView.ts
+++ b/mcpjam-inspector/client/src/hooks/useSaveView.ts
@@ -9,6 +9,7 @@ import {
   type ServerInfo,
 } from "./useViews";
 import { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
+import { synthesizeFallbackResourceUri } from "@/lib/mcp-ui/synthesize-fallback-uri";
 import { useCurrentDisplayContext } from "@/lib/display-context-utils";
 
 // Data extracted from ToolPart for saving
@@ -232,14 +233,24 @@ export function useSaveView({
           : undefined;
 
         // Canonical fallback URI is `ui://` per SEP-1865. The previous
-        // `mcp://` fallback was a SEP violation and is what motivates
-        // the paired backend Phase A loosening; once that ships we can
-        // tighten the server back to a hard reject.
-        const fallbackResourceUri = `ui://mcpjam/${serverName}/${toolData.toolName}`;
+        // `mcp://` fallback was a SEP violation; this form is also
+        // collision-safe (uses the immutable `serverId` rather than
+        // the display `serverName`) and URI-safe (`toolName` is hashed
+        // so spaces, slashes, and other unescaped characters cannot
+        // produce ambiguous paths). Two saves of the same tool on the
+        // same server are idempotent because the hash is
+        // deterministic.
+        const fallbackResourceUri = synthesizeFallbackResourceUri({
+          serverId,
+          toolName: toolData.toolName,
+        });
+        const liveOutputTemplate = toolData.outputTemplate?.trim();
+        const liveOutputTemplateIsUi =
+          !!liveOutputTemplate && liveOutputTemplate.startsWith("ui://");
         const resourceUri =
           toolData.resourceUri ||
-          (toolData.outputTemplate?.startsWith("ui://")
-            ? toolData.outputTemplate
+          (liveOutputTemplateIsUi
+            ? liveOutputTemplate!
             : fallbackResourceUri);
 
         const isOpenAIOrigin = protocol === "openai-apps";
@@ -252,8 +263,16 @@ export function useSaveView({
           widgetPermissions: toolData.widgetPermissions,
           widgetPermissive: toolData.widgetPermissive,
           widgetHtmlBlobId,
-          // Legacy aliases (input-only on the backend normalizer):
-          outputTemplate: isOpenAIOrigin ? toolData.outputTemplate : undefined,
+          // Legacy aliases (input-only on the backend normalizer). The
+          // backend validates `outputTemplate` whenever it is supplied,
+          // even when `resourceUri` wins precedence, so we only
+          // forward it when it is itself spec-compliant. A non-ui://
+          // OpenAI template (e.g. `https://...`) is dropped on the
+          // floor here — the canonical `resourceUri` is what matters.
+          outputTemplate:
+            isOpenAIOrigin && liveOutputTemplateIsUi
+              ? liveOutputTemplate
+              : undefined,
           serverInfo: isOpenAIOrigin ? toolData.serverInfo : undefined,
           // Documentation-only provenance:
           viewOriginProtocol: isOpenAIOrigin ? "openai-apps" : "mcp-apps",

--- a/mcpjam-inspector/client/src/hooks/useSaveView.ts
+++ b/mcpjam-inspector/client/src/hooks/useSaveView.ts
@@ -78,12 +78,9 @@ export function useSaveView({
   // Get current display context from shared utility
   const currentDisplayContext = useCurrentDisplayContext();
 
-  const {
-    createMcpView,
-    createOpenaiView,
-    generateMcpUploadUrl,
-    generateOpenaiUploadUrl,
-  } = useViewMutations();
+  // `createMcpView` is now the only write path; the OpenAI mutation is
+  // kept on the hook for legacy read/delete callers only.
+  const { createMcpView, generateMcpUploadUrl } = useViewMutations();
 
   const { serversByName } = useProjectServers({
     isAuthenticated,
@@ -118,24 +115,17 @@ export function useSaveView({
     [serversByName, projectId, createServer],
   );
 
-  // Upload output blob to Convex storage
+  // Upload output blob to Convex storage. The protocol arg is kept on
+  // the signature for compatibility with callers but the upload URL
+  // now always comes from the canonical mcpAppViews path.
   const uploadOutputBlob = useCallback(
-    async (
-      output: unknown,
-      protocol: "mcp-apps" | "openai-apps",
-    ): Promise<string> => {
-      // Generate upload URL based on protocol
-      const uploadUrl =
-        protocol === "mcp-apps"
-          ? await generateMcpUploadUrl({})
-          : await generateOpenaiUploadUrl({});
+    async (output: unknown): Promise<string> => {
+      const uploadUrl = await generateMcpUploadUrl({});
 
-      // Create blob from output
       const blob = new Blob([JSON.stringify(output)], {
         type: "application/json",
       });
 
-      // Upload blob
       const response = await fetch(uploadUrl, {
         method: "POST",
         body: blob,
@@ -148,27 +138,18 @@ export function useSaveView({
       const result = await response.json();
       return result.storageId;
     },
-    [generateMcpUploadUrl, generateOpenaiUploadUrl],
+    [generateMcpUploadUrl],
   );
 
-  // Upload widget HTML blob to Convex storage (for offline rendering)
+  // Upload widget HTML blob to Convex storage (for offline rendering).
   const uploadWidgetHtmlBlob = useCallback(
-    async (
-      html: string,
-      protocol: "mcp-apps" | "openai-apps",
-    ): Promise<string> => {
-      // Both MCP and OpenAI apps now support widget HTML caching
-      const uploadUrl =
-        protocol === "mcp-apps"
-          ? await generateMcpUploadUrl({})
-          : await generateOpenaiUploadUrl({});
+    async (html: string): Promise<string> => {
+      const uploadUrl = await generateMcpUploadUrl({});
 
-      // Create blob from HTML
       const blob = new Blob([html], {
         type: "text/html",
       });
 
-      // Upload blob
       const response = await fetch(uploadUrl, {
         method: "POST",
         body: blob,
@@ -181,7 +162,7 @@ export function useSaveView({
       const result = await response.json();
       return result.storageId;
     },
-    [generateMcpUploadUrl, generateOpenaiUploadUrl],
+    [generateMcpUploadUrl],
   );
 
   // Save view
@@ -208,18 +189,12 @@ export function useSaveView({
         const serverId = await getOrCreateServerId(serverName);
 
         // Upload output blob
-        const toolOutputBlobId = await uploadOutputBlob(
-          toolData.output,
-          protocol,
-        );
+        const toolOutputBlobId = await uploadOutputBlob(toolData.output);
 
         // Upload widget HTML blob (for offline rendering - both MCP and OpenAI apps)
         let widgetHtmlBlobId: string | undefined;
         if (toolData.widgetHtml) {
-          widgetHtmlBlobId = await uploadWidgetHtmlBlob(
-            toolData.widgetHtml,
-            protocol,
-          );
+          widgetHtmlBlobId = await uploadWidgetHtmlBlob(toolData.widgetHtml);
         }
 
         // Prepare base args
@@ -240,42 +215,49 @@ export function useSaveView({
           toolMetadata: toolData.toolMetadata,
         };
 
-        let viewId: string;
+        // Unified save path per SEP-1865 (MCP Apps, Stable 2026-01-26):
+        // all writes go through `mcpAppViews:create`. OpenAI-origin
+        // tool results pass `outputTemplate` as a legacy alias which
+        // the backend normalizer maps to `resourceUri`. Renderer
+        // choice at read time is driven by `injectedOpenAiCompat` and
+        // `detectUIType(toolMetadata)` — never by a protocol field.
+        const rawCsp = toolData.widgetDebugInfo?.csp;
+        const filteredWidgetCsp = rawCsp
+          ? {
+              connectDomains: rawCsp.connectDomains,
+              resourceDomains: rawCsp.resourceDomains,
+              frameDomains: rawCsp.frameDomains,
+              baseUriDomains: rawCsp.baseUriDomains,
+            }
+          : undefined;
 
-        if (protocol === "mcp-apps") {
-          // Filter widgetCsp to only include schema-allowed fields
-          // (excludes runtime debug data like mode, violations, widgetDeclared)
-          const rawCsp = toolData.widgetDebugInfo?.csp;
-          const filteredWidgetCsp = rawCsp
-            ? {
-                connectDomains: rawCsp.connectDomains,
-                resourceDomains: rawCsp.resourceDomains,
-                frameDomains: rawCsp.frameDomains,
-                baseUriDomains: rawCsp.baseUriDomains,
-              }
-            : undefined;
+        // Canonical fallback URI is `ui://` per SEP-1865. The previous
+        // `mcp://` fallback was a SEP violation and is what motivates
+        // the paired backend Phase A loosening; once that ships we can
+        // tighten the server back to a hard reject.
+        const fallbackResourceUri = `ui://mcpjam/${serverName}/${toolData.toolName}`;
+        const resourceUri =
+          toolData.resourceUri ||
+          (toolData.outputTemplate?.startsWith("ui://")
+            ? toolData.outputTemplate
+            : fallbackResourceUri);
 
-          // MCP-specific save
-          viewId = await createMcpView({
-            ...baseArgs,
-            resourceUri:
-              toolData.resourceUri ||
-              `mcp://${serverName}/${toolData.toolName}`,
-            toolsMetadata: toolData.toolsMetadata,
-            widgetCsp: filteredWidgetCsp,
-            widgetPermissions: toolData.widgetPermissions,
-            widgetPermissive: toolData.widgetPermissive,
-            widgetHtmlBlobId, // Include cached widget HTML for offline rendering
-          });
-        } else {
-          // OpenAI-specific save
-          viewId = await createOpenaiView({
-            ...baseArgs,
-            outputTemplate: toolData.outputTemplate || "",
-            serverInfo: toolData.serverInfo,
-            widgetHtmlBlobId, // Include cached widget HTML for offline rendering
-          });
-        }
+        const isOpenAIOrigin = protocol === "openai-apps";
+
+        const viewId: string = await createMcpView({
+          ...baseArgs,
+          resourceUri,
+          toolsMetadata: toolData.toolsMetadata,
+          widgetCsp: filteredWidgetCsp,
+          widgetPermissions: toolData.widgetPermissions,
+          widgetPermissive: toolData.widgetPermissive,
+          widgetHtmlBlobId,
+          // Legacy aliases (input-only on the backend normalizer):
+          outputTemplate: isOpenAIOrigin ? toolData.outputTemplate : undefined,
+          serverInfo: isOpenAIOrigin ? toolData.serverInfo : undefined,
+          // Documentation-only provenance:
+          viewOriginProtocol: isOpenAIOrigin ? "openai-apps" : "mcp-apps",
+        });
 
         toast.success(`View "${formData.name}" saved successfully`);
         return viewId;
@@ -296,7 +278,6 @@ export function useSaveView({
       uploadOutputBlob,
       uploadWidgetHtmlBlob,
       createMcpView,
-      createOpenaiView,
     ],
   );
 

--- a/mcpjam-inspector/client/src/hooks/useSaveView.ts
+++ b/mcpjam-inspector/client/src/hooks/useSaveView.ts
@@ -9,7 +9,10 @@ import {
   type ServerInfo,
 } from "./useViews";
 import { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
-import { synthesizeFallbackResourceUri } from "@/lib/mcp-ui/synthesize-fallback-uri";
+import {
+  resolveCanonicalResourceUri,
+  synthesizeFallbackResourceUri,
+} from "@/lib/mcp-ui/synthesize-fallback-uri";
 import { useCurrentDisplayContext } from "@/lib/display-context-utils";
 
 // Data extracted from ToolPart for saving
@@ -247,11 +250,17 @@ export function useSaveView({
         const liveOutputTemplate = toolData.outputTemplate?.trim();
         const liveOutputTemplateIsUi =
           !!liveOutputTemplate && liveOutputTemplate.startsWith("ui://");
-        const resourceUri =
-          toolData.resourceUri ||
-          (liveOutputTemplateIsUi
-            ? liveOutputTemplate!
-            : fallbackResourceUri);
+        // `toolData.resourceUri` comes from `getUIResourceUri()` in
+        // part-switch.tsx, which for OpenAI-origin tools returns the
+        // raw `openai/outputTemplate` value verbatim — any scheme. We
+        // must gate on `ui://` here, otherwise a non-compliant
+        // template like `https://...` lands in the canonical column
+        // bypassing the fallback synthesizer entirely.
+        const resourceUri = resolveCanonicalResourceUri({
+          candidate: toolData.resourceUri,
+          legacyOutputTemplate: liveOutputTemplate,
+          fallback: fallbackResourceUri,
+        });
 
         const isOpenAIOrigin = protocol === "openai-apps";
 

--- a/mcpjam-inspector/client/src/hooks/useViews.ts
+++ b/mcpjam-inspector/client/src/hooks/useViews.ts
@@ -171,7 +171,11 @@ export function useViewMutations() {
     "mcpAppViews:generateUploadUrl" as any,
   );
 
-  // OpenAI mutations
+  // OpenAI mutations (legacy table). New writes MUST go through
+  // `createMcpView` per SEP-1865; these stay registered only so the
+  // inspector can list and delete pre-backfill rows during the
+  // transition. After `migrations/backfillOpenaiAppViews` finishes and
+  // the table is drained, these will be removed in a cleanup PR.
   const createOpenaiView = useMutation("openaiAppViews:create" as any);
   const updateOpenaiView = useMutation("openaiAppViews:update" as any);
   const removeOpenaiView = useMutation("openaiAppViews:remove" as any);

--- a/mcpjam-inspector/client/src/lib/mcp-ui/__tests__/synthesize-fallback-uri.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcp-ui/__tests__/synthesize-fallback-uri.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import {
+  synthesizeFallbackResourceUri,
+  djb2Hex16,
+} from "../synthesize-fallback-uri";
+
+describe("synthesizeFallbackResourceUri", () => {
+  it("uses ui:// scheme per SEP-1865", () => {
+    const uri = synthesizeFallbackResourceUri({
+      serverId: "srv_abc",
+      toolName: "fetch-weather",
+    });
+    expect(uri.startsWith("ui://")).toBe(true);
+  });
+
+  it("is namespaced under inspector + serverId so two servers cannot forge each other's URIs", () => {
+    const a = synthesizeFallbackResourceUri({
+      serverId: "srv_a",
+      toolName: "tool",
+    });
+    const b = synthesizeFallbackResourceUri({
+      serverId: "srv_b",
+      toolName: "tool",
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("is deterministic — same inputs hash to the same URI", () => {
+    const a = synthesizeFallbackResourceUri({
+      serverId: "srv_1",
+      toolName: "fetch-weather",
+    });
+    const b = synthesizeFallbackResourceUri({
+      serverId: "srv_1",
+      toolName: "fetch-weather",
+    });
+    expect(a).toBe(b);
+  });
+
+  it("handles tool names with spaces / slashes / special characters without producing ambiguous paths", () => {
+    // Two distinct tool names that would have collapsed under a
+    // naive `${serverName}/${toolName}` join must hash to different
+    // segments here.
+    const a = synthesizeFallbackResourceUri({
+      serverId: "srv_1",
+      toolName: "fetch weather",
+    });
+    const b = synthesizeFallbackResourceUri({
+      serverId: "srv_1",
+      toolName: "fetch/weather",
+    });
+    expect(a).not.toBe(b);
+    expect(a).not.toContain(" ");
+    expect(b.endsWith("/")).toBe(false);
+    expect(b.includes("/inspector/")).toBe(true);
+  });
+
+  it("hash output is 16 hex chars", () => {
+    expect(djb2Hex16("anything")).toMatch(/^[0-9a-f]{16}$/);
+  });
+});

--- a/mcpjam-inspector/client/src/lib/mcp-ui/__tests__/synthesize-fallback-uri.test.ts
+++ b/mcpjam-inspector/client/src/lib/mcp-ui/__tests__/synthesize-fallback-uri.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
-  synthesizeFallbackResourceUri,
   djb2Hex16,
+  resolveCanonicalResourceUri,
+  synthesizeFallbackResourceUri,
 } from "../synthesize-fallback-uri";
 
 describe("synthesizeFallbackResourceUri", () => {
@@ -57,5 +58,93 @@ describe("synthesizeFallbackResourceUri", () => {
 
   it("hash output is 16 hex chars", () => {
     expect(djb2Hex16("anything")).toMatch(/^[0-9a-f]{16}$/);
+  });
+});
+
+describe("resolveCanonicalResourceUri", () => {
+  const fallback = "ui://mcpjam/inspector/srv_1/abc1234567890def";
+
+  it("accepts a ui:// candidate verbatim", () => {
+    expect(
+      resolveCanonicalResourceUri({
+        candidate: "ui://weather/dashboard",
+        legacyOutputTemplate: undefined,
+        fallback,
+      })
+    ).toBe("ui://weather/dashboard");
+  });
+
+  it("trims whitespace around a ui:// candidate", () => {
+    expect(
+      resolveCanonicalResourceUri({
+        candidate: "  ui://weather/dashboard  ",
+        legacyOutputTemplate: undefined,
+        fallback,
+      })
+    ).toBe("ui://weather/dashboard");
+  });
+
+  it("REGRESSION: a non-ui:// candidate does NOT pass through (OpenAI bug)", () => {
+    // `getUIResourceUri(UIType.OPENAI_SDK, toolMeta)` returns the raw
+    // `openai/outputTemplate` value verbatim — any scheme. Pre-fix,
+    // that flowed straight into the canonical column. We must reject
+    // the non-compliant value and fall through.
+    expect(
+      resolveCanonicalResourceUri({
+        candidate: "https://example.com/widget",
+        legacyOutputTemplate: undefined,
+        fallback,
+      })
+    ).toBe(fallback);
+  });
+
+  it("rejects a legacy mcp:// candidate too", () => {
+    expect(
+      resolveCanonicalResourceUri({
+        candidate: "mcp://server/tool",
+        legacyOutputTemplate: undefined,
+        fallback,
+      })
+    ).toBe(fallback);
+  });
+
+  it("falls through to legacy outputTemplate when it is ui:// and candidate is not", () => {
+    expect(
+      resolveCanonicalResourceUri({
+        candidate: "https://bad",
+        legacyOutputTemplate: "ui://weather/dashboard",
+        fallback,
+      })
+    ).toBe("ui://weather/dashboard");
+  });
+
+  it("returns fallback when both candidate and legacy template are non-ui://", () => {
+    expect(
+      resolveCanonicalResourceUri({
+        candidate: "https://bad-a",
+        legacyOutputTemplate: "https://bad-b",
+        fallback,
+      })
+    ).toBe(fallback);
+  });
+
+  it("returns fallback when neither field is provided", () => {
+    expect(
+      resolveCanonicalResourceUri({
+        candidate: undefined,
+        legacyOutputTemplate: undefined,
+        fallback,
+      })
+    ).toBe(fallback);
+  });
+
+  it("treats empty / whitespace-only candidate as absent", () => {
+    expect(
+      resolveCanonicalResourceUri({
+        candidate: "   ",
+        legacyOutputTemplate: undefined,
+        fallback,
+      })
+    ).toBe(fallback);
   });
 });

--- a/mcpjam-inspector/client/src/lib/mcp-ui/synthesize-fallback-uri.ts
+++ b/mcpjam-inspector/client/src/lib/mcp-ui/synthesize-fallback-uri.ts
@@ -1,0 +1,38 @@
+/**
+ * Build a canonical `ui://` fallback `resourceUri` for a saved view
+ * whose source tool did not supply an explicit one.
+ *
+ * - `serverId` is the immutable Convex id, NOT the display
+ *   `serverName`. Server display names can contain spaces, slashes,
+ *   and other characters that produce ambiguous URI paths, and can be
+ *   renamed.
+ * - `toolName` is hashed so any characters that would need escaping
+ *   in a URI segment cannot collapse two distinct tools into the same
+ *   path.
+ * - The result is deterministic — saving the same tool's view on the
+ *   same server twice produces the same `resourceUri`, which keeps the
+ *   backend's idempotency check happy.
+ *
+ * The hash matches the server-side helper in
+ * `mcpjam-backend/convex/lib/legacyViewUriSynth.ts` so synthesized
+ * URIs are predictable across the two sides.
+ */
+export function synthesizeFallbackResourceUri(input: {
+  serverId: string;
+  toolName: string;
+}): string {
+  return `ui://mcpjam/inspector/${input.serverId}/${djb2Hex16(input.toolName)}`;
+}
+
+/**
+ * Deterministic 64-bit string hash, returned as 16 hex chars.
+ * Non-cryptographic but stable across runs and URI-safe.
+ */
+export function djb2Hex16(input: string): string {
+  let h = 5381n;
+  const mask = 0xffffffffffffffffn;
+  for (let i = 0; i < input.length; i++) {
+    h = ((h << 5n) + h + BigInt(input.charCodeAt(i))) & mask;
+  }
+  return h.toString(16).padStart(16, "0").slice(0, 16);
+}

--- a/mcpjam-inspector/client/src/lib/mcp-ui/synthesize-fallback-uri.ts
+++ b/mcpjam-inspector/client/src/lib/mcp-ui/synthesize-fallback-uri.ts
@@ -25,6 +25,41 @@ export function synthesizeFallbackResourceUri(input: {
 }
 
 /**
+ * Pick the canonical `resourceUri` to persist on a saved view.
+ *
+ * The caller may supply a `candidate` (e.g. `getUIResourceUri()` for
+ * the active tool, which for OpenAI-origin tools returns the raw
+ * `openai/outputTemplate` value — *any* scheme) and/or a
+ * `legacyOutputTemplate` (the explicit OpenAI alias on the save
+ * payload). Either field may be missing or non-`ui://`. The chosen
+ * URI must be `ui://`-scheme per SEP-1865.
+ *
+ * Resolution order:
+ *   1. Trimmed `candidate` starts with `ui://` → use it.
+ *   2. Trimmed `legacyOutputTemplate` starts with `ui://` → use it.
+ *   3. Otherwise → return the caller's `fallback`.
+ *
+ * Without (1) gating on `ui://`, a non-compliant OpenAI template like
+ * `https://...` flowed past `useSaveView` straight into the canonical
+ * column, bypassing the fallback synth entirely.
+ */
+export function resolveCanonicalResourceUri(input: {
+  candidate: string | undefined;
+  legacyOutputTemplate: string | undefined;
+  fallback: string;
+}): string {
+  const trimmedCandidate = input.candidate?.trim();
+  if (trimmedCandidate && trimmedCandidate.startsWith("ui://")) {
+    return trimmedCandidate;
+  }
+  const trimmedLegacy = input.legacyOutputTemplate?.trim();
+  if (trimmedLegacy && trimmedLegacy.startsWith("ui://")) {
+    return trimmedLegacy;
+  }
+  return input.fallback;
+}
+
+/**
  * Deterministic 64-bit string hash, returned as 16 hex chars.
  * Non-cryptographic but stable across runs and URI-safe.
  */


### PR DESCRIPTION
## Summary

Inspector half of the saved-view unification. Pairs with backend [MCPJam/mcpjam-backend#314](https://github.com/MCPJam/mcpjam-backend/pull/314) (Phase A) and [#315](https://github.com/MCPJam/mcpjam-backend/pull/315) (Phase B).

- All `useSaveView` writes now go through `mcpAppViews:create`. OpenAI-origin tools pass `outputTemplate`, `serverInfo`, and a `viewOriginProtocol: "openai-apps"` provenance tag as legacy aliases; the backend normalizer maps them to canonical `resourceUri`.
- Fallback URI is now `ui://mcpjam/<server>/<tool>` (was `mcp://...`, a SEP-1865 violation).
- `openaiAppViews:create`/`generateUploadUrl` are no longer called from any code path. The mutations remain registered on `useViewMutations` with a deprecation comment so existing ViewsTab list/delete still works on pre-backfill rows.

## Why a deploy-order note matters

The original Phase A backend rejected any non-`ui://` `resourceUri` strictly, which would have broken every existing save the moment Phase A deployed (because the old inspector fallback was `mcp://`). That has been loosened to a `console.warn`. This inspector PR removes the `mcp://` writer entirely; once both repos are deployed, a follow-up backend PR can flip the warn back to a hard reject.

## Test plan

- [x] `npm run typecheck:client -w @mcpjam/inspector` — clean
- [x] `npm run test -w @mcpjam/inspector` — 4349 passed, 6 skipped, 0 fail (full suite, ~41s)
- [x] `PartSwitch.test.tsx` and `ViewsTab.layout.test.tsx` re-verified independently
- [ ] Manual: save an OpenAI-style view, confirm it lands in `mcpAppViews` with `viewOriginProtocol: "openai-apps"` and renders identically.
- [ ] Manual: save an MCP-Apps view, confirm `viewOriginProtocol: "mcp-apps"` and `resourceUri` starts with `ui://`.

## Out of scope (follow-ups)

- Renderer consolidation: `chatgpt-app-renderer.tsx` vs `mcp-apps-renderer.tsx`. They already dispatch via field presence rather than the row's `protocol` field, so this PR doesn't need to touch them.
- Collapsing `OpenaiAppView | McpAppView` into a single type and dropping `viewsByProtocol`. Worth doing once `openaiAppViews` is drained by the backfill.
- Removing the `openaiAppViews:*` mutation registrations once nothing reads them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the persistence path for saved views and how `resourceUri` is derived, which could affect where new views are stored and how they render if the backend normalizer/SEP-1865 assumptions differ. Risk is moderated by targeted validation/gating and added unit tests for URI synthesis/resolution.
> 
> **Overview**
> All saved-view writes from `useSaveView` are now **unified onto** `mcpAppViews:create` (including OpenAI-origin tool results), and blob uploads always use `mcpAppViews:generateUploadUrl`; OpenAI fields are forwarded only as *legacy aliases* (`outputTemplate`, `serverInfo`, plus a `viewOriginProtocol` tag) for backend normalization.
> 
> Fixes `resourceUri` handling to be SEP-1865 compliant by synthesizing a deterministic, collision-safe `ui://mcpjam/inspector/<serverId>/<hash>` fallback and by rejecting non-`ui://` candidates/templates instead of persisting them.
> 
> Adds `synthesize-fallback-uri.ts` with unit tests covering hashing, determinism, and canonical URI resolution; `useViewMutations` keeps legacy `openaiAppViews:*` mutations registered with deprecation guidance for transitional read/delete flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3ccd5ebbdf1f37f36494f7bc08a0cc60ada0a26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->