### PR TITLE
fix(sep-1865): hide tools when visibility array omits "model"

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -157,6 +157,42 @@ describe("prepareChatV2", () => {
     ]);
   });
 
+  it("hides tools whose visibility array is set but omits 'model'", async () => {
+    // SEP-1865: "Host MUST NOT include tools in the agent's tool list
+    // when their visibility does not include 'model'." Covers `[]` and
+    // any future scope literal that isn't "model" — the upstream
+    // `isToolVisibilityAppOnly` helper only matches exactly `["app"]`
+    // and would leak these through.
+    const manager = mockManager({
+      empty_visibility_tool: { description: "empty", _serverId: "srv" },
+      future_scope_tool: { description: "future scope", _serverId: "srv" },
+      omitted_visibility_tool: { description: "omitted", _serverId: "srv" },
+    });
+    manager.getAllToolsMetadata = vi.fn((id: string) =>
+      id === "srv"
+        ? {
+            empty_visibility_tool: { ui: { visibility: [] } },
+            // Cast through `any` — the typed schema only allows
+            // "model"|"app", but the wire shape can carry anything.
+            future_scope_tool: {
+              ui: { visibility: ["future-scope"] as any },
+            },
+            // No `_meta.ui.visibility` at all → default `["model","app"]`.
+            omitted_visibility_tool: {},
+          }
+        : {},
+    );
+
+    const result = await prepareChatV2({
+      mcpClientManager: manager,
+      selectedServers: ["srv"],
+      modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
+      systemPrompt: "Base prompt.",
+    });
+
+    expect(Object.keys(result.allTools)).toEqual(["omitted_visibility_tool"]);
+  });
+
   it("filters selectedServers down to ids the manager has registered", async () => {
     const manager = mockManager({});
     manager.hasServer = vi.fn((id: string) => id === "live-server");

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -18,7 +18,6 @@
 import type { ModelMessage } from "@ai-sdk/provider-utils";
 import type { ToolSet } from "ai";
 import { MCPClientManager } from "@mcpjam/sdk";
-import { isToolVisibilityAppOnly } from "@modelcontextprotocol/ext-apps/app-bridge";
 import {
   isAnthropicCompatibleModel,
   getInvalidAnthropicToolNames,
@@ -34,11 +33,29 @@ import { HOSTED_MODE } from "../config.js";
 const DEFAULT_TEMPERATURE = 0.7;
 
 /**
- * Mutates `tools` in place, removing entries whose source MCP tool
- * declares SEP-1865 `_meta.ui.visibility` as exactly `["app"]`.
+ * SEP-1865: "Host MUST NOT include tools in the agent's tool list when
+ * their visibility does not include 'model'." Hide when `visibility` is
+ * an array that doesn't contain "model" — covers `["app"]`, `[]`, and
+ * any future scope literal that isn't "model".
  *
- * The visibility array defaults to `["model", "app"]` per SEP-1865, so a
- * tool with no visibility metadata is treated as visible to both.
+ * Missing `visibility` (or non-array) defaults to both per the spec, so
+ * the tool stays visible. We can't use the upstream
+ * `isToolVisibilityAppOnly` helper for this — it only matches exactly
+ * `["app"]` and would leak the `[]` and future-scope cases through.
+ */
+function shouldHideFromModel(
+  meta: Record<string, unknown> | undefined,
+): boolean {
+  const ui = meta?.ui as { visibility?: unknown } | undefined;
+  const visibility = ui?.visibility;
+  if (!Array.isArray(visibility)) return false;
+  return !visibility.includes("model");
+}
+
+/**
+ * Mutates `tools` in place, removing entries whose source MCP tool
+ * declares a SEP-1865 `_meta.ui.visibility` that does not include
+ * `"model"`. Tools remain callable from the iframe bridge.
  */
 function filterAppOnlyTools(
   tools: ToolSet,
@@ -59,10 +76,7 @@ function filterAppOnlyTools(
     const serverId = (tool as { _serverId?: unknown })._serverId;
     if (typeof serverId !== "string") continue;
     const meta = getMeta(serverId)[name];
-    // SDK helper takes a tool-shaped object with `_meta`; wrap the per-tool
-    // metadata to match its expected shape. Returns true iff `_meta.ui.visibility`
-    // is exactly `["app"]`.
-    if (isToolVisibilityAppOnly({ _meta: meta })) {
+    if (shouldHideFromModel(meta)) {
       delete tools[name];
     }
   }


### PR DESCRIPTION
## Summary

The visibility filter merged in #2249 used the upstream `isToolVisibilityAppOnly` helper from `@modelcontextprotocol/ext-apps/app-bridge`, which only matches a visibility of *exactly* `["app"]`. SEP-1865 actually says:

> Host MUST NOT include tools in the agent's tool list when their visibility does not include `"model"` (e.g., `visibility: ["app"]`).

So values like `[]` and any future non-`"model"` scope literal were leaking through to the model.

This PR swaps the SDK call for a spec-strict predicate `!visibility.includes("model")`, gated on `Array.isArray` so omitted visibility still defaults to `["model", "app"]` per spec.

## Coverage matrix

| `visibility` value | Spec | Before | After |
|---|---|---|---|
| omitted | show | show ✅ | show ✅ |
| `["model"]` | show | show ✅ | show ✅ |
| `["model","app"]` | show | show ✅ | show ✅ |
| `["app"]` | hide | hide ✅ | hide ✅ |
| `[]` (empty) | hide | **show** ❌ | hide ✅ |
| `["future-scope"]` | hide | **show** ❌ | hide ✅ |

## Test plan

- [x] `npx vitest run server/utils/__tests__/chat-v2-orchestration.test.ts` — all 5 pass, including new "hides tools whose visibility array is set but omits 'model'" regression test
- [x] Existing "hides SEP-1865 app-only tools" test still passes (the `["app"]` path is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which MCP tools the LLM can invoke in chat-v2; mis-filtering could hide needed tools or expose app-only ones, but scope is small and covered by tests.
> 
> **Overview**
> Tightens **SEP-1865** tool visibility in `prepareChatV2` so MCP tools are dropped from the model’s AI SDK tool set whenever `_meta.ui.visibility` is an array that does **not** include `"model"` (not only `["app"]`).
> 
> The upstream `isToolVisibilityAppOnly` check is replaced with local `shouldHideFromModel`, which leaves tools visible when `visibility` is missing or not an array (spec default). Empty `[]` and other non-`model` scopes are now hidden from the model while still callable via the app bridge.
> 
> A regression test asserts only tools with omitted/default visibility remain exposed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa441dbd072426a1e4fc0e28c3fe945b4e1c1180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->