### PR TITLE
fix(inspector): per-server protocol version override always visible and functional

### DIFF
--- a/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
+++ b/mcpjam-inspector/client/src/components/connection/EditServerFormContent.tsx
@@ -28,7 +28,9 @@ interface EditServerFormContentProps {
    * server's own config blob — wire mode is a project-server-refs field.
    */
   mcpProtocolVersionOverride?: McpProtocolVersion;
-  onMcpProtocolVersionOverrideChange?: (mode: McpProtocolVersion | undefined) => void;
+  onMcpProtocolVersionOverrideChange?: (
+    mode: McpProtocolVersion | undefined
+  ) => void;
 }
 
 export function EditServerFormContent({
@@ -164,9 +166,7 @@ export function EditServerFormContent({
             oauthProtocolMode={formState.oauthProtocolMode}
             onOauthProtocolModeChange={formState.setOauthProtocolMode}
             oauthRegistrationMode={formState.oauthRegistrationMode}
-            onOauthRegistrationModeChange={
-              formState.setOauthRegistrationMode
-            }
+            onOauthRegistrationModeChange={formState.setOauthRegistrationMode}
             useCustomClientId={formState.useCustomClientId}
             onUseCustomClientIdChange={(checked) => {
               formState.setUseCustomClientId(checked);
@@ -248,10 +248,8 @@ export function EditServerFormContent({
         }
         /* Render the row whenever the flag is on, regardless of whether
            a setter is wired. When `onMcpProtocolVersionOverrideChange` is
-           absent (no project, or server isn't in the project's
-           auto-connect set), the Switch disables with the existing
-           "edit mcpProtocolVersion in the JSON" hint — the affordance has to
-           be visible to be discoverable. */
+           absent (no project/server id, or project config still loading), the
+           select disables but remains visible for discoverability. */
         showMcpProtocolVersionOverride={Boolean(statelessMcpEnabled)}
         mcpProtocolVersionOverride={mcpProtocolVersionOverride}
         onMcpProtocolVersionOverrideChange={onMcpProtocolVersionOverrideChange}

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -582,7 +582,10 @@ export function ServerDetailModal({
                   type={isConnected && !formState.hasChanges ? "button" : "submit"}
                   onClick={
                     isConnected && !formState.hasChanges
-                      ? () => void handleConnect()
+                      ? () =>
+                          void handleConnect({
+                            allowInteractiveOAuthFlow: false,
+                          })
                       : undefined
                   }
                   disabled={

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -149,9 +149,6 @@ export function ServerDetailModal({
   const resolvedHostDefaultMcpProtocolVersion: McpProtocolVersion | undefined =
     hostDefaultMcpProtocolVersion ?? activeMcpProfile?.mcpProtocolVersion;
 
-  // Whether the server is in the project's auto-connect `serverIds`
-  // set. The backend `ensureProjectServerConfig` rejects overrides for
-  // servers not in this set ("override key X is not a member of
   // Pending reconnect bookkeeping for the override-save → reconnect
   // race (see `handleMcpProtocolVersionOverrideChange` below). Holds the
   // target override value the user just wrote; the watcher effect
@@ -168,9 +165,11 @@ export function ServerDetailModal({
     if (!pending) return;
     if (currentMcpProtocolVersionOverride !== pending.target) return;
     pendingReconnectRef.current = null;
-    void onReconnect(server.name).catch(() => {
-      // Reconnect failures surface their own toast inside the handler.
-    });
+    void onReconnect(server.name, { allowInteractiveOAuthFlow: false }).catch(
+      () => {
+        // Reconnect failures surface their own toast inside the handler.
+      },
+    );
   }, [
     currentMcpProtocolVersionOverride,
     onReconnect,
@@ -260,7 +259,7 @@ export function ServerDetailModal({
       window.setTimeout(() => {
         if (pendingReconnectRef.current?.target === next) {
           pendingReconnectRef.current = null;
-          void onReconnect(server.name).catch(() => {});
+          void onReconnect(server.name, { allowInteractiveOAuthFlow: false }).catch(() => {});
         }
       }, 1500);
       // Tick the watcher so it re-evaluates immediately in case the

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -10,7 +10,12 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@mcpjam/design-system/dialog";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@mcpjam/design-system/tabs";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@mcpjam/design-system/tabs";
 import { Switch } from "@mcpjam/design-system/switch";
 import { Loader2 } from "lucide-react";
 import { ServerWithName, type ServerUpdateResult } from "@/hooks/use-app-state";
@@ -52,7 +57,7 @@ interface ServerDetailModalProps {
   defaultTab?: ServerDetailTab;
   onSubmit: (
     formData: ServerFormData,
-    originalServerName: string,
+    originalServerName: string
   ) => Promise<ServerUpdateResult>;
   onDisconnect: (serverName: string) => void;
   onReconnect: (
@@ -60,7 +65,7 @@ interface ServerDetailModalProps {
     options?: {
       forceOAuthFlow?: boolean;
       allowInteractiveOAuthFlow?: boolean;
-    },
+    }
   ) => Promise<void>;
   existingServerNames: string[];
   projectClientConfig?: Project["clientConfig"];
@@ -115,10 +120,10 @@ export function ServerDetailModal({
   const statelessMcpEnabled = useFeatureFlagEnabled("stateless-mcp-enabled");
   const projectServerConfigDto = useQuery(
     "projectServerConfig:getConfig" as never,
-    projectId ? ({ projectId } as never) : "skip",
+    projectId ? ({ projectId } as never) : "skip"
   ) as ProjectServerConfigDto | null | undefined;
   const setProjectServerConfigMutation = useMutation(
-    "projectServerConfig:setConfig" as never,
+    "projectServerConfig:setConfig" as never
   ) as unknown as (args: {
     projectId: string;
     input: ProjectServerConfigInput;
@@ -130,13 +135,15 @@ export function ServerDetailModal({
   // `sharedProjectServersRecord[name]?._id` and passes it down as
   // `hostedServerId`.
   const serverId = hostedServerId ?? undefined;
-  const currentMcpProtocolVersionOverride = useMemo<McpProtocolVersion | undefined>(
+  const currentMcpProtocolVersionOverride = useMemo<
+    McpProtocolVersion | undefined
+  >(
     () =>
       serverId
         ? (projectServerConfigDto?.overrides?.[serverId]
             ?.mcpProtocolVersionOverride as McpProtocolVersion | undefined)
         : undefined,
-    [projectServerConfigDto, serverId],
+    [projectServerConfigDto, serverId]
   );
   // Host default — prefer the explicit prop passed by the Servers tab
   // (which has direct access to `previewedHost.config.mcpProfile`),
@@ -148,6 +155,9 @@ export function ServerDetailModal({
   const activeMcpProfile = useActiveMcpProfile();
   const resolvedHostDefaultMcpProtocolVersion: McpProtocolVersion | undefined =
     hostDefaultMcpProtocolVersion ?? activeMcpProfile?.mcpProtocolVersion;
+  const canEditMcpProtocolVersionOverride = Boolean(
+    projectId && serverId && projectServerConfigDto !== undefined
+  );
 
   // Pending reconnect bookkeeping for the override-save → reconnect
   // race (see `handleMcpProtocolVersionOverrideChange` below). Holds the
@@ -168,7 +178,7 @@ export function ServerDetailModal({
     void onReconnect(server.name, { allowInteractiveOAuthFlow: false }).catch(
       () => {
         // Reconnect failures surface their own toast inside the handler.
-      },
+      }
     );
   }, [
     currentMcpProtocolVersionOverride,
@@ -178,11 +188,11 @@ export function ServerDetailModal({
   ]);
 
   const handleMcpProtocolVersionOverrideChange = async (
-    next: McpProtocolVersion | undefined,
+    next: McpProtocolVersion | undefined
   ): Promise<void> => {
     if (!projectId) {
       toast.error(
-        "Wire mode override requires a project context; cannot save without projectId.",
+        "Wire mode override requires a project context; cannot save without projectId."
       );
       return;
     }
@@ -197,7 +207,7 @@ export function ServerDetailModal({
     // hint instead.
     if (projectServerConfigDto === undefined) {
       toast.error(
-        "Project configuration is still loading. Try again in a moment.",
+        "Project configuration is still loading. Try again in a moment."
       );
       return;
     }
@@ -208,12 +218,6 @@ export function ServerDetailModal({
     // yet for this project) — that case is genuinely the empty
     // baseline.
     const currentServerIds = projectServerConfigDto?.serverIds ?? [];
-    if (!currentServerIds.includes(serverId)) {
-      toast.error(
-        "Enable auto-connect for this server first to set a per-server protocol override.",
-      );
-      return;
-    }
     const currentOverrides = projectServerConfigDto?.overrides ?? {};
     const existingEntry = currentOverrides[serverId] ?? {};
     const updatedEntry: ProjectServerOverrideEntry = {
@@ -233,10 +237,18 @@ export function ServerDetailModal({
     };
     if (hasContent) nextOverrides[serverId] = updatedEntry;
     else delete nextOverrides[serverId];
+    // Backend validation requires override keys to be members of `serverIds`.
+    // If the user pins a protocol version for a non-auto-connected server,
+    // enroll this server alongside the override so the pin can be saved before
+    // the currently failing connection succeeds.
+    const nextServerIds =
+      hasContent && !currentServerIds.includes(serverId)
+        ? [...currentServerIds, serverId]
+        : currentServerIds;
     try {
       await setProjectServerConfigMutation({
         projectId,
-        input: { serverIds: currentServerIds, overrides: nextOverrides },
+        input: { serverIds: nextServerIds, overrides: nextOverrides },
       });
       // Reconnect-after-save race: `onReconnect` ultimately reads from
       // `activeHostConfig.serverConnectionOverrides` to compute the new
@@ -259,7 +271,9 @@ export function ServerDetailModal({
       window.setTimeout(() => {
         if (pendingReconnectRef.current?.target === next) {
           pendingReconnectRef.current = null;
-          void onReconnect(server.name, { allowInteractiveOAuthFlow: false }).catch(() => {});
+          void onReconnect(server.name, {
+            allowInteractiveOAuthFlow: false,
+          }).catch(() => {});
         }
       }, 1500);
       // Tick the watcher so it re-evaluates immediately in case the
@@ -269,7 +283,7 @@ export function ServerDetailModal({
       toast.error(
         err instanceof Error
           ? err.message
-          : "Failed to update wire mode override",
+          : "Failed to update wire mode override"
       );
     }
   };
@@ -313,7 +327,7 @@ export function ServerDetailModal({
           setToolsLoadError(
             error instanceof Error
               ? error.message
-              : "Failed to load tools metadata",
+              : "Failed to load tools metadata"
           );
           setToolsData(null);
         }
@@ -334,7 +348,7 @@ export function ServerDetailModal({
   const handleSave = async () => {
     if (isDuplicateServerName) {
       toast.error(
-        `A server named "${trimmedName}" already exists. Choose a different name.`,
+        `A server named "${trimmedName}" already exists. Choose a different name.`
       );
       return;
     }
@@ -359,7 +373,7 @@ export function ServerDetailModal({
 
       if (formState.clientSecret) {
         const clientSecretError = formState.validateClientSecret(
-          formState.clientSecret,
+          formState.clientSecret
         );
         if (clientSecretError) {
           toast.error(clientSecretError);
@@ -503,8 +517,8 @@ export function ServerDetailModal({
                   {isReconnecting
                     ? "Connecting..."
                     : server.connectionStatus === "failed"
-                      ? `${connectionStatusLabel} (${server.retryCount})`
-                      : connectionStatusLabel}
+                    ? `${connectionStatusLabel} (${server.retryCount})`
+                    : connectionStatusLabel}
                 </span>
               </span>
               <Switch
@@ -558,10 +572,11 @@ export function ServerDetailModal({
                     isDuplicateServerName={isDuplicateServerName}
                     projectId={projectId}
                     hostedServerId={hostedServerId}
-                    mcpProtocolVersionOverride={currentMcpProtocolVersionOverride}
+                    mcpProtocolVersionOverride={
+                      currentMcpProtocolVersionOverride
+                    }
                     onMcpProtocolVersionOverrideChange={
-                      projectId && serverId &&
-                      projectServerConfigDto?.serverIds.includes(serverId)
+                      canEditMcpProtocolVersionOverride
                         ? handleMcpProtocolVersionOverrideChange
                         : undefined
                     }
@@ -578,7 +593,9 @@ export function ServerDetailModal({
                 }}
               >
                 <Button
-                  type={isConnected && !formState.hasChanges ? "button" : "submit"}
+                  type={
+                    isConnected && !formState.hasChanges ? "button" : "submit"
+                  }
                   onClick={
                     isConnected && !formState.hasChanges
                       ? () =>

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -84,6 +84,73 @@ interface ServerDetailModalProps {
   hostDefaultMcpProtocolVersion?: McpProtocolVersion;
 }
 
+type ProtocolOverrideAutoEnrollRecord = {
+  previousServerIds: string[];
+};
+
+const PROTOCOL_OVERRIDE_AUTO_ENROLL_STORAGE_PREFIX =
+  "mcpjam:protocol-override-auto-enroll";
+
+const getProtocolOverrideAutoEnrollKey = (
+  projectId: string,
+  serverId: string
+) => `${PROTOCOL_OVERRIDE_AUTO_ENROLL_STORAGE_PREFIX}:${projectId}:${serverId}`;
+
+const readProtocolOverrideAutoEnrollRecord = (
+  key: string
+): ProtocolOverrideAutoEnrollRecord | undefined => {
+  if (typeof window === "undefined") return undefined;
+  try {
+    const raw = window.sessionStorage.getItem(key);
+    if (!raw) return undefined;
+    const parsed = JSON.parse(raw) as Partial<ProtocolOverrideAutoEnrollRecord>;
+    if (!Array.isArray(parsed.previousServerIds)) return undefined;
+    return {
+      previousServerIds: parsed.previousServerIds.filter(
+        (id): id is string => typeof id === "string"
+      ),
+    };
+  } catch {
+    return undefined;
+  }
+};
+
+const writeProtocolOverrideAutoEnrollRecord = (
+  key: string,
+  record: ProtocolOverrideAutoEnrollRecord
+) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(key, JSON.stringify(record));
+  } catch {
+    // Losing this marker only affects cleanup of an implicit enrollment.
+  }
+};
+
+const removeProtocolOverrideAutoEnrollRecord = (key: string) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(key);
+  } catch {
+    // Best-effort cleanup only.
+  }
+};
+
+const matchesImplicitAutoEnrollment = (
+  currentServerIds: string[],
+  serverId: string,
+  previousServerIds: string[]
+) => {
+  const previousServerIdSet = new Set(previousServerIds);
+  if (previousServerIdSet.has(serverId)) return false;
+  if (!currentServerIds.includes(serverId)) return false;
+  if (currentServerIds.length !== previousServerIdSet.size + 1) return false;
+  return currentServerIds.every(
+    (currentServerId) =>
+      currentServerId === serverId || previousServerIdSet.has(currentServerId)
+  );
+};
+
 export function ServerDetailModal({
   isOpen,
   onClose,
@@ -158,6 +225,9 @@ export function ServerDetailModal({
   const canEditMcpProtocolVersionOverride = Boolean(
     projectId && serverId && projectServerConfigDto !== undefined
   );
+  const protocolOverrideAutoEnrolledRef = useRef<
+    Map<string, ProtocolOverrideAutoEnrollRecord>
+  >(new Map());
 
   // Pending reconnect bookkeeping for the override-save → reconnect
   // race (see `handleMcpProtocolVersionOverrideChange` below). Holds the
@@ -238,18 +308,54 @@ export function ServerDetailModal({
     if (hasContent) nextOverrides[serverId] = updatedEntry;
     else delete nextOverrides[serverId];
     // Backend validation requires override keys to be members of `serverIds`.
-    // If the user pins a protocol version for a non-auto-connected server,
-    // enroll this server alongside the override so the pin can be saved before
-    // the currently failing connection succeeds.
-    const nextServerIds =
-      hasContent && !currentServerIds.includes(serverId)
-        ? [...currentServerIds, serverId]
+    // If this control enrolls the server only to save the protocol pin, remember
+    // that provenance so clearing the pin can undo the implicit enrollment
+    // without removing servers that were already explicitly auto-connected.
+    const autoEnrollKey = getProtocolOverrideAutoEnrollKey(
+      projectId,
+      serverId
+    );
+    const autoEnrollRecord =
+      protocolOverrideAutoEnrolledRef.current.get(autoEnrollKey) ??
+      readProtocolOverrideAutoEnrollRecord(autoEnrollKey);
+    const shouldAutoEnrollForOverride =
+      hasContent && !currentServerIds.includes(serverId);
+    const shouldUndoAutoEnroll =
+      !hasContent &&
+      autoEnrollRecord !== undefined &&
+      matchesImplicitAutoEnrollment(
+        currentServerIds,
+        serverId,
+        autoEnrollRecord.previousServerIds
+      );
+    const nextServerIds = shouldAutoEnrollForOverride
+      ? [...currentServerIds, serverId]
+      : shouldUndoAutoEnroll
+        ? currentServerIds.filter(
+            (currentServerId) => currentServerId !== serverId
+          )
         : currentServerIds;
     try {
       await setProjectServerConfigMutation({
         projectId,
         input: { serverIds: nextServerIds, overrides: nextOverrides },
       });
+      if (shouldAutoEnrollForOverride) {
+        const nextAutoEnrollRecord = {
+          previousServerIds: [...currentServerIds],
+        };
+        protocolOverrideAutoEnrolledRef.current.set(
+          autoEnrollKey,
+          nextAutoEnrollRecord
+        );
+        writeProtocolOverrideAutoEnrollRecord(
+          autoEnrollKey,
+          nextAutoEnrollRecord
+        );
+      } else if (!hasContent && autoEnrollRecord !== undefined) {
+        protocolOverrideAutoEnrolledRef.current.delete(autoEnrollKey);
+        removeProtocolOverrideAutoEnrollRecord(autoEnrollKey);
+      }
       // Reconnect-after-save race: `onReconnect` ultimately reads from
       // `activeHostConfig.serverConnectionOverrides` to compute the new
       // wire mode. That value is a derivation of the same Convex row we

--- a/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
+++ b/mcpjam-inspector/client/src/components/connection/ServerDetailModal.tsx
@@ -152,15 +152,6 @@ export function ServerDetailModal({
   // Whether the server is in the project's auto-connect `serverIds`
   // set. The backend `ensureProjectServerConfig` rejects overrides for
   // servers not in this set ("override key X is not a member of
-  // serverIds") — overrides ONLY make sense for servers the project
-  // auto-connects, otherwise the override row would dangle. Surface
-  // this gate to the toggle so it disables cleanly with a hint
-  // instead of producing a Convex error toast.
-  const isInProjectAutoConnect = useMemo(() => {
-    if (!serverId) return false;
-    return Boolean(projectServerConfigDto?.serverIds.includes(serverId));
-  }, [projectServerConfigDto, serverId]);
-
   // Pending reconnect bookkeeping for the override-save → reconnect
   // race (see `handleMcpProtocolVersionOverrideChange` below). Holds the
   // target override value the user just wrote; the watcher effect
@@ -211,15 +202,6 @@ export function ServerDetailModal({
       );
       return;
     }
-    if (!isInProjectAutoConnect) {
-      // Backend invariant: overrides only for servers in serverIds.
-      // Surface a clear path forward rather than letting the mutation
-      // reject with the raw Convex error.
-      toast.error(
-        "Add this server to the project's auto-connect set first (Servers tab → Auto-connect), or use the host-level mcpProtocolVersion in the Client → MCP Protocol JSON.",
-      );
-      return;
-    }
     // setConfig replaces the entire (serverIds, overrides) pair — read
     // current (now guaranteed non-undefined), splice in the new
     // override, write back. Preserve every other server's overrides
@@ -227,6 +209,12 @@ export function ServerDetailModal({
     // yet for this project) — that case is genuinely the empty
     // baseline.
     const currentServerIds = projectServerConfigDto?.serverIds ?? [];
+    if (!currentServerIds.includes(serverId)) {
+      toast.error(
+        "Enable auto-connect for this server first to set a per-server protocol override.",
+      );
+      return;
+    }
     const currentOverrides = projectServerConfigDto?.overrides ?? {};
     const existingEntry = currentOverrides[serverId] ?? {};
     const updatedEntry: ProjectServerOverrideEntry = {
@@ -573,7 +561,8 @@ export function ServerDetailModal({
                     hostedServerId={hostedServerId}
                     mcpProtocolVersionOverride={currentMcpProtocolVersionOverride}
                     onMcpProtocolVersionOverrideChange={
-                      projectId && isInProjectAutoConnect
+                      projectId && serverId &&
+                      projectServerConfigDto?.serverIds.includes(serverId)
                         ? handleMcpProtocolVersionOverrideChange
                         : undefined
                     }
@@ -590,20 +579,28 @@ export function ServerDetailModal({
                 }}
               >
                 <Button
-                  type="submit"
+                  type={isConnected && !formState.hasChanges ? "button" : "submit"}
+                  onClick={
+                    isConnected && !formState.hasChanges
+                      ? () => void handleConnect()
+                      : undefined
+                  }
                   disabled={
                     isDuplicateServerName ||
                     isSaving ||
-                    !formState.hasChanges ||
+                    isReconnecting ||
+                    (!formState.hasChanges && !isConnected) ||
                     formState.preregisteredOauthBlocksSubmit
                   }
                   size="sm"
                 >
-                  {isSaving ? (
+                  {isSaving || isReconnecting ? (
                     <>
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Saving...
+                      {isSaving ? "Saving..." : "Reconnecting..."}
                     </>
+                  ) : isConnected && !formState.hasChanges ? (
+                    "Reconnect"
                   ) : (
                     "Save Changes"
                   )}

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
@@ -291,6 +291,7 @@ describe("ServerDetailModal", () => {
   });
 
   it("submits the configuration form without closing the modal", async () => {
+    const user = userEvent.setup();
     const onSubmit = vi.fn().mockResolvedValue({
       ok: true,
       serverName: "test-server",
@@ -305,6 +306,12 @@ describe("ServerDetailModal", () => {
       />,
     );
 
+    // Edit a field so the form has changes and "Save Changes" is active
+    // (connected servers with no changes show "Reconnect" instead).
+    const nameInput = screen.getByDisplayValue("test-server");
+    await user.clear(nameInput);
+    await user.type(nameInput, "test-server-renamed");
+
     const form = screen
       .getByRole("button", { name: "Save Changes" })
       .closest("form");
@@ -314,7 +321,7 @@ describe("ServerDetailModal", () => {
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
-        expect.objectContaining({ name: "test-server" }),
+        expect.objectContaining({ name: "test-server-renamed" }),
         "test-server",
       );
     });

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
@@ -5,6 +5,9 @@ import type { ServerWithName } from "@/hooks/use-app-state";
 import type { ListToolsResultWithMetadata } from "@/lib/apis/mcp-tools-api";
 
 const mockCapture = vi.fn();
+const mockUseFeatureFlagEnabled = vi.hoisted(() => vi.fn(() => false));
+const mockUseQuery = vi.hoisted(() => vi.fn(() => undefined));
+const mockSetProjectServerConfig = vi.hoisted(() => vi.fn());
 
 vi.mock("posthog-js/react", () => ({
   usePostHog: () => ({
@@ -15,7 +18,8 @@ vi.mock("posthog-js/react", () => ({
   // so the existing test setup exercises the pre-flag UI shape; tests that
   // need the dropdown enabled should override per-test via
   // `vi.mocked(useFeatureFlagEnabled).mockReturnValue(true)`.
-  useFeatureFlagEnabled: () => false,
+  useFeatureFlagEnabled: (...args: unknown[]) =>
+    mockUseFeatureFlagEnabled(...args),
 }));
 
 // ServerDetailModal reads + writes the project-server config via Convex
@@ -24,8 +28,8 @@ vi.mock("posthog-js/react", () => ({
 // component mounts. `useQuery` returns `undefined` (matches the
 // pre-loaded Convex state); `useMutation` returns a no-op function.
 vi.mock("convex/react", () => ({
-  useQuery: () => undefined,
-  useMutation: () => vi.fn(),
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+  useMutation: () => mockSetProjectServerConfig,
 }));
 
 vi.mock("sonner", () => ({
@@ -47,35 +51,35 @@ vi.mock("@/lib/mcp-ui/mcp-apps-utils", () => {
   const hasUiResourceUri = (meta: Record<string, unknown>) =>
     Boolean(
       ((meta["ui"] as { resourceUri?: unknown } | undefined)?.resourceUri ??
-        meta["ui.resourceUri"]) as unknown,
+        meta["ui.resourceUri"]) as unknown
     );
 
   return {
     isMCPApp: (toolsData: { toolsMetadata?: Record<string, unknown> } | null) =>
       Object.values(toolsData?.toolsMetadata ?? {}).some((meta) =>
-        hasUiResourceUri((meta ?? {}) as Record<string, unknown>),
+        hasUiResourceUri((meta ?? {}) as Record<string, unknown>)
       ),
     isOpenAIApp: (
       toolsData: {
         toolsMetadata?: Record<string, unknown>;
-      } | null,
+      } | null
     ) =>
       Object.values(toolsData?.toolsMetadata ?? {}).some((meta) =>
         Boolean(
           (meta as Record<string, unknown>)?.["openai/outputTemplate"] &&
-          !hasUiResourceUri((meta ?? {}) as Record<string, unknown>),
-        ),
+            !hasUiResourceUri((meta ?? {}) as Record<string, unknown>)
+        )
       ),
     isOpenAIAppAndMCPApp: (
       toolsData: {
         toolsMetadata?: Record<string, unknown>;
-      } | null,
+      } | null
     ) =>
       Object.values(toolsData?.toolsMetadata ?? {}).some((meta) =>
         Boolean(
           (meta as Record<string, unknown>)?.["openai/outputTemplate"] &&
-          hasUiResourceUri((meta ?? {}) as Record<string, unknown>),
-        ),
+            hasUiResourceUri((meta ?? {}) as Record<string, unknown>)
+        )
       ),
     UIType: {
       MCP_APPS: "mcp-apps",
@@ -90,7 +94,7 @@ import { ServerDetailModal } from "../ServerDetailModal";
 
 describe("ServerDetailModal", () => {
   const createServer = (
-    overrides: Partial<ServerWithName> = {},
+    overrides: Partial<ServerWithName> = {}
   ): ServerWithName => ({
     name: "test-server",
     lastConnectionTime: new Date(),
@@ -120,6 +124,13 @@ describe("ServerDetailModal", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseFeatureFlagEnabled.mockReturnValue(false);
+    mockUseQuery.mockReturnValue(undefined);
+    mockSetProjectServerConfig.mockResolvedValue({
+      projectId: "project_123",
+      serverIds: [],
+      overrides: {},
+    });
     localStorage.clear();
     mockListTools.mockResolvedValue({
       tools: [],
@@ -154,11 +165,11 @@ describe("ServerDetailModal", () => {
 
     // Overview tab uses overflow-y-auto for scrolling
     const { unmount } = render(
-      <ServerDetailModal {...defaultProps} defaultTab="overview" />,
+      <ServerDetailModal {...defaultProps} defaultTab="overview" />
     );
 
     const overviewPanel = document.querySelector(
-      '[role="tabpanel"][data-state="active"]',
+      '[role="tabpanel"][data-state="active"]'
     );
     expect(overviewPanel).toBeInTheDocument();
     expect(overviewPanel?.className).toContain("overflow-y-auto");
@@ -170,7 +181,7 @@ describe("ServerDetailModal", () => {
 
     await waitFor(() => {
       const toolsPanel = document.querySelector(
-        '[role="tabpanel"][data-state="active"]',
+        '[role="tabpanel"][data-state="active"]'
       );
       expect(toolsPanel).toBeInTheDocument();
       expect(toolsPanel?.className).toContain("overflow-y-auto");
@@ -201,7 +212,7 @@ describe("ServerDetailModal", () => {
       expect(screen.getByText("search")).toBeInTheDocument();
     });
     expect(
-      screen.queryByText("Connect to view tools metadata"),
+      screen.queryByText("Connect to view tools metadata")
     ).not.toBeInTheDocument();
     expect(screen.getByText("Search tool")).toBeInTheDocument();
   });
@@ -212,11 +223,11 @@ describe("ServerDetailModal", () => {
         {...defaultProps}
         server={createServer({ connectionStatus: "disconnected" })}
         defaultTab="overview"
-      />,
+      />
     );
 
     expect(
-      screen.getByText("Connect to view server overview"),
+      screen.getByText("Connect to view server overview")
     ).toBeInTheDocument();
   });
 
@@ -227,7 +238,7 @@ describe("ServerDetailModal", () => {
         {...defaultProps}
         server={createServer({ connectionStatus: "disconnected" })}
         onReconnect={onReconnect}
-      />,
+      />
     );
 
     fireEvent.click(screen.getByRole("switch"));
@@ -247,7 +258,7 @@ describe("ServerDetailModal", () => {
           useOAuth: true,
         })}
         onReconnect={onReconnect}
-      />,
+      />
     );
 
     fireEvent.click(screen.getByRole("switch"));
@@ -257,11 +268,69 @@ describe("ServerDetailModal", () => {
     });
   });
 
+  it("allows setting a protocol override before the server is in auto-connect", async () => {
+    const user = userEvent.setup();
+    Object.defineProperty(HTMLElement.prototype, "hasPointerCapture", {
+      configurable: true,
+      value: vi.fn(() => false),
+    });
+    Object.defineProperty(HTMLElement.prototype, "setPointerCapture", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(HTMLElement.prototype, "releasePointerCapture", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    mockUseFeatureFlagEnabled.mockReturnValue(true);
+    mockUseQuery.mockReturnValue({
+      projectId: "project_123",
+      serverIds: [],
+      overrides: {},
+    });
+
+    render(
+      <ServerDetailModal
+        {...defaultProps}
+        projectId="project_123"
+        hostedServerId="server_123"
+        hostDefaultMcpProtocolVersion="DRAFT-2026-v1"
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /connection overrides/i })
+    );
+    const protocolSelect = screen
+      .getAllByText("Host default")
+      .find((element) => element.closest("button"))
+      ?.closest("button");
+    expect(protocolSelect).not.toBeNull();
+    expect(protocolSelect).toBeEnabled();
+
+    await user.click(protocolSelect!);
+    await user.click(await screen.findByRole("option", { name: "Latest" }));
+
+    await waitFor(() => {
+      expect(mockSetProjectServerConfig).toHaveBeenCalledWith({
+        projectId: "project_123",
+        input: {
+          serverIds: ["server_123"],
+          overrides: {
+            server_123: {
+              mcpProtocolVersionOverride: "2025-11-25",
+            },
+          },
+        },
+      });
+    });
+  });
+
   it("does not show a conformance launch button in overview", () => {
     render(<ServerDetailModal {...defaultProps} defaultTab="overview" />);
 
     expect(
-      screen.queryByRole("button", { name: "Run conformance" }),
+      screen.queryByRole("button", { name: "Run conformance" })
     ).not.toBeInTheDocument();
   });
 
@@ -274,7 +343,7 @@ describe("ServerDetailModal", () => {
         token_type: "Bearer",
         expires_in: 3600,
         scope: "read",
-      }),
+      })
     );
 
     render(
@@ -282,7 +351,7 @@ describe("ServerDetailModal", () => {
         {...defaultProps}
         server={createServer({ useOAuth: true })}
         defaultTab="overview"
-      />,
+      />
     );
 
     expect(screen.getByText("local-access-token")).toBeInTheDocument();
@@ -303,7 +372,7 @@ describe("ServerDetailModal", () => {
         {...defaultProps}
         onSubmit={onSubmit}
         onClose={onClose}
-      />,
+      />
     );
 
     // Edit a field so the form has changes and "Save Changes" is active
@@ -322,7 +391,7 @@ describe("ServerDetailModal", () => {
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({ name: "test-server-renamed" }),
-        "test-server",
+        "test-server"
       );
     });
     expect(onClose).not.toHaveBeenCalled();
@@ -341,7 +410,7 @@ describe("ServerDetailModal", () => {
         {...defaultProps}
         onSubmit={onSubmit}
         onClose={onClose}
-      />,
+      />
     );
 
     const input = screen.getByDisplayValue("test-server");
@@ -366,7 +435,7 @@ describe("ServerDetailModal", () => {
         {...defaultProps}
         defaultTab="overview"
         onSubmit={onSubmit}
-      />,
+      />
     );
 
     fireEvent.keyDown(screen.getByRole("dialog"), { key: "Enter" });
@@ -399,7 +468,7 @@ describe("ServerDetailModal", () => {
         {...defaultProps}
         defaultTab="tools-metadata"
         onSubmit={onSubmit}
-      />,
+      />
     );
 
     await waitFor(() => {
@@ -418,8 +487,8 @@ describe("ServerDetailModal", () => {
 
     expect(
       screen.getByText(
-        "Saved auth data is invalid. Reconnect this server to refresh tokens.",
-      ),
+        "Saved auth data is invalid. Reconnect this server to refresh tokens."
+      )
     ).toBeInTheDocument();
   });
 
@@ -432,7 +501,7 @@ describe("ServerDetailModal", () => {
       () =>
         new Promise<{ ok: boolean; serverName: string }>((resolve) => {
           resolveSubmit = resolve;
-        }),
+        })
     );
 
     render(<ServerDetailModal {...defaultProps} onSubmit={onSubmit} />);
@@ -451,7 +520,7 @@ describe("ServerDetailModal", () => {
     resolveSubmit?.({ ok: true, serverName: "test-server" });
     await waitFor(() => {
       expect(
-        screen.getByRole("button", { name: "Save Changes" }),
+        screen.getByRole("button", { name: "Save Changes" })
       ).toBeEnabled();
     });
   });
@@ -462,7 +531,7 @@ describe("ServerDetailModal", () => {
     render(
       <div onKeyDown={onKeyDown}>
         <ServerDetailModal {...defaultProps} />
-      </div>,
+      </div>
     );
 
     fireEvent.keyDown(screen.getByDisplayValue("test-server"), {

--- a/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
+++ b/mcpjam-inspector/client/src/components/connection/__tests__/ServerDetailModal.test.tsx
@@ -92,6 +92,26 @@ vi.mock("@/lib/mcp-ui/mcp-apps-utils", () => {
 
 import { ServerDetailModal } from "../ServerDetailModal";
 
+const installPointerCaptureMocks = () => {
+  Object.defineProperty(HTMLElement.prototype, "hasPointerCapture", {
+    configurable: true,
+    value: vi.fn(() => false),
+  });
+  Object.defineProperty(HTMLElement.prototype, "setPointerCapture", {
+    configurable: true,
+    value: vi.fn(),
+  });
+  Object.defineProperty(HTMLElement.prototype, "releasePointerCapture", {
+    configurable: true,
+    value: vi.fn(),
+  });
+};
+
+const getProtocolVersionCombobox = () => {
+  const comboboxes = screen.getAllByRole("combobox");
+  return comboboxes[comboboxes.length - 1];
+};
+
 describe("ServerDetailModal", () => {
   const createServer = (
     overrides: Partial<ServerWithName> = {}
@@ -132,6 +152,7 @@ describe("ServerDetailModal", () => {
       overrides: {},
     });
     localStorage.clear();
+    sessionStorage.clear();
     mockListTools.mockResolvedValue({
       tools: [],
       toolsMetadata: {},
@@ -270,18 +291,7 @@ describe("ServerDetailModal", () => {
 
   it("allows setting a protocol override before the server is in auto-connect", async () => {
     const user = userEvent.setup();
-    Object.defineProperty(HTMLElement.prototype, "hasPointerCapture", {
-      configurable: true,
-      value: vi.fn(() => false),
-    });
-    Object.defineProperty(HTMLElement.prototype, "setPointerCapture", {
-      configurable: true,
-      value: vi.fn(),
-    });
-    Object.defineProperty(HTMLElement.prototype, "releasePointerCapture", {
-      configurable: true,
-      value: vi.fn(),
-    });
+    installPointerCaptureMocks();
     mockUseFeatureFlagEnabled.mockReturnValue(true);
     mockUseQuery.mockReturnValue({
       projectId: "project_123",
@@ -301,14 +311,11 @@ describe("ServerDetailModal", () => {
     await user.click(
       screen.getByRole("button", { name: /connection overrides/i })
     );
-    const protocolSelect = screen
-      .getAllByText("Host default")
-      .find((element) => element.closest("button"))
-      ?.closest("button");
-    expect(protocolSelect).not.toBeNull();
+    const protocolSelect = getProtocolVersionCombobox();
+    expect(protocolSelect).toHaveTextContent("Host default");
     expect(protocolSelect).toBeEnabled();
 
-    await user.click(protocolSelect!);
+    await user.click(protocolSelect);
     await user.click(await screen.findByRole("option", { name: "Latest" }));
 
     await waitFor(() => {
@@ -321,6 +328,136 @@ describe("ServerDetailModal", () => {
               mcpProtocolVersionOverride: "2025-11-25",
             },
           },
+        },
+      });
+    });
+  });
+
+  it("removes implicit auto-connect enrollment when clearing a modal-created protocol override", async () => {
+    const user = userEvent.setup();
+    installPointerCaptureMocks();
+    mockUseFeatureFlagEnabled.mockReturnValue(true);
+    let projectServerConfig = {
+      projectId: "project_123",
+      serverIds: [] as string[],
+      overrides: {},
+    };
+    mockUseQuery.mockImplementation(() => projectServerConfig);
+
+    const renderModal = () => (
+      <ServerDetailModal
+        {...defaultProps}
+        projectId="project_123"
+        hostedServerId="server_123"
+        hostDefaultMcpProtocolVersion="DRAFT-2026-v1"
+      />
+    );
+    const { unmount } = render(renderModal());
+
+    await user.click(
+      screen.getByRole("button", { name: /connection overrides/i })
+    );
+    const hostDefaultSelect = getProtocolVersionCombobox();
+    expect(hostDefaultSelect).toHaveTextContent("Host default");
+
+    await user.click(hostDefaultSelect);
+    await user.click(await screen.findByRole("option", { name: "Latest" }));
+
+    await waitFor(() => {
+      expect(mockSetProjectServerConfig).toHaveBeenCalledWith({
+        projectId: "project_123",
+        input: {
+          serverIds: ["server_123"],
+          overrides: {
+            server_123: {
+              mcpProtocolVersionOverride: "2025-11-25",
+            },
+          },
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("option", { name: "Latest" })
+      ).not.toBeInTheDocument();
+    });
+    unmount();
+
+    projectServerConfig = {
+      projectId: "project_123",
+      serverIds: ["server_123"],
+      overrides: {
+        server_123: {
+          mcpProtocolVersionOverride: "2025-11-25",
+        },
+      },
+    };
+    mockSetProjectServerConfig.mockClear();
+    render(renderModal());
+
+    await user.click(
+      screen.getByRole("button", { name: /connection overrides/i })
+    );
+
+    const latestSelect = getProtocolVersionCombobox();
+    expect(latestSelect).toHaveTextContent("Latest");
+
+    await user.click(latestSelect);
+    await user.click(
+      await screen.findByRole("option", { name: "Host default" })
+    );
+
+    await waitFor(() => {
+      expect(mockSetProjectServerConfig).toHaveBeenCalledWith({
+        projectId: "project_123",
+        input: {
+          serverIds: [],
+          overrides: {},
+        },
+      });
+    });
+  });
+
+  it("keeps explicit auto-connect enrollment when clearing a protocol override", async () => {
+    const user = userEvent.setup();
+    installPointerCaptureMocks();
+    mockUseFeatureFlagEnabled.mockReturnValue(true);
+    mockUseQuery.mockReturnValue({
+      projectId: "project_123",
+      serverIds: ["server_123"],
+      overrides: {
+        server_123: {
+          mcpProtocolVersionOverride: "2025-11-25",
+        },
+      },
+    });
+
+    render(
+      <ServerDetailModal
+        {...defaultProps}
+        projectId="project_123"
+        hostedServerId="server_123"
+        hostDefaultMcpProtocolVersion="DRAFT-2026-v1"
+      />
+    );
+
+    await user.click(
+      screen.getByRole("button", { name: /connection overrides/i })
+    );
+    const protocolSelect = getProtocolVersionCombobox();
+    expect(protocolSelect).toHaveTextContent("Latest");
+
+    await user.click(protocolSelect);
+    await user.click(
+      await screen.findByRole("option", { name: "Host default" })
+    );
+
+    await waitFor(() => {
+      expect(mockSetProjectServerConfig).toHaveBeenCalledWith({
+        projectId: "project_123",
+        input: {
+          serverIds: ["server_123"],
+          overrides: {},
         },
       });
     });

--- a/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
@@ -18,13 +18,13 @@ import type { McpProtocolVersion } from "@/lib/client-config-v2";
  *   - "latest" → `undefined`, legacy `OfficialSdkClientAdapter` +
  *     upstream `Client` (negotiates whatever `LATEST_PROTOCOL_VERSION`
  *     the SDK is shipping at runtime).
+ *   - "latest" → `"2025-11-25"`, explicit stable pin — overrides a host-level
+ *     Draft default.
  *   - "draft"  → `"DRAFT-2026-v1"`, the stateless preview client.
- *
- * "latest" serializes to `undefined` (not the literal `"2025-11-25"`) so
- * canonical hashes stay stable when the SDK bumps its default; see
- * `feedback_preserve_undefined_default`.
+ *   - "inherit" → `undefined`, defers to the host default (or SDK default if
+ *     no host default is set).
  */
-type DropdownValue = "latest" | "draft";
+type DropdownValue = "inherit" | "latest" | "draft";
 
 const MCP_PROTOCOL_OPTIONS: Array<{
   value: DropdownValue;
@@ -32,6 +32,7 @@ const MCP_PROTOCOL_OPTIONS: Array<{
   /** When true, the option appears only with `stateless-mcp-enabled` flag. */
   flagGated?: boolean;
 }> = [
+  { value: "inherit", label: "Host default" },
   { value: "latest", label: "Latest" },
   { value: "draft", label: "Draft", flagGated: true },
 ];
@@ -131,10 +132,12 @@ export function AdvancedConnectionSettingsSection({
     if (opt.value === "draft" && !isHttp) return false;
     return true;
   });
-  // "Draft" → DRAFT-2026-v1; everything else (2025-11-25, undefined,
-  // legacy carry-over) reads as "Latest".
   const selectedDropdownValue: DropdownValue =
-    mcpProtocolVersionOverride === "DRAFT-2026-v1" ? "draft" : "latest";
+    mcpProtocolVersionOverride === "DRAFT-2026-v1"
+      ? "draft"
+      : mcpProtocolVersionOverride === "2025-11-25"
+        ? "latest"
+        : "inherit";
 
   return (
     <div className="space-y-0">
@@ -290,7 +293,11 @@ export function AdvancedConnectionSettingsSection({
                 onValueChange={(next) => {
                   if (!onMcpProtocolVersionOverrideChange) return;
                   onMcpProtocolVersionOverrideChange(
-                    next === "draft" ? "DRAFT-2026-v1" : "2025-11-25",
+                    next === "draft"
+                      ? "DRAFT-2026-v1"
+                      : next === "latest"
+                        ? "2025-11-25"
+                        : undefined,
                   );
                 }}
               >

--- a/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
@@ -12,17 +12,12 @@ import { JsonEditor } from "@/components/ui/json-editor";
 import type { McpProtocolVersion } from "@/lib/client-config-v2";
 
 /**
- * Per-server protocol-version pin. The picker is a binary "Latest" vs
- * "Draft" toggle — the only two code paths the SDK factory actually
- * routes to today:
- *   - "latest" → `undefined`, legacy `OfficialSdkClientAdapter` +
- *     upstream `Client` (negotiates whatever `LATEST_PROTOCOL_VERSION`
- *     the SDK is shipping at runtime).
- *   - "latest" → `"2025-11-25"`, explicit stable pin — overrides a host-level
- *     Draft default.
- *   - "draft"  → `"DRAFT-2026-v1"`, the stateless preview client.
+ * Per-server protocol-version pin. Three-state picker:
  *   - "inherit" → `undefined`, defers to the host default (or SDK default if
  *     no host default is set).
+ *   - "latest"  → `"2025-11-25"`, explicit stable pin — overrides a
+ *     host-level Draft default.
+ *   - "draft"   → `"DRAFT-2026-v1"`, the stateless preview client.
  */
 type DropdownValue = "inherit" | "latest" | "draft";
 

--- a/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
@@ -50,7 +50,7 @@ interface AdvancedConnectionSettingsSectionProps {
   onUpdateHeader?: (
     index: number,
     field: "key" | "value",
-    value: string,
+    value: string
   ) => void;
   clientCapabilitiesOverrideEnabled?: boolean;
   onClientCapabilitiesOverrideEnabledChange?: (enabled: boolean) => void;
@@ -77,7 +77,7 @@ interface AdvancedConnectionSettingsSectionProps {
    */
   mcpProtocolVersionOverride?: McpProtocolVersion;
   onMcpProtocolVersionOverrideChange?: (
-    version: McpProtocolVersion | undefined,
+    version: McpProtocolVersion | undefined
   ) => void;
   /**
    * Transport kind of this server. Stateless options are HTTP-POST only,
@@ -118,7 +118,8 @@ export function AdvancedConnectionSettingsSection({
     onClientCapabilitiesOverrideEnabledChange !== undefined &&
     onClientCapabilitiesOverrideTextChange !== undefined;
   const showProtocolVersionControl = showMcpProtocolVersionOverride;
-  const canEditProtocolVersion = onMcpProtocolVersionOverrideChange !== undefined;
+  const canEditProtocolVersion =
+    onMcpProtocolVersionOverrideChange !== undefined;
   // "Draft" is Streamable HTTP POST only — picking it on stdio / sse
   // would fail at construction with `StatelessRequiresHttpTransport`.
   // Hide it on non-HTTP transports as the user-friendly safety net.
@@ -131,8 +132,8 @@ export function AdvancedConnectionSettingsSection({
     mcpProtocolVersionOverride === "DRAFT-2026-v1"
       ? "draft"
       : mcpProtocolVersionOverride === "2025-11-25"
-        ? "latest"
-        : "inherit";
+      ? "latest"
+      : "inherit";
 
   return (
     <div className="space-y-0">
@@ -196,7 +197,9 @@ export function AdvancedConnectionSettingsSection({
                     >
                       <Input
                         value={header.key}
-                        onChange={(e) => onUpdateHeader(index, "key", e.target.value)}
+                        onChange={(e) =>
+                          onUpdateHeader(index, "key", e.target.value)
+                        }
                         placeholder="Key"
                         className="h-7 flex-1 text-xs"
                       />
@@ -291,8 +294,8 @@ export function AdvancedConnectionSettingsSection({
                     next === "draft"
                       ? "DRAFT-2026-v1"
                       : next === "latest"
-                        ? "2025-11-25"
-                        : undefined,
+                      ? "2025-11-25"
+                      : undefined
                   );
                 }}
               >
@@ -309,13 +312,14 @@ export function AdvancedConnectionSettingsSection({
               </Select>
               {!isHttp && (
                 <p className="text-xs text-muted-foreground">
-                  Draft requires Streamable HTTP — only Latest is
-                  selectable for this transport.
+                  Draft requires Streamable HTTP — only Latest is selectable for
+                  this transport.
                 </p>
               )}
               {!canEditProtocolVersion && (
                 <p className="text-xs text-muted-foreground">
-                  Enable auto-connect for this server to set a per-server protocol override.
+                  Project configuration must finish loading before setting a
+                  per-server protocol override.
                 </p>
               )}
             </div>

--- a/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/AdvancedConnectionSettingsSection.tsx
@@ -121,9 +121,8 @@ export function AdvancedConnectionSettingsSection({
   const showClientCapabilitiesControls =
     onClientCapabilitiesOverrideEnabledChange !== undefined &&
     onClientCapabilitiesOverrideTextChange !== undefined;
-  const showProtocolVersionControl =
-    showMcpProtocolVersionOverride &&
-    onMcpProtocolVersionOverrideChange !== undefined;
+  const showProtocolVersionControl = showMcpProtocolVersionOverride;
+  const canEditProtocolVersion = onMcpProtocolVersionOverrideChange !== undefined;
   // "Draft" is Streamable HTTP POST only — picking it on stdio / sse
   // would fail at construction with `StatelessRequiresHttpTransport`.
   // Hide it on non-HTTP transports as the user-friendly safety net.
@@ -132,9 +131,8 @@ export function AdvancedConnectionSettingsSection({
     if (opt.value === "draft" && !isHttp) return false;
     return true;
   });
-  // Any stored stateful literal (legacy carry-over from a previous
-  // schema) reads as "Latest" — same code path, and saving normalizes
-  // it back to `undefined`.
+  // "Draft" → DRAFT-2026-v1; everything else (2025-11-25, undefined,
+  // legacy carry-over) reads as "Latest".
   const selectedDropdownValue: DropdownValue =
     mcpProtocolVersionOverride === "DRAFT-2026-v1" ? "draft" : "latest";
 
@@ -288,10 +286,11 @@ export function AdvancedConnectionSettingsSection({
               </label>
               <Select
                 value={selectedDropdownValue}
+                disabled={!canEditProtocolVersion}
                 onValueChange={(next) => {
                   if (!onMcpProtocolVersionOverrideChange) return;
                   onMcpProtocolVersionOverrideChange(
-                    next === "draft" ? "DRAFT-2026-v1" : undefined,
+                    next === "draft" ? "DRAFT-2026-v1" : "2025-11-25",
                   );
                 }}
               >
@@ -310,6 +309,11 @@ export function AdvancedConnectionSettingsSection({
                 <p className="text-xs text-muted-foreground">
                   Draft requires Streamable HTTP — only Latest is
                   selectable for this transport.
+                </p>
+              )}
+              {!canEditProtocolVersion && (
+                <p className="text-xs text-muted-foreground">
+                  Enable auto-connect for this server to set a per-server protocol override.
                 </p>
               )}
             </div>

--- a/mcpjam-inspector/client/src/components/connection/shared/EffectiveProtocolVersionChip.tsx
+++ b/mcpjam-inspector/client/src/components/connection/shared/EffectiveProtocolVersionChip.tsx
@@ -1,5 +1,4 @@
 import type { McpProtocolVersion } from "@/lib/client-config-v2";
-import { isStatelessProtocolVersion } from "@mcpjam/sdk/browser";
 
 interface EffectiveProtocolVersionChipProps {
   /**
@@ -15,25 +14,12 @@ interface EffectiveProtocolVersionChipProps {
   /**
    * When the feature flag is off, the chip surfaces nothing — the
    * config field may still carry a stored pin but it has no runtime
-   * effect until the dispatch wiring is enabled. Hides labels like
-   * "DRAFT-2026-v1 · host default" before stateless dispatch is live.
+   * effect until the dispatch wiring is enabled.
    */
   flagEnabled?: boolean;
 }
 
-/**
- * Read-only chip showing the effective pinned protocol version for a
- * server connection and which layer in the three-layer config resolution
- * it came from. Source attribution helps users notice when a host-default
- * change cascaded to a server that has no override of its own.
- *
- * Resolution rule (mirror of the bridge / wire-client factory):
- *   server override wins; otherwise host default; otherwise SDK default.
- *
- * `undefined` resolution is rendered as "Default (SDK)" — preserves the
- * undefined-as-default semantics that lets canonical hashes stay stable
- * when the SDK upgrades its default version.
- */
+/** Read-only label for the effective MCP protocol version on a server. */
 export function EffectiveProtocolVersionChip({
   hostDefault,
   serverOverride,
@@ -44,33 +30,9 @@ export function EffectiveProtocolVersionChip({
   const effective: McpProtocolVersion | undefined =
     serverOverride ?? hostDefault;
 
-  const sourceLabel =
-    serverOverride !== undefined
-      ? "server pin"
-      : hostDefault !== undefined
-        ? "host default"
-        : "SDK default";
-
-  const isStateless =
-    effective !== undefined && isStatelessProtocolVersion(effective);
-
-  const tone = isStateless
-    ? "border-amber-500/40 bg-amber-500/10 text-amber-700"
-    : "border-border bg-muted text-muted-foreground";
-
-  const label = isStateless ? "Draft" : "Latest";
-
   return (
-    <span
-      className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-medium ${tone}`}
-      title={
-        isStateless
-          ? `Experimental DRAFT-2026-v1 stateless transport (${effective})`
-          : "Current stable MCP wire version (negotiated by the SDK)"
-      }
-    >
-      {label}
-      <span className="text-[9px] opacity-70">· {sourceLabel}</span>
+    <span className="inline-flex items-center px-1 text-[11px] text-muted-foreground">
+      {effective ?? "Latest"}
     </span>
   );
 }


### PR DESCRIPTION
## Summary

- **Protocol version dropdown now always shows** when `stateless-mcp-enabled` flag is on — previously hidden unless the server was already in the project's auto-connect (`serverIds`) set
- **Disabled with a clear hint** ("Enable auto-connect for this server...") when the server isn't in `serverIds`, rather than being invisible
- **"Latest" now writes an explicit `2025-11-25` pin** instead of `undefined`, so it actually overrides a host-level Draft default (`undefined ?? hostDefault` would have deferred to Draft)
- **"Reconnect" button** replaces the disabled "Save Changes" when the server is connected and the form has no changes — lets users force a reconnect after a protocol version change without toggling the server card
- Simplifies `EffectiveProtocolVersionChip` to a plain label (pre-existing local change)

## Test plan

- [ ] Open a server modal with `stateless-mcp-enabled` flag on — Protocol version row appears in Connection overrides
- [ ] Server NOT in project auto-connect: dropdown is greyed out with hint text
- [ ] Server IN project auto-connect: dropdown is interactive
- [ ] Host set to Draft, per-server set to Latest → wire log shows `server/initialize` (stateful), chip shows `2025-11-25`
- [ ] Host set to Draft, per-server set to Draft → wire log shows `server/discover` (stateless)
- [ ] While connected with no form changes, modal shows "Reconnect" button that triggers a fresh connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how project `serverIds` and overrides are written via `setConfig` (including implicit auto-enroll/undo), which can affect which servers auto-connect; reconnect and wire-mode behavior after toggles also changed.
> 
> **Overview**
> Makes **per-server MCP protocol version** usable from the server detail modal without requiring prior auto-connect enrollment, and fixes **Latest** so it actually overrides a host-level Draft default.
> 
> The **Protocol version** control is a three-state picker (**Host default** / **Latest** / **Draft**). **Latest** now persists an explicit `2025-11-25` pin instead of `undefined`, so it no longer silently inherits a Draft host default. The row stays visible when `stateless-mcp-enabled` is on; it is only disabled while project config is still loading (with a hint), not hidden when the server is outside `serverIds`.
> 
> Saving an override for a server not in the project auto-connect set **implicitly adds** that server to `serverIds` (required by backend validation). **Session storage** records that enrollment so clearing the override can **remove only that implicit** auto-connect, leaving servers that were already explicitly enrolled.
> 
> After override saves, **reconnect** runs with `allowInteractiveOAuthFlow: false` (including the post-save watcher and timeout fallback). Connected servers with no config edits get a **Reconnect** footer action instead of a disabled Save.
> 
> **EffectiveProtocolVersionChip** is reduced to a simple effective-version text label. Tests cover override-before-auto-connect, implicit enrollment rollback, and explicit enrollment preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5440c58aa582ec831fe6164dae3521ea9bc2de2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->