### PR TITLE
MCP App toggle

### DIFF
--- a/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/canvas/canvasBuilder.ts
@@ -28,6 +28,7 @@ import {
   type SandboxConfigSubKey,
 } from "../types";
 import { fieldsWithIssues } from "../focus/useClientDraftValidation";
+import { clientAdvertisesMcpApps } from "@/lib/host-capabilities";
 
 /* ============================================================
    Layout constants. The host renders as a single matrix node;
@@ -720,15 +721,17 @@ export function buildRedesignedHostCanvas(
     return { name, version };
   })();
 
-  // Whether the client advertises the MCP UI extension. Host-side Apps
-  // capabilities only matter when the client opts in to rendering iframes;
-  // a CLI like codex-mcp-client publishes neither the extension nor any
-  // UI ext block, so the matrix should hide the Apps section entirely.
-  const appsExtensionAdvertised = (() => {
-    const exts = draft.clientCapabilities?.extensions;
-    if (!isRecord(exts)) return false;
-    return isRecord(exts["io.modelcontextprotocol/ui"]);
-  })();
+  // Whether the client advertises the MCP UI extension with the spec-
+  // required MIME type. Host-side Apps capabilities only matter when the
+  // client opts in to rendering iframes; a CLI like codex-mcp-client
+  // publishes neither the extension nor any UI ext block, so the matrix
+  // should hide the Apps section entirely. Shared predicate keeps this
+  // gate aligned with `hostSupportsWidgetRendering` at runtime — earlier
+  // versions accepted a bare `{}` payload here while the renderer
+  // refused, which silently desynced the canvas from what would render.
+  const appsExtensionAdvertised = clientAdvertisesMcpApps(
+    draft.clientCapabilities,
+  );
 
   // Resolved vendor compat-runtime shim state. Drives the "Compat
   // shims" chip in the matrix. The "fromOverride" flag tracks whether

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -1300,13 +1300,6 @@ function McpAppsCapabilityMatrix({
       : legacyOverride !== undefined
         ? (hostCapabilitiesOverrideToMatrix(legacyOverride) ?? undefined)
         : undefined;
-  // Preset baseline alone (no override applied) — used when toggling rows
-  // back to preset values. The "Overridden" badge tracks divergences.
-  const presetCapabilities: ResolvedMcpAppsCapabilities =
-    resolveEffectiveMcpAppsCapabilities({
-      profile: undefined,
-      hostStyle: draft.hostStyle,
-    });
   // Effective values shown in the matrix UI. Uses the virtually-
   // migrated legacy when the matrix is absent so the UI shows what
   // the resolver advertises today (legacy path) — not what it would

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -19,7 +19,16 @@ import type {
   ResolvedMcpAppsCapabilities,
   ResolvedOpenAiAppsCapabilities,
 } from "@/lib/client-styles";
+import {
+  getDefaultClientCapabilities,
+  MCP_UI_EXTENSION_ID,
+  MCP_UI_RESOURCE_MIME_TYPE,
+} from "@mcpjam/sdk/browser";
 import { Switch } from "@mcpjam/design-system/switch";
+import {
+  clientAdvertisesMcpApps,
+  isRecord,
+} from "@/lib/host-capabilities";
 import type { HostAttentionIssue, SandboxConfigSubKey } from "../types";
 import { useJsonDraftBuffer } from "./useJsonDraftBuffer";
 
@@ -996,14 +1005,11 @@ function OpenaiAppsCapabilityMatrix({
                     >
                       <div className="flex flex-col gap-0.5">
                         <span className="font-mono text-[12px]">{label}</span>
-                        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-                          <span>Preset: {String(presetValue)}</span>
-                          {overridden ? (
-                            <span className="rounded bg-orange-500/15 px-1 py-px text-orange-600 dark:text-orange-300">
-                              Overridden
-                            </span>
-                          ) : null}
-                        </div>
+                        {overridden ? (
+                          <span className="w-fit rounded bg-orange-500/15 px-1 py-px text-[10px] text-orange-600 dark:text-orange-300">
+                            Overridden
+                          </span>
+                        ) : null}
                       </div>
                       {key === "requestDisplayMode" ? (
                         <RequestDisplayModeControl
@@ -1149,46 +1155,93 @@ function setMcpAppsOverridesOnDraft(
   };
 }
 
-/**
- * Main-disclosure matrix dimensions — the rows that vary across
- * published host tables (Microsoft 365 Copilot's M365 reference). Order
- * matches the M365 Component-bridge table where applicable.
- */
-const MCP_APPS_MAIN_DIMENSIONS: Array<{
-  key: Exclude<keyof McpAppsCapabilities, "availableDisplayModes">;
-  label: string;
-}> = [
-  { key: "toolInputPartial", label: "toolInputPartial" },
-  { key: "toolCancelled", label: "toolCancelled" },
-  { key: "hostContextChanged", label: "hostContextChanged" },
-  { key: "resourceTeardown", label: "resourceTeardown" },
-  { key: "serverResources", label: "serverResources" },
-  { key: "logging", label: "logging" },
-];
+type McpAppsDimensionKey = Exclude<
+  keyof McpAppsCapabilities,
+  "availableDisplayModes"
+>;
 
