### PR TITLE
fix(sdk): filter SEP-1865 app-only tools in getToolsForAiSdk by default

### DIFF
--- a/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
+++ b/mcpjam-inspector/server/utils/__tests__/chat-v2-orchestration.test.ts
@@ -269,6 +269,9 @@ describe("prepareChatV2", () => {
       "both_tool",
       "model_tool",
     ]);
+    expect(manager.getToolsForAiSdk).toHaveBeenCalledWith(["srv"], {
+      includeAppOnly: true,
+    });
   });
 
   it("filters selectedServers down to ids the manager has registered", async () => {

--- a/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
+++ b/mcpjam-inspector/server/utils/chat-v2-orchestration.ts
@@ -541,17 +541,27 @@ export async function prepareChatV2(
     mcpClientManager.hasServer(id)
   );
 
+  const toolOptions =
+    requireToolApproval || respectToolVisibility === false
+      ? {
+          ...(requireToolApproval
+            ? { needsApproval: requireToolApproval }
+            : {}),
+          ...(respectToolVisibility === false ? { includeAppOnly: true } : {}),
+        }
+      : undefined;
+
   // 1. Get MCP + skill tools
   const mcpTools = await mcpClientManager.getToolsForAiSdk(
     knownSelectedServers,
-    requireToolApproval ? { needsApproval: requireToolApproval } : undefined
+    toolOptions
   );
 
   // SEP-1865: tools whose `_meta.ui.visibility` is exactly `["app"]` are
   // hidden from the model — they remain callable from the iframe via the
-  // bridge but must not appear in the AI SDK tool set. The conversion
-  // helper doesn't lift `_meta` onto the AiSdkTool, so we look the
-  // metadata back up per (serverId, toolName) from the manager's cache.
+  // bridge but must not appear in the AI SDK tool set. When the host
+  // explicitly opts out, include them in the SDK conversion above so this
+  // gate remains the single policy switch.
   //
   // Gated by the host policy `respectToolVisibility`. `undefined` and
   // `true` both filter (spec default); only an explicit `false` opts

--- a/sdk/src/TestAgent.ts
+++ b/sdk/src/TestAgent.ts
@@ -28,7 +28,10 @@ import type {
   EvalWidgetSnapshotInput,
   MCPServerReplayConfig,
 } from "./eval-reporting-types.js";
-import { ensureJsonSchemaObject } from "./mcp-client-manager/tool-converters.js";
+import {
+  ensureJsonSchemaObject,
+  isAppOnlyTool,
+} from "./mcp-client-manager/tool-converters.js";
 import { assertCallToolResult } from "./mcp-client-manager/result-guards.js";
 import { buildMcpAppWidgetSnapshot } from "./widget-snapshots.js";
 import { injectOpenAICompat } from "./widget-helpers.js";
@@ -88,10 +91,7 @@ function convertToToolSet(tools: Tool[]): ToolSet {
   const toolSet: ToolSet = {};
   for (const tool of tools) {
     // Filter out app-only tools (visibility: ["app"]) per SEP-1865
-    const visibility = (tool._meta?.ui as any)?.visibility as
-      | Array<"model" | "app">
-      | undefined;
-    if (visibility && visibility.length === 1 && visibility[0] === "app") {
+    if (isAppOnlyTool(tool._meta as Record<string, unknown> | undefined)) {
       continue;
     }
 

--- a/sdk/src/mcp-client-manager/MCPClientManager.ts
+++ b/sdk/src/mcp-client-manager/MCPClientManager.ts
@@ -634,6 +634,13 @@ export class MCPClientManager {
     options: {
       schemas?: ToolSchemaOverrides | "automatic";
       needsApproval?: boolean;
+      /**
+       * When true, include SEP-1865 app-only tools (`_meta.ui.visibility = ["app"]`)
+       * in the returned tool set. Defaults to `false` (spec-compliant: app-only
+       * tools are hidden from the model). Use this only when intentionally
+       * mirroring a host that does not implement visibility filtering.
+       */
+      includeAppOnly?: boolean;
     } = {}
   ): Promise<AiSdkTool> {
     const ids = Array.isArray(serverIds)
@@ -650,6 +657,7 @@ export class MCPClientManager {
           const tools = await convertMCPToolsToVercelTools(listToolsResult, {
             schemas: options.schemas,
             needsApproval: options.needsApproval,
+            includeAppOnly: options.includeAppOnly,
             callTool: async ({ name, args, options: callOptions }) => {
               const requestOptions = callOptions?.abortSignal
                 ? { signal: callOptions.abortSignal }

--- a/sdk/src/mcp-client-manager/tool-converters.ts
+++ b/sdk/src/mcp-client-manager/tool-converters.ts
@@ -103,6 +103,14 @@ export interface ConvertOptions<
   callTool: CallToolExecutor;
   /** When true, each tool requires user approval before execution */
   needsApproval?: boolean;
+  /**
+   * When true, include tools whose `_meta.ui.visibility` is `["app"]`
+   * (SEP-1865 app-only tools) in the returned tool set. Defaults to `false`,
+   * which is the spec-compliant behavior: app-only tools are hidden from the
+   * model-facing tool set. Set to `true` only when intentionally mirroring a
+   * host that does not implement SEP-1865 visibility filtering.
+   */
+  includeAppOnly?: boolean;
 }
 
 /**
@@ -132,6 +140,26 @@ export function isChatGPTAppTool(
 ): boolean {
   if (!toolMeta) return false;
   return typeof toolMeta["openai/outputTemplate"] === "string";
+}
+
+/**
+ * Checks whether a tool is app-only per SEP-1865 (`_meta.ui.visibility = ["app"]`).
+ *
+ * Per SEP-1865, tools whose visibility does not include `"model"` MUST NOT be
+ * included in the agent's tool list. They remain callable from the iframe/app
+ * via `tools/call`, but the model never sees them.
+ *
+ * @param toolMeta - The tool's `_meta` field from listTools result
+ * @returns true if the tool is app-only (must be hidden from the model)
+ */
+export function isAppOnlyTool(
+  toolMeta: Record<string, unknown> | undefined
+): boolean {
+  if (!toolMeta) return false;
+  const visibility = (toolMeta as { ui?: { visibility?: unknown } }).ui
+    ?.visibility;
+  if (!Array.isArray(visibility)) return false;
+  return visibility.length === 1 && visibility[0] === "app";
 }
 
 /**
@@ -210,6 +238,7 @@ export async function convertMCPToolsToVercelTools(
     schemas = "automatic",
     callTool,
     needsApproval,
+    includeAppOnly = false,
   }: ConvertOptions<ToolSchemaOverrides | "automatic">
 ): Promise<ToolSet> {
   const tools: ToolSet = {};
@@ -219,6 +248,12 @@ export async function convertMCPToolsToVercelTools(
     const toolMeta = toolDescription._meta as
       | Record<string, unknown>
       | undefined;
+
+    // SEP-1865: hosts that negotiate `io.modelcontextprotocol/ui` MUST NOT
+    // include tools whose visibility omits `"model"` in the agent's tool list.
+    if (!includeAppOnly && isAppOnlyTool(toolMeta)) {
+      continue;
+    }
 
     // Create the execute function that delegates to the provided callTool
     const execute = async (args: unknown, options?: ToolCallOptions) => {

--- a/sdk/tests/tool-converters.test.ts
+++ b/sdk/tests/tool-converters.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import type { ListToolsResult } from "@modelcontextprotocol/client";
+import {
+  convertMCPToolsToVercelTools,
+  isAppOnlyTool,
+} from "../src/mcp-client-manager/tool-converters.js";
+
+const callTool = async () => ({ content: [{ type: "text", text: "ok" }] });
+
+const listToolsFixture: ListToolsResult = {
+  tools: [
+    {
+      name: "app_only",
+      description: "Should not be model-facing (SEP-1865 visibility=['app'])",
+      inputSchema: { type: "object", properties: {} },
+      _meta: { ui: { visibility: ["app"] } },
+    },
+    {
+      name: "model_only",
+      description: "Explicitly model-only",
+      inputSchema: { type: "object", properties: {} },
+      _meta: { ui: { visibility: ["model"] } },
+    },
+    {
+      name: "model_and_app",
+      description: "Visible to both",
+      inputSchema: { type: "object", properties: {} },
+      _meta: { ui: { visibility: ["model", "app"] } },
+    },
+    {
+      name: "default_visibility",
+      description: "No visibility field — spec default is ['model','app']",
+      inputSchema: { type: "object", properties: {} },
+    },
+  ],
+} as unknown as ListToolsResult;
+
+describe("isAppOnlyTool", () => {
+  it("identifies visibility=['app'] as app-only", () => {
+    expect(isAppOnlyTool({ ui: { visibility: ["app"] } })).toBe(true);
+  });
+
+  it("does not treat ['model','app'] as app-only", () => {
+    expect(isAppOnlyTool({ ui: { visibility: ["model", "app"] } })).toBe(false);
+  });
+
+  it("does not treat ['model'] as app-only", () => {
+    expect(isAppOnlyTool({ ui: { visibility: ["model"] } })).toBe(false);
+  });
+
+  it("treats omitted visibility as not app-only (spec default ['model','app'])", () => {
+    expect(isAppOnlyTool(undefined)).toBe(false);
+    expect(isAppOnlyTool({})).toBe(false);
+    expect(isAppOnlyTool({ ui: {} })).toBe(false);
+  });
+
+  it("ignores non-array visibility values", () => {
+    expect(isAppOnlyTool({ ui: { visibility: "app" } })).toBe(false);
+  });
+});
+
+describe("convertMCPToolsToVercelTools — SEP-1865 visibility filtering", () => {
+  it("excludes visibility=['app'] tools from the model-facing tool set by default", async () => {
+    const tools = await convertMCPToolsToVercelTools(listToolsFixture, {
+      callTool,
+    });
+
+    expect(tools.app_only).toBeUndefined();
+    expect(tools.model_only).toBeDefined();
+    expect(tools.model_and_app).toBeDefined();
+    expect(tools.default_visibility).toBeDefined();
+  });
+
+  it("included tools have an executable `execute` function", async () => {
+    const tools = await convertMCPToolsToVercelTools(listToolsFixture, {
+      callTool,
+    });
+
+    expect(typeof (tools.model_only as { execute?: unknown }).execute).toBe(
+      "function"
+    );
+  });
+
+  it("includes app-only tools when includeAppOnly is true (Cursor-template parity)", async () => {
+    const tools = await convertMCPToolsToVercelTools(listToolsFixture, {
+      callTool,
+      includeAppOnly: true,
+    });
+
+    expect(tools.app_only).toBeDefined();
+    expect(tools.model_only).toBeDefined();
+    expect(tools.model_and_app).toBeDefined();
+    expect(tools.default_visibility).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Per SEP-1865, hosts that negotiate `io.modelcontextprotocol/ui` MUST NOT include tools whose `_meta.ui.visibility` omits `"model"` (e.g. `visibility: ["app"]`) in the agent's tool list. `@mcpjam/sdk`'s `getToolsForAiSdk()` was advertising the extension but handing every tool — including `["app"]`-only ones — to the model. `TestAgent` already filtered correctly; the public converter did not.

- Extracts `isAppOnlyTool(meta)` into `tool-converters.ts` and reuses it in `TestAgent` so the two paths can't drift.
- `convertMCPToolsToVercelTools` skips app-only tools by default.
- New `includeAppOnly?: boolean` opt-out on `ConvertOptions` and `MCPClientManager.getToolsForAiSdk`, off by default. Hosts that intentionally mirror a SEP-1865-non-conformant host (e.g. real Cursor today, which doesn't filter on `visibility`) can pass `includeAppOnly: true` to recover the previous behavior. This preserves mcpjam-inspector's Cursor-template parity path established in #2268.
- Regression tests cover `["app"]`, `["model"]`, `["model","app"]`, omitted visibility, malformed visibility, and the opt-out.

## Impact

- mcpjam-inspector: no behavior change. Chat path already filters post-hoc via `filterAppOnlyTools` (#2268).
- Third-party SDK consumers and `create-mcp-eval`-generated eval files: were exposing `["app"]` tools to the model; now spec-compliant by default.
- TestAgent: predicate is unchanged in behavior — refactor to a single source of truth.

## Test plan

- [x] `npx vitest run tests/tool-converters.test.ts` — 8/8 pass (new file)
- [x] `npx vitest run` (full sdk suite) — 926/926 pass, no regressions
- [x] Prettier check on changed files — clean (pre-existing repo-wide prettier debt is out of scope)
- [ ] Bump `@mcpjam/sdk` to 1.8.1 and republish on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default tool exposure for SDK consumers of `getToolsForAiSdk()` (fewer tools reach the model), which is intentional but can break evals or integrations that relied on app-only tools being visible unless they pass `includeAppOnly: true`.
> 
> **Overview**
> **`getToolsForAiSdk()` / `convertMCPToolsToVercelTools`** now hide SEP-1865 app-only tools (`_meta.ui.visibility = ["app"]`) from the model-facing tool set by default, matching spec behavior that `TestAgent` already had via inline filtering.
> 
> A shared **`isAppOnlyTool()`** helper in `tool-converters.ts` centralizes the visibility check; **`TestAgent`** uses it instead of duplicating the predicate so eval and public SDK paths stay aligned.
> 
> **`includeAppOnly?: boolean`** (default `false`) on conversion options and **`MCPClientManager.getToolsForAiSdk()`** restores the old “expose every tool to the model” behavior for hosts that do not filter visibility (e.g. Cursor-template parity).
> 
> New **`tool-converters.test.ts`** covers `isAppOnlyTool`, default filtering, and the opt-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02a84a63c86c47f1ed3cda4868d664eff7298f0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->