### PR TITLE
cleanup(views): drop legacy openai delete hook

### DIFF
--- a/mcpjam-inspector/client/src/components/ViewsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ViewsTab.tsx
@@ -214,7 +214,6 @@ export function ViewsTab({
     createMcpView,
     updateMcpView,
     removeMcpView,
-    removeOpenaiView,
     generateMcpUploadUrl,
   } = useViewMutations();
 
@@ -480,11 +479,7 @@ export function ViewsTab({
     async (view: AnyView) => {
       setDeletingViewId(view._id);
       try {
-        if (view.protocol === "mcp-apps") {
-          await removeMcpView({ viewId: view._id });
-        } else {
-          await removeOpenaiView({ viewId: view._id });
-        }
+        await removeMcpView({ viewId: view._id });
 
         toast.success(`View "${view.name}" deleted`);
 
@@ -505,7 +500,7 @@ export function ViewsTab({
         setDeletingViewId(null);
       }
     },
-    [selectedViewId, removeMcpView, removeOpenaiView, posthog],
+    [selectedViewId, removeMcpView, posthog],
   );
 
   // Handle edit

--- a/mcpjam-inspector/client/src/components/__tests__/ViewsTab.layout.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ViewsTab.layout.test.tsx
@@ -34,7 +34,6 @@ const {
     createMcpView: vi.fn(),
     updateMcpView: vi.fn(),
     removeMcpView: vi.fn(),
-    removeOpenaiView: vi.fn(),
     generateMcpUploadUrl: vi.fn(),
   },
 }));

--- a/mcpjam-inspector/client/src/hooks/useViews.ts
+++ b/mcpjam-inspector/client/src/hooks/useViews.ts
@@ -163,7 +163,9 @@ export function useViewQueries({
 
 // Mutation hook for view operations
 export function useViewMutations() {
-  // MCP mutations — canonical write path per SEP-1865.
+  // MCP mutations — canonical write path per SEP-1865. All saved views
+  // live in mcpAppViews after the Phase B backfill; the legacy
+  // openaiAppViews table is being dropped in backend Phase C2.
   const createMcpView = useMutation("mcpAppViews:create" as any);
   const updateMcpView = useMutation("mcpAppViews:update" as any);
   const removeMcpView = useMutation("mcpAppViews:remove" as any);
@@ -171,17 +173,11 @@ export function useViewMutations() {
     "mcpAppViews:generateUploadUrl" as any,
   );
 
-  // Legacy openai delete, kept for tombstone cleanup of pre-backfill
-  // rows. Visible-list queries shadow these rows, but the mutation
-  // stays available for ad-hoc deletion paths.
-  const removeOpenaiView = useMutation("openaiAppViews:remove" as any);
-
   return {
     createMcpView,
     updateMcpView,
     removeMcpView,
     generateMcpUploadUrl,
-    removeOpenaiView,
   };
 }
 


### PR DESCRIPTION
## Summary

Follow-up to inspector PR #2222 and paired with backend Phase C2 (which drops the `openaiAppViews` table from the schema). Phase B backfill moved all `openai-apps` rows into `mcpAppViews`, the prod `openaiAppViews` table is empty (verified after backend PR #320 ran `clearLegacy`), and PR #2222 already removed the openai create/update/upload paths plus the rename/duplicate/save branching.

This drops the last legacy openai delete tombstone:

- `client/src/hooks/useViews.ts` — remove the `removeOpenaiView` mutation declaration and return entry; refresh the comment to point at SEP-1865 + Phase C2.
- `client/src/components/ViewsTab.tsx` — drop the `removeOpenaiView` destructure and its dep entry; collapse `handleDeleteView` to call `removeMcpView` directly (matches the pattern PR #2222 used for rename/duplicate/save).
- `client/src/components/__tests__/ViewsTab.layout.test.tsx` — drop the matching `mockViewMutations.removeOpenaiView` entry.

The `OpenaiAppView` type and the `protocol === "openai-apps"` narrowing in `ViewsTab.tsx` are intentionally left alone — backend Phase C3 will drop `outputTemplate` from the response shape, and the inspector will follow then.

## Context

- Inspector PR #2222 (already merged): removed `createOpenaiView`, `updateOpenaiView`, `generateOpenaiUploadUrl`, openai-protocol rename/duplicate/save branches.
- Backend PRs #314 (Phase A), #315 (Phase B), #318 (Phase C1), #320 (clearLegacy hotfix): all merged and deployed.
- Backend Phase C2 PR (drops `openaiAppViews` from schema): opening in parallel — search MCPJam/mcpjam-backend for `cleanup/unify-app-views-phase-c2` once it exists.

## Test plan

- [x] `npm run typecheck:client` — clean
- [x] `npx vitest run client/src/components/__tests__/ViewsTab.layout.test.tsx` — 2/2 pass
- [ ] Manual: delete an `mcp-apps` view in the inspector views tab; confirm it disappears and toast appears.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that removes a now-unused legacy delete path and simplifies view deletion to a single mutation; primary risk is any remaining data still needing the old `openaiAppViews:remove` endpoint.
> 
> **Overview**
> Removes the last legacy `openaiAppViews` delete mutation from `useViewMutations` and updates the associated comment to reflect the post-backfill/Phase C2 cleanup.
> 
> Simplifies `ViewsTab` deletion logic to always call `removeMcpView` (dropping protocol branching and the `removeOpenaiView` dependency), and updates the ViewsTab layout test mocks accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29255c8f080d83fa21f6ee8d26fb7eb1fa11d9b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->