### PR TITLE
Evals playground information architecture

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -2816,8 +2816,13 @@ export default function App() {
         }
       : undefined;
 
+  const shouldShowGlobalHostBar = activeTab !== "evals";
+
   const globalHostBarProps =
-    hostsHubFlagEnabled && isAuthenticated && convexProjectId
+    shouldShowGlobalHostBar &&
+    hostsHubFlagEnabled &&
+    isAuthenticated &&
+    convexProjectId
       ? {
           projectId: convexProjectId,
           onEditHost: (hostId: string) => {

--- a/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
+++ b/mcpjam-inspector/client/src/__tests__/App.hosted-oauth.test.tsx
@@ -2571,6 +2571,80 @@ describe("App hosted OAuth callback handling", () => {
     expect(screen.queryByTestId("ci-evals-tab")).not.toBeInTheDocument();
   });
 
+  it("hides the global client bar on the Playground evals tab", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    window.history.replaceState({}, "", "/evals");
+    mockHandleOAuthCallback.mockReset();
+    mockUseAppState.mockImplementation(() => ({
+      ...createAppStateMock(),
+      isCloudSyncActive: true,
+      projects: {
+        ws_local: {
+          id: "ws_local",
+          name: "Project One",
+          sharedProjectId: "shared-ws-1",
+          organizationId: "org-1",
+          servers: {},
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      },
+    }));
+    mockUseFeatureFlagEnabled.mockImplementation(
+      (flag: string) =>
+        flag === "hosts-enabled" || flag === "playground-enabled"
+    );
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("evals-tab")).toBeInTheDocument();
+    });
+
+    const latestProps = mockHeader.mock.calls.at(-1)?.[0] as {
+      globalHostBarProps?: { projectId?: string };
+    };
+    expect(latestProps.globalHostBarProps).toBeUndefined();
+  });
+
+  it("shows the global client bar outside the Playground evals tab", async () => {
+    clearHostedOAuthPendingState();
+    clearChatboxSession();
+    window.history.replaceState({}, "", "/tools");
+    mockHandleOAuthCallback.mockReset();
+    mockUseAppState.mockImplementation(() => ({
+      ...createAppStateMock(),
+      isCloudSyncActive: true,
+      projects: {
+        ws_local: {
+          id: "ws_local",
+          name: "Project One",
+          sharedProjectId: "shared-ws-1",
+          organizationId: "org-1",
+          servers: {},
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      },
+    }));
+    mockUseFeatureFlagEnabled.mockImplementation(
+      (flag: string) => flag === "hosts-enabled"
+    );
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockHeader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          globalHostBarProps: expect.objectContaining({
+            projectId: "shared-ws-1",
+          }),
+        })
+      );
+    });
+  });
+
   it("waits on ci-evals while the evaluate-runs flag is still loading", async () => {
     clearHostedOAuthPendingState();
     clearChatboxSession();

--- a/mcpjam-inspector/client/src/components/evals/__tests__/create-suite-navigation.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/create-suite-navigation.test.ts
@@ -57,6 +57,15 @@ describe("createPlaygroundSuiteNavigation", () => {
     });
   });
 
