### PR TITLE
feat(apps): matrix-gate HostContext.toolInfo and availableDisplayModes

### DIFF
--- a/.changeset/mcp-apps-advertisement-gates.md
+++ b/.changeset/mcp-apps-advertisement-gates.md
@@ -1,0 +1,6 @@
+---
+"@mcpjam/inspector": minor
+---
+
+### `@mcpjam/inspector`
+- **HostContext advertisement gates (PR C of the foundation series)**: the MCP Apps spec-bridge matrix now also gates the `HostContext` payload advertised in `ui/initialize`. (1) `HostContext.toolInfo` is omitted entirely when `matrix.toolInfo === false` — Microsoft 365 Copilot doesn't deliver `app.getHostContext()?.toolInfo` per its published Component-bridge table, so simulated Copilot widgets now see `undefined` matching real Copilot. (2) `HostContext.availableDisplayModes` is intersected with `matrix.availableDisplayModes` — Copilot's allowlist becomes `["fullscreen"]` instead of the inspector's permissive `["inline", "fullscreen", "pip"]` default. When the intersection would be empty (configured asks for modes the simulated host doesn't advertise), falls back to the matrix value alone so the widget never sees an unrenderable empty array (matrix invariant `length >= 1`). The existing `bridge.onrequestdisplaymode` clamp at the renderer already honors `HostContext.availableDisplayModes`, so this PR carries the matrix value through to the place that already enforces it. 4 new renderer tests cover Claude full-surface + Copilot subset for both fields.

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -538,6 +538,36 @@ describe("MCPAppsRenderer tool input streaming", () => {
     ]);
   });
 
