### PR TITLE
cleanup(views): drop legacy openai view write hooks

### DIFF
--- a/mcpjam-inspector/client/src/components/ViewsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ViewsTab.tsx
@@ -212,13 +212,10 @@ export function ViewsTab({
   // Mutations
   const {
     createMcpView,
-    createOpenaiView,
     updateMcpView,
-    updateOpenaiView,
     removeMcpView,
     removeOpenaiView,
     generateMcpUploadUrl,
-    generateOpenaiUploadUrl,
   } = useViewMutations();
 
   // Get selected view (from filtered list)
@@ -537,11 +534,7 @@ export function ViewsTab({
           name: newName,
         };
 
-        if (view.protocol === "mcp-apps") {
-          await updateMcpView(updates);
-        } else {
-          await updateOpenaiView(updates);
-        }
+        await updateMcpView(updates);
 
         toast.success(`View renamed to "${newName}"`);
 
@@ -556,7 +549,7 @@ export function ViewsTab({
         throw error; // Re-throw so the sidebar knows to keep editing mode
       }
     },
-    [updateMcpView, updateOpenaiView, posthog],
+    [updateMcpView, posthog],
   );
 
   // Handle duplicate
@@ -574,10 +567,7 @@ export function ViewsTab({
           if (response.ok) {
             const data = await response.json();
             // Upload as a new blob
-            const uploadUrl =
-              view.protocol === "mcp-apps"
-                ? await generateMcpUploadUrl()
-                : await generateOpenaiUploadUrl();
+            const uploadUrl = await generateMcpUploadUrl();
 
             const uploadResponse = await fetch(uploadUrl, {
               method: "POST",
@@ -598,10 +588,7 @@ export function ViewsTab({
           const response = await fetch(view.widgetHtmlUrl);
           if (response.ok) {
             const htmlContent = await response.text();
-            const uploadUrl =
-              view.protocol === "mcp-apps"
-                ? await generateMcpUploadUrl()
-                : await generateOpenaiUploadUrl();
+            const uploadUrl = await generateMcpUploadUrl();
 
             const uploadResponse = await fetch(uploadUrl, {
               method: "POST",
@@ -633,51 +620,27 @@ export function ViewsTab({
             ? { injectedOpenAiCompat: view.injectedOpenAiCompat }
             : {};
 
-        if (view.protocol === "mcp-apps") {
-          await createMcpView({
-            projectId,
-            serverId: view.serverId,
-            name: newName,
-            description: view.description,
-            resourceUri: (view as any).resourceUri,
-            toolName: view.toolName,
-            toolState: view.toolState,
-            toolInput: view.toolInput,
-            toolOutputBlobId,
-            widgetHtmlBlobId,
-            // Carry the cached-HTML provenance flag across duplicate
-            // only when the copy also carries cached widget bytes.
-            ...injectedOpenAiCompatCopy,
-            toolErrorText: view.toolErrorText,
-            toolMetadata: view.toolMetadata,
-            prefersBorder: view.prefersBorder,
-            tags: view.tags,
-            category: view.category,
-            defaultContext: view.defaultContext,
-          });
-        } else {
-          await createOpenaiView({
-            projectId,
-            serverId: view.serverId,
-            name: newName,
-            description: view.description,
-            outputTemplate: (view as any).outputTemplate,
-            toolName: view.toolName,
-            toolState: view.toolState,
-            toolInput: view.toolInput,
-            toolOutputBlobId,
-            widgetHtmlBlobId,
-            ...injectedOpenAiCompatCopy,
-            toolErrorText: view.toolErrorText,
-            toolMetadata: view.toolMetadata,
-            prefersBorder: view.prefersBorder,
-            tags: view.tags,
-            category: view.category,
-            defaultContext: view.defaultContext,
-            serverInfo: (view as any).serverInfo,
-            widgetState: view.widgetState,
-          });
-        }
+        await createMcpView({
+          projectId,
+          serverId: view.serverId,
+          name: newName,
+          description: view.description,
+          resourceUri: (view as any).resourceUri,
+          toolName: view.toolName,
+          toolState: view.toolState,
+          toolInput: view.toolInput,
+          toolOutputBlobId,
+          widgetHtmlBlobId,
+          // Carry the cached-HTML provenance flag across duplicate
+          // only when the copy also carries cached widget bytes.
+          ...injectedOpenAiCompatCopy,
+          toolErrorText: view.toolErrorText,
+          toolMetadata: view.toolMetadata,
+          prefersBorder: view.prefersBorder,
+          tags: view.tags,
+          category: view.category,
+          defaultContext: view.defaultContext,
+        });
 
         toast.success(`View duplicated as "${newName}"`);
 
@@ -693,15 +656,7 @@ export function ViewsTab({
         setDuplicatingViewId(null);
       }
     },
-    [
-      projectId,
-      filteredViews,
-      createMcpView,
-      createOpenaiView,
-      generateMcpUploadUrl,
-      generateOpenaiUploadUrl,
-      posthog,
-    ],
+    [projectId, filteredViews, createMcpView, generateMcpUploadUrl, posthog],
   );
 
   // Handle live data changes from editor (for real-time preview)
@@ -772,19 +727,13 @@ export function ViewsTab({
         currentDisplayContext,
         selectedView.defaultContext,
       );
-      const widgetStateChanged =
-        selectedView.protocol === "openai-apps" &&
-        currentSignatures.widgetState !== baselineSignatures.widgetState;
 
       let toolOutputBlobId: string | undefined;
       let widgetHtmlBlobId: string | undefined;
 
       if (toolOutputChanged && liveToolOutput !== null) {
         // Upload new toolOutput as JSON blob
-        const uploadUrl =
-          selectedView.protocol === "mcp-apps"
-            ? await generateMcpUploadUrl()
-            : await generateOpenaiUploadUrl();
+        const uploadUrl = await generateMcpUploadUrl();
 
         const response = await fetch(uploadUrl, {
           method: "POST",
@@ -806,10 +755,7 @@ export function ViewsTab({
       const widgetHtml = previewWidgetDebugInfo?.widgetHtml;
       if (widgetHtml && widgetHtml !== lastUploadedWidgetHtmlRef.current) {
         // Upload new widget HTML blob
-        const uploadUrl =
-          selectedView.protocol === "mcp-apps"
-            ? await generateMcpUploadUrl()
-            : await generateOpenaiUploadUrl();
+        const uploadUrl = await generateMcpUploadUrl();
 
         const response = await fetch(uploadUrl, {
           method: "POST",
@@ -853,19 +799,7 @@ export function ViewsTab({
         updates.defaultContext = currentDisplayContext;
       }
 
-      if (selectedView.protocol === "openai-apps") {
-        if (widgetStateChanged) {
-          updates.widgetState = liveWidgetState ?? null;
-        } else if (previewWidgetDebugInfo !== undefined) {
-          updates.widgetState = previewWidgetDebugInfo.widgetState;
-        }
-      }
-
-      if (selectedView.protocol === "mcp-apps") {
-        await updateMcpView(updates);
-      } else {
-        await updateOpenaiView(updates);
-      }
+      await updateMcpView(updates);
 
       // Update original values to reflect saved state
       setOriginalToolOutput(liveToolOutput);
@@ -889,14 +823,11 @@ export function ViewsTab({
     hasLiveUnsavedChanges,
     liveToolInput,
     liveToolOutput,
-    liveWidgetState,
     currentSignatures,
     baselineSignatures,
     currentDisplayContext,
     generateMcpUploadUrl,
-    generateOpenaiUploadUrl,
     updateMcpView,
-    updateOpenaiView,
     widgetsMap,
     posthog,
   ]);

--- a/mcpjam-inspector/client/src/components/__tests__/ViewsTab.layout.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ViewsTab.layout.test.tsx
@@ -32,13 +32,10 @@ const {
   },
   mockViewMutations: {
     createMcpView: vi.fn(),
-    createOpenaiView: vi.fn(),
     updateMcpView: vi.fn(),
-    updateOpenaiView: vi.fn(),
     removeMcpView: vi.fn(),
     removeOpenaiView: vi.fn(),
     generateMcpUploadUrl: vi.fn(),
-    generateOpenaiUploadUrl: vi.fn(),
   },
 }));
 

--- a/mcpjam-inspector/client/src/hooks/useViews.ts
+++ b/mcpjam-inspector/client/src/hooks/useViews.ts
@@ -163,7 +163,7 @@ export function useViewQueries({
 
 // Mutation hook for view operations
 export function useViewMutations() {
-  // MCP mutations
+  // MCP mutations — canonical write path per SEP-1865.
   const createMcpView = useMutation("mcpAppViews:create" as any);
   const updateMcpView = useMutation("mcpAppViews:update" as any);
   const removeMcpView = useMutation("mcpAppViews:remove" as any);
@@ -171,29 +171,17 @@ export function useViewMutations() {
     "mcpAppViews:generateUploadUrl" as any,
   );
 
-  // OpenAI mutations (legacy table). New writes MUST go through
-  // `createMcpView` per SEP-1865; these stay registered only so the
-  // inspector can list and delete pre-backfill rows during the
-  // transition. After `migrations/backfillOpenaiAppViews` finishes and
-  // the table is drained, these will be removed in a cleanup PR.
-  const createOpenaiView = useMutation("openaiAppViews:create" as any);
-  const updateOpenaiView = useMutation("openaiAppViews:update" as any);
+  // Legacy openai delete, kept for tombstone cleanup of pre-backfill
+  // rows. Visible-list queries shadow these rows, but the mutation
+  // stays available for ad-hoc deletion paths.
   const removeOpenaiView = useMutation("openaiAppViews:remove" as any);
-  const generateOpenaiUploadUrl = useMutation(
-    "openaiAppViews:generateUploadUrl" as any,
-  );
 
   return {
-    // MCP
     createMcpView,
     updateMcpView,
     removeMcpView,
     generateMcpUploadUrl,
-    // OpenAI
-    createOpenaiView,
-    updateOpenaiView,
     removeOpenaiView,
-    generateOpenaiUploadUrl,
   };
 }
 


### PR DESCRIPTION
## Summary

Phase C1 (inspector side) of the saved-view table unification — paired with backend [PR #318](https://github.com/MCPJam/mcpjam-backend/pull/318) and following [#2216](https://github.com/MCPJam/inspector/pull/2216). After the prod backfill (63 legacy \`openaiAppViews\` rows copied to canonical \`mcpAppViews\`, all shadowed by the combined-list de-dup), no visible view has \`protocol === "openai-apps"\` — \`convex/views.ts\` tags every row from \`mcpAppViews\` as \`mcp-apps\`. That makes the openai write paths in the inspector dead code.

- \`useViews.ts\` — drop \`createOpenaiView\`, \`updateOpenaiView\`, \`generateOpenaiUploadUrl\`. \`removeOpenaiView\` stays for ad-hoc tombstone cleanup of pre-backfill rows.
- \`ViewsTab.tsx\` — collapse the \`view.protocol === "openai-apps"\` branches in rename, duplicate, and editor-save handlers to the mcp path. \`mcpAppViewCreateArgs\`/\`UpdateArgs\` already accept \`outputTemplate\` and \`serverInfo\` via the shared normalizer; \`widgetState\` was the only openai-only payload field and the backfill dropped it.
- \`ViewsTab.layout.test.tsx\` — prune unused mock entries.

## \`view.outputTemplate\` audit (for backend Phase C3, drop column)

Per the plan handoff, scanned the four files known to reference \`outputTemplate\`:

| File | Status | Notes |
| --- | --- | --- |
| \`chatgpt-app-renderer.tsx\` | **MCP \_meta passthrough** | Reads \`toolMetadata["openai/outputTemplate"]\` off the live tool result, not from a stored view row. Safe. |
| \`part-switch.tsx\` | **MCP \_meta passthrough** | Same pattern — reads from \`effectiveToolMeta\`. Safe. |
| \`tool-render-overrides.ts\` | None | No \`outputTemplate\` references. |
| \`persisted-execution-replay.ts\` | None | No \`outputTemplate\` references. |

No \`view.outputTemplate\` (or \`(view as any).outputTemplate\`) fallback reads anywhere in \`client/\`. The \`OpenaiAppView.outputTemplate\` type in \`useViews.ts\` remains as a typed shape; it can be removed alongside the backend column drop in Phase C3.

## Test plan

- [x] \`npm run typecheck:client\` — clean
- [x] \`npx vitest run client/src/components/__tests__/ViewsTab.layout.test.tsx\` — 2/2 passing
- [ ] Smoke test renaming a saved view in the inspector
- [ ] Smoke test duplicating a saved view in the inspector
- [ ] Smoke test editing toolInput/toolOutput in the editor and saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes rename/duplicate/save flows to always write via `mcpAppViews`, which could affect any remaining legacy `openai-apps` rows or fields (e.g., `widgetState`) during the transition.
> 
> **Overview**
> **Unifies saved-view writes on the inspector side.** Removes `createOpenaiView`, `updateOpenaiView`, and `generateOpenaiUploadUrl` from `useViewMutations`, keeping only `removeOpenaiView` for legacy-row cleanup.
> 
> Updates `ViewsTab` so rename, duplicate (including blob re-upload), and editor save always call `updateMcpView`/`createMcpView` and always use `generateMcpUploadUrl`, deleting protocol-based branching and the OpenAI-only save payload handling. Tests are updated to drop the now-unused OpenAI mutation mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e2149fe22b837adff7dab2b8aa7cd8c7b1589be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->