### PR TITLE
feat(skills): inspector sync + endpoints for Shared Project Skills V1

### DIFF
--- a/mcpjam-inspector/client/src/lib/apis/mcp-skills-api.ts
+++ b/mcpjam-inspector/client/src/lib/apis/mcp-skills-api.ts
@@ -21,16 +21,37 @@ export interface UploadSkillResponse {
 }
 
 /**
+ * A shared (project-published) skill, sourced from Convex. Distinct from a
+ * SkillListItem because it carries the publisher's identity for UI rendering
+ * and the Convex row id needed for update/archive calls.
+ */
+export interface SharedProjectSkillSummary {
+  skillId: string;
+  projectId: string;
+  creatorUserId: string;
+  creatorName: string | null;
+  creatorEmail: string | null;
+  creatorImageUrl: string | null;
+  name: string;
+  description: string;
+  status: "active" | "archived";
+  createdAt: number;
+  updatedAt: number;
+}
+
+/**
  * List all available skills from .mcpjam/skills/
  */
-export async function listSkills(): Promise<SkillListItem[]> {
+export async function listSkills(
+  opts?: { projectId?: string },
+): Promise<SkillListItem[]> {
   return runByMode({
     hosted: async () => [],
     local: async () => {
       const res = await authFetch("/api/mcp/skills/list", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
+        body: JSON.stringify({ projectId: opts?.projectId }),
       });
 
       let body: any = null;
@@ -51,13 +72,140 @@ export async function listSkills(): Promise<SkillListItem[]> {
 }
 
 /**
+ * List project-shared (published) skills. Returns [] when not signed in or
+ * when no projectId is available; the popover treats that as "show local
+ * skills only".
+ */
+export async function listProjectSkills(
+  projectId: string,
+  convexAuthToken: string,
+): Promise<SharedProjectSkillSummary[]> {
+  if (!projectId || !convexAuthToken) return [];
+  const res = await authFetch("/api/mcp/skills/list-project", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ projectId, convexAuthToken }),
+  });
+
+  let body: any = null;
+  try {
+    body = await res.json();
+  } catch {}
+
+  if (!res.ok) {
+    const message =
+      body?.error || `List project skills failed (${res.status})`;
+    throw new Error(message);
+  }
+
+  return Array.isArray(body?.skills)
+    ? (body.skills as SharedProjectSkillSummary[])
+    : [];
+}
+
+/**
+ * Trigger a server-side sync that pulls the project's shared skills from
+ * Convex onto disk so the filesystem-backed loader can use them.
+ */
+export async function syncProjectSkills(
+  projectId: string,
+  convexAuthToken: string,
+): Promise<{
+  materialized: string[];
+  pruned: number;
+  cacheDir: string;
+}> {
+  const res = await authFetch("/api/mcp/skills/sync-project", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ projectId, convexAuthToken }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(body?.error || `Sync project skills failed (${res.status})`);
+  }
+  return body;
+}
+
+/**
+ * Publish a local skill (by name) to the current project. Server reads the
+ * full bundle from the filesystem and writes it to Convex. Returns a
+ * structured `nameCollision` code when an active skill in the same project
+ * already uses the requested name.
+ */
+export async function publishSkillToProject(args: {
+  projectId: string;
+  convexAuthToken: string;
+  name: string;
+  publishAs?: string;
+}): Promise<
+  | { kind: "ok"; skill: SharedProjectSkillSummary }
+  | { kind: "nameCollision"; message: string }
+> {
+  const res = await authFetch("/api/mcp/skills/publish-to-project", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(args),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (res.status === 409 && body?.code === "nameCollision") {
+    return { kind: "nameCollision", message: body.error };
+  }
+  if (!res.ok) {
+    throw new Error(body?.error || `Publish failed (${res.status})`);
+  }
+  return { kind: "ok", skill: body.skill as SharedProjectSkillSummary };
+}
+
+/**
+ * Push the local copy of a previously-published skill back to Convex.
+ */
+export async function updatePublishedSkill(args: {
+  skillId: string;
+  convexAuthToken: string;
+  sourceName: string;
+}): Promise<SharedProjectSkillSummary> {
+  const res = await authFetch("/api/mcp/skills/update-published", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(args),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(body?.error || `Update failed (${res.status})`);
+  }
+  return body.skill as SharedProjectSkillSummary;
+}
+
+/**
+ * Archive (unshare) a published skill in Convex. Creator or admin/owner.
+ */
+export async function archivePublishedSkill(args: {
+  skillId: string;
+  convexAuthToken: string;
+}): Promise<void> {
+  const res = await authFetch("/api/mcp/skills/archive-published", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(args),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body?.error || `Archive failed (${res.status})`);
+  }
+}
+
+/**
  * Get full skill content by name
  */
-export async function getSkill(name: string): Promise<Skill> {
+export async function getSkill(
+  name: string,
+  opts?: { projectId?: string },
+): Promise<Skill> {
   const res = await authFetch("/api/mcp/skills/get", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name }),
+    body: JSON.stringify({ name, projectId: opts?.projectId }),
   });
 
   let body: any = null;
