### PR TITLE
remove vestigial per-tool protocol toggle

### DIFF
--- a/mcpjam-inspector/client/src/components/ViewsTab.tsx
+++ b/mcpjam-inspector/client/src/components/ViewsTab.tsx
@@ -27,7 +27,6 @@ import {
 } from "@/lib/display-context-utils";
 import { useWidgetDebugStore } from "@/stores/widget-debug-store";
 import { PlaygroundMain } from "./ui-playground/PlaygroundMain";
-import { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import { useUIPlaygroundStore } from "@/stores/ui-playground-store";
 import { ToolRenderOverride } from "@/components/chat-v2/thread/tool-render-overrides";
 import { buildPersistedExecutionReplay } from "@/components/chat-v2/thread/persisted-execution-replay";
@@ -122,9 +121,6 @@ export function ViewsTab({
   const lastInjectedViewSignature = useRef<string | null>(null);
   const lastUploadedWidgetHtmlRef = useRef<string | null>(null);
 
-  const setSelectedProtocol = useUIPlaygroundStore(
-    (s) => s.setSelectedProtocol,
-  );
   const setDeviceType = useUIPlaygroundStore((s) => s.setDeviceType);
   const setCustomViewport = useUIPlaygroundStore((s) => s.setCustomViewport);
   const updateGlobal = useUIPlaygroundStore((s) => s.updateGlobal);
@@ -230,14 +226,11 @@ export function ViewsTab({
     lastUploadedWidgetHtmlRef.current = null;
   }, [selectedView?._id]);
 
-  // Keep playground protocol and display context aligned to selected view
+  // Keep playground display context aligned to selected view. The active
+  // protocol is now derived from the selected tool's metadata downstream,
+  // so we no longer push a `selectedProtocol` value here.
   useEffect(() => {
     if (!selectedView) return;
-    setSelectedProtocol(
-      selectedView.protocol === "mcp-apps"
-        ? UIType.MCP_APPS
-        : UIType.OPENAI_SDK,
-    );
     if (!selectedView.defaultContext) return;
     const ctx = selectedView.defaultContext;
     if (ctx.deviceType) setDeviceType(ctx.deviceType);
@@ -248,7 +241,6 @@ export function ViewsTab({
     if (ctx.safeAreaInsets) setSafeAreaInsets(ctx.safeAreaInsets);
   }, [
     selectedView,
-    setSelectedProtocol,
     setDeviceType,
     setCustomViewport,
     updateGlobal,

--- a/mcpjam-inspector/client/src/components/__tests__/ViewsTab.layout.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/ViewsTab.layout.test.tsx
@@ -23,7 +23,6 @@ const {
     safeAreaInsets: { top: 0, bottom: 0, left: 0, right: 0 },
   })),
   mockPlaygroundStoreState: {
-    setSelectedProtocol: vi.fn(),
     setDeviceType: vi.fn(),
     setCustomViewport: vi.fn(),
     updateGlobal: vi.fn(),

--- a/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
@@ -13,7 +13,6 @@ import { type DisplayMode } from "@/stores/ui-playground-store";
 import { ToolServerMap } from "@/lib/apis/mcp-tools-api";
 import { ThinkingIndicator } from "@/components/chat-v2/shared/thinking-indicator";
 import { FullscreenChatOverlay } from "@/components/chat-v2/fullscreen-chat-overlay";
-import { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import { ToolRenderOverride } from "@/components/chat-v2/thread/tool-render-overrides";
 import { useResolvedHostStyleForIndicator } from "@/components/chat-v2/shared/loading-indicator-content";
 import {
@@ -50,7 +49,6 @@ interface ThreadProps {
   fullscreenChatDisabled?: boolean;
   fullscreenChatSendBlocked?: boolean;
   onFullscreenChatStop?: () => void;
-  selectedProtocolOverrideIfBothExists?: UIType;
   onToolApprovalResponse?: (options: { id: string; approved: boolean }) => void;
   toolRenderOverrides?: Record<string, ToolRenderOverride>;
   showSaveViewButton?: boolean;
@@ -94,7 +92,6 @@ export function Thread({
   fullscreenChatDisabled = false,
   fullscreenChatSendBlocked = isLoading,
   onFullscreenChatStop,
-  selectedProtocolOverrideIfBothExists,
   onToolApprovalResponse,
   toolRenderOverrides,
   showSaveViewButton = true,
@@ -217,9 +214,6 @@ export function Thread({
         onExitFullscreen={handleExitFullscreen}
         displayMode={displayMode}
         onDisplayModeChange={onDisplayModeChange}
-        selectedProtocolOverrideIfBothExists={
-          selectedProtocolOverrideIfBothExists
-        }
         onToolApprovalResponse={onToolApprovalResponse}
         toolRenderOverrides={toolRenderOverrides}
         showSaveViewButton={showSaveViewButton}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/message-view.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/message-view.tsx
@@ -17,7 +17,6 @@ import {
   isHiddenInternalMessage,
 } from "./thread-helpers";
 import { ToolServerMap } from "@/lib/apis/mcp-tools-api";
-import { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import { ToolRenderOverride } from "@/components/chat-v2/thread/tool-render-overrides";
 import { type ReasoningDisplayMode } from "./parts/reasoning-part";
 import { ClaudeLoadingIndicator } from "@/lib/client-styles/indicators/claude-mark";
@@ -51,7 +50,6 @@ interface MessageViewProps {
   onExitFullscreen: (toolCallId: string) => void;
   displayMode?: DisplayMode;
   onDisplayModeChange?: (mode: DisplayMode) => void;
-  selectedProtocolOverrideIfBothExists?: UIType;
   onToolApprovalResponse?: (options: { id: string; approved: boolean }) => void;
   toolRenderOverrides?: Record<string, ToolRenderOverride>;
   showSaveViewButton?: boolean;
@@ -140,8 +138,6 @@ function areMessageViewPropsEqual(
     prev.onExitFullscreen === next.onExitFullscreen &&
     prev.displayMode === next.displayMode &&
     prev.onDisplayModeChange === next.onDisplayModeChange &&
-    prev.selectedProtocolOverrideIfBothExists ===
-      next.selectedProtocolOverrideIfBothExists &&
     prev.onToolApprovalResponse === next.onToolApprovalResponse &&
     prev.toolRenderOverrides === next.toolRenderOverrides &&
     prev.showSaveViewButton === next.showSaveViewButton &&
@@ -171,7 +167,6 @@ function MessageViewImpl({
   onExitFullscreen,
   displayMode,
   onDisplayModeChange,
-  selectedProtocolOverrideIfBothExists,
   onToolApprovalResponse,
   toolRenderOverrides,
   showSaveViewButton = true,
@@ -235,9 +230,6 @@ function MessageViewImpl({
                 onExitFullscreen={onExitFullscreen}
                 displayMode={displayMode}
                 onDisplayModeChange={onDisplayModeChange}
-                selectedProtocolOverrideIfBothExists={
-                  selectedProtocolOverrideIfBothExists
-                }
                 toolRenderOverrides={toolRenderOverrides}
                 showSaveViewButton={showSaveViewButton}
                 minimalMode={minimalMode}
@@ -268,9 +260,6 @@ function MessageViewImpl({
                 onExitFullscreen={onExitFullscreen}
                 displayMode={displayMode}
                 onDisplayModeChange={onDisplayModeChange}
-                selectedProtocolOverrideIfBothExists={
-                  selectedProtocolOverrideIfBothExists
-                }
                 toolRenderOverrides={toolRenderOverrides}
                 showSaveViewButton={showSaveViewButton}
                 minimalMode={minimalMode}
@@ -346,9 +335,6 @@ function MessageViewImpl({
                   onExitFullscreen={onExitFullscreen}
                   displayMode={displayMode}
                   onDisplayModeChange={onDisplayModeChange}
-                  selectedProtocolOverrideIfBothExists={
-                    selectedProtocolOverrideIfBothExists
-                  }
                   onToolApprovalResponse={onToolApprovalResponse}
                   messageParts={message.parts}
                   toolRenderOverrides={toolRenderOverrides}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
@@ -65,7 +65,6 @@ export function PartSwitch({
   onExitFullscreen,
   displayMode,
   onDisplayModeChange,
-  selectedProtocolOverrideIfBothExists = UIType.OPENAI_SDK,
   onToolApprovalResponse,
   messageParts,
   toolRenderOverrides,
@@ -95,7 +94,6 @@ export function PartSwitch({
   onExitFullscreen: (toolCallId: string) => void;
   displayMode?: DisplayMode;
   onDisplayModeChange?: (mode: DisplayMode) => void;
-  selectedProtocolOverrideIfBothExists?: UIType;
   onToolApprovalResponse?: (options: { id: string; approved: boolean }) => void;
   messageParts?: AnyPart[];
   toolRenderOverrides?: Record<string, ToolRenderOverride>;
@@ -383,9 +381,6 @@ export function PartSwitch({
             onDisplayModeChange={interactive ? onDisplayModeChange : undefined}
             onAppSupportedDisplayModesChange={
               interactive ? setAppSupportedDisplayModes : undefined
-            }
-            selectedProtocolOverrideIfBothExists={
-              selectedProtocolOverrideIfBothExists
             }
             minimalMode={minimalMode}
           />

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/transcript-thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/transcript-thread.tsx
@@ -17,7 +17,6 @@ import type { ProjectThreadOwnerAvatar } from "@/components/chat-v2/history/proj
 import type { ModelDefinition } from "@/shared/types";
 import type { DisplayMode } from "@/stores/ui-playground-store";
 import type { ToolServerMap } from "@/lib/apis/mcp-tools-api";
-import type { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import { cn } from "@/lib/utils";
 import { useResolvedHostStyleForIndicator } from "@/components/chat-v2/shared/loading-indicator-content";
 import { getChatboxHostFamily } from "@/lib/chatbox-client-style";
@@ -95,7 +94,6 @@ export interface TranscriptThreadProps extends MessageViewPassthroughProps {
   onExitFullscreen?: (toolCallId: string) => void;
   displayMode?: DisplayMode;
   onDisplayModeChange?: (mode: DisplayMode) => void;
-  selectedProtocolOverrideIfBothExists?: UIType;
   focusMessageId?: string | null;
   highlightedMessageIds?: string[];
   navigationKey?: string | number | null;
@@ -216,7 +214,6 @@ export function TranscriptThread({
   onExitFullscreen = NOOP,
   displayMode,
   onDisplayModeChange,
-  selectedProtocolOverrideIfBothExists,
   onToolApprovalResponse,
   toolRenderOverrides,
   showSaveViewButton = true,
@@ -505,9 +502,6 @@ export function TranscriptThread({
               onExitFullscreen={onExitFullscreen}
               displayMode={displayMode}
               onDisplayModeChange={onDisplayModeChange}
-              selectedProtocolOverrideIfBothExists={
-                selectedProtocolOverrideIfBothExists
-              }
               onToolApprovalResponse={onToolApprovalResponse}
               toolRenderOverrides={toolRenderOverrides}
               showSaveViewButton={showSaveViewButton}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/widget-replay.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/widget-replay.tsx
@@ -50,13 +50,6 @@ export interface WidgetReplayProps {
   displayMode?: DisplayMode;
   onDisplayModeChange?: (mode: DisplayMode) => void;
   onAppSupportedDisplayModesChange?: (modes: DisplayMode[] | undefined) => void;
-  /**
-   * @deprecated The renderer is now protocol-agnostic: both `openai/outputTemplate`
-   * and `_meta.ui.resourceUri` route through MCPAppsRenderer, which always
-   * injects the window.openai compat shim. Kept on the props bag to avoid
-   * a wide call-site refactor; ignored.
-   */
-  selectedProtocolOverrideIfBothExists?: UIType;
   minimalMode?: boolean;
 }
 
@@ -85,10 +78,8 @@ export function WidgetReplay({
   displayMode,
   onDisplayModeChange,
   onAppSupportedDisplayModesChange,
-  selectedProtocolOverrideIfBothExists: _ignored,
   minimalMode = false,
 }: WidgetReplayProps) {
-  void _ignored;
   const resolveHostCaps = useActiveHostCapsResolver();
   const effectiveToolMeta =
     renderOverride?.toolMetadata ??

--- a/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
+++ b/mcpjam-inspector/client/src/components/evals/trace-viewer.tsx
@@ -17,7 +17,6 @@ import type { ToolServerMap } from "@/lib/apis/mcp-tools-api";
 import { JsonEditor } from "@/components/ui/json-editor";
 import { Thread } from "@/components/chat-v2/thread";
 import type { DisplayMode } from "@/stores/ui-playground-store";
-import type { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import {
   adaptTraceToUiMessages,
   type TraceEnvelope,
@@ -109,7 +108,6 @@ interface TraceViewerProps {
   ) => void;
   displayMode?: DisplayMode;
   onDisplayModeChange?: (mode: DisplayMode) => void;
-  selectedProtocolOverrideIfBothExists?: UIType;
   onToolApprovalResponse?: (options: { id: string; approved: boolean }) => void;
   interactive?: boolean;
   enableFullscreenChatOverlay?: boolean;
@@ -218,7 +216,6 @@ export function TraceViewer({
   onModelContextUpdate,
   displayMode,
   onDisplayModeChange,
-  selectedProtocolOverrideIfBothExists,
   onToolApprovalResponse,
   interactive = false,
   enableFullscreenChatOverlay = false,
@@ -681,9 +678,6 @@ export function TraceViewer({
                           fullscreenChatSendBlocked={fullscreenChatSendBlocked}
                           onFullscreenChatStop={onFullscreenChatStop}
                           onFullscreenChange={onFullscreenChange}
-                          selectedProtocolOverrideIfBothExists={
-                            selectedProtocolOverrideIfBothExists
-                          }
                           onToolApprovalResponse={onToolApprovalResponse}
                           toolRenderOverrides={adaptedTrace.toolRenderOverrides}
                           showSaveViewButton={false}

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundLeft.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundLeft.tsx
@@ -32,7 +32,6 @@ import { TabHeader } from "./TabHeader";
 import { ToolList } from "./ToolList";
 import { SelectedToolHeader } from "./SelectedToolHeader";
 import { ParametersForm } from "./ParametersForm";
-import { detectUiTypeFromTool, UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 
 interface PlaygroundLeftProps {
   tools: Record<string, Tool>;
@@ -148,15 +147,6 @@ export function PlaygroundLeft({
     onExecute();
   };
 
-  const shouldRenderUiTypeOverrideSelector = useMemo(() => {
-    if (!selectedToolName) return false;
-    const tool = tools[selectedToolName];
-    if (!tool) return false;
-    return (
-      detectUiTypeFromTool(tool) === UIType.OPENAI_SDK_AND_MCP_APPS
-    );
-  }, [selectedToolName, tools]);
-
   const mainContent = (
     <div className="h-full min-h-0">
       {activeTab === "saved" && !selectedToolName ? (
@@ -193,9 +183,6 @@ export function PlaygroundLeft({
           onSelectTool={onSelectTool}
           onFieldChange={onFieldChange}
           onToggleField={onToggleField}
-          shouldRenderUiTypeOverrideSelector={
-            shouldRenderUiTypeOverrideSelector
-          }
         />
       )}
     </div>
@@ -319,7 +306,6 @@ interface ToolParametersViewProps {
   onSelectTool: (name: string | null) => void;
   onFieldChange: (name: string, value: unknown) => void;
   onToggleField: (name: string, isSet: boolean) => void;
-  shouldRenderUiTypeOverrideSelector: boolean;
 }
 
 function ToolParametersView({
@@ -331,7 +317,6 @@ function ToolParametersView({
   onSelectTool,
   onFieldChange,
   onToggleField,
-  shouldRenderUiTypeOverrideSelector,
 }: ToolParametersViewProps) {
   const hasParameters = formFields && formFields.length > 0;
   const [openSections, setOpenSections] = useState<string[]>(["description"]);
@@ -349,7 +334,6 @@ function ToolParametersView({
           names: toolNames,
           onSelect: (name) => onSelectTool(name),
         }}
-        showProtocolSelector={shouldRenderUiTypeOverrideSelector}
       />
       <ScrollArea className="flex-1 min-h-0">
         <Accordion

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -82,6 +82,7 @@ import {
   getChatboxHostFamily,
 } from "@/lib/chatbox-client-style";
 import { DEFAULT_HOST_STYLE } from "@/lib/client-styles";
+import { detectUiTypeFromTool } from "@/lib/mcp-ui/mcp-apps-utils";
 import { PRESET_DEVICE_CONFIGS } from "@/components/shared/ClientContextHeader";
 import { usePostHog } from "posthog-js/react";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
@@ -769,8 +770,17 @@ export function PlaygroundMain({
     setSelectedModel,
   ]);
 
-  // Currently selected protocol (detected from tool metadata)
-  const selectedProtocol = useUIPlaygroundStore((s) => s.selectedProtocol);
+  // Currently selected protocol — derived from the selected tool's metadata
+  // so the CSP-mode chip in ClientContextHeader matches the active widget
+  // family without a redundant store field.
+  const selectedToolName = useUIPlaygroundStore((s) => s.selectedTool);
+  const playgroundTools = useUIPlaygroundStore((s) => s.tools);
+  const selectedProtocol = useMemo(() => {
+    if (!selectedToolName) return null;
+    const tool = playgroundTools[selectedToolName];
+    if (!tool) return null;
+    return detectUiTypeFromTool(tool);
+  }, [selectedToolName, playgroundTools]);
 
   // Host chat background: actual chat area colors from each host's UI
   // (separate from the 76 MCP spec widget design tokens)
@@ -2906,9 +2916,6 @@ export function PlaygroundMain({
                 displayMode={displayMode}
                 onDisplayModeChange={handleDisplayModeChange}
                 onFullscreenChange={setIsWidgetFullscreen}
-                selectedProtocolOverrideIfBothExists={
-                  selectedProtocol ?? undefined
-                }
                 onToolApprovalResponse={addToolApprovalResponse}
                 toolRenderOverrides={mergedToolRenderOverrides}
                 showSaveViewButton={!hideSaveViewButton}
@@ -3242,7 +3249,6 @@ export function PlaygroundMain({
                         hostStyle={column.hostSnapshot.hostStyle}
                         effectiveThreadTheme={effectiveThreadTheme}
                         deviceType={storeDeviceType}
-                        selectedProtocol={selectedProtocol}
                         hideSaveViewButton={hideSaveViewButton}
                         onWidgetStateChange={onWidgetStateChange}
                         toolRenderOverrides={externalToolRenderOverrides}
@@ -3318,7 +3324,6 @@ export function PlaygroundMain({
                           hostStyle={hostStyle}
                           effectiveThreadTheme={effectiveThreadTheme}
                           deviceType={storeDeviceType}
-                          selectedProtocol={selectedProtocol}
                           hideSaveViewButton={hideSaveViewButton}
                           onWidgetStateChange={onWidgetStateChange}
                           toolRenderOverrides={externalToolRenderOverrides}

--- a/mcpjam-inspector/client/src/components/ui-playground/SelectedToolHeader.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/SelectedToolHeader.tsx
@@ -2,12 +2,11 @@
  * SelectedToolHeader
  *
  * Compact header showing the currently selected tool with expand action,
- * optional tool-switch dropdown, save, and optional protocol selector.
+ * optional tool-switch dropdown, and save.
  */
 
 import { ChevronDown, ChevronLeft, Save } from "lucide-react";
 import { Button } from "@mcpjam/design-system/button";
-import { Switch } from "@mcpjam/design-system/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@mcpjam/design-system/tooltip";
 import {
   DropdownMenu,
@@ -15,8 +14,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@mcpjam/design-system/dropdown-menu";
-import { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
-import { useUIPlaygroundStore } from "@/stores/ui-playground-store";
 import { cn } from "@/lib/utils";
 
 export interface ToolSwitchListProps {
@@ -33,8 +30,6 @@ interface SelectedToolHeaderProps {
   description?: string;
   // Optional save action
   onSave?: () => void;
-  // Protocol selector (optional)
-  showProtocolSelector?: boolean;
 }
 
 export function SelectedToolHeader({
@@ -43,13 +38,7 @@ export function SelectedToolHeader({
   toolSwitchList,
   description,
   onSave,
-  showProtocolSelector = false,
 }: SelectedToolHeaderProps) {
-  const selectedProtocol = useUIPlaygroundStore((s) => s.selectedProtocol);
-  const setSelectedProtocol = useUIPlaygroundStore(
-    (s) => s.setSelectedProtocol,
-  );
-
   const toolNameControl =
     toolSwitchList && toolSwitchList.names.length > 0 ? (
       <DropdownMenu>
@@ -140,73 +129,6 @@ export function SelectedToolHeader({
           </Tooltip>
         )}
       </div>
-
-      {/* Protocol selector (shown when tool supports both protocols) */}
-      {showProtocolSelector && (
-        <div className="flex items-center justify-between gap-3 px-3 py-2.5">
-          <p className="flex-1 text-[11px] leading-tight text-muted-foreground">
-            This tool contains ChatGPT Apps & MCP Apps (ext-apps) metadata.
-            Toggle between.
-          </p>
-          <div className="flex flex-shrink-0 items-center gap-2">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div
-                  className={`transition-opacity ${
-                    selectedProtocol === UIType.OPENAI_SDK ||
-                    selectedProtocol === null
-                      ? "opacity-100"
-                      : "opacity-40"
-                  }`}
-                >
-                  <img
-                    src="/openai_logo.png"
-                    alt="ChatGPT Apps"
-                    className="h-4 w-4 object-contain"
-                  />
-                </div>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p className="font-medium">ChatGPT Apps</p>
-                <p className="text-xs text-muted-foreground">OpenAI SDK</p>
-              </TooltipContent>
-            </Tooltip>
-
-            <Switch
-              checked={selectedProtocol === UIType.MCP_APPS}
-              onCheckedChange={(checked) => {
-                setSelectedProtocol(
-                  checked ? UIType.MCP_APPS : UIType.OPENAI_SDK,
-                );
-              }}
-              aria-label="Toggle between ChatGPT Apps and MCP Apps"
-              className="data-[state=checked]:bg-input data-[state=unchecked]:bg-input dark:data-[state=checked]:bg-input/80"
-            />
-
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div
-                  className={`transition-opacity ${
-                    selectedProtocol === UIType.MCP_APPS
-                      ? "opacity-100"
-                      : "opacity-40"
-                  }`}
-                >
-                  <img
-                    src="/mcp.svg"
-                    alt="MCP Apps"
-                    className="h-4 w-4 object-contain"
-                  />
-                </div>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p className="font-medium">MCP Apps</p>
-                <p className="text-xs text-muted-foreground">SEP-1865</p>
-              </TooltipContent>
-            </Tooltip>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/AppBuilderTab.shell-sidebar.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/AppBuilderTab.shell-sidebar.test.tsx
@@ -18,7 +18,6 @@ const mockUIPlaygroundStore = {
   isExecuting: false,
   deviceType: "mobile",
   isSidebarVisible: true,
-  selectedProtocol: null,
   setTools: vi.fn(),
   setSelectedTool: vi.fn(),
   setFormFields: vi.fn(),
@@ -31,7 +30,6 @@ const mockUIPlaygroundStore = {
   setWidgetState: vi.fn(),
   setDeviceType: vi.fn(),
   toggleSidebar: vi.fn(),
-  setSelectedProtocol: vi.fn(),
   reset: vi.fn(),
   setSidebarVisible: vi.fn(),
 };
@@ -212,7 +210,6 @@ describe("AppBuilderTab shell sidebar", () => {
       isExecuting: false,
       deviceType: "mobile",
       isSidebarVisible: true,
-      selectedProtocol: null,
     });
 
     Object.assign(mockOnboarding, {

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/AppBuilderTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/AppBuilderTab.test.tsx
@@ -90,7 +90,6 @@ const mockUIPlaygroundStore = {
   setDisplayMode: vi.fn(),
   updateGlobal: vi.fn(),
   toggleSidebar: vi.fn(),
-  setSelectedProtocol: vi.fn(),
   reset: vi.fn(),
   setSidebarVisible: vi.fn(),
 };

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.multi-host.test.tsx
@@ -323,7 +323,6 @@ const mockUIPlaygroundStore = {
   setCspMode: vi.fn(),
   mcpAppsCspMode: "widget-declared",
   setMcpAppsCspMode: vi.fn(),
-  selectedProtocol: null,
   capabilities: { hover: true, touch: true },
   setCapabilities: vi.fn(),
 };

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/PlaygroundMain.test.tsx
@@ -470,7 +470,6 @@ const mockUIPlaygroundStore = {
   setCspMode: vi.fn(),
   mcpAppsCspMode: "widget-declared",
   setMcpAppsCspMode: vi.fn(),
-  selectedProtocol: null,
   capabilities: { hover: true, touch: true },
   setCapabilities: vi.fn(),
 };

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.provider-shadow.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.provider-shadow.test.tsx
@@ -164,7 +164,6 @@ const baseProps = {
   hostStyle: "chatgpt" as const,
   effectiveThreadTheme: "light" as const,
   deviceType: "desktop" as const,
-  selectedProtocol: null,
   onSummaryChange: vi.fn(),
 };
 

--- a/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/__tests__/multi-model-playground-card.test.tsx
@@ -172,7 +172,6 @@ function Harness() {
         hostStyle="chatgpt"
         effectiveThreadTheme="light"
         deviceType="mobile"
-        selectedProtocol={null}
         onSummaryChange={(summary) =>
           setSummaries((previous) => ({
             ...previous,
@@ -223,7 +222,6 @@ describe("MultiModelPlaygroundCard", () => {
         hostStyle="chatgpt"
         effectiveThreadTheme="light"
         deviceType="mobile"
-        selectedProtocol={null}
         onSummaryChange={vi.fn()}
         showComparisonChrome={false}
       />,
@@ -250,7 +248,6 @@ describe("MultiModelPlaygroundCard", () => {
         hostStyle="chatgpt"
         effectiveThreadTheme="light"
         deviceType="mobile"
-        selectedProtocol={null}
         onSummaryChange={vi.fn()}
         suppressThreadEmptyHint
       />,
@@ -279,7 +276,6 @@ describe("MultiModelPlaygroundCard", () => {
         hostStyle="chatgpt"
         effectiveThreadTheme="light"
         deviceType="mobile"
-        selectedProtocol={null}
         onSummaryChange={vi.fn()}
       />,
     );
@@ -301,7 +297,6 @@ describe("MultiModelPlaygroundCard", () => {
         hostStyle="chatgpt"
         effectiveThreadTheme="light"
         deviceType="mobile"
-        selectedProtocol={null}
         onSummaryChange={vi.fn()}
       />,
     );
@@ -335,7 +330,6 @@ describe("MultiModelPlaygroundCard", () => {
           hostStyle="chatgpt"
           effectiveThreadTheme="light"
           deviceType="desktop"
-          selectedProtocol={null}
           onSummaryChange={vi.fn()}
         />,
       );
@@ -372,7 +366,6 @@ describe("MultiModelPlaygroundCard", () => {
           hostStyle="chatgpt"
           effectiveThreadTheme="light"
           deviceType="desktop"
-          selectedProtocol={null}
           onSummaryChange={vi.fn()}
         />,
       );
@@ -409,7 +402,6 @@ describe("MultiModelPlaygroundCard", () => {
           hostStyle="chatgpt"
           effectiveThreadTheme="light"
           deviceType="mobile"
-          selectedProtocol={null}
           onSummaryChange={vi.fn()}
         />,
       );

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/use-app-builder-state.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/use-app-builder-state.ts
@@ -58,7 +58,6 @@ import type {
   SnapshotAppInspectorCommand,
 } from "@/shared/inspector-command.js";
 import { useSavedRequests, useServerKey, useToolExecution } from "./index";
-import { UIType, detectUiTypeFromTool } from "@/lib/mcp-ui/mcp-apps-utils";
 import { PANEL_SIZES } from "../constants";
 
 const SERVER_SYNC_TIMEOUT_MS = 10000;
@@ -200,7 +199,6 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
     isExecuting,
     deviceType,
     isSidebarVisible,
-    selectedProtocol,
     setTools,
     setSelectedTool,
     setFormFields,
@@ -215,7 +213,6 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
     setDisplayMode,
     updateGlobal,
     toggleSidebar,
-    setSelectedProtocol,
     reset,
     setSidebarVisible,
   } = useUIPlaygroundStore();
@@ -489,7 +486,6 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
     return {
       serverName: serverName ?? null,
       selectedTool: playgroundState.selectedTool,
-      selectedProtocol: playgroundState.selectedProtocol,
       deviceType: playgroundState.deviceType,
       displayMode: playgroundState.displayMode,
       globals: playgroundState.globals,
@@ -547,23 +543,6 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
       setFormFields([]);
     }
   }, [selectedTool, tools, setFormFields]);
-
-  useEffect(() => {
-    if (selectedTool) {
-      const tool = tools[selectedTool];
-      if (!tool) return;
-      const uiType = detectUiTypeFromTool(tool);
-      if (uiType === UIType.OPENAI_SDK_AND_MCP_APPS) {
-        const validProtocols = [UIType.MCP_APPS, UIType.OPENAI_SDK];
-        if (!selectedProtocol || !validProtocols.includes(selectedProtocol)) {
-          setSelectedProtocol(UIType.OPENAI_SDK);
-        }
-      } else {
-        setSelectedProtocol(uiType);
-      }
-      return;
-    }
-  }, [selectedTool, tools, setSelectedProtocol, selectedProtocol]);
 
   const selectToolForCommand = useCallback(
     async (
@@ -655,19 +634,6 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
     ],
   );
 
-  const resolveCommandProtocol = useCallback(
-    (protocol?: SetAppContextInspectorCommand["payload"]["protocol"]) => {
-      if (!protocol) return undefined;
-      if (protocol === UIType.MCP_APPS) return UIType.MCP_APPS;
-      if (protocol === UIType.OPENAI_SDK) return UIType.OPENAI_SDK;
-      throw createInspectorCommandClientError(
-        "invalid_request",
-        `Unsupported protocol "${protocol}".`,
-      );
-    },
-    [],
-  );
-
   // useLayoutEffect so handlers update synchronously during commit — before
   // setTimeout(0)-based waitForUiCommit() resolves. Prevents stale-closure
   // races when sequential commands arrive faster than useEffect re-registers.
@@ -752,7 +718,6 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
       "setAppContext",
       async (rawCommand) => {
         const command = rawCommand as SetAppContextInspectorCommand;
-        const protocol = resolveCommandProtocol(command.payload.protocol);
 
         if (command.payload.deviceType) {
           setDeviceType(command.payload.deviceType);
@@ -768,9 +733,6 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
         }
         if (command.payload.theme) {
           updateGlobal("theme", command.payload.theme);
-        }
-        if (protocol) {
-          setSelectedProtocol(protocol);
         }
 
         await waitForUiCommit();
@@ -808,11 +770,9 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
     buildAppBuilderSnapshot,
     executeTool,
     injectToolResult,
-    resolveCommandProtocol,
     selectToolForCommand,
     setDeviceType,
     setDisplayMode,
-    setSelectedProtocol,
     updateGlobal,
     waitForExecutionInjection,
   ]);

--- a/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
@@ -55,7 +55,6 @@ import {
 import { ActiveHostCapsResolverScope } from "@/contexts/active-host-client-capabilities-context";
 import type { HostConfigDtoV2 } from "@/lib/client-config-v2";
 import type { HostSnapshot } from "@/lib/host-snapshot";
-import type { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 import {
   getChatboxChatBackground,
   type ChatboxHostStyle,
@@ -137,7 +136,6 @@ interface MultiModelPlaygroundCardProps {
   hostStyle: ChatboxHostStyle;
   effectiveThreadTheme: ThreadThemeMode;
   deviceType: DeviceType;
-  selectedProtocol: UIType | null;
   hideSaveViewButton?: boolean;
   onWidgetStateChange?: (toolCallId: string, state: unknown) => void;
   toolRenderOverrides?: Record<string, ToolRenderOverride>;
@@ -210,7 +208,6 @@ export function MultiModelPlaygroundCard({
   hostStyle,
   effectiveThreadTheme,
   deviceType,
-  selectedProtocol,
   hideSaveViewButton = false,
   onWidgetStateChange,
   toolRenderOverrides = {},
@@ -729,9 +726,6 @@ export function MultiModelPlaygroundCard({
                   sendFollowUpMessage={handleSendFollowUp}
                   displayMode={displayMode}
                   onDisplayModeChange={onDisplayModeChange}
-                  selectedProtocolOverrideIfBothExists={
-                    selectedProtocol ?? undefined
-                  }
                   onWidgetStateChange={onWidgetStateChange}
                   onModelContextUpdate={handleModelContextUpdate}
                   enableFullscreenChatOverlay
@@ -817,9 +811,6 @@ export function MultiModelPlaygroundCard({
                       displayMode={displayMode}
                       onDisplayModeChange={onDisplayModeChange}
                       onFullscreenChange={setIsWidgetFullscreen}
-                      selectedProtocolOverrideIfBothExists={
-                        selectedProtocol ?? undefined
-                      }
                       onToolApprovalResponse={addToolApprovalResponse}
                       toolRenderOverrides={mergedToolRenderOverrides}
                       showSaveViewButton={!hideSaveViewButton}

--- a/mcpjam-inspector/client/src/stores/ui-playground-store.ts
+++ b/mcpjam-inspector/client/src/stores/ui-playground-store.ts
@@ -9,7 +9,6 @@
 import { create } from "zustand";
 import type { Tool } from "@modelcontextprotocol/client";
 import type { FormField } from "@/lib/tool-form";
-import { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
 
 export type DeviceType = "mobile" | "tablet" | "desktop" | "custom";
 
@@ -123,9 +122,6 @@ interface UIPlaygroundState {
   // CSP enforcement mode for MCP Apps (SEP-1865)
   mcpAppsCspMode: CspMode;
 
-  // Currently selected app protocol (detected from tool metadata)
-  selectedProtocol: UIType | null;
-
   // Device capabilities (hover/touch support)
   capabilities: DeviceCapabilities;
 
@@ -163,7 +159,6 @@ interface UIPlaygroundState {
   setPlaygroundActive: (active: boolean) => void;
   setCspMode: (mode: CspMode) => void;
   setMcpAppsCspMode: (mode: CspMode) => void;
-  setSelectedProtocol: (protocol: UIType | null) => void;
   setCapabilities: (capabilities: Partial<DeviceCapabilities>) => void;
   setSafeAreaPreset: (preset: SafeAreaPreset) => void;
   setSafeAreaInsets: (insets: Partial<SafeAreaInsets>) => void;
@@ -183,7 +178,6 @@ const getInitialGlobals = (): PlaygroundGlobals => ({
 const STORAGE_KEY_SIDEBAR = "mcpjam-ui-playground-sidebar-visible";
 const STORAGE_KEY_CUSTOM_VIEWPORT = "mcpjam-ui-playground-custom-viewport";
 const STORAGE_KEY_DEVICE_TYPE = "mcpjam-ui-playground-device-type";
-const STORAGE_KEY_SELECTED_PROTOCOL = "mcpjam-ui-playground-selected-protocol";
 const getStoredVisibility = (key: string, defaultValue: boolean): boolean => {
   if (typeof window === "undefined") return defaultValue;
   const stored = localStorage.getItem(key);
@@ -206,18 +200,6 @@ const getStoredDeviceType = (): DeviceType => {
     return stored as DeviceType;
   }
   return "desktop";
-};
-
-const getStoredSelectedProtocol = (): UIType | null => {
-  if (typeof window === "undefined") return null;
-  const stored = localStorage.getItem(STORAGE_KEY_SELECTED_PROTOCOL);
-  if (
-    stored &&
-    [UIType.MCP_APPS, UIType.OPENAI_SDK].includes(stored as UIType)
-  ) {
-    return stored as UIType;
-  }
-  return null;
 };
 
 /** Get default capabilities based on device type */
@@ -256,7 +238,6 @@ const initialState = {
   isSidebarVisible: getStoredVisibility(STORAGE_KEY_SIDEBAR, true),
   cspMode: "permissive" as CspMode,
   mcpAppsCspMode: "permissive" as CspMode,
-  selectedProtocol: getStoredSelectedProtocol(),
   capabilities: getDefaultCapabilities("desktop"),
   safeAreaPreset: "none" as SafeAreaPreset,
   safeAreaInsets: SAFE_AREA_PRESETS["none"],
@@ -368,13 +349,6 @@ export const useUIPlaygroundStore = create<UIPlaygroundState>((set) => ({
 
   setMcpAppsCspMode: (mode) => set({ mcpAppsCspMode: mode }),
 
-  setSelectedProtocol: (protocol) => {
-    if (protocol) {
-      localStorage.setItem(STORAGE_KEY_SELECTED_PROTOCOL, protocol);
-    }
-    return set({ selectedProtocol: protocol });
-  },
-
   setCapabilities: (newCapabilities) =>
     set((state) => ({
       capabilities: { ...state.capabilities, ...newCapabilities },
@@ -423,8 +397,6 @@ export const useUIPlaygroundStore = create<UIPlaygroundState>((set) => ({
         deviceType: storedDeviceType,
         customViewport: getStoredCustomViewport(),
         capabilities: getDefaultCapabilities(storedDeviceType),
-        // Preserve selected protocol from localStorage
-        selectedProtocol: getStoredSelectedProtocol(),
         // Preserve CSP modes (may be set via CLI config before reset fires)
         cspMode: state.cspMode,
         mcpAppsCspMode: state.mcpAppsCspMode,

--- a/mcpjam-inspector/shared/inspector-command.ts
+++ b/mcpjam-inspector/shared/inspector-command.ts
@@ -1,6 +1,5 @@
 export type InspectorAppDeviceType = "mobile" | "tablet" | "desktop" | "custom";
 export type InspectorAppDisplayMode = "inline" | "pip" | "fullscreen";
-export type InspectorAppProtocol = "mcp-apps" | "openai-sdk";
 
 export const INSPECTOR_COMMAND_DEFAULT_TIMEOUT_MS = 30_000;
 
@@ -72,7 +71,6 @@ export interface SetAppContextInspectorCommand {
     locale?: string;
     timeZone?: string;
     theme?: "light" | "dark";
-    protocol?: InspectorAppProtocol;
   };
   timeoutMs?: number;
 }


### PR DESCRIPTION
## Summary

- Removes the SelectedToolHeader \"ChatGPT Apps <-> MCP Apps\" toggle, the `selectedProtocol` field on `useUIPlaygroundStore`, the `selectedProtocolOverrideIfBothExists` prop chain end-to-end (PlaygroundMain -> Thread -> TranscriptThread -> MessageView -> PartSwitch -> WidgetReplay, plus MultiModelPlaygroundCard and TraceViewer), the auto-detect effect in `use-app-builder-state`, the `ViewsTab.tsx` setSelectedProtocol bridge, and the `protocol` field on `SetAppContextInspectorCommand.payload` / `InspectorAppProtocol` type alias.
- Safe to remove because the downstream renderer was already protocol-agnostic: `WidgetReplay` destructured the prop as `_ignored` and explicitly `void`'d it, and the BOTH-metadata render path is single-path through `MCPAppsRenderer` with the `window.openai` compat shim. The only remaining functional reader (`ClientContextHeader.tsx`) keeps its `protocol` prop and now receives a pure derivation from `detectUiTypeFromTool(currentTool)` inside `PlaygroundMain`, so the CSP-mode chip continues to pick `mcpAppsCspMode` vs `cspMode` correctly.
- Behavior change: none for the BOTH-metadata render path (it was already single-path via MCPAppsRenderer). CSP-mode chip in `ClientContextHeader` keeps reflecting the same family it does today. Localstorage key `mcpjam-ui-playground-selected-protocol` is left orphaned in users' browsers (harmless, cheaper than a migration).

## Test plan

- [x] `npm run typecheck:client` clean
- [x] Full `npm test` green (434 files / 4451 tests passed, 2 skipped)
- [ ] Manual `/playground` smoke with a BOTH-metadata example server (e.g. `examples/apps-sdk-everything` or `examples/mcp-apps-everything`): confirm the toggle is gone from SelectedToolHeader, the tool renders correctly via MCPAppsRenderer, `window.openai.*` calls inside the widget still work via the compat shim, `ui/*` JSON-RPC still works, and the CSP-mode chip in ClientContextHeader reflects the right family for both BOTH-metadata and MCP-Apps-only tools
- [ ] `/views` smoke: select a saved view -> tool selects -> widget renders -> CSP-mode chip correct
- [ ] Trace viewer smoke: replay a saved trace -> widget renders

## Follow-up

If per-host BOTH-disambiguation is ever wanted again, the right long-term home is a static `protocolOverride` on `ResolvedMcpAppsCapabilities` in `client/src/lib/client-styles/built-ins.ts` (already wired through the host capability resolver). Out of scope for this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor that deletes unused override plumbing; render path was already single-path and CSP header still gets protocol from tool metadata. Orphaned localStorage key is harmless.
> 
> **Overview**
> Removes the manual **ChatGPT Apps ↔ MCP Apps** protocol override that was threaded through the playground store, chat transcript, and inspector commands. Widget rendering already routes dual-metadata tools through a single **MCPAppsRenderer** path, so the override prop chain (`selectedProtocolOverrideIfBothExists`) and the **SelectedToolHeader** toggle were dead UI/state.
> 
> **Store & playground:** Drops `selectedProtocol` / `setSelectedProtocol` and its localStorage key from `useUIPlaygroundStore`. **PlaygroundMain** now derives the value passed to **ClientContextHeader** (CSP chip family) via `detectUiTypeFromTool` on the active tool instead of persisting a user toggle. **ViewsTab** stops syncing view protocol into the store; display context sync is unchanged.
> 
> **Chat & evals:** Removes `selectedProtocolOverrideIfBothExists` from **Thread** → **TranscriptThread** → **MessageView** → **PartSwitch** → **WidgetReplay**, plus **MultiModelPlaygroundCard** and **TraceViewer**.
> 
> **Automation:** **use-app-builder-state** no longer auto-sets protocol on tool select or honors `protocol` in `setAppContext` inspector commands; **`InspectorAppProtocol`** and the payload field are removed from **`inspector-command.ts`**.
> 
> Tests and mocks are updated to match the slimmer APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 382f153327007b55d8fe308abb6c257653436a73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->