### PR TITLE
Fix BYOK chat auth routing

### DIFF
--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
@@ -290,7 +290,8 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
         },
       })
     );
@@ -302,7 +303,8 @@ describe("useChatSession hosted mode", () => {
       chatSessionId: "chat-session-id",
       selectedServerIds: ["server-id-1"],
       selectedServerNames: ["server-1"],
-      chatboxId: "cbx_test", accessVersion: 1,
+      chatboxId: "cbx_test",
+      accessVersion: 1,
       accessScope: "chat_v2",
     });
     unmount();
@@ -315,7 +317,8 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
           oauthTokens: {
             "server-id-1": "browser-token",
           },
@@ -330,7 +333,8 @@ describe("useChatSession hosted mode", () => {
       chatSessionId: "chat-session-id",
       selectedServerIds: ["server-id-1"],
       selectedServerNames: ["server-1"],
-      chatboxId: "cbx_test", accessVersion: 1,
+      chatboxId: "cbx_test",
+      accessVersion: 1,
       accessScope: "chat_v2",
     });
     expect(body).not.toHaveProperty("oauthTokens");
@@ -344,7 +348,8 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
           chatboxSurface: "preview",
         },
       })
@@ -352,7 +357,8 @@ describe("useChatSession hosted mode", () => {
 
     const body = lastTransportOptions.body();
     expect(body).toMatchObject({
-      chatboxId: "cbx_test", accessVersion: 1,
+      chatboxId: "cbx_test",
+      accessVersion: 1,
       surface: "preview",
     });
     unmount();
@@ -377,16 +383,17 @@ describe("useChatSession hosted mode", () => {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
         },
-      }),
+      })
     );
 
     await waitFor(() => {
       expect(result.current.availableModels.map((model) => model.id)).toContain(
-        "gpt-4o-mini",
+        "gpt-4o-mini"
       );
     });
     expect(result.current.selectedModel.id).toBe("gpt-4o-mini");
     expect(result.current.isMcpJamModel).toBe(false);
+    expect(result.current.traceViewsSupported).toBe(true);
     unmount();
   });
 
@@ -417,7 +424,8 @@ describe("useChatSession hosted mode", () => {
           hostedContext: {
             projectId: "project-1",
             selectedServerIds: ["server-id-1"],
-            chatboxId: "cbx_1", accessVersion: 1,
+            chatboxId: "cbx_1",
+            accessVersion: 1,
           },
         },
       }
@@ -436,7 +444,8 @@ describe("useChatSession hosted mode", () => {
       hostedContext: {
         projectId: "project-2",
         selectedServerIds: ["server-id-2"],
-        chatboxId: "cbx_2", accessVersion: 1,
+        chatboxId: "cbx_2",
+        accessVersion: 1,
       },
     });
 
@@ -669,7 +678,8 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
         },
       })
     );
@@ -739,7 +749,8 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
         },
       })
     );
@@ -761,7 +772,8 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
         },
       })
     );
@@ -936,8 +948,7 @@ describe("useChatSession hosted mode", () => {
     });
 
     await waitFor(() => {
-      const mcp =
-        result.current.restoredToolRenderOverrides["tool-call-mcp"];
+      const mcp = result.current.restoredToolRenderOverrides["tool-call-mcp"];
       const openai =
         result.current.restoredToolRenderOverrides["tool-call-openai"];
       expect(mcp).toBeDefined();
@@ -968,7 +979,8 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
         },
       })
     );

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
@@ -102,7 +102,7 @@ vi.mock("@/components/chat-v2/shared/model-helpers", () => ({
         (provider: any) =>
           provider.providerKey === "anthropic" &&
           provider.enabled &&
-          provider.hasSecret,
+          provider.hasSecret
       )
     ) {
       return [mcpJamModel, orgAnthropicModel];
@@ -227,7 +227,7 @@ vi.mock("@ai-sdk/react", async () => {
           setMessages: mockSetMessages,
           addToolApprovalResponse: mockAddToolApprovalResponse,
         };
-      },
+      }
     ),
   };
 });
@@ -307,7 +307,7 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "You are a helpful assistant.",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -315,7 +315,7 @@ describe("useChatSession minimal mode parity", () => {
     });
     expect(mockGetToolsMetadata).toHaveBeenCalledWith(
       ["server-1"],
-      "openai/gpt-4",
+      "openai/gpt-4"
     );
   });
 
@@ -328,13 +328,13 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "Custom prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
       expect(mockCountTextTokens).toHaveBeenCalledWith(
         "Custom prompt",
-        "openai/gpt-4",
+        "openai/gpt-4"
       );
     });
   });
