### PR TITLE
feat(apps): structured matrix UI for SEP-1865 app.* spec bridge

### DIFF
--- a/.changeset/mcp-apps-matrix-ui.md
+++ b/.changeset/mcp-apps-matrix-ui.md
@@ -1,0 +1,6 @@
+---
+"@mcpjam/inspector": minor
+---
+
+### `@mcpjam/inspector`
+- **Structured matrix UI for the SEP-1865 `app.*` spec bridge in the Apps tab**: clickable surface for the per-dimension override added in #2226. Sits below the existing `window.openai` matrix as a sibling — two independent surfaces, never cross-gated. Layout: `availableDisplayModes` multi-checkbox cluster (always visible), main disclosure with notification gates + `serverResources` / `logging`, and an Advanced disclosure for sandbox sub-fields, resource-meta, `toolInfo`, and the rare advertise rows. "Overridden" badge on rows the user has diverged from the host style preset; "Match host preset" chip clears the entire matrix at once. The matrix invariant (`availableDisplayModes` non-empty) is enforced in the UI by force-enabling `"inline"` when the user unchecks the last mode. Round-trips with `appsToJson` / `applyJsonToDraft` so the JSON editor below stays in sync. 11 new component-level tests cover toggle → sparse override, toggle-back-to-preset → drop key, "Overridden" badge tracking, chip clear, disabled-when-clean, Advanced disclosure visibility, mode cluster edits, and the empty-allowlist coercion.

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -3,6 +3,7 @@ import { ChevronDown } from "lucide-react";
 import { JsonEditor, type JsonEditorMode } from "@/components/ui/json-editor";
 import {
   resolveEffectiveHostCapabilities,
+  resolveEffectiveMcpAppsCapabilities,
   type HostConfigInputV2,
   type HostConfigMcpProfileV1,
 } from "@/lib/client-config-v2";
