### PR TITLE
[Payments Tab] PR-I5: Drop redundant Top up button in empty state

### DIFF
--- a/mcpjam-inspector/client/src/components/billing/PaymentsHistorySection.tsx
+++ b/mcpjam-inspector/client/src/components/billing/PaymentsHistorySection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import {
   CheckCircle2,
   Clock,
@@ -7,7 +7,6 @@ import {
 } from "lucide-react";
 import { usePostHog, useFeatureFlagEnabled } from "posthog-js/react";
 import { Badge } from "@mcpjam/design-system/badge";
-import { Button } from "@mcpjam/design-system/button";
 import { Card, CardContent } from "@mcpjam/design-system/card";
 import { Skeleton } from "@mcpjam/design-system/skeleton";
 import {
@@ -18,7 +17,6 @@ import {
   TableHeader,
   TableRow,
 } from "@mcpjam/design-system/table";
-import { CreditTopupDialog } from "@/components/billing/CreditTopupDialog";
 import {
   usePaymentsHistory,
   type PaymentHistoryEntry,
@@ -57,7 +55,6 @@ export function PaymentsHistorySection() {
   const { entries, isLoading } = usePaymentsHistory();
   const posthog = usePostHog();
   const viewedRef = useRef(false);
-  const [isTopupOpen, setIsTopupOpen] = useState(false);
 
   const safeEntries = entries ?? [];
 
@@ -81,36 +78,20 @@ export function PaymentsHistorySection() {
   if (flagEnabled !== true) return null;
 
   return (
-    <>
-      <Card className="border-border/60 py-6 shadow-sm">
-        <CardContent className="flex flex-col gap-4">
-          <div className="flex items-center justify-between">
-            <h2 className="text-lg font-semibold">Payment history</h2>
-          </div>
-          {isLoading ? (
-            <LoadingRows />
-          ) : safeEntries.length === 0 ? (
-            <EmptyState
-              onTopUp={() => {
-                posthog?.capture("credit_topup_cta_clicked", {
-                  source: "history_empty_state",
-                });
-                setIsTopupOpen(true);
-              }}
-            />
-          ) : (
-            <PaymentsTable entries={safeEntries} />
-          )}
-        </CardContent>
-      </Card>
-      <CreditTopupDialog
-        open={isTopupOpen}
-        onOpenChange={setIsTopupOpen}
-        chatSessionId=""
-        lastUserMessage=""
-        source="billing_page"
-      />
-    </>
+    <Card className="border-border/60 py-6 shadow-sm">
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Payment history</h2>
+        </div>
+        {isLoading ? (
+          <LoadingRows />
+        ) : safeEntries.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <PaymentsTable entries={safeEntries} />
+        )}
+      </CardContent>
+    </Card>
   );
 }
 
@@ -251,18 +232,13 @@ function ReceiptCell({ entry }: { entry: PaymentHistoryEntry }) {
   return <span className={muted}>—</span>;
 }
 
-function EmptyState({ onTopUp }: { onTopUp: () => void }) {
+function EmptyState() {
   return (
     <div
-      className="flex flex-col items-center gap-3 rounded-md border border-dashed border-border/60 py-8 text-center"
+      className="flex flex-col items-center rounded-md border border-dashed border-border/60 py-8 text-center"
       data-testid="payments-history-empty"
     >
-      <p className="text-sm text-muted-foreground">
-        No payments yet. Top up to add credits.
-      </p>
-      <Button type="button" onClick={onTopUp}>
-        Top up
-      </Button>
+      <p className="text-sm text-muted-foreground">No payments yet.</p>
     </div>
   );
 }

--- a/mcpjam-inspector/client/src/components/billing/__tests__/PaymentsHistorySection.test.tsx
+++ b/mcpjam-inspector/client/src/components/billing/__tests__/PaymentsHistorySection.test.tsx
@@ -27,13 +27,6 @@ vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({ capture: captureMock }),
 }));
 
-// The empty-state CTA opens CreditTopupDialog; stub it so we don't drag
-// Convex + the topup hook stack into this test.
-vi.mock("@/components/billing/CreditTopupDialog", () => ({
-  CreditTopupDialog: ({ open }: { open: boolean }) =>
-    open ? <div data-testid="stub-topup-dialog" /> : null,
-}));
-
 function makeEntry(
   overrides: Partial<PaymentHistoryEntry> & { id: string },
 ): PaymentHistoryEntry {
@@ -101,7 +94,10 @@ describe("PaymentsHistorySection", () => {
       expect(screen.getByTestId("payments-history-loading")).toBeInTheDocument();
     });
 
-    it("renders the empty state with a Top up CTA when there are no entries", async () => {
+    it("renders the empty state with no CTA when there are no entries", () => {
+      // The empty state intentionally has no Top up button — the
+      // CreditBalanceCard renders one directly above this section, so
+      // duplicating it here would be visual noise.
       hookState = {
         entries: [],
         isLoading: false,
@@ -110,13 +106,7 @@ describe("PaymentsHistorySection", () => {
       render(<PaymentsHistorySection />);
       const empty = screen.getByTestId("payments-history-empty");
       expect(empty).toHaveTextContent(/No payments yet/);
-      const cta = within(empty).getByRole("button", { name: /Top up/ });
-      await userEvent.click(cta);
-      expect(captureMock).toHaveBeenCalledWith("credit_topup_cta_clicked", {
-        source: "history_empty_state",
-      });
-      // CTA opens the stubbed dialog
-      expect(screen.getByTestId("stub-topup-dialog")).toBeInTheDocument();
+      expect(within(empty).queryByRole("button")).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
The payment-history section's empty state had a Top up button that duplicated the one in the credit-balance card right above it — two identical CTAs within ~150px of each other when a user has no payments yet.

Empty state now shows only "No payments yet." copy. The action lives one card above and is always visible when the section renders.

## Before / After

**Before:** Top up button in the credit card (top-right) AND a Top up button in the empty state below. Visual noise + reviewer confusion.

**After:** Only the credit-card Top up button. Empty state is a single line of muted copy in a dashed box.

## Why this is the right call
- Empty-state CTAs work when the empty state is the only visible UI. Here it isn't.
- The existing balance card's Top up button is always visible on this page and is the canonical action.
- Removes a competing call-to-action that would otherwise compete for the same click.

## Changes
| File | Change |
|---|---|
| `PaymentsHistorySection.tsx` | Drop button, dialog state, `useState`, `Button` + `CreditTopupDialog` imports, and the empty-state CTA telemetry fire path. Net: 23 insertions / 57 deletions. |
| `__tests__/PaymentsHistorySection.test.tsx` | Drop the CreditTopupDialog stub mock; replace the "Top up CTA" test with one asserting NO button is present in the empty state. |

## Test plan
- [x] Updated empty-state test asserts the empty container has no button
- [x] Existing tests still pass (flag gating, loading skeleton, populated rows, telemetry)
- [ ] Manual: verify the empty-state box renders cleanly with only "No payments yet." text

🤖 Generated with [Claude Code](https://claude.com/claude-code)