@@ -350,7 +350,7 @@ describe("useChatSession minimal mode parity", () => {
           temperature: 0.7,
           requireToolApproval: false,
         },
-      }),
+      })
     );
 
     expect(result.current.systemPrompt).toBe(DEFAULT_SYSTEM_PROMPT);
@@ -358,7 +358,7 @@ describe("useChatSession minimal mode parity", () => {
     await waitFor(() => {
       expect(mockCountTextTokens).toHaveBeenCalledWith(
         DEFAULT_SYSTEM_PROMPT,
-        "openai/gpt-4",
+        "openai/gpt-4"
       );
     });
 
@@ -370,7 +370,7 @@ describe("useChatSession minimal mode parity", () => {
       expect(getTransportRequests()).toContainEqual(
         expect.objectContaining({
           systemPrompt: DEFAULT_SYSTEM_PROMPT,
-        }),
+        })
       );
     });
   });
@@ -388,12 +388,13 @@ describe("useChatSession minimal mode parity", () => {
         selectedServers,
         minimalMode: true,
         hostedContext: {
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
         },
         executionConfig: {
           systemPrompt: "Prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -419,7 +420,7 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "Prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -440,8 +441,8 @@ describe("useChatSession minimal mode parity", () => {
     await waitFor(() => {
       expect(
         mockTransportInstances.some(
-          (instance) => instance.sendMessages.mock.calls.length === 1,
-        ),
+          (instance) => instance.sendMessages.mock.calls.length === 1
+        )
       ).toBe(true);
     });
     expect(getUsedTransport().options.api).toBe("/api/mcp/chat-v2");
@@ -450,7 +451,7 @@ describe("useChatSession minimal mode parity", () => {
       expect.objectContaining({
         method: "POST",
         headers: { Authorization: "Bearer guest-token" },
-      }),
+      })
     );
     expect(mockAuthFetch).not.toHaveBeenCalled();
   });
@@ -470,8 +471,8 @@ describe("useChatSession minimal mode parity", () => {
         {
           status: 429,
           headers: { "Content-Type": "application/json" },
-        },
-      ),
+        }
+      )
     );
 
     const { result } = renderHook(() =>
@@ -481,7 +482,7 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "Prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -506,7 +507,7 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "Prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -516,8 +517,8 @@ describe("useChatSession minimal mode parity", () => {
     act(() => {
       mockUseChatErrorHandlers.at(-1)?.(
         new Error(
-          "Daily MCPJam model limit reached. Use BYOK or try again tomorrow.",
-        ),
+          "Daily MCPJam model limit reached. Use BYOK or try again tomorrow."
+        )
       );
     });
 
@@ -543,8 +544,8 @@ describe("useChatSession minimal mode parity", () => {
         {
           status: 429,
           headers: { "Content-Type": "application/json" },
-        },
-      ),
+        }
+      )
     );
 
     const { result } = renderHook(() =>
@@ -554,7 +555,7 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "Prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -590,8 +591,8 @@ describe("useChatSession minimal mode parity", () => {
         {
           status: 429,
           headers: { "Content-Type": "application/json" },
-        },
-      ),
+        }
+      )
     );
 
     const { result } = renderHook(() =>
@@ -601,7 +602,7 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "Prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -639,7 +640,7 @@ describe("useChatSession minimal mode parity", () => {
         executionConfig: {
           systemPrompt: "Prompt",
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -660,25 +661,25 @@ describe("useChatSession minimal mode parity", () => {
     ]);
     expect(
       result.current.availableModels.find((model) => model.id === "gpt-4")
-        ?.disabled,
+        ?.disabled
     ).toBeUndefined();
     expect(
       result.current.availableModels.find(
-        (model) => model.id === "openai/gpt-5.4-pro",
-      ),
+        (model) => model.id === "openai/gpt-5.4-pro"
+      )
     ).toMatchObject({
       disabled: true,
       disabledReason: "Sign in to use MCPJam provided models",
     });
     expect(
       result.current.availableModels.find(
-        (model) => model.id === "openai/gpt-5-mini",
-      )?.disabled,
+        (model) => model.id === "openai/gpt-5-mini"
+      )?.disabled
     ).toBeUndefined();
     expect(
       result.current.availableModels.find(
-        (model) => model.id === "anthropic/claude-haiku-4.5",
-      )?.disabled,
+        (model) => model.id === "anthropic/claude-haiku-4.5"
+      )?.disabled
     ).toBeUndefined();
     expect(result.current.selectedModel.id).toBe("openai/gpt-5-mini");
     expect(mockAuthFetch).not.toHaveBeenCalled();
