### PR TITLE
Simplify Apps extension matrix UI for clarity.

### DIFF
--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/ClientCapabilityMatrix.tsx
@@ -63,10 +63,10 @@ export interface HostMatrixCardProps {
   /**
    * Resolved vendor compat-runtime shim state. `openaiApps: true` →
    * inspector injects `window.openai` into widget HTML; `false` → no
-   * shim. `fromOverride: false` means the injection flag comes from
-   * the host style preset (drives the "from preset" chip qualifier).
-   * `hasMethodOverrides` / `methodCount` / `methodTotal` summarize the
-   * per-method matrix for the chip's "custom (N/M methods)" subtitle.
+   * shim. `fromOverride: true` means injection differs from the host
+   * style preset (drives the chip's optional subtitle). `hasMethodOverrides`
+   * / `methodCount` / `methodTotal` summarize the per-method matrix for
+   * the chip's optional "N/M methods" subtitle.
    */
   compatRuntime: {
     openaiApps: boolean;
@@ -366,23 +366,18 @@ function ViewIframeInjectedGlobals({
   };
   onClick: () => void;
 }) {
-  // Tri-state label for window.openai: off / preset / custom. "Custom"
-  // wins whenever the user has flipped at least one per-method override,
-  // even if injection itself is at the preset default.
+  // Tag subtitles only when state differs from the host style preset.
+  // Default preset values need no qualifier — the green dot is enough.
   const openaiSubtitle = compatRuntime.hasMethodOverrides
-    ? `custom (${compatRuntime.methodCount}/${compatRuntime.methodTotal} methods)`
+    ? `${compatRuntime.methodCount}/${compatRuntime.methodTotal} methods`
     : compatRuntime.fromOverride
       ? "overridden"
-      : "from preset";
-  // Bi-state label for app.*: "from preset" or "custom (N overrides)".
-  // Counts sparse-override keys directly — heterogeneous dimensions
-  // (booleans + mode array + sandbox + resource-meta) make a flat
-  // "active" count harder to interpret than just "edits applied."
+      : null;
   const mcpAppsSubtitle = mcpAppsBridge.hasOverrides
-    ? `custom (${mcpAppsBridge.overrideCount} ${
+    ? `${mcpAppsBridge.overrideCount} ${
         mcpAppsBridge.overrideCount === 1 ? "override" : "overrides"
-      })`
-    : "from preset";
+      }`
+    : null;
   return (
     <div className="hp-view-injected">
       <button
@@ -402,7 +397,7 @@ function ViewIframeInjectedGlobals({
       >
         <span className="hp-cap-dot" aria-hidden />
         <span className="hp-cap-name">window.openai</span>
-        {compatRuntime.openaiApps ? (
+        {openaiSubtitle ? (
           <span className="hp-cap-tag">{openaiSubtitle}</span>
         ) : null}
       </button>
@@ -422,8 +417,10 @@ function ViewIframeInjectedGlobals({
         }
       >
         <span className="hp-cap-dot" aria-hidden />
-        <span className="hp-cap-name">app.*</span>
-        <span className="hp-cap-tag">{mcpAppsSubtitle}</span>
+        <span className="hp-cap-name">MCP Apps</span>
+        {mcpAppsSubtitle ? (
+          <span className="hp-cap-tag">{mcpAppsSubtitle}</span>
+        ) : null}
       </button>
     </div>
   );

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/__tests__/RedesignedClientCanvas.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/__tests__/RedesignedClientCanvas.test.tsx
@@ -89,6 +89,23 @@ describe("RedesignedClientCanvas", () => {
     expect(node!.querySelector(".hp-view-empty-label")).toBeNull();
   });
 
+  it("does not show 'from preset' on injected-globals chips at the host preset default", () => {
+    const { container } = renderCanvas({
+      draft: emptyHostConfigInputV2({ hostStyle: "chatgpt" }),
+    });
+    const node = container.querySelector(
+      `.react-flow__node[data-id="${HOST_MATRIX_NODE_ID}"]`,
+    ) as HTMLElement | null;
+    expect(node).not.toBeNull();
+    const injected = node!.querySelector(".hp-view-injected");
+    expect(injected).not.toBeNull();
+    expect(injected!.textContent).not.toMatch(/from preset/i);
+    const injectedScope = within(injected as HTMLElement);
+    expect(injectedScope.getByText("window.openai")).toBeInTheDocument();
+    expect(injectedScope.getByText("MCP Apps")).toBeInTheDocument();
+    expect(injectedScope.queryByText("overridden")).toBeNull();
+  });
+
   it("adds a client capability chip when that cap is enabled on the host", () => {
     const base = emptyHostConfigInputV2();
     const { container } = renderCanvas({

--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
@@ -1,6 +1,6 @@
 import type { Edge } from "@xyflow/react";
 import { getModelById } from "@/shared/types";
-import { findHostStyle } from "@/lib/client-styles";
+import { findHostStyle, getCompatRuntimeForStyle } from "@/lib/client-styles";
 import {
   resolveEffectiveCompatRuntime,
   resolveEffectiveHostCapabilities,
@@ -730,15 +730,13 @@ export function buildRedesignedHostCanvas(
     return isRecord(exts["io.modelcontextprotocol/ui"]);
   })();
 
-  // Resolved vendor compat-runtime shim state. Drives the "Compat
-  // shims" chip in the matrix. The "fromOverride" flag tracks whether
-  // the value came from the user-set profile (`apps.compatRuntime`)
-  // or from the host style preset — the chip's "(from preset)"
-  // qualifier surfaces this distinction so users know whether their
-  // edit is doing something.
+  // Resolved vendor compat-runtime shim state. Drives the injected-globals
+  // chips in the matrix. Tags on the chips only appear when the effective
+  // surface diverges from the host style preset — not for the default case.
   const compatRuntimeOverride = draft.mcpProfile?.apps?.compatRuntime?.openaiApps;
   const overridesRecord =
     draft.mcpProfile?.apps?.compatRuntime?.openaiAppsOverrides;
+  const presetCompatRuntime = getCompatRuntimeForStyle(draft.hostStyle);
   const effectiveCompatRuntime = resolveEffectiveCompatRuntime({
     profile: draft.mcpProfile,
     hostStyle: draft.hostStyle,
@@ -759,7 +757,9 @@ export function buildRedesignedHostCanvas(
     : 0;
   const compatRuntime = {
     openaiApps: effectiveCompatRuntime.injected,
-    fromOverride: typeof compatRuntimeOverride === "boolean",
+    fromOverride:
+      typeof compatRuntimeOverride === "boolean" &&
+      compatRuntimeOverride !== presetCompatRuntime.injected,
     // Whether the user has set any per-method override on top of the
     // preset — drives the "custom" vs "preset" label in the chip.
     hasMethodOverrides:

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -1289,13 +1289,6 @@ function McpAppsCapabilityMatrix({
       : legacyOverride !== undefined
         ? (hostCapabilitiesOverrideToMatrix(legacyOverride) ?? undefined)
         : undefined;
-  // Preset baseline alone (no override applied) — used when toggling rows
-  // back to preset values. The "Overridden" badge tracks divergences.
-  const presetCapabilities: ResolvedMcpAppsCapabilities =
-    resolveEffectiveMcpAppsCapabilities({
-      profile: undefined,
-      hostStyle: draft.hostStyle,
-    });
   // Effective values shown in the matrix UI. Uses the virtually-
   // migrated legacy when the matrix is absent so the UI shows what
   // the resolver advertises today (legacy path) — not what it would

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -996,14 +996,11 @@ function OpenaiAppsCapabilityMatrix({
                     >
                       <div className="flex flex-col gap-0.5">
                         <span className="font-mono text-[12px]">{label}</span>
-                        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-                          <span>Preset: {String(presetValue)}</span>
-                          {overridden ? (
-                            <span className="rounded bg-orange-500/15 px-1 py-px text-orange-600 dark:text-orange-300">
-                              Overridden
-                            </span>
-                          ) : null}
-                        </div>
+                        {overridden ? (
+                          <span className="w-fit rounded bg-orange-500/15 px-1 py-px text-[10px] text-orange-600 dark:text-orange-300">
+                            Overridden
+                          </span>
+                        ) : null}
                       </div>
                       {key === "requestDisplayMode" ? (
                         <RequestDisplayModeControl
@@ -1149,46 +1146,93 @@ function setMcpAppsOverridesOnDraft(
   };
 }
 
-/**
- * Main-disclosure matrix dimensions — the rows that vary across
- * published host tables (Microsoft 365 Copilot's M365 reference). Order
- * matches the M365 Component-bridge table where applicable.
- */
-const MCP_APPS_MAIN_DIMENSIONS: Array<{
-  key: Exclude<keyof McpAppsCapabilities, "availableDisplayModes">;
-  label: string;
-}> = [
-  { key: "toolInputPartial", label: "toolInputPartial" },
-  { key: "toolCancelled", label: "toolCancelled" },
-  { key: "hostContextChanged", label: "hostContextChanged" },
-  { key: "resourceTeardown", label: "resourceTeardown" },
-  { key: "serverResources", label: "serverResources" },
-  { key: "logging", label: "logging" },
-];
+type McpAppsDimensionKey = Exclude<
+  keyof McpAppsCapabilities,
+  "availableDisplayModes"
+>;
 
-/**
- * Advanced disclosure — rare dimensions that rarely vary across hosts
- * but are needed for completeness (sandbox sub-fields, resource-meta
- * interpretation, HostContext fine grain, hands-off advertise rows
- * that almost every preset enables).
- */
-const MCP_APPS_ADVANCED_DIMENSIONS: Array<{
-  key: Exclude<keyof McpAppsCapabilities, "availableDisplayModes">;
-  label: string;
-}> = [
-  { key: "toolInfo", label: "toolInfo" },
-  { key: "openLinks", label: "openLinks" },
-  { key: "serverTools", label: "serverTools" },
-  { key: "updateModelContext", label: "updateModelContext" },
-  { key: "message", label: "message" },
-  { key: "sandboxPermissions", label: "sandbox.permissions" },
-  { key: "cspFrameDomains", label: "sandbox.csp.frameDomains" },
-  { key: "cspBaseUriDomains", label: "sandbox.csp.baseUriDomains" },
-  { key: "resourcePrefersBorder", label: "_meta.ui.prefersBorder" },
+/** Per-dimension matrix metadata. Description is shown on row hover. */
+type McpAppsDimensionMeta = {
+  key: McpAppsDimensionKey;
+  description: string;
+};
+
+/** All boolean MCP Apps matrix dimensions in display order. */
+const MCP_APPS_DIMENSIONS: McpAppsDimensionMeta[] = [
+  {
+    key: "toolInputPartial",
+    description:
+      "Send ui/notifications/tool-input-partial while the agent streams arguments",
+  },
+  {
+    key: "toolCancelled",
+    description:
+      "Notify the app when tool execution is cancelled (ui/notifications/tool-cancelled)",
+  },
+  {
+    key: "hostContextChanged",
+    description:
+      "Notify the app when theme, display mode, or other host context changes",
+  },
+  {
+    key: "resourceTeardown",
+    description:
+      "Send ui/resource-teardown before destroying the app view",
+  },
+  {
+    key: "serverResources",
+    description: "Advertise resources/read proxy capability in ui/initialize",
+  },
+  {
+    key: "logging",
+    description: "Accept notifications/message log calls from the app",
+  },
+  {
+    key: "toolInfo",
+    description: "Include calling-tool metadata in HostContext.toolInfo",
+  },
+  {
+    key: "openLinks",
+    description: "Advertise ui/open-link capability",
+  },
+  {
+    key: "serverTools",
+    description: "Advertise tools/call proxy capability",
+  },
+  {
+    key: "updateModelContext",
+    description: "Accept ui/update-model-context requests from the app",
+  },
+  {
+    key: "message",
+    description: "Accept ui/message requests that add content to the conversation",
+  },
+  {
+    key: "sandboxPermissions",
+    description: "Honor _meta.ui.permissions when configuring the iframe",
+  },
+  {
+    key: "cspFrameDomains",
+    description: "Honor _meta.ui.csp.frameDomains for nested iframes",
+  },
+  {
+    key: "cspBaseUriDomains",
+    description: "Honor _meta.ui.csp.baseUriDomains in CSP",
+  },
+  {
+    key: "resourcePrefersBorder",
+    description: "Honor _meta.ui.prefersBorder when rendering app chrome",
+  },
 ];
 
 const ALL_DISPLAY_MODES = ["inline", "fullscreen", "pip"] as const;
 type DisplayMode = (typeof ALL_DISPLAY_MODES)[number];
+
+const DISPLAY_MODE_LABELS: Record<DisplayMode, string> = {
+  inline: "Inline",
+  fullscreen: "Fullscreen",
+  pip: "PiP",
+};
 
 /**
  * Per-dimension capability matrix for the SEP-1865 `app.*` spec bridge.
@@ -1198,16 +1242,12 @@ type DisplayMode = (typeof ALL_DISPLAY_MODES)[number];
  * no tri-state (the matrix is always advertised).
  *
  * Layout:
- * - `availableDisplayModes` cluster at the top (multi-checkbox for the
- *   array allowlist; inline is force-enabled if user clears all three).
- * - Main disclosure: notification gates + serverResources / logging —
- *   the rows that vary across published host tables.
- * - Advanced disclosure: sandbox sub-fields, resource-meta, toolInfo,
- *   and advertise rows that almost every preset enables (still
- *   surfaced so legacy `{}` migrations are visible).
+ * - `availableDisplayModes` cluster at the top.
+ * - Flat list of all boolean matrix dimensions below.
  * - Per-row "Overridden" badge when the user has diverged from the
  *   host style preset; rows show the preset value for context.
- * - "Match host preset" chip clears the entire matrix override.
+ * - "Reset" button clears the entire matrix override (shown only when
+ *   overrides are active).
  *
  * The matrix round-trips through `appsToJson` / `applyJsonToDraft` so
  * the JSON editor below stays in sync.
@@ -1225,7 +1265,6 @@ function McpAppsCapabilityMatrix({
     updater: (prev: HostConfigInputV2) => HostConfigInputV2,
   ) => void;
 }) {
-  const [advancedOpen, setAdvancedOpen] = useState(false);
   const rawOverridesRecord = draft.mcpProfile?.apps?.mcpAppsOverrides;
   const legacyOverride = draft.hostCapabilitiesOverride;
   // Legacy `hostCapabilitiesOverride` is the pre-matrix way of
@@ -1250,8 +1289,8 @@ function McpAppsCapabilityMatrix({
       : legacyOverride !== undefined
         ? (hostCapabilitiesOverrideToMatrix(legacyOverride) ?? undefined)
         : undefined;
-  // Preset baseline alone (no override applied) — used to compute the
-  // per-row "Preset: X" hint and the "Overridden" badge.
+  // Preset baseline alone (no override applied) — used when toggling rows
+  // back to preset values. The "Overridden" badge tracks divergences.
   const presetCapabilities: ResolvedMcpAppsCapabilities =
     resolveEffectiveMcpAppsCapabilities({
       profile: undefined,
@@ -1410,63 +1449,59 @@ function McpAppsCapabilityMatrix({
   const overrideCount = hasAnyOverride
     ? Object.keys(effectiveOverridesForDisplay!).length
     : 0;
+  const enabledCount = MCP_APPS_DIMENSIONS.filter(({ key }) =>
+    Boolean(effectiveCapabilities[key]),
+  ).length;
   const subline = hasAnyOverride
     ? `${overrideCount} ${overrideCount === 1 ? "override" : "overrides"} active${
         rawOverridesRecord === undefined && legacyOverride !== undefined
           ? " (legacy)"
           : ""
       }`
-    : "Matches host style preset";
+    : `${enabledCount} of ${MCP_APPS_DIMENSIONS.length} enabled`;
 
   return (
     <div className="rounded-[10px] border border-border bg-background">
-      {/* Header strip: section label + override count + clear-to-preset chip. */}
+      {/* Header strip: title + status; reset only when the user has overrides. */}
       <div className="flex items-stretch border-b border-border">
         <div className="flex flex-1 flex-col gap-0.5 px-3.5 py-2.5">
-          <span className="text-[12px] font-medium">
-            <span className="font-mono">app.*</span> spec bridge
-            <span className="ml-1.5 text-[10px] font-normal text-muted-foreground">
-              (SEP-1865)
-            </span>
-          </span>
+          <span className="text-[12px] font-medium">MCP Apps</span>
           <span className="text-[11px] text-muted-foreground">{subline}</span>
         </div>
-        <div className="flex items-center border-l border-border pr-3.5 pl-3">
-          <button
-            type="button"
-            disabled={!hasAnyOverride}
-            onClick={clearOverride}
-            className="rounded border border-border bg-background px-2 py-0.5 text-[11px] text-muted-foreground transition hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
-            title="Clear all overrides on this matrix and revert every dimension to the host style preset"
-          >
-            Match host preset
-          </button>
-        </div>
+        {hasAnyOverride ? (
+          <div className="flex items-center border-l border-border pr-3.5 pl-3">
+            <button
+              type="button"
+              onClick={clearOverride}
+              className="rounded border border-border bg-background px-2 py-0.5 text-[11px] text-muted-foreground transition hover:bg-muted"
+              title="Revert all overrides to the host style preset"
+            >
+              Reset
+            </button>
+          </div>
+        ) : null}
       </div>
 
       {/* availableDisplayModes — multi-checkbox cluster. Always visible
           (it's the most-edited dimension and the one published host
           tables most prominently differ on, e.g. Copilot is fullscreen-
           only). */}
-      <div className="flex items-center justify-between gap-3 border-b border-border/50 px-3.5 py-2">
-        <div className="flex flex-col gap-0.5">
-          <span className="font-mono text-[12px]">availableDisplayModes</span>
-          <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-            <span>
-              Preset:{" "}
-              <span className="font-mono">
-                [{presetCapabilities.availableDisplayModes.join(", ")}]
-              </span>
-            </span>
+      <div
+        data-testid="mcp-apps-dimension-availableDisplayModes"
+        className="flex items-center justify-between gap-3 border-b border-border/50 px-3.5 py-2"
+      >
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+            <span className="font-mono text-[12px]">availableDisplayModes</span>
             {effectiveOverridesForDisplay?.availableDisplayModes !==
             undefined ? (
-              <span className="rounded bg-orange-500/15 px-1 py-px text-orange-600 dark:text-orange-300">
+              <span className="rounded bg-orange-500/15 px-1 py-px text-[10px] text-orange-600 dark:text-orange-300">
                 Overridden
               </span>
             ) : null}
           </div>
         </div>
-        <div className="inline-flex overflow-hidden rounded-md border border-border text-[11px]">
+        <div className="inline-flex shrink-0 overflow-hidden rounded-md border border-border text-[11px]">
           {ALL_DISPLAY_MODES.map((mode) => {
             const enabled =
               effectiveCapabilities.availableDisplayModes.includes(mode);
@@ -1474,29 +1509,29 @@ function McpAppsCapabilityMatrix({
               <button
                 key={mode}
                 type="button"
+                aria-label={mode}
+                title={mode}
                 className={
                   enabled
-                    ? "bg-foreground/10 px-2 py-0.5 font-medium"
-                    : "px-2 py-0.5 text-muted-foreground hover:bg-muted"
+                    ? "bg-foreground/10 px-2.5 py-0.5 font-medium"
+                    : "px-2.5 py-0.5 text-muted-foreground hover:bg-muted"
                 }
                 onClick={() => toggleDisplayMode(mode)}
               >
-                {mode}
+                {DISPLAY_MODE_LABELS[mode]}
               </button>
             );
           })}
         </div>
       </div>
 
-      {/* Main dimensions — notification gates + serverResources / logging. */}
       <div className="flex flex-col">
-        {MCP_APPS_MAIN_DIMENSIONS.map(({ key, label }) => (
+        {MCP_APPS_DIMENSIONS.map(({ key, description }) => (
           <McpAppsDimensionRow
             key={key}
             dimensionKey={key}
-            label={label}
+            description={description}
             effective={Boolean(effectiveCapabilities[key])}
-            presetValue={Boolean(presetCapabilities[key])}
             overridden={
               effectiveOverridesForDisplay !== undefined &&
               key in effectiveOverridesForDisplay
@@ -1505,63 +1540,21 @@ function McpAppsCapabilityMatrix({
           />
         ))}
       </div>
-
-      {/* Advanced disclosure — sandbox sub-fields, resource-meta,
-          toolInfo, plus the "always on across every preset" advertise
-          rows. Surfaced so legacy `{}` migrations are visible and
-          unusual hosts can be modeled. */}
-      <button
-        type="button"
-        onClick={() => setAdvancedOpen((v) => !v)}
-        aria-expanded={advancedOpen}
-        aria-controls="apps-extension-mcp-apps-advanced"
-        className="flex w-full items-center justify-between gap-2 border-t border-border/50 px-3.5 py-2 text-left text-[11px] text-muted-foreground hover:bg-muted/40"
-      >
-        <span>Advanced ({MCP_APPS_ADVANCED_DIMENSIONS.length} dimensions)</span>
-        <ChevronDown
-          className={`h-3.5 w-3.5 shrink-0 transition-transform ${
-            advancedOpen ? "rotate-180" : ""
-          }`}
-        />
-      </button>
-      {advancedOpen ? (
-        <div
-          id="apps-extension-mcp-apps-advanced"
-          className="flex flex-col border-t border-border/50"
-        >
-          {MCP_APPS_ADVANCED_DIMENSIONS.map(({ key, label }) => (
-            <McpAppsDimensionRow
-              key={key}
-              dimensionKey={key}
-              label={label}
-              effective={Boolean(effectiveCapabilities[key])}
-              presetValue={Boolean(presetCapabilities[key])}
-              overridden={
-                effectiveOverridesForDisplay !== undefined &&
-                key in effectiveOverridesForDisplay
-              }
-              onToggle={(next) => setBooleanOverride(key, next)}
-            />
-          ))}
-        </div>
-      ) : null}
     </div>
   );
 }
 
-/** Single boolean dimension row — preset hint + overridden badge + toggle. */
+/** Single boolean dimension row — technical key + optional overridden badge. */
 function McpAppsDimensionRow({
   dimensionKey,
-  label,
+  description,
   effective,
-  presetValue,
   overridden,
   onToggle,
 }: {
-  dimensionKey: Exclude<keyof McpAppsCapabilities, "availableDisplayModes">;
-  label: string;
+  dimensionKey: McpAppsDimensionKey;
+  description: string;
   effective: boolean;
-  presetValue: boolean;
   overridden: boolean;
   onToggle: (next: boolean) => void;
 }) {
@@ -1569,22 +1562,20 @@ function McpAppsDimensionRow({
     <div
       data-testid={`mcp-apps-dimension-${dimensionKey}`}
       className="flex items-center justify-between gap-3 border-b border-border/50 px-3.5 py-2 last:border-b-0"
+      title={description}
     >
-      <div className="flex flex-col gap-0.5">
-        <span className="font-mono text-[12px]">{label}</span>
-        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-          <span>Preset: {String(presetValue)}</span>
-          {overridden ? (
-            <span className="rounded bg-orange-500/15 px-1 py-px text-orange-600 dark:text-orange-300">
-              Overridden
-            </span>
-          ) : null}
-        </div>
+      <div className="min-w-0 flex flex-col gap-0.5">
+        <span className="font-mono text-[12px]">{dimensionKey}</span>
+        {overridden ? (
+          <span className="w-fit rounded bg-orange-500/15 px-1 py-px text-[10px] text-orange-600 dark:text-orange-300">
+            Overridden
+          </span>
+        ) : null}
       </div>
       <Switch
         checked={effective}
         onCheckedChange={onToggle}
-        aria-label={label}
+        aria-label={dimensionKey}
       />
     </div>
   );

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
@@ -54,25 +54,27 @@ function renderMatrix(initial?: Partial<HostConfigInputV2>) {
 }
 
 describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
-  it("renders the spec-bridge section with the SEP-1865 label", () => {
+  it("renders the MCP Apps section header", () => {
     renderMatrix();
-    // Two-matrix architecture: window.openai and app.* are sibling
-    // sections in the same tab. The label disambiguates them.
-    expect(screen.getByText("app.*")).toBeInTheDocument();
-    expect(screen.getByText(/SEP-1865/)).toBeInTheDocument();
+    // Two-matrix architecture: window.openai and MCP Apps are sibling
+    // sections in the same tab.
+    expect(screen.getByText("MCP Apps")).toBeInTheDocument();
   });
 
-  it("starts at 'Matches host style preset' subline when no override is set", () => {
+  it("does not show Preset hints on matrix rows", () => {
     renderMatrix();
-    expect(screen.getByText(/Matches host style preset/)).toBeInTheDocument();
+    expect(screen.queryByText(/^Preset:/)).toBeNull();
+  });
+
+  it("shows an enabled-capability summary when no override is set", () => {
+    renderMatrix();
+    expect(screen.getByText("15 of 15 enabled")).toBeInTheDocument();
   });
 
   it("renders the availableDisplayModes cluster with Claude's preset (all three modes)", () => {
     renderMatrix();
     // Claude advertises the FULL surface: inline + fullscreen + pip.
-    const cluster = screen
-      .getByText("availableDisplayModes")
-      .closest("div")!.parentElement!;
+    const cluster = screen.getByTestId("mcp-apps-dimension-availableDisplayModes");
     for (const mode of ["inline", "fullscreen", "pip"] as const) {
       const button = within(cluster).getByRole("button", { name: mode });
       // Selected modes use the elevated background class.
@@ -171,7 +173,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
     expect(within(cleanRow).queryByText("Overridden")).toBeNull();
   });
 
-  it("'Match host preset' chip clears the entire matrix override", async () => {
+  it("Reset button clears the entire matrix override", async () => {
     const user = userEvent.setup();
     const draft = emptyHostConfigInputV2({ hostStyle: "claude" });
     draft.mcpProfile = {
@@ -193,29 +195,23 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
         attention={[]}
       />,
     );
-    const chip = screen.getByRole("button", { name: /Match host preset/ });
-    expect(chip).toBeEnabled();
-    await user.click(chip);
+    const reset = screen.getByRole("button", { name: "Reset" });
+    await user.click(reset);
     expect(draftRef.current.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
   });
 
-  it("'Match host preset' chip is disabled when no override is set", () => {
+  it("hides the Reset button when no override is set", () => {
     renderMatrix();
-    const chip = screen.getByRole("button", { name: /Match host preset/ });
-    expect(chip).toBeDisabled();
+    expect(screen.queryByRole("button", { name: "Reset" })).toBeNull();
   });
 
-  it("the Advanced disclosure hides rare dimensions until expanded", async () => {
-    const user = userEvent.setup();
+  it("renders all matrix dimensions in one flat list", () => {
     renderMatrix();
-    // Sandbox sub-fields live in Advanced — hidden by default.
-    expect(
-      screen.queryByTestId("mcp-apps-dimension-sandboxPermissions"),
-    ).toBeNull();
-    await user.click(screen.getByRole("button", { name: /Advanced/ }));
     expect(
       screen.getByTestId("mcp-apps-dimension-sandboxPermissions"),
     ).toBeInTheDocument();
+    expect(screen.queryByText("ADVANCED")).toBeNull();
+    expect(screen.queryByText(/Notifications & capabilities/i)).toBeNull();
   });
 
   it("clicking a display mode in the cluster updates the allowlist on the draft", async () => {
@@ -223,9 +219,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
     const { draftRef } = renderMatrix();
     // Claude's preset is [inline, fullscreen, pip]. Click "pip" to
     // remove it → override should be [inline, fullscreen].
-    const cluster = screen
-      .getByText("availableDisplayModes")
-      .closest("div")!.parentElement!;
+    const cluster = screen.getByTestId("mcp-apps-dimension-availableDisplayModes");
     await user.click(within(cluster).getByRole("button", { name: "pip" }));
     expect(
       draftRef.current.mcpProfile?.apps?.mcpAppsOverrides
@@ -238,9 +232,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
     const { draftRef } = renderMatrix({ hostStyle: "copilot" });
     // Copilot preset is already ["fullscreen"]; unchecking it should
     // coerce to ["inline"] (matrix invariant — never empty).
-    const cluster = screen
-      .getByText("availableDisplayModes")
-      .closest("div")!.parentElement!;
+    const cluster = screen.getByTestId("mcp-apps-dimension-availableDisplayModes");
     await user.click(
       within(cluster).getByRole("button", { name: "fullscreen" }),
     );
@@ -328,7 +320,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix legacy-override migration
     });
   });
 
-  it("'Match host preset' clears both the matrix override AND the legacy hostCapabilitiesOverride", async () => {
+  it("Reset clears both the matrix override AND the legacy hostCapabilitiesOverride", async () => {
     // The chip's contract is "revert to preset". If we only cleared
     // the matrix, the legacy path would silently keep the override
     // alive — the matrix would say "Matches host style preset" while
@@ -341,7 +333,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix legacy-override migration
         serverTools: {},
       },
     });
-    await user.click(screen.getByRole("button", { name: /Match host preset/ }));
+    await user.click(screen.getByRole("button", { name: "Reset" }));
     expect(draftRef.current.hostCapabilitiesOverride).toBeUndefined();
     expect(
       draftRef.current.mcpProfile?.apps?.mcpAppsOverrides,


### PR DESCRIPTION
Replace preset jargon with actionable summaries, flatten the MCP Apps dimension list, and only show canvas chip tags when overrides diverge from the host style.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-focused changes that adjust labeling, summaries, and when override tags appear; primary risk is confusing users if preset/override detection or counts are incorrect.
> 
> **Overview**
> Simplifies the Apps extension matrices by removing “from preset”/preset hint jargon, renaming `app.*` to **MCP Apps**, and flattening the MCP Apps boolean dimensions into a single list with hover descriptions.
> 
> Canvas injected-globals chips now only show subtitles when the effective value diverges from the host style preset (and show concise counts like `N/M methods` or `N overrides`), with `fromOverride` recalculated against the preset via `getCompatRuntimeForStyle`. Tests were updated/added to assert the new labeling, reset behavior, and absence of preset tags/hints at defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc2589a6ef71b3a2ee0f3de1bef43131eaa9564d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->