+  it("clamps HostContext.displayMode to the matrix allowlist (Copilot in pip parent state coerces to fullscreen)", async () => {
+    // Regression: previously the matrix-clamped allowlist was only
+    // written into `HostContext.availableDisplayModes`, but
+    // `effectiveDisplayMode` was still computed against the
+    // playground/configured allowlist alone. A Copilot host could
+    // initialize or remain in `pip` if the parent's display state
+    // was sticky `"pip"` from a previous widget, while advertising
+    // `availableDisplayModes: ["fullscreen"]` — an inconsistent
+    // HostContext. Fix clamps the displayMode against the matrix
+    // too.
+    render(
+      <ChatboxHostStyleProvider value="copilot">
+        <MCPAppsRenderer
+          {...baseProps}
+          displayMode="pip"
+          pipWidgetId="call-1"
+        />
+      </ChatboxHostStyleProvider>,
+    );
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+    const hostContext = appBridgeArgsRef.current?.options?.hostContext as
+      | Record<string, unknown>
+      | undefined;
+    // Matrix-clamped: only fullscreen is allowed, so pip coerces.
+    expect(hostContext?.availableDisplayModes).toEqual(["fullscreen"]);
+    expect(hostContext?.displayMode).toBe("fullscreen");
+  });
+
   it("does not block pure MCP Apps from booting while ChatGPT compat is enabled", async () => {
     render(
       <ChatboxHostStyleProvider value="chatgpt">

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -463,6 +463,81 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(modalCaps).not.toHaveProperty("logging");
   });
 
+  it("includes HostContext.toolInfo when the matrix has toolInfo: true (Claude default)", async () => {
+    render(
+      <ChatboxHostStyleProvider value="claude">
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostStyleProvider>,
+    );
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+    const hostContext = appBridgeArgsRef.current?.options?.hostContext as
+      | Record<string, unknown>
+      | undefined;
+    expect(hostContext).toHaveProperty("toolInfo");
+    expect((hostContext?.toolInfo as { tool: { name: string } }).tool.name).toBe(
+      "test-tool",
+    );
+  });
+
+  it("omits HostContext.toolInfo entirely when the matrix has toolInfo: false (Copilot)", async () => {
+    // Microsoft 365 Copilot doesn't deliver `app.getHostContext()?.toolInfo`
+    // per its published Component-bridge table. A widget that probes
+    // for that field must see undefined — same as real Copilot.
+    render(
+      <ChatboxHostStyleProvider value="copilot">
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostStyleProvider>,
+    );
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+    const hostContext = appBridgeArgsRef.current?.options?.hostContext as
+      | Record<string, unknown>
+      | undefined;
+    expect(hostContext).not.toHaveProperty("toolInfo");
+  });
+
+  it("advertises matrix-clamped HostContext.availableDisplayModes (Copilot: ['fullscreen'] only)", async () => {
+    // Copilot's published Component-bridge table says
+    // requestDisplayMode is fullscreen-only. The matrix's
+    // availableDisplayModes is ["fullscreen"]; the host must
+    // advertise exactly that, not the inspector's permissive
+    // default of all three.
+    render(
+      <ChatboxHostStyleProvider value="copilot">
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostStyleProvider>,
+    );
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+    const hostContext = appBridgeArgsRef.current?.options?.hostContext as
+      | Record<string, unknown>
+      | undefined;
+    expect(hostContext?.availableDisplayModes).toEqual(["fullscreen"]);
+  });
+
+  it("advertises all three modes on Claude (full surface matrix)", async () => {
+    render(
+      <ChatboxHostStyleProvider value="claude">
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostStyleProvider>,
+    );
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+    const hostContext = appBridgeArgsRef.current?.options?.hostContext as
+      | Record<string, unknown>
+      | undefined;
+    expect(hostContext?.availableDisplayModes).toEqual([
+      "inline",
+      "fullscreen",
+      "pip",
+    ]);
+  });
+
   it("does not block pure MCP Apps from booting while ChatGPT compat is enabled", async () => {
     render(
       <ChatboxHostStyleProvider value="chatgpt">

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -255,8 +255,10 @@ import {
   ChatboxHostThemeProvider,
 } from "@/contexts/chatbox-client-style-context";
 import { ChatboxHostCapabilitiesOverrideProvider } from "@/contexts/chatbox-client-capabilities-override-context";
+import { ActiveMcpProfileProvider } from "@/contexts/active-mcp-profile-context";
 import { WidgetSurfaceProvider } from "@/contexts/widget-surface-context";
 import type { McpUiHostCapabilities } from "@modelcontextprotocol/ext-apps/app-bridge";
+import type { HostConfigMcpProfileV1 } from "@/lib/client-config-v2";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 const baseProps = {
@@ -499,6 +501,28 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(hostContext).not.toHaveProperty("toolInfo");
   });
 
+  it("strips inherited HostContext.toolInfo when the matrix has toolInfo: false", async () => {
+    mockHostContextStoreState.draftHostContext = {
+      toolInfo: {
+        id: "draft-call",
+        tool: { name: "draft-tool" },
+      },
+    };
+
+    render(
+      <ChatboxHostStyleProvider value="copilot">
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostStyleProvider>,
+    );
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+    const hostContext = appBridgeArgsRef.current?.options?.hostContext as
+      | Record<string, unknown>
+      | undefined;
+    expect(hostContext).not.toHaveProperty("toolInfo");
+  });
+
   it("advertises matrix-clamped HostContext.availableDisplayModes (Copilot: ['fullscreen'] only)", async () => {
     // Copilot's published Component-bridge table says
     // requestDisplayMode is fullscreen-only. The matrix's
@@ -566,6 +590,40 @@ describe("MCPAppsRenderer tool input streaming", () => {
     // Matrix-clamped: only fullscreen is allowed, so pip coerces.
     expect(hostContext?.availableDisplayModes).toEqual(["fullscreen"]);
     expect(hostContext?.displayMode).toBe("fullscreen");
+  });
+
+  it("keeps HostContext.displayMode inside the advertised intersection for custom display-mode overrides", async () => {
+    const profile: HostConfigMcpProfileV1 = {
+      profileVersion: 1,
+      apps: {
+        mcpAppsOverrides: {
+          availableDisplayModes: ["inline", "pip"],
+        },
+      },
+    };
+    mockHostContextStoreState.draftHostContext = {
+      availableDisplayModes: ["fullscreen", "pip"],
+    };
+
+    render(
+      <ActiveMcpProfileProvider value={profile}>
+        <ChatboxHostStyleProvider value="claude">
+          <MCPAppsRenderer
+            {...baseProps}
+            displayMode="fullscreen"
+            fullscreenWidgetId="call-1"
+          />
+        </ChatboxHostStyleProvider>
+      </ActiveMcpProfileProvider>,
+    );
+    await vi.waitFor(() => {
+      expect(mockBridge.connect).toHaveBeenCalled();
+    });
+    const hostContext = appBridgeArgsRef.current?.options?.hostContext as
+      | Record<string, unknown>
+      | undefined;
+    expect(hostContext?.availableDisplayModes).toEqual(["pip"]);
+    expect(hostContext?.displayMode).toBe("pip");
   });
 
   it("does not block pure MCP Apps from booting while ChatGPT compat is enabled", async () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -507,6 +507,33 @@ export function MCPAppsRenderer({
     () => extractHostDisplayModes(draftHostContext),
     [draftHostContext],
   );
+  // Resolve `effectiveHostStyle` early (it's a 3-way ternary on values
+  // already available above) so the SEP-1865 matrix can be computed
+  // before the display-mode clamp at `effectiveDisplayMode` below. The
+  // duplicate-looking `effectiveHostStyle = ...` further down (around
+  // the original `hostStyleDefinition`) reads the same value; both
+  // assignments produce identical strings because the dependencies are
+  // identical, so the bridge handshake / sandbox composition see the
+  // same host style id.
+  //
+  // Matrix-resolved `availableDisplayModes` is what we advertise in
+  // `HostContext.availableDisplayModes` AND what we clamp the
+  // current/initial `effectiveDisplayMode` against. Without this
+  // earlier clamp, a Copilot-preset host could initialize in (or
+  // remain in) `pip` because the parent's `displayMode === "pip"`,
+  // while advertising `availableDisplayModes: ["fullscreen"]` —
+  // the View would see inconsistent HostContext.
+  const earlyEffectiveHostStyle = isPlaygroundActive
+    ? sharedHostStyle
+    : chatboxHostStyle;
+  const earlyEffectiveMcpAppsCapabilities = useMemo(
+    () =>
+      resolveEffectiveMcpAppsCapabilities({
+        profile: activeMcpProfile,
+        hostStyle: earlyEffectiveHostStyle,
+      }),
+    [activeMcpProfile, earlyEffectiveHostStyle],
+  );
 
   // Get device capabilities from playground store (SEP-1865)
   const playgroundCapabilities = useUIPlaygroundStore((s) => s.capabilities);
@@ -584,14 +611,28 @@ export function MCPAppsRenderer({
     if (displayMode === "pip" && pipWidgetId === toolCallId) return "pip";
     return "inline";
   }, [displayMode, fullscreenWidgetId, isControlled, pipWidgetId, toolCallId]);
-  const effectiveDisplayMode = useMemo<DisplayMode>(
-    () =>
-      clampDisplayModeToAvailableModes(
-        requestedDisplayMode,
-        configuredAvailableDisplayModes,
-      ),
-    [configuredAvailableDisplayModes, requestedDisplayMode],
-  );
+  // Clamp the requested display mode against BOTH the playground/
+  // configured allowlist AND the matrix allowlist. A Copilot host
+  // initializing in `pip` (parent's `displayMode` is sticky from a
+  // previous widget) must coerce down to `fullscreen` because the
+  // matrix's `availableDisplayModes` is `["fullscreen"]` — otherwise
+  // `HostContext.displayMode` would say "pip" while
+  // `HostContext.availableDisplayModes` advertises only fullscreen,
+  // an inconsistent payload.
+  const effectiveDisplayMode = useMemo<DisplayMode>(() => {
+    const configClamp = clampDisplayModeToAvailableModes(
+      requestedDisplayMode,
+      configuredAvailableDisplayModes,
+    );
+    return clampDisplayModeToAvailableModes(
+      configClamp,
+      earlyEffectiveMcpAppsCapabilities.availableDisplayModes,
+    );
+  }, [
+    configuredAvailableDisplayModes,
+    requestedDisplayMode,
+    earlyEffectiveMcpAppsCapabilities.availableDisplayModes,
+  ]);
   const setDisplayMode = useCallback(
     (mode: DisplayMode) => {
       if (isControlled) {
@@ -1463,14 +1504,12 @@ export function MCPAppsRenderer({
   // `liveOpenAiCompatCapabilitiesRef` pattern has, and the gate
   // contract reads `null` as "default on" so the brief window emits
   // notifications (matches pre-matrix behavior).
-  const effectiveMcpAppsCapabilities = useMemo(
-    () =>
-      resolveEffectiveMcpAppsCapabilities({
-        profile: activeMcpProfile,
-        hostStyle: effectiveHostStyle,
-      }),
-    [activeMcpProfile, effectiveHostStyle],
-  );
+  //
+  // The matrix itself is computed earlier in the render
+  // (`earlyEffectiveMcpAppsCapabilities` near the display-mode
+  // resolution) so the `effectiveDisplayMode` clamp can use it. We
+  // alias the same value here for downstream consumers.
+  const effectiveMcpAppsCapabilities = earlyEffectiveMcpAppsCapabilities;
   mcpAppsCapabilitiesRef.current = effectiveMcpAppsCapabilities;
   themeModeRef.current = resolvedTheme;
   const styleVariables = useMemo(

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1519,12 +1519,47 @@ export function MCPAppsRenderer({
 
   // containerDimensions (maxWidth/maxHeight) was previously sent here but
   // removed — width is now fully host-controlled.
-  const hostContext = useMemo<McpUiHostContext>(
-    () => ({
+  //
+  // Matrix-gated HostContext fields (PR C of the foundation series):
+  //
+  // - `availableDisplayModes`: intersection of the matrix's allowed
+  //   modes (`matrix.availableDisplayModes`) with whatever the
+  //   playground / draft host context configures. Both constraints
+  //   apply — the matrix says "what the simulated host's capability
+  //   advertises," the configured list says "what the user further
+  //   narrowed in the playground." If the intersection would be
+  //   empty (configured asks for modes the simulated host doesn't
+  //   advertise), fall back to the matrix value alone so the widget
+  //   still gets a usable allowlist instead of an unrenderable empty
+  //   array. Matches the matrix invariant (`length >= 1`).
+  //
+  // - `toolInfo`: omitted entirely when `matrix.toolInfo === false`
+  //   (Microsoft 365 Copilot doesn't deliver this HostContext field
+  //   per its published Component-bridge table). A widget that
+  //   probes `app.getHostContext()?.toolInfo` on a simulated Copilot
+  //   host now correctly sees undefined — same as real Copilot.
+  const effectiveAvailableDisplayModes = useMemo(() => {
+    const matrixModes = effectiveMcpAppsCapabilities.availableDisplayModes;
+    if (
+      configuredAvailableDisplayModes === undefined ||
+      configuredAvailableDisplayModes.length === 0
+    ) {
+      return matrixModes;
+    }
+    const intersection = matrixModes.filter((m) =>
+      configuredAvailableDisplayModes.includes(m as DisplayMode),
+    );
+    return intersection.length > 0 ? intersection : matrixModes;
+  }, [
+    effectiveMcpAppsCapabilities.availableDisplayModes,
+    configuredAvailableDisplayModes,
+  ]);
+  const hostContext = useMemo<McpUiHostContext>(() => {
+    const base: McpUiHostContext = {
       ...baseHostContext,
       theme: resolvedTheme,
       displayMode: effectiveDisplayMode,
-      availableDisplayModes: configuredAvailableDisplayModes,
+      availableDisplayModes: effectiveAvailableDisplayModes,
       locale,
       timeZone,
       platform:
@@ -1537,7 +1572,9 @@ export function MCPAppsRenderer({
       deviceCapabilities,
       safeAreaInsets,
       styles: mergedStyles,
-      toolInfo: {
+    };
+    if (effectiveMcpAppsCapabilities.toolInfo) {
+      base.toolInfo = {
         id: toolCallId,
         tool: {
           name: toolName,
@@ -1549,24 +1586,25 @@ export function MCPAppsRenderer({
             }) ?? DEFAULT_INPUT_SCHEMA,
           description: toolMetadata?.description as string | undefined,
         },
-      },
-    }),
-    [
-      baseHostContext,
-      resolvedTheme,
-      effectiveDisplayMode,
-      configuredAvailableDisplayModes,
-      locale,
-      timeZone,
-      deviceCapabilities,
-      safeAreaInsets,
-      mergedStyles,
-      hostStyleDefinition,
-      toolCallId,
-      toolName,
-      toolMetadata,
-    ],
-  );
+      };
+    }
+    return base;
+  }, [
+    baseHostContext,
+    resolvedTheme,
+    effectiveDisplayMode,
+    effectiveAvailableDisplayModes,
+    locale,
+    timeZone,
+    deviceCapabilities,
+    safeAreaInsets,
+    mergedStyles,
+    hostStyleDefinition,
+    toolCallId,
+    toolName,
+    toolMetadata,
+    effectiveMcpAppsCapabilities.toolInfo,
+  ]);
 
   useEffect(() => {
     hostContextRef.current = hostContext;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -535,6 +535,37 @@ export function MCPAppsRenderer({
     [activeMcpProfile, earlyEffectiveHostStyle],
   );
 
+  // Intersection of the matrix's allowed modes with the playground /
+  // draft host context's configured modes — single source of truth for
+  // both the runtime clamp at `effectiveDisplayMode` below AND the
+  // value advertised in `HostContext.availableDisplayModes`. Computed
+  // here (early) so the clamp can use it.
+  //
+  // Without sharing the intersection between the two consumers, the
+  // matrix-only clamp inside `effectiveDisplayMode` could land on
+  // `matrix[0]` while `HostContext.availableDisplayModes` advertised a
+  // strict subset (the intersection). E.g. matrix=["pip","fullscreen"],
+  // configured=["inline","fullscreen"], requested="inline" →
+  // matrix-only clamp produced "pip" (matrix[0]) while advertised list
+  // was ["fullscreen"]. Fix: clamp against the intersection itself.
+  //
+  // Fallback to matrix alone when the intersection would be empty —
+  // matches the matrix invariant (`length >= 1`) and avoids advertising
+  // an unrenderable empty array. `configuredAvailableDisplayModes` is
+  // always a non-empty array (see `extractHostDisplayModes` fallbacks)
+  // so the only way intersection is empty is when the playground asks
+  // for modes the simulated host doesn't advertise.
+  const effectiveAvailableDisplayModes = useMemo(() => {
+    const matrixModes = earlyEffectiveMcpAppsCapabilities.availableDisplayModes;
+    const intersection = matrixModes.filter((m) =>
+      configuredAvailableDisplayModes.includes(m as DisplayMode),
+    );
+    return intersection.length > 0 ? intersection : matrixModes;
+  }, [
+    earlyEffectiveMcpAppsCapabilities.availableDisplayModes,
+    configuredAvailableDisplayModes,
+  ]);
+
   // Get device capabilities from playground store (SEP-1865)
   const playgroundCapabilities = useUIPlaygroundStore((s) => s.capabilities);
   const deviceCapabilities = useMemo(() => {
@@ -611,28 +642,20 @@ export function MCPAppsRenderer({
     if (displayMode === "pip" && pipWidgetId === toolCallId) return "pip";
     return "inline";
   }, [displayMode, fullscreenWidgetId, isControlled, pipWidgetId, toolCallId]);
-  // Clamp the requested display mode against BOTH the playground/
-  // configured allowlist AND the matrix allowlist. A Copilot host
-  // initializing in `pip` (parent's `displayMode` is sticky from a
-  // previous widget) must coerce down to `fullscreen` because the
-  // matrix's `availableDisplayModes` is `["fullscreen"]` — otherwise
-  // `HostContext.displayMode` would say "pip" while
-  // `HostContext.availableDisplayModes` advertises only fullscreen,
-  // an inconsistent payload.
-  const effectiveDisplayMode = useMemo<DisplayMode>(() => {
-    const configClamp = clampDisplayModeToAvailableModes(
-      requestedDisplayMode,
-      configuredAvailableDisplayModes,
-    );
-    return clampDisplayModeToAvailableModes(
-      configClamp,
-      earlyEffectiveMcpAppsCapabilities.availableDisplayModes,
-    );
-  }, [
-    configuredAvailableDisplayModes,
-    requestedDisplayMode,
-    earlyEffectiveMcpAppsCapabilities.availableDisplayModes,
-  ]);
+  // Clamp the requested display mode against the same intersection
+  // that gets advertised in `HostContext.availableDisplayModes` so
+  // the runtime mode is always a member of the advertised set. A
+  // Copilot host initializing in `pip` (parent's `displayMode` is
+  // sticky from a previous widget) coerces down to `fullscreen`
+  // because the intersection resolves to `["fullscreen"]`.
+  const effectiveDisplayMode = useMemo<DisplayMode>(
+    () =>
+      clampDisplayModeToAvailableModes(
+        requestedDisplayMode,
+        effectiveAvailableDisplayModes,
+      ),
+    [requestedDisplayMode, effectiveAvailableDisplayModes],
+  );
   const setDisplayMode = useCallback(
     (mode: DisplayMode) => {
       if (isControlled) {
@@ -1562,40 +1585,26 @@ export function MCPAppsRenderer({
   // Matrix-gated HostContext fields (PR C of the foundation series):
   //
   // - `availableDisplayModes`: intersection of the matrix's allowed
-  //   modes (`matrix.availableDisplayModes`) with whatever the
-  //   playground / draft host context configures. Both constraints
-  //   apply — the matrix says "what the simulated host's capability
-  //   advertises," the configured list says "what the user further
-  //   narrowed in the playground." If the intersection would be
-  //   empty (configured asks for modes the simulated host doesn't
-  //   advertise), fall back to the matrix value alone so the widget
-  //   still gets a usable allowlist instead of an unrenderable empty
-  //   array. Matches the matrix invariant (`length >= 1`).
+  //   modes with playground / draft configured modes, computed earlier
+  //   as `effectiveAvailableDisplayModes` so the runtime
+  //   `effectiveDisplayMode` clamp and the advertised list agree.
   //
   // - `toolInfo`: omitted entirely when `matrix.toolInfo === false`
   //   (Microsoft 365 Copilot doesn't deliver this HostContext field
   //   per its published Component-bridge table). A widget that
   //   probes `app.getHostContext()?.toolInfo` on a simulated Copilot
-  //   host now correctly sees undefined — same as real Copilot.
-  const effectiveAvailableDisplayModes = useMemo(() => {
-    const matrixModes = effectiveMcpAppsCapabilities.availableDisplayModes;
-    if (
-      configuredAvailableDisplayModes === undefined ||
-      configuredAvailableDisplayModes.length === 0
-    ) {
-      return matrixModes;
-    }
-    const intersection = matrixModes.filter((m) =>
-      configuredAvailableDisplayModes.includes(m as DisplayMode),
-    );
-    return intersection.length > 0 ? intersection : matrixModes;
-  }, [
-    effectiveMcpAppsCapabilities.availableDisplayModes,
-    configuredAvailableDisplayModes,
-  ]);
+  //   host now correctly sees undefined — same as real Copilot. The
+  //   gate strips any inherited `toolInfo` from `baseHostContext`
+  //   too: a draft host context that pre-populates `toolInfo` would
+  //   otherwise leak through the spread and defeat the gate.
   const hostContext = useMemo<McpUiHostContext>(() => {
+    // Strip toolInfo from the spread source so the matrix gate is
+    // authoritative — if the matrix says off, no upstream value
+    // (drafts, playground state) can reintroduce it via inheritance.
+    const { toolInfo: _toolInfoFromBase, ...baseWithoutToolInfo } =
+      baseHostContext as McpUiHostContext & { toolInfo?: unknown };
     const base: McpUiHostContext = {
-      ...baseHostContext,
+      ...baseWithoutToolInfo,
       theme: resolvedTheme,
       displayMode: effectiveDisplayMode,
       availableDisplayModes: effectiveAvailableDisplayModes,


### PR DESCRIPTION
## Summary

**PR C of the foundation series.** Carries the matrix's `availableDisplayModes` allowlist and the `toolInfo` advertise bit through to the `HostContext` payload the inspector advertises in `ui/initialize`. Builds on PR B's notification-emission gates with the smaller advertisement gates.

## Gates wired

### 1. `HostContext.toolInfo` (matrix.toolInfo)

Omitted entirely when `matrix.toolInfo === false`. A widget that probes `app.getHostContext()?.toolInfo` on a simulated Microsoft 365 Copilot host now correctly sees `undefined` — same as real Copilot, which doesn't deliver this field per its published Component-bridge table.

### 2. `HostContext.availableDisplayModes` (matrix.availableDisplayModes)

Intersected with the playground / draft `hostContext.availableDisplayModes`. Both constraints apply: the matrix says "what the simulated host advertises"; the configured list says "what the user further narrowed in the playground."

Empty-intersection fallback uses the matrix value alone — the widget never sees an unrenderable empty array (matrix invariant `length >= 1`).

The existing `bridge.onrequestdisplaymode` clamp at the renderer already enforces against `HostContext.availableDisplayModes` (via `clampDisplayModeToAvailableModes` reading `extractHostDisplayModes(hostContext)`), so this PR just carries the matrix value through to the place that already enforces it. Copilot's matrix is `["fullscreen"]` → widget requesting `pip` gets clamped to `fullscreen` automatically.

## Concrete behavior

| Host preset | Pre-PR `HostContext.toolInfo` | Post-PR `HostContext.toolInfo` | Pre-PR `availableDisplayModes` | Post-PR `availableDisplayModes` |
|---|---|---|---|---|
| Claude | ✅ `{ id, tool }` | ✅ `{ id, tool }` | `["inline", "fullscreen", "pip"]` | `["inline", "fullscreen", "pip"]` |
| Copilot | ✅ `{ id, tool }` (wrong) | ❌ omitted (matches M365) | `["inline", "fullscreen", "pip"]` (wrong) | `["fullscreen"]` (matches M365) |

## Two-matrix isolation preserved

Gates read only `effectiveMcpAppsCapabilities`, never the OpenAI shim's `liveOpenAiCompatCapabilitiesRef`. Cross-matrix isolation test from #2238 catches accidental cross-wiring at PR review time.

## Tests

4 new renderer tests:
1. Claude full-surface includes `HostContext.toolInfo`
2. Copilot omits `HostContext.toolInfo`
3. Copilot advertises `availableDisplayModes: ["fullscreen"]` only
4. Claude advertises all three modes

**697/697 client tests pass.**

## End-to-end status after this PR

Advertisement and notification gates are now complete for the foundation series:
- `HostCapabilities` blob (foundation PR #2226)
- Notification emissions: `tool-input-partial`, `tool-cancelled`, `host-context-changed` (PR B #2239)
- HostContext fields: `toolInfo`, `availableDisplayModes` (this PR)

Remaining PR D work: resource-meta gates (`_meta.ui.prefersBorder`, `frameDomains`, `baseUriDomains`, `permissions` honoring). Those are the resource-side interpretation gates — independent from advertisement and runtime emission.

## Test plan

- [x] `npx vitest run client/src/components/chat-v2/thread/mcp-apps/__tests__/` — 58/58 (4 new)
- [x] Full client suite — 697/697 pass
- [x] `npx tsc -p client/tsconfig.json --noEmit` — no new errors
- [ ] Manual: load a widget on the `copilot` host preset; probe `app.getHostContext()?.toolInfo` from the widget → confirm `undefined`
- [ ] Manual: same widget calls `app.requestDisplayMode({ mode: "pip" })` → confirm the actual mode returned is `"fullscreen"` (clamped by `HostContext.availableDisplayModes: ["fullscreen"]`)
- [ ] Manual: switch the same widget to the `claude` preset → `toolInfo` is now populated; `pip` requests resolve to `pip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `ui/initialize` `HostContext` payload and display-mode coercion, which can affect widget initialization and layout across host presets (notably Copilot).
> 
> **Overview**
> Aligns MCP Apps `HostContext` with the host-style matrix by **omitting `toolInfo` when `matrix.toolInfo === false`** (and stripping any inherited `toolInfo` from draft/playground host context so it can’t leak through).
> 
> Introduces a single **intersection-based source of truth** for `availableDisplayModes`, using it for both the value advertised in `HostContext.availableDisplayModes` and the runtime `displayMode` clamp so `HostContext.displayMode` is always a member of the advertised set (with matrix-only fallback when the intersection is empty).
> 
> Extends renderer tests to cover Copilot vs Claude behavior, inherited `toolInfo` stripping, and intersection-based display-mode clamping with custom profile overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67b72c20b3ed078b02a6ab0d8dd78abd7f7f7a40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->