-/**
- * Advanced disclosure — rare dimensions that rarely vary across hosts
- * but are needed for completeness (sandbox sub-fields, resource-meta
- * interpretation, HostContext fine grain, hands-off advertise rows
- * that almost every preset enables).
- */
-const MCP_APPS_ADVANCED_DIMENSIONS: Array<{
-  key: Exclude<keyof McpAppsCapabilities, "availableDisplayModes">;
-  label: string;
-}> = [
-  { key: "toolInfo", label: "toolInfo" },
-  { key: "openLinks", label: "openLinks" },
-  { key: "serverTools", label: "serverTools" },
-  { key: "updateModelContext", label: "updateModelContext" },
-  { key: "message", label: "message" },
-  { key: "sandboxPermissions", label: "sandbox.permissions" },
-  { key: "cspFrameDomains", label: "sandbox.csp.frameDomains" },
-  { key: "cspBaseUriDomains", label: "sandbox.csp.baseUriDomains" },
-  { key: "resourcePrefersBorder", label: "_meta.ui.prefersBorder" },
+/** Per-dimension matrix metadata. Description is shown on row hover. */
+type McpAppsDimensionMeta = {
+  key: McpAppsDimensionKey;
+  description: string;
+};
+
+/** All boolean MCP Apps matrix dimensions in display order. */
+const MCP_APPS_DIMENSIONS: McpAppsDimensionMeta[] = [
+  {
+    key: "toolInputPartial",
+    description:
+      "Send ui/notifications/tool-input-partial while the agent streams arguments",
+  },
+  {
+    key: "toolCancelled",
+    description:
+      "Notify the app when tool execution is cancelled (ui/notifications/tool-cancelled)",
+  },
+  {
+    key: "hostContextChanged",
+    description:
+      "Notify the app when theme, display mode, or other host context changes",
+  },
+  {
+    key: "resourceTeardown",
+    description:
+      "Send ui/resource-teardown before destroying the app view",
+  },
+  {
+    key: "serverResources",
+    description: "Advertise resources/read proxy capability in ui/initialize",
+  },
+  {
+    key: "logging",
+    description: "Accept notifications/message log calls from the app",
+  },
+  {
+    key: "toolInfo",
+    description: "Include calling-tool metadata in HostContext.toolInfo",
+  },
+  {
+    key: "openLinks",
+    description: "Advertise ui/open-link capability",
+  },
+  {
+    key: "serverTools",
+    description: "Advertise tools/call proxy capability",
+  },
+  {
+    key: "updateModelContext",
+    description: "Accept ui/update-model-context requests from the app",
+  },
+  {
+    key: "message",
+    description: "Accept ui/message requests that add content to the conversation",
+  },
+  {
+    key: "sandboxPermissions",
+    description: "Honor _meta.ui.permissions when configuring the iframe",
+  },
+  {
+    key: "cspFrameDomains",
+    description: "Honor _meta.ui.csp.frameDomains for nested iframes",
+  },
+  {
+    key: "cspBaseUriDomains",
+    description: "Honor _meta.ui.csp.baseUriDomains in CSP",
+  },
+  {
+    key: "resourcePrefersBorder",
+    description: "Honor _meta.ui.prefersBorder when rendering app chrome",
+  },
 ];
 
 const ALL_DISPLAY_MODES = ["inline", "fullscreen", "pip"] as const;
 type DisplayMode = (typeof ALL_DISPLAY_MODES)[number];
+
+const DISPLAY_MODE_LABELS: Record<DisplayMode, string> = {
+  inline: "Inline",
+  fullscreen: "Fullscreen",
+  pip: "PiP",
+};
 
 /**
  * Per-dimension capability matrix for the SEP-1865 `app.*` spec bridge.
@@ -1198,16 +1251,12 @@ type DisplayMode = (typeof ALL_DISPLAY_MODES)[number];
  * no tri-state (the matrix is always advertised).
  *
  * Layout:
- * - `availableDisplayModes` cluster at the top (multi-checkbox for the
- *   array allowlist; inline is force-enabled if user clears all three).
- * - Main disclosure: notification gates + serverResources / logging —
- *   the rows that vary across published host tables.
- * - Advanced disclosure: sandbox sub-fields, resource-meta, toolInfo,
- *   and advertise rows that almost every preset enables (still
- *   surfaced so legacy `{}` migrations are visible).
+ * - `availableDisplayModes` cluster at the top.
+ * - Flat list of all boolean matrix dimensions below.
  * - Per-row "Overridden" badge when the user has diverged from the
  *   host style preset; rows show the preset value for context.
- * - "Match host preset" chip clears the entire matrix override.
+ * - "Reset" button clears the entire matrix override (shown only when
+ *   overrides are active).
  *
  * The matrix round-trips through `appsToJson` / `applyJsonToDraft` so
  * the JSON editor below stays in sync.
@@ -1225,7 +1274,8 @@ function McpAppsCapabilityMatrix({
     updater: (prev: HostConfigInputV2) => HostConfigInputV2,
   ) => void;
 }) {
-  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [dimensionsOpen, setDimensionsOpen] = useState(false);
+  const advertised = clientAdvertisesMcpApps(draft.clientCapabilities);
   const rawOverridesRecord = draft.mcpProfile?.apps?.mcpAppsOverrides;
   const legacyOverride = draft.hostCapabilitiesOverride;
   // Legacy `hostCapabilitiesOverride` is the pre-matrix way of
@@ -1250,8 +1300,8 @@ function McpAppsCapabilityMatrix({
       : legacyOverride !== undefined
         ? (hostCapabilitiesOverrideToMatrix(legacyOverride) ?? undefined)
         : undefined;
-  // Preset baseline alone (no override applied) — used to compute the
-  // per-row "Preset: X" hint and the "Overridden" badge.
+  // Preset baseline alone (no override applied) — used when toggling rows
+  // back to preset values. The "Overridden" badge tracks divergences.
   const presetCapabilities: ResolvedMcpAppsCapabilities =
     resolveEffectiveMcpAppsCapabilities({
       profile: undefined,
@@ -1318,8 +1368,50 @@ function McpAppsCapabilityMatrix({
     };
   };
 
-  const clearOverride = () => {
-    // "Match host preset" clears BOTH paths — the matrix override
+  const setAdvertised = (next: boolean) => {
+    onDraftChange((prev) => {
+      const nextCaps: Record<string, unknown> = {
+        ...(prev.clientCapabilities ?? {}),
+      };
+      const exts: Record<string, unknown> = isRecord(nextCaps.extensions)
+        ? { ...nextCaps.extensions }
+        : {};
+      if (next) {
+        const defaultCaps = getDefaultClientCapabilities() as Record<
+          string,
+          unknown
+        >;
+        const defaultExts = isRecord(defaultCaps.extensions)
+          ? defaultCaps.extensions
+          : {};
+        const defaultUi = defaultExts[MCP_UI_EXTENSION_ID];
+        exts[MCP_UI_EXTENSION_ID] = isRecord(defaultUi)
+          ? { ...defaultUi }
+          : { mimeTypes: [MCP_UI_RESOURCE_MIME_TYPE] };
+      } else {
+        delete exts[MCP_UI_EXTENSION_ID];
+      }
+      nextCaps.extensions = exts;
+      let nextDraft: HostConfigInputV2 = {
+        ...prev,
+        clientCapabilities: nextCaps,
+      };
+      if (!next) {
+        // Host-side caps are inert without the client extension — clear
+        // overrides the same way turning off window.openai injection
+        // clears per-method overrides.
+        nextDraft = setMcpAppsOverridesOnDraft(nextDraft, undefined);
+        if (nextDraft.hostCapabilitiesOverride !== undefined) {
+          nextDraft = { ...nextDraft, hostCapabilitiesOverride: undefined };
+        }
+      }
+      return nextDraft;
+    });
+  };
+
+  const clearOverride = (event?: { stopPropagation: () => void }) => {
+    event?.stopPropagation();
+    // Reset clears BOTH paths — the matrix override
     // and the legacy `hostCapabilitiesOverride` — so the resolver
     // falls back cleanly to the host style preset. Leaving the
     // legacy alive would silently keep the override active through
@@ -1410,63 +1502,103 @@ function McpAppsCapabilityMatrix({
   const overrideCount = hasAnyOverride
     ? Object.keys(effectiveOverridesForDisplay!).length
     : 0;
-  const subline = hasAnyOverride
-    ? `${overrideCount} ${overrideCount === 1 ? "override" : "overrides"} active${
+  const sublineParts: string[] = [];
+  if (advertised && hasAnyOverride) {
+    sublineParts.push(
+      `${overrideCount} ${overrideCount === 1 ? "override" : "overrides"} active${
         rawOverridesRecord === undefined && legacyOverride !== undefined
           ? " (legacy)"
           : ""
-      }`
-    : "Matches host style preset";
+      }`,
+    );
+  }
+  const subline = sublineParts.join(" · ");
 
   return (
     <div className="rounded-[10px] border border-border bg-background">
-      {/* Header strip: section label + override count + clear-to-preset chip. */}
+      {/* Single header row: left half is the disclosure (label + subline +
+          chevron), right half is the master Switch in its own hit zone.
+          Mirrors the window.openai section above. When the client does
+          not advertise the MCP UI extension the disclosure renders as
+          static (chevron hidden, no hover) since the dimension list is
+          inert without it. */}
       <div className="flex items-stretch border-b border-border">
