### PR TITLE
Fix: Copilot widgets open inline by default, not forced fullscreen

### DIFF
--- a/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
+++ b/mcpjam-inspector/client/src/components/chat-v2/thread/mcp-apps/__tests__/mcp-apps-renderer.test.tsx
@@ -986,12 +986,12 @@ describe("MCPAppsRenderer tool input streaming", () => {
     expect(hostContext).not.toHaveProperty("toolInfo");
   });
 
-  it("advertises matrix-clamped HostContext.availableDisplayModes (Copilot: ['fullscreen'] only)", async () => {
-    // Copilot's published Component-bridge table says
-    // requestDisplayMode is fullscreen-only. The matrix's
-    // availableDisplayModes is ["fullscreen"]; the host must
-    // advertise exactly that, not the inspector's permissive
-    // default of all three.
+  it("advertises matrix-clamped HostContext.availableDisplayModes (Copilot: inline + fullscreen, no pip)", async () => {
+    // Copilot's published Component-bridge table says requestDisplayMode
+    // is supported "fullscreen only" — fullscreen is the only expansion a
+    // widget may request, not that inline is unavailable. Copilot renders
+    // widgets inline by default, so the host advertises
+    // ["inline", "fullscreen"] (dropping the inspector's permissive pip).
     render(
       <ChatboxHostStyleProvider value="copilot">
         <MCPAppsRenderer {...baseProps} />
@@ -1003,7 +1003,10 @@ describe("MCPAppsRenderer tool input streaming", () => {
     const hostContext = appBridgeArgsRef.current?.options?.hostContext as
       | Record<string, unknown>
       | undefined;
-    expect(hostContext?.availableDisplayModes).toEqual(["fullscreen"]);
+    expect(hostContext?.availableDisplayModes).toEqual([
+      "inline",
+      "fullscreen",
+    ]);
   });
 
   it("advertises all three modes on Claude (full surface matrix)", async () => {
@@ -1025,16 +1028,17 @@ describe("MCPAppsRenderer tool input streaming", () => {
     ]);
   });
 
-  it("clamps HostContext.displayMode to the matrix allowlist (Copilot in pip parent state coerces to fullscreen)", async () => {
+  it("clamps HostContext.displayMode to the matrix allowlist (Copilot in pip parent state coerces to inline)", async () => {
     // Regression: previously the matrix-clamped allowlist was only
     // written into `HostContext.availableDisplayModes`, but
     // `effectiveDisplayMode` was still computed against the
     // playground/configured allowlist alone. A Copilot host could
     // initialize or remain in `pip` if the parent's display state
-    // was sticky `"pip"` from a previous widget, while advertising
-    // `availableDisplayModes: ["fullscreen"]` — an inconsistent
-    // HostContext. Fix clamps the displayMode against the matrix
-    // too.
+    // was sticky `"pip"` from a previous widget, while advertising a
+    // narrower allowlist — an inconsistent HostContext. Fix clamps the
+    // displayMode against the matrix too. Copilot's matrix is
+    // ["inline", "fullscreen"], so an unsupported pip coerces to the
+    // first allowed mode (inline), not fullscreen.
     render(
       <ChatboxHostStyleProvider value="copilot">
         <MCPAppsRenderer
@@ -1050,9 +1054,12 @@ describe("MCPAppsRenderer tool input streaming", () => {
     const hostContext = appBridgeArgsRef.current?.options?.hostContext as
       | Record<string, unknown>
       | undefined;
-    // Matrix-clamped: only fullscreen is allowed, so pip coerces.
-    expect(hostContext?.availableDisplayModes).toEqual(["fullscreen"]);
-    expect(hostContext?.displayMode).toBe("fullscreen");
+    // Matrix-clamped: pip isn't allowed, so it coerces to inline (matrix[0]).
+    expect(hostContext?.availableDisplayModes).toEqual([
+      "inline",
+      "fullscreen",
+    ]);
+    expect(hostContext?.displayMode).toBe("inline");
   });
 
   it("keeps HostContext.displayMode inside the advertised intersection for custom display-mode overrides", async () => {

--- a/mcpjam-inspector/client/src/lib/__tests__/client-config-v2.test.ts
+++ b/mcpjam-inspector/client/src/lib/__tests__/client-config-v2.test.ts
@@ -361,9 +361,9 @@ describe("resolveEffectiveMcpAppsCapabilities", () => {
       hostStyle: "copilot",
       profile: undefined,
     });
-    // Copilot preset: fullscreen-only, no serverResources / logging,
-    // no notification gates.
-    expect(resolved.availableDisplayModes).toEqual(["fullscreen"]);
+    // Copilot preset: inline default + requestable fullscreen (no pip),
+    // no serverResources / logging, no notification gates.
+    expect(resolved.availableDisplayModes).toEqual(["inline", "fullscreen"]);
     expect(resolved.serverResources).toBe(false);
     expect(resolved.logging).toBe(false);
     expect(resolved.toolInputPartial).toBe(false);

--- a/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
+++ b/mcpjam-inspector/client/src/lib/client-styles/built-ins.ts
@@ -171,9 +171,16 @@ export const MCP_APPS_NO_CLAIMS_SURFACE: ResolvedMcpAppsCapabilities = {
  * https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/plugin-mcp-apps
  *
  * Diffs from FULL:
- *   - `availableDisplayModes` clamped to `["fullscreen"]` (only fullscreen
- *     is honored; the docs say `requestDisplayMode` is supported as
- *     "fullscreen only").
+ *   - `availableDisplayModes` is `["inline", "fullscreen"]` (no `pip`).
+ *     Copilot renders widgets INLINE by default and supports fullscreen as
+ *     a mode the widget can request. The docs phrase
+ *     `requestDisplayMode` as supported "fullscreen only" — that means
+ *     fullscreen is the only expansion a widget may request, NOT that
+ *     inline is unavailable (the docs show an inline widget screenshot and
+ *     a user-clicked "Enter Fullscreen" button). Advertising
+ *     `["fullscreen"]` alone made the clamp coerce the initial mode to
+ *     fullscreen and trap the widget there (the close button could never
+ *     return to inline).
  *   - `toolInputPartial`, `toolCancelled`, `hostContextChanged`,
  *     `resourceTeardown` off — these `ui/notifications/*` are not
  *     delivered by Copilot.
@@ -188,7 +195,7 @@ export const MCP_APPS_NO_CLAIMS_SURFACE: ResolvedMcpAppsCapabilities = {
  * Note: `updateModelContext` and `message` stay on (Copilot honors both).
  */
 export const MCP_APPS_COPILOT_SURFACE: ResolvedMcpAppsCapabilities = {
-  availableDisplayModes: ["fullscreen"],
+  availableDisplayModes: ["inline", "fullscreen"],
   toolInputPartial: false,
   toolCancelled: false,
   hostContextChanged: false,


### PR DESCRIPTION
- Copilot widgets were auto-opening in fullscreen and the X (close) button did nothing — you could never get back to the inline view.
- Cause: our Copilot client matrix said Copilot only supports fullscreen, so a clamp helper rewrote every other size (including "inline") to fullscreen, and snapped it back whenever you tried to leave.
- Microsoft's docs actually mean fullscreen is the only size a widget can *request* — widgets still render inline by default. So this sets Copilot to support both inline and fullscreen.
- After the fix: Copilot widgets show inline first, can go fullscreen when requested, and the X button returns them to inline.
- Updated the tests that had locked in the old (wrong) behavior; all affected tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)