### PR TITLE
fix(apps): modal widget advertises same HostCapabilities as inline

### DIFF
--- a/.changeset/mcp-apps-modal-parity.md
+++ b/.changeset/mcp-apps-modal-parity.md
@@ -1,0 +1,6 @@
+---
+"@mcpjam/inspector": patch
+---
+
+### `@mcpjam/inspector`
+- **Modal widget advertises the same `HostCapabilities` as the inline widget**: previously `mcp-apps-modal.tsx` hardcoded `{ openLinks, serverTools, serverResources, logging, updateModelContext, message }` at AppBridge construction, which masked Copilot's published M365 subset (no `serverResources` / `logging`) and silently ignored user overrides in `mcpProfile.apps.mcpAppsOverrides`. The modal now receives the resolved `effectiveHostCapabilities` from the inline renderer and advertises an identical surface — `app.getHostCapabilities()` returns the same record regardless of which iframe the widget is mounted in. Test added that asserts inline/modal parity on Copilot.

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -235,8 +235,16 @@ vi.mock("lucide-react", () => ({
   X: (props: any) => <div {...props} />,
 }));
 
+// Capture props passed into the modal so tests can assert inline/modal
+// HostCapabilities parity without mounting a real second AppBridge.
+const mcpAppsModalPropsRef: { current: Record<string, unknown> | null } = {
+  current: null,
+};
 vi.mock("../mcp-apps-modal", () => ({
-  McpAppsModal: () => null,
+  McpAppsModal: (props: Record<string, unknown>) => {
+    mcpAppsModalPropsRef.current = props;
+    return null;
+  },
 }));
 
 // ── Import component under test (after mocks) ─────────────────────────────
