### PR TITLE
cleanup(workspaces): drop legacy workspace data-model from inspector

### DIFF
--- a/mcpjam-inspector/client/src/hooks/use-local-state-migration.ts
+++ b/mcpjam-inspector/client/src/hooks/use-local-state-migration.ts
@@ -74,7 +74,6 @@ function looksPermanent(errorMessage: string): boolean {
  */
 const FORBIDDEN_LEGACY_EXACT_KEYS = [
   "mcp-inspector-projects",
-  "mcp-inspector-workspaces",
   "mcp-inspector-state",
 ];
 const FORBIDDEN_LEGACY_PREFIXES = ["mcp-env-"];

--- a/mcpjam-inspector/client/src/lib/__tests__/local-state-migration.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/local-state-migration.test.ts
@@ -113,7 +113,7 @@ describe("local-state-migration", () => {
       expect(payload!.projects).toHaveLength(1);
     });
 
-    it("falls back to mcp-inspector-state when no projects/workspaces present", () => {
+    it("falls back to mcp-inspector-state when no projects present", () => {
       // Pre-projects format: servers live at the top level of `mcp-inspector-state`.
       // Without this fallback, users on this format would have the migration
       // mark itself complete with nothing pushed to Convex, then later have

--- a/mcpjam-inspector/client/src/lib/local-state-migration.ts
+++ b/mcpjam-inspector/client/src/lib/local-state-migration.ts
@@ -1,11 +1,11 @@
 /**
  * One-time migration shim from legacy localStorage state to Convex.
  *
- * Reads, in priority order: `mcp-inspector-projects`, the older
- * `mcp-inspector-workspaces`, and the still-older `mcp-inspector-state`
- * (pre-projects format whose servers live at the top level). For each, pushes
- * the resulting project(s) + servers to Convex via `projects:createProject`
- * (which materializes the flat `servers` rows via `syncProjectServers`).
+ * Reads, in priority order: `mcp-inspector-projects` and the older
+ * `mcp-inspector-state` (pre-projects format whose servers live at the top
+ * level). For each, pushes the resulting project(s) + servers to Convex via
+ * `projects:createProject` (which materializes the flat `servers` rows via
+ * `syncProjectServers`).
  *
  * **OAuth tokens are imported.** After each `createProject`, the migration
  * resolves the new server IDs by name (`projects:getProjectServers`) and
@@ -39,7 +39,6 @@ export const MIGRATION_FLAG_KEY = "mcp-inspector-migrated-to-convex";
 export const MIGRATION_PROGRESS_KEY = "mcp-inspector-migration-progress";
 
 const LEGACY_PROJECTS_KEY = "mcp-inspector-projects";
-const LEGACY_WORKSPACES_KEY = "mcp-inspector-workspaces";
 const LEGACY_STATE_KEY = "mcp-inspector-state";
 
 // Per-server OAuth keys are name-scoped. Migration scans the full localStorage
@@ -123,9 +122,7 @@ function reviveServer(name: string, raw: any): ServerWithName | null {
 function readProjectsFromLegacyStorage(): Project[] | null {
   let raw: string | null;
   try {
-    raw =
-      localStorage.getItem(LEGACY_PROJECTS_KEY) ??
-      localStorage.getItem(LEGACY_WORKSPACES_KEY);
+    raw = localStorage.getItem(LEGACY_PROJECTS_KEY);
   } catch {
     return null;
   }
@@ -138,7 +135,7 @@ function readProjectsFromLegacyStorage(): Project[] | null {
     return null;
   }
 
-  const rawProjects = parsed?.projects ?? parsed?.workspaces;
+  const rawProjects = parsed?.projects;
   if (!rawProjects || typeof rawProjects !== "object") return null;
 
   const projects: Project[] = [];
@@ -225,8 +222,8 @@ export function readLegacyMigrationPayloadResult(): LegacyReadResult {
 
   const projectsRead = readProjectsFromLegacyStorage();
 
-  // If the newer projects/workspaces store is present but unparseable, stop
-  // here. Falling back to `mcp-inspector-state` and migrating that successfully
+  // If the newer projects store is present but unparseable, stop here.
+  // Falling back to `mcp-inspector-state` and migrating that successfully
   // would let `clearLegacyKeys()` delete the unreadable newer store along
   // with the rest, losing data that a future parser fix or manual recovery
   // could have salvaged. Surface as `unreadable` so the runner records the
@@ -234,7 +231,7 @@ export function readLegacyMigrationPayloadResult(): LegacyReadResult {
   if (projectsRead === null) {
     return {
       kind: "unreadable",
-      reason: "legacy projects/workspaces store is unreadable",
+      reason: "legacy projects store is unreadable",
     };
   }
 
@@ -300,7 +297,6 @@ export function clearLegacyKeys(): void {
   if (typeof window === "undefined") return;
   try {
     localStorage.removeItem(LEGACY_PROJECTS_KEY);
-    localStorage.removeItem(LEGACY_WORKSPACES_KEY);
     localStorage.removeItem(LEGACY_STATE_KEY);
     for (const key of LEGACY_OAUTH_SINGLETONS) {
       localStorage.removeItem(key);
@@ -695,7 +691,7 @@ export async function runLocalStateMigration(
 
       // Default-project branch: the actor already has an auto-provisioned
       // Convex default (created by `users:ensureUser`). Calling
-      // `createProject` here would trip `maxWorkspaces` on free-plan orgs
+      // `createProject` here would trip the project limit on free-plan orgs
       // (cap=1, slot already filled). Resolve the existing default and
       // merge servers into it instead. Idempotent on retry.
       const useDefaultMergePath =

--- a/mcpjam-inspector/server/routes/shared/evals.ts
+++ b/mcpjam-inspector/server/routes/shared/evals.ts
@@ -735,12 +735,8 @@ export async function runEvalsWithManager(
     !!modelApiKeys && Object.keys(modelApiKeys).length > 0;
   const resolvedModelApiKeys = hasClientKeys ? modelApiKeys : undefined;
   let resolvedOrgModelConfig = orgModelConfig;
-  let resolvedOrgModelConfigTarget:
-    | { projectId: string }
-    | { workspaceId: string }
-    | undefined;
+  let resolvedOrgModelConfigTarget: { projectId: string } | undefined;
   let projectIdForOrgConfig: string | undefined = projectId;
-  let legacyWorkspaceIdForOrgConfig: string | undefined;
   if (!projectIdForOrgConfig && resolvedSuiteId) {
     try {
       const suite = await convexClient.query("testSuites:getTestSuite" as any, {
@@ -748,8 +744,6 @@ export async function runEvalsWithManager(
       });
       if (suite?.projectId) {
         projectIdForOrgConfig = String(suite.projectId);
-      } else if (suite?.workspaceId) {
-        legacyWorkspaceIdForOrgConfig = String(suite.workspaceId);
       }
     } catch (error) {
       logger.warn("[evals] Failed to load suite for projectId fallback", {
@@ -760,8 +754,6 @@ export async function runEvalsWithManager(
   }
   const orgConfigTarget = projectIdForOrgConfig
     ? { projectId: projectIdForOrgConfig }
-    : legacyWorkspaceIdForOrgConfig
-    ? { workspaceId: legacyWorkspaceIdForOrgConfig }
     : undefined;
   resolvedOrgModelConfigTarget = orgConfigTarget;
 
@@ -778,7 +770,6 @@ export async function runEvalsWithManager(
       } catch (error) {
         logger.warn("[evals] Failed to resolve org model config", {
           projectId: projectIdForOrgConfig,
-          legacyWorkspaceId: legacyWorkspaceIdForOrgConfig,
           error: error instanceof Error ? error.message : String(error),
         });
       }
@@ -898,14 +889,8 @@ export async function runEvalTestCaseWithManager(
   let resolvedOrgModelConfig = orgModelConfig;
   const testCaseProjectId =
     typeof testCase.projectId === "string" ? testCase.projectId : undefined;
-  const testCaseLegacyWorkspaceId =
-    !testCaseProjectId && typeof testCase.workspaceId === "string"
-      ? testCase.workspaceId
-      : undefined;
   const testCaseOrgConfigTarget = testCaseProjectId
     ? { projectId: testCaseProjectId }
-    : testCaseLegacyWorkspaceId
-    ? { workspaceId: testCaseLegacyWorkspaceId }
     : undefined;
   if (
     !resolvedModelApiKeys &&
@@ -1161,14 +1146,8 @@ export async function streamEvalTestCaseWithManager(
   let resolvedStreamOrgModelConfig = orgModelConfig;
   const streamTestCaseProjectId =
     typeof testCase.projectId === "string" ? testCase.projectId : undefined;
-  const streamTestCaseLegacyWorkspaceId =
-    !streamTestCaseProjectId && typeof testCase.workspaceId === "string"
-      ? testCase.workspaceId
-      : undefined;
   const streamTestCaseOrgConfigTarget = streamTestCaseProjectId
     ? { projectId: streamTestCaseProjectId }
-    : streamTestCaseLegacyWorkspaceId
-    ? { workspaceId: streamTestCaseLegacyWorkspaceId }
     : undefined;
   if (
     !resolvedStreamModelApiKeys &&

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -37,10 +37,6 @@ const clientCapabilitiesSchema = z.record(z.string(), z.unknown());
 
 export const projectServerSchema = z.object({
   projectId: z.string().min(1),
-  // Optional but declared so zod doesn't strip it. Downstream callers in
-  // servers.ts and conformance.ts read this when present to scope authorize
-  // calls to a workspace mirror instead of a project.
-  workspaceId: z.string().min(1).optional(),
   serverId: z.string().min(1),
   serverName: z.string().min(1).optional(),
   clientCapabilities: clientCapabilitiesSchema.optional(),
@@ -248,7 +244,6 @@ export async function authorizeServer(
   serverId: string,
   options?: {
     accessScope?: "project_member" | "chat_v2";
-    workspaceId?: string;
     chatboxId?: string;
     accessVersion?: number;
   }
@@ -271,9 +266,7 @@ export async function authorizeServer(
         Authorization: `Bearer ${bearerToken}`,
       },
       body: JSON.stringify({
-        ...(options?.workspaceId
-          ? { workspaceId: options.workspaceId }
-          : { projectId }),
+        projectId,
         serverId,
         ...(options?.accessScope ? { accessScope: options.accessScope } : {}),
         ...(options?.chatboxId ? { chatboxId: options.chatboxId } : {}),
@@ -329,7 +322,6 @@ export async function authorizeBatch(
   serverIds: string[],
   options?: {
     accessScope?: "project_member" | "chat_v2";
-    workspaceId?: string;
     chatboxId?: string;
     accessVersion?: number;
   }
@@ -352,9 +344,7 @@ export async function authorizeBatch(
         Authorization: `Bearer ${bearerToken}`,
       },
       body: JSON.stringify({
-        ...(options?.workspaceId
-          ? { workspaceId: options.workspaceId }
-          : { projectId }),
+        projectId,
         serverIds,
         ...(options?.accessScope ? { accessScope: options.accessScope } : {}),
         ...(options?.chatboxId ? { chatboxId: options.chatboxId } : {}),
@@ -527,7 +517,6 @@ export async function createAuthorizedManager(
   clientCapabilities?: Record<string, unknown>,
   options?: {
     accessScope?: "project_member" | "chat_v2";
-    workspaceId?: string;
     chatboxId?: string;
     accessVersion?: number;
     rpcLogger?: RpcLogger;
@@ -572,7 +561,6 @@ export async function createAuthorizedManager(
     uniqueServerIds,
     {
       accessScope: options?.accessScope,
-      workspaceId: options?.workspaceId,
       chatboxId: options?.chatboxId,
       accessVersion: options?.accessVersion,
     }
@@ -606,7 +594,6 @@ export async function createAuthorizedManager(
             serverId,
             serverName: displayServerName,
             accessScope: options?.accessScope,
-            workspaceId: options?.workspaceId,
             shareToken: (options as { shareToken?: string })?.shareToken,
             chatboxId: options?.chatboxId,
             accessVersion: options?.accessVersion,
@@ -852,8 +839,6 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
           undefined,
         {
           accessScope,
-          workspaceId:
-            typeof raw.workspaceId === "string" ? raw.workspaceId : undefined,
           chatboxId,
           accessVersion,
           rpcLogger: rpcCollector?.rpcLogger,

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -70,10 +70,6 @@ chatV2.post("/", async (c) => {
 
     // ── Convex authorization path: guest and signed-in actors ─────
     const hostedBody = parseWithSchema(hostedChatSchema, rawBody);
-    const legacyWorkspaceId =
-      typeof (hostedBody as any).workspaceId === "string"
-        ? ((hostedBody as any).workspaceId as string)
-        : undefined;
     const body = rawBody as unknown as ChatV2Request & {
       projectId: string;
       selectedServerIds: string[];
@@ -344,7 +340,6 @@ chatV2.post("/", async (c) => {
           return handleLocalOrgChatModel({
             provider: runtime.provider,
             projectId: hostedBody.projectId,
-            workspaceId: legacyWorkspaceId,
             modelId,
             chatSessionId: hostedChatSessionId,
             sourceType,
@@ -368,7 +363,6 @@ chatV2.post("/", async (c) => {
 
         return handleHostedOrgChatModel({
           projectId: hostedBody.projectId,
-          workspaceId: legacyWorkspaceId,
           providerKey: runtime.providerKey,
           modelId,
           chatSessionId: hostedChatSessionId,

--- a/mcpjam-inspector/server/routes/web/conformance.ts
+++ b/mcpjam-inspector/server/routes/web/conformance.ts
@@ -43,8 +43,6 @@ async function resolveHostedHttpConfig(
   customHeaders?: Record<string, string>;
 }> {
   const wsBody = parseWithSchema(projectServerSchema, body);
-  const workspaceId =
-    typeof body.workspaceId === "string" ? body.workspaceId : undefined;
   const auth = await authorizeServer(
     c,
     bearerToken,
@@ -52,7 +50,6 @@ async function resolveHostedHttpConfig(
     wsBody.serverId,
     {
       accessScope: wsBody.accessScope,
-      workspaceId,
       chatboxId: wsBody.chatboxId,
       accessVersion: wsBody.accessVersion,
     }
@@ -99,8 +96,6 @@ async function resolveHostedServerConfig(
   body: Record<string, unknown>
 ): Promise<MCPAppsConformanceConfig> {
   const wsBody = parseWithSchema(projectServerSchema, body);
-  const workspaceId =
-    typeof body.workspaceId === "string" ? body.workspaceId : undefined;
   const auth = await authorizeServer(
     c,
     bearerToken,
@@ -108,7 +103,6 @@ async function resolveHostedServerConfig(
     wsBody.serverId,
     {
       accessScope: wsBody.accessScope,
-      workspaceId,
       chatboxId: wsBody.chatboxId,
       accessVersion: wsBody.accessVersion,
     }

--- a/mcpjam-inspector/server/routes/web/errors.ts
+++ b/mcpjam-inspector/server/routes/web/errors.ts
@@ -102,30 +102,7 @@ export async function readJsonBody<T>(c: any): Promise<T> {
 }
 
 export function parseWithSchema<T>(schema: z.ZodSchema<T>, data: unknown): T {
-  let normalized = data;
-  if (data && typeof data === "object" && !Array.isArray(data)) {
-    const record = data as Record<string, unknown>;
-    const shouldMapProjectId =
-      typeof record.projectId !== "string" &&
-      typeof record.workspaceId === "string";
-    const shouldMapAccessScope = record.accessScope === "workspace_member";
-
-    if (shouldMapProjectId || shouldMapAccessScope) {
-      normalized = {
-        ...record,
-        ...(shouldMapProjectId ? { projectId: record.workspaceId } : {}),
-        ...(shouldMapAccessScope ? { accessScope: "project_member" } : {}),
-      };
-      if (shouldMapProjectId) {
-        console.warn("legacy workspaceId request field used");
-      }
-      if (shouldMapAccessScope) {
-        console.warn("legacy workspace_member accessScope used");
-      }
-    }
-  }
-
-  const parsed = schema.safeParse(normalized);
+  const parsed = schema.safeParse(data);
   if (!parsed.success) {
     const issue = parsed.error.issues[0];
     throw new WebRouteError(
@@ -134,15 +111,5 @@ export function parseWithSchema<T>(schema: z.ZodSchema<T>, data: unknown): T {
       issue?.message ?? "Request validation failed"
     );
   }
-  const parsedData = parsed.data as T & { workspaceId?: unknown };
-  if (
-    data &&
-    typeof data === "object" &&
-    !Array.isArray(data) &&
-    typeof (data as Record<string, unknown>).workspaceId === "string" &&
-    typeof (data as Record<string, unknown>).projectId !== "string"
-  ) {
-    parsedData.workspaceId = (data as Record<string, unknown>).workspaceId;
-  }
-  return parsedData;
+  return parsed.data;
 }

--- a/mcpjam-inspector/server/routes/web/servers.ts
+++ b/mcpjam-inspector/server/routes/web/servers.ts
@@ -48,10 +48,6 @@ servers.post("/check-oauth", async (c) =>
       body.serverId,
       {
         accessScope: body.accessScope,
-        workspaceId:
-          typeof (body as { workspaceId?: unknown }).workspaceId === "string"
-            ? (body as unknown as { workspaceId: string }).workspaceId
-            : undefined,
         chatboxId: body.chatboxId,
         accessVersion: body.accessVersion,
       }
@@ -108,10 +104,6 @@ async function runHostedDoctor(
     body.serverId,
     {
       accessScope: body.accessScope,
-      workspaceId:
-        typeof (body as { workspaceId?: unknown }).workspaceId === "string"
-          ? (body as unknown as { workspaceId: string }).workspaceId
-          : undefined,
       chatboxId: body.chatboxId,
       accessVersion: body.accessVersion,
     }

--- a/mcpjam-inspector/server/services/evals-runner.ts
+++ b/mcpjam-inspector/server/services/evals-runner.ts
@@ -1200,10 +1200,6 @@ function resolveOrgTargetForEval(
   if (typeof maybeProjectId === "string" && maybeProjectId.trim()) {
     return { projectId: maybeProjectId.trim() };
   }
-  const maybeWorkspaceId = (test as { workspaceId?: unknown }).workspaceId;
-  if (typeof maybeWorkspaceId === "string" && maybeWorkspaceId.trim()) {
-    return { workspaceId: maybeWorkspaceId.trim() };
-  }
   return undefined;
 }
 

--- a/mcpjam-inspector/server/services/evals/replay-suite-run.ts
+++ b/mcpjam-inspector/server/services/evals/replay-suite-run.ts
@@ -126,14 +126,8 @@ export async function executeSuiteReplayFromRun(
       typeof replayMetadata.projectId === "string"
         ? replayMetadata.projectId
         : undefined;
-    const replayLegacyWorkspaceId =
-      !replayProjectId && typeof replayMetadata.workspaceId === "string"
-        ? replayMetadata.workspaceId
-        : undefined;
     const replayOrgConfigTarget = replayProjectId
       ? { projectId: replayProjectId }
-      : replayLegacyWorkspaceId
-      ? { workspaceId: replayLegacyWorkspaceId }
       : undefined;
     if (
       !resolvedModelApiKeys &&

--- a/mcpjam-inspector/server/services/evals/trace-repair-runner.ts
+++ b/mcpjam-inspector/server/services/evals/trace-repair-runner.ts
@@ -321,14 +321,8 @@ export async function runTraceRepairJob(
       );
       const repairProjectId =
         typeof job?.projectId === "string" ? job.projectId : undefined;
-      const repairLegacyWorkspaceId =
-        !repairProjectId && typeof job?.workspaceId === "string"
-          ? job.workspaceId
-          : undefined;
       const repairOrgConfigTarget = repairProjectId
         ? { projectId: repairProjectId }
-        : repairLegacyWorkspaceId
-        ? { workspaceId: repairLegacyWorkspaceId }
         : undefined;
       if (repairOrgConfigTarget) {
         const orgConfig = await resolveOrgModelConfig(

--- a/mcpjam-inspector/server/utils/__tests__/hosted-oauth-refresh.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/hosted-oauth-refresh.test.ts
@@ -51,37 +51,6 @@ describe("forceRefreshHostedOAuthAccessToken", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("prefers workspaceId over projectId in the body when supplied", async () => {
-    const fetchMock = vi.fn(async (_input: any, init?: any) => {
-      expect(JSON.parse(init?.body)).toEqual({
-        workspaceId: "ws-1",
-        serverId: "server-1",
-        accessScope: "chat_v2",
-        chatboxId: "cbx_1",
-        accessVersion: 3,
-      });
-      return new Response(
-        JSON.stringify({ accessToken: "fresh-token" }),
-        { status: 200, headers: { "Content-Type": "application/json" } }
-      );
-    });
-    vi.stubGlobal("fetch", fetchMock);
-
-    await expect(
-      forceRefreshHostedOAuthAccessToken(
-        "bearer-token",
-        "project-1",
-        "server-1",
-        {
-          accessScope: "chat_v2",
-          workspaceId: "ws-1",
-          chatboxId: "cbx_1",
-          accessVersion: 3,
-        }
-      )
-    ).resolves.toBe("fresh-token");
-  });
-
   it("maps refresh_token_invalid to a WebRouteError with reconnect details", async () => {
     vi.stubGlobal(
       "fetch",

--- a/mcpjam-inspector/server/utils/hosted-oauth-refresh.ts
+++ b/mcpjam-inspector/server/utils/hosted-oauth-refresh.ts
@@ -7,7 +7,6 @@ import {
 
 export type HostedOAuthRefreshOptions = {
   accessScope?: "project_member" | "chat_v2";
-  workspaceId?: string;
   shareToken?: string;
   /**
    * Resolved chatbox identity (post-redeem). The backend scopes OAuth
@@ -53,9 +52,7 @@ export async function forceRefreshHostedOAuthAccessToken(
         Authorization: `Bearer ${bearerToken}`,
       },
       body: JSON.stringify({
-        ...(options?.workspaceId
-          ? { workspaceId: options.workspaceId }
-          : { projectId }),
+        projectId,
         serverId,
         ...(options?.accessScope ? { accessScope: options.accessScope } : {}),
         ...(options?.shareToken ? { shareToken: options.shareToken } : {}),
@@ -122,7 +119,6 @@ export type HostedOAuthUnauthorizedHandlerArgs = {
   serverId: string;
   serverName: string;
   accessScope?: "project_member" | "chat_v2";
-  workspaceId?: string;
   shareToken?: string;
   chatboxId?: string;
   accessVersion?: number;
@@ -144,7 +140,6 @@ export function buildHostedOAuthUnauthorizedHandler(
       args.serverId,
       {
         accessScope: args.accessScope,
-        workspaceId: args.workspaceId,
         shareToken: args.shareToken,
         chatboxId: args.chatboxId,
         accessVersion: args.accessVersion,

--- a/mcpjam-inspector/server/utils/org-model-config.ts
+++ b/mcpjam-inspector/server/utils/org-model-config.ts
@@ -25,12 +25,9 @@ export type ResolvedOrgModelConfig = {
 
 export type ResolveOrgModelConfigTarget =
   | { projectId: string }
-  | { workspaceId: string }
   | { organizationId: string };
 
-export type ResolveOrgProviderRuntimeTarget =
-  | { projectId: string }
-  | { workspaceId: string };
+export type ResolveOrgProviderRuntimeTarget = { projectId: string };
 
 export type ResolveOrgModelConfigAuth = {
   authHeader?: string;
@@ -111,8 +108,6 @@ function formatTargetForCache(
 ): string {
   return "projectId" in params
     ? `project:${params.projectId}`
-    : "workspaceId" in params
-    ? `legacy-workspace:${params.workspaceId}`
     : `org:${params.organizationId}`;
 }
 

--- a/mcpjam-inspector/server/utils/org-model-stream-handler.ts
+++ b/mcpjam-inspector/server/utils/org-model-stream-handler.ts
@@ -75,7 +75,6 @@ const DEFAULT_MAX_STEPS_LOCAL_ORG = 30;
 
 export interface OrgModelHandlerOptions {
   projectId: string;
-  workspaceId?: string;
   providerKey: string;
   modelId: string;
   chatSessionId?: string;
@@ -229,7 +228,6 @@ export interface OrgLocalModelHandlerOptions {
   /** The resolved local provider config (from /stream/org/resolve). */
   provider: OrgProviderResolvedConfig;
   projectId: string;
-  workspaceId?: string;
   modelId: string;
   chatSessionId?: string;
   sourceType?: string;
@@ -272,7 +270,6 @@ export function handleLocalOrgChatModel(
   const {
     provider,
     projectId,
-    workspaceId,
     modelId,
     chatSessionId,
     sourceType,
@@ -577,7 +574,6 @@ export function handleLocalOrgChatModel(
           // Post usage to Convex (best-effort, non-blocking on failure).
           postLocalUsage({
             projectId,
-            workspaceId,
             providerKey: provider.providerKey,
             model: modelId,
             usage: traceTurn.turnUsage,
@@ -640,7 +636,6 @@ export function handleLocalOrgChatModel(
 
 async function postLocalUsage(params: {
   projectId: string;
-  workspaceId?: string;
   providerKey: string;
   model: string;
   usage?: LiveChatTraceUsage;
@@ -670,7 +665,6 @@ async function postLocalUsage(params: {
       },
       body: JSON.stringify({
         projectId: params.projectId,
-        ...(params.workspaceId ? { workspaceId: params.workspaceId } : {}),
         providerKey: params.providerKey,
         model: params.model,
         ...(params.usage ? { usage: params.usage } : {}),
@@ -724,7 +718,7 @@ export async function handleHostedOrgChatModel(
     systemPrompt: options.systemPrompt,
     temperature: options.temperature,
     tools: options.tools,
-    projectId: options.workspaceId ? undefined : options.projectId,
+    projectId: options.projectId,
     authHeader: options.authHeader,
     chatboxId: options.chatboxId,
     accessVersion: options.accessVersion,
@@ -742,7 +736,6 @@ export async function handleHostedOrgChatModel(
     endpointPath: "/stream/org",
     extraBodyFields: {
       providerKey: options.providerKey,
-      ...(options.workspaceId ? { workspaceId: options.workspaceId } : {}),
       // chatboxId / accessVersion are set on the body by
       // handleMCPJamFreeChatModel itself.
       ...((options.serverIds ?? options.selectedServers)?.length


### PR DESCRIPTION
## Summary

Workspaces were replaced by Projects. This PR hard-removes the backward-compat plumbing that was still accepting and translating `workspaceId` on inspector routes.

**Schema / field-mapping shims removed**
- `errors.ts:parseWithSchema` no longer maps incoming `workspaceId` → `projectId` or `accessScope: "workspace_member"` → `"project_member"`. Any client still sending those fields will now get a `VALIDATION_ERROR` instead of a deprecation warning.
- `projectServerSchema` no longer declares `workspaceId` as an optional pass-through field.

**Helpers / option types**
- Removed `workspaceId` from `authorizeServer`, `authorizeBatch`, `createAuthorizedManager`, `forceRefreshHostedOAuthAccessToken`, `buildHostedOAuthUnauthorizedHandler`.
- Removed `workspaceId` extraction in `withEphemeralConnection`.

**Eval / org-model-config legacy fallbacks**
- Dropped `{ workspaceId: string }` variant from `ResolveOrgModelConfigTarget` and `ResolveOrgProviderRuntimeTarget` unions.
- Removed `legacy-workspace:${id}` cache-key branch in `formatTargetForCache`.
- Removed `legacyWorkspaceId` fallback paths in `evals.ts` (suite + 2× test-case sites), `evals-runner.ts`, `trace-repair-runner.ts`, `replay-suite-run.ts` — these no longer fall back to `suite.workspaceId` / `testCase.workspaceId` when `projectId` is missing.

**Chat / conformance / servers routes**
- `chat-v2.ts` no longer extracts or forwards `legacyWorkspaceId` to the org chat handlers.
- `conformance.ts` and `servers.ts` no longer read `workspaceId` from the request body.
- `org-model-stream-handler.ts`: removed `workspaceId` from `OrgModelHandlerOptions` / `OrgLocalModelHandlerOptions`, from the `postLocalUsage` body, and from the `/stream/org` extraBodyFields.

**Client migration**
- `local-state-migration.ts` no longer reads from the `mcp-inspector-workspaces` localStorage key or the `workspaces` field. The general localStorage→Convex migration path remains (still reads `mcp-inspector-projects` and the older `mcp-inspector-state`).
- `use-local-state-migration.ts` no longer audits for the workspaces key in the forbidden-legacy-keys check.

**Tests**
- Removed the `prefers workspaceId over projectId` test in `hosted-oauth-refresh.test.ts`.
- Renamed the local-state-migration test that covered the now-removed workspaces-key fallback path.

Net: 16 files changed, -158 lines.

## Test plan

- [x] `npx tsc --noEmit -p client/tsconfig.typecheck.json` — clean
- [x] `npx vitest run server/services/evals/__tests__/ server/routes/shared/__tests__/` — 78 / 78 pass
- [x] `npx vitest run server/utils/__tests__/hosted-oauth-refresh.test.ts` — 8 / 8 pass
- [x] `npx vitest run client/src/lib/__tests__/local-state-migration.test.ts` — 25 / 25 pass
- [x] `npx vitest run server/routes/web/__tests__/ server/utils/__tests__/` — 411 tests pass (5 suites fail to load due to a pre-existing missing `SandboxProxyHtml.bundled.js` build artifact unrelated to this change)
- [ ] Pairs with backend PR — the Convex backend still needs to stop writing `workspaceId` on the request envelopes this PR no longer accepts. Coordinate deploys.

> Note for reviewers: this is a hard removal. Any inspector client/build still sending `workspaceId` or `workspace_member` will now get a 400 from the hosted routes instead of being silently mapped to projectId. We assume "all migrated" — confirm before merging if there's still an old client surface in the wild.

https://claude.ai/code/session_014gvb6fXqT1fX1METkY6iBX

---
_Generated by [Claude Code](https://claude.ai/code/session_014gvb6fXqT1fX1METkY6iBX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes backward-compat request field mapping and legacy ID fallbacks across multiple server routes and services, so any still-deployed older clients sending `workspaceId`/`workspace_member` will now hard-fail with 400s. Also changes client localStorage migration to no longer read the legacy `mcp-inspector-workspaces` key, which could strand data if that key still exists in the wild.
> 
> **Overview**
> **Hard-removes legacy “workspaces” compatibility across the inspector**, standardizing request/targeting to `projectId` only.
> 
> Server-side, this deletes the `workspaceId` passthrough from request schemas and removes the `workspaceId`→`projectId` / `workspace_member`→`project_member` normalization in `parseWithSchema`, plus strips all remaining `workspaceId` options/fallback branches in authorization, chat, conformance, servers, evals/org-model-config resolution, and hosted OAuth refresh calls.
> 
> Client-side, the localStorage→Convex migration no longer reads or clears `mcp-inspector-workspaces`/`workspaces` and the post-migration forbidden-key audit stops checking for that key; associated tests are updated by removing the workspace-preference coverage and renaming the migration fallback test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c6eebf093756408f0590c0aa5f867d816cc22f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->