### PR TITLE
feat(apps): JSON editor round-trip for mcpAppsOverrides

### DIFF
--- a/.changeset/mcp-apps-overrides-json-roundtrip.md
+++ b/.changeset/mcp-apps-overrides-json-roundtrip.md
@@ -1,0 +1,6 @@
+---
+"@mcpjam/inspector": patch
+---
+
+### `@mcpjam/inspector`
+- **Apps tab JSON editor surfaces `mcpAppsOverrides`**: round-trip serialize + parse for the SEP-1865 `app.*` spec-bridge sparse matrix override added in #2226. Until the structured matrix UI lands, users can configure the override by hand-editing JSON in the Apps tab — typing `{ "mcpAppsOverrides": { "serverResources": false, "logging": false } }` now persists to `mcpProfile.apps.mcpAppsOverrides` instead of being silently dropped. Soft-validated on parse: boolean rows require booleans, `availableDisplayModes` filters to known modes (`inline` / `fullscreen` / `pip`), and entirely-invalid blocks collapse to `undefined` so the resolver falls back cleanly to the host style preset. Sibling fields (`compatRuntime`, `sandbox`, `uiInitialize`) are preserved across edits. Sparse in serialize: omitted from the JSON when no override is persisted.

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -438,33 +438,97 @@ export function applyJsonToDraft(
     delete nextCaps.extensions;
   }
 
+  // mcpAppsOverrides — parsed FIRST so the `hostCapabilities` diff
+  // target below knows what wire shape the matrix would produce. Sparse
+  // spec-bridge override; soft-validated per field (booleans for
+  // boolean rows; mode-array filtered to known members). Empty /
+  // fully-invalid input collapses to undefined so the resolver falls
+  // back cleanly to the host style preset.
+  let nextMcpAppsOverrides: McpAppsCapabilities | undefined = undefined;
+  if (isPlainObject(parsed.mcpAppsOverrides)) {
+    const incoming = parsed.mcpAppsOverrides as Record<string, unknown>;
+    const out: McpAppsCapabilities = {};
+    const booleanKeys: Array<keyof McpAppsCapabilities> = [
+      "toolInputPartial",
+      "toolCancelled",
+      "hostContextChanged",
+      "resourceTeardown",
+      "toolInfo",
+      "openLinks",
+      "serverTools",
+      "serverResources",
+      "logging",
+      "updateModelContext",
+      "message",
+      "sandboxPermissions",
+      "cspFrameDomains",
+      "cspBaseUriDomains",
+      "resourcePrefersBorder",
+    ];
+    for (const key of booleanKeys) {
+      const value = incoming[key];
+      if (typeof value === "boolean") {
+        (out as Record<string, unknown>)[key] = value;
+      }
+    }
+    const modes = incoming.availableDisplayModes;
+    if (Array.isArray(modes)) {
+      const filtered = modes.filter(
+        (m): m is "inline" | "fullscreen" | "pip" =>
+          m === "inline" || m === "fullscreen" || m === "pip",
+      );
+      // Soft-validate: only emit the array when at least one valid
+      // member survived. An empty filter result reads as "user typed
+      // garbage" — fall through to the preset rather than persisting an
+      // empty allowlist the resolver would have to coerce to ["inline"].
+      if (filtered.length > 0) out.availableDisplayModes = filtered;
+    }
+    if (Object.keys(out).length > 0) nextMcpAppsOverrides = out;
+  }
+
   // hostCapabilities — the user sees the EFFECTIVE merged value, so on