+  it("toSuiteOverview can navigate to the user-facing Runs section", () => {
+    const nav = createPlaygroundSuiteNavigation();
+    nav.toSuiteOverview("suite-1", "executions");
+    expect(navigateSpy).toHaveBeenCalledWith(
+      "/evals/suite/suite-1?view=executions",
+      { replace: undefined },
+    );
+  });
+
   it("toTestEdit emits compare links for results routes", () => {
     const nav = createPlaygroundSuiteNavigation();
     nav.toTestEdit("suite-1", "case-1", {

--- a/mcpjam-inspector/client/src/components/evals/__tests__/eval-ia-surfaces.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/eval-ia-surfaces.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  EVAL_IA_SURFACE_SEQUENCE,
+  getEvalIaSurfaceReference,
+} from "../eval-ia-surfaces";
+
+describe("eval IA surface sequence", () => {
+  it("keeps the canonical surfaces in dependency order", () => {
+    expect(EVAL_IA_SURFACE_SEQUENCE.map((surface) => surface.id)).toEqual([
+      "S1",
+      "S2",
+      "S3",
+      "S4",
+      "S5",
+      "S6",
+    ]);
+    expect(getEvalIaSurfaceReference("S1").primary).toBe("S1_Primary");
+    expect(getEvalIaSurfaceReference("S5").dependsOn).toEqual(["S3"]);
+    expect(getEvalIaSurfaceReference("S6").dependsOn).toEqual([
+      "S2",
+      "S3",
+      "S4",
+    ]);
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-dashboard-data.test.ts
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-dashboard-data.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { buildSuiteDashboardMatrixFoundation } from "../suite-dashboard-data";
+import type { EvalCase, EvalIteration, EvalSuiteRun } from "../types";
+
+const baseRun: EvalSuiteRun = {
+  _id: "run-latest",
+  suiteId: "suite-1",
+  createdBy: "user-1",
+  runNumber: 2,
+  configRevision: "1",
+  configSnapshot: { tests: [], environment: { servers: [] } },
+  status: "completed",
+  createdAt: 10,
+  completedAt: 20,
+};
+
+const olderRun: EvalSuiteRun = {
+  ...baseRun,
+  _id: "run-old",
+  runNumber: 1,
+  createdAt: 1,
+  completedAt: 5,
+};
+
+const testCase: EvalCase = {
+  _id: "case-1",
+  testSuiteId: "suite-1",
+  createdBy: "user-1",
+  title: "Create a diagram",
+  query: "Create a diagram",
+  models: [{ provider: "anthropic", model: "claude-haiku-4-5" }],
+  runs: 10,
+  expectedToolCalls: [],
+};
+
+const iteration: EvalIteration = {
+  _id: "iter-1",
+  testCaseId: "case-1",
+  suiteRunId: "run-latest",
+  createdBy: "user-1",
+  createdAt: 11,
+  startedAt: 12,
+  updatedAt: 15,
+  iterationNumber: 1,
+  status: "completed",
+  result: "failed",
+  actualToolCalls: [{ toolName: "search_shapes", arguments: {} }],
+  tokensUsed: 120,
+  metadata: { missingCount: 1 },
+  testCaseSnapshot: {
+    title: "Create a diagram",
+    query: "Create a diagram",
+    provider: "openai",
+    model: "gpt-4o-mini",
+    expectedToolCalls: [{ toolName: "create_diagram", arguments: {} }],
+  },
+};
+
+describe("buildSuiteDashboardMatrixFoundation", () => {
+  it("identifies the latest completed run and dashboard matrix axes", () => {
+    const foundation = buildSuiteDashboardMatrixFoundation({
+      cases: [testCase],
+      allIterations: [iteration],
+      runs: [olderRun, baseRun],
+    });
+
+    expect(foundation.latestCompletedRun?._id).toBe("run-latest");
+    expect(foundation.latestRunIterations.map((item) => item._id)).toEqual([
+      "iter-1",
+    ]);
+    expect(foundation.caseIds).toEqual(["case-1"]);
+    expect(foundation.modelKeys).toEqual([
+      "anthropic/claude-haiku-4-5",
+      "openai/gpt-4o-mini",
+    ]);
+    expect(foundation.availableMetrics).toEqual([
+      "pass-rate",
+      "latency",
+      "tokens",
+      "validators",
+    ]);
+  });
+
+  it("falls back to all iterations when no completed run exists", () => {
+    const foundation = buildSuiteDashboardMatrixFoundation({
+      cases: [],
+      allIterations: [iteration],
+      runs: [{ ...baseRun, status: "running", completedAt: undefined }],
+    });
+
+    expect(foundation.latestCompletedRun).toBeNull();
+    expect(foundation.latestRunIterations).toEqual([]);
+    expect(foundation.caseIds).toEqual(["case-1"]);
+    expect(foundation.availableMetrics).toContain("pass-rate");
+  });
+});

--- a/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-master-detail.test.tsx
+++ b/mcpjam-inspector/client/src/components/evals/__tests__/suite-iterations-master-detail.test.tsx
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   useQuery: vi.fn(),
   suiteHeader: vi.fn(),
   runOverview: vi.fn(),
+  suiteDashboard: vi.fn(),
 }));
 
 vi.mock("convex/react", () => ({
@@ -49,6 +50,13 @@ vi.mock("../run-overview", () => ({
   RunOverview: (props: unknown) => {
     mocks.runOverview(props);
     return <div data-testid="run-overview" />;
+  },
+}));
+
+vi.mock("../suite-dashboard", () => ({
+  SuiteDashboard: (props: unknown) => {
+    mocks.suiteDashboard(props);
+    return <div data-testid="suite-dashboard" />;
   },
 }));
 
@@ -113,6 +121,92 @@ describe("SuiteIterationsView caseListInSidebar", () => {
       }
       return undefined;
     });
+  });
+
+  it("treats the default playground suite route as Dashboard", () => {
+    render(
+      <SuiteIterationsView
+        suite={baseSuite}
+        cases={[]}
+        iterations={[]}
+        allIterations={[]}
+        runs={[]}
+        runsLoading={false}
+        aggregate={null}
+        onRerun={vi.fn()}
+        onCancelRun={vi.fn()}
+        onDelete={vi.fn()}
+        onDeleteRun={vi.fn()}
+        onDirectDeleteRun={vi.fn().mockResolvedValue(undefined)}
+        connectedServerNames={new Set()}
+        canDeleteSuite={false}
+        rerunningSuiteId={null}
+        cancellingRunId={null}
+        deletingSuiteId={null}
+        deletingRunId={null}
+        availableModels={[]}
+        route={{
+          type: "suite-overview",
+          suiteId: "suite-1",
+          view: "runs",
+        }}
+        navigation={noopNav}
+        hideRunActions
+      />,
+    );
+
+    expect(screen.getByRole("tab", { name: "Dashboard" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    expect(screen.getByTestId("suite-dashboard")).toBeInTheDocument();
+    expect(screen.queryByTestId("run-overview")).toBeNull();
+  });
+
+  it("maps the Runs workspace tab to the executions route", async () => {
+    const user = userEvent.setup();
+    const navigation = {
+      ...noopNav,
+      toSuiteOverview: vi.fn(),
+    };
+
+    render(
+      <SuiteIterationsView
+        suite={baseSuite}
+        cases={[]}
+        iterations={[]}
+        allIterations={[]}
+        runs={[]}
+        runsLoading={false}
+        aggregate={null}
+        onRerun={vi.fn()}
+        onCancelRun={vi.fn()}
+        onDelete={vi.fn()}
+        onDeleteRun={vi.fn()}
+        onDirectDeleteRun={vi.fn().mockResolvedValue(undefined)}
+        connectedServerNames={new Set()}
+        canDeleteSuite={false}
+        rerunningSuiteId={null}
+        cancellingRunId={null}
+        deletingSuiteId={null}
+        deletingRunId={null}
+        availableModels={[]}
+        route={{
+          type: "suite-overview",
+          suiteId: "suite-1",
+          view: "runs",
+        }}
+        navigation={navigation}
+        hideRunActions
+      />,
+    );
+
+    await user.click(screen.getByRole("tab", { name: "Runs" }));
+
+    expect(navigation.toSuiteOverview).toHaveBeenCalledWith(
+      "suite-1",
+      "executions",
+    );
   });
 
   it("does not mount TestCasesOverview when case index is in the parent sidebar", () => {

--- a/mcpjam-inspector/client/src/components/evals/eval-ia-surfaces.ts
+++ b/mcpjam-inspector/client/src/components/evals/eval-ia-surfaces.ts
@@ -1,0 +1,60 @@
+export type EvalIaSurfaceId = "S1" | "S2" | "S3" | "S4" | "S5" | "S6";
+
+export interface EvalIaSurfaceReference {
+  id: EvalIaSurfaceId;
+  title: string;
+  primary: string;
+  alt?: string;
+  dependsOn: EvalIaSurfaceId[];
+}
+
+export const EVAL_IA_SURFACE_SEQUENCE = [
+  {
+    id: "S1",
+    title: "Suite Dashboard / Cases",
+    primary: "S1_Primary",
+    alt: "S1_Alt",
+    dependsOn: [],
+  },
+  {
+    id: "S2",
+    title: "Live Run",
+    primary: "S2_Primary",
+    alt: "S2_Alt",
+    dependsOn: ["S1"],
+  },
+  {
+    id: "S3",
+    title: "Completed Run Detail",
+    primary: "S3_Primary",
+    alt: "S3_Alt",
+    dependsOn: ["S1"],
+  },
+  {
+    id: "S4",
+    title: "Case Editor / Runner",
+    primary: "S4_Primary",
+    alt: "S4_Alt",
+    dependsOn: ["S1"],
+  },
+  {
+    id: "S5",
+    title: "Run Compare",
+    primary: "S5_Primary",
+    alt: "S5_Alt",
+    dependsOn: ["S3"],
+  },
+  {
+    id: "S6",
+    title: "Iteration Navigation",
+    primary: "S6_Anatomy",
+    alt: "S6_RouteMap",
+    dependsOn: ["S2", "S3", "S4"],
+  },
+] as const satisfies ReadonlyArray<EvalIaSurfaceReference>;
+
+export function getEvalIaSurfaceReference(
+  id: EvalIaSurfaceId,
+): EvalIaSurfaceReference {
+  return EVAL_IA_SURFACE_SEQUENCE.find((surface) => surface.id === id)!;
+}

--- a/mcpjam-inspector/client/src/components/evals/suite-dashboard-data.ts
+++ b/mcpjam-inspector/client/src/components/evals/suite-dashboard-data.ts
@@ -1,0 +1,142 @@
+import type { EvalCase, EvalIteration, EvalSuiteRun } from "./types";
+
+export type SuiteDashboardMatrixMetric =
+  | "pass-rate"
+  | "latency"
+  | "tokens"
+  | "validators";
+
+export const SUITE_DASHBOARD_MATRIX_METRICS = [
+  "pass-rate",
+  "latency",
+  "tokens",
+  "validators",
+] as const satisfies ReadonlyArray<SuiteDashboardMatrixMetric>;
+
+export interface SuiteDashboardMatrixFoundation {
+  latestCompletedRun: EvalSuiteRun | null;
+  latestRunIterations: EvalIteration[];
+  caseIds: string[];
+  modelKeys: string[];
+  availableMetrics: SuiteDashboardMatrixMetric[];
+}
+
+export function buildSuiteDashboardMatrixFoundation({
+  cases,
+  allIterations,
+  runs,
+}: {
+  cases: EvalCase[];
+  allIterations: EvalIteration[];
+  runs: EvalSuiteRun[];
+}): SuiteDashboardMatrixFoundation {
+  const latestCompletedRun = getLatestCompletedRun(runs);
+  const latestRunIterations = latestCompletedRun
+    ? allIterations.filter((iteration) => iteration.suiteRunId === latestCompletedRun._id)
+    : [];
+  const sourceIterations =
+    latestRunIterations.length > 0 ? latestRunIterations : allIterations;
+
+  const availableMetrics: SuiteDashboardMatrixMetric[] = [];
+  if (sourceIterations.length > 0) {
+    availableMetrics.push("pass-rate");
+  }
+  if (sourceIterations.some(hasDurationMs)) {
+    availableMetrics.push("latency");
+  }
+  if (sourceIterations.some((iteration) => (iteration.tokensUsed ?? 0) > 0)) {
+    availableMetrics.push("tokens");
+  }
+  if (sourceIterations.some(hasValidatorSignal)) {
+    availableMetrics.push("validators");
+  }
+
+  return {
+    latestCompletedRun,
+    latestRunIterations,
+    caseIds: collectCaseIds(cases, sourceIterations),
+    modelKeys: collectModelKeys(cases, sourceIterations),
+    availableMetrics,
+  };
+}
+
+function getLatestCompletedRun(runs: EvalSuiteRun[]): EvalSuiteRun | null {
+  const completedRuns = runs.filter((run) => run.status === "completed");
+  if (completedRuns.length === 0) {
+    return null;
+  }
+
+  return completedRuns.sort((a, b) => {
+    const aTime = a.completedAt ?? a.createdAt ?? 0;
+    const bTime = b.completedAt ?? b.createdAt ?? 0;
+    return bTime - aTime;
+  })[0];
+}
+
+function collectCaseIds(
+  cases: EvalCase[],
+  iterations: EvalIteration[],
+): string[] {
+  const ids = new Set<string>();
+  for (const testCase of cases) {
+    ids.add(testCase._id);
+  }
+  for (const iteration of iterations) {
+    if (iteration.testCaseId) {
+      ids.add(iteration.testCaseId);
+    }
+  }
+  return [...ids];
+}
+
+function collectModelKeys(
+  cases: EvalCase[],
+  iterations: EvalIteration[],
+): string[] {
+  const keys = new Set<string>();
+  for (const testCase of cases) {
+    for (const model of testCase.models ?? []) {
+      keys.add(`${model.provider}/${model.model}`);
+    }
+  }
+  for (const iteration of iterations) {
+    const snapshot = iteration.testCaseSnapshot;
+    if (snapshot?.provider && snapshot.model) {
+      keys.add(`${snapshot.provider}/${snapshot.model}`);
+    }
+  }
+  return [...keys];
+}
+
+function hasDurationMs(iteration: EvalIteration): boolean {
+  if (typeof iteration.startedAt !== "number") {
+    return false;
+  }
+  const finishedAt = iteration.updatedAt ?? iteration.startedAt;
+  return finishedAt > iteration.startedAt;
+}
+
+function hasValidatorSignal(iteration: EvalIteration): boolean {
+  const metadata = iteration.metadata;
+  if (metadata) {
+    for (const key of [
+      "missingCount",
+      "unexpectedCount",
+      "argumentMismatchCount",
+      "mismatchCount",
+    ]) {
+      const value = metadata[key];
+      if (typeof value === "number" && value > 0) {
+        return true;
+      }
+      if (typeof value === "string" && Number(value) > 0) {
+        return true;
+      }
+    }
+  }
+
+  return (
+    (iteration.testCaseSnapshot?.expectedToolCalls.length ?? 0) > 0 ||
+    iteration.actualToolCalls.length > 0
+  );
+}

--- a/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-iterations-view.tsx
@@ -22,6 +22,7 @@ import { SuiteDashboard } from "./suite-dashboard";
 import { EvalExportModal } from "./eval-export-modal";
 import { SuiteExecutionConfigEditor } from "./suite-execution-config-editor";
 import { useSuiteData, useRunDetailData } from "./use-suite-data";
+import { SuiteWorkspaceNav } from "./suite-workspace-nav";
 import type {
   EvalCase,
   EvalIteration,
@@ -29,7 +30,12 @@ import type {
   EvalSuiteRun,
   SuiteAggregate,
 } from "./types";
-import type { EvalRoute } from "@/lib/eval-route-types";
+import type { EvalRoute, SuiteOverviewView } from "@/lib/eval-route-types";
+import {
+  getSuiteWorkspaceSection,
+  workspaceSectionToSuiteOverviewView,
+  type SuiteWorkspaceSection,
+} from "@/lib/eval-suite-ia";
 import { getBillingErrorMessage } from "@/lib/billing-entitlements";
 import { useSharedAppState } from "@/state/app-state-context";
 import { isMCPJamProvidedModel } from "@/shared/types";
@@ -51,7 +57,7 @@ import {
 } from "@/lib/evals/eval-export";
 
 export interface SuiteNavigation {
-  toSuiteOverview: (suiteId: string, view?: "runs" | "test-cases") => void;
+  toSuiteOverview: (suiteId: string, view?: SuiteOverviewView) => void;
   toRunDetail: (
     suiteId: string,
     runId: string,
@@ -211,6 +217,23 @@ export function SuiteIterationsView({
     route.type === "suite-overview" && route.view === "test-cases"
       ? "test-cases"
       : "runs";
+  const suiteWorkspaceSection =
+    getSuiteWorkspaceSection(route) ?? "dashboard";
+  const isPlaygroundSuiteWorkspace = hideRunActions && !caseListInSidebar;
+  const showSuiteWorkspaceNav =
+    isPlaygroundSuiteWorkspace &&
+    (viewMode === "overview" || suiteWorkspaceSection === "settings");
+  const showPlaygroundDashboard =
+    isPlaygroundSuiteWorkspace &&
+    viewMode === "overview" &&
+    suiteWorkspaceSection === "dashboard";
+  const showPlaygroundRuns =
+    isPlaygroundSuiteWorkspace &&
+    viewMode === "overview" &&
+    suiteWorkspaceSection === "runs";
+  const showSuiteHeaderCaseActions =
+    isPlaygroundSuiteWorkspace &&
+    (suiteWorkspaceSection === "dashboard" || suiteWorkspaceSection === "cases");
 
   // Local state that's not in the URL
   const [runDetailSortBy, setRunDetailSortBy] = useState<
@@ -445,6 +468,20 @@ export function SuiteIterationsView({
     navigation.toSuiteOverview(suite._id);
   };
 
+  const handleSuiteWorkspaceSectionChange = (
+    section: SuiteWorkspaceSection,
+  ) => {
+    if (section === "settings") {
+      navigation.toSuiteEdit(suite._id);
+      return;
+    }
+
+    navigation.toSuiteOverview(
+      suite._id,
+      workspaceSectionToSuiteOverviewView(section),
+    );
+  };
+
   const handleOpenSuiteExport = useCallback(() => {
     setExportState({
       scope: "suite",
@@ -543,7 +580,7 @@ export function SuiteIterationsView({
             onOpenExportSuite={handleOpenSuiteExport}
             readOnlyConfig={readOnlyConfig}
             hideRunActions={hideRunActions}
-            unifiedSuiteDashboard={hideRunActions && !caseListInSidebar}
+            unifiedSuiteDashboard={showSuiteHeaderCaseActions}
             casesSidebarHidden={casesSidebarHidden}
             onShowCasesSidebar={onShowCasesSidebar}
             onCreateTestCase={onCreateTestCase}
@@ -574,6 +611,12 @@ export function SuiteIterationsView({
             }
           />
         </div>
+      ) : null}
+      {showSuiteWorkspaceNav ? (
+        <SuiteWorkspaceNav
+          activeSection={suiteWorkspaceSection}
+          onSectionChange={handleSuiteWorkspaceSectionChange}
+        />
       ) : null}
 
       {/* Content */}
@@ -670,7 +713,7 @@ export function SuiteIterationsView({
                 );
               })()
             ) : viewMode === "overview" ? (
-              hideRunActions && !caseListInSidebar ? (
+              showPlaygroundDashboard ? (
                 <motion.div
                   key={contentKey}
                   initial={shouldReduceMotion ? false : { opacity: 0 }}
@@ -710,7 +753,7 @@ export function SuiteIterationsView({
                     userMap={userMap}
                   />
                 </motion.div>
-              ) : runsViewMode === "runs" ? (
+              ) : showPlaygroundRuns || runsViewMode === "runs" ? (
                 <motion.div
                   key={contentKey}
                   initial={shouldReduceMotion ? false : { opacity: 0 }}

--- a/mcpjam-inspector/client/src/components/evals/suite-workspace-nav.tsx
+++ b/mcpjam-inspector/client/src/components/evals/suite-workspace-nav.tsx
@@ -1,0 +1,45 @@
+import {
+  SUITE_WORKSPACE_SECTIONS,
+  type SuiteWorkspaceSection,
+} from "@/lib/eval-suite-ia";
+import { cn } from "@/lib/utils";
+
+interface SuiteWorkspaceNavProps {
+  activeSection: SuiteWorkspaceSection;
+  onSectionChange: (section: SuiteWorkspaceSection) => void;
+}
+
+export function SuiteWorkspaceNav({
+  activeSection,
+  onSectionChange,
+}: SuiteWorkspaceNavProps) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Suite workspace sections"
+      className="mb-4 flex shrink-0 items-center gap-1 border-b border-border/60"
+    >
+      {SUITE_WORKSPACE_SECTIONS.map((section) => {
+        const active = section.id === activeSection;
+        return (
+          <button
+            key={section.id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onSectionChange(section.id)}
+            className={cn(
+              "-mb-px border-b-2 border-transparent px-3 pb-2 pt-1 text-sm font-medium transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2",
+              active
+                ? "border-primary text-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {section.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/mcpjam-inspector/client/src/lib/__tests__/eval-route-url.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/eval-route-url.test.ts
@@ -40,6 +40,13 @@ describe("eval-route-url", () => {
       view: "test-cases",
       fromCommit: "abc123",
     });
+    expect(
+      parseEvalRouteFromUrl("/evals", "/evals/suite/s_123", "?view=executions"),
+    ).toEqual({
+      type: "suite-overview",
+      suiteId: "s_123",
+      view: "executions",
+    });
   });
 
   it("builds eval suite overview routes", () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/eval-suite-ia.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/eval-suite-ia.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSuiteWorkspaceSection,
+  suiteOverviewViewToWorkspaceSection,
+  SUITE_DASHBOARD_ROUTE_VIEW,
+  workspaceSectionToSuiteOverviewView,
+} from "../eval-suite-ia";
+
+describe("eval-suite-ia", () => {
+  it("keeps the default suite route mapped to Dashboard", () => {
+    expect(SUITE_DASHBOARD_ROUTE_VIEW).toBe("runs");
+    expect(suiteOverviewViewToWorkspaceSection()).toBe("dashboard");
+    expect(suiteOverviewViewToWorkspaceSection("runs")).toBe("dashboard");
+    expect(workspaceSectionToSuiteOverviewView("dashboard")).toBe("runs");
+  });
+
+  it("maps IA labels onto the existing route views", () => {
+    expect(suiteOverviewViewToWorkspaceSection("test-cases")).toBe("cases");
+    expect(suiteOverviewViewToWorkspaceSection("executions")).toBe("runs");
+    expect(workspaceSectionToSuiteOverviewView("cases")).toBe("test-cases");
+    expect(workspaceSectionToSuiteOverviewView("runs")).toBe("executions");
+  });
+
+  it("derives the active workspace section from drill-down routes", () => {
+    expect(
+      getSuiteWorkspaceSection({
+        type: "run-detail",
+        suiteId: "suite-1",
+        runId: "run-1",
+      }),
+    ).toBe("runs");
+    expect(
+      getSuiteWorkspaceSection({
+        type: "test-edit",
+        suiteId: "suite-1",
+        testId: "case-1",
+      }),
+    ).toBe("cases");
+    expect(
+      getSuiteWorkspaceSection({ type: "suite-edit", suiteId: "suite-1" }),
+    ).toBe("settings");
+  });
+});

--- a/mcpjam-inspector/client/src/lib/app-navigation.ts
+++ b/mcpjam-inspector/client/src/lib/app-navigation.ts
@@ -14,6 +14,7 @@ import {
 } from "react-router";
 import { getAppRouter } from "../router-ref";
 import type { EvalRoute } from "./eval-route-types";
+import { SUITE_DASHBOARD_ROUTE_VIEW } from "./eval-suite-ia";
 import {
   HOSTED_HASH_ALLOWED_TABS,
   HOSTED_HASH_BLOCKED_TABS,
@@ -92,7 +93,9 @@ function buildEvalRoutePath(prefix: "/evals" | "/ci-evals", route: EvalRoute): s
       return `${prefix}/create`;
     case "suite-overview": {
       const params = new URLSearchParams();
-      if (route.view && route.view !== "runs") params.set("view", route.view);
+      if (route.view && route.view !== SUITE_DASHBOARD_ROUTE_VIEW) {
+        params.set("view", route.view);
+      }
       if (route.fromCommit) params.set("fromCommit", route.fromCommit);
       const query = params.toString();
       return `${prefix}/suite/${encodeURIComponent(route.suiteId)}${query ? `?${query}` : ""}`;

--- a/mcpjam-inspector/client/src/lib/eval-route-url.ts
+++ b/mcpjam-inspector/client/src/lib/eval-route-url.ts
@@ -1,6 +1,7 @@
 import { useContext, useMemo } from "react";
 import { UNSAFE_LocationContext } from "react-router";
 import type { EvalRoute, SuiteOverviewView } from "./eval-route-types";
+import { SUITE_DASHBOARD_ROUTE_VIEW } from "./eval-suite-ia";
 
 export type EvalRoutePrefix = "/evals" | "/ci-evals";
 
@@ -129,7 +130,9 @@ export function useCiEvalsRouteFromUrl(): EvalRoute {
 }
 
 function parseSuiteOverviewView(value: string | null): SuiteOverviewView {
-  return value === "test-cases" || value === "executions" ? value : "runs";
+  return value === "test-cases" || value === "executions"
+    ? value
+    : SUITE_DASHBOARD_ROUTE_VIEW;
 }
 
 function parseTruthyParam(value: string | null): boolean {

--- a/mcpjam-inspector/client/src/lib/eval-suite-ia.ts
+++ b/mcpjam-inspector/client/src/lib/eval-suite-ia.ts
@@ -1,0 +1,65 @@
+import type { EvalRoute, SuiteOverviewView } from "./eval-route-types";
+
+export type SuiteWorkspaceSection = "dashboard" | "cases" | "runs" | "settings";
+
+export const SUITE_DASHBOARD_ROUTE_VIEW = "runs" satisfies SuiteOverviewView;
+
+export const SUITE_WORKSPACE_SECTIONS = [
+  { id: "dashboard", label: "Dashboard" },
+  { id: "cases", label: "Cases" },
+  { id: "runs", label: "Runs" },
+  { id: "settings", label: "Settings" },
+] as const satisfies ReadonlyArray<{
+  id: SuiteWorkspaceSection;
+  label: string;
+}>;
+
+export function suiteOverviewViewToWorkspaceSection(
+  view?: SuiteOverviewView,
+): Exclude<SuiteWorkspaceSection, "settings"> {
+  switch (view ?? SUITE_DASHBOARD_ROUTE_VIEW) {
+    case "test-cases":
+      return "cases";
+    case "executions":
+      return "runs";
+    case "runs":
+    default:
+      return "dashboard";
+  }
+}
+
+export function workspaceSectionToSuiteOverviewView(
+  section: Exclude<SuiteWorkspaceSection, "settings">,
+): SuiteOverviewView {
+  switch (section) {
+    case "cases":
+      return "test-cases";
+    case "runs":
+      return "executions";
+    case "dashboard":
+    default:
+      return SUITE_DASHBOARD_ROUTE_VIEW;
+  }
+}
+
+export function getSuiteWorkspaceSection(
+  route: EvalRoute,
+): SuiteWorkspaceSection | null {
+  if (route.type === "suite-edit") {
+    return "settings";
+  }
+
+  if (route.type === "suite-overview") {
+    return suiteOverviewViewToWorkspaceSection(route.view);
+  }
+
+  if (route.type === "run-detail") {
+    return "runs";
+  }
+
+  if (route.type === "test-detail" || route.type === "test-edit") {
+    return "cases";
+  }
+
+  return null;
+}


### PR DESCRIPTION
- Adds the Evals Playground information architecture foundation for Dashboard / Cases / Runs / Settings
- Keeps `/evals/suite/:suiteId` route-compatible as the Dashboard default
- Adds tested helpers for future dashboard matrix data and canonical v2 surface sequencing