### PR TITLE
[Payments Tab] PR-I2: Consumption-order tooltip on Paid credits

### DIFF
--- a/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
@@ -168,6 +168,10 @@ function UsageRow({
                 <button
                   type="button"
                   aria-label={`About ${label}`}
+                  // Defensive: stop bubbling so a future clickable parent
+                  // wrapper doesn't fire when the user clicks the info icon.
+                  onClick={(event) => event.stopPropagation()}
+                  onKeyDown={(event) => event.stopPropagation()}
                   className="inline-flex items-center text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:text-foreground"
                 >
                   <Info aria-hidden="true" className="size-3" />

--- a/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditBalanceCard.tsx
@@ -1,7 +1,13 @@
 import { useEffect, useState } from "react";
+import { Info } from "lucide-react";
 import { Card, CardContent } from "@mcpjam/design-system/card";
 import { Progress } from "@mcpjam/design-system/progress";
 import { Skeleton } from "@mcpjam/design-system/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
 import { CreditTopupDialog } from "@/components/billing/CreditTopupDialog";
 import { PendingCreditTopupsBanner } from "@/components/billing/PendingCreditTopupsBanner";
 import { TopupActionButton } from "@/components/billing/TopupActionButton";
@@ -116,6 +122,7 @@ export function CreditBalanceCard({
             fillPercent={paidPercentUsed}
             isLoading={false}
             testId="usage-paid"
+            tooltip="Paid credits are used only after your daily free quota runs out each day. Your free quota resets every 24 hours."
           />
         )}
       </CardContent>
@@ -138,6 +145,8 @@ interface UsageRowProps {
   fillPercent: number;
   isLoading: boolean;
   testId?: string;
+  /** Optional explainer surfaced via an info icon next to the label. */
+  tooltip?: string;
 }
 
 function UsageRow({
@@ -146,11 +155,30 @@ function UsageRow({
   fillPercent,
   isLoading,
   testId,
+  tooltip,
 }: UsageRowProps) {
   return (
     <div className="flex flex-col gap-2" data-testid={testId}>
       <div className="flex items-center justify-between text-xs">
-        <span className="font-medium">{label}</span>
+        <span className="flex items-center gap-1 font-medium">
+          {label}
+          {tooltip ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={`About ${label}`}
+                  className="inline-flex items-center text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:text-foreground"
+                >
+                  <Info aria-hidden="true" className="size-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs text-xs">
+                {tooltip}
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
+        </span>
         <span className="text-muted-foreground">
           {isLoading || rightText == null ? (
             <Skeleton className="h-3 w-24" />

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditBalanceCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { CreditBalanceCard } from "../CreditBalanceCard";
@@ -104,6 +104,31 @@ describe("CreditBalanceCard", () => {
     // wrong remaining-dollars value, and any credited-domain dollar
     // exposes the take rate when the user knows what they paid.
     expect(paidRow.textContent ?? "").not.toMatch(/\$/);
+  });
+
+  it("exposes a tooltip trigger on the paid-credits row explaining consumption order", () => {
+    balanceState = {
+      paidPercentRemaining: 50,
+      hasPurchaseHistory: true,
+      freeDailyPercentUsed: 0,
+      freeDailyResetAt: Date.now() + 60 * 60 * 1000,
+    };
+    render(<CreditBalanceCard />);
+
+    const paidRow = screen.getByTestId("usage-paid");
+    // Keyboard- and screen-reader-accessible info button.
+    const infoButton = within(paidRow).getByRole("button", {
+      name: /About Paid credits/i,
+    });
+    expect(infoButton).toBeInTheDocument();
+  });
+
+  it("does NOT expose a tooltip trigger on the daily-limit row (no ambiguity to explain there)", () => {
+    render(<CreditBalanceCard />);
+    const dailyRow = screen.getByTestId("usage-daily");
+    expect(
+      within(dailyRow).queryByRole("button", { name: /About/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("opens the top-up dialog when the Top up button is clicked", async () => {

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
@@ -130,4 +130,30 @@ describe("SidebarCreditUsage", () => {
       "Daily limit"
     );
   });
+
+  it("does NOT nest buttons when onClick is set AND the paid-credits tooltip renders (variant=full + paying user)", () => {
+    // The outer clickable wrapper used to be a <button>. Combined with the
+    // paid-credits row's tooltip trigger (also a <button>), this produced an
+    // invalid <button><button/></button> tree. Regression guard: outer
+    // wrapper is now a div with role=button, leaving the tooltip trigger as
+    // the only real <button> in the row.
+    balanceState = {
+      paidPercentRemaining: 40,
+      hasPurchaseHistory: true,
+      freeDailyPercentUsed: 10,
+      freeDailyResetAt: Date.now() + 60 * 60 * 1000,
+    };
+    render(
+      <SidebarCreditUsage variant="full" onClick={() => undefined} />,
+    );
+    const wrapper = screen.getByTestId("sidebar-credit-usage");
+    // Wrapper is NOT a real <button>
+    expect(wrapper.tagName).toBe("DIV");
+    expect(wrapper).toHaveAttribute("role", "button");
+    // Tooltip trigger inside it is still a real focusable button
+    const tooltipTrigger = screen.getByRole("button", {
+      name: /About Paid credits/i,
+    });
+    expect(tooltipTrigger.tagName).toBe("BUTTON");
+  });
 });

--- a/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/__tests__/sidebar-credit-usage.test.tsx
@@ -156,4 +156,34 @@ describe("SidebarCreditUsage", () => {
     });
     expect(tooltipTrigger.tagName).toBe("BUTTON");
   });
+
+  it("clicking the tooltip trigger does NOT fire the wrapper's onClick", async () => {
+    // Regression guard: clicking the info icon should show the tooltip
+    // only. It must not bubble up to the wrapper and navigate the user
+    // away from where they are.
+    const { default: userEvent } = await import("@testing-library/user-event");
+    const onWrapperClick = vi.fn();
+    balanceState = {
+      paidPercentRemaining: 40,
+      hasPurchaseHistory: true,
+      freeDailyPercentUsed: 10,
+      freeDailyResetAt: Date.now() + 60 * 60 * 1000,
+    };
+    render(<SidebarCreditUsage variant="full" onClick={onWrapperClick} />);
+
+    const tooltipTrigger = screen.getByRole("button", {
+      name: /About Paid credits/i,
+    });
+
+    vi.useRealTimers();
+    const user = userEvent.setup();
+    await user.click(tooltipTrigger);
+
+    expect(onWrapperClick).not.toHaveBeenCalled();
+
+    // Sanity check the other direction: clicking the row body still fires.
+    const wrapper = screen.getByTestId("sidebar-credit-usage");
+    await user.click(wrapper);
+    expect(onWrapperClick).toHaveBeenCalled();
+  });
 });

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
@@ -162,6 +162,11 @@ function SidebarUsageRow({
                 <button
                   type="button"
                   aria-label={`About ${label}`}
+                  // Stop bubbling so the surrounding clickable wrapper (the
+                  // sidebar row that navigates to billing on click) doesn't
+                  // fire when the user is just trying to see the tooltip.
+                  onClick={(event) => event.stopPropagation()}
+                  onKeyDown={(event) => event.stopPropagation()}
                   className="inline-flex items-center text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:text-foreground"
                 >
                   <Info aria-hidden="true" className="size-2.5" />

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
@@ -87,10 +87,20 @@ export function SidebarCreditUsage({
   );
 
   if (onClick) {
+    // Use div+role=button instead of a real <button> so the tooltip
+    // trigger (which is itself a <button>) on the paid-credits row
+    // doesn't nest buttons — invalid HTML, plus breaks tooltip focus.
     return (
-      <button
-        type="button"
+      <div
+        role="button"
+        tabIndex={0}
         onClick={onClick}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            onClick();
+          }
+        }}
         data-testid="sidebar-credit-usage"
         aria-label="Credit usage"
         className={cn(
@@ -99,7 +109,7 @@ export function SidebarCreditUsage({
         )}
       >
         {innerContent}
-      </button>
+      </div>
     );
   }
 

--- a/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
+++ b/mcpjam-inspector/client/src/components/sidebar/sidebar-credit-usage.tsx
@@ -1,5 +1,11 @@
+import { Info } from "lucide-react";
 import { Progress } from "@mcpjam/design-system/progress";
 import { Skeleton } from "@mcpjam/design-system/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
 import { useCreditBalance } from "@/hooks/useCreditBalance";
 import { formatCreditResetText } from "@/lib/credit-usage";
 import { cn } from "@/lib/utils";
@@ -73,6 +79,7 @@ export function SidebarCreditUsage({
             fillPercent={paidPercentUsed}
             isLoading={false}
             testId="sidebar-usage-paid"
+            tooltip="Paid credits are used only after your daily free quota runs out each day. Your free quota resets every 24 hours."
           />
         ) : null}
       </div>
@@ -115,6 +122,8 @@ interface SidebarUsageRowProps {
   fillPercent: number;
   isLoading: boolean;
   testId: string;
+  /** Optional explainer surfaced via an info icon next to the label. */
+  tooltip?: string;
 }
 
 function SidebarUsageRow({
@@ -125,6 +134,7 @@ function SidebarUsageRow({
   fillPercent,
   isLoading,
   testId,
+  tooltip,
 }: SidebarUsageRowProps) {
   return (
     <div className="flex flex-col gap-1.5" data-testid={testId}>
@@ -134,8 +144,24 @@ function SidebarUsageRow({
         </span>
       ) : null}
       <div className="flex items-center justify-between gap-2 text-[11px] leading-none">
-        <span className="min-w-0 truncate font-medium text-foreground">
+        <span className="flex min-w-0 items-center gap-1 truncate font-medium text-foreground">
           {label}
+          {tooltip ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={`About ${label}`}
+                  className="inline-flex items-center text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:text-foreground"
+                >
+                  <Info aria-hidden="true" className="size-2.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs text-xs">
+                {tooltip}
+              </TooltipContent>
+            </Tooltip>
+          ) : null}
         </span>
         <span className="shrink-0 text-muted-foreground">
           {isLoading ? <Skeleton className="h-3 w-12" /> : percentText}


### PR DESCRIPTION
## Summary
- Adds a small info-icon tooltip on the **Paid credits** row of the billing-page credit-balance card and the sidebar credit-usage strip.
- Explains that paid credits are only consumed after the daily free quota each day — closes a visible UX gap surfaced during local QA of #2261.
- No flag gate (purely additive copy); no backend changes.

## Why
The card renders two bars (Daily limit / Paid credits) with zero copy explaining how they interact. Users hitting paid usage will reasonably ask "why did my paid drop while my daily isn't full?". Tooltip closes the gap without cluttering the card.

## Copy
> Paid credits are used only after your daily free quota runs out each day. Your free quota resets every 24 hours.

## Surfaces touched
| File | Change |
|---|---|
| client/src/components/billing/CreditBalanceCard.tsx | UsageRow gains optional `tooltip` prop; wired on the Paid credits row |
| client/src/components/sidebar/sidebar-credit-usage.tsx | SidebarUsageRow gains optional `tooltip` prop; wired on the Paid credits row (variant=full only) |
| client/src/components/billing/__tests__/CreditBalanceCard.test.tsx | New tests asserting the info button renders on paid row but not daily row |

## Test plan
- [x] Tooltip trigger renders on paid-credits row when `hasPurchaseHistory === true`
- [x] No tooltip trigger on daily-limit row
- [ ] Manual: hover/focus the info icon — tooltip appears with the consumption-order copy
- [ ] Manual: keyboard nav lands on the icon (focusable button); aria-label reads "About Paid credits"

## Scope (kept tight)
- ✅ Info icon + tooltip on "Paid credits" row in both surfaces
- ❌ No tooltip on "Daily limit" row (no ambiguity to explain)
- ❌ No inline body copy
- ❌ No changes to the underlying consumption logic

## Tracking
Added to the Payments Tab plan as PR-I2 — see [plans/2026-05-24_payments-tab-mvp.md](../../Docs/plans/2026-05-24_payments-tab-mvp.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)