### PR TITLE
was sending service token for byok

### DIFF
--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -777,7 +777,7 @@ describe("POST /api/mcp/chat-v2", () => {
       const originalFetch = global.fetch;
       global.fetch = vi
         .fn()
-        .mockImplementation(async (input: RequestInfo | URL) => {
+        .mockImplementation(async (input: Parameters<typeof fetch>[0]) => {
           const url = String(input);
           if (url === "https://test-convex.example.com/stream") {
             return createSseResponse([
@@ -861,7 +861,7 @@ describe("POST /api/mcp/chat-v2", () => {
       const originalFetch = global.fetch;
       global.fetch = vi
         .fn()
-        .mockImplementation(async (input: RequestInfo | URL) => {
+        .mockImplementation(async (input: Parameters<typeof fetch>[0]) => {
           const url = String(input);
           if (url === "https://test-convex.example.com/stream") {
             return createSseResponse([
@@ -915,7 +915,7 @@ describe("POST /api/mcp/chat-v2", () => {
       const originalFetch = global.fetch;
       global.fetch = vi
         .fn()
-        .mockImplementation(async (input: RequestInfo | URL) => {
+        .mockImplementation(async (input: Parameters<typeof fetch>[0]) => {
           const url = String(input);
           if (url === "https://test-convex.example.com/stream") {
             return createSseResponse([
@@ -970,7 +970,7 @@ describe("POST /api/mcp/chat-v2", () => {
       const originalFetch = global.fetch;
       global.fetch = vi
         .fn()
-        .mockImplementation(async (input: RequestInfo | URL) => {
+        .mockImplementation(async (input: Parameters<typeof fetch>[0]) => {
           const url = String(input);
           if (url === "https://test-convex.example.com/stream") {
             return createSseResponse([
@@ -1027,7 +1027,7 @@ describe("POST /api/mcp/chat-v2", () => {
       const originalFetch = global.fetch;
       global.fetch = vi
         .fn()
-        .mockImplementation(async (input: RequestInfo | URL) => {
+        .mockImplementation(async (input: Parameters<typeof fetch>[0]) => {
           const url = String(input);
           if (url === "https://test-convex.example.com/stream") {
             return createSseResponse([
@@ -1081,7 +1081,7 @@ describe("POST /api/mcp/chat-v2", () => {
       const originalFetch = global.fetch;
       global.fetch = vi
         .fn()
-        .mockImplementation(async (input: RequestInfo | URL) => {
+        .mockImplementation(async (input: Parameters<typeof fetch>[0]) => {
           const url = String(input);
           if (url === "https://test-convex.example.com/stream") {
             return createSseResponse([
@@ -1135,7 +1135,7 @@ describe("POST /api/mcp/chat-v2", () => {
       const originalFetch = global.fetch;
       global.fetch = vi
         .fn()
-        .mockImplementation(async (input: RequestInfo | URL) => {
+        .mockImplementation(async (input: Parameters<typeof fetch>[0]) => {
           const url = String(input);
           if (url === "https://test-convex.example.com/stream") {
             return createSseResponse([
@@ -1206,7 +1206,7 @@ describe("POST /api/mcp/chat-v2", () => {
             messages: [{ role: "user", content: "Hello" }],
             model: { id, provider },
           });
-          const { status, data } = await expectJson(res);
+          const { status, data } = await expectJson<ErrorResponse>(res);
 
           expect(status).toBe(403);
           expect(data.error).toBe(
@@ -1221,6 +1221,143 @@ describe("POST /api/mcp/chat-v2", () => {
         }
       },
     );
+  });
+
+  describe("Org BYOK Convex routing", () => {
+    beforeEach(async () => {
+      const { isMCPJamProvidedModel } = await import("@/shared/types");
+      vi.mocked(isMCPJamProvidedModel).mockReturnValue(false);
+      process.env.CONVEX_HTTP_URL = "https://test-convex.example.com";
+    });
+
+    afterEach(() => {
+      delete process.env.CONVEX_HTTP_URL;
+    });
+
+    it("routes cloud org BYOK chat through /stream/org without a service token", async () => {
+      const originalFetch = global.fetch;
+      const fetchMock = vi.fn().mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === "https://test-convex.example.com/stream/org") {
+          const headers = new Headers(
+            (init as RequestInit | undefined)?.headers,
+          );
+          expect(headers.get("X-Inspector-Service-Token")).toBeNull();
+          expect(headers.get("Authorization")).toBe(
+            "Bearer signed-in-test-token",
+          );
+          const body = JSON.parse(String((init as RequestInit).body ?? "{}"));
+          expect(body).toMatchObject({
+            projectId: "project-1",
+            providerKey: "openai",
+            model: "gpt-4-turbo",
+          });
+          return createSseResponse([
+            {
+              type: "finish",
+              finishReason: "stop",
+              messageMetadata: {
+                inputTokens: 1,
+                outputTokens: 1,
+                totalTokens: 2,
+              },
+            },
+          ]);
+        }
+        throw new Error(`Unexpected fetch URL: ${url}`);
+      });
+      global.fetch = fetchMock;
+
+      try {
+        const res = await postAuthenticatedJson({
+          messages: [{ role: "user", content: "Hello" }],
+          model: { id: "gpt-4-turbo", provider: "openai" },
+          projectId: "project-1",
+        });
+
+        expect(res.status).toBe(200);
+        await lastStreamExecution;
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+      } finally {
+        global.fetch = originalFetch;
+      }
+    });
+
+    it("resolves local-runtime org BYOK chat before running locally", async () => {
+      const originalFetch = global.fetch;
+      const fetchMock = vi.fn().mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === "https://test-convex.example.com/stream/org/resolve") {
+          const headers = new Headers(
+            (init as RequestInit | undefined)?.headers,
+          );
+          expect(headers.get("X-Inspector-Service-Token")).toBeNull();
+          expect(headers.get("Authorization")).toBe(
+            "Bearer signed-in-test-token",
+          );
+          const body = JSON.parse(String((init as RequestInit).body ?? "{}"));
+          expect(body).toMatchObject({
+            projectId: "project-1",
+            providerKey: "custom:local-one",
+            model: "custom:local-one:m-1",
+          });
+          return Response.json({
+            ok: true,
+            runtimeLocation: "local",
+            provider: {
+              providerKey: "custom:local-one",
+              apiKey: "sk-local",
+              baseUrl: "https://llm.example.com",
+              protocol: "openai-compatible",
+              modelIds: ["m-1"],
+            },
+          });
+        }
+        if (url === "https://test-convex.example.com/stream/org/local-usage") {
+          const headers = new Headers(
+            (init as RequestInit | undefined)?.headers,
+          );
+          expect(headers.get("X-Inspector-Service-Token")).toBeNull();
+          expect(headers.get("Authorization")).toBe(
+            "Bearer signed-in-test-token",
+          );
+          return Response.json({ ok: true });
+        }
+        throw new Error(`Unexpected fetch URL: ${url}`);
+      });
+      global.fetch = fetchMock;
+
+      try {
+        const res = await postAuthenticatedJson({
+          messages: [{ role: "user", content: "Hello" }],
+          model: {
+            id: "custom:local-one:m-1",
+            provider: "custom",
+            customProviderName: "local-one",
+          },
+          projectId: "project-1",
+        });
+
+        expect(res.status).toBe(200);
+        await lastStreamExecution;
+        expect(fetchMock).toHaveBeenCalledWith(
+          "https://test-convex.example.com/stream/org/resolve",
+          expect.anything(),
+        );
+        expect(fetchMock).toHaveBeenCalledWith(
+          "https://test-convex.example.com/stream/org/local-usage",
+          expect.anything(),
+        );
+        expect(
+          fetchMock.mock.calls.some(
+            ([input]) =>
+              String(input) === "https://test-convex.example.com/stream/org",
+          ),
+        ).toBe(false);
+      } finally {
+        global.fetch = originalFetch;
+      }
+    });
   });
 
   describe("unresolved tool calls from aborted requests (MCPJam models)", () => {

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -20,9 +20,16 @@ import { getProductionGuestAuthHeader } from "../../utils/guest-auth.js";
 import { logger } from "../../utils/logger";
 import { fetchChatboxRuntimeConfig } from "../../utils/chatbox-runtime-config";
 import { handleMCPJamFreeChatModel } from "../../utils/mcpjam-stream-handler";
-import { handleHostedOrgChatModel } from "../../utils/org-model-stream-handler.js";
-import { deriveOrgProviderKey } from "../../utils/org-model-config.js";
-import { HOSTED_MODE } from "../../config";
+import {
+  handleHostedOrgChatModel,
+  handleLocalOrgChatModel,
+} from "../../utils/org-model-stream-handler.js";
+import {
+  deriveOrgProviderKey,
+  isLocalRuntimeEligible,
+  resolveOrgProviderRuntime,
+  type OrgProviderRuntime,
+} from "../../utils/org-model-config.js";
 import {
   buildDirectHostConfig,
   persistChatSessionToConvex,
@@ -745,18 +752,12 @@ chatV2.post("/", async (c) => {
       });
     }
 
-    // Hosted org BYOK: only in hosted mode, only when Convex is reachable,
-    // only when the request carries a projectId, and only when the caller
-    // hasn't supplied a client-side apiKey. A client-supplied apiKey is the
-    // strongest signal that the caller wants direct BYOK, so it wins —
-    // matches the precedence used in the eval flows (modelApiKeys ?? org).
-    // Otherwise we route the LLM call through Convex (/stream/org) so the
-    // org's vault-resolved provider keys never leave Convex. Local-mode BYOK
-    // (CLI / no Convex) falls through to createLlmModel + streamText below.
+    // Org BYOK: when Convex is reachable, the request carries a projectId,
+    // and the caller hasn't supplied a client-side apiKey, use the org's
+    // Convex config. Cloud runtime stays in Convex; local runtime resolves a
+    // scoped provider config and executes in this inspector.
     if (
-      HOSTED_MODE &&
       process.env.CONVEX_HTTP_URL &&
-      process.env.INSPECTOR_SERVICE_TOKEN &&
       typeof body.projectId === "string" &&
       body.projectId &&
       !apiKey
@@ -771,59 +772,98 @@ chatV2.post("/", async (c) => {
       );
       const sessionStartedAt = Date.now();
       const chatSessionId = body.chatSessionId;
+      const modelId = String(modelDefinition.id);
+      const runtime: OrgProviderRuntime = isLocalRuntimeEligible(providerKey)
+        ? await resolveOrgProviderRuntime(
+            body.projectId,
+            providerKey,
+            modelId,
+            {
+              authHeader: requestAuthHeader,
+              chatboxId: bodyChatboxId,
+              accessVersion: bodyAccessVersion,
+              serverIds: hostConfigServerIds,
+            },
+          )
+        : { runtimeLocation: "cloud", providerKey };
+      const onConversationComplete = chatSessionId
+        ? async (fullHistory: ModelMessage[], turnTrace: PersistedTurnTrace) => {
+            await persistChatSessionToConvex({
+              chatSessionId,
+              modelId,
+              modelSource:
+                runtime.runtimeLocation === "local" ? "local_byok" : "byok",
+              sourceType: chatSessionSourceType,
+              ...(chatSessionSurface ? { surface: chatSessionSurface } : {}),
+              ...(bodyChatboxId ? { chatboxId: bodyChatboxId } : {}),
+              ...(bodyChatboxId && Number.isFinite(bodyAccessVersion)
+                ? { accessVersion: bodyAccessVersion }
+                : {}),
+              authHeader: requestAuthHeader,
+              sessionMessages: stampSenderUserIdsOnSessionMessages(
+                fullHistory,
+                messages,
+              ),
+              startedAt: sessionStartedAt,
+              lastActivityAt: Date.now(),
+              projectId: body.projectId,
+              ...(isChatboxSession
+                ? {}
+                : {
+                    directVisibility: body.directVisibility,
+                    resumeConfig: {
+                      systemPrompt,
+                      temperature,
+                      requireToolApproval,
+                      selectedServers,
+                    },
+                    ...(directHostConfig
+                      ? { hostConfig: directHostConfig }
+                      : {}),
+                  }),
+              expectedVersion: body.expectedVersion,
+              turnTrace,
+              forwardHeaders: pickEnrichmentHeaders(c.req.raw.headers),
+            });
+          }
+        : undefined;
+
+      if (runtime.runtimeLocation === "local") {
+        return handleLocalOrgChatModel({
+          provider: runtime.provider,
+          projectId: body.projectId,
+          modelId,
+          chatSessionId,
+          sourceType: chatSessionSourceType,
+          messages: modelMessages,
+          systemPrompt: enhancedSystemPrompt,
+          temperature: resolvedTemperature,
+          tools: allTools as ToolSet,
+          authHeader: requestAuthHeader,
+          chatboxId: bodyChatboxId,
+          accessVersion: bodyAccessVersion,
+          selectedServers,
+          serverIds: hostConfigServerIds,
+          requireToolApproval,
+          onConversationComplete,
+        });
+      }
+
       return handleHostedOrgChatModel({
         projectId: body.projectId,
         providerKey,
-        modelId: String(modelDefinition.id),
+        modelId,
         messages: modelMessages,
         systemPrompt: enhancedSystemPrompt,
         temperature: resolvedTemperature,
         tools: allTools as ToolSet,
-        authHeader: c.req.header("authorization"),
+        authHeader: requestAuthHeader,
         clientIp: getClientIp(c),
         mcpClientManager,
         selectedServers,
+        serverIds: hostConfigServerIds,
         requireToolApproval,
-        onConversationComplete: chatSessionId
-          ? async (fullHistory, turnTrace) => {
-              await persistChatSessionToConvex({
-                chatSessionId,
-                modelId: String(modelDefinition.id),
-                modelSource: "byok",
-                sourceType: chatSessionSourceType,
-                ...(chatSessionSurface ? { surface: chatSessionSurface } : {}),
-                ...(bodyChatboxId ? { chatboxId: bodyChatboxId } : {}),
-                ...(bodyChatboxId && Number.isFinite(bodyAccessVersion)
-                  ? { accessVersion: bodyAccessVersion }
-                  : {}),
-                authHeader: c.req.header("authorization"),
-                sessionMessages: stampSenderUserIdsOnSessionMessages(
-                  fullHistory,
-                  messages,
-                ),
-                startedAt: sessionStartedAt,
-                lastActivityAt: Date.now(),
-                projectId: body.projectId,
-                ...(isChatboxSession
-                  ? {}
-                  : {
-                      directVisibility: body.directVisibility,
-                      resumeConfig: {
-                        systemPrompt,
-                        temperature,
-                        requireToolApproval,
-                        selectedServers,
-                      },
-                      ...(directHostConfig
-                        ? { hostConfig: directHostConfig }
-                        : {}),
-                    }),
-                expectedVersion: body.expectedVersion,
-                turnTrace,
-                forwardHeaders: pickEnrichmentHeaders(c.req.raw.headers),
-              });
-            }
-          : undefined,
+        onConversationComplete,
       });
     }
 

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -735,32 +735,37 @@ export async function runEvalsWithManager(
     !!modelApiKeys && Object.keys(modelApiKeys).length > 0;
   const resolvedModelApiKeys = hasClientKeys ? modelApiKeys : undefined;
   let resolvedOrgModelConfig = orgModelConfig;
-  if (!resolvedModelApiKeys && !resolvedOrgModelConfig) {
-    let projectIdForOrgConfig: string | undefined = projectId;
-    let legacyWorkspaceIdForOrgConfig: string | undefined;
-    if (!projectIdForOrgConfig && resolvedSuiteId) {
-      try {
-        const suite = await convexClient.query(
-          "testSuites:getTestSuite" as any,
-          { suiteId: resolvedSuiteId },
-        );
-        if (suite?.projectId) {
-          projectIdForOrgConfig = String(suite.projectId);
-        } else if (suite?.workspaceId) {
-          legacyWorkspaceIdForOrgConfig = String(suite.workspaceId);
-        }
-      } catch (error) {
-        logger.warn("[evals] Failed to load suite for projectId fallback", {
-          suiteId: resolvedSuiteId,
-          error: error instanceof Error ? error.message : String(error),
-        });
+  let resolvedOrgModelConfigTarget:
+    | { projectId: string }
+    | { workspaceId: string }
+    | undefined;
+  let projectIdForOrgConfig: string | undefined = projectId;
+  let legacyWorkspaceIdForOrgConfig: string | undefined;
+  if (!projectIdForOrgConfig && resolvedSuiteId) {
+    try {
+      const suite = await convexClient.query("testSuites:getTestSuite" as any, {
+        suiteId: resolvedSuiteId,
+      });
+      if (suite?.projectId) {
+        projectIdForOrgConfig = String(suite.projectId);
+      } else if (suite?.workspaceId) {
+        legacyWorkspaceIdForOrgConfig = String(suite.workspaceId);
       }
+    } catch (error) {
+      logger.warn("[evals] Failed to load suite for projectId fallback", {
+        suiteId: resolvedSuiteId,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
-    const orgConfigTarget = projectIdForOrgConfig
-      ? { projectId: projectIdForOrgConfig }
-      : legacyWorkspaceIdForOrgConfig
-      ? { workspaceId: legacyWorkspaceIdForOrgConfig }
-      : undefined;
+  }
+  const orgConfigTarget = projectIdForOrgConfig
+    ? { projectId: projectIdForOrgConfig }
+    : legacyWorkspaceIdForOrgConfig
+    ? { workspaceId: legacyWorkspaceIdForOrgConfig }
+    : undefined;
+  resolvedOrgModelConfigTarget = orgConfigTarget;
+
+  if (!resolvedModelApiKeys && !resolvedOrgModelConfig) {
     if (orgConfigTarget) {
       try {
         const orgConfig = await resolveOrgModelConfig(orgConfigTarget, {
@@ -786,6 +791,7 @@ export async function runEvalsWithManager(
     config,
     modelApiKeys: resolvedModelApiKeys ?? undefined,
     orgModelConfig: resolvedOrgModelConfig,
+    orgModelConfigTarget: resolvedOrgModelConfigTarget,
     convexClient,
     convexHttpUrl,
     convexAuthToken,
@@ -933,6 +939,7 @@ export async function runEvalTestCaseWithManager(
     },
     modelApiKeys: resolvedModelApiKeys ?? undefined,
     orgModelConfig: resolvedOrgModelConfig,
+    orgModelConfigTarget: testCaseOrgConfigTarget,
     convexClient,
     convexHttpUrl,
     convexAuthToken,
@@ -1207,6 +1214,7 @@ export async function streamEvalTestCaseWithManager(
           recorder: null,
           modelApiKeys: resolvedStreamModelApiKeys ?? undefined,
           orgModelConfig: resolvedStreamOrgModelConfig,
+          orgModelConfigTarget: streamTestCaseOrgConfigTarget,
           convexHttpUrl,
           convexAuthToken,
           convexClient,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -37,7 +37,6 @@ import {
   mapRuntimeError,
 } from "./auth.js";
 import {
-  attachHostedRpcLogs,
   createHostedRpcLogCollector,
 } from "./hosted-rpc-logs.js";
 import { getClientIp } from "../../utils/client-ip.js";
@@ -253,13 +252,6 @@ chatV2.post("/", async (c) => {
             "Server missing CONVEX_HTTP_URL configuration",
           );
         }
-        if (!process.env.INSPECTOR_SERVICE_TOKEN) {
-          throw new WebRouteError(
-            500,
-            ErrorCode.INTERNAL_ERROR,
-            "Server missing INSPECTOR_SERVICE_TOKEN configuration",
-          );
-        }
         // Hosted org BYOK: resolve runtime location first.
         // Cloud → LLM executes in Convex (/stream/org), keys never leave Convex.
         // Local → LLM executes in the inspector using the decrypted API key.
@@ -358,6 +350,7 @@ chatV2.post("/", async (c) => {
             chatboxId,
             accessVersion,
             selectedServers: selectedServerIds,
+            serverIds: selectedServerIds,
             requireToolApproval,
             onConversationComplete,
             onStreamComplete: cleanupStream,
@@ -383,6 +376,7 @@ chatV2.post("/", async (c) => {
           accessVersion,
           mcpClientManager: manager,
           selectedServers: selectedServerIds,
+          serverIds: selectedServerIds,
           requireToolApproval,
           onConversationComplete,
           onStreamComplete: cleanupStream,
@@ -494,7 +488,7 @@ chatV2.post("/", async (c) => {
           oauthRequired: true,
           serverUrl: firstUrl,
         },
-        rpcCollector?.buildEnvelope()
+        rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined
       );
     }
     const routeError = mapRuntimeError(error);
@@ -504,7 +498,7 @@ chatV2.post("/", async (c) => {
       routeError.code,
       routeError.message,
       routeError.details,
-      rpcCollector?.buildEnvelope()
+      rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined
     );
   }
 });

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -28,6 +28,10 @@ import { logger } from "../utils/logger";
 import { injectOpenAICompat } from "../utils/widget-helpers.js";
 import {
   buildLlmRuntimeConfigFromOrgConfig,
+  deriveOrgProviderKey,
+  isLocalRuntimeEligible,
+  resolveOrgProviderRuntimeForTarget,
+  type ResolveOrgModelConfigTarget,
   type ResolvedOrgModelConfig,
 } from "../utils/org-model-config";
 import {
@@ -133,6 +137,7 @@ export type RunEvalSuiteOptions = {
   };
   modelApiKeys?: Record<string, string>;
   orgModelConfig?: ResolvedOrgModelConfig;
+  orgModelConfigTarget?: ResolveOrgModelConfigTarget;
   convexClient: ConvexHttpClient;
   convexHttpUrl: string;
   convexAuthToken: string;
@@ -1046,6 +1051,7 @@ type RunIterationBaseParams = {
   suiteId?: string;
   modelApiKeys?: Record<string, string>;
   orgModelConfig?: ResolvedOrgModelConfig;
+  orgModelConfigTarget?: ResolveOrgModelConfigTarget;
   convexClient: ConvexHttpClient;
   runId: string | null; // For cancellation checks
   abortSignal?: AbortSignal; // For aborting in-flight requests
@@ -1075,6 +1081,8 @@ type RunIterationBackendParams = RunIterationBaseParams & {
   convexHttpUrl: string;
   convexAuthToken: string;
   modelId: string;
+  endpointPath?: "/stream" | "/stream/org";
+  extraBodyFields?: Record<string, unknown>;
 };
 
 function parseCustomProviderName(modelId: string): string | undefined {
@@ -1148,6 +1156,106 @@ function resolveEvalModelRuntime(args: {
     ...(orgRuntime?.customProviders.length
       ? { customProviders: orgRuntime.customProviders }
       : {}),
+  };
+}
+
+function hasExplicitModelApiKeys(
+  modelApiKeys: Record<string, string> | undefined,
+): boolean {
+  return Boolean(modelApiKeys && Object.keys(modelApiKeys).length > 0);
+}
+
+function readBackendUsage(usage: unknown): {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+} {
+  const record =
+    usage && typeof usage === "object"
+      ? (usage as Record<string, unknown>)
+      : {};
+  const inputTokens =
+    typeof record.inputTokens === "number"
+      ? record.inputTokens
+      : typeof record.promptTokens === "number"
+        ? record.promptTokens
+        : 0;
+  const outputTokens =
+    typeof record.outputTokens === "number"
+      ? record.outputTokens
+      : typeof record.completionTokens === "number"
+        ? record.completionTokens
+        : 0;
+  const totalTokens =
+    typeof record.totalTokens === "number" ? record.totalTokens : 0;
+  return { inputTokens, outputTokens, totalTokens };
+}
+
+function resolveOrgTargetForEval(
+  test: EvalTestCase,
+  explicitTarget?: ResolveOrgModelConfigTarget,
+): ResolveOrgModelConfigTarget | undefined {
+  if (explicitTarget) return explicitTarget;
+  const maybeProjectId = (test as { projectId?: unknown }).projectId;
+  if (typeof maybeProjectId === "string" && maybeProjectId.trim()) {
+    return { projectId: maybeProjectId.trim() };
+  }
+  const maybeWorkspaceId = (test as { workspaceId?: unknown }).workspaceId;
+  if (typeof maybeWorkspaceId === "string" && maybeWorkspaceId.trim()) {
+    return { workspaceId: maybeWorkspaceId.trim() };
+  }
+  return undefined;
+}
+
+async function resolveOrgByokEvalRuntime(args: {
+  test: EvalTestCase;
+  modelDefinition: ModelDefinition;
+  modelApiKeys?: Record<string, string>;
+  orgModelConfig?: ResolvedOrgModelConfig;
+  orgModelConfigTarget?: ResolveOrgModelConfigTarget;
+  convexAuthToken: string;
+}): Promise<
+  | {
+      kind: "cloud";
+      providerKey: string;
+      target: ResolveOrgModelConfigTarget;
+    }
+  | {
+      kind: "local";
+      orgModelConfig: ResolvedOrgModelConfig;
+    }
+  | undefined
+> {
+  if (hasExplicitModelApiKeys(args.modelApiKeys)) return undefined;
+
+  const providerKeyResult = deriveOrgProviderKey(args.modelDefinition);
+  if (!providerKeyResult.ok) return undefined;
+
+  const target = resolveOrgTargetForEval(args.test, args.orgModelConfigTarget);
+  if (!target) return undefined;
+
+  const providerKey = providerKeyResult.key;
+  if (!isLocalRuntimeEligible(providerKey)) {
+    return { kind: "cloud", providerKey, target };
+  }
+
+  if ("organizationId" in target) {
+    return { kind: "cloud", providerKey, target };
+  }
+
+  const runtime = await resolveOrgProviderRuntimeForTarget(
+    target,
+    providerKey,
+    String(args.modelDefinition.id),
+    { bearerToken: args.convexAuthToken },
+  );
+  if (runtime.runtimeLocation === "cloud") {
+    return { kind: "cloud", providerKey: runtime.providerKey, target };
+  }
+
+  return {
+    kind: "local",
+    orgModelConfig: { providers: [runtime.provider] },
   };
 }
 
@@ -1620,6 +1728,8 @@ const runIterationViaBackend = async ({
   convexHttpUrl,
   convexAuthToken,
   modelId,
+  endpointPath = "/stream",
+  extraBodyFields,
   convexClient,
   runId,
   abortSignal,
@@ -1792,7 +1902,7 @@ const runIterationViaBackend = async ({
       const llmStartAbs = stepStartAbs;
       const stepMessageStartIndex = messageHistory.length;
       try {
-        const res = await fetch(`${convexHttpUrl}/stream`, {
+        const res = await fetch(`${convexHttpUrl}${endpointPath}`, {
           method: "POST",
           headers: {
             "content-type": "application/json",
@@ -1807,6 +1917,7 @@ const runIterationViaBackend = async ({
             ...(toolChoice ? { toolChoice } : {}),
             tools: toolDefs,
             maxOutputTokens: 16384,
+            ...(extraBodyFields ?? {}),
           }),
           ...(abortSignal ? { signal: abortSignal } : {}),
         });
@@ -1857,16 +1968,13 @@ const runIterationViaBackend = async ({
           break;
         }
 
-        if (json.usage) {
-          accumulatedUsage.inputTokens =
-            (accumulatedUsage.inputTokens || 0) +
-            (json.usage.promptTokens || 0);
-          accumulatedUsage.outputTokens =
-            (accumulatedUsage.outputTokens || 0) +
-            (json.usage.completionTokens || 0);
-          accumulatedUsage.totalTokens =
-            (accumulatedUsage.totalTokens || 0) + (json.usage.totalTokens || 0);
-        }
+        const stepUsage = readBackendUsage(json.usage);
+        accumulatedUsage.inputTokens =
+          (accumulatedUsage.inputTokens || 0) + stepUsage.inputTokens;
+        accumulatedUsage.outputTokens =
+          (accumulatedUsage.outputTokens || 0) + stepUsage.outputTokens;
+        accumulatedUsage.totalTokens =
+          (accumulatedUsage.totalTokens || 0) + stepUsage.totalTokens;
 
         for (const msg of json.messages as any[]) {
           if (msg?.role === "assistant" && Array.isArray(msg.content)) {
@@ -1957,9 +2065,9 @@ const runIterationViaBackend = async ({
               },
               {
                 modelId,
-                inputTokens: json.usage?.promptTokens,
-                outputTokens: json.usage?.completionTokens,
-                totalTokens: json.usage?.totalTokens,
+                inputTokens: stepUsage.inputTokens,
+                outputTokens: stepUsage.outputTokens,
+                totalTokens: stepUsage.totalTokens,
                 messageStartIndex:
                   stepMessageEndIndex != null
                     ? stepMessageStartIndex
@@ -1985,9 +2093,9 @@ const runIterationViaBackend = async ({
               failAbs,
               {
                 modelId,
-                inputTokens: json.usage?.promptTokens,
-                outputTokens: json.usage?.completionTokens,
-                totalTokens: json.usage?.totalTokens,
+                inputTokens: stepUsage.inputTokens,
+                outputTokens: stepUsage.outputTokens,
+                totalTokens: stepUsage.totalTokens,
                 messageStartIndex:
                   stepMessageEndIndex != null
                     ? stepMessageStartIndex
@@ -2016,9 +2124,9 @@ const runIterationViaBackend = async ({
             undefined,
             {
               modelId,
-              inputTokens: json.usage?.promptTokens,
-              outputTokens: json.usage?.completionTokens,
-              totalTokens: json.usage?.totalTokens,
+              inputTokens: stepUsage.inputTokens,
+              outputTokens: stepUsage.outputTokens,
+              totalTokens: stepUsage.totalTokens,
               messageStartIndex:
                 stepMessageEndIndex != null ? stepMessageStartIndex : undefined,
               messageEndIndex: stepMessageEndIndex,
@@ -2159,6 +2267,7 @@ const runTestCase = async (params: {
   recorder: SuiteRunRecorder | null;
   modelApiKeys?: Record<string, string>;
   orgModelConfig?: ResolvedOrgModelConfig;
+  orgModelConfigTarget?: ResolveOrgModelConfigTarget;
   convexHttpUrl: string;
   convexAuthToken: string;
   convexClient: ConvexHttpClient;
@@ -2177,6 +2286,7 @@ const runTestCase = async (params: {
     recorder,
     modelApiKeys,
     orgModelConfig,
+    orgModelConfigTarget,
     convexHttpUrl,
     convexAuthToken,
     convexClient,
@@ -2197,6 +2307,16 @@ const runTestCase = async (params: {
     resolvedModelId,
     modelDefinition.provider,
   );
+  const orgByokRuntime = isJamModel
+    ? undefined
+    : await resolveOrgByokEvalRuntime({
+        test,
+        modelDefinition,
+        modelApiKeys,
+        orgModelConfig,
+        orgModelConfigTarget,
+        convexAuthToken,
+      });
 
   const outcomes: EvalIterationOutcome[] = [];
 
@@ -2277,6 +2397,37 @@ const runTestCase = async (params: {
       continue;
     }
 
+    if (orgByokRuntime?.kind === "cloud") {
+      const iterationOutcome = await runIterationViaBackend({
+        test,
+        runIndex,
+        tools,
+        mcpClientManager,
+        recorder,
+        testCaseId,
+        suiteId,
+        convexHttpUrl,
+        convexAuthToken,
+        modelId: String(modelDefinition.id),
+        endpointPath: "/stream/org",
+        extraBodyFields: {
+          providerKey: orgByokRuntime.providerKey,
+          ...orgByokRuntime.target,
+        },
+        convexClient,
+        modelApiKeys,
+        orgModelConfig,
+        orgModelConfigTarget,
+        runId,
+        abortSignal,
+        compareRunId,
+        precreatedIterationId,
+        injectOpenAiCompat,
+      });
+      outcomes.push(iterationOutcome);
+      continue;
+    }
+
     const iterationOutcome = await runIterationWithAiSdk({
       test,
       runIndex,
@@ -2287,7 +2438,11 @@ const runTestCase = async (params: {
       suiteId,
       modelDefinition,
       modelApiKeys,
-      orgModelConfig,
+      orgModelConfig:
+        orgByokRuntime?.kind === "local"
+          ? orgByokRuntime.orgModelConfig
+          : orgModelConfig,
+      orgModelConfigTarget,
       convexClient,
       runId,
       abortSignal,
@@ -2307,6 +2462,7 @@ export const runEvalSuiteWithAiSdk = async ({
   config,
   modelApiKeys,
   orgModelConfig,
+  orgModelConfigTarget,
   convexClient,
   convexHttpUrl,
   convexAuthToken,
@@ -2382,6 +2538,7 @@ export const runEvalSuiteWithAiSdk = async ({
         recorder,
         modelApiKeys,
         orgModelConfig,
+        orgModelConfigTarget,
         convexHttpUrl,
         convexAuthToken,
         convexClient,
@@ -3106,6 +3263,8 @@ const streamIterationViaBackend = async ({
   convexHttpUrl,
   convexAuthToken,
   modelId,
+  endpointPath = "/stream",
+  extraBodyFields,
   convexClient,
   runId,
   abortSignal,
@@ -3286,7 +3445,7 @@ const streamIterationViaBackend = async ({
       const llmStartAbs = stepStartAbs;
       const stepMessageStartIndex = messageHistory.length;
       try {
-        const res = await fetch(`${convexHttpUrl}/stream`, {
+        const res = await fetch(`${convexHttpUrl}${endpointPath}`, {
           method: "POST",
           headers: {
             "content-type": "application/json",
@@ -3301,6 +3460,7 @@ const streamIterationViaBackend = async ({
             ...(toolChoice ? { toolChoice } : {}),
             tools: toolDefs,
             maxOutputTokens: 16384,
+            ...(extraBodyFields ?? {}),
           }),
           ...(abortSignal ? { signal: abortSignal } : {}),
         });
@@ -3876,6 +4036,7 @@ export const streamTestCase = async (params: {
   recorder: SuiteRunRecorder | null;
   modelApiKeys?: Record<string, string>;
   orgModelConfig?: ResolvedOrgModelConfig;
+  orgModelConfigTarget?: ResolveOrgModelConfigTarget;
   convexHttpUrl: string;
   convexAuthToken: string;
   convexClient: ConvexHttpClient;
@@ -3900,6 +4061,7 @@ export const streamTestCase = async (params: {
     recorder,
     modelApiKeys,
     orgModelConfig,
+    orgModelConfigTarget,
     convexHttpUrl,
     convexAuthToken,
     convexClient,
@@ -3921,6 +4083,16 @@ export const streamTestCase = async (params: {
     resolvedModelId,
     modelDefinition.provider,
   );
+  const orgByokRuntime = isJamModel
+    ? undefined
+    : await resolveOrgByokEvalRuntime({
+        test,
+        modelDefinition,
+        modelApiKeys,
+        orgModelConfig,
+        orgModelConfigTarget,
+        convexAuthToken,
+      });
 
   const outcomes: EvalIterationOutcome[] = [];
 
@@ -4005,6 +4177,38 @@ export const streamTestCase = async (params: {
       continue;
     }
 
+    if (orgByokRuntime?.kind === "cloud") {
+      const iterationOutcome = await streamIterationViaBackend({
+        test,
+        runIndex,
+        tools,
+        mcpClientManager,
+        recorder,
+        testCaseId,
+        suiteId,
+        convexHttpUrl,
+        convexAuthToken,
+        modelId: String(modelDefinition.id),
+        endpointPath: "/stream/org",
+        extraBodyFields: {
+          providerKey: orgByokRuntime.providerKey,
+          ...orgByokRuntime.target,
+        },
+        convexClient,
+        modelApiKeys,
+        orgModelConfig,
+        orgModelConfigTarget,
+        runId,
+        abortSignal,
+        emit,
+        compareRunId,
+        precreatedIterationId,
+        injectOpenAiCompat,
+      });
+      outcomes.push(iterationOutcome);
+      continue;
+    }
+
     const iterationOutcome = await streamIterationWithAiSdk({
       test,
       runIndex,
@@ -4015,7 +4219,11 @@ export const streamTestCase = async (params: {
       suiteId,
       modelDefinition,
       modelApiKeys,
-      orgModelConfig,
+      orgModelConfig:
+        orgByokRuntime?.kind === "local"
+          ? orgByokRuntime.orgModelConfig
+          : orgModelConfig,
+      orgModelConfigTarget,
       convexClient,
       runId,
       abortSignal,

--- a/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/evals-runner.test.ts
@@ -523,6 +523,62 @@ describe("runEvalSuiteWithAiSdk compare session metadata", () => {
     );
   });
 
+  it("runs org BYOK cloud eval models through Convex without raw provider keys", async () => {
+    fetchMock.mockResolvedValue(createBackendSuccessResponse());
+
+    await runEvalSuiteWithAiSdk({
+      suiteId: "suite-1",
+      runId: null,
+      config: {
+        tests: [
+          {
+            title: "Org BYOK Case",
+            query: "Hello",
+            runs: 1,
+            model: "gpt-4-turbo",
+            provider: "openai",
+            expectedToolCalls: [],
+            promptTurns: [
+              { id: "turn-1", prompt: "Hello", expectedToolCalls: [] },
+            ],
+            testCaseId: "case-1",
+          },
+        ],
+        environment: { servers: ["srv-1"] },
+      },
+      modelApiKeys: {},
+      orgModelConfigTarget: { projectId: "project-1" },
+      convexClient: convexClient as any,
+      convexHttpUrl: "https://example.convex.site",
+      convexAuthToken: "token",
+      mcpClientManager: mcpClientManager as any,
+      testCaseId: "case-1",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.convex.site/stream/org",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+    const request = fetchMock.mock.calls[0]?.[1] as {
+      body?: string;
+      headers?: ConstructorParameters<typeof Headers>[0];
+    };
+    const body = JSON.parse(request.body ?? "{}");
+    expect(body).toMatchObject({
+      mode: "step",
+      model: "gpt-4-turbo",
+      providerKey: "openai",
+      projectId: "project-1",
+    });
+    expect(body).not.toHaveProperty("apiKey");
+    expect(new Headers(request.headers).get("authorization")).toBe(
+      "Bearer token",
+    );
+    expect(createLlmModelMock).not.toHaveBeenCalled();
+  });
+
   it("uses full org config for custom eval models", async () => {
     await runEvalSuiteWithAiSdk({
       suiteId: "suite-1",

--- a/mcpjam-inspector/server/services/evals/__tests__/route-helpers.test.ts
+++ b/mcpjam-inspector/server/services/evals/__tests__/route-helpers.test.ts
@@ -21,12 +21,10 @@ import {
 } from "../route-helpers";
 
 const ORIGINAL_CONVEX_HTTP_URL = process.env.CONVEX_HTTP_URL;
-const ORIGINAL_INSPECTOR_SERVICE_TOKEN = process.env.INSPECTOR_SERVICE_TOKEN;
 
 describe("fetchReplayConfig", () => {
   beforeEach(() => {
     process.env.CONVEX_HTTP_URL = "https://convex.example";
-    process.env.INSPECTOR_SERVICE_TOKEN = "service-token";
     vi.stubGlobal("fetch", vi.fn());
   });
 
@@ -37,14 +35,9 @@ describe("fetchReplayConfig", () => {
     } else {
       process.env.CONVEX_HTTP_URL = ORIGINAL_CONVEX_HTTP_URL;
     }
-    if (ORIGINAL_INSPECTOR_SERVICE_TOKEN === undefined) {
-      delete process.env.INSPECTOR_SERVICE_TOKEN;
-    } else {
-      process.env.INSPECTOR_SERVICE_TOKEN = ORIGINAL_INSPECTOR_SERVICE_TOKEN;
-    }
   });
 
-  it("sends both the user bearer token and inspector service token", async () => {
+  it("sends the user bearer token to the public replay-config route", async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock.mockResolvedValue(
       new Response(
@@ -66,23 +59,26 @@ describe("fetchReplayConfig", () => {
     await fetchReplayConfig("run_123", "user-token");
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://convex.example/internal/v1/evals/runs/replay-config",
+      "https://convex.example/v1/evals/runs/replay-config",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
           Authorization: "Bearer user-token",
-          "X-Inspector-Service-Token": "service-token",
         }),
         signal: expect.any(AbortSignal),
       }),
     );
+    expect(
+      new Headers((fetchMock.mock.calls[0]?.[1] as RequestInit).headers).get(
+        "X-Inspector-Service-Token",
+      ),
+    ).toBeNull();
   });
 });
 
 describe("storeReplayConfig", () => {
   beforeEach(() => {
     process.env.CONVEX_HTTP_URL = "https://convex.example";
-    process.env.INSPECTOR_SERVICE_TOKEN = "service-token";
     vi.stubGlobal("fetch", vi.fn());
   });
 
@@ -93,14 +89,9 @@ describe("storeReplayConfig", () => {
     } else {
       process.env.CONVEX_HTTP_URL = ORIGINAL_CONVEX_HTTP_URL;
     }
-    if (ORIGINAL_INSPECTOR_SERVICE_TOKEN === undefined) {
-      delete process.env.INSPECTOR_SERVICE_TOKEN;
-    } else {
-      process.env.INSPECTOR_SERVICE_TOKEN = ORIGINAL_INSPECTOR_SERVICE_TOKEN;
-    }
   });
 
-  it("sends both the user bearer token and inspector service token", async () => {
+  it("sends the user bearer token to the public store-replay-config route", async () => {
     const fetchMock = vi.mocked(fetch);
     fetchMock.mockResolvedValue(
       new Response(
@@ -127,16 +118,20 @@ describe("storeReplayConfig", () => {
     );
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://convex.example/internal/v1/evals/runs/store-replay-config",
+      "https://convex.example/v1/evals/runs/store-replay-config",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
           Authorization: "Bearer user-token",
-          "X-Inspector-Service-Token": "service-token",
         }),
         signal: expect.any(AbortSignal),
       }),
     );
+    expect(
+      new Headers((fetchMock.mock.calls[0]?.[1] as RequestInit).headers).get(
+        "X-Inspector-Service-Token",
+      ),
+    ).toBeNull();
   });
 });
 

--- a/mcpjam-inspector/server/services/evals/replay-suite-run.ts
+++ b/mcpjam-inspector/server/services/evals/replay-suite-run.ts
@@ -162,6 +162,7 @@ export async function executeSuiteReplayFromRun(
       config,
       modelApiKeys: resolvedModelApiKeys ?? undefined,
       orgModelConfig: resolvedOrgModelConfig,
+      orgModelConfigTarget: replayOrgConfigTarget,
       convexClient,
       convexHttpUrl,
       convexAuthToken,

--- a/mcpjam-inspector/server/services/evals/route-helpers.ts
+++ b/mcpjam-inspector/server/services/evals/route-helpers.ts
@@ -11,8 +11,6 @@ import {
 } from "../../utils/export-helpers.js";
 import { INSPECTOR_MCP_RETRY_POLICY } from "../../utils/mcp-retry-policy.js";
 
-const INSPECTOR_SERVICE_TOKEN_HEADER = "X-Inspector-Service-Token";
-
 export type ReplayConfig = {
   runId: string;
   suiteId: string;
@@ -64,10 +62,6 @@ export async function fetchReplayConfig(
   userAuthToken: string,
 ): Promise<ReplayConfig | null> {
   const convexHttpUrl = requireConvexHttpUrl();
-  const inspectorServiceToken = process.env.INSPECTOR_SERVICE_TOKEN;
-  if (!inspectorServiceToken) {
-    throw new Error("INSPECTOR_SERVICE_TOKEN is not set");
-  }
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => {
@@ -77,13 +71,12 @@ export async function fetchReplayConfig(
   let response: Response;
   try {
     response = await fetch(
-      `${convexHttpUrl}/internal/v1/evals/runs/replay-config`,
+      `${convexHttpUrl}/v1/evals/runs/replay-config`,
       {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${userAuthToken}`,
-          [INSPECTOR_SERVICE_TOKEN_HEADER]: inspectorServiceToken,
         },
         body: JSON.stringify({ runId }),
         signal: controller.signal,
@@ -120,10 +113,6 @@ export async function storeReplayConfig(
   userAuthToken: string,
 ): Promise<void> {
   const convexHttpUrl = requireConvexHttpUrl();
-  const inspectorServiceToken = process.env.INSPECTOR_SERVICE_TOKEN;
-  if (!inspectorServiceToken) {
-    throw new Error("INSPECTOR_SERVICE_TOKEN is not set");
-  }
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => {
@@ -133,13 +122,12 @@ export async function storeReplayConfig(
   let response: Response;
   try {
     response = await fetch(
-      `${convexHttpUrl}/internal/v1/evals/runs/store-replay-config`,
+      `${convexHttpUrl}/v1/evals/runs/store-replay-config`,
       {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
           Authorization: `Bearer ${userAuthToken}`,
-          [INSPECTOR_SERVICE_TOKEN_HEADER]: inspectorServiceToken,
         },
         body: JSON.stringify({ runId, serverReplayConfigs }),
         signal: controller.signal,

--- a/mcpjam-inspector/server/utils/__tests__/org-model-config.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/org-model-config.test.ts
@@ -157,6 +157,9 @@ describe("isLocalRuntimeEligible", () => {
     expect(isLocalRuntimeEligible("azure")).toBe(false);
     expect(isLocalRuntimeEligible("google")).toBe(false);
     expect(isLocalRuntimeEligible("openrouter")).toBe(false);
-    expect(isLocalRuntimeEligible("custom:my-llm")).toBe(false);
+  });
+
+  it("returns true for custom providers because they can run locally", () => {
+    expect(isLocalRuntimeEligible("custom:my-llm")).toBe(true);
   });
 });

--- a/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/mcpjam-stream-handler.ts
@@ -105,10 +105,9 @@ export interface MCPJamHandlerOptions {
    */
   endpointPath?: string;
   /**
-   * Extra headers added to every per-step Convex request. Used by org BYOK
-   * chat to send the X-Inspector-Service-Token (the org route doesn't use
-   * Convex user auth). The standard authHeader is still forwarded so MCPJam
-   * billing identity can be derived on the /stream route.
+   * Extra headers added to every per-step Convex request. The standard
+   * authHeader is forwarded so Convex can resolve the caller for /stream and
+   * /stream/org.
    */
   extraHeaders?: Record<string, string>;
   /**
@@ -259,15 +258,6 @@ function createToolCallIdNormalizer(
     usedToolCallIds.add(normalized);
     return normalized;
   };
-}
-
-function getLatestUserMessageIndex(messageHistory: ModelMessage[]): number {
-  for (let index = messageHistory.length - 1; index >= 0; index -= 1) {
-    if (messageHistory[index]?.role === "user") {
-      return index;
-    }
-  }
-  return -1;
 }
 
 function getPromptAssistantStepBaseIndex(
@@ -691,7 +681,7 @@ function emitToolResults(
               : undefined;
           const rawOutput = part.output ?? (part as any).result;
 
-          let outputForUi = rawOutput;
+          let outputForUi: unknown = rawOutput;
           if (rawOutput && typeof rawOutput === "object") {
             const rawOutputObj = rawOutput as Record<string, unknown>;
             const existingMeta =
@@ -1046,7 +1036,7 @@ async function processOneStep(
 
   // Call the Convex streaming endpoint. The default endpoint is /stream
   // (MCPJam-provided models); org BYOK chat targets /stream/org and adds
-  // a service-token header via extraHeaders.
+  // provider/project fields via extraBodyFields.
   const {
     endpointPath,
     extraHeaders,

--- a/mcpjam-inspector/server/utils/org-model-config.ts
+++ b/mcpjam-inspector/server/utils/org-model-config.ts
@@ -28,6 +28,10 @@ export type ResolveOrgModelConfigTarget =
   | { workspaceId: string }
   | { organizationId: string };
 
+export type ResolveOrgProviderRuntimeTarget =
+  | { projectId: string }
+  | { workspaceId: string };
+
 export type ResolveOrgModelConfigAuth = {
   authHeader?: string;
   bearerToken?: string;
@@ -55,7 +59,10 @@ export type ResolveOrgModelConfigAuth = {
 const LOCAL_RUNTIME_ELIGIBLE_PROVIDERS = new Set(["ollama"]);
 
 export function isLocalRuntimeEligible(providerKey: string): boolean {
-  return LOCAL_RUNTIME_ELIGIBLE_PROVIDERS.has(providerKey);
+  return (
+    LOCAL_RUNTIME_ELIGIBLE_PROVIDERS.has(providerKey) ||
+    providerKey.startsWith("custom:")
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -99,15 +106,21 @@ function normalizeServerIds(serverIds: string[] | undefined): string[] {
   ).sort();
 }
 
-function buildCacheKey(
-  params: ResolveOrgModelConfigTarget,
-  auth: ResolveOrgModelConfigAuth | undefined,
+function formatTargetForCache(
+  params: ResolveOrgModelConfigTarget | ResolveOrgProviderRuntimeTarget,
 ): string {
-  const target = "projectId" in params
+  return "projectId" in params
     ? `project:${params.projectId}`
     : "workspaceId" in params
     ? `legacy-workspace:${params.workspaceId}`
     : `org:${params.organizationId}`;
+}
+
+function buildCacheKey(
+  params: ResolveOrgModelConfigTarget,
+  auth: ResolveOrgModelConfigAuth | undefined,
+): string {
+  const target = formatTargetForCache(params);
   // Cache key hashes (chatboxId, accessVersion) so a link-token rotation
   // doesn't invalidate cache entries while an accessVersion bump (mode
   // change, revoke, allowlist edit) does.
@@ -187,7 +200,11 @@ export async function resolveOrgModelConfig(
       throw new Error(message);
     }
 
-    const data = await response.json();
+    const data = (await response.json()) as {
+      ok?: boolean;
+      error?: string;
+      providers?: ResolvedProviderConfig[];
+    };
     if (!data?.ok) {
       throw new Error(data?.error ?? "Failed to resolve org model config");
     }
@@ -476,7 +493,7 @@ function pruneRuntimeResolveCache(now: number): void {
 }
 
 function buildRuntimeCacheKey(
-  projectId: string,
+  target: ResolveOrgProviderRuntimeTarget,
   providerKey: string,
   model: string,
   auth: ResolveOrgModelConfigAuth | undefined,
@@ -495,7 +512,7 @@ function buildRuntimeCacheKey(
       }),
     )
     .digest("hex");
-  return `runtime:project:${projectId}:${providerKey}:${model}:auth:${authHash}`;
+  return `runtime:${formatTargetForCache(target)}:${providerKey}:${model}:auth:${authHash}`;
 }
 
 /**
@@ -515,13 +532,24 @@ export async function resolveOrgProviderRuntime(
   model: string,
   auth?: ResolveOrgModelConfigAuth,
 ): Promise<OrgProviderRuntime> {
+  return resolveOrgProviderRuntimeForTarget(
+    { projectId },
+    providerKey,
+    model,
+    auth,
+  );
+}
+
+export async function resolveOrgProviderRuntimeForTarget(
+  target: ResolveOrgProviderRuntimeTarget,
+  providerKey: string,
+  model: string,
+  auth?: ResolveOrgModelConfigAuth,
+): Promise<OrgProviderRuntime> {
   const convexHttpUrl = process.env.CONVEX_HTTP_URL;
   if (!convexHttpUrl) throw new Error("CONVEX_HTTP_URL is not set");
 
-  const inspectorServiceToken = process.env.INSPECTOR_SERVICE_TOKEN;
-  if (!inspectorServiceToken) throw new Error("INSPECTOR_SERVICE_TOKEN is not set");
-
-  const cacheKey = buildRuntimeCacheKey(projectId, providerKey, model, auth);
+  const cacheKey = buildRuntimeCacheKey(target, providerKey, model, auth);
   const now = Date.now();
   pruneRuntimeResolveCache(now);
   const cached = runtimeResolveCache.get(cacheKey);
@@ -542,11 +570,10 @@ export async function resolveOrgProviderRuntime(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        [INSPECTOR_SERVICE_TOKEN_HEADER]: inspectorServiceToken,
         ...(authHeader ? { Authorization: authHeader } : {}),
       },
       body: JSON.stringify({
-        projectId,
+        ...target,
         providerKey,
         model,
         ...(auth?.chatboxId?.trim()
@@ -572,15 +599,29 @@ export async function resolveOrgProviderRuntime(
       throw new Error(message);
     }
 
-    const data = await response.json();
+    const data = (await response.json()) as {
+      ok?: boolean;
+      error?: string;
+      runtimeLocation?: string;
+      provider?: unknown;
+      providerKey?: unknown;
+    };
     if (!data?.ok) {
       throw new Error(data?.error ?? "Failed to resolve org provider runtime");
     }
 
     if (data.runtimeLocation === "local") {
-      const rawProvider = data.provider;
-      if (!rawProvider || typeof rawProvider.providerKey !== "string" || rawProvider.providerKey.length === 0) {
-        throw new Error("Org runtime resolve returned invalid local provider config");
+      const rawProvider = data.provider as
+        | Partial<OrgProviderResolvedConfig>
+        | undefined;
+      if (
+        !rawProvider ||
+        typeof rawProvider.providerKey !== "string" ||
+        rawProvider.providerKey.length === 0
+      ) {
+        throw new Error(
+          "Org runtime resolve returned invalid local provider config",
+        );
       }
       // SSRF guard: in hosted mode reject baseUrls that point to private,
       // loopback, link-local, or cloud-metadata addresses — including
@@ -599,7 +640,8 @@ export async function resolveOrgProviderRuntime(
       };
     } else {
       const resolvedKey =
-        typeof data.providerKey === "string" && data.providerKey.trim().length > 0
+        typeof data.providerKey === "string" &&
+        data.providerKey.trim().length > 0
           ? data.providerKey
           : providerKey;
       result = {

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -6,7 +6,7 @@
  * (local runtime, API key returned by /stream/org/resolve for this request only).
  *
  * handleHostedOrgChatModel → cloud: wraps handleMCPJamFreeChatModel and
- *   points it at /stream/org with the inspector service token + providerKey.
+ *   points it at /stream/org with the user auth header + providerKey.
  *
  * handleLocalOrgChatModel → local: builds the AI SDK model directly in the
  *   inspector using buildOrgModelFromResolvedConfig, runs streamText with the
@@ -79,6 +79,7 @@ export interface OrgModelHandlerOptions {
   tools: ToolSet;
   mcpClientManager: MCPClientManager;
   selectedServers?: string[];
+  serverIds?: string[];
   requireToolApproval?: boolean;
   onConversationComplete?: (
     fullHistory: ModelMessage[],
@@ -92,8 +93,7 @@ export interface OrgModelHandlerOptions {
   /**
    * The end user's Authorization header from the inbound request. Forwarded
    * to /stream/org so Convex can re-authorize the user against the project.
-   * Without this, /stream/org can only authenticate the inspector backend
-   * (via the service token) and will reject the request as unauthenticated.
+   * This is the auth boundary for org BYOK runtime requests.
    */
   authHeader?: string;
   /**
@@ -217,6 +217,7 @@ export interface OrgLocalModelHandlerOptions {
   temperature?: number;
   tools: ToolSet;
   selectedServers?: string[];
+  serverIds?: string[];
   requireToolApproval?: boolean;
   /** Forwarded to /stream/org/local-usage for identity resolution. */
   authHeader?: string;
@@ -513,6 +514,7 @@ export function handleLocalOrgChatModel(
             chatboxId,
             accessVersion,
             selectedServers: options.selectedServers,
+            serverIds: options.serverIds,
           }).catch((err) => {
             logger.warn("[org/local] Failed to post local usage", {
               error: err instanceof Error ? err.message : String(err),
@@ -575,10 +577,10 @@ async function postLocalUsage(params: {
   chatboxId?: string;
   accessVersion?: number;
   selectedServers?: string[];
+  serverIds?: string[];
 }): Promise<void> {
   const convexHttpUrl = process.env.CONVEX_HTTP_URL;
-  const inspectorServiceToken = process.env.INSPECTOR_SERVICE_TOKEN;
-  if (!convexHttpUrl || !inspectorServiceToken) return;
+  if (!convexHttpUrl) return;
 
   const url = `${convexHttpUrl.replace(/\/$/, "")}/stream/org/local-usage`;
   const controller = new AbortController();
@@ -588,7 +590,6 @@ async function postLocalUsage(params: {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "X-Inspector-Service-Token": inspectorServiceToken,
         ...(params.authHeader ? { Authorization: params.authHeader } : {}),
       },
       body: JSON.stringify({
@@ -610,8 +611,8 @@ async function postLocalUsage(params: {
         ...(params.chatboxId && Number.isFinite(params.accessVersion)
           ? { accessVersion: params.accessVersion }
           : {}),
-        ...(params.selectedServers && params.selectedServers.length > 0
-          ? { serverIds: params.selectedServers }
+        ...((params.serverIds ?? params.selectedServers)?.length
+          ? { serverIds: params.serverIds ?? params.selectedServers }
           : {}),
       }),
       signal: controller.signal,
@@ -638,10 +639,6 @@ export async function handleHostedOrgChatModel(
   if (!process.env.CONVEX_HTTP_URL) {
     throw new Error("CONVEX_HTTP_URL is not set");
   }
-  const inspectorServiceToken = process.env.INSPECTOR_SERVICE_TOKEN;
-  if (!inspectorServiceToken) {
-    throw new Error("INSPECTOR_SERVICE_TOKEN is not set");
-  }
 
   return handleMCPJamFreeChatModel({
     messages: options.messages,
@@ -664,16 +661,13 @@ export async function handleHostedOrgChatModel(
     onLiveTextDelta: options.onLiveTextDelta,
     clientIp: options.clientIp,
     endpointPath: "/stream/org",
-    extraHeaders: {
-      "X-Inspector-Service-Token": inspectorServiceToken,
-    },
     extraBodyFields: {
       providerKey: options.providerKey,
       ...(options.workspaceId ? { workspaceId: options.workspaceId } : {}),
       // chatboxId / accessVersion are set on the body by
       // handleMCPJamFreeChatModel itself.
-      ...(options.selectedServers && options.selectedServers.length > 0
-        ? { serverIds: options.selectedServers }
+      ...((options.serverIds ?? options.selectedServers)?.length
+        ? { serverIds: options.serverIds ?? options.selectedServers }
         : {}),
     },
   });


### PR DESCRIPTION
- Removes `INSPECTOR_SERVICE_TOKEN` from normal BYOK chat/eval traffic.
- BYOK now works the same in hosted and local/npx: user auth goes to Convex, Convex checks project access, then runs or resolves the provider.
- Keeps raw-key routes private: decrypted org model config still requires the service token.
- Lets npx evals save/load replay setup using user auth instead of the private service token.
- Adds `/stream/org` eval step-mode parity with `/stream`, so cloud BYOK evals can run in Convex without exposing provider keys.
- Keeps local-runtime providers like Ollama/custom Base URL as the exception: they still resolve through `/stream/org/resolve` and run in the inspector, matching PR #2064 behavior.
- Adds tests for chat, evals, replay config, and rollout compatibility.