### PR TITLE
feat: Respect tool visibility toggle in Agent tab

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -980,6 +980,7 @@ export function ChatV2Route() {
                 temperature: activeHost.temperature,
                 requireToolApproval: activeHost.requireToolApproval,
                 progressiveToolDiscovery: activeHost.progressiveToolDiscovery,
+                respectToolVisibility: activeHost.respectToolVisibility,
               }
             : undefined
         }

--- a/mcpjam-inspector/client/src/components/ChatTabV2.tsx
+++ b/mcpjam-inspector/client/src/components/ChatTabV2.tsx
@@ -2318,6 +2318,8 @@ export function ChatTabV2({
                             // what BehaviorTab saved.
                             progressiveToolDiscovery:
                               executionConfig?.progressiveToolDiscovery,
+                            respectToolVisibility:
+                              executionConfig?.respectToolVisibility,
                           }}
                           hostedContext={{
                             ...hostedContext,

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/TranscriptThread.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/TranscriptThread.test.tsx
@@ -60,7 +60,7 @@ class ControlledResizeObserver {
 
   trigger(elements?: Element[]) {
     const targets = (elements ?? Array.from(this.observed)).filter((element) =>
-      this.observed.has(element),
+      this.observed.has(element)
     );
     if (targets.length === 0) return;
 
@@ -73,9 +73,9 @@ class ControlledResizeObserver {
             borderBoxSize: [],
             contentBoxSize: [],
             devicePixelContentBoxSize: [],
-          }) as ResizeObserverEntry,
+          } as ResizeObserverEntry)
       ),
-      this as unknown as ResizeObserver,
+      this as unknown as ResizeObserver
     );
   }
 
@@ -142,7 +142,7 @@ function mockElementRect(
     height: number;
     left?: number;
     width?: number;
-  },
+  }
 ) {
   Object.defineProperty(element, "getBoundingClientRect", {
     configurable: true,
@@ -249,11 +249,11 @@ describe("TranscriptThread", () => {
         {...defaultProps}
         focusMessageId="assistant-1"
         highlightedMessageIds={["assistant-1"]}
-      />,
+      />
     );
 
     const wrapper = document.querySelector(
-      '[data-message-id="assistant-1"]',
+      '[data-message-id="assistant-1"]'
     ) as HTMLElement | null;
     expect(wrapper).not.toBeNull();
     expect(wrapper).toHaveAttribute("data-focused", "true");
@@ -268,20 +268,118 @@ describe("TranscriptThread", () => {
     render(<TranscriptThread {...defaultProps} />);
 
     const wrapper = document.querySelector(
-      '[data-message-id="assistant-1"]',
+      '[data-message-id="assistant-1"]'
     ) as HTMLElement | null;
     expect(wrapper).not.toBeNull();
     expect(wrapper?.style.contentVisibility).toBe("auto");
     expect(wrapper?.style.containIntrinsicSize).toBe("0 160px");
   });
 
+  it("renders app-initiated tool invocations under the owning tool message", () => {
+    render(
+      <TranscriptThread
+        {...defaultProps}
+        messages={[
+          {
+            id: "assistant-tool",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-transparency-test",
+                toolCallId: "call-1",
+                state: "output-available",
+              } as any,
+            ],
+          },
+        ]}
+        appToolInvocations={[
+          {
+            id: "call-1:app-tool:0",
+            parentToolCallId: "call-1",
+            toolName: "transparency-test",
+            input: { value: 1 },
+            output: { content: [{ type: "text", text: "ok" }] },
+            status: "success",
+            startedAt: 1,
+            completedAt: 2,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("transparency-test")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Data" })).toBeInTheDocument();
+  });
+
+  it("does not render app-initiated tool invocations after their owning tool message is gone", () => {
+    const { rerender } = render(
+      <TranscriptThread
+        {...defaultProps}
+        messages={[
+          {
+            id: "assistant-tool",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-transparency-test",
+                toolCallId: "call-1",
+                state: "output-available",
+              } as any,
+            ],
+          },
+        ]}
+        appToolInvocations={[
+          {
+            id: "call-1:app-tool:0",
+            parentToolCallId: "call-1",
+            toolName: "transparency-test",
+            status: "success",
+            startedAt: 1,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("transparency-test")).toBeInTheDocument();
+
+    rerender(
+      <TranscriptThread
+        {...defaultProps}
+        messages={[
+          {
+            id: "assistant-other",
+            role: "assistant",
+            parts: [
+              {
+                type: "tool-other",
+                toolCallId: "call-2",
+                state: "output-available",
+              } as any,
+            ],
+          },
+        ]}
+        appToolInvocations={[
+          {
+            id: "call-1:app-tool:0",
+            parentToolCallId: "call-1",
+            toolName: "transparency-test",
+            status: "success",
+            startedAt: 1,
+          },
+        ]}
+      />
+    );
+
+    expect(screen.queryByText("transparency-test")).not.toBeInTheDocument();
+  });
+
   it("disables content-visibility containment while a fullscreen widget is active", () => {
     render(
-      <TranscriptThread {...defaultProps} fullscreenWidgetId="tool-call-1" />,
+      <TranscriptThread {...defaultProps} fullscreenWidgetId="tool-call-1" />
     );
 
     const wrapper = document.querySelector(
-      '[data-message-id="assistant-1"]',
+      '[data-message-id="assistant-1"]'
     ) as HTMLElement | null;
     expect(wrapper).not.toBeNull();
     expect(wrapper?.style.contentVisibility).toBe("");
@@ -292,7 +390,7 @@ describe("TranscriptThread", () => {
     render(<TranscriptThread {...defaultProps} pipWidgetId="tool-call-1" />);
 
     const wrapper = document.querySelector(
-      '[data-message-id="assistant-1"]',
+      '[data-message-id="assistant-1"]'
     ) as HTMLElement | null;
     expect(wrapper).not.toBeNull();
     expect(wrapper?.style.contentVisibility).toBe("");
@@ -307,20 +405,20 @@ describe("TranscriptThread", () => {
           isLoading={true}
           lastRenderableMessageId="assistant-1"
         />
-      </ChatboxHostStyleProvider>,
+      </ChatboxHostStyleProvider>
     );
 
     expect(mockMessageView).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.objectContaining({ id: "assistant-1" }),
         claudeFooterMode: "animated",
-      }),
+      })
     );
     expect(mockMessageView).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.objectContaining({ id: "user-1" }),
         claudeFooterMode: "none",
-      }),
+      })
     );
   });
 
@@ -332,14 +430,14 @@ describe("TranscriptThread", () => {
           isLoading={false}
           lastRenderableMessageId="assistant-1"
         />
-      </ChatboxHostStyleProvider>,
+      </ChatboxHostStyleProvider>
     );
 
     expect(mockMessageView).toHaveBeenCalledWith(
       expect.objectContaining({
         message: expect.objectContaining({ id: "assistant-1" }),
         claudeFooterMode: "static",
-      }),
+      })
     );
   });
 
@@ -352,11 +450,11 @@ describe("TranscriptThread", () => {
         focusMessageId="assistant-1"
         highlightedMessageIds={["assistant-1"]}
         navigationKey={1}
-      />,
+      />
     );
 
     const target = document.querySelector(
-      '[data-message-id="assistant-1"]',
+      '[data-message-id="assistant-1"]'
     ) as HTMLElement;
     mockElementRect(target, { top: 520, height: 40 });
 
@@ -368,7 +466,7 @@ describe("TranscriptThread", () => {
       expect.objectContaining({
         top: 340,
         behavior: "smooth",
-      }),
+      })
     );
   });
 
@@ -384,13 +482,13 @@ describe("TranscriptThread", () => {
         navigationKey={1}
         viewportRef={viewportRef}
       />,
-      { overflowY: "visible" },
+      { overflowY: "visible" }
     );
 
     viewportRef.current = scrollHost;
 
     const target = document.querySelector(
-      '[data-message-id="assistant-1"]',
+      '[data-message-id="assistant-1"]'
     ) as HTMLElement;
     mockElementRect(target, { top: 520, height: 40 });
 
@@ -403,7 +501,7 @@ describe("TranscriptThread", () => {
       expect.objectContaining({
         top: 340,
         behavior: "smooth",
-      }),
+      })
     );
 
     mockElementRect(target, { top: 420, height: 40 });
@@ -414,7 +512,7 @@ describe("TranscriptThread", () => {
         highlightedMessageIds={["assistant-1"]}
         navigationKey={2}
         viewportRef={viewportRef}
-      />,
+      />
     );
 
     act(() => {
@@ -426,7 +524,7 @@ describe("TranscriptThread", () => {
       expect.objectContaining({
         top: 240,
         behavior: "smooth",
-      }),
+      })
     );
   });
 
