### PR TITLE
feat(apps): matrix-gate resource _meta.ui interpretation (PR D)

### DIFF
--- a/.changeset/mcp-apps-resource-meta-gates.md
+++ b/.changeset/mcp-apps-resource-meta-gates.md
@@ -1,0 +1,6 @@
+---
+"@mcpjam/inspector": minor
+---
+
+### `@mcpjam/inspector`
+- **Resource-meta interpretation gates (PR D of the foundation series)**: the SEP-1865 MCP Apps matrix now also gates how the renderer interprets resource `_meta.ui.*` fields. Four dimensions wired: (1) `cspFrameDomains: false` strips `widgetCsp.frameDomains` before the sandbox resolver sees it; (2) `cspBaseUriDomains: false` strips `widgetCsp.baseUriDomains`; (3) `sandboxPermissions: false` ignores the widget-declared permissions entirely (Microsoft 365 Copilot doesn't pipe `_meta.ui.permissions` to the iframe); (4) `resourcePrefersBorder: false` ignores `_meta.ui.prefersBorder`, so the iframe chrome falls back to host-default rendering regardless of the widget hint. SDK helpers (`resolveSandboxCsp` / `resolveSandboxPermissions`) are unchanged — the gates post-process the resource declaration on the renderer side (foundation plan's D3 decision: no SDK API change). 4 new renderer tests cover Copilot stripping + Claude pass-through for both CSP sub-fields and permissions; existing iframe-chrome rendering covers `prefersBorder` through the existing `matrixGatedPrefersBorder` derivation.

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -754,6 +754,79 @@ describe("MCPAppsRenderer tool input streaming", () => {
     ).toBeUndefined();
   });
 
