### PR TITLE
[Payments Tab] PR-I4: Pass returnUrl from top-up dialog

### DIFF
--- a/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
@@ -62,8 +62,6 @@ export function CreditTopupDialog({
         chatSessionId,
         lastUserMessage,
         source,
-        // Round-trip Stripe back to the exact page the user initiated
-        // from. Backend validates same-origin before honoring it.
         ...(typeof window !== "undefined"
           ? { returnUrl: window.location.href }
           : {}),

--- a/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
+++ b/mcpjam-inspector/client/src/components/billing/CreditTopupDialog.tsx
@@ -62,6 +62,11 @@ export function CreditTopupDialog({
         chatSessionId,
         lastUserMessage,
         source,
+        // Round-trip Stripe back to the exact page the user initiated
+        // from. Backend validates same-origin before honoring it.
+        ...(typeof window !== "undefined"
+          ? { returnUrl: window.location.href }
+          : {}),
       });
     } catch (err) {
       const message =

--- a/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/CreditTopupDialog.test.tsx
@@ -103,12 +103,38 @@ describe("CreditTopupDialog", () => {
     );
 
     expect(startCheckoutMock).toHaveBeenCalledTimes(1);
-    expect(startCheckoutMock).toHaveBeenCalledWith({
-      amountCents: 1000,
-      chatSessionId: "chat-1",
-      lastUserMessage: "please continue",
-      source: "chat_banner",
-    });
+    expect(startCheckoutMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amountCents: 1000,
+        chatSessionId: "chat-1",
+        lastUserMessage: "please continue",
+        source: "chat_banner",
+      }),
+    );
+  });
+
+  it("passes the current page URL as returnUrl so Stripe round-trips back to it", async () => {
+    const user = userEvent.setup();
+    render(
+      <CreditTopupDialog
+        open
+        onOpenChange={vi.fn()}
+        chatSessionId="chat-1"
+        lastUserMessage=""
+        source="billing_page"
+      />,
+    );
+
+    await user.click(screen.getByRole("radio", { name: "$10" }));
+    await user.click(
+      screen.getByRole("button", { name: /Continue with \$10/ }),
+    );
+
+    expect(startCheckoutMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        returnUrl: window.location.href,
+      }),
+    );
   });
 
   it("calls onOpenChange(false) when Cancel is clicked", async () => {


### PR DESCRIPTION
## Summary
- `CreditTopupDialog` now passes `returnUrl: window.location.href` when starting Stripe Checkout.
- After payment, Stripe will redirect users back to the exact page they initiated the top-up from (org-scoped billing page, chat session, etc.) instead of a generic landing page.
- A paired backend change validates same-origin before honoring the value (open-redirect defense); off-origin or malformed URLs fall back to the legacy default — safe degrade.

## Test plan
- [x] Existing dialog test updated to use `objectContaining` (more flexible)
- [x] New test asserts `returnUrl: window.location.href` is included in the `startCheckout` call
- [ ] Manual: top-up from `/organizations/<orgId>/billing` → after payment, redirect lands back on that exact URL with `?topup=success&session_id=...`
- [ ] Manual: top-up from chat banner (different page) → redirect lands back on the chat URL with same query params (the existing return-flow handler in chat catches `?topup=success`)

## Notes
Depends on a paired backend change being deployed first. If this lands first, the inspector passes an arg the backend silently drops — falls back to the existing default redirect (no error). Once the backend ships, the round-trip works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)