### PR TITLE
outter wrapper + tool streamer

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -1734,7 +1734,7 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(sandboxedIframePropsRef.current?.style?.height).toBe("300px");
   });
 
-  it("applies size-changed width to the inline renderer container", async () => {
+  it("keeps inline renderer width host-controlled when the app reports size", async () => {
     const renderInline = () => (
       <MCPAppsRenderer
         {...baseProps}
@@ -1752,16 +1752,16 @@ describe("MCPAppsRenderer tool input streaming", () => {
     act(() => {
       mockBridge.onsizechange?.({ width: 300, height: 300 });
     });
+    rerender(renderInline());
 
     const hostChrome = screen.getByTestId("mcp-app-host-chrome");
     const container = hostChrome.parentElement as HTMLElement;
-    expect(container.style.width).toBe("300px");
+    expect(container.style.width).toBe("");
+    expect(sandboxedIframePropsRef.current?.style?.height).toBe("300px");
+    expect(sandboxedIframePropsRef.current?.style?.width).toBe("100%");
 
     rerender(renderInline());
-    expect(hostChrome.parentElement).toHaveStyle({
-      width: "300px",
-      maxWidth: "100%",
-    });
+    expect((hostChrome.parentElement as HTMLElement).style.width).toBe("");
     expect(sandboxedIframePropsRef.current?.style?.width).toBe("100%");
   });
 

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/useToolInputStreaming.test.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/useToolInputStreaming.test.ts
@@ -364,7 +364,7 @@ describe("useToolInputStreaming", () => {
     expect(result.current.canRenderStreamingInput).toBe(true);
   });
 
-  it("fallback reveal timer does not render before parseable partial args arrive", () => {
+  it("fallback reveal timer renders when parseable partial args never arrive", () => {
     const props = createDefaultProps(bridge);
     props.toolState = "input-streaming";
     // No toolInput — so no partial will be sent, relying on fallback timer
@@ -374,13 +374,32 @@ describe("useToolInputStreaming", () => {
     // Before fallback timer: not signaled, no delivery
     expect(result.current.canRenderStreamingInput).toBe(false);
 
-    // Advance past fallback timer. This is only a render signal; without
-    // delivered input, revealing the iframe produces a blank-shell flicker.
+    // Advance past fallback timer. The host should reveal instead of leaving
+    // streaming apps hidden indefinitely when no parseable partial input arrives.
     act(() => {
       vi.advanceTimersByTime(STREAMING_REVEAL_FALLBACK_MS + 10);
     });
 
+    expect(result.current.canRenderStreamingInput).toBe(true);
+  });
+
+  it("keeps fallback reveal alive after a render signal without partial args", () => {
+    const props = createDefaultProps(bridge);
+    props.toolState = "input-streaming";
+
+    const { result } = renderHook(() => useToolInputStreaming(props));
+
+    act(() => {
+      result.current.signalStreamingRender();
+    });
+
     expect(result.current.canRenderStreamingInput).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(STREAMING_REVEAL_FALLBACK_MS + 10);
+    });
+
+    expect(result.current.canRenderStreamingInput).toBe(true);
   });
 
   it("does not send partial when bridge is null", () => {

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -553,7 +553,6 @@ export function MCPAppsRendererSurface({
   persistentSurfaceId,
   persistentSurfaceInitialToolCallId,
 }: MCPAppsRendererProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
   const sandboxRef = useRef<SandboxedIframeHandle>(null);
   const themeMode = usePreferencesStore((s) => s.themeMode);
   const sharedHostStyle = usePreferencesStore((s) => s.hostStyle);
@@ -1178,13 +1177,6 @@ export function MCPAppsRendererSurface({
   // tool-call mount re-arms the promote — a fresh chat with the same
   // app gets the same affordance.
   const hasAutoPromotedForAppToolsRef = useRef(false);
-  // SEP-1865: width is honored only when the host's outer container is
-  // unbounded (no `width` from `containerDimensions`). The chatbox bubble
-  // is the bounding box today, so this stays null until the app sends a
-  // width request. The renderer applies the value to the visible inline
-  // container and caps it with max-width: 100%.
-  const lastInlineWidthRef = useRef<string | null>(null);
-
   // SEP-1865 App-Provided Tools: per-bridge identity used to register and
   // unregister this iframe's tools in `useAppToolsRegistry`.
   const appToolsBridgeIdRef = useRef<string | null>(null);
@@ -1205,15 +1197,14 @@ export function MCPAppsRendererSurface({
 
   // Reset widget-identity-scoped state when the renderer is reused for a
   // different resource / widget bundle. Without this the next widget
-  // inherits the previous widget's intersected display modes, its
-  // narrowed inline width, and (if the user had dismissed to inline) its
-  // sticky inline preference. Also re-seeds the sticky flag from the
+  // inherits the previous widget's intersected display modes and (if the user
+  // had dismissed to inline) its sticky inline preference. Also re-seeds the
+  // sticky flag from the
   // current `widgetDisplayModeRequests` policy so flipping the Apps tab
   // tri-state on an already-mounted renderer takes effect on the next
   // identity change instead of waiting for an unmount.
   useEffect(() => {
     setAppSupportedDisplayModes(undefined);
-    lastInlineWidthRef.current = null;
     userPreferInlineRef.current =
       earlyEffectiveMcpAppsCapabilities.widgetDisplayModeRequests ===
       "user-initiated-only";
@@ -2908,27 +2899,16 @@ export function MCPAppsRendererSurface({
         };
       }
 
-      // SEP-1865: apply both height AND width when the host outer
-      // container is flexible (no fixed `width` published via
-      // `containerDimensions`). The renderer caps the requested width
-      // to 100% of the parent via `max-width: 100%` so a misbehaving
-      // widget can't overflow the chatbox bubble. Fixed-
-      // width contexts (PIP/fullscreen, or future hosts that publish
-      // `containerDimensions.width`) ignore the width request — the
-      // height-only path remains.
-      bridge.onsizechange = ({ height, width }) => {
+      // Inline width is owned by the host shell. Some widgets report their
+      // preferred content width in `ui/notifications/size-changed`; applying it
+      // to the chat container shrinks wide hosted transcripts and leaves the
+      // app pinned to the left. Height remains app-driven for natural inline
+      // layout, while PIP/fullscreen keep their fixed shell sizing.
+      bridge.onsizechange = ({ height }) => {
         if (effectiveDisplayModeRef.current !== "inline") return;
         const iframe = sandboxRef.current?.getIframeElement();
-        const container = containerRef.current;
-        if (!iframe || !container) return;
-        if (height === undefined && width === undefined) return;
-        const hostCtx = hostContextRef.current as
-          | (McpUiHostContext & {
-              containerDimensions?: { width?: number };
-            })
-          | null;
-        const hostHasFixedWidth =
-          typeof hostCtx?.containerDimensions?.width === "number";
+        if (!iframe) return;
+        if (height === undefined) return;
 
         // The MCP App has requested a `height`, but if
         // `box-sizing: border-box` is applied to the outer iframe element, then we
@@ -2954,31 +2934,7 @@ export function MCPAppsRendererSurface({
           lastInlineHeightRef.current = `${adjustedHeight}px`;
         }
 
-        if (width !== undefined && !hostHasFixedWidth) {
-          let adjustedWidth = width;
-          if (isBorderBox) {
-            adjustedWidth +=
-              parseFloat(style.borderLeftWidth) +
-              parseFloat(style.borderRightWidth);
-          }
-          // Cap to parent so an over-eager widget can't escape the
-          // bounding bubble. Keep `width` as a plain px value and rely on
-          // `max-width: 100%` for the cap; this is equivalent to
-          // `min(width, 100%)` in browsers and easier for tests/DevTools.
-          const widthCss = `${adjustedWidth}px`;
-          from.width = `${container.offsetWidth}px`;
-          container.style.width = to.width = widthCss;
-          iframe.style.width = "100%";
-          lastInlineWidthRef.current = widthCss;
-        }
-
         iframe.animate([from, to], { duration: 300, easing: "ease-out" });
-        if (to.width !== undefined) {
-          container.animate?.([{ width: from.width }, { width: to.width }], {
-            duration: 300,
-            easing: "ease-out",
-          });
-        }
         // size-changed fires on every resize/animation tick — chatty widgets
         // can flood the traffic log. The corresponding ui/notifications/
         // size-changed transport message is already suppressed above; rely on
@@ -3689,11 +3645,6 @@ export function MCPAppsRendererSurface({
 
     return "mt-3 space-y-2 relative group";
   })();
-  const containerStyle: CSSProperties | undefined =
-    !isFullscreen && !isPip && lastInlineWidthRef.current
-      ? { width: lastInlineWidthRef.current, maxWidth: "100%" }
-      : undefined;
-
   const canTransitionHeight =
     !isFullscreen && effectiveDisplayModeRef.current === effectiveDisplayMode;
   const iframeStyle: CSSProperties = {
@@ -3767,13 +3718,11 @@ export function MCPAppsRendererSurface({
 
   return (
     <div
-      ref={containerRef}
       className={containerClassName}
       data-mcp-app-persistent-initial-tool-call-id={
         persistentSurfaceInitialToolCallId
       }
       data-mcp-app-persistent-surface-id={persistentSurfaceId}
-      style={containerStyle}
     >
       {((isFullscreen && isContainedFullscreenMode) ||
         (isPip && isMobilePlaygroundMode)) && (

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/useToolInputStreaming.ts
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/useToolInputStreaming.ts
@@ -221,6 +221,8 @@ export function useToolInputStreaming({
   // ── Internal state ───────────────────────────────────────────────────────
 
   const [streamingRenderSignaled, setStreamingRenderSignaled] = useState(false);
+  const [streamingRevealFallbackElapsed, setStreamingRevealFallbackElapsed] =
+    useState(false);
   const [hasDeliveredStreamingInput, setHasDeliveredStreamingInput] =
     useState(false);
 
@@ -234,12 +236,16 @@ export function useToolInputStreaming({
   const canRenderStreamingInput = useMemo(() => {
     if (toolState !== "input-streaming") return true;
     if (!sendToolInput) return true;
-    // Avoid revealing a blank app shell on the fallback timer alone. The view
-    // becomes visible after we have both a render signal and delivered input.
-    return streamingRenderSignaled && hasDeliveredStreamingInput;
+    // Prefer revealing after the first delivered partial, but do not keep the
+    // iframe hidden forever when a provider streams no parseable partial args.
+    return (
+      streamingRevealFallbackElapsed ||
+      (streamingRenderSignaled && hasDeliveredStreamingInput)
+    );
   }, [
     hasDeliveredStreamingInput,
     sendToolInput,
+    streamingRevealFallbackElapsed,
     streamingRenderSignaled,
     toolState,
   ]);
@@ -263,6 +269,7 @@ export function useToolInputStreaming({
     lastToolErrorRef.current = null;
     toolInputSentRef.current = false;
     setStreamingRenderSignaled(false);
+    setStreamingRevealFallbackElapsed(false);
     setHasDeliveredStreamingInput(false);
   }, []);
 
@@ -284,27 +291,41 @@ export function useToolInputStreaming({
     toolInputSentRef.current = false;
   }, [reinitCount]);
 
-  // 1. Clear reveal timer when signaled
+  // 1. Clear reveal timer once the iframe is allowed to become visible. A
+  // render signal alone can come from size-changed before any parseable streamed
+  // args arrive, so keep the fallback alive for that case.
   useEffect(() => {
-    if (!streamingRenderSignaled) return;
+    if (!hasDeliveredStreamingInput && !streamingRevealFallbackElapsed) return;
     if (streamingRevealTimerRef.current !== null) {
       window.clearTimeout(streamingRevealTimerRef.current);
       streamingRevealTimerRef.current = null;
     }
-  }, [streamingRenderSignaled]);
+  }, [hasDeliveredStreamingInput, streamingRevealFallbackElapsed]);
 
   // 2. Fallback reveal timer
   useEffect(() => {
     if (!sendToolInput) return;
-    if (!isReady || toolState !== "input-streaming" || streamingRenderSignaled)
+    if (
+      !isReady ||
+      toolState !== "input-streaming" ||
+      hasDeliveredStreamingInput ||
+      streamingRevealFallbackElapsed
+    )
       return;
     if (streamingRevealTimerRef.current !== null) return;
 
     streamingRevealTimerRef.current = window.setTimeout(() => {
       streamingRevealTimerRef.current = null;
       setStreamingRenderSignaled(true);
+      setStreamingRevealFallbackElapsed(true);
     }, STREAMING_REVEAL_FALLBACK_MS);
-  }, [isReady, sendToolInput, streamingRenderSignaled, toolState]);
+  }, [
+    hasDeliveredStreamingInput,
+    isReady,
+    sendToolInput,
+    streamingRevealFallbackElapsed,
+    toolState,
+  ]);
 
   // 3. Re-entry detection
   useEffect(() => {


### PR DESCRIPTION
- Fix MCP Apps looking too narrow in prod.
- Inline apps now keep the normal chat width.
- Apps can still control their height.
- Fix streaming apps staying invisible.
- If streamed JSON is slow or missing, show the renderer after a short delay.
- This fixes cases where apps only appeared after fullscreen.