### PR TITLE
Remove Playground announcement popover

### DIFF
--- a/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
+++ b/mcpjam-inspector/client/src/components/mcp-sidebar.tsx
@@ -212,12 +212,6 @@ const navigationSections: NavSection[] = [
         url: "/playground",
         icon: MessageCircle,
         featureFlag: "playground-tab-enabled",
-        announcement: {
-          id: "playground-tab-rename-2026-05",
-          badge: "NEW",
-          title: "Playground just got more powerful",
-          body: "Playground now includes everything from App Builder — generate, preview, and test MCP-powered apps without switching tabs.",
-        },
       },
     ],
   },


### PR DESCRIPTION
## Summary
- Drop the one-time \"Playground just got more powerful\" announcement attached to the Playground sidebar item in [mcp-sidebar.tsx](mcpjam-inspector/client/src/components/mcp-sidebar.tsx). The popover has served its purpose and shouldn't keep showing up for new users.

## Test plan
- [ ] Reset the dismissal localStorage key (`mcpjam:announcement-dismissed:playground-tab-rename-2026-05`) and confirm no announcement popover appears next to Playground in the sidebar.
- [ ] Verify the Playground sidebar item still navigates correctly with the `playground-tab-enabled` flag on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar-only config removal with no routing, auth, or data changes.
> 
> **Overview**
> Removes the one-time **Playground** sidebar announcement (`playground-tab-rename-2026-05`) that showed a **NEW** badge and popover about App Builder capabilities being merged into Playground.
> 
> The Playground nav entry is unchanged aside from dropping the `announcement` config; routing and the `playground-tab-enabled` flag behavior stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f25b32a24ef172fd17b8fa802542152ea4bb50e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->