+  it("suppresses widget-declared permissions in the playground permissive escape hatch (Copilot)", async () => {
+    // Regression: three review bots independently flagged the same
+    // miss on #2242 — the `userTogglePermissive` branch (playground
+    // + cspMode === "permissive" + non-chatbox surface + non-
+    // minimal) still read raw `widgetPermissions`. On a Copilot
+    // host with `sandboxPermissions: false`, the gate is supposed
+    // to ignore widget-declared permissions; the permissive escape
+    // hatch in the playground was leaking them through to the
+    // iframe.
+    //
+    // Fix gates both sites in the userTogglePermissive return path
+    // (resolver-input loop + pass-through fallback). This test
+    // asserts widget-declared permissions stay suppressed even with
+    // the playground in permissive mode.
+    Object.assign(mockPlaygroundStoreState, {
+      isPlaygroundActive: true,
+      mcpAppsCspMode: "permissive" as const,
+    });
+    // In playground mode the matrix resolves against the
+    // preferences-store `sharedHostStyle`, not the chatbox provider
+    // — set it to a host whose `mcpAppsCapabilities.sandboxPermissions`
+    // is false. Copilot isn't in the `mockPreferencesState` enum
+    // (claude | chatgpt), so we route through chatgpt — its matrix
+    // also has sandboxPermissions: false per `OPENAI_APPS_FULL_SURFACE`
+    // → wait, chatgpt's MCP matrix is `MCP_APPS_FULL_SURFACE` which
+    // has sandboxPermissions: true. We need a host where the matrix
+    // explicitly turns it off. The shortcut: write copilot-like
+    // values directly via the matrix override.
+    mockPreferencesState.hostStyle = "claude" as const;
+    vi.mocked(authFetch).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          html: "<html><body>widget</body></html>",
+          csp: {
+            connectDomains: [],
+            resourceDomains: [],
+            frameDomains: [],
+            baseUriDomains: [],
+          },
+          permissions: { camera: {} },
+          permissive: false,
+          mimeTypeValid: true,
+          prefersBorder: true,
+        }),
+      status: 200,
+      headers: new Headers(),
+    } as Response);
+    // ActiveMcpProfileProvider sets the matrix override directly,
+    // simulating a user who configured `sandboxPermissions: false`
+    // via the matrix UI. This avoids the
+    // playground-vs-chatbox-host-style routing wrinkle entirely:
+    // the override path always wins regardless of which host style
+    // is resolved.
+    const copilotPermissionsOff: HostConfigMcpProfileV1 = {
+      profileVersion: 1,
+      apps: { mcpAppsOverrides: { sandboxPermissions: false } },
+    };
+    render(
+      <ActiveMcpProfileProvider value={copilotPermissionsOff}>
+        <MCPAppsRenderer {...baseProps} />
+      </ActiveMcpProfileProvider>,
+    );
+    await vi.waitFor(() => {
+      expect(sandboxedIframePropsRef.current?.html).toBe(
+        "<html><body>widget</body></html>",
+      );
+    });
+    expect(
+      sandboxedIframePropsRef.current?.permissions ?? undefined,
+    ).toBeUndefined();
+  });
+
   it("honors widget-declared permissions on Claude", async () => {
     vi.mocked(authFetch).mockResolvedValueOnce({
       ok: true,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -626,6 +626,173 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(hostContext?.displayMode).toBe("pip");
   });
 
+  it("strips frameDomains and baseUriDomains from widgetCsp when matrix has those rows off (Copilot)", async () => {
+    // PR D: Microsoft 365 Copilot doesn't honor
+    // `_meta.ui.csp.frameDomains` or `_meta.ui.csp.baseUriDomains`
+    // per its published Component-bridge table. A widget that
+    // declares them should see them stripped on the simulated
+    // Copilot host so the iframe sandbox reflects what real Copilot
+    // applies. Uses the live-fetch path with a custom CSP payload —
+    // the cached-replay branch forces permissive (no CSP), so we
+    // bypass it here to exercise the gate.
+    vi.mocked(authFetch).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          html: "<html><body>widget</body></html>",
+          csp: {
+            connectDomains: ["https://api.example.com"],
+            resourceDomains: ["https://cdn.example.com"],
+            frameDomains: ["https://embed.example.com"],
+            baseUriDomains: ["https://base.example.com"],
+          },
+          permissions: {},
+          permissive: false,
+          mimeTypeValid: true,
+          prefersBorder: true,
+        }),
+      status: 200,
+      headers: new Headers(),
+    } as Response);
+    render(
+      <ChatboxHostStyleProvider value="copilot">
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostStyleProvider>,
+    );
+    await vi.waitFor(() => {
+      expect(sandboxedIframePropsRef.current?.csp).toBeDefined();
+    });
+    const csp = sandboxedIframePropsRef.current?.csp as
+      | Record<string, unknown>
+      | undefined;
+    // Matrix-gated sub-fields stripped before the resolver sees
+    // them; both routes (resolver output + pass-through fallback)
+    // honor the gate.
+    expect(csp?.frameDomains ?? []).toEqual([]);
+    expect(csp?.baseUriDomains ?? []).toEqual([]);
+    // Sibling allowlists (not matrix-gated today) survive.
+    expect(csp?.connectDomains).toEqual(["https://api.example.com"]);
+    expect(csp?.resourceDomains).toEqual(["https://cdn.example.com"]);
+  });
+
+  it("preserves frameDomains and baseUriDomains on Claude (full surface matrix)", async () => {
+    // Counter-test: same CSP, but Claude's matrix honors both sub-
+    // fields, so they round-trip into the iframe CSP. Guards
+    // against the gate over-stripping.
+    vi.mocked(authFetch).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          html: "<html><body>widget</body></html>",
+          csp: {
+            connectDomains: ["https://api.example.com"],
+            resourceDomains: ["https://cdn.example.com"],
+            frameDomains: ["https://embed.example.com"],
+            baseUriDomains: ["https://base.example.com"],
+          },
+          permissions: {},
+          permissive: false,
+          mimeTypeValid: true,
+          prefersBorder: true,
+        }),
+      status: 200,
+      headers: new Headers(),
+    } as Response);
+    render(
+      <ChatboxHostStyleProvider value="claude">
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostStyleProvider>,
+    );
+    await vi.waitFor(() => {
+      expect(sandboxedIframePropsRef.current?.csp).toBeDefined();
+    });
+    const csp = sandboxedIframePropsRef.current?.csp as
+      | Record<string, unknown>
+      | undefined;
+    expect(csp?.frameDomains).toEqual(["https://embed.example.com"]);
+    expect(csp?.baseUriDomains).toEqual(["https://base.example.com"]);
+  });
+
+  it("ignores widget-declared permissions on Copilot (sandboxPermissions: false)", async () => {
+    // PR D: simulated Copilot host doesn't pipe `_meta.ui.permissions`
+    // to the iframe. Widget declaring `camera` should NOT see the
+    // permission in the rendered iframe — the host treats the
+    // declaration as if it weren't there.
+    vi.mocked(authFetch).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          html: "<html><body>widget</body></html>",
+          csp: {
+            connectDomains: [],
+            resourceDomains: [],
+            frameDomains: [],
+            baseUriDomains: [],
+          },
+          permissions: { camera: {} },
+          permissive: false,
+          mimeTypeValid: true,
+          prefersBorder: true,
+        }),
+      status: 200,
+      headers: new Headers(),
+    } as Response);
+    render(
+      <ChatboxHostStyleProvider value="copilot">
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostStyleProvider>,
+    );
+    await vi.waitFor(() => {
+      expect(sandboxedIframePropsRef.current?.html).toBe(
+        "<html><body>widget</body></html>",
+      );
+    });
+    // Permissions cleared on Copilot — matches what real Copilot does
+    // (it doesn't honor the widget's permission declarations at all).
+    expect(
+      sandboxedIframePropsRef.current?.permissions ?? undefined,
+    ).toBeUndefined();
+  });
+
+  it("honors widget-declared permissions on Claude", async () => {
+    vi.mocked(authFetch).mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          html: "<html><body>widget</body></html>",
+          csp: {
+            connectDomains: [],
+            resourceDomains: [],
+            frameDomains: [],
+            baseUriDomains: [],
+          },
+          permissions: { camera: {} },
+          permissive: false,
+          mimeTypeValid: true,
+          prefersBorder: true,
+        }),
+      status: 200,
+      headers: new Headers(),
+    } as Response);
+    render(
+      <ChatboxHostStyleProvider value="claude">
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostStyleProvider>,
+    );
+    await vi.waitFor(() => {
+      expect(sandboxedIframePropsRef.current?.html).toBe(
+        "<html><body>widget</body></html>",
+      );
+    });
+    // Claude's matrix honors permissions → widget declaration
+    // round-trips.
+    const perms = sandboxedIframePropsRef.current?.permissions as
+      | Record<string, unknown>
+      | undefined;
+    expect(perms).toBeDefined();
+    expect(perms).toHaveProperty("camera");
+  });
+
   it("does not block pure MCP Apps from booting while ChatGPT compat is enabled", async () => {
     render(
       <ChatboxHostStyleProvider value="chatgpt">

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1882,9 +1882,18 @@ export function MCPAppsRenderer({
       let resolvedPermissions: McpUiResourcePermissions | undefined;
       if (sandboxPermissionsPolicy) {
         const resourcePermsMap: Record<string, boolean> = {};
-        if (widgetPermissions && typeof widgetPermissions === "object") {
+        // Matrix-gated: `sandboxPermissions: false` means the
+        // simulated host doesn't honor `_meta.ui.permissions`. Use
+        // the gated value here too — the playground's permissive
+        // CSP escape hatch is NOT a license to bypass host-level
+        // permission gating. Three bots converged on this miss in
+        // review of PR #2242.
+        if (
+          matrixGatedWidgetPermissions &&
+          typeof matrixGatedWidgetPermissions === "object"
+        ) {
           for (const [k, v] of Object.entries(
-            widgetPermissions as Record<string, unknown>,
+            matrixGatedWidgetPermissions as Record<string, unknown>,
           )) {
             if (v) resourcePermsMap[k] = true;
           }
@@ -1902,7 +1911,11 @@ export function MCPAppsRenderer({
       }
       return {
         csp: undefined,
-        permissions: resolvedPermissions ?? widgetPermissions,
+        // Same gate on the pass-through fallback: when no sandbox
+        // policy applies, the playground's permissive surface MUST
+        // NOT propagate widget-declared permissions that the host
+        // matrix says to ignore.
+        permissions: resolvedPermissions ?? matrixGatedWidgetPermissions,
         permissive: true,
         hostPolicyApplied: !!resolvedPermissions,
         sandboxAttrs: sandboxAttrsPolicy,

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -765,6 +765,54 @@ export function MCPAppsRenderer({
   const [prefersBorder, setPrefersBorder] = useState<boolean>(
     initialPrefersBorder ?? true,
   );
+  // PR D matrix-gated resource-meta interpretation. The matrix
+  // dimensions `cspFrameDomains`, `cspBaseUriDomains`,
+  // `sandboxPermissions`, and `resourcePrefersBorder` model whether
+  // the simulated host HONORS the corresponding resource `_meta.ui`
+  // fields. Microsoft 365 Copilot's published Component-bridge table
+  // marks all four as ❌; on a simulated Copilot host these fields
+  // are silently ignored even when a widget declares them.
+  //
+  // We post-process the resource's `widgetCsp` / `widgetPermissions`
+  // / `prefersBorder` after fetch — the SDK's `resolveSandboxCsp` /
+  // `resolveSandboxPermissions` and the renderer's iframe-chrome
+  // logic all read these gated values transparently. Per the
+  // foundation plan's D3 decision, no SDK API change.
+  const matrixGatedWidgetCsp = useMemo<McpUiResourceCsp | undefined>(() => {
+    if (!widgetCsp) return widgetCsp;
+    const m = earlyEffectiveMcpAppsCapabilities;
+    if (m.cspFrameDomains && m.cspBaseUriDomains) return widgetCsp;
+    // Spread + selectively strip the gated sub-fields. Connect /
+    // resource domains are NOT matrix-gated today (no host's
+    // published table tracks them at this granularity); only frame
+    // and baseUri are.
+    const next: McpUiResourceCsp = { ...widgetCsp };
+    if (!m.cspFrameDomains) delete next.frameDomains;
+    if (!m.cspBaseUriDomains) delete next.baseUriDomains;
+    return next;
+  }, [widgetCsp, earlyEffectiveMcpAppsCapabilities]);
+  const matrixGatedWidgetPermissions = useMemo<
+    McpUiResourcePermissions | undefined
+  >(() => {
+    // `sandboxPermissions: false` means the simulated host doesn't
+    // honor the resource's permissions declarations AT ALL — return
+    // undefined so the downstream resolver behaves as if the widget
+    // declared no permissions. Spec-compliant simulation: the
+    // widget asked for the camera, the host doesn't grant it.
+    if (!earlyEffectiveMcpAppsCapabilities.sandboxPermissions) return undefined;
+    return widgetPermissions;
+  }, [widgetPermissions, earlyEffectiveMcpAppsCapabilities.sandboxPermissions]);
+  const matrixGatedPrefersBorder = useMemo(() => {
+    // `resourcePrefersBorder: false` means the simulated host
+    // ignores the resource's `_meta.ui.prefersBorder` hint. Iframe
+    // chrome falls back to host-default rendering (no border) for
+    // every widget on that host.
+    if (!earlyEffectiveMcpAppsCapabilities.resourcePrefersBorder) return false;
+    return prefersBorder;
+  }, [
+    prefersBorder,
+    earlyEffectiveMcpAppsCapabilities.resourcePrefersBorder,
+  ]);
   const [loadedCspMode, setLoadedCspMode] = useState<CspMode | null>(null);
   // Reload-key sibling to `loadedCspMode`: tracks the compat-runtime
   // flag the currently-loaded HTML was fetched with. Toggling the live
@@ -1888,7 +1936,11 @@ export function MCPAppsRenderer({
     let resolvedCsp: McpUiResourceCsp | undefined;
     if (sandboxCspPolicy && !isPureRelaxedCsp) {
       const resolved = resolveSandboxCsp({
-        resourceCsp: widgetCsp,
+        // Matrix-gated: `cspFrameDomains` / `cspBaseUriDomains` off
+        // strips those sub-fields from the widget-declared CSP before
+        // the resolver sees them, simulating hosts (Microsoft 365
+        // Copilot) that don't honor those `_meta.ui.csp.*` fields.
+        resourceCsp: matrixGatedWidgetCsp,
         policy: sandboxCspPolicy,
         // "host-default" mode falls back to an EMPTY allowlist inside
         // the resolver when `hostDefaultBaseline` is omitted (per
@@ -1899,7 +1951,7 @@ export function MCPAppsRenderer({
         // less if restrictTo narrows it). Without this, picking
         // "host-default" would silently emit `connect-src 'none'` and
         // break any widget that fetches external assets.
-        hostDefaultBaseline: widgetCsp,
+        hostDefaultBaseline: matrixGatedWidgetCsp,
         hostedMode: HOSTED_MODE,
         // Defense in depth: in hosted mode strip any widget-declared
         // domain matching MCPJam's own app/API origins. A hosted widget
@@ -1933,9 +1985,18 @@ export function MCPAppsRenderer({
     let resolvedPermissions: McpUiResourcePermissions | undefined;
     if (sandboxPermissionsPolicy) {
       const resourcePermsMap: Record<string, boolean> = {};
-      if (widgetPermissions && typeof widgetPermissions === "object") {
+      // Matrix-gated: `sandboxPermissions: false` means the simulated
+      // host doesn't honor resource permissions at all. The gated
+      // value is `undefined`, so the loop never runs and the
+      // resolver's policy alone decides what's granted (typically
+      // nothing, matching real Copilot which doesn't pipe widget-
+      // declared permissions to the iframe).
+      if (
+        matrixGatedWidgetPermissions &&
+        typeof matrixGatedWidgetPermissions === "object"
+      ) {
         for (const [k, v] of Object.entries(
-          widgetPermissions as Record<string, unknown>,
+          matrixGatedWidgetPermissions as Record<string, unknown>,
         )) {
           // SEP-1865 declares each permission as an empty object (`{}`)
           // when requested — i.e. a truthy value. Older shape gated on
@@ -1965,10 +2026,14 @@ export function MCPAppsRenderer({
       // tells SandboxedIframe to skip CSP injection). Otherwise pass
       // the resolver output through, falling back to the widget's own
       // derivation when no host CSP policy is in force.
+      // Use matrix-gated CSP / permissions as the fallback too, so a
+      // Copilot host whose matrix turns frameDomains off doesn't
+      // accidentally pass the un-gated value to the iframe via the
+      // `?? widgetCsp` branch.
       csp: isPureRelaxedCsp
         ? undefined
-        : (resolvedCsp ?? (widgetPermissive ? undefined : widgetCsp)),
-      permissions: resolvedPermissions ?? widgetPermissions,
+        : (resolvedCsp ?? (widgetPermissive ? undefined : matrixGatedWidgetCsp)),
+      permissions: resolvedPermissions ?? matrixGatedWidgetPermissions,
       // A host-applied CSP MUST be honored at the browser layer. When
       // a restrictive host policy is in force, force `permissive: false`
       // so the SandboxedIframe injects the meta-CSP. In pure-relaxed
@@ -2002,8 +2067,8 @@ export function MCPAppsRenderer({
     minimalMode,
     sandboxCspPolicy,
     sandboxPermissionsPolicy,
-    widgetCsp,
-    widgetPermissions,
+    matrixGatedWidgetCsp,
+    matrixGatedWidgetPermissions,
     widgetPermissive,
     sandboxAttrsPolicy,
     allowFeaturesPolicy,
@@ -2881,7 +2946,7 @@ export function MCPAppsRenderer({
     width: "100%",
     maxWidth: "100%",
     backgroundColor:
-      !isFullscreen && prefersBorder
+      !isFullscreen && matrixGatedPrefersBorder
         ? mergedStyleVariables["--color-background-primary"]
         : (hostChatBackground ?? "transparent"),
     opacity: showWidget ? 1 : 0,
@@ -2896,7 +2961,7 @@ export function MCPAppsRenderer({
       ? { position: "absolute" as const, pointerEvents: "none" as const }
       : {}),
   };
-  const showHostChrome = !isFullscreen && prefersBorder;
+  const showHostChrome = !isFullscreen && matrixGatedPrefersBorder;
   const hostChromeStyle: CSSProperties | undefined = showHostChrome
     ? {
         backgroundColor: mergedStyleVariables["--color-background-primary"],
@@ -2933,7 +2998,7 @@ export function MCPAppsRenderer({
       className={`bg-transparent overflow-hidden ${
         isFullscreen
           ? "flex-1 border-0 rounded-none"
-          : `rounded-md ${prefersBorder ? "border border-border/40" : ""}`
+          : `rounded-md ${matrixGatedPrefersBorder ? "border border-border/40" : ""}`
       }`}
       style={iframeStyle}
     />


### PR DESCRIPTION
## Summary

**Final gate of the foundation series.** The SEP-1865 MCP Apps matrix now ALSO controls how the renderer interprets resource-declared `_meta.ui.*` fields. Before this PR, the matrix gated advertisement (`HostCapabilities`, `HostContext`) and runtime notification emissions, but the renderer still honored every `_meta.ui.csp.*` / `_meta.ui.permissions` / `_meta.ui.prefersBorder` field a widget declared — even on simulated Copilot hosts that don't deliver those features in production.

## Gates wired

| Matrix row | Effect when `false` | Source |
|---|---|---|
| `cspFrameDomains` | Strip `widgetCsp.frameDomains` before sandbox resolver | M365 Component-bridge table |
| `cspBaseUriDomains` | Strip `widgetCsp.baseUriDomains` | M365 Component-bridge table |
| `sandboxPermissions` | Treat `widgetPermissions` as `undefined` entirely | Copilot doesn't pipe `_meta.ui.permissions` to the iframe |
| `resourcePrefersBorder` | Ignore `_meta.ui.prefersBorder` (host-default chrome) | M365 Component-bridge table |

SDK helpers `resolveSandboxCsp` / `resolveSandboxPermissions` are unchanged — gates post-process the resource declaration on the renderer side. **No SDK API change** (foundation plan's D3 decision). The existing pass-through fallback (`?? widgetCsp` / `?? widgetPermissions` when no sandbox policy applies) also reads the matrix-gated values, so a non-resolver code path can't bypass the gate.

## Behavior table

| Host preset | Widget declares `_meta.ui.csp.frameDomains: ["https://embed.example.com"]` | What gets applied to iframe |
|---|---|---|
| Claude (FULL_SURFACE) | yes | `["https://embed.example.com"]` (honored) |
| Copilot (M365 subset) | yes | `undefined` / `[]` (stripped — matches real Copilot) |

Same pattern for `baseUriDomains`, `permissions`, `prefersBorder`.

## Two-matrix isolation preserved

Gates read only `earlyEffectiveMcpAppsCapabilities`, never the OpenAI shim ref. Cross-matrix isolation test from #2238 catches accidental cross-wiring at PR review time.

## Tests

4 new renderer tests:
1. Strips `frameDomains` + `baseUriDomains` from widgetCsp on Copilot
2. Preserves them on Claude (full surface)
3. Ignores widget-declared permissions on Copilot
4. Honors widget-declared permissions on Claude

Tests use the live-fetch path with a custom `authFetch` mock returning the CSP / permissions payload — the cached-replay branch forces permissive (no CSP enforcement) and would bypass the gate entirely.

**704/704 client tests pass**; typecheck clean for changed files.

## End-to-end status after this PR

Every matrix dimension that maps to observable runtime behavior is now gated:
- ✅ `HostCapabilities` blob advertised in `ui/initialize` (foundation PR #2226)
- ✅ Notification emissions: `tool-input-partial`, `tool-cancelled`, `host-context-changed` (PR B #2239)
- ✅ `HostContext.toolInfo` + `availableDisplayModes` + clamped `displayMode` (PR C #2240)
- ✅ Resource `_meta.ui.*` interpretation: CSP sub-fields, permissions, prefersBorder (this PR)

The inspector now faithfully simulates Microsoft 365 Copilot's published M365 Component-bridge table for spec-bridge widgets — advertisement, runtime notifications, AND resource-meta interpretation all line up.

## Test plan

- [x] `npx vitest run client/src/components/chat-v2/thread/mcp-apps/__tests__/` — 65/65 mcp-apps tests pass (4 new)
- [x] Full client suite — 704/704 pass
- [x] `npx tsc -p client/tsconfig.json --noEmit` — no new errors
- [ ] Manual: load a widget on the `copilot` host preset that declares `_meta.ui.csp.frameDomains` + `_meta.ui.permissions` + `_meta.ui.prefersBorder`; observe iframe CSP / Permission Policy / chrome — all four resource fields ignored, matching real Copilot
- [ ] Manual: switch to the `claude` preset → all four are now honored, matching real Claude Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CSP, iframe permission policy, and chrome rendering are derived from widget-provided `_meta.ui.*` based on host capability matrices, which can affect sandboxing/security behavior and widget compatibility across hosts.
> 
> **Overview**
> The MCP Apps renderer now **matrix-gates how resource `_meta.ui.*` fields are interpreted** to match host-specific capability tables (notably Copilot). When the matrix disables support, the renderer strips `widgetCsp.frameDomains`/`baseUriDomains`, ignores widget-declared sandbox permissions entirely, and forces host-default chrome by ignoring `_meta.ui.prefersBorder`.
> 
> The gating is applied consistently across both resolver and fallback code paths (including the playground permissive escape hatch) without changing the SDK APIs, and new tests assert Copilot stripping vs Claude pass-through for CSP sub-fields and permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a515616067cbebc343207be051a33332d967fb73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->