### PR TITLE
fix(playground): route App Builder app-tool execution through AppBridge

### DIFF
--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundLeft.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundLeft.tsx
@@ -322,15 +322,20 @@ function ToolParametersView({
   // Fall back to the app-tools registry when the selection is an
   // `app_<hash>` alias — the server-tool dict won't have it. Same shape:
   // we only read `description`, `inputSchema`, and `outputSchema` below,
-  // and `AppToolDescriptor` carries all three.
+  // and `AppToolDescriptor` carries all three. Routing through the
+  // registry's `resolve()` inherits its `activeBridgeByParent` gate so a
+  // superseded sibling instance won't render here.
   const appToolDescriptor = useAppToolsRegistry((s) => {
     if (selectedTool) return undefined;
-    const aliasEntry = s.aliases.get(selectedToolName);
-    if (!aliasEntry) return undefined;
-    const inst = s.instancesByBridgeId.get(aliasEntry.bridgeId);
-    return inst?.tools.find((t) => t.name === aliasEntry.rawName);
+    const resolved = s.resolve(selectedToolName);
+    if (!resolved) return undefined;
+    return resolved.instance.tools.find((t) => t.name === resolved.rawName);
   });
   const effectiveTool = selectedTool ?? appToolDescriptor;
+  // For app-tool aliases (`app_<hash>`), show the raw advertised tool name in
+  // the header instead of the opaque alias. Server tools fall back to the
+  // selection key, which is already the raw name.
+  const headerToolName = appToolDescriptor?.name ?? selectedToolName;
   const hasParameters = formFields && formFields.length > 0;
   const [openSections, setOpenSections] = useState<string[]>(["description"]);
 
@@ -341,7 +346,7 @@ function ToolParametersView({
   return (
     <div className="h-full flex flex-col">
       <SelectedToolHeader
-        toolName={selectedToolName}
+        toolName={headerToolName}
         onExpand={onExpand}
         toolSwitchList={{
           names: toolNames,

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundLeft.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundLeft.tsx
@@ -15,6 +15,7 @@ import {
   AccordionContent,
 } from "@mcpjam/design-system/accordion";
 import type { Tool } from "@modelcontextprotocol/client";
+import { useAppToolsRegistry } from "@/components/chat-v2/thread/mcp-apps/app-tools-registry";
 import { ScrollArea } from "@mcpjam/design-system/scroll-area";
 import { SearchInput } from "../ui/search-input";
 import { SavedRequestItem } from "../tools/SavedRequestItem";
@@ -318,6 +319,18 @@ function ToolParametersView({
   onFieldChange,
   onToggleField,
 }: ToolParametersViewProps) {
+  // Fall back to the app-tools registry when the selection is an
+  // `app_<hash>` alias — the server-tool dict won't have it. Same shape:
+  // we only read `description`, `inputSchema`, and `outputSchema` below,
+  // and `AppToolDescriptor` carries all three.
+  const appToolDescriptor = useAppToolsRegistry((s) => {
+    if (selectedTool) return undefined;
+    const aliasEntry = s.aliases.get(selectedToolName);
+    if (!aliasEntry) return undefined;
+    const inst = s.instancesByBridgeId.get(aliasEntry.bridgeId);
+    return inst?.tools.find((t) => t.name === aliasEntry.rawName);
+  });
+  const effectiveTool = selectedTool ?? appToolDescriptor;
   const hasParameters = formFields && formFields.length > 0;
   const [openSections, setOpenSections] = useState<string[]>(["description"]);
 
@@ -342,35 +355,35 @@ function ToolParametersView({
           onValueChange={setOpenSections}
           className="px-3"
         >
-          {selectedTool?.description && (
+          {effectiveTool?.description && (
             <AccordionItem value="description">
               <AccordionTrigger className="text-xs">
                 Description
               </AccordionTrigger>
               <AccordionContent>
                 <p className="text-xs text-muted-foreground leading-relaxed">
-                  {selectedTool.description}
+                  {effectiveTool.description}
                 </p>
               </AccordionContent>
             </AccordionItem>
           )}
-          {selectedTool?.inputSchema && (
+          {effectiveTool?.inputSchema && (
             <AccordionItem value="input-schema">
               <AccordionTrigger className="text-xs">
                 Input Schema
               </AccordionTrigger>
               <AccordionContent>
-                <SchemaViewer schema={selectedTool.inputSchema} />
+                <SchemaViewer schema={effectiveTool.inputSchema} />
               </AccordionContent>
             </AccordionItem>
           )}
-          {selectedTool?.outputSchema && (
+          {effectiveTool?.outputSchema && (
             <AccordionItem value="output-schema">
               <AccordionTrigger className="text-xs">
                 Output Schema
               </AccordionTrigger>
               <AccordionContent>
-                <SchemaViewer schema={selectedTool.outputSchema} />
+                <SchemaViewer schema={effectiveTool.outputSchema} />
               </AccordionContent>
             </AccordionItem>
           )}

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/__tests__/useToolExecution.app-routing.test.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/__tests__/useToolExecution.app-routing.test.ts
@@ -1,0 +1,279 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import {
+  classifySelectedTool,
+  useToolExecution,
+} from "../useToolExecution";
+import {
+  useAppToolsRegistry,
+  type AppInstance,
+  type AppToolDescriptor,
+} from "@/components/chat-v2/thread/mcp-apps/app-tools-registry";
+
+// --- Mocks ------------------------------------------------------------------
+
+vi.mock("posthog-js/react", () => ({
+  usePostHog: () => ({
+    capture: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/PosthogUtils", () => ({
+  detectEnvironment: vi.fn().mockReturnValue("test"),
+  detectPlatform: vi.fn().mockReturnValue("web"),
+}));
+
+const mockExecuteToolApi = vi.fn();
+vi.mock("@/lib/apis/mcp-tools-api", () => ({
+  executeToolApi: (...args: unknown[]) => mockExecuteToolApi(...args),
+}));
+
+// --- Helpers ----------------------------------------------------------------
+
+function tool(name: string, extra?: Partial<AppToolDescriptor>): AppToolDescriptor {
+  return {
+    name,
+    annotations: { readOnlyHint: true },
+    inputSchema: { type: "object", properties: {} },
+    ...extra,
+  };
+}
+
+function makeInstance(
+  bridgeId: string,
+  tools: AppToolDescriptor[],
+  callTool: AppInstance["bridge"]["callTool"],
+): AppInstance {
+  return {
+    bridgeId,
+    parentToolCallId: "call-1",
+    serverId: "srv-1",
+    appName: "Demo",
+    appVersion: "1.0.0",
+    surface: "inline",
+    bridge: { callTool } as unknown as AppInstance["bridge"],
+    tools,
+    registeredAtMs: Date.now(),
+  };
+}
+
+function makeHookOptions(overrides?: {
+  serverName?: string;
+  selectedTool?: string | null;
+}) {
+  return {
+    serverName: overrides?.serverName ?? "srv-1",
+    selectedTool: overrides?.selectedTool ?? null,
+    toolsMetadata: {},
+    formFields: [],
+    setIsExecuting: vi.fn(),
+    setExecutionError: vi.fn(),
+    setToolOutput: vi.fn(),
+    setToolResponseMetadata: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  useAppToolsRegistry.setState({
+    instancesByBridgeId: new Map(),
+    aliases: new Map(),
+    activeBridgeByParent: new Map(),
+    pendingControllers: new Map(),
+  });
+  mockExecuteToolApi.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// --- Tests ------------------------------------------------------------------
+
+describe("classifySelectedTool", () => {
+  it("returns null when no tool is selected", () => {
+    expect(classifySelectedTool(null)).toBeNull();
+  });
+
+  it("classifies a name not in the alias registry as a server tool", () => {
+    expect(classifySelectedTool("get_weather")).toEqual({
+      kind: "server",
+      name: "get_weather",
+    });
+  });
+
+  it("classifies a registered alias as an app tool", async () => {
+    await useAppToolsRegistry
+      .getState()
+      .registerInstance(makeInstance("b-1", [tool("ping")], vi.fn()));
+    const alias = [...useAppToolsRegistry.getState().aliases.keys()][0];
+    expect(classifySelectedTool(alias)).toEqual({ kind: "app", alias });
+  });
+
+  it("classifies an alias-shaped handle as app even when registry forgot it", () => {
+    // Mimics the post-iframe-teardown case: the alias survives in
+    // `selectedTool` but the registry no longer carries it.
+    expect(classifySelectedTool("app_deadbeef")).toEqual({
+      kind: "app",
+      alias: "app_deadbeef",
+    });
+  });
+});
+
+describe("useToolExecution app-tool routing", () => {
+  it("server tool still calls executeToolApi and never touches the bridge", async () => {
+    const callTool = vi.fn();
+    await useAppToolsRegistry
+      .getState()
+      .registerInstance(makeInstance("b-1", [tool("ping")], callTool));
+
+    mockExecuteToolApi.mockResolvedValueOnce({
+      status: "completed",
+      result: { content: [{ type: "text", text: "ok" }] },
+    });
+
+    const { result } = renderHook(() =>
+      useToolExecution(makeHookOptions({ selectedTool: "get_weather" })),
+    );
+
+    let outcome: Awaited<ReturnType<typeof result.current.executeTool>> | undefined;
+    await act(async () => {
+      outcome = await result.current.executeTool({ parameters: { city: "NYC" } });
+    });
+
+    expect(mockExecuteToolApi).toHaveBeenCalledWith(
+      "srv-1",
+      "get_weather",
+      { city: "NYC" },
+    );
+    expect(callTool).not.toHaveBeenCalled();
+    expect(outcome?.ok).toBe(true);
+  });
+
+  it("app tool dispatches via bridge.callTool with rawName, not the alias", async () => {
+    const callTool = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "from app" }],
+    });
+    await useAppToolsRegistry
+      .getState()
+      .registerInstance(makeInstance("b-1", [tool("draw_chart")], callTool));
+    const alias = [...useAppToolsRegistry.getState().aliases.keys()][0];
+
+    const { result } = renderHook(() =>
+      useToolExecution(makeHookOptions({ selectedTool: alias })),
+    );
+
+    let outcome: Awaited<ReturnType<typeof result.current.executeTool>> | undefined;
+    await act(async () => {
+      outcome = await result.current.executeTool({
+        parameters: { kind: "bar" },
+      });
+    });
+
+    // Critical: dispatched with the raw tool name, never the alias.
+    expect(callTool).toHaveBeenCalledTimes(1);
+    expect(callTool).toHaveBeenCalledWith({
+      name: "draw_chart",
+      arguments: { kind: "bar" },
+    });
+    expect(mockExecuteToolApi).not.toHaveBeenCalled();
+    expect(outcome?.ok).toBe(true);
+    if (outcome?.ok) {
+      // The completed-tool record uses the rawName so the UI doesn't show
+      // a synthetic `app_<hash>` label.
+      expect(outcome.toolName).toBe("draw_chart");
+    }
+  });
+
+  it("stale alias returns a clear error and never calls the MCP server", async () => {
+    const { result } = renderHook(() =>
+      useToolExecution(makeHookOptions({ selectedTool: "app_deadbeef" })),
+    );
+
+    let outcome: Awaited<ReturnType<typeof result.current.executeTool>> | undefined;
+    await act(async () => {
+      outcome = await result.current.executeTool({ parameters: {} });
+    });
+
+    expect(outcome?.ok).toBe(false);
+    if (outcome && !outcome.ok) {
+      expect(outcome.error).toMatch(/no longer available/i);
+      expect(outcome.toolName).toBe("app_deadbeef");
+    }
+    expect(mockExecuteToolApi).not.toHaveBeenCalled();
+  });
+
+  it("stores the unscrubbed CallToolResult so the playground can inspect _meta", async () => {
+    const raw = {
+      content: [{ type: "text", text: "from app" }],
+      structuredContent: { score: 42 },
+      _meta: { "mcpjam.test": true },
+    };
+    const callTool = vi.fn().mockResolvedValue(raw);
+    await useAppToolsRegistry
+      .getState()
+      .registerInstance(makeInstance("b-1", [tool("draw_chart")], callTool));
+    const alias = [...useAppToolsRegistry.getState().aliases.keys()][0];
+
+    const options = makeHookOptions({ selectedTool: alias });
+    const { result } = renderHook(() => useToolExecution(options));
+
+    await act(async () => {
+      await result.current.executeTool({ parameters: {} });
+    });
+
+    // The playground's inspector pane reads `setToolOutput` — assert the full
+    // raw payload landed there (including `structuredContent` + `_meta`).
+    expect(options.setToolOutput).toHaveBeenCalledWith(raw);
+    // `_meta` is extracted into the response-metadata slot for the UI badge.
+    expect(options.setToolResponseMetadata).toHaveBeenCalledWith({
+      "mcpjam.test": true,
+    });
+  });
+
+  it("registers and unregisters the pending controller on the bridge's bridgeId", async () => {
+    const callTool = vi.fn().mockResolvedValue({ content: [] });
+    await useAppToolsRegistry
+      .getState()
+      .registerInstance(makeInstance("b-1", [tool("draw_chart")], callTool));
+    const alias = [...useAppToolsRegistry.getState().aliases.keys()][0];
+
+    const { result } = renderHook(() =>
+      useToolExecution(makeHookOptions({ selectedTool: alias })),
+    );
+
+    await act(async () => {
+      await result.current.executeTool({ parameters: {} });
+    });
+
+    // After settle, the pending set should be empty (or absent) — the
+    // dispatch path must clean up after itself even on success.
+    const pending = useAppToolsRegistry.getState().pendingControllers.get("b-1");
+    expect(pending === undefined || pending.size === 0).toBe(true);
+  });
+
+  it("app tool dispatch can still execute without a connected MCP server", async () => {
+    // Regression guard: server tools require `effectiveServerName`. App
+    // tools must not — the iframe owns its own connection.
+    const callTool = vi.fn().mockResolvedValue({ content: [] });
+    await useAppToolsRegistry
+      .getState()
+      .registerInstance(makeInstance("b-1", [tool("draw_chart")], callTool));
+    const alias = [...useAppToolsRegistry.getState().aliases.keys()][0];
+
+    const { result } = renderHook(() =>
+      useToolExecution({
+        ...makeHookOptions({ selectedTool: alias }),
+        serverName: undefined,
+      }),
+    );
+
+    let outcome: Awaited<ReturnType<typeof result.current.executeTool>> | undefined;
+    await act(async () => {
+      outcome = await result.current.executeTool({ parameters: {} });
+    });
+
+    expect(outcome?.ok).toBe(true);
+    expect(callTool).toHaveBeenCalled();
+  });
+});

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/use-app-builder-state.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/use-app-builder-state.ts
@@ -538,13 +538,14 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
   // Subscribe to the app-tools registry so form fields regenerate when an
   // app re-lists its tools (e.g. inputSchema changes mid-session). Returning
   // the resolved descriptor keeps the schema reference stable across renders
-  // that didn't actually change the registry entry.
+  // that didn't actually change the registry entry. Routes through the
+  // registry's `resolve()` so we inherit its `activeBridgeByParent` gate
+  // (a superseded sibling instance won't be treated as live).
   const selectedAppToolDescriptor = useAppToolsRegistry((s) => {
     if (!selectedTool) return undefined;
-    const aliasEntry = s.aliases.get(selectedTool);
-    if (!aliasEntry) return undefined;
-    const inst = s.instancesByBridgeId.get(aliasEntry.bridgeId);
-    return inst?.tools.find((t) => t.name === aliasEntry.rawName);
+    const resolved = s.resolve(selectedTool);
+    if (!resolved) return undefined;
+    return resolved.instance.tools.find((t) => t.name === resolved.rawName);
   });
 
   useEffect(() => {

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/use-app-builder-state.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/use-app-builder-state.ts
@@ -50,6 +50,7 @@ import {
   createInspectorCommandClientError,
   registerInspectorCommandHandler,
 } from "@/lib/inspector-command-handlers";
+import { useAppToolsRegistry } from "@/components/chat-v2/thread/mcp-apps/app-tools-registry";
 import type {
   ExecuteToolInspectorCommand,
   RenderToolResultInspectorCommand,
@@ -534,15 +535,33 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
     tools,
   ]);
 
+  // Subscribe to the app-tools registry so form fields regenerate when an
+  // app re-lists its tools (e.g. inputSchema changes mid-session). Returning
+  // the resolved descriptor keeps the schema reference stable across renders
+  // that didn't actually change the registry entry.
+  const selectedAppToolDescriptor = useAppToolsRegistry((s) => {
+    if (!selectedTool) return undefined;
+    const aliasEntry = s.aliases.get(selectedTool);
+    if (!aliasEntry) return undefined;
+    const inst = s.instancesByBridgeId.get(aliasEntry.bridgeId);
+    return inst?.tools.find((t) => t.name === aliasEntry.rawName);
+  });
+
   useEffect(() => {
     if (selectedTool && tools[selectedTool]) {
       setFormFields(
         generateFormFieldsFromSchema(tools[selectedTool].inputSchema),
       );
-    } else {
-      setFormFields([]);
+      return;
     }
-  }, [selectedTool, tools, setFormFields]);
+    if (selectedAppToolDescriptor) {
+      setFormFields(
+        generateFormFieldsFromSchema(selectedAppToolDescriptor.inputSchema),
+      );
+      return;
+    }
+    setFormFields([]);
+  }, [selectedTool, tools, selectedAppToolDescriptor, setFormFields]);
 
   const selectToolForCommand = useCallback(
     async (

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/useToolExecution.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/useToolExecution.ts
@@ -15,6 +15,15 @@ import {
 } from "@/lib/apis/mcp-tools-api";
 import { usePostHog } from "posthog-js/react";
 import { detectEnvironment, detectPlatform } from "@/lib/PosthogUtils";
+import {
+  recordAppToolInvocation,
+  useAppToolsRegistry,
+} from "@/components/chat-v2/thread/mcp-apps/app-tools-registry";
+
+// Matches `app_<8 hex chars>` aliases minted by the app-tools registry.
+// Kept local to avoid widening the registry's public surface; the registry
+// owns the canonical pattern (`ALIAS_REGEX`) and exports it via `__internal`.
+const APP_TOOL_ALIAS_REGEX = /^app_[a-z0-9]{8}$/i;
 
 // Result metadata type for tool responses
 interface ToolResponseMeta {
@@ -39,6 +48,38 @@ export interface UseToolExecutionOptions {
   setExecutionError: (error: string | null) => void;
   setToolOutput: (output: unknown) => void;
   setToolResponseMetadata: (meta: Record<string, unknown> | null) => void;
+}
+
+/**
+ * Explicit reference to the playground's selected tool. Server tools are
+ * keyed by their MCP name; app-provided tools (SEP-1865) are keyed by the
+ * opaque `app_<hash>` alias the registry minted for them. Routing branches
+ * on `kind` so server execution never accidentally calls the MCP server
+ * with a synthetic alias.
+ */
+export type SelectedToolRef =
+  | { kind: "server"; name: string }
+  | { kind: "app"; alias: string };
+
+/**
+ * Classify a flat tool handle (server name or app alias) by consulting the
+ * app-tools registry. Used by the App Builder execution path so the same
+ * `selectedTool: string` slot can address both worlds without ambiguity.
+ *
+ * Read via `getState()` — callers are dispatch sites that just need the
+ * current classification once, not a reactive subscription.
+ */
+export function classifySelectedTool(
+  name: string | null,
+): SelectedToolRef | null {
+  if (!name) return null;
+  const aliasEntry = useAppToolsRegistry.getState().aliases.get(name);
+  if (aliasEntry) return { kind: "app", alias: name };
+  // Treat alias-shaped handles as app even when the registry has forgotten
+  // them — the executor surfaces a clean "no longer available" error rather
+  // than routing the synthetic name to the MCP server (which would 404).
+  if (APP_TOOL_ALIAS_REGEX.test(name)) return { kind: "app", alias: name };
+  return { kind: "server", name };
 }
 
 export interface UseToolExecutionReturn {
@@ -170,7 +211,32 @@ export function useToolExecution({
       const params =
         options?.parameters ?? buildParametersFromFields(effectiveFormFields);
 
-      if (!effectiveToolName || !effectiveServerName) {
+      if (!effectiveToolName) {
+        return {
+          ok: false,
+          error: "A tool selection is required.",
+        };
+      }
+
+      // App-tool routing: when the selected handle is a registry alias, the
+      // playground must dispatch into the live MCP App iframe via
+      // `AppBridge.callTool` and NOT call the MCP server with the synthetic
+      // `app_<hash>` alias. The alias is a model/server-orchestration name
+      // only — the iframe knows the tool by its raw advertised name. See
+      // SEP-1865 and `app-tools-registry.ts` for the contract.
+      const selectedRef = classifySelectedTool(effectiveToolName);
+      if (selectedRef?.kind === "app") {
+        return executeAppTool({
+          alias: selectedRef.alias,
+          params,
+          posthog,
+          setExecutionError,
+          setIsExecuting,
+          storeCompletedToolResult,
+        });
+      }
+
+      if (!effectiveServerName) {
         return {
           ok: false,
           error: "A connected server and tool selection are required.",
@@ -194,6 +260,7 @@ export function useToolExecution({
             platform: detectPlatform(),
             environment: detectEnvironment(),
             toolName: effectiveToolName,
+            source: "server",
             success: false,
             errorType: "api_error",
           });
@@ -243,6 +310,7 @@ export function useToolExecution({
           platform: detectPlatform(),
           environment: detectEnvironment(),
           toolName: effectiveToolName,
+          source: "server",
           success: true,
         });
 
@@ -263,6 +331,7 @@ export function useToolExecution({
           platform: detectPlatform(),
           environment: detectEnvironment(),
           toolName: effectiveToolName,
+          source: "server",
           success: false,
           errorType: "exception",
         });
@@ -329,4 +398,147 @@ export function useToolExecution({
     executeTool,
     injectToolResult,
   };
+}
+
+interface ExecuteAppToolArgs {
+  alias: string;
+  params: Record<string, unknown>;
+  posthog: ReturnType<typeof usePostHog>;
+  setExecutionError: (error: string | null) => void;
+  setIsExecuting: (executing: boolean) => void;
+  storeCompletedToolResult: (
+    effectiveToolName: string,
+    params: Record<string, unknown>,
+    result: unknown,
+    toolCallId?: string,
+  ) => void;
+}
+
+/**
+ * Dispatch a playground-issued tool call into the live MCP App iframe.
+ *
+ * Mirrors the chat-path dispatch in `use-chat-session.ts`: register an
+ * `AbortController` against the bridge's pending set BEFORE awaiting so a
+ * mid-flight iframe teardown rejects the await instead of hanging the UI,
+ * and call back through the registry's pending bookkeeping in `finally`.
+ *
+ * The alias is the model/server-orchestration handle; the iframe knows
+ * the tool by its `rawName`, so dispatch always uses `entry.rawName`.
+ */
+async function executeAppTool({
+  alias,
+  params,
+  posthog,
+  setExecutionError,
+  setIsExecuting,
+  storeCompletedToolResult,
+}: ExecuteAppToolArgs): Promise<ExecuteToolInvocationResult> {
+  const registry = useAppToolsRegistry.getState();
+  const entry = registry.resolve(alias);
+  // Tag posthog with the raw advertised name when we have it; aliases are
+  // intentionally opaque and unhelpful for product analytics.
+  const reportedName = entry?.rawName ?? alias;
+
+  if (!entry) {
+    const message =
+      "App tool is no longer available — the widget was closed or replaced.";
+    setExecutionError(message);
+    posthog.capture("app_builder_tool_executed", {
+      location: "app_builder_tab",
+      platform: detectPlatform(),
+      environment: detectEnvironment(),
+      toolName: reportedName,
+      source: "app",
+      success: false,
+      errorType: "stale_app_alias",
+    });
+    return {
+      ok: false,
+      toolName: alias,
+      parameters: params,
+      error: message,
+    };
+  }
+
+  setIsExecuting(true);
+  setExecutionError(null);
+
+  const controller = new AbortController();
+  registry.registerPendingCall(entry.instance.bridgeId, controller);
+
+  try {
+    const call = entry.bridge.callTool({
+      name: entry.rawName,
+      arguments: params,
+    });
+    const raw = await new Promise<
+      Awaited<ReturnType<typeof entry.bridge.callTool>>
+    >((resolve, reject) => {
+      const onAbort = () =>
+        reject(new Error("App iframe was torn down mid-dispatch"));
+      if (controller.signal.aborted) {
+        onAbort();
+        return;
+      }
+      controller.signal.addEventListener("abort", onAbort, { once: true });
+      call.then(resolve, reject);
+    });
+
+    // Store the full untouched CallToolResult — the playground inspector
+    // should be able to see `structuredContent`/`_meta` the chat path
+    // intentionally strips before handing back to the model.
+    storeCompletedToolResult(entry.rawName, params, raw);
+
+    recordAppToolInvocation({
+      alias,
+      rawName: entry.rawName,
+      appName: entry.instance.appName,
+      serverId: entry.instance.serverId,
+      parentToolCallId: entry.instance.parentToolCallId,
+      bridgeId: entry.instance.bridgeId,
+      input: params,
+      raw,
+    });
+
+    posthog.capture("app_builder_tool_executed", {
+      location: "app_builder_tab",
+      platform: detectPlatform(),
+      environment: detectEnvironment(),
+      toolName: reportedName,
+      source: "app",
+      success: true,
+    });
+
+    return {
+      ok: true,
+      toolName: entry.rawName,
+      parameters: params,
+      result: raw,
+      response: { status: "completed", result: raw },
+    };
+  } catch (err) {
+    console.error("App tool execution error:", err);
+    const message = err instanceof Error ? err.message : "App tool execution failed";
+    setExecutionError(message);
+
+    posthog.capture("app_builder_tool_executed", {
+      location: "app_builder_tab",
+      platform: detectPlatform(),
+      environment: detectEnvironment(),
+      toolName: reportedName,
+      source: "app",
+      success: false,
+      errorType: "exception",
+    });
+
+    return {
+      ok: false,
+      toolName: entry.rawName,
+      parameters: params,
+      error: message,
+    };
+  } finally {
+    registry.unregisterPendingCall(entry.instance.bridgeId, controller);
+    setIsExecuting(false);
+  }
 }


### PR DESCRIPTION
## Summary

Selecting an app-provided tool in App Builder and hitting **Execute** was sending the synthetic `app_<hash>` alias to the MCP server via `executeToolApi`, which 404s — the alias only exists in the model/server orchestration namespace; the iframe knows the tool by its raw advertised name.

This PR routes alias-shaped selections through the live MCP App iframe via `AppBridge.callTool({ name: rawName, arguments })`, mirroring the chat-path dispatch in `use-chat-session.ts`.

- **`useToolExecution.ts`** — new `classifySelectedTool` helper + `executeAppTool` branch. Dispatch registers an `AbortController` against the bridge's pending set so iframe teardown rejects the await instead of hanging the UI, and records the invocation via `recordAppToolInvocation`. Stale aliases (registry forgot them after a widget close) return a clean "no longer available" error instead of leaking the synthetic name to the server.
- **`use-app-builder-state.ts`** — subscribes to the app-tools registry so `formFields` regenerate from the app-tool `inputSchema` when an alias is selected.
- **`PlaygroundLeft.tsx`** (`ToolParametersView`) — falls back to the registry descriptor for description/inputSchema/outputSchema when `tools[name]` is undefined.
- **Tests** — 10 new cases: server-path passthrough, alias → rawName dispatch (never the alias), stale alias error, full `CallToolResult` storage including `structuredContent`/`_meta`, pending-controller cleanup, and app dispatch without a connected MCP server.

The architectural rule stays simple: aliases are for exposing app tools to the model/server loop; direct App Builder execution always resolves the alias locally and calls the app bridge with the raw app tool name.

## Test plan

- [x] `npm test` — app-tools + ui-playground suites (214 tests) pass, including 10 new routing tests
- [x] `npm run typecheck:client` — clean
- [ ] `npm run build:client` — pre-existing failure in `use-chat-session.ts:29` (`lastAssistantMessageIsCompleteWithApprovalResponses` not exported by the installed `ai@5.0.28`). Unrelated to this change; the file is untouched and the import was added in main HEAD `535c7bfa`. May need `npm install` at the repo root.
- [ ] Manual: open an MCP App that registers an app-provided tool → confirm it appears in the App Builder tool list → select it → confirm input form uses the app-tool schema → Execute → confirm the iframe receives `tools/call` via the bridge and the MCP server is NOT called with `app_<hash>` → close the app and confirm executing again surfaces a clear stale-alias error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core tool execution routing and iframe bridge lifecycle; well-tested but affects how playground dispatches tool calls for app-provided tools.
> 
> **Overview**
> Fixes App Builder / Playground **Execute** for MCP App tools: synthetic `app_<hash>` selections no longer go to `executeToolApi` (which 404s); they route through **`AppBridge.callTool`** using the tool’s **raw name**, aligned with the chat path.
> 
> **`useToolExecution`** adds `classifySelectedTool` and an `executeAppTool` path with pending `AbortController` registration, full `CallToolResult` storage (including `_meta`), stale-alias errors, and no requirement for a connected MCP server. **`use-app-builder-state`** and **`PlaygroundLeft`** subscribe to the app-tools registry so forms and schema/description panels work for alias selections.
> 
> New Vitest coverage for server vs app routing, stale aliases, and bridge cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbb0b7342e8e75054f8c3f4e49d60c59526d9fca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->