-  // parse-back we diff against the preset to decide whether to store an
-  // override:
-  //   - absent in JSON → undefined override (revert to preset)
-  //   - equal to preset → undefined override (clean revert)
-  //   - different from preset → override = parsed value (incl. `{}` for
-  //     "advertise nothing")
-  // Sandbox is its own top-level block now; if a `sandbox` key sneaks into
-  // hostCapabilities (paste from an older export, hand-edit), strip it so
-  // it doesn't pollute the override diff.
-  // `presetEffective` is the wire shape with NO override applied — the
-  // diff target used to decide whether a parsed JSON-editor value is a
-  // "real" override or a no-op revert to preset. Profile context-free on
-  // purpose: a user typing `hostCapabilities` in the editor is overriding
-  // both the preset AND any matrix override; the diff target should be
-  // the preset alone so the override clears cleanly when the user pastes
-  // back the preset value.
-  const presetEffective = resolveEffectiveHostCapabilities({
+  // parse-back we diff against the MATRIX-RESOLVED shape (preset +
+  // mcpAppsOverrides) to decide whether to store a legacy override:
+  //   - absent in JSON → undefined legacy override
+  //   - equal to matrix-resolved shape → undefined legacy override
+  //     (the user is just looking at a faithful serialization of the
+  //     matrix; no extra opinion expressed)
+  //   - different from matrix-resolved shape → legacy override = parsed
+  //     value (the user typed a `hostCapabilities` value the matrix
+  //     can't produce — persist as legacy `hostCapabilitiesOverride`
+  //     so it survives the round-trip)
+  // Sandbox is its own top-level block now; if a `sandbox` key sneaks
+  // into hostCapabilities (paste from an older export, hand-edit),
+  // strip it so it doesn't pollute the override diff.
+  //
+  // Why diff against the matrix-resolved shape, not the preset alone:
+  // when `mcpAppsOverrides` makes the matrix produce a non-preset wire
+  // shape (e.g. Claude with serverResources turned off), `appsToJson`
+  // serializes that non-preset shape into `hostCapabilities`. Diffing
+  // against the preset alone would falsely flag every such round-trip
+  // as a legacy override, creating a stale `hostCapabilitiesOverride`
+  // beside the matrix. Removing `mcpAppsOverrides` later would then
+  // appear to "do nothing" because the stale legacy keeps the same
+  // shape alive.
+  const matrixResolvedHostCapabilities = resolveEffectiveHostCapabilities({
     hostStyle: prev.hostStyle,
-    profile: undefined,
+    profile:
+      nextMcpAppsOverrides !== undefined
+        ? {
+            profileVersion: 1,
+            apps: { mcpAppsOverrides: nextMcpAppsOverrides },
+          }
+        : undefined,
     hostCapabilitiesOverride: undefined,
   }) as Record<string, unknown>;
   let nextOverride: Record<string, unknown> | undefined = undefined;
   if ("hostCapabilities" in parsed) {
     if (isPlainObject(parsed.hostCapabilities)) {
       const { sandbox: _ignored, ...incoming } = parsed.hostCapabilities;
-      if (stableStringifyJson(incoming) === stableStringifyJson(presetEffective)) {
+      if (
+        stableStringifyJson(incoming) ===
+        stableStringifyJson(matrixResolvedHostCapabilities)
+      ) {
         nextOverride = undefined;
       } else {
         nextOverride = incoming;
@@ -632,52 +696,6 @@ export function applyJsonToDraft(
     if (Object.keys(parsedOverrides).length > 0) {
       newCompatRuntime.openaiAppsOverrides = parsedOverrides;
     }
-  }
-
-  // mcpAppsOverrides — sparse spec-bridge override. Soft-validated per
-  // field (booleans for boolean rows; mode-array filtered to known
-  // members). Empty / fully-invalid input collapses to undefined so the
-  // resolver falls back cleanly to the host style preset.
-  let nextMcpAppsOverrides: McpAppsCapabilities | undefined = undefined;
-  if (isPlainObject(parsed.mcpAppsOverrides)) {
-    const incoming = parsed.mcpAppsOverrides as Record<string, unknown>;
-    const out: McpAppsCapabilities = {};
-    const booleanKeys: Array<keyof McpAppsCapabilities> = [
-      "toolInputPartial",
-      "toolCancelled",
-      "hostContextChanged",
-      "resourceTeardown",
-      "toolInfo",
-      "openLinks",
-      "serverTools",
-      "serverResources",
-      "logging",
-      "updateModelContext",
-      "message",
-      "sandboxPermissions",
-      "cspFrameDomains",
-      "cspBaseUriDomains",
-      "resourcePrefersBorder",
-    ];
-    for (const key of booleanKeys) {
-      const value = incoming[key];
-      if (typeof value === "boolean") {
-        (out as Record<string, unknown>)[key] = value;
-      }
-    }
-    const modes = incoming.availableDisplayModes;
-    if (Array.isArray(modes)) {
-      const filtered = modes.filter(
-        (m): m is "inline" | "fullscreen" | "pip" =>
-          m === "inline" || m === "fullscreen" || m === "pip",
-      );
-      // Soft-validate: only emit the array when at least one valid
-      // member survived. An empty filter result reads as "user typed
-      // garbage" — fall through to the preset rather than persisting an
-      // empty allowlist the resolver would have to coerce to ["inline"].
-      if (filtered.length > 0) out.availableDisplayModes = filtered;
-    }
-    if (Object.keys(out).length > 0) nextMcpAppsOverrides = out;
   }
 
   const appsBlock: NonNullable<HostConfigMcpProfileV1["apps"]> = {};

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -12,6 +12,7 @@ import {
   OPENAI_APPS_FULL_SURFACE,
 } from "@/lib/client-styles";
 import type {
+  McpAppsCapabilities,
   OpenAiAppsCapabilities,
   ResolvedOpenAiAppsCapabilities,
 } from "@/lib/client-styles";
@@ -151,6 +152,19 @@ type AppsDoc = {
     openaiApps?: boolean;
     openaiAppsOverrides?: OpenAiAppsCapabilities;
   };
+  /**
+   * Sparse SEP-1865 `app.*` spec-bridge per-dimension override. Sibling
+   * to `compatRuntime` — `compatRuntime` covers vendor compat shims
+   * (`window.openai`), this covers the primary protocol surface. The
+   * two matrices are independent (toggling one never affects the other).
+   *
+   * Round-trips with `mcpProfile.apps.mcpAppsOverrides`. Present here
+   * only when non-empty so absent in the JSON means "use the host
+   * style preset". Booleans / mode-array soft-validated on parse; the
+   * backend canonicalizer is strict, but the editor accepts hand-typed
+   * JSON that may be one rev behind.
+   */
+  mcpAppsOverrides?: McpAppsCapabilities;
 };
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
@@ -391,6 +405,19 @@ function appsToJson(draft: HostConfigInputV2): AppsDoc {
     if (Object.keys(compatOut).length > 0) doc.compatRuntime = compatOut;
   }
 
+  // mcpProfile.apps.mcpAppsOverrides — sparse override on the SEP-1865
+  // `app.*` spec-bridge matrix. Sibling to `compatRuntime` so the JSON
+  // reflects what's persisted; absent here means "use the host style
+  // preset". Surfaced only when non-empty (matches `openaiAppsOverrides`'
+  // sparsity convention).
+  const mcpAppsOverrides = draft.mcpProfile?.apps?.mcpAppsOverrides;
+  if (
+    mcpAppsOverrides !== undefined &&
+    Object.keys(mcpAppsOverrides).length > 0
+  ) {
+    doc.mcpAppsOverrides = { ...mcpAppsOverrides };
+  }
+
   return doc;
 }
 
@@ -607,6 +634,52 @@ export function applyJsonToDraft(
     }
   }
 
+  // mcpAppsOverrides — sparse spec-bridge override. Soft-validated per
+  // field (booleans for boolean rows; mode-array filtered to known
+  // members). Empty / fully-invalid input collapses to undefined so the
+  // resolver falls back cleanly to the host style preset.
+  let nextMcpAppsOverrides: McpAppsCapabilities | undefined = undefined;
+  if (isPlainObject(parsed.mcpAppsOverrides)) {
+    const incoming = parsed.mcpAppsOverrides as Record<string, unknown>;
+    const out: McpAppsCapabilities = {};
+    const booleanKeys: Array<keyof McpAppsCapabilities> = [
+      "toolInputPartial",
+      "toolCancelled",
+      "hostContextChanged",
+      "resourceTeardown",
+      "toolInfo",
+      "openLinks",
+      "serverTools",
+      "serverResources",
+      "logging",
+      "updateModelContext",
+      "message",
+      "sandboxPermissions",
+      "cspFrameDomains",
+      "cspBaseUriDomains",
+      "resourcePrefersBorder",
+    ];
+    for (const key of booleanKeys) {
+      const value = incoming[key];
+      if (typeof value === "boolean") {
+        (out as Record<string, unknown>)[key] = value;
+      }
+    }
+    const modes = incoming.availableDisplayModes;
+    if (Array.isArray(modes)) {
+      const filtered = modes.filter(
+        (m): m is "inline" | "fullscreen" | "pip" =>
+          m === "inline" || m === "fullscreen" || m === "pip",
+      );
+      // Soft-validate: only emit the array when at least one valid
+      // member survived. An empty filter result reads as "user typed
+      // garbage" — fall through to the preset rather than persisting an
+      // empty allowlist the resolver would have to coerce to ["inline"].
+      if (filtered.length > 0) out.availableDisplayModes = filtered;
+    }
+    if (Object.keys(out).length > 0) nextMcpAppsOverrides = out;
+  }
+
   const appsBlock: NonNullable<HostConfigMcpProfileV1["apps"]> = {};
   if (nextSandbox) appsBlock.sandbox = nextSandbox;
   if (newAppsHostInfo) {
@@ -614,6 +687,9 @@ export function applyJsonToDraft(
   }
   if (Object.keys(newCompatRuntime).length > 0) {
     appsBlock.compatRuntime = newCompatRuntime;
+  }
+  if (nextMcpAppsOverrides !== undefined) {
+    appsBlock.mcpAppsOverrides = nextMcpAppsOverrides;
   }
   const hasApps = Object.keys(appsBlock).length > 0;
 

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -487,30 +487,36 @@ export function applyJsonToDraft(
   }
 
   // hostCapabilities — the user sees the EFFECTIVE merged value, so on
-  // parse-back we diff against the MATRIX-RESOLVED shape (preset +
-  // mcpAppsOverrides) to decide whether to store a legacy override:
-  //   - absent in JSON → undefined legacy override
-  //   - equal to matrix-resolved shape → undefined legacy override
-  //     (the user is just looking at a faithful serialization of the
-  //     matrix; no extra opinion expressed)
-  //   - different from matrix-resolved shape → legacy override = parsed
-  //     value (the user typed a `hostCapabilities` value the matrix
-  //     can't produce — persist as legacy `hostCapabilitiesOverride`
-  //     so it survives the round-trip)
+  // parse-back we decide whether the parsed value is a legacy override
+  // or just a stale serialization of the matrix. A legacy
+  // `hostCapabilitiesOverride` is only persisted when the user typed
+  // something the matrix cannot produce.
+  //
+  // We compare `parsed.hostCapabilities` against BOTH:
+  //   1. `matrixResolvedNext` — the wire shape the matrix WILL produce
+  //      after this save (preset + post-parse `mcpAppsOverrides`).
+  //   2. `matrixResolvedPrev` — the wire shape the matrix WAS
+  //      producing before this save (prev's `mcpAppsOverrides`).
+  //
+  // Match either → undefined legacy override:
+  //   - Matches (1): user is looking at a faithful serialization of
+  //     the matrix they're saving. No extra opinion expressed.
+  //   - Matches (2): user removed/changed `mcpAppsOverrides` but the
+  //     JSON's `hostCapabilities` still shows the pre-change matrix
+  //     shape — that's a stale artifact of `appsToJson` re-emitting
+  //     effective caps on every render, NOT a deliberate legacy
+  //     override. Removing only `mcpAppsOverrides` must actually revert
+  //     to preset; persisting the stale shape would keep the override
+  //     behavior alive through the legacy path.
+  //
+  // Match neither → the user typed something the matrix can't produce;
+  // persist as legacy `hostCapabilitiesOverride` so it survives the
+  // round-trip.
+  //
   // Sandbox is its own top-level block now; if a `sandbox` key sneaks
   // into hostCapabilities (paste from an older export, hand-edit),
   // strip it so it doesn't pollute the override diff.
-  //
-  // Why diff against the matrix-resolved shape, not the preset alone:
-  // when `mcpAppsOverrides` makes the matrix produce a non-preset wire
-  // shape (e.g. Claude with serverResources turned off), `appsToJson`
-  // serializes that non-preset shape into `hostCapabilities`. Diffing
-  // against the preset alone would falsely flag every such round-trip
-  // as a legacy override, creating a stale `hostCapabilitiesOverride`
-  // beside the matrix. Removing `mcpAppsOverrides` later would then
-  // appear to "do nothing" because the stale legacy keeps the same
-  // shape alive.
-  const matrixResolvedHostCapabilities = resolveEffectiveHostCapabilities({
+  const matrixResolvedNext = resolveEffectiveHostCapabilities({
     hostStyle: prev.hostStyle,
     profile:
       nextMcpAppsOverrides !== undefined
@@ -521,13 +527,19 @@ export function applyJsonToDraft(
         : undefined,
     hostCapabilitiesOverride: undefined,
   }) as Record<string, unknown>;
+  const matrixResolvedPrev = resolveEffectiveHostCapabilities({
+    hostStyle: prev.hostStyle,
+    profile: prev.mcpProfile,
+    hostCapabilitiesOverride: undefined,
+  }) as Record<string, unknown>;
   let nextOverride: Record<string, unknown> | undefined = undefined;
   if ("hostCapabilities" in parsed) {
     if (isPlainObject(parsed.hostCapabilities)) {
       const { sandbox: _ignored, ...incoming } = parsed.hostCapabilities;
+      const incomingStr = stableStringifyJson(incoming);
       if (
-        stableStringifyJson(incoming) ===
-        stableStringifyJson(matrixResolvedHostCapabilities)
+        incomingStr === stableStringifyJson(matrixResolvedNext) ||
+        incomingStr === stableStringifyJson(matrixResolvedPrev)
       ) {
         nextOverride = undefined;
       } else {

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
@@ -436,6 +436,100 @@ describe("AppsExtensionTab — mcpAppsOverrides JSON round-trip", () => {
     expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
   });
 
+  it("serialize/parse round-trip with mcpAppsOverrides does NOT create a stale legacy hostCapabilitiesOverride", () => {
+    // Regression: the diff target for `hostCapabilities` was the
+    // preset alone, so any matrix override that produced a non-preset
+    // wire shape (e.g. Claude with serverResources turned off) would
+    // round-trip into a stale legacy `hostCapabilitiesOverride` —
+    // every editor save would silently create one beside the matrix.
+    // The fix diffs against the matrix-resolved shape instead, so a
+    // faithful serialization round-trips with no legacy override.
+    const prev = emptyHostConfigInputV2({ hostStyle: "claude" });
+    prev.mcpProfile = {
+      profileVersion: 1,
+      apps: { mcpAppsOverrides: { serverResources: false, logging: false } },
+    };
+    // What the editor would actually show on serialize: the matrix-
+    // derived effective hostCapabilities + the matrix override.
+    const effectiveHostCapabilities = resolveEffectiveHostCapabilities({
+      hostStyle: "claude",
+      profile: prev.mcpProfile,
+    });
+    const next = applyJsonToDraft(
+      {
+        hostContext: {},
+        hostCapabilities: effectiveHostCapabilities,
+        mcpAppsOverrides: { serverResources: false, logging: false },
+      },
+      prev,
+    );
+    // Matrix preserved; legacy override NOT created.
+    expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toEqual({
+      serverResources: false,
+      logging: false,
+    });
+    expect(next?.hostCapabilitiesOverride).toBeUndefined();
+  });
+
+  it("removing mcpAppsOverrides from JSON actually reverts the resolver to the host style preset", () => {
+    // Regression: when the user removes `mcpAppsOverrides`, the
+    // resolver should fall back to the preset. The pre-fix parser
+    // would create a stale legacy `hostCapabilitiesOverride` from
+    // the serialized matrix-derived `hostCapabilities`, keeping the
+    // same capability behavior alive even though the matrix was
+    // cleared.
+    const prev = emptyHostConfigInputV2({ hostStyle: "claude" });
+    prev.mcpProfile = {
+      profileVersion: 1,
+      apps: { mcpAppsOverrides: { serverResources: false, logging: false } },
+    };
+    // User edits the JSON: removes `mcpAppsOverrides`, but the
+    // `hostCapabilities` field in the JSON might still be the
+    // pre-removal matrix-derived shape (the editor serializer would
+    // refresh it on next render, but parse needs to handle this
+    // intermediate state correctly).
+    const stalehostCapabilities = resolveEffectiveHostCapabilities({
+      hostStyle: "claude",
+      profile: prev.mcpProfile,
+    });
+    const next = applyJsonToDraft(
+      {
+        hostContext: {},
+        hostCapabilities: stalehostCapabilities,
+        // mcpAppsOverrides removed
+      },
+      prev,
+    );
+    // Matrix cleared. The stale hostCapabilities serialization
+    // becomes a legacy override (the matrix can no longer produce
+    // it, so the user must have meant the literal value) — but
+    // that's a separate explicit choice the user is making by
+    // leaving the JSON in that state.
+    expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
+    // The KEY regression test: if the user removes BOTH
+    // `mcpAppsOverrides` AND clears `hostCapabilities` back to the
+    // preset shape, the resolver fully reverts.
+    const presetEffective = resolveEffectiveHostCapabilities({
+      hostStyle: "claude",
+    });
+    const fullyCleared = applyJsonToDraft(
+      {
+        hostContext: {},
+        hostCapabilities: presetEffective,
+      },
+      prev,
+    );
+    expect(fullyCleared?.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
+    expect(fullyCleared?.hostCapabilitiesOverride).toBeUndefined();
+    // Confirm the resolver advertises the bare preset.
+    const advertised = resolveEffectiveHostCapabilities({
+      hostStyle: fullyCleared!.hostStyle,
+      profile: fullyCleared!.mcpProfile,
+      hostCapabilitiesOverride: fullyCleared!.hostCapabilitiesOverride,
+    });
+    expect(advertised).toEqual(presetEffective);
+  });
+
   it("preserves siblings (compatRuntime, sandbox, uiInitialize) when only mcpAppsOverrides changes", () => {
     // Sibling fields under `mcpProfile.apps` round-trip through their own
     // serializers; touching mcpAppsOverrides must not collateral-damage

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
@@ -365,3 +365,108 @@ describe("AppsExtensionTab — sandbox JSON round-trip", () => {
     );
   });
 });
+
+describe("AppsExtensionTab — mcpAppsOverrides JSON round-trip", () => {
+  it("parses a sparse mcpAppsOverrides block into mcpProfile.apps.mcpAppsOverrides", () => {
+    const next = applyJsonToDraft(
+      {
+        hostContext: {},
+        mcpAppsOverrides: {
+          serverResources: false,
+          logging: false,
+          availableDisplayModes: ["fullscreen"],
+        },
+      },
+      emptyHostConfigInputV2(),
+    );
+    expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toEqual({
+      serverResources: false,
+      logging: false,
+      availableDisplayModes: ["fullscreen"],
+    });
+  });
+
+  it("drops non-boolean / non-mode-string entries silently (soft validation)", () => {
+    // Hand-typed JSON might be one rev behind the schema; tolerate stray
+    // fields rather than crashing the editor on parse.
+    const next = applyJsonToDraft(
+      {
+        hostContext: {},
+        mcpAppsOverrides: {
+          serverResources: false,
+          totallyBogus: "ignored",
+          availableDisplayModes: ["inline", "weirdmode", "pip"],
+        },
+      },
+      emptyHostConfigInputV2(),
+    );
+    expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toEqual({
+      serverResources: false,
+      availableDisplayModes: ["inline", "pip"],
+    });
+  });
+
+  it("collapses an entirely-invalid block to undefined (falls back to preset)", () => {
+    // Nothing salvageable → no override persisted → the resolver uses
+    // the host style preset on the next read.
+    const next = applyJsonToDraft(
+      {
+        hostContext: {},
+        mcpAppsOverrides: {
+          totallyBogus: "ignored",
+          availableDisplayModes: ["weirdmode"],
+        },
+      },
+      emptyHostConfigInputV2(),
+    );
+    expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
+  });
+
+  it("clears mcpAppsOverrides when the key is absent from the parsed JSON", () => {
+    // User edits the JSON to remove the entire mcpAppsOverrides block →
+    // the override clears so the resolver falls back to the preset.
+    const prev = emptyHostConfigInputV2();
+    prev.mcpProfile = {
+      profileVersion: 1,
+      apps: {
+        mcpAppsOverrides: { serverResources: false },
+      },
+    };
+    const next = applyJsonToDraft({ hostContext: {} }, prev);
+    expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
+  });
+
+  it("preserves siblings (compatRuntime, sandbox, uiInitialize) when only mcpAppsOverrides changes", () => {
+    // Sibling fields under `mcpProfile.apps` round-trip through their own
+    // serializers; touching mcpAppsOverrides must not collateral-damage
+    // the other apps subsections.
+    const prev = emptyHostConfigInputV2();
+    prev.mcpProfile = {
+      profileVersion: 1,
+      apps: {
+        sandbox: {
+          permissions: { mode: "deny-all" },
+        },
+        compatRuntime: { openaiApps: false },
+        uiInitialize: { hostInfo: { name: "fakehost", version: "1.0" } },
+      },
+    };
+    const next = applyJsonToDraft(
+      {
+        hostContext: {},
+        compatRuntime: { openaiApps: false },
+        uiInitialize: { hostInfo: { name: "fakehost", version: "1.0" } },
+        mcpAppsOverrides: { logging: false },
+      },
+      prev,
+    );
+    expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toEqual({
+      logging: false,
+    });
+    expect(next?.mcpProfile?.apps?.compatRuntime?.openaiApps).toBe(false);
+    expect(next?.mcpProfile?.apps?.uiInitialize?.hostInfo).toEqual({
+      name: "fakehost",
+      version: "1.0",
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts
@@ -471,23 +471,30 @@ describe("AppsExtensionTab — mcpAppsOverrides JSON round-trip", () => {
     expect(next?.hostCapabilitiesOverride).toBeUndefined();
   });
 
-  it("removing mcpAppsOverrides from JSON actually reverts the resolver to the host style preset", () => {
-    // Regression: when the user removes `mcpAppsOverrides`, the
-    // resolver should fall back to the preset. The pre-fix parser
-    // would create a stale legacy `hostCapabilitiesOverride` from
-    // the serialized matrix-derived `hostCapabilities`, keeping the
-    // same capability behavior alive even though the matrix was
-    // cleared.
+  it("removing only mcpAppsOverrides from JSON fully reverts to host style preset (stale hostCapabilities does NOT become a legacy override)", () => {
+    // Regression (caught by codex review): when the user removes
+    // `mcpAppsOverrides`, `appsToJson` may still be showing the
+    // pre-removal matrix-derived `hostCapabilities` (the editor
+    // serializer refreshes on next render, but the parse round-trip
+    // sees the intermediate state). The pre-fix parser diffed only
+    // against the post-parse matrix-resolved shape, so the stale
+    // serialization would silently persist as a legacy
+    // `hostCapabilitiesOverride` — keeping the override behavior
+    // alive through the legacy path even though the matrix was
+    // cleared. Removing the matrix has to actually disable the
+    // override.
+    //
+    // Fix: also diff against the PRE-parse matrix-resolved shape so
+    // stale `hostCapabilities` is recognized as a serialization
+    // artifact, not a deliberate legacy override.
     const prev = emptyHostConfigInputV2({ hostStyle: "claude" });
     prev.mcpProfile = {
       profileVersion: 1,
       apps: { mcpAppsOverrides: { serverResources: false, logging: false } },
     };
-    // User edits the JSON: removes `mcpAppsOverrides`, but the
-    // `hostCapabilities` field in the JSON might still be the
-    // pre-removal matrix-derived shape (the editor serializer would
-    // refresh it on next render, but parse needs to handle this
-    // intermediate state correctly).
+    // Stale `hostCapabilities` field reflects what `appsToJson` was
+    // emitting before the user deleted `mcpAppsOverrides` from the
+    // JSON. The save fires against this intermediate state.
     const stalehostCapabilities = resolveEffectiveHostCapabilities({
       hostStyle: "claude",
       profile: prev.mcpProfile,
@@ -496,38 +503,43 @@ describe("AppsExtensionTab — mcpAppsOverrides JSON round-trip", () => {
       {
         hostContext: {},
         hostCapabilities: stalehostCapabilities,
-        // mcpAppsOverrides removed
+        // mcpAppsOverrides removed — the only deliberate user action
       },
       prev,
     );
-    // Matrix cleared. The stale hostCapabilities serialization
-    // becomes a legacy override (the matrix can no longer produce
-    // it, so the user must have meant the literal value) — but
-    // that's a separate explicit choice the user is making by
-    // leaving the JSON in that state.
+    // Matrix cleared.
     expect(next?.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
-    // The KEY regression test: if the user removes BOTH
-    // `mcpAppsOverrides` AND clears `hostCapabilities` back to the
-    // preset shape, the resolver fully reverts.
+    // No stale legacy override. The user removed the matrix; the
+    // resolver MUST advertise the bare host style preset on the next
+    // read, not silently continue the override via the legacy path.
+    expect(next?.hostCapabilitiesOverride).toBeUndefined();
     const presetEffective = resolveEffectiveHostCapabilities({
       hostStyle: "claude",
     });
-    const fullyCleared = applyJsonToDraft(
+    const advertised = resolveEffectiveHostCapabilities({
+      hostStyle: next!.hostStyle,
+      profile: next!.mcpProfile,
+      hostCapabilitiesOverride: next!.hostCapabilitiesOverride,
+    });
+    expect(advertised).toEqual(presetEffective);
+  });
+
+  it("typing a hostCapabilities value the matrix can't produce still persists as a legacy override", () => {
+    // Counter-test for the regression above: when the user types
+    // something genuinely distinct (not the prev matrix shape, not
+    // the post-parse matrix shape, not the preset), the legacy
+    // `hostCapabilitiesOverride` path still works. The matrix-stale-
+    // serialization detection must not over-clear deliberate input.
+    const prev = emptyHostConfigInputV2({ hostStyle: "claude" });
+    const deliberate = { openLinks: {} }; // strictly less than Claude's preset
+    const next = applyJsonToDraft(
       {
         hostContext: {},
-        hostCapabilities: presetEffective,
+        hostCapabilities: deliberate,
       },
       prev,
     );
-    expect(fullyCleared?.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
-    expect(fullyCleared?.hostCapabilitiesOverride).toBeUndefined();
-    // Confirm the resolver advertises the bare preset.
-    const advertised = resolveEffectiveHostCapabilities({
-      hostStyle: fullyCleared!.hostStyle,
-      profile: fullyCleared!.mcpProfile,
-      hostCapabilitiesOverride: fullyCleared!.hostCapabilitiesOverride,
-    });
-    expect(advertised).toEqual(presetEffective);
+    expect(next?.hostCapabilitiesOverride).toEqual(deliberate);
   });
 
   it("preserves siblings (compatRuntime, sandbox, uiInitialize) when only mcpAppsOverrides changes", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/client-config-v2.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/client-config-v2.test.ts
@@ -481,7 +481,11 @@ describe("hostCapabilitiesOverrideToMatrix", () => {
 // presets/FULL_SURFACE constant without coupling these tests to a
 // specific import path that might shift around during the migration.
 const MCP_APPS_FULL_SURFACE_FOR_TEST = {
-  availableDisplayModes: ["inline", "fullscreen", "pip"] as const,
+  availableDisplayModes: ["inline", "fullscreen", "pip"] as (
+    | "inline"
+    | "fullscreen"
+    | "pip"
+  )[],
   toolInputPartial: true,
   toolCancelled: true,
   hostContextChanged: true,


### PR DESCRIPTION
## Summary

Plumbs `mcpAppsOverrides` through the Apps tab's JSON editor. Before this PR, typing `mcpAppsOverrides` into the editor silently dropped on save (no matching key in `AppsDoc`); after, it round-trips to `mcpProfile.apps.mcpAppsOverrides` and the resolver actually uses it (per #2226).

This is the serialization layer the (still-to-come) structured matrix UI will hook into. Until then, advanced users can configure the MCP Apps capability override by hand-editing JSON.

## What changes for users

Typing this in the Apps tab editor now actually persists:

```jsonc
{
  "hostContext": { ... },
  "mcpAppsOverrides": {
    "serverResources": false,
    "logging": false,
    "availableDisplayModes": ["fullscreen"]
  }
}
```

On the next read, `app.getHostCapabilities()` from a widget will reflect the override — `serverResources` and `logging` will be absent. Combine with the `copilot` host preset to simulate the M365-published subset exactly.

## Inspector changes

- **`AppsDoc` type**: new `mcpAppsOverrides?: McpAppsCapabilities` field. Sibling to `compatRuntime` (the two cover different surfaces: spec bridge vs vendor shim, per the two-matrix architecture established in #2226).
- **`appsToJson` serializer**: surfaces `mcpAppsOverrides` only when non-empty, matching `compatRuntime.openaiAppsOverrides`' sparsity convention. Absent in JSON means "use the host style preset."
- **`applyJsonToDraft` parser**: soft-validates each field — boolean rows require booleans, `availableDisplayModes` filters to known modes (`inline` / `fullscreen` / `pip`). Entirely-invalid blocks collapse to `undefined` so the resolver falls back cleanly to the host style preset. Hand-typed JSON one rev behind the schema doesn't crash the editor.

## Tests

- **5 new cases** in `AppsExtensionTab.sandbox.test.ts`:
  1. Parses a sparse `mcpAppsOverrides` block into `mcpProfile.apps.mcpAppsOverrides`
  2. Drops non-boolean / non-mode-string entries silently
  3. Collapses entirely-invalid block to `undefined`
  4. Clears `mcpAppsOverrides` when the key is absent from parsed JSON
  5. Preserves siblings (`compatRuntime`, `sandbox`, `uiInitialize`) when only `mcpAppsOverrides` changes
- **659/659 client tests pass** (broader suite: lib + client-styles + mcp-apps renderer + clients/redesigned).

## Test plan

- [x] `npx vitest run client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.sandbox.test.ts` — 21/21 pass (5 new)
- [x] `npx vitest run client/src/lib/__tests__/ client/src/lib/client-styles/__tests__/ client/src/components/chat-v2/thread/mcp-apps/__tests__/ client/src/components/clients/redesigned/` — 659/659 pass
- [x] `npx tsc -p client/tsconfig.json --noEmit` — no new errors in changed files
- [ ] Manual: open the Apps tab on the `copilot` host; paste the override block from the Summary above; save; reopen — confirm the JSON survives the round-trip. Load a widget; probe `app.getHostCapabilities()`; confirm `serverResources` / `logging` are absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how host capability overrides are parsed/persisted and adjusts the legacy `hostCapabilitiesOverride` diffing logic, which could affect what capabilities are advertised if edge cases are missed.
> 
> **Overview**
> Enables the Apps tab JSON editor to **serialize and persist** `mcpAppsOverrides` to `mcpProfile.apps.mcpAppsOverrides` (sparse emission when non-empty), so hand-edited SEP-1865 `app.*` matrix overrides no longer get dropped.
> 
> Updates JSON parsing to **soft-validate** `mcpAppsOverrides` (booleans only, `availableDisplayModes` filtered to `inline`/`fullscreen`/`pip`) and to avoid creating **stale legacy `hostCapabilitiesOverride`** by diffing `hostCapabilities` against the matrix-resolved shapes (prev and next) before persisting a legacy override. Adds targeted tests covering round-trip, clearing behavior, validation, sibling preservation, and the stale-override regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cbc43612db292a2cfc6ef114fd534704d835ac5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->