@@ -163,11 +311,14 @@ export async function deleteSkill(name: string): Promise<void> {
 /**
  * List all files in a skill directory
  */
-export async function listSkillFiles(name: string): Promise<SkillFile[]> {
+export async function listSkillFiles(
+  name: string,
+  opts?: { projectId?: string },
+): Promise<SkillFile[]> {
   const res = await authFetch("/api/mcp/skills/files", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name }),
+    body: JSON.stringify({ name, projectId: opts?.projectId }),
   });
 
   let body: any = null;
@@ -189,11 +340,12 @@ export async function listSkillFiles(name: string): Promise<SkillFile[]> {
 export async function readSkillFile(
   name: string,
   filePath: string,
+  opts?: { projectId?: string },
 ): Promise<SkillFileContent> {
   const res = await authFetch("/api/mcp/skills/read-file", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name, filePath }),
+    body: JSON.stringify({ name, filePath, projectId: opts?.projectId }),
   });
 
   let body: any = null;

--- a/mcpjam-inspector/server/routes/mcp/skills.ts
+++ b/mcpjam-inspector/server/routes/mcp/skills.ts
@@ -20,33 +20,73 @@ import type {
   SkillFile,
   SkillFileContent,
 } from "../../../shared/skill-types";
+import {
+  getSharedProjectSkillsCacheDir,
+  readLocalSkillBundle,
+  syncSharedProjectSkills,
+} from "../../services/project-skills-sync";
+import { ConvexHttpClient } from "convex/browser";
 
 const skills = new Hono();
 
 /**
- * Get all skills directories as absolute paths
+ * Read the optional `projectId` request hint that lets project-aware callers
+ * include the shared project skills cache in their search path. Local
+ * uploads, deletes, and unscoped listings stay backwards-compatible by
+ * leaving `projectId` undefined.
+ */
+function readProjectIdHint(body: unknown): string | undefined {
+  if (
+    body &&
+    typeof body === "object" &&
+    "projectId" in body &&
+    typeof (body as { projectId?: unknown }).projectId === "string"
+  ) {
+    const value = (body as { projectId: string }).projectId;
+    if (/^[A-Za-z0-9_-]+$/.test(value)) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Get all skills directories as absolute paths.
  *
  * Skills can come from:
- * 1. Global user skills: ~/.mcpjam/skills/ and ~/.agents/skills/
- * 2. Project-local skills: .mcpjam/skills/ and .agents/skills/ (relative to cwd)
+ * 1. Global user skills: ~/.claude/skills/, ~/.mcpjam/skills/, ~/.agents/skills/
+ * 2. Shared project skills cache: ~/.mcpjam/projects/<projectId>/skills/
+ * 3. Project-local skills: .claude/skills/, .mcpjam/skills/, .agents/skills/
  *
- * Order matters - first writable directory is used for uploads
+ * Order matters: first match wins for `findSkillDirectory`, so a global
+ * personal skill with the same name as a shared project skill overrides the
+ * shared copy. This keeps surprise low for users who already had a local
+ * skill named the same thing before joining the project.
  */
-function getSkillsDirs(): string[] {
+function getSkillsDirs(projectId?: string): string[] {
   const homeDir = os.homedir();
   const cwd = process.cwd();
 
-  return [
+  const dirs: string[] = [
     // Global skills (always accessible regardless of how app is launched)
     path.join(homeDir, ".claude", "skills"), // Claude Desktop global skills
     path.join(homeDir, ".mcpjam", "skills"), // MCPJam global skills
     path.join(homeDir, ".agents", "skills"), // npx skills global installs
+  ];
 
-    // Project-local skills (when launched from project directory)
+  // Shared project cache slot — populated by syncSharedProjectSkills(). Sits
+  // between global personal skills and project-local skills so a user's own
+  // global override wins, but the shared cache still beats per-cwd files.
+  if (projectId) {
+    dirs.push(getSharedProjectSkillsCacheDir(projectId));
+  }
+
+  // Project-local skills (when launched from project directory)
+  dirs.push(
     path.join(cwd, ".claude", "skills"), // Claude Desktop project skills
     path.join(cwd, ".mcpjam", "skills"),
     path.join(cwd, ".agents", "skills"),
-  ];
+  );
+
+  return dirs;
 }
 
 /**
@@ -84,8 +124,11 @@ async function directoryExists(dirPath: string): Promise<boolean> {
  * Find the directory path for a skill by name
  * Returns the full path to the skill directory, or null if not found
  */
-async function findSkillDirectory(name: string): Promise<string | null> {
-  const skillsDirs = getSkillsDirs();
+async function findSkillDirectory(
+  name: string,
+  projectId?: string,
+): Promise<string | null> {
+  const skillsDirs = getSkillsDirs(projectId);
 
   for (const skillsDir of skillsDirs) {
     if (!(await directoryExists(skillsDir))) {
@@ -121,7 +164,15 @@ async function findSkillDirectory(name: string): Promise<string | null> {
  */
 skills.post("/list", async (c) => {
   try {
-    const skillsDirs = getSkillsDirs();
+    // Body is optional for backwards compatibility — older clients post `{}`.
+    let body: unknown = null;
+    try {
+      body = await c.req.json();
+    } catch {
+      body = null;
+    }
+    const projectId = readProjectIdHint(body);
+    const skillsDirs = getSkillsDirs(projectId);
     const skillsList: SkillListItem[] = [];
     const seenNames = new Set<string>(); // Prevent duplicates by name
 
@@ -177,13 +228,18 @@ skills.post("/list", async (c) => {
  */
 skills.post("/get", async (c) => {
   try {
-    const { name } = (await c.req.json()) as { name?: string };
+    const body = (await c.req.json()) as {
+      name?: string;
+      projectId?: string;
+    };
+    const { name } = body;
 
     if (!name) {
       return c.json({ success: false, error: "name is required" }, 400);
     }
 
-    const skillsDirs = getSkillsDirs();
+    const projectId = readProjectIdHint(body);
+    const skillsDirs = getSkillsDirs(projectId);
 
     // Search through all skills directories
     for (const skillsDir of skillsDirs) {
@@ -530,13 +586,17 @@ skills.post("/delete", async (c) => {
  */
 skills.post("/files", async (c) => {
   try {
-    const { name } = (await c.req.json()) as { name?: string };
+    const body = (await c.req.json()) as {
+      name?: string;
+      projectId?: string;
+    };
+    const { name } = body;
 
     if (!name) {
       return c.json({ success: false, error: "name is required" }, 400);
     }
 
-    const skillDir = await findSkillDirectory(name);
+    const skillDir = await findSkillDirectory(name, readProjectIdHint(body));
     if (!skillDir) {
       return c.json(
         { success: false, error: `Skill '${name}' not found` },
@@ -563,10 +623,12 @@ skills.post("/files", async (c) => {
  */
 skills.post("/read-file", async (c) => {
   try {
-    const { name, filePath } = (await c.req.json()) as {
+    const body = (await c.req.json()) as {
       name?: string;
       filePath?: string;
+      projectId?: string;
     };
+    const { name, filePath } = body;
 
     if (!name) {
       return c.json({ success: false, error: "name is required" }, 400);
@@ -576,7 +638,7 @@ skills.post("/read-file", async (c) => {
       return c.json({ success: false, error: "filePath is required" }, 400);
     }
 
-    const skillDir = await findSkillDirectory(name);
+    const skillDir = await findSkillDirectory(name, readProjectIdHint(body));
     if (!skillDir) {
       return c.json(
         { success: false, error: `Skill '${name}' not found` },
@@ -638,6 +700,359 @@ skills.post("/read-file", async (c) => {
     }
   } catch (error) {
     logger.error("Error reading skill file", error);
+    return c.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      500,
+    );
+  }
+});
+
+/**
+ * Build a project-scoped Convex client using the auth token the client
+ * already plumbs through for other authenticated endpoints. Returns null and
+ * a 400-shaped error if either piece is missing — these endpoints only make
+ * sense when the inspector is signed in and aware of its project.
+ */
+function buildProjectConvexClient(opts: {
+  convexAuthToken?: string;
+}): ConvexHttpClient | null {
+  const url = process.env.CONVEX_URL;
+  if (!url || !opts.convexAuthToken) return null;
+  const client = new ConvexHttpClient(url);
+  client.setAuth(opts.convexAuthToken);
+  return client;
+}
+
+/**
+ * List active shared skills for a project from Convex (separate from the
+ * filesystem `/list` route so the popover can render shared vs local in
+ * different sections without one masking the other).
+ */
+skills.post("/list-project", async (c) => {
+  try {
+    const body = (await c.req.json()) as {
+      projectId?: string;
+      convexAuthToken?: string;
+    };
+    if (!body.projectId) {
+      return c.json({ success: false, error: "projectId is required" }, 400);
+    }
+    const client = buildProjectConvexClient(body);
+    if (!client) {
+      return c.json(
+        {
+          success: false,
+          error:
+            "Project-shared skills require a signed-in Convex session (set CONVEX_URL and pass convexAuthToken)",
+        },
+        400,
+      );
+    }
+    const summaries = await client.query(
+      "projectSkills:listProjectSkills" as any,
+      { projectId: body.projectId },
+    );
+    return c.json({ skills: summaries });
+  } catch (error) {
+    logger.error("Error listing project skills", error);
+    return c.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      500,
+    );
+  }
+});
+
+/**
+ * Sync the local cache for a project with Convex. Idempotent: re-callable
+ * after every popover open or after publish/update/archive to keep the
+ * filesystem cache and the canonical Convex copy in sync.
+ */
+skills.post("/sync-project", async (c) => {
+  try {
+    const body = (await c.req.json()) as {
+      projectId?: string;
+      convexAuthToken?: string;
+    };
+    if (!body.projectId) {
+      return c.json({ success: false, error: "projectId is required" }, 400);
+    }
+    if (!body.convexAuthToken) {
+      return c.json(
+        { success: false, error: "convexAuthToken is required" },
+        400,
+      );
+    }
+    const result = await syncSharedProjectSkills(
+      body.projectId,
+      body.convexAuthToken,
+    );
+    return c.json({ success: true, ...result });
+  } catch (error) {
+    logger.error("Error syncing project skills", error);
+    return c.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      500,
+    );
+  }
+});
+
+/**
+ * Publish a locally-stored skill to a project. The local copy stays where it
+ * is — this only copies the skill bundle into Convex so other members can
+ * sync it. Callers identify the local skill by name; we look it up in the
+ * filesystem precedence chain (NOT including the shared cache, since that
+ * would let us "publish" a copy of someone else's shared skill).
+ */
+skills.post("/publish-to-project", async (c) => {
+  try {
+    const body = (await c.req.json()) as {
+      projectId?: string;
+      convexAuthToken?: string;
+      name?: string;
+      // Optional override so the published copy can use a different name (for
+      // collision resolution). The on-disk local skill is NOT renamed.
+      publishAs?: string;
+    };
+
+    if (!body.projectId) {
+      return c.json({ success: false, error: "projectId is required" }, 400);
+    }
+    if (!body.convexAuthToken) {
+      return c.json(
+        { success: false, error: "convexAuthToken is required" },
+        400,
+      );
+    }
+    if (!body.name) {
+      return c.json({ success: false, error: "name is required" }, 400);
+    }
+    const publishName = body.publishAs ?? body.name;
+    if (!isValidSkillName(publishName)) {
+      return c.json(
+        { success: false, error: `Invalid publish name: ${publishName}` },
+        400,
+      );
+    }
+
+    // Resolve to the local-only filesystem dirs (no projectId here).
+    const localDir = await findSkillDirectory(body.name);
+    if (!localDir) {
+      return c.json(
+        { success: false, error: `Skill '${body.name}' not found locally` },
+        404,
+      );
+    }
+
+    const skillMdRaw = await fs.readFile(
+      path.join(localDir, "SKILL.md"),
+      "utf-8",
+    );
+    const parsed = parseSkillFile(skillMdRaw, localDir);
+    if (!parsed) {
+      return c.json(
+        {
+          success: false,
+          error: "Local SKILL.md is not valid; cannot publish",
+        },
+        400,
+      );
+    }
+
+    const { skillMd, files } = await readLocalSkillBundle(localDir);
+
+    // If publishing under a different name, rewrite the frontmatter `name`
+    // field so the materialized copy matches the published name on disk.
+    const normalizedSkillMd =
+      publishName === parsed.name
+        ? skillMd
+        : skillMd.replace(
+            /(^---[\s\S]*?^name:\s*)([^\n]+)(\n)/m,
+            `$1${publishName}$3`,
+          );
+
+    const client = buildProjectConvexClient(body);
+    if (!client) {
+      return c.json(
+        {
+          success: false,
+          error:
+            "Project-shared skills require a signed-in Convex session (set CONVEX_URL)",
+        },
+        400,
+      );
+    }
+
+    try {
+      const detail = await client.mutation(
+        "projectSkills:publishProjectSkill" as any,
+        {
+          projectId: body.projectId,
+          name: publishName,
+          description: parsed.description,
+          skillMd: normalizedSkillMd,
+          files,
+        },
+      );
+      return c.json({ success: true, skill: detail });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // Surface structured nameCollision so the popover/dialog can render
+      // the rename-and-publish affordance without parsing free text.
+      const match = message.match(/\{[^}]*nameCollision[^}]*\}/);
+      if (match) {
+        try {
+          const payload = JSON.parse(match[0]);
+          if (payload.code === "nameCollision") {
+            return c.json(
+              {
+                success: false,
+                error: payload.message,
+                code: "nameCollision",
+              },
+              409,
+            );
+          }
+        } catch {
+          // fall through
+        }
+      }
+      throw err;
+    }
+  } catch (error) {
+    logger.error("Error publishing project skill", error);
+    return c.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      500,
+    );
+  }
+});
+
+/**
+ * Push an updated copy of a locally-stored skill to its existing published
+ * row in Convex. Only the creator is allowed — Convex enforces this server-
+ * side too, but we surface the failure here for a nicer error.
+ */
+skills.post("/update-published", async (c) => {
+  try {
+    const body = (await c.req.json()) as {
+      skillId?: string;
+      convexAuthToken?: string;
+      // The local skill directory name to read from (defaults to the same
+      // name the published copy uses).
+      sourceName?: string;
+    };
+    if (!body.skillId) {
+      return c.json({ success: false, error: "skillId is required" }, 400);
+    }
+    if (!body.convexAuthToken) {
+      return c.json(
+        { success: false, error: "convexAuthToken is required" },
+        400,
+      );
+    }
+    if (!body.sourceName) {
+      return c.json(
+        { success: false, error: "sourceName is required" },
+        400,
+      );
+    }
+
+    const localDir = await findSkillDirectory(body.sourceName);
+    if (!localDir) {
+      return c.json(
+        {
+          success: false,
+          error: `Local skill '${body.sourceName}' not found`,
+        },
+        404,
+      );
+    }
+    const skillMdRaw = await fs.readFile(
+      path.join(localDir, "SKILL.md"),
+      "utf-8",
+    );
+    const parsed = parseSkillFile(skillMdRaw, localDir);
+    if (!parsed) {
+      return c.json(
+        { success: false, error: "Local SKILL.md is not valid" },
+        400,
+      );
+    }
+    const { skillMd, files } = await readLocalSkillBundle(localDir);
+
+    const client = buildProjectConvexClient(body);
+    if (!client) {
+      return c.json(
+        { success: false, error: "Project-shared skills require Convex" },
+        400,
+      );
+    }
+    const detail = await client.mutation(
+      "projectSkills:updateProjectSkill" as any,
+      {
+        skillId: body.skillId,
+        description: parsed.description,
+        skillMd,
+        files,
+      },
+    );
+    return c.json({ success: true, skill: detail });
+  } catch (error) {
+    logger.error("Error updating published skill", error);
+    return c.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      500,
+    );
+  }
+});
+
+/**
+ * Archive (unshare) a published project skill. Creator or project admin/
+ * owner can do this — Convex is authoritative on the permission check.
+ */
+skills.post("/archive-published", async (c) => {
+  try {
+    const body = (await c.req.json()) as {
+      skillId?: string;
+      convexAuthToken?: string;
+    };
+    if (!body.skillId) {
+      return c.json({ success: false, error: "skillId is required" }, 400);
+    }
+    if (!body.convexAuthToken) {
+      return c.json(
+        { success: false, error: "convexAuthToken is required" },
+        400,
+      );
+    }
+    const client = buildProjectConvexClient(body);
+    if (!client) {
+      return c.json(
+        { success: false, error: "Project-shared skills require Convex" },
+        400,
+      );
+    }
+    await client.mutation("projectSkills:archiveProjectSkill" as any, {
+      skillId: body.skillId,
+    });
+    return c.json({ success: true });
+  } catch (error) {
+    logger.error("Error archiving published skill", error);
     return c.json(
       {
         success: false,

--- a/mcpjam-inspector/server/services/project-skills-sync.ts
+++ b/mcpjam-inspector/server/services/project-skills-sync.ts
@@ -1,0 +1,331 @@
+/**
+ * Project-shared skills sync service.
+ *
+ * Materializes the project-shared skill rows stored in Convex into a managed
+ * cache directory under `~/.mcpjam/projects/<projectId>/skills/<name>/`. The
+ * existing filesystem-backed skill loader, file tree, and `readSkillFile`
+ * flows then operate on that cache directory unchanged.
+ *
+ * The cache is disposable: each sync re-materializes from Convex and removes
+ * cache entries whose Convex row was archived or deleted. Direct edits made
+ * inside the cache are NOT pushed back — the canonical copy lives in Convex
+ * and the inspector treats the cache as read-only mirror state.
+ */
+
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { ConvexHttpClient } from "convex/browser";
+import { logger } from "../utils/logger";
+import { isPathWithinDirectory } from "../utils/skill-parser";
+
+export type SharedProjectSkillFile = {
+  path: string;
+  contentBase64: string;
+  mimeType: string;
+  size: number;
+  isText: boolean;
+};
+
+export type SharedProjectSkillSummary = {
+  skillId: string;
+  projectId: string;
+  creatorUserId: string;
+  creatorName: string | null;
+  creatorEmail: string | null;
+  creatorImageUrl: string | null;
+  name: string;
+  description: string;
+  status: "active" | "archived";
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type SharedProjectSkillDetail = SharedProjectSkillSummary & {
+  skillMd: string;
+  files: SharedProjectSkillFile[];
+};
+
+/**
+ * Root cache directory for all projects' shared skills. We never write
+ * anywhere except inside this tree, so disk-traversal protections in the
+ * skill parser keep applying.
+ */
+export function getSharedProjectSkillsCacheRoot(): string {
+  return path.join(os.homedir(), ".mcpjam", "projects");
+}
+
+/**
+ * Cache directory for a specific project's shared skills. The directory
+ * shape mirrors `~/.mcpjam/skills/`, so the existing `getSkillsDirs()`
+ * scanner can list it without any new code paths once we add it to the
+ * precedence list.
+ */
+export function getSharedProjectSkillsCacheDir(projectId: string): string {
+  const safeProjectId = sanitizeProjectIdSegment(projectId);
+  return path.join(
+    getSharedProjectSkillsCacheRoot(),
+    safeProjectId,
+    "skills",
+  );
+}
+
+function sanitizeProjectIdSegment(projectId: string): string {
+  // Convex IDs are URL-safe by construction, but defend against the unlikely
+  // case of a caller passing a path-shaped value (e.g., '../../etc/passwd').
+  if (!/^[A-Za-z0-9_-]+$/.test(projectId)) {
+    throw new Error(`Invalid projectId for cache dir: ${projectId}`);
+  }
+  return projectId;
+}
+
+async function directoryExists(dirPath: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(dirPath);
+    return stat.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate a relative bundled-file path so a malicious or buggy publisher
+ * can't write outside the per-skill cache directory.
+ */
+function isSafeBundledPath(skillDir: string, relPath: string): boolean {
+  if (!relPath || relPath === "SKILL.md") return false;
+  if (relPath.startsWith("/") || relPath.includes("\\")) return false;
+  if (relPath.split("/").some((segment) => segment === "..")) return false;
+  return isPathWithinDirectory(skillDir, relPath);
+}
+
+async function writeSharedSkill(
+  cacheDir: string,
+  skill: SharedProjectSkillDetail,
+): Promise<void> {
+  // The skill name comes from the Convex row, which validated it against the
+  // same rules as local uploads. Still re-check before mkdir, as defense in
+  // depth.
+  if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$|^[a-z0-9]$/.test(skill.name)) {
+    throw new Error(`Refusing to materialize skill with invalid name: ${skill.name}`);
+  }
+  const skillDir = path.join(cacheDir, skill.name);
+
+  // Start clean: remove any leftover files so we never leak stale assets
+  // from a previous version of the published skill.
+  await fs.rm(skillDir, { recursive: true, force: true });
+  await fs.mkdir(skillDir, { recursive: true });
+
+  await fs.writeFile(
+    path.join(skillDir, "SKILL.md"),
+    skill.skillMd,
+    "utf-8",
+  );
+
+  for (const file of skill.files) {
+    if (!isSafeBundledPath(skillDir, file.path)) {
+      logger.warn(
+        `[project-skills-sync] skipping unsafe bundled path: ${file.path}`,
+      );
+      continue;
+    }
+    const fullPath = path.join(skillDir, file.path);
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+    const buffer = Buffer.from(file.contentBase64, "base64");
+    await fs.writeFile(fullPath, buffer);
+  }
+}
+
+/**
+ * Remove cache entries for skills that are no longer present in `keepNames`.
+ */
+async function pruneStaleSkills(
+  cacheDir: string,
+  keepNames: Set<string>,
+): Promise<void> {
+  if (!(await directoryExists(cacheDir))) return;
+  const entries = await fs.readdir(cacheDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (keepNames.has(entry.name)) continue;
+    await fs.rm(path.join(cacheDir, entry.name), {
+      recursive: true,
+      force: true,
+    });
+  }
+}
+
+export type SyncResult = {
+  projectId: string;
+  cacheDir: string;
+  materialized: string[];
+  pruned: number;
+};
+
+/**
+ * Materialize all active shared skills for `projectId` into the local cache
+ * directory. Caller supplies the Convex auth token that the local inspector
+ * already plumbs through for other authenticated endpoints.
+ */
+export async function syncSharedProjectSkills(
+  projectId: string,
+  convexAuthToken: string,
+  convexUrl?: string,
+): Promise<SyncResult> {
+  const url = convexUrl ?? process.env.CONVEX_URL;
+  if (!url) {
+    throw new Error("CONVEX_URL is not set; cannot sync project skills");
+  }
+
+  const cacheDir = getSharedProjectSkillsCacheDir(projectId);
+  await fs.mkdir(cacheDir, { recursive: true });
+
+  const client = new ConvexHttpClient(url);
+  client.setAuth(convexAuthToken);
+
+  const summaries = (await client.query(
+    "projectSkills:listProjectSkills" as any,
+    { projectId },
+  )) as SharedProjectSkillSummary[];
+
+  const materialized: string[] = [];
+  const seenNames = new Set<string>();
+
+  for (const summary of summaries) {
+    if (summary.status !== "active") continue;
+    if (seenNames.has(summary.name)) {
+      // Active uniqueness on (projectId, name) is enforced server-side; this
+      // is defensive in case two rows somehow share a name.
+      logger.warn(
+        `[project-skills-sync] duplicate active skill name in project ${projectId}: ${summary.name}`,
+      );
+      continue;
+    }
+
+    const detail = (await client.query(
+      "projectSkills:getProjectSkill" as any,
+      { skillId: summary.skillId },
+    )) as SharedProjectSkillDetail;
+
+    await writeSharedSkill(cacheDir, detail);
+    seenNames.add(detail.name);
+    materialized.push(detail.name);
+  }
+
+  // Count pre-existing dirs we'll prune so the caller can surface the diff.
+  let prunedCount = 0;
+  if (await directoryExists(cacheDir)) {
+    const entries = await fs.readdir(cacheDir, { withFileTypes: true });
+    prunedCount = entries.filter(
+      (e) => e.isDirectory() && !seenNames.has(e.name),
+    ).length;
+  }
+  await pruneStaleSkills(cacheDir, seenNames);
+
+  return {
+    projectId,
+    cacheDir,
+    materialized,
+    pruned: prunedCount,
+  };
+}
+
+/**
+ * Read all bundled files from a local skill directory into the wire shape
+ * the Convex publish/update mutations expect.
+ *
+ * Skips SKILL.md (handled separately) and applies the same path-traversal
+ * guards as the materialization step.
+ */
+export async function readLocalSkillBundle(
+  skillDir: string,
+): Promise<{
+  skillMd: string;
+  files: SharedProjectSkillFile[];
+}> {
+  const skillMdPath = path.join(skillDir, "SKILL.md");
+  const skillMd = await fs.readFile(skillMdPath, "utf-8");
+
+  const files: SharedProjectSkillFile[] = [];
+
+  async function walk(currentDir: string): Promise<void> {
+    const entries = await fs.readdir(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = path.join(currentDir, entry.name);
+      const rel = path.relative(skillDir, full);
+      if (entry.isDirectory()) {
+        await walk(full);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (rel === "SKILL.md") continue;
+      if (!isSafeBundledPath(skillDir, rel)) {
+        logger.warn(
+          `[project-skills-sync] skipping unsafe local path during bundle: ${rel}`,
+        );
+        continue;
+      }
+      const stat = await fs.stat(full);
+      const buffer = await fs.readFile(full);
+      const mimeType = guessMimeType(entry.name);
+      const isText = isTextMimeType(mimeType);
+      files.push({
+        path: rel,
+        contentBase64: buffer.toString("base64"),
+        mimeType,
+        size: stat.size,
+        isText,
+      });
+    }
+  }
+
+  await walk(skillDir);
+  return { skillMd, files };
+}
+
+function guessMimeType(name: string): string {
+  const ext = path.extname(name).toLowerCase();
+  switch (ext) {
+    case ".md":
+    case ".markdown":
+      return "text/markdown";
+    case ".txt":
+      return "text/plain";
+    case ".json":
+      return "application/json";
+    case ".yaml":
+    case ".yml":
+      return "application/x-yaml";
+    case ".js":
+    case ".mjs":
+    case ".jsx":
+      return "text/javascript";
+    case ".ts":
+    case ".tsx":
+      return "text/typescript";
+    case ".py":
+      return "text/x-python";
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".gif":
+      return "image/gif";
+    case ".svg":
+      return "image/svg+xml";
+    case ".webp":
+      return "image/webp";
+    default:
+      return "application/octet-stream";
+  }
+}
+
+function isTextMimeType(mimeType: string): boolean {
+  return (
+    mimeType.startsWith("text/") ||
+    mimeType === "application/json" ||
+    mimeType === "application/x-yaml" ||
+    mimeType === "image/svg+xml"
+  );
+}

--- a/mcpjam-inspector/server/utils/skill-tools.ts
+++ b/mcpjam-inspector/server/utils/skill-tools.ts
@@ -20,22 +20,39 @@ import {
 import type { Skill, SkillListItem, SkillFile } from "../../shared/skill-types";
 
 /**
- * Get all skills directories
+ * Get all skills directories.
+ *
+ * When `projectId` is provided, the shared project-skills cache is inserted
+ * between the global personal skills and the project-local skills, mirroring
+ * the precedence used by the REST routes. The shared cache is populated by
+ * `syncSharedProjectSkills` (services/project-skills-sync); this function
+ * only resolves the path.
  */
-function getSkillsDirs(): string[] {
+function getSkillsDirs(projectId?: string): string[] {
   const homeDir = os.homedir();
   const cwd = process.cwd();
 
-  return [
+  const dirs: string[] = [
     // Global skills
     path.join(homeDir, ".claude", "skills"), // Claude Desktop global skills
     path.join(homeDir, ".mcpjam", "skills"),
     path.join(homeDir, ".agents", "skills"),
-    // Project-local skills
+  ];
+
+  if (projectId && /^[A-Za-z0-9_-]+$/.test(projectId)) {
+    dirs.push(
+      path.join(homeDir, ".mcpjam", "projects", projectId, "skills"),
+    );
+  }
+
+  // Project-local skills
+  dirs.push(
     path.join(cwd, ".claude", "skills"), // Claude Desktop project skills
     path.join(cwd, ".mcpjam", "skills"),
     path.join(cwd, ".agents", "skills"),
-  ];
+  );
+
+  return dirs;
 }
 
 /**
@@ -64,8 +81,10 @@ async function directoryExists(dirPath: string): Promise<boolean> {
 /**
  * List all available skills (metadata only)
  */
-async function listSkillsMetadata(): Promise<SkillListItem[]> {
-  const skillsDirs = getSkillsDirs();
+async function listSkillsMetadata(
+  projectId?: string,
+): Promise<SkillListItem[]> {
+  const skillsDirs = getSkillsDirs(projectId);
   const skillsList: SkillListItem[] = [];
   const seenNames = new Set<string>();
 
@@ -107,8 +126,11 @@ async function listSkillsMetadata(): Promise<SkillListItem[]> {
 /**
  * Find skill directory by name
  */
-async function findSkillDirectory(name: string): Promise<string | null> {
-  const skillsDirs = getSkillsDirs();
+async function findSkillDirectory(
+  name: string,
+  projectId?: string,
+): Promise<string | null> {
+  const skillsDirs = getSkillsDirs(projectId);
 
   for (const skillsDir of skillsDirs) {
     if (!(await directoryExists(skillsDir))) {
@@ -142,8 +164,11 @@ async function findSkillDirectory(name: string): Promise<string | null> {
 /**
  * Get full skill content by name
  */
-async function getSkillContent(name: string): Promise<Skill | null> {
-  const skillDir = await findSkillDirectory(name);
+async function getSkillContent(
+  name: string,
+  projectId?: string,
+): Promise<Skill | null> {
+  const skillDir = await findSkillDirectory(name, projectId);
   if (!skillDir) return null;
 
   const skillFilePath = path.join(skillDir, "SKILL.md");
@@ -194,9 +219,13 @@ function flattenFiles(files: SkillFile[]): SkillFile[] {
 
 /**
  * Create skill tools for AI SDK
- * Returns tools that can be merged with MCP tools
+ * Returns tools that can be merged with MCP tools.
+ *
+ * Passing `projectId` extends the lookup to also include the shared project
+ * skills cache so the LLM can load skills published by other project members.
  */
-export function createSkillTools() {
+export function createSkillTools(opts?: { projectId?: string }) {
+  const projectId = opts?.projectId;
   return {
     loadSkill: tool({
       description:
@@ -215,7 +244,7 @@ export function createSkillTools() {
         }
 
         try {
-          const skill = await getSkillContent(name);
+          const skill = await getSkillContent(name, projectId);
           if (!skill) {
             return `Error: Skill "${name}" not found.`;
           }
@@ -223,7 +252,7 @@ export function createSkillTools() {
           let response = `# Skill: ${skill.name}\n\n${skill.content}`;
 
           // Add supporting files section if any exist
-          const skillDir = await findSkillDirectory(name);
+          const skillDir = await findSkillDirectory(name, projectId);
           if (skillDir) {
             const files = await listFilesRecursive(skillDir);
             const supportingFiles = flattenFiles(files).filter(
@@ -259,7 +288,7 @@ export function createSkillTools() {
         }
 
         try {
-          const skillDir = await findSkillDirectory(name);
+          const skillDir = await findSkillDirectory(name, projectId);
           if (!skillDir) {
             return `Error: Skill "${name}" not found.`;
           }
@@ -296,7 +325,7 @@ export function createSkillTools() {
         }
 
         try {
-          const skillDir = await findSkillDirectory(name);
+          const skillDir = await findSkillDirectory(name, projectId);
           if (!skillDir) {
             return `Error: Skill "${name}" not found.`;
           }
@@ -345,8 +374,10 @@ export function createSkillTools() {
 /**
  * Build the available skills section for the system prompt
  */
-export async function buildSkillsSystemPromptSection(): Promise<string> {
-  const skills = await listSkillsMetadata();
+export async function buildSkillsSystemPromptSection(
+  opts?: { projectId?: string },
+): Promise<string> {
+  const skills = await listSkillsMetadata(opts?.projectId);
 
   if (skills.length === 0) {
     return "";
@@ -368,8 +399,9 @@ export async function buildSkillsSystemPromptSection(): Promise<string> {
  * Get skill tools and system prompt section together
  * Only returns tools if there are skills available
  */
-export async function getSkillToolsAndPrompt() {
-  const skills = await listSkillsMetadata();
+export async function getSkillToolsAndPrompt(opts?: { projectId?: string }) {
+  const projectId = opts?.projectId;
+  const skills = await listSkillsMetadata(projectId);
 
   // Only add skill tools and prompt section if there are skills loaded
   if (skills.length === 0) {
@@ -379,7 +411,7 @@ export async function getSkillToolsAndPrompt() {
     };
   }
 
-  const tools = createSkillTools();
+  const tools = createSkillTools({ projectId });
 
   // Build prompt section from the already-fetched skills list
   let systemPromptSection = `\n\n## Available Skills\n\n`;


### PR DESCRIPTION
- Adds a sync service that pulls active project-shared skills from Convex into a managed cache at \`~/.mcpjam/projects/<projectId>/skills/\` so the existing filesystem-backed loader/file-tree code keeps working unchanged.
- Threads an optional \`projectId\` through \`/list\`, \`/get\`, \`/files\`, and \`/read-file\` and inserts the shared cache between global and project-local skills (first-match-wins, so a user's own global skill still overrides a shared one with the same name).
- Adds 5 new endpoints — \`/list-project\`, \`/sync-project\`, \`/publish-to-project\`, \`/update-published\`, \`/archive-published\` — that proxy to the Convex \`projectSkills\` mutations. Publish surfaces a structured \`nameCollision\` 409 so the UI can offer rename-and-publish.
- Mirrors the new endpoints in \`mcp-skills-api.ts\`.

UI (popover split, publish toggle, per-row actions) and inspector tests land in follow-up commits on this branch. Backend half: [mcpjam-backend#326](https://github.com/MCPJam/mcpjam-backend/pull/326).