### PR TITLE
cleanup(views): stop sending outputTemplate + serverInfo to createMcpView

### DIFF
--- a/mcpjam-inspector/client/src/hooks/useSaveView.ts
+++ b/mcpjam-inspector/client/src/hooks/useSaveView.ts
@@ -265,8 +265,6 @@ export function useSaveView({
           toolName: toolData.toolName,
         });
         const liveOutputTemplate = toolData.outputTemplate?.trim();
-        const liveOutputTemplateIsUi =
-          !!liveOutputTemplate && liveOutputTemplate.startsWith("ui://");
         // `toolData.resourceUri` comes from `getUIResourceUri()` in
         // part-switch.tsx, which for OpenAI-origin tools returns the
         // raw `openai/outputTemplate` value verbatim — any scheme. We
@@ -302,17 +300,6 @@ export function useSaveView({
           injectedOpenAiCompatCapabilities: widgetHtmlBlobId
             ? toolData.injectedOpenAiCompatCapabilities
             : undefined,
-          // Legacy aliases (input-only on the backend normalizer). The
-          // backend validates `outputTemplate` whenever it is supplied,
-          // even when `resourceUri` wins precedence, so we only
-          // forward it when it is itself spec-compliant. A non-ui://
-          // OpenAI template (e.g. `https://...`) is dropped on the
-          // floor here — the canonical `resourceUri` is what matters.
-          outputTemplate:
-            isOpenAIOrigin && liveOutputTemplateIsUi
-              ? liveOutputTemplate
-              : undefined,
-          serverInfo: isOpenAIOrigin ? toolData.serverInfo : undefined,
           // Documentation-only provenance:
           viewOriginProtocol: isOpenAIOrigin ? "openai-apps" : "mcp-apps",
         });


### PR DESCRIPTION
## Summary

Paired with backend [PR #323](https://github.com/MCPJam/mcpjam-backend/pull/323) (Phase C3), which removes \`outputTemplate\` and \`serverInfo\` from \`mcpAppViewCreateArgs\`. After C3 deploys, the backend args validator rejects writes that include either field, so the inspector must stop forwarding them.

This PR is intentionally minimal: just the two field entries in the \`createMcpView({...})\` call in \`useSaveView.ts\` are removed (13 lines). The \`ToolDataForSave\` interface still types both fields as optional — they're harmless on the JS side because they're no longer read in the save path.

## Deferred to a follow-up

The larger type-narrowing cascade — dropping \`OpenaiAppView\` from \`useViews.ts\`, narrowing \`AnyView\` to mcp-only, and cleaning up the residual \`protocol === \"openai-apps\"\` dead branches in \`ViewsTab.tsx\` — is **not** in this PR. Those branches are unreachable (no visible view has \`protocol === \"openai-apps\"\` after the prod backfill) but still typecheck and don't block saves. Leaving them for a focused follow-up keeps this paired PR small.

## Test plan

- [x] \`npm run typecheck:client\` — clean
- [x] \`npx vitest run client/src/components/__tests__/ViewsTab.layout.test.tsx client/src/hooks\` — 348 pass, 6 skipped
- [ ] Backend #323 deploys to staging
- [ ] Smoke test: save a new view in the inspector — should land in \`mcpAppViews\` without backend validator rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only removes two legacy fields from the client `createMcpView` payload to match updated backend validation; it should only affect saves if backend still expects these deprecated args.
> 
> **Overview**
> View saves via `useSaveView` no longer forward the legacy OpenAI-origin fields `outputTemplate` and `serverInfo` in the `createMcpView` request.
> 
> This keeps the save payload aligned with the backend’s `mcpAppViewCreateArgs` changes and prevents validator rejections while leaving the client-side types/derivations intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 882d4f35d7fc3b39abfafeb7c7ff78c509599c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->