### PR TITLE
fix(chat-v2): keep widgets visible when reopening past chats

### DIFF
--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -80,6 +80,7 @@ import { ChatHistoryRail } from "@/components/chat-v2/history/ChatHistoryRail";
 import {
   chatHistoryAction,
   getChatHistoryDetail,
+  getChatHistoryWidgetSnapshotSignature,
   type ChatHistoryDetailSession,
   type ChatHistorySession,
   type ChatHistoryTurnTrace,
@@ -265,6 +266,7 @@ export function ChatTabV2({
   const lastAppliedReactiveVersionRef = useRef<{
     sessionId: string;
     version: number;
+    widgetSnapshotSignature: string | null;
   } | null>(null);
   const hasUnsavedDraftRef = useRef(false);
 
@@ -566,6 +568,12 @@ export function ChatTabV2({
     lastAppliedReactiveVersionRef.current = {
       sessionId: activeHistorySessionId,
       version: resumedVersion,
+      // Preserve any signature stamped by loadHistorySession when the
+      // session id matches; otherwise we don't yet have one to track.
+      widgetSnapshotSignature:
+        lastApplied?.sessionId === activeHistorySessionId
+          ? lastApplied.widgetSnapshotSignature
+          : null,
     };
   }, [activeHistorySessionId, resumedVersion]);
 
@@ -683,6 +691,8 @@ export function ChatTabV2({
       lastAppliedReactiveVersionRef.current = {
         sessionId: detail._id,
         version: detail.version,
+        widgetSnapshotSignature:
+          getChatHistoryWidgetSnapshotSignature(widgetSnapshots),
       };
       void markHistorySessionRead(detail._id);
     },
@@ -810,9 +820,14 @@ export function ChatTabV2({
     }
 
     const lastApplied = lastAppliedReactiveVersionRef.current;
+    const incomingSignature = getChatHistoryWidgetSnapshotSignature(
+      reactiveHistoryWidgetSnapshots,
+    );
+
     if (
       lastApplied?.sessionId === reactiveHistorySession._id &&
-      lastApplied.version >= reactiveHistorySession.version
+      lastApplied.version >= reactiveHistorySession.version &&
+      lastApplied.widgetSnapshotSignature === incomingSignature
     ) {
       return;
     }

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -395,6 +395,8 @@ export function ChatTabV2({
       selectedServerIds: effectiveHostedSelectedServerIds,
       oauthTokens: effectiveHostedOAuthTokens,
     },
+    resolveServerConvexId: (localServerId) =>
+      serversByName.get(localServerId),
     executionConfig,
     // Phase 3: forward the resolved chat-tab host style so direct
     // chat traces persist with `claude`/`chatgpt` rather than

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -397,6 +397,7 @@ export function ChatTabV2({
     },
     resolveServerConvexId: (localServerId) =>
       serversByName.get(localServerId),
+    resolveServerLocalId: (convexServerId) => serversById.get(convexServerId),
     executionConfig,
     // Phase 3: forward the resolved chat-tab host style so direct
     // chat traces persist with `claude`/`chatgpt` rather than

--- a/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ChatTabV2.history-sync.test.tsx
@@ -419,6 +419,20 @@ vi.mock("@/lib/apis/web/chat-history-api", () => ({
   getChatHistoryDetail: (...args: unknown[]) =>
     mockGetChatHistoryDetail(...args),
   chatHistoryAction: (...args: unknown[]) => mockChatHistoryAction(...args),
+  getChatHistoryWidgetSnapshotSignature: (
+    snapshots: Array<Record<string, unknown>> | undefined,
+  ): string =>
+    (snapshots ?? [])
+      .map((snapshot) =>
+        JSON.stringify([
+          snapshot._id,
+          snapshot.toolCallId,
+          snapshot.resourceUri ?? "",
+          snapshot.createdAt ?? 0,
+        ]),
+      )
+      .sort()
+      .join("|"),
 }));
 
 describe("ChatTabV2 history sync", () => {
@@ -956,5 +970,128 @@ describe("ChatTabV2 history sync", () => {
       "archive",
       "history-1"
     );
+  });
+
+  it("reloads when a new widget snapshot arrives at the same session version", async () => {
+    const initialDetailResponse = {
+      ok: true,
+      session: {
+        ...mockHistorySession,
+        messagesBlobUrl: "https://storage.test/blob",
+        resumeConfig: {
+          selectedServers: ["server-1"],
+        },
+      },
+      widgetSnapshots: [],
+    };
+
+    mockGetChatHistoryDetail.mockResolvedValue(initialDetailResponse);
+
+    const view = render(<ChatTabV2 {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Show sessions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select thread" }));
+    await flushMicrotasks();
+
+    expect(mockUseChatSession.loadChatSession).toHaveBeenCalledTimes(1);
+
+    mockUseChatSession.loadChatSession.mockClear();
+
+    // Reactive query emits the same session version, but with a newly
+    // inserted widget snapshot row.
+    mockReactiveHistoryState.session = {
+      ...initialDetailResponse.session,
+    };
+    mockReactiveHistoryState.widgetSnapshots = [
+      {
+        _id: "snap-1",
+        sessionId: "history-1",
+        toolCallId: "call-1",
+        toolName: "search",
+        serverId: "server-1",
+        uiType: "mcp-apps" as const,
+        resourceUri: "ui://widget.html",
+        widgetCsp: null,
+        widgetPermissions: null,
+        widgetPermissive: false,
+        prefersBorder: false,
+        widgetHtmlUrl: "https://storage.test/widget-html-1",
+        toolOutputUrl: "https://storage.test/tool-output-1",
+        createdAt: 1_700_000_000_000,
+      },
+    ];
+
+    view.rerender(<ChatTabV2 {...defaultProps} />);
+    await flushMicrotasks();
+
+    expect(mockUseChatSession.loadChatSession).toHaveBeenCalledTimes(1);
+    const loadArgs = mockUseChatSession.loadChatSession.mock.calls[0][0];
+    expect(loadArgs.widgetSnapshots).toHaveLength(1);
+    expect(loadArgs.widgetSnapshots[0]._id).toBe("snap-1");
+  });
+
+  it("does not reload when only signed snapshot URLs change", async () => {
+    const baseSnapshot = {
+      _id: "snap-1",
+      sessionId: "history-1",
+      toolCallId: "call-1",
+      toolName: "search",
+      serverId: "server-1",
+      uiType: "mcp-apps" as const,
+      resourceUri: "ui://widget.html",
+      widgetCsp: null,
+      widgetPermissions: null,
+      widgetPermissive: false,
+      prefersBorder: false,
+      createdAt: 1_700_000_000_000,
+    };
+
+    const initialDetailResponse = {
+      ok: true,
+      session: {
+        ...mockHistorySession,
+        messagesBlobUrl: "https://storage.test/blob",
+        resumeConfig: {
+          selectedServers: ["server-1"],
+        },
+      },
+      widgetSnapshots: [
+        {
+          ...baseSnapshot,
+          widgetHtmlUrl: "https://storage.test/widget-html-old?sig=A",
+          toolOutputUrl: "https://storage.test/tool-output-old?sig=A",
+        },
+      ],
+    };
+
+    mockGetChatHistoryDetail.mockResolvedValue(initialDetailResponse);
+
+    const view = render(<ChatTabV2 {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Show sessions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Select thread" }));
+    await flushMicrotasks();
+
+    expect(mockUseChatSession.loadChatSession).toHaveBeenCalledTimes(1);
+    mockUseChatSession.loadChatSession.mockClear();
+
+    // Same session version, identical snapshot signature — only the signed
+    // storage URLs change. The reactive effect must not call
+    // loadChatSession again.
+    mockReactiveHistoryState.session = {
+      ...initialDetailResponse.session,
+    };
+    mockReactiveHistoryState.widgetSnapshots = [
+      {
+        ...baseSnapshot,
+        widgetHtmlUrl: "https://storage.test/widget-html-old?sig=B",
+        toolOutputUrl: "https://storage.test/tool-output-old?sig=B",
+      },
+    ];
+
+    view.rerender(<ChatTabV2 {...defaultProps} />);
+    await flushMicrotasks();
+
+    expect(mockUseChatSession.loadChatSession).not.toHaveBeenCalled();
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-app-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/chatgpt-app-renderer.tsx
@@ -923,6 +923,8 @@ export function ChatGPTAppRenderer({
     setWidgetDebugInfo(resolvedToolCallId, {
       toolName,
       protocol: "openai-apps",
+      serverId,
+      resourceUri: outputTemplate,
       widgetState: initialWidgetState ?? null,
       prefersBorder,
       globals: {
@@ -942,6 +944,8 @@ export function ChatGPTAppRenderer({
     resolvedToolCallId,
     toolName,
     setWidgetDebugInfo,
+    serverId,
+    outputTemplate,
     resolvedTheme,
     effectiveDisplayMode,
     maxHeight,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1153,6 +1153,8 @@ export function MCPAppsRenderer({
     setWidgetDebugInfo(toolCallId, {
       toolName,
       protocol: "mcp-apps",
+      serverId,
+      resourceUri,
       // Seed from persisted state when a saved view / fork supplied one,
       // so the Debug "Widget State" tab shows the restored value on
       // first render instead of `null`. Apps SDK widgets that call
@@ -1173,6 +1175,8 @@ export function MCPAppsRenderer({
     toolCallId,
     toolName,
     setWidgetDebugInfo,
+    serverId,
+    resourceUri,
     resolvedTheme,
     effectiveDisplayMode,
     locale,

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer-adapter.ts
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer-adapter.ts
@@ -155,8 +155,19 @@ export function buildToolRenderOverridesFromSnapshots(
   const preferLive = options.preferLiveWhenPossible ?? false;
   const overrides: Record<string, ToolRenderOverride> = {};
   for (const snap of snapshots) {
+    // If the serverId still looks like a Convex `Id<'servers'>`
+    // (32-char alphanumeric), the reverse resolver didn't translate it
+    // back to a local runtime identifier — most likely because the
+    // server doc isn't visible to the current project. Forcing a live
+    // fetch in that state hits the local widget-content route with a
+    // Convex Id that the MCP client manager doesn't recognise and 500s
+    // in a loop. Pin to the cached path so replay stays stable.
+    const serverIdLooksLikeConvexId = /^[a-z0-9]{32}$/.test(snap.serverId);
     const canLiveFetch =
-      preferLive && snap.protocol === "mcp-apps" && !!snap.resourceUri;
+      preferLive &&
+      snap.protocol === "mcp-apps" &&
+      !!snap.resourceUri &&
+      !serverIdLooksLikeConvexId;
     const cachedWidgetHtmlUrl = snap.widgetHtmlUrl ?? undefined;
     const replay = buildPersistedExecutionReplay({
       protocol: snap.protocol,

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer-adapter.ts
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer-adapter.ts
@@ -77,6 +77,14 @@ export interface TraceWidgetSnapshot {
 /**
  * Convert raw SharedChatWidgetSnapshot records (from Convex) into the
  * TraceWidgetSnapshot shape used by the trace viewer adapter.
+ *
+ * `resolveServerLocalId` translates the snapshot's Convex `Id<'servers'>`
+ * (the only shape the backend accepts on the write path) back to the
+ * runtime identifier the local renderer / MCP client manager understands.
+ * In hosted mode the two are already the same. In local mode the renderer
+ * keys connections by display name (e.g. "Champions"), so without this
+ * translation the live-fetch path POSTs the Convex Id and the local
+ * widget-content route returns 500.
  */
 export function snapshotsToTraceWidgetSnapshots(
   snapshots: Array<{
@@ -93,6 +101,7 @@ export function snapshotsToTraceWidgetSnapshots(
     toolOutput?: unknown;
     injectedOpenAiCompat?: boolean;
   }>,
+  resolveServerLocalId?: (convexServerId: string) => string | undefined,
 ): TraceWidgetSnapshot[] {
   return snapshots.map((snap) => {
     // Reconstruct toolMetadata so detectUIType returns the correct widget type.
@@ -104,11 +113,14 @@ export function snapshotsToTraceWidgetSnapshots(
           ? { "openai/outputTemplate": "__cached__" }
           : {};
 
+    const resolvedServerId =
+      resolveServerLocalId?.(snap.serverId) ?? snap.serverId;
+
     return {
       toolCallId: snap.toolCallId,
       toolName: snap.toolName,
       protocol: snap.uiType,
-      serverId: snap.serverId,
+      serverId: resolvedServerId,
       resourceUri: snap.resourceUri,
       toolMetadata,
       widgetCsp: snap.widgetCsp,

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -147,6 +147,7 @@ import type { EvalChatHandoff } from "@/lib/eval-chat-handoff";
 import {
   chatHistoryAction,
   getChatHistoryDetail,
+  getChatHistoryWidgetSnapshotSignature,
   type ChatHistorySession,
   type ChatHistoryDetailSession,
   type ChatHistoryWidgetSnapshot,
@@ -171,18 +172,12 @@ function buildHistoryContentSignature(
   session: ChatHistoryDetailSession,
   widgetSnapshots?: ChatHistoryWidgetSnapshot[],
 ) {
-  const snapshotSignature = (widgetSnapshots ?? [])
-    .map((snapshot) =>
-      [
-        snapshot._id,
-        snapshot.toolCallId,
-        snapshot.resourceUri ?? "",
-        snapshot.widgetHtmlUrl ?? "",
-        snapshot.toolOutputUrl ?? "",
-      ].join(":"),
-    )
-    .sort()
-    .join("|");
+  // Delegate the snapshot portion to the shared helper so it intentionally
+  // excludes signed storage URLs (`widgetHtmlUrl`, `toolOutputUrl`), which
+  // can change between reactive emissions even when underlying snapshot
+  // content has not changed.
+  const snapshotSignature =
+    getChatHistoryWidgetSnapshotSignature(widgetSnapshots);
   return [
     session._id,
     session.chatSessionId,
@@ -1584,18 +1579,19 @@ export function PlaygroundMain({
       return;
     }
 
-    if (
-      resumedVersion !== null &&
-      reactiveHistorySession.version <= resumedVersion
-    ) {
-      return;
-    }
-
     const contentSignature = buildHistoryContentSignature(
       reactiveHistorySession,
       reactiveHistoryWidgetSnapshots,
     );
-    if (appliedHistoryContentSignatureRef.current === contentSignature) {
+    const signatureUnchanged =
+      appliedHistoryContentSignatureRef.current === contentSignature;
+    const versionNotAdvanced =
+      resumedVersion !== null &&
+      reactiveHistorySession.version <= resumedVersion;
+
+    if (versionNotAdvanced && signatureUnchanged) return;
+
+    if (signatureUnchanged) {
       setPendingDirectVisibility(reactiveHistorySession.directVisibility);
       syncResumedVersion(reactiveHistorySession.version);
       return;

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -652,6 +652,7 @@ export function PlaygroundMain({
     },
     resolveServerConvexId: (localServerId) =>
       serversByName.get(localServerId),
+    resolveServerLocalId: (convexServerId) => serversById.get(convexServerId),
     onReset: (reason?: ChatSessionResetReason) => {
       setModelContextQueue([]);
       setPreludeTraceExecutions([]);

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -650,6 +650,8 @@ export function PlaygroundMain({
       selectedServerIds: hostedSelectedServerIds,
       oauthTokens: hostedOAuthTokens,
     },
+    resolveServerConvexId: (localServerId) =>
+      serversByName.get(localServerId),
     onReset: (reason?: ChatSessionResetReason) => {
       setModelContextQueue([]);
       setPreludeTraceExecutions([]);

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -176,6 +176,29 @@ vi.mock("@/lib/apis/web/chat-history-api", () => ({
   getChatHistoryDetail: (...args: unknown[]) =>
     mockGetChatHistoryDetail(...args),
   chatHistoryAction: (...args: unknown[]) => mockChatHistoryAction(...args),
+  getChatHistoryWidgetSnapshotSignature: (
+    snapshots: Array<Record<string, unknown>> | undefined,
+  ): string =>
+    (snapshots ?? [])
+      .map((snapshot) =>
+        JSON.stringify([
+          snapshot._id,
+          snapshot.toolCallId,
+          snapshot.resourceUri ?? "",
+          snapshot.createdAt ?? 0,
+        ]),
+      )
+      .sort()
+      .join("|"),
+}));
+
+const mockReactiveDirectSession = vi.hoisted(() => ({
+  session: undefined as any,
+  widgetSnapshots: undefined as any,
+}));
+
+vi.mock("@/hooks/use-direct-chat-session-subscription", () => ({
+  useDirectChatSessionSubscription: () => mockReactiveDirectSession,
 }));
 
 // Mock useChatSession hook
@@ -589,6 +612,8 @@ describe("PlaygroundMain", () => {
     mockGetChatHistoryDetail.mockReset();
     mockChatHistoryAction.mockReset();
     mockChatHistoryAction.mockResolvedValue({ ok: true });
+    mockReactiveDirectSession.session = undefined;
+    mockReactiveDirectSession.widgetSnapshots = undefined;
     mockPreferencesState.themeMode = "light";
     mockPreferencesState.themePreset = "soft-pop";
     mockPreferencesState.hostStyle = "claude";
@@ -1849,4 +1874,144 @@ describe("PlaygroundMain", () => {
       });
     });
   });
+
+  describe("reactive widget snapshot refresh", () => {
+    function makeSession(suffix: string) {
+      return {
+        _id: `history-reactive-${suffix}`,
+        chatSessionId: `chat-session-reactive-${suffix}`,
+        firstMessagePreview: "Hello",
+        status: "active" as const,
+        directVisibility: "private" as const,
+        messageCount: 2,
+        version: 4,
+        startedAt: 1,
+        lastActivityAt: 1,
+        isPinned: false,
+        manualUnread: false,
+        isUnread: false,
+        messagesBlobUrl: "https://storage.test/blob",
+        resumeConfig: { selectedServers: ["test-server"] },
+      };
+    }
+
+    function makeSnapshot(sessionId: string) {
+      return {
+        _id: "snap-1",
+        sessionId,
+        toolCallId: "call-1",
+        toolName: "search",
+        serverId: "server-1",
+        uiType: "mcp-apps" as const,
+        resourceUri: "ui://widget.html",
+        widgetCsp: null,
+        widgetPermissions: null,
+        widgetPermissive: false,
+        prefersBorder: false,
+        createdAt: 1_700_000_000_000,
+      };
+    }
+
+    it("reloads when a new widget snapshot arrives at the same session version", async () => {
+      const session = makeSession("snapshot-add");
+      const snapshot = makeSnapshot(session._id);
+      mockGetChatHistoryDetail.mockResolvedValueOnce({
+        ok: true,
+        session,
+        widgetSnapshots: [],
+      });
+
+      const view = render(<PlaygroundMain {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(
+          usePlaygroundChatHistoryBridgeStore.getState().bridge,
+        ).not.toBe(null);
+      });
+
+      await act(async () => {
+        const bridge = usePlaygroundChatHistoryBridgeStore.getState().bridge;
+        await Promise.resolve(bridge?.onSelectThread(session));
+      });
+      await waitFor(() => {
+        expect(mockUseChatSession.loadChatSession).toHaveBeenCalledTimes(1);
+      });
+
+      mockUseChatSession.loadChatSession.mockClear();
+
+      mockReactiveDirectSession.session = { ...session };
+      mockReactiveDirectSession.widgetSnapshots = [
+        {
+          ...snapshot,
+          widgetHtmlUrl: "https://storage.test/widget-html-1?sig=A",
+          toolOutputUrl: "https://storage.test/tool-output-1?sig=A",
+        },
+      ];
+
+      view.rerender(<PlaygroundMain {...defaultProps} />);
+      await waitFor(() => {
+        expect(mockUseChatSession.loadChatSession).toHaveBeenCalledTimes(1);
+      });
+
+      const loadArgs = mockUseChatSession.loadChatSession.mock.calls[0][0];
+      expect(loadArgs.widgetSnapshots).toHaveLength(1);
+      expect(loadArgs.widgetSnapshots[0]._id).toBe("snap-1");
+      expect(loadArgs.turnTraces).toBeUndefined();
+    });
+
+    it("does not reload when only signed snapshot URLs change", async () => {
+      const session = makeSession("signed-url-only");
+      const snapshot = makeSnapshot(session._id);
+      mockGetChatHistoryDetail.mockResolvedValueOnce({
+        ok: true,
+        session,
+        widgetSnapshots: [
+          {
+            ...snapshot,
+            widgetHtmlUrl: "https://storage.test/widget-html?sig=A",
+            toolOutputUrl: "https://storage.test/tool-output?sig=A",
+          },
+        ],
+      });
+
+      const view = render(<PlaygroundMain {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(
+          usePlaygroundChatHistoryBridgeStore.getState().bridge,
+        ).not.toBe(null);
+      });
+
+      await act(async () => {
+        const bridge = usePlaygroundChatHistoryBridgeStore.getState().bridge;
+        await Promise.resolve(bridge?.onSelectThread(session));
+      });
+      await waitFor(() => {
+        expect(mockUseChatSession.loadChatSession).toHaveBeenCalledTimes(1);
+      });
+
+      mockUseChatSession.loadChatSession.mockClear();
+
+      mockReactiveDirectSession.session = { ...session };
+      mockReactiveDirectSession.widgetSnapshots = [
+        {
+          ...snapshot,
+          widgetHtmlUrl: "https://storage.test/widget-html?sig=B",
+          toolOutputUrl: "https://storage.test/tool-output?sig=B",
+        },
+      ];
+
+      view.rerender(<PlaygroundMain {...defaultProps} />);
+      await flushMicrotasksWithAct();
+
+      expect(mockUseChatSession.loadChatSession).not.toHaveBeenCalled();
+    });
+  });
 });
+
+async function flushMicrotasksWithAct() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}

--- a/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
@@ -1060,4 +1060,123 @@ describe("useSharedChatWidgetCapture", () => {
 
     unmount();
   });
+
+  it("falls back to renderer-known serverId/resourceUri when the tool result omits _meta._serverId", async () => {
+    const { unmount } = renderHook(() =>
+      useSharedChatWidgetCapture({
+        enabled: true,
+        chatSessionId: "chat-session-fallback",
+        hostedChatboxId: "cbx_1",
+        hostedAccessVersion: 1,
+        messages: [
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-search",
+                toolCallId: "call-fallback",
+                input: { q: "hello" },
+                // Intentionally no _meta._serverId / outputTemplate. The
+                // renderer-stamped fields on the widget debug store should
+                // fill in.
+                output: { result: "world" },
+              },
+            ],
+          } as any,
+        ],
+      }),
+    );
+
+    act(() => {
+      useWidgetDebugStore.setState({
+        widgets: new Map([
+          [
+            "call-fallback",
+            {
+              toolCallId: "call-fallback",
+              toolName: "search",
+              protocol: "mcp-apps",
+              widgetState: null,
+              globals: { theme: "dark", displayMode: "inline" },
+              widgetHtml: "<div>Widget</div>",
+              serverId: "server-1",
+              resourceUri: "ui://widget.html",
+              updatedAt: Date.now(),
+            },
+          ],
+        ]),
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    await flushMicrotasks();
+
+    expect(mockCreateWidgetSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockCreateWidgetSnapshot.mock.calls[0][0]).toMatchObject({
+      serverId: "server-1",
+      resourceUri: "ui://widget.html",
+      toolCallId: "call-fallback",
+    });
+
+    unmount();
+  });
+
+  it("skips snapshot capture when neither the tool result nor the widget store has a serverId", async () => {
+    const { unmount } = renderHook(() =>
+      useSharedChatWidgetCapture({
+        enabled: true,
+        chatSessionId: "chat-session-no-server",
+        hostedChatboxId: "cbx_1",
+        hostedAccessVersion: 1,
+        messages: [
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-search",
+                toolCallId: "call-no-server",
+                input: { q: "hello" },
+                output: { result: "world" },
+              },
+            ],
+          } as any,
+        ],
+      }),
+    );
+
+    act(() => {
+      useWidgetDebugStore.setState({
+        widgets: new Map([
+          [
+            "call-no-server",
+            {
+              toolCallId: "call-no-server",
+              toolName: "search",
+              protocol: "mcp-apps",
+              widgetState: null,
+              globals: { theme: "dark", displayMode: "inline" },
+              widgetHtml: "<div>Widget</div>",
+              updatedAt: Date.now(),
+            },
+          ],
+        ]),
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    await flushMicrotasks();
+
+    expect(mockGenerateSnapshotUploadUrl).not.toHaveBeenCalled();
+    expect(mockCreateWidgetSnapshot).not.toHaveBeenCalled();
+
+    unmount();
+  });
 });

--- a/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/useSharedChatWidgetCapture.test.tsx
@@ -76,7 +76,7 @@ describe("useSharedChatWidgetCapture", () => {
                   result: "world",
                   _meta: {
                     "openai/outputTemplate": "ui://widget.html",
-                    _serverId: "server-1",
+                    _serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr",
                   },
                 },
               },
@@ -134,7 +134,7 @@ describe("useSharedChatWidgetCapture", () => {
     expect(mockCreateWidgetSnapshot).toHaveBeenCalledWith({
       chatboxId: "cbx_1", accessVersion: 1,
       chatSessionId: "chat-session-1",
-      serverId: "server-1",
+      serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr",
       toolCallId: "call-1",
       toolName: "search",
       widgetHtmlBlobId: expect.stringMatching(/^blob-/),
@@ -187,7 +187,7 @@ describe("useSharedChatWidgetCapture", () => {
                   type: "tool-search",
                   toolCallId: "call-1",
                   input: { q: "hello" },
-                  output: { result: "world", _serverId: "server-1" },
+                  output: { result: "world", _serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr" },
                 },
               ],
             } as any,
@@ -266,7 +266,7 @@ describe("useSharedChatWidgetCapture", () => {
                   type: "tool-search",
                   toolCallId: "call-1",
                   input: { q: "hello" },
-                  output: { result: "world", _serverId: "server-1" },
+                  output: { result: "world", _serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr" },
                 },
               ],
             } as any,
@@ -373,7 +373,7 @@ describe("useSharedChatWidgetCapture", () => {
                   type: "tool-search",
                   toolCallId: "call-pending",
                   input: { q: "hello" },
-                  output: { result: "world", _serverId: "server-1" },
+                  output: { result: "world", _serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr" },
                 },
               ],
             } as any,
@@ -441,7 +441,7 @@ describe("useSharedChatWidgetCapture", () => {
                   result: "ok",
                   _meta: {
                     "openai/outputTemplate": "ui://widget.html",
-                    _serverId: "srv_123",
+                    _serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr",
                   },
                 },
               },
@@ -483,7 +483,7 @@ describe("useSharedChatWidgetCapture", () => {
     expect(mockCreateWidgetSnapshot).toHaveBeenCalledWith({
       chatboxId: "cbx_1", accessVersion: 1,
       chatSessionId: "chat-session-2",
-      serverId: "srv_123",
+      serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr",
       toolCallId: "call-2",
       toolName: "search",
       widgetHtmlBlobId: expect.stringMatching(/^blob-/),
@@ -538,7 +538,7 @@ describe("useSharedChatWidgetCapture", () => {
                 type: "tool-search",
                 toolCallId: "call-stale",
                 input: { q: "hello" },
-                output: { result: "world", _serverId: "server-1" },
+                output: { result: "world", _serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr" },
               },
             ],
           } as any,
@@ -630,13 +630,13 @@ describe("useSharedChatWidgetCapture", () => {
                 type: "tool-search",
                 toolCallId: "call-a",
                 input: { q: "a" },
-                output: { result: "a", _serverId: "server-1" },
+                output: { result: "a", _serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr" },
               },
               {
                 type: "tool-search",
                 toolCallId: "call-b",
                 input: { q: "b" },
-                output: { result: "b", _serverId: "server-1" },
+                output: { result: "b", _serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr" },
               },
             ],
           } as any,
@@ -734,7 +734,7 @@ describe("useSharedChatWidgetCapture", () => {
                 type: "tool-search",
                 toolCallId: "call-backoff",
                 input: { q: "hello" },
-                output: { result: "world", _serverId: "server-1" },
+                output: { result: "world", _serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr" },
               },
             ],
           } as any,
@@ -815,7 +815,7 @@ describe("useSharedChatWidgetCapture", () => {
                   type: "tool-search",
                   toolCallId: "call-race",
                   input: { q: "race" },
-                  output: { result: "ok", _serverId: "server-1" },
+                  output: { result: "ok", _serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr" },
                 },
               ],
             } as any,
@@ -937,7 +937,7 @@ describe("useSharedChatWidgetCapture", () => {
                   type: "tool-search",
                   toolCallId: "call-replay",
                   input: { q: "hello" },
-                  output: { result: "world", _serverId: "server-1" },
+                  output: { result: "world", _serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr" },
                 },
               ],
             } as any,
@@ -1018,7 +1018,7 @@ describe("useSharedChatWidgetCapture", () => {
                 input: { q: "history" },
                 output: {
                   result: "ok",
-                  _meta: { _serverId: "server-1" },
+                  _meta: { _serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr" },
                 },
               },
             ],
@@ -1100,7 +1100,7 @@ describe("useSharedChatWidgetCapture", () => {
               widgetState: null,
               globals: { theme: "dark", displayMode: "inline" },
               widgetHtml: "<div>Widget</div>",
-              serverId: "server-1",
+              serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr",
               resourceUri: "ui://widget.html",
               updatedAt: Date.now(),
             },
@@ -1117,7 +1117,7 @@ describe("useSharedChatWidgetCapture", () => {
 
     expect(mockCreateWidgetSnapshot).toHaveBeenCalledTimes(1);
     expect(mockCreateWidgetSnapshot.mock.calls[0][0]).toMatchObject({
-      serverId: "server-1",
+      serverId: "p57f6yjbcv8dg5qge7msrsy7sx86pydr",
       resourceUri: "ui://widget.html",
       toolCallId: "call-fallback",
     });
@@ -1157,6 +1157,133 @@ describe("useSharedChatWidgetCapture", () => {
             {
               toolCallId: "call-no-server",
               toolName: "search",
+              protocol: "mcp-apps",
+              widgetState: null,
+              globals: { theme: "dark", displayMode: "inline" },
+              widgetHtml: "<div>Widget</div>",
+              updatedAt: Date.now(),
+            },
+          ],
+        ]),
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    await flushMicrotasks();
+
+    expect(mockGenerateSnapshotUploadUrl).not.toHaveBeenCalled();
+    expect(mockCreateWidgetSnapshot).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it("resolves a local server name to a Convex Id via resolveServerConvexId", async () => {
+    const convexId = "p57f6yjbcv8dg5qge7msrsy7sx86pydr";
+    const resolveServerConvexId = vi.fn(
+      (local: string) => (local === "Champions" ? convexId : undefined),
+    );
+
+    const { unmount } = renderHook(() =>
+      useSharedChatWidgetCapture({
+        enabled: true,
+        chatSessionId: "chat-session-local",
+        resolveServerConvexId,
+        messages: [
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-show-squad",
+                toolCallId: "call-local",
+                input: { team: "Arsenal" },
+                // Local-mode stamp: `_meta._serverId` is the connection
+                // *name*, not a Convex Id.
+                output: {
+                  result: "ok",
+                  _meta: {
+                    _serverId: "Champions",
+                    ui: { resourceUri: "ui://squad-manager/mcp-app.html" },
+                  },
+                },
+              },
+            ],
+          } as any,
+        ],
+      }),
+    );
+
+    act(() => {
+      useWidgetDebugStore.setState({
+        widgets: new Map([
+          [
+            "call-local",
+            {
+              toolCallId: "call-local",
+              toolName: "show-squad",
+              protocol: "mcp-apps",
+              widgetState: null,
+              globals: { theme: "dark", displayMode: "inline" },
+              widgetHtml: "<div>Widget</div>",
+              updatedAt: Date.now(),
+            },
+          ],
+        ]),
+      });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    await flushMicrotasks();
+
+    expect(resolveServerConvexId).toHaveBeenCalledWith("Champions");
+    expect(mockCreateWidgetSnapshot).toHaveBeenCalledTimes(1);
+    expect(mockCreateWidgetSnapshot.mock.calls[0][0]).toMatchObject({
+      serverId: convexId,
+      toolCallId: "call-local",
+    });
+
+    unmount();
+  });
+
+  it("skips capture when no resolver is supplied and the serverId is not Convex-shaped", async () => {
+    const { unmount } = renderHook(() =>
+      useSharedChatWidgetCapture({
+        enabled: true,
+        chatSessionId: "chat-session-noresolver",
+        messages: [
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-show-squad",
+                toolCallId: "call-bad-id",
+                input: {},
+                output: {
+                  result: "ok",
+                  _meta: { _serverId: "Champions" },
+                },
+              },
+            ],
+          } as any,
+        ],
+      }),
+    );
+
+    act(() => {
+      useWidgetDebugStore.setState({
+        widgets: new Map([
+          [
+            "call-bad-id",
+            {
+              toolCallId: "call-bad-id",
+              toolName: "show-squad",
               protocol: "mcp-apps",
               widgetState: null,
               globals: { theme: "dark", displayMode: "inline" },

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -224,6 +224,15 @@ export interface UseChatSessionOptions {
    * Typically wired from `useProjectServers().serversByName`.
    */
   resolveServerConvexId?: (localServerId: string) => string | undefined;
+  /**
+   * Reverse of `resolveServerConvexId` — translate a Convex `Id<'servers'>`
+   * from a persisted snapshot back to the local runtime identifier the
+   * MCP client manager understands (display name in local mode). Without
+   * this, replay tries to live-fetch widget content using the Convex Id,
+   * which the local widget-content route can't resolve → 500.
+   * Typically wired from `useProjectServers().serversById`.
+   */
+  resolveServerLocalId?: (convexServerId: string) => string | undefined;
 }
 
 export type ChatSessionResetReason =
@@ -1057,7 +1066,12 @@ export function useChatSession(
     hostStyle,
     onReset,
     resolveServerConvexId,
+    resolveServerLocalId,
   } = options;
+  const resolveServerLocalIdRef = useRef(resolveServerLocalId);
+  useEffect(() => {
+    resolveServerLocalIdRef.current = resolveServerLocalId;
+  }, [resolveServerLocalId]);
   // Surfaces that omit `executionConfig` entirely (e.g. Playground) own their
   // chat-execution state imperatively and must not be re-synced from prop
   // defaults. Surfaces that pass `executionConfig` are in controlled mode and
@@ -1939,7 +1953,8 @@ export function useChatSession(
         hydratedWidgetSnapshots?.map((snapshot) => snapshot.toolCallId) ?? [];
       if (hydratedWidgetSnapshots && hydratedWidgetSnapshots.length > 0) {
         const traceSnapshots = snapshotsToTraceWidgetSnapshots(
-          hydratedWidgetSnapshots
+          hydratedWidgetSnapshots,
+          resolveServerLocalIdRef.current,
         );
         // In-flow session revisit: prefer the live MCP Apps fetch over the
         // cached snapshot HTML so the widget re-renders against the active

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -1739,7 +1739,11 @@ export function useChatSession(
   }, [chatSessionId]);
 
   useSharedChatWidgetCapture({
-    enabled: HOSTED_MODE && isAuthenticated,
+    // Convex-backed chat history works in both hosted and local mode for
+    // authenticated users. Reads (loadChatSession) are unconditional, so
+    // gating writes on HOSTED_MODE leaves local-mode chats with rendered
+    // widgets that vanish on reopen.
+    enabled: isAuthenticated,
     readyToPersist: status === "ready",
     chatSessionId,
     hostedChatboxId,

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -216,6 +216,14 @@ export interface UseChatSessionOptions {
   hostStyle?: "claude" | "chatgpt";
   /** Callback when chat is reset */
   onReset?: (reason?: ChatSessionResetReason) => void;
+  /**
+   * Resolve a local server identifier (display name in local mode, Convex
+   * Id in hosted) to a Convex `Id<'servers'>`. Used by the widget snapshot
+   * capture path because the backend mutation requires a Convex Id and
+   * local-mode tool results stamp `_meta._serverId` with the local name.
+   * Typically wired from `useProjectServers().serversByName`.
+   */
+  resolveServerConvexId?: (localServerId: string) => string | undefined;
 }
 
 export type ChatSessionResetReason =
@@ -1048,6 +1056,7 @@ export function useChatSession(
     executionConfig,
     hostStyle,
     onReset,
+    resolveServerConvexId,
   } = options;
   // Surfaces that omit `executionConfig` entirely (e.g. Playground) own their
   // chat-execution state imperatively and must not be re-synced from prop
@@ -1751,6 +1760,7 @@ export function useChatSession(
     persistedSnapshotToolCallIds,
     messages,
     onStaleHostedAccess: requestRefreshAccessVersion,
+    resolveServerConvexId,
   });
 
   const setMessages = useCallback<

--- a/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
@@ -27,6 +27,12 @@ interface UseSharedChatWidgetCaptureOptions {
   // /web/chatbox/redeem fetch so a fresh `hostedAccessVersion` flows back
   // into this hook and the capture loop re-fires.
   onStaleHostedAccess?: () => void;
+  // Resolve a local server identifier (e.g. display name in local mode)
+  // to a Convex `Id<'servers'>` for the snapshot mutation. Local-mode tool
+  // results stamp `_meta._serverId` with the local connection name, which
+  // the backend would otherwise reject. Caller supplies this via
+  // `useProjectServers().serversByName` (or equivalent).
+  resolveServerConvexId?: (localServerId: string) => string | undefined;
 }
 
 const MAX_PENDING_SESSION_RETRIES = 5;
@@ -199,6 +205,7 @@ export function useSharedChatWidgetCapture({
   persistedSnapshotToolCallIds = [],
   messages,
   onStaleHostedAccess,
+  resolveServerConvexId,
 }: UseSharedChatWidgetCaptureOptions): void {
   const widgets = useWidgetDebugStore((state) => state.widgets);
   const generateSnapshotUploadUrl = useMutation(
@@ -234,6 +241,7 @@ export function useSharedChatWidgetCapture({
     new Set(persistedSnapshotToolCallIds),
   );
   const onStaleHostedAccessRef = useRef(onStaleHostedAccess);
+  const resolveServerConvexIdRef = useRef(resolveServerConvexId);
   // ToolCallIds whose upload was abandoned mid-flight because the backend
   // reported `chatbox_access_stale`. Replayed once the next
   // `hostedAccessVersion` arrives — without this, the parent's re-redeem
@@ -267,6 +275,10 @@ export function useSharedChatWidgetCapture({
   useEffect(() => {
     onStaleHostedAccessRef.current = onStaleHostedAccess;
   }, [onStaleHostedAccess]);
+
+  useEffect(() => {
+    resolveServerConvexIdRef.current = resolveServerConvexId;
+  }, [resolveServerConvexId]);
 
   // Re-fire the parent's refresh callback on a backoff while the queue is
   // non-empty and accessVersion hasn't advanced. The parent's redeem can
@@ -412,8 +424,22 @@ export function useSharedChatWidgetCapture({
     // omits `_meta._serverId` / `_meta["openai/outputTemplate"]`. The
     // renderer stamps these into the widget debug store from its own props
     // before the snapshot hook runs.
-    const serverId = toolSource.serverId ?? widget.serverId;
+    const rawServerId = toolSource.serverId ?? widget.serverId;
     const resourceUri = toolSource.resourceUri ?? widget.resourceUri;
+    if (!rawServerId) {
+      return;
+    }
+    // Capture backend validates `serverId: v.id('servers')` and the direct
+    // path also throws "serverId is required". In hosted mode the live
+    // tool result's `_meta._serverId` is already a Convex Id. In local
+    // mode `_serverId` is a local connection name (e.g. "Champions") —
+    // we resolve it to a Convex Id via the caller-supplied map before
+    // sending. If we still don't have a Convex Id, give up rather than
+    // letting the mutation reject silently.
+    const looksLikeConvexId = /^[a-z0-9]{32}$/.test(rawServerId);
+    const serverId = looksLikeConvexId
+      ? rawServerId
+      : resolveServerConvexIdRef.current?.(rawServerId);
     if (!serverId) {
       return;
     }

--- a/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
+++ b/mcpjam-inspector/client/src/hooks/useSharedChatWidgetCapture.ts
@@ -408,7 +408,13 @@ export function useSharedChatWidgetCapture({
     if (persistedSnapshotToolCallIdsRef.current.has(toolCallId)) {
       return;
     }
-    if (!toolSource.serverId) {
+    // Fall back to renderer-known identity when the tool-result envelope
+    // omits `_meta._serverId` / `_meta["openai/outputTemplate"]`. The
+    // renderer stamps these into the widget debug store from its own props
+    // before the snapshot hook runs.
+    const serverId = toolSource.serverId ?? widget.serverId;
+    const resourceUri = toolSource.resourceUri ?? widget.resourceUri;
+    if (!serverId) {
       return;
     }
 
@@ -490,12 +496,12 @@ export function useSharedChatWidgetCapture({
           ? { accessVersion }
           : {}),
         chatSessionId: sessionIdRef.current,
-        ...(toolSource.serverId ? { serverId: toolSource.serverId } : {}),
+        serverId,
         toolCallId,
         toolName: toolSource.toolName,
         widgetHtmlBlobId: cached.widgetHtmlBlobId,
         uiType: widget.protocol,
-        resourceUri: toolSource.resourceUri,
+        resourceUri,
         toolInputBlobId: cached.toolInputBlobId,
         toolOutputBlobId: cached.toolOutputBlobId,
         widgetCsp: toWidgetCsp(widget),

--- a/mcpjam-inspector/client/src/lib/apis/web/chat-history-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/chat-history-api.ts
@@ -72,6 +72,32 @@ export interface ChatHistoryWidgetSnapshot {
   prefersBorder: boolean;
   widgetHtmlUrl?: string | null;
   toolOutputUrl?: string | null;
+  createdAt?: number;
+}
+
+/**
+ * Stable signature for a list of widget snapshots, used to detect when a
+ * reactive history refresh carries newly inserted or updated snapshot rows
+ * even though the parent chat session `version` did not advance. Signed
+ * storage URLs (`widgetHtmlUrl`, `toolInputUrl`, `toolOutputUrl`) are
+ * intentionally excluded — they can change between reactive emissions
+ * without any underlying snapshot content change and would otherwise force
+ * redundant reloads.
+ */
+export function getChatHistoryWidgetSnapshotSignature(
+  snapshots: ChatHistoryWidgetSnapshot[] | undefined,
+): string {
+  return (snapshots ?? [])
+    .map((snapshot) =>
+      JSON.stringify([
+        snapshot._id,
+        snapshot.toolCallId,
+        snapshot.resourceUri ?? "",
+        snapshot.createdAt ?? 0,
+      ]),
+    )
+    .sort()
+    .join("|");
 }
 
 export interface ChatHistoryTurnTrace {

--- a/mcpjam-inspector/client/src/stores/widget-debug-store.ts
+++ b/mcpjam-inspector/client/src/stores/widget-debug-store.ts
@@ -195,6 +195,17 @@ export interface WidgetDebugInfo {
   prefersBorder?: boolean;
   updatedAt: number;
   /**
+   * Renderer-known server identity. Set by the renderer's init effect from
+   * the tool-call provenance; lets the snapshot capture hook persist saves
+   * even when the tool-result envelope omits `_meta._serverId`.
+   */
+  serverId?: string;
+  /**
+   * MCP Apps resource URI, or OpenAI Apps `openai/outputTemplate`. Same
+   * fallback role as `serverId` above.
+   */
+  resourceUri?: string;
+  /**
    * CSP configuration and violation tracking. Historical field name —
    * keeps the existing `setWidgetCsp` / `addCspViolation` /
    * `clearCspViolations` API surface unchanged. The Sandbox debug panel
@@ -370,6 +381,8 @@ export const useWidgetDebugStore = create<WidgetDebugStore>((set, get) => ({
           info.prefersBorder !== undefined
             ? info.prefersBorder
             : existing?.prefersBorder,
+        serverId: info.serverId ?? existing?.serverId,
+        resourceUri: info.resourceUri ?? existing?.resourceUri,
         csp: existing?.csp, // Preserve CSP violations across updates
         // Preserve runtime-only fields populated by the renderer's
         // create-if-missing setters (setSandboxApplied / appendLifecycle).
@@ -531,6 +544,8 @@ export const useWidgetDebugStore = create<WidgetDebugStore>((set, get) => ({
         widgetState: existing?.widgetState ?? null,
         globals: existing?.globals ?? { theme: "dark", displayMode: "inline" },
         prefersBorder: existing?.prefersBorder,
+        serverId: existing?.serverId,
+        resourceUri: existing?.resourceUri,
         csp: existing?.csp,
         applied: existing?.applied,
         hostProfileId: existing?.hostProfileId,
@@ -563,6 +578,8 @@ export const useWidgetDebugStore = create<WidgetDebugStore>((set, get) => ({
         widgetState: existing?.widgetState ?? null,
         globals: existing?.globals ?? { theme: "dark", displayMode: "inline" },
         prefersBorder: existing?.prefersBorder,
+        serverId: existing?.serverId,
+        resourceUri: existing?.resourceUri,
         csp: existing?.csp,
         applied,
         hostProfileId: hostProfileId ?? existing?.hostProfileId,
@@ -602,6 +619,8 @@ export const useWidgetDebugStore = create<WidgetDebugStore>((set, get) => ({
         widgetState: existing?.widgetState ?? null,
         globals: existing?.globals ?? { theme: "dark", displayMode: "inline" },
         prefersBorder: existing?.prefersBorder,
+        serverId: existing?.serverId,
+        resourceUri: existing?.resourceUri,
         csp: existing?.csp,
         applied: existing?.applied,
         hostProfileId: existing?.hostProfileId,
@@ -632,6 +651,8 @@ export const useWidgetDebugStore = create<WidgetDebugStore>((set, get) => ({
         widgetState: existing?.widgetState ?? null,
         globals: existing?.globals ?? { theme: "dark", displayMode: "inline" },
         prefersBorder: existing?.prefersBorder,
+        serverId: existing?.serverId,
+        resourceUri: existing?.resourceUri,
         csp: existing?.csp,
         applied: existing?.applied,
         hostProfileId: existing?.hostProfileId,


### PR DESCRIPTION
- When you open an old chat, sometimes the MCP/OpenAI Apps widgets just… disappeared. This brings them back.
- Two reasons they were going missing: (1) the widget snapshot wasn't getting saved when the tool's response didn't include a `_serverId` field, even though the renderer already knew which server it was from, and (2) when a snapshot did land in the database later, the chat session's version number didn't change, so the UI ignored it.
- Fix: the renderer now stamps the `serverId`/`resourceUri` it already knows into the widget debug store, the snapshot-capture hook reads from there as a fallback, and the reactive history refresh now also notices when a new snapshot row arrives (via a stable signature that ignores signed storage URLs so we don't reload for nothing).
- Added unit tests for all three pieces.