### PR TITLE
Fix JSON editor click-to-edit misalignment in wrap mode

### DIFF
--- a/mcpjam-inspector/client/src/components/ui/json-editor/json-editor-edit.tsx
+++ b/mcpjam-inspector/client/src/components/ui/json-editor/json-editor-edit.tsx
@@ -638,7 +638,13 @@ export function JsonEditorEdit({
                 "pointer-events-none m-0",
                 "text-muted-foreground", // Base color for unhighlighted text during typing
               )}
-              style={fontStyle}
+              // scrollbar-gutter: stable reserves the same width on both the
+              // textarea (which scrolls) and this overlay (which doesn't), so
+              // the textarea's wrap column always matches the overlay's. Without
+              // this, when the textarea's vertical scrollbar appears it eats
+              // ~15px of width and the two wrap at different character counts,
+              // making clicked lines and rendered lines drift apart.
+              style={{ ...fontStyle, scrollbarGutter: "stable" }}
               aria-hidden="true"
             >
               <div
@@ -689,7 +695,7 @@ export function JsonEditorEdit({
                   ? "overflow-auto whitespace-pre-wrap break-words"
                   : "overflow-auto whitespace-pre",
               )}
-              style={{ ...fontStyle, tabSize: 2 }}
+              style={{ ...fontStyle, tabSize: 2, scrollbarGutter: "stable" }}
             />
           </>
         )}


### PR DESCRIPTION
- In the JSON editor, when line wrapping is on (used in the View Editor), clicking a line would put your cursor on a different line — your typing landed in the wrong place.
- Cause: the editor stacks two layers — an invisible textarea you type into, and the colored syntax-highlighted view on top. The textarea was a few pixels narrower because of its scrollbar, so it wrapped long lines in different spots than the colored view, and the two drifted out of sync after each wrapped line.
- Fix: reserve the same scrollbar space on both layers (`scrollbar-gutter: stable`) so they always wrap at the same column and the line you click is the line you edit.
- Only file changed: `client/src/components/ui/json-editor/json-editor-edit.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)