### PR TITLE
[codex] Fix MCP apps compat output boot

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -413,7 +413,27 @@ describe("MCPAppsRenderer tool input streaming", () => {
     );
   });
 
-  it("waits for completed tool output before booting the OpenAI compat runtime", async () => {
+  it("does not block pure MCP Apps from booting while ChatGPT compat is enabled", async () => {
+    render(
+      <ChatboxHostStyleProvider value="chatgpt">
+        <MCPAppsRenderer
+          {...baseProps}
+          toolState="input-streaming"
+          toolInput={{ query: "yellow" }}
+          toolOutput={undefined}
+        />
+      </ChatboxHostStyleProvider>,
+    );
+
+    await vi.waitFor(() => {
+      expect(authFetch).toHaveBeenCalled();
+    });
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+  });
+
+  it("waits for completed tool output before booting legacy OpenAI outputTemplate widgets", async () => {
     const { rerender } = render(
       <ChatboxHostStyleProvider value="chatgpt">
         <MCPAppsRenderer
@@ -421,6 +441,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
           toolState="input-streaming"
           toolInput={{ query: "yellow" }}
           toolOutput={undefined}
+          toolMetadata={{ "openai/outputTemplate": "ui://widget/test.html" }}
         />
       </ChatboxHostStyleProvider>,
     );
@@ -442,6 +463,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
             content: [{ type: "text", text: "done" }],
             structuredContent: { route: "Yellow-N" },
           }}
+          toolMetadata={{ "openai/outputTemplate": "ui://widget/test.html" }}
         />
       </ChatboxHostStyleProvider>,
     );

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -413,6 +413,56 @@ describe("MCPAppsRenderer tool input streaming", () => {
     );
   });
 
