### PR TITLE
[codex] fix hosted mixed protocol tools

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -182,10 +182,10 @@ import { getEffectiveProjectClientCapabilities } from "./lib/client-config";
 import {
   getDefaultClientCapabilities,
   isKnownProtocolVersion,
-  isStatelessProtocolVersion,
   type McpProtocolVersion,
 } from "@mcpjam/sdk/browser";
 import { resolveEffectiveMcpProtocolVersion } from "./lib/client-config-v2";
+import type { ProjectServerConfigDto } from "./lib/project-server-config";
 import {
   buildClientsPath,
   buildOrganizationPath,
@@ -1210,13 +1210,6 @@ export default function App() {
   const playgroundTabEnabled = useFeatureFlagEnabled("playground-tab-enabled");
   const evaluateRunsEnabled = useFeatureFlagEnabled("evaluate-runs");
   const xaaEnabled = useFeatureFlagEnabled("xaa");
-  // Rollout kill-switch for the DRAFT-2026-v1 stateless transport. Gates
-  // both UI controls (ProtocolTab, ServerDetailModal, EditServerFormContent,
-  // AdvancedConnectionSettingsSection) AND request stamping — a persisted
-  // override from a prior flag-on session must NOT bypass the switch
-  // (otherwise hosted validate/tools/resources/prompts flows still
-  // activate the stateless transport).
-  const statelessMcpEnabled = useFeatureFlagEnabled("stateless-mcp-enabled");
   const {
     getAccessToken,
     signIn,
@@ -1825,6 +1818,12 @@ export default function App() {
     getEffectiveProjectClientCapabilities(activeProject?.clientConfig) ??
     getDefaultClientCapabilities()) as Record<string, unknown>;
   const convexProjectId = activeProject?.sharedProjectId ?? null;
+  const projectServerConfigDto = useQuery(
+    "projectServerConfig:getConfig" as never,
+    convexProjectId ? ({ projectId: convexProjectId } as never) : "skip"
+  ) as ProjectServerConfigDto | null | undefined;
+  const isProjectServerConfigLoading =
+    Boolean(convexProjectId) && projectServerConfigDto === undefined;
   // hostsTabSelectedHostId is a Hosts-tab-local cursor; drop it when scope
   // changes so it can't bleed across projects. `activeHostId` is owned by
   // useAppState (project-keyed in localStorage) and self-resets.
@@ -2037,12 +2036,16 @@ export default function App() {
         ? rawHostPin
         : undefined;
 
-    const mcpProtocolVersionsByServerId: Record<
-      string,
-      McpProtocolVersion
-    > = {};
+    const mcpProtocolVersionsByServerId: Record<string, McpProtocolVersion> =
+      {};
     for (const serverId of new Set(Object.values(hostedServerIdsByName))) {
+      // Project-server config is the control-plane source for per-server
+      // protocol overrides. Host config mirrors it through Convex fan-out,
+      // but hosted API calls should not fall back to the host default while
+      // that reactive host snapshot is still catching up.
       const rawServerOverride =
+        projectServerConfigDto?.overrides?.[serverId]
+          ?.mcpProtocolVersionOverride ??
         activeHost?.serverConnectionOverrides?.[serverId]
           ?.mcpProtocolVersionOverride;
       const serverOverride: McpProtocolVersion | undefined =
@@ -2055,15 +2058,6 @@ export default function App() {
         hostPin
       );
       if (!effective) continue;
-      // Persisted stateless pins (DRAFT-2026-v1) MUST NOT bypass the
-      // rollout flag. The UI gates only control authoring; without this
-      // gate, a server config saved while the flag was on (or set by an
-      // admin) would still route every hosted call through the stateless
-      // preview after the flag is flipped off. Stateful pins like
-      // "2025-11-25" are unaffected.
-      if (!statelessMcpEnabled && isStatelessProtocolVersion(effective)) {
-        continue;
-      }
       mcpProtocolVersionsByServerId[serverId] = effective;
     }
 
@@ -2079,7 +2073,7 @@ export default function App() {
     activeHost?.serverConnectionOverrides,
     activeMcpProfile,
     hostedServerIdsByName,
-    statelessMcpEnabled,
+    projectServerConfigDto?.overrides,
   ]);
   useApiContext({
     projectId: convexProjectId,
@@ -2089,7 +2083,8 @@ export default function App() {
     supportedProtocolVersions: hostedMcpProfilePins.supportedProtocolVersions,
     mcpProtocolVersionsByServerId:
       hostedMcpProfilePins.mcpProtocolVersionsByServerId,
-    clientConfigSyncPending: isClientConfigSyncPending,
+    clientConfigSyncPending:
+      isClientConfigSyncPending || isProjectServerConfigLoading,
     getAccessToken,
     oauthTokensByServerId,
     // `ApiContext.isAuthenticated` means "WorkOS user is signed in",

--- a/mcpjam-inspector/client/src/components/ui-playground/hooks/use-app-builder-state.ts
+++ b/mcpjam-inspector/client/src/components/ui-playground/hooks/use-app-builder-state.ts
@@ -22,6 +22,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   type ReactNode,
 } from "react";
 import type { Tool } from "@modelcontextprotocol/client";
@@ -51,6 +52,10 @@ import {
   registerInspectorCommandHandler,
 } from "@/lib/inspector-command-handlers";
 import { useAppToolsRegistry } from "@/components/chat-v2/thread/mcp-apps/app-tools-registry";
+import {
+  getApiContextRevision,
+  subscribeApiContext,
+} from "@/lib/apis/web/context";
 import type {
   ExecuteToolInspectorCommand,
   RenderToolResultInspectorCommand,
@@ -88,10 +93,10 @@ export interface UseAppBuilderStateOptions {
   onConnect?: (formData: ServerFormData) => void;
   onSaveHostContext?: (
     projectId: string,
-    hostContext: ProjectHostContextDraft,
+    hostContext: ProjectHostContextDraft
   ) => Promise<void>;
   ensureServersReady?: (
-    serverNames: string[],
+    serverNames: string[]
   ) => Promise<EnsureServersReadyResult>;
   onOnboardingChange?: (isOnboarding: boolean) => void;
   /**
@@ -171,7 +176,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
         serverName,
         servers,
       }),
-    [selectedServerNames, serverName, servers],
+    [selectedServerNames, serverName, servers]
   );
 
   const posthog = usePostHog();
@@ -285,6 +290,11 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
   });
 
   const executionInjectionWaitersRef = useRef<ExecutionInjectionWaiter[]>([]);
+  const apiContextRevision = useSyncExternalStore(
+    subscribeApiContext,
+    getApiContextRevision,
+    getApiContextRevision
+  );
 
   const waitForExecutionInjection = useCallback(
     (expectedToolCallId: string | undefined, timeoutMs?: number) => {
@@ -298,7 +308,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
         if (!waiter) return;
         executionInjectionWaitersRef.current =
           executionInjectionWaitersRef.current.filter(
-            (entry) => entry !== waiter,
+            (entry) => entry !== waiter
           );
       };
 
@@ -308,8 +318,8 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
           reject(
             createInspectorCommandClientError(
               "timeout",
-              `Tool result was not rendered in App Builder within ${effectiveTimeoutMs}ms.`,
-            ),
+              `Tool result was not rendered in App Builder within ${effectiveTimeoutMs}ms.`
+            )
           );
         }, effectiveTimeoutMs);
 
@@ -335,7 +345,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
         promise,
       };
     },
-    [],
+    []
   );
 
   const handleExecutionInjected = useCallback(
@@ -358,7 +368,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
         waiter.resolve(toolCallId);
       }
     },
-    [clearPendingExecution],
+    [clearPendingExecution]
   );
 
   useEffect(() => {
@@ -369,8 +379,8 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
         waiter.reject(
           createInspectorCommandClientError(
             "unsupported_in_mode",
-            "App Builder unmounted before the tool result rendered.",
-          ),
+            "App Builder unmounted before the tool result rendered."
+          )
         );
       }
     };
@@ -395,26 +405,26 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
       const data = await listTools({ serverId: serverName });
       const toolArray = data.tools ?? [];
       const dictionary = Object.fromEntries(
-        toolArray.map((tool: Tool) => [tool.name, tool]),
+        toolArray.map((tool: Tool) => [tool.name, tool])
       );
       setTools(dictionary);
       setToolsMetadata(data.toolsMetadata ?? {});
     } catch (err) {
       console.error("Failed to fetch tools:", err);
       setExecutionError(
-        err instanceof Error ? err.message : "Failed to fetch tools",
+        err instanceof Error ? err.message : "Failed to fetch tools"
       );
     } finally {
       setFetchingTools(false);
     }
-  }, [serverName, reset, setTools, setExecutionError]);
+  }, [serverName, reset, setTools, setExecutionError, apiContextRevision]);
 
   const loadToolsUntilMatch = useCallback(
     async (toolName?: string) => {
       if (!serverName) {
         throw createInspectorCommandClientError(
           "disconnected_server",
-          "No server is selected in the App Builder.",
+          "No server is selected in the App Builder."
         );
       }
 
@@ -438,7 +448,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
           const data = await listTools({ serverId: serverName, cursor });
           const toolArray = data.tools ?? [];
           const dictionary = Object.fromEntries(
-            toolArray.map((tool: Tool) => [tool.name, tool]),
+            toolArray.map((tool: Tool) => [tool.name, tool])
           );
 
           Object.assign(aggregatedTools, dictionary);
@@ -456,7 +466,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
             setExecutionError(message);
             throw createInspectorCommandClientError(
               "execution_failed",
-              message,
+              message
             );
           }
 
@@ -478,7 +488,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
         setFetchingTools(false);
       }
     },
-    [serverName, setExecutionError, setTools, tools, toolsMetadata],
+    [serverName, setExecutionError, setTools, tools, toolsMetadata]
   );
 
   const buildAppBuilderSnapshot = useCallback(() => {
@@ -530,6 +540,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
     serverConfig,
     serverName,
     serverConnectionStatus,
+    apiContextRevision,
     fetchTools,
     reset,
     tools,
@@ -551,13 +562,13 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
   useEffect(() => {
     if (selectedTool && tools[selectedTool]) {
       setFormFields(
-        generateFormFieldsFromSchema(tools[selectedTool].inputSchema),
+        generateFormFieldsFromSchema(tools[selectedTool].inputSchema)
       );
       return;
     }
     if (selectedAppToolDescriptor) {
       setFormFields(
-        generateFormFieldsFromSchema(selectedAppToolDescriptor.inputSchema),
+        generateFormFieldsFromSchema(selectedAppToolDescriptor.inputSchema)
       );
       return;
     }
@@ -569,7 +580,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
       command:
         | SelectToolInspectorCommand
         | ExecuteToolInspectorCommand
-        | RenderToolResultInspectorCommand,
+        | RenderToolResultInspectorCommand
     ) => {
       // Accept both `app-builder` (legacy) and `playground` (transition). The
       // `playground-tab-enabled` flag controls which surface actually mounts,
@@ -580,7 +591,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
       ) {
         throw createInspectorCommandClientError(
           "unsupported_in_mode",
-          `AppBuilderTab cannot handle ${command.type} for ${command.payload.surface}.`,
+          `AppBuilderTab cannot handle ${command.type} for ${command.payload.surface}.`
         );
       }
 
@@ -591,7 +602,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
       ) {
         throw createInspectorCommandClientError(
           "disconnected_server",
-          "The App Builder requires a connected server before tools can be selected.",
+          "The App Builder requires a connected server before tools can be selected."
         );
       }
 
@@ -601,18 +612,18 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
       ) {
         throw createInspectorCommandClientError(
           "unknown_server",
-          `App Builder is focused on "${serverName}", not "${command.payload.serverName}".`,
+          `App Builder is focused on "${serverName}", not "${command.payload.serverName}".`
         );
       }
 
       const { tools: availableTools } = await loadToolsUntilMatch(
-        command.payload.toolName,
+        command.payload.toolName
       );
       const tool = availableTools[command.payload.toolName];
       if (!tool) {
         throw createInspectorCommandClientError(
           "unknown_tool",
-          `Unknown tool "${command.payload.toolName}" on server "${serverName}".`,
+          `Unknown tool "${command.payload.toolName}" on server "${serverName}".`
         );
       }
 
@@ -637,7 +648,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
       if (command.payload.parameters) {
         const latestFields = useUIPlaygroundStore.getState().formFields;
         setFormFields(
-          applyParamsToFields(latestFields, command.payload.parameters),
+          applyParamsToFields(latestFields, command.payload.parameters)
         );
         await waitForUiCommit();
       }
@@ -651,7 +662,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
       serverName,
       setFormFields,
       setSelectedTool,
-    ],
+    ]
   );
 
   // useLayoutEffect so handlers update synchronously during commit — before
@@ -669,7 +680,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
           toolName: command.payload.toolName,
           parameterKeys: Object.keys(selection.parameters),
         };
-      },
+      }
     );
 
     const unregisterExecuteTool = registerInspectorCommandHandler(
@@ -687,7 +698,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
           throw createInspectorCommandClientError(
             "execution_failed",
             outcome.error,
-            outcome.response,
+            outcome.response
           );
         }
 
@@ -698,7 +709,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
           parameters: outcome.parameters,
           result: outcome.result,
         };
-      },
+      }
     );
 
     const unregisterRenderToolResult = registerInspectorCommandHandler(
@@ -708,7 +719,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
         const selection = await selectToolForCommand(command);
         const injection = waitForExecutionInjection(
           command.id,
-          command.timeoutMs,
+          command.timeoutMs
         );
         let outcome: Awaited<ReturnType<typeof injectToolResult>>;
         try {
@@ -731,7 +742,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
           parameters: outcome.parameters,
           result: outcome.result,
         };
-      },
+      }
     );
 
     const unregisterSetAppContext = registerInspectorCommandHandler(
@@ -757,7 +768,7 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
 
         await waitForUiCommit();
         return buildAppBuilderSnapshot();
-      },
+      }
     );
 
     const unregisterSnapshotApp = registerInspectorCommandHandler(
@@ -771,12 +782,12 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
         ) {
           throw createInspectorCommandClientError(
             "unsupported_in_mode",
-            `AppBuilderTab cannot snapshot ${command.payload.surface}.`,
+            `AppBuilderTab cannot snapshot ${command.payload.surface}.`
           );
         }
 
         return buildAppBuilderSnapshot();
-      },
+      }
     );
 
     return () => {
@@ -840,10 +851,10 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
     isWaitingForServerSync
       ? { kind: "skeleton" }
       : !serverConfig && isServerSyncing && syncTimedOut
-        ? { kind: "sync-timed-out" }
-        : !serverConfig
-          ? { kind: "no-server" }
-          : { kind: "ready" };
+      ? { kind: "sync-timed-out" }
+      : !serverConfig
+      ? { kind: "no-server" }
+      : { kind: "ready" };
 
   return {
     loadingState,
@@ -897,8 +908,9 @@ export function useAppBuilderState(options: UseAppBuilderStateOptions) {
  * state, refs, and inspector command registrations — calling it twice would
  * double-register handlers).
  */
-const AppBuilderStateContext =
-  createContext<UseAppBuilderStateReturn | null>(null);
+const AppBuilderStateContext = createContext<UseAppBuilderStateReturn | null>(
+  null
+);
 
 export function AppBuilderStateProvider({
   value,
@@ -914,7 +926,7 @@ export function useAppBuilderStateContext(): UseAppBuilderStateReturn {
   const ctx = useContext(AppBuilderStateContext);
   if (!ctx) {
     throw new Error(
-      "useAppBuilderStateContext must be used inside an AppBuilderStateProvider",
+      "useAppBuilderStateContext must be used inside an AppBuilderStateProvider"
     );
   }
   return ctx;

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-aggregated-tools.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-aggregated-tools.test.tsx
@@ -1,0 +1,61 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAggregatedTools } from "../use-aggregated-tools";
+import { setApiContext } from "@/lib/apis/web/context";
+import { listTools } from "@/lib/apis/mcp-tools-api";
+
+vi.mock("@/lib/apis/mcp-tools-api", () => ({
+  listTools: vi.fn(),
+}));
+
+describe("useAggregatedTools", () => {
+  beforeEach(() => {
+    vi.mocked(listTools).mockImplementation(async ({ serverId }) => ({
+      tools: [
+        {
+          name: `${serverId}_tool`,
+          description: `${serverId} tool`,
+          inputSchema: { type: "object", properties: {} },
+        },
+      ],
+    }));
+  });
+
+  afterEach(() => {
+    setApiContext(null);
+    vi.clearAllMocks();
+  });
+
+  it("refetches when hosted API context changes", async () => {
+    const { result, unmount } = renderHook(() =>
+      useAggregatedTools(["Excalidraw", "stateless"])
+    );
+
+    await waitFor(() => {
+      expect(result.current.flat.map((entry) => entry.toolName).sort()).toEqual(
+        ["Excalidraw_tool", "stateless_tool"]
+      );
+    });
+
+    await act(async () => {
+      setApiContext({
+        projectId: "project-1",
+        serverIdsByName: {
+          Excalidraw: "server-stateful",
+          stateless: "server-stateless",
+        },
+        mcpProtocolVersionsByServerId: {
+          "server-stateful": "2025-11-25",
+          "server-stateless": "DRAFT-2026-v1",
+        },
+        getAccessToken: async () => null,
+      });
+    });
+
+    await waitFor(() => {
+      expect(listTools).toHaveBeenCalledTimes(4);
+    });
+
+    unmount();
+  });
+});

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-chat-session.hosted.test.tsx
@@ -162,6 +162,35 @@ vi.mock("@/lib/guest-session", () => ({
 
 vi.mock("@/lib/apis/web/context", () => ({
   buildServerRequest: mockState.buildServerRequest,
+  buildResolvedServerBatchRequest: vi.fn(
+    ({
+      projectId,
+      serverIds,
+      serverNames,
+      oauthTokens,
+      accessScope,
+      chatboxId,
+      accessVersion,
+    }: {
+      projectId: string;
+      serverIds: string[];
+      serverNames: string[];
+      oauthTokens?: Record<string, string>;
+      accessScope?: string;
+      chatboxId?: string;
+      accessVersion?: number;
+    }) => ({
+      projectId,
+      serverIds,
+      serverNames,
+      ...(oauthTokens ? { oauthTokens } : {}),
+      ...(accessScope ? { accessScope } : {}),
+      ...(chatboxId ? { chatboxId } : {}),
+      ...(chatboxId && Number.isFinite(accessVersion) ? { accessVersion } : {}),
+    })
+  ),
+  getApiContextRevision: vi.fn(() => 0),
+  subscribeApiContext: vi.fn(() => () => {}),
 }));
 
 vi.mock("@workos-inc/authkit-react", () => ({
@@ -290,7 +319,8 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
         },
       })
     );
@@ -302,7 +332,8 @@ describe("useChatSession hosted mode", () => {
       chatSessionId: "chat-session-id",
       selectedServerIds: ["server-id-1"],
       selectedServerNames: ["server-1"],
-      chatboxId: "cbx_test", accessVersion: 1,
+      chatboxId: "cbx_test",
+      accessVersion: 1,
       accessScope: "chat_v2",
     });
     unmount();
@@ -315,7 +346,8 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
           oauthTokens: {
             "server-id-1": "browser-token",
           },
@@ -330,7 +362,8 @@ describe("useChatSession hosted mode", () => {
       chatSessionId: "chat-session-id",
       selectedServerIds: ["server-id-1"],
       selectedServerNames: ["server-1"],
-      chatboxId: "cbx_test", accessVersion: 1,
+      chatboxId: "cbx_test",
+      accessVersion: 1,
       accessScope: "chat_v2",
     });
     expect(body).not.toHaveProperty("oauthTokens");
@@ -344,7 +377,8 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
           chatboxSurface: "preview",
         },
       })
@@ -352,7 +386,8 @@ describe("useChatSession hosted mode", () => {
 
     const body = lastTransportOptions.body();
     expect(body).toMatchObject({
-      chatboxId: "cbx_test", accessVersion: 1,
+      chatboxId: "cbx_test",
+      accessVersion: 1,
       surface: "preview",
     });
     unmount();
@@ -377,12 +412,12 @@ describe("useChatSession hosted mode", () => {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
         },
-      }),
+      })
     );
 
     await waitFor(() => {
       expect(result.current.availableModels.map((model) => model.id)).toContain(
-        "gpt-4o-mini",
+        "gpt-4o-mini"
       );
     });
     expect(result.current.selectedModel.id).toBe("gpt-4o-mini");
@@ -418,7 +453,8 @@ describe("useChatSession hosted mode", () => {
           hostedContext: {
             projectId: "project-1",
             selectedServerIds: ["server-id-1"],
-            chatboxId: "cbx_1", accessVersion: 1,
+            chatboxId: "cbx_1",
+            accessVersion: 1,
           },
         },
       }
@@ -437,7 +473,8 @@ describe("useChatSession hosted mode", () => {
       hostedContext: {
         projectId: "project-2",
         selectedServerIds: ["server-id-2"],
-        chatboxId: "cbx_2", accessVersion: 1,
+        chatboxId: "cbx_2",
+        accessVersion: 1,
       },
     });
 
@@ -670,7 +707,8 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
         },
       })
     );
@@ -740,7 +778,8 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
         },
       })
     );
