### PR TITLE
[codex] Persist MCP app surfaces across tool calls

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/FullscreenChatOverlay.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/FullscreenChatOverlay.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import type { UIMessage } from "@ai-sdk/react";
@@ -7,6 +7,11 @@ import {
   ChatboxHostStyleProvider,
   ChatboxHostThemeProvider,
 } from "@/contexts/chatbox-client-style-context";
+import {
+  useAppToolInvocationLog,
+  useAppToolsRegistry,
+} from "@/components/chat-v2/thread/mcp-apps/app-tools-registry";
+import { PreferencesStoreProvider } from "@/stores/preferences/preferences-provider";
 import { FullscreenChatOverlay } from "../fullscreen-chat-overlay";
 
 // Mock loading-indicator-content so the test can assert which brand path
@@ -35,8 +40,8 @@ vi.mock("../shared/loading-indicator-content", async () => {
         resolved === "claude"
           ? "claude-mark"
           : resolved === "chatgpt"
-            ? "chatgpt-dot"
-            : "default";
+          ? "chatgpt-dot"
+          : "default";
       return <div data-testid={`loading-indicator-${variant}`} />;
     },
     useResolvedHostStyleForIndicator: (modelProvider?: string | null) => {
@@ -59,6 +64,16 @@ vi.mock("@/lib/client-styles/indicators/claude-mark", () => ({
 }));
 
 describe("FullscreenChatOverlay", () => {
+  beforeEach(() => {
+    useAppToolsRegistry.setState({
+      activeBridgeByParent: new Map(),
+      aliases: new Map(),
+      instancesByBridgeId: new Map(),
+      pendingControllers: new Map(),
+    });
+    useAppToolInvocationLog.getState().clear();
+  });
+
   const createMessage = (overrides: Partial<UIMessage> = {}): UIMessage => ({
     id: `msg-${Math.random().toString(36).slice(2)}`,
     role: "user",
@@ -80,56 +95,63 @@ describe("FullscreenChatOverlay", () => {
     onSend: vi.fn(),
   };
 
+  const renderWithProviders = (ui: ReactElement) =>
+    render(
+      <PreferencesStoreProvider themeMode="light" themePreset="default">
+        {ui}
+      </PreferencesStoreProvider>
+    );
+
   const renderWithHostStyle = (
     hostStyle: "chatgpt" | "claude",
     theme: "light" | "dark",
-    ui: ReactElement,
+    ui: ReactElement
   ) =>
-    render(
+    renderWithProviders(
       <ChatboxHostStyleProvider value={hostStyle}>
         <ChatboxHostThemeProvider value={theme}>{ui}</ChatboxHostThemeProvider>
-      </ChatboxHostStyleProvider>,
+      </ChatboxHostStyleProvider>
     );
 
   it("shows a standalone Claude placeholder row before the first assistant token appears", () => {
-    render(
+    renderWithProviders(
       <ChatboxHostStyleProvider value="claude">
         <FullscreenChatOverlay
           {...defaultProps}
           messages={[createMessage({ id: "msg-1", role: "user" })]}
           isThinking={true}
         />
-      </ChatboxHostStyleProvider>,
+      </ChatboxHostStyleProvider>
     );
 
     expect(screen.getByTestId("fullscreen-thinking-row")).toBeInTheDocument();
     expect(
-      screen.getByTestId("loading-indicator-claude-mark"),
+      screen.getByTestId("loading-indicator-claude-mark")
     ).toBeInTheDocument();
     expect(
-      screen.queryByTestId("fullscreen-claude-footer-animated"),
+      screen.queryByTestId("fullscreen-claude-footer-animated")
     ).not.toBeInTheDocument();
   });
 
   it("shows a standalone GPT pulse before the first assistant token appears", () => {
-    render(
+    renderWithProviders(
       <ChatboxHostStyleProvider value="chatgpt">
         <FullscreenChatOverlay
           {...defaultProps}
           messages={[createMessage({ id: "msg-1", role: "user" })]}
           isThinking={true}
         />
-      </ChatboxHostStyleProvider>,
+      </ChatboxHostStyleProvider>
     );
 
     expect(screen.getByTestId("fullscreen-thinking-row")).toBeInTheDocument();
     expect(
-      screen.getByTestId("loading-indicator-chatgpt-dot"),
+      screen.getByTestId("loading-indicator-chatgpt-dot")
     ).toBeInTheDocument();
   });
 
   it("hides the GPT pulse once assistant preview text is visible while streaming", () => {
-    render(
+    renderWithProviders(
       <ChatboxHostStyleProvider value="chatgpt">
         <FullscreenChatOverlay
           {...defaultProps}
@@ -143,19 +165,206 @@ describe("FullscreenChatOverlay", () => {
           ]}
           isThinking={true}
         />
-      </ChatboxHostStyleProvider>,
+      </ChatboxHostStyleProvider>
     );
 
     expect(
-      screen.queryByTestId("fullscreen-thinking-row"),
+      screen.queryByTestId("fullscreen-thinking-row")
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId("loading-indicator-chatgpt-dot"),
+      screen.queryByTestId("loading-indicator-chatgpt-dot")
     ).not.toBeInTheDocument();
   });
 
+  it("keeps tool-only assistant activity visible while streaming", () => {
+    renderWithProviders(
+      <ChatboxHostStyleProvider value="chatgpt">
+        <FullscreenChatOverlay
+          {...defaultProps}
+          messages={[
+            createMessage({ id: "msg-1", role: "user" }),
+            createMessage({
+              id: "msg-2",
+              role: "assistant",
+              parts: [
+                {
+                  type: "dynamic-tool",
+                  toolName: "search_docs",
+                  toolCallId: "tool-1",
+                  state: "input-streaming",
+                  input: {},
+                } as any,
+              ],
+            }),
+          ]}
+          isThinking={true}
+        />
+      </ChatboxHostStyleProvider>
+    );
+
+    expect(screen.getByText("search_docs")).toBeInTheDocument();
+    expect(screen.getByTitle("Input streaming")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("fullscreen-thinking-row")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders assistant markdown like thread text parts", () => {
+    renderWithProviders(
+      <FullscreenChatOverlay
+        {...defaultProps}
+        messages={[
+          createMessage({ id: "msg-1", role: "user" }),
+          createMessage({
+            id: "msg-2",
+            role: "assistant",
+            parts: [{ type: "text", text: "Invoked `start_game`" }],
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText("start_game")).toBeInTheDocument();
+    expect(screen.queryByText(/`start_game`/)).not.toBeInTheDocument();
+  });
+
+  it("keeps tool-only assistant output details collapsed until expanded", () => {
+    renderWithProviders(
+      <FullscreenChatOverlay
+        {...defaultProps}
+        messages={[
+          createMessage({ id: "msg-1", role: "user" }),
+          createMessage({
+            id: "msg-2",
+            role: "assistant",
+            parts: [
+              {
+                type: "dynamic-tool",
+                toolName: "search_docs",
+                toolCallId: "tool-1",
+                state: "output-available",
+                input: {},
+                output: {
+                  content: [{ type: "text", text: "Found the matching doc." }],
+                },
+              } as any,
+            ],
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText("search_docs")).toBeInTheDocument();
+    expect(screen.queryByText("Result")).not.toBeInTheDocument();
+
+    const toolHeader = screen.getByText("search_docs").closest('[role="button"]');
+    expect(toolHeader).not.toBeNull();
+    fireEvent.click(toolHeader!);
+
+    expect(screen.getByText("Result")).toBeInTheDocument();
+  });
+
+  it("keeps assistant content visible when a tool part is added to the same message", () => {
+    renderWithProviders(
+      <ChatboxHostStyleProvider value="claude">
+        <FullscreenChatOverlay
+          {...defaultProps}
+          messages={[
+            createMessage({ id: "msg-1", role: "user" }),
+            createMessage({
+              id: "msg-2",
+              role: "assistant",
+              content: "Let me check the board state." as any,
+              parts: [
+                {
+                  type: "dynamic-tool",
+                  toolName: "make_move",
+                  toolCallId: "tool-1",
+                  state: "output-available",
+                  input: {},
+                } as any,
+              ],
+            } as Partial<UIMessage>),
+          ]}
+          isThinking={true}
+        />
+      </ChatboxHostStyleProvider>
+    );
+
+    expect(
+      screen.getByText("Let me check the board state.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("make_move")).toBeInTheDocument();
+    expect(screen.queryByText("Used make_move")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("fullscreen-thinking-row")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId("fullscreen-claude-footer-animated")
+    ).toBeInTheDocument();
+  });
+
+  it("resolves app-provided tool aliases in fullscreen tool cards", () => {
+    useAppToolsRegistry.setState({
+      activeBridgeByParent: new Map([["parent-1", "bridge-1"]]),
+      aliases: new Map([
+        [
+          "app_951c1f5d",
+          {
+            alias: "app_951c1f5d",
+            bridgeId: "bridge-1",
+            rawName: "move_piece",
+            readOnly: false,
+          },
+        ],
+      ]),
+      instancesByBridgeId: new Map([
+        [
+          "bridge-1",
+          {
+            appName: "Chess",
+            bridge: {} as any,
+            bridgeId: "bridge-1",
+            parentToolCallId: "parent-1",
+            registeredAtMs: Date.now(),
+            serverId: "server-1",
+            surface: "inline",
+            tools: [],
+          },
+        ],
+      ]),
+      pendingControllers: new Map(),
+    });
+
+    renderWithProviders(
+      <FullscreenChatOverlay
+        {...defaultProps}
+        messages={[
+          createMessage({ id: "msg-1", role: "user" }),
+          createMessage({
+            id: "msg-2",
+            role: "assistant",
+            parts: [
+              {
+                type: "dynamic-tool",
+                toolName: "app_951c1f5d",
+                toolCallId: "tool-1",
+                state: "output-available",
+                input: {},
+              } as any,
+            ],
+          }),
+        ]}
+      />
+    );
+
+    expect(screen.getByText("move_piece")).toBeInTheDocument();
+    expect(screen.getByText("from Chess")).toBeInTheDocument();
+    expect(screen.queryByText(/app_951c1f5d/)).not.toBeInTheDocument();
+  });
+
   it("keeps the GPT pulse hidden after the response finishes", () => {
-    render(
+    renderWithProviders(
       <ChatboxHostStyleProvider value="chatgpt">
         <FullscreenChatOverlay
           {...defaultProps}
@@ -169,19 +378,71 @@ describe("FullscreenChatOverlay", () => {
           ]}
           isThinking={false}
         />
-      </ChatboxHostStyleProvider>,
+      </ChatboxHostStyleProvider>
     );
 
     expect(
-      screen.queryByTestId("fullscreen-thinking-row"),
+      screen.queryByTestId("fullscreen-thinking-row")
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByTestId("loading-indicator-chatgpt-dot"),
+      screen.queryByTestId("loading-indicator-chatgpt-dot")
     ).not.toBeInTheDocument();
   });
 
+  it("keeps autoscrolling as the latest assistant text grows", () => {
+    const hadScrollIntoView = "scrollIntoView" in Element.prototype;
+    const originalScrollIntoView = Element.prototype.scrollIntoView;
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(Element.prototype, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+
+    try {
+      const userMessage = createMessage({ id: "msg-1", role: "user" });
+      const assistantMessage = (text: string) =>
+        createMessage({
+          id: "msg-2",
+          role: "assistant",
+          parts: [{ type: "text", text }],
+        });
+
+      const { rerender } = renderWithProviders(
+        <FullscreenChatOverlay
+          {...defaultProps}
+          messages={[userMessage, assistantMessage("First chunk")]}
+          isThinking={true}
+        />
+      );
+
+      expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+      rerender(
+        <FullscreenChatOverlay
+          {...defaultProps}
+          messages={[
+            userMessage,
+            assistantMessage("First chunk\nMore streamed content"),
+          ]}
+          isThinking={true}
+        />
+      );
+
+      expect(scrollIntoView).toHaveBeenCalledTimes(2);
+    } finally {
+      if (hadScrollIntoView) {
+        Object.defineProperty(Element.prototype, "scrollIntoView", {
+          configurable: true,
+          value: originalScrollIntoView,
+        });
+      } else {
+        delete (Element.prototype as Partial<Element>).scrollIntoView;
+      }
+    }
+  });
+
   it("moves the Claude mascot onto the latest assistant bubble while streaming", () => {
-    render(
+    renderWithProviders(
       <ChatboxHostStyleProvider value="claude">
         <FullscreenChatOverlay
           {...defaultProps}
@@ -195,20 +456,20 @@ describe("FullscreenChatOverlay", () => {
           ]}
           isThinking={true}
         />
-      </ChatboxHostStyleProvider>,
+      </ChatboxHostStyleProvider>
     );
 
     expect(
-      screen.queryByTestId("fullscreen-thinking-row"),
+      screen.queryByTestId("fullscreen-thinking-row")
     ).not.toBeInTheDocument();
     expect(
-      screen.getByTestId("fullscreen-claude-footer-animated"),
+      screen.getByTestId("fullscreen-claude-footer-animated")
     ).toBeInTheDocument();
     expect(screen.getByTestId("claude-indicator-animated")).toBeInTheDocument();
   });
 
   it("keeps only one static Claude footer on the latest assistant bubble after loading", () => {
-    render(
+    renderWithProviders(
       <ChatboxHostStyleProvider value="claude">
         <FullscreenChatOverlay
           {...defaultProps}
@@ -227,14 +488,14 @@ describe("FullscreenChatOverlay", () => {
           ]}
           isThinking={false}
         />
-      </ChatboxHostStyleProvider>,
+      </ChatboxHostStyleProvider>
     );
 
     expect(
-      screen.queryByTestId("fullscreen-thinking-row"),
+      screen.queryByTestId("fullscreen-thinking-row")
     ).not.toBeInTheDocument();
     expect(
-      screen.getByTestId("fullscreen-claude-footer-static"),
+      screen.getByTestId("fullscreen-claude-footer-static")
     ).toBeInTheDocument();
     expect(screen.getAllByTestId(/fullscreen-claude-footer-/)).toHaveLength(1);
     expect(screen.getByTestId("claude-indicator-static")).toBeInTheDocument();
@@ -249,14 +510,14 @@ describe("FullscreenChatOverlay", () => {
         messages={[createMessage({ id: "msg-1", role: "user" })]}
         input="Follow up"
         canSend={true}
-      />,
+      />
     );
 
     expect(screen.getByTestId("fullscreen-composer")).toHaveClass(
-      "chatbox-host-composer",
+      "chatbox-host-composer"
     );
     expect(screen.getByTestId("fullscreen-composer")).toHaveStyle(
-      "background-color: rgba(249, 247, 243, 1)",
+      "background-color: rgba(249, 247, 243, 1)"
     );
   });
 
@@ -269,14 +530,14 @@ describe("FullscreenChatOverlay", () => {
         messages={[createMessage({ id: "msg-1", role: "user" })]}
         input="Follow up"
         canSend={true}
-      />,
+      />
     );
 
     expect(screen.getByTestId("fullscreen-composer")).toHaveClass(
-      "chatbox-host-composer",
+      "chatbox-host-composer"
     );
     expect(screen.getByTestId("fullscreen-composer")).toHaveStyle(
-      "background-color: rgba(38, 38, 36, 1)",
+      "background-color: rgba(38, 38, 36, 1)"
     );
   });
 
@@ -289,14 +550,14 @@ describe("FullscreenChatOverlay", () => {
         messages={[createMessage({ id: "msg-1", role: "user" })]}
         input="Follow up"
         canSend={true}
-      />,
+      />
     );
 
     expect(screen.getByTestId("fullscreen-composer")).toHaveClass(
-      "chatbox-host-composer",
+      "chatbox-host-composer"
     );
     expect(screen.getByTestId("fullscreen-composer")).toHaveStyle(
-      "background-color: rgba(255, 255, 255, 1)",
+      "background-color: rgba(255, 255, 255, 1)"
     );
   });
 
@@ -309,61 +570,61 @@ describe("FullscreenChatOverlay", () => {
         messages={[createMessage({ id: "msg-1", role: "user" })]}
         input="Follow up"
         canSend={true}
-      />,
+      />
     );
 
     expect(screen.getByTestId("fullscreen-composer")).toHaveClass(
-      "chatbox-host-composer",
+      "chatbox-host-composer"
     );
     expect(screen.getByTestId("fullscreen-composer")).toHaveStyle(
-      "background-color: rgba(33, 33, 33, 1)",
+      "background-color: rgba(33, 33, 33, 1)"
     );
   });
 
   it("keeps the default fullscreen composer styling when no host style is active", () => {
-    render(
+    renderWithProviders(
       <FullscreenChatOverlay
         {...defaultProps}
         messages={[createMessage({ id: "msg-1", role: "user" })]}
         input="Follow up"
         canSend={true}
-      />,
+      />
     );
 
     expect(screen.getByTestId("fullscreen-composer")).toHaveClass(
       "rounded-full",
-      "bg-background/95",
+      "bg-background/95"
     );
   });
 
   it("keeps the fullscreen textarea editable while thinking", () => {
-    render(
+    renderWithProviders(
       <FullscreenChatOverlay
         {...defaultProps}
         input="Draft while thinking"
         isThinking={true}
-      />,
+      />
     );
 
     expect(screen.getByPlaceholderText("Message…")).not.toBeDisabled();
     expect(
-      screen.getByRole("button", { name: "Stop generating" }),
+      screen.getByRole("button", { name: "Stop generating" })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Send message" }),
+      screen.queryByRole("button", { name: "Send message" })
     ).not.toBeInTheDocument();
   });
 
   it("calls onStop from the fullscreen composer while thinking", () => {
     const onStop = vi.fn();
 
-    render(
+    renderWithProviders(
       <FullscreenChatOverlay
         {...defaultProps}
         input="Draft while thinking"
         isThinking={true}
         onStop={onStop}
-      />,
+      />
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Stop generating" }));
@@ -372,16 +633,16 @@ describe("FullscreenChatOverlay", () => {
   });
 
   it("preserves the draft and re-enables send after thinking stops", () => {
-    const { rerender } = render(
+    const { rerender } = renderWithProviders(
       <FullscreenChatOverlay
         {...defaultProps}
         input="Draft while thinking"
         isThinking={true}
-      />,
+      />
     );
 
     expect(screen.getByPlaceholderText("Message…")).toHaveValue(
-      "Draft while thinking",
+      "Draft while thinking"
     );
 
     rerender(
@@ -390,11 +651,11 @@ describe("FullscreenChatOverlay", () => {
         input="Draft while thinking"
         canSend={true}
         isThinking={false}
-      />,
+      />
     );
 
     expect(screen.getByPlaceholderText("Message…")).toHaveValue(
-      "Draft while thinking",
+      "Draft while thinking"
     );
     expect(screen.getByRole("button", { name: "Send message" })).toBeEnabled();
   });

--- a/mcpjam-inspector/client/src/components/chat-v2/__tests__/Thread.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/__tests__/Thread.test.tsx
@@ -5,6 +5,7 @@ import { Thread } from "../thread";
 import type { UIMessage } from "@ai-sdk/react";
 import type { ModelDefinition } from "@/shared/types";
 import { ChatboxHostStyleProvider } from "@/contexts/chatbox-client-style-context";
+import { useWidgetSurfaceStore } from "../thread/mcp-apps/widget-surface-store";
 
 const mockMessageView = vi.fn();
 const mockThinkingIndicator = vi.fn();
@@ -86,6 +87,10 @@ describe("Thread", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    useWidgetSurfaceStore.setState({
+      surfaces: new Map(),
+      nextOrder: 0,
+    });
   });
 
   describe("message rendering", () => {
@@ -533,6 +538,122 @@ describe("Thread", () => {
           onStop: onFullscreenChatStop,
         }),
       );
+    });
+
+    it("exits fullscreen when a persistent surface id owns the raw tool call", () => {
+      useWidgetSurfaceStore.setState({
+        surfaces: new Map([
+          [
+            "surface-1",
+            {
+              surfaceId: "surface-1",
+              chatSessionId: "other-chat",
+              initialToolCallId: "call-1",
+              latestToolCallId: "call-2",
+              registrations: new Map([
+                [
+                  "call-1",
+                  {
+                    toolCallId: "call-1",
+                    order: 0,
+                    props: {} as any,
+                    anchorElement: null,
+                  },
+                ],
+                [
+                  "call-2",
+                  {
+                    toolCallId: "call-2",
+                    order: 1,
+                    props: {} as any,
+                    anchorElement: null,
+                  },
+                ],
+              ]),
+            },
+          ],
+        ]),
+      });
+      const messages = [createMessage({ id: "msg-1", role: "assistant" })];
+
+      render(
+        <Thread
+          {...defaultProps}
+          chatSessionId="chat-1"
+          messages={messages}
+          enableFullscreenChatOverlay={true}
+        />,
+      );
+
+      act(() => {
+        mockMessageView.mock.calls.at(-1)?.[0]?.onRequestFullscreen("call-1");
+      });
+
+      expect(screen.getByTestId("fullscreen-chat-overlay")).toBeInTheDocument();
+
+      act(() => {
+        mockMessageView.mock.calls.at(-1)?.[0]?.onExitFullscreen("surface-1");
+      });
+
+      expect(
+        screen.queryByTestId("fullscreen-chat-overlay"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("tears down every registered tool call for a persistent surface", () => {
+      useWidgetSurfaceStore.setState({
+        surfaces: new Map([
+          [
+            "surface-1",
+            {
+              surfaceId: "surface-1",
+              chatSessionId: "other-chat",
+              initialToolCallId: "call-1",
+              latestToolCallId: "call-2",
+              registrations: new Map([
+                [
+                  "call-1",
+                  {
+                    toolCallId: "call-1",
+                    order: 0,
+                    props: {} as any,
+                    anchorElement: null,
+                  },
+                ],
+                [
+                  "call-2",
+                  {
+                    toolCallId: "call-2",
+                    order: 1,
+                    props: {} as any,
+                    anchorElement: null,
+                  },
+                ],
+              ]),
+            },
+          ],
+        ]),
+      });
+      const messages = [createMessage({ id: "msg-1", role: "assistant" })];
+
+      render(
+        <Thread
+          {...defaultProps}
+          chatSessionId="chat-1"
+          messages={messages}
+        />,
+      );
+
+      act(() => {
+        mockMessageView.mock.calls
+          .at(-1)?.[0]
+          ?.onRequestTeardown("call-2", "surface-1");
+      });
+
+      const tornDownWidgetIds = mockMessageView.mock.calls.at(-1)?.[0]
+        ?.tornDownWidgetIds as ReadonlySet<string>;
+      expect(tornDownWidgetIds.has("call-1")).toBe(true);
+      expect(tornDownWidgetIds.has("call-2")).toBe(true);
     });
   });
 

--- a/mcpjam-inspector/client/src/components/chat-v2/fullscreen-chat-overlay.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/fullscreen-chat-overlay.tsx
@@ -2,6 +2,7 @@ import { FormEvent, KeyboardEvent, useEffect, useMemo, useRef } from "react";
 import type { CSSProperties } from "react";
 
 import type { UIMessage } from "@ai-sdk/react";
+import type { DynamicToolUIPart, ToolUIPart, UITools } from "ai";
 import { ArrowUp, ChevronDown, ChevronUp, Square } from "lucide-react";
 
 import {
@@ -21,29 +22,171 @@ import {
   useResolvedHostStyleForIndicator,
 } from "@/components/chat-v2/shared/loading-indicator-content";
 import { ClaudeLoadingIndicator } from "@/lib/client-styles/indicators/claude-mark";
-import { getRenderableConversationMessages } from "@/components/chat-v2/thread/thread-helpers";
+import {
+  type AnyPart,
+  getRenderableConversationMessages,
+  getToolInfo,
+  isDataPart,
+  isDynamicTool,
+  isToolPart,
+} from "@/components/chat-v2/thread/thread-helpers";
+import { ToolPart } from "@/components/chat-v2/thread/parts/tool-part";
+import { TextPart } from "@/components/chat-v2/thread/parts/text-part";
 
-function getMessagePreviewText(message: UIMessage): string {
-  const parts = Array.isArray(message?.parts) ? message.parts : [];
-  const texts = parts
-    .map((part: any) => {
-      if (!part || typeof part !== "object") return "";
-      if (part.type === "text" && typeof part.text === "string")
-        return part.text;
-      if ("text" in part && typeof part.text === "string") return part.text;
-      return "";
-    })
-    .filter(Boolean);
+function extractTextFromUnknown(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  if (Array.isArray(value)) {
+    return value.map(extractTextFromUnknown).filter(Boolean).join("\n").trim();
+  }
+  if (!value || typeof value !== "object") return "";
 
-  if (texts.length > 0) return texts.join("\n").trim();
-  if (typeof (message as any)?.content === "string")
-    return ((message as any).content as string).trim();
+  const record = value as Record<string, unknown>;
+  if (typeof record.text === "string") return record.text.trim();
+  if (Array.isArray(record.content)) {
+    return extractTextFromUnknown(record.content);
+  }
+  if (record.value !== undefined) {
+    return extractTextFromUnknown(record.value);
+  }
   return "";
+}
+
+function getNonToolPartPreview(part: AnyPart): string {
+  if (isDataPart(part)) {
+    return extractTextFromUnknown((part as { data?: unknown }).data);
+  }
+
+  if (
+    part.type === "reasoning" &&
+    typeof (part as { text?: unknown }).text === "string" &&
+    (part as { text: string }).text.trim() !== "[REDACTED]"
+  ) {
+    return "Reasoning...";
+  }
+
+  return "";
+}
+
+function getLegacyMessageContentText(message: UIMessage): string {
+  const content = (message as unknown as { content?: unknown }).content;
+  if (typeof content !== "string") {
+    return "";
+  }
+
+  return content.trim();
+}
+
+function getTextPartPreview(part: AnyPart): string {
+  if (!part || typeof part !== "object") return "";
+  if (part.type !== "text") return "";
+  if (typeof (part as { text?: unknown }).text !== "string") return "";
+  return (part as { text: string }).text.trim();
+}
+
+type FullscreenToolPart = ToolUIPart<UITools> | DynamicToolUIPart;
+
+type FullscreenMessageEntry =
+  | {
+      kind: "bubble";
+      key: string;
+      message: UIMessage;
+      text: string;
+    }
+  | {
+      kind: "tool";
+      key: string;
+      message: UIMessage;
+      part: FullscreenToolPart;
+    };
+
+function getSerializableLength(value: unknown): number {
+  if (value === undefined || value === null) return 0;
+  try {
+    return JSON.stringify(value)?.length ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+function getToolEntrySignature(part: FullscreenToolPart): string {
+  const toolInfo = getToolInfo(part);
+  return [
+    toolInfo.toolCallId ?? "",
+    toolInfo.toolName,
+    toolInfo.toolState ?? "",
+    getSerializableLength(toolInfo.input),
+    getSerializableLength(toolInfo.rawOutput),
+    toolInfo.errorText?.length ?? 0,
+  ].join(":");
+}
+
+function getMessageEntries(message: UIMessage): FullscreenMessageEntry[] {
+  const parts = Array.isArray(message?.parts) ? message.parts : [];
+  const entries: FullscreenMessageEntry[] = [];
+  const hasTextPart = parts.some((part) => getTextPartPreview(part).length > 0);
+  const legacyContentText = hasTextPart
+    ? ""
+    : getLegacyMessageContentText(message);
+
+  if (legacyContentText) {
+    entries.push({
+      kind: "bubble",
+      key: `${message.id ?? message.role}:legacy-content`,
+      message,
+      text: legacyContentText,
+    });
+  }
+
+  parts.forEach((part, partIndex) => {
+    const text = getTextPartPreview(part);
+    if (text) {
+      entries.push({
+        kind: "bubble",
+        key: `${message.id ?? message.role}:text:${partIndex}`,
+        message,
+        text,
+      });
+      return;
+    }
+
+    if (isToolPart(part) || isDynamicTool(part)) {
+      const toolInfo = getToolInfo(part);
+      entries.push({
+        kind: "tool",
+        key: `${message.id ?? message.role}:tool:${
+          toolInfo.toolCallId ?? toolInfo.toolName
+        }:${partIndex}`,
+        message,
+        part,
+      });
+      return;
+    }
+
+    const fallbackText = getNonToolPartPreview(part);
+    if (fallbackText) {
+      entries.push({
+        kind: "bubble",
+        key: `${message.id ?? message.role}:fallback:${partIndex}`,
+        message,
+        text: fallbackText,
+      });
+    }
+  });
+
+  return entries;
+}
+
+function getVisibleMessageEntries(
+  messages: UIMessage[]
+): FullscreenMessageEntry[] {
+  return getRenderableConversationMessages(messages).flatMap((message) =>
+    getMessageEntries(message)
+  );
 }
 
 function getFullscreenChatAppearance(
   chatboxHostStyle: ChatboxHostStyle | null,
-  isDarkChatboxTheme: boolean,
+  isDarkChatboxTheme: boolean
 ) {
   const hostFamily = getChatboxHostFamily(chatboxHostStyle);
   return {
@@ -53,46 +196,46 @@ function getFullscreenChatAppearance(
             "chatbox-host-composer rounded-[1.75rem]",
             isDarkChatboxTheme
               ? "border border-white/10 shadow-[0_1px_2px_rgba(0,0,0,0.28),0_4px_24px_rgba(130,130,130,0.14)]"
-              : "border border-neutral-200/90 shadow-[0_1px_2px_rgba(0,0,0,0.04),0_4px_22px_rgba(100,100,100,0.08)]",
+              : "border border-neutral-200/90 shadow-[0_1px_2px_rgba(0,0,0,0.04),0_4px_22px_rgba(100,100,100,0.08)]"
           )
         : hostFamily === "claude"
-          ? cn(
-              "chatbox-host-composer rounded-[1.35rem]",
-              isDarkChatboxTheme
-                ? "border-[#4b463d] shadow-[0_1px_2px_rgba(0,0,0,0.28),0_4px_22px_rgba(120,120,120,0.12)]"
-                : "border border-[#DFDFDB] shadow-[0_1px_2px_rgba(0,0,0,0.05),0_4px_20px_rgba(110,110,110,0.08)]",
-            )
-          : "rounded-full border border-border/40 bg-background/95 backdrop-blur-xl",
+        ? cn(
+            "chatbox-host-composer rounded-[1.35rem]",
+            isDarkChatboxTheme
+              ? "border-[#4b463d] shadow-[0_1px_2px_rgba(0,0,0,0.28),0_4px_22px_rgba(120,120,120,0.12)]"
+              : "border border-[#DFDFDB] shadow-[0_1px_2px_rgba(0,0,0,0.05),0_4px_20px_rgba(110,110,110,0.08)]"
+          )
+        : "rounded-full border border-border/40 bg-background/95 backdrop-blur-xl",
     activeSubmitButtonClassName:
       hostFamily === "chatgpt"
         ? isDarkChatboxTheme
           ? "bg-[#f4f4f4] text-[#1f1f1f] hover:bg-[#e8e8e8]"
           : "bg-[#1f1f1f] text-white hover:bg-[#303030]"
         : hostFamily === "claude"
-          ? isDarkChatboxTheme
-            ? "bg-[#d07b53] text-[#fff7f0] hover:bg-[#c06f49]"
-            : "bg-[#e27d47] text-white hover:bg-[#d16f3d]"
-          : "bg-primary text-primary-foreground hover:bg-primary/90",
+        ? isDarkChatboxTheme
+          ? "bg-[#d07b53] text-[#fff7f0] hover:bg-[#c06f49]"
+          : "bg-[#e27d47] text-white hover:bg-[#d16f3d]"
+        : "bg-primary text-primary-foreground hover:bg-primary/90",
     inactiveSubmitButtonClassName:
       hostFamily === "chatgpt"
         ? isDarkChatboxTheme
           ? "bg-[#3a3a3a] text-[#8a8a8a] cursor-not-allowed"
           : "bg-[#e7e7e7] text-[#9b9b9b] cursor-not-allowed"
         : hostFamily === "claude"
-          ? isDarkChatboxTheme
-            ? "bg-[#45413b] text-[#8d857a] cursor-not-allowed"
-            : "bg-[#ebe5dc] text-[#b6ada0] cursor-not-allowed"
-          : "bg-muted text-muted-foreground cursor-not-allowed",
+        ? isDarkChatboxTheme
+          ? "bg-[#45413b] text-[#8d857a] cursor-not-allowed"
+          : "bg-[#ebe5dc] text-[#b6ada0] cursor-not-allowed"
+        : "bg-muted text-muted-foreground cursor-not-allowed",
   };
 }
 
 function getFullscreenSurfaceStyle(
   chatboxHostStyle: ChatboxHostStyle | null,
-  resolvedThemeMode: "light" | "dark",
+  resolvedThemeMode: "light" | "dark"
 ): CSSProperties | undefined {
   const backgroundColor = getChatboxChatBackground(
     chatboxHostStyle,
-    resolvedThemeMode,
+    resolvedThemeMode
   );
   return backgroundColor ? { backgroundColor } : undefined;
 }
@@ -118,10 +261,10 @@ function MessageBubble({
             "rounded-2xl px-3 py-2 text-sm leading-6 whitespace-pre-wrap",
             isUser
               ? "bg-primary text-primary-foreground"
-              : "bg-muted text-foreground",
+              : "bg-muted text-foreground"
           )}
         >
-          {text}
+          {isUser ? text : <TextPart text={text} role="assistant" />}
         </div>
         {showClaudeFooter ? (
           <div
@@ -136,11 +279,35 @@ function MessageBubble({
   );
 }
 
-function ThinkingRow({
-  modelProvider,
+function ToolMessageEntry({
+  part,
+  chatSessionId,
+  claudeFooterMode = "none",
 }: {
-  modelProvider?: string | null;
+  part: FullscreenToolPart;
+  chatSessionId?: string;
+  claudeFooterMode?: "none" | "animated" | "static";
 }) {
+  const showClaudeFooter = claudeFooterMode !== "none";
+
+  return (
+    <div className="flex w-full justify-start">
+      <div className={cn("w-full", showClaudeFooter && "space-y-3")}>
+        <ToolPart part={part} chatSessionId={chatSessionId} />
+        {showClaudeFooter ? (
+          <div
+            data-testid={`fullscreen-claude-footer-${claudeFooterMode}`}
+            className="pl-1"
+          >
+            <ClaudeLoadingIndicator mode={claudeFooterMode} />
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ThinkingRow({ modelProvider }: { modelProvider?: string | null }) {
   // Branded indicators (Claude / ChatGPT) render bare so the brand art
   // owns the spacing; the generic "Thinking…" text gets the muted bubble.
   const hasBrandIndicator =
@@ -178,7 +345,7 @@ function ToggleButton({
         open ? "-top-11" : "-top-9",
         "inline-flex h-8 w-8 items-center justify-center rounded-full",
         "border border-border/40 bg-background/95 shadow-sm backdrop-blur-md",
-        "text-muted-foreground hover:text-foreground hover:bg-background hover:border-border/60",
+        "text-muted-foreground hover:text-foreground hover:bg-background hover:border-border/60"
       )}
       onClick={onToggle}
     >
@@ -196,11 +363,13 @@ function MessageList({
   isThinking,
   open,
   modelProvider,
+  chatSessionId,
 }: {
   messages: UIMessage[];
   isThinking: boolean;
   open: boolean;
   modelProvider?: string | null;
+  chatSessionId?: string;
 }) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const resolvedIndicatorHostStyle =
@@ -213,17 +382,18 @@ function MessageList({
   const isClaudeFamily =
     getChatboxHostFamily(resolvedIndicatorHostStyle) === "claude";
 
-  const visibleMessages = useMemo(
-    () =>
-      getRenderableConversationMessages(messages)
-        .map((message) => ({
-          message,
-          text: getMessagePreviewText(message),
-        }))
-        .filter((entry) => entry.text.length > 0),
-    [messages],
-  );
-  const lastVisibleMessage = visibleMessages.at(-1)?.message ?? null;
+  const visibleEntries = getVisibleMessageEntries(messages);
+  const visibleMessageScrollKey = visibleEntries
+    .map((entry) =>
+      entry.kind === "tool"
+        ? `${entry.key}:${entry.message.role}:${getToolEntrySignature(
+            entry.part
+          )}`
+        : `${entry.key}:${entry.message.role}:${entry.text.length}`
+    )
+    .join("|");
+  const lastVisibleEntry = visibleEntries.at(-1) ?? null;
+  const lastVisibleMessage = lastVisibleEntry?.message ?? null;
   const hasVisibleAssistantResponse = lastVisibleMessage?.role === "assistant";
   const shouldShowStandaloneThinkingRow = hasBrandIndicator
     ? isThinking && !hasVisibleAssistantResponse
@@ -232,26 +402,34 @@ function MessageList({
   useEffect(() => {
     if (!open) return;
     bottomRef.current?.scrollIntoView({ block: "end" });
-  }, [open, visibleMessages.length, isThinking]);
+  }, [open, visibleMessageScrollKey, isThinking]);
 
   if (!open) return null;
 
   return (
     <div className="mb-4 overflow-hidden rounded-3xl border border-border/40 bg-background/95 shadow-2xl backdrop-blur-xl">
       <div className="max-h-[45vh] overflow-y-auto px-4 py-3 space-y-3">
-        {visibleMessages.map(({ message, text }, idx) => {
+        {visibleEntries.map((entry) => {
+          const message = entry.message;
           const claudeFooterMode =
             isClaudeFamily &&
             message.role === "assistant" &&
-            message.id === lastVisibleMessage?.id
+            entry.key === lastVisibleEntry?.key
               ? isThinking
                 ? "animated"
                 : "static"
               : "none";
-          return (
+          return entry.kind === "tool" ? (
+            <ToolMessageEntry
+              key={entry.key}
+              part={entry.part}
+              chatSessionId={chatSessionId}
+              claudeFooterMode={claudeFooterMode}
+            />
+          ) : (
             <MessageBubble
-              key={message.id ?? `${message.role}-${idx}`}
-              text={text}
+              key={entry.key}
+              text={entry.text}
               isUser={message.role === "user"}
               claudeFooterMode={claudeFooterMode}
             />
@@ -331,7 +509,7 @@ function Composer({
           className={cn(
             "w-full resize-none border-none bg-transparent dark:bg-transparent px-0 py-0 min-h-0 text-sm leading-tight",
             "placeholder:text-muted-foreground/60 shadow-none",
-            "focus-visible:ring-0 focus-visible:outline-none focus-visible:border-none",
+            "focus-visible:ring-0 focus-visible:outline-none focus-visible:border-none"
           )}
         />
         {isThinking ? (
@@ -344,7 +522,7 @@ function Composer({
               onStop
                 ? activeSubmitButtonClassName
                 : inactiveSubmitButtonClassName,
-              onStop && "hover:scale-105",
+              onStop && "hover:scale-105"
             )}
             disabled={!onStop}
             onClick={() => onStop?.()}
@@ -361,7 +539,7 @@ function Composer({
               canSend
                 ? activeSubmitButtonClassName
                 : inactiveSubmitButtonClassName,
-              canSend && "hover:scale-105",
+              canSend && "hover:scale-105"
             )}
             disabled={!canSend}
           >
@@ -374,6 +552,7 @@ function Composer({
 }
 
 type FullscreenChatOverlayProps = {
+  chatSessionId?: string;
   messages: UIMessage[];
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -390,6 +569,7 @@ type FullscreenChatOverlayProps = {
   modelProvider?: string | null;
 };
 export function FullscreenChatOverlay({
+  chatSessionId,
   messages,
   open,
   onOpenChange,
@@ -409,11 +589,11 @@ export function FullscreenChatOverlay({
   const isDarkChatboxTheme = resolvedThemeMode === "dark";
   const appearance = useMemo(
     () => getFullscreenChatAppearance(chatboxHostStyle, isDarkChatboxTheme),
-    [chatboxHostStyle, isDarkChatboxTheme],
+    [chatboxHostStyle, isDarkChatboxTheme]
   );
   const surfaceStyle = useMemo(
     () => getFullscreenSurfaceStyle(chatboxHostStyle, resolvedThemeMode),
-    [chatboxHostStyle, resolvedThemeMode],
+    [chatboxHostStyle, resolvedThemeMode]
   );
 
   return (
@@ -429,6 +609,7 @@ export function FullscreenChatOverlay({
             isThinking={isThinking}
             open={open}
             modelProvider={modelProvider}
+            chatSessionId={chatSessionId}
           />
           <Composer
             value={input}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
@@ -168,12 +168,16 @@ export function Thread({
         current !== null &&
         (current === toolCallId || current === displayWidgetId);
       setPipWidgetId((current) => (matchesOwnership(current) ? null : current));
-      setFullscreenWidgetId((current) => {
-        if (!matchesOwnership(current)) return current;
+      // Keep the updater pure (StrictMode double-invokes); fire the
+      // fullscreen callback once, outside, based on the same ownership check.
+      const clearedFullscreen = matchesOwnership(fullscreenWidgetId);
+      setFullscreenWidgetId((current) =>
+        matchesOwnership(current) ? null : current
+      );
+      if (clearedFullscreen) {
         onFullscreenChange?.(false);
-        return null;
-      });
-      if (matchesOwnership(pipWidgetId) || matchesOwnership(fullscreenWidgetId)) {
+      }
+      if (matchesOwnership(pipWidgetId) || clearedFullscreen) {
         onDisplayModeChange?.("inline");
       }
     },

--- a/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
@@ -31,6 +31,10 @@ import {
   getLastRenderableConversationMessage,
   hasRenderableConversationContent,
 } from "./thread/thread-helpers";
+import {
+  WidgetSurfaceHost,
+  WidgetSurfaceHostProvider,
+} from "./thread/mcp-apps/widget-surface-host";
 
 interface ThreadProps {
   chatSessionId?: string;
@@ -219,89 +223,93 @@ export function Thread({
     : undefined;
 
   return (
-    <div
-      className={cn(
-        "flex-1 min-h-0 min-w-0 pb-4",
-        isChatgptDark && "text-[#DFDFDF]"
-      )}
-      style={
-        chatgptFamilyDarkBackground
-          ? { backgroundColor: chatgptFamilyDarkBackground }
-          : undefined
-      }
-    >
-      {/* Fixed spacer to reserve space for PIP widget */}
-      {pipWidgetId && (
-        <div className="h-[480px] flex-shrink-0 pointer-events-none" />
-      )}
-      <TranscriptThread
-        chatSessionId={chatSessionId}
-        messages={messages}
-        model={model}
-        sendFollowUpMessage={sendFollowUpMessage}
-        toolsMetadata={toolsMetadata}
-        toolServerMap={toolServerMap}
-        onWidgetStateChange={onWidgetStateChange}
-        onModelContextUpdate={onModelContextUpdate}
-        pipWidgetId={pipWidgetId}
-        fullscreenWidgetId={fullscreenWidgetId}
-        onRequestPip={handleRequestPip}
-        onExitPip={handleExitPip}
-        onRequestFullscreen={handleRequestFullscreen}
-        onExitFullscreen={handleExitFullscreen}
-        onRequestTeardown={handleRequestTeardown}
-        tornDownWidgetIds={tornDownWidgetIds}
-        displayMode={displayMode}
-        onDisplayModeChange={onDisplayModeChange}
-        onToolApprovalResponse={onToolApprovalResponse}
-        toolRenderOverrides={toolRenderOverrides}
-        showSaveViewButton={showSaveViewButton}
-        minimalMode={minimalMode}
-        interactive={interactive}
-        reasoningDisplayMode={reasoningDisplayMode}
-        focusMessageId={focusMessageId}
-        highlightedMessageIds={highlightedMessageIds}
-        navigationKey={navigationKey}
-        viewportRef={viewportRef}
-        isLoading={isLoading}
-        lastRenderableMessageId={lastRenderableMessageId}
-        contentClassName={
-          contentClassName ??
-          "min-w-0 w-full max-w-4xl mx-auto px-4 pt-8 pb-16 space-y-8"
+    <WidgetSurfaceHostProvider>
+      <div
+        className={cn(
+          "flex-1 min-h-0 min-w-0 pb-4",
+          isChatgptDark && "text-[#DFDFDF]"
+        )}
+        style={
+          chatgptFamilyDarkBackground
+            ? { backgroundColor: chatgptFamilyDarkBackground }
+            : undefined
         }
-        getMessageWrapperProps={getMessageWrapperProps}
-        renderUserMessageActions={renderUserMessageActions}
-        showSenderAvatars={showSenderAvatars}
-        resolveSenderAvatar={resolveSenderAvatar}
-      />
-      {shouldShowStandaloneThinkingIndicator && (
-        <div className="min-w-0 w-full max-w-4xl mx-auto px-4">
-          <ThinkingIndicator model={model} />
-        </div>
-      )}
-
-      {showFullscreenChatOverlay && (
-        <FullscreenChatOverlay
+      >
+        {/* Fixed spacer to reserve space for PIP widget */}
+        {pipWidgetId && (
+          <div className="h-[480px] flex-shrink-0 pointer-events-none" />
+        )}
+        <TranscriptThread
+          chatSessionId={chatSessionId}
           messages={messages}
-          modelProvider={model.provider}
-          open={isFullscreenChatOpen}
-          onOpenChange={setIsFullscreenChatOpen}
-          input={fullscreenChatInput}
-          onInputChange={setFullscreenChatInput}
-          placeholder={fullscreenChatPlaceholder}
-          disabled={fullscreenChatDisabled}
-          canSend={canSendFullscreenChat}
-          isThinking={isLoading}
-          onStop={onFullscreenChatStop}
-          onSend={() => {
-            if (!canSendFullscreenChat) return;
-            const text = fullscreenChatInput;
-            setIsFullscreenChatOpen(true);
-            setFullscreenChatInput("");
-            sendFollowUpMessage(text);
-          }}
+          model={model}
+          sendFollowUpMessage={sendFollowUpMessage}
+          toolsMetadata={toolsMetadata}
+          toolServerMap={toolServerMap}
+          onWidgetStateChange={onWidgetStateChange}
+          onModelContextUpdate={onModelContextUpdate}
+          pipWidgetId={pipWidgetId}
+          fullscreenWidgetId={fullscreenWidgetId}
+          onRequestPip={handleRequestPip}
+          onExitPip={handleExitPip}
+          onRequestFullscreen={handleRequestFullscreen}
+          onExitFullscreen={handleExitFullscreen}
+          onRequestTeardown={handleRequestTeardown}
+          tornDownWidgetIds={tornDownWidgetIds}
+          displayMode={displayMode}
+          onDisplayModeChange={onDisplayModeChange}
+          onToolApprovalResponse={onToolApprovalResponse}
+          toolRenderOverrides={toolRenderOverrides}
+          showSaveViewButton={showSaveViewButton}
+          minimalMode={minimalMode}
+          interactive={interactive}
+          reasoningDisplayMode={reasoningDisplayMode}
+          focusMessageId={focusMessageId}
+          highlightedMessageIds={highlightedMessageIds}
+          navigationKey={navigationKey}
+          viewportRef={viewportRef}
+          isLoading={isLoading}
+          lastRenderableMessageId={lastRenderableMessageId}
+          contentClassName={
+            contentClassName ??
+            "min-w-0 w-full max-w-4xl mx-auto px-4 pt-8 pb-16 space-y-8"
+          }
+          getMessageWrapperProps={getMessageWrapperProps}
+          renderUserMessageActions={renderUserMessageActions}
+          showSenderAvatars={showSenderAvatars}
+          resolveSenderAvatar={resolveSenderAvatar}
         />
-      )}
-    </div>
+        <WidgetSurfaceHost chatSessionId={chatSessionId} />
+
+        {shouldShowStandaloneThinkingIndicator && (
+          <div className="min-w-0 w-full max-w-4xl mx-auto px-4">
+            <ThinkingIndicator model={model} />
+          </div>
+        )}
+
+        {showFullscreenChatOverlay && (
+          <FullscreenChatOverlay
+            messages={messages}
+            modelProvider={model.provider}
+            open={isFullscreenChatOpen}
+            onOpenChange={setIsFullscreenChatOpen}
+            input={fullscreenChatInput}
+            onInputChange={setFullscreenChatInput}
+            placeholder={fullscreenChatPlaceholder}
+            disabled={fullscreenChatDisabled}
+            canSend={canSendFullscreenChat}
+            isThinking={isLoading}
+            onStop={onFullscreenChatStop}
+            onSend={() => {
+              if (!canSendFullscreenChat) return;
+              const text = fullscreenChatInput;
+              setIsFullscreenChatOpen(true);
+              setFullscreenChatInput("");
+              sendFollowUpMessage(text);
+            }}
+          />
+        )}
+      </div>
+    </WidgetSurfaceHostProvider>
   );
 }

--- a/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
@@ -35,6 +35,7 @@ import {
   WidgetSurfaceHost,
   WidgetSurfaceHostProvider,
 } from "./thread/mcp-apps/widget-surface-host";
+import { useWidgetSurfaceStore } from "./thread/mcp-apps/widget-surface-store";
 
 interface ThreadProps {
   chatSessionId?: string;
@@ -86,6 +87,22 @@ interface ThreadProps {
   resolveSenderAvatar?: TranscriptThreadProps["resolveSenderAvatar"];
 }
 
+function getWidgetOwnershipIds(toolCallId: string, displayWidgetId?: string) {
+  const ids = new Set<string>([toolCallId]);
+  if (displayWidgetId) ids.add(displayWidgetId);
+
+  const surfaces = useWidgetSurfaceStore.getState().surfaces;
+  const surface =
+    surfaces.get(displayWidgetId ?? "") ?? surfaces.get(toolCallId);
+  if (surface) {
+    for (const registeredToolCallId of surface.registrations.keys()) {
+      ids.add(registeredToolCallId);
+    }
+  }
+
+  return ids;
+}
+
 export function Thread({
   chatSessionId,
   messages,
@@ -135,7 +152,8 @@ export function Thread({
   };
 
   const handleExitPip = (toolCallId: string) => {
-    if (pipWidgetId === toolCallId) {
+    const ownershipIds = getWidgetOwnershipIds(toolCallId);
+    if (pipWidgetId !== null && ownershipIds.has(pipWidgetId)) {
       setPipWidgetId(null);
     }
   };
@@ -146,7 +164,8 @@ export function Thread({
   };
 
   const handleExitFullscreen = (toolCallId: string) => {
-    if (fullscreenWidgetId === toolCallId) {
+    const ownershipIds = getWidgetOwnershipIds(toolCallId);
+    if (fullscreenWidgetId !== null && ownershipIds.has(fullscreenWidgetId)) {
       setFullscreenWidgetId(null);
       onFullscreenChange?.(false);
     }
@@ -154,19 +173,25 @@ export function Thread({
 
   const handleRequestTeardown = useCallback(
     (toolCallId: string, displayWidgetId?: string) => {
+      const ownershipIds = getWidgetOwnershipIds(toolCallId, displayWidgetId);
       setTornDownWidgetIds((prev) => {
-        if (prev.has(toolCallId)) return prev;
-        return new Set(prev).add(toolCallId);
+        let changed = false;
+        const next = new Set(prev);
+        for (const id of ownershipIds) {
+          if (next.has(id)) continue;
+          next.add(id);
+          changed = true;
+        }
+        return changed ? next : prev;
       });
       // Mirror `handleExitPip` / `handleExitFullscreen`: if the widget that
       // asked for teardown was the one currently in PIP or fullscreen, clear
       // that state too. Persistent surfaces claim fullscreen/PiP under
       // `displayWidgetId` (the surface id), but `tornDownWidgetIds` is keyed
-      // by `toolCallId` — accept either so the overlay/spacer doesn't get
-      // stuck after a persistent surface tears itself down.
+      // by tool-call ids — expand the surface to all active registrations so
+      // the old row cannot keep the shared iframe alive after teardown.
       const matchesOwnership = (current: string | null) =>
-        current !== null &&
-        (current === toolCallId || current === displayWidgetId);
+        current !== null && ownershipIds.has(current);
       setPipWidgetId((current) => (matchesOwnership(current) ? null : current));
       // Keep the updater pure (StrictMode double-invokes); fire the
       // fullscreen callback once, outside, based on the same ownership check.

--- a/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
@@ -153,24 +153,27 @@ export function Thread({
   };
 
   const handleRequestTeardown = useCallback(
-    (toolCallId: string) => {
+    (toolCallId: string, displayWidgetId?: string) => {
       setTornDownWidgetIds((prev) => {
         if (prev.has(toolCallId)) return prev;
         return new Set(prev).add(toolCallId);
       });
-      // Mirror `handleExitPip` / `handleExitFullscreen`: if the
-      // widget that asked for teardown was the one currently in PIP
-      // or fullscreen, clear that state too. Without this the iframe
-      // is gone but the parent still reserves the PIP spacer / keeps
-      // the fullscreen overlay open / reports fullscreen=true to
-      // `onFullscreenChange`.
-      setPipWidgetId((current) => (current === toolCallId ? null : current));
+      // Mirror `handleExitPip` / `handleExitFullscreen`: if the widget that
+      // asked for teardown was the one currently in PIP or fullscreen, clear
+      // that state too. Persistent surfaces claim fullscreen/PiP under
+      // `displayWidgetId` (the surface id), but `tornDownWidgetIds` is keyed
+      // by `toolCallId` — accept either so the overlay/spacer doesn't get
+      // stuck after a persistent surface tears itself down.
+      const matchesOwnership = (current: string | null) =>
+        current !== null &&
+        (current === toolCallId || current === displayWidgetId);
+      setPipWidgetId((current) => (matchesOwnership(current) ? null : current));
       setFullscreenWidgetId((current) => {
-        if (current !== toolCallId) return current;
+        if (!matchesOwnership(current)) return current;
         onFullscreenChange?.(false);
         return null;
       });
-      if (pipWidgetId === toolCallId || fullscreenWidgetId === toolCallId) {
+      if (matchesOwnership(pipWidgetId) || matchesOwnership(fullscreenWidgetId)) {
         onDisplayModeChange?.("inline");
       }
     },

--- a/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread.tsx
@@ -296,6 +296,7 @@ export function Thread({
 
         {showFullscreenChatOverlay && (
           <FullscreenChatOverlay
+            chatSessionId={chatSessionId}
             messages={messages}
             modelProvider={model.provider}
             open={isFullscreenChatOpen}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -352,6 +352,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     appBridgeArgsRef.current = null;
     useWidgetSurfaceStore.setState({
       surfaces: new Map(),
+      nextOrder: 0,
     });
 
     vi.mocked(global.fetch).mockResolvedValue({
@@ -517,30 +518,63 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(sandboxedIframeUnmountsRef.current).toBe(0);
   });
 
-  it("creates a fresh persistent surface for a new tool call to the same widget", async () => {
-    render(
+  it("shares one persistent surface across tool calls to the same widget", async () => {
+    const firstOutput = { content: [{ type: "text" as const, text: "first" }] };
+    const secondOutput = {
+      content: [{ type: "text" as const, text: "second" }],
+    };
+    const renderTree = (includeSecondCall: boolean) => (
       <WidgetSurfaceHostProvider>
-        <MCPAppsRenderer {...baseProps} toolCallId="call-1" />
         <MCPAppsRenderer
           {...baseProps}
-          toolCallId="call-2"
-          toolOutput={{ content: [{ type: "text" as const, text: "next" }] }}
+          toolCallId="call-1"
+          toolInput={{ move: "e4" }}
+          toolOutput={firstOutput}
         />
+        {includeSecondCall ? (
+          <MCPAppsRenderer
+            {...baseProps}
+            toolCallId="call-2"
+            toolInput={{ move: "c5" }}
+            toolOutput={secondOutput}
+          />
+        ) : null}
         <WidgetSurfaceHost />
       </WidgetSurfaceHostProvider>
     );
 
+    const { rerender } = render(renderTree(false));
+
     await vi.waitFor(() => {
-      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(2);
-      expect(screen.getAllByTestId("sandboxed-iframe")).toHaveLength(2);
+      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("sandboxed-iframe")).toBeInTheDocument();
     });
 
+    act(() => triggerReady());
+
+    await vi.waitFor(() => {
+      expect(mockBridge.sendToolInput).toHaveBeenCalledTimes(1);
+      expect(mockBridge.sendToolInput).toHaveBeenCalledWith({
+        arguments: { move: "e4" },
+      });
+      expect(mockBridge.sendToolResult).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(renderTree(true));
+
+    await vi.waitFor(() => {
+      expect(mockBridge.sendToolResult).toHaveBeenCalledTimes(2);
+      expect(mockBridge.sendToolResult).toHaveBeenLastCalledWith(secondOutput);
+    });
+
+    expect(mockBridge.sendToolInput).toHaveBeenCalledTimes(1);
     expect(mockBridge.close).not.toHaveBeenCalled();
     expect(mockBridge.teardownResource).not.toHaveBeenCalled();
-    expect(sandboxedIframeMountsRef.current).toBe(2);
+    expect(sandboxedIframeMountsRef.current).toBe(1);
+    expect(sandboxedIframeUnmountsRef.current).toBe(0);
   });
 
-  it("keeps live-preferred cached tool calls isolated per tool call", async () => {
+  it("keeps live-preferred cached tool calls on one persistent resource surface", async () => {
     render(
       <WidgetSurfaceHostProvider>
         <MCPAppsRenderer
@@ -561,15 +595,52 @@ describe("MCPAppsRenderer tool input streaming", () => {
     );
 
     await vi.waitFor(() => {
-      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(2);
-      expect(screen.getAllByTestId("sandboxed-iframe")).toHaveLength(2);
+      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("sandboxed-iframe")).toBeInTheDocument();
     });
 
-    expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(1);
     expect(vi.mocked(global.fetch)).not.toHaveBeenCalledWith("blob:cached");
     expect(mockBridge.close).not.toHaveBeenCalled();
     expect(mockBridge.teardownResource).not.toHaveBeenCalled();
-    expect(sandboxedIframeMountsRef.current).toBe(2);
+    expect(sandboxedIframeMountsRef.current).toBe(1);
+    expect(sandboxedIframeUnmountsRef.current).toBe(0);
+  });
+
+  it("sends identical persistent surface results for different tool calls", async () => {
+    const sameOutput = { content: [{ type: "text" as const, text: "same" }] };
+    const renderTree = (toolCallId: string) => (
+      <WidgetSurfaceHostProvider>
+        <MCPAppsRenderer
+          {...baseProps}
+          toolCallId={toolCallId}
+          toolOutput={sameOutput}
+        />
+        <WidgetSurfaceHost />
+      </WidgetSurfaceHostProvider>
+    );
+
+    const { rerender } = render(renderTree("call-1"));
+
+    await vi.waitFor(() => {
+      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => triggerReady());
+
+    await vi.waitFor(() => {
+      expect(mockBridge.sendToolResult).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(renderTree("call-2"));
+
+    await vi.waitFor(() => {
+      expect(mockBridge.sendToolResult).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockBridge.sendToolResult).toHaveBeenLastCalledWith(sameOutput);
+    expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
+    expect(sandboxedIframeMountsRef.current).toBe(1);
     expect(sandboxedIframeUnmountsRef.current).toBe(0);
   });
 
@@ -607,7 +678,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(sandboxedIframeUnmountsRef.current).toBe(0);
   });
 
-  it("keeps fullscreen ownership for a persistent tool-call surface", async () => {
+  it("keeps fullscreen ownership for a persistent resource surface", async () => {
     render(
       <WidgetSurfaceHostProvider>
         <MCPAppsRenderer

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -249,6 +249,11 @@ vi.mock("../mcp-apps-modal", () => ({
 
 // ── Import component under test (after mocks) ─────────────────────────────
 import { MCPAppsRenderer } from "../mcp-apps-renderer";
+import {
+  WidgetSurfaceHost,
+  WidgetSurfaceHostProvider,
+} from "../widget-surface-host";
+import { useWidgetSurfaceStore } from "../widget-surface-store";
 import { authFetch } from "@/lib/session-token";
 import {
   ChatboxHostStyleProvider,
@@ -270,6 +275,33 @@ const baseProps = {
   toolOutput: { content: [{ type: "text" as const, text: "ok" }] },
   resourceUri: "mcp-app://test",
 };
+
+const createEquivalentMcpProfile = (): HostConfigMcpProfileV1 => ({
+  profileVersion: 1,
+  apps: {
+    sandbox: {
+      csp: {
+        mode: "declared",
+        restrictTo: {
+          connectDomains: ["https://api.example.com"],
+          resourceDomains: ["https://cdn.example.com"],
+        },
+      },
+      permissions: {
+        mode: "custom",
+        allow: { camera: true },
+      },
+      sandboxAttrs: ["allow-popups"],
+      allowFeatures: { fullscreen: "*" },
+    },
+    uiInitialize: {
+      hostInfo: {
+        name: "test-host",
+        version: "1.0.0",
+      },
+    },
+  },
+});
 
 // ── Tests ──────────────────────────────────────────────────────────────────
 describe("MCPAppsRenderer tool input streaming", () => {
@@ -318,6 +350,9 @@ describe("MCPAppsRenderer tool input streaming", () => {
     sandboxedIframeUnmountsRef.current = 0;
     sandboxProxyBehaviorRef.current.autoReady = true;
     appBridgeArgsRef.current = null;
+    useWidgetSurfaceStore.setState({
+      surfaces: new Map(),
+    });
 
     vi.mocked(global.fetch).mockResolvedValue({
       ok: true,
@@ -389,6 +424,212 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(appBridgeArgsRef.current?.hostCapabilities).toEqual(
       expect.objectContaining(getHostCapabilitiesForStyle("claude"))
     );
+  });
+
+  it("keeps the iframe and bridge alive when only the tool call id changes", async () => {
+    const { rerender } = render(<MCPAppsRenderer {...baseProps} />);
+
+    await vi.waitFor(() => {
+      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("sandboxed-iframe")).toBeInTheDocument();
+    });
+
+    expect(sandboxedIframeMountsRef.current).toBe(1);
+
+    act(() => triggerReady());
+
+    rerender(
+      <MCPAppsRenderer
+        {...baseProps}
+        toolCallId="call-2"
+        toolOutput={{ content: [{ type: "text" as const, text: "next" }] }}
+      />
+    );
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("sandboxed-iframe")).toBeInTheDocument();
+    });
+
+    expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
+    expect(mockBridge.close).not.toHaveBeenCalled();
+    expect(mockBridge.teardownResource).not.toHaveBeenCalled();
+    expect(sandboxedIframeMountsRef.current).toBe(1);
+    expect(sandboxedIframeUnmountsRef.current).toBe(0);
+  });
+
+  it("does not rebuild when the active MCP profile is recreated without semantic changes", async () => {
+    const renderTree = () => (
+      <ActiveMcpProfileProvider value={createEquivalentMcpProfile()}>
+        <MCPAppsRenderer {...baseProps} />
+      </ActiveMcpProfileProvider>
+    );
+
+    const { rerender } = render(renderTree());
+
+    await vi.waitFor(() => {
+      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("sandboxed-iframe")).toBeInTheDocument();
+    });
+
+    act(() => triggerReady());
+
+    rerender(renderTree());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
+    expect(mockBridge.close).not.toHaveBeenCalled();
+    expect(mockBridge.teardownResource).not.toHaveBeenCalled();
+    expect(sandboxedIframeMountsRef.current).toBe(1);
+    expect(sandboxedIframeUnmountsRef.current).toBe(0);
+  });
+
+  it("does not rebuild when the host capabilities override is recreated without semantic changes", async () => {
+    const renderTree = () => (
+      <ChatboxHostCapabilitiesOverrideProvider
+        value={{ openLinks: {}, logging: {}, serverTools: {} }}
+      >
+        <MCPAppsRenderer {...baseProps} />
+      </ChatboxHostCapabilitiesOverrideProvider>
+    );
+
+    const { rerender } = render(renderTree());
+
+    await vi.waitFor(() => {
+      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("sandboxed-iframe")).toBeInTheDocument();
+    });
+
+    act(() => triggerReady());
+
+    rerender(renderTree());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
+    expect(mockBridge.close).not.toHaveBeenCalled();
+    expect(mockBridge.teardownResource).not.toHaveBeenCalled();
+    expect(sandboxedIframeMountsRef.current).toBe(1);
+    expect(sandboxedIframeUnmountsRef.current).toBe(0);
+  });
+
+  it("creates a fresh persistent surface for a new tool call to the same widget", async () => {
+    render(
+      <WidgetSurfaceHostProvider>
+        <MCPAppsRenderer {...baseProps} toolCallId="call-1" />
+        <MCPAppsRenderer
+          {...baseProps}
+          toolCallId="call-2"
+          toolOutput={{ content: [{ type: "text" as const, text: "next" }] }}
+        />
+        <WidgetSurfaceHost />
+      </WidgetSurfaceHostProvider>
+    );
+
+    await vi.waitFor(() => {
+      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(2);
+      expect(screen.getAllByTestId("sandboxed-iframe")).toHaveLength(2);
+    });
+
+    expect(mockBridge.close).not.toHaveBeenCalled();
+    expect(mockBridge.teardownResource).not.toHaveBeenCalled();
+    expect(sandboxedIframeMountsRef.current).toBe(2);
+  });
+
+  it("keeps live-preferred cached tool calls isolated per tool call", async () => {
+    render(
+      <WidgetSurfaceHostProvider>
+        <MCPAppsRenderer
+          {...baseProps}
+          toolCallId="call-1"
+          cachedWidgetHtmlUrl="blob:cached"
+          liveFetchPreferred
+        />
+        <MCPAppsRenderer
+          {...baseProps}
+          toolCallId="call-2"
+          cachedWidgetHtmlUrl="blob:cached"
+          liveFetchPreferred
+          toolOutput={{ content: [{ type: "text" as const, text: "next" }] }}
+        />
+        <WidgetSurfaceHost />
+      </WidgetSurfaceHostProvider>
+    );
+
+    await vi.waitFor(() => {
+      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(2);
+      expect(screen.getAllByTestId("sandboxed-iframe")).toHaveLength(2);
+    });
+
+    expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(global.fetch)).not.toHaveBeenCalledWith("blob:cached");
+    expect(mockBridge.close).not.toHaveBeenCalled();
+    expect(mockBridge.teardownResource).not.toHaveBeenCalled();
+    expect(sandboxedIframeMountsRef.current).toBe(2);
+    expect(sandboxedIframeUnmountsRef.current).toBe(0);
+  });
+
+  it("keeps the iframe alive when the same tool call anchor is re-keyed", async () => {
+    const renderTree = (showCall: boolean) => (
+      <WidgetSurfaceHostProvider>
+        {showCall ? (
+          <MCPAppsRenderer {...baseProps} toolCallId="call-1" />
+        ) : null}
+        <WidgetSurfaceHost />
+      </WidgetSurfaceHostProvider>
+    );
+
+    const { rerender } = render(renderTree(true));
+
+    await vi.waitFor(() => {
+      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId("sandboxed-iframe")).toBeInTheDocument();
+    });
+
+    act(() => triggerReady());
+
+    rerender(renderTree(false));
+    rerender(renderTree(true));
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+
+    expect(screen.getByTestId("sandboxed-iframe")).toBeInTheDocument();
+    expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
+    expect(mockBridge.close).not.toHaveBeenCalled();
+    expect(mockBridge.teardownResource).not.toHaveBeenCalled();
+    expect(sandboxedIframeMountsRef.current).toBe(1);
+    expect(sandboxedIframeUnmountsRef.current).toBe(0);
+  });
+
+  it("keeps fullscreen ownership for a persistent tool-call surface", async () => {
+    render(
+      <WidgetSurfaceHostProvider>
+        <MCPAppsRenderer
+          {...baseProps}
+          toolCallId="call-1"
+          displayMode="fullscreen"
+          fullscreenWidgetId="call-1"
+        />
+        <WidgetSurfaceHost />
+      </WidgetSurfaceHostProvider>
+    );
+
+    await vi.waitFor(() => {
+      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
+    });
+
+    expect(appBridgeArgsRef.current?.options?.hostContext?.displayMode).toBe(
+      "fullscreen"
+    );
+    expect(mockBridge.close).not.toHaveBeenCalled();
+    expect(mockBridge.teardownResource).not.toHaveBeenCalled();
+    expect(sandboxedIframeMountsRef.current).toBe(1);
   });
 
   it("falls back to the spec-default 'no claims' blob when no style is resolvable", async () => {
@@ -1596,6 +1837,34 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(sandboxedIframePropsRef.current?.permissive).toBe(false);
   });
 
+  it("uses the current live compat recipe for live-preferred cached revisits", async () => {
+    render(
+      <ChatboxHostStyleProvider value="chatgpt">
+        <MCPAppsRenderer
+          {...baseProps}
+          cachedWidgetHtmlUrl="blob:cached"
+          liveFetchPreferred
+          injectedOpenAiCompat={false}
+          injectedOpenAiCompatCapabilities={{ callTool: false }}
+        />
+      </ChatboxHostStyleProvider>
+    );
+
+    await vi.waitFor(() => {
+      expect(authFetch).toHaveBeenCalled();
+    });
+
+    const requestInit = vi.mocked(authFetch).mock.calls[0]?.[1] as
+      | RequestInit
+      | undefined;
+    const body = JSON.parse(String(requestInit?.body ?? "{}")) as Record<
+      string,
+      any
+    >;
+    expect(body.injectOpenAiCompat).toBe(true);
+    expect(body.openAiCompatCapabilities?.callTool).toBe(true);
+  });
+
   it("falls back to cached HTML when the live fetch throws (e.g. server disconnected)", async () => {
     vi.mocked(authFetch).mockRejectedValueOnce(
       new Error('Hosted server not found for "server-1"')
@@ -1681,7 +1950,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
   it("drops stale live-fetch results when the source key has moved on (renderer reuse)", async () => {
     // Hold the first live fetch open with a controllable promise so we can
     // simulate the source key changing (e.g. session swap, cspMode toggle,
-    // different toolCallId) before it resolves.
+    // or different resource URI) before it resolves.
     let resolveStale!: (response: Response) => void;
     const staleResponse = new Promise<Response>((r) => {
       resolveStale = r;
@@ -1691,7 +1960,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     const { rerender } = render(
       <MCPAppsRenderer
         {...baseProps}
-        toolCallId="call-stale"
+        resourceUri="mcp-app://stale"
         cachedWidgetHtmlUrl="blob:cached"
         liveFetchPreferred
       />
@@ -1702,13 +1971,13 @@ describe("MCPAppsRenderer tool input streaming", () => {
       expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(1);
     });
 
-    // Re-render with a new toolCallId. This rotates the source-identity key.
+    // Re-render with a new resource URI. This rotates the source-identity key.
     // A second live fetch is queued for the new key; we let it resolve
     // normally with the default authFetch mock.
     rerender(
       <MCPAppsRenderer
         {...baseProps}
-        toolCallId="call-fresh"
+        resourceUri="mcp-app://fresh"
         cachedWidgetHtmlUrl="blob:cached"
         liveFetchPreferred
       />

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -2892,7 +2892,42 @@ describe("MCPAppsRenderer requestTeardown policy", () => {
     });
 
     expect(mockBridge.teardownResource).toHaveBeenCalledWith({});
-    expect(onRequestTeardown).toHaveBeenCalledWith("call-1");
+    // Non-persistent path: displayWidgetId falls back to toolCallId.
+    expect(onRequestTeardown).toHaveBeenCalledWith("call-1", "call-1");
+  });
+
+  it("forwards the persistent surface id alongside the tool call id on teardown", async () => {
+    const onRequestTeardown = vi.fn();
+    render(
+      <WidgetSurfaceHostProvider>
+        <ActiveMcpProfileProvider value={profileWithRequestTeardown(true)}>
+          <ChatboxHostStyleProvider value="claude">
+            <MCPAppsRenderer
+              {...baseProps}
+              onRequestTeardown={onRequestTeardown}
+            />
+            <WidgetSurfaceHost />
+          </ChatboxHostStyleProvider>
+        </ActiveMcpProfileProvider>
+      </WidgetSurfaceHostProvider>
+    );
+
+    await vi.waitFor(() => {
+      expect(mockBridge.onrequestteardown).not.toBeNull();
+    });
+
+    await act(async () => {
+      await mockBridge.onrequestteardown();
+    });
+
+    expect(onRequestTeardown).toHaveBeenCalledTimes(1);
+    const [calledToolCallId, calledDisplayWidgetId] =
+      onRequestTeardown.mock.calls[0]!;
+    expect(calledToolCallId).toBe("call-1");
+    // Persistent path mints a surface id distinct from the tool call id;
+    // Thread.handleRequestTeardown needs it to clear stuck fullscreen/PiP.
+    expect(typeof calledDisplayWidgetId).toBe("string");
+    expect(calledDisplayWidgetId).not.toBe("call-1");
   });
 
   it("leaves request teardown unhandled when disabled", async () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -549,6 +549,12 @@ describe("MCPAppsRenderer tool input streaming", () => {
       expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
       expect(screen.getByTestId("sandboxed-iframe")).toBeInTheDocument();
     });
+    const getSurfaceContainer = () =>
+      document.querySelector("[data-mcp-app-surface-container]") as HTMLElement;
+    expect(getSurfaceContainer().parentElement).toHaveAttribute(
+      "data-mcp-app-surface-anchor",
+      "call-1"
+    );
 
     act(() => triggerReady());
 
@@ -567,6 +573,10 @@ describe("MCPAppsRenderer tool input streaming", () => {
       expect(mockBridge.sendToolResult).toHaveBeenLastCalledWith(secondOutput);
     });
 
+    expect(getSurfaceContainer().parentElement).toHaveAttribute(
+      "data-mcp-app-surface-anchor",
+      "call-1"
+    );
     expect(mockBridge.sendToolInput).toHaveBeenCalledTimes(1);
     expect(mockBridge.close).not.toHaveBeenCalled();
     expect(mockBridge.teardownResource).not.toHaveBeenCalled();

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -520,16 +520,22 @@ describe("MCPAppsRenderer tool input streaming", () => {
 
   it("shares one persistent surface across tool calls to the same widget", async () => {
     const firstOutput = { content: [{ type: "text" as const, text: "first" }] };
+    const updatedFirstOutput = {
+      content: [{ type: "text" as const, text: "first-rerendered" }],
+    };
     const secondOutput = {
       content: [{ type: "text" as const, text: "second" }],
     };
-    const renderTree = (includeSecondCall: boolean) => (
+    const renderTree = (
+      includeSecondCall: boolean,
+      currentFirstOutput = firstOutput
+    ) => (
       <WidgetSurfaceHostProvider>
         <MCPAppsRenderer
           {...baseProps}
           toolCallId="call-1"
           toolInput={{ move: "e4" }}
-          toolOutput={firstOutput}
+          toolOutput={currentFirstOutput}
         />
         {includeSecondCall ? (
           <MCPAppsRenderer
@@ -573,6 +579,13 @@ describe("MCPAppsRenderer tool input streaming", () => {
       expect(mockBridge.sendToolResult).toHaveBeenLastCalledWith(secondOutput);
     });
 
+    rerender(renderTree(true, updatedFirstOutput));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockBridge.sendToolResult).toHaveBeenCalledTimes(2);
+    expect(mockBridge.sendToolResult).toHaveBeenLastCalledWith(secondOutput);
     expect(getSurfaceContainer().parentElement).toHaveAttribute(
       "data-mcp-app-surface-anchor",
       "call-1"

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -518,24 +518,18 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(sandboxedIframeUnmountsRef.current).toBe(0);
   });
 
-  it("shares one persistent surface across tool calls to the same widget", async () => {
+  it("renders separate iframes for distinct tool calls on the same widget", async () => {
     const firstOutput = { content: [{ type: "text" as const, text: "first" }] };
-    const updatedFirstOutput = {
-      content: [{ type: "text" as const, text: "first-rerendered" }],
-    };
     const secondOutput = {
       content: [{ type: "text" as const, text: "second" }],
     };
-    const renderTree = (
-      includeSecondCall: boolean,
-      currentFirstOutput = firstOutput
-    ) => (
+    const renderTree = (includeSecondCall: boolean) => (
       <WidgetSurfaceHostProvider>
         <MCPAppsRenderer
           {...baseProps}
           toolCallId="call-1"
           toolInput={{ move: "e4" }}
-          toolOutput={currentFirstOutput}
+          toolOutput={firstOutput}
         />
         {includeSecondCall ? (
           <MCPAppsRenderer
@@ -555,12 +549,6 @@ describe("MCPAppsRenderer tool input streaming", () => {
       expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
       expect(screen.getByTestId("sandboxed-iframe")).toBeInTheDocument();
     });
-    const getSurfaceContainer = () =>
-      document.querySelector("[data-mcp-app-surface-container]") as HTMLElement;
-    expect(getSurfaceContainer().parentElement).toHaveAttribute(
-      "data-mcp-app-surface-anchor",
-      "call-1"
-    );
 
     act(() => triggerReady());
 
@@ -574,34 +562,23 @@ describe("MCPAppsRenderer tool input streaming", () => {
 
     rerender(renderTree(true));
 
+    // Each tool call is a semantically distinct View (SEP-1865 lifecycle):
+    // call-2 must mount its own iframe under its own row instead of
+    // collapsing into call-1's surface and leaving call-2's row empty.
     await vi.waitFor(() => {
-      expect(mockBridge.sendToolInput).toHaveBeenCalledTimes(2);
-      expect(mockBridge.sendToolInput).toHaveBeenLastCalledWith({
-        arguments: { move: "c5" },
-      });
-      expect(mockBridge.sendToolResult).toHaveBeenCalledTimes(2);
-      expect(mockBridge.sendToolResult).toHaveBeenLastCalledWith(secondOutput);
+      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(2);
+      expect(sandboxedIframeMountsRef.current).toBe(2);
+      const anchors = Array.from(
+        document.querySelectorAll("[data-mcp-app-surface-container]")
+      ).map((node) =>
+        node.parentElement?.getAttribute("data-mcp-app-surface-anchor")
+      );
+      expect(anchors).toContain("call-1");
+      expect(anchors).toContain("call-2");
     });
-
-    rerender(renderTree(true, updatedFirstOutput));
-    await act(async () => {
-      await Promise.resolve();
-    });
-
-    expect(mockBridge.sendToolResult).toHaveBeenCalledTimes(2);
-    expect(mockBridge.sendToolResult).toHaveBeenLastCalledWith(secondOutput);
-    expect(getSurfaceContainer().parentElement).toHaveAttribute(
-      "data-mcp-app-surface-anchor",
-      "call-1"
-    );
-    expect(mockBridge.sendToolInput).toHaveBeenCalledTimes(2);
-    expect(mockBridge.close).not.toHaveBeenCalled();
-    expect(mockBridge.teardownResource).not.toHaveBeenCalled();
-    expect(sandboxedIframeMountsRef.current).toBe(1);
-    expect(sandboxedIframeUnmountsRef.current).toBe(0);
   });
 
-  it("keeps live-preferred cached tool calls on one persistent resource surface", async () => {
+  it("mounts a separate live-preferred surface per cached tool call", async () => {
     render(
       <WidgetSurfaceHostProvider>
         <MCPAppsRenderer
@@ -621,20 +598,18 @@ describe("MCPAppsRenderer tool input streaming", () => {
       </WidgetSurfaceHostProvider>
     );
 
+    // Live-preferred path bypasses cached blob — both tool calls trigger a
+    // live fetch and each mounts its own iframe in its own row.
     await vi.waitFor(() => {
-      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
-      expect(screen.getByTestId("sandboxed-iframe")).toBeInTheDocument();
+      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(2);
+      expect(sandboxedIframeMountsRef.current).toBe(2);
     });
 
-    expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(2);
     expect(vi.mocked(global.fetch)).not.toHaveBeenCalledWith("blob:cached");
-    expect(mockBridge.close).not.toHaveBeenCalled();
-    expect(mockBridge.teardownResource).not.toHaveBeenCalled();
-    expect(sandboxedIframeMountsRef.current).toBe(1);
-    expect(sandboxedIframeUnmountsRef.current).toBe(0);
   });
 
-  it("sends identical persistent surface results for different tool calls", async () => {
+  it("mounts a fresh surface when the same row is re-keyed with a new tool call id", async () => {
     const sameOutput = { content: [{ type: "text" as const, text: "same" }] };
     const renderTree = (toolCallId: string) => (
       <WidgetSurfaceHostProvider>
@@ -661,14 +636,12 @@ describe("MCPAppsRenderer tool input streaming", () => {
 
     rerender(renderTree("call-2"));
 
+    // Distinct tool call ⇒ distinct View. The previous surface tears
+    // down and a fresh one mounts for call-2.
     await vi.waitFor(() => {
-      expect(mockBridge.sendToolResult).toHaveBeenCalledTimes(2);
+      expect(mockAppBridgeCtor).toHaveBeenCalledTimes(2);
+      expect(sandboxedIframeMountsRef.current).toBe(2);
     });
-
-    expect(mockBridge.sendToolResult).toHaveBeenLastCalledWith(sameOutput);
-    expect(mockAppBridgeCtor).toHaveBeenCalledTimes(1);
-    expect(sandboxedIframeMountsRef.current).toBe(1);
-    expect(sandboxedIframeUnmountsRef.current).toBe(0);
   });
 
   it("keeps the iframe alive when the same tool call anchor is re-keyed", async () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -575,6 +575,10 @@ describe("MCPAppsRenderer tool input streaming", () => {
     rerender(renderTree(true));
 
     await vi.waitFor(() => {
+      expect(mockBridge.sendToolInput).toHaveBeenCalledTimes(2);
+      expect(mockBridge.sendToolInput).toHaveBeenLastCalledWith({
+        arguments: { move: "c5" },
+      });
       expect(mockBridge.sendToolResult).toHaveBeenCalledTimes(2);
       expect(mockBridge.sendToolResult).toHaveBeenLastCalledWith(secondOutput);
     });
@@ -590,7 +594,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
       "data-mcp-app-surface-anchor",
       "call-1"
     );
-    expect(mockBridge.sendToolInput).toHaveBeenCalledTimes(1);
+    expect(mockBridge.sendToolInput).toHaveBeenCalledTimes(2);
     expect(mockBridge.close).not.toHaveBeenCalled();
     expect(mockBridge.teardownResource).not.toHaveBeenCalled();
     expect(sandboxedIframeMountsRef.current).toBe(1);

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/useToolInputStreaming.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/useToolInputStreaming.test.ts
@@ -130,6 +130,8 @@ interface HookProps {
   toolOutput: unknown;
   toolErrorText: string | undefined;
   toolCallId: string;
+  sendToolInput: boolean;
+  onToolInputSent?: () => void;
   reinitCount: number;
   mcpAppsCapabilitiesRef: React.RefObject<any>;
 }
@@ -152,6 +154,7 @@ function createDefaultProps(
     toolOutput: undefined,
     toolErrorText: undefined,
     toolCallId: "call-1",
+    sendToolInput: true,
     reinitCount: 0,
     mcpAppsCapabilitiesRef,
   };
@@ -403,6 +406,21 @@ describe("useToolInputStreaming", () => {
     expect(bridge.sendToolInputPartial).not.toHaveBeenCalled();
   });
 
+  it("suppresses tool input while still rendering and delivering results", () => {
+    const props = createDefaultProps(bridge);
+    props.sendToolInput = false;
+    props.toolState = "output-available";
+    props.toolInput = { code: "final" };
+    props.toolOutput = { content: [{ type: "text", text: "result" }] };
+
+    const { result } = renderHook(() => useToolInputStreaming(props));
+
+    expect(result.current.canRenderStreamingInput).toBe(true);
+    expect(bridge.sendToolInput).not.toHaveBeenCalled();
+    expect(bridge.sendToolInputPartial).not.toHaveBeenCalled();
+    expect(bridge.sendToolResult).toHaveBeenCalledTimes(1);
+  });
+
   it("does not send complete input for duplicate payload", () => {
     const props = createDefaultProps(bridge);
     props.toolState = "input-available";
@@ -432,6 +450,21 @@ describe("useToolInputStreaming", () => {
     rerender();
 
     expect(bridge.sendToolResult).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends identical tool results for different tool calls", () => {
+    const props = createDefaultProps(bridge);
+    props.toolState = "output-available";
+    props.toolOutput = { content: [{ type: "text", text: "same" }] };
+
+    const { rerender } = renderHook(() => useToolInputStreaming(props));
+
+    expect(bridge.sendToolResult).toHaveBeenCalledTimes(1);
+
+    props.toolCallId = "call-2";
+    rerender();
+
+    expect(bridge.sendToolResult).toHaveBeenCalledTimes(2);
   });
 
   it("does not send tool error for duplicate error message", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/app-tools-registry.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/app-tools-registry.ts
@@ -18,7 +18,9 @@
  * server-tool approval flow onto app-provided tools.
  */
 
+import { useCallback } from "react";
 import { create } from "zustand";
+import { useShallow } from "zustand/react/shallow";
 import type { AppBridge } from "@modelcontextprotocol/ext-apps/app-bridge";
 import type { CallToolResult } from "@modelcontextprotocol/client";
 import { useTrafficLogStore } from "@/stores/traffic-log-store";
@@ -78,6 +80,11 @@ const MAX_SNAPSHOT_ENTRIES = 64;
 const MAX_DESCRIPTION_CHARS = 512;
 const MAX_INPUT_SCHEMA_BYTES = 8 * 1024;
 const ALIAS_REGEX = /^app_[a-z0-9]{8}$/i;
+
+export interface AppToolAttribution {
+  rawName: string;
+  appName: string;
+}
 
 interface AppToolsRegistryState {
   instancesByBridgeId: Map<BridgeId, AppInstance>;
@@ -621,6 +628,51 @@ export function recordAppToolInvocation(
     // Defensive: the traffic-log store is best-effort observability;
     // never let a logger failure bubble into the dispatch path.
   }
+}
+
+export function useAppToolAttributionResolver(chatSessionId?: string) {
+  const registrySnapshot = useAppToolsRegistry(
+    useShallow((s) => ({
+      activeBridgeByParent: s.activeBridgeByParent,
+      aliases: s.aliases,
+      instancesByBridgeId: s.instancesByBridgeId,
+    })),
+  );
+  const resolve = useAppToolsRegistry((s) => s.resolve);
+  const invocationRecords = useAppToolInvocationLog((s) => s.records);
+
+  return useCallback(
+    (label: string): AppToolAttribution | null => {
+      if (!ALIAS_REGEX.test(label)) return null;
+
+      const resolved = resolve(label, chatSessionId);
+      if (resolved) {
+        return {
+          rawName: resolved.rawName,
+          appName: resolved.instance.appName,
+        };
+      }
+
+      for (let i = invocationRecords.length - 1; i >= 0; i -= 1) {
+        const record = invocationRecords[i];
+        if (record.alias === label) {
+          return { rawName: record.rawName, appName: record.appName };
+        }
+      }
+
+      return null;
+    },
+    [chatSessionId, invocationRecords, registrySnapshot, resolve],
+  );
+}
+
+export function useAppToolAttribution(
+  label: string,
+  chatSessionId?: string,
+): AppToolAttribution | null {
+  const resolveAppToolAttribution =
+    useAppToolAttributionResolver(chatSessionId);
+  return resolveAppToolAttribution(label);
 }
 
 // Exports for tests.

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -908,11 +908,15 @@ export function MCPAppsRendererSurface({
         setInternalDisplayMode(mode);
       }
 
-      // Notify parent about fullscreen state changes regardless of controlled mode
+      // Notify parent about fullscreen state changes regardless of controlled
+      // mode. Always forward this widget's own id (`displayWidgetId`); the
+      // parent runs an ownership check, which safely no-ops if our local
+      // `displayMode` was stale at "fullscreen" because another widget took
+      // over the global slot.
       if (mode === "fullscreen") {
         onRequestFullscreen?.(displayWidgetId);
       } else if (displayMode === "fullscreen") {
-        onExitFullscreen?.(fullscreenWidgetId ?? displayWidgetId);
+        onExitFullscreen?.(displayWidgetId);
       }
     },
     [
@@ -922,7 +926,6 @@ export function MCPAppsRendererSurface({
       onRequestFullscreen,
       onExitFullscreen,
       displayMode,
-      fullscreenWidgetId,
     ]
   );
   const lastForcedDisplayModeRef = useRef<DisplayMode | null>(null);

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -277,9 +277,16 @@ export interface MCPAppsRendererProps {
   minimalMode?: boolean;
   /**
    * Stable identity assigned by WidgetSurfaceHost. Present only when the
-   * renderer is mounted as a persistent, tool-call-scoped surface.
+   * renderer is mounted as a persistent, resource-scoped surface.
    */
   persistentSurfaceId?: string;
+  /**
+   * The first tool call registered for a resource-scoped persistent surface.
+   * Kept for host/debug attribution; complete tool-input is still gated by
+   * the surface's one-shot delivery latch so restored transcripts cannot skip
+   * input when multiple rows register before the host mounts.
+   */
+  persistentSurfaceInitialToolCallId?: string;
 }
 
 /**
@@ -385,7 +392,6 @@ function getPersistentSurfaceId(props: MCPAppsRendererProps): string {
     chatSessionId: props.chatSessionId ?? null,
     serverId: props.serverId,
     resourceUri: props.resourceUri,
-    toolCallId: props.toolCallId,
     surface: "inline",
   });
   return `mcp-app:${hashSurfaceIdentity(identity)}`;
@@ -439,7 +445,7 @@ function scheduleSurfaceRelease(surfaceId: string, toolCallId: string) {
 function PersistentMCPAppsRendererRegistration(props: MCPAppsRendererProps) {
   const surfaceId = useMemo(
     () => getPersistentSurfaceId(props),
-    [props.chatSessionId, props.resourceUri, props.serverId, props.toolCallId]
+    [props.chatSessionId, props.resourceUri, props.serverId]
   );
   const anchorRef = useRef<HTMLDivElement | null>(null);
 
@@ -536,6 +542,7 @@ export function MCPAppsRendererSurface({
   initialWidgetState,
   minimalMode = false,
   persistentSurfaceId,
+  persistentSurfaceInitialToolCallId,
 }: MCPAppsRendererProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const sandboxRef = useRef<SandboxedIframeHandle>(null);
@@ -1265,6 +1272,13 @@ export function MCPAppsRendererSurface({
   const mcpAppsCapabilitiesRef = useRef<ResolvedMcpAppsCapabilities | null>(
     null
   );
+  const persistentToolInputSentRef = useRef(false);
+  const shouldSendToolInput =
+    persistentSurfaceId === undefined || !persistentToolInputSentRef.current;
+  const markPersistentToolInputSent = useCallback(() => {
+    if (persistentSurfaceId === undefined) return;
+    persistentToolInputSentRef.current = true;
+  }, [persistentSurfaceId]);
 
   const {
     canRenderStreamingInput,
@@ -1279,6 +1293,8 @@ export function MCPAppsRendererSurface({
     toolOutput,
     toolErrorText,
     toolCallId,
+    sendToolInput: shouldSendToolInput,
+    onToolInputSent: markPersistentToolInputSent,
     reinitCount,
     mcpAppsCapabilitiesRef,
   });
@@ -3753,6 +3769,10 @@ export function MCPAppsRendererSurface({
     <div
       ref={containerRef}
       className={containerClassName}
+      data-mcp-app-persistent-initial-tool-call-id={
+        persistentSurfaceInitialToolCallId
+      }
+      data-mcp-app-persistent-surface-id={persistentSurfaceId}
       style={containerStyle}
     >
       {((isFullscreen && isContainedFullscreenMode) ||

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1272,14 +1272,6 @@ export function MCPAppsRendererSurface({
   const mcpAppsCapabilitiesRef = useRef<ResolvedMcpAppsCapabilities | null>(
     null
   );
-  const persistentToolInputSentRef = useRef(false);
-  const shouldSendToolInput =
-    persistentSurfaceId === undefined || !persistentToolInputSentRef.current;
-  const markPersistentToolInputSent = useCallback(() => {
-    if (persistentSurfaceId === undefined) return;
-    persistentToolInputSentRef.current = true;
-  }, [persistentSurfaceId]);
-
   const {
     canRenderStreamingInput,
     signalStreamingRender,
@@ -1293,8 +1285,7 @@ export function MCPAppsRendererSurface({
     toolOutput,
     toolErrorText,
     toolCallId,
-    sendToolInput: shouldSendToolInput,
-    onToolInputSent: markPersistentToolInputSent,
+    sendToolInput: true,
     reinitCount,
     mcpAppsCapabilitiesRef,
   });

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -388,10 +388,19 @@ function hashSurfaceIdentity(value: string): string {
 }
 
 function getPersistentSurfaceId(props: MCPAppsRendererProps): string {
+  // Identity is per-tool-call, not per-resource. The persistent surface's
+  // job is to keep one iframe alive across re-renders of the same row
+  // (e.g. fullscreen toggle, transcript reshuffles) — the `toolCallId`
+  // is stable across all of those. Two distinct `tools/call` invocations
+  // on the same resource are semantically two separate Views per
+  // SEP-1865's lifecycle, so they must get their own surface; otherwise
+  // the second tool-call row renders empty because the lone iframe is
+  // anchored under the first row.
   const identity = stableStringifyJson({
     chatSessionId: props.chatSessionId ?? null,
     serverId: props.serverId,
     resourceUri: props.resourceUri,
+    toolCallId: props.toolCallId,
     surface: "inline",
   });
   return `mcp-app:${hashSurfaceIdentity(identity)}`;
@@ -445,7 +454,7 @@ function scheduleSurfaceRelease(surfaceId: string, toolCallId: string) {
 function PersistentMCPAppsRendererRegistration(props: MCPAppsRendererProps) {
   const surfaceId = useMemo(
     () => getPersistentSurfaceId(props),
-    [props.chatSessionId, props.resourceUri, props.serverId]
+    [props.chatSessionId, props.resourceUri, props.serverId, props.toolCallId]
   );
   const anchorRef = useRef<HTMLDivElement | null>(null);
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -225,7 +225,7 @@ export interface MCPAppsRendererProps {
    * unmount this tool call's MCP app surface (e.g. dismiss the modal,
    * collapse the inline view).
    */
-  onRequestTeardown?: (toolCallId: string) => void;
+  onRequestTeardown?: (toolCallId: string, displayWidgetId?: string) => void;
   /** Whether the server is offline (for using cached content) */
   isOffline?: boolean;
   /** URL to cached widget HTML for offline rendering */
@@ -1380,7 +1380,7 @@ export function MCPAppsRendererSurface({
       // so live host edits don't churn the snapshot.
       setLoadedMcpAppsCapabilitiesHash(widgetMcpAppsCapabilitiesReloadKey);
       setWidgetHtmlStore(
-        toolCallId,
+        toolCallIdRef.current,
         html,
         loadedCachedCompatKey ?? undefined,
         // Persisted capabilities flow into the debug store so a
@@ -3145,7 +3145,10 @@ export function MCPAppsRendererSurface({
               error: err instanceof Error ? err.message : String(err),
             });
           }
-          onRequestTeardownRef.current?.(toolCallIdRef.current);
+          onRequestTeardownRef.current?.(
+            toolCallIdRef.current,
+            displayWidgetIdRef.current
+          );
         };
       }
     },

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -97,6 +97,10 @@ import {
   resolveHostInfo,
 } from "@/lib/client-config-v2";
 import type { ResolvedMcpAppsCapabilities } from "@/lib/client-styles";
+import { usePersistentWidgetSurfaceHost } from "./widget-surface-context";
+import {
+  useWidgetSurfaceStore,
+} from "./widget-surface-store";
 
 // Injected by Vite at build time from package.json
 declare const __APP_VERSION__: string;
@@ -164,7 +168,7 @@ function sanitizeHostStyleVariables(
 
 // CSP and permissions metadata types are now imported from SDK
 
-interface MCPAppsRendererProps {
+export interface MCPAppsRendererProps {
   chatSessionId?: string;
   serverId: string;
   toolCallId: string;
@@ -271,6 +275,11 @@ interface MCPAppsRendererProps {
   initialWidgetState?: unknown;
   /** Minimal mode hides diagnostics and metadata surfaces */
   minimalMode?: boolean;
+  /**
+   * Stable identity assigned by WidgetSurfaceHost. Present only when the
+   * renderer is mounted as a persistent, tool-call-scoped surface.
+   */
+  persistentSurfaceId?: string;
 }
 
 /**
@@ -332,15 +341,14 @@ function mapLogToLifecycle(
 /**
  * Segments of the fetch-source key, in the same order as the renderer
  * builds it below. Used to describe re-mount reasons for the Sandbox
- * debug panel — e.g. "cachedWidgetHtmlUrl, liveFetchPreferred" when a
- * Convex history snapshot lands.
+ * debug panel — e.g. "cachedReplayWidgetHtmlUrl, fetchMode" when a saved
+ * view swaps in a byte-frozen snapshot.
  */
 const FETCH_SOURCE_KEY_SEGMENTS = [
-  "toolCallId",
   "resourceUri",
-  "cachedWidgetHtmlUrl",
+  "cachedReplayWidgetHtmlUrl",
   "cspMode",
-  "liveFetchPreferred",
+  "fetchMode",
   // `injectOpenAiCompat` boolean and the per-method capability hash
   // are part of the rendering recipe: a host swap from ChatGPT-full
   // to Copilot-subset (or a master-toggle flip) changes the bytes
@@ -363,7 +371,133 @@ function describeFetchSourceKeyDiff(prev: string, next: string): string {
   return changes.length === 0 ? "remount" : changes.join(", ");
 }
 
-export function MCPAppsRenderer({
+function hashSurfaceIdentity(value: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function getPersistentSurfaceId(props: MCPAppsRendererProps): string {
+  const identity = stableStringifyJson({
+    chatSessionId: props.chatSessionId ?? null,
+    serverId: props.serverId,
+    resourceUri: props.resourceUri,
+    toolCallId: props.toolCallId,
+    surface: "inline",
+  });
+  return `mcp-app:${hashSurfaceIdentity(identity)}`;
+}
+
+const pendingSurfaceReleaseTimers = new Map<string, number>();
+const pendingAnchorClearTimers = new Map<string, number>();
+
+function getSurfaceRegistrationKey(surfaceId: string, toolCallId: string) {
+  return `${surfaceId}\0${toolCallId}`;
+}
+
+function cancelPendingAnchorClear(surfaceId: string, toolCallId: string) {
+  const key = getSurfaceRegistrationKey(surfaceId, toolCallId);
+  const timer = pendingAnchorClearTimers.get(key);
+  if (timer === undefined) return;
+  window.clearTimeout(timer);
+  pendingAnchorClearTimers.delete(key);
+}
+
+function scheduleAnchorClear(surfaceId: string, toolCallId: string) {
+  const key = getSurfaceRegistrationKey(surfaceId, toolCallId);
+  const existing = pendingAnchorClearTimers.get(key);
+  if (existing !== undefined) window.clearTimeout(existing);
+  const timer = window.setTimeout(() => {
+    pendingAnchorClearTimers.delete(key);
+    useWidgetSurfaceStore.getState().setAnchor(surfaceId, toolCallId, null);
+  }, 0);
+  pendingAnchorClearTimers.set(key, timer);
+}
+
+function cancelPendingSurfaceRelease(surfaceId: string, toolCallId: string) {
+  const key = getSurfaceRegistrationKey(surfaceId, toolCallId);
+  const timer = pendingSurfaceReleaseTimers.get(key);
+  if (timer === undefined) return;
+  window.clearTimeout(timer);
+  pendingSurfaceReleaseTimers.delete(key);
+}
+
+function scheduleSurfaceRelease(surfaceId: string, toolCallId: string) {
+  const key = getSurfaceRegistrationKey(surfaceId, toolCallId);
+  const existing = pendingSurfaceReleaseTimers.get(key);
+  if (existing !== undefined) window.clearTimeout(existing);
+  const timer = window.setTimeout(() => {
+    pendingSurfaceReleaseTimers.delete(key);
+    useWidgetSurfaceStore.getState().releaseRegistration(surfaceId, toolCallId);
+  }, 0);
+  pendingSurfaceReleaseTimers.set(key, timer);
+}
+
+function PersistentMCPAppsRendererRegistration(props: MCPAppsRendererProps) {
+  const surfaceId = useMemo(
+    () => getPersistentSurfaceId(props),
+    [props.chatSessionId, props.resourceUri, props.serverId, props.toolCallId]
+  );
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+
+  useLayoutEffect(() => {
+    cancelPendingAnchorClear(surfaceId, props.toolCallId);
+    cancelPendingSurfaceRelease(surfaceId, props.toolCallId);
+    return () => {
+      scheduleSurfaceRelease(surfaceId, props.toolCallId);
+    };
+  }, [surfaceId, props.toolCallId]);
+
+  useLayoutEffect(() => {
+    cancelPendingAnchorClear(surfaceId, props.toolCallId);
+    cancelPendingSurfaceRelease(surfaceId, props.toolCallId);
+    const store = useWidgetSurfaceStore.getState();
+    store.upsertRegistration(surfaceId, props.toolCallId, props);
+    store.setAnchor(surfaceId, props.toolCallId, anchorRef.current);
+  });
+
+  const setAnchor = useCallback(
+    (node: HTMLDivElement | null) => {
+      anchorRef.current = node;
+      if (node === null) {
+        scheduleAnchorClear(surfaceId, props.toolCallId);
+        return;
+      }
+      cancelPendingAnchorClear(surfaceId, props.toolCallId);
+      useWidgetSurfaceStore
+        .getState()
+        .setAnchor(surfaceId, props.toolCallId, node);
+    },
+    [surfaceId, props.toolCallId]
+  );
+
+  return (
+    <div
+      ref={setAnchor}
+      data-mcp-app-surface-id={surfaceId}
+      data-mcp-app-surface-anchor={props.toolCallId}
+    />
+  );
+}
+
+export function MCPAppsRenderer(props: MCPAppsRendererProps) {
+  const persistentHostEnabled = usePersistentWidgetSurfaceHost();
+  const isCachedReplay =
+    !!props.cachedWidgetHtmlUrl && !props.liveFetchPreferred;
+  const shouldUsePersistentSurface =
+    persistentHostEnabled && !props.isOffline && !isCachedReplay;
+
+  if (!shouldUsePersistentSurface) {
+    return <MCPAppsRendererSurface {...props} />;
+  }
+
+  return <PersistentMCPAppsRendererRegistration {...props} />;
+}
+
+export function MCPAppsRendererSurface({
   chatSessionId,
   serverId,
   toolCallId,
@@ -401,6 +535,7 @@ export function MCPAppsRenderer({
   injectedOpenAiCompatCapabilities: initialInjectedOpenAiCompatCapabilities,
   initialWidgetState,
   minimalMode = false,
+  persistentSurfaceId,
 }: MCPAppsRendererProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const sandboxRef = useRef<SandboxedIframeHandle>(null);
@@ -413,16 +548,28 @@ export function MCPAppsRenderer({
   // session, project default, eval suite). Drives the resolver below
   // when set; undefined preserves widget-derived sandbox behavior.
   const activeMcpProfile = useActiveMcpProfile();
+  const activeMcpProfileKey = useMemo(
+    () => stableStringifyJson(activeMcpProfile ?? null),
+    [activeMcpProfile]
+  );
+  const hostCapabilitiesOverrideKey = useMemo(
+    () => stableStringifyJson(hostCapabilitiesOverride ?? null),
+    [hostCapabilitiesOverride]
+  );
   // Resolved compat-runtime flag for the active host. Claude/Cursor/
   // Codex-style hosts leave it off; ChatGPT/Copilot and MCPJam's dev
   // surface enable it. User override on the profile wins. The resolved
   // boolean travels into the widget-content request body and into the
   // renderer's reload-key so toggling the flag forces a refetch instead
   // of silently reusing the old HTML.
-  const liveEffectiveCompatRuntime = resolveEffectiveCompatRuntime({
-    profile: activeMcpProfile,
-    hostStyle: chatboxHostStyle ?? sharedHostStyle,
-  });
+  const liveEffectiveCompatRuntime = useMemo(
+    () =>
+      resolveEffectiveCompatRuntime({
+        profile: activeMcpProfile,
+        hostStyle: chatboxHostStyle ?? sharedHostStyle,
+      }),
+    [activeMcpProfileKey, chatboxHostStyle, sharedHostStyle]
+  );
   const liveInjectOpenAiCompat = liveEffectiveCompatRuntime.injected;
   // Capability surface accompanying `liveInjectOpenAiCompat`. Travels
   // into the widget-content request alongside the boolean so the SDK
@@ -432,11 +579,23 @@ export function MCPAppsRenderer({
   const liveOpenAiCompatCapabilities = liveEffectiveCompatRuntime.injected
     ? liveEffectiveCompatRuntime.capabilities
     : null;
-  // Cached replay: when a saved view / eval snapshot persisted the
-  // flag, trust it (HTML is byte-frozen at capture time). Fall back
-  // to the live flag for fresh fetches.
+  // A cached URL can exist during an in-flow revisit while the renderer still
+  // prefers live HTML. Treat only cached-only renders as replay; live compat
+  // fetches still need completed tool output baked into window.openai at boot.
+  const isCachedReplay = !!cachedWidgetHtmlUrl && !liveFetchPreferred;
+  const cachedReplayWidgetHtmlUrl = isCachedReplay
+    ? cachedWidgetHtmlUrl
+    : undefined;
+  const widgetFetchModeKey = isCachedReplay ? "cached" : "live";
+  const cachedReplayPrefersBorder = isCachedReplay
+    ? initialPrefersBorder
+    : undefined;
+  // Cached replay: when a saved view / eval snapshot persisted the flag, trust
+  // it because the HTML is byte-frozen at capture time. Live-preferred revisits
+  // must use the current host config so a cached fallback does not create a
+  // distinct render recipe from the next live tool call.
   const effectiveInjectOpenAiCompat =
-    typeof initialInjectedOpenAiCompat === "boolean"
+    isCachedReplay && typeof initialInjectedOpenAiCompat === "boolean"
       ? initialInjectedOpenAiCompat
       : liveInjectOpenAiCompat;
   const draftHostContext = useHostContextStore((s) => s.draftHostContext);
@@ -547,7 +706,7 @@ export function MCPAppsRenderer({
         profile: activeMcpProfile,
         hostStyle: earlyEffectiveHostStyle,
       }),
-    [activeMcpProfile, earlyEffectiveHostStyle]
+    [activeMcpProfileKey, earlyEffectiveHostStyle]
   );
 
   // Intersection of the matrix's allowed modes with the playground /
@@ -700,13 +859,20 @@ export function MCPAppsRenderer({
     )
   );
   const displayMode = isControlled ? displayModeProp : internalDisplayMode;
+  const displayWidgetId = persistentSurfaceId ?? toolCallId;
+  const ownsFullscreenDisplayMode =
+    fullscreenWidgetId === displayWidgetId ||
+    fullscreenWidgetId === toolCallId;
+  const ownsPipDisplayMode =
+    pipWidgetId === displayWidgetId || pipWidgetId === toolCallId;
   const requestedDisplayMode = useMemo<DisplayMode>(() => {
     if (!isControlled) return displayMode;
-    if (displayMode === "fullscreen" && fullscreenWidgetId === toolCallId)
+    if (displayMode === "fullscreen" && ownsFullscreenDisplayMode) {
       return "fullscreen";
-    if (displayMode === "pip" && pipWidgetId === toolCallId) return "pip";
+    }
+    if (displayMode === "pip" && ownsPipDisplayMode) return "pip";
     return "inline";
-  }, [displayMode, fullscreenWidgetId, isControlled, pipWidgetId, toolCallId]);
+  }, [displayMode, isControlled, ownsFullscreenDisplayMode, ownsPipDisplayMode]);
   // Clamp the requested display mode against the same intersection
   // that gets advertised in `HostContext.availableDisplayModes` so
   // the runtime mode is always a member of the advertised set. A
@@ -744,18 +910,19 @@ export function MCPAppsRenderer({
 
       // Notify parent about fullscreen state changes regardless of controlled mode
       if (mode === "fullscreen") {
-        onRequestFullscreen?.(toolCallId);
+        onRequestFullscreen?.(displayWidgetId);
       } else if (displayMode === "fullscreen") {
-        onExitFullscreen?.(toolCallId);
+        onExitFullscreen?.(fullscreenWidgetId ?? displayWidgetId);
       }
     },
     [
       isControlled,
       onDisplayModeChange,
-      toolCallId,
+      displayWidgetId,
       onRequestFullscreen,
       onExitFullscreen,
       displayMode,
+      fullscreenWidgetId,
     ]
   );
   const lastForcedDisplayModeRef = useRef<DisplayMode | null>(null);
@@ -780,10 +947,6 @@ export function MCPAppsRenderer({
   const [widgetHtml, setWidgetHtml] = useState<string | null>(null);
   const [sandboxProxyReady, setSandboxProxyReady] = useState(false);
   const [bridgeTransportReady, setBridgeTransportReady] = useState(false);
-  // A cached URL can exist during an in-flow revisit while the renderer still
-  // prefers live HTML. Treat only cached-only renders as replay; live compat
-  // fetches still need completed tool output baked into window.openai at boot.
-  const isCachedReplay = !!cachedWidgetHtmlUrl && !liveFetchPreferred;
   const cachedReplayInjectOpenAiCompat =
     typeof initialInjectedOpenAiCompat === "boolean"
       ? initialInjectedOpenAiCompat
@@ -941,7 +1104,10 @@ export function MCPAppsRenderer({
     useState<CheckoutSession | null>(null);
   const [checkoutCallId, setCheckoutCallId] = useState<number | null>(null);
 
-  // Reset widget HTML when cachedWidgetHtmlUrl changes (e.g., different view selected)
+  // Reset widget HTML when the actual replay source changes (e.g., different
+  // saved view selected). A live-preferred cached URL is only a fallback; it
+  // must not churn a persistent live surface when the next tool call has no
+  // cached fallback.
   useEffect(() => {
     setWidgetHtml(null);
     setBridgeTransportReady(false);
@@ -949,21 +1115,14 @@ export function MCPAppsRenderer({
     setLoadedInjectOpenAiCompat(null);
     setLoadedCompatCapabilitiesHash(null);
     setLoadError(null);
-    setWidgetCsp(isCachedReplay ? undefined : initialWidgetCsp ?? undefined);
-    setWidgetPermissions(
-      isCachedReplay ? undefined : initialWidgetPermissions ?? undefined
-    );
-    setWidgetPermissive(
-      isCachedReplay ? true : initialWidgetPermissive ?? false
-    );
-    setPrefersBorder(initialPrefersBorder ?? true);
+    setWidgetCsp(undefined);
+    setWidgetPermissions(undefined);
+    setWidgetPermissive(isCachedReplay ? true : false);
+    setPrefersBorder(cachedReplayPrefersBorder ?? true);
   }, [
-    cachedWidgetHtmlUrl,
+    cachedReplayWidgetHtmlUrl,
+    cachedReplayPrefersBorder,
     isCachedReplay,
-    initialWidgetCsp,
-    initialWidgetPermissions,
-    initialWidgetPermissive,
-    initialPrefersBorder,
   ]);
 
   const bridgeRef = useRef<AppBridge | null>(null);
@@ -1012,9 +1171,7 @@ export function MCPAppsRenderer({
   const appToolsBridgeIdRef = useRef<string | null>(null);
   const appToolsListedBridgeIdsRef = useRef<Set<string>>(new Set());
   const appToolsListInFlightBridgeIdsRef = useRef<Set<string>>(new Set());
-  const appToolsListRefreshPendingBridgeIdsRef = useRef<Set<string>>(
-    new Set()
-  );
+  const appToolsListRefreshPendingBridgeIdsRef = useRef<Set<string>>(new Set());
   // Reactive mirror of `appToolsBridgeIdRef` so the in-flight busy
   // indicator can subscribe to `useAppToolsRegistry.pendingControllers`
   // by bridge id. Refs alone don't trigger re-renders.
@@ -1023,13 +1180,13 @@ export function MCPAppsRenderer({
   >(null);
   const pendingAppToolCalls = useAppToolsRegistry((s) =>
     appToolsBridgeIdState
-      ? (s.pendingControllers.get(appToolsBridgeIdState)?.size ?? 0)
+      ? s.pendingControllers.get(appToolsBridgeIdState)?.size ?? 0
       : 0
   );
 
   // Reset widget-identity-scoped state when the renderer is reused for a
-  // different tool call / resource / widget bundle. Without this the next
-  // widget inherits the previous widget's intersected display modes, its
+  // different resource / widget bundle. Without this the next widget
+  // inherits the previous widget's intersected display modes, its
   // narrowed inline width, and (if the user had dismissed to inline) its
   // sticky inline preference. Also re-seeds the sticky flag from the
   // current `widgetDisplayModeRequests` policy so flipping the Apps tab
@@ -1042,7 +1199,6 @@ export function MCPAppsRenderer({
       earlyEffectiveMcpAppsCapabilities.widgetDisplayModeRequests ===
       "user-initiated-only";
   }, [
-    toolCallId,
     resourceUri,
     cachedWidgetHtmlUrl,
     earlyEffectiveMcpAppsCapabilities.widgetDisplayModeRequests,
@@ -1059,7 +1215,9 @@ export function MCPAppsRenderer({
   const effectiveDisplayModeRef = useRef(effectiveDisplayMode);
   const serverIdRef = useRef(serverId);
   const toolCallIdRef = useRef(toolCallId);
+  const displayWidgetIdRef = useRef(displayWidgetId);
   const pipWidgetIdRef = useRef(pipWidgetId);
+  const ownsPipDisplayModeRef = useRef(ownsPipDisplayMode);
   const toolsMetadataRef = useRef(toolsMetadata);
   const onModelContextUpdateRef = useRef(onModelContextUpdate);
   const onAppSupportedDisplayModesChangeRef = useRef(
@@ -1077,10 +1235,10 @@ export function MCPAppsRenderer({
 
   // Source-identity guard for the async fetch effect. The renderer can be
   // reused across session swaps and prop changes, so an older fetch can
-  // resolve after `{ toolCallId, resourceUri, cachedWidgetHtmlUrl, cspMode,
-  // liveFetchPreferred }` has moved on. Each effect run sets this ref to
-  // its own key; the helpers below drop any state writes that don't still
-  // match the latest key.
+  // resolve after `{ resourceUri, cachedReplayWidgetHtmlUrl, cspMode,
+  // widgetFetchModeKey }` has moved on. Each effect run sets this ref to its
+  // own key; the helpers below drop any state writes that don't still match
+  // the latest key.
   const latestFetchSourceKeyRef = useRef<string>("");
   /**
    * Previous fetch-source key, kept for the debug-panel mount log. We
@@ -1150,11 +1308,10 @@ export function MCPAppsRenderer({
     // longer matches `latestFetchSourceKeyRef.current` when it resolves is
     // stale and MUST NOT mutate state.
     const fetchSourceKey = [
-      toolCallId,
       resourceUri ?? "",
-      cachedWidgetHtmlUrl ?? "",
+      cachedReplayWidgetHtmlUrl ?? "",
       cspMode,
-      liveFetchPreferred ? "live-pref" : "",
+      widgetFetchModeKey,
       // String() so `null` (cached-replay sentinel), `true`, and
       // `false` all serialize distinctly into the pipe-joined key.
       String(widgetInjectOpenAiCompatReloadKey),
@@ -1164,9 +1321,9 @@ export function MCPAppsRenderer({
     latestFetchSourceKeyRef.current = fetchSourceKey;
     // Mount log for the Sandbox debug panel. Record one entry per real
     // key change (not per effect re-run) so devs can spot self-induced
-    // reloads — e.g. a Convex history snapshot landing and flipping
-    // `cachedWidgetHtmlUrl`/`liveFetchPreferred` mid-session, which
-    // remounts the iframe and visually wipes the previous render.
+    // reloads — e.g. a saved view replay swapping in a different cached
+    // snapshot, which remounts the iframe and visually wipes the previous
+    // render.
     if (prevLoggedFetchSourceKeyRef.current !== fetchSourceKey) {
       const prev = prevLoggedFetchSourceKeyRef.current;
       const reason =
@@ -1174,7 +1331,7 @@ export function MCPAppsRenderer({
           ? "initial"
           : describeFetchSourceKeyDiff(prev, fetchSourceKey);
       prevLoggedFetchSourceKeyRef.current = fetchSourceKey;
-      recordMountStore(toolCallId, reason);
+      recordMountStore(toolCallIdRef.current, reason);
     }
     const isStillCurrent = () =>
       latestFetchSourceKeyRef.current === fetchSourceKey;
@@ -1274,7 +1431,7 @@ export function MCPAppsRenderer({
           readToolResultMeta(toolOutputRef.current) ??
           null,
         initialWidgetState,
-        toolId: toolCallId,
+        toolId: toolCallIdRef.current,
         toolName,
         theme: themeModeRef.current,
         cspMode,
@@ -1306,7 +1463,7 @@ export function MCPAppsRenderer({
           : undefined);
 
       // Stale fetch: source key moved on (e.g. session swap, CSP toggle,
-      // tool call change) while this request was in flight. Drop the
+      // or resource change) while this request was in flight. Drop the
       // result so it can't overwrite the newer commit's state.
       if (!isStillCurrent()) return true;
 
@@ -1345,7 +1502,7 @@ export function MCPAppsRenderer({
       // injected at fetch time. Replay reads both back when reproducing
       // the original render.
       setWidgetHtmlStore(
-        toolCallId,
+        toolCallIdRef.current,
         html,
         resolvedInjectedOpenAiCompat,
         resolvedInjectedOpenAiCompatCapabilities
@@ -1353,7 +1510,7 @@ export function MCPAppsRenderer({
 
       // Update the widget debug store with CSP and permissions info
       if (csp || permissions || !permissive) {
-        setWidgetCspStore(toolCallId, {
+        setWidgetCspStore(toolCallIdRef.current, {
           mode: permissive ? "permissive" : "widget-declared",
           connectDomains: csp?.connectDomains || [],
           resourceDomains: csp?.resourceDomains || [],
@@ -1448,7 +1605,6 @@ export function MCPAppsRenderer({
     // serverId/toolCallId via refs) and is declared after this effect.
   }, [
     toolState,
-    toolCallId,
     widgetHtml,
     loadedCspMode,
     loadedInjectOpenAiCompat,
@@ -1465,7 +1621,9 @@ export function MCPAppsRenderer({
     cspMode,
     isOffline,
     cachedWidgetHtmlUrl,
+    cachedReplayWidgetHtmlUrl,
     liveFetchPreferred,
+    widgetFetchModeKey,
     initialPrefersBorder,
     cachedReplayInjectOpenAiCompat,
     initialInjectedOpenAiCompatCapabilities,
@@ -1560,11 +1718,8 @@ export function MCPAppsRenderer({
               cursor === undefined ? {} : { cursor }
             );
             tools.push(
-              ...(result.tools ?? []).filter(
-                (t): t is AppToolDescriptor =>
-                  Boolean(
-                    t && typeof t.name === "string" && t.name.length > 0
-                  )
+              ...(result.tools ?? []).filter((t): t is AppToolDescriptor =>
+                Boolean(t && typeof t.name === "string" && t.name.length > 0)
               )
             );
             cursor = result.nextCursor;
@@ -1837,7 +1992,7 @@ export function MCPAppsRenderer({
         profile: activeMcpProfile,
         hostCapabilitiesOverride,
       }),
-    [effectiveHostStyle, activeMcpProfile, hostCapabilitiesOverride]
+    [effectiveHostStyle, activeMcpProfileKey, hostCapabilitiesOverrideKey]
   );
   // SEP-1865 spec-bridge matrix resolved from the live profile +
   // host style. Gates notification emissions (`tool-input-partial`,
@@ -2009,16 +2164,30 @@ export function MCPAppsRenderer({
   // `effectivePermissive` collapses to `false` whenever a host policy applies
   // — SandboxedIframe treats `permissive: true` as "skip CSP injection
   // entirely", which would silently neuter the resolver output.
-  const sandboxCspPolicy = activeMcpProfile?.apps?.sandbox?.csp;
-  const sandboxPermissionsPolicy = activeMcpProfile?.apps?.sandbox?.permissions;
+  const sandboxCspPolicy = useMemo(
+    () => activeMcpProfile?.apps?.sandbox?.csp,
+    [activeMcpProfileKey]
+  );
+  const sandboxPermissionsPolicy = useMemo(
+    () => activeMcpProfile?.apps?.sandbox?.permissions,
+    [activeMcpProfileKey]
+  );
   // Inspector-only emission knobs sourced directly from the profile. They
   // bypass the SEP-1865 resolver because they model browser-emission state
   // that has no spec slot (raw `sandbox=`/`allow=` tokens, CSP source
   // expressions). Passed through unchanged to <SandboxedIframe>.
-  const sandboxAttrsPolicy = activeMcpProfile?.apps?.sandbox?.sandboxAttrs;
-  const allowFeaturesPolicy = activeMcpProfile?.apps?.sandbox?.allowFeatures;
-  const cspDirectivesPolicy =
-    activeMcpProfile?.apps?.sandbox?.csp?.cspDirectives;
+  const sandboxAttrsPolicy = useMemo(
+    () => activeMcpProfile?.apps?.sandbox?.sandboxAttrs,
+    [activeMcpProfileKey]
+  );
+  const allowFeaturesPolicy = useMemo(
+    () => activeMcpProfile?.apps?.sandbox?.allowFeatures,
+    [activeMcpProfileKey]
+  );
+  const cspDirectivesPolicy = useMemo(
+    () => activeMcpProfile?.apps?.sandbox?.csp?.cspDirectives,
+    [activeMcpProfileKey]
+  );
   // Hosted-mode clamp for cspDirectives. The resolver's
   // `hostedClampExtraDeny` strips MCPJam app/API origins from the
   // widget-declared CSP (`restrictTo` + resource declaration), but
@@ -2400,7 +2569,15 @@ export function MCPAppsRenderer({
     if (typeof name !== "string" || typeof version !== "string") return null;
     if (name.trim() === "" || version.trim() === "") return null;
     return { name, version };
-  }, [activeMcpProfile]);
+  }, [activeMcpProfileKey]);
+  const resolvedBridgeHostInfo = useMemo(
+    () =>
+      (resolveHostInfo(activeMcpProfile) ?? {
+        name: "mcpjam-inspector",
+        version: __APP_VERSION__,
+      }) as { name: string; version: string },
+    [activeMcpProfileKey]
+  );
 
   useEffect(() => {
     if (!toolCallId) return;
@@ -2440,7 +2617,9 @@ export function MCPAppsRenderer({
     effectiveDisplayModeRef.current = effectiveDisplayMode;
     serverIdRef.current = serverId;
     toolCallIdRef.current = toolCallId;
+    displayWidgetIdRef.current = displayWidgetId;
     pipWidgetIdRef.current = pipWidgetId;
+    ownsPipDisplayModeRef.current = ownsPipDisplayMode;
     toolsMetadataRef.current = toolsMetadata;
     onModelContextUpdateRef.current = onModelContextUpdate;
     onAppSupportedDisplayModesChangeRef.current =
@@ -2457,7 +2636,9 @@ export function MCPAppsRenderer({
     effectiveDisplayMode,
     serverId,
     toolCallId,
+    displayWidgetId,
     pipWidgetId,
+    ownsPipDisplayMode,
     toolsMetadata,
     onModelContextUpdate,
     onAppSupportedDisplayModesChange,
@@ -2839,12 +3020,14 @@ export function MCPAppsRenderer({
         setDisplayModeRef.current(actualMode);
 
         if (actualMode === "pip") {
-          onRequestPipRef.current?.(toolCallIdRef.current);
+          onRequestPipRef.current?.(displayWidgetIdRef.current);
         } else if (
           (actualMode === "inline" || actualMode === "fullscreen") &&
-          pipWidgetIdRef.current === toolCallIdRef.current
+          ownsPipDisplayModeRef.current
         ) {
-          onExitPipRef.current?.(toolCallIdRef.current);
+          onExitPipRef.current?.(
+            pipWidgetIdRef.current ?? displayWidgetIdRef.current
+          );
         }
 
         return { mode: actualMode };
@@ -2855,14 +3038,15 @@ export function MCPAppsRenderer({
           content,
           structuredContent,
         }) => {
+          const currentToolCallId = toolCallIdRef.current;
           // Store in debug store for UI display
-          setWidgetModelContext(toolCallId, {
+          setWidgetModelContext(currentToolCallId, {
             content,
             structuredContent,
           });
 
           // Notify parent component to queue for next model turn
-          onModelContextUpdateRef.current?.(toolCallId, {
+          onModelContextUpdateRef.current?.(currentToolCallId, {
             content,
             structuredContent,
           });
@@ -2967,7 +3151,6 @@ export function MCPAppsRenderer({
     },
     [
       setIsReady,
-      toolCallId,
       setWidgetModelContext,
       logWidgetDebug,
       refreshAppProvidedTools,
@@ -3016,13 +3199,9 @@ export function MCPAppsRenderer({
     // another host (e.g. ChatGPT) override this via
     // `mcpProfile.apps.uiInitialize.hostInfo`; backend soft-validates
     // name+version when set so the cast below is safe.
-    const resolvedHostInfo = (resolveHostInfo(activeMcpProfile) ?? {
-      name: "mcpjam-inspector",
-      version: __APP_VERSION__,
-    }) as { name: string; version: string };
     const bridge = new AppBridge(
       null,
-      resolvedHostInfo,
+      resolvedBridgeHostInfo,
       {
         ...effectiveHostCapabilities,
         sandbox: {
@@ -3051,8 +3230,8 @@ export function MCPAppsRenderer({
           }
           if (SUPPRESSED_UI_LOG_METHODS.has(method)) return;
           logUiEvent({
-            widgetId: toolCallId,
-            serverId,
+            widgetId: toolCallIdRef.current,
+            serverId: serverIdRef.current,
             direction: "host-to-ui",
             protocol: "mcp-apps",
             method,
@@ -3085,8 +3264,8 @@ export function MCPAppsRenderer({
           }
           if (SUPPRESSED_UI_LOG_METHODS.has(method)) return;
           logUiEvent({
-            widgetId: toolCallId,
-            serverId,
+            widgetId: toolCallIdRef.current,
+            serverId: serverIdRef.current,
             direction: "ui-to-host",
             protocol: "mcp-apps",
             method,
@@ -3146,13 +3325,12 @@ export function MCPAppsRenderer({
       }
       bridge.close().catch(() => {});
       // Clear model context on widget teardown
-      setWidgetModelContext(toolCallId, null);
+      setWidgetModelContext(toolCallIdRef.current, null);
     };
   }, [
     logUiEvent,
     minimalMode,
     serverId,
-    toolCallId,
     widgetHtml,
     sandboxProxyReady,
     registerBridgeHandlers,
@@ -3172,7 +3350,7 @@ export function MCPAppsRenderer({
     // Bridge must rebuild when the host identity advertised in
     // ui/initialize changes — switching to a template that overrides
     // hostInfo (e.g. ChatGPT) is observable to the View.
-    activeMcpProfile,
+    resolvedBridgeHostInfo,
   ]);
 
   useEffect(() => {
@@ -3578,7 +3756,7 @@ export function MCPAppsRenderer({
             userPreferInlineRef.current = true;
             setDisplayMode("inline");
             if (isPip) {
-              onExitPip?.(toolCallId);
+              onExitPip?.(pipWidgetId ?? displayWidgetId);
             }
             // onExitFullscreen is called within setDisplayMode when leaving fullscreen
           }}
@@ -3599,8 +3777,8 @@ export function MCPAppsRenderer({
             onClick={() => {
               userPreferInlineRef.current = true;
               setDisplayMode("inline");
-              if (pipWidgetId === toolCallId) {
-                onExitPip?.(toolCallId);
+              if (ownsPipDisplayMode) {
+                onExitPip?.(pipWidgetId ?? displayWidgetId);
               }
             }}
             className="p-2 rounded-lg hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
@@ -3616,7 +3794,7 @@ export function MCPAppsRenderer({
           onClick={() => {
             userPreferInlineRef.current = true;
             setDisplayMode("inline");
-            onExitPip?.(toolCallId);
+            onExitPip?.(pipWidgetId ?? displayWidgetId);
           }}
           className="absolute left-2 top-2 z-10 flex h-6 w-6 items-center justify-center rounded-md bg-background/80 hover:bg-background border border-border/50 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
           aria-label="Close PiP mode"

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/useToolInputStreaming.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/useToolInputStreaming.ts
@@ -147,6 +147,14 @@ export interface UseToolInputStreamingParams {
   toolOutput: unknown;
   toolErrorText: string | undefined;
   toolCallId: string;
+  /**
+   * Whether this View should receive the one-shot complete tool-input
+   * notification for the current render. Resource-scoped persistent Views
+   * keep the iframe alive across tool calls, so later calls suppress input
+   * while still delivering results.
+   */
+  sendToolInput: boolean;
+  onToolInputSent?: () => void;
   /** Incremented when the guest re-initializes (e.g. SDK app after openai-compat shim) */
   reinitCount: number;
   /**
@@ -189,6 +197,8 @@ export function useToolInputStreaming({
   toolOutput,
   toolErrorText,
   toolCallId,
+  sendToolInput,
+  onToolInputSent,
   reinitCount,
   mcpAppsCapabilitiesRef,
 }: UseToolInputStreamingParams): UseToolInputStreamingReturn {
@@ -223,10 +233,16 @@ export function useToolInputStreaming({
 
   const canRenderStreamingInput = useMemo(() => {
     if (toolState !== "input-streaming") return true;
+    if (!sendToolInput) return true;
     // Avoid revealing a blank app shell on the fallback timer alone. The view
     // becomes visible after we have both a render signal and delivered input.
     return streamingRenderSignaled && hasDeliveredStreamingInput;
-  }, [hasDeliveredStreamingInput, streamingRenderSignaled, toolState]);
+  }, [
+    hasDeliveredStreamingInput,
+    sendToolInput,
+    streamingRenderSignaled,
+    toolState,
+  ]);
 
   // ── Callbacks ────────────────────────────────────────────────────────────
 
@@ -279,6 +295,7 @@ export function useToolInputStreaming({
 
   // 2. Fallback reveal timer
   useEffect(() => {
+    if (!sendToolInput) return;
     if (!isReady || toolState !== "input-streaming" || streamingRenderSignaled)
       return;
     if (streamingRevealTimerRef.current !== null) return;
@@ -287,7 +304,7 @@ export function useToolInputStreaming({
       streamingRevealTimerRef.current = null;
       setStreamingRenderSignaled(true);
     }, STREAMING_REVEAL_FALLBACK_MS);
-  }, [isReady, streamingRenderSignaled, toolState]);
+  }, [isReady, sendToolInput, streamingRenderSignaled, toolState]);
 
   // 3. Re-entry detection
   useEffect(() => {
@@ -308,7 +325,12 @@ export function useToolInputStreaming({
 
   // 4. Partial input throttled delivery
   useEffect(() => {
-    if (!isReady || toolState !== "input-streaming" || toolInputSentRef.current)
+    if (
+      !sendToolInput ||
+      !isReady ||
+      toolState !== "input-streaming" ||
+      toolInputSentRef.current
+    )
       return;
     if (!hasToolInputData) return;
     const resolvedToolInput = toolInput ?? {};
@@ -367,6 +389,7 @@ export function useToolInputStreaming({
   }, [
     hasToolInputData,
     isReady,
+    sendToolInput,
     toolCallId,
     toolInput,
     toolState,
@@ -388,6 +411,7 @@ export function useToolInputStreaming({
       streamingRevealTimerRef.current = null;
     }
     pendingToolInputPartialRef.current = null;
+    if (!sendToolInput) return;
     const bridge = bridgeRef.current;
     if (!bridge) return;
 
@@ -401,13 +425,23 @@ export function useToolInputStreaming({
     }
     lastToolInputRef.current = serialized;
     toolInputSentRef.current = true;
+    onToolInputSent?.();
     Promise.resolve(
       bridge.sendToolInput({ arguments: resolvedToolInput }),
     ).catch(() => {
       toolInputSentRef.current = false;
       lastToolInputRef.current = null;
     });
-  }, [isReady, toolCallId, toolInput, toolState, bridgeRef, reinitCount]);
+  }, [
+    isReady,
+    toolCallId,
+    toolInput,
+    toolState,
+    bridgeRef,
+    reinitCount,
+    sendToolInput,
+    onToolInputSent,
+  ]);
 
   // 6. Tool result delivery
   useEffect(() => {
@@ -416,8 +450,9 @@ export function useToolInputStreaming({
     if (!bridge || !toolOutput) return;
 
     const serialized = JSON.stringify(toolOutput);
-    if (lastToolOutputRef.current === serialized) return;
-    lastToolOutputRef.current = serialized;
+    const outputKey = `${toolCallId}:${serialized}`;
+    if (lastToolOutputRef.current === outputKey) return;
+    lastToolOutputRef.current = outputKey;
     bridge.sendToolResult(toolOutput as CallToolResult);
   }, [isReady, toolCallId, toolOutput, toolState, bridgeRef, reinitCount]);
 
@@ -435,8 +470,9 @@ export function useToolInputStreaming({
           ? toolOutput
           : "Tool execution failed");
 
-    if (lastToolErrorRef.current === errorMessage) return;
-    lastToolErrorRef.current = errorMessage;
+    const errorKey = `${toolCallId}:${errorMessage}`;
+    if (lastToolErrorRef.current === errorKey) return;
+    lastToolErrorRef.current = errorKey;
 
     // SEP-1865: Send tool-cancelled for errors instead of tool-result
     // with isError. Matrix gate: Microsoft 365 Copilot does not

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/useToolInputStreaming.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/useToolInputStreaming.ts
@@ -150,8 +150,8 @@ export interface UseToolInputStreamingParams {
   /**
    * Whether this View should receive the one-shot complete tool-input
    * notification for the current render. Resource-scoped persistent Views
-   * keep the iframe alive across tool calls, so later calls suppress input
-   * while still delivering results.
+   * keep the iframe alive across tool calls, but each new tool call still
+   * gets a complete input notification before its result.
    */
   sendToolInput: boolean;
   onToolInputSent?: () => void;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-surface-context.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-surface-context.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+const WidgetSurfaceHostContext = createContext(false);
+
+export function WidgetSurfaceHostProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <WidgetSurfaceHostContext.Provider value={true}>
+      {children}
+    </WidgetSurfaceHostContext.Provider>
+  );
+}
+
+export function usePersistentWidgetSurfaceHost() {
+  return useContext(WidgetSurfaceHostContext);
+}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-surface-host.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-surface-host.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useLayoutEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  MCPAppsRendererSurface,
+  type MCPAppsRendererProps,
+} from "./mcp-apps-renderer";
+import {
+  getRenderableSurfaceEntries,
+  useWidgetSurfaceStore,
+  type WidgetSurfaceId,
+} from "./widget-surface-store";
+export { WidgetSurfaceHostProvider } from "./widget-surface-context";
+
+function createSurfaceContainer(surfaceId: WidgetSurfaceId) {
+  const container = document.createElement("div");
+  container.dataset.mcpAppSurfaceContainer = surfaceId;
+  container.style.display = "contents";
+  return container;
+}
+
+function WidgetSurfacePortal({
+  anchorElement,
+  parkingElement,
+  props,
+  surfaceId,
+}: {
+  anchorElement: HTMLDivElement | null;
+  parkingElement: HTMLDivElement | null;
+  props: MCPAppsRendererProps;
+  surfaceId: WidgetSurfaceId;
+}) {
+  const [container] = useState(() => createSurfaceContainer(surfaceId));
+  const targetElement = anchorElement ?? parkingElement;
+
+  useLayoutEffect(() => {
+    if (!targetElement) return;
+    if (container.parentElement !== targetElement) {
+      targetElement.appendChild(container);
+    }
+  }, [container, targetElement]);
+
+  useEffect(() => {
+    return () => {
+      container.remove();
+    };
+  }, [container]);
+
+  return createPortal(
+    <MCPAppsRendererSurface
+      {...props}
+      persistentSurfaceId={surfaceId}
+    />,
+    container,
+    surfaceId
+  );
+}
+
+export function WidgetSurfaceHost({
+  chatSessionId,
+}: {
+  chatSessionId?: string;
+}) {
+  const [parkingElement, setParkingElement] = useState<HTMLDivElement | null>(
+    null
+  );
+  const surfaces = useWidgetSurfaceStore((state) => state.surfaces);
+  const entries = useMemo(
+    () => getRenderableSurfaceEntries(surfaces, chatSessionId),
+    [chatSessionId, surfaces]
+  );
+
+  useEffect(() => {
+    return () => {
+      useWidgetSurfaceStore.getState().clearChatSession(chatSessionId);
+    };
+  }, [chatSessionId]);
+
+  return (
+    <>
+      <div
+        ref={setParkingElement}
+        data-mcp-app-surface-parking
+        style={{
+          height: 0,
+          overflow: "hidden",
+          pointerEvents: "none",
+          position: "absolute",
+          width: 0,
+        }}
+      />
+      {entries.map(({ surfaceId, anchorElement, props }) => (
+        <WidgetSurfacePortal
+          key={surfaceId}
+          anchorElement={anchorElement}
+          parkingElement={parkingElement}
+          props={props}
+          surfaceId={surfaceId}
+        />
+      ))}
+    </>
+  );
+}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-surface-host.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-surface-host.tsx
@@ -20,11 +20,13 @@ function createSurfaceContainer(surfaceId: WidgetSurfaceId) {
 
 function WidgetSurfacePortal({
   anchorElement,
+  initialToolCallId,
   parkingElement,
   props,
   surfaceId,
 }: {
   anchorElement: HTMLDivElement | null;
+  initialToolCallId: string;
   parkingElement: HTMLDivElement | null;
   props: MCPAppsRendererProps;
   surfaceId: WidgetSurfaceId;
@@ -48,6 +50,7 @@ function WidgetSurfacePortal({
   return createPortal(
     <MCPAppsRendererSurface
       {...props}
+      persistentSurfaceInitialToolCallId={initialToolCallId}
       persistentSurfaceId={surfaceId}
     />,
     container,
@@ -88,10 +91,11 @@ export function WidgetSurfaceHost({
           width: 0,
         }}
       />
-      {entries.map(({ surfaceId, anchorElement, props }) => (
+      {entries.map(({ surfaceId, anchorElement, initialToolCallId, props }) => (
         <WidgetSurfacePortal
           key={surfaceId}
           anchorElement={anchorElement}
+          initialToolCallId={initialToolCallId}
           parkingElement={parkingElement}
           props={props}
           surfaceId={surfaceId}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-surface-store.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-surface-store.ts
@@ -1,0 +1,109 @@
+import { create } from "zustand";
+import type { MCPAppsRendererProps } from "./mcp-apps-renderer";
+
+export type WidgetSurfaceId = string;
+
+export interface WidgetSurfaceRecord {
+  surfaceId: WidgetSurfaceId;
+  chatSessionId?: string;
+  toolCallId: string;
+  props: MCPAppsRendererProps;
+  anchorElement: HTMLDivElement | null;
+}
+
+interface WidgetSurfaceStoreState {
+  surfaces: Map<WidgetSurfaceId, WidgetSurfaceRecord>;
+  upsertRegistration: (
+    surfaceId: WidgetSurfaceId,
+    toolCallId: string,
+    props: MCPAppsRendererProps
+  ) => void;
+  setAnchor: (
+    surfaceId: WidgetSurfaceId,
+    toolCallId: string,
+    anchorElement: HTMLDivElement | null
+  ) => void;
+  releaseRegistration: (surfaceId: WidgetSurfaceId, toolCallId: string) => void;
+  clearChatSession: (chatSessionId?: string) => void;
+}
+
+export const useWidgetSurfaceStore = create<WidgetSurfaceStoreState>((set) => ({
+  surfaces: new Map(),
+
+  upsertRegistration: (surfaceId, toolCallId, props) => {
+    set((state) => {
+      const surfaces = new Map(state.surfaces);
+      const existing = surfaces.get(surfaceId);
+
+      surfaces.set(surfaceId, {
+        surfaceId,
+        chatSessionId: props.chatSessionId,
+        toolCallId,
+        props,
+        anchorElement: existing?.anchorElement ?? null,
+      });
+
+      return { surfaces };
+    });
+  },
+
+  setAnchor: (surfaceId, toolCallId, anchorElement) => {
+    set((state) => {
+      const existing = state.surfaces.get(surfaceId);
+      if (!existing || existing.toolCallId !== toolCallId) return {};
+      if (existing.anchorElement === anchorElement) return {};
+
+      const surfaces = new Map(state.surfaces);
+      surfaces.set(surfaceId, {
+        ...existing,
+        anchorElement,
+      });
+      return { surfaces };
+    });
+  },
+
+  releaseRegistration: (surfaceId, toolCallId) => {
+    set((state) => {
+      const existing = state.surfaces.get(surfaceId);
+      if (!existing || existing.toolCallId !== toolCallId) return {};
+
+      const surfaces = new Map(state.surfaces);
+      surfaces.delete(surfaceId);
+      return { surfaces };
+    });
+  },
+
+  clearChatSession: (chatSessionId) => {
+    set((state) => {
+      const surfaces = new Map(state.surfaces);
+      for (const [surfaceId, surface] of state.surfaces) {
+        if (surface.chatSessionId === chatSessionId) {
+          surfaces.delete(surfaceId);
+        }
+      }
+      return { surfaces };
+    });
+  },
+}));
+
+export function getRenderableSurfaceEntries(
+  surfaces: Map<WidgetSurfaceId, WidgetSurfaceRecord>,
+  chatSessionId?: string
+) {
+  const entries: Array<{
+    surfaceId: WidgetSurfaceId;
+    anchorElement: HTMLDivElement | null;
+    props: MCPAppsRendererProps;
+  }> = [];
+
+  for (const surface of surfaces.values()) {
+    if (surface.chatSessionId !== chatSessionId) continue;
+    entries.push({
+      surfaceId: surface.surfaceId,
+      anchorElement: surface.anchorElement,
+      props: surface.props,
+    });
+  }
+
+  return entries;
+}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-surface-store.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-surface-store.ts
@@ -168,6 +168,12 @@ export function getRenderableSurfaceEntries(
       surface.latestToolCallId
     );
     if (!latestRegistration) continue;
+    // Keep the mounted iframe under its original row. Reparenting a live
+    // iframe can reload its browsing context in real browsers, which wipes
+    // in-memory app state for stateful widgets like games.
+    const initialRegistration = surface.registrations.get(
+      surface.initialToolCallId
+    );
     const fallbackAnchor =
       Array.from(surface.registrations.values()).find(
         (registration) => registration.anchorElement !== null
@@ -175,7 +181,7 @@ export function getRenderableSurfaceEntries(
 
     entries.push({
       surfaceId: surface.surfaceId,
-      anchorElement: latestRegistration.anchorElement ?? fallbackAnchor,
+      anchorElement: initialRegistration?.anchorElement ?? fallbackAnchor,
       initialToolCallId: surface.initialToolCallId,
       props: latestRegistration.props,
     });

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-surface-store.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-surface-store.ts
@@ -3,16 +3,24 @@ import type { MCPAppsRendererProps } from "./mcp-apps-renderer";
 
 export type WidgetSurfaceId = string;
 
-export interface WidgetSurfaceRecord {
-  surfaceId: WidgetSurfaceId;
-  chatSessionId?: string;
+interface WidgetSurfaceRegistration {
   toolCallId: string;
+  order: number;
   props: MCPAppsRendererProps;
   anchorElement: HTMLDivElement | null;
 }
 
+export interface WidgetSurfaceRecord {
+  surfaceId: WidgetSurfaceId;
+  chatSessionId?: string;
+  initialToolCallId: string;
+  latestToolCallId: string;
+  registrations: Map<string, WidgetSurfaceRegistration>;
+}
+
 interface WidgetSurfaceStoreState {
   surfaces: Map<WidgetSurfaceId, WidgetSurfaceRecord>;
+  nextOrder: number;
   upsertRegistration: (
     surfaceId: WidgetSurfaceId,
     toolCallId: string,
@@ -29,34 +37,55 @@ interface WidgetSurfaceStoreState {
 
 export const useWidgetSurfaceStore = create<WidgetSurfaceStoreState>((set) => ({
   surfaces: new Map(),
+  nextOrder: 0,
 
   upsertRegistration: (surfaceId, toolCallId, props) => {
     set((state) => {
       const surfaces = new Map(state.surfaces);
       const existing = surfaces.get(surfaceId);
+      const registrations = new Map(existing?.registrations);
+      const currentRegistration = registrations.get(toolCallId);
+      const isNewRegistration = !currentRegistration;
+      const order = currentRegistration?.order ?? state.nextOrder;
+
+      registrations.set(toolCallId, {
+        toolCallId,
+        order,
+        props,
+        anchorElement: currentRegistration?.anchorElement ?? null,
+      });
 
       surfaces.set(surfaceId, {
         surfaceId,
         chatSessionId: props.chatSessionId,
-        toolCallId,
-        props,
-        anchorElement: existing?.anchorElement ?? null,
+        initialToolCallId: existing?.initialToolCallId ?? toolCallId,
+        latestToolCallId: toolCallId,
+        registrations,
       });
 
-      return { surfaces };
+      return {
+        surfaces,
+        nextOrder: isNewRegistration ? state.nextOrder + 1 : state.nextOrder,
+      };
     });
   },
 
   setAnchor: (surfaceId, toolCallId, anchorElement) => {
     set((state) => {
       const existing = state.surfaces.get(surfaceId);
-      if (!existing || existing.toolCallId !== toolCallId) return {};
-      if (existing.anchorElement === anchorElement) return {};
+      const registration = existing?.registrations.get(toolCallId);
+      if (!existing || !registration) return {};
+      if (registration.anchorElement === anchorElement) return {};
 
+      const registrations = new Map(existing.registrations);
+      registrations.set(toolCallId, {
+        ...registration,
+        anchorElement,
+      });
       const surfaces = new Map(state.surfaces);
       surfaces.set(surfaceId, {
         ...existing,
-        anchorElement,
+        registrations,
       });
       return { surfaces };
     });
@@ -65,16 +94,52 @@ export const useWidgetSurfaceStore = create<WidgetSurfaceStoreState>((set) => ({
   releaseRegistration: (surfaceId, toolCallId) => {
     set((state) => {
       const existing = state.surfaces.get(surfaceId);
-      if (!existing || existing.toolCallId !== toolCallId) return {};
+      if (!existing || !existing.registrations.has(toolCallId)) return {};
 
       const surfaces = new Map(state.surfaces);
-      surfaces.delete(surfaceId);
+      const registrations = new Map(existing.registrations);
+      registrations.delete(toolCallId);
+
+      if (registrations.size === 0) {
+        surfaces.delete(surfaceId);
+        return { surfaces };
+      }
+
+      let latestRegistration: WidgetSurfaceRegistration | null = null;
+      for (const registration of registrations.values()) {
+        if (
+          latestRegistration === null ||
+          registration.order > latestRegistration.order
+        ) {
+          latestRegistration = registration;
+        }
+      }
+
+      surfaces.set(surfaceId, {
+        ...existing,
+        latestToolCallId:
+          existing.latestToolCallId === toolCallId
+            ? latestRegistration?.toolCallId ?? existing.latestToolCallId
+            : existing.latestToolCallId,
+        registrations,
+      });
       return { surfaces };
     });
   },
 
   clearChatSession: (chatSessionId) => {
     set((state) => {
+      // Skip the Map allocation + subscriber notification when no surface
+      // belongs to this session (the common case on Thread unmount).
+      let hasMatch = false;
+      for (const surface of state.surfaces.values()) {
+        if (surface.chatSessionId === chatSessionId) {
+          hasMatch = true;
+          break;
+        }
+      }
+      if (!hasMatch) return {};
+
       const surfaces = new Map(state.surfaces);
       for (const [surfaceId, surface] of state.surfaces) {
         if (surface.chatSessionId === chatSessionId) {
@@ -93,15 +158,26 @@ export function getRenderableSurfaceEntries(
   const entries: Array<{
     surfaceId: WidgetSurfaceId;
     anchorElement: HTMLDivElement | null;
+    initialToolCallId: string;
     props: MCPAppsRendererProps;
   }> = [];
 
   for (const surface of surfaces.values()) {
     if (surface.chatSessionId !== chatSessionId) continue;
+    const latestRegistration = surface.registrations.get(
+      surface.latestToolCallId
+    );
+    if (!latestRegistration) continue;
+    const fallbackAnchor =
+      Array.from(surface.registrations.values()).find(
+        (registration) => registration.anchorElement !== null
+      )?.anchorElement ?? null;
+
     entries.push({
       surfaceId: surface.surfaceId,
-      anchorElement: surface.anchorElement,
-      props: surface.props,
+      anchorElement: latestRegistration.anchorElement ?? fallbackAnchor,
+      initialToolCallId: surface.initialToolCallId,
+      props: latestRegistration.props,
     });
   }
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-surface-store.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/widget-surface-store.ts
@@ -47,6 +47,13 @@ export const useWidgetSurfaceStore = create<WidgetSurfaceStoreState>((set) => ({
       const currentRegistration = registrations.get(toolCallId);
       const isNewRegistration = !currentRegistration;
       const order = currentRegistration?.order ?? state.nextOrder;
+      const latestRegistration = existing?.registrations.get(
+        existing.latestToolCallId
+      );
+      const shouldBecomeLatest =
+        !existing ||
+        !latestRegistration ||
+        (isNewRegistration && order > latestRegistration.order);
 
       registrations.set(toolCallId, {
         toolCallId,
@@ -59,7 +66,9 @@ export const useWidgetSurfaceStore = create<WidgetSurfaceStoreState>((set) => ({
         surfaceId,
         chatSessionId: props.chatSessionId,
         initialToolCallId: existing?.initialToolCallId ?? toolCallId,
-        latestToolCallId: toolCallId,
+        latestToolCallId: shouldBecomeLatest
+          ? toolCallId
+          : existing.latestToolCallId,
         registrations,
       });
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/message-view.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/message-view.tsx
@@ -49,7 +49,7 @@ interface MessageViewProps {
   onExitPip: (toolCallId: string) => void;
   onRequestFullscreen: (toolCallId: string) => void;
   onExitFullscreen: (toolCallId: string) => void;
-  onRequestTeardown?: (toolCallId: string) => void;
+  onRequestTeardown?: (toolCallId: string, displayWidgetId?: string) => void;
   tornDownWidgetIds?: ReadonlySet<string>;
   displayMode?: DisplayMode;
   onDisplayModeChange?: (mode: DisplayMode) => void;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
@@ -339,6 +339,7 @@ export function PartSwitch({
         <>
           <ToolPart
             part={toolPart}
+            chatSessionId={chatSessionId}
             uiType={uiType}
             displayMode={interactive ? displayMode : undefined}
             pipWidgetId={pipWidgetId}
@@ -403,6 +404,7 @@ export function PartSwitch({
     return (
       <ToolPart
         part={toolPart}
+        chatSessionId={chatSessionId}
         uiType={uiType}
         onSaveView={allowSaveView ? handleSaveView : undefined}
         canSaveView={allowSaveView ? canSaveView : undefined}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/part-switch.tsx
@@ -96,7 +96,7 @@ export function PartSwitch({
   onExitPip: (toolCallId: string) => void;
   onRequestFullscreen: (toolCallId: string) => void;
   onExitFullscreen: (toolCallId: string) => void;
-  onRequestTeardown?: (toolCallId: string) => void;
+  onRequestTeardown?: (toolCallId: string, displayWidgetId?: string) => void;
   tornDownWidgetIds?: ReadonlySet<string>;
   displayMode?: DisplayMode;
   onDisplayModeChange?: (mode: DisplayMode) => void;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/parts/tool-part.tsx
@@ -29,11 +29,7 @@ import { type DisplayMode } from "@/stores/ui-playground-store";
 import { usePreferencesStore } from "@/stores/preferences/preferences-provider";
 import { useWidgetDebugStore } from "@/stores/widget-debug-store";
 import { UIType } from "@/lib/mcp-ui/mcp-apps-utils";
-import {
-  useAppToolInvocationLog,
-  useAppToolsRegistry,
-} from "../mcp-apps/app-tools-registry";
-import { useShallow } from "zustand/react/shallow";
+import { useAppToolAttribution } from "../mcp-apps/app-tools-registry";
 import {
   getToolNameFromType,
   getToolStateMeta,
@@ -62,6 +58,7 @@ const SAVE_VIEW_REDIRECTED_KEY = "mcpjam-save-view-redirected";
 
 export function ToolPart({
   part,
+  chatSessionId,
   uiType,
   displayMode,
   pipWidgetId,
@@ -82,6 +79,7 @@ export function ToolPart({
   minimalMode = false,
 }: {
   part: ToolUIPart<UITools> | DynamicToolUIPart;
+  chatSessionId?: string;
   uiType?: UIType | null;
   displayMode?: DisplayMode;
   pipWidgetId?: string | null;
@@ -113,41 +111,10 @@ export function ToolPart({
     ? part.toolName
     : getToolNameFromType((part as any).type);
 
-  // SEP-1865 App-Provided Tools: tool names matching `/^app_[a-z0-9]{8}$/i`
-  // are opaque aliases for tools registered inside iframes. Subscribe to the
-  // registry so the UI shows the human-readable raw name + an attribution
-  // chip ("from <App Name>") instead of the alias. Falls back to the raw
-  // alias when the registry has no entry — happens during the brief window
-  // before `oninitialized` fires, or after the iframe has been torn down.
-  //
-  // `useShallow` is load-bearing: the selector returns a fresh object on
-  // every call, so without shallow equality Zustand sees "changed" on
-  // every render and triggers infinite re-renders while the model
-  // streams tool-call parts.
-  const registryAppToolAttribution = useAppToolsRegistry(
-    useShallow((s) => {
-      if (!/^app_[a-z0-9]{8}$/i.test(label)) return null;
-      const entry = s.aliases.get(label);
-      if (!entry) return null;
-      const inst = s.instancesByBridgeId.get(entry.bridgeId);
-      if (!inst) return null;
-      return { rawName: entry.rawName, appName: inst.appName };
-    })
-  );
-  const invocationAppToolAttribution = useAppToolInvocationLog(
-    useShallow((s) => {
-      if (!/^app_[a-z0-9]{8}$/i.test(label)) return null;
-      for (let i = s.records.length - 1; i >= 0; i -= 1) {
-        const record = s.records[i];
-        if (record.alias === label) {
-          return { rawName: record.rawName, appName: record.appName };
-        }
-      }
-      return null;
-    })
-  );
-  const appToolAttribution =
-    registryAppToolAttribution ?? invocationAppToolAttribution;
+  // SEP-1865 App-Provided Tools: opaque `app_<hash>` aliases are resolved
+  // through the shared app-tool registry/log helper so UI never leaks the
+  // model-facing alias when a human-readable tool name is available.
+  const appToolAttribution = useAppToolAttribution(label, chatSessionId);
   const displayLabel = appToolAttribution?.rawName ?? label;
 
   const toolCallId = (part as any).toolCallId as string | undefined;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/transcript-thread.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/transcript-thread.tsx
@@ -94,7 +94,7 @@ export interface TranscriptThreadProps extends MessageViewPassthroughProps {
   onExitPip?: (toolCallId: string) => void;
   onRequestFullscreen?: (toolCallId: string) => void;
   onExitFullscreen?: (toolCallId: string) => void;
-  onRequestTeardown?: (toolCallId: string) => void;
+  onRequestTeardown?: (toolCallId: string, displayWidgetId?: string) => void;
   tornDownWidgetIds?: ReadonlySet<string>;
   displayMode?: DisplayMode;
   onDisplayModeChange?: (mode: DisplayMode) => void;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/widget-replay.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/widget-replay.tsx
@@ -48,7 +48,7 @@ export interface WidgetReplayProps {
   onExitPip?: (toolCallId: string) => void;
   onRequestFullscreen?: (toolCallId: string) => void;
   onExitFullscreen?: (toolCallId: string) => void;
-  onRequestTeardown?: (toolCallId: string) => void;
+  onRequestTeardown?: (toolCallId: string, displayWidgetId?: string) => void;
   displayMode?: DisplayMode;
   onDisplayModeChange?: (mode: DisplayMode) => void;
   onAppSupportedDisplayModesChange?: (modes: DisplayMode[] | undefined) => void;

--- a/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
+++ b/mcpjam-inspector/client/src/components/ui-playground/PlaygroundMain.tsx
@@ -2971,6 +2971,7 @@ export function PlaygroundMain({
       {/* Fullscreen overlay chat (input pinned + collapsible thread) */}
       {showFullscreenChatOverlay && (
         <FullscreenChatOverlay
+          chatSessionId={chatSessionId}
           messages={messages}
           open={isFullscreenChatOpen}
           onOpenChange={setIsFullscreenChatOpen}

--- a/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
+++ b/mcpjam-inspector/client/src/components/ui/__tests__/sandboxed-iframe.test.tsx
@@ -15,7 +15,7 @@
  * stricter real host.
  */
 import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import { SandboxedIframe } from "@/components/ui/sandboxed-iframe";
 
 function getOuterIframeSandbox(container: HTMLElement): string[] {
@@ -267,6 +267,69 @@ describe("SandboxedIframe — outer allow attribute (allowFeatures injection gua
     const allow = getOuterIframeAllow(container);
     expect(allow).toContain("camera *");
     expect(allow).not.toContain("local-network-access");
+  });
+});
+
+describe("SandboxedIframe — resource-ready delivery", () => {
+  function dispatchFromIframe(
+    iframe: HTMLIFrameElement,
+    data: unknown,
+  ): void {
+    const proxyOrigin = new URL(iframe.src).origin;
+    const event = new MessageEvent("message", {
+      data,
+      source: iframe.contentWindow!,
+      origin: proxyOrigin,
+    });
+    window.dispatchEvent(event);
+  }
+
+  it("does not resend sandbox-resource-ready for semantically unchanged payloads", async () => {
+    const renderIframe = (csp: { connectDomains: string[] }) => (
+      <SandboxedIframe
+        html="<html><body>widget</body></html>"
+        csp={{
+          connectDomains: csp.connectDomains,
+          resourceDomains: [],
+          frameDomains: [],
+          baseUriDomains: [],
+        }}
+        permissions={{ clipboardWrite: {} }}
+        sandboxAttrs={["allow-forms"]}
+        cspDirectives={{ "script-src": ["'unsafe-inline'"] }}
+        onMessage={() => {}}
+      />
+    );
+    const { container, rerender } = render(
+      renderIframe({ connectDomains: ["https://api.example.com"] }),
+    );
+    const iframe = container.querySelector("iframe") as HTMLIFrameElement;
+    const postMessageSpy = vi.spyOn(iframe.contentWindow!, "postMessage");
+
+    act(() => {
+      dispatchFromIframe(iframe, {
+        jsonrpc: "2.0",
+        method: "ui/notifications/sandbox-proxy-ready",
+      });
+    });
+
+    await vi.waitFor(() => {
+      expect(postMessageSpy).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(renderIframe({ connectDomains: ["https://api.example.com"] }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(postMessageSpy).toHaveBeenCalledTimes(1);
+
+    rerender(renderIframe({ connectDomains: ["https://next.example.com"] }));
+
+    await vi.waitFor(() => {
+      expect(postMessageSpy).toHaveBeenCalledTimes(2);
+    });
   });
 });
 

--- a/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
+++ b/mcpjam-inspector/client/src/components/ui/sandboxed-iframe.tsx
@@ -14,6 +14,7 @@
  */
 
 import { HOSTED_MODE, SANDBOX_ORIGIN } from "@/lib/config";
+import { stableStringifyJson } from "@/lib/client-config";
 import {
   useRef,
   useState,
@@ -113,6 +114,7 @@ export const SandboxedIframe = forwardRef<
 ) {
   const outerRef = useRef<HTMLIFrameElement>(null);
   const [proxyReady, setProxyReady] = useState(false);
+  const lastResourceReadyKeyRef = useRef<string | null>(null);
 
   // SEP-1865: Host and Sandbox MUST have different origins.
   //
@@ -338,9 +340,38 @@ export const SandboxedIframe = forwardRef<
     return Array.from(tokens).sort().join(" ");
   }, [sandbox, sandboxAttrs]);
 
+  const resourceReadyKey = useMemo(
+    () =>
+      stableStringifyJson({
+        csp: csp ?? null,
+        cspDirectives: cspDirectives ?? null,
+        html: html ?? null,
+        permissive: permissive ?? null,
+        permissions: permissions ?? null,
+        sandbox,
+        sandboxAttrs: sandboxAttrs ?? null,
+      }),
+    [
+      csp,
+      cspDirectives,
+      html,
+      permissive,
+      permissions,
+      sandbox,
+      sandboxAttrs,
+    ],
+  );
+
+  useEffect(() => {
+    if (!proxyReady) lastResourceReadyKeyRef.current = null;
+  }, [proxyReady]);
+
   // Send HTML, CSP, and permissions to sandbox when ready (SEP-1865)
   useEffect(() => {
     if (!proxyReady || !html) return;
+    const resourceTargetKey = `${sandboxProxyOrigin}\0${resourceReadyKey}`;
+    if (lastResourceReadyKeyRef.current === resourceTargetKey) return;
+    lastResourceReadyKeyRef.current = resourceTargetKey;
 
     outerRef.current?.contentWindow?.postMessage(
       {
@@ -366,6 +397,10 @@ export const SandboxedIframe = forwardRef<
       },
       sandboxProxyOrigin,
     );
+    // This effect intentionally depends on the semantic payload key instead
+    // of raw object props. Re-sending `sandbox-resource-ready` makes the
+    // proxy assign inner `srcdoc` again, which restarts the app even when the
+    // HTML/CSP/permission payload is unchanged.
     // `colorScheme` and `allowFeatures` are intentionally OMITTED from
     // this dep list. The proxy handles `sandbox-resource-ready` by
     // rebuilding the CSP and assigning `inner.srcdoc`, which reloads the
@@ -385,12 +420,7 @@ export const SandboxedIframe = forwardRef<
   }, [
     proxyReady,
     html,
-    sandbox,
-    csp,
-    permissions,
-    sandboxAttrs,
-    cspDirectives,
-    permissive,
+    resourceReadyKey,
     sandboxProxyOrigin,
   ]);
 


### PR DESCRIPTION
## Summary

Persist MCP App iframes across transcript re-renders while keeping the spec boundary at one View per tool call. The thread-level surface host now keeps each tool call's iframe alive through anchor churn, but a later tool call for the same `ui://` resource gets its own fresh iframe/AppBridge.

## Root Cause

The state loss was not browser-specific. A live MCP App iframe was tied directly to a transient transcript anchor, so React could unmount the iframe during message/tool-call rerenders, close the bridge, emit `ui/resource-teardown`, and drop fullscreen/state.

The earlier resource-scoped version overcorrected by sharing one iframe across repeated tool calls for the same resource. SEP-1865 describes `toolInfo` as the metadata of the tool call that instantiated the View, and `ui/notifications/tool-input` is at most once per View before `tool-result`, so the persistent boundary should be a single tool call, not a resource across calls.

Additional same-call reset paths were possible when recreated-but-equivalent host profile/capability/sandbox objects rebuilt the bridge, when a transient anchor `null` moved the iframe into parking, or when `SandboxedIframe` resent an equivalent `sandbox-resource-ready` payload and the proxy reassigned inner `srcdoc`.

## Changes

- Add a persistent widget surface host/store/context for MCP Apps.
- Key live surfaces by `chatSessionId`, `serverId`, `resourceUri`, `toolCallId`, and surface kind.
- Keep each tool call's DOM container stable while its transcript anchor rerenders.
- Create a fresh AppBridge/iframe for a new tool call, even when it uses the same `resourceUri`.
- Remove the cross-call owner/latest registration model from the surface store.
- Delay anchor clearing for one tick so transient ref-null during transcript rerender does not park/move the live iframe.
- Make `SandboxedIframe` idempotent for semantically unchanged `sandbox-resource-ready` payloads so prop identity churn does not reload inner `srcdoc`.
- Avoid treating live-preferred cached fallback props as a new cached-only replay source.
- Use stable semantic keys for active MCP profile, host capability override, and sandbox policy dependencies so recreated equivalent objects do not rebuild the bridge.
- Add regression coverage for same-call anchor churn, new tool-call isolation, profile/override object recreation, fullscreen ownership, and resource-ready idempotence.

## Validation

- `npm test -w @mcpjam/inspector -- client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx`
- `npm test -w @mcpjam/inspector -- client/src/components/chat-v2/__tests__/Thread.test.tsx client/src/components/chat-v2/__tests__/TranscriptThread.test.tsx client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx client/src/components/ui/__tests__/sandboxed-iframe.test.tsx`
- `npm run typecheck:client -w @mcpjam/inspector && git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large changes to MCP App iframe lifecycle, display-mode ownership, and fullscreen transcript rendering; mistakes could cause stale widgets, stuck fullscreen, or lost in-iframe state, though behavior is heavily covered by new tests.
> 
> **Overview**
> Introduces a **persistent widget surface host** so live MCP App iframes stay mounted through anchor/transcript churn instead of tearing down on every rerender. Surfaces are keyed by **tool call** (session, server, resource URI, `toolCallId`) so a new `tools/call` on the same resource gets its own iframe/AppBridge, matching SEP-1865 one-View-per-call semantics. Rows register stable anchor divs; `WidgetSurfaceHost` portals `MCPAppsRendererSurface` into them, with deferred anchor clears to avoid parking the iframe on transient ref-null.
> 
> **Thread** wraps the transcript in `WidgetSurfaceHostProvider`, mounts `WidgetSurfaceHost`, and expands PiP/fullscreen/teardown handling via **widget ownership sets** (surface id plus all registered tool calls). Teardown and exit callbacks can take an optional **display widget id** for persistent surfaces.
> 
> **MCPAppsRenderer** splits into registration vs inline surface; live paths use the store unless offline or cached-only replay. Fetch/reload keys drop spurious `toolCallId` churn where appropriate, treat live-preferred cached URLs separately from replay, and memoize profile/capability/sandbox inputs so equivalent recreated objects do not rebuild the bridge. **useToolInputStreaming** adds a `sendToolInput` gate and scopes duplicate suppression for results/errors per tool call.
> 
> **SandboxedIframe** skips resending `sandbox-resource-ready` when the semantic payload is unchanged, preventing inner `srcdoc` reloads from prop identity noise.
> 
> **FullscreenChatOverlay** renders message entries like the main thread—markdown text, collapsible **ToolPart** cards, app-tool alias resolution, tool-only streaming visibility, and scroll-into-view on growing assistant content—with `chatSessionId` passed through.
> 
> Shared **app-tool attribution** hooks replace inline registry lookups in `ToolPart`. Broad regression tests cover persistence, isolation, fullscreen ownership, sandbox idempotence, and overlay behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48871f759cc9c8360ccc84d5794535545657a2c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->