+  it("waits for completed tool output before booting the OpenAI compat runtime", async () => {
+    const { rerender } = render(
+      <ChatboxHostStyleProvider value="chatgpt">
+        <MCPAppsRenderer
+          {...baseProps}
+          toolState="input-streaming"
+          toolInput={{ query: "yellow" }}
+          toolOutput={undefined}
+        />
+      </ChatboxHostStyleProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(authFetch).not.toHaveBeenCalled();
+    expect(mockBridge.connect).not.toHaveBeenCalled();
+
+    rerender(
+      <ChatboxHostStyleProvider value="chatgpt">
+        <MCPAppsRenderer
+          {...baseProps}
+          toolState="output-available"
+          toolInput={{ query: "yellow" }}
+          toolOutput={{
+            content: [{ type: "text", text: "done" }],
+            structuredContent: { route: "Yellow-N" },
+          }}
+        />
+      </ChatboxHostStyleProvider>,
+    );
+
+    await vi.waitFor(() => {
+      expect(authFetch).toHaveBeenCalled();
+    });
+
+    const requestInit = vi.mocked(authFetch).mock.calls[0]?.[1] as
+      | RequestInit
+      | undefined;
+    const body = JSON.parse(String(requestInit?.body ?? "{}")) as Record<
+      string,
+      unknown
+    >;
+    expect(body.toolOutput).toEqual({
+      content: [{ type: "text", text: "done" }],
+      structuredContent: { route: "Yellow-N" },
+    });
+  });
+
   it("user override wins over the host style preset", async () => {
     const override = {
       openLinks: {},

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -485,6 +485,65 @@ describe("MCPAppsRenderer tool input streaming", () => {
     });
   });
 
+  it("still waits for completed compat output when live fetch is preferred over a cached URL", async () => {
+    const { rerender } = render(
+      <ChatboxHostStyleProvider value="chatgpt">
+        <MCPAppsRenderer
+          {...baseProps}
+          toolState="input-streaming"
+          toolInput={{ query: "yellow" }}
+          toolOutput={undefined}
+          toolMetadata={{ "openai/outputTemplate": "ui://widget/test.html" }}
+          cachedWidgetHtmlUrl="blob:cached"
+          liveFetchPreferred
+        />
+      </ChatboxHostStyleProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(authFetch).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalledWith("blob:cached");
+    expect(mockBridge.connect).not.toHaveBeenCalled();
+
+    rerender(
+      <ChatboxHostStyleProvider value="chatgpt">
+        <MCPAppsRenderer
+          {...baseProps}
+          toolState="output-available"
+          toolInput={{ query: "yellow" }}
+          toolOutput={{
+            content: [{ type: "text", text: "done" }],
+            structuredContent: { route: "Yellow-N" },
+          }}
+          toolMetadata={{ "openai/outputTemplate": "ui://widget/test.html" }}
+          cachedWidgetHtmlUrl="blob:cached"
+          liveFetchPreferred
+        />
+      </ChatboxHostStyleProvider>,
+    );
+
+    await vi.waitFor(() => {
+      expect(authFetch).toHaveBeenCalled();
+    });
+
+    expect(global.fetch).not.toHaveBeenCalledWith("blob:cached");
+
+    const requestInit = vi.mocked(authFetch).mock.calls[0]?.[1] as
+      | RequestInit
+      | undefined;
+    const body = JSON.parse(String(requestInit?.body ?? "{}")) as Record<
+      string,
+      unknown
+    >;
+    expect(body.toolOutput).toEqual({
+      content: [{ type: "text", text: "done" }],
+      structuredContent: { route: "Yellow-N" },
+    });
+  });
+
   it("user override wins over the host style preset", async () => {
     const override = {
       openLinks: {},

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/useToolInputStreaming.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/useToolInputStreaming.test.ts
@@ -355,7 +355,7 @@ describe("useToolInputStreaming", () => {
     expect(result.current.canRenderStreamingInput).toBe(true);
   });
 
-  it("fallback reveal timer fires after STREAMING_REVEAL_FALLBACK_MS", () => {
+  it("fallback reveal timer permits rendering before parseable partial args arrive", () => {
     const props = createDefaultProps(bridge);
     props.toolState = "input-streaming";
     // No toolInput — so no partial will be sent, relying on fallback timer
@@ -365,7 +365,8 @@ describe("useToolInputStreaming", () => {
     // Before fallback timer: not signaled, no delivery
     expect(result.current.canRenderStreamingInput).toBe(false);
 
-    // Advance past fallback timer
+    // Advance past fallback timer. Providers that never stream parseable
+    // partial args should still let the iframe boot and wait for final input.
     act(() => {
       vi.advanceTimersByTime(STREAMING_REVEAL_FALLBACK_MS + 10);
     });

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/useToolInputStreaming.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/useToolInputStreaming.test.ts
@@ -355,7 +355,7 @@ describe("useToolInputStreaming", () => {
     expect(result.current.canRenderStreamingInput).toBe(true);
   });
 
-  it("fallback reveal timer permits rendering before parseable partial args arrive", () => {
+  it("fallback reveal timer does not render before parseable partial args arrive", () => {
     const props = createDefaultProps(bridge);
     props.toolState = "input-streaming";
     // No toolInput — so no partial will be sent, relying on fallback timer
@@ -365,13 +365,13 @@ describe("useToolInputStreaming", () => {
     // Before fallback timer: not signaled, no delivery
     expect(result.current.canRenderStreamingInput).toBe(false);
 
-    // Advance past fallback timer. Providers that never stream parseable
-    // partial args should still let the iframe boot and wait for final input.
+    // Advance past fallback timer. This is only a render signal; without
+    // delivered input, revealing the iframe produces a blank-shell flicker.
     act(() => {
       vi.advanceTimersByTime(STREAMING_REVEAL_FALLBACK_MS + 10);
     });
 
-    expect(result.current.canRenderStreamingInput).toBe(true);
+    expect(result.current.canRenderStreamingInput).toBe(false);
   });
 
   it("does not send partial when bridge is null", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/useToolInputStreaming.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/useToolInputStreaming.test.ts
@@ -323,16 +323,14 @@ describe("useToolInputStreaming", () => {
   it("signalStreamingRender sets the render signal", () => {
     const props = createDefaultProps(bridge);
     props.toolState = "input-streaming";
-    // Start without toolInput — the reset-on-toolCallId effect also fires on
-    // the first render and would undo the partial delivery state.
     props.toolInput = undefined;
 
     const { result, rerender } = renderHook(() => useToolInputStreaming(props));
 
     expect(result.current.canRenderStreamingInput).toBe(false);
 
-    // Now set toolInput — only the partial delivery effect re-fires,
-    // the reset effect does NOT (toolCallId hasn't changed).
+    // Now set toolInput — only the partial delivery effect re-fires
+    // because toolCallId hasn't changed.
     props.toolInput = { code: "hello" };
     rerender();
 
@@ -372,10 +370,7 @@ describe("useToolInputStreaming", () => {
       vi.advanceTimersByTime(STREAMING_REVEAL_FALLBACK_MS + 10);
     });
 
-    // Fallback timer sets streamingRenderSignaled, but hasDeliveredStreamingInput
-    // is still false — so canRenderStreamingInput remains false
-    // (both conditions must be true)
-    expect(result.current.canRenderStreamingInput).toBe(false);
+    expect(result.current.canRenderStreamingInput).toBe(true);
   });
 
   it("does not send partial when bridge is null", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -613,6 +613,17 @@ export function MCPAppsRenderer({
   const widgetInjectOpenAiCompatReloadKey = isCachedReplay
     ? cachedReplayInjectOpenAiCompat
     : effectiveInjectOpenAiCompat;
+  // The OpenAI Apps SDK compatibility runtime bakes toolInput/toolOutput into
+  // `window.openai` during HTML injection. Pure SEP-1865 views can boot while
+  // input is still streaming and receive the final result via
+  // ui/notifications/tool-result, but many Apps SDK widgets read
+  // window.openai.toolOutput once on mount. Booting those widgets before the
+  // tool has completed leaves them looking stuck even though the bridge later
+  // delivers the result event.
+  const shouldWaitForCompatToolOutput =
+    !isCachedReplay &&
+    effectiveInjectOpenAiCompat &&
+    toolState !== "output-available";
   const [widgetCsp, setWidgetCsp] = useState<McpUiResourceCsp | undefined>(
     isCachedReplay ? undefined : (initialWidgetCsp ?? undefined),
   );
@@ -750,6 +761,7 @@ export function MCPAppsRenderer({
       toolState === "input-available" ||
       toolState === "output-available";
     if (!isActiveToolState) return;
+    if (shouldWaitForCompatToolOutput) return;
     // Re-fetch if CSP mode changed (widget needs to reload with new CSP
     // policy) OR if the compat-runtime flag changed (HTML needs to be
     // rebuilt with/without the `window.openai` shim). Both belong in
@@ -1017,6 +1029,7 @@ export function MCPAppsRenderer({
     liveFetchPreferred,
     initialPrefersBorder,
     cachedReplayInjectOpenAiCompat,
+    shouldWaitForCompatToolOutput,
     recordMountStore,
   ]);
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -605,7 +605,10 @@ export function MCPAppsRenderer({
   const [widgetHtml, setWidgetHtml] = useState<string | null>(null);
   const [sandboxProxyReady, setSandboxProxyReady] = useState(false);
   const [bridgeTransportReady, setBridgeTransportReady] = useState(false);
-  const isCachedReplay = !!cachedWidgetHtmlUrl;
+  // A cached URL can exist during an in-flow revisit while the renderer still
+  // prefers live HTML. Treat only cached-only renders as replay; live compat
+  // fetches still need completed tool output baked into window.openai at boot.
+  const isCachedReplay = !!cachedWidgetHtmlUrl && !liveFetchPreferred;
   const cachedReplayInjectOpenAiCompat =
     typeof initialInjectedOpenAiCompat === "boolean"
       ? initialInjectedOpenAiCompat
@@ -823,18 +826,24 @@ export function MCPAppsRenderer({
       setLoadedCspMode(cspMode);
       // Cached replay: HTML is byte-frozen at capture time. Trust persisted
       // provenance when available; otherwise keep it unknown instead of
-      // inferring from the current live host.
-      setLoadedInjectOpenAiCompat(cachedReplayInjectOpenAiCompat);
+      // inferring from the current live host. When this is the fallback path
+      // after a preferred live fetch failed, mark the loaded fallback as
+      // satisfying the current reload key so the effect doesn't immediately
+      // retry live and overwrite the cached render.
+      const loadedCachedCompatKey = isCachedReplay
+        ? cachedReplayInjectOpenAiCompat
+        : widgetInjectOpenAiCompatReloadKey;
+      setLoadedInjectOpenAiCompat(loadedCachedCompatKey);
       setWidgetHtmlStore(
         toolCallId,
         html,
-        cachedReplayInjectOpenAiCompat ?? undefined,
+        loadedCachedCompatKey ?? undefined,
       );
       logWidgetDebug("host-to-ui", "debug/widget-content-ready", {
         cached: true,
         cspMode,
         htmlLength: html.length,
-        injectOpenAiCompat: cachedReplayInjectOpenAiCompat,
+        injectOpenAiCompat: loadedCachedCompatKey,
         permissive: true,
       });
     };

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -616,13 +616,15 @@ export function MCPAppsRenderer({
   // The OpenAI Apps SDK compatibility runtime bakes toolInput/toolOutput into
   // `window.openai` during HTML injection. Pure SEP-1865 views can boot while
   // input is still streaming and receive the final result via
-  // ui/notifications/tool-result, but many Apps SDK widgets read
-  // window.openai.toolOutput once on mount. Booting those widgets before the
-  // tool has completed leaves them looking stuck even though the bridge later
-  // delivers the result event.
+  // ui/notifications/tool-result. Legacy Apps SDK templates declared through
+  // `openai/outputTemplate` are different: many read window.openai.toolOutput
+  // once on mount, so they still need the completed output before boot.
+  const requiresCompatOutputAtBoot =
+    effectiveInjectOpenAiCompat &&
+    typeof toolMetadata?.["openai/outputTemplate"] === "string";
   const shouldWaitForCompatToolOutput =
     !isCachedReplay &&
-    effectiveInjectOpenAiCompat &&
+    requiresCompatOutputAtBoot &&
     toolState !== "output-available";
   const [widgetCsp, setWidgetCsp] = useState<McpUiResourceCsp | undefined>(
     isCachedReplay ? undefined : (initialWidgetCsp ?? undefined),

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/useToolInputStreaming.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/useToolInputStreaming.ts
@@ -7,7 +7,14 @@
  * without touching the renderer component.
  */
 
-import { useRef, useState, useMemo, useCallback, useEffect } from "react";
+import {
+  useRef,
+  useState,
+  useMemo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+} from "react";
 import type { AppBridge } from "@modelcontextprotocol/ext-apps/app-bridge";
 import type { CallToolResult } from "@modelcontextprotocol/client";
 
@@ -178,6 +185,7 @@ export function useToolInputStreaming({
   const lastToolErrorRef = useRef<string | null>(null);
   const toolInputSentRef = useRef(false);
   const previousToolStateRef = useRef<ToolState | undefined>(toolState);
+  const previousToolCallIdRef = useRef(toolCallId);
 
   // ── Internal state ───────────────────────────────────────────────────────
 
@@ -194,7 +202,10 @@ export function useToolInputStreaming({
 
   const canRenderStreamingInput = useMemo(() => {
     if (toolState !== "input-streaming") return true;
-    return streamingRenderSignaled && hasDeliveredStreamingInput;
+    // Some providers do not surface parseable partial tool args before the
+    // complete input arrives. Reveal after the fallback signal so the iframe can
+    // initialize and show its own loading state instead of staying invisible.
+    return streamingRenderSignaled || hasDeliveredStreamingInput;
   }, [hasDeliveredStreamingInput, streamingRenderSignaled, toolState]);
 
   // ── Callbacks ────────────────────────────────────────────────────────────
@@ -321,7 +332,15 @@ export function useToolInputStreaming({
       partialInputTimerRef.current = null;
       flushPartialInput();
     }, PARTIAL_INPUT_THROTTLE_MS - elapsed);
-  }, [hasToolInputData, isReady, toolInput, toolState, bridgeRef, isReadyRef]);
+  }, [
+    hasToolInputData,
+    isReady,
+    toolCallId,
+    toolInput,
+    toolState,
+    bridgeRef,
+    isReadyRef,
+  ]);
 
   // 5. Complete input delivery
   useEffect(() => {
@@ -356,7 +375,7 @@ export function useToolInputStreaming({
       toolInputSentRef.current = false;
       lastToolInputRef.current = null;
     });
-  }, [isReady, toolInput, toolState, bridgeRef, reinitCount]);
+  }, [isReady, toolCallId, toolInput, toolState, bridgeRef, reinitCount]);
 
   // 6. Tool result delivery
   useEffect(() => {
@@ -368,7 +387,7 @@ export function useToolInputStreaming({
     if (lastToolOutputRef.current === serialized) return;
     lastToolOutputRef.current = serialized;
     bridge.sendToolResult(toolOutput as CallToolResult);
-  }, [isReady, toolOutput, toolState, bridgeRef, reinitCount]);
+  }, [isReady, toolCallId, toolOutput, toolState, bridgeRef, reinitCount]);
 
   // 7. Tool error/cancellation delivery
   useEffect(() => {
@@ -389,10 +408,20 @@ export function useToolInputStreaming({
 
     // SEP-1865: Send tool-cancelled for errors instead of tool-result with isError
     bridge.sendToolCancelled({ reason: errorMessage });
-  }, [isReady, toolErrorText, toolOutput, toolState, bridgeRef, reinitCount]);
+  }, [
+    isReady,
+    toolCallId,
+    toolErrorText,
+    toolOutput,
+    toolState,
+    bridgeRef,
+    reinitCount,
+  ]);
 
   // 8. Reset on toolCallId change
-  useEffect(() => {
+  useLayoutEffect(() => {
+    if (previousToolCallIdRef.current === toolCallId) return;
+    previousToolCallIdRef.current = toolCallId;
     resetStreamingState();
   }, [toolCallId, resetStreamingState]);
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/useToolInputStreaming.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/useToolInputStreaming.ts
@@ -202,11 +202,9 @@ export function useToolInputStreaming({
 
   const canRenderStreamingInput = useMemo(() => {
     if (toolState !== "input-streaming") return true;
-    // Some providers do not surface parseable partial tool args before the
-    // complete input arrives. Reveal after the fallback signal so the iframe can
-    // initialize and show its own loading state instead of staying invisible;
-    // views still receive ui/notifications/tool-input once final args arrive.
-    return streamingRenderSignaled || hasDeliveredStreamingInput;
+    // Avoid revealing a blank app shell on the fallback timer alone. The view
+    // becomes visible after we have both a render signal and delivered input.
+    return streamingRenderSignaled && hasDeliveredStreamingInput;
   }, [hasDeliveredStreamingInput, streamingRenderSignaled, toolState]);
 
   // ── Callbacks ────────────────────────────────────────────────────────────

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/useToolInputStreaming.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/useToolInputStreaming.ts
@@ -204,7 +204,8 @@ export function useToolInputStreaming({
     if (toolState !== "input-streaming") return true;
     // Some providers do not surface parseable partial tool args before the
     // complete input arrives. Reveal after the fallback signal so the iframe can
-    // initialize and show its own loading state instead of staying invisible.
+    // initialize and show its own loading state instead of staying invisible;
+    // views still receive ui/notifications/tool-input once final args arrive.
     return streamingRenderSignaled || hasDeliveredStreamingInput;
   }, [hasDeliveredStreamingInput, streamingRenderSignaled, toolState]);
 
@@ -418,7 +419,8 @@ export function useToolInputStreaming({
     reinitCount,
   ]);
 
-  // 8. Reset on toolCallId change
+  // 8. Reset on toolCallId change. Do this before paint so a recycled renderer
+  // cannot briefly expose the previous call's delivery guards.
   useLayoutEffect(() => {
     if (previousToolCallIdRef.current === toolCallId) return;
     previousToolCallIdRef.current = toolCallId;

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -45,6 +45,12 @@ const createAsyncIterable = (events: any[]) => ({
   },
 });
 
+const createThrowingAsyncIterable = (error: unknown) => ({
+  async *[Symbol.asyncIterator]() {
+    throw error;
+  },
+});
+
 // Mock the AI SDK
 vi.mock("ai", async () => {
   const actual = await vi.importActual<typeof import("ai")>("ai");
@@ -507,6 +513,44 @@ describe("POST /api/mcp/chat-v2", () => {
 
       expect(status).toBe(500);
       expect(data.error).toBe("Unexpected error");
+    });
+
+    it("swallows abort errors without emitting a user-visible stream error", async () => {
+      const { streamText } = await import("ai");
+      const abortError = new Error("The operation was aborted");
+      abortError.name = "AbortError";
+      let capturedToUiMessageStreamOnError:
+        | ((error: unknown) => string)
+        | undefined;
+
+      vi.mocked(streamText).mockImplementationOnce(
+        (() => ({
+          toUIMessageStream: vi.fn((options?: { onError?: unknown }) => {
+            capturedToUiMessageStreamOnError = options?.onError as
+              | ((error: unknown) => string)
+              | undefined;
+            return createThrowingAsyncIterable(abortError);
+          }),
+          toUIMessageStreamResponse: vi.fn(),
+        })) as any,
+      );
+
+      const res = await postJson(app, "/api/mcp/chat-v2", {
+        messages: [{ role: "user", content: "Hello" }],
+        model: { id: "gpt-4", provider: "openai" },
+        apiKey: "test-key",
+      });
+
+      expect(res.status).toBe(200);
+      await expect(lastStreamExecution).resolves.toBeUndefined();
+      expect(capturedCreateUiStreamOnError?.(abortError)).toBe("");
+      expect(capturedToUiMessageStreamOnError?.(abortError)).toBe("");
+      expect(
+        capturedStreamEvents.some(
+          (event) =>
+            event?.type === "data-trace-event" && event.data?.type === "error",
+        ),
+      ).toBe(false);
     });
   });
 

--- a/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
+++ b/mcpjam-inspector/server/routes/mcp/__tests__/chat-v2.test.ts
@@ -453,6 +453,22 @@ describe("POST /api/mcp/chat-v2", () => {
       );
     });
 
+    it("passes the inbound abort signal to user-provided streamText calls", async () => {
+      const { streamText } = await import("ai");
+
+      await postJson(app, "/api/mcp/chat-v2", {
+        messages: [{ role: "user", content: "Hello" }],
+        model: { id: "gpt-4", provider: "openai" },
+        apiKey: "test-key",
+      });
+
+      expect(streamText).toHaveBeenCalledWith(
+        expect.objectContaining({
+          abortSignal: expect.any(AbortSignal),
+        }),
+      );
+    });
+
     it("includes system prompt when provided", async () => {
       const { streamText } = await import("ai");
 

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -67,6 +67,7 @@ import {
   mergeLiveChatTraceUsage,
   type LiveChatTraceUsage,
 } from "@/shared/live-chat-trace";
+import { isAbortError } from "@/shared/abort-errors";
 
 function formatStreamError(error: unknown, provider?: ModelProvider): string {
   if (!(error instanceof Error)) {
@@ -195,6 +196,7 @@ function streamDirectChatWithLiveTrace(options: {
   systemPrompt: string;
   temperature?: number;
   tools: ToolSet;
+  abortSignal?: AbortSignal;
   onPersist?: (event: {
     responseMessages: ModelMessage[];
     assistantText: string;
@@ -213,6 +215,7 @@ function streamDirectChatWithLiveTrace(options: {
     systemPrompt,
     temperature,
     tools,
+    abortSignal,
     onPersist,
   } = options;
 
@@ -236,9 +239,17 @@ function streamDirectChatWithLiveTrace(options: {
   const providerSystemPrompt = normalizeSystemPromptForProvider(systemPrompt);
   let currentStepIndex = 0;
   let turnFinished = false;
+  let aborted = abortSignal?.aborted === true;
+  const markAborted = () => {
+    aborted = true;
+  };
+  abortSignal?.addEventListener("abort", markAborted, { once: true });
 
   const stream = createUIMessageStream({
     onError: (error) => {
+      if (aborted || isAbortError(error)) {
+        return "";
+      }
       logger.error("[mcp/chat-v2] stream error", error);
       return formatStreamError(error, provider);
     },
@@ -274,6 +285,7 @@ function streamDirectChatWithLiveTrace(options: {
         system: providerSystemPrompt,
         tools: tracedTools,
         stopWhen: stepCountIs(20),
+        ...(abortSignal ? { abortSignal } : {}),
         prepareStep: ({ stepNumber }) => {
           currentStepIndex = stepNumber;
           registerAiSdkPrepareStep(traceContext, stepNumber, {
@@ -363,6 +375,11 @@ function streamDirectChatWithLiveTrace(options: {
           if (turnFinished) {
             return;
           }
+          if (aborted || isAbortError(error)) {
+            aborted = true;
+            turnFinished = true;
+            return;
+          }
 
           const failAt = Date.now();
           finalizeAiSdkTraceOnFailure(traceContext, failAt, {
@@ -389,6 +406,12 @@ function streamDirectChatWithLiveTrace(options: {
           turnFinished = true;
         },
         onFinish: async (event) => {
+          if (aborted || abortSignal?.aborted) {
+            aborted = true;
+            turnFinished = true;
+            return;
+          }
+
           patchAiSdkRecordedSpansMessageRangesFromSteps(
             traceContext.recordedSpans,
             initialMessageHistoryLength,
@@ -449,19 +472,32 @@ function streamDirectChatWithLiveTrace(options: {
         },
       });
 
-      for await (const chunk of result.toUIMessageStream({
-        messageMetadata: ({ part }) => {
-          if (part.type === "finish-step") {
-            return {
-              inputTokens: part.usage.inputTokens,
-              outputTokens: part.usage.outputTokens,
-              totalTokens: part.usage.totalTokens,
-            };
-          }
-        },
-        onError: (error) => formatStreamError(error, provider),
-      })) {
-        writer.write(chunk);
+      try {
+        for await (const chunk of result.toUIMessageStream({
+          messageMetadata: ({ part }) => {
+            if (part.type === "finish-step") {
+              return {
+                inputTokens: part.usage.inputTokens,
+                outputTokens: part.usage.outputTokens,
+                totalTokens: part.usage.totalTokens,
+              };
+            }
+          },
+          onError: (error) => {
+            if (aborted || isAbortError(error)) return "";
+            return formatStreamError(error, provider);
+          },
+        })) {
+          writer.write(chunk);
+        }
+      } catch (error) {
+        if (aborted || isAbortError(error)) {
+          aborted = true;
+          return;
+        }
+        throw error;
+      } finally {
+        abortSignal?.removeEventListener("abort", markAborted);
       }
     },
   });
@@ -858,6 +894,10 @@ chatV2.post("/", async (c) => {
     const streamStartedAt = Date.now();
     const authHeader = c.req.header("authorization");
     const chatSessionId = body.chatSessionId;
+    const inboundAbortSignalDirect = c.req.raw.signal as
+      | AbortSignal
+      | undefined;
+    warnIfChatAbortSignalMissing(inboundAbortSignalDirect, "mcp/chat-v2");
 
     const scrubbedModelMessages = scrubMessages(
       modelMessages as ModelMessage[]
@@ -871,6 +911,7 @@ chatV2.post("/", async (c) => {
       systemPrompt: enhancedSystemPrompt,
       temperature: resolvedTemperature,
       tools: allTools as ToolSet,
+      abortSignal: inboundAbortSignalDirect,
       onPersist: chatSessionId
         ? async ({
             responseMessages,

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -278,7 +278,7 @@ function streamDirectChatWithLiveTrace(options: {
         traceTurn.promptIndex
       ) as ToolSet;
 
-      const result = streamText({
+      const streamTextOptions: Parameters<typeof streamText>[0] = {
         model: llmModel,
         messages: messageHistory,
         ...(temperature !== undefined ? { temperature } : {}),
@@ -470,7 +470,19 @@ function streamDirectChatWithLiveTrace(options: {
             });
           }
         },
-      });
+      };
+
+      let result: ReturnType<typeof streamText>;
+      try {
+        result = streamText(streamTextOptions);
+      } catch (error) {
+        abortSignal?.removeEventListener("abort", markAborted);
+        if (aborted || isAbortError(error)) {
+          aborted = true;
+          return;
+        }
+        throw error;
+      }
 
       try {
         for await (const chunk of result.toUIMessageStream({


### PR DESCRIPTION
## Summary

Fixes the MCP Apps renderer path for ChatGPT/OpenAI-compatible widgets by waiting until the initial tool call reaches output-available before fetching and injecting the widget HTML when the window.openai compatibility runtime is enabled.

## Root Cause

The consolidated renderer treated input-streaming and input-available as active states for every widget. That is correct for pure SEP-1865 apps because the bridge later sends ui/notifications/tool-result, but the OpenAI compatibility runtime bakes window.openai.toolOutput into the initial HTML injection. Widgets that read window.openai.toolOutput once on mount could boot with no output and then appear stuck.

## Changes

- Gate live widget-content fetches behind output-available only when OpenAI compatibility injection is active.
- Preserve existing cached replay behavior and pure MCP Apps streaming behavior.
- Add a renderer regression test that verifies ChatGPT-style hosts do not fetch widget HTML until completed output is available, and that the completed output is sent in the request body.

## Validation

- npm run test -w @mcpjam/inspector -- client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
- npm run typecheck:client -w @mcpjam/inspector

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes widget boot timing for OpenAI-compat templates and modifies server streaming abort handling, which could affect when/if widgets render and how chat streams terminate under cancellation.
> 
> **Overview**
> **Fixes OpenAI Apps SDK compatibility widgets booting without `toolOutput`.** `MCPAppsRenderer` now delays live widget HTML fetching/injection until `toolState` is `output-available` *only* when `openai/outputTemplate` is present and OpenAI compat injection is enabled, while keeping pure SEP-1865 apps booting during input streaming.
> 
> **Tightens cached/live replay behavior for compat.** Cached renders are only treated as “replay” when live fetch isn’t preferred, and the cached fallback path now records a compat reload key that prevents immediate re-fetch loops.
> 
> **Improves streaming input and server abort behavior with regression coverage.** `useToolInputStreaming` resets state on `toolCallId` changes before paint and includes `toolCallId` in delivery effect deps; server `chat-v2` passes the inbound abort signal into `streamText` and suppresses user-visible errors/trace error events on abort. Added tests covering the new gating and abort semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 369cc4fb15befff2ec13afd80cddb33701d45ce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->