### PR TITLE
Catch convex error and show UI prompt to sign in instead

### DIFF
--- a/mcpjam-inspector/client/src/components/EvalsTab.tsx
+++ b/mcpjam-inspector/client/src/components/EvalsTab.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import posthog from "posthog-js";
 import { Button } from "@mcpjam/design-system/button";
 import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorBoundary } from "@/components/ui/error-boundary";
 import { useProjectServers } from "@/hooks/useViews";
 import { useEvalsRouteFromUrl } from "@/lib/eval-route-url";
 import { useEvalTabContext } from "@/hooks/use-eval-tab-context";
@@ -55,6 +56,72 @@ interface EvalsTabProps {
 }
 
 export function EvalsTab({
+  projectId,
+  onContinueInChat,
+  ensureServersReady,
+}: EvalsTabProps) {
+  const { isAuthenticated } = useConvexAuth();
+
+  return (
+    <ErrorBoundary
+      key={`${projectId ?? "none"}:${isAuthenticated ? "authed" : "guest"}`}
+      fallback={({ error, reset }) => (
+        <EvalTabErrorFallback error={error} onRetry={reset} />
+      )}
+    >
+      <EvalsTabContent
+        projectId={projectId}
+        onContinueInChat={onContinueInChat}
+        ensureServersReady={ensureServersReady}
+      />
+    </ErrorBoundary>
+  );
+}
+
+function isGuestUnavailableError(error: Error | null): boolean {
+  return (
+    error?.message.includes("Not available for guests yet. Sign in to use this.") ??
+    false
+  );
+}
+
+function EvalTabErrorFallback({
+  error,
+  onRetry,
+}: {
+  error: Error | null;
+  onRetry: () => void;
+}) {
+  if (isGuestUnavailableError(error)) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon={FlaskConical}
+          title="Sign in to use Testing"
+          description="Testing suites are not available for guests yet. Sign in to create suites, view runs, and investigate cases."
+          className="h-[calc(100vh-200px)]"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6">
+      <EmptyState
+        icon={FlaskConical}
+        title="Could not load Testing"
+        description="Something went wrong while loading suites. Try again in a moment."
+        className="h-[calc(100vh-200px)]"
+      >
+        <Button type="button" variant="outline" onClick={onRetry}>
+          Try again
+        </Button>
+      </EmptyState>
+    </div>
+  );
+}
+
+function EvalsTabContent({
   projectId,
   onContinueInChat,
   ensureServersReady,

--- a/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/EvalsTab.test.tsx
@@ -294,4 +294,29 @@ describe("EvalsTab", () => {
     });
   });
 
+  it("shows a sign-in state instead of crashing when Convex rejects guest eval overview", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    try {
+      mocks.useEvalQueries.mockImplementation(() => {
+        throw new Error(
+          "[CONVEX Q(testSuites:getTestSuitesOverview)] [Request ID: test] Server Error\nUncaught Error: Not available for guests yet. Sign in to use this.",
+        );
+      });
+
+      render(<EvalsTab projectId="guest-project" />);
+
+      expect(screen.getByText("Sign in to use Testing")).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Testing suites are not available for guests yet. Sign in to create suites, view runs, and investigate cases.",
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("suite-sidebar")).toBeNull();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
 });


### PR DESCRIPTION
### TL;DR

Wrap the Evals tab in an error boundary that shows a friendly sign-in prompt when Convex rejects requests for guest users, instead of crashing the UI.

Was crashing for guests hitting evals tab in inspector
<img width="1728" height="802" alt="Screenshot 2026-05-24 at 1 59 54 PM" src="https://github.com/user-attachments/assets/57186333-d34f-4362-8694-bbda69b8141b" />

```
5/24/2026, 1:57:17 PM [CONVEX Q(testSuites:getTestSuitesOverview)] Uncaught Error: Not available for guests yet. Sign in to use this.
    at requireEvalUserActor (../convex/testSuites.ts:1166:9)
    at handler (../convex/testSuites.ts:5555:21)
```

### ![Screenshot 2026-05-24 at 1.55.41 PM.png](https://app.graphite.com/user-attachments/assets/409b4f62-d627-4369-835e-3c4e8d39ab4e.png)

Now showing above^

### What changed?

The `EvalsTab` component now renders an `ErrorBoundary` around the tab content. The boundary resets whenever the project ID or authentication state changes. Two error fallback states are handled:

- **Guest unavailable error** – when Convex throws a "Not available for guests yet" error, a sign-in prompt is shown with messaging that testing suites require authentication.
- **Generic error** – any other failure shows a generic "Could not load Testing" message with a "Try again" button that resets the boundary.

The original tab logic was extracted into a new `EvalsTabContent` component, and the outer `EvalsTab` component now solely handles the boundary setup.

### How to test?

1. Open the Evals tab as a guest (unauthenticated) user — the sign-in empty state should appear instead of a crash or error screen.
2. Open the Evals tab as an authenticated user — the tab should load normally.
3. Simulate a generic error in the tab and confirm the "Could not load Testing" fallback appears with a working "Try again" button.
4. Run the test suite and confirm the new test case (`shows a sign-in state instead of crashing when Convex rejects guest eval overview`) passes.

### Why make this change?

Guest users were causing an unhandled error when Convex rejected eval queries with a "Not available for guests yet" message, crashing the tab entirely. This change gracefully handles that case with a clear call-to-action to sign in, improving the guest user experience and preventing unexpected UI failures.