### PR TITLE
[Payments Tab] PR-I1: Payment history section on billing page

### DIFF
--- a/mcpjam-inspector/client/src/components/billing/PaymentsHistorySection.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PaymentsHistorySection.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  CheckCircle2,
+  Clock,
+  CircleAlert,
+  ExternalLink,
+} from "lucide-react";
+import { usePostHog } from "posthog-js/react";
+import { useFeatureFlagEnabled } from "posthog-js/react";
+import { Badge } from "@mcpjam/design-system/badge";
+import { Button } from "@mcpjam/design-system/button";
+import { Card, CardContent } from "@mcpjam/design-system/card";
+import { Skeleton } from "@mcpjam/design-system/skeleton";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@mcpjam/design-system/table";
+import { cn } from "@/lib/utils";
+import { CreditTopupDialog } from "@/components/billing/CreditTopupDialog";
+import {
+  usePaymentsHistory,
+  type PaymentHistoryEntry,
+} from "@/hooks/usePaymentsHistory";
+
+const formatUsd = (cents: number): string => {
+  const dollars = cents / 100;
+  return Number.isInteger(dollars) ? `$${dollars}` : `$${dollars.toFixed(2)}`;
+};
+
+const formatDate = (epochMs: number): string => {
+  try {
+    return new Date(epochMs).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  } catch {
+    return "";
+  }
+};
+
+function bucketEntryCount(count: number): string {
+  if (count <= 1) return "1";
+  if (count <= 5) return "2-5";
+  if (count <= 20) return "6-20";
+  return "20+";
+}
+
+export function PaymentsHistorySection() {
+  // Hooks must be called unconditionally before any early-return — flag check
+  // happens after. PostHog's `useFeatureFlagEnabled` can return `undefined`
+  // during bootstrap; treat anything other than `true` as off so we don't
+  // flash content before the flag resolves.
+  const flagEnabled = useFeatureFlagEnabled("billing-entitlements-ui");
+  const { entries, isLoading } = usePaymentsHistory();
+  const posthog = usePostHog();
+  const viewedRef = useRef(false);
+  const [isTopupOpen, setIsTopupOpen] = useState(false);
+
+  const safeEntries = entries ?? [];
+
+  // Fire the view event once per mount when entries first load and aren't
+  // empty. Ref guard defeats StrictMode double-mount and the auth-resolve
+  // re-render that flips isLoading false.
+  useEffect(() => {
+    if (viewedRef.current) return;
+    if (isLoading) return;
+    if (safeEntries.length === 0) return;
+    viewedRef.current = true;
+    posthog?.capture("credit_topup_history_viewed", {
+      entry_count_bucket: bucketEntryCount(safeEntries.length),
+      has_failed: safeEntries.some((e) => e.status === "failed"),
+      has_pending: safeEntries.some((e) => e.status === "pending"),
+    });
+  }, [isLoading, posthog, safeEntries]);
+
+  if (flagEnabled !== true) return null;
+
+  return (
+    <>
+      <Card className="border-border/60 py-6 shadow-sm">
+        <CardContent className="flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold">Payment history</h2>
+          </div>
+          {isLoading ? (
+            <LoadingRows />
+          ) : safeEntries.length === 0 ? (
+            <EmptyState
+              onTopUp={() => {
+                posthog?.capture("credit_topup_cta_clicked", {
+                  source: "history_empty_state",
+                });
+                setIsTopupOpen(true);
+              }}
+            />
+          ) : (
+            <PaymentsTable entries={safeEntries} />
+          )}
+        </CardContent>
+      </Card>
+      <CreditTopupDialog
+        open={isTopupOpen}
+        onOpenChange={setIsTopupOpen}
+        chatSessionId=""
+        lastUserMessage=""
+        source="billing_page"
+      />
+    </>
+  );
+}
+
+function PaymentsTable({ entries }: { entries: PaymentHistoryEntry[] }) {
+  return (
+    <div data-testid="payments-history-table">
+      {/* Desktop: real table at sm+ */}
+      <div className="hidden sm:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Date</TableHead>
+              <TableHead>Amount</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="text-right">Receipt</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {entries.map((entry) => (
+              <TableRow key={entry.sessionId}>
+                <TableCell className="whitespace-nowrap text-sm">
+                  {formatDate(entry.occurredAt)}
+                </TableCell>
+                <TableCell className="whitespace-nowrap text-sm tabular-nums">
+                  {formatUsd(entry.paidAmountCents)}
+                </TableCell>
+                <TableCell>
+                  <StatusBadge status={entry.status} />
+                </TableCell>
+                <TableCell className="text-right">
+                  <ReceiptCell entry={entry} />
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      {/* Mobile: stacked rows */}
+      <div className="flex flex-col gap-3 sm:hidden">
+        {entries.map((entry) => (
+          <MobileRow key={entry.sessionId} entry={entry} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MobileRow({ entry }: { entry: PaymentHistoryEntry }) {
+  return (
+    <div className="flex flex-col gap-1.5 rounded-md border border-border/60 p-3">
+      <div className="flex items-center justify-between text-sm">
+        <span>{formatDate(entry.occurredAt)}</span>
+        <span className="tabular-nums font-medium">
+          {formatUsd(entry.paidAmountCents)}
+        </span>
+      </div>
+      <div className="flex items-center justify-between">
+        <StatusBadge status={entry.status} />
+        <ReceiptCell entry={entry} />
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: PaymentHistoryEntry["status"] }) {
+  if (status === "succeeded") {
+    return (
+      <Badge
+        variant="outline"
+        className="border-emerald-300 bg-emerald-50 text-emerald-900 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-100"
+      >
+        <CheckCircle2 aria-hidden="true" />
+        Succeeded
+      </Badge>
+    );
+  }
+  if (status === "pending") {
+    return (
+      <Badge
+        variant="outline"
+        className="border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100"
+      >
+        <Clock aria-hidden="true" />
+        Pending
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="destructive">
+      <CircleAlert aria-hidden="true" />
+      Failed
+    </Badge>
+  );
+}
+
+function ReceiptCell({ entry }: { entry: PaymentHistoryEntry }) {
+  const posthog = usePostHog();
+
+  if (entry.receiptUrl) {
+    const ageDays = Math.max(
+      0,
+      Math.round((Date.now() - entry.occurredAt) / (24 * 60 * 60 * 1000)),
+    );
+    return (
+      <a
+        href={entry.receiptUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        referrerPolicy="no-referrer"
+        data-ph-no-capture
+        aria-label={`View receipt for ${formatDate(entry.occurredAt)} payment (opens in new tab)`}
+        className="inline-flex items-center gap-1 text-sm text-primary underline-offset-4 hover:underline"
+        onClick={() => {
+          posthog?.capture("credit_topup_receipt_opened", {
+            entry_age_days: ageDays,
+          });
+        }}
+      >
+        View receipt
+        <ExternalLink aria-hidden="true" className="size-3.5" />
+        <span className="sr-only">(opens in new tab)</span>
+      </a>
+    );
+  }
+
+  // No URL: distinguish the three cases so a succeeded-without-URL row
+  // doesn't read the same as a failed row (which legitimately has no
+  // receipt).
+  const muted = "text-sm text-muted-foreground";
+  if (entry.status === "succeeded") {
+    return <span className={muted}>Not available</span>;
+  }
+  if (entry.status === "pending") {
+    return <span className={muted}>Processing</span>;
+  }
+  return <span className={muted}>—</span>;
+}
+
+function EmptyState({ onTopUp }: { onTopUp: () => void }) {
+  return (
+    <div
+      className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border/60 py-8 text-center"
+      data-testid="payments-history-empty"
+    >
+      <p className="text-sm text-muted-foreground">
+        No payments yet. Top up to add credits.
+      </p>
+      <Button type="button" onClick={onTopUp}>
+        Top up
+      </Button>
+    </div>
+  );
+}
+
+function LoadingRows() {
+  return (
+    <div className="flex flex-col gap-2" data-testid="payments-history-loading">
+      {[0, 1, 2].map((i) => (
+        <Skeleton key={i} className="h-9 w-full" />
+      ))}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/billing/PaymentsHistorySection.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PaymentsHistorySection.tsx
@@ -117,10 +117,12 @@ export function PaymentsHistorySection() {
 function PaymentsTable({ entries }: { entries: PaymentHistoryEntry[] }) {
   return (
     <div data-testid="payments-history-table">
-      {/* Desktop: real table at sm+ */}
-      <div className="hidden sm:block">
+      {/* Desktop: real table at sm+. Cap visible height at ~5 rows; older
+       * rows scroll inside the card so the section never balloons even at
+       * the 50-row server cap. */}
+      <div className="hidden sm:block max-h-[280px] overflow-y-auto rounded-md border border-border/40">
         <Table>
-          <TableHeader>
+          <TableHeader className="sticky top-0 bg-background">
             <TableRow>
               <TableHead>Date</TableHead>
               <TableHead>Amount</TableHead>
@@ -148,8 +150,8 @@ function PaymentsTable({ entries }: { entries: PaymentHistoryEntry[] }) {
           </TableBody>
         </Table>
       </div>
-      {/* Mobile: stacked rows */}
-      <div className="flex flex-col gap-3 sm:hidden">
+      {/* Mobile: stacked rows. Same height cap as desktop. */}
+      <div className="flex flex-col gap-3 sm:hidden max-h-[400px] overflow-y-auto">
         {entries.map((entry) => (
           <MobileRow key={entry.sessionId} entry={entry} />
         ))}

--- a/mcpjam-inspector/client/src/components/billing/PaymentsHistorySection.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PaymentsHistorySection.tsx
@@ -1,12 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   CheckCircle2,
   Clock,
   CircleAlert,
   ExternalLink,
 } from "lucide-react";
-import { usePostHog } from "posthog-js/react";
-import { useFeatureFlagEnabled } from "posthog-js/react";
+import { usePostHog, useFeatureFlagEnabled } from "posthog-js/react";
 import { Badge } from "@mcpjam/design-system/badge";
 import { Button } from "@mcpjam/design-system/button";
 import { Card, CardContent } from "@mcpjam/design-system/card";
@@ -19,7 +18,6 @@ import {
   TableHeader,
   TableRow,
 } from "@mcpjam/design-system/table";
-import { cn } from "@/lib/utils";
 import { CreditTopupDialog } from "@/components/billing/CreditTopupDialog";
 import {
   usePaymentsHistory,
@@ -65,8 +63,10 @@ export function PaymentsHistorySection() {
 
   // Fire the view event once per mount when entries first load and aren't
   // empty. Ref guard defeats StrictMode double-mount and the auth-resolve
-  // re-render that flips isLoading false.
+  // re-render that flips isLoading false. Gated on flagEnabled so we never
+  // pollute telemetry for users who can't see the surface.
   useEffect(() => {
+    if (flagEnabled !== true) return;
     if (viewedRef.current) return;
     if (isLoading) return;
     if (safeEntries.length === 0) return;
@@ -76,7 +76,7 @@ export function PaymentsHistorySection() {
       has_failed: safeEntries.some((e) => e.status === "failed"),
       has_pending: safeEntries.some((e) => e.status === "pending"),
     });
-  }, [isLoading, posthog, safeEntries]);
+  }, [flagEnabled, isLoading, posthog, safeEntries]);
 
   if (flagEnabled !== true) return null;
 

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PaymentsHistorySection.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PaymentsHistorySection.test.tsx
@@ -61,16 +61,37 @@ describe("PaymentsHistorySection", () => {
   });
 
   describe("flag gating", () => {
-    it("renders nothing when the flag is off", () => {
+    // Seed populated entries so a missing flag-gate on the telemetry effect
+    // would otherwise fire the view event. Asserts both render-suppression
+    // AND telemetry-suppression in the same test.
+    const populated: typeof hookState = {
+      entries: [
+        makeEntry({ id: "flag_test_entry", status: "succeeded" }),
+      ],
+      isLoading: false,
+      isAuthenticated: true,
+    };
+
+    it("renders nothing and fires no telemetry when the flag is off", () => {
       flagState = false;
+      hookState = populated;
       const { container } = render(<PaymentsHistorySection />);
       expect(container.firstChild).toBeNull();
+      const calls = captureMock.mock.calls.filter(
+        (c) => c[0] === "credit_topup_history_viewed",
+      );
+      expect(calls).toHaveLength(0);
     });
 
-    it("renders nothing when the flag is still undefined (bootstrap window)", () => {
+    it("renders nothing and fires no telemetry while the flag is undefined (bootstrap)", () => {
       flagState = undefined;
+      hookState = populated;
       const { container } = render(<PaymentsHistorySection />);
       expect(container.firstChild).toBeNull();
+      const calls = captureMock.mock.calls.filter(
+        (c) => c[0] === "credit_topup_history_viewed",
+      );
+      expect(calls).toHaveLength(0);
     });
   });
 

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PaymentsHistorySection.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PaymentsHistorySection.test.tsx
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { PaymentsHistorySection } from "../PaymentsHistorySection";
+import type {
+  PaymentHistoryEntry,
+  UsePaymentsHistoryResult,
+} from "@/hooks/usePaymentsHistory";
+
+let hookState: UsePaymentsHistoryResult = {
+  entries: undefined,
+  isLoading: true,
+  isAuthenticated: false,
+};
+
+let flagState: boolean | undefined = true;
+const captureMock = vi.fn();
+
+vi.mock("@/hooks/usePaymentsHistory", () => ({
+  usePaymentsHistory: () => hookState,
+}));
+
+vi.mock("posthog-js/react", () => ({
+  useFeatureFlagEnabled: (flag: string) =>
+    flag === "billing-entitlements-ui" ? flagState : false,
+  usePostHog: () => ({ capture: captureMock }),
+}));
+
+// The empty-state CTA opens CreditTopupDialog; stub it so we don't drag
+// Convex + the topup hook stack into this test.
+vi.mock("@/components/billing/CreditTopupDialog", () => ({
+  CreditTopupDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="stub-topup-dialog" /> : null,
+}));
+
+function makeEntry(
+  overrides: Partial<PaymentHistoryEntry> & { id: string },
+): PaymentHistoryEntry {
+  return {
+    id: overrides.id,
+    sessionId: overrides.sessionId ?? `cs_${overrides.id}`,
+    paidAmountCents: overrides.paidAmountCents ?? 1000,
+    status: overrides.status ?? "succeeded",
+    occurredAt: overrides.occurredAt ?? Date.now(),
+    ...(overrides.receiptUrl !== undefined
+      ? { receiptUrl: overrides.receiptUrl }
+      : {}),
+  };
+}
+
+describe("PaymentsHistorySection", () => {
+  beforeEach(() => {
+    hookState = {
+      entries: undefined,
+      isLoading: true,
+      isAuthenticated: false,
+    };
+    flagState = true;
+    captureMock.mockReset();
+  });
+
+  describe("flag gating", () => {
+    it("renders nothing when the flag is off", () => {
+      flagState = false;
+      const { container } = render(<PaymentsHistorySection />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("renders nothing when the flag is still undefined (bootstrap window)", () => {
+      flagState = undefined;
+      const { container } = render(<PaymentsHistorySection />);
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("loading + empty states", () => {
+    it("renders loading skeletons while the query is in flight", () => {
+      render(<PaymentsHistorySection />);
+      expect(screen.getByTestId("payments-history-loading")).toBeInTheDocument();
+    });
+
+    it("renders the empty state with a Top up CTA when there are no entries", async () => {
+      hookState = {
+        entries: [],
+        isLoading: false,
+        isAuthenticated: true,
+      };
+      render(<PaymentsHistorySection />);
+      const empty = screen.getByTestId("payments-history-empty");
+      expect(empty).toHaveTextContent(/No payments yet/);
+      const cta = within(empty).getByRole("button", { name: /Top up/ });
+      await userEvent.click(cta);
+      expect(captureMock).toHaveBeenCalledWith("credit_topup_cta_clicked", {
+        source: "history_empty_state",
+      });
+      // CTA opens the stubbed dialog
+      expect(screen.getByTestId("stub-topup-dialog")).toBeInTheDocument();
+    });
+  });
+
+  describe("populated table", () => {
+    const fixture: PaymentHistoryEntry[] = [
+      makeEntry({
+        id: "1",
+        sessionId: "cs_succeeded_with_link",
+        paidAmountCents: 2500,
+        status: "succeeded",
+        receiptUrl: "https://pay.stripe.com/receipts/abc",
+        occurredAt: Date.UTC(2026, 4, 22),
+      }),
+      makeEntry({
+        id: "2",
+        sessionId: "cs_legacy_succeeded",
+        paidAmountCents: 1000,
+        status: "succeeded",
+        occurredAt: Date.UTC(2026, 4, 14),
+      }),
+      makeEntry({
+        id: "3",
+        sessionId: "cs_pending",
+        paidAmountCents: 5000,
+        status: "pending",
+        occurredAt: Date.UTC(2026, 4, 10),
+      }),
+      makeEntry({
+        id: "4",
+        sessionId: "cs_failed",
+        paidAmountCents: 2500,
+        status: "failed",
+        occurredAt: Date.UTC(2026, 4, 3),
+      }),
+    ];
+
+    beforeEach(() => {
+      hookState = {
+        entries: fixture,
+        isLoading: false,
+        isAuthenticated: true,
+      };
+    });
+
+    it("renders one row per entry with status-appropriate receipt copy", () => {
+      render(<PaymentsHistorySection />);
+      // Succeeded + URL → "View receipt"
+      expect(
+        screen.getAllByRole("link", { name: /View receipt/ }),
+      ).toHaveLength(1);
+      // Succeeded + no URL → "Not available"
+      expect(screen.getAllByText(/Not available/)[0]).toBeInTheDocument();
+      // Pending → "Processing"
+      expect(screen.getAllByText(/Processing/)[0]).toBeInTheDocument();
+      // Failed → em-dash
+      expect(screen.getAllByText("—")[0]).toBeInTheDocument();
+    });
+
+    it("renders the receipt link with full safety attributes", () => {
+      render(<PaymentsHistorySection />);
+      const link = screen.getAllByRole("link", { name: /View receipt/ })[0];
+      expect(link).toHaveAttribute(
+        "href",
+        "https://pay.stripe.com/receipts/abc",
+      );
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+      expect(link).toHaveAttribute("referrerpolicy", "no-referrer");
+      expect(link).toHaveAttribute("data-ph-no-capture");
+      expect(link.getAttribute("aria-label")).toMatch(/opens in new tab/);
+    });
+
+    it("fires credit_topup_receipt_opened on receipt click (no URL prop, no status prop)", async () => {
+      render(<PaymentsHistorySection />);
+      const link = screen.getAllByRole("link", { name: /View receipt/ })[0];
+      await userEvent.click(link);
+      const call = captureMock.mock.calls.find(
+        (c) => c[0] === "credit_topup_receipt_opened",
+      );
+      expect(call).toBeDefined();
+      const props = call?.[1] as Record<string, unknown>;
+      expect(props).not.toHaveProperty("status");
+      expect(props).not.toHaveProperty("receipt_url");
+      expect(props).not.toHaveProperty("url");
+      expect(typeof props.entry_age_days).toBe("number");
+    });
+
+    it("fires credit_topup_history_viewed once with bucketed entry_count", () => {
+      render(<PaymentsHistorySection />);
+      const calls = captureMock.mock.calls.filter(
+        (c) => c[0] === "credit_topup_history_viewed",
+      );
+      expect(calls).toHaveLength(1);
+      const props = calls[0][1] as Record<string, unknown>;
+      expect(props.entry_count_bucket).toBe("2-5");
+      expect(props.has_failed).toBe(true);
+      expect(props.has_pending).toBe(true);
+    });
+
+    it("does not fire credit_topup_history_viewed when there are zero entries", () => {
+      hookState = {
+        entries: [],
+        isLoading: false,
+        isAuthenticated: true,
+      };
+      render(<PaymentsHistorySection />);
+      const calls = captureMock.mock.calls.filter(
+        (c) => c[0] === "credit_topup_history_viewed",
+      );
+      expect(calls).toHaveLength(0);
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PaymentsHistorySection.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PaymentsHistorySection.test.tsx
@@ -163,16 +163,20 @@ describe("PaymentsHistorySection", () => {
 
     it("renders one row per entry with status-appropriate receipt copy", () => {
       render(<PaymentsHistorySection />);
-      // Succeeded + URL → "View receipt"
+      // Each entry is rendered TWICE: once in the desktop table (sm+) and
+      // once in the mobile stacked layout (<sm). Tailwind hides one via CSS
+      // but jsdom doesn't apply CSS visibility, so getAllBy* returns both
+      // copies. We assert the doubled count to lock in the dual-render.
+      // Succeeded + URL → "View receipt" (1 entry × 2 layouts = 2 links)
       expect(
         screen.getAllByRole("link", { name: /View receipt/ }),
-      ).toHaveLength(1);
+      ).toHaveLength(2);
       // Succeeded + no URL → "Not available"
-      expect(screen.getAllByText(/Not available/)[0]).toBeInTheDocument();
+      expect(screen.getAllByText(/Not available/)).toHaveLength(2);
       // Pending → "Processing"
-      expect(screen.getAllByText(/Processing/)[0]).toBeInTheDocument();
+      expect(screen.getAllByText(/Processing/)).toHaveLength(2);
       // Failed → em-dash
-      expect(screen.getAllByText("—")[0]).toBeInTheDocument();
+      expect(screen.getAllByText("—")).toHaveLength(2);
     });
 
     it("renders the receipt link with full safety attributes", () => {

--- a/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
@@ -41,6 +41,7 @@ import { cn } from "@/lib/utils";
 import { buildComparePlanSectionsFromCatalog } from "@/components/organization/billing-compare-view-model";
 import { type ComparePlanCell } from "@/components/organization/compare-plan-marketing";
 import { CreditBalanceCard } from "@/components/billing/CreditBalanceCard";
+import { PaymentsHistorySection } from "@/components/billing/PaymentsHistorySection";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
 
 const PLAN_ORDER: OrganizationPlan[] = ["free", "team", "enterprise"];
@@ -708,6 +709,10 @@ export function OrganizationBillingSection({
 
       <ErrorBoundary fallback={null}>
         <CreditBalanceCard />
+      </ErrorBoundary>
+
+      <ErrorBoundary fallback={null}>
+        <PaymentsHistorySection />
       </ErrorBoundary>
 
       {checkoutIntent ? (

--- a/mcpjam-inspector/client/src/hooks/__tests__/usePaymentsHistory.test.ts
+++ b/mcpjam-inspector/client/src/hooks/__tests__/usePaymentsHistory.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+let convexAuth = { isAuthenticated: true, isLoading: false };
+let workOsAuth: { user: unknown; isLoading: boolean } = {
+  user: { id: "u_test" },
+  isLoading: false,
+};
+let queryReturn: unknown = undefined;
+
+vi.mock("convex/react", () => ({
+  useConvexAuth: () => convexAuth,
+  useQuery: (..._args: unknown[]) => queryReturn,
+}));
+
+vi.mock("@workos-inc/authkit-react", () => ({
+  useAuth: () => workOsAuth,
+}));
+
+// Import AFTER mocks are set up.
+import { usePaymentsHistory } from "../usePaymentsHistory";
+
+describe("usePaymentsHistory", () => {
+  beforeEach(() => {
+    convexAuth = { isAuthenticated: true, isLoading: false };
+    workOsAuth = { user: { id: "u_test" }, isLoading: false };
+    queryReturn = undefined;
+  });
+
+  describe("auth gating", () => {
+    it("returns isLoading=true and entries=undefined while convex auth is loading", () => {
+      convexAuth = { isAuthenticated: false, isLoading: true };
+      const { result } = renderHook(() => usePaymentsHistory());
+      expect(result.current.isLoading).toBe(true);
+      expect(result.current.entries).toBeUndefined();
+    });
+
+    it("returns isLoading=false and entries=undefined when unauthenticated (query is skipped)", () => {
+      convexAuth = { isAuthenticated: false, isLoading: false };
+      workOsAuth = { user: null, isLoading: false };
+      const { result } = renderHook(() => usePaymentsHistory());
+      // Query is skipped so we don't wait on a response.
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.entries).toBeUndefined();
+    });
+  });
+
+  describe("normalize", () => {
+    it("normalizes a well-formed { items: [...] } envelope", () => {
+      queryReturn = {
+        items: [
+          {
+            id: "row_1",
+            sessionId: "cs_1",
+            paidAmountCents: 2500,
+            status: "succeeded",
+            occurredAt: 100,
+            receiptUrl: "https://pay.stripe.com/receipts/abc",
+          },
+        ],
+      };
+      const { result } = renderHook(() => usePaymentsHistory());
+      expect(result.current.entries).toHaveLength(1);
+      expect(result.current.entries?.[0]).toEqual({
+        id: "row_1",
+        sessionId: "cs_1",
+        paidAmountCents: 2500,
+        status: "succeeded",
+        occurredAt: 100,
+        receiptUrl: "https://pay.stripe.com/receipts/abc",
+      });
+    });
+
+    it("accepts a bare array (no envelope)", () => {
+      queryReturn = [
+        {
+          id: "row_2",
+          sessionId: "cs_2",
+          paidAmountCents: 1000,
+          status: "pending",
+          occurredAt: 200,
+        },
+      ];
+      const { result } = renderHook(() => usePaymentsHistory());
+      expect(result.current.entries).toHaveLength(1);
+      expect(result.current.entries?.[0].status).toBe("pending");
+      expect(result.current.entries?.[0].receiptUrl).toBeUndefined();
+    });
+
+    it("drops malformed rows but keeps valid neighbors", () => {
+      queryReturn = {
+        items: [
+          { id: "good", sessionId: "cs_good", paidAmountCents: 100, status: "failed", occurredAt: 1 },
+          { id: 123, sessionId: "cs_bad", paidAmountCents: 100, status: "failed", occurredAt: 1 },
+          { id: "no_status", sessionId: "cs_n", paidAmountCents: 100, status: "weird", occurredAt: 1 },
+        ],
+      };
+      const { result } = renderHook(() => usePaymentsHistory());
+      expect(result.current.entries).toHaveLength(1);
+      expect(result.current.entries?.[0].id).toBe("good");
+    });
+
+    it("returns undefined when raw is not an array or envelope", () => {
+      queryReturn = "not an array";
+      const { result } = renderHook(() => usePaymentsHistory());
+      expect(result.current.entries).toBeUndefined();
+    });
+
+    it("drops empty-string receiptUrl rather than passing it through", () => {
+      queryReturn = {
+        items: [
+          {
+            id: "row",
+            sessionId: "cs_e",
+            paidAmountCents: 100,
+            status: "succeeded",
+            occurredAt: 1,
+            receiptUrl: "",
+          },
+        ],
+      };
+      const { result } = renderHook(() => usePaymentsHistory());
+      expect(result.current.entries?.[0].receiptUrl).toBeUndefined();
+    });
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/usePaymentsHistory.ts
+++ b/mcpjam-inspector/client/src/hooks/usePaymentsHistory.ts
@@ -1,0 +1,100 @@
+import { useAuth } from "@workos-inc/authkit-react";
+import { useConvexAuth, useQuery } from "convex/react";
+import { useMemo } from "react";
+
+export type PaymentHistoryStatus = "succeeded" | "pending" | "failed";
+
+export interface PaymentHistoryEntry {
+  id: string;
+  sessionId: string;
+  paidAmountCents: number;
+  status: PaymentHistoryStatus;
+  occurredAt: number;
+  receiptUrl?: string;
+}
+
+interface RawEntry {
+  id?: unknown;
+  sessionId?: unknown;
+  paidAmountCents?: unknown;
+  status?: unknown;
+  occurredAt?: unknown;
+  receiptUrl?: unknown;
+}
+
+const isValidStatus = (value: unknown): value is PaymentHistoryStatus =>
+  value === "succeeded" || value === "pending" || value === "failed";
+
+const normalize = (raw: unknown): PaymentHistoryEntry[] | undefined => {
+  // Accept either a bare array or `{ items: [...] }`. Loose-shape parsing
+  // matches the rest of the billing hooks so the backend can evolve without
+  // forcing a coordinated inspector PR.
+  let items: unknown = raw;
+  if (
+    raw &&
+    typeof raw === "object" &&
+    !Array.isArray(raw) &&
+    "items" in raw
+  ) {
+    items = (raw as { items?: unknown }).items;
+  }
+  if (!Array.isArray(items)) return undefined;
+
+  const out: PaymentHistoryEntry[] = [];
+  for (const item of items as RawEntry[]) {
+    if (
+      typeof item?.id !== "string" ||
+      typeof item.sessionId !== "string" ||
+      typeof item.paidAmountCents !== "number" ||
+      !isValidStatus(item.status) ||
+      typeof item.occurredAt !== "number"
+    ) {
+      continue;
+    }
+    out.push({
+      id: item.id,
+      sessionId: item.sessionId,
+      paidAmountCents: item.paidAmountCents,
+      status: item.status,
+      occurredAt: item.occurredAt,
+      ...(typeof item.receiptUrl === "string" && item.receiptUrl.length > 0
+        ? { receiptUrl: item.receiptUrl }
+        : {}),
+    });
+  }
+  return out;
+};
+
+export interface UsePaymentsHistoryResult {
+  entries: PaymentHistoryEntry[] | undefined;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+}
+
+export function usePaymentsHistory(): UsePaymentsHistoryResult {
+  const {
+    isAuthenticated: hasConvexIdentity,
+    isLoading: isConvexAuthLoading,
+  } = useConvexAuth();
+  const { user, isLoading: isWorkOsLoading } = useAuth();
+  const hasWorkOsUser = !!user;
+  const isAuthLoading = isConvexAuthLoading || isWorkOsLoading;
+  const shouldFetch = !isAuthLoading && hasConvexIdentity && hasWorkOsUser;
+
+  const raw = useQuery(
+    "billing/creditHistory:listTopupHistoryForCurrentUser" as any,
+    shouldFetch ? ({} as any) : "skip",
+  ) as unknown | undefined;
+
+  // Stable reference: Convex returns the same object when nothing has
+  // changed, so memoizing on `raw` keeps the normalized array stable too.
+  const entries = useMemo(() => normalize(raw), [raw]);
+
+  const isLoading = isAuthLoading || (shouldFetch && raw === undefined);
+
+  return {
+    entries,
+    isLoading,
+    isAuthenticated: hasConvexIdentity,
+  };
+}

--- a/mcpjam-inspector/client/src/hooks/usePaymentsHistory.ts
+++ b/mcpjam-inspector/client/src/hooks/usePaymentsHistory.ts
@@ -91,10 +91,14 @@ export function usePaymentsHistory(): UsePaymentsHistoryResult {
   const entries = useMemo(() => normalize(raw), [raw]);
 
   const isLoading = isAuthLoading || (shouldFetch && raw === undefined);
+  // Reflect the same gate the fetch uses (convex identity AND workos user)
+  // so consumers don't see `isAuthenticated=true` while the query is
+  // skipped because the workos side hasn't resolved.
+  const isAuthenticated = hasConvexIdentity && hasWorkOsUser;
 
   return {
     entries,
     isLoading,
-    isAuthenticated: hasConvexIdentity,
+    isAuthenticated,
   };
 }


### PR DESCRIPTION
## Summary
- Adds a Payment history section to the org billing page that lists the user's recent top-ups with date, amount, status, and a link to the Stripe-hosted receipt where available.
- Reads from the new billing history endpoint; renders nothing while the underlying flag is off or hasn't bootstrapped yet, so there's no flash of empty UI.
- Empty / loading / populated states all covered.

## Surface
Renders as a sibling card below the existing credit balance card on the org billing page. Mobile collapses each row into a stacked card.

## UX details
- Status badges carry both color and an icon (a11y).
- Missing-receipt cells render contextual copy: "Not available" (succeeded without link), "Processing" (pending), em-dash (failed).
- Receipt links open in a new tab, `referrerPolicy="no-referrer"`, `data-ph-no-capture` so the receipt token isn't autocaptured or sent as a Referer.
- React key is on the session id so the pending → succeeded transition doesn't unmount/remount.

## Telemetry
- `credit_topup_history_viewed` — once per mount, bucketed entry_count
- `credit_topup_receipt_opened` — on click, no URL or status prop
- Reuses existing `credit_topup_cta_clicked` with `source: "history_empty_state"` for the empty-state CTA

## Test plan
- [x] Component tests covering: flag off / flag undefined / loading / empty + CTA / populated rows / receipt link safety attrs / receipt-click telemetry / view-event fires once with right props / view-event suppressed when empty
- [x] Hook tests covering: auth gating + skip / envelope normalization / bare-array shape / malformed-row drop / non-array short-circuit / empty-string receipt URL drop
- [ ] Manual QA in preview with the flag enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)