### PR TITLE
feat(apps): matrix-gated notification emissions for SEP-1865 bridge

### DIFF
--- a/.changeset/mcp-apps-notification-gates.md
+++ b/.changeset/mcp-apps-notification-gates.md
@@ -1,0 +1,7 @@
+---
+"@mcpjam/inspector": minor
+---
+
+### `@mcpjam/inspector`
+- **Matrix-gated notification emissions (PR B of the foundation series)**: the MCP Apps spec-bridge matrix now actually suppresses runtime notification emissions on hosts that flip the matching row off. `bridge.sendToolInputPartial` and `bridge.sendToolCancelled` honor `mcpAppsOverrides.toolInputPartial` and `.toolCancelled` (in both `useToolInputStreaming.ts` and the renderer's `oncalltool` failure paths). `bridge.setHostContext` honors `mcpAppsOverrides.hostContextChanged` — Microsoft 365 Copilot doesn't deliver `host-context-changed` per its published Component-bridge table, so simulated Copilot hosts now match: the host context update is only applied at `ui/initialize` time and never emitted mid-session. Null matrix ref (initial render window) reads as "default on" so pre-matrix behavior survives every host the renderer hasn't classified yet.
+- **Resolver default-on for unknown hosts without override**: `resolveEffectiveMcpAppsCapabilities` now returns `MCP_APPS_FULL_SURFACE` when no host style is configured AND no override is set — preserves pre-matrix permissive defaults for callers that don't supply a host style (test renderers, edge cases during init). When an override IS present against an unknown host, the foundation PR's NO_CLAIMS fallback still applies so persisted opt-ins can't accidentally advertise near-full support.

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/useToolInputStreaming.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/useToolInputStreaming.test.ts
@@ -131,6 +131,7 @@ interface HookProps {
   toolErrorText: string | undefined;
   toolCallId: string;
   reinitCount: number;
+  mcpAppsCapabilitiesRef: React.RefObject<any>;
 }
 
 function createDefaultProps(
@@ -138,6 +139,10 @@ function createDefaultProps(
 ): HookProps {
   const bridgeRef = { current: bridge };
   const isReadyRef = { current: true };
+  // Default to null → "default on" per the hook's gate contract.
+  // Tests that want to exercise the gate flip mcpAppsCapabilitiesRef.current
+  // to a resolved matrix value with the relevant dimension off.
+  const mcpAppsCapabilitiesRef = { current: null };
   return {
     bridgeRef,
     isReady: true,
@@ -148,6 +153,7 @@ function createDefaultProps(
     toolErrorText: undefined,
     toolCallId: "call-1",
     reinitCount: 0,
+    mcpAppsCapabilitiesRef,
   };
 }
 
@@ -476,5 +482,121 @@ describe("useToolInputStreaming", () => {
     rerender();
 
     expect(bridge.sendToolCancelled).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("useToolInputStreaming — MCP Apps matrix notification gates", () => {
+  let bridge: ReturnType<typeof createMockBridge>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    bridge = createMockBridge();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Helper: build a resolved matrix with all dimensions on except the
+  // ones the test wants to flip off. Mirrors the inspector's
+  // MCP_APPS_FULL_SURFACE so tests stay self-contained.
+  function fullSurfaceMatrix(overrides: Record<string, unknown> = {}) {
+    return {
+      availableDisplayModes: ["inline", "fullscreen", "pip"],
+      toolInputPartial: true,
+      toolCancelled: true,
+      hostContextChanged: true,
+      resourceTeardown: true,
+      toolInfo: true,
+      openLinks: true,
+      serverTools: true,
+      serverResources: true,
+      logging: true,
+      updateModelContext: true,
+      message: true,
+      sandboxPermissions: true,
+      cspFrameDomains: true,
+      cspBaseUriDomains: true,
+      resourcePrefersBorder: true,
+      ...overrides,
+    };
+  }
+
+  it("suppresses bridge.sendToolInputPartial when matrix has toolInputPartial: false (simulates Copilot)", () => {
+    const props = createDefaultProps(bridge);
+    props.mcpAppsCapabilitiesRef = {
+      current: fullSurfaceMatrix({ toolInputPartial: false }),
+    };
+    props.toolState = "input-streaming";
+    props.toolInput = { code: "hello" };
+    renderHook(() => useToolInputStreaming(props));
+    // The streaming UX still progressed internally, but the wire
+    // notification was suppressed. Widget on this simulated host
+    // sees no `tool-input-partial` — same as real Copilot.
+    expect(bridge.sendToolInputPartial).not.toHaveBeenCalled();
+  });
+
+  it("emits bridge.sendToolInputPartial when matrix is null (default-on fallback)", () => {
+    // Null matrix ref → fail-open. During initial mount before the
+    // renderer's matrix resolver runs, notifications must still
+    // emit (matches pre-matrix behavior for any host).
+    const props = createDefaultProps(bridge);
+    props.mcpAppsCapabilitiesRef = { current: null };
+    props.toolState = "input-streaming";
+    props.toolInput = { code: "hello" };
+    renderHook(() => useToolInputStreaming(props));
+    expect(bridge.sendToolInputPartial).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits bridge.sendToolInputPartial when matrix.toolInputPartial: true (default ChatGPT/Claude surface)", () => {
+    const props = createDefaultProps(bridge);
+    props.mcpAppsCapabilitiesRef = { current: fullSurfaceMatrix() };
+    props.toolState = "input-streaming";
+    props.toolInput = { code: "hello" };
+    renderHook(() => useToolInputStreaming(props));
+    expect(bridge.sendToolInputPartial).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses bridge.sendToolCancelled on tool error when matrix has toolCancelled: false (simulates Copilot)", () => {
+    const props = createDefaultProps(bridge);
+    props.mcpAppsCapabilitiesRef = {
+      current: fullSurfaceMatrix({ toolCancelled: false }),
+    };
+    props.toolState = "output-error";
+    props.toolErrorText = "boom";
+    renderHook(() => useToolInputStreaming(props));
+    expect(bridge.sendToolCancelled).not.toHaveBeenCalled();
+  });
+
+  it("emits bridge.sendToolCancelled on tool error when matrix.toolCancelled: true", () => {
+    const props = createDefaultProps(bridge);
+    props.mcpAppsCapabilitiesRef = { current: fullSurfaceMatrix() };
+    props.toolState = "output-error";
+    props.toolErrorText = "boom";
+    renderHook(() => useToolInputStreaming(props));
+    expect(bridge.sendToolCancelled).toHaveBeenCalledWith({ reason: "boom" });
+  });
+
+  it("toolInputPartial gate and toolCancelled gate are independent (flipping one doesn't suppress the other)", () => {
+    // Two-matrix isolation defense at the runtime-gate level —
+    // each row gates exactly its own emission, no spurious
+    // coupling.
+    const props = createDefaultProps(bridge);
+    props.mcpAppsCapabilitiesRef = {
+      current: fullSurfaceMatrix({
+        toolInputPartial: false,
+        toolCancelled: true,
+      }),
+    };
+    props.toolState = "input-streaming";
+    props.toolInput = { code: "hello" };
+    const { rerender } = renderHook(() => useToolInputStreaming(props));
+    expect(bridge.sendToolInputPartial).not.toHaveBeenCalled();
+    // Now flip to error state with the same matrix → tool-cancelled
+    // must still fire because that row is on.
+    props.toolState = "output-error";
+    props.toolErrorText = "boom";
+    rerender();
+    expect(bridge.sendToolCancelled).toHaveBeenCalledWith({ reason: "boom" });
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -92,8 +92,10 @@ import {
 import {
   resolveEffectiveCompatRuntime,
   resolveEffectiveHostCapabilities,
+  resolveEffectiveMcpAppsCapabilities,
   resolveHostInfo,
 } from "@/lib/client-config-v2";
+import type { ResolvedMcpAppsCapabilities } from "@/lib/client-styles";
 
 // Injected by Vite at build time from package.json
 declare const __APP_VERSION__: string;
@@ -811,6 +813,15 @@ export function MCPAppsRenderer({
   // synchronously inside the effect body, so it has to be in scope here.
   const recordMountStore = useWidgetDebugStore((s) => s.recordMount);
 
+  // SEP-1865 MCP Apps spec-bridge matrix ref. Populated further down
+  // in the render (after `effectiveHostStyle` / `activeMcpProfile`
+  // resolve), but declared here so `useToolInputStreaming` below can
+  // read it without forward-reference issues. Null reads as "default
+  // on" — matches pre-matrix behavior during the brief initial-mount
+  // window before the matrix resolver runs.
+  const mcpAppsCapabilitiesRef =
+    useRef<ResolvedMcpAppsCapabilities | null>(null);
+
   const {
     canRenderStreamingInput,
     signalStreamingRender,
@@ -825,6 +836,7 @@ export function MCPAppsRenderer({
     toolErrorText,
     toolCallId,
     reinitCount,
+    mcpAppsCapabilitiesRef,
   });
   const hasWidgetHtml = widgetHtml !== null;
   const widgetHtmlLength = widgetHtml?.length ?? 0;
@@ -1431,6 +1443,35 @@ export function MCPAppsRenderer({
       }),
     [effectiveHostStyle, activeMcpProfile, hostCapabilitiesOverride],
   );
+  // SEP-1865 spec-bridge matrix resolved from the live profile +
+  // host style. Gates notification emissions (`tool-input-partial`,
+  // `tool-cancelled`, `host-context-changed`) so simulated hosts
+  // like Microsoft 365 Copilot match their published Component-
+  // bridge table. Sibling to `effectiveHostCapabilities` — the wire
+  // shape advertised in `ui/initialize` is derived from this matrix
+  // via `buildHostCapabilities`, but the matrix itself is what
+  // runtime notification gates read.
+  //
+  // INDEPENDENT from the OpenAI shim's `activeShimCapabilities`
+  // ref. Two-matrix architecture (see
+  // feedback_two_matrix_architecture memory): toggling a row on one
+  // matrix never reads the other.
+  //
+  // The ref is declared above (with initial `null`) so it's visible
+  // to `useToolInputStreaming` earlier in the render. We populate
+  // `.current` here — same one-step-behind-during-mount caveat the
+  // `liveOpenAiCompatCapabilitiesRef` pattern has, and the gate
+  // contract reads `null` as "default on" so the brief window emits
+  // notifications (matches pre-matrix behavior).
+  const effectiveMcpAppsCapabilities = useMemo(
+    () =>
+      resolveEffectiveMcpAppsCapabilities({
+        profile: activeMcpProfile,
+        hostStyle: effectiveHostStyle,
+      }),
+    [activeMcpProfile, effectiveHostStyle],
+  );
+  mcpAppsCapabilitiesRef.current = effectiveMcpAppsCapabilities;
   themeModeRef.current = resolvedTheme;
   const styleVariables = useMemo(
     () => hostStyleDefinition.mcp.resolveStyleVariables(resolvedTheme),
@@ -2058,6 +2099,20 @@ export function MCPAppsRenderer({
       }
 
       if (effectiveHostCapabilities.serverTools) {
+        // Matrix-gated `sendToolCancelled` for app-initiated tool
+        // calls failing in this handler. Microsoft 365 Copilot does
+        // not deliver `ui/notifications/tool-cancelled` per its
+        // published Component-bridge table; simulated Copilot hosts
+        // must not see the cancelled callback even when the
+        // underlying tool throws. The handler still THROWS so the
+        // AppBridge's request/response path reports an error to the
+        // calling widget — only the side-channel notification is
+        // suppressed.
+        const sendToolCancelledIfAllowed = (reason: string) => {
+          const matrix = mcpAppsCapabilitiesRef.current;
+          if (matrix !== null && matrix.toolCancelled === false) return;
+          bridge.sendToolCancelled({ reason });
+        };
         bridge.oncalltool = async ({ name, arguments: args }, _extra) => {
           // Check if tool is model-only (not callable by apps) per SEP-1865
           const calledToolMeta = toolsMetadataRef.current?.[name];
@@ -2065,13 +2120,13 @@ export function MCPAppsRenderer({
             const error = new Error(
               `Tool "${name}" is not callable by apps (visibility: model-only)`,
             );
-            bridge.sendToolCancelled({ reason: error.message });
+            sendToolCancelledIfAllowed(error.message);
             throw error;
           }
 
           if (!onCallToolRef.current) {
             const error = new Error("Tool calls not supported");
-            bridge.sendToolCancelled({ reason: error.message });
+            sendToolCancelledIfAllowed(error.message);
             throw error;
           }
 
@@ -2083,9 +2138,9 @@ export function MCPAppsRenderer({
             return result as CallToolResult;
           } catch (error) {
             // SEP-1865: Send tool-cancelled for failed app-initiated tool calls
-            bridge.sendToolCancelled({
-              reason: error instanceof Error ? error.message : String(error),
-            });
+            sendToolCancelledIfAllowed(
+              error instanceof Error ? error.message : String(error),
+            );
             throw error;
           }
         };
@@ -2411,6 +2466,22 @@ export function MCPAppsRenderer({
   useEffect(() => {
     const bridge = bridgeRef.current;
     if (!bridge || !isReady) return;
+    // `bridge.setHostContext` updates the AppBridge's cached
+    // `_hostContext` AND emits `ui/notifications/host-context-changed`
+    // to the View. Matrix gate: Microsoft 365 Copilot does not
+    // deliver this notification per its published Component-bridge
+    // table (theme / displayMode updates are one-shot at
+    // `ui/initialize` time on that host). Null matrix → default on.
+    //
+    // We still skip the call entirely when gated rather than only
+    // suppressing the wire notification — the bridge's internal
+    // cache also tracks `_hostContext`, but on Copilot-style hosts
+    // the spec says it doesn't update mid-session, so keeping the
+    // cache frozen matches the simulated host's behavior. (If a
+    // future host wants the cache to update without emitting the
+    // notification, we'll split this gate.)
+    const matrix = mcpAppsCapabilitiesRef.current;
+    if (matrix !== null && matrix.hostContextChanged === false) return;
     bridge.setHostContext(hostContext);
   }, [hostContext, isReady]);
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/useToolInputStreaming.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/useToolInputStreaming.ts
@@ -17,6 +17,7 @@ import {
 } from "react";
 import type { AppBridge } from "@modelcontextprotocol/ext-apps/app-bridge";
 import type { CallToolResult } from "@modelcontextprotocol/client";
+import type { ResolvedMcpAppsCapabilities } from "@/lib/client-styles";
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -148,6 +149,25 @@ export interface UseToolInputStreamingParams {
   toolCallId: string;
   /** Incremented when the guest re-initializes (e.g. SDK app after openai-compat shim) */
   reinitCount: number;
+  /**
+   * Resolved SEP-1865 MCP Apps spec-bridge matrix. Gates the
+   * notifications this hook emits to the View:
+   *   - `toolInputPartial: false` → suppress
+   *     `bridge.sendToolInputPartial` (Microsoft 365 Copilot does
+   *     not deliver this notification — widgets running under that
+   *     simulated surface must not see partials).
+   *   - `toolCancelled: false` → suppress `bridge.sendToolCancelled`
+   *     (Copilot does not deliver this either).
+   *
+   * Passed as a ref so the hook reads the latest resolved value
+   * without rebuilding the effect closures on every host-style /
+   * profile change. Null while the renderer is still resolving the
+   * matrix (e.g. before host context is wired) — null reads as
+   * "default on" so the inspector keeps emitting notifications by
+   * default, matching the pre-matrix behavior for any host the
+   * renderer hasn't classified yet.
+   */
+  mcpAppsCapabilitiesRef: React.RefObject<ResolvedMcpAppsCapabilities | null>;
 }
 
 export interface UseToolInputStreamingReturn {
@@ -170,6 +190,7 @@ export function useToolInputStreaming({
   toolErrorText,
   toolCallId,
   reinitCount,
+  mcpAppsCapabilitiesRef,
 }: UseToolInputStreamingParams): UseToolInputStreamingReturn {
   // ── Internal refs ────────────────────────────────────────────────────────
 
@@ -305,6 +326,18 @@ export function useToolInputStreaming({
       lastToolInputPartialSentAtRef.current = Date.now();
       setHasDeliveredStreamingInput(true);
       setStreamingRenderSignaled(true);
+      // Matrix gate: SEP-1865 hosts that don't deliver
+      // `ui/notifications/tool-input-partial` (notably Microsoft 365
+      // Copilot per its published Component-bridge table) flip this
+      // dimension off in the matrix. Null ref → default on (matches
+      // pre-matrix behavior for any host the renderer hasn't
+      // classified yet). The streaming signature / streaming-render
+      // gating above still fires regardless so the inspector's
+      // internal streaming UX (which mirrors the bridge
+      // notification cadence) doesn't go silent on Copilot-style
+      // hosts — it's only the wire emission that's suppressed.
+      const matrix = mcpAppsCapabilitiesRef.current;
+      if (matrix !== null && matrix.toolInputPartial === false) return;
       Promise.resolve(
         bridge.sendToolInputPartial({ arguments: pending }),
       ).catch(() => {});
@@ -405,7 +438,14 @@ export function useToolInputStreaming({
     if (lastToolErrorRef.current === errorMessage) return;
     lastToolErrorRef.current = errorMessage;
 
-    // SEP-1865: Send tool-cancelled for errors instead of tool-result with isError
+    // SEP-1865: Send tool-cancelled for errors instead of tool-result
+    // with isError. Matrix gate: Microsoft 365 Copilot does not
+    // deliver this notification per its published Component-bridge
+    // table; widgets running under that simulated surface must not
+    // see a cancelled callback. Null matrix ref → default on (same
+    // fail-open contract as the partial-input gate above).
+    const matrix = mcpAppsCapabilitiesRef.current;
+    if (matrix !== null && matrix.toolCancelled === false) return;
     bridge.sendToolCancelled({ reason: errorMessage });
   }, [
     isReady,
@@ -415,6 +455,7 @@ export function useToolInputStreaming({
     toolState,
     bridgeRef,
     reinitCount,
+    mcpAppsCapabilitiesRef,
   ]);
 
   // 8. Reset on toolCallId change. Do this before paint so a recycled renderer

--- a/mcpjam-inspector/client/src/lib/__tests__/client-config-v2.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/client-config-v2.test.ts
@@ -384,10 +384,10 @@ describe("resolveEffectiveMcpAppsCapabilities", () => {
     expect(resolved.serverTools).toBe(true);
   });
 
-  it("falls back to NO_CLAIMS for unknown host styles (not FULL_SURFACE)", () => {
+  it("falls back to NO_CLAIMS for unknown host styles WHEN an override is present (so persisted opt-ins can't accidentally advertise near-full support)", () => {
     // Regression: a persisted mcpAppsOverrides against a removed host
-    // must NOT advertise near-full support. Mirrors getHostCapabilities-
-    // ForStyle's honest "no claims" baseline.
+    // must NOT advertise near-full support. The override only turns
+    // ON what the user asked for, against a no-claims baseline.
     const resolved = resolveEffectiveMcpAppsCapabilities({
       hostStyle: "does-not-exist",
       profile: {
@@ -397,10 +397,29 @@ describe("resolveEffectiveMcpAppsCapabilities", () => {
     });
     expect(resolved.openLinks).toBe(false);
     expect(resolved.serverTools).toBe(false);
-    // The override only turns ON what the user asked for, against a
-    // no-claims baseline.
     expect(resolved.serverResources).toBe(true);
     expect(resolved.logging).toBe(false);
+  });
+
+  it("falls back to FULL_SURFACE for unknown host styles WHEN no override is present (preserves pre-matrix runtime defaults)", () => {
+    // Counter-test for the gate above. Notification gates (added in
+    // PR B) suppress emissions when their matrix row is `false`. If
+    // the resolver returned NO_CLAIMS for "no host style + no
+    // override", any caller that doesn't supply a host style (test
+    // renderers, edge cases during init) would suddenly suppress
+    // every notification — a runtime regression the matrix
+    // shouldn't introduce when there's literally nothing to honor.
+    // The opt-in signal is the override; without it, fall back to
+    // permissive defaults.
+    const resolved = resolveEffectiveMcpAppsCapabilities({
+      hostStyle: "does-not-exist",
+      profile: undefined,
+    });
+    expect(resolved.toolInputPartial).toBe(true);
+    expect(resolved.toolCancelled).toBe(true);
+    expect(resolved.hostContextChanged).toBe(true);
+    expect(resolved.openLinks).toBe(true);
+    expect(resolved.serverTools).toBe(true);
   });
 });
 

--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -22,6 +22,7 @@ import {
   findHostStyle,
   getCompatRuntimeForStyle,
   getHostCapabilitiesForStyle,
+  MCP_APPS_FULL_SURFACE,
   MCP_APPS_NO_CLAIMS_SURFACE,
   OPENAI_APPS_FULL_SURFACE,
 } from "@/lib/client-styles";
@@ -710,18 +711,32 @@ export function resolveEffectiveMcpAppsCapabilities(args: {
   profile: HostConfigMcpProfileV1 | undefined;
   hostStyle: ChatboxHostStyle | string | null | undefined;
 }): ResolvedMcpAppsCapabilities {
-  // Unknown / unrecognized host styles fall back to NO_CLAIMS, not the
-  // full surface — matches `getHostCapabilitiesForStyle`'s honest "no
-  // claims" baseline (`registry.ts:SPEC_DEFAULT_HOST_CAPABILITIES`) so a
-  // persisted `mcpAppsOverrides` against a removed host can't silently
-  // advertise near-full capability support.
+  const hostStylePreset = findHostStyle(args.hostStyle)?.mcp
+    .mcpAppsCapabilities;
+  const override = args.profile?.apps?.mcpAppsOverrides;
+  // Unknown / unrecognized host style fallback depends on whether the
+  // user has explicitly opted in via override:
+  //
+  // - **Override present + host style unknown** → start from
+  //   NO_CLAIMS so the user's sparse override only enables rows
+  //   they explicitly set. A persisted override against a removed
+  //   host can't silently advertise near-full support — matches
+  //   `getHostCapabilitiesForStyle`'s honest "no claims" baseline
+  //   (`registry.ts:SPEC_DEFAULT_HOST_CAPABILITIES`).
+  //
+  // - **No override + host style unknown** → fall back to
+  //   FULL_SURFACE so runtime behavior matches pre-matrix
+  //   permissive defaults. Without this, callers that don't supply
+  //   a host style (test renderers, edge cases during init) would
+  //   suddenly suppress every notification — a runtime regression
+  //   the matrix shouldn't introduce when there's literally nothing
+  //   to honor.
   const preset =
-    findHostStyle(args.hostStyle)?.mcp.mcpAppsCapabilities ??
-    MCP_APPS_NO_CLAIMS_SURFACE;
-  return mergeMcpAppsCapabilities(
-    preset,
-    args.profile?.apps?.mcpAppsOverrides,
-  );
+    hostStylePreset ??
+    (override !== undefined
+      ? MCP_APPS_NO_CLAIMS_SURFACE
+      : MCP_APPS_FULL_SURFACE);
+  return mergeMcpAppsCapabilities(preset, override);
 }
 
 /**


### PR DESCRIPTION
## Summary

**PR B of the foundation series.** The matrix UI lets users disable spec-bridge dimensions (#2236); this PR makes those disable bits actually suppress the corresponding runtime notification emissions. Until this commit, toggling `toolInputPartial: false` on a Copilot-preset host had no effect — the host kept emitting partials to the View regardless of the matrix state.

## Gates wired

1. **`bridge.sendToolInputPartial`** (`useToolInputStreaming.ts`) → `matrix.toolInputPartial`. Streaming UX (signature dedup, render reveal) still progresses internally; only the wire emission is suppressed. Microsoft 365 Copilot doesn't deliver this notification per its published Component-bridge table.

2. **`bridge.sendToolCancelled`** (both `useToolInputStreaming.ts` and the renderer's `oncalltool` failure paths) → `matrix.toolCancelled`. Bridge handler still throws so the request/response error path reports back to the calling widget — only the side-channel notification is suppressed.

3. **`bridge.setHostContext`** (renderer) → `matrix.hostContextChanged`. On Copilot-style hosts the spec says host context doesn't update mid-session, so the AppBridge's `_hostContext` cache stays frozen at `ui/initialize`-time values. If a future host wants the cache to update without emitting the notification, we'll split this gate.

## Plumbing

New `mcpAppsCapabilitiesRef` ref declared early in `mcp-apps-renderer.tsx` (initial `null`), populated once `effectiveMcpAppsCapabilities` resolves further down in the render. Threaded into `useToolInputStreaming` so the hook reads the latest resolved matrix without rebuilding its effect closures on every profile change. Null reads as **"default on"** — matches pre-matrix behavior during the brief initial-mount window before the resolver runs.

## Resolver fix

The foundation PR's NO_CLAIMS fallback for unknown host styles was too aggressive for runtime gates. When no host style is configured AND no override is set, the resolver now falls back to `MCP_APPS_FULL_SURFACE` (preserving pre-matrix permissive defaults). NO_CLAIMS still applies when an override IS present against an unknown host (the foundation PR's actual concern — persisted opt-ins shouldn't accidentally advertise near-full support).

This was caught by existing renderer tests at `mcp-apps-renderer.test.tsx` that don't wrap in a host style provider — they would have been silently broken by the gates. Counter-test added.

## Two-matrix architecture preserved

Gates read only the MCP Apps matrix ref, never the OpenAI shim's `liveOpenAiCompatCapabilitiesRef`. Cross-matrix isolation test from #2238 catches accidental cross-wiring at PR review time.

## Tests

- **6 new in `useToolInputStreaming.test.ts`**: gate-on suppresses `toolInputPartial` / `toolCancelled`, default-on emits, two-row independence.
- **1 updated + 1 new in `client-config-v2.test.ts`**: resolver fallback split (NO_CLAIMS with override, FULL_SURFACE without).
- **693/693 client tests pass**.
- TypeScript clean for changed files.

## End-to-end

With this PR + the backend canonicalizer companion (`mcpjam-backend` #324 — already merged), the full matrix UI series is functional end-to-end for advertisement AND notification emission:
- Inspector matrix UI edits persist through Convex.
- Live notification emissions honor the resolved matrix.
- Simulated Copilot widgets see the M365-published subset both in advertisement (`HostCapabilities`) AND in the notifications they actually receive.

Remaining PR C/D work in the original plan covers: HostContext field trimming, display-mode clamping in `requestDisplayMode`, sandbox resource-meta gating. Those are the smaller behavioral gates and can land independently.

## Test plan

- [x] `npx vitest run client/src/lib/__tests__/ client/src/lib/client-styles/__tests__/ client/src/components/chat-v2/thread/mcp-apps/__tests__/ client/src/components/clients/redesigned/` — 693/693 pass
- [x] `npx tsc -p client/tsconfig.json --noEmit` — no new errors in changed files
- [ ] Manual: open a streaming-tool widget on the `copilot` host preset; toggle `toolInputPartial` off (it's already off by Copilot's default matrix); confirm the widget sees no `tool-input-partial` notification
- [ ] Manual: switch the same widget to the `claude` preset; confirm partials resume (Claude's matrix has `toolInputPartial: true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime behavior of MCP Apps bridge notifications and host-context updates based on the resolved capability matrix, which can affect widget/host interactions across different simulated host presets. Risk is mitigated by fail-open `null` defaults and added unit tests covering gated vs ungated paths and resolver fallbacks.
> 
> **Overview**
> Implements **matrix-gated MCP Apps runtime notifications** so turning off a spec-bridge dimension actually suppresses the corresponding emissions.
> 
> `useToolInputStreaming` now reads a new `mcpAppsCapabilitiesRef` and conditionally suppresses `bridge.sendToolInputPartial` and `bridge.sendToolCancelled` when `toolInputPartial` / `toolCancelled` are `false` (while keeping internal streaming UX state progression). `mcp-apps-renderer` resolves `effectiveMcpAppsCapabilities` via `resolveEffectiveMcpAppsCapabilities`, threads it into the hook, gates `sendToolCancelled` in `oncalltool` error paths, and skips `bridge.setHostContext` when `hostContextChanged` is `false`.
> 
> Updates `resolveEffectiveMcpAppsCapabilities` to fall back to `MCP_APPS_FULL_SURFACE` for unknown host styles *only when no override is present* (preserving pre-matrix permissive defaults), while retaining `NO_CLAIMS` fallback for unknown hosts when an override exists. Adds focused tests for the new gates and the resolver fallback split, plus a changeset bump for `@mcpjam/inspector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb64968b7e1cd65d4234236ab0872edaae9521c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->