### PR TITLE
[Payments Tab] PR-I6: Top-up return flow on billing tab

### DIFF
--- a/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
+++ b/mcpjam-inspector/client/src/components/__tests__/OrganizationsTab.billing.test.tsx
@@ -254,6 +254,7 @@ vi.mock("convex/react", () => ({
 vi.mock("posthog-js/react", () => ({
   useFeatureFlagEnabled: (...args: unknown[]) =>
     mockUseFeatureFlagEnabled(...args),
+  usePostHog: () => undefined,
 }));
 
 vi.mock("sonner", () => ({

--- a/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
+++ b/mcpjam-inspector/client/src/components/organization/OrganizationBillingSection.tsx
@@ -43,6 +43,7 @@ import { type ComparePlanCell } from "@/components/organization/compare-plan-mar
 import { CreditBalanceCard } from "@/components/billing/CreditBalanceCard";
 import { PaymentsHistorySection } from "@/components/billing/PaymentsHistorySection";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { useCreditTopupReturnFlowBilling } from "@/hooks/useCreditTopupReturnFlow";
 
 const PLAN_ORDER: OrganizationPlan[] = ["free", "team", "enterprise"];
 
@@ -499,6 +500,8 @@ export function OrganizationBillingSection({
   checkoutIntent = null,
   onCheckoutIntentConsumed,
 }: OrganizationBillingSectionProps) {
+  useCreditTopupReturnFlowBilling();
+
   const autoCheckoutStartedForKeyRef = useRef<string | null>(null);
   const [billingInterval, setBillingInterval] =
     useState<BillingInterval>("monthly");

--- a/mcpjam-inspector/client/src/hooks/useCreditTopupReturnFlow.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditTopupReturnFlow.ts
@@ -91,3 +91,46 @@ export function useCreditTopupReturnFlow({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 }
+
+/**
+ * Surface-agnostic variant for non-chat pages (e.g. the org billing tab):
+ * strip the topup query params, emit a PostHog return event, and surface a
+ * confirmation toast. Does NOT touch the pending message stash — that
+ * belongs to the chat surface and a billing-initiated round trip has no
+ * queued message to resend.
+ */
+export function useCreditTopupReturnFlowBilling(): void {
+  const posthog = usePostHog();
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    const topupParam = params.get("topup");
+    if (topupParam !== "success" && topupParam !== "cancelled") return;
+
+    params.delete("topup");
+    params.delete("session_id");
+    const search = params.toString();
+    const cleanedUrl =
+      window.location.pathname + (search ? `?${search}` : "");
+    window.history.replaceState(null, "", cleanedUrl);
+
+    const pending = peekPendingTopup();
+    const hadPendingStash = pending !== null;
+
+    if (topupParam === "cancelled") {
+      posthog?.capture("credit_topup_return_cancelled", {
+        had_pending_stash: hadPendingStash,
+      });
+      return;
+    }
+
+    toast.success("Credits added.");
+    posthog?.capture("credit_topup_return_success", {
+      had_pending_stash: hadPendingStash,
+      chat_session_matched: false,
+      resend_executed: false,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+}

--- a/mcpjam-inspector/client/src/hooks/useCreditTopupReturnFlow.ts
+++ b/mcpjam-inspector/client/src/hooks/useCreditTopupReturnFlow.ts
@@ -115,22 +115,13 @@ export function useCreditTopupReturnFlowBilling(): void {
       window.location.pathname + (search ? `?${search}` : "");
     window.history.replaceState(null, "", cleanedUrl);
 
-    const pending = peekPendingTopup();
-    const hadPendingStash = pending !== null;
-
     if (topupParam === "cancelled") {
-      posthog?.capture("credit_topup_return_cancelled", {
-        had_pending_stash: hadPendingStash,
-      });
+      posthog?.capture("credit_topup_return_cancelled");
       return;
     }
 
     toast.success("Credits added.");
-    posthog?.capture("credit_topup_return_success", {
-      had_pending_stash: hadPendingStash,
-      chat_session_matched: false,
-      resend_executed: false,
-    });
+    posthog?.capture("credit_topup_return_success");
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 }


### PR DESCRIPTION
## Summary

Top-ups initiated from the billing tab returned to `/billing/credits?topup=success&session_id=…` with no confirmation. This PR adds a return-flow handler for the billing tab — strips the query params and shows a success toast.

## Changes

- New `useCreditTopupReturnFlowBilling` hook in `useCreditTopupReturnFlow.ts`.
- Wired into `OrganizationBillingSection`.

## Verification

- `npm run typecheck:client` clean.
- Manual: hit `/billing/credits?topup=success` and `?topup=cancelled` in dev; confirm URL cleans and toast appears on success only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)