@@ -704,7 +705,7 @@ describe("useChatSession minimal mode parity", () => {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -731,13 +732,63 @@ describe("useChatSession minimal mode parity", () => {
       accessScope: "chat_v2",
     });
     expect(transport.requests[0]).not.toHaveProperty("apiKey");
-    expect(mockWindowFetch).toHaveBeenCalledWith(
+    expect(mockAuthFetch).toHaveBeenCalledWith(
       "/api/web/chat-v2",
       expect.objectContaining({
         headers: { Authorization: "Bearer guest-token" },
-      }),
+      })
     );
-    expect(mockAuthFetch).not.toHaveBeenCalled();
+    expect(mockWindowFetch).not.toHaveBeenCalledWith(
+      "/api/web/chat-v2",
+      expect.anything()
+    );
+  });
+
+  it("keeps project-scoped BYOK on the authenticated web route even before org config is loaded", async () => {
+    const projectScopedByokModelId = "claude-sonnet-4-5";
+    mockModelState.availableModels = [mcpJamModel];
+    mockGetToken.mockReturnValue("");
+
+    const { result } = renderHook(() =>
+      useChatSession({
+        selectedServers: ["server-1"],
+        hostedContext: {
+          projectId: "project-1",
+          selectedServerIds: ["server-id-1"],
+        },
+        executionConfig: {
+          modelId: projectScopedByokModelId,
+        },
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.isAuthReady).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.sendMessage({ text: "hello" });
+    });
+
+    const transport = getUsedTransport();
+    expect(transport.options.api).toBe("/api/web/chat-v2");
+    expect(transport.requests[0]).toMatchObject({
+      model: expect.objectContaining({
+        id: projectScopedByokModelId,
+        provider: "anthropic",
+      }),
+      projectId: "project-1",
+      selectedServerIds: ["server-id-1"],
+      selectedServerNames: ["server-1"],
+      accessScope: "chat_v2",
+    });
+    expect(transport.requests[0]).not.toHaveProperty("apiKey");
+    expect(mockAuthFetch).toHaveBeenCalledWith(
+      "/api/web/chat-v2",
+      expect.objectContaining({
+        headers: { Authorization: "Bearer guest-token" },
+      })
+    );
   });
 
   it("falls back to local provider keys when non-hosted org config is empty", async () => {
@@ -753,7 +804,7 @@ describe("useChatSession minimal mode parity", () => {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -793,7 +844,7 @@ describe("useChatSession minimal mode parity", () => {
           systemPrompt: "Prompt",
           modelId: gatedMcpJamModel.id,
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -827,7 +878,7 @@ describe("useChatSession minimal mode parity", () => {
           systemPrompt: "Prompt",
           modelId: gatedMcpJamModel.id,
         },
-      }),
+      })
     );
 
     await waitFor(() => {
@@ -836,7 +887,7 @@ describe("useChatSession minimal mode parity", () => {
 
     expect(result.current.selectedModel).toMatchObject({
       id: "openai/gpt-5.4-pro",
-      name: "openai/gpt-5.4-pro",
+      name: "GPT-5.4 Pro (Free)",
       provider: "openai",
       disabled: true,
       disabledReason: "Sign in to use MCPJam provided models",
@@ -859,7 +910,7 @@ describe("useChatSession minimal mode parity", () => {
         initialProps: {
           selectedServers: ["server-1"],
         },
-      },
+      }
     );
 
     await waitFor(() => {

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -32,6 +32,7 @@ import {
 import { useAuth } from "@workos-inc/authkit-react";
 import { useConvexAuth } from "convex/react";
 import {
+  getModelById,
   ModelDefinition,
   type ModelProvider,
 } from "@/shared/types";
@@ -395,10 +396,12 @@ function inferModelProviderFromId(modelId: string): ModelProvider {
 }
 
 function createLockedInitialModel(modelId: string): ModelDefinition {
+  const knownModel = getModelById(modelId);
   return {
+    ...knownModel,
     id: modelId,
-    name: modelId,
-    provider: inferModelProviderFromId(modelId),
+    name: knownModel?.name ?? modelId,
+    provider: knownModel?.provider ?? inferModelProviderFromId(modelId),
     disabled: true,
     disabledReason: GUEST_LOCKED_MODEL_REASON,
   };
@@ -1036,6 +1039,27 @@ function isAuthDeniedError(error: unknown): boolean {
   return /\b(401|403)\b|unauthorized|forbidden/i.test(withStatus.message);
 }
 
+function getRequestPathname(input: RequestInfo | URL): string {
+  const rawUrl =
+    input instanceof URL
+      ? input.toString()
+      : typeof Request !== "undefined" && input instanceof Request
+      ? input.url
+      : String(input);
+  const baseOrigin =
+    typeof window !== "undefined" ? window.location.origin : "http://localhost";
+
+  try {
+    return new URL(rawUrl, baseOrigin).pathname;
+  } catch {
+    return rawUrl.split("?")[0] ?? rawUrl;
+  }
+}
+
+function shouldUseAuthenticatedChatFetch(input: RequestInfo | URL): boolean {
+  return HOSTED_MODE || getRequestPathname(input).startsWith("/api/web/");
+}
+
 export function useChatSession(
   options: UseChatSessionOptions
 ): UseChatSessionReturn {
@@ -1323,15 +1347,37 @@ export function useChatSession(
       ? isMCPJamProvidedModel(String(selectedModel.id))
       : false;
   }, [selectedModel]);
+  const selectedModelLocalApiKey = useMemo(() => {
+    if (
+      selectedModel.provider === "custom" &&
+      selectedModel.customProviderName
+    ) {
+      return (
+        getCustomProviderByName(selectedModel.customProviderName)?.apiKey || ""
+      );
+    }
+    return getToken(selectedModel.provider as keyof ProviderTokens);
+  }, [getCustomProviderByName, getToken, selectedModel]);
   const selectedModelUsesOrgRuntime = useMemo(
     () => isOrgManagedModel(hostedOrgModelConfig, selectedModel),
     [hostedOrgModelConfig, selectedModel]
   );
-  const traceViewsSupported = HOSTED_MODE ? isMcpJamModel : true;
+  const selectedModelCanUseProjectOrgRuntime =
+    Boolean(hostedProjectId) && !isMcpJamModel && !selectedModelLocalApiKey;
+  const shouldUseOrgAwareChatApi =
+    HOSTED_MODE ||
+    selectedModelUsesOrgRuntime ||
+    selectedModelCanUseProjectOrgRuntime;
+  const traceViewsSupported = HOSTED_MODE
+    ? isMcpJamModel ||
+      selectedModelUsesOrgRuntime ||
+      selectedModelCanUseProjectOrgRuntime
+    : true;
 
   const chatFetch = useCallback(
     async (input: RequestInfo | URL, init?: RequestInit) => {
-      const response = HOSTED_MODE
+      const useAuthFetch = shouldUseAuthenticatedChatFetch(input);
+      const response = useAuthFetch
         ? await authFetch(input, init)
         : await fetch(input, init);
       if (!response.ok) {
@@ -1369,19 +1415,7 @@ export function useChatSession(
 
   // Create transport
   const transport = useMemo(() => {
-    const shouldUseOrgAwareChatApi =
-      HOSTED_MODE || selectedModelUsesOrgRuntime;
-    let apiKey: string;
-    if (
-      selectedModel.provider === "custom" &&
-      selectedModel.customProviderName
-    ) {
-      // For custom providers, the API key is embedded in the provider config
-      const cp = getCustomProviderByName(selectedModel.customProviderName);
-      apiKey = cp?.apiKey || "";
-    } else {
-      apiKey = getToken(selectedModel.provider as keyof ProviderTokens);
-    }
+    const apiKey = selectedModelLocalApiKey;
 
     // Merge session auth headers with workos auth headers
     const sessionHeaders = getSessionAuthHeaders();
@@ -1502,11 +1536,10 @@ export function useChatSession(
     });
   }, [
     selectedModel,
-    getToken,
-    getCustomProviderByName,
+    selectedModelLocalApiKey,
     customProviders,
     authHeaders,
-    selectedModelUsesOrgRuntime,
+    shouldUseOrgAwareChatApi,
     temperature,
     systemPrompt,
     selectedServers,
@@ -2306,7 +2339,7 @@ export function useChatSession(
   // In non-hosted mode: auth is needed for org-managed BYOK and sign-in-only MCPJam models.
   const requiresAuthForChat = HOSTED_MODE
     ? true
-    : selectedModelUsesOrgRuntime ||
+    : shouldUseOrgAwareChatApi ||
       (isMcpJamModel &&
         !isMCPJamGuestAllowedModel(String(selectedModel?.id ?? "")));
   const isAuthReady =
@@ -2317,7 +2350,7 @@ export function useChatSession(
   const authHeadersNotReady =
     requiresAuthForChat && isAuthenticated && !authHeaders;
   const hostedContextNotReady =
-    (HOSTED_MODE || selectedModelUsesOrgRuntime) &&
+    shouldUseOrgAwareChatApi &&
     (!hostedProjectId ||
       (selectedServers.length > 0 &&
         hostedSelectedServerIds.length !== selectedServers.length));


### PR DESCRIPTION
- Keeps project/org BYOK chat on the authenticated web route instead of falling into the local MCP route.\n- Uses authFetch for /api/web/chat-v2 in local/dev too, so Convex /stream/org gets a real bearer token.\n- Preserves known model metadata when restoring a saved BYOK model before org config finishes loading.\n- Adds tests for non-hosted org BYOK routing and hosted BYOK trace support.