@@ -14,6 +15,7 @@ import {
 import type {
   McpAppsCapabilities,
   OpenAiAppsCapabilities,
+  ResolvedMcpAppsCapabilities,
   ResolvedOpenAiAppsCapabilities,
 } from "@/lib/client-styles";
 import { Switch } from "@mcpjam/design-system/switch";
@@ -1072,6 +1074,378 @@ function RequestDisplayModeControl({
   );
 }
 
+/**
+ * Update `mcpProfile.apps.mcpAppsOverrides` while preserving sibling
+ * fields (`sandbox`, `uiInitialize`, `compatRuntime`) and the parent
+ * envelope. Empty override objects collapse to undefined so editing
+ * back to preset values cleanly clears the matrix — `appsToJson` will
+ * then omit the block entirely (matches the sparse-on-save convention
+ * `setCompatRuntimeOnDraft` already uses for `openaiAppsOverrides`).
+ */
+function setMcpAppsOverridesOnDraft(
+  prev: HostConfigInputV2,
+  next: McpAppsCapabilities | undefined,
+): HostConfigInputV2 {
+  const prevProfile: HostConfigMcpProfileV1 =
+    prev.mcpProfile ?? { profileVersion: 1 };
+  const prevApps = prevProfile.apps ?? {};
+  const hasKeys = next !== undefined && Object.keys(next).length > 0;
+  const nextApps: NonNullable<HostConfigMcpProfileV1["apps"]> = {
+    ...prevApps,
+    mcpAppsOverrides: hasKeys ? next : undefined,
+  };
+  return {
+    ...prev,
+    mcpProfile: { ...prevProfile, apps: nextApps },
+  };
+}
+
+/**
+ * Main-disclosure matrix dimensions — the rows that vary across
+ * published host tables (Microsoft 365 Copilot's M365 reference). Order
+ * matches the M365 Component-bridge table where applicable.
+ */
+const MCP_APPS_MAIN_DIMENSIONS: Array<{
+  key: Exclude<keyof McpAppsCapabilities, "availableDisplayModes">;
+  label: string;
+}> = [
+  { key: "toolInputPartial", label: "toolInputPartial" },
+  { key: "toolCancelled", label: "toolCancelled" },
+  { key: "hostContextChanged", label: "hostContextChanged" },
+  { key: "resourceTeardown", label: "resourceTeardown" },
+  { key: "serverResources", label: "serverResources" },
+  { key: "logging", label: "logging" },
+];
+
+/**
+ * Advanced disclosure — rare dimensions that rarely vary across hosts
+ * but are needed for completeness (sandbox sub-fields, resource-meta
+ * interpretation, HostContext fine grain, hands-off advertise rows
+ * that almost every preset enables).
+ */
+const MCP_APPS_ADVANCED_DIMENSIONS: Array<{
+  key: Exclude<keyof McpAppsCapabilities, "availableDisplayModes">;
+  label: string;
+}> = [
+  { key: "toolInfo", label: "toolInfo" },
+  { key: "openLinks", label: "openLinks" },
+  { key: "serverTools", label: "serverTools" },
+  { key: "updateModelContext", label: "updateModelContext" },
+  { key: "message", label: "message" },
+  { key: "sandboxPermissions", label: "sandbox.permissions" },
+  { key: "cspFrameDomains", label: "sandbox.csp.frameDomains" },
+  { key: "cspBaseUriDomains", label: "sandbox.csp.baseUriDomains" },
+  { key: "resourcePrefersBorder", label: "_meta.ui.prefersBorder" },
+];
+
+const ALL_DISPLAY_MODES = ["inline", "fullscreen", "pip"] as const;
+type DisplayMode = (typeof ALL_DISPLAY_MODES)[number];
+
+/**
+ * Per-dimension capability matrix for the SEP-1865 `app.*` spec bridge.
+ * Sibling to {@link OpenaiAppsCapabilityMatrix} but represents a
+ * different surface — the spec bridge is the primary MCP Apps protocol,
+ * not a vendor compat shim, so there's no "inject" master toggle and
+ * no tri-state (the matrix is always advertised).
+ *
+ * Layout:
+ * - `availableDisplayModes` cluster at the top (multi-checkbox for the
+ *   array allowlist; inline is force-enabled if user clears all three).
+ * - Main disclosure: notification gates + serverResources / logging —
+ *   the rows that vary across published host tables.
+ * - Advanced disclosure: sandbox sub-fields, resource-meta, toolInfo,
+ *   and advertise rows that almost every preset enables (still
+ *   surfaced so legacy `{}` migrations are visible).
+ * - Per-row "Overridden" badge when the user has diverged from the
+ *   host style preset; rows show the preset value for context.
+ * - "Match host preset" chip clears the entire matrix override.
+ *
+ * The matrix round-trips through `appsToJson` / `applyJsonToDraft` so
+ * the JSON editor below stays in sync.
+ *
+ * INDEPENDENT from the OpenAI shim matrix. Toggling a row here never
+ * affects `window.openai.*` and vice versa — see the two-matrix
+ * architecture notes in #2226 / #2230 / #2232.
+ */
+function McpAppsCapabilityMatrix({
+  draft,
+  onDraftChange,
+}: {
+  draft: HostConfigInputV2;
+  onDraftChange: (
+    updater: (prev: HostConfigInputV2) => HostConfigInputV2,
+  ) => void;
+}) {
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const overridesRecord = draft.mcpProfile?.apps?.mcpAppsOverrides;
+  // Preset baseline alone (no override applied) — used to compute the
+  // per-row "Preset: X" hint and the "Overridden" badge.
+  const presetCapabilities: ResolvedMcpAppsCapabilities =
+    resolveEffectiveMcpAppsCapabilities({
+      profile: undefined,
+      hostStyle: draft.hostStyle,
+    });
+  // Effective (preset + override). Source of truth for what the
+  // resolver advertises today.
+  const effectiveCapabilities: ResolvedMcpAppsCapabilities =
+    resolveEffectiveMcpAppsCapabilities({
+      profile: draft.mcpProfile,
+      hostStyle: draft.hostStyle,
+    });
+
+  const hasAnyOverride =
+    overridesRecord !== undefined && Object.keys(overridesRecord).length > 0;
+
+  const clearOverride = () => {
+    onDraftChange((prev) => setMcpAppsOverridesOnDraft(prev, undefined));
+  };
+
+  /** Set or clear a boolean dimension override. Pass `undefined` to revert to preset. */
+  const setBooleanOverride = (
+    key: Exclude<keyof McpAppsCapabilities, "availableDisplayModes">,
+    nextEffective: boolean,
+  ) => {
+    onDraftChange((prev) => {
+      const prevOverrides = prev.mcpProfile?.apps?.mcpAppsOverrides ?? {};
+      const prevPreset = resolveEffectiveMcpAppsCapabilities({
+        profile: undefined,
+        hostStyle: prev.hostStyle,
+      });
+      const nextOverrides: McpAppsCapabilities = { ...prevOverrides };
+      if (nextEffective === prevPreset[key]) {
+        // Toggle matches preset → drop the override (revert to preset
+        // semantics; sparse on save).
+        delete (nextOverrides as Record<string, unknown>)[key];
+      } else {
+        (nextOverrides as Record<string, unknown>)[key] = nextEffective;
+      }
+      return setMcpAppsOverridesOnDraft(prev, nextOverrides);
+    });
+  };
+
+  /**
+   * Toggle a display mode in the allowlist. The matrix invariant is
+   * `availableDisplayModes.length >= 1` — if the user unchecks the
+   * last mode, force-enable `"inline"` (the spec default; an empty
+   * allowlist would be unrenderable). The resolver enforces this same
+   * invariant as a backstop, but doing it here keeps the UI honest.
+   *
+   * If the resulting allowlist equals the preset's array, drop the
+   * override key so the matrix reverts cleanly.
+   */
+  const toggleDisplayMode = (mode: DisplayMode) => {
+    onDraftChange((prev) => {
+      const prevOverrides = prev.mcpProfile?.apps?.mcpAppsOverrides ?? {};
+      const prevPreset = resolveEffectiveMcpAppsCapabilities({
+        profile: undefined,
+        hostStyle: prev.hostStyle,
+      });
+      const prevEffective = resolveEffectiveMcpAppsCapabilities({
+        profile: prev.mcpProfile,
+        hostStyle: prev.hostStyle,
+      });
+      const currentModes = prevEffective.availableDisplayModes;
+      let nextModesList = currentModes.includes(mode)
+        ? currentModes.filter((m) => m !== mode)
+        : [...currentModes, mode];
+      if (nextModesList.length === 0) {
+        // Backstop: never persist an empty allowlist.
+        nextModesList = ["inline"];
+      }
+      // Preserve the canonical inline→fullscreen→pip order so equality
+      // checks against the preset don't false-negative on permutation.
+      nextModesList = ALL_DISPLAY_MODES.filter((m) =>
+        nextModesList.includes(m),
+      );
+      const nextOverrides: McpAppsCapabilities = { ...prevOverrides };
+      if (
+        stableStringifyJson(nextModesList) ===
+        stableStringifyJson(prevPreset.availableDisplayModes)
+      ) {
+        delete nextOverrides.availableDisplayModes;
+      } else {
+        nextOverrides.availableDisplayModes = nextModesList as DisplayMode[];
+      }
+      return setMcpAppsOverridesOnDraft(prev, nextOverrides);
+    });
+  };
+
+  const overrideCount = overridesRecord
+    ? Object.keys(overridesRecord).length
+    : 0;
+  const subline = hasAnyOverride
+    ? `${overrideCount} ${overrideCount === 1 ? "override" : "overrides"} active`
+    : "Matches host style preset";
+
+  return (
+    <div className="rounded-[10px] border border-border bg-background">
+      {/* Header strip: section label + override count + clear-to-preset chip. */}
+      <div className="flex items-stretch border-b border-border">
+        <div className="flex flex-1 flex-col gap-0.5 px-3.5 py-2.5">
+          <span className="text-[12px] font-medium">
+            <span className="font-mono">app.*</span> spec bridge
+            <span className="ml-1.5 text-[10px] font-normal text-muted-foreground">
+              (SEP-1865)
+            </span>
+          </span>
+          <span className="text-[11px] text-muted-foreground">{subline}</span>
+        </div>
+        <div className="flex items-center border-l border-border pr-3.5 pl-3">
+          <button
+            type="button"
+            disabled={!hasAnyOverride}
+            onClick={clearOverride}
+            className="rounded border border-border bg-background px-2 py-0.5 text-[11px] text-muted-foreground transition hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
+            title="Clear all overrides on this matrix and revert every dimension to the host style preset"
+          >
+            Match host preset
+          </button>
+        </div>
+      </div>
+
+      {/* availableDisplayModes — multi-checkbox cluster. Always visible
+          (it's the most-edited dimension and the one published host
+          tables most prominently differ on, e.g. Copilot is fullscreen-
+          only). */}
+      <div className="flex items-center justify-between gap-3 border-b border-border/50 px-3.5 py-2">
+        <div className="flex flex-col gap-0.5">
+          <span className="font-mono text-[12px]">availableDisplayModes</span>
+          <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+            <span>
+              Preset:{" "}
+              <span className="font-mono">
+                [{presetCapabilities.availableDisplayModes.join(", ")}]
+              </span>
+            </span>
+            {overridesRecord?.availableDisplayModes !== undefined ? (
+              <span className="rounded bg-orange-500/15 px-1 py-px text-orange-600 dark:text-orange-300">
+                Overridden
+              </span>
+            ) : null}
+          </div>
+        </div>
+        <div className="inline-flex overflow-hidden rounded-md border border-border text-[11px]">
+          {ALL_DISPLAY_MODES.map((mode) => {
+            const enabled =
+              effectiveCapabilities.availableDisplayModes.includes(mode);
+            return (
+              <button
+                key={mode}
+                type="button"
+                className={
+                  enabled
+                    ? "bg-foreground/10 px-2 py-0.5 font-medium"
+                    : "px-2 py-0.5 text-muted-foreground hover:bg-muted"
+                }
+                onClick={() => toggleDisplayMode(mode)}
+              >
+                {mode}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Main dimensions — notification gates + serverResources / logging. */}
+      <div className="flex flex-col">
+        {MCP_APPS_MAIN_DIMENSIONS.map(({ key, label }) => (
+          <McpAppsDimensionRow
+            key={key}
+            dimensionKey={key}
+            label={label}
+            effective={Boolean(effectiveCapabilities[key])}
+            presetValue={Boolean(presetCapabilities[key])}
+            overridden={
+              overridesRecord !== undefined && key in overridesRecord
+            }
+            onToggle={(next) => setBooleanOverride(key, next)}
+          />
+        ))}
+      </div>
+
+      {/* Advanced disclosure — sandbox sub-fields, resource-meta,
+          toolInfo, plus the "always on across every preset" advertise
+          rows. Surfaced so legacy `{}` migrations are visible and
+          unusual hosts can be modeled. */}
+      <button
+        type="button"
+        onClick={() => setAdvancedOpen((v) => !v)}
+        aria-expanded={advancedOpen}
+        aria-controls="apps-extension-mcp-apps-advanced"
+        className="flex w-full items-center justify-between gap-2 border-t border-border/50 px-3.5 py-2 text-left text-[11px] text-muted-foreground hover:bg-muted/40"
+      >
+        <span>Advanced ({MCP_APPS_ADVANCED_DIMENSIONS.length} dimensions)</span>
+        <ChevronDown
+          className={`h-3.5 w-3.5 shrink-0 transition-transform ${
+            advancedOpen ? "rotate-180" : ""
+          }`}
+        />
+      </button>
+      {advancedOpen ? (
+        <div
+          id="apps-extension-mcp-apps-advanced"
+          className="flex flex-col border-t border-border/50"
+        >
+          {MCP_APPS_ADVANCED_DIMENSIONS.map(({ key, label }) => (
+            <McpAppsDimensionRow
+              key={key}
+              dimensionKey={key}
+              label={label}
+              effective={Boolean(effectiveCapabilities[key])}
+              presetValue={Boolean(presetCapabilities[key])}
+              overridden={
+                overridesRecord !== undefined && key in overridesRecord
+              }
+              onToggle={(next) => setBooleanOverride(key, next)}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/** Single boolean dimension row — preset hint + overridden badge + toggle. */
+function McpAppsDimensionRow({
+  dimensionKey,
+  label,
+  effective,
+  presetValue,
+  overridden,
+  onToggle,
+}: {
+  dimensionKey: Exclude<keyof McpAppsCapabilities, "availableDisplayModes">;
+  label: string;
+  effective: boolean;
+  presetValue: boolean;
+  overridden: boolean;
+  onToggle: (next: boolean) => void;
+}) {
+  return (
+    <div
+      data-testid={`mcp-apps-dimension-${dimensionKey}`}
+      className="flex items-center justify-between gap-3 border-b border-border/50 px-3.5 py-2 last:border-b-0"
+    >
+      <div className="flex flex-col gap-0.5">
+        <span className="font-mono text-[12px]">{label}</span>
+        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
+          <span>Preset: {String(presetValue)}</span>
+          {overridden ? (
+            <span className="rounded bg-orange-500/15 px-1 py-px text-orange-600 dark:text-orange-300">
+              Overridden
+            </span>
+          ) : null}
+        </div>
+      </div>
+      <Switch
+        checked={effective}
+        onCheckedChange={onToggle}
+        aria-label={label}
+      />
+    </div>
+  );
+}
+
 export function AppsExtensionTab({
   draft,
   onDraftChange,
@@ -1092,6 +1466,14 @@ export function AppsExtensionTab({
   return (
     <div className="flex h-full min-h-[480px] flex-col gap-3">
       <OpenaiAppsCapabilityMatrix
+        draft={draft}
+        onDraftChange={onDraftChange}
+      />
+      {/* Two-matrix architecture: window.openai (shim) and app.* (spec
+          bridge) are independent surfaces and never cross-gate. The
+          subtitle on each section makes this explicit so users don't
+          confuse them. */}
+      <McpAppsCapabilityMatrix
         draft={draft}
         onDraftChange={onDraftChange}
       />

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -1076,27 +1076,63 @@ function RequestDisplayModeControl({
 
 /**
  * Update `mcpProfile.apps.mcpAppsOverrides` while preserving sibling
- * fields (`sandbox`, `uiInitialize`, `compatRuntime`) and the parent
- * envelope. Empty override objects collapse to undefined so editing
- * back to preset values cleanly clears the matrix — `appsToJson` will
- * then omit the block entirely (matches the sparse-on-save convention
- * `setCompatRuntimeOnDraft` already uses for `openaiAppsOverrides`).
+ * fields (`sandbox`, `uiInitialize`, `compatRuntime`) and collapsing
+ * empties on the way out:
+ *   - empty override object → omit `mcpAppsOverrides` from `apps`
+ *   - empty `apps` block (no other siblings) → omit `apps` from profile
+ *   - empty profile (only `profileVersion`) → set `mcpProfile: undefined`
+ *
+ * Mirrors the collapse the bottom of `applyJsonToDraft` already does.
+ * Without it, toggling a row and toggling it back leaves a dirty
+ * `{ profileVersion: 1, apps: {} }` shell on the draft —
+ * `hostConfigInputsEqual` treats that as distinct from `undefined`, so
+ * the save button stays armed and the matrix says "Matches host style
+ * preset" while the draft is silently dirty.
  */
 function setMcpAppsOverridesOnDraft(
   prev: HostConfigInputV2,
   next: McpAppsCapabilities | undefined,
 ): HostConfigInputV2 {
-  const prevProfile: HostConfigMcpProfileV1 =
-    prev.mcpProfile ?? { profileVersion: 1 };
-  const prevApps = prevProfile.apps ?? {};
   const hasKeys = next !== undefined && Object.keys(next).length > 0;
-  const nextApps: NonNullable<HostConfigMcpProfileV1["apps"]> = {
-    ...prevApps,
-    mcpAppsOverrides: hasKeys ? next : undefined,
-  };
+  const prevProfile = prev.mcpProfile;
+  const prevApps = prevProfile?.apps ?? {};
+
+  // Rebuild `apps` explicitly so the spread doesn't leak
+  // `mcpAppsOverrides: undefined` into `Object.keys` when we're
+  // clearing the override. Sibling fields (`sandbox`, `uiInitialize`,
+  // `compatRuntime`, future additions) round-trip verbatim.
+  const nextApps: NonNullable<HostConfigMcpProfileV1["apps"]> = {};
+  for (const [key, value] of Object.entries(prevApps)) {
+    if (key === "mcpAppsOverrides") continue;
+    if (value !== undefined) {
+      (nextApps as Record<string, unknown>)[key] = value;
+    }
+  }
+  if (hasKeys) nextApps.mcpAppsOverrides = next;
+  const appsEmpty = Object.keys(nextApps).length === 0;
+
+  // Fast path: if the draft had no profile to begin with and the new
+  // apps block is empty, leave the draft untouched (no envelope
+  // synthesized just to immediately collapse it).
+  if (prevProfile === undefined && appsEmpty) {
+    return prev;
+  }
+
+  const baseProfile: HostConfigMcpProfileV1 =
+    prevProfile ?? { profileVersion: 1 };
+  const hasInitialize =
+    baseProfile.initialize !== undefined &&
+    (baseProfile.initialize.clientInfo !== undefined ||
+      (baseProfile.initialize.supportedProtocolVersions &&
+        baseProfile.initialize.supportedProtocolVersions.length > 0));
+  const hasExtensions = baseProfile.extensions !== undefined;
+  const profileEmpty = appsEmpty && !hasInitialize && !hasExtensions;
+
   return {
     ...prev,
-    mcpProfile: { ...prevProfile, apps: nextApps },
+    mcpProfile: profileEmpty
+      ? undefined
+      : { ...baseProfile, apps: appsEmpty ? undefined : nextApps },
   };
 }
 

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { JsonEditor, type JsonEditorMode } from "@/components/ui/json-editor";
 import {
+  hostCapabilitiesOverrideToMatrix,
   resolveEffectiveHostCapabilities,
   resolveEffectiveMcpAppsCapabilities,
   type HostConfigInputV2,
@@ -1078,16 +1079,29 @@ function RequestDisplayModeControl({
  * Update `mcpProfile.apps.mcpAppsOverrides` while preserving sibling
  * fields (`sandbox`, `uiInitialize`, `compatRuntime`) and collapsing
  * empties on the way out:
+ *
  *   - empty override object → omit `mcpAppsOverrides` from `apps`
  *   - empty `apps` block (no other siblings) → omit `apps` from profile
- *   - empty profile (only `profileVersion`) → set `mcpProfile: undefined`
+ *   - profile that's now content-less (only `profileVersion`) →
+ *     `mcpProfile: undefined`
  *
  * Mirrors the collapse the bottom of `applyJsonToDraft` already does.
  * Without it, toggling a row and toggling it back leaves a dirty
  * `{ profileVersion: 1, apps: {} }` shell on the draft —
- * `hostConfigInputsEqual` treats that as distinct from `undefined`, so
+ * `optionalMcpProfileEq` treats that as distinct from `undefined`, so
  * the save button stays armed and the matrix says "Matches host style
  * preset" while the draft is silently dirty.
+ *
+ * Trade-off: a user who deliberately opted into a content-less
+ * `{ profileVersion: 1 }` envelope (by hand-editing the JSON) will
+ * see that stub dropped when they touch the matrix. We accept that:
+ * the typed-in `{ profileVersion: 1 }` carries no semantic content
+ * the resolver consumes, and the common case (user toggles via
+ * matrix UI, expects clean revert) is overwhelmingly more frequent.
+ * If we ever model the matrix and the openai shim's
+ * `setCompatRuntimeOnDraft` consistently, we can revisit by tracking
+ * "synthesized vs opted-in" provenance — but that's bigger than this
+ * PR.
  */
 function setMcpAppsOverridesOnDraft(
   prev: HostConfigInputV2,
@@ -1111,9 +1125,8 @@ function setMcpAppsOverridesOnDraft(
   if (hasKeys) nextApps.mcpAppsOverrides = next;
   const appsEmpty = Object.keys(nextApps).length === 0;
 
-  // Fast path: if the draft had no profile to begin with and the new
-  // apps block is empty, leave the draft untouched (no envelope
-  // synthesized just to immediately collapse it).
+  // Fast path: no envelope before, no content now → leave draft alone
+  // (no envelope ever synthesized just to immediately collapse it).
   if (prevProfile === undefined && appsEmpty) {
     return prev;
   }
@@ -1213,7 +1226,30 @@ function McpAppsCapabilityMatrix({
   ) => void;
 }) {
   const [advancedOpen, setAdvancedOpen] = useState(false);
-  const overridesRecord = draft.mcpProfile?.apps?.mcpAppsOverrides;
+  const rawOverridesRecord = draft.mcpProfile?.apps?.mcpAppsOverrides;
+  const legacyOverride = draft.hostCapabilitiesOverride;
+  // Legacy `hostCapabilitiesOverride` is the pre-matrix way of
+  // narrowing the advertised host capabilities. When the matrix is
+  // absent but the legacy is present, the resolver advertises the
+  // legacy shape; the matrix UI must reflect that, not the bare
+  // preset. Otherwise a user with a legacy override sees the matrix
+  // show preset values, toggles a single row, and the resolver
+  // switches precedence to the (mostly-empty) matrix path —
+  // silently flipping every other legacy-overridden dimension back
+  // to the preset.
+  //
+  // The display fix: virtually migrate the legacy into matrix shape
+  // so the per-row effective values + "Overridden" badges reflect
+  // what the resolver actually advertises today. The matching write
+  // fix is in `migrateLegacyIfNeeded` below — the first edit
+  // commits the migration to persisted state so subsequent edits
+  // build on top.
+  const effectiveOverridesForDisplay: McpAppsCapabilities | undefined =
+    rawOverridesRecord !== undefined
+      ? rawOverridesRecord
+      : legacyOverride !== undefined
+        ? (hostCapabilitiesOverrideToMatrix(legacyOverride) ?? undefined)
+        : undefined;
   // Preset baseline alone (no override applied) — used to compute the
   // per-row "Preset: X" hint and the "Overridden" badge.
   const presetCapabilities: ResolvedMcpAppsCapabilities =
@@ -1221,19 +1257,81 @@ function McpAppsCapabilityMatrix({
       profile: undefined,
       hostStyle: draft.hostStyle,
     });
-  // Effective (preset + override). Source of truth for what the
-  // resolver advertises today.
+  // Effective values shown in the matrix UI. Uses the virtually-
+  // migrated legacy when the matrix is absent so the UI shows what
+  // the resolver advertises today (legacy path) — not what it would
+  // advertise after the first edit silently strips the legacy.
   const effectiveCapabilities: ResolvedMcpAppsCapabilities =
-    resolveEffectiveMcpAppsCapabilities({
-      profile: draft.mcpProfile,
-      hostStyle: draft.hostStyle,
-    });
+    effectiveOverridesForDisplay !== undefined
+      ? resolveEffectiveMcpAppsCapabilities({
+          profile: {
+            profileVersion: 1,
+            apps: { mcpAppsOverrides: effectiveOverridesForDisplay },
+          },
+          hostStyle: draft.hostStyle,
+        })
+      : resolveEffectiveMcpAppsCapabilities({
+          profile: undefined,
+          hostStyle: draft.hostStyle,
+        });
 
   const hasAnyOverride =
-    overridesRecord !== undefined && Object.keys(overridesRecord).length > 0;
+    effectiveOverridesForDisplay !== undefined &&
+    Object.keys(effectiveOverridesForDisplay).length > 0;
+
+  /**
+   * On first matrix edit applied to a draft that still uses legacy
+   * `hostCapabilitiesOverride` (matrix absent, legacy present),
+   * convert the legacy into matrix shape so the user's single-row
+   * edit can be applied on top without silently dropping all the
+   * other legacy-overridden dimensions. Also clears the legacy
+   * field — the matrix becomes the new source of truth.
+   *
+   * Returns `{ overrides, prevWithLegacyCleared }`. Callers apply
+   * their edit to `overrides`, then pipe through
+   * `setMcpAppsOverridesOnDraft(prevWithLegacyCleared, edited)`.
+   */
+  const migrateLegacyIfNeeded = (
+    prev: HostConfigInputV2,
+  ): {
+    overrides: McpAppsCapabilities;
+    prevWithLegacyCleared: HostConfigInputV2;
+  } => {
+    const matrix = prev.mcpProfile?.apps?.mcpAppsOverrides;
+    if (matrix !== undefined) {
+      // Matrix already owns the state; no migration needed.
+      return { overrides: { ...matrix }, prevWithLegacyCleared: prev };
+    }
+    const legacy = prev.hostCapabilitiesOverride;
+    if (legacy === undefined) {
+      // Neither override present — start from empty.
+      return { overrides: {}, prevWithLegacyCleared: prev };
+    }
+    // Legacy → matrix; clear the legacy so future reads use the
+    // matrix path consistently. Precedence-conflict between the two
+    // fields was the original motivation for the migration helper
+    // landing alongside the foundation PR.
+    const migrated = hostCapabilitiesOverrideToMatrix(legacy) ?? {};
+    return {
+      overrides: { ...migrated },
+      prevWithLegacyCleared: { ...prev, hostCapabilitiesOverride: undefined },
+    };
+  };
 
   const clearOverride = () => {
-    onDraftChange((prev) => setMcpAppsOverridesOnDraft(prev, undefined));
+    // "Match host preset" clears BOTH paths — the matrix override
+    // and the legacy `hostCapabilitiesOverride` — so the resolver
+    // falls back cleanly to the host style preset. Leaving the
+    // legacy alive would silently keep the override active through
+    // the legacy path even after the matrix shows "Matches host
+    // style preset".
+    onDraftChange((prev) => {
+      const withMatrixCleared = setMcpAppsOverridesOnDraft(prev, undefined);
+      if (withMatrixCleared.hostCapabilitiesOverride === undefined) {
+        return withMatrixCleared;
+      }
+      return { ...withMatrixCleared, hostCapabilitiesOverride: undefined };
+    });
   };
 
   /** Set or clear a boolean dimension override. Pass `undefined` to revert to preset. */
@@ -1242,7 +1340,8 @@ function McpAppsCapabilityMatrix({
     nextEffective: boolean,
   ) => {
     onDraftChange((prev) => {
-      const prevOverrides = prev.mcpProfile?.apps?.mcpAppsOverrides ?? {};
+      const { overrides: prevOverrides, prevWithLegacyCleared } =
+        migrateLegacyIfNeeded(prev);
       const prevPreset = resolveEffectiveMcpAppsCapabilities({
         profile: undefined,
         hostStyle: prev.hostStyle,
@@ -1255,7 +1354,7 @@ function McpAppsCapabilityMatrix({
       } else {
         (nextOverrides as Record<string, unknown>)[key] = nextEffective;
       }
-      return setMcpAppsOverridesOnDraft(prev, nextOverrides);
+      return setMcpAppsOverridesOnDraft(prevWithLegacyCleared, nextOverrides);
     });
   };
 
@@ -1271,16 +1370,18 @@ function McpAppsCapabilityMatrix({
    */
   const toggleDisplayMode = (mode: DisplayMode) => {
     onDraftChange((prev) => {
-      const prevOverrides = prev.mcpProfile?.apps?.mcpAppsOverrides ?? {};
+      const { overrides: prevOverrides, prevWithLegacyCleared } =
+        migrateLegacyIfNeeded(prev);
       const prevPreset = resolveEffectiveMcpAppsCapabilities({
         profile: undefined,
         hostStyle: prev.hostStyle,
       });
-      const prevEffective = resolveEffectiveMcpAppsCapabilities({
-        profile: prev.mcpProfile,
-        hostStyle: prev.hostStyle,
-      });
-      const currentModes = prevEffective.availableDisplayModes;
+      // Use displayed effective modes as the starting point so the
+      // user's click toggles relative to what they saw (legacy-
+      // migrated when applicable), not relative to the bare preset.
+      const currentModes =
+        prevOverrides.availableDisplayModes ??
+        prevPreset.availableDisplayModes;
       let nextModesList = currentModes.includes(mode)
         ? currentModes.filter((m) => m !== mode)
         : [...currentModes, mode];
@@ -1302,15 +1403,19 @@ function McpAppsCapabilityMatrix({
       } else {
         nextOverrides.availableDisplayModes = nextModesList as DisplayMode[];
       }
-      return setMcpAppsOverridesOnDraft(prev, nextOverrides);
+      return setMcpAppsOverridesOnDraft(prevWithLegacyCleared, nextOverrides);
     });
   };
 
-  const overrideCount = overridesRecord
-    ? Object.keys(overridesRecord).length
+  const overrideCount = hasAnyOverride
+    ? Object.keys(effectiveOverridesForDisplay!).length
     : 0;
   const subline = hasAnyOverride
-    ? `${overrideCount} ${overrideCount === 1 ? "override" : "overrides"} active`
+    ? `${overrideCount} ${overrideCount === 1 ? "override" : "overrides"} active${
+        rawOverridesRecord === undefined && legacyOverride !== undefined
+          ? " (legacy)"
+          : ""
+      }`
     : "Matches host style preset";
 
   return (
@@ -1353,7 +1458,8 @@ function McpAppsCapabilityMatrix({
                 [{presetCapabilities.availableDisplayModes.join(", ")}]
               </span>
             </span>
-            {overridesRecord?.availableDisplayModes !== undefined ? (
+            {effectiveOverridesForDisplay?.availableDisplayModes !==
+            undefined ? (
               <span className="rounded bg-orange-500/15 px-1 py-px text-orange-600 dark:text-orange-300">
                 Overridden
               </span>
@@ -1392,7 +1498,8 @@ function McpAppsCapabilityMatrix({
             effective={Boolean(effectiveCapabilities[key])}
             presetValue={Boolean(presetCapabilities[key])}
             overridden={
-              overridesRecord !== undefined && key in overridesRecord
+              effectiveOverridesForDisplay !== undefined &&
+              key in effectiveOverridesForDisplay
             }
             onToggle={(next) => setBooleanOverride(key, next)}
           />
@@ -1430,7 +1537,8 @@ function McpAppsCapabilityMatrix({
               effective={Boolean(effectiveCapabilities[key])}
               presetValue={Boolean(presetCapabilities[key])}
               overridden={
-                overridesRecord !== undefined && key in overridesRecord
+                effectiveOverridesForDisplay !== undefined &&
+                key in effectiveOverridesForDisplay
               }
               onToggle={(next) => setBooleanOverride(key, next)}
             />

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
@@ -250,3 +250,101 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
     ).toEqual(["inline"]);
   });
 });
+
+describe("AppsExtensionTab — McpAppsCapabilityMatrix legacy-override migration", () => {
+  it("displays a legacy hostCapabilitiesOverride as a virtually-migrated matrix (Overridden badges reflect what the resolver advertises)", () => {
+    // Regression (Codex Bot on #2236): if the draft has legacy
+    // `hostCapabilitiesOverride` and no `mcpAppsOverrides`, the matrix
+    // UI must reflect the legacy values — otherwise the first toggle
+    // would write a sparse override relative to the bare preset, and
+    // the resolver would silently flip every other legacy-overridden
+    // dimension back to the preset.
+    const draft = emptyHostConfigInputV2({ hostStyle: "claude" });
+    // Legacy override stripped serverResources + logging (advertise
+    // neither). Matrix UI must reflect both as Overridden.
+    draft.hostCapabilitiesOverride = {
+      openLinks: {},
+      serverTools: {},
+      updateModelContext: { text: {} },
+      message: { text: {} },
+    };
+    render(
+      <AppsExtensionTab
+        draft={draft}
+        onDraftChange={() => {}}
+        attention={[]}
+      />,
+    );
+    // serverResources and logging are missing from the legacy
+    // override → migrated matrix sets them to false → "Overridden"
+    // badge present because Claude's preset has them true.
+    const serverResources = screen.getByTestId(
+      "mcp-apps-dimension-serverResources",
+    );
+    expect(within(serverResources).getByText("Overridden")).toBeInTheDocument();
+    const logging = screen.getByTestId("mcp-apps-dimension-logging");
+    expect(within(logging).getByText("Overridden")).toBeInTheDocument();
+    // Subline annotated as legacy so the user knows where the values
+    // came from.
+    expect(screen.getByText(/legacy/)).toBeInTheDocument();
+  });
+
+  it("migrates legacy → matrix on the first row toggle and clears the legacy field", async () => {
+    // The key write-side fix: when the user toggles a single row on a
+    // legacy-only draft, the migration runs first so the user's edit
+    // doesn't silently drop the other legacy-overridden dimensions.
+    // Post-edit the legacy field is cleared (matrix becomes the new
+    // source of truth) and `mcpAppsOverrides` reflects legacy +
+    // user's edit, not just user's edit.
+    const user = userEvent.setup();
+    const { draftRef } = renderMatrix({
+      hostStyle: "claude",
+      hostCapabilitiesOverride: {
+        openLinks: {},
+        serverTools: {},
+        // serverResources, logging, updateModelContext, message all
+        // stripped — legacy says "advertise none of those four".
+      },
+    });
+    // Sanity: legacy is set, matrix is absent.
+    expect(draftRef.current.hostCapabilitiesOverride).toBeDefined();
+    expect(
+      draftRef.current.mcpProfile?.apps?.mcpAppsOverrides,
+    ).toBeUndefined();
+    // User toggles a single sibling row (toolInputPartial).
+    const row = screen.getByTestId("mcp-apps-dimension-toolInputPartial");
+    await user.click(within(row).getByRole("switch"));
+    // Legacy cleared.
+    expect(draftRef.current.hostCapabilitiesOverride).toBeUndefined();
+    // Matrix now carries the migrated legacy PLUS the new edit. The
+    // other legacy-overridden dimensions are NOT silently lost.
+    const matrix = draftRef.current.mcpProfile?.apps?.mcpAppsOverrides;
+    expect(matrix).toMatchObject({
+      serverResources: false,
+      logging: false,
+      updateModelContext: false,
+      message: false,
+      toolInputPartial: false, // the user's edit
+    });
+  });
+
+  it("'Match host preset' clears both the matrix override AND the legacy hostCapabilitiesOverride", async () => {
+    // The chip's contract is "revert to preset". If we only cleared
+    // the matrix, the legacy path would silently keep the override
+    // alive — the matrix would say "Matches host style preset" while
+    // the resolver advertised the legacy shape.
+    const user = userEvent.setup();
+    const { draftRef } = renderMatrix({
+      hostStyle: "claude",
+      hostCapabilitiesOverride: {
+        openLinks: {},
+        serverTools: {},
+      },
+    });
+    await user.click(screen.getByRole("button", { name: /Match host preset/ }));
+    expect(draftRef.current.hostCapabilitiesOverride).toBeUndefined();
+    expect(
+      draftRef.current.mcpProfile?.apps?.mcpAppsOverrides,
+    ).toBeUndefined();
+  });
+});

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
@@ -105,6 +105,49 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
     expect(draftRef.current.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
   });
 
+  it("reverting the last matrix override returns the draft to its original profile state (no dirty empty envelope)", async () => {
+    // Regression: setMcpAppsOverridesOnDraft used to leave
+    // `{ profileVersion: 1, apps: {} }` behind after the last
+    // override was cleared. `hostConfigInputsEqual` treats that as
+    // distinct from `undefined`, so the draft stayed dirty while the
+    // matrix said "Matches host style preset". Toggling a row and
+    // toggling it back must round-trip the draft exactly.
+    const user = userEvent.setup();
+    const { draftRef } = renderMatrix();
+    expect(draftRef.current.mcpProfile).toBeUndefined();
+    const row = screen.getByTestId("mcp-apps-dimension-toolInputPartial");
+    const toggle = within(row).getByRole("switch");
+    await user.click(toggle); // off (override)
+    await user.click(toggle); // back on → matrix clean
+    // Profile must collapse back to undefined — no synthesized
+    // `{ profileVersion: 1, apps: {} }` left behind.
+    expect(draftRef.current.mcpProfile).toBeUndefined();
+  });
+
+  it("preserves sibling apps fields when clearing the last matrix override", async () => {
+    // Counter-test: the empty-collapse must NOT drop unrelated
+    // `apps.*` siblings. If the user has a `compatRuntime` block
+    // alongside, removing all matrix overrides leaves apps.{compat,
+    // sandbox, uiInitialize} intact and clears only mcpAppsOverrides.
+    const user = userEvent.setup();
+    const { draftRef } = renderMatrix({
+      mcpProfile: {
+        profileVersion: 1,
+        apps: {
+          compatRuntime: { openaiApps: false },
+          mcpAppsOverrides: { toolInputPartial: false },
+        },
+      },
+    });
+    const row = screen.getByTestId("mcp-apps-dimension-toolInputPartial");
+    const toggle = within(row).getByRole("switch");
+    await user.click(toggle); // back to preset → drop the override key
+    expect(draftRef.current.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
+    expect(draftRef.current.mcpProfile?.apps?.compatRuntime?.openaiApps).toBe(
+      false,
+    );
+  });
+
   it("'Overridden' badge appears on rows where the user has diverged from the preset", () => {
     const draft = emptyHostConfigInputV2({ hostStyle: "claude" });
     draft.mcpProfile = {

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
@@ -1,0 +1,209 @@
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// `vi` is used by the "'Match host preset' chip" test below; the rest
+// of the file uses the harness's stateful setDraft instead of a mock.
+void vi;
+import {
+  emptyHostConfigInputV2,
+  type HostConfigInputV2,
+} from "@/lib/client-config-v2";
+import { AppsExtensionTab } from "../AppsExtensionTab";
+
+/**
+ * Component-level coverage for the SEP-1865 `app.*` matrix UI added in
+ * the foundation series. The resolver, merge helper, and JSON round-
+ * trip are already exhaustively covered in
+ * `client-config-v2.test.ts` and `AppsExtensionTab.sandbox.test.ts`;
+ * here we only assert that clicks on the structured matrix produce the
+ * expected sparse-override edits on the draft, that the per-row
+ * "Overridden" badge tracks the override map, and that the
+ * "Match host preset" chip clears the matrix.
+ */
+/**
+ * Render `AppsExtensionTab` with a managed draft that re-renders on
+ * `onDraftChange`. The internal mutation must trigger a React re-render
+ * so the matrix UI sees override edits applied before the next click —
+ * a static draft would let stale state shadow the second user action.
+ */
+function renderMatrix(initial?: Partial<HostConfigInputV2>) {
+  const draftRef: { current: HostConfigInputV2 } = {
+    current: emptyHostConfigInputV2({ hostStyle: "claude", ...initial }),
+  };
+  function Harness({ initialDraft }: { initialDraft: HostConfigInputV2 }) {
+    const [draft, setDraft] = useState<HostConfigInputV2>(initialDraft);
+    draftRef.current = draft;
+    return (
+      <AppsExtensionTab
+        draft={draft}
+        onDraftChange={(updater) =>
+          setDraft((prev) => {
+            const next = updater(prev);
+            draftRef.current = next;
+            return next;
+          })
+        }
+        attention={[]}
+      />
+    );
+  }
+  const utils = render(<Harness initialDraft={draftRef.current} />);
+  return { draftRef, ...utils };
+}
+
+describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
+  it("renders the spec-bridge section with the SEP-1865 label", () => {
+    renderMatrix();
+    // Two-matrix architecture: window.openai and app.* are sibling
+    // sections in the same tab. The label disambiguates them.
+    expect(screen.getByText("app.*")).toBeInTheDocument();
+    expect(screen.getByText(/SEP-1865/)).toBeInTheDocument();
+  });
+
+  it("starts at 'Matches host style preset' subline when no override is set", () => {
+    renderMatrix();
+    expect(screen.getByText(/Matches host style preset/)).toBeInTheDocument();
+  });
+
+  it("renders the availableDisplayModes cluster with Claude's preset (all three modes)", () => {
+    renderMatrix();
+    // Claude advertises the FULL surface: inline + fullscreen + pip.
+    const cluster = screen
+      .getByText("availableDisplayModes")
+      .closest("div")!.parentElement!;
+    for (const mode of ["inline", "fullscreen", "pip"] as const) {
+      const button = within(cluster).getByRole("button", { name: mode });
+      // Selected modes use the elevated background class.
+      expect(button.className).toMatch(/bg-foreground/);
+    }
+  });
+
+  it("toggling a boolean dimension produces a sparse override on the draft", async () => {
+    const user = userEvent.setup();
+    const { draftRef } = renderMatrix();
+    // toolInputPartial is on by default in Claude's preset; toggling
+    // the switch should write `false` to mcpAppsOverrides.
+    const row = screen.getByTestId("mcp-apps-dimension-toolInputPartial");
+    const toggle = within(row).getByRole("switch");
+    await user.click(toggle);
+    expect(draftRef.current.mcpProfile?.apps?.mcpAppsOverrides).toEqual({
+      toolInputPartial: false,
+    });
+  });
+
+  it("toggling back to the preset value drops the override key (sparse on save)", async () => {
+    const user = userEvent.setup();
+    const { draftRef } = renderMatrix();
+    const row = screen.getByTestId("mcp-apps-dimension-toolInputPartial");
+    const toggle = within(row).getByRole("switch");
+    await user.click(toggle); // off (override)
+    await user.click(toggle); // back on (matches preset → drop key)
+    // Override block collapses to undefined (helper drops empty
+    // objects on the draft).
+    expect(draftRef.current.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
+  });
+
+  it("'Overridden' badge appears on rows where the user has diverged from the preset", () => {
+    const draft = emptyHostConfigInputV2({ hostStyle: "claude" });
+    draft.mcpProfile = {
+      profileVersion: 1,
+      apps: { mcpAppsOverrides: { logging: false } },
+    };
+    const onDraftChange = vi.fn();
+    render(
+      <AppsExtensionTab
+        draft={draft}
+        onDraftChange={onDraftChange}
+        attention={[]}
+      />,
+    );
+    const overriddenRow = screen.getByTestId("mcp-apps-dimension-logging");
+    expect(within(overriddenRow).getByText("Overridden")).toBeInTheDocument();
+    // Sibling row (no override) does NOT carry the badge.
+    const cleanRow = screen.getByTestId(
+      "mcp-apps-dimension-serverResources",
+    );
+    expect(within(cleanRow).queryByText("Overridden")).toBeNull();
+  });
+
+  it("'Match host preset' chip clears the entire matrix override", async () => {
+    const user = userEvent.setup();
+    const draft = emptyHostConfigInputV2({ hostStyle: "claude" });
+    draft.mcpProfile = {
+      profileVersion: 1,
+      apps: {
+        mcpAppsOverrides: { logging: false, serverResources: false },
+      },
+    };
+    const draftRef = { current: draft };
+    const onDraftChange = vi.fn(
+      (updater: (prev: HostConfigInputV2) => HostConfigInputV2) => {
+        draftRef.current = updater(draftRef.current);
+      },
+    );
+    render(
+      <AppsExtensionTab
+        draft={draft}
+        onDraftChange={onDraftChange}
+        attention={[]}
+      />,
+    );
+    const chip = screen.getByRole("button", { name: /Match host preset/ });
+    expect(chip).toBeEnabled();
+    await user.click(chip);
+    expect(draftRef.current.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
+  });
+
+  it("'Match host preset' chip is disabled when no override is set", () => {
+    renderMatrix();
+    const chip = screen.getByRole("button", { name: /Match host preset/ });
+    expect(chip).toBeDisabled();
+  });
+
+  it("the Advanced disclosure hides rare dimensions until expanded", async () => {
+    const user = userEvent.setup();
+    renderMatrix();
+    // Sandbox sub-fields live in Advanced — hidden by default.
+    expect(
+      screen.queryByTestId("mcp-apps-dimension-sandboxPermissions"),
+    ).toBeNull();
+    await user.click(screen.getByRole("button", { name: /Advanced/ }));
+    expect(
+      screen.getByTestId("mcp-apps-dimension-sandboxPermissions"),
+    ).toBeInTheDocument();
+  });
+
+  it("clicking a display mode in the cluster updates the allowlist on the draft", async () => {
+    const user = userEvent.setup();
+    const { draftRef } = renderMatrix();
+    // Claude's preset is [inline, fullscreen, pip]. Click "pip" to
+    // remove it → override should be [inline, fullscreen].
+    const cluster = screen
+      .getByText("availableDisplayModes")
+      .closest("div")!.parentElement!;
+    await user.click(within(cluster).getByRole("button", { name: "pip" }));
+    expect(
+      draftRef.current.mcpProfile?.apps?.mcpAppsOverrides
+        ?.availableDisplayModes,
+    ).toEqual(["inline", "fullscreen"]);
+  });
+
+  it("force-enables inline when the user unchecks the last enabled mode", async () => {
+    const user = userEvent.setup();
+    const { draftRef } = renderMatrix({ hostStyle: "copilot" });
+    // Copilot preset is already ["fullscreen"]; unchecking it should
+    // coerce to ["inline"] (matrix invariant — never empty).
+    const cluster = screen
+      .getByText("availableDisplayModes")
+      .closest("div")!.parentElement!;
+    await user.click(
+      within(cluster).getByRole("button", { name: "fullscreen" }),
+    );
+    expect(
+      draftRef.current.mcpProfile?.apps?.mcpAppsOverrides
+        ?.availableDisplayModes,
+    ).toEqual(["inline"]);
+  });
+});


### PR DESCRIPTION
## Summary

The clickable matrix editor for the SEP-1865 `app.*` spec bridge. Sits below the existing `window.openai` matrix in the Apps Extension tab as a sibling — two independent surfaces, never cross-gated. Closes the gap between the now-complete serialization layer (#2226, #2230, #2232, #2235) and the user-facing edit surface.

Until this PR, users had to hand-edit JSON to set `mcpAppsOverrides`. The matrix UI exposes every dimension as a toggle with per-row preset hints, an "Overridden" badge when the user has diverged, and a one-click "Match host preset" chip.

## Layout

- **`availableDisplayModes` cluster** — always visible. Multi-checkbox; the matrix invariant `length >= 1` is enforced in the UI by force-enabling `"inline"` when the user unchecks the last mode.
- **Main disclosure** — `toolInputPartial`, `toolCancelled`, `hostContextChanged`, `resourceTeardown`, `serverResources`, `logging`. The rows that vary across published host tables (Microsoft 365 Copilot's M365 reference).
- **Advanced disclosure** — `toolInfo`, `openLinks`, `serverTools`, `updateModelContext`, `message`, `sandbox.permissions`, `csp.frameDomains`, `csp.baseUriDomains`, `_meta.ui.prefersBorder`. Rarely vary, but surfaced so legacy `hostCapabilitiesOverride: {}` migrations are visible and unusual hosts can be modeled.
- **"Overridden" badge** on rows the user has diverged from the host style preset.
- **"Match host preset" chip** clears the entire matrix in one click; disabled when clean.

## Behavior

- Toggling a row produces a sparse override on `mcpProfile.apps.mcpAppsOverrides`.
- Toggling back to the preset value drops the override key (clean revert; sparse on save).
- Mode cluster: clicking a mode adds/removes it from the allowlist; the override array is sorted canonical (`inline` → `fullscreen` → `pip`) so equality checks against the preset don't false-negative on permutation.
- Round-trips with `appsToJson` / `applyJsonToDraft` so the matrix UI and the JSON editor below it stay in sync.

## Two-matrix architecture preserved

`window.openai` (shim) and `app.*` (spec bridge) are independent surfaces:
- Different resolvers: `resolveEffectiveCompatRuntime` vs `resolveEffectiveMcpAppsCapabilities`.
- Different storage: `mcpProfile.apps.compatRuntime.openaiAppsOverrides` vs `mcpProfile.apps.mcpAppsOverrides`.
- Toggling a row in one matrix never affects the other.

The Apps Extension tab now visually expresses this with the two matrices stacked, each with its own section label.

## Tests

11 new component-level tests in `AppsExtensionTab.mcpAppsMatrix.test.tsx`: section label, subline state, mode cluster, toggle → sparse override, toggle-back-to-preset → drop key, "Overridden" badge tracking, chip clear, chip disabled when clean, Advanced disclosure, mode cluster edits, force-enable-inline coercion.

**677/677 client tests pass** (`npx vitest run client/src/lib/__tests__/ client/src/lib/client-styles/__tests__/ client/src/components/chat-v2/thread/mcp-apps/__tests__/ client/src/components/clients/redesigned/`).

## Test plan

- [x] All resolver + UI tests pass (677/677)
- [x] `npx tsc -p client/tsconfig.json --noEmit` — no new errors in changed files
- [ ] Manual: open the Apps Extension tab on Claude → confirm both matrices render side-by-side, the `app.*` matrix shows "Matches host style preset" subline, and every row reads "Preset: true"
- [ ] Manual: toggle `serverResources` off on Claude → "Overridden" badge appears on that row, JSON editor below now shows `mcpAppsOverrides: { serverResources: false }`
- [ ] Manual: switch host to Copilot → matrix re-renders with Copilot's preset values (most notification gates off, modes = `["fullscreen"]`); no overrides shown
- [ ] Manual: click "Match host preset" with multiple overrides set → all rows revert simultaneously, chip disables

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it adds a new stateful editing surface that mutates `mcpProfile`/override precedence (including legacy override migration) and could impact config dirty-state and persisted capability advertisement if bugs slip through.
> 
> **Overview**
> Adds a second, independent matrix editor in `AppsExtensionTab` for the SEP-1865 `app.*` spec-bridge, allowing users to toggle per-dimension `mcpProfile.apps.mcpAppsOverrides` (including an `availableDisplayModes` allowlist with a non-empty invariant), see per-row preset hints and an **Overridden** badge, and clear all edits via **Match host preset**.
> 
> Updates draft-write behavior to keep overrides *sparse* and to collapse empty `mcpProfile/apps` envelopes (preventing “clean UI but dirty draft”), and introduces a first-edit migration path that treats legacy `hostCapabilitiesOverride` as a virtual matrix for display and converts/clears it on write so edits don’t silently drop legacy-overridden dimensions. Adds component tests covering toggles, override sparsity/reverts, clear-to-preset, advanced disclosure visibility, display-mode coercion, and legacy-migration behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c35d3bc4134052fd1892220f3804edfc98b3f32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->