### PR TITLE
feat(apps): app.* chip on canvas view-iframe injected-globals strip

### DIFF
--- a/.changeset/mcp-apps-canvas-chip.md
+++ b/.changeset/mcp-apps-canvas-chip.md
@@ -1,0 +1,6 @@
+---
+"@mcpjam/inspector": patch
+---
+
+### `@mcpjam/inspector`
+- **`app.*` chip in the canvas view-iframe injected-globals strip**: surfaces the SEP-1865 MCP Apps spec-bridge override state alongside the existing `window.openai` chip. Reads "from preset" when the user hasn't touched the matrix, or "custom (N overrides)" when `mcpProfile.apps.mcpAppsOverrides` has sparse keys. Clicking the chip routes to the Apps Extension tab (same destination as the `window.openai` chip). The two chips are independent — `window.openai` and `app.*` represent different surfaces and never cross-gate. Tooltip on the `app.*` chip explains the spec bridge is the primary protocol surface (always present, no injection toggle).

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
@@ -75,6 +75,14 @@ export interface HostMatrixCardProps {
     methodCount: number;
     methodTotal: number;
   };
+  /**
+   * SEP-1865 `app.*` spec-bridge override state. Independent from
+   * `compatRuntime` — see HostRedesignFlowNode types for the contract.
+   */
+  mcpAppsBridge: {
+    hasOverrides: boolean;
+    overrideCount: number;
+  };
   selectedNodeId: string | null;
   onSelectNode: (nodeId: string) => void;
 }