@@ -762,7 +801,8 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
         },
       })
     );
@@ -937,8 +977,7 @@ describe("useChatSession hosted mode", () => {
     });
 
     await waitFor(() => {
-      const mcp =
-        result.current.restoredToolRenderOverrides["tool-call-mcp"];
+      const mcp = result.current.restoredToolRenderOverrides["tool-call-mcp"];
       const openai =
         result.current.restoredToolRenderOverrides["tool-call-openai"];
       expect(mcp).toBeDefined();
@@ -969,7 +1008,8 @@ describe("useChatSession hosted mode", () => {
         hostedContext: {
           projectId: "project-1",
           selectedServerIds: ["server-id-1"],
-          chatboxId: "cbx_test", accessVersion: 1,
+          chatboxId: "cbx_test",
+          accessVersion: 1,
         },
       })
     );

--- a/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.protocol-revalidation.test.tsx
+++ b/mcpjam-inspector/client/src/hooks/__tests__/use-server-state.protocol-revalidation.test.tsx
@@ -24,7 +24,6 @@ const {
   getStoredTokensMock,
   getInitializationInfoMock,
   mockUseDbUserReady,
-  useFeatureFlagEnabledMock,
 } = vi.hoisted(() => ({
   reconnectServerMock: vi.fn(),
   tryResolveProjectServerMock: vi.fn<
@@ -33,16 +32,6 @@ const {
   getStoredTokensMock: vi.fn(),
   getInitializationInfoMock: vi.fn(),
   mockUseDbUserReady: vi.fn(() => true),
-  // Controllable per-test. Returning `false` by default matches the
-  // production rollout posture (flag off until explicit opt-in).
-  useFeatureFlagEnabledMock: vi.fn<(flag: string) => boolean | undefined>(
-    () => true,
-  ),
-}));
-
-vi.mock("posthog-js/react", () => ({
-  useFeatureFlagEnabled: (flag: string) => useFeatureFlagEnabledMock(flag),
-  usePostHog: () => null,
 }));
 
 vi.mock("sonner", () => ({
@@ -235,12 +224,6 @@ beforeEach(() => {
     initInfo: null,
   });
   mockUseDbUserReady.mockReturnValue(true);
-  // Default: stateless rollout flag ON for the bulk of these tests
-  // (the in-isolation Cursor / codex reviewers exercised the
-  // flag-on path). Specific tests flip it via `mockReturnValue`.
-  useFeatureFlagEnabledMock.mockImplementation((flag: string) =>
-    flag === "stateless-mcp-enabled" ? true : false,
-  );
 });
 
 describe("useServerState mcpProtocolVersion re-validation", () => {
@@ -395,78 +378,4 @@ describe("useServerState mcpProtocolVersion re-validation", () => {
     expect(reconnectServerMock).not.toHaveBeenCalled();
   });
 
-  it("re-tests when the stateless rollout flag flips ON for a server with a persisted DRAFT pin", async () => {
-    // Flag-flip regression. Scenario:
-    // 1. Flag OFF, persisted pin DRAFT-2026-v1. Server connected with
-    //    legacy transport (the gate in `buildResolverConnectionDefaults`
-    //    drops stateless pins when the flag is off).
-    // 2. Flag flips ON. `buildResolverConnectionDefaults` now stamps
-    //    DRAFT-2026-v1 → wire mode silently changes from legacy to
-    //    stateless. Without tracking the *effective* (flag-gated) pin,
-    //    the re-validation effect saw `previous === effective ===
-    //    "DRAFT-2026-v1"` and skipped the re-test.
-    useFeatureFlagEnabledMock.mockImplementation((flag: string) =>
-      flag === "stateless-mcp-enabled" ? false : false,
-    );
-    reconnectServerMock.mockResolvedValue({ success: true, initInfo: null });
-
-    const dispatch = vi.fn();
-    const { rerender } = renderRevalidationHook(dispatch, {
-      profile: { mcpProtocolVersion: "DRAFT-2026-v1" },
-      hostConfig: buildHostConfig(),
-    });
-
-    await flushAsyncWork(5);
-    expect(reconnectServerMock).not.toHaveBeenCalled();
-
-    // Flip the flag ON. Rerender with the same profile/hostConfig —
-    // only the flag changed. Effective pin: undefined → DRAFT-2026-v1.
-    useFeatureFlagEnabledMock.mockImplementation((flag: string) =>
-      flag === "stateless-mcp-enabled" ? true : false,
-    );
-    rerender({
-      profile: { mcpProtocolVersion: "DRAFT-2026-v1" },
-      hostConfig: buildHostConfig(),
-    });
-
-    await waitFor(() => {
-      expect(reconnectServerMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("re-tests when the stateless rollout flag flips OFF for a server with a persisted DRAFT pin", async () => {
-    // Mirror of the previous test: flag ON → OFF with a persisted DRAFT
-    // pin means stateless transport silently drops back to legacy.
-    // Connected stateless servers must re-test against the new
-    // (legacy) transport so a stateless-only fixture doesn't keep
-    // claiming "Connected" while every request actually fails.
-    useFeatureFlagEnabledMock.mockImplementation((flag: string) =>
-      flag === "stateless-mcp-enabled" ? true : false,
-    );
-    reconnectServerMock.mockResolvedValue({
-      success: false,
-      error: "legacy server cannot speak DRAFT-2026-v1 anyway",
-    });
-
-    const dispatch = vi.fn();
-    const { rerender } = renderRevalidationHook(dispatch, {
-      profile: { mcpProtocolVersion: "DRAFT-2026-v1" },
-      hostConfig: buildHostConfig(),
-    });
-
-    await flushAsyncWork(5);
-    expect(reconnectServerMock).not.toHaveBeenCalled();
-
-    useFeatureFlagEnabledMock.mockImplementation((flag: string) =>
-      flag === "stateless-mcp-enabled" ? false : false,
-    );
-    rerender({
-      profile: { mcpProtocolVersion: "DRAFT-2026-v1" },
-      hostConfig: buildHostConfig(),
-    });
-
-    await waitFor(() => {
-      expect(reconnectServerMock).toHaveBeenCalledTimes(1);
-    });
-  });
 });

--- a/mcpjam-inspector/client/src/hooks/use-aggregated-tools.ts
+++ b/mcpjam-inspector/client/src/hooks/use-aggregated-tools.ts
@@ -1,6 +1,17 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import type { Tool } from "@modelcontextprotocol/client";
 import { listTools } from "@/lib/apis/mcp-tools-api";
+import {
+  getApiContextRevision,
+  subscribeApiContext,
+} from "@/lib/apis/web/context";
 
 export interface ServerScopedTool {
   serverId: string;
@@ -34,16 +45,21 @@ export interface AggregatedToolsState {
  *     last-seen-wins collision behavior baked into `ToolServerMap`.
  */
 export function useAggregatedTools(
-  serverNames: string[],
+  serverNames: string[]
 ): AggregatedToolsState {
+  const apiContextRevision = useSyncExternalStore(
+    subscribeApiContext,
+    getApiContextRevision,
+    getApiContextRevision
+  );
   const [toolsByServer, setToolsByServer] = useState<Record<string, Tool[]>>(
-    {},
+    {}
   );
   const [loadingByServer, setLoadingByServer] = useState<
     Record<string, boolean>
   >({});
   const [errorByServer, setErrorByServer] = useState<Record<string, string>>(
-    {},
+    {}
   );
 
   // Stable key so the effect doesn't re-run when the parent passes a fresh
@@ -51,7 +67,7 @@ export function useAggregatedTools(
   // can't appear inside a serverName.
   const serversKey = useMemo(
     () => [...serverNames].sort().join("\x00"),
-    [serverNames],
+    [serverNames]
   );
   const serverNamesRef = useRef<string[]>([]);
   serverNamesRef.current = serversKey ? serversKey.split("\x00") : [];
@@ -74,7 +90,7 @@ export function useAggregatedTools(
     // just-deselected servers disappear immediately rather than lingering
     // until the new fetch returns.
     const activeSet = new Set(names);
-    const pruneToActive = <V,>(prev: Record<string, V>): Record<string, V> => {
+    const pruneToActive = <V>(prev: Record<string, V>): Record<string, V> => {
       const next: Record<string, V> = {};
       for (const key of Object.keys(prev)) {
         if (activeSet.has(key)) next[key] = prev[key];
@@ -99,7 +115,7 @@ export function useAggregatedTools(
             err instanceof Error ? err.message : "Failed to fetch tools";
           return { serverId, tools: [], error: message };
         }
-      }),
+      })
     );
 
     if (token !== fetchTokenRef.current) return;
@@ -121,7 +137,7 @@ export function useAggregatedTools(
       for (const { serverId } of results) next[serverId] = false;
       return next;
     });
-  }, [serversKey]);
+  }, [serversKey, apiContextRevision]);
 
   useEffect(() => {
     void fetchAll();

--- a/mcpjam-inspector/client/src/hooks/use-chat-session.ts
+++ b/mcpjam-inspector/client/src/hooks/use-chat-session.ts
@@ -19,6 +19,7 @@ import {
   useCallback,
   useRef,
   useLayoutEffect,
+  useSyncExternalStore,
 } from "react";
 import { useChat, type UIMessage } from "@ai-sdk/react";
 import {
@@ -108,6 +109,11 @@ import { isHostedRpcLogDataPart } from "@/shared/hosted-rpc-log";
 import { ingestHostedRpcLogsFromResponse } from "@/lib/apis/web/rpc-logs";
 import type { ExecutionConfig } from "@/lib/chat-execution-config";
 import type { HostedRuntimeContext } from "@/lib/hosted-runtime-context";
+import {
+  buildResolvedServerBatchRequest,
+  getApiContextRevision,
+  subscribeApiContext,
+} from "@/lib/apis/web/context";
 
 const GUEST_LOCKED_MODEL_REASON = "Sign in to use MCPJam provided models";
 
@@ -1227,6 +1233,11 @@ export function useChatSession(
     () => selectedServers.join("\u0000"),
     [selectedServers]
   );
+  const apiContextRevision = useSyncExternalStore(
+    subscribeApiContext,
+    getApiContextRevision,
+    getApiContextRevision
+  );
   const liveTraceEnvelopeBase = useMemo(
     () => buildLiveTraceEnvelope(liveTraceState),
     [liveTraceState]
@@ -1472,24 +1483,34 @@ export function useChatSession(
         throw new Error("Hosted chat context is not ready: missing projectId.");
       }
       const isHostedDirectChat = !hostedChatboxId;
-      return {
+      const hostedServerBatch = buildResolvedServerBatchRequest({
         projectId: hostedProjectId,
-        chatSessionId,
-        selectedServerIds: hostedSelectedServerIds,
-        selectedServerNames: selectedServers,
-        accessScope: "chat_v2" as const,
-        ...(isHostedDirectChat ? { directVisibility } : {}),
-        ...(hostedChatboxId ? { chatboxId: hostedChatboxId } : {}),
-        ...(hostedChatboxId && Number.isFinite(hostedAccessVersion)
-          ? { accessVersion: hostedAccessVersion }
-          : {}),
-        ...(hostedChatboxId && hostedChatboxSurface
-          ? { surface: hostedChatboxSurface }
-          : {}),
+        serverIds: hostedSelectedServerIds,
+        serverNames: selectedServers,
+        accessScope: "chat_v2",
         ...(isHostedDirectChat &&
         hostedOAuthTokens &&
         Object.keys(hostedOAuthTokens).length > 0
           ? { oauthTokens: hostedOAuthTokens }
+          : {}),
+        ...(hostedChatboxId ? { chatboxId: hostedChatboxId } : {}),
+        ...(hostedChatboxId && Number.isFinite(hostedAccessVersion)
+          ? { accessVersion: hostedAccessVersion }
+          : {}),
+      });
+      const {
+        serverIds: resolvedServerIds,
+        serverNames: resolvedServerNames,
+        ...hostedServerBatchPins
+      } = hostedServerBatch;
+      return {
+        ...hostedServerBatchPins,
+        selectedServerIds: resolvedServerIds,
+        selectedServerNames: resolvedServerNames,
+        chatSessionId,
+        ...(isHostedDirectChat ? { directVisibility } : {}),
+        ...(hostedChatboxId && hostedChatboxSurface
+          ? { surface: hostedChatboxSurface }
           : {}),
       };
     };
@@ -1707,9 +1728,7 @@ export function useChatSession(
             const viewportHeight =
               window.innerHeight || document.documentElement.clientHeight;
             const fullyInView =
-              rect.top >= 0 &&
-              rect.bottom <= viewportHeight &&
-              rect.height > 0;
+              rect.top >= 0 && rect.bottom <= viewportHeight && rect.height > 0;
             if (!fullyInView) {
               requestAnimationFrame(() => {
                 iframe.scrollIntoView({
@@ -2502,7 +2521,12 @@ export function useChatSession(
     };
 
     fetchToolsMetadata();
-  }, [selectedServersSignature, selectedModel, hostedChatboxId]);
+  }, [
+    selectedServersSignature,
+    selectedModel,
+    hostedChatboxId,
+    apiContextRevision,
+  ]);
 
   // System prompt token count
   useEffect(() => {

--- a/mcpjam-inspector/client/src/hooks/use-server-state.ts
+++ b/mcpjam-inspector/client/src/hooks/use-server-state.ts
@@ -2,11 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, type Dispatch } from "react";
 import { useConvex } from "convex/react";
 import { toast } from "sonner";
 import type { HttpServerConfig, MCPServerConfig } from "@mcpjam/sdk/browser";
-import {
-  isKnownProtocolVersion,
-  isStatelessProtocolVersion,
-} from "@mcpjam/sdk/browser";
-import { useFeatureFlagEnabled } from "posthog-js/react";
+import { isKnownProtocolVersion } from "@mcpjam/sdk/browser";
 import type {
   AppAction,
   AppState,
@@ -439,7 +435,7 @@ function requiresFreshOAuthAuthorization(error: unknown): boolean {
 }
 
 export function shouldRetryOAuthConnectionFailure(
-  errorMessage?: string,
+  errorMessage?: string
 ): boolean {
   if (!errorMessage) {
     return false;
@@ -576,10 +572,6 @@ export function useServerState({
 }: UseServerStateParams) {
   const isUserReady = useDbUserReady();
   const convex = useConvex();
-  // Rollout kill-switch for stateless wire mode. Mirrors the App.tsx gate
-  // on the hosted path so local-mode connects can't bypass it either via
-  // a persisted `mcpProtocolVersion: "DRAFT-2026-v1"` override.
-  const statelessMcpEnabled = useFeatureFlagEnabled("stateless-mcp-enabled");
   const {
     createServerIfMissing: convexCreateServerIfMissing,
     updateServer: convexUpdateServer,
@@ -811,7 +803,7 @@ export function useServerState({
           const resolved = resolveServerConnectionSettings(
             serverBase,
             activeHostConfig.connectionDefaults,
-            perServerOverride,
+            perServerOverride
           );
           mergedHeaders = resolved.headers;
           effectiveTimeout = resolved.timeout;
@@ -972,7 +964,7 @@ export function useServerState({
         // "server speaks a later listed version → connect fails," which
         // defeats the point of letting users pin a multi-version list.
         defaults.supportedProtocolVersions = versions.filter(
-          (v): v is string => typeof v === "string" && v.trim() !== "",
+          (v): v is string => typeof v === "string" && v.trim() !== ""
         );
       }
       // Effective pinned MCP protocol version: per-server override
@@ -999,21 +991,14 @@ export function useServerState({
           : undefined;
       const effective = resolveEffectiveMcpProtocolVersion(
         serverOverride,
-        hostPin,
+        hostPin
       );
-      // Stateless versions are gated behind the rollout flag. A persisted
-      // override from a prior flag-on session must NOT bypass the gate
-      // (the UI controls only gate authoring). Stateful pins like
-      // "2025-11-25" still flow through.
-      if (
-        effective !== undefined &&
-        (statelessMcpEnabled || !isStatelessProtocolVersion(effective))
-      ) {
+      if (effective !== undefined) {
         defaults.mcpProtocolVersion = effective;
       }
       return Object.keys(defaults).length > 0 ? defaults : undefined;
     },
-    [activeHostConfig, statelessMcpEnabled]
+    [activeHostConfig]
   );
 
   const guardedTestConnection = useCallback(
@@ -1036,7 +1021,7 @@ export function useServerState({
           connectionDefaults: buildResolverConnectionDefaults(
             serverConfig,
             activeMcpProfile,
-            resolved.serverId,
+            resolved.serverId
           ),
         });
       }
@@ -1056,7 +1041,7 @@ export function useServerState({
       if (resolved) {
         const configWithDefaults = withProjectConnectionDefaults(
           serverConfig,
-          resolved.serverId,
+          resolved.serverId
         );
         return reconnectServer(resolved.serverId, configWithDefaults, {
           projectId: resolved.projectId,
@@ -1064,7 +1049,7 @@ export function useServerState({
           connectionDefaults: buildResolverConnectionDefaults(
             configWithDefaults,
             activeMcpProfile,
-            resolved.serverId,
+            resolved.serverId
           ),
         });
       }
@@ -1687,19 +1672,8 @@ export function useServerState({
         serverOverride,
         hostPin
       );
-      // Track the EFFECTIVELY-STAMPED pin (after the rollout-flag gate),
-      // not the raw resolved pin. `buildResolverConnectionDefaults`
-      // drops stateless pins when `stateless-mcp-enabled` is off, so a
-      // raw resolved `DRAFT-2026-v1` against a flag-off state actually
-      // stamps `undefined` on the wire. Tracking the raw pin would
-      // miss flag-flip transitions — toggling the flag changes the wire
-      // mode without changing the stored pin, and `previous === resolved`
-      // would skip the re-test even though the transport just changed.
-      const effective: McpProtocolVersion | undefined =
-        resolvedPin !== undefined &&
-        (statelessMcpEnabled || !isStatelessProtocolVersion(resolvedPin))
-          ? resolvedPin
-          : undefined;
+      // Gate removed — stateless-mcp-enabled goes permanent 2026-05-27.
+      const effective: McpProtocolVersion | undefined = resolvedPin;
 
       const seenBefore = lastAppliedProtocolVersionRef.current.has(name);
       const previous = lastAppliedProtocolVersionRef.current.get(name);
@@ -1771,7 +1745,6 @@ export function useServerState({
     appState.servers,
     activeMcpProfile?.mcpProtocolVersion,
     activeHostConfig,
-    statelessMcpEnabled,
     dispatch,
     guardedReconnectServer,
     storeInitInfo,
@@ -1796,7 +1769,7 @@ export function useServerState({
           {
             serverName,
             error: firstResult.error,
-          },
+          }
         );
       } catch (error) {
         const errorMessage =
@@ -2839,8 +2812,7 @@ export function useServerState({
           if (cliConfig) {
             if (
               cliConfig.initialTab &&
-              (!window.location.pathname ||
-                window.location.pathname === "/")
+              (!window.location.pathname || window.location.pathname === "/")
             ) {
               const tab = cliConfig.initialTab.replace(/^[#/]+/, "");
               if (tab) {
@@ -2986,7 +2958,7 @@ export function useServerState({
     (serverName: string) => {
       dispatch({ type: "DISCONNECT", name: serverName });
     },
-    [dispatch],
+    [dispatch]
   );
 
   const cleanupServerLocalArtifacts = useCallback((serverName: string) => {
@@ -3116,10 +3088,7 @@ export function useServerState({
       // can retry against a ready app.
       if (HOSTED_MODE) {
         const projectIdForReconnect = effectiveActiveProjectIdRef.current;
-        if (
-          !projectIdForReconnect ||
-          projectIdForReconnect === "none"
-        ) {
+        if (!projectIdForReconnect || projectIdForReconnect === "none") {
           logger.info("Deferring reconnect: app still bootstrapping", {
             serverName,
           });

--- a/mcpjam-inspector/client/src/lib/__tests__/hosted-web-context.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/hosted-web-context.test.ts
@@ -7,10 +7,13 @@ vi.mock("../config", () => ({
 }));
 
 import {
+  buildResolvedServerBatchRequest,
   buildHostedEvalServerBatchRequest,
   buildServerBatchRequest,
   buildServerRequest,
+  getApiContextRevision,
   setApiContext,
+  subscribeApiContext,
 } from "../apis/web/context";
 
 describe("hosted web context", () => {
@@ -121,13 +124,13 @@ describe("hosted web context", () => {
     });
 
     expect(() => buildServerRequest("myServer")).toThrow(
-      "hosted projectId is not in the API context yet",
+      "hosted projectId is not in the API context yet"
     );
     expect(() => buildServerBatchRequest(["myServer"])).toThrow(
-      "hosted projectId is not in the API context yet",
+      "hosted projectId is not in the API context yet"
     );
     expect(() => buildHostedEvalServerBatchRequest(["myServer"])).toThrow(
-      "hosted projectId is not in the API context yet",
+      "hosted projectId is not in the API context yet"
     );
   });
 
@@ -136,7 +139,7 @@ describe("hosted web context", () => {
       "mcp-tokens-myServer",
       JSON.stringify({
         access_token: "storage-access-token",
-      }),
+      })
     );
 
     setApiContext({
@@ -197,6 +200,91 @@ describe("hosted web context", () => {
     });
   });
 
+  it("forwards MCP profile pins on multi-server hosted requests", () => {
+    setApiContext({
+      projectId: "ws_stateless",
+      serverIdsByName: {
+        Excalidraw: "srv_stateful",
+        stateless: "srv_stateless",
+      },
+      clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
+      supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
+      mcpProtocolVersionsByServerId: {
+        srv_stateful: "2025-11-25",
+        srv_stateless: "DRAFT-2026-v1",
+      },
+      getAccessToken: async () => null,
+    });
+
+    expect(buildServerBatchRequest(["Excalidraw", "stateless"])).toEqual({
+      projectId: "ws_stateless",
+      serverIds: ["srv_stateful", "srv_stateless"],
+      serverNames: ["Excalidraw", "stateless"],
+      clientCapabilities: defaultClientCapabilities,
+      clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
+      supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
+      mcpProtocolVersionsByServerId: {
+        srv_stateful: "2025-11-25",
+        srv_stateless: "DRAFT-2026-v1",
+      },
+    });
+  });
+
+  it("forwards pins for already-resolved chat server ids", () => {
+    setApiContext({
+      projectId: "ws_stateless",
+      serverIdsByName: {
+        Excalidraw: "srv_stateful",
+        stateless: "srv_stateless",
+      },
+      clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
+      supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
+      mcpProtocolVersionsByServerId: {
+        srv_stateful: "2025-11-25",
+        srv_stateless: "DRAFT-2026-v1",
+      },
+      getAccessToken: async () => null,
+    });
+
+    expect(
+      buildResolvedServerBatchRequest({
+        projectId: "ws_stateless",
+        serverIds: ["srv_stateful", "srv_stateless"],
+        serverNames: ["Excalidraw", "stateless"],
+        accessScope: "chat_v2",
+      })
+    ).toEqual({
+      projectId: "ws_stateless",
+      serverIds: ["srv_stateful", "srv_stateless"],
+      serverNames: ["Excalidraw", "stateless"],
+      clientCapabilities: defaultClientCapabilities,
+      clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
+      supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
+      mcpProtocolVersionsByServerId: {
+        srv_stateful: "2025-11-25",
+        srv_stateless: "DRAFT-2026-v1",
+      },
+      accessScope: "chat_v2",
+    });
+  });
+
+  it("notifies subscribers when hosted API context changes", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeApiContext(listener);
+    const before = getApiContextRevision();
+
+    setApiContext({
+      projectId: "ws_notify",
+      serverIdsByName: {},
+      getAccessToken: async () => null,
+    });
+
+    expect(getApiContextRevision()).toBeGreaterThan(before);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+  });
+
   it("blocks hosted project requests while client config sync is pending", () => {
     setApiContext({
       projectId: "ws_pending",
@@ -206,13 +294,13 @@ describe("hosted web context", () => {
     });
 
     expect(() => buildServerRequest("bench")).toThrow(
-      CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE,
+      CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE
     );
     expect(() => buildServerBatchRequest(["bench"])).toThrow(
-      CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE,
+      CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE
     );
     expect(() => buildHostedEvalServerBatchRequest(["bench"])).toThrow(
-      CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE,
+      CLIENT_CONFIG_SYNC_PENDING_ERROR_MESSAGE
     );
   });
 
@@ -228,7 +316,7 @@ describe("hosted web context", () => {
     });
 
     expect(
-      buildHostedEvalServerBatchRequest(["asana", "srv_asana", "github"]),
+      buildHostedEvalServerBatchRequest(["asana", "srv_asana", "github"])
     ).toEqual({
       projectId: "ws_eval",
       serverIds: ["srv_asana", "srv_github"],

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -46,11 +46,31 @@ const EMPTY_CONTEXT: ApiContext = {
 
 let apiContext: ApiContext = EMPTY_CONTEXT;
 let cachedBearerToken: { token: string; expiresAt: number } | null = null;
+let apiContextRevision = 0;
+const apiContextListeners = new Set<() => void>();
 
 const TOKEN_CACHE_TTL_MS = 30_000;
 
 export function resetTokenCache() {
   cachedBearerToken = null;
+}
+
+function notifyApiContextChanged() {
+  apiContextRevision += 1;
+  for (const listener of apiContextListeners) {
+    listener();
+  }
+}
+
+export function subscribeApiContext(listener: () => void): () => void {
+  apiContextListeners.add(listener);
+  return () => {
+    apiContextListeners.delete(listener);
+  };
+}
+
+export function getApiContextRevision(): number {
+  return apiContextRevision;
 }
 
 function assertHostedMode() {
@@ -108,6 +128,7 @@ export function setApiContext(next: ApiContext | null): void {
       }
     : EMPTY_CONTEXT;
   resetTokenCache();
+  notifyApiContextChanged();
 }
 
 /**
@@ -126,7 +147,7 @@ export function setApiContext(next: ApiContext | null): void {
  */
 export function injectHostedServerMapping(
   serverName: string,
-  serverId: string,
+  serverId: string
 ): void {
   apiContext = {
     ...apiContext,
@@ -135,6 +156,7 @@ export function injectHostedServerMapping(
       [serverName]: serverId,
     },
   };
+  notifyApiContextChanged();
 }
 
 export function getHostedProjectId(): string {
@@ -144,7 +166,7 @@ export function getHostedProjectId(): string {
   if (!projectId) {
     throw new BootstrapNotReadyError(
       "provisioning-project",
-      "hosted projectId is not in the API context yet",
+      "hosted projectId is not in the API context yet"
     );
   }
 
@@ -161,15 +183,13 @@ export function getHostedProjectId(): string {
  * resolve to a Convex Id. Callers handle null by using the legacy shape.
  */
 export function tryResolveProjectServer(
-  serverNameOrId: string,
+  serverNameOrId: string
 ): { projectId: string; serverId: string } | null {
   const projectId = apiContext.projectId;
   if (!projectId) return null;
   const direct = apiContext.serverIdsByName[serverNameOrId];
   if (direct) return { projectId, serverId: direct };
-  if (
-    Object.values(apiContext.serverIdsByName).includes(serverNameOrId)
-  ) {
+  if (Object.values(apiContext.serverIdsByName).includes(serverNameOrId)) {
     return { projectId, serverId: serverNameOrId };
   }
   return null;
@@ -179,7 +199,9 @@ export function tryResolveProjectServer(
  * Long alphanumeric refs are usually Convex/legacy document ids. Never echo
  * them in user-visible error strings; short names and slugs may still be shown.
  */
-function shouldIncludeHostedRefInNotFoundError(serverNameOrId: string): boolean {
+function shouldIncludeHostedRefInNotFoundError(
+  serverNameOrId: string
+): boolean {
   const t = serverNameOrId.trim();
   if (t.length < 1) {
     return false;
@@ -200,9 +222,7 @@ export function resolveHostedServerId(serverNameOrId: string): string {
   if (mapped) return mapped;
 
   // Allow direct server IDs for callers that already resolved names.
-  if (
-    Object.values(apiContext.serverIdsByName).includes(serverNameOrId)
-  ) {
+  if (Object.values(apiContext.serverIdsByName).includes(serverNameOrId)) {
     return serverNameOrId;
   }
 
@@ -228,7 +248,7 @@ export function resolveHostedServerIds(serverNamesOrIds: string[]): string[] {
 
 function findHostedServerName(serverId: string): string | undefined {
   return Object.entries(apiContext.serverIdsByName).find(
-    ([, mappedId]) => mappedId === serverId,
+    ([, mappedId]) => mappedId === serverId
   )?.[0];
 }
 
@@ -239,7 +259,7 @@ function findHostedServerName(serverId: string): string | undefined {
  * (for example, the server was removed from the project).
  */
 export function tryGetHostedServerDisplayName(
-  serverNameOrId: string,
+  serverNameOrId: string
 ): string | undefined {
   if (!HOSTED_MODE) {
     return undefined;
@@ -258,7 +278,7 @@ export function tryGetHostedServerDisplayName(
 }
 
 export function normalizeHostedServerNames(
-  serverNamesOrIds: string[],
+  serverNamesOrIds: string[]
 ): string[] {
   assertHostedMode();
 
@@ -278,7 +298,7 @@ export function normalizeHostedServerNames(
     const serverName =
       apiContext.serverIdsByName[trimmed] !== undefined
         ? trimmed
-        : (findHostedServerName(trimmed) ?? trimmed);
+        : findHostedServerName(trimmed) ?? trimmed;
     const dedupeKey = serverName.toLowerCase();
     if (seen.has(dedupeKey)) {
       continue;
@@ -292,7 +312,7 @@ export function normalizeHostedServerNames(
 }
 
 function resolveHostedServerEntries(
-  serverNamesOrIds: string[],
+  serverNamesOrIds: string[]
 ): Array<{ serverId: string; serverName: string }> {
   const seen = new Set<string>();
   const resolved: Array<{ serverId: string; serverName: string }> = [];
@@ -307,7 +327,7 @@ function resolveHostedServerEntries(
       serverName:
         apiContext.serverIdsByName[serverNameOrId] !== undefined
           ? serverNameOrId
-          : (findHostedServerName(serverId) ?? serverNameOrId),
+          : findHostedServerName(serverId) ?? serverNameOrId,
     });
   }
 
@@ -331,7 +351,7 @@ function getHostedAccessScope(): HostedAccessScope | undefined {
 }
 
 export function buildServerRequest(
-  serverNameOrId: string,
+  serverNameOrId: string
 ): Record<string, unknown> {
   // Single hosted path: every request — guest or authed — carries
   // {projectId, serverId}. UI surfaces gate on `useAppReady()` so this
@@ -355,7 +375,7 @@ export function buildServerRequest(
     serverName:
       apiContext.serverIdsByName[serverNameOrId] !== undefined
         ? serverNameOrId
-        : (findHostedServerName(serverId) ?? serverNameOrId),
+        : findHostedServerName(serverId) ?? serverNameOrId,
     ...(oauthToken ? { oauthAccessToken: oauthToken } : {}),
     ...(apiContext.clientCapabilities
       ? { clientCapabilities: apiContext.clientCapabilities }
@@ -372,9 +392,7 @@ export function buildServerRequest(
       : {}),
     ...(accessScope ? { accessScope } : {}),
     ...(chatboxId ? { chatboxId } : {}),
-    ...(chatboxId && Number.isFinite(accessVersion)
-      ? { accessVersion }
-      : {}),
+    ...(chatboxId && Number.isFinite(accessVersion) ? { accessVersion } : {}),
   };
 }
 
@@ -383,6 +401,9 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
   serverIds: string[];
   serverNames: string[];
   clientCapabilities?: Record<string, unknown>;
+  clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
+  supportedProtocolVersions?: string[];
+  mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
   chatboxId?: string;
@@ -394,6 +415,7 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
   const serverIds = serverEntries.map((entry) => entry.serverId);
   const serverNames = serverEntries.map((entry) => entry.serverName);
   const oauthTokens = buildHostedOAuthTokensMap(serverIds);
+  const protocolVersions = buildBatchProtocolVersionMap(serverIds);
   const chatboxId = getHostedChatboxId();
   const accessVersion = getHostedChatboxAccessVersion();
   const accessScope = getHostedAccessScope();
@@ -404,11 +426,80 @@ export function buildServerBatchRequest(serverNamesOrIds: string[]): {
     ...(apiContext.clientCapabilities
       ? { clientCapabilities: apiContext.clientCapabilities }
       : {}),
+    ...(apiContext.clientInfo ? { clientInfo: apiContext.clientInfo } : {}),
+    ...(apiContext.supportedProtocolVersions?.length
+      ? { supportedProtocolVersions: apiContext.supportedProtocolVersions }
+      : {}),
+    ...(protocolVersions
+      ? { mcpProtocolVersionsByServerId: protocolVersions }
+      : {}),
     ...(oauthTokens ? { oauthTokens } : {}),
     ...(accessScope ? { accessScope } : {}),
     ...(chatboxId ? { chatboxId } : {}),
-    ...(chatboxId && Number.isFinite(accessVersion)
-      ? { accessVersion }
+    ...(chatboxId && Number.isFinite(accessVersion) ? { accessVersion } : {}),
+  };
+}
+
+/**
+ * `App.tsx` validates host profile pins and per-server overrides before
+ * populating `apiContext.mcpProtocolVersionsByServerId`, so this helper only
+ * filters the already-resolved map down to the requested server ids.
+ */
+function buildBatchProtocolVersionMap(
+  serverIds: string[]
+): Record<string, McpProtocolVersion> | undefined {
+  const source = apiContext.mcpProtocolVersionsByServerId;
+  if (!source) return undefined;
+  const filtered: Record<string, McpProtocolVersion> = {};
+  for (const id of serverIds) {
+    const pin = source[id];
+    if (pin) filtered[id] = pin;
+  }
+  return Object.keys(filtered).length > 0 ? filtered : undefined;
+}
+
+export function buildResolvedServerBatchRequest(input: {
+  projectId: string;
+  serverIds: string[];
+  serverNames: string[];
+  oauthTokens?: Record<string, string>;
+  accessScope?: HostedAccessScope;
+  chatboxId?: string;
+  accessVersion?: number;
+}): {
+  projectId: string;
+  serverIds: string[];
+  serverNames: string[];
+  clientCapabilities?: Record<string, unknown>;
+  clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
+  supportedProtocolVersions?: string[];
+  mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
+  oauthTokens?: Record<string, string>;
+  accessScope?: HostedAccessScope;
+  chatboxId?: string;
+  accessVersion?: number;
+} {
+  assertClientConfigSynced();
+  const protocolVersions = buildBatchProtocolVersionMap(input.serverIds);
+  return {
+    projectId: input.projectId,
+    serverIds: input.serverIds,
+    serverNames: input.serverNames,
+    ...(apiContext.clientCapabilities
+      ? { clientCapabilities: apiContext.clientCapabilities }
+      : {}),
+    ...(apiContext.clientInfo ? { clientInfo: apiContext.clientInfo } : {}),
+    ...(apiContext.supportedProtocolVersions?.length
+      ? { supportedProtocolVersions: apiContext.supportedProtocolVersions }
+      : {}),
+    ...(protocolVersions
+      ? { mcpProtocolVersionsByServerId: protocolVersions }
+      : {}),
+    ...(input.oauthTokens ? { oauthTokens: input.oauthTokens } : {}),
+    ...(input.accessScope ? { accessScope: input.accessScope } : {}),
+    ...(input.chatboxId ? { chatboxId: input.chatboxId } : {}),
+    ...(input.chatboxId && Number.isFinite(input.accessVersion)
+      ? { accessVersion: input.accessVersion }
       : {}),
   };
 }
@@ -418,6 +509,9 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
   serverIds: string[];
   serverNames: string[];
   clientCapabilities?: Record<string, unknown>;
+  clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
+  supportedProtocolVersions?: string[];
+  mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
   oauthTokens?: Record<string, string>;
   accessScope?: HostedAccessScope;
   chatboxId?: string;
@@ -429,6 +523,7 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
   const serverIds = serverEntries.map((entry) => entry.serverId);
   const serverNames = serverEntries.map((entry) => entry.serverName);
   const oauthTokens = buildHostedOAuthTokensMap(serverIds);
+  const protocolVersions = buildBatchProtocolVersionMap(serverIds);
   const chatboxId = getHostedChatboxId();
   const accessVersion = getHostedChatboxAccessVersion();
   const accessScope = getHostedAccessScope();
@@ -440,17 +535,22 @@ export function buildHostedEvalServerBatchRequest(serverNamesOrIds: string[]): {
     ...(apiContext.clientCapabilities
       ? { clientCapabilities: apiContext.clientCapabilities }
       : {}),
+    ...(apiContext.clientInfo ? { clientInfo: apiContext.clientInfo } : {}),
+    ...(apiContext.supportedProtocolVersions?.length
+      ? { supportedProtocolVersions: apiContext.supportedProtocolVersions }
+      : {}),
+    ...(protocolVersions
+      ? { mcpProtocolVersionsByServerId: protocolVersions }
+      : {}),
     ...(oauthTokens ? { oauthTokens } : {}),
     ...(accessScope ? { accessScope } : {}),
     ...(chatboxId ? { chatboxId } : {}),
-    ...(chatboxId && Number.isFinite(accessVersion)
-      ? { accessVersion }
-      : {}),
+    ...(chatboxId && Number.isFinite(accessVersion) ? { accessVersion } : {}),
   };
 }
 
 export function buildHostedOAuthTokensMap(
-  serverIds: string[],
+  serverIds: string[]
 ): Record<string, string> | undefined {
   const map: Record<string, string> = {};
   for (const id of serverIds) {

--- a/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
+++ b/mcpjam-inspector/server/routes/web/__tests__/chat-v2.hosted.test.ts
@@ -102,6 +102,7 @@ vi.mock("@/shared/types", async () => {
 });
 
 import { createWebTestApp, postJson } from "./helpers/test-app.js";
+import { MCPClientManager } from "@mcpjam/sdk";
 
 describe("web routes — chat-v2 hosted mode", () => {
   const originalFetch = global.fetch;
@@ -300,6 +301,91 @@ describe("web routes — chat-v2 hosted mode", () => {
           serverIds: ["server-1", "server-2"],
         }),
       })
+    );
+  });
+
+  it("forwards MCP profile protocol pins into the hosted chat manager", async () => {
+    const { app, token } = createWebTestApp();
+
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        projectId: "project-1",
+        selectedServerIds: ["server-1"],
+        selectedServerNames: ["Stateless"],
+        clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
+        supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
+        mcpProtocolVersionsByServerId: {
+          "server-1": "DRAFT-2026-v1",
+        },
+        chatSessionId: "chat-session-stateless",
+        messages: [{ role: "user", content: "hello" }],
+        model: {
+          id: "openai/gpt-5-mini",
+          provider: "openai",
+          name: "GPT-5 Mini",
+        },
+      },
+      token
+    );
+
+    expect(response.status).toBe(200);
+    expect(MCPClientManager).toHaveBeenCalledWith(
+      {
+        "server-1": expect.objectContaining({
+          url: "https://server-1.example.com/mcp",
+          clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
+          supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
+          mcpProtocolVersion: "DRAFT-2026-v1",
+        }),
+      },
+      expect.any(Object)
+    );
+  });
+
+  it("normalizes mixed stateless host defaults with stateful per-server overrides", async () => {
+    const { app, token } = createWebTestApp();
+
+    const response = await postJson(
+      app,
+      "/api/web/chat-v2",
+      {
+        projectId: "project-1",
+        selectedServerIds: ["server-stateful", "server-stateless"],
+        selectedServerNames: ["Excalidraw", "stateless"],
+        clientInfo: { name: "mcpjam-inspector", version: "1.0.0" },
+        supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
+        mcpProtocolVersionsByServerId: {
+          "server-stateful": "2025-11-25",
+          "server-stateless": "DRAFT-2026-v1",
+        },
+        chatSessionId: "chat-session-mixed",
+        messages: [{ role: "user", content: "hello" }],
+        model: {
+          id: "openai/gpt-5-mini",
+          provider: "openai",
+          name: "GPT-5 Mini",
+        },
+      },
+      token
+    );
+
+    expect(response.status).toBe(200);
+    expect(MCPClientManager).toHaveBeenCalledWith(
+      {
+        "server-stateful": expect.objectContaining({
+          url: "https://server-stateful.example.com/mcp",
+          supportedProtocolVersions: ["2025-11-25"],
+          mcpProtocolVersion: "2025-11-25",
+        }),
+        "server-stateless": expect.objectContaining({
+          url: "https://server-stateless.example.com/mcp",
+          supportedProtocolVersions: ["DRAFT-2026-v1", "2025-11-25"],
+          mcpProtocolVersion: "DRAFT-2026-v1",
+        }),
+      },
+      expect.any(Object)
     );
   });
 

--- a/mcpjam-inspector/server/routes/web/auth.ts
+++ b/mcpjam-inspector/server/routes/web/auth.ts
@@ -3,6 +3,7 @@ import type { Context } from "hono";
 import {
   MCPClientManager,
   isKnownProtocolVersion,
+  isStatelessProtocolVersion,
   type McpProtocolVersion,
 } from "@mcpjam/sdk";
 import type {
@@ -36,6 +37,30 @@ import { buildHostedOAuthUnauthorizedHandler } from "../../utils/hosted-oauth-re
 // ── Zod Schemas ──────────────────────────────────────────────────────
 
 const clientCapabilitiesSchema = z.record(z.string(), z.unknown());
+const clientInfoBatchSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    version: z.string().min(1).optional(),
+  })
+  .passthrough()
+  .optional();
+const supportedProtocolVersionsBatchSchema = z
+  .array(z.string().min(1))
+  .optional();
+const mcpProtocolVersionEnum = z.enum([
+  "2025-03-26",
+  "2025-06-18",
+  "2025-11-25",
+  "DRAFT-2026-v1",
+]);
+// Per-server `mcpProtocolVersion` map. Map entries are validated against
+// the wire-mode enum so a typo in one server's pin doesn't tank the whole
+// batch — Zod returns the typed enum union, and the route handler can
+// still defensively re-check via `isKnownProtocolVersion` before passing
+// to the SDK factory.
+export const mcpProtocolVersionsByServerIdSchema = z
+  .record(z.string().min(1), mcpProtocolVersionEnum)
+  .optional();
 
 export const projectServerSchema = z.object({
   projectId: z.string().min(1),
@@ -72,14 +97,7 @@ export const projectServerSchema = z.object({
   // backend constant); typo values are rejected at this trust boundary
   // and never reach the SDK's open-routing predicate. Absent means
   // "use SDK default (negotiates at request time)".
-  mcpProtocolVersion: z
-    .enum([
-      "2025-03-26",
-      "2025-06-18",
-      "2025-11-25",
-      "DRAFT-2026-v1",
-    ])
-    .optional(),
+  mcpProtocolVersion: mcpProtocolVersionEnum.optional(),
 });
 
 export const toolsListSchema = projectServerSchema.extend({
@@ -110,6 +128,16 @@ export const promptsListMultiSchema = z.object({
   serverIds: z.array(z.string().min(1)).min(1),
   serverNames: z.array(z.string().min(1)).optional(),
   clientCapabilities: clientCapabilitiesSchema.optional(),
+  // mcpProfile.initialize pins, threaded from the active host profile so
+  // multi-server prompts list connects honor the same protocol pins as
+  // single-server calls. `clientInfo` and `supportedProtocolVersions` are
+  // host-level (uniform per batch). `mcpProtocolVersionsByServerId` is
+  // per-server so different servers in the batch can be on different
+  // wire modes (e.g. one pinned to DRAFT-2026-v1 stateless, others on
+  // legacy 2025-11-25 negotiation).
+  clientInfo: clientInfoBatchSchema,
+  supportedProtocolVersions: supportedProtocolVersionsBatchSchema,
+  mcpProtocolVersionsByServerId: mcpProtocolVersionsByServerIdSchema,
   oauthTokens: z.record(z.string(), z.string()).optional(),
   accessScope: z.enum(["project_member", "chat_v2"]).optional(),
   // See projectServerSchema — chatbox identity is `chatboxId` + `accessVersion`.
@@ -539,6 +567,49 @@ export interface AuthorizedManagerResult {
   authenticatedUserId?: string | null;
 }
 
+function resolveEffectiveInitializePinsForServer(
+  serverId: string,
+  initializePins?: {
+    clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
+    supportedProtocolVersions?: string[];
+    mcpProtocolVersion?: McpProtocolVersion;
+  },
+  mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>
+):
+  | {
+      clientInfo?: { name?: string; version?: string } & Record<
+        string,
+        unknown
+      >;
+      supportedProtocolVersions?: string[];
+      mcpProtocolVersion?: McpProtocolVersion;
+    }
+  | undefined {
+  const perServerPin = mcpProtocolVersionsByServerId?.[serverId];
+  const mcpProtocolVersion =
+    typeof perServerPin === "string" && isKnownProtocolVersion(perServerPin)
+      ? perServerPin
+      : initializePins?.mcpProtocolVersion;
+  const supportedProtocolVersions =
+    mcpProtocolVersion &&
+    !isStatelessProtocolVersion(mcpProtocolVersion) &&
+    initializePins?.supportedProtocolVersions?.includes(mcpProtocolVersion)
+      ? [mcpProtocolVersion]
+      : initializePins?.supportedProtocolVersions;
+
+  const resolved = {
+    ...(initializePins?.clientInfo
+      ? { clientInfo: initializePins.clientInfo }
+      : {}),
+    ...(supportedProtocolVersions && supportedProtocolVersions.length > 0
+      ? { supportedProtocolVersions }
+      : {}),
+    ...(mcpProtocolVersion ? { mcpProtocolVersion } : {}),
+  };
+
+  return Object.keys(resolved).length > 0 ? resolved : undefined;
+}
+
 export async function createAuthorizedManager(
   c: Context,
   bearerToken: string,
@@ -554,11 +625,14 @@ export async function createAuthorizedManager(
     rpcLogger?: RpcLogger;
     serverNames?: string[];
     /**
-     * mcpProfile.initialize.* pins, applied uniformly to every
-     * authorized server in this batch. The same pins flow into every
-     * HttpServerConfig because hosted batches resolve under one
-     * profile context — we don't currently support per-server
-     * mcpProfile overrides.
+     * mcpProfile.initialize.* pins. `clientInfo` and
+     * `supportedProtocolVersions` are host-profile-level — they apply
+     * uniformly to every authorized server in the batch.
+     * `mcpProtocolVersion` is the batch-uniform fallback wire mode;
+     * `mcpProtocolVersionsByServerId` (sibling option below) overrides
+     * it per server. This lets a batch contain one server pinned to
+     * DRAFT-2026-v1 stateless alongside another on legacy
+     * 2025-11-25 negotiation.
      */
     initializePins?: {
       clientInfo?: { name?: string; version?: string } & Record<
@@ -568,6 +642,18 @@ export async function createAuthorizedManager(
       supportedProtocolVersions?: string[];
       mcpProtocolVersion?: McpProtocolVersion;
     };
+    /**
+     * Per-server `mcpProtocolVersion` overrides keyed by serverId.
+     * Values already passed `isKnownProtocolVersion` at the route
+     * boundary (the schema validates each entry against the wire-mode
+     * enum); we re-check here as a defense-in-depth so a future
+     * caller bypassing the schema can't slip a typo to the SDK.
+     *
+     * Resolution: `mcpProtocolVersionsByServerId[serverId]` (if known)
+     * → `initializePins.mcpProtocolVersion` (batch-uniform) →
+     * undefined (SDK chooses at request time).
+     */
+    mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
   }
 ): Promise<AuthorizedManagerResult> {
   const serverNamesById = buildServerNamesById(serverIds, options?.serverNames);
@@ -653,6 +739,12 @@ export async function createAuthorizedManager(
       }
     }
 
+    const effectiveInitializePins = resolveEffectiveInitializePinsForServer(
+      serverId,
+      options?.initializePins,
+      options?.mcpProtocolVersionsByServerId
+    );
+
     return [
       serverId,
       toHttpConfig(
@@ -661,7 +753,7 @@ export async function createAuthorizedManager(
         oauthToken,
         clientCapabilities,
         onUnauthorized,
-        options?.initializePins
+        effectiveInitializePins
       ),
     ] as const;
   });
@@ -748,6 +840,84 @@ function resolveConnectionParams(body: Record<string, unknown>): {
   };
 }
 
+export function extractMcpInitializeOptions(raw: Record<string, unknown>): {
+  initializePins?: {
+    clientInfo?: { name?: string; version?: string } & Record<string, unknown>;
+    supportedProtocolVersions?: string[];
+    mcpProtocolVersion?: McpProtocolVersion;
+  };
+  mcpProtocolVersionsByServerId?: Record<string, McpProtocolVersion>;
+} {
+  // Extract mcpProfile.initialize.* pins so they flow into every
+  // HttpServerConfig created by createAuthorizedManager. Defensive shape
+  // gating: malformed fields silently fall back to SDK defaults rather
+  // than failing the whole route.
+  const rawClientInfo = raw.clientInfo;
+  const initializeClientInfo =
+    rawClientInfo &&
+    typeof rawClientInfo === "object" &&
+    !Array.isArray(rawClientInfo)
+      ? (rawClientInfo as { name?: string; version?: string } & Record<
+          string,
+          unknown
+        >)
+      : undefined;
+  const rawSupportedVersions = raw.supportedProtocolVersions;
+  const initializeSupportedVersions =
+    Array.isArray(rawSupportedVersions) &&
+    rawSupportedVersions.every((v) => typeof v === "string" && v.length > 0)
+      ? (rawSupportedVersions as string[])
+      : undefined;
+  const rawProtocolVersion = raw.mcpProtocolVersion;
+  const initializeWireMode: McpProtocolVersion | undefined =
+    typeof rawProtocolVersion === "string" &&
+    isKnownProtocolVersion(rawProtocolVersion)
+      ? rawProtocolVersion
+      : undefined;
+  const initializePins =
+    initializeClientInfo || initializeSupportedVersions || initializeWireMode
+      ? {
+          ...(initializeClientInfo ? { clientInfo: initializeClientInfo } : {}),
+          ...(initializeSupportedVersions
+            ? { supportedProtocolVersions: initializeSupportedVersions }
+            : {}),
+          ...(initializeWireMode
+            ? { mcpProtocolVersion: initializeWireMode }
+            : {}),
+        }
+      : undefined;
+
+  const rawProtocolVersionsByServerId = raw.mcpProtocolVersionsByServerId;
+  const mcpProtocolVersionsByServerId:
+    | Record<string, McpProtocolVersion>
+    | undefined =
+    rawProtocolVersionsByServerId &&
+    typeof rawProtocolVersionsByServerId === "object" &&
+    !Array.isArray(rawProtocolVersionsByServerId)
+      ? (() => {
+          const filtered: Record<string, McpProtocolVersion> = {};
+          for (const [serverId, value] of Object.entries(
+            rawProtocolVersionsByServerId as Record<string, unknown>
+          )) {
+            if (
+              typeof serverId === "string" &&
+              serverId.length > 0 &&
+              typeof value === "string" &&
+              isKnownProtocolVersion(value)
+            ) {
+              filtered[serverId] = value;
+            }
+          }
+          return Object.keys(filtered).length > 0 ? filtered : undefined;
+        })()
+      : undefined;
+
+  return {
+    ...(initializePins ? { initializePins } : {}),
+    ...(mcpProtocolVersionsByServerId ? { mcpProtocolVersionsByServerId } : {}),
+  };
+}
+
 /**
  * Stateless per-request lifecycle: authorize → connect → execute → disconnect.
  *
@@ -827,59 +997,8 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
       Number.isFinite(raw.accessVersion)
         ? raw.accessVersion
         : undefined;
-
-    // Extract mcpProfile.initialize.* pins so they flow into every
-    // HttpServerConfig created by createAuthorizedManager. The schema
-    // (projectServerSchema or any extension thereof) declares
-    // `clientInfo` / `supportedProtocolVersions` as optional fields —
-    // when present, the client has resolved them from the active
-    // hostConfig and wants the hosted route to honor them on
-    // `initialize`. Defensive shape gating: only forward an object
-    // `clientInfo` and only a non-empty string array for
-    // `supportedProtocolVersions`. A malformed payload silently falls
-    // back to SDK defaults rather than failing the whole route.
-    const rawClientInfo = raw.clientInfo;
-    const initializeClientInfo =
-      rawClientInfo &&
-      typeof rawClientInfo === "object" &&
-      !Array.isArray(rawClientInfo)
-        ? (rawClientInfo as { name?: string; version?: string } & Record<
-            string,
-            unknown
-          >)
-        : undefined;
-    const rawSupportedVersions = raw.supportedProtocolVersions;
-    const initializeSupportedVersions =
-      Array.isArray(rawSupportedVersions) &&
-      rawSupportedVersions.every((v) => typeof v === "string" && v.length > 0)
-        ? (rawSupportedVersions as string[])
-        : undefined;
-    // mcpProtocolVersion — membership-gate via `isKnownProtocolVersion`
-    // so typo values fall back to SDK default rather than reach the
-    // SDK's open-routing predicate. Same defensive pattern as the
-    // other initializePins fields above.
-    const rawProtocolVersion = raw.mcpProtocolVersion;
-    const initializeWireMode: McpProtocolVersion | undefined =
-      typeof rawProtocolVersion === "string" &&
-      isKnownProtocolVersion(rawProtocolVersion)
-        ? rawProtocolVersion
-        : undefined;
-    const initializePins =
-      initializeClientInfo ||
-      initializeSupportedVersions ||
-      initializeWireMode
-        ? {
-            ...(initializeClientInfo
-              ? { clientInfo: initializeClientInfo }
-              : {}),
-            ...(initializeSupportedVersions
-              ? { supportedProtocolVersions: initializeSupportedVersions }
-              : {}),
-            ...(initializeWireMode
-              ? { mcpProtocolVersion: initializeWireMode }
-              : {}),
-          }
-        : undefined;
+    const { initializePins, mcpProtocolVersionsByServerId } =
+      extractMcpInitializeOptions(raw);
 
     const result = await withManager(
       createAuthorizedManager(
@@ -898,6 +1017,7 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
           rpcLogger: rpcCollector?.rpcLogger,
           serverNames,
           initializePins,
+          mcpProtocolVersionsByServerId,
         }
       ),
       (manager) => fn(manager, body as z.infer<S>)
@@ -912,7 +1032,7 @@ export async function withEphemeralConnection<S extends z.ZodTypeAny, T>(
       routeError.code,
       routeError.message,
       routeError.details,
-      rpcCollector?.buildEnvelope()
+      rpcCollector?.buildEnvelope() as Record<string, unknown> | undefined
     );
   }
 }

--- a/mcpjam-inspector/server/routes/web/chat-v2.ts
+++ b/mcpjam-inspector/server/routes/web/chat-v2.ts
@@ -45,6 +45,7 @@ import {
   WebRouteError,
   webError,
   mapRuntimeError,
+  extractMcpInitializeOptions,
 } from "./auth.js";
 import { createHostedRpcLogCollector } from "./hosted-rpc-logs.js";
 import { getClientIp } from "../../utils/client-ip.js";
@@ -75,6 +76,8 @@ chatV2.post("/", async (c) => {
 
     // ── Convex authorization path: guest and signed-in actors ─────
     const hostedBody = parseWithSchema(hostedChatSchema, rawBody);
+    const { initializePins, mcpProtocolVersionsByServerId } =
+      extractMcpInitializeOptions(rawBody);
     const body = rawBody as unknown as ChatV2Request & {
       projectId: string;
       selectedServerIds: string[];
@@ -272,6 +275,8 @@ chatV2.post("/", async (c) => {
         accessVersion,
         rpcLogger: rpcCollector.rpcLogger,
         serverNames: selectedServerNames,
+        initializePins,
+        mcpProtocolVersionsByServerId,
       }
     );
     oauthServerUrls = urls;
@@ -284,11 +289,7 @@ chatV2.post("/", async (c) => {
       validatedAppTools = validateAppToolEntries(body.appTools);
     } catch (error) {
       if (error instanceof AppToolValidationError) {
-        throw new WebRouteError(
-          400,
-          ErrorCode.VALIDATION_ERROR,
-          error.message,
-        );
+        throw new WebRouteError(400, ErrorCode.VALIDATION_ERROR, error.message);
       }
       throw error;
     }


### PR DESCRIPTION
## Summary

- Forward hosted MCP profile pins and per-server protocol overrides through chat/tools batch request bodies.
- Subscribe tools metadata and UI tool fetching to hosted API context changes so late-hydrated overrides trigger refetches.
- Apply per-server MCP protocol versions in hosted ephemeral managers, including mixed stateless/stateful batches.
- Add regression coverage for mixed protocol chat and hosted tools refetch behavior.

## Root Cause

A stateful per-server override could hydrate after the first tools fetch. When the host default was stateless, Excalidraw could be queried with the wrong protocol, fail discovery, and remain absent because the tools hooks did not observe API context changes.

## Validation

- npm test -- server/routes/web/__tests__/authorize-batch.test.ts server/routes/web/__tests__/chat-v2.hosted.test.ts client/src/lib/__tests__/hosted-web-context.test.ts client/src/hooks/__tests__/use-chat-session.hosted.test.tsx client/src/hooks/__tests__/use-aggregated-tools.test.tsx
- npm run typecheck:client
- git diff --check

## Notes

- npx tsc --noEmit -p server/tsconfig.json still fails on existing repo-wide server type errors unrelated to this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hosted MCP connect/stamping and chat/tools request bodies; incorrect pins could break multi-server discovery, but behavior is covered by new tests and mainly affects protocol override timing.
> 
> **Overview**
> Fixes hosted **mixed stateful/stateless** tool discovery when per-server protocol overrides arrive after the first fetch.
> 
> **Control plane:** Hosted API context now prefers **`projectServerConfig` overrides** for per-server `mcpProtocolVersion` (ahead of reactive host snapshots), and treats project server config loading like client-config sync pending so requests wait instead of using stale pins.
> 
> **Client transport:** Removes the **`stateless-mcp-enabled`** rollout gate from hosted stamping and local reconnect logic so **DRAFT-2026-v1** pins always apply. Adds an **API context revision + subscription** so chat tools metadata, aggregated tools, and App Builder **refetch** when hosted context (including protocol maps) updates. Batch builders and chat now attach **`clientInfo`**, **`supportedProtocolVersions`**, and **`mcpProtocolVersionsByServerId`** via **`buildResolvedServerBatchRequest`**.
> 
> **Server:** **`createAuthorizedManager`** resolves **per-server** wire modes (with stateful pins narrowing supported versions), **`extractMcpInitializeOptions`** centralizes pin parsing, and **chat-v2** forwards pins into ephemeral **`MCPClientManager`** configs.
> 
> Regression tests cover mixed-protocol chat, batch request shaping, and tools refetch on context change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95d3c2e954cca028ff2b494d3f070df7a81a06c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->