-        <div className="flex flex-1 flex-col gap-0.5 px-3.5 py-2.5">
-          <span className="text-[12px] font-medium">
-            <span className="font-mono">app.*</span> spec bridge
-            <span className="ml-1.5 text-[10px] font-normal text-muted-foreground">
-              (SEP-1865)
-            </span>
-          </span>
-          <span className="text-[11px] text-muted-foreground">{subline}</span>
-        </div>
-        <div className="flex items-center border-l border-border pr-3.5 pl-3">
+        {advertised ? (
           <button
             type="button"
-            disabled={!hasAnyOverride}
-            onClick={clearOverride}
-            className="rounded border border-border bg-background px-2 py-0.5 text-[11px] text-muted-foreground transition hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed"
-            title="Clear all overrides on this matrix and revert every dimension to the host style preset"
+            onClick={() => setDimensionsOpen((v) => !v)}
+            aria-expanded={dimensionsOpen}
+            aria-controls="apps-extension-mcp-apps-dimensions"
+            className="flex flex-1 items-center justify-between gap-2 px-3.5 py-2.5 text-left hover:bg-muted/40"
           >
-            Match host preset
+            <div className="flex flex-col gap-0.5">
+              <span className="text-[12px] font-medium">MCP App support</span>
+              {subline ? (
+                <span className="text-[11px] text-muted-foreground">
+                  {subline}
+                  {" · "}
+                  <span
+                    role="link"
+                    tabIndex={0}
+                    className="cursor-pointer underline hover:text-foreground"
+                    onClick={(event) => clearOverride(event)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        clearOverride(event);
+                      }
+                    }}
+                  >
+                    Reset
+                  </span>
+                </span>
+              ) : null}
+            </div>
+            <ChevronDown
+              className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${
+                dimensionsOpen ? "rotate-180" : ""
+              }`}
+            />
           </button>
+        ) : (
+          <div className="flex flex-1 items-center px-3.5 py-2.5">
+            <label
+              htmlFor="apps-extension-mcp-apps-toggle"
+              className="text-[12px] font-medium"
+            >
+              MCP App support
+            </label>
+          </div>
+        )}
+        <div className="flex items-center border-l border-border pl-3 pr-3.5">
+          <Switch
+            id="apps-extension-mcp-apps-toggle"
+            checked={advertised}
+            onCheckedChange={setAdvertised}
+            aria-label="Advertise MCP App support"
+          />
         </div>
       </div>
 
-      {/* availableDisplayModes — multi-checkbox cluster. Always visible
-          (it's the most-edited dimension and the one published host
-          tables most prominently differ on, e.g. Copilot is fullscreen-
-          only). */}
-      <div className="flex items-center justify-between gap-3 border-b border-border/50 px-3.5 py-2">
-        <div className="flex flex-col gap-0.5">
-          <span className="font-mono text-[12px]">availableDisplayModes</span>
-          <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-            <span>
-              Preset:{" "}
-              <span className="font-mono">
-                [{presetCapabilities.availableDisplayModes.join(", ")}]
-              </span>
-            </span>
+      {advertised && dimensionsOpen ? (
+        <div id="apps-extension-mcp-apps-dimensions">
+          {/* availableDisplayModes — multi-checkbox cluster. */}
+          <div
+            data-testid="mcp-apps-dimension-availableDisplayModes"
+            className="flex items-center justify-between gap-3 border-b border-border/50 px-3.5 py-2"
+          >
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5">
+            <span className="font-mono text-[12px]">availableDisplayModes</span>
             {effectiveOverridesForDisplay?.availableDisplayModes !==
             undefined ? (
-              <span className="rounded bg-orange-500/15 px-1 py-px text-orange-600 dark:text-orange-300">
+              <span className="rounded bg-orange-500/15 px-1 py-px text-[10px] text-orange-600 dark:text-orange-300">
                 Overridden
               </span>
             ) : null}
           </div>
         </div>
-        <div className="inline-flex overflow-hidden rounded-md border border-border text-[11px]">
+        <div className="inline-flex shrink-0 overflow-hidden rounded-md border border-border text-[11px]">
           {ALL_DISPLAY_MODES.map((mode) => {
             const enabled =
               effectiveCapabilities.availableDisplayModes.includes(mode);
@@ -1474,94 +1606,54 @@ function McpAppsCapabilityMatrix({
               <button
                 key={mode}
                 type="button"
+                aria-label={mode}
+                title={mode}
                 className={
                   enabled
-                    ? "bg-foreground/10 px-2 py-0.5 font-medium"
-                    : "px-2 py-0.5 text-muted-foreground hover:bg-muted"
+                    ? "bg-foreground/10 px-2.5 py-0.5 font-medium"
+                    : "px-2.5 py-0.5 text-muted-foreground hover:bg-muted"
                 }
                 onClick={() => toggleDisplayMode(mode)}
               >
-                {mode}
+                {DISPLAY_MODE_LABELS[mode]}
               </button>
             );
           })}
         </div>
       </div>
 
-      {/* Main dimensions — notification gates + serverResources / logging. */}
-      <div className="flex flex-col">
-        {MCP_APPS_MAIN_DIMENSIONS.map(({ key, label }) => (
-          <McpAppsDimensionRow
-            key={key}
-            dimensionKey={key}
-            label={label}
-            effective={Boolean(effectiveCapabilities[key])}
-            presetValue={Boolean(presetCapabilities[key])}
-            overridden={
-              effectiveOverridesForDisplay !== undefined &&
-              key in effectiveOverridesForDisplay
-            }
-            onToggle={(next) => setBooleanOverride(key, next)}
-          />
-        ))}
-      </div>
-
-      {/* Advanced disclosure — sandbox sub-fields, resource-meta,
-          toolInfo, plus the "always on across every preset" advertise
-          rows. Surfaced so legacy `{}` migrations are visible and
-          unusual hosts can be modeled. */}
-      <button
-        type="button"
-        onClick={() => setAdvancedOpen((v) => !v)}
-        aria-expanded={advancedOpen}
-        aria-controls="apps-extension-mcp-apps-advanced"
-        className="flex w-full items-center justify-between gap-2 border-t border-border/50 px-3.5 py-2 text-left text-[11px] text-muted-foreground hover:bg-muted/40"
-      >
-        <span>Advanced ({MCP_APPS_ADVANCED_DIMENSIONS.length} dimensions)</span>
-        <ChevronDown
-          className={`h-3.5 w-3.5 shrink-0 transition-transform ${
-            advancedOpen ? "rotate-180" : ""
-          }`}
-        />
-      </button>
-      {advancedOpen ? (
-        <div
-          id="apps-extension-mcp-apps-advanced"
-          className="flex flex-col border-t border-border/50"
-        >
-          {MCP_APPS_ADVANCED_DIMENSIONS.map(({ key, label }) => (
-            <McpAppsDimensionRow
-              key={key}
-              dimensionKey={key}
-              label={label}
-              effective={Boolean(effectiveCapabilities[key])}
-              presetValue={Boolean(presetCapabilities[key])}
-              overridden={
-                effectiveOverridesForDisplay !== undefined &&
-                key in effectiveOverridesForDisplay
-              }
-              onToggle={(next) => setBooleanOverride(key, next)}
-            />
-          ))}
+          <div className="flex flex-col">
+            {MCP_APPS_DIMENSIONS.map(({ key, description }) => (
+              <McpAppsDimensionRow
+                key={key}
+                dimensionKey={key}
+                description={description}
+                effective={Boolean(effectiveCapabilities[key])}
+                overridden={
+                  effectiveOverridesForDisplay !== undefined &&
+                  key in effectiveOverridesForDisplay
+                }
+                onToggle={(next) => setBooleanOverride(key, next)}
+              />
+            ))}
+          </div>
         </div>
       ) : null}
     </div>
   );
 }
 
-/** Single boolean dimension row — preset hint + overridden badge + toggle. */
+/** Single boolean dimension row — technical key + optional overridden badge. */
 function McpAppsDimensionRow({
   dimensionKey,
-  label,
+  description,
   effective,
-  presetValue,
   overridden,
   onToggle,
 }: {
-  dimensionKey: Exclude<keyof McpAppsCapabilities, "availableDisplayModes">;
-  label: string;
+  dimensionKey: McpAppsDimensionKey;
+  description: string;
   effective: boolean;
-  presetValue: boolean;
   overridden: boolean;
   onToggle: (next: boolean) => void;
 }) {
@@ -1569,22 +1661,20 @@ function McpAppsDimensionRow({
     <div
       data-testid={`mcp-apps-dimension-${dimensionKey}`}
       className="flex items-center justify-between gap-3 border-b border-border/50 px-3.5 py-2 last:border-b-0"
+      title={description}
     >
-      <div className="flex flex-col gap-0.5">
-        <span className="font-mono text-[12px]">{label}</span>
-        <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
-          <span>Preset: {String(presetValue)}</span>
-          {overridden ? (
-            <span className="rounded bg-orange-500/15 px-1 py-px text-orange-600 dark:text-orange-300">
-              Overridden
-            </span>
-          ) : null}
-        </div>
+      <div className="min-w-0 flex flex-col gap-0.5">
+        <span className="font-mono text-[12px]">{dimensionKey}</span>
+        {overridden ? (
+          <span className="w-fit rounded bg-orange-500/15 px-1 py-px text-[10px] text-orange-600 dark:text-orange-300">
+            Overridden
+          </span>
+        ) : null}
       </div>
       <Switch
         checked={effective}
         onCheckedChange={onToggle}
-        aria-label={label}
+        aria-label={dimensionKey}
       />
     </div>
   );

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -1384,21 +1384,21 @@ function McpAppsCapabilityMatrix({
       } else {
         delete exts[MCP_UI_EXTENSION_ID];
       }
-      nextCaps.extensions = exts;
-      let nextDraft: HostConfigInputV2 = {
-        ...prev,
-        clientCapabilities: nextCaps,
-      };
-      if (!next) {
-        // Host-side caps are inert without the client extension — clear
-        // overrides the same way turning off window.openai injection
-        // clears per-method overrides.
-        nextDraft = setMcpAppsOverridesOnDraft(nextDraft, undefined);
-        if (nextDraft.hostCapabilitiesOverride !== undefined) {
-          nextDraft = { ...nextDraft, hostCapabilitiesOverride: undefined };
-        }
+      // Preserve sibling extension keys when present; drop the envelope
+      // entirely when emptied so `appsToJson` / `applyJsonToDraft` and
+      // the JSON editor agree (an empty `extensions: {}` is the kind of
+      // hidden dirty shape the round-trip helpers collapse away).
+      if (Object.keys(exts).length === 0) {
+        delete nextCaps.extensions;
+      } else {
+        nextCaps.extensions = exts;
       }
-      return nextDraft;
+      // Overrides are preserved across master toggle — turning the
+      // master switch off leaves any configured `mcpAppsOverrides` /
+      // legacy `hostCapabilitiesOverride` dormant so toggling back on
+      // restores the user's prior per-dimension model. "Reset" is the
+      // explicit destructive action for clearing overrides.
+      return { ...prev, clientCapabilities: nextCaps };
     });
   };
 
@@ -1495,17 +1495,15 @@ function McpAppsCapabilityMatrix({
   const overrideCount = hasAnyOverride
     ? Object.keys(effectiveOverridesForDisplay!).length
     : 0;
-  const sublineParts: string[] = [];
-  if (advertised && hasAnyOverride) {
-    sublineParts.push(
-      `${overrideCount} ${overrideCount === 1 ? "override" : "overrides"} active${
-        rawOverridesRecord === undefined && legacyOverride !== undefined
-          ? " (legacy)"
-          : ""
-      }`,
-    );
-  }
-  const subline = sublineParts.join(" · ");
+  const showResetButton = advertised && hasAnyOverride;
+  const subline =
+    advertised && hasAnyOverride
+      ? `${overrideCount} ${overrideCount === 1 ? "override" : "overrides"} active${
+          rawOverridesRecord === undefined && legacyOverride !== undefined
+            ? " (legacy)"
+            : ""
+        }`
+      : "";
 
   return (
     <div className="rounded-[10px] border border-border bg-background">
@@ -1529,21 +1527,6 @@ function McpAppsCapabilityMatrix({
               {subline ? (
                 <span className="text-[11px] text-muted-foreground">
                   {subline}
-                  {" · "}
-                  <span
-                    role="link"
-                    tabIndex={0}
-                    className="cursor-pointer underline hover:text-foreground"
-                    onClick={(event) => clearOverride(event)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter" || event.key === " ") {
-                        event.preventDefault();
-                        clearOverride(event);
-                      }
-                    }}
-                  >
-                    Reset
-                  </span>
                 </span>
               ) : null}
             </div>
@@ -1563,6 +1546,20 @@ function McpAppsCapabilityMatrix({
             </label>
           </div>
         )}
+        {showResetButton ? (
+          // Sibling of the disclosure button — nesting an interactive
+          // Reset control inside a `<button>` is invalid and confuses
+          // keyboard / screen-reader users.
+          <div className="flex items-center border-l border-border px-3">
+            <button
+              type="button"
+              onClick={() => clearOverride()}
+              className="cursor-pointer text-[11px] text-muted-foreground underline hover:text-foreground"
+            >
+              Reset
+            </button>
+          </div>
+        ) : null}
         <div className="flex items-center border-l border-border pl-3 pr-3.5">
           <Switch
             id="apps-extension-mcp-apps-toggle"

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
@@ -210,14 +210,14 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
         attention={[]}
       />,
     );
-    const reset = screen.getByRole("link", { name: "Reset" });
+    const reset = screen.getByRole("button", { name: "Reset" });
     await user.click(reset);
     expect(draftRef.current.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
   });
 
-  it("hides the Reset link when no override is set", () => {
+  it("hides the Reset button when no override is set", () => {
     renderMatrix();
-    expect(screen.queryByRole("link", { name: "Reset" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Reset" })).toBeNull();
   });
 
   it("renders the master advertise switch in the header", () => {
@@ -266,6 +266,50 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
       draftRef.current.mcpProfile?.apps?.mcpAppsOverrides
         ?.availableDisplayModes,
     ).toEqual(["inline"]);
+  });
+
+  it("master toggle off preserves mcpAppsOverrides as dormant state (Reset stays the destructive action)", async () => {
+    // The master switch turns advertising off without losing the
+    // user's per-dimension model — toggling back on must restore the
+    // exact override set, not start fresh.
+    const user = userEvent.setup();
+    const { draftRef } = renderMatrix();
+    await expandMcpAppsDimensions(user);
+    const row = screen.getByTestId("mcp-apps-dimension-toolInputPartial");
+    await user.click(within(row).getByRole("switch")); // write override
+    expect(
+      draftRef.current.mcpProfile?.apps?.mcpAppsOverrides,
+    ).toEqual({ toolInputPartial: false });
+    // Master off → overrides persist (dormant), only the extension
+    // advertisement flips.
+    await user.click(
+      screen.getByRole("switch", { name: "Advertise MCP App support" }),
+    );
+    expect(
+      draftRef.current.mcpProfile?.apps?.mcpAppsOverrides,
+    ).toEqual({ toolInputPartial: false });
+    // Master back on → user sees the same override they configured.
+    await user.click(
+      screen.getByRole("switch", { name: "Advertise MCP App support" }),
+    );
+    expect(
+      draftRef.current.mcpProfile?.apps?.mcpAppsOverrides,
+    ).toEqual({ toolInputPartial: false });
+  });
+
+  it("master toggle off does not leave a dirty empty `extensions: {}` envelope", async () => {
+    // After deleting the only extension key the envelope must collapse
+    // — `appsToJson` / `applyJsonToDraft` hide empty extensions, so a
+    // residual `{}` would diverge from what the JSON editor shows.
+    const user = userEvent.setup();
+    const { draftRef } = renderMatrix();
+    await user.click(
+      screen.getByRole("switch", { name: "Advertise MCP App support" }),
+    );
+    expect(
+      (draftRef.current.clientCapabilities as Record<string, unknown>)
+        ?.extensions,
+    ).toBeUndefined();
   });
 });
 
@@ -356,7 +400,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix legacy-override migration
         serverTools: {},
       },
     });
-    await user.click(screen.getByRole("link", { name: "Reset" }));
+    await user.click(screen.getByRole("button", { name: "Reset" }));
     expect(draftRef.current.hostCapabilitiesOverride).toBeUndefined();
     expect(
       draftRef.current.mcpProfile?.apps?.mcpAppsOverrides,

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
@@ -53,26 +53,37 @@ function renderMatrix(initial?: Partial<HostConfigInputV2>) {
   return { draftRef, ...utils };
 }
 
+async function expandMcpAppsDimensions(
+  user: ReturnType<typeof userEvent.setup>,
+) {
+  await user.click(
+    screen.getByRole("button", { name: /MCP App support/i }),
+  );
+}
+
 describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
-  it("renders the spec-bridge section with the SEP-1865 label", () => {
+  it("renders the MCP App support section header", () => {
     renderMatrix();
-    // Two-matrix architecture: window.openai and app.* are sibling
-    // sections in the same tab. The label disambiguates them.
-    expect(screen.getByText("app.*")).toBeInTheDocument();
-    expect(screen.getByText(/SEP-1865/)).toBeInTheDocument();
+    expect(screen.getByText("MCP App support")).toBeInTheDocument();
   });
 
-  it("starts at 'Matches host style preset' subline when no override is set", () => {
+  it("does not show Preset hints on matrix rows", () => {
     renderMatrix();
-    expect(screen.getByText(/Matches host style preset/)).toBeInTheDocument();
+    expect(screen.queryByText(/^Preset:/)).toBeNull();
   });
 
-  it("renders the availableDisplayModes cluster with Claude's preset (all three modes)", () => {
+  it("hides the header subline when no override is set", () => {
     renderMatrix();
+    expect(screen.queryByText(/enabled$/)).toBeNull();
+    expect(screen.queryByText(/Matches host style preset/)).toBeNull();
+  });
+
+  it("renders the availableDisplayModes cluster with Claude's preset (all three modes)", async () => {
+    const user = userEvent.setup();
+    renderMatrix();
+    await expandMcpAppsDimensions(user);
     // Claude advertises the FULL surface: inline + fullscreen + pip.
-    const cluster = screen
-      .getByText("availableDisplayModes")
-      .closest("div")!.parentElement!;
+    const cluster = screen.getByTestId("mcp-apps-dimension-availableDisplayModes");
     for (const mode of ["inline", "fullscreen", "pip"] as const) {
       const button = within(cluster).getByRole("button", { name: mode });
       // Selected modes use the elevated background class.
@@ -83,6 +94,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
   it("toggling a boolean dimension produces a sparse override on the draft", async () => {
     const user = userEvent.setup();
     const { draftRef } = renderMatrix();
+    await expandMcpAppsDimensions(user);
     // toolInputPartial is on by default in Claude's preset; toggling
     // the switch should write `false` to mcpAppsOverrides.
     const row = screen.getByTestId("mcp-apps-dimension-toolInputPartial");
@@ -96,6 +108,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
   it("toggling back to the preset value drops the override key (sparse on save)", async () => {
     const user = userEvent.setup();
     const { draftRef } = renderMatrix();
+    await expandMcpAppsDimensions(user);
     const row = screen.getByTestId("mcp-apps-dimension-toolInputPartial");
     const toggle = within(row).getByRole("switch");
     await user.click(toggle); // off (override)
@@ -114,6 +127,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
     // toggling it back must round-trip the draft exactly.
     const user = userEvent.setup();
     const { draftRef } = renderMatrix();
+    await expandMcpAppsDimensions(user);
     expect(draftRef.current.mcpProfile).toBeUndefined();
     const row = screen.getByTestId("mcp-apps-dimension-toolInputPartial");
     const toggle = within(row).getByRole("switch");
@@ -139,6 +153,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
         },
       },
     });
+    await expandMcpAppsDimensions(user);
     const row = screen.getByTestId("mcp-apps-dimension-toolInputPartial");
     const toggle = within(row).getByRole("switch");
     await user.click(toggle); // back to preset → drop the override key
@@ -148,7 +163,8 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
     );
   });
 
-  it("'Overridden' badge appears on rows where the user has diverged from the preset", () => {
+  it("'Overridden' badge appears on rows where the user has diverged from the preset", async () => {
+    const user = userEvent.setup();
     const draft = emptyHostConfigInputV2({ hostStyle: "claude" });
     draft.mcpProfile = {
       profileVersion: 1,
@@ -162,6 +178,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
         attention={[]}
       />,
     );
+    await expandMcpAppsDimensions(user);
     const overriddenRow = screen.getByTestId("mcp-apps-dimension-logging");
     expect(within(overriddenRow).getByText("Overridden")).toBeInTheDocument();
     // Sibling row (no override) does NOT carry the badge.
@@ -171,7 +188,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
     expect(within(cleanRow).queryByText("Overridden")).toBeNull();
   });
 
-  it("'Match host preset' chip clears the entire matrix override", async () => {
+  it("Reset button clears the entire matrix override", async () => {
     const user = userEvent.setup();
     const draft = emptyHostConfigInputV2({ hostStyle: "claude" });
     draft.mcpProfile = {
@@ -193,39 +210,41 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
         attention={[]}
       />,
     );
-    const chip = screen.getByRole("button", { name: /Match host preset/ });
-    expect(chip).toBeEnabled();
-    await user.click(chip);
+    const reset = screen.getByRole("link", { name: "Reset" });
+    await user.click(reset);
     expect(draftRef.current.mcpProfile?.apps?.mcpAppsOverrides).toBeUndefined();
   });
 
-  it("'Match host preset' chip is disabled when no override is set", () => {
+  it("hides the Reset link when no override is set", () => {
     renderMatrix();
-    const chip = screen.getByRole("button", { name: /Match host preset/ });
-    expect(chip).toBeDisabled();
+    expect(screen.queryByRole("link", { name: "Reset" })).toBeNull();
   });
 
-  it("the Advanced disclosure hides rare dimensions until expanded", async () => {
+  it("renders the master advertise switch in the header", () => {
+    renderMatrix();
+    expect(
+      screen.getByRole("switch", { name: "Advertise MCP App support" }),
+    ).toBeChecked();
+  });
+
+  it("renders all matrix dimensions in one flat list", async () => {
     const user = userEvent.setup();
     renderMatrix();
-    // Sandbox sub-fields live in Advanced — hidden by default.
-    expect(
-      screen.queryByTestId("mcp-apps-dimension-sandboxPermissions"),
-    ).toBeNull();
-    await user.click(screen.getByRole("button", { name: /Advanced/ }));
+    await expandMcpAppsDimensions(user);
     expect(
       screen.getByTestId("mcp-apps-dimension-sandboxPermissions"),
     ).toBeInTheDocument();
+    expect(screen.queryByText("ADVANCED")).toBeNull();
+    expect(screen.queryByText(/Notifications & capabilities/i)).toBeNull();
   });
 
   it("clicking a display mode in the cluster updates the allowlist on the draft", async () => {
     const user = userEvent.setup();
     const { draftRef } = renderMatrix();
+    await expandMcpAppsDimensions(user);
     // Claude's preset is [inline, fullscreen, pip]. Click "pip" to
     // remove it → override should be [inline, fullscreen].
-    const cluster = screen
-      .getByText("availableDisplayModes")
-      .closest("div")!.parentElement!;
+    const cluster = screen.getByTestId("mcp-apps-dimension-availableDisplayModes");
     await user.click(within(cluster).getByRole("button", { name: "pip" }));
     expect(
       draftRef.current.mcpProfile?.apps?.mcpAppsOverrides
@@ -236,11 +255,10 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
   it("force-enables inline when the user unchecks the last enabled mode", async () => {
     const user = userEvent.setup();
     const { draftRef } = renderMatrix({ hostStyle: "copilot" });
+    await expandMcpAppsDimensions(user);
     // Copilot preset is already ["fullscreen"]; unchecking it should
     // coerce to ["inline"] (matrix invariant — never empty).
-    const cluster = screen
-      .getByText("availableDisplayModes")
-      .closest("div")!.parentElement!;
+    const cluster = screen.getByTestId("mcp-apps-dimension-availableDisplayModes");
     await user.click(
       within(cluster).getByRole("button", { name: "fullscreen" }),
     );
@@ -252,7 +270,8 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
 });
 
 describe("AppsExtensionTab — McpAppsCapabilityMatrix legacy-override migration", () => {
-  it("displays a legacy hostCapabilitiesOverride as a virtually-migrated matrix (Overridden badges reflect what the resolver advertises)", () => {
+  it("displays a legacy hostCapabilitiesOverride as a virtually-migrated matrix (Overridden badges reflect what the resolver advertises)", async () => {
+    const user = userEvent.setup();
     // Regression (Codex Bot on #2236): if the draft has legacy
     // `hostCapabilitiesOverride` and no `mcpAppsOverrides`, the matrix
     // UI must reflect the legacy values — otherwise the first toggle
@@ -275,18 +294,14 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix legacy-override migration
         attention={[]}
       />,
     );
-    // serverResources and logging are missing from the legacy
-    // override → migrated matrix sets them to false → "Overridden"
-    // badge present because Claude's preset has them true.
+    expect(screen.getByText(/legacy/)).toBeInTheDocument();
+    await expandMcpAppsDimensions(user);
     const serverResources = screen.getByTestId(
       "mcp-apps-dimension-serverResources",
     );
     expect(within(serverResources).getByText("Overridden")).toBeInTheDocument();
     const logging = screen.getByTestId("mcp-apps-dimension-logging");
     expect(within(logging).getByText("Overridden")).toBeInTheDocument();
-    // Subline annotated as legacy so the user knows where the values
-    // came from.
-    expect(screen.getByText(/legacy/)).toBeInTheDocument();
   });
 
   it("migrates legacy → matrix on the first row toggle and clears the legacy field", async () => {
@@ -311,7 +326,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix legacy-override migration
     expect(
       draftRef.current.mcpProfile?.apps?.mcpAppsOverrides,
     ).toBeUndefined();
-    // User toggles a single sibling row (toolInputPartial).
+    await expandMcpAppsDimensions(user);
     const row = screen.getByTestId("mcp-apps-dimension-toolInputPartial");
     await user.click(within(row).getByRole("switch"));
     // Legacy cleared.
@@ -328,7 +343,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix legacy-override migration
     });
   });
 
-  it("'Match host preset' clears both the matrix override AND the legacy hostCapabilitiesOverride", async () => {
+  it("Reset clears both the matrix override AND the legacy hostCapabilitiesOverride", async () => {
     // The chip's contract is "revert to preset". If we only cleared
     // the matrix, the legacy path would silently keep the override
     // alive — the matrix would say "Matches host style preset" while
@@ -341,7 +356,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix legacy-override migration
         serverTools: {},
       },
     });
-    await user.click(screen.getByRole("button", { name: /Match host preset/ }));
+    await user.click(screen.getByRole("link", { name: "Reset" }));
     expect(draftRef.current.hostCapabilitiesOverride).toBeUndefined();
     expect(
       draftRef.current.mcpProfile?.apps?.mcpAppsOverrides,

--- a/mcpjam-inspector/client/src/lib/host-capabilities.ts
+++ b/mcpjam-inspector/client/src/lib/host-capabilities.ts
@@ -47,6 +47,22 @@ export function hostSupportsWidgetRendering(
   clientCapabilities: Record<string, unknown> | undefined
 ): boolean {
   if (clientCapabilities === undefined) return true;
+  return clientAdvertisesMcpApps(clientCapabilities);
+}
+
+/**
+ * Strict predicate: does this `clientCapabilities` blob advertise the MCP
+ * UI extension with the spec-required MIME type?
+ *
+ * Same shape check as `hostSupportsWidgetRendering` but treats `undefined`
+ * as `false` — the matrix UI and the canvas's "Apps section visible" gate
+ * need a concrete advertised/not-advertised answer, not the legacy
+ * "no host modeled → assume capable" semantics.
+ */
+export function clientAdvertisesMcpApps(
+  clientCapabilities: Record<string, unknown> | undefined
+): boolean {
+  if (!clientCapabilities) return false;
   const extensions = clientCapabilities.extensions;
   if (!isRecord(extensions)) return false;
   const uiExt = extensions[MCP_UI_EXTENSION_ID];
@@ -56,6 +72,6 @@ export function hostSupportsWidgetRendering(
   return mimeTypes.includes(MCP_UI_RESOURCE_MIME_TYPE);
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
+export function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how capability advertisement toggling mutates persisted config (`clientCapabilities.extensions`) and preserves/clears overrides, which could affect what hosts advertise and what the JSON editor round-trips.
> 
> **Overview**
> Adjusts the MCP Apps master "Advertise" toggle so it **no longer clears** `mcpAppsOverrides`/legacy `hostCapabilitiesOverride` when turned off; overrides remain dormant and are only removed via the explicit **Reset** action.
> 
> Fixes config dirtiness by collapsing `clientCapabilities.extensions` when it would otherwise become an empty `{}` after removing the MCP UI extension, keeping structured-editor state consistent with `appsToJson`/`applyJsonToDraft`.
> 
> Improves accessibility by moving **Reset** out of the disclosure `<button>` (now a sibling `button`), and updates/extends tests to cover the new Reset role and the non-destructive master toggle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb2c549e999c245c765e8076fa27fd19c9d11015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->