@@ -439,11 +537,11 @@ describe("TranscriptThread", () => {
         focusMessageId="assistant-1"
         highlightedMessageIds={["assistant-1"]}
         navigationKey={1}
-      />,
+      />
     );
 
     const target = document.querySelector(
-      '[data-message-id="assistant-1"]',
+      '[data-message-id="assistant-1"]'
     ) as HTMLElement;
     mockElementRect(target, { top: 520, height: 120 });
 
@@ -455,7 +553,7 @@ describe("TranscriptThread", () => {
       expect.objectContaining({
         top: 404,
         behavior: "smooth",
-      }),
+      })
     );
   });
 
@@ -473,11 +571,11 @@ describe("TranscriptThread", () => {
         focusMessageId="assistant-1"
         highlightedMessageIds={["assistant-1"]}
         navigationKey={1}
-      />,
+      />
     );
 
     const target = document.querySelector(
-      '[data-message-id="assistant-1"]',
+      '[data-message-id="assistant-1"]'
     ) as HTMLElement;
     mockElementRect(target, { top: 520, height: 40 });
 
@@ -490,7 +588,7 @@ describe("TranscriptThread", () => {
       expect.objectContaining({
         top: 340,
         behavior: "smooth",
-      }),
+      })
     );
 
     const resizeObserver = ControlledResizeObserver.latest();
@@ -509,7 +607,7 @@ describe("TranscriptThread", () => {
       expect.objectContaining({
         top: 80,
         behavior: "auto",
-      }),
+      })
     );
 
     mockElementRect(target, { top: 300, height: 40 });