@@ -89,6 +97,7 @@ export const HostMatrixCard = memo(function HostMatrixCard({
   hostInfo,
   appsExtensionAdvertised,
   compatRuntime,
+  mcpAppsBridge,
   selectedNodeId,
   onSelectNode,
 }: HostMatrixCardProps) {
@@ -306,6 +315,7 @@ export const HostMatrixCard = memo(function HostMatrixCard({
             viewIframeInjectedGlobals={
               <ViewIframeInjectedGlobals
                 compatRuntime={compatRuntime}
+                mcpAppsBridge={mcpAppsBridge}
                 onClick={() => onSelectNode(APPS_HUB_NODE_ID)}
               />
             }
@@ -319,17 +329,28 @@ export const HostMatrixCard = memo(function HostMatrixCard({
 
 /* Injected globals strip inside the View iframe frame.
  *
- * `window.openai` is not in SEP-1865 — it's a ChatGPT-only compatibility
- * layer the inspector injects into widget HTML before sandboxing, so widgets
- * written against the OpenAI Apps SDK keep working. Rendering this inside
- * the View iframe block makes the spatial claim true: this is what the
- * widget's JS actually sees on `window` at runtime.
+ * Two chips rendered side by side, representing the two distinct surfaces
+ * the widget JS sees on `window` at runtime:
  *
- * Clicking routes to the Apps Extension tab, where the per-host toggle
- * (`mcpProfile.apps.compatRuntime.openaiApps`) lives.
+ *   - `window.openai` — ChatGPT-only compatibility shim (NOT in SEP-1865).
+ *     Inspector injects into widget HTML before sandboxing so widgets
+ *     written against the OpenAI Apps SDK keep working. Toggled by
+ *     `mcpProfile.apps.compatRuntime.openaiApps` + per-method overrides.
+ *
+ *   - `app.*` — SEP-1865 MCP Apps spec bridge. Always present (it's the
+ *     primary protocol). Sparse per-dimension overrides via
+ *     `mcpProfile.apps.mcpAppsOverrides` let users simulate a published
+ *     host's subset (e.g. Microsoft 365 Copilot's M365 table).
+ *
+ * The two surfaces are INDEPENDENT — toggling one never affects the
+ * other. They share this chip strip purely because spatially, both are
+ * "things the widget's JS sees on window at runtime."
+ *
+ * Clicking either chip routes to the Apps Extension tab.
  */
 function ViewIframeInjectedGlobals({
   compatRuntime,
+  mcpAppsBridge,
   onClick,
 }: {
   compatRuntime: {
@@ -339,17 +360,29 @@ function ViewIframeInjectedGlobals({
     methodCount: number;
     methodTotal: number;
   };
+  mcpAppsBridge: {
+    hasOverrides: boolean;
+    overrideCount: number;
+  };
   onClick: () => void;
 }) {
-  // Tri-state label: off / preset / custom. "Custom" wins whenever the
-  // user has flipped at least one per-method override, even if injection
-  // itself is at the preset default. Matches what the Apps tab matrix
-  // shows — the chip is a summary of the same state.
-  const customSubtitle = compatRuntime.hasMethodOverrides
+  // Tri-state label for window.openai: off / preset / custom. "Custom"
+  // wins whenever the user has flipped at least one per-method override,
+  // even if injection itself is at the preset default.
+  const openaiSubtitle = compatRuntime.hasMethodOverrides
     ? `custom (${compatRuntime.methodCount}/${compatRuntime.methodTotal} methods)`
     : compatRuntime.fromOverride
       ? "overridden"
       : "from preset";
+  // Bi-state label for app.*: "from preset" or "custom (N overrides)".
+  // Counts sparse-override keys directly — heterogeneous dimensions
+  // (booleans + mode array + sandbox + resource-meta) make a flat
+  // "active" count harder to interpret than just "edits applied."
+  const mcpAppsSubtitle = mcpAppsBridge.hasOverrides
+    ? `custom (${mcpAppsBridge.overrideCount} ${
+        mcpAppsBridge.overrideCount === 1 ? "override" : "overrides"
+      })`
+    : "from preset";
   return (
     <div className="hp-view-injected">
       <button
@@ -370,8 +403,27 @@ function ViewIframeInjectedGlobals({
         <span className="hp-cap-dot" aria-hidden />
         <span className="hp-cap-name">window.openai</span>
         {compatRuntime.openaiApps ? (
-          <span className="hp-cap-tag">{customSubtitle}</span>
+          <span className="hp-cap-tag">{openaiSubtitle}</span>
         ) : null}
+      </button>
+      <button
+        type="button"
+        className="hp-cap"
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick();
+        }}
+        title={
+          mcpAppsBridge.hasOverrides
+            ? `SEP-1865 app.* spec bridge with ${mcpAppsBridge.overrideCount} sparse ${
+                mcpAppsBridge.overrideCount === 1 ? "override" : "overrides"
+              } on top of the host preset (e.g. Copilot's M365-published subset). Click to view the matrix.`
+            : "SEP-1865 app.* spec bridge — primary MCP Apps protocol surface, always present. Click to view the per-dimension matrix."
+        }
+      >
+        <span className="hp-cap-dot" aria-hidden />
+        <span className="hp-cap-name">app.*</span>
+        <span className="hp-cap-tag">{mcpAppsSubtitle}</span>
       </button>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/RedesignedClientCanvas.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/RedesignedClientCanvas.tsx
@@ -109,6 +109,7 @@ const HostMatrixNodeRenderer = memo(
           hostInfo={data.hostInfo}
           appsExtensionAdvertised={data.appsExtensionAdvertised}
           compatRuntime={data.compatRuntime}
+          mcpAppsBridge={data.mcpAppsBridge}
           selectedNodeId={ctx?.selectedNodeId ?? null}
           onSelectNode={ctx?.onSelectNode ?? (() => {})}
         />

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/__tests__/canvasBuilder.test.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/__tests__/canvasBuilder.test.ts
@@ -493,3 +493,64 @@ describe("buildRedesignedHostCanvas — sandbox config rows", () => {
     expect(restrictTo?.isChanged).toBe(true);
   });
 });
+
+describe("buildRedesignedHostCanvas — mcpAppsBridge canvas chip", () => {
+  it("reports no overrides when mcpAppsOverrides is absent from the profile", () => {
+    const data = matrixData(buildVm());
+    expect(data.mcpAppsBridge).toEqual({
+      hasOverrides: false,
+      overrideCount: 0,
+    });
+  });
+
+  it("reports the sparse-override key count when the user has matrix edits", () => {
+    const draft = emptyHostConfigInputV2();
+    draft.mcpProfile = {
+      profileVersion: 1,
+      apps: {
+        mcpAppsOverrides: {
+          serverResources: false,
+          logging: false,
+          availableDisplayModes: ["fullscreen"],
+        },
+      },
+    };
+    const data = matrixData(buildVm({ draft }));
+    expect(data.mcpAppsBridge).toEqual({
+      hasOverrides: true,
+      overrideCount: 3,
+    });
+  });
+
+  it("treats an empty mcpAppsOverrides record as 'no overrides' (sparse-key count is 0)", () => {
+    // An empty {} is the same as undefined for chip purposes — the
+    // user hasn't edited anything. Don't show a misleading "0
+    // overrides" tag.
+    const draft = emptyHostConfigInputV2();
+    draft.mcpProfile = {
+      profileVersion: 1,
+      apps: { mcpAppsOverrides: {} },
+    };
+    const data = matrixData(buildVm({ draft }));
+    expect(data.mcpAppsBridge.hasOverrides).toBe(false);
+    expect(data.mcpAppsBridge.overrideCount).toBe(0);
+  });
+
+  it("counts mcpAppsOverrides independently of compatRuntime.openaiAppsOverrides (two-matrix isolation)", () => {
+    // Both matrices may have overrides on the same profile; the chip
+    // counts must reflect their respective records, not cross-pollinate.
+    const draft = emptyHostConfigInputV2();
+    draft.mcpProfile = {
+      profileVersion: 1,
+      apps: {
+        compatRuntime: {
+          openaiAppsOverrides: { uploadFile: false, requestModal: false },
+        },
+        mcpAppsOverrides: { logging: false },
+      },
+    };
+    const data = matrixData(buildVm({ draft }));
+    expect(data.mcpAppsBridge.overrideCount).toBe(1);
+    expect(data.compatRuntime.hasMethodOverrides).toBe(true);
+  });
+});

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
@@ -771,6 +771,27 @@ export function buildRedesignedHostCanvas(
     methodTotal: 13,
   };
 
+  // SEP-1865 `app.*` spec-bridge state. Independent from `compatRuntime`
+  // (the OpenAI shim) — the spec bridge is always present (no
+  // "injected" toggle), so this only summarizes whether the user has
+  // sparse-overridden any of the matrix's dimensions for the canvas
+  // chip subtitle.
+  const mcpAppsOverridesRecord = draft.mcpProfile?.apps?.mcpAppsOverrides;
+  const mcpAppsBridge = {
+    hasOverrides:
+      mcpAppsOverridesRecord !== undefined &&
+      Object.keys(mcpAppsOverridesRecord).length > 0,
+    // Number of sparse-override keys the user has set. Chip reads this
+    // as "N overrides" — simpler than "N of M dimensions" because the
+    // matrix is heterogeneous (booleans + mode array + sandbox flags +
+    // resource-meta flags) and a flat "active" count would be hard to
+    // interpret across those buckets.
+    overrideCount:
+      mcpAppsOverridesRecord !== undefined
+        ? Object.keys(mcpAppsOverridesRecord).length
+        : 0,
+  };
+
   // ---- Nodes / edges ----
   const nodes: HostRedesignFlowNode[] = [];
   const edges: Edge[] = [];
@@ -792,6 +813,7 @@ export function buildRedesignedHostCanvas(
       hostInfo,
       appsExtensionAdvertised,
       compatRuntime,
+      mcpAppsBridge,
     },
     draggable: false,
     selectable: false,

--- a/mcpjam-inspector/client/src/components/clients/redesigned/types.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/types.ts
@@ -297,6 +297,31 @@ export interface HostMatrixNodeData extends Record<string, unknown> {
      */
     methodTotal: number;
   };
+  /**
+   * SEP-1865 `app.*` spec-bridge override state. Independent from
+   * {@link compatRuntime} (the OpenAI shim) — the two matrices represent
+   * different surfaces and are never cross-gated. Rendered as a sibling
+   * chip in the View iframe injected-globals strip so the user can see
+   * at a glance whether they've sparse-overridden the host's preset.
+   *
+   * No `injected` flag here: the spec bridge is always present (it's
+   * the primary protocol, not a vendor compat shim).
+   */
+  mcpAppsBridge: {
+    /**
+     * Whether the user has set any key on `mcpAppsOverrides`. Drives
+     * the chip's "custom (N overrides)" vs "from preset" subtitle.
+     */
+    hasOverrides: boolean;
+    /**
+     * Number of sparse-override keys the user has set. Surfaced in the
+     * chip subtitle. Counts edited dimensions (not "active" effective
+     * values) — the matrix is heterogeneous (booleans + mode array +
+     * sandbox flags + resource-meta flags) and an "active" count
+     * wouldn't cleanly compose across the buckets.
+     */
+    overrideCount: number;
+  };
 }
 
 export interface ServersHubNodeData extends Record<string, unknown> {


### PR DESCRIPTION
## Summary

Adds an `app.*` chip alongside the existing `window.openai` chip in the canvas view-iframe injected-globals strip, so the overview surfaces the SEP-1865 MCP Apps spec-bridge override state. Until this PR, the canvas exposed only the OpenAI shim's matrix-override count; users editing `mcpProfile.apps.mcpAppsOverrides` (currently via JSON, eventually via the structured matrix UI) had no overview-level signal that an override was active.

## What the chip reads

| Profile state | Chip subtitle |
|---|---|
| No `mcpAppsOverrides` (or `{}`) | `from preset` |
| 1 sparse-override key | `custom (1 override)` |
| N sparse-override keys | `custom (N overrides)` |

Click routes to the Apps Extension tab (same destination as `window.openai`'s chip). Tooltip explains the spec bridge is the primary protocol surface — always present, no injection toggle (unlike the shim).

## Two-matrix architecture, defended

`window.openai.callTool` and `app.callTool` are independent surfaces representing different APIs. The two chips stand side-by-side spatially (both "things the widget's JS sees on `window` at runtime") but their override counts are computed independently:
- `compatRuntime.hasMethodOverrides` ← `mcpProfile.apps.compatRuntime.openaiAppsOverrides`
- `mcpAppsBridge.hasOverrides` ← `mcpProfile.apps.mcpAppsOverrides`

New canvas test exercises both override fields on the same profile and asserts the counts don't cross-pollinate.

## Files

- `client/src/components/clients/redesigned/canvas/canvasBuilder.ts` — compute `mcpAppsBridge` summary from the profile
- `client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx` — render the new chip in `ViewIframeInjectedGlobals`
- `client/src/components/clients/redesigned/canvas/RedesignedClientCanvas.tsx` — thread `mcpAppsBridge` from node data to `HostMatrixCard`
- `client/src/components/clients/redesigned/types.ts` — add `mcpAppsBridge` to `HostMatrixNodeData`
- `client/src/components/clients/redesigned/canvas/__tests__/canvasBuilder.test.ts` — 4 new tests (no overrides / N overrides / empty record / cross-matrix isolation)
- `.changeset/mcp-apps-canvas-chip.md` — patch bump

## Tests

- **666/666 client tests pass** (`npx vitest run client/src/lib/__tests__/ client/src/lib/client-styles/__tests__/ client/src/components/chat-v2/thread/mcp-apps/__tests__/ client/src/components/clients/redesigned/`).
- **`npx tsc -p client/tsconfig.json --noEmit`** — no new errors in changed files.

## Test plan

- [x] Resolver + canvas builder + chip data shape all unit-tested (666/666 pass)
- [x] TypeScript clean for changed files
- [ ] Manual: open the canvas on a host with no profile overrides → both chips read "from preset"
- [ ] Manual: edit the Apps tab JSON to add `mcpAppsOverrides: { "serverResources": false }` → save → return to canvas → `app.*` chip subtitle reads "custom (1 override)"; `window.openai` chip stays "from preset" (independence)
- [ ] Manual: click the `app.*` chip → routes to the Apps Extension tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new UI-only summary field and chip driven by existing `mcpProfile.apps.mcpAppsOverrides`, plus type/threading and unit tests; no protocol/auth/data-path behavior changes.
> 
> **Overview**
> Surfaces SEP-1865 `app.*` spec-bridge override state on the redesigned host canvas by adding a second chip alongside `window.openai` in the View-iframe injected-globals strip.
> 
> The canvas builder now computes and threads a new `mcpAppsBridge` summary (`hasOverrides`/`overrideCount` based on sparse keys in `mcpProfile.apps.mcpAppsOverrides`) into `HostMatrixNodeData`, renders the chip subtitle/tooltip, and routes chip clicks to the Apps Extension tab. Tests were added to cover absent/empty override records and to ensure `app.*` override counting stays independent from `compatRuntime.openaiAppsOverrides`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 928e2a694d39dd85b61d48f21928424e93c08699. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->