@@ -418,6 +426,41 @@ describe("MCPAppsRenderer tool input streaming", () => {
     const advertised = appBridgeArgsRef.current?.hostCapabilities;
     expect(advertised).not.toHaveProperty("serverResources");
     expect(advertised).not.toHaveProperty("logging");
+  });
+
+  it("passes the same effectiveHostCapabilities to the modal as the inline AppBridge advertises", async () => {
+    // Inline + modal must speak an identical HostCapabilities surface.
+    // Previously the modal hardcoded {openLinks, serverTools,
+    // serverResources, logging, updateModelContext, message} — that
+    // disagreed with Copilot's matrix-derived blob (which drops
+    // serverResources / logging) and silently ignored user overrides
+    // in mcpProfile.apps.mcpAppsOverrides.
+    mcpAppsModalPropsRef.current = null;
+    render(
+      <ChatboxHostStyleProvider value="copilot">
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostStyleProvider>,
+    );
+
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+    await vi.waitFor(() => {
+      expect(mcpAppsModalPropsRef.current).not.toBeNull();
+    });
+
+    const modalCaps = mcpAppsModalPropsRef.current
+      ?.effectiveHostCapabilities as Record<string, unknown>;
+    const { sandbox: _sandbox, ...inlineVendorOnly } =
+      (appBridgeArgsRef.current?.hostCapabilities ?? {}) as Record<
+        string,
+        unknown
+      >;
+    expect(modalCaps).toEqual(inlineVendorOnly);
+    // Sentinel: Copilot's preset matrix strips both keys in inline AND
+    // modal post-fix. (Pre-fix the modal would have included them.)
+    expect(modalCaps).not.toHaveProperty("serverResources");
+    expect(modalCaps).not.toHaveProperty("logging");
   });
 
   it("does not block pure MCP Apps from booting while ChatGPT compat is enabled", async () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-modal.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-modal.tsx
@@ -13,6 +13,7 @@ import { extractMethod } from "@/stores/traffic-log-store";
 import {
   AppBridge,
   PostMessageTransport,
+  type McpUiHostCapabilities,
   type McpUiHostContext,
   type McpUiResourceCsp,
   type McpUiResourcePermissions,
@@ -54,6 +55,20 @@ export interface McpAppsModalProps {
    * shimmed while the inline view isn't (or vice versa).
    */
   injectOpenAiCompat: boolean;
+  /**
+   * Resolved MCP Apps `HostCapabilities` blob the inline renderer
+   * already computed via `resolveEffectiveHostCapabilities`. Pass-down
+   * mirrors {@link injectOpenAiCompat}: the modal mounts its own
+   * AppBridge and we want inline + modal to advertise an identical
+   * surface to the widget. Previously the modal hardcoded `{ openLinks,
+   * serverTools, serverResources, logging, updateModelContext, message }`
+   * — that masked Copilot's M365-published subset (which strips
+   * `serverResources` / `logging`) and any user override in
+   * `mcpProfile.apps.mcpAppsOverrides`. The `sandbox` slice is composed
+   * separately at AppBridge construction from the widget-level CSP /
+   * permissions props.
+   */
+  effectiveHostCapabilities: Omit<McpUiHostCapabilities, "sandbox">;
   toolInputRef: React.RefObject<Record<string, unknown> | undefined>;
   toolOutputRef: React.RefObject<unknown>;
   themeModeRef: React.RefObject<string>;
@@ -88,6 +103,7 @@ export function McpAppsModal({
   toolName,
   cspMode,
   injectOpenAiCompat,
+  effectiveHostCapabilities,
   toolInputRef,
   toolOutputRef,
   themeModeRef,
@@ -169,16 +185,16 @@ export function McpAppsModal({
       name: "mcpjam-inspector",
       version: __APP_VERSION__,
     }) as { name: string; version: string };
+    // Vendor-trait HostCapabilities come from the inline renderer's
+    // resolver (matrix-derived + user override). Sandbox is composed
+    // here from the widget-level resource CSP / permissions per
+    // SEP-1865 (sandbox is per-resource, not a vendor trait — see
+    // HostMcpProfile.mcpAppsCapabilities doc).
     const bridge = new AppBridge(
       null,
       resolvedHostInfo,
       {
-        openLinks: {},
-        serverTools: {},
-        serverResources: {},
-        logging: {},
-        updateModelContext: {},
-        message: {},
+        ...effectiveHostCapabilities,
         sandbox: {
           csp: widgetPermissive ? undefined : widgetCsp,
           permissions: widgetPermissions,
@@ -277,6 +293,7 @@ export function McpAppsModal({
     toolInputRef,
     toolOutputRef,
     activeMcpProfile,
+    effectiveHostCapabilities,
   ]);
 
   const handleModalMessage = (event: MessageEvent) => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -2870,6 +2870,11 @@ export function MCPAppsRenderer({
         toolName={toolName}
         cspMode={cspMode}
         injectOpenAiCompat={effectiveInjectOpenAiCompat}
+        // Same resolved blob the inline AppBridge advertises. Inline +
+        // modal must speak an identical surface to the widget so
+        // app.getHostCapabilities() returns the same record regardless
+        // of which iframe the widget is mounted in.
+        effectiveHostCapabilities={effectiveHostCapabilities}
         toolInputRef={toolInputRef}
         toolOutputRef={toolOutputRef}
         themeModeRef={themeModeRef}


### PR DESCRIPTION
## Summary

Surgical follow-up to #2226. The MCP Apps modal widget (`mcp-apps-modal.tsx`) had a hardcoded `HostCapabilities` literal at `new AppBridge(...)` that bypassed the matrix resolver. This PR threads the inline renderer's `effectiveHostCapabilities` down into the modal so both iframes advertise an identical surface.

## What was wrong

After the foundation PR (#2226), the inline renderer started advertising Copilot's M365-published subset correctly (no `serverResources` / `logging`). But the modal continued to declare:

```ts
new AppBridge(null, hostInfo, {
  openLinks: {},
  serverTools: {},
  serverResources: {},   // ← always on, regardless of host
  logging: {},           // ← always on, regardless of host
  updateModelContext: {},
  message: {},
  sandbox: { ... },
})
```

So:
1. **Copilot widgets in fullscreen mode** would see `serverResources: {}` from `app.getHostCapabilities()` — the opposite of what real Copilot returns. Widget behavior in the inspector wouldn't match Copilot behavior.
2. **User overrides on `mcpProfile.apps.mcpAppsOverrides`** flowed into the inline renderer's `effectiveHostCapabilities` but not the modal's hardcoded blob. So a user toggling a row in (an as-yet-unbuilt) matrix UI would see inline change, modal stay stuck.

## Fix

`McpAppsModalProps` gains a new `effectiveHostCapabilities` prop. The inline renderer passes the value it already computes via `resolveEffectiveHostCapabilities` (which now reads the matrix path per #2226). The modal spreads this into `new AppBridge(...)` and composes `sandbox` separately from its widget-level CSP / permissions props (per SEP-1865, sandbox is per-resource, not a vendor trait).

Mirrors the pre-existing pass-down pattern for `injectOpenAiCompat` (see the prop's doc comment, lines 49–55) — explicit lockstep so the two iframes can't end up advertising different surfaces.

## Tests

- New `mcp-apps-renderer.test.tsx` case: captures props passed to the mocked `McpAppsModal` and asserts (a) modal `effectiveHostCapabilities` equals inline `hostCapabilities` minus `sandbox`, (b) Copilot's stripped keys (`serverResources`, `logging`) are absent from both.
- **95/95 mcp-apps renderer tests pass** (`npx vitest run client/src/components/chat-v2/thread/mcp-apps/__tests__/`).

## Files

- `client/src/components/chat-v2/thread/mcp-apps/mcp-apps-modal.tsx` — new `effectiveHostCapabilities` prop; spread into AppBridge ctor; sandbox composed separately
- `client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx` — pass `effectiveHostCapabilities` to `<McpAppsModal />`
- `client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx` — modal mock captures props; new parity test
- `.changeset/mcp-apps-modal-parity.md` — patch bump

## Test plan

- [x] `npx vitest run client/src/components/chat-v2/thread/mcp-apps/__tests__/` — 95/95 pass
- [x] `npx tsc -p client/tsconfig.json --noEmit` — no new errors in changed files
- [ ] Manual: open a widget in modal mode on the `copilot` host preset; probe `app.getHostCapabilities()` and confirm `serverResources` / `logging` are NOT present (matching inline behavior)
- [ ] Manual: switch the same widget between inline and modal modes; confirm `app.getHostCapabilities()` returns the same record in both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small prop-threading change to the modal AppBridge handshake plus a targeted test; main impact is correcting advertised capability surface rather than altering core widget behavior.
> 
> **Overview**
> Ensures the MCP Apps **modal** iframe advertises the same resolved `HostCapabilities` as the **inline** renderer. The modal no longer hardcodes a capability literal; it now receives `effectiveHostCapabilities` from `MCPAppsRenderer` and spreads it into its `AppBridge` constructor while continuing to compose `sandbox` from per-resource CSP/permissions.
> 
> Adds a regression test that captures props passed to the modal and asserts inline/modal capability parity for the Copilot preset (notably excluding `serverResources` and `logging`), and includes a patch changeset for `@mcpjam/inspector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6eb1839d847e1004afe2fe5f6e969f04a1c2d83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->