@@ -535,7 +633,7 @@ describe("TranscriptThread", () => {
       expect.objectContaining({
         top: 120,
         behavior: "auto",
-      }),
+      })
     );
 
     act(() => {
@@ -550,7 +648,7 @@ describe("TranscriptThread", () => {
       expect.objectContaining({
         top: 120,
         behavior: "auto",
-      }),
+      })
     );
 
     act(() => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
@@ -36,6 +36,10 @@ import {
   WidgetSurfaceHostProvider,
 } from "./thread/mcp-apps/widget-surface-host";
 import { useWidgetSurfaceStore } from "./thread/mcp-apps/widget-surface-store";
+import type {
+  AppToolInvocation,
+  AppToolInvocationUpdate,
+} from "./thread/app-tool-invocations";
 
 interface ThreadProps {
   chatSessionId?: string;
@@ -103,6 +107,19 @@ function getWidgetOwnershipIds(toolCallId: string, displayWidgetId?: string) {
   return ids;
 }
 
+function getMessageToolCallIds(messages: UIMessage[]): Set<string> {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    for (const part of message.parts ?? []) {
+      const toolCallId = (part as { toolCallId?: unknown }).toolCallId;
+      if (typeof toolCallId === "string" && toolCallId.length > 0) {
+        ids.add(toolCallId);
+      }
+    }
+  }
+  return ids;
+}
+
 export function Thread({
   chatSessionId,
   messages,
@@ -146,6 +163,38 @@ export function Thread({
   >(() => new Set());
   const [isFullscreenChatOpen, setIsFullscreenChatOpen] = useState(false);
   const [fullscreenChatInput, setFullscreenChatInput] = useState("");
+  const [appToolInvocations, setAppToolInvocations] = useState<
+    AppToolInvocation[]
+  >([]);
+
+  const handleAppToolInvocationChange = useCallback(
+    (invocation: AppToolInvocationUpdate) => {
+      setAppToolInvocations((current) => {
+        const index = current.findIndex((item) => item.id === invocation.id);
+        if (index === -1) {
+          return [...current, invocation];
+        }
+        const next = [...current];
+        next[index] = invocation;
+        return next;
+      });
+    },
+    []
+  );
+
+  useEffect(() => {
+    setAppToolInvocations([]);
+  }, [chatSessionId]);
+
+  useEffect(() => {
+    const liveToolCallIds = getMessageToolCallIds(messages);
+    setAppToolInvocations((current) => {
+      const next = current.filter((invocation) =>
+        liveToolCallIds.has(invocation.parentToolCallId)
+      );
+      return next.length === current.length ? current : next;
+    });
+  }, [messages]);
 
   const handleRequestPip = (toolCallId: string) => {
     setPipWidgetId(toolCallId);
@@ -280,6 +329,8 @@ export function Thread({
           toolServerMap={toolServerMap}
           onWidgetStateChange={onWidgetStateChange}
           onModelContextUpdate={onModelContextUpdate}
+          appToolInvocations={appToolInvocations}
+          onAppToolInvocationChange={handleAppToolInvocationChange}
           pipWidgetId={pipWidgetId}
           fullscreenWidgetId={fullscreenWidgetId}
           onRequestPip={handleRequestPip}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/app-tool-invocations.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/app-tool-invocations.ts
@@ -1,0 +1,15 @@
+export type AppToolInvocationStatus = "running" | "success" | "error";
+
+export interface AppToolInvocation {
+  id: string;
+  parentToolCallId: string;
+  toolName: string;
+  input?: Record<string, unknown>;
+  output?: unknown;
+  errorText?: string;
+  status: AppToolInvocationStatus;
+  startedAt: number;
+  completedAt?: number;
+}
+
+export type AppToolInvocationUpdate = AppToolInvocation;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -2765,6 +2765,57 @@ describe("MCPAppsRenderer host capability enforcement", () => {
     }
   );
 
+  it("reports widget-initiated server tool calls for transcript rendering", async () => {
+    const onCallTool = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "tool ok" }],
+    });
+    const onAppToolInvocationChange = vi.fn();
+
+    render(
+      <ChatboxHostCapabilitiesOverrideProvider value={{ serverTools: {} }}>
+        <MCPAppsRenderer
+          {...baseProps}
+          onCallTool={onCallTool}
+          onAppToolInvocationChange={onAppToolInvocationChange}
+        />
+      </ChatboxHostCapabilitiesOverrideProvider>
+    );
+
+    await vi.waitFor(() => {
+      expect(mockBridge.oncalltool).not.toBeNull();
+    });
+
+    await act(async () => {
+      await mockBridge.oncalltool({
+        name: "transparency-test",
+        arguments: { value: 1 },
+      });
+    });
+
+    expect(onCallTool).toHaveBeenCalledWith("transparency-test", { value: 1 });
+    expect(onAppToolInvocationChange).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        id: "call-1:app-tool:0",
+        parentToolCallId: "call-1",
+        toolName: "transparency-test",
+        input: { value: 1 },
+        status: "running",
+      })
+    );
+    expect(onAppToolInvocationChange).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        id: "call-1:app-tool:0",
+        parentToolCallId: "call-1",
+        toolName: "transparency-test",
+        input: { value: 1 },
+        output: { content: [{ type: "text", text: "tool ok" }] },
+        status: "success",
+      })
+    );
+  });
+
   it("registers all three serverResources handlers under a single cap", async () => {
     render(
       <ChatboxHostCapabilitiesOverrideProvider value={{ serverResources: {} }}>

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -77,6 +77,7 @@ import { readToolResultMeta } from "@/lib/tool-result-utils";
 import type { CheckoutSession } from "@/shared/acp-types";
 import { listResources, readResource } from "@/lib/apis/mcp-resources-api";
 import { listPrompts } from "@/lib/apis/mcp-prompts-api";
+import type { AppToolInvocationUpdate } from "../app-tool-invocations";
 import {
   useChatboxHostStyle,
   useChatboxHostTheme,
@@ -98,9 +99,7 @@ import {
 } from "@/lib/client-config-v2";
 import type { ResolvedMcpAppsCapabilities } from "@/lib/client-styles";
 import { usePersistentWidgetSurfaceHost } from "./widget-surface-context";
-import {
-  useWidgetSurfaceStore,
-} from "./widget-surface-store";
+import { useWidgetSurfaceStore } from "./widget-surface-store";
 
 // Injected by Vite at build time from package.json
 declare const __APP_VERSION__: string;
@@ -196,6 +195,7 @@ export interface MCPAppsRendererProps {
     toolName: string,
     params: Record<string, unknown>
   ) => Promise<unknown>;
+  onAppToolInvocationChange?: (invocation: AppToolInvocationUpdate) => void;
   onWidgetStateChange?: (toolCallId: string, state: unknown) => void;
   pipWidgetId?: string | null;
   fullscreenWidgetId?: string | null;
@@ -527,6 +527,7 @@ export function MCPAppsRendererSurface({
   toolsMetadata,
   onSendFollowUp,
   onCallTool,
+  onAppToolInvocationChange,
   onWidgetStateChange,
   pipWidgetId,
   fullscreenWidgetId,
@@ -876,8 +877,7 @@ export function MCPAppsRendererSurface({
   const displayMode = isControlled ? displayModeProp : internalDisplayMode;
   const displayWidgetId = persistentSurfaceId ?? toolCallId;
   const ownsFullscreenDisplayMode =
-    fullscreenWidgetId === displayWidgetId ||
-    fullscreenWidgetId === toolCallId;
+    fullscreenWidgetId === displayWidgetId || fullscreenWidgetId === toolCallId;
   const ownsPipDisplayMode =
     pipWidgetId === displayWidgetId || pipWidgetId === toolCallId;
   const requestedDisplayMode = useMemo<DisplayMode>(() => {
@@ -887,7 +887,12 @@ export function MCPAppsRendererSurface({
     }
     if (displayMode === "pip" && ownsPipDisplayMode) return "pip";
     return "inline";
-  }, [displayMode, isControlled, ownsFullscreenDisplayMode, ownsPipDisplayMode]);
+  }, [
+    displayMode,
+    isControlled,
+    ownsFullscreenDisplayMode,
+    ownsPipDisplayMode,
+  ]);
   // Clamp the requested display mode against the same intersection
   // that gets advertised in `HostContext.availableDisplayModes` so
   // the runtime mode is always a member of the advertised set. A
@@ -1137,11 +1142,7 @@ export function MCPAppsRendererSurface({
     setWidgetPermissions(undefined);
     setWidgetPermissive(isCachedReplay ? true : false);
     setPrefersBorder(cachedReplayPrefersBorder ?? true);
-  }, [
-    cachedReplayWidgetHtmlUrl,
-    cachedReplayPrefersBorder,
-    isCachedReplay,
-  ]);
+  }, [cachedReplayWidgetHtmlUrl, cachedReplayPrefersBorder, isCachedReplay]);
 
   const bridgeRef = useRef<AppBridge | null>(null);
   const hostContextRef = useRef<McpUiHostContext | null>(null);
@@ -1216,6 +1217,8 @@ export function MCPAppsRendererSurface({
 
   const onSendFollowUpRef = useRef(onSendFollowUp);
   const onCallToolRef = useRef(onCallTool);
+  const onAppToolInvocationChangeRef = useRef(onAppToolInvocationChange);
+  const appToolInvocationSequenceRef = useRef(0);
   const onRequestPipRef = useRef(onRequestPip);
   const onExitPipRef = useRef(onExitPip);
   const onRequestTeardownRef = useRef(onRequestTeardown);
@@ -2619,6 +2622,7 @@ export function MCPAppsRendererSurface({
   useLayoutEffect(() => {
     onSendFollowUpRef.current = onSendFollowUp;
     onCallToolRef.current = onCallTool;
+    onAppToolInvocationChangeRef.current = onAppToolInvocationChange;
     onRequestPipRef.current = onRequestPip;
     onExitPipRef.current = onExitPip;
     setDisplayModeRef.current = setDisplayMode;
@@ -2638,6 +2642,7 @@ export function MCPAppsRendererSurface({
   }, [
     onSendFollowUp,
     onCallTool,
+    onAppToolInvocationChange,
     onRequestPip,
     onExitPip,
     setDisplayMode,
@@ -2816,23 +2821,64 @@ export function MCPAppsRendererSurface({
             throw error;
           }
 
+          const invocationInput = (args ?? {}) as Record<string, unknown>;
+          const invocationId = `${
+            toolCallIdRef.current
+          }:app-tool:${appToolInvocationSequenceRef.current++}`;
+          const startedAt = Date.now();
+          onAppToolInvocationChangeRef.current?.({
+            id: invocationId,
+            parentToolCallId: toolCallIdRef.current,
+            toolName: name,
+            input: invocationInput,
+            status: "running",
+            startedAt,
+          });
+
           if (!onCallToolRef.current) {
             const error = new Error("Tool calls not supported");
+            onAppToolInvocationChangeRef.current?.({
+              id: invocationId,
+              parentToolCallId: toolCallIdRef.current,
+              toolName: name,
+              input: invocationInput,
+              errorText: error.message,
+              status: "error",
+              startedAt,
+              completedAt: Date.now(),
+            });
             sendToolCancelledIfAllowed(error.message);
             throw error;
           }
 
           try {
-            const result = await onCallToolRef.current(
-              name,
-              (args ?? {}) as Record<string, unknown>
-            );
+            const result = await onCallToolRef.current(name, invocationInput);
+            onAppToolInvocationChangeRef.current?.({
+              id: invocationId,
+              parentToolCallId: toolCallIdRef.current,
+              toolName: name,
+              input: invocationInput,
+              output: result,
+              status: "success",
+              startedAt,
+              completedAt: Date.now(),
+            });
             return result as CallToolResult;
           } catch (error) {
+            const errorText =
+              error instanceof Error ? error.message : String(error);
+            onAppToolInvocationChangeRef.current?.({
+              id: invocationId,
+              parentToolCallId: toolCallIdRef.current,
+              toolName: name,
+              input: invocationInput,
+              errorText,
+              status: "error",
+              startedAt,
+              completedAt: Date.now(),
+            });
             // SEP-1865: Send tool-cancelled for failed app-initiated tool calls
-            sendToolCancelledIfAllowed(
-              error instanceof Error ? error.message : String(error)
-            );
+            sendToolCancelledIfAllowed(errorText);
             throw error;
           }
         };

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/message-view.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/message-view.tsx
@@ -24,6 +24,7 @@ import { getAssistantAvatarDescriptor } from "@/components/chat-v2/shared/assist
 import { SenderAvatar } from "@/components/chat-v2/shared/sender-avatar";
 import type { ProjectThreadOwnerAvatar } from "@/components/chat-v2/history/project-thread-owner-avatar";
 import { CopilotMessageHeader } from "./copilot-message-header";
+import type { AppToolInvocationUpdate } from "./app-tool-invocations";
 
 type ClaudeFooterMode = "none" | "animated" | "static";
 type MessagePart = UIMessage["parts"][number];
@@ -43,6 +44,7 @@ interface MessageViewProps {
       structuredContent?: Record<string, unknown>;
     }
   ) => void;
+  onAppToolInvocationChange?: (invocation: AppToolInvocationUpdate) => void;
   pipWidgetId: string | null;
   fullscreenWidgetId: string | null;
   onRequestPip: (toolCallId: string) => void;
@@ -134,6 +136,7 @@ function areMessageViewPropsEqual(
     prev.toolServerMap === next.toolServerMap &&
     prev.onWidgetStateChange === next.onWidgetStateChange &&
     prev.onModelContextUpdate === next.onModelContextUpdate &&
+    prev.onAppToolInvocationChange === next.onAppToolInvocationChange &&
     prev.pipWidgetId === next.pipWidgetId &&
     prev.fullscreenWidgetId === next.fullscreenWidgetId &&
     prev.onRequestPip === next.onRequestPip &&
@@ -166,6 +169,7 @@ function MessageViewImpl({
   toolServerMap,
   onWidgetStateChange,
   onModelContextUpdate,
+  onAppToolInvocationChange,
   pipWidgetId,
   fullscreenWidgetId,
   onRequestPip,
@@ -232,6 +236,7 @@ function MessageViewImpl({
                 toolServerMap={toolServerMap}
                 onWidgetStateChange={onWidgetStateChange}
                 onModelContextUpdate={onModelContextUpdate}
+                onAppToolInvocationChange={onAppToolInvocationChange}
                 pipWidgetId={pipWidgetId}
                 fullscreenWidgetId={fullscreenWidgetId}
                 onRequestPip={onRequestPip}
@@ -265,6 +270,7 @@ function MessageViewImpl({
                 toolServerMap={toolServerMap}
                 onWidgetStateChange={onWidgetStateChange}
                 onModelContextUpdate={onModelContextUpdate}
+                onAppToolInvocationChange={onAppToolInvocationChange}
                 pipWidgetId={pipWidgetId}
                 fullscreenWidgetId={fullscreenWidgetId}
                 onRequestPip={onRequestPip}
@@ -343,6 +349,7 @@ function MessageViewImpl({
                   toolServerMap={toolServerMap}
                   onWidgetStateChange={onWidgetStateChange}
                   onModelContextUpdate={onModelContextUpdate}
+                  onAppToolInvocationChange={onAppToolInvocationChange}
                   pipWidgetId={pipWidgetId}
                   fullscreenWidgetId={fullscreenWidgetId}
                   onRequestPip={onRequestPip}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
@@ -48,6 +48,7 @@ import {
   readToolResultMeta,
   readToolResultServerId,
 } from "@/lib/tool-result-utils";
+import type { AppToolInvocationUpdate } from "./app-tool-invocations";
 
 export function PartSwitch({
   part,
@@ -58,6 +59,7 @@ export function PartSwitch({
   toolServerMap,
   onWidgetStateChange,
   onModelContextUpdate,
+  onAppToolInvocationChange,
   pipWidgetId,
   fullscreenWidgetId,
   onRequestPip,
@@ -90,6 +92,7 @@ export function PartSwitch({
       structuredContent?: Record<string, unknown>;
     }
   ) => void;
+  onAppToolInvocationChange?: (invocation: AppToolInvocationUpdate) => void;
   pipWidgetId: string | null;
   fullscreenWidgetId: string | null;
   onRequestPip: (toolCallId: string) => void;
@@ -379,6 +382,7 @@ export function PartSwitch({
                     callTool(serverId ?? "offline-view", toolName, params)
                 : undefined
             }
+            onAppToolInvocationChange={onAppToolInvocationChange}
             onWidgetStateChange={interactive ? onWidgetStateChange : undefined}
             onModelContextUpdate={
               interactive ? onModelContextUpdate : undefined

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/app-tool-invocation-part.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/app-tool-invocation-part.tsx
@@ -1,0 +1,177 @@
+import { useState, type KeyboardEvent } from "react";
+import {
+  CheckCircle2,
+  ChevronDown,
+  Database,
+  Loader2,
+  XCircle,
+} from "lucide-react";
+
+import { JsonEditor } from "@/components/ui/json-editor";
+import { cn } from "@/lib/chat-utils";
+import type { AppToolInvocation } from "../app-tool-invocations";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@mcpjam/design-system/tooltip";
+
+export function AppToolInvocationPart({
+  invocation,
+}: {
+  invocation: AppToolInvocation;
+}) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const hasInput = invocation.input !== undefined;
+  const hasOutput = invocation.output !== undefined;
+  const hasError = invocation.status === "error" && !!invocation.errorText;
+  const hasDetails = hasInput || hasOutput || hasError;
+
+  const toggleExpanded = () => {
+    if (!hasDetails) return;
+    setIsExpanded((value) => !value);
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    toggleExpanded();
+  };
+
+  const StatusIcon =
+    invocation.status === "running"
+      ? Loader2
+      : invocation.status === "error"
+      ? XCircle
+      : CheckCircle2;
+
+  return (
+    <div className="@container rounded-lg border text-xs border-border/50 bg-background/70">
+      <div
+        role="button"
+        tabIndex={hasDetails ? 0 : -1}
+        className={cn(
+          "flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-[11px] font-semibold uppercase tracking-wide text-muted-foreground",
+          hasDetails && "cursor-pointer"
+        )}
+        onClick={toggleExpanded}
+        onKeyDown={handleKeyDown}
+        aria-expanded={isExpanded}
+      >
+        <span className="inline-flex items-center gap-2 font-medium normal-case text-foreground min-w-0">
+          <span className="inline-flex items-center gap-2 min-w-0">
+            <img
+              src="/mcp.svg"
+              alt=""
+              role="presentation"
+              aria-hidden="true"
+              className="h-3 w-3 shrink-0"
+            />
+            <span className="font-mono text-xs tracking-tight text-muted-foreground/80 truncate">
+              {invocation.toolName}
+            </span>
+          </span>
+        </span>
+        <span className="inline-flex items-center gap-1.5 text-muted-foreground shrink-0">
+          <StatusIcon
+            className={cn(
+              "h-3.5 w-3.5",
+              invocation.status === "running" && "animate-spin",
+              invocation.status === "error" && "text-destructive",
+              invocation.status === "success" && "text-success"
+            )}
+          />
+          {hasDetails && (
+            <span
+              className="inline-flex items-center gap-0.5 border border-border/40 rounded-md p-0.5 bg-muted/30"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label="Data"
+                    onClick={toggleExpanded}
+                    className={cn(
+                      "inline-flex items-center gap-1 px-1.5 py-1 rounded transition-colors cursor-pointer",
+                      isExpanded
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground/60 hover:text-muted-foreground hover:bg-background/50"
+                    )}
+                  >
+                    <Database className="h-3.5 w-3.5" />
+                    <span className="text-[9px] leading-none hidden @[33rem]:inline">
+                      Data
+                    </span>
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="font-medium">Data</p>
+                </TooltipContent>
+              </Tooltip>
+            </span>
+          )}
+          {hasDetails && (
+            <ChevronDown
+              className={cn(
+                "h-3.5 w-3.5 transition-transform",
+                isExpanded && "rotate-180"
+              )}
+            />
+          )}
+        </span>
+      </div>
+
+      {isExpanded && hasDetails && (
+        <div className="border-t border-border/40 p-3 space-y-4">
+          {hasInput && (
+            <div className="space-y-1">
+              <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">
+                Input
+              </div>
+              <div className="rounded-md border border-border/30 bg-muted/20 max-h-[300px] overflow-auto">
+                <JsonEditor
+                  height="100%"
+                  viewOnly
+                  value={invocation.input}
+                  className="p-2 text-[11px]"
+                  collapsible
+                  defaultExpandDepth={2}
+                />
+              </div>
+            </div>
+          )}
+
+          {hasOutput && (
+            <div className="space-y-1">
+              <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">
+                Result
+              </div>
+              <div className="rounded-md border border-border/30 bg-muted/20 max-h-[300px] overflow-auto">
+                <JsonEditor
+                  height="100%"
+                  viewOnly
+                  value={invocation.output}
+                  className="p-2 text-[11px]"
+                  collapsible
+                  defaultExpandDepth={2}
+                />
+              </div>
+            </div>
+          )}
+
+          {hasError && (
+            <div className="space-y-1">
+              <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/70">
+                Error
+              </div>
+              <div className="rounded border border-destructive/40 bg-destructive/10 p-2 text-destructive">
+                {invocation.errorText}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/transcript-thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/transcript-thread.tsx
@@ -13,6 +13,11 @@ import type { UIMessage } from "@ai-sdk/react";
 import { motion, useReducedMotion } from "framer-motion";
 import { MessageView } from "./message-view";
 import { isHiddenInternalMessage } from "./thread-helpers";
+import type {
+  AppToolInvocation,
+  AppToolInvocationUpdate,
+} from "./app-tool-invocations";
+import { AppToolInvocationPart } from "./parts/app-tool-invocation-part";
 import type { ProjectThreadOwnerAvatar } from "@/components/chat-v2/history/project-thread-owner-avatar";
 import type { ModelDefinition } from "@/shared/types";
 import type { DisplayMode } from "@/stores/ui-playground-store";
@@ -56,6 +61,7 @@ type MessageViewPassthroughProps = Omit<
   | "onExitFullscreen"
   | "onRequestTeardown"
   | "tornDownWidgetIds"
+  | "onAppToolInvocationChange"
   | "senderAvatar"
   | "showSenderAvatar"
 >;
@@ -88,6 +94,8 @@ export interface TranscriptThreadProps extends MessageViewPassthroughProps {
   sendFollowUpMessage?: (text: string) => void;
   toolsMetadata: Record<string, Record<string, any>>;
   toolServerMap: ToolServerMap;
+  appToolInvocations?: AppToolInvocation[];
+  onAppToolInvocationChange?: (invocation: AppToolInvocationUpdate) => void;
   pipWidgetId?: string | null;
   fullscreenWidgetId?: string | null;
   onRequestPip?: (toolCallId: string) => void;
@@ -202,6 +210,17 @@ function scrollMessageToViewportPosition(params: {
   });
 }
 
+function getMessageToolCallIds(message: UIMessage): Set<string> {
+  const ids = new Set<string>();
+  for (const part of message.parts ?? []) {
+    const toolCallId = (part as { toolCallId?: unknown }).toolCallId;
+    if (typeof toolCallId === "string" && toolCallId.length > 0) {
+      ids.add(toolCallId);
+    }
+  }
+  return ids;
+}
+
 export function TranscriptThread({
   chatSessionId,
   messages,
@@ -211,6 +230,8 @@ export function TranscriptThread({
   toolServerMap,
   onWidgetStateChange,
   onModelContextUpdate,
+  appToolInvocations = [],
+  onAppToolInvocationChange,
   pipWidgetId = null,
   fullscreenWidgetId = null,
   onRequestPip = NOOP,
@@ -255,6 +276,18 @@ export function TranscriptThread({
     () => new Set(highlightedMessageIds),
     [highlightedMessageIds]
   );
+  const appToolInvocationsByParentId = useMemo(() => {
+    const grouped = new Map<string, AppToolInvocation[]>();
+    for (const invocation of appToolInvocations) {
+      const existing = grouped.get(invocation.parentToolCallId);
+      if (existing) {
+        existing.push(invocation);
+      } else {
+        grouped.set(invocation.parentToolCallId, [invocation]);
+      }
+    }
+    return grouped;
+  }, [appToolInvocations]);
   const shouldUseContentVisibility =
     focusMessageId === null &&
     highlightedMessageIds.length === 0 &&
@@ -443,6 +476,13 @@ export function TranscriptThread({
               ? "animated"
               : "static"
             : "none";
+        const messageToolCallIds = getMessageToolCallIds(message);
+        const messageAppToolInvocations =
+          messageToolCallIds.size > 0
+            ? Array.from(messageToolCallIds).flatMap(
+                (id) => appToolInvocationsByParentId.get(id) ?? []
+              )
+            : [];
 
         return (
           <div
@@ -502,6 +542,7 @@ export function TranscriptThread({
               toolServerMap={toolServerMap}
               onWidgetStateChange={onWidgetStateChange}
               onModelContextUpdate={onModelContextUpdate}
+              onAppToolInvocationChange={onAppToolInvocationChange}
               pipWidgetId={pipWidgetId}
               fullscreenWidgetId={fullscreenWidgetId}
               onRequestPip={onRequestPip}
@@ -523,6 +564,16 @@ export function TranscriptThread({
               senderAvatar={senderAvatar}
               showSenderAvatar={showSenderAvatarForMessage}
             />
+            {messageAppToolInvocations.length > 0 && (
+              <div className="mt-3 space-y-2">
+                {messageAppToolInvocations.map((invocation) => (
+                  <AppToolInvocationPart
+                    key={invocation.id}
+                    invocation={invocation}
+                  />
+                ))}
+              </div>
+            )}
           </div>
         );
       })}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/widget-replay.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/widget-replay.tsx
@@ -15,6 +15,7 @@ import {
   readToolResultServerId,
 } from "@/lib/tool-result-utils";
 import type { DisplayMode } from "@/stores/ui-playground-store";
+import type { AppToolInvocationUpdate } from "./app-tool-invocations";
 
 export interface WidgetReplayProps {
   chatSessionId?: string;
@@ -34,6 +35,7 @@ export interface WidgetReplayProps {
     toolName: string,
     params: Record<string, unknown>
   ) => Promise<unknown>;
+  onAppToolInvocationChange?: (invocation: AppToolInvocationUpdate) => void;
   onWidgetStateChange?: (toolCallId: string, state: unknown) => void;
   onModelContextUpdate?: (
     toolCallId: string,
@@ -70,6 +72,7 @@ export function WidgetReplay({
   renderOverride,
   onSendFollowUp,
   onCallTool,
+  onAppToolInvocationChange,
   onWidgetStateChange,
   onModelContextUpdate,
   pipWidgetId,
@@ -163,6 +166,7 @@ export function WidgetReplay({
       toolsMetadata={toolsMetadata}
       onSendFollowUp={onSendFollowUp}
       onCallTool={onCallTool}
+      onAppToolInvocationChange={onAppToolInvocationChange}
       onWidgetStateChange={onWidgetStateChange}
       onModelContextUpdate={onModelContextUpdate}
       pipWidgetId={pipWidgetId}

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/BehaviorTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/BehaviorTab.tsx
@@ -139,6 +139,19 @@ export function BehaviorTab({
         />
 
         <FieldRow
+          label="Respect tool visibility"
+          control={
+            <Switch
+              checked={draft.respectToolVisibility}
+              onCheckedChange={(checked) =>
+                update({ respectToolVisibility: checked })
+              }
+              aria-label="Respect tool visibility"
+            />
+          }
+        />
+
+        <FieldRow
           label={
             <span className="inline-flex items-center gap-1.5">
               Progressive tools
@@ -166,10 +179,12 @@ export function BehaviorTab({
               </Tooltip>
             </span>
           }
-          // 3-state, not 2-state: the backend reads `undefined` as
-          // "auto" and may enable progressive discovery above catalog/
-          // context thresholds even with no user opt-in. A Switch would
-          // hide that — "Auto" makes the auto-policy state explicit.
+          /**
+           * 3-state, not 2-state: the backend reads `undefined` as
+           * "auto" and may enable progressive discovery above catalog/
+           * context thresholds even with no user opt-in. A Switch would
+           * hide that, so "Auto" makes the auto-policy state explicit.
+           */
           control={
             <ToggleGroup
               type="single"
@@ -199,6 +214,19 @@ export function BehaviorTab({
                 Off
               </ToggleGroupItem>
             </ToggleGroup>
+          }
+        />
+
+        <FieldRow
+          label="Respect tool visibility"
+          control={
+            <Switch
+              checked={draft.respectToolVisibility}
+              onCheckedChange={(checked) =>
+                update({ respectToolVisibility: checked })
+              }
+              aria-label="Respect tool visibility"
+            />
           }
         />
       </FocusBlock>

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -656,6 +656,7 @@ export function PlaygroundMain({
     // DTO so flipping it in the host's Agent → Behavior tab takes
     // effect on the very next send without remounting the playground.
     progressiveToolDiscovery: previewedHost?.config?.progressiveToolDiscovery,
+    respectToolVisibility: previewedHost?.config?.respectToolVisibility,
     onReset: (reason?: ChatSessionResetReason) => {
       setModelContextQueue([]);
       setPreludeTraceExecutions([]);
@@ -3305,6 +3306,10 @@ export function PlaygroundMain({
                             systemPrompt,
                             temperature,
                             requireToolApproval,
+                            progressiveToolDiscovery:
+                              previewedHost?.config?.progressiveToolDiscovery,
+                            respectToolVisibility:
+                              previewedHost?.config?.respectToolVisibility,
                           }}
                           hostedContext={{
                             projectId: convexProjectId,

--- a/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/multi-model-playground-card.tsx
@@ -308,6 +308,7 @@ export function MultiModelPlaygroundCard({
     // `undefined` pass through to fall back to the orchestrator's auto
     // policy in that case.
     progressiveToolDiscovery: hostCapsResolver?.progressiveToolDiscovery,
+    respectToolVisibility: hostCapsResolver?.respectToolVisibility,
     onReset: () => {
       setModelContextQueue([]);
       setPreludeTraceExecutions([]);

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.minimal-mode.test.tsx
@@ -375,6 +375,45 @@ describe("useChatSession minimal mode parity", () => {
     });
   });
 
+  it("sends host-level respectToolVisibility overrides from uncontrolled callers", async () => {
+    const selectedServers = ["server-1"];
+    const { result, rerender } = renderHook(
+      ({ respectToolVisibility }: { respectToolVisibility: boolean }) =>
+        useChatSession({
+          selectedServers,
+          minimalMode: true,
+          respectToolVisibility,
+        }),
+      { initialProps: { respectToolVisibility: false } },
+    );
+
+    act(() => {
+      result.current.sendMessage({ text: "hello" });
+    });
+
+    await waitFor(() => {
+      expect(getTransportRequests()).toContainEqual(
+        expect.objectContaining({
+          respectToolVisibility: false,
+        }),
+      );
+    });
+
+    rerender({ respectToolVisibility: true });
+
+    act(() => {
+      result.current.sendMessage({ text: "hello again" });
+    });
+
+    await waitFor(() => {
+      expect(getTransportRequests()).toContainEqual(
+        expect.objectContaining({
+          respectToolVisibility: true,
+        }),
+      );
+    });
+  });
+
   it("soft-fails shared metadata auth denial without noisy warning", async () => {
     mockGetToolsMetadata.mockRejectedValue({
       status: 403,

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -237,6 +237,14 @@ export interface UseChatSessionOptions {
    * mid-session toggle flip is reflected on the next send.
    */
   progressiveToolDiscovery?: boolean;
+  /**
+   * Host-level SEP-1865 visibility policy. When false, tools marked
+   * `visibility: ["app"]` are still advertised to the model, matching
+   * clients that do not implement visibility filtering. Sourced from the
+   * caller's resolved host config; held in a ref so client/profile flips
+   * affect the next send without remounting.
+   */
+  respectToolVisibility?: boolean;
   /** Callback when chat is reset */
   onReset?: (reason?: ChatSessionResetReason) => void;
 }
@@ -337,6 +345,7 @@ export interface UseChatSessionReturn {
         systemPrompt?: string;
         temperature?: number;
         requireToolApproval?: boolean;
+        respectToolVisibility?: boolean;
         selectedServers?: string[];
       };
       version: number;
@@ -1096,6 +1105,8 @@ export function useChatSession(
   const initialTemperature = executionConfig?.temperature ?? 0.7;
   const initialRequireToolApproval =
     executionConfig?.requireToolApproval ?? false;
+  const initialRespectToolVisibility =
+    executionConfig?.respectToolVisibility ?? true;
   const {
     getAccessToken,
     user: workOsUser,
@@ -1185,6 +1196,14 @@ export function useChatSession(
   progressiveToolDiscoveryRef.current =
     options.progressiveToolDiscovery ??
     options.executionConfig?.progressiveToolDiscovery;
+  const [respectToolVisibility, setRespectToolVisibility] = useState(
+    initialRespectToolVisibility
+  );
+  const respectToolVisibilityRef = useRef<boolean>(respectToolVisibility);
+  respectToolVisibilityRef.current =
+    options.respectToolVisibility ??
+    options.executionConfig?.respectToolVisibility ??
+    respectToolVisibility;
   const isHostedGuest = HOSTED_MODE && !workOsUser && !isWorkOsLoading;
   const sharedGuestMode =
     isHostedGuest && !isAuthLoading && !!hostedProjectId && !!hostedChatboxId;
@@ -1534,6 +1553,7 @@ export function useChatSession(
                   : {}),
               }),
           requireToolApproval: requireToolApprovalRef.current,
+          respectToolVisibility: respectToolVisibilityRef.current,
           // Only send when the user explicitly set the host-level toggle.
           // Omitting the field tells the backend orchestrator to use its
           // auto policy (currently: off for hosted unless the env override
@@ -2142,6 +2162,7 @@ export function useChatSession(
           systemPrompt?: string;
           temperature?: number;
           requireToolApproval?: boolean;
+          respectToolVisibility?: boolean;
           selectedServers?: string[];
         };
         version: number;
@@ -2211,6 +2232,9 @@ export function useChatSession(
         if (session.resumeConfig?.requireToolApproval !== undefined) {
           setRequireToolApproval(session.resumeConfig.requireToolApproval);
         }
+        if (session.resumeConfig?.respectToolVisibility !== undefined) {
+          setRespectToolVisibility(session.resumeConfig.respectToolVisibility);
+        }
       }
 
       if (options?.shouldApply && !options.shouldApply()) {
@@ -2241,6 +2265,7 @@ export function useChatSession(
   const executionSystemPrompt = executionConfig?.systemPrompt;
   const executionTemperature = executionConfig?.temperature;
   const executionRequireToolApproval = executionConfig?.requireToolApproval;
+  const executionRespectToolVisibility = executionConfig?.respectToolVisibility;
   useEffect(() => {
     if (!isExecutionConfigControlled) return;
     setSystemPrompt(executionSystemPrompt ?? DEFAULT_SYSTEM_PROMPT);
@@ -2255,6 +2280,13 @@ export function useChatSession(
     if (!isExecutionConfigControlled) return;
     setRequireToolApproval(executionRequireToolApproval ?? false);
   }, [isExecutionConfigControlled, executionRequireToolApproval]);
+
+  useEffect(() => {
+    if (!isExecutionConfigControlled) return;
+    // Default to the spec-default `true` when the host config doesn't set
+    // the field (legacy rows). Matches `emptyHostConfigInputV2`.
+    setRespectToolVisibility(executionRespectToolVisibility ?? true);
+  }, [isExecutionConfigControlled, executionRespectToolVisibility]);
 
   // Auth headers setup - reset chat after auth changes to ensure transport has correct headers
   useEffect(() => {

--- a/mcpjam-inspector/client/src/lib/chat-execution-config.ts
+++ b/mcpjam-inspector/client/src/lib/chat-execution-config.ts
@@ -13,4 +13,6 @@ export type ExecutionConfig = {
    * auto policy.
    */
   progressiveToolDiscovery?: boolean;
+  /** See HostConfigInputV2.respectToolVisibility. */
+  respectToolVisibility?: boolean;
 };

--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -295,6 +295,15 @@ export type HostConfigInputV2 = {
   temperature: number;
   requireToolApproval: boolean;
   /**
+   * Host-level switch for SEP-1865 `_meta.ui.visibility` filtering. When
+   * `true`, tools whose visibility doesn't include "model" are hidden
+   * from the agent's tool list (spec-default). When `false`, every tool
+   * flows to the model — faithful to hosts that don't yet honor
+   * visibility (e.g. real Cursor today). Defaults to `true` for new
+   * configs; Cursor's template explicitly sets it to `false`.
+   */
+  respectToolVisibility: boolean;
+  /**
    * Host-level opt-in for progressive MCP tool discovery
    * (`search_mcp_tools` / `load_mcp_tools` meta-tools instead of sending
    * every tool definition every turn). Optional and undefined-by-default:
@@ -366,6 +375,12 @@ export type HostConfigDtoV2 = {
   systemPrompt: string;
   temperature: number;
   requireToolApproval: boolean;
+  /**
+   * See HostConfigInputV2.respectToolVisibility. Optional on the DTO
+   * because pre-feature rows persisted without it; `hostConfigDtoToInput`
+   * coerces `undefined` to the spec default (`true`).
+   */
+  respectToolVisibility?: boolean;
   /** Surfaced verbatim — see HostConfigInputV2.progressiveToolDiscovery. */
   progressiveToolDiscovery?: boolean;
   serverIds: string[];
@@ -406,6 +421,10 @@ export function emptyHostConfigInputV2(
     systemPrompt: partial.systemPrompt ?? "",
     temperature: partial.temperature ?? DEFAULT_TEMPERATURE_V2,
     requireToolApproval: partial.requireToolApproval ?? false,
+    // Default ON: every new config respects SEP-1865 visibility filtering
+    // unless the template (e.g. Cursor) explicitly opts out. Matches the
+    // spec-default behavior.
+    respectToolVisibility: partial.respectToolVisibility ?? true,
     // Brand-new inputs default to explicit Off. The orchestrator still
     // reads `undefined` as "auto policy" (existing rows surfaced by
     // `hostConfigDtoToInput` round-trip verbatim), but creating a fresh
@@ -494,6 +513,9 @@ export function hostConfigDtoToInput(
     systemPrompt: dto.systemPrompt,
     temperature: dto.temperature,
     requireToolApproval: dto.requireToolApproval,
+    // DTO carries `undefined` when the persisted row predates this
+    // feature; treat that as the spec default (filter app-only tools).
+    respectToolVisibility: dto.respectToolVisibility ?? true,
     progressiveToolDiscovery: dto.progressiveToolDiscovery,
     serverIds: [...dto.serverIds],
     optionalServerIds: [...dto.optionalServerIds],
@@ -926,6 +948,7 @@ export function hostConfigInputsEqual(
   if (a.systemPrompt !== b.systemPrompt) return false;
   if (a.temperature !== b.temperature) return false;
   if (a.requireToolApproval !== b.requireToolApproval) return false;
+  if (a.respectToolVisibility !== b.respectToolVisibility) return false;
   // Optional boolean: undefined / true / false are three distinct states
   // (backend hashes them distinctly). A strict !== covers all three since
   // we never coerce undefined to false elsewhere in the input pipeline.

--- a/mcpjam-inspector/client/src/lib/client-templates.ts
+++ b/mcpjam-inspector/client/src/lib/client-templates.ts
@@ -726,6 +726,12 @@ export const HOST_TEMPLATES: readonly HostTemplate[] = [
         modelId: "anthropic/claude-sonnet-4.5",
         temperature: 0.7,
         requireToolApproval: false,
+        // Real Cursor (3.4.20 probe) doesn't yet implement SEP-1865
+        // visibility filtering — app-only tools still flow to the model.
+        // Faithful mirror: MCPJam-as-Cursor leaves visibility off so the
+        // inspector behaves the same way. Every other template inherits
+        // the spec-default `true` via emptyHostConfigInputV2.
+        respectToolVisibility: false,
       });
       const theme = opts?.theme ?? DEFAULT_SEED_THEME;
       // clientCapabilities: matches what real Cursor publishes during MCP

--- a/mcpjam-inspector/server/routes/mcp/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/mcp/chat-v2.ts
@@ -585,6 +585,7 @@ chatV2.post("/", async (c) => {
       selectedServers,
       selectedServerIds: bodySelectedServerIds,
       requireToolApproval: bodyRequireToolApproval,
+      respectToolVisibility: bodyRespectToolVisibility,
       chatboxId: bodyChatboxId,
       accessVersion: bodyAccessVersion,
       surface: bodySurface,
@@ -604,6 +605,7 @@ chatV2.post("/", async (c) => {
     let resolvedSystemPrompt = bodySystemPrompt;
     let resolvedTemperatureOverride = bodyTemperature;
     let resolvedRequireToolApproval = bodyRequireToolApproval;
+    let resolvedRespectToolVisibility = bodyRespectToolVisibility;
     let resolvedModelOverride: typeof model | null = null;
     // See web/chat-v2 for rationale: body is authoritative for direct
     // chat (sourced from the project default), host overrides for
@@ -620,6 +622,19 @@ chatV2.post("/", async (c) => {
         });
         if (runtime.ok) {
           const cfg = runtime.config;
+          if (
+            bodyRequireToolApproval !== undefined &&
+            cfg.requireToolApproval !== bodyRequireToolApproval
+          ) {
+            logger.warn(
+              "[mcp/chat-v2] client requireToolApproval differs from host; using host value",
+              {
+                chatboxId: bodyChatboxId,
+                body: bodyRequireToolApproval,
+                host: cfg.requireToolApproval,
+              }
+            );
+          }
           resolvedSystemPrompt = cfg.systemPrompt;
           resolvedTemperatureOverride = cfg.temperature;
           resolvedRequireToolApproval = cfg.requireToolApproval;
@@ -644,6 +659,22 @@ chatV2.post("/", async (c) => {
               );
             }
             resolvedProgressiveToolDiscovery = cfg.progressiveToolDiscovery;
+          }
+          if (cfg.respectToolVisibility !== undefined) {
+            if (
+              bodyRespectToolVisibility !== undefined &&
+              cfg.respectToolVisibility !== bodyRespectToolVisibility
+            ) {
+              logger.warn(
+                "[mcp/chat-v2] client respectToolVisibility differs from host; using host value",
+                {
+                  chatboxId: bodyChatboxId,
+                  body: bodyRespectToolVisibility,
+                  host: cfg.respectToolVisibility,
+                }
+              );
+            }
+            resolvedRespectToolVisibility = cfg.respectToolVisibility;
           }
           // See web/chat-v2 for rationale: host's modelId wins on
           // chatbox-bound turns. Built-in catalog hit → full
@@ -687,6 +718,7 @@ chatV2.post("/", async (c) => {
     const systemPrompt = resolvedSystemPrompt;
     const temperature = resolvedTemperatureOverride;
     const requireToolApproval = resolvedRequireToolApproval;
+    const respectToolVisibility = resolvedRespectToolVisibility;
 
     // Local-mode `selectedServers` is server *names*, not Convex Ids. The
     // backend's `hostConfigPayloadValidator` requires `v.array(v.id('servers'))`,
@@ -771,6 +803,7 @@ chatV2.post("/", async (c) => {
         systemPrompt,
         temperature,
         requireToolApproval,
+        respectToolVisibility,
         customProviders: body.customProviders,
         priorMessages: priorModelMessages,
         // Body for direct chat (project default), host-re-resolved for
@@ -828,6 +861,7 @@ chatV2.post("/", async (c) => {
           requestedTemperature: temperature,
           resolvedTemperature,
           requireToolApproval,
+          respectToolVisibility,
           selectedServerIds: hostConfigServerIds,
         })
       : undefined;
@@ -914,6 +948,7 @@ chatV2.post("/", async (c) => {
                         systemPrompt,
                         temperature,
                         requireToolApproval,
+                        respectToolVisibility,
                         selectedServers,
                       },
                       ...(directHostConfig
@@ -998,6 +1033,7 @@ chatV2.post("/", async (c) => {
                       systemPrompt,
                       temperature,
                       requireToolApproval,
+                      respectToolVisibility,
                       selectedServers,
                     },
                     ...(directHostConfig
@@ -1137,6 +1173,7 @@ chatV2.post("/", async (c) => {
                       systemPrompt,
                       temperature,
                       requireToolApproval,
+                      respectToolVisibility,
                       selectedServers,
                     },
                     ...(directHostConfig

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -95,6 +95,7 @@ chatV2.post("/", async (c) => {
       systemPrompt: bodySystemPrompt,
       temperature: bodyTemperature,
       requireToolApproval: bodyRequireToolApproval,
+      respectToolVisibility: bodyRespectToolVisibility,
       selectedServerIds,
       selectedServerNames,
       chatboxId,
@@ -130,6 +131,7 @@ chatV2.post("/", async (c) => {
     let resolvedSystemPrompt = bodySystemPrompt;
     let resolvedTemperatureOverride = bodyTemperature;
     let resolvedRequireToolApproval = bodyRequireToolApproval;
+    let resolvedRespectToolVisibility = bodyRespectToolVisibility;
     // Host-level toggle. For non-chatbox direct chat the body is the
     // source (the inspector reads the project's default HostConfigV2 and
     // threads the value through); for chatbox sessions we re-resolve from
@@ -211,6 +213,22 @@ chatV2.post("/", async (c) => {
           }
           resolvedProgressiveToolDiscovery = cfg.progressiveToolDiscovery;
         }
+        if (cfg.respectToolVisibility !== undefined) {
+          if (
+            bodyRespectToolVisibility !== undefined &&
+            cfg.respectToolVisibility !== bodyRespectToolVisibility
+          ) {
+            logger.warn(
+              "[chat-v2] client respectToolVisibility differs from host; using host value",
+              {
+                chatboxId,
+                body: bodyRespectToolVisibility,
+                host: cfg.respectToolVisibility,
+              }
+            );
+          }
+          resolvedRespectToolVisibility = cfg.respectToolVisibility;
+        }
       } else {
         // Don't fail the chat send on a transient Convex blip — fall
         // through to client-supplied values and warn. The chat will run
@@ -230,6 +248,7 @@ chatV2.post("/", async (c) => {
     const systemPrompt = resolvedSystemPrompt;
     const temperature = resolvedTemperatureOverride;
     const requireToolApproval = resolvedRequireToolApproval;
+    const respectToolVisibility = resolvedRespectToolVisibility;
 
     // Membership chat (no share/chatbox token) is the default — the backend
     // authorizes via project ownership for both guest and authed users.
@@ -302,6 +321,7 @@ chatV2.post("/", async (c) => {
           systemPrompt,
           temperature,
           requireToolApproval,
+          respectToolVisibility,
           customProviders: body.customProviders,
           priorMessages: modelMessages,
           // Host-level toggle. Sourced from the project's default
@@ -417,6 +437,7 @@ chatV2.post("/", async (c) => {
                         systemPrompt,
                         temperature,
                         requireToolApproval,
+                        respectToolVisibility,
                         selectedServers:
                           Array.isArray(selectedServerNames) &&
                           selectedServerNames.length ===
@@ -435,6 +456,7 @@ chatV2.post("/", async (c) => {
                         requestedTemperature: temperature,
                         resolvedTemperature,
                         requireToolApproval,
+                        respectToolVisibility,
                         selectedServerIds,
                       }),
                     }
@@ -564,6 +586,7 @@ chatV2.post("/", async (c) => {
                         systemPrompt,
                         temperature,
                         requireToolApproval,
+                        respectToolVisibility,
                         selectedServers:
                           Array.isArray(selectedServerNames) &&
                           selectedServerNames.length ===
@@ -584,6 +607,7 @@ chatV2.post("/", async (c) => {
                         requestedTemperature: temperature,
                         resolvedTemperature,
                         requireToolApproval,
+                        respectToolVisibility,
                         selectedServerIds,
                       }),
                     }

--- a/mcpjam-inspector/server/utils/__tests__/chat-ingestion.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-ingestion.test.ts
@@ -532,6 +532,19 @@ describe("buildDirectHostConfig", () => {
     expect(undef.requireToolApproval).toBe(false);
   });
 
+  it("includes respectToolVisibility in Convex hostConfig payloads", () => {
+    const config = buildDirectHostConfig({
+      modelId: "anthropic/claude-haiku-4.5",
+      systemPrompt: "p",
+      resolvedTemperature: 0.7,
+      selectedServerIds: ["x"],
+      requireToolApproval: false,
+      respectToolVisibility: false,
+    });
+
+    expect(config.respectToolVisibility).toBe(false);
+  });
+
   it("defaults hostStyle to 'claude' when omitted (Phase 3 read switch)", () => {
     // Phase 3: legacy `'direct'` is no longer the default. Callers
     // that used to omit hostStyle now get 'claude' so new direct chat

--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -237,6 +237,40 @@ describe("prepareChatV2", () => {
     ]);
   });
 
+  it("shows app-only tools when respectToolVisibility is false", async () => {
+    // Host opted out of SEP-1865 visibility filtering (e.g. the Cursor
+    // template mirroring real Cursor's behavior). Every tool flows to
+    // the model regardless of `_meta.ui.visibility`.
+    const manager = mockManager({
+      model_tool: { description: "model only", _serverId: "srv" },
+      app_tool: { description: "app only", _serverId: "srv" },
+      both_tool: { description: "default both", _serverId: "srv" },
+    });
+    manager.getAllToolsMetadata = vi.fn((id: string) =>
+      id === "srv"
+        ? {
+            model_tool: { ui: { visibility: ["model"] } },
+            app_tool: { ui: { visibility: ["app"] } },
+            both_tool: { ui: { visibility: ["model", "app"] } },
+          }
+        : {},
+    );
+
+    const result = await prepareChatV2({
+      mcpClientManager: manager,
+      selectedServers: ["srv"],
+      modelDefinition: { id: "gpt-4.1", provider: "openai" } as any,
+      systemPrompt: "Base prompt.",
+      respectToolVisibility: false,
+    });
+
+    expect(Object.keys(result.allTools).sort()).toEqual([
+      "app_tool",
+      "both_tool",
+      "model_tool",
+    ]);
+  });
+
   it("filters selectedServers down to ids the manager has registered", async () => {
     const manager = mockManager({});
     manager.hasServer = vi.fn((id: string) => id === "live-server");

--- a/mcpjam-inspector/server/utils/chat-ingestion.ts
+++ b/mcpjam-inspector/server/utils/chat-ingestion.ts
@@ -38,6 +38,7 @@ interface ResumeConfig {
   systemPrompt?: string;
   temperature?: number;
   requireToolApproval?: boolean;
+  respectToolVisibility?: boolean;
   selectedServers?: string[];
 }
 
@@ -61,6 +62,12 @@ export interface DirectHostConfig {
   modelId: string;
   temperature: number;
   requireToolApproval: boolean;
+  /**
+   * Optional SEP-1865 visibility filter switch. Undefined means "use the
+   * spec default" — the backend's hostConfigV2 canonicalizer drops
+   * `undefined` so pre-feature rows stay byte-identical.
+   */
+  respectToolVisibility?: boolean;
   selectedServerIds: string[];
 }
 
@@ -84,6 +91,7 @@ export function buildDirectHostConfig(input: {
   requestedTemperature?: number;
   resolvedTemperature?: number;
   requireToolApproval?: boolean;
+  respectToolVisibility?: boolean;
   selectedServerIds?: string[];
 }): DirectHostConfig {
   const {
@@ -93,6 +101,7 @@ export function buildDirectHostConfig(input: {
     requestedTemperature,
     resolvedTemperature,
     requireToolApproval,
+    respectToolVisibility,
     selectedServerIds,
   } = input;
   return {
@@ -106,6 +115,9 @@ export function buildDirectHostConfig(input: {
         ? requestedTemperature
         : 0.7,
     requireToolApproval: requireToolApproval === true,
+    // Pass through verbatim so undefined-vs-set semantics survive into
+    // the backend canonicalizer (drops undefined; keeps explicit false).
+    respectToolVisibility,
     selectedServerIds: selectedServerIds ?? [],
   };
 }

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -449,6 +449,13 @@ export interface PrepareChatV2Options {
   systemPrompt?: string;
   temperature?: number;
   requireToolApproval?: boolean;
+  /**
+   * Host-level switch for SEP-1865 `_meta.ui.visibility` filtering.
+   * `undefined` or `true` filters app-only tools out of the model tool
+   * set (spec default). Only an explicit `false` opts out — used by the
+   * Cursor template to mirror hosts that don't yet implement visibility.
+   */
+  respectToolVisibility?: boolean;
   customProviders?: CustomProviderConfig[];
   /** Progressive discovery overrides (e.g. tighter thresholds for tests). */
   progressiveToolDiscovery?: ProgressiveDiscoveryOptions;
@@ -522,6 +529,7 @@ export async function prepareChatV2(
     systemPrompt,
     temperature,
     requireToolApproval,
+    respectToolVisibility,
     customProviders,
     appTools,
   } = options;
@@ -544,7 +552,14 @@ export async function prepareChatV2(
   // bridge but must not appear in the AI SDK tool set. The conversion
   // helper doesn't lift `_meta` onto the AiSdkTool, so we look the
   // metadata back up per (serverId, toolName) from the manager's cache.
-  filterAppOnlyTools(mcpTools, mcpClientManager);
+  //
+  // Gated by the host policy `respectToolVisibility`. `undefined` and
+  // `true` both filter (spec default); only an explicit `false` opts
+  // out — currently the Cursor template, which mirrors real Cursor's
+  // lack of visibility filtering.
+  if (respectToolVisibility !== false) {
+    filterAppOnlyTools(mcpTools, mcpClientManager);
+  }
   const { tools: skillTools, systemPromptSection: skillsPromptSection } =
     HOSTED_MODE
       ? { tools: {}, systemPromptSection: "" }

--- a/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
+++ b/mcpjam-inspector/server/utils/chatbox-runtime-config.ts
@@ -22,6 +22,9 @@ export type ChatboxRuntimeConfig = {
   systemPrompt: string;
   temperature: number;
   requireToolApproval: boolean;
+  // Optional for compatibility with backends that predate SEP-1865
+  // visibility filtering on runtime-config.
+  respectToolVisibility?: boolean;
   hostStyle: string;
   // Host-level opt-in for progressive MCP tool discovery, mirrored from
   // the chatbox's pinned HostConfigV2. Optional so a backend older than

--- a/mcpjam-inspector/shared/chat-v2.ts
+++ b/mcpjam-inspector/shared/chat-v2.ts
@@ -45,6 +45,13 @@ export interface ChatV2Request {
    */
   progressiveToolDiscovery?: boolean;
   /**
+   * SEP-1865 visibility filter switch (see HostConfigInputV2.respectToolVisibility).
+   * Optional — `undefined` means "use the spec default" (filter app-only
+   * tools). The server re-resolves from the persisted host config when
+   * the request is chatbox-bound, so the host value wins.
+   */
+  respectToolVisibility?: boolean;
+  /**
    * Phase 3 read switch: real host style for direct chat traces. When
    * unset, the backend's chatIngestion path defaults to `'claude'` —
    * so existing call sites that don't yet thread this through still


### PR DESCRIPTION
## Summary

Adds a "Respect tool visibility" toggle to the Agent tab (next to "Require tool approval") so users can match how each real host treats SEP-1865 `_meta.ui.visibility`.

- ON (default for every template): `["app"]`-only tools are hidden from the model tool set — the current post-#2249 behavior.
- OFF (Cursor template default): every tool flows to the model regardless of visibility — faithful to real Cursor 3.4.20, which doesn't yet implement visibility filtering.

Backed by a new optional `respectToolVisibility?: boolean` on `HostConfigV2` (see backend PR linked below). End-to-end wiring follows the existing `requireToolApproval` pattern.

## Cross-repo

**Backend**: MCPJam/mcpjam-backend#337 — must merge and deploy first. The Convex canonicalizer is allow-list based; until the validator knows the field name, the inspector's payload is silently stripped.

## Test plan
- [x] `npx vitest run server/utils/__tests__/chat-v2-orchestration.test.ts` — 5/5 pass, including new "shows app-only tools when respectToolVisibility is false" regression
- [x] `npx vitest run client/src/lib/__tests__/client-config-v2.test.ts` — 36/36 pass (hostConfigInputsEqual now compares the new field)
- [x] `npx vitest run server/utils/__tests__/chat-ingestion.test.ts` — 20/20 pass (DirectHostConfig + builder signature changes)
- [ ] **Manual**: Spin up a server with a tool declaring `_meta.ui.visibility: ["app"]`. Create a Cursor-template chatbox → confirm toggle is OFF and the model sees the tool. Toggle ON → tool disappears from the model's list. Create a Claude-template chatbox → confirm toggle is ON by default and tool is hidden.
- [ ] **Manual**: Reload the page after toggling — confirm Convex round-trip persists the user's choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which MCP tools the model sees at runtime and depends on backend PR #337 for persistence; misconfiguration could expose app-only tools to the model or hide them unexpectedly.
> 
> **Overview**
> Adds a per-host **Respect tool visibility** switch (Agent behavior tab) and threads **`respectToolVisibility`** through host config, chat execution, and both **`/api/mcp/chat-v2`** and **`/api/web/chat-v2`** paths—mirroring **`requireToolApproval`**.
> 
> When **ON** (default for new configs and legacy rows without the field), **`prepareChatV2`** keeps filtering **`["app"]`-only** tools out of the model tool set. When **OFF** (Cursor template default), that filter is skipped so all tools reach the model, matching hosts that do not implement SEP-1865 visibility yet.
> 
> The flag is persisted on **`HostConfigV2`**, included in **`resumeConfig`** / direct-chat **`hostConfig`** ingestion, and on chatbox-bound turns the server **re-resolves from Convex** so the stored host value wins over a stale client body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f88a7c054c6b5d19f541350b879135311b5b6a54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->