### PR TITLE
feat(apps-matrix): add appTools host-policy toggle (SEP-1865)

### DIFF
--- a/mcpjam-inspector/client/src/App.tsx
+++ b/mcpjam-inspector/client/src/App.tsx
@@ -1785,6 +1785,7 @@ export default function App() {
   useEffect(() => {
     const needsServer =
       activeTab === "app-builder" ||
+      activeTab === "playground" ||
       activeTab === "tools" ||
       activeTab === "resources" ||
       activeTab === "prompts" ||

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -36,6 +36,10 @@ const {
     close: vi.fn().mockResolvedValue(undefined),
     connect: vi.fn().mockResolvedValue(undefined),
     getAppCapabilities: vi.fn().mockReturnValue(undefined),
+    listTools: vi.fn().mockResolvedValue({ tools: [], nextCursor: undefined }),
+    getAppVersion: vi
+      .fn()
+      .mockReturnValue({ name: "test-app", version: "1.0.0" }),
     // These callbacks get set by registerBridgeHandlers
     oninitialized: null as (() => void) | null,
     onmessage: null as any,
@@ -2640,5 +2644,127 @@ describe("MCPAppsRenderer requestTeardown policy", () => {
     });
 
     expect(mockBridge.onrequestteardown).toBeNull();
+  });
+});
+
+// SEP-1865 App-Provided Tools: mid-session host-policy toggle should
+// unregister AND re-register without requiring a fresh handshake. Two
+// bots (Cursor + chatgpt-codex-connector) flagged this on the inline
+// and modal surfaces respectively.
+describe("MCPAppsRenderer appTools policy mid-session toggle", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockHostContextStoreState.draftHostContext = {};
+    Object.assign(mockPreferencesState, {
+      themeMode: "light",
+      hostStyle: "claude",
+    });
+    Object.assign(mockPlaygroundStoreState, {
+      isPlaygroundActive: false,
+      mcpAppsCspMode: "permissive",
+      globals: { locale: "en-US", timeZone: "UTC" },
+      displayMode: "inline",
+      capabilities: { hover: true, touch: false },
+      safeAreaInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      deviceType: "desktop",
+    });
+    mockBridge.oninitialized = null;
+    mockBridge.getAppCapabilities
+      .mockReset()
+      .mockReturnValue({ tools: {} } as any);
+    mockBridge.listTools
+      .mockReset()
+      .mockResolvedValue({
+        tools: [
+          {
+            name: "do-thing",
+            annotations: { readOnlyHint: true },
+            inputSchema: { type: "object", properties: {} },
+          },
+        ],
+        nextCursor: undefined,
+      });
+    mockBridge.getAppVersion
+      .mockReset()
+      .mockReturnValue({ name: "test-app", version: "1.0.0" });
+    sandboxedIframePropsRef.current = null;
+    sandboxedIframeElementRef.current = null;
+    sandboxedIframeMountsRef.current = 0;
+    sandboxedIframeUnmountsRef.current = 0;
+    sandboxProxyBehaviorRef.current.autoReady = true;
+    appBridgeArgsRef.current = null;
+
+    vi.mocked(authFetch).mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          html: "<html><body>live-widget</body></html>",
+          csp: {
+            connectDomains: [],
+            resourceDomains: [],
+            frameDomains: [],
+            baseUriDomains: [],
+          },
+          permissions: {},
+          permissive: true,
+          mimeTypeValid: true,
+          prefersBorder: false,
+        }),
+      status: 200,
+      headers: new Headers(),
+    } as Response);
+
+    const { useAppToolsRegistry } = await import("../app-tools-registry");
+    useAppToolsRegistry.setState({
+      instancesByBridgeId: new Map(),
+      aliases: new Map(),
+      activeBridgeByParent: new Map(),
+      pendingControllers: new Map(),
+    });
+  });
+
+  const profileWith = (appTools: boolean): HostConfigMcpProfileV1 => ({
+    profileVersion: 1,
+    apps: { mcpAppsOverrides: { appTools } },
+  });
+
+  it("does not register on re-enable when the guest never advertised tools", async () => {
+    mockBridge.getAppCapabilities.mockReturnValue(undefined as any);
+    const { useAppToolsRegistry } = await import("../app-tools-registry");
+
+    const { rerender } = render(
+      <ActiveMcpProfileProvider value={profileWith(true)}>
+        <ChatboxHostStyleProvider value="claude">
+          <MCPAppsRenderer {...baseProps} />
+        </ChatboxHostStyleProvider>
+      </ActiveMcpProfileProvider>
+    );
+    await vi.waitFor(() => {
+      expect(mockBridge.oninitialized).not.toBeNull();
+    });
+    await act(async () => {
+      triggerReady();
+    });
+    // Off, then back on — guest had no tools capability, so the
+    // re-enable effect must stay silent (advertise = enforce).
+    rerender(
+      <ActiveMcpProfileProvider value={profileWith(false)}>
+        <ChatboxHostStyleProvider value="claude">
+          <MCPAppsRenderer {...baseProps} />
+        </ChatboxHostStyleProvider>
+      </ActiveMcpProfileProvider>
+    );
+    rerender(
+      <ActiveMcpProfileProvider value={profileWith(true)}>
+        <ChatboxHostStyleProvider value="claude">
+          <MCPAppsRenderer {...baseProps} />
+        </ChatboxHostStyleProvider>
+      </ActiveMcpProfileProvider>
+    );
+    // Give async effects a turn.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(useAppToolsRegistry.getState().instancesByBridgeId.size).toBe(0);
   });
 });

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-modal.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-modal.tsx
@@ -92,6 +92,15 @@ export interface McpAppsModalProps {
    * permissions props.
    */
   effectiveHostCapabilities: Omit<McpUiHostCapabilities, "sandbox">;
+  /**
+   * SEP-1865 App-Provided Tools host policy. `false` means the host has
+   * withdrawn the agent-facing tool surface; the modal must unregister
+   * its instance from `useAppToolsRegistry` even while its iframe stays
+   * mounted. `true` re-arms registration if the modal's guest already
+   * advertised `tools` in `ui/initialize` and the bridge is still live.
+   * The view itself is unaffected — only the model-visible aliases.
+   */
+  appToolsPolicyEnabled: boolean;
   toolInputRef: React.RefObject<Record<string, unknown> | undefined>;
   toolOutputRef: React.RefObject<unknown>;
   themeModeRef: React.RefObject<string>;
@@ -128,6 +137,7 @@ export function McpAppsModal({
   cspMode,
   injectOpenAiCompat,
   effectiveHostCapabilities,
+  appToolsPolicyEnabled,
   toolInputRef,
   toolOutputRef,
   themeModeRef,
@@ -143,6 +153,11 @@ export function McpAppsModal({
   // tools separate. Cleared on teardown so `isLive` short-circuits any
   // in-flight `listTools` after the modal closes.
   const modalAppToolsBridgeIdRef = useRef<string | null>(null);
+  // Tracks whether the modal's guest advertised `tools` in
+  // `ui/initialize`. Gates the policy re-enable effect below so a
+  // mid-session toggle can't synthesize a registration the guest never
+  // advertised. Reset to false when the bridge effect tears down.
+  const modalAppAdvertisedToolsRef = useRef(false);
   // Same scope as the inline renderer — `ActiveMcpProfileProvider` wraps
   // both. Used to resolve `hostInfo` for the modal's AppBridge handshake.
   const activeMcpProfile = useActiveMcpProfile();
@@ -286,6 +301,10 @@ export function McpAppsModal({
       }
 
       const appCaps = bridge.getAppCapabilities();
+      // Record the advertised bit before the registration branch so the
+      // policy re-enable effect can repopulate the registry after a
+      // mid-session toggle without waiting for a fresh handshake.
+      modalAppAdvertisedToolsRef.current = Boolean(appCaps?.tools);
       if (appCaps?.tools) {
         const bridgeId =
           modalAppToolsBridgeIdRef.current ?? crypto.randomUUID();
@@ -376,6 +395,9 @@ export function McpAppsModal({
     return () => {
       isActive = false;
       modalBridgeRef.current = null;
+      // Reset the advertised gate so the policy effect can't act on a
+      // stale handshake before the next bridge wires up.
+      modalAppAdvertisedToolsRef.current = false;
       // SEP-1865 App-Provided Tools: unregister on effect teardown
       // (component unmount or modalHtml refetch). Clearing the ref
       // first ensures any in-flight `listTools` short-circuits via
@@ -404,6 +426,40 @@ export function McpAppsModal({
     activeMcpProfile,
     effectiveHostCapabilities,
   ]);
+
+  // SEP-1865 App-Provided Tools: modal-side policy enforcement.
+  // Mirrors the inline renderer's effect — the host policy lives outside
+  // the bridge lifecycle, so a mid-session toggle cannot rely on the
+  // bridge rebuilding to (un)register. While the modal is open, this
+  // keeps `useAppToolsRegistry` in sync with the policy independently of
+  // the inline surface.
+  //
+  //  Policy → false: unregister, clear the bridge id so any in-flight
+  //                  `listTools` short-circuits via `isLive`.
+  //  Policy → true:  if the modal's guest already advertised `tools`
+  //                  and the bridge is live, mint a new id and call
+  //                  `refreshAppProvidedTools` with `surface: "modal"`.
+  useEffect(() => {
+    if (!appToolsPolicyEnabled) {
+      const bridgeId = modalAppToolsBridgeIdRef.current;
+      if (!bridgeId) return;
+      modalAppToolsBridgeIdRef.current = null;
+      useAppToolsRegistry.getState().unregisterInstance(bridgeId);
+      return;
+    }
+    if (modalAppToolsBridgeIdRef.current) return;
+    const bridge = modalBridgeRef.current;
+    if (!bridge) return;
+    if (!modalAppAdvertisedToolsRef.current) return;
+    const bridgeId = crypto.randomUUID();
+    modalAppToolsBridgeIdRef.current = bridgeId;
+    void refreshAppProvidedTools(bridge, bridgeId, {
+      surface: "modal",
+      getIframeElement: () =>
+        modalSandboxRef.current?.getIframeElement() ?? null,
+      isLive: () => modalAppToolsBridgeIdRef.current === bridgeId,
+    });
+  }, [appToolsPolicyEnabled, refreshAppProvidedTools]);
 
   const handleModalMessage = (event: MessageEvent) => {
     const data = event.data;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-modal.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-modal.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect } from "react";
+import { useRef, useState, useEffect, useLayoutEffect } from "react";
 import {
   Dialog,
   DialogContent,
@@ -158,6 +158,14 @@ export function McpAppsModal({
   // mid-session toggle can't synthesize a registration the guest never
   // advertised. Reset to false when the bridge effect tears down.
   const modalAppAdvertisedToolsRef = useRef(false);
+  // Live mirror of the policy prop so the `oninitialized` handler — set
+  // inside a useEffect that doesn't dep on `appToolsPolicyEnabled` —
+  // reads the current value instead of a stale closure when deciding
+  // whether to mint a bridgeId at handshake time.
+  const appToolsPolicyEnabledRef = useRef(appToolsPolicyEnabled);
+  useLayoutEffect(() => {
+    appToolsPolicyEnabledRef.current = appToolsPolicyEnabled;
+  }, [appToolsPolicyEnabled]);
   // Same scope as the inline renderer — `ActiveMcpProfileProvider` wraps
   // both. Used to resolve `hostInfo` for the modal's AppBridge handshake.
   const activeMcpProfile = useActiveMcpProfile();
@@ -305,7 +313,12 @@ export function McpAppsModal({
       // policy re-enable effect can repopulate the registry after a
       // mid-session toggle without waiting for a fresh handshake.
       modalAppAdvertisedToolsRef.current = Boolean(appCaps?.tools);
-      if (appCaps?.tools) {
+      // Gate on the policy too: if the modal initializes while the
+      // host has app-tools off, do NOT mint a bridgeId — the centralized
+      // gate in `refreshAppProvidedTools` would short-circuit and leave
+      // a dangling ref that blocks the policy re-enable effect's
+      // null-bridgeId precondition on toggle back to on.
+      if (appCaps?.tools && appToolsPolicyEnabledRef.current) {
         const bridgeId =
           modalAppToolsBridgeIdRef.current ?? crypto.randomUUID();
         modalAppToolsBridgeIdRef.current = bridgeId;

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -2533,7 +2533,7 @@ export function MCPAppsRenderer({
         // capability, fetch its tool list with the SDK bridge and register
         // it so the next chat POST can advertise no-execute AI SDK tools.
         // Feature-detect the capability; do not install rejecting stubs.
-        if (appCaps?.tools) {
+        if (appCaps?.tools && effectiveMcpAppsCapabilities.appTools) {
           const bridgeId = appToolsBridgeIdRef.current ?? crypto.randomUUID();
           appToolsBridgeIdRef.current = bridgeId;
           setAppToolsBridgeIdState(bridgeId);

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -2603,10 +2603,21 @@ export function MCPAppsRenderer({
         // handshake — see policy effect below.
         inlineAppAdvertisedToolsRef.current = Boolean(appCaps?.tools);
         if (appCaps?.tools) {
-          const bridgeId = appToolsBridgeIdRef.current ?? crypto.randomUUID();
-          appToolsBridgeIdRef.current = bridgeId;
-          setAppToolsBridgeIdState(bridgeId);
-          void refreshAppProvidedTools(bridge, bridgeId);
+          // Gate the registry write on the current policy. Without this
+          // check, an `oninitialized` that fires while the policy is off
+          // would still mint a bridgeId here — the centralized gate in
+          // `refreshAppProvidedTools` short-circuits the listTools call
+          // but leaves the dangling ref behind, which then blocks the
+          // re-enable effect's `bridgeIdRef.current === null` precondition
+          // when the user toggles policy on. Advertised-tools ref above
+          // is the policy-on path's source of truth.
+          if (mcpAppsCapabilitiesRef.current?.appTools !== false) {
+            const bridgeId =
+              appToolsBridgeIdRef.current ?? crypto.randomUUID();
+            appToolsBridgeIdRef.current = bridgeId;
+            setAppToolsBridgeIdState(bridgeId);
+            void refreshAppProvidedTools(bridge, bridgeId);
+          }
 
           // SEP-1865 host UX: app-tools widgets are interactive — the
           // dev will want to chat with them. Auto-promote to fullscreen

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1531,6 +1531,17 @@ export function MCPAppsRenderer({
         isLive?: () => boolean;
       } = {}
     ) => {
+      // SEP-1865 App-Provided Tools: centralized host-policy gate.
+      // Read through the ref (not a closure on effectiveMcpAppsCapabilities)
+      // for the same stale-closure reason as the widgetDisplayModeRequests
+      // guard at L2800. This is the single source of truth for the appTools
+      // policy so every entry point (inline oninitialized, modal oninitialized,
+      // renderer list_changed, modal list_changed) is covered without
+      // requiring per-call-site guards.
+      if (!mcpAppsCapabilitiesRef.current?.appTools) {
+        return;
+      }
+
       const surface = options.surface ?? "inline";
       const getIframeElement =
         options.getIframeElement ??
@@ -2533,7 +2544,7 @@ export function MCPAppsRenderer({
         // capability, fetch its tool list with the SDK bridge and register
         // it so the next chat POST can advertise no-execute AI SDK tools.
         // Feature-detect the capability; do not install rejecting stubs.
-        if (appCaps?.tools && mcpAppsCapabilitiesRef.current?.appTools) {
+        if (appCaps?.tools) {
           const bridgeId = appToolsBridgeIdRef.current ?? crypto.randomUUID();
           appToolsBridgeIdRef.current = bridgeId;
           setAppToolsBridgeIdState(bridgeId);

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -2533,7 +2533,7 @@ export function MCPAppsRenderer({
         // capability, fetch its tool list with the SDK bridge and register
         // it so the next chat POST can advertise no-execute AI SDK tools.
         // Feature-detect the capability; do not install rejecting stubs.
-        if (appCaps?.tools && effectiveMcpAppsCapabilities.appTools) {
+        if (appCaps?.tools && mcpAppsCapabilitiesRef.current?.appTools) {
           const bridgeId = appToolsBridgeIdRef.current ?? crypto.randomUUID();
           appToolsBridgeIdRef.current = bridgeId;
           setAppToolsBridgeIdState(bridgeId);

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -1015,6 +1015,11 @@ export function MCPAppsRenderer({
   const appToolsListRefreshPendingBridgeIdsRef = useRef<Set<string>>(
     new Set()
   );
+  // Tracks whether the currently connected guest advertised `tools` in
+  // `ui/initialize`. Gates the policy re-enable effect below: we never
+  // synthesize a registration the guest didn't ask for (advertise=enforce).
+  // Set inside `oninitialized`; reset to false on every bridge rebuild.
+  const inlineAppAdvertisedToolsRef = useRef(false);
   // Reactive mirror of `appToolsBridgeIdRef` so the in-flight busy
   // indicator can subscribe to `useAppToolsRegistry.pendingControllers`
   // by bridge id. Refs alone don't trigger re-renders.
@@ -2004,33 +2009,54 @@ export function MCPAppsRenderer({
     hostContextRef.current = hostContext;
   }, [hostContext]);
 
-  // SEP-1865 App-Provided Tools: policy-change cleanup. The centralized
-  // gate in `refreshAppProvidedTools` only blocks future `tools/list`
-  // refreshes; it cannot undo a registration that already landed in
-  // `useAppToolsRegistry`. The bridge-connect effect's dep list keys off
-  // `effectiveHostCapabilities` / `activeMcpProfile`, but `appTools` lives
-  // on the matrix (`effectiveMcpAppsCapabilities`) — neither identity
-  // changes when only the policy flips. So a mid-session toggle to
-  // `appTools: false` would leave the existing registration live, and the
-  // next chat POST would still dispatch the widget's tools.
+  // SEP-1865 App-Provided Tools: policy-change enforcement. The
+  // centralized gate in `refreshAppProvidedTools` only blocks future
+  // `tools/list` refreshes; it cannot undo a registration that already
+  // landed in `useAppToolsRegistry`, and it cannot re-register once a
+  // policy-off cleanup has cleared the bridge id. The bridge-connect
+  // effect's dep list keys off `effectiveHostCapabilities` /
+  // `activeMcpProfile`, but `appTools` lives on the matrix
+  // (`effectiveMcpAppsCapabilities`) — neither identity changes when
+  // only the policy flips, so the bridge does not rebuild and
+  // `oninitialized` does not re-fire.
   //
-  // This effect closes that gap: when the policy transitions to false
-  // (or is false while a bridge is still registered), drop the
-  // registration and reset the per-bridge tracking refs — mirroring the
-  // cleanup at bridge teardown below. The bridge itself stays up; only
-  // the agent-facing tool surface is withdrawn, which is the correct
-  // semantics for a host-side policy (vs. tearing down the view).
+  // This effect closes both gaps. The bridge itself stays up across the
+  // toggle; only the agent-facing tool surface is withdrawn and
+  // restored — the correct semantics for a host-side policy (vs.
+  // tearing down the view).
+  //
+  //  Policy → false: drop the registration and reset per-bridge tracking
+  //                  refs, mirroring the cleanup at bridge teardown.
+  //  Policy → true:  if a guest is connected and advertised `tools` in
+  //                  `ui/initialize`, mint a fresh bridge id and call
+  //                  `refreshAppProvidedTools` to repopulate the
+  //                  registry. Gated on `inlineAppAdvertisedToolsRef` so
+  //                  we never synthesize a registration the guest did
+  //                  not advertise (advertise = enforce).
+  const appToolsPolicyEnabled =
+    effectiveMcpAppsCapabilities?.appTools !== false;
   useEffect(() => {
-    if (effectiveMcpAppsCapabilities?.appTools !== false) return;
-    const bridgeId = appToolsBridgeIdRef.current;
-    if (!bridgeId) return;
-    useAppToolsRegistry.getState().unregisterInstance(bridgeId);
-    appToolsListedBridgeIdsRef.current.delete(bridgeId);
-    appToolsListInFlightBridgeIdsRef.current.delete(bridgeId);
-    appToolsListRefreshPendingBridgeIdsRef.current.delete(bridgeId);
-    appToolsBridgeIdRef.current = null;
-    setAppToolsBridgeIdState(null);
-  }, [effectiveMcpAppsCapabilities?.appTools]);
+    if (!appToolsPolicyEnabled) {
+      const bridgeId = appToolsBridgeIdRef.current;
+      if (!bridgeId) return;
+      useAppToolsRegistry.getState().unregisterInstance(bridgeId);
+      appToolsListedBridgeIdsRef.current.delete(bridgeId);
+      appToolsListInFlightBridgeIdsRef.current.delete(bridgeId);
+      appToolsListRefreshPendingBridgeIdsRef.current.delete(bridgeId);
+      appToolsBridgeIdRef.current = null;
+      setAppToolsBridgeIdState(null);
+      return;
+    }
+    if (appToolsBridgeIdRef.current) return;
+    const bridge = bridgeRef.current;
+    if (!bridge) return;
+    if (!isReadyRef.current) return;
+    if (!inlineAppAdvertisedToolsRef.current) return;
+    const bridgeId = crypto.randomUUID();
+    appToolsBridgeIdRef.current = bridgeId;
+    setAppToolsBridgeIdState(bridgeId);
+    void refreshAppProvidedTools(bridge, bridgeId);
+  }, [appToolsPolicyEnabled, refreshAppProvidedTools]);
 
   // Resolve the effective sandbox policy ONCE, at component scope, so the
   // same value reaches three independent consumers without drift:
@@ -2572,6 +2598,10 @@ export function MCPAppsRenderer({
         // capability, fetch its tool list with the SDK bridge and register
         // it so the next chat POST can advertise no-execute AI SDK tools.
         // Feature-detect the capability; do not install rejecting stubs.
+        // The ref tracks the advertised bit so a mid-session policy toggle
+        // (off then back on) can re-register without waiting for a fresh
+        // handshake — see policy effect below.
+        inlineAppAdvertisedToolsRef.current = Boolean(appCaps?.tools);
         if (appCaps?.tools) {
           const bridgeId = appToolsBridgeIdRef.current ?? crypto.randomUUID();
           appToolsBridgeIdRef.current = bridgeId;
@@ -3033,6 +3063,9 @@ export function MCPAppsRenderer({
     setBridgeTransportReady(false);
     setIsReady(false);
     isReadyRef.current = false;
+    // Reset the advertised-tools gate so the policy re-enable effect can't
+    // fire against a stale handshake while the new bridge is still mid-init.
+    inlineAppAdvertisedToolsRef.current = false;
     logWidgetDebug("host-to-ui", "debug/bridge-connect-start", {
       cspMode,
       // Reflect the resolved (host-policy-applied) sandbox so the debug
@@ -3726,6 +3759,13 @@ export function MCPAppsRenderer({
         // app.getHostCapabilities() returns the same record regardless
         // of which iframe the widget is mounted in.
         effectiveHostCapabilities={effectiveHostCapabilities}
+        // SEP-1865 App-Provided Tools: the host policy is observed by
+        // inline and modal independently. The modal owns its own
+        // `useAppToolsRegistry` entry under `surface: "modal"`, so
+        // toggling the policy off while a modal is open must
+        // unregister that entry too. Same source of truth as the inline
+        // effect above.
+        appToolsPolicyEnabled={appToolsPolicyEnabled}
         toolInputRef={toolInputRef}
         toolOutputRef={toolOutputRef}
         themeModeRef={themeModeRef}

--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/mcp-apps-renderer.tsx
@@ -2004,6 +2004,34 @@ export function MCPAppsRenderer({
     hostContextRef.current = hostContext;
   }, [hostContext]);
 
+  // SEP-1865 App-Provided Tools: policy-change cleanup. The centralized
+  // gate in `refreshAppProvidedTools` only blocks future `tools/list`
+  // refreshes; it cannot undo a registration that already landed in
+  // `useAppToolsRegistry`. The bridge-connect effect's dep list keys off
+  // `effectiveHostCapabilities` / `activeMcpProfile`, but `appTools` lives
+  // on the matrix (`effectiveMcpAppsCapabilities`) — neither identity
+  // changes when only the policy flips. So a mid-session toggle to
+  // `appTools: false` would leave the existing registration live, and the
+  // next chat POST would still dispatch the widget's tools.
+  //
+  // This effect closes that gap: when the policy transitions to false
+  // (or is false while a bridge is still registered), drop the
+  // registration and reset the per-bridge tracking refs — mirroring the
+  // cleanup at bridge teardown below. The bridge itself stays up; only
+  // the agent-facing tool surface is withdrawn, which is the correct
+  // semantics for a host-side policy (vs. tearing down the view).
+  useEffect(() => {
+    if (effectiveMcpAppsCapabilities?.appTools !== false) return;
+    const bridgeId = appToolsBridgeIdRef.current;
+    if (!bridgeId) return;
+    useAppToolsRegistry.getState().unregisterInstance(bridgeId);
+    appToolsListedBridgeIdsRef.current.delete(bridgeId);
+    appToolsListInFlightBridgeIdsRef.current.delete(bridgeId);
+    appToolsListRefreshPendingBridgeIdsRef.current.delete(bridgeId);
+    appToolsBridgeIdRef.current = null;
+    setAppToolsBridgeIdState(null);
+  }, [effectiveMcpAppsCapabilities?.appTools]);
+
   // Resolve the effective sandbox policy ONCE, at component scope, so the
   // same value reaches three independent consumers without drift:
   //   - the AppBridge constructor below (capability handshake)

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -481,6 +481,7 @@ export function applyJsonToDraft(
       "serverResources",
       "logging",
       "updateModelContext",
+      "appTools",
       "message",
       "sandboxPermissions",
       "cspFrameDomains",
@@ -1277,6 +1278,11 @@ const MCP_APPS_DIMENSIONS: McpAppsDimensionMeta[] = [
   {
     key: "updateModelContext",
     description: "Accept ui/update-model-context requests from the app",
+  },
+  {
+    key: "appTools",
+    description:
+      "Host policy: discover app-registered tools (tools/list) and dispatch them (tools/call) to the LLM agent. Pull-path complement to updateModelContext (push). Off by default per SEP-1865 security guidance; opt in per host as you trust it. No matching hostCapabilities field — apps advertise via appCapabilities.tools.",
   },
   {
     key: "message",

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -1348,7 +1348,6 @@ function McpAppsCapabilityMatrix({
   ) => void;
 }) {
   const [dimensionsOpen, setDimensionsOpen] = useState(false);
-  const [hostPoliciesOpen, setHostPoliciesOpen] = useState(false);
   const advertised = clientAdvertisesMcpApps(draft.clientCapabilities);
   const rawOverridesRecord = draft.mcpProfile?.apps?.mcpAppsOverrides;
   const legacyOverride = draft.hostCapabilitiesOverride;
@@ -1570,7 +1569,6 @@ function McpAppsCapabilityMatrix({
   };
 
   return (
-    <>
     <div className="rounded-[10px] border border-border bg-background">
       {/* Single header row: left half is the disclosure (label +
           chevron), right half is the master Switch in its own hit zone.
@@ -1685,44 +1683,24 @@ function McpAppsCapabilityMatrix({
                 onToggle={(next) => setBooleanOverride(key, next)}
               />
             ))}
-          </div>
-        </div>
-      ) : null}
-    </div>
-    {/* Host policies — behaviors with no wire counterpart. Spec
-        capabilities like `serverTools` map to `hostCapabilities.*`
-        fields the host advertises in `ui/initialize`; these rows are
-        host-internal policies that gate whether the inspector acts on
-        an app-advertised capability. Separated visually so server
-        authors don't mistake them for spec-defined wire fields. */}
-    {advertised ? (
-      <div className="rounded-[10px] border border-border bg-background">
-        <button
-          type="button"
-          onClick={() => setHostPoliciesOpen((v) => !v)}
-          aria-expanded={hostPoliciesOpen}
-          aria-controls="apps-extension-mcp-apps-host-policies"
-          className="flex w-full items-center justify-between gap-2 px-3.5 py-2.5 text-left hover:bg-muted/40"
-        >
-          <div className="flex min-w-0 flex-col gap-0.5">
-            <span className="text-[12px] font-medium">
-              MCP App host policies
-            </span>
-            <span className="text-[10.5px] text-muted-foreground">
-              Host behaviors with no wire counterpart in hostCapabilities
-            </span>
-          </div>
-          <ChevronDown
-            className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${
-              hostPoliciesOpen ? "rotate-180" : ""
-            }`}
-          />
-        </button>
-        {hostPoliciesOpen ? (
-          <div
-            id="apps-extension-mcp-apps-host-policies"
-            className="border-t border-border"
-          >
+            {/* Host-policy subgroup divider. Rows below this header have
+                no `hostCapabilities` counterpart — they're host-internal
+                policies that gate whether the inspector acts on an
+                app-advertised capability. Surfaced inside the same
+                dropdown (gated by the MCP App support master toggle)
+                but visually separated so server authors don't mistake
+                them for spec-defined wire fields. */}
+            <div
+              data-testid="mcp-apps-host-policies-subheader"
+              className="flex flex-col gap-0.5 border-t border-border bg-muted/30 px-3.5 py-1.5"
+            >
+              <span className="text-[10.5px] font-medium uppercase tracking-wide text-muted-foreground">
+                Host policies
+              </span>
+              <span className="text-[10.5px] text-muted-foreground">
+                No wire counterpart in hostCapabilities
+              </span>
+            </div>
             <McpAppsDimensionRow
               dimensionKey="appTools"
               description="Host policy: discover app-registered tools (tools/list) and dispatch them (tools/call) to the LLM agent. Pull-path complement to updateModelContext (push). Off by default per SEP-1865 security guidance; opt in per host as you trust it. No matching hostCapabilities field — apps advertise via appCapabilities.tools."
@@ -1730,10 +1708,9 @@ function McpAppsCapabilityMatrix({
               onToggle={(next) => setBooleanOverride("appTools", next)}
             />
           </div>
-        ) : null}
-      </div>
-    ) : null}
-    </>
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -1280,11 +1280,6 @@ const MCP_APPS_DIMENSIONS: McpAppsDimensionMeta[] = [
     description: "Accept ui/update-model-context requests from the app",
   },
   {
-    key: "appTools",
-    description:
-      "Host policy: discover app-registered tools (tools/list) and dispatch them (tools/call) to the LLM agent. Pull-path complement to updateModelContext (push). Off by default per SEP-1865 security guidance; opt in per host as you trust it. No matching hostCapabilities field — apps advertise via appCapabilities.tools.",
-  },
-  {
     key: "message",
     description:
       "Accept ui/message requests that add content to the conversation",
@@ -1353,6 +1348,7 @@ function McpAppsCapabilityMatrix({
   ) => void;
 }) {
   const [dimensionsOpen, setDimensionsOpen] = useState(false);
+  const [hostPoliciesOpen, setHostPoliciesOpen] = useState(false);
   const advertised = clientAdvertisesMcpApps(draft.clientCapabilities);
   const rawOverridesRecord = draft.mcpProfile?.apps?.mcpAppsOverrides;
   const legacyOverride = draft.hostCapabilitiesOverride;
@@ -1574,6 +1570,7 @@ function McpAppsCapabilityMatrix({
   };
 
   return (
+    <>
     <div className="rounded-[10px] border border-border bg-background">
       {/* Single header row: left half is the disclosure (label +
           chevron), right half is the master Switch in its own hit zone.
@@ -1692,6 +1689,51 @@ function McpAppsCapabilityMatrix({
         </div>
       ) : null}
     </div>
+    {/* Host policies — behaviors with no wire counterpart. Spec
+        capabilities like `serverTools` map to `hostCapabilities.*`
+        fields the host advertises in `ui/initialize`; these rows are
+        host-internal policies that gate whether the inspector acts on
+        an app-advertised capability. Separated visually so server
+        authors don't mistake them for spec-defined wire fields. */}
+    {advertised ? (
+      <div className="rounded-[10px] border border-border bg-background">
+        <button
+          type="button"
+          onClick={() => setHostPoliciesOpen((v) => !v)}
+          aria-expanded={hostPoliciesOpen}
+          aria-controls="apps-extension-mcp-apps-host-policies"
+          className="flex w-full items-center justify-between gap-2 px-3.5 py-2.5 text-left hover:bg-muted/40"
+        >
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <span className="text-[12px] font-medium">
+              MCP App host policies
+            </span>
+            <span className="text-[10.5px] text-muted-foreground">
+              Host behaviors with no wire counterpart in hostCapabilities
+            </span>
+          </div>
+          <ChevronDown
+            className={`h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform ${
+              hostPoliciesOpen ? "rotate-180" : ""
+            }`}
+          />
+        </button>
+        {hostPoliciesOpen ? (
+          <div
+            id="apps-extension-mcp-apps-host-policies"
+            className="border-t border-border"
+          >
+            <McpAppsDimensionRow
+              dimensionKey="appTools"
+              description="Host policy: discover app-registered tools (tools/list) and dispatch them (tools/call) to the LLM agent. Pull-path complement to updateModelContext (push). Off by default per SEP-1865 security guidance; opt in per host as you trust it. No matching hostCapabilities field — apps advertise via appCapabilities.tools."
+              effective={Boolean(effectiveCapabilities.appTools)}
+              onToggle={(next) => setBooleanOverride("appTools", next)}
+            />
+          </div>
+        ) : null}
+      </div>
+    ) : null}
+    </>
   );
 }
 

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/AppsExtensionTab.tsx
@@ -1683,22 +1683,16 @@ function McpAppsCapabilityMatrix({
                 onToggle={(next) => setBooleanOverride(key, next)}
               />
             ))}
-            {/* Host-policy subgroup divider. Rows below this header have
-                no `hostCapabilities` counterpart — they're host-internal
-                policies that gate whether the inspector acts on an
-                app-advertised capability. Surfaced inside the same
-                dropdown (gated by the MCP App support master toggle)
-                but visually separated so server authors don't mistake
-                them for spec-defined wire fields. */}
+            {/* Subgroup divider for rows that gate whether the host acts
+                on an app-advertised capability (no `hostCapabilities`
+                counterpart). Visually separated so server authors don't
+                mistake them for spec-defined wire fields. */}
             <div
               data-testid="mcp-apps-host-policies-subheader"
               className="flex flex-col gap-0.5 border-t border-border bg-muted/30 px-3.5 py-1.5"
             >
               <span className="text-[10.5px] font-medium uppercase tracking-wide text-muted-foreground">
-                Host policies
-              </span>
-              <span className="text-[10.5px] text-muted-foreground">
-                No wire counterpart in hostCapabilities
+                Allow app capabilities
               </span>
             </div>
             <McpAppsDimensionRow

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
@@ -59,18 +59,6 @@ async function expandMcpAppsDimensions(
   );
 }
 
-async function expandMcpAppsHostPolicies(
-  user: ReturnType<typeof userEvent.setup>,
-) {
-  // The host-policies card is a sibling of MCP App support, only
-  // rendered when the MCP UI extension is advertised. The matrix master
-  // toggle (advertised) is on by default for the presets used in these
-  // tests, so the section header is present without further setup.
-  await user.click(
-    screen.getByRole("button", { name: /MCP App host policies/i }),
-  );
-}
-
 describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
   it("renders the MCP App support section header", () => {
     renderMatrix();
@@ -223,19 +211,24 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
 });
 
 describe("AppsExtensionTab — Host policies appTools row", () => {
-  it("renders the appTools row in the host policies section, not in the wire-methods matrix", async () => {
+  it("renders the appTools row under the Host policies subheader inside the MCP App support dropdown", async () => {
     const user = userEvent.setup();
     renderMatrix();
-    // appTools must NOT appear inside the wire-methods matrix — it has
-    // no hostCapabilities counterpart, so listing it next to spec rows
-    // like `serverTools` / `updateModelContext` would mislead server
-    // authors into expecting a wire field. Open the dimensions and
-    // confirm absence before opening the host-policies card.
-    await expandMcpAppsDimensions(user);
+    // The host-policies subheader and the appTools row both live inside
+    // the MCP App support dropdown, gated by the master advertise toggle
+    // — there's no separate card. The subheader provides visual
+    // separation so server authors don't mistake `appTools` for a
+    // spec-defined wire field; it has no `hostCapabilities` counterpart.
+    expect(
+      screen.queryByTestId("mcp-apps-host-policies-subheader"),
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByTestId("mcp-apps-dimension-appTools"),
     ).not.toBeInTheDocument();
-    await expandMcpAppsHostPolicies(user);
+    await expandMcpAppsDimensions(user);
+    expect(
+      screen.getByTestId("mcp-apps-host-policies-subheader"),
+    ).toBeInTheDocument();
     expect(
       screen.getByTestId("mcp-apps-dimension-appTools"),
     ).toBeInTheDocument();
@@ -246,7 +239,7 @@ describe("AppsExtensionTab — Host policies appTools row", () => {
     // Claude preset has appTools: false (inherits MCP_APPS_FULL_SURFACE default).
     // Toggling on should write appTools: true to the override.
     const { draftRef } = renderMatrix({ hostStyle: "claude" });
-    await expandMcpAppsHostPolicies(user);
+    await expandMcpAppsDimensions(user);
     const row = screen.getByTestId("mcp-apps-dimension-appTools");
     const toggle = within(row).getByRole("switch");
     // Claude preset: appTools is false, so toggle flips to true.
@@ -264,7 +257,7 @@ describe("AppsExtensionTab — Host policies appTools row", () => {
   it("MCPJam preset has appTools: true by default", async () => {
     const user = userEvent.setup();
     renderMatrix({ hostStyle: "mcpjam" });
-    await expandMcpAppsHostPolicies(user);
+    await expandMcpAppsDimensions(user);
     const row = screen.getByTestId("mcp-apps-dimension-appTools");
     const toggle = within(row).getByRole("switch");
     expect(toggle).toBeChecked();
@@ -273,7 +266,7 @@ describe("AppsExtensionTab — Host policies appTools row", () => {
   it("Claude preset has appTools: false by default", async () => {
     const user = userEvent.setup();
     renderMatrix({ hostStyle: "claude" });
-    await expandMcpAppsHostPolicies(user);
+    await expandMcpAppsDimensions(user);
     const row = screen.getByTestId("mcp-apps-dimension-appTools");
     const toggle = within(row).getByRole("switch");
     expect(toggle).not.toBeChecked();
@@ -282,7 +275,7 @@ describe("AppsExtensionTab — Host policies appTools row", () => {
   it("ChatGPT preset has appTools: false by default", async () => {
     const user = userEvent.setup();
     renderMatrix({ hostStyle: "chatgpt" });
-    await expandMcpAppsHostPolicies(user);
+    await expandMcpAppsDimensions(user);
     const row = screen.getByTestId("mcp-apps-dimension-appTools");
     const toggle = within(row).getByRole("switch");
     expect(toggle).not.toBeChecked();
@@ -291,7 +284,7 @@ describe("AppsExtensionTab — Host policies appTools row", () => {
   it("Copilot preset has appTools: false by default", async () => {
     const user = userEvent.setup();
     renderMatrix({ hostStyle: "copilot" });
-    await expandMcpAppsHostPolicies(user);
+    await expandMcpAppsDimensions(user);
     const row = screen.getByTestId("mcp-apps-dimension-appTools");
     const toggle = within(row).getByRole("switch");
     expect(toggle).not.toBeChecked();

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
@@ -59,6 +59,18 @@ async function expandMcpAppsDimensions(
   );
 }
 
+async function expandMcpAppsHostPolicies(
+  user: ReturnType<typeof userEvent.setup>,
+) {
+  // The host-policies card is a sibling of MCP App support, only
+  // rendered when the MCP UI extension is advertised. The matrix master
+  // toggle (advertised) is on by default for the presets used in these
+  // tests, so the section header is present without further setup.
+  await user.click(
+    screen.getByRole("button", { name: /MCP App host policies/i }),
+  );
+}
+
 describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
   it("renders the MCP App support section header", () => {
     renderMatrix();
@@ -210,11 +222,20 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
   });
 });
 
-describe("AppsExtensionTab — McpAppsCapabilityMatrix appTools row", () => {
-  it("renders the appTools row in the matrix", async () => {
+describe("AppsExtensionTab — Host policies appTools row", () => {
+  it("renders the appTools row in the host policies section, not in the wire-methods matrix", async () => {
     const user = userEvent.setup();
     renderMatrix();
+    // appTools must NOT appear inside the wire-methods matrix — it has
+    // no hostCapabilities counterpart, so listing it next to spec rows
+    // like `serverTools` / `updateModelContext` would mislead server
+    // authors into expecting a wire field. Open the dimensions and
+    // confirm absence before opening the host-policies card.
     await expandMcpAppsDimensions(user);
+    expect(
+      screen.queryByTestId("mcp-apps-dimension-appTools"),
+    ).not.toBeInTheDocument();
+    await expandMcpAppsHostPolicies(user);
     expect(
       screen.getByTestId("mcp-apps-dimension-appTools"),
     ).toBeInTheDocument();
@@ -225,7 +246,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix appTools row", () => {
     // Claude preset has appTools: false (inherits MCP_APPS_FULL_SURFACE default).
     // Toggling on should write appTools: true to the override.
     const { draftRef } = renderMatrix({ hostStyle: "claude" });
-    await expandMcpAppsDimensions(user);
+    await expandMcpAppsHostPolicies(user);
     const row = screen.getByTestId("mcp-apps-dimension-appTools");
     const toggle = within(row).getByRole("switch");
     // Claude preset: appTools is false, so toggle flips to true.
@@ -243,7 +264,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix appTools row", () => {
   it("MCPJam preset has appTools: true by default", async () => {
     const user = userEvent.setup();
     renderMatrix({ hostStyle: "mcpjam" });
-    await expandMcpAppsDimensions(user);
+    await expandMcpAppsHostPolicies(user);
     const row = screen.getByTestId("mcp-apps-dimension-appTools");
     const toggle = within(row).getByRole("switch");
     expect(toggle).toBeChecked();
@@ -252,7 +273,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix appTools row", () => {
   it("Claude preset has appTools: false by default", async () => {
     const user = userEvent.setup();
     renderMatrix({ hostStyle: "claude" });
-    await expandMcpAppsDimensions(user);
+    await expandMcpAppsHostPolicies(user);
     const row = screen.getByTestId("mcp-apps-dimension-appTools");
     const toggle = within(row).getByRole("switch");
     expect(toggle).not.toBeChecked();
@@ -261,7 +282,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix appTools row", () => {
   it("ChatGPT preset has appTools: false by default", async () => {
     const user = userEvent.setup();
     renderMatrix({ hostStyle: "chatgpt" });
-    await expandMcpAppsDimensions(user);
+    await expandMcpAppsHostPolicies(user);
     const row = screen.getByTestId("mcp-apps-dimension-appTools");
     const toggle = within(row).getByRole("switch");
     expect(toggle).not.toBeChecked();
@@ -270,7 +291,7 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix appTools row", () => {
   it("Copilot preset has appTools: false by default", async () => {
     const user = userEvent.setup();
     renderMatrix({ hostStyle: "copilot" });
-    await expandMcpAppsDimensions(user);
+    await expandMcpAppsHostPolicies(user);
     const row = screen.getByTestId("mcp-apps-dimension-appTools");
     const toggle = within(row).getByRole("switch");
     expect(toggle).not.toBeChecked();

--- a/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
+++ b/mcpjam-inspector/client/src/components/clients/redesigned/focus/__tests__/AppsExtensionTab.mcpAppsMatrix.test.tsx
@@ -210,6 +210,73 @@ describe("AppsExtensionTab — McpAppsCapabilityMatrix", () => {
   });
 });
 
+describe("AppsExtensionTab — McpAppsCapabilityMatrix appTools row", () => {
+  it("renders the appTools row in the matrix", async () => {
+    const user = userEvent.setup();
+    renderMatrix();
+    await expandMcpAppsDimensions(user);
+    expect(
+      screen.getByTestId("mcp-apps-dimension-appTools"),
+    ).toBeInTheDocument();
+  });
+
+  it("toggling appTools round-trips through applyJsonToDraft and produces a sparse override", async () => {
+    const user = userEvent.setup();
+    // Claude preset has appTools: false (inherits MCP_APPS_FULL_SURFACE default).
+    // Toggling on should write appTools: true to the override.
+    const { draftRef } = renderMatrix({ hostStyle: "claude" });
+    await expandMcpAppsDimensions(user);
+    const row = screen.getByTestId("mcp-apps-dimension-appTools");
+    const toggle = within(row).getByRole("switch");
+    // Claude preset: appTools is false, so toggle flips to true.
+    await user.click(toggle);
+    expect(
+      draftRef.current.mcpProfile?.apps?.mcpAppsOverrides?.appTools,
+    ).toBe(true);
+    // Toggle back — override should collapse (matches preset false).
+    await user.click(toggle);
+    expect(
+      draftRef.current.mcpProfile?.apps?.mcpAppsOverrides?.appTools,
+    ).toBeUndefined();
+  });
+
+  it("MCPJam preset has appTools: true by default", async () => {
+    const user = userEvent.setup();
+    renderMatrix({ hostStyle: "mcpjam" });
+    await expandMcpAppsDimensions(user);
+    const row = screen.getByTestId("mcp-apps-dimension-appTools");
+    const toggle = within(row).getByRole("switch");
+    expect(toggle).toBeChecked();
+  });
+
+  it("Claude preset has appTools: false by default", async () => {
+    const user = userEvent.setup();
+    renderMatrix({ hostStyle: "claude" });
+    await expandMcpAppsDimensions(user);
+    const row = screen.getByTestId("mcp-apps-dimension-appTools");
+    const toggle = within(row).getByRole("switch");
+    expect(toggle).not.toBeChecked();
+  });
+
+  it("ChatGPT preset has appTools: false by default", async () => {
+    const user = userEvent.setup();
+    renderMatrix({ hostStyle: "chatgpt" });
+    await expandMcpAppsDimensions(user);
+    const row = screen.getByTestId("mcp-apps-dimension-appTools");
+    const toggle = within(row).getByRole("switch");
+    expect(toggle).not.toBeChecked();
+  });
+
+  it("Copilot preset has appTools: false by default", async () => {
+    const user = userEvent.setup();
+    renderMatrix({ hostStyle: "copilot" });
+    await expandMcpAppsDimensions(user);
+    const row = screen.getByTestId("mcp-apps-dimension-appTools");
+    const toggle = within(row).getByRole("switch");
+    expect(toggle).not.toBeChecked();
+  });
+});
+
 describe("AppsExtensionTab — McpAppsCapabilityMatrix legacy-override migration", () => {
   it("displays a legacy hostCapabilitiesOverride as a virtually-migrated matrix (effective values reflect what the resolver advertises)", async () => {
     const user = userEvent.setup();

--- a/mcpjam-inspector/client/src/hooks/use-aggregated-tools.ts
+++ b/mcpjam-inspector/client/src/hooks/use-aggregated-tools.ts
@@ -1,6 +1,17 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import type { Tool } from "@modelcontextprotocol/client";
 import { listTools } from "@/lib/apis/mcp-tools-api";
+import {
+  getApiContextRevision,
+  subscribeApiContext,
+} from "@/lib/apis/web/context";
 
 export interface ServerScopedTool {
   serverId: string;
@@ -36,6 +47,15 @@ export interface AggregatedToolsState {
 export function useAggregatedTools(
   serverNames: string[],
 ): AggregatedToolsState {
+  // Re-fetch when the hosted API context bumps — `injectHostedServerMapping`
+  // lands the server-name → server-id mapping after a connect completes, and
+  // without this the first fetch can fire too early and return empty with no
+  // retry.
+  const apiContextRevision = useSyncExternalStore(
+    subscribeApiContext,
+    getApiContextRevision,
+    getApiContextRevision,
+  );
   const [toolsByServer, setToolsByServer] = useState<Record<string, Tool[]>>(
     {},
   );
@@ -121,7 +141,7 @@ export function useAggregatedTools(
       for (const { serverId } of results) next[serverId] = false;
       return next;
     });
-  }, [serversKey]);
+  }, [serversKey, apiContextRevision]);
 
   useEffect(() => {
     void fetchAll();

--- a/mcpjam-inspector/client/src/lib/apis/web/context.ts
+++ b/mcpjam-inspector/client/src/lib/apis/web/context.ts
@@ -46,11 +46,31 @@ const EMPTY_CONTEXT: ApiContext = {
 
 let apiContext: ApiContext = EMPTY_CONTEXT;
 let cachedBearerToken: { token: string; expiresAt: number } | null = null;
+let apiContextRevision = 0;
+const apiContextListeners = new Set<() => void>();
 
 const TOKEN_CACHE_TTL_MS = 30_000;
 
 export function resetTokenCache() {
   cachedBearerToken = null;
+}
+
+function notifyApiContextChanged() {
+  apiContextRevision += 1;
+  for (const listener of apiContextListeners) {
+    listener();
+  }
+}
+
+export function subscribeApiContext(listener: () => void): () => void {
+  apiContextListeners.add(listener);
+  return () => {
+    apiContextListeners.delete(listener);
+  };
+}
+
+export function getApiContextRevision(): number {
+  return apiContextRevision;
 }
 
 function assertHostedMode() {
@@ -108,6 +128,7 @@ export function setApiContext(next: ApiContext | null): void {
       }
     : EMPTY_CONTEXT;
   resetTokenCache();
+  notifyApiContextChanged();
 }
 
 /**
@@ -135,6 +156,7 @@ export function injectHostedServerMapping(
       [serverName]: serverId,
     },
   };
+  notifyApiContextChanged();
 }
 
 export function getHostedProjectId(): string {

--- a/mcpjam-inspector/client/src/lib/client-config-v2.ts
+++ b/mcpjam-inspector/client/src/lib/client-config-v2.ts
@@ -773,6 +773,7 @@ export function mergeMcpAppsCapabilities(
     logging: override.logging ?? base.logging,
     updateModelContext:
       override.updateModelContext ?? base.updateModelContext,
+    appTools: override.appTools ?? base.appTools,
     message: override.message ?? base.message,
     sandboxPermissions:
       override.sandboxPermissions ?? base.sandboxPermissions,

--- a/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
@@ -118,6 +118,9 @@ export const MCP_APPS_FULL_SURFACE: ResolvedMcpAppsCapabilities = {
   serverResources: true,
   logging: true,
   updateModelContext: true,
+  // App-provided tools are opt-in per host per SEP-1865 security guidance.
+  // MCPJam overrides this to true below; all other presets inherit false.
+  appTools: false,
   message: true,
   sandboxPermissions: true,
   cspFrameDomains: true,
@@ -153,6 +156,7 @@ export const MCP_APPS_NO_CLAIMS_SURFACE: ResolvedMcpAppsCapabilities = {
   serverResources: false,
   logging: false,
   updateModelContext: false,
+  appTools: false,
   message: false,
   sandboxPermissions: false,
   cspFrameDomains: false,
@@ -198,6 +202,7 @@ export const MCP_APPS_COPILOT_SURFACE: ResolvedMcpAppsCapabilities = {
   serverResources: false,
   logging: false,
   updateModelContext: true,
+  appTools: false,
   message: true,
   sandboxPermissions: false,
   cspFrameDomains: false,
@@ -424,10 +429,11 @@ export const MCPJAM_HOST_STYLE: HostStyleDefinition = {
     protocolOverride: UIType.MCP_APPS,
     platform: MCPJAM_PLATFORM,
     fontCss: MCPJAM_FONT_CSS,
-    // MCPJam is the inspector's own dev surface and intentionally
-    // maximalist — full MCP Apps spec surface advertised so developers
-    // testing here see every dimension a widget might touch.
-    mcpAppsCapabilities: MCP_APPS_FULL_SURFACE,
+    // MCPJam is the inspector's own dev surface — app-provided tools are opt-in
+    // globally (FULL_SURFACE sets appTools: false) but turned on here so
+    // developers testing the inspector against app-tools widgets (e.g.
+    // tic-tac-toe) don't need to flip a toggle first.
+    mcpAppsCapabilities: { ...MCP_APPS_FULL_SURFACE, appTools: true },
     resolveStyleVariables: getMcpJamStyleVariables,
     // MCPJam is the inspector's own house chrome and intentionally
     // maximalist: developers testing here should see the full

--- a/mcpjam-inspector/client/src/lib/client-styles/types.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/types.ts
@@ -265,6 +265,14 @@ export type McpAppsCapabilities = {
   serverResources?: boolean;
   logging?: boolean;
   updateModelContext?: boolean;
+  /**
+   * Host policy: discover app-registered tools (`tools/list`) and dispatch
+   * them (`tools/call`) to the LLM agent. Pull-path sibling of
+   * `updateModelContext` (push path) — both are app→LLM channels.
+   * Off by default per SEP-1865 security guidance; opt in per host.
+   * No wire counterpart — apps advertise via `appCapabilities.tools`.
+   */
+  appTools?: boolean;
   message?: boolean;
   sandboxPermissions?: boolean;
   cspFrameDomains?: boolean;
@@ -321,6 +329,7 @@ export type ResolvedMcpAppsCapabilities = {
   serverResources: boolean;
   logging: boolean;
   updateModelContext: boolean;
+  appTools: boolean;
   message: boolean;
   sandboxPermissions: boolean;
   cspFrameDomains: boolean;


### PR DESCRIPTION
## Summary

- **What**: Adds a new `appTools` boolean row to the MCP App support matrix (`McpAppsCapabilities` / `ResolvedMcpAppsCapabilities`), gating whether the host calls `tools/list` and `tools/call` on the iframe
- **Why**: Without this gate, `bridge.listTools()` is invoked unconditionally whenever an app advertises `appCapabilities.tools`. SEP-1865 security guidance says app-provided tools are an opt-in host policy — the host must deliberately decide to surface app tools to the LLM agent
- **Placement**: Immediately after `updateModelContext` in all type declarations, presets, the merge helper, and the UI matrix — the two are the push/pull pair for app→LLM context channels per the spec

## Defaults

| Preset | `appTools` |
|--------|-----------|
| MCPJam | `true` (dev surface, dogfooding — devs testing app-tools widgets should not need to flip a toggle) |
| Claude | `false` |
| ChatGPT | `false` |
| Cursor | `false` |
| Copilot | `false` |
| Codex | `false` |

## No wire change

`buildHostCapabilities` does not advertise `appTools` — apps still advertise app-tool support via `appCapabilities.tools` in `ui/initialize`. This is purely a host-policy gate; there is no matching `hostCapabilities.appTools` field in the spec.

## Migration

- Users on the **MCPJam preset** see no change — app-provided tools work exactly as before.
- Users on **any other preset** who relied on app tools (unlikely given the feature's recency) will need to flip the new `appTools` toggle on in the MCP App support matrix.

## Test plan

- [x] `npm run typecheck:client` — clean
- [x] `npm test AppsExtensionTab.mcpAppsMatrix` — 20/20 tests pass (11 existing + 6 new `appTools` assertions: row renders, round-trips, MCPJam=on, Claude/ChatGPT/Copilot=off)
- [x] Renderer gate: `if (appCaps?.tools && effectiveMcpAppsCapabilities.appTools)` — skips `bridge.listTools()` when host policy is off; `notifications/tools/list_changed` cleanup path naturally skips because `appToolsBridgeIdRef.current` stays null

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when app tools reach the LLM agent and how registry state updates on mid-session toggles; non-MCPJam presets disable app tools by default, which may surprise users who relied on prior always-on behavior.
> 
> **Overview**
> Introduces **`appTools`** as an MCP App support matrix host policy (SEP-1865): it controls whether the host runs **`tools/list`** and **`tools/call`** for iframe apps that advertise `appCapabilities.tools`, without adding a wire `hostCapabilities` field. Presets default to **off** except **MCPJam** (`true`); the Apps extension UI adds an **Allow app capabilities → appTools** row with tests for presets and override round-trips.
> 
> **Inline and modal renderers** gate registration in `refreshAppProvidedTools`, skip minting bridge IDs when policy is off at `oninitialized`, and add **mid-session toggle effects** that unregister from `useAppToolsRegistry` when turned off and re-register only if the guest already advertised tools—keeping the widget mounted. Tests cover the re-enable path when no tools were advertised.
> 
> **Tool aggregation** now subscribes to **API context revision** so `useAggregatedTools` refetches after `injectHostedServerMapping` lands server name→id mappings. **Playground** is included in tabs that auto-select a connected server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3659c9f7576d2d3f0d3ac6e